### PR TITLE
feat(agents): establish One-led multi-agent runtime

### DIFF
--- a/.codex/skills/docs-governance/SKILL.md
+++ b/.codex/skills/docs-governance/SKILL.md
@@ -60,11 +60,12 @@ Non-owned surfaces:
 8. Route founder or board-facing shared briefs, architecture PDFs, and paper-style founder artifacts to `founder-brief-curation` after docs-home scope is clear.
 9. Keep public prose on the Hussh brand while preserving exact compatibility identifiers such as `./bin/hushh`, `hushh-webapp`, and `@hushh/mcp`.
 10. Treat diagram quality and shareable-link hygiene as blocking issues for shared artifacts, not optional polish.
-11. Enforce current-state versus future-state wording for the Hussh / One / Kai / Nav ontology:
+11. Enforce current-state versus future-state wording for the Hussh / One / Kai / Nav / KYC ontology:
     - Hussh is platform, trust model, and infrastructure.
     - One is approved top personal-agent direction unless a checked-in runtime surface proves current implementation.
     - Kai is the current finance specialist, not the platform-level identity.
     - Nav is reserved for privacy, consent, vault, deletion, and scope-review language, not ordinary navigation.
+    - KYC is a bounded identity/KYC workflow specialist under One, not a second top-level app or broad email agent.
 12. Keep navigation action ids under `route.*` in docs. Treat `nav.*` as valid only for true Nav guardian capabilities or clearly marked future-roadmap prose.
 13. Do not introduce celebrity voice references or personal numeric preferences into canonical docs.
 14. Normalize founder draft language before promoting it into canonical docs:
@@ -72,6 +73,7 @@ Non-owned surfaces:
     - approved: `One listens, remembers, decides, and acts under consent.`
     - approved: `Kai is the finance specialist One summons.`
     - approved: `Nav is the privacy and consent guardian One summons.`
+    - approved: `KYC is the identity workflow specialist One summons.`
     - retired: `Hussh is your personal MCP server and AI agent.`
     - retired: `One has two faces.`
     - retired: `Kai is the One who remembers.`

--- a/.codex/skills/kai-voice-governance/SKILL.md
+++ b/.codex/skills/kai-voice-governance/SKILL.md
@@ -81,7 +81,8 @@ Non-owned surfaces:
 12. Update docs and tests in the same change when capability semantics shift.
 13. During review, require:
     - local contracts for new discoverable capabilities
-    - `speaker_persona` on every action with allowed values `one`, `kai`, or `nav`
+    - `speaker_persona` on every action with allowed values `one`, `kai`, `nav`, or `kyc`
+    - `delegate_agent_id` on actions executed by a specialist on behalf of One, with allowed values `one`, `kai`, `nav`, or `kyc`
     - stable `control_ids` for mapped UI actionables
     - shared `action_id` parity across search and voice
     - `route.*` for ordinary navigation and `nav.*` only for Nav privacy/consent guardian actions
@@ -91,6 +92,7 @@ Non-owned surfaces:
     - One owns route, shell, memory, generic, and handoff framing.
     - Kai owns finance, analysis, portfolio, market, and RIA finance actions.
     - Nav owns privacy, consent, vault, deletion, revocation, and scope-review actions.
+    - KYC owns explicit identity/KYC workflow status, missing-document review, approval-gated drafts, and structured PKM writeback.
     It must never grant authority or bypass auth, vault, consent, persona, workspace, rollout, or kill-switch gates.
 15. Do not add legacy aliases for old navigation `nav.*` ids. Navigation namespace migrations are straight renames unless the user explicitly approves a compatibility program.
 

--- a/.codex/skills/kai-voice-governance/references/voice-review-checklist.md
+++ b/.codex/skills/kai-voice-governance/references/voice-review-checklist.md
@@ -6,7 +6,8 @@ Use this when reviewing Kai voice or typed-search changes.
 
 - Does each new discoverable capability have a local `.voice-action-contract.json` entry?
 - Is the `action_id` stable and reused across voice, search, and UI actionables?
-- Does every action declare `speaker_persona` as `one`, `kai`, or `nav`?
+- Does every action declare `speaker_persona` as `one`, `kai`, `nav`, or `kyc`?
+- Does every One-framed action executed by a specialist declare `delegate_agent_id` as `kai`, `nav`, or `kyc`?
 - Are ordinary navigation actions under `route.*`, with `nav.*` reserved for true Nav guardian actions?
 - Are `control_ids` present for UI affordances that should map back to the action?
 

--- a/.codex/skills/pr-governance-review/SKILL.md
+++ b/.codex/skills/pr-governance-review/SKILL.md
@@ -60,6 +60,7 @@ Non-owned surfaces:
 2. Start with `python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo <repo> --pr <number> --text` to summarize current head status, changed surfaces, and automatic drift flags.
 3. For batched contributor review or merge-train planning, use `python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo <repo> --prs <n1,n2,...> --text` first. This batch mode is the default when the user asks for “all healthy PRs by contributor”, “review these PRs together”, or “tell me how these relate”.
    - Treat the script fields `contract_set`, `duplicate_group`, `author_group`, `exact_file_overlap`, `concept_overlap`, `lane`, `patch_then_merge_reason`, `public_comment_policy`, and `live_report_action` as the minimum decision record.
+   - Treat `what_this_is_about` and operator-batch intent as mandatory planning context. Every batch plan must explain the product/runtime purpose before lane mechanics, merge order, or GitHub process.
    - Green CI never overrides exact file overlap, duplicate product contracts, schema-contract drift, or raw-error leakage findings.
 4. Respect the project-wide delegation checkpoint in `AGENTS.md`. For large or mixed-domain batch reviews, record the subagent decision using `.codex/skills/agent-orchestration-governance/references/delegation-contract.md`:
    - delegate only when the user explicitly allows subagents or the workflow has an approved delegation step
@@ -67,6 +68,7 @@ Non-owned surfaces:
    - do not delegate branch switching, approval, merge, deploy, credential handling, or final recommendations
    - if the batch stays local, record the reason briefly in the report or response
 5. In batch mode, do not stop at titles and green checks. The minimum overview must include, per PR:
+   - what the PR is actually about in product/runtime terms, stated before merge mechanics
    - current head SHA
    - size and changed file count
    - extracted PR summary / issue linkage
@@ -89,12 +91,19 @@ Non-owned surfaces:
    - whether the change is product-semantic rather than purely code-local
    - whether an apparently isolated PR still changes a trust boundary, user-visible truth model, or external ingress surface
    - whether the helper found a concept-level overlap that requires `patch_then_merge` or `block` even when exact file overlap is zero
+   - whether the PR adds or changes files under `consent-protocol/db/migrations/`, DB schema contracts, or `release_migration_manifest.json`; these require a DB release-contract review before merge and a live UAT schema guard before any UAT-ready claim
+   - whether a migration PR updates all three DB release surfaces together when the live contract changes: SQL migration, release manifest ordering/grouping, and the checked-in schema contract for the affected environment
+   - whether the migration is idempotent or narrowly safe to run against UAT, and whether the operator plan says exactly when to run `./bin/hushh db verify-release-contract`, live `./bin/hushh db verify-uat-schema`, and any required migration apply step
    - whether the PR is overbuilt relative to the core repo model: small contributor surface, consent-first access, BYOK/zero-knowledge boundaries, canonical routes, and meaningful tests
    - whether the PR blurs Hussh / One / Kai / Nav ownership by making Hussh speak as a character, treating Kai as the full platform identity, using One as a shipped-runtime claim without proof, or using `nav.*` for ordinary navigation
    - whether founder-copy updates preserve the canonical ontology: Hussh as platform, One as personal agent, Kai as finance specialist, and Nav as privacy/consent guardian
    - whether the PR imports retired founder-draft wording such as `Hussh is your personal MCP server and AI agent`, `One has two faces`, or `Kai is the One who remembers`
    - whether `hu_ssh`, `SSH for humans`, or `Ask. Approve. Audit.` are mapped back to Human Secure Socket Host and the current Consent Protocol instead of replacing implementation truth
    - whether BYO AI, portable One memory, no platform-controlled recovery, or user-private receipt claims are supported by checked-in runtime docs and tests before being described as shipped
+   - whether same-file overlap is true duplicate work or only a shared-file sequence; same file is not enough to close a PR as duplicate
+   - whether two PRs have the same product/runtime outcome, not just the same edited file, before using `harvest_then_close` or public duplicate language
+   - when two PRs solve the same product contract, whether the selected canonical PR is actually stronger on implementation quality, not merely smaller; for UI duplicates compare scope containment, design-system primitives, accessibility, layout safety, contract preservation, and type/test readiness before using diff size as a tie-breaker
+   - whether a shared service-file batch should land as sequential runtime evolution, with each PR rebased onto the previous one, instead of treating later PRs as superseded
 7. For every lane, perform two explicit verification passes and say which pass you are in:
    - Pass 1: repo and product verification against current `main`, current head SHA, changed surfaces, and architectural truth
    - Pass 2: authoritative workflow verification after action, including current PR checks, merge queue validation, and post-merge smoke where applicable
@@ -117,6 +126,9 @@ Non-owned surfaces:
    - tests that cannot fail, duplicate production logic inside tests, or proof that only exercises mocks while claiming contract coverage
    - Playwright/browser route tests that claim Next.js navigation, memory, cache, or vault continuity while only using `page.goto(...)`, skipping through protected routes directly, or missing a sequential UI-navigation lane with a JS-context/same-session probe
    - Playwright config where `baseURL`, `webServer.url`, and dev-server port can drift from each other, making browser evidence ambiguous
+   - DB migration files without a matching `release_migration_manifest.json` update
+   - DB schema contract changes without a matching SQL migration
+   - migration PRs that claim UAT readiness without live UAT schema verification, especially when the deployed runtime would call a new table, column, index, trigger, or function
    - a new agent, service, reducer, export path, ingestion path, or PKM write surface without explicit consent-scope and caller-contract proof
    - a public ingress surface that lacks explicit rollout, abuse-control, or authority-model proof
    - ordinary route navigation introduced under `nav.*` instead of `route.*`
@@ -157,16 +169,17 @@ Non-owned surfaces:
    - `block` or `changes_requested`: headline `## Changes Requested: <blocker>`, then `### Direction`, `### Blocker`, `### Path To Merge`, and `### Proof Needed`.
    - superseded or opposite-decision close: headline `## Closed: <reason>`, then `### Decision`, `### What We Kept`, and `### Proof`.
    - post-merge record: headline `## Merged: <contract or outcome>`, then `### What Landed`, optional `### Maintainer Patch`, optional `### Documentation Updated`, `### Proof`, and `### Outcome`.
-23. For every maintainer patch, the post-merge GitHub note must state who patched, what surface changed, why the patch was the smallest merge-safe path, which tests or checks prove it, and whether related PRs were merged, superseded, or left blocked. Do not bury patching inside a generic approval paragraph.
-24. If durable docs changed, include `### Documentation Updated` in the post-merge note with direct Markdown links to the canonical docs or files changed. Omit this section when no durable docs changed.
-25. `### Proof` is the only evidence heading for public GitHub comments. Do not use `### Verification` in new or edited PR comments except when preserving old quoted text.
-26. `### Outcome` must explain the product, architecture, trust-boundary, or operational consequence of the landed change. It should not merely repeat that the PR merged. If a boundary remains intentionally partial, state that boundary plainly.
-27. Keep GitHub sections external-facing. Do not publish maintainer-only bookkeeping such as `Next: this is canonical`, `future PRs should...`, batch sequencing, report status, or internal governance reminders. Put that in the working report or final Codex response instead. The GitHub comment should explain the outcome, why it happened, what proof passed, and, only for open blocked PRs, what the contributor can change to get merged.
-28. Keep sections short. Each section should add evidence or contributor-actionable context; omit ceremonial acknowledgments unless they clarify contributor ownership or why the landed path differs from the submitted branch.
-29. After the merge path is monitored to the required terminal state, post or update one contributor-facing post-merge note only when the write policy above says it is useful. Do not treat the merge trigger or queue entry itself as the posting point.
-30. Monitoring is part of execution, not an optional follow-up. Once Codex triggers merge, auto-merge, or queue entry, it must stay attached to the workflow chain until the required terminal state is known. Stopping at queue placement, green PR checks, or "already queued" is workflow failure unless the user explicitly limited the task to queue placement only.
-31. Before any maintainer patch push, merge repair push, or force-push to a PR branch, rerun the repo-operations DCO gate with `bash scripts/ci/check-dco-signoff.sh origin/main HEAD`. This is required after subtree sync, branch merge, rebase, signed squash, or queue repair because those operations can create new commits after the earlier pre-PR check.
-32. After any PR state-changing action, update the active working report before final response when one exists, especially `tmp/pr-governance-live-report.md`. Reports named `live` must stay live-only:
+23. Public duplicate language is allowed only for `exact_duplicate`, `semantic_duplicate`, or manually confirmed duplicate product outcomes. If PRs merely share files, describe the issue as sequencing, rebase, or maintainer integration work.
+24. For every maintainer patch, the post-merge GitHub note must state who patched, what surface changed, why the patch was the smallest merge-safe path, which tests or checks prove it, and whether related PRs were merged, superseded, or left blocked. Do not bury patching inside a generic approval paragraph.
+25. If durable docs changed, include `### Documentation Updated` in the post-merge note with direct Markdown links to the canonical docs or files changed. Omit this section when no durable docs changed.
+26. `### Proof` is the only evidence heading for public GitHub comments. Do not use `### Verification` in new or edited PR comments except when preserving old quoted text.
+27. `### Outcome` must explain the product, architecture, trust-boundary, or operational consequence of the landed change. It should not merely repeat that the PR merged. If a boundary remains intentionally partial, state that boundary plainly.
+28. Keep GitHub sections external-facing. Do not publish maintainer-only bookkeeping such as `Next: this is canonical`, `future PRs should...`, batch sequencing, report status, or internal governance reminders. Put that in the working report or final Codex response instead. The GitHub comment should explain the outcome, why it happened, what proof passed, and, only for open blocked PRs, what the contributor can change to get merged.
+29. Keep sections short. Each section should add evidence or contributor-actionable context; omit ceremonial acknowledgments unless they clarify contributor ownership or why the landed path differs from the submitted branch.
+30. After the merge path is monitored to the required terminal state, post or update one contributor-facing post-merge note only when the write policy above says it is useful. Do not treat the merge trigger or queue entry itself as the posting point.
+31. Monitoring is part of execution, not an optional follow-up. Once Codex triggers merge, auto-merge, or queue entry, it must stay attached to the workflow chain until the required terminal state is known. Stopping at queue placement, green PR checks, or "already queued" is workflow failure unless the user explicitly limited the task to queue placement only.
+32. Before any maintainer patch push, merge repair push, or force-push to a PR branch, rerun the repo-operations DCO gate with `bash scripts/ci/check-dco-signoff.sh origin/main HEAD`. This is required after subtree sync, branch merge, rebase, signed squash, or queue repair because those operations can create new commits after the earlier pre-PR check.
+33. After any PR state-changing action, update the active working report before final response when one exists, especially `tmp/pr-governance-live-report.md`. Reports named `live` must stay live-only:
    - update the timestamp and live query scope
    - include a clickable `## Index` with anchors for the live summary, live risk matrix, recommended PR sets, operator batches, individual PR assessments, cross-PR overlaps, and each active PR assessment
    - keep `## Live Risk Matrix` first, `## Recommended PR Sets` second, `## Operator Batches` third, and `## Individual PR Assessments` fourth so high-volume review starts with scan-level triage, then broad intake grouping, then execution-sized batches, then PR-level detail
@@ -183,14 +196,25 @@ Non-owned surfaces:
    - record contributor pushes that changed head SHA or review decision after a maintainer comment
    - update batch counts and recommended next order
    - record terminal queue/smoke evidence only in GitHub comments, final handoff, or a separate non-live audit ledger
-33. If a working report contains its own update checklist, treat that checklist as part of the action flow. Do not end the turn while the checklist is stale.
-34. If the user asks for a batch, produce a comprehensive overview before recommending any merge order. The overview must make overlap, duplication, domain boundaries, lean/core bloat risk, subagent-delegation decision, flow mode, isolation strategy, contract-set grouping, author-grouping decision, and maintainer-patch batching plan explicit enough that the merge plan is auditable.
-35. Use `#498/#505/#444` as the calibration batch for account export and error-leakage governance:
+34. If a working report contains its own update checklist, treat that checklist as part of the action flow. Do not end the turn while the checklist is stale.
+35. If the user asks for a batch, produce a comprehensive overview before recommending any merge order. The overview must make product/runtime purpose, overlap, duplication, domain boundaries, lean/core bloat risk, subagent-delegation decision, flow mode, isolation strategy, contract-set grouping, author-grouping decision, and maintainer-patch batching plan explicit enough that the merge plan is auditable.
+36. For DB migration or schema-contract PRs, use this migration-release gate:
+   - `merge_now` is allowed only when the SQL migration, release manifest, checked-in schema contract, and local release-contract verification move together
+   - `patch_then_merge` is required when a migration exists but the manifest or contract evidence is incomplete
+   - `block` is required when the SQL is unsafe for UAT, destructive without an explicit operator plan, or changes a live runtime contract without tests/proof
+   - after merge, do not call UAT ready until live `./bin/hushh db verify-uat-schema` is green; if it fails, apply only the missing ordered migration and rerun the guard
+   - GitHub comments should keep merge proof and UAT execution proof separate: a PR can be merged to `main` while UAT still needs the runtime DB migration step before deployment is complete
+37. Use `#498/#505/#444` as the calibration batch for account export and error-leakage governance:
    - `#498` must classify as `frontend-error-safety` and `patch_then_merge` when `403` permission failures are categorized as authentication.
    - `#505` must classify as `account-export` and `patch_then_merge` when export SQL drifts from checked-in DB contracts, backend/proxy errors leak raw detail, or schema-happy-path tests are missing.
    - `#444` must classify as `account-export` and `harvest_then_close` or `close_duplicate` when `#505` is the smaller canonical base for the same route/service/proxy/frontend contract.
-36. If the PR is clear, say why it is safe in concrete terms: current head SHA, current gate result, blocker count, chosen lane, flow mode, lean/core risk, the result of both verification passes, report-update status, and any remaining residual risk.
-37. When explaining this skill to the team in Discord or an internal channel, route the wording through `comms-community` and keep the explanation operator-facing:
+38. Use `#531/#529/#435` as the calibration batch for same-file sequencing governance:
+   - `#531` must classify as `merge_now` for Kai chat startup performance unless current checks regress.
+   - `#529` must classify as `patch_then_merge` when it schedules background attribute extraction without explicit exception logging.
+   - `#435` must remain a sequential Kai chat safety PR, not a duplicate closure, unless the response-validation behavior already landed on `main`.
+   - The operator batch title must explain the purpose as Kai chat service evolution, not a harvest cluster.
+39. If the PR is clear, say why it is safe in concrete terms: current head SHA, current gate result, blocker count, chosen lane, flow mode, lean/core risk, the result of both verification passes, report-update status, and any remaining residual risk.
+40. When explaining this skill to the team in Discord or an internal channel, route the wording through `comms-community` and keep the explanation operator-facing:
    - state that `tmp/pr-governance-live-report.md` is generated in ignored `tmp/` and is a live workspace artifact, not a durable audit ledger
    - show the three report layers: `Index`, `Live Risk Matrix`, and `Individual PR Assessments`
    - explain the merge philosophy: green CI is intake, not authority; authority comes from contract safety, non-duplication, lean/core fit, proof, and monitored merge outcome
@@ -211,6 +235,7 @@ Non-owned surfaces:
 python3 -m py_compile .codex/skills/pr-governance-review/scripts/pr_review_checklist.py
 python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --pr 437 --text
 python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --prs 498,505,444 --text
+python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --prs 531,529,435 --text
 python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --prs 488,489 --text
 python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --live-report --text
 ./bin/hushh codex audit --text

