### PR TITLE
fix(ria): gate onboarding by CRD verification

### DIFF
--- a/.codex/skills/kai-test-account-reset/SKILL.md
+++ b/.codex/skills/kai-test-account-reset/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: kai-test-account-reset
+description: Use when resetting a Kai/UAT test account by email for end-to-end onboarding, vault, RIA, consent, or profile retesting.
+---
+
+# Kai Test Account Reset Skill
+
+## Purpose and Trigger
+
+- Primary scope: `kai-test-account-reset`
+- Trigger on requests to delete or reset a Kai test user, especially when the user provides an email and wants to retest onboarding end to end.
+- Avoid overlap with `vault-pkm-governance`, `iam-consent-governance`, and `repo-operations`.
+
+## Coverage and Ownership
+
+- Role: `spoke`
+- Owner family: `security-audit`
+
+Owned repo surfaces:
+
+1. `.codex/skills/kai-test-account-reset`
+
+Non-owned surfaces:
+
+1. `security-audit`
+2. `vault-pkm-governance`
+3. `iam-consent-governance`
+4. `repo-operations`
+5. `backend`
+
+## Do Use
+
+1. UAT/local test-account resets where the email is explicitly supplied by the user.
+2. Dry-run discovery of Firebase UID shadows, actor profile rows, vault/PKM/RIA/consent rows, and email-linked developer/invite rows.
+3. Operator-side cleanup that must remain separate from the user-facing account deletion UI.
+
+## Do Not Use
+
+1. Production account deletion.
+2. Deleting accounts without an explicit user-authored email and action-time confirmation.
+3. Bypassing the in-app `profile.delete_account` vault-owner flow for normal user-initiated deletion.
+4. Firebase Auth account deletion or browser-local storage deletion unless explicitly scoped and confirmed.
+
+## Read First
+
+1. `consent-protocol/api/routes/account.py`
+2. `consent-protocol/hushh_mcp/services/account_service.py`
+3. `docs/reference/kai/kai-action-gateway-vnext.md`
+
+## Workflow
+
+1. Run a dry run first:
+   ```bash
+   consent-protocol/.venv/bin/python .codex/skills/kai-test-account-reset/scripts/reset_kai_test_account.py --email <email>
+   ```
+2. Report the matched UID preview and planned cleanup scope without printing secrets.
+   Add `--include-counts` only when row counts are needed; it can be slow on large UAT tables.
+3. Ask for action-time confirmation before deletion, naming the email, environment, and data classes.
+4. Execute only after confirmation:
+   ```bash
+   consent-protocol/.venv/bin/python .codex/skills/kai-test-account-reset/scripts/reset_kai_test_account.py --email <email> --execute --confirm-email <email>
+   ```
+5. Re-run the dry run to verify there are no DB rows left for the email/UID.
+6. Keep Firebase Auth and browser-local state separate unless the user explicitly asks for those deletions too.
+
+## Handoff Rules
+
+1. Route schema or account-deletion-service gaps to `iam-consent-governance` or `vault-pkm-governance`.
+2. Route backend runtime/proxy failures to `repo-operations`.
+3. Route user-facing Kai voice/search action changes to `kai-voice-governance`.
+
+## Required Checks
+
+```bash
+consent-protocol/.venv/bin/python .codex/skills/kai-test-account-reset/scripts/reset_kai_test_account.py --email ankit@hushh.ai
+consent-protocol/.venv/bin/python -m py_compile .codex/skills/kai-test-account-reset/scripts/reset_kai_test_account.py
+python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py
+```

