### PR TITLE
chore: add pre-pr CI mirror and explicit UAT cadence

### DIFF
--- a/.codex/skills/codex-skill-authoring/scripts/skill_lint.py
+++ b/.codex/skills/codex-skill-authoring/scripts/skill_lint.py
@@ -60,6 +60,7 @@ EXPECTED_WORKFLOW_IDS = [
     "analytics-observability-review",
     "bug-triage",
     "ci-watch-and-heal",
+    "pre-pr-readiness",
     "security-consent-audit",
     "mobile-parity-check",
     "release-readiness",

--- a/.codex/skills/repo-context/scripts/repo_scan.py
+++ b/.codex/skills/repo-context/scripts/repo_scan.py
@@ -72,6 +72,7 @@ REQUIRED_WORKFLOWS = [
     "analytics-observability-review",
     "bug-triage",
     "ci-watch-and-heal",
+    "pre-pr-readiness",
     "security-consent-audit",
     "mobile-parity-check",
     "release-readiness",

--- a/.codex/skills/repo-operations/SKILL.md
+++ b/.codex/skills/repo-operations/SKILL.md
@@ -64,23 +64,25 @@ Non-owned surfaces:
 8. Monitor the resulting workflow chain until terminal success or a concrete blocker.
 9. For core authority surfaces, the task is not complete while GitHub still shows any relevant run for the touched SHA as `queued`, `in_progress`, or `requested`.
 10. Core authority surfaces are `PR Validation`, `Queue Validation`, `Main Post-Merge Smoke`, `Deploy to UAT`, and any RCA-triggered release-authority rerun for the same SHA.
-11. After a merge to `main`, continue monitoring through `Main Post-Merge Smoke` and downstream `Deploy to UAT`; a merged PR with an active post-merge or UAT chain is still in progress.
-12. If a core run fails, default to the smallest safe repair and rerun loop before declaring a blocker. Only stop early for a real permissions, product, or platform boundary.
-13. Default runtime launch behavior must be visible separate OS terminal windows, not hidden Codex sessions.
-14. For local app work, prefer separate `./bin/hushh terminal backend --mode local --reload` and `./bin/hushh terminal web --mode <mode>` commands unless the user explicitly asks for something else.
-15. Use hidden long-lived Codex sessions only for background monitoring, one-off debugging, or when a visible terminal is not desired.
-16. Use `./bin/hushh terminal stack --mode local` only when one combined visible terminal is explicitly preferred.
-17. Default branch policy: continue work on the user's active development branch. Do not create a new temporary branch for incremental fixes, validation follow-ups, or polish work unless the user explicitly asks for branch isolation.
-18. Create a new branch only when one of these is true:
+11. Before opening or updating a pull request, run `./bin/hushh codex pre-pr` as the canonical local mirror of `PR Validation` and `CI Status Gate`.
+12. Treat user intent literally: `merge to main` means land the change and monitor through `Main Post-Merge Smoke` only; do not dispatch UAT unless the user explicitly asks to deploy to UAT.
+13. Treat `deploy to UAT` as a separate cadence: land the change on `main`, identify the exact green `main` SHA, manually dispatch `Deploy to UAT` for that SHA, then monitor the deploy chain to terminal state.
+14. If a core run fails, default to the smallest safe repair and rerun loop before declaring a blocker. Only stop early for a real permissions, product, or platform boundary.
+15. Default runtime launch behavior must be visible separate OS terminal windows, not hidden Codex sessions.
+16. For local app work, prefer separate `./bin/hushh terminal backend --mode local --reload` and `./bin/hushh terminal web --mode <mode>` commands unless the user explicitly asks for something else.
+17. Use hidden long-lived Codex sessions only for background monitoring, one-off debugging, or when a visible terminal is not desired.
+18. Use `./bin/hushh terminal stack --mode local` only when one combined visible terminal is explicitly preferred.
+19. Default branch policy: continue work on the user's active development branch. Do not create a new temporary branch for incremental fixes, validation follow-ups, or polish work unless the user explicitly asks for branch isolation.
+20. Create a new branch only when one of these is true:
    - the fix is a post-merge blocker and must start from the latest `main`
    - the repo workflow requires an isolated hotfix from `main`
    - the current branch contains unrelated in-flight work that would make the fix unsafe to ship
-19. After a merge-driven hotfix is complete, delete the temporary branch remotely and locally when it is safe to do so, then return local state to the user's normal working branch or `main`; do not leave Codex parked on a temporary branch.
-20. If the user has an active development branch, back-sync merged hotfixes into that branch before closing the task so the real working branch does not drift behind `main`.
-21. For CI workflows, branch protection, env/bootstrap, or deploy-authority changes, do a second verification pass after edits instead of trusting the first green run.
-22. For branch protection, merge queue, release authority, or production deploy-governance changes, do a third independent check against live GitHub or runtime state before calling the work complete.
-23. For UAT runtime failures, start with `./bin/hushh codex rca --surface uat --text` so secret drift, legacy runtime mounts, DB drift, and semantic runtime breakage are classified before editing or redeploying.
-24. Treat only core runtime/release surfaces as blocking in the RCA loop: runtime contract, deploy/runtime env contract, DB release contract, semantic UAT verification, and Gmail/voice/auth availability on the release lane. Helper-only drift stays advisory unless it masks one of those surfaces.
+21. After a merge-driven hotfix is complete, delete the temporary branch remotely and locally when it is safe to do so, then return local state to the user's normal working branch or `main`; do not leave Codex parked on a temporary branch.
+22. If the user has an active development branch, back-sync merged hotfixes into that branch before closing the task so the real working branch does not drift behind `main`.
+23. For CI workflows, branch protection, env/bootstrap, or deploy-authority changes, do a second verification pass after edits instead of trusting the first green run.
+24. For branch protection, merge queue, release authority, or production deploy-governance changes, do a third independent check against live GitHub or runtime state before calling the work complete.
+25. For UAT runtime failures, start with `./bin/hushh codex rca --surface uat --text` so secret drift, legacy runtime mounts, DB drift, and semantic runtime breakage are classified before editing or redeploying.
+26. Treat only core runtime/release surfaces as blocking in the RCA loop: runtime contract, deploy/runtime env contract, DB release contract, semantic UAT verification, and Gmail/voice/auth availability on the release lane. Helper-only drift stays advisory unless it masks one of those surfaces.
 
 ## Handoff Rules
 
@@ -97,6 +99,7 @@ Non-owned surfaces:
 
 ```bash
 ./bin/hushh codex ci-status
+./bin/hushh codex pre-pr
 ./bin/hushh codex rca --surface uat --text
 ./bin/hushh docs verify
 ./bin/hushh ci

--- a/.codex/skills/repo-operations/references/operations-surface.md
+++ b/.codex/skills/repo-operations/references/operations-surface.md
@@ -16,6 +16,7 @@ Use this reference to orient DevOps work in `hushh-research`.
 
 ```bash
 ./bin/hushh codex ci-status
+./bin/hushh codex pre-pr
 ./bin/hushh ci
 ./bin/hushh docs verify
 ./bin/hushh sync main
@@ -30,6 +31,7 @@ Use this reference to orient DevOps work in `hushh-research`.
 3. deploy workflow state via repository Actions runs
 4. Cloud Run and Cloud Build only after verifying the repo workflow and env contract
 5. Codex PR check routing via `./bin/hushh codex ci-status`
+6. UAT workflow dispatch from `main` only after the exact green `main` SHA is known
 
 ## Repo invariants
 
@@ -38,7 +40,7 @@ Use this reference to orient DevOps work in `hushh-research`.
 3. `CI Status Gate` is the blocking queue/PR check on pre-merge commits.
 4. `Main Freshness Gate` is advisory on PRs and blocking on `merge_group`.
 5. `Main Post-Merge Smoke Gate` is the deploy-authority check on the real `main` SHA.
-6. UAT deploys from a green `main` SHA that passed post-merge smoke.
+6. UAT deploys only from an explicitly chosen green `main` SHA that passed post-merge smoke.
 7. Production deploys from an approved green `main` SHA that passed post-merge smoke.
 
 ## Review bypass semantics

--- a/.codex/skills/repo-operations/scripts/ci_monitor.py
+++ b/.codex/skills/repo-operations/scripts/ci_monitor.py
@@ -237,7 +237,7 @@ def _build_payload(pr_payload: dict[str, Any]) -> OrderedDict[str, Any]:
     elif pending_checks:
         completion_gate = OrderedDict(
             task_complete=False,
-            reason="Core checks are still active. Keep monitoring until GitHub reaches a terminal state; after merge, continue through Main Post-Merge Smoke and Deploy to UAT.",
+            reason="Core checks are still active. Keep monitoring until GitHub reaches a terminal state; after merge, continue through Main Post-Merge Smoke, and only continue into Deploy to UAT if a UAT deployment was explicitly requested or already dispatched.",
         )
     elif overall_status == "booting":
         completion_gate = OrderedDict(
@@ -247,7 +247,7 @@ def _build_payload(pr_payload: dict[str, Any]) -> OrderedDict[str, Any]:
     else:
         completion_gate = OrderedDict(
             task_complete=True,
-            reason="Core PR checks are terminal green. If the change has landed on main, continue monitoring post-merge smoke and downstream UAT before closing the task.",
+            reason="Core PR checks are terminal green. If the change has landed on main, continue monitoring post-merge smoke before closing the task; proceed to Deploy to UAT only when that deployment was explicitly requested.",
         )
     next_actions = OrderedDict()
     next_actions["route_task"] = "./bin/hushh codex route-task ci-watch-and-heal"

--- a/.codex/skills/repo-operations/scripts/pre_pr_readiness.py
+++ b/.codex/skills/repo-operations/scripts/pre_pr_readiness.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _git_branch() -> str:
+    result = subprocess.run(
+        ["git", "branch", "--show-current"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return (result.stdout or "").strip() or "detached-head"
+
+
+def _run(
+    command: list[str],
+    *,
+    stream_output: bool,
+) -> dict[str, Any]:
+    if stream_output:
+        result = subprocess.run(
+            command,
+            cwd=REPO_ROOT,
+            text=True,
+            check=False,
+        )
+        return {
+            "command": command,
+            "returncode": result.returncode,
+            "ok": result.returncode == 0,
+            "stdout_tail": "",
+            "stderr_tail": "",
+        }
+
+    result = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return {
+        "command": command,
+        "returncode": result.returncode,
+        "ok": result.returncode == 0,
+        "stdout_tail": result.stdout[-4000:],
+        "stderr_tail": result.stderr[-4000:],
+    }
+
+
+def _render_text(payload: dict[str, Any]) -> str:
+    lines = [
+        f"Workflow: {payload['workflow_id']}",
+        f"Status: {payload['status']}",
+        f"Branch: {payload['branch']}",
+        f"Mirrors GitHub: {', '.join(payload['mirrors_workflows'])}",
+        f"Include advisory: {payload['include_advisory']}",
+        "Commands:",
+    ]
+    for command in payload["commands"]:
+        lines.append(f"- {command}")
+    if payload.get("next_actions"):
+        lines.append("Next actions:")
+        for item in payload["next_actions"]:
+            lines.append(f"- {item}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run the local CI surface that mirrors the GitHub PR gate before opening or updating a pull request."
+    )
+    parser.add_argument("--include-advisory", action="store_true", help="Include the advisory CI lane after the blocking gate.")
+    parser.add_argument("--report-path", help="Optional path for a machine-readable report.")
+    parser.add_argument("--json", action="store_true", help="Emit JSON output.")
+    parser.add_argument("--text", action="store_true", help="Emit text output (default).")
+    args = parser.parse_args()
+
+    json_mode = bool(args.json)
+    ci_command = ["./bin/hushh", "ci"]
+    if args.include_advisory:
+        ci_command.append("--include-advisory")
+
+    if not json_mode:
+        print("Running the local PR mirror before opening or updating a pull request.")
+        print(f"Command: {' '.join(ci_command)}")
+
+    result = _run(ci_command, stream_output=not json_mode)
+    payload: OrderedDict[str, Any] = OrderedDict(
+        workflow_id="pre-pr-readiness",
+        status="passing" if result["ok"] else "failing",
+        branch=_git_branch(),
+        mirrors_workflows=["PR Validation", "CI Status Gate"],
+        include_advisory=args.include_advisory,
+        commands=[" ".join(ci_command)],
+        reports=OrderedDict(),
+        command_result=OrderedDict(
+            returncode=result["returncode"],
+            stdout_tail=result["stdout_tail"],
+            stderr_tail=result["stderr_tail"],
+        ),
+        next_actions=[
+            "Open or update the pull request once the local mirror is green."
+            if result["ok"]
+            else "Fix the failing local check before opening or updating the pull request.",
+            "Use ./bin/hushh codex ci-status --watch after the PR opens so GitHub reaches a terminal state.",
+        ],
+    )
+
+    if args.report_path:
+        report_path = Path(args.report_path)
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        payload["reports"]["report_path"] = str(report_path)
+
+    if json_mode:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(_render_text(payload))
+
+    return int(result["returncode"])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/skills/repo-operations/skill.json
+++ b/.codex/skills/repo-operations/skill.json
@@ -21,6 +21,7 @@
     "subtree-upstream-governance"
   ],
   "task_types": [
+    "pre-pr-readiness",
     "ci-watch-and-heal",
     "release-readiness",
     "mobile-parity-check",
@@ -35,6 +36,7 @@
   ],
   "required_commands": [
     "./bin/hushh codex ci-status",
+    "./bin/hushh codex pre-pr",
     "./bin/hushh codex rca --surface uat --text",
     "./bin/hushh docs verify",
     "./bin/hushh ci",
@@ -46,6 +48,7 @@
       "id": "repo-operations",
       "commands": [
         "./bin/hushh codex ci-status",
+        "./bin/hushh codex pre-pr",
         "./bin/hushh codex rca --surface uat --text",
         "./bin/hushh docs verify",
         "./bin/hushh ci",

--- a/.codex/workflows/ci-watch-and-heal/PLAYBOOK.md
+++ b/.codex/workflows/ci-watch-and-heal/PLAYBOOK.md
@@ -11,8 +11,8 @@ Monitor PR checks live, classify failures into the correct owner skill, and keep
 1. Start with `repo-operations` and use `owner skill only` as the default narrow path.
 2. Run `./bin/hushh codex ci-status --watch` on the active PR or current branch.
 3. Distinguish the failing stage before editing code:
-   `PR Validation` is developer feedback, `Queue Validation` is the authoritative pre-merge blocker, and `Main Post-Merge Smoke` is the deploy-authority blocker on the real `main` SHA.
-4. If the change lands on `main`, continue the same monitoring chain through `Main Post-Merge Smoke` and downstream `Deploy to UAT`; do not call the task complete while any core run for the touched SHA is still queued or in progress.
+   `PR Validation` is developer feedback, `Queue Validation` is the authoritative pre-merge blocker, and `Main Post-Merge Smoke` is the merge-to-main completion gate on the real `main` SHA.
+4. If the change lands on `main`, continue the monitoring chain through `Main Post-Merge Smoke`. Continue into `Deploy to UAT` only when the user explicitly asked for a UAT deployment or that dispatch has already started.
 5. Route each failed check through the owner skill suggested by the monitor before editing code.
 6. Pull the failing job logs, apply the smallest fix that addresses the actual check failure, and rerun the local parity bundle.
 7. Capture every field listed in `impact_fields` before calling the work complete.
@@ -23,4 +23,4 @@ Monitor PR checks live, classify failures into the correct owner skill, and keep
 2. fixing the wrong subsystem because the failing job was not classified first
 3. treating queue failures and post-merge smoke failures as the same class of problem
 4. rerunning once and walking away before terminal green
-5. treating a merged PR as done while downstream UAT is still active
+5. treating every merge as an implicit UAT deploy instead of a separate explicit cadence

--- a/.codex/workflows/ci-watch-and-heal/workflow.json
+++ b/.codex/workflows/ci-watch-and-heal/workflow.json
@@ -1,7 +1,7 @@
 {
   "id": "ci-watch-and-heal",
   "title": "CI Watch And Heal",
-  "goal": "Monitor PR, merge-queue, post-merge smoke, and downstream UAT release checks live, classify failures into the correct owner skill, pull the failing job logs, and keep the fix-and-rerun loop tight until the full core workflow chain reaches a terminal state or a hard blocker is identified.",
+  "goal": "Monitor PR, merge-queue, post-merge smoke, and explicitly dispatched UAT release checks live, classify failures into the correct owner skill, pull the failing job logs, and keep the fix-and-rerun loop tight until the relevant core workflow chain reaches a terminal state or a hard blocker is identified.",
   "owner_skill": "repo-operations",
   "default_spoke": null,
   "task_type": "ci-watch-and-heal",
@@ -60,6 +60,6 @@
     "not routing the failed job to the correct owner skill",
     "not distinguishing PR feedback from queue authority or post-merge deploy authority",
     "stopping after rerun without monitoring terminal state",
-    "calling the task complete while post-merge smoke or downstream UAT is still running"
+    "treating every merge as an implicit downstream UAT deploy instead of a separate explicit dispatch"
   ]
 }

--- a/.codex/workflows/pre-pr-readiness/PLAYBOOK.md
+++ b/.codex/workflows/pre-pr-readiness/PLAYBOOK.md
@@ -1,0 +1,21 @@
+# Pre-PR Readiness
+
+Use this workflow pack before opening or updating a pull request.
+
+## Goal
+
+Run the same local blocking CI surface that GitHub expects for `PR Validation` and `CI Status Gate`, so failures are found locally first.
+
+## Steps
+
+1. Start with `repo-operations`.
+2. Run `./bin/hushh codex pre-pr`.
+3. Use `./bin/hushh codex pre-pr --include-advisory` only when you intentionally want the wider local release/readiness lane.
+4. If the local mirror fails, fix the failing surface before opening or updating the pull request.
+5. After the pull request opens, switch to `./bin/hushh codex ci-status --watch` and monitor GitHub to terminal state.
+
+## Common Drift Risks
+
+1. opening a pull request without running the local mirror
+2. adding GitHub-required checks without keeping the local mirror aligned
+3. using advisory checks as the default pre-PR blocker

--- a/.codex/workflows/pre-pr-readiness/workflow.json
+++ b/.codex/workflows/pre-pr-readiness/workflow.json
@@ -1,0 +1,56 @@
+{
+  "id": "pre-pr-readiness",
+  "title": "Pre-PR Readiness",
+  "goal": "Run the local CI surface that mirrors GitHub PR validation before opening or updating a pull request, so the developer sees CI Status Gate failures locally first.",
+  "owner_skill": "repo-operations",
+  "default_spoke": null,
+  "task_type": "pre-pr-readiness",
+  "affected_surfaces": [
+    "bin",
+    "scripts",
+    ".github/workflows",
+    "docs/reference/operations"
+  ],
+  "required_reads": [
+    "docs/reference/operations/ci.md",
+    "docs/reference/operations/cli.md",
+    ".codex/skills/repo-operations/references/agent-trigger-policy.md"
+  ],
+  "required_commands": [
+    "./bin/hushh codex route-task pre-pr-readiness",
+    "./bin/hushh codex pre-pr",
+    "./bin/hushh codex pre-pr --include-advisory"
+  ],
+  "verification_bundle": {
+    "id": "pre-pr-readiness",
+    "commands": [
+      "./bin/hushh codex pre-pr"
+    ],
+    "tests": [
+      "./bin/hushh ci"
+    ]
+  },
+  "deliverables": [
+    "local CI mirror result",
+    "blocking-vs-advisory lane choice",
+    "pre-PR readiness summary"
+  ],
+  "impact_fields": [
+    "Workflow mirrored",
+    "Blocking checks passed",
+    "Advisory lane included",
+    "Verification commands executed"
+  ],
+  "handoff_chain": [
+    "repo-operations",
+    "quality-contracts",
+    "frontend",
+    "backend",
+    "docs-governance"
+  ],
+  "common_failures": [
+    "opening or updating a PR without running the local mirror first",
+    "inventing a second local CI path instead of reusing ./bin/hushh ci",
+    "treating advisory checks as blocking by default"
+  ]
+}

--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -1,13 +1,6 @@
 name: Deploy to UAT
 
 on:
-  workflow_run:
-    workflows:
-      - "Main Post-Merge Smoke"
-    types:
-      - completed
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       scope:
@@ -40,18 +33,16 @@ env:
   PROTOCOL_PYTHON: ${{ github.workspace }}/consent-protocol/.venv/bin/python
 
 concurrency:
-  group: deploy-uat-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.event.inputs.sha || github.run_id }}
+  group: deploy-uat-${{ github.event.inputs.sha || github.run_id }}
   cancel-in-progress: false
 
 jobs:
   deploy:
     name: Deploy UAT Scope
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')
 
     steps:
       - name: Assert manual dispatch originates from main
-        if: github.event_name == 'workflow_dispatch'
         shell: bash
         run: |
           set -euo pipefail
@@ -67,7 +58,6 @@ jobs:
           ref: main
 
       - name: Assert manual UAT dispatch actor policy
-        if: github.event_name == 'workflow_dispatch'
         shell: bash
         run: |
           set -euo pipefail
@@ -78,9 +68,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ "${GITHUB_EVENT_NAME}" = "workflow_run" ]; then
-            DEPLOY_SHA="${{ github.event.workflow_run.head_sha }}"
-          elif [ -n "${{ github.event.inputs.sha }}" ]; then
+          if [ -n "${{ github.event.inputs.sha }}" ]; then
             DEPLOY_SHA="${{ github.event.inputs.sha }}"
           else
             git fetch --no-tags origin main
@@ -127,11 +115,7 @@ jobs:
         id: scope
         shell: bash
         run: |
-          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            SCOPE="${{ github.event.inputs.scope }}"
-          else
-            SCOPE="all"
-          fi
+          SCOPE="${{ github.event.inputs.scope }}"
 
           case "$SCOPE" in
             backend)

--- a/bin/hushh
+++ b/bin/hushh
@@ -94,6 +94,7 @@ Usage:
   ./bin/hushh codex route-task <workflow-id> [--json|--text] [--verbose]
   ./bin/hushh codex impact <workflow-id> [--path <repo-path>]... [--json|--text] [--verbose]
   ./bin/hushh codex list-workflows [--json|--text] [--verbose]
+  ./bin/hushh codex pre-pr [--include-advisory] [--report-path <path>] [--json|--text]
   ./bin/hushh codex ci-status [--pr <number>|--branch <name>] [--watch] [--interval <seconds>] [--timeout <seconds>] [--json|--text]
   ./bin/hushh codex audit [--json|--text]
   ./bin/hushh codex rca --surface <uat|runtime|ci> [--project <gcp-project>] [--region <region>] [--backend-service <name>] [--frontend-service <name>] [--backend-url <url>] [--frontend-url <url>] [--report-path <path>] [--json|--text]
@@ -476,6 +477,12 @@ run_codex() {
     impact)
       [ "${#args[@]}" -ge 1 ] || die "codex impact requires <workflow-id>"
       exec python3 "$REPO_ROOT/.codex/skills/repo-context/scripts/repo_scan.py" impact "${args[@]}" "$format_flag"
+      ;;
+    pre-pr)
+      if [ "${#args[@]}" -gt 0 ]; then
+        exec python3 "$REPO_ROOT/.codex/skills/repo-operations/scripts/pre_pr_readiness.py" "${args[@]}" "$format_flag"
+      fi
+      exec python3 "$REPO_ROOT/.codex/skills/repo-operations/scripts/pre_pr_readiness.py" "$format_flag"
       ;;
     ci-status)
       if [ "${#args[@]}" -gt 0 ]; then

