### PR TITLE
fix: stabilize persona switching and uat smoke auth

### DIFF
--- a/consent-protocol/api/routes/health.py
+++ b/consent-protocol/api/routes/health.py
@@ -3,6 +3,7 @@
 Health check endpoints.
 """
 
+import hmac
 import logging
 import os
 
@@ -25,6 +26,23 @@ def _env_truthy(name: str, fallback: str = "false") -> bool:
 
 def _is_app_review_mode_enabled() -> bool:
     return _env_truthy("APP_REVIEW_MODE")
+
+
+def _runtime_profile() -> str:
+    return str(os.getenv("APP_RUNTIME_PROFILE", "")).strip().lower()
+
+
+def _resolve_smoke_overlay_identity(smoke_passphrase: str | None) -> tuple[str, str] | None:
+    configured_uid = str(os.getenv("UAT_SMOKE_USER_ID", "")).strip()
+    configured_passphrase = str(os.getenv("UAT_SMOKE_PASSPHRASE", "")).strip()
+    provided_passphrase = str(smoke_passphrase or "").strip()
+    if _runtime_profile() == "production":
+        return None
+    if not configured_uid or not configured_passphrase or not provided_passphrase:
+        return None
+    if not hmac.compare_digest(provided_passphrase, configured_passphrase):
+        return None
+    return configured_uid, "uat_smoke"
 
 
 @router.get("/")
@@ -56,15 +74,30 @@ async def issue_app_review_mode_session(request: Request):
     - Uses fixed REVIEWER_UID from server env
     - Never returns reviewer password to clients
     """
-    if not _is_app_review_mode_enabled():
-        raise HTTPException(
-            status_code=403,
-            detail="App review mode is disabled",
-            headers=NO_STORE_HEADERS,
-        )
+    try:
+        payload = await request.json()
+    except Exception:
+        payload = {}
+    if not isinstance(payload, dict):
+        payload = {}
 
-    reviewer_uid = str(os.getenv("REVIEWER_UID", "")).strip()
+    session_subject = "reviewer"
+    reviewer_uid = ""
     failure_reason = "missing_reviewer_uid"
+
+    if _is_app_review_mode_enabled():
+        reviewer_uid = str(os.getenv("REVIEWER_UID", "")).strip()
+    else:
+        smoke_overlay = _resolve_smoke_overlay_identity(payload.get("smoke_passphrase"))
+        if smoke_overlay:
+            reviewer_uid, session_subject = smoke_overlay
+            failure_reason = "missing_uat_smoke_user_id"
+        else:
+            raise HTTPException(
+                status_code=403,
+                detail="App review mode is disabled",
+                headers=NO_STORE_HEADERS,
+            )
 
     if not reviewer_uid:
         logger.error("app_review_mode.session_failed reason=%s", failure_reason)
@@ -105,7 +138,7 @@ async def issue_app_review_mode_session(request: Request):
     logger.info(
         "app_review_mode.session_issued reviewer_uid=%s subject=%s project_id=%s client_ip=%s",
         reviewer_uid,
-        "reviewer",
+        session_subject,
         project_id or "unknown",
         client_ip,
     )

