### PR TITLE
Reduce Dependabot fan-out and unblock bot PR scans

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,11 @@ updates:
   - package-ecosystem: "npm"
     directory: "/hushh-webapp"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
+      interval: "weekly"
+      day: "monday"
+      time: "15:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 3
     labels:
       - "dependencies"
       - "security"
@@ -16,12 +19,19 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "npm"
     directory: "/packages/hushh-mcp"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
+      interval: "weekly"
+      day: "tuesday"
+      time: "15:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 2
     labels:
       - "dependencies"
       - "security"
@@ -33,13 +43,19 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "pip"
     directory: "/consent-protocol"
     schedule:
       interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 10
+      day: "wednesday"
+      time: "15:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 2
     labels:
       - "dependencies"
       - "security"
@@ -51,13 +67,19 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 10
+      day: "thursday"
+      time: "15:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 2
     labels:
       - "dependencies"
       - "security"
@@ -69,3 +91,7 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,8 @@ jobs:
         env:
           GITLEAKS_LOG_OPTS: ${{ steps.scan-range.outputs.log_opts }}
           GH_TOKEN: ${{ secrets.GH_SECURITY_ALERTS_TOKEN != '' && secrets.GH_SECURITY_ALERTS_TOKEN || github.token }}
-          REQUIRE_GITHUB_ALERTS_CLEAN: "1"
-          REQUIRE_GITHUB_SECRET_ALERTS_CLEAN: "1"
+          REQUIRE_GITHUB_ALERTS_CLEAN: ${{ github.actor == 'dependabot[bot]' && '0' || '1' }}
+          REQUIRE_GITHUB_SECRET_ALERTS_CLEAN: ${{ github.actor == 'dependabot[bot]' && '0' || '1' }}
           REQUIRE_GITHUB_DEPENDABOT_ALERTS_CLEAN: "0"
 
   # ============================================================================


### PR DESCRIPTION
## What changed
- reduced Dependabot cadence from immediate daily fan-out to staggered weekly windows
- limited automated updates to grouped patch/minor lanes and ignored semver-major upgrades by default
- lowered open PR caps per ecosystem
- stopped `PR Validation` secret-scan from hard-failing Dependabot PRs on privileged GitHub alert access that the bot cannot use

## Why it changed
- merging the first Dependabot policy caused a one-time flood of major-version PRs and redundant Actions noise
- grouped patch/minor PRs were also failing early in `Secret Scan` for bot-permission reasons rather than real code breakage

## Operational outcome
- only grouped patch/minor Dependabot PRs should remain open going forward
- major upgrades are now intentional manual work
- current noisy major Dependabot PRs were closed after the policy change

## Validation
- `python3 - <<'PY' ... yaml.safe_load('.github/dependabot.yml', '.github/workflows/ci.yml') ...`
- `./bin/hushh docs verify`
- live UAT run `24274751149` on merge commit `95edbb11...` completed successfully while this cleanup was in progress
