### PR TITLE
Codex maintenance ops and visible terminal launcher

### DIFF
--- a/.codex/skills/backend/SKILL.md
+++ b/.codex/skills/backend/SKILL.md
@@ -55,6 +55,8 @@ Non-owned surfaces:
 1. Decide whether the task belongs to runtime governance, API contracts, agents/operons, or the MCP developer surface.
 2. Keep backend docs, tests, and boundary contracts aligned when the underlying rule changes.
 3. Route IAM, consent, vault, PKM, and audit-heavy issues into `security-audit` when those are the real ownership surface.
+4. If the user explicitly wants a visible OS terminal window, prefer `./bin/hushh terminal backend --mode local --reload` as the primary backend path.
+5. Use `./bin/hushh terminal stack --mode local` only when one combined visible terminal is explicitly preferred over separate backend/frontend terminals.
 
 ## Handoff Rules
 

--- a/.codex/skills/codex-skill-authoring/scripts/skill_lint.py
+++ b/.codex/skills/codex-skill-authoring/scripts/skill_lint.py
@@ -52,6 +52,13 @@ REQUIRED_WORKFLOW_KEYS = [
     "impact_fields",
     "handoff_chain",
     "common_failures",
+    "scheduled_safe",
+    "maintenance_cadence",
+    "maintenance_runner",
+    "maintenance_owner",
+    "maintenance_issue_section",
+    "maintenance_blockers",
+    "maintenance_prerequisites",
 ]
 EXPECTED_WORKFLOW_IDS = [
     "repo-orientation",
@@ -67,8 +74,10 @@ EXPECTED_WORKFLOW_IDS = [
     "board-update",
     "community-response",
     "mcp-surface-change",
+    "security-posture-maintenance",
 ]
 SPECIAL_HANDOFF_TOKENS = {"selected-owner-skill"}
+MAINTENANCE_CADENCES = {"daily", "weekly", "monthly", "manual"}
 MEANINGFUL_SURFACES = [
     "README.md",
     "bin",
@@ -372,6 +381,7 @@ def validate_workflows(skill_manifests: dict[str, dict[str, Any]], errors: list[
         for manifest in skill_manifests.values()
         for task_type in manifest.get("task_types", [])
     }
+    issue_sections: dict[str, str] = {}
 
     for workflow_dir in sorted(path for path in WORKFLOWS_ROOT.iterdir() if path.is_dir()):
         workflow_path = workflow_dir / "workflow.json"
@@ -417,12 +427,50 @@ def validate_workflows(skill_manifests: dict[str, dict[str, Any]], errors: list[
             if not isinstance(value, list) or not value:
                 errors.append(f"{workflow_path.relative_to(REPO_ROOT)}: `{field}` must be a non-empty list")
 
+        if not isinstance(workflow.get("scheduled_safe"), bool):
+            errors.append(f"{workflow_path.relative_to(REPO_ROOT)}: `scheduled_safe` must be a boolean")
+        cadence = workflow.get("maintenance_cadence")
+        if cadence not in MAINTENANCE_CADENCES:
+            errors.append(f"{workflow_path.relative_to(REPO_ROOT)}: maintenance_cadence must be one of {sorted(MAINTENANCE_CADENCES)}")
+        maintenance_owner = workflow.get("maintenance_owner")
+        if maintenance_owner not in skill_manifests:
+            errors.append(f"{workflow_path.relative_to(REPO_ROOT)}: maintenance_owner `{maintenance_owner}` does not exist")
+        issue_section = workflow.get("maintenance_issue_section")
+        if not isinstance(issue_section, str) or not issue_section.strip():
+            errors.append(f"{workflow_path.relative_to(REPO_ROOT)}: maintenance_issue_section must be a non-empty string")
+        else:
+            other = issue_sections.get(issue_section)
+            if other:
+                errors.append(f"{workflow_path.relative_to(REPO_ROOT)}: maintenance_issue_section `{issue_section}` already used by {other}")
+            else:
+                issue_sections[issue_section] = str(workflow_path.relative_to(REPO_ROOT))
+        runner = workflow.get("maintenance_runner")
+        if not isinstance(runner, list) or not all(isinstance(item, str) and item for item in runner):
+            errors.append(f"{workflow_path.relative_to(REPO_ROOT)}: maintenance_runner must be a string list")
+        blockers = workflow.get("maintenance_blockers")
+        if not isinstance(blockers, list) or not all(isinstance(item, str) and item for item in blockers):
+            errors.append(f"{workflow_path.relative_to(REPO_ROOT)}: maintenance_blockers must be a string list")
+        prerequisites = workflow.get("maintenance_prerequisites")
+        if not isinstance(prerequisites, list) or not all(isinstance(item, str) and item for item in prerequisites):
+            errors.append(f"{workflow_path.relative_to(REPO_ROOT)}: maintenance_prerequisites must be a string list")
+        if workflow.get("scheduled_safe") and cadence == "manual":
+            errors.append(f"{workflow_path.relative_to(REPO_ROOT)}: scheduled_safe workflows cannot use manual cadence")
+        if not workflow.get("scheduled_safe") and cadence != "manual":
+            errors.append(f"{workflow_path.relative_to(REPO_ROOT)}: manual-only workflows must use maintenance_cadence `manual`")
+        if workflow.get("scheduled_safe") and not runner:
+            errors.append(f"{workflow_path.relative_to(REPO_ROOT)}: scheduled_safe workflow must declare maintenance_runner commands")
+        if cadence == "monthly" and workflow.get("scheduled_safe") and not prerequisites:
+            errors.append(f"{workflow_path.relative_to(REPO_ROOT)}: monthly scheduled workflow must declare maintenance_prerequisites")
+
         for candidate in workflow.get("affected_surfaces", []):
             if candidate.startswith(PATH_PREFIXES) and not path_exists(candidate):
                 errors.append(f"{workflow_path.relative_to(REPO_ROOT)}: affected surface does not exist: {candidate}")
         for candidate in workflow.get("required_reads", []):
             if candidate.startswith(PATH_PREFIXES) and not path_exists(candidate):
                 errors.append(f"{workflow_path.relative_to(REPO_ROOT)}: required read does not exist: {candidate}")
+        for command in workflow.get("maintenance_runner", []):
+            if not re.search(r"^\./bin/hushh\s+|^python3\s+|^cd ", command):
+                errors.append(f"{workflow_path.relative_to(REPO_ROOT)}: maintenance_runner command has unsupported shape: {command}")
 
         validate_verification_bundle(workflow.get("verification_bundle"), str(workflow_path.relative_to(REPO_ROOT)), errors)
 

--- a/.codex/skills/frontend/SKILL.md
+++ b/.codex/skills/frontend/SKILL.md
@@ -55,6 +55,8 @@ Non-owned surfaces:
 2. Decide whether the work belongs to `frontend-design-system`, `frontend-architecture`, or `frontend-surface-placement`.
 3. Route native-only concerns to `mobile-native`.
 4. Keep route and verification changes aligned with existing package scripts and contracts.
+5. If the user explicitly wants a visible OS terminal window, prefer `./bin/hushh terminal web --mode <mode>` as the primary frontend path.
+6. Use `./bin/hushh terminal stack --mode <mode>` only when one combined visible terminal is explicitly preferred over separate backend/frontend terminals.
 
 ## Handoff Rules
 

--- a/.codex/skills/repo-context/scripts/repo_scan.py
+++ b/.codex/skills/repo-context/scripts/repo_scan.py
@@ -75,6 +75,7 @@ REQUIRED_WORKFLOWS = [
     "board-update",
     "community-response",
     "mcp-surface-change",
+    "security-posture-maintenance",
 ]
 PATH_PREFIXES = (
     ".codex/",
@@ -97,10 +98,12 @@ COMMAND_PATTERNS = [
     r"^cd consent-protocol && python3 ",
     r"^cd consent-protocol && pytest ",
     r"^cd packages/hushh-mcp && npm run ",
+    r"^python3 scripts/ops/codex_maintenance.py ",
     r"^python3 \.codex/",
     r"^python3 -m py_compile ",
     r"^# TODO$",
 ]
+MAINTENANCE_CADENCES = {"daily", "weekly", "monthly", "manual"}
 
 
 def _load_text(path: Path) -> str:
@@ -410,12 +413,15 @@ def build_commands_section() -> dict[str, Any]:
         repo_commands=[
             "./bin/hushh bootstrap",
             "./bin/hushh doctor --mode uat",
+            "./bin/hushh terminal backend --mode local --reload",
+            "./bin/hushh terminal web --mode uat",
             "./bin/hushh web --mode uat",
             "./bin/hushh docs verify",
             "./bin/hushh ci",
             "./bin/hushh codex onboard",
             "./bin/hushh codex route-task <workflow-id>",
             "./bin/hushh codex impact <workflow-id> [--path <repo-path>]",
+            "./bin/hushh codex maintenance <daily|weekly|monthly>",
             "./bin/hushh codex audit",
         ],
         package_commands=OrderedDict(
@@ -464,6 +470,8 @@ def build_workflow_list(verbose: bool = False) -> dict[str, Any]:
                 owner_skill=workflow["owner_skill"],
                 default_spoke=workflow["default_spoke"],
                 task_type=workflow["task_type"],
+                scheduled_safe=workflow.get("scheduled_safe"),
+                maintenance_cadence=workflow.get("maintenance_cadence"),
                 playbook=workflow["playbook"],
             )
         )
@@ -607,6 +615,7 @@ def build_audit() -> dict[str, Any]:
     coverage, uncovered = _surface_coverage(skills)
 
     findings: dict[str, list[str]] = {"high": [], "medium": [], "low": []}
+    issue_sections: dict[str, str] = {}
 
     for skill_md in sorted(SKILLS_ROOT.glob("*/SKILL.md")):
         skill_id = skill_md.parent.name
@@ -635,10 +644,37 @@ def build_audit() -> dict[str, Any]:
     for workflow in workflows:
         if not workflow.get("verification_bundle"):
             findings["medium"].append(f"Missing verification_bundle for workflow {workflow['id']}")
+        if not isinstance(workflow.get("scheduled_safe"), bool):
+            findings["high"].append(f"Workflow {workflow['id']} missing scheduled_safe boolean")
+        cadence = workflow.get("maintenance_cadence")
+        if cadence not in MAINTENANCE_CADENCES:
+            findings["high"].append(f"Workflow {workflow['id']} has invalid maintenance_cadence: {cadence}")
+        if workflow.get("maintenance_owner") not in skills_by_id:
+            findings["high"].append(f"Workflow {workflow['id']} maintenance_owner is missing or unknown")
+        if not isinstance(workflow.get("maintenance_issue_section"), str) or not workflow.get("maintenance_issue_section", "").strip():
+            findings["medium"].append(f"Workflow {workflow['id']} missing maintenance_issue_section")
+        else:
+            other = issue_sections.get(workflow["maintenance_issue_section"])
+            if other:
+                findings["high"].append(
+                    f"Workflow {workflow['id']} shares maintenance_issue_section `{workflow['maintenance_issue_section']}` with {other}"
+                )
+            else:
+                issue_sections[workflow["maintenance_issue_section"]] = workflow["id"]
+        if workflow.get("scheduled_safe") and not workflow.get("maintenance_runner"):
+            findings["high"].append(f"Workflow {workflow['id']} is scheduled-safe but has no maintenance_runner")
+        if not workflow.get("scheduled_safe") and cadence != "manual":
+            findings["high"].append(f"Workflow {workflow['id']} is manual-only but does not use manual maintenance cadence")
+        if cadence == "monthly" and workflow.get("scheduled_safe") and not workflow.get("maintenance_prerequisites"):
+            findings["medium"].append(f"Workflow {workflow['id']} is monthly but missing maintenance_prerequisites")
         for candidate in workflow.get("required_reads", []):
             if candidate.startswith(PATH_PREFIXES) and not _path_exists(candidate):
                 findings["medium"].append(f"Stale required_read in workflow {workflow['id']}: {candidate}")
-        for command in workflow.get("required_commands", []) + workflow.get("verification_bundle", {}).get("commands", []):
+        for command in (
+            workflow.get("required_commands", [])
+            + workflow.get("verification_bundle", {}).get("commands", [])
+            + workflow.get("maintenance_runner", [])
+        ):
             if not _validate_command_string(command):
                 findings["medium"].append(f"Stale or unknown command shape in workflow {workflow['id']}: {command}")
         if not workflow.get("handoff_chain"):
@@ -721,6 +757,7 @@ def build_section(name: str, verbose: bool = False) -> dict[str, Any]:
 def validate_index() -> dict[str, Any]:
     errors: list[str] = []
     warnings: list[str] = []
+    issue_sections: dict[str, str] = {}
 
     for path in ENTRYPOINTS + DOCS_HOMES:
         if not (REPO_ROOT / path).exists():
@@ -760,6 +797,27 @@ def validate_index() -> dict[str, Any]:
             errors.append(f"Workflow owner_skill not found: {workflow['id']} -> {workflow['owner_skill']}")
         if workflow.get("default_spoke") and workflow["default_spoke"] not in skill_ids:
             errors.append(f"Workflow default_spoke not found: {workflow['id']} -> {workflow['default_spoke']}")
+        if workflow.get("maintenance_owner") not in skill_ids:
+            errors.append(f"Workflow maintenance_owner not found: {workflow['id']} -> {workflow.get('maintenance_owner')}")
+        if workflow.get("maintenance_cadence") not in MAINTENANCE_CADENCES:
+            errors.append(f"Workflow has invalid maintenance_cadence: {workflow['id']} -> {workflow.get('maintenance_cadence')}")
+        if not isinstance(workflow.get("scheduled_safe"), bool):
+            errors.append(f"Workflow scheduled_safe must be boolean: {workflow['id']}")
+        if workflow.get("scheduled_safe") and workflow.get("maintenance_cadence") == "manual":
+            errors.append(f"Workflow scheduled_safe cannot use manual maintenance cadence: {workflow['id']}")
+        if not workflow.get("scheduled_safe") and workflow.get("maintenance_cadence") != "manual":
+            errors.append(f"Workflow manual-only cadence mismatch: {workflow['id']}")
+        if workflow.get("maintenance_cadence") == "monthly" and workflow.get("scheduled_safe") and not workflow.get("maintenance_prerequisites"):
+            errors.append(f"Workflow monthly maintenance prerequisites missing: {workflow['id']}")
+        section = workflow.get("maintenance_issue_section")
+        if not isinstance(section, str) or not section.strip():
+            errors.append(f"Workflow maintenance_issue_section missing: {workflow['id']}")
+        else:
+            other = issue_sections.get(section)
+            if other:
+                errors.append(f"Workflow maintenance_issue_section duplicated: {workflow['id']} and {other} -> {section}")
+            else:
+                issue_sections[section] = workflow["id"]
         for value in workflow.get("affected_surfaces", []) + workflow.get("required_reads", []):
             if value.startswith(PATH_PREFIXES) and not _path_exists(value):
                 errors.append(f"Workflow path not found: {workflow['id']} -> {value}")
@@ -846,7 +904,8 @@ def _render_validation_text(payload: dict[str, Any]) -> str:
 def _render_workflows_text(payload: dict[str, Any]) -> str:
     lines = ["Codex Workflows"]
     for workflow in payload["data"]["workflows"]:
-        lines.append(f"- {workflow['id']}: {workflow['title']} [{workflow['owner_skill']}]")
+        cadence = workflow.get("maintenance_cadence", "manual")
+        lines.append(f"- {workflow['id']}: {workflow['title']} [{workflow['owner_skill']}] cadence={cadence}")
     lines.append(f"Recommended entrypoint: {payload['data']['recommended_entrypoint']}")
     return "\n".join(lines)
 

--- a/.codex/skills/repo-operations/SKILL.md
+++ b/.codex/skills/repo-operations/SKILL.md
@@ -60,6 +60,9 @@ Non-owned surfaces:
 5. Treat the delivery model as three stages: PR feedback lane, queue authority lane, and post-merge deploy-authority lane.
 6. Treat GitHub approval and GitHub bypass as separate states: a PR author still cannot self-approve, but a bypass-listed actor may waive the review gate and, when configured, use the dedicated queue-bypass owner path.
 7. Monitor the resulting workflow chain until terminal success or a concrete blocker.
+8. If the user explicitly wants visible OS terminal windows for runtime commands, prefer separate `./bin/hushh terminal backend --mode local --reload` and `./bin/hushh terminal web --mode <mode>` commands instead of long-lived hidden Codex sessions.
+9. Use `./bin/hushh terminal stack --mode local` only when one combined visible terminal is explicitly preferred.
+10. Prefer `./bin/hushh codex maintenance <daily|weekly|monthly>` for unattended repo-health runs so the workflow metadata, GitHub schedules, and rolling maintenance issue stay aligned.
 
 ## Handoff Rules
 
@@ -72,6 +75,7 @@ Non-owned surfaces:
 
 ```bash
 ./bin/hushh codex ci-status
+./bin/hushh codex maintenance daily --no-issue-update --text
 ./bin/hushh docs verify
 ./bin/hushh ci
 ./scripts/ci/verify-main-branch-protection.sh

--- a/.codex/skills/security-audit/skill.json
+++ b/.codex/skills/security-audit/skill.json
@@ -22,6 +22,7 @@
   ],
   "task_types": [
     "security-consent-audit",
+    "security-posture-maintenance",
     "release-readiness",
     "bug-triage"
   ],
@@ -33,14 +34,16 @@
   ],
   "required_commands": [
     "./bin/hushh docs verify",
-    "cd consent-protocol && python3 -m pytest tests/quality -q"
+    "cd consent-protocol && python3 -m pytest tests/quality -q",
+    "./bin/hushh codex maintenance daily --no-issue-update --text"
   ],
   "verification_bundles": [
     {
       "id": "security-audit-core",
       "commands": [
         "./bin/hushh docs verify",
-        "cd consent-protocol && python3 -m pytest tests/quality -q"
+        "cd consent-protocol && python3 -m pytest tests/quality -q",
+        "./bin/hushh codex maintenance daily --no-issue-update --text"
       ],
       "tests": [
         "./bin/hushh docs verify",

--- a/.codex/workflows/api-contract-change/workflow.json
+++ b/.codex/workflows/api-contract-change/workflow.json
@@ -56,5 +56,14 @@
     "changing backend response shape without proxy/service updates",
     "updating runtime without contract docs",
     "missing auth or consent boundary review"
-  ]
+  ],
+  "scheduled_safe": false,
+  "maintenance_cadence": "manual",
+  "maintenance_runner": [],
+  "maintenance_owner": "backend",
+  "maintenance_issue_section": "api-contract-change",
+  "maintenance_blockers": [
+    "workflow is manual-only and should not run unattended"
+  ],
+  "maintenance_prerequisites": []
 }

--- a/.codex/workflows/board-update/workflow.json
+++ b/.codex/workflows/board-update/workflow.json
@@ -39,5 +39,14 @@
   "common_failures": [
     "creating draft work without issue backing",
     "updating board without status and date hygiene"
-  ]
+  ],
+  "scheduled_safe": false,
+  "maintenance_cadence": "manual",
+  "maintenance_runner": [],
+  "maintenance_owner": "planning-board",
+  "maintenance_issue_section": "board-update",
+  "maintenance_blockers": [
+    "workflow is manual-only and should not run unattended"
+  ],
+  "maintenance_prerequisites": []
 }

--- a/.codex/workflows/bug-triage/workflow.json
+++ b/.codex/workflows/bug-triage/workflow.json
@@ -57,5 +57,14 @@
     "jumping into a subsystem before bounding blast radius",
     "fixing symptoms without docs/tests updates",
     "running oversized verification instead of targeted checks"
-  ]
+  ],
+  "scheduled_safe": false,
+  "maintenance_cadence": "manual",
+  "maintenance_runner": [],
+  "maintenance_owner": "repo-context",
+  "maintenance_issue_section": "bug-triage",
+  "maintenance_blockers": [
+    "workflow is manual-only and should not run unattended"
+  ],
+  "maintenance_prerequisites": []
 }

--- a/.codex/workflows/ci-watch-and-heal/workflow.json
+++ b/.codex/workflows/ci-watch-and-heal/workflow.json
@@ -60,5 +60,14 @@
     "not routing the failed job to the correct owner skill",
     "not distinguishing PR feedback from queue authority or post-merge deploy authority",
     "stopping after rerun without monitoring terminal state"
-  ]
+  ],
+  "scheduled_safe": false,
+  "maintenance_cadence": "manual",
+  "maintenance_runner": [],
+  "maintenance_owner": "repo-operations",
+  "maintenance_issue_section": "ci-watch-and-heal",
+  "maintenance_blockers": [
+    "workflow is manual-only and should not run unattended"
+  ],
+  "maintenance_prerequisites": []
 }

--- a/.codex/workflows/community-response/workflow.json
+++ b/.codex/workflows/community-response/workflow.json
@@ -41,5 +41,14 @@
   "common_failures": [
     "overstating shipped functionality",
     "mixing roadmap with runtime truth"
-  ]
+  ],
+  "scheduled_safe": false,
+  "maintenance_cadence": "manual",
+  "maintenance_runner": [],
+  "maintenance_owner": "comms-community",
+  "maintenance_issue_section": "community-response",
+  "maintenance_blockers": [
+    "workflow is manual-only and should not run unattended"
+  ],
+  "maintenance_prerequisites": []
 }

--- a/.codex/workflows/docs-sync/workflow.json
+++ b/.codex/workflows/docs-sync/workflow.json
@@ -47,5 +47,19 @@
     "documenting helper details in the wrong docs home",
     "leaving stale doc paths after refactor",
     "writing new docs instead of updating canonical docs"
+  ],
+  "scheduled_safe": true,
+  "maintenance_cadence": "weekly",
+  "maintenance_runner": [
+    "./bin/hushh docs verify"
+  ],
+  "maintenance_owner": "docs-governance",
+  "maintenance_issue_section": "docs-sync",
+  "maintenance_blockers": [
+    "docs verification fails",
+    "canonical docs references drift"
+  ],
+  "maintenance_prerequisites": [
+    "command:python3"
   ]
 }

--- a/.codex/workflows/mcp-surface-change/workflow.json
+++ b/.codex/workflows/mcp-surface-change/workflow.json
@@ -53,5 +53,23 @@
     "changing package behavior without docs updates",
     "breaking remote vs local MCP parity",
     "forgetting developer API contract sync"
+  ],
+  "scheduled_safe": true,
+  "maintenance_cadence": "monthly",
+  "maintenance_runner": [
+    "cd packages/hushh-mcp && npm run docs:check",
+    "./bin/hushh protocol test-ci",
+    "./bin/hushh docs verify"
+  ],
+  "maintenance_owner": "backend",
+  "maintenance_issue_section": "mcp-surface-change",
+  "maintenance_blockers": [
+    "MCP docs check fails",
+    "protocol test-ci fails",
+    "developer API docs drift"
+  ],
+  "maintenance_prerequisites": [
+    "command:npm",
+    "command:python3"
   ]
 }

--- a/.codex/workflows/mobile-parity-check/workflow.json
+++ b/.codex/workflows/mobile-parity-check/workflow.json
@@ -55,5 +55,23 @@
     "updating web path without native parity review",
     "forgetting plugin registration",
     "allowing docs/runtime/native route drift"
+  ],
+  "scheduled_safe": true,
+  "maintenance_cadence": "monthly",
+  "maintenance_runner": [
+    "./bin/hushh native ios --mode uat",
+    "./bin/hushh native android --mode uat",
+    "cd hushh-webapp && npm run verify:routes"
+  ],
+  "maintenance_owner": "mobile-native",
+  "maintenance_issue_section": "mobile-parity-check",
+  "maintenance_blockers": [
+    "iOS parity command fails",
+    "Android parity command fails",
+    "route parity verification fails"
+  ],
+  "maintenance_prerequisites": [
+    "command:xcodebuild",
+    "command:adb"
   ]
 }

--- a/.codex/workflows/new-feature-tri-flow/workflow.json
+++ b/.codex/workflows/new-feature-tri-flow/workflow.json
@@ -70,5 +70,14 @@
     "adding fetch calls directly in components",
     "forgetting API/route-contract doc updates",
     "missing service-layer or proxy alignment"
-  ]
+  ],
+  "scheduled_safe": false,
+  "maintenance_cadence": "manual",
+  "maintenance_runner": [],
+  "maintenance_owner": "frontend",
+  "maintenance_issue_section": "new-feature-tri-flow",
+  "maintenance_blockers": [
+    "workflow is manual-only and should not run unattended"
+  ],
+  "maintenance_prerequisites": []
 }

--- a/.codex/workflows/release-readiness/workflow.json
+++ b/.codex/workflows/release-readiness/workflow.json
@@ -55,5 +55,22 @@
     "treating advisory findings as invisible",
     "shipping without docs parity",
     "skipping native checks when mobile surfaces changed"
+  ],
+  "scheduled_safe": true,
+  "maintenance_cadence": "weekly",
+  "maintenance_runner": [
+    "./bin/hushh ci --include-advisory",
+    "./bin/hushh docs verify"
+  ],
+  "maintenance_owner": "repo-operations",
+  "maintenance_issue_section": "release-readiness",
+  "maintenance_blockers": [
+    "ci advisory bundle fails",
+    "docs verification fails",
+    "release readiness audit reports blocking drift"
+  ],
+  "maintenance_prerequisites": [
+    "command:gh",
+    "gh-auth"
   ]
 }

--- a/.codex/workflows/repo-orientation/workflow.json
+++ b/.codex/workflows/repo-orientation/workflow.json
@@ -48,5 +48,22 @@
     "choosing a spoke before routing through the owner skill",
     "loading broad repo context too early",
     "skipping north-star invariants before execution"
+  ],
+  "scheduled_safe": true,
+  "maintenance_cadence": "weekly",
+  "maintenance_runner": [
+    "./bin/hushh codex scan summary --text",
+    "./bin/hushh codex scan section skills --text",
+    "./bin/hushh codex list-workflows --text"
+  ],
+  "maintenance_owner": "repo-context",
+  "maintenance_issue_section": "repo-orientation",
+  "maintenance_blockers": [
+    "repo-context summary fails",
+    "workflow routing output is unavailable",
+    "skill topology drifts from the owner model"
+  ],
+  "maintenance_prerequisites": [
+    "command:python3"
   ]
 }

--- a/.codex/workflows/security-consent-audit/workflow.json
+++ b/.codex/workflows/security-consent-audit/workflow.json
@@ -59,5 +59,22 @@
     "treating signed-in as consent",
     "allowing delegated scope escalation",
     "ignoring vault or PKM boundary docs"
+  ],
+  "scheduled_safe": true,
+  "maintenance_cadence": "weekly",
+  "maintenance_runner": [
+    "./bin/hushh docs verify",
+    "./bin/hushh protocol test-ci",
+    "cd consent-protocol && python3 scripts/verify_adk_a2a_compliance.py"
+  ],
+  "maintenance_owner": "security-audit",
+  "maintenance_issue_section": "security-consent-audit",
+  "maintenance_blockers": [
+    "protocol verification fails",
+    "consent or IAM docs drift",
+    "ADK or A2A compliance check fails"
+  ],
+  "maintenance_prerequisites": [
+    "command:python3"
   ]
 }

--- a/.codex/workflows/security-posture-maintenance/PLAYBOOK.md
+++ b/.codex/workflows/security-posture-maintenance/PLAYBOOK.md
@@ -1,0 +1,20 @@
+# Security Posture Maintenance
+
+Use this workflow pack when the task matches `security-posture-maintenance`.
+
+## Goal
+
+Review live GitHub security drift and Codex-system integrity on a recurring cadence without waiting for a feature PR to surface aged backlog.
+
+## Steps
+
+1. Start with `security-audit` and treat GitHub alert state plus Codex audit state as one maintenance surface.
+2. Run only the maintenance-safe commands listed in `workflow.json`; do not expand into feature or incident work unless the findings require it.
+3. Update the rolling maintenance issue after every unattended run so the backlog stays visible.
+4. Escalate through `handoff_chain` when the findings move from security posture into repo operations, docs, or skill-system drift.
+
+## Common Drift Risks
+
+1. letting open high-severity backlog age outside normal PR traffic
+2. treating workflow drift as separate from security posture
+3. running scheduled maintenance without updating the rolling issue

--- a/.codex/workflows/security-posture-maintenance/workflow.json
+++ b/.codex/workflows/security-posture-maintenance/workflow.json
@@ -1,0 +1,86 @@
+{
+  "id": "security-posture-maintenance",
+  "title": "Security Posture Maintenance",
+  "goal": "Review live GitHub security drift and Codex-system integrity on a recurring cadence without waiting for a feature PR to surface aged backlog.",
+  "owner_skill": "security-audit",
+  "default_spoke": null,
+  "task_type": "security-posture-maintenance",
+  "affected_surfaces": [
+    ".github/workflows",
+    ".github/dependabot.yml",
+    "scripts/ci",
+    "scripts/ops",
+    "docs/reference/operations",
+    ".codex/workflows/security-posture-maintenance"
+  ],
+  "required_reads": [
+    "docs/reference/operations/ci.md",
+    "docs/project_context_map.md",
+    "docs/reference/iam/README.md"
+  ],
+  "required_commands": [
+    "./bin/hushh codex route-task security-posture-maintenance",
+    "./bin/hushh codex maintenance daily",
+    "python3 scripts/ops/codex_maintenance.py snapshot-alerts --kind dependabot --severity-threshold high",
+    "python3 scripts/ops/codex_maintenance.py snapshot-alerts --kind code-scanning --severity-threshold high"
+  ],
+  "verification_bundle": {
+    "id": "security-posture-maintenance",
+    "commands": [
+      "./bin/hushh codex audit --json",
+      "python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py",
+      "./bin/hushh docs verify",
+      "python3 scripts/ops/codex_maintenance.py snapshot-alerts --kind dependabot --severity-threshold high",
+      "python3 scripts/ops/codex_maintenance.py snapshot-alerts --kind code-scanning --severity-threshold high"
+    ],
+    "tests": [
+      "./bin/hushh codex audit --json",
+      "python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py",
+      "./bin/hushh docs verify"
+    ]
+  },
+  "deliverables": [
+    "security severity snapshot",
+    "Codex audit scorecard",
+    "workflow maintenance report",
+    "updated rolling maintenance issue"
+  ],
+  "impact_fields": [
+    "Security findings",
+    "Docs updated",
+    "Verification commands executed"
+  ],
+  "handoff_chain": [
+    "security-audit",
+    "repo-operations",
+    "codex-skill-authoring",
+    "docs-governance"
+  ],
+  "common_failures": [
+    "letting open high-severity backlog age outside normal PR traffic",
+    "treating workflow drift as separate from security posture",
+    "running scheduled maintenance without updating the rolling issue"
+  ],
+  "scheduled_safe": true,
+  "maintenance_cadence": "daily",
+  "maintenance_runner": [
+    "./bin/hushh codex audit --json",
+    "python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py",
+    "./bin/hushh docs verify",
+    "python3 scripts/ops/codex_maintenance.py snapshot-alerts --kind dependabot --severity-threshold high",
+    "python3 scripts/ops/codex_maintenance.py snapshot-alerts --kind code-scanning --severity-threshold high"
+  ],
+  "maintenance_owner": "security-audit",
+  "maintenance_issue_section": "security-posture-maintenance",
+  "maintenance_blockers": [
+    "high or critical Dependabot alerts remain open",
+    "high or critical code scanning alerts remain open",
+    "codex audit reports high findings",
+    "skill lint fails"
+  ],
+  "maintenance_prerequisites": [
+    "command:gh",
+    "gh-auth",
+    "command:python3"
+  ]
+}

--- a/.codex/workflows/skill-authoring/workflow.json
+++ b/.codex/workflows/skill-authoring/workflow.json
@@ -50,5 +50,21 @@
     "adding markdown-only skills without manifest metadata",
     "creating overlapping task types",
     "forgetting onboarding or audit updates"
+  ],
+  "scheduled_safe": true,
+  "maintenance_cadence": "weekly",
+  "maintenance_runner": [
+    "python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py",
+    "./bin/hushh codex audit --json"
+  ],
+  "maintenance_owner": "codex-skill-authoring",
+  "maintenance_issue_section": "skill-authoring",
+  "maintenance_blockers": [
+    "skill lint fails",
+    "codex audit reports high findings",
+    "workflow or skill manifests drift"
+  ],
+  "maintenance_prerequisites": [
+    "command:python3"
   ]
 }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,71 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/hushh-webapp"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "security"
+    groups:
+      web-patch-minor:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/hushh-mcp"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "security"
+    groups:
+      mcp-patch-minor:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "pip"
+    directory: "/consent-protocol"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "security"
+    groups:
+      protocol-patch-minor:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "security"
+    groups:
+      actions-patch-minor:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/codex-maintenance-daily.yml
+++ b/.github/workflows/codex-maintenance-daily.yml
@@ -1,0 +1,59 @@
+name: "Codex Maintenance Daily"
+
+on:
+  schedule:
+    - cron: "17 14 * * 1-5"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  security-events: read
+
+concurrency:
+  group: codex-maintenance-daily
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: "20"
+  PYTHON_VERSION: "3.13"
+
+jobs:
+  maintenance:
+    name: "Daily Maintenance"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+          cache-dependency-path: |
+            hushh-webapp/package-lock.json
+            packages/hushh-mcp/package-lock.json
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: "pip"
+          cache-dependency-path: consent-protocol/requirements.txt
+
+      - name: Run daily Codex maintenance
+        env:
+          GH_TOKEN: ${{ secrets.GH_SECURITY_ALERTS_TOKEN != '' && secrets.GH_SECURITY_ALERTS_TOKEN || github.token }}
+        run: |
+          mkdir -p tmp/codex-maintenance/daily
+          ./bin/hushh codex maintenance daily \
+            --report-file tmp/codex-maintenance/daily/report.json \
+            --artifacts-dir tmp/codex-maintenance/daily/artifacts \
+            --json
+
+      - name: Upload maintenance artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-maintenance-daily
+          path: tmp/codex-maintenance/daily
+

--- a/.github/workflows/codex-maintenance-monthly.yml
+++ b/.github/workflows/codex-maintenance-monthly.yml
@@ -1,0 +1,59 @@
+name: "Codex Maintenance Monthly"
+
+on:
+  schedule:
+    - cron: "11 16 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  security-events: read
+
+concurrency:
+  group: codex-maintenance-monthly
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: "20"
+  PYTHON_VERSION: "3.13"
+
+jobs:
+  maintenance:
+    name: "Monthly Maintenance"
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+          cache-dependency-path: |
+            hushh-webapp/package-lock.json
+            packages/hushh-mcp/package-lock.json
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: "pip"
+          cache-dependency-path: consent-protocol/requirements.txt
+
+      - name: Run monthly Codex maintenance
+        env:
+          GH_TOKEN: ${{ secrets.GH_SECURITY_ALERTS_TOKEN != '' && secrets.GH_SECURITY_ALERTS_TOKEN || github.token }}
+        run: |
+          mkdir -p tmp/codex-maintenance/monthly
+          ./bin/hushh codex maintenance monthly \
+            --report-file tmp/codex-maintenance/monthly/report.json \
+            --artifacts-dir tmp/codex-maintenance/monthly/artifacts \
+            --json
+
+      - name: Upload maintenance artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-maintenance-monthly
+          path: tmp/codex-maintenance/monthly
+

--- a/.github/workflows/codex-maintenance-weekly.yml
+++ b/.github/workflows/codex-maintenance-weekly.yml
@@ -1,0 +1,59 @@
+name: "Codex Maintenance Weekly"
+
+on:
+  schedule:
+    - cron: "37 15 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  security-events: read
+
+concurrency:
+  group: codex-maintenance-weekly
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: "20"
+  PYTHON_VERSION: "3.13"
+
+jobs:
+  maintenance:
+    name: "Weekly Maintenance"
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+          cache-dependency-path: |
+            hushh-webapp/package-lock.json
+            packages/hushh-mcp/package-lock.json
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: "pip"
+          cache-dependency-path: consent-protocol/requirements.txt
+
+      - name: Run weekly Codex maintenance
+        env:
+          GH_TOKEN: ${{ secrets.GH_SECURITY_ALERTS_TOKEN != '' && secrets.GH_SECURITY_ALERTS_TOKEN || github.token }}
+        run: |
+          mkdir -p tmp/codex-maintenance/weekly
+          ./bin/hushh codex maintenance weekly \
+            --report-file tmp/codex-maintenance/weekly/report.json \
+            --artifacts-dir tmp/codex-maintenance/weekly/artifacts \
+            --json
+
+      - name: Upload maintenance artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-maintenance-weekly
+          path: tmp/codex-maintenance/weekly
+

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,66 +2,62 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Runtime: UAT Stack",
+      "name": "Runtime: Visible Local Backend",
       "type": "node-terminal",
       "request": "launch",
-      "command": "make uat",
+      "command": "./bin/hushh terminal backend --mode local --reload",
       "cwd": "${workspaceFolder}"
     },
     {
-      "name": "Runtime: Production Stack",
+      "name": "Runtime: Visible Local Frontend",
       "type": "node-terminal",
       "request": "launch",
-      "command": "make prod",
+      "command": "./bin/hushh terminal web --mode local",
       "cwd": "${workspaceFolder}"
     },
     {
-      "name": "Runtime: Local Web",
+      "name": "Runtime: Visible UAT Frontend",
       "type": "node-terminal",
       "request": "launch",
-      "command": "make local-web",
+      "command": "./bin/hushh terminal web --mode uat",
       "cwd": "${workspaceFolder}"
     },
     {
-      "name": "Runtime: UAT Web",
+      "name": "Runtime: Visible Production Frontend",
       "type": "node-terminal",
       "request": "launch",
-      "command": "make uat-web",
+      "command": "./bin/hushh terminal web --mode prod",
       "cwd": "${workspaceFolder}"
     },
     {
-      "name": "Runtime: Production Web",
+      "name": "Runtime: Visible Local Stack",
       "type": "node-terminal",
       "request": "launch",
-      "command": "make prod-web",
-      "cwd": "${workspaceFolder}"
-    },
-    {
-      "name": "Runtime: Local Backend",
-      "type": "node-terminal",
-      "request": "launch",
-      "command": "make local-backend",
+      "command": "./bin/hushh terminal stack --mode local",
       "cwd": "${workspaceFolder}"
     },
     {
       "name": "Native: Android Local",
       "type": "node-terminal",
       "request": "launch",
-      "command": "cd hushh-webapp && npm run cap:android:run -- --profile local-uatdb --fresh",
+      "command": "./bin/hushh native android --mode local --fresh",
       "cwd": "${workspaceFolder}"
     },
     {
       "name": "Native: iOS Local",
       "type": "node-terminal",
       "request": "launch",
-      "command": "cd hushh-webapp && npm run cap:ios:run -- --profile local-uatdb --fresh",
+      "command": "./bin/hushh native ios --mode local --fresh",
       "cwd": "${workspaceFolder}"
     }
   ],
   "compounds": [
     {
-      "name": "Runtime: Local Dev",
-      "configurations": ["Runtime: Local Backend", "Runtime: Local Web"],
+      "name": "Runtime: Visible Local Dev",
+      "configurations": [
+        "Runtime: Visible Local Backend",
+        "Runtime: Visible Local Frontend"
+      ],
       "stopAll": true
     }
   ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,72 +2,45 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "Profile: Local",
+      "label": "Runtime: Visible Local Backend",
       "type": "shell",
-      "command": "make profile-use PROFILE=local-uatdb",
+      "command": "./bin/hushh terminal backend --mode local --reload",
       "options": {
         "cwd": "${workspaceFolder}"
       },
       "problemMatcher": []
     },
     {
-      "label": "Profile: UAT",
+      "label": "Runtime: Visible Local Frontend",
       "type": "shell",
-      "command": "make profile-use PROFILE=uat-remote",
+      "command": "./bin/hushh terminal web --mode local",
       "options": {
         "cwd": "${workspaceFolder}"
       },
       "problemMatcher": []
     },
     {
-      "label": "Profile: Production",
+      "label": "Runtime: Visible UAT Frontend",
       "type": "shell",
-      "command": "make profile-use PROFILE=prod-remote",
+      "command": "./bin/hushh terminal web --mode uat",
       "options": {
         "cwd": "${workspaceFolder}"
       },
       "problemMatcher": []
     },
     {
-      "label": "Runtime: Local Stack",
+      "label": "Runtime: Visible Production Frontend",
       "type": "shell",
-      "command": "make local",
+      "command": "./bin/hushh terminal web --mode prod",
       "options": {
         "cwd": "${workspaceFolder}"
       },
       "problemMatcher": []
     },
     {
-      "label": "Runtime: UAT Stack",
+      "label": "Runtime: Visible Local Stack",
       "type": "shell",
-      "command": "make uat",
-      "options": {
-        "cwd": "${workspaceFolder}"
-      },
-      "problemMatcher": []
-    },
-    {
-      "label": "Runtime: Production Stack",
-      "type": "shell",
-      "command": "make prod",
-      "options": {
-        "cwd": "${workspaceFolder}"
-      },
-      "problemMatcher": []
-    },
-    {
-      "label": "Runtime: Local Web",
-      "type": "shell",
-      "command": "make local-web",
-      "options": {
-        "cwd": "${workspaceFolder}"
-      },
-      "problemMatcher": []
-    },
-    {
-      "label": "Runtime: Local Backend",
-      "type": "shell",
-      "command": "make local-backend",
+      "command": "./bin/hushh terminal stack --mode local",
       "options": {
         "cwd": "${workspaceFolder}"
       },
@@ -76,7 +49,7 @@
     {
       "label": "Native: Android Local",
       "type": "shell",
-      "command": "cd hushh-webapp && npm run cap:android:run -- --profile local-uatdb --fresh",
+      "command": "./bin/hushh native android --mode local --fresh",
       "options": {
         "cwd": "${workspaceFolder}"
       },
@@ -85,7 +58,7 @@
     {
       "label": "Native: iOS Local",
       "type": "shell",
-      "command": "cd hushh-webapp && npm run cap:ios:run -- --profile local-uatdb --fresh",
+      "command": "./bin/hushh native ios --mode local --fresh",
       "options": {
         "cwd": "${workspaceFolder}"
       },

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ That is the canonical first-run path:
 ./bin/hushh codex onboard
 ./bin/hushh codex ci-status --watch
 ./bin/hushh codex route-task repo-orientation
+./bin/hushh codex maintenance daily
 ./bin/hushh web --mode uat
 ./bin/hushh native ios --mode uat
 ./bin/hushh native android --mode uat

--- a/bin/hushh
+++ b/bin/hushh
@@ -18,6 +18,7 @@ Core commands:
   bootstrap [--mode <local|uat|prod>]
   doctor --mode <local|uat|prod> [--json]
   stack --mode <local|uat|prod> [-- <next-dev args>]
+  terminal <stack|web|backend> [...]
   web [--mode <local|uat|prod>] [-- <next-dev args>]
   backend [--mode local] [--reload|--no-reload]
   native <ios|android> [--mode <local|uat|prod>] [--fresh]
@@ -90,6 +91,7 @@ Usage:
   ./bin/hushh codex route-task <workflow-id> [--json|--text] [--verbose]
   ./bin/hushh codex impact <workflow-id> [--path <repo-path>]... [--json|--text] [--verbose]
   ./bin/hushh codex list-workflows [--json|--text] [--verbose]
+  ./bin/hushh codex maintenance <daily|weekly|monthly> [--json|--text] [--report-file <path>] [--artifacts-dir <path>] [--no-issue-update]
   ./bin/hushh codex ci-status [--pr <number>|--branch <name>] [--watch] [--interval <seconds>] [--timeout <seconds>] [--json|--text]
   ./bin/hushh codex audit [--json|--text]
 EOF
@@ -129,6 +131,130 @@ EOF
     exec npm run dev -- "${next_args[@]}"
   fi
   exec npm run dev
+}
+
+run_terminal() {
+  [ "$#" -ge 1 ] || die "terminal requires <stack|web|backend>"
+
+  local target="${1:-}"
+  shift || true
+  local title=""
+  local command_args=()
+
+  case "$target" in
+    stack)
+      local mode=""
+      local next_args=()
+      while [ "$#" -gt 0 ]; do
+        case "${1:-}" in
+          --mode)
+            mode="${2:-}"
+            shift 2
+            ;;
+          --)
+            shift
+            next_args=("$@")
+            break
+            ;;
+          -h|--help)
+            cat <<'EOF'
+Usage:
+  ./bin/hushh terminal stack --mode <local|uat|prod> [-- <next-dev args>]
+EOF
+            exit 0
+            ;;
+          *)
+            die "Unknown option for terminal stack: $1"
+            ;;
+        esac
+      done
+      [ -n "$mode" ] || die "terminal stack requires --mode"
+      title="Hushh stack (${mode})"
+      command_args=(./bin/hushh stack --mode "$mode")
+      if [ "${#next_args[@]}" -gt 0 ]; then
+        command_args+=(-- "${next_args[@]}")
+      fi
+      ;;
+    web)
+      local mode="uat"
+      local next_args=()
+      while [ "$#" -gt 0 ]; do
+        case "${1:-}" in
+          --mode)
+            mode="${2:-}"
+            shift 2
+            ;;
+          --)
+            shift
+            next_args=("$@")
+            break
+            ;;
+          -h|--help)
+            cat <<'EOF'
+Usage:
+  ./bin/hushh terminal web [--mode <local|uat|prod>] [-- <next-dev args>]
+EOF
+            exit 0
+            ;;
+          *)
+            die "Unknown option for terminal web: $1"
+            ;;
+        esac
+      done
+      title="Hushh web (${mode})"
+      command_args=(./bin/hushh web --mode "$mode")
+      if [ "${#next_args[@]}" -gt 0 ]; then
+        command_args+=(-- "${next_args[@]}")
+      fi
+      ;;
+    backend)
+      local mode="local"
+      local extra=()
+      while [ "$#" -gt 0 ]; do
+        case "${1:-}" in
+          --mode)
+            mode="${2:-}"
+            shift 2
+            ;;
+          --reload|--no-reload|--skip-activate|--preflight-only|--skip-preflight)
+            extra+=("$1")
+            shift
+            ;;
+          -h|--help)
+            cat <<'EOF'
+Usage:
+  ./bin/hushh terminal backend [--mode local] [--reload|--no-reload]
+EOF
+            exit 0
+            ;;
+          *)
+            die "Unknown option for terminal backend: $1"
+            ;;
+        esac
+      done
+      title="Hushh backend (${mode})"
+      command_args=(./bin/hushh backend --mode "$mode" "${extra[@]}")
+      ;;
+    -h|--help|help)
+      cat <<'EOF'
+Usage:
+  ./bin/hushh terminal stack --mode <local|uat|prod> [-- <next-dev args>]
+  ./bin/hushh terminal web [--mode <local|uat|prod>] [-- <next-dev args>]
+  ./bin/hushh terminal backend [--mode local] [--reload|--no-reload]
+
+Opens a visible OS terminal window and runs the canonical Hushh command there.
+EOF
+      exit 0
+      ;;
+    *)
+      die "Unknown terminal target: $target"
+      ;;
+  esac
+
+  exec bash "$REPO_ROOT/scripts/runtime/open_visible_terminal.sh" \
+    --cwd "$REPO_ROOT" \
+    --title "$title" \
+    -- "${command_args[@]}"
 }
 
 run_native() {
@@ -341,6 +467,21 @@ run_codex() {
       [ "${#args[@]}" -ge 1 ] || die "codex impact requires <workflow-id>"
       exec python3 "$REPO_ROOT/.codex/skills/repo-context/scripts/repo_scan.py" impact "${args[@]}" "$format_flag"
       ;;
+    maintenance)
+      [ "${#args[@]}" -ge 1 ] || die "codex maintenance requires <daily|weekly|monthly>"
+      local cadence="${args[0]}"
+      case "$cadence" in
+        daily|weekly|monthly)
+          ;;
+        *)
+          die "Unknown codex maintenance cadence: $cadence"
+          ;;
+      esac
+      if [ "${#args[@]}" -gt 1 ]; then
+        exec python3 "$REPO_ROOT/scripts/ops/codex_maintenance.py" run --cadence "$cadence" "${args[@]:1}" "$format_flag"
+      fi
+      exec python3 "$REPO_ROOT/scripts/ops/codex_maintenance.py" run --cadence "$cadence" "$format_flag"
+      ;;
     ci-status)
       if [ "${#args[@]}" -gt 0 ]; then
         exec python3 "$REPO_ROOT/.codex/skills/repo-operations/scripts/ci_monitor.py" "${args[@]}" "$format_flag"
@@ -528,6 +669,9 @@ EOF
       exec bash "$REPO_ROOT/scripts/runtime/launch_stack.sh" "$mode" -- "${next_args[@]}"
     fi
     exec bash "$REPO_ROOT/scripts/runtime/launch_stack.sh" "$mode"
+    ;;
+  terminal)
+    run_terminal "$@"
     ;;
   web)
     run_web "$@"

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -69,8 +69,11 @@ If you are not doing backend work, stop there. Do not start the local backend or
 ./bin/hushh doctor --mode uat
 ./bin/hushh doctor --mode prod
 
+./bin/hushh terminal backend --mode local --reload
+./bin/hushh terminal web --mode local
 ./bin/hushh web --mode uat
 ./bin/hushh web --mode prod
+./bin/hushh terminal web --mode uat
 ./bin/hushh native ios --mode uat
 ./bin/hushh native android --mode uat
 ```
@@ -94,10 +97,11 @@ The default contributor path does not require it.
 When you do need the full local stack:
 
 ```bash
-./bin/hushh backend
+./bin/hushh terminal backend --mode local --reload
+./bin/hushh terminal web --mode local
 ```
 
-That remains a maintainer/deeper-development path, not the primary onboarding contract.
+That separate-terminal backend + frontend flow is the preferred maintainer path. Use `./bin/hushh terminal stack --mode local` only if you deliberately want one visible terminal window to own both processes.
 
 The local backend path is the only place that uses:
 

--- a/docs/guides/mobile.md
+++ b/docs/guides/mobile.md
@@ -61,7 +61,7 @@ Every visible page route must be documented as either native-supported or explic
 
 Recommended commands:
 
-- Terminal A (repo root): `./bin/hushh backend`
+- Terminal A (repo root): `./bin/hushh terminal backend --mode local --reload`
 - Terminal B (repo root):
   - Android: `./bin/hushh native android --mode local --fresh`
   - iOS: `./bin/hushh native ios --mode local --fresh`

--- a/docs/reference/operations/README.md
+++ b/docs/reference/operations/README.md
@@ -42,6 +42,7 @@ Use the root CLI for agent-first onboarding and deterministic workflow routing:
 - `./bin/hushh codex route-task <workflow-id>`
 - `./bin/hushh codex impact <workflow-id> [--path <repo-path>]`
 - `./bin/hushh codex ci-status [--watch]`
+- `./bin/hushh codex maintenance <daily|weekly|monthly>`
 - `./bin/hushh codex audit`
 
 ## Codex skills
@@ -61,6 +62,7 @@ Top-level owner skills:
 
 Specialist spoke skills live under the same tree and should be used after the correct owner skill or `repo-context` has narrowed the request.
 Workflow packs under `.codex/workflows/` are the canonical recurring task surface for routing and onboarding.
+Scheduled Codex maintenance workflows are the canonical time-driven maintenance surface for workflow drift, security backlog visibility, and the rolling `Codex Maintenance Radar` issue.
 Use `ci-watch-and-heal` plus `./bin/hushh codex ci-status` when the task depends on live PR checks or GitHub Actions state.
 
 ## References

--- a/docs/reference/operations/ci.md
+++ b/docs/reference/operations/ci.md
@@ -187,6 +187,43 @@ The secret gate is intentionally stricter than raw regex scanning:
   - GitHub still reports any open secret-scanning alerts
 - open Dependabot alerts are currently advisory in CI; they are still reported in logs and should be managed as backlog, but they do not block unrelated merges
 
+## Scheduled Codex Maintenance
+
+Merge-time CI stays event-driven. Time-driven maintenance runs beside it through three scheduled workflows:
+
+1. `Codex Maintenance Daily`
+2. `Codex Maintenance Weekly`
+3. `Codex Maintenance Monthly`
+
+Canonical entrypoint:
+
+```bash
+./bin/hushh codex maintenance daily
+./bin/hushh codex maintenance weekly
+./bin/hushh codex maintenance monthly
+```
+
+These runs:
+
+1. execute only workflow packs marked `scheduled_safe=true`
+2. respect each workflow pack's `maintenance_cadence`
+3. snapshot live GitHub Dependabot and code-scanning alerts
+4. run Codex audit and skill lint checks
+5. update one rolling GitHub issue: `Codex Maintenance Radar`
+
+Cadence contract:
+
+1. `daily`
+   - security posture and Codex-system integrity
+   - fails on open `high` or `critical` GitHub security alerts
+2. `weekly`
+   - repo-health workflow packs: `repo-orientation`, `docs-sync`, `security-consent-audit`, `release-readiness`, `skill-authoring`
+3. `monthly`
+   - environment-sensitive workflow packs: `mobile-parity-check`, `mcp-surface-change`
+   - unmet prerequisites are recorded as `skipped`, not `passed`
+
+Dependency-update cadence is repo-tracked in [`.github/dependabot.yml`](../../../.github/dependabot.yml).
+
 ## Advisory Checks (Non-Blocking By Default)
 
 1. `scripts/ci/docs-parity-check.sh`

--- a/docs/reference/operations/cli.md
+++ b/docs/reference/operations/cli.md
@@ -23,6 +23,9 @@ Use package-local commands only when you are working inside a package on purpose
 <repo-root>/bin/hushh codex ci-status --watch
 <repo-root>/bin/hushh web --mode uat
 <repo-root>/bin/hushh stack --mode local
+<repo-root>/bin/hushh terminal backend --mode local --reload
+<repo-root>/bin/hushh terminal web --mode local
+<repo-root>/bin/hushh terminal web --mode uat
 <repo-root>/bin/hushh backend
 <repo-root>/bin/hushh native ios --mode local --fresh
 <repo-root>/bin/hushh lint
@@ -38,6 +41,9 @@ Use package-local commands only when you are working inside a package on purpose
 <repo-root>/bin/hushh codex scan section skills
 <repo-root>/bin/hushh codex list-workflows
 <repo-root>/bin/hushh codex ci-status
+<repo-root>/bin/hushh codex maintenance daily
+<repo-root>/bin/hushh codex maintenance weekly
+<repo-root>/bin/hushh codex maintenance monthly
 <repo-root>/bin/hushh codex audit
 <repo-root>/bin/hushh env bootstrap
 <repo-root>/bin/hushh env use --mode prod
@@ -56,3 +62,6 @@ Use package-local commands only when you are working inside a package on purpose
 - Do not document `make`.
 - Keep helper output and runbooks aligned with this CLI.
 - Contributor and agent onboarding should start with `./bin/hushh codex onboard`, not direct internal script paths.
+- Use `./bin/hushh codex maintenance <daily|weekly|monthly>` as the canonical unattended maintenance surface; do not hardcode deep internal scripts in scheduled workflows.
+- Use `./bin/hushh terminal backend --mode local --reload` and `./bin/hushh terminal web --mode <mode>` as the preferred visible-terminal dev flow.
+- Use `./bin/hushh terminal stack --mode local` only when you explicitly want one combined terminal window to own both processes.

--- a/scripts/ops/codex_maintenance.py
+++ b/scripts/ops/codex_maintenance.py
@@ -1,0 +1,594 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from collections import Counter, OrderedDict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS_ROOT = REPO_ROOT / ".codex/workflows"
+ISSUE_TITLE = "Codex Maintenance Radar"
+CADENCES = {"daily", "weekly", "monthly", "manual"}
+SEVERITY_ORDER = {
+    "info": 0,
+    "note": 0,
+    "warning": 1,
+    "low": 1,
+    "medium": 2,
+    "moderate": 2,
+    "high": 3,
+    "critical": 4,
+    "error": 4,
+}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def resolve_repo() -> str:
+    if os.environ.get("GITHUB_REPOSITORY"):
+        return os.environ["GITHUB_REPOSITORY"]
+    result = subprocess.run(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return result.stdout.strip()
+    remote = subprocess.run(
+        ["git", "remote", "get-url", "origin"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    value = remote.stdout.strip()
+    if value.startswith("https://github.com/"):
+        return value.removeprefix("https://github.com/").removesuffix(".git")
+    if value.startswith("git@github.com:"):
+        return value.removeprefix("git@github.com:").removesuffix(".git")
+    raise RuntimeError("could not resolve GitHub repository")
+
+
+def load_workflows() -> list[dict[str, Any]]:
+    workflows: list[dict[str, Any]] = []
+    for workflow_path in sorted(WORKFLOWS_ROOT.glob("*/workflow.json")):
+        workflow = load_json(workflow_path)
+        workflow["path"] = str(workflow_path.relative_to(REPO_ROOT))
+        workflows.append(workflow)
+    return workflows
+
+
+def run_shell(command: str, *, artifacts_dir: Path | None = None, prefix: str = "command") -> OrderedDict[str, Any]:
+    start = time.time()
+    result = subprocess.run(
+        ["/bin/bash", "-lc", command],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    duration = round(time.time() - start, 2)
+    stdout = result.stdout
+    stderr = result.stderr
+    artifact_payload: OrderedDict[str, str] = OrderedDict()
+    if artifacts_dir is not None:
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
+        stdout_path = artifacts_dir / f"{prefix}.stdout.log"
+        stderr_path = artifacts_dir / f"{prefix}.stderr.log"
+        stdout_path.write_text(stdout, encoding="utf-8")
+        stderr_path.write_text(stderr, encoding="utf-8")
+        artifact_payload["stdout"] = str(stdout_path.relative_to(REPO_ROOT))
+        artifact_payload["stderr"] = str(stderr_path.relative_to(REPO_ROOT))
+    return OrderedDict(
+        command=command,
+        exit_code=result.returncode,
+        status="passed" if result.returncode == 0 else "failed",
+        duration_seconds=duration,
+        stdout_tail=stdout[-4000:],
+        stderr_tail=stderr[-4000:],
+        artifacts=artifact_payload,
+    )
+
+
+def evaluate_prerequisite(token: str) -> tuple[bool, str]:
+    if token == "gh-auth":
+        result = subprocess.run(
+            ["gh", "auth", "status"],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        return result.returncode == 0, "gh auth status failed" if result.returncode != 0 else "ok"
+    if token.startswith("command:"):
+        name = token.split(":", 1)[1]
+        return shutil.which(name) is not None, f"missing command `{name}`"
+    if token.startswith("env:"):
+        name = token.split(":", 1)[1]
+        return bool(os.environ.get(name)), f"missing env `{name}`"
+    if token.startswith("path:"):
+        candidate = token.split(":", 1)[1]
+        return (REPO_ROOT / candidate).exists(), f"missing path `{candidate}`"
+    return False, f"unknown prerequisite token `{token}`"
+
+
+def evaluate_prerequisites(tokens: list[str]) -> tuple[list[str], list[str]]:
+    met: list[str] = []
+    unmet: list[str] = []
+    for token in tokens:
+        ok, message = evaluate_prerequisite(token)
+        if ok:
+            met.append(token)
+        else:
+            unmet.append(message)
+    return met, unmet
+
+
+def gh_api_json(repo: str, endpoint: str) -> list[dict[str, Any]]:
+    result = subprocess.run(
+        ["gh", "api", "-H", "Accept: application/vnd.github+json", endpoint],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+        env=os.environ.copy(),
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or f"gh api failed for {endpoint}")
+    return json.loads(result.stdout)
+
+
+def normalize_severity(raw: str | None) -> str:
+    value = (raw or "").strip().lower()
+    if value in {"warning", "error", "note"}:
+        return {"warning": "medium", "error": "high", "note": "low"}[value]
+    if value in SEVERITY_ORDER:
+        return value
+    return "unknown"
+
+
+def alert_severity(alert: dict[str, Any], kind: str) -> str:
+    if kind == "dependabot":
+        advisory = alert.get("security_advisory") or {}
+        return normalize_severity(advisory.get("severity"))
+    rule = alert.get("rule") or {}
+    instance = alert.get("most_recent_instance") or {}
+    return normalize_severity(
+        rule.get("security_severity_level")
+        or instance.get("security_severity_level")
+        or rule.get("severity")
+        or instance.get("severity")
+    )
+
+
+def summarize_alerts(kind: str, alerts: list[dict[str, Any]]) -> OrderedDict[str, Any]:
+    counter: Counter[str] = Counter()
+    top_items: list[OrderedDict[str, Any]] = []
+    for alert in alerts:
+        severity = alert_severity(alert, kind)
+        counter[severity] += 1
+        if len(top_items) >= 8:
+            continue
+        if kind == "dependabot":
+            dependency = (((alert.get("dependency") or {}).get("package") or {}).get("name")) or "<unknown>"
+            summary = ((alert.get("security_advisory") or {}).get("summary")) or ""
+            top_items.append(
+                OrderedDict(
+                    number=alert.get("number"),
+                    dependency=dependency,
+                    severity=severity,
+                    summary=summary.strip(),
+                )
+            )
+        else:
+            tool = ((alert.get("tool") or {}).get("name")) or "codeql"
+            rule = ((alert.get("rule") or {}).get("id")) or "<unknown>"
+            location = ((alert.get("most_recent_instance") or {}).get("location") or {}).get("path") or "<unknown>"
+            top_items.append(
+                OrderedDict(
+                    number=alert.get("number"),
+                    tool=tool,
+                    rule=rule,
+                    severity=severity,
+                    location=location,
+                )
+            )
+    return OrderedDict(
+        total=len(alerts),
+        counts=OrderedDict((key, counter.get(key, 0)) for key in ("critical", "high", "medium", "low", "unknown")),
+        top_items=top_items,
+    )
+
+
+def exceeds_threshold(summary: dict[str, Any], threshold: str) -> bool:
+    if threshold == "none":
+        return False
+    rank = SEVERITY_ORDER.get(threshold, 99)
+    for severity, count in (summary.get("counts") or {}).items():
+        if count and SEVERITY_ORDER.get(severity, -1) >= rank:
+            return True
+    return False
+
+
+def fetch_alert_snapshot(kind: str, repo: str, *, threshold: str = "none", artifacts_dir: Path | None = None) -> OrderedDict[str, Any]:
+    if kind == "dependabot":
+        endpoint = f"/repos/{repo}/dependabot/alerts?state=open&per_page=100"
+    elif kind == "code-scanning":
+        endpoint = f"/repos/{repo}/code-scanning/alerts?state=open&per_page=100"
+    else:
+        raise ValueError(f"unsupported alert kind: {kind}")
+    alerts = gh_api_json(repo, endpoint)
+    summary = summarize_alerts(kind, alerts)
+    payload = OrderedDict(
+        kind=kind,
+        threshold=threshold,
+        summary=summary,
+        status="failed" if exceeds_threshold(summary, threshold) else "passed",
+    )
+    if artifacts_dir is not None:
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
+        raw_path = artifacts_dir / f"{kind}-alerts.raw.json"
+        summary_path = artifacts_dir / f"{kind}-alerts.summary.json"
+        raw_path.write_text(json.dumps(alerts, indent=2), encoding="utf-8")
+        summary_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        payload["artifacts"] = OrderedDict(
+            raw=str(raw_path.relative_to(REPO_ROOT)),
+            summary=str(summary_path.relative_to(REPO_ROOT)),
+        )
+    return payload
+
+
+def run_workflow_maintenance(workflow: dict[str, Any], artifacts_dir: Path | None = None) -> OrderedDict[str, Any]:
+    _, unmet = evaluate_prerequisites(workflow.get("maintenance_prerequisites", []))
+    commands = workflow.get("maintenance_runner", [])
+    result = OrderedDict(
+        id=workflow["id"],
+        maintenance_owner=workflow.get("maintenance_owner"),
+        cadence=workflow.get("maintenance_cadence"),
+        scheduled_safe=workflow.get("scheduled_safe"),
+        blockers=workflow.get("maintenance_blockers", []),
+        prerequisites=workflow.get("maintenance_prerequisites", []),
+    )
+    if unmet:
+        result["status"] = "skipped"
+        result["skip_reason"] = ", ".join(unmet)
+        result["commands"] = []
+        return result
+
+    command_results: list[OrderedDict[str, Any]] = []
+    workflow_artifacts = None
+    if artifacts_dir is not None:
+        workflow_artifacts = artifacts_dir / workflow["id"]
+    status = "passed"
+    for index, command in enumerate(commands, start=1):
+        command_result = run_shell(
+            command,
+            artifacts_dir=workflow_artifacts,
+            prefix=f"{index:02d}",
+        )
+        command_results.append(command_result)
+        if command_result["status"] != "passed":
+            status = "failed"
+            break
+    result["status"] = status
+    result["commands"] = command_results
+    return result
+
+
+def run_codex_audit(artifacts_dir: Path | None = None) -> OrderedDict[str, Any]:
+    result = run_shell("./bin/hushh codex audit --json", artifacts_dir=artifacts_dir, prefix="codex-audit")
+    payload: OrderedDict[str, Any] = OrderedDict(status=result["status"], command=result)
+    if result["status"] == "passed":
+        rerun = subprocess.run(
+            ["/bin/bash", "-lc", "./bin/hushh codex audit --json"],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        audit = json.loads(rerun.stdout)
+        payload["audit"] = audit.get("audit", {})
+    return payload
+
+
+def remediation_items(report: dict[str, Any]) -> list[str]:
+    items: list[str] = []
+    security = report.get("security", {})
+    for kind in ("dependabot", "code_scanning"):
+        summary = ((security.get(kind) or {}).get("summary")) or {}
+        counts = summary.get("counts") or {}
+        severe = counts.get("critical", 0) + counts.get("high", 0)
+        if severe:
+            items.append(f"{kind.replace('_', ' ')} has {severe} high/critical open alerts")
+    audit = ((report.get("codex_audit") or {}).get("audit")) or {}
+    for finding in (audit.get("findings") or {}).get("high", [])[:5]:
+        items.append(f"Codex audit high: {finding}")
+    for workflow in report.get("workflow_results", []):
+        if workflow.get("status") == "failed":
+            items.append(f"{workflow['id']} failed: {(workflow.get('blockers') or ['maintenance runner failed'])[0]}")
+    return items[:10]
+
+
+def build_issue_body(report: dict[str, Any], previous_body: str = "") -> str:
+    timestamp = report["generated_at"]
+    security = report["security"]
+    dependabot = security["dependabot"]["summary"]["counts"]
+    code_scanning = security["code_scanning"]["summary"]["counts"]
+    audit = ((report.get("codex_audit") or {}).get("audit")) or {}
+    scorecard = audit.get("scorecard") or {}
+
+    history_sections: list[str] = []
+    if "## History" in previous_body:
+        history_sections = previous_body.split("## History", 1)[1].strip().split("\n### ")
+        if history_sections and history_sections[0]:
+            history_sections[0] = history_sections[0].lstrip("# ").strip()
+    new_history_entry = "\n".join(
+        [
+            f"### {timestamp} ({report['cadence']})",
+            f"- status: {report['status']}",
+            f"- workflows: {report['summary']['passed_workflows']} passed, {report['summary']['failed_workflows']} failed, {report['summary']['skipped_workflows']} skipped",
+            f"- dependabot high/critical: {dependabot.get('high', 0) + dependabot.get('critical', 0)}",
+            f"- code scanning high/critical: {code_scanning.get('high', 0) + code_scanning.get('critical', 0)}",
+        ]
+    )
+    prior_entries = [entry for entry in history_sections if entry.strip()]
+    history = [new_history_entry] + [f"### {entry}" if not entry.startswith("### ") else entry for entry in prior_entries[:9]]
+
+    workflow_lines = []
+    for workflow in report["workflow_results"]:
+        line = f"- `{workflow['id']}`: {workflow['status']}"
+        if workflow.get("skip_reason"):
+            line += f" ({workflow['skip_reason']})"
+        workflow_lines.append(line)
+
+    remediation = remediation_items(report)
+    remediation_lines = remediation or ["- none"]
+
+    return "\n".join(
+        [
+            "<!-- codex-maintenance-radar -->",
+            "# Codex Maintenance Radar",
+            "",
+            "## Latest",
+            f"- generated_at: `{timestamp}`",
+            f"- cadence: `{report['cadence']}`",
+            f"- status: `{report['status']}`",
+            "",
+            "## Security",
+            f"- Dependabot: critical={dependabot.get('critical', 0)}, high={dependabot.get('high', 0)}, medium={dependabot.get('medium', 0)}, low={dependabot.get('low', 0)}",
+            f"- Code scanning: critical={code_scanning.get('critical', 0)}, high={code_scanning.get('high', 0)}, medium={code_scanning.get('medium', 0)}, low={code_scanning.get('low', 0)}",
+            "",
+            "## Codex Audit",
+            f"- status: `{audit.get('status', 'unknown')}`",
+            f"- scorecard: coverage={scorecard.get('coverage', 'n/a')}, routing={scorecard.get('routing_integrity', 'n/a')}, verification={scorecard.get('verification_integrity', 'n/a')}, onboarding={scorecard.get('onboarding_readiness', 'n/a')}",
+            "",
+            "## Workflow Results",
+            *workflow_lines,
+            "",
+            "## Top Remediation Items",
+            *remediation_lines,
+            "",
+            "## History",
+            *history,
+        ]
+    )
+
+
+def upsert_issue(repo: str, report: dict[str, Any]) -> OrderedDict[str, Any]:
+    issue_list = subprocess.run(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--search",
+            f'"{ISSUE_TITLE}" in:title',
+            "--json",
+            "number,title,body,url",
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if issue_list.returncode != 0:
+        raise RuntimeError(issue_list.stderr.strip() or "failed to list maintenance issues")
+    existing = json.loads(issue_list.stdout)
+    previous_body = existing[0]["body"] if existing else ""
+    body = build_issue_body(report, previous_body=previous_body)
+    if existing:
+        number = str(existing[0]["number"])
+        edit = subprocess.run(
+            ["gh", "issue", "edit", number, "--repo", repo, "--body-file", "-"],
+            cwd=REPO_ROOT,
+            text=True,
+            input=body,
+            capture_output=True,
+            check=False,
+        )
+        if edit.returncode != 0:
+            raise RuntimeError(edit.stderr.strip() or "failed to update maintenance issue")
+        return OrderedDict(action="updated", number=existing[0]["number"], url=existing[0]["url"])
+    create = subprocess.run(
+        ["gh", "issue", "create", "--repo", repo, "--title", ISSUE_TITLE, "--body-file", "-"],
+        cwd=REPO_ROOT,
+        text=True,
+        input=body,
+        capture_output=True,
+        check=False,
+    )
+    if create.returncode != 0:
+        raise RuntimeError(create.stderr.strip() or "failed to create maintenance issue")
+    return OrderedDict(action="created", number=None, url=create.stdout.strip())
+
+
+def run_maintenance(cadence: str, *, artifacts_dir: Path | None = None, update_issue_enabled: bool = True) -> OrderedDict[str, Any]:
+    repo = resolve_repo()
+    workflows = [
+        workflow
+        for workflow in load_workflows()
+        if workflow.get("scheduled_safe") is True and workflow.get("maintenance_cadence") == cadence
+    ]
+    workflow_results = [run_workflow_maintenance(workflow, artifacts_dir=artifacts_dir) for workflow in workflows]
+    security_dir = artifacts_dir / "security" if artifacts_dir is not None else None
+    security = OrderedDict(
+        dependabot=fetch_alert_snapshot(
+            "dependabot",
+            repo,
+            threshold="high" if cadence == "daily" else "none",
+            artifacts_dir=security_dir,
+        ),
+        code_scanning=fetch_alert_snapshot(
+            "code-scanning",
+            repo,
+            threshold="high" if cadence == "daily" else "none",
+            artifacts_dir=security_dir,
+        ),
+    )
+    audit_dir = artifacts_dir / "codex-audit" if artifacts_dir is not None else None
+    codex_audit = run_codex_audit(artifacts_dir=audit_dir)
+
+    failed_workflows = sum(1 for item in workflow_results if item["status"] == "failed")
+    skipped_workflows = sum(1 for item in workflow_results if item["status"] == "skipped")
+    passed_workflows = sum(1 for item in workflow_results if item["status"] == "passed")
+
+    status = "ok"
+    if failed_workflows:
+        status = "failed"
+    if cadence == "daily" and (
+        security["dependabot"]["status"] == "failed" or security["code_scanning"]["status"] == "failed"
+    ):
+        status = "failed"
+    if cadence in {"daily", "weekly"}:
+        audit_payload = (codex_audit.get("audit") or {})
+        if (audit_payload.get("findings") or {}).get("high"):
+            status = "failed"
+
+    report = OrderedDict(
+        version=1,
+        generated_at=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ"),
+        repository=repo,
+        cadence=cadence,
+        status=status,
+        workflow_results=workflow_results,
+        security=OrderedDict(
+            dependabot=security["dependabot"],
+            code_scanning=security["code_scanning"],
+        ),
+        codex_audit=codex_audit,
+        summary=OrderedDict(
+            selected_workflows=[workflow["id"] for workflow in workflows],
+            passed_workflows=passed_workflows,
+            failed_workflows=failed_workflows,
+            skipped_workflows=skipped_workflows,
+        ),
+    )
+
+    if update_issue_enabled:
+        report["maintenance_issue"] = upsert_issue(repo, report)
+
+    return report
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run Codex maintenance workflows and security posture snapshots.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = subparsers.add_parser("run", help="run a maintenance cadence")
+    run_parser.add_argument("--cadence", choices=sorted(CADENCES - {"manual"}), required=True)
+    run_parser.add_argument("--report-file", help="write the JSON report to this path")
+    run_parser.add_argument("--artifacts-dir", help="write logs and snapshots into this directory")
+    run_parser.add_argument("--no-issue-update", action="store_true", help="skip the rolling issue update")
+    run_parser.add_argument("--json", action="store_true", help="emit JSON")
+    run_parser.add_argument("--text", action="store_true", help="emit concise text")
+
+    snapshot_parser = subparsers.add_parser("snapshot-alerts", help="snapshot GitHub alert surfaces")
+    snapshot_parser.add_argument("--kind", choices=["dependabot", "code-scanning"], required=True)
+    snapshot_parser.add_argument("--severity-threshold", choices=["none", "high", "critical"], default="none")
+    snapshot_parser.add_argument("--output", help="write JSON output to this path")
+    snapshot_parser.add_argument("--json", action="store_true", help="emit JSON")
+    snapshot_parser.add_argument("--text", action="store_true", help="emit concise text")
+
+    return parser.parse_args()
+
+
+def render_text(report: dict[str, Any]) -> str:
+    if report.get("kind"):
+        counts = report["summary"]["counts"]
+        return (
+            f"{report['kind']} alerts: total={report['summary']['total']}, "
+            f"critical={counts.get('critical', 0)}, high={counts.get('high', 0)}, "
+            f"medium={counts.get('medium', 0)}, low={counts.get('low', 0)}"
+        )
+    lines = [
+        f"Codex maintenance ({report['cadence']}): {report['status']}",
+        f"Workflows: passed={report['summary']['passed_workflows']}, failed={report['summary']['failed_workflows']}, skipped={report['summary']['skipped_workflows']}",
+    ]
+    for workflow in report["workflow_results"]:
+        line = f"- {workflow['id']}: {workflow['status']}"
+        if workflow.get("skip_reason"):
+            line += f" ({workflow['skip_reason']})"
+        lines.append(line)
+    dependabot = report["security"]["dependabot"]["summary"]["counts"]
+    code_scanning = report["security"]["code_scanning"]["summary"]["counts"]
+    lines.append(
+        "Security: "
+        f"dependabot high/critical={dependabot.get('high', 0) + dependabot.get('critical', 0)}, "
+        f"code-scanning high/critical={code_scanning.get('high', 0) + code_scanning.get('critical', 0)}"
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    if args.command == "snapshot-alerts":
+        payload = fetch_alert_snapshot(
+            args.kind,
+            resolve_repo(),
+            threshold=args.severity_threshold,
+        )
+        if args.output:
+            output_path = Path(args.output)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        if args.text:
+            print(render_text(payload))
+        else:
+            print(json.dumps(payload, indent=2))
+        return 1 if payload["status"] == "failed" else 0
+
+    artifacts_dir = Path(args.artifacts_dir) if args.artifacts_dir else None
+    report = run_maintenance(
+        args.cadence,
+        artifacts_dir=artifacts_dir,
+        update_issue_enabled=not args.no_issue_update,
+    )
+    if args.report_file:
+        report_path = Path(args.report_file)
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    if args.text:
+        print(render_text(report))
+    else:
+        print(json.dumps(report, indent=2))
+    return 1 if report["status"] == "failed" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/runtime/open_visible_terminal.sh
+++ b/scripts/runtime/open_visible_terminal.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/runtime/open_visible_terminal.sh --cwd <path> --title <title> -- <command> [args...]
+
+Opens a visible OS terminal window and runs the requested command there.
+
+Environment:
+  HUSHH_VISIBLE_TERMINAL_APP   Optional terminal preference (for example: terminal, iterm, gnome-terminal, konsole, kitty, wt)
+EOF
+}
+
+die() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+require_gui_display() {
+  if [ -z "${DISPLAY:-}" ] && [ -z "${WAYLAND_DISPLAY:-}" ]; then
+    die "No graphical display detected. Use the direct ./bin/hushh commands in the current shell instead."
+  fi
+}
+
+detect_os() {
+  case "$(uname -s)" in
+    Darwin)
+      echo "darwin"
+      ;;
+    Linux)
+      if [ -n "${WSL_DISTRO_NAME:-}" ] || grep -qi microsoft /proc/version 2>/dev/null; then
+        echo "wsl"
+      else
+        echo "linux"
+      fi
+      ;;
+    MINGW*|MSYS*|CYGWIN*)
+      echo "windows"
+      ;;
+    *)
+      echo "unknown"
+      ;;
+  esac
+}
+
+PREFERRED_TERMINAL="${HUSHH_VISIBLE_TERMINAL_APP:-}"
+PREFERRED_TERMINAL_LOWER="$(printf '%s' "$PREFERRED_TERMINAL" | tr '[:upper:]' '[:lower:]')"
+CWD=""
+TITLE="Hushh terminal"
+COMMAND_ARGS=()
+
+while [ "$#" -gt 0 ]; do
+  case "${1:-}" in
+    --cwd)
+      CWD="${2:-}"
+      shift 2
+      ;;
+    --title)
+      TITLE="${2:-}"
+      shift 2
+      ;;
+    --)
+      shift
+      COMMAND_ARGS=("$@")
+      break
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown option: $1"
+      ;;
+  esac
+done
+
+[ -n "$CWD" ] || die "--cwd is required"
+[ "${#COMMAND_ARGS[@]}" -gt 0 ] || die "Command is required after --"
+
+mkdir -p "${TMPDIR:-/tmp}"
+LAUNCHER_BASE="$(mktemp "${TMPDIR:-/tmp}/hushh-visible-terminal.XXXXXX")"
+LAUNCHER_SCRIPT="${LAUNCHER_BASE}.sh"
+mv "$LAUNCHER_BASE" "$LAUNCHER_SCRIPT"
+chmod +x "$LAUNCHER_SCRIPT"
+
+printf -v COMMAND_STRING '%q ' "${COMMAND_ARGS[@]}"
+COMMAND_STRING="${COMMAND_STRING% }"
+
+cat >"$LAUNCHER_SCRIPT" <<EOF
+#!/usr/bin/env bash
+set -uo pipefail
+cd $(printf '%q' "$CWD")
+printf '\\033]0;%s\\007' $(printf '%q' "$TITLE") >/dev/null 2>&1 || true
+${COMMAND_STRING}
+status=\$?
+echo
+if [ "\$status" -eq 0 ]; then
+  echo "[hushh terminal] Command finished successfully."
+else
+  echo "[hushh terminal] Command exited with status \$status."
+fi
+echo "[hushh terminal] Leaving shell open in $(printf '%q' "$CWD")."
+rm -f -- "\$0" >/dev/null 2>&1 || true
+exec "\${SHELL:-/bin/bash}" -l
+EOF
+
+launch_macos_terminal() {
+  osascript <<EOF
+tell application "Terminal"
+  activate
+  do script "bash $(printf '%q' "$LAUNCHER_SCRIPT")"
+end tell
+EOF
+}
+
+launch_macos_iterm() {
+  osascript <<EOF
+tell application "iTerm"
+  activate
+  create window with default profile
+  tell current session of current window
+    write text "bash $(printf '%q' "$LAUNCHER_SCRIPT")"
+  end tell
+end tell
+EOF
+}
+
+launch_linux_terminal() {
+  require_gui_display
+  case "$PREFERRED_TERMINAL_LOWER" in
+    ""|auto) ;;
+    gnome-terminal)
+      command -v gnome-terminal >/dev/null 2>&1 || die "Preferred terminal gnome-terminal is not installed."
+      gnome-terminal -- bash "$LAUNCHER_SCRIPT" >/dev/null 2>&1 &
+      return
+      ;;
+    konsole)
+      command -v konsole >/dev/null 2>&1 || die "Preferred terminal konsole is not installed."
+      konsole --noclose -e bash "$LAUNCHER_SCRIPT" >/dev/null 2>&1 &
+      return
+      ;;
+    kitty)
+      command -v kitty >/dev/null 2>&1 || die "Preferred terminal kitty is not installed."
+      kitty --hold bash "$LAUNCHER_SCRIPT" >/dev/null 2>&1 &
+      return
+      ;;
+    wezterm)
+      command -v wezterm >/dev/null 2>&1 || die "Preferred terminal wezterm is not installed."
+      wezterm start -- bash "$LAUNCHER_SCRIPT" >/dev/null 2>&1 &
+      return
+      ;;
+    x-terminal-emulator)
+      command -v x-terminal-emulator >/dev/null 2>&1 || die "Preferred terminal x-terminal-emulator is not installed."
+      x-terminal-emulator -e bash "$LAUNCHER_SCRIPT" >/dev/null 2>&1 &
+      return
+      ;;
+    *)
+      die "Unsupported HUSHH_VISIBLE_TERMINAL_APP for Linux: $PREFERRED_TERMINAL"
+      ;;
+  esac
+
+  if command -v x-terminal-emulator >/dev/null 2>&1; then
+    x-terminal-emulator -e bash "$LAUNCHER_SCRIPT" >/dev/null 2>&1 &
+  elif command -v gnome-terminal >/dev/null 2>&1; then
+    gnome-terminal -- bash "$LAUNCHER_SCRIPT" >/dev/null 2>&1 &
+  elif command -v konsole >/dev/null 2>&1; then
+    konsole --noclose -e bash "$LAUNCHER_SCRIPT" >/dev/null 2>&1 &
+  elif command -v xfce4-terminal >/dev/null 2>&1; then
+    xfce4-terminal --hold --command "bash $(printf '%q' "$LAUNCHER_SCRIPT")" >/dev/null 2>&1 &
+  elif command -v mate-terminal >/dev/null 2>&1; then
+    mate-terminal -- bash "$LAUNCHER_SCRIPT" >/dev/null 2>&1 &
+  elif command -v kitty >/dev/null 2>&1; then
+    kitty --hold bash "$LAUNCHER_SCRIPT" >/dev/null 2>&1 &
+  elif command -v wezterm >/dev/null 2>&1; then
+    wezterm start -- bash "$LAUNCHER_SCRIPT" >/dev/null 2>&1 &
+  elif command -v xterm >/dev/null 2>&1; then
+    xterm -hold -e bash "$LAUNCHER_SCRIPT" >/dev/null 2>&1 &
+  else
+    die "No supported Linux terminal launcher found. Try setting HUSHH_VISIBLE_TERMINAL_APP or run the command directly."
+  fi
+}
+
+launch_wsl_or_windows() {
+  if command -v wt.exe >/dev/null 2>&1; then
+    if [ "$(detect_os)" = "wsl" ]; then
+      wt.exe new-tab --title "$TITLE" wsl.exe bash -lc "bash $(printf '%q' "$LAUNCHER_SCRIPT")" >/dev/null 2>&1 &
+    else
+      wt.exe new-tab --title "$TITLE" bash -lc "bash $(printf '%q' "$LAUNCHER_SCRIPT")" >/dev/null 2>&1 &
+    fi
+    return
+  fi
+
+  if command -v cmd.exe >/dev/null 2>&1; then
+    if [ "$(detect_os)" = "wsl" ]; then
+      cmd.exe /c start "" wsl.exe bash -lc "bash $(printf '%q' "$LAUNCHER_SCRIPT")" >/dev/null 2>&1 &
+    else
+      cmd.exe /c start "" bash -lc "bash $(printf '%q' "$LAUNCHER_SCRIPT")" >/dev/null 2>&1 &
+    fi
+    return
+  fi
+
+  if command -v powershell.exe >/dev/null 2>&1; then
+    powershell.exe -NoProfile -Command "Start-Process powershell -ArgumentList '-NoExit','-Command','bash $(printf "%q" "$LAUNCHER_SCRIPT")'" >/dev/null 2>&1 &
+    return
+  fi
+
+  die "No supported Windows terminal launcher found. Run the command directly in your terminal."
+}
+
+case "$(detect_os)" in
+  darwin)
+    case "$PREFERRED_TERMINAL_LOWER" in
+      ""|auto|terminal)
+        launch_macos_terminal
+        ;;
+      iterm|iterm2)
+        launch_macos_iterm
+        ;;
+      *)
+        die "Unsupported HUSHH_VISIBLE_TERMINAL_APP for macOS: $PREFERRED_TERMINAL"
+        ;;
+    esac
+    ;;
+  linux)
+    launch_linux_terminal
+    ;;
+  wsl|windows)
+    launch_wsl_or_windows
+    ;;
+  *)
+    die "Unsupported operating system: $(uname -s)"
+    ;;
+esac
+
+echo "Opened visible terminal window for: ${COMMAND_ARGS[*]}"