--- a/contributing.md
+++ b/contributing.md
@@ -109,7 +109,7 @@ Those are real, but they are not part of the normal first-PR path. If you need t
 Common checks:
 
 ```bash
-./bin/hushh ci
+./bin/hushh codex pre-pr
 ./bin/hushh docs verify
 cd hushh-webapp && npm run verify:docs
 ```

--- a/docs/guides/advanced-ops.md
+++ b/docs/guides/advanced-ops.md
@@ -56,13 +56,13 @@ The blocking CI surface stays intentionally small:
 Canonical local parity run:
 
 ```bash
-./bin/hushh ci
+./bin/hushh codex pre-pr
 ```
 
 Advisory checks remain opt-in:
 
 ```bash
-./bin/hushh ci --include-advisory
+./bin/hushh codex pre-pr --include-advisory
 ```
 
 ## Deploy
@@ -78,7 +78,7 @@ Recommended sequence:
 bash scripts/ci/orchestrate.sh all
 
 # merge the approved change into main
-# UAT auto-deploys the successful main SHA
+# trigger UAT manually only when you explicitly want hosted validation on that green main SHA
 ```
 
 That workflow is wired through [`.github/workflows/deploy-uat.yml`](../../.github/workflows/deploy-uat.yml), which now checks:

--- a/docs/reference/operations/README.md
+++ b/docs/reference/operations/README.md
@@ -47,6 +47,7 @@ Use the root CLI for agent-first onboarding and deterministic workflow routing:
 - `./bin/hushh codex list-workflows`
 - `./bin/hushh codex route-task <workflow-id>`
 - `./bin/hushh codex impact <workflow-id> [--path <repo-path>]`
+- `./bin/hushh codex pre-pr`
 - `./bin/hushh codex ci-status [--watch]`
 - `./bin/hushh codex audit`
 

--- a/docs/reference/operations/branch-governance.md
+++ b/docs/reference/operations/branch-governance.md
@@ -8,7 +8,7 @@ flowchart LR
   feature["feature / fix / dev branches"]
   main["main"]
   green["Green main SHA"]
-  uat["UAT deploy<br/>auto from exact SHA"]
+  uat["UAT deploy<br/>manual exact SHA"]
   prod["Production deploy<br/>manual chosen SHA"]
   feature --> main --> green
   green --> uat
@@ -20,7 +20,7 @@ This repo now runs on one integration branch plus SHA-based environment deployme
 | Lane | Purpose | Default policy |
 |---|---|---|
 | `main` | Team integration branch | Every feature PR targets `main` |
-| UAT | Hosted validation environment | Auto-deploys the exact green `main` SHA |
+| UAT | Hosted validation environment | Manual deploy of an exact green `main` SHA |
 | Production | Live user traffic | Manual deploy of an approved green `main` SHA |
 
 ## Working Rules
@@ -31,7 +31,7 @@ This repo now runs on one integration branch plus SHA-based environment deployme
 4. Create a new branch only when isolation is materially required, such as a post-merge hotfix from `main`, a deploy blocker that must land independently, or unrelated in-flight changes on the current branch.
 5. After an isolated hotfix lands, return local work to the normal development branch or `main` and delete the temporary branch after rollout validation.
 6. Do not use `deploy_uat` or `deploy` as release branches; they are retired from the deployment path.
-7. UAT deploys only from a successful `Main Post-Merge Smoke` run on `main` and uses that exact commit SHA.
+7. UAT deploys only from a successful `Main Post-Merge Smoke` run on `main` and uses an explicitly chosen exact green commit SHA.
 8. Production deploys only from a manually chosen SHA that is reachable from `origin/main` and already green in CI.
 9. Do not open release PRs into environment branches; the deployment source of truth is `main`.
 
@@ -54,9 +54,9 @@ Before deleting a local backup branch, classify its unique commits as:
 
 ### UAT
 
-1. Auto-deploys only after a successful `Main Post-Merge Smoke` push run on `main`.
-2. The workflow checks out the exact green `main` SHA from that CI run.
-3. Manual dispatch is limited to `kushaltrivedi5`, `Akash-292`, and `RGlodAkshat` for redeploying a chosen green `main` SHA.
+1. UAT deploys only through a manual workflow dispatch with an explicit green `main` SHA.
+2. The workflow checks out that exact chosen green `main` SHA.
+3. Manual dispatch is limited to `kushaltrivedi5`, `Akash-292`, and `RGlodAkshat`.
 4. Workflow preflight fails if the requested SHA is not reachable from `origin/main`.
 5. Workflow preflight also fails if the SHA does not already have a successful `Main Post-Merge Smoke Gate`.
 
@@ -72,7 +72,7 @@ Before deleting a local backup branch, classify its unique commits as:
 
 1. Create the hotfix branch from the latest `main`.
 2. Merge the hotfix into `main`.
-3. Let UAT auto-deploy the new green `main` SHA, or manually redeploy that same SHA to UAT if needed.
+3. If hosted validation is required, manually deploy that same green `main` SHA to UAT.
 4. If another blocker appears after that rollout, create a new hotfix branch from the updated `main`.
 5. Do not reuse an already-merged hotfix branch for a second fix.
 

--- a/docs/reference/operations/ci.md
+++ b/docs/reference/operations/ci.md
@@ -22,7 +22,7 @@ flowchart TB
   subgraph release["Environment deployment lanes"]
     green["Green main SHA"]
     smoke["Main Post-Merge Smoke<br/>deploy-authority on main"]
-    uat["Deploy to UAT<br/>auto from workflow_run"]
+    uat["Deploy to UAT<br/>manual exact-SHA dispatch"]
     prod["Deploy to Production<br/>manual SHA dispatch"]
   end
 
@@ -36,11 +36,20 @@ flowchart TB
   green --> prod
 ```
 
