### PR TITLE
Fix: valid Kai tokens rejected as "Malformed"

### DIFF
--- a/consent-protocol/hushh_mcp/consent/scope_helpers.py
+++ b/consent-protocol/hushh_mcp/consent/scope_helpers.py
@@ -49,16 +49,21 @@ def resolve_scope_to_enum(scope: str) -> ConsentScope:
     if scope == "pkm.write":
         return ConsentScope.PKM_WRITE
 
-    # Agent permissions
+    # Agent permissions — direct enum lookup; never silently map unknown scopes
     if scope.startswith("agent."):
-        return ConsentScope.AGENT_EXECUTE
+        try:
+            return ConsentScope(scope)
+        except ValueError:
+            raise ValueError(
+                f"Unknown agent scope '{scope}'. "
+                f"Valid agent scopes: {[s.value for s in ConsentScope.agent_scopes()]}"
+            )
 
-    # Custom/temporary scopes
-    if scope.startswith("custom."):
-        return ConsentScope.CUSTOM_TEMPORARY
-
-    # Default to custom temporary
-    return ConsentScope.CUSTOM_TEMPORARY
+    # Direct enum lookup for all other static scopes
+    try:
+        return ConsentScope(scope)
+    except ValueError:
+        raise ValueError(f"Unknown scope '{scope}' cannot be resolved to a ConsentScope enum")
 
 
 def scope_matches(granted_scope: str, requested_scope: str) -> bool:

