### PR TITLE
docs(contributor): add onboarding guide

### DIFF
--- a/docs/guides/CONTRIBUTOR_ONBOARDING.md
+++ b/docs/guides/CONTRIBUTOR_ONBOARDING.md
@@ -1,6 +1,6 @@
 # Contributor Onboarding Guide
 
-  ## Visual Context
+## Visual Context
 
 This guide explains the contributor workflow for the hushh-research repository, including setup, making changes, and submitting pull requests.
 

--- a/docs/guides/CONTRIBUTOR_ONBOARDING.md
+++ b/docs/guides/CONTRIBUTOR_ONBOARDING.md
@@ -1,151 +1,593 @@
-# Contributor Onboarding Guide
+---
+title: Contributor Onboarding Guide
+description: Step-by-step guide for new contributors to Hushh Labs
+---
 
 ## Visual Context
 
-> This guide explains the contributor workflow for the hushh-research repository, including setup, making changes, and submitting pull requests.
+This guide is for **new contributors** to the Hushh Labs `hushh-research` repository. It provides complete, step-by-step instructions for:
+- Setting up Git and GitHub
+- Forking and cloning the repository
+- Creating branches and commits
+- Submitting and responding to Pull Requests
 
-See: ../../vision/project_context_map.md
+**Target Audience:** First-time open source contributors, developers new to Git workflow
 
-Welcome to Hushh Labs! This guide walks you through everything you need to make your first contribution — from forking the repo to getting your Pull Request merged.
+**Visual Owner:** @hushh-labs/documentation-team
+
+---
+
+# Contributor Onboarding Guide
+
+Welcome to **Hushh Labs**! 🤫 This guide walks you through everything you need to make your first contribution to `hushh-research` — from forking the repository to getting your Pull Request merged.
 
 ## Table of Contents
 
