### PR TITLE
[codex] tighten RIA onboarding step 2 verified-access gate

### DIFF
--- a/consent-protocol/api/routes/ria.py
+++ b/consent-protocol/api/routes/ria.py
@@ -51,6 +51,10 @@ class RIAOnboardingSubmitRequest(BaseModel):
     force_live_verification: bool = False
 
 
+class RIAOnboardingVerifyNameRequest(BaseModel):
+    query: str = Field(..., min_length=1)
+
+
 class RIAConsentRequestCreate(BaseModel):
     subject_user_id: str = Field(..., min_length=1)
     requester_actor_type: str = Field(default="ria")
@@ -190,6 +194,19 @@ async def submit_onboarding(
         )
     except IAMSchemaNotReadyError as exc:
         return _iam_schema_not_ready_response(str(exc))
+    except RIAIAMPolicyError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+
+
+@router.post("/onboarding/verify-name")
+async def verify_onboarding_name(
+    payload: RIAOnboardingVerifyNameRequest,
+    firebase_uid: str = Depends(require_firebase_auth),
+):
+    service = RIAIAMService()
+    try:
+        _ = firebase_uid
+        return await service.verify_ria_name(payload.query)
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 

--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -23,6 +23,8 @@ from hushh_mcp.services.email_delivery_queue_service import get_email_delivery_q
 from hushh_mcp.services.kai_invite_email_service import get_kai_invite_email_service
 from hushh_mcp.services.ria_verification import (
     FinraVerificationAdapter,
+    NameVerificationResult,
+    RIAIntelligenceStage1LookupAdapter,
     VerificationGateway,
     VerificationResult,
 )
@@ -132,6 +134,7 @@ class _PooledAsyncpgConnection:
 class RIAIAMService:
     def __init__(self) -> None:
         self._verification_gateway = VerificationGateway(FinraVerificationAdapter())
+        self._name_verification_gateway = RIAIntelligenceStage1LookupAdapter()
 
     @staticmethod
     def _runtime_environment() -> str:
@@ -440,7 +443,13 @@ class RIAIAMService:
     @staticmethod
     def _verification_provider_label(result: VerificationResult) -> str:
         provider = str((result.metadata or {}).get("provider") or "").strip().lower()
-        if provider in {"ria_intelligence", "iapd", "dev_allowlist", "advisory_bypass"}:
+        if provider in {
+            "ria_intelligence",
+            "ria_intelligence_stage1",
+            "iapd",
+            "dev_allowlist",
+            "advisory_bypass",
+        }:
             return provider
         return "regulatory_verification"
 
@@ -459,6 +468,7 @@ class RIAIAMService:
         strategy: str | None,
         disclosures_url: str | None,
         require_regulatory_identity: bool,
+        require_advisory_firm_identifiers: bool = True,
     ) -> dict[str, Any]:
         normalized_display_name = (display_name or "").strip()
         if not normalized_display_name:
@@ -510,7 +520,7 @@ class RIAIAMService:
                     status_code=400,
                 )
 
-        if "advisory" in normalized_capabilities:
+        if "advisory" in normalized_capabilities and require_advisory_firm_identifiers:
             if not normalized_advisory_firm_legal_name:
                 raise RIAIAMPolicyError(
                     "advisory_firm_legal_name is required when advisory capability is requested",
@@ -548,6 +558,41 @@ class RIAIAMService:
             "disclosures_url": RIAIAMService._normalize_optional_text(disclosures_url),
             "require_regulatory_identity": bool(require_regulatory_identity),
         }
+
+    @staticmethod
+    def _serialize_name_verification_result(result: NameVerificationResult) -> dict[str, Any]:
+        return {
+            "status": result.status,
+            "matched_name": result.matched_name,
+            "crd_number": result.crd_number,
+            "current_firm": result.current_firm,
+            "sec_number": result.sec_number,
+            "reason": result.reason,
+            "reason_code": result.reason_code,
+            "suggested_names": list(result.suggested_names or []),
+            "provider": result.provider,
+        }
+
+    async def _verify_ria_name_result(
+        self,
+        query: str,
+        *,
+        use_cache: bool = True,
+    ) -> NameVerificationResult:
+        normalized_query = str(query or "").strip()
+        if not normalized_query:
+            raise RIAIAMPolicyError("query is required", status_code=400)
+        return await self._name_verification_gateway.verify_name(
+            query=normalized_query,
+            use_cache=use_cache,
+        )
+
+    async def verify_ria_name(
+        self,
+        query: str,
+    ) -> dict[str, Any]:
+        result = await self._verify_ria_name_result(query, use_cache=True)
+        return self._serialize_name_verification_result(result)
 
     @staticmethod
     def _advisory_status_from_row(row: Any) -> str:
@@ -2102,56 +2147,73 @@ class RIAIAMService:
         primary_firm_role: str | None = None,
         force_live_verification: bool = False,
     ) -> dict[str, Any]:
-        if not display_name.strip():
-            raise RIAIAMPolicyError("display_name is required", status_code=400)
-
-        normalized_requested_capabilities: list[str] = []
-        for capability in requested_capabilities or []:
-            candidate = str(capability or "").strip().lower()
-            if not candidate:
-                continue
-            if candidate not in _ALLOWED_PROFESSIONAL_CAPABILITIES:
-                raise RIAIAMPolicyError(
-                    "requested_capabilities contains unsupported capability",
-                    status_code=400,
-                )
-            if candidate not in normalized_requested_capabilities:
-                normalized_requested_capabilities.append(candidate)
-        if not normalized_requested_capabilities:
-            normalized_requested_capabilities = ["advisory"]
+        prepared = self._prepare_professional_onboarding_inputs(
+            display_name=display_name,
+            requested_capabilities=requested_capabilities or ["advisory"],
+            individual_legal_name=individual_legal_name or legal_name,
+            individual_crd=individual_crd or finra_crd,
+            advisory_firm_legal_name=advisory_firm_legal_name or primary_firm_name,
+            advisory_firm_iapd_number=advisory_firm_iapd_number or sec_iard,
+            broker_firm_legal_name=broker_firm_legal_name,
+            broker_firm_crd=broker_firm_crd,
+            bio=bio,
+            strategy=strategy,
+            disclosures_url=disclosures_url,
+            require_regulatory_identity=False,
+            require_advisory_firm_identifiers=False,
+        )
+        normalized_display_name = str(prepared["display_name"])
+        normalized_requested_capabilities = list(prepared["requested_capabilities"])
+        name_lookup = await self._verify_ria_name_result(normalized_display_name, use_cache=True)
+        if name_lookup.status == "provider_unavailable":
+            raise RIAIAMPolicyError(
+                name_lookup.reason or "RIA name verification provider unavailable.",
+                status_code=503,
+            )
+        if name_lookup.status != "verified" or not self._normalize_optional_text(
+            name_lookup.crd_number
+        ):
+            raise RIAIAMPolicyError(
+                name_lookup.reason
+                or "Advisor name could not be verified against a CRD-backed registration.",
+                status_code=400,
+            )
 
         effective_legal_name = (
-            self._normalize_optional_text(individual_legal_name)
-            or self._normalize_optional_text(legal_name)
-            or display_name.strip()
+            self._normalize_optional_text(name_lookup.matched_name) or normalized_display_name
         )
-        effective_finra_crd = self._normalize_optional_text(
-            individual_crd
-        ) or self._normalize_optional_text(finra_crd)
+        effective_finra_crd = self._normalize_optional_text(name_lookup.crd_number)
         effective_sec_iard = self._normalize_optional_text(
-            advisory_firm_iapd_number
-        ) or self._normalize_optional_text(sec_iard)
-        effective_primary_firm_name = self._normalize_optional_text(
-            advisory_firm_legal_name
-        ) or self._normalize_optional_text(primary_firm_name)
-        effective_broker_firm_name = self._normalize_optional_text(broker_firm_legal_name)
-        effective_broker_firm_crd = self._normalize_optional_text(broker_firm_crd)
-
-        if not effective_legal_name:
-            raise RIAIAMPolicyError(
-                "individual_legal_name is required for regulatory verification",
-                status_code=400,
-            )
-        if not effective_finra_crd:
-            raise RIAIAMPolicyError(
-                "individual_crd is required for regulatory verification",
-                status_code=400,
-            )
-        if "advisory" in normalized_requested_capabilities and not effective_sec_iard:
-            raise RIAIAMPolicyError(
-                "advisory_firm_iapd_number is required for regulatory verification",
-                status_code=400,
-            )
+            name_lookup.sec_number
+        ) or self._normalize_optional_text(prepared.get("advisory_firm_iapd_number"))
+        effective_primary_firm_name = (
+            self._normalize_optional_text(name_lookup.current_firm)
+            or self._normalize_optional_text(prepared.get("advisory_firm_legal_name"))
+            or self._normalize_optional_text(primary_firm_name)
+        )
+        effective_broker_firm_name = self._normalize_optional_text(
+            prepared.get("broker_firm_legal_name")
+        )
+        effective_broker_firm_crd = self._normalize_optional_text(prepared.get("broker_firm_crd"))
+        verification_result = VerificationResult(
+            verified=True,
+            rejected=False,
+            outcome="verified",
+            message="RIA verification succeeded from the Stage 1 name lookup.",
+            expires_at=datetime.now(timezone.utc) + timedelta(days=30),
+            metadata={
+                "provider": name_lookup.provider,
+                "matched_name": name_lookup.matched_name,
+                "crd_number": name_lookup.crd_number,
+                "current_firm": name_lookup.current_firm,
+                "sec_number": name_lookup.sec_number,
+                "reason_code": name_lookup.reason_code,
+                "suggested_names": list(name_lookup.suggested_names or []),
+                **dict(name_lookup.metadata or {}),
+            },
+        )
+        verification_provider = self._verification_provider_label(verification_result)
+        next_status = "verified"
 
         conn = await self._conn()
         try:
@@ -2221,13 +2283,13 @@ class RIAIAMService:
                     RETURNING id, user_id, display_name, legal_name, finra_crd, sec_iard, verification_status
                     """,
                     user_id,
-                    display_name.strip(),
+                    normalized_display_name,
                     effective_legal_name,
                     effective_finra_crd,
                     effective_sec_iard or "",
-                    (bio or "").strip(),
-                    (strategy or "").strip(),
-                    (disclosures_url or "").strip(),
+                    str(prepared.get("bio") or ""),
+                    str(prepared.get("strategy") or ""),
+                    str(prepared.get("disclosures_url") or ""),
                 )
                 if ria is None:
                     raise RuntimeError("Failed to create RIA profile")
@@ -2268,21 +2330,7 @@ class RIAIAMService:
                             (primary_firm_role or "").strip(),
                         )
 
-                verification_result: VerificationResult = await self._verification_gateway.verify(
-                    legal_name=effective_legal_name,
-                    finra_crd=effective_finra_crd,
-                    sec_iard=effective_sec_iard,
-                    force_live=force_live_verification,
-                )
-                verification_provider = self._verification_provider_label(verification_result)
-
-                next_status = "submitted"
-                if verification_result.outcome == "bypassed":
-                    next_status = "bypassed"
-                elif verification_result.verified:
-                    next_status = "finra_verified"
-                elif verification_result.rejected:
-                    next_status = "rejected"
+                _ = force_live_verification
 
                 await conn.execute(
                     """
@@ -2299,6 +2347,46 @@ class RIAIAMService:
                     verification_provider,
                     verification_result.expires_at,
                 )