--- a/.codex/skills/pr-governance-review/scripts/pr_review_checklist.py
+++ b/.codex/skills/pr-governance-review/scripts/pr_review_checklist.py
@@ -19,12 +19,16 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 SALVAGEABLE_HIGH_FINDINGS = {
     "account_export_schema_contract_mismatch",
     "backend_contract_without_caller_change",
+    "db_contract_without_matching_migration",
+    "db_migration_missing_release_manifest",
     "dual_auth_dependency_overlap",
 }
 SALVAGEABLE_MEDIUM_FINDINGS = {
     "account_export_backend_error_detail_leak",
     "account_export_proxy_raw_error_leak",
     "account_export_missing_schema_happy_path_tests",
+    "background_task_without_failure_logging",
+    "db_migration_missing_schema_contract_update",
     "frontend_error_sanitizer_403_permission_mismatch",
     "service_layer_browser_download_side_effect",
     "runtime_dependency_not_pinned_in_manifest",
@@ -38,6 +42,11 @@ ACCOUNT_EXPORT_CORE_FILES = {
     "hushh-webapp/app/api/account/export/route.ts",
     "hushh-webapp/lib/services/account-service.ts",
 }
+DB_CONTRACT_FILES = {
+    "consent-protocol/db/contracts/uat_integrated_schema.json",
+    "consent-protocol/db/contracts/prod_integrated_schema.json",
+}
+DB_RELEASE_MANIFEST_FILE = "consent-protocol/db/release_migration_manifest.json"
 SCHEMA_CONTRACT_PATH = REPO_ROOT / "consent-protocol/db/contracts/uat_integrated_schema.json"
 CONCEPT_RULES: tuple[dict[str, Any], ...] = (
     {
@@ -232,7 +241,7 @@ RELATED_SURFACE_RULES: tuple[dict[str, Any], ...] = (
 PATH_SUMMARIES: dict[str, str] = {
     "consent-protocol/api/routes/consent.py": "Route contract for consent lifecycle, relationship events, and timeline-facing APIs.",
     "consent-protocol/api/routes/ria.py": "Advisor-facing route surface that enforces RIA verification and access gating.",
-    "consent-protocol/api/routes/email_agent.py": "Inbound email webhook surface proposed for Kai-owned email/KYC workflows.",
+    "consent-protocol/api/routes/email_agent.py": "Inbound email webhook surface proposed for One-led KYC workflows.",
     "consent-protocol/api/routes/kai/support.py": "Existing support ingress used as the comparison point for shared transport primitives.",
     "consent-protocol/hushh_mcp/services/ria_iam_service.py": "Canonical RIA access-control service for verified access and relationship-scoped authorization.",
     "consent-protocol/hushh_mcp/services/ria_verification.py": "Verification policy service that determines whether an RIA is eligible for protected flows.",
@@ -277,7 +286,7 @@ PATH_SUMMARIES: dict[str, str] = {
     "docs/reference/architecture/pkm-cutover-runbook.md": "Runbook for PKM product migration and current ownership path.",
     "docs/reference/kai/kai-interconnection-map.md": "High-level Kai subsystem map including the canonical decision-card surface.",
     "docs/reference/kai/kai-change-impact-matrix.md": "Kai change-governance matrix describing decision-card and stream-contract impacts.",
-    "docs/future/kai/email-kyc-pkm-assistant.md": "Future-plan contract for Kai-owned email/KYC workflow and consent-scoped rollout.",
+    "docs/future/kai/email-kyc-pkm-assistant.md": "Superseded planning history for One-led KYC workflow and consent-scoped rollout.",
 }
 
 
@@ -359,6 +368,8 @@ def _load_schema_contract_columns() -> dict[str, set[str]]:
 
 def _contract_set(files: list[str], patch_map: dict[str, str]) -> str:
     patch_text = "\n".join(patch_map.values())
+    if any(path.startswith("consent-protocol/db/") for path in files):
+        return "db-release-contract"
     if any(path in ACCOUNT_EXPORT_CORE_FILES for path in files) and (
         "/account/export" in patch_text
         or "exportData" in patch_text
@@ -390,6 +401,168 @@ def _duplicate_group(contract_set: str, files: list[str]) -> str | None:
     if any(path.startswith("hushh-webapp/app/api/account/export/") for path in files):
         return "account-export"
     return None
+
+
+def _normal_text(*values: str | None) -> str:
+    return " ".join(str(value or "").lower() for value in values)
+
+
+def _semantic_duplicate_group(
+    left: dict[str, Any],
+    right: dict[str, Any],
+    shared_files: list[str],
+) -> str | None:
+    shared = set(shared_files)
+    left_text = _normal_text(left["pr"]["title"], left["pr"].get("summary"))
+    right_text = _normal_text(right["pr"]["title"], right["pr"].get("summary"))
+    combined = f"{left_text} {right_text}"
+
+    if {
+        "hushh-webapp/components/navbar.tsx",
+        "hushh-webapp/components/theme-toggle.tsx",
+    } <= shared and all(
+        token in combined for token in ("theme", "toggle")
+    ) and any(
+        token in combined for token in ("top-right", "top right", "compact", "dropdown")
+    ):
+        return "semantic-duplicate:theme-toggle-top-right"
+
+    return None
+
+
+def _theme_toggle_duplicate_factors(patch_map: dict[str, str]) -> OrderedDict[str, Any]:
+    patch_text = "\n".join(patch_map.values())
+    normalized = _normal_text(patch_text)
+    factors = OrderedDict(
+        scope_containment="themetogglecompact" in normalized,
+        design_system_fit="dropdownmenu" in normalized
+        and "@/components/ui/dropdown-menu" in normalized,
+        accessibility="aria-label" in normalized,
+        layout_safety="app-safe-area-top-effective" in normalized,
+        contract_preservation="export function themetogglecompact" in normalized,
+        type_readiness="nouncheckedindexedaccess" in normalized
+        or "typeof theme_options)[number]" in normalized,
+        hover_dependent="onmouseenter" in normalized or "onmouseleave" in normalized,
+        fixed_top_right="top-4 right-4" in normalized,
+        rewrites_shared_toggle="export function themetoggle" in normalized
+        and "export function themetogglecompact" not in normalized,
+    )
+    score = sum(
+        1
+        for key in (
+            "scope_containment",
+            "design_system_fit",
+            "accessibility",
+            "layout_safety",
+            "contract_preservation",
+            "type_readiness",
+        )
+        if factors[key]
+    )
+    score -= sum(
+        1
+        for key in ("hover_dependent", "fixed_top_right", "rewrites_shared_toggle")
+        if factors[key]
+    )
+    factors["score"] = score
+    return factors
+
+
+def _duplicate_selection_factors(
+    contract_set: str,
+    files: list[str],
+    patch_map: dict[str, str],
+) -> OrderedDict[str, Any] | None:
+    if contract_set == "frontend" and {
+        "hushh-webapp/components/navbar.tsx",
+        "hushh-webapp/components/theme-toggle.tsx",
+    } <= set(files):
+        return _theme_toggle_duplicate_factors(patch_map)
+    return None
+
+
+def _canonical_selection_rationale(group: str, preferred: dict[str, Any]) -> str:
+    factors = preferred.get("duplicate_selection_factors") or {}
+    if group.startswith("semantic-duplicate:theme-toggle-top-right") and factors:
+        strengths = []
+        if factors.get("scope_containment"):
+            strengths.append("adds a narrow compact variant instead of rewriting the shared toggle")
+        if factors.get("design_system_fit"):
+            strengths.append("uses the existing DropdownMenu primitive")
+        if factors.get("accessibility"):
+            strengths.append("keeps explicit trigger labeling")
+        if factors.get("layout_safety"):
+            strengths.append("preserves safe-area-aware onboarding chrome placement")
+        if factors.get("contract_preservation"):
+            strengths.append("keeps the segmented ThemeToggle available for wider settings surfaces")
+        if factors.get("type_readiness"):
+            strengths.append("accounts for strict TypeScript fallback handling")
+        if strengths:
+            return "; ".join(strengths) + "."
+    return "Selected by duplicate-governance ranking; diff size is only a tie-breaker."
+
+
+def _duplicate_preference_key(report: dict[str, Any], group: str) -> tuple[int, int, int]:
+    factors = report.get("duplicate_selection_factors") or {}
+    score = int(factors.get("score", 0)) if group.startswith("semantic-duplicate:") else 0
+    churn = report["pr"]["additions"] + report["pr"]["deletions"]
+    return (score, -churn, -int(report["pr"]["number"]))
+
+
+def _what_this_is_about(
+    title: str,
+    summary: str | None,
+    files: list[str],
+    patch_map: dict[str, str],
+    contract_set: str,
+) -> str:
+    text = _normal_text(title, summary, "\n".join(patch_map.values()))
+
+    if "consent-protocol/hushh_mcp/services/kai_chat_service.py" in files:
+        if "get_initial_chat_state" in text and "get_portfolio" in text:
+            return (
+                "Kai chat startup performance: derive portfolio presence from PKM metadata "
+                "instead of making a second portfolio DB call when opening chat."
+            )
+        if "extract_and_store" in text and ("create_task" in text or "background" in text):
+            return (
+                "Kai chat response latency: move attribute learning behind the response so "
+                "Gemini-backed memory extraction does not block the user-visible answer."
+            )
+        if "validate_response" in text or "safe_fallback" in text or "grounded" in text:
+            return (
+                "Kai chat answer safety: validate generated assistant text, retry malformed output, "
+                "and return a stable fallback when the model response is not usable."
+            )
+        return "Kai chat service behavior: review runtime effect before treating file overlap as duplication."
+
+    if {
+        "hushh-webapp/components/navbar.tsx",
+        "hushh-webapp/components/theme-toggle.tsx",
+    } <= set(files):
+        return "Frontend shell polish: move theme switching into a compact top-right control."
+
+    if any(path.startswith("hushh-webapp/lib/portfolio-share/") for path in files):
+        return (
+            "Portfolio share token security: fail closed in production when signing secrets are "
+            "missing while preserving local development fallback behavior."
+        )
+
+    if contract_set == "account-export":
+        return "Account export contract: package user-owned export data without leaking raw backend failures."
+    if contract_set == "frontend-error-safety":
+        return "Frontend error safety: normalize user-facing error messages without exposing raw service details."
+    if contract_set == "db-release-contract":
+        return "DB release contract: advance migrations, schema contracts, and UAT/prod migration readiness together."
+    if contract_set == "voice":
+        return "Kai voice capability: expand or refine voice-driven action coverage."
+    if contract_set == "pkm-privacy":
+        return "PKM privacy/runtime contract: adjust personal knowledge storage, access, or projection behavior."
+    if contract_set == "backend":
+        return "Backend runtime behavior: change service-side behavior under existing API contracts."
+    if contract_set == "frontend":
+        return "Frontend behavior: change user-facing UI without an obvious backend contract shift."
+    return "General repo change: review product intent, changed surfaces, and proof before merge."
 
 
 def _author_group(author: str | None) -> str:
@@ -491,7 +664,12 @@ def _surface_tags(files: list[str]) -> list[str]:
         tags.append("backend-service")
     if any(path.startswith("consent-protocol/db/") for path in files):
         tags.append("db-contract")
-    if any(path.startswith("hushh-webapp/lib/services/") or path.startswith("hushh-webapp/app/api/") for path in files):
+    if any(
+        path.startswith("hushh-webapp/lib/services/")
+        or path.startswith("hushh-webapp/app/api/")
+        or path.startswith("hushh-webapp/lib/portfolio-share/")
+        for path in files
+    ):
         tags.append("frontend-caller")
     if any(path.startswith("deploy/") or path.endswith("Dockerfile") for path in files):
         tags.append("deploy-runtime")
@@ -602,6 +780,19 @@ def _has_test_or_doc_change(files: list[str]) -> bool:
     )
 
 
+def _db_migration_files(files: list[str]) -> list[str]:
+    return sorted(
+        path
+        for path in files
+        if path.startswith("consent-protocol/db/migrations/")
+        and path.endswith(".sql")
+    )
+
+
+def _db_contract_files(files: list[str]) -> list[str]:
+    return sorted(path for path in files if path in DB_CONTRACT_FILES)
+
+
 def _file_patch_map(patch: str) -> dict[str, str]:
     sections: dict[str, list[str]] = {}
     current: str | None = None
@@ -610,7 +801,10 @@ def _file_patch_map(patch: str) -> dict[str, str]:
             parts = line.split()
             if len(parts) >= 4:
                 current = parts[3][2:]
-                sections[current] = [line]
+                sections.setdefault(current, [])
+                if sections[current]:
+                    sections[current].append("")
+                sections[current].append(line)
             else:
                 current = None
             continue
@@ -639,6 +833,46 @@ def _build_findings(files: list[str], patch_map: dict[str, str]) -> list[dict[st
                 "severity": "high",
                 "summary": "Backend route files changed without matching caller or proxy changes.",
                 "files": [path for path in files if path.startswith("consent-protocol/api/routes/")],
+            }
+        )
+
+    migration_files = _db_migration_files(files)
+    contract_files = _db_contract_files(files)
+    release_manifest_changed = DB_RELEASE_MANIFEST_FILE in files
+    if migration_files:
+        if not release_manifest_changed:
+            findings.append(
+                {
+                    "id": "db_migration_missing_release_manifest",
+                    "severity": "high",
+                    "summary": (
+                        "DB migration files changed without updating the release migration "
+                        "manifest, so UAT/prod operators may not apply the migration in order."
+                    ),
+                    "files": migration_files,
+                }
+            )
+        if not contract_files:
+            findings.append(
+                {
+                    "id": "db_migration_missing_schema_contract_update",
+                    "severity": "medium",
+                    "summary": (
+                        "DB migration files changed without a checked-in schema contract update; "
+                        "verify whether the migration changes live UAT/prod contract shape."
+                    ),
+                    "files": migration_files,
+                }
+            )
+    if contract_files and not migration_files:
+        findings.append(
+            {
+                "id": "db_contract_without_matching_migration",
+                "severity": "high",
+                "summary": (
+                    "DB schema contract files changed without a matching SQL migration in the PR."
+                ),
+                "files": contract_files,
             }
         )
 
@@ -681,6 +915,21 @@ def _build_findings(files: list[str], patch_map: dict[str, str]) -> list[dict[st
                     "files": [path],
             }
         )
+
+        if (
+            path == "consent-protocol/hushh_mcp/services/kai_chat_service.py"
+            and "asyncio.create_task(" in section
+            and ".add_done_callback" not in section
+            and "logger.exception" not in section
+        ):
+            findings.append(
+                {
+                    "id": "background_task_without_failure_logging",
+                    "severity": "medium",
+                    "summary": "Kai chat schedules background work without an explicit completion callback or exception logger.",
+                    "files": [path],
+                }
+            )
 
     if contract_set == "frontend-error-safety":
         sanitizer_section = patch_map.get("hushh-webapp/lib/services/error-sanitizer.ts", "")
@@ -820,6 +1069,19 @@ def _recommend_merge_lane(
         )
 
     if not findings:
+        if "db-contract" in surface_tags:
+            return OrderedDict(
+                lane="merge_now",
+                rationale=(
+                    "Current head SHA is green and the DB migration package appears "
+                    "internally complete: migration, release manifest, and schema contract "
+                    "move together."
+                ),
+                next_steps=[
+                    "Run `./bin/hushh db verify-release-contract` before merge.",
+                    "Before any UAT-ready claim, run live `./bin/hushh db verify-uat-schema`; if it fails, apply the specific missing migration and rerun the guard.",
+                ],
+            )
         return OrderedDict(
             lane="merge_now",
             rationale="Current head SHA is green and no blocker or review-risk findings were detected.",
@@ -1006,6 +1268,7 @@ def _single_pr_live_assessment(report: dict[str, Any]) -> list[str]:
         f"- Contract/lane: `{report['contract_set']}` / `{report['lane']}`",
         f"- Lean/core risk: `{_lean_core_risk(report)}`",
         f"- Size/surfaces: `+{pr['additions']}` / `-{pr['deletions']}` across `{pr['changed_files_count']}` files; tags `{', '.join(report['surface_tags']) or 'none'}`",
+        f"- What this is about: {report['what_this_is_about']}",
         f"- Summary: {pr.get('summary') or 'No PR summary extracted.'}",
         f"- Findings: {_findings_summary(report)}",
         f"- Overlap: {_overlap_summary(report)}",
@@ -1035,6 +1298,19 @@ def _report_sort_key(report: dict[str, Any]) -> tuple[int, int, int]:
     )
 
 
+def _operator_component_sort_key(report: dict[str, Any]) -> tuple[int, int, int, int]:
+    if "consent-protocol/hushh_mcp/services/kai_chat_service.py" in report["changed_files"]:
+        intent = report.get("what_this_is_about", "")
+        if "startup performance" in intent:
+            return (0, 0, report["pr"]["additions"] + report["pr"]["deletions"], report["pr"]["number"])
+        if "response latency" in intent:
+            return (0, 1, report["pr"]["additions"] + report["pr"]["deletions"], report["pr"]["number"])
+        if "answer safety" in intent:
+            return (0, 2, report["pr"]["additions"] + report["pr"]["deletions"], report["pr"]["number"])
+    lane_rank, size, number = _report_sort_key(report)
+    return (1, lane_rank, size, number)
+
+
 def _report_has_duplicate_finding(report: dict[str, Any]) -> bool:
     return any(
         finding["id"] in {"duplicate_exact_file_overlap", "duplicate_product_contract"}
@@ -1042,9 +1318,35 @@ def _report_has_duplicate_finding(report: dict[str, Any]) -> bool:
     )
 
 
+def _operator_batch_intent(reports: list[dict[str, Any]], shared_files: list[str]) -> str:
+    shared = set(shared_files)
+    if len({report["pr"]["head_sha"] for report in reports}) == 1:
+        return "Exact duplicate cleanup: one head SHA is represented by multiple open PRs."
+    if "consent-protocol/hushh_mcp/services/kai_chat_service.py" in shared:
+        return (
+            "Kai chat service evolution: coordinate startup latency, response latency, "
+            "and answer-safety changes that share one service file but affect different runtime behaviors."
+        )
+    if {
+        "hushh-webapp/components/navbar.tsx",
+        "hushh-webapp/components/theme-toggle.tsx",
+    } <= shared:
+        return "Theme toggle shell placement: choose one compact top-right UI implementation."
+    if any("package.json" in path or "package-lock.json" in path for path in shared):
+        return "Dependency/test surface alignment: sequence package-lock changes before dependent test infrastructure."
+    if any(_report_has_duplicate_finding(report) for report in reports):
+        return "Shared contract cleanup: select the canonical implementation and harvest only unique proof."
+    return "Shared-file sequencing: same files require ordered merge or rebase, but are not automatically duplicate work."
+
+
 def _operator_batch_title(reports: list[dict[str, Any]], preferred: dict[str, Any]) -> str:
     if len({report["pr"]["head_sha"] for report in reports}) == 1:
         return f"Exact Duplicate Cleanup: #{preferred['pr']['number']}"
+    if any(
+        "consent-protocol/hushh_mcp/services/kai_chat_service.py" in report["changed_files"]
+        for report in reports
+    ):
+        return "Kai Chat Service Evolution Batch"
     if any(_report_has_duplicate_finding(report) for report in reports):
         return f"Shared-File Harvest Cluster: #{preferred['pr']['number']}"
     if any(
@@ -1063,6 +1365,14 @@ def _operator_batch_action(reports: list[dict[str, Any]], preferred: dict[str, A
     if len({report["pr"]["head_sha"] for report in reports}) == 1:
         duplicate_noun = "an exact duplicate" if len(rest) == 1 else "exact duplicates"
         return f"Review and merge `#{preferred_number}` as the canonical PR, then close {rest_label} as {duplicate_noun}."
+    if any(
+        "consent-protocol/hushh_mcp/services/kai_chat_service.py" in report["changed_files"]
+        for report in reports
+    ):
+        return (
+            "Merge in runtime-evolution order: startup optimization first, response-latency change second, "
+            "answer-safety change last; rebase and rerun shared Kai chat service checks after each step."
+        )
     if any(_report_has_duplicate_finding(report) for report in reports):
         return f"Review `#{preferred_number}` as canonical first; harvest only unique proof from {rest_label} before closing duplicates."
     return "Review these PRs together because they touch the same files; merge one at a time with the shared checks rerun after each merge."
@@ -1097,7 +1407,7 @@ def _operator_batches(
         seen |= component
         component_reports = sorted(
             (by_number[item] for item in component),
-            key=_report_sort_key,
+            key=_operator_component_sort_key,
         )
         preferred = component_reports[0]
         shared_files = sorted(
@@ -1121,6 +1431,7 @@ def _operator_batches(
                     (f"#{report['pr']['number']}", _lean_core_risk(report))
                     for report in component_reports
                 ),
+                intent=_operator_batch_intent(component_reports, shared_files),
                 shared_files=shared_files,
                 action=_operator_batch_action(component_reports, preferred),
                 reason="Exact file overlap creates a real sequencing or duplicate-resolution dependency.",
@@ -1151,6 +1462,7 @@ def _operator_batches(
                     contract_sets=[contract_set],
                     lanes=OrderedDict((f"#{report['pr']['number']}", report["lane"]) for report in grouped),
                     risks=OrderedDict((f"#{report['pr']['number']}", _lean_core_risk(report)) for report in grouped),
+                    intent=f"Adjacent {contract_set} review: same narrow contract, separate files, low current risk.",
                     shared_files=[],
                     action="Review together for product/context coherence, but merge separately unless manual review finds a shared proof surface.",
                     reason="Same narrow contract, green gate, low/non-runtime risk, and no exact file overlap.",
@@ -1166,6 +1478,7 @@ def _operator_batches(
                     contract_sets=[contract_set],
                     lanes=OrderedDict((f"#{report['pr']['number']}", report["lane"]) for report in grouped),
                     risks=OrderedDict((f"#{report['pr']['number']}", _lean_core_risk(report)) for report in grouped),
+                    intent=f"{contract_set} intake warning: broad shared label is not enough to form a merge batch.",
                     shared_files=[],
                     action="Keep as separate reviews until manual inspection proves these PRs share a real implementation or product dependency.",
                     reason="Same broad contract label, but no exact file overlap and lane/risk profile is not a low-risk adjacent batch.",
@@ -1191,6 +1504,7 @@ def _operator_batch_lines(batches: list[OrderedDict[str, Any]]) -> list[str]:
                 f"- Lanes: `{json.dumps(batch['lanes'])}`",
                 f"- Lean/core risk: `{json.dumps(batch['risks'])}`",
                 f"- Confidence: `{batch['confidence']}`",
+                f"- What this is about: {batch.get('intent', 'Shared PR sequencing.')}",
                 f"- Why together: {batch['reason']}",
                 f"- Operator action: {batch['action']}",
                 f"- Shared files: {_compact_file_list(batch['shared_files'], limit=8)}",
@@ -1214,9 +1528,12 @@ def _text_report(report: dict[str, Any]) -> str:
         lines.append(f"Issue linkage: {', '.join('#' + item for item in pr['closed_issues'])}")
     if pr.get("summary"):
         lines.append(f"Summary: {pr['summary']}")
+    lines.append(f"What this is about: {report['what_this_is_about']}")
     lines.append(f"Current CI Status Gate: {report['current_ci_status_gate']}")
     lines.append(f"Contract set: {report['contract_set']}")
     lines.append(f"Duplicate group: {report['duplicate_group'] or 'none'}")
+    if report.get("canonical_selection_rationale"):
+        lines.append(f"Canonical selection rationale: {report['canonical_selection_rationale']}")
     lines.append(f"Author group: {report['author_group']}")
     lines.append(f"Recommended lane: {report['decision']['lane']}")
     lines.append(f"Decision rationale: {report['decision']['rationale']}")
@@ -1334,20 +1651,27 @@ def _apply_batch_context(reports: list[dict[str, Any]]) -> list[dict[str, Any]]:
         right["exact_file_overlap"].append(
             OrderedDict(other_pr=left["pr"]["number"], shared_files=shared)
         )
-        same_file_set = set(left["changed_files"]) == set(right["changed_files"])
         same_head = left["pr"]["head_sha"] == right["pr"]["head_sha"]
-        if same_file_set or same_head:
-            signature_source = (
-                left["pr"]["head_sha"]
-                if same_head
-                else "\n".join(sorted(set(left["changed_files"])))
-            )
+        semantic_group = _semantic_duplicate_group(left, right, shared)
+        if same_head or semantic_group:
+            signature_source = left["pr"]["head_sha"] if same_head else semantic_group
             duplicate_signature = hashlib.sha1(signature_source.encode("utf-8")).hexdigest()[:10]
-            duplicate_group = f"exact-duplicate:{duplicate_signature}"
+            duplicate_group = (
+                f"exact-duplicate:{duplicate_signature}"
+                if same_head
+                else f"{semantic_group}:{duplicate_signature}"
+            )
             if not left.get("duplicate_group"):
                 left["duplicate_group"] = duplicate_group
             if not right.get("duplicate_group"):
                 right["duplicate_group"] = duplicate_group
+        elif set(left["changed_files"]) == set(right["changed_files"]):
+            left["concept_overlap"].append(
+                f"shared_file_sequence with #{right['pr']['number']}: same files, different head; manual diff review required before calling this duplicate"
+            )
+            right["concept_overlap"].append(
+                f"shared_file_sequence with #{left['pr']['number']}: same files, different head; manual diff review required before calling this duplicate"
+            )
 
     duplicate_groups: dict[str, list[dict[str, Any]]] = {}
     for report in reports:
@@ -1359,18 +1683,23 @@ def _apply_batch_context(reports: list[dict[str, Any]]) -> list[dict[str, Any]]:
     for group, grouped_reports in duplicate_groups.items():
         if len(grouped_reports) < 2:
             continue
-        group_label = "exact duplicate" if group.startswith("exact-duplicate:") else group
-        preferred = min(
+        group_label = (
+            "exact duplicate"
+            if group.startswith("exact-duplicate:")
+            else "semantic duplicate"
+            if group.startswith("semantic-duplicate:")
+            else group
+        )
+        preferred = max(
             grouped_reports,
-            key=lambda item: (
-                item["pr"]["additions"] + item["pr"]["deletions"],
-                item["pr"]["number"],
-            ),
+            key=lambda item: _duplicate_preference_key(item, group),
         )
         preferred_number = preferred["pr"]["number"]
+        rationale = _canonical_selection_rationale(group, preferred)
         for report in grouped_reports:
+            report["canonical_selection_rationale"] = rationale
             report["concept_overlap"].append(
-                f"{group_label}: preferred canonical candidate is #{preferred_number}"
+                f"{group_label}: preferred canonical candidate is #{preferred_number} ({rationale})"
             )
             if report["pr"]["number"] == preferred_number:
                 continue
@@ -1467,6 +1796,11 @@ def _batch_text_report(batch: dict[str, Any]) -> str:
     lines.append(
         f"Batch PR review: {', '.join('#' + str(pr) for pr in batch['prs'])}"
     )
+    if batch.get("operator_batches"):
+        lines.append(
+            "What this batch is about: "
+            + str(batch["operator_batches"][0].get("intent", "Shared PR sequencing."))
+        )
     lines.append(f"Lane counts: {json.dumps(batch['lane_counts'], sort_keys=True)}")
     lines.append(f"Surface counts: {json.dumps(batch['surface_counts'], sort_keys=True)}")
     lines.append(f"Root counts: {json.dumps(batch['root_counts'], sort_keys=True)}")
@@ -1776,7 +2110,16 @@ def build_report(repo: str, pr: int) -> dict[str, Any]:
         ),
         changed_files=files,
         contract_set=contract_set,
+        what_this_is_about=_what_this_is_about(
+            pr_view["title"],
+            _extract_summary(pr_view.get("body")),
+            files,
+            patch_map,
+            contract_set,
+        ),
         duplicate_group=_duplicate_group(contract_set, files),
+        duplicate_selection_factors=_duplicate_selection_factors(contract_set, files, patch_map),
+        canonical_selection_rationale=None,
         author_group=_author_group(pr_view.get("author", {}).get("login")),
         exact_file_overlap=[],
         concept_overlap=[],

--- a/.codex/skills/pr-governance-review/skill.json
+++ b/.codex/skills/pr-governance-review/skill.json
@@ -31,6 +31,7 @@
     "python3 -m py_compile .codex/skills/pr-governance-review/scripts/pr_review_checklist.py",
     "python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --pr 437 --text",
     "python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --prs 498,505,444 --text",
+    "python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --prs 531,529,435 --text",
     "python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --prs 488,489 --text",
     "python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --live-report --text",
     "./bin/hushh codex audit --text",
@@ -43,6 +44,7 @@
         "python3 -m py_compile .codex/skills/pr-governance-review/scripts/pr_review_checklist.py",
         "python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --pr 437 --text",
         "python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --prs 498,505,444 --text",
+        "python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --prs 531,529,435 --text",
         "python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --prs 488,489 --text",
         "python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --live-report --text",
         "./bin/hushh codex audit --text",
@@ -51,6 +53,7 @@
       "tests": [
         "python3 -m py_compile .codex/skills/pr-governance-review/scripts/pr_review_checklist.py",
         "python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --prs 498,505,444 --text",
+        "python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --prs 531,529,435 --text",
         "python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --prs 488,489 --text",
         "./bin/hushh codex audit --text",
         "./bin/hushh docs verify"

--- a/.codex/skills/repo-operations/SKILL.md
+++ b/.codex/skills/repo-operations/SKILL.md
@@ -81,15 +81,20 @@ Run this gate before CI, deploy, PR, hotfix, or validation work:
 14. If the change touches `.codex/`, `docs/`, `config/`, `scripts`, or other governance-owned surfaces, rerun `bash scripts/ci/orchestrate.sh governance` after the final local edit instead of relying only on an earlier green `pre-pr` result.
 15. Treat user intent literally: `merge to main` means land the change and monitor through `Main Post-Merge Smoke` only; do not dispatch UAT unless the user explicitly asks to deploy to UAT.
 16. Treat `deploy to UAT` as a separate cadence: land the change on `main`, identify the exact green `main` SHA, manually dispatch `Deploy to UAT` for that SHA, then monitor the deploy chain to terminal state.
-17. If a core run fails, default to the smallest safe repair and rerun loop before declaring a blocker. Only stop early for a real permissions, product, or platform boundary.
-18. Default runtime launch behavior must be visible separate OS terminal windows, not hidden Codex sessions.
-19. For local app work, prefer separate `./bin/hushh terminal backend --mode local --reload` and `./bin/hushh terminal web --mode <mode>` commands unless the user explicitly asks for something else.
-20. If the user explicitly says `inline`, `inside Codex`, `in Codex`, or asks to keep the servers/background logs in the Codex session, run the same canonical backend/web commands directly through long-lived Codex `exec_command` sessions and keep those sessions open until the user asks to stop or the task ends.
-21. Use hidden long-lived Codex sessions only for the explicit inline override, background monitoring, one-off debugging, or when a visible terminal is not desired.
-22. Use `./bin/hushh terminal stack --mode local` only when one combined visible terminal is explicitly preferred.
-23. When the user says `restart servers`, treat that as a graceful terminal-managed restart, not just a port kill. First inspect existing repo-launched visible terminals, stop the running backend/web processes, then terminate the login shells cleanly before closing any leftover windows so Terminal does not prompt `Do you want to terminate running processes in this window?`.
-24. When the user says `restart servers inline`, stop any existing repo-launched backend/web listeners first, then run `./bin/hushh backend --mode local --reload` and `./bin/hushh web --mode local` in long-lived Codex sessions instead of reopening Terminal windows.
-25. For macOS Terminal restarts, prefer this order:
+17. For any merged change that touches files under `consent-protocol/db/migrations/`, files under `consent-protocol/db/contracts/`, or `consent-protocol/db/release_migration_manifest.json`, insert a DB release gate before UAT is called ready:
+   - run `./bin/hushh db verify-release-contract` from the exact code SHA
+   - run live `./bin/hushh db verify-uat-schema --report-path <tmp-report>`
+   - if the live guard reports a missing table, column, function, trigger, or version required by the checked-in contract, apply only the specific ordered migration needed for UAT, then rerun the live guard
+   - do not hide this inside a generic deploy note; report the DB guard result separately from app deploy health
+18. If a core run fails, default to the smallest safe repair and rerun loop before declaring a blocker. Only stop early for a real permissions, product, or platform boundary.
+19. Default runtime launch behavior must be visible separate OS terminal windows, not hidden Codex sessions.
+20. For local app work, prefer separate `./bin/hushh terminal backend --mode local --reload` and `./bin/hushh terminal web --mode <mode>` commands unless the user explicitly asks for something else.
+21. If the user explicitly says `inline`, `inside Codex`, `in Codex`, or asks to keep the servers/background logs in the Codex session, run the same canonical backend/web commands directly through long-lived Codex `exec_command` sessions and keep those sessions open until the user asks to stop or the task ends.
+22. Use hidden long-lived Codex sessions only for the explicit inline override, background monitoring, one-off debugging, or when a visible terminal is not desired.
+23. Use `./bin/hushh terminal stack --mode local` only when one combined visible terminal is explicitly preferred.
+24. When the user says `restart servers`, treat that as a graceful terminal-managed restart, not just a port kill. First inspect existing repo-launched visible terminals, stop the running backend/web processes, then terminate the login shells cleanly before closing any leftover windows so Terminal does not prompt `Do you want to terminate running processes in this window?`.
+25. When the user says `restart servers inline`, stop any existing repo-launched backend/web listeners first, then run `./bin/hushh backend --mode local --reload` and `./bin/hushh web --mode local` in long-lived Codex sessions instead of reopening Terminal windows.
+26. For macOS Terminal restarts, prefer this order:
    - identify the repo-launched Terminal tabs/windows and their ttys
    - stop the backend/web processes attached to those ttys
    - verify the ports are no longer listening
@@ -97,29 +102,29 @@ Run this gate before CI, deploy, PR, hotfix, or validation work:
    - wait for the windows to disappear on their own or become truly idle
    - only then close any leftover idle Terminal windows
    - relaunch fresh visible terminals
-26. Do not close a Terminal window that still has a live shell just because the app listener is gone. A plain `close ... saving no` still triggers the terminate-process prompt on macOS if `zsh` is alive.
-27. If a terminal refuses to disappear after `exit`, treat force-close as fallback only. Prefer proving the shell is gone first, then closing the leftover idle window.
-28. If `./bin/hushh terminal web` opens but the frontend never binds, inspect the actual package surface before retrying. A common failure mode is `npm run dev` -> `sh: next: command not found`, which means the frontend install surface is broken even if dependencies appear partially present.
-29. In that case, verify the local Next binary resolves from the `hushh-webapp` package context, for example by checking `npm exec next -- --version` or an equivalent package-local resolution step. If Next does not resolve, repair the workspace through the canonical bootstrap path (`./bin/hushh bootstrap`) before relaunching the web terminal.
-30. Do not claim the server restart succeeded until both backend and web have been probed successfully after relaunch (`:8000/health` and `:3000`).
-31. Default branch policy: continue work on the user's active development branch. At task start, identify and preserve that branch as the return target before any temporary hotfix, detached checkout, or merge/deploy operation.
-32. If the workspace is detached or sitting on a temporary branch and the user has an established development branch, switch back to that branch before starting new edits unless the user explicitly asks for a different base.
-33. Do not create a new temporary branch for incremental fixes, validation follow-ups, or polish work unless the user explicitly asks for branch isolation.
-34. Create a new branch only when one of these is true:
+27. Do not close a Terminal window that still has a live shell just because the app listener is gone. A plain `close ... saving no` still triggers the terminate-process prompt on macOS if `zsh` is alive.
+28. If a terminal refuses to disappear after `exit`, treat force-close as fallback only. Prefer proving the shell is gone first, then closing the leftover idle window.
+29. If `./bin/hushh terminal web` opens but the frontend never binds, inspect the actual package surface before retrying. A common failure mode is `npm run dev` -> `sh: next: command not found`, which means the frontend install surface is broken even if dependencies appear partially present.
+30. In that case, verify the local Next binary resolves from the `hushh-webapp` package context, for example by checking `npm exec next -- --version` or an equivalent package-local resolution step. If Next does not resolve, repair the workspace through the canonical bootstrap path (`./bin/hushh bootstrap`) before relaunching the web terminal.
+31. Do not claim the server restart succeeded until both backend and web have been probed successfully after relaunch (`:8000/health` and `:3000`).
+32. Default branch policy: continue work on the user's active development branch. At task start, identify and preserve that branch as the return target before any temporary hotfix, detached checkout, or merge/deploy operation.
+33. If the workspace is detached or sitting on a temporary branch and the user has an established development branch, switch back to that branch before starting new edits unless the user explicitly asks for a different base.
+34. Do not create a new temporary branch for incremental fixes, validation follow-ups, or polish work unless the user explicitly asks for branch isolation.
+35. Create a new branch only when one of these is true:
    - the fix is a post-merge blocker and must start from the latest `main`
    - the repo workflow requires an isolated hotfix from `main`
    - the current branch contains unrelated in-flight work that would make the fix unsafe to ship
-35. After a merge-driven hotfix is complete, delete the temporary branch remotely and locally when it is safe to do so, then return local state to the user's preserved development branch; use `main` only when the user has no development branch.
-36. Back-sync merged hotfixes into the preserved development branch before closing the task so the real working branch does not drift behind `main`.
-37. Do not leave the workspace detached or parked on a temporary branch at handoff. If a branch switch is unsafe because of conflicts or local-only edits, state the blocker explicitly and leave the user on their development branch whenever possible.
-38. For CI workflows, branch protection, env/bootstrap, or deploy-authority changes, do a second verification pass after edits instead of trusting the first green run.
-39. For branch protection, merge queue, release authority, or production deploy-governance changes, do a third independent check against live GitHub or runtime state before calling the work complete.
-40. For UAT runtime failures, start with `./bin/hushh codex rca --surface uat --text` so secret drift, legacy runtime mounts, DB drift, and semantic runtime breakage are classified before editing or redeploying.
-41. Treat only core runtime/release surfaces as blocking in the RCA loop: runtime contract, deploy/runtime env contract, DB release contract, semantic UAT verification, and Gmail/voice/auth availability on the release lane. Helper-only drift stays advisory unless it masks one of those surfaces.
-42. For Firebase Auth env parity work, verify the shared auth project, API key restrictions, auth domain, authorized domains, phone provider state, and app-verification flag separately; do not treat a local real-SMS `too-many-requests` throttle as proof that UAT is misconfigured.
-43. Before claiming a UAT auth rollout is ready, confirm the hosted UAT origin is authorized in Firebase Auth and that local origin changes did not break vault/passkey behavior.
-44. Do not conflate `Upstream Sync` with `Main Freshness Gate`. Freshness is branch-to-main currency; upstream sync is consent-protocol subtree state and must route through `subtree-upstream-governance`.
-45. When rendering or summarizing PR operations, show the actual subtree status from `scripts/ci/subtree-sync-check.sh`, not a generic freshness or status-gate description.
+36. After a merge-driven hotfix is complete, delete the temporary branch remotely and locally when it is safe to do so, then return local state to the user's preserved development branch; use `main` only when the user has no development branch.
+37. Back-sync merged hotfixes into the preserved development branch before closing the task so the real working branch does not drift behind `main`.
+38. Do not leave the workspace detached or parked on a temporary branch at handoff. If a branch switch is unsafe because of conflicts or local-only edits, state the blocker explicitly and leave the user on their development branch whenever possible.
+39. For CI workflows, branch protection, env/bootstrap, or deploy-authority changes, do a second verification pass after edits instead of trusting the first green run.
+40. For branch protection, merge queue, release authority, or production deploy-governance changes, do a third independent check against live GitHub or runtime state before calling the work complete.
+41. For UAT runtime failures, start with `./bin/hushh codex rca --surface uat --text` so secret drift, legacy runtime mounts, DB drift, and semantic runtime breakage are classified before editing or redeploying.
+42. Treat only core runtime/release surfaces as blocking in the RCA loop: runtime contract, deploy/runtime env contract, DB release contract, semantic UAT verification, and Gmail/voice/auth availability on the release lane. Helper-only drift stays advisory unless it masks one of those surfaces.
+43. For Firebase Auth env parity work, verify the shared auth project, API key restrictions, auth domain, authorized domains, phone provider state, and app-verification flag separately; do not treat a local real-SMS `too-many-requests` throttle as proof that UAT is misconfigured.
+44. Before claiming a UAT auth rollout is ready, confirm the hosted UAT origin is authorized in Firebase Auth and that local origin changes did not break vault/passkey behavior.
+45. Do not conflate `Upstream Sync` with `Main Freshness Gate`. Freshness is branch-to-main currency; upstream sync is consent-protocol subtree state and must route through `subtree-upstream-governance`.
+46. When rendering or summarizing PR operations, show the actual subtree status from `scripts/ci/subtree-sync-check.sh`, not a generic freshness or status-gate description.
 
 ## Handoff Rules
 

--- a/consent-protocol/docs/reference/agent-development.md
+++ b/consent-protocol/docs/reference/agent-development.md
@@ -390,7 +390,7 @@ app.include_router(my_agent_router)
 
 ```python
 # hushh_mcp/agents/orchestrator/tools.py
-@hushh_tool(scope="vault.owner", name="delegate_to_my_agent")
+@hushh_tool(scope="agent.one.orchestrate", name="delegate_to_my_agent")
 async def delegate_to_my_agent(query: str) -> dict:
     """Delegate to MyDomain agent."""
     # ... forward to MyDomainAgent
@@ -402,8 +402,10 @@ async def delegate_to_my_agent(query: str) -> dict:
 
 | Agent               | Directory                    | Scopes                          | Tools                            |
 | ------------------- | ---------------------------- | ------------------------------- | -------------------------------- |
-| OrchestratorAgent   | `agents/orchestrator/`       | `vault.owner`                   | `delegate_to_kai`                |
-| KaiAgent            | `agents/kai/`                | `attr.financial.*`              | `perform_fundamental_analysis`, `perform_sentiment_analysis`, `perform_valuation_analysis` |
+| OneAgent            | `agents/one/` and legacy `agents/orchestrator/` | `agent.one.orchestrate` | delegate to Kai, Nav, and KYC |
+| KaiAgent            | `agents/kai/`                | `agent.kai.analyze`             | `perform_fundamental_analysis`, `perform_sentiment_analysis`, `perform_valuation_analysis` |
+| NavAgent            | `agents/nav/`                | `agent.nav.review`              | scope review, vault/deletion/revocation guidance |
+| KycAgent            | `agents/kyc/`                | `agent.kyc.process`             | identity workflow state, approval-gated drafts, structured PKM writeback |
 | PortfolioImportAgent| (inline in `kai/portfolio.py`)| `vault.owner`                  | File parsing + LLM fallback      |
 
 ---
@@ -439,13 +441,14 @@ icon: string                  # Optional UI icon
 
 ## A2A Communication
 
-Agent-to-agent communication uses the `KaiA2AServer` pattern:
+Agent-to-agent communication uses the shared A2A delegation pattern:
 
 - Consent tokens are passed in HTTP headers
 - Agent cards describe capabilities (manifest-based)
 - Delegation uses `@hushh_tool` wrappers
+- Specialist entry points validate the least-privilege specialist scope instead of defaulting to `vault.owner`
 
-See the Kai agent for the reference implementation.
+See `hushh_mcp/adk_bridge/delegation.py` and the Kai agent for the reference implementation.
 
 ### ADK/A2A Compliance Verification
 
@@ -457,7 +460,7 @@ python scripts/verify_adk_a2a_compliance.py
 
 The verifier checks:
 - `X-Consent-Token` enforcement in A2A entry points.
-- Token validation using `ConsentScope.VAULT_OWNER`.
+- Token validation using the specialist scope map, for example `agent.kai.analyze` for Kai A2A.
 - Google A2A compatibility flag and route wiring.
 - Required agent -> operon data-source calls for fundamental/sentiment/valuation paths.
 

--- a/consent-protocol/hushh_mcp/adk_bridge/delegation.py
+++ b/consent-protocol/hushh_mcp/adk_bridge/delegation.py
@@ -1,0 +1,43 @@
+"""Shared A2A delegation consent helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from hushh_mcp.consent.token import validate_token
+from hushh_mcp.constants import ConsentScope
+
+SPECIALIST_A2A_SCOPE_MAP: dict[str, ConsentScope] = {
+    "agent_one": ConsentScope.AGENT_ONE_ORCHESTRATE,
+    "agent_kai": ConsentScope.AGENT_KAI_ANALYZE,
+    "agent_nav": ConsentScope.AGENT_NAV_REVIEW,
+    "agent_kyc": ConsentScope.AGENT_KYC_PROCESS,
+}
+
+
+@dataclass(frozen=True)
+class A2AConsentValidation:
+    ok: bool
+    reason: str
+    user_id: str | None
+    required_scope: ConsentScope
+
+
+def get_a2a_required_scope(agent_id: str) -> ConsentScope:
+    """Return the least-privilege consent scope required by an A2A specialist."""
+    try:
+        return SPECIALIST_A2A_SCOPE_MAP[agent_id]
+    except KeyError as exc:
+        raise ValueError(f"Unknown A2A specialist: {agent_id!r}") from exc
+
+
+def validate_a2a_consent_token(agent_id: str, consent_token: str) -> A2AConsentValidation:
+    """Validate an A2A consent token against the specialist-specific scope."""
+    required_scope = get_a2a_required_scope(agent_id)
+    valid, reason, payload = validate_token(consent_token, required_scope)
+    return A2AConsentValidation(
+        ok=bool(valid and payload),
+        reason=reason,
+        user_id=payload.user_id if payload else None,
+        required_scope=required_scope,
+    )

--- a/consent-protocol/hushh_mcp/adk_bridge/kai_agent.py
+++ b/consent-protocol/hushh_mcp/adk_bridge/kai_agent.py
@@ -5,12 +5,11 @@ from python_a2a.models.content import ErrorContent, TextContent
 from python_a2a.models.message import Message, MessageRole
 from python_a2a.server.a2a_server import A2AServer
 
+from hushh_mcp.adk_bridge.delegation import validate_a2a_consent_token
 from hushh_mcp.agents.kai.debate_engine import DebateEngine
 from hushh_mcp.agents.kai.fundamental_agent import FundamentalAgent
 from hushh_mcp.agents.kai.sentiment_agent import SentimentAgent
 from hushh_mcp.agents.kai.valuation_agent import ValuationAgent
-from hushh_mcp.consent.token import validate_token
-from hushh_mcp.constants import ConsentScope
 from hushh_mcp.hushh_adk.context import HushhContext
 from hushh_mcp.services.consent_db import ConsentDBService
 
@@ -55,17 +54,16 @@ class KaiA2AServer(A2AServer):
                 )
 
             # 2. VALIDATION
-            # Validate token using direct helper (CPU bound, fast)
-            # Scope: VAULT_OWNER for full access, similar to /analyze/stream
-            valid, reason, payload = validate_token(consent_token, ConsentScope.VAULT_OWNER)
+            # Validate token using the least-privilege Kai A2A specialist scope.
+            validation = validate_a2a_consent_token("agent_kai", consent_token)
 
-            if not valid or not payload:
-                logger.warning(f"A2A Request rejected: Invalid Token ({reason})")
+            if not validation.ok or not validation.user_id:
+                logger.warning(f"A2A Request rejected: Invalid Token ({validation.reason})")
                 return self._create_error_response(
-                    message, f"Access Denied: Invalid Consent Token. {reason}"
+                    message, f"Access Denied: Invalid Consent Token. {validation.reason}"
                 )
 
-            user_id = payload.user_id
+            user_id = validation.user_id
 
             # 2.1 Audit Logging
             try:

--- a/consent-protocol/hushh_mcp/agents/kyc/__init__.py
+++ b/consent-protocol/hushh_mcp/agents/kyc/__init__.py
@@ -1,0 +1,1 @@
+"""KYC agent package."""

--- a/consent-protocol/hushh_mcp/agents/kyc/agent.yaml
+++ b/consent-protocol/hushh_mcp/agents/kyc/agent.yaml
@@ -1,0 +1,16 @@
+id: agent_kyc
+name: Agent KYC
+version: 0.1.0
+description: Identity/KYC workflow specialist for requirements, missing-document state, approval-gated drafts, and structured PKM writeback.
+model: gemini-3-flash-preview
+system_instruction: |
+  You are KYC, a bounded identity workflow specialist. Process KYC requirements
+  only inside explicit workflow consent, draft outbound messages for approval,
+  and write only structured facts or workflow artifacts back to PKM.
+required_scopes:
+  - agent.kyc.process
+optional_scopes:
+  - agent.kyc.draft
+  - agent.kyc.writeback
+  - pkm.write
+

--- a/consent-protocol/hushh_mcp/agents/kyc/manifest.py
+++ b/consent-protocol/hushh_mcp/agents/kyc/manifest.py
@@ -1,0 +1,48 @@
+"""Agent KYC manifest."""
+
+from hushh_mcp.constants import ConsentScope
+
+KYC_WORKFLOW_STATES = (
+    "needs_scope",
+    "needs_documents",
+    "drafting",
+    "waiting_on_user",
+    "waiting_on_counterparty",
+    "completed",
+    "blocked",
+)
+
+MANIFEST = {
+    "agent_id": "agent_kyc",
+    "name": "Agent KYC",
+    "version": "0.1.0",
+    "description": "Identity/KYC workflow specialist for requirements, missing-document state, approval-gated drafts, and structured PKM writeback.",
+    "required_scopes": [
+        ConsentScope.AGENT_KYC_PROCESS,
+    ],
+    "optional_scopes": [
+        ConsentScope.AGENT_KYC_DRAFT,
+        ConsentScope.AGENT_KYC_WRITEBACK,
+        ConsentScope.PKM_WRITE,
+    ],
+    "workflow_states": KYC_WORKFLOW_STATES,
+    "specialists": [],
+    "capabilities": {
+        "requirements_review": True,
+        "missing_document_state": True,
+        "approval_gated_drafts": True,
+        "structured_pkm_writeback": True,
+        "raw_thread_persistence": False,
+    },
+    "compliance": {
+        "consent_required": True,
+        "approval_required_for_outbound_send": True,
+        "structured_writeback_only": True,
+        "audit_trail": True,
+    },
+}
+
+
+def get_manifest():
+    """Get agent manifest."""
+    return MANIFEST

--- a/consent-protocol/hushh_mcp/agents/nav/__init__.py
+++ b/consent-protocol/hushh_mcp/agents/nav/__init__.py
@@ -1,0 +1,1 @@
+"""Nav agent package."""

--- a/consent-protocol/hushh_mcp/agents/nav/agent.yaml
+++ b/consent-protocol/hushh_mcp/agents/nav/agent.yaml
@@ -1,0 +1,12 @@
+id: agent_nav
+name: Agent Nav
+version: 0.1.0
+description: Privacy and consent guardian for scope review, vault friction, deletion, and revocation.
+model: gemini-3-flash-preview
+system_instruction: |
+  You are Nav, the privacy and consent guardian. Review scopes, explain trust
+  boundaries, and help users narrow, revoke, or approve access. Do not provide
+  finance analysis or general relationship memory.
+required_scopes:
+  - agent.nav.review
+

--- a/consent-protocol/hushh_mcp/agents/nav/manifest.py
+++ b/consent-protocol/hushh_mcp/agents/nav/manifest.py
@@ -1,0 +1,33 @@
+"""Agent Nav manifest."""
+
+from hushh_mcp.constants import ConsentScope
+
+MANIFEST = {
+    "agent_id": "agent_nav",
+    "name": "Agent Nav",
+    "version": "0.1.0",
+    "description": "Privacy and consent guardian for scope review, vault friction, deletion, and revocation.",
+    "required_scopes": [
+        ConsentScope.AGENT_NAV_REVIEW,
+    ],
+    "optional_scopes": [
+        ConsentScope.AGENT_NAV_REVOKE,
+    ],
+    "specialists": [],
+    "capabilities": {
+        "scope_review": True,
+        "revocation_guidance": True,
+        "vault_friction": True,
+        "finance_analysis": False,
+    },
+    "compliance": {
+        "consent_required": True,
+        "privacy_guardian": True,
+        "audit_trail": True,
+    },
+}
+
+
+def get_manifest():
+    """Get agent manifest."""
+    return MANIFEST

--- a/consent-protocol/hushh_mcp/agents/one/__init__.py
+++ b/consent-protocol/hushh_mcp/agents/one/__init__.py
@@ -1,0 +1,1 @@
+"""One agent package."""

--- a/consent-protocol/hushh_mcp/agents/one/agent.yaml
+++ b/consent-protocol/hushh_mcp/agents/one/agent.yaml
@@ -1,0 +1,14 @@
+id: agent_one
+legacy_ids:
+  - agent_orchestrator
+name: Agent One
+version: 0.1.0
+description: Top personal agent that frames user intent and delegates specialist work.
+model: gemini-3-flash-preview
+system_instruction: |
+  You are One, the top personal agent in Hussh. Hold the relationship layer,
+  clarify intent, and delegate finance work to Kai, privacy work to Nav, and
+  identity/KYC workflow work to KYC.
+required_scopes:
+  - agent.one.orchestrate
+

--- a/consent-protocol/hushh_mcp/agents/one/manifest.py
+++ b/consent-protocol/hushh_mcp/agents/one/manifest.py
@@ -1,0 +1,60 @@
+"""Agent One manifest.
+
+One is the top personal agent and relationship layer. Runtime code may still
+use the legacy orchestrator package while migration proceeds.
+"""
+
+from hushh_mcp.constants import ConsentScope
+
+MANIFEST = {
+    "agent_id": "agent_one",
+    "legacy_ids": ["agent_orchestrator"],
+    "name": "Agent One",
+    "version": "0.1.0",
+    "description": "Top personal agent that frames user intent and delegates specialist work.",
+    "required_scopes": [
+        ConsentScope.AGENT_ONE_ORCHESTRATE,
+    ],
+    "optional_scopes": [],
+    "specialists": [
+        {
+            "id": "kai",
+            "name": "Kai",
+            "description": "Finance, portfolio, market, and RIA/investor specialist.",
+            "color": "#D4AF37",
+            "icon": "chart-line",
+        },
+        {
+            "id": "nav",
+            "name": "Nav",
+            "description": "Privacy, consent, vault, deletion, and scope-review guardian.",
+            "color": "#10B981",
+            "icon": "shield-check",
+        },
+        {
+            "id": "kyc",
+            "name": "KYC",
+            "description": "Identity/KYC workflow, missing-document state, and structured PKM writeback specialist.",
+            "color": "#6366F1",
+            "icon": "id-card",
+        },
+    ],
+    "capabilities": {
+        "relationship_layer": True,
+        "specialist_delegation": True,
+        "direct_finance_analysis": False,
+        "direct_privacy_enforcement": False,
+        "direct_kyc_processing": False,
+    },
+    "compliance": {
+        "consent_required": True,
+        "vault_gated": True,
+        "delegation_scoped": True,
+        "audit_trail": True,
+    },
+}
+
+
+def get_manifest():
+    """Get agent manifest."""
+    return MANIFEST

--- a/consent-protocol/hushh_mcp/agents/orchestrator/agent.py
+++ b/consent-protocol/hushh_mcp/agents/orchestrator/agent.py
@@ -1,8 +1,8 @@
 """
-Hushh Orchestrator Agent (ADK Port)
+Agent One Orchestrator (ADK Port)
 
 Central routing agent that uses LLM semantic understanding to delegate tasks.
-Replaces legacy regex/classifier logic.
+Keeps the legacy orchestrator package path while One becomes the product owner.
 """
 
 import logging
@@ -13,14 +13,14 @@ from hushh_mcp.hushh_adk.core import HushhAgent
 from hushh_mcp.hushh_adk.manifest import ManifestLoader
 
 # Import tools for registration
-from .tools import delegate_to_food_agent, delegate_to_kai_agent, delegate_to_professional_agent
+from .tools import delegate_to_kai_agent, delegate_to_kyc_agent, delegate_to_nav_agent
 
 logger = logging.getLogger(__name__)
 
 
 class OrchestratorAgent(HushhAgent):
     """
-    Semantic Router for Hushh Ecosystem.
+    Compatibility wrapper for Agent One.
     """
 
     def __init__(self):
@@ -33,7 +33,7 @@ class OrchestratorAgent(HushhAgent):
             name=self.manifest.name,
             model=self.manifest.model,
             system_prompt=self.manifest.system_instruction,
-            tools=[delegate_to_food_agent, delegate_to_professional_agent, delegate_to_kai_agent],
+            tools=[delegate_to_kai_agent, delegate_to_nav_agent, delegate_to_kyc_agent],
             required_scopes=self.manifest.required_scopes,
         )
 
@@ -44,15 +44,12 @@ class OrchestratorAgent(HushhAgent):
         Args:
             message: User input
             user_id: User identifier
-            consent_token: (Optional) Token, though Orchestrator is often public entry
+            consent_token: Token with `agent.one.orchestrate` for delegated work
 
         Returns:
             Dict containing response text and optional delegation info.
         """
-        # Orchestrator often runs without a strict token at entry (public gatekeeper)
-        # But if we pass specific user data, we might need one.
-        # For now, we allow empty token for routing only.
-        token = consent_token or "public_access_token"
+        token = consent_token
 
         try:
             # Run the agent (this invokes the LLM + Tools)

--- a/consent-protocol/hushh_mcp/agents/orchestrator/agent.yaml
+++ b/consent-protocol/hushh_mcp/agents/orchestrator/agent.yaml
@@ -1,40 +1,43 @@
-id: agent_orchestrator
-name: Hushh Orchestrator
+id: agent_one
+legacy_ids:
+  - agent_orchestrator
+name: Agent One
 version: 2.0.0
-description: Central routing agent that classifies user intent and delegates to domain specialists.
+description: Top personal agent that classifies user intent, frames specialist handoffs, and delegates to Kai, Nav, and KYC.
 model: gemini-3-flash-preview
 system_instruction: |
-  You are the Hushh Orchestrator, a privacy-first routing agent.
-  Your ONLY job is to route the user's request to the correct specialist agent.
+  You are One, the top personal agent in Hussh.
+  Your job is to hold the relationship layer, frame the user's request, and route specialist work to the correct agent.
 
   Do NOT attempt to answer the user's question directly if it falls into a specialized domain.
   Instead, use the available tools to delegate the task.
 
   Available Specialists:
-  - Food & Dining: For restaurant recommendations, dietary needs, meal planning.
-  - Professional Profile: For career advice, resume building, job search preferences.
-  - Kai Investment: For stock analysis, market research, portfolio management.
+  - Kai: Finance, portfolio, market research, recommendations, and RIA/investor workflows.
+  - Nav: Consent, scopes, vault, deletion, privacy review, and suspicious access.
+  - KYC: Identity/KYC requirements, missing-document state, approval-gated drafts, and structured PKM writeback.
 
   If the request is general (e.g., "Hello", "Who are you?", "Help"), answer it yourself politely.
-  Always maintain a helpful and professional tone.
+  Always maintain a calm, privacy-first tone.
 
-required_scopes: []
+required_scopes:
+  - agent.one.orchestrate
 
 tools:
-  - name: delegate_to_food_agent
-    py_func: hushh_mcp.agents.orchestrator.tools.delegate_to_food_agent
-    required_scope: ""
-    description: Delegate to the Food & Dining specialist.
-
-  - name: delegate_to_professional_agent
-    py_func: hushh_mcp.agents.orchestrator.tools.delegate_to_professional_agent
-    required_scope: ""
-    description: Delegate to the Professional Profile specialist.
-
   - name: delegate_to_kai_agent
     py_func: hushh_mcp.agents.orchestrator.tools.delegate_to_kai_agent
-    required_scope: ""
-    description: Delegate to the Kai Investment specialist.
+    required_scope: agent.kai.analyze
+    description: Delegate to the Kai finance specialist.
+
+  - name: delegate_to_nav_agent
+    py_func: hushh_mcp.agents.orchestrator.tools.delegate_to_nav_agent
+    required_scope: agent.nav.review
+    description: Delegate to the Nav privacy and consent guardian.
+
+  - name: delegate_to_kyc_agent
+    py_func: hushh_mcp.agents.orchestrator.tools.delegate_to_kyc_agent
+    required_scope: agent.kyc.process
+    description: Delegate to the KYC identity workflow specialist.
 
 inputs:
   - name: user_id

--- a/consent-protocol/hushh_mcp/agents/orchestrator/manifest.py
+++ b/consent-protocol/hushh_mcp/agents/orchestrator/manifest.py
@@ -1,7 +1,8 @@
 manifest = {
-    "id": "agent_orchestrator",
-    "name": "Hushh Orchestrator",
-    "description": "Primary interface. Analyzes intent and delegates to domain agents.",
-    "scopes": ["trust.delegate", "orchestrate.all"],
-    "version": "0.1.0",
+    "id": "agent_one",
+    "legacy_ids": ["agent_orchestrator"],
+    "name": "Agent One",
+    "description": "Top personal agent. Frames the relationship layer and delegates to Kai, Nav, and KYC specialists.",
+    "scopes": ["agent.one.orchestrate"],
+    "version": "0.2.0",
 }

--- a/consent-protocol/hushh_mcp/agents/orchestrator/tools.py
+++ b/consent-protocol/hushh_mcp/agents/orchestrator/tools.py
@@ -1,7 +1,7 @@
 """
 Orchestrator Tools
 
-Delegation functions for the Orchestrator agent.
+Delegation functions for One, the top personal agent.
 These tools are used by the LLM to route requests to specialized agents.
 """
 
@@ -23,22 +23,36 @@ def _create_delegation_response(
     }
 
 
-@hushh_tool(scope="", name="delegate_to_food_agent")
+@hushh_tool(scope="agent.one.orchestrate", name="delegate_to_food_agent")
 def delegate_to_food_agent() -> Dict[str, Any]:
-    """Delegate current conversation to Food & Dining Agent."""
+    """Deprecated compatibility delegate for older roadmap experiments."""
     ctx = HushhContext.current()
     return _create_delegation_response("food_dining", "agent_food_dining", ctx)
 
 
-@hushh_tool(scope="", name="delegate_to_professional_agent")
+@hushh_tool(scope="agent.one.orchestrate", name="delegate_to_professional_agent")
 def delegate_to_professional_agent() -> Dict[str, Any]:
-    """Delegate current conversation to Professional Profile Agent."""
+    """Deprecated compatibility delegate for older roadmap experiments."""
     ctx = HushhContext.current()
     return _create_delegation_response("professional_profile", "agent_professional_profile", ctx)
 
 
-@hushh_tool(scope="", name="delegate_to_kai_agent")
+@hushh_tool(scope="agent.kai.analyze", name="delegate_to_kai_agent")
 def delegate_to_kai_agent() -> Dict[str, Any]:
-    """Delegate current conversation to Kai Investment Agent."""
+    """Delegate current conversation to Kai, the finance specialist."""
     ctx = HushhContext.current()
-    return _create_delegation_response("kai_investment", "agent_kai", ctx)
+    return _create_delegation_response("finance", "agent_kai", ctx)
+
+
+@hushh_tool(scope="agent.nav.review", name="delegate_to_nav_agent")
+def delegate_to_nav_agent() -> Dict[str, Any]:
+    """Delegate current conversation to Nav, the privacy and consent guardian."""
+    ctx = HushhContext.current()
+    return _create_delegation_response("privacy_consent", "agent_nav", ctx)
+
+
+@hushh_tool(scope="agent.kyc.process", name="delegate_to_kyc_agent")
+def delegate_to_kyc_agent() -> Dict[str, Any]:
+    """Delegate current conversation to KYC, the identity workflow specialist."""
+    ctx = HushhContext.current()
+    return _create_delegation_response("kyc_identity_workflow", "agent_kyc", ctx)

--- a/consent-protocol/hushh_mcp/consent/scope_bundles.py
+++ b/consent-protocol/hushh_mcp/consent/scope_bundles.py
@@ -73,6 +73,19 @@ CANONICAL_BUNDLES: dict[str, ScopeBundle] = {
             "attr.shopping.*",
         ),
     ),
+    "kyc_workflow": ScopeBundle(
+        bundle_key="kyc_workflow",
+        label="KYC Workflow",
+        description="Identity workflow processing, approval-gated drafts, and structured PKM writeback",
+        icon_name="id-card",
+        color_hex="#6366F1",
+        scopes=(
+            "agent.kyc.process",
+            "agent.kyc.draft",
+            "agent.kyc.writeback",
+            "pkm.write",
+        ),
+    ),
 }
 
 

--- a/consent-protocol/hushh_mcp/consent/scope_helpers.py
+++ b/consent-protocol/hushh_mcp/consent/scope_helpers.py
@@ -51,11 +51,17 @@ def resolve_scope_to_enum(scope: str) -> ConsentScope:
 
     # Agent permissions
     _AGENT_SCOPE_MAP = {
+        "agent.one.orchestrate": ConsentScope.AGENT_ONE_ORCHESTRATE,
         "agent.kai.analyze": ConsentScope.AGENT_KAI_ANALYZE,
         "agent.kai.debate": ConsentScope.AGENT_KAI_DEBATE,
         "agent.kai.infer": ConsentScope.AGENT_KAI_INFER,
         "agent.kai.chat": ConsentScope.AGENT_KAI_CHAT,
         "agent.kai.execute": ConsentScope.AGENT_KAI_EXECUTE,
+        "agent.nav.review": ConsentScope.AGENT_NAV_REVIEW,
+        "agent.nav.revoke": ConsentScope.AGENT_NAV_REVOKE,
+        "agent.kyc.process": ConsentScope.AGENT_KYC_PROCESS,
+        "agent.kyc.draft": ConsentScope.AGENT_KYC_DRAFT,
+        "agent.kyc.writeback": ConsentScope.AGENT_KYC_WRITEBACK,
     }
     if scope.startswith("agent."):
         resolved = _AGENT_SCOPE_MAP.get(scope)
@@ -172,6 +178,12 @@ def get_scope_display_metadata(scope: str) -> dict:
             "icon_name": "pencil",
             "color_hex": "#3B82F6",
         },
+        "agent.one.orchestrate": {
+            "label": "One Orchestration",
+            "description": "Allow One to route a bounded task to the right specialist",
+            "icon_name": "route",
+            "color_hex": "#3B82F6",
+        },
         "agent.kai.analyze": {
             "label": "Kai Analysis",
             "description": "Allow Kai agent to analyze your data",
@@ -183,6 +195,36 @@ def get_scope_display_metadata(scope: str) -> dict:
             "description": "Allow Kai agent to execute actions",
             "icon_name": "zap",
             "color_hex": "#D4AF37",
+        },
+        "agent.nav.review": {
+            "label": "Nav Scope Review",
+            "description": "Allow Nav to review consent, privacy, vault, and scope decisions",
+            "icon_name": "shield-check",
+            "color_hex": "#10B981",
+        },
+        "agent.nav.revoke": {
+            "label": "Nav Revocation",
+            "description": "Allow Nav to help revoke or narrow an existing permission",
+            "icon_name": "shield-x",
+            "color_hex": "#10B981",
+        },
+        "agent.kyc.process": {
+            "label": "KYC Processing",
+            "description": "Allow KYC to process identity workflow requirements inside the granted scope",
+            "icon_name": "id-card",
+            "color_hex": "#6366F1",
+        },
+        "agent.kyc.draft": {
+            "label": "KYC Drafts",
+            "description": "Allow KYC to draft approval-gated workflow replies",
+            "icon_name": "file-pen",
+            "color_hex": "#6366F1",
+        },
+        "agent.kyc.writeback": {
+            "label": "KYC PKM Writeback",
+            "description": "Allow KYC to save structured workflow facts and artifacts to PKM",
+            "icon_name": "database",
+            "color_hex": "#6366F1",
         },
     }
 
@@ -212,6 +254,9 @@ def is_write_scope(scope: str) -> bool:
         return True
 
     if scope == "pkm.write":
+        return True
+
+    if scope == "agent.kyc.writeback":
         return True
 
     # For attr.* scopes, write is determined by context, not scope

--- a/consent-protocol/hushh_mcp/constants.py
+++ b/consent-protocol/hushh_mcp/constants.py
@@ -46,12 +46,21 @@ class ConsentScope(str, Enum):
     PKM_WRITE = "pkm.write"
     PKM_METADATA = "pkm.metadata"
 
-    # ==================== KAI AGENT OPERATIONS ====================
+    # ==================== AGENT OPERATIONS ====================
+    AGENT_ONE_ORCHESTRATE = "agent.one.orchestrate"
+
     AGENT_KAI_ANALYZE = "agent.kai.analyze"
     AGENT_KAI_DEBATE = "agent.kai.debate"
     AGENT_KAI_INFER = "agent.kai.infer"
     AGENT_KAI_CHAT = "agent.kai.chat"
     AGENT_KAI_EXECUTE = "agent.kai.execute"
+
+    AGENT_NAV_REVIEW = "agent.nav.review"
+    AGENT_NAV_REVOKE = "agent.nav.revoke"
+
+    AGENT_KYC_PROCESS = "agent.kyc.process"
+    AGENT_KYC_DRAFT = "agent.kyc.draft"
+    AGENT_KYC_WRITEBACK = "agent.kyc.writeback"
 
     # ==================== EXTERNAL DATA SOURCES ====================
     # Hybrid mode - per-request consent
@@ -187,11 +196,17 @@ class ConsentScope(str, Enum):
     def agent_scopes(cls):
         """Return all agent operation scopes."""
         return [
+            cls.AGENT_ONE_ORCHESTRATE,
             cls.AGENT_KAI_ANALYZE,
             cls.AGENT_KAI_DEBATE,
             cls.AGENT_KAI_INFER,
             cls.AGENT_KAI_CHAT,
             cls.AGENT_KAI_EXECUTE,
+            cls.AGENT_NAV_REVIEW,
+            cls.AGENT_NAV_REVOKE,
+            cls.AGENT_KYC_PROCESS,
+            cls.AGENT_KYC_DRAFT,
+            cls.AGENT_KYC_WRITEBACK,
         ]
 
     @classmethod
@@ -210,7 +225,10 @@ class ConsentScope(str, Enum):
 # Port assignments for agent-to-agent communication
 AGENT_PORTS = {
     "agent_orchestrator": 10000,
+    "agent_one": 10000,  # One top personal agent / orchestration layer
     "agent_kai": 10005,  # Kai investment analysis agent
+    "agent_nav": 10006,  # Nav privacy and consent guardian
+    "agent_kyc": 10007,  # KYC identity workflow specialist
 }
 
 # ==================== Token & Link Prefixes ====================

--- a/consent-protocol/hushh_mcp/services/voice_action_manifest.py
+++ b/consent-protocol/hushh_mcp/services/voice_action_manifest.py
@@ -22,8 +22,11 @@ def _normalize_action_entry(raw: Any) -> dict[str, Any] | None:
     aliases_raw = raw.get("aliases")
     aliases = [str(item).strip() for item in aliases_raw or [] if str(item or "").strip()]
     speaker_persona = str(raw.get("speaker_persona") or "one").strip().lower()
-    if speaker_persona not in {"one", "kai", "nav"}:
+    if speaker_persona not in {"one", "kai", "nav", "kyc"}:
         speaker_persona = "one"
+    delegate_agent_id = str(raw.get("delegate_agent_id") or "").strip().lower() or None
+    if delegate_agent_id not in {None, "one", "kai", "nav", "kyc"}:
+        delegate_agent_id = None
     scope = (
         raw.get("reachability")
         if isinstance(raw.get("reachability"), dict)
@@ -65,6 +68,7 @@ def _normalize_action_entry(raw: Any) -> dict[str, Any] | None:
         "label": label,
         "meaning": meaning,
         "speaker_persona": speaker_persona,
+        "delegate_agent_id": delegate_agent_id,
         "aliases": aliases,
         "scope": {
             "screens": [

--- a/consent-protocol/hushh_mcp/services/voice_app_knowledge.py
+++ b/consent-protocol/hushh_mcp/services/voice_app_knowledge.py
@@ -888,16 +888,18 @@ _COMPAT_GLOBAL_CONCEPTS: dict[str, dict[str, Any]] = {
 }
 
 _KAI_VOICE_IDENTITY_CONTEXT: dict[str, Any] = {
-    "app_name": "Kai",
+    "app_name": "One",
     "assistant_role": "in_app_voice_interface",
     "role_summary": (
-        "Kai is the app. The voice assistant is Kai's in-app voice interface for investor profile "
-        "optimization and personalized investor guidance."
+        "One is the top personal agent and app-level relationship layer. Kai is the finance "
+        "specialist, Nav is the privacy and consent guardian, and KYC is the bounded identity "
+        "workflow specialist."
     ),
     "core_capabilities": [
-        "explain current Kai screens and visible controls",
-        "navigate inside Kai",
+        "explain current One and Kai screens and visible controls",
+        "navigate inside the app",
         "start approved in-app investor actions",
+        "hand off finance work to Kai, trust work to Nav, and identity workflow work to KYC",
         "use PKM context when policy and permissions allow it",
         "use connected Gmail receipt workflows when available",
     ],

--- a/consent-protocol/scripts/verify_adk_a2a_compliance.py
+++ b/consent-protocol/scripts/verify_adk_a2a_compliance.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Static compliance checks for Kai ADK and Google A2A contracts."""
+"""Static compliance checks for ADK and Google A2A contracts."""
 
 from __future__ import annotations
 
@@ -31,9 +31,18 @@ def main() -> int:
             ROOT / "hushh_mcp/adk_bridge/kai_agent.py",
             [
                 r"X-Consent-Token",
-                r"validate_token\(consent_token,\s*ConsentScope\.VAULT_OWNER\)",
+                r"validate_a2a_consent_token\(\"agent_kai\",\s*consent_token\)",
                 r"orchestrate_debate_stream",
                 r"DebateEngine",
+            ],
+        ),
+        _check_patterns(
+            ROOT / "hushh_mcp/adk_bridge/delegation.py",
+            [
+                r"\"agent_one\":\s*ConsentScope\.AGENT_ONE_ORCHESTRATE",
+                r"\"agent_kai\":\s*ConsentScope\.AGENT_KAI_ANALYZE",
+                r"\"agent_nav\":\s*ConsentScope\.AGENT_NAV_REVIEW",
+                r"\"agent_kyc\":\s*ConsentScope\.AGENT_KYC_PROCESS",
             ],
         ),
         _check_patterns(

--- a/consent-protocol/tests/test_a2a_delegation_scopes.py
+++ b/consent-protocol/tests/test_a2a_delegation_scopes.py
@@ -1,0 +1,56 @@
+"""Contract tests for least-privilege A2A specialist scopes."""
+
+from __future__ import annotations
+
+import pytest
+
+from hushh_mcp.adk_bridge.delegation import (
+    SPECIALIST_A2A_SCOPE_MAP,
+    get_a2a_required_scope,
+    validate_a2a_consent_token,
+)
+from hushh_mcp.consent.token import issue_token
+from hushh_mcp.constants import ConsentScope
+
+
+def test_specialist_a2a_scope_map_uses_least_privilege_scopes() -> None:
+    assert SPECIALIST_A2A_SCOPE_MAP == {
+        "agent_one": ConsentScope.AGENT_ONE_ORCHESTRATE,
+        "agent_kai": ConsentScope.AGENT_KAI_ANALYZE,
+        "agent_nav": ConsentScope.AGENT_NAV_REVIEW,
+        "agent_kyc": ConsentScope.AGENT_KYC_PROCESS,
+    }
+    assert ConsentScope.VAULT_OWNER not in SPECIALIST_A2A_SCOPE_MAP.values()
+
+
+def test_get_a2a_required_scope_rejects_unknown_specialist() -> None:
+    with pytest.raises(ValueError, match="Unknown A2A specialist"):
+        get_a2a_required_scope("agent_unknown")
+
+
+def test_validate_a2a_consent_token_accepts_matching_scope() -> None:
+    token = issue_token(
+        "user_a2a",
+        "agent_one",
+        ConsentScope.AGENT_KYC_PROCESS,
+    )
+
+    validation = validate_a2a_consent_token("agent_kyc", token.token)
+
+    assert validation.ok is True
+    assert validation.user_id == "user_a2a"
+    assert validation.required_scope == ConsentScope.AGENT_KYC_PROCESS
+
+
+def test_validate_a2a_consent_token_rejects_wrong_specialist_scope() -> None:
+    token = issue_token(
+        "user_a2a",
+        "agent_one",
+        ConsentScope.AGENT_KAI_ANALYZE,
+    )
+
+    validation = validate_a2a_consent_token("agent_kyc", token.token)
+
+    assert validation.ok is False
+    assert validation.user_id is None
+    assert validation.required_scope == ConsentScope.AGENT_KYC_PROCESS

--- a/consent-protocol/tests/test_agent_manifests.py
+++ b/consent-protocol/tests/test_agent_manifests.py
@@ -15,6 +15,10 @@ import pytest
 
 from hushh_mcp.agents.kai.manifest import MANIFEST as KAI_MANIFEST
 from hushh_mcp.agents.kai.manifest import get_manifest as get_kai_manifest
+from hushh_mcp.agents.kyc.manifest import KYC_WORKFLOW_STATES
+from hushh_mcp.agents.kyc.manifest import MANIFEST as KYC_MANIFEST
+from hushh_mcp.agents.nav.manifest import MANIFEST as NAV_MANIFEST
+from hushh_mcp.agents.one.manifest import MANIFEST as ONE_MANIFEST
 from hushh_mcp.agents.orchestrator.manifest import manifest as ORCHESTRATOR_MANIFEST
 from hushh_mcp.constants import ConsentScope
 
@@ -181,6 +185,63 @@ class TestOrchestratorManifest:
         scopes = list(ORCHESTRATOR_MANIFEST["scopes"])
         assert len(scopes) == len(set(scopes))
 
+    def test_orchestrator_is_agent_one_with_legacy_alias(self) -> None:
+        assert ORCHESTRATOR_MANIFEST["id"] == "agent_one"
+        assert "agent_orchestrator" in ORCHESTRATOR_MANIFEST["legacy_ids"]
+        assert ORCHESTRATOR_MANIFEST["scopes"] == [ConsentScope.AGENT_ONE_ORCHESTRATE.value]
+
+
+# ---------------------------------------------------------------------------
+# One/Nav/KYC manifests
+# ---------------------------------------------------------------------------
+
+
+class TestOneNavKycManifests:
+    @pytest.mark.parametrize(
+        "manifest",
+        [ONE_MANIFEST, NAV_MANIFEST, KYC_MANIFEST],
+    )
+    def test_required_manifest_shape(self, manifest: dict) -> None:
+        for key in (
+            "agent_id",
+            "name",
+            "version",
+            "description",
+            "required_scopes",
+            "optional_scopes",
+            "capabilities",
+            "compliance",
+        ):
+            assert key in manifest, f"missing key: {key}"
+
+    @pytest.mark.parametrize(
+        "manifest",
+        [ONE_MANIFEST, NAV_MANIFEST, KYC_MANIFEST],
+    )
+    def test_manifest_scope_entries_are_consent_scopes(self, manifest: dict) -> None:
+        for scope in [*manifest["required_scopes"], *manifest["optional_scopes"]]:
+            assert isinstance(scope, ConsentScope)
+
+    def test_expected_agent_ids(self) -> None:
+        assert ONE_MANIFEST["agent_id"] == "agent_one"
+        assert NAV_MANIFEST["agent_id"] == "agent_nav"
+        assert KYC_MANIFEST["agent_id"] == "agent_kyc"
+
+    def test_one_delegates_to_kai_nav_kyc(self) -> None:
+        specialist_ids = {specialist["id"] for specialist in ONE_MANIFEST["specialists"]}
+        assert {"kai", "nav", "kyc"} <= specialist_ids
+
+    def test_kyc_workflow_states_are_canonical(self) -> None:
+        assert KYC_WORKFLOW_STATES == (
+            "needs_scope",
+            "needs_documents",
+            "drafting",
+            "waiting_on_user",
+            "waiting_on_counterparty",
+            "completed",
+            "blocked",
+        )
+
 
 # ---------------------------------------------------------------------------
 # Cross-manifest isolation: agent_ids do not collide
@@ -190,3 +251,4 @@ class TestOrchestratorManifest:
 class TestManifestIsolation:
     def test_kai_and_orchestrator_have_distinct_ids(self) -> None:
         assert KAI_MANIFEST["agent_id"] != ORCHESTRATOR_MANIFEST["id"]
+        assert KAI_MANIFEST["agent_id"] != ONE_MANIFEST["agent_id"]

--- a/consent-protocol/tests/test_granular_scopes.py
+++ b/consent-protocol/tests/test_granular_scopes.py
@@ -39,12 +39,16 @@ class TestStaticScopes:
         assert ConsentScope.PKM_WRITE.value == "pkm.write"
         assert ConsentScope.PKM_METADATA.value == "pkm.metadata"
 
-    def test_kai_agent_scopes(self):
-        """Test Kai agent operation scopes."""
+    def test_agent_scope_values(self):
+        """Test One/Kai/Nav/KYC agent operation scopes."""
+        assert ConsentScope.AGENT_ONE_ORCHESTRATE.value == "agent.one.orchestrate"
         assert ConsentScope.AGENT_KAI_ANALYZE.value == "agent.kai.analyze"
         assert ConsentScope.AGENT_KAI_DEBATE.value == "agent.kai.debate"
         assert ConsentScope.AGENT_KAI_INFER.value == "agent.kai.infer"
         assert ConsentScope.AGENT_KAI_CHAT.value == "agent.kai.chat"
+        assert ConsentScope.AGENT_NAV_REVIEW.value == "agent.nav.review"
+        assert ConsentScope.AGENT_KYC_PROCESS.value == "agent.kyc.process"
+        assert ConsentScope.AGENT_KYC_WRITEBACK.value == "agent.kyc.writeback"
 
     def test_external_data_scopes(self):
         """Test external data source scopes."""
@@ -80,9 +84,12 @@ class TestStaticScopes:
         """Test agent_scopes() returns correct scopes."""
         agent_scopes = ConsentScope.agent_scopes()
 
+        assert ConsentScope.AGENT_ONE_ORCHESTRATE in agent_scopes
         assert ConsentScope.AGENT_KAI_ANALYZE in agent_scopes
         assert ConsentScope.AGENT_KAI_CHAT in agent_scopes
         assert ConsentScope.AGENT_KAI_EXECUTE in agent_scopes
+        assert ConsentScope.AGENT_NAV_REVIEW in agent_scopes
+        assert ConsentScope.AGENT_KYC_PROCESS in agent_scopes
 
     def test_external_scopes(self):
         """Test external_scopes() returns correct scopes."""

--- a/consent-protocol/tests/test_scope_bundle_contract.py
+++ b/consent-protocol/tests/test_scope_bundle_contract.py
@@ -3,7 +3,7 @@
 These tests validate the structural and behavioral integrity of
 CANONICAL_BUNDLES so that adding or editing a bundle cannot silently
 break consent grant resolution. Every scope in every bundle must be a
-valid dynamic scope that the scope matching system recognizes.
+valid dynamic or static consent scope that the scope matching system recognizes.
 """
 
 from __future__ import annotations
@@ -20,6 +20,7 @@ from hushh_mcp.consent.scope_bundles import (
 )
 from hushh_mcp.consent.scope_generator import get_scope_generator
 from hushh_mcp.consent.scope_helpers import scope_matches
+from hushh_mcp.constants import ConsentScope
 
 # ---------------------------------------------------------------------------
 # Structural invariants
@@ -87,9 +88,9 @@ class TestBundleScopeMatching:
         "key,scope",
         [(k, s) for k, b in CANONICAL_BUNDLES.items() for s in b.scopes],
     )
-    def test_scope_is_dynamic(self, key: str, scope: str) -> None:
-        assert self.gen.is_dynamic_scope(scope), (
-            f"Bundle {key} has scope {scope} that is not a valid dynamic scope"
+    def test_scope_is_valid(self, key: str, scope: str) -> None:
+        assert self.gen.is_dynamic_scope(scope) or ConsentScope.validate(scope), (
+            f"Bundle {key} has scope {scope} that is not a valid consent scope"
         )
 
     @pytest.mark.parametrize(

--- a/consent-protocol/tests/test_scope_helpers_dynamic.py
+++ b/consent-protocol/tests/test_scope_helpers_dynamic.py
@@ -2,7 +2,12 @@
 
 import pytest
 
-from hushh_mcp.consent.scope_helpers import normalize_scope, resolve_scope_to_enum, scope_matches
+from hushh_mcp.consent.scope_helpers import (
+    is_write_scope,
+    normalize_scope,
+    resolve_scope_to_enum,
+    scope_matches,
+)
 from hushh_mcp.constants import ConsentScope
 
 
@@ -34,6 +39,13 @@ def test_resolve_scope_to_enum_agent_kai_execute_scope():
     assert resolve_scope_to_enum("agent.kai.execute") == ConsentScope.AGENT_KAI_EXECUTE
 
 
+def test_resolve_scope_to_enum_one_nav_kyc_agent_scopes():
+    assert resolve_scope_to_enum("agent.one.orchestrate") == ConsentScope.AGENT_ONE_ORCHESTRATE
+    assert resolve_scope_to_enum("agent.nav.review") == ConsentScope.AGENT_NAV_REVIEW
+    assert resolve_scope_to_enum("agent.kyc.process") == ConsentScope.AGENT_KYC_PROCESS
+    assert resolve_scope_to_enum("agent.kyc.writeback") == ConsentScope.AGENT_KYC_WRITEBACK
+
+
 def test_resolve_scope_to_enum_unknown_agent_scope_is_rejected():
     with pytest.raises(ValueError, match="Unknown agent scope"):
         resolve_scope_to_enum("agent.kai.unknown")
@@ -42,3 +54,8 @@ def test_resolve_scope_to_enum_unknown_agent_scope_is_rejected():
 def test_resolve_scope_to_enum_unknown_static_scope_is_rejected():
     with pytest.raises(ValueError, match="Unknown scope"):
         resolve_scope_to_enum("custom.temporary")
+
+
+def test_kyc_writeback_is_write_scope():
+    assert is_write_scope("agent.kyc.writeback") is True
+    assert is_write_scope("agent.kyc.process") is False

--- a/contracts/kai/kai-action-gateway.vnext.json
+++ b/contracts/kai/kai-action-gateway.vnext.json
@@ -178,6 +178,7 @@
       ],
       "meaning": "Navigates directly to the Kai analysis workspace and history route.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/kai/analysis"
@@ -237,6 +238,7 @@
       ],
       "meaning": "Navigates to analysis page history context.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/kai/analysis",
@@ -299,6 +301,7 @@
       ],
       "meaning": "Creates fresh analysis intent and opens the debate workspace.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/kai/analysis"
@@ -363,6 +366,7 @@
       ],
       "meaning": "Attaches to currently running debate task and opens focused analysis route.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/kai/analysis",
@@ -430,6 +434,7 @@
       ],
       "meaning": "Cancels running debate task and returns to history view.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/kai/analysis"
@@ -496,6 +501,7 @@
       ],
       "meaning": "Legacy tab token accepted by parser but no transcript tab is rendered in current analysis UI.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/kai/analysis?tab=transcript"
@@ -557,6 +563,7 @@
       ],
       "meaning": "Navigates to profile landing route.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile"
@@ -619,6 +626,7 @@
       ],
       "meaning": "Navigates to hidden Gmail detail panel in Profile > Account.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile?panel=gmail"
@@ -681,6 +689,7 @@
       ],
       "meaning": "Navigates to hidden support panel in Profile > Account.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile?tab=account&panel=support"
@@ -744,6 +753,7 @@
       ],
       "meaning": "Navigates to hidden security panel in Profile > Privacy.",
       "speaker_persona": "nav",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile?tab=privacy&panel=security"
@@ -807,6 +817,7 @@
       ],
       "meaning": "Navigates to the PKM Agent Lab privacy workspace.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile/pkm-agent-lab"
@@ -869,6 +880,7 @@
       ],
       "meaning": "Sends support/bug/developer feedback email via support service.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile?tab=account&panel=support"
@@ -935,6 +947,7 @@
       ],
       "meaning": "Opts investor persona in/out of RIA marketplace discoverability.",
       "speaker_persona": "nav",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile?tab=privacy"
@@ -998,6 +1011,7 @@
       ],
       "meaning": "Ends current session and redirects to home route.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile"
@@ -1059,6 +1073,7 @@
       ],
       "meaning": "Deletes investor/ria persona or full account depending on selected target.",
       "speaker_persona": "nav",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile"
@@ -1124,6 +1139,7 @@
       ],
       "meaning": "Builds the current PKM Agent Lab capture preview without saving it.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile/pkm-agent-lab"
@@ -1188,6 +1204,7 @@
       ],
       "meaning": "Persists the current PKM Agent Lab capture into encrypted PKM storage.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile/pkm-agent-lab"
@@ -1255,6 +1272,7 @@
       ],
       "meaning": "Navigates directly to receipts page from any investor surface.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile/receipts"
@@ -1326,6 +1344,7 @@
       ],
       "meaning": "Starts OAuth flow for Gmail receipts connector.",
       "speaker_persona": "nav",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile",
@@ -1396,6 +1415,7 @@
       ],
       "meaning": "Queues and polls Gmail receipt sync run.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile/receipts",
@@ -1472,6 +1492,7 @@
       ],
       "meaning": "Builds the receipts-to-PKM preview from stored Gmail receipts.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile/receipts"
@@ -1538,6 +1559,7 @@
       ],
       "meaning": "Persists the current receipts-memory preview into shopping.receipts_memory.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile/receipts"
@@ -1604,6 +1626,7 @@
       ],
       "meaning": "Disconnects Gmail OAuth credentials for future syncs.",
       "speaker_persona": "nav",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile?panel=gmail"
@@ -1672,6 +1695,7 @@
       ],
       "meaning": "Navigates to the RIA workspace home route.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/ria"
@@ -1765,6 +1789,7 @@
       ],
       "meaning": "Navigates to consents route.",
       "speaker_persona": "nav",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/consents"
@@ -1824,6 +1849,7 @@
       ],
       "meaning": "Navigates back to the previous Kai or profile surface in browser history.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/kai",
@@ -1893,6 +1919,7 @@
       ],
       "meaning": "Navigates to portfolio dashboard for source/holdings context.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/kai/portfolio"
@@ -1952,6 +1979,7 @@
       ],
       "meaning": "Navigates to import flow for statement upload / portfolio bootstrap.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/kai/import"
@@ -2012,6 +2040,7 @@
       ],
       "meaning": "Navigates to investments workspace from hidden or non-visible surface.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/kai/investments"
@@ -2077,6 +2106,7 @@
       ],
       "meaning": "Navigates to optimize workspace route directly.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/kai/optimize"
@@ -2142,6 +2172,7 @@
       ],
       "meaning": "Navigates to the Investor Kai market home surface.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/kai",

--- a/contracts/kai/voice-action-manifest.v1.json
+++ b/contracts/kai/voice-action-manifest.v1.json
@@ -8,6 +8,7 @@
       "label": "Open Analysis Surface",
       "meaning": "Navigates directly to the Kai analysis workspace and history route.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "aliases": [
         "open analysis",
         "go to analysis"
@@ -40,6 +41,7 @@
       "label": "Open Analysis History",
       "meaning": "Navigates to analysis page history context.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "aliases": [
         "open analysis history",
         "show past analysis"
@@ -73,6 +75,7 @@
       "label": "Start Stock Analysis",
       "meaning": "Creates fresh analysis intent and opens the debate workspace.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "aliases": [
         "analyze stock",
         "start stock analysis",
@@ -111,6 +114,7 @@
       "label": "Resume Active Analysis Run",
       "meaning": "Attaches to currently running debate task and opens focused analysis route.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "aliases": [
         "resume analysis",
         "open active analysis"
@@ -149,6 +153,7 @@
       "label": "Cancel Active Analysis Run",
       "meaning": "Cancels running debate task and returns to history view.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "aliases": [
         "cancel analysis",
         "stop analysis"
@@ -187,6 +192,7 @@
       "label": "Legacy Transcript Tab Route",
       "meaning": "Legacy tab token accepted by parser but no transcript tab is rendered in current analysis UI.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "aliases": [
         "open transcript tab",
         "show transcript tab"
@@ -221,6 +227,7 @@
       "label": "Open Profile",
       "meaning": "Navigates to profile landing route.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "aliases": [
         "open profile",
         "go to profile"
@@ -255,6 +262,7 @@
       "label": "Open Gmail Connector Panel",
       "meaning": "Navigates to hidden Gmail detail panel in Profile > Account.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "aliases": [
         "open gmail settings",
         "open gmail panel"
@@ -290,6 +298,7 @@
       "label": "Open Support Panel",
       "meaning": "Navigates to hidden support panel in Profile > Account.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "aliases": [
         "open support",
         "contact support"
@@ -325,6 +334,7 @@
       "label": "Open Vault Security Panel",
       "meaning": "Navigates to hidden security panel in Profile > Privacy.",
       "speaker_persona": "nav",
+      "delegate_agent_id": null,
       "aliases": [
         "open security",
         "vault security"
@@ -360,6 +370,7 @@
       "label": "Open PKM Agent Lab",
       "meaning": "Navigates to the PKM Agent Lab privacy workspace.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "aliases": [
         "open pkm lab",
         "open memory lab"
@@ -394,6 +405,7 @@
       "label": "Submit Support Message",
       "meaning": "Sends support/bug/developer feedback email via support service.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "aliases": [
         "send support message",
         "submit support message"
@@ -428,6 +440,7 @@
       "label": "Toggle Marketplace Visibility",
       "meaning": "Opts investor persona in/out of RIA marketplace discoverability.",
       "speaker_persona": "nav",
+      "delegate_agent_id": null,
       "aliases": [
         "toggle marketplace visibility",
         "change marketplace visibility"
@@ -463,6 +476,7 @@
       "label": "Sign Out",
       "meaning": "Ends current session and redirects to home route.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "aliases": [
         "sign out",
         "log out"
@@ -497,6 +511,7 @@
       "label": "Delete Account",
       "meaning": "Deletes investor/ria persona or full account depending on selected target.",
       "speaker_persona": "nav",
+      "delegate_agent_id": null,
       "aliases": [
         "delete my account",
         "remove account"
@@ -534,6 +549,7 @@
       "label": "Generate PKM capture preview",
       "meaning": "Builds the current PKM Agent Lab capture preview without saving it.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "aliases": [
         "preview pkm capture",
         "generate pkm preview"
@@ -568,6 +584,7 @@
       "label": "Save PKM capture",
       "meaning": "Persists the current PKM Agent Lab capture into encrypted PKM storage.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "aliases": [
         "save pkm capture",
         "save memory capture"
@@ -605,6 +622,7 @@
       "label": "Open Receipts Page",
       "meaning": "Navigates directly to receipts page from any investor surface.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "aliases": [
         "open receipts",
         "open gmail receipts"
@@ -639,6 +657,7 @@
       "label": "Connect Gmail",
       "meaning": "Starts OAuth flow for Gmail receipts connector.",
       "speaker_persona": "nav",
+      "delegate_agent_id": null,
       "aliases": [
         "connect gmail",
         "link gmail"
@@ -674,6 +693,7 @@
       "label": "Sync Gmail Receipts Now",
       "meaning": "Queues and polls Gmail receipt sync run.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "aliases": [
         "sync gmail receipts",
         "refresh gmail receipts"
@@ -711,6 +731,7 @@
       "label": "Build receipts memory preview",
       "meaning": "Builds the receipts-to-PKM preview from stored Gmail receipts.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "aliases": [
         "preview receipts memory",
         "generate receipts memory preview"
@@ -743,6 +764,7 @@
       "label": "Save receipts memory to PKM",
       "meaning": "Persists the current receipts-memory preview into shopping.receipts_memory.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "aliases": [
         "save receipts memory",
         "save receipts to memory"
@@ -780,6 +802,7 @@
       "label": "Disconnect Gmail",
       "meaning": "Disconnects Gmail OAuth credentials for future syncs.",
       "speaker_persona": "nav",
+      "delegate_agent_id": null,
       "aliases": [
         "disconnect gmail",
         "unlink gmail"
@@ -815,6 +838,7 @@
       "label": "Open RIA Home",
       "meaning": "Navigates to the RIA workspace home route.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "aliases": [
         "open ria workspace",
         "go to ria home"
@@ -852,6 +876,7 @@
       "label": "Open Consent Center",
       "meaning": "Navigates to consents route.",
       "speaker_persona": "nav",
+      "delegate_agent_id": null,
       "aliases": [
         "open consent center",
         "open consents"
@@ -884,6 +909,7 @@
       "label": "Go Back",
       "meaning": "Navigates back to the previous Kai or profile surface in browser history.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "aliases": [
         "go back",
         "back"
@@ -923,6 +949,7 @@
       "label": "Open Portfolio Dashboard",
       "meaning": "Navigates to portfolio dashboard for source/holdings context.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "aliases": [
         "open portfolio dashboard",
         "open portfolio",
@@ -956,6 +983,7 @@
       "label": "Open Portfolio Import",
       "meaning": "Navigates to import flow for statement upload / portfolio bootstrap.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "aliases": [
         "import portfolio",
         "open import"
@@ -988,6 +1016,7 @@
       "label": "Open Investments Surface",
       "meaning": "Navigates to investments workspace from hidden or non-visible surface.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "aliases": [
         "open investments",
         "show investments"
@@ -1024,6 +1053,7 @@
       "label": "Open Optimize Surface",
       "meaning": "Navigates to optimize workspace route directly.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "aliases": [
         "optimize portfolio",
         "open optimize"
@@ -1058,6 +1088,7 @@
       "label": "Open Market Home",
       "meaning": "Navigates to the Investor Kai market home surface.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "aliases": [
         "open kai home",
         "open market home",

--- a/docs/future/README.md
+++ b/docs/future/README.md
@@ -8,7 +8,7 @@
 flowchart TD
   root["docs/future/<br/>planning-only roadmap home"]
   kai["kai/<br/>assistant and workflow concepts"]
-  oneNav["one-nav-runtime-plan.md<br/>One/Nav runtime migration"]
+  oneNav["one-nav-runtime-plan.md<br/>One/Kai/Nav/KYC runtime migration"]
   execution["promotion to execution docs<br/>only after approval"]
 
   root --> kai
@@ -56,8 +56,8 @@ Promotion targets:
 
 ## Current Domains
 
-- [kai/README.md](./kai/README.md): Kai future-state concepts and delegated workflow planning
-- [one-nav-runtime-plan.md](./one-nav-runtime-plan.md): planning-only migration path from the current Kai-first runtime to the One/Kai/Nav ontology
+- [kai/README.md](./kai/README.md): Kai future-state concepts and superseded planning history that has not yet moved
+- [one-nav-runtime-plan.md](./one-nav-runtime-plan.md): planning-only migration path from the current Kai-first runtime to the One/Kai/Nav/KYC ontology
 
 ## References
 

--- a/docs/future/kai/README.md
+++ b/docs/future/kai/README.md
@@ -7,7 +7,7 @@
 ```mermaid
 flowchart TD
   root["docs/future/kai/<br/>Kai future roadmap"]
-  email["Email / KYC / PKM assistant"]
+  email["Superseded Email / KYC / PKM concept"]
 
   root --> email
 ```
@@ -24,7 +24,9 @@ Kai north stars stay in [../../vision/kai/README.md](../../vision/kai/README.md)
 
 ## Current Concepts
 
-- [email-kyc-pkm-assistant.md](./email-kyc-pkm-assistant.md): Kai-owned delegated email/KYC assistant with PKM-aware structured writeback and scoped consent
+- [email-kyc-pkm-assistant.md](./email-kyc-pkm-assistant.md): superseded planning history for email/KYC structured writeback. KYC is now owned by the One-led multi-agent roadmap, not by Kai.
+
+Current One/Kai/Nav/KYC ownership lives in [../one-nav-runtime-plan.md](../one-nav-runtime-plan.md).
 
 ## Promotion Rule
 

--- a/docs/future/kai/email-kyc-pkm-assistant.md
+++ b/docs/future/kai/email-kyc-pkm-assistant.md
@@ -1,4 +1,4 @@
-# Kai Email / KYC / PKM Assistant
+# One-Led Email / KYC / PKM Specialist
 
 ## Status
 
@@ -8,15 +8,17 @@
 
 ## Visual Context
 
-Canonical visual owner: [Kai Future Roadmap](./README.md). Use that map for the planning hierarchy; this page is the narrower concept note beneath it.
+Canonical visual owner: [Vision Index](../../vision/README.md), with the detailed planning map in [One/Kai/Nav/KYC Runtime Plan](../one-nav-runtime-plan.md). This page supersedes the previous Kai-owned KYC framing and remains here only as planning history until it is moved into a One/KYC future home.
 
 ## Summary
 
-This concept keeps Kai as the primary assistant and adds a Kai-owned delegated email/KYC specialist that can execute narrow workflow tasks after on-demand scoped consent.
+This concept makes One the user-facing orchestrator and adds KYC as a delegated identity/workflow specialist that can execute narrow email-backed KYC tasks after on-demand scoped consent.
 
 The goal is not a generic email bot or a public inbox-first workflow. The goal is a trust-bound workflow component that fits Hussh's existing architecture:
 
-- Kai remains the user-facing orchestrator
+- One remains the user-facing relationship layer and orchestrator
+- Nav owns consent and trust review when the workflow needs additional scope
+- KYC owns identity/KYC workflow execution inside the granted scope
 - PKM remains the durable personal memory layer
 - Consent Protocol remains the authority layer
 - delegated runtime state stays task-local and minimal
@@ -28,8 +30,8 @@ This concept aligns with existing Hussh north stars when it keeps these invarian
 1. consent-first access
 2. BYOK and zero-knowledge boundaries
 3. PKM as durable personal memory
-4. Kai as the assistant the user trusts directly
-5. delegated agents operating only inside explicit authority boundaries
+4. One as the personal agent the user trusts directly
+5. Kai, Nav, and KYC operating as delegated specialists inside explicit authority boundaries
 
 ## Current-State Overlap
 
@@ -38,29 +40,29 @@ What already exists in the repo today:
 - PKM as the durable personal-memory model
 - Consent Protocol for scoped access and audit
 - ADK-backed agent orchestration surfaces in the backend
-- Kai as the user-facing assistant identity
+- One/Kai/Nav ontology in `docs/vision/agent-ontology.md`
 - connector-aware runtime patterns for delegated actions
 - authenticated support and feedback delivery routed through the existing Gmail-backed support transport
 
 What does not yet exist as a first-class product/runtime contract:
 
-- a Kai-owned email/KYC delegated sub-agent contract
+- a One-owned email/KYC delegated specialist contract
 - workflow-specific on-demand consent metadata for this task family
 - a canonical runtime-memory/writeback split for delegated email/KYC workflows
 - explicit user-facing trust-state UX for this workflow family
-- an approved `kai@hushh.ai` runtime contract for public inbound email
+- an approved `one@hushh.ai` runtime contract for public inbound KYC email
 
 ## Future Concept
 
 The future-state model is:
 
-1. the user asks Kai to handle a scheduling or KYC email workflow
-2. Kai determines that email-backed delegated execution is needed
-3. Kai requests narrow, on-demand consent with task metadata
-4. Kai delegates the task to a Kai-owned specialist through an A2A-style boundary
+1. the user asks One to handle a scheduling or KYC email workflow
+2. One determines that email-backed delegated execution is needed
+3. One asks Nav to frame narrow, on-demand consent with task metadata when new scope is required
+4. One delegates the task to the KYC specialist through an A2A-style boundary
 5. the specialist executes only within the granted scope
 6. only structured facts write back into PKM
-7. Kai stays the visible orchestrator for status, approvals, and outcome
+7. One stays the visible relationship layer for status, approvals, and outcome
 
 ## Exemplar Workflows
 
@@ -105,12 +107,15 @@ Before execution, this concept likely needs:
 4. trust-state UX contract for waiting, approval, and completion
 5. promotion of connector boundaries from concept to execution-owned docs
 6. a transport-sharing rule that allows reuse of support/email queue primitives without inheriting the support trust model
+7. `agent.kyc.*` scopes, a KYC agent manifest, and a One-to-KYC delegation contract
+8. `one@hushh.ai` mailbox/delegated-sender ownership before public inbound rollout
 
 ## Edge and Risk Assessment
 
 ### Trust and authority
 
 - a delegated specialist must not become a separate uncontrolled trust domain
+- KYC must not become a second top-level personal agent; One owns the relationship layer
 - send authority must stay workflow-specific and legible
 - final authority boundaries need to distinguish low-risk coordination from sensitive KYC actions
 
@@ -150,7 +155,7 @@ This concept does not assume:
 - raw email threads as permanent PKM memory by default
 - immediate implementation of a durable workflow engine
 - bypassing consent or trust-state UX in the name of speed
-- approval of a live public `kai@hushh.ai` inbound webhook before the trust and rollout contract is explicitly owned
+- approval of a live public `one@hushh.ai` inbound webhook before the trust and rollout contract is explicitly owned
 
 ## Promotion Readiness Checklist
 
@@ -162,6 +167,7 @@ Do not promote this concept into execution docs until these are explicit:
 4. runtime-state contract
 5. user-facing trust-state UX
 6. approval policy for outbound actions
+7. One/Nav/KYC prompt, speaker, and delegated-agent contracts
 
 ## Recommended Execution Split
 

--- a/docs/future/one-nav-runtime-plan.md
+++ b/docs/future/one-nav-runtime-plan.md
@@ -1,4 +1,4 @@
-# One/Nav Runtime Plan
+# One/Kai/Nav/KYC Runtime Plan
 
 Status: planning-only roadmap. This is not a current-state implementation contract.
 
@@ -10,52 +10,62 @@ flowchart TB
   one["One layer<br/>default speaker + memory relationship"]
   kai["Kai specialist<br/>finance actions"]
   nav["Nav specialist<br/>privacy + consent actions"]
+  kyc["KYC specialist<br/>identity + workflow actions"]
   gates["Promotion gates<br/>contracts, tests, copy, rollout"]
 
   current --> one
   one --> kai
   one --> nav
+  one --> kyc
   one --> gates
 ```
 
 ## Current Overlap
 
-The current app already has pieces the One/Nav model can reuse:
+The current app already has pieces the One/Kai/Nav/KYC model can reuse:
 
 - a generated voice/action gateway from local `.voice-action-contract.json` files
 - route, persona, vault, auth, consent, and onboarding guards
 - encrypted, vault-gated durable voice memory
 - consent center, profile security, deletion, and scoped-access surfaces
 - Kai finance routes, analysis actions, search grounding, and command execution
+- PKM writeback patterns that can become the structured memory layer for KYC outcomes
 
 The gap is not capability existence. The gap is ownership clarity: the live runtime still defaults to Kai as the assistant identity in many places, while the product direction makes One the top relationship layer and Nav the privacy guardian.
 
+KYC is the first planned specialist added to this roadmap after Kai and Nav. KYC is not a second top-level application identity. One owns the user relationship, Nav owns consent and trust review, and KYC owns bounded identity/KYC workflows.
+
 ## Missing Primitives
 
-Before One/Nav becomes current-state runtime, the repo needs these primitives:
+Before One/Kai/Nav/KYC becomes current-state runtime, the repo needs these primitives:
 
 1. `speaker_persona` carried from local action contracts through the generated gateway, manifest, frontend registry, backend prompt selection, and composer path.
-2. Prompt identity templates for `one`, `kai`, and `nav`.
-3. TTS instruction selection for the active speaker persona.
-4. Shell copy ownership rules for greetings, notifications, memory, consent, and specialist handoffs.
-5. Nav-owned action inventory for consent, vault, deletion, revocation, and scope review.
-6. Analytics/event fields that distinguish workspace persona from speaking agent.
-7. Verification that `nav.*` means Nav guardian capability, while `route.*` means navigation.
-8. One-owned memory portability, export, and retention contracts that separate relationship memory from Kai finance memory and Nav trust memory.
-9. BYO AI / BYO model policy that distinguishes user-held keys from provider routing, model availability, and local-device capability.
-10. Action-receipt privacy rules that define which receipts are encrypted for the user, which audit rows are visible to platform services, and which metadata remains operationally necessary.
+2. `delegate_agent_id` carried where a user-facing action is executed by a specialist instead of the top One layer.
+3. Prompt identity templates for `one`, `kai`, `nav`, and `kyc`.
+4. TTS instruction selection for the active speaker persona.
+5. Shell copy ownership rules for greetings, notifications, memory, consent, and specialist handoffs.
+6. Nav-owned action inventory for consent, vault, deletion, revocation, and scope review.
+7. KYC-owned action inventory for identity/KYC requests, missing-document review, approval-gated drafts, and structured PKM writeback.
+8. Analytics/event fields that distinguish workspace persona, speaking persona, and delegated specialist.
+9. Verification that `nav.*` means Nav guardian capability, while `route.*` means navigation.
+10. One-owned memory portability, export, and retention contracts that separate relationship memory from Kai finance memory and Nav trust memory.
+11. KYC memory/writeback rules that allow structured facts and workflow artifacts without raw email-thread persistence.
+12. BYO AI / BYO model policy that distinguishes user-held keys from provider routing, model availability, and local-device capability.
+13. Action-receipt privacy rules that define which receipts are encrypted for the user, which audit rows are visible to platform services, and which metadata remains operationally necessary.
 
 ## Promotion Criteria
 
 Move this plan into execution docs only when:
 
 - every generated action has a valid `speaker_persona`
+- delegated specialist actions have a valid `delegate_agent_id`
 - `rg "nav\\." contracts/kai hushh-webapp consent-protocol docs .codex` finds only true Nav guardian actions or roadmap prose
-- voice planner/composer prompts can select One, Kai, or Nav without weakening existing English-only, vault, consent, or rollout controls
-- shell and design-system docs define which copy surfaces belong to One, Kai, and Nav
-- tests cover route actions, finance actions, and privacy/consent actions with the correct speaker persona
+- voice planner/composer prompts can select One, Kai, Nav, or KYC without weakening existing English-only, vault, consent, or rollout controls
+- shell and design-system docs define which copy surfaces belong to One, Kai, Nav, and KYC
+- tests cover route actions, finance actions, privacy/consent actions, and KYC workflow actions with the correct speaker persona and delegated specialist
 - UAT can prove that finance workflows still execute through Kai while consent/privacy workflows are framed by Nav
-- PKM docs can truthfully describe One-owned relationship memory, Kai finance memory, and Nav privacy memory without contradicting the checked-in storage and unlock path
+- UAT can prove that KYC workflows are framed by One, scope-reviewed by Nav when needed, and executed by KYC only inside a bounded consent grant
+- PKM docs can truthfully describe One-owned relationship memory, Kai finance memory, Nav privacy memory, and KYC workflow artifacts without contradicting the checked-in storage and unlock path
 - claims such as on-device memory, no platform-controlled backdoor recovery, portable One memory export, BYO model execution, and user-private action receipts are backed by implementation references and tests
 
 ## Founder Claims Held Here Until Shipped
@@ -68,29 +78,31 @@ The founder drafts are directionally important, but the following claims remain 
 | There is no platform-controlled recovery path | Vault/key-management docs and recovery UX prove the exact no-backdoor model |
 | Users can bring any model or key | Provider routing, key storage, local execution, and failure-mode docs prove BYO AI behavior |
 | Every action leaves a receipt only the user can read | Receipt schema, encryption boundary, audit visibility, and support/debug metadata rules are documented and tested |
-| One can act across messages, calendar, accounts, finance, and consent | Route/action contracts and consent scopes exist for those domains |
+| One can act across messages, calendar, accounts, finance, KYC, and consent | Route/action contracts, delegated specialists, and consent scopes exist for those domains |
 
 ## Phases
 
 ### Phase 1: Contract Hygiene
 
 - Rename navigation action ids from `nav.*` to `route.*`.
-- Add `speaker_persona` to local contracts and generated outputs.
+- Add `speaker_persona` and `delegate_agent_id` to local contracts and generated outputs.
 - Reserve `nav.*` for true Nav guardian actions.
+- Reserve KYC execution for `kyc.*` workflow actions or explicit `delegate_agent_id: "kyc"`.
 - Update docs, skills, tests, and audits in the same change.
 
 ### Phase 2: Prompt And Speech Selection
 
-- Add One/Kai/Nav prompt identity templates.
+- Add One/Kai/Nav/KYC prompt identity templates.
 - Route planner/composer speech through `speaker_persona`.
 - Keep English-only STT/planner/composer/TTS constraints unchanged.
-- Do not change trust or execution authority based on speaker persona.
+- Do not change trust or execution authority based on speaker persona; authority comes from consent, vault, persona, workspace, and delegated-agent policy.
 
 ### Phase 3: Shell And Copy Migration
 
 - Move greetings, notifications, memory recall, and generic help toward One.
 - Move consent review, scope review, deletion, revocation, vault, and suspicious-access copy toward Nav.
 - Keep finance analysis, market, portfolio, and RIA finance decisions with Kai.
+- Move KYC status, missing-document review, and approval-gated draft language toward KYC only on explicit KYC workflow surfaces; One frames and closes the handoff.
 
 ### Phase 4: Nav Capability Inventory
 
@@ -98,11 +110,18 @@ The founder drafts are directionally important, but the following claims remain 
 - Keep route actions as `route.*`.
 - Add tests proving Nav actions are not just renamed navigation actions.
 
-### Phase 5: UAT Promotion
+### Phase 5: KYC Capability Inventory
+
+- Add KYC actions for identity/KYC request intake, missing-document status, draft generation, and structured PKM writeback.
+- Use `one@hushh.ai` as the planned inbound identity only after mailbox, delegated sender, consent, and rollout ownership are approved.
+- Default outbound KYC messages to user approval before send.
+- Add tests proving KYC cannot read or write outside its workflow consent.
+
+### Phase 6: UAT Promotion
 
 - Run focused voice, docs, typecheck, and backend voice suites.
-- Run UAT smoke for finance, consent, vault, deletion, and notification flows.
-- Promote only after current-state docs can describe One/Nav without future-state caveats.
+- Run UAT smoke for finance, consent, vault, deletion, notification, and KYC workflow flows.
+- Promote only after current-state docs can describe One/Kai/Nav/KYC without future-state caveats.
 
 ## Risks
 
@@ -110,7 +129,8 @@ The founder drafts are directionally important, but the following claims remain 
 | --- | --- |
 | Kai identity bleeds into generic assistant copy | Design-system copy ownership rules and voice prompt speaker selection |
 | Nav becomes a branding label for navigation | Reserve `nav.*` for privacy/consent guardian actions; use `route.*` for navigation |
-| One/Nav copy overclaims shipped runtime | Docs governance requires current-state versus future-state wording |
+| KYC becomes an uncontrolled email agent | Keep One as relationship owner, Nav as consent reviewer, KYC as bounded workflow specialist, and outbound send approval-gated |
+| One/Kai/Nav/KYC copy overclaims shipped runtime | Docs governance requires current-state versus future-state wording |
 | Personality work weakens trust controls | Speaker persona never changes guards, tokens, vault policy, or consent enforcement |
 | Duplicate action paths appear during migration | Straight rename only; no legacy alias, no dual-write, no compatibility acceptance path |
 | BYO AI language implies unsupported providers or local inference | Provider/model claims stay future-state until backed by runtime config, docs, and tests |
@@ -124,6 +144,7 @@ Contract hygiene:
 cd hushh-webapp && npm run build:voice-gateway
 cd hushh-webapp && npm run verify:voice-gateway
 rg "nav\\." contracts/kai hushh-webapp consent-protocol docs .codex
+rg "delegate_agent_id" contracts/kai hushh-webapp consent-protocol docs .codex
 ```
 
 Runtime proof:
@@ -145,7 +166,8 @@ python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py
 
 ## Out Of Scope
 
-- No production claim that One/Nav is fully shipped before the runtime proves it.
+- No production claim that One/Kai/Nav/KYC is fully shipped before the runtime proves it.
 - No callable alias path for previous route-navigation `nav.*` action ids.
 - No celebrity voice references in canonical docs.
 - No personal numeric preference in canonical docs.
+- No live public `one@hushh.ai` inbound KYC workflow until mailbox, delegated sender, consent, and rollout ownership are approved.

--- a/docs/reference/kai/kai-action-gateway-vnext.md
+++ b/docs/reference/kai/kai-action-gateway-vnext.md
@@ -130,6 +130,7 @@ Required action fields:
 
 Optional but recommended action fields:
 
+- `delegate_agent_id`
 - `state_exposure`
 - `docs_references`
 - `expected_effects`
@@ -144,14 +145,18 @@ Each action declares `speaker_persona`:
 | `one` | One owns the spoken framing. Use for generic, route, shell, memory, notification, and handoff actions. |
 | `kai` | Kai owns the spoken framing. Use for finance, analysis, portfolio, market, and RIA finance actions. |
 | `nav` | Nav owns the spoken framing. Use for privacy, consent, vault, deletion, revocation, and scope-review actions. |
+| `kyc` | KYC owns the spoken framing. Use only for explicit KYC workflow status, missing-document review, approval-gated drafts, and structured writeback actions. |
 
 Speaker persona is presentation and prompt ownership only. It does not create authorization and must never bypass auth, vault, consent, persona, workspace, or rollout gates.
+
+`delegate_agent_id` is nullable and declares which specialist executes a user-facing action when One frames the handoff. Allowed values are `one`, `kai`, `nav`, and `kyc`.
 
 Action namespace rules:
 
 - `route.*` is the namespace for navigation and route changes.
 - `analysis.*` and `kai.*` remain finance/Kai specialist namespaces.
 - `nav.*` is reserved for true Nav privacy/consent guardian actions.
+- `kyc.*` is reserved for true KYC identity-workflow actions.
 - Do not add legacy aliases from old navigation `nav.*` ids. This migration is a straight rename.
 
 ## Multi-Step Workflow Model

--- a/docs/reference/kai/kai-architecture-specification-v1.md
+++ b/docs/reference/kai/kai-architecture-specification-v1.md
@@ -194,7 +194,8 @@ The current actionability model is contract-first:
 3. frontend and backend load that gateway through adapters
 4. voice, typed search, UI actionables, analytics, and docs share one stable `action_id`
 5. pure route navigation actions use `route.*`; `nav.*` is reserved for future Nav privacy/consent guardian actions
-6. generated actions carry `speaker_persona` with allowed values `one`, `kai`, and `nav`
+6. generated actions carry `speaker_persona` with allowed values `one`, `kai`, `nav`, and `kyc`
+7. delegated specialist actions may carry `delegate_agent_id` with allowed values `one`, `kai`, `nav`, and `kyc`
 
 Current runtime loop:
 
@@ -213,6 +214,7 @@ Important current constraints:
 - durable voice memory remains encrypted and vault-gated
 - persona, workspace, auth, consent, and onboarding guards remain central preconditions
 - `speaker_persona` describes who should own the spoken framing; it does not grant authority or bypass guards
+- `delegate_agent_id` describes which specialist executes delegated work; consent, vault, persona, workspace, and route guards still decide authority
 
 ## Brokerage, Portfolio, And Analysis Architecture
 

--- a/docs/reference/kai/kai-voice-assistant-architecture.md
+++ b/docs/reference/kai/kai-voice-assistant-architecture.md
@@ -47,11 +47,11 @@ Residual compatibility shims intentionally still present:
 
 This document was the implementation-ready architecture spec for the Kai in-app voice assistant. It is now retained as the migration/audit record behind the implemented runtime.
 
-Product correction applied throughout this spec:
+Historical product correction captured by this spec:
 
-- Kai is the app.
-- The voice assistant lives inside Kai.
-- The assistant must speak as Kai's in-app voice interface, not as a generic external chatbot.
+- This spec originally corrected the app from a generic assistant into a Kai-first in-app runtime.
+- The newer durable ontology is One as the top personal agent, with Kai as the finance specialist, Nav as the guardian, and KYC as the identity workflow specialist.
+- Treat this document as a migration/audit record when it conflicts with [../../vision/agent-ontology.md](../../vision/agent-ontology.md).
 
 ## Historical Pre-Phase-4 Audit Snapshot
 
@@ -67,7 +67,7 @@ The table below records the audit state that motivated the migration. It is not 
 | Backend response contract | Backend responses are normalized into `kind`, `message`, `speak`, `execution_allowed`, optional `tool_call`, and legacy hints. | [voice_intent_service.py](../../../consent-protocol/hushh_mcp/services/voice_intent_service.py), [voice.py](../../../consent-protocol/api/routes/kai/voice.py) | The new canonical contract must dual-write during migration without breaking existing clients. |
 | Deterministic fast paths | The backend resolves many intents without the LLM: screen explain, knowledge, status, some surface navigation, import/resume/cancel, and keyword navigation. | [voice_intent_service.py](../../../consent-protocol/hushh_mcp/services/voice_intent_service.py) | The target design should preserve deterministic fast paths for latency-sensitive turns. |
 | Existing app knowledge | Backend knowledge entries already define PKM, Gmail connector, receipt memory, consent center, and several surface concepts. | [voice_app_knowledge.py](../../../consent-protocol/hushh_mcp/services/voice_app_knowledge.py) | Extend this module for Kai app identity and assistant role instead of embedding one giant prompt string. |
-| Backend identity mismatch | A compat global concept still describes Kai as an in-app investor agent, which conflicts with the corrected product model that Kai is the app and the assistant lives inside it. | [voice_app_knowledge.py](../../../consent-protocol/hushh_mcp/services/voice_app_knowledge.py) | The identity layer must correct this language before broader prompt reuse. |
+| Backend identity mismatch | A compat global concept can drift from the One/Kai/Nav/KYC ontology. | [voice_app_knowledge.py](../../../consent-protocol/hushh_mcp/services/voice_app_knowledge.py) | The identity layer must keep One as the app-level relationship layer while preserving Kai as the finance specialist. |
 | Final speech timing | The frontend determines `finalText` before dispatch, then executes the action, then speaks the already chosen text. | [voice-turn-orchestrator.ts](../../../hushh-webapp/lib/voice/voice-turn-orchestrator.ts) | This is the primary reason speech can drift from real execution outcome. |
 | Grounded execution path | The frontend can execute grounded actions for both `execute` and `speak_only` planner responses. | [voice-response-executor.ts](../../../hushh-webapp/lib/voice/voice-response-executor.ts) | `speak_only` must stop being implicitly executable on the normal path. |
 | Transcript heuristics | The frontend can infer `actionId` directly from transcript patterns and prefer planner-grounded response actions only when available. | [voice-grounding.ts](../../../hushh-webapp/lib/voice/voice-grounding.ts) | Transcript heuristics should be demoted to explicit fallback mode only. |

--- a/docs/reference/kai/kai-voice-runtime-architecture.md
+++ b/docs/reference/kai/kai-voice-runtime-architecture.md
@@ -297,11 +297,12 @@ Runtime consumption:
 
 The older [voice-action-manifest.v1.json](../../../contracts/kai/voice-action-manifest.v1.json) still exists, but it is now a generated compatibility artifact rather than the primary authored source.
 
-Generated actions include `speaker_persona`:
+Generated actions include `speaker_persona` and may include `delegate_agent_id`:
 
 - `one`: general, route, shell, memory, and handoff framing
 - `kai`: finance and analysis actions
 - `nav`: privacy, consent, vault, deletion, revocation, and scope-review actions
+- `kyc`: explicit identity/KYC workflow status, missing-document review, approval-gated draft, and structured writeback actions
 
 Navigation action ids use `route.*`. The `nav.*` namespace is reserved for true Nav guardian actions and must not be used for ordinary route changes.
 

--- a/docs/reference/quality/app-surface-design-system.md
+++ b/docs/reference/quality/app-surface-design-system.md
@@ -11,7 +11,7 @@ Profile remains the reference implementation for settings rows. This document ex
 
 ## Agent Copy Ownership
 
-The app uses the Hussh / One / Kai / Nav ontology from [../../vision/agent-ontology.md](../../vision/agent-ontology.md).
+The app uses the Hussh / One / Kai / Nav / KYC ontology from [../../vision/agent-ontology.md](../../vision/agent-ontology.md).
 
 Rules:
 
@@ -35,9 +35,15 @@ Rules:
    - deletion and revocation
    - suspicious-access or trust-state warnings
 5. Route navigation action ids use `route.*`. The `nav.*` namespace is reserved for true Nav guardian actions, not navigation.
-6. Local voice/action contracts must set `speaker_persona` to `one`, `kai`, or `nav` using the same ownership rules.
-7. Persona switching changes the workspace context. It does not change the top relationship agent; One stays the default shell voice.
-8. Canonical app copy uses neutral voice descriptors. Do not encode celebrity references or personal numeric preferences in maintained UI copy or docs.
+6. KYC owns explicit identity/KYC workflow copy:
+   - requirements and missing-document state
+   - approval-gated drafts
+   - workflow status
+   - structured PKM writeback summaries
+7. Local voice/action contracts must set `speaker_persona` to `one`, `kai`, `nav`, or `kyc` using the same ownership rules.
+8. Actions executed by a specialist on behalf of One should set `delegate_agent_id` to `kai`, `nav`, or `kyc`.
+9. Persona switching changes the workspace context. It does not change the top relationship agent; One stays the default shell voice.
+10. Canonical app copy uses neutral voice descriptors. Do not encode celebrity references or personal numeric preferences in maintained UI copy or docs.
 
 ## Shell Contract
 

--- a/docs/vision/agent-ontology.md
+++ b/docs/vision/agent-ontology.md
@@ -1,6 +1,6 @@
 # Hussh Agent Ontology
 
-Status: canonical durable ontology for Hussh, One, Kai, Nav, and future specialists.
+Status: canonical durable ontology for Hussh, One, Kai, Nav, KYC, and future specialists.
 
 ## Visual Map
 
@@ -10,11 +10,13 @@ flowchart TB
   one["One<br/>top personal agent"]
   kai["Kai<br/>finance specialist"]
   nav["Nav<br/>privacy and consent guardian"]
+  kyc["KYC<br/>identity workflow specialist"]
   future["Future specialists<br/>below One"]
 
   hussh --> one
   one --> kai
   one --> nav
+  one --> kyc
   one --> future
 ```
 
@@ -26,6 +28,7 @@ flowchart TB
 | One | Relationship layer, greeting, memory framing, shell notifications, cross-domain help, specialist handoffs | Deep finance judgment, privacy-policy enforcement, or pretending to be every specialist |
 | Kai | Finance analysis, portfolio context, market intelligence, investment debate, RIA/investor finance workflows | Consent-policy authority, vault/deletion decisions, platform identity |
 | Nav | Consent review, scope grants, vault friction, deletion, suspicious access, privacy and trust explanations | Finance analysis, market judgment, general relationship memory |
+| KYC | Identity/KYC workflow requirements, missing-document state, approval-gated drafts, structured PKM writeback | Broad email autonomy, platform identity, finance judgment, consent-policy authority |
 
 Future specialists slot below One. Do not add a second top-level personal agent unless the product ontology itself changes.
 
@@ -48,7 +51,7 @@ The current checked-in runtime is still Kai-first. Kai voice, action grounding, 
 
 One and Nav are approved direction, not a claim that the current app already runs a full One/Nav runtime. Current-state docs must say this plainly when discussing implementation.
 
-Current memory wording must be equally precise: PKM is the checked-in encrypted memory architecture, and today it is described through Kai-first implementation docs. The durable direction is One-owned relationship memory with Kai finance memory as a specialist slice and Nav consent/privacy memory as a guardian slice.
+Current memory wording must be equally precise: PKM is the checked-in encrypted memory architecture, and today it is described through Kai-first implementation docs. The durable direction is One-owned relationship memory with Kai finance memory as a specialist slice, Nav consent/privacy memory as a guardian slice, and KYC workflow artifacts as structured identity-workflow writebacks.
 
 ## Tone And Copy Ownership
 
@@ -77,6 +80,13 @@ Nav speaks for:
 - deletion and revocation
 - suspicious access or trust-state warnings
 
+KYC speaks only on explicit KYC workflow surfaces for:
+
+- KYC requirements and missing-document state
+- approval-gated drafts
+- workflow status
+- structured PKM writeback summaries
+
 ## Trust Invariants
 
 The ontology changes no trust boundary:
@@ -84,7 +94,7 @@ The ontology changes no trust boundary:
 - BYOK remains the key boundary.
 - Zero-knowledge and ciphertext-at-rest claims must stay repo-backed.
 - Capability tokens, consent tokens, `VAULT_OWNER`, and scoped exports remain literal implementation labels where precision matters.
-- One, Kai, and Nav must operate inside consent, vault, persona, workspace, and route guards.
+- One, Kai, Nav, and KYC must operate inside consent, vault, persona, workspace, and route guards.
 
 If a copy or personality decision conflicts with a trust invariant, the trust invariant wins.
 
@@ -96,10 +106,10 @@ Approved pattern:
 
 1. One identifies the specialist need.
 2. One says the handoff plainly.
-3. Kai or Nav speaks only inside its owned domain.
+3. Kai, Nav, or KYC speaks only inside its owned domain.
 4. One returns only when the cross-domain or relationship layer needs closure.
 
-Do not blur ownership by letting Kai explain vault policy, letting Nav make finance recommendations, or making Hussh speak as a personal assistant.
+Do not blur ownership by letting Kai explain vault policy, letting Nav make finance recommendations, letting KYC become a broad email agent, or making Hussh speak as a personal assistant.
 
 ## Founder Copy Rules
 
@@ -109,6 +119,7 @@ Approved founder-facing rewrites:
 - `One listens, remembers, decides, and acts under consent.`
 - `Kai is the finance specialist One summons.`
 - `Nav is the privacy and consent guardian One summons.`
+- `KYC is the identity workflow specialist One summons.`
 - `Your agents. Yours to own.`
 
 Retired or stale wording:
@@ -132,6 +143,14 @@ Local `.voice-action-contract.json` actions declare `speaker_persona`:
 - `one` for general and route/navigation actions
 - `kai` for finance analysis actions
 - `nav` for privacy, consent, vault, deletion, and scope-review actions
+- `kyc` for explicit KYC workflow status, missing-document review, approval-gated draft, and structured writeback actions
+
+Delegated actions may also declare `delegate_agent_id` with one of:
+
+- `one`
+- `kai`
+- `nav`
+- `kyc`
 
 ## Public Voice Descriptor Rule
 
@@ -140,5 +159,6 @@ Canonical docs use neutral voice descriptors:
 - One: calm, present, attentive, quietly competent
 - Kai: warm, sourced, finance-specific
 - Nav: precise, protective, calm under pressure
+- KYC: crisp, process-aware, approval-conscious
 
 Do not encode celebrity references or personal numeric preferences into canonical docs.

--- a/hushh-webapp/__tests__/voice/kai-action-gateway.test.ts
+++ b/hushh-webapp/__tests__/voice/kai-action-gateway.test.ts
@@ -70,7 +70,14 @@ describe("kai-action-gateway", () => {
     expect(ids.every((id) => !id.startsWith(reservedNavPrefix))).toBe(true);
     expect(
       KAI_ACTION_GATEWAY.actions.every((action) =>
-        ["one", "kai", "nav"].includes(action.speaker_persona)
+        ["one", "kai", "nav", "kyc"].includes(action.speaker_persona)
+      )
+    ).toBe(true);
+    expect(
+      KAI_ACTION_GATEWAY.actions.every(
+        (action) =>
+          action.delegate_agent_id === null ||
+          ["one", "kai", "nav", "kyc"].includes(action.delegate_agent_id)
       )
     ).toBe(true);
     expect(getKaiActionById("route.kai_dashboard")?.speaker_persona).toBe("kai");

--- a/hushh-webapp/__tests__/voice/voice-action-manifest.test.ts
+++ b/hushh-webapp/__tests__/voice/voice-action-manifest.test.ts
@@ -68,6 +68,7 @@ function projectRegistryAction(action: InvestorKaiActionDefinition) {
     label: action.label,
     meaning: action.meaning,
     speaker_persona: action.speakerPersona,
+    delegate_agent_id: action.delegateAgentId,
     scope: {
       routes: unique(action.scope.routes),
       screens: [...action.scope.screens],

--- a/hushh-webapp/contracts/kai/kai-action-gateway.vnext.json
+++ b/hushh-webapp/contracts/kai/kai-action-gateway.vnext.json
@@ -178,6 +178,7 @@
       ],
       "meaning": "Navigates directly to the Kai analysis workspace and history route.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/kai/analysis"
@@ -237,6 +238,7 @@
       ],
       "meaning": "Navigates to analysis page history context.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/kai/analysis",
@@ -299,6 +301,7 @@
       ],
       "meaning": "Creates fresh analysis intent and opens the debate workspace.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/kai/analysis"
@@ -363,6 +366,7 @@
       ],
       "meaning": "Attaches to currently running debate task and opens focused analysis route.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/kai/analysis",
@@ -430,6 +434,7 @@
       ],
       "meaning": "Cancels running debate task and returns to history view.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/kai/analysis"
@@ -496,6 +501,7 @@
       ],
       "meaning": "Legacy tab token accepted by parser but no transcript tab is rendered in current analysis UI.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/kai/analysis?tab=transcript"
@@ -557,6 +563,7 @@
       ],
       "meaning": "Navigates to profile landing route.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile"
@@ -619,6 +626,7 @@
       ],
       "meaning": "Navigates to hidden Gmail detail panel in Profile > Account.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile?panel=gmail"
@@ -681,6 +689,7 @@
       ],
       "meaning": "Navigates to hidden support panel in Profile > Account.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile?tab=account&panel=support"
@@ -744,6 +753,7 @@
       ],
       "meaning": "Navigates to hidden security panel in Profile > Privacy.",
       "speaker_persona": "nav",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile?tab=privacy&panel=security"
@@ -807,6 +817,7 @@
       ],
       "meaning": "Navigates to the PKM Agent Lab privacy workspace.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile/pkm-agent-lab"
@@ -869,6 +880,7 @@
       ],
       "meaning": "Sends support/bug/developer feedback email via support service.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile?tab=account&panel=support"
@@ -935,6 +947,7 @@
       ],
       "meaning": "Opts investor persona in/out of RIA marketplace discoverability.",
       "speaker_persona": "nav",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile?tab=privacy"
@@ -998,6 +1011,7 @@
       ],
       "meaning": "Ends current session and redirects to home route.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile"
@@ -1059,6 +1073,7 @@
       ],
       "meaning": "Deletes investor/ria persona or full account depending on selected target.",
       "speaker_persona": "nav",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile"
@@ -1124,6 +1139,7 @@
       ],
       "meaning": "Builds the current PKM Agent Lab capture preview without saving it.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile/pkm-agent-lab"
@@ -1188,6 +1204,7 @@
       ],
       "meaning": "Persists the current PKM Agent Lab capture into encrypted PKM storage.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile/pkm-agent-lab"
