### PR TITLE
feat(account): add VAULT_OWNER-gated account export flow

### DIFF
--- a/consent-protocol/api/routes/account.py
+++ b/consent-protocol/api/routes/account.py
@@ -89,6 +89,6 @@ async def export_account_data(token_data: dict = Depends(require_vault_owner_tok
     result = await service.export_data(user_id)
 
     if not result["success"]:
-        raise HTTPException(status_code=500, detail=f"Export failed: {result.get('error')}")
+        raise HTTPException(status_code=500, detail="Account export failed")
 
     return result

--- a/consent-protocol/api/routes/account.py
+++ b/consent-protocol/api/routes/account.py
@@ -8,6 +8,7 @@ Endpoints for account lifecycle management.
 Routes:
     POST /api/account/identity/refresh - Refresh backend identity shadow from Firebase Auth
     DELETE /api/account/delete - Delete account and all data
+    GET /api/account/export - Export encrypted account data bundle
 
 Security:
     Identity refresh requires Firebase auth.
@@ -69,5 +70,25 @@ async def delete_account(
 
     if not result["success"]:
         raise HTTPException(status_code=500, detail=f"Deletion failed: {result.get('error')}")
+
+    return result
+
+
+@router.get("/export")
+async def export_account_data(token_data: dict = Depends(require_vault_owner_token)):
+    """
+    Export logged-in user's account data bundle.
+
+    Returns encrypted/private-user-bound payloads only. No plaintext PKM content.
+    Requires VAULT_OWNER token.
+    """
+    user_id = token_data["user_id"]
+    logger.info("Account export requested for user %s", user_id)
+
+    service = AccountService()
+    result = await service.export_data(user_id)
+
+    if not result["success"]:
+        raise HTTPException(status_code=500, detail=f"Export failed: {result.get('error')}")
 
     return result

--- a/consent-protocol/hushh_mcp/services/account_service.py
+++ b/consent-protocol/hushh_mcp/services/account_service.py
@@ -2,6 +2,7 @@
 """Account deletion orchestration for full-account and persona-scoped cleanup."""
 
 import logging
+from datetime import datetime, timezone
 from typing import Any, Dict, Literal
 
 from sqlalchemy import text
@@ -33,6 +34,63 @@ class AccountService:
             "pkm_data": text("DELETE FROM pkm_data WHERE user_id = :user_id"),
             "kai_plaid_user_profile_cache": text(
                 "DELETE FROM kai_plaid_user_profile_cache WHERE user_id = :user_id"
+            ),
+        }
+        self._safe_export_queries = {
+            "actor_profile": text(
+                """
+                SELECT user_id, personas, last_active_persona, investor_marketplace_opt_in, updated_at
+                FROM actor_profiles
+                WHERE user_id = :user_id
+                """
+            ),
+            "runtime_persona_state": text(
+                """
+                SELECT user_id, last_active_persona, updated_at
+                FROM runtime_persona_state
+                WHERE user_id = :user_id
+                """
+            ),
+            "encrypted_vault_keys": text(
+                """
+                SELECT user_id, encrypted_key, wrapped_by, created_at, updated_at
+                FROM vault_keys
+                WHERE user_id = :user_id
+                ORDER BY created_at DESC
+                """
+            ),
+            "encrypted_pkm_manifests": text(
+                """
+                SELECT user_id, scope, stored_version, schema_version, storage_layout, updated_at
+                FROM pkm_manifests
+                WHERE user_id = :user_id
+                ORDER BY updated_at DESC
+                """
+            ),
+            "encrypted_pkm_index": text(
+                """
+                SELECT user_id, domain, record_count, updated_at
+                FROM pkm_index
+                WHERE user_id = :user_id
+                ORDER BY updated_at DESC
+                """
+            ),
+            "encrypted_pkm_blobs": text(
+                """
+                SELECT user_id, domain, blob_size, encrypted_blob, iv, tag, updated_at
+                FROM pkm_blobs
+                WHERE user_id = :user_id
+                ORDER BY updated_at DESC
+                """
+            ),
+            "consent_audit": text(
+                """
+                SELECT user_id, scope, action, app_id, actor_type, occurred_at
+                FROM consent_audit
+                WHERE user_id = :user_id
+                ORDER BY occurred_at DESC
+                LIMIT 500
+                """
             ),
         }
 
@@ -543,7 +601,64 @@ class AccountService:
         - PKM Data (Encrypted)
         - Identity (Encrypted)
         """
-        # NOT_IN_SCOPE: Full data export deferred. Current specific export
-        # endpoints (vault keys, PKM index, identity) serve all active use-cases.
-        # Revisit when GDPR bulk-export or account portability becomes a requirement.
-        pass
+        try:
+            with get_db_connection() as conn:
+                params = {"user_id": user_id}
+                export_payload = {
+                    "actor_profile": self._fetch_optional_single_row(
+                        conn, table_name="actor_profiles", query_name="actor_profile", params=params
+                    ),
+                    "runtime_persona_state": self._fetch_optional_single_row(
+                        conn,
+                        table_name="runtime_persona_state",
+                        query_name="runtime_persona_state",
+                        params=params,
+                    ),
+                    "encrypted_vault_keys": self._fetch_optional_many_rows(
+                        conn, table_name="vault_keys", query_name="encrypted_vault_keys", params=params
+                    ),
+                    "encrypted_pkm_manifests": self._fetch_optional_many_rows(
+                        conn,
+                        table_name="pkm_manifests",
+                        query_name="encrypted_pkm_manifests",
+                        params=params,
+                    ),
+                    "encrypted_pkm_index": self._fetch_optional_many_rows(
+                        conn, table_name="pkm_index", query_name="encrypted_pkm_index", params=params
+                    ),
+                    "encrypted_pkm_blobs": self._fetch_optional_many_rows(
+                        conn, table_name="pkm_blobs", query_name="encrypted_pkm_blobs", params=params
+                    ),
+                    "consent_audit": self._fetch_optional_many_rows(
+                        conn, table_name="consent_audit", query_name="consent_audit", params=params
+                    ),
+                }
+            return {
+                "success": True,
+                "requested_target": "account",
+                "exported_at": datetime.now(timezone.utc).isoformat(),
+                "data": export_payload,
+            }
+        except Exception as exc:
+            logger.exception("❌ Account export failed for %s", user_id)
+            return {"success": False, "error": str(exc)}
+
+    def _fetch_optional_single_row(
+        self, conn, *, table_name: str, query_name: str, params: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        if not self._table_exists(conn, table_name):
+            logger.info("Skipping export for missing table: %s", table_name)
+            return None
+        query = self._safe_export_queries[query_name]
+        row = conn.execute(query, params).mappings().first()
+        return dict(row) if row else None
+
+    def _fetch_optional_many_rows(
+        self, conn, *, table_name: str, query_name: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        if not self._table_exists(conn, table_name):
+            logger.info("Skipping export for missing table: %s", table_name)
+            return []
+        query = self._safe_export_queries[query_name]
+        rows = conn.execute(query, params).mappings().all()
+        return [dict(row) for row in rows]

--- a/consent-protocol/hushh_mcp/services/account_service.py
+++ b/consent-protocol/hushh_mcp/services/account_service.py
@@ -39,7 +39,7 @@ class AccountService:
         self._safe_export_queries = {
             "actor_profile": text(
                 """
-                SELECT user_id, personas, last_active_persona, investor_marketplace_opt_in, updated_at
+                SELECT user_id, personas, last_active_persona, investor_marketplace_opt_in, created_at, updated_at
                 FROM actor_profiles
                 WHERE user_id = :user_id
                 """
@@ -53,7 +53,9 @@ class AccountService:
             ),
             "encrypted_vault_keys": text(
                 """
-                SELECT user_id, encrypted_key, wrapped_by, created_at, updated_at
+                SELECT user_id, vault_status, primary_method, primary_wrapper_id,
+                       recovery_encrypted_vault_key, recovery_salt, recovery_iv,
+                       created_at, updated_at
                 FROM vault_keys
                 WHERE user_id = :user_id
                 ORDER BY created_at DESC
@@ -61,7 +63,9 @@ class AccountService:
             ),
             "encrypted_pkm_manifests": text(
                 """
-                SELECT user_id, scope, stored_version, schema_version, storage_layout, updated_at
+                SELECT user_id, domain, manifest_version, structure_decision,
+                       summary_projection, top_level_scope_paths, domain_contract_version,
+                       readable_summary_version, upgraded_at, created_at, updated_at
                 FROM pkm_manifests
                 WHERE user_id = :user_id
                 ORDER BY updated_at DESC
@@ -69,7 +73,8 @@ class AccountService:
             ),
             "encrypted_pkm_index": text(
                 """
-                SELECT user_id, domain, record_count, updated_at
+                SELECT user_id, available_domains, domain_summaries, computed_tags,
+                       total_attributes, model_version, last_upgraded_at, created_at, updated_at
                 FROM pkm_index
                 WHERE user_id = :user_id
                 ORDER BY updated_at DESC
@@ -77,7 +82,8 @@ class AccountService:
             ),
             "encrypted_pkm_blobs": text(
                 """
-                SELECT user_id, domain, blob_size, encrypted_blob, iv, tag, updated_at
+                SELECT user_id, domain, segment_id, ciphertext, iv, tag,
+                       content_revision, manifest_revision, created_at, updated_at
                 FROM pkm_blobs
                 WHERE user_id = :user_id
                 ORDER BY updated_at DESC
@@ -85,10 +91,10 @@ class AccountService:
             ),
             "consent_audit": text(
                 """
-                SELECT user_id, scope, action, app_id, actor_type, occurred_at
+                SELECT id, token_id, user_id, agent_id, scope, action, issued_at, poll_timeout_at
                 FROM consent_audit
                 WHERE user_id = :user_id
-                ORDER BY occurred_at DESC
+                ORDER BY issued_at DESC
                 LIMIT 500
                 """
             ),
@@ -615,7 +621,10 @@ class AccountService:
                         params=params,
                     ),
                     "encrypted_vault_keys": self._fetch_optional_many_rows(
-                        conn, table_name="vault_keys", query_name="encrypted_vault_keys", params=params
+                        conn,
+                        table_name="vault_keys",
+                        query_name="encrypted_vault_keys",
+                        params=params,
                     ),
                     "encrypted_pkm_manifests": self._fetch_optional_many_rows(
                         conn,
@@ -624,10 +633,16 @@ class AccountService:
                         params=params,
                     ),
                     "encrypted_pkm_index": self._fetch_optional_many_rows(
-                        conn, table_name="pkm_index", query_name="encrypted_pkm_index", params=params
+                        conn,
+                        table_name="pkm_index",
+                        query_name="encrypted_pkm_index",
+                        params=params,
                     ),
                     "encrypted_pkm_blobs": self._fetch_optional_many_rows(
-                        conn, table_name="pkm_blobs", query_name="encrypted_pkm_blobs", params=params
+                        conn,
+                        table_name="pkm_blobs",
+                        query_name="encrypted_pkm_blobs",
+                        params=params,
                     ),
                     "consent_audit": self._fetch_optional_many_rows(
                         conn, table_name="consent_audit", query_name="consent_audit", params=params
@@ -639,9 +654,9 @@ class AccountService:
                 "exported_at": datetime.now(timezone.utc).isoformat(),
                 "data": export_payload,
             }
-        except Exception as exc:
+        except Exception:
             logger.exception("❌ Account export failed for %s", user_id)
-            return {"success": False, "error": str(exc)}
+            return {"success": False, "error": "Account export failed"}
 
     def _fetch_optional_single_row(
         self, conn, *, table_name: str, query_name: str, params: dict[str, Any]

--- a/consent-protocol/tests/services/test_account_service_cleanup_tables.py
+++ b/consent-protocol/tests/services/test_account_service_cleanup_tables.py
@@ -43,3 +43,37 @@ def test_delete_user_rows_if_table_exists_rejects_unsupported_table(monkeypatch)
             table_name="unsafe_table",
             params={"user_id": "user_123"},
         )
+
+
+def test_fetch_optional_many_rows_returns_empty_when_table_missing(monkeypatch):
+    service = AccountService()
+    conn = MagicMock()
+
+    monkeypatch.setattr(service, "_table_exists", lambda _conn, _table: False)
+
+    rows = service._fetch_optional_many_rows(
+        conn,
+        table_name="pkm_blobs",
+        query_name="encrypted_pkm_blobs",
+        params={"user_id": "user_123"},
+    )
+
+    assert rows == []
+    conn.execute.assert_not_called()
+
+
+def test_fetch_optional_single_row_returns_none_when_table_missing(monkeypatch):
+    service = AccountService()
+    conn = MagicMock()
+
+    monkeypatch.setattr(service, "_table_exists", lambda _conn, _table: False)
+
+    row = service._fetch_optional_single_row(
+        conn,
+        table_name="actor_profiles",
+        query_name="actor_profile",
+        params={"user_id": "user_123"},
+    )
+
+    assert row is None
+    conn.execute.assert_not_called()

--- a/consent-protocol/tests/services/test_account_service_export.py
+++ b/consent-protocol/tests/services/test_account_service_export.py
@@ -1,0 +1,183 @@
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes.account import export_account_data
+from hushh_mcp.services.account_service import AccountService
+
+USER_ID = "user_export_123"
+NOW = datetime(2026, 4, 27, tzinfo=timezone.utc)
+
+
+class _QueryRows:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def mappings(self):
+        return self
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+    def all(self):
+        return self._rows
+
+
+@contextmanager
+def _db(conn):
+    yield conn
+
+
+def _conn_with_schema_rows():
+    rows_by_table = {
+        "actor_profiles": [
+            {
+                "user_id": USER_ID,
+                "personas": ["investor"],
+                "last_active_persona": "investor",
+                "investor_marketplace_opt_in": True,
+                "created_at": NOW,
+                "updated_at": NOW,
+            }
+        ],
+        "runtime_persona_state": [
+            {"user_id": USER_ID, "last_active_persona": "investor", "updated_at": NOW}
+        ],
+        "vault_keys": [
+            {
+                "user_id": USER_ID,
+                "vault_status": "active",
+                "primary_method": "passkey",
+                "primary_wrapper_id": "wrapper_123",
+                "recovery_encrypted_vault_key": "ciphertext",
+                "recovery_salt": "salt",
+                "recovery_iv": "iv",
+                "created_at": NOW,
+                "updated_at": NOW,
+            }
+        ],
+        "pkm_manifests": [
+            {
+                "user_id": USER_ID,
+                "domain": "finance",
+                "manifest_version": 1,
+                "structure_decision": {"layout": "domain"},
+                "summary_projection": {"summary": "encrypted"},
+                "top_level_scope_paths": ["attr.financial.*"],
+                "domain_contract_version": 1,
+                "readable_summary_version": 1,
+                "upgraded_at": NOW,
+                "created_at": NOW,
+                "updated_at": NOW,
+            }
+        ],
+        "pkm_index": [
+            {
+                "user_id": USER_ID,
+                "available_domains": ["finance"],
+                "domain_summaries": {"finance": "ready"},
+                "computed_tags": ["investor"],
+                "total_attributes": 4,
+                "model_version": 2,
+                "last_upgraded_at": NOW,
+                "created_at": NOW,
+                "updated_at": NOW,
+            }
+        ],
+        "pkm_blobs": [
+            {
+                "user_id": USER_ID,
+                "domain": "finance",
+                "segment_id": "holdings",
+                "ciphertext": "encrypted-payload",
+                "iv": "iv",
+                "tag": "tag",
+                "content_revision": 3,
+                "manifest_revision": 2,
+                "created_at": NOW,
+                "updated_at": NOW,
+            }
+        ],
+        "consent_audit": [
+            {
+                "id": "audit_123",
+                "token_id": "token_123",
+                "user_id": USER_ID,
+                "agent_id": "kai",
+                "scope": "VAULT_OWNER",
+                "action": "issued",
+                "issued_at": NOW,
+                "poll_timeout_at": NOW,
+            }
+        ],
+    }
+
+    def execute(query, _params):
+        sql = str(query)
+        for table, rows in rows_by_table.items():
+            if f"FROM {table}" in sql:
+                return _QueryRows(rows)
+        return _QueryRows([])
+
+    conn = MagicMock()
+    conn.execute.side_effect = execute
+    return conn
+
+
+@pytest.mark.asyncio
+async def test_export_data_uses_current_schema_contract_columns(monkeypatch):
+    service = AccountService()
+    conn = _conn_with_schema_rows()
+
+    monkeypatch.setattr(service, "_table_exists", lambda _conn, _table: True)
+
+    with patch("hushh_mcp.services.account_service.get_db_connection", return_value=_db(conn)):
+        result = await service.export_data(USER_ID)
+
+    assert result["success"] is True
+    assert result["requested_target"] == "account"
+    assert result["data"]["actor_profile"]["user_id"] == USER_ID
+    assert result["data"]["encrypted_pkm_index"][0]["available_domains"] == ["finance"]
+    assert result["data"]["encrypted_pkm_blobs"][0]["ciphertext"] == "encrypted-payload"
+    assert result["data"]["encrypted_pkm_manifests"][0]["manifest_version"] == 1
+    assert result["data"]["consent_audit"][0]["issued_at"] == NOW
+
+    executed_sql = "\n".join(str(call.args[0]) for call in conn.execute.call_args_list)
+    assert "activity_score" not in executed_sql
+    assert "encrypted_blob" not in executed_sql
+    assert "blob_size" not in executed_sql
+    assert "stored_version" not in executed_sql
+    assert "storage_layout" not in executed_sql
+    assert "occurred_at" not in executed_sql
+    assert "vault_key_wrappers" not in executed_sql
+
+
+@pytest.mark.asyncio
+async def test_export_data_hides_raw_database_error():
+    service = AccountService()
+
+    with patch(
+        "hushh_mcp.services.account_service.get_db_connection",
+        side_effect=RuntimeError("database password leaked in stack"),
+    ):
+        result = await service.export_data(USER_ID)
+
+    assert result == {"success": False, "error": "Account export failed"}
+
+
+@pytest.mark.asyncio
+async def test_export_route_hides_raw_export_failure(monkeypatch):
+    class FailingAccountService:
+        async def export_data(self, _user_id):
+            return {"success": False, "error": "raw database failure detail"}
+
+    monkeypatch.setattr("api.routes.account.AccountService", FailingAccountService)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await export_account_data({"user_id": USER_ID})
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == "Account export failed"

--- a/hushh-webapp/__tests__/api/account-export-proxy.test.ts
+++ b/hushh-webapp/__tests__/api/account-export-proxy.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/app/api/_utils/backend", () => ({
+  getPythonApiUrl: () => "http://backend.test",
+}));
+
+type AccountExportRoute = {
+  GET: (request: NextRequest) => Promise<Response>;
+};
+
+let route: AccountExportRoute;
+
+beforeEach(async () => {
+  vi.restoreAllMocks();
+  route = await import("../../app/api/account/export/route");
+});
+
+function request(headers: Record<string, string> = {}) {
+  return new NextRequest("http://localhost:3000/api/account/export", {
+    method: "GET",
+    headers,
+  });
+}
+
+describe("GET /api/account/export proxy", () => {
+  it("does not expose raw backend error text", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("raw database failure with table names", { status: 500 })
+    );
+
+    const response = await route.GET(request({ Authorization: "Bearer HCT:test" }));
+    const payload = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(payload).toEqual({ error: "Failed to export account data" });
+  });
+
+  it("returns a stable error for invalid backend success payloads", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("not json", { status: 200 }));
+
+    const response = await route.GET(request({ Authorization: "Bearer HCT:test" }));
+    const payload = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(payload).toEqual({ error: "Invalid response from backend" });
+  });
+});

--- a/hushh-webapp/__tests__/services/account-service.test.ts
+++ b/hushh-webapp/__tests__/services/account-service.test.ts
@@ -114,4 +114,32 @@ describe("AccountService", () => {
       expect(result.remaining_personas).toEqual(["ria"]);
     });
   });
+
+  describe("exportData", () => {
+    it("throws when no vault owner token is provided", async () => {
+      await expect(AccountService.exportData("")).rejects.toThrow("VAULT_OWNER token required");
+    });
+
+    it("calls export route with VAULT_OWNER authorization header", async () => {
+      mockApiJson.mockResolvedValue({
+        success: true,
+        exported_at: "2026-04-24T00:00:00Z",
+        requested_target: "account",
+      });
+
+      const result = await AccountService.exportData("vault-token-abc");
+
+      expect(mockApiJson).toHaveBeenCalledWith(
+        "/api/account/export",
+        expect.objectContaining({
+          method: "GET",
+          headers: {
+            Authorization: "Bearer vault-token-abc",
+          },
+        })
+      );
+      expect(result.success).toBe(true);
+      expect(result.requested_target).toBe("account");
+    });
+  });
 });

--- a/hushh-webapp/app/api/account/export/route.ts
+++ b/hushh-webapp/app/api/account/export/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getPythonApiUrl } from "@/app/api/_utils/backend";
+
+const BACKEND_URL = getPythonApiUrl();
+
+export async function GET(request: NextRequest) {
+  try {
+    const authHeader = request.headers.get("authorization") || request.headers.get("Authorization");
+
+    if (!authHeader) {
+      return NextResponse.json({ error: "Missing Authorization header" }, { status: 401 });
+    }
+
+    const backendUrl = `${BACKEND_URL}/api/account/export`;
+    const response = await fetch(backendUrl, {
+      method: "GET",
+      headers: {
+        Authorization: authHeader,
+      },
+    });
+
+    const responseText = await response.text();
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: responseText || "Failed to export account data" },
+        { status: response.status }
+      );
+    }
+
+    try {
+      return NextResponse.json(JSON.parse(responseText));
+    } catch {
+      return NextResponse.json({ success: true, raw: responseText });
+    }
+  } catch (error) {
+    console.error("[API] Account export proxy error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/hushh-webapp/app/api/account/export/route.ts
+++ b/hushh-webapp/app/api/account/export/route.ts
@@ -22,7 +22,7 @@ export async function GET(request: NextRequest) {
     const responseText = await response.text();
     if (!response.ok) {
       return NextResponse.json(
-        { error: responseText || "Failed to export account data" },
+        { error: "Failed to export account data" },
         { status: response.status }
       );
     }
@@ -30,7 +30,7 @@ export async function GET(request: NextRequest) {
     try {
       return NextResponse.json(JSON.parse(responseText));
     } catch {
-      return NextResponse.json({ success: true, raw: responseText });
+      return NextResponse.json({ error: "Invalid response from backend" }, { status: 502 });
     }
   } catch (error) {
     console.error("[API] Account export proxy error:", error);

--- a/hushh-webapp/lib/observability/route-map.ts
+++ b/hushh-webapp/lib/observability/route-map.ts
@@ -355,6 +355,10 @@ const API_TEMPLATE_RULES: Array<{ regex: RegExp; template: string }> = [
     template: "/api/account/delete",
   },
   {
+    regex: /^\/api\/account\/export(?:\?.*)?$/i,
+    template: "/api/account/export",
+  },
+  {
     regex: /^\/api\/developer\/access(?:\?.*)?$/i,
     template: "/api/developer/access",
   },

--- a/hushh-webapp/lib/services/account-service.ts
+++ b/hushh-webapp/lib/services/account-service.ts
@@ -16,6 +16,21 @@ export interface AccountDeletionResult {
   details?: Record<string, unknown>;
 }
 
+export interface AccountDataExportResult {
+  success: boolean;
+  exported_at?: string;
+  requested_target?: "account";
+  data?: {
+    actor_profile?: Record<string, unknown> | null;
+    runtime_persona_state?: Record<string, unknown> | null;
+    encrypted_vault_keys?: Array<Record<string, unknown>>;
+    encrypted_pkm_manifests?: Array<Record<string, unknown>>;
+    encrypted_pkm_index?: Array<Record<string, unknown>>;
+    encrypted_pkm_blobs?: Array<Record<string, unknown>>;
+    consent_audit?: Array<Record<string, unknown>>;
+  };
+}
+
 export class AccountServiceImpl {
   /**
    * Delete the user's account and all data.
@@ -83,9 +98,17 @@ export class AccountServiceImpl {
   /**
    * Export user data.
    */
-  async exportData(): Promise<any> {
-    // TODO: Implement export
-    return {};
+  async exportData(vaultOwnerToken: string): Promise<AccountDataExportResult> {
+    if (!vaultOwnerToken) {
+      throw new Error("VAULT_OWNER token required - vault must be unlocked");
+    }
+
+    return apiJson<AccountDataExportResult>("/api/account/export", {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${vaultOwnerToken}`,
+      },
+    });
   }
 }
 


### PR DESCRIPTION
# Description

Implemented a production-grade account export flow across frontend and backend to replace the unimplemented `exportData()` service path.

## 📌 Impact Map (Required)

- Routes touched:
  - [ ] None
  - [x] Listed below:
    - `hushh-webapp/app/api/account/export/route.ts` (new)
    - `consent-protocol/api/routes/account.py` (`GET /api/account/export`)

- API / schema / type changes:
  - [ ] None
  - [x] Listed below:
    - Added frontend export response type in `hushh-webapp/lib/services/account-service.ts`:
      - `AccountDataExportResult`
    - Added backend response shape for account export payload via `AccountService.export_data(...)`

- Cache keys touched:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None
  - [ ] Listed below:
    - Change is web + backend service/proxy path only; no iOS/Android plugin behavior changed.

- Docs updated (exact files):
  - [x] None

- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm test`
  - [ ] `cd hushh-webapp && npm run build`
  - [ ] `cd hushh-webapp && npm run ios:test`
  - [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000`
  - [x] `cd consent-protocol && uv run pytest tests/services/test_account_service_cleanup_tables.py -q`

## 🛑 Tri-Flow Architecture Check

_Every feature must be implemented across all three layers or explicitly marked as not applicable._

- [x] **Web**: Next.js implementation (`app/api/...`)
- [ ] **iOS**: Swift Capacitor Plugin (`ios/App/App/Plugins/...`) *(N/A for this change)*
- [ ] **Android**: Kotlin Capacitor Plugin (`android/app/.../plugins/...`) *(N/A for this change)*

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [ ] Tested on iOS Simulator/Device *(N/A for this change)*
- [ ] Tested on Android Emulator/Device *(N/A for this change)*
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

No UI visual changes.  
Attached command outputs/logs for:
- frontend test + typecheck
- backend targeted pytest

## 🛡️ Privacy & Consent

- [x] Does this change access user data?
- [x] If yes, have you implemented `checkConsentToken()`?

Notes:
- Route enforces `VAULT_OWNER` auth via backend dependency `require_vault_owner_token`.
- No plaintext user vault material introduced by this PR.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed

Closes #503 