### PR TITLE
feat: add askkai@hushh.ai inbound email endpoint for KYC agent

### DIFF
--- a/consent-protocol/api/routes/email_agent.py
+++ b/consent-protocol/api/routes/email_agent.py
@@ -8,11 +8,12 @@ Security:
 - No Firebase auth required (webhook from email provider).
 - Webhook authenticity should be verified via SENDGRID_WEBHOOK_SECRET when
   configured; otherwise the endpoint is open (suitable for dev/staging).
-- Rate-limited to prevent abuse.
+- Callers should apply rate limiting at the infrastructure level (e.g. WAF).
 """
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import hmac
 import logging
@@ -87,9 +88,18 @@ async def inbound_email_webhook(request: Request):
 
     Accepts both JSON bodies and form-data (SendGrid default).
     """
+    # Verify webhook signature before doing any body parsing.
+    raw_body = await request.body()
+    signature = request.headers.get("x-twilio-email-event-webhook-signature")
+    if not _verify_sendgrid_signature(raw_body, signature):
+        logger.warning("email_agent.inbound.invalid_signature")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid webhook signature.",
+        )
+
     content_type = request.headers.get("content-type", "")
 
-    # Parse the raw payload depending on content type.
     if "application/json" in content_type:
         raw_payload: dict[str, Any] = await request.json()
     elif "multipart/form-data" in content_type or "application/x-www-form-urlencoded" in content_type:
@@ -99,15 +109,6 @@ async def inbound_email_webhook(request: Request):
         raise HTTPException(
             status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
             detail="Expected JSON or form-data payload.",
-        )
-
-    # Optional webhook signature check.
-    signature = request.headers.get("x-twilio-email-event-webhook-signature")
-    if not _verify_sendgrid_signature(await request.body(), signature):
-        logger.warning("email_agent.inbound.invalid_signature")
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Invalid webhook signature.",
         )
 
     # Parse the email.
@@ -126,8 +127,7 @@ async def inbound_email_webhook(request: Request):
         parsed.subject,
     )
 
-    # Generate agent response (synchronous Kai call — lightweight for KYC).
-    agent_reply = generate_agent_response(parsed)
+    agent_reply = await asyncio.to_thread(generate_agent_response, parsed)
 
     # Queue the outbound reply via the existing email delivery queue.
     try:

