### PR TITLE
feat: harden RIA verification with fail-closed gate and dev allowlist

### DIFF
--- a/consent-protocol/api/routes/consent.py
+++ b/consent-protocol/api/routes/consent.py
@@ -29,7 +29,11 @@ from hushh_mcp.constants import ConsentScope
 from hushh_mcp.services.actor_identity_service import ActorIdentityService
 from hushh_mcp.services.consent_center_service import ConsentCenterService
 from hushh_mcp.services.consent_db import ConsentDBService
-from hushh_mcp.services.ria_iam_service import IAMSchemaNotReadyError, RIAIAMPolicyError, RIAIAMService
+from hushh_mcp.services.ria_iam_service import (
+    IAMSchemaNotReadyError,
+    RIAIAMPolicyError,
+    RIAIAMService,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/consent-protocol/api/routes/consent.py
+++ b/consent-protocol/api/routes/consent.py
@@ -29,7 +29,7 @@ from hushh_mcp.constants import ConsentScope
 from hushh_mcp.services.actor_identity_service import ActorIdentityService
 from hushh_mcp.services.consent_center_service import ConsentCenterService
 from hushh_mcp.services.consent_db import ConsentDBService
-from hushh_mcp.services.ria_iam_service import RIAIAMPolicyError, RIAIAMService
+from hushh_mcp.services.ria_iam_service import IAMSchemaNotReadyError, RIAIAMPolicyError, RIAIAMService
 
 logger = logging.getLogger(__name__)
 
@@ -665,6 +665,17 @@ async def create_generic_consent_request(
     payload: GenericConsentRequestCreate,
     firebase_uid: str = Depends(require_firebase_auth),
 ):
+    # If the requester is an RIA, enforce verification before allowing
+    # consent requests to investors (mirrors the gate on POST /api/ria/requests).
+    if payload.requester_actor_type == "ria":
+        service = RIAIAMService()
+        try:
+            await service.require_ria_verified(firebase_uid)
+        except IAMSchemaNotReadyError as exc:
+            raise HTTPException(status_code=503, detail="Verification service unavailable") from exc
+        except RIAIAMPolicyError as exc:
+            raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+
     try:
         return await RIAIAMService().create_ria_consent_request(
             firebase_uid,

--- a/consent-protocol/api/routes/ria.py
+++ b/consent-protocol/api/routes/ria.py
@@ -24,8 +24,8 @@ async def _require_ria_verified(
     service = RIAIAMService()
     try:
         await service.require_ria_verified(firebase_uid)
-    except IAMSchemaNotReadyError:
-        pass  # let the downstream handler surface the 503
+    except IAMSchemaNotReadyError as exc:
+        raise HTTPException(status_code=503, detail="Verification service unavailable") from exc
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
     return firebase_uid

--- a/consent-protocol/api/routes/ria.py
+++ b/consent-protocol/api/routes/ria.py
@@ -17,6 +17,20 @@ from hushh_mcp.services.ria_iam_service import (
 router = APIRouter(prefix="/api/ria", tags=["RIA"])
 
 
+async def _require_ria_verified(
+    firebase_uid: str = Depends(require_firebase_auth),
+) -> str:
+    """Fail-closed dependency: 403 if the caller is not a verified RIA."""
+    service = RIAIAMService()
+    try:
+        await service.require_ria_verified(firebase_uid)
+    except IAMSchemaNotReadyError:
+        pass  # let the downstream handler surface the 503
+    except RIAIAMPolicyError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+    return firebase_uid
+
+
 class RIAOnboardingSubmitRequest(BaseModel):
     display_name: str = Field(..., min_length=1)
     requested_capabilities: list[str] = Field(default_factory=lambda: ["advisory"])
@@ -241,7 +255,7 @@ async def ria_clients(
     status: str | None = Query(default=None),
     page: int = Query(default=1, ge=1),
     limit: int = Query(default=50, ge=1, le=100),
-    firebase_uid: str = Depends(require_firebase_auth),
+    firebase_uid: str = Depends(_require_ria_verified),
 ):
     service = RIAIAMService()
     try:
@@ -262,7 +276,7 @@ async def ria_clients(
 @router.get("/clients/{investor_user_id}", response_model=RIAClientDetailResponse)
 async def ria_client_detail(
     investor_user_id: str,
-    firebase_uid: str = Depends(require_firebase_auth),
+    firebase_uid: str = Depends(_require_ria_verified),
 ):
     service = RIAIAMService()
     try:
@@ -314,7 +328,7 @@ async def ria_invites(firebase_uid: str = Depends(require_firebase_auth)):
 @router.post("/invites")
 async def create_ria_invites(
     payload: RIAInviteCreateRequest,
-    firebase_uid: str = Depends(require_firebase_auth),
+    firebase_uid: str = Depends(_require_ria_verified),
 ):
     service = RIAIAMService()
     try:
@@ -355,7 +369,7 @@ async def update_ria_marketplace_discoverability(
 @router.post("/requests")
 async def create_ria_request(
     payload: RIAConsentRequestCreate,
-    firebase_uid: str = Depends(require_firebase_auth),
+    firebase_uid: str = Depends(_require_ria_verified),
 ):
     service = RIAIAMService()
     try:
@@ -380,7 +394,7 @@ async def create_ria_request(
 @router.post("/request-bundles")
 async def create_ria_request_bundle(
     payload: RIAConsentBundleCreate,
-    firebase_uid: str = Depends(require_firebase_auth),
+    firebase_uid: str = Depends(_require_ria_verified),
 ):
     service = RIAIAMService()
     try:
@@ -525,7 +539,7 @@ async def upload_ria_picks(
 @router.get("/workspace/{investor_user_id}")
 async def ria_workspace(
     investor_user_id: str,
-    firebase_uid: str = Depends(require_firebase_auth),
+    firebase_uid: str = Depends(_require_ria_verified),
 ):
     service = RIAIAMService()
     try:
@@ -540,7 +554,7 @@ async def ria_workspace(
 async def set_ria_client_picks_share(
     investor_user_id: str,
     payload: RIAPicksShareStateRequest,
-    firebase_uid: str = Depends(require_firebase_auth),
+    firebase_uid: str = Depends(_require_ria_verified),
 ):
     service = RIAIAMService()
     try:

--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -196,8 +196,51 @@ class RIAIAMService:
         return self._runtime_environment() not in {"prod", "production"}
 
     def _is_dev_bypass_allowed(self, user_id: str) -> bool:
-        _ = user_id
-        return self._is_ria_dev_bypass_enabled()
+        if not self._is_ria_dev_bypass_enabled():
+            return False
+        allowlist_raw = str(os.getenv("RIA_DEV_ALLOWLIST", "")).strip()
+        if not allowlist_raw:
+            return True
+        allowed_ids = {uid.strip() for uid in allowlist_raw.split(",") if uid.strip()}
+        return user_id in allowed_ids
+
+    _RIA_VERIFIED_STATUSES: frozenset[str] = frozenset(
+        {"active", "verified", "bypassed", "finra_verified"}
+    )
+
+    async def require_ria_verified(self, user_id: str) -> None:
+        """Fail-closed check: raises 403 if the RIA is not verified.
+
+        Checked before any endpoint that exposes investor data.
+        """
+        if self._is_dev_bypass_allowed(user_id):
+            return
+        conn = await self._conn()
+        try:
+            await self._ensure_iam_schema_ready(conn)
+            status_val = await conn.fetchval(
+                """
+                SELECT COALESCE(advisory_status, verification_status, 'draft')
+                FROM ria_profiles
+                WHERE user_id = $1
+                """,
+                user_id,
+            )
+        except asyncpg.exceptions.UndefinedColumnError:
+            status_val = await conn.fetchval(
+                "SELECT verification_status FROM ria_profiles WHERE user_id = $1",
+                user_id,
+            )
+        except asyncpg.exceptions.UndefinedTableError as exc:
+            raise IAMSchemaNotReadyError() from exc
+        finally:
+            await conn.close()
+
+        if str(status_val or "").strip().lower() not in self._RIA_VERIFIED_STATUSES:
+            raise RIAIAMPolicyError(
+                "RIA verification incomplete. Non-verified advisors cannot access investor data.",
+                status_code=403,
+            )
 
     @staticmethod
     def _normalize_persona(value: str) -> PersonaType:

--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -215,7 +215,10 @@ class RIAIAMService:
         """
         if self._is_dev_bypass_allowed(user_id):
             return
-        conn = await self._conn()
+        try:
+            conn = await self._conn()
+        except Exception as exc:
+            raise IAMSchemaNotReadyError() from exc
         try:
             await self._ensure_iam_schema_ready(conn)
             status_val = await conn.fetchval(
@@ -232,6 +235,10 @@ class RIAIAMService:
                 user_id,
             )
         except asyncpg.exceptions.UndefinedTableError as exc:
+            raise IAMSchemaNotReadyError() from exc
+        except IAMSchemaNotReadyError:
+            raise
+        except Exception as exc:
             raise IAMSchemaNotReadyError() from exc
         finally:
             await conn.close()

--- a/consent-protocol/hushh_mcp/services/ria_verification.py
+++ b/consent-protocol/hushh_mcp/services/ria_verification.py
@@ -45,6 +45,9 @@ def validate_regulated_runtime_configuration() -> None:
             "ADVISORY_VERIFICATION_BYPASS_ENABLED / RIA_DEV_BYPASS_ENABLED must remain false in production."
         )
 
+    if str(os.getenv("RIA_DEV_ALLOWLIST", "")).strip():
+        raise RuntimeError("RIA_DEV_ALLOWLIST must not be set in production.")
+
     if _env_truthy("BROKER_VERIFICATION_BYPASS_ENABLED"):
         raise RuntimeError("BROKER_VERIFICATION_BYPASS_ENABLED must remain false in production.")
 

--- a/consent-protocol/tests/test_ria_iam_routes.py
+++ b/consent-protocol/tests/test_ria_iam_routes.py
@@ -67,11 +67,10 @@ def test_iam_persona_schema_not_ready_returns_compat_payload(monkeypatch):
 
 
 def test_ria_request_enforces_verification_policy(monkeypatch):
-    async def _mock_create(self, user_id: str, **kwargs):  # noqa: ANN003
-        assert user_id == "user_test_123"
+    async def _mock_require(self, user_id: str):
         raise RIAIAMPolicyError("RIA verification incomplete", status_code=403)
 
-    monkeypatch.setattr(RIAIAMService, "create_ria_consent_request", _mock_create)
+    monkeypatch.setattr(RIAIAMService, "require_ria_verified", _mock_require)
 
     client = TestClient(_build_app())
     response = client.post(
@@ -91,10 +90,14 @@ def test_ria_request_enforces_verification_policy(monkeypatch):
 
 
 def test_ria_clients_schema_not_ready_returns_503(monkeypatch):
+    async def _mock_require(self, user_id: str):
+        return
+
     async def _mock_clients(self, user_id: str):
         assert user_id == "user_test_123"
         raise IAMSchemaNotReadyError("IAM schema is not ready")
 
+    monkeypatch.setattr(RIAIAMService, "require_ria_verified", _mock_require)
     monkeypatch.setattr(RIAIAMService, "list_ria_clients", _mock_clients)
 
     client = TestClient(_build_app())
@@ -272,12 +275,16 @@ def test_ria_picks_parse_requires_csv(monkeypatch):
 
 
 def test_ria_client_picks_share_toggle(monkeypatch):
+    async def _mock_require(self, user_id: str):
+        return
+
     async def _mock_toggle(self, user_id: str, *, investor_user_id: str, enabled: bool):
         assert user_id == "user_test_123"
         assert investor_user_id == "investor_1"
         assert enabled is False
         return {"enabled": False, "status": "revoked", "grant_key": "ria_active_picks_feed_v1"}
 
+    monkeypatch.setattr(RIAIAMService, "require_ria_verified", _mock_require)
     monkeypatch.setattr(RIAIAMService, "set_ria_pick_share_state", _mock_toggle)
 
     client = TestClient(_build_app())
@@ -314,6 +321,9 @@ def test_ria_home_omits_pick_history_fields(monkeypatch):
 
 
 def test_ria_invites_create(monkeypatch):
+    async def _mock_require(self, user_id: str):
+        return
+
     async def _mock_create(self, user_id: str, **kwargs):  # noqa: ANN003
         assert user_id == "user_test_123"
         assert kwargs["scope_template_id"] == "ria_financial_summary_v1"
@@ -327,6 +337,7 @@ def test_ria_invites_create(monkeypatch):
             ]
         }
 
+    monkeypatch.setattr(RIAIAMService, "require_ria_verified", _mock_require)
     monkeypatch.setattr(RIAIAMService, "create_ria_invites", _mock_create)
 
     client = TestClient(_build_app())
@@ -558,6 +569,11 @@ def test_generic_consent_request_routes_to_ria_request_creation(monkeypatch):
 
 
 def test_ria_client_detail_route_exposes_relationship_share_fields(monkeypatch):
+    async def _mock_require(self, user_id: str):
+        return
+
+    monkeypatch.setattr(RIAIAMService, "require_ria_verified", _mock_require)
+
     async def _mock_detail(self, user_id: str, investor_user_id: str):
         assert user_id == "user_test_123"
         assert investor_user_id == "investor_1"

--- a/consent-protocol/tests/test_ria_iam_routes.py
+++ b/consent-protocol/tests/test_ria_iam_routes.py
@@ -544,11 +544,15 @@ def test_consent_center_list_route_supports_top_preview(monkeypatch):
 
 
 def test_generic_consent_request_routes_to_ria_request_creation(monkeypatch):
+    async def _mock_require(self, user_id: str):
+        return
+
     async def _mock_create(self, user_id: str, **kwargs):  # noqa: ANN003
         assert user_id == "user_test_123"
         assert kwargs["scope_template_id"] == "ria_financial_summary_v1"
         return {"request_id": "req_generic_1", "status": "REQUESTED"}
 
+    monkeypatch.setattr(RIAIAMService, "require_ria_verified", _mock_require)
     monkeypatch.setattr(RIAIAMService, "create_ria_consent_request", _mock_create)
 
     client = TestClient(_build_app())

--- a/consent-protocol/tests/test_ria_verification_hardening.py
+++ b/consent-protocol/tests/test_ria_verification_hardening.py
@@ -1,0 +1,240 @@
+"""Tests for RIA verification hardening and dev allowlist (issue #123)."""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.middleware import require_firebase_auth
+from api.routes import ria
+from hushh_mcp.services.ria_iam_service import (
+    IAMSchemaNotReadyError,
+    RIAIAMPolicyError,
+    RIAIAMService,
+)
+from hushh_mcp.services.ria_verification import validate_regulated_runtime_configuration
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(ria.router)
+    app.dependency_overrides[require_firebase_auth] = lambda: "user_test_123"
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Backend: dev allowlist respects RIA_DEV_ALLOWLIST
+# ---------------------------------------------------------------------------
+
+
+def test_dev_bypass_allowed_when_no_allowlist_set(monkeypatch):
+    monkeypatch.setenv("RIA_DEV_BYPASS_ENABLED", "true")
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.delenv("RIA_DEV_ALLOWLIST", raising=False)
+
+    service = RIAIAMService()
+    assert service._is_dev_bypass_allowed("any_user_id") is True
+
+
+def test_dev_bypass_allowed_for_listed_user(monkeypatch):
+    monkeypatch.setenv("RIA_DEV_BYPASS_ENABLED", "true")
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("RIA_DEV_ALLOWLIST", "user_a,user_b")
+
+    service = RIAIAMService()
+    assert service._is_dev_bypass_allowed("user_a") is True
+    assert service._is_dev_bypass_allowed("user_b") is True
+
+
+def test_dev_bypass_denied_for_unlisted_user(monkeypatch):
+    monkeypatch.setenv("RIA_DEV_BYPASS_ENABLED", "true")
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("RIA_DEV_ALLOWLIST", "user_a,user_b")
+
+    service = RIAIAMService()
+    assert service._is_dev_bypass_allowed("user_c") is False
+
+
+def test_dev_bypass_denied_in_production(monkeypatch):
+    monkeypatch.setenv("RIA_DEV_BYPASS_ENABLED", "true")
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("RIA_DEV_ALLOWLIST", "user_a")
+
+    service = RIAIAMService()
+    assert service._is_dev_bypass_allowed("user_a") is False
+
+
+def test_dev_bypass_denied_when_flag_off(monkeypatch):
+    monkeypatch.setenv("RIA_DEV_BYPASS_ENABLED", "false")
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("RIA_DEV_ALLOWLIST", "user_a")
+
+    service = RIAIAMService()
+    assert service._is_dev_bypass_allowed("user_a") is False
+
+
+# ---------------------------------------------------------------------------
+# Backend: production never exposes bypass / allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_production_rejects_ria_dev_allowlist(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("IAPD_VERIFY_BASE_URL", "https://iapd.example.com")
+    monkeypatch.setenv("IAPD_VERIFY_API_KEY", "secret")
+    monkeypatch.setenv("RIA_DEV_BYPASS_ENABLED", "false")
+    monkeypatch.setenv("ADVISORY_VERIFICATION_BYPASS_ENABLED", "false")
+    monkeypatch.setenv("BROKER_VERIFICATION_BYPASS_ENABLED", "false")
+    monkeypatch.setenv("RIA_DEV_ALLOWLIST", "user_a")
+
+    with pytest.raises(RuntimeError, match="RIA_DEV_ALLOWLIST must not be set in production"):
+        validate_regulated_runtime_configuration()
+
+
+def test_production_passes_without_allowlist(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("IAPD_VERIFY_BASE_URL", "https://iapd.example.com")
+    monkeypatch.setenv("IAPD_VERIFY_API_KEY", "secret")
+    monkeypatch.setenv("RIA_DEV_BYPASS_ENABLED", "false")
+    monkeypatch.setenv("ADVISORY_VERIFICATION_BYPASS_ENABLED", "false")
+    monkeypatch.setenv("BROKER_VERIFICATION_BYPASS_ENABLED", "false")
+    monkeypatch.delenv("RIA_DEV_ALLOWLIST", raising=False)
+
+    # Should not raise
+    validate_regulated_runtime_configuration()
+
+
+# ---------------------------------------------------------------------------
+# Route-level: non-verified RIA gets 403 on investor data endpoints
+# ---------------------------------------------------------------------------
+
+
+def test_unverified_ria_blocked_on_clients(monkeypatch):
+    async def _mock_require(self, user_id):
+        raise RIAIAMPolicyError(
+            "RIA verification incomplete. Non-verified advisors cannot access investor data.",
+            status_code=403,
+        )
+
+    monkeypatch.setattr(RIAIAMService, "require_ria_verified", _mock_require)
+
+    client = TestClient(_build_app())
+    response = client.get("/api/ria/clients")
+    assert response.status_code == 403
+    assert "verification" in response.json()["detail"].lower()
+
+
+def test_unverified_ria_blocked_on_client_detail(monkeypatch):
+    async def _mock_require(self, user_id):
+        raise RIAIAMPolicyError(
+            "RIA verification incomplete.", status_code=403
+        )
+
+    monkeypatch.setattr(RIAIAMService, "require_ria_verified", _mock_require)
+
+    client = TestClient(_build_app())
+    response = client.get("/api/ria/clients/investor_1")
+    assert response.status_code == 403
+
+
+def test_unverified_ria_blocked_on_create_request(monkeypatch):
+    async def _mock_require(self, user_id):
+        raise RIAIAMPolicyError(
+            "RIA verification incomplete.", status_code=403
+        )
+
+    monkeypatch.setattr(RIAIAMService, "require_ria_verified", _mock_require)
+
+    client = TestClient(_build_app())
+    response = client.post(
+        "/api/ria/requests",
+        json={
+            "subject_user_id": "investor_1",
+            "scope_template_id": "ria_financial_summary_v1",
+        },
+    )
+    assert response.status_code == 403
+
+
+def test_unverified_ria_blocked_on_workspace(monkeypatch):
+    async def _mock_require(self, user_id):
+        raise RIAIAMPolicyError(
+            "RIA verification incomplete.", status_code=403
+        )
+
+    monkeypatch.setattr(RIAIAMService, "require_ria_verified", _mock_require)
+
+    client = TestClient(_build_app())
+    response = client.get("/api/ria/workspace/investor_1")
+    assert response.status_code == 403
+
+
+def test_unverified_ria_blocked_on_create_invites(monkeypatch):
+    async def _mock_require(self, user_id):
+        raise RIAIAMPolicyError(
+            "RIA verification incomplete.", status_code=403
+        )
+
+    monkeypatch.setattr(RIAIAMService, "require_ria_verified", _mock_require)
+
+    client = TestClient(_build_app())
+    response = client.post(
+        "/api/ria/invites",
+        json={
+            "scope_template_id": "ria_financial_summary_v1",
+            "targets": [],
+        },
+    )
+    assert response.status_code == 403
+
+
+def test_verified_ria_passes_gate(monkeypatch):
+    async def _mock_require(self, user_id):
+        return  # verified, no exception
+
+    async def _mock_clients(self, user_id, **kwargs):
+        return {"items": [], "total": 0, "page": 1, "limit": 50, "has_more": False}
+
+    monkeypatch.setattr(RIAIAMService, "require_ria_verified", _mock_require)
+    monkeypatch.setattr(RIAIAMService, "list_ria_clients", _mock_clients)
+
+    client = TestClient(_build_app())
+    response = client.get("/api/ria/clients")
+    assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Route-level: non-gated endpoints still work without verification
+# ---------------------------------------------------------------------------
+
+
+def test_onboarding_status_not_gated(monkeypatch):
+    async def _mock_status(self, user_id):
+        return {"exists": False, "verification_status": "draft", "dev_ria_bypass_allowed": False}
+
+    monkeypatch.setattr(RIAIAMService, "get_ria_onboarding_status", _mock_status)
+
+    client = TestClient(_build_app())
+    response = client.get("/api/ria/onboarding/status")
+    assert response.status_code == 200
+
+
+def test_home_not_gated(monkeypatch):
+    async def _mock_home(self, user_id):
+        return {
+            "onboarding": {"exists": False, "verification_status": "draft"},
+            "verification_status": "draft",
+            "primary_action": {"label": "Setup", "href": "/ria/onboarding", "description": "Go."},
+            "counts": {"active_clients": 0, "needs_attention": 0, "invites": 0},
+            "needs_attention": [],
+            "active_picks": {"status": "empty", "active_rows": 0},
+        }
+
+    monkeypatch.setattr(RIAIAMService, "get_ria_home", _mock_home)
+
+    client = TestClient(_build_app())
+    response = client.get("/api/ria/home")
+    assert response.status_code == 200

--- a/consent-protocol/tests/test_ria_verification_hardening.py
+++ b/consent-protocol/tests/test_ria_verification_hardening.py
@@ -1,17 +1,13 @@
 """Tests for RIA verification hardening and dev allowlist (issue #123)."""
 from __future__ import annotations
 
-import os
-
 import pytest
-
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from api.middleware import require_firebase_auth
 from api.routes import ria
 from hushh_mcp.services.ria_iam_service import (
-    IAMSchemaNotReadyError,
     RIAIAMPolicyError,
     RIAIAMService,
 )

--- a/hushh-webapp/app/ria/clients/page.tsx
+++ b/hushh-webapp/app/ria/clients/page.tsx
@@ -30,7 +30,7 @@ import {
   type RiaClientListResponse,
 } from "@/lib/services/ria-service";
 import { cn } from "@/lib/utils";
-import { RiaCompatibilityState } from "@/components/ria/ria-page-shell";
+import { RiaCompatibilityState, RiaVerificationGate } from "@/components/ria/ria-page-shell";
 
 type ClientListItem = RiaClientAccess & {
   isTestProfile?: boolean;
@@ -153,6 +153,7 @@ export default function RiaClientsPage() {
       </AppPageHeaderRegion>
 
       <AppPageContentRegion>
+        <RiaVerificationGate>
         <div className="flex flex-col gap-8">
           <SettingsGroup
             embedded
@@ -220,6 +221,7 @@ export default function RiaClientsPage() {
             )}
           </SettingsGroup>
         </div>
+        </RiaVerificationGate>
       </AppPageContentRegion>
     </AppPageShell>
   );

--- a/hushh-webapp/app/ria/page.tsx
+++ b/hushh-webapp/app/ria/page.tsx
@@ -9,7 +9,7 @@ import {
   Loader2,
 } from "lucide-react";
 
-import { RiaCompatibilityState, RiaPageShell, RiaSurface } from "@/components/ria/ria-page-shell";
+import { RiaCompatibilityState, RiaDevAllowlistBadge, RiaPageShell, RiaSurface } from "@/components/ria/ria-page-shell";
 import { Badge } from "@/components/ui/badge";
 import { useAuth } from "@/hooks/use-auth";
 import { usePersonaState } from "@/lib/persona/persona-context";
@@ -195,9 +195,12 @@ export default function RiaHomePage() {
           >
             <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
               <div className="min-w-0 space-y-3">
-                <Badge className={cn("w-fit", badgeToneClass(verification.tone))}>
-                  {verification.label}
-                </Badge>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge className={cn("w-fit", badgeToneClass(verification.tone))}>
+                    {verification.label}
+                  </Badge>
+                  <RiaDevAllowlistBadge />
+                </div>
                 <div className="space-y-2">
                   <h2 className="text-[clamp(1.25rem,3vw,1.85rem)] font-semibold tracking-tight text-foreground">
                     {heroTitle}

--- a/hushh-webapp/components/ria/ria-page-shell.tsx
+++ b/hushh-webapp/components/ria/ria-page-shell.tsx
@@ -240,7 +240,7 @@ export function RiaStatusPanel({
   );
 }
 
-const _VERIFIED_STATUSES = new Set(["active", "verified", "bypassed"]);
+const _VERIFIED_STATUSES = new Set(["active", "verified", "bypassed", "finra_verified"]);
 
 export function isRiaVerified(status?: string | null): boolean {
   return _VERIFIED_STATUSES.has(String(status || "").toLowerCase());

--- a/hushh-webapp/components/ria/ria-page-shell.tsx
+++ b/hushh-webapp/components/ria/ria-page-shell.tsx
@@ -2,7 +2,9 @@
 
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
 import type { LucideIcon } from "lucide-react";
-import { BriefcaseBusiness, ShieldCheck, TriangleAlert } from "lucide-react";
+import { BriefcaseBusiness, ShieldAlert, ShieldCheck, TriangleAlert } from "lucide-react";
+
+import { usePersonaState } from "@/lib/persona/persona-context";
 
 import {
   AppPageContentRegion,
@@ -235,5 +237,50 @@ export function RiaStatusPanel({
         ))}
       </div>
     </RiaSurface>
+  );
+}
+
+const _VERIFIED_STATUSES = new Set(["active", "verified", "bypassed"]);
+
+export function isRiaVerified(status?: string | null): boolean {
+  return _VERIFIED_STATUSES.has(String(status || "").toLowerCase());
+}
+
+export function RiaVerificationGate({ children }: { children: ReactNode }) {
+  const { riaOnboardingStatus, devRiaBypassAllowed, loading } = usePersonaState();
+  const status = riaOnboardingStatus?.advisory_status || riaOnboardingStatus?.verification_status;
+
+  if (loading) return null;
+
+  if (!isRiaVerified(status) && !devRiaBypassAllowed) {
+    return (
+      <section className="space-y-3">
+        <SectionHeader
+          eyebrow="Verification required"
+          title="Complete advisor verification first"
+          description="Non-verified advisors cannot access investor data. Finish the verification flow in onboarding, then come back."
+          icon={ShieldAlert}
+        />
+        <RiaSurface tone="warning" className="border-dashed">
+          <p className="text-sm leading-6 text-muted-foreground">
+            Investor data, client workspaces, and consent requests are locked until
+            regulatory verification is complete.
+          </p>
+        </RiaSurface>
+      </section>
+    );
+  }
+
+  return <>{children}</>;
+}
+
+export function RiaDevAllowlistBadge() {
+  const { devRiaBypassAllowed } = usePersonaState();
+  if (!devRiaBypassAllowed) return null;
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full border border-amber-500/20 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest text-amber-700 dark:text-amber-300">
+      <ShieldCheck className="h-3 w-3" />
+      Dev allowlist
+    </span>
   );
 }


### PR DESCRIPTION
## Summary

- Adds fail-closed verification check on all endpoints that expose investor data
- Non-verified RIAs receive 403 on investor-data routes
- Dev allowlist (RIA_DEV_ALLOWLIST) scopes bypass to specific user IDs in non-production only
- Production runtime guard rejects the allowlist env var entirely
- Generic consent route (POST /api/consent/requests) now also enforces RIA verification when requester is an RIA

## Problem

Non-verified RIAs could potentially access investor data endpoints without completing FINRA or manual verification. The dev bypass was also unbounded (any user could bypass in non-production). Additionally, the generic consent request endpoint allowed unverified RIAs to create consent requests to investors, bypassing the verification gate entirely.

## Approach

**Backend - verification gate:**
- `require_ria_verified()` async method on RIAIAMService performs DB check against ria_profiles
- Accepts statuses: active, verified, bypassed, finra_verified
- All other statuses (draft, submitted, rejected) get 403
- Non-existent profiles (no row) get 403
- DB connection errors and schema issues get 503 (fail-closed, never fail-open)

**Backend - route gating:**
- FastAPI dependency applied to 7 investor-data endpoints: /clients, /clients/{id}, /requests, /request-bundles, /invites, /workspace/{id}, /clients/{id}/picks-share
- Also applied inline to POST /api/consent/requests when requester_actor_type is "ria"
- Non-gated endpoints (onboarding, home, picks, universe) remain accessible

**Backend - dev allowlist:**
- RIA_DEV_ALLOWLIST env var accepts comma-separated user IDs
- Only works when RIA_DEV_BYPASS_ENABLED=true AND environment is not production
- validate_regulated_runtime_configuration() rejects RIA_DEV_ALLOWLIST in production at startup

**Frontend:**
- RiaVerificationGate component blocks investor data views for unverified RIAs
- RiaDevAllowlistBadge shows amber badge when dev bypass is active
- Frontend status set matches backend exactly (active, verified, bypassed, finra_verified)

## Test plan

- [x] 15 new tests covering: allowlist filtering (in/out/empty), production guard, per-route 403 enforcement, verified pass-through, non-gated endpoints still accessible
- [x] 5 existing tests updated to mock new dependency
- [x] TypeScript type check passes with zero errors
- [x] No secrets or env files in diff

Closes #123