-This document describes the queue-first CI model and how to stay aligned with it so code changes do not fail CI or deploy from the wrong authority gate. Run local checks before every commit.
+This document describes the queue-first CI model and how to stay aligned with it so code changes do not fail CI or deploy from the wrong authority gate. Run the local mirror before opening or updating a pull request, and before commits that touch core authority surfaces.
 
 **Workflow files:** [.github/workflows/ci.yml](../../../.github/workflows/ci.yml), [.github/workflows/queue-validation.yml](../../../.github/workflows/queue-validation.yml), [.github/workflows/main-post-merge-smoke.yml](../../../.github/workflows/main-post-merge-smoke.yml)  
-**Local mirror:** [`./bin/hushh ci`](./cli.md)  
+**Pre-PR mirror:** [`./bin/hushh codex pre-pr`](./cli.md)  
+**Underlying local lane:** [`./bin/hushh ci`](./cli.md)  
 **Orchestrator:** [scripts/ci/orchestrate.sh](../../../scripts/ci/orchestrate.sh)
+
+Canonical pre-PR command:
+
+```bash
+./bin/hushh codex pre-pr
+```
+
+This command runs the same blocking local CI surface that feeds GitHub `PR Validation` and `CI Status Gate`. Use `./bin/hushh codex pre-pr --include-advisory` only when you intentionally want the wider non-blocking readiness lane too.
 
 ## Monitoring Rule
 
