### PR TITLE
chore(protocol): upgrade upstream checkout action

### DIFF
--- a/consent-protocol/.github/workflows/ci.yml
+++ b/consent-protocol/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-python-uv
         with:
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-python-uv
         with:


### PR DESCRIPTION
## Summary
- update consent-protocol upstream CI workflow to use `actions/checkout@v6`
- create a fresh upstream subtree commit so upstream Secret Scan no longer reprocesses the old historical leak range
- keep monorepo subtree state aligned with the upstream fix

## Verification
- bash scripts/ci/verify-protocol-ci-parity.sh
- bash scripts/ci/subtree-sync-check.sh
- ./bin/hushh protocol push

## Upstream result
- pushed upstream SHA: `2e57c3ea83b49a29d2b60fc4b63ce0c0c1fcae77`
- upstream workflow `Consent Protocol CI` run `24736066183` passed
