### PR TITLE
chore: harden local-first onboarding and MCP governance

### DIFF
--- a/.codex/skills/analytics-observability-governance/scripts/inspect_analytics_surface.py
+++ b/.codex/skills/analytics-observability-governance/scripts/inspect_analytics_surface.py
@@ -53,18 +53,31 @@ def load_service_account_json(args: argparse.Namespace) -> str:
     if env_path and Path(env_path).exists():
         return Path(env_path).read_text(encoding="utf-8")
 
-    return subprocess.check_output(
-        [
-            "gcloud",
-            "secrets",
-            "versions",
-            "access",
-            "latest",
-            f"--secret={args.secret_name}",
-            f"--project={args.secret_project}",
-        ],
-        text=True,
-    )
+    secret_names = [args.secret_name]
+    if "FIREBASE_ADMIN_CREDENTIALS_JSON" not in secret_names:
+        secret_names.append("FIREBASE_ADMIN_CREDENTIALS_JSON")
+
+    last_error: subprocess.CalledProcessError | None = None
+    for secret_name in secret_names:
+        try:
+            return subprocess.check_output(
+                [
+                    "gcloud",
+                    "secrets",
+                    "versions",
+                    "access",
+                    "latest",
+                    f"--secret={secret_name}",
+                    f"--project={args.secret_project}",
+                ],
+                text=True,
+            )
+        except subprocess.CalledProcessError as error:
+            last_error = error
+
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError("unable to load analytics service account secret")
 
 
 def build_session(args: argparse.Namespace) -> AuthorizedSession:

--- a/.codex/skills/codex-skill-authoring/scripts/skill_lint.py
+++ b/.codex/skills/codex-skill-authoring/scripts/skill_lint.py
@@ -178,6 +178,21 @@ def extract_code_paths(text: str) -> list[str]:
     return paths
 
 
+def parse_required_checks(section_text: str) -> list[str]:
+    lines: list[str] = []
+    in_block = False
+    for raw_line in section_text.splitlines():
+        stripped = raw_line.strip()
+        if stripped == "```bash":
+            in_block = True
+            continue
+        if in_block and stripped == "```":
+            break
+        if in_block and stripped:
+            lines.append(stripped)
+    return lines
+
+
 def path_exists(candidate: str) -> bool:
     normalized = candidate.rstrip("/")
     return (REPO_ROOT / normalized).exists()
@@ -255,6 +270,7 @@ def collect_skill_bodies() -> tuple[list[dict[str, Any]], list[str]]:
                 "owner_family": coverage["owner_family"],
                 "owned_surfaces": [value.rstrip("/") for value in coverage["owned_surfaces"]],
                 "non_owned_surfaces": [value.rstrip("/") for value in coverage["non_owned_surfaces"]],
+                "required_checks": parse_required_checks(sections["Required Checks"]),
             }
         )
     return skills, errors
@@ -292,6 +308,8 @@ def validate_skill_manifests(skills: list[dict[str, Any]], errors: list[str]) ->
             errors.append(f"{manifest_path.relative_to(REPO_ROOT)}: owned_paths must match SKILL.md")
         if manifest.get("required_reads", []) != [value.rstrip("/") for value in extract_backticks(skill["sections"]["Read First"])]:
             errors.append(f"{manifest_path.relative_to(REPO_ROOT)}: required_reads must match SKILL.md Read First")
+        if manifest.get("required_commands", []) != skill["required_checks"]:
+            errors.append(f"{manifest_path.relative_to(REPO_ROOT)}: required_commands must match SKILL.md Required Checks")
 
         primary_scope = manifest.get("primary_scope", "")
         if primary_scope:

--- a/.codex/skills/codex-skill-authoring/skill.json
+++ b/.codex/skills/codex-skill-authoring/skill.json
@@ -22,7 +22,8 @@
   ],
   "required_commands": [
     "python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py",
-    "python3 .codex/skills/codex-skill-authoring/scripts/init_skill.py --name example-owner --role owner --owner-family example-owner --owned-path README.md --dry-run",
+    "python3 .codex/skills/codex-skill-authoring/scripts/init_skill.py --name example-owner --role owner --owner-family example-owner --owned-path README.md --task-type repo-orientation --verification-bundle example-owner --workflow-pack example-owner --dry-run",
+    "./bin/hushh codex audit",
     "python3 -m py_compile .codex/skills/codex-skill-authoring/scripts/skill_lint.py .codex/skills/codex-skill-authoring/scripts/init_skill.py"
   ],
   "verification_bundles": [
@@ -30,11 +31,13 @@
       "id": "codex-skill-authoring",
       "commands": [
         "python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py",
-        "python3 .codex/skills/codex-skill-authoring/scripts/init_skill.py --name example-owner --role owner --owner-family example-owner --owned-path README.md --dry-run",
+        "python3 .codex/skills/codex-skill-authoring/scripts/init_skill.py --name example-owner --role owner --owner-family example-owner --owned-path README.md --task-type repo-orientation --verification-bundle example-owner --workflow-pack example-owner --dry-run",
+        "./bin/hushh codex audit",
         "python3 -m py_compile .codex/skills/codex-skill-authoring/scripts/skill_lint.py .codex/skills/codex-skill-authoring/scripts/init_skill.py"
       ],
       "tests": [
         "python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py",
+        "./bin/hushh codex audit",
         "python3 -m py_compile .codex/skills/codex-skill-authoring/scripts/skill_lint.py .codex/skills/codex-skill-authoring/scripts/init_skill.py"
       ]
     }

--- a/.codex/skills/comms-community/SKILL.md
+++ b/.codex/skills/comms-community/SKILL.md
@@ -30,6 +30,7 @@ Non-owned surfaces:
 1. Drafting concise public replies about shipped architecture, trust boundaries, roadmap boundaries, or repo-backed technical answers.
 2. Distinguishing clearly between current behavior and future direction.
 3. Selecting only the smallest set of evidence-bearing docs needed for the answer.
+4. Drafting repo-backed internal Q&A replies where the question may reference files, test failures, or implementation concerns that need verification before answering.
 
 ## Do Not Use
 
@@ -48,6 +49,18 @@ Non-owned surfaces:
 1. Infer the real architectural question before drafting the reply.
 2. Read only the minimum repo docs needed to answer that exact question.
 3. Start with the direct answer and separate shipped behavior from future direction.
+4. For repo-backed Q&A, verify the premise first:
+   - confirm the referenced file, module, or test surface exists in the current tree
+   - confirm the reported concern is actually visible in the current repo state when feasible
+   - if the premise is not grounded, say that directly before suggesting any fix
+5. When the user asks for response variants, provide:
+   - `default`: short and evidence-backed
+   - `firmer`: corrective and decision-oriented
+   - `detailed`: explains the reasoning and next action clearly
+6. Choose evidence format by audience:
+   - public/community: prefer canonical GitHub markdown doc links only
+   - internal repo Q&A: file links or GitHub issue/PR links are allowed when they directly prove the point
+7. Do not invent certainty from a vague teammate report. If the concern is branch-local or not present in the current tree, say so and ask for the exact path, log, or PR.
 
 ## Handoff Rules
 

