### PR TITLE
chore: mandate terminal monitoring for core workflow chains

### DIFF
--- a/.codex/skills/autonomous-rca-governance/SKILL.md
+++ b/.codex/skills/autonomous-rca-governance/SKILL.md
@@ -62,8 +62,9 @@ Non-owned surfaces:
    - `db_contract_drift`
 3. Apply the smallest safe remediation for the highest-signal blocking class first.
 4. Rerun the authoritative checks twice after the remediation instead of trusting the first green pass.
-5. Stop only when the blocking classifications are empty or a real permissions/product boundary is explicit.
-6. Advisory doc/skill drift should be recorded, but it must not block the loop unless it masks a core runtime failure.
+5. Do not call the RCA task complete while a relevant core run for the touched SHA is still `queued`, `in_progress`, or `requested`; keep monitoring until GitHub reaches a terminal state.
+6. Stop only when the blocking classifications are empty and the relevant core run chain is terminal green, or a real permissions/product boundary is explicit.
+7. Advisory doc/skill drift should be recorded, but it must not block the loop unless it masks a core runtime failure.
 
 ## Handoff Rules
 

--- a/.codex/skills/repo-operations/SKILL.md
+++ b/.codex/skills/repo-operations/SKILL.md
@@ -62,21 +62,25 @@ Non-owned surfaces:
 6. Treat GitHub approval and GitHub bypass as separate states: a PR author still cannot self-approve, but a bypass-listed actor may waive the review gate and, when configured, use the dedicated queue-bypass owner path.
 7. Do not flag the sanctioned `main` owner-bypass trio as governance drift when the live review-bypass allowlist exactly matches `config/ci-governance.json` and includes `kushaltrivedi5`.
 8. Monitor the resulting workflow chain until terminal success or a concrete blocker.
-9. Default runtime launch behavior must be visible separate OS terminal windows, not hidden Codex sessions.
-10. For local app work, prefer separate `./bin/hushh terminal backend --mode local --reload` and `./bin/hushh terminal web --mode <mode>` commands unless the user explicitly asks for something else.
-11. Use hidden long-lived Codex sessions only for background monitoring, one-off debugging, or when a visible terminal is not desired.
-12. Use `./bin/hushh terminal stack --mode local` only when one combined visible terminal is explicitly preferred.
-13. Default branch policy: continue work on the user's active development branch. Do not create a new temporary branch for incremental fixes, validation follow-ups, or polish work unless the user explicitly asks for branch isolation.
-14. Create a new branch only when one of these is true:
+9. For core authority surfaces, the task is not complete while GitHub still shows any relevant run for the touched SHA as `queued`, `in_progress`, or `requested`.
+10. Core authority surfaces are `PR Validation`, `Queue Validation`, `Main Post-Merge Smoke`, `Deploy to UAT`, and any RCA-triggered release-authority rerun for the same SHA.
+11. After a merge to `main`, continue monitoring through `Main Post-Merge Smoke` and downstream `Deploy to UAT`; a merged PR with an active post-merge or UAT chain is still in progress.
+12. If a core run fails, default to the smallest safe repair and rerun loop before declaring a blocker. Only stop early for a real permissions, product, or platform boundary.
+13. Default runtime launch behavior must be visible separate OS terminal windows, not hidden Codex sessions.
+14. For local app work, prefer separate `./bin/hushh terminal backend --mode local --reload` and `./bin/hushh terminal web --mode <mode>` commands unless the user explicitly asks for something else.
+15. Use hidden long-lived Codex sessions only for background monitoring, one-off debugging, or when a visible terminal is not desired.
+16. Use `./bin/hushh terminal stack --mode local` only when one combined visible terminal is explicitly preferred.
+17. Default branch policy: continue work on the user's active development branch. Do not create a new temporary branch for incremental fixes, validation follow-ups, or polish work unless the user explicitly asks for branch isolation.
+18. Create a new branch only when one of these is true:
    - the fix is a post-merge blocker and must start from the latest `main`
    - the repo workflow requires an isolated hotfix from `main`
    - the current branch contains unrelated in-flight work that would make the fix unsafe to ship
