### PR TITLE
fix: align UAT schema contract with migration 045

### DIFF
--- a/consent-protocol/db/schema_contract/uat_integrated_schema.json
+++ b/consent-protocol/db/schema_contract/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 44,
+  "expected_migration_version": 45,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",
@@ -238,6 +238,46 @@
       "artifact_metadata",
       "created_at",
       "updated_at"
+    ],
+    "kai_funding_trade_intents": [
+      "intent_id",
+      "user_id",
+      "transfer_id",
+      "alpaca_account_id",
+      "funding_item_id",
+      "funding_account_id",
+      "symbol",
+      "side",
+      "order_type",
+      "time_in_force",
+      "notional_usd",
+      "quantity",
+      "limit_price",
+      "status",
+      "order_id",
+      "idempotency_key",
+      "request_payload_json",
+      "transfer_snapshot_json",
+      "order_payload_json",
+      "failure_code",
+      "failure_message",
+      "requested_at",
+      "executed_at",
+      "created_at",
+      "updated_at"
+    ],
+    "kai_funding_trade_events": [
+      "event_id",
+      "intent_id",
+      "user_id",
+      "event_source",
+      "event_type",
+      "event_status",
+      "reason_code",
+      "reason_message",
+      "payload_json",
+      "occurred_at",
+      "created_at"
     ]
   }
 }


### PR DESCRIPTION
## What changed
- advance the UAT integrated schema contract from migration `044` to `045`
- add the new `kai_funding_trade_intents` and `kai_funding_trade_events` tables to the UAT contract surface

## Why
UAT auto-deploy failed after the queue-first CI/CD merge because the predeploy schema guard still expected migration `044` while the release manifest already includes `045_kai_funding_trade_intents.sql`.

## Impact
- restores parity between the release migration set and the UAT integrated schema contract
- unblocks the UAT deploy guard on the real merged `main` SHA

## Checks
- `python3 scripts/ops/db_migration_release_guard.py --contract-file consent-protocol/db/schema_contract/uat_integrated_schema.json --skip-db-check`
- `python3 -m json.tool consent-protocol/db/schema_contract/uat_integrated_schema.json >/dev/null`
