### PR TITLE
fix: remove credential fragments from client-side console logging

### DIFF
--- a/hushh-webapp/lib/notifications/fcm-service.ts
+++ b/hushh-webapp/lib/notifications/fcm-service.ts
@@ -374,7 +374,7 @@ async function initializeNativeFCM(
 
     // Step 2: Get FCM token
     const { token } = await FirebaseMessaging.getToken();
-    console.log("[FCM] Got token:", token.substring(0, 20) + "...");
+    console.log("[FCM] Got push token");
 
     // Step 3: Register token with backend
     const platform = Capacitor.getPlatform() as "ios" | "android" | "web";
@@ -595,7 +595,7 @@ async function initializeWebFCM(
       return { status: "push_failed", detail: "empty_push_token" };
     }
 
-    console.log("[FCM] Got token:", token.substring(0, 20) + "...");
+    console.log("[FCM] Got push token");
 
     // Register token with backend
     console.log("[FCM] Registering token with backend...");
@@ -734,7 +734,7 @@ function setupNativeListeners(): void {
       );
 
       await FirebaseMessaging.addListener("tokenReceived", async (event) => {
-        console.log("[FCM] Token refreshed:", event.token.substring(0, 20) + "...");
+        console.log("[FCM] Push token refreshed");
         const platform = Capacitor.getPlatform() as "ios" | "android" | "web";
         try {
           if (lastKnownSession) {

--- a/hushh-webapp/lib/services/account-service.ts
+++ b/hushh-webapp/lib/services/account-service.ts
@@ -38,12 +38,7 @@ export class AccountServiceImpl {
       result: "success",
     });
 
-    console.log(
-      "[AccountService] Deleting account with target:",
-      target,
-      "token:",
-      vaultOwnerToken.substring(0, 30) + "..."
-    );
+    console.log("[AccountService] Deleting account with target:", target);
 
     try {
       if (Capacitor.isNativePlatform()) {


### PR DESCRIPTION
## Summary

- Removes 4 console.log calls that exposed token prefixes in browser DevTools
- Replaces with action-only log messages (no credential material)

## Problem

Found during a security sweep of client-side logging:

| File | What was logged | Risk |
|------|----------------|------|
| account-service.ts:45 | First 30 chars of VAULT_OWNER consent token | Consent token prefix in browser console |
| fcm-service.ts:377 | First 20 chars of FCM push token | Push token prefix in browser console |
| fcm-service.ts:598 | First 20 chars of FCM push token | Same, duplicate code path |
| fcm-service.ts:737 | First 20 chars of refreshed FCM token | Same, token refresh path |

These fragments are visible in DevTools, capturable by browser extensions (including malicious ones), and potentially forwarded by client-side observability tools. The VAULT_OWNER token prefix is especially sensitive since it is a consent-scoped credential.

## Approach

Replaced each call with an action-only message that confirms the operation happened without including any credential material:

- `"[AccountService] Deleting account with target:", target, "token:", vaultOwnerToken.substring(0, 30)` -> `"[AccountService] Deleting account with target:", target`
- `"[FCM] Got token:", token.substring(0, 20)` -> `"[FCM] Got push token"`
- `"[FCM] Token refreshed:", event.token.substring(0, 20)` -> `"[FCM] Push token refreshed"`

Also verified via grep that no other `.substring()` or `.slice()` patterns remain in console.log calls across the frontend codebase.

## Test plan

- [x] TypeScript typecheck passes (zero new errors; pre-existing voice-tts-playback.ts errors unchanged)
- [x] `grep -rn "console.log.*\.substring" hushh-webapp/` returns zero results after fix
- [x] 2 files changed, 4 insertions, 9 deletions
- [x] No secrets or env files in diff