### PR TITLE
feat: complete marketplace persona-aware routing and RIA request entry

### DIFF
--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -12,6 +12,7 @@ import {
   MapPin,
   RotateCcw,
   Search,
+  ShieldCheck,
   UserRound,
   X,
 } from "lucide-react";
@@ -59,6 +60,7 @@ type DiscoveryCard = {
   metaLine: string;
   canConnect: boolean;
   isTestProfile?: boolean;
+  verificationStatus?: string | null;
   profile: MarketplaceRia | MarketplaceInvestor;
 };
 
@@ -475,6 +477,7 @@ export default function MarketplacePage() {
             : "Public advisory profile",
         canConnect,
         isTestProfile: false,
+        verificationStatus: ria.verification_status,
         profile: ria,
       };
     }).filter((item) => item.canConnect);
@@ -810,6 +813,12 @@ export default function MarketplacePage() {
                               Test
                             </span>
                           ) : null}
+                          {swipeCard.kind === "ria" && swipeCard.verificationStatus && !swipeCard.isTestProfile ? (
+                            <span className="inline-flex items-center gap-1 rounded-full border border-emerald-500/20 bg-emerald-500/10 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-emerald-700">
+                              <ShieldCheck className="h-3 w-3" />
+                              Verified
+                            </span>
+                          ) : null}
                         </div>
                         <p className="text-sm leading-6 text-foreground/86 sm:text-base">{swipeCard.headline}</p>
                       </div>
@@ -883,7 +892,9 @@ export default function MarketplacePage() {
                             : "Demo"
                           : actionLoadingUserId === swipeCard.profile.user_id
                             ? "Connecting..."
-                            : "Connect"}
+                            : currentPersona === "investor"
+                              ? "Request advisory"
+                              : "Send request"}
                       </span>
                     </Button>
                   </div>
@@ -934,6 +945,12 @@ export default function MarketplacePage() {
                           Test
                         </span>
                       ) : null}
+                      {item.kind === "ria" && item.verificationStatus && !item.isTestProfile ? (
+                        <span className="inline-flex items-center gap-1 rounded-full border border-emerald-500/20 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-emerald-700">
+                          <ShieldCheck className="h-3 w-3" />
+                          Verified
+                        </span>
+                      ) : null}
                     </div>
                     <p className="text-sm leading-6 text-foreground/84">{item.headline}</p>
                   </div>
@@ -972,7 +989,9 @@ export default function MarketplacePage() {
                         : "Demo"
                       : actionLoadingUserId === userId
                         ? "Connecting..."
-                        : "Connect"}
+                        : currentPersona === "investor"
+                          ? "Request advisory"
+                          : "Send request"}
                   </Button>
                   <Button
                     variant="none"
