### PR TITLE
chore(ops): seal protected pipeline edits

### DIFF
--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -17,6 +17,19 @@
       "Akash-292",
       "RGlodAkshat",
       "ankitkumarsingh1702"
+    ],
+    "protected_pipeline_edit_users": [
+      "kushaltrivedi5",
+      "Akash-292",
+      "RGlodAkshat",
+      "ankitkumarsingh1702"
+    ],
+    "protected_pipeline_paths": [
+      ".github/workflows/",
+      ".github/actions/",
+      "scripts/ci/",
+      "deploy/",
+      "config/ci-governance.json"
     ]
   },
   "uat": {

--- a/docs/reference/operations/ci.md
+++ b/docs/reference/operations/ci.md
@@ -126,6 +126,20 @@ To prevent CI check-sprawl, only these queue/PR checks are hard-blocking by defa
 
 The local parity script mirrors the blocking pre-merge validation stages. On GitHub, `main` should require `CI Status Gate` as the blocking status check on PR and queue commits, keep `Main Freshness Gate` advisory on pull requests, enforce freshness authoritatively through merge queue validation, trust `Main Post-Merge Smoke Gate` for deployment eligibility on the landed `main` SHA, and restrict queue bypass to the dedicated sanctioned owner cohort only.
 
+### Protected pipeline surfaces
+
+Core CI and deploy surfaces are sealed separately from blanket owner-review policy.
+
+- PRs that change protected pipeline paths are allowed only for the sanctioned bypass cohort defined in [config/ci-governance.json](../../../config/ci-governance.json).
+- This guard currently covers:
+  - `.github/workflows/**`
+  - `.github/actions/**`
+  - `scripts/ci/**`
+  - `deploy/**`
+  - `config/ci-governance.json`
+- Enforcement happens inside the blocking governance lane through [scripts/ci/verify-protected-pipeline-edits.py](../../../scripts/ci/verify-protected-pipeline-edits.py).
+- This does not change the repo-wide `0`-approval policy on `main`; it only seals core pipeline and CI authority to the sanctioned maintainer cohort.
+
 ### PKM rollout blocker
 
 Production rollout is blocked unless PKM compatibility stays green for supported stored-version paths. The blocking CI manifests now explicitly include:
@@ -229,6 +243,8 @@ GitHub deployment environments are part of the release authority surface and sho
   - used by [`.github/workflows/deploy-production.yml`](../../../.github/workflows/deploy-production.yml)
 
 There should not be parallel legacy production environments carrying approval logic that the current workflows no longer use.
+
+GitHub only records deployment history under an environment after a workflow job actually runs with `environment: <name>`. Older deploy runs from before that binding existed are not retroactively re-linked. If `uat` or `production` looks empty after environment cleanup, trigger one fresh deploy from a green `main` SHA to seed the canonical history.
 
 Verify live environment governance with:
 

--- a/scripts/ci/repo-governance-check.sh
+++ b/scripts/ci/repo-governance-check.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
+python3 scripts/ci/verify-protected-pipeline-edits.py
 ./bin/hushh docs verify
 python3 scripts/licenses/verify_apache_surface.py
 python3 scripts/ci/verify-runtime-config-contract.py

--- a/scripts/ci/verify-protected-pipeline-edits.py
+++ b/scripts/ci/verify-protected-pipeline-edits.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Hushh
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+POLICY_PATH = REPO_ROOT / "config" / "ci-governance.json"
+DEFAULT_PROTECTED_PATHS = [
+    ".github/workflows/",
+    ".github/actions/",
+    "scripts/ci/",
+    "deploy/",
+    "config/ci-governance.json",
+]
+
+
+def _load_policy() -> dict:
+    return json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+
+
+def _normalize_csv(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _matches(path: str, protected_path: str) -> bool:
+    if protected_path.endswith("/"):
+        return path.startswith(protected_path)
+    return path == protected_path
+
+
+def _fetch_pr_files(repo: str, pr_number: int, token: str) -> list[str]:
+    files: list[str] = []
+    page = 1
+    while True:
+        url = (
+            f"https://api.github.com/repos/{repo}/pulls/{pr_number}/files"
+            f"?per_page=100&page={page}"
+        )
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        with urllib.request.urlopen(request) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        if not payload:
+            break
+        files.extend(
+            item["filename"].strip()
+            for item in payload
+            if isinstance(item, dict) and item.get("filename")
+        )
+        page += 1
+    return files
+
+
+def _files_from_event(args: argparse.Namespace) -> list[str]:
+    if args.files:
+        return _normalize_csv(args.files)
+    event_name = args.event_name or os.environ.get("GITHUB_EVENT_NAME", "")
+    if event_name not in {"pull_request", "pull_request_target"}:
+        return []
+    event_path = os.environ.get("GITHUB_EVENT_PATH", "")
+    if not event_path:
+        return []
+    payload = json.loads(Path(event_path).read_text(encoding="utf-8"))
+    pull_request = payload.get("pull_request") or {}
+    pr_number = args.pr_number or pull_request.get("number")
+    repo = args.repo or os.environ.get("GITHUB_REPOSITORY", "").strip()
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or ""
+    if not pr_number or not repo or not token:
+        return []
+    return _fetch_pr_files(repo=repo, pr_number=int(pr_number), token=token)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Fail PR governance when non-maintainers edit protected CI/pipeline surfaces."
+    )
+    parser.add_argument("--event-name", help="Override GitHub event name.")
+    parser.add_argument("--actor", help="Override GitHub actor.")
+    parser.add_argument("--repo", help="Override GitHub repo owner/name.")
+    parser.add_argument("--pr-number", type=int, help="Override pull request number.")
+    parser.add_argument(
+        "--files",
+        help="Comma-separated changed files for local verification.",
+    )
+    args = parser.parse_args()
+
+    policy = _load_policy()
+    main_policy = policy["main"]
+    allowed_users = sorted(
+        set(
+            main_policy.get("protected_pipeline_edit_users")
+            or main_policy.get("review_bypass_users")
+            or []
+        )
+    )
+    protected_paths = main_policy.get("protected_pipeline_paths") or DEFAULT_PROTECTED_PATHS
+    event_name = args.event_name or os.environ.get("GITHUB_EVENT_NAME", "")
+
+    if event_name not in {"pull_request", "pull_request_target"} and not args.files:
+        print(
+            f"Protected pipeline edit guard: skip for event '{event_name or 'local'}'; "
+            "PR enforcement only."
+        )
+        return 0
+
+    changed_files = _files_from_event(args)
+    if not changed_files:
+        print("Protected pipeline edit guard: no changed files resolved; nothing to enforce.")
+        return 0
+
+    protected_changes = sorted(
+        path
+        for path in changed_files
+        if any(_matches(path, protected_path) for protected_path in protected_paths)
+    )
+    if not protected_changes:
+        print("Protected pipeline edit guard: no protected pipeline surfaces changed.")
+        return 0
+
+    actor = (args.actor or os.environ.get("GITHUB_ACTOR", "")).strip()
+    if actor in allowed_users:
+        print(
+            "Protected pipeline edit guard: allowed "
+            f"(actor={actor}, files={protected_changes}, allowed_users={allowed_users})."
+        )
+        return 0
+
+    print(
+        "ERROR: protected pipeline surfaces changed by non-sanctioned actor "
+        f"'{actor or '<unknown>'}'."
+    )
+    print(f"ERROR: protected files={protected_changes}")
+    print(f"ERROR: allowed users={allowed_users}")
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except urllib.error.HTTPError as exc:
+        print(f"ERROR: failed to resolve PR files from GitHub API: {exc}", file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
- seal core pipeline edits to the sanctioned bypass cohort
- wire the guard into governance CI
- document the GitHub deployment-history seeding rule for uat and production

## Testing
- python3 -m py_compile scripts/ci/verify-protected-pipeline-edits.py
- python3 scripts/ci/verify-protected-pipeline-edits.py --files '.github/workflows/deploy-production.yml,config/ci-governance.json' --actor kushaltrivedi5
- python3 scripts/ci/verify-protected-pipeline-edits.py --files '.github/workflows/deploy-production.yml,config/ci-governance.json' --actor some-random-user || true
- bash scripts/ci/orchestrate.sh governance
- git diff --check