@@ -1255,6 +1272,7 @@
       ],
       "meaning": "Navigates directly to receipts page from any investor surface.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile/receipts"
@@ -1326,6 +1344,7 @@
       ],
       "meaning": "Starts OAuth flow for Gmail receipts connector.",
       "speaker_persona": "nav",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile",
@@ -1396,6 +1415,7 @@
       ],
       "meaning": "Queues and polls Gmail receipt sync run.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile/receipts",
@@ -1472,6 +1492,7 @@
       ],
       "meaning": "Builds the receipts-to-PKM preview from stored Gmail receipts.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile/receipts"
@@ -1538,6 +1559,7 @@
       ],
       "meaning": "Persists the current receipts-memory preview into shopping.receipts_memory.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile/receipts"
@@ -1604,6 +1626,7 @@
       ],
       "meaning": "Disconnects Gmail OAuth credentials for future syncs.",
       "speaker_persona": "nav",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/profile?panel=gmail"
@@ -1672,6 +1695,7 @@
       ],
       "meaning": "Navigates to the RIA workspace home route.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/ria"
@@ -1765,6 +1789,7 @@
       ],
       "meaning": "Navigates to consents route.",
       "speaker_persona": "nav",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/consents"
@@ -1824,6 +1849,7 @@
       ],
       "meaning": "Navigates back to the previous Kai or profile surface in browser history.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/kai",