-15. After a merge-driven hotfix is complete, delete the temporary branch remotely and locally when it is safe to do so, then return local state to the user's normal working branch or `main`; do not leave Codex parked on a temporary branch.
-16. If the user has an active development branch, back-sync merged hotfixes into that branch before closing the task so the real working branch does not drift behind `main`.
-17. For CI workflows, branch protection, env/bootstrap, or deploy-authority changes, do a second verification pass after edits instead of trusting the first green run.
-18. For branch protection, merge queue, release authority, or production deploy-governance changes, do a third independent check against live GitHub or runtime state before calling the work complete.
-19. For UAT runtime failures, start with `./bin/hushh codex rca --surface uat --text` so secret drift, legacy runtime mounts, DB drift, and semantic runtime breakage are classified before editing or redeploying.
-20. Treat only core runtime/release surfaces as blocking in the RCA loop: runtime contract, deploy/runtime env contract, DB release contract, semantic UAT verification, and Gmail/voice/auth availability on the release lane. Helper-only drift stays advisory unless it masks one of those surfaces.
+19. After a merge-driven hotfix is complete, delete the temporary branch remotely and locally when it is safe to do so, then return local state to the user's normal working branch or `main`; do not leave Codex parked on a temporary branch.
+20. If the user has an active development branch, back-sync merged hotfixes into that branch before closing the task so the real working branch does not drift behind `main`.
+21. For CI workflows, branch protection, env/bootstrap, or deploy-authority changes, do a second verification pass after edits instead of trusting the first green run.
+22. For branch protection, merge queue, release authority, or production deploy-governance changes, do a third independent check against live GitHub or runtime state before calling the work complete.
+23. For UAT runtime failures, start with `./bin/hushh codex rca --surface uat --text` so secret drift, legacy runtime mounts, DB drift, and semantic runtime breakage are classified before editing or redeploying.
+24. Treat only core runtime/release surfaces as blocking in the RCA loop: runtime contract, deploy/runtime env contract, DB release contract, semantic UAT verification, and Gmail/voice/auth availability on the release lane. Helper-only drift stays advisory unless it masks one of those surfaces.
 
 ## Handoff Rules
 

--- a/.codex/skills/repo-operations/scripts/ci_monitor.py
+++ b/.codex/skills/repo-operations/scripts/ci_monitor.py
@@ -210,6 +210,7 @@ def _overall_status(checks: list[dict[str, Any]]) -> str:
 def _build_payload(pr_payload: dict[str, Any]) -> OrderedDict[str, Any]:
     checks = _normalize_checks(pr_payload)
     review_policy = _review_policy()
+    overall_status = _overall_status(checks)
     status_counts = Counter(
         "failing"
         if (check["conclusion"] or "").upper() in FAILURE_CONCLUSIONS
@@ -228,9 +229,30 @@ def _build_payload(pr_payload: dict[str, Any]) -> OrderedDict[str, Any]:
         for check in checks
         if (check["status"] or "").upper() not in TERMINAL_STATUSES
     ]
+    if failing_checks:
+        completion_gate = OrderedDict(
+            task_complete=False,
+            reason="Core checks are failing. Repair the failing workflow chain or emit a concrete blocker with workflow, job, and step context.",
+        )
+    elif pending_checks:
+        completion_gate = OrderedDict(
+            task_complete=False,
+            reason="Core checks are still active. Keep monitoring until GitHub reaches a terminal state; after merge, continue through Main Post-Merge Smoke and Deploy to UAT.",
+        )
+    elif overall_status == "booting":
+        completion_gate = OrderedDict(
+            task_complete=False,
+            reason="GitHub has not reported checks yet. The task is still in progress until the core check set becomes terminal.",
+        )
+    else:
+        completion_gate = OrderedDict(
+            task_complete=True,
+            reason="Core PR checks are terminal green. If the change has landed on main, continue monitoring post-merge smoke and downstream UAT before closing the task.",
+        )
     next_actions = OrderedDict()
     next_actions["route_task"] = "./bin/hushh codex route-task ci-watch-and-heal"
     next_actions["impact"] = "./bin/hushh codex impact ci-watch-and-heal"
