### PR TITLE
fix(ops): report subtree status in upstream sync summary

### DIFF
--- a/.codex/skills/repo-operations/SKILL.md
+++ b/.codex/skills/repo-operations/SKILL.md
@@ -99,6 +99,8 @@ Non-owned surfaces:
 33. For branch protection, merge queue, release authority, or production deploy-governance changes, do a third independent check against live GitHub or runtime state before calling the work complete.
 34. For UAT runtime failures, start with `./bin/hushh codex rca --surface uat --text` so secret drift, legacy runtime mounts, DB drift, and semantic runtime breakage are classified before editing or redeploying.
 35. Treat only core runtime/release surfaces as blocking in the RCA loop: runtime contract, deploy/runtime env contract, DB release contract, semantic UAT verification, and Gmail/voice/auth availability on the release lane. Helper-only drift stays advisory unless it masks one of those surfaces.
+36. Do not conflate `Upstream Sync` with `Main Freshness Gate`. Freshness is branch-to-main currency; upstream sync is consent-protocol subtree state and must route through `subtree-upstream-governance`.
+37. When rendering or summarizing PR operations, show the actual subtree status from `scripts/ci/subtree-sync-check.sh`, not a generic freshness or status-gate description.
 
 ## Handoff Rules
 

--- a/.codex/skills/repo-operations/references/operations-surface.md
+++ b/.codex/skills/repo-operations/references/operations-surface.md
@@ -39,9 +39,10 @@ Use this reference to orient DevOps work in `hushh-research`.
 2. Merge queue is the standard path to `main`.
 3. `CI Status Gate` is the blocking queue/PR check on pre-merge commits.
 4. `Main Freshness Gate` is advisory on PRs and blocking on `merge_group`.
-5. `Main Post-Merge Smoke Gate` is the deploy-authority check on the real `main` SHA.
-6. UAT deploys only from an explicitly chosen green `main` SHA that passed post-merge smoke.
-7. Production deploys from an approved green `main` SHA that passed post-merge smoke.
+5. `Upstream Sync` is the subtree/governance signal for `consent-protocol`; it is not a freshness alias.
+6. `Main Post-Merge Smoke Gate` is the deploy-authority check on the real `main` SHA.
+7. UAT deploys only from an explicitly chosen green `main` SHA that passed post-merge smoke.
+8. Production deploys from an approved green `main` SHA that passed post-merge smoke.
 
 ## Review bypass semantics
 

--- a/.codex/skills/repo-operations/scripts/ci_monitor.py
+++ b/.codex/skills/repo-operations/scripts/ci_monitor.py
@@ -26,8 +26,13 @@ CHECK_ROUTES: list[tuple[re.Pattern[str], str, str]] = [
     (re.compile(r"protocol|python|fastapi|backend", re.I), "backend", "bug-triage"),
     (re.compile(r"integration|pkm|parity|playwright", re.I), "quality-contracts", "bug-triage"),
     (re.compile(r"publish\s+@hushh/mcp|mcp", re.I), "mcp-developer-surface", "mcp-surface-change"),
-    (re.compile(r"deploy to uat|deploy to production|freshness|secret scan|status gate|upstream sync", re.I), "repo-operations", "ci-watch-and-heal"),
+    (re.compile(r"upstream sync", re.I), "subtree-upstream-governance", "subtree-upstream-governance"),
+    (re.compile(r"deploy to uat|deploy to production|freshness|secret scan|status gate", re.I), "repo-operations", "ci-watch-and-heal"),
 ]
+UPSTREAM_SYNC_CHECK_NAMES = {"Upstream Sync"}
+ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
+SUBTREE_SYNC_SUMMARY_COMMAND = "./scripts/ci/subtree-sync-check.sh"
+_SUBTREE_STATUS_CACHE: OrderedDict[str, Any] | None = None
 
 
 def _run(command: list[str]) -> str:
@@ -118,6 +123,66 @@ def _workflow_stage(workflow_name: str | None) -> str:
     return "unknown"
 
 
