### PR TITLE
Promote main to deploy_uat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,6 +269,35 @@ jobs:
           MAIN_SYNC_CURRENT_BRANCH: ${{ github.head_ref }}
         run: sh scripts/git/check-main-sync.sh
 
+  release-lane-gate:
+    name: "Release Lane Gate"
+    if: github.event_name == 'pull_request' && (github.base_ref == 'deploy_uat' || github.base_ref == 'deploy')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Require promotion from main only
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.head_ref }}" != "main" ]; then
+            echo "Release branches only accept promotion PRs from 'main'."
+            echo "Got head branch: '${{ github.head_ref }}'"
+            exit 1
+          fi
+
+      - name: Verify promotion branch contains latest origin/main
+        env:
+          MAIN_SYNC_REMOTE: origin
+          MAIN_SYNC_BRANCH: main
+          MAIN_SYNC_MODE: block
+          MAIN_SYNC_CURRENT_BRANCH: release-promotion-${{ github.base_ref }}
+        run: sh scripts/git/check-main-sync.sh
+
   branch-freshness-advisory:
     name: "Branch Freshness Advisory"
     if: github.event_name == 'push' && github.ref_name != 'main' && github.ref_name != 'deploy' && github.ref_name != 'deploy_uat'
@@ -295,6 +324,8 @@ jobs:
       - web-check
       - protocol-check
       - integration-check
+      - main-freshness-gate
+      - release-lane-gate
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -307,15 +338,19 @@ jobs:
           WEB="${{ needs['web-check'].result }}"
           PROTOCOL="${{ needs['protocol-check'].result }}"
           INTEGRATION="${{ needs['integration-check'].result }}"
+          MAIN_FRESHNESS="${{ needs['main-freshness-gate'].result }}"
+          RELEASE_LANE="${{ needs['release-lane-gate'].result }}"
 
           printf 'secret-scan=%s\n' "$SECRET_SCAN"
           printf 'paths=%s\n' "$PATHS"
           printf 'web-check=%s\n' "$WEB"
           printf 'protocol-check=%s\n' "$PROTOCOL"
           printf 'integration-check=%s\n' "$INTEGRATION"
+          printf 'main-freshness-gate=%s\n' "$MAIN_FRESHNESS"
+          printf 'release-lane-gate=%s\n' "$RELEASE_LANE"
 
           fail=0
-          for result in "$SECRET_SCAN" "$PATHS" "$WEB" "$PROTOCOL" "$INTEGRATION"; do
+          for result in "$SECRET_SCAN" "$PATHS" "$WEB" "$PROTOCOL" "$INTEGRATION" "$MAIN_FRESHNESS" "$RELEASE_LANE"; do
             if [ "$result" = "failure" ] || [ "$result" = "cancelled" ] || [ "$result" = "timed_out" ]; then
               fail=1
             fi

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,6 +1,13 @@
 name: Deploy to Production
 
 on:
+  workflow_run:
+    workflows:
+      - "Tri-Flow CI"
+    types:
+      - completed
+    branches:
+      - deploy
   workflow_dispatch:
     inputs:
       scope:
@@ -33,20 +40,27 @@ env:
   BACKUP_MAX_AGE_HOURS: "30"
   BACKUP_JOB_NAME: prod-supabase-logical-backup
 
+concurrency:
+  group: deploy-production-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     name: Deploy Production Scope
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch'
-    environment: ${{ github.actor == 'kushaltrivedi' && 'production-owner-bypass' || 'production-approval' }}
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'deploy')
+    environment: production-owner-bypass
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - name: Assert production branch contains latest main
+        env:
+          GITHUB_REF_NAME: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref_name }}
         run: bash scripts/ci/require-branch-contains-main.sh deploy
 
       - name: Report deployment approval lane

--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -1,7 +1,11 @@
 name: Deploy to UAT
 
 on:
-  push:
+  workflow_run:
+    workflows:
+      - "Tri-Flow CI"
+    types:
+      - completed
     branches:
       - deploy_uat
   workflow_dispatch:
@@ -25,18 +29,26 @@ env:
   UAT_DB_UNIX_SOCKET: /cloudsql/hushh-pda-uat:us-central1:hushh-uat-pg
   CLOUD_RUN_REVISION_RETENTION: "10"
 
+concurrency:
+  group: deploy-uat-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     name: Deploy UAT Scope
     runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'deploy_uat')
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - name: Assert UAT branch contains latest main
+        env:
+          GITHUB_REF_NAME: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref_name }}
         run: bash scripts/ci/require-branch-contains-main.sh deploy_uat
 
       - name: Authenticate to Google Cloud

--- a/docs/reference/operations/branch-governance.md
+++ b/docs/reference/operations/branch-governance.md
@@ -38,19 +38,21 @@ Before deleting a local backup branch, classify its unique commits as:
 
 ### `deploy_uat`
 
-1. Auto-deploys to UAT on push.
-2. Manual dispatch is also allowed.
+1. Auto-deploys to UAT only after successful `Tri-Flow CI` on `deploy_uat`.
+2. Manual dispatch is allowed only as an emergency rerun path.
 3. No reviewer gate is required in the workflow itself.
 4. Workflow preflight fails if `deploy_uat` does not contain the latest `origin/main`.
 5. The intended promotion path is `feature/hotfix -> main -> deploy_uat`.
+6. Only `main -> deploy_uat` promotion PRs are valid.
 
 ### `deploy`
 
