### PR TITLE
fix: stabilize uat semantic bootstrap

### DIFF
--- a/.codex/skills/repo-operations/SKILL.md
+++ b/.codex/skills/repo-operations/SKILL.md
@@ -70,11 +70,12 @@ Non-owned surfaces:
    - the fix is a post-merge blocker and must start from the latest `main`
    - the repo workflow requires an isolated hotfix from `main`
    - the current branch contains unrelated in-flight work that would make the fix unsafe to ship
-14. After a merge-driven hotfix is complete, return local state to the user's normal working branch or `main`; do not leave Codex parked on a temporary branch.
-15. For CI workflows, branch protection, env/bootstrap, or deploy-authority changes, do a second verification pass after edits instead of trusting the first green run.
-16. For branch protection, merge queue, release authority, or production deploy-governance changes, do a third independent check against live GitHub or runtime state before calling the work complete.
-17. For UAT runtime failures, start with `./bin/hushh codex rca --surface uat --text` so secret drift, legacy runtime mounts, DB drift, and semantic runtime breakage are classified before editing or redeploying.
-18. Treat only core runtime/release surfaces as blocking in the RCA loop: runtime contract, deploy/runtime env contract, DB release contract, semantic UAT verification, and Gmail/voice/auth availability on the release lane. Helper-only drift stays advisory unless it masks one of those surfaces.
+14. After a merge-driven hotfix is complete, delete the temporary branch remotely and locally when it is safe to do so, then return local state to the user's normal working branch or `main`; do not leave Codex parked on a temporary branch.
+15. If the user has an active development branch, back-sync merged hotfixes into that branch before closing the task so the real working branch does not drift behind `main`.
+16. For CI workflows, branch protection, env/bootstrap, or deploy-authority changes, do a second verification pass after edits instead of trusting the first green run.
+17. For branch protection, merge queue, release authority, or production deploy-governance changes, do a third independent check against live GitHub or runtime state before calling the work complete.
+18. For UAT runtime failures, start with `./bin/hushh codex rca --surface uat --text` so secret drift, legacy runtime mounts, DB drift, and semantic runtime breakage are classified before editing or redeploying.
+19. Treat only core runtime/release surfaces as blocking in the RCA loop: runtime contract, deploy/runtime env contract, DB release contract, semantic UAT verification, and Gmail/voice/auth availability on the release lane. Helper-only drift stays advisory unless it masks one of those surfaces.
 
 ## Handoff Rules
 

--- a/scripts/env/bootstrap_profiles.sh
+++ b/scripts/env/bootstrap_profiles.sh
@@ -107,9 +107,9 @@ require_cmd() {
 require_cmd jq
 require_cmd python3
 
-declare -a SUMMARY
-declare -a WARNINGS
-declare -a MISSING_REQUIRED
+declare -a SUMMARY=()
+declare -a WARNINGS=()
+declare -a MISSING_REQUIRED=()
 
 GCLOUD_AVAILABLE=false
 GCLOUD_ACCOUNT=""


### PR DESCRIPTION
## Summary
- initialize bootstrap warning and missing-value arrays so strict shell mode does not crash on a clean run
- codify repo-operations cleanup to delete temporary hotfix branches and back-sync updates into the active dev branch
- unblock post-deploy semantic verification on the UAT release lane

## Testing
- BOOTSTRAP_FOCUS_PROFILE=uat bash scripts/env/bootstrap_profiles.sh --strict
- bash scripts/env/use_profile.sh uat
- python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py