### PR TITLE
fix: correct persona endpoint path in setup_kai_test_marketplace_profiles.py

### DIFF
--- a/consent-protocol/scripts/setup_kai_test_marketplace_profiles.py
+++ b/consent-protocol/scripts/setup_kai_test_marketplace_profiles.py
@@ -245,7 +245,7 @@ def main() -> int:
 
     # ─── Step 6: Verify persona state ───
     log("Step 6: Checking persona state...")
-    persona = api("GET", backend_url, "/api/iam/persona-state", auth_headers)
+    persona = api("GET", backend_url, "/api/iam/persona", auth_headers)
     log(f"  personas={persona.get('personas')}")
     log(f"  active_persona={persona.get('active_persona')}")
     log(f"  ria_switch_available={persona.get('ria_switch_available')}")


### PR DESCRIPTION

## Description

The UAT setup script was calling `/api/iam/persona-state` in Step 6 (persona state verification), which is a non-existent endpoint and returns 404. The correct endpoint is `/api/iam/persona`, which is the canonical path used consistently across the rest of the codebase.

This caused the script to silently fail persona state verification during test environment setup — engineers running the script would get `None` for all persona fields (`personas`, `active_persona`, `iam_schema_ready`, etc.) without any obvious error, leading to misconfigured UAT profiles.

**Changed:** `consent-protocol/scripts/setup_kai_test_marketplace_profiles.py` line 248

```python
# Before
persona = api("GET", backend_url, "/api/iam/persona-state", auth_headers)

# After
persona = api("GET", backend_url, "/api/iam/persona", auth_headers)
```

---

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below:
    - `GET /api/iam/persona` — no change to the route itself; only the caller was wrong
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None — developer/ops script, not a product flow
- Docs updated (exact files):
  - [x] None
- Verification commands executed:
  - Cross-referenced against `consent-protocol/tests/test_ria_iam_routes.py`, `hushh-webapp/lib/services/ria-service.ts`, and `consent-protocol/scripts/uat_kai_regression_smoke.py` — all confirm `/api/iam/persona` is the correct path

---

## 🛑 Tri-Flow Architecture Check

- [x] **Web:** N/A — developer script, not a product surface
- [x] **iOS:** N/A
- [x] **Android:** N/A

---

## 🧪 Testing

- [x] Commits are signed off (`git commit -s`)

**Validation method:** The fix cannot be end-to-end tested without a running backend stack, but correctness is confirmed by static cross-reference — `/api/iam/persona` is the only registered IAM persona route in the backend (verified in `test_ria_iam_routes.py`) and is the path used by every other caller in the codebase. The wrong path `/api/iam/persona-state` exists nowhere else.

---

## 📸 Screenshots / Video

N/A — script-only fix. The 404 was documented in `.claude/projects/.../memory/performance_notes_20260331.md` by the dev team.

---

## 🛡️ Privacy & Consent

- [x] Does this change access user data? **No**
- `checkConsentToken()` not applicable — ops/test script run by engineers, not a user-facing data flow

---

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No new dependencies introduced