@@ -1893,6 +1919,7 @@
       ],
       "meaning": "Navigates to portfolio dashboard for source/holdings context.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/kai/portfolio"
@@ -1952,6 +1979,7 @@
       ],
       "meaning": "Navigates to import flow for statement upload / portfolio bootstrap.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/kai/import"
@@ -2012,6 +2040,7 @@
       ],
       "meaning": "Navigates to investments workspace from hidden or non-visible surface.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/kai/investments"
@@ -2077,6 +2106,7 @@
       ],
       "meaning": "Navigates to optimize workspace route directly.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/kai/optimize"
@@ -2142,6 +2172,7 @@
       ],
       "meaning": "Navigates to the Investor Kai market home surface.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "reachability": {
         "routes": [
           "/kai",

--- a/hushh-webapp/contracts/kai/voice-action-manifest.v1.json
+++ b/hushh-webapp/contracts/kai/voice-action-manifest.v1.json
@@ -8,6 +8,7 @@
       "label": "Open Analysis Surface",
       "meaning": "Navigates directly to the Kai analysis workspace and history route.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "aliases": [
         "open analysis",
         "go to analysis"
@@ -40,6 +41,7 @@
       "label": "Open Analysis History",
       "meaning": "Navigates to analysis page history context.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "aliases": [
         "open analysis history",
         "show past analysis"
@@ -73,6 +75,7 @@
       "label": "Start Stock Analysis",
       "meaning": "Creates fresh analysis intent and opens the debate workspace.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "aliases": [
         "analyze stock",
         "start stock analysis",
@@ -111,6 +114,7 @@
       "label": "Resume Active Analysis Run",
       "meaning": "Attaches to currently running debate task and opens focused analysis route.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "aliases": [
         "resume analysis",
         "open active analysis"
@@ -149,6 +153,7 @@
       "label": "Cancel Active Analysis Run",
       "meaning": "Cancels running debate task and returns to history view.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "aliases": [
         "cancel analysis",
         "stop analysis"
@@ -187,6 +192,7 @@
       "label": "Legacy Transcript Tab Route",
       "meaning": "Legacy tab token accepted by parser but no transcript tab is rendered in current analysis UI.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "aliases": [
         "open transcript tab",
         "show transcript tab"
@@ -221,6 +227,7 @@
       "label": "Open Profile",
       "meaning": "Navigates to profile landing route.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "aliases": [
         "open profile",
         "go to profile"
@@ -255,6 +262,7 @@
       "label": "Open Gmail Connector Panel",
       "meaning": "Navigates to hidden Gmail detail panel in Profile > Account.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "aliases": [
         "open gmail settings",
         "open gmail panel"
@@ -290,6 +298,7 @@
       "label": "Open Support Panel",
       "meaning": "Navigates to hidden support panel in Profile > Account.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "aliases": [
         "open support",
         "contact support"
@@ -325,6 +334,7 @@
       "label": "Open Vault Security Panel",
       "meaning": "Navigates to hidden security panel in Profile > Privacy.",
       "speaker_persona": "nav",
+      "delegate_agent_id": null,
       "aliases": [
         "open security",
         "vault security"
@@ -360,6 +370,7 @@
       "label": "Open PKM Agent Lab",
       "meaning": "Navigates to the PKM Agent Lab privacy workspace.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "aliases": [
         "open pkm lab",
         "open memory lab"
@@ -394,6 +405,7 @@
       "label": "Submit Support Message",
       "meaning": "Sends support/bug/developer feedback email via support service.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "aliases": [
         "send support message",
         "submit support message"
@@ -428,6 +440,7 @@
       "label": "Toggle Marketplace Visibility",
       "meaning": "Opts investor persona in/out of RIA marketplace discoverability.",
       "speaker_persona": "nav",
+      "delegate_agent_id": null,
       "aliases": [
         "toggle marketplace visibility",
         "change marketplace visibility"
@@ -463,6 +476,7 @@
       "label": "Sign Out",
       "meaning": "Ends current session and redirects to home route.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "aliases": [
         "sign out",
         "log out"
@@ -497,6 +511,7 @@
       "label": "Delete Account",
       "meaning": "Deletes investor/ria persona or full account depending on selected target.",
       "speaker_persona": "nav",
+      "delegate_agent_id": null,
       "aliases": [
         "delete my account",
         "remove account"
@@ -534,6 +549,7 @@
       "label": "Generate PKM capture preview",
       "meaning": "Builds the current PKM Agent Lab capture preview without saving it.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "aliases": [
         "preview pkm capture",
         "generate pkm preview"
@@ -568,6 +584,7 @@
       "label": "Save PKM capture",
       "meaning": "Persists the current PKM Agent Lab capture into encrypted PKM storage.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "aliases": [
         "save pkm capture",
         "save memory capture"
@@ -605,6 +622,7 @@
       "label": "Open Receipts Page",
       "meaning": "Navigates directly to receipts page from any investor surface.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "aliases": [
         "open receipts",
         "open gmail receipts"
@@ -639,6 +657,7 @@
       "label": "Connect Gmail",
       "meaning": "Starts OAuth flow for Gmail receipts connector.",
       "speaker_persona": "nav",
+      "delegate_agent_id": null,
       "aliases": [
         "connect gmail",
         "link gmail"
@@ -674,6 +693,7 @@
       "label": "Sync Gmail Receipts Now",
       "meaning": "Queues and polls Gmail receipt sync run.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "aliases": [
         "sync gmail receipts",
         "refresh gmail receipts"
@@ -711,6 +731,7 @@
       "label": "Build receipts memory preview",
       "meaning": "Builds the receipts-to-PKM preview from stored Gmail receipts.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "aliases": [
         "preview receipts memory",
         "generate receipts memory preview"
@@ -743,6 +764,7 @@
       "label": "Save receipts memory to PKM",
       "meaning": "Persists the current receipts-memory preview into shopping.receipts_memory.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "aliases": [
         "save receipts memory",
         "save receipts to memory"
@@ -780,6 +802,7 @@
       "label": "Disconnect Gmail",
       "meaning": "Disconnects Gmail OAuth credentials for future syncs.",
       "speaker_persona": "nav",
+      "delegate_agent_id": null,
       "aliases": [
         "disconnect gmail",
         "unlink gmail"
@@ -815,6 +838,7 @@
       "label": "Open RIA Home",
       "meaning": "Navigates to the RIA workspace home route.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "aliases": [
         "open ria workspace",
         "go to ria home"
@@ -852,6 +876,7 @@
       "label": "Open Consent Center",
       "meaning": "Navigates to consents route.",
       "speaker_persona": "nav",
+      "delegate_agent_id": null,
       "aliases": [
         "open consent center",
         "open consents"
@@ -884,6 +909,7 @@
       "label": "Go Back",
       "meaning": "Navigates back to the previous Kai or profile surface in browser history.",
       "speaker_persona": "one",
+      "delegate_agent_id": null,
       "aliases": [
         "go back",
         "back"
@@ -923,6 +949,7 @@
       "label": "Open Portfolio Dashboard",
       "meaning": "Navigates to portfolio dashboard for source/holdings context.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "aliases": [
         "open portfolio dashboard",
         "open portfolio",
@@ -956,6 +983,7 @@
       "label": "Open Portfolio Import",
       "meaning": "Navigates to import flow for statement upload / portfolio bootstrap.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "aliases": [
         "import portfolio",
         "open import"
@@ -988,6 +1016,7 @@
       "label": "Open Investments Surface",
       "meaning": "Navigates to investments workspace from hidden or non-visible surface.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "aliases": [
         "open investments",
         "show investments"
@@ -1024,6 +1053,7 @@
       "label": "Open Optimize Surface",
       "meaning": "Navigates to optimize workspace route directly.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "aliases": [
         "optimize portfolio",
         "open optimize"
@@ -1058,6 +1088,7 @@
       "label": "Open Market Home",
       "meaning": "Navigates to the Investor Kai market home surface.",
       "speaker_persona": "kai",
+      "delegate_agent_id": null,
       "aliases": [
         "open kai home",
         "open market home",

--- a/hushh-webapp/lib/voice/investor-kai-action-registry.ts
+++ b/hushh-webapp/lib/voice/investor-kai-action-registry.ts
@@ -7,6 +7,7 @@ import {
   listKaiActions,
   listKaiActionsForSurface,
   type KaiActionDefinition,
+  type KaiActionDelegateAgentId,
   type KaiActionExecutionPolicy,
   type KaiActionExecutionTarget,
   type KaiActionRiskLevel,
@@ -66,6 +67,7 @@ export type InvestorKaiActionDefinition = {
   searchKeywords: readonly string[];
   meaning: string;
   speakerPersona: KaiActionSpeakerPersona;
+  delegateAgentId: KaiActionDelegateAgentId | null;
   scope: {
     routes: readonly string[];
     screens: readonly InvestorKaiScreenScope[];
@@ -226,6 +228,7 @@ function toRegistryAction(action: KaiActionDefinition): InvestorKaiActionDefinit
     searchKeywords: action.search_keywords,
     meaning: action.meaning,
     speakerPersona: action.speaker_persona,
+    delegateAgentId: action.delegate_agent_id,
     scope: {
       routes: action.reachability.routes,
       screens: action.reachability.screens,

--- a/hushh-webapp/lib/voice/kai-action-gateway.ts
+++ b/hushh-webapp/lib/voice/kai-action-gateway.ts
@@ -7,7 +7,8 @@ import type { VoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
 
 export type KaiActionRiskLevel = "low" | "medium" | "high";
 export type KaiActionExecutionPolicy = "allow_direct" | "confirm_required" | "manual_only";
-export type KaiActionSpeakerPersona = "one" | "kai" | "nav";
+export type KaiActionSpeakerPersona = "one" | "kai" | "nav" | "kyc";
+export type KaiActionDelegateAgentId = "one" | "kai" | "nav" | "kyc";
 export type KaiActionExecutionTarget =
   | {
       status: "wired";
@@ -96,6 +97,7 @@ export type KaiActionDefinition = {
   search_keywords: string[];
   meaning: string;
   speaker_persona: KaiActionSpeakerPersona;
+  delegate_agent_id: KaiActionDelegateAgentId | null;
   reachability: {
     routes: string[];
     screens: string[];
@@ -179,8 +181,21 @@ function isStringArray(value: unknown): value is string[] {
 
 function validateSpeakerPersona(value: unknown): KaiActionSpeakerPersona {
   const normalized = cleanString(value);
-  if (normalized === "kai" || normalized === "nav") return normalized;
+  if (normalized === "kai" || normalized === "nav" || normalized === "kyc") return normalized;
   return "one";
+}
+
+function validateDelegateAgentId(value: unknown): KaiActionDelegateAgentId | null {
+  const normalized = cleanString(value);
+  if (
+    normalized === "one" ||
+    normalized === "kai" ||
+    normalized === "nav" ||
+    normalized === "kyc"
+  ) {
+    return normalized;
+  }
+  return null;
 }
 
 function validateExecutionTarget(value: unknown): KaiActionExecutionTarget | null {
@@ -339,6 +354,7 @@ function validateAction(value: unknown): KaiActionDefinition | null {
     search_keywords: isStringArray(value.search_keywords) ? value.search_keywords : [],
     meaning,
     speaker_persona: validateSpeakerPersona(value.speaker_persona),
+    delegate_agent_id: validateDelegateAgentId(value.delegate_agent_id),
     reachability: {
       routes: value.reachability.routes,
       screens: value.reachability.screens,

--- a/hushh-webapp/lib/voice/voice-action-manifest.ts
+++ b/hushh-webapp/lib/voice/voice-action-manifest.ts
@@ -3,7 +3,8 @@ import manifestJson from "@/contracts/kai/voice-action-manifest.v1.json";
 export type VoiceActionManifestRiskLevel = "low" | "medium" | "high";
 export type VoiceActionManifestExecutionPolicy = "allow_direct" | "confirm_required" | "manual_only";
 export type VoiceActionManifestExecutionPath = "kai_command" | "voice_tool" | "route";
-export type VoiceActionManifestSpeakerPersona = "one" | "kai" | "nav";
+export type VoiceActionManifestSpeakerPersona = "one" | "kai" | "nav" | "kyc";
+export type VoiceActionManifestDelegateAgentId = "one" | "kai" | "nav" | "kyc";
 export type VoiceActionManifestExecutionHint =
   | {
       status: "wired";
@@ -35,6 +36,7 @@ export type VoiceActionManifestAction = {
   label: string;
   meaning: string;
   speaker_persona: VoiceActionManifestSpeakerPersona;
+  delegate_agent_id: VoiceActionManifestDelegateAgentId | null;
   scope: {
     routes: string[];
     screens: string[];
@@ -63,8 +65,13 @@ function isStringArray(value: unknown): value is string[] {
 }
 
 function validateSpeakerPersona(value: unknown): VoiceActionManifestSpeakerPersona {
-  if (value === "kai" || value === "nav") return value;
+  if (value === "kai" || value === "nav" || value === "kyc") return value;
   return "one";
+}
+
+function validateDelegateAgentId(value: unknown): VoiceActionManifestDelegateAgentId | null {
+  if (value === "one" || value === "kai" || value === "nav" || value === "kyc") return value;
+  return null;
 }
 
 function validateExecutionHint(input: unknown): VoiceActionManifestExecutionHint | null {
@@ -162,6 +169,7 @@ function validateAction(input: unknown): VoiceActionManifestAction | null {
     label: input.label.trim(),
     meaning: input.meaning.trim(),
     speaker_persona: validateSpeakerPersona(input.speaker_persona),
+    delegate_agent_id: validateDelegateAgentId(input.delegate_agent_id),
     scope: {
       routes: input.scope.routes.map((route) => route.trim()),
       screens: input.scope.screens.map((screen) => screen.trim()),

--- a/hushh-webapp/scripts/voice/generate-kai-action-gateway.mjs
+++ b/hushh-webapp/scripts/voice/generate-kai-action-gateway.mjs
@@ -20,7 +20,8 @@ const WEBAPP_MANIFEST_OUTPUT_PATH = path.resolve(
   "contracts/kai/voice-action-manifest.v1.json"
 );
 
-const SPEAKER_PERSONAS = new Set(["one", "kai", "nav"]);
+const AGENT_PERSONAS = new Set(["one", "kai", "nav", "kyc"]);
+const SPEAKER_PERSONAS = AGENT_PERSONAS;
 const DEFAULT_TRIGGER = {
   primary: "voice",
   supported: ["voice", "tap", "keyboard", "programmatic"],
@@ -296,6 +297,13 @@ function normalizeAction(surface, action) {
       `${actionId}: speaker_persona must be one of ${Array.from(SPEAKER_PERSONAS).join(", ")}`
     );
   }
+  const delegateAgentId =
+    cleanString(action.delegate_agent_id) || cleanString(surface.defaults?.delegate_agent_id);
+  if (delegateAgentId && !AGENT_PERSONAS.has(delegateAgentId)) {
+    throw new Error(
+      `${actionId}: delegate_agent_id must be one of ${Array.from(AGENT_PERSONAS).join(", ")}`
+    );
+  }
 
   const docsReferences = uniqueStrings([
     ...surface.docs_references,
@@ -309,6 +317,7 @@ function normalizeAction(surface, action) {
     search_keywords: uniqueStrings(action.search_keywords),
     meaning,
     speaker_persona: speakerPersona,
+    delegate_agent_id: delegateAgentId || null,
     reachability: normalizeReachability(action.reachability, surface.defaults?.reachability, actionId),
     guard_ids: uniqueStrings(action.guard_ids),
     risk_level: riskLevel,
@@ -380,6 +389,7 @@ function toLegacyManifestAction(action) {
     label: action.label,
     meaning: action.meaning,
     speaker_persona: action.speaker_persona,
+    delegate_agent_id: action.delegate_agent_id,
     aliases: action.aliases,
     scope: {
       routes: action.reachability.routes,


### PR DESCRIPTION
## Summary
- promotes One as the app-level orchestrator with Kai, Nav, and KYC specialist manifests
- adds least-privilege A2A delegation scopes and tests for specialist consent checks
- extends voice/action contracts with speaker_persona and delegate_agent_id coverage
- updates roadmap, ontology, skills, and governance docs for One/Kai/Nav/KYC boundaries
- syncs consent-protocol subtree upstream before monorepo merge

## Verification
- cd hushh-webapp && npm run build:voice-gateway && npm run verify:voice-gateway && npm run test -- __tests__/voice/kai-action-gateway.test.ts __tests__/voice/voice-action-manifest.test.ts
- cd hushh-webapp && npm run typecheck
- cd hushh-webapp && npm run lint
- cd consent-protocol && python3 -m pytest tests/test_granular_scopes.py tests/test_scope_helpers_dynamic.py tests/test_scope_bundle_contract.py tests/test_agent_manifests.py tests/test_a2a_delegation_scopes.py tests/test_adk_a2a_compliance_script.py tests/test_hushh_adk_foundation.py -q
- python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py
- ./bin/hushh docs verify
- bash scripts/ci/check-dco-signoff.sh origin/main HEAD
- ./scripts/ci/subtree-sync-check.sh
- ./bin/hushh protocol push, upstream Consent Protocol CI passed at https://github.com/hushh-labs/consent-protocol/actions/runs/25038201153

## Notes
- ./bin/hushh codex audit returns attention only for existing github-contribution-governance command-shape warnings; no high findings.
