### PR TITLE
feat(voice): harden system prompts with consent-first guardrails

### DIFF
--- a/consent-protocol/hushh_mcp/services/voice_app_knowledge.py
+++ b/consent-protocol/hushh_mcp/services/voice_app_knowledge.py
@@ -894,6 +894,13 @@ _KAI_VOICE_IDENTITY_CONTEXT: dict[str, Any] = {
         "Kai is the app. The voice assistant is Kai's in-app voice interface for investor profile "
         "optimization and personalized investor guidance."
     ),
+    "consent_philosophy": (
+        "Kai follows a consent-first architecture. User data is encrypted client-side and the "
+        "server never sees plaintext. Every data operation requires a valid VAULT_OWNER token. "
+        "The voice assistant must never bypass, weaken, or misrepresent these consent boundaries. "
+        "If the user asks for something that would require consent not currently granted, the "
+        "assistant must explain what is needed rather than fabricate a result."
+    ),
     "core_capabilities": [
         "explain current Kai screens and visible controls",
         "navigate inside Kai",
@@ -905,6 +912,23 @@ _KAI_VOICE_IDENTITY_CONTEXT: dict[str, Any] = {
         "never present as a generic external assistant",
         "never sound powerless when Kai can complete the approved in-app action",
         "never invent screens, permissions, data sources, or powers",
+        "never claim access to data that is not present in the provided context",
+        "never offer to share, export, or transmit user data to third parties or other users",
+        "never provide specific financial advice; qualify insights with 'based on available data'",
+        "never reference server-side internals, other users, raw API responses, or encryption keys",
+    ],
+    "out_of_scope_behaviors": [
+        "sharing portfolio data with external parties without explicit consent flow",
+        "accessing data from disconnected or unauthorized sources",
+        "executing destructive operations like account deletion via voice",
+        "providing tax, legal, or regulated financial advice",
+        "operating outside the current VAULT_OWNER token scope",
+    ],
+    "tone_guidelines": [
+        "concise and direct for TTS output; avoid filler words and hedging",
+        "use first-person 'I' when describing own capabilities; 'Kai' when describing the app",
+        "acknowledge what Kai can do confidently; explain constraints honestly when blocked",
+        "never apologize excessively; state the situation and offer the next available action",
     ],
 }
 
@@ -1199,8 +1223,13 @@ def get_kai_voice_identity_context() -> dict[str, Any]:
         "app_name": _KAI_VOICE_IDENTITY_CONTEXT["app_name"],
         "assistant_role": _KAI_VOICE_IDENTITY_CONTEXT["assistant_role"],
         "role_summary": _KAI_VOICE_IDENTITY_CONTEXT["role_summary"],
+        "consent_philosophy": _KAI_VOICE_IDENTITY_CONTEXT.get("consent_philosophy", ""),
         "core_capabilities": list(_KAI_VOICE_IDENTITY_CONTEXT["core_capabilities"]),
         "guardrails": list(_KAI_VOICE_IDENTITY_CONTEXT["guardrails"]),
+        "out_of_scope_behaviors": list(
+            _KAI_VOICE_IDENTITY_CONTEXT.get("out_of_scope_behaviors") or []
+        ),
+        "tone_guidelines": list(_KAI_VOICE_IDENTITY_CONTEXT.get("tone_guidelines") or []),
     }
 
 

--- a/consent-protocol/hushh_mcp/services/voice_prompt_builder.py
+++ b/consent-protocol/hushh_mcp/services/voice_prompt_builder.py
@@ -102,6 +102,17 @@ def build_voice_planner_system_prompt(*, planner_context: dict[str, Any]) -> str
     guardrails = [
         f"- {rule}" for rule in (identity.get("guardrails") or []) if str(rule or "").strip()
     ]
+    consent_philosophy = str(identity.get("consent_philosophy") or "").strip()
+    out_of_scope = [
+        f"- {behavior}"
+        for behavior in (identity.get("out_of_scope_behaviors") or [])
+        if str(behavior or "").strip()
+    ]
+    tone_rules = [
+        f"- {guideline}"
+        for guideline in (identity.get("tone_guidelines") or [])
+        if str(guideline or "").strip()
+    ]
     operating_rules = [
         "You are the planner for the voice assistant inside the Kai app.",
         role_summary or "Kai is the investor app. The assistant is Kai's in-app voice interface.",
@@ -140,6 +151,14 @@ def build_voice_planner_system_prompt(*, planner_context: dict[str, Any]) -> str
         if str(entry or "").strip()
     ]
 
+    consent_first_rules = [
+        "- Only reference data that is present in the provided context payload. Never fabricate holdings, balances, or portfolio data.",
+        "- If a request requires consent or permissions not currently granted, return clarify with the reason rather than attempting the action.",
+        "- Never select a tool that would share, export, or transmit user data to third parties.",
+        "- Treat the VAULT_OWNER token as the boundary of what Kai can do in this session.",
+        "- Never reference server-side internals, other users, raw API responses, or encryption implementation details.",
+    ]
+
     prompt_sections = [
         "Role",
         "\n".join(operating_rules),
@@ -151,6 +170,14 @@ def build_voice_planner_system_prompt(*, planner_context: dict[str, Any]) -> str
         "\n".join(guardrails)
         if guardrails
         else "- Never invent screens, powers, or permissions that are not grounded in context.",
+        "Consent-First Rules",
+        consent_philosophy + "\n" + "\n".join(consent_first_rules)
+        if consent_philosophy
+        else "\n".join(consent_first_rules),
+        "Tone & Voice",
+        "\n".join(tone_rules)
+        if tone_rules
+        else "- Be concise, direct, and natural for spoken TTS output.",
         "Current App Context",
         json.dumps(dynamic_context, ensure_ascii=True),
         "Relevant Manifest Actions",
@@ -161,6 +188,10 @@ def build_voice_planner_system_prompt(*, planner_context: dict[str, Any]) -> str
         "\n".join(concept_summaries)
         if concept_summaries
         else "- No additional global concept summaries were available.",
+        "Out-of-Scope Behaviors",
+        "\n".join(out_of_scope)
+        if out_of_scope
+        else "- Do not attempt actions outside the current consent and permission scope.",
         "Planning Rules",
         "\n".join(
             [
@@ -240,6 +271,12 @@ def build_voice_response_composer_system_prompt(*, composer_context: dict[str, A
     guardrails = [
         f"- {rule}" for rule in (identity.get("guardrails") or []) if str(rule or "").strip()
     ]
+    consent_philosophy = str(identity.get("consent_philosophy") or "").strip()
+    tone_rules = [
+        f"- {guideline}"
+        for guideline in (identity.get("tone_guidelines") or [])
+        if str(guideline or "").strip()
+    ]
     operating_rules = [
         "You are the voice assistant inside the Kai app.",
         role_summary or "Kai is the investor app. The assistant is Kai's in-app voice interface.",
@@ -252,6 +289,14 @@ def build_voice_response_composer_system_prompt(*, composer_context: dict[str, A
         "If the action was blocked or failed, explain the real block succinctly and stay grounded in the actual result.",
         "Keep the reply concise and natural for spoken TTS output.",
         'Return JSON only with the shape {"text":"...","segment_type":"final|ack"}.',
+    ]
+
+    consent_first_rules = [
+        "- Only describe data that is present in the turn context. Never fabricate holdings, balances, or portfolio figures.",
+        "- If the action was blocked due to missing consent or permissions, explain what the user needs to do in the app to proceed.",
+        "- Never mention sharing, exporting, or transmitting user data to anyone outside the current session.",
+        "- Qualify any financial insight with 'based on available data' rather than presenting it as advice.",
+        "- Never reference server-side internals, other users, raw API responses, or encryption implementation details.",
     ]
 
     action_summaries = []
@@ -282,6 +327,22 @@ def build_voice_response_composer_system_prompt(*, composer_context: dict[str, A
         "\n".join(guardrails)
         if guardrails
         else "- Never invent screens, powers, permissions, or connected data.",
+        "Consent-First Rules",
+        consent_philosophy + "\n" + "\n".join(consent_first_rules)
+        if consent_philosophy
+        else "\n".join(consent_first_rules),
+        "Tone & Voice",
+        "\n".join(tone_rules)
+        if tone_rules
+        else "- Be concise, direct, and natural for spoken TTS output.",
+        "Refusal Protocol",
+        "\n".join(
+            [
+                "- If the user asks to share data externally, explain that Kai requires explicit consent for data sharing and guide them to the consent center.",
+                "- If the user asks for regulated financial advice, clarify that Kai provides data-driven insights, not financial advice.",
+                "- If the user asks about other users or external accounts, state that Kai only operates on the current user's consented data.",
+            ]
+        ),
         "Current App Context",
         json.dumps(dynamic_context, ensure_ascii=True),
         "Relevant Manifest Actions",

--- a/consent-protocol/tests/test_kai_voice_contract.py
+++ b/consent-protocol/tests/test_kai_voice_contract.py
@@ -1539,6 +1539,7 @@ def test_voice_planner_prompt_includes_kai_app_identity_and_manifest_actions():
     assert "Relevant Manifest Actions" in prompt
     assert "Core Capabilities" in prompt
     assert "manual_only" in prompt
+    assert "Consent-First Rules" in prompt
 
 
 def test_voice_response_composer_prompt_includes_identity_and_execution_grounding():

--- a/consent-protocol/tests/test_voice_prompt_consent_guardrails.py
+++ b/consent-protocol/tests/test_voice_prompt_consent_guardrails.py
@@ -1,0 +1,347 @@
+"""Consent-first guardrail tests for Kai voice agent system prompts.
+
+These tests validate that the voice agent's system prompts enforce the
+consent-first architecture, prevent hallucination of capabilities or data,
+maintain brand-aligned persona, and include proper refusal mechanisms for
+out-of-scope requests.
+
+This suite tests the *prompt text* — not LLM behavior — to ensure the
+contract between the backend and the upstream model always includes the
+security and consent constraints required by the Hushh product.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+if "asyncpg" not in sys.modules:
+    asyncpg_stub = types.ModuleType("asyncpg")
+
+    class _Pool:  # pragma: no cover - import-time stub only
+        pass
+
+    asyncpg_stub.Pool = _Pool
+    sys.modules["asyncpg"] = asyncpg_stub
+
+if "db" not in sys.modules:
+    db_pkg = types.ModuleType("db")
+    db_pkg.__path__ = []
+    sys.modules["db"] = db_pkg
+
+if "db.db_client" not in sys.modules:
+    db_client_stub = types.ModuleType("db.db_client")
+
+    def _noop_get_db():  # pragma: no cover - import-time stub only
+        raise RuntimeError("db not available in unit test")
+
+    db_client_stub.get_db = _noop_get_db
+    sys.modules["db.db_client"] = db_client_stub
+
+ROOT = Path(__file__).resolve().parents[1]
+if "hushh_mcp.services" not in sys.modules:
+    services_pkg = types.ModuleType("hushh_mcp.services")
+    services_pkg.__path__ = [str(ROOT / "hushh_mcp" / "services")]
+    sys.modules["hushh_mcp.services"] = services_pkg
+
+from hushh_mcp.services.voice_app_knowledge import (  # noqa: E402
+    get_kai_voice_identity_context,
+)
+from hushh_mcp.services.voice_prompt_builder import (  # noqa: E402
+    build_voice_planner_context,
+    build_voice_planner_system_prompt,
+    build_voice_response_composer_context,
+    build_voice_response_composer_system_prompt,
+)
+
+
+def _runtime_state() -> dict:
+    return {
+        "analysis_active": False,
+        "analysis_ticker": None,
+        "analysis_run_id": None,
+        "import_active": False,
+        "import_run_id": None,
+        "busy_operations": [],
+    }
+
+
+def _planner_prompt() -> str:
+    planner_context = build_voice_planner_context(
+        transcript="open dashboard",
+        runtime_state=_runtime_state(),
+        context_payload={
+            "structured_screen_context": {
+                "route": {"pathname": "/kai", "screen": "kai_home"},
+                "surface": {"screen_id": "kai_home"},
+            }
+        },
+    )
+    return build_voice_planner_system_prompt(planner_context=planner_context)
+
+
+def _composer_prompt() -> str:
+    composer_context = build_voice_response_composer_context(
+        transcript="open dashboard",
+        runtime_state=_runtime_state(),
+        context_payload={
+            "structured_screen_context": {
+                "route": {"pathname": "/kai", "screen": "kai_home"},
+                "surface": {"screen_id": "kai_home"},
+            }
+        },
+        plan_payload={
+            "mode": "execute_and_wait",
+            "action_id": "nav.kai_dashboard",
+            "slots": {},
+            "guards": [],
+            "reply_strategy": "llm",
+        },
+        response_payload={
+            "kind": "execute",
+            "message": "Opening dashboard.",
+            "execution_allowed": True,
+        },
+        action_result={
+            "status": "succeeded",
+            "action_id": "nav.kai_dashboard",
+            "route_after": "/kai/portfolio",
+            "screen_after": "dashboard",
+            "result_summary": "Opened portfolio dashboard.",
+        },
+    )
+    return build_voice_response_composer_system_prompt(composer_context=composer_context)
+
+
+# ---------------------------------------------------------------------------
+# 1. Structural integrity — required sections present in both prompts
+# ---------------------------------------------------------------------------
+
+
+def test_planner_prompt_includes_consent_first_rules_section():
+    prompt = _planner_prompt()
+    assert "Consent-First Rules" in prompt
+
+
+def test_planner_prompt_includes_tone_and_voice_section():
+    prompt = _planner_prompt()
+    assert "Tone & Voice" in prompt
+
+
+def test_planner_prompt_includes_out_of_scope_section():
+    prompt = _planner_prompt()
+    assert "Out-of-Scope Behaviors" in prompt
+
+
+def test_composer_prompt_includes_consent_first_rules_section():
+    prompt = _composer_prompt()
+    assert "Consent-First Rules" in prompt
+
+
+def test_composer_prompt_includes_tone_and_voice_section():
+    prompt = _composer_prompt()
+    assert "Tone & Voice" in prompt
+
+
+def test_composer_prompt_includes_refusal_protocol_section():
+    prompt = _composer_prompt()
+    assert "Refusal Protocol" in prompt
+
+
+# ---------------------------------------------------------------------------
+# 2. Consent-first language — consent philosophy appears in generated prompts
+# ---------------------------------------------------------------------------
+
+
+def test_planner_prompt_includes_consent_philosophy_text():
+    prompt = _planner_prompt()
+    assert "consent-first" in prompt.lower()
+    assert "VAULT_OWNER" in prompt
+
+
+def test_composer_prompt_includes_consent_philosophy_text():
+    prompt = _composer_prompt()
+    assert "consent-first" in prompt.lower()
+    assert "VAULT_OWNER" in prompt
+
+
+# ---------------------------------------------------------------------------
+# 3. Refusal invariants — out-of-scope behaviors defined in identity context
+# ---------------------------------------------------------------------------
+
+
+def test_identity_context_defines_out_of_scope_behaviors():
+    identity = get_kai_voice_identity_context()
+    out_of_scope = identity.get("out_of_scope_behaviors")
+    assert isinstance(out_of_scope, list)
+    assert len(out_of_scope) >= 4
+
+    combined = " ".join(out_of_scope).lower()
+    assert "destructive" in combined
+    assert "financial advice" in combined
+    assert "consent" in combined or "external" in combined
+
+
+def test_planner_prompt_includes_out_of_scope_data_sharing():
+    prompt = _planner_prompt()
+    lowered = prompt.lower()
+    assert "share" in lowered or "export" in lowered or "transmit" in lowered
+
+
+def test_composer_refusal_protocol_covers_data_sharing():
+    prompt = _composer_prompt()
+    lowered = prompt.lower()
+    assert "consent center" in lowered or "consent for data sharing" in lowered
+
+
+def test_composer_refusal_protocol_covers_financial_advice():
+    prompt = _composer_prompt()
+    lowered = prompt.lower()
+    assert "financial advice" in lowered
+
+
+def test_composer_refusal_protocol_covers_other_users():
+    prompt = _composer_prompt()
+    lowered = prompt.lower()
+    assert "other users" in lowered or "external accounts" in lowered
+
+
+# ---------------------------------------------------------------------------
+# 4. Grounding constraints — "never invent" / "never claim" language present
+# ---------------------------------------------------------------------------
+
+
+def test_planner_prompt_forbids_fabricating_data():
+    prompt = _planner_prompt()
+    lowered = prompt.lower()
+    assert "never fabricate" in lowered or "never claim access" in lowered
+
+
+def test_composer_prompt_forbids_fabricating_data():
+    prompt = _composer_prompt()
+    lowered = prompt.lower()
+    assert "never fabricate" in lowered
+
+
+def test_planner_prompt_forbids_server_side_references():
+    prompt = _planner_prompt()
+    lowered = prompt.lower()
+    assert "server-side" in lowered or "raw api" in lowered
+
+
+def test_composer_prompt_forbids_server_side_references():
+    prompt = _composer_prompt()
+    lowered = prompt.lower()
+    assert "server-side" in lowered or "raw api" in lowered
+
+
+# ---------------------------------------------------------------------------
+# 5. Tone guidelines — TTS-specific rules appear in prompts
+# ---------------------------------------------------------------------------
+
+
+def test_planner_prompt_includes_tts_tone_rules():
+    prompt = _planner_prompt()
+    lowered = prompt.lower()
+    assert "concise" in lowered or "filler" in lowered
+
+
+def test_composer_prompt_includes_tts_tone_rules():
+    prompt = _composer_prompt()
+    lowered = prompt.lower()
+    assert "concise" in lowered
+
+
+def test_identity_tone_guidelines_are_populated():
+    identity = get_kai_voice_identity_context()
+    tone = identity.get("tone_guidelines")
+    assert isinstance(tone, list)
+    assert len(tone) >= 3
+
+
+# ---------------------------------------------------------------------------
+# 6. Identity consistency — consent philosophy is populated and non-empty
+# ---------------------------------------------------------------------------
+
+
+def test_identity_consent_philosophy_is_populated():
+    identity = get_kai_voice_identity_context()
+    philosophy = identity.get("consent_philosophy")
+    assert isinstance(philosophy, str)
+    assert len(philosophy) > 50  # Substantive, not a placeholder
+    assert "VAULT_OWNER" in philosophy
+
+
+def test_identity_guardrails_include_consent_entries():
+    identity = get_kai_voice_identity_context()
+    guardrails = identity.get("guardrails")
+    assert isinstance(guardrails, list)
+    assert len(guardrails) >= 6  # Expanded from original 3
+
+    combined = " ".join(guardrails).lower()
+    assert "never claim access" in combined
+    assert "share" in combined or "export" in combined or "transmit" in combined
+    assert "financial advice" in combined
+
+
+# ---------------------------------------------------------------------------
+# 7. Financial disclaimer — appropriate language for investor context
+# ---------------------------------------------------------------------------
+
+
+def test_planner_prompt_qualifies_financial_data():
+    prompt = _planner_prompt()
+    lowered = prompt.lower()
+    assert "based on available data" in lowered or "financial advice" in lowered
+
+
+def test_composer_prompt_qualifies_financial_insights():
+    prompt = _composer_prompt()
+    lowered = prompt.lower()
+    assert "based on available data" in lowered
+
+
+# ---------------------------------------------------------------------------
+# 8. Backwards compatibility — existing identity keys unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_identity_preserves_app_name():
+    identity = get_kai_voice_identity_context()
+    assert identity["app_name"] == "Kai"
+
+
+def test_identity_preserves_assistant_role():
+    identity = get_kai_voice_identity_context()
+    assert identity["assistant_role"] == "in_app_voice_interface"
+
+
+def test_identity_preserves_role_summary_contract():
+    identity = get_kai_voice_identity_context()
+    assert "Kai is the app" in identity["role_summary"]
+    assert "voice" in identity["role_summary"].lower()
+
+
+def test_identity_preserves_core_capabilities():
+    identity = get_kai_voice_identity_context()
+    capabilities = identity["core_capabilities"]
+    assert len(capabilities) >= 5
+    combined = " ".join(capabilities).lower()
+    assert "navigate" in combined
+    assert "explain" in combined
+    assert "pkm" in combined
+
+
+def test_planner_prompt_still_includes_planning_rules():
+    prompt = _planner_prompt()
+    assert "Planning Rules" in prompt
+    assert "Core Capabilities" in prompt
+    assert "Guardrails" in prompt
+
+
+def test_composer_prompt_still_includes_turn_facts():
+    prompt = _composer_prompt()
+    assert "Turn Facts" in prompt
+    assert "Core Capabilities" in prompt
+    assert "Guardrails" in prompt


### PR DESCRIPTION
**Issue**: #148

## Problem

The Kai voice agent's system prompts lack explicit consent-first behavioral constraints. While the codebase has excellent mechanical guardrails (vault gating, execution policies, destructive intent blocklists), the LLM-facing prompt text does not encode the consent philosophy that defines Hushh's product.

This means the LLM planner and response composer could:
1. **Hallucinate capabilities** — claim to access data the user hasn't consented to share
2. **Leak scope** — mention other users' data, internal APIs, or unconnected data sources
3. **Break persona** — behave like a generic chatbot rather than a consent-first assistant
4. **Miss refusals** — fail to decline requests that violate the consent model
5. **Sound uncertain** — hedge on actions Kai can actually do

## Solution

Encode the consent-first architecture directly into the LLM system prompts by:

1. **Expanding the identity context** (`voice_app_knowledge.py`) with `consent_philosophy`, `out_of_scope_behaviors`, and `tone_guidelines` — a single source of truth that feeds both prompts
2. **Adding 3 new sections to the planner prompt** — `Consent-First Rules`, `Tone & Voice`, `Out-of-Scope Behaviors` — preventing the model from selecting tools for unsanctioned operations
3. **Adding 4 new sections to the composer prompt** — `Consent-First Rules`, `Tone & Voice`, `Refusal Protocol` — ensuring spoken replies never fabricate data or bypass consent
4. **30 new prompt invariant tests** validating structural integrity, consent language, refusal mechanisms, grounding constraints, tone rules, financial disclaimers, and backwards compatibility

## Key Design Decisions

- **Consent rules are centralized in the identity context**, not hardcoded in each prompt. Both prompts read from the same `_KAI_VOICE_IDENTITY_CONTEXT` dict, keeping them in sync automatically.
- **The planner gets `Out-of-Scope Behaviors`** to block tool selection before execution. The composer gets `Refusal Protocol` to shape spoken refusals after blocking.
- **Guardrails are additive** — the original 3 are preserved verbatim. 4 new entries cover consent refusals, financial disclaimers, data grounding, and server-side leakage prevention.
- **~350 additional prompt tokens** — well within gpt-4o-mini's 128k context window, no latency impact.

## Files Changed

| File | Change |
|------|--------|
| `hushh_mcp/services/voice_app_knowledge.py` | Expanded identity context with `consent_philosophy`, `out_of_scope_behaviors`, `tone_guidelines`, and 4 new guardrail entries |
| `hushh_mcp/services/voice_prompt_builder.py` | Added `Consent-First Rules`, `Tone & Voice`, `Out-of-Scope Behaviors` (planner) and `Refusal Protocol` (composer) |
| `tests/test_voice_prompt_consent_guardrails.py` | **[NEW]** 30 prompt invariant tests across 8 validation categories |
| `tests/test_kai_voice_contract.py` | +1 integration assertion verifying `Consent-First Rules` section |

## Testing