+    next_actions["completion_gate"] = completion_gate["reason"]
     if review_policy["current_actor_can_bypass_review"]:
         next_actions["review_gate"] = "Current actor may waive the review gate on main; this is not the same as self-approval."
     else:
@@ -265,7 +287,8 @@ def _build_payload(pr_payload: dict[str, Any]) -> OrderedDict[str, Any]:
             head_ref=pr_payload["headRefName"],
         ),
         review_policy=review_policy,
-        overall_status=_overall_status(checks),
+        overall_status=overall_status,
+        completion_gate=completion_gate,
         status_counts=OrderedDict(
             passing=status_counts["passing"],
             pending=status_counts["pending"],
@@ -318,6 +341,8 @@ def _render_text(payload: OrderedDict[str, Any]) -> str:
             f"merge_queue_required={payload['review_policy']['merge_queue_required']}"
         ),
         f"Overall status: {payload['overall_status']}",
+        f"Task complete: {payload['completion_gate']['task_complete']}",
+        f"Completion gate: {payload['completion_gate']['reason']}",
         (
             "Counts: "
             f"passing={payload['status_counts']['passing']}, "
@@ -369,6 +394,8 @@ def main() -> int:
         print(json.dumps(payload, indent=2))
     else:
         print(_render_text(payload))
+    if args.watch:
+        return 0 if payload["overall_status"] == "passing" else 1
     return 0 if payload["overall_status"] in {"passing", "pending", "booting"} else 1
 
 

--- a/.codex/workflows/autonomous-rca-governance/PLAYBOOK.md
+++ b/.codex/workflows/autonomous-rca-governance/PLAYBOOK.md
@@ -13,7 +13,8 @@ Classify core runtime and release failures into a small RCA taxonomy, run the sm
    `secret_missing`, `runtime_mount_missing`, `runtime_mount_legacy`, `runtime_behavior_failed`, `smoke_overlay_dependency_leak`, `db_contract_drift`.
 3. Route the fix to the smallest owner skill that can actually remediate the blocking class.
 4. Rerun the authoritative checks twice after the remediation instead of trusting the first green pass.
-5. Keep advisory doc/skill drift recorded, but do not let it block the loop unless it masks a core runtime failure.
+5. Do not call the task complete while the relevant deploy or UAT run for the touched SHA is still queued or in progress; keep monitoring until the release chain is terminal.
+6. Keep advisory doc/skill drift recorded, but do not let it block the loop unless it masks a core runtime failure.
 
 ## Common Drift Risks
 

--- a/.codex/workflows/autonomous-rca-governance/workflow.json
+++ b/.codex/workflows/autonomous-rca-governance/workflow.json
@@ -1,7 +1,7 @@
 {
   "id": "autonomous-rca-governance",
   "title": "Autonomous RCA Governance",
-  "goal": "Classify core runtime and release failures into a small RCA taxonomy, run the smallest authoritative checks, and keep machine-readable artifacts that let later agents resume without rediscovering the same blocker.",
+  "goal": "Classify core runtime and release failures into a small RCA taxonomy, run the smallest authoritative checks, keep machine-readable artifacts that let later agents resume without rediscovering the same blocker, and continue monitoring until the relevant core run chain reaches terminal green or a concrete blocker.",
   "owner_skill": "autonomous-rca-governance",
   "default_spoke": null,
   "task_type": "autonomous-rca-governance",
@@ -40,7 +40,8 @@
     "blocking RCA classifications",
     "resume-safe RCA artifact",
     "smallest safe remediation direction",
-    "authoritative rerun record"
+    "authoritative rerun record",
+    "terminal release outcome or blocker note"
   ],
   "impact_fields": [
     "Surface",
@@ -60,6 +61,7 @@
     "treating secret drift and runtime-mount drift as the same class of problem",
     "declaring success when the semantic verifier never wrote an artifact",
     "rerunning checks once and trusting the first green pass",
-    "blocking on helper drift instead of core runtime authority"
+    "blocking on helper drift instead of core runtime authority",
+    "declaring success while the relevant deploy or UAT run is still active"
   ]
 }