--- a/.codex/skills/kai-test-account-reset/scripts/reset_kai_test_account.py
+++ b/.codex/skills/kai-test-account-reset/scripts/reset_kai_test_account.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env python3
+"""Dry-run and execute a guarded Kai/UAT test-account reset by email.
+
+This tool intentionally does not delete Firebase Auth users or browser-local
+state. It cleans backend database state for a supplied email/user id so local
+and UAT onboarding flows can be retested.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CONSENT_ROOT = REPO_ROOT / "consent-protocol"
+if str(CONSENT_ROOT) not in sys.path:
+    sys.path.insert(0, str(CONSENT_ROOT))
+
+from dotenv import load_dotenv  # noqa: E402
+
+
+EMAIL_LINK_TABLES: dict[str, tuple[str, ...]] = {
+    "actor_identity_cache": ("email",),
+    "developer_apps": ("owner_email", "contact_email"),
+    "developer_applications": ("contact_email",),
+    "ria_client_invites": ("target_email",),
+}
+
+UID_DISCOVERY_TABLES: dict[str, tuple[str, ...]] = {
+    "actor_identity_cache": ("user_id",),
+    "developer_apps": ("owner_firebase_uid",),
+    "ria_client_invites": ("target_investor_user_id", "accepted_by_user_id"),
+}
+
+RESIDUAL_USER_TABLES: dict[str, tuple[str, ...]] = {
+    "actor_identity_cache": ("user_id",),
+    "actor_profiles": ("user_id",),
+    "runtime_persona_state": ("user_id",),
+    "vault_keys": ("user_id",),
+    "vault_key_wrappers": ("user_id",),
+    "pkm_data": ("user_id",),
+    "pkm_index": ("user_id",),
+    "pkm_blobs": ("user_id",),
+    "pkm_manifests": ("user_id",),
+    "pkm_manifest_paths": ("user_id",),
+    "pkm_scope_registry": ("user_id",),
+    "pkm_events": ("user_id",),
+    "pkm_migration_state": ("user_id",),
+    "pkm_upgrade_runs": ("user_id",),
+    "kai_plaid_items": ("user_id",),
+    "kai_plaid_refresh_runs": ("user_id",),
+    "kai_plaid_link_sessions": ("user_id",),
+    "kai_plaid_user_profile_cache": ("user_id",),
+    "kai_alpaca_connect_sessions": ("user_id",),
+    "kai_alpaca_accounts": ("user_id",),
+    "kai_alpaca_positions": ("user_id",),
+    "kai_funding_trade_intents": ("user_id",),
+    "kai_funding_trade_events": ("user_id",),
+    "kai_receipt_memory_artifacts": ("user_id",),
+    "gmail_watch_history": ("user_id",),
+    "gmail_receipt_sync_runs": ("user_id",),
+    "gmail_receipts": ("user_id",),
+    "consent_audit": ("user_id",),
+    "internal_access_events": ("user_id",),
+    "user_push_tokens": ("user_id",),
+    "consent_exports": ("user_id",),
+    "consent_export_refresh_jobs": ("user_id",),
+    "ria_profiles": ("user_id",),
+    "ria_firm_memberships": ("user_id",),
+    "ria_verification_events": ("user_id",),
+    "marketplace_public_profiles": ("user_id",),
+    "advisor_investor_relationships": ("advisor_user_id", "investor_user_id"),
+    "relationship_share_grants": ("provider_user_id", "receiver_user_id"),
+    "relationship_share_grant_audit": ("provider_user_id", "receiver_user_id"),
+    "ria_client_invites": ("target_investor_user_id", "accepted_by_user_id"),
+    "ria_pick_lists": ("uploaded_by_user_id",),
+    "ria_pick_uploads": ("uploaded_by_user_id",),
+    "ria_pick_share_artifacts": ("provider_user_id", "receiver_user_id"),
+    "developer_apps": ("owner_firebase_uid",),
+}
+
+def _preview(value: str) -> str:
+    return f"{value[:8]}..." if value else ""
+
+
+def _quote_ident(value: str) -> str:
+    return '"' + value.replace('"', '""') + '"'
+
+
+def _load_env() -> None:
+    load_dotenv(CONSENT_ROOT / ".env")
+
+
+def _db_kwargs() -> dict[str, Any]:
+    return {
+        "host": os.getenv("DB_HOST"),
+        "port": int(os.getenv("DB_PORT", "5432")),
+        "database": os.getenv("DB_NAME"),
+        "user": os.getenv("DB_USER"),
+        "password": os.getenv("DB_PASSWORD"),
+    }
+
+
+async def _connect():
+    import asyncpg
+
+    return await asyncpg.connect(**_db_kwargs())
+
+
+async def _table_exists(conn: Any, table: str) -> bool:
+    return bool(await conn.fetchval("SELECT to_regclass($1) IS NOT NULL", f"public.{table}"))
+
+
+async def _existing_columns(conn: Any, table: str, columns: tuple[str, ...]) -> list[str]:
+    rows = await conn.fetch(
+        """
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = $1
+          AND column_name = ANY($2::text[])
+        """,
+        table,
+        list(columns),
+    )
+    found = {row["column_name"] for row in rows}
+    return [column for column in columns if column in found]
+
+
+async def _discover_user_ids(conn: Any, email: str, supplied_user_ids: list[str]) -> tuple[list[str], list[dict[str, Any]]]:
+    user_ids = {uid.strip() for uid in supplied_user_ids if uid.strip()}
+    hits: list[dict[str, Any]] = []
+    for table, email_columns in EMAIL_LINK_TABLES.items():
+        if not await _table_exists(conn, table):
+            continue
+        existing_email_columns = await _existing_columns(conn, table, email_columns)
+        existing_uid_columns = await _existing_columns(conn, table, UID_DISCOVERY_TABLES.get(table, ()))
+        for email_column in existing_email_columns:
+            uid_select = ", ".join(
+                f"array_remove(array_agg(DISTINCT {_quote_ident(column)}), NULL) AS {_quote_ident(column)}"
+                for column in existing_uid_columns
+            )
+            query = (
+                f"SELECT count(*) AS rows"
+                f"{', ' + uid_select if uid_select else ''} "
+                f"FROM {_quote_ident(table)} "
+                f"WHERE lower({_quote_ident(email_column)}) = lower($1)"
+            )
+            row = await conn.fetchrow(query, email)
+            row_count = int(row["rows"] or 0)
+            if row_count <= 0:
+                continue
+            hit: dict[str, Any] = {
+                "table": table,
+                "email_column": email_column,
+                "rows": row_count,
+                "user_id_columns": {},
+            }
+            for uid_column in existing_uid_columns:
+                values = [value for value in (row[uid_column] or []) if value]
+                if values:
+                    user_ids.update(values)
+                    hit["user_id_columns"][uid_column] = [_preview(value) for value in values]
+            hits.append(hit)
+    return sorted(user_ids), hits
+
+
+async def _discover_dynamic_link_columns(conn: Any, *, kind: str) -> dict[str, tuple[str, ...]]:
+    _ = conn
+    if kind == "email":
+        return EMAIL_LINK_TABLES
+    elif kind == "user_id":
+        merged: dict[str, tuple[str, ...]] = dict(RESIDUAL_USER_TABLES)
+        for table, columns in UID_DISCOVERY_TABLES.items():
+            merged[table] = tuple(dict.fromkeys((*merged.get(table, ()), *columns)))
+        return merged
+    else:
+        raise ValueError(f"Unsupported link column kind: {kind}")
+
+
+async def _count_linked_rows(
+    conn: Any,
+    linked_columns: dict[str, tuple[str, ...]],
+    values: list[str],
+    *,
+    kind: str,
+) -> list[dict[str, Any]]:
+    if not values:
+        return []
+    results: list[dict[str, Any]] = []
+    for table, columns in linked_columns.items():
+        if not columns or not await _table_exists(conn, table):
+            continue
+        existing = await _existing_columns(conn, table, columns)
+        if not existing:
+            continue
+        try:
+            if kind == "email":
+                where = " OR ".join(f"lower({_quote_ident(column)}::text) = lower($1)" for column in existing)
+                row_count = await conn.fetchval(f"SELECT count(*) FROM {_quote_ident(table)} WHERE {where}", values[0])
+            elif kind == "user_id":
+                where = " OR ".join(f"{_quote_ident(column)} = ANY($1::text[])" for column in existing)
+                row_count = await conn.fetchval(f"SELECT count(*) FROM {_quote_ident(table)} WHERE {where}", values)
+            else:
+                raise ValueError(f"Unsupported linked row count kind: {kind}")
+        except Exception as exc:  # noqa: BLE001
+            results.append({"table": table, "columns": existing, "rows": None, "error": str(exc).splitlines()[0]})
+            continue
+        if int(row_count or 0) > 0:
+            results.append({"table": table, "columns": existing, "rows": int(row_count)})
+    return results
+
+
+async def _delete_linked_rows(
+    conn: Any,
+    linked_columns: dict[str, tuple[str, ...]],
+    values: list[str],
+    *,
+    kind: str,
+) -> list[dict[str, Any]]:
+    if not values:
+        return []
+    results: list[dict[str, Any]] = []
+    for table, columns in linked_columns.items():
+        if not columns or not await _table_exists(conn, table):
+            continue
+        existing = await _existing_columns(conn, table, columns)
+        if not existing:
+            continue
+        if kind == "email":
+            where = " OR ".join(f"lower({_quote_ident(column)}::text) = lower($1)" for column in existing)
+            command = f"DELETE FROM {_quote_ident(table)} WHERE {where}"
+            args: tuple[Any, ...] = (values[0],)
+        elif kind == "user_id":
+            where = " OR ".join(f"{_quote_ident(column)} = ANY($1::text[])" for column in existing)
+            command = f"DELETE FROM {_quote_ident(table)} WHERE {where}"
+            args = (values,)
+        else:
+            raise ValueError(f"Unsupported linked row delete kind: {kind}")
+        try:
+            status = await conn.execute(command, *args)
+        except Exception as exc:  # noqa: BLE001
+            results.append({"table": table, "by": kind, "columns": existing, "error": str(exc).splitlines()[0]})
+            continue
+        if status != "DELETE 0":
+            results.append({"table": table, "by": kind, "columns": existing, "status": status})
+    return results
+
+
+async def _delete_by_email(conn: Any, email: str) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for table, columns in EMAIL_LINK_TABLES.items():
+        if not await _table_exists(conn, table):
+            continue
+        existing = await _existing_columns(conn, table, columns)
+        if not existing:
+            continue
+        where = " OR ".join(f"lower({_quote_ident(column)}) = lower($1)" for column in existing)
+        command = f"DELETE FROM {_quote_ident(table)} WHERE {where}"
+        status = await conn.execute(command, email)
+        results.append({"table": table, "by": "email", "status": status})
+    return results
+
+
+async def _delete_residual_user_rows(conn: Any, user_ids: list[str]) -> list[dict[str, Any]]:
+    if not user_ids:
+        return []
+    results: list[dict[str, Any]] = []
+    # Several tables cascade from vault_keys/actor_profiles. This residual sweep
+    # is intentionally best-effort and runs after AccountService deletion.
+    for _ in range(3):
+        changed = False
+        for table, columns in RESIDUAL_USER_TABLES.items():
+            if not await _table_exists(conn, table):
+                continue
+            existing = await _existing_columns(conn, table, columns)
+            if not existing:
+                continue
+            where = " OR ".join(f"{_quote_ident(column)} = ANY($1::text[])" for column in existing)
+            try:
+                status = await conn.execute(f"DELETE FROM {_quote_ident(table)} WHERE {where}", user_ids)
+            except Exception as exc:  # noqa: BLE001
+                results.append({"table": table, "by": "user_id", "error": str(exc).splitlines()[0]})
+                continue
+            if status != "DELETE 0":
+                changed = True
+                results.append({"table": table, "by": "user_id", "status": status})
+        if not changed:
+            break
+    return results
+
+
+async def _run_account_service_delete(user_ids: list[str]) -> list[dict[str, Any]]:
+    from hushh_mcp.services.account_service import AccountService
+
+    service = AccountService()
+    results: list[dict[str, Any]] = []
+    for user_id in user_ids:
+        result = await service.delete_account(user_id, target="both")
+        results.append(
+            {
+                "user_id_preview": _preview(user_id),
+                "success": bool(result.get("success")),
+                "deleted_target": result.get("deleted_target"),
+                "account_deleted": result.get("account_deleted"),
+                "error": result.get("error"),
+                "details": result.get("details"),
+            }
+        )
+    return results
+
+
+async def run(args: argparse.Namespace) -> dict[str, Any]:
+    _load_env()
+    conn = await _connect()
+    try:
+        await conn.execute("SET statement_timeout = '1000ms'")
+        user_ids, email_hits = await _discover_user_ids(conn, args.email, args.user_id or [])
+        dynamic_user_columns = await _discover_dynamic_link_columns(conn, kind="user_id")
+        dynamic_email_columns = await _discover_dynamic_link_columns(conn, kind="email")
+        if args.execute or not args.include_counts:
+            user_id_row_counts = []
+            email_row_counts = []
+        else:
+            user_id_row_counts = await _count_linked_rows(
+                conn,
+                dynamic_user_columns,
+                user_ids,
+                kind="user_id",
+            )
+            email_row_counts = await _count_linked_rows(
+                conn,
+                dynamic_email_columns,
+                [args.email],
+                kind="email",
+            )
+        payload: dict[str, Any] = {
+            "mode": "execute" if args.execute else "dry_run",
+            "email": args.email,
+            "matched_user_ids_preview": [_preview(user_id) for user_id in user_ids],
+            "matched_user_ids_count": len(user_ids),
+            "email_hits": email_hits,
+            "linked_user_id_row_counts": user_id_row_counts,
+            "linked_email_row_counts": email_row_counts,
+            "firebase_auth_deleted": False,
+            "browser_local_state_deleted": False,
+            "row_counts_included": bool(args.include_counts and not args.execute),
+        }
+        if not args.execute:
+            payload["planned_operations"] = [
+                "AccountService.delete_account(target='both') for each matched user_id",
+                "Best-effort residual cleanup for known user_id columns",
+                "Bounded cleanup for app-owned user_id and firebase_uid columns",
+                "Email-linked cleanup for actor_identity_cache, developer apps/applications, and RIA invites",
+            ]
+            payload["execute_command"] = (
+                f"{sys.executable} .codex/skills/kai-test-account-reset/scripts/reset_kai_test_account.py "
+                f"--email {args.email} --execute --confirm-email {args.email}"
+            )
+            return payload
+        if args.confirm_email != args.email:
+            raise SystemExit("--execute requires --confirm-email with the exact email value.")
+    finally:
+        await conn.close()
+
+    account_results = await _run_account_service_delete(user_ids)
+    conn = await _connect()
+    try:
+        await conn.execute("SET statement_timeout = '5000ms'")
+        residual_results = await _delete_residual_user_rows(conn, user_ids)
+        email_results = await _delete_by_email(conn, args.email)
+        dynamic_user_columns = await _discover_dynamic_link_columns(conn, kind="user_id")
+        dynamic_email_columns = await _discover_dynamic_link_columns(conn, kind="email")
+        dynamic_user_results = await _delete_linked_rows(
+            conn,
+            dynamic_user_columns,
+            user_ids,
+            kind="user_id",
+        )
+        dynamic_email_results = await _delete_linked_rows(
+            conn,
+            dynamic_email_columns,
+            [args.email],
+            kind="email",
+        )
+        remaining_user_id_row_counts = await _count_linked_rows(
+            conn,
+            dynamic_user_columns,
+            user_ids,
+            kind="user_id",
+        )
+        remaining_email_row_counts = await _count_linked_rows(
+            conn,
+            dynamic_email_columns,
+            [args.email],
+            kind="email",
+        )
+    finally:
+        await conn.close()
+
+    return {
+        "mode": "execute",
+        "email": args.email,
+        "matched_user_ids_preview": [_preview(user_id) for user_id in user_ids],
+        "matched_user_ids_count": len(user_ids),
+        "account_service_results": account_results,
+        "residual_results": residual_results,
+        "email_cleanup_results": email_results,
+        "dynamic_user_id_cleanup_results": dynamic_user_results,
+        "dynamic_email_cleanup_results": dynamic_email_results,
+        "remaining_user_id_row_counts": remaining_user_id_row_counts,
+        "remaining_email_row_counts": remaining_email_row_counts,
+        "firebase_auth_deleted": False,
+        "browser_local_state_deleted": False,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--email", required=True, help="User-authored email to reset.")
+    parser.add_argument("--user-id", action="append", default=[], help="Optional explicit Firebase UID.")
+    parser.add_argument("--include-counts", action="store_true", help="Include bounded row counts. Can be slow on large UAT tables.")
+    parser.add_argument("--execute", action="store_true", help="Perform deletion. Omit for dry run.")
+    parser.add_argument("--confirm-email", default="", help="Required with --execute; must equal --email.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    result = asyncio.run(run(parse_args()))
+    print(json.dumps(result, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/.codex/skills/kai-test-account-reset/skill.json
+++ b/.codex/skills/kai-test-account-reset/skill.json
@@ -1,0 +1,64 @@
+{
+  "id": "kai-test-account-reset",
+  "role": "spoke",
+  "owner_family": "security-audit",
+  "primary_scope": "kai-test-account-reset",
+  "description": "Use when resetting a Kai/UAT test account by email for end-to-end onboarding, vault, RIA, consent, or profile retesting.",
+  "owned_paths": [
+    ".codex/skills/kai-test-account-reset"
+  ],
+  "non_owned_paths": [
+    "security-audit",
+    "vault-pkm-governance",
+    "iam-consent-governance",
+    "repo-operations",
+    "backend"
+  ],
+  "task_types": [
+    "security-consent-audit"
+  ],
+  "required_reads": [
+    "consent-protocol/api/routes/account.py",
+    "consent-protocol/hushh_mcp/services/account_service.py",
+    "docs/reference/kai/kai-action-gateway-vnext.md"
+  ],
+  "required_commands": [
+    "consent-protocol/.venv/bin/python .codex/skills/kai-test-account-reset/scripts/reset_kai_test_account.py --email ankit@hushh.ai",
+    "consent-protocol/.venv/bin/python -m py_compile .codex/skills/kai-test-account-reset/scripts/reset_kai_test_account.py",
+    "python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py"
+  ],
+  "verification_bundles": [
+    {
+      "id": "kai-test-account-reset",
+      "commands": [
+        "consent-protocol/.venv/bin/python .codex/skills/kai-test-account-reset/scripts/reset_kai_test_account.py --email ankit@hushh.ai",
+        "consent-protocol/.venv/bin/python -m py_compile .codex/skills/kai-test-account-reset/scripts/reset_kai_test_account.py",
+        "python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py"
+      ],
+      "tests": [
+        "consent-protocol/.venv/bin/python .codex/skills/kai-test-account-reset/scripts/reset_kai_test_account.py --email ankit@hushh.ai",
+        "consent-protocol/.venv/bin/python -m py_compile .codex/skills/kai-test-account-reset/scripts/reset_kai_test_account.py"
+      ]
+    }
+  ],
+  "handoff_targets": [
+    "security-audit",
+    "vault-pkm-governance",
+    "iam-consent-governance",
+    "repo-operations",
+    "kai-voice-governance"
+  ],
+  "adjacent_skills": [
+    "security-audit",
+    "vault-pkm-governance",
+    "iam-consent-governance",
+    "repo-operations",
+    "kai-voice-governance"
+  ],
+  "risk_tags": [
+    "destructive-data-delete",
+    "uat-test-account-reset",
+    "vault-pkm-cleanup",
+    "iam-consent-cleanup"
+  ]
+}

--- a/consent-protocol/api/routes/ria.py
+++ b/consent-protocol/api/routes/ria.py
@@ -53,6 +53,7 @@ class RIAOnboardingSubmitRequest(BaseModel):
 
 class RIAOnboardingVerifyNameRequest(BaseModel):
     query: str = Field(..., min_length=1)
+    crd_number: str | None = None
 
 
 class RIAConsentRequestCreate(BaseModel):
@@ -206,7 +207,7 @@ async def verify_onboarding_name(
     service = RIAIAMService()
     try:
         _ = firebase_uid
-        return await service.verify_ria_name(payload.query)
+        return await service.verify_ria_name(payload.query, crd_number=payload.crd_number)
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 

--- a/consent-protocol/hushh_mcp/services/account_service.py
+++ b/consent-protocol/hushh_mcp/services/account_service.py
@@ -31,10 +31,82 @@ class AccountService:
         self._supabase = None
         self._table_exists_cache: dict[str, bool] = {}
         self._delete_by_user_queries = {
+            "actor_identity_cache": text(
+                "DELETE FROM actor_identity_cache WHERE user_id = :user_id"
+            ),
+            "actor_profiles": text("DELETE FROM actor_profiles WHERE user_id = :user_id"),
+            "consent_export_refresh_jobs": text(
+                "DELETE FROM consent_export_refresh_jobs WHERE user_id = :user_id"
+            ),
+            "consent_exports": text("DELETE FROM consent_exports WHERE user_id = :user_id"),
+            "internal_access_events": text(
+                "DELETE FROM internal_access_events WHERE user_id = :user_id"
+            ),
+            "kai_funding_ach_relationships": text(
+                "DELETE FROM kai_funding_ach_relationships WHERE user_id = :user_id"
+            ),
+            "kai_funding_alpaca_connect_sessions": text(
+                "DELETE FROM kai_funding_alpaca_connect_sessions WHERE user_id = :user_id"
+            ),
+            "kai_funding_brokerage_accounts": text(
+                "DELETE FROM kai_funding_brokerage_accounts WHERE user_id = :user_id"
+            ),
+            "kai_funding_consent_records": text(
+                "DELETE FROM kai_funding_consent_records WHERE user_id = :user_id"
+            ),
+            "kai_funding_plaid_accounts": text(
+                "DELETE FROM kai_funding_plaid_accounts WHERE user_id = :user_id"
+            ),
+            "kai_funding_plaid_items": text(
+                "DELETE FROM kai_funding_plaid_items WHERE user_id = :user_id"
+            ),
+            "kai_funding_reconciliation_runs": text(
+                "DELETE FROM kai_funding_reconciliation_runs WHERE user_id = :user_id"
+            ),
+            "kai_funding_support_escalations": text(
+                "DELETE FROM kai_funding_support_escalations WHERE user_id = :user_id"
+            ),
+            "kai_funding_trade_events": text(
+                "DELETE FROM kai_funding_trade_events WHERE user_id = :user_id"
+            ),
+            "kai_funding_trade_intents": text(
+                "DELETE FROM kai_funding_trade_intents WHERE user_id = :user_id"
+            ),
+            "kai_funding_transfer_events": text(
+                "DELETE FROM kai_funding_transfer_events WHERE user_id = :user_id"
+            ),
+            "kai_funding_transfers": text(
+                "DELETE FROM kai_funding_transfers WHERE user_id = :user_id"
+            ),
+            "kai_gmail_connections": text(
+                "DELETE FROM kai_gmail_connections WHERE user_id = :user_id"
+            ),
+            "kai_gmail_receipts": text("DELETE FROM kai_gmail_receipts WHERE user_id = :user_id"),
+            "kai_gmail_sync_runs": text("DELETE FROM kai_gmail_sync_runs WHERE user_id = :user_id"),
+            "kai_portfolio_source_preferences": text(
+                "DELETE FROM kai_portfolio_source_preferences WHERE user_id = :user_id"
+            ),
+            "kai_plaid_link_sessions": text(
+                "DELETE FROM kai_plaid_link_sessions WHERE user_id = :user_id"
+            ),
+            "kai_plaid_refresh_runs": text(
+                "DELETE FROM kai_plaid_refresh_runs WHERE user_id = :user_id"
+            ),
+            "marketplace_public_profiles": text(
+                "DELETE FROM marketplace_public_profiles WHERE user_id = :user_id"
+            ),
             "pkm_data": text("DELETE FROM pkm_data WHERE user_id = :user_id"),
+            "pkm_upgrade_runs": text("DELETE FROM pkm_upgrade_runs WHERE user_id = :user_id"),
             "kai_plaid_user_profile_cache": text(
                 "DELETE FROM kai_plaid_user_profile_cache WHERE user_id = :user_id"
             ),
+            "kai_receipt_memory_artifacts": text(
+                "DELETE FROM kai_receipt_memory_artifacts WHERE user_id = :user_id"
+            ),
+            "runtime_persona_state": text(
+                "DELETE FROM runtime_persona_state WHERE user_id = :user_id"
+            ),
+            "user_push_tokens": text("DELETE FROM user_push_tokens WHERE user_id = :user_id"),
         }
         self._safe_export_queries = {
             "actor_profile": text(
@@ -170,6 +242,18 @@ class AccountService:
             raise ValueError(f"Unsafe or unsupported cleanup table requested: {table_name}")
         conn.execute(query, params)
 
+    def _delete_optional_user_tables(
+        self,
+        conn,
+        *,
+        table_names: list[str],
+        params: dict[str, Any],
+        results: dict[str, bool],
+    ) -> None:
+        for table_name in table_names:
+            self._delete_user_rows_if_table_exists(conn, table_name=table_name, params=params)
+            results[table_name] = True
+
     async def delete_account(
         self,
         user_id: str,
@@ -225,6 +309,8 @@ class AccountService:
     ) -> Dict[str, Any]:
         logger.warning("🚨 FULL ACCOUNT DELETION requested for %s", user_id)
         results = {
+            "actor_identity_cache": False,
+            "actor_profiles": False,
             "pkm_data": False,
             "pkm_index": False,
             "pkm_blobs": False,
@@ -232,20 +318,74 @@ class AccountService:
             "pkm_manifest_paths": False,
             "pkm_scope_registry": False,
             "pkm_events": False,
+            "pkm_upgrade_runs": False,
             "plaid_items": False,
             "plaid_refresh_runs": False,
             "plaid_link_sessions": False,
             "plaid_profile_cache": False,
+            "kai_portfolio_source_preferences": False,
+            "kai_gmail_connections": False,
+            "kai_gmail_receipts": False,
+            "kai_gmail_sync_runs": False,
+            "kai_receipt_memory_artifacts": False,
+            "kai_funding_trade_events": False,
+            "kai_funding_trade_intents": False,
+            "kai_funding_transfer_events": False,
+            "kai_funding_support_escalations": False,
+            "kai_funding_transfers": False,
+            "kai_funding_ach_relationships": False,
+            "kai_funding_consent_records": False,
+            "kai_funding_plaid_accounts": False,
+            "kai_funding_plaid_items": False,
+            "kai_funding_brokerage_accounts": False,
+            "kai_funding_alpaca_connect_sessions": False,
+            "kai_funding_reconciliation_runs": False,
+            "consent_exports": False,
+            "consent_export_refresh_jobs": False,
             "consent_audit": False,
             "internal_access_events": False,
             "push_tokens": False,
             "invite_links": False,
+            "relationships": False,
+            "relationship_share_events": False,
+            "relationship_share_grants": False,
+            "ria_pick_share_artifacts": False,
+            "ria_pick_uploads": False,
+            "marketplace_profile": False,
+            "runtime_persona_state": False,
             "vault_keys": False,
         }
 
         try:
             with get_db_connection() as conn:
                 params = {"user_id": user_id}
+                self._delete_optional_user_tables(
+                    conn,
+                    table_names=[
+                        "kai_funding_trade_events",
+                        "kai_funding_trade_intents",
+                        "kai_funding_transfer_events",
+                        "kai_funding_support_escalations",
+                        "kai_funding_transfers",
+                        "kai_funding_ach_relationships",
+                        "kai_funding_consent_records",
+                        "kai_funding_plaid_accounts",
+                        "kai_funding_plaid_items",
+                        "kai_funding_brokerage_accounts",
+                        "kai_funding_alpaca_connect_sessions",
+                        "kai_funding_reconciliation_runs",
+                        "kai_gmail_receipts",
+                        "kai_gmail_sync_runs",
+                        "kai_gmail_connections",
+                        "kai_receipt_memory_artifacts",
+                        "kai_portfolio_source_preferences",
+                        "consent_export_refresh_jobs",
+                        "consent_exports",
+                        "pkm_upgrade_runs",
+                    ],
+                    params=params,
+                    results=results,
+                )
                 conn.execute(
                     text("DELETE FROM kai_plaid_refresh_runs WHERE user_id = :user_id"), params
                 )
@@ -291,15 +431,116 @@ class AccountService:
                     params,
                 )
                 results["invite_links"] = True
+
+                if self._table_exists(conn, "relationship_share_events"):
+                    conn.execute(
+                        text(
+                            """
+                            DELETE FROM relationship_share_events
+                            WHERE provider_user_id = :user_id
+                               OR receiver_user_id = :user_id
+                            """
+                        ),
+                        params,
+                    )
+                results["relationship_share_events"] = True
+                if self._table_exists(conn, "relationship_share_grants"):
+                    conn.execute(
+                        text(
+                            """
+                            DELETE FROM relationship_share_grants
+                            WHERE provider_user_id = :user_id
+                               OR receiver_user_id = :user_id
+                            """
+                        ),
+                        params,
+                    )
+                results["relationship_share_grants"] = True
+                if self._table_exists(conn, "ria_pick_share_artifacts"):
+                    conn.execute(
+                        text(
+                            """
+                            DELETE FROM ria_pick_share_artifacts
+                            WHERE provider_user_id = :user_id
+                               OR receiver_user_id = :user_id
+                            """
+                        ),
+                        params,
+                    )
+                results["ria_pick_share_artifacts"] = True
+                if self._table_exists(conn, "ria_pick_uploads"):
+                    if self._table_exists(conn, "ria_profiles"):
+                        conn.execute(
+                            text(
+                                """
+                                DELETE FROM ria_pick_uploads
+                                WHERE uploaded_by_user_id = :user_id
+                                   OR ria_profile_id IN (
+                                     SELECT id FROM ria_profiles WHERE user_id = :user_id
+                                   )
+                                """
+                            ),
+                            params,
+                        )
+                    else:
+                        conn.execute(
+                            text(
+                                "DELETE FROM ria_pick_uploads WHERE uploaded_by_user_id = :user_id"
+                            ),
+                            params,
+                        )
+                results["ria_pick_uploads"] = True
+                if self._table_exists(conn, "advisor_investor_relationships"):
+                    if self._table_exists(conn, "ria_profiles"):
+                        conn.execute(
+                            text(
+                                """
+                                DELETE FROM advisor_investor_relationships
+                                WHERE investor_user_id = :user_id
+                                   OR ria_profile_id IN (
+                                     SELECT id FROM ria_profiles WHERE user_id = :user_id
+                                   )
+                                """
+                            ),
+                            params,
+                        )
+                    else:
+                        conn.execute(
+                            text(
+                                """
+                                DELETE FROM advisor_investor_relationships
+                                WHERE investor_user_id = :user_id
+                                """
+                            ),
+                            params,
+                        )
+                results["relationships"] = True
+                self._delete_user_rows_if_table_exists(
+                    conn, table_name="marketplace_public_profiles", params=params
+                )
+                results["marketplace_profile"] = True
                 conn.execute(text("DELETE FROM consent_audit WHERE user_id = :user_id"), params)
                 results["consent_audit"] = True
-                conn.execute(
-                    text("DELETE FROM internal_access_events WHERE user_id = :user_id"),
-                    params,
+                self._delete_user_rows_if_table_exists(
+                    conn, table_name="internal_access_events", params=params
                 )
                 results["internal_access_events"] = True
-                conn.execute(text("DELETE FROM user_push_tokens WHERE user_id = :user_id"), params)
+                self._delete_user_rows_if_table_exists(
+                    conn, table_name="user_push_tokens", params=params
+                )
                 results["push_tokens"] = True
+                self._delete_user_rows_if_table_exists(
+                    conn, table_name="actor_identity_cache", params=params
+                )
+                results["actor_identity_cache"] = True
+                self._delete_user_rows_if_table_exists(
+                    conn, table_name="runtime_persona_state", params=params
+                )
+                results["runtime_persona_state"] = True
+                self._delete_user_rows_if_table_exists(
+                    conn, table_name="actor_profiles", params=params
+                )
+                results["actor_profiles"] = True
                 conn.execute(text("DELETE FROM vault_keys WHERE user_id = :user_id"), params)
                 results["vault_keys"] = True
 

--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -489,6 +489,10 @@ class RIAIAMService:
         return normalized or None
 
     @staticmethod
+    def _normalize_crd_text(value: str | None) -> str:
+        return "".join(ch for ch in str(value or "") if ch.isdigit())
+
+    @staticmethod
     def _normalize_legacy_verification_status(status: str | None) -> str:
         normalized = (status or "").strip().lower()
         if normalized == "finra_verified":
@@ -642,6 +646,7 @@ class RIAIAMService:
         self,
         query: str,
         *,
+        crd_number: str | None = None,
         use_cache: bool = True,
     ) -> NameVerificationResult:
         normalized_query = str(query or "").strip()
@@ -649,14 +654,16 @@ class RIAIAMService:
             raise RIAIAMPolicyError("query is required", status_code=400)
         return await self._name_verification_gateway.verify_name(
             query=normalized_query,
+            crd_number=crd_number,
             use_cache=use_cache,
         )
 
     async def verify_ria_name(
         self,
         query: str,
+        crd_number: str | None = None,
     ) -> dict[str, Any]:
-        result = await self._verify_ria_name_result(query, use_cache=True)
+        result = await self._verify_ria_name_result(query, crd_number=crd_number, use_cache=True)
         return self._serialize_name_verification_result(result)
 
     @staticmethod
@@ -2229,7 +2236,12 @@ class RIAIAMService:
         )
         normalized_display_name = str(prepared["display_name"])
         normalized_requested_capabilities = list(prepared["requested_capabilities"])
-        name_lookup = await self._verify_ria_name_result(normalized_display_name, use_cache=True)
+        submitted_individual_crd = self._normalize_optional_text(prepared.get("individual_crd"))
+        name_lookup = await self._verify_ria_name_result(
+            normalized_display_name,
+            crd_number=submitted_individual_crd,
+            use_cache=not force_live_verification,
+        )
         if name_lookup.status == "provider_unavailable":
             raise RIAIAMPolicyError(
                 name_lookup.reason or "RIA name verification provider unavailable.",
@@ -2241,6 +2253,14 @@ class RIAIAMService:
             raise RIAIAMPolicyError(
                 name_lookup.reason
                 or "Advisor name could not be verified against a CRD-backed registration.",
+                status_code=400,
+            )
+        if submitted_individual_crd and (
+            self._normalize_crd_text(name_lookup.crd_number)
+            != self._normalize_crd_text(submitted_individual_crd)
+        ):
+            raise RIAIAMPolicyError(
+                "The verified CRD did not match the CRD you entered. Check the CRD or remove it and verify by name.",
                 status_code=400,
             )
 

--- a/consent-protocol/hushh_mcp/services/ria_verification.py
+++ b/consent-protocol/hushh_mcp/services/ria_verification.py
@@ -449,6 +449,7 @@ class RIAIntelligenceStage1LookupAdapter:
         self,
         *,
         query: str,
+        crd_number: str | None = None,
     ) -> tuple[dict[str, Any] | None, NameVerificationResult | None]:
         request_url = self._verify_url or (
             f"{self._base_url}{self._endpoint_path}" if self._base_url else ""
@@ -465,6 +466,12 @@ class RIAIntelligenceStage1LookupAdapter:
         if self._api_key:
             headers["Authorization"] = f"Bearer {self._api_key}"
 
+        context: dict[str, Any] = {"targetName": query}
+        normalized_crd = _normalize_crd(crd_number)
+        if normalized_crd:
+            context["crdNumber"] = normalized_crd
+        request_body: dict[str, Any] = {"query": query, "context": context}
+
         try:
             async with httpx.AsyncClient(
                 timeout=self._timeout_seconds,
@@ -473,7 +480,7 @@ class RIAIntelligenceStage1LookupAdapter:
             ) as client:
                 response = await client.post(
                     request_url,
-                    json={"query": query},
+                    json=request_body,
                 )
         except Exception as exc:  # noqa: BLE001
             logger.warning("ria.intelligence_stage1_request_failed: %s", exc)
@@ -484,7 +491,7 @@ class RIAIntelligenceStage1LookupAdapter:
                 metadata={"provider": self._provider_label, "error": type(exc).__name__},
             )
 
-        if response.status_code >= 500:
+        if response.status_code >= 400:
             return None, NameVerificationResult(
                 status="provider_unavailable",
                 reason="RIA intelligence verification provider unavailable",
@@ -492,7 +499,19 @@ class RIAIntelligenceStage1LookupAdapter:
                 metadata={"provider": self._provider_label, "status_code": response.status_code},
             )
 
-        payload = response.json() if response.content else {}
+        try:
+            payload = response.json() if response.content else {}
+        except Exception as exc:  # noqa: BLE001
+            return None, NameVerificationResult(
+                status="provider_unavailable",
+                reason="RIA intelligence verification returned invalid JSON",
+                provider=self._provider_label,
+                metadata={
+                    "provider": self._provider_label,
+                    "status_code": response.status_code,
+                    "error": type(exc).__name__,
+                },
+            )
         if not isinstance(payload, dict):
             return None, NameVerificationResult(
                 status="provider_unavailable",
@@ -502,8 +521,8 @@ class RIAIntelligenceStage1LookupAdapter:
             )
         return payload, None
 
-    def _cache_key(self, query: str) -> str:
-        return _normalize_identity_text(query)
+    def _cache_key(self, query: str, crd_number: str | None = None) -> str:
+        return f"{_normalize_identity_text(query)}|crd:{_normalize_crd(crd_number)}"
 
     @classmethod
     def _prune_expired_cache(cls, now: datetime) -> None:
@@ -511,19 +530,28 @@ class RIAIntelligenceStage1LookupAdapter:
         for key in expired_keys:
             cls._cache.pop(key, None)
 
-    def _get_cached_result(self, query: str) -> NameVerificationResult | None:
+    def _get_cached_result(
+        self,
+        query: str,
+        crd_number: str | None = None,
+    ) -> NameVerificationResult | None:
         now = datetime.now(timezone.utc)
         self._prune_expired_cache(now)
-        entry = self._cache.get(self._cache_key(query))
+        entry = self._cache.get(self._cache_key(query, crd_number))
         if entry is None or entry.expires_at <= now:
             return None
         return entry.result
 
-    def _store_cached_result(self, query: str, result: NameVerificationResult) -> None:
+    def _store_cached_result(
+        self,
+        query: str,
+        result: NameVerificationResult,
+        crd_number: str | None = None,
+    ) -> None:
         if result.status not in {"verified", "not_verified"} or self._cache_ttl_seconds <= 0:
             return
         self._prune_expired_cache(datetime.now(timezone.utc))
-        self._cache[self._cache_key(query)] = _Stage1LookupCacheEntry(
+        self._cache[self._cache_key(query, crd_number)] = _Stage1LookupCacheEntry(
             expires_at=datetime.now(timezone.utc) + timedelta(seconds=self._cache_ttl_seconds),
             result=result,
         )
@@ -532,9 +560,11 @@ class RIAIntelligenceStage1LookupAdapter:
         self,
         *,
         query: str,
+        crd_number: str | None = None,
         use_cache: bool = True,
     ) -> NameVerificationResult:
         normalized_query = str(query or "").strip()
+        normalized_input_crd = _normalize_crd(crd_number)
         if not normalized_query:
             return NameVerificationResult(
                 status="not_verified",
@@ -545,11 +575,14 @@ class RIAIntelligenceStage1LookupAdapter:
             )
 
         if use_cache:
-            cached = self._get_cached_result(normalized_query)
+            cached = self._get_cached_result(normalized_query, normalized_input_crd)
             if cached is not None:
                 return cached
 
-        payload, error = await self._request_payload(query=normalized_query)
+        payload, error = await self._request_payload(
+            query=normalized_query,
+            crd_number=normalized_input_crd,
+        )
         if error is not None:
             return error
         if payload is None:
@@ -572,7 +605,44 @@ class RIAIntelligenceStage1LookupAdapter:
         source_urls = self._source_urls(payload)
         metadata = {"provider": self._provider_label, "source_urls": source_urls}
 
-        if exists_on_finra and _normalize_crd(crd_number):
+        normalized_result_crd = _normalize_crd(crd_number)
+        if exists_on_finra and not normalized_result_crd:
+            result = NameVerificationResult(
+                status="not_verified",
+                matched_name=matched_name,
+                crd_number=crd_number,
+                current_firm=current_firm,
+                sec_number=sec_number,
+                reason="Verification did not return a CRD-backed advisor record. Onboarding stays blocked.",
+                reason_code="no_confident_match",
+                suggested_names=suggested_names,
+                provider=self._provider_label,
+                metadata={**metadata, "reason_code": "missing_crd"},
+            )
+            self._store_cached_result(normalized_query, result, normalized_input_crd)
+            return result
+
+        if (
+            exists_on_finra
+            and normalized_input_crd
+            and normalized_result_crd != normalized_input_crd
+        ):
+            result = NameVerificationResult(
+                status="not_verified",
+                matched_name=matched_name,
+                crd_number=crd_number,
+                current_firm=current_firm,
+                sec_number=sec_number,
+                reason="The verified CRD did not match the CRD you entered. Check the CRD or remove it and verify by name.",
+                reason_code="no_confident_match",
+                suggested_names=suggested_names,
+                provider=self._provider_label,
+                metadata={**metadata, "reason_code": "crd_mismatch"},
+            )
+            self._store_cached_result(normalized_query, result, normalized_input_crd)
+            return result
+
+        if exists_on_finra and normalized_result_crd:
             result = NameVerificationResult(
                 status="verified",
                 matched_name=matched_name,
@@ -582,7 +652,7 @@ class RIAIntelligenceStage1LookupAdapter:
                 provider=self._provider_label,
                 metadata=metadata,
             )
-            self._store_cached_result(normalized_query, result)
+            self._store_cached_result(normalized_query, result, normalized_input_crd)
             return result
 
         result = NameVerificationResult(
@@ -601,7 +671,7 @@ class RIAIntelligenceStage1LookupAdapter:
                 "suggested_names": suggested_names,
             },
         )
-        self._store_cached_result(normalized_query, result)
+        self._store_cached_result(normalized_query, result, normalized_input_crd)
         return result
 
 

--- a/consent-protocol/tests/services/test_account_service_cleanup_tables.py
+++ b/consent-protocol/tests/services/test_account_service_cleanup_tables.py
@@ -1,8 +1,14 @@
-from unittest.mock import MagicMock
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from hushh_mcp.services.account_service import AccountService
+
+
+@contextmanager
+def _db(conn):
+    yield conn
 
 
 def test_delete_user_rows_if_table_exists_supports_pkm_data(monkeypatch):
@@ -43,6 +49,67 @@ def test_delete_user_rows_if_table_exists_rejects_unsupported_table(monkeypatch)
             table_name="unsafe_table",
             params={"user_id": "user_123"},
         )
+
+
+@pytest.mark.asyncio
+async def test_full_account_deletion_covers_account_owned_tables(monkeypatch):
+    service = AccountService()
+    conn = MagicMock()
+    user_id = "user_delete_123"
+
+    monkeypatch.setattr(service, "_table_exists", lambda _conn, _table: True)
+
+    with patch("hushh_mcp.services.account_service.get_db_connection", return_value=_db(conn)):
+        result = await service._delete_full_account(user_id, requested_target="both")
+
+    assert result["success"] is True
+    assert result["account_deleted"] is True
+
+    executed_sql = "\n".join(str(call.args[0]) for call in conn.execute.call_args_list)
+    expected_fragments = [
+        "DELETE FROM kai_funding_trade_events",
+        "DELETE FROM kai_funding_trade_intents",
+        "DELETE FROM kai_funding_transfer_events",
+        "DELETE FROM kai_funding_transfers",
+        "DELETE FROM kai_funding_ach_relationships",
+        "DELETE FROM kai_funding_plaid_accounts",
+        "DELETE FROM kai_funding_plaid_items",
+        "DELETE FROM kai_funding_brokerage_accounts",
+        "DELETE FROM kai_funding_alpaca_connect_sessions",
+        "DELETE FROM kai_gmail_receipts",
+        "DELETE FROM kai_gmail_sync_runs",
+        "DELETE FROM kai_gmail_connections",
+        "DELETE FROM consent_export_refresh_jobs",
+        "DELETE FROM consent_exports",
+        "DELETE FROM pkm_upgrade_runs",
+        "DELETE FROM kai_receipt_memory_artifacts",
+        "DELETE FROM kai_portfolio_source_preferences",
+        "DELETE FROM relationship_share_events",
+        "DELETE FROM relationship_share_grants",
+        "DELETE FROM ria_pick_share_artifacts",
+        "DELETE FROM ria_pick_uploads",
+        "DELETE FROM advisor_investor_relationships",
+        "DELETE FROM marketplace_public_profiles",
+        "DELETE FROM actor_identity_cache",
+        "DELETE FROM runtime_persona_state",
+        "DELETE FROM actor_profiles",
+        "DELETE FROM vault_keys",
+    ]
+    for fragment in expected_fragments:
+        assert fragment in executed_sql
+
+    assert executed_sql.index("DELETE FROM actor_profiles") < executed_sql.index(
+        "DELETE FROM vault_keys"
+    )
+    assert executed_sql.index("DELETE FROM consent_export_refresh_jobs") < executed_sql.index(
+        "DELETE FROM consent_exports"
+    )
+    assert executed_sql.index("DELETE FROM relationship_share_events") < executed_sql.index(
+        "DELETE FROM relationship_share_grants"
+    )
+    assert executed_sql.index("DELETE FROM relationship_share_grants") < executed_sql.index(
+        "DELETE FROM advisor_investor_relationships"
+    )
 
 
 def test_fetch_optional_many_rows_returns_empty_when_table_missing(monkeypatch):

--- a/consent-protocol/tests/test_ria_iam_routes.py
+++ b/consent-protocol/tests/test_ria_iam_routes.py
@@ -178,8 +178,9 @@ def test_ria_onboarding_submit_maps_professional_capabilities(monkeypatch):
 
 
 def test_ria_name_verification_route_maps_stage1_lookup(monkeypatch):
-    async def _mock_verify_name(self, query: str):
+    async def _mock_verify_name(self, query: str, crd_number: str | None = None):
         assert query == "Ana Roumenova Carter"
+        assert crd_number == "4424794"
         return {
             "status": "verified",
             "matched_name": "Ana Roumenova Carter",
@@ -196,7 +197,7 @@ def test_ria_name_verification_route_maps_stage1_lookup(monkeypatch):
     client = TestClient(_build_app())
     response = client.post(
         "/api/ria/onboarding/verify-name",
-        json={"query": "Ana Roumenova Carter"},
+        json={"query": "Ana Roumenova Carter", "crd_number": "4424794"},
     )
 
     assert response.status_code == 200

--- a/consent-protocol/tests/test_ria_iam_service_architecture.py
+++ b/consent-protocol/tests/test_ria_iam_service_architecture.py
@@ -186,8 +186,14 @@ def test_regulated_runtime_guard_rejects_prod_bypass(monkeypatch):
 async def test_verify_ria_name_serializes_verified_stage1_lookup(monkeypatch):
     service = RIAIAMService()
 
-    async def _mock_lookup(*, query: str, use_cache: bool = True):
+    async def _mock_lookup(
+        *,
+        query: str,
+        crd_number: str | None = None,
+        use_cache: bool = True,
+    ):
         assert query == "Advisor Alpha"
+        assert crd_number is None
         assert use_cache is True
         return NameVerificationResult(
             status="verified",
@@ -211,8 +217,14 @@ async def test_verify_ria_name_serializes_verified_stage1_lookup(monkeypatch):
 async def test_verify_ria_name_serializes_reason_code_for_broad_queries(monkeypatch):
     service = RIAIAMService()
 
-    async def _mock_lookup(*, query: str, use_cache: bool = True):
+    async def _mock_lookup(
+        *,
+        query: str,
+        crd_number: str | None = None,
+        use_cache: bool = True,
+    ):
         assert query == "Andrew G"
+        assert crd_number is None
         assert use_cache is True
         return NameVerificationResult(
             status="not_verified",
@@ -277,9 +289,15 @@ async def test_submit_ria_onboarding_reverifies_stage1_before_granting_access(mo
     async def _fake_runtime_persona(_conn, _user_id, _persona):
         return None
 
-    async def _fake_verify_name_result(query: str, *, use_cache: bool = True):
+    async def _fake_verify_name_result(
+        query: str,
+        *,
+        crd_number: str | None = None,
+        use_cache: bool = True,
+    ):
         assert query == "Advisor Alpha"
-        assert use_cache is True
+        assert crd_number == "12345"
+        assert use_cache is False
         return NameVerificationResult(
             status="verified",
             matched_name="Advisor Alpha",
@@ -299,6 +317,8 @@ async def test_submit_ria_onboarding_reverifies_stage1_before_granting_access(mo
         "user-1",
         display_name="Advisor Alpha",
         requested_capabilities=["advisory"],
+        individual_crd="12345",
+        force_live_verification=True,
         strategy="Long-term planning",
     )
 
@@ -306,6 +326,40 @@ async def test_submit_ria_onboarding_reverifies_stage1_before_granting_access(mo
     assert result["advisory_status"] == "verified"
     assert result["professional_access_granted"] is True
     assert result["individual_crd"] == "12345"
+
+
+@pytest.mark.asyncio
+async def test_submit_ria_onboarding_rejects_entered_crd_mismatch(monkeypatch):
+    service = RIAIAMService()
+
+    async def _fake_verify_name_result(
+        query: str,
+        *,
+        crd_number: str | None = None,
+        use_cache: bool = True,
+    ):
+        assert query == "Advisor Alpha"
+        assert crd_number == "12345"
+        assert use_cache is False
+        return NameVerificationResult(
+            status="verified",
+            matched_name="Advisor Alpha",
+            crd_number="99999",
+            current_firm="Advisor Alpha LLC",
+            sec_number="801-12345",
+            provider="ria_intelligence_stage1",
+        )
+
+    monkeypatch.setattr(service, "_verify_ria_name_result", _fake_verify_name_result)
+
+    with pytest.raises(RIAIAMPolicyError, match="verified CRD did not match"):
+        await service.submit_ria_onboarding(
+            "user-1",
+            display_name="Advisor Alpha",
+            requested_capabilities=["advisory"],
+            individual_crd="12345",
+            force_live_verification=True,
+        )
 
 
 @pytest.mark.asyncio

--- a/consent-protocol/tests/test_ria_verification_intelligence.py
+++ b/consent-protocol/tests/test_ria_verification_intelligence.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import httpx
 import pytest
 
@@ -344,16 +346,90 @@ def test_stage1_lookup_returns_verified_when_crd_present(monkeypatch):
     monkeypatch.setenv("RIA_INTELLIGENCE_VERIFY_BASE_URL", "https://ria-intelligence.example")
     monkeypatch.delenv("RIA_INTELLIGENCE_VERIFY_URL", raising=False)
 
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/ria/profile/stage1"
+        assert request.headers["content-type"] == "application/json"
+        payload = request.read()
+        body = json.loads(payload)
+        assert body == {
+            "query": "Akash Katla",
+            "context": {
+                "targetName": "Akash Katla",
+                "crdNumber": "1234567",
+            },
+        }
+        return httpx.Response(status_code=200, json=_stage1_payload())
+
+    adapter = RIAIntelligenceStage1LookupAdapter(transport=httpx.MockTransport(handler))
+    result = _run(adapter.verify_name(query="Akash Katla", crd_number="123-4567"))
+
+    assert result.status == "verified"
+    assert result.crd_number == "1234567"
+    assert result.provider == "ria_intelligence_stage1"
+
+
+def test_stage1_lookup_blocks_entered_crd_mismatch(monkeypatch):
+    monkeypatch.setenv("RIA_INTELLIGENCE_VERIFY_BASE_URL", "https://ria-intelligence.example")
+    monkeypatch.delenv("RIA_INTELLIGENCE_VERIFY_URL", raising=False)
+
     adapter = RIAIntelligenceStage1LookupAdapter(
         transport=httpx.MockTransport(
             lambda request: httpx.Response(status_code=200, json=_stage1_payload())
         )
     )
+    result = _run(adapter.verify_name(query="Akash Katla", crd_number="7654321"))
+
+    assert result.status == "not_verified"
+    assert result.reason_code == "no_confident_match"
+    assert "CRD" in (result.reason or "")
+
+
+def test_stage1_lookup_blocks_verified_payload_without_crd(monkeypatch):
+    monkeypatch.setenv("RIA_INTELLIGENCE_VERIFY_BASE_URL", "https://ria-intelligence.example")
+    monkeypatch.delenv("RIA_INTELLIGENCE_VERIFY_URL", raising=False)
+
+    adapter = RIAIntelligenceStage1LookupAdapter(
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(
+                status_code=200,
+                json=_stage1_payload(exists_on_finra=True, crd_number=None),
+            )
+        )
+    )
     result = _run(adapter.verify_name(query="Akash Katla"))
 
-    assert result.status == "verified"
-    assert result.crd_number == "1234567"
-    assert result.provider == "ria_intelligence_stage1"
+    assert result.status == "not_verified"
+    assert "CRD-backed" in (result.reason or "")
+
+
+def test_stage1_lookup_maps_auth_and_rate_limit_failures_to_unavailable(monkeypatch):
+    monkeypatch.setenv("RIA_INTELLIGENCE_VERIFY_BASE_URL", "https://ria-intelligence.example")
+    monkeypatch.delenv("RIA_INTELLIGENCE_VERIFY_URL", raising=False)
+
+    for status_code in (401, 403, 429):
+        adapter = RIAIntelligenceStage1LookupAdapter(
+            transport=httpx.MockTransport(
+                lambda request, code=status_code: httpx.Response(status_code=code)
+            )
+        )
+        result = _run(adapter.verify_name(query=f"Akash Katla {status_code}"))
+        assert result.status == "provider_unavailable"
+        assert result.metadata["status_code"] == status_code
+
+
+def test_stage1_lookup_maps_invalid_json_to_unavailable(monkeypatch):
+    monkeypatch.setenv("RIA_INTELLIGENCE_VERIFY_BASE_URL", "https://ria-intelligence.example")
+    monkeypatch.delenv("RIA_INTELLIGENCE_VERIFY_URL", raising=False)
+
+    adapter = RIAIntelligenceStage1LookupAdapter(
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(status_code=200, content=b"not-json")
+        )
+    )
+    result = _run(adapter.verify_name(query="Akash Katla"))
+
+    assert result.status == "provider_unavailable"
+    assert "invalid JSON" in (result.reason or "")
 
 
 def test_stage1_lookup_returns_not_verified_with_suggestions(monkeypatch):

--- a/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
@@ -222,11 +222,13 @@ describe("RiaOnboardingPage", () => {
     render(<RiaOnboardingPage />);
 
     const input = await screen.findByLabelText("Advisor name");
+    const crdInput = screen.getByLabelText("CRD") as HTMLInputElement;
     const continueButton = screen.getByRole("button", { name: "Continue" }) as HTMLButtonElement;
     const verifyButton = screen.getByRole("button", { name: "Verify" }) as HTMLButtonElement;
 
     expect(continueButton.disabled).toBe(true);
     expect(screen.queryByRole("button", { name: "Use manual CRD fallback" })).toBeNull();
+    expect(crdInput.placeholder).toBe("Optional CRD number");
 
     fireEvent.change(input, { target: { value: "Ana Roumenova Carter" } });
     await new Promise((resolve) => setTimeout(resolve, 450));
@@ -245,6 +247,7 @@ describe("RiaOnboardingPage", () => {
     expect(mocks.riaService.verifyOnboardingName).toHaveBeenCalledTimes(1);
 
     await screen.findByText("Verified name");
+    await waitFor(() => expect(crdInput.value).toBe("4424794"));
     expect(screen.getByText("4424794")).toBeTruthy();
     expect(screen.getByText("LCG CAPITAL ADVISORS, LLC")).toBeTruthy();
     expect(screen.getByText("801-12345")).toBeTruthy();
@@ -255,6 +258,95 @@ describe("RiaOnboardingPage", () => {
     await waitFor(() => {
       expect(screen.queryByText("Verified name")).toBeNull();
     });
+    expect(continueButton.disabled).toBe(true);
+  });
+
+  it("sends optional CRD and blocks when the provider CRD does not match", async () => {
+    mocks.riaService.verifyOnboardingName.mockResolvedValue({
+      status: "not_verified",
+      matched_name: "Ana Roumenova Carter",
+      crd_number: "4424794",
+      current_firm: "LCG CAPITAL ADVISORS, LLC",
+      sec_number: "801-12345",
+      reason:
+        "The verified CRD did not match the CRD you entered. Check the CRD or remove it and verify by name.",
+      reason_code: "no_confident_match",
+      provider: "ria_intelligence_stage1",
+      suggested_names: [],
+    });
+
+    render(<RiaOnboardingPage />);
+
+    const input = await screen.findByLabelText("Advisor name");
+    const crdInput = screen.getByLabelText("CRD");
+    const continueButton = screen.getByRole("button", { name: "Continue" }) as HTMLButtonElement;
+
+    fireEvent.change(input, { target: { value: "Ana Roumenova Carter" } });
+    fireEvent.change(crdInput, { target: { value: "0000000" } });
+    fireEvent.click(screen.getByRole("button", { name: "Verify" }));
+
+    await waitFor(() =>
+      expect(mocks.riaService.verifyOnboardingName).toHaveBeenCalledWith(
+        "token-ria-1",
+        { query: "Ana Roumenova Carter", crd_number: "0000000" },
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      )
+    );
+    await screen.findByText(/verified CRD did not match/i);
+    expect(continueButton.disabled).toBe(true);
+  });
+
+  it("clears verified state when CRD changes after a successful lookup", async () => {
+    mocks.riaService.verifyOnboardingName.mockResolvedValue({
+      status: "verified",
+      matched_name: "Ana Roumenova Carter",
+      crd_number: "4424794",
+      current_firm: "LCG CAPITAL ADVISORS, LLC",
+      sec_number: "801-12345",
+      provider: "ria_intelligence_stage1",
+      suggested_names: [],
+    });
+
+    render(<RiaOnboardingPage />);
+
+    const input = await screen.findByLabelText("Advisor name");
+    const crdInput = screen.getByLabelText("CRD");
+    const continueButton = screen.getByRole("button", { name: "Continue" }) as HTMLButtonElement;
+
+    fireEvent.change(input, { target: { value: "Ana Roumenova Carter" } });
+    fireEvent.click(screen.getByRole("button", { name: "Verify" }));
+
+    await screen.findByText("Verified name");
+    expect(continueButton.disabled).toBe(false);
+
+    fireEvent.change(crdInput, { target: { value: "4424795" } });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Verified name")).toBeNull();
+    });
+    expect(continueButton.disabled).toBe(true);
+  });
+
+  it("keeps continue blocked when verification returns no CRD", async () => {
+    mocks.riaService.verifyOnboardingName.mockResolvedValue({
+      status: "verified",
+      matched_name: "Ana Roumenova Carter",
+      crd_number: null,
+      current_firm: "LCG CAPITAL ADVISORS, LLC",
+      sec_number: "801-12345",
+      provider: "ria_intelligence_stage1",
+      suggested_names: [],
+    });
+
+    render(<RiaOnboardingPage />);
+
+    const input = await screen.findByLabelText("Advisor name");
+    const continueButton = screen.getByRole("button", { name: "Continue" }) as HTMLButtonElement;
+
+    fireEvent.change(input, { target: { value: "Ana Roumenova Carter" } });
+    fireEvent.click(screen.getByRole("button", { name: "Verify" }));
+
+    await screen.findByText(/did not return a CRD-backed advisor record/i);
     expect(continueButton.disabled).toBe(true);
   });
 

--- a/hushh-webapp/app/ria/onboarding/page.tsx
+++ b/hushh-webapp/app/ria/onboarding/page.tsx
@@ -114,6 +114,10 @@ function isAdvisoryAccessReady(status?: string | null): boolean {
   return status === "active" || status === "verified" || status === "bypassed";
 }
 
+function normalizeCrd(value?: string | null): string {
+  return String(value || "").replace(/\D/g, "");
+}
+
 async function waitForNameVerificationResult<T>(
   promise: Promise<T | null>,
   options: { timeoutMs: number; onTimeout?: () => void }
@@ -268,9 +272,11 @@ export default function RiaOnboardingPage() {
   const [nameVerificationStatus, setNameVerificationStatus] = useState<NameVerificationState>("idle");
   const [nameVerificationResult, setNameVerificationResult] = useState<RiaNameVerificationResult | null>(null);
   const [lastVerifiedQuery, setLastVerifiedQuery] = useState<string | null>(null);
+  const [lastVerifiedCrd, setLastVerifiedCrd] = useState<string | null>(null);
   const verificationRequestIdRef = useRef(0);
   const verificationAbortRef = useRef<AbortController | null>(null);
   const latestDisplayNameRef = useRef("");
+  const latestCrdRef = useRef("");
 
   useEffect(() => {
     let cancelled = false;
@@ -284,6 +290,7 @@ export default function RiaOnboardingPage() {
           setNameVerificationStatus("idle");
           setNameVerificationResult(null);
           setLastVerifiedQuery(null);
+          setLastVerifiedCrd(null);
         }
         return;
       }
@@ -312,7 +319,8 @@ export default function RiaOnboardingPage() {
           isAdvisoryAccessReady(nextStatus?.advisory_status || nextStatus?.verification_status) &&
           Boolean(seededIdentity.crdNumber) &&
           Boolean(persistedDisplayName) &&
-          persistedDisplayName === seeded.displayName.trim();
+          persistedDisplayName === seeded.displayName.trim() &&
+          normalizeCrd(seededIdentity.crdNumber) === normalizeCrd(seeded.individualCrd);
         const currentStepId = resolveRiaOnboardingStepId(seeded, localDraft?.currentStepId, {
           nameVerificationSatisfied: seededVerified,
         });
@@ -331,10 +339,12 @@ export default function RiaOnboardingPage() {
             suggested_names: [],
           });
           setLastVerifiedQuery(seeded.displayName.trim() || seededIdentity.matchedName);
+          setLastVerifiedCrd(normalizeCrd(seededIdentity.crdNumber));
         } else {
           setNameVerificationStatus("idle");
           setNameVerificationResult(null);
           setLastVerifiedQuery(null);
+          setLastVerifiedCrd(null);
         }
         setShouldPersistDraft(true);
       } catch (loadError) {
@@ -378,19 +388,26 @@ export default function RiaOnboardingPage() {
   const advisoryVerificationStatus = status?.advisory_status || status?.verification_status || "draft";
   const advisoryAccessReady = isAdvisoryAccessReady(advisoryVerificationStatus);
   const displayNameQuery = draft.displayName.trim();
+  const displayCrdQuery = draft.individualCrd.trim();
+  const normalizedDisplayCrd = normalizeCrd(displayCrdQuery);
   latestDisplayNameRef.current = displayNameQuery;
+  latestCrdRef.current = normalizedDisplayCrd;
   const persistedVerifiedDisplayName = status?.display_name?.trim() || "";
+  const persistedVerifiedCrd = normalizeCrd(status?.individual_crd || status?.finra_crd);
   const persistedVerificationSatisfied =
     isAdvisoryAccessReady(status?.advisory_status || status?.verification_status) &&
-    Boolean(status?.individual_crd || status?.finra_crd) &&
+    Boolean(persistedVerifiedCrd) &&
     Boolean(persistedVerifiedDisplayName) &&
-    persistedVerifiedDisplayName === displayNameQuery;
+    persistedVerifiedDisplayName === displayNameQuery &&
+    persistedVerifiedCrd === normalizedDisplayCrd;
   const nameVerificationSatisfied =
     persistedVerificationSatisfied ||
     (nameVerificationStatus === "verified" &&
-      Boolean(nameVerificationResult?.crd_number) &&
+      Boolean(normalizeCrd(nameVerificationResult?.crd_number)) &&
       Boolean(displayNameQuery) &&
-      lastVerifiedQuery === displayNameQuery);
+      lastVerifiedQuery === displayNameQuery &&
+      Boolean(lastVerifiedCrd) &&
+      lastVerifiedCrd === normalizedDisplayCrd);
   const flowOptions = useMemo<RiaOnboardingFlowOptions>(
     () => ({ nameVerificationSatisfied }),
     [nameVerificationSatisfied]
@@ -403,7 +420,11 @@ export default function RiaOnboardingPage() {
     Boolean(user) &&
     displayNameQuery.length > 0 &&
     nameVerificationStatus !== "verifying" &&
-    !(nameVerificationStatus === "verified" && lastVerifiedQuery === displayNameQuery);
+    !(
+      nameVerificationStatus === "verified" &&
+      lastVerifiedQuery === displayNameQuery &&
+      lastVerifiedCrd === normalizedDisplayCrd
+    );
   const isBroadNameQuery =
     nameVerificationStatus === "not_verified" &&
     nameVerificationResult?.reason_code === "query_too_broad";
@@ -436,6 +457,14 @@ export default function RiaOnboardingPage() {
     verificationAbortRef.current = null;
   }
 
+  function clearNameVerification() {
+    cancelActiveVerification();
+    setNameVerificationStatus("idle");
+    setNameVerificationResult(null);
+    setLastVerifiedQuery(null);
+    setLastVerifiedCrd(null);
+  }
+
   function applyVerifiedIdentityToDraft(result: RiaNameVerificationResult) {
     setShouldPersistDraft(true);
     setDraft((current) => ({
@@ -448,15 +477,24 @@ export default function RiaOnboardingPage() {
   }
 
   function handleDisplayNameChange(value: string) {
-    cancelActiveVerification();
-    setNameVerificationStatus("idle");
-    setNameVerificationResult(null);
-    setLastVerifiedQuery(null);
+    clearNameVerification();
     latestDisplayNameRef.current = value.trim();
+    latestCrdRef.current = "";
     updateDraft({
       displayName: value,
       individualLegalName: "",
       individualCrd: "",
+      advisoryFirmName: "",
+      advisoryFirmIapdNumber: "",
+    });
+  }
+
+  function handleCrdChange(value: string) {
+    clearNameVerification();
+    latestCrdRef.current = normalizeCrd(value);
+    updateDraft({
+      individualLegalName: "",
+      individualCrd: value,
       advisoryFirmName: "",
       advisoryFirmIapdNumber: "",
     });
@@ -472,6 +510,7 @@ export default function RiaOnboardingPage() {
   async function handleVerifyName(overrideQuery?: string) {
     if (!user) return;
     const normalizedQuery = (overrideQuery || draft.displayName).trim();
+    const normalizedInputCrd = normalizeCrd(draft.individualCrd);
     if (!normalizedQuery) return;
 
     cancelActiveVerification();
@@ -484,13 +523,17 @@ export default function RiaOnboardingPage() {
     setNameVerificationStatus("verifying");
     setNameVerificationResult(null);
     setLastVerifiedQuery(null);
+    setLastVerifiedCrd(null);
 
     try {
       const idToken = await user.getIdToken();
       const initialResolution = await waitForNameVerificationResult(
         RiaService.verifyOnboardingName(
           idToken,
-          { query: normalizedQuery },
+          {
+            query: normalizedQuery,
+            ...(normalizedInputCrd ? { crd_number: normalizedInputCrd } : {}),
+          },
           { signal: controller.signal }
         ),
         {
@@ -510,6 +553,7 @@ export default function RiaOnboardingPage() {
         });
         setNameVerificationStatus("provider_unavailable");
         setLastVerifiedQuery(null);
+        setLastVerifiedCrd(null);
         return;
       }
 
@@ -517,17 +561,41 @@ export default function RiaOnboardingPage() {
       if (
         controller.signal.aborted ||
         requestId !== verificationRequestIdRef.current ||
-        latestDisplayNameRef.current !== normalizedQuery
+        latestDisplayNameRef.current !== normalizedQuery ||
+        latestCrdRef.current !== normalizedInputCrd
       ) {
         return;
       }
-      setNameVerificationResult(result);
-      setNameVerificationStatus(result.status);
-      if (result.status === "verified") {
-        applyVerifiedIdentityToDraft(result);
+      const verifiedCrd = normalizeCrd(result.crd_number);
+      const resolvedResult =
+        result.status === "verified" && !verifiedCrd
+          ? {
+              ...result,
+              status: "not_verified" as const,
+              reason:
+                "Verification did not return a CRD-backed advisor record. Onboarding stays blocked.",
+              reason_code: "no_confident_match" as const,
+            }
+          : result.status === "verified" &&
+              normalizedInputCrd &&
+              verifiedCrd !== normalizedInputCrd
+            ? {
+                ...result,
+                status: "not_verified" as const,
+                reason:
+                  "The verified CRD did not match the CRD you entered. Check the CRD or remove it and verify by name.",
+                reason_code: "no_confident_match" as const,
+              }
+            : result;
+      setNameVerificationResult(resolvedResult);
+      setNameVerificationStatus(resolvedResult.status);
+      if (resolvedResult.status === "verified") {
+        applyVerifiedIdentityToDraft(resolvedResult);
         setLastVerifiedQuery(normalizedQuery);
+        setLastVerifiedCrd(verifiedCrd);
       } else {
         setLastVerifiedQuery(null);
+        setLastVerifiedCrd(null);
       }
     } catch (verificationError) {
       if (
@@ -544,6 +612,7 @@ export default function RiaOnboardingPage() {
         setNameVerificationStatus("idle");
         setNameVerificationResult(null);
         setLastVerifiedQuery(null);
+        setLastVerifiedCrd(null);
         return;
       }
       setNameVerificationResult({
@@ -557,6 +626,7 @@ export default function RiaOnboardingPage() {
       });
       setNameVerificationStatus("provider_unavailable");
       setLastVerifiedQuery(null);
+      setLastVerifiedCrd(null);
     } finally {
       if (requestId === verificationRequestIdRef.current) {
         verificationAbortRef.current = null;
@@ -645,6 +715,7 @@ export default function RiaOnboardingPage() {
           suggested_names: [],
         });
         setLastVerifiedQuery(draft.displayName.trim());
+        setLastVerifiedCrd(normalizeCrd(result.individual_crd));
       }
       trackEvent("ria_onboarding_submitted", {
         result: "success",
@@ -841,6 +912,18 @@ export default function RiaOnboardingPage() {
               placeholder="Ana Roumenova Carter"
               value={draft.displayName}
               onChange={handleDisplayNameChange}
+              onKeyDown={(event) => {
+                if (event.key !== "Enter") return;
+                event.preventDefault();
+                void handleVerifyName();
+              }}
+            />
+            <TextField
+              label="CRD"
+              placeholder="Optional CRD number"
+              value={draft.individualCrd}
+              inputMode="numeric"
+              onChange={handleCrdChange}
               onKeyDown={(event) => {
                 if (event.key !== "Enter") return;
                 event.preventDefault();

--- a/hushh-webapp/lib/services/ria-service.ts
+++ b/hushh-webapp/lib/services/ria-service.ts
@@ -1050,7 +1050,7 @@ export class RiaService {
 
   static async verifyOnboardingName(
     idToken: string,
-    payload: { query: string },
+    payload: { query: string; crd_number?: string },
     options?: { signal?: AbortSignal }
   ): Promise<RiaNameVerificationResult> {
     const response = await authFetch("/api/ria/onboarding/verify-name", {

--- a/hushh-webapp/scripts/architecture/audit-ui-surfaces.mjs
+++ b/hushh-webapp/scripts/architecture/audit-ui-surfaces.mjs
@@ -2,8 +2,9 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), "../..");
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const scanRoots = [
   path.join(repoRoot, "components/app-ui"),
   path.join(repoRoot, "lib/morphy-ux"),

--- a/hushh-webapp/scripts/architecture/verify-design-system.mjs
+++ b/hushh-webapp/scripts/architecture/verify-design-system.mjs
@@ -2,8 +2,9 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), "../..");
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
 const STOCK_UI_FILES = new Set([
   "accordion.tsx",

--- a/hushh-webapp/scripts/architecture/verify-docs.mjs
+++ b/hushh-webapp/scripts/architecture/verify-docs.mjs
@@ -2,8 +2,9 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), "../..");
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const packageJson = JSON.parse(
   fs.readFileSync(path.join(repoRoot, "package.json"), "utf8")
 );


### PR DESCRIPTION
## Summary
- Gate RIA onboarding progression on a CRD-backed Stage 1 RIA Intelligence match.
- Add optional CRD input and stale-response-safe verification UX on `/ria/onboarding`.
- Re-verify server-side on onboarding submit with `force_live_verification=true`.
- Harden full account deletion cleanup for newer account-owned tables and add the Kai test-account reset skill.
- Fix local web architecture verifiers for workspace paths containing spaces.

## UAT test reset
- Confirmed reset was run for `ankit@hushh.ai` / UID prefix `UHntnlEx...` against UAT DB via Cloud SQL proxy.
- Firebase Auth user and browser local storage were intentionally not deleted.

## Validation
- `cd consent-protocol && ./.venv/bin/ruff check hushh_mcp/services/account_service.py tests/services/test_account_service_cleanup_tables.py`
- `cd consent-protocol && ./.venv/bin/pytest tests/services/test_account_service_cleanup_tables.py tests/services/test_account_service_export.py tests/test_ria_verification_intelligence.py tests/test_ria_iam_service_architecture.py tests/test_ria_iam_routes.py -q`
- `cd hushh-webapp && npm run test -- __tests__/app/ria/onboarding-page.test.tsx __tests__/services/ria-onboarding-flow.test.ts __tests__/services/ria-onboarding-draft-local-service.test.ts`
- `cd hushh-webapp && npm run typecheck`
- `./bin/hushh codex pre-pr`
