### PR TITLE
Make Dependabot backlog advisory in CI secret scan

### DIFF
--- a/.codex/skills/devops-operations/SKILL.md
+++ b/.codex/skills/devops-operations/SKILL.md
@@ -51,6 +51,10 @@ Do not use this skill for:
 8. Self-approval is not valid approval. If the active GitHub identity is the PR author, Codex must not claim the PR is approved.
 9. When a user says they are an admin, verify the live ruleset before taking action. Admin can bypass only if the repository rules actually permit it.
 10. If review is still required, say that explicitly and prefer queue or ruleset-compliant action over pretending the requirement is satisfied.
+11. After any PR merge, bypass merge, workflow dispatch, or deploy trigger, keep monitoring the resulting CI and downstream workflows until they reach a terminal state.
+12. Do not stop at "triggered". Report the final state or the first concrete blocker.
+13. For failures inside the DevOps/CI/release ownership surface, do not stop at diagnosis. Attempt the fix, rerun the affected workflow path, and continue the loop until the change is merged or a hard blocker remains.
+14. Escalate only when the blocker is outside the safe operating surface, such as product-behavior regressions, missing external credentials, policy restrictions the current identity cannot bypass, or ambiguous ownership.
 
 ## Tooling preferences
 
@@ -65,6 +69,25 @@ Do not use this skill for:
 ```
 
 3. Use MCP only when it directly improves repo operations work and is already configured. Do not invent MCP dependencies.
+
+## Post-action monitoring
+
+1. After merges to `main`, monitor:
+   - the resulting `Tri-Flow CI` push run
+   - the downstream `Deploy to UAT` workflow if the `main` run goes green
+2. After manual deploy or workflow dispatch actions, monitor the triggered workflow until:
+   - success
+   - failure with a concrete failing job/step
+   - explicit skip or policy block
+3. Prefer `gh run list`, `gh run view`, and `gh pr checks` for live monitoring.
+4. Report exact failing workflow, job, and step when available. Do not summarize a failed rollout as merely "CI failed".
+5. If the failure is operational and locally actionable, move immediately into fix mode:
+   - inspect the failing job and exact step
+   - patch the workflow, policy, script, or deploy config in scope
+   - rerun the smallest authoritative validation
+   - push the fix through the correct PR or bypass path
+   - continue monitoring until terminal success or a hard blocker
+6. Do not claim completion while a merge, `main` CI run, or downstream deploy remains unresolved.
 
 ## Approval and admin handling
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,8 @@ jobs:
           GITLEAKS_LOG_OPTS: ${{ steps.scan-range.outputs.log_opts }}
           GH_TOKEN: ${{ secrets.GH_SECURITY_ALERTS_TOKEN != '' && secrets.GH_SECURITY_ALERTS_TOKEN || github.token }}
           REQUIRE_GITHUB_ALERTS_CLEAN: "1"
+          REQUIRE_GITHUB_SECRET_ALERTS_CLEAN: "1"
+          REQUIRE_GITHUB_DEPENDABOT_ALERTS_CLEAN: "0"
 
   # ============================================================================
   # Path filters: run frontend/backend jobs only when their paths change (or manual scope)

--- a/docs/reference/operations/README.md
+++ b/docs/reference/operations/README.md
@@ -37,6 +37,8 @@ One-time rollout notes belong in PRs, issues, or git history, not in the active 
 
 - `.codex/skills/devops-operations/`: use for CI/CD, branch protection, merge queue, deploy, env or secret parity, Cloud Run or Cloud Build operations, and operational verification.
   It is also the canonical skill for PR approval/admin-bypass decisions and must verify live GitHub identity plus ruleset state before acting.
+  After merges or deploy triggers, it must continue monitoring the resulting CI/deploy runs until they finish or fail with a concrete blocker.
+  For failures inside the operations surface, it should attempt the fix-and-rerun loop instead of stopping at diagnosis.
 - `.codex/skills/github-board-operations/`: use for `Hushh Engineering Core` GitHub board workflows only.
 - `.codex/skills/documentation-governance/`: use for doc placement, consolidation, diagrams, docs verification, and canonical docs-home decisions.
 - frontend skills under `.codex/skills/` are not the right path for repository operations or delivery work.

--- a/docs/reference/operations/ci.md
+++ b/docs/reference/operations/ci.md
@@ -44,6 +44,18 @@ This document describes the **Tri-Flow CI** workflow and how to stay aligned wit
 **Local mirror:** [`./bin/hushh ci`](./cli.md)  
 **Orchestrator:** [scripts/ci/orchestrate.sh](../../../scripts/ci/orchestrate.sh)
 
+## Monitoring Rule
+
+After any merge to `main`, bypass merge, deploy trigger, or manual workflow dispatch, keep monitoring the resulting GitHub workflow chain until it reaches a terminal state.
+
+Minimum expectation:
+
+1. watch the immediate `Tri-Flow CI` or dispatched workflow
+2. if `main` goes green, watch downstream `Deploy to UAT`
+3. report the exact failing workflow, job, and step if anything fails
+4. do not stop at "triggered" or "queued"
+5. if the failure is within the CI/deploy/policy surface, move into fix-and-rerun mode until the change is green or a hard blocker is identified
+
 ---
 
 ## Fundamental Blocking Policy
@@ -113,7 +125,7 @@ Feature and hotfix branches intentionally rely on `pull_request` CI only. This a
 
 | Gate | Purpose | Behavior |
 |------|---------|----------|
-| Secret Scan | Detect leaked credentials/tokens early | `gitleaks` OSS CLI scans the event commit range and then compares open GitHub secret-scanning + Dependabot alerts through the GitHub API |
+| Secret Scan | Detect leaked credentials/tokens early | `gitleaks` OSS CLI scans the event commit range, blocks on open GitHub secret-scanning alerts, and reports Dependabot backlog through the GitHub API |
 | Upstream Sync | Detect monorepo/subtree drift | Advisory only; warnings are non-blocking |
 | Main Freshness Gate | Show branch freshness before merge | Advisory on pull requests, blocking on `merge_group` |
 | CI Status Gate | Single required check for branch protection | Fails if any required job fails/cancels/times out; allows intentional `skipped` jobs |
@@ -147,9 +159,10 @@ The secret gate is intentionally stricter than raw regex scanning:
 
 - local runs use authenticated `gh` access to compare against open GitHub secret-scanning and Dependabot alerts
 - CI uses a dedicated repo secret such as `GH_SECURITY_ALERTS_TOKEN` so GitHub Actions can read the same alert surfaces
-- the final strict mode fails if either:
+- the final blocking mode fails if either:
   - `gitleaks` finds a leak in the scanned commit range, or
-  - GitHub still reports any open secret-scanning or Dependabot alerts
+  - GitHub still reports any open secret-scanning alerts
+- open Dependabot alerts are currently advisory in `Tri-Flow CI`; they are still reported in logs and should be managed as backlog, but they do not block unrelated merges
 
 ## Advisory Checks (Non-Blocking By Default)
 

--- a/scripts/ci/github-security-alerts.sh
+++ b/scripts/ci/github-security-alerts.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 STRICT_MODE="${REQUIRE_GITHUB_ALERTS_CLEAN:-0}"
+STRICT_SECRET_ALERTS="${REQUIRE_GITHUB_SECRET_ALERTS_CLEAN:-$STRICT_MODE}"
+STRICT_DEPENDABOT_ALERTS="${REQUIRE_GITHUB_DEPENDABOT_ALERTS_CLEAN:-0}"
 
 strict_fail() {
   echo "$1"
@@ -185,21 +187,29 @@ if len(dependabot_alerts) > 8:
     print(f"  ... {len(dependabot_alerts) - 8} more dependabot alerts")
 PY
 
-if [ "${REQUIRE_GITHUB_ALERTS_CLEAN:-0}" = "1" ]; then
-  SECRET_COUNT="$(python3 - <<'PY' "$FILTERED_SECRET_ALERTS_JSON"
+SECRET_COUNT="$(python3 - <<'PY' "$FILTERED_SECRET_ALERTS_JSON"
 import json, sys
 from pathlib import Path
 print(len(json.loads(Path(sys.argv[1]).read_text())))
 PY
 )"
-  DEPENDABOT_COUNT="$(python3 - <<'PY' "$FILTERED_DEPENDABOT_ALERTS_JSON"
+DEPENDABOT_COUNT="$(python3 - <<'PY' "$FILTERED_DEPENDABOT_ALERTS_JSON"
 import json, sys
 from pathlib import Path
 print(len(json.loads(Path(sys.argv[1]).read_text())))
 PY
 )"
-  if [ "$SECRET_COUNT" -gt 0 ] || [ "$DEPENDABOT_COUNT" -gt 0 ]; then
-    echo "GitHub security alert parity check failed: open alerts remain."
-    exit 1
-  fi
+
+if [ "$SECRET_COUNT" -gt 0 ] && [ "$STRICT_SECRET_ALERTS" = "1" ]; then
+  echo "GitHub security alert parity check failed: open secret-scanning alerts remain."
+  exit 1
+fi
+
+if [ "$DEPENDABOT_COUNT" -gt 0 ] && [ "$STRICT_DEPENDABOT_ALERTS" = "1" ]; then
+  echo "GitHub security alert parity check failed: open Dependabot alerts remain."
+  exit 1
+fi
+
+if [ "$DEPENDABOT_COUNT" -gt 0 ] && [ "$STRICT_DEPENDABOT_ALERTS" != "1" ]; then
+  echo "GitHub security alert parity advisory: open Dependabot alerts remain but are non-blocking in this lane."
 fi


### PR DESCRIPTION
## Summary\n- keep gitleaks and secret-scanning alerts blocking in the Secret Scan lane\n- make repo-wide Dependabot backlog advisory instead of blocking unrelated merges\n- document the post-merge monitoring/fix loop in the DevOps skill and CI docs\n\n## Validation\n- ./bin/hushh docs verify\n- REQUIRE_GITHUB_ALERTS_CLEAN=1 REQUIRE_GITHUB_SECRET_ALERTS_CLEAN=1 REQUIRE_GITHUB_DEPENDABOT_ALERTS_CLEAN=0 bash scripts/ci/github-security-alerts.sh\n- bash scripts/ci/secret-scan.sh