### PR TITLE
feat(ui): convert theme toggle to icon dropdown with hover and click …

### DIFF
--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -173,14 +173,10 @@ export const Navbar = () => {
   if (!isAuthenticated || useOnboardingChrome) {
     return (
       <nav
-        className="fixed left-0 right-0 z-50 flex justify-center px-4 pointer-events-none"
-        style={{
-          bottom:
-            "calc(max(var(--app-safe-area-bottom-effective), 0.5rem) + var(--app-bottom-chrome-lift, 0px))",
-        }}
+        className="fixed top-4 right-4 z-50 pointer-events-none"
       >
         <div ref={pillRef} className="pointer-events-auto">
-          <ThemeToggle className="bg-white/85 dark:bg-black/85" />
+          <ThemeToggle className="bg-white/85 dark:bg-black/85 w-auto" />
         </div>
       </nav>
     );

--- a/hushh-webapp/components/theme-toggle.tsx
+++ b/hushh-webapp/components/theme-toggle.tsx
@@ -23,6 +23,7 @@ const THEME_OPTIONS: Array<{
 export function ThemeToggle({ className }: { className?: string }) {
   const { theme, setTheme, resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
 
   useEffect(() => {
     setMounted(true);
@@ -38,51 +39,68 @@ export function ThemeToggle({ className }: { className?: string }) {
   if (!mounted) return null;
 
   return (
-    <div
-      data-theme-control
-      role="radiogroup"
-      aria-label="Theme selector"
-      className={cn(
-        "relative grid w-full min-w-0 grid-cols-3 items-center rounded-full p-1 backdrop-blur-xl sm:w-[216px]",
-        isDark
-          ? "border border-white/6 bg-black"
-          : "border border-slate-200 bg-white",
-        className
-      )}
-    >
-      {THEME_OPTIONS.map((option) => {
-        const isActive = option.value === activeTheme;
-        return (
-          <button
-            key={option.value}
-            type="button"
-            role="radio"
-            aria-checked={isActive}
-            onClick={() => {
-              if (option.value === activeTheme) return;
-              setTheme(option.value);
-            }}
-            className={cn(
-              "relative flex min-h-10 min-w-0 items-center justify-center gap-1.5 overflow-hidden rounded-full border px-2 py-2 text-center transition-[background-color,border-color,color,transform] duration-150",
-              isDark
-                ? isActive
-                  ? "border-white/8 bg-neutral-900 text-white"
-                  : "border-transparent bg-transparent text-zinc-400 hover:bg-white/[0.03] hover:text-zinc-100"
-                : isActive
-                  ? "border-slate-200/90 bg-[linear-gradient(180deg,rgba(255,255,255,1),rgba(248,250,252,0.98))] text-slate-950"
-                  : "border-transparent bg-transparent text-slate-500 hover:bg-white/72 hover:text-slate-900"
-            )}
-          >
-            <span className="relative z-10 inline-flex items-center gap-1.5">
-              <Icon icon={option.icon} size="sm" />
-              <span className="text-[11px] font-medium leading-none sm:text-xs">
+    <div className="relative">
+      {/* Main Icon Button */}
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        onMouseEnter={() => setIsOpen(true)}
+        className={cn(
+          "flex h-10 w-10 items-center justify-center rounded-full border backdrop-blur-xl transition",
+          isDark
+            ? "border-white/10 bg-black text-white"
+            : "border-slate-200 bg-white text-slate-900"
+        )}
+      >
+        <Icon
+          icon={
+            activeTheme === "light"
+              ? Sun
+              : activeTheme === "dark"
+              ? Moon
+              : Monitor
+          }
+          size="sm"
+        />
+      </button>
+
+      {/* Dropdown Options */}
+      {isOpen && (
+        <div
+          onMouseLeave={() => setIsOpen(false)}
+          className={cn(
+            "absolute right-0 mt-2 min-w-[120px] flex flex-col rounded-xl border shadow-lg z-50",
+            isDark
+              ? "border-white/10 bg-neutral-900"
+              : "border-slate-200 bg-white"
+          )}
+        >
+          {THEME_OPTIONS.map((option) => {
+            const isActive = option.value === activeTheme;
+
+            return (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => {
+                  setTheme(option.value);
+                  setIsOpen(false);
+                }}
+                className={cn(
+                  "flex items-center gap-2 px-3 py-2 text-sm transition",
+                  isDark
+                    ? "hover:bg-white/5 text-white"
+                    : "hover:bg-slate-100 text-slate-900",
+                  isActive && "font-semibold"
+                )}
+              >
+                <Icon icon={option.icon} size="sm" />
                 {option.label}
-              </span>
-            </span>
-            <MaterialRipple variant="none" effect="fade" className="z-0" />
-          </button>
-        );
-      })}
+              </button>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/hushh-webapp/components/theme-toggle.tsx
+++ b/hushh-webapp/components/theme-toggle.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from "react";
 import { Moon, Monitor, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 
-import { MaterialRipple } from "@/lib/morphy-ux/material-ripple";
 import { Icon } from "@/lib/morphy-ux/ui";
 import { cn } from "@/lib/utils";
 
@@ -39,7 +38,7 @@ export function ThemeToggle({ className }: { className?: string }) {
   if (!mounted) return null;
 
   return (
-    <div className="relative">
+    <div className={cn("relative", className)}>
       {/* Main Icon Button */}
       <button
         type="button"


### PR DESCRIPTION
# Move Theme Toggle to Top-Right Icon Dropdown

## Description

This change converts the theme toggle from a full-width bottom control into a compact icon-based dropdown positioned at the top-right corner.

The dropdown supports:
- Hover to preview theme options
- Click to keep dropdown open briefly
- Selection of Light / Dark / System themes

This improves layout compactness, reduces UI clutter, and aligns with standard UI placement patterns.

---

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None

- Docs updated (exact files):
  - [x] None

- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm run build`

---

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: UI-only frontend change
- [ ] **iOS**: Not required (no native changes)
- [ ] **Android**: Not required (no native changes)

---

## 🧪 Testing

- [x] Tested on Web (Chrome)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

---

## 📸 Screenshots / Video

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/838d0f73-76af-4d35-8235-8f46dc4369b1" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/db2e32d3-3013-4837-912e-f870166e7c86" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/1d86f6db-4063-4df3-a486-0e3fbc164c9a" />


---

## 🛡️ Privacy & Consent

- [x] Does this change access user data? → No

---

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed → No dependency changes