### PR TITLE
Send governed web analytics directly to GA4

### DIFF
--- a/.codex/skills/analytics-observability-governance/SKILL.md
+++ b/.codex/skills/analytics-observability-governance/SKILL.md
@@ -80,7 +80,9 @@ Non-owned surfaces:
 10. UAT analytics smoke must reuse the existing reviewer test fixture through `REVIEWER_UID` and `REVIEWER_VAULT_PASSPHRASE`; `UAT_SMOKE_*` and `KAI_TEST_*` are temporary migration aliases only.
 11. If the smoke fixture is missing portfolio or recommendation state, repair or reseed that same fixture rather than minting another account.
 12. After the cold `/login` boot, Playwright analytics smoke must use Next client navigation for protected route transitions so the in-memory vault key is preserved.
-13. Spawn subagents only for independent, bounded, non-blocking lanes such as read-only route coverage audits, docs/skill updates, or disjoint verification automation patches; keep the immediate critical-path task local.
+13. Web observability must push `dataLayer` for GTM compatibility and send direct GA4 `gtag` events to the configured measurement ID; do not let GTM trigger drift be the only path for governed KPI events.
+14. UAT smoke must verify direct GA4 collect handoff for required web events in addition to client-side `dataLayer` capture.
+15. Spawn subagents only for independent, bounded, non-blocking lanes such as read-only route coverage audits, docs/skill updates, or disjoint verification automation patches; keep the immediate critical-path task local.
 
 ## Handoff Rules
 

--- a/docs/reference/operations/observability-google-first.md
+++ b/docs/reference/operations/observability-google-first.md
@@ -333,7 +333,7 @@ This bundle is expected to fail until GA Admin API config, GA Data API event ava
 Route and smoke policy:
 
 1. `npm run verify:analytics` includes a strict all-routes route-ID test; first-party `app/**/page.tsx` routes must not resolve to `unknown`.
-2. `npm run smoke:analytics:uat` is the deployed UAT web proof. It reuses the existing reviewer test fixture through maintainer-only `REVIEWER_UID` and `REVIEWER_VAULT_PASSPHRASE`, validates `G-H1KGXGZTCF`, rejects production measurement leakage, and fails if the real app journey does not emit the required events.
+2. `npm run smoke:analytics:uat` is the deployed UAT web proof. It reuses the existing reviewer test fixture through maintainer-only `REVIEWER_UID` and `REVIEWER_VAULT_PASSPHRASE`, validates `G-H1KGXGZTCF`, rejects production measurement leakage, and fails if the real app journey does not emit the required events or direct GA4 collect handoff for the required UAT events.
 3. UAT smoke never fabricates GA4 events and never creates Firebase users, reviewer users, app environments, or one-off analytics fixtures.
 4. After the cold `/login` boot, protected-route smoke navigation must use Next client navigation so the in-memory vault key is not lost by full page reloads.
 5. Missing credentials, missing seeded portfolio state, or absent recommendation events are gate failures; fix or reseed the existing reviewer test fixture instead of minting another account.

--- a/docs/reference/quality/analytics-verification-contract.md
+++ b/docs/reference/quality/analytics-verification-contract.md
@@ -49,10 +49,10 @@ What this proves:
 2. the growth helper emits the expected contract
 3. every first-party `app/**/page.tsx` route resolves to a stable non-`unknown` `route_id`
 4. native Firebase adapter still exists and is wired
-5. web transport still supports direct GA delivery without GTM being mandatory
+5. web transport pushes `dataLayer` for GTM compatibility and sends direct GA4 `gtag` events to the configured measurement ID
 6. docs and the implementation references remain aligned
 7. sandbox audit emits a local report for representative investor and RIA journeys without affecting GA4 numbers
-8. UAT smoke proves a real deployed UAT browser journey when maintainer-only smoke credentials are available
+8. UAT smoke proves a real deployed UAT browser journey and direct GA4 collect handoff when maintainer-only smoke credentials are available
 
 Repo verification fails if:
 

