### PR TITLE
docs(kai): refresh voice runtime architecture references

### DIFF
--- a/consent-protocol/docs/README.md
+++ b/consent-protocol/docs/README.md
@@ -55,6 +55,7 @@ It does not own:
 | Publish against the developer API / MCP | [reference/developer-api.md](./reference/developer-api.md) |
 | Understand data encryption and storage | [reference/personal-knowledge-model.md](./reference/personal-knowledge-model.md) |
 | Learn the 3-agent debate system | [reference/kai-agents.md](./reference/kai-agents.md) |
+| Understand the current Kai voice runtime contract | [../../docs/reference/kai/kai-voice-runtime-architecture.md](../../docs/reference/kai/kai-voice-runtime-architecture.md) |
 | Understand the consent token model | [reference/consent-protocol.md](./reference/consent-protocol.md) |
 | FCM push notification architecture | [reference/fcm-notifications.md](./reference/fcm-notifications.md) |
 | Understand MCP runtime and contributor-local setup | [mcp-setup.md](./mcp-setup.md) |

--- a/contracts/kai/voice-action-manifest.v1.json
+++ b/contracts/kai/voice-action-manifest.v1.json
@@ -20,7 +20,7 @@
         "path": "kai_command",
         "target": "home"
       },
-      "map_references": ["docs/voice-navigation-architecture-plan.md#3"]
+      "map_references": ["docs/reference/kai/kai-voice-runtime-architecture.md"]
     },
     {
       "id": "nav.kai_dashboard",
@@ -40,7 +40,7 @@
         "path": "kai_command",
         "target": "dashboard"
       },
-      "map_references": ["docs/voice-navigation-architecture-plan.md#3"]
+      "map_references": ["docs/reference/kai/kai-voice-runtime-architecture.md"]
     },
     {
       "id": "nav.kai_analysis",
@@ -80,7 +80,7 @@
         "path": "kai_command",
         "target": "history"
       },
-      "map_references": ["docs/voice-navigation-architecture-plan.md#3"]
+      "map_references": ["docs/reference/kai/kai-voice-runtime-architecture.md"]
     },
     {
       "id": "analysis.start",
@@ -103,7 +103,7 @@
           "requires_symbol": true
         }
       },
-      "map_references": ["docs/voice-navigation-architecture-plan.md#4"]
+      "map_references": ["docs/reference/kai/kai-voice-runtime-architecture.md"]
     },
     {
       "id": "analysis.resume_active",
@@ -123,7 +123,7 @@
         "path": "voice_tool",
         "target": "resume_active_analysis"
       },
-      "map_references": ["docs/voice-navigation-architecture-plan.md#4"]
+      "map_references": ["docs/reference/kai/kai-voice-runtime-architecture.md"]
     },
     {
       "id": "analysis.cancel_active",
@@ -147,7 +147,7 @@
         "path": "voice_tool",
         "target": "cancel_active_analysis"
       },
-      "map_references": ["docs/voice-navigation-architecture-plan.md#4"]
+      "map_references": ["docs/reference/kai/kai-voice-runtime-architecture.md"]
     },
     {
       "id": "nav.kai_import",
@@ -167,7 +167,7 @@
         "path": "kai_command",
         "target": "import"
       },
-      "map_references": ["docs/voice-navigation-architecture-plan.md#3"]
+      "map_references": ["docs/reference/kai/kai-voice-runtime-architecture.md"]
     },
     {
       "id": "nav.kai_investments",
@@ -229,7 +229,7 @@
         "path": "kai_command",
         "target": "consent"
       },
-      "map_references": ["docs/voice-navigation-architecture-plan.md#3"]
+      "map_references": ["docs/reference/kai/kai-voice-runtime-architecture.md"]
     },
     {
       "id": "nav.profile",
@@ -249,7 +249,7 @@
         "path": "kai_command",
         "target": "profile"
       },