### PR DESCRIPTION
## What changed
- added Codex maintenance scheduling, security posture workflow metadata, and rolling issue/update infrastructure
- added visible OS terminal launcher support and aligned CLI/docs/VS Code helpers around the `./bin/hushh terminal ...` flow
- extended the Codex audit, workflow linting, and repo-context routing surfaces to understand maintenance cadence and scheduled-safe workflows

## Why it changed
- the repo had strong request-time routing and CI-time security checks, but no time-driven maintenance layer to keep workflows, security backlog, and docs integrity exercised on cadence
- local runtime startup was also split between hidden agent sessions and stale editor launch configs, which created drift in the supported dev flow

## Impact
- new scheduled workflows now cover daily, weekly, and monthly Codex maintenance
- repo-tracked Dependabot policy is now explicit
- contributors and agents now have one canonical visible-terminal flow for frontend/backend startup
- daily maintenance will currently fail on the existing GitHub Dependabot backlog until those alerts are remediated

## Validation
- `./bin/hushh docs verify`
- `python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py`
- `python3 .codex/skills/repo-context/scripts/repo_scan.py validate --text`
- `python3 -m py_compile scripts/ops/codex_maintenance.py .codex/skills/repo-context/scripts/repo_scan.py .codex/skills/codex-skill-authoring/scripts/skill_lint.py`
- `bash -n bin/hushh scripts/runtime/open_visible_terminal.sh scripts/ci/github-security-alerts.sh`
- `./bin/hushh codex audit --text`
- `./bin/hushh codex maintenance daily --no-issue-update --json`