--- a/consent-protocol/api/routes/email_agent.py
+++ b/consent-protocol/api/routes/email_agent.py
@@ -1,0 +1,167 @@
+"""Email agent routes — askkai@hushh.ai inbound webhook.
+
+POST /api/email/inbound receives incoming emails (SendGrid Inbound Parse or
+compatible JSON), routes the message through the Kai agent for KYC processing,
+and queues a reply back to the sender.
+
+Security:
+- No Firebase auth required (webhook from email provider).
+- Webhook authenticity should be verified via SENDGRID_WEBHOOK_SECRET when
+  configured; otherwise the endpoint is open (suitable for dev/staging).
+- Rate-limited to prevent abuse.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import os
+from functools import partial
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request, status
+from pydantic import BaseModel, Field
+
+from hushh_mcp.services.email_agent_service import (
+    generate_agent_response,
+    parse_sendgrid_inbound,
+    send_reply,
+)
+from hushh_mcp.services.email_delivery_queue_service import (
+    get_email_delivery_queue_service,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/email", tags=["Email Agent"])
+
+
+# ---------------------------------------------------------------------------
+# Webhook signature verification (optional — skipped when secret is unset)
+# ---------------------------------------------------------------------------
+
+
+def _verify_sendgrid_signature(request_body: bytes, signature: str | None) -> bool:
+    """Verify SendGrid webhook signature if SENDGRID_WEBHOOK_SECRET is set."""
+    secret = (os.getenv("SENDGRID_WEBHOOK_SECRET") or "").strip()
+    if not secret:
+        # No secret configured — skip verification (dev / staging).
+        return True
+    if not signature:
+        return False
+    expected = hmac.new(secret.encode(), request_body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, signature)
+
+
+# ---------------------------------------------------------------------------
+# Request / Response models
+# ---------------------------------------------------------------------------
+
+
+class InboundEmailPayload(BaseModel):
+    """Subset of SendGrid Inbound Parse fields we require.
+
+    SendGrid sends form-data, but we also accept JSON for easier testing
+    and alternative providers.
+    """
+
+    # SendGrid field names use plain strings (from, to, subject, text, html)
+    from_field: str = Field(..., alias="from", description="Sender address (Name <addr> or bare)")
+    to: str = Field(default="", description="Recipient address")
+    subject: str = Field(default="", description="Email subject line")
+    text: str = Field(default="", description="Plain text body")
+    html: str = Field(default="", description="HTML body (fallback if text is empty)")
+
+    model_config = {"populate_by_name": True}
+
+
+# ---------------------------------------------------------------------------
+# Inbound webhook endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.post("/inbound", status_code=status.HTTP_202_ACCEPTED)
+async def inbound_email_webhook(request: Request):
+    """Receive an inbound email, process through Kai, and queue a reply.
+
+    Accepts both JSON bodies and form-data (SendGrid default).
+    """
+    content_type = request.headers.get("content-type", "")
+
+    # Parse the raw payload depending on content type.
+    if "application/json" in content_type:
+        raw_payload: dict[str, Any] = await request.json()
+    elif "multipart/form-data" in content_type or "application/x-www-form-urlencoded" in content_type:
+        form = await request.form()
+        raw_payload = dict(form)
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail="Expected JSON or form-data payload.",
+        )
+
+    # Optional webhook signature check.
+    signature = request.headers.get("x-twilio-email-event-webhook-signature")
+    if not _verify_sendgrid_signature(await request.body(), signature):
+        logger.warning("email_agent.inbound.invalid_signature")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid webhook signature.",
+        )
+
+    # Parse the email.
+    try:
+        parsed = parse_sendgrid_inbound(raw_payload)
+    except ValueError as exc:
+        logger.warning("email_agent.inbound.parse_failed reason=%s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
+
+    logger.info(
+        "email_agent.inbound.received sender=%s subject=%s",
+        parsed.sender_email,
+        parsed.subject,
+    )
+
+    # Generate agent response (synchronous Kai call — lightweight for KYC).
+    agent_reply = generate_agent_response(parsed)
+
+    # Queue the outbound reply via the existing email delivery queue.
+    try:
+        queue_result = await get_email_delivery_queue_service().enqueue(
+            kind="support_message",  # reuse existing job kind
+            send_callable=partial(
+                send_reply,
+                to_email=parsed.sender_email,
+                subject=parsed.subject,
+                body_text=agent_reply,
+            ),
+            context={
+                "channel": "askkai_email",
+                "sender": parsed.sender_email,
+                "subject": parsed.subject,
+            },
+        )
+    except Exception as exc:
+        logger.exception("email_agent.inbound.queue_failed sender=%s", parsed.sender_email)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to queue reply.",
+        ) from exc
+
+    return {
+        "accepted": True,
+        "sender": parsed.sender_email,
+        "subject": parsed.subject,
+        "reply_queued": True,
+        "job_id": queue_result.get("job_id"),
+    }
+
+
+@router.get("/health")
+async def email_agent_health():
+    """Simple health check for the email agent endpoint."""
+    return {"status": "ok", "service": "askkai-email-agent"}

--- a/consent-protocol/hushh_mcp/services/email_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/email_agent_service.py
@@ -1,0 +1,291 @@
+"""Email agent service for askkai@hushh.ai — KYC agent over email.
+
+Parses inbound email webhooks (SendGrid Inbound Parse format), extracts user
+intent from the email body, routes to Kai for response generation, and sends
+the reply back via the existing Gmail delivery infrastructure.
+
+Consent boundary: the sender email address is treated as the identity anchor.
+No vault keys are exposed; the agent operates in a public-access / KYC-only
+scope until the user completes full onboarding through the app.
+"""
+
+from __future__ import annotations
+
+import base64
+import html as html_mod
+import logging
+import re
+from dataclasses import dataclass
+from email.message import EmailMessage
+from typing import Any
+
+from hushh_mcp.services.support_email_service import (
+    SupportEmailConfig,
+    SupportEmailNotConfiguredError,
+    SupportEmailSendError,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Inbound email parsing
+# ---------------------------------------------------------------------------
+
+# SendGrid Inbound Parse webhook fields:
+#   from, to, subject, text, html, envelope, headers, sender_ip, ...
+# We also support a generic JSON shape for testing / alternative providers.
+
+_EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
+
+
+def _extract_email_address(raw: str | None) -> str | None:
+    """Pull the first email address out of a 'Name <addr>' or bare string."""
+    if not raw:
+        return None
+    match = _EMAIL_RE.search(raw)
+    return match.group(0).lower() if match else None
+
+
+def _extract_display_name(raw: str | None) -> str | None:
+    """Best-effort display name from 'Display Name <addr@example.com>'."""
+    if not raw:
+        return None
+    raw = raw.strip()
+    if "<" in raw:
+        name = raw[: raw.index("<")].strip().strip('"').strip("'")
+        return name or None
+    return None
+
+
+def _strip_quoted_reply(text: str) -> str:
+    """Remove quoted reply lines (lines starting with '>') and signature blocks."""
+    lines: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        # Stop at common signature / reply markers
+        if stripped.startswith(">"):
+            continue
+        if stripped.startswith("On ") and stripped.endswith("wrote:"):
+            break
+        if stripped == "--":
+            break
+        if stripped.startswith("---------- Forwarded message"):
+            break
+        lines.append(line)
+    return "\n".join(lines).strip()
+
+
+@dataclass(frozen=True)
+class ParsedInboundEmail:
+    """Structured representation of an inbound email."""
+
+    sender_email: str
+    sender_name: str | None
+    recipient_email: str | None
+    subject: str
+    body_text: str
+    raw_body: str
+
+    @property
+    def user_message(self) -> str:
+        """The cleaned user message to send to the agent."""
+        cleaned = _strip_quoted_reply(self.body_text)
+        return cleaned or self.body_text
+
+
+def parse_sendgrid_inbound(payload: dict[str, Any]) -> ParsedInboundEmail:
+    """Parse a SendGrid Inbound Parse webhook payload.
+
+    Also works as a generic parser when callers provide ``from``, ``subject``,
+    and ``text`` fields.
+    """
+    sender_raw = str(payload.get("from", ""))
+    sender_email = _extract_email_address(sender_raw)
+    if not sender_email:
+        raise ValueError("Inbound email is missing a valid sender address.")
+
+    recipient_raw = str(payload.get("to", ""))
+    recipient_email = _extract_email_address(recipient_raw)
+
+    subject = str(payload.get("subject", "")).strip() or "(no subject)"
+
+    # Prefer plain-text body; fall back to HTML-stripped version.
+    body_text = str(payload.get("text", "")).strip()
+    if not body_text:
+        html_body = str(payload.get("html", "")).strip()
+        # Rough HTML-to-text: strip tags, decode entities.
+        body_text = re.sub(r"<[^>]+>", " ", html_body)
+        body_text = html_mod.unescape(body_text).strip()
+
+    if not body_text:
+        raise ValueError("Inbound email has no readable body content.")
+
+    return ParsedInboundEmail(
+        sender_email=sender_email,
+        sender_name=_extract_display_name(sender_raw),
+        recipient_email=recipient_email,
+        subject=subject,
+        body_text=body_text,
+        raw_body=str(payload.get("text", payload.get("html", ""))),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Agent interaction
+# ---------------------------------------------------------------------------
+
+
+def _build_agent_prompt(email: ParsedInboundEmail) -> str:
+    """Convert the parsed email into a prompt for the Kai agent.
+
+    Provides the subject as context and wraps the body so the agent knows this
+    came through the email channel (helpful for tone and response formatting).
+    """
+    parts = [
+        f"[Email from {email.sender_email}]",
+        f"Subject: {email.subject}",
+        "",
+        email.user_message,
+    ]
+    return "\n".join(parts)
+
+
+def generate_agent_response(email: ParsedInboundEmail) -> str:
+    """Route the email body through the Kai agent and return the text reply.
+
+    Uses the Kai singleton in a consent-light mode (no vault keys, public scope)
+    since the email sender has not yet gone through full in-app consent.
+    """
+    from hushh_mcp.agents.kai.agent import get_kai_agent
+
+    prompt = _build_agent_prompt(email)
+    # Use sender email as user_id for tracking; no consent token required
+    # for this public KYC channel.
+    try:
+        result = get_kai_agent().handle_message(
+            message=prompt,
+            user_id=email.sender_email,
+            consent_token="",  # public KYC scope — no privileged access
+        )
+        return str(result.get("response", "")).strip() or _fallback_response()
+    except Exception:
+        logger.exception(
+            "email_agent.kai_agent_failed sender=%s subject=%s",
+            email.sender_email,
+            email.subject,
+        )
+        return _fallback_response()
+
+
+def _fallback_response() -> str:
+    return (
+        "Thank you for reaching out to Kai. I was not able to process your "
+        "request right now. Please try again shortly or visit https://www.hushh.ai "
+        "to continue through the app."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Outbound reply (via existing Gmail infrastructure)
+# ---------------------------------------------------------------------------
+
+
+_ASKKAI_FROM_DISPLAY = "Kai by Hushh"
+
+
+def _build_reply_email(
+    *,
+    to_email: str,
+    subject: str,
+    body_text: str,
+    from_email: str,
+) -> EmailMessage:
+    msg = EmailMessage()
+    msg["To"] = to_email
+    msg["From"] = f"{_ASKKAI_FROM_DISPLAY} <{from_email}>"
+    # Prefix Re: only if not already present
+    if not subject.lower().startswith("re:"):
+        subject = f"Re: {subject}"
+    msg["Subject"] = subject
+    msg.set_content(body_text)
+    return msg
+
+
+def send_reply(
+    *,
+    to_email: str,
+    subject: str,
+    body_text: str,
+) -> dict[str, Any]:
+    """Send the agent reply back to the original sender via Gmail API.
+
+    Reuses the SupportEmailConfig / Gmail delegation path that the rest of
+    the platform already uses for outbound mail.
+    """
+    from google.auth.transport.requests import AuthorizedSession
+    from google.oauth2 import service_account
+
+    _GMAIL_SEND_SCOPE = "https://www.googleapis.com/auth/gmail.send"
+    _GMAIL_SEND_ENDPOINT = "https://gmail.googleapis.com/gmail/v1/users/me/messages/send"
+
+    cfg = SupportEmailConfig.from_env()
+    if not cfg.configured:
+        raise SupportEmailNotConfiguredError(
+            "Email agent reply delivery is not configured. "
+            "Provide SUPPORT_EMAIL_SERVICE_ACCOUNT_JSON or equivalent credentials."
+        )
+
+    from_email = cfg.from_email
+    email_message = _build_reply_email(
+        to_email=to_email,
+        subject=subject,
+        body_text=body_text,
+        from_email=from_email,
+    )
+    encoded = base64.urlsafe_b64encode(email_message.as_bytes()).decode("utf-8")
+
+    credentials = service_account.Credentials.from_service_account_info(
+        cfg.service_account_info,
+        scopes=[_GMAIL_SEND_SCOPE],
+        subject=cfg.delegated_user,
+    )
+    session = AuthorizedSession(credentials)
+
+    try:
+        response = session.post(_GMAIL_SEND_ENDPOINT, json={"raw": encoded}, timeout=20)
+    except Exception as exc:
+        logger.exception("email_agent.reply_transport_failed to=%s", to_email)
+        raise SupportEmailSendError(
+            "Email agent reply delivery failed. Check Gmail delegation."
+        ) from exc
+
+    try:
+        payload = response.json()
+    except Exception:
+        payload = {}
+
+    if response.status_code >= 400:
+        logger.error(
+            "email_agent.reply_send_failed status=%s to=%s payload=%s",
+            response.status_code,
+            to_email,
+            payload,
+        )
+        detail = (
+            payload.get("error", {}).get("message")
+            if isinstance(payload, dict)
+            and isinstance(payload.get("error"), dict)
+            and isinstance(payload.get("error", {}).get("message"), str)
+            else None
+        )
+        raise SupportEmailSendError(
+            detail or f"Email agent reply failed with status {response.status_code}"
+        )
+
+    message_id = payload.get("id") if isinstance(payload, dict) else None
+    return {
+        "accepted": True,
+        "message_id": message_id if isinstance(message_id, str) else None,
+        "to": to_email,
+        "from_email": from_email,
+    }

--- a/consent-protocol/server.py
+++ b/consent-protocol/server.py
@@ -291,6 +291,11 @@ app.include_router(marketplace.router)
 app.include_router(invites.router)
 logger.info("ria.routes_enabled")
 
+# askkai@hushh.ai email agent routes (/api/email/...)
+from api.routes.email_agent import router as email_agent_router  # noqa: E402
+
+app.include_router(email_agent_router)
+
 logger.info(
     "🚀 Hushh Consent Protocol server initialized with modular routes - KAI V2 + PHASE 2 + PKM ENABLED"
 )

--- a/consent-protocol/tests/test_email_agent.py
+++ b/consent-protocol/tests/test_email_agent.py
@@ -1,0 +1,280 @@
+"""Tests for the askkai@hushh.ai email agent service and route.
+
+Covers:
+- Inbound email parsing (SendGrid format, edge cases)
+- Quoted reply stripping
+- Agent prompt construction
+- Route payload handling (JSON and form-data)
+- Webhook signature verification
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+
+# Set env vars BEFORE any hushh_mcp imports (config.py validates at import time).
+os.environ.setdefault("SECRET_KEY", "a" * 32)
+os.environ.setdefault("VAULT_ENCRYPTION_KEY", "b" * 64)
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hushh_mcp.services.email_agent_service import (
+    ParsedInboundEmail,
+    _build_agent_prompt,
+    _extract_display_name,
+    _extract_email_address,
+    _fallback_response,
+    _strip_quoted_reply,
+    parse_sendgrid_inbound,
+)
+
+
+# ==========================================================================
+# Email address extraction
+# ==========================================================================
+
+
+class TestExtractEmailAddress:
+    def test_bare_email(self):
+        assert _extract_email_address("alice@example.com") == "alice@example.com"
+
+    def test_display_name_format(self):
+        assert _extract_email_address("Alice Smith <alice@example.com>") == "alice@example.com"
+
+    def test_uppercase_normalized(self):
+        assert _extract_email_address("BOB@EXAMPLE.COM") == "bob@example.com"
+
+    def test_none_returns_none(self):
+        assert _extract_email_address(None) is None
+
+    def test_empty_returns_none(self):
+        assert _extract_email_address("") is None
+
+    def test_no_at_sign(self):
+        assert _extract_email_address("not-an-email") is None
+
+
+class TestExtractDisplayName:
+    def test_with_angle_brackets(self):
+        assert _extract_display_name("Alice Smith <alice@example.com>") == "Alice Smith"
+
+    def test_quoted_name(self):
+        assert _extract_display_name('"Bob Jones" <bob@example.com>') == "Bob Jones"
+
+    def test_bare_email_returns_none(self):
+        assert _extract_display_name("alice@example.com") is None
+
+    def test_none_returns_none(self):
+        assert _extract_display_name(None) is None
+
+
+# ==========================================================================
+# Quoted reply stripping
+# ==========================================================================
+
+
+class TestStripQuotedReply:
+    def test_removes_quoted_lines(self):
+        text = "Hello Kai\n\n> Previous message\n> More quoted"
+        assert _strip_quoted_reply(text) == "Hello Kai"
+
+    def test_stops_at_on_wrote_marker(self):
+        text = "My question is about KYC.\n\nOn Mon, Apr 14, 2025 at 10:00 AM Support wrote:\n> old reply"
+        result = _strip_quoted_reply(text)
+        assert "My question is about KYC." in result
+        assert "wrote:" not in result
+
+    def test_stops_at_signature_dash(self):
+        text = "Hello\n--\nJohn Doe\nCEO"
+        assert _strip_quoted_reply(text) == "Hello"
+
+    def test_preserves_clean_text(self):
+        text = "Just a simple message with no replies."
+        assert _strip_quoted_reply(text) == text
+
+    def test_stops_at_forwarded_message(self):
+        text = "Check this\n---------- Forwarded message ----------\nOriginal"
+        assert _strip_quoted_reply(text) == "Check this"
+
+
+# ==========================================================================
+# SendGrid inbound parsing
+# ==========================================================================
+
+
+class TestParseSendgridInbound:
+    def test_basic_payload(self):
+        payload = {
+            "from": "Alice <alice@example.com>",
+            "to": "askkai@hushh.ai",
+            "subject": "KYC question",
+            "text": "What documents do I need?",
+        }
+        parsed = parse_sendgrid_inbound(payload)
+        assert parsed.sender_email == "alice@example.com"
+        assert parsed.sender_name == "Alice"
+        assert parsed.recipient_email == "askkai@hushh.ai"
+        assert parsed.subject == "KYC question"
+        assert parsed.body_text == "What documents do I need?"
+
+    def test_html_fallback(self):
+        payload = {
+            "from": "bob@example.com",
+            "subject": "Hello",
+            "html": "<p>Hi there!</p>",
+        }
+        parsed = parse_sendgrid_inbound(payload)
+        assert "Hi there!" in parsed.body_text
+
+    def test_missing_sender_raises(self):
+        payload = {"subject": "No sender", "text": "Body"}
+        with pytest.raises(ValueError, match="sender"):
+            parse_sendgrid_inbound(payload)
+
+    def test_empty_body_raises(self):
+        payload = {"from": "alice@example.com", "subject": "Empty", "text": "", "html": ""}
+        with pytest.raises(ValueError, match="body"):
+            parse_sendgrid_inbound(payload)
+
+    def test_no_subject_defaults(self):
+        payload = {"from": "alice@example.com", "text": "Body text"}
+        parsed = parse_sendgrid_inbound(payload)
+        assert parsed.subject == "(no subject)"
+
+    def test_user_message_strips_quotes(self):
+        payload = {
+            "from": "alice@example.com",
+            "subject": "Re: KYC",
+            "text": "My follow-up question\n\n> Previous message from Kai",
+        }
+        parsed = parse_sendgrid_inbound(payload)
+        assert parsed.user_message == "My follow-up question"
+
+
+# ==========================================================================
+# Agent prompt building
+# ==========================================================================
+
+
+class TestBuildAgentPrompt:
+    def test_includes_sender_and_subject(self):
+        email = ParsedInboundEmail(
+            sender_email="alice@example.com",
+            sender_name="Alice",
+            recipient_email="askkai@hushh.ai",
+            subject="My KYC question",
+            body_text="What do I need to get started?",
+            raw_body="What do I need to get started?",
+        )
+        prompt = _build_agent_prompt(email)
+        assert "alice@example.com" in prompt
+        assert "My KYC question" in prompt
+        assert "What do I need to get started?" in prompt
+
+
+# ==========================================================================
+# Fallback response
+# ==========================================================================
+
+
+class TestFallbackResponse:
+    def test_contains_hushh_url(self):
+        assert "hushh.ai" in _fallback_response()
+
+
+# ==========================================================================
+# Route-level tests (using FastAPI TestClient)
+# ==========================================================================
+
+
+class TestInboundEmailRoute:
+    """Test the /api/email/inbound endpoint logic without a running server."""
+
+    @pytest.fixture
+    def client(self):
+        """Build a TestClient around the email_agent router only."""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from api.routes.email_agent import router
+
+        app = FastAPI()
+        app.include_router(router)
+        return TestClient(app)
+
+    def test_health(self, client):
+        resp = client.get("/api/email/health")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+    @patch("api.routes.email_agent.generate_agent_response", return_value="Kai says hi")
+    @patch("api.routes.email_agent.get_email_delivery_queue_service")
+    def test_inbound_json_accepted(self, mock_queue, mock_agent, client):
+        async def _mock_enqueue(**kwargs):
+            return {"delivery_status": "queued", "job_id": "job_abc"}
+
+        mock_queue.return_value = MagicMock()
+        mock_queue.return_value.enqueue = _mock_enqueue
+
+        resp = client.post(
+            "/api/email/inbound",
+            json={
+                "from": "alice@example.com",
+                "to": "askkai@hushh.ai",
+                "subject": "KYC help",
+                "text": "I want to onboard.",
+            },
+        )
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["accepted"] is True
+        assert body["sender"] == "alice@example.com"
+        assert body["reply_queued"] is True
+
+    def test_inbound_missing_sender_returns_422(self, client):
+        resp = client.post(
+            "/api/email/inbound",
+            json={"subject": "No sender", "text": "Body"},
+        )
+        assert resp.status_code == 422
+
+    def test_inbound_unsupported_content_type(self, client):
+        resp = client.post(
+            "/api/email/inbound",
+            content=b"plain text",
+            headers={"content-type": "text/plain"},
+        )
+        assert resp.status_code == 415
+
+
+# ==========================================================================
+# Webhook signature verification
+# ==========================================================================
+
+
+class TestWebhookSignatureVerification:
+    def test_no_secret_configured_passes(self, monkeypatch):
+        monkeypatch.delenv("SENDGRID_WEBHOOK_SECRET", raising=False)
+        from api.routes.email_agent import _verify_sendgrid_signature
+
+        assert _verify_sendgrid_signature(b"body", None) is True
+
+    def test_valid_signature_passes(self, monkeypatch):
+        secret = "test-webhook-secret"
+        monkeypatch.setenv("SENDGRID_WEBHOOK_SECRET", secret)
+        body = b'{"from":"a@b.com"}'
+        sig = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+        from api.routes.email_agent import _verify_sendgrid_signature
+
+        assert _verify_sendgrid_signature(body, sig) is True
+
+    def test_invalid_signature_fails(self, monkeypatch):
+        monkeypatch.setenv("SENDGRID_WEBHOOK_SECRET", "real-secret")
+        from api.routes.email_agent import _verify_sendgrid_signature
+
+        assert _verify_sendgrid_signature(b"body", "wrong-sig") is False

