### PR TITLE
fix(web): unblock RIA onboarding role switch

### DIFF
--- a/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
@@ -41,7 +41,6 @@ vi.mock("lucide-react", () => ({
   CheckCircle2: () => <span />,
   Loader2: () => <span />,
   ShieldCheck: () => <span />,
-  ShieldQuestion: () => <span />,
 }));
 
 vi.mock("@/components/app-ui/command-fields", () => ({
@@ -257,6 +256,58 @@ describe("RiaOnboardingPage", () => {
       expect(screen.queryByText("Verified name")).toBeNull();
     });
     expect(continueButton.disabled).toBe(true);
+  });
+
+  it("keeps non-actionable helper cards out of onboarding", async () => {
+    render(<RiaOnboardingPage />);
+
+    await screen.findByLabelText("Advisor name");
+
+    expect(screen.queryByText("Trust summary")).toBeNull();
+    expect(screen.queryByText("Deferred for later settings")).toBeNull();
+  });
+
+  it("offers the verification bypass only when the environment allows it", async () => {
+    mocks.usePersonaState.mockReturnValue({
+      devRiaBypassAllowed: true,
+      refresh: mocks.refreshPersonaState,
+    });
+    mocks.riaService.activateDevRia.mockResolvedValue({
+      ria_profile_id: "ria-profile-1",
+      verification_status: "active",
+      advisory_status: "active",
+      brokerage_status: "draft",
+      requested_capabilities: ["advisory"],
+      verification_outcome: "dev_allowlist",
+      verification_message: "RIA activated for an allowlisted development account",
+      brokerage_outcome: "not_requested",
+      brokerage_message: "Brokerage capability was not requested.",
+      professional_access_granted: true,
+      individual_legal_name: "Local Advisor",
+      individual_crd: null,
+      advisory_firm_legal_name: null,
+      advisory_firm_iapd_number: null,
+      broker_firm_legal_name: null,
+      broker_firm_crd: null,
+    });
+
+    render(<RiaOnboardingPage />);
+
+    const input = await screen.findByLabelText("Advisor name");
+    fireEvent.change(input, { target: { value: "Local Advisor" } });
+    fireEvent.click(screen.getByRole("button", { name: "Bypass verification" }));
+
+    await waitFor(() => {
+      expect(mocks.riaService.activateDevRia).toHaveBeenCalledWith(
+        "token-ria-1",
+        expect.objectContaining({
+          display_name: "Local Advisor",
+          requested_capabilities: ["advisory"],
+        })
+      );
+    });
+    expect(mocks.riaService.verifyOnboardingName).not.toHaveBeenCalled();
+    expect(mocks.refreshPersonaState).toHaveBeenCalledWith({ force: true });
   });
 
   it("supports Enter-to-verify and blocks continue after a failed lookup", async () => {

--- a/hushh-webapp/__tests__/components/top-app-bar.contract.test.ts
+++ b/hushh-webapp/__tests__/components/top-app-bar.contract.test.ts
@@ -20,4 +20,14 @@ describe("Top app bar responsive contract", () => {
     expect(source).toContain('className="shrink-0 text-current"');
     expect(source).toContain('className="h-4 w-4 shrink-0 text-current/70 transition-colors group-hover:text-current"');
   });
+
+  it("keeps RIA onboarding persona switching interactive", () => {
+    const source = read("components/app-ui/top-app-bar.tsx");
+
+    expect(source).toContain(
+      'return { label: "Set up RIA", icon: BriefcaseBusiness, interactive: true as const };'
+    );
+    expect(source).toContain('pathname === ROUTES.RIA_ONBOARDING && target === "investor"');
+    expect(source).toContain("router.push(nextRoute);");
+  });
 });

--- a/hushh-webapp/__tests__/services/user-local-state-service.test.ts
+++ b/hushh-webapp/__tests__/services/user-local-state-service.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  clearPreVault: vi.fn(),
+  clearKaiNavTour: vi.fn(),
+  clearRiaOnboardingDraft: vi.fn(),
+  clearVaultMethodPrompt: vi.fn(),
+}));
+
+vi.mock("@/lib/services/pre-vault-onboarding-service", () => ({
+  PreVaultOnboardingService: { clear: mocks.clearPreVault },
+}));
+
+vi.mock("@/lib/services/kai-nav-tour-local-service", () => ({
+  KaiNavTourLocalService: { clear: mocks.clearKaiNavTour },
+}));
+
+vi.mock("@/lib/services/ria-onboarding-draft-local-service", () => ({
+  RiaOnboardingDraftLocalService: { clear: mocks.clearRiaOnboardingDraft },
+}));
+
+vi.mock("@/lib/services/vault-method-prompt-local-service", () => ({
+  VaultMethodPromptLocalService: { clear: mocks.clearVaultMethodPrompt },
+}));
+
+import { UserLocalStateService } from "@/lib/services/user-local-state-service";
+
+describe("UserLocalStateService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.clearPreVault.mockResolvedValue(undefined);
+    mocks.clearKaiNavTour.mockResolvedValue(undefined);
+    mocks.clearRiaOnboardingDraft.mockResolvedValue(undefined);
+    mocks.clearVaultMethodPrompt.mockResolvedValue(undefined);
+  });
+
+  it("clears all user-scoped local state, including RIA onboarding drafts", async () => {
+    await UserLocalStateService.clearForUser("uid-1");
+
+    expect(mocks.clearPreVault).toHaveBeenCalledWith("uid-1");
+    expect(mocks.clearKaiNavTour).toHaveBeenCalledWith("uid-1");
+    expect(mocks.clearRiaOnboardingDraft).toHaveBeenCalledWith("uid-1");
+    expect(mocks.clearVaultMethodPrompt).toHaveBeenCalledWith("uid-1");
+  });
+});

