### PR TITLE
fix: unblock UAT semantic verifier runtime paths

### DIFF
--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -450,6 +450,8 @@ jobs:
           "${{ env.PROTOCOL_PYTHON }}" scripts/ops/verify_uat_release.py \
             --backend-url "${{ steps.current-state.outputs.backend_url }}" \
             --frontend-url "${{ env.APP_FRONTEND_ORIGIN }}" \
+            --protocol-env consent-protocol/.env \
+            --web-env hushh-webapp/.env.local \
             --report-path /tmp/uat-release-verify-attempt-1.json
 
       - name: Semantic UAT verification retry
@@ -463,6 +465,8 @@ jobs:
           "${{ env.PROTOCOL_PYTHON }}" scripts/ops/verify_uat_release.py \
             --backend-url "${{ steps.current-state.outputs.backend_url }}" \
             --frontend-url "${{ env.APP_FRONTEND_ORIGIN }}" \
+            --protocol-env consent-protocol/.env \
+            --web-env hushh-webapp/.env.local \
             --report-path /tmp/uat-release-verify-attempt-2.json
 
       - name: Classify UAT release outcome

--- a/consent-protocol/scripts/uat_kai_regression_smoke.py
+++ b/consent-protocol/scripts/uat_kai_regression_smoke.py
@@ -45,16 +45,15 @@ from mcp.client.streamable_http import streamablehttp_client
 from sqlalchemy import create_engine, text
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = PROJECT_ROOT.parent
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from api.utils.fcm_messages import build_push_message  # noqa: E402
 
 DEFAULT_BACKEND_URL = "https://api.uat.hushh.ai"
-DEFAULT_PROTOCOL_ENV = os.path.expanduser("~/Documents/GitHub/hushh-research/consent-protocol/.env")
-DEFAULT_WEBAPP_ENV = os.path.expanduser(
-    "~/Documents/GitHub/hushh-research/hushh-webapp/.env.uat.local"
-)
+DEFAULT_PROTOCOL_ENV = str(PROJECT_ROOT / ".env")
+DEFAULT_WEBAPP_ENV = str(REPO_ROOT / "hushh-webapp" / ".env.uat.local")
 DEFAULT_TIMEOUT = 45
 UAT_SMOKE_USER_ID_KEY = "UAT_SMOKE_USER_ID"
 UAT_SMOKE_PASSPHRASE_KEY = "UAT_SMOKE_PASSPHRASE"  # noqa: S105

--- a/hushh-webapp/scripts/testing/verify-signed-in-routes.mjs
+++ b/hushh-webapp/scripts/testing/verify-signed-in-routes.mjs
@@ -8,7 +8,6 @@ import { fileURLToPath } from "node:url";
 import { spawn } from "node:child_process";
 import process from "node:process";
 
