### PR TITLE
test(api): add account and notifications route coverage

### DIFF
--- a/consent-protocol/tests/test_account_routes.py
+++ b/consent-protocol/tests/test_account_routes.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.middleware import require_firebase_auth, require_vault_owner_token
+from api.routes import account
+from hushh_mcp.services.account_service import AccountService
+from hushh_mcp.services.actor_identity_service import ActorIdentityService
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(account.router)
+    return app
+
+
+def test_refresh_account_identity_requires_firebase_auth():
+    client = TestClient(_build_app())
+    response = client.post("/api/account/identity/refresh")
+
+    assert response.status_code == 401
+
+
+def test_refresh_account_identity_returns_synced_identity(monkeypatch):
+    async def _mock_sync(self, firebase_uid: str, force: bool = False):
+        assert firebase_uid == "firebase_uid_123"
+        assert force is True
+        return {"personas": ["investor"], "last_active_persona": "investor"}
+
+    app = _build_app()
+    app.dependency_overrides[require_firebase_auth] = lambda: "firebase_uid_123"
+    monkeypatch.setattr(ActorIdentityService, "sync_from_firebase", _mock_sync)
+
+    client = TestClient(app)
+    response = client.post("/api/account/identity/refresh")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["user_id"] == "firebase_uid_123"
+    assert payload["identity"]["last_active_persona"] == "investor"
+
+
+def test_delete_account_requires_vault_owner_token():
+    client = TestClient(_build_app())
+    response = client.delete("/api/account/delete")
+
+    assert response.status_code == 401
+
+
+def test_delete_account_defaults_target_to_both(monkeypatch):
+    async def _mock_delete(self, user_id: str, target: str = "both"):
+        assert user_id == "user_123"
+        assert target == "both"
+        return {"success": True, "deleted_target": "both", "account_deleted": True}
+
+    app = _build_app()
+    app.dependency_overrides[require_vault_owner_token] = lambda: {"user_id": "user_123"}
+    monkeypatch.setattr(AccountService, "delete_account", _mock_delete)
+
+    client = TestClient(app)
+    response = client.delete("/api/account/delete")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["account_deleted"] is True
+
+
+def test_delete_account_forwards_requested_target(monkeypatch):
+    async def _mock_delete(self, user_id: str, target: str = "both"):
+        assert user_id == "user_123"
+        assert target == "investor"
+        return {"success": True, "deleted_target": "investor", "remaining_personas": ["ria"]}
+
+    app = _build_app()
+    app.dependency_overrides[require_vault_owner_token] = lambda: {"user_id": "user_123"}
+    monkeypatch.setattr(AccountService, "delete_account", _mock_delete)
+
+    client = TestClient(app)
+    response = client.request(
+        "DELETE",
+        "/api/account/delete",
+        json={"target": "investor"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["deleted_target"] == "investor"
+    assert payload["remaining_personas"] == ["ria"]
+
+
+def test_delete_account_maps_service_failure_to_500(monkeypatch):
+    async def _mock_delete(self, user_id: str, target: str = "both"):
+        assert user_id == "user_123"
+        assert target == "both"
+        return {"success": False, "error": "boom"}
+
+    app = _build_app()
+    app.dependency_overrides[require_vault_owner_token] = lambda: {"user_id": "user_123"}
+    monkeypatch.setattr(AccountService, "delete_account", _mock_delete)
+
+    client = TestClient(app)
+    response = client.delete("/api/account/delete")
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Deletion failed: boom"
+
+
+def test_export_account_data_requires_vault_owner_token():
+    client = TestClient(_build_app())
+    response = client.get("/api/account/export")
+
+    assert response.status_code == 401
+
+
+def test_export_account_data_returns_service_payload(monkeypatch):
+    async def _mock_export(self, user_id: str):
+        assert user_id == "user_123"
+        return {
+            "success": True,
+            "requested_target": "account",
+            "data": {
+                "actor_profile": {"user_id": "user_123"},
+                "encrypted_vault_keys": [],
+            },
+        }
+
+    app = _build_app()
+    app.dependency_overrides[require_vault_owner_token] = lambda: {"user_id": "user_123"}
+    monkeypatch.setattr(AccountService, "export_data", _mock_export)
+
+    client = TestClient(app)
+    response = client.get("/api/account/export")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["requested_target"] == "account"
+    assert payload["data"]["actor_profile"]["user_id"] == "user_123"
+
+
+def test_export_account_data_maps_failure_to_500(monkeypatch):
+    async def _mock_export(self, user_id: str):
+        assert user_id == "user_123"
+        return {"success": False, "error": "boom"}
+
+    app = _build_app()
+    app.dependency_overrides[require_vault_owner_token] = lambda: {"user_id": "user_123"}
+    monkeypatch.setattr(AccountService, "export_data", _mock_export)
+
+    client = TestClient(app)
+    response = client.get("/api/account/export")
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Account export failed"

--- a/consent-protocol/tests/test_notifications_routes.py
+++ b/consent-protocol/tests/test_notifications_routes.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routes import notifications
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(notifications.router)
+    return app
+
+
+def test_register_push_token_requires_firebase_auth():
+    client = TestClient(_build_app())
+    response = client.post(
+        "/api/notifications/register",
+        json={"user_id": "user_123", "token": "fcm_token_123", "platform": "web"},
+    )
+
+    assert response.status_code == 401
+
+
+def test_register_push_token_rejects_invalid_json(monkeypatch):
+    client = TestClient(_build_app())
+    monkeypatch.setattr(
+        "api.routes.notifications.verify_firebase_bearer",
+        lambda auth_header: "user_123",
+    )
+
+    response = client.post(
+        "/api/notifications/register",
+        content="{invalid json",
+        headers={"Authorization": "Bearer firebase-token"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid JSON body"
+
+
+def test_register_push_token_requires_user_id_and_token(monkeypatch):
+    client = TestClient(_build_app())
+    monkeypatch.setattr(
+        "api.routes.notifications.verify_firebase_bearer",
+        lambda auth_header: "user_123",
+    )
+
+    response = client.post(
+        "/api/notifications/register",
+        json={"platform": "web"},
+        headers={"Authorization": "Bearer firebase-token"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "user_id and token are required"
+
+
+def test_register_push_token_rejects_cross_user_registration(monkeypatch):
+    client = TestClient(_build_app())
+    monkeypatch.setattr(
+        "api.routes.notifications.verify_firebase_bearer",
+        lambda auth_header: "user_123",
+    )
+
+    response = client.post(
+        "/api/notifications/register",
+        json={"user_id": "user_456", "token": "fcm_token_123", "platform": "web"},
+        headers={"Authorization": "Bearer firebase-token"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Cannot register token for another user"
+
+
+def test_register_push_token_rejects_invalid_platform(monkeypatch):
+    client = TestClient(_build_app())
+    monkeypatch.setattr(
+        "api.routes.notifications.verify_firebase_bearer",
+        lambda auth_header: "user_123",
+    )
+
+    response = client.post(
+        "/api/notifications/register",
+        json={
+            "user_id": "user_123",
+            "token": "fcm_token_123",
+            "platform": "desktop",
+        },
+        headers={"Authorization": "Bearer firebase-token"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "platform must be one of: web, ios, android"
+
+
+def test_register_push_token_defaults_platform_to_web(monkeypatch):
+    client = TestClient(_build_app())
+    monkeypatch.setattr(
+        "api.routes.notifications.verify_firebase_bearer",
+        lambda auth_header: "user_123",
+    )
+
+    with patch("api.routes.notifications.PushTokensService") as mock_service_class:
+        mock_service = MagicMock()
+        mock_service.upsert_user_push_token.return_value = "push_token_123"
+        mock_service_class.return_value = mock_service
+
+        response = client.post(
+            "/api/notifications/register",
+            json={"user_id": "user_123", "token": "fcm_token_123"},
+            headers={"Authorization": "Bearer firebase-token"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "ok": True,
+        "user_id": "user_123",
+        "platform": "web",
+        "id": "push_token_123",
+    }
+
+
+def test_register_push_token_maps_service_failure_to_500(monkeypatch):
+    client = TestClient(_build_app())
+    monkeypatch.setattr(
+        "api.routes.notifications.verify_firebase_bearer",
+        lambda auth_header: "user_123",
+    )
+
+    with patch("api.routes.notifications.PushTokensService") as mock_service_class:
+        mock_service = MagicMock()
+        mock_service.upsert_user_push_token.side_effect = RuntimeError("db down")
+        mock_service_class.return_value = mock_service
+
+        response = client.post(
+            "/api/notifications/register",
+            json={"user_id": "user_123", "token": "fcm_token_123", "platform": "web"},
+            headers={"Authorization": "Bearer firebase-token"},
+        )
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Failed to register token"
+
+
+def test_unregister_push_token_requires_firebase_auth():
+    client = TestClient(_build_app())
+    response = client.request("DELETE", "/api/notifications/unregister")
+
+    assert response.status_code == 401
+
+
+def test_unregister_push_token_defaults_user_id_from_firebase_uid(monkeypatch):
+    client = TestClient(_build_app())
+    monkeypatch.setattr(
+        "api.routes.notifications.verify_firebase_bearer",
+        lambda auth_header: "user_123",
+    )
+
+    with patch("api.routes.notifications.PushTokensService") as mock_service_class:
+        mock_service = MagicMock()
+        mock_service.delete_user_push_tokens.return_value = 2
+        mock_service_class.return_value = mock_service
+
+        response = client.request(
+            "DELETE",
+            "/api/notifications/unregister",
+            headers={"Authorization": "Bearer firebase-token"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True, "user_id": "user_123", "deleted": 2}
+    mock_service.delete_user_push_tokens.assert_called_once_with(user_id="user_123", platform=None)
+
+
+def test_unregister_push_token_forwards_platform(monkeypatch):
+    client = TestClient(_build_app())
+    monkeypatch.setattr(
+        "api.routes.notifications.verify_firebase_bearer",
+        lambda auth_header: "user_123",
+    )
+
+    with patch("api.routes.notifications.PushTokensService") as mock_service_class:
+        mock_service = MagicMock()
+        mock_service.delete_user_push_tokens.return_value = 1
+        mock_service_class.return_value = mock_service
+
+        response = client.request(
+            "DELETE",
+            "/api/notifications/unregister",
+            json={"platform": "ios"},
+            headers={"Authorization": "Bearer firebase-token"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True, "user_id": "user_123", "deleted": 1}
+    mock_service.delete_user_push_tokens.assert_called_once_with(user_id="user_123", platform="ios")
+
+
+def test_unregister_push_token_rejects_cross_user_unregistration(monkeypatch):
+    client = TestClient(_build_app())
+    monkeypatch.setattr(
+        "api.routes.notifications.verify_firebase_bearer",
+        lambda auth_header: "user_123",
+    )
+
+    response = client.request(
+        "DELETE",
+        "/api/notifications/unregister",
+        json={"user_id": "user_456"},
+        headers={"Authorization": "Bearer firebase-token"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Cannot unregister tokens for another user"
+
+
+def test_unregister_push_token_handles_missing_json_body(monkeypatch):
+    client = TestClient(_build_app())
+    monkeypatch.setattr(
+        "api.routes.notifications.verify_firebase_bearer",
+        lambda auth_header: "user_123",
+    )
+
+    with patch("api.routes.notifications.PushTokensService") as mock_service_class:
+        mock_service = MagicMock()
+        mock_service.delete_user_push_tokens.return_value = 3
+        mock_service_class.return_value = mock_service
+
+        response = client.request(
+            "DELETE",
+            "/api/notifications/unregister",
+            content="{invalid json",
+            headers={"Authorization": "Bearer firebase-token"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True, "user_id": "user_123", "deleted": 3}
+    mock_service.delete_user_push_tokens.assert_called_once_with(user_id="user_123", platform=None)
+
+
+def test_unregister_push_token_maps_service_failure_to_500(monkeypatch):
+    client = TestClient(_build_app())
+    monkeypatch.setattr(
+        "api.routes.notifications.verify_firebase_bearer",
+        lambda auth_header: "user_123",
+    )
+
+    with patch("api.routes.notifications.PushTokensService") as mock_service_class:
+        mock_service = MagicMock()
+        mock_service.delete_user_push_tokens.side_effect = RuntimeError("db down")
+        mock_service_class.return_value = mock_service
+
+        response = client.request(
+            "DELETE",
+            "/api/notifications/unregister",
+            json={"platform": "web"},
+            headers={"Authorization": "Bearer firebase-token"},
+        )
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Failed to unregister token(s)"


### PR DESCRIPTION
# Description

Adds route-level unit tests for the consent-protocol account and notifications APIs. These tests cover authentication requirements, request validation, service wiring, and error handling using the same FastAPI `TestClient` pattern already used in the repository.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below:

  - `/api/account/identity/refresh`
  - `/api/account/delete`
  - `/api/account/export`
  - `/api/notifications/register`
  - `/api/notifications/unregister`

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None

- Docs updated (exact files):
  - [x] None

## 🛑 Tri-Flow Architecture Check

_Every feature must be implemented across all three layers or explicitly marked as not applicable._

- [x] **Web**: Not applicable
- [x] **iOS**: Not applicable
- [x] **Android**: Not applicable

## 🧪 Testing

- [x] Tested on Web (backend route tests via FastAPI `TestClient`)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Not applicable for backend unit test changes.

## 🛡️ Privacy & Consent

- [ ] Does this change access user data?
- [x] If yes, have you implemented `checkConsentToken()`?

This PR adds test coverage only and does not change runtime data access behavior.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed

Closes #549 