+def _classify_subtree_status(output: str) -> str:
+    haystack = output.lower()
+    if "behind upstream by" in haystack:
+        return "behind_upstream"
+    if "ahead of upstream by" in haystack:
+        return "ahead_of_upstream"
+    if "diverged from upstream" in haystack:
+        return "diverged"
+    if "tree-level sync detected" in haystack or "content matches upstream" in haystack or "in sync with upstream" in haystack:
+        return "in_sync"
+    if "metadata was stale" in haystack:
+        return "metadata_healed"
+    if "could not fetch upstream" in haystack or "could not resolve upstream commit" in haystack:
+        return "upstream_unavailable"
+    if "no valid subtree sync baseline found" in haystack:
+        return "missing_sync_baseline"
+    if "direction undetermined" in haystack:
+        return "direction_undetermined"
+    return "unknown"
+
+
+def _subtree_status_summary() -> OrderedDict[str, Any]:
+    global _SUBTREE_STATUS_CACHE
+    if _SUBTREE_STATUS_CACHE is not None:
+        return _SUBTREE_STATUS_CACHE
+
+    try:
+        completed = subprocess.run(
+            ["bash", "scripts/ci/subtree-sync-check.sh"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=45,
+        )
+        raw_output = f"{completed.stdout or ''}{completed.stderr or ''}"
+        output = ANSI_ESCAPE_RE.sub("", raw_output).strip()
+        lines = [line.strip() for line in output.splitlines() if line.strip()]
+        summary = lines[-1] if lines else "No subtree sync summary was emitted."
+        _SUBTREE_STATUS_CACHE = OrderedDict(
+            status=_classify_subtree_status(output),
+            summary=summary,
+            command=SUBTREE_SYNC_SUMMARY_COMMAND,
+            timed_out=False,
+            exit_code=completed.returncode,
+        )
+    except subprocess.TimeoutExpired:
+        _SUBTREE_STATUS_CACHE = OrderedDict(
+            status="probe_timed_out",
+            summary=(
+                "Subtree sync probe timed out while computing consent-protocol status. "
+                "Run ./bin/hushh protocol check-sync for the authoritative result."
+            ),
+            command=SUBTREE_SYNC_SUMMARY_COMMAND,
+            timed_out=True,
+            exit_code=None,
+        )
+    return _SUBTREE_STATUS_CACHE
+
+
 def _normalize_checks(pr_payload: dict[str, Any]) -> list[dict[str, Any]]:
     checks: list[dict[str, Any]] = []
     for raw_check in pr_payload.get("statusCheckRollup", []):
@@ -128,6 +193,10 @@ def _normalize_checks(pr_payload: dict[str, Any]) -> list[dict[str, Any]]:
         next_commands = [f"./bin/hushh codex route-task {workflow_id}"]
         if run_id and job_id:
             next_commands.append(f"gh run view {run_id} --job {job_id} --log-failed")
+        subtree_summary: OrderedDict[str, Any] | None = None
+        if name in UPSTREAM_SYNC_CHECK_NAMES:
+            subtree_summary = _subtree_status_summary()
+            next_commands.append("./bin/hushh protocol check-sync")
         checks.append(
             OrderedDict(
                 name=name,
@@ -143,6 +212,9 @@ def _normalize_checks(pr_payload: dict[str, Any]) -> list[dict[str, Any]]:
                 run_id=run_id,
                 job_id=job_id,
                 recommended_next_commands=next_commands,
+                surface_summary=subtree_summary["summary"] if subtree_summary else None,
+                surface_status=subtree_summary["status"] if subtree_summary else None,
+                surface_command=subtree_summary["command"] if subtree_summary else None,
             )
         )
     return sorted(checks, key=lambda item: (item["workflow_name"] or "", item["name"]))
@@ -278,6 +350,10 @@ def _build_payload(pr_payload: dict[str, Any]) -> OrderedDict[str, Any]:
         next_actions["primary_owner_skills"] = sorted({check["recommended_owner_skill"] for check in pending_checks})
     else:
         next_actions["primary_owner_skills"] = []
+    upstream_sync_check = next((check for check in checks if check["name"] in UPSTREAM_SYNC_CHECK_NAMES), None)
+    if upstream_sync_check and upstream_sync_check.get("surface_summary"):
+        next_actions["upstream_subtree_summary"] = upstream_sync_check["surface_summary"]
+        next_actions["upstream_subtree_route_task"] = "./bin/hushh codex route-task subtree-upstream-governance"
 
     return OrderedDict(
         pr=OrderedDict(
@@ -369,6 +445,12 @@ def _render_text(payload: OrderedDict[str, Any]) -> str:
         lines.append("Checks have not been reported by GitHub yet.")
     else:
         lines.append("No failing or pending checks.")
+    upstream_sync_check = next((check for check in payload["checks"] if check["name"] in UPSTREAM_SYNC_CHECK_NAMES), None)
+    if upstream_sync_check and upstream_sync_check.get("surface_summary"):
+        lines.append(
+            "Upstream subtree summary: "
+            f"{upstream_sync_check['surface_summary']}"
+        )
     lines.append("Next actions:")
     for key, value in payload["next_actions"].items():
         if isinstance(value, list):

--- a/docs/reference/operations/ci.md
+++ b/docs/reference/operations/ci.md
@@ -178,9 +178,15 @@ Feature and hotfix branches intentionally rely on `pull_request` CI only. Merge 
 | Gate | Purpose | Behavior |
 |------|---------|----------|
 | Secret Scan | Detect leaked credentials/tokens early | `gitleaks` OSS CLI scans the event commit range, blocks on open GitHub secret-scanning alerts, and reports Dependabot backlog through the GitHub API |
-| Upstream Sync | Detect monorepo/subtree drift | Advisory only; warnings are non-blocking |
+| Upstream Sync | Detect consent-protocol subtree drift against upstream | Advisory only; warnings are non-blocking |
 | Main Freshness Gate | Show branch freshness before merge | Advisory on pull requests, blocking on `merge_group` |
 | CI Status Gate | Single required check for branch protection | Fails if any required job fails/cancels/times out; allows intentional `skipped` jobs |
+
+Operational note:
+
+- `Upstream Sync` and `Main Freshness Gate` are different surfaces.
+- `Upstream Sync` must summarize the actual `consent-protocol/` subtree state from `scripts/ci/subtree-sync-check.sh`.
+- `Main Freshness Gate` only describes branch currency relative to `main`.
 
 ## Live GitHub Enforcement
 

--- a/scripts/ci/subtree-sync-check.sh
+++ b/scripts/ci/subtree-sync-check.sh
@@ -53,6 +53,11 @@ fi
 UPSTREAM_TREE="$(git rev-parse "$UPSTREAM_REMOTE/$UPSTREAM_BRANCH^{tree}" 2>/dev/null || true)"
 LOCAL_TREE="$(git rev-parse "HEAD:$SUBTREE_PREFIX" 2>/dev/null || true)"
 
+if [ -n "$UPSTREAM_TREE" ] && [ -n "$LOCAL_TREE" ] && [ "$UPSTREAM_TREE" = "$LOCAL_TREE" ]; then
+  echo "✅ consent-protocol/ subtree content matches upstream."
+  exit 0
+fi
+
 LOCAL_SPLIT="$(git subtree split --prefix="$SUBTREE_PREFIX" HEAD 2>/dev/null || true)"
 if [ -z "$LOCAL_SPLIT" ]; then
   # Some histories contain missing split hashes from old subtree joins.
@@ -74,11 +79,6 @@ fi
 if [ -n "$LOCAL_SPLIT" ] && git merge-base --is-ancestor "$LOCAL_SPLIT" "$UPSTREAM_COMMIT" 2>/dev/null; then
   BEHIND_BY="$(git rev-list --count "$LOCAL_SPLIT..$UPSTREAM_COMMIT" 2>/dev/null || echo "unknown")"
   log_warning "consent-protocol/ subtree is behind upstream by ${BEHIND_BY} commit(s). Run: ./bin/hushh protocol sync"
-  exit 0
-fi
-
-if [ -n "$UPSTREAM_TREE" ] && [ -n "$LOCAL_TREE" ] && [ "$UPSTREAM_TREE" = "$LOCAL_TREE" ]; then
-  echo "✅ consent-protocol/ subtree content matches upstream."
   exit 0
 fi
 


### PR DESCRIPTION
## Summary
- distinguish Upstream Sync from Main Freshness Gate in PR operations
- surface the real consent-protocol subtree status in ci-status output
- short-circuit subtree sync checks on tree equality so the summary returns faster

## Verification
- bash scripts/ci/subtree-sync-check.sh
- bash scripts/ci/orchestrate.sh governance
- ./bin/hushh docs verify
- ./bin/hushh codex pre-pr
- ./bin/hushh protocol push

## Notes
- pushed consent-protocol subtree upstream to ec43e885
- upstream consent-protocol CI failed in Secret Scan on the upstream repo after the push