-import dotenv from "dotenv";
 import { chromium } from "playwright";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -19,14 +18,40 @@ const contractPath = path.join(webDir, "lib", "navigation", "app-route-layout.co
 const webEnvPath = path.join(webDir, ".env.local");
 const protocolEnvPath = path.join(repoRoot, "consent-protocol", ".env");
 
-dotenv.config({ path: webEnvPath });
-dotenv.config({ path: protocolEnvPath, override: false });
-const parsedWebEnv = fs.existsSync(webEnvPath)
-  ? dotenv.parse(fs.readFileSync(webEnvPath))
-  : {};
-const parsedProtocolEnv = fs.existsSync(protocolEnvPath)
-  ? dotenv.parse(fs.readFileSync(protocolEnvPath))
-  : {};
+function parseEnvFile(filePath) {
+  if (!fs.existsSync(filePath)) return {};
+  const parsed = {};
+  const content = fs.readFileSync(filePath, "utf8");
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const separatorIndex = line.indexOf("=");
+    if (separatorIndex <= 0) continue;
+    const key = line.slice(0, separatorIndex).trim();
+    let value = line.slice(separatorIndex + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    parsed[key] = value;
+  }
+  return parsed;
+}
+
+function seedProcessEnv(parsed) {
+  for (const [key, value] of Object.entries(parsed)) {
+    if (!process.env[key] && value) {
+      process.env[key] = value;
+    }
+  }
+}
+
+const parsedWebEnv = parseEnvFile(webEnvPath);
+const parsedProtocolEnv = parseEnvFile(protocolEnvPath);
+seedProcessEnv(parsedProtocolEnv);
+seedProcessEnv(parsedWebEnv);
 
 function readRawEnvLiteral(filePath, key) {
   if (!fs.existsSync(filePath)) return "";
@@ -52,17 +77,17 @@ const appOrigin = (
 ).replace(/\/$/, "");
 const routeFilter = String(process.env.HUSHH_ROUTE_FILTER || "").trim().toLowerCase();
 const viewportFilter = String(process.env.HUSHH_VIEWPORT_FILTER || "").trim().toLowerCase();
-const rawProtocolReviewerPassphrase = readRawEnvLiteral(protocolEnvPath, "KAI_TEST_PASSPHRASE");
+const rawProtocolReviewerPassphrase = readRawEnvLiteral(protocolEnvPath, "UAT_SMOKE_PASSPHRASE");
 const reviewerPassphrase =
   sanitizeConfiguredValue(process.env.HUSHH_REVIEWER_PASSPHRASE) ||
+  sanitizeConfiguredValue(process.env.UAT_SMOKE_PASSPHRASE) ||
+  sanitizeConfiguredValue(parsedProtocolEnv.UAT_SMOKE_PASSPHRASE) ||
   sanitizeConfiguredValue(rawProtocolReviewerPassphrase) ||
-  sanitizeConfiguredValue(parsedProtocolEnv.KAI_TEST_PASSPHRASE) ||
-  sanitizeConfiguredValue(process.env.HUSHH_KAI_TEST_PASSPHRASE) ||
-  sanitizeConfiguredValue(process.env.KAI_TEST_PASSPHRASE) ||
   "test#123";
-const kaiTestUserId =
-  sanitizeConfiguredValue(process.env.NEXT_PUBLIC_KAI_TEST_USER_ID) ||
-  sanitizeConfiguredValue(parsedWebEnv.NEXT_PUBLIC_KAI_TEST_USER_ID) ||
+const smokeUserId =
+  sanitizeConfiguredValue(process.env.HUSHH_SMOKE_USER_ID) ||
+  sanitizeConfiguredValue(process.env.UAT_SMOKE_USER_ID) ||
+  sanitizeConfiguredValue(parsedProtocolEnv.UAT_SMOKE_USER_ID) ||
   "s3xmA4lNSAQFrIaOytnSGAOzXlL2";
 
 const VIEWPORTS = [
@@ -96,22 +121,22 @@ const TERMINAL_DATA_STATES = new Set([
 
 const DYNAMIC_ROUTE_FIXTURES = {
   "/ria/clients/[userId]": {
-    path: `/ria/clients/${kaiTestUserId}?tab=overview&test_profile=1`,
-    expectedPathname: `/ria/clients/${kaiTestUserId}`,
+    path: `/ria/clients/${smokeUserId}?tab=overview&test_profile=1`,
+    expectedPathname: `/ria/clients/${smokeUserId}`,
     expectedQueryIncludes: ["tab=overview", "test_profile=1"],
     allowedRouteIds: ["/ria/clients/[userId]"],
     requireBackButton: false,
   },
   "/ria/clients/[userId]/accounts/[accountId]": {
-    path: `/ria/clients/${kaiTestUserId}/accounts/acct_demo_taxable_main?test_profile=1`,
-    expectedPathname: `/ria/clients/${kaiTestUserId}/accounts/acct_demo_taxable_main`,
+    path: `/ria/clients/${smokeUserId}/accounts/acct_demo_taxable_main?test_profile=1`,
+    expectedPathname: `/ria/clients/${smokeUserId}/accounts/acct_demo_taxable_main`,
     expectedQueryIncludes: ["test_profile=1"],
     allowedRouteIds: ["/ria/clients/[userId]/accounts/[accountId]"],
     requireBackButton: true,
   },
   "/ria/clients/[userId]/requests/[requestId]": {
-    path: `/ria/clients/${kaiTestUserId}/requests/request_demo_kai_specialized_bundle?test_profile=1`,
-    expectedPathname: `/ria/clients/${kaiTestUserId}/requests/request_demo_kai_specialized_bundle`,
+    path: `/ria/clients/${smokeUserId}/requests/request_demo_kai_specialized_bundle?test_profile=1`,
+    expectedPathname: `/ria/clients/${smokeUserId}/requests/request_demo_kai_specialized_bundle`,
     expectedQueryIncludes: ["test_profile=1"],
     allowedRouteIds: ["/ria/clients/[userId]/requests/[requestId]"],
     requireBackButton: true,
@@ -167,8 +192,8 @@ const REDIRECT_EXPECTATIONS = {
     requiresColdEntry: true,
   },
   "/ria/workspace": {
-    path: `/ria/workspace?clientId=${encodeURIComponent(kaiTestUserId)}&tab=overview&test_profile=1`,
-    expectedPathname: `/ria/clients/${kaiTestUserId}`,
+    path: `/ria/workspace?clientId=${encodeURIComponent(smokeUserId)}&tab=overview&test_profile=1`,
+    expectedPathname: `/ria/clients/${smokeUserId}`,
     expectedQueryIncludes: ["tab=overview", "test_profile=1"],
     allowedRouteIds: ["/ria/clients/[userId]"],
   },


### PR DESCRIPTION
## Summary
- pass the bootstrapped runtime env files explicitly into UAT semantic verification
- make UAT smoke defaults repo-relative instead of workstation-specific
- remove the signed-in route verifier's runtime dependency on dotenv and use the smoke overlay envs

## Testing
- python3 -m py_compile consent-protocol/scripts/uat_kai_regression_smoke.py scripts/ops/verify_uat_release.py
- node --check hushh-webapp/scripts/testing/verify-signed-in-routes.mjs
- python3 - <<'PY'
from pathlib import Path
import yaml
yaml.safe_load(Path('.github/workflows/deploy-uat.yml').read_text())
print('yaml-ok')
PY