@@ -50,7 +59,7 @@ Minimum expectation:
 
 1. watch the immediate `PR Validation`, `Queue Validation`, or dispatched workflow
 2. if `main` goes green, watch `Main Post-Merge Smoke`
-3. if post-merge smoke goes green, watch downstream `Deploy to UAT`
+3. if a UAT deployment was explicitly requested, dispatch `Deploy to UAT` for that same green `main` SHA and watch it to terminal state
 4. report the exact failing workflow, job, and step if anything fails
 5. do not stop at "triggered" or "queued"
 6. if the failure is within the CI/deploy/policy surface, move into fix-and-rerun mode until the change is green or a hard blocker is identified
@@ -77,13 +86,13 @@ Use this command when the failure is already on a core authority surface and the
 Canonical watcher:
 
 ```bash
-scripts/ci/watch-gh-workflow-chain.sh --run-id <ci-run-id> --follow-workflow "Main Post-Merge Smoke" --follow-workflow "Deploy to UAT"
+scripts/ci/watch-gh-workflow-chain.sh --run-id <ci-run-id> --follow-workflow "Main Post-Merge Smoke"
 ```
 
 Local daemon form:
 
 ```bash
-scripts/ci/watch-gh-workflow-chain.sh --run-id <ci-run-id> --follow-workflow "Main Post-Merge Smoke" --follow-workflow "Deploy to UAT" --daemonize
+scripts/ci/watch-gh-workflow-chain.sh --run-id <ci-run-id> --follow-workflow "Main Post-Merge Smoke" --daemonize
 ```
 
 For deploy-only monitoring:
