### PR TITLE
test: add contract tests for Kai and orchestrator agent manifests

### DIFF
--- a/consent-protocol/tests/test_agent_manifests.py
+++ b/consent-protocol/tests/test_agent_manifests.py
@@ -1,0 +1,192 @@
+"""Contract tests for Kai and orchestrator agent manifests.
+
+Validates that the manifest metadata consumed by the agent registry,
+MCP server, and consent UI is structurally sound: required scope
+references resolve to real ConsentScope enum members, specialist ids
+are unique, color hex values are valid, and compliance flags are
+all booleans.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from hushh_mcp.agents.kai.manifest import MANIFEST as KAI_MANIFEST
+from hushh_mcp.agents.kai.manifest import get_manifest as get_kai_manifest
+from hushh_mcp.agents.orchestrator.manifest import manifest as ORCHESTRATOR_MANIFEST
+from hushh_mcp.constants import ConsentScope
+
+HEX_COLOR_PATTERN = re.compile(r"^#[0-9A-Fa-f]{6}$")
+SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+# ---------------------------------------------------------------------------
+# Kai manifest: top-level shape
+# ---------------------------------------------------------------------------
+
+
+class TestKaiManifestShape:
+    def test_required_top_level_keys_present(self) -> None:
+        for key in (
+            "agent_id",
+            "name",
+            "version",
+            "description",
+            "required_scopes",
+            "optional_scopes",
+            "specialists",
+            "capabilities",
+            "compliance",
+        ):
+            assert key in KAI_MANIFEST, f"missing key: {key}"
+
+    def test_agent_id_non_empty(self) -> None:
+        assert KAI_MANIFEST["agent_id"].strip()
+
+    def test_name_non_empty(self) -> None:
+        assert KAI_MANIFEST["name"].strip()
+
+    def test_description_non_empty(self) -> None:
+        assert KAI_MANIFEST["description"].strip()
+
+    def test_version_is_semver(self) -> None:
+        assert SEMVER_PATTERN.match(KAI_MANIFEST["version"]), (
+            f"version {KAI_MANIFEST['version']} is not semver"
+        )
+
+    def test_get_manifest_returns_same_dict(self) -> None:
+        assert get_kai_manifest() is KAI_MANIFEST
+
+
+# ---------------------------------------------------------------------------
+# Kai manifest: scope references resolve to ConsentScope enum
+# ---------------------------------------------------------------------------
+
+
+class TestKaiManifestScopes:
+    @pytest.mark.parametrize("scope", list(KAI_MANIFEST["required_scopes"]))
+    def test_required_scope_is_consent_scope(self, scope) -> None:  # noqa: ANN001
+        assert isinstance(scope, ConsentScope), (
+            f"required scope {scope!r} is not a ConsentScope enum member"
+        )
+
+    @pytest.mark.parametrize("scope", list(KAI_MANIFEST["optional_scopes"]))
+    def test_optional_scope_is_consent_scope(self, scope) -> None:  # noqa: ANN001
+        assert isinstance(scope, ConsentScope), (
+            f"optional scope {scope!r} is not a ConsentScope enum member"
+        )
+
+    def test_required_scopes_no_duplicates(self) -> None:
+        scopes = list(KAI_MANIFEST["required_scopes"])
+        assert len(scopes) == len(set(scopes))
+
+    def test_optional_scopes_no_duplicates(self) -> None:
+        scopes = list(KAI_MANIFEST["optional_scopes"])
+        assert len(scopes) == len(set(scopes))
+
+    def test_no_overlap_between_required_and_optional(self) -> None:
+        required = set(KAI_MANIFEST["required_scopes"])
+        optional = set(KAI_MANIFEST["optional_scopes"])
+        assert not (required & optional), (
+            "a scope should be declared in required or optional, not both"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Kai manifest: specialists
+# ---------------------------------------------------------------------------
+
+
+class TestKaiSpecialists:
+    def test_specialists_non_empty(self) -> None:
+        assert len(KAI_MANIFEST["specialists"]) > 0
+
+    @pytest.mark.parametrize("specialist", list(KAI_MANIFEST["specialists"]))
+    def test_specialist_required_keys(self, specialist: dict) -> None:
+        for key in ("id", "name", "description", "color", "icon"):
+            assert key in specialist, f"specialist missing key: {key}"
+            assert str(specialist[key]).strip(), f"specialist {key} is empty"
+
+    @pytest.mark.parametrize("specialist", list(KAI_MANIFEST["specialists"]))
+    def test_specialist_color_is_valid_hex(self, specialist: dict) -> None:
+        assert HEX_COLOR_PATTERN.match(specialist["color"]), (
+            f"specialist {specialist['id']} has invalid color {specialist['color']}"
+        )
+
+    def test_specialist_ids_unique(self) -> None:
+        ids = [s["id"] for s in KAI_MANIFEST["specialists"]]
+        assert len(ids) == len(set(ids))
+
+    def test_specialist_ids_lowercase(self) -> None:
+        for specialist in KAI_MANIFEST["specialists"]:
+            assert specialist["id"] == specialist["id"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Kai manifest: capabilities + compliance are all booleans
+# ---------------------------------------------------------------------------
+
+
+class TestKaiFlags:
+    @pytest.mark.parametrize("value", list(KAI_MANIFEST["capabilities"].values()))
+    def test_capabilities_are_bool(self, value) -> None:  # noqa: ANN001
+        assert isinstance(value, bool)
+
+    @pytest.mark.parametrize("value", list(KAI_MANIFEST["compliance"].values()))
+    def test_compliance_flags_are_bool(self, value) -> None:  # noqa: ANN001
+        assert isinstance(value, bool)
+
+    def test_compliance_requires_educational_only(self) -> None:
+        # Kai is explicitly not investment advice. This flag must stay true
+        # to keep the disclaimer surfaced in the UI.
+        assert KAI_MANIFEST["compliance"]["educational_only"] is True
+
+    def test_compliance_disclaimer_required(self) -> None:
+        assert KAI_MANIFEST["compliance"]["disclaimer_required"] is True
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator manifest
+# ---------------------------------------------------------------------------
+
+
+class TestOrchestratorManifest:
+    def test_required_keys_present(self) -> None:
+        for key in ("id", "name", "description", "scopes", "version"):
+            assert key in ORCHESTRATOR_MANIFEST, f"missing key: {key}"
+
+    def test_id_non_empty(self) -> None:
+        assert ORCHESTRATOR_MANIFEST["id"].strip()
+
+    def test_name_non_empty(self) -> None:
+        assert ORCHESTRATOR_MANIFEST["name"].strip()
+
+    def test_description_non_empty(self) -> None:
+        assert ORCHESTRATOR_MANIFEST["description"].strip()
+
+    def test_version_is_semver(self) -> None:
+        assert SEMVER_PATTERN.match(ORCHESTRATOR_MANIFEST["version"])
+
+    def test_scopes_non_empty(self) -> None:
+        assert len(ORCHESTRATOR_MANIFEST["scopes"]) > 0
+
+    def test_scopes_all_strings(self) -> None:
+        for scope in ORCHESTRATOR_MANIFEST["scopes"]:
+            assert isinstance(scope, str)
+            assert scope.strip()
+
+    def test_scopes_no_duplicates(self) -> None:
+        scopes = list(ORCHESTRATOR_MANIFEST["scopes"])
+        assert len(scopes) == len(set(scopes))
+
+
+# ---------------------------------------------------------------------------
+# Cross-manifest isolation: agent_ids do not collide
+# ---------------------------------------------------------------------------
+
+
+class TestManifestIsolation:
+    def test_kai_and_orchestrator_have_distinct_ids(self) -> None:
+        assert KAI_MANIFEST["agent_id"] != ORCHESTRATOR_MANIFEST["id"]


### PR DESCRIPTION
## Summary

- 43 contract tests validating `MANIFEST` for Agent Kai and `manifest` for the orchestrator
- Covers required shape, scope enum references, specialist uniqueness, color hex validity, capability and compliance flag types, semver versions, and cross-manifest isolation
- Acts as a guardrail so future manifest edits cannot silently break the agent registry or consent UI

## Problem

`hushh_mcp/agents/kai/manifest.py` and `hushh_mcp/agents/orchestrator/manifest.py` are the source of truth consumed by the agent registry, the MCP server, and the consent UI when surfacing scope requirements and specialist metadata. The scope list in `required_scopes` must resolve to real `ConsentScope` enum members or consent grant resolution silently fails. Specialist ids must stay unique and colors must be valid hex values for the decision-card rendering to stay consistent. Flags in `capabilities` and `compliance` must stay boolean so downstream consumers can trust the type. None of this was asserted in the existing test suite.

## Approach

Mirrors the pattern merged in #398 (scope bundle tests).

**Kai manifest shape (6 tests):**
- Required top-level keys: `agent_id`, `name`, `version`, `description`, `required_scopes`, `optional_scopes`, `specialists`, `capabilities`, `compliance`
- Non-empty strings, semver version
- `get_manifest()` returns the same dict object

**Kai scope references (parametrized across every scope):**
- Every `required_scopes` entry is a `ConsentScope` enum member
- Every `optional_scopes` entry is a `ConsentScope` enum member
- No duplicates within either list
- No overlap between required and optional

**Kai specialists (parametrized per specialist):**
- Required keys: `id`, `name`, `description`, `color`, `icon`
- `color` matches `^#[0-9A-Fa-f]{6}$`
- Ids unique and lowercase

**Kai capabilities and compliance:**
- Every value is `bool`
- `educational_only` and `disclaimer_required` pinned `True` so the UI keeps the disclaimer surfaced

**Orchestrator manifest (7 tests):**
- Required keys, non-empty strings, semver, scopes list is non-empty, all scopes are strings, no duplicates

**Cross-manifest isolation:**
- Kai and orchestrator have distinct agent ids

## Test plan

- [x] 43/43 tests pass locally
- [x] Parametrized across every scope, specialist, capability, compliance flag so future additions get covered automatically
- [x] Pure data assertions, no DB or network
- [x] ruff check passes
- [x] No secrets or env files in diff

Closes: N/A (follows #398 pattern)