--- a/consent-protocol/tests/test_email_agent.py
+++ b/consent-protocol/tests/test_email_agent.py
@@ -12,12 +12,6 @@ from __future__ import annotations
 
 import hashlib
 import hmac
-import os
-
-# Set env vars BEFORE any hushh_mcp imports (config.py validates at import time).
-os.environ.setdefault("SECRET_KEY", "a" * 32)
-os.environ.setdefault("VAULT_ENCRYPTION_KEY", "b" * 64)
-
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -31,7 +25,6 @@ from hushh_mcp.services.email_agent_service import (
     _strip_quoted_reply,
     parse_sendgrid_inbound,
 )
-
 
 # ==========================================================================
 # Email address extraction
@@ -264,7 +257,7 @@ class TestWebhookSignatureVerification:
         assert _verify_sendgrid_signature(b"body", None) is True
 
     def test_valid_signature_passes(self, monkeypatch):
-        secret = "test-webhook-secret"
+        secret = "test-webhook-secret"  # noqa: S105
         monkeypatch.setenv("SENDGRID_WEBHOOK_SECRET", secret)
         body = b'{"from":"a@b.com"}'
         sig = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()


### PR DESCRIPTION
## Summary

- Adds email-based KYC agent accessible via askkai@hushh.ai
- Inbound emails parsed from SendGrid webhook, routed through existing Kai agent
- Replies queued via existing Gmail delivery infrastructure
- Public KYC scope only, no vault keys exposed through email channel

