### PR TITLE
fix(security): accept Authorization Bearer for developer API + remote MCP (close token-in-URL leak vector)

### DIFF
--- a/consent-protocol/api/developer_auth.py
+++ b/consent-protocol/api/developer_auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 
 from fastapi import HTTPException, Request, status
@@ -8,6 +9,8 @@ from hushh_mcp.services.developer_registry_service import (
     DeveloperPrincipal,
     DeveloperRegistryService,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _env_truthy(name: str, fallback: str = "false") -> bool:
@@ -73,12 +76,48 @@ def _resolve_query_token(token: str | None = None) -> str:
     return str(token or "").strip()
 
 
-def _developer_token_query_required_error() -> HTTPException:
-    return HTTPException(
-        status_code=status.HTTP_400_BAD_REQUEST,
-        detail={
-            "error_code": "DEVELOPER_TOKEN_QUERY_REQUIRED",
-            "message": "Use ?token=<developer-token> instead of Authorization header for developer access.",
+def _resolve_developer_token(
+    *,
+    token: str | None,
+    authorization: str | None,
+) -> tuple[str, str]:
+    """
+    Resolve the developer token from either an Authorization: Bearer header or
+    a ?token= query parameter, in that order of preference.
+
+    Returns a (raw_token, source) tuple where source is "bearer", "query", or
+    "" when neither carries a value. Bearer is preferred because tokens passed
+    in URLs leak via Referer headers, server access logs, browser history, and
+    proxy/CDN logs (CWE-598). Query support is retained so existing developer
+    API and remote MCP clients keep working.
+    """
+    bearer_token = _resolve_bearer_token(authorization)
+    if bearer_token:
+        return bearer_token, "bearer"
+
+    query_token = _resolve_query_token(token)
+    if query_token:
+        return query_token, "query"
+
+    return "", ""
+
+
+def _warn_query_token_leak_risk(*, request: Request | None) -> None:
+    path = ""
+    client_ip = ""
+    if request is not None:
+        try:
+            path = request.url.path
+        except Exception:
+            path = ""
+        client_ip = request.client.host if request.client else ""
+    logger.warning(
+        "Developer token received via query parameter; prefer Authorization: Bearer header "
+        "to avoid URL-leak vectors (Referer, access logs, browser history).",
+        extra={
+            "event_type": "developer_token_query_param_use",
+            "path": path,
+            "client_ip": client_ip,
         },
     )
 
@@ -92,17 +131,21 @@ def authenticate_developer_principal(
     if not developer_api_enabled():
         raise developer_api_disabled_error()
 
-    raw_token = _resolve_query_token(token)
+    raw_token, source = _resolve_developer_token(token=token, authorization=authorization)
     if not raw_token:
-        if _resolve_bearer_token(authorization):
-            raise _developer_token_query_required_error()
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail={
                 "error_code": "DEVELOPER_TOKEN_REQUIRED",
-                "message": "Developer token is required. Pass ?token=<developer-token>.",
+                "message": (
+                    "Developer token is required. Pass it as 'Authorization: Bearer <token>' "
+                    "(preferred) or '?token=<token>' (legacy)."
+                ),
             },
         )
+
+    if source == "query":
+        _warn_query_token_leak_risk(request=request)
 
     client_ip = request.client.host if request and request.client else None
     user_agent = request.headers.get("user-agent") if request else None
@@ -131,11 +174,12 @@ def try_authenticate_developer_principal(
     if not developer_api_enabled():
         return None
 
-    raw_token = _resolve_query_token(token)
+    raw_token, source = _resolve_developer_token(token=token, authorization=authorization)
     if not raw_token:
-        if _resolve_bearer_token(authorization):
-            raise _developer_token_query_required_error()
         return None
+
+    if source == "query":
+        _warn_query_token_leak_risk(request=request)
 
     client_ip = request.client.host if request and request.client else None
     user_agent = request.headers.get("user-agent") if request else None

--- a/consent-protocol/mcp_remote.py
+++ b/consent-protocol/mcp_remote.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
 from urllib.parse import parse_qs
 
@@ -13,6 +14,8 @@ from mcp_modules.developer_context import (
     set_current_developer_principal,
 )
 from mcp_server import server as mcp_server
+
+logger = logging.getLogger(__name__)
 
 
 def _header_value(scope: dict[str, Any], header_name: bytes) -> str | None:
@@ -68,18 +71,18 @@ class AuthenticatedRemoteMCPApp:
             await _send_json(send, exc.status_code, exc.detail)
             return
 
-        raw_token = _parse_query_token(scope)
-        has_legacy_header = bool(_header_value(scope, b"authorization"))
-        if not raw_token and has_legacy_header:
-            await _send_json(
-                send,
-                400,
-                {
-                    "error_code": "DEVELOPER_TOKEN_QUERY_REQUIRED",
-                    "message": "Use /mcp/?token=<developer-token> instead of Authorization header.",
-                },
-            )
-            return
+        bearer_header = (_header_value(scope, b"authorization") or "").strip()
+        bearer_token = ""
+        if bearer_header.lower().startswith("bearer "):
+            bearer_token = bearer_header[7:].strip()
+
+        query_token = _parse_query_token(scope)
+
+        # Prefer the Authorization header. Tokens carried in URLs leak via
+        # Referer headers, server access logs, browser history, and CDN/proxy
+        # logs (CWE-598). Query parameters remain accepted for backward
+        # compatibility with existing MCP clients that cannot set headers.
+        raw_token = bearer_token or query_token
 
         if not raw_token:
             await _send_json(
@@ -87,10 +90,24 @@ class AuthenticatedRemoteMCPApp:
                 401,
                 {
                     "error_code": "DEVELOPER_TOKEN_REQUIRED",
-                    "message": "Developer token is required for remote MCP. Use /mcp/?token=<developer-token>.",
+                    "message": (
+                        "Developer token is required for remote MCP. Pass it as "
+                        "'Authorization: Bearer <token>' (preferred) or '?token=<token>' (legacy)."
+                    ),
                 },
             )
             return
+
+        if not bearer_token and query_token:
+            logger.warning(
+                "Remote MCP token received via query parameter; prefer Authorization: Bearer "
+                "header to avoid URL-leak vectors.",
+                extra={
+                    "event_type": "developer_token_query_param_use",
+                    "transport": "remote_mcp",
+                    "client_ip": _client_ip(scope) or "",
+                },
+            )
 
         principal = self._registry.authenticate_token(
             raw_token,

--- a/consent-protocol/tests/test_developer_api_routes.py
+++ b/consent-protocol/tests/test_developer_api_routes.py
@@ -122,7 +122,7 @@ def test_user_scopes_accepts_authorization_bearer_header(monkeypatch):
     )
 
     assert response.status_code == 200
-    assert captured["raw_token"] == "hdk_demo"
+    assert captured["raw_token"] == "hdk_demo"  # noqa: S105
     assert response.json()["app_id"] == "app_demo_123"
 
 
@@ -171,7 +171,7 @@ def test_user_scopes_authorization_bearer_takes_precedence_over_query(monkeypatc
     )
 
     assert response.status_code == 200
-    assert captured["raw_token"] == "from_header"
+    assert captured["raw_token"] == "from_header"  # noqa: S105
 
 
 def test_user_scopes_query_token_logs_url_leak_warning(monkeypatch, caplog):

--- a/consent-protocol/tests/test_developer_api_routes.py
+++ b/consent-protocol/tests/test_developer_api_routes.py
@@ -79,9 +79,41 @@ def test_user_scopes_requires_developer_key(monkeypatch):
     assert detail["error_code"] == "DEVELOPER_TOKEN_REQUIRED"
 
 
-def test_user_scopes_rejects_authorization_header(monkeypatch):
+class _EmptyScopeGenerator:
+    async def get_available_scopes(self, user_id: str) -> list[str]:
+        return []
+
+    async def get_available_scope_entries(self, user_id: str) -> list[dict]:
+        return []
+
+
+class _EmptyIndex:
+    available_domains: list[str] = []
+
+
+class _EmptyPkmService:
+    scope_generator = _EmptyScopeGenerator()
+
+    async def resolve_metadata_index(self, user_id: str):
+        return _EmptyIndex()
+
+
+def test_user_scopes_accepts_authorization_bearer_header(monkeypatch):
     monkeypatch.setenv("ENVIRONMENT", "development")
     monkeypatch.setenv("DEVELOPER_API_ENABLED", "true")
+
+    captured: dict[str, object] = {}
+
+    def _fake_authenticate_token(self, raw_token, *, ip_address=None, user_agent=None):
+        captured["raw_token"] = raw_token
+        return _fake_principal()
+
+    monkeypatch.setattr(
+        developer.DeveloperRegistryService,
+        "authenticate_token",
+        _fake_authenticate_token,
+    )
+    monkeypatch.setattr(developer, "get_pkm_service", lambda: _EmptyPkmService())
 
     client = TestClient(_build_app())
     response = client.get(
@@ -89,9 +121,82 @@ def test_user_scopes_rejects_authorization_header(monkeypatch):
         headers={"Authorization": "Bearer hdk_demo"},
     )
 
-    assert response.status_code == 400
+    assert response.status_code == 200
+    assert captured["raw_token"] == "hdk_demo"
+    assert response.json()["app_id"] == "app_demo_123"
+
+
+def test_user_scopes_invalid_authorization_bearer_returns_403(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("DEVELOPER_API_ENABLED", "true")
+
+    monkeypatch.setattr(
+        developer.DeveloperRegistryService,
+        "authenticate_token",
+        lambda self, *_args, **_kwargs: None,
+    )
+
+    client = TestClient(_build_app())
+    response = client.get(
+        "/api/v1/user-scopes/user_123",
+        headers={"Authorization": "Bearer not-a-real-token"},
+    )
+
+    assert response.status_code == 403
     detail = response.json()["detail"]
-    assert detail["error_code"] == "DEVELOPER_TOKEN_QUERY_REQUIRED"
+    assert detail["error_code"] == "DEVELOPER_TOKEN_INVALID"
+
+
+def test_user_scopes_authorization_bearer_takes_precedence_over_query(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("DEVELOPER_API_ENABLED", "true")
+
+    captured: dict[str, object] = {}
+
+    def _fake_authenticate_token(self, raw_token, *, ip_address=None, user_agent=None):
+        captured["raw_token"] = raw_token
+        return _fake_principal()
+
+    monkeypatch.setattr(
+        developer.DeveloperRegistryService,
+        "authenticate_token",
+        _fake_authenticate_token,
+    )
+    monkeypatch.setattr(developer, "get_pkm_service", lambda: _EmptyPkmService())
+
+    client = TestClient(_build_app())
+    response = client.get(
+        "/api/v1/user-scopes/user_123?token=from_query",
+        headers={"Authorization": "Bearer from_header"},
+    )
+
+    assert response.status_code == 200
+    assert captured["raw_token"] == "from_header"
+
+
+def test_user_scopes_query_token_logs_url_leak_warning(monkeypatch, caplog):
+    import logging as _logging
+
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("DEVELOPER_API_ENABLED", "true")
+
+    monkeypatch.setattr(
+        developer.DeveloperRegistryService,
+        "authenticate_token",
+        lambda self, *_args, **_kwargs: _fake_principal(),
+    )
+    monkeypatch.setattr(developer, "get_pkm_service", lambda: _EmptyPkmService())
+
+    client = TestClient(_build_app())
+    with caplog.at_level(_logging.WARNING, logger="api.developer_auth"):
+        response = client.get("/api/v1/user-scopes/user_123?token=hdk_demo")
+
+    assert response.status_code == 200
+    assert any(
+        getattr(rec, "event_type", "") == "developer_token_query_param_use"
+        or "Authorization: Bearer" in rec.getMessage()
+        for rec in caplog.records
+    )
 
 
 def test_user_scopes_returns_discovered_domains(monkeypatch):
@@ -291,9 +396,15 @@ def test_tool_catalog_filters_to_public_beta_defaults(monkeypatch):
     assert "list_ria_profiles" not in tool_names
 
 
-def test_tool_catalog_rejects_authorization_header(monkeypatch):
+def test_tool_catalog_accepts_authorization_bearer_header(monkeypatch):
     monkeypatch.setenv("ENVIRONMENT", "development")
     monkeypatch.setenv("DEVELOPER_API_ENABLED", "true")
+
+    monkeypatch.setattr(
+        developer.DeveloperRegistryService,
+        "authenticate_token",
+        lambda self, *_args, **_kwargs: _fake_principal(),
+    )
 
     client = TestClient(_build_app())
     response = client.get(
@@ -301,9 +412,7 @@ def test_tool_catalog_rejects_authorization_header(monkeypatch):
         headers={"Authorization": "Bearer hdk_demo"},
     )
 
-    assert response.status_code == 400
-    detail = response.json()["detail"]
-    assert detail["error_code"] == "DEVELOPER_TOKEN_QUERY_REQUIRED"
+    assert response.status_code == 200
 
 
 def test_request_consent_creates_pending_request(monkeypatch):


### PR DESCRIPTION
## Summary

The developer API (`/api/v1/*`) and the remote MCP transport (`/mcp/`) currently authenticate **only** by `?token=<developer-token>` query parameter and actively reject `Authorization: Bearer` with a `400 DEVELOPER_TOKEN_QUERY_REQUIRED`. This forces every external developer to put a long-lived API key into the URL.

Tokens carried in URLs leak through every layer that touches a URL:

- **Referer headers** when the page links out anywhere external
- **Server access logs** (Cloud Run, nginx, ALB, etc. — full URL by default)
- **Browser history** and shared screenshots
- **CDN, WAF, and proxy logs**
- **Browser extensions** that read URLs

This is CWE-598 (Use of GET Request Method With Sensitive Query Strings) and OWASP A02:2021 (Cryptographic Failures). The blast radius is the full developer API surface — `user-scopes/{user_id}`, `consent-status`, `request-consent`, and `scoped-export` (which returns the encrypted vault export tied to the consent token). A single leaked URL gives an attacker the same access as the legitimate app.

## Repro on current main

```
GET /api/v1/user-scopes/user_123
Authorization: Bearer hdk_demo

HTTP/1.1 400 Bad Request
{"detail":{"error_code":"DEVELOPER_TOKEN_QUERY_REQUIRED",
 "message":"Use ?token=<developer-token> instead of Authorization header for developer access."}}
```

The application is _refusing_ the safer path and forcing the insecure one.

## Fix

Accept either transport, prefer the header. Bearer is the canonical RFC 6750 mechanism and survives every URL-leak vector above.

```python
def _resolve_developer_token(*, token, authorization):
    bearer_token = _resolve_bearer_token(authorization)
    if bearer_token:
        return bearer_token, "bearer"
    query_token = _resolve_query_token(token)
    if query_token:
        return query_token, "query"
    return "", ""
```

Applied to both [consent-protocol/api/developer_auth.py](consent-protocol/api/developer_auth.py) (`authenticate_developer_principal`, `try_authenticate_developer_principal`) and the ASGI guard in [consent-protocol/mcp_remote.py](consent-protocol/mcp_remote.py).

When a token still arrives via the query parameter, the auth layer emits a structured `WARNING` log (`event_type=developer_token_query_param_use`) so ops can observe migration progress and pinpoint clients still on the legacy transport before the query-fallback is ultimately removed:

```
Developer token received via query parameter; prefer Authorization: Bearer header
to avoid URL-leak vectors (Referer, access logs, browser history).
```

The 401 message is updated to reflect both options:

```
Developer token is required. Pass it as 'Authorization: Bearer <token>' (preferred)
or '?token=<token>' (legacy).
```

## Validation

```
$ cd consent-protocol
$ uv run pytest tests/test_developer_api_routes.py -v
============================== 24 passed in 0.37s ==============================
```

New tests in [tests/test_developer_api_routes.py](consent-protocol/tests/test_developer_api_routes.py):

- `test_user_scopes_accepts_authorization_bearer_header` — happy path via header (replaces the previous test that pinned the broken `400 DEVELOPER_TOKEN_QUERY_REQUIRED` response).
- `test_user_scopes_invalid_authorization_bearer_returns_403` — invalid header still rejected.
- `test_user_scopes_authorization_bearer_takes_precedence_over_query` — when both are sent, header wins (so a deploy that flips a client to header auth doesn't accidentally still leak the URL token).
- `test_user_scopes_query_token_logs_url_leak_warning` — observable migration signal.
- `test_tool_catalog_accepts_authorization_bearer_header` — second route covered for parity.

The two existing `test_*_rejects_authorization_header` tests that codified the broken behavior are replaced rather than deleted.

## Risk

- **Backward compatibility:** all existing `?token=` callers continue to work unchanged. Any deployed developer app, MCP client, or shell snippet keeps functioning. The only behavior change visible to legacy callers is a single structured log line on each request.
- **Bearer precedence:** if a (theoretical) caller is sending both a header and a query token, the header now wins. There is no in-tree caller doing this; an external caller doing it would typically be migrating off the query path, which is exactly the desired direction.
- **Scope:** patch is local to two files plus tests. No DB schema change, no migration, no ops change.

## Notes for reviewers

- This is framed as hardening rather than a vulnerability disclosure, per `SECURITY.md`'s private-channel policy. If the security team would prefer this tracked as a parallel private advisory, happy to file one.
- The remote MCP path keeps the `?token=` fallback because some MCP HTTP/SSE clients cannot attach custom headers; the warning log lets operators flag those clients for migration without breaking them.

## Follow-ups (out of scope)

- After a deprecation window driven by the new warning log, drop the `?token=` query path entirely (single line: remove the `query_token` fallback in `_resolve_developer_token`).
- Document the header-first contract in `docs/reference/architecture/route-contracts.md` so future developer-API routes inherit the safer default.