--- a/consent-protocol/tests/test_health_review_mode.py
+++ b/consent-protocol/tests/test_health_review_mode.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routes import health
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(health.router)
+    return app
+
+
+def test_review_mode_session_requires_app_review_or_smoke_overlay(monkeypatch):
+    monkeypatch.setenv("APP_RUNTIME_PROFILE", "uat")
+    monkeypatch.delenv("APP_REVIEW_MODE", raising=False)
+    monkeypatch.delenv("UAT_SMOKE_USER_ID", raising=False)
+    monkeypatch.delenv("UAT_SMOKE_PASSPHRASE", raising=False)
+
+    client = TestClient(_build_app())
+    response = client.post("/api/app-config/review-mode/session", json={"subject": "reviewer"})
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "App review mode is disabled"
+
+
+def test_review_mode_session_accepts_uat_smoke_overlay(monkeypatch):
+    monkeypatch.setenv("APP_RUNTIME_PROFILE", "uat")
+    monkeypatch.delenv("APP_REVIEW_MODE", raising=False)
+    monkeypatch.setenv("UAT_SMOKE_USER_ID", "user_smoke_123")
+    monkeypatch.setenv("UAT_SMOKE_PASSPHRASE", "secret-passphrase")
+
+    monkeypatch.setattr(health, "ensure_firebase_auth_admin", lambda: (True, "demo-project"))
+    monkeypatch.setattr(health, "get_firebase_auth_app", lambda: object())
+
+    minted: dict[str, object] = {}
+
+    class _FakeFirebaseAuth:
+        @staticmethod
+        def create_custom_token(uid: str, app: object | None = None):
+            minted["uid"] = uid
+            minted["app"] = app
+            return b"custom-token"
+
+    import sys
+    import types
+
+    firebase_admin_module = types.ModuleType("firebase_admin")
+    firebase_admin_module.auth = _FakeFirebaseAuth
+    monkeypatch.setitem(sys.modules, "firebase_admin", firebase_admin_module)
+
+    client = TestClient(_build_app())
+    response = client.post(
+        "/api/app-config/review-mode/session",
+        json={
+            "subject": "reviewer",
+            "smoke_passphrase": "secret-passphrase",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"token": "custom-token"}
+    assert minted["uid"] == "user_smoke_123"

--- a/hushh-webapp/__tests__/components/persona-bootstrap-redirect.test.tsx
+++ b/hushh-webapp/__tests__/components/persona-bootstrap-redirect.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PersonaBootstrapRedirect } from "@/components/iam/persona-bootstrap-redirect";
+
+const replace = vi.fn();
+const switchPersona = vi.fn();
+
+let personaStateValue: Record<string, unknown> = {};
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/kai",
+  useRouter: () => ({
+    replace,
+  }),
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({
+    user: { uid: "user-1" },
+    isAuthenticated: true,
+  }),
+}));
+
+vi.mock("@/lib/vault/vault-context", () => ({
+  useVault: () => ({
+    isVaultUnlocked: true,
+  }),
+}));
+
+vi.mock("@/lib/stores/kai-session-store", () => ({
+  useKaiSession: (selector: (state: { lastKaiPath: string; lastRiaPath: string }) => unknown) =>
+    selector({
+      lastKaiPath: "/kai",
+      lastRiaPath: "/ria",
+    }),
+}));
+
+vi.mock("@/lib/persona/persona-context", () => ({
+  usePersonaState: () => personaStateValue,
+}));
+
+describe("PersonaBootstrapRedirect", () => {
+  beforeEach(() => {
+    replace.mockReset();
+    switchPersona.mockReset();
+    personaStateValue = {
+      personaState: {
+        active_persona: "ria",
+        last_active_persona: "ria",
+        primary_nav_persona: "ria",
+      },
+      activePersona: "ria",
+      loading: false,
+      personaTransitionTarget: null,
+      refreshing: false,
+      riaCapability: "switch",
+      riaEntryRoute: "/ria",
+      switchPersona,
+    };
+  });
+
+  it("shows the mismatch dialog when route and persona are out of sync", () => {
+    render(<PersonaBootstrapRedirect />);
+
+    expect(
+      screen.getByText("Your active role and current route are out of sync")
+    ).toBeTruthy();
+  });
+
+  it("suppresses the mismatch dialog during an intentional persona transition", () => {
+    personaStateValue = {
+      ...personaStateValue,
+      personaTransitionTarget: "ria",
+    };
+
+    render(<PersonaBootstrapRedirect />);
+
+    expect(
+      screen.queryByText("Your active role and current route are out of sync")
+    ).toBeNull();
+  });
+});

--- a/hushh-webapp/components/app-ui/native-test-bootstrap.tsx
+++ b/hushh-webapp/components/app-ui/native-test-bootstrap.tsx
@@ -93,7 +93,9 @@ export function NativeTestBootstrap() {
               localReviewerCredentials.password
             )
           : await (async () => {
-              const { token } = await ApiService.createAppReviewModeSession("reviewer");
+              const { token } = await ApiService.createAppReviewModeSession("reviewer", {
+                smokePassphrase: config.vaultPassphrase,
+              });
               return AuthService.signInWithCustomToken(token);
             })();
         const authenticatedUser = authResult.user;
@@ -134,6 +136,7 @@ export function NativeTestBootstrap() {
     config.autoReviewerLogin,
     config.enabled,
     config.expectedUserId,
+    config.vaultPassphrase,
     setNativeUser,
     user,
   ]);

