### PR TITLE
fix: unblock uat release migrations

### DIFF
--- a/consent-protocol/db/migrate.py
+++ b/consent-protocol/db/migrate.py
@@ -1172,11 +1172,6 @@ Examples:
         help="Apply strict zero-knowledge consent export evolution",
     )
     parser.add_argument(
-        "--release",
-        action="store_true",
-        help="Apply the canonical ordered release migration manifest",
-    )
-    parser.add_argument(
         "--full", action="store_true", help="Drop and recreate ALL tables (DESTRUCTIVE!)"
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- remove the duplicate `--release` argparse registration in `consent-protocol/db/migrate.py`
- unblock the `Deploy to UAT` migration gate that currently fails before any schema work runs

## Verification
- `cd consent-protocol && PYTHONPATH=. .venv/bin/python -m py_compile db/migrate.py`
- `cd consent-protocol && PYTHONPATH=. .venv/bin/python db/migrate.py --help`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the `--release` command-line option from the migration script. Workflows or commands using this flag will require updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->