### PR TITLE
Bump UAT schema contract to migration 044

### DIFF
--- a/consent-protocol/db/schema_contract/uat_integrated_schema.json
+++ b/consent-protocol/db/schema_contract/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 43,
+  "expected_migration_version": 44,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",


### PR DESCRIPTION
## Summary\n- update the UAT integrated schema contract to expect migration 044\n- unblock the UAT predeploy schema gate for the current release train\n\n## Validation\n- python3 scripts/ops/db_migration_release_guard.py --contract-file consent-protocol/db/schema_contract/uat_integrated_schema.json --skip-db-check\n- pre-commit quick lint on consent-protocol passed