### PR TITLE
chore: reduce CI branch noise and document branch lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,10 @@ on:
   pull_request:
     branches: ["**"]
   push:
-    branches: ["**"]
+    branches:
+      - main
+      - deploy_uat
+      - deploy
   merge_group:
     branches: [main]
   workflow_dispatch:
@@ -144,7 +147,7 @@ jobs:
   web-check:
     name: "Web (Next.js)"
     needs: [paths]
-    if: needs.paths.outputs.frontend == 'true' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deploy'))
+    if: needs.paths.outputs.frontend == 'true' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deploy_uat' || github.ref == 'refs/heads/deploy'))
     runs-on: ubuntu-latest
     timeout-minutes: 35
     steps:
@@ -185,7 +188,7 @@ jobs:
   protocol-check:
     name: "Protocol (Python)"
     needs: [paths]
-    if: needs.paths.outputs.backend == 'true' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deploy'))
+    if: needs.paths.outputs.backend == 'true' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deploy_uat' || github.ref == 'refs/heads/deploy'))
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
@@ -212,7 +215,7 @@ jobs:
   integration-check:
     name: "Integration"
     needs: [paths]
-    if: needs.paths.outputs.frontend == 'true' || needs.paths.outputs.backend == 'true' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deploy'))
+    if: needs.paths.outputs.frontend == 'true' || needs.paths.outputs.backend == 'true' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deploy_uat' || github.ref == 'refs/heads/deploy'))
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/docs/reference/operations/branch-governance.md
+++ b/docs/reference/operations/branch-governance.md
@@ -17,6 +17,22 @@ This repo runs on three branch lanes:
    - `deploy_uat` for UAT rollout
    - `deploy` for production release preparation
 5. A release branch must contain the latest `origin/main` before deployment.
+6. Do not open feature or hotfix PRs directly to `deploy_uat`; promote via `main`.
+
+## Branch Types and Retention
+
+| Branch type | Naming pattern | Retention |
+|---|---|---|
+| Developer branch | `feature/*`, `feat/*`, `agent_*`, developer-owned names | Keep while active |
+| Hotfix branch | `fix/*` | Delete after merge to `main` and successful promotion |
+| Promotion PR head | `main` -> `deploy_uat` or `main` -> `deploy` | Keep permanent release branches only |
+| Local backup branch | `backup/*`, `publishable/*` | Audit unique commits, salvage if needed, then delete |
+
+Before deleting a local backup branch, classify its unique commits as:
+
+1. already represented in `main`
+2. obsolete and safe to drop
+3. still valuable and worth promoting onto a fresh salvage branch from current `main`
 
 ## Deployment Lanes
 
@@ -26,6 +42,7 @@ This repo runs on three branch lanes:
 2. Manual dispatch is also allowed.
 3. No reviewer gate is required in the workflow itself.
 4. Workflow preflight fails if `deploy_uat` does not contain the latest `origin/main`.
+5. The intended promotion path is `feature/hotfix -> main -> deploy_uat`.
 
 ### `deploy`
 
@@ -33,6 +50,15 @@ This repo runs on three branch lanes:
 2. Production deploy is manual only through `.github/workflows/deploy-production.yml`.
 3. The workflow is valid only when dispatched from the `deploy` branch.
 4. Workflow preflight fails if `deploy` does not contain the latest `origin/main`.
+5. The intended promotion path is `feature/hotfix -> main -> deploy`.
+
+## Hotfix Playbook
+
+1. Create the hotfix branch from the latest `main`.
+2. Merge the hotfix into `main`.
+3. Promote `main` into `deploy_uat`.
+4. If another blocker appears after that promotion, create a new hotfix branch from the updated `main`.
+5. Do not reuse an already-merged hotfix branch for a second fix.
 
 ## GitHub Admin Checklist
 

--- a/docs/reference/operations/ci.md
+++ b/docs/reference/operations/ci.md
@@ -24,7 +24,7 @@ The local parity script mirrors those same blocking stages. On GitHub, `main` sh
 | Trigger | Branches | Behavior |
 |--------|-----------|----------|
 | Pull request | All branches (`**`) | Full CI (path-filtered) |
-| Push | All branches (`**`) | Full CI (path-filtered) |
+| Push | `main`, `deploy_uat`, `deploy` | Full CI (path-filtered for normal changes, forced on release lanes when needed) |
 | Merge queue | `main` | Full CI (frontend + backend forced on) |
 | Manual | Any | **workflow_dispatch** with scope: `frontend` \| `backend` \| `all` |
 
@@ -33,6 +33,21 @@ The local parity script mirrors those same blocking stages. On GitHub, `main` sh
 - **Frontend job** runs when `hushh-webapp/**` changes.
 - **Backend job** runs when `consent-protocol/**` changes.
 - **Integration job** runs when either frontend or backend paths change.
+
+### Duplicate-Run Policy
+
+Feature and hotfix branches intentionally rely on `pull_request` CI only. This avoids the same head SHA fan-out that happens when a branch triggers both:
+
+1. a `push` run, and
+2. one or more `pull_request` runs for different base branches.
+
+Protected release branches still keep `push` CI:
+
+- `main`
+- `deploy_uat`
+- `deploy`
+
+That keeps one authoritative post-merge CI run on each release lane without duplicating feature-branch noise.
 
 ---
 
@@ -90,6 +105,7 @@ Do not add new CI/parity scripts without replacing or consolidating an existing 
 2. `deploy_uat` is the UAT rollout lane and must contain the latest `main`.
 3. `deploy` is the production release lane and must contain the latest `main`.
 4. Production deploys are manual and handled by `.github/workflows/deploy-production.yml`, not by the main CI workflow.
+5. Feature or hotfix branches should never target `deploy_uat` directly; promote through `main`.
 
 See [Branch Governance](./branch-governance.md).
 


### PR DESCRIPTION
## Summary
- limit push-triggered Tri-Flow CI to release branches only
- document the release promotion lane and hotfix retention policy
- clean up stale local and remote branches from the recent deployment incident

## Verification
- python YAML parse for `.github/workflows/ci.yml`
- branch cleanup verified locally with `git branch`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined CI/CD pipeline triggers to run only on release branches (`main`, `deploy_uat`, `deploy`), optimizing automation for feature development workflows.

* **Documentation**
  * Added comprehensive branch governance guidelines with naming conventions and retention policies.
  * Published hotfix playbook with step-by-step promotion procedures and blocker handling.
  * Documented CI automation behavior and duplicate-run prevention strategy across branch types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->