### PR TITLE
fix: install signed-in route deps in UAT deploy

### DIFF
--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -441,6 +441,14 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_ENV"
 
+      - name: Install signed-in route verification dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd hushh-webapp
+          npm ci
+          npx playwright install chromium
+
       - name: Semantic UAT verification
         id: verify-uat-1
         continue-on-error: true
@@ -683,12 +691,14 @@ jobs:
             fi
           fi
 
+          export STATUS
           python3 - <<'PY'
           import json
+          import os
           from pathlib import Path
 
           payload = {
-              "status": "${STATUS}",
+              "status": os.environ["STATUS"],
               "sha": "${{ steps.resolve-sha.outputs.sha }}",
               "scope": "${{ steps.scope.outputs.scope }}",
               "app_frontend_origin": "${{ env.APP_FRONTEND_ORIGIN }}",


### PR DESCRIPTION
## Summary
- install the existing hushh-webapp route-verification dependencies inside the UAT deploy lane
- install the Playwright chromium runtime before semantic verification
- write the final UAT release status artifact from the real shell status value

## Testing
- python3 - <<'PY'
from pathlib import Path
import yaml
yaml.safe_load(Path('.github/workflows/deploy-uat.yml').read_text())
print('yaml-ok')
PY