### PR TITLE
chore: align branch governance and actions runtime

### DIFF
--- a/.codex/skills/repo-operations/SKILL.md
+++ b/.codex/skills/repo-operations/SKILL.md
@@ -60,22 +60,23 @@ Non-owned surfaces:
 4. Use `./bin/hushh codex ci-status` for PR-check status and `scripts/ci/watch-gh-workflow-chain.sh` for long-running post-merge or deploy workflow chains.
 5. Treat the delivery model as three stages: PR feedback lane, queue authority lane, and post-merge deploy-authority lane.
 6. Treat GitHub approval and GitHub bypass as separate states: a PR author still cannot self-approve, but a bypass-listed actor may waive the review gate and, when configured, use the dedicated queue-bypass owner path.
-7. Monitor the resulting workflow chain until terminal success or a concrete blocker.
-8. Default runtime launch behavior must be visible separate OS terminal windows, not hidden Codex sessions.
-9. For local app work, prefer separate `./bin/hushh terminal backend --mode local --reload` and `./bin/hushh terminal web --mode <mode>` commands unless the user explicitly asks for something else.
-10. Use hidden long-lived Codex sessions only for background monitoring, one-off debugging, or when a visible terminal is not desired.
-11. Use `./bin/hushh terminal stack --mode local` only when one combined visible terminal is explicitly preferred.
-12. Default branch policy: continue work on the user's active development branch. Do not create a new temporary branch for incremental fixes, validation follow-ups, or polish work unless the user explicitly asks for branch isolation.
-13. Create a new branch only when one of these is true:
+7. Do not flag the sanctioned `main` owner-bypass trio as governance drift when the live review-bypass allowlist exactly matches `config/ci-governance.json` and includes `kushaltrivedi5`.
+8. Monitor the resulting workflow chain until terminal success or a concrete blocker.
+9. Default runtime launch behavior must be visible separate OS terminal windows, not hidden Codex sessions.
+10. For local app work, prefer separate `./bin/hushh terminal backend --mode local --reload` and `./bin/hushh terminal web --mode <mode>` commands unless the user explicitly asks for something else.
+11. Use hidden long-lived Codex sessions only for background monitoring, one-off debugging, or when a visible terminal is not desired.
+12. Use `./bin/hushh terminal stack --mode local` only when one combined visible terminal is explicitly preferred.
+13. Default branch policy: continue work on the user's active development branch. Do not create a new temporary branch for incremental fixes, validation follow-ups, or polish work unless the user explicitly asks for branch isolation.
+14. Create a new branch only when one of these is true:
    - the fix is a post-merge blocker and must start from the latest `main`
    - the repo workflow requires an isolated hotfix from `main`
    - the current branch contains unrelated in-flight work that would make the fix unsafe to ship
-14. After a merge-driven hotfix is complete, delete the temporary branch remotely and locally when it is safe to do so, then return local state to the user's normal working branch or `main`; do not leave Codex parked on a temporary branch.
-15. If the user has an active development branch, back-sync merged hotfixes into that branch before closing the task so the real working branch does not drift behind `main`.
-16. For CI workflows, branch protection, env/bootstrap, or deploy-authority changes, do a second verification pass after edits instead of trusting the first green run.
-17. For branch protection, merge queue, release authority, or production deploy-governance changes, do a third independent check against live GitHub or runtime state before calling the work complete.
-18. For UAT runtime failures, start with `./bin/hushh codex rca --surface uat --text` so secret drift, legacy runtime mounts, DB drift, and semantic runtime breakage are classified before editing or redeploying.
-19. Treat only core runtime/release surfaces as blocking in the RCA loop: runtime contract, deploy/runtime env contract, DB release contract, semantic UAT verification, and Gmail/voice/auth availability on the release lane. Helper-only drift stays advisory unless it masks one of those surfaces.
+15. After a merge-driven hotfix is complete, delete the temporary branch remotely and locally when it is safe to do so, then return local state to the user's normal working branch or `main`; do not leave Codex parked on a temporary branch.
+16. If the user has an active development branch, back-sync merged hotfixes into that branch before closing the task so the real working branch does not drift behind `main`.
+17. For CI workflows, branch protection, env/bootstrap, or deploy-authority changes, do a second verification pass after edits instead of trusting the first green run.
+18. For branch protection, merge queue, release authority, or production deploy-governance changes, do a third independent check against live GitHub or runtime state before calling the work complete.
+19. For UAT runtime failures, start with `./bin/hushh codex rca --surface uat --text` so secret drift, legacy runtime mounts, DB drift, and semantic runtime breakage are classified before editing or redeploying.
+20. Treat only core runtime/release surfaces as blocking in the RCA loop: runtime contract, deploy/runtime env contract, DB release contract, semantic UAT verification, and Gmail/voice/auth availability on the release lane. Helper-only drift stays advisory unless it masks one of those surfaces.
 
 ## Handoff Rules
 