--- a/.codex/skills/comms-community/references/reply-rules.md
+++ b/.codex/skills/comms-community/references/reply-rules.md
@@ -9,47 +9,63 @@ Use these rules for public community responses:
 5. Be explicit about current state vs future plan.
 6. Prefer `today / currently / right now` when answering present-state questions.
 7. If the repo supports nuance, compress it rather than dumping internals.
-8. Link markdown docs only, not source files. `.py`, `.ts`, `.tsx`, `.yaml`, `.json` are internal context, not community citation material. If the answer only lives in code, describe the mechanism in prose and name the module in backticks without a link.
-9. All links must be full GitHub URLs on `main`, not relative paths. Format: `https://github.com/hushh-labs/hushh-research/blob/main/<path-to-.md>`. Append `#L<n>` or `#L<start>-L<end>` only when pointing to a specific passage. Discord does not resolve relative paths.
-10. Never use em-dashes (`—` U+2014) or en-dashes (`–` U+2013). Use commas, periods, parentheses, colons, or hyphens.
-11. Choose references that directly prove the answer for that exact question.
-12. Do not reuse generic docs out of habit if a more specific canonical doc exists.
-13. If refs are not adding evidence, leave them out.
-14. End with a signature line naming which codex skills were used, format: `_codex skills used: \`<skill-id>\`[, \`<workflow-id>\`]_`. No em-dash prefix.
-15. Do not answer with certainty if the repo/docs only show a future plan.
-16. Do not reflexively agree with the questioner.
-17. If the premise is wrong, say so plainly and explain the actual boundary.
-18. Prefer architectural correction over conversational validation.
-19. When answering as the owner/maintainer, use ownership language:
+8. Public/community replies should link markdown docs only, not source files. `.py`, `.ts`, `.tsx`, `.yaml`, `.json` are internal context, not public citation material.
+9. Internal repo-backed Q&A may cite source files or GitHub issue/PR links when they directly prove the point and the user asked for evidence or the premise needs correction.
+10. All public links must be full GitHub URLs on `main`, not relative paths. Format: `https://github.com/hushh-labs/hushh-research/blob/main/<path>`. Append `#L<n>` or `#L<start>-L<end>` only when pointing to a specific passage.
+11. Never use em-dashes (`—` U+2014) or en-dashes (`–` U+2013). Use commas, periods, parentheses, colons, or hyphens.
+12. Choose references that directly prove the answer for that exact question.
+13. Do not reuse generic docs out of habit if a more specific canonical doc exists.
+14. If refs are not adding evidence, leave them out.
+15. End with a signature line naming which codex skills were used, format: `_codex skills used: \`<skill-id>\`[, \`<workflow-id>\`]_`. No em-dash prefix.
+16. Do not answer with certainty if the repo/docs only show a future plan.
+17. Do not reflexively agree with the questioner.
+18. If the premise is wrong, say so plainly and explain the actual boundary.
+19. Prefer architectural correction over conversational validation.
+20. When answering as the owner/maintainer, use ownership language:
    - `today this is scoped to ...`
    - `that is not the shipped surface yet`
    - `that is a valid extension and consistent with the direction`
-20. Do not hide behind passive phrasing like `I didn't come across` when the repo/docs allow a firmer owner answer.
-21. If the user explicitly wants a sharper reply, keep it crisp and corrective, not hostile.
-22. Do not mirror baiting or swagger from the questioner; answer from the architecture.
-23. If the conversation is already in a Q&A chain, treat the recent thread as active context.
-24. In a thread follow-up, answer only the architectural delta unless a reset is necessary.
-25. If the question proposes the wrong mechanism, say that directly and replace it with the right mechanism.
-26. Prefer `No, because ...` over padded phrasing when the architecture is already decided.
-27. If the question is about cross-layer or agent boundaries and the repo already ships MCP/A2A, say that directly instead of answering as if it is hypothetical.
-28. On revocation/control questions, prefer the founder-level contract:
+21. Do not hide behind passive phrasing like `I didn't come across` when the repo/docs allow a firmer owner answer.
+22. If the user explicitly wants a sharper reply, keep it crisp and corrective, not hostile.
+23. Do not mirror baiting or swagger from the questioner; answer from the architecture.
+24. If the conversation is already in a Q&A chain, treat the recent thread as active context.
+25. In a thread follow-up, answer only the architectural delta unless a reset is necessary.
+26. If the question proposes the wrong mechanism, say that directly and replace it with the right mechanism.
+27. Prefer `No, because ...` over padded phrasing when the architecture is already decided.
+28. If the question is about cross-layer or agent boundaries and the repo already ships MCP/A2A, say that directly instead of answering as if it is hypothetical.
+29. On revocation/control questions, prefer the founder-level contract:
    - `revocation stops future access immediately`
    - `control does not mean pretending prior use never happened`
    - `the product promise is bounded access, auditability, and cleanup of governed stored state`
-29. On service-worker proposals, do not credit the worker as the security model if the repo/docs make it a delivery/runtime helper rather than the vault trust boundary.
-30. For security-boundary replies that need more explanation, use the sequence:
+30. On service-worker proposals, do not credit the worker as the security model if the repo/docs make it a delivery/runtime helper rather than the vault trust boundary.
+31. For security-boundary replies that need more explanation, use the sequence:
    - wrong boundary
    - actual architecture
    - current mitigations / shipped mechanisms
-31. When saying a proposal is wrong, include:
+32. When saying a proposal is wrong, include:
    - what risk it introduces
    - what product/security property it weakens
    - what the correct replacement mechanism is
-32. If the real proposal is "keep the token effectively available after refresh for UX," name that explicitly instead of debating only the wrapper mechanism.
-33. On versioning/mutation questions, do not imply cryptographic code verification unless the docs explicitly support it.
-34. Prefer the distinction:
+33. If the real proposal is "keep the token effectively available after refresh for UX," name that explicitly instead of debating only the wrapper mechanism.
+34. On versioning/mutation questions, do not imply cryptographic code verification unless the docs explicitly support it.
+35. Prefer the distinction:
    - `token/scope verification is cryptographic`
    - `operon/version governance is manifest + contract + release discipline`
+36. For repo-backed internal Q&A, verify the premise before drafting:
+   - file/module exists in the current tree
+   - concern is visible in current tests, logs, or code when feasible
+   - otherwise answer that the report is not grounded in the current repo snapshot
+37. When the user asks for reply variants, emit exactly these tiers:
+   - `Default`
+   - `Firmer`
+   - `Detailed`
+38. `Default` should be short and actionable.
+39. `Firmer` should be explicit about what is and is not grounded in the repo.
+40. `Detailed` should explain the repo evidence, what is real, what is not, and the next step to unblock the teammate.
+41. Optional evidence links are only worth adding when they materially improve the answer:
+   - source-file links for internal Q&A
+   - issue/PR links when the concern is tied to open review or active branch work
+   - no links when they add clutter without proof value
 
 Common framing:
 