--- a/consent-protocol/hushh_mcp/consent/token.py
+++ b/consent-protocol/hushh_mcp/consent/token.py
@@ -74,20 +74,18 @@ def issue_token(
 def _scope_str_to_enum(scope_str: str) -> ConsentScope:
     """
     Map a scope string to its ConsentScope enum equivalent.
-    Dynamic scopes (attr.*) map to PKM_READ.
+    Dynamic attr.* scopes map to PKM_READ.
+    All other scopes MUST exist in the enum - unknown scopes raise ValueError.
     """
     try:
         return ConsentScope(scope_str)
     except ValueError:
-        if scope_str == "pkm.read":
-            return ConsentScope.PKM_READ
-        if scope_str == "pkm.write":
-            return ConsentScope.PKM_WRITE
-        # Dynamic scope (e.g., attr.financial.*) - map to PKM_READ
+        # Dynamic attr.* scopes are validated separately; map to PKM_READ for type alignment.
         if scope_str.startswith("attr."):
             return ConsentScope.PKM_READ
-        # Unknown scope - default to PKM_READ
-        return ConsentScope.PKM_READ
+        # Re-raise for all unknown scopes - do NOT silently map to PKM_READ.
+        # A missing enum entry is a code bug and must surface loudly.
+        raise
 
 
 # ========== Token Verifier ==========
@@ -165,7 +163,9 @@ def validate_token(
         )
         return True, None, token
 
-    except Exception as e:
+    except (ValueError, KeyError, AttributeError, UnicodeDecodeError) as e:
+        # Only catch structural/parse errors that indicate a genuinely malformed token.
+        logger.debug("Token parse failed (malformed token): %s", e)
         return False, f"Malformed token: {str(e)}", None
 
 

--- a/consent-protocol/hushh_mcp/constants.py
+++ b/consent-protocol/hushh_mcp/constants.py
@@ -49,6 +49,7 @@ class ConsentScope(str, Enum):
     # ==================== KAI AGENT OPERATIONS ====================
     AGENT_KAI_ANALYZE = "agent.kai.analyze"
     AGENT_KAI_DEBATE = "agent.kai.debate"
+    AGENT_KAI_EXECUTE = "agent.kai.execute"  # FIX #408: was missing, caused valid tokens to be rejected
     AGENT_KAI_INFER = "agent.kai.infer"
     AGENT_KAI_CHAT = "agent.kai.chat"
 

--- a/consent-protocol/test_bug408_dryrun.py
+++ b/consent-protocol/test_bug408_dryrun.py
@@ -3,12 +3,10 @@ Dry-run verification for Bug #408 fix.
 Mirrors the 5 tests shown in the GitHub issue screenshots.
 Writes results to bug408_results.log (UTF-8).
 """
+import builtins
 import os
 import sys
 import types
-import builtins
-
-
 
 sys.path.insert(0, os.path.dirname(__file__))
 

--- a/consent-protocol/test_bug408_dryrun.py
+++ b/consent-protocol/test_bug408_dryrun.py
@@ -1,0 +1,132 @@
+"""
+Dry-run verification for Bug #408 fix.
+Mirrors the 5 tests shown in the GitHub issue screenshots.
+Writes results to bug408_results.log (UTF-8).
+"""
+import sys
+import os
+sys.path.insert(0, os.path.dirname(__file__))
+
+# Minimal env setup BEFORE any hushh_mcp imports
+os.environ["APP_SIGNING_KEY"] = "test-signing-key-dryrun-must-be-at-least-32-chars-long"
+os.environ["VAULT_DATA_KEY"] = "a" * 64  # 64-char hex string (256-bit AES key)
+os.environ["TESTING"] = "true"
+
+# Mock DB drivers so tests work without real DB infrastructure
+import types
+for mod_name in ["asyncpg", "psycopg2", "psycopg2.extras", "psycopg2.extensions", "psycopg"]:
+    if mod_name not in sys.modules:
+        mock = types.ModuleType(mod_name)
+        sys.modules[mod_name] = mock
+
+# psycopg2.extras needs a Json adapter stub (used by db_client.py)
+_extras = sys.modules["psycopg2.extras"]
+if not hasattr(_extras, "Json"):
+    _extras.Json = lambda obj: obj  # type: ignore[attr-defined]
+
+LOG_FILE = os.path.join(os.path.dirname(__file__), "bug408_results.log")
+log = open(LOG_FILE, "w", encoding="utf-8")
+
+results = []
+
+def out(msg=""):
+    log.write(msg + "\n")
+    log.flush()
+
+def check(label, ok, detail=""):
+    tag = "[PASS]" if ok else "[FAIL]"
+    out(f"{tag} {label}")
+    if detail:
+        out(f"       {detail}")
+    results.append(ok)
+
+out("=" * 60)
+out(" Bug #408 Dry-Run - 5 Tests")
+out("=" * 60)
+
+# -- TEST 1 --
+out("\n[TEST 1] ConsentScope.AGENT_KAI_EXECUTE exists")
+try:
+    from hushh_mcp.constants import ConsentScope
+    val = ConsentScope.AGENT_KAI_EXECUTE
+    check("AGENT_KAI_EXECUTE attribute exists", True, f"value = '{val.value}'")
+except AttributeError as e:
+    check("AGENT_KAI_EXECUTE attribute exists", False, str(e))
+
+# -- TEST 2 --
+out("\n[TEST 2] ConsentScope('agent.kai.execute') resolves without error")
+try:
+    from hushh_mcp.constants import ConsentScope
+    scope = ConsentScope("agent.kai.execute")
+    check("ConsentScope('agent.kai.execute') resolves", True, f"-> {scope}")
+except ValueError as e:
+    check("ConsentScope('agent.kai.execute') resolves", False, str(e))
+
+# -- TEST 3 --
+out("\n[TEST 3] resolve_scope_to_enum('agent.kai.execute') returns correct enum")
+try:
+    from hushh_mcp.consent.scope_helpers import resolve_scope_to_enum
+    from hushh_mcp.constants import ConsentScope
+    result = resolve_scope_to_enum("agent.kai.execute")
+    correct = result == ConsentScope.AGENT_KAI_EXECUTE
+    wrong_scope = result == ConsentScope.AGENT_KAI_ANALYZE
+    if correct:
+        check("Returns AGENT_KAI_EXECUTE (not AGENT_KAI_ANALYZE)", True, f"-> {result}")
+    elif wrong_scope:
+        check("Returns AGENT_KAI_EXECUTE (not AGENT_KAI_ANALYZE)", False,
+              "BUG: silently returned AGENT_KAI_ANALYZE - privilege escalation")
+    else:
+        check("Returns AGENT_KAI_EXECUTE (not AGENT_KAI_ANALYZE)", False, f"Unexpected: {result}")
+except Exception as e:
+    check("Returns AGENT_KAI_EXECUTE (not AGENT_KAI_ANALYZE)", False, f"Raised: {e}")
+
+# -- TEST 4 --
+out("\n[TEST 4] get_scope_display_metadata('agent.kai.execute') + enum round-trip")
+try:
+    from hushh_mcp.consent.scope_helpers import get_scope_display_metadata
+    from hushh_mcp.constants import ConsentScope
+    meta = get_scope_display_metadata("agent.kai.execute")
+    scope_str = "agent.kai.execute"
+    enum_val = ConsentScope(scope_str)
+    check("Display metadata + enum round-trip works", True,
+          f"label='{meta['label']}', enum='{enum_val}'")
+except Exception as e:
+    check("Display metadata + enum round-trip works", False, str(e))
+
+# -- TEST 5 --
+out("\n[TEST 5] validate_token() with agent.kai.execute scope returns (True, ..., payload)")
+try:
+    from hushh_mcp.consent.token import issue_token, validate_token
+    from hushh_mcp.constants import ConsentScope
+
+    token_obj = issue_token(
+        user_id="user_test",
+        agent_id="agent_kai",
+        scope=ConsentScope.AGENT_KAI_EXECUTE,
+    )
+    valid, reason, payload = validate_token(token_obj.token)
+    if valid and payload is not None:
+        check("validate_token returns (True, None, payload)", True,
+              f"scope_str='{payload.scope_str}'")
+    else:
+        check("validate_token returns (True, None, payload)", False,
+              f"valid={valid}, reason='{reason}'")
+except Exception as e:
+    check("validate_token returns (True, None, payload)", False, f"Exception: {e}")
+
+# -- SUMMARY --
+out("\n" + "=" * 60)
+passed = sum(results)
+total = len(results)
+out(f" Result: {passed}/{total} tests passed")
+if passed == total:
+    out(" ALL TESTS PASSED - Bug #408 is fixed.")
+else:
+    out(f" {total - passed} test(s) FAILED - fix incomplete.")
+out("=" * 60)
+
+log.close()
+
+# Also print the log file path so the user knows where to look
+import builtins
+builtins.print(f"Results written to: {LOG_FILE}")

--- a/consent-protocol/test_bug408_dryrun.py
+++ b/consent-protocol/test_bug408_dryrun.py
@@ -3,8 +3,13 @@ Dry-run verification for Bug #408 fix.
 Mirrors the 5 tests shown in the GitHub issue screenshots.
 Writes results to bug408_results.log (UTF-8).
 """
-import sys
 import os
+import sys
+import types
+import builtins
+
+
+
 sys.path.insert(0, os.path.dirname(__file__))
 
 # Minimal env setup BEFORE any hushh_mcp imports
@@ -13,7 +18,8 @@ os.environ["VAULT_DATA_KEY"] = "a" * 64  # 64-char hex string (256-bit AES key)
 os.environ["TESTING"] = "true"
 
 # Mock DB drivers so tests work without real DB infrastructure
-import types
+
+
 for mod_name in ["asyncpg", "psycopg2", "psycopg2.extras", "psycopg2.extensions", "psycopg"]:
     if mod_name not in sys.modules:
         mock = types.ModuleType(mod_name)
@@ -128,5 +134,5 @@ out("=" * 60)
 log.close()
 
 # Also print the log file path so the user knows where to look
-import builtins
+
 builtins.print(f"Results written to: {LOG_FILE}")


### PR DESCRIPTION
### 🐛 Fix: Valid Kai tokens incorrectly rejected as "Malformed"

#### 🔍 Root Cause

* `agent.kai.execute` was referenced in `scope_helpers.py` but missing in `ConsentScope` enum
* This caused a `ValueError` during enum conversion
* A broad `except Exception` in `validate_token()` masked the real issue

#### ✅ Fix Implemented

* Added missing enum:
  AGENT_KAI_EXECUTE = "agent.kai.execute"
* Fixed scope resolution logic
* Prevented incorrect fallback behavior

#### 🧪 Validation

* Reproduced issue using test harness
* Added test: `test_bug408_dryrun.py`
* Verified token validation works correctly

#### 🔐 Impact

* Fixes valid token rejection
* Improves reliability of authentication layer

#### 📁 Files Modified

* constants.py
* scope_helpers.py
* token.py
* test_bug408_dryrun.py

#### ⚠️ Note

* Full test suite not executed due to missing dependencies
* Dry-run test confirms fix for reported issue
