### PR TITLE
fix: reject bool and string NaN/Inf in _parse_live_number extract path

### DIFF
--- a/consent-protocol/hushh_mcp/kai_import/extract_v2.py
+++ b/consent-protocol/hushh_mcp/kai_import/extract_v2.py
@@ -101,6 +101,8 @@ def _phase_progress_from_chunks_v2(phase: str, chunk_count: int) -> float:
 def _parse_live_number(raw: Any) -> float | None:
     if raw is None:
         return None
+    if isinstance(raw, bool):
+        return None
     if isinstance(raw, (int, float)):
         value = float(raw)
         return value if math.isfinite(value) else None
@@ -121,6 +123,8 @@ def _parse_live_number(raw: Any) -> float | None:
     try:
         value = float(cleaned)
     except Exception:
+        return None
+    if not math.isfinite(value):
         return None
     return -value if negative else value
 

--- a/consent-protocol/tests/test_extract_v2_parse_live_number.py
+++ b/consent-protocol/tests/test_extract_v2_parse_live_number.py
@@ -1,0 +1,140 @@
+"""Tests for _parse_live_number in extract_v2.
+
+Covers the live portfolio extraction parser used on every incoming
+holding row. Ensures NaN, Inf, and boolean inputs cannot reach
+downstream reconciliation or quality math.
+"""
+
+from __future__ import annotations
+
+import math
+
+from hushh_mcp.kai_import.extract_v2 import _parse_live_number
+
+# ---------------------------------------------------------------------------
+# Standard numeric conversions
+# ---------------------------------------------------------------------------
+
+
+class TestParseLiveNumberStandard:
+    def test_int(self) -> None:
+        assert _parse_live_number(42) == 42.0
+
+    def test_float(self) -> None:
+        assert _parse_live_number(3.14) == 3.14
+
+    def test_zero(self) -> None:
+        assert _parse_live_number(0) == 0.0
+
+    def test_negative(self) -> None:
+        assert _parse_live_number(-5) == -5.0
+
+    def test_dollar_string(self) -> None:
+        assert _parse_live_number("$1,234.56") == 1234.56
+
+    def test_parens_negative(self) -> None:
+        assert _parse_live_number("(100)") == -100.0
+
+    def test_dollar_parens_negative(self) -> None:
+        assert _parse_live_number("($500.00)") == -500.0
+
+    def test_percentage_stripped(self) -> None:
+        assert _parse_live_number("12.5%") == 12.5
+
+    def test_plain_negative_string(self) -> None:
+        assert _parse_live_number("-100") == -100.0
+
+
+# ---------------------------------------------------------------------------
+# None-returning paths
+# ---------------------------------------------------------------------------
+
+
+class TestParseLiveNumberNone:
+    def test_none(self) -> None:
+        assert _parse_live_number(None) is None
+
+    def test_empty_string(self) -> None:
+        assert _parse_live_number("") is None
+
+    def test_whitespace(self) -> None:
+        assert _parse_live_number("   ") is None
+
+    def test_invalid_string(self) -> None:
+        assert _parse_live_number("abc") is None
+
+    def test_empty_parens(self) -> None:
+        assert _parse_live_number("()") is None
+
+    def test_just_dollar(self) -> None:
+        assert _parse_live_number("$") is None
+
+
+# ---------------------------------------------------------------------------
+# Float NaN / Inf are already rejected via math.isfinite
+# ---------------------------------------------------------------------------
+
+
+class TestFloatPoison:
+    def test_float_nan(self) -> None:
+        assert _parse_live_number(float("nan")) is None
+
+    def test_float_inf(self) -> None:
+        assert _parse_live_number(float("inf")) is None
+
+    def test_float_neg_inf(self) -> None:
+        assert _parse_live_number(float("-inf")) is None
+
+
+# ---------------------------------------------------------------------------
+# Booleans: bool is subclass of int in Python (the bug this PR fixes)
+# ---------------------------------------------------------------------------
+
+
+class TestBoolPoison:
+    def test_bool_true_returns_none(self) -> None:
+        # Previously returned 1.0. A JSON flag like is_cash_equivalent coming
+        # through the extraction pipeline would parse as a phantom $1 holding.
+        assert _parse_live_number(True) is None
+
+    def test_bool_false_returns_none(self) -> None:
+        assert _parse_live_number(False) is None
+
+
+# ---------------------------------------------------------------------------
+# String-form NaN / Inf (the sneakier bug this PR fixes)
+# ---------------------------------------------------------------------------
+
+
+class TestStringPoison:
+    """Python's float() accepts 'inf', 'nan', 'Infinity', etc. These strings
+    appear when JSON serializers round-trip non-finite floats through text.
+    Without a post-parse finiteness check they previously leaked through.
+    """
+
+    def test_string_inf(self) -> None:
+        assert _parse_live_number("inf") is None
+
+    def test_string_Inf(self) -> None:
+        assert _parse_live_number("Inf") is None
+
+    def test_string_Infinity(self) -> None:
+        assert _parse_live_number("Infinity") is None
+
+    def test_string_negative_infinity(self) -> None:
+        assert _parse_live_number("-inf") is None
+
+    def test_string_nan_lower(self) -> None:
+        assert _parse_live_number("nan") is None
+
+    def test_string_nan_upper(self) -> None:
+        assert _parse_live_number("NaN") is None
+
+    def test_string_negative_nan(self) -> None:
+        assert _parse_live_number("-nan") is None
+
+    def test_parens_infinity_does_not_produce_neg_inf(self) -> None:
+        # Previously produced -inf via the parens-negate path
+        result = _parse_live_number("(inf)")
+        assert result is None or math.isfinite(result)
+        assert _parse_live_number("(inf)") is None


