### PR TITLE
fix: update UAT schema contract to version 40

### DIFF
--- a/consent-protocol/db/schema_contract/uat_integrated_schema.json
+++ b/consent-protocol/db/schema_contract/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 37,
+  "expected_migration_version": 40,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",


### PR DESCRIPTION
## Summary
- UAT schema contract expected version 37 but code has migrations up to 040
- Updated `expected_migration_version` from 37 to 40 to unblock UAT deploy

## Test plan
- [ ] UAT deploy succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)