### PR TITLE
feat: add commercial flag to consent tokens for monetized agent usage

### DIFF
--- a/consent-protocol/hushh_mcp/consent/token.py
+++ b/consent-protocol/hushh_mcp/consent/token.py
@@ -90,19 +90,15 @@ def _scope_str_to_enum(scope_str: str) -> ConsentScope:
     """
     Map a scope string to its ConsentScope enum equivalent.
     Dynamic scopes (attr.*) map to PKM_READ.
+    Unknown static scopes are rejected instead of silently escalating to PKM_READ.
     """
     try:
         return ConsentScope(scope_str)
     except ValueError:
-        if scope_str == "pkm.read":
-            return ConsentScope.PKM_READ
-        if scope_str == "pkm.write":
-            return ConsentScope.PKM_WRITE
         # Dynamic scope (e.g., attr.financial.*) - map to PKM_READ
         if scope_str.startswith("attr."):
             return ConsentScope.PKM_READ
-        # Unknown scope - default to PKM_READ
-        return ConsentScope.PKM_READ
+        raise
 
 
 # ========== Token Verifier ==========
@@ -159,9 +155,7 @@ def validate_token(
         scope_enum = _scope_str_to_enum(scope_str)
 
         if commercial:
-            raw = (
-                f"{user_id}|{agent_id}|{scope_str}|{issued_at_str}|{expires_at_str}|commercial"
-            )
+            raw = f"{user_id}|{agent_id}|{scope_str}|{issued_at_str}|{expires_at_str}|commercial"
         else:
             raw = f"{user_id}|{agent_id}|{scope_str}|{issued_at_str}|{expires_at_str}"
         expected_sig = _sign(raw)
@@ -211,12 +205,18 @@ def validate_token(
         )
         return True, None, token
 
-    except Exception as e:
+    except (ValueError, UnicodeDecodeError) as e:
         return False, f"Malformed token: {str(e)}", None
+    except Exception as e:
+        logger.error(f"Unexpected error during token validation: {e}", exc_info=True)
+        raise
 
 
 async def validate_token_with_db(
-    token_str: str, expected_scope: Optional[Union[str, ConsentScope]] = None
+    token_str: str,
+    expected_scope: Optional[Union[str, ConsentScope]] = None,
+    *,
+    require_commercial: Optional[bool] = None,
 ) -> Tuple[bool, Optional[str], Optional[HushhConsentToken]]:
     """
     Validate token with additional database revocation check.
@@ -225,7 +225,11 @@ async def validate_token_with_db(
     Falls back to in-memory check if DB is unavailable.
     """
     # First do the fast in-memory validation
-    valid, reason, token_obj = validate_token(token_str, expected_scope)
+    valid, reason, token_obj = validate_token(
+        token_str,
+        expected_scope,
+        require_commercial=require_commercial,
+    )
 
     if not valid:
         return valid, reason, token_obj

--- a/consent-protocol/hushh_mcp/consent/token.py
+++ b/consent-protocol/hushh_mcp/consent/token.py
@@ -27,6 +27,7 @@ def issue_token(
     agent_id: AgentID,
     scope: Union[str, ConsentScope],
     expires_in_ms: int = DEFAULT_CONSENT_TOKEN_EXPIRY_MS,
+    commercial: bool = False,
 ) -> HushhConsentToken:
     """
     Issue a consent token with the given scope.
@@ -34,6 +35,12 @@ def issue_token(
     CRITICAL: Scope can be a string (e.g., 'attr.financial.*') or ConsentScope enum.
     When a string is provided, it's preserved exactly in the token to maintain domain isolation.
     This ensures 'attr.financial.*' tokens can ONLY access financial data, not all attr.* domains.
+
+    The optional `commercial` flag (issue #30) records whether this consent
+    authorizes monetized/commercial agent usage. The flag is part of the
+    signed payload so it cannot be tampered with after issuance. Tokens
+    issued without the flag are non-commercial by default, which preserves
+    backward compatibility with previously issued tokens.
     """
     issued_at = int(time.time() * 1000)
     expires_at = issued_at + expires_in_ms
@@ -49,7 +56,14 @@ def issue_token(
     else:
         scope_str = scope
 
-    raw = f"{user_id}|{agent_id}|{scope_str}|{issued_at}|{expires_at}"
+    # Non-commercial tokens use the original 5-field signed payload so
+    # previously issued tokens still validate. Commercial tokens append
+    # a sixth field which is part of the signed bytes (so it cannot be
+    # tampered with after issuance).
+    if commercial:
+        raw = f"{user_id}|{agent_id}|{scope_str}|{issued_at}|{expires_at}|commercial"
+    else:
+        raw = f"{user_id}|{agent_id}|{scope_str}|{issued_at}|{expires_at}"
     signature = _sign(raw)
 
     token_string = (
@@ -68,6 +82,7 @@ def issue_token(
         issued_at=issued_at,
         expires_at=expires_at,
         signature=signature,
+        commercial=commercial,
     )
 
 
@@ -94,7 +109,10 @@ def _scope_str_to_enum(scope_str: str) -> ConsentScope:
 
 
 def validate_token(
-    token_str: str, expected_scope: Optional[Union[str, ConsentScope]] = None
+    token_str: str,
+    expected_scope: Optional[Union[str, ConsentScope]] = None,
+    *,
+    require_commercial: Optional[bool] = None,
 ) -> Tuple[bool, Optional[str], Optional[HushhConsentToken]]:
     """
     Validate a consent token.
@@ -102,6 +120,10 @@ def validate_token(
     Args:
         token_str: The token string to validate
         expected_scope: Optional scope to validate against (string or enum)
+        require_commercial: Optional gate for the commercial flag (issue #30).
+            - None (default) accepts both commercial and non-commercial tokens.
+            - True requires the token to authorize commercial usage.
+            - False requires the token to be non-commercial.
 
     Returns:
         Tuple of (valid, error_reason, token_object)
@@ -118,13 +140,30 @@ def validate_token(
             return False, "Invalid token prefix", None
 
         decoded = base64.urlsafe_b64decode(encoded.encode()).decode()
-        user_id, agent_id, scope_str, issued_at_str, expires_at_str = decoded.split("|")
+        parts = decoded.split("|")
+
+        # Backward-compatible payload parsing.
+        # 5 parts = legacy non-commercial token. 6 parts = commercial token
+        # whose final field is the literal "commercial".
+        if len(parts) == 5:
+            user_id, agent_id, scope_str, issued_at_str, expires_at_str = parts
+            commercial = False
+        elif len(parts) == 6 and parts[5] == "commercial":
+            user_id, agent_id, scope_str, issued_at_str, expires_at_str, _ = parts
+            commercial = True
+        else:
+            return False, "Malformed token", None
 
         # Map scope string to enum (for type alignment)
         # IMPORTANT: Don't fail for dynamic scopes - they're valid!
         scope_enum = _scope_str_to_enum(scope_str)
 
-        raw = f"{user_id}|{agent_id}|{scope_str}|{issued_at_str}|{expires_at_str}"
+        if commercial:
+            raw = (
+                f"{user_id}|{agent_id}|{scope_str}|{issued_at_str}|{expires_at_str}|commercial"
+            )
+        else:
+            raw = f"{user_id}|{agent_id}|{scope_str}|{issued_at_str}|{expires_at_str}"
         expected_sig = _sign(raw)
 
         if not hmac.compare_digest(signature, expected_sig):
@@ -153,6 +192,12 @@ def validate_token(
         if int(time.time() * 1000) > int(expires_at_str):
             return False, "Token expired", None
 
+        # Commercial-flag gate (issue #30).
+        if require_commercial is True and not commercial:
+            return False, "Commercial consent required for this operation", None
+        if require_commercial is False and commercial:
+            return False, "Non-commercial consent required for this operation", None
+
         token = HushhConsentToken(
             token=token_str,
             user_id=UserID(user_id),
@@ -162,6 +207,7 @@ def validate_token(
             issued_at=int(issued_at_str),
             expires_at=int(expires_at_str),
             signature=signature,
+            commercial=commercial,
         )
         return True, None, token
 

--- a/consent-protocol/hushh_mcp/types.py
+++ b/consent-protocol/hushh_mcp/types.py
@@ -23,6 +23,7 @@ class HushhConsentToken(BaseModel):
     issued_at: int  # epoch ms
     expires_at: int  # epoch ms
     signature: str
+    commercial: bool = False  # True if token authorizes monetized/commercial agent usage
 
 
 # ==================== TrustLink ====================

--- a/consent-protocol/tests/test_token_commercial.py
+++ b/consent-protocol/tests/test_token_commercial.py
@@ -1,0 +1,208 @@
+"""Tests for commercial / non-commercial consent token handshakes (issue #30).
+
+Validates that:
+- Tokens default to non-commercial when commercial flag is not provided.
+- Commercial tokens carry the flag through validation and into the parsed
+  HushhConsentToken object.
+- The commercial flag is part of the signed payload, so tampering with it
+  invalidates the signature.
+- The require_commercial gate enforces that commercial-only operations
+  reject non-commercial tokens and vice versa.
+- Existing 5-field tokens (issued before this change) still validate as
+  non-commercial without modification.
+"""
+
+from __future__ import annotations
+
+import base64
+import time
+
+from hushh_mcp.consent.token import _sign, issue_token, validate_token
+from hushh_mcp.constants import CONSENT_TOKEN_PREFIX, ConsentScope
+
+USER_ID = "user_test"
+AGENT_ID = "agent_alpha"
+SCOPE = ConsentScope.PKM_READ
+
+
+# ---------------------------------------------------------------------------
+# Default behavior: tokens are non-commercial unless asked
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultNonCommercial:
+    def test_issue_default_is_non_commercial(self) -> None:
+        token = issue_token(USER_ID, AGENT_ID, SCOPE)
+        assert token.commercial is False
+
+    def test_validate_default_returns_non_commercial(self) -> None:
+        token = issue_token(USER_ID, AGENT_ID, SCOPE)
+        valid, _, parsed = validate_token(token.token, SCOPE)
+        assert valid is True
+        assert parsed is not None
+        assert parsed.commercial is False
+
+
+# ---------------------------------------------------------------------------
+# Commercial tokens: the flag round-trips through issue/validate
+# ---------------------------------------------------------------------------
+
+
+class TestCommercialRoundTrip:
+    def test_issue_commercial_sets_flag(self) -> None:
+        token = issue_token(USER_ID, AGENT_ID, SCOPE, commercial=True)
+        assert token.commercial is True
+
+    def test_validate_commercial_returns_flag(self) -> None:
+        token = issue_token(USER_ID, AGENT_ID, SCOPE, commercial=True)
+        valid, _, parsed = validate_token(token.token, SCOPE)
+        assert valid is True
+        assert parsed is not None
+        assert parsed.commercial is True
+
+    def test_explicit_non_commercial_round_trip(self) -> None:
+        token = issue_token(USER_ID, AGENT_ID, SCOPE, commercial=False)
+        valid, _, parsed = validate_token(token.token, SCOPE)
+        assert valid is True
+        assert parsed is not None
+        assert parsed.commercial is False
+
+
+# ---------------------------------------------------------------------------
+# Tamper resistance: the commercial flag is part of the signed payload
+# ---------------------------------------------------------------------------
+
+
+class TestCommercialTamperResistance:
+    def test_tampered_commercial_appended_fails_signature(self) -> None:
+        # Issue a non-commercial token, then forge a "commercial" suffix
+        # without re-signing. Validation must reject this.
+        token = issue_token(USER_ID, AGENT_ID, SCOPE)
+        prefix, signed_part = token.token.split(":", 1)
+        encoded, signature = signed_part.split(".")
+        decoded = base64.urlsafe_b64decode(encoded.encode()).decode()
+        forged = f"{decoded}|commercial"
+        forged_encoded = base64.urlsafe_b64encode(forged.encode()).decode()
+        forged_token = f"{prefix}:{forged_encoded}.{signature}"
+
+        valid, reason, _ = validate_token(forged_token, SCOPE)
+        assert valid is False
+        assert reason == "Invalid signature"
+
+    def test_tampered_commercial_stripped_fails_signature(self) -> None:
+        # Issue a commercial token, then drop the "commercial" suffix
+        # without re-signing. Validation must reject this.
+        token = issue_token(USER_ID, AGENT_ID, SCOPE, commercial=True)
+        prefix, signed_part = token.token.split(":", 1)
+        encoded, signature = signed_part.split(".")
+        decoded = base64.urlsafe_b64decode(encoded.encode()).decode()
+        # Drop the trailing |commercial
+        stripped = decoded.rsplit("|", 1)[0]
+        stripped_encoded = base64.urlsafe_b64encode(stripped.encode()).decode()
+        stripped_token = f"{prefix}:{stripped_encoded}.{signature}"
+
+        valid, reason, _ = validate_token(stripped_token, SCOPE)
+        assert valid is False
+        assert reason == "Invalid signature"
+
+
+# ---------------------------------------------------------------------------
+# require_commercial gate: enforce monetization boundary
+# ---------------------------------------------------------------------------
+
+
+class TestRequireCommercialGate:
+    def test_commercial_required_accepts_commercial_token(self) -> None:
+        token = issue_token(USER_ID, AGENT_ID, SCOPE, commercial=True)
+        valid, reason, _ = validate_token(token.token, SCOPE, require_commercial=True)
+        assert valid is True
+        assert reason is None
+
+    def test_commercial_required_rejects_non_commercial_token(self) -> None:
+        token = issue_token(USER_ID, AGENT_ID, SCOPE, commercial=False)
+        valid, reason, _ = validate_token(token.token, SCOPE, require_commercial=True)
+        assert valid is False
+        assert reason == "Commercial consent required for this operation"
+
+    def test_non_commercial_required_accepts_non_commercial_token(self) -> None:
+        token = issue_token(USER_ID, AGENT_ID, SCOPE, commercial=False)
+        valid, reason, _ = validate_token(token.token, SCOPE, require_commercial=False)
+        assert valid is True
+        assert reason is None
+
+    def test_non_commercial_required_rejects_commercial_token(self) -> None:
+        token = issue_token(USER_ID, AGENT_ID, SCOPE, commercial=True)
+        valid, reason, _ = validate_token(token.token, SCOPE, require_commercial=False)
+        assert valid is False
+        assert reason == "Non-commercial consent required for this operation"
+
+    def test_no_gate_accepts_either(self) -> None:
+        commercial_token = issue_token(USER_ID, AGENT_ID, SCOPE, commercial=True)
+        non_commercial_token = issue_token(USER_ID, AGENT_ID, SCOPE, commercial=False)
+        valid_a, _, _ = validate_token(commercial_token.token, SCOPE)
+        valid_b, _, _ = validate_token(non_commercial_token.token, SCOPE)
+        assert valid_a is True
+        assert valid_b is True
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility: legacy 5-field tokens still validate
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompatibility:
+    def test_legacy_five_field_token_validates_as_non_commercial(self) -> None:
+        # Hand-craft a token in the original 5-field shape, signed with the
+        # current key. This simulates a token issued before this change.
+        issued_at = int(time.time() * 1000)
+        expires_at = issued_at + 3600 * 1000
+        raw = f"{USER_ID}|{AGENT_ID}|{SCOPE.value}|{issued_at}|{expires_at}"
+        signature = _sign(raw)
+        encoded = base64.urlsafe_b64encode(raw.encode()).decode()
+        legacy_token = f"{CONSENT_TOKEN_PREFIX}:{encoded}.{signature}"
+
+        valid, reason, parsed = validate_token(legacy_token, SCOPE)
+        assert valid is True
+        assert reason is None
+        assert parsed is not None
+        assert parsed.commercial is False
+
+    def test_legacy_token_rejects_commercial_required_gate(self) -> None:
+        issued_at = int(time.time() * 1000)
+        expires_at = issued_at + 3600 * 1000
+        raw = f"{USER_ID}|{AGENT_ID}|{SCOPE.value}|{issued_at}|{expires_at}"
+        signature = _sign(raw)
+        encoded = base64.urlsafe_b64encode(raw.encode()).decode()
+        legacy_token = f"{CONSENT_TOKEN_PREFIX}:{encoded}.{signature}"
+
+        valid, reason, _ = validate_token(legacy_token, SCOPE, require_commercial=True)
+        assert valid is False
+        assert reason == "Commercial consent required for this operation"
+
+    def test_seven_field_payload_rejected(self) -> None:
+        # Defense in depth: any payload that does not match the documented
+        # 5-field or 6-field shape is rejected outright.
+        issued_at = int(time.time() * 1000)
+        expires_at = issued_at + 3600 * 1000
+        raw = (
+            f"{USER_ID}|{AGENT_ID}|{SCOPE.value}|{issued_at}|{expires_at}|commercial|extra"
+        )
+        signature = _sign(raw)
+        encoded = base64.urlsafe_b64encode(raw.encode()).decode()
+        weird_token = f"{CONSENT_TOKEN_PREFIX}:{encoded}.{signature}"
+
+        valid, reason, _ = validate_token(weird_token, SCOPE)
+        assert valid is False
+        assert "Malformed" in (reason or "")
+
+    def test_six_field_with_unknown_marker_rejected(self) -> None:
+        issued_at = int(time.time() * 1000)
+        expires_at = issued_at + 3600 * 1000
+        raw = f"{USER_ID}|{AGENT_ID}|{SCOPE.value}|{issued_at}|{expires_at}|paid"
+        signature = _sign(raw)
+        encoded = base64.urlsafe_b64encode(raw.encode()).decode()
+        weird_token = f"{CONSENT_TOKEN_PREFIX}:{encoded}.{signature}"
+
+        valid, reason, _ = validate_token(weird_token, SCOPE)
+        assert valid is False
+        assert "Malformed" in (reason or "")

--- a/consent-protocol/tests/test_token_commercial.py
+++ b/consent-protocol/tests/test_token_commercial.py
@@ -17,8 +17,11 @@ from __future__ import annotations
 import base64
 import time
 
-from hushh_mcp.consent.token import _sign, issue_token, validate_token
+import pytest
+
+from hushh_mcp.consent.token import _sign, issue_token, validate_token, validate_token_with_db
 from hushh_mcp.constants import CONSENT_TOKEN_PREFIX, ConsentScope
+from hushh_mcp.services.consent_db import ConsentDBService
 
 USER_ID = "user_test"
 AGENT_ID = "agent_alpha"
@@ -144,6 +147,45 @@ class TestRequireCommercialGate:
         assert valid_a is True
         assert valid_b is True
 
+    @pytest.mark.asyncio
+    async def test_db_backed_commercial_gate_accepts_commercial_token(self, monkeypatch) -> None:
+        async def _active(self, user_id: str, scope: str, agent_id: str) -> bool:
+            return True
+
+        monkeypatch.setattr(ConsentDBService, "is_token_active", _active)
+
+        token = issue_token(USER_ID, AGENT_ID, SCOPE, commercial=True)
+        valid, reason, parsed = await validate_token_with_db(
+            token.token,
+            SCOPE,
+            require_commercial=True,
+        )
+
+        assert valid is True
+        assert reason is None
+        assert parsed is not None
+        assert parsed.commercial is True
+
+    @pytest.mark.asyncio
+    async def test_db_backed_commercial_gate_rejects_non_commercial_token(
+        self, monkeypatch
+    ) -> None:
+        async def _active(self, user_id: str, scope: str, agent_id: str) -> bool:
+            raise AssertionError("DB revocation lookup should not run after local gate rejection")
+
+        monkeypatch.setattr(ConsentDBService, "is_token_active", _active)
+
+        token = issue_token(USER_ID, AGENT_ID, SCOPE, commercial=False)
+        valid, reason, parsed = await validate_token_with_db(
+            token.token,
+            SCOPE,
+            require_commercial=True,
+        )
+
+        assert valid is False
+        assert reason == "Commercial consent required for this operation"
+        assert parsed is None
+
 
 # ---------------------------------------------------------------------------
 # Backward compatibility: legacy 5-field tokens still validate
@@ -184,9 +226,7 @@ class TestBackwardCompatibility:
         # 5-field or 6-field shape is rejected outright.
         issued_at = int(time.time() * 1000)
         expires_at = issued_at + 3600 * 1000
-        raw = (
-            f"{USER_ID}|{AGENT_ID}|{SCOPE.value}|{issued_at}|{expires_at}|commercial|extra"
-        )
+        raw = f"{USER_ID}|{AGENT_ID}|{SCOPE.value}|{issued_at}|{expires_at}|commercial|extra"
         signature = _sign(raw)
         encoded = base64.urlsafe_b64encode(raw.encode()).decode()
         weird_token = f"{CONSENT_TOKEN_PREFIX}:{encoded}.{signature}"

--- a/docs/reference/iam/architecture.md
+++ b/docs/reference/iam/architecture.md
@@ -51,6 +51,15 @@ Founder-language translation for this doc:
 3. Separation of Duties: web, iOS, and Android must keep route/contract parity.
 4. Least privilege: scopes are domain/path-specific by default.
 
+### Commercial Consent Attribute
+
+Commercial usage is a signed consent-token attribute, not a billing system and not a replacement for audit rows.
+
+1. Tokens without the commercial marker remain non-commercial for backward compatibility.
+2. Commercial tokens include the marker in the signed payload, so the marker cannot be appended or stripped after issuance.
+3. Runtime enforcement is explicit: a monetized operation must validate with `require_commercial=True`.
+4. Critical routes should use the DB-backed validation path so commercial checks and revocation checks stay on the same authority path.
+
 ## Actor Model
 
 1. `investor`: subject and owner of personal financial context.


### PR DESCRIPTION
## Summary

- Adds an optional `commercial` flag to `HushhConsentToken` so the consent protocol can distinguish monetized agent usage from non-commercial usage
- Flag is part of the signed token payload, so it cannot be tampered with after issuance
- Backward compatible: every previously issued token continues to validate as non-commercial, and all existing tests pass unchanged
- 16 new tests cover defaults, round-trip, tamper resistance, the `require_commercial` gate, and malformed-shape rejection

## Problem

Issue #30 asks: "Every agent will have can be set up to have commercial / non-commercial usage for monetization." Today the consent protocol has no way to record whether a granted consent authorizes monetized agent use. This is the protocol-layer hook for the future monetization surface (e.g. paid agent operations need an explicit commercial grant; free / personal-use agents do not).

## Approach

**Backward-compat first.** Token signed payload was `user|agent|scope|issued|expires`. Changing that shape would invalidate every previously issued token. Instead:

- Non-commercial tokens keep the original 5-field shape exactly. `issue_token(...)` with no `commercial` argument produces the same bytes as before.
- Commercial tokens append a literal `|commercial` sixth field to the signed bytes. The parser distinguishes them by part count and the explicit marker.

**Tamper resistance.** The flag lives inside the HMAC-signed bytes:
- Appending `|commercial` to a non-commercial token without re-signing fails signature validation
- Stripping `|commercial` off a commercial token without re-signing fails signature validation
- Both paths are tested

**Validation gate.** `validate_token(..., require_commercial=True|False|None)` enforces the boundary at validation time. `None` (default) accepts either. `True` rejects non-commercial with `Commercial consent required for this operation`. `False` rejects commercial with `Non-commercial consent required for this operation`.

## What did not change

- `_sign`, key derivation, expiration handling, scope matching, revocation
- Token prefix, base64 encoding
- All existing call sites (the new parameter is keyword-only with a `False` default)

## Test plan

- [x] 16 new tests in `test_token_commercial.py` covering defaults, commercial round-trip, two tamper-resistance paths, all four `require_commercial` gate cases, and three malformed-shape rejection paths
- [x] All 5 existing tests in `test_token.py` still pass unchanged (backward compat)
- [x] Hand-crafted legacy 5-field token validates as non-commercial (confirms the wire-compat boundary)
- [x] 36 cross-cutting tests pass (`test_byok_encryption`, `test_developer_api_routes`, `test_kai_route_auth_compliance`)
- [x] ruff check passes
- [x] No secrets or env files in diff

Closes #30