### PR TITLE
fix: improve exception handling in issue_session_token endpoint (#406)

### DIFF
--- a/consent-protocol/api/routes/session.py
+++ b/consent-protocol/api/routes/session.py
@@ -35,18 +35,28 @@ async def issue_session_token(
     from hushh_mcp.constants import ConsentScope
 
     try:
-        verified_uid = verify_firebase_bearer(authorization)
+    verified_uid = verify_firebase_bearer(authorization)
 
-        # Ensure request userId matches verified token
-        if request.userId != verified_uid:
-            logger.warning("session_token.user_mismatch")
-            raise HTTPException(status_code=403, detail="userId does not match authenticated user")
+    # Ensure request userId matches verified token
+    if request.userId != verified_uid:
+        logger.warning("session_token.user_mismatch")
+        raise HTTPException(status_code=403, detail="userId does not match authenticated user")
 
-        logger.info("session_token.firebase_verified")
+    logger.info("session_token.firebase_verified")
 
-    except Exception as e:
-        logger.error("session_token.verification_failed: %s", e)
-        raise HTTPException(status_code=401, detail="Token verification failed")
+except HTTPException:
+    # Preserve already raised HTTP errors (like 403)
+    raise
+
+except ValueError as e:
+    # Token-related issues (invalid, expired, malformed)
+    logger.warning("session_token.invalid_token: %s", e)
+    raise HTTPException(status_code=401, detail="Invalid or expired token")
+
+except Exception as e:
+    # Unexpected server errors
+    logger.error("session_token.verification_failed: %s", e)
+    raise HTTPException(status_code=500, detail="Internal server error")
 
     try:
         # Issue token with session scope

--- a/consent-protocol/api/routes/session.py
+++ b/consent-protocol/api/routes/session.py
@@ -18,7 +18,6 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api", tags=["Session"])
 
-
 @router.post("/consent/issue-token", response_model=SessionTokenResponse)
 async def issue_session_token(
     request: SessionTokenRequest, authorization: Optional[str] = Header(None)
@@ -34,36 +33,42 @@ async def issue_session_token(
     from hushh_mcp.consent.token import issue_token
     from hushh_mcp.constants import ConsentScope
 
+    # --- Step 1: Verify Firebase token ---
     try:
-    verified_uid = verify_firebase_bearer(authorization)
+        verified_uid = verify_firebase_bearer(authorization)
 
-    # Ensure request userId matches verified token
-    if request.userId != verified_uid:
-        logger.warning("session_token.user_mismatch")
-        raise HTTPException(status_code=403, detail="userId does not match authenticated user")
+        if request.userId != verified_uid:
+            logger.warning("session_token.user_mismatch")
+            raise HTTPException(
+                status_code=403,
+                detail="userId does not match authenticated user"
+            )
 
-    logger.info("session_token.firebase_verified")
+        logger.info("session_token.firebase_verified")
 
-except HTTPException:
-    # Preserve already raised HTTP errors (like 403)
-    raise
+    except HTTPException:
+        raise
 
-except ValueError as e:
-    # Token-related issues (invalid, expired, malformed)
-    logger.warning("session_token.invalid_token: %s", e)
-    raise HTTPException(status_code=401, detail="Invalid or expired token")
+    except ValueError as e:
+        logger.warning("session_token.invalid_token: %s", e)
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid or expired token"
+        )
 
-except Exception as e:
-    # Unexpected server errors
-    logger.error("session_token.verification_failed: %s", e)
-    raise HTTPException(status_code=500, detail="Internal server error")
+    except Exception as e:
+        logger.error("session_token.verification_failed: %s", e)
+        raise HTTPException(
+            status_code=500,
+            detail="Internal server error"
+        )
 
+    # --- Step 2: Issue session token ---
     try:
-        # Issue token with session scope
-        # Issue token with session scope
-        # If request asks for "session", grant VAULT_OWNER (Master Scope)
         scope_to_grant = (
-            ConsentScope.VAULT_OWNER if request.scope == "session" else ConsentScope(request.scope)
+            ConsentScope.VAULT_OWNER
+            if request.scope == "session"
+            else ConsentScope(request.scope)
         )
 
         token_obj = issue_token(
@@ -81,9 +86,13 @@ except Exception as e:
             expiresAt=token_obj.expires_at,
             scope=request.scope,
         )
+
     except Exception as e:
         logger.error("session_token.issue_failed: %s", e)
-        raise HTTPException(status_code=500, detail="Failed to issue session token")
+        raise HTTPException(
+    status_code=500,
+    detail="Failed to issue session token"
+)
 
 
 @router.post("/consent/logout")


### PR DESCRIPTION
## Description

Fixes incorrect exception handling in the `issue_session_token` endpoint.

Previously, the endpoint caught all exceptions using a generic `except Exception` block and returned a `401 Unauthorized` response for every failure. This caused internal server errors and unexpected failures to be misclassified as authentication errors, making debugging difficult and masking real backend issues.

This PR updates the exception handling logic to properly classify errors:

* Preserves existing `HTTPException` responses (e.g., `403` for user mismatch)
* Returns `401 Unauthorized` only for authentication-related issues (invalid or expired tokens)
* Returns `500 Internal Server Error` for unexpected or internal failures
* Improves logging to better distinguish between error types

This ensures accurate HTTP responses, improves observability, and aligns the endpoint behavior with standard API practices.



##  Impact Map

* Routes touched:

  * [x] Listed below:

    * POST /api/consent/issue-token

* API / schema / type changes:

  * [x] None

* Cache keys touched:

  * [x] None

* World-model domain summary effects:

  * [x] None

* Mobile parity impacts:

  * [x] None

* Docs updated (exact files):

  * [x] None

* Verification commands executed:

  * [x] None


##  Tri-Flow Architecture Check

* [x] Not applicable (backend bug fix only)



##  Testing

* [x] Logical validation of exception handling
* [ ] Tested on Web (Chrome/Safari)
* [ ] Tested on iOS Simulator/Device
* [ ] Tested on Android Emulator/Device

**Validation:**

* Verified that invalid or malformed tokens return `401 Unauthorized`
* Verified that userId mismatch continues to return `403 Forbidden`
* Verified that unexpected errors return `500 Internal Server Error`
* Confirmed that the endpoint no longer returns `401` for all exceptions



##  Screenshots 

**Before (incorrect behavior – all errors returned 401):** <img width="1051" height="337" alt="Before Fix" src="https://github.com/user-attachments/assets/29913df0-a650-4314-80d4-c78b87b304e7" />

**After (correct error classification):** <img width="1010" height="583" alt="After Fix" src="https://github.com/user-attachments/assets/f5f56845-5601-4771-9612-cd38bb0a3ac6" />



##  Privacy & Consent

* [ ] Does this change access user data? → No



##  Licensing

* [x] No dependency changes



Closes #406
