### PR TITLE
Improve Kai Chat reliability with validation, retry, and grounded pro…

### DIFF
--- a/consent-protocol/hushh_mcp/services/kai_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/kai_chat_service.py
@@ -181,40 +181,67 @@ class KaiChatResponse:
     tokens_used: Optional[int] = None
 
 
+@dataclass
+class ResponseValidationResult:
+    """Validation outcome for model-generated assistant text."""
+
+    is_valid: bool
+    text: str
+    reason: Optional[str] = None
+
+
 # System prompt for Kai
 SYSTEM_PROMPT = """You are Kai, a friendly and knowledgeable personal AI assistant from Hussh. You help users manage their personal data, analyze investments, and provide personalized insights.
 
-Your personality:
+Personality:
 - Warm, approachable, and professional
-- Concise but thorough - don't be overly verbose
-- Proactive in offering relevant suggestions
-- Privacy-conscious - remind users their data is encrypted and under their control
+- Concise but thorough
+- Proactive when it is clearly helpful
+- Privacy-conscious; remind users their data is encrypted and under their control when relevant
 
-Your capabilities:
+Capabilities:
 - Analyze investment portfolios and identify underperformers
 - Learn user preferences and remember them for personalized advice
 - Help users understand their financial risk profile
-- Provide insights based on user's PKM data
+- Provide insights based only on the supplied PKM and chat context
 
-PROACTIVE BEHAVIORS:
-1. If the user is new (no portfolio data), proactively offer to import their brokerage statement
-2. When discussing investments without portfolio context, remind them importing helps personalization
-3. After learning about user preferences, acknowledge what you learned
-4. If the user seems unsure, guide them through available features
+Grounding rules:
+- Only use information explicitly provided in the supplied context.
+- Do not assume missing data.
+- If the available context is not enough to support a claim, say "insufficient data".
+- Do not fabricate market details, portfolio details, holdings, prices, performance, or user-specific facts.
+- Do not imply you know more about the user than what is shown in the provided context.
+- Separate confirmed facts from suggestions or general guidance.
 
+Proactive behaviors:
+1. If the user is new and no portfolio data is present, offer portfolio import.
+2. When discussing investments without portfolio context, explain that personalization is limited by insufficient data.
+3. After learning user preferences from the current exchange, acknowledge them clearly.
+4. If the user seems unsure, guide them through available features without inventing missing facts.
+
+Provided user context:
 {user_context}
 
-Guidelines:
-1. If the user mentions preferences (food, travel, financial, etc.), acknowledge you'll remember them
-2. If asked about portfolio analysis, offer to import their brokerage statement
-3. Keep responses conversational but informative
-4. When discussing investments, be balanced and mention risks
-5. Never give specific financial advice - provide analysis and let users decide
-6. For new users, warmly welcome them and suggest starting with portfolio import
+Response guidelines:
+1. Keep responses conversational, clear, and informative.
+2. If the user mentions preferences, acknowledge what was explicitly stated.
+3. If asked about portfolio analysis, offer portfolio import when relevant.
+4. When discussing investments, be balanced and mention risks.
+5. Never give specific financial advice; provide analysis and let the user decide.
+6. For new users, warmly welcome them and suggest starting with portfolio import.
+7. If context is incomplete, explicitly say "insufficient data" instead of guessing.
 
 Current conversation context:
 {chat_history}
 """
+
+SAFE_FALLBACK_RESPONSE = "I'm unable to generate a reliable response right now."
+MIN_RESPONSE_CHARS = 24
+GENERIC_FALLBACK_TEXTS = {
+    "i'm having trouble generating a response right now. please try again.",
+    "i apologize, but i encountered an issue processing your message. please try again.",
+    SAFE_FALLBACK_RESPONSE.lower(),
+}
 
 
 class KaiChatService:
@@ -372,8 +399,36 @@ class KaiChatService:
             # 7. Build system prompt with context
             system_prompt = self._build_system_prompt(user_context, history)
 