@@ -233,7 +242,7 @@ Post-merge smoke remains the deployment eligibility gate for `main`.
 
 1. `main` is the only integration branch for day-to-day development.
 2. A successful `Main Post-Merge Smoke` run produces the only deployable source of truth: the green `main` SHA.
-3. UAT auto-deploys from that green `main` SHA through `.github/workflows/deploy-uat.yml`.
+3. UAT deploys only by an explicit manual dispatch of that green `main` SHA through `.github/workflows/deploy-uat.yml`.
 4. Manual UAT dispatch is limited to `kushaltrivedi5`, `Akash-292`, and `RGlodAkshat`.
 5. Production deploys only through a manual SHA dispatch in `.github/workflows/deploy-production.yml`, and only `kushaltrivedi5` may trigger it.
 6. Manual UAT or production redeploys must use a SHA that is reachable from `origin/main` and already green in post-merge smoke.
@@ -241,13 +250,14 @@ Post-merge smoke remains the deployment eligibility gate for `main`.
 
 Deploy to UAT is expected to behave as a closed-loop release lane:
 
-1. sync canonical secrets
-2. capture last healthy revisions
-3. deploy changed surfaces
-4. verify runtime mounts and semantic behavior
-5. retry once on transient readiness
-6. roll back only the failing changed surface
-7. publish release artifacts with revisions, reports, and final status
+1. start from an explicitly chosen green `main` SHA
+2. sync canonical secrets
+3. capture last healthy revisions
+4. deploy changed surfaces
+5. verify runtime mounts and semantic behavior
+6. retry once on transient readiness
+7. roll back only the failing changed surface
+8. publish release artifacts with revisions, reports, and final status
 
 See [Branch Governance](./branch-governance.md).
 