-      "map_references": ["docs/voice-navigation-architecture-plan.md#3"]
+      "map_references": ["docs/reference/kai/kai-voice-runtime-architecture.md"]
     },
     {
       "id": "nav.profile_receipts",

--- a/docs/reference/kai/README.md
+++ b/docs/reference/kai/README.md
@@ -8,8 +8,10 @@ flowchart TD
   root["Kai Index"]
   n1["Kai Accuracy Contract"]
   root --> n1
-  n10["Kai Voice Assistant Architecture"]
+  n10["Kai Voice Runtime Architecture"]
   root --> n10
+  n11["Kai Voice Migration Audit"]
+  root --> n11
   n2["Kai Brokerage Connectivity Architecture"]
   root --> n2
   n3["Kai Change Impact Matrix"]
@@ -28,17 +30,21 @@ flowchart TD
   root --> n9
 ```
 
-Kai-specific architecture, runtime, and rollout references live here.
+Kai-specific architecture, runtime, rollout, and audit references live here.
 
 ## References
 
+- Canonical current-state references:
 - [kai-interconnection-map.md](./kai-interconnection-map.md): dependency map and upstream boundaries.
 - [kai-change-impact-matrix.md](./kai-change-impact-matrix.md): blast-radius guide for Kai changes.
-- [kai-voice-assistant-architecture.md](./kai-voice-assistant-architecture.md): current-state audit, implemented closed-loop voice architecture, migration notes, and remaining compatibility shims for the Kai in-app voice assistant.
+- [kai-voice-runtime-architecture.md](./kai-voice-runtime-architecture.md): canonical current runtime architecture for Kai voice, including planner, compose, execution, settlement, and manifest/file ownership.
 - [kai-brokerage-connectivity-architecture.md](./kai-brokerage-connectivity-architecture.md): brokerage and import architecture.
 - [kai-accuracy-contract.md](./kai-accuracy-contract.md): accuracy and output expectations.
 - [kai-route-audit-matrix.md](./kai-route-audit-matrix.md): route-level audit map.
 - [kai-runtime-smoke-checklist.md](./kai-runtime-smoke-checklist.md): runtime smoke checklist.
 - [kai-rate-limit-playbook.md](./kai-rate-limit-playbook.md): rate-limit handling.
 - [mobile-kai-parity-map.md](./mobile-kai-parity-map.md): mobile parity map.
-- [kai-v6-execution-plan.md](./kai-v6-execution-plan.md): currently tracked Kai execution plan.
+
+- Historical or plan references:
+- [kai-voice-assistant-architecture.md](./kai-voice-assistant-architecture.md): original migration/audit spec for the Kai voice redesign.
+- [kai-v6-execution-plan.md](./kai-v6-execution-plan.md): execution-plan artifact, not the source of truth for current runtime behavior.

--- a/docs/reference/kai/kai-route-audit-matrix.md
+++ b/docs/reference/kai/kai-route-audit-matrix.md
@@ -17,6 +17,11 @@ Operational matrix for runtime audits without expanding automated test suites.
 | `/kai/portfolio` | `GET` | Portfolio route reachable |
 | `/kai/analysis` | `GET` | Analysis route reachable |
 | `/kai/optimize` | `GET` | Optimize route reachable |
+| `/api/kai/voice/capability` | `GET` | Voice capability contract reachable and gated correctly for the current user/runtime |
+| `/api/kai/voice/plan` | `POST` | Voice planning contract reachable with canonical planner fields plus legacy response envelope |
+| `/api/kai/voice/compose` | `POST` | Post-execution voice composition contract reachable for final spoken reply generation |
+| `/api/kai/voice/stt` | `POST` | Voice STT contract reachable for non-realtime fallback paths |
+| `/api/kai/voice/tts` | `POST` | Voice TTS contract reachable for explicit synthesized playback |
 | `/api/kai/plaid/status/{user_id}` | `GET` | Plaid aggregate status and source metadata available |
 | `/api/kai/plaid/oauth/resume` | `POST` | OAuth resume session can mint a fresh Link continuation |
 | `/api/kai/plaid/exchange-public-token` | `POST` | Public-token exchange syncs read-only holdings + transactions |
@@ -50,3 +55,4 @@ In addition to route reachability, review these runtime behaviors:
 3. Cache-first `/kai` refresh behavior within fresh TTL windows.
 4. Onboarding chrome gating and command bar visibility during onboarding/import.
 5. Bottom chrome scroll hide/reveal behavior on mobile-sized viewports.
+6. Voice route family reachability, capability gating, and planner/compose contract health.

--- a/docs/reference/kai/kai-route-audit-matrix.md
+++ b/docs/reference/kai/kai-route-audit-matrix.md
@@ -17,7 +17,7 @@ Operational matrix for runtime audits without expanding automated test suites.
 | `/kai/portfolio` | `GET` | Portfolio route reachable |
 | `/kai/analysis` | `GET` | Analysis route reachable |
 | `/kai/optimize` | `GET` | Optimize route reachable |
-| `/api/kai/voice/capability` | `GET` | Voice capability contract reachable and gated correctly for the current user/runtime |
+| `/api/kai/voice/capability` | `POST` | Voice capability contract reachable and gated correctly for the current user/runtime |
 | `/api/kai/voice/plan` | `POST` | Voice planning contract reachable with canonical planner fields plus legacy response envelope |
 | `/api/kai/voice/compose` | `POST` | Post-execution voice composition contract reachable for final spoken reply generation |
 | `/api/kai/voice/stt` | `POST` | Voice STT contract reachable for non-realtime fallback paths |

--- a/docs/reference/kai/kai-runtime-smoke-checklist.md
+++ b/docs/reference/kai/kai-runtime-smoke-checklist.md
@@ -39,6 +39,29 @@ Runtime truth note:
    - `/kai/portfolio`
    - `/kai/analysis`
    - `/kai/optimize`
+ 4. Verify required voice routes are present and reachable in the protected API surface:
+   - `/api/kai/voice/capability`
+   - `/api/kai/voice/plan`
+   - `/api/kai/voice/compose`
+   - `/api/kai/voice/stt`
+   - `/api/kai/voice/tts`
+
+## 0a) Voice Runtime Sanity
+1. Open a signed-in Kai route where voice is eligible.
+2. Confirm voice capability reports enabled for the current user/runtime and that the mic surface can enter listening state.
+3. Run one `answer_now` turn such as:
+   - `Who are you?`
+4. Run one `execute_and_wait` turn such as:
+   - `Take me to my profile.`
+5. Run one post-navigation explanation turn such as:
+   - `Open Gmail and tell me what I can do here.`
+6. Run one `start_background_and_ack` turn such as:
+   - `Analyze Nvidia.`
+7. Confirm:
+   - planner/dispatch/tts stages progress without a generic `stt_unusable` fallback,
+   - successful navigation waits for route/screen settlement before final speech,
+   - analysis start responds with an acknowledgement rather than a fake completion claim,
+   - final spoken text comes from the post-execution compose path or the explicit deterministic fallback.
 
 ## 1) Fresh User Import Flow
 1. Sign in with a user that has no `financial` domain.

--- a/docs/reference/kai/kai-v6-execution-plan.md
+++ b/docs/reference/kai/kai-v6-execution-plan.md
@@ -5,6 +5,11 @@
 
 Canonical visual owner: [Kai Index](README.md). Use that map for the top-down system view; this page is the narrower detail beneath it.
 
+Plan status note:
+
+- This file is an execution-plan artifact, not the source of truth for current Kai runtime behavior.
+- For the live Kai voice/runtime implementation, use [kai-voice-runtime-architecture.md](./kai-voice-runtime-architecture.md).
+
 ## Objective
 Deliver a production-grade Kai experience where dashboard, analysis, and optimization are strictly based on validated realtime + filing-backed evidence, with no speculative fallback in decision-critical flows.
 

--- a/docs/reference/kai/kai-voice-assistant-architecture.md
+++ b/docs/reference/kai/kai-voice-assistant-architecture.md
@@ -19,6 +19,11 @@ flowchart LR
 
 Status: implemented through Phase 4 for the Kai app's in-app voice assistant, with a small set of explicit compatibility shims still gated for migration safety.
 
+Current-state note:
+
+- This document is the original migration/audit spec for the Kai voice redesign.
+- For the current checked-in runtime architecture, use [kai-voice-runtime-architecture.md](./kai-voice-runtime-architecture.md).
+
 ## Phase 4 Status
 
 The closed-loop Kai voice runtime described in this document is now the default architecture in the checked-in codebase:

--- a/docs/reference/kai/kai-voice-runtime-architecture.md
+++ b/docs/reference/kai/kai-voice-runtime-architecture.md
@@ -1,0 +1,347 @@
+# Kai Voice Runtime Architecture
+
+## Visual Map
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant FE as Frontend voice runtime
+  participant Plan as /voice/plan
+  participant Exec as Frontend executor
+  participant Compose as /voice/compose
+  participant TTS as TTS path
+
+  User->>FE: Speak
+  FE->>FE: Build structured screen context
+  FE->>Plan: transcript + runtime state + context
+  Plan-->>FE: response envelope + canonical plan
+  FE->>Exec: execute canonical action_id
+  Exec-->>FE: VoiceActionResult
+  FE->>Compose: transcript + plan + response + action_result + post-action context
+  Compose-->>FE: final spoken text
+  FE->>TTS: speak final text
+```
+
+Status: canonical current-state reference for the Kai app's in-app voice assistant.
+
+## Purpose
+
+This document describes how the Kai voice runtime works in the checked-in codebase today.
+
+Product truth:
+
+- Kai is the app.
+- The voice assistant lives inside Kai.
+- The assistant should speak as Kai's in-app voice interface, not as a generic external assistant.
+
+Use this file as the maintained architecture reference. The older [kai-voice-assistant-architecture.md](./kai-voice-assistant-architecture.md) remains useful as the original migration/audit document, but it is no longer the best source for current runtime behavior.
+
+## Source Of Truth
+
+The maintained voice implementation is spread across these canonical surfaces:
+
+- Shared semantic manifest: [contracts/kai/voice-action-manifest.v1.json](../../../contracts/kai/voice-action-manifest.v1.json)
+- Frontend registry and loaders:
+  - [hushh-webapp/lib/voice/investor-kai-action-registry.ts](../../../hushh-webapp/lib/voice/investor-kai-action-registry.ts)
+  - [hushh-webapp/lib/voice/voice-action-manifest.ts](../../../hushh-webapp/lib/voice/voice-action-manifest.ts)
+- Frontend runtime:
+  - [hushh-webapp/lib/voice/voice-turn-orchestrator.ts](../../../hushh-webapp/lib/voice/voice-turn-orchestrator.ts)
+  - [hushh-webapp/lib/voice/voice-grounding.ts](../../../hushh-webapp/lib/voice/voice-grounding.ts)
+  - [hushh-webapp/lib/voice/voice-response-executor.ts](../../../hushh-webapp/lib/voice/voice-response-executor.ts)
+  - [hushh-webapp/lib/voice/voice-action-dispatcher.ts](../../../hushh-webapp/lib/voice/voice-action-dispatcher.ts)
+  - [hushh-webapp/lib/voice/voice-action-settlement.ts](../../../hushh-webapp/lib/voice/voice-action-settlement.ts)
+  - [hushh-webapp/lib/voice/voice-response-composer.ts](../../../hushh-webapp/lib/voice/voice-response-composer.ts)
+  - [hushh-webapp/lib/kai/command-executor.ts](../../../hushh-webapp/lib/kai/command-executor.ts)
+- Frontend context and UI entrypoints:
+  - [hushh-webapp/lib/voice/screen-context-builder.ts](../../../hushh-webapp/lib/voice/screen-context-builder.ts)
+  - [hushh-webapp/lib/voice/voice-surface-metadata.ts](../../../hushh-webapp/lib/voice/voice-surface-metadata.ts)
+  - [hushh-webapp/components/kai/kai-command-bar-global.tsx](../../../hushh-webapp/components/kai/kai-command-bar-global.tsx)
+  - [hushh-webapp/components/kai/kai-search-bar.tsx](../../../hushh-webapp/components/kai/kai-search-bar.tsx)
+- Backend runtime:
+  - [consent-protocol/api/routes/kai/voice.py](../../../consent-protocol/api/routes/kai/voice.py)
+  - [consent-protocol/hushh_mcp/services/voice_intent_service.py](../../../consent-protocol/hushh_mcp/services/voice_intent_service.py)
+  - [consent-protocol/hushh_mcp/services/voice_prompt_builder.py](../../../consent-protocol/hushh_mcp/services/voice_prompt_builder.py)
+  - [consent-protocol/hushh_mcp/services/voice_action_manifest.py](../../../consent-protocol/hushh_mcp/services/voice_action_manifest.py)
+  - [consent-protocol/hushh_mcp/services/voice_app_knowledge.py](../../../consent-protocol/hushh_mcp/services/voice_app_knowledge.py)
+
+## Runtime Flow
+
+The current runtime is a closed-loop hybrid flow:
+
+1. Speech enters the frontend voice runtime.
+2. The frontend builds live route, screen, runtime, auth, vault, and surface metadata context.
+3. The frontend calls `/voice/plan`.
+4. The backend planner returns both:
+   - a legacy-compatible response envelope
+   - canonical planner fields such as `mode`, `action_id`, `slots`, `guards`, and `reply_strategy`
+5. The frontend grounds and executes the canonical plan.
+6. The executor emits a typed `VoiceActionResult`.
+7. The frontend rebuilds post-action screen context.
+8. When the plan requests LLM-backed final speech, the frontend calls `/voice/compose`.
+9. The composed or fallback text is spoken through the active TTS path.
+
+The canonical plan modes are:
+
+- `answer_now`
+- `execute_and_wait`
+- `start_background_and_ack`
+- `clarify`
+
+## Backend Architecture
+
+### Prompt and identity layers
+
+The backend uses layered prompt/context construction instead of one inline prompt string.
+
+- [voice_prompt_builder.py](../../../consent-protocol/hushh_mcp/services/voice_prompt_builder.py) builds shared planner/composer context
+- [voice_app_knowledge.py](../../../consent-protocol/hushh_mcp/services/voice_app_knowledge.py) provides Kai identity, PKM/Gmail/receipt concepts, and global knowledge summaries
+- [voice_action_manifest.py](../../../consent-protocol/hushh_mcp/services/voice_action_manifest.py) loads the shared semantic action data used by prompt selection
+
+Planner context currently includes:
+
+- Kai role summary and guardrails
+- relevant manifest actions for the current screen and transcript
+- runtime state
+- global concept summaries
+
+Composer context reuses the same layers and adds:
+
+- transcript
+- canonical plan payload
+- response payload
+- observed `action_result`
+
+### Planning and response normalization
+
+[voice_intent_service.py](../../../consent-protocol/hushh_mcp/services/voice_intent_service.py) owns:
+
+- realtime/STT/TTS upstream calls
+- deterministic fast paths
+- LLM planning
+- tool-call validation
+- canonical-plan normalization
+- post-execution response composition
+
+Important current behavior:
+
+- deterministic fast paths still exist for low-latency explain/status/navigation turns
+- the LLM still plans through a tool-call schema, then canonical fields are normalized afterward
+- canonical plan data is first-class in the current route contract
+- legacy response fields are still dual-written for compatibility
+
+### Routes
+
+[voice.py](../../../consent-protocol/api/routes/kai/voice.py) exposes multiple voice surfaces. The main runtime routes are:
+
+- `/voice/plan`
+- `/voice/compose`
+- `/voice/tts`
+- `/voice/stt`
+- `/voice/realtime/session`
+- `/voice/capability`
+
+`/voice/plan` is the main planning transport and still preserves rollout, canary, and kill-switch behavior.
+
+`/voice/compose` is the post-execution response-composition transport. It receives:
+
+- transcript
+- response envelope
+- canonical plan fields
+- `action_result`
+- runtime state
+- structured screen context after execution
+
+and calls `compose_voice_reply(...)` in [voice_intent_service.py](../../../consent-protocol/hushh_mcp/services/voice_intent_service.py).
+
+## Frontend Architecture
+
+### Context building
+
+The frontend creates the structured voice context from:
+
+- route state
+- current screen identity
+- surface metadata
+- visible controls/actions
+- auth/vault/runtime state
+- short-term and retrieved memory when available
+
+Key files:
+
+- [screen-context-builder.ts](../../../hushh-webapp/lib/voice/screen-context-builder.ts)
+- [voice-surface-metadata.ts](../../../hushh-webapp/lib/voice/voice-surface-metadata.ts)
+- [kai-command-bar-global.tsx](../../../hushh-webapp/components/kai/kai-command-bar-global.tsx)
+- [kai-search-bar.tsx](../../../hushh-webapp/components/kai/kai-search-bar.tsx)
+
+### Grounding and execution
+
+The normal execution path is canonical-plan first:
+
+- [voice-grounding.ts](../../../hushh-webapp/lib/voice/voice-grounding.ts) prefers planner-provided `action_id`
+- transcript heuristics remain only as compatibility fallback
+- [voice-response-executor.ts](../../../hushh-webapp/lib/voice/voice-response-executor.ts) and [voice-action-dispatcher.ts](../../../hushh-webapp/lib/voice/voice-action-dispatcher.ts) execute the grounded action
+- [command-executor.ts](../../../hushh-webapp/lib/kai/command-executor.ts) returns typed execution outcomes
+
+### Settlement and final speech
+
+[voice-action-settlement.ts](../../../hushh-webapp/lib/voice/voice-action-settlement.ts) waits for:
+
+- route change
+- expected screen identity
+- meaningful surface metadata
+
+before a navigation turn is treated as settled.
+
+[voice-turn-orchestrator.ts](../../../hushh-webapp/lib/voice/voice-turn-orchestrator.ts) then:
+
+1. dispatches the action
+2. captures `VoiceActionResult`
+3. rebuilds post-action context
+4. calls `/voice/compose` when `reply_strategy === "llm"`
+5. falls back to [voice-response-composer.ts](../../../hushh-webapp/lib/voice/voice-response-composer.ts) only when needed
+
+The important correction from the older architecture is that the normal path is now `plan -> execute -> observe -> compose -> speak`.
+
+## Shared Manifest And Contracts
+
+### Shared semantic manifest
+
+The shared source of truth for canonical actions is [contracts/kai/voice-action-manifest.v1.json](../../../contracts/kai/voice-action-manifest.v1.json).
+
+It is consumed by:
+
+- backend loader: [voice_action_manifest.py](../../../consent-protocol/hushh_mcp/services/voice_action_manifest.py)
+- frontend loader: [voice-action-manifest.ts](../../../hushh-webapp/lib/voice/voice-action-manifest.ts)
+
+The frontend registry still owns the richer runtime wiring and UI-oriented semantics. The JSON manifest is the shared semantic contract, not the entire runtime binding surface.
+
+### Canonical plan fields
+
+The current frontend/backend contract recognizes:
+
+- `schema_version`
+- `mode`
+- `action_id`
+- `slots`
+- `guards`
+- `reply_strategy`
+- `clarification`
+- `action_completion`
+
+Types live in [voice-types.ts](../../../hushh-webapp/lib/voice/voice-types.ts). Validation lives in [voice-json-validator.ts](../../../hushh-webapp/lib/voice/voice-json-validator.ts).
+
+### VoiceActionResult
+
+The current typed observed result includes:
+
+- `status`
+- `action_id`
+- `route_before`
+- `route_after`
+- `screen_before`
+- `screen_after`
+- `settled_by`
+- `result_summary`
+- optional structured `data`
+
+This is the contract shared by the backend composer path and the deterministic fallback composer.
+
+## Voice Navigation And Analysis Surfaces
+
+The primary navigation and analysis actions are defined in:
+
+- [investor-kai-action-registry.ts](../../../hushh-webapp/lib/voice/investor-kai-action-registry.ts)
+- [contracts/kai/voice-action-manifest.v1.json](../../../contracts/kai/voice-action-manifest.v1.json)
+
+Important current voice surfaces include:
+
+- Kai home / market
+- portfolio dashboard
+- analysis workspace
+- analysis history
+- import
+- profile
+- Gmail receipts
+- PKM / PKM Agent Lab
+- consent center
+
+Important analysis actions include:
+
+- `analysis.start`
+- `analysis.resume_active`
+- `analysis.cancel_active`
+
+## Observability And Debugging
+
+Current voice debugging spans both frontend and backend.
+
+Backend:
+
+- `/voice/plan` tracing and latency metrics
+- `/voice/compose` tracing and latency metrics
+- rollout/canary/kill-switch decisions in the route layer
+
+Frontend:
+
+- `stt`
+- `planner`
+- `dispatch`
+- `tts`
+- `ui_fsm`
+
+These stage names line up with the current voice debug overlay and recent-event payloads.
+
+## Remaining Compatibility Shims
+
+The current runtime is implemented, but a few compatibility shims remain intentional:
+
+- backend still dual-writes legacy response fields such as `kind`, `message`, and `tool_call`
+- rollout/kill-switch logic can still downgrade execution-capable turns to `speak_only`
+- `resolveGroundedVoicePlan(... allowCompatibilityFallback)` still exists for planner payloads that omit `action_id`
+- `executeVoiceResponse(... allowSpeakOnlyCompatibilityFallback)` still exists as an opt-in escape hatch, default off
+- deterministic fast paths still coexist with the LLM planner for latency-sensitive turns
+
+These are compatibility measures, not the main architecture.
+
+## Known Drift To Watch
+
+The main documentation/code drift found during this refresh:
+
+- some in-code `mapReferences` still pointed at a deleted historical voice-navigation planning doc
+- the older migration/audit doc still described several pre-implementation problems as if they were current state
+- `/voice/understand` remains a legacy combined surface and does not expose the richest canonical route contract
+- screen identifiers still drift across route derivation, command execution, surface publishers, and manifest expectations, which can cause settlement to fall back to timeout on otherwise successful navigations
+- some surface-published action IDs are still freer-form than the central registry, so action availability context is not yet perfectly canonical
+
+## Maintainer Checklist
+
+When changing Kai voice behavior:
+
+1. update the frontend registry and the shared manifest together
+2. keep backend route contracts, frontend types, and validators aligned
+3. update this document when the canonical runtime flow or shared contract changes
+4. update the historical audit doc only when its migration notes need correction, not as the main runtime source
+
+## Verification
+
+Minimum verification for docs-only changes:
+
+```bash
+./bin/hushh docs verify
+python3 .codex/skills/docs-governance/scripts/doc_inventory.py tier-a
+```
+
+If the shared manifest or voice registry changes, also run:
+
+```bash
+cd hushh-webapp && npm test -- __tests__/voice/voice-action-manifest.test.ts __tests__/voice/investor-kai-action-registry.test.ts
+```
+
+If backend voice routes or planner/composer contracts change, also run the focused backend voice suites.
+
+## Related References
+
+- [kai-voice-assistant-architecture.md](./kai-voice-assistant-architecture.md)
+- [kai-route-audit-matrix.md](./kai-route-audit-matrix.md)
+- [kai-runtime-smoke-checklist.md](./kai-runtime-smoke-checklist.md)
+- [env-and-secrets.md](../operations/env-and-secrets.md)

--- a/docs/reference/kai/kai-voice-runtime-architecture.md
+++ b/docs/reference/kai/kai-voice-runtime-architecture.md
@@ -138,7 +138,7 @@ Important current behavior:
 - `/voice/tts`
 - `/voice/stt`
 - `/voice/realtime/session`
-- `/voice/capability`
+- `/voice/capability` (`POST`)
 
 `/voice/plan` is the main planning transport and still preserves rollout, canary, and kill-switch behavior.
 

--- a/docs/vision/kai/README.md
+++ b/docs/vision/kai/README.md
@@ -14,6 +14,12 @@ flowchart TD
 
 Forward-looking Kai roadmap and R&D planning now belong under [../../future/kai/README.md](../../future/kai/README.md). `docs/vision/kai/` stays north-star oriented; speculative execution-model docs should not start here.
 
+Current implementation note:
+
+- This vision document is not the source of truth for the shipped Kai runtime.
+- For the live Kai voice/runtime architecture, use [../../reference/kai/kai-voice-runtime-architecture.md](../../reference/kai/kai-voice-runtime-architecture.md).
+- For on-device AI status, use [../../reference/ai/on-device-future-plan/README.md](../../reference/ai/on-device-future-plan/README.md); cloud remains the current primary runtime path.
+
 ---
 
 <p align="center">

--- a/hushh-webapp/docs/README.md
+++ b/hushh-webapp/docs/README.md
@@ -37,5 +37,6 @@ This docs home is package-local. It should stay focused on frontend/native imple
 ## Related References
 
 - Cross-cutting docs entry: [`docs/README.md`](../../docs/README.md)
+- Kai voice runtime architecture: [`docs/reference/kai/kai-voice-runtime-architecture.md`](../../docs/reference/kai/kai-voice-runtime-architecture.md)
 - Documentation homes map: [`docs/reference/operations/documentation-architecture-map.md`](../../docs/reference/operations/documentation-architecture-map.md)
 - Backend docs entry: [`consent-protocol/docs/README.md`](../../consent-protocol/docs/README.md)

--- a/hushh-webapp/lib/voice/investor-kai-action-registry.ts
+++ b/hushh-webapp/lib/voice/investor-kai-action-registry.ts
@@ -156,7 +156,7 @@ export const INVESTOR_KAI_ACTION_REGISTRY: readonly InvestorKaiActionDefinition[
         command: "home",
       },
     },
