### PR TITLE
feat(pkm): add KYC/email artifact write path and explorer integration

### DIFF
--- a/hushh-webapp/__tests__/services/kyc-workflow-pkm-service.test.ts
+++ b/hushh-webapp/__tests__/services/kyc-workflow-pkm-service.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/services/pkm-write-coordinator", () => ({
+  PkmWriteCoordinator: {
+    saveMergedDomain: vi.fn(),
+  },
+}));
+
+import {
+  KycWorkflowPkmService,
+  KYC_WORKFLOW_PKM_DOMAIN,
+} from "@/lib/services/kyc-pkm-write-service";
+
+describe("KycWorkflowPkmService", () => {
+  it("uses a workflow namespace instead of a canonical kyc fact domain", () => {
+    expect(KYC_WORKFLOW_PKM_DOMAIN).toBe("kyc_workflow");
+  });
+
+  it("returns empty state when no workflow artifact exists", () => {
+    expect(KycWorkflowPkmService.readWorkflowArtifact(null)).toEqual({
+      found: false,
+      artifact: null,
+    });
+    expect(KycWorkflowPkmService.readWorkflowArtifact({})).toEqual({
+      found: false,
+      artifact: null,
+    });
+  });
+
+  it("reads KYC workflow state without treating it as canonical identity storage", () => {
+    const result = KycWorkflowPkmService.readWorkflowArtifact({
+      checks: {
+        identity: {
+          status: "verified",
+          updated_at: "2026-04-20T00:00:00.000Z",
+          method: "document_review",
+          source_domain: "identity",
+        },
+        address: {
+          status: "pending",
+          updated_at: null,
+          method: null,
+          source_domain: "address",
+        },
+      },
+      counterparty: "example fund admin",
+      request_summary: "Missing proof of address",
+      pending_requirements: ["proof_of_address"],
+      completed_requirements: ["identity_document"],
+      overall_status: "pending",
+      last_updated: "2026-04-20T00:00:00.000Z",
+    });
+
+    expect(result.found).toBe(true);
+    expect(result.artifact?.checks.identity.status).toBe("verified");
+    expect(result.artifact?.checks.identity.source_domain).toBe("identity");
+    expect(result.artifact?.checks.address.status).toBe("pending");
+    expect(result.artifact?.checks.bank.status).toBe("not_started");
+    expect(result.artifact?.pending_requirements).toEqual(["proof_of_address"]);
+    expect(result.artifact).not.toHaveProperty("email.address");
+  });
+});

--- a/hushh-webapp/components/onboarding/previews/KycPreviewCompact.tsx
+++ b/hushh-webapp/components/onboarding/previews/KycPreviewCompact.tsx
@@ -6,7 +6,10 @@ import { Icon } from "@/lib/morphy-ux/ui";
 import { useAuth } from "@/hooks/use-auth";
 import { useVault } from "@/lib/vault/vault-context";
 import { usePkmDomainResource } from "@/lib/pkm/pkm-domain-resource";
-import { KycPkmWriteService, KYC_PKM_DOMAIN } from "@/lib/services/kyc-pkm-write-service";
+import {
+  KycWorkflowPkmService,
+  KYC_WORKFLOW_PKM_DOMAIN,
+} from "@/lib/services/kyc-pkm-write-service";
 import { CircleCheck, CircleDashed, Home, Landmark, User } from "lucide-react";
 
 type KycItemStatus = "verified" | "pending" | "not_started" | "failed";
@@ -25,25 +28,27 @@ function StatusIcon({ status }: { status: KycItemStatus }) {
   return <Icon icon={CircleDashed} size="lg" className="text-muted-foreground" />;
 }
 