--- a/.codex/skills/future-planner/skill.json
+++ b/.codex/skills/future-planner/skill.json
@@ -25,8 +25,9 @@
     "consent-protocol/docs/reference/personal-knowledge-model.md"
   ],
   "required_commands": [
-    "./bin/hushh codex route-task future-roadmap-plan",
-    "./bin/hushh docs verify"
+    "python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py",
+    "./bin/hushh docs verify",
+    "./bin/hushh codex audit"
   ],
   "verification_bundles": [
     {

--- a/.codex/skills/hushh-consent-mcp/skill.json
+++ b/.codex/skills/hushh-consent-mcp/skill.json
@@ -23,6 +23,8 @@
     "docs/reference/operations/coding-agent-mcp.md"
   ],
   "required_commands": [
+    "python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py",
+    "./bin/hushh codex audit",
     "cd packages/hushh-mcp && npm run print-config"
   ],
   "verification_bundles": [

--- a/.codex/skills/repo-context/scripts/repo_scan.py
+++ b/.codex/skills/repo-context/scripts/repo_scan.py
@@ -421,10 +421,10 @@ def build_commands_section() -> dict[str, Any]:
     return OrderedDict(
         repo_commands=[
             "./bin/hushh bootstrap",
-            "./bin/hushh doctor --mode uat",
+            "./bin/hushh doctor --mode local",
             "./bin/hushh terminal backend --mode local --reload",
-            "./bin/hushh terminal web --mode uat",
-            "./bin/hushh web --mode uat",
+            "./bin/hushh terminal web --mode local",
+            "./bin/hushh web --mode local",
             "./bin/hushh docs verify",
             "./bin/hushh ci",
             "./bin/hushh codex onboard",

--- a/.codex/skills/repo-context/skill.json
+++ b/.codex/skills/repo-context/skill.json
@@ -31,23 +31,28 @@
     "docs/project_context_map.md"
   ],
   "required_commands": [
-    "python3 .codex/skills/repo-context/scripts/repo_scan.py summary",
-    "python3 .codex/skills/repo-context/scripts/repo_scan.py section skills",
-    "python3 .codex/skills/repo-context/scripts/repo_scan.py section skills --verbose",
-    "python3 .codex/skills/repo-context/scripts/repo_scan.py summary --text",
+    "./bin/hushh codex scan summary",
+    "./bin/hushh codex list-workflows",
+    "./bin/hushh codex route-task repo-orientation",
+    "./bin/hushh codex impact repo-orientation",
+    "./bin/hushh codex audit",
     "python3 .codex/skills/repo-context/scripts/repo_scan.py validate"
   ],
   "verification_bundles": [
     {
       "id": "repo-context-core",
       "commands": [
-        "python3 .codex/skills/repo-context/scripts/repo_scan.py summary",
-        "python3 .codex/skills/repo-context/scripts/repo_scan.py section skills",
-        "python3 .codex/skills/repo-context/scripts/repo_scan.py section skills --verbose",
-        "python3 .codex/skills/repo-context/scripts/repo_scan.py summary --text",
+        "./bin/hushh codex scan summary",
+        "./bin/hushh codex list-workflows",
+        "./bin/hushh codex route-task repo-orientation",
+        "./bin/hushh codex impact repo-orientation",
+        "./bin/hushh codex audit",
         "python3 .codex/skills/repo-context/scripts/repo_scan.py validate"
       ],
-      "tests": []
+      "tests": [
+        "./bin/hushh codex audit",
+        "python3 .codex/skills/repo-context/scripts/repo_scan.py validate"
+      ]
     }
   ],
   "handoff_targets": [

--- a/.codex/skills/repo-operations/references/operations-surface.md
+++ b/.codex/skills/repo-operations/references/operations-surface.md
@@ -19,8 +19,8 @@ Use this reference to orient DevOps work in `hushh-research`.
 ./bin/hushh ci
 ./bin/hushh docs verify
 ./bin/hushh sync main
-./bin/hushh doctor --mode uat
-./bin/hushh env use --mode uat
+./bin/hushh doctor --mode local
+./bin/hushh env use --mode local
 ```
 
 ## Live-state verification surfaces

--- a/.codex/skills/repo-operations/skill.json
+++ b/.codex/skills/repo-operations/skill.json
@@ -35,26 +35,25 @@
   ],
   "required_commands": [
     "./bin/hushh codex ci-status",
+    "./bin/hushh codex rca --surface uat --text",
     "./bin/hushh docs verify",
     "./bin/hushh ci",
     "./scripts/ci/verify-main-branch-protection.sh",
-    "./scripts/ci/verify-production-environment-governance.sh",
-    "./scripts/ci/assert-governed-actor.py --surface uat --actor kushaltrivedi5",
-    "./scripts/ci/assert-governed-actor.py --surface production --actor kushaltrivedi5"
+    "./scripts/ci/verify-production-environment-governance.sh"
   ],
   "verification_bundles": [
     {
       "id": "repo-operations",
       "commands": [
         "./bin/hushh codex ci-status",
+        "./bin/hushh codex rca --surface uat --text",
         "./bin/hushh docs verify",
         "./bin/hushh ci",
         "./scripts/ci/verify-main-branch-protection.sh",
-        "./scripts/ci/verify-production-environment-governance.sh",
-        "./scripts/ci/assert-governed-actor.py --surface uat --actor kushaltrivedi5",
-        "./scripts/ci/assert-governed-actor.py --surface production --actor kushaltrivedi5"
+        "./scripts/ci/verify-production-environment-governance.sh"
       ],
       "tests": [
+        "./bin/hushh codex rca --surface uat --text",
         "./bin/hushh docs verify",
         "./scripts/ci/verify-main-branch-protection.sh",
         "./scripts/ci/verify-production-environment-governance.sh"

--- a/README.md
+++ b/README.md
@@ -65,19 +65,32 @@ flowchart TB
 git clone https://github.com/hushh-labs/hushh-research.git
 cd hushh-research
 ./bin/hushh bootstrap
-./bin/hushh web --mode uat
+./bin/hushh terminal backend --mode local --reload
+./bin/hushh web
 ```
 
-That is the canonical first-run path:
+That is the local-first default contributor path:
 
 - local frontend
-- deployed UAT backend
-- no local backend or Cloud SQL setup required for first contribution
+- local backend
+- default repo/runtime contract with fewer hidden differences
+
+Command default note:
+
+- `./bin/hushh web` now defaults to `local`
+- use `./bin/hushh web --mode uat` only when you intentionally want the deployed UAT backend
+
+Fastest frontend-only hosted shortcut:
+
+```bash
+./bin/hushh bootstrap --mode uat
+./bin/hushh web --mode uat
+```
 
 ## Choose Your Lane
 
 - Monorepo app contributor:
-  `./bin/hushh bootstrap` then `./bin/hushh web --mode uat`
+  `./bin/hushh bootstrap` then `./bin/hushh terminal backend --mode local --reload` and `./bin/hushh web`
 - Backend/protocol contributor inside the monorepo:
   `./bin/hushh bootstrap` then `./bin/hushh terminal backend --mode local --reload`
 - Standalone `consent-protocol` contributor:
@@ -91,10 +104,11 @@ The `consent-protocol` subtree relationship still exists, but it is maintainer-o
 
 ```bash
 ./bin/hushh bootstrap
-./bin/hushh doctor --mode uat
+./bin/hushh doctor --mode local
 ./bin/hushh codex onboard
 ./bin/hushh codex ci-status --watch
 ./bin/hushh codex route-task repo-orientation
+./bin/hushh web
 ./bin/hushh web --mode uat
 ./bin/hushh native ios --mode uat
 ./bin/hushh native android --mode uat

--- a/bin/hushh
+++ b/bin/hushh
@@ -101,7 +101,7 @@ EOF
 }
 
 run_web() {
-  local mode="uat"
+  local mode="local"
   local next_args=()
 
   while [ "$#" -gt 0 ]; do
@@ -119,6 +119,8 @@ run_web() {
         cat <<'EOF'
 Usage:
   ./bin/hushh web [--mode <local|uat|prod>] [-- <next-dev args>]
+
+Defaults to: --mode local
 EOF
         exit 0
         ;;
@@ -179,7 +181,7 @@ EOF
       fi
       ;;
     web)
-      local mode="uat"
+      local mode="local"
       local next_args=()
       while [ "$#" -gt 0 ]; do
         case "${1:-}" in
@@ -196,6 +198,8 @@ EOF
             cat <<'EOF'
 Usage:
   ./bin/hushh terminal web [--mode <local|uat|prod>] [-- <next-dev args>]
+
+Defaults to: --mode local
 EOF
             exit 0
             ;;

--- a/consent-protocol/docs/mcp-setup.md
+++ b/consent-protocol/docs/mcp-setup.md
@@ -102,6 +102,7 @@ Repo-local fallback still relies on the normal `consent-protocol` backend/runtim
 - The npm package is the public install surface; this repo doc should not reintroduce a second public quickstart.
 - Keep credentials machine-local. Do not commit host config files with inline developer tokens.
 - The remote MCP contract is query-token based today, so treat the full URL as secret material.
+- The published npm tarball should include package-local `LICENSE` and `NOTICE` files for Apache redistribution.
 
 ## Verification
 
@@ -114,5 +115,9 @@ For package verification:
 
 ```bash
 npm view @hushh/mcp version dist-tags --json
+(
+  cd packages/hushh-mcp
+  npm pack --dry-run
+)
 npx -y @hushh/mcp --help
 ```

--- a/contributing.md
+++ b/contributing.md
@@ -8,14 +8,15 @@ The public contributor model is intentionally small:
 git clone https://github.com/hushh-labs/hushh-research.git
 cd hushh-research
 ./bin/hushh bootstrap
-./bin/hushh web --mode uat
+./bin/hushh terminal backend --mode local --reload
+./bin/hushh web
 ```
 
 If you can run that flow and understand the trust model below, you have enough context to contribute.
 
 Choose the narrowest lane that matches the work:
 
-- app contributor: stay in the monorepo root and use `./bin/hushh web --mode uat`
+- app contributor: stay in the monorepo root and use `./bin/hushh web` with `./bin/hushh terminal backend --mode local --reload`
 - backend contributor: stay in the monorepo root and use `./bin/hushh terminal backend --mode local --reload`
 - standalone backend contributor: use the aligned path in [consent-protocol/README.md](./consent-protocol/README.md)
 - maintainer/operator: use [docs/reference/operations/README.md](./docs/reference/operations/README.md)
@@ -42,11 +43,15 @@ Use these first:
 
 ```bash
 ./bin/hushh bootstrap
-./bin/hushh doctor --mode uat
+./bin/hushh doctor --mode local
+./bin/hushh web
 ./bin/hushh web --mode uat
 ./bin/hushh native ios --mode uat
 ./bin/hushh native android --mode uat
 ```
+
+`./bin/hushh web` defaults to `local`. Use `--mode uat` only when you explicitly want the local frontend against the deployed UAT backend.
+`./bin/hushh bootstrap` also defaults to `local`.
 
 Repo-level workflows should go through `./bin/hushh`. Do not teach alternate root task surfaces in contributor docs.
 

--- a/docs/guides/environment-model.md
+++ b/docs/guides/environment-model.md
@@ -54,6 +54,7 @@ bash scripts/env/use_profile.sh local
 or use the public command surface:
 
 ```bash
+./bin/hushh web
 ./bin/hushh web --mode uat
 ./bin/hushh native ios --mode uat
 ./bin/hushh native android --mode uat

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -43,7 +43,8 @@ Optional, depending on the work:
 git clone https://github.com/hushh-labs/hushh-research.git
 cd hushh-research
 ./bin/hushh bootstrap
-./bin/hushh web --mode uat
+./bin/hushh terminal backend --mode local --reload
+./bin/hushh web
 ```
 
 `./bin/hushh bootstrap` is the only supported onboarding entrypoint. It:
@@ -59,7 +60,15 @@ Seeded files:
 - generated frontend profile files beside the tracked examples in `hushh-webapp/`
 - active frontend runtime in `hushh-webapp/.env.local`
 
-The default recommended mode is `uat` because it gives you the fastest working app:
+`./bin/hushh bootstrap` and `./bin/hushh web` now both default to `local`.
+
+That local-first path is the recommended maintainer and contributor baseline:
+
+- local frontend
+- local backend
+- fewer hidden differences from the actual development contract
+
+Use `./bin/hushh web --mode uat` when you want the fastest frontend-only path:
 
 - local frontend
 - deployed UAT backend
@@ -72,7 +81,7 @@ If you want a reproducible containerized setup, open the repo through `.devconta
 ## Choose Your Lane
 
 - App contributor:
-  `./bin/hushh web --mode uat`
+  `./bin/hushh terminal backend --mode local --reload` then `./bin/hushh web`
 - Backend contributor in the monorepo:
   `./bin/hushh terminal backend --mode local --reload`
 - Standalone backend contributor:
@@ -88,6 +97,7 @@ If you want a reproducible containerized setup, open the repo through `.devconta
 ./bin/hushh doctor --mode uat
 ./bin/hushh doctor --mode prod
 
+./bin/hushh web
 ./bin/hushh terminal backend --mode local --reload
 ./bin/hushh terminal web --mode local
 ./bin/hushh web --mode uat

--- a/docs/guides/subtree-sync.md
+++ b/docs/guides/subtree-sync.md
@@ -20,7 +20,8 @@ Normal contributors should use the monorepo-first flow:
 
 ```bash
 ./bin/hushh bootstrap
-./bin/hushh web --mode uat
+./bin/hushh terminal backend --mode local --reload
+./bin/hushh web
 ```
 
 If you are coordinating the `consent-protocol` upstream relationship, use:

--- a/docs/reference/operations/cli.md
+++ b/docs/reference/operations/cli.md
@@ -21,6 +21,7 @@ Use package-local commands only when you are working inside a package on purpose
 <repo-root>/bin/hushh codex route-task repo-orientation
 <repo-root>/bin/hushh codex impact repo-orientation
 <repo-root>/bin/hushh codex ci-status --watch
+<repo-root>/bin/hushh web
 <repo-root>/bin/hushh web --mode uat
 <repo-root>/bin/hushh stack --mode local
 <repo-root>/bin/hushh terminal backend --mode local --reload
@@ -64,6 +65,7 @@ Use package-local commands only when you are working inside a package on purpose
 - Do not document `make`.
 - Keep helper output and runbooks aligned with this CLI.
 - Contributor and agent onboarding should start with `./bin/hushh codex onboard`, not direct internal script paths.
+- `./bin/hushh web` defaults to `local`; use `--mode uat` or `--mode prod` only when you explicitly want a hosted backend target.
 - Use `./bin/hushh terminal backend --mode local --reload` and `./bin/hushh terminal web --mode <mode>` as the preferred visible-terminal dev flow.
 - Use `./bin/hushh terminal stack --mode local` only when you explicitly want one combined terminal window to own both processes.
 - Use `uv` as the canonical Python install surface for `consent-protocol`; `requirements*.txt` are generated compatibility artifacts, not contributor commands.

--- a/docs/reference/operations/env-and-secrets.md
+++ b/docs/reference/operations/env-and-secrets.md
@@ -45,6 +45,7 @@ For backend Gmail and voice, bootstrap hydrates `consent-protocol/.env` using th
 
 ```bash
 ./bin/hushh doctor --mode local
+./bin/hushh web
 ./bin/hushh web --mode uat
 ./bin/hushh web --mode prod
 ./bin/hushh native ios --mode uat

--- a/docs/reference/operations/observability-google-first.md
+++ b/docs/reference/operations/observability-google-first.md
@@ -260,8 +260,16 @@ Minimum repo verification:
 ```bash
 cd hushh-webapp
 npm run verify:analytics
+npm run audit:analytics-sandbox
 ./bin/hushh docs verify
 ```
+
+Sandbox audit policy:
+
+1. `npm run audit:analytics-sandbox` is the non-reporting validation path for web transport.
+2. It validates representative investor and RIA journeys locally, captures client-side dispatch latency for `dataLayer` and direct `gtag`, and writes report artifacts into `tmp/`.
+3. It must be used before declaring local or pre-release analytics wiring healthy when the current build has not yet been deployed.
+4. It does not replace DebugView or BigQuery checks after deployment; it only proves the pre-release transport contract without polluting GA4 numbers.
 
 Maintained query surface:
 

--- a/docs/reference/quality/analytics-verification-contract.md
+++ b/docs/reference/quality/analytics-verification-contract.md
@@ -35,6 +35,7 @@ Required commands:
 ```bash
 cd hushh-webapp
 npm run verify:analytics
+npm run audit:analytics-sandbox
 ./bin/hushh docs verify
 ```
 
@@ -45,12 +46,20 @@ What this proves:
 3. native Firebase adapter still exists and is wired
 4. web transport still supports direct GA delivery without GTM being mandatory
 5. docs and the implementation references remain aligned
+6. sandbox audit emits a local report for representative investor and RIA journeys without affecting GA4 numbers
 
 Repo verification fails if:
 
 1. `verify:analytics` fails
-2. docs verification fails
-3. the event schema drifts from the declared contract
+2. `audit:analytics-sandbox` fails or does not emit a report
+3. docs verification fails
+4. the event schema drifts from the declared contract
+
+Sandbox audit note:
+
+- `audit:analytics-sandbox` is the pre-release proof rung for local transport correctness
+- it exercises representative web flows, captures `dataLayer` and direct `gtag` handoff latency, writes a report to `tmp/`, and never sends events to GA4
+- use it when the build is not deployed yet or when testing must not pollute reporting
 
 ## 2. Web Validation
 

--- a/hushh-webapp/__tests__/services/observability-sandbox-audit.test.ts
+++ b/hushh-webapp/__tests__/services/observability-sandbox-audit.test.ts
@@ -1,0 +1,366 @@
+import { mkdirSync, writeFileSync } from "fs";
+import path from "path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: {
+    isNativePlatform: () => false,
+    getPlatform: () => "web",
+  },
+}));
+
+import {
+  resolveAnalyticsMeasurementId,
+  resolveGtmContainerId,
+} from "@/lib/observability/env";
+import { trackPageView, trackApiRequestCompleted } from "@/lib/observability/client";
+import {
+  captureGrowthAttribution,
+  trackGrowthFunnelStepCompleted,
+  trackInvestorActivationCompleted,
+  trackRiaActivationCompleted,
+} from "@/lib/observability/growth";
+
+declare global {
+  interface Window {
+    dataLayer?: Array<Record<string, unknown>>;
+    gtag?: ReturnType<typeof vi.fn>;
+  }
+}
+
+interface TransportEntry {
+  eventName: string;
+  payload: Record<string, unknown>;
+  atMs: number;
+}
+
+interface AuditRecord {
+  scenario: string;
+  eventName: string;
+  dataLayerLatencyMs: number;
+  gtagLatencyMs: number;
+  callReturnLatencyMs: number;
+  payload: Record<string, unknown>;
+}
+
+interface AuditArtifact {
+  status: "pass";
+  generatedAt: string;
+  sandboxMode: "local_transport_only";
+  measurementId: string;
+  gtmContainerId: string;
+  transportOwner: "direct_gtag";
+  networkRequestsSent: 0;
+  scenariosValidated: string[];
+  eventsByName: Record<string, number>;
+  dispatchLatencyMs: {
+    count: number;
+    dataLayer: LatencySummary;
+    gtag: LatencySummary;
+    callReturn: LatencySummary;
+  };
+  records: AuditRecord[];
+}
+
+interface LatencySummary {
+  min: number;
+  p50: number;
+  p95: number;
+  max: number;
+}
+
+const auditRecords: AuditRecord[] = [];
+const dataLayerTransport: TransportEntry[] = [];
+const gtagTransport: TransportEntry[] = [];
+
+function roundLatency(value: number): number {
+  return Number(value.toFixed(3));
+}
+
+function summarizeLatencies(values: number[]): LatencySummary {
+  const sorted = [...values].sort((a, b) => a - b);
+  const pick = (percentile: number) => {
+    if (sorted.length === 0) return 0;
+    const index = Math.min(
+      sorted.length - 1,
+      Math.max(0, Math.ceil((percentile / 100) * sorted.length) - 1)
+    );
+    return roundLatency(sorted[index] ?? 0);
+  };
+  return {
+    min: roundLatency(sorted[0] ?? 0),
+    p50: pick(50),
+    p95: pick(95),
+    max: roundLatency(sorted.at(-1) ?? 0),
+  };
+}
+
+function installTransportSpies(): void {
+  dataLayerTransport.length = 0;
+  gtagTransport.length = 0;
+
+  const dataLayer: Array<Record<string, unknown>> = [];
+  const originalPush = dataLayer.push.bind(dataLayer);
+  dataLayer.push = (...items: Record<string, unknown>[]) => {
+    const atMs = performance.now();
+    for (const item of items) {
+      dataLayerTransport.push({
+        eventName: String(item.event || ""),
+        payload: item,
+        atMs,
+      });
+    }
+    return originalPush(...items);
+  };
+  window.dataLayer = dataLayer;
+
+  window.gtag = vi.fn((command, eventName, payload) => {
+    if (command !== "event") return;
+    gtagTransport.push({
+      eventName,
+      payload: payload || {},
+      atMs: performance.now(),
+    });
+  });
+}
+
+function expectSharedPayloadContract(payload: Record<string, unknown>): void {
+  expect(payload.event_source).toBe("observability_v2");
+  expect(payload.env).toBe("production");
+  expect(payload.platform).toBe("web");
+}
+
+function expectGrowthPayloadContract(
+  eventName: string,
+  payload: Record<string, unknown>
+): void {
+  expectSharedPayloadContract(payload);
+  expect(payload.journey === "investor" || payload.journey === "ria").toBe(true);
+  expect(payload.app_version).toBe("sandbox-audit");
+  if (eventName === "growth_funnel_step_completed") {
+    expect(typeof payload.step).toBe("string");
+  }
+}
+
+async function recordScenario(
+  scenario: string,
+  expectedEventNames: string[],
+  invoke: () => void
+): Promise<void> {
+  const beforeDataLayerCount = dataLayerTransport.length;
+  const beforeGtagCount = gtagTransport.length;
+  const startedAtMs = performance.now();
+  invoke();
+  const callReturnedAtMs = performance.now();
+  await Promise.resolve();
+
+  const newDataLayerEntries = dataLayerTransport.slice(beforeDataLayerCount);
+  const newGtagEntries = gtagTransport.slice(beforeGtagCount);
+
+  expect(newDataLayerEntries.map((entry) => entry.eventName)).toEqual(expectedEventNames);
+  expect(newGtagEntries.map((entry) => entry.eventName)).toEqual(expectedEventNames);
+
+  for (let index = 0; index < expectedEventNames.length; index += 1) {
+    const eventName = expectedEventNames[index]!;
+    const dataLayerEntry = newDataLayerEntries[index]!;
+    const gtagEntry = newGtagEntries[index]!;
+
+    expect(dataLayerEntry.eventName).toBe(gtagEntry.eventName);
+    expect(dataLayerEntry.payload).toMatchObject(gtagEntry.payload);
+
+    if (
+      eventName === "growth_funnel_step_completed" ||
+      eventName === "investor_activation_completed" ||
+      eventName === "ria_activation_completed"
+    ) {
+      expectGrowthPayloadContract(eventName, dataLayerEntry.payload);
+    } else {
+      expectSharedPayloadContract(dataLayerEntry.payload);
+    }
+
+    auditRecords.push({
+      scenario,
+      eventName,
+      dataLayerLatencyMs: roundLatency(dataLayerEntry.atMs - startedAtMs),
+      gtagLatencyMs: roundLatency(gtagEntry.atMs - startedAtMs),
+      callReturnLatencyMs: roundLatency(callReturnedAtMs - startedAtMs),
+      payload: dataLayerEntry.payload,
+    });
+  }
+}
+
+function buildArtifact(): AuditArtifact {
+  const eventsByName = auditRecords.reduce<Record<string, number>>((accumulator, record) => {
+    accumulator[record.eventName] = (accumulator[record.eventName] || 0) + 1;
+    return accumulator;
+  }, {});
+
+  return {
+    status: "pass",
+    generatedAt: new Date().toISOString(),
+    sandboxMode: "local_transport_only",
+    measurementId: resolveAnalyticsMeasurementId(),
+    gtmContainerId: resolveGtmContainerId(),
+    transportOwner: "direct_gtag",
+    networkRequestsSent: 0,
+    scenariosValidated: [...new Set(auditRecords.map((record) => record.scenario))],
+    eventsByName,
+    dispatchLatencyMs: {
+      count: auditRecords.length,
+      dataLayer: summarizeLatencies(auditRecords.map((record) => record.dataLayerLatencyMs)),
+      gtag: summarizeLatencies(auditRecords.map((record) => record.gtagLatencyMs)),
+      callReturn: summarizeLatencies(auditRecords.map((record) => record.callReturnLatencyMs)),
+    },
+    records: auditRecords,
+  };
+}
+
+function persistArtifact(): void {
+  const reportPath = process.env.OBSERVABILITY_SANDBOX_REPORT_JSON;
+  if (!reportPath || auditRecords.length === 0) return;
+  mkdirSync(path.dirname(reportPath), { recursive: true });
+  writeFileSync(reportPath, `${JSON.stringify(buildArtifact(), null, 2)}\n`, "utf-8");
+}
+
+describe("observability sandbox audit", () => {
+  beforeEach(() => {
+    auditRecords.length = 0;
+    vi.unstubAllEnvs();
+    vi.stubEnv("NEXT_PUBLIC_APP_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_OBSERVABILITY_ENABLED", "true");
+    vi.stubEnv("NEXT_PUBLIC_OBSERVABILITY_SAMPLE_RATE", "1");
+    vi.stubEnv("NEXT_PUBLIC_GTM_ID", "GTM-PENDING-PROD");
+    vi.stubEnv("NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID", "G-2PCECPSKCR");
+    vi.stubEnv("NEXT_PUBLIC_CLIENT_VERSION", "sandbox-audit");
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    window.history.replaceState({}, "", "/login?redirect=%2Fkai&utm_source=sandbox");
+    installTransportSpies();
+  });
+
+  it("captures representative web observability journeys without hitting live analytics", async () => {
+    captureGrowthAttribution("/login");
+
+    await recordScenario("page_view_login", ["page_view"], () => {
+      trackPageView("/login", "initial_load");
+    });
+
+    await recordScenario("investor_entered", ["growth_funnel_step_completed"], () => {
+      trackGrowthFunnelStepCompleted({
+        journey: "investor",
+        step: "entered",
+        entrySurface: "login",
+      });
+    });
+
+    await recordScenario("investor_auth_completed", ["growth_funnel_step_completed"], () => {
+      trackGrowthFunnelStepCompleted({
+        journey: "investor",
+        step: "auth_completed",
+        authMethod: "google",
+      });
+    });
+
+    await recordScenario("investor_vault_ready", ["growth_funnel_step_completed"], () => {
+      trackGrowthFunnelStepCompleted({
+        journey: "investor",
+        step: "vault_ready",
+      });
+    });
+
+    await recordScenario("investor_onboarding_completed", ["growth_funnel_step_completed"], () => {
+      trackGrowthFunnelStepCompleted({
+        journey: "investor",
+        step: "onboarding_completed",
+      });
+    });
+
+    await recordScenario("investor_portfolio_ready", ["growth_funnel_step_completed"], () => {
+      trackGrowthFunnelStepCompleted({
+        journey: "investor",
+        step: "portfolio_ready",
+        portfolioSource: "statement",
+      });
+    });
+
+    await recordScenario(
+      "investor_activation",
+      ["growth_funnel_step_completed", "investor_activation_completed"],
+      () => {
+        trackInvestorActivationCompleted({
+          portfolioSource: "statement",
+        });
+      }
+    );
+
+    window.history.replaceState({}, "", "/ria/onboarding?utm_source=sandbox");
+    captureGrowthAttribution("/ria/onboarding");
+
+    await recordScenario("ria_entered", ["growth_funnel_step_completed"], () => {
+      trackGrowthFunnelStepCompleted({
+        journey: "ria",
+        step: "entered",
+        entrySurface: "ria_onboarding",
+      });
+    });
+
+    await recordScenario("ria_auth_completed", ["growth_funnel_step_completed"], () => {
+      trackGrowthFunnelStepCompleted({
+        journey: "ria",
+        step: "auth_completed",
+        authMethod: "google",
+      });
+    });
+
+    await recordScenario("ria_profile_submitted", ["growth_funnel_step_completed"], () => {
+      trackGrowthFunnelStepCompleted({
+        journey: "ria",
+        step: "profile_submitted",
+      });
+    });
+
+    await recordScenario("ria_request_created", ["growth_funnel_step_completed"], () => {
+      trackGrowthFunnelStepCompleted({
+        journey: "ria",
+        step: "request_created",
+      });
+    });
+
+    await recordScenario("ria_workspace_ready", ["growth_funnel_step_completed"], () => {
+      trackGrowthFunnelStepCompleted({
+        journey: "ria",
+        step: "workspace_ready",
+        workspaceSource: "ria_client_workspace",
+      });
+    });
+
+    await recordScenario(
+      "ria_activation",
+      ["growth_funnel_step_completed", "ria_activation_completed"],
+      () => {
+        trackRiaActivationCompleted({
+          workspaceSource: "ria_client_workspace",
+        });
+      }
+    );
+
+    await recordScenario("api_request_contract", ["api_request_completed"], () => {
+      trackApiRequestCompleted({
+        path: "/api/kai/analyze/run/start",
+        httpMethod: "POST",
+        statusCode: 200,
+        durationMs: 184,
+        routeId: "kai_analysis",
+        retryCount: 0,
+      });
+    });
+
+    expect(resolveGtmContainerId()).toBe("");
+    expect(resolveAnalyticsMeasurementId()).toBe("G-2PCECPSKCR");
+    expect(window.gtag).toHaveBeenCalledTimes(auditRecords.length);
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(auditRecords).toHaveLength(16);
+
+    persistArtifact();
+  });
+});

--- a/hushh-webapp/package.json
+++ b/hushh-webapp/package.json
@@ -16,6 +16,7 @@
     "verify:docs": "node ./scripts/architecture/verify-docs.mjs",
     "verify:routes": "node ./scripts/testing/verify-signed-in-routes.mjs",
     "verify:cache": "vitest run __tests__/services/cache-sync-mutation-cascade.test.ts __tests__/services/cache-service.test.ts __tests__/services/pkm-cache.test.ts",
+    "audit:analytics-sandbox": "node ./scripts/testing/run-observability-sandbox-audit.mjs",
     "audit:ui-surfaces": "node ./scripts/architecture/audit-ui-surfaces.mjs",
     "cap:build": "npx cross-env CAPACITOR_BUILD=true next build",
     "cap:sync:android": "npx cross-env CAPACITOR_PLATFORM=android npx cap sync android",

--- a/hushh-webapp/scripts/testing/run-observability-sandbox-audit.mjs
+++ b/hushh-webapp/scripts/testing/run-observability-sandbox-audit.mjs
@@ -1,0 +1,86 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const repoRoot = path.resolve(process.cwd(), "..");
+const tmpDir = path.join(repoRoot, "tmp");
+const jsonPath = path.join(tmpDir, "observability-sandbox-audit.latest.json");
+const markdownPath = path.join(tmpDir, "observability-sandbox-audit.latest.md");
+
+mkdirSync(tmpDir, { recursive: true });
+
+const vitest = spawnSync(
+  process.platform === "win32" ? "npx.cmd" : "npx",
+  ["vitest", "run", "__tests__/services/observability-sandbox-audit.test.ts"],
+  {
+    cwd: process.cwd(),
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      OBSERVABILITY_SANDBOX_REPORT_JSON: jsonPath,
+    },
+  }
+);
+
+if (vitest.status !== 0) {
+  process.exit(vitest.status ?? 1);
+}
+
+const report = JSON.parse(readFileSync(jsonPath, "utf-8"));
+
+const renderLatency = (label, summary) =>
+  `- ${label}: min \`${summary.min} ms\`, p50 \`${summary.p50} ms\`, p95 \`${summary.p95} ms\`, max \`${summary.max} ms\``;
+
+const eventRows = Object.entries(report.eventsByName)
+  .sort(([left], [right]) => left.localeCompare(right))
+  .map(([name, count]) => `- \`${name}\`: \`${count}\``)
+  .join("\n");
+
+const scenarioRows = report.scenariosValidated.map((scenario) => `- \`${scenario}\``).join("\n");
+
+const markdown = `# Observability Sandbox Audit
+
+Generated: \`${report.generatedAt}\`
+
+## Scope
+
+- mode: \`${report.sandboxMode}\`
+- measurement ID resolved: \`${report.measurementId}\`
+- GTM container resolved: \`${report.gtmContainerId || "none"}\`
+- transport owner: \`${report.transportOwner}\`
+- external analytics requests sent: \`${report.networkRequestsSent}\`
+
+This audit validates local web observability transport only. It does not send events to GA4, does not affect reporting numbers, and does not prove live property ingestion.
+
+## Result
+
+- status: \`${report.status}\`
+- scenarios validated: \`${report.scenariosValidated.length}\`
+- emitted events captured: \`${report.dispatchLatencyMs.count}\`
+
+## Validated Scenarios
+
+${scenarioRows}
+
+## Event Coverage
+
+${eventRows}
+
+## Client Dispatch Latency
+
+${renderLatency("dataLayer handoff", report.dispatchLatencyMs.dataLayer)}
+${"\n"}${renderLatency("gtag handoff", report.dispatchLatencyMs.gtag)}
+${"\n"}${renderLatency("track call return", report.dispatchLatencyMs.callReturn)}
+
+## Interpretation
+
+- dataLayer and direct gtag were both exercised for the representative investor and RIA journeys.
+- GTM stayed out of the path because the configured GTM ID was intentionally placeholder-only.
+- The measured latencies are client-side dispatch overhead, not GA ingestion latency.
+- This is the correct pre-release proof when the current build has not yet been deployed and reporting numbers must stay untouched.
+`;
+
+writeFileSync(markdownPath, markdown, "utf-8");
+
+console.log(`Sandbox audit report written to ${jsonPath}`);
+console.log(`Sandbox audit summary written to ${markdownPath}`);

--- a/packages/hushh-mcp/LICENSE
+++ b/packages/hushh-mcp/LICENSE
@@ -1,0 +1,159 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this
+License, each Contributor hereby grants to You a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+reproduce, prepare Derivative Works of, publicly display, publicly perform,
+sublicense, and distribute the Work and such Derivative Works in Source or
+Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License,
+each Contributor hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section) patent
+license to make, have made, use, offer to sell, sell, import, and otherwise
+transfer the Work, where such license applies only to those patent claims
+licensable by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s) with the Work
+to which such Contribution(s) was submitted. If You institute patent litigation
+against any entity (including a cross-claim or counterclaim in a lawsuit)
+alleging that the Work or a Contribution incorporated within the Work
+constitutes direct or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate as of the date
+such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or
+Derivative Works thereof in any medium, with or without modifications, and in
+Source or Object form, provided that You meet the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+
+(b) You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You
+distribute, all copyright, patent, trademark, and attribution notices from the
+Source form of the Work, excluding those notices that do not pertain to any part
+of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution, then
+any Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along with
+the Derivative Works; or, within a display generated by the Derivative Works, if
+and wherever such third-party notices normally appear. The contents of the
+NOTICE file are for informational purposes only and do not modify the License.
+You may add Your own attribution notices within Derivative Works that You
+distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any
+Contribution intentionally submitted for inclusion in the Work by You to the
+Licensor shall be under the terms and conditions of this License, without any
+additional terms or conditions. Notwithstanding the above, nothing herein shall
+supersede or modify the terms of any separate license agreement you may have
+executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names,
+trademarks, service marks, or product names of the Licensor, except as required
+for reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in
+writing, Licensor provides the Work (and each Contributor provides its
+Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied, including, without limitation, any warranties
+or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any risks
+associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in
+tort (including negligence), contract, or otherwise, unless required by
+applicable law (such as deliberate and grossly negligent acts) or agreed to in
+writing, shall any Contributor be liable to You for damages, including any
+direct, indirect, special, incidental, or consequential damages of any
+character arising as a result of this License or out of the use or inability to
+use the Work (including but not limited to damages for loss of goodwill, work
+stoppage, computer failure or malfunction, or any and all other commercial
+damages or losses), even if such Contributor has been advised of the possibility
+of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or
+Derivative Works thereof, You may choose to offer, and charge a fee for,
+acceptance of support, warranty, indemnity, or other liability obligations
+and/or rights consistent with this License. However, in accepting such
+obligations, You may act only on Your own behalf and on Your sole responsibility,
+not on behalf of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability incurred by, or
+claims asserted against, such Contributor by reason of your accepting any such
+warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/packages/hushh-mcp/NOTICE
+++ b/packages/hushh-mcp/NOTICE
@@ -1,0 +1,8 @@
+Hushh MCP
+Copyright 2026 Hushh
+
+This npm package includes the Hushh Consent MCP launcher and a vendored
+consent-protocol runtime snapshot, distributed under the Apache License 2.0.
+
+Third-party dependency attributions and license summaries for the repository are
+documented at the repo root in THIRD_PARTY_NOTICES.md.

--- a/packages/hushh-mcp/README.md
+++ b/packages/hushh-mcp/README.md
@@ -204,6 +204,12 @@ The data flow is:
 - encrypted export back to the external connector
 - local decryption on the connector side
 
+## License
+
+This package is licensed under `Apache-2.0`.
+
+The published npm tarball includes package-local `LICENSE` and `NOTICE` files for Apache redistribution.
+
 ## Self-hosted and contributor development
 
 This package can also bootstrap a generic `consent-protocol` runtime for local development or self-hosted use.

--- a/packages/hushh-mcp/package.json
+++ b/packages/hushh-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hushh/mcp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Launch-friendly npm wrapper for the Hushh Consent MCP server",
   "license": "Apache-2.0",
   "repository": {
@@ -16,6 +16,8 @@
     "hushh-mcp": "bin/hushh-mcp.js"
   },
   "files": [
+    "LICENSE",
+    "NOTICE",
     "README.md",
     "bin/",
     "public-docs.json",

--- a/packages/hushh-mcp/public-docs.json
+++ b/packages/hushh-mcp/public-docs.json
@@ -1,5 +1,7 @@
 {
   "packageName": "@hushh/mcp",
+  "license": "Apache-2.0",
+  "noticeSummary": "The published npm package ships package-local LICENSE and NOTICE files for Apache redistribution.",
   "tokenEnvVar": "HUSHH_DEVELOPER_TOKEN",
   "promotedEnvironment": {
     "label": "UAT",

--- a/packages/hushh-mcp/scripts/render-readme.mjs
+++ b/packages/hushh-mcp/scripts/render-readme.mjs
@@ -135,6 +135,12 @@ The data flow is:
 - encrypted export back to the external connector
 - local decryption on the connector side
 
+## License
+
+This package is licensed under \`${contract.license}\`.
+
+The published npm tarball includes package-local \`LICENSE\` and \`NOTICE\` files for Apache redistribution.
+
 ## Self-hosted and contributor development
 
 This package can also bootstrap a generic \`consent-protocol\` runtime for local development or self-hosted use.

--- a/scripts/env/bootstrap.sh
+++ b/scripts/env/bootstrap.sh
@@ -19,15 +19,17 @@ Description:
   - runs the environment doctor for the selected profile
 
 Notes:
-  - Default mode is uat so a first-time contributor can get the app
-    running against deployed UAT without local backend/proxy setup.
+  - Default mode is local so contributor bootstrap aligns with the
+    local-first runtime contract.
+  - Use --mode uat when you intentionally want the fastest frontend-only
+    path against the deployed UAT backend.
   - If gcloud is unavailable, runtime files are created from templates and
     cached local values where possible.
   - This command does not print secrets.
 USAGE
 }
 
-PROFILE="uat"
+PROFILE="local"
 while [ "$#" -gt 0 ]; do
   case "${1:-}" in
     --mode)
@@ -183,6 +185,7 @@ echo ""
 
 echo "Bootstrap complete."
 echo "Next steps:"
-echo "  ./bin/hushh web --mode uat"
+echo "  ./bin/hushh terminal backend --mode local --reload"
+echo "  ./bin/hushh web               # defaults to local"
+echo "  ./bin/hushh web --mode uat    # explicit hosted-backend frontend path"
 echo "  ./bin/hushh doctor --mode local"
-echo "  ./bin/hushh backend   # when you need local backend work"


### PR DESCRIPTION
## Summary\n- default bootstrap and web flows to local-first contributor mode\n- tighten MCP Apache publication surface and package docs\n- harden Codex/runtime audit checks for the updated env contract\n\n## Verification\n- ./bin/hushh ci\n- ./bin/hushh docs verify\n- python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py\n- python3 scripts/licenses/verify_apache_surface.py\n- python3 scripts/ci/verify-runtime-config-contract.py\n