### PR TITLE
Fix path to uv devcontainer feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
     "ghcr.io/devcontainers/features/python:1": {
       "version": "3.13"
     },
-    "ghcr.io/astral-sh/uv/devcontainer-features/uv:1": {}
+    "ghcr.io/devcontainer-community/devcontainer-features/astral.sh-uv:1": {}
   },
   "postCreateCommand": "bash ./bin/hushh bootstrap --mode uat",
   "customizations": {


### PR DESCRIPTION
Path to uv devcontaier feature is broken, and leads to following error when setting up the repository.

```
[101662 ms] Resolving Feature dependencies for 'ghcr.io/astral-sh/uv/devcontainer-features/uv:1'...
[101662 ms] * Processing feature: ghcr.io/astral-sh/uv/devcontainer-features/uv:1
[101954 ms] Could not resolve Feature manifest for 'ghcr.io/astral-sh/uv/devcontainer-features/uv:1'.  If necessary, provide registry credentials with 'docker login <registry>'.
[101954 ms] Github feature.
[101954 ms] Could not resolve Feature 'ghcr.io/astral-sh/uv/devcontainer-features/uv:1'.  Ensure the Feature is published and accessible from your current environment.
[101954 ms] Error: ERR: Feature 'ghcr.io/astral-sh/uv/devcontainer-features/uv:1' could not be processed.  You may not have permission to access this Feature, or may not be logged in.  If the issue persists, report this to the Feature author.
```