-1. Does not auto-deploy production.
-2. Production deploy is manual only through `.github/workflows/deploy-production.yml`.
-3. The workflow is valid only when dispatched from the `deploy` branch.
+1. Auto-deploys production only after successful `Tri-Flow CI` on `deploy`.
+2. Manual dispatch remains available only as an emergency rerun path.
+3. The workflow is valid only from the `deploy` branch.
 4. Workflow preflight fails if `deploy` does not contain the latest `origin/main`.
 5. The intended promotion path is `feature/hotfix -> main -> deploy`.
+6. Only `main -> deploy` promotion PRs are valid.
 
 ## Hotfix Playbook
 
@@ -68,25 +70,29 @@ Before deleting a local backup branch, classify its unique commits as:
 2. Require the `CI Status Gate` and `Main Freshness Gate` status checks.
 3. Block force-pushes.
 4. Block branch deletion.
-5. Decide explicitly whether admins can bypass branch protection.
+5. Use bypass for the 3 core owners only; do not rely on overlapping push restrictions.
+6. Keep ordinary development off `main`; use PRs from developer branches.
 
 Current operating note:
 
-- if `enforce_admins=false`, admins can still push directly even when `main` is protected
+- `enforce_admins` should stay enabled
 - verify the live setting with `./scripts/ci/verify-main-branch-protection.sh`
 
 ### `deploy`
 
 1. Protect the branch.
-2. Restrict who can push or merge.
-3. Treat it as release-only.
-4. Use it only after syncing from `main`.
+2. Require PR merge from `main` only.
+3. Require `CI Status Gate` and `Release Lane Gate`.
+4. Treat it as release-only.
+5. Use bypass only for the 3 core owners.
 
 ### `deploy_uat`
 
 1. Protect the branch.
-2. Allow approved developers to push.
-3. Keep it synced from `main` before rollout.
+2. Require PR merge from `main` only.
+3. Require `CI Status Gate` and `Release Lane Gate`.
+4. Keep it synced from `main` before rollout.
+5. Use bypass only for the 3 core owners.
 
 ## Production Approval Environments
 

--- a/docs/reference/operations/ci.md
+++ b/docs/reference/operations/ci.md
@@ -58,15 +58,24 @@ That keeps one authoritative post-merge CI run on each release lane without dupl
 | Secret Scan | Detect leaked credentials/tokens early | `gitleaks` OSS CLI (license-free) scans the event commit range, not full repo history |
 | Upstream Sync | Detect monorepo/subtree drift | Advisory only; warnings are non-blocking |
 | Main Freshness Gate | Prevent stale PR merges into `main` | Blocks pull requests targeting `main` unless the branch contains latest `origin/main` |
+| Release Lane Gate | Prevent invalid promotions into `deploy_uat` or `deploy` | Blocks PRs targeting release branches unless the head branch is `main` and it contains latest `origin/main` |
 | Branch Freshness Advisory | Early stale-branch signal on feature-branch pushes | Warn-only; does not block CI or merges |
 | CI Status Gate | Single required check for branch protection | Fails if any required job fails/cancels/times out; allows intentional `skipped` jobs |
 
 ## Live GitHub Enforcement
 
-`main` is expected to enforce the same CI contract documented here:
+Protected branches are expected to enforce the same CI contract documented here:
 
-- at least `1` approving review
-- required status checks: `CI Status Gate`, `Main Freshness Gate`
+- `main`
+  - at least `1` approving review
+  - required status checks: `CI Status Gate`, `Main Freshness Gate`
+  - strict/up-to-date checks enabled
+- `deploy_uat`
+  - at least `1` approving review
+  - required status checks: `CI Status Gate`, `Release Lane Gate`
+- `deploy`
+  - at least `1` approving review
+  - required status checks: `CI Status Gate`, `Release Lane Gate`
 - force-pushes disabled
 - branch deletion disabled
 
@@ -78,8 +87,8 @@ The live GitHub setting can drift from the docs, so verify it directly:
 
 Current live nuance:
 
-- admin enforcement is currently off, so admins/bypass users can still push directly if they have that level of access
-- there is no extra ruleset layered on top of `main` unless GitHub shows one in the verification output
+- the repo currently uses classic branch protection rather than GitHub repository rulesets
+- bypass actors should be limited to the 3 core owners, without overlapping push-restriction lists
 
 ## Advisory Checks (Non-Blocking By Default)
 
@@ -104,8 +113,10 @@ Do not add new CI/parity scripts without replacing or consolidating an existing 
 1. `main` is the only integration branch for day-to-day development.
 2. `deploy_uat` is the UAT rollout lane and must contain the latest `main`.
 3. `deploy` is the production release lane and must contain the latest `main`.
-4. Production deploys are manual and handled by `.github/workflows/deploy-production.yml`, not by the main CI workflow.
-5. Feature or hotfix branches should never target `deploy_uat` directly; promote through `main`.
+4. `deploy_uat` auto-deploys only after successful protected-branch CI.
+5. `deploy` auto-deploys only after successful protected-branch CI.
+6. Manual deploy dispatch remains an emergency rerun path, not the default release path.
+7. Feature or hotfix branches should never target `deploy_uat` or `deploy` directly; promote through `main`.
 
 See [Branch Governance](./branch-governance.md).
 


### PR DESCRIPTION
## Summary
- promote the protected-branch governance and CI/CD flow reset to UAT
- bring the release lane gate and CI-chained deploy behavior to deploy_uat
- keep deploy_uat aligned with latest main before rollout