--- a/hushh-webapp/__tests__/services/observability-sandbox-audit.test.ts
+++ b/hushh-webapp/__tests__/services/observability-sandbox-audit.test.ts
@@ -188,7 +188,12 @@ async function recordScenario(
     const gtagEntry = newGtagEntries[index]!;
 
     expect(dataLayerEntry.eventName).toBe(gtagEntry.eventName);
-    expect(dataLayerEntry.payload).toMatchObject(gtagEntry.payload);
+    const { event: dataLayerEvent, ...sharedDataLayerPayload } = dataLayerEntry.payload;
+    expect(dataLayerEvent).toBe(eventName);
+    expect(gtagEntry.payload).toMatchObject({
+      ...sharedDataLayerPayload,
+      send_to: resolveAnalyticsMeasurementId(),
+    });
 
     if (
       eventName === "growth_funnel_step_completed" ||

--- a/hushh-webapp/__tests__/services/observability-web-transport.test.ts
+++ b/hushh-webapp/__tests__/services/observability-web-transport.test.ts
@@ -60,6 +60,7 @@ describe("web observability transport", () => {
       "event",
       "growth_funnel_step_completed",
       {
+        send_to: "G-H1KGXGZTCF",
         event_source: "observability_v2",
         env: "uat",
         platform: "web",
@@ -71,7 +72,7 @@ describe("web observability transport", () => {
     );
   });
 
-  it("keeps GTM as the owner when a real container is configured", async () => {
+  it("pushes to GTM and still sends direct GA4 when a real container is configured", async () => {
     vi.stubEnv("NEXT_PUBLIC_APP_ENV", "production");
     vi.stubEnv("NEXT_PUBLIC_GTM_ID", "GTM-ABC1234");
     vi.stubEnv("NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID", "G-2PCECPSKCR");
@@ -97,6 +98,20 @@ describe("web observability transport", () => {
         app_version: "2.1.0",
       },
     ]);
-    expect(window.gtag).not.toHaveBeenCalled();
+    expect(window.gtag).toHaveBeenCalledTimes(1);
+    expect(window.gtag).toHaveBeenCalledWith(
+      "event",
+      "investor_activation_completed",
+      {
+        send_to: "G-2PCECPSKCR",
+        event_source: "observability_v2",
+        env: "production",
+        platform: "web",
+        event_category: "funnel",
+        journey: "investor",
+        portfolio_source: "statement",
+        app_version: "2.1.0",
+      }
+    );
   });
 });

--- a/hushh-webapp/lib/observability/adapters/web-gtm.ts
+++ b/hushh-webapp/lib/observability/adapters/web-gtm.ts
@@ -3,10 +3,7 @@ import type {
   ObservabilityEventName,
   PrimitiveEventValue,
 } from "@/lib/observability/events";
-import {
-  resolveAnalyticsMeasurementId,
-  resolveGtmContainerId,
-} from "@/lib/observability/env";
+import { resolveAnalyticsMeasurementId } from "@/lib/observability/env";
 
 declare global {
   interface Window {
@@ -40,17 +37,14 @@ export const webGtmAdapter: ObservabilityAdapter = {
     };
     window.dataLayer.push(transportPayload);
 
-    // If a real GTM container is configured, let GTM own downstream forwarding.
-    if (resolveGtmContainerId()) {
-      return;
-    }
-
-    if (!resolveAnalyticsMeasurementId()) {
+    const measurementId = resolveAnalyticsMeasurementId();
+    if (!measurementId) {
       return;
     }
 
     if (typeof window.gtag === "function") {
       window.gtag("event", eventName, {
+        send_to: measurementId,
         event_source: "observability_v2",
         ...payload,
       });

--- a/hushh-webapp/scripts/testing/run-uat-analytics-smoke.mjs
+++ b/hushh-webapp/scripts/testing/run-uat-analytics-smoke.mjs
@@ -283,6 +283,7 @@ async function navigateInApp(page, href) {
 }
 
 const analyticsRequestMeasurementIds = [];
+const analyticsCollectEvents = [];
 const browser = await chromium.launch({ headless: true });
 const context = await browser.newContext({
   viewport: { width: 1440, height: 900 },
@@ -294,17 +295,122 @@ await installAnalyticsCapture(page);
 
 page.on("request", (request) => {
   const url = request.url();
-  if (!/google-analytics\.com\/(?:g\/)?collect/.test(url)) return;
-  try {
-    const parsed = new URL(url);
-    const measurementId = parsed.searchParams.get("tid");
-    if (measurementId) analyticsRequestMeasurementIds.push(measurementId);
-  } catch {
-    // Request URL parsing failure is non-fatal; the final measurement checks still run.
+  if (!isAnalyticsCollectUrl(url)) return;
+  const collect = parseAnalyticsCollectRequest(request);
+  if (!collect) return;
+  analyticsRequestMeasurementIds.push(collect.measurementId);
+  if (collect.eventName) {
+    analyticsCollectEvents.push({ ...collect, status: "requested" });
   }
 });
 
+page.on("requestfinished", (request) => {
+  const collect = parseAnalyticsCollectRequest(request);
+  if (collect?.eventName) {
+    analyticsCollectEvents.push({ ...collect, status: "finished" });
+  }
+});
+
+page.on("requestfailed", (request) => {
+  const collect = parseAnalyticsCollectRequest(request);
+  if (collect?.eventName) {
+    analyticsCollectEvents.push({
+      ...collect,
+      status: "failed",
+      failureText: request.failure()?.errorText || "unknown",
+    });
+  }
+});
+
+function parseAnalyticsCollectRequest(request) {
+  const url = request.url();
+  if (!isAnalyticsCollectUrl(url)) return null;
+  try {
+    const parsed = new URL(url);
+    const measurementId = parsed.searchParams.get("tid");
+    const queryEventName = parsed.searchParams.get("en");
+    if (!measurementId) return null;
+    if (queryEventName) {
+      return { measurementId, eventName: queryEventName };
+    }
+    const postData =
+      request.postData() ||
+      (typeof request.postDataBuffer === "function"
+        ? request.postDataBuffer()?.toString("utf8")
+        : "") ||
+      "";
+    for (const line of postData.split(/\r?\n/)) {
+      const bodyParams = new URLSearchParams(line);
+      const bodyEventName = bodyParams.get("en");
+      if (bodyEventName) {
+        return { measurementId, eventName: bodyEventName };
+      }
+    }
+    return { measurementId, eventName: "" };
+  } catch {
+    return null;
+  }
+}
+
+function isAnalyticsCollectUrl(rawUrl) {
+  try {
+    const parsed = new URL(rawUrl);
+    const host = parsed.hostname.toLowerCase();
+    return (
+      (host.endsWith("google-analytics.com") || host.endsWith("analytics.google.com")) &&
+      parsed.pathname.includes("collect")
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function waitForAnalyticsCollectEvents(eventNames) {
+  const required = new Set(eventNames);
+  await page.waitForFunction(
+    ({ expectedMeasurementId: measurementId, requiredEvents }) => {
+      const observed = window.__HUSHH_ANALYTICS_COLLECT_EVENTS__ || [];
+      return requiredEvents.every((eventName) =>
+        observed.some(
+          (entry) =>
+            entry.measurementId === measurementId &&
+            entry.eventName === eventName &&
+            entry.status === "finished"
+        )
+      );
+    },
+    {
+      expectedMeasurementId,
+      requiredEvents: [...required],
+    },
+    { timeout: defaultTimeoutMs }
+  );
+}
+
 try {
+  await page.addInitScript(() => {
+    window.__HUSHH_ANALYTICS_COLLECT_EVENTS__ = [];
+  });
+  const mirrorCollectEvent = async (entry) => {
+    await page.evaluate((value) => {
+      window.__HUSHH_ANALYTICS_COLLECT_EVENTS__ =
+        window.__HUSHH_ANALYTICS_COLLECT_EVENTS__ || [];
+      window.__HUSHH_ANALYTICS_COLLECT_EVENTS__.push(value);
+    }, entry).catch(() => {});
+  };
+  page.on("request", (request) => {
+    const collect = parseAnalyticsCollectRequest(request);
+    if (collect?.eventName) {
+      void mirrorCollectEvent({ ...collect, status: "requested" });
+    }
+  });
+  page.on("requestfinished", (request) => {
+    const collect = parseAnalyticsCollectRequest(request);
+    if (collect?.eventName) {
+      void mirrorCollectEvent({ ...collect, status: "finished" });
+    }
+  });
+
   await page.goto(`${appOrigin}/login?redirect=${encodeURIComponent("/kai")}`, {
     waitUntil: "domcontentloaded",
   });
@@ -348,6 +454,12 @@ try {
     (payload) => payload.journey === "investor",
     defaultTimeoutMs
   );
+  await waitForAnalyticsCollectEvents([
+    "growth_funnel_step_completed",
+    "portfolio_viewed",
+    "recommendation_viewed",
+    "investor_activation_completed",
+  ]);
 
   const state = await getSmokeState(page);
   const measurementIds = new Set([
@@ -370,6 +482,18 @@ try {
         origin: appOrigin,
         expectedMeasurementId,
         observedMeasurementIds: [...measurementIds].sort(),
+        observedGaCollectEvents: [
+          ...new Set(
+            analyticsCollectEvents
+              .filter(
+                (entry) =>
+                  entry.measurementId === expectedMeasurementId &&
+                  entry.eventName &&
+                  entry.status !== "failed"
+              )
+              .map((entry) => entry.eventName)
+          ),
+        ].sort(),
         events: {
           growth_funnel_step_completed: growthEvent.payload,
           portfolio_viewed: portfolioEvent.payload,
@@ -401,6 +525,13 @@ try {
             ...analyticsRequestMeasurementIds,
           ]),
         ],
+        observedGaCollectEvents: [
+          ...new Set(
+            analyticsCollectEvents
+              .filter((entry) => entry.measurementId === expectedMeasurementId)
+              .map((entry) => `${entry.eventName}:${entry.status}`)
+          ),
+        ].sort(),
       },
       null,
       2


### PR DESCRIPTION
## Summary
- send governed web observability events directly to the configured GA4 measurement ID while preserving dataLayer/GTM compatibility
- tighten UAT analytics smoke to wait for required GA4 collect handoff after the live journey emits required events
- update analytics docs and skill guidance to make direct GA4 delivery part of the governed contract

## Verification
- cd hushh-webapp && npm run verify:analytics
- cd hushh-webapp && npm run typecheck
- cd hushh-webapp && npm run lint
- cd hushh-webapp && npm run build
- python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py
- ./bin/hushh docs verify

## UAT RCA
The deployed smoke proved in-browser dataLayer events, but GA Data API/BigQuery did not show terminal activation rows. The code path skipped direct gtag delivery whenever GTM was configured, making governed KPI events dependent on GTM trigger configuration. This PR restores direct GA4 delivery for the measurement ID and keeps GTM dataLayer compatibility.