-    mapReferences: ["docs/voice-navigation-architecture-plan.md#3"],
+    mapReferences: ["docs/reference/kai/kai-voice-runtime-architecture.md"],
   },
   {
     id: "nav.kai_dashboard",
@@ -189,7 +189,7 @@ export const INVESTOR_KAI_ACTION_REGISTRY: readonly InvestorKaiActionDefinition[
         command: "dashboard",
       },
     },
-    mapReferences: ["docs/voice-navigation-architecture-plan.md#3"],
+    mapReferences: ["docs/reference/kai/kai-voice-runtime-architecture.md"],
   },
   {
     id: "nav.kai_analysis",
@@ -255,7 +255,7 @@ export const INVESTOR_KAI_ACTION_REGISTRY: readonly InvestorKaiActionDefinition[
         command: "history",
       },
     },
-    mapReferences: ["docs/voice-navigation-architecture-plan.md#3"],
+    mapReferences: ["docs/reference/kai/kai-voice-runtime-architecture.md"],
   },
   {
     id: "analysis.start",
@@ -299,7 +299,7 @@ export const INVESTOR_KAI_ACTION_REGISTRY: readonly InvestorKaiActionDefinition[
         },
       },
     },
-    mapReferences: ["docs/voice-navigation-architecture-plan.md#4"],
+    mapReferences: ["docs/reference/kai/kai-voice-runtime-architecture.md"],
   },
   {
     id: "analysis.resume_active",
@@ -341,7 +341,7 @@ export const INVESTOR_KAI_ACTION_REGISTRY: readonly InvestorKaiActionDefinition[
         toolName: "resume_active_analysis",
       },
     },
