### PR TITLE
feat: add personalized Decision Card UI with portfolio context

### DIFF
--- a/hushh-webapp/components/kai/decision-card.tsx
+++ b/hushh-webapp/components/kai/decision-card.tsx
@@ -1,0 +1,475 @@
+"use client";
+
+import { useState } from "react";
+import {
+  TrendingUp,
+  TrendingDown,
+  ChevronDown,
+  ChevronUp,
+  Bookmark,
+  Share2,
+  GitCompareArrows,
+  Users,
+  ShieldAlert,
+} from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { Card, CardContent } from "@/lib/morphy-ux/card";
+import { Button } from "@/lib/morphy-ux/button";
+import { Icon } from "@/lib/morphy-ux/ui";
+import { SymbolAvatar } from "@/components/kai/shared/symbol-avatar";
+import { cn } from "@/lib/utils";
+
+import type { AnalysisHistoryEntry } from "@/lib/services/kai-history-service";
+import type { Holding } from "@/components/kai/types/portfolio";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type DecisionVerdict = "buy" | "hold" | "reduce" | string;
+
+export interface PortfolioContext {
+  /** User's current position in this ticker (from portfolio holdings) */
+  holding?: Holding | null;
+  /** Total portfolio value used for computing allocation % */
+  totalPortfolioValue?: number;
+}
+
+export interface PeerInsight {
+  /** e.g. "68% of investors like you who hold AAPL rated it a Buy" */
+  label: string;
+}
+
+export interface DecisionCardProps {
+  /** The analysis entry produced by Kai's debate pipeline */
+  entry: AnalysisHistoryEntry;
+  /** Optional portfolio context (client-side decrypted data) */
+  portfolioContext?: PortfolioContext | null;
+  /** Optional peer comparison insight */
+  peerInsight?: PeerInsight | null;
+  /** Callbacks for card actions */
+  onSave?: (ticker: string) => void;
+  onShare?: (ticker: string) => void;
+  onCompare?: (ticker: string) => void;
+  /** If true, the card starts with the debate section expanded */
+  defaultDebateOpen?: boolean;
+  className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+function formatPct(value: number): string {
+  const sign = value >= 0 ? "+" : "";
+  return `${sign}${value.toFixed(2)}%`;
+}
+
+function formatConfidence(value: number): string {
+  // Confidence may come as 0-1 or 0-100 depending on the backend
+  const normalized = value > 1 ? value : value * 100;
+  return `${Math.round(normalized)}%`;
+}
+
+function verdictLabel(decision: DecisionVerdict): string {
+  const upper = String(decision).toUpperCase();
+  if (upper === "BUY") return "BUY";
+  if (upper === "HOLD" || upper === "WATCH") return "HOLD";
+  if (upper === "REDUCE" || upper === "SELL") return "REDUCE";
+  return upper || "HOLD";
+}
+
+function verdictTone(decision: DecisionVerdict): string {
+  const label = verdictLabel(decision);
+  if (label === "BUY")
+    return "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
+  if (label === "REDUCE")
+    return "bg-orange-500/10 text-orange-700 dark:text-orange-300";
+  return "bg-blue-500/10 text-blue-700 dark:text-blue-300";
+}
+
+function confidenceTone(confidence: number): "default" | "success" | "warning" | "danger" {
+  const normalized = confidence > 1 ? confidence : confidence * 100;
+  if (normalized >= 75) return "success";
+  if (normalized >= 50) return "warning";
+  return "danger";
+}
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - Date.parse(iso);
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return "Just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function extractPrice(entry: AnalysisHistoryEntry): number | null {
+  const card = entry.raw_card;
+  if (!card || typeof card !== "object") return null;
+  const candidates = [
+    card.current_price,
+    card.price,
+    card.last_price,
+    card.close,
+  ];
+  for (const c of candidates) {
+    const n = typeof c === "number" ? c : Number(c);
+    if (Number.isFinite(n) && n > 0) return n;
+  }
+  return null;
+}
+
+function extractKeyMetrics(
+  entry: AnalysisHistoryEntry
+): Array<{ label: string; value: string }> {
+  const card = entry.raw_card;
+  if (!card || typeof card !== "object") return [];
+  const metrics: Array<{ label: string; value: string }> = [];
+  const rawMetrics = card.key_metrics ?? card.keyMetrics;
+  if (rawMetrics && typeof rawMetrics === "object") {
+    const map = rawMetrics as Record<string, unknown>;
+    if (map.pe_ratio !== undefined)
+      metrics.push({ label: "P/E", value: String(Number(map.pe_ratio).toFixed(1)) });
+    if (map.market_cap !== undefined)
+      metrics.push({ label: "Mkt Cap", value: String(map.market_cap) });
+    if (map.dividend_yield !== undefined)
+      metrics.push({
+        label: "Div Yield",
+        value: `${Number(map.dividend_yield).toFixed(2)}%`,
+      });
+    if (map.beta !== undefined)
+      metrics.push({ label: "Beta", value: String(Number(map.beta).toFixed(2)) });
+  }
+  return metrics.slice(0, 4);
+}
+
+function agentVoteSummary(
+  votes: Record<string, string>
+): Array<{ agent: string; vote: string }> {
+  return Object.entries(votes).map(([agent, vote]) => ({
+    agent: agent.charAt(0).toUpperCase() + agent.slice(1),
+    vote: String(vote).toUpperCase(),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function PortfolioContextBlock({
+  holding,
+  totalPortfolioValue,
+}: {
+  holding: Holding;
+  totalPortfolioValue?: number;
+}) {
+  const allocationPct =
+    totalPortfolioValue && totalPortfolioValue > 0
+      ? (holding.market_value / totalPortfolioValue) * 100
+      : null;
+  const positive = (holding.unrealized_gain_loss ?? 0) >= 0;
+
+  return (
+    <div className="rounded-xl border border-border/60 bg-muted/30 p-3 space-y-2">
+      <p className="text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground">
+        For YOUR Portfolio
+      </p>
+      <div className="grid grid-cols-3 gap-3 text-sm">
+        <div>
+          <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground/70">
+            Shares
+          </p>
+          <p className="font-semibold">{holding.quantity.toLocaleString()}</p>
+        </div>
+        <div>
+          <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground/70">
+            Value
+          </p>
+          <p className="font-semibold">{formatCurrency(holding.market_value)}</p>
+        </div>
+        {allocationPct !== null && (
+          <div>
+            <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground/70">
+              Allocation
+            </p>
+            <p className="font-semibold">{allocationPct.toFixed(1)}%</p>
+          </div>
+        )}
+      </div>
+      {holding.unrealized_gain_loss !== undefined && (
+        <p
+          className={cn(
+            "text-xs font-semibold",
+            positive ? "text-emerald-600" : "text-red-500"
+          )}
+        >
+          {positive ? "+" : ""}
+          {formatCurrency(holding.unrealized_gain_loss)}
+          {holding.unrealized_gain_loss_pct !== undefined &&
+            ` (${formatPct(holding.unrealized_gain_loss_pct)})`}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function DebateSection({
+  entry,
+  defaultOpen,
+}: {
+  entry: AnalysisHistoryEntry;
+  defaultOpen: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  const votes = agentVoteSummary(entry.agent_votes);
+  const transcript = entry.debate_transcript;
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger asChild>
+        <button
+          type="button"
+          className="flex w-full items-center justify-between rounded-lg border border-border/50 bg-muted/20 px-3 py-2 text-left text-xs font-semibold text-muted-foreground transition-colors hover:bg-muted/40"
+        >
+          <span>Agent Debate {entry.consensus_reached ? "(Consensus)" : "(Split)"}</span>
+          <Icon icon={open ? ChevronUp : ChevronDown} size="sm" />
+        </button>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="mt-2 space-y-3">
+          {/* Agent votes */}
+          {votes.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {votes.map(({ agent, vote }) => (
+                <Badge
+                  key={agent}
+                  className={cn(
+                    "rounded-full px-2.5 py-1 text-[10px] font-bold tracking-wide",
+                    vote === "BUY"
+                      ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+                      : vote === "REDUCE" || vote === "SELL"
+                        ? "bg-orange-500/10 text-orange-700 dark:text-orange-300"
+                        : "bg-blue-500/10 text-blue-700 dark:text-blue-300"
+                  )}
+                >
+                  {agent}: {vote}
+                </Badge>
+              ))}
+            </div>
+          )}
+
+          {/* Round summaries from transcript */}
+          {transcript && (
+            <div className="space-y-2">
+              {(["round1", "round2"] as const).map((round) => {
+                const agents = transcript[round];
+                if (!agents || typeof agents !== "object") return null;
+                return (
+                  <div key={round} className="space-y-1">
+                    <p className="text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground">
+                      {round === "round1" ? "Round 1 - Analysis" : "Round 2 - Debate"}
+                    </p>
+                    {Object.entries(agents).map(([agentKey, agentData]) => {
+                      const data = agentData as Record<string, unknown>;
+                      const text = String(data?.text || data?.summary || "").trim();
+                      if (!text) return null;
+                      return (
+                        <div
+                          key={agentKey}
+                          className="rounded-lg bg-muted/30 px-3 py-2 text-xs leading-relaxed"
+                        >
+                          <span className="font-bold capitalize text-foreground/80">
+                            {agentKey}:
+                          </span>{" "}
+                          <span className="text-muted-foreground line-clamp-3">
+                            {text}
+                          </span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main Component
+// ---------------------------------------------------------------------------
+
+export function DecisionCard({
+  entry,
+  portfolioContext,
+  peerInsight,
+  onSave,
+  onShare,
+  onCompare,
+  defaultDebateOpen = false,
+  className,
+}: DecisionCardProps) {
+  const price = extractPrice(entry);
+  const keyMetrics = extractKeyMetrics(entry);
+  const holding = portfolioContext?.holding;
+  const label = verdictLabel(entry.decision);
+
+  return (
+    <Card
+      variant="none"
+      effect="glass"
+      preset="surface"
+      showRipple={false}
+      glassAccent="soft"
+      className={cn(
+        "group relative isolate !overflow-hidden !gap-0 !py-0 rounded-[24px] transition-[border-color,box-shadow] duration-200 ease-out",
+        className
+      )}
+    >
+      <CardContent className="relative z-[1] space-y-4 p-5">
+        {/* ---- Header: ticker + verdict badge ---- */}
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex min-w-0 items-start gap-3">
+            <SymbolAvatar symbol={entry.ticker} size="md" />
+            <div className="min-w-0 space-y-0.5">
+              <h3 className="text-base font-black tracking-tight leading-tight">
+                {entry.ticker}
+              </h3>
+              {price !== null && (
+                <p className="text-sm text-muted-foreground">
+                  {formatCurrency(price)}
+                </p>
+              )}
+            </div>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <span className="inline-flex items-center rounded-full bg-background/75 px-2 py-1 text-[10px] font-bold tracking-wide text-muted-foreground">
+              {formatConfidence(entry.confidence)} conf.
+            </span>
+            <span
+              className={cn(
+                "inline-flex items-center rounded-full px-3 py-1 text-[11px] font-extrabold tracking-wide",
+                verdictTone(entry.decision)
+              )}
+            >
+              {label}
+            </span>
+          </div>
+        </div>
+
+        {/* ---- Key metrics strip ---- */}
+        {keyMetrics.length > 0 && (
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs">
+            {keyMetrics.map((m) => (
+              <span key={m.label} className="text-muted-foreground">
+                <span className="font-bold text-foreground/70">{m.label}</span>{" "}
+                {m.value}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* ---- Final statement ---- */}
+        {entry.final_statement && (
+          <p className="text-sm font-medium leading-relaxed">
+            {entry.final_statement}
+          </p>
+        )}
+
+        {/* ---- Personalized portfolio context ---- */}
+        {holding && (
+          <PortfolioContextBlock
+            holding={holding}
+            totalPortfolioValue={portfolioContext?.totalPortfolioValue}
+          />
+        )}
+
+        {/* ---- Debate section (expandable) ---- */}
+        <DebateSection entry={entry} defaultOpen={defaultDebateOpen} />
+
+        {/* ---- Peer insight ---- */}
+        {peerInsight && (
+          <div className="flex items-center gap-2 rounded-lg bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
+            <Icon icon={Users} size="sm" className="shrink-0" />
+            <span>{peerInsight.label}</span>
+          </div>
+        )}
+
+        {/* ---- Actions: Save / Share / Compare ---- */}
+        <div className="flex items-center gap-2 border-t border-border/40 pt-3">
+          {onSave && (
+            <Button
+              variant="none"
+              effect="fade"
+              size="sm"
+              onClick={() => onSave(entry.ticker)}
+              aria-label={`Save analysis for ${entry.ticker}`}
+            >
+              <Icon icon={Bookmark} size="sm" className="mr-1.5" />
+              Save
+            </Button>
+          )}
+          {onShare && (
+            <Button
+              variant="none"
+              effect="fade"
+              size="sm"
+              onClick={() => onShare(entry.ticker)}
+              aria-label={`Share analysis for ${entry.ticker}`}
+            >
+              <Icon icon={Share2} size="sm" className="mr-1.5" />
+              Share
+            </Button>
+          )}
+          {onCompare && (
+            <Button
+              variant="none"
+              effect="fade"
+              size="sm"
+              onClick={() => onCompare(entry.ticker)}
+              aria-label={`Compare analysis for ${entry.ticker}`}
+            >
+              <Icon icon={GitCompareArrows} size="sm" className="mr-1.5" />
+              Compare
+            </Button>
+          )}
+          <span className="ml-auto text-[10px] text-muted-foreground/60">
+            {relativeTime(entry.timestamp)}
+          </span>
+        </div>
+
+        {/* ---- Disclaimer (always visible per spec) ---- */}
+        <div className="flex items-start gap-1.5 rounded-lg bg-muted/15 px-3 py-2 text-[10px] leading-snug text-muted-foreground/60">
+          <Icon icon={ShieldAlert} size="xs" className="mt-0.5 shrink-0" />
+          <span>
+            For informational purposes only. Not financial advice. All data is
+            processed locally on your device.
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default DecisionCard;

--- a/hushh-webapp/components/kai/decision-card.tsx
+++ b/hushh-webapp/components/kai/decision-card.tsx
@@ -2,8 +2,6 @@
 
 import { useState } from "react";
 import {
-  TrendingUp,
-  TrendingDown,
   ChevronDown,
   ChevronUp,
   Bookmark,
@@ -101,13 +99,6 @@ function verdictTone(decision: DecisionVerdict): string {
   if (label === "REDUCE")
     return "bg-orange-500/10 text-orange-700 dark:text-orange-300";
   return "bg-blue-500/10 text-blue-700 dark:text-blue-300";
-}
-
-function confidenceTone(confidence: number): "default" | "success" | "warning" | "danger" {
-  const normalized = confidence > 1 ? confidence : confidence * 100;
-  if (normalized >= 75) return "success";
-  if (normalized >= 50) return "warning";
-  return "danger";
 }
 
 function relativeTime(iso: string): string {

--- a/hushh-webapp/components/kai/decision-card.tsx
+++ b/hushh-webapp/components/kai/decision-card.tsx
@@ -102,7 +102,9 @@ function verdictTone(decision: DecisionVerdict): string {
 }
 
 function relativeTime(iso: string): string {
-  const diff = Date.now() - Date.parse(iso);
+  const parsed = Date.parse(iso);
+  if (Number.isNaN(parsed)) return "";
+  const diff = Date.now() - parsed;
   const minutes = Math.floor(diff / 60_000);
   if (minutes < 1) return "Just now";
   if (minutes < 60) return `${minutes}m ago`;
@@ -137,17 +139,15 @@ function extractKeyMetrics(
   const rawMetrics = card.key_metrics ?? card.keyMetrics;
   if (rawMetrics && typeof rawMetrics === "object") {
     const map = rawMetrics as Record<string, unknown>;
-    if (map.pe_ratio !== undefined)
-      metrics.push({ label: "P/E", value: String(Number(map.pe_ratio).toFixed(1)) });
+    const num = (v: unknown) => { const n = Number(v); return Number.isFinite(n) ? n : null; };
+    const pe = num(map.pe_ratio);
+    if (pe !== null) metrics.push({ label: "P/E", value: pe.toFixed(1) });
     if (map.market_cap !== undefined)
       metrics.push({ label: "Mkt Cap", value: String(map.market_cap) });
-    if (map.dividend_yield !== undefined)
-      metrics.push({
-        label: "Div Yield",
-        value: `${Number(map.dividend_yield).toFixed(2)}%`,
-      });
-    if (map.beta !== undefined)
-      metrics.push({ label: "Beta", value: String(Number(map.beta).toFixed(2)) });
+    const divYield = num(map.dividend_yield);
+    if (divYield !== null) metrics.push({ label: "Div Yield", value: `${divYield.toFixed(2)}%` });
+    const beta = num(map.beta);
+    if (beta !== null) metrics.push({ label: "Beta", value: beta.toFixed(2) });
   }
   return metrics.slice(0, 4);
 }

--- a/hushh-webapp/components/kai/decision-cards-grid.tsx
+++ b/hushh-webapp/components/kai/decision-cards-grid.tsx
@@ -7,7 +7,6 @@ import {
 } from "lucide-react";
 
 import { Icon } from "@/lib/morphy-ux/ui";
-import { Button } from "@/lib/morphy-ux/button";
 import { cn } from "@/lib/utils";
 
 import {

--- a/hushh-webapp/components/kai/decision-cards-grid.tsx
+++ b/hushh-webapp/components/kai/decision-cards-grid.tsx
@@ -12,7 +12,6 @@ import { cn } from "@/lib/utils";
 
 import {
   DecisionCard,
-  type DecisionCardProps,
   type PortfolioContext,
 } from "@/components/kai/decision-card";
 import type {

--- a/hushh-webapp/components/kai/decision-cards-grid.tsx
+++ b/hushh-webapp/components/kai/decision-cards-grid.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo, useState } from "react";
 import {
-  SlidersHorizontal,
   Search,
   FileQuestion,
 } from "lucide-react";

--- a/hushh-webapp/components/kai/decision-cards-grid.tsx
+++ b/hushh-webapp/components/kai/decision-cards-grid.tsx
@@ -1,0 +1,315 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  SlidersHorizontal,
+  Search,
+  FileQuestion,
+} from "lucide-react";
+
+import { Icon } from "@/lib/morphy-ux/ui";
+import { Button } from "@/lib/morphy-ux/button";
+import { cn } from "@/lib/utils";
+
+import {
+  DecisionCard,
+  type DecisionCardProps,
+  type PortfolioContext,
+} from "@/components/kai/decision-card";
+import type {
+  AnalysisHistoryEntry,
+  AnalysisHistoryMap,
+} from "@/lib/services/kai-history-service";
+import type { Holding } from "@/components/kai/types/portfolio";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SortField = "date" | "confidence" | "ticker";
+export type SortDirection = "asc" | "desc";
+
+export interface DecisionCardsGridProps {
+  /** All analysis history entries keyed by ticker */
+  historyMap: AnalysisHistoryMap;
+  /** Optional portfolio holdings for personalization (decrypted client-side) */
+  holdings?: Holding[];
+  /** Total portfolio value for allocation % */
+  totalPortfolioValue?: number;
+  /** Card action callbacks (passed through to each DecisionCard) */
+  onSave?: (ticker: string) => void;
+  onShare?: (ticker: string) => void;
+  onCompare?: (ticker: string) => void;
+  className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function flattenHistory(historyMap: AnalysisHistoryMap): AnalysisHistoryEntry[] {
+  return Object.values(historyMap)
+    .flatMap((entries) => entries)
+    .filter(Boolean);
+}
+
+function extractSectors(entries: AnalysisHistoryEntry[], holdings?: Holding[]): string[] {
+  const sectors = new Set<string>();
+  for (const h of holdings ?? []) {
+    if (h.sector) sectors.add(h.sector);
+  }
+  // Also pull from raw_card if present
+  for (const e of entries) {
+    const sector = (e.raw_card as Record<string, unknown>)?.sector;
+    if (typeof sector === "string" && sector.trim()) {
+      sectors.add(sector.trim());
+    }
+  }
+  return Array.from(sectors).sort();
+}
+
+function matchesSearch(entry: AnalysisHistoryEntry, query: string): boolean {
+  if (!query) return true;
+  const q = query.toLowerCase();
+  if (entry.ticker.toLowerCase().includes(q)) return true;
+  if (entry.final_statement?.toLowerCase().includes(q)) return true;
+  if (String(entry.decision).toLowerCase().includes(q)) return true;
+  return false;
+}
+
+function holdingForTicker(
+  holdings: Holding[] | undefined,
+  ticker: string
+): Holding | null {
+  if (!holdings) return null;
+  const upper = ticker.toUpperCase();
+  return holdings.find((h) => h.symbol.toUpperCase() === upper) ?? null;
+}
+
+function sortEntries(
+  entries: AnalysisHistoryEntry[],
+  field: SortField,
+  direction: SortDirection
+): AnalysisHistoryEntry[] {
+  const sorted = [...entries].sort((a, b) => {
+    if (field === "date") {
+      return Date.parse(b.timestamp) - Date.parse(a.timestamp);
+    }
+    if (field === "confidence") {
+      return (b.confidence ?? 0) - (a.confidence ?? 0);
+    }
+    // ticker
+    return a.ticker.localeCompare(b.ticker);
+  });
+  return direction === "desc" ? sorted : sorted.reverse();
+}
+
+// ---------------------------------------------------------------------------
+// Filter bar
+// ---------------------------------------------------------------------------
+
+function FilterBar({
+  searchQuery,
+  onSearchChange,
+  sortField,
+  onSortFieldChange,
+  sectors,
+  activeSector,
+  onSectorChange,
+}: {
+  searchQuery: string;
+  onSearchChange: (q: string) => void;
+  sortField: SortField;
+  onSortFieldChange: (f: SortField) => void;
+  sectors: string[];
+  activeSector: string | null;
+  onSectorChange: (s: string | null) => void;
+}) {
+  return (
+    <div className="space-y-3">
+      {/* Search + sort row */}
+      <div className="flex items-center gap-2">
+        <div className="relative flex-1">
+          <Icon
+            icon={Search}
+            size="sm"
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground/60"
+          />
+          <input
+            type="text"
+            placeholder="Search decisions..."
+            value={searchQuery}
+            onChange={(e) => onSearchChange(e.target.value)}
+            className="h-9 w-full rounded-xl border border-border/60 bg-muted/30 pl-9 pr-3 text-sm outline-none placeholder:text-muted-foreground/50 focus:border-primary/40 transition-colors"
+          />
+        </div>
+        <div className="flex items-center gap-1 rounded-xl border border-border/60 bg-muted/30 p-0.5">
+          {(["date", "confidence", "ticker"] as const).map((f) => (
+            <button
+              key={f}
+              type="button"
+              onClick={() => onSortFieldChange(f)}
+              className={cn(
+                "rounded-lg px-2.5 py-1.5 text-[10px] font-bold uppercase tracking-wider transition-colors",
+                f === sortField
+                  ? "bg-primary/10 text-primary"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              {f === "date" ? "Date" : f === "confidence" ? "Conf" : "A-Z"}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Sector chips */}
+      {sectors.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          <button
+            type="button"
+            onClick={() => onSectorChange(null)}
+            className={cn(
+              "rounded-full px-2.5 py-1 text-[10px] font-bold tracking-wide transition-colors",
+              activeSector === null
+                ? "bg-primary/10 text-primary"
+                : "bg-muted/40 text-muted-foreground hover:bg-muted/60"
+            )}
+          >
+            All
+          </button>
+          {sectors.map((s) => (
+            <button
+              key={s}
+              type="button"
+              onClick={() => onSectorChange(s === activeSector ? null : s)}
+              className={cn(
+                "rounded-full px-2.5 py-1 text-[10px] font-bold tracking-wide transition-colors",
+                s === activeSector
+                  ? "bg-primary/10 text-primary"
+                  : "bg-muted/40 text-muted-foreground hover:bg-muted/60"
+              )}
+            >
+              {s}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
+      <div className="grid h-14 w-14 place-items-center rounded-2xl bg-muted/50">
+        <Icon icon={FileQuestion} size="lg" className="text-muted-foreground/60" />
+      </div>
+      <div className="space-y-1">
+        <p className="text-sm font-semibold">No Decision Cards Yet</p>
+        <p className="max-w-xs text-xs text-muted-foreground">
+          Analyze a stock with Kai to see personalized decision cards here.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function DecisionCardsGrid({
+  historyMap,
+  holdings,
+  totalPortfolioValue,
+  onSave,
+  onShare,
+  onCompare,
+  className,
+}: DecisionCardsGridProps) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [sortField, setSortField] = useState<SortField>("date");
+  const [activeSector, setActiveSector] = useState<string | null>(null);
+
+  const allEntries = useMemo(() => flattenHistory(historyMap), [historyMap]);
+  const sectors = useMemo(
+    () => extractSectors(allEntries, holdings),
+    [allEntries, holdings]
+  );
+
+  const filtered = useMemo(() => {
+    let result = allEntries;
+
+    // Text search
+    if (searchQuery.trim()) {
+      result = result.filter((e) => matchesSearch(e, searchQuery.trim()));
+    }
+
+    // Sector filter
+    if (activeSector) {
+      result = result.filter((e) => {
+        const holding = holdingForTicker(holdings, e.ticker);
+        if (holding?.sector === activeSector) return true;
+        const cardSector = (e.raw_card as Record<string, unknown>)?.sector;
+        return typeof cardSector === "string" && cardSector.trim() === activeSector;
+      });
+    }
+
+    // Sort
+    return sortEntries(result, sortField, "desc");
+  }, [allEntries, searchQuery, activeSector, sortField, holdings]);
+
+  if (allEntries.length === 0) {
+    return (
+      <div className={className}>
+        <EmptyState />
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("space-y-4", className)}>
+      <FilterBar
+        searchQuery={searchQuery}
+        onSearchChange={setSearchQuery}
+        sortField={sortField}
+        onSortFieldChange={setSortField}
+        sectors={sectors}
+        activeSector={activeSector}
+        onSectorChange={setActiveSector}
+      />
+
+      {filtered.length === 0 ? (
+        <div className="py-10 text-center text-sm text-muted-foreground">
+          No decisions match your filters.
+        </div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {filtered.map((entry) => {
+            const holding = holdingForTicker(holdings, entry.ticker);
+            const portfolioContext: PortfolioContext | null = holding
+              ? { holding, totalPortfolioValue }
+              : null;
+
+            return (
+              <DecisionCard
+                key={`${entry.ticker}-${entry.timestamp}`}
+                entry={entry}
+                portfolioContext={portfolioContext}
+                onSave={onSave}
+                onShare={onShare}
+                onCompare={onCompare}
+              />
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default DecisionCardsGrid;


### PR DESCRIPTION
## Summary

- Adds DecisionCard and DecisionCardsGrid components for Kai analysis results
- Each card shows ticker metrics, debate summary, confidence, and personalized portfolio context
- Grid provides search, sort, and sector filtering with responsive layout

## Problem

Issue #15 requested personalized Decision Cards that surface Kai's multi-agent debate results with portfolio context, peer comparisons, and save/share/compare actions. No such component existed.

## Approach

**DecisionCard component:**
- Header: SymbolAvatar, ticker, price, confidence badge, verdict (BUY/HOLD/REDUCE)
- Key metrics strip: P/E, Market Cap, Div Yield, Beta (extracted from raw_card with NaN-safe formatting)
- Final statement summary from the debate
- "For YOUR Portfolio" block: shares owned, position value, allocation %, unrealized P&L (only renders when portfolio context provided)
- Expandable debate section: agent votes with round 1/round 2 transcript summaries
- Optional peer insight block
- Action buttons: Save, Share, Compare
- Always-visible disclaimer

**DecisionCardsGrid container:**
- Takes AnalysisHistoryMap and optional Holding[] for personalization
- Automatically matches holdings to entries by ticker symbol
- Filter bar: search (ticker, decision, statement), sort (date/confidence/ticker), sector chip filters
- Responsive grid: 1 col mobile, 2 cols sm, 3 cols lg
- Empty state when no analyses exist

**Design patterns:**
- Uses existing morphy-ux Card/Button/Icon, SymbolAvatar, Badge, Collapsible
- Glass-morphism style consistent with other Kai components
- All metric extraction helpers guard against null, undefined, and non-numeric values

## Test plan

- [x] TypeScript compilation passes
- [x] All imports verified (AnalysisHistoryEntry, Holding, SymbolAvatar, morphy-ux primitives)
- [x] No new API calls, consumes data from existing history/portfolio services
- [x] No unused imports or dead code
- [x] No secrets or env files in diff

Closes #15