--- a/hushh-webapp/components/iam/persona-bootstrap-redirect.tsx
+++ b/hushh-webapp/components/iam/persona-bootstrap-redirect.tsx
@@ -40,6 +40,7 @@ export function PersonaBootstrapRedirect() {
     personaState,
     activePersona,
     loading,
+    personaTransitionTarget,
     refreshing,
     riaCapability,
     riaEntryRoute,
@@ -57,6 +58,9 @@ export function PersonaBootstrapRedirect() {
     if (!isAuthenticated || !user || loading || refreshing || !personaState || !isVaultUnlocked) {
       return null;
     }
+    if (personaTransitionTarget) {
+      return null;
+    }
     if (!routePersona || routePersona === activePersona) {
       return null;
     }
@@ -68,7 +72,17 @@ export function PersonaBootstrapRedirect() {
       scopedRouteLabel: routePersona === "ria" ? "RIA workspace" : "Kai workspace",
       activePersonaLabel: activePersona === "ria" ? "RIA workspace" : "Investor workspace",
     };
-  }, [activePersona, isAuthenticated, isVaultUnlocked, loading, personaState, refreshing, routePersona, user]);
+  }, [
+    activePersona,
+    isAuthenticated,
+    isVaultUnlocked,
+    loading,
+    personaState,
+    personaTransitionTarget,
+    refreshing,
+    routePersona,
+    user,
+  ]);
 
   const handleSwitchToActivePersona = useCallback(async () => {
     if (!mismatch) return;

--- a/hushh-webapp/components/onboarding/AuthStep.tsx
+++ b/hushh-webapp/components/onboarding/AuthStep.tsx
@@ -250,7 +250,11 @@ export function AuthStep({
             localReviewerCredentials.password
           )
         : await (async () => {
-            const { token } = await ApiService.createAppReviewModeSession("reviewer");
+            const { token } = await ApiService.createAppReviewModeSession("reviewer", {
+              smokePassphrase: nativeTestConfig.autoReviewerLogin
+                ? nativeTestConfig.vaultPassphrase
+                : null,
+            });
             return AuthService.signInWithCustomToken(token);
           })();
       const authenticatedUser = authResult.user;
@@ -299,6 +303,7 @@ export function AuthStep({
     growthEntrySurface,
     growthJourney,
     nativeTestConfig.autoReviewerLogin,
+    nativeTestConfig.vaultPassphrase,
     resolveAndNavigate,
     reviewModeConfig.enabled,
     setNativeUser,

--- a/hushh-webapp/lib/persona/persona-context.tsx
+++ b/hushh-webapp/lib/persona/persona-context.tsx
@@ -14,6 +14,7 @@ import { usePathname } from "next/navigation";
 
 import { CacheSyncService } from "@/lib/cache/cache-sync-service";
 import { useAuth } from "@/hooks/use-auth";
+import { getRouteScope, routePersonaForScope } from "@/lib/navigation/route-scope";
 import { CacheService, CACHE_KEYS, CACHE_TTL } from "@/lib/services/cache-service";
 import {
   RiaService,
@@ -30,6 +31,7 @@ interface PersonaContextValue {
   riaOnboardingStatus: RiaOnboardingStatus | null;
   loading: boolean;
   refreshing: boolean;
+  personaTransitionTarget: Persona | null;
   activePersona: Persona;
   primaryNavPersona: Persona;
   riaCapability: RiaCapability;
@@ -42,6 +44,7 @@ interface PersonaContextValue {
 }
 
 const PersonaContext = createContext<PersonaContextValue | null>(null);
+const PERSONA_TRANSITION_TIMEOUT_MS = 4_000;
 
 function readCachedPersona(userId: string) {
   const cache = CacheService.getInstance();
@@ -75,6 +78,7 @@ export function PersonaProvider({ children }: { children: ReactNode }) {
   const [riaOnboardingStatus, setRiaOnboardingStatus] = useState<RiaOnboardingStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
+  const [personaTransitionTarget, setPersonaTransitionTarget] = useState<Persona | null>(null);
   const pathnameRef = useRef(pathname);
 
   useEffect(() => {
@@ -89,6 +93,7 @@ export function PersonaProvider({ children }: { children: ReactNode }) {
         setRiaOnboardingStatus(null);
         setLoading(false);
         setRefreshing(false);
+        setPersonaTransitionTarget(null);
         return;
       }
 
@@ -169,14 +174,20 @@ export function PersonaProvider({ children }: { children: ReactNode }) {
   const switchPersona = useCallback(
     async (target: Persona) => {
       if (!user || !isAuthenticated) return null;
-      const idToken = await user.getIdToken();
-      const next = await RiaService.switchPersona(idToken, target);
-      const cache = CacheService.getInstance();
-      CacheSyncService.onPersonaStateChanged(user.uid, { preservePersonaState: true });
-      cache.set(CACHE_KEYS.PERSONA_STATE(user.uid), next, CACHE_TTL.SESSION);
-      setPersonaState(next);
-      void refresh({ force: true });
-      return next;
+      setPersonaTransitionTarget(target);
+      try {
+        const idToken = await user.getIdToken();
+        const next = await RiaService.switchPersona(idToken, target);
+        const cache = CacheService.getInstance();
+        CacheSyncService.onPersonaStateChanged(user.uid, { preservePersonaState: true });
+        cache.set(CACHE_KEYS.PERSONA_STATE(user.uid), next, CACHE_TTL.SESSION);
+        setPersonaState(next);
+        void refresh({ force: true });
+        return next;
+      } catch (error) {
+        setPersonaTransitionTarget(null);
+        throw error;
+      }
     },
     [isAuthenticated, refresh, user]
   );
@@ -192,6 +203,34 @@ export function PersonaProvider({ children }: { children: ReactNode }) {
   const activePersona: Persona = useMemo(() => {
     return personaState?.active_persona || personaState?.last_active_persona || "investor";
   }, [personaState]);
+
+  const routePersona = useMemo(() => {
+    return routePersonaForScope(getRouteScope(pathname));
+  }, [pathname]);
+
+  useEffect(() => {
+    if (!personaTransitionTarget) {
+      return;
+    }
+
+    if (
+      activePersona === personaTransitionTarget &&
+      (!routePersona || routePersona === personaTransitionTarget)
+    ) {
+      setPersonaTransitionTarget(null);
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setPersonaTransitionTarget((current) =>
+        current === personaTransitionTarget ? null : current
+      );
+    }, PERSONA_TRANSITION_TIMEOUT_MS);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [activePersona, personaTransitionTarget, routePersona]);
 
   const primaryNavPersona: Persona = useMemo(() => {
     return personaState?.primary_nav_persona || activePersona;
@@ -226,6 +265,7 @@ export function PersonaProvider({ children }: { children: ReactNode }) {
       riaOnboardingStatus,
       loading,
       refreshing,
+      personaTransitionTarget,
       activePersona,
       primaryNavPersona,
       riaCapability,
@@ -240,6 +280,7 @@ export function PersonaProvider({ children }: { children: ReactNode }) {
       activePersona,
       devRiaBypassAllowed,
       loading,
+      personaTransitionTarget,
       personaState,
       primaryNavPersona,
       refresh,

--- a/hushh-webapp/lib/services/api-service.ts
+++ b/hushh-webapp/lib/services/api-service.ts
@@ -1332,7 +1332,10 @@ export class ApiService {
    * Request a backend-minted Firebase custom token for reviewer login.
    * Only available when app-review mode is enabled server-side.
    */
-  static async createAppReviewModeSession(subject: "reviewer" = "reviewer"): Promise<{ token: string }> {
+  static async createAppReviewModeSession(
+    subject: "reviewer" = "reviewer",
+    options?: { smokePassphrase?: string | null }
+  ): Promise<{ token: string }> {
     if (this.appReviewModeSessionInflight) {
       return this.appReviewModeSessionInflight;
     }
@@ -1344,7 +1347,13 @@ export class ApiService {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ subject }),
+        body: JSON.stringify({
+          subject,
+          smoke_passphrase:
+            typeof options?.smokePassphrase === "string" && options.smokePassphrase.trim().length > 0
+              ? options.smokePassphrase
+              : undefined,
+        }),
       });
 
       const payload = (await response.json().catch(() => ({}))) as Record<


### PR DESCRIPTION
## Summary
- suppress persona route mismatch prompts during intentional role transitions
- let non-production UAT smoke auth mint the smoke session from the explicit smoke overlay instead of requiring APP_REVIEW_MODE
- add focused frontend and backend regression tests for both paths

## Verification
- ./bin/hushh ci
- npm test -- --run __tests__/components/persona-bootstrap-redirect.test.tsx
- python3 -m pytest consent-protocol/tests/test_health_review_mode.py