### PR TITLE
feat(codex): add silent hook routing bridge

### DIFF
--- a/.claude/skills/codex-bridge/scripts/route.py
+++ b/.claude/skills/codex-bridge/scripts/route.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 from collections import OrderedDict
@@ -570,11 +571,116 @@ def _prepend_response_rules(briefing: str, repo_root: Path, query: str) -> str:
     return "\n".join(header) + briefing
 
 
+HOOK_MIN_PROMPT_LEN = 12
+HOOK_WORKFLOW_SCORE = 8
+HOOK_SKILL_SCORE = 10
+
+
+def _read_hook_stdin() -> str:
+    """Read UserPromptSubmit hook JSON from stdin and return the prompt field.
+
+    Claude Code feeds hooks a JSON payload containing at least `prompt`,
+    `session_id`, `cwd`, and `hook_event_name`. We only need `prompt`.
+    Returns "" on any parse failure so the hook stays silent.
+    """
+    try:
+        raw = sys.stdin.read()
+    except Exception:
+        return ""
+    if not raw.strip():
+        return ""
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return ""
+    if not isinstance(data, dict):
+        return ""
+    return str(data.get("prompt") or "").strip()
+
+
+def _hook_wrap(briefing: str, match_id: str, kind: str) -> str:
+    header = (
+        "# Auto-routed by codex-bridge\n\n"
+        f"_Your prompt matched **{kind} `{match_id}`** in the codex tree. "
+        "Treat the briefing below as authoritative for this turn: follow its "
+        "Read-First list, workflow steps, and required checks, and hand off "
+        "if the task leaves scope. If the match looks wrong, ignore this "
+        "block and proceed with the user's request as stated._\n\n---\n\n"
+    )
+    return header + briefing
+
+
+def _route_hook(
+    repo_root: Path,
+    skills: list[Entry],
+    workflows: list[Entry],
+    query: str,
+) -> tuple[str, int]:
+    """Silent-fallback mode for the UserPromptSubmit hook.
+
+    Emits a wrapped briefing only on a confident match. Conversational or
+    off-topic prompts produce empty stdout so the hook does not bury the
+    turn in catalog dumps.
+    """
+    if os.environ.get("CODEX_BRIDGE_DISABLE") == "1":
+        return ("", 0)
+    if not query or len(query) < HOOK_MIN_PROMPT_LEN:
+        return ("", 0)
+
+    skills_by_id = {s.name: s for s in skills}
+
+    direct_workflow = exact_match(query, workflows)
+    if direct_workflow:
+        briefing = compose_workflow_briefing(direct_workflow, skills_by_id)
+        return _prepend_response_rules(
+            _hook_wrap(briefing, direct_workflow.name, "workflow"), repo_root, query
+        ), 0
+
+    direct_skill = exact_match(query, skills)
+    if direct_skill:
+        briefing = compose_skill_briefing(direct_skill, workflows, skills_by_id)
+        return _prepend_response_rules(
+            _hook_wrap(briefing, direct_skill.name, "skill"), repo_root, query
+        ), 0
+
+    tokens = _tokens(query)
+    if not tokens:
+        return ("", 0)
+
+    ranked_skills = sorted(((score_skill(e, tokens), e) for e in skills), key=lambda x: -x[0])
+    ranked_workflows = sorted(((score_workflow(e, tokens), e) for e in workflows), key=lambda x: -x[0])
+
+    best_skill_score, best_skill = (ranked_skills[0] if ranked_skills else (0, None))
+    best_wf_score, best_wf = (ranked_workflows[0] if ranked_workflows else (0, None))
+
+    if best_wf is not None and best_wf_score >= HOOK_WORKFLOW_SCORE and best_wf_score >= best_skill_score:
+        briefing = compose_workflow_briefing(best_wf, skills_by_id)
+        return _prepend_response_rules(
+            _hook_wrap(briefing, best_wf.name, "workflow"), repo_root, query
+        ), 0
+
+    if best_skill is not None and best_skill_score >= HOOK_SKILL_SCORE:
+        close = [e for s, e in ranked_skills if s >= best_skill_score - 2 and e is not best_skill]
+        if close:
+            return ("", 0)
+        briefing = compose_skill_briefing(best_skill, workflows, skills_by_id)
+        return _prepend_response_rules(
+            _hook_wrap(briefing, best_skill.name, "skill"), repo_root, query
+        ), 0
+
+    return ("", 0)
+
+
 def route(argv: list[str]) -> tuple[str, int]:
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument("--list", action="store_true")
     parser.add_argument("--check", action="store_true")
     parser.add_argument("--coverage", action="store_true")
+    parser.add_argument(
+        "--hook",
+        action="store_true",
+        help="UserPromptSubmit hook mode: read prompt JSON from stdin and emit a briefing only on a confident match.",
+    )
     parser.add_argument("--repo", default=None)
     parser.add_argument("query", nargs="*")
     args = parser.parse_args(argv)
@@ -582,7 +688,13 @@ def route(argv: list[str]) -> tuple[str, int]:
     repo_root = Path(args.repo).resolve() if args.repo else find_repo_root(Path.cwd())
     skills, workflows = discover(repo_root)
     if not skills and not workflows:
