### PR TITLE
fix: remove user ID from server-side logs in consent and vault routes

### DIFF
--- a/hushh-webapp/app/api/consent/logout/route.ts
+++ b/hushh-webapp/app/api/consent/logout/route.ts
@@ -24,7 +24,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    console.log(`[API] Destroying session tokens for user: ${userId}`);
+    console.log("[API] Destroying session tokens");
 
     const response = await fetch(`${BACKEND_URL}/api/consent/logout`, {
       method: "POST",
@@ -42,7 +42,7 @@ export async function POST(request: NextRequest) {
     }
 
     const data = await response.json();
-    console.log(`[API] Session tokens destroyed for: ${userId}`);
+    console.log("[API] Session tokens destroyed");
 
     return NextResponse.json(data);
   } catch (error) {

--- a/hushh-webapp/app/api/consent/pending/approve/route.ts
+++ b/hushh-webapp/app/api/consent/pending/approve/route.ts
@@ -56,7 +56,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    console.log(`[API] User ${userId} approving consent request: ${requestId}`);
+    console.log(`[API] Approving consent request: ${requestId}`);
     console.log(`[API] Export data present: ${!!encryptedData}`);
 
     // Forward to FastAPI with encrypted export

--- a/hushh-webapp/app/api/consent/pending/deny/route.ts
+++ b/hushh-webapp/app/api/consent/pending/deny/route.ts
@@ -33,7 +33,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    console.log(`[API] User ${userId} denying consent request: ${requestId}`);
+    console.log(`[API] Denying consent request: ${requestId}`);
 
     const response = await fetch(
       `${BACKEND_URL}/api/consent/pending/deny?userId=${userId}&requestId=${requestId}`,

--- a/hushh-webapp/app/api/consent/revoke/route.ts
+++ b/hushh-webapp/app/api/consent/revoke/route.ts
@@ -30,7 +30,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    console.log(`[API] Revoking consent for user: ${userId}, scope: ${scope}`);
+    console.log(`[API] Revoking consent for scope: ${scope}`);
 
     const backendUrl = `${BACKEND_URL}/api/consent/revoke`;
     console.log(`[API] Calling backend: ${backendUrl}`);

--- a/hushh-webapp/app/api/consent/session-token/route.ts
+++ b/hushh-webapp/app/api/consent/session-token/route.ts
@@ -36,7 +36,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    console.log(`[API] Issuing session token for user: ${userId}`);
+    console.log("[API] Issuing session token");
 
     const response = await fetch(`${BACKEND_URL}/api/consent/issue-token`, {
       method: "POST",

--- a/hushh-webapp/app/api/vault/store-preferences/route.ts
+++ b/hushh-webapp/app/api/vault/store-preferences/route.ts
@@ -80,9 +80,7 @@ export async function POST(request: NextRequest) {
 
     // Additional check: token user must match request user
     if (validation.user_id && validation.user_id !== userId) {
-      console.warn(
-        `❌ Vault write rejected: User mismatch (token: ${validation.user_id}, request: ${userId})`
-      );
+      console.warn("❌ Vault write rejected: consent token user mismatch");
       return NextResponse.json(
         {
           error: "Consent token user mismatch",
@@ -106,7 +104,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    console.log(`📦 Storing preferences for user: ${userId}`);
+    console.log("📦 Storing preferences");
     console.log(`📋 Fields to store: ${Object.keys(preferences).join(", ")}`);
 
     // Dynamically store each preference field
@@ -141,9 +139,7 @@ export async function POST(request: NextRequest) {
 
     await Promise.all(storePromises);
 
-    console.log(
-      `✅ Stored ${storePromises.length} preferences for user: ${userId}`
-    );
+    console.log(`✅ Stored ${storePromises.length} preferences`);
 
     return NextResponse.json({
       success: true,


### PR DESCRIPTION
## Summary

- Removes 8 console.log / console.warn calls in Next.js API route handlers that logged the authenticated user ID on every request
- Completes the PII log sweep started client-side in merged PR #397 and open PR #460, now covering the server-side route handlers

## Problem

Under the consent-first trust contract, user identifiers should not appear in aggregate server logs. The Next.js API route handlers in `app/api/consent/*` and `app/api/vault/*` log user IDs on every protected operation. When those process logs get shipped to observability tools, retained in cloud run history, or indexed for debugging, the user IDs become a long-lived trail of authenticated activity.

Leaks found (6 files, 8 sites):

| File | Site | What leaked |
|------|------|-------------|
| consent/revoke/route.ts:33 | revoke entry | userId + scope |
| consent/logout/route.ts:27 | destroy start | userId |
| consent/logout/route.ts:45 | destroy success | userId |
| consent/session-token/route.ts:39 | token issue | userId |
| consent/pending/approve/route.ts:59 | approve path | userId + requestId |
| consent/pending/deny/route.ts:36 | deny path | userId + requestId |
| vault/store-preferences/route.ts:84 | user-mismatch warn | two userIds |
| vault/store-preferences/route.ts:143 | store success | userId |

Verified via `grep -rn 'console.log.*\${.*user\|console.log.*\${.*email' hushh-webapp/app/api/` before and after.

## Approach

Replace each call with an action-only message that still describes the operation for debugging without including the user identifier. Scope labels (`scope`, `requestId`) stay since they are not user PII. The vault mismatch warning collapses to `consent token user mismatch` without dumping both user IDs on the rejection path.

Sibling of merged PR #397 (client-side token fragments) and open PR #460 (client-side user identity). This PR closes the server-side surface.

## Test plan

- [x] 6 files changed, 9 insertions, 13 deletions
- [x] Post-fix grep returns zero remaining matches for user identity in console logging across `app/api/`
- [x] eslint clean on all 6 files
- [x] No functional changes, only log statements
- [x] No secrets or env files in diff

Closes: N/A (follows #397 pattern)