### PR TITLE
chore(ci): unblock fork PR secret scan parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,8 @@ jobs:
         env:
           GITLEAKS_LOG_OPTS: ${{ steps.scan-range.outputs.log_opts }}
           GH_TOKEN: ${{ secrets.GH_SECURITY_ALERTS_TOKEN != '' && secrets.GH_SECURITY_ALERTS_TOKEN || github.token }}
-          REQUIRE_GITHUB_ALERTS_CLEAN: ${{ github.actor == 'dependabot[bot]' && '0' || '1' }}
-          REQUIRE_GITHUB_SECRET_ALERTS_CLEAN: ${{ github.actor == 'dependabot[bot]' && '0' || '1' }}
+          REQUIRE_GITHUB_ALERTS_CLEAN: ${{ github.actor == 'dependabot[bot]' && '0' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && '0' || '1' }}
+          REQUIRE_GITHUB_SECRET_ALERTS_CLEAN: ${{ github.actor == 'dependabot[bot]' && '0' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && '0' || '1' }}
           REQUIRE_GITHUB_DEPENDABOT_ALERTS_CLEAN: "0"
 
   dco-check:

--- a/scripts/ci/github-security-alerts.sh
+++ b/scripts/ci/github-security-alerts.sh
@@ -62,7 +62,11 @@ PR_EVENT_CUTOFF=""
 
 if ! gh api -H 'Accept: application/vnd.github+json' \
   "/repos/${REPO}/secret-scanning/alerts?state=open&per_page=100" >"$SECRET_ALERTS_JSON" 2>"$TMPDIR/secret-errors.log"; then
-  echo "GitHub security alert parity check failed: unable to read secret-scanning alerts."
+  if [ "$STRICT_MODE" = "1" ]; then
+    echo "GitHub security alert parity check failed: unable to read secret-scanning alerts."
+  else
+    echo "GitHub security alert parity advisory: unable to read secret-scanning alerts."
+  fi
   sed 's/^/  /' "$TMPDIR/secret-errors.log" || true
   if grep -q "Resource not accessible by integration" "$TMPDIR/secret-errors.log"; then
     echo "  Hint: set a repo secret like GH_SECURITY_ALERTS_TOKEN with a PAT that can read secret-scanning and Dependabot alerts."
@@ -75,7 +79,11 @@ fi
 
 if ! gh api -H 'Accept: application/vnd.github+json' \
   "/repos/${REPO}/dependabot/alerts?state=open&per_page=100" >"$DEPENDABOT_ALERTS_JSON" 2>"$TMPDIR/dependabot-errors.log"; then
-  echo "GitHub security alert parity check failed: unable to read dependabot alerts."
+  if [ "$STRICT_MODE" = "1" ]; then
+    echo "GitHub security alert parity check failed: unable to read dependabot alerts."
+  else
+    echo "GitHub security alert parity advisory: unable to read dependabot alerts."
+  fi
   sed 's/^/  /' "$TMPDIR/dependabot-errors.log" || true
   if grep -q "Resource not accessible by integration" "$TMPDIR/dependabot-errors.log"; then
     echo "  Hint: set a repo secret like GH_SECURITY_ALERTS_TOKEN with a PAT that can read secret-scanning and Dependabot alerts."


### PR DESCRIPTION
## Summary
- make GitHub alert parity advisory for cross-repo PRs
- keep gitleaks blocking in PR Validation
- keep queue/internal security parity strict

## Verification
- bash -n scripts/ci/github-security-alerts.sh
- bash -n scripts/ci/secret-scan.sh
- bash scripts/ci/orchestrate.sh secret
- ./bin/hushh docs verify