### PR TITLE
fix(security): use DB-backed token validation in Kai stream auth (#429)

### DIFF
--- a/consent-protocol/api/routes/kai/stream.py
+++ b/consent-protocol/api/routes/kai/stream.py
@@ -30,7 +30,7 @@ from hushh_mcp.agents.kai.debate_engine import DebateEngine
 from hushh_mcp.agents.kai.fundamental_agent import FundamentalAgent, FundamentalInsight
 from hushh_mcp.agents.kai.sentiment_agent import SentimentAgent, SentimentInsight
 from hushh_mcp.agents.kai.valuation_agent import ValuationAgent, ValuationInsight
-from hushh_mcp.consent.token import validate_token
+from hushh_mcp.consent.token import validate_token, validate_token_with_db
 from hushh_mcp.constants import ConsentScope
 from hushh_mcp.operons.kai.llm import (
     get_gemini_unavailable_reason,
@@ -63,7 +63,10 @@ async def _require_vault_owner_token(
         )
 
     consent_token = authorization.replace("Bearer ", "")
-    valid, reason, payload = validate_token(consent_token, ConsentScope.VAULT_OWNER)
+    # DB-backed check catches cross-instance revocations (issue #429).
+    valid, reason, payload = await validate_token_with_db(
+        consent_token, ConsentScope.VAULT_OWNER
+    )
 
     if not valid or not payload:
         raise HTTPException(status_code=401, detail=f"Invalid token: {reason}")
@@ -2409,7 +2412,7 @@ async def analyze_stream(
     - decision: Final decision card
     - error: Fatal error
     """
-    # Auth path includes validate_token() inside _require_vault_owner_token().
+    # Auth path includes validate_token_with_db() inside _require_vault_owner_token().
     consent_token = await _require_vault_owner_token(user_id=user_id, authorization=authorization)
 
     # Log operation for audit trail (shows what vault.owner token was used for)
@@ -2445,7 +2448,7 @@ async def analyze_stream_post(
     POST version of streaming analysis (allows context in body).
     Also supports streaming an existing resumable run via run_id.
     """
-    # Auth path includes validate_token() inside _require_vault_owner_token().
+    # Auth path includes validate_token_with_db() inside _require_vault_owner_token().
     consent_token = await _require_vault_owner_token(
         user_id=body.user_id,
         authorization=authorization,

--- a/consent-protocol/tests/test_kai_stream_revocation_bypass.py
+++ b/consent-protocol/tests/test_kai_stream_revocation_bypass.py
@@ -1,0 +1,129 @@
+"""Regression tests for issue #429: Kai stream must honor DB revocation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routes.kai import router as kai_router
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(kai_router)
+    return TestClient(app)
+
+
+def _bearer(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def stub_stream_generator(monkeypatch):
+    import api.routes.kai.stream as stream_routes
+
+    async def _noop_log_operation(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def _fake_generator(*args: Any, **kwargs: Any):
+        yield {"event": "ping", "data": "{}", "id": "1"}
+
+    monkeypatch.setattr(stream_routes.ConsentDBService, "log_operation", _noop_log_operation)
+    monkeypatch.setattr(stream_routes, "analyze_stream_generator", _fake_generator)
+
+
+@pytest.fixture(autouse=True)
+def _clear_testing_env(monkeypatch):
+    # validate_token_with_db skips the DB check when TESTING=true.
+    monkeypatch.delenv("TESTING", raising=False)
+
+
+def test_revoked_token_is_rejected_on_analyze_stream_get(
+    client, vault_owner_token_for_user, monkeypatch
+):
+    token = vault_owner_token_for_user("user_a")
+
+    async def _inactive(self, user_id, scope, agent_id):
+        return False
+
+    from hushh_mcp.services.consent_db import ConsentDBService
+
+    monkeypatch.setattr(ConsentDBService, "is_token_active", _inactive)
+
+    response = client.get(
+        "/api/kai/analyze/stream",
+        params={"ticker": "AAPL", "user_id": "user_a"},
+        headers=_bearer(token),
+    )
+
+    assert response.status_code == 401
+    assert "revoked" in response.json().get("detail", "").lower()
+
+
+def test_revoked_token_is_rejected_on_analyze_stream_post(
+    client, vault_owner_token_for_user, monkeypatch
+):
+    token = vault_owner_token_for_user("user_a")
+
+    async def _inactive(self, user_id, scope, agent_id):
+        return False
+
+    from hushh_mcp.services.consent_db import ConsentDBService
+
+    monkeypatch.setattr(ConsentDBService, "is_token_active", _inactive)
+
+    response = client.post(
+        "/api/kai/analyze/stream",
+        json={"ticker": "AAPL", "user_id": "user_a"},
+        headers=_bearer(token),
+    )
+
+    assert response.status_code == 401
+    assert "revoked" in response.json().get("detail", "").lower()
+
+
+def test_active_token_still_passes_auth_gate(
+    client, vault_owner_token_for_user, monkeypatch, stub_stream_generator
+):
+    token = vault_owner_token_for_user("user_a")
+
+    async def _active(self, user_id, scope, agent_id):
+        return True
+
+    from hushh_mcp.services.consent_db import ConsentDBService
+
+    monkeypatch.setattr(ConsentDBService, "is_token_active", _active)
+
+    response = client.get(
+        "/api/kai/analyze/stream",
+        params={"ticker": "AAPL", "user_id": "user_a"},
+        headers=_bearer(token),
+    )
+
+    assert response.status_code not in {401, 403}
+
+
+def test_db_outage_does_not_downgrade_to_unauthenticated(
+    client, vault_owner_token_for_user, monkeypatch, stub_stream_generator
+):
+    # Transient DB failure must not log every user out of Kai.
+    token = vault_owner_token_for_user("user_a")
+
+    async def _boom(self, user_id, scope, agent_id):
+        raise RuntimeError("simulated DB outage")
+
+    from hushh_mcp.services.consent_db import ConsentDBService
+
+    monkeypatch.setattr(ConsentDBService, "is_token_active", _boom)
+
+    response = client.get(
+        "/api/kai/analyze/stream",
+        params={"ticker": "AAPL", "user_id": "user_a"},
+        headers=_bearer(token),
+    )
+
+    assert response.status_code not in {401, 403}


### PR DESCRIPTION
## Summary

`_require_vault_owner_token` in [consent-protocol/api/routes/kai/stream.py](consent-protocol/api/routes/kai/stream.py#L54) called `validate_token`, which only checks the per-process in-memory revoked set. A consent token revoked on another Cloud Run instance (or revoked via `/api/consent/revoke` right before a load-balancer failover to a different replica) continued to authenticate Kai `/api/kai/analyze/stream` requests on the replica that had not yet seen the revocation locally.

This leaves a cross-instance **consent revocation bypass** on the vault-owner surface that fronts Kai analysis and the PKM vault — a direct violation of the consent-first guarantee.

## Root cause

- `hushh_mcp/consent/token.py` exposes two validators:
  - `validate_token` — signature, expiry, and *in-process* `_revoked_tokens` set only.
  - `validate_token_with_db` — the above plus `ConsentDBService.is_token_active` (authoritative, shared across replicas).
- Every other sensitive Kai route (chat, portfolio, losers stream, etc.) already uses the DB-backed path. The analyze/stream guard was the outlier.

## Fix

Switch `_require_vault_owner_token` to `validate_token_with_db(consent_token, ConsentScope.VAULT_OWNER)`. The function was already `async` and every caller already `await`s it, so no signature change propagates.

`validate_token_with_db` has a safe fallback: if the DB lookup itself raises (transient outage), it logs and returns the in-memory result, so legitimate non-revoked tokens are not 401'd during a DB blip.

## Validation

```
$ cd consent-protocol
$ uv run pytest tests/test_kai_stream_revocation_bypass.py -v
============================== 4 passed in 25.47s ==============================
```

New regression tests ([consent-protocol/tests/test_kai_stream_revocation_bypass.py](consent-protocol/tests/test_kai_stream_revocation_bypass.py)):

1. `test_revoked_token_is_rejected_on_analyze_stream_get` — monkeypatches `ConsentDBService.is_token_active` to return `False`; GET returns `401 Invalid token: Token has been revoked`.
2. `test_revoked_token_is_rejected_on_analyze_stream_post` — same check, POST body variant.
3. `test_active_token_still_passes_auth_gate` — happy path; returns non-401/403.
4. `test_db_outage_does_not_downgrade_to_unauthenticated` — raises `RuntimeError` from `is_token_active`; legitimate token still passes (fallback works). Prevents turning a transient DB outage into a global Kai logout.

No regression in adjacent suites:

```
$ uv run pytest tests/test_kai_auth_matrix.py tests/test_kai_stream_contract.py tests/test_kai_stream_context_gate.py -v
============================== 56 passed in 5.59s ==============================
```

## Risk

- **Latency:** adds one indexed DB read per authed SSE open. Negligible vs SSE runtime.
- **Availability:** `validate_token_with_db` degrades to in-memory on DB errors (same behavior every other Kai route already exhibits).
- **Compatibility:** no request/response contract change, no public-surface change.

## Follow-ups (out of scope)

- Consider raising the log level for DB-fallback to `WARNING` plus adding a counter metric so ops can see when the fallback window is load-bearing.
- Audit remaining `validate_token` callsites inside `consent-protocol/` for the same cross-instance revocation gap.

---

Closes #429.