### PR TITLE
feat: harden remote mcp bootstrap and smoke coverage

### DIFF
--- a/.github/workflows/publish-hushh-mcp.yml
+++ b/.github/workflows/publish-hushh-mcp.yml
@@ -1,0 +1,56 @@
+name: Publish @hushh/mcp
+
+on:
+  workflow_dispatch:
+    inputs:
+      dist_tag:
+        description: "npm dist-tag to publish"
+        required: true
+        default: beta
+        type: choice
+        options:
+          - beta
+          - latest
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      PACKAGE_DIR: packages/hushh-mcp
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Dry-run tarball
+        working-directory: ${{ env.PACKAGE_DIR }}
+        run: npm pack --dry-run
+
+      - name: Guard against duplicate npm version
+        working-directory: ${{ env.PACKAGE_DIR }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          PACKAGE_NAME="$(node -p "require('./package.json').name")"
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          if npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version >/dev/null 2>&1; then
+            echo "Version ${PACKAGE_NAME}@${PACKAGE_VERSION} is already published."
+            exit 1
+          fi
+
+      - name: Publish package
+        working-directory: ${{ env.PACKAGE_DIR }}
+        run: npm publish --tag "${{ github.event.inputs.dist_tag }}"
+
+      - name: Verify npx install surface
+        run: npx -y "@hushh/mcp@${{ github.event.inputs.dist_tag }}" --help

--- a/consent-protocol/.env.example
+++ b/consent-protocol/.env.example
@@ -63,7 +63,7 @@ GOOGLE_GENAI_USE_VERTEXAI=True
 # developer lookups. Contributors can leave this blank until they enable
 # developer access from the Kai app.
 HUSHH_DEVELOPER_TOKEN=
-MCP_DEVELOPER_TOKEN=replace_with_mcp_developer_token
+MCP_DEVELOPER_TOKEN=
 DEVELOPER_API_ENABLED=true
 REMOTE_MCP_ENABLED=false
 CONSENT_SSE_ENABLED=true

--- a/consent-protocol/mcp_modules/tools/utility_tools.py
+++ b/consent-protocol/mcp_modules/tools/utility_tools.py
@@ -22,7 +22,8 @@ from hushh_mcp.consent.token import validate_token
 from hushh_mcp.constants import AGENT_PORTS
 from hushh_mcp.trust.link import create_trust_link, verify_trust_link
 from hushh_mcp.types import AgentID, UserID
-from mcp_modules.config import FASTAPI_URL, MCP_DEVELOPER_TOKEN
+from mcp_modules.config import FASTAPI_URL
+from mcp_modules.developer_context import get_developer_request_query
 
 logger = logging.getLogger("hushh-mcp-server")
 
@@ -224,10 +225,11 @@ async def handle_discover_user_domains(args: dict) -> list[TextContent]:
 
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
-            headers = {}
-            if MCP_DEVELOPER_TOKEN:
-                headers["X-MCP-Developer-Token"] = MCP_DEVELOPER_TOKEN
-            r = await client.get(f"{FASTAPI_URL}/api/v1/user-scopes/{uid}", headers=headers)
+            token_query = get_developer_request_query()
+            r = await client.get(
+                f"{FASTAPI_URL}/api/v1/user-scopes/{uid}",
+                params=token_query or None,
+            )
             if r.status_code == 404:
                 return [
                     TextContent(
@@ -243,15 +245,15 @@ async def handle_discover_user_domains(args: dict) -> list[TextContent]:
                         ),
                     )
                 ]