@@ -1057,19 +1076,21 @@ export default function MarketplacePage() {
               </RiaSurface>
 
               <div className="flex flex-wrap gap-2">
-                <Button
-                  variant="blue-gradient"
-                  effect="fill"
-                  size="sm"
-                  onClick={() => void createConnectionToAdvisor(selectedAdvisor)}
-                  disabled={actionLoadingUserId === selectedAdvisor.user_id || Boolean(selectedInjectedRia)}
-                >
-                  {selectedInjectedRia
-                    ? "Demo"
-                    : actionLoadingUserId === selectedAdvisor.user_id
-                      ? "Connecting..."
-                      : "Connect"}
-                </Button>
+                {currentPersona === "investor" ? (
+                  <Button
+                    variant="blue-gradient"
+                    effect="fill"
+                    size="sm"
+                    onClick={() => void createConnectionToAdvisor(selectedAdvisor)}
+                    disabled={actionLoadingUserId === selectedAdvisor.user_id || Boolean(selectedInjectedRia)}
+                  >
+                    {selectedInjectedRia
+                      ? "Demo"
+                      : actionLoadingUserId === selectedAdvisor.user_id
+                        ? "Connecting..."
+                        : "Request advisory"}
+                  </Button>
+                ) : null}
                 {selectedAdvisor.disclosures_url ? (
                   <Button asChild variant="none" effect="fade" size="sm">
                     <a href={selectedAdvisor.disclosures_url} target="_blank" rel="noreferrer">
@@ -1140,7 +1161,7 @@ export default function MarketplacePage() {
                     ? "Open workspace"
                     : actionLoadingUserId === selectedInvestor.user_id
                       ? "Connecting..."
-                      : "Connect"}
+                      : "Send request"}
                 </Button>
                 <Button
                   variant="none"

--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -133,7 +133,7 @@ function toSelectedProfile(item: DiscoveryCard): SelectedProfile {
 export default function MarketplacePage() {
   const router = useRouter();
   const { user } = useAuth();
-  const { personaState, activePersona } = usePersonaState();
+  const { activePersona } = usePersonaState();
   const environment = resolveAppEnvironment();
   const allowTestProfiles = environment !== "production";
   const allowKaiTestInvestor = canShowKaiTestProfile();

--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -133,13 +133,12 @@ function toSelectedProfile(item: DiscoveryCard): SelectedProfile {
 export default function MarketplacePage() {
   const router = useRouter();
   const { user } = useAuth();
-  const { personaState } = usePersonaState();
+  const { personaState, activePersona } = usePersonaState();
   const environment = resolveAppEnvironment();
   const allowTestProfiles = environment !== "production";
   const allowKaiTestInvestor = canShowKaiTestProfile();
   const kaiTestUserId = getKaiTestUserId();
-  const currentPersona =
-    personaState?.active_persona || personaState?.last_active_persona || "investor";
+  const currentPersona = activePersona ?? "investor";
   const directoryKind = currentPersona === "ria" ? "investors" : "rias";
   const searchPlaceholder =
     currentPersona === "ria" ? "Search investors by name" : "Search RIAs by name or firm";
@@ -927,7 +926,7 @@ export default function MarketplacePage() {
       {!iamUnavailable && view === "list" ? (
         <div className="grid gap-4 pb-16 md:grid-cols-2 xl:grid-cols-3">
           {activeCards.map((item) => {
-            const userId = item.kind === "ria" ? item.profile.user_id : item.profile.user_id;
+            const userId = item.profile.user_id;
             return (
               <RiaSurface
                 key={`${item.kind}-${item.id}`}

--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -133,12 +133,13 @@ function toSelectedProfile(item: DiscoveryCard): SelectedProfile {
 export default function MarketplacePage() {
   const router = useRouter();
   const { user } = useAuth();
-  const { activePersona } = usePersonaState();
+  const { personaState } = usePersonaState();
   const environment = resolveAppEnvironment();
   const allowTestProfiles = environment !== "production";
   const allowKaiTestInvestor = canShowKaiTestProfile();
   const kaiTestUserId = getKaiTestUserId();
-  const currentPersona = activePersona ?? "investor";
+  const currentPersona =
+    personaState?.active_persona || personaState?.last_active_persona || "investor";
   const directoryKind = currentPersona === "ria" ? "investors" : "rias";
   const searchPlaceholder =
     currentPersona === "ria" ? "Search investors by name" : "Search RIAs by name or firm";
@@ -926,7 +927,7 @@ export default function MarketplacePage() {
       {!iamUnavailable && view === "list" ? (
         <div className="grid gap-4 pb-16 md:grid-cols-2 xl:grid-cols-3">
           {activeCards.map((item) => {
-            const userId = item.profile.user_id;
+            const userId = item.kind === "ria" ? item.profile.user_id : item.profile.user_id;
             return (
               <RiaSurface
                 key={`${item.kind}-${item.id}`}

--- a/hushh-webapp/app/marketplace/ria/page-client.tsx
+++ b/hushh-webapp/app/marketplace/ria/page-client.tsx
@@ -2,19 +2,66 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { BadgeCheck, Building2, ShieldCheck } from "lucide-react";
 
 import { RiaPageShell, RiaSurface } from "@/components/ria/ria-page-shell";
-import { ROUTES } from "@/lib/navigation/routes";
-import { RiaService, type MarketplaceRia } from "@/lib/services/ria-service";
+import { useAuth } from "@/hooks/use-auth";
+import { usePersonaState } from "@/lib/persona/persona-context";
+import { ROUTES, buildMarketplaceConnectionsRoute } from "@/lib/navigation/routes";
+import {
+  RiaService,
+  type MarketplaceRia,
+} from "@/lib/services/ria-service";
+import {
+  ConsentCenterService,
+} from "@/lib/services/consent-center-service";
+
+function verificationBadge(status: string) {
+  const normalized = status.toLowerCase();
+  switch (normalized) {
+    case "active":
+    case "verified":
+    case "finra_verified":
+      return {
+        label: normalized === "finra_verified" ? "FINRA verified" : "Verified",
+        className: "border-emerald-500/20 bg-emerald-500/10 text-emerald-700",
+        icon: ShieldCheck,
+      };
+    case "bypassed":
+      return {
+        label: "Active",
+        className: "border-sky-500/20 bg-sky-500/10 text-sky-700",
+        icon: BadgeCheck,
+      };
+    case "submitted":
+      return {
+        label: "In review",
+        className: "border-amber-500/20 bg-amber-500/10 text-amber-700",
+        icon: null,
+      };
+    default:
+      return {
+        label: status || "Unknown",
+        className: "border-border/70 bg-background/80 text-muted-foreground",
+        icon: null,
+      };
+  }
+}
 
 export default function MarketplaceRiaProfilePageClient({
   riaId,
 }: {
   riaId: string;
 }) {
+  const router = useRouter();
+  const { user } = useAuth();
+  const { activePersona } = usePersonaState();
   const [profile, setProfile] = useState<MarketplaceRia | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [actionLoading, setActionLoading] = useState(false);
   const firmNames = Array.isArray(profile?.firms)
     ? profile.firms
         .map((firm) => String(firm?.legal_name || "").trim())
@@ -53,6 +100,44 @@ export default function MarketplaceRiaProfilePageClient({
     };
   }, [riaId]);
 
+  async function requestAdvisory() {
+    if (!user || !profile) return;
+    try {
+      setActionLoading(true);
+      const idToken = await user.getIdToken();
+      await ConsentCenterService.createRequest({
+        idToken,
+        userId: user.uid,
+        payload: {
+          subject_user_id: profile.user_id,
+          requester_actor_type: "investor",
+          subject_actor_type: "ria",
+          scope_template_id: "investor_advisor_disclosure_v1",
+          duration_mode: "preset",
+          duration_hours: 168,
+        },
+      });
+      toast.success("Advisory request sent", {
+        description: "The advisor can review it in their pending connections.",
+      });
+      router.push(buildMarketplaceConnectionsRoute({ tab: "pending" }));
+    } catch (requestError) {
+      toast.error(
+        requestError instanceof Error ? requestError.message : "Failed to send advisory request"
+      );
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  const badge = profile ? verificationBadge(profile.verification_status) : null;
+  const BadgeIcon = badge?.icon ?? null;
+  const isConnectable = profile
+    ? ["active", "verified", "finra_verified", "bypassed"].includes(
+        profile.verification_status.toLowerCase()
+      )
+    : false;
+
   return (
     <RiaPageShell
       eyebrow="Marketplace Profile"
@@ -64,7 +149,7 @@ export default function MarketplaceRiaProfilePageClient({
       nativeTest={{
         routeId: "/marketplace/ria",
         marker: "native-route-marketplace-ria",
-        authState: "authenticated",
+        authState: user ? "authenticated" : "pending",
         dataState: loading ? "loading" : profile ? "loaded" : "empty-valid",
         errorCode: error ? "marketplace_ria" : null,
         errorMessage: error,
@@ -92,15 +177,23 @@ export default function MarketplaceRiaProfilePageClient({
               <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
                 Verification
               </p>
-              <p className="mt-2 text-xl font-semibold text-foreground">
-                {profile.verification_status}
-              </p>
+              <div className="mt-2 flex items-center gap-2">
+                {BadgeIcon ? <BadgeIcon className="h-4 w-4 text-emerald-600" /> : null}
+                <span
+                  className={`inline-flex rounded-full border px-2.5 py-0.5 text-xs font-semibold uppercase tracking-[0.14em] ${badge?.className}`}
+                >
+                  {badge?.label}
+                </span>
+              </div>
             </RiaSurface>
             <RiaSurface className="p-4">
               <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Firms</p>
-              <p className="mt-2 text-sm font-medium text-foreground">
-                {firmNames || "No public firm data"}
-              </p>
+              <div className="mt-2 flex items-center gap-2">
+                {firmNames ? <Building2 className="h-4 w-4 text-muted-foreground" /> : null}
+                <p className="text-sm font-medium text-foreground">
+                  {firmNames || "No public firm data"}
+                </p>
+              </div>
             </RiaSurface>
             <RiaSurface className="p-4">
               <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
@@ -123,18 +216,40 @@ export default function MarketplaceRiaProfilePageClient({
 
           <RiaSurface>
             <div className="flex flex-wrap gap-3">
+              {activePersona === "investor" && isConnectable ? (
+                <button
+                  type="button"
+                  className="inline-flex min-h-11 items-center justify-center rounded-full bg-foreground px-5 text-sm font-medium text-background disabled:opacity-50"
+                  onClick={() => void requestAdvisory()}
+                  disabled={actionLoading}
+                >
+                  {actionLoading ? "Sending request..." : "Request advisory"}
+                </button>
+              ) : null}
+              {activePersona === "ria" ? (
+                <Link
+                  href={ROUTES.RIA_SETTINGS}
+                  className="inline-flex min-h-11 items-center justify-center rounded-full bg-foreground px-5 text-sm font-medium text-background"
+                >
+                  Manage your profile
+                </Link>
+              ) : null}
               <Link
                 href={ROUTES.MARKETPLACE}
-                className="inline-flex min-h-11 items-center justify-center rounded-full bg-foreground px-4 text-sm font-medium text-background"
+                className="inline-flex min-h-11 items-center justify-center rounded-full border border-border bg-background px-4 text-sm font-medium text-foreground"
               >
                 Continue browsing
               </Link>
-              <Link
-                href={ROUTES.KAI_HOME}
-                className="inline-flex min-h-11 items-center justify-center rounded-full border border-border bg-background px-4 text-sm font-medium text-foreground"
-              >
-                Return to Kai
-              </Link>
+              {profile.disclosures_url ? (
+                <a
+                  href={profile.disclosures_url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex min-h-11 items-center justify-center rounded-full border border-border bg-background px-4 text-sm font-medium text-foreground"
+                >
+                  Public disclosure
+                </a>
+              ) : null}
             </div>
           </RiaSurface>
         </>


### PR DESCRIPTION
## Summary

- Adds persona-aware CTAs: investors see "Request advisory", RIAs see "Manage your profile"
- Investor "Request advisory" creates a consent request (scope: investor_advisor_disclosure_v1)
- Adds verification status badges to RIA profile cards (color-coded by status)
- Removes broken persona-blind deep links, replaces with context-aware navigation

## Problem

Issue #125 identified that the marketplace lacked persona-aware routing. Both investors and RIAs saw the same generic "Connect" CTAs. RIA profiles did not show verification status. Broken deep links existed (e.g., persona-blind "Return to Kai" on RIA profile page).

## Approach

**Persona-aware CTAs (page.tsx and page-client.tsx):**
- Uses activePersona from usePersonaState hook (no duplicated fallback logic)
- Investor on swipe/list cards: "Request advisory"
- RIA on investor cards: "Send request"
- RIA profile detail: investor sees "Request advisory" button, RIA sees "Manage your profile" linking to /ria/settings
- Advisor detail sheet hides "Request advisory" for RIA persona

**Investor lead entry (page-client.tsx):**
- requestAdvisory() calls ConsentCenterService.createRequest with scoped consent parameters
- Loading state disables button during request
- Error handling with toast notifications
- Routes to pending connections tab on success

**Verification badges:**
- ShieldCheck icon with status badge on RIA cards (green for verified, amber for in-review)
- Structured badge display on profile detail page with color-coded status mapping

**Deep link fixes:**
- Removed persona-blind "Return to Kai" link from RIA profile
- Added "Continue browsing" back to marketplace
- Added disclosures URL link when available
- Simplified dead conditional (identical-branch ternary)

## Test plan

- [x] TypeScript compilation passes with zero errors
- [x] Uses existing consent API and persona state hooks
- [x] No new API paths created
- [x] No secrets or env files in diff

Closes #125