### PR TITLE
chore(codex): harden governance workflows and bypass policy

### DIFF
--- a/.codex/skills/codex-skill-authoring/scripts/skill_lint.py
+++ b/.codex/skills/codex-skill-authoring/scripts/skill_lint.py
@@ -57,6 +57,7 @@ EXPECTED_WORKFLOW_IDS = [
     "repo-orientation",
     "new-feature-tri-flow",
     "api-contract-change",
+    "pr-governance-review",
     "analytics-observability-review",
     "bug-triage",
     "ci-watch-and-heal",

--- a/.codex/skills/pr-governance-review/SKILL.md
+++ b/.codex/skills/pr-governance-review/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: pr-governance-review
+description: Use when reviewing an incoming pull request for north-star alignment, trust-boundary regressions, malicious or low-signal degradation, stale-vs-current CI interpretation, and true merge readiness beyond a green gate.
+---
+
+# Hushh PR Governance Review Skill
+
+## Purpose and Trigger
+
+- Primary scope: `pr-governance-review-intake`
+- Trigger on incoming pull request review, contributor PR triage, merge-readiness assessment, or any case where CI may be green but the change could still erode Hushh north stars, trust boundaries, runtime contracts, or repo quality.
+- Avoid overlap with `repo-context`, `repo-operations`, and `quality-contracts` when the task is broad repo discovery, CI repair, or test-policy design rather than PR trust review.
+
+## Coverage and Ownership
+
+- Role: `owner`
+- Owner family: `pr-governance-review`
+
+Owned repo surfaces:
+
+1. `.codex/skills/pr-governance-review`
+
+Non-owned surfaces:
+
+1. `repo-context`
+2. `repo-operations`
+3. `quality-contracts`
+4. `backend-runtime-governance`
+5. `frontend-architecture`
+6. `security-audit`
+
+## Do Use
+
+1. Reviewing community or internal PRs where “green CI” is necessary but not sufficient.
+2. Distinguishing stale failed checks from the current head SHA before judging a contributor response.
+3. Flagging backend contract changes that do not carry matching caller, proxy, docs, or test updates.
+4. Flagging auth, vault, consent, runtime, deploy, Docker, `.gitignore`, or secret-surface changes that could quietly degrade the repo.
+5. Drafting concise maintainer-ready markdown that acknowledges the contributor, explains what was adopted or patched, and keeps blocker reasoning explicit.
+
+## Do Not Use
+
+1. Broad feature implementation or fixing the contributor PR directly unless the user explicitly asks for a maintainer patch.
+2. CI workflow repair when the failing root cause is inside repo operations rather than the PR itself.
+3. Generic style-only review without merge-governance implications.
+
+## Read First
+
+1. `README.md`
+2. `docs/reference/operations/ci.md`
+3. `.codex/skills/repo-operations/SKILL.md`
+4. `.codex/skills/quality-contracts/SKILL.md`
+5. `.codex/skills/pr-governance-review/references/review-axes.md`
+
+## Workflow
+
+1. Lock review to the current PR head SHA first; do not reason from stale runs or old maintainer comments.
+2. Start with `python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo <repo> --pr <number> --text` to summarize current head status, changed surfaces, and automatic drift flags.
+3. For batched contributor review or merge-train planning, use `python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo <repo> --prs <n1,n2,...> --text` first. This batch mode is the default when the user asks for “all healthy PRs by contributor”, “review these PRs together”, or “tell me how these relate”.
+4. In batch mode, do not stop at titles and green checks. The minimum overview must include, per PR:
+   - current head SHA
+   - size and changed file count
+   - extracted PR summary / issue linkage
+   - owned surfaces touched
+   - recommended lane
+   - cross-PR file overlap with other PRs in the batch
+   - helper-detected main-overlap and parallel-architecture findings when a concept already exists on `main` in a different file family
+5. Batch helper output is intake, not final merge authority. Before recommending consolidation or merge order, manually verify:
+   - whether `main` already contains part of the behavior
+   - whether the PR overlaps tasks already closed on the board
+   - whether the change is product-semantic rather than purely code-local
+   - whether an apparently isolated PR still changes a trust boundary, user-visible truth model, or external ingress surface
+   - whether the helper found a concept-level overlap that requires `patch_then_merge` or `block` even when exact file overlap is zero
+6. For every lane, perform two explicit verification passes and say which pass you are in:
+   - Pass 1: repo and product verification against current `main`, current head SHA, changed surfaces, and architectural truth
+   - Pass 2: authoritative workflow verification after action, including current PR checks, merge queue validation, and post-merge smoke where applicable
+7. Review findings in this order:
+   - north-star drift
+   - trust-boundary or auth regression
+   - backend/frontend/proxy contract mismatch
+   - deploy/runtime reproducibility drift
+   - tests/docs/proof gaps
+   - contributor communication accuracy
+8. Treat these patterns as merge blockers until disproven:
+   - tightening or widening auth without matching caller changes
+   - backend route or payload changes without caller/proxy/test changes
+   - deploy/runtime changes that introduce unpinned or undocumented dependencies
+   - `.gitignore`, secret, or credential-surface changes that can hide risk
+   - event-stream or async changes that alter user-visible semantics while claiming performance gains
+   - a second product or component architecture path for a concept already implemented on `main`
+   - a public ingress surface that lacks explicit rollout, abuse-control, or authority-model proof
+9. If the PR touches multiple domains, hand off to the right owner skills for deeper verification, but keep this skill as the merge-readiness authority.
+10. Classify the result into one lane only:
+   - `merge_now`
+   - `patch_then_merge`
+   - `block`
+11. Use `patch_then_merge` when the direction is good but the current head is not merge-safe. In that lane, do not merge the contributor head directly; integrate the smallest maintainer patch first, rerun checks, then communicate clearly with the author.
+12. When a maintainer patch is needed, prefer patching the contributor branch directly if `maintainerCanModify=true`. Only create a short-lived `temp/pr-<number>-patch` branch when direct patching is not possible or the fix needs isolated maintainer staging. Delete the temp branch after the merge path is resolved.
+13. Do not imply approval or recommend merge while blocker findings remain on the current merge candidate. A short acknowledgment of the contributor or the good direction is fine, but it must not soften or hide blocker findings.
+14. Before Codex triggers merge, auto-merge, or merge-queue entry, prepare a contributor-facing markdown draft for the current lane. Keep that draft in the turn output for operator visibility, but do not wait for separate posting confirmation once the policy is finalized.
+15. When communicating back on a PR, prefer this concise markdown shape:
+   - `## Acknowledgment`
+   - `## What We Adopted`
+   - `## Merge Decision`, `## Maintainer Patch`, or `## Blockers`
+   - `## Related Surfaces` when concrete file and higher-level doc references materially help future readers understand the landed boundary; use clickable GitHub links and add a one-line note per entry so future readers know why each file or doc matters
+   - `## Why`
+   - `## Next` only when there is still contributor action or maintainer follow-up to explain
+16. After the merge path is monitored to the required terminal state, post the contributor-facing note automatically. Do not treat the merge trigger or queue entry itself as the posting point.
+17. Monitoring is part of execution, not an optional follow-up. Once Codex triggers merge, auto-merge, or queue entry, it must stay attached to the workflow chain until the required terminal state is known. Stopping at queue placement, green PR checks, or "already queued" is workflow failure unless the user explicitly limited the task to queue placement only.
+18. If the user asks for a batch, produce a comprehensive overview before recommending any merge order. The overview must make overlap, duplication, domain boundaries, and isolation strategy explicit enough that the merge plan is auditable.
+19. If the PR is clear, say why it is safe in concrete terms: current head SHA, current gate result, blocker count, chosen lane, the result of both verification passes, and any remaining residual risk.
+
+## Handoff Rules
+
+1. Use `repo-operations` when the real blocker is CI design, workflow permissions, branch protection, or deployment policy.
+2. Use `quality-contracts` when the problem is missing or misplaced proof, contract tests, or release gating.
+3. Use `backend-runtime-governance` when backend route placement or runtime ownership is the real issue.
+4. Use `frontend-architecture` when a frontend/proxy caller contract is implicated.
+5. Use `security-audit` when the PR touches IAM, consent, vault, PKM, or sensitive data boundaries.
+
+## Required Checks
+
+```bash
+python3 -m py_compile .codex/skills/pr-governance-review/scripts/pr_review_checklist.py
+python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --pr 437 --text
+./bin/hushh codex audit --text
+./bin/hushh docs verify
+```

--- a/.codex/skills/pr-governance-review/references/review-axes.md
+++ b/.codex/skills/pr-governance-review/references/review-axes.md
@@ -1,0 +1,96 @@
+# PR Review Axes
+
+Use these axes in order. A green gate does not clear a PR if any blocker remains here.
+
+## 1. North-Star Alignment
+
+- Does the change make the repo leaner, clearer, and more scalable?
+- Does it preserve consent-first, trust-boundary clarity, and local-first contributor ergonomics?
+- Does it remove friction or add invisible complexity?
+
+## 2. Trust Boundary Integrity
+
+- Are auth, vault, consent, PKM, Gmail, Plaid, Firebase, or role surfaces changed?
+- Does the caller still provide the correct credential or token shape?
+- Is one header or state channel now asked to carry two incompatible identities?
+
+## 3. Contract Symmetry
+
+- If a backend route changes, did the frontend caller or Next proxy change too?
+- If the runtime contract changes, did bootstrap, docs, and tests move with it?
+- If event semantics change, do clients still interpret them correctly?
+
+## 4. Main Overlap and Architecture Path Integrity
+
+- Does `main` already implement the concept in a different file family or route family?
+- Is the PR adding a second architecture path for the same product concept instead of extending the canonical one?
+- Is the right outcome `patch_then_merge` or `block` even though exact file overlap is zero?
+
+## 5. Deploy and Runtime Integrity
+
+- Did the PR change Docker, deploy YAML, CI, runtime entrypoints, or package install paths?
+- Are new runtime dependencies pinned in the real dependency surface instead of injected ad hoc?
+- Does the change make builds more reproducible or less reproducible?
+
+## 6. Proof Quality
+
+- Are there targeted tests or contract checks for the changed behavior?
+- Did the PR only make the existing gate green, or did it prove the new behavior?
+- Are stale runs or old comments being mistaken for the current head state?
+
+## 7. Malicious or Low-Signal Degradation Signals
+
+- `.gitignore` expanded around credentials, secrets, generated artifacts, or local scripts
+- auth tightened or widened without matching caller changes
+- “performance” changes that alter semantics, latency visibility, or observability
+- runtime dependency added in Docker or CI without manifest ownership
+- docs/tests omitted on a sensitive contract change
+- public ingress added without explicit rollout and abuse-control proof
+- a second product surface added when `main` already has the concept
+
+## Decision Rule
+
+- Block merge if any high-severity finding remains.
+- Do not thank, approve, or recommend merge while blockers remain.
+- For `merge_now` and `patch_then_merge`, always prepare the contributor-facing acknowledgment draft before the merge action.
+- Post that note only after the monitored merge path reaches the required terminal state.
+- Once this policy is in force, do not require an extra confirmation step for posting the note.
+- When the merge affects a reusable subsystem or trust boundary, include a compact `Related Surfaces` section so the PR history points to the canonical files and higher-level docs that define the surrounding contract. Prefer clickable GitHub links when the target can be resolved safely, and add a one-line reason for every linked entry.
+- If the contributor is correct about a repo-side CI bug, say so explicitly and separate that from code safety.
+
+## Merge Lanes
+
+Use one of these three lanes after the review:
+
+### 1. `merge_now`
+
+Use only when:
+- current head SHA is green
+- no blocker findings remain
+- any residual risk is low and already documented by the existing contract
+
+### 2. `patch_then_merge`
+
+Use when:
+- the direction is good
+- the findings are bounded and maintainer-fixable
+- merging the contributor head directly would still be unsafe
+
+Typical examples:
+- backend contract changed without matching caller updates
+- auth tightening is directionally right but only one side moved
+- runtime/deploy improvement is reasonable but not yet pinned or documented
+
+Execution rule:
+- do not merge the unsafe contributor head
+- if maintainers can modify the contributor branch, patch that branch directly
+- otherwise create a short-lived branch named `temp/pr-<number>-patch`, apply the fix there, and delete it after the issue is resolved
+- rerun CI on the updated merge candidate
+- then thank the author and explain what was integrated and what was corrected
+
+### 3. `block`
+
+Use when:
+- the change is broad, unclear, or unsafe
+- the findings are not bounded enough for a small maintainer patch
+- the PR weakens repo governance, trust boundaries, or contributor safety

--- a/.codex/skills/pr-governance-review/scripts/pr_review_checklist.py
+++ b/.codex/skills/pr-governance-review/scripts/pr_review_checklist.py
@@ -1,0 +1,980 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import OrderedDict
+from itertools import combinations
+from datetime import datetime, timezone
+from pathlib import Path
+import re
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SALVAGEABLE_HIGH_FINDINGS = {
+    "backend_contract_without_caller_change",
+    "dual_auth_dependency_overlap",
+}
+SALVAGEABLE_MEDIUM_FINDINGS = {
+    "runtime_dependency_not_pinned_in_manifest",
+    "ignore_surface_changed",
+    "sensitive_runtime_change_without_supporting_proof",
+    "marketplace_flow_overlap_on_main",
+}
+CONCEPT_RULES: tuple[dict[str, Any], ...] = (
+    {
+        "id": "parallel_decision_card_path",
+        "severity": "high",
+        "summary": (
+            "PR introduces a second decision-card component family while main already has "
+            "a Kai decision-card surface under the views path."
+        ),
+        "changed_any": [
+            "hushh-webapp/components/kai/decision-card.tsx",
+            "hushh-webapp/components/kai/decision-cards-grid.tsx",
+        ],
+        "main_paths": [
+            "hushh-webapp/components/kai/views/decision-card.tsx",
+        ],
+    },
+    {
+        "id": "parallel_pkm_product_surface",
+        "severity": "high",
+        "summary": (
+            "PR introduces a standalone PKM browsing route while main already has PKM "
+            "exploration surfaces in profile or agent-lab flows."
+        ),
+        "changed_any": [
+            "hushh-webapp/app/pkm-explorer/page.tsx",
+        ],
+        "main_paths": [
+            "hushh-webapp/components/profile/pkm-explorer-panel.tsx",
+            "hushh-webapp/app/profile/pkm-agent-lab/page-client.tsx",
+        ],
+    },
+    {
+        "id": "marketplace_flow_overlap_on_main",
+        "severity": "medium",
+        "summary": (
+            "Marketplace advisory/request-entry flow already exists on main; review this PR "
+            "as a delta extraction rather than a title-only merge."
+        ),
+        "changed_any": [
+            "hushh-webapp/app/marketplace/page.tsx",
+            "hushh-webapp/app/marketplace/ria/page-client.tsx",
+        ],
+        "main_contains": [
+            {
+                "path": "hushh-webapp/app/marketplace/page.tsx",
+                "needle": "investor_advisor_disclosure_v1",
+            },
+            {
+                "path": "hushh-webapp/app/marketplace/ria/page-client.tsx",
+                "needle": "Continue browsing",
+            },
+        ],
+    },
+    {
+        "id": "public_email_ingress_without_live_contract",
+        "severity": "high",
+        "summary": (
+            "PR introduces a public inbound email ingress surface. Green CI is not enough; "
+            "this requires explicit rollout, abuse-control, and authority-model review."
+        ),
+        "changed_any": [
+            "consent-protocol/api/routes/email_agent.py",
+        ],
+    },
+)
+
+RELATED_SURFACE_RULES: tuple[dict[str, Any], ...] = (
+    {
+        "id": "ria_verification",
+        "match_prefixes": (
+            "consent-protocol/api/routes/ria.py",
+            "consent-protocol/hushh_mcp/services/ria_iam_service.py",
+            "consent-protocol/hushh_mcp/services/ria_verification.py",
+            "hushh-webapp/app/ria/",
+            "hushh-webapp/components/ria/",
+        ),
+        "files": (
+            "consent-protocol/api/routes/ria.py",
+            "consent-protocol/hushh_mcp/services/ria_iam_service.py",
+            "consent-protocol/hushh_mcp/services/ria_verification.py",
+            "hushh-webapp/app/ria/page.tsx",
+        ),
+        "docs": (
+            "docs/reference/iam/architecture.md",
+            "docs/reference/iam/runtime-surface.md",
+            "docs/reference/iam/README.md",
+        ),
+    },
+    {
+        "id": "consent_handshake",
+        "match_prefixes": (
+            "consent-protocol/api/routes/consent.py",
+            "consent-protocol/hushh_mcp/services/consent_center_service.py",
+            "hushh-webapp/components/consent/",
+            "hushh-webapp/lib/services/consent-center-service.ts",
+        ),
+        "files": (
+            "consent-protocol/api/routes/consent.py",
+            "consent-protocol/hushh_mcp/services/consent_center_service.py",
+            "hushh-webapp/components/consent/consent-center-page.tsx",
+            "hushh-webapp/components/consent/handshake-timeline.tsx",
+            "hushh-webapp/lib/services/consent-center-service.ts",
+        ),
+        "docs": (
+            "docs/reference/iam/architecture.md",
+            "docs/reference/architecture/api-contracts.md",
+            "consent-protocol/docs/reference/developer-api.md",
+        ),
+    },
+    {
+        "id": "consent_scope_bundles",
+        "match_prefixes": (
+            "consent-protocol/tests/test_scope_bundle_contract.py",
+            "consent-protocol/hushh_mcp/consent/",
+            "consent-protocol/mcp_modules/tools/consent_tools.py",
+        ),
+        "files": (
+            "consent-protocol/hushh_mcp/consent/scope_bundles.py",
+            "consent-protocol/mcp_modules/tools/consent_tools.py",
+            "consent-protocol/tests/test_scope_bundle_contract.py",
+        ),
+        "docs": (
+            "docs/reference/iam/consent-scope-catalog.md",
+            "docs/reference/iam/architecture.md",
+        ),
+    },
+    {
+        "id": "marketplace_flow",
+        "match_prefixes": (
+            "hushh-webapp/app/marketplace/ria/",
+            "hushh-webapp/lib/services/ria-service.ts",
+        ),
+        "files": (
+            "hushh-webapp/app/marketplace/page.tsx",
+            "hushh-webapp/app/marketplace/ria/page-client.tsx",
+            "hushh-webapp/lib/services/ria-service.ts",
+        ),
+        "docs": (
+            "docs/reference/iam/marketplace-contract.md",
+            "docs/reference/architecture/route-contracts.md",
+            "docs/reference/iam/architecture.md",
+        ),
+    },
+    {
+        "id": "portfolio_normalization",
+        "match_prefixes": (
+            "consent-protocol/hushh_mcp/kai_import/normalize_v2.py",
+            "consent-protocol/tests/test_normalize_v2.py",
+        ),
+        "files": (
+            "consent-protocol/hushh_mcp/kai_import/normalize_v2.py",
+            "consent-protocol/tests/test_normalize_v2.py",
+        ),
+        "docs": (
+            "docs/reference/architecture/api-contracts.md",
+        ),
+    },
+    {
+        "id": "frontend_credentials",
+        "match_prefixes": (
+            "hushh-webapp/lib/services/account-service.ts",
+            "hushh-webapp/lib/notifications/fcm-service.ts",
+        ),
+        "files": (
+            "hushh-webapp/lib/services/account-service.ts",
+            "hushh-webapp/lib/notifications/fcm-service.ts",
+        ),
+        "docs": (
+            "docs/reference/operations/env-and-secrets.md",
+            "consent-protocol/docs/reference/fcm-notifications.md",
+        ),
+    },
+    {
+        "id": "email_kyc_future_plan",
+        "match_prefixes": (
+            "consent-protocol/api/routes/email_agent.py",
+            "consent-protocol/hushh_mcp/services/email_agent_service.py",
+        ),
+        "files": (
+            "consent-protocol/api/routes/email_agent.py",
+            "consent-protocol/hushh_mcp/services/email_agent_service.py",
+            "consent-protocol/api/routes/kai/support.py",
+        ),
+        "docs": (
+            "docs/future/kai/email-kyc-pkm-assistant.md",
+            "docs/reference/architecture/api-contracts.md",
+        ),
+    },
+)
+
+PATH_SUMMARIES: dict[str, str] = {
+    "consent-protocol/api/routes/consent.py": "Route contract for consent lifecycle, relationship events, and timeline-facing APIs.",
+    "consent-protocol/api/routes/ria.py": "Advisor-facing route surface that enforces RIA verification and access gating.",
+    "consent-protocol/api/routes/email_agent.py": "Inbound email webhook surface proposed for Kai-owned email/KYC workflows.",
+    "consent-protocol/api/routes/kai/support.py": "Existing support ingress used as the comparison point for shared transport primitives.",
+    "consent-protocol/hushh_mcp/services/ria_iam_service.py": "Canonical RIA access-control service for verified access and relationship-scoped authorization.",
+    "consent-protocol/hushh_mcp/services/ria_verification.py": "Verification policy service that determines whether an RIA is eligible for protected flows.",
+    "consent-protocol/hushh_mcp/services/consent_center_service.py": "Consent-center aggregation layer that builds relationship and handshake history views.",
+    "consent-protocol/hushh_mcp/services/email_agent_service.py": "Email agent orchestration layer behind the proposed inbound KYC flow.",
+    "consent-protocol/hushh_mcp/services/support_email_service.py": "Current support-email execution path that may share transport primitives but not trust rules.",
+    "consent-protocol/hushh_mcp/consent/scope_bundles.py": "Canonical scope bundle registry that defines reusable consent bundle grammar.",
+    "consent-protocol/mcp_modules/tools/consent_tools.py": "Developer-facing consent tooling that consumes the canonical bundle registry.",
+    "consent-protocol/hushh_mcp/kai_import/normalize_v2.py": "Portfolio normalization pipeline where numeric coercion and financial math safety are enforced.",
+    "consent-protocol/tests/test_normalize_v2.py": "Regression coverage for portfolio number parsing and normalization edge cases.",
+    "consent-protocol/tests/test_scope_bundle_contract.py": "Contract suite that guards scope bundle structure, wildcard matching, and cross-domain isolation.",
+    "consent-protocol/docs/reference/developer-api.md": "Developer-facing contract reference for consent and runtime APIs.",
+    "consent-protocol/docs/reference/env-vars.md": "Environment-variable contract for backend email and runtime configuration surfaces.",
+    "consent-protocol/docs/reference/fcm-notifications.md": "Notification integration reference tied to the frontend FCM client logging surface.",
+    "hushh-webapp/app/ria/page.tsx": "Top-level RIA surface that reflects verification and gated advisor flows.",
+    "hushh-webapp/app/marketplace/page.tsx": "Marketplace investor entry surface for advisory request and persona-aware actions.",
+    "hushh-webapp/app/marketplace/ria/page-client.tsx": "RIA public-profile browsing surface for verification-aware actions and request entry.",
+    "hushh-webapp/app/pkm-explorer/page.tsx": "Standalone PKM route proposed by the rejected parallel product-surface PR.",
+    "hushh-webapp/app/profile/pkm-agent-lab/page-client.tsx": "Existing PKM exploration surface that remains the canonical product path.",
+    "hushh-webapp/components/profile/pkm-explorer-panel.tsx": "Reusable PKM browser panel already embedded in the current profile flow.",
+    "hushh-webapp/lib/personal-knowledge-model/natural-language.ts": "Current natural-language PKM presentation layer used instead of a separate explorer route.",
+    "hushh-webapp/components/consent/consent-center-page.tsx": "Consent-center UI shell that hosts relationship and handshake detail views.",
+    "hushh-webapp/components/consent/handshake-timeline.tsx": "Timeline renderer for investor/RIA consent lifecycle events.",
+    "hushh-webapp/lib/services/consent-center-service.ts": "Frontend service that calls the consent-center relationship and history APIs.",
+    "hushh-webapp/lib/services/ria-service.ts": "Frontend RIA data service used by marketplace and advisor-facing flows.",
+    "hushh-webapp/lib/services/account-service.ts": "Frontend account service where credential fragments were previously logged.",
+    "hushh-webapp/lib/notifications/fcm-service.ts": "Frontend FCM client surface where notification-token fragments were previously logged.",
+    "hushh-webapp/components/kai/decision-card.tsx": "Parallel decision-card component path introduced by the rejected duplicate-architecture PR.",
+    "hushh-webapp/components/kai/views/decision-card.tsx": "Canonical Kai decision-card renderer used by the current product flow.",
+    "hushh-webapp/components/kai/views/history-detail-view.tsx": "History detail surface that composes the canonical decision-card family.",
+    "hushh-webapp/components/kai/debate-stream-view.tsx": "Streaming Kai surface that feeds into the canonical decision-card path.",
+    "docs/reference/iam/architecture.md": "High-level IAM and consent architecture defining verified access and relationship boundaries.",
+    "docs/reference/iam/runtime-surface.md": "Runtime ownership map for IAM routes and services.",
+    "docs/reference/iam/README.md": "Index into the IAM reference set and canonical governance docs.",
+    "docs/reference/iam/ria-verification-policy.md": "Policy reference for RIA verification and fail-closed gating behavior.",
+    "docs/reference/iam/consent-scope-catalog.md": "Canonical catalog of consent scopes and scope-bundle semantics.",
+    "docs/reference/iam/marketplace-contract.md": "Marketplace contract defining investor/RIA request-entry and persona-aware behavior.",
+    "docs/reference/operations/env-and-secrets.md": "Operational contract for frontend and backend environment-secret handling.",
+    "docs/reference/architecture/api-contracts.md": "System-level API contract reference for shared route semantics.",
+    "docs/reference/architecture/route-contracts.md": "Frontend route and navigation contract reference for product surfaces.",
+    "docs/reference/architecture/pkm-storage-adr.md": "ADR describing PKM storage and canonical product-surface assumptions.",
+    "docs/reference/architecture/pkm-cutover-runbook.md": "Runbook for PKM product migration and current ownership path.",
+    "docs/reference/kai/kai-interconnection-map.md": "High-level Kai subsystem map including the canonical decision-card surface.",
+    "docs/reference/kai/kai-change-impact-matrix.md": "Kai change-governance matrix describing decision-card and stream-contract impacts.",
+    "docs/future/kai/email-kyc-pkm-assistant.md": "Future-plan contract for Kai-owned email/KYC workflow and consent-scoped rollout.",
+}
+
+
+def _run(cmd: list[str]) -> str:
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        message = completed.stderr.strip() or completed.stdout.strip() or "command failed"
+        raise RuntimeError(f"{' '.join(cmd)}: {message}")
+    return completed.stdout
+
+
+def _gh_json(repo: str, pr: int, fields: list[str]) -> dict[str, Any]:
+    output = _run(
+        [
+            "gh",
+            "pr",
+            "view",
+            str(pr),
+            "--repo",
+            repo,
+            "--json",
+            ",".join(fields),
+        ]
+    )
+    return json.loads(output)
+
+
+def _extract_summary(body: str | None) -> str:
+    if not body:
+        return ""
+    text = body.strip()
+    summary_match = re.search(
+        r"^## Summary\s*(.*?)(?=^##\s|\Z)",
+        text,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    section = summary_match.group(1).strip() if summary_match else text
+    lines: list[str] = []
+    for raw_line in section.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        line = re.sub(r"^[-*]\s*", "", line)
+        lines.append(line)
+        if len(lines) == 3:
+            break
+    return " | ".join(lines)
+
+
+def _extract_closed_issues(body: str | None) -> list[str]:
+    if not body:
+        return []
+    return re.findall(r"(?:Closes|Close|Fixes|Fix|Resolves|Resolve)\s+#(\d+)", body, flags=re.IGNORECASE)
+
+
+def _gh_diff_name_only(repo: str, pr: int) -> list[str]:
+    output = _run(["gh", "pr", "diff", str(pr), "--repo", repo, "--name-only"])
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def _gh_diff_patch(repo: str, pr: int) -> str:
+    return _run(["gh", "pr", "diff", str(pr), "--repo", repo, "--patch", "--color=never"])
+
+
+def _git_show_origin_main(path: str) -> str | None:
+    completed = subprocess.run(
+        ["git", "show", f"origin/main:{path}"],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+    if completed.returncode != 0:
+        return None
+    return completed.stdout
+
+
+def _iso_or_empty(value: str | None) -> str:
+    return value or ""
+
+
+def _current_checks(status_check_rollup: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    latest_by_name: dict[str, dict[str, Any]] = {}
+    for item in status_check_rollup:
+        if item.get("__typename") != "CheckRun":
+            continue
+        name = item.get("name") or "unknown"
+        current = latest_by_name.get(name)
+        current_ts = max(_iso_or_empty(current.get("completedAt") if current else ""), _iso_or_empty(current.get("startedAt") if current else ""))
+        candidate_ts = max(_iso_or_empty(item.get("completedAt")), _iso_or_empty(item.get("startedAt")))
+        if current is None or candidate_ts >= current_ts:
+            latest_by_name[name] = item
+    return sorted(latest_by_name.values(), key=lambda item: item.get("name") or "")
+
+
+def _surface_tags(files: list[str]) -> list[str]:
+    tags: list[str] = []
+    if any(path.startswith("consent-protocol/api/") for path in files):
+        tags.append("backend-api")
+    if any(path.startswith("hushh-webapp/lib/services/") or path.startswith("hushh-webapp/app/api/") for path in files):
+        tags.append("frontend-caller")
+    if any(path.startswith("deploy/") or path.endswith("Dockerfile") for path in files):
+        tags.append("deploy-runtime")
+    if any(path.endswith(".gitignore") for path in files):
+        tags.append("ignore-surface")
+    if any(path.startswith(".github/") or path.startswith("scripts/ci/") or path.startswith("config/") for path in files):
+        tags.append("governance")
+    if any("/tests/" in path or path.startswith("consent-protocol/tests/") or path.startswith("hushh-webapp/__tests__/") for path in files):
+        tags.append("tests")
+    if any(path.startswith("docs/") or path.startswith("consent-protocol/docs/") or path.startswith("hushh-webapp/docs/") for path in files):
+        tags.append("docs")
+    return tags
+
+
+def _path_exists(path: str) -> bool:
+    return (REPO_ROOT / path).exists()
+
+
+def _github_blob_url(repo: str, ref: str, path: str) -> str:
+    return f"https://github.com/{repo}/blob/{ref}/{path}"
+
+
+def _github_link_ref(report: dict[str, Any], path: str) -> str:
+    return "main" if _git_show_origin_main(path) is not None else report["pr"]["head_sha"]
+
+
+def _markdown_path_link(repo: str, ref: str, path: str) -> str:
+    return f"[`{path}`]({_github_blob_url(repo, ref, path)})"
+
+
+def _path_summary(path: str) -> str:
+    return PATH_SUMMARIES.get(path, "Related reviewed surface for this change.")
+
+
+def _preferred_related_files(files: list[str], limit: int = 4) -> list[str]:
+    preferred: list[str] = []
+    for path in files:
+        if path.startswith("docs/") or path.startswith("consent-protocol/docs/") or path.startswith("hushh-webapp/docs/"):
+            continue
+        if "/tests/" in path or path.startswith("consent-protocol/tests/") or path.startswith("hushh-webapp/__tests__/"):
+            continue
+        preferred.append(path)
+    if not preferred:
+        preferred = [path for path in files if not path.startswith("docs/")]
+    return preferred[:limit]
+
+
+def _related_surfaces(files: list[str]) -> OrderedDict[str, list[OrderedDict[str, str]]]:
+    related_files: list[str] = []
+    related_docs: list[str] = []
+
+    for rule in RELATED_SURFACE_RULES:
+        if not any(any(path.startswith(prefix) for prefix in rule["match_prefixes"]) for path in files):
+            continue
+        for path in rule["files"]:
+            if _path_exists(path) and path not in related_files:
+                related_files.append(path)
+        for path in rule["docs"]:
+            if _path_exists(path) and path not in related_docs:
+                related_docs.append(path)
+
+    for path in _preferred_related_files(files):
+        if _path_exists(path) and path not in related_files:
+            related_files.append(path)
+
+    return OrderedDict(
+        files=[
+            OrderedDict(path=path, summary=_path_summary(path))
+            for path in related_files[:5]
+        ],
+        docs=[
+            OrderedDict(path=path, summary=_path_summary(path))
+            for path in related_docs[:4]
+        ],
+    )
+
+
+def _route_files_without_caller_changes(files: list[str]) -> bool:
+    backend_routes = any(path.startswith("consent-protocol/api/routes/") for path in files)
+    caller_changes = any(
+        path.startswith("hushh-webapp/lib/services/")
+        or path.startswith("hushh-webapp/app/api/")
+        or path.startswith("hushh-webapp/components/")
+        for path in files
+    )
+    return backend_routes and not caller_changes
+
+
+def _has_sensitive_runtime_change(files: list[str]) -> bool:
+    return any(
+        path.endswith("Dockerfile")
+        or path.startswith("deploy/")
+        or path.startswith(".github/workflows/")
+        or path.startswith("scripts/ci/")
+        for path in files
+    )
+
+
+def _has_test_or_doc_change(files: list[str]) -> bool:
+    return any(
+        "/tests/" in path
+        or path.startswith("consent-protocol/tests/")
+        or path.startswith("hushh-webapp/__tests__/")
+        or path.startswith("docs/")
+        or path.startswith("consent-protocol/docs/")
+        or path.startswith("hushh-webapp/docs/")
+        for path in files
+    )
+
+
+def _file_patch_map(patch: str) -> dict[str, str]:
+    sections: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in patch.splitlines():
+        if line.startswith("diff --git "):
+            parts = line.split()
+            if len(parts) >= 4:
+                current = parts[3][2:]
+                sections[current] = [line]
+            else:
+                current = None
+            continue
+        if current is not None:
+            sections[current].append(line)
+    return {key: "\n".join(value) for key, value in sections.items()}
+
+
+def _build_findings(files: list[str], patch_map: dict[str, str]) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    explicit_dual_auth_support = (
+        "consent-protocol/api/middleware.py" in files
+        and "X-Hushh-Consent" in patch_map.get("consent-protocol/api/middleware.py", "")
+        and any(
+            path.startswith("hushh-webapp/lib/services/") or path.startswith("hushh-webapp/app/api/")
+            for path in files
+        )
+    )
+
+    if _route_files_without_caller_changes(files):
+        findings.append(
+            {
+                "id": "backend_contract_without_caller_change",
+                "severity": "high",
+                "summary": "Backend route files changed without matching caller or proxy changes.",
+                "files": [path for path in files if path.startswith("consent-protocol/api/routes/")],
+            }
+        )
+
+    for path, section in patch_map.items():
+        if (
+            path.startswith("consent-protocol/api/routes/")
+            and "require_firebase_auth" in section
+            and "require_vault_owner_token" in section
+            and not explicit_dual_auth_support
+        ):
+            findings.append(
+                {
+                    "id": "dual_auth_dependency_overlap",
+                    "severity": "high",
+                    "summary": "A route now depends on both Firebase auth and VAULT_OWNER token review on the same surface; verify caller token shape and header semantics explicitly.",
+                    "files": [path],
+                }
+            )
+
+        if path.endswith("Dockerfile") and "gunicorn" in section and not any(
+            dependency_path.endswith("requirements.txt")
+            or dependency_path.endswith("pyproject.toml")
+            for dependency_path in files
+        ):
+            findings.append(
+                {
+                    "id": "runtime_dependency_not_pinned_in_manifest",
+                    "severity": "medium",
+                    "summary": "Runtime dependency behavior changed in Docker without a matching dependency-manifest change.",
+                    "files": [path],
+                }
+            )
+
+        if path.endswith(".gitignore"):
+            findings.append(
+                {
+                    "id": "ignore_surface_changed",
+                    "severity": "medium",
+                    "summary": "Ignore rules changed; verify that secrets, credentials, or local validation files are not being hidden in a way that weakens review.",
+                    "files": [path],
+                }
+            )
+
+    if _has_sensitive_runtime_change(files) and not _has_test_or_doc_change(files):
+        findings.append(
+            {
+                "id": "sensitive_runtime_change_without_supporting_proof",
+                "severity": "medium",
+                "summary": "Deploy/runtime or governance surfaces changed without matching tests or docs in the same PR.",
+                "files": [path for path in files if _has_sensitive_runtime_change([path])],
+            }
+        )
+
+    changed_set = set(files)
+    for rule in CONCEPT_RULES:
+        changed_any = set(rule.get("changed_any", []))
+        if changed_any and not (changed_set & changed_any):
+            continue
+        main_paths = rule.get("main_paths", [])
+        main_contains = rule.get("main_contains", [])
+        main_match = any(_git_show_origin_main(path) is not None for path in main_paths)
+        if not main_match and main_contains:
+            for item in main_contains:
+                content = _git_show_origin_main(item["path"])
+                if content and item["needle"] in content:
+                    main_match = True
+                    break
+        if main_paths or main_contains:
+            if not main_match:
+                continue
+        findings.append(
+            {
+                "id": rule["id"],
+                "severity": rule["severity"],
+                "summary": rule["summary"],
+                "files": sorted(changed_set & changed_any) or sorted(changed_set),
+            }
+        )
+
+    return findings
+
+
+def _recommend_merge_lane(
+    ci_status_gate: str,
+    findings: list[dict[str, Any]],
+    surface_tags: list[str],
+    changed_files: list[str],
+) -> dict[str, Any]:
+    if ci_status_gate != "SUCCESS":
+        return OrderedDict(
+            lane="block",
+            rationale="Current required PR gate is not green on the reviewed head SHA.",
+            next_steps=[
+                "Wait for the current head SHA to reach a green `CI Status Gate` before deciding merge readiness.",
+                "Review only the current head SHA after the gate is terminal.",
+            ],
+        )
+
+    if not findings:
+        return OrderedDict(
+            lane="merge_now",
+            rationale="Current head SHA is green and no blocker or review-risk findings were detected.",
+            next_steps=[
+                "Proceed with normal maintainer review and merge flow.",
+            ],
+        )
+
+    high_ids = {finding["id"] for finding in findings if finding["severity"] == "high"}
+    medium_ids = {finding["id"] for finding in findings if finding["severity"] == "medium"}
+    if not high_ids and medium_ids and medium_ids <= {"ignore_surface_changed"}:
+        return OrderedDict(
+            lane="merge_now",
+            rationale=(
+                "Current head SHA is green and the only remaining review note is ignore-surface hygiene. "
+                "That should be reviewed, but it does not require a maintainer patch before merge."
+            ),
+            next_steps=[
+                "Do one quick maintainer sanity check on the ignore rules.",
+                "Proceed with normal review and merge flow if the ignore additions are intentional.",
+            ],
+        )
+    unsupported_high = high_ids - SALVAGEABLE_HIGH_FINDINGS
+    unsupported_medium = medium_ids - SALVAGEABLE_MEDIUM_FINDINGS
+    governance_heavy = "governance" in surface_tags and len(changed_files) > 5
+
+    if (
+        not unsupported_high
+        and not unsupported_medium
+        and not governance_heavy
+    ):
+        return OrderedDict(
+            lane="patch_then_merge",
+            rationale=(
+                "The direction appears useful, but the current head is not merge-safe. "
+                "The remaining findings are bounded integration or reproducibility issues "
+                "that should be corrected by a small maintainer patch before merge."
+            ),
+            next_steps=[
+                "Do not merge the contributor head directly.",
+                "Apply the smallest maintainer integration patch on the contributor branch when maintainers can modify it.",
+                "If direct patching is not possible, use a short-lived `temp/pr-<number>-patch` branch and delete it after the merge path is resolved.",
+                "Rerun PR Validation on the updated merge candidate and re-review the new head SHA.",
+                "Then thank the author and explain the integration fix that was needed.",
+            ],
+        )
+
+    return OrderedDict(
+        lane="block",
+        rationale=(
+            "The remaining findings are too broad or too risky for a small maintainer integration patch. "
+            "This PR should stay blocked until the contributor or maintainer narrows the change."
+        ),
+        next_steps=[
+            "Keep the PR blocked.",
+            "Respond with blocker-first findings tied to the current head SHA.",
+            "Only reconsider merge after the risky surface is narrowed or independently proven safe.",
+        ],
+    )
+
+
+def _text_report(report: dict[str, Any]) -> str:
+    lines: list[str] = []
+    pr = report["pr"]
+    lines.append(f"PR #{pr['number']}: {pr['title']}")
+    lines.append(f"URL: {pr['url']}")
+    lines.append(f"Head SHA: {pr['head_sha']}")
+    lines.append(
+        f"Size: +{pr['additions']} / -{pr['deletions']} across {pr['changed_files_count']} files"
+    )
+    lines.append(f"Mergeable: {pr['mergeable']} ({pr['merge_state_status']})")
+    if pr.get("closed_issues"):
+        lines.append(f"Issue linkage: {', '.join('#' + item for item in pr['closed_issues'])}")
+    if pr.get("summary"):
+        lines.append(f"Summary: {pr['summary']}")
+    lines.append(f"Current CI Status Gate: {report['current_ci_status_gate']}")
+    lines.append(f"Recommended lane: {report['decision']['lane']}")
+    lines.append(f"Decision rationale: {report['decision']['rationale']}")
+    lines.append(f"Changed surfaces: {', '.join(report['surface_tags']) or 'none'}")
+    lines.append("Current checks:")
+    for check in report["current_checks"]:
+        lines.append(f"- {check['name']}: {check['conclusion']}")
+    if report["findings"]:
+        lines.append("Findings:")
+        for finding in report["findings"]:
+            files = ", ".join(finding["files"])
+            lines.append(f"- [{finding['severity']}] {finding['id']}: {finding['summary']} ({files})")
+    else:
+        lines.append("Findings: none")
+    related = report["related_surfaces"]
+    if related["files"] or related["docs"]:
+        lines.append("Related surfaces:")
+        if related["files"]:
+            lines.append("- Files:")
+            for entry in related["files"]:
+                lines.append(f"  - {entry['path']}: {entry['summary']}")
+        if related["docs"]:
+            lines.append("- Docs:")
+            for entry in related["docs"]:
+                lines.append(f"  - {entry['path']}: {entry['summary']}")
+    lines.append("Next steps:")
+    for step in report["decision"]["next_steps"]:
+        lines.append(f"- {step}")
+    lines.append("Suggested PR note:")
+    lines.append(report["communication_markdown"])
+    return "\n".join(lines)
+
+
+def _top_roots(files: list[str]) -> list[str]:
+    roots: list[str] = []
+    for path in files:
+        root = path.split("/", 1)[0]
+        if root not in roots:
+            roots.append(root)
+    return roots
+
+
+def build_batch_report(repo: str, prs: list[int]) -> dict[str, Any]:
+    reports = [build_report(repo, pr) for pr in prs]
+    overlaps: list[dict[str, Any]] = []
+    for left, right in combinations(reports, 2):
+        shared = sorted(set(left["changed_files"]) & set(right["changed_files"]))
+        if not shared:
+            continue
+        overlaps.append(
+            OrderedDict(
+                pair=[left["pr"]["number"], right["pr"]["number"]],
+                shared_files=shared,
+            )
+        )
+
+    surface_counts: dict[str, int] = {}
+    root_counts: dict[str, int] = {}
+    lane_counts: dict[str, int] = {}
+    for report in reports:
+        lane = report["decision"]["lane"]
+        lane_counts[lane] = lane_counts.get(lane, 0) + 1
+        for tag in report["surface_tags"]:
+            surface_counts[tag] = surface_counts.get(tag, 0) + 1
+        for root in _top_roots(report["changed_files"]):
+            root_counts[root] = root_counts.get(root, 0) + 1
+
+    return OrderedDict(
+        generated_at=datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        repo=repo,
+        prs=prs,
+        lane_counts=lane_counts,
+        surface_counts=OrderedDict(sorted(surface_counts.items())),
+        root_counts=OrderedDict(sorted(root_counts.items())),
+        overlaps=overlaps,
+        reports=reports,
+    )
+
+
+def _batch_text_report(batch: dict[str, Any]) -> str:
+    lines: list[str] = []
+    lines.append(
+        f"Batch PR review: {', '.join('#' + str(pr) for pr in batch['prs'])}"
+    )
+    lines.append(f"Lane counts: {json.dumps(batch['lane_counts'], sort_keys=True)}")
+    lines.append(f"Surface counts: {json.dumps(batch['surface_counts'], sort_keys=True)}")
+    lines.append(f"Root counts: {json.dumps(batch['root_counts'], sort_keys=True)}")
+    if batch["overlaps"]:
+        lines.append("Cross-PR file overlaps:")
+        for overlap in batch["overlaps"]:
+            lines.append(
+                f"- #{overlap['pair'][0]} <-> #{overlap['pair'][1]}: "
+                + ", ".join(overlap["shared_files"])
+            )
+    else:
+        lines.append("Cross-PR file overlaps: none")
+    lines.append("")
+    for report in batch["reports"]:
+        lines.append(_text_report(report))
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+def _communication_markdown(report: dict[str, Any]) -> str:
+    pr = report["pr"]
+    repo = report["repo"]
+    lane = report["decision"]["lane"]
+    acknowledgment = (
+        f"Thanks @{pr['author']} for the contribution and for pushing this direction forward."
+        if pr.get("author")
+        else "Thanks for the contribution and for pushing this direction forward."
+    )
+
+    if lane == "merge_now":
+        adopted = "The current head is aligned with the existing caller, runtime, and trust-boundary contracts."
+        patch_or_blockers = "No maintainer patch is needed on this head SHA."
+        why = "The required gate is green and the review did not find contract or governance regressions."
+    elif lane == "patch_then_merge":
+        findings = report["findings"]
+        adopted = "We are taking the direction in this PR, but not merging the current head unchanged."
+        patch_or_blockers = (
+            "A small maintainer integration patch is required first to close the remaining bounded gaps: "
+            + ", ".join(finding["id"] for finding in findings)
+            + "."
+        )
+        why = report["decision"]["rationale"]
+        next_step = "Patch the contributor branch, rerun PR Validation on the updated head SHA, then re-review for merge."
+    else:
+        findings = report["findings"]
+        adopted = "The intent may still be useful, but the current merge candidate is not safe to land."
+        patch_or_blockers = (
+            "The current blockers are: "
+            + ", ".join(finding["id"] for finding in findings)
+            + "."
+        ) if findings else "The current required gate is not green yet."
+        why = report["decision"]["rationale"]
+        next_step = "Keep the PR open, narrow the risky surface, and rerun the gate on the next head SHA."
+
+    sections = [
+        "## Acknowledgment",
+        acknowledgment,
+        "",
+        "## What We Adopted",
+        adopted,
+        "",
+        (
+            "## Merge Decision"
+            if lane == "merge_now"
+            else "## Maintainer Patch" if lane == "patch_then_merge" else "## Blockers"
+        ),
+        patch_or_blockers,
+    ]
+    related = report["related_surfaces"]
+    if related["files"] or related["docs"]:
+        sections.extend([
+            "",
+            "## Related Surfaces",
+        ])
+        if related["files"]:
+            sections.append("Files:")
+            for entry in related["files"]:
+                path = entry["path"]
+                sections.append(
+                    f"- {_markdown_path_link(repo, _github_link_ref(report, path), path)}: {entry['summary']}"
+                )
+        if related["docs"]:
+            sections.append("Docs:")
+            for entry in related["docs"]:
+                path = entry["path"]
+                sections.append(
+                    f"- {_markdown_path_link(repo, _github_link_ref(report, path), path)}: {entry['summary']}"
+                )
+    sections.extend([
+        "",
+        "## Why",
+        why,
+    ])
+    if lane != "merge_now":
+        sections.extend([
+            "",
+            "## Next",
+            next_step,
+        ])
+    return "\n".join(sections)
+
+
+def build_report(repo: str, pr: int) -> dict[str, Any]:
+    pr_view = _gh_json(
+        repo,
+        pr,
+        [
+            "number",
+            "title",
+            "url",
+            "author",
+            "headRefOid",
+            "headRefName",
+            "baseRefName",
+            "mergeable",
+            "mergeStateStatus",
+            "reviewDecision",
+            "statusCheckRollup",
+            "additions",
+            "deletions",
+            "changedFiles",
+            "body",
+        ],
+    )
+    files = _gh_diff_name_only(repo, pr)
+    patch = _gh_diff_patch(repo, pr)
+    patch_map = _file_patch_map(patch)
+    current_checks = _current_checks(pr_view.get("statusCheckRollup", []))
+    ci_status_gate = next(
+        (item.get("conclusion", "UNKNOWN") for item in current_checks if item.get("name") == "CI Status Gate"),
+        "MISSING",
+    )
+    report = OrderedDict(
+        generated_at=datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        repo=repo,
+        pr=OrderedDict(
+            number=pr_view["number"],
+            title=pr_view["title"],
+            url=pr_view["url"],
+            author=pr_view.get("author", {}).get("login"),
+            summary=_extract_summary(pr_view.get("body")),
+            closed_issues=_extract_closed_issues(pr_view.get("body")),
+            head_sha=pr_view["headRefOid"],
+            head_ref=pr_view["headRefName"],
+            base_ref=pr_view["baseRefName"],
+            additions=pr_view.get("additions", 0),
+            deletions=pr_view.get("deletions", 0),
+            changed_files_count=pr_view.get("changedFiles", len(files)),
+            mergeable=pr_view["mergeable"],
+            merge_state_status=pr_view["mergeStateStatus"],
+            review_decision=pr_view.get("reviewDecision") or "",
+        ),
+        changed_files=files,
+        surface_tags=_surface_tags(files),
+        current_ci_status_gate=ci_status_gate,
+        current_checks=[
+            OrderedDict(
+                name=item.get("name"),
+                conclusion=item.get("conclusion"),
+                workflow=item.get("workflowName"),
+                details_url=item.get("detailsUrl"),
+            )
+            for item in current_checks
+        ],
+        findings=_build_findings(files, patch_map),
+        related_surfaces=_related_surfaces(files),
+    )
+    report["decision"] = _recommend_merge_lane(
+        ci_status_gate=ci_status_gate,
+        findings=report["findings"],
+        surface_tags=report["surface_tags"],
+        changed_files=files,
+    )
+    report["communication_markdown"] = _communication_markdown(report)
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Summarize current-head PR review risks.")
+    parser.add_argument("--repo", default="hushh-labs/hushh-research")
+    parser.add_argument("--pr", type=int)
+    parser.add_argument("--prs", help="Comma-separated PR numbers for batch review.")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--text", action="store_true")
+    args = parser.parse_args()
+
+    if not args.pr and not args.prs:
+        parser.error("one of --pr or --prs is required")
+    if args.pr and args.prs:
+        parser.error("use either --pr or --prs, not both")
+
+    try:
+        if args.prs:
+            prs = [int(item.strip()) for item in args.prs.split(",") if item.strip()]
+            report = build_batch_report(args.repo, prs)
+            is_batch = True
+        else:
+            report = build_report(args.repo, args.pr)
+            is_batch = False
+    except Exception as exc:
+        print(f"pr_review_checklist failed: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(_batch_text_report(report) if is_batch else _text_report(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/skills/pr-governance-review/skill.json
+++ b/.codex/skills/pr-governance-review/skill.json
@@ -1,0 +1,72 @@
+{
+  "id": "pr-governance-review",
+  "role": "owner",
+  "owner_family": "pr-governance-review",
+  "primary_scope": "pr-governance-review-intake",
+  "description": "Use when reviewing an incoming pull request for north-star alignment, trust-boundary regressions, malicious or low-signal degradation, stale-vs-current CI interpretation, and true merge readiness beyond a green gate.",
+  "owned_paths": [
+    ".codex/skills/pr-governance-review"
+  ],
+  "non_owned_paths": [
+    "repo-context",
+    "repo-operations",
+    "quality-contracts",
+    "backend-runtime-governance",
+    "frontend-architecture",
+    "security-audit"
+  ],
+  "task_types": [
+    "pr-governance-review"
+  ],
+  "required_reads": [
+    "README.md",
+    "docs/reference/operations/ci.md",
+    ".codex/skills/repo-operations/SKILL.md",
+    ".codex/skills/quality-contracts/SKILL.md",
+    ".codex/skills/pr-governance-review/references/review-axes.md"
+  ],
+  "required_commands": [
+    "python3 -m py_compile .codex/skills/pr-governance-review/scripts/pr_review_checklist.py",
+    "python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --pr 437 --text",
+    "./bin/hushh codex audit --text",
+    "./bin/hushh docs verify"
+  ],
+  "verification_bundles": [
+    {
+      "id": "pr-governance-review",
+      "commands": [
+        "python3 -m py_compile .codex/skills/pr-governance-review/scripts/pr_review_checklist.py",
+        "python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --pr 437 --text",
+        "./bin/hushh codex audit --text",
+        "./bin/hushh docs verify"
+      ],
+      "tests": [
+        "python3 -m py_compile .codex/skills/pr-governance-review/scripts/pr_review_checklist.py",
+        "./bin/hushh codex audit --text",
+        "./bin/hushh docs verify"
+      ]
+    }
+  ],
+  "handoff_targets": [
+    "repo-context",
+    "repo-operations",
+    "quality-contracts",
+    "backend-runtime-governance",
+    "frontend-architecture",
+    "security-audit"
+  ],
+  "adjacent_skills": [
+    "repo-context",
+    "repo-operations",
+    "quality-contracts",
+    "backend-runtime-governance",
+    "frontend-architecture",
+    "security-audit"
+  ],
+  "risk_tags": [
+    "north-star-drift",
+    "trust-boundary-regression",
+    "merge-readiness-false-positive",
+    "malicious-degradation-risk"
+  ]
+}

--- a/.codex/skills/repo-context/scripts/repo_scan.py
+++ b/.codex/skills/repo-context/scripts/repo_scan.py
@@ -51,6 +51,7 @@ MEANINGFUL_SURFACES = [
 SECTION_NAMES = ("docs", "frontend", "backend", "skills", "commands")
 REQUIRED_OWNER_SKILLS = [
     "repo-context",
+    "pr-governance-review",
     "frontend",
     "mobile-native",
     "backend",
@@ -69,6 +70,7 @@ REQUIRED_WORKFLOWS = [
     "repo-orientation",
     "new-feature-tri-flow",
     "api-contract-change",
+    "pr-governance-review",
     "analytics-observability-review",
     "bug-triage",
     "ci-watch-and-heal",

--- a/.codex/skills/repo-operations/SKILL.md
+++ b/.codex/skills/repo-operations/SKILL.md
@@ -65,15 +65,17 @@ Non-owned surfaces:
 9. For core authority surfaces, the task is not complete while GitHub still shows any relevant run for the touched SHA as `queued`, `in_progress`, or `requested`.
 10. Core authority surfaces are `PR Validation`, `Queue Validation`, `Main Post-Merge Smoke`, `Deploy to UAT`, and any RCA-triggered release-authority rerun for the same SHA.
 11. Before opening or updating a pull request, run `./bin/hushh codex pre-pr` as the canonical local mirror of `PR Validation` and `CI Status Gate`.
-12. Treat user intent literally: `merge to main` means land the change and monitor through `Main Post-Merge Smoke` only; do not dispatch UAT unless the user explicitly asks to deploy to UAT.
-13. Treat `deploy to UAT` as a separate cadence: land the change on `main`, identify the exact green `main` SHA, manually dispatch `Deploy to UAT` for that SHA, then monitor the deploy chain to terminal state.
-14. If a core run fails, default to the smallest safe repair and rerun loop before declaring a blocker. Only stop early for a real permissions, product, or platform boundary.
-15. Default runtime launch behavior must be visible separate OS terminal windows, not hidden Codex sessions.
-16. For local app work, prefer separate `./bin/hushh terminal backend --mode local --reload` and `./bin/hushh terminal web --mode <mode>` commands unless the user explicitly asks for something else.
-17. Use hidden long-lived Codex sessions only for background monitoring, one-off debugging, or when a visible terminal is not desired.
-18. Use `./bin/hushh terminal stack --mode local` only when one combined visible terminal is explicitly preferred.
-19. When the user says `restart servers`, treat that as a graceful terminal-managed restart, not just a port kill. First inspect existing repo-launched visible terminals, stop the running backend/web processes, then terminate the login shells cleanly before closing any leftover windows so Terminal does not prompt `Do you want to terminate running processes in this window?`.
-20. For macOS Terminal restarts, prefer this order:
+12. Before the first push of any branch that is headed to GitHub review or merge, verify that every local commit on the branch carries a DCO signoff trailer. Prefer `git commit -s` for new commits. If unsigned commits already exist, repair them before pushing with `git rebase --signoff <base>`.
+13. If the change touches `.codex/`, `docs/`, `config/`, `scripts/`, or other governance-owned surfaces, rerun `bash scripts/ci/orchestrate.sh governance` after the final local edit instead of relying only on an earlier green `pre-pr` result.
+14. Treat user intent literally: `merge to main` means land the change and monitor through `Main Post-Merge Smoke` only; do not dispatch UAT unless the user explicitly asks to deploy to UAT.
+15. Treat `deploy to UAT` as a separate cadence: land the change on `main`, identify the exact green `main` SHA, manually dispatch `Deploy to UAT` for that SHA, then monitor the deploy chain to terminal state.
+16. If a core run fails, default to the smallest safe repair and rerun loop before declaring a blocker. Only stop early for a real permissions, product, or platform boundary.
+17. Default runtime launch behavior must be visible separate OS terminal windows, not hidden Codex sessions.
+18. For local app work, prefer separate `./bin/hushh terminal backend --mode local --reload` and `./bin/hushh terminal web --mode <mode>` commands unless the user explicitly asks for something else.
+19. Use hidden long-lived Codex sessions only for background monitoring, one-off debugging, or when a visible terminal is not desired.
+20. Use `./bin/hushh terminal stack --mode local` only when one combined visible terminal is explicitly preferred.
+21. When the user says `restart servers`, treat that as a graceful terminal-managed restart, not just a port kill. First inspect existing repo-launched visible terminals, stop the running backend/web processes, then terminate the login shells cleanly before closing any leftover windows so Terminal does not prompt `Do you want to terminate running processes in this window?`.
+22. For macOS Terminal restarts, prefer this order:
    - identify the repo-launched Terminal tabs/windows and their ttys
    - stop the backend/web processes attached to those ttys
    - verify the ports are no longer listening
@@ -81,22 +83,22 @@ Non-owned surfaces:
    - wait for the windows to disappear on their own or become truly idle
    - only then close any leftover idle Terminal windows
    - relaunch fresh visible terminals
-21. Do not close a Terminal window that still has a live shell just because the app listener is gone. A plain `close ... saving no` still triggers the terminate-process prompt on macOS if `zsh` is alive.
-22. If a terminal refuses to disappear after `exit`, treat force-close as fallback only. Prefer proving the shell is gone first, then closing the leftover idle window.
-23. If `./bin/hushh terminal web` opens but the frontend never binds, inspect the actual package surface before retrying. A common failure mode is `npm run dev` -> `sh: next: command not found`, which means the frontend install surface is broken even if dependencies appear partially present.
-24. In that case, verify the local Next binary resolves from the `hushh-webapp` package context, for example by checking `npm exec next -- --version` or an equivalent package-local resolution step. If Next does not resolve, repair the workspace through the canonical bootstrap path (`./bin/hushh bootstrap`) before relaunching the web terminal.
-25. Do not claim the server restart succeeded until both backend and web have been probed successfully after relaunch (`:8000/health` and `:3000`).
-26. Default branch policy: continue work on the user's active development branch. Do not create a new temporary branch for incremental fixes, validation follow-ups, or polish work unless the user explicitly asks for branch isolation.
-27. Create a new branch only when one of these is true:
+23. Do not close a Terminal window that still has a live shell just because the app listener is gone. A plain `close ... saving no` still triggers the terminate-process prompt on macOS if `zsh` is alive.
+24. If a terminal refuses to disappear after `exit`, treat force-close as fallback only. Prefer proving the shell is gone first, then closing the leftover idle window.
+25. If `./bin/hushh terminal web` opens but the frontend never binds, inspect the actual package surface before retrying. A common failure mode is `npm run dev` -> `sh: next: command not found`, which means the frontend install surface is broken even if dependencies appear partially present.
+26. In that case, verify the local Next binary resolves from the `hushh-webapp` package context, for example by checking `npm exec next -- --version` or an equivalent package-local resolution step. If Next does not resolve, repair the workspace through the canonical bootstrap path (`./bin/hushh bootstrap`) before relaunching the web terminal.
+27. Do not claim the server restart succeeded until both backend and web have been probed successfully after relaunch (`:8000/health` and `:3000`).
+28. Default branch policy: continue work on the user's active development branch. Do not create a new temporary branch for incremental fixes, validation follow-ups, or polish work unless the user explicitly asks for branch isolation.
+29. Create a new branch only when one of these is true:
    - the fix is a post-merge blocker and must start from the latest `main`
    - the repo workflow requires an isolated hotfix from `main`
    - the current branch contains unrelated in-flight work that would make the fix unsafe to ship
-28. After a merge-driven hotfix is complete, delete the temporary branch remotely and locally when it is safe to do so, then return local state to the user's normal working branch or `main`; do not leave Codex parked on a temporary branch.
-29. If the user has an active development branch, back-sync merged hotfixes into that branch before closing the task so the real working branch does not drift behind `main`.
-30. For CI workflows, branch protection, env/bootstrap, or deploy-authority changes, do a second verification pass after edits instead of trusting the first green run.
-31. For branch protection, merge queue, release authority, or production deploy-governance changes, do a third independent check against live GitHub or runtime state before calling the work complete.
-32. For UAT runtime failures, start with `./bin/hushh codex rca --surface uat --text` so secret drift, legacy runtime mounts, DB drift, and semantic runtime breakage are classified before editing or redeploying.
-33. Treat only core runtime/release surfaces as blocking in the RCA loop: runtime contract, deploy/runtime env contract, DB release contract, semantic UAT verification, and Gmail/voice/auth availability on the release lane. Helper-only drift stays advisory unless it masks one of those surfaces.
+30. After a merge-driven hotfix is complete, delete the temporary branch remotely and locally when it is safe to do so, then return local state to the user's normal working branch or `main`; do not leave Codex parked on a temporary branch.
+31. If the user has an active development branch, back-sync merged hotfixes into that branch before closing the task so the real working branch does not drift behind `main`.
+32. For CI workflows, branch protection, env/bootstrap, or deploy-authority changes, do a second verification pass after edits instead of trusting the first green run.
+33. For branch protection, merge queue, release authority, or production deploy-governance changes, do a third independent check against live GitHub or runtime state before calling the work complete.
+34. For UAT runtime failures, start with `./bin/hushh codex rca --surface uat --text` so secret drift, legacy runtime mounts, DB drift, and semantic runtime breakage are classified before editing or redeploying.
+35. Treat only core runtime/release surfaces as blocking in the RCA loop: runtime contract, deploy/runtime env contract, DB release contract, semantic UAT verification, and Gmail/voice/auth availability on the release lane. Helper-only drift stays advisory unless it masks one of those surfaces.
 
 ## Handoff Rules
 

--- a/.codex/skills/repo-operations/SKILL.md
+++ b/.codex/skills/repo-operations/SKILL.md
@@ -60,7 +60,7 @@ Non-owned surfaces:
 4. Use `./bin/hushh codex ci-status` for PR-check status and `scripts/ci/watch-gh-workflow-chain.sh` for long-running post-merge or deploy workflow chains.
 5. Treat the delivery model as three stages: PR feedback lane, queue authority lane, and post-merge deploy-authority lane.
 6. Treat GitHub approval and GitHub bypass as separate states: a PR author still cannot self-approve, but a bypass-listed actor may waive the review gate and, when configured, use the dedicated queue-bypass owner path.
-7. Do not flag the sanctioned `main` owner-bypass trio as governance drift when the live review-bypass allowlist exactly matches `config/ci-governance.json` and includes `kushaltrivedi5`.
+7. Do not flag the sanctioned `main` owner-bypass cohort as governance drift when the live review-bypass allowlist exactly matches `config/ci-governance.json` and includes `kushaltrivedi5`.
 8. Monitor the resulting workflow chain until terminal success or a concrete blocker.
 9. For core authority surfaces, the task is not complete while GitHub still shows any relevant run for the touched SHA as `queued`, `in_progress`, or `requested`.
 10. Core authority surfaces are `PR Validation`, `Queue Validation`, `Main Post-Merge Smoke`, `Deploy to UAT`, and any RCA-triggered release-authority rerun for the same SHA.
@@ -72,17 +72,31 @@ Non-owned surfaces:
 16. For local app work, prefer separate `./bin/hushh terminal backend --mode local --reload` and `./bin/hushh terminal web --mode <mode>` commands unless the user explicitly asks for something else.
 17. Use hidden long-lived Codex sessions only for background monitoring, one-off debugging, or when a visible terminal is not desired.
 18. Use `./bin/hushh terminal stack --mode local` only when one combined visible terminal is explicitly preferred.
-19. Default branch policy: continue work on the user's active development branch. Do not create a new temporary branch for incremental fixes, validation follow-ups, or polish work unless the user explicitly asks for branch isolation.
-20. Create a new branch only when one of these is true:
+19. When the user says `restart servers`, treat that as a graceful terminal-managed restart, not just a port kill. First inspect existing repo-launched visible terminals, stop the running backend/web processes, then terminate the login shells cleanly before closing any leftover windows so Terminal does not prompt `Do you want to terminate running processes in this window?`.
+20. For macOS Terminal restarts, prefer this order:
+   - identify the repo-launched Terminal tabs/windows and their ttys
+   - stop the backend/web processes attached to those ttys
+   - verify the ports are no longer listening
+   - send `exit` into the affected Terminal tabs so the login shells terminate cleanly
+   - wait for the windows to disappear on their own or become truly idle
+   - only then close any leftover idle Terminal windows
+   - relaunch fresh visible terminals
+21. Do not close a Terminal window that still has a live shell just because the app listener is gone. A plain `close ... saving no` still triggers the terminate-process prompt on macOS if `zsh` is alive.
+22. If a terminal refuses to disappear after `exit`, treat force-close as fallback only. Prefer proving the shell is gone first, then closing the leftover idle window.
+23. If `./bin/hushh terminal web` opens but the frontend never binds, inspect the actual package surface before retrying. A common failure mode is `npm run dev` -> `sh: next: command not found`, which means the frontend install surface is broken even if `hushh-webapp/node_modules/` exists.
+24. In that case, verify `hushh-webapp/node_modules/.bin/next` explicitly. If it is missing, repair the workspace through the canonical bootstrap path (`./bin/hushh bootstrap`) before relaunching the web terminal.
+25. Do not claim the server restart succeeded until both backend and web have been probed successfully after relaunch (`:8000/health` and `:3000`).
+26. Default branch policy: continue work on the user's active development branch. Do not create a new temporary branch for incremental fixes, validation follow-ups, or polish work unless the user explicitly asks for branch isolation.
+27. Create a new branch only when one of these is true:
    - the fix is a post-merge blocker and must start from the latest `main`
    - the repo workflow requires an isolated hotfix from `main`
    - the current branch contains unrelated in-flight work that would make the fix unsafe to ship
-21. After a merge-driven hotfix is complete, delete the temporary branch remotely and locally when it is safe to do so, then return local state to the user's normal working branch or `main`; do not leave Codex parked on a temporary branch.
-22. If the user has an active development branch, back-sync merged hotfixes into that branch before closing the task so the real working branch does not drift behind `main`.
-23. For CI workflows, branch protection, env/bootstrap, or deploy-authority changes, do a second verification pass after edits instead of trusting the first green run.
-24. For branch protection, merge queue, release authority, or production deploy-governance changes, do a third independent check against live GitHub or runtime state before calling the work complete.
-25. For UAT runtime failures, start with `./bin/hushh codex rca --surface uat --text` so secret drift, legacy runtime mounts, DB drift, and semantic runtime breakage are classified before editing or redeploying.
-26. Treat only core runtime/release surfaces as blocking in the RCA loop: runtime contract, deploy/runtime env contract, DB release contract, semantic UAT verification, and Gmail/voice/auth availability on the release lane. Helper-only drift stays advisory unless it masks one of those surfaces.
+28. After a merge-driven hotfix is complete, delete the temporary branch remotely and locally when it is safe to do so, then return local state to the user's normal working branch or `main`; do not leave Codex parked on a temporary branch.
+29. If the user has an active development branch, back-sync merged hotfixes into that branch before closing the task so the real working branch does not drift behind `main`.
+30. For CI workflows, branch protection, env/bootstrap, or deploy-authority changes, do a second verification pass after edits instead of trusting the first green run.
+31. For branch protection, merge queue, release authority, or production deploy-governance changes, do a third independent check against live GitHub or runtime state before calling the work complete.
+32. For UAT runtime failures, start with `./bin/hushh codex rca --surface uat --text` so secret drift, legacy runtime mounts, DB drift, and semantic runtime breakage are classified before editing or redeploying.
+33. Treat only core runtime/release surfaces as blocking in the RCA loop: runtime contract, deploy/runtime env contract, DB release contract, semantic UAT verification, and Gmail/voice/auth availability on the release lane. Helper-only drift stays advisory unless it masks one of those surfaces.
 
 ## Handoff Rules
 

--- a/.codex/skills/repo-operations/SKILL.md
+++ b/.codex/skills/repo-operations/SKILL.md
@@ -83,8 +83,8 @@ Non-owned surfaces:
    - relaunch fresh visible terminals
 21. Do not close a Terminal window that still has a live shell just because the app listener is gone. A plain `close ... saving no` still triggers the terminate-process prompt on macOS if `zsh` is alive.
 22. If a terminal refuses to disappear after `exit`, treat force-close as fallback only. Prefer proving the shell is gone first, then closing the leftover idle window.
-23. If `./bin/hushh terminal web` opens but the frontend never binds, inspect the actual package surface before retrying. A common failure mode is `npm run dev` -> `sh: next: command not found`, which means the frontend install surface is broken even if `hushh-webapp/node_modules/` exists.
-24. In that case, verify `hushh-webapp/node_modules/.bin/next` explicitly. If it is missing, repair the workspace through the canonical bootstrap path (`./bin/hushh bootstrap`) before relaunching the web terminal.
+23. If `./bin/hushh terminal web` opens but the frontend never binds, inspect the actual package surface before retrying. A common failure mode is `npm run dev` -> `sh: next: command not found`, which means the frontend install surface is broken even if dependencies appear partially present.
+24. In that case, verify the local Next binary resolves from the `hushh-webapp` package context, for example by checking `npm exec next -- --version` or an equivalent package-local resolution step. If Next does not resolve, repair the workspace through the canonical bootstrap path (`./bin/hushh bootstrap`) before relaunching the web terminal.
 25. Do not claim the server restart succeeded until both backend and web have been probed successfully after relaunch (`:8000/health` and `:3000`).
 26. Default branch policy: continue work on the user's active development branch. Do not create a new temporary branch for incremental fixes, validation follow-ups, or polish work unless the user explicitly asks for branch isolation.
 27. Create a new branch only when one of these is true:

--- a/.codex/skills/repo-operations/references/operations-surface.md
+++ b/.codex/skills/repo-operations/references/operations-surface.md
@@ -48,6 +48,6 @@ Use this reference to orient DevOps work in `hushh-research`.
 1. Review approval and review bypass are different GitHub states.
 2. A PR author cannot self-approve through GitHub.
 3. A bypass-listed actor may still waive the review gate when the live branch protection allows it.
-4. The sanctioned `main` owner-bypass trio is intentional policy, not a finding, when it exactly matches `config/ci-governance.json` and includes `kushaltrivedi5`.
+4. The sanctioned `main` owner-bypass cohort is intentional policy, not a finding, when it exactly matches `config/ci-governance.json` and includes `kushaltrivedi5`.
 5. Merge-queue rules remain separate from review bypass and are satisfied through the dedicated `main-bypass-queue` owner team.
-6. The privileged three may dispatch UAT manually; only `kushaltrivedi5` may dispatch Production.
+6. The privileged `main` bypass cohort may dispatch UAT manually; only `kushaltrivedi5` may dispatch Production.

--- a/.codex/skills/repo-operations/scripts/ci_monitor.py
+++ b/.codex/skills/repo-operations/scripts/ci_monitor.py
@@ -190,7 +190,7 @@ def _review_policy(base_branch: str = "main") -> OrderedDict[str, Any]:
         notes=[
             "A PR author still cannot self-approve through GitHub.",
             "Review bypass and merge-queue policy are separate gates.",
-            "The sanctioned main owner-bypass trio may waive review on main and bypass merge queue through the dedicated team-backed owner path.",
+            "The sanctioned main owner-bypass cohort may waive review on main and bypass merge queue through the dedicated team-backed owner path.",
         ],
     )
 

--- a/.codex/workflows/pr-governance-review/PLAYBOOK.md
+++ b/.codex/workflows/pr-governance-review/PLAYBOOK.md
@@ -1,0 +1,57 @@
+# PR Governance Review
+
+Use this workflow pack when reviewing an incoming pull request for true merge readiness.
+
+## Goal
+
+Review the current PR head, not stale history, and decide whether the change is actually safe to merge against Hushh north stars and trust boundaries.
+
+## Steps
+
+1. Start with `pr-governance-review`.
+2. Run `python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo <repo> --pr <number> --text`.
+3. For batched review, run `python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo <repo> --prs <n1,n2,...> --text` first and use that output to identify overlap, duplication, and safe batching boundaries before looking at merge order.
+4. Treat helper-detected main-overlap and parallel-architecture findings as first-class review inputs, not optional notes. Exact file overlap is not the only duplication signal that matters.
+5. Lock the review to the current head SHA and current `CI Status Gate` result.
+6. Use a two-pass review model on every lane:
+   - Pass 1: verify against current `main`, the current PR head, and product architecture truth before taking action
+   - Pass 2: verify the authoritative workflow chain after action, including PR validation, queue validation, and main post-merge smoke where applicable
+7. Assess findings in blocker-first order:
+   - north-star drift
+   - trust-boundary regression
+   - caller/proxy/backend mismatch
+   - deploy/runtime reproducibility drift
+   - proof gaps
+   - main-overlap / parallel-architecture drift
+8. Choose exactly one lane:
+   - `merge_now`
+   - `patch_then_merge`
+   - `block`
+9. If the lane is `patch_then_merge`, do not merge the contributor head directly. Apply the smallest maintainer integration patch first, rerun checks, then communicate the adopted fix back to the author.
+10. Prefer patching the contributor branch directly when maintainers are allowed to modify it. Use a short-lived `temp/pr-<number>-patch` branch only when direct patching is not possible or isolated maintainer staging is safer.
+11. In a batch, do not recommend “merge all healthy PRs” unless the review explicitly proves there is no meaningful overlap or ordering dependency between them.
+12. Before triggering merge, auto-merge, or merge-queue entry, produce the contributor-facing markdown draft for the selected lane. Do not post it yet.
+13. When replying on the PR, use a brief markdown note with:
+   - `## Acknowledgment`
+   - `## What We Adopted`
+   - `## Merge Decision`, `## Maintainer Patch`, or `## Blockers`
+   - `## Related Surfaces` when the merge touched a trust boundary, product boundary, or reusable subsystem and future readers need the higher-level repo context; prefer clickable GitHub links to repo files and docs and include a one-line explanation for each entry
+   - `## Why`
+   - `## Next` only when there is real follow-up to communicate
+14. Once the policy is finalized, do not ask for a second confirmation before posting the contributor-facing note. The note should be posted automatically after the monitored merge result reaches the required terminal state for that lane.
+15. Do not stop monitoring after `gh pr merge`, `gh pr merge --auto`, queue entry, or green PR checks. Stay attached until the authoritative workflow chain is terminal for that PR:
+   - `Queue Validation` terminal when merge queue is involved
+   - `Main Post-Merge Smoke` terminal if the PR lands on `main`
+16. Treat early stop as process drift. Codex should not need a user reminder to continue monitoring once it initiated the merge path.
+17. Hand off only when the blocker lives inside another owner family.
+18. Do not imply approval or recommend merge while blocker findings remain on the current merge candidate.
+
+## Common Drift Risks
+
+1. stale maintainer comments misleading the current review
+2. repo-side CI bugs being mistaken for contributor code bugs, or vice versa
+3. auth or runtime tightening that breaks current callers
+4. performance claims that silently alter streaming or user-visible semantics
+5. merging or queueing a PR without preparing the contributor-facing acknowledgment draft
+6. posting the acknowledgment before the monitored merge outcome is actually known
+7. stopping at queue entry or green PR checks instead of monitoring through post-merge authority

--- a/.codex/workflows/pr-governance-review/workflow.json
+++ b/.codex/workflows/pr-governance-review/workflow.json
@@ -1,0 +1,71 @@
+{
+  "id": "pr-governance-review",
+  "title": "PR Governance Review",
+  "goal": "Review the current head of an incoming pull request for north-star alignment, trust-boundary regressions, stale-vs-current CI interpretation, and true merge readiness beyond a green gate.",
+  "owner_skill": "pr-governance-review",
+  "default_spoke": null,
+  "task_type": "pr-governance-review",
+  "affected_surfaces": [
+    ".codex/skills/pr-governance-review",
+    ".github",
+    "consent-protocol/api",
+    "consent-protocol/tests",
+    "hushh-webapp/app",
+    "hushh-webapp/lib",
+    "deploy",
+    "scripts"
+  ],
+  "required_reads": [
+    "README.md",
+    "docs/reference/operations/ci.md",
+    ".codex/skills/pr-governance-review/references/review-axes.md",
+    ".codex/skills/repo-operations/SKILL.md"
+  ],
+  "required_commands": [
+    "python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --pr 437 --text",
+    "./bin/hushh codex audit --text"
+  ],
+  "verification_bundle": {
+    "id": "pr-governance-review",
+    "commands": [
+      "python3 -m py_compile .codex/skills/pr-governance-review/scripts/pr_review_checklist.py",
+      "python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --pr 437 --text",
+      "./bin/hushh codex audit --text",
+      "./bin/hushh docs verify"
+    ],
+    "tests": [
+      "python3 -m py_compile .codex/skills/pr-governance-review/scripts/pr_review_checklist.py",
+      "./bin/hushh codex audit --text",
+      "./bin/hushh docs verify"
+    ]
+  },
+  "deliverables": [
+    "current-head SHA review summary",
+    "blocker-first findings list",
+    "stale-vs-current CI interpretation",
+    "merge lane recommendation"
+  ],
+  "impact_fields": [
+    "Head SHA reviewed",
+    "Current CI Status Gate state",
+    "Blocker findings",
+    "Chosen merge lane",
+    "Docs updated",
+    "Verification commands executed"
+  ],
+  "handoff_chain": [
+    "pr-governance-review",
+    "repo-operations",
+    "quality-contracts",
+    "backend-runtime-governance",
+    "frontend-architecture",
+    "security-audit"
+  ],
+  "common_failures": [
+    "reviewing a stale failed run instead of the current head SHA",
+    "treating green CI as sufficient proof for a sensitive contract change",
+    "missing backend-to-caller contract drift because only one side of the change moved",
+    "thanking or merging before blocker findings are explicitly cleared",
+    "merging a directionally good but currently unsafe contributor head instead of using the patch-then-merge lane"
+  ]
+}

--- a/.codex/workflows/pre-pr-readiness/PLAYBOOK.md
+++ b/.codex/workflows/pre-pr-readiness/PLAYBOOK.md
@@ -10,19 +10,23 @@ Run the same local blocking CI surface that GitHub expects for `PR Validation` a
 
 1. Start with `repo-operations`.
 2. Run `./bin/hushh codex pre-pr`.
-3. Use `./bin/hushh codex pre-pr --include-advisory` only when you intentionally want the wider local release/readiness lane.
-4. If the local mirror fails, fix the failing surface before opening or updating the pull request.
-5. After the pull request opens, switch to `./bin/hushh codex ci-status --watch` and monitor GitHub to terminal state.
-6. After Codex triggers merge, auto-merge, or merge-queue entry, keep monitoring until the authoritative chain reaches terminal state.
-7. For merge-queue repos, do not stop at `queued to merge`; the minimum completion bar is:
+3. Before the first push, ensure every local commit destined for the pull request has a DCO trailer. Prefer `git commit -s`; if unsigned commits already exist, repair them with `git rebase --signoff <base>`.
+4. If the change touches `.codex/`, `docs/`, `config/`, or `scripts/`, rerun `bash scripts/ci/orchestrate.sh governance` after the last local edit.
+5. Use `./bin/hushh codex pre-pr --include-advisory` only when you intentionally want the wider local release/readiness lane.
+6. If the local mirror fails, fix the failing surface before opening or updating the pull request.
+7. After the pull request opens, switch to `./bin/hushh codex ci-status --watch` and monitor GitHub to terminal state.
+8. After Codex triggers merge, auto-merge, or merge-queue entry, keep monitoring until the authoritative chain reaches terminal state.
+9. For merge-queue repos, do not stop at `queued to merge`; the minimum completion bar is:
    - queue entry confirmed
    - `Queue Validation` terminal
    - if the change lands on `main`, `Main Post-Merge Smoke` terminal
-8. Only stop at the queue stage when the user asked to queue the PR, not to see it fully land.
+10. Only stop at the queue stage when the user asked to queue the PR, not to see it fully land.
 
 ## Common Drift Risks
 
 1. opening a pull request without running the local mirror
-2. adding GitHub-required checks without keeping the local mirror aligned
-3. using advisory checks as the default pre-PR blocker
-4. treating `merge triggered` or `queued to merge` as task completion
+2. pushing unsigned commits and letting DCO fail on GitHub
+3. changing `.codex/`, `docs/`, `config/`, or `scripts/` without rerunning the governance lane
+4. adding GitHub-required checks without keeping the local mirror aligned
+5. using advisory checks as the default pre-PR blocker
+6. treating `merge triggered` or `queued to merge` as task completion

--- a/.codex/workflows/pre-pr-readiness/PLAYBOOK.md
+++ b/.codex/workflows/pre-pr-readiness/PLAYBOOK.md
@@ -13,9 +13,16 @@ Run the same local blocking CI surface that GitHub expects for `PR Validation` a
 3. Use `./bin/hushh codex pre-pr --include-advisory` only when you intentionally want the wider local release/readiness lane.
 4. If the local mirror fails, fix the failing surface before opening or updating the pull request.
 5. After the pull request opens, switch to `./bin/hushh codex ci-status --watch` and monitor GitHub to terminal state.
+6. After Codex triggers merge, auto-merge, or merge-queue entry, keep monitoring until the authoritative chain reaches terminal state.
+7. For merge-queue repos, do not stop at `queued to merge`; the minimum completion bar is:
+   - queue entry confirmed
+   - `Queue Validation` terminal
+   - if the change lands on `main`, `Main Post-Merge Smoke` terminal
+8. Only stop at the queue stage when the user asked to queue the PR, not to see it fully land.
 
 ## Common Drift Risks
 
 1. opening a pull request without running the local mirror
 2. adding GitHub-required checks without keeping the local mirror aligned
 3. using advisory checks as the default pre-PR blocker
+4. treating `merge triggered` or `queued to merge` as task completion

--- a/.codex/workflows/pre-pr-readiness/workflow.json
+++ b/.codex/workflows/pre-pr-readiness/workflow.json
@@ -32,6 +32,8 @@
   },
   "deliverables": [
     "local CI mirror result",
+    "DCO signoff state for branch commits",
+    "governance rerun state for skill/docs/config/scripts changes",
     "blocking-vs-advisory lane choice",
     "pre-PR readiness summary",
     "post-trigger monitoring state when Codex opens, updates, or queues a PR merge"
@@ -52,6 +54,8 @@
   ],
   "common_failures": [
     "opening or updating a PR without running the local mirror first",
+    "pushing unsigned commits and discovering DCO only on GitHub",
+    "changing .codex/docs/config/scripts without rerunning the governance lane",
     "inventing a second local CI path instead of reusing ./bin/hushh ci",
     "treating advisory checks as blocking by default",
     "treating merge-queue entry as completion instead of monitoring queue and post-merge authority surfaces"

--- a/.codex/workflows/pre-pr-readiness/workflow.json
+++ b/.codex/workflows/pre-pr-readiness/workflow.json
@@ -33,13 +33,15 @@
   "deliverables": [
     "local CI mirror result",
     "blocking-vs-advisory lane choice",
-    "pre-PR readiness summary"
+    "pre-PR readiness summary",
+    "post-trigger monitoring state when Codex opens, updates, or queues a PR merge"
   ],
   "impact_fields": [
     "Workflow mirrored",
     "Blocking checks passed",
     "Advisory lane included",
-    "Verification commands executed"
+    "Verification commands executed",
+    "Post-trigger terminal status"
   ],
   "handoff_chain": [
     "repo-operations",
@@ -51,6 +53,7 @@
   "common_failures": [
     "opening or updating a PR without running the local mirror first",
     "inventing a second local CI path instead of reusing ./bin/hushh ci",
-    "treating advisory checks as blocking by default"
+    "treating advisory checks as blocking by default",
+    "treating merge-queue entry as completion instead of monitoring queue and post-merge authority surfaces"
   ]
 }

--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -7,14 +7,16 @@
     "review_bypass_users": [
       "kushaltrivedi5",
       "Akash-292",
-      "RGlodAkshat"
+      "RGlodAkshat",
+      "ankitkumarsingh1702"
     ],
     "merge_queue_required": true,
     "merge_queue_bypass_team_slug": "main-bypass-queue",
     "merge_queue_bypass_users": [
       "kushaltrivedi5",
       "Akash-292",
-      "RGlodAkshat"
+      "RGlodAkshat",
+      "ankitkumarsingh1702"
     ]
   },
   "uat": {
@@ -23,7 +25,8 @@
     "manual_dispatch_users": [
       "kushaltrivedi5",
       "Akash-292",
-      "RGlodAkshat"
+      "RGlodAkshat",
+      "ankitkumarsingh1702"
     ]
   },
   "production": {

--- a/consent-protocol/hushh_mcp/services/consent_center_service.py
+++ b/consent-protocol/hushh_mcp/services/consent_center_service.py
@@ -1374,9 +1374,7 @@ class ConsentCenterService:
         # 1) Consent audit events between user and the counterpart agent_id.
         #    The agent_id in consent_audit for RIA requests is typically
         #    "ria:<ria_profile_id>" or the ria_user_id.
-        audit_result = await self._consent_db.get_audit_log(
-            user_id, page=1, limit=500
-        )
+        audit_result = await self._consent_db.get_audit_log(user_id, page=1, limit=500)
         audit_items = audit_result.get("items", [])
 
         # Filter to events involving the counterpart.

--- a/consent-protocol/tests/test_consent_handshake.py
+++ b/consent-protocol/tests/test_consent_handshake.py
@@ -173,7 +173,9 @@ def test_full_handshake_lifecycle(monkeypatch):
     monkeypatch.setattr(
         consent,
         "issue_token",
-        lambda **_kwargs: SimpleNamespace(token=issued_token, expires_at=int(time.time() * 1000) + 86400000),
+        lambda **_kwargs: SimpleNamespace(
+            token=issued_token, expires_at=int(time.time() * 1000) + 86400000
+        ),
     )
     monkeypatch.setattr(consent, "revoke_token", lambda t: None)
     monkeypatch.setattr(consent, "RIAIAMService", _NoOpRIAIAMService)
@@ -420,7 +422,12 @@ def test_handshake_history_empty_for_unrelated_counterpart():
     with patch(
         "hushh_mcp.services.consent_center_service.ConsentCenterService.get_handshake_history",
         new_callable=AsyncMock,
-        return_value={"user_id": "investor_1", "counterpart_id": "unknown", "total": 0, "timeline": []},
+        return_value={
+            "user_id": "investor_1",
+            "counterpart_id": "unknown",
+            "total": 0,
+            "timeline": [],
+        },
     ):
         client = TestClient(app)
         resp = client.get(

--- a/consent-protocol/tests/test_ria_verification_hardening.py
+++ b/consent-protocol/tests/test_ria_verification_hardening.py
@@ -1,4 +1,5 @@
 """Tests for RIA verification hardening and dev allowlist (issue #123)."""
+
 from __future__ import annotations
 
 import pytest
@@ -125,9 +126,7 @@ def test_unverified_ria_blocked_on_clients(monkeypatch):
 
 def test_unverified_ria_blocked_on_client_detail(monkeypatch):
     async def _mock_require(self, user_id):
-        raise RIAIAMPolicyError(
-            "RIA verification incomplete.", status_code=403
-        )
+        raise RIAIAMPolicyError("RIA verification incomplete.", status_code=403)
 
     monkeypatch.setattr(RIAIAMService, "require_ria_verified", _mock_require)
 
@@ -138,9 +137,7 @@ def test_unverified_ria_blocked_on_client_detail(monkeypatch):
 
 def test_unverified_ria_blocked_on_create_request(monkeypatch):
     async def _mock_require(self, user_id):
-        raise RIAIAMPolicyError(
-            "RIA verification incomplete.", status_code=403
-        )
+        raise RIAIAMPolicyError("RIA verification incomplete.", status_code=403)
 
     monkeypatch.setattr(RIAIAMService, "require_ria_verified", _mock_require)
 
@@ -157,9 +154,7 @@ def test_unverified_ria_blocked_on_create_request(monkeypatch):
 
 def test_unverified_ria_blocked_on_workspace(monkeypatch):
     async def _mock_require(self, user_id):
-        raise RIAIAMPolicyError(
-            "RIA verification incomplete.", status_code=403
-        )
+        raise RIAIAMPolicyError("RIA verification incomplete.", status_code=403)
 
     monkeypatch.setattr(RIAIAMService, "require_ria_verified", _mock_require)
 
@@ -170,9 +165,7 @@ def test_unverified_ria_blocked_on_workspace(monkeypatch):
 
 def test_unverified_ria_blocked_on_create_invites(monkeypatch):
     async def _mock_require(self, user_id):
-        raise RIAIAMPolicyError(
-            "RIA verification incomplete.", status_code=403
-        )
+        raise RIAIAMPolicyError("RIA verification incomplete.", status_code=403)
 
     monkeypatch.setattr(RIAIAMService, "require_ria_verified", _mock_require)
 

--- a/consent-protocol/tests/test_scope_bundle_contract.py
+++ b/consent-protocol/tests/test_scope_bundle_contract.py
@@ -51,9 +51,7 @@ class TestBundleStructure:
     @pytest.mark.parametrize("key", list(CANONICAL_BUNDLES.keys()))
     def test_color_hex_valid(self, key: str) -> None:
         color = CANONICAL_BUNDLES[key].color_hex
-        assert re.match(
-            r"^#[0-9A-Fa-f]{6}$", color
-        ), f"{key} has invalid color_hex: {color}"
+        assert re.match(r"^#[0-9A-Fa-f]{6}$", color), f"{key} has invalid color_hex: {color}"
 
     @pytest.mark.parametrize("key", list(CANONICAL_BUNDLES.keys()))
     def test_scopes_non_empty(self, key: str) -> None:
@@ -87,11 +85,7 @@ class TestBundleScopeMatching:
 
     @pytest.mark.parametrize(
         "key,scope",
-        [
-            (k, s)
-            for k, b in CANONICAL_BUNDLES.items()
-            for s in b.scopes
-        ],
+        [(k, s) for k, b in CANONICAL_BUNDLES.items() for s in b.scopes],
     )
     def test_scope_is_dynamic(self, key: str, scope: str) -> None:
         assert self.gen.is_dynamic_scope(scope), (
@@ -100,25 +94,14 @@ class TestBundleScopeMatching:
 
     @pytest.mark.parametrize(
         "key,scope",
-        [
-            (k, s)
-            for k, b in CANONICAL_BUNDLES.items()
-            for s in b.scopes
-        ],
+        [(k, s) for k, b in CANONICAL_BUNDLES.items() for s in b.scopes],
     )
     def test_scope_matches_itself(self, key: str, scope: str) -> None:
-        assert scope_matches(scope, scope), (
-            f"Bundle {key} scope {scope} does not match itself"
-        )
+        assert scope_matches(scope, scope), f"Bundle {key} scope {scope} does not match itself"
 
     @pytest.mark.parametrize(
         "key,scope",
-        [
-            (k, s)
-            for k, b in CANONICAL_BUNDLES.items()
-            for s in b.scopes
-            if s.endswith(".*")
-        ],
+        [(k, s) for k, b in CANONICAL_BUNDLES.items() for s in b.scopes if s.endswith(".*")],
     )
     def test_wildcard_scope_matches_child(self, key: str, scope: str) -> None:
         child = scope.replace(".*", ".test_attribute")
@@ -168,7 +151,15 @@ class TestBundleAPI:
 
     def test_get_bundle_display_info_has_required_fields(self) -> None:
         info = get_bundle_display_info("financial_overview")
-        for field in ("bundle_key", "label", "description", "icon_name", "color_hex", "scopes", "scope_count"):
+        for field in (
+            "bundle_key",
+            "label",
+            "description",
+            "icon_name",
+            "color_hex",
+            "scopes",
+            "scope_count",
+        ):
             assert field in info, f"Missing field: {field}"
 
     def test_get_bundle_display_info_unknown_raises(self) -> None:

--- a/docs/future/kai/email-kyc-pkm-assistant.md
+++ b/docs/future/kai/email-kyc-pkm-assistant.md
@@ -14,7 +14,7 @@ Canonical visual owner: [Kai Future Roadmap](./README.md). Use that map for the 
 
 This concept keeps Kai as the primary assistant and adds a Kai-owned delegated email/KYC specialist that can execute narrow workflow tasks after on-demand scoped consent.
 
-The goal is not a generic email bot. The goal is a trust-bound workflow component that fits Hushh's existing architecture:
+The goal is not a generic email bot or a public inbox-first workflow. The goal is a trust-bound workflow component that fits Hushh's existing architecture:
 
 - Kai remains the user-facing orchestrator
 - PKM remains the durable personal memory layer
@@ -40,6 +40,7 @@ What already exists in the repo today:
 - ADK-backed agent orchestration surfaces in the backend
 - Kai as the user-facing assistant identity
 - connector-aware runtime patterns for delegated actions
+- authenticated support and feedback delivery routed through the existing Gmail-backed support transport
 
 What does not yet exist as a first-class product/runtime contract:
 
@@ -47,6 +48,7 @@ What does not yet exist as a first-class product/runtime contract:
 - workflow-specific on-demand consent metadata for this task family
 - a canonical runtime-memory/writeback split for delegated email/KYC workflows
 - explicit user-facing trust-state UX for this workflow family
+- an approved `kai@hushh.ai` runtime contract for public inbound email
 
 ## Future Concept
 
@@ -102,6 +104,7 @@ Before execution, this concept likely needs:
 3. outbound-action policy by workflow type
 4. trust-state UX contract for waiting, approval, and completion
 5. promotion of connector boundaries from concept to execution-owned docs
+6. a transport-sharing rule that allows reuse of support/email queue primitives without inheriting the support trust model
 
 ## Edge and Risk Assessment
 
@@ -127,6 +130,7 @@ Before execution, this concept likely needs:
 - on-demand consent should carry enough metadata for the user to understand what is being requested
 - connector permissions must stay task-specific instead of broad background access
 - delegated execution must fail closed when scope, authority, or freshness is unclear
+- email/KYC may share delivery and queueing primitives with Support, but it must not share Support's authority model or bypass the consent boundary
 
 ### UX risk
 
@@ -146,6 +150,7 @@ This concept does not assume:
 - raw email threads as permanent PKM memory by default
 - immediate implementation of a durable workflow engine
 - bypassing consent or trust-state UX in the name of speed
+- approval of a live public `kai@hushh.ai` inbound webhook before the trust and rollout contract is explicitly owned
 
 ## Promotion Readiness Checklist
 

--- a/docs/reference/operations/branch-governance.md
+++ b/docs/reference/operations/branch-governance.md
@@ -56,7 +56,7 @@ Before deleting a local backup branch, classify its unique commits as:
 
 1. UAT deploys only through a manual workflow dispatch with an explicit green `main` SHA.
 2. The workflow checks out that exact chosen green `main` SHA.
-3. Manual dispatch is limited to `kushaltrivedi5`, `Akash-292`, and `RGlodAkshat`.
+3. Manual dispatch is limited to `kushaltrivedi5`, `Akash-292`, `RGlodAkshat`, and `ankitkumarsingh1702`.
 4. Workflow preflight fails if the requested SHA is not reachable from `origin/main`.
 5. Workflow preflight also fails if the SHA does not already have a successful `Main Post-Merge Smoke Gate`.
 
@@ -88,7 +88,7 @@ Before deleting a local backup branch, classify its unique commits as:
 6. Block force-pushes.
 7. Block branch deletion.
 8. Do not require blanket PR approvals on `main`; CI status plus merge queue are the default merge gates.
-9. Use review bypass plus the dedicated `main-bypass-queue` team for the 3 core owners only; do not rely on overlapping push restrictions.
+9. Use review bypass plus the dedicated `main-bypass-queue` team for the sanctioned `main` bypass cohort only; do not rely on overlapping push restrictions.
 10. Keep ordinary development off `main`; use PRs from developer branches.
 
 Current operating note:
@@ -99,9 +99,9 @@ Current operating note:
 - `main` intentionally requires `0` blanket approvals; the external community still goes through PR + CI + queue
 - admin ownership does not count as an independent PR approval
 - a PR author cannot self-approve through GitHub; review remains a separate state from admin privileges
-- the current live `main` branch protection review-bypass allowlist is `kushaltrivedi5`, `Akash-292`, and `RGlodAkshat`
-- the current live merge-queue bypass team is `main-bypass-queue`, containing those same 3 users only
-- the sanctioned review-bypass trio is intentional policy and should not be reported as governance drift when it matches `config/ci-governance.json`
+- the current live `main` branch protection review-bypass allowlist is `kushaltrivedi5`, `Akash-292`, `RGlodAkshat`, and `ankitkumarsingh1702`
+- the current live merge-queue bypass team is `main-bypass-queue`, containing those same 4 users only
+- the sanctioned review-bypass cohort is intentional policy and should not be reported as governance drift when it matches `config/ci-governance.json`
 - if an admin needs to proceed on a green PR, verify whether the live ruleset allows queue entry; do not assume approval is implicitly satisfied
 - bypass actors may waive review through branch protection and bypass queue through the dedicated owner team path
 - direct pushes to `main` are not the default bypass model; the preferred path is a green PR plus bypass merge

--- a/docs/reference/operations/ci.md
+++ b/docs/reference/operations/ci.md
@@ -242,6 +242,12 @@ The required pre-merge lane stays intentionally small:
 
 Post-merge smoke remains the deployment eligibility gate for `main`.
 
+Practical maintainer rule:
+
+1. Use `git commit -s` for new branch commits that are headed to GitHub.
+2. If unsigned commits already exist on the branch, repair them before push with `git rebase --signoff <base>`.
+3. If the last local edit touched `.codex/`, `docs/`, `config/`, or `scripts/`, rerun `bash scripts/ci/orchestrate.sh governance` even if an earlier `./bin/hushh codex pre-pr` was green.
+
 ### Script Lifecycle Policy
 
 1. Add a new CI/helper script only when it replaces or consolidates an existing one in the same PR.

--- a/docs/reference/operations/ci.md
+++ b/docs/reference/operations/ci.md
@@ -64,6 +64,7 @@ Minimum expectation:
 5. do not stop at "triggered" or "queued"
 6. if the failure is within the CI/deploy/policy surface, move into fix-and-rerun mode until the change is green or a hard blocker is identified
 7. when the run is expected to outlive the current chat turn, start the persistent watcher instead of relying on manual follow-up
+8. when Codex initiated the merge or queue action, continuing this watch is mandatory; needing a user reminder to resume monitoring is process drift
 
 Codex-first PR watcher:
 
@@ -72,6 +73,15 @@ Codex-first PR watcher:
 ```
 
 Use this command first for active pull-request checks because it classifies failing jobs into the right owner skill and points to the next workflow pack before dropping to raw `gh run` inspection.
+
+Merge-queue rule:
+
+If Codex triggers `gh pr merge`, `gh pr merge --auto`, or any action that places a PR into merge queue, that is not completion. Codex must confirm the queue entry, then continue monitoring the authoritative workflow chain until:
+
+1. `Queue Validation` reaches terminal state for the merge candidate
+2. if the PR lands, `Main Post-Merge Smoke` reaches terminal state for the landed `main` SHA
+3. only stop earlier when the user explicitly asked for queue placement rather than landed completion
+4. if Codex triggered the merge path, it owns this monitoring step through terminal completion and should not pause after the queue accepts the PR
 
 Codex-first RCA surface:
 

--- a/docs/reference/operations/ci.md
+++ b/docs/reference/operations/ci.md
@@ -124,7 +124,7 @@ To prevent CI check-sprawl, only these queue/PR checks are hard-blocking by defa
 3. `scripts/ci/protocol-check.sh`
 4. `scripts/ci/integration-check.sh`
 
-The local parity script mirrors the blocking pre-merge validation stages. On GitHub, `main` should require `CI Status Gate` as the blocking status check on PR and queue commits, keep `Main Freshness Gate` advisory on pull requests, enforce freshness authoritatively through merge queue validation, trust `Main Post-Merge Smoke Gate` for deployment eligibility on the landed `main` SHA, and restrict queue bypass to the dedicated three-person owner team only.
+The local parity script mirrors the blocking pre-merge validation stages. On GitHub, `main` should require `CI Status Gate` as the blocking status check on PR and queue commits, keep `Main Freshness Gate` advisory on pull requests, enforce freshness authoritatively through merge queue validation, trust `Main Post-Merge Smoke Gate` for deployment eligibility on the landed `main` SHA, and restrict queue bypass to the dedicated sanctioned owner cohort only.
 
 ### PKM rollout blocker
 
@@ -204,8 +204,8 @@ The live GitHub setting can drift from the docs, so verify it directly:
 Current live nuance:
 
 - the repo uses branch protection for review, freshness, and conversation-resolution requirements
-- the sanctioned bypass trio should be limited to the 3 core owners, without overlapping push-restriction lists
-- that sanctioned trio is intentional governance and should not be reported as drift when it exactly matches `config/ci-governance.json` and includes `kushaltrivedi5`
+- the sanctioned bypass cohort should be limited to the approved owner set, without overlapping push-restriction lists
+- that sanctioned cohort is intentional governance and should not be reported as drift when it exactly matches `config/ci-governance.json` and includes `kushaltrivedi5`
 
 ### GitHub Alert Parity
 
@@ -253,7 +253,7 @@ Post-merge smoke remains the deployment eligibility gate for `main`.
 1. `main` is the only integration branch for day-to-day development.
 2. A successful `Main Post-Merge Smoke` run produces the only deployable source of truth: the green `main` SHA.
 3. UAT deploys only by an explicit manual dispatch of that green `main` SHA through `.github/workflows/deploy-uat.yml`.
-4. Manual UAT dispatch is limited to `kushaltrivedi5`, `Akash-292`, and `RGlodAkshat`.
+4. Manual UAT dispatch is limited to `kushaltrivedi5`, `Akash-292`, `RGlodAkshat`, and `ankitkumarsingh1702`.
 5. Production deploys only through a manual SHA dispatch in `.github/workflows/deploy-production.yml`, and only `kushaltrivedi5` may trigger it.
 6. Manual UAT or production redeploys must use a SHA that is reachable from `origin/main` and already green in post-merge smoke.
 7. Feature or hotfix branches never deploy directly; they merge through `main`.


### PR DESCRIPTION
## Summary
- harden the PR governance review workflow and related checklist generation
- expand the sanctioned main/UAT bypass cohort to include `ankitkumarsingh1702`
- tighten repo-operations restart guidance so visible server restarts terminate shells cleanly before closing Terminal windows
- apply canonical consent-protocol formatting fixes required by the pre-push gate

## Verification
- `./bin/hushh docs verify`
- `python3 -m py_compile .codex/skills/repo-operations/scripts/ci_monitor.py`
- `./scripts/ci/verify-main-branch-protection.sh`
- `./bin/hushh codex pre-pr`
- `./bin/hushh protocol fix`