## Problem

Issue #53 (labeled help wanted) requested an email endpoint where users can interact with the Kai KYC agent via email. No email ingestion path existed in the codebase.

## Approach

**New route** (POST /api/email/inbound):
- Accepts SendGrid Inbound Parse webhook (JSON or form-data)
- Verifies webhook signature BEFORE parsing body (rejects invalid payloads cheaply)
- Optional signature verification via SENDGRID_WEBHOOK_SECRET env var (skipped when unset for dev/staging)
- Proper error handling: 415 wrong content type, 422 unparseable, 403 invalid signature

**New service** (email_agent_service.py):
- parse_sendgrid_inbound() extracts sender, subject, body from webhook payload
- Strips quoted reply chains, signatures, forwarded message markers
- generate_agent_response() routes through existing Kai agent singleton with consent-light mode (no vault keys)
- send_reply() uses existing SupportEmailConfig and Gmail delivery infrastructure
- Graceful fallback if Kai agent errors

**Integration:**
- Agent call wrapped in asyncio.to_thread to avoid blocking the event loop
- Reuses existing email delivery queue (no new email transport introduced)
- Sender email serves as identity anchor
- Router registered in server.py alongside existing routes

## Test plan

- [x] 30 tests covering: email parsing (6), display name extraction (4), quoted reply stripping (5), SendGrid parsing (6), prompt construction (1), fallback response (1), route integration (4), webhook signature verification (3)
- [x] All imports verified against existing codebase (SupportEmailConfig, EmailDeliveryQueueService, get_kai_agent)
- [x] No secrets or env files in diff

Closes #53