### PR TITLE
feat: add compact theme toggle and move it to top-right on onboarding

### DIFF
--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -17,7 +17,7 @@ import {
 } from "lucide-react";
 
 import { useAuth } from "@/hooks/use-auth";
-import { ThemeToggle } from "@/components/theme-toggle";
+import { ThemeToggleCompact } from "@/components/theme-toggle";
 import { useConsentPendingSummaryCount } from "@/lib/consent/use-consent-pending-summary-count";
 import { useKaiSession } from "@/lib/stores/kai-session-store";
 import { getKaiChromeState } from "@/lib/navigation/kai-chrome-state";
@@ -173,14 +173,13 @@ export const Navbar = () => {
   if (!isAuthenticated || useOnboardingChrome) {
     return (
       <nav
-        className="fixed left-0 right-0 z-50 flex justify-center px-4 pointer-events-none"
+        className="fixed right-0 top-0 z-50 flex justify-end px-4 pointer-events-none"
         style={{
-          bottom:
-            "calc(max(var(--app-safe-area-bottom-effective), 0.5rem) + var(--app-bottom-chrome-lift, 0px))",
+          top: "calc(max(var(--app-safe-area-top-effective), 0.5rem))",
         }}
       >
         <div ref={pillRef} className="pointer-events-auto">
-          <ThemeToggle className="bg-white/85 dark:bg-black/85" />
+          <ThemeToggleCompact />
         </div>
       </nav>
     );

--- a/hushh-webapp/components/theme-toggle.tsx
+++ b/hushh-webapp/components/theme-toggle.tsx
@@ -113,8 +113,11 @@ export function ThemeToggleCompact({ className }: { className?: string }) {
   if (!mounted) return null;
 
   const activeTheme = resolveActiveTheme(theme);
-  const activeOption =
-    THEME_OPTIONS.find((option) => option.value === activeTheme) ?? THEME_OPTIONS[2];
+  // resolveActiveTheme always returns one of the THEME_OPTIONS values, so
+  // .find() is guaranteed to hit. Assert with a non-null fallback for the
+  // type checker under noUncheckedIndexedAccess.
+  const activeOption: (typeof THEME_OPTIONS)[number] =
+    THEME_OPTIONS.find((option) => option.value === activeTheme) ?? THEME_OPTIONS[0]!;
   const isDark = resolvedTheme === "dark";
 
   return (

--- a/hushh-webapp/components/theme-toggle.tsx
+++ b/hushh-webapp/components/theme-toggle.tsx
@@ -4,6 +4,12 @@ import { useEffect, useState } from "react";
 import { Moon, Monitor, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { MaterialRipple } from "@/lib/morphy-ux/material-ripple";
 import { Icon } from "@/lib/morphy-ux/ui";
 import { cn } from "@/lib/utils";
@@ -20,6 +26,14 @@ const THEME_OPTIONS: Array<{
   { value: "system", label: "System", icon: Monitor },
 ];
 
+function resolveActiveTheme(theme: string | undefined): ThemeOption {
+  const normalized = (theme ?? "").trim().toLowerCase();
+  if (normalized === "light" || normalized === "dark" || normalized === "system") {
+    return normalized as ThemeOption;
+  }
+  return "system";
+}
+
 export function ThemeToggle({ className }: { className?: string }) {
   const { theme, setTheme, resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
@@ -28,11 +42,7 @@ export function ThemeToggle({ className }: { className?: string }) {
     setMounted(true);
   }, []);
 
-  const normalizedTheme = (theme ?? "").trim().toLowerCase();
-  const activeTheme: ThemeOption =
-    normalizedTheme === "light" || normalizedTheme === "dark" || normalizedTheme === "system"
-      ? (normalizedTheme as ThemeOption)
-      : "system";
+  const activeTheme = resolveActiveTheme(theme);
   const isDark = resolvedTheme === "dark";
 
   if (!mounted) return null;
@@ -84,5 +94,67 @@ export function ThemeToggle({ className }: { className?: string }) {
         );
       })}
     </div>
+  );
+}
+
+/**
+ * Compact icon-only theme switcher for tight surfaces (e.g. onboarding chrome).
+ * Closes #506: replaces the full segmented control with a 36px icon button
+ * that opens a dropdown with the same Light / Dark / System options.
+ */
+export function ThemeToggleCompact({ className }: { className?: string }) {
+  const { theme, setTheme, resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
+
+  const activeTheme = resolveActiveTheme(theme);
+  const activeOption =
+    THEME_OPTIONS.find((option) => option.value === activeTheme) ?? THEME_OPTIONS[2];
+  const isDark = resolvedTheme === "dark";
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label={`Theme: ${activeOption.label}. Click to change.`}
+          className={cn(
+            "inline-flex h-9 w-9 items-center justify-center rounded-full border backdrop-blur-xl transition-[background-color,border-color,color] duration-150",
+            isDark
+              ? "border-white/8 bg-black/85 text-zinc-100 hover:bg-neutral-900"
+              : "border-slate-200 bg-white/85 text-slate-700 hover:bg-white",
+            className
+          )}
+        >
+          <Icon icon={activeOption.icon} size="sm" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" sideOffset={8} className="min-w-[140px]">
+        {THEME_OPTIONS.map((option) => {
+          const isActive = option.value === activeTheme;
+          return (
+            <DropdownMenuItem
+              key={option.value}
+              onSelect={() => {
+                if (!isActive) setTheme(option.value);
+              }}
+              className={cn(
+                "flex items-center gap-2",
+                isActive && "font-medium"
+              )}
+            >
+              <Icon icon={option.icon} size="sm" />
+              <span className="flex-1">{option.label}</span>
+              {isActive ? <span aria-hidden className="text-xs">✓</span> : null}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }


### PR DESCRIPTION
## Summary

- Adds `ThemeToggleCompact` (single 36px icon button with dropdown) alongside the existing `ThemeToggle` (segmented control) in the same module
- Onboarding navbar now uses the compact variant in the top-right corner instead of the segmented control at bottom-center
- Frees the bottom of the screen for primary content and aligns with the common top-right placement for theme controls
- Profile/settings keeps the full segmented control where the wider surface and labels help discoverability

## Problem

Issue #506: the theme switcher was placed at bottom-center on the onboarding screen. The segmented "Light / Dark / System" control took fixed visible space in a position that competes with primary actions, and on small screens it pushed content above it.

## Approach

Two design choices worth flagging:

1. **One module, two variants.** Added `ThemeToggleCompact` in the same `components/theme-toggle.tsx` file as the existing component, sharing `THEME_OPTIONS` and the `resolveActiveTheme` helper. Avoids creating a parallel component file for the same concept.

2. **Reused the existing dropdown primitive.** The compact variant uses `DropdownMenu` from `components/ui/dropdown-menu.tsx` (already in the design system, Radix-backed) so the popover styling matches the rest of the app.

The navbar `useOnboardingChrome` branch flips from `fixed bottom + justify-center` to `fixed top-0 right-0 + justify-end`, with `top` driven by `--app-safe-area-top-effective` to respect device notches the same way the previous bottom variant respected the safe-area inset.

## What did not change

- The segmented `ThemeToggle` is still used in `profile/page.tsx` and `app/profile/page.tsx`. Removing it would be a bigger UX call than this issue.
- All three modes (Light / Dark / System) are preserved.
- `next-themes` integration is unchanged.

## Test plan

- [x] eslint clean on `components/theme-toggle.tsx` and `components/navbar.tsx`
- [x] Compact variant has `aria-label` reading the active theme so screen readers work
- [x] Active option shows a check mark and the trigger icon updates on selection
- [x] No new top-level routes or component files (avoids parallel-surface trap)
- [x] No secrets or env files in diff

Closes #506