### PR TITLE
Performance : replace N+1 IAM schema check with single batch query (~11× speedup)

### DIFF
--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -52,7 +52,12 @@ _IAM_REQUIRED_TABLES: tuple[str, ...] = (
     "relationship_share_events",
 )
 _RUNTIME_PERSONA_STATE_TABLE = "runtime_persona_state"
-_TABLE_EXISTS_CACHE: dict[str, bool] = {}
+# TTL-aware cache: maps table_name -> expiry datetime (UTC).
+# Using a TTL (default 300 s) instead of a permanent boolean means a
+# newly-migrated schema is recognised within 5 minutes without a restart,
+# and avoids stale state across uvicorn worker respawns.
+_TABLE_EXISTS_CACHE_TTL = timedelta(seconds=300)
+_TABLE_EXISTS_CACHE: dict[str, datetime] = {}
 _IAM_SCHEMA_READY_CACHE = False
 _RELATIONSHIP_SHARE_ACTIVE_PICKS = "ria_active_picks_feed_v1"
 _RELATIONSHIP_SHARE_ORIGIN_RELATIONSHIP_IMPLICIT = "relationship_implicit"
@@ -249,12 +254,67 @@ class RIAIAMService:
 
     @staticmethod
     async def _table_exists(conn: asyncpg.Connection, table_name: str) -> bool:
-        if _TABLE_EXISTS_CACHE.get(table_name):
+        """Check whether a single table exists in the public schema.
+
+        Uses a TTL-aware in-process cache so repeated calls within the TTL
+        window are free.  A TTL (rather than a permanent boolean) ensures
+        that a table added by a migration is recognised without a full
+        process restart.
+        """
+        now = datetime.now(tz=timezone.utc)
+        expiry = _TABLE_EXISTS_CACHE.get(table_name)
+        if expiry is not None and now < expiry:
             return True
         exists = bool(await conn.fetchval("SELECT to_regclass($1)", f"public.{table_name}"))
         if exists:
-            _TABLE_EXISTS_CACHE[table_name] = True
+            _TABLE_EXISTS_CACHE[table_name] = now + _TABLE_EXISTS_CACHE_TTL
         return exists
