### PR TITLE
perf(kai): refactor market insights orchestration into concurrent DAG

### DIFF
--- a/consent-protocol/api/routes/kai/market_insights.py
+++ b/consent-protocol/api/routes/kai/market_insights.py
@@ -827,28 +827,36 @@ async def _fetch_vix_signal() -> dict[str, Any]:
 
 async def _fetch_macro_bundle() -> dict[str, Any]:
     statuses: dict[str, str] = {}
-    try:
-        vix = await _fetch_vix_signal()
-        statuses["volatility"] = "partial" if vix.get("degraded") else "ok"
-    except Exception as exc:
-        logger.warning("[Kai Market] volatility failed: %s", exc)
-        vix = {
-            "label": "Volatility",
-            "value": None,
-            "delta_pct": None,
-            "as_of": None,
-            "source": "Unavailable",
-            "degraded": True,
-        }
-        statuses["volatility"] = _provider_status_from_exception(exc)
 
-    try:
-        market_status = await _fetch_market_status()
-        statuses["market_status"] = "partial" if market_status.get("degraded") else "ok"
-    except Exception as exc:
-        logger.warning("[Kai Market] market status failed: %s", exc)
-        market_status = _scheduled_market_status_fallback()
-        statuses["market_status"] = _provider_status_from_exception(exc)
+    async def safe_vix() -> tuple[dict[str, Any], str]:
+        try:
+            vix = await _fetch_vix_signal()
+            return vix, "partial" if vix.get("degraded") else "ok"
+        except Exception as exc:
+            logger.warning("[Kai Market] volatility failed: %s", exc)
+            fallback = {
+                "label": "Volatility",
+                "value": None,
+                "delta_pct": None,
+                "as_of": None,
+                "source": "Unavailable",
+                "degraded": True,
+            }
+            return fallback, _provider_status_from_exception(exc)
+
+    async def safe_market_status() -> tuple[dict[str, Any], str]:
+        try:
+            market_status = await _fetch_market_status()
+            return market_status, "partial" if market_status.get("degraded") else "ok"
+        except Exception as exc:
+            logger.warning("[Kai Market] market status failed: %s", exc)
+            return _scheduled_market_status_fallback(), _provider_status_from_exception(exc)
+
+    (vix, vix_status), (market_status, ms_status) = await asyncio.gather(
+        safe_vix(), safe_market_status()
+    )
+    statuses["volatility"] = vix_status
+    statuses["market_status"] = ms_status
 
     return {
         "vix": vix,
@@ -1128,29 +1136,17 @@ def _normalize_mover_row(row: dict[str, Any], source: str) -> dict[str, Any] | N
 async def _fetch_movers_from_fmp() -> tuple[dict[str, Any], dict[str, str]]:
     status_map: dict[str, str] = {}
 
-    gainers_rows = await _fetch_pmp_json(
-        [
-            "/stable/biggest-gainers",
-            "/stable/market-gainers",
-            "/stable/market/gainers",
-        ],
-        {},
+    gainers_task = _fetch_pmp_json(
+        ["/stable/biggest-gainers", "/stable/market-gainers", "/stable/market/gainers"], {}
     )
-    losers_rows = await _fetch_pmp_json(
-        [
-            "/stable/biggest-losers",
-            "/stable/market-losers",
-            "/stable/market/losers",
-        ],
-        {},
+    losers_task = _fetch_pmp_json(
+        ["/stable/biggest-losers", "/stable/market-losers", "/stable/market/losers"], {}
     )
-    active_rows = await _fetch_pmp_json(
-        [
-            "/stable/most-actives",
-            "/stable/market-most-actives",
-            "/stable/market/actives",
-        ],
-        {},
+    active_task = _fetch_pmp_json(
+        ["/stable/most-actives", "/stable/market-most-actives", "/stable/market/actives"], {}
+    )
+    gainers_rows, losers_rows, active_rows = await asyncio.gather(
+        gainers_task, losers_task, active_task
     )
 
     gainers = [row for row in (_normalize_mover_row(r, "PMP/FMP") for r in gainers_rows) if row]
@@ -1876,19 +1872,43 @@ async def _get_market_insights_payload(
                 "generated_at": _now_iso(),
             }
 
-        (
-            quotes_value,
-            quotes_stale,
-            _quotes_age_seconds,
-            quotes_cache_tier,
-            quotes_cache_hit,
-        ) = await _get_or_refresh_public_module(
+        # ⚡️ CONCURRENCY REFACTOR
+
+        quotes_task = _get_or_refresh_public_module(
             key=quotes_key,
             fresh_ttl_seconds=QUOTES_FRESH_TTL_SECONDS,
             stale_ttl_seconds=QUOTES_STALE_TTL_SECONDS,
             fetcher=fetch_quotes_bundle,
-            warm_source="request",
+            warm_source=warm_source,
         )
+
+        macro_task = _get_or_refresh_public_module(
+            key="macro:us",
+            fresh_ttl_seconds=QUOTES_FRESH_TTL_SECONDS,
+            stale_ttl_seconds=QUOTES_STALE_TTL_SECONDS,
+            fetcher=_fetch_macro_bundle,
+            warm_source=warm_source,
+        )
+        movers_task = _get_or_refresh_public_module(
+            key="movers:us",
+            fresh_ttl_seconds=MOVERS_FRESH_TTL_SECONDS,
+            stale_ttl_seconds=MOVERS_STALE_TTL_SECONDS,
+            fetcher=_fetch_movers_from_fmp,
+            warm_source=warm_source,
+        )
+        sectors_task = _get_or_refresh_public_module(
+            key="sectors:us",
+            fresh_ttl_seconds=SECTORS_FRESH_TTL_SECONDS,
+            stale_ttl_seconds=SECTORS_STALE_TTL_SECONDS,
+            fetcher=lambda: _fetch_sector_rotation_snapshot(user_id, consent_token),
+            warm_source=warm_source,
+        )
+        (
+            (quotes_value, quotes_stale, _quotes_age, quotes_cache_tier, quotes_cache_hit),
+            (macro_value, macro_stale, _macro_age, macro_cache_tier, macro_cache_hit),
+            (movers_value, movers_stale, _movers_age, movers_cache_tier, movers_cache_hit),
+            (sectors_value, sectors_stale, _sectors_age, sectors_cache_tier, sectors_cache_hit),
+        ) = await asyncio.gather(quotes_task, macro_task, movers_task, sectors_task)
         quote_bundle = quotes_value if isinstance(quotes_value, dict) else {}
         quote_map = (
             quote_bundle.get("quotes") if isinstance(quote_bundle.get("quotes"), dict) else {}
@@ -1899,32 +1919,15 @@ async def _get_market_insights_payload(
         stale = stale or quotes_stale
         aggregated_cache_tier = _merge_cache_tier(aggregated_cache_tier, quotes_cache_tier)
         aggregated_cache_hit = aggregated_cache_hit and quotes_cache_hit
-
         spy_quote = quote_map.get("SPY") if isinstance(quote_map, dict) else None
         qqq_quote = quote_map.get("QQQ") if isinstance(quote_map, dict) else None
-
-        # Drop invalid/non-quoted watchlist symbols when at least one symbol has live quote data.
         quoted_watchlist_symbols = [
-            symbol
-            for symbol in watchlist_symbols
-            if _safe_float((quote_map.get(symbol) or {}).get("price")) is not None
+            s
+            for s in watchlist_symbols
+            if _safe_float((quote_map.get(s) or {}).get("price")) is not None
         ]
         watchlist_symbols_for_cards = (
             quoted_watchlist_symbols if quoted_watchlist_symbols else watchlist_symbols
-        )
-
-        (
-            macro_value,
-            macro_stale,
-            _macro_age_seconds,
-            macro_cache_tier,
-            macro_cache_hit,
-        ) = await _get_or_refresh_public_module(
-            key="macro:us",
-            fresh_ttl_seconds=QUOTES_FRESH_TTL_SECONDS,
-            stale_ttl_seconds=QUOTES_STALE_TTL_SECONDS,
-            fetcher=_fetch_macro_bundle,
-            warm_source="request",
         )
         macro_bundle = macro_value if isinstance(macro_value, dict) else {}
         vix_payload = (
@@ -1957,12 +1960,13 @@ async def _get_market_insights_payload(
         stale = stale or macro_stale
         aggregated_cache_tier = _merge_cache_tier(aggregated_cache_tier, macro_cache_tier)
         aggregated_cache_hit = aggregated_cache_hit and macro_cache_hit
-
         watchlist_rows: list[dict[str, Any]] = []
         renaissance_rows: list[dict[str, Any]] = []
         rec_semaphore = asyncio.Semaphore(RECOMMENDATION_FANOUT_CONCURRENCY)
 
-        async def build_watchlist_row(symbol: str) -> tuple[dict[str, Any], dict[str, str], bool]:
+        async def build_watchlist_row(
+            symbol: str,
+        ) -> tuple[dict[str, Any], dict[str, str], bool, str, bool]:
             quote = quote_map.get(symbol) if isinstance(quote_map, dict) else None
             quote_price = _safe_float((quote or {}).get("price"))
             rec_key = f"recommendation:{symbol}"
@@ -1988,7 +1992,7 @@ async def _get_market_insights_payload(
                 fresh_ttl_seconds=RECOMMENDATION_FRESH_TTL_SECONDS,
                 stale_ttl_seconds=RECOMMENDATION_STALE_TTL_SECONDS,
                 fetcher=fetch_recommendation_bundle,
-                warm_source="request",
+                warm_source=warm_source,
             )
             rec_bundle = rec_value if isinstance(rec_value, dict) else {}
             recommendation = (
@@ -2034,6 +2038,7 @@ async def _get_market_insights_payload(
         watchlist_results = await asyncio.gather(
             *(build_watchlist_row(symbol) for symbol in watchlist_symbols_for_cards)
         )
+
         for row, status_map, row_stale, row_cache_tier, row_cache_hit in watchlist_results:
             watchlist_rows.append(row)
             provider_status.update(status_map)
@@ -2053,10 +2058,7 @@ async def _get_market_insights_payload(
             if not quote and quote_symbol and quote_status != "unsupported":
                 try:
                     rescued_quote = await fetch_market_data(
-                        quote_symbol,
-                        user_id,
-                        consent_token,
-                        allow_slow_fallbacks=True,
+                        quote_symbol, user_id, consent_token, allow_slow_fallbacks=True
                     )
                 except Exception as rescue_error:
                     logger.debug(
@@ -2074,8 +2076,7 @@ async def _get_market_insights_payload(
                         if isinstance(quote_map, dict):
                             quote_map[quote_symbol] = quote
                         market_insights_cache.append_series_point(
-                            f"quote:{quote_symbol}",
-                            rescued_price,
+                            f"quote:{quote_symbol}", rescued_price
                         )
             renaissance_rows.append(
                 {
@@ -2111,19 +2112,6 @@ async def _get_market_insights_payload(
                 }
             )
 
-        (
-            movers_value,
-            movers_stale,
-            _movers_age_seconds,
-            movers_cache_tier,
-            movers_cache_hit,
-        ) = await _get_or_refresh_public_module(
-            key="movers:us",
-            fresh_ttl_seconds=MOVERS_FRESH_TTL_SECONDS,
-            stale_ttl_seconds=MOVERS_STALE_TTL_SECONDS,
-            fetcher=_fetch_movers_from_fmp,
-            warm_source="request",
-        )
         movers_pair = movers_value if isinstance(movers_value, (tuple, list)) else ({}, {})
         movers_payload = (
             movers_pair[0] if len(movers_pair) > 0 and isinstance(movers_pair[0], dict) else {}
@@ -2139,23 +2127,11 @@ async def _get_market_insights_payload(
                 "movers:active": "partial",
             }
         provider_status.update({str(k): str(v) for k, v in movers_status.items()})
+
         stale = stale or movers_stale
         aggregated_cache_tier = _merge_cache_tier(aggregated_cache_tier, movers_cache_tier)
         aggregated_cache_hit = aggregated_cache_hit and movers_cache_hit
 
-        (
-            sectors_value,
-            sectors_stale,
-            _sectors_age_seconds,
-            sectors_cache_tier,
-            sectors_cache_hit,
-        ) = await _get_or_refresh_public_module(
-            key="sectors:us",
-            fresh_ttl_seconds=SECTORS_FRESH_TTL_SECONDS,
-            stale_ttl_seconds=SECTORS_STALE_TTL_SECONDS,
-            fetcher=lambda: _fetch_sector_rotation_snapshot(user_id, consent_token),
-            warm_source="request",
-        )
         sectors_pair = (
             sectors_value if isinstance(sectors_value, (tuple, list)) else ([], "partial")
         )
@@ -2167,10 +2143,12 @@ async def _get_market_insights_payload(
             if len(sectors_pair) > 1 and isinstance(sectors_pair[1], str)
             else "partial"
         )
+
         if not sector_rotation:
             sector_rotation = _fallback_sector_rotation_from_watchlist(watchlist_rows)
             sector_status = "partial"
         provider_status["sectors"] = sector_status
+
         stale = stale or sectors_stale
         aggregated_cache_tier = _merge_cache_tier(aggregated_cache_tier, sectors_cache_tier)
         aggregated_cache_hit = aggregated_cache_hit and sectors_cache_hit

--- a/consent-protocol/api/routes/kai/market_insights.py
+++ b/consent-protocol/api/routes/kai/market_insights.py
@@ -1872,43 +1872,101 @@ async def _get_market_insights_payload(
                 "generated_at": _now_iso(),
             }
 
-        # ⚡️ CONCURRENCY REFACTOR
+        def failed_module(value: Any) -> tuple[Any, bool, int, str, bool]:
+            return (value, True, 0, "live", False)
 
-        quotes_task = _get_or_refresh_public_module(
-            key=quotes_key,
-            fresh_ttl_seconds=QUOTES_FRESH_TTL_SECONDS,
-            stale_ttl_seconds=QUOTES_STALE_TTL_SECONDS,
-            fetcher=fetch_quotes_bundle,
-            warm_source=warm_source,
-        )
+        async def safe_public_module(
+            name: str,
+            task: Any,
+            fallback_factory: Any,
+        ) -> tuple[Any, bool, int, str, bool]:
+            try:
+                return await task
+            except Exception as exc:
+                status_value = _provider_status_from_exception(exc)
+                logger.warning(
+                    "[Kai Market] %s module failed during concurrent refresh: %s",
+                    name,
+                    exc,
+                )
+                return failed_module(fallback_factory(status_value))
 
-        macro_task = _get_or_refresh_public_module(
-            key="macro:us",
-            fresh_ttl_seconds=QUOTES_FRESH_TTL_SECONDS,
-            stale_ttl_seconds=QUOTES_STALE_TTL_SECONDS,
-            fetcher=_fetch_macro_bundle,
-            warm_source=warm_source,
-        )
-        movers_task = _get_or_refresh_public_module(
-            key="movers:us",
-            fresh_ttl_seconds=MOVERS_FRESH_TTL_SECONDS,
-            stale_ttl_seconds=MOVERS_STALE_TTL_SECONDS,
-            fetcher=_fetch_movers_from_fmp,
-            warm_source=warm_source,
-        )
-        sectors_task = _get_or_refresh_public_module(
-            key="sectors:us",
-            fresh_ttl_seconds=SECTORS_FRESH_TTL_SECONDS,
-            stale_ttl_seconds=SECTORS_STALE_TTL_SECONDS,
-            fetcher=lambda: _fetch_sector_rotation_snapshot(user_id, consent_token),
-            warm_source=warm_source,
-        )
         (
             (quotes_value, quotes_stale, _quotes_age, quotes_cache_tier, quotes_cache_hit),
             (macro_value, macro_stale, _macro_age, macro_cache_tier, macro_cache_hit),
             (movers_value, movers_stale, _movers_age, movers_cache_tier, movers_cache_hit),
             (sectors_value, sectors_stale, _sectors_age, sectors_cache_tier, sectors_cache_hit),
-        ) = await asyncio.gather(quotes_task, macro_task, movers_task, sectors_task)
+        ) = await asyncio.gather(
+            safe_public_module(
+                "quotes",
+                _get_or_refresh_public_module(
+                    key=quotes_key,
+                    fresh_ttl_seconds=QUOTES_FRESH_TTL_SECONDS,
+                    stale_ttl_seconds=QUOTES_STALE_TTL_SECONDS,
+                    fetcher=fetch_quotes_bundle,
+                    warm_source=warm_source,
+                ),
+                lambda status_value: {
+                    "quotes": {},
+                    "provider_status": {f"quote:{symbol}": status_value for symbol in symbol_set},
+                    "generated_at": _now_iso(),
+                },
+            ),
+            safe_public_module(
+                "macro",
+                _get_or_refresh_public_module(
+                    key="macro:us",
+                    fresh_ttl_seconds=QUOTES_FRESH_TTL_SECONDS,
+                    stale_ttl_seconds=QUOTES_STALE_TTL_SECONDS,
+                    fetcher=_fetch_macro_bundle,
+                    warm_source=warm_source,
+                ),
+                lambda status_value: {
+                    "vix": {
+                        "label": "Volatility",
+                        "value": None,
+                        "delta_pct": None,
+                        "as_of": None,
+                        "source": "Unavailable",
+                        "degraded": True,
+                    },
+                    "market_status": _scheduled_market_status_fallback(),
+                    "provider_status": {
+                        "volatility": status_value,
+                        "market_status": status_value,
+                    },
+                },
+            ),
+            safe_public_module(
+                "movers",
+                _get_or_refresh_public_module(
+                    key="movers:us",
+                    fresh_ttl_seconds=MOVERS_FRESH_TTL_SECONDS,
+                    stale_ttl_seconds=MOVERS_STALE_TTL_SECONDS,
+                    fetcher=_fetch_movers_from_fmp,
+                    warm_source=warm_source,
+                ),
+                lambda status_value: (
+                    {},
+                    {
+                        "movers:gainers": status_value,
+                        "movers:losers": status_value,
+                        "movers:active": status_value,
+                    },
+                ),
+            ),
+            safe_public_module(
+                "sectors",
+                _get_or_refresh_public_module(
+                    key="sectors:us",
+                    fresh_ttl_seconds=SECTORS_FRESH_TTL_SECONDS,
+                    stale_ttl_seconds=SECTORS_STALE_TTL_SECONDS,
+                    fetcher=lambda: _fetch_sector_rotation_snapshot(user_id, consent_token),
+                    warm_source=warm_source,
+                ),
+                lambda status_value: ([], status_value),
+            ),
+        )
         quote_bundle = quotes_value if isinstance(quotes_value, dict) else {}
         quote_map = (
             quote_bundle.get("quotes") if isinstance(quote_bundle.get("quotes"), dict) else {}

--- a/consent-protocol/tests/test_kai_market_public_cache.py
+++ b/consent-protocol/tests/test_kai_market_public_cache.py
@@ -139,6 +139,89 @@ def test_repair_quote_symbol_normalizes_known_provider_aliases():
 
 
 @pytest.mark.asyncio
+async def test_concurrent_public_module_failure_degrades_without_collapsing_home(monkeypatch):
+    async def _fake_resolve_pick_source_rows(*_args, **_kwargs):
+        return [], [market_insights._default_pick_source()], market_insights.DEFAULT_PICK_SOURCE_ID
+
+    async def _fake_public_module(**kwargs):
+        key = str(kwargs["key"])
+        if key.startswith("home:"):
+            return await kwargs["fetcher"](), False, 0, "live", False
+        if key.startswith("quotes:"):
+            raise RuntimeError("quote provider unavailable")
+        if key == "macro:us":
+            return (
+                {
+                    "vix": {
+                        "label": "Volatility",
+                        "value": None,
+                        "delta_pct": None,
+                        "as_of": None,
+                        "source": "Unavailable",
+                        "degraded": True,
+                    },
+                    "market_status": market_insights._scheduled_market_status_fallback(),
+                    "provider_status": {"volatility": "partial", "market_status": "partial"},
+                },
+                False,
+                0,
+                "live",
+                False,
+            )
+        if key == "movers:us":
+            return ({}, {"movers:gainers": "partial"}), False, 0, "live", False
+        if key == "sectors:us":
+            return ([], "partial"), False, 0, "live", False
+        if key.startswith("recommendation:"):
+            symbol = key.split(":", 1)[1]
+            return (
+                {
+                    "recommendation": market_insights._fallback_recommendation_from_quote(
+                        symbol, None
+                    ),
+                    "status": "partial",
+                    "provider_status": {f"recommendation:{symbol}": "partial"},
+                },
+                False,
+                0,
+                "live",
+                False,
+            )
+        if key.startswith("news:"):
+            return {"rows": [], "provider_status": {}}, False, 0, "live", False
+        raise AssertionError(f"unexpected cache key {key}")
+
+    monkeypatch.setattr(
+        market_insights,
+        "_resolve_pick_source_rows",
+        _fake_resolve_pick_source_rows,
+    )
+    monkeypatch.setattr(
+        market_insights,
+        "_get_or_refresh_public_module",
+        _fake_public_module,
+    )
+
+    payload = await market_insights._get_market_insights_payload(
+        user_id="test-user",
+        requested_watchlist_symbols=["AAPL"],
+        filtered_symbols=[],
+        watchlist_symbols=["AAPL"],
+        days_back=7,
+        active_pick_source=market_insights.DEFAULT_PICK_SOURCE_ID,
+        consent_token=None,
+        personalized=False,
+    )
+
+    assert payload["stale"] is True
+    assert payload["provider_status"]["quote:AAPL"] == "failed"
+    assert payload["watchlist"][0]["symbol"] == "AAPL"
+    assert payload["watchlist"][0]["degraded"] is True
+    assert payload["movers"]["degraded"] is True
+    assert payload["provider_status"]["sectors"] == "partial"
+
+
+@pytest.mark.asyncio
 async def test_startup_warm_seeds_shared_baseline_home_after_public_modules(monkeypatch):
     call_order: list[str] = []
     captured: dict[str, object] = {}


### PR DESCRIPTION
# Description

While profiling the `market_insights.py` orchestration pipeline, I identified a severe blocking waterfall in the data fetching logic. Independent public modules (Quotes, Macro/VIX, Movers, and Sectors) were fetched using sequential `await` calls, driving TTFB up to 18+ seconds on cold caches and triggering 20-second Uvicorn startup timeouts.

I overhauled the orchestration to execute as a high-concurrency Directed Acyclic Graph (DAG) using `asyncio.gather`:
* **Phase 1 (Independent Variables):** Pooled the fetching of `quotes`, `macro`, `movers`, and `sectors` into a single concurrent wave.
* **Phase 2 (Dependent Variables):** Maintained the strict execution order for `watchlist` and `spotlights`, which inherently depend on the output of the `quotes` execution phase.
* **Sub-routine Optimization:** Refactored `_fetch_movers_from_fmp` and `_fetch_macro_bundle` to pull their respective downstream endpoints concurrently.

This mathematically flattens the I/O bound from O(N) to O(1) regarding external network calls, reducing cold-cache latency by >4 seconds and completely stabilizing the backend startup sequence.

## Impact Map (Required)

- Routes touched:
  - [ ] None
  - [x] Listed below:
    - `GET /market/insights/baseline/{user_id}`
    - `GET /market/insights/{user_id}`

- API / schema / type changes:
  - [x] None (Response payload remains identical, just generated faster)
  - [ ] Listed below:

- Cache keys touched:
  - [x] None (Interaction methods changed, but keys/schema remain the same)
  - [ ] Listed below:

- World-model domain summary effects:
  - [x] None
  - [ ] Listed below:

- Mobile parity impacts:
  - [x] None
  - [ ] Listed below:

- Docs updated (exact files):
  - [x] None
  - [ ] Listed below:

- Verification commands executed:
  - [ ] `cd hushh-webapp && npm run typecheck`
  - [ ] `cd hushh-webapp && npm test`
  - [ ] `cd hushh-webapp && npm run build`
  - [ ] `cd hushh-webapp && npm run ios:test`
  - [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000`
  - **[x] `./bin/consent-protocol ci` (Passed all 204 checks including ruff, mypy, tests)**
  - **[x] Custom `time curl` profiling (Local validation)**

## Tri-Flow Architecture Check

_Every feature must be implemented across all three layers or explicitly marked as not applicable._

- [ ] **Web**: Next.js implementation (`app/api/...`)
- [ ] **iOS**: Swift Capacitor Plugin (`ios/App/App/Plugins/...`)
- [ ] **Android**: Kotlin Capacitor Plugin (`android/app/.../plugins/...`)
- **N/A:** This is a pure Python backend API performance optimization. No client-side native architecture changes required.

## Testing

- [x] Tested on Web (Chrome/Safari) / API Level
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## Screenshots / Video
<img width="377" height="135" alt="image" src="https://github.com/user-attachments/assets/30c8a887-ac7d-493e-909f-a55c707365e7" />
<img width="354" height="137" alt="image" src="https://github.com/user-attachments/assets/5cb7c1d2-c453-4c8c-a3be-51c678ab89bb" />

**Before Patch (18.6s Cold Cache):**
```text
real    0m18.685s
user    0m0.000s
sys     0m0.027s

**After Patch (12.5s Cold Cache - Bound only by intentional ETF semaphores):**
```text
real    0m12.464s
user    0m0.000s
sys     0m0.014s
**Privacy & Consent**
[x] Does this change access user data? (Yes, the personalized route does).

[x] If yes, have you implemented checkConsentToken()? (Maintained existing require_vault_owner_token and require_firebase_auth middleware blocks perfectly intact).

**Licensing**
[x] First-party changes remain Apache-2.0 compatible

[x] Third-party notice impact reviewed when dependencies changed (No dependencies added)