@@ -368,10 +378,10 @@ Minimum checks for streaming changes:
 ./bin/hushh ci
 ```
 
-This script:
+This script, which also powers `./bin/hushh codex pre-pr`:
 
 1. Validates required files (e.g. `package-lock.json`, `next.config.ts`, `pyproject.toml`, `uv.lock`, generated runtime artifacts, test files).
-2. Checks Node (20+) and Python (3.13) and uses `uv` as the canonical backend toolchain.
+2. Checks Node (24+) and Python (3.13) and uses `uv` as the canonical backend toolchain.
 3. Runs **frontend** checks: install, `tsc`, lint, Next build, audit-budget gate, curated test suite.
 4. Runs **backend** checks: shared parity verification, install, Ruff, mypy, Bandit, curated test suite.
 5. Runs **integration**: route/runtime contract verification.
@@ -410,6 +420,7 @@ Secret-scan note:
 | Frontend | `cd hushh-webapp && npm ci && npm run typecheck && npm run lint -- --max-warnings=0 && npm run build && npm run test:ci` |
 | Backend | `cd consent-protocol && uv sync --frozen --group dev && bash scripts/sync_runtime_requirements.sh --check && uv run ruff check . && uv run mypy --config-file pyproject.toml --ignore-missing-imports && uv run bandit -r hushh_mcp/ api/ -c pyproject.toml -ll && bash scripts/run-test-ci.sh` |
 | Integration | `bash scripts/ci/docs-parity-check.sh` |
+| Pre-PR mirror | `./bin/hushh codex pre-pr` |
 | All | `./bin/hushh ci` |
 
 ---

--- a/docs/reference/operations/cli.md
+++ b/docs/reference/operations/cli.md
@@ -20,6 +20,7 @@ Use package-local commands only when you are working inside a package on purpose
 <repo-root>/bin/hushh codex onboard
 <repo-root>/bin/hushh codex route-task repo-orientation
 <repo-root>/bin/hushh codex impact repo-orientation
+<repo-root>/bin/hushh codex pre-pr
 <repo-root>/bin/hushh codex ci-status --watch
 <repo-root>/bin/hushh web
 <repo-root>/bin/hushh web --mode uat
@@ -41,6 +42,7 @@ Use package-local commands only when you are working inside a package on purpose
 <repo-root>/bin/hushh codex scan summary
 <repo-root>/bin/hushh codex scan section skills
 <repo-root>/bin/hushh codex list-workflows
+<repo-root>/bin/hushh codex pre-pr --include-advisory
 <repo-root>/bin/hushh codex ci-status
 <repo-root>/bin/hushh codex audit
 <repo-root>/bin/hushh codex rca --surface runtime
@@ -71,3 +73,4 @@ Use package-local commands only when you are working inside a package on purpose
 - Use `uv` as the canonical Python install surface for `consent-protocol`; `requirements*.txt` are generated compatibility artifacts, not contributor commands.
 - Treat `./bin/hushh db verify-release-contract`, `./bin/hushh db verify-uat-schema`, and `./bin/hushh db report-prod-posture` as the authoritative DB governance surface.
 - Use `./bin/hushh codex rca --surface runtime|uat|ci` as the canonical machine-readable RCA surface for core runtime, CI, and UAT release failures.
+- Use `./bin/hushh codex pre-pr` as the canonical pre-PR local mirror of `PR Validation` and `CI Status Gate`; add `--include-advisory` only when you intentionally want the wider readiness lane.


### PR DESCRIPTION
## Summary
- add a canonical codex pre-PR local CI mirror command and workflow pack
- separate merge-to-main from deploy-to-UAT in repo operations policy and docs
- make UAT deployment an explicit manual exact-SHA dispatch instead of an automatic post-merge trigger

## Verification
- python3 -m py_compile .codex/skills/repo-operations/scripts/ci_monitor.py .codex/skills/repo-operations/scripts/pre_pr_readiness.py .codex/skills/codex-skill-authoring/scripts/skill_lint.py .codex/skills/repo-context/scripts/repo_scan.py
- python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py
- ./bin/hushh docs verify
- ./bin/hushh codex audit --text
- ./bin/hushh codex pre-pr --json --report-path tmp/pre-pr-readiness.json