--- a/.codex/skills/repo-operations/references/operations-surface.md
+++ b/.codex/skills/repo-operations/references/operations-surface.md
@@ -46,5 +46,6 @@ Use this reference to orient DevOps work in `hushh-research`.
 1. Review approval and review bypass are different GitHub states.
 2. A PR author cannot self-approve through GitHub.
 3. A bypass-listed actor may still waive the review gate when the live branch protection allows it.
-4. Merge-queue rules remain separate from review bypass and are satisfied through the dedicated `main-bypass-queue` owner team.
-5. The privileged three may dispatch UAT manually; only `kushaltrivedi5` may dispatch Production.
+4. The sanctioned `main` owner-bypass trio is intentional policy, not a finding, when it exactly matches `config/ci-governance.json` and includes `kushaltrivedi5`.
+5. Merge-queue rules remain separate from review bypass and are satisfied through the dedicated `main-bypass-queue` owner team.
+6. The privileged three may dispatch UAT manually; only `kushaltrivedi5` may dispatch Production.

--- a/.codex/skills/repo-operations/scripts/ci_monitor.py
+++ b/.codex/skills/repo-operations/scripts/ci_monitor.py
@@ -190,7 +190,7 @@ def _review_policy(base_branch: str = "main") -> OrderedDict[str, Any]:
         notes=[
             "A PR author still cannot self-approve through GitHub.",
             "Review bypass and merge-queue policy are separate gates.",
-            "The privileged three may waive review on main and bypass merge queue through the dedicated team-backed owner path.",
+            "The sanctioned main owner-bypass trio may waive review on main and bypass merge queue through the dedicated team-backed owner path.",
         ],
     )
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,23 +1,23 @@
 # CODEOWNERS - Automatic PR Review Assignment
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# Global owners (fallback)
-* @hushh-labs/maintainers
+# Global owner of record (fallback)
+* @kushaltrivedi5
 
 # Backend (Python/FastAPI) -- GIT SUBTREE: upstream at hushh-labs/consent-protocol
-/consent-protocol/ @hushh-labs/maintainers
+/consent-protocol/ @kushaltrivedi5
 
 # Frontend (Next.js/Capacitor)
-/hushh-webapp/ @hushh-labs/maintainers
+/hushh-webapp/ @kushaltrivedi5
 
 # Documentation
-/docs/ @hushh-labs/maintainers
+/docs/ @kushaltrivedi5
 
 # CI/CD and workflows
-/.github/ @hushh-labs/maintainers
+/.github/ @kushaltrivedi5
 
 # Deployment configs
-/deploy/ @hushh-labs/maintainers
+/deploy/ @kushaltrivedi5
 
 # Scripts and utilities
