### PR TITLE
fix: align uat schema contract with migration 037

### DIFF
--- a/consent-protocol/db/schema_contract/uat_integrated_schema.json
+++ b/consent-protocol/db/schema_contract/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 36,
+  "expected_migration_version": 37,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",
@@ -27,6 +27,17 @@
       "personas",
       "last_active_persona",
       "investor_marketplace_opt_in",
+      "created_at",
+      "updated_at"
+    ],
+    "actor_identity_cache": [
+      "user_id",
+      "display_name",
+      "email",
+      "photo_url",
+      "email_verified",
+      "source",
+      "last_synced_at",
       "created_at",
       "updated_at"
     ],


### PR DESCRIPTION
## Summary
- update `uat_integrated_schema.json` to expect migration `037`
- add `actor_identity_cache` to the required UAT table contract

## Why
- the previous UAT deploy moved past the duplicate `--release` bug
- it now fails correctly on `contract_version_mismatch:policy=exact:highest_local=037:expected=036`

## Verification
- `python3 -m json.tool consent-protocol/db/schema_contract/uat_integrated_schema.json >/dev/null`
- `python3 scripts/ops/db_migration_release_guard.py --contract-file consent-protocol/db/schema_contract/uat_integrated_schema.json --skip-db-check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database schema to support improved identity management and caching capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->