-            # 8. Generate response via LLM
-            response_text, tokens = await self._generate_response(system_prompt, message)
+            # 8. Generate and validate response before using it anywhere else.
+            response_text, tokens, response_valid = await self._generate_validated_response(
+                system_prompt,
+                message,
+            )
+
+            if not response_valid:
+                logger.warning(
+                    "Kai chat returned safe fallback after validation failure user_id=%s",
+                    user_id,
+                )
+                await self.chat_db.add_message(
+                    conversation_id=conversation.id,
+                    role=MessageRole.USER,
+                    content=message,
+                )
+                await self.chat_db.add_message(
+                    conversation_id=conversation.id,
+                    role=MessageRole.ASSISTANT,
+                    content=response_text,
+                    content_type=ContentType.TEXT,
+                    tokens_used=tokens,
+                    model_used=GEMINI_MODEL,
+                )
+                return KaiChatResponse(
+                    conversation_id=str(conversation.id),
+                    response=response_text,
+                    learned_attributes=[],
+                    tokens_used=tokens,
+                )
 
             # 9. Fire attribute extraction in the background; the response does
             # not need to wait for learned attributes to be persisted.
@@ -404,7 +459,7 @@ class KaiChatService:
                 else None,
                 component_data=component.data if component else None,
                 tokens_used=tokens,
-                model_used="gemini-1.5-flash",
+                model_used=GEMINI_MODEL,
             )
 
             return KaiChatResponse(
@@ -768,14 +823,21 @@ class KaiChatService:
         self,
         system_prompt: str,
         user_message: str,
+        *,
+        stricter: bool = False,
+        previous_response: Optional[str] = None,
     ) -> tuple[str, Optional[int]]:
         """Generate a response using the LLM."""
         try:
-            # Combine system prompt and user message
-            full_prompt = f"{system_prompt}\n\nUser: {user_message}\n\nKai:"
+            full_prompt = self._build_generation_prompt(
+                system_prompt=system_prompt,
+                user_message=user_message,
+                stricter=stricter,
+                previous_response=previous_response,
+            )
 
             config = genai_types.GenerateContentConfig(
-                temperature=0.7,
+                temperature=0.3 if stricter else 0.7,
                 max_output_tokens=1024,
             )
 
@@ -795,6 +857,113 @@ class KaiChatService:
         except Exception as e:
             logger.error(f"Error generating response: {e}")
             return "I'm having trouble generating a response right now. Please try again.", None