--- a/hushh-webapp/app/ria/onboarding/page.tsx
+++ b/hushh-webapp/app/ria/onboarding/page.tsx
@@ -9,11 +9,10 @@ import {
   CheckCircle2,
   Loader2,
   ShieldCheck,
-  ShieldQuestion,
 } from "lucide-react";
 
 import { PopupTextEditorField } from "@/components/app-ui/command-fields";
-import { SurfaceCard, SurfaceCardContent, SurfaceCardHeader, SurfaceInset } from "@/components/app-ui/surfaces";
+import { SurfaceCard, SurfaceCardContent, SurfaceCardHeader } from "@/components/app-ui/surfaces";
 import { SettingsGroup, SettingsRow } from "@/components/profile/settings-ui";
 import { Progress } from "@/components/ui/progress";
 import { Badge } from "@/components/ui/badge";
@@ -50,36 +49,6 @@ import {
   trackGrowthFunnelStepCompleted,
   trackRiaActivationCompleted,
 } from "@/lib/observability/growth";
-
-function formatVerificationStatus(
-  status?: string | null,
-  loading?: boolean,
-  lane: "advisory" | "brokerage" = "advisory"
-) {
-  if (loading) return "Loading";
-  switch (status) {
-    case "verified":
-      return lane === "brokerage" ? "Broker verified" : "IAPD verified";
-    case "active":
-      return "Active";
-    case "bypassed":
-      return "Bypassed";
-    case "submitted":
-      return "Submitted";
-    case "rejected":
-      return "Rejected";
-    case "draft":
-    default:
-      return "Draft";
-  }
-}
-
-function compactDate(value?: string | null): string | null {
-  if (!value) return null;
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return null;
-  return date.toLocaleDateString();
-}
 
 type NameVerificationState =
   | "idle"
@@ -139,14 +108,6 @@ function buildSubmitPayload(draft: RiaOnboardingDraft) {
     broker_firm_crd: brokerageEnabled ? draft.brokerFirmCrd.trim() || undefined : undefined,
     strategy: draft.strategySummary.trim() || undefined,
   };