-/scripts/ @hushh-labs/maintainers
+/scripts/ @kushaltrivedi5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: "20"
+  NODE_VERSION: "24"
   PYTHON_VERSION: "3.13"
   CI_NATIVE_PARITY_REQUIRED: "0"
   CI_DOCS_PARITY_REQUIRED: "0"
@@ -210,10 +210,11 @@ jobs:
 
       - name: Upload security audit artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: web-npm-audit-report
           path: hushh-webapp/npm-audit-report.json
+          if-no-files-found: ignore
 
   # ============================================================================
   # Backend (Python FastAPI) -- same shared script as upstream consent-protocol CI

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -251,7 +251,7 @@ jobs:
 
       - name: Upload production DB governance artifacts
         if: always() && steps.scope.outputs.deploy_backend == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: prod-db-governance-${{ github.run_id }}
           if-no-files-found: ignore

--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -777,7 +777,7 @@ jobs:
 
       - name: Upload UAT deploy artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: uat-release-${{ github.run_id }}
           if-no-files-found: ignore

--- a/.github/workflows/main-post-merge-smoke.yml
+++ b/.github/workflows/main-post-merge-smoke.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: "20"
+  NODE_VERSION: "24"
   PYTHON_VERSION: "3.13"
 
 jobs:

--- a/.github/workflows/prod-supabase-backup-posture.yml
+++ b/.github/workflows/prod-supabase-backup-posture.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload backup posture artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: prod-backup-posture-${{ github.run_id }}
           if-no-files-found: ignore

--- a/.github/workflows/queue-validation.yml
+++ b/.github/workflows/queue-validation.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: "20"
+  NODE_VERSION: "24"
   PYTHON_VERSION: "3.13"
   CI_NATIVE_PARITY_REQUIRED: "0"
   CI_DOCS_PARITY_REQUIRED: "0"
@@ -115,10 +115,11 @@ jobs:
 
       - name: Upload security audit artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: web-npm-audit-report
           path: hushh-webapp/npm-audit-report.json
+          if-no-files-found: ignore
 
   protocol-check:
     name: "Protocol (Python)"

