### PR TITLE
fix: remove user email, uid, and displayName from client-side console logs

### DIFF
--- a/hushh-webapp/lib/capacitor/plugins/auth-web.ts
+++ b/hushh-webapp/lib/capacitor/plugins/auth-web.ts
@@ -49,7 +49,7 @@ export class HushhAuthWeb implements HushhAuthPlugin {
       this.currentIdToken = idToken;
       this.currentAccessToken = accessToken;
       
-      console.log("✅ [HushhAuthWeb] Google Sign-in successful:", user.email);
+      console.log("✅ [HushhAuthWeb] Google Sign-in successful");
       
       return { idToken, accessToken, user };
     } catch (error: unknown) {
@@ -85,7 +85,7 @@ export class HushhAuthWeb implements HushhAuthPlugin {
       this.currentUser = user;
       this.currentIdToken = idToken;
       
-      console.log("✅ [HushhAuthWeb] Apple Sign-in successful:", user.email || "(hidden email)");
+      console.log("✅ [HushhAuthWeb] Apple Sign-in successful");
       
       return { idToken, user };
     } catch (error: unknown) {

--- a/hushh-webapp/lib/firebase/auth-context.tsx
+++ b/hushh-webapp/lib/firebase/auth-context.tsx
@@ -508,7 +508,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     checkAuth,
     refreshUser,
     setNativeUser: (user: User | null) => {
-      console.log("🍎 [AuthContext] Manually setting Native User:", user?.uid);
+      console.log("🍎 [AuthContext] Manually setting Native User");
       applyAuthUser(user);
       setLoading(false);
     },

--- a/hushh-webapp/lib/vault/prf-auth.ts
+++ b/hushh-webapp/lib/vault/prf-auth.ts
@@ -279,7 +279,6 @@ export async function registerWithPrf(
 
   console.log("🔐 Registering passkey with PRF...");
   console.log("  RP ID:", rpId);
-  console.log("  User:", displayName);
 
   const createOptions: PublicKeyCredentialCreationOptions = {
     challenge,


### PR DESCRIPTION
## Summary

- Removes 4 client-side console.log calls that exposed user identity fragments in browser DevTools
- Extends the credential-log sweep started in #397 to user identity (email, uid, displayName)

## Problem

Sibling of merged PR #397. The previous sweep fixed token fragments; this one covers user identity fields that are equally sensitive in the browser console:

| File | What was logged | Risk |
|------|----------------|------|
| `lib/capacitor/plugins/auth-web.ts:52` | `user.email` on Google Sign-in success | Email in DevTools on every sign-in |
| `lib/capacitor/plugins/auth-web.ts:88` | `user.email` on Apple Sign-in success | Same, duplicate code path |
| `lib/firebase/auth-context.tsx:353` | `user?.uid` when setting native user | Firebase UID exposed on auth transitions |
| `lib/vault/prf-auth.ts:282` | `displayName` during passkey registration | Name exposed during WebAuthn flow |

These fragments are visible in DevTools, capturable by browser extensions, and forwardable by client-side observability tools. Under the BYOK trust model the client should not leak user identity through developer logging.

## Approach

Replace each call with an action-only message that confirms the operation without including identity material:

- `"Google Sign-in successful:", user.email` -> `"Google Sign-in successful"`
- `"Apple Sign-in successful:", user.email || "(hidden email)"` -> `"Apple Sign-in successful"`
- `"Manually setting Native User:", user?.uid` -> `"Manually setting Native User"`
- `"User:", displayName` -> removed

Also grepped for residual `.uid` / `.email` / `displayName` in console.log calls to confirm zero remain.

## Test plan

- [x] 3 files changed, 3 insertions, 4 deletions
- [x] Post-fix grep returns zero remaining matches for user identity in console.log
- [x] eslint clean (zero warnings) on all 3 files
- [x] No secrets or env files in diff

Closes: N/A (follows #397 pattern)