+        if args.hook:
+            return ("", 0)
         return (f"_No `.codex/skills/` or `.codex/workflows/` entries under {repo_root}._\n", 1)
+
+    if args.hook:
+        query = _read_hook_stdin()
+        return _route_hook(repo_root, skills, workflows, query)
 
     if args.check:
         return render_check(repo_root, skills, workflows)

--- a/.claude/skills/codex-bridge/scripts/test_route_hook.py
+++ b/.claude/skills/codex-bridge/scripts/test_route_hook.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Regression test for route.py --hook mode (UserPromptSubmit contract).
+
+Run:
+    python3 .claude/skills/codex-bridge/scripts/test_route_hook.py
+
+The hook contract:
+  - Never block the turn: exit code must be 0 on every path, including malformed stdin.
+  - Silent on weak matches: empty stdout for chitchat, short prompts, missing fields.
+  - Wrapped briefing on strong matches: exact name or free-text score above gate.
+  - Q&A rules header prepended when the prompt has a QA_MARKERS hit.
+  - Env kill-switch: CODEX_BRIDGE_DISABLE=1 forces silence.
+
+Exits non-zero if any assertion fails so CI can depend on it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).parent / "route.py"
+
+
+def run_hook(payload: str, env: dict | None = None) -> tuple[str, int]:
+    proc = subprocess.run(
+        ["python3", str(SCRIPT), "--hook"],
+        input=payload,
+        capture_output=True,
+        text=True,
+        env={**os.environ, **(env or {})},
+        timeout=20,
+    )
+    return proc.stdout, proc.returncode
+
+
+def payload(prompt: str) -> str:
+    return json.dumps({
+        "session_id": "test",
+        "cwd": str(Path.cwd()),
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": prompt,
+    })
+
+
+FAILED: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  pass  {name}")
+    else:
+        print(f"  FAIL  {name}  {detail}")
+        FAILED.append(name)
+
+
+def main() -> int:
+    print("=== codex-bridge route.py --hook regression ===")
+
+    out, code = run_hook("")
+    check("empty stdin is silent and exit 0", out.strip() == "" and code == 0, f"code={code} out={out!r}")
+
+    out, code = run_hook("not json at all")
+    check("malformed stdin is silent and exit 0", out.strip() == "" and code == 0, f"code={code} out={out!r}")
+
+    out, code = run_hook(json.dumps(["a", "b"]))
+    check("non-dict json stdin is silent", out.strip() == "" and code == 0)
+
+    out, code = run_hook(json.dumps({"session_id": "x"}))
+    check("missing prompt field is silent", out.strip() == "" and code == 0)
+
+    out, code = run_hook(payload("hi"))
+    check("prompt shorter than floor is silent", out.strip() == "" and code == 0)
+
+    out, code = run_hook(payload("hey how are you doing today friend"))
+    check("chitchat is silent", out.strip() == "" and code == 0, f"leaked={out[:160]!r}")
+
+    out, code = run_hook(payload("repo-operations"))
+    check(
+        "exact skill name emits wrapped briefing",
+        code == 0
+        and "Auto-routed by codex-bridge" in out
+        and "skill `repo-operations`" in out,
+        f"head={out[:200]!r}",
+    )
+
+    out, code = run_hook(payload("ci-watch-and-heal"))
+    check(
+        "exact workflow name emits wrapped briefing",
+        code == 0
+        and "Auto-routed by codex-bridge" in out
+        and "workflow `ci-watch-and-heal`" in out,
+        f"head={out[:200]!r}",
+    )
+
+    out, code = run_hook(payload("repo-operations guidance for branch protection and merge queue state"))
+    check(
+        "strong free-text match emits wrapped briefing",
+        code == 0 and "Auto-routed by codex-bridge" in out,
+        f"head={out[:200]!r}",
+    )
+
+    out, code = run_hook(payload("how does repo-operations manage branch protection and merge queue settings?"))
+    check(
+        "Q&A marker plus strong match prepends reply-rules header",
+        code == 0
+        and "Response format (codex Q&A rules)" in out
+        and "Auto-routed by codex-bridge" in out,
+        f"head={out[:200]!r}",
+    )
+
+    out, code = run_hook(
+        payload("how does repo-operations manage branch protection and merge queue settings?"),
+        env={"CODEX_BRIDGE_DISABLE": "1"},
+    )
+    check(
+        "CODEX_BRIDGE_DISABLE=1 forces silence even on strong match",
+        out.strip() == "" and code == 0,
+        f"code={code} out={out[:120]!r}",
+    )
+
+    if FAILED:
+        print(f"\n{len(FAILED)} check(s) failed: {FAILED}")
+        return 1
+    print("\nall checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a silent UserPromptSubmit hook mode to codex-bridge
- emit wrapped briefings only on confident skill or workflow matches
- add regression coverage for silent fallback, exact matches, free-text matches, and kill-switch behavior

## Testing
- python3 -m py_compile .claude/skills/codex-bridge/scripts/route.py
- python3 -m py_compile .claude/skills/codex-bridge/scripts/test_route_hook.py
- python3 .claude/skills/codex-bridge/scripts/test_route_hook.py