### PR TITLE
feat(kai): add multi-language support to voice agent tool calling

### DIFF
--- a/consent-protocol/hushh_mcp/agents/kai/agent.py
+++ b/consent-protocol/hushh_mcp/agents/kai/agent.py
@@ -7,6 +7,7 @@ MIGRATED TO ADK (v2.0.0)
 
 import logging
 import os
+import re
 from typing import Any, Dict
 
 from hushh_mcp.hushh_adk.core import HushhAgent
@@ -49,15 +50,33 @@ class KaiAgent(HushhAgent):
     ) -> Dict[str, Any]:
         """
         Agentic Entry Point.
+        Detects the language of the incoming message and passes it
+        to the tools so responses are returned in the user's language.
         """
         try:
+            # Detect language from the incoming message
+            language = self._detect_language(message)
+            logger.info(f"KaiAgent detected language: {language}")
+
+            # Inject language into the message context for the LLM
+            language_instruction = (
+                f"\n\n[SYSTEM: The user is communicating in language code '{language}'. "
+                f"Call all tools with language='{language}' and respond to the user "
+                f"in the same language as their message.]"
+            )
+            message_with_language = message + language_instruction
+
             # Execute ADK run
-            # Note: For long running analysis, we might want to stream or notify
-            response = self.run(message, user_id=user_id, consent_token=consent_token)
+            response = self.run(
+                message_with_language,
+                user_id=user_id,
+                consent_token=consent_token,
+            )
 
             return {
                 "response": response.text if hasattr(response, "text") else str(response),
                 "is_complete": True,
+                "language": language,
             }
 
         except Exception as e:
@@ -66,6 +85,44 @@ class KaiAgent(HushhAgent):
                 "response": "I encountered an error analyzing the market data.",
                 "error": str(e),
             }
+
+    def _detect_language(self, text: str) -> str:
+        """
+        Detect the language of the input text using character analysis.
+        Returns a BCP-47 language code (e.g., 'en', 'hi', 'fr', 'ja').
+        Falls back to 'en' if detection is uncertain.
+        """
+        if not text or len(text.strip()) < 3:
+            return "en"
+
+        # Detect script-based languages using unicode ranges
+        hindi_chars = len(re.findall(r'[\u0900-\u097F]', text))
+        arabic_chars = len(re.findall(r'[\u0600-\u06FF]', text))
+        chinese_chars = len(re.findall(r'[\u4E00-\u9FFF]', text))
+        japanese_chars = len(re.findall(r'[\u3040-\u30FF]', text))
+        korean_chars = len(re.findall(r'[\uAC00-\uD7AF]', text))
+        cyrillic_chars = len(re.findall(r'[\u0400-\u04FF]', text))
+        greek_chars = len(re.findall(r'[\u0370-\u03FF]', text))
+
+        total = len(text)
+
+        if hindi_chars / total > 0.2:
+            return "hi"
+        if arabic_chars / total > 0.2:
+            return "ar"
+        if japanese_chars / total > 0.2:
+            return "ja"
+        if chinese_chars / total > 0.2:
+            return "zh"
+        if korean_chars / total > 0.2:
+            return "ko"
+        if cyrillic_chars / total > 0.2:
+            return "ru"
+        if greek_chars / total > 0.2:
+            return "el"
+
+        # Default to English for Latin-script languages
+        return "en"
 
 
 # Singleton

--- a/consent-protocol/hushh_mcp/agents/kai/agent.yaml
+++ b/consent-protocol/hushh_mcp/agents/kai/agent.yaml
@@ -19,6 +19,9 @@ system_instruction: |
   4. Always cite your data sources.
   5. If user data is relevant (e.g., portfolio holdings), use it contextually.
 
+  VOICE FORMAT:
+  - Speak in the same language the user used in their message.
+
   Tone: Professional, data-driven, objective, and insightful.
 
 required_scopes:
@@ -43,8 +46,12 @@ tools:
 inputs:
   - name: user_id
     type: string
-  - name: consent_token
+  - name: vault_token
     type: string
+  - name: language
+    type: string
+    default: "en"
+    description: "BCP-47 language code detected from user message"
 
 outputs:
   - name: response

--- a/consent-protocol/hushh_mcp/agents/kai/agent.yaml
+++ b/consent-protocol/hushh_mcp/agents/kai/agent.yaml
@@ -46,7 +46,7 @@ tools:
 inputs:
   - name: user_id
     type: string
-  - name: vault_token
+  - name: consent_token
     type: string
   - name: language
     type: string

--- a/consent-protocol/hushh_mcp/agents/kai/tools.py
+++ b/consent-protocol/hushh_mcp/agents/kai/tools.py
@@ -12,16 +12,18 @@ from hushh_mcp.hushh_adk.context import HushhContext
 from hushh_mcp.hushh_adk.tools import hushh_tool
 
 # Import the existing "Agents" which we are now treating as "Analysis Engines"