+                try:
+                    await conn.execute(
+                        """
+                        UPDATE ria_profiles
+                        SET
+                          requested_capabilities = $2::text[],
+                          individual_legal_name = NULLIF($3, ''),
+                          individual_crd = NULLIF($4, ''),
+                          advisory_firm_legal_name = NULLIF($5, ''),
+                          advisory_firm_iapd_number = NULLIF($6, ''),
+                          broker_firm_legal_name = NULLIF($7, ''),
+                          broker_firm_crd = NULLIF($8, ''),
+                          advisory_status = $9,
+                          brokerage_status = $10,
+                          advisory_provider = $11,
+                          brokerage_provider = $12,
+                          advisory_verification_expires_at = $13,
+                          brokerage_verification_expires_at = $14,
+                          updated_at = NOW()
+                        WHERE id = $1
+                        """,
+                        ria["id"],
+                        normalized_requested_capabilities,
+                        effective_legal_name or "",
+                        effective_finra_crd or "",
+                        effective_primary_firm_name or "",
+                        effective_sec_iard or "",
+                        effective_broker_firm_name or "",
+                        effective_broker_firm_crd or "",
+                        "verified",
+                        "draft",
+                        verification_provider,
+                        None,
+                        verification_result.expires_at,
+                        None,
+                    )
+                except asyncpg.exceptions.UndefinedColumnError:
+                    logger.warning(
+                        "ria_profiles capability columns unavailable during onboarding write; using legacy verification fields only"
+                    )
 
                 await conn.execute(
                     """
@@ -2364,20 +2452,18 @@ class RIAIAMService:
                       strategy_summary = EXCLUDED.strategy_summary,
                       verification_badge = EXCLUDED.verification_badge,
                       is_discoverable = TRUE,
-                      updated_at = NOW()
+                    updated_at = NOW()
                     """,
                     user_id,
-                    display_name.strip(),
-                    (bio or "").strip(),
-                    (strategy or "").strip(),
+                    normalized_display_name,
+                    str(prepared.get("bio") or ""),
+                    str(prepared.get("strategy") or ""),
                     next_status,
                 )
 
-                advisory_status = self._normalize_legacy_verification_status(next_status)
-                brokerage_status = (
-                    "draft" if "brokerage" in normalized_requested_capabilities else "draft"
-                )
-                professional_access_granted = advisory_status in {"verified", "active", "bypassed"}
+                advisory_status = "verified"
+                brokerage_status = "draft"
+                professional_access_granted = True
                 brokerage_outcome = (
                     "not_requested"
                     if "brokerage" not in normalized_requested_capabilities

--- a/consent-protocol/hushh_mcp/services/ria_verification.py
+++ b/consent-protocol/hushh_mcp/services/ria_verification.py
@@ -72,12 +72,70 @@ class VerificationResult:
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
+@dataclass(frozen=True)
+class NameVerificationResult:
+    status: str
+    matched_name: str | None = None
+    crd_number: str | None = None
+    current_firm: str | None = None
+    sec_number: str | None = None
+    reason: str | None = None
+    reason_code: str | None = None
+    suggested_names: list[str] = field(default_factory=list)
+    provider: str = "ria_intelligence_stage1"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class _Stage1LookupCacheEntry:
+    expires_at: datetime
+    result: NameVerificationResult
+
+
 def _normalize_identity_text(value: str | None) -> str:
     return re.sub(r"[^a-z0-9]+", " ", str(value or "").lower()).strip()
 
 
 def _normalize_crd(value: str | None) -> str:
     return "".join(ch for ch in str(value or "") if ch.isdigit())
+
+
+def _normalize_stage1_path(value: str | None) -> str:
+    normalized = str(value or "").strip()
+    if not normalized:
+        return "/v1/ria/profile/stage1"
+    if not normalized.startswith("/"):
+        normalized = f"/{normalized}"
+    if normalized.rstrip("/") == "/v1/ria/profile":
+        return "/v1/ria/profile/stage1"
+    return normalized
+
+
+def _normalize_stage1_url(value: str | None) -> str:
+    normalized = str(value or "").strip()
+    if not normalized:
+        return ""
+    if normalized.rstrip("/").endswith("/v1/ria/profile"):
+        return f"{normalized.rstrip('/')}/stage1"
+    return normalized
+
+
+def _reason_code_from_provider_reason(reason: str | None) -> str:
+    normalized = str(reason or "").strip().lower()
+    if not normalized:
+        return "no_confident_match"
+    broad_markers = (
+        "too broad",
+        "insufficiently specific",
+        "more specific",
+        "full last name",
+        "full legal name",
+        "firm context",
+        "confidently identify a single",
+    )
+    if any(marker in normalized for marker in broad_markers):
+        return "query_too_broad"
+    return "no_confident_match"
 
 
 def _contains_official_regulator_source(payload: dict[str, Any]) -> bool:
@@ -326,6 +384,225 @@ class RIAIntelligenceVerificationAdapter:
                 "source_urls": source_urls[:5],
             },
         )
