### PR TITLE
perf: fire attribute extraction as background task to eliminate LLM wait from chat response

### DIFF
--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 47,
+  "expected_migration_version": 48,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 48,
+  "expected_migration_version": 47,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/hushh_mcp/services/kai_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/kai_chat_service.py
@@ -375,19 +375,12 @@ class KaiChatService:
             # 8. Generate response via LLM
             response_text, tokens = await self._generate_response(system_prompt, message)
 
-            # 9. Fire attribute extraction in the background — do NOT await it.
-            # The LLM call inside extract_and_store adds ~300-800ms of latency
-            # that the caller never benefits from (learned_attributes in the API
-            # response is informational only and nothing downstream blocks on it).
-            # asyncio.create_task schedules it concurrently; the response is
-            # returned to the client immediately after step 8.
-            asyncio.create_task(
-                self.attribute_learner.extract_and_store(
-                    user_id=user_id,
-                    user_message=message,
-                    assistant_response=response_text,
-                ),
-                name=f"attr_learn:{user_id}",
+            # 9. Fire attribute extraction in the background; the response does
+            # not need to wait for learned attributes to be persisted.
+            self._schedule_attribute_learning(
+                user_id=user_id,
+                user_message=message,
+                assistant_response=response_text,
             )
 
             # 10. Store messages in chat history
@@ -431,6 +424,33 @@ class KaiChatService:
                 response="I apologize, but I encountered an issue processing your message. Please try again.",
                 learned_attributes=[],
             )
+
+    def _schedule_attribute_learning(
+        self,
+        *,
+        user_id: str,
+        user_message: str,
+        assistant_response: str,
+    ) -> None:
+        task = asyncio.create_task(
+            self.attribute_learner.extract_and_store(
+                user_id=user_id,
+                user_message=user_message,
+                assistant_response=assistant_response,
+            ),
+            name=f"attr_learn:{user_id}",
+        )
+
+        def _log_attribute_learning_failure(done: asyncio.Task) -> None:
+            try:
+                done.result()
+            except Exception:
+                logger.exception(
+                    "kai_chat.attribute_learning_failed user_id=%s",
+                    user_id,
+                )
+
+        task.add_done_callback(_log_attribute_learning_failure)
 
     async def _should_prompt_portfolio(
         self,

--- a/consent-protocol/hushh_mcp/services/kai_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/kai_chat_service.py
@@ -12,6 +12,7 @@ This service handles:
 7. Intent classification for workflow triggers
 """
 
+import asyncio
 import logging
 import os
 import re
@@ -374,11 +375,19 @@ class KaiChatService:
             # 8. Generate response via LLM
             response_text, tokens = await self._generate_response(system_prompt, message)
 
-            # 9. Extract and store any learned attributes (async, don't block)
-            learned = await self.attribute_learner.extract_and_store(
-                user_id=user_id,
-                user_message=message,
-                assistant_response=response_text,
+            # 9. Fire attribute extraction in the background — do NOT await it.
+            # The LLM call inside extract_and_store adds ~300-800ms of latency
+            # that the caller never benefits from (learned_attributes in the API
+            # response is informational only and nothing downstream blocks on it).
+            # asyncio.create_task schedules it concurrently; the response is
+            # returned to the client immediately after step 8.
+            asyncio.create_task(
+                self.attribute_learner.extract_and_store(
+                    user_id=user_id,
+                    user_message=message,
+                    assistant_response=response_text,
+                ),
+                name=f"attr_learn:{user_id}",
             )
 
             # 10. Store messages in chat history
@@ -410,7 +419,7 @@ class KaiChatService:
                 response=response_text,
                 component_type=component.type if component else None,
                 component_data=component.data if component else None,
-                learned_attributes=learned,
+                learned_attributes=[],  # populated async in background; not available synchronously
                 tokens_used=tokens,
             )
 

--- a/consent-protocol/tests/services/test_kai_chat_service.py
+++ b/consent-protocol/tests/services/test_kai_chat_service.py
@@ -1,0 +1,73 @@
+import asyncio
+import logging
+
+import pytest
+
+from hushh_mcp.services.kai_chat_service import KaiChatService
+
+
+class SlowAttributeLearner:
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+        self.completed = asyncio.Event()
+
+    async def extract_and_store(
+        self,
+        *,
+        user_id: str,
+        user_message: str,
+        assistant_response: str,
+    ) -> list[dict]:
+        self.started.set()
+        await self.release.wait()
+        self.completed.set()
+        return []
+
+
+class FailingAttributeLearner:
+    async def extract_and_store(
+        self,
+        *,
+        user_id: str,
+        user_message: str,
+        assistant_response: str,
+    ) -> list[dict]:
+        raise RuntimeError("attribute extraction failed")
+
+
+@pytest.mark.asyncio
+async def test_schedule_attribute_learning_does_not_block_response_path():
+    service = KaiChatService()
+    learner = SlowAttributeLearner()
+    service._attribute_learner = learner
+
+    service._schedule_attribute_learning(
+        user_id="user-123",
+        user_message="remember that I prefer index funds",
+        assistant_response="Got it.",
+    )
+
+    await asyncio.wait_for(learner.started.wait(), timeout=1)
+    assert not learner.completed.is_set()
+
+    learner.release.set()
+    await asyncio.wait_for(learner.completed.wait(), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_schedule_attribute_learning_logs_background_failure(caplog):
+    service = KaiChatService()
+    service._attribute_learner = FailingAttributeLearner()
+
+    with caplog.at_level(logging.ERROR, logger="hushh_mcp.services.kai_chat_service"):
+        service._schedule_attribute_learning(
+            user_id="user-123",
+            user_message="remember this",
+            assistant_response="Saved.",
+        )
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    assert "kai_chat.attribute_learning_failed user_id=user-123" in caplog.text
+    assert "attribute extraction failed" in caplog.text


### PR DESCRIPTION
## Description

`kai_chat_service.py`: fire attribute extraction as a background task instead of awaiting it on the chat response path.

Previously, every `/chat` request awaited `attribute_learner.extract_and_store()` — a full Gemini API call — before returning the response to the client. This added 300–800ms of latency that the caller never benefited from .

Changed `await self.attribute_learner.extract_and_store(...)` to `asyncio.create_task(...)`. The extraction now runs concurrently after the response is returned. `learned_attributes` in the API response is set to `[]` (was already unused by the frontend).

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] `KaiChatResponse.learned_attributes` will always return `[]` — was already ignored by all clients
- Cache keys touched:
  - [x] None
- World-model domain summary effects:
  - [x] None — attributes still get written to PKM, just ~500ms later than before
- Mobile parity impacts:
  - [x] None — no mobile code touched
- Docs updated:
  - [x] None
- Verification commands executed:
  - [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000`

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: N/A — backend-only change
- [x] **iOS**: N/A
- [x] **Android**: N/A

## 🧪 Testing

- [ ] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

N/A — latency improvement; no visual change.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No — extraction behaviour is unchanged, only scheduling.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No new dependencies added