--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -1,7 +1,7 @@
 {
   "main": {
     "required_status_check": "CI Status Gate",
-    "required_approving_reviews": 1,
+    "required_approving_reviews": 0,
     "require_strict_status_checks": true,
     "require_conversation_resolution": true,
     "review_bypass_users": [

--- a/consent-protocol/.github/actions/setup-python-uv/action.yml
+++ b/consent-protocol/.github/actions/setup-python-uv/action.yml
@@ -22,7 +22,7 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
-    - uses: astral-sh/setup-uv@v6
+    - uses: astral-sh/setup-uv@v7
       with:
         version: "0.10.10"
 

--- a/docs/reference/operations/branch-governance.md
+++ b/docs/reference/operations/branch-governance.md
@@ -87,18 +87,21 @@ Before deleting a local backup branch, classify its unique commits as:
 5. Enable merge queue for `main`.
 6. Block force-pushes.
 7. Block branch deletion.
-8. Use review bypass plus the dedicated `main-bypass-queue` team for the 3 core owners only; do not rely on overlapping push restrictions.
-9. Keep ordinary development off `main`; use PRs from developer branches.
+8. Do not require blanket PR approvals on `main`; CI status plus merge queue are the default merge gates.
+9. Use review bypass plus the dedicated `main-bypass-queue` team for the 3 core owners only; do not rely on overlapping push restrictions.
+10. Keep ordinary development off `main`; use PRs from developer branches.
 
 Current operating note:
 
 - `enforce_admins` should stay enabled
 - DCO is enforced in CI, not via a separate GitHub branch-protection primitive
 - verify the live setting with `../../../scripts/ci/verify-main-branch-protection.sh`
+- `main` intentionally requires `0` blanket approvals; the external community still goes through PR + CI + queue
 - admin ownership does not count as an independent PR approval
 - a PR author cannot self-approve through GitHub; review remains a separate state from admin privileges
 - the current live `main` branch protection review-bypass allowlist is `kushaltrivedi5`, `Akash-292`, and `RGlodAkshat`
 - the current live merge-queue bypass team is `main-bypass-queue`, containing those same 3 users only
+- the sanctioned review-bypass trio is intentional policy and should not be reported as governance drift when it matches `config/ci-governance.json`
 - if an admin needs to proceed on a green PR, verify whether the live ruleset allows queue entry; do not assume approval is implicitly satisfied
 - bypass actors may waive review through branch protection and bypass queue through the dedicated owner team path
 - direct pushes to `main` are not the default bypass model; the preferred path is a green PR plus bypass merge

--- a/docs/reference/operations/ci.md
+++ b/docs/reference/operations/ci.md
@@ -168,7 +168,7 @@ Feature and hotfix branches intentionally rely on `pull_request` CI only. Merge 
 Protected branches are expected to enforce the same CI contract documented here:
 
 - `main`
-  - at least `1` approving review
+  - `0` blanket approving reviews
   - required status checks: `CI Status Gate`
   - strict/up-to-date checks enabled
   - conversation resolution required
@@ -185,7 +185,8 @@ The live GitHub setting can drift from the docs, so verify it directly:
 Current live nuance:
 
 - the repo uses branch protection for review, freshness, and conversation-resolution requirements
-- bypass actors should be limited to the 3 core owners, without overlapping push-restriction lists
+- the sanctioned bypass trio should be limited to the 3 core owners, without overlapping push-restriction lists
+- that sanctioned trio is intentional governance and should not be reported as drift when it exactly matches `config/ci-governance.json` and includes `kushaltrivedi5`
 
 ### GitHub Alert Parity
 

--- a/scripts/ci/verify-main-branch-protection.sh
+++ b/scripts/ci/verify-main-branch-protection.sh
@@ -33,14 +33,14 @@ import subprocess
 import sys
 from pathlib import Path
 
-required_checks_arg, min_approvals_arg, require_strict_arg, require_merge_queue_arg, require_conversation_resolution_arg, repo = sys.argv[1:]
+required_checks_arg, expected_approvals_arg, require_strict_arg, require_merge_queue_arg, require_conversation_resolution_arg, repo = sys.argv[1:]
 policy = json.loads(Path(os.environ["POLICY_FILE"]).read_text(encoding="utf-8"))
 required_checks = [
     item.strip()
     for item in (required_checks_arg or policy["main"]["required_status_check"]).split(",")
     if item.strip()
 ]
-min_approvals = int(min_approvals_arg or policy["main"]["required_approving_reviews"])
+expected_approvals = int(expected_approvals_arg or policy["main"]["required_approving_reviews"])
 require_strict = (
     require_strict_arg.lower() == "true"
     if require_strict_arg
@@ -154,8 +154,8 @@ errors = []
 for required_check in required_checks:
     if required_check not in checks:
         errors.append(f"required status check missing: {required_check}")
-if approvals < min_approvals:
-    errors.append(f"required approvals too low: {approvals} < {min_approvals}")
+if approvals != expected_approvals:
+    errors.append(f"required approvals drifted: expected {expected_approvals}, got {approvals}")
 if require_strict and not strict_checks:
     errors.append("required status checks are not strict/up-to-date")
 if require_conversation_resolution and not conversation_resolution:


### PR DESCRIPTION
## Summary\n- remove blanket main approval requirement while preserving the sanctioned bypass trio and merge queue\n- align repo governance docs, CODEOWNERS, and Codex skill rules to that live policy\n- move GitHub Actions runtime surfaces to current Node 24-capable action versions\n\n## Verification\n- ./scripts/ci/verify-main-branch-protection.sh\n- ./bin/hushh docs verify\n- python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py\n- python3 -m py_compile .codex/skills/repo-operations/scripts/ci_monitor.py\n- ./bin/hushh ci\n