-function buildDisplayItems(artifact: ReturnType<typeof KycPkmWriteService.readKycArtifact>["artifact"]): KycDisplayItem[] {
+function buildDisplayItems(
+  artifact: ReturnType<typeof KycWorkflowPkmService.readWorkflowArtifact>["artifact"]
+): KycDisplayItem[] {
   return [
     {
-      label: "Identity verified",
+      label: "Identity requirement",
       icon: User,
       iconTone: "text-[var(--tone-blue)] bg-[var(--tone-blue-bg)]",
-      status: artifact?.identity.status ?? "not_started",
+      status: artifact?.checks.identity.status ?? "not_started",
     },
     {
-      label: "Address verified",
+      label: "Address requirement",
       icon: Home,
       iconTone: "text-violet-600 bg-violet-100 dark:text-violet-300 dark:bg-violet-900/35",
-      status: artifact?.address.status ?? "not_started",
+      status: artifact?.checks.address.status ?? "not_started",
     },
     {
-      label: "Bank account linked",
+      label: "Bank requirement",
       icon: Landmark,
       iconTone: "text-[var(--tone-green)] bg-[var(--tone-green-bg)]",
-      status: artifact?.bank.status ?? "not_started",
+      status: artifact?.checks.bank.status ?? "not_started",
     },
   ];
 }
@@ -54,19 +59,19 @@ export function KycPreviewCompact() {
 
   const { data: snapshot } = usePkmDomainResource({
     userId: user?.uid ?? "",
-    domain: KYC_PKM_DOMAIN,
+    domain: KYC_WORKFLOW_PKM_DOMAIN,
     vaultKey,
     vaultOwnerToken,
     enabled: Boolean(user?.uid && isVaultUnlocked),
   });
 
-  const { artifact } = KycPkmWriteService.readKycArtifact(
+  const { artifact } = KycWorkflowPkmService.readWorkflowArtifact(
     snapshot?.data ?? null
   );
 
   const items = buildDisplayItems(artifact);
   const allVerified = items.every((item) => item.status === "verified");
-  const overallLabel = allVerified ? "KYC completed" : "KYC in progress";
+  const overallLabel = allVerified ? "KYC workflow completed" : "KYC workflow in progress";
   const speedLabel = allVerified ? "SPEED: INSTANT" : "Verification pending";
 
   return (
@@ -113,7 +118,7 @@ export function KycPreviewCompact() {
               </p>
             ) : (
               <p className="text-xs font-medium text-muted-foreground">
-                Complete verification to unlock all features
+                Review pending requirements to keep this workflow moving
               </p>
             )}
           </div>

--- a/hushh-webapp/components/onboarding/previews/KycPreviewCompact.tsx
+++ b/hushh-webapp/components/onboarding/previews/KycPreviewCompact.tsx
@@ -3,27 +3,72 @@
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/lib/morphy-ux/card";
 import { Icon } from "@/lib/morphy-ux/ui";
-import { CircleCheck, Home, Landmark, User } from "lucide-react";
+import { useAuth } from "@/hooks/use-auth";
+import { useVault } from "@/lib/vault/vault-context";
+import { usePkmDomainResource } from "@/lib/pkm/pkm-domain-resource";
+import { KycPkmWriteService, KYC_PKM_DOMAIN } from "@/lib/services/kyc-pkm-write-service";
+import { CircleCheck, CircleDashed, Home, Landmark, User } from "lucide-react";
 
-const KYC_ITEMS = [
-  {
-    label: "Identity verified",
-    icon: User,
-    iconTone: "text-[var(--tone-blue)] bg-[var(--tone-blue-bg)]",
-  },
-  {
-    label: "Address verified",
-    icon: Home,
-    iconTone: "text-violet-600 bg-violet-100 dark:text-violet-300 dark:bg-violet-900/35",
-  },
-  {
-    label: "Bank account linked",
-    icon: Landmark,
-    iconTone: "text-[var(--tone-green)] bg-[var(--tone-green-bg)]",
-  },
-] as const;
+type KycItemStatus = "verified" | "pending" | "not_started" | "failed";
+
+type KycDisplayItem = {
+  label: string;
+  icon: typeof User;
+  iconTone: string;
+  status: KycItemStatus;
+};
+
+function StatusIcon({ status }: { status: KycItemStatus }) {
+  if (status === "verified") {
+    return <Icon icon={CircleCheck} size="lg" className="text-emerald-500" />;
+  }
+  return <Icon icon={CircleDashed} size="lg" className="text-muted-foreground" />;
+}
+
+function buildDisplayItems(artifact: ReturnType<typeof KycPkmWriteService.readKycArtifact>["artifact"]): KycDisplayItem[] {
+  return [
+    {
+      label: "Identity verified",
+      icon: User,
+      iconTone: "text-[var(--tone-blue)] bg-[var(--tone-blue-bg)]",
+      status: artifact?.identity.status ?? "not_started",
+    },
+    {
+      label: "Address verified",
+      icon: Home,
+      iconTone: "text-violet-600 bg-violet-100 dark:text-violet-300 dark:bg-violet-900/35",
+      status: artifact?.address.status ?? "not_started",
+    },
+    {
+      label: "Bank account linked",
+      icon: Landmark,
+      iconTone: "text-[var(--tone-green)] bg-[var(--tone-green-bg)]",
+      status: artifact?.bank.status ?? "not_started",
+    },
+  ];
+}
 
 export function KycPreviewCompact() {
+  const { user } = useAuth();
+  const { vaultKey, vaultOwnerToken, isVaultUnlocked } = useVault();
+
+  const { data: snapshot } = usePkmDomainResource({
+    userId: user?.uid ?? "",
+    domain: KYC_PKM_DOMAIN,
+    vaultKey,
+    vaultOwnerToken,
+    enabled: Boolean(user?.uid && isVaultUnlocked),
+  });
+
+  const { artifact } = KycPkmWriteService.readKycArtifact(
+    snapshot?.data ?? null
+  );
+
+  const items = buildDisplayItems(artifact);
+  const allVerified = items.every((item) => item.status === "verified");
+  const overallLabel = allVerified ? "KYC completed" : "KYC in progress";
+  const speedLabel = allVerified ? "SPEED: INSTANT" : "Verification pending";
+
   return (
     <Card
       variant="none"
@@ -36,11 +81,11 @@ export function KycPreviewCompact() {
       <div className="morphy-theme-content relative overflow-hidden p-7">
         <div className="relative space-y-6">
           <h3 className="text-center text-xl font-extrabold tracking-tight">
-            Status: KYC completed
+            Status: {overallLabel}
           </h3>
 
           <div className="space-y-3">
-            {KYC_ITEMS.map((item) => (
+            {items.map((item) => (
               <div
                 key={item.label}
                 className="flex items-center justify-between rounded-2xl border border-background/70 bg-background/50 px-3.5 py-3"
@@ -53,18 +98,24 @@ export function KycPreviewCompact() {
                   </div>
                   <span className="text-[15px] font-semibold">{item.label}</span>
                 </div>
-                <Icon icon={CircleCheck} size="lg" className="text-emerald-500" />
+                <StatusIcon status={item.status} />
               </div>
             ))}
           </div>
 
           <div className="space-y-2 text-center">
             <Badge className="rounded-full border border-[var(--brand-200)] bg-[var(--brand-50)] px-4 py-1.5 text-[11px] font-bold tracking-wide text-[var(--tone-blue)] uppercase">
-              SPEED: INSTANT
+              {speedLabel}
             </Badge>
-            <p className="text-xs font-medium text-muted-foreground">
-              Accelerated by 90% via automated verification
-            </p>
+            {allVerified ? (
+              <p className="text-xs font-medium text-muted-foreground">
+                Accelerated by 90% via automated verification
+              </p>
+            ) : (
+              <p className="text-xs font-medium text-muted-foreground">
+                Complete verification to unlock all features
+              </p>
+            )}
           </div>
         </div>
       </div>

--- a/hushh-webapp/components/profile/pkm-explorer-panel.tsx
+++ b/hushh-webapp/components/profile/pkm-explorer-panel.tsx
@@ -30,7 +30,7 @@ import {
 } from "@/lib/services/personal-knowledge-model-service";
 import { Button } from "@/lib/morphy-ux/morphy";
 import { type DomainManifest } from "@/lib/personal-knowledge-model/manifest";
-import {  KYC_PKM_DOMAIN } from "@/lib/services/kyc-pkm-write-service";
+import { KYC_WORKFLOW_PKM_DOMAIN } from "@/lib/services/kyc-pkm-write-service";
 
 type DomainInspectorState = {
   manifest: DomainManifest | null;
@@ -308,18 +308,22 @@ export function PkmExplorerPanel() {
                     onClick={() => setSelectedDomain(domain.key)}
                   >
                     <div className="flex items-start justify-between gap-3">
-                     <div className="min-w-0">
+                      <div className="min-w-0">
                         <p className="text-sm font-semibold">{domain.displayName}</p>
                         <p className="text-xs text-muted-foreground">{domain.key}</p>
                       </div>
                       <div className="flex flex-col items-end gap-1">
                         <Badge variant="secondary">{domain.attributeCount}</Badge>
-                        {domain.key === KYC_PKM_DOMAIN ? (
-                          <Badge variant="outline" className="text-[10px] text-emerald-600 border-emerald-300">
-                            KYC
+                        {domain.key === KYC_WORKFLOW_PKM_DOMAIN ? (
+                          <Badge
+                            variant="outline"
+                            className="border-emerald-300 text-[10px] text-emerald-600"
+                          >
+                            KYC workflow
                           </Badge>
                         ) : null}
-                      </div>                    </div>
+                      </div>
+                    </div>
                     <p className="mt-2 text-xs text-muted-foreground">
                       Updated {formatTimestamp(domain.lastUpdated)}
                     </p>

--- a/hushh-webapp/components/profile/pkm-explorer-panel.tsx
+++ b/hushh-webapp/components/profile/pkm-explorer-panel.tsx
@@ -21,6 +21,7 @@ import { PkmJsonTree, PkmManifestTree } from "@/components/profile/pkm-tree-view
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Badge } from "@/components/ui/badge";
 import { useAuth } from "@/hooks/use-auth";
+import { useVault } from "@/lib/vault/vault-context";
 import {
   PersonalKnowledgeModelService,
   type DomainSummary,

--- a/hushh-webapp/components/profile/pkm-explorer-panel.tsx
+++ b/hushh-webapp/components/profile/pkm-explorer-panel.tsx
@@ -29,7 +29,7 @@ import {
 } from "@/lib/services/personal-knowledge-model-service";
 import { Button } from "@/lib/morphy-ux/morphy";
 import { type DomainManifest } from "@/lib/personal-knowledge-model/manifest";
-import { useVault } from "@/lib/vault/vault-context";
+import {  KYC_PKM_DOMAIN } from "@/lib/services/kyc-pkm-write-service";
 
 type DomainInspectorState = {
   manifest: DomainManifest | null;
@@ -307,12 +307,18 @@ export function PkmExplorerPanel() {
                     onClick={() => setSelectedDomain(domain.key)}
                   >
                     <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
+                     <div className="min-w-0">
                         <p className="text-sm font-semibold">{domain.displayName}</p>
                         <p className="text-xs text-muted-foreground">{domain.key}</p>
                       </div>
-                      <Badge variant="secondary">{domain.attributeCount}</Badge>
-                    </div>
+                      <div className="flex flex-col items-end gap-1">
+                        <Badge variant="secondary">{domain.attributeCount}</Badge>
+                        {domain.key === KYC_PKM_DOMAIN ? (
+                          <Badge variant="outline" className="text-[10px] text-emerald-600 border-emerald-300">
+                            KYC
+                          </Badge>
+                        ) : null}
+                      </div>                    </div>
                     <p className="mt-2 text-xs text-muted-foreground">
                       Updated {formatTimestamp(domain.lastUpdated)}
                     </p>

--- a/hushh-webapp/lib/services/kyc-pkm-write-service.ts
+++ b/hushh-webapp/lib/services/kyc-pkm-write-service.ts
@@ -3,66 +3,94 @@
 import { PkmWriteCoordinator } from "@/lib/services/pkm-write-coordinator";
 import type { PkmWriteCoordinatorResult } from "@/lib/services/pkm-write-coordinator";
 
-export const KYC_PKM_DOMAIN = "kyc" as const;
+export const KYC_WORKFLOW_PKM_DOMAIN = "kyc_workflow" as const;
 
-export type KycVerificationStatus = "verified" | "pending" | "failed" | "not_started";
+export type KycWorkflowStatus = "verified" | "pending" | "failed" | "not_started";
+export type KycWorkflowCheckKey = "identity" | "address" | "bank" | "email";
 
-export type KycArtifact = {
-  identity: {
-    status: KycVerificationStatus;
-    verified_at: string | null;
-    method: string | null;
-  };
-  address: {
-    status: KycVerificationStatus;
-    verified_at: string | null;
-    method: string | null;
-  };
-  bank: {
-    status: KycVerificationStatus;
-    linked_at: string | null;
-    method: string | null;
-  };
-  email: {
-    address: string | null;
-    verified: boolean;
-    verified_at: string | null;
-  };
-  overall_status: KycVerificationStatus;
+export type KycWorkflowCheck = {
+  status: KycWorkflowStatus;
+  updated_at: string | null;
+  method: string | null;
+  source_domain: string | null;
+};
+
+export type KycWorkflowArtifact = {
+  checks: Record<KycWorkflowCheckKey, KycWorkflowCheck>;
+  overall_status: KycWorkflowStatus;
+  counterparty: string | null;
+  request_summary: string | null;
+  pending_requirements: string[];
+  completed_requirements: string[];
   last_updated: string;
   schema_version: 1;
 };
 
-export type KycPkmWriteParams = {
+export type KycWorkflowPkmWriteParams = {
   userId: string;
   vaultKey: string | null;
   vaultOwnerToken: string | null;
-  artifact: Omit<KycArtifact, "last_updated" | "schema_version">;
+  artifact: Omit<KycWorkflowArtifact, "last_updated" | "schema_version">;
 };
 
-export type KycPkmReadResult = {
+export type KycWorkflowPkmReadResult = {
   found: boolean;
-  artifact: KycArtifact | null;
+  artifact: KycWorkflowArtifact | null;
 };
 
-function buildKycSummary(artifact: KycArtifact): Record<string, unknown> {
+function emptyCheck(): KycWorkflowCheck {
   return {
+    status: "not_started",
+    updated_at: null,
+    method: null,
+    source_domain: null,
+  };
+}
+
+function normalizeCheck(value: unknown): KycWorkflowCheck {
+  if (!value || typeof value !== "object") return emptyCheck();
+  const record = value as Partial<KycWorkflowCheck>;
+  return {
+    status: record.status ?? "not_started",
+    updated_at: record.updated_at ?? null,
+    method: record.method ?? null,
+    source_domain: record.source_domain ?? null,
+  };
+}
+
+function normalizeChecks(value: unknown): KycWorkflowArtifact["checks"] {
+  const record = value && typeof value === "object"
+    ? value as Partial<Record<KycWorkflowCheckKey, unknown>>
+    : {};
+  return {
+    identity: normalizeCheck(record.identity),
+    address: normalizeCheck(record.address),
+    bank: normalizeCheck(record.bank),
+    email: normalizeCheck(record.email),
+  };
+}
+
+function buildKycSummary(artifact: KycWorkflowArtifact): Record<string, unknown> {
+  return {
+    workflow_type: "kyc",
     overall_status: artifact.overall_status,
-    identity_verified: artifact.identity.status === "verified",
-    address_verified: artifact.address.status === "verified",
-    bank_linked: artifact.bank.status === "verified",
-    email_verified: artifact.email.verified,
+    identity_verified: artifact.checks.identity.status === "verified",
+    address_verified: artifact.checks.address.status === "verified",
+    bank_linked: artifact.checks.bank.status === "verified",
+    email_verified: artifact.checks.email.status === "verified",
+    pending_requirement_count: artifact.pending_requirements.length,
+    completed_requirement_count: artifact.completed_requirements.length,
     last_updated: artifact.last_updated,
   };
 }
 
-export class KycPkmWriteService {
-  static async writeKycArtifact(
-    params: KycPkmWriteParams
+export class KycWorkflowPkmService {
+  static async writeWorkflowArtifact(
+    params: KycWorkflowPkmWriteParams
   ): Promise<PkmWriteCoordinatorResult> {
     const now = new Date().toISOString();
 
-    const artifact: KycArtifact = {
+    const artifact: KycWorkflowArtifact = {
       ...params.artifact,
       last_updated: now,
       schema_version: 1,
@@ -70,25 +98,31 @@ export class KycPkmWriteService {
 
     return PkmWriteCoordinator.saveMergedDomain({
       userId: params.userId,
-      domain: KYC_PKM_DOMAIN,
+      domain: KYC_WORKFLOW_PKM_DOMAIN,
       vaultKey: params.vaultKey,
       vaultOwnerToken: params.vaultOwnerToken,
       build: (context) => {
-        const existing = (context.currentDomainData ?? {}) as Partial<KycArtifact>;
-        const merged: KycArtifact = {
-          identity: artifact.identity.status !== "not_started"
-            ? artifact.identity
-            : (existing.identity ?? artifact.identity),
-          address: artifact.address.status !== "not_started"
-            ? artifact.address
-            : (existing.address ?? artifact.address),
-          bank: artifact.bank.status !== "not_started"
-            ? artifact.bank
-            : (existing.bank ?? artifact.bank),
-          email: artifact.email.verified
-            ? artifact.email
-            : (existing.email ?? artifact.email),
+        const existing = this.readWorkflowArtifact(context.currentDomainData).artifact;
+        const merged: KycWorkflowArtifact = {
+          checks: {
+            identity: artifact.checks.identity.status !== "not_started"
+              ? artifact.checks.identity
+              : existing?.checks.identity ?? artifact.checks.identity,
+            address: artifact.checks.address.status !== "not_started"
+              ? artifact.checks.address
+              : existing?.checks.address ?? artifact.checks.address,
+            bank: artifact.checks.bank.status !== "not_started"
+              ? artifact.checks.bank
+              : existing?.checks.bank ?? artifact.checks.bank,
+            email: artifact.checks.email.status !== "not_started"
+              ? artifact.checks.email
+              : existing?.checks.email ?? artifact.checks.email,
+          },
           overall_status: artifact.overall_status,
+          counterparty: artifact.counterparty ?? existing?.counterparty ?? null,
+          request_summary: artifact.request_summary ?? existing?.request_summary ?? null,
+          pending_requirements: artifact.pending_requirements,
+          completed_requirements: artifact.completed_requirements,
           last_updated: now,
           schema_version: 1,
         };
@@ -101,28 +135,35 @@ export class KycPkmWriteService {
     });
   }
 
-  static readKycArtifact(
+  static readWorkflowArtifact(
     domainData: Record<string, unknown> | null
-  ): KycPkmReadResult {
+  ): KycWorkflowPkmReadResult {
     if (!domainData) {
       return { found: false, artifact: null };
     }
 
-    const identity = domainData.identity as KycArtifact["identity"] | undefined;
-    const address = domainData.address as KycArtifact["address"] | undefined;
-    const bank = domainData.bank as KycArtifact["bank"] | undefined;
-    const email = domainData.email as KycArtifact["email"] | undefined;
+    const checks = normalizeChecks(domainData.checks);
+    const hasChecks = Object.values(checks).some((check) => check.status !== "not_started");
+    const pendingRequirements = Array.isArray(domainData.pending_requirements)
+      ? domainData.pending_requirements.filter((item): item is string => typeof item === "string")
+      : [];
+    const completedRequirements = Array.isArray(domainData.completed_requirements)
+      ? domainData.completed_requirements.filter((item): item is string => typeof item === "string")
+      : [];
 
-    if (!identity && !address && !bank && !email) {
+    if (!hasChecks && pendingRequirements.length === 0 && completedRequirements.length === 0) {
       return { found: false, artifact: null };
     }
 
-    const artifact: KycArtifact = {
-      identity: identity ?? { status: "not_started", verified_at: null, method: null },
-      address: address ?? { status: "not_started", verified_at: null, method: null },
-      bank: bank ?? { status: "not_started", linked_at: null, method: null },
-      email: email ?? { address: null, verified: false, verified_at: null },
-      overall_status: (domainData.overall_status as KycVerificationStatus) ?? "not_started",
+    const artifact: KycWorkflowArtifact = {
+      checks,
+      overall_status: (domainData.overall_status as KycWorkflowStatus) ?? "not_started",
+      counterparty: typeof domainData.counterparty === "string" ? domainData.counterparty : null,
+      request_summary: typeof domainData.request_summary === "string"
+        ? domainData.request_summary
+        : null,
+      pending_requirements: pendingRequirements,
+      completed_requirements: completedRequirements,
       last_updated: (domainData.last_updated as string) ?? new Date().toISOString(),
       schema_version: 1,
     };

--- a/hushh-webapp/lib/services/kyc-pkm-write-service.ts
+++ b/hushh-webapp/lib/services/kyc-pkm-write-service.ts
@@ -1,0 +1,132 @@
+"use client";
+
+import { PkmWriteCoordinator } from "@/lib/services/pkm-write-coordinator";
+import type { PkmWriteCoordinatorResult } from "@/lib/services/pkm-write-coordinator";
+
+export const KYC_PKM_DOMAIN = "kyc" as const;
+
+export type KycVerificationStatus = "verified" | "pending" | "failed" | "not_started";
+
+export type KycArtifact = {
+  identity: {
+    status: KycVerificationStatus;
+    verified_at: string | null;
+    method: string | null;
+  };
+  address: {
+    status: KycVerificationStatus;
+    verified_at: string | null;
+    method: string | null;
+  };
+  bank: {
+    status: KycVerificationStatus;
+    linked_at: string | null;
+    method: string | null;
+  };
+  email: {
+    address: string | null;
+    verified: boolean;
+    verified_at: string | null;
+  };
+  overall_status: KycVerificationStatus;
+  last_updated: string;
+  schema_version: 1;
+};
+
+export type KycPkmWriteParams = {
+  userId: string;
+  vaultKey: string | null;
+  vaultOwnerToken: string | null;
+  artifact: Omit<KycArtifact, "last_updated" | "schema_version">;
+};
+
+export type KycPkmReadResult = {
+  found: boolean;
+  artifact: KycArtifact | null;
+};
+
+function buildKycSummary(artifact: KycArtifact): Record<string, unknown> {
+  return {
+    overall_status: artifact.overall_status,
+    identity_verified: artifact.identity.status === "verified",
+    address_verified: artifact.address.status === "verified",
+    bank_linked: artifact.bank.status === "verified",
+    email_verified: artifact.email.verified,
+    last_updated: artifact.last_updated,
+  };
+}
+
+export class KycPkmWriteService {
+  static async writeKycArtifact(
+    params: KycPkmWriteParams
+  ): Promise<PkmWriteCoordinatorResult> {
+    const now = new Date().toISOString();
+
+    const artifact: KycArtifact = {
+      ...params.artifact,
+      last_updated: now,
+      schema_version: 1,
+    };
+
+    return PkmWriteCoordinator.saveMergedDomain({
+      userId: params.userId,
+      domain: KYC_PKM_DOMAIN,
+      vaultKey: params.vaultKey,
+      vaultOwnerToken: params.vaultOwnerToken,
+      build: (context) => {
+        const existing = (context.currentDomainData ?? {}) as Partial<KycArtifact>;
+        const merged: KycArtifact = {
+          identity: artifact.identity.status !== "not_started"
+            ? artifact.identity
+            : (existing.identity ?? artifact.identity),
+          address: artifact.address.status !== "not_started"
+            ? artifact.address
+            : (existing.address ?? artifact.address),
+          bank: artifact.bank.status !== "not_started"
+            ? artifact.bank
+            : (existing.bank ?? artifact.bank),
+          email: artifact.email.verified
+            ? artifact.email
+            : (existing.email ?? artifact.email),
+          overall_status: artifact.overall_status,
+          last_updated: now,
+          schema_version: 1,
+        };
+
+        return {
+          domainData: merged as unknown as Record<string, unknown>,
+          summary: buildKycSummary(merged),
+        };
+      },
+    });
+  }
+
+  static readKycArtifact(
+    domainData: Record<string, unknown> | null
+  ): KycPkmReadResult {
+    if (!domainData) {
+      return { found: false, artifact: null };
+    }
+
+    const identity = domainData.identity as KycArtifact["identity"] | undefined;
+    const address = domainData.address as KycArtifact["address"] | undefined;
+    const bank = domainData.bank as KycArtifact["bank"] | undefined;
+    const email = domainData.email as KycArtifact["email"] | undefined;
+
+    if (!identity && !address && !bank && !email) {
+      return { found: false, artifact: null };
+    }
+
+    const artifact: KycArtifact = {
+      identity: identity ?? { status: "not_started", verified_at: null, method: null },
+      address: address ?? { status: "not_started", verified_at: null, method: null },
+      bank: bank ?? { status: "not_started", linked_at: null, method: null },
+      email: email ?? { address: null, verified: false, verified_at: null },
+      overall_status: (domainData.overall_status as KycVerificationStatus) ?? "not_started",
+      last_updated: (domainData.last_updated as string) ?? new Date().toISOString(),
+      schema_version: 1,
+    };
+
+    return { found: true, artifact };
+  }
+}


### PR DESCRIPTION


# Description

## Summary
Closes #374 

The PKM write path for KYC/email data did not exist.
KycPreviewCompact showed hardcoded static data.
The explorer had no way to surface KYC domain data.

## Changes

### New: lib/services/kyc-pkm-write-service.ts
- KYC_PKM_DOMAIN constant ("kyc")
- KycArtifact type with identity, address, bank, email fields
- KycPkmWriteService.writeKycArtifact() — writes normalized
  KYC artifacts into PKM using PkmWriteCoordinator with
  conflict retry and vault token enforcement
- KycPkmWriteService.readKycArtifact() — reads and normalizes
  KYC data back from PKM domain data
- Merge logic preserves existing verified fields when new
  artifact has not_started status

### Modified: components/onboarding/previews/KycPreviewCompact.tsx
- Replaced hardcoded KYC_ITEMS array with live PKM data
- Uses usePkmDomainResource to load kyc domain from vault
- Uses KycPkmWriteService.readKycArtifact to parse domain data
- Status badge and description update dynamically based on
  actual verification state

### Modified: components/profile/pkm-explorer-panel.tsx
- Added KYC_PKM_DOMAIN import
- Added KYC badge next to domain attribute count when the
  kyc domain is present in the explorer domain list