+
+    @staticmethod
+    async def _batch_tables_exist(
+        conn: asyncpg.Connection, table_names: tuple[str, ...]
+    ) -> set[str]:
+        """Return the subset of *table_names* that exist in the public schema.
+
+        Issues a **single** query instead of N individual round-trips.
+        Results are stored in the TTL cache so subsequent single-table
+        lookups within the TTL window are also free.
+
+        Performance: replaces the previous 11-query loop that caused ~1 300 ms
+        latency on the first ``/api/iam/marketplace/opt-in`` request
+        (each ``to_regclass`` round-trip costs ~50-80 ms over Cloud SQL proxy).
+        """
+        now = datetime.now(tz=timezone.utc)
+
+        # Fast path: all tables already cached and unexpired.
+        missing = [t for t in table_names if not (
+            (exp := _TABLE_EXISTS_CACHE.get(t)) is not None and now < exp
+        )]
+        if not missing:
+            return set(table_names)
+
+        # Single query: ask pg_catalog for all requested table names at once.
+        rows: list[asyncpg.Record] = await conn.fetch(
+            """
+            SELECT tablename
+            FROM   pg_catalog.pg_tables
+            WHERE  schemaname = 'public'
+              AND  tablename  = ANY($1::text[])
+            """,
+            list(missing),
+        )
+        found_in_db: set[str] = {r["tablename"] for r in rows}
+
+        # Populate TTL cache for every table we queried (hit or miss).
+        # Misses are intentionally *not* cached so a pending migration is
+        # picked up on the next call without waiting for the TTL to expire.
+        expiry = now + _TABLE_EXISTS_CACHE_TTL
+        for t in found_in_db:
+            _TABLE_EXISTS_CACHE[t] = expiry
+
+        # Return all tables that are confirmed present (cached + just found).
+        cached_present = {t for t in table_names if t not in missing}
+        return cached_present | found_in_db
 
     async def _investor_identity_projection(
         self,
@@ -290,11 +350,14 @@ class RIAIAMService:
         global _IAM_SCHEMA_READY_CACHE
         if _IAM_SCHEMA_READY_CACHE:
             return True
-        for table_name in _IAM_REQUIRED_TABLES:
-            if not await self._table_exists(conn, table_name):
-                return False
-        _IAM_SCHEMA_READY_CACHE = True
-        return True
+        # Single round-trip instead of N serial to_regclass() calls.
+        present = await self._batch_tables_exist(conn, _IAM_REQUIRED_TABLES)
+        if present >= set(_IAM_REQUIRED_TABLES):
+            _IAM_SCHEMA_READY_CACHE = True
+            return True
+        missing = set(_IAM_REQUIRED_TABLES) - present
+        logger.debug("IAM schema not ready. Missing tables: %s", missing)
+        return False
 
     async def _ensure_iam_schema_ready(self, conn: asyncpg.Connection) -> None:
         if not await self._is_iam_schema_ready(conn):

--- a/consent-protocol/tests/test_iam_schema_batch_benchmark.py
+++ b/consent-protocol/tests/test_iam_schema_batch_benchmark.py
@@ -1,0 +1,192 @@
+# tests/test_iam_schema_batch_benchmark.py
+"""
+Benchmark: batch IAM schema check vs the previous N+1 serial approach.
+
+This test does NOT require a real database.  It uses an in-process fake
+connection with a configurable artificial delay (default 60 ms, matching
+the ~50-80 ms Cloud SQL proxy round-trip documented in performance notes)
+to produce wall-clock numbers that reflect real-world conditions.
+
+Run with:
+    pytest tests/test_iam_schema_batch_benchmark.py -v -s
+"""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+
+import hushh_mcp.services.ria_iam_service as _mod
+from hushh_mcp.services.ria_iam_service import _IAM_REQUIRED_TABLES, RIAIAMService
+
+# Simulated network latency per DB round-trip (ms).
+# Cloud SQL proxy UAT latency from performance_notes_20260331.md: 50-80 ms.
+SIMULATED_LATENCY_MS = 60
+TABLE_COUNT = len(_IAM_REQUIRED_TABLES)
+
+
+def _clear_caches() -> None:
+    _mod._TABLE_EXISTS_CACHE.clear()
+    _mod._IAM_SCHEMA_READY_CACHE = False
+
+
+# ---------------------------------------------------------------------------
+# Fake connections
+# ---------------------------------------------------------------------------
+
+def _make_serial_conn(present_tables: list[str]) -> AsyncMock:
+    """Simulates the OLD approach: one fetchval() call per table."""
+    conn = AsyncMock()
+
+    async def _fetchval(query: str, table_qualified: str) -> str | None:
+        await asyncio.sleep(SIMULATED_LATENCY_MS / 1000)
+        # table_qualified is "public.<name>"
+        name = table_qualified.split(".")[-1]
+        return table_qualified if name in present_tables else None
+
+    conn.fetchval.side_effect = _fetchval
+    return conn
+
+
+def _make_batch_conn(present_tables: list[str]) -> AsyncMock:
+    """Simulates the NEW approach: one fetch() call for all tables."""
+    conn = AsyncMock()
+
+    async def _fetch(query: str, table_list: list[str]) -> list[dict]:
+        await asyncio.sleep(SIMULATED_LATENCY_MS / 1000)
+        return [{"tablename": t} for t in table_list if t in present_tables]
+
+    conn.fetch.side_effect = _fetch
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Old approach re-implemented inline for comparison
+# ---------------------------------------------------------------------------
+
+async def _old_is_iam_schema_ready(conn: AsyncMock) -> tuple[bool, int]:
+    """Mirrors the pre-fix implementation exactly."""
+    query_count = 0
+    for table_name in _IAM_REQUIRED_TABLES:
+        exists = bool(
+            await conn.fetchval("SELECT to_regclass($1)", f"public.{table_name}")
+        )
+        query_count += 1
+        if not exists:
+            return False, query_count
+    return True, query_count
+
+
+# ---------------------------------------------------------------------------
+# Benchmark tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_benchmark_query_count():
+    """
+    Core correctness assertion: new approach uses 1 query, old uses N.
+    No timing involved — pure call-count check.
+    """
+    _clear_caches()
+
+    # --- Old approach ---
+    serial_conn = _make_serial_conn(list(_IAM_REQUIRED_TABLES))
+    _, old_query_count = await _old_is_iam_schema_ready(serial_conn)
+
+    # --- New approach ---
+    batch_conn = _make_batch_conn(list(_IAM_REQUIRED_TABLES))
+    service = RIAIAMService.__new__(RIAIAMService)
+    await service._is_iam_schema_ready(batch_conn)
+    new_query_count = batch_conn.fetch.call_count
+
+    print(f"\n  Query count  — old: {old_query_count}  new: {new_query_count}")
+
+    assert old_query_count == TABLE_COUNT, (
+        f"Old approach should issue {TABLE_COUNT} queries, issued {old_query_count}"
+    )
+    assert new_query_count == 1, (
+        f"New approach should issue 1 query, issued {new_query_count}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_benchmark_wall_clock_with_simulated_latency():
+    """
+    Wall-clock comparison using {SIMULATED_LATENCY_MS} ms artificial delay
+    per round-trip (matches Cloud SQL proxy latency from performance notes).
+
+    Expected:
+      old ≈ {TABLE_COUNT} × {SIMULATED_LATENCY_MS} ms  (~{TABLE_COUNT * SIMULATED_LATENCY_MS} ms)
+      new ≈ 1 × {SIMULATED_LATENCY_MS} ms              (~{SIMULATED_LATENCY_MS} ms)
+    """
+    _clear_caches()
+
+    # --- Old approach ---
+    serial_conn = _make_serial_conn(list(_IAM_REQUIRED_TABLES))
+    t0 = time.perf_counter()
+    await _old_is_iam_schema_ready(serial_conn)
+    old_ms = (time.perf_counter() - t0) * 1000
+
+    # --- New approach ---
+    _clear_caches()
+    batch_conn = _make_batch_conn(list(_IAM_REQUIRED_TABLES))
+    t1 = time.perf_counter()
+    service = RIAIAMService.__new__(RIAIAMService)
+    await service._is_iam_schema_ready(batch_conn)
+    new_ms = (time.perf_counter() - t1) * 1000
+
+    speedup = old_ms / new_ms if new_ms > 0 else float("inf")
+
+    print(
+        f"\n  Simulated latency : {SIMULATED_LATENCY_MS} ms/query"
+        f"\n  Table count       : {TABLE_COUNT}"
+        f"\n  Old (N+1) time    : {old_ms:.1f} ms  ({serial_conn.fetchval.call_count} queries)"
+        f"\n  New (batch) time  : {new_ms:.1f} ms  ({batch_conn.fetch.call_count} query)"
+        f"\n  Speedup           : {speedup:.1f}×"
+    )
+
+    # New must be at least 5× faster (conservatively — real gain is ~11×).
+    assert speedup >= 5, (
+        f"Expected ≥5× speedup, got {speedup:.1f}×. "
+        f"old={old_ms:.1f}ms new={new_ms:.1f}ms"
+    )
+
+
+@pytest.mark.asyncio
+async def test_benchmark_ttl_cache_eliminates_db_on_repeat_calls():
+    """
+    Second call within TTL window should cost ~0 ms (pure memory lookup).
+    Demonstrates why the TTL cache matters for repeated API requests.
+    """
+    _clear_caches()
+    batch_conn = _make_batch_conn(list(_IAM_REQUIRED_TABLES))
+    service = RIAIAMService.__new__(RIAIAMService)
+
+    # First call — hits DB.
+    t0 = time.perf_counter()
+    await service._is_iam_schema_ready(batch_conn)
+    first_ms = (time.perf_counter() - t0) * 1000
+
+    # Reset the global schema cache but keep the TTL table cache.
+    _mod._IAM_SCHEMA_READY_CACHE = False
+
+    # Second call — everything in TTL cache, no DB.
+    batch_conn2 = _make_batch_conn(list(_IAM_REQUIRED_TABLES))
+    t1 = time.perf_counter()
+    await service._is_iam_schema_ready(batch_conn2)
+    second_ms = (time.perf_counter() - t1) * 1000
+
+    print(
+        f"\n  First call  : {first_ms:.1f} ms (DB hit)"
+        f"\n  Second call : {second_ms:.1f} ms (TTL cache)"
+        f"\n  DB queries on second call: {batch_conn2.fetch.call_count}"
+    )
+
+    assert batch_conn2.fetch.call_count == 0, (
+        "Second call within TTL should issue zero DB queries"
+    )
+    assert second_ms < first_ms / 5, (
+        f"Cached call should be much faster than first call. "
+        f"first={first_ms:.1f}ms second={second_ms:.1f}ms"
+    )

--- a/consent-protocol/tests/test_iam_schema_batch_check.py
+++ b/consent-protocol/tests/test_iam_schema_batch_check.py
@@ -1,0 +1,197 @@
+# tests/test_iam_schema_batch_check.py
+"""
+Unit tests for the batch IAM schema-readiness check introduced to replace
+the previous N+1 serial ``to_regclass()`` loop.
+
+These tests are fully offline — no database required.  They use a fake
+asyncpg connection that records which queries were issued so we can assert
+that exactly ONE query is fired instead of 11.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import hushh_mcp.services.ria_iam_service as _mod
+from hushh_mcp.services.ria_iam_service import RIAIAMService, _IAM_REQUIRED_TABLES
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_fake_conn(present_tables: list[str]) -> AsyncMock:
+    """Return a fake asyncpg connection that answers pg_catalog queries."""
+    conn = AsyncMock()
+
+    async def _fetch(query: str, table_list: list[str]) -> list[dict]:
+        assert "pg_catalog.pg_tables" in query, (
+            "Expected a single pg_catalog query, got: " + query
+        )
+        return [{"tablename": t} for t in table_list if t in present_tables]
+
+    conn.fetch.side_effect = _fetch
+    return conn
+
+
+def _clear_caches() -> None:
+    """Reset module-level caches between tests."""
+    _mod._TABLE_EXISTS_CACHE.clear()
+    _mod._IAM_SCHEMA_READY_CACHE = False
+
+
+# ---------------------------------------------------------------------------
+# _batch_tables_exist
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_batch_tables_exist_issues_single_query_for_all_tables():
+    """11 required tables must be checked with exactly ONE DB round-trip."""
+    _clear_caches()
+    conn = _make_fake_conn(present_tables=list(_IAM_REQUIRED_TABLES))
+
+    result = await RIAIAMService._batch_tables_exist(conn, _IAM_REQUIRED_TABLES)
+
+    assert result == set(_IAM_REQUIRED_TABLES)
+    assert conn.fetch.call_count == 1, (
+        f"Expected 1 DB query, got {conn.fetch.call_count}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_batch_tables_exist_returns_only_present_tables():
+    """When some tables are missing, only the present ones are returned."""
+    _clear_caches()
+    present = list(_IAM_REQUIRED_TABLES[:5])
+    conn = _make_fake_conn(present_tables=present)
+
+    result = await RIAIAMService._batch_tables_exist(conn, _IAM_REQUIRED_TABLES)
+
+    assert result == set(present)
+
+
+@pytest.mark.asyncio
+async def test_batch_tables_exist_skips_db_when_all_cached():
+    """A second call within the TTL window must not hit the DB at all."""
+    _clear_caches()
+    conn = _make_fake_conn(present_tables=list(_IAM_REQUIRED_TABLES))
+
+    # First call populates the TTL cache.
+    await RIAIAMService._batch_tables_exist(conn, _IAM_REQUIRED_TABLES)
+    first_call_count = conn.fetch.call_count
+
+    # Second call — everything is cached and unexpired.
+    await RIAIAMService._batch_tables_exist(conn, _IAM_REQUIRED_TABLES)
+
+    assert conn.fetch.call_count == first_call_count, (
+        "Second call within TTL should not issue additional DB queries"
+    )
+
+
+@pytest.mark.asyncio
+async def test_batch_tables_exist_re_queries_after_ttl_expiry():
+    """After TTL expiry the cache is stale and the DB must be queried again."""
+    _clear_caches()
+    conn = _make_fake_conn(present_tables=list(_IAM_REQUIRED_TABLES))
+
+    # Warm the cache with an already-expired expiry timestamp.
+    past = datetime.now(tz=timezone.utc) - timedelta(seconds=1)
+    for t in _IAM_REQUIRED_TABLES:
+        _mod._TABLE_EXISTS_CACHE[t] = past
+
+    await RIAIAMService._batch_tables_exist(conn, _IAM_REQUIRED_TABLES)
+
+    assert conn.fetch.call_count == 1, (
+        "Expired cache entries must trigger a fresh DB query"
+    )
+
+
+@pytest.mark.asyncio
+async def test_batch_tables_exist_does_not_cache_missing_tables():
+    """Missing tables must NOT be cached so a pending migration is detected promptly."""
+    _clear_caches()
+    # First call: only half the tables exist.
+    present_first = list(_IAM_REQUIRED_TABLES[:5])
+    conn = _make_fake_conn(present_tables=present_first)
+    await RIAIAMService._batch_tables_exist(conn, _IAM_REQUIRED_TABLES)
+
+    # Second call: now all tables exist (migration ran between calls).
+    conn2 = _make_fake_conn(present_tables=list(_IAM_REQUIRED_TABLES))
+    result = await RIAIAMService._batch_tables_exist(conn2, _IAM_REQUIRED_TABLES)
+
+    assert set(_IAM_REQUIRED_TABLES[:5]).issubset(result), (
+        "Previously-present tables should remain in result"
+    )
+    assert conn2.fetch.call_count == 1, (
+        "Missing tables from first call should trigger a DB query on second call"
+    )
+
+
+# ---------------------------------------------------------------------------
+# _is_iam_schema_ready
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_is_iam_schema_ready_returns_true_when_all_tables_present():
+    _clear_caches()
+    conn = _make_fake_conn(present_tables=list(_IAM_REQUIRED_TABLES))
+    service = RIAIAMService.__new__(RIAIAMService)
+
+    result = await service._is_iam_schema_ready(conn)
+
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_is_iam_schema_ready_returns_false_when_table_missing():
+    """Schema is NOT ready if even one required table is absent."""
+    _clear_caches()
+    # All tables except the last one.
+    present = list(_IAM_REQUIRED_TABLES[:-1])
+    conn = _make_fake_conn(present_tables=present)
+    service = RIAIAMService.__new__(RIAIAMService)
+
+    result = await service._is_iam_schema_ready(conn)
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_is_iam_schema_ready_sets_global_cache_on_success():
+    """Once all tables are confirmed present the global flag must be set."""
+    _clear_caches()
+    conn = _make_fake_conn(present_tables=list(_IAM_REQUIRED_TABLES))
+    service = RIAIAMService.__new__(RIAIAMService)
+
+    await service._is_iam_schema_ready(conn)
+
+    assert _mod._IAM_SCHEMA_READY_CACHE is True
+
+
+@pytest.mark.asyncio
+async def test_is_iam_schema_ready_does_not_set_cache_when_partial():
+    """Global cache must NOT be set if any table is missing."""
+    _clear_caches()
+    conn = _make_fake_conn(present_tables=list(_IAM_REQUIRED_TABLES[:-1]))
+    service = RIAIAMService.__new__(RIAIAMService)
+
+    await service._is_iam_schema_ready(conn)
+
+    assert _mod._IAM_SCHEMA_READY_CACHE is False
+
+
+@pytest.mark.asyncio
+async def test_is_iam_schema_ready_short_circuits_when_global_cache_set():
+    """If _IAM_SCHEMA_READY_CACHE is True, no DB query should be issued."""
+    _clear_caches()
+    _mod._IAM_SCHEMA_READY_CACHE = True
+    conn = _make_fake_conn(present_tables=[])  # DB would return empty — irrelevant.
+    service = RIAIAMService.__new__(RIAIAMService)
+
+    result = await service._is_iam_schema_ready(conn)
+
+    assert result is True
+    conn.fetch.assert_not_called()

--- a/consent-protocol/tests/test_iam_schema_batch_check.py
+++ b/consent-protocol/tests/test_iam_schema_batch_check.py
@@ -8,16 +8,13 @@ asyncpg connection that records which queries were issued so we can assert
 that exactly ONE query is fired instead of 11.
 """
 
-from __future__ import annotations
-
 from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
 import hushh_mcp.services.ria_iam_service as _mod
-from hushh_mcp.services.ria_iam_service import RIAIAMService, _IAM_REQUIRED_TABLES
-
+from hushh_mcp.services.ria_iam_service import _IAM_REQUIRED_TABLES, RIAIAMService
 
 # ---------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
# perf: replace N+1 IAM schema check with single batch query (~11× speedup)

## Description

`_is_iam_schema_ready()` in `RIAIAMService` previously verified IAM schema
readiness by looping over 11 required table names and issuing a separate
`SELECT to_regclass($1)` for each — 11 serial DB round-trips on every cold
call. Over a Cloud SQL proxy connection (50–80 ms per round-trip, documented
in `performance_notes_20260331.md`), this produced a **~1,359 ms cold-start
latency** on `POST /api/iam/marketplace/opt-in`.

Three targeted changes fix this:

1. **New `_batch_tables_exist()` static method** — issues a single
   `pg_catalog.pg_tables WHERE tablename = ANY($1)` query to check all
   required tables at once. One round-trip regardless of table count.

2. **`_is_iam_schema_ready()` updated** — replaces the `for table_name in
   _IAM_REQUIRED_TABLES` loop with a single `_batch_tables_exist()` call.
   Adds `logger.debug` listing missing tables to aid migration diagnosis.

3. **TTL-aware `_TABLE_EXISTS_CACHE`** — changed from `dict[str, bool]`
   (permanent, never invalidated) to `dict[str, datetime]` storing expiry
   timestamps (TTL: 300 s). Missing tables are intentionally not cached so
   a pending migration is detected on the next call without a restart.

**Benchmark (60 ms simulated Cloud SQL latency):**

| | Queries | Time |
|---|---|---|
| Old (N+1 serial) | 11 | 705.9 ms |
| New (batch) | 1 | 63.2 ms |
| Repeat call (TTL cache) | 0 | 0.0 ms |
| **Speedup** | | **11.2×** |

---

## Impact Map (Required)

- Routes touched:
  - [x] Listed below:
    - `POST /api/iam/marketplace/opt-in` — primary beneficiary (1,359 ms → ~80 ms)
    - `GET /api/ria/onboarding/status` — also calls `_ensure_iam_schema_ready`
    - `POST /api/ria/marketplace/discoverability` — also calls `_ensure_iam_schema_ready`
- API / schema / type changes:
  - [x] None — no route contracts, request/response shapes, or DB schema changed
- Cache keys touched:
  - [x] Listed below:
    - `_TABLE_EXISTS_CACHE` — type changed from `dict[str, bool]` to `dict[str, datetime]` (TTL-aware, in-process only)
    - `_IAM_SCHEMA_READY_CACHE` — behaviour unchanged; still a module-level boolean fast-path
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None — pure backend performance change, no frontend or Capacitor surface affected
- Docs updated (exact files):
  - [x] None
- Verification commands executed:
  - [x] `pytest tests/test_iam_schema_batch_check.py -v` — 10 passed
  - [x] `pytest tests/test_iam_schema_batch_benchmark.py -v -s` — 3 passed
  - [x] `pytest tests/test_ria_iam_service_architecture.py -v` — 24 passed (no regressions)
  - [x] Combined: **37 passed, 0 failed**

---

## Tri-Flow Architecture Check

- [x] **Web:** N/A — backend-only change, no Next.js route modified
- [x] **iOS:** N/A
- [x] **Android:** N/A

---

## Testing

- [x] `tests/test_iam_schema_batch_check.py` — 10 unit tests:
  single query assertion, partial schema, TTL cache hit, TTL expiry,
  missing tables not cached, global cache flag behaviour
- [x] `tests/test_iam_schema_batch_benchmark.py` — 3 benchmark tests
  with simulated Cloud SQL latency proving 11.2× speedup
- [x] All 24 existing `test_ria_iam_service_architecture.py` tests pass
- [x] Commits are signed off (`git commit -s`)

---

## Screenshots / Video

**Benchmark output:**
<img width="1920" height="1140" alt="image" src="https://github.com/user-attachments/assets/f34b5569-68a8-4fc8-b6c2-94cdadbe751d" />
<img width="1920" height="1140" alt="image" src="https://github.com/user-attachments/assets/e2f386e1-8411-4d00-9263-ebb04aad6f82" />

---

## Privacy & Consent

- [x] Does this change access user data? **No**
- Only reads `pg_catalog.pg_tables` (system catalogue). No user data read,
  written, or transmitted. `checkConsentToken()` not applicable.

---

## Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No new dependencies — uses only `asyncpg` (already a core dependency)
  and Python stdlib `datetime`