### PR DESCRIPTION
## Summary

- `_parse_live_number` in `extract_v2.py` now rejects booleans and string-form NaN/Inf that previously leaked through the live portfolio extraction path
- 28 tests cover standard numeric conversions, None paths, float poison, bool poison, and every string non-finite variant

## Problem

`_parse_live_number` is called on every incoming holding row during Kai portfolio import extraction. Two poison input classes leaked through:

1. **Booleans:** `isinstance(True, int)` is `True` in Python, so `bool True` / `False` parsed as `1.0` / `0.0`. A JSON flag like `is_cash_equivalent` coming through the extraction pipeline would materialize as a phantom $1 holding.

2. **String-form NaN / Inf:** Python's `float("inf")` and `float("nan")` are valid. The string branch called `float(cleaned)` inside try/except but had no finiteness check afterward, so `"inf"`, `"nan"`, `"Infinity"`, `"-inf"`, and even `"(inf)"` (which went through the parens-negate path as `-inf`) all leaked through into holding `market_value` fields.

Reproduced all of these on current main:
- `_parse_live_number(True)` returned `1.0`
- `_parse_live_number("inf")` returned `inf`
- `_parse_live_number("NaN")` returned `nan`
- `_parse_live_number("(inf)")` returned `-inf`

Same poison-input class fixed in merged PR #396 (normalize_v2) and open PR #458 (quality_v2). Completing the sweep on the live extraction path.

## Approach

Two-line guards in `_parse_live_number`, mirroring the pattern from #396:

1. Add `isinstance(raw, bool)` check before `isinstance(raw, (int, float))` since bool is a subclass of int
2. Add `math.isfinite(value)` check after `float(cleaned)` on the string branch

The float branch already guards NaN/Inf via `math.isfinite(value)` so no change there. No behavior change for valid inputs.

## Test plan

28 tests in `test_extract_v2_parse_live_number.py`, all passing locally (0.03s):

- [x] 9 standard conversion tests (int, float, zero, negative, dollar string, parens negative, dollar parens negative, percentage, negative string)
- [x] 6 None-returning tests (None, empty, whitespace, invalid, empty parens, just dollar)
- [x] 3 float poison tests (NaN, Inf, -Inf already handled)
- [x] 2 bool poison tests (True, False)
- [x] 8 string poison tests (inf, Inf, Infinity, -inf, nan, NaN, -nan, (inf))
- [x] ruff check passes
- [x] No secrets or env files in diff

Closes: N/A (follows #396 pattern, completes the live-extraction branch of the sweep)