+
+
+class RIAIntelligenceStage1LookupAdapter:
+    _cache: dict[str, _Stage1LookupCacheEntry] = {}
+    _provider_label = "ria_intelligence_stage1"
+
+    def __init__(
+        self,
+        *,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._base_url = str(os.getenv("RIA_INTELLIGENCE_VERIFY_BASE_URL", "")).strip().rstrip("/")
+        self._verify_url = _normalize_stage1_url(os.getenv("RIA_INTELLIGENCE_VERIFY_URL", ""))
+        self._endpoint_path = _normalize_stage1_path(
+            os.getenv("RIA_INTELLIGENCE_VERIFY_ENDPOINT_PATH", "/v1/ria/profile/stage1")
+        )
+        self._api_key = str(os.getenv("RIA_INTELLIGENCE_VERIFY_API_KEY", "")).strip()
+        self._timeout_seconds = float(os.getenv("RIA_INTELLIGENCE_VERIFY_TIMEOUT_SECONDS", "60"))
+        self._transport = transport
+        self._cache_ttl_seconds = int(os.getenv("RIA_INTELLIGENCE_STAGE1_CACHE_TTL_SECONDS", "300"))
+
+    @staticmethod
+    def _profile_payload(payload: dict[str, Any]) -> dict[str, Any]:
+        profile = payload.get("profile")
+        return profile if isinstance(profile, dict) else {}
+
+    @classmethod
+    def _suggested_names(cls, payload: dict[str, Any]) -> list[str]:
+        profile = cls._profile_payload(payload)
+        value = profile.get("suggestedNames")
+        if not isinstance(value, list):
+            return []
+        out: list[str] = []
+        for item in value:
+            candidate = str(item or "").strip()
+            if candidate:
+                out.append(candidate)
+        return out
+
+    @classmethod
+    def _not_found_reason(cls, payload: dict[str, Any]) -> str:
+        profile = cls._profile_payload(payload)
+        candidate = str(profile.get("reasonIfNotExists") or "").strip()
+        if candidate:
+            return candidate
+        return "No confident FINRA or SEC match was found for the query."
+
+    @classmethod
+    def _source_urls(cls, payload: dict[str, Any]) -> list[str]:
+        sources = payload.get("sources")
+        if not isinstance(sources, list):
+            return []
+        out: list[str] = []
+        for item in sources:
+            if not isinstance(item, dict):
+                continue
+            candidate = str(item.get("uri") or item.get("url") or "").strip()
+            if candidate:
+                out.append(candidate)
+        return out[:5]
+
+    async def _request_payload(
+        self,
+        *,
+        query: str,
+    ) -> tuple[dict[str, Any] | None, NameVerificationResult | None]:
+        request_url = self._verify_url or (
+            f"{self._base_url}{self._endpoint_path}" if self._base_url else ""
+        )
+        if not request_url:
+            return None, NameVerificationResult(
+                status="provider_unavailable",
+                reason="RIA intelligence verification provider not configured",
+                provider=self._provider_label,
+                metadata={"provider": self._provider_label, "reason": "not_configured"},
+            )
+
+        headers: dict[str, str] = {"Content-Type": "application/json"}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+
+        try:
+            async with httpx.AsyncClient(
+                timeout=self._timeout_seconds,
+                transport=self._transport,
+                headers=headers,
+            ) as client:
+                response = await client.post(
+                    request_url,
+                    json={"query": query},
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("ria.intelligence_stage1_request_failed: %s", exc)
+            return None, NameVerificationResult(
+                status="provider_unavailable",
+                reason="RIA intelligence verification request failed",
+                provider=self._provider_label,
+                metadata={"provider": self._provider_label, "error": type(exc).__name__},
+            )
+
+        if response.status_code >= 500:
+            return None, NameVerificationResult(
+                status="provider_unavailable",
+                reason="RIA intelligence verification provider unavailable",
+                provider=self._provider_label,
+                metadata={"provider": self._provider_label, "status_code": response.status_code},
+            )
+
+        payload = response.json() if response.content else {}
+        if not isinstance(payload, dict):
+            return None, NameVerificationResult(
+                status="provider_unavailable",
+                reason="RIA intelligence verification returned invalid payload",
+                provider=self._provider_label,
+                metadata={"provider": self._provider_label, "status_code": response.status_code},
+            )
+        return payload, None
+
+    def _cache_key(self, query: str) -> str:
+        return _normalize_identity_text(query)
+
+    @classmethod
+    def _prune_expired_cache(cls, now: datetime) -> None:
+        expired_keys = [key for key, entry in cls._cache.items() if entry.expires_at <= now]
+        for key in expired_keys:
+            cls._cache.pop(key, None)
+
+    def _get_cached_result(self, query: str) -> NameVerificationResult | None:
+        now = datetime.now(timezone.utc)
+        self._prune_expired_cache(now)
+        entry = self._cache.get(self._cache_key(query))
+        if entry is None or entry.expires_at <= now:
+            return None
+        return entry.result
+
+    def _store_cached_result(self, query: str, result: NameVerificationResult) -> None:
+        if result.status not in {"verified", "not_verified"} or self._cache_ttl_seconds <= 0:
+            return
+        self._prune_expired_cache(datetime.now(timezone.utc))
+        self._cache[self._cache_key(query)] = _Stage1LookupCacheEntry(
+            expires_at=datetime.now(timezone.utc) + timedelta(seconds=self._cache_ttl_seconds),
+            result=result,
+        )
+
+    async def verify_name(
+        self,
+        *,
+        query: str,
+        use_cache: bool = True,
+    ) -> NameVerificationResult:
+        normalized_query = str(query or "").strip()
+        if not normalized_query:
+            return NameVerificationResult(
+                status="not_verified",
+                reason="query must not be blank",
+                reason_code="no_confident_match",
+                provider=self._provider_label,
+                metadata={"provider": self._provider_label, "reason": "missing_query"},
+            )
+
+        if use_cache:
+            cached = self._get_cached_result(normalized_query)
+            if cached is not None:
+                return cached
+
+        payload, error = await self._request_payload(query=normalized_query)
+        if error is not None:
+            return error
+        if payload is None:
+            return NameVerificationResult(
+                status="provider_unavailable",
+                reason="RIA intelligence verification returned no payload.",
+                provider=self._provider_label,
+                metadata={"provider": self._provider_label, "reason": "missing_payload"},
+            )
+
+        profile = self._profile_payload(payload)
+        exists_on_finra = bool(profile.get("existsOnFinra") is True)
+        matched_name = str(profile.get("fullName") or normalized_query).strip() or None
+        crd_number = str(profile.get("crdNumber") or "").strip() or None
+        current_firm = str(profile.get("currentFirm") or "").strip() or None
+        sec_number = str(profile.get("secNumber") or "").strip() or None
+        suggested_names = self._suggested_names(payload)
+        not_found_reason = self._not_found_reason(payload)
+        reason_code = _reason_code_from_provider_reason(not_found_reason)
+        source_urls = self._source_urls(payload)
+        metadata = {"provider": self._provider_label, "source_urls": source_urls}
+
+        if exists_on_finra and _normalize_crd(crd_number):
+            result = NameVerificationResult(
+                status="verified",
+                matched_name=matched_name,
+                crd_number=crd_number,
+                current_firm=current_firm,
+                sec_number=sec_number,
+                provider=self._provider_label,
+                metadata=metadata,
+            )
+            self._store_cached_result(normalized_query, result)
+            return result
+
+        result = NameVerificationResult(
+            status="not_verified",
+            matched_name=matched_name,
+            crd_number=crd_number,
+            current_firm=current_firm,
+            sec_number=sec_number,
+            reason=not_found_reason,
+            reason_code=reason_code,
+            suggested_names=suggested_names,
+            provider=self._provider_label,
+            metadata={
+                **metadata,
+                "reason_code": reason_code,
+                "suggested_names": suggested_names,
+            },
+        )
+        self._store_cached_result(normalized_query, result)
+        return result
 
 
 class IapdVerificationAdapter:

--- a/consent-protocol/tests/test_ria_iam_routes.py
+++ b/consent-protocol/tests/test_ria_iam_routes.py
@@ -177,6 +177,35 @@ def test_ria_onboarding_submit_maps_professional_capabilities(monkeypatch):
     assert payload["requested_capabilities"] == ["advisory", "brokerage"]
 
 
+def test_ria_name_verification_route_maps_stage1_lookup(monkeypatch):
+    async def _mock_verify_name(self, query: str):
+        assert query == "Ana Roumenova Carter"
+        return {
+            "status": "verified",
+            "matched_name": "Ana Roumenova Carter",
+            "crd_number": "4424794",
+            "current_firm": "LCG CAPITAL ADVISORS, LLC",
+            "sec_number": "801-12345",
+            "reason": None,
+            "suggested_names": [],
+            "provider": "ria_intelligence_stage1",
+        }
+
+    monkeypatch.setattr(RIAIAMService, "verify_ria_name", _mock_verify_name)
+
+    client = TestClient(_build_app())
+    response = client.post(
+        "/api/ria/onboarding/verify-name",
+        json={"query": "Ana Roumenova Carter"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "verified"
+    assert payload["crd_number"] == "4424794"
+    assert payload["provider"] == "ria_intelligence_stage1"
+
+
 def test_marketplace_schema_not_ready_returns_503(monkeypatch):
     async def _mock_search(self, **kwargs):  # noqa: ANN003
         _ = kwargs

--- a/consent-protocol/tests/test_ria_iam_service_architecture.py
+++ b/consent-protocol/tests/test_ria_iam_service_architecture.py
@@ -6,7 +6,10 @@ import pytest
 from hushh_mcp.services.consent_center_service import ConsentCenterService
 from hushh_mcp.services.renaissance_service import RenaissanceService
 from hushh_mcp.services.ria_iam_service import RIAIAMPolicyError, RIAIAMService
-from hushh_mcp.services.ria_verification import validate_regulated_runtime_configuration
+from hushh_mcp.services.ria_verification import (
+    NameVerificationResult,
+    validate_regulated_runtime_configuration,
+)
 
 
 def test_runtime_persona_only_overrides_for_setup_mode():
@@ -120,6 +123,28 @@ def test_professional_inputs_accept_dual_capability_payload():
     assert payload["disclosures_url"] == "https://example.com/disclosures"
 
 
+def test_name_first_inputs_allow_missing_manual_regulatory_identity():
+    payload = RIAIAMService._prepare_professional_onboarding_inputs(
+        display_name="Advisor Alpha",
+        requested_capabilities=["advisory"],
+        individual_legal_name="",
+        individual_crd="",
+        advisory_firm_legal_name="",
+        advisory_firm_iapd_number="",
+        broker_firm_legal_name=None,
+        broker_firm_crd=None,
+        bio=None,
+        strategy=None,
+        disclosures_url=None,
+        require_regulatory_identity=False,
+        require_advisory_firm_identifiers=False,
+    )
+
+    assert payload["display_name"] == "Advisor Alpha"
+    assert payload["individual_legal_name"] is None
+    assert payload["advisory_firm_iapd_number"] is None
+
+
 def test_ria_verified_status_helper_matches_expected_statuses():
     assert RIAIAMService._is_verified_ria_status("verified") is True
     assert RIAIAMService._is_verified_ria_status("active") is True
@@ -155,6 +180,132 @@ def test_regulated_runtime_guard_rejects_prod_bypass(monkeypatch):
         assert "BYPASS" in str(exc)
     else:
         raise AssertionError("Expected production runtime guard to reject bypass flags")
+
+
+@pytest.mark.asyncio
+async def test_verify_ria_name_serializes_verified_stage1_lookup(monkeypatch):
+    service = RIAIAMService()
+
+    async def _mock_lookup(*, query: str, use_cache: bool = True):
+        assert query == "Advisor Alpha"
+        assert use_cache is True
+        return NameVerificationResult(
+            status="verified",
+            matched_name="Advisor Alpha",
+            crd_number="12345",
+            current_firm="Advisor Alpha LLC",
+            sec_number="801-12345",
+            provider="ria_intelligence_stage1",
+        )
+
+    monkeypatch.setattr(service._name_verification_gateway, "verify_name", _mock_lookup)
+
+    result = await service.verify_ria_name("Advisor Alpha")
+
+    assert result["status"] == "verified"
+    assert result["matched_name"] == "Advisor Alpha"
+    assert result["crd_number"] == "12345"
+
+
+@pytest.mark.asyncio
+async def test_verify_ria_name_serializes_reason_code_for_broad_queries(monkeypatch):
+    service = RIAIAMService()
+
+    async def _mock_lookup(*, query: str, use_cache: bool = True):
+        assert query == "Andrew G"
+        assert use_cache is True
+        return NameVerificationResult(
+            status="not_verified",
+            matched_name=None,
+            crd_number=None,
+            current_firm=None,
+            sec_number=None,
+            reason=(
+                "The query 'Andrew G' is too broad and lacks a full last name or firm context."
+            ),
+            reason_code="query_too_broad",
+            suggested_names=["Andrew Garrett Kirkland"],
+            provider="ria_intelligence_stage1",
+        )
+
+    monkeypatch.setattr(service._name_verification_gateway, "verify_name", _mock_lookup)
+
+    result = await service.verify_ria_name("Andrew G")
+
+    assert result["status"] == "not_verified"
+    assert result["reason_code"] == "query_too_broad"
+    assert result["suggested_names"] == ["Andrew Garrett Kirkland"]
+
+
+@pytest.mark.asyncio
+async def test_submit_ria_onboarding_reverifies_stage1_before_granting_access(monkeypatch):
+    service = RIAIAMService()
+
+    class _FakeTransaction:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class _FakeConn:
+        def transaction(self):
+            return _FakeTransaction()
+
+        async def fetchrow(self, query: str, *_args):
+            if "INSERT INTO ria_profiles" in query:
+                return {"id": "ria-profile-1", "user_id": "user-1", "display_name": "Advisor Alpha"}
+            if "INSERT INTO ria_firms" in query:
+                return {"id": "firm-1"}
+            return None
+
+        async def execute(self, *_args, **_kwargs):
+            return None
+
+        async def close(self):
+            return None
+
+    async def _fake_conn():
+        return _FakeConn()
+
+    async def _fake_schema_ready(_conn):
+        return None
+
+    async def _fake_vault_user_row(_conn, _user_id):
+        return None
+
+    async def _fake_runtime_persona(_conn, _user_id, _persona):
+        return None
+
+    async def _fake_verify_name_result(query: str, *, use_cache: bool = True):
+        assert query == "Advisor Alpha"
+        assert use_cache is True
+        return NameVerificationResult(
+            status="verified",
+            matched_name="Advisor Alpha",
+            crd_number="12345",
+            current_firm="Advisor Alpha LLC",
+            sec_number="801-12345",
+            provider="ria_intelligence_stage1",
+        )
+
+    monkeypatch.setattr(service, "_conn", _fake_conn)
+    monkeypatch.setattr(service, "_ensure_iam_schema_ready", _fake_schema_ready)
+    monkeypatch.setattr(service, "_ensure_vault_user_row", _fake_vault_user_row)
+    monkeypatch.setattr(service, "_set_runtime_last_persona", _fake_runtime_persona)
+    monkeypatch.setattr(service, "_verify_ria_name_result", _fake_verify_name_result)
+
+    result = await service.submit_ria_onboarding(
+        "user-1",
+        display_name="Advisor Alpha",
+        requested_capabilities=["advisory"],
+        strategy="Long-term planning",
+    )
+
+    assert result["verification_status"] == "verified"
+    assert result["advisory_status"] == "verified"
+    assert result["professional_access_granted"] is True
+    assert result["individual_crd"] == "12345"
 
 
 def test_renaissance_service_exposes_generic_security_list_descriptors():

--- a/consent-protocol/tests/test_ria_verification_intelligence.py
+++ b/consent-protocol/tests/test_ria_verification_intelligence.py
@@ -1,12 +1,50 @@
 from __future__ import annotations
 
 import httpx
+import pytest
 
 from hushh_mcp.services.ria_verification import (
     FinraVerificationAdapter,
     IapdVerificationAdapter,
+    RIAIntelligenceStage1LookupAdapter,
     RIAIntelligenceVerificationAdapter,
 )
+
+
+@pytest.fixture(autouse=True)
+def clear_stage1_lookup_cache():
+    RIAIntelligenceStage1LookupAdapter._cache.clear()
+    yield
+    RIAIntelligenceStage1LookupAdapter._cache.clear()
+
+
+def _stage1_payload(
+    *,
+    exists_on_finra: bool = True,
+    crd_number: str | None = "1234567",
+    sec_number: str | None = "801-12345",
+    full_name: str | None = "Akash Katla",
+    current_firm: str | None = "Example Advisory LLC",
+    reason: str | None = None,
+    suggested_names: list[str] | None = None,
+) -> dict:
+    return {
+        "profile": {
+            "existsOnFinra": exists_on_finra,
+            "crdNumber": crd_number,
+            "secNumber": sec_number,
+            "fullName": full_name,
+            "currentFirm": current_firm,
+            "reasonIfNotExists": reason,
+            "suggestedNames": suggested_names or [],
+        },
+        "sources": [
+            {
+                "title": "BrokerCheck Report",
+                "uri": "https://files.brokercheck.finra.org/individual/individual_1234567.pdf",
+            }
+        ],
+    }
 
 
 def test_ria_intelligence_verifier_accepts_matching_crd_and_iard(monkeypatch):
@@ -300,6 +338,129 @@ def test_iapd_adapter_honors_advisory_bypass_in_non_production(monkeypatch):
     assert result.rejected is False
     assert result.outcome == "bypassed"
     assert "bypass" in result.message.lower()
+
+
+def test_stage1_lookup_returns_verified_when_crd_present(monkeypatch):
+    monkeypatch.setenv("RIA_INTELLIGENCE_VERIFY_BASE_URL", "https://ria-intelligence.example")
+    monkeypatch.delenv("RIA_INTELLIGENCE_VERIFY_URL", raising=False)
+
+    adapter = RIAIntelligenceStage1LookupAdapter(
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(status_code=200, json=_stage1_payload())
+        )
+    )
+    result = _run(adapter.verify_name(query="Akash Katla"))
+
+    assert result.status == "verified"
+    assert result.crd_number == "1234567"
+    assert result.provider == "ria_intelligence_stage1"
+
+
+def test_stage1_lookup_returns_not_verified_with_suggestions(monkeypatch):
+    monkeypatch.setenv("RIA_INTELLIGENCE_VERIFY_BASE_URL", "https://ria-intelligence.example")
+    monkeypatch.delenv("RIA_INTELLIGENCE_VERIFY_URL", raising=False)
+
+    adapter = RIAIntelligenceStage1LookupAdapter(
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(
+                status_code=200,
+                json=_stage1_payload(
+                    exists_on_finra=False,
+                    crd_number=None,
+                    sec_number=None,
+                    full_name="Jane Doe",
+                    current_firm=None,
+                    reason="No confident FINRA or SEC match was found for the query.",
+                    suggested_names=["Jane A Doe"],
+                ),
+            )
+        )
+    )
+    result = _run(adapter.verify_name(query="Jane Doe"))
+
+    assert result.status == "not_verified"
+    assert result.reason == "No confident FINRA or SEC match was found for the query."
+    assert result.reason_code == "no_confident_match"
+    assert result.suggested_names == ["Jane A Doe"]
+
+
+def test_stage1_lookup_marks_broad_query_reason_code(monkeypatch):
+    monkeypatch.setenv("RIA_INTELLIGENCE_VERIFY_BASE_URL", "https://ria-intelligence.example")
+    monkeypatch.delenv("RIA_INTELLIGENCE_VERIFY_URL", raising=False)
+
+    adapter = RIAIntelligenceStage1LookupAdapter(
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(
+                status_code=200,
+                json=_stage1_payload(
+                    exists_on_finra=False,
+                    crd_number=None,
+                    sec_number=None,
+                    full_name=None,
+                    current_firm=None,
+                    reason=(
+                        "The query 'Andrew G' is too broad and lacks a full last name or firm "
+                        "context, making it impossible to confidently identify a single "
+                        "registered financial professional or firm in FINRA or SEC public records."
+                    ),
+                    suggested_names=[
+                        "Andrew Garcia",
+                        "Andrew Green",
+                        "Andrew Gonzalez",
+                    ],
+                ),
+            )
+        )
+    )
+    result = _run(adapter.verify_name(query="Andrew G"))
+
+    assert result.status == "not_verified"
+    assert result.reason_code == "query_too_broad"
+    assert result.suggested_names == [
+        "Andrew Garcia",
+        "Andrew Green",
+        "Andrew Gonzalez",
+    ]
+
+
+def test_stage1_lookup_caches_verified_and_not_verified_results(monkeypatch):
+    monkeypatch.setenv("RIA_INTELLIGENCE_VERIFY_BASE_URL", "https://ria-intelligence.example")
+    monkeypatch.setenv("RIA_INTELLIGENCE_STAGE1_CACHE_TTL_SECONDS", "300")
+
+    calls = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["count"] += 1
+        return httpx.Response(status_code=200, json=_stage1_payload())
+
+    adapter = RIAIntelligenceStage1LookupAdapter(transport=httpx.MockTransport(handler))
+
+    first = _run(adapter.verify_name(query="Akash Katla"))
+    second = _run(adapter.verify_name(query="Akash Katla"))
+
+    assert first.status == "verified"
+    assert second.status == "verified"
+    assert calls["count"] == 1
+
+
+def test_stage1_lookup_does_not_cache_provider_unavailable(monkeypatch):
+    monkeypatch.setenv("RIA_INTELLIGENCE_VERIFY_BASE_URL", "https://ria-intelligence.example")
+    monkeypatch.setenv("RIA_INTELLIGENCE_STAGE1_CACHE_TTL_SECONDS", "300")
+
+    calls = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["count"] += 1
+        return httpx.Response(status_code=500)
+
+    adapter = RIAIntelligenceStage1LookupAdapter(transport=httpx.MockTransport(handler))
+
+    first = _run(adapter.verify_name(query="Akash Katla"))
+    second = _run(adapter.verify_name(query="Akash Katla"))
+
+    assert first.status == "provider_unavailable"
+    assert second.status == "provider_unavailable"
+    assert calls["count"] == 2
 
 
 def test_finra_adapter_honors_ria_dev_bypass_alias(monkeypatch):

--- a/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
@@ -1,0 +1,346 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  routerPush: vi.fn(),
+  useAuth: vi.fn(),
+  usePersonaState: vi.fn(),
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+  },
+  riaService: {
+    getOnboardingStatus: vi.fn(),
+    getRiaPublicProfile: vi.fn(),
+    verifyOnboardingName: vi.fn(),
+    submitOnboarding: vi.fn(),
+    activateDevRia: vi.fn(),
+    setRiaMarketplaceDiscoverability: vi.fn(),
+  },
+  draftService: {
+    load: vi.fn(),
+    save: vi.fn(),
+    clear: vi.fn(),
+  },
+  refreshPersonaState: vi.fn(),
+  trackEvent: vi.fn(),
+  trackGrowthFunnelStepCompleted: vi.fn(),
+  trackRiaActivationCompleted: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mocks.routerPush }),
+}));
+
+vi.mock("lucide-react", () => ({
+  ArrowLeft: () => <span />,
+  ArrowRight: () => <span />,
+  CheckCircle2: () => <span />,
+  Loader2: () => <span />,
+  ShieldCheck: () => <span />,
+  ShieldQuestion: () => <span />,
+}));
+
+vi.mock("@/components/app-ui/command-fields", () => ({
+  PopupTextEditorField: ({
+    value,
+    placeholder,
+    onSave,
+  }: {
+    value: string;
+    placeholder?: string;
+    onSave: (value: string) => void;
+  }) => (
+    <textarea
+      value={value}
+      placeholder={placeholder}
+      onChange={(event) => onSave(event.target.value)}
+    />
+  ),
+}));
+
+vi.mock("@/components/app-ui/surfaces", () => ({
+  SurfaceCard: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div {...props}>{children}</div>
+  ),
+  SurfaceCardContent: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div {...props}>{children}</div>
+  ),
+  SurfaceCardHeader: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div {...props}>{children}</div>
+  ),
+  SurfaceInset: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div {...props}>{children}</div>
+  ),
+}));
+
+vi.mock("@/components/profile/settings-ui", () => ({
+  SettingsGroup: ({
+    title,
+    children,
+  }: {
+    title: string;
+    children: React.ReactNode;
+  }) => (
+    <section>
+      <h2>{title}</h2>
+      {children}
+    </section>
+  ),
+  SettingsRow: ({
+    title,
+    description,
+  }: {
+    title: string;
+    description?: string;
+  }) => (
+    <div>
+      <span>{title}</span>
+      <span>{description}</span>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/ui/progress", () => ({
+  Progress: ({ value }: { value?: number }) => <div data-testid="progress" data-value={value} />,
+}));
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ria/ria-page-shell", () => ({
+  RiaPageShell: ({
+    title,
+    description,
+    children,
+  }: {
+    title: string;
+    description: string;
+    children: React.ReactNode;
+  }) => (
+    <section>
+      <h1>{title}</h1>
+      <p>{description}</p>
+      {children}
+    </section>
+  ),
+  RiaCompatibilityState: ({
+    title,
+    description,
+  }: {
+    title: string;
+    description: string;
+  }) => (
+    <div>
+      <span>{title}</span>
+      <span>{description}</span>
+    </div>
+  ),
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: mocks.useAuth,
+}));
+
+vi.mock("@/lib/morphy-ux/morphy", () => ({
+  morphyToast: mocks.toast,
+}));
+
+vi.mock("@/lib/navigation/routes", () => ({
+  ROUTES: {
+    RIA_HOME: "/ria",
+    RIA_CLIENTS: "/ria/clients",
+  },
+}));
+
+vi.mock("@/lib/services/ria-onboarding-draft-local-service", () => ({
+  RiaOnboardingDraftLocalService: mocks.draftService,
+}));
+
+vi.mock("@/lib/services/ria-service", () => ({
+  RiaService: mocks.riaService,
+  isIAMSchemaNotReadyError: () => false,
+}));
+
+vi.mock("@/lib/persona/persona-context", () => ({
+  usePersonaState: mocks.usePersonaState,
+}));
+
+vi.mock("@/lib/observability/client", () => ({
+  trackEvent: mocks.trackEvent,
+}));
+
+vi.mock("@/lib/observability/growth", () => ({
+  trackGrowthFunnelStepCompleted: mocks.trackGrowthFunnelStepCompleted,
+  trackRiaActivationCompleted: mocks.trackRiaActivationCompleted,
+}));
+
+import RiaOnboardingPage from "@/app/ria/onboarding/page";
+
+describe("RiaOnboardingPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.useAuth.mockReturnValue({
+      user: {
+        uid: "user-ria-1",
+        displayName: "Ana Carter",
+        email: "ana@example.com",
+        getIdToken: vi.fn().mockResolvedValue("token-ria-1"),
+      },
+    });
+    mocks.usePersonaState.mockReturnValue({
+      devRiaBypassAllowed: false,
+      refresh: mocks.refreshPersonaState,
+    });
+    mocks.draftService.load.mockResolvedValue(null);
+    mocks.draftService.save.mockResolvedValue(undefined);
+    mocks.draftService.clear.mockResolvedValue(undefined);
+    mocks.riaService.getOnboardingStatus.mockResolvedValue({
+      exists: false,
+      verification_status: "draft",
+      requested_capabilities: ["advisory"],
+    });
+    mocks.riaService.getRiaPublicProfile.mockResolvedValue(null);
+    mocks.riaService.setRiaMarketplaceDiscoverability.mockResolvedValue(undefined);
+  });
+
+  it("only verifies on explicit CTA and autofills read-only verified fields", async () => {
+    mocks.riaService.verifyOnboardingName.mockResolvedValue({
+      status: "verified",
+      matched_name: "Ana Roumenova Carter",
+      crd_number: "4424794",
+      current_firm: "LCG CAPITAL ADVISORS, LLC",
+      sec_number: "801-12345",
+      provider: "ria_intelligence_stage1",
+      suggested_names: [],
+    });
+
+    render(<RiaOnboardingPage />);
+
+    const input = await screen.findByLabelText("Advisor name");
+    const continueButton = screen.getByRole("button", { name: "Continue" }) as HTMLButtonElement;
+    const verifyButton = screen.getByRole("button", { name: "Verify" }) as HTMLButtonElement;
+
+    expect(continueButton.disabled).toBe(true);
+    expect(screen.queryByRole("button", { name: "Use manual CRD fallback" })).toBeNull();
+
+    fireEvent.change(input, { target: { value: "Ana Roumenova Carter" } });
+    await new Promise((resolve) => setTimeout(resolve, 450));
+
+    expect(mocks.riaService.verifyOnboardingName).not.toHaveBeenCalled();
+
+    fireEvent.click(verifyButton);
+
+    await waitFor(() =>
+      expect(mocks.riaService.verifyOnboardingName).toHaveBeenCalledWith(
+        "token-ria-1",
+        { query: "Ana Roumenova Carter" },
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      )
+    );
+    expect(mocks.riaService.verifyOnboardingName).toHaveBeenCalledTimes(1);
+
+    await screen.findByText("Verified name");
+    expect(screen.getByText("4424794")).toBeTruthy();
+    expect(screen.getByText("LCG CAPITAL ADVISORS, LLC")).toBeTruthy();
+    expect(screen.getByText("801-12345")).toBeTruthy();
+    expect(continueButton.disabled).toBe(false);
+
+    fireEvent.change(input, { target: { value: "Ana Carter" } });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Verified name")).toBeNull();
+    });
+    expect(continueButton.disabled).toBe(true);
+  });
+
+  it("supports Enter-to-verify and blocks continue after a failed lookup", async () => {
+    mocks.riaService.verifyOnboardingName.mockResolvedValue({
+      status: "not_verified",
+      matched_name: "Ana Carter",
+      crd_number: null,
+      current_firm: null,
+      sec_number: null,
+      reason: "No confident FINRA or SEC match was found for the query.",
+      provider: "ria_intelligence_stage1",
+      suggested_names: ["Ana Roumenova Carter"],
+    });
+
+    render(<RiaOnboardingPage />);
+
+    const input = await screen.findByLabelText("Advisor name");
+    const continueButton = screen.getByRole("button", { name: "Continue" }) as HTMLButtonElement;
+
+    fireEvent.change(input, { target: { value: "Ana Carter" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+    await waitFor(() => {
+      expect(mocks.riaService.verifyOnboardingName).toHaveBeenCalledTimes(1);
+    });
+
+    await screen.findByRole("button", { name: "Retry verification" });
+    // No manual fallback — strict gate: must verify via API
+    expect(screen.queryByRole("button", { name: "Use manual CRD fallback" })).toBeNull();
+    expect(continueButton.disabled).toBe(true);
+  });
+
+  it("guides broad partial-name queries toward fuller suggestions without opening fallback", async () => {
+    mocks.riaService.verifyOnboardingName
+      .mockResolvedValueOnce({
+        status: "not_verified",
+        matched_name: null,
+        crd_number: null,
+        current_firm: null,
+        sec_number: null,
+        reason:
+          "The query 'Andrew G' is too broad and lacks a full last name or firm context, making it impossible to confidently identify a single registered financial professional or firm in FINRA or SEC public records.",
+        reason_code: "query_too_broad",
+        provider: "ria_intelligence_stage1",
+        suggested_names: ["Andrew Garrett Kirkland"],
+      })
+      .mockResolvedValueOnce({
+        status: "verified",
+        matched_name: "Andrew Garrett Kirkland",
+        crd_number: "7413463",
+        current_firm: "Eissman Wealth Management",
+        sec_number: null,
+        provider: "ria_intelligence_stage1",
+        suggested_names: [],
+      });
+
+    render(<RiaOnboardingPage />);
+
+    const input = await screen.findByLabelText("Advisor name");
+    const continueButton = screen.getByRole("button", { name: "Continue" }) as HTMLButtonElement;
+
+    fireEvent.change(input, { target: { value: "Andrew G" } });
+    fireEvent.click(screen.getByRole("button", { name: "Verify" }));
+
+    await screen.findByText(/more specific advisor name/i);
+    expect(screen.getByText(/Try the advisor's full legal name/i)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Andrew Garrett Kirkland" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Use manual CRD fallback" })).toBeNull();
+    expect(continueButton.disabled).toBe(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "Andrew Garrett Kirkland" }));
+
+    await waitFor(() => {
+      expect(mocks.riaService.verifyOnboardingName).toHaveBeenNthCalledWith(
+        2,
+        "token-ria-1",
+        { query: "Andrew Garrett Kirkland" },
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
+    });
+
+    await screen.findByText("Verified name");
+    expect(screen.getByDisplayValue("Andrew Garrett Kirkland")).toBeTruthy();
+    expect(continueButton.disabled).toBe(false);
+  });
+
+});

--- a/hushh-webapp/__tests__/services/ria-onboarding-flow.test.ts
+++ b/hushh-webapp/__tests__/services/ria-onboarding-flow.test.ts
@@ -18,8 +18,6 @@ describe("ria-onboarding-flow", () => {
     expect(buildRiaOnboardingSteps(draft).map((step) => step.id)).toEqual([
       "capabilities",
       "display_name",
-      "legal_identity",
-      "advisory_firm",
       "broker_firm",
       "public_profile",
       "review",
@@ -46,7 +44,11 @@ describe("ria-onboarding-flow", () => {
     };
 
     expect(canContinueRiaOnboardingStep("capabilities", draft)).toBe(true);
-    expect(canContinueRiaOnboardingStep("display_name", draft)).toBe(true);
+    expect(
+      canContinueRiaOnboardingStep("display_name", draft, {
+        nameVerificationSatisfied: true,
+      })
+    ).toBe(true);
     expect(canContinueRiaOnboardingStep("legal_identity", draft)).toBe(true);
     expect(canContinueRiaOnboardingStep("advisory_firm", draft)).toBe(true);
     expect(canContinueRiaOnboardingStep("public_profile", draft)).toBe(true);
@@ -59,7 +61,11 @@ describe("ria-onboarding-flow", () => {
       individualCrd: "12345",
     });
 
-    expect(findFirstIncompleteRiaOnboardingStepId(draft)).toBe("advisory_firm");
+    expect(
+      findFirstIncompleteRiaOnboardingStepId(draft, {
+        nameVerificationSatisfied: true,
+      })
+    ).toBe("public_profile");
   });
 
   it("clamps removed steps when capabilities change", () => {
@@ -68,5 +74,18 @@ describe("ria-onboarding-flow", () => {
     });
 
     expect(resolveRiaOnboardingStepId(draft, "broker_firm")).toBe("capabilities");
+  });
+
+  it("blocks the default display-name step until explicit verification succeeds", () => {
+    const draft = normalizeRiaOnboardingDraft({
+      displayName: "Ana Roumenova Carter",
+    });
+
+    expect(canContinueRiaOnboardingStep("display_name", draft)).toBe(false);
+    expect(
+      canContinueRiaOnboardingStep("display_name", draft, {
+        nameVerificationSatisfied: true,
+      })
+    ).toBe(true);
   });
 });

--- a/hushh-webapp/app/api/ria/[...path]/route.ts
+++ b/hushh-webapp/app/api/ria/[...path]/route.ts
@@ -39,7 +39,11 @@ function writeHotGetCache(key: string, value: { status: number; payload: unknown
 function resolveProxyTimeoutMs(path: string, method: "GET" | "POST"): number {
   if (
     method === "POST" &&
-    (path.startsWith("onboarding/submit") || path.startsWith("onboarding/dev-activate"))
+    (
+      path.startsWith("onboarding/submit") ||
+      path.startsWith("onboarding/dev-activate") ||
+      path.startsWith("onboarding/verify-name")
+    )
   ) {
     return ONBOARDING_PROXY_TIMEOUT_MS;
   }

--- a/hushh-webapp/app/ria/onboarding/page.tsx
+++ b/hushh-webapp/app/ria/onboarding/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useState, type InputHTMLAttributes } from "react";
+import { useEffect, useMemo, useRef, useState, type InputHTMLAttributes } from "react";
 import { useRouter } from "next/navigation";
 import {
   ArrowLeft,
@@ -26,6 +26,7 @@ import {
   buildRiaOnboardingSteps,
   canContinueRiaOnboardingStep,
   getRequestedCapabilityLabels,
+  type RiaOnboardingFlowOptions,
   getRiaOnboardingStepIndex,
   normalizeRiaOnboardingDraft,
   resolveRiaOnboardingStepId,
@@ -37,8 +38,10 @@ import {
 import { RiaOnboardingDraftLocalService } from "@/lib/services/ria-onboarding-draft-local-service";
 import {
   isIAMSchemaNotReadyError,
+  RiaApiError,
   RiaService,
   type MarketplaceRia,
+  type RiaNameVerificationResult,
   type RiaOnboardingStatus,
 } from "@/lib/services/ria-service";
 import { usePersonaState } from "@/lib/persona/persona-context";
@@ -77,6 +80,15 @@ function compactDate(value?: string | null): string | null {
   if (Number.isNaN(date.getTime())) return null;
   return date.toLocaleDateString();
 }
+
+type NameVerificationState =
+  | "idle"
+  | "verifying"
+  | "verified"
+  | "not_verified"
+  | "provider_unavailable";
+
+const NAME_VERIFICATION_VISIBLE_TIMEOUT_MS = 90_000;
 
 const FALLBACK_STEP: RiaOnboardingStep = {
   id: "capabilities",
@@ -119,7 +131,8 @@ function buildSubmitPayload(draft: RiaOnboardingDraft) {
     requested_capabilities: draft.requestedCapabilities,
     individual_legal_name: draft.individualLegalName.trim() || undefined,
     individual_crd: draft.individualCrd.trim() || undefined,
-    advisory_firm_legal_name: advisoryEnabled ? draft.advisoryFirmName.trim() || undefined : undefined,
+    advisory_firm_legal_name:
+      advisoryEnabled ? draft.advisoryFirmName.trim() || undefined : undefined,
     advisory_firm_iapd_number:
       advisoryEnabled ? draft.advisoryFirmIapdNumber.trim() || undefined : undefined,
     broker_firm_legal_name: brokerageEnabled ? draft.brokerFirmName.trim() || undefined : undefined,
@@ -134,6 +147,59 @@ function latestVerificationCopy(status: RiaOnboardingStatus | null): string {
   const outcome = latest.outcome || "latest check";
   const checkedAt = compactDate(latest.checked_at);
   return checkedAt ? `${outcome} on ${checkedAt}` : outcome;
+}
+
+function isAdvisoryAccessReady(status?: string | null): boolean {
+  return status === "active" || status === "verified" || status === "bypassed";
+}
+
+async function waitForNameVerificationResult<T>(
+  promise: Promise<T | null>,
+  options: { timeoutMs: number; onTimeout?: () => void }
+): Promise<{ timedOut: boolean; value: T | null }> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const timeoutId = window.setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      options.onTimeout?.();
+      resolve({ timedOut: true, value: null });
+    }, options.timeoutMs);
+
+    promise.then(
+      (value) => {
+        if (settled) return;
+        settled = true;
+        window.clearTimeout(timeoutId);
+        resolve({ timedOut: false, value });
+      },
+      (error) => {
+        if (settled) return;
+        settled = true;
+        window.clearTimeout(timeoutId);
+        reject(error);
+      }
+    );
+  });
+}
+
+function resolvedVerifiedIdentity(
+  status: RiaOnboardingStatus | null,
+  result: RiaNameVerificationResult | null,
+  draft: RiaOnboardingDraft
+) {
+  return {
+    matchedName:
+      result?.matched_name ||
+      status?.individual_legal_name ||
+      status?.legal_name ||
+      draft.displayName.trim() ||
+      null,
+    crdNumber: result?.crd_number || status?.individual_crd || status?.finra_crd || null,
+    currentFirm: result?.current_firm || status?.advisory_firm_legal_name || null,
+    secNumber:
+      result?.sec_number || status?.advisory_firm_iapd_number || status?.sec_iard || null,
+  };
 }
 
 function StepChoice({
@@ -176,12 +242,14 @@ function TextField({
   value,
   onChange,
   inputMode,
+  onKeyDown,
 }: {
   label: string;
   placeholder: string;
   value: string;
   onChange: (value: string) => void;
   inputMode?: InputHTMLAttributes<HTMLInputElement>["inputMode"];
+  onKeyDown?: InputHTMLAttributes<HTMLInputElement>["onKeyDown"];
 }) {
   return (
     <label className="space-y-2">
@@ -192,6 +260,7 @@ function TextField({
         value={value}
         onChange={(event) => onChange(event.target.value)}
         inputMode={inputMode}
+        onKeyDown={onKeyDown}
         className="min-h-12 w-full rounded-[22px] border border-border/70 bg-background/90 px-4 text-sm outline-none transition-[border-color,box-shadow] focus:border-foreground/30 focus:shadow-[0_0_0_4px_rgba(15,23,42,0.06)]"
         placeholder={placeholder}
       />
@@ -235,6 +304,12 @@ export default function RiaOnboardingPage() {
   const [iamUnavailable, setIamUnavailable] = useState(false);
   const [draftReady, setDraftReady] = useState(false);
   const [shouldPersistDraft, setShouldPersistDraft] = useState(false);
+  const [nameVerificationStatus, setNameVerificationStatus] = useState<NameVerificationState>("idle");
+  const [nameVerificationResult, setNameVerificationResult] = useState<RiaNameVerificationResult | null>(null);
+  const [lastVerifiedQuery, setLastVerifiedQuery] = useState<string | null>(null);
+  const verificationRequestIdRef = useRef(0);
+  const verificationAbortRef = useRef<AbortController | null>(null);
+  const latestDisplayNameRef = useRef("");
 
   useEffect(() => {
     let cancelled = false;
@@ -245,6 +320,9 @@ export default function RiaOnboardingPage() {
           setLoading(false);
           setDraftReady(true);
           setShouldPersistDraft(false);
+          setNameVerificationStatus("idle");
+          setNameVerificationResult(null);
+          setLastVerifiedQuery(null);
         }
         return;
       }
@@ -267,10 +345,36 @@ export default function RiaOnboardingPage() {
           ...draftFromStatus(nextStatus, publicProfile),
           ...localDraft,
         });
-        const currentStepId = resolveRiaOnboardingStepId(seeded, localDraft?.currentStepId);
+        const seededIdentity = resolvedVerifiedIdentity(nextStatus, null, seeded);
+        const persistedDisplayName = nextStatus?.display_name?.trim() || "";
+        const seededVerified =
+          isAdvisoryAccessReady(nextStatus?.advisory_status || nextStatus?.verification_status) &&
+          Boolean(seededIdentity.crdNumber) &&
+          Boolean(persistedDisplayName) &&
+          persistedDisplayName === seeded.displayName.trim();
+        const currentStepId = resolveRiaOnboardingStepId(seeded, localDraft?.currentStepId, {
+          nameVerificationSatisfied: seededVerified,
+        });
 
         setStatus(nextStatus);
         setDraft({ ...seeded, currentStepId });
+        if (seededVerified) {
+          setNameVerificationStatus("verified");
+          setNameVerificationResult({
+            status: "verified",
+            matched_name: seededIdentity.matchedName,
+            crd_number: seededIdentity.crdNumber,
+            current_firm: seededIdentity.currentFirm,
+            sec_number: seededIdentity.secNumber,
+            provider: nextStatus?.verification_provider || "ria_intelligence_stage1",
+            suggested_names: [],
+          });
+          setLastVerifiedQuery(seeded.displayName.trim() || seededIdentity.matchedName);
+        } else {
+          setNameVerificationStatus("idle");
+          setNameVerificationResult(null);
+          setLastVerifiedQuery(null);
+        }
         setShouldPersistDraft(true);
       } catch (loadError) {
         if (!cancelled) {
@@ -303,25 +407,206 @@ export default function RiaOnboardingPage() {
     void RiaOnboardingDraftLocalService.save(user.uid, draft);
   }, [draft, draftReady, iamUnavailable, shouldPersistDraft, user]);
 
-  const steps = useMemo(() => buildRiaOnboardingSteps(draft), [draft]);
-  const currentStepIndex = useMemo(
-    () => getRiaOnboardingStepIndex(draft, draft.currentStepId),
-    [draft]
+  useEffect(
+    () => () => {
+      verificationAbortRef.current?.abort();
+    },
+    []
   );
-  const currentStep = steps[currentStepIndex] ?? steps[0] ?? FALLBACK_STEP;
-  const canContinue = canContinueRiaOnboardingStep(currentStep.id, draft);
+
   const advisoryVerificationStatus = status?.advisory_status || status?.verification_status || "draft";
   const brokerageVerificationStatus = status?.brokerage_status || "draft";
-  const advisoryAccessReady =
-    advisoryVerificationStatus === "active" ||
-    advisoryVerificationStatus === "verified" ||
-    advisoryVerificationStatus === "bypassed";
+  const advisoryAccessReady = isAdvisoryAccessReady(advisoryVerificationStatus);
   const brokerageAccessReady =
     brokerageVerificationStatus === "active" ||
     brokerageVerificationStatus === "verified" ||
     brokerageVerificationStatus === "bypassed";
+  const displayNameQuery = draft.displayName.trim();
+  latestDisplayNameRef.current = displayNameQuery;
+  const persistedVerifiedDisplayName = status?.display_name?.trim() || "";
+  const persistedVerificationSatisfied =
+    isAdvisoryAccessReady(status?.advisory_status || status?.verification_status) &&
+    Boolean(status?.individual_crd || status?.finra_crd) &&
+    Boolean(persistedVerifiedDisplayName) &&
+    persistedVerifiedDisplayName === displayNameQuery;
+  const nameVerificationSatisfied =
+    persistedVerificationSatisfied ||
+    (nameVerificationStatus === "verified" &&
+      Boolean(nameVerificationResult?.crd_number) &&
+      Boolean(displayNameQuery) &&
+      lastVerifiedQuery === displayNameQuery);
+  const flowOptions = useMemo<RiaOnboardingFlowOptions>(
+    () => ({ nameVerificationSatisfied }),
+    [nameVerificationSatisfied]
+  );
+  const verifiedIdentity = useMemo(
+    () => resolvedVerifiedIdentity(status, nameVerificationResult, draft),
+    [draft, nameVerificationResult, status]
+  );
+  const canVerifyName =
+    Boolean(user) &&
+    displayNameQuery.length > 0 &&
+    nameVerificationStatus !== "verifying" &&
+    !(nameVerificationStatus === "verified" && lastVerifiedQuery === displayNameQuery);
+  const isBroadNameQuery =
+    nameVerificationStatus === "not_verified" &&
+    nameVerificationResult?.reason_code === "query_too_broad";
+  const steps = useMemo(() => buildRiaOnboardingSteps(draft, flowOptions), [draft, flowOptions]);
+  const currentStepIndex = useMemo(
+    () => getRiaOnboardingStepIndex(draft, draft.currentStepId, flowOptions),
+    [draft, flowOptions]
+  );
+  const currentStep = steps[currentStepIndex] ?? steps[0] ?? FALLBACK_STEP;
+  const canContinue = canContinueRiaOnboardingStep(currentStep.id, draft, flowOptions);
   const capabilityLabels = getRequestedCapabilityLabels(draft);
   const progressValue = Math.round(((currentStepIndex + 1) / Math.max(steps.length, 1)) * 100);
+
+  useEffect(() => {
+    setDraft((current) => {
+      const nextStepId = resolveRiaOnboardingStepId(current, current.currentStepId, flowOptions);
+      if (nextStepId === current.currentStepId) {
+        return current;
+      }
+      return {
+        ...current,
+        currentStepId: nextStepId,
+      };
+    });
+  }, [flowOptions]);
+
+  function cancelActiveVerification() {
+    verificationRequestIdRef.current += 1;
+    verificationAbortRef.current?.abort();
+    verificationAbortRef.current = null;
+  }
+
+  function applyVerifiedIdentityToDraft(result: RiaNameVerificationResult) {
+    setShouldPersistDraft(true);
+    setDraft((current) => ({
+      ...current,
+      individualLegalName: result.matched_name || "",
+      individualCrd: result.crd_number || "",
+      advisoryFirmName: result.current_firm || "",
+      advisoryFirmIapdNumber: result.sec_number || "",
+    }));
+  }
+
+  function handleDisplayNameChange(value: string) {
+    cancelActiveVerification();
+    setNameVerificationStatus("idle");
+    setNameVerificationResult(null);
+    setLastVerifiedQuery(null);
+    latestDisplayNameRef.current = value.trim();
+    updateDraft({
+      displayName: value,
+      individualLegalName: "",
+      individualCrd: "",
+      advisoryFirmName: "",
+      advisoryFirmIapdNumber: "",
+    });
+  }
+
+  function handleSuggestedNameSelect(value: string) {
+    handleDisplayNameChange(value);
+    window.setTimeout(() => {
+      void handleVerifyName(value);
+    }, 0);
+  }
+
+  async function handleVerifyName(overrideQuery?: string) {
+    if (!user) return;
+    const normalizedQuery = (overrideQuery || draft.displayName).trim();
+    if (!normalizedQuery) return;
+
+    cancelActiveVerification();
+    const requestId = verificationRequestIdRef.current;
+    const controller = new AbortController();
+    verificationAbortRef.current = controller;
+
+    setNotice(null);
+    setError(null);
+    setNameVerificationStatus("verifying");
+    setNameVerificationResult(null);
+    setLastVerifiedQuery(null);
+
+    try {
+      const idToken = await user.getIdToken();
+      const initialResolution = await waitForNameVerificationResult(
+        RiaService.verifyOnboardingName(
+          idToken,
+          { query: normalizedQuery },
+          { signal: controller.signal }
+        ),
+        {
+          timeoutMs: NAME_VERIFICATION_VISIBLE_TIMEOUT_MS,
+          onTimeout: () => {
+            controller.abort();
+          },
+        }
+      );
+      if (initialResolution.timedOut || !initialResolution.value) {
+        setNameVerificationResult({
+          status: "provider_unavailable",
+          reason:
+            "This advisor lookup is taking longer than expected. Retry in a moment.",
+          provider: "ria_intelligence_stage1",
+          suggested_names: [],
+        });
+        setNameVerificationStatus("provider_unavailable");
+        setLastVerifiedQuery(null);
+        return;
+      }
+
+      const result = initialResolution.value;
+      if (
+        controller.signal.aborted ||
+        requestId !== verificationRequestIdRef.current ||
+        latestDisplayNameRef.current !== normalizedQuery
+      ) {
+        return;
+      }
+      setNameVerificationResult(result);
+      setNameVerificationStatus(result.status);
+      if (result.status === "verified") {
+        applyVerifiedIdentityToDraft(result);
+        setLastVerifiedQuery(normalizedQuery);
+      } else {
+        setLastVerifiedQuery(null);
+      }
+    } catch (verificationError) {
+      if (
+        controller.signal.aborted ||
+        (verificationError &&
+          typeof verificationError === "object" &&
+          "name" in verificationError &&
+          verificationError.name === "AbortError")
+      ) {
+        return;
+      }
+      if (verificationError instanceof RiaApiError && verificationError.status === 429) {
+        setError(verificationError.message);
+        setNameVerificationStatus("idle");
+        setNameVerificationResult(null);
+        setLastVerifiedQuery(null);
+        return;
+      }
+      setNameVerificationResult({
+        status: "provider_unavailable",
+        reason:
+          verificationError instanceof Error
+            ? verificationError.message
+            : "Could not verify this RIA name right now.",
+        provider: "ria_intelligence_stage1",
+        suggested_names: [],
+      });
+      setNameVerificationStatus("provider_unavailable");
+      setLastVerifiedQuery(null);
+    } finally {
+      if (requestId === verificationRequestIdRef.current) {
+        verificationAbortRef.current = null;
+      }
+    }
+  }
 
   function updateDraft(patch: Partial<RiaOnboardingDraft>) {
     setNotice(null);
@@ -334,7 +619,7 @@ export default function RiaOnboardingPage() {
       });
       return {
         ...next,
-        currentStepId: resolveRiaOnboardingStepId(next, next.currentStepId),
+        currentStepId: resolveRiaOnboardingStepId(next, next.currentStepId, flowOptions),
       };
     });
   }
@@ -342,7 +627,7 @@ export default function RiaOnboardingPage() {
   function moveToStep(stepId: RiaOnboardingStepId) {
     setDraft((current) => ({
       ...current,
-      currentStepId: resolveRiaOnboardingStepId(current, stepId),
+      currentStepId: resolveRiaOnboardingStepId(current, stepId, flowOptions),
     }));
   }
 
@@ -368,6 +653,9 @@ export default function RiaOnboardingPage() {
     setNotice(null);
     try {
       const idToken = await user.getIdToken();
+      if (mode === "submit" && !nameVerificationSatisfied) {
+        throw new Error("Verify the advisor name and wait for a CRD-backed result before continuing.");
+      }
       const payload = buildSubmitPayload(draft);
       const result =
         mode === "submit"
@@ -378,17 +666,30 @@ export default function RiaOnboardingPage() {
         ...(current || { exists: true }),
         display_name: draft.displayName.trim(),
         requested_capabilities: result.requested_capabilities,
-        individual_legal_name: draft.individualLegalName.trim() || undefined,
-        individual_crd: draft.individualCrd.trim() || undefined,
-        advisory_firm_legal_name: draft.advisoryFirmName.trim() || undefined,
-        advisory_firm_iapd_number: draft.advisoryFirmIapdNumber.trim() || undefined,
-        broker_firm_legal_name: draft.brokerFirmName.trim() || undefined,
-        broker_firm_crd: draft.brokerFirmCrd.trim() || undefined,
+        individual_legal_name: result.individual_legal_name || undefined,
+        individual_crd: result.individual_crd || undefined,
+        advisory_firm_legal_name: result.advisory_firm_legal_name || undefined,
+        advisory_firm_iapd_number: result.advisory_firm_iapd_number || undefined,
+        broker_firm_legal_name: result.broker_firm_legal_name || draft.brokerFirmName.trim() || undefined,
+        broker_firm_crd: result.broker_firm_crd || draft.brokerFirmCrd.trim() || undefined,
         verification_status: result.verification_status,
         advisory_status: result.advisory_status,
         brokerage_status: result.brokerage_status,
         dev_ria_bypass_allowed: mode === "dev_activate" ? true : current?.dev_ria_bypass_allowed,
       }));
+      if (mode === "submit" && result.advisory_status === "verified") {
+        setNameVerificationStatus("verified");
+        setNameVerificationResult({
+          status: "verified",
+          matched_name: result.individual_legal_name || draft.displayName.trim() || null,
+          crd_number: result.individual_crd || null,
+          current_firm: result.advisory_firm_legal_name || null,
+          sec_number: result.advisory_firm_iapd_number || null,
+          provider: result.verification_provider || "ria_intelligence_stage1",
+          suggested_names: [],
+        });
+        setLastVerifiedQuery(draft.displayName.trim());
+      }
       trackEvent("ria_onboarding_submitted", {
         result: "success",
       });
@@ -450,11 +751,11 @@ export default function RiaOnboardingPage() {
         toast.error("Verification failed", {
           description:
             result.verification_message ||
-            "The Individual CRD and Firm IAPD / IARD details did not verify.",
+            "The advisor name could not be verified against a CRD-backed registration.",
         });
         setNotice(
           result.verification_message ||
-            "Verification was rejected. Please verify legal name and CRD and submit again."
+            "Verification was rejected. Retry the advisor name."
         );
       } else if (advisoryOutcome === "verified" || advisoryOutcome === "active") {
         trackEvent("ria_verification_status_changed", {
@@ -464,7 +765,7 @@ export default function RiaOnboardingPage() {
         toast.success("Credentials verified", {
           description:
             result.verification_message ||
-            "Your Individual CRD and Firm IAPD / IARD checks passed.",
+            "Your advisor name resolved to a verified CRD-backed RIA record.",
         });
         setNotice("Verification passed. Your RIA workspace is ready.");
       } else if (advisoryOutcome === "bypassed") {
@@ -503,10 +804,10 @@ export default function RiaOnboardingPage() {
         toast.info("Verification submitted", {
           description:
             result.verification_message ||
-            "We are still validating the Individual CRD and Firm IAPD / IARD details.",
+            "Kai is still validating the advisor name.",
         });
         setNotice(
-          "Onboarding submitted. Kai will keep the verification lane fail-closed until trust clears."
+          "Onboarding submitted. Kai will keep this profile locked until verification clears."
         );
       }
       moveToStep("review");
@@ -550,7 +851,7 @@ export default function RiaOnboardingPage() {
               <StepChoice
                 active={draft.requestedCapabilities.includes("advisory")}
                 label="Advisory"
-                description="Unlock the current RIA workflow once IAPD verification passes."
+                description="Unlock the current RIA workflow once the advisor name is verified."
                 onClick={() => {
                   const next: RiaCapability[] = draft.requestedCapabilities.includes("advisory")
                     ? draft.requestedCapabilities.filter((value) => value !== "advisory")
@@ -580,51 +881,201 @@ export default function RiaOnboardingPage() {
         return (
           <div className="space-y-4">
             <TextField
-              label="Display name"
-              placeholder="Manish Sainani"
+              label="Advisor name"
+              placeholder="Ana Roumenova Carter"
               value={draft.displayName}
-              onChange={(value) => updateDraft({ displayName: value })}
+              onChange={handleDisplayNameChange}
+              onKeyDown={(event) => {
+                if (event.key !== "Enter") return;
+                event.preventDefault();
+                void handleVerifyName();
+              }}
             />
+            {nameVerificationStatus === "idle" ? (
+              <p className="text-sm leading-6 text-muted-foreground">
+                Kai verifies your identity against FINRA and SEC records before unlocking the advisory workflow.
+              </p>
+            ) : null}
+            {nameVerificationStatus !== "idle" ? (
+            <div
+              className={cn(
+                "rounded-[24px] border px-4 py-4 text-sm",
+                nameVerificationStatus === "verified"
+                  ? "border-emerald-500/20 bg-emerald-500/8"
+                  : nameVerificationStatus === "not_verified"
+                    ? "border-amber-500/20 bg-amber-500/8"
+                    : nameVerificationStatus === "provider_unavailable"
+                      ? "border-rose-500/20 bg-rose-500/8"
+                      : "border-border/70 bg-background/70"
+              )}
+            >
+              {displayNameQuery.length > 0 && nameVerificationStatus === "verifying" ? (
+                  <div className="flex items-start gap-3">
+                    <Loader2 className="mt-0.5 h-4 w-4 animate-spin text-muted-foreground" />
+                    <div className="space-y-1">
+                      <p className="leading-6 text-muted-foreground">
+                        Verifying this advisor name now.
+                      </p>
+                      <p className="text-sm leading-6 text-muted-foreground">
+                        This can take a few moments the first time.
+                      </p>
+                    </div>
+                  </div>
+                ) : null}
+              {nameVerificationStatus === "verified" && verifiedIdentity.crdNumber ? (
+                <div className="space-y-4">
+                  <div className="flex items-start gap-3">
+                    <CheckCircle2 className="mt-0.5 h-4 w-4 text-emerald-600" />
+                    <div className="space-y-1">
+                      <p className="font-medium text-foreground">
+                        RIA verified: {verifiedIdentity.matchedName || draft.displayName.trim()}
+                      </p>
+                      <p className="leading-6 text-muted-foreground">
+                        CRD {verifiedIdentity.crdNumber}
+                        {verifiedIdentity.currentFirm ? ` · ${verifiedIdentity.currentFirm}` : ""}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <ReviewField
+                      label="Verified name"
+                      value={verifiedIdentity.matchedName || "Not returned"}
+                    />
+                    <ReviewField
+                      label="CRD"
+                      value={verifiedIdentity.crdNumber || "Not returned"}
+                    />
+                    <ReviewField
+                      label="Advisory firm"
+                      value={verifiedIdentity.currentFirm || "Not returned"}
+                    />
+                    <ReviewField
+                      label="IAPD / IARD"
+                      value={verifiedIdentity.secNumber || "Not returned"}
+                    />
+                  </div>
+                </div>
+              ) : null}
+              {nameVerificationStatus === "not_verified" ? (
+                <div className="space-y-2">
+                  <p className="font-medium text-foreground">
+                    {isBroadNameQuery
+                      ? "Kai needs a more specific advisor name before verification can continue."
+                      : "Kai could not verify this advisor name yet."}
+                  </p>
+                  <p className="leading-6 text-muted-foreground">
+                    {isBroadNameQuery
+                      ? "Try the advisor's full legal name so Kai can narrow to one registered professional."
+                      : nameVerificationResult?.reason ||
+                        "No confident FINRA or SEC match was found for the query."}
+                  </p>
+                  {isBroadNameQuery && nameVerificationResult?.reason ? (
+                    <p className="leading-6 text-muted-foreground">{nameVerificationResult.reason}</p>
+                  ) : null}
+                  {nameVerificationResult?.suggested_names?.length ? (
+                    <div className="space-y-2">
+                      <p className="leading-6 text-muted-foreground">
+                        {isBroadNameQuery
+                          ? "Try one of these fuller names:"
+                          : "Suggested matches:"}
+                      </p>
+                      <div className="flex flex-wrap gap-2">
+                        {nameVerificationResult.suggested_names.map((suggestion) => (
+                          <button
+                            key={suggestion}
+                            type="button"
+                            onClick={() => handleSuggestedNameSelect(suggestion)}
+                            className="inline-flex min-h-9 items-center rounded-full border border-border bg-background px-3 text-sm font-medium text-foreground hover:bg-muted/40"
+                          >
+                            {suggestion}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
+              {nameVerificationStatus === "provider_unavailable" ? (
+                <div className="space-y-2">
+                  <p className="font-medium text-foreground">
+                    Kai could not complete verification right now.
+                  </p>
+                  <p className="leading-6 text-muted-foreground">
+                    {nameVerificationResult?.reason ||
+                      "The verification service is unavailable right now."}
+                  </p>
+                </div>
+              ) : null}
+            </div>
+            ) : null}
+
+            <div className="flex flex-wrap gap-2">
+              {nameVerificationStatus !== "verified" ? (
+                <button
+                  type="button"
+                  onClick={() => void handleVerifyName()}
+                  disabled={!canVerifyName}
+                  className="inline-flex min-h-10 items-center rounded-full bg-foreground px-4 text-sm font-medium text-background disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {nameVerificationStatus === "verifying"
+                    ? "Verifying..."
+                    : nameVerificationStatus === "not_verified" ||
+                        nameVerificationStatus === "provider_unavailable"
+                      ? "Retry verification"
+                      : "Verify"}
+                </button>
+              ) : null}
+            </div>
+
             <p className="text-sm leading-6 text-muted-foreground">
-              Investors should recognize this name immediately on discovery cards, connection
-              requests, and consent prompts.
+              Advisory access requires a verified CRD-backed identity. If the name does not resolve to a unique registration, update it and retry verification.
             </p>
           </div>
         );
       case "legal_identity":
         return (
-          <div className="grid gap-4 sm:grid-cols-2">
-            <TextField
-              label="Individual legal name"
-              placeholder="Full legal adviser or broker name"
-              value={draft.individualLegalName}
-              onChange={(value) => updateDraft({ individualLegalName: value })}
-            />
-            <TextField
-              label="Individual CRD"
-              placeholder="CRD number"
-              value={draft.individualCrd}
-              inputMode="numeric"
-              onChange={(value) => updateDraft({ individualCrd: value })}
-            />
+          <div className="space-y-4">
+            <div className="rounded-[20px] border border-border/70 bg-background/70 px-4 py-4 text-sm text-muted-foreground">
+              Manual fallback is only for cases where the name-first Stage 1 lookup cannot verify the advisor cleanly.
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <TextField
+                label="Individual legal name"
+                placeholder="Full legal adviser or broker name"
+                value={draft.individualLegalName}
+                onChange={(value) => updateDraft({ individualLegalName: value })}
+              />
+              <TextField
+                label="Individual CRD"
+                placeholder="CRD number"
+                value={draft.individualCrd}
+                inputMode="numeric"
+                onChange={(value) => updateDraft({ individualCrd: value })}
+              />
+            </div>
           </div>
         );
       case "advisory_firm":
         return (
-          <div className="grid gap-4 sm:grid-cols-2">
-            <TextField
-              label="Advisory firm name"
-              placeholder="Registered advisory firm name"
-              value={draft.advisoryFirmName}
-              onChange={(value) => updateDraft({ advisoryFirmName: value })}
-            />
-            <TextField
-              label="Firm IAPD / IARD"
-              placeholder="IAPD / IARD number"
-              value={draft.advisoryFirmIapdNumber}
-              inputMode="numeric"
-              onChange={(value) => updateDraft({ advisoryFirmIapdNumber: value })}
-            />
+          <div className="space-y-4">
+            <p className="text-sm leading-6 text-muted-foreground">
+              Kai only asks for firm IAPD / IARD when you explicitly choose the manual fallback path.
+            </p>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <TextField
+                label="Advisory firm name"
+                placeholder="Registered advisory firm name"
+                value={draft.advisoryFirmName}
+                onChange={(value) => updateDraft({ advisoryFirmName: value })}
+              />
+              <TextField
+                label="Firm IAPD / IARD"
+                placeholder="IAPD / IARD number"
+                value={draft.advisoryFirmIapdNumber}
+                inputMode="numeric"
+                onChange={(value) => updateDraft({ advisoryFirmIapdNumber: value })}
+              />
+            </div>
           </div>
         );
       case "broker_firm":
@@ -699,17 +1150,17 @@ export default function RiaOnboardingPage() {
               title="Regulatory identity Kai will verify"
             >
               <SettingsRow
-                title={draft.displayName.trim() || "Display name missing"}
+                title={verifiedIdentity.matchedName || draft.displayName.trim() || "Display name missing"}
                 description="Investor-facing professional identity"
               />
               <SettingsRow
-                title={draft.individualLegalName.trim() || "Legal name missing"}
-                description={`CRD ${draft.individualCrd.trim() || "not provided yet"}`}
+                title={verifiedIdentity.matchedName || "Name verification pending"}
+                description={`CRD ${verifiedIdentity.crdNumber || "not verified yet"}`}
               />
-              {draft.requestedCapabilities.includes("advisory") ? (
+              {draft.requestedCapabilities.includes("advisory") && verifiedIdentity.currentFirm ? (
                 <SettingsRow
-                  title={draft.advisoryFirmName.trim() || "Advisory firm missing"}
-                  description={`IAPD / IARD ${draft.advisoryFirmIapdNumber.trim() || "not provided yet"}`}
+                  title={verifiedIdentity.currentFirm || "Advisory firm not returned"}
+                  description={`IAPD / IARD ${verifiedIdentity.secNumber || "not returned"}`}
                 />
               ) : null}
               {draft.requestedCapabilities.includes("brokerage") ? (

--- a/hushh-webapp/lib/ria/ria-onboarding-flow.ts
+++ b/hushh-webapp/lib/ria/ria-onboarding-flow.ts
@@ -32,6 +32,10 @@ export type RiaOnboardingStep = {
   description: string;
 };
 
+export type RiaOnboardingFlowOptions = {
+  nameVerificationSatisfied?: boolean;
+};
+
 const STEP_ORDER: RiaOnboardingStepId[] = [
   "capabilities",
   "display_name",
@@ -105,7 +109,10 @@ export function normalizeRiaOnboardingDraft(
   };
 }
 
-export function buildRiaOnboardingSteps(draft: RiaOnboardingDraft): RiaOnboardingStep[] {
+export function buildRiaOnboardingSteps(
+  draft: RiaOnboardingDraft,
+  _options?: RiaOnboardingFlowOptions
+): RiaOnboardingStep[] {
   const steps: RiaOnboardingStep[] = [
     {
       id: "capabilities",
@@ -117,28 +124,11 @@ export function buildRiaOnboardingSteps(draft: RiaOnboardingDraft): RiaOnboardin
     {
       id: "display_name",
       eyebrow: "Identity",
-      title: "What name should investors recognize immediately?",
+      title: "What name should Kai verify first?",
       description:
-        "This is the public name carried into discovery, invites, and consent surfaces.",
-    },
-    {
-      id: "legal_identity",
-      eyebrow: "Verification",
-      title: "Who should Kai verify against regulator records?",
-      description:
-        "We use your legal name and individual CRD to fail closed before any advisor workflow goes live.",
+        "Enter the advisor name once. Kai verifies it in the background before the rest of the RIA workflow opens.",
     },
   ];
-
-  if (draft.requestedCapabilities.includes("advisory")) {
-    steps.push({
-      id: "advisory_firm",
-      eyebrow: "Advisory Firm",
-      title: "Which advisory firm should Kai verify with your profile?",
-      description:
-        "Use the primary registered advisory firm and IAPD/IARD number investors should trust.",
-    });
-  }
 
   if (draft.requestedCapabilities.includes("brokerage")) {
     steps.push({
@@ -172,13 +162,14 @@ export function buildRiaOnboardingSteps(draft: RiaOnboardingDraft): RiaOnboardin
 
 export function canContinueRiaOnboardingStep(
   stepId: RiaOnboardingStepId,
-  draft: RiaOnboardingDraft
+  draft: RiaOnboardingDraft,
+  options?: RiaOnboardingFlowOptions
 ): boolean {
   switch (stepId) {
     case "capabilities":
       return draft.requestedCapabilities.length > 0;
     case "display_name":
-      return draft.displayName.trim().length > 0;
+      return draft.displayName.trim().length > 0 && Boolean(options?.nameVerificationSatisfied);
     case "legal_identity":
       return (
         draft.individualLegalName.trim().length > 0 &&
@@ -210,30 +201,36 @@ export function getRequestedCapabilityLabels(draft: RiaOnboardingDraft): string[
 
 export function resolveRiaOnboardingStepId(
   draft: RiaOnboardingDraft,
-  preferredStepId?: RiaOnboardingStepId | null
+  preferredStepId?: RiaOnboardingStepId | null,
+  options?: RiaOnboardingFlowOptions
 ): RiaOnboardingStepId {
-  const steps = buildRiaOnboardingSteps(draft);
+  const steps = buildRiaOnboardingSteps(draft, options);
   if (preferredStepId && steps.some((step) => step.id === preferredStepId)) {
     return preferredStepId;
   }
   if (preferredStepId) {
     return steps[0]?.id || "capabilities";
   }
-  return findFirstIncompleteRiaOnboardingStepId(draft);
+  return findFirstIncompleteRiaOnboardingStepId(draft, options);
 }
 
 export function findFirstIncompleteRiaOnboardingStepId(
-  draft: RiaOnboardingDraft
+  draft: RiaOnboardingDraft,
+  options?: RiaOnboardingFlowOptions
 ): RiaOnboardingStepId {
-  const steps = buildRiaOnboardingSteps(draft);
-  const incomplete = steps.find((step) => step.id !== "review" && !canContinueRiaOnboardingStep(step.id, draft));
+  const steps = buildRiaOnboardingSteps(draft, options);
+  const incomplete = steps.find(
+    (step) =>
+      step.id !== "review" && !canContinueRiaOnboardingStep(step.id, draft, options)
+  );
   return incomplete?.id || "review";
 }
 
 export function getRiaOnboardingStepIndex(
   draft: RiaOnboardingDraft,
-  currentStepId: RiaOnboardingStepId
+  currentStepId: RiaOnboardingStepId,
+  options?: RiaOnboardingFlowOptions
 ): number {
-  const index = buildRiaOnboardingSteps(draft).findIndex((step) => step.id === currentStepId);
+  const index = buildRiaOnboardingSteps(draft, options).findIndex((step) => step.id === currentStepId);
   return index >= 0 ? index : 0;
 }

--- a/hushh-webapp/lib/services/ria-service.ts
+++ b/hushh-webapp/lib/services/ria-service.ts
@@ -61,6 +61,7 @@ export interface RiaOnboardingStatus {
   exists: boolean;
   ria_profile_id?: string;
   verification_status: string;
+  verification_provider?: string;
   advisory_status?: string;
   brokerage_status?: string;
   requested_capabilities?: string[];
@@ -93,6 +94,18 @@ export interface RiaOnboardingStatus {
     expires_at?: string | null;
     reference_metadata?: Record<string, unknown>;
   } | null;
+}
+
+export interface RiaNameVerificationResult {
+  status: "verified" | "not_verified" | "provider_unavailable";
+  matched_name?: string | null;
+  crd_number?: string | null;
+  current_firm?: string | null;
+  sec_number?: string | null;
+  reason?: string | null;
+  reason_code?: "query_too_broad" | "no_confident_match";
+  suggested_names?: string[];
+  provider: string;
 }
 
 export interface RiaFirmMembership {
@@ -488,6 +501,7 @@ interface FetchOptions {
   method: "GET" | "POST";
   body?: Record<string, unknown>;
   idToken?: string;
+  signal?: AbortSignal;
 }
 
 interface CachedReadOptions {
@@ -766,6 +780,7 @@ async function authFetch(path: string, options: FetchOptions): Promise<Response>
     method: options.method,
     headers,
     body: options.body ? JSON.stringify(options.body) : undefined,
+    signal: options.signal,
   });
 }
 
@@ -1018,6 +1033,12 @@ export class RiaService {
     brokerage_outcome: string;
     brokerage_message: string;
     professional_access_granted: boolean;
+    individual_legal_name?: string | null;
+    individual_crd?: string | null;
+    advisory_firm_legal_name?: string | null;
+    advisory_firm_iapd_number?: string | null;
+    broker_firm_legal_name?: string | null;
+    broker_firm_crd?: string | null;
   }> {
     const response = await authFetch("/api/ria/onboarding/submit", {
       method: "POST",
@@ -1025,6 +1046,20 @@ export class RiaService {
       body: payload,
     });
     return toJsonOrThrow(response);
+  }
+
+  static async verifyOnboardingName(
+    idToken: string,
+    payload: { query: string },
+    options?: { signal?: AbortSignal }
+  ): Promise<RiaNameVerificationResult> {
+    const response = await authFetch("/api/ria/onboarding/verify-name", {
+      method: "POST",
+      idToken,
+      body: payload,
+      signal: options?.signal,
+    });
+    return toJsonOrThrow<RiaNameVerificationResult>(response);
   }
 
   static async getOnboardingStatus(
@@ -1080,6 +1115,12 @@ export class RiaService {
     brokerage_outcome: string;
     brokerage_message: string;
     professional_access_granted: boolean;
+    individual_legal_name?: string | null;
+    individual_crd?: string | null;
+    advisory_firm_legal_name?: string | null;
+    advisory_firm_iapd_number?: string | null;
+    broker_firm_legal_name?: string | null;
+    broker_firm_crd?: string | null;
   }> {
     const response = await authFetch("/api/ria/onboarding/dev-activate", {
       method: "POST",


### PR DESCRIPTION
## What changed
- make RIA onboarding Step 2 explicit-action only: user enters advisor name, clicks `Verify`, and `Continue` unlocks only after a verified Stage 1 result with a CRD
- keep Stage 1 as the only verification lane for this flow and remove manual fallback / reCAPTCHA handling from the frontend-backend contract
- re-verify the advisor server-side on submit so only verified RIAs can complete onboarding and receive access
- preserve the verified regulatory summary shown after success: matched name, CRD, firm, and IARD when available
- clean related env, deploy, and docs references so the verification contract matches the code path in production

## Why this changed
Step 2 had drifted into a more complex flow than the product contract. We wanted a tighter onboarding gate where advisory access is only granted after an explicit name verification with a CRD-backed Stage 1 match, without hidden prefetches, fallback branches, or reCAPTCHA-specific handling.

## Impact
- advisors must explicitly verify their name before continuing
- failed lookups remain retry-only and do not unlock the onboarding flow
- backend submit stays fail-closed for unverified advisors
- deploy and docs references now align with the Stage 1-only contract

## Validation
- `npm run typecheck`
- `npm run test -- __tests__/app/ria/onboarding-page.test.tsx __tests__/services/ria-onboarding-flow.test.ts`
- `/Volumes/AnkitSSD/Projects/github/hushh-labs/hushh-research/consent-protocol/.venv/bin/python -m pytest tests/test_ria_iam_routes.py tests/test_ria_iam_service_architecture.py tests/test_ria_verification_intelligence.py -q`