-# We backed them up, but we'll use the ones in the current directory as library code.
 from .fundamental_agent import fundamental_agent as fundamental_engine
 from .sentiment_agent import sentiment_agent as sentiment_engine
 from .valuation_agent import valuation_agent as valuation_engine
 
 
 @hushh_tool(scope=ConsentScope.AGENT_KAI_ANALYZE, name="perform_fundamental_analysis")
-async def perform_fundamental_analysis(ticker: str) -> Dict[str, Any]:
+async def perform_fundamental_analysis(ticker: str, language: str = "en") -> Dict[str, Any]:
     """
     Analyze business fundamentals (SEC filings, financial health, moat).
+    Args:
+        ticker: Stock ticker symbol (e.g., AAPL)
+        language: BCP-47 language code for response language (e.g., 'en', 'hi', 'fr')
     """
     ctx = HushhContext.current()
     if not ctx:
@@ -30,13 +32,12 @@ async def perform_fundamental_analysis(ticker: str) -> Dict[str, Any]:
     print(f"🔧 Tool invoked: perform_fundamental_analysis for {ticker}")
 
     # Delegate to the fundamental engine
-    # Note: The engine's analyze method is async
     try:
         insight = await fundamental_engine.analyze(
             ticker=ticker, user_id=ctx.user_id, consent_token=ctx.consent_token
         )
 
-        # Convert dataclass/result to dict
+        # Fixed indentation here
         return {
             "summary": insight.summary,
             "business_moat": insight.business_moat,
@@ -44,16 +45,20 @@ async def perform_fundamental_analysis(ticker: str) -> Dict[str, Any]:
             "recommendation": insight.recommendation,
             "confidence": insight.confidence,
             "metrics": insight.quant_metrics,
-        }
+            "language": language,
+        }    
     except Exception as e:
         return {"error": f"Fundamental analysis failed: {str(e)}"}
 
 
 @hushh_tool(scope=ConsentScope.AGENT_KAI_ANALYZE, name="perform_sentiment_analysis")
-async def perform_sentiment_analysis(ticker: str) -> Dict[str, Any]:
+async def perform_sentiment_analysis(ticker: str, language: str = "en") -> Dict[str, Any]:
     """
     Analyze market sentiment (News, Social Media, Analyst Ratings).
-    """
+    Args:
+        ticker: Stock ticker symbol (e.g., AAPL)
+        language: BCP-47 language code for response language (e.g., 'en', 'hi', 'fr')
+    """   
     ctx = HushhContext.current()
     if not ctx:
         raise PermissionError("No active context")
@@ -72,15 +77,19 @@ async def perform_sentiment_analysis(ticker: str) -> Dict[str, Any]:
             "recommendation": insight.recommendation,
             "confidence": insight.confidence,
             "news_highlights": insight.key_news[:3] if hasattr(insight, "key_news") else [],
+            "language": language,
         }
     except Exception as e:
         return {"error": f"Sentiment analysis failed: {str(e)}"}
 
 
 @hushh_tool(scope=ConsentScope.AGENT_KAI_ANALYZE, name="perform_valuation_analysis")
-async def perform_valuation_analysis(ticker: str) -> Dict[str, Any]:
+async def perform_valuation_analysis(ticker: str, language: str = "en") -> Dict[str, Any]:
     """
     Perform quantitative valuation (DCF, Multiples, Fair Value).
+    Args:
+        ticker: Stock ticker symbol (e.g., AAPL)
+        language: BCP-47 language code for response language (e.g., 'en', 'hi', 'fr')
     """
     ctx = HushhContext.current()
     if not ctx:
@@ -100,6 +109,7 @@ async def perform_valuation_analysis(ticker: str) -> Dict[str, Any]:
             "risk_assessment": insight.risk_assessment,
             "recommendation": insight.recommendation,
             "confidence": insight.confidence,
+            "language": language,
         }
     except Exception as e:
         return {"error": f"Valuation analysis failed: {str(e)}"}


### PR DESCRIPTION
## Summary
Closes #302

The Kai voice agent tools had no language parameter, meaning all
tool responses were always in English regardless of the user's language.

## Changes

### tools.py
- Added `language: str = "en"` parameter to all 3 tool functions
- Added `"language": language` to all 3 return dicts so the LLM
  knows which language to respond in

### agent.py
- Added `import re`
- Added `_detect_language()` method using unicode range detection
  covering Hindi, Arabic, Japanese, Chinese, Korean, Russian, Greek
- Updated `handle_message()` to detect language from incoming message
  and inject it into the LLM context before running tools
- Added `"language"` field to the response dict

### agent.yaml
- Added `language` input field with default "en"
- Updated voice format rule to respond in the user's language

## How it works
1. User sends a message in any language
2. `_detect_language()` detects the script using unicode ranges
3. The detected language code is injected into the message context
4. The LLM calls all tools with `language=detected_code`
5. All tools return the language code in their response
6. The LLM responds to the user in their own language

## Languages supported
Hindi, Arabic, Japanese, Chinese, Korean, Russian, Greek, English (default)