### PR TITLE
chore(ops): collapse deploy environments to uat and production

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -51,7 +51,7 @@ jobs:
     name: Deploy Production Scope
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch'
-    environment: production-owner-bypass
+    environment: production
 
     steps:
       - name: Assert manual dispatch originates from main
@@ -91,7 +91,7 @@ jobs:
 
       - name: Report production deploy lane
         run: |
-          echo "Owner-only production deploy: using production-owner-bypass environment."
+          echo "Owner-only production deploy: using production environment."
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2

--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -35,6 +35,6 @@
     "manual_dispatch_users": [
       "kushaltrivedi5"
     ],
-    "owner_environment": "production-owner-bypass"
+    "owner_environment": "production"
   }
 }

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -241,7 +241,7 @@ Deploys Next.js frontend to Cloud Run:
 
 The repo includes:
 
-- [.github/workflows/deploy-production.yml](../.github/workflows/deploy-production.yml): manual production deploy (`workflow_dispatch`) through `production-owner-bypass`.
+- [.github/workflows/deploy-production.yml](../.github/workflows/deploy-production.yml): manual production deploy (`workflow_dispatch`) through `production`.
 - [.github/workflows/deploy-uat.yml](../.github/workflows/deploy-uat.yml): manual UAT deploy (`workflow_dispatch`) through `uat`.
 
 Manual dispatch now supports `scope`:
@@ -256,7 +256,7 @@ Manual dispatch now supports `scope`:
 2. **Branch flow:** merge to `main` for UAT rollout; use manual dispatch for production rollout from a green `main` SHA.
 3. **Environment policy:** keep only the canonical deploy environments in active use:
    - `uat`
-   - `production-owner-bypass`
+   - `production`
    Legacy unused production environments should not remain as parallel approval lanes.
 
 ### CI Security Gates

--- a/docs/guides/advanced-ops.md
+++ b/docs/guides/advanced-ops.md
@@ -108,7 +108,7 @@ Deploy workflows already validate:
 - runtime env/secret parity
 - backend/frontend runtime contract injection
 
-Production is no longer an auto-deploy branch lane. It is a manual dispatch of an approved green `main` SHA via [`.github/workflows/deploy-production.yml`](../../.github/workflows/deploy-production.yml), recorded under the canonical `production-owner-bypass` environment.
+Production is no longer an auto-deploy branch lane. It is a manual dispatch of an approved green `main` SHA via [`.github/workflows/deploy-production.yml`](../../.github/workflows/deploy-production.yml), recorded under the canonical `production` environment.
 
 Reference docs:
 

--- a/docs/reference/operations/branch-governance.md
+++ b/docs/reference/operations/branch-governance.md
@@ -68,7 +68,7 @@ Before deleting a local backup branch, classify its unique commits as:
 3. The workflow validates that the SHA is reachable from `origin/main`.
 4. The workflow also validates that `Main Post-Merge Smoke Gate` succeeded for that SHA before deployment starts.
 5. Only `kushaltrivedi5` may dispatch the production workflow after the SHA preflight passes.
-6. The canonical GitHub deployment environment for this lane is `production-owner-bypass`.
+6. The canonical GitHub deployment environment for this lane is `production`.
 
 ## Hotfix Playbook
 
@@ -121,7 +121,7 @@ The production workflow uses one active GitHub environment name:
 
 | Environment | Intended use |
 |---|---|
-| `production-owner-bypass` | Owner-only production deploy lane for `kushaltrivedi5` |
+| `production` | Owner-only production deploy lane for `kushaltrivedi5` |
 
 The UAT workflow uses one active GitHub environment name:
 
@@ -133,6 +133,6 @@ Operational rules:
 
 1. Only `kushaltrivedi5` may dispatch the production workflow.
 2. Other developers may still merge to `main` through PR flow, but production dispatch remains owner-only.
-3. `production-owner-bypass` should not require reviewers and should not allow admin bypass.
+3. `production` should not require reviewers and should not allow admin bypass.
 4. Verify the live setup with `../../../scripts/ci/verify-production-environment-governance.sh`.
 5. Verify both deploy lanes together with `../../../scripts/ci/verify-deployment-environment-governance.py`.

--- a/docs/reference/operations/ci.md
+++ b/docs/reference/operations/ci.md
@@ -222,7 +222,7 @@ GitHub deployment environments are part of the release authority surface and sho
   - no admin bypass
   - protected branches only
   - used by [`.github/workflows/deploy-uat.yml`](../../../.github/workflows/deploy-uat.yml)
-- `production-owner-bypass`
+- `production`
   - no reviewers
   - no admin bypass
   - protected branches only


### PR DESCRIPTION
## Summary
- rename the canonical production deploy environment to `production`
- keep only two active deploy environments on GitHub: `uat` and `production`
- align workflow, policy, and docs to the two-lane environment model

## Testing
- python3 scripts/ci/verify-deployment-environment-governance.py
- bash scripts/ci/verify-production-environment-governance.sh
- bash scripts/ci/orchestrate.sh governance
- git diff --check