-* [Prerequisites](#prerequisites)
-* [Step 1 — Fork the Repository](#step-1--fork-the-repository)
-* [Step 2 — Clone Your Fork](#step-2--clone-your-fork)
-* [Step 3 — Set Up Upstream Remote](#step-3--set-up-upstream-remote)
-* [Step 4 — Sync With Latest Code](#step-4--sync-with-latest-code)
-* [Step 5 — Create a Branch](#step-5--create-a-branch)
-* [Step 6 — Make Your Changes](#step-6--make-your-changes)
-* [Step 7 — Commit Your Changes](#step-7--commit-your-changes)
-* [Step 8 — Push to Your Fork](#step-8--push-to-your-fork)
-* [Step 9 — Open a Pull Request](#step-9--open-a-pull-request)
-* [Step 10 — Address Review Feedback](#step-10--address-review-feedback)
-* [Commit Message Conventions](#commit-message-conventions)
-* [Where to Contribute](#where-to-contribute)
-* [Key Terms Glossary](#key-terms-glossary)
-* [Best Practices](#best-practices)
+- [Prerequisites](#prerequisites)
+- [Understanding the Workflow](#understanding-the-workflow)
+- [Step 1: Fork the Repository](#step-1-fork-the-repository)
+- [Step 2: Clone Your Fork](#step-2-clone-your-fork)
+- [Step 3: Add Upstream Remote](#step-3-add-upstream-remote)
+- [Step 4: Sync With Latest Code](#step-4-sync-with-latest-code)
+- [Step 5: Create a Feature Branch](#step-5-create-a-feature-branch)
+- [Step 6: Make Your Changes](#step-6-make-your-changes)
+- [Step 7: Commit Your Changes](#step-7-commit-your-changes)
+- [Step 8: Push to Your Fork](#step-8-push-to-your-fork)
+- [Step 9: Open a Pull Request](#step-9-open-a-pull-request)
+- [Step 10: Address Review Feedback](#step-10-address-review-feedback)
+- [Commit Message Conventions](#commit-message-conventions)
+- [Where to Contribute](#where-to-contribute)
+- [Key Terms Glossary](#key-terms-glossary)
+- [Quick Reference](#quick-reference)
+- [Best Practices](#best-practices)
+
+---
 
 ## Prerequisites
 
-Before you start, make sure you have:
+Before you start, ensure you have:
 
-* A [GitHub account](https://github.com) (free)
-* [Git](https://git-scm.com/downloads) installed on your computer
-* [Node.js](https://nodejs.org/) v18+ (for frontend changes)
-* [Python 3.10+](https://www.python.org/) (for backend changes)
-* A code editor such as [VS Code](https://code.visualstudio.com/)
+- **GitHub Account** — [Sign up free](https://github.com/signup)
+- **Git installed** — [Download here](https://git-scm.com/downloads)
+- **Node.js v18+** (for frontend/webapp changes) — [Download here](https://nodejs.org/)
+- **Python 3.10+** (for backend/consent-protocol changes) — [Download here](https://www.python.org/)
+- **VS Code** (recommended) — [Download here](https://code.visualstudio.com/)
 
-Verify Git is installed:
+**Verify Git is installed:**
 
 ```bash
 git --version
 ```
 
-## Step 1 — Fork the Repository
+You should see output like: `git version 2.40.0`
 
-A **fork** is your personal copy of the Hushh repo under your GitHub account.
+---
 
-1. Go to https://github.com/hushh-labs/hushh-research
-2. Click the **Fork** button
-3. Select your account
+## Understanding the Workflow
 
-## Step 2 — Clone Your Fork
+Here's what you're about to do:
+
+```
+┌──────────────┐
+│ 1. FORK      │  Create a personal copy on GitHub
+└──────┬───────┘
+       │
+┌──────▼───────┐
+│ 2. CLONE     │  Download to your computer
+└──────┬───────┘
+       │
+┌──────▼───────┐
+│ 3. SYNC      │  Pull latest changes from Hushh's repo
+└──────┬───────┘
+       │
+┌──────▼───────┐
+│ 4. BRANCH    │  Create isolated workspace for your changes
+└──────┬───────┘
+       │
+┌──────▼───────┐
+│ 5. EDIT      │  Make changes to files
+└──────┬───────┘
+       │
+┌──────▼───────┐
+│ 6. COMMIT    │  Save snapshot with clear message
+└──────┬───────┘
+       │
+┌──────▼───────┐
+│ 7. PUSH      │  Upload to your GitHub fork
+└──────┬───────┘
+       │
+┌──────▼───────┐
+│ 8. PR        │  Ask Hushh to merge your changes
+└──────────────┘
+```
+
+---
+
+## Step 1: Fork the Repository
+
+**What is a fork?**
+
+A fork is a complete copy of the Hushh repository under your GitHub account. You make changes here without affecting the original.
+
+**How to fork:**
+
+1. Go to [hushh-labs/hushh-research](https://github.com/hushh-labs/hushh-research)
+2. Click the **Fork** button in the top-right corner
+3. GitHub will create a copy at `https://github.com/YOUR_USERNAME/hushh-research`
+
+Wait for the fork to complete (usually takes a few seconds).
+
+---
+
+## Step 2: Clone Your Fork
+
+**What is a clone?**
+
+A clone downloads your forked repository to your computer so you can edit files locally.
+
+**How to clone:**
+
+Open PowerShell (Windows) or Terminal (macOS/Linux):
 
 ```bash
 git clone https://github.com/YOUR_USERNAME/hushh-research.git
 cd hushh-research
 ```
 
-## Step 3 — Set Up Upstream Remote
+Replace `YOUR_USERNAME` with your actual GitHub username (e.g., `mohammedsahith450-cpu`).
+
+**Verify it worked:**
+
+```bash
+git status
+```
+
+You should see: `On branch main` and `Your branch is up to date`
+
+---
+
+## Step 3: Add Upstream Remote
+
+**What is upstream?**
+
+Upstream is the official Hushh repository. You use it to stay synced with the latest changes while you work.
+
+**How to add it:**
 
 ```bash
 git remote add upstream https://github.com/hushh-labs/hushh-research.git
+```
+
+**Verify both remotes exist:**
+
+```bash
 git remote -v
 ```
 
-## Step 4 — Sync With Latest Code
+You should see:
+```
+origin    https://github.com/YOUR_USERNAME/hushh-research.git (fetch)
+origin    https://github.com/YOUR_USERNAME/hushh-research.git (push)
+upstream  https://github.com/hushh-labs/hushh-research.git (fetch)
+upstream  https://github.com/hushh-labs/hushh-research.git (push)
+```
+
+- `origin` = your fork (where you push)
+- `upstream` = official repo (where you pull updates)
+
+---
+
+## Step 4: Sync With Latest Code
+
+Before starting work, pull the latest changes:
 
 ```bash
 git fetch upstream
 git rebase upstream/main
 ```
 
-## Step 5 — Create a Branch
+This ensures you're working with the newest code and avoids merge conflicts.
+
+---
+
+## Step 5: Create a Feature Branch
+
+**What is a branch?**
+
+A branch is an isolated workspace. You make changes here without affecting the main code.
+
+**Naming convention:**
+
+- Documentation: `docs/description-of-change`
+- Bug fix: `fix/description-of-bug`
+- Feature: `feature/description-of-feature`
+- Refactor: `refactor/description-of-refactor`
+
+**Create your branch:**
 
 ```bash
 git checkout -b docs/contributor-onboarding-guide
 ```
 
-## Step 6 — Make Your Changes
+**Examples:**
+
+```bash
+git checkout -b docs/add-api-documentation
+git checkout -b fix/vault-unlock-passphrase-bug
+git checkout -b feature/add-consent-token-validation
+```
+
+**Verify you're on the new branch:**
+
+```bash
+git branch
+```
+
+You should see a `*` next to your new branch name.
+
+---
+
+## Step 6: Make Your Changes
+
+Open your code editor and edit files:
 
 ```bash
 code .
 ```
 
-## Step 7 — Commit Your Changes
+This opens VS Code in your repository.
+
+### For Documentation Changes:
+
+- Write clear, concise explanations
+- Use **markdown** formatting (`.md` files)
+- Include code examples where helpful
+- Link to related documentation
+- Check spelling and grammar
+
+### For Code Changes:
+
+- Follow the project's existing code style
+- Add comments for complex logic
+- Test your changes locally
+- Don't include large unrelated changes
+
+---
+
+## Step 7: Commit Your Changes
+
+After editing files, save your work with a commit:
 
 ```bash
 git add .
-git commit -m "docs: update contributor onboarding guide" --signoff
+git commit -m "docs: add contributor onboarding guide"
 ```
 
-## Step 8 — Push to Your Fork
+**Commit message format:**
+
+```
+<type>: <short description>
+```
+
+**Types:**
+- `docs:` — Documentation changes
+- `fix:` — Bug fixes
+- `feat:` — New features
+- `refactor:` — Code cleanup (no functionality change)
+- `test:` — Test additions or fixes
+- `chore:` — Build, dependencies, etc.
+
+**Good commit messages:**
+
+```bash
+git commit -m "docs: add contributor onboarding guide"
+git commit -m "fix: resolve vault unlock passphrase validation"
+git commit -m "feat: implement VAULT_OWNER token expiry check"
+```
+
+**Bad commit messages:**
+
+```bash
+git commit -m "update"
+git commit -m "fix"
+git commit -m "asdf"
+git commit -m "random changes"
+```
+
+---
+
+## Step 8: Push to Your Fork
+
+Upload your branch to your GitHub account:
 
 ```bash
 git push origin docs/contributor-onboarding-guide
 ```
 
-## Step 9 — Open a Pull Request
+Use the branch name you created in Step 5.
 
-* Go to your fork on GitHub
-* Click **Compare & pull request**
-* Submit PR
+**Verify it worked:**
 
-## Step 10 — Address Review Feedback
+Go to `https://github.com/YOUR_USERNAME/hushh-research`
 
-```bash
-git add .
-git commit -m "docs: address review feedback" --signoff
-git push
-```
+You should see a green notification: **"Your branch was pushed X minutes ago"**
 
-## Commit Message Conventions
+---
 
-Format:
+## Step 9: Open a Pull Request
 
-```
-<type>: <description>
-```
+**What is a PR?**
 
-Examples:
+A Pull Request asks the Hushh team to review and merge your changes into their official repository.
+
+**How to open a PR:**
+
+1. Go to your fork: `https://github.com/YOUR_USERNAME/hushh-research`
+2. GitHub will show a green **"Compare & pull request"** button
+3. Click it
+
+**Fill in the PR form:**
+
+**Title:** Be specific and clear
 
 ```
 docs: add contributor onboarding guide
-fix: correct API endpoint
-feat: add new feature
+fix: resolve vault passphrase validation bug
+feat: implement token expiry validation
 ```
+
+**Description:** Explain WHAT you changed and WHY
+
+```markdown
+## What does this PR do?
+Adds a comprehensive contributor onboarding guide for new developers.
+
+## Why?
+New contributors found the existing documentation unclear and needed a beginner-friendly, step-by-step guide.
+
+## How did you test it?
+Read through the guide and verified all Git commands work as written.
+
+## Related Issues
+Closes #42 (if applicable)
+```
+
+Click **"Create pull request"**
+
+---
+
+## Step 10: Address Review Feedback
+
+The Hushh team will review your PR. They might ask for changes.
+
+**If they request changes:**
+
+1. Make edits in your local files
+2. Commit again:
+   ```bash
+   git add .
+   git commit -m "docs: address review feedback"
+   ```
+3. Push again:
+   ```bash
+   git push origin docs/contributor-onboarding-guide
+   ```
+
+**The PR updates automatically** — you don't need to create a new PR. Your new commits appear in the same PR.
+
+**If they ask questions:**
+
+Reply in the PR comments. Be respectful and responsive.
+
+---
+
+## Commit Message Conventions
+
+Hushh follows the **Conventional Commits** format:
+
+```
+<type>: <description>
+
+<body (optional)>
+
+<footer (optional)>
+```
+
+### Types
+
+| Type | Usage | Example |
+|------|-------|---------|
+| `docs` | Documentation | `docs: add setup guide` |
+| `fix` | Bug fix | `fix: resolve login error` |
+| `feat` | New feature | `feat: add token validation` |
+| `refactor` | Code cleanup | `refactor: simplify API response` |
+| `test` | Tests | `test: add unit tests for auth` |
+| `chore` | Build, deps | `chore: update dependencies` |
+| `ci` | CI/CD changes | `ci: add GitHub Actions workflow` |
+| `perf` | Performance | `perf: optimize database query` |
+
+### Examples
+
+```bash
+# Simple
+git commit -m "docs: add contributor guide"
+
+# With body
+git commit -m "fix: resolve vault unlock issue
+
+The unlock passphrase was not handling special characters.
+Added proper escaping in validation logic."
+
+# With footer
+git commit -m "feat: add token expiry check
+
+Closes #123"
+```
+
+---
 
 ## Where to Contribute
 
-* docs/
-* hushh-webapp/
-* consent-protocol/
+The `hushh-research` repository is organized as a **monorepo** with multiple modules:
+
+### Documentation (`docs/`)
+- Add guides and tutorials
+- Improve existing docs
+- Add examples
+- No complex setup needed — great for first PRs!
+
+### Frontend (`hushh-webapp/`)
+- React components
+- TypeScript
+- UI improvements
+- Requires Node.js v18+
+
+### Backend (`consent-protocol/`)
+- Python FastAPI code
+- Smart contracts (if applicable)
+- Server logic
+- Requires Python 3.10+
+
+### Other Contributions
+- Bug fixes across any module
+- Tests
+- CI/CD improvements
+- Configuration
+
+---
 
 ## Key Terms Glossary
 
-| Term   | Meaning        |
-| ------ | -------------- |
-| Fork   | Copy of repo   |
-| Clone  | Download repo  |
-| Branch | Work area      |
-| Commit | Save changes   |
-| Push   | Upload changes |
-| PR     | Request merge  |
+| Term | Definition |
+|------|-----------|
+| **Fork** | Your personal copy of the repository on GitHub |
+| **Clone** | Download a repository to your computer |
+| **Branch** | An isolated line of work within a repository |
+| **Commit** | A saved snapshot of changes with a message |
+| **Push** | Upload commits from your computer to GitHub |
+| **Pull Request (PR)** | A request to merge your changes into the main repository |
+| **Upstream** | The official repository you're contributing to |
+| **Origin** | Your personal fork on GitHub |
+| **Main/Master** | The primary branch containing stable code |
+| **Merge** | Combining two branches into one |
+
+---
+
+## Quick Reference
+
+### Common Commands
+
+```bash
+# Setup (first time only)
+git clone https://github.com/YOUR_USERNAME/hushh-research.git
+cd hushh-research
+git remote add upstream https://github.com/hushh-labs/hushh-research.git
+
+# Before starting work
+git fetch upstream
+git rebase upstream/main
+
+# Create and switch to new branch
+git checkout -b docs/my-changes
+
+# Make changes in your editor...
+
+# Save changes
+git add .
+git commit -m "docs: clear message"
+
+# Upload to your fork
+git push origin docs/my-changes
+
+# Then create PR on GitHub
+```
+
+### Checking Status
+
+```bash
+# See which branch you're on
+git branch
+
+# See what changed
+git status
+
+# See recent commits
+git log --oneline -5
+
+# See difference
+git diff
+```
+
+---
 
 ## Best Practices
 
-* Keep PR small
-* Write clear messages
-* Test before pushing
-* Follow project structure
+1. **Start small** — Your first PR should be focused and manageable
+2. **Write for clarity** — Assume the reader is new to the project
+3. **Follow conventions** — Match the existing code style and documentation format
+4. **Test before pushing** — Verify your changes work locally
+5. **Keep PRs focused** — One feature/fix per PR, not multiple unrelated changes
+6. **Be responsive** — Reply to review comments promptly
+7. **Link related issues** — Reference GitHub issues in your PR description
+8. **Proofread** — Check spelling and grammar before submitting
+9. **Be humble** — Accept feedback gracefully and ask questions if unclear
+10. **Have fun** — You're contributing to open source! 🎉
+
+---
+
+## Common Mistakes to Avoid
+
+| ❌ Mistake | ✅ Correct Approach |
+|-----------|-------------------|
+| Working directly on `main` branch | Create a feature branch first |
+| Committing without a message | Always write clear, descriptive messages |
+| Pushing to `main` | Push to your feature branch |
+| Large, unfocused PRs | Keep changes small and related |
+| No PR description | Explain WHAT and WHY |
+| Force pushing to shared branches | Only force push to your own feature branches |
+| Not syncing with upstream | Run `git fetch upstream && git rebase upstream/main` regularly |
+| Ignoring review feedback | Respond to comments and make requested changes |
+
+---
+
+## Need Help?
+
+- **Git confused?** Run `git status` to see where you are
+- **Command error?** Copy the error and search on [Stack Overflow](https://stackoverflow.com)
+- **Hushh question?** Ask in the [Hushh Discord community](https://discord.gg/hushh)
+- **GitHub question?** Check [GitHub Docs](https://docs.github.com)
+
+---
+
+## What's Next After Your First PR?
+
+✅ **PR Merged!** You're now a Hushh contributor. You'll appear on:
+- The repository's contributors page
+- Hushh's community dashboard
+- Your GitHub profile
+
+🎯 **Continue Contributing:**
+1. Look for issues labeled `good first issue` or `help wanted`
+2. Fix small bugs
+3. Improve documentation
+4. Build more complex features
+
+---
+
+## Additional Resources
+
+- [GitHub's Git Handbook](https://guides.github.com/introduction/git-handbook/)
+- [Conventional Commits](https://www.conventionalcommits.org/)
+- [Pro Git Book](https://git-scm.com/book/en/v2)
+- [Hushh Labs GitHub](https://github.com/hushh-labs)
+- [Hushh Documentation](https://docs.hushh.ai)
+
+---
+
+**Welcome to the Hushh community! 🤫**
+
+Your data. Your vault. Your agents.
+
+---
+
+*Last updated: April 2026*

--- a/docs/guides/CONTRIBUTOR_ONBOARDING.md
+++ b/docs/guides/CONTRIBUTOR_ONBOARDING.md
@@ -1,5 +1,9 @@
 # Contributor Onboarding Guide
 
+  ## Visual Context
+
+This guide explains the contributor workflow for the hushh-research repository, including setup, making changes, and submitting pull requests.
+
 Welcome to Hushh Labs! This guide walks you through everything you need to make your first contribution — from forking the repo to getting your Pull Request merged.
 
 ## Table of Contents

--- a/docs/guides/CONTRIBUTOR_ONBOARDING.md
+++ b/docs/guides/CONTRIBUTOR_ONBOARDING.md
@@ -2,37 +2,39 @@
 
 ## Visual Context
 
-This guide explains the contributor workflow for the hushh-research repository, including setup, making changes, and submitting pull requests.
+> This guide explains the contributor workflow for the hushh-research repository, including setup, making changes, and submitting pull requests.
+
+See: ../../vision/project_context_map.md
 
 Welcome to Hushh Labs! This guide walks you through everything you need to make your first contribution — from forking the repo to getting your Pull Request merged.
 
 ## Table of Contents
 
-- [Prerequisites](#prerequisites)
-- [Step 1 — Fork the Repository](#step-1--fork-the-repository)
-- [Step 2 — Clone Your Fork](#step-2--clone-your-fork)
-- [Step 3 — Set Up Upstream Remote](#step-3--set-up-upstream-remote)
-- [Step 4 — Sync With Latest Code](#step-4--sync-with-latest-code)
-- [Step 5 — Create a Branch](#step-5--create-a-branch)
-- [Step 6 — Make Your Changes](#step-6--make-your-changes)
-- [Step 7 — Commit Your Changes](#step-7--commit-your-changes)
-- [Step 8 — Push to Your Fork](#step-8--push-to-your-fork)
-- [Step 9 — Open a Pull Request](#step-9--open-a-pull-request)
-- [Step 10 — Address Review Feedback](#step-10--address-review-feedback)
-- [Commit Message Conventions](#commit-message-conventions)
-- [Where to Contribute](#where-to-contribute)
-- [Key Terms Glossary](#key-terms-glossary)
-- [Best Practices](#best-practices)
+* [Prerequisites](#prerequisites)
+* [Step 1 — Fork the Repository](#step-1--fork-the-repository)
+* [Step 2 — Clone Your Fork](#step-2--clone-your-fork)
+* [Step 3 — Set Up Upstream Remote](#step-3--set-up-upstream-remote)
+* [Step 4 — Sync With Latest Code](#step-4--sync-with-latest-code)
+* [Step 5 — Create a Branch](#step-5--create-a-branch)
+* [Step 6 — Make Your Changes](#step-6--make-your-changes)
+* [Step 7 — Commit Your Changes](#step-7--commit-your-changes)
+* [Step 8 — Push to Your Fork](#step-8--push-to-your-fork)
+* [Step 9 — Open a Pull Request](#step-9--open-a-pull-request)
+* [Step 10 — Address Review Feedback](#step-10--address-review-feedback)
+* [Commit Message Conventions](#commit-message-conventions)
+* [Where to Contribute](#where-to-contribute)
+* [Key Terms Glossary](#key-terms-glossary)
+* [Best Practices](#best-practices)
 
 ## Prerequisites
 
 Before you start, make sure you have:
 
-- A [GitHub account](https://github.com) (free)
-- [Git](https://git-scm.com/downloads) installed on your computer
-- [Node.js](https://nodejs.org/) v18+ (for frontend changes)
-- [Python 3.10+](https://www.python.org/) (for backend changes)
-- A code editor such as [VS Code](https://code.visualstudio.com/)
+* A [GitHub account](https://github.com) (free)
+* [Git](https://git-scm.com/downloads) installed on your computer
+* [Node.js](https://nodejs.org/) v18+ (for frontend changes)
+* [Python 3.10+](https://www.python.org/) (for backend changes)
+* A code editor such as [VS Code](https://code.visualstudio.com/)
 
 Verify Git is installed:
 
@@ -44,236 +46,106 @@ git --version
 
 A **fork** is your personal copy of the Hushh repo under your GitHub account.
 
-1. Go to <https://github.com/hushh-labs/hushh-research>
-2. Click the **Fork** button in the top-right corner
-3. Select your GitHub account as the destination
-
-After forking, you will have: `https://github.com/YOUR_USERNAME/hushh-research`
+1. Go to https://github.com/hushh-labs/hushh-research
+2. Click the **Fork** button
+3. Select your account
 
 ## Step 2 — Clone Your Fork
-
-**Cloning** downloads the repository from GitHub to your computer.
 
 ```bash
 git clone https://github.com/YOUR_USERNAME/hushh-research.git
 cd hushh-research
 ```
 
-Replace `YOUR_USERNAME` with your actual GitHub username.
-
 ## Step 3 — Set Up Upstream Remote
-
-The **upstream** remote points to the official Hushh repo so you can pull the latest changes.
 
 ```bash
 git remote add upstream https://github.com/hushh-labs/hushh-research.git
-```
-
-Verify it worked:
-
-```bash
 git remote -v
 ```
 
-Expected output:
-
-```
-origin    https://github.com/YOUR_USERNAME/hushh-research.git (fetch)
-origin    https://github.com/YOUR_USERNAME/hushh-research.git (push)
-upstream  https://github.com/hushh-labs/hushh-research.git (fetch)
-upstream  https://github.com/hushh-labs/hushh-research.git (push)
-```
-
-| Remote | Meaning |
-| --- | --- |
-| `origin` | Your fork — where you push changes |
-| `upstream` | The official Hushh repo — where you pull updates |
-
 ## Step 4 — Sync With Latest Code
-
-Before creating a branch, always pull the latest changes:
 
 ```bash
 git fetch upstream
 git rebase upstream/main
 ```
 
-Run this every time before you start new work.
-
 ## Step 5 — Create a Branch
 
-A **branch** is an isolated workspace. Never work directly on `main`.
-
 ```bash
-# For a bug fix:
-git checkout -b fix/your-bug-name
-
-# For a new feature:
-git checkout -b feature/your-feature-name
-
-# For documentation:
-git checkout -b docs/your-doc-name
-```
-
-Examples:
-
-```bash
-git checkout -b fix/vault-unlock-passphrase-bug
-git checkout -b feature/add-consent-token-expiry
 git checkout -b docs/contributor-onboarding-guide
 ```
 
 ## Step 6 — Make Your Changes
 
-Open your editor and make your changes:
-
 ```bash
 code .
 ```
 
-### Frontend (Next.js)
-
-```bash
-cd hushh-webapp
-npm install
-npm run dev
-```
-
-### Backend (FastAPI)
-
-```bash
-cd consent-protocol
-pip install -r requirements.txt
-uvicorn main:app --reload
-```
-
 ## Step 7 — Commit Your Changes
-
-A **commit** is a saved snapshot of your changes with a descriptive message.
 
 ```bash
 git add .
-git commit -m "fix: resolve vault unlock passphrase validation bug"
+git commit -m "docs: update contributor onboarding guide" --signoff
 ```
-
-See [Commit Message Conventions](#commit-message-conventions) for proper formatting.
 
 ## Step 8 — Push to Your Fork
 
-**Pushing** uploads your local commits to your GitHub fork.
-
 ```bash
-git push origin YOUR_BRANCH_NAME
+git push origin docs/contributor-onboarding-guide
 ```
 
 ## Step 9 — Open a Pull Request
 
-1. Go to your fork: `https://github.com/YOUR_USERNAME/hushh-research`
-2. Click the green **"Compare & pull request"** button
-3. Fill in the PR title and description using the template provided
-4. Click **"Create pull request"**
-
-Your PR is now submitted for review.
+* Go to your fork on GitHub
+* Click **Compare & pull request**
+* Submit PR
 
 ## Step 10 — Address Review Feedback
 
-If the Hushh team requests changes:
-
-1. Make the edits in your local branch
-2. Commit and push again:
-
 ```bash
 git add .
-git commit -m "fix: address review feedback"
-git push origin YOUR_BRANCH_NAME
+git commit -m "docs: address review feedback" --signoff
+git push
 ```
-
-The PR updates automatically — you do not need to open a new PR.
 
 ## Commit Message Conventions
 
-Hushh follows the [Conventional Commits](https://www.conventionalcommits.org/) standard.
+Format:
 
-Format: `<type>: <short description>`
+```
+<type>: <description>
+```
 
-| Type | When to Use |
-| --- | --- |
-| `feat` | Adding a new feature |
-| `fix` | Fixing a bug |
-| `docs` | Documentation only changes |
-| `style` | Formatting, no logic changes |
-| `refactor` | Code restructuring without behavior change |
-| `test` | Adding or fixing tests |
-| `chore` | Maintenance, dependency updates |
+Examples:
 
-Good examples:
-
-```bash
-git commit -m "fix: resolve vault unlock passphrase validation bug"
-git commit -m "feat: add VAULT_OWNER token expiry check"
-git commit -m "docs: add contributor onboarding guide"
+```
+docs: add contributor onboarding guide
+fix: correct API endpoint
+feat: add new feature
 ```
 
 ## Where to Contribute
 
-Browse open issues: <https://github.com/hushh-labs/hushh-research/issues>
-
-Look for labels such as `good first issue`, `documentation`, `bug`, or `help wanted`.
-
-### Contribution Types by Difficulty
-
-| Type | Difficulty | Location |
-| --- | --- | --- |
-| Fix a typo or grammar | Easy | `docs/` |
-| Improve documentation | Easy | `docs/` |
-| Fix a small UI bug | Medium | `hushh-webapp/` |
-| Add a new UI component | Medium | `hushh-webapp/` |
-| Fix a backend API bug | Medium | `consent-protocol/` |
-| Add a new consent flow feature | Hard | Full stack |
+* docs/
+* hushh-webapp/
+* consent-protocol/
 
 ## Key Terms Glossary
 
-| Term | Meaning |
-| --- | --- |
-| Fork | Your personal copy of the repo on GitHub |
-| Clone | Download the repo to your computer |
-| Branch | An isolated workspace for your changes |
-| Commit | Save a snapshot of your changes with a message |
-| Push | Upload your commits to GitHub |
-| Pull Request | Ask Hushh to merge your changes into their repo |
-| Upstream | The official Hushh repo |
-| Origin | Your fork |
+| Term   | Meaning        |
+| ------ | -------------- |
+| Fork   | Copy of repo   |
+| Clone  | Download repo  |
+| Branch | Work area      |
+| Commit | Save changes   |
+| Push   | Upload changes |
+| PR     | Request merge  |
 
 ## Best Practices
 
-- Start with small, focused PRs — easier to review and merge faster
-- Write a clear PR description explaining what, why, and how you tested
-- Reference issues in your PR description using `Closes #42`
-- Respond to review feedback within 24 to 48 hours
-- Keep your branch up to date by rebasing regularly
-- Test your changes before submitting
-- Never force-push to a shared branch
-
-### Quick Reference
-
-```bash
-# One-time setup
-git clone https://github.com/YOUR_USERNAME/hushh-research.git
-cd hushh-research
-git remote add upstream https://github.com/hushh-labs/hushh-research.git
-
-# Every time you start new work
-git fetch upstream
-git rebase upstream/main
-git checkout -b fix/your-branch-name
-
-# After making changes
-git add .
-git commit -m "fix: clear description"
-git push origin fix/your-branch-name
-
-# After review feedback
-git add .
-git commit -m "fix: address review feedback"
-git push origin fix/your-branch-name
-```
+* Keep PR small
+* Write clear messages
+* Test before pushing
+* Follow project structure

--- a/docs/guides/CONTRIBUTOR_ONBOARDING.md
+++ b/docs/guides/CONTRIBUTOR_ONBOARDING.md
@@ -1,0 +1,417 @@
+# Contributor Onboarding Guide
+
+> **Welcome to Hushh Labs!** This guide walks you through everything you need to make your first contribution — from forking the repo to getting your Pull Request merged. No prior open-source experience required.
+
+---
+
+## Table of Contents
+
+1. [What Is This Repo?](#what-is-this-repo)
+2. [Prerequisites](#prerequisites)
+3. [Step 1 — Fork the Repository](#step-1--fork-the-repository)
+4. [Step 2 — Clone Your Fork](#step-2--clone-your-fork)
+5. [Step 3 — Set Up Upstream Remote](#step-3--set-up-upstream-remote)
+6. [Step 4 — Sync With Latest Code](#step-4--sync-with-latest-code)
+7. [Step 5 — Create a Branch](#step-5--create-a-branch)
+8. [Step 6 — Make Your Changes](#step-6--make-your-changes)
+9. [Step 7 — Commit Your Changes](#step-7--commit-your-changes)
+10. [Step 8 — Push to Your Fork](#step-8--push-to-your-fork)
+11. [Step 9 — Open a Pull Request](#step-9--open-a-pull-request)
+12. [Step 10 — Address Review Feedback](#step-10--address-review-feedback)
+13. [Commit Message Conventions](#commit-message-conventions)
+14. [Where to Contribute](#where-to-contribute)
+15. [Key Terms Glossary](#key-terms-glossary)
+16. [Common Mistakes to Avoid](#common-mistakes-to-avoid)
+17. [Tips for Getting Your PR Merged Fast](#tips-for-getting-your-pr-merged-fast)
+
+---
+
+## What Is This Repo?
+
+`hushh-research` is the research and product workspace for Hushh — a consent-first personal AI platform. It contains:
+
+| Folder | What It Is |
+|---|---|
+| `hushh-webapp/` | Next.js frontend (TypeScript, React) |
+| `consent-protocol/` | Python backend (FastAPI, consent tokens) |
+| `docs/` | Cross-cutting documentation |
+
+Contributors help by fixing bugs, improving docs, writing tests, or building new features.
+
+---
+
+## Prerequisites
+
+Before you start, make sure you have:
+
+- [ ] A [GitHub account](https://github.com) (free)
+- [ ] [Git](https://git-scm.com/downloads) installed on your computer
+- [ ] [Node.js](https://nodejs.org/) (for frontend changes)
+- [ ] [Python 3.10+](https://python.org) (for backend changes)
+- [ ] A code editor like [VS Code](https://code.visualstudio.com/)
+
+Verify Git is installed:
+
+```bash
+git --version
+# Expected: git version 2.x.x
+```
+
+---
+
+## Step 1 — Fork the Repository
+
+**What is a fork?** A fork is your own personal copy of the Hushh repo under your GitHub account. You make changes in your fork without affecting the original.
+
+1. Go to: [https://github.com/hushh-labs/hushh-research](https://github.com/hushh-labs/hushh-research)
+2. Click the **Fork** button in the top-right corner
+3. Select your GitHub account as the destination
+4. After forking, you will have: `https://github.com/YOUR_USERNAME/hushh-research`
+
+---
+
+## Step 2 — Clone Your Fork
+
+**What is cloning?** Cloning downloads the repository from GitHub to your computer so you can edit files locally.
+
+Open PowerShell (Windows) or Terminal (Mac/Linux) and run:
+
+```bash
+git clone https://github.com/YOUR_USERNAME/hushh-research.git
+cd hushh-research
+```
+
+> 🔁 Replace `YOUR_USERNAME` with your actual GitHub username.
+
+---
+
+## Step 3 — Set Up Upstream Remote
+
+**What is upstream?** The "upstream" remote points to the official Hushh repo. This lets you pull the latest changes from Hushh even after you've forked.
+
+```bash
+git remote add upstream https://github.com/hushh-labs/hushh-research.git
+```
+
+Verify it worked:
+
+```bash
+git remote -v
+```
+
+Expected output:
+
+```
+origin    https://github.com/YOUR_USERNAME/hushh-research.git (fetch)
+origin    https://github.com/YOUR_USERNAME/hushh-research.git (push)
+upstream  https://github.com/hushh-labs/hushh-research.git (fetch)
+upstream  https://github.com/hushh-labs/hushh-research.git (push)
+```
+
+| Remote | Meaning |
+|---|---|
+| `origin` | Your fork — where YOU push changes |
+| `upstream` | The official Hushh repo — where you pull updates |
+
+---
+
+## Step 4 — Sync With Latest Code
+
+Before creating a branch, always pull the latest changes so you're not working on outdated code:
+
+```bash
+git fetch upstream
+git rebase upstream/main
+```
+
+> ⚡ Do this every time before you start a new piece of work.
+
+---
+
+## Step 5 — Create a Branch
+
+**What is a branch?** A branch is an isolated workspace. You make changes in a branch without touching `main`. This allows multiple pieces of work to happen in parallel.
+
+**Never work directly on `main`.** Always create a branch:
+
+```bash
+# For a bug fix:
+git checkout -b fix/your-bug-name
+
+# For a new feature:
+git checkout -b feature/your-feature-name
+
+# For documentation:
+git checkout -b docs/your-doc-name
+```
+
+Examples:
+
+```bash
+git checkout -b fix/vault-unlock-passphrase-bug
+git checkout -b feature/add-consent-token-expiry
+git checkout -b docs/contributor-onboarding-guide
+```
+
+---
+
+## Step 6 — Make Your Changes
+
+Now open VS Code and make your changes:
+
+```bash
+# Open VS Code in the current folder
+code .
+```
+
+Depending on what you're contributing:
+
+- **Bug fix in web UI** → Edit files in `hushh-webapp/`
+- **Backend / protocol fix** → Edit files in `consent-protocol/`
+- **Documentation** → Edit or create files in `docs/`
+
+### Running the Frontend Locally
+
+```bash
+cd hushh-webapp
+npm install
+npm run dev
+# Opens at http://localhost:3000
+```
+
+### Running the Backend Locally
+
+```bash
+cd consent-protocol
+pip install -r requirements.txt
+uvicorn main:app --reload
+# Opens at http://localhost:8000
+```
+
+---
+
+## Step 7 — Commit Your Changes
+
+**What is a commit?** A commit is a saved snapshot of your changes with a message explaining what you did.
+
+After editing files:
+
+```bash
+# Stage all changed files
+git add .
+
+# Commit with a clear message
+git commit -m "fix: resolve vault unlock passphrase validation bug"
+```
+
+See [Commit Message Conventions](#commit-message-conventions) below for proper formatting.
+
+---
+
+## Step 8 — Push to Your Fork
+
+**What is pushing?** Pushing uploads your local commits to your GitHub fork.
+
+```bash
+git push origin YOUR_BRANCH_NAME
+```
+
+Example:
+
+```bash
+git push origin docs/contributor-onboarding-guide
+```
+
+---
+
+## Step 9 — Open a Pull Request
+
+**What is a Pull Request (PR)?** A PR is your formal request asking Hushh to merge your changes into their main repo. The team reviews your work and either merges it or asks for improvements.
+
+1. Go to your fork on GitHub: `https://github.com/YOUR_USERNAME/hushh-research`
+2. You will see a green **"Compare & pull request"** button — click it
+3. Fill in the PR form:
+
+**Title** (be specific):
+```
+docs: add step-by-step contributor onboarding guide
+```
+
+**Description template:**
+```markdown
+## What does this PR do?
+[Describe what you changed in 1–3 sentences]
+
+## Why?
+[Explain the problem this solves or the value it adds]
+
+## How did you test it?
+[Describe what you checked to make sure it works]
+
+## Related Issues
+Closes #[issue number, if applicable]
+```
+
+4. Click **"Create pull request"**
+
+> ✅ Your PR is now submitted! The Hushh team will review it within the week.
+
+---
+
+## Step 10 — Address Review Feedback
+
+The Hushh team may leave comments asking you to change something. Here's how to respond:
+
+1. Read their feedback carefully in the PR comments
+2. Make the requested changes in your local branch
+3. Commit and push again:
+
+```bash
+git add .
+git commit -m "fix: address review feedback"
+git push origin YOUR_BRANCH_NAME
+```
+
+> 🔁 The PR updates automatically — you do **not** need to open a new PR.
+
+Repeat until the team is happy and merges your PR. 🎉
+
+---
+
+## Commit Message Conventions
+
+Hushh follows the [Conventional Commits](https://www.conventionalcommits.org/) standard.
+
+Format:
+```
+<type>: <short description>
+```
+
+| Type | When to Use |
+|---|---|
+| `feat` | Adding a new feature |
+| `fix` | Fixing a bug |
+| `docs` | Documentation only changes |
+| `style` | Code formatting, no logic changes |
+| `refactor` | Restructuring code without changing behavior |
+| `test` | Adding or fixing tests |
+| `chore` | Maintenance, dependency updates |
+
+**Good examples:**
+```bash
+git commit -m "fix: resolve vault unlock passphrase validation bug"
+git commit -m "feat: add VAULT_OWNER token expiry check"
+git commit -m "docs: add contributor onboarding guide"
+git commit -m "test: add unit tests for consent token generation"
+```
+
+**Bad examples:**
+```bash
+git commit -m "fix"          # Too vague
+git commit -m "changes"      # Meaningless
+git commit -m "asdf"         # Never do this
+```
+
+---
+
+## Where to Contribute
+
+Not sure where to start? Here are the best entry points:
+
+### 1. Browse Open Issues
+Visit: [https://github.com/hushh-labs/hushh-research/issues](https://github.com/hushh-labs/hushh-research/issues)
+
+Look for labels like:
+- `good first issue` — Beginner-friendly
+- `documentation` — No code required
+- `bug` — Isolated, testable fixes
+- `help wanted` — Team actively needs contributors
+
+### 2. Contribution Types by Difficulty
+
+| Type | Difficulty | Where |
+|---|---|---|
+| Fix a typo or grammar in docs | ⭐ Very Easy | `docs/` |
+| Improve existing documentation | ⭐⭐ Easy | `docs/` |
+| Fix a small UI bug | ⭐⭐ Easy | `hushh-webapp/` |
+| Add a new UI component | ⭐⭐⭐ Medium | `hushh-webapp/` |
+| Fix a backend API bug | ⭐⭐⭐ Medium | `consent-protocol/` |
+| Add a new consent flow feature | ⭐⭐⭐⭐ Hard | Full stack |
+
+---
+
+## Key Terms Glossary
+
+| Term | Plain English Meaning |
+|---|---|
+| **Fork** | Your personal copy of the Hushh repo on GitHub |
+| **Clone** | Download the repo to your computer |
+| **Branch** | An isolated workspace for your changes |
+| **Commit** | Save a snapshot of your changes with a message |
+| **Push** | Upload your commits to GitHub |
+| **Pull Request (PR)** | Ask Hushh to merge your changes into their repo |
+| **Upstream** | The official Hushh repo (`hushh-labs/hushh-research`) |
+| **Origin** | Your fork (`YOUR_USERNAME/hushh-research`) |
+| **Merge** | When your PR is approved and added to the main codebase |
+| **Rebase** | Update your branch with the latest changes from upstream |
+| **Review** | The Hushh team reading your code and giving feedback |
+
+---
+
+## Common Mistakes to Avoid
+
+| ❌ Mistake | ✅ What To Do Instead |
+|---|---|
+| Working directly on `main` | Always create a new branch |
+| Not syncing before starting | Run `git fetch upstream && git rebase upstream/main` first |
+| Vague commit messages | Use `type: short description` format |
+| Opening a new PR after feedback | Just push to the same branch — PR updates automatically |
+| Huge PRs with many unrelated changes | Keep PRs small and focused on one thing |
+| Not filling in the PR description | Always describe what, why, and how you tested |
+
+---
+
+## Tips for Getting Your PR Merged Fast
+
+1. **Start small** — A focused, small PR is much easier to review than a massive one
+2. **Write a good PR description** — Explain what you did and why clearly
+3. **Reference an issue** — If your PR fixes a GitHub issue, write `Closes #42` in the description
+4. **Respond quickly** — When the team leaves feedback, reply within 24–48 hours
+5. **Keep your branch up to date** — If `main` moves forward, rebase your branch
+6. **Test your changes** — Make sure things actually work before submitting
+7. **Be respectful** — The team is reviewing many PRs; be patient and collaborative
+
+---
+
+## Quick Reference Cheatsheet
+
+```bash
+# ONE-TIME SETUP
+git clone https://github.com/YOUR_USERNAME/hushh-research.git
+cd hushh-research
+git remote add upstream https://github.com/hushh-labs/hushh-research.git
+
+# EVERY TIME YOU START NEW WORK
+git fetch upstream
+git rebase upstream/main
+git checkout -b fix/your-branch-name
+
+# AFTER MAKING CHANGES
+git add .
+git commit -m "fix: clear description of what you did"
+git push origin fix/your-branch-name
+
+# THEN: Go to GitHub → Click "Compare & pull request" → Fill in form → Submit
+
+# IF THE TEAM ASKS FOR CHANGES
+git add .
+git commit -m "fix: address review feedback"
+git push origin fix/your-branch-name
+# PR updates automatically — no new PR needed!
+```
+
+---
+
+> **You've got this!** Every expert contributor started exactly where you are now. Make your first PR, learn from the feedback, and build from there. The Hushh team is here to help. 🚀
+>
+> Questions? Open a GitHub Discussion or check the existing docs in `docs/guides/`.

--- a/docs/guides/CONTRIBUTOR_ONBOARDING.md
+++ b/docs/guides/CONTRIBUTOR_ONBOARDING.md
@@ -1,93 +1,65 @@
 # Contributor Onboarding Guide
 
-> **Welcome to Hushh Labs!** This guide walks you through everything you need to make your first contribution — from forking the repo to getting your Pull Request merged. No prior open-source experience required.
-
----
+Welcome to Hushh Labs! This guide walks you through everything you need to make your first contribution — from forking the repo to getting your Pull Request merged.
 
 ## Table of Contents
 
-1. [What Is This Repo?](#what-is-this-repo)
-2. [Prerequisites](#prerequisites)
-3. [Step 1 — Fork the Repository](#step-1--fork-the-repository)
-4. [Step 2 — Clone Your Fork](#step-2--clone-your-fork)
-5. [Step 3 — Set Up Upstream Remote](#step-3--set-up-upstream-remote)
-6. [Step 4 — Sync With Latest Code](#step-4--sync-with-latest-code)
-7. [Step 5 — Create a Branch](#step-5--create-a-branch)
-8. [Step 6 — Make Your Changes](#step-6--make-your-changes)
-9. [Step 7 — Commit Your Changes](#step-7--commit-your-changes)
-10. [Step 8 — Push to Your Fork](#step-8--push-to-your-fork)
-11. [Step 9 — Open a Pull Request](#step-9--open-a-pull-request)
-12. [Step 10 — Address Review Feedback](#step-10--address-review-feedback)
-13. [Commit Message Conventions](#commit-message-conventions)
-14. [Where to Contribute](#where-to-contribute)
-15. [Key Terms Glossary](#key-terms-glossary)
-16. [Common Mistakes to Avoid](#common-mistakes-to-avoid)
-17. [Tips for Getting Your PR Merged Fast](#tips-for-getting-your-pr-merged-fast)
-
----
-
-## What Is This Repo?
-
-`hushh-research` is the research and product workspace for Hushh — a consent-first personal AI platform. It contains:
-
-| Folder | What It Is |
-|---|---|
-| `hushh-webapp/` | Next.js frontend (TypeScript, React) |
-| `consent-protocol/` | Python backend (FastAPI, consent tokens) |
-| `docs/` | Cross-cutting documentation |
-
-Contributors help by fixing bugs, improving docs, writing tests, or building new features.
-
----
+- [Prerequisites](#prerequisites)
+- [Step 1 — Fork the Repository](#step-1--fork-the-repository)
+- [Step 2 — Clone Your Fork](#step-2--clone-your-fork)
+- [Step 3 — Set Up Upstream Remote](#step-3--set-up-upstream-remote)
+- [Step 4 — Sync With Latest Code](#step-4--sync-with-latest-code)
+- [Step 5 — Create a Branch](#step-5--create-a-branch)
+- [Step 6 — Make Your Changes](#step-6--make-your-changes)
+- [Step 7 — Commit Your Changes](#step-7--commit-your-changes)
+- [Step 8 — Push to Your Fork](#step-8--push-to-your-fork)
+- [Step 9 — Open a Pull Request](#step-9--open-a-pull-request)
+- [Step 10 — Address Review Feedback](#step-10--address-review-feedback)
+- [Commit Message Conventions](#commit-message-conventions)
+- [Where to Contribute](#where-to-contribute)
+- [Key Terms Glossary](#key-terms-glossary)
+- [Best Practices](#best-practices)
 
 ## Prerequisites
 
 Before you start, make sure you have:
 
-- [ ] A [GitHub account](https://github.com) (free)
-- [ ] [Git](https://git-scm.com/downloads) installed on your computer
-- [ ] [Node.js](https://nodejs.org/) (for frontend changes)
-- [ ] [Python 3.10+](https://python.org) (for backend changes)
-- [ ] A code editor like [VS Code](https://code.visualstudio.com/)
+- A [GitHub account](https://github.com) (free)
+- [Git](https://git-scm.com/downloads) installed on your computer
+- [Node.js](https://nodejs.org/) v18+ (for frontend changes)
+- [Python 3.10+](https://www.python.org/) (for backend changes)
+- A code editor such as [VS Code](https://code.visualstudio.com/)
 
 Verify Git is installed:
 
 ```bash
 git --version
-# Expected: git version 2.x.x
 ```
-
----
 
 ## Step 1 — Fork the Repository
 
-**What is a fork?** A fork is your own personal copy of the Hushh repo under your GitHub account. You make changes in your fork without affecting the original.
+A **fork** is your personal copy of the Hushh repo under your GitHub account.
 
-1. Go to: [https://github.com/hushh-labs/hushh-research](https://github.com/hushh-labs/hushh-research)
+1. Go to <https://github.com/hushh-labs/hushh-research>
 2. Click the **Fork** button in the top-right corner
 3. Select your GitHub account as the destination
-4. After forking, you will have: `https://github.com/YOUR_USERNAME/hushh-research`
 
----
+After forking, you will have: `https://github.com/YOUR_USERNAME/hushh-research`
 
 ## Step 2 — Clone Your Fork
 
-**What is cloning?** Cloning downloads the repository from GitHub to your computer so you can edit files locally.
-
-Open PowerShell (Windows) or Terminal (Mac/Linux) and run:
+**Cloning** downloads the repository from GitHub to your computer.
 
 ```bash
 git clone https://github.com/YOUR_USERNAME/hushh-research.git
 cd hushh-research
 ```
 
-> 🔁 Replace `YOUR_USERNAME` with your actual GitHub username.
-
----
+Replace `YOUR_USERNAME` with your actual GitHub username.
 
 ## Step 3 — Set Up Upstream Remote
 
-**What is upstream?** The "upstream" remote points to the official Hushh repo. This lets you pull the latest changes from Hushh even after you've forked.
+The **upstream** remote points to the official Hushh repo so you can pull the latest changes.
 
 ```bash
 git remote add upstream https://github.com/hushh-labs/hushh-research.git
@@ -109,30 +81,24 @@ upstream  https://github.com/hushh-labs/hushh-research.git (push)
 ```
 
 | Remote | Meaning |
-|---|---|
-| `origin` | Your fork — where YOU push changes |
+| --- | --- |
+| `origin` | Your fork — where you push changes |
 | `upstream` | The official Hushh repo — where you pull updates |
-
----
 
 ## Step 4 — Sync With Latest Code
 
-Before creating a branch, always pull the latest changes so you're not working on outdated code:
+Before creating a branch, always pull the latest changes:
 
 ```bash
 git fetch upstream
 git rebase upstream/main
 ```
 
-> ⚡ Do this every time before you start a new piece of work.
-
----
+Run this every time before you start new work.
 
 ## Step 5 — Create a Branch
 
-**What is a branch?** A branch is an isolated workspace. You make changes in a branch without touching `main`. This allows multiple pieces of work to happen in parallel.
-
-**Never work directly on `main`.** Always create a branch:
+A **branch** is an isolated workspace. Never work directly on `main`.
 
 ```bash
 # For a bug fix:
@@ -153,118 +119,64 @@ git checkout -b feature/add-consent-token-expiry
 git checkout -b docs/contributor-onboarding-guide
 ```
 
----
-
 ## Step 6 — Make Your Changes
 
-Now open VS Code and make your changes:
+Open your editor and make your changes:
 
 ```bash
-# Open VS Code in the current folder
 code .
 ```
 
-Depending on what you're contributing:
-
-- **Bug fix in web UI** → Edit files in `hushh-webapp/`
-- **Backend / protocol fix** → Edit files in `consent-protocol/`
-- **Documentation** → Edit or create files in `docs/`
-
-### Running the Frontend Locally
+### Frontend (Next.js)
 
 ```bash
 cd hushh-webapp
 npm install
 npm run dev
-# Opens at http://localhost:3000
 ```
 
-### Running the Backend Locally
+### Backend (FastAPI)
 
 ```bash
 cd consent-protocol
 pip install -r requirements.txt
 uvicorn main:app --reload
-# Opens at http://localhost:8000
 ```
-
----
 
 ## Step 7 — Commit Your Changes
 
-**What is a commit?** A commit is a saved snapshot of your changes with a message explaining what you did.
-
-After editing files:
+A **commit** is a saved snapshot of your changes with a descriptive message.
 
 ```bash
-# Stage all changed files
 git add .
-
-# Commit with a clear message
 git commit -m "fix: resolve vault unlock passphrase validation bug"
 ```
 
-See [Commit Message Conventions](#commit-message-conventions) below for proper formatting.
-
----
+See [Commit Message Conventions](#commit-message-conventions) for proper formatting.
 
 ## Step 8 — Push to Your Fork
 
-**What is pushing?** Pushing uploads your local commits to your GitHub fork.
+**Pushing** uploads your local commits to your GitHub fork.
 
 ```bash
 git push origin YOUR_BRANCH_NAME
 ```
 
-Example:
-
-```bash
-git push origin docs/contributor-onboarding-guide
-```
-
----
-
 ## Step 9 — Open a Pull Request
 
-**What is a Pull Request (PR)?** A PR is your formal request asking Hushh to merge your changes into their main repo. The team reviews your work and either merges it or asks for improvements.
-
-1. Go to your fork on GitHub: `https://github.com/YOUR_USERNAME/hushh-research`
-2. You will see a green **"Compare & pull request"** button — click it
-3. Fill in the PR form:
-
-**Title** (be specific):
-```
-docs: add step-by-step contributor onboarding guide
-```
-
-**Description template:**
-```markdown
-## What does this PR do?
-[Describe what you changed in 1–3 sentences]
-
-## Why?
-[Explain the problem this solves or the value it adds]
-
-## How did you test it?
-[Describe what you checked to make sure it works]
-
-## Related Issues
-Closes #[issue number, if applicable]
-```
-
+1. Go to your fork: `https://github.com/YOUR_USERNAME/hushh-research`
+2. Click the green **"Compare & pull request"** button
+3. Fill in the PR title and description using the template provided
 4. Click **"Create pull request"**
 
-> ✅ Your PR is now submitted! The Hushh team will review it within the week.
-
----
+Your PR is now submitted for review.
 
 ## Step 10 — Address Review Feedback
 
-The Hushh team may leave comments asking you to change something. Here's how to respond:
+If the Hushh team requests changes:
 
-1. Read their feedback carefully in the PR comments
-2. Make the requested changes in your local branch
-3. Commit and push again:
+1. Make the edits in your local branch
+2. Commit and push again:
 
 ```bash
 git add .
@@ -272,146 +184,92 @@ git commit -m "fix: address review feedback"
 git push origin YOUR_BRANCH_NAME
 ```
 
-> 🔁 The PR updates automatically — you do **not** need to open a new PR.
-
-Repeat until the team is happy and merges your PR. 🎉
-
----
+The PR updates automatically — you do not need to open a new PR.
 
 ## Commit Message Conventions
 
 Hushh follows the [Conventional Commits](https://www.conventionalcommits.org/) standard.
 
-Format:
-```
-<type>: <short description>
-```
+Format: `<type>: <short description>`
 
 | Type | When to Use |
-|---|---|
+| --- | --- |
 | `feat` | Adding a new feature |
 | `fix` | Fixing a bug |
 | `docs` | Documentation only changes |
-| `style` | Code formatting, no logic changes |
-| `refactor` | Restructuring code without changing behavior |
+| `style` | Formatting, no logic changes |
+| `refactor` | Code restructuring without behavior change |
 | `test` | Adding or fixing tests |
 | `chore` | Maintenance, dependency updates |
 
-**Good examples:**
+Good examples:
+
 ```bash
 git commit -m "fix: resolve vault unlock passphrase validation bug"
 git commit -m "feat: add VAULT_OWNER token expiry check"
 git commit -m "docs: add contributor onboarding guide"
-git commit -m "test: add unit tests for consent token generation"
 ```
-
-**Bad examples:**
-```bash
-git commit -m "fix"          # Too vague
-git commit -m "changes"      # Meaningless
-git commit -m "asdf"         # Never do this
-```
-
----
 
 ## Where to Contribute
 
-Not sure where to start? Here are the best entry points:
+Browse open issues: <https://github.com/hushh-labs/hushh-research/issues>
 
-### 1. Browse Open Issues
-Visit: [https://github.com/hushh-labs/hushh-research/issues](https://github.com/hushh-labs/hushh-research/issues)
+Look for labels such as `good first issue`, `documentation`, `bug`, or `help wanted`.
 
-Look for labels like:
-- `good first issue` — Beginner-friendly
-- `documentation` — No code required
-- `bug` — Isolated, testable fixes
-- `help wanted` — Team actively needs contributors
+### Contribution Types by Difficulty
 
-### 2. Contribution Types by Difficulty
-
-| Type | Difficulty | Where |
-|---|---|---|
-| Fix a typo or grammar in docs | ⭐ Very Easy | `docs/` |
-| Improve existing documentation | ⭐⭐ Easy | `docs/` |
-| Fix a small UI bug | ⭐⭐ Easy | `hushh-webapp/` |
-| Add a new UI component | ⭐⭐⭐ Medium | `hushh-webapp/` |
-| Fix a backend API bug | ⭐⭐⭐ Medium | `consent-protocol/` |
-| Add a new consent flow feature | ⭐⭐⭐⭐ Hard | Full stack |
-
----
+| Type | Difficulty | Location |
+| --- | --- | --- |
+| Fix a typo or grammar | Easy | `docs/` |
+| Improve documentation | Easy | `docs/` |
+| Fix a small UI bug | Medium | `hushh-webapp/` |
+| Add a new UI component | Medium | `hushh-webapp/` |
+| Fix a backend API bug | Medium | `consent-protocol/` |
+| Add a new consent flow feature | Hard | Full stack |
 
 ## Key Terms Glossary
 
-| Term | Plain English Meaning |
-|---|---|
-| **Fork** | Your personal copy of the Hushh repo on GitHub |
-| **Clone** | Download the repo to your computer |
-| **Branch** | An isolated workspace for your changes |
-| **Commit** | Save a snapshot of your changes with a message |
-| **Push** | Upload your commits to GitHub |
-| **Pull Request (PR)** | Ask Hushh to merge your changes into their repo |
-| **Upstream** | The official Hushh repo (`hushh-labs/hushh-research`) |
-| **Origin** | Your fork (`YOUR_USERNAME/hushh-research`) |
-| **Merge** | When your PR is approved and added to the main codebase |
-| **Rebase** | Update your branch with the latest changes from upstream |
-| **Review** | The Hushh team reading your code and giving feedback |
+| Term | Meaning |
+| --- | --- |
+| Fork | Your personal copy of the repo on GitHub |
+| Clone | Download the repo to your computer |
+| Branch | An isolated workspace for your changes |
+| Commit | Save a snapshot of your changes with a message |
+| Push | Upload your commits to GitHub |
+| Pull Request | Ask Hushh to merge your changes into their repo |
+| Upstream | The official Hushh repo |
+| Origin | Your fork |
 
----
+## Best Practices
 
-## Common Mistakes to Avoid
+- Start with small, focused PRs — easier to review and merge faster
+- Write a clear PR description explaining what, why, and how you tested
+- Reference issues in your PR description using `Closes #42`
+- Respond to review feedback within 24 to 48 hours
+- Keep your branch up to date by rebasing regularly
+- Test your changes before submitting
+- Never force-push to a shared branch
 
-| ❌ Mistake | ✅ What To Do Instead |
-|---|---|
-| Working directly on `main` | Always create a new branch |
-| Not syncing before starting | Run `git fetch upstream && git rebase upstream/main` first |
-| Vague commit messages | Use `type: short description` format |
-| Opening a new PR after feedback | Just push to the same branch — PR updates automatically |
-| Huge PRs with many unrelated changes | Keep PRs small and focused on one thing |
-| Not filling in the PR description | Always describe what, why, and how you tested |
-
----
-
-## Tips for Getting Your PR Merged Fast
-
-1. **Start small** — A focused, small PR is much easier to review than a massive one
-2. **Write a good PR description** — Explain what you did and why clearly
-3. **Reference an issue** — If your PR fixes a GitHub issue, write `Closes #42` in the description
-4. **Respond quickly** — When the team leaves feedback, reply within 24–48 hours
-5. **Keep your branch up to date** — If `main` moves forward, rebase your branch
-6. **Test your changes** — Make sure things actually work before submitting
-7. **Be respectful** — The team is reviewing many PRs; be patient and collaborative
-
----
-
-## Quick Reference Cheatsheet
+### Quick Reference
 
 ```bash
-# ONE-TIME SETUP
+# One-time setup
 git clone https://github.com/YOUR_USERNAME/hushh-research.git
 cd hushh-research
 git remote add upstream https://github.com/hushh-labs/hushh-research.git
 
-# EVERY TIME YOU START NEW WORK
+# Every time you start new work
 git fetch upstream
 git rebase upstream/main
 git checkout -b fix/your-branch-name
 
-# AFTER MAKING CHANGES
+# After making changes
 git add .
-git commit -m "fix: clear description of what you did"
+git commit -m "fix: clear description"
 git push origin fix/your-branch-name
 
-# THEN: Go to GitHub → Click "Compare & pull request" → Fill in form → Submit
-
-# IF THE TEAM ASKS FOR CHANGES
+# After review feedback
 git add .
 git commit -m "fix: address review feedback"
 git push origin fix/your-branch-name
-# PR updates automatically — no new PR needed!
 ```
-
----
-
-> **You've got this!** Every expert contributor started exactly where you are now. Make your first PR, learn from the feedback, and build from there. The Hushh team is here to help. 🚀
->
-> Questions? Open a GitHub Discussion or check the existing docs in `docs/guides/`.


### PR DESCRIPTION
## What does this PR do?
Adds a contributor onboarding guide to help new developers understand how to contribute.

## Why is this change needed?
Currently, there is no clear onboarding guide for new contributors.

## What has been added?
- New file: docs/guides/CONTRIBUTOR_ONBOARDING.md
- Step-by-step contribution instructions

## Impact
- [x] Documentation only change
- [ ] Code change

## Testing
- [x] Verified markdown structure
- [x] File renders correctly