-}
-
-function latestVerificationCopy(status: RiaOnboardingStatus | null): string {
-  const latest = status?.latest_advisory_event || status?.latest_verification_event;
-  if (!latest) return "Verification starts after you submit this trust profile.";
-  const outcome = latest.outcome || "latest check";
-  const checkedAt = compactDate(latest.checked_at);
-  return checkedAt ? `${outcome} on ${checkedAt}` : outcome;
 }
 
 function isAdvisoryAccessReady(status?: string | null): boolean {
@@ -415,12 +376,7 @@ export default function RiaOnboardingPage() {
   );
 
   const advisoryVerificationStatus = status?.advisory_status || status?.verification_status || "draft";
-  const brokerageVerificationStatus = status?.brokerage_status || "draft";
   const advisoryAccessReady = isAdvisoryAccessReady(advisoryVerificationStatus);
-  const brokerageAccessReady =
-    brokerageVerificationStatus === "active" ||
-    brokerageVerificationStatus === "verified" ||
-    brokerageVerificationStatus === "bypassed";
   const displayNameQuery = draft.displayName.trim();
   latestDisplayNameRef.current = displayNameQuery;
   const persistedVerifiedDisplayName = status?.display_name?.trim() || "";
@@ -1025,6 +981,16 @@ export default function RiaOnboardingPage() {
                       : "Verify"}
                 </button>
               ) : null}
+              {devRiaBypassAllowed && !nameVerificationSatisfied ? (
+                <button
+                  type="button"
+                  onClick={() => void handleDevActivate()}
+                  disabled={saving || displayNameQuery.length === 0}
+                  className="inline-flex min-h-10 items-center rounded-full border border-border bg-background px-4 text-sm font-medium text-foreground hover:bg-muted/40 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {saving ? "Activating..." : "Bypass verification"}
+                </button>
+              ) : null}
             </div>
 
             <p className="text-sm leading-6 text-muted-foreground">
@@ -1247,71 +1213,6 @@ export default function RiaOnboardingPage() {
 
       {!iamUnavailable ? (
         <div className="space-y-5">
-          <SurfaceInset className="space-y-4 px-4 py-4">
-            <div className="flex flex-wrap items-start justify-between gap-3">
-              <div className="space-y-1">
-                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-primary/80">
-                  Trust summary
-                </p>
-                <h2 className="text-sm font-semibold">Keep the verification state visible, not heavy</h2>
-                <p className="max-w-3xl text-sm text-muted-foreground">
-                  This summary stays persistent while the wizard keeps attention on one decision at a time.
-                </p>
-              </div>
-              {loading ? (
-                <Badge variant="secondary">
-                  <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
-                  Loading
-                </Badge>
-              ) : (
-                <Badge variant="secondary">
-                  {formatVerificationStatus(advisoryVerificationStatus, false)}
-                </Badge>
-              )}
-            </div>
-
-            <div className="flex flex-wrap gap-2">
-              <Badge variant="secondary">
-                {capabilityLabels.length > 0 ? capabilityLabels.join(" + ") : "No capabilities selected"}
-              </Badge>
-              <Badge variant="secondary">
-                {advisoryAccessReady
-                  ? "RIA workspace ready"
-                  : brokerageAccessReady
-                    ? "Broker lane verified"
-                    : "Activation still gated"}
-              </Badge>
-              {draft.displayName.trim() ? (
-                <Badge variant="secondary">{draft.displayName.trim()}</Badge>
-              ) : null}
-            </div>
-
-            <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-              <ReviewField
-                label="Verification"
-                value={formatVerificationStatus(advisoryVerificationStatus, loading)}
-                helper={latestVerificationCopy(status)}
-              />
-              {draft.requestedCapabilities.includes("brokerage") ? (
-                <ReviewField
-                  label="Brokerage"
-                  value={formatVerificationStatus(brokerageVerificationStatus, false, "brokerage")}
-                  helper="Broker capability stays isolated from advisory access."
-                />
-              ) : null}
-              <ReviewField
-                label="Current focus"
-                value={`Step ${currentStepIndex + 1} of ${steps.length}`}
-                helper={currentStep?.title}
-              />
-              <ReviewField
-                label="Investor identity"
-                value={draft.displayName.trim() || user?.displayName || user?.email || "Not set yet"}
-                helper="The name carried into invites and consent prompts."
-              />
-            </div>
-          </SurfaceInset>
-
           <SurfaceCard className="mx-auto w-full max-w-3xl">
             <SurfaceCardHeader className="space-y-4 border-b border-border/60">
               <div className="flex items-center justify-between gap-3">
@@ -1412,17 +1313,6 @@ export default function RiaOnboardingPage() {
             </SurfaceCardContent>
           </SurfaceCard>
 
-          <SurfaceInset className="space-y-3 px-4 py-4">
-            <div className="flex items-start gap-3">
-              <ShieldQuestion className="mt-0.5 h-4 w-4 text-muted-foreground" />
-              <div className="space-y-1">
-                <p className="text-sm font-medium text-foreground">Deferred for later settings</p>
-                <p className="text-sm text-muted-foreground">
-                  Long bio, disclosures URL, firm role, communication style, and alert cadence now stay out of onboarding so activation feels shorter and clearer.
-                </p>
-              </div>
-            </div>
-          </SurfaceInset>
         </div>
       ) : null}
     </RiaPageShell>

--- a/hushh-webapp/components/app-ui/top-app-bar.tsx
+++ b/hushh-webapp/components/app-ui/top-app-bar.tsx
@@ -113,7 +113,7 @@ function getTopBarTitle(
   }
 
   if (pathname === ROUTES.RIA_ONBOARDING || pathname.startsWith(`${ROUTES.RIA_ONBOARDING}/`)) {
-    return { label: "Set up RIA", interactive: false as const };
+    return { label: "Set up RIA", icon: BriefcaseBusiness, interactive: true as const };
   }
 
   if (pathname === ROUTES.DEVELOPERS) {
@@ -194,6 +194,9 @@ export function TopAppBar({ className }: TopAppBarProps) {
       });
 
       if (target === activePersona) {
+        if (pathname === ROUTES.RIA_ONBOARDING && target === "investor") {
+          router.push(nextRoute);
+        }
         return;
       }
 
@@ -214,7 +217,7 @@ export function TopAppBar({ className }: TopAppBarProps) {
         setSwitchingPersona(null);
       }
     },
-    [activePersona, lastKaiPath, lastRiaPath, riaCapability, riaEntryRoute, router, switchPersona]
+    [activePersona, lastKaiPath, lastRiaPath, pathname, riaCapability, riaEntryRoute, router, switchPersona]
   );
 
   // Subscribe to scroll-direction store so top glass height follows tabs visibility.