-    mapReferences: ["docs/voice-navigation-architecture-plan.md#4"],
+    mapReferences: ["docs/reference/kai/kai-voice-runtime-architecture.md"],
   },
   {
     id: "analysis.cancel_active",
@@ -391,7 +391,7 @@ export const INVESTOR_KAI_ACTION_REGISTRY: readonly InvestorKaiActionDefinition[
         toolName: "cancel_active_analysis",
       },
     },
-    mapReferences: ["docs/voice-navigation-architecture-plan.md#4"],
+    mapReferences: ["docs/reference/kai/kai-voice-runtime-architecture.md"],
   },
   {
     id: "nav.kai_import",
@@ -424,7 +424,7 @@ export const INVESTOR_KAI_ACTION_REGISTRY: readonly InvestorKaiActionDefinition[
         command: "import",
       },
     },
-    mapReferences: ["docs/voice-navigation-architecture-plan.md#3"],
+    mapReferences: ["docs/reference/kai/kai-voice-runtime-architecture.md"],
   },
   {
     id: "nav.kai_investments",
@@ -528,7 +528,7 @@ export const INVESTOR_KAI_ACTION_REGISTRY: readonly InvestorKaiActionDefinition[
         command: "consent",
       },
     },
-    mapReferences: ["docs/voice-navigation-architecture-plan.md#3"],
+    mapReferences: ["docs/reference/kai/kai-voice-runtime-architecture.md"],
   },
   {
     id: "nav.profile",
@@ -561,7 +561,7 @@ export const INVESTOR_KAI_ACTION_REGISTRY: readonly InvestorKaiActionDefinition[
         command: "profile",
       },
     },
-    mapReferences: ["docs/voice-navigation-architecture-plan.md#3"],
+    mapReferences: ["docs/reference/kai/kai-voice-runtime-architecture.md"],
   },
   {
     id: "nav.profile_receipts",


### PR DESCRIPTION
## Summary
- add a canonical Kai voice runtime architecture reference and route/runtime smoke guidance
- reclassify older Kai voice docs as migration or planning artifacts instead of current runtime truth
- retarget package and manifest/action-registry references away from the removed legacy voice navigation plan doc

## Verification
- ./bin/hushh docs verify
- python3 .codex/skills/docs-governance/scripts/doc_inventory.py tier-a
- cd hushh-webapp && npm test -- __tests__/voice/voice-action-manifest.test.ts __tests__/voice/investor-kai-action-registry.test.ts
- cd hushh-webapp && npm run verify:docs
- bash scripts/ci/orchestrate.sh governance
- GH_TOKEN=*** ./bin/hushh ci
