### PR TITLE
Promote main to deploy_uat

### DIFF
--- a/consent-protocol/db/migrate.py
+++ b/consent-protocol/db/migrate.py
@@ -1172,11 +1172,6 @@ Examples:
         help="Apply strict zero-knowledge consent export evolution",
     )
     parser.add_argument(
-        "--release",
-        action="store_true",
-        help="Apply the canonical ordered release migration manifest",
-    )
-    parser.add_argument(
         "--full", action="store_true", help="Drop and recreate ALL tables (DESTRUCTIVE!)"
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- promote the latest `main` into `deploy_uat`
- includes the migration hotfix that removes the duplicate `--release` CLI registration in `consent-protocol/db/migrate.py`

## Why
- the previous UAT deploy was blocked inside `python3 db/migrate.py --release`
- `deploy_uat` is required to contain the latest `main` before the deploy workflow will proceed