--- a/.codex/workflows/ci-watch-and-heal/PLAYBOOK.md
+++ b/.codex/workflows/ci-watch-and-heal/PLAYBOOK.md
@@ -12,9 +12,10 @@ Monitor PR checks live, classify failures into the correct owner skill, and keep
 2. Run `./bin/hushh codex ci-status --watch` on the active PR or current branch.
 3. Distinguish the failing stage before editing code:
    `PR Validation` is developer feedback, `Queue Validation` is the authoritative pre-merge blocker, and `Main Post-Merge Smoke` is the deploy-authority blocker on the real `main` SHA.
-4. Route each failed check through the owner skill suggested by the monitor before editing code.
-5. Pull the failing job logs, apply the smallest fix that addresses the actual check failure, and rerun the local parity bundle.
-6. Capture every field listed in `impact_fields` before calling the work complete.
+4. If the change lands on `main`, continue the same monitoring chain through `Main Post-Merge Smoke` and downstream `Deploy to UAT`; do not call the task complete while any core run for the touched SHA is still queued or in progress.
+5. Route each failed check through the owner skill suggested by the monitor before editing code.
+6. Pull the failing job logs, apply the smallest fix that addresses the actual check failure, and rerun the local parity bundle.
+7. Capture every field listed in `impact_fields` before calling the work complete.
 
 ## Common Drift Risks
 
@@ -22,3 +23,4 @@ Monitor PR checks live, classify failures into the correct owner skill, and keep
 2. fixing the wrong subsystem because the failing job was not classified first
 3. treating queue failures and post-merge smoke failures as the same class of problem
 4. rerunning once and walking away before terminal green
+5. treating a merged PR as done while downstream UAT is still active

--- a/.codex/workflows/ci-watch-and-heal/workflow.json
+++ b/.codex/workflows/ci-watch-and-heal/workflow.json
@@ -1,7 +1,7 @@
 {
   "id": "ci-watch-and-heal",
   "title": "CI Watch And Heal",
-  "goal": "Monitor PR, merge-queue, and post-merge smoke checks live, classify failures into the correct owner skill, pull the failing job logs, and keep the fix-and-rerun loop tight until CI reaches a terminal state or a hard blocker is identified.",
+  "goal": "Monitor PR, merge-queue, post-merge smoke, and downstream UAT release checks live, classify failures into the correct owner skill, pull the failing job logs, and keep the fix-and-rerun loop tight until the full core workflow chain reaches a terminal state or a hard blocker is identified.",
   "owner_skill": "repo-operations",
   "default_spoke": null,
   "task_type": "ci-watch-and-heal",
@@ -38,7 +38,7 @@
     "delivery stage classification",
     "failing job classification",
     "fix-and-rerun log",
-    "terminal CI outcome or blocker note"
+    "terminal workflow-chain outcome or blocker note"
   ],
   "impact_fields": [
     "Failing checks",
@@ -59,6 +59,7 @@
     "treating a red check as someone else's problem",
     "not routing the failed job to the correct owner skill",
     "not distinguishing PR feedback from queue authority or post-merge deploy authority",
-    "stopping after rerun without monitoring terminal state"
+    "stopping after rerun without monitoring terminal state",
+    "calling the task complete while post-merge smoke or downstream UAT is still running"
   ]
 }


### PR DESCRIPTION
## Summary
- require repo operations and RCA workflows to keep monitoring core GitHub runs until terminal state
- make the CI monitor emit an explicit completion gate instead of treating active runs as implicitly done
- tighten workflow packs so post-merge smoke and downstream UAT remain part of task completion

## Verification
- python3 -m py_compile .codex/skills/repo-operations/scripts/ci_monitor.py
- python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py
- ./bin/hushh docs verify
- ./bin/hushh codex audit --text
- ./bin/hushh ci