### PR TITLE
fix: remove dead backend cloud build substitutions

### DIFF
--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -111,27 +111,7 @@ timeout: "1200s"
 substitutions:
   _BACKEND_SERVICE: consent-protocol
   _REGION: us-central1
-  _ENVIRONMENT: production
-  _DB_HOST: aws-1-us-east-1.pooler.supabase.com
-  _DB_PORT: "5432"
-  _DB_NAME: postgres
-  _DB_UNIX_SOCKET: ""
   _CLOUDSQL_INSTANCES: ""
-  _CORS_ALLOWED_ORIGINS: https://hushh-webapp-XXXXXXXXXX-uc.a.run.app
-  _OBS_DATA_STALE_RATIO_THRESHOLD: "0.25"
-  _CONSENT_SSE_ENABLED: "false"
-  _SYNC_REMOTE_ENABLED: "false"
-  _DEVELOPER_API_ENABLED: "false"
-  _REMOTE_MCP_ENABLED: "false"
-  _PASSKEY_ALLOWED_RP_IDS: ""
-  _PLAID_ENV: ""
-  _PLAID_CLIENT_NAME: ""
-  _PLAID_COUNTRY_CODES: ""
-  _PLAID_WEBHOOK_URL: ""
-  _PLAID_REDIRECT_PATH: ""
-  _PLAID_REDIRECT_URI: ""
-  _PLAID_TX_HISTORY_DAYS: ""
-  _RIA_DEV_BYPASS_ENABLED: ""
   _PLAID_CLIENT_ID_SECRET: ""
   _PLAID_SECRET_SECRET: ""
   _APP_SIGNING_KEY_SECRET: APP_SIGNING_KEY


### PR DESCRIPTION
## Summary
- remove stale backend Cloud Build substitutions that no longer exist in the runtime contract
- keep the deploy template aligned with the hosted secret-backed config model
- unblock the UAT backend deploy step from failing before rollout starts

## Testing
- python3 - <<'PY'
from pathlib import Path
import re
text = Path("deploy/backend.cloudbuild.yaml").read_text()
subs = re.findall(r"^\s+(_[A-Z0-9_]+):", text, re.M)
unused=[]
for name in subs:
    refs = len(re.findall(re.escape("${"+name+"}"), text))
    if refs == 0:
        unused.append(name)
print("unused:", unused)
assert not unused
PY
- python3 - <<'PY'
import yaml
from pathlib import Path
with Path("deploy/backend.cloudbuild.yaml").open() as f:
    yaml.safe_load(f)
print("yaml-ok")
PY