+
+    def _build_generation_prompt(
+        self,
+        *,
+        system_prompt: str,
+        user_message: str,
+        stricter: bool,
+        previous_response: Optional[str],
+    ) -> str:
+        """Build the final generation prompt for the chat model."""
+        base_prompt = f"{system_prompt}\n\nUser: {user_message}\n\nKai:"
+        if not stricter:
+            return base_prompt
+
+        retry_note = (
+            "\n\nIMPORTANT RETRY INSTRUCTIONS:\n"
+            "- Return one direct assistant reply only.\n"
+            "- Do not include role labels like 'User:' or 'Kai:'.\n"
+            "- Do not return placeholders, templates, or meta commentary.\n"
+            f"- The reply must be specific, complete, and longer than {MIN_RESPONSE_CHARS} characters.\n"
+            "- If the available context is insufficient, say that clearly and keep the reply useful.\n"
+            "- Do not repeat generic fallback text.\n"
+        )
+        if previous_response:
+            retry_note += f"\nPrevious invalid response:\n{previous_response}\n"
+        return f"{base_prompt}{retry_note}"
+
+    def validate_response(self, response_text: str) -> ResponseValidationResult:
+        """Validate that generated assistant text is safe to use and store."""
+        normalized = re.sub(r"\s+", " ", str(response_text or "")).strip()
+        if not normalized:
+            return ResponseValidationResult(is_valid=False, text="", reason="empty")
+
+        if len(normalized) < MIN_RESPONSE_CHARS:
+            return ResponseValidationResult(
+                is_valid=False,
+                text=normalized,
+                reason="too_short",
+            )
+
+        if normalized.lower() in GENERIC_FALLBACK_TEXTS:
+            return ResponseValidationResult(
+                is_valid=False,
+                text=normalized,
+                reason="generic_fallback",
+            )
+
+        malformed_markers = (
+            normalized.startswith("User:"),
+            normalized.startswith("Kai:"),
+            "{user_context}" in normalized,
+            "{chat_history}" in normalized,
+            "Current conversation context:" in normalized,
+            "\nUser:" in response_text,
+            "\nKai:" in response_text,
+        )
+        if any(malformed_markers):
+            return ResponseValidationResult(
+                is_valid=False,
+                text=normalized,
+                reason="malformed_structure",
+            )
+
+        return ResponseValidationResult(is_valid=True, text=normalized)
+
+    async def _generate_validated_response(
+        self,
+        system_prompt: str,
+        user_message: str,
+    ) -> tuple[str, Optional[int], bool]:
+        """
+        Generate a chat response, validate it, retry once with stricter instructions,
+        and finally return a safe fallback if no valid answer is produced.
+        """
+        response_text, tokens = await self._generate_response(system_prompt, user_message)
+        validation = self.validate_response(response_text)
+        if validation.is_valid:
+            return validation.text, tokens, True
+
+        logger.warning(
+            "kai_chat.response_validation_failed reason=%s attempt=1",
+            validation.reason,
+        )
+        logger.info(
+            "kai_chat.response_retry_triggered reason=%s",
+            validation.reason,
+        )
+
+        retry_text, retry_tokens = await self._generate_response(
+            system_prompt,
+            user_message,
+            stricter=True,
+            previous_response=validation.text,
+        )
+        retry_validation = self.validate_response(retry_text)
+        if retry_validation.is_valid:
+            return retry_validation.text, retry_tokens, True
+
+        logger.warning(
+            "kai_chat.response_validation_failed reason=%s attempt=2",
+            retry_validation.reason,
+        )
+        logger.warning(
+            "kai_chat.safe_fallback_triggered final_reason=%s",
+            retry_validation.reason,
+        )
+        return SAFE_FALLBACK_RESPONSE, None, False
 
     def _detect_component(
         self,

--- a/consent-protocol/tests/services/test_kai_chat_service.py
+++ b/consent-protocol/tests/services/test_kai_chat_service.py
@@ -3,7 +3,11 @@ import logging
 
 import pytest
 
-from hushh_mcp.services.kai_chat_service import KaiChatService
+from hushh_mcp.services.kai_chat_service import (
+    MIN_RESPONSE_CHARS,
+    SAFE_FALLBACK_RESPONSE,
+    KaiChatService,
+)
 
 
 class SlowAttributeLearner:
@@ -71,3 +75,100 @@ async def test_schedule_attribute_learning_logs_background_failure(caplog):
 
     assert "kai_chat.attribute_learning_failed user_id=user-123" in caplog.text
     assert "attribute extraction failed" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("response_text", "reason"),
+    [
+        ("", "empty"),
+        ("too short", "too_short"),
+        (
+            "I'm having trouble generating a response right now. Please try again.",
+            "generic_fallback",
+        ),
+        ("User: this includes a role label and should not be stored", "malformed_structure"),
+        ("This response leaked {user_context} from the prompt template.", "malformed_structure"),
+    ],
+)
+def test_validate_response_rejects_unsafe_model_output(response_text, reason):
+    service = KaiChatService()
+
+    result = service.validate_response(response_text)
+
+    assert result.is_valid is False
+    assert result.reason == reason
+
+
+def test_validate_response_accepts_specific_complete_output():
+    service = KaiChatService()
+    response_text = "I only have insufficient data, but I can help you import a portfolio first."
+
+    result = service.validate_response(response_text)
+
+    assert result.is_valid is True
+    assert result.text == response_text
+    assert len(result.text) >= MIN_RESPONSE_CHARS
+
+
+@pytest.mark.asyncio
+async def test_generate_validated_response_retries_once_and_returns_valid_output():
+    service = KaiChatService()
+    calls: list[dict] = []
+
+    async def fake_generate_response(
+        system_prompt: str,
+        user_message: str,
+        *,
+        stricter: bool = False,
+        previous_response: str | None = None,
+    ) -> tuple[str, int]:
+        calls.append({"stricter": stricter, "previous_response": previous_response})
+        if len(calls) == 1:
+            return "Kai: bad", 10
+        return "I only have insufficient data, but I can help you import a portfolio first.", 20
+
+    service._generate_response = fake_generate_response
+
+    response_text, tokens, is_valid = await service._generate_validated_response(
+        "system",
+        "what should I do?",
+    )
+
+    assert is_valid is True
+    assert tokens == 20
+    assert (
+        response_text
+        == "I only have insufficient data, but I can help you import a portfolio first."
+    )
+    assert calls == [
+        {"stricter": False, "previous_response": None},
+        {"stricter": True, "previous_response": "Kai: bad"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_generate_validated_response_returns_safe_fallback_after_retry_failure():
+    service = KaiChatService()
+    calls: list[dict] = []
+
+    async def fake_generate_response(
+        system_prompt: str,
+        user_message: str,
+        *,
+        stricter: bool = False,
+        previous_response: str | None = None,
+    ) -> tuple[str, int]:
+        calls.append({"stricter": stricter, "previous_response": previous_response})
+        return "User: malformed model output", 10
+
+    service._generate_response = fake_generate_response
+
+    response_text, tokens, is_valid = await service._generate_validated_response(
+        "system",
+        "what should I do?",
+    )
+
+    assert response_text == SAFE_FALLBACK_RESPONSE
+    assert tokens is None
+    assert is_valid is False
+    assert len(calls) == 2


### PR DESCRIPTION
# Improve Kai Chat Reliability with Response Validation, Retry, and Grounded Prompting

This PR improves Kai’s reliability by preventing invalid or hallucinated LLM outputs from propagating into the system.

---

## Problem

- Model outputs were not validated before downstream use  
- Invalid or hallucinated responses could propagate into attribute learning and persistence  
- Prompt structure allowed assumptions beyond provided context, increasing hallucination risk  

---

## Solution

- Introduced a response validation layer to enforce output quality before downstream usage  
- Implemented a single retry mechanism with stricter prompt constraints  
- Added deterministic safe fallback for repeated failures  
- Introduced strict grounding rules in the system prompt to prevent fabricated outputs  
- Blocked invalid responses from entering attribute learning and persistence  

---

## Key Improvements

- Eliminates silent failure modes in LLM response handling  
- Reduces hallucination risk through strict grounding constraints  
- Improves overall system reliability and user trust  
- Ensures outputs are aligned strictly with available context  
- Introduces production-grade safeguards (validation, retry, safe degradation)  

---

## Before vs After

### Case 1 — Ambiguous query  
**Example:** *Should I sell this stock?*

**Before**
- Prompt allowed generic investment commentary without requiring explicit context  
- Responses could speculate on market conditions not present in input  

**After**
- Kai is restricted to explicit context and must return *“insufficient data”* when required  

**Expected response**
> Insufficient data. I don’t have the stock, position, or current portfolio context needed to suggest whether you should sell. If you share the ticker or import your portfolio, I can help analyze it more reliably.

---

### Case 2 — Missing context  
**Example:** *What do you think about my portfolio?*

**Before**
- Prompt encouraged personalization even with incomplete data  
- Could result in fabricated portfolio insights  

**After**
- Prompt explicitly prohibits fabricated user-specific and market details  

**Expected response**
> Insufficient data. I don’t have your actual holdings or allocation in the provided context, so I can’t assess your portfolio reliably. If you import your brokerage statement, I can give a grounded analysis.

---

### Case 3 — Failure handling

**Before**
- Empty, malformed, or generic outputs could pass through  
- Attribute learning and persistence could proceed on invalid responses  

**After**
- Validation rejects invalid outputs before storage and learning  
- One retry is attempted with stricter constraints  
- If retry fails, a deterministic safe fallback is returned  

**Fallback response**
> I'm unable to generate a reliable response right now.

---

## Validation Simulation

```python
empty => {'is_valid': False, 'reason': 'empty', 'text': ''}
too_short => {'is_valid': False, 'reason': 'too_short', 'text': 'Okay.'}
generic_fallback => {'is_valid': False, 'reason': 'generic_fallback', 'text': "I'm having trouble generating a response right now. Please try again."}
malformed_user => {'is_valid': False, 'reason': 'malformed_structure', 'text': 'User: Should I buy AAPL?'}
malformed_prompt_leak => {'is_valid': False, 'reason': 'malformed_structure', 'text': 'Current conversation context: User: hello'}
valid => {'is_valid': True, 'reason': None, 'text': 'Based on the supplied context, insufficient data is available to assess your portfolio yet. Importing your holdings would allow a more reliable answer.'}
safe_fallback => I'm unable to generate a reliable response right now.

```

## Testing

### Normal Inputs
- Valid responses pass validation and proceed to storage and learning  

### Edge Cases
- Empty response → rejected  
- Too-short response → rejected  
- Generic fallback text → rejected  
- Malformed / prompt-leak output → rejected  

### Failure Scenarios
- Validation failure triggers one retry with stricter constraints  
- Repeated failure returns deterministic safe fallback  
- Invalid outputs are prevented from entering attribute learning and persistence  

### Validation + Retry Confirmation

```bash
python -m py_compile consent-protocol/hushh_mcp/services/kai_chat_service.py

```

Note: Secret scan failure appears to be due to fork permission limitations (HTTP 403). The scan output indicates no leaks were found.