### PR TITLE
fix(auth): standardize token validation to validate_token_with_db across routes

### DIFF
--- a/consent-protocol/api/routes/consent.py
+++ b/consent-protocol/api/routes/consent.py
@@ -24,7 +24,7 @@ from api.utils.firebase_auth import verify_firebase_bearer
 from db.db_client import DatabaseExecutionError
 from hushh_mcp.consent.scope_helpers import get_scope_description as get_dynamic_scope_description
 from hushh_mcp.consent.scope_helpers import resolve_scope_to_enum
-from hushh_mcp.consent.token import issue_token, revoke_token, validate_token
+from hushh_mcp.consent.token import issue_token, revoke_token, validate_token, validate_token_with_db
 from hushh_mcp.constants import ConsentScope
 from hushh_mcp.services.actor_identity_service import ActorIdentityService
 from hushh_mcp.services.consent_center_service import ConsentCenterService
@@ -795,7 +795,7 @@ async def issue_vault_owner_token(request: Request):
                         logger.warning("vault_owner.reuse_missing_token_id")
                         break
 
-                    is_valid, reason, payload = validate_token(
+                    is_valid, reason, payload = await validate_token_with_db(
                         candidate_token, ConsentScope.VAULT_OWNER
                     )
                     if not is_valid or not payload:
@@ -968,11 +968,15 @@ async def get_consent_export_data(consent_token: str):
     """
     logger.info("consent.export_requested")
 
-    # Validate the consent token
-    valid, reason, token_obj = validate_token(consent_token)
+    # Validate the consent token — DB-backed revocation check.
+    valid, reason, token_obj = await validate_token_with_db(consent_token)
     if not valid:
         logger.warning("consent.export_invalid_token reason=%s", reason)
-        raise HTTPException(status_code=401, detail="Invalid token")
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
     # Try in-memory cache first (fast path)
     if consent_token in _consent_exports:
@@ -1089,11 +1093,12 @@ async def upload_refreshed_export(
     if token_data["user_id"] != request.userId:
         raise HTTPException(status_code=403, detail="User ID does not match authenticated user")
 
-    valid, reason, token_obj = validate_token(request.consentToken)
+    valid, reason, token_obj = await validate_token_with_db(request.consentToken)
     if not valid or token_obj is None:
         raise HTTPException(
             status_code=401,
             detail=f"Invalid consent token for export refresh: {reason or 'unknown'}",
+            headers={"WWW-Authenticate": "Bearer"},
         )
     if str(token_obj.user_id) != request.userId:
         raise HTTPException(status_code=403, detail="Consent token user mismatch")

--- a/consent-protocol/api/routes/consent.py
+++ b/consent-protocol/api/routes/consent.py
@@ -24,7 +24,7 @@ from api.utils.firebase_auth import verify_firebase_bearer
 from db.db_client import DatabaseExecutionError
 from hushh_mcp.consent.scope_helpers import get_scope_description as get_dynamic_scope_description
 from hushh_mcp.consent.scope_helpers import resolve_scope_to_enum
-from hushh_mcp.consent.token import issue_token, revoke_token, validate_token, validate_token_with_db
+from hushh_mcp.consent.token import issue_token, revoke_token, validate_token_with_db
 from hushh_mcp.constants import ConsentScope
 from hushh_mcp.services.actor_identity_service import ActorIdentityService
 from hushh_mcp.services.consent_center_service import ConsentCenterService

--- a/consent-protocol/api/routes/db_proxy.py
+++ b/consent-protocol/api/routes/db_proxy.py
@@ -602,9 +602,7 @@ async def validate_vault_owner_token(consent_token: str, user_id: str) -> None:
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    valid, reason, token_obj = await validate_token_with_db(
-        consent_token, ConsentScope.VAULT_OWNER
-    )
+    valid, reason, token_obj = await validate_token_with_db(consent_token, ConsentScope.VAULT_OWNER)
 
     if not valid:
         logger.warning(f"Invalid consent token: {reason}")

--- a/consent-protocol/api/routes/db_proxy.py
+++ b/consent-protocol/api/routes/db_proxy.py
@@ -26,7 +26,7 @@ from pydantic import BaseModel
 from api.middleware import require_firebase_auth, verify_user_id_match
 from db.connection import DatabaseUnavailableError
 from db.db_client import DatabaseExecutionError
-from hushh_mcp.consent.token import validate_token
+from hushh_mcp.consent.token import validate_token_with_db
 from hushh_mcp.constants import ConsentScope
 from hushh_mcp.services.vault_keys_service import VaultKeysService
 
@@ -593,23 +593,34 @@ async def vault_integrity(
 # ============================================================================
 
 
-def validate_vault_owner_token(consent_token: str, user_id: str) -> None:
-    """Validate VAULT_OWNER consent token."""
+async def validate_vault_owner_token(consent_token: str, user_id: str) -> None:
+    """Validate VAULT_OWNER consent token with DB-backed revocation check."""
     if not consent_token:
         raise HTTPException(
             status_code=401,
             detail="Missing consent token. Vault owner must provide VAULT_OWNER token.",
+            headers={"WWW-Authenticate": "Bearer"},
         )
 
-    valid, reason, token_obj = validate_token(consent_token)
+    valid, reason, token_obj = await validate_token_with_db(
+        consent_token, ConsentScope.VAULT_OWNER
+    )
 
     if not valid:
         logger.warning(f"Invalid consent token: {reason}")
-        raise HTTPException(status_code=401, detail=f"Invalid consent token: {reason}")
+        raise HTTPException(
+            status_code=401,
+            detail=f"Invalid consent token: {reason}",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
     if token_obj is None:
         logger.error("Consent token validated but payload missing")
-        raise HTTPException(status_code=401, detail="Invalid consent token: missing token payload")
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid consent token: missing token payload",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
     if token_obj.scope != ConsentScope.VAULT_OWNER:
         logger.warning(
@@ -651,6 +662,7 @@ async def get_vault_status(
 
         # Use VaultKeysService (handles consent validation internally)
         service = VaultKeysService()
+        await validate_vault_owner_token(consent_token, user_id)
         status = await service.get_vault_status(user_id, consent_token)
 
         return status

--- a/consent-protocol/api/routes/session.py
+++ b/consent-protocol/api/routes/session.py
@@ -7,8 +7,9 @@ import logging
 import os
 from typing import Any, Optional
 
-from fastapi import APIRouter, Header, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException
 
+from api.middleware import require_vault_owner_token
 from api.models import LogoutRequest, SessionTokenRequest, SessionTokenResponse
 from api.utils.firebase_admin import get_firebase_auth_app
 from api.utils.firebase_auth import verify_firebase_bearer
@@ -111,27 +112,17 @@ async def get_consent_history(
     userId: str,
     page: int = 1,
     limit: int = 50,
-    authorization: str = Header(..., description="Bearer VAULT_OWNER consent token"),
+    token_data: dict = Depends(require_vault_owner_token),
 ):
     """
     Get paginated consent audit history for a user.
 
-    REQUIRES: VAULT_OWNER consent token.
+    REQUIRES: VAULT_OWNER consent token (via Authorization header).
     Returns all consent actions grouped by app for the Audit Log tab.
     Uses database via consent_db module for persistence.
     """
-    # Validate VAULT_OWNER token
-    from hushh_mcp.consent.token import validate_token
-    from hushh_mcp.constants import ConsentScope
-
-    if not authorization.startswith("Bearer "):
-        raise HTTPException(status_code=401, detail="Missing consent token")
-    token = authorization.replace("Bearer ", "")
-    valid, reason, payload = validate_token(token, ConsentScope.VAULT_OWNER)
-    if not valid or not payload:
-        _ = reason
-        raise HTTPException(status_code=401, detail="Invalid token")
-    if payload.user_id != userId:
+    # Canonical guard: DB-backed revocation, safe extraction, RFC-7235 headers.
+    if str(token_data["user_id"]) != userId:
         raise HTTPException(status_code=403, detail="Token user mismatch")
 
     logger.info("consent_history.fetch page=%s", page)
@@ -172,27 +163,18 @@ async def get_consent_history(
 
 @router.get("/consent/active")
 async def get_active_consents(
-    userId: str, authorization: str = Header(..., description="Bearer VAULT_OWNER consent token")
+    userId: str,
+    token_data: dict = Depends(require_vault_owner_token),
 ):
     """
     Get active (non-expired) consent tokens for a user.
 
-    REQUIRES: VAULT_OWNER consent token.
+    REQUIRES: VAULT_OWNER consent token (via Authorization header).
     Returns consents grouped by app for the Session tab.
     Uses database via consent_db module for persistence.
     """
-    # Validate VAULT_OWNER token
-    from hushh_mcp.consent.token import validate_token
-    from hushh_mcp.constants import ConsentScope
-
-    if not authorization.startswith("Bearer "):
-        raise HTTPException(status_code=401, detail="Missing consent token")
-    token = authorization.replace("Bearer ", "")
-    valid, reason, payload = validate_token(token, ConsentScope.VAULT_OWNER)
-    if not valid or not payload:
-        _ = reason
-        raise HTTPException(status_code=401, detail="Invalid token")
-    if payload.user_id != userId:
+    # Canonical guard: DB-backed revocation, safe extraction, RFC-7235 headers.
+    if str(token_data["user_id"]) != userId:
         raise HTTPException(status_code=403, detail="Token user mismatch")
 
     logger.info("consent_active.fetch")

--- a/consent-protocol/tests/test_consent_handshake.py
+++ b/consent-protocol/tests/test_consent_handshake.py
@@ -317,16 +317,17 @@ def test_no_data_access_before_approved_consent(monkeypatch):
     """
     Core invariant: consent/data endpoint rejects requests with no valid token.
     """
-    monkeypatch.setattr(
-        consent,
-        "validate_token",
-        lambda token_str, expected_scope=None: (False, "Token has been revoked", None),
-    )
+
+    async def mock_validate_token_with_db(token_str, expected_scope=None):
+        return (False, "Token has been revoked", None)
+
+    monkeypatch.setattr(consent, "validate_token_with_db", mock_validate_token_with_db)
 
     app = _build_app()
     client = TestClient(app)
     resp = client.get("/api/consent/data", params={"consent_token": "bad_token"})
     assert resp.status_code == 401
+    assert resp.headers.get("WWW-Authenticate") == "Bearer"
     assert "Invalid token" in resp.json()["detail"]
 
 
@@ -338,7 +339,7 @@ def test_revoke_immediately_invalidates_data_access(monkeypatch):
     def mock_revoke(t):
         revoked_tokens.add(t)
 
-    def mock_validate(token_str, expected_scope=None):
+    async def mock_validate_token_with_db(token_str, expected_scope=None):
         if token_str in revoked_tokens:
             return (False, "Token has been revoked", None)
         return (
@@ -356,7 +357,7 @@ def test_revoke_immediately_invalidates_data_access(monkeypatch):
     monkeypatch.setattr(consent, "ConsentDBService", lambda: fake_db)
     monkeypatch.setattr(consent, "revoke_token", mock_revoke)
     monkeypatch.setattr(token_module, "revoke_token", mock_revoke)  # Patch the source module too
-    monkeypatch.setattr(consent, "validate_token", mock_validate)
+    monkeypatch.setattr(consent, "validate_token_with_db", mock_validate_token_with_db)
     monkeypatch.setattr(consent, "RIAIAMService", _NoOpRIAIAMService)
 
     token_id = "token_to_revoke"  # noqa: S105

--- a/consent-protocol/tests/test_db_proxy_vault_owner_token.py
+++ b/consent-protocol/tests/test_db_proxy_vault_owner_token.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes import db_proxy
+from hushh_mcp.constants import ConsentScope
+
+
+@pytest.mark.asyncio
+async def test_validate_vault_owner_token_uses_db_backed_validation(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def _validate_token_with_db(token: str, scope: ConsentScope):
+        captured["token"] = token
+        captured["scope"] = scope
+        return (
+            True,
+            None,
+            SimpleNamespace(user_id="user_123", scope=ConsentScope.VAULT_OWNER),
+        )
+
+    monkeypatch.setattr(db_proxy, "validate_token_with_db", _validate_token_with_db)
+
+    await db_proxy.validate_vault_owner_token("consent-token", "user_123")
+
+    assert captured == {
+        "token": "consent-token",
+        "scope": ConsentScope.VAULT_OWNER,
+    }
+
+
+@pytest.mark.asyncio
+async def test_validate_vault_owner_token_invalid_token_returns_401(monkeypatch):
+    async def _validate_token_with_db(token: str, scope: ConsentScope):
+        return (False, "revoked", None)
+
+    monkeypatch.setattr(db_proxy, "validate_token_with_db", _validate_token_with_db)
+
+    with pytest.raises(HTTPException) as exc:
+        await db_proxy.validate_vault_owner_token("revoked-token", "user_123")
+
+    assert exc.value.status_code == 401
+    assert exc.value.headers == {"WWW-Authenticate": "Bearer"}
+    assert "revoked" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_validate_vault_owner_token_user_mismatch_returns_403(monkeypatch):
+    async def _validate_token_with_db(token: str, scope: ConsentScope):
+        return (
+            True,
+            None,
+            SimpleNamespace(user_id="other_user", scope=ConsentScope.VAULT_OWNER),
+        )
+
+    monkeypatch.setattr(db_proxy, "validate_token_with_db", _validate_token_with_db)
+
+    with pytest.raises(HTTPException) as exc:
+        await db_proxy.validate_vault_owner_token("consent-token", "user_123")
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "Token userId does not match requested userId"

--- a/consent-protocol/tests/test_session_issue_token.py
+++ b/consent-protocol/tests/test_session_issue_token.py
@@ -62,3 +62,81 @@ def test_issue_session_token_unexpected_verifier_failure_returns_500(monkeypatch
 
     assert response.status_code == 500
     assert response.json()["detail"] == "Internal server error"
+
+
+class _FakeConsentDBService:
+    async def get_audit_log(self, user_id: str, page: int, limit: int):
+        assert user_id == "user_123"
+        assert page == 2
+        assert limit == 10
+        return {
+            "page": page,
+            "limit": limit,
+            "total": 1,
+            "items": [{"agent_id": "agent_a", "action": "GRANTED"}],
+        }
+
+    async def get_active_tokens(self, user_id: str):
+        assert user_id == "user_123"
+        return [
+            {
+                "developer": "developer:test_app",
+                "scope": "vault.owner",
+                "id": "tok_123",
+                "issued_at": 1,
+                "expires_at": 2,
+                "time_remaining_ms": 1000,
+            }
+        ]
+
+
+def test_consent_history_uses_vault_owner_dependency(monkeypatch):
+    app = _build_app()
+    app.dependency_overrides[session.require_vault_owner_token] = lambda: {"user_id": "user_123"}
+    monkeypatch.setattr(session, "ConsentDBService", _FakeConsentDBService)
+
+    client = TestClient(app)
+    response = client.get(
+        "/api/consent/history", params={"userId": "user_123", "page": 2, "limit": 10}
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["items"] == [{"agent_id": "agent_a", "action": "GRANTED"}]
+    assert payload["grouped"] == {"agent_a": [{"agent_id": "agent_a", "action": "GRANTED"}]}
+
+
+def test_consent_history_rejects_token_user_mismatch():
+    app = _build_app()
+    app.dependency_overrides[session.require_vault_owner_token] = lambda: {"user_id": "other_user"}
+
+    client = TestClient(app)
+    response = client.get("/api/consent/history", params={"userId": "user_123"})
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Token user mismatch"
+
+
+def test_active_consents_uses_vault_owner_dependency(monkeypatch):
+    app = _build_app()
+    app.dependency_overrides[session.require_vault_owner_token] = lambda: {"user_id": "user_123"}
+    monkeypatch.setattr(session, "ConsentDBService", _FakeConsentDBService)
+
+    client = TestClient(app)
+    response = client.get("/api/consent/active", params={"userId": "user_123"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["active"][0]["id"] == "tok_123"
+    assert payload["grouped"]["developer:test_app"]["appName"] == "test_app"
+
+
+def test_active_consents_rejects_token_user_mismatch():
+    app = _build_app()
+    app.dependency_overrides[session.require_vault_owner_token] = lambda: {"user_id": "other_user"}
+
+    client = TestClient(app)
+    response = client.get("/api/consent/active", params={"userId": "user_123"})
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Token user mismatch"


### PR DESCRIPTION
## Summary

Follow-up to #428 and #429. Closes #453.

After the stream auth hardening in PR #428, a post-fix review (issue #453) identified the same three defect categories in other routes:

| Defect | Description |
|---|---|
| **D1 - Offline-only validation** | `validate_token` used instead of `validate_token_with_db`; revoked tokens remain valid |
| **D2 - Unsafe extraction** | `.replace("Bearer ", "")` can corrupt tokens containing that substring |
| **D3 - RFC-7235 non-compliance** | 401 responses missing `WWW-Authenticate: Bearer` header |

---

## Changes

### `api/routes/session.py`
- `GET /api/consent/history` and `GET /api/consent/active`: replaced 12-line inline validation block (D1 + D2 + D3) with `Depends(require_vault_owner_token)` - the canonical guard already present in `api/middleware.py`. This is the same pattern used by `deny_consent`, `cancel_consent`, `revoke_consent`, and all other correctly-guarded routes.

### `api/routes/consent.py`
- **L798** (vault-owner token reuse check inside `issue_vault_owner_token`): upgraded `validate_token` ? `await validate_token_with_db` so a revoked token is not recycled as a new session.
- **L972** (`GET /data`): upgraded `validate_token` ? `await validate_token_with_db` + added `WWW-Authenticate: Bearer` on 401.
- **L1092** (`POST /export-refresh/upload`): same upgrade + RFC-7235 header.

### `api/routes/db_proxy.py`
- `validate_vault_owner_token` helper: made async, upgraded to `await validate_token_with_db(ConsentScope.VAULT_OWNER)` with explicit scope enforcement; all 401 paths now carry `WWW-Authenticate: Bearer`.
- `get_vault_status` call-site updated to `await validate_vault_owner_token(...)`.

---

## Testing

- Existing quality gate `tests/quality/test_kai_route_auth_compliance.py`: **2/2 pass**.
- No changes to token issuance, revocation, or DB schema.

---

## Related

- Issue: #453
- Parent fix: #428, #429