### PR TITLE
[codex] Add GitHub contribution governance skill

### DIFF
--- a/.codex/skills/codex-skill-authoring/scripts/skill_lint.py
+++ b/.codex/skills/codex-skill-authoring/scripts/skill_lint.py
@@ -62,6 +62,7 @@ EXPECTED_WORKFLOW_IDS = [
     "analytics-observability-review",
     "bug-triage",
     "ci-watch-and-heal",
+    "github-contribution-governance",
     "pre-pr-readiness",
     "security-consent-audit",
     "mobile-parity-check",

--- a/.codex/skills/github-contribution-governance/SKILL.md
+++ b/.codex/skills/github-contribution-governance/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: github-contribution-governance
+description: Use when verifying GitHub contribution attribution, green-dot eligibility, commit author email, PR targeting, and merge readiness for Hussh work so daily contributions land on the intended GitHub profile.
+---
+
+# GitHub Contribution Governance
+
+## Purpose and Trigger
+
+- Primary scope: `github-contribution-governance`
+- Trigger on GitHub contribution graph, green-dot, commit attribution, author-email, PR target, or merge-readiness questions for Hussh work.
+- Avoid overlap with `repo-context`, `github:yeet`, and `github:gh-fix-ci`.
+
+## Coverage and Ownership
+
+- Role: `spoke`
+- Owner family: `repo-operations`
+
+Owned repo surfaces:
+
+1. `.codex/skills/github-contribution-governance`
+2. `.codex/workflows/github-contribution-governance`
+
+Non-owned surfaces:
+
+1. `repo-operations`
+2. `.github/workflows`
+3. `docs`
+
+## Do Use
+
+1. Confirm the active GitHub account before committing, pushing, opening PRs, or merging.
+2. Verify local Git author identity before creating new commits.
+3. Diagnose why a commit, branch, or PR is not showing on the GitHub contribution graph.
+4. Keep daily contribution work on a PR path into `main`, `develop`, or the repository default branch.
+5. Check that GitHub attributes pushed commits to the intended account via the GitHub API.
+
+## Do Not Use
+
+1. Do not rewrite already-pushed history without an explicit user request for the exact branch.
+2. Do not merge a PR before required checks and repository policy are understood.
+3. Do not expose private verified emails from `gh api user/emails`; summarize whether a verified address exists.
+4. Do not treat a pushed feature branch as green-dot complete until GitHub shows an eligible PR or default-branch path.
+5. Do not handle failing CI root cause here; route that to `github:gh-fix-ci` or `repo-operations`.
+
+## Read First
+
+1. `docs/reference/operations/ci.md`
+2. `docs/reference/operations/branch-governance.md`
+3. `https://docs.github.com/en/account-and-profile/reference/profile-contributions-reference`
+4. `https://docs.github.com/en/account-and-profile/how-tos/contribution-settings/troubleshooting-missing-contributions`
+5. `https://docs.github.com/en/account-and-profile/how-tos/email-preferences/setting-your-commit-email-address`
+
+## Workflow
+
+1. Establish identity:
+   - run `gh auth status`
+   - run `gh api user --jq '.login'`
+   - run `git config --get user.name` and `git config --get user.email`
+2. If the local commit email is blank, generic, or not the GitHub no-reply/verified email for the active account, set repo-local Git config before committing.
+3. Before committing, confirm the worktree scope and stage only files that belong to the contribution task.
+4. After committing and pushing, verify attribution with:
+   - `gh api repos/<owner>/<repo>/commits/<sha> --jq '{authorLogin:.author.login,email:.commit.author.email,date:.commit.author.date}'`
+5. If there is no PR for the branch, create one against the requested base or the repository default branch.
+6. For green-dot commit credit, do not stop at branch push. GitHub counts commits when the author email is associated with the account and the commits land on the default branch or `gh-pages`; PRs and issues can also count as contribution events when opened in a standalone repository.
+7. Monitor PR checks through `./bin/hushh codex ci-status` or `gh run list` before merge. If checks fail, hand off to `github:gh-fix-ci`.
+8. Merge only when repository policy allows it and the user has requested merge. After merge, verify the landed commit on `main` or the canonical base.
+9. For older `.local` commits from the last working window, explain the two safe recovery paths:
+   - amend/rebase those commits with the verified email and force-push the feature branch before merge
+   - create a new correctly-authored follow-up commit and merge it
+   Do not rewrite shared history without explicit branch-level approval.
+
+## Handoff Rules
+
+1. If the request is still broad or ambiguous, route it back to `repo-operations`.
+2. If the task is full branch publish or PR creation, use `github:yeet` after this skill verifies author identity.
+3. If the PR checks fail, use `github:gh-fix-ci`.
+4. If branch protection, merge queue, or deployment gates block merge, use `repo-operations`.
+
+## Required Checks
+
+```bash
+gh auth status
+gh api user --jq '.login'
+git config --get user.email
+python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py
+```

--- a/.codex/skills/github-contribution-governance/skill.json
+++ b/.codex/skills/github-contribution-governance/skill.json
@@ -1,0 +1,58 @@
+{
+  "id": "github-contribution-governance",
+  "role": "spoke",
+  "owner_family": "repo-operations",
+  "primary_scope": "github-contribution-governance",
+  "description": "Use when verifying GitHub contribution attribution, green-dot eligibility, commit author email, PR targeting, and merge readiness for Hussh work so daily contributions land on the intended GitHub profile.",
+  "owned_paths": [
+    ".codex/skills/github-contribution-governance",
+    ".codex/workflows/github-contribution-governance"
+  ],
+  "non_owned_paths": [
+    "repo-operations",
+    ".github/workflows",
+    "docs"
+  ],
+  "task_types": [
+    "github-contribution-governance"
+  ],
+  "required_reads": [
+    "docs/reference/operations/ci.md",
+    "docs/reference/operations/branch-governance.md",
+    "https://docs.github.com/en/account-and-profile/reference/profile-contributions-reference",
+    "https://docs.github.com/en/account-and-profile/how-tos/contribution-settings/troubleshooting-missing-contributions",
+    "https://docs.github.com/en/account-and-profile/how-tos/email-preferences/setting-your-commit-email-address"
+  ],
+  "required_commands": [
+    "gh auth status",
+    "gh api user --jq '.login'",
+    "git config --get user.email",
+    "python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py"
+  ],
+  "verification_bundles": [
+    {
+      "id": "github-contribution-governance",
+      "commands": [
+        "gh auth status",
+        "gh api user --jq '.login'",
+        "git config --get user.email",
+        "python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py"
+      ],
+      "tests": []
+    }
+  ],
+  "handoff_targets": [
+    "repo-operations",
+    "planning-board"
+  ],
+  "adjacent_skills": [
+    "repo-operations",
+    "planning-board"
+  ],
+  "risk_tags": [
+    "contribution-attribution-drift",
+    "wrong-author-email",
+    "unmerged-branch-drift",
+    "self-merge-policy-risk"
+  ]
+}

--- a/.codex/skills/repo-context/references/ownership-map.md
+++ b/.codex/skills/repo-context/references/ownership-map.md
@@ -47,6 +47,10 @@ Use this reference after the initial scan to choose the correct owner skill firs
 3. `quality-contracts`
 4. `streaming-contracts`
 
+### `repo-operations`
+
+1. `github-contribution-governance`
+
 ## Canonical workflow packs
 
 1. `repo-orientation`
@@ -67,3 +71,4 @@ Use this reference after the initial scan to choose the correct owner skill firs
 16. `oss-license-governance`
 17. `contributor-onboarding`
 18. `subtree-upstream-governance`
+19. `github-contribution-governance`

--- a/.codex/skills/repo-context/scripts/repo_scan.py
+++ b/.codex/skills/repo-context/scripts/repo_scan.py
@@ -74,6 +74,7 @@ REQUIRED_WORKFLOWS = [
     "analytics-observability-review",
     "bug-triage",
     "ci-watch-and-heal",
+    "github-contribution-governance",
     "pre-pr-readiness",
     "security-consent-audit",
     "mobile-parity-check",

--- a/.codex/skills/repo-operations/skill.json
+++ b/.codex/skills/repo-operations/skill.json
@@ -25,7 +25,8 @@
     "ci-watch-and-heal",
     "release-readiness",
     "mobile-parity-check",
-    "docs-sync"
+    "docs-sync",
+    "github-contribution-governance"
   ],
   "required_reads": [
     "docs/reference/operations/README.md",

--- a/.codex/workflows/github-contribution-governance/PLAYBOOK.md
+++ b/.codex/workflows/github-contribution-governance/PLAYBOOK.md
@@ -1,0 +1,26 @@
+# GitHub Contribution Governance
+
+Use this workflow pack when the task matches `github-contribution-governance`.
+
+## Goal
+
+Ensure GitHub work is attributable to the intended account, visible through a PR/check path, and eligible for contribution graph credit once merged.
+
+## Steps
+
+1. Start with `repo-operations` and use `github-contribution-governance` as the narrow path.
+2. Read the GitHub contribution docs listed in `workflow.json` when the question is about green dots or missing activity.
+3. Confirm `gh auth status`, active login, local `user.email`, and the exact author identity on any relevant commit SHA.
+4. If the next commit would use a generic or unverified email, set repo-local Git config before committing.
+5. Confirm whether the branch has an open PR against `main`, `develop`, or the repository default branch.
+6. If no PR exists and the user requested publication, hand off to `github:yeet` for PR creation.
+7. Watch PR checks through `repo-operations`; hand off to `github:gh-fix-ci` for failures.
+8. Merge only when the user requested merge and repo policy permits it.
+9. Verify the landed commit on the eligible branch and report whether GitHub may still take up to 24 hours to refresh the contribution graph.
+
+## Common Drift Risks
+
+1. Branch commits are attributed to the right account but never land on the default branch.
+2. Older `.local` commits cannot be linked without history rewrite or replacement commits.
+3. A PR contribution appears, but commit green squares do not because the commits have not merged.
+4. A self-authored PR is blocked by review, branch protection, or merge queue policy.

--- a/.codex/workflows/github-contribution-governance/workflow.json
+++ b/.codex/workflows/github-contribution-governance/workflow.json
@@ -1,0 +1,62 @@
+{
+  "id": "github-contribution-governance",
+  "title": "GitHub Contribution Governance",
+  "goal": "Make contribution-sensitive GitHub work attributable to the intended account, PR-backed, check-visible, and eligible for GitHub contribution graph credit.",
+  "owner_skill": "repo-operations",
+  "default_spoke": "github-contribution-governance",
+  "task_type": "github-contribution-governance",
+  "affected_surfaces": [
+    ".codex/skills/github-contribution-governance",
+    ".codex/workflows/github-contribution-governance"
+  ],
+  "required_reads": [
+    "docs/reference/operations/ci.md",
+    "docs/reference/operations/branch-governance.md",
+    "https://docs.github.com/en/account-and-profile/reference/profile-contributions-reference",
+    "https://docs.github.com/en/account-and-profile/how-tos/contribution-settings/troubleshooting-missing-contributions",
+    "https://docs.github.com/en/account-and-profile/how-tos/email-preferences/setting-your-commit-email-address"
+  ],
+  "required_commands": [
+    "gh auth status",
+    "gh api user --jq '.login'",
+    "git config --get user.email",
+    "python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py"
+  ],
+  "verification_bundle": {
+    "id": "github-contribution-governance",
+    "commands": [
+      "gh auth status",
+      "gh api user --jq '.login'",
+      "git config --get user.email",
+      "python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py"
+    ],
+    "tests": []
+  },
+  "deliverables": [
+    "active GitHub account and author-email status",
+    "commit attribution evidence for relevant SHAs",
+    "PR target and check-state summary",
+    "merge or blocker outcome",
+    "contribution graph eligibility note"
+  ],
+  "impact_fields": [
+    "GitHub account",
+    "Commit author email",
+    "PR target branch",
+    "Contribution eligibility",
+    "Docs updated",
+    "Verification commands executed"
+  ],
+  "handoff_chain": [
+    "repo-operations",
+    "github-contribution-governance",
+    "planning-board"
+  ],
+  "common_failures": [
+    "committing with a generic .local email",
+    "stopping after pushing a non-default feature branch",
+    "assuming repo ownership alone makes branch commits count",
+    "opening a PR without monitoring checks",
+    "rewriting pushed commits without explicit approval"
+  ]
+}

--- a/docs/reference/operations/README.md
+++ b/docs/reference/operations/README.md
@@ -84,8 +84,10 @@ Top-level owner skills:
 - `.codex/skills/agent-orchestration-governance/`: repo-scoped custom-agent authoring, bounded subagent limits, delegation authority, and handoff verification.
 
 Specialist spoke skills live under the same tree and should be used after the correct owner skill or `repo-context` has narrowed the request.
+Use `.codex/skills/github-contribution-governance/` as the repo-operations spoke for GitHub contribution attribution, author-email checks, PR targeting, and green-dot eligibility.
 Workflow packs under `.codex/workflows/` are the canonical recurring task surface for routing and onboarding.
 Use `ci-watch-and-heal` plus `./bin/hushh codex ci-status` when the task depends on live PR checks or GitHub Actions state.
+Use `github-contribution-governance` when contribution graph visibility, verified author email, PR target branch, or merge eligibility affects the task outcome.
 
 ## References
 

--- a/docs/reference/operations/coding-agent-mcp.md
+++ b/docs/reference/operations/coding-agent-mcp.md
@@ -206,11 +206,12 @@ When working in this repo:
    - `.codex/skills/oss-license-governance/`
    - `.codex/skills/contributor-onboarding/`
    - `.codex/skills/subtree-upstream-governance/`
-10. Use spoke skills only after the domain is narrowed to a specific frontend, backend, mobile, or security workflow.
-11. Use `.codex/skills/codex-skill-authoring/` when creating or retrofitting repo-local Codex skills, adding skill tooling, or tightening the local taxonomy and coverage rules.
-12. Use `.codex/skills/future-planner/` for future-state roadmap concepts, R&D architecture notes, and planning-only assessments that must stay separate from north-star vision and active implementation docs.
-13. Use `.codex/skills/planning-board/` for `Hussh Engineering Core` board work and `.codex/skills/comms-community/` for public/community explanation workflows.
-14. Use `.codex/skills/agent-orchestration-governance/` when changing repo-scoped custom agents, `.codex/config.toml` agent limits, or delegation authority and handoff rules.
+10. Use spoke skills only after the domain is narrowed to a specific frontend, backend, mobile, security, or repo-operations workflow.
+11. Use `.codex/skills/github-contribution-governance/` for GitHub contribution attribution, author-email checks, PR targeting, and green-dot eligibility.
+12. Use `.codex/skills/codex-skill-authoring/` when creating or retrofitting repo-local Codex skills, adding skill tooling, or tightening the local taxonomy and coverage rules.
+13. Use `.codex/skills/future-planner/` for future-state roadmap concepts, R&D architecture notes, and planning-only assessments that must stay separate from north-star vision and active implementation docs.
+14. Use `.codex/skills/planning-board/` for `Hussh Engineering Core` board work and `.codex/skills/comms-community/` for public/community explanation workflows.
+15. Use `.codex/skills/agent-orchestration-governance/` when changing repo-scoped custom agents, `.codex/config.toml` agent limits, or delegation authority and handoff rules.
 
 If a developer has not configured MCP yet:
 


### PR DESCRIPTION
## Summary
- add the `github-contribution-governance` repo-local skill and workflow pack
- document the green-dot attribution path: verified author email plus PR/default-branch merge eligibility
- wire the workflow into repo routing, skill lint, and operations docs

## Verification
- `python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py`
- `python3 .codex/skills/repo-context/scripts/repo_scan.py validate`
- `./bin/hushh codex route-task github-contribution-governance`
- `git diff --check`
- `SKIP_SECRET_SCAN=1 ./bin/hushh codex pre-pr` reached the final integration guard; local-only failure is from untracked `.codex-worktrees/`, which is not staged or pushed

## Contribution attribution
- GitHub commit author resolves to `ankitkumarsingh1702`
- Commit email is `94732725+ankitkumarsingh1702@users.noreply.github.com`