### PR TITLE
fix: align UAT release contract with migration 046

### DIFF
--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -22,7 +22,8 @@
     "042_ria_pick_single_active_record.sql",
     "043_ria_pick_share_artifacts.sql",
     "044_kai_alpaca_connect_sessions.sql",
-    "045_kai_funding_trade_intents.sql"
+    "045_kai_funding_trade_intents.sql",
+    "046_kai_gmail_receipt_total.sql"
   ],
   "groups": {
     "iam": [

--- a/consent-protocol/db/schema_contract/uat_integrated_schema.json
+++ b/consent-protocol/db/schema_contract/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 45,
+  "expected_migration_version": 46,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",


### PR DESCRIPTION
## Summary
- add migration `046_kai_gmail_receipt_total.sql` to the canonical release manifest
- bump the UAT integrated schema contract from 45 to 46

## Local verification
- `python3 scripts/ops/db_migration_release_guard.py --contract-file consent-protocol/db/schema_contract/uat_integrated_schema.json --skip-db-check --print-json`

## Why
- the automatic UAT deploy for main SHA `7cfd114e270f17a5e5d0aafa7defaee39ae59ed5` failed on `contract_version_mismatch:policy=exact:highest_local=046:expected=045`
