### PR TITLE
fix: trim overkill postdeploy uat checks

### DIFF
--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -478,14 +478,6 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_ENV"
 
-      - name: Install signed-in route verification dependencies
-        shell: bash
-        run: |
-          set -euo pipefail
-          cd hushh-webapp
-          npm ci
-          npx playwright install chromium
-
       - name: Semantic UAT verification
         id: verify-uat-1
         continue-on-error: true
@@ -597,16 +589,20 @@ jobs:
               backend_failure = True
 
           semantic_failures = set(semantic_report.get("failures") or [])
+          advisory_semantic_failures = sorted(
+              item for item in semantic_failures if item.startswith("signed_in_routes:")
+          )
+          blocking_semantic_failures = {
+              item for item in semantic_failures if not item.startswith("signed_in_routes:")
+          }
           if not semantic_success:
-              append_unique(blocking, ["runtime_behavior_failed"])
-              if "smoke_auth" in semantic_failures:
+              if blocking_semantic_failures:
+                  append_unique(blocking, ["runtime_behavior_failed"])
+              if "smoke_auth" in blocking_semantic_failures:
                   append_unique(blocking, ["smoke_overlay_dependency_leak"])
-              if semantic_failures & {"backend_health", "smoke_auth", "gmail_status", "voice_capability", "voice_realtime_session"}:
+              if blocking_semantic_failures & {"backend_health", "smoke_auth", "gmail_status", "voice_capability", "voice_realtime_session"}:
                   backend_failure = True
-              if "frontend_login" in semantic_failures:
-                  frontend_failure = True
-              if any(item.startswith("signed_in_routes:") for item in semantic_failures):
-                  backend_failure = True
+              if "frontend_login" in blocking_semantic_failures:
                   frontend_failure = True
 
           if db_outcome == "failure":
@@ -632,6 +628,8 @@ jobs:
                   "attempt_2": os.environ.get("SEMANTIC_ATTEMPT_2", ""),
                   "success": semantic_success,
                   "failures": sorted(semantic_failures),
+                  "blocking_failures": sorted(blocking_semantic_failures),
+                  "advisory_failures": advisory_semantic_failures,
               },
               "db_contract": {
                   "outcome": db_outcome,

--- a/scripts/ops/verify_uat_release.py
+++ b/scripts/ops/verify_uat_release.py
@@ -93,6 +93,11 @@ def main() -> int:
     parser.add_argument("--protocol-env", default=DEFAULT_PROTOCOL_ENV)
     parser.add_argument("--web-env", default=DEFAULT_WEBAPP_ENV)
     parser.add_argument("--report-path", required=True)
+    parser.add_argument(
+        "--include-signed-in-routes",
+        action="store_true",
+        help="Run the heavy signed-in route browser sweep and include it in the report.",
+    )
     args = parser.parse_args()
 
     report: dict[str, Any] = {
@@ -197,19 +202,29 @@ def main() -> int:
         except Exception as exc:  # pragma: no cover - exercised in live verification
             _record_exception(report, failures, name="voice_realtime_session", exc=exc)
 
-    route_results = []
-    for route_filter in ("consents", "ria/picks"):
-        route_result = _run_signed_in_routes(args.frontend_url, route_filter)
-        route_results.append({"route_filter": route_filter, **route_result})
-        if not route_result["ok"]:
-            failures.append(f"signed_in_routes:{route_filter}")
-    report["checks"].append(
-        {
-            "name": "signed_in_routes",
-            "ok": all(item["ok"] for item in route_results),
-            "routes": route_results,
-        }
-    )
+    if args.include_signed_in_routes:
+        route_results = []
+        for route_filter in ("consents", "ria/picks"):
+            route_result = _run_signed_in_routes(args.frontend_url, route_filter)
+            route_results.append({"route_filter": route_filter, **route_result})
+            if not route_result["ok"]:
+                failures.append(f"signed_in_routes:{route_filter}")
+        report["checks"].append(
+            {
+                "name": "signed_in_routes",
+                "ok": all(item["ok"] for item in route_results),
+                "routes": route_results,
+            }
+        )
+    else:
+        report["checks"].append(
+            {
+                "name": "signed_in_routes",
+                "ok": True,
+                "skipped": True,
+                "reason": "non_blocking_postdeploy_surface",
+            }
+        )
 
     if failures:
         report["status"] = "blocked"


### PR DESCRIPTION
## Summary
- remove the browser-level signed-in route sweep from the blocking UAT deploy gate
- keep post-deploy parity, db contract, smoke auth, gmail, and voice verification as the release blockers
- keep signed-in route coverage out of the deploy rollback path

## Verification
- python3 -m py_compile scripts/ops/verify_uat_release.py
- YAML parse for .github/workflows/deploy-uat.yml