--- a/hushh-webapp/lib/services/user-local-state-service.ts
+++ b/hushh-webapp/lib/services/user-local-state-service.ts
@@ -2,6 +2,7 @@
 
 import { KaiNavTourLocalService } from "@/lib/services/kai-nav-tour-local-service";
 import { PreVaultOnboardingService } from "@/lib/services/pre-vault-onboarding-service";
+import { RiaOnboardingDraftLocalService } from "@/lib/services/ria-onboarding-draft-local-service";
 import { VaultMethodPromptLocalService } from "@/lib/services/vault-method-prompt-local-service";
 
 /**
@@ -19,6 +20,7 @@ export class UserLocalStateService {
     const tasks: Array<Promise<unknown>> = [
       PreVaultOnboardingService.clear(userId),
       KaiNavTourLocalService.clear(userId),
+      RiaOnboardingDraftLocalService.clear(userId),
       VaultMethodPromptLocalService.clear(userId),
     ];
 
@@ -30,4 +32,3 @@ export class UserLocalStateService {
     }
   }
 }
-


### PR DESCRIPTION
## Summary
- make the shared persona pill interactive on RIA onboarding and allow selecting Investor to leave onboarding even when Investor is already the persisted persona
- add the existing non-production RIA verification bypass directly on the advisor-name step
- remove the RIA onboarding trust summary/deferred-settings helper cards and clear persisted RIA onboarding drafts during account/persona cleanup

## Verification
- ./bin/hushh codex pre-pr
- cd hushh-webapp && npm run test -- __tests__/app/ria/onboarding-page.test.tsx __tests__/components/top-app-bar.contract.test.ts __tests__/services/user-local-state-service.test.ts
- cd hushh-webapp && npm run typecheck
- cd hushh-webapp && npm run verify:cache
- cd hushh-webapp && npm run verify:docs
- cd hushh-webapp && npm run verify:design-system
- cd hushh-webapp && npm run lint
- cd consent-protocol && python3 -m pytest tests/test_ria_iam_routes.py -q
- cd consent-protocol && python3 -m pytest tests/test_granular_scopes.py -q

## Known local-only gap
- cd hushh-webapp && npm run verify:routes currently cannot bootstrap reviewer login because local APP_REVIEW_MODE is disabled; failure reports `App review mode is disabled`, not a route regression.