### PR TITLE
fix: harden UAT frontend standalone bootstrap

### DIFF
--- a/hushh-webapp/Dockerfile
+++ b/hushh-webapp/Dockerfile
@@ -84,16 +84,33 @@ ENV HOSTNAME="0.0.0.0"
 # In monorepo local builds, it may be at .next/standalone/hushh-webapp/server.js
 COPY --from=builder /app/.next/standalone ./
 
-# Copy public assets (server.js expects these relative to its own directory)
+# Copy public assets and static files for the root standalone layout.
 COPY --from=builder /app/public ./public
 
 # Copy static assets
 COPY --from=builder /app/.next/static ./.next/static
+
+# Normalize both standalone layouts so Cloud Run always has one canonical
+# entrypoint and the nested monorepo-aware path still resolves its assets.
+RUN set -eux; \
+    mkdir -p /app/hushh-webapp/.next; \
+    if [ -f /app/server.js ]; then \
+      ln -sfn /app/server.js /app/hushh-webapp/server.js; \
+    elif [ -f /app/hushh-webapp/server.js ]; then \
+      ln -sfn /app/hushh-webapp/server.js /app/server.js; \
+    else \
+      echo "No standalone server.js found after copy" >&2; \
+      find /app -maxdepth 4 -name server.js -print >&2; \
+      exit 1; \
+    fi; \
+    rm -rf /app/hushh-webapp/public /app/hushh-webapp/.next/static; \
+    ln -sfn ../public /app/hushh-webapp/public; \
+    ln -sfn ../../.next/static /app/hushh-webapp/.next/static
 
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider http://localhost:8080/ || exit 1
 
-# Start the standalone server — try root first (Docker), then monorepo subdir (local)
-CMD ["sh", "-c", "node server.js 2>/dev/null || node hushh-webapp/server.js"]
+# Start the canonical normalized standalone server.
+CMD ["node", "server.js"]


### PR DESCRIPTION
## Summary
- normalize the frontend standalone layout at image build time instead of guessing at runtime
- ensure one canonical `/app/server.js` entrypoint always exists while keeping nested monorepo assets resolvable
- fail the image build early if neither standalone server path exists so Cloud Run startup errors do not get masked

## Root cause
UAT frontend deploys were succeeding through image build and failing only at Cloud Run startup. The current image startup command suppressed stderr on the root `server.js` path and then fell through to `/app/hushh-webapp/server.js`, which also was not present in the built image. That hid the real layout mismatch until runtime.

## Verification
- `git diff --check`
- inspected failing GitHub Actions run `23877512751`
- inspected Cloud Build `8c3cf80c-57fb-40a7-b580-e56f441cd840`
- inspected Cloud Run revision logs for `hushh-webapp-00033-879` and `hushh-webapp-00034-xst`

## Notes
I could not run a local Docker build here because Docker is not installed in this environment.