-            if r.status_code == 401 and not MCP_DEVELOPER_TOKEN:
+            if r.status_code == 401 and not token_query:
                 return [
                     TextContent(
                         type="text",
                         text=json.dumps(
                             {
                                 "error": "developer_token_missing",
-                                "message": "MCP_DEVELOPER_TOKEN is required for discover_user_domains",
-                                "hint": "Set MCP_DEVELOPER_TOKEN in MCP environment to call /api/v1/user-scopes/{user_id}.",
+                                "message": "HUSHH_DEVELOPER_TOKEN is required for discover_user_domains",
+                                "hint": "Set HUSHH_DEVELOPER_TOKEN in MCP environment to call /api/v1/user-scopes/{user_id}. MCP_DEVELOPER_TOKEN remains a compatibility alias.",
                             }
                         ),
                     )

--- a/consent-protocol/scripts/uat_kai_regression_smoke.py
+++ b/consent-protocol/scripts/uat_kai_regression_smoke.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Live UAT regression smoke for the Kai test user.
+"""Live regression smoke for the Kai test user.
 
 Runs against the hosted UAT backend using the real Firebase/Kai auth path and
 verifies the recent consent/PKM/RIA integration lanes together:
@@ -10,13 +10,15 @@ verifies the recent consent/PKM/RIA integration lanes together:
 - consent export refresh queue + refresh upload
 - RIA implicit picks-share relationship gating
 
-This script is intentionally UAT-only and mutates Kai test-user state.
-Do not point it at production.
+The full and connection_portfolio scenarios mutate Kai test-user state and should
+stay on local/UAT test users. The MCP transport scenario is safe for any
+environment that has a valid developer token.
 """
 
 from __future__ import annotations
 
 import argparse
+import asyncio
 import base64
 import copy
 import json
@@ -36,6 +38,8 @@ from cryptography.hazmat.primitives.asymmetric.x25519 import (
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from dotenv import dotenv_values
+from mcp.client.session import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
 
 DEFAULT_BACKEND_URL = "https://consent-protocol-f2gsa4kfsq-uc.a.run.app"
 DEFAULT_PROTOCOL_ENV = os.path.expanduser("~/Documents/GitHub/hushh-research/consent-protocol/.env")
@@ -187,7 +191,11 @@ class UatKaiSmoke:
         self.timeout = timeout
         self.user_id = _require(self.config, "KAI_TEST_USER_ID")
         self.passphrase = _require(self.config, "KAI_TEST_PASSPHRASE")
-        self.developer_token = str(self.config.get("MCP_DEVELOPER_TOKEN") or "").strip() or None
+        self.developer_token = (
+            str(self.config.get("HUSHH_DEVELOPER_TOKEN") or "").strip()
+            or str(self.config.get("MCP_DEVELOPER_TOKEN") or "").strip()
+            or None
+        )
         self.firebase_auth_service_account = json.loads(
             _require(self.config, "FIREBASE_AUTH_SERVICE_ACCOUNT_JSON")
         )
@@ -200,6 +208,180 @@ class UatKaiSmoke:
 
     def log(self, message: str) -> None:
         print(f"[uat-smoke] {message}")
+
+    def remote_mcp_url(self) -> str:
+        if not self.developer_token:
+            raise RuntimeError("Developer token is required for remote MCP smoke.")
+        return f"{self.backend_url.rstrip('/')}/mcp/?token={quote_plus(self.developer_token)}"
+
+    def _parse_mcp_json(self, result: Any) -> dict[str, Any]:
+        content = getattr(result, "content", None)
+        if not isinstance(content, list) or not content:
+            raise RuntimeError(f"Unexpected MCP tool response shape: {result!r}")
+        for item in content:
+            text = getattr(item, "text", None)
+            if not text:
+                continue
+            try:
+                parsed = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise RuntimeError(f"MCP tool returned non-JSON text: {text}") from exc
+            if isinstance(parsed, dict):
+                return parsed
+            raise RuntimeError(f"MCP tool returned non-object JSON: {parsed!r}")
+        raise RuntimeError(f"MCP tool returned no text payload: {result!r}")
+
+    async def _run_remote_mcp_transport_async(self) -> tuple[set[str], set[str]]:
+        async with streamablehttp_client(
+            self.remote_mcp_url(),
+            timeout=self.timeout,
+            sse_read_timeout=max(self.timeout, 60),
+        ) as (read_stream, write_stream, _get_session_id):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                tools_result = await session.list_tools()
+                resources_result = await session.list_resources()
+        tool_names = {tool.name for tool in getattr(tools_result, "tools", [])}
+        resource_uris = {
+            str(resource.uri) for resource in getattr(resources_result, "resources", [])
+        }
+        return tool_names, resource_uris
+
+    async def _run_remote_mcp_consent_async(self, *, scope: str) -> None:
+        async with streamablehttp_client(
+            self.remote_mcp_url(),
+            timeout=self.timeout,
+            sse_read_timeout=max(self.timeout, 60),
+        ) as (read_stream, write_stream, _get_session_id):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+
+                tools_result = await session.list_tools()
+                tool_names = {tool.name for tool in getattr(tools_result, "tools", [])}
+                required_tools = {
+                    "discover_user_domains",
+                    "request_consent",
+                    "check_consent_status",
+                    "get_encrypted_scoped_export",
+                    "validate_token",
+                    "list_scopes",
+                }
+                missing_tools = sorted(required_tools - tool_names)
+                if missing_tools:
+                    raise RuntimeError(f"Remote MCP missing expected tools: {missing_tools}")
+
+                resources_result = await session.list_resources()
+                resource_uris = {
+                    str(resource.uri) for resource in getattr(resources_result, "resources", [])
+                }
+                expected_resources = {
+                    "hushh://info/server",
+                    "hushh://info/protocol",
+                    "hushh://info/connector",
+                }
+                missing_resources = sorted(expected_resources - resource_uris)
+                if missing_resources:
+                    raise RuntimeError(
+                        f"Remote MCP missing expected resources: {missing_resources}"
+                    )
+
+                discovered = self._parse_mcp_json(
+                    await session.call_tool("discover_user_domains", {"user_id": self.user_id})
+                )
+                scopes = {
+                    str(item.get("name") or item.get("scope") or "").strip()
+                    for item in (discovered.get("scopes") or [])
+                    if isinstance(item, dict)
+                }
+                if scope not in scopes:
+                    raise RuntimeError(
+                        f"discover_user_domains did not expose {scope}: {discovered}"
+                    )
+
+                requested = self._parse_mcp_json(
+                    await session.call_tool(
+                        "request_consent",
+                        {
+                            "user_id": self.user_id,
+                            "scope": scope,
+                            "reason": "Kai MCP streamable regression smoke",
+                            "expiry_hours": 24,
+                            "approval_timeout_minutes": 60,
+                            "connector_public_key": self.connector.public_key_b64,
+                            "connector_key_id": self.connector.key_id,
+                            "connector_wrapping_alg": "X25519-AES256-GCM",
+                        },
+                    )
+                )
+                request_status = str(requested.get("status") or "").strip().lower()
+                request_id = str(requested.get("request_id") or "").strip()
+                consent_token = str(requested.get("consent_token") or "").strip()
+                if request_status == "pending":
+                    if not request_id:
+                        raise RuntimeError(
+                            f"MCP request_consent returned no request_id: {requested}"
+                        )
+                    self.approve_pending_request(
+                        request_id=request_id,
+                        scope=scope,
+                        duration_hours=24,
+                    )
+                    status_payload = self._parse_mcp_json(
+                        await session.call_tool(
+                            "check_consent_status",
+                            {
+                                "user_id": self.user_id,
+                                "scope": scope,
+                                "request_id": request_id,
+                            },
+                        )
+                    )
+                    if str(status_payload.get("status") or "").strip().lower() != "granted":
+                        raise RuntimeError(
+                            f"MCP check_consent_status did not reach granted: {status_payload}"
+                        )
+                    consent_token = str(status_payload.get("consent_token") or "").strip()
+                elif request_status not in {"granted", "already_granted"}:
+                    raise RuntimeError(f"Unexpected MCP request_consent status: {requested}")
+
+                if not consent_token:
+                    raise RuntimeError("MCP consent flow did not return a consent token.")
+
+                validated = self._parse_mcp_json(
+                    await session.call_tool(
+                        "validate_token",
+                        {"token": consent_token, "expected_scope": scope},
+                    )
+                )
+                if not validated.get("valid"):
+                    raise RuntimeError(f"MCP validate_token failed: {validated}")
+
+                encrypted_export = self._parse_mcp_json(
+                    await session.call_tool(
+                        "get_encrypted_scoped_export",
+                        {
+                            "user_id": self.user_id,
+                            "consent_token": consent_token,
+                            "expected_scope": scope,
+                        },
+                    )
+                )
+                if str(encrypted_export.get("status") or "").strip().lower() != "success":
+                    raise RuntimeError(
+                        f"MCP get_encrypted_scoped_export failed: {encrypted_export}"
+                    )
+
+                decrypted_export = self._decrypt_scoped_export(encrypted_export)
+                narrowed_export = narrow_decrypted_export(decrypted_export, scope)
+                quality_metrics = (
+                    narrowed_export.get("financial", {})
+                    .get("analytics", {})
+                    .get("quality_metrics", {})
+                )
+                if not isinstance(quality_metrics, dict) or not quality_metrics:
+                    raise RuntimeError(
+                        "MCP encrypted scoped export decrypted successfully but did not materialize financial analytics."
+                    )
 
     def _request(
         self,
@@ -1407,6 +1589,42 @@ class UatKaiSmoke:
         self.log("Connection-led Kai portfolio access bundle expansion passed.")
         self.log("Connection portfolio UAT smoke passed.")
 
+    def run_mcp_transport(self) -> None:
+        if not self.developer_token:
+            self.authenticate()
+        tool_names, resource_uris = asyncio.run(self._run_remote_mcp_transport_async())
+        required_tools = {
+            "discover_user_domains",
+            "request_consent",
+            "check_consent_status",
+            "get_encrypted_scoped_export",
+            "validate_token",
+            "list_scopes",
+        }
+        missing_tools = sorted(required_tools - tool_names)
+        if missing_tools:
+            raise RuntimeError(f"Remote MCP missing expected tools: {missing_tools}")
+        expected_resources = {
+            "hushh://info/server",
+            "hushh://info/protocol",
+            "hushh://info/connector",
+        }
+        missing_resources = sorted(expected_resources - resource_uris)
+        if missing_resources:
+            raise RuntimeError(f"Remote MCP missing expected resources: {missing_resources}")
+        self.log(
+            "Remote MCP transport passed with tools="
+            f"{sorted(tool_names)} resources={sorted(resource_uris)}."
+        )
+
+    def run_mcp_consent(self) -> None:
+        self.authenticate()
+        self.derive_vault_key()
+        scope = "attr.financial.analytics.quality_metrics"
+        self.reset_smoke_scope_state(scope=scope)
+        asyncio.run(self._run_remote_mcp_consent_async(scope=scope))
+        self.log("Remote MCP consent/export flow passed.")
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run the Kai UAT regression smoke.")
@@ -1416,7 +1634,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT)
     parser.add_argument(
         "--scenario",
-        choices=["full", "connection_portfolio"],
+        choices=["full", "connection_portfolio", "mcp_transport", "mcp_consent"],
         default="full",
     )
     return parser.parse_args()
@@ -1432,6 +1650,10 @@ def main() -> int:
     )
     if args.scenario == "connection_portfolio":
         runner.run_connection_portfolio()
+    elif args.scenario == "mcp_transport":
+        runner.run_mcp_transport()
+    elif args.scenario == "mcp_consent":
+        runner.run_mcp_consent()
     else:
         runner.run()
     return 0

--- a/packages/hushh-mcp/package.json
+++ b/packages/hushh-mcp/package.json
@@ -18,6 +18,9 @@
     "print-codex-toml": "node ./bin/hushh-mcp.js --print-codex-toml",
     "print-remote-config": "node ./bin/hushh-mcp.js --print-remote-config"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=18.18"
   }


### PR DESCRIPTION
## Summary
- add public npm publish workflow for `@hushh/mcp`
- canonicalize MCP developer-token handling in the smoke and tool path
- add remote MCP streamable transport and consent smoke scenarios

## Validation
- `cd packages/hushh-mcp && npm pack --dry-run`
- `cd consent-protocol && PYTHONPATH=. python3 -m py_compile scripts/uat_kai_regression_smoke.py mcp_modules/tools/utility_tools.py`
- local MCP transport smoke via `scripts/uat_kai_regression_smoke.py --scenario mcp_transport`
- UAT hosted MCP transport smoke via `scripts/uat_kai_regression_smoke.py --backend-url https://consent-protocol-f2gsa4kfsq-uc.a.run.app --scenario mcp_transport`

## Notes
- npm publish itself still requires npm registry credentials
- UAT hosted MCP consent smoke depends on this fix being deployed to UAT first