### PR TITLE
fix(web): bypass phone mandate on localhost

### DIFF
--- a/hushh-webapp/__tests__/components/phone-mandate-guard.test.tsx
+++ b/hushh-webapp/__tests__/components/phone-mandate-guard.test.tsx
@@ -40,6 +40,7 @@ vi.mock("@/lib/services/vault-service", () => ({
 
 describe("PhoneMandateGuard", () => {
   beforeEach(() => {
+    vi.stubEnv("NEXT_PUBLIC_APP_ENV", "uat");
     replace.mockReset();
     checkVaultMock.mockReset();
     pathnameValue = "/profile";
@@ -103,5 +104,22 @@ describe("PhoneMandateGuard", () => {
       expect(screen.getByText("kai content")).toBeTruthy();
     });
     expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("keeps localhost development users in the app without requiring phone verification", async () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_ENV", "development");
+    checkVaultMock.mockResolvedValue(false);
+
+    render(
+      <PhoneMandateGuard exemptVaultUsers>
+        <div>profile content</div>
+      </PhoneMandateGuard>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("profile content")).toBeTruthy();
+    });
+    expect(replace).not.toHaveBeenCalled();
+    expect(checkVaultMock).not.toHaveBeenCalled();
   });
 });

--- a/hushh-webapp/__tests__/services/post-auth-route-service.test.ts
+++ b/hushh-webapp/__tests__/services/post-auth-route-service.test.ts
@@ -40,6 +40,7 @@ import { PostAuthRouteService } from "@/lib/services/post-auth-route-service";
 
 describe("PostAuthRouteService", () => {
   beforeEach(() => {
+    vi.stubEnv("NEXT_PUBLIC_APP_ENV", "uat");
     bootstrapStateMock.mockReset();
     updatePreVaultStateMock.mockReset();
     loadPendingOnboardingMock.mockReset();
@@ -159,6 +160,25 @@ describe("PostAuthRouteService", () => {
       PostAuthRouteService.resolveAfterLogin({
         userId: "user_123",
         phoneNumber: "+16505550101",
+      })
+    ).resolves.toBe(ROUTES.KAI_HOME);
+  });
+
+  it("skips the phone mandate for localhost development sessions", async () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_ENV", "development");
+    bootstrapStateMock.mockResolvedValue({
+      hasVault: false,
+      preOnboardingCompleted: true,
+      preOnboardingCompletedAt: 1,
+      preOnboardingSkipped: false,
+    });
+    loadPendingOnboardingMock.mockResolvedValue(null);
+
+    await expect(
+      PostAuthRouteService.resolveAfterLogin({
+        userId: "user_123",
+        phoneNumber: null,
+        hostname: "localhost",
       })
     ).resolves.toBe(ROUTES.KAI_HOME);
   });

--- a/hushh-webapp/app/register-phone/page.tsx
+++ b/hushh-webapp/app/register-phone/page.tsx
@@ -12,6 +12,7 @@ import { useAuth } from "@/lib/firebase/auth-context";
 import { ROUTES } from "@/lib/navigation/routes";
 import { AccountIdentityService } from "@/lib/services/account-identity-service";
 import { PostAuthRouteService } from "@/lib/services/post-auth-route-service";
+import { shouldBypassPhoneMandateForLocalhost } from "@/lib/services/phone-mandate-service";
 
 const FLOW_SHELL_STYLE = {
   "--page-top-local-offset": "clamp(1.25rem, 4vh, 3rem)",
@@ -74,14 +75,33 @@ function PhoneMandatePageContent() {
         redirectPath,
         idToken,
         phoneNumber: activeUser.phoneNumber,
+        hostname: window.location.hostname,
       });
       router.replace(nextPath);
     },
     [redirectPath, refreshUser, router, user]
   );
 
+  const shouldBypassLocalPhoneMandate =
+    !loading &&
+    Boolean(user) &&
+    !phoneNumber &&
+    typeof window !== "undefined" &&
+    shouldBypassPhoneMandateForLocalhost(window.location.hostname);
+
+  useEffect(() => {
+    if (!shouldBypassLocalPhoneMandate || !user) {
+      return;
+    }
+    void continueToNextRoute(user);
+  }, [continueToNextRoute, shouldBypassLocalPhoneMandate, user]);
+
   if (loading || !user) {
     return <HushhLoader label="Loading phone verification..." variant="fullscreen" />;
+  }
+
+  if (shouldBypassLocalPhoneMandate) {
+    return <HushhLoader label="Continuing local session..." variant="fullscreen" />;
   }
 
   const shell = (

--- a/hushh-webapp/components/auth/phone-mandate-guard.tsx
+++ b/hushh-webapp/components/auth/phone-mandate-guard.tsx
@@ -6,7 +6,10 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { HushhLoader } from "@/components/app-ui/hushh-loader";
 import { useAuth } from "@/lib/firebase/auth-context";
 import { buildPhoneMandateRoute, ROUTES } from "@/lib/navigation/routes";
-import { shouldRequirePhoneMandate } from "@/lib/services/phone-mandate-service";
+import {
+  shouldBypassPhoneMandateForLocalhost,
+  shouldRequirePhoneMandate,
+} from "@/lib/services/phone-mandate-service";
 import { VaultService } from "@/lib/services/vault-service";
 
 const vaultPresenceCache = new Map<string, boolean>();
@@ -23,10 +26,17 @@ export function PhoneMandateGuard({
   const searchParams = useSearchParams();
   const { user, loading, phoneNumber } = useAuth();
   const [hasVault, setHasVault] = useState<boolean | null>(null);
+  const hostname = typeof window === "undefined" ? null : window.location.hostname;
+  const localPhoneMandateBypassed = shouldBypassPhoneMandateForLocalhost(hostname);
 
   useEffect(() => {
     if (!user?.uid) {
       setHasVault(null);
+      return;
+    }
+
+    if (localPhoneMandateBypassed) {
+      setHasVault(false);
       return;
     }
 
@@ -58,7 +68,7 @@ export function PhoneMandateGuard({
     return () => {
       cancelled = true;
     };
-  }, [user?.uid]);
+  }, [localPhoneMandateBypassed, user?.uid]);
 
   const currentRoute = useMemo(() => {
     const query = searchParams.toString();
@@ -72,6 +82,7 @@ export function PhoneMandateGuard({
       phoneNumber,
       hasVault,
       exemptVaultUsers,
+      hostname,
     });
 
   useEffect(() => {

--- a/hushh-webapp/lib/services/phone-mandate-service.ts
+++ b/hushh-webapp/lib/services/phone-mandate-service.ts
@@ -1,15 +1,37 @@
+import { resolveAppEnvironment } from "@/lib/app-env";
 import { ROUTES } from "@/lib/navigation/routes";
+
+const LOCAL_PHONE_MANDATE_BYPASS_HOSTS = new Set(["localhost", "127.0.0.1"]);
+
+function normalizeHostname(hostname?: string | null): string {
+  return String(hostname ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/:\d+$/, "");
+}
 
 export function hasVerifiedPhoneNumber(phoneNumber?: string | null): boolean {
   return String(phoneNumber ?? "").trim().length > 0;
+}
+
+export function shouldBypassPhoneMandateForLocalhost(hostname?: string | null): boolean {
+  return (
+    resolveAppEnvironment() === "development" &&
+    LOCAL_PHONE_MANDATE_BYPASS_HOSTS.has(normalizeHostname(hostname))
+  );
 }
 
 export function shouldRequirePhoneMandate(params: {
   phoneNumber?: string | null;
   hasVault: boolean;
   exemptVaultUsers?: boolean;
+  hostname?: string | null;
 }): boolean {
   if (hasVerifiedPhoneNumber(params.phoneNumber)) {
+    return false;
+  }
+
+  if (shouldBypassPhoneMandateForLocalhost(params.hostname)) {
     return false;
   }
 

--- a/hushh-webapp/lib/services/post-auth-route-service.ts
+++ b/hushh-webapp/lib/services/post-auth-route-service.ts
@@ -23,6 +23,7 @@ export class PostAuthRouteService {
     redirectPath?: string;
     idToken?: string;
     phoneNumber?: string | null;
+    hostname?: string | null;
   }): Promise<string> {
     const fallbackRoute = normalizeRedirectPath(params.redirectPath);
     const remoteState = await PreVaultUserStateService.bootstrapState(params.userId);
@@ -94,6 +95,8 @@ export class PostAuthRouteService {
       shouldRequirePhoneMandate({
         phoneNumber: params.phoneNumber,
         hasVault: false,
+        hostname:
+          params.hostname ?? (typeof window === "undefined" ? null : window.location.hostname),
       })
     ) {
       return buildPhoneMandateRoute(resolvedNoVaultRoute);


### PR DESCRIPTION
## Summary
- skip the mandatory phone gate only for localhost/127.0.0.1 when NEXT_PUBLIC_APP_ENV resolves to development
- keep UAT/prod phone verification strict and leave Firebase phone linking unchanged
- auto-continue direct /register-phone visits on local dev instead of showing the phone verification step

## Verification
- ./bin/hushh codex pre-pr
- cd hushh-webapp && npm test -- --run __tests__/services/post-auth-route-service.test.ts __tests__/components/phone-mandate-guard.test.tsx __tests__/services/auth-service.test.ts
- cd hushh-webapp && npm run typecheck
- cd hushh-webapp && npm run lint