### PR TITLE
fix(pkm): document cloud projection boundary

### DIFF
--- a/consent-protocol/db/migrations/048_merge_pkm_domain_summary_rpc.sql
+++ b/consent-protocol/db/migrations/048_merge_pkm_domain_summary_rpc.sql
@@ -1,6 +1,9 @@
--- Migration 048: atomic JSONB merge RPC for pkm_index domain summaries
--- Replaces the read-modify-write in update_domain_summary() with a single
--- DB-level upsert, eliminating the race window on concurrent writes.
+-- Migration 048: atomic JSONB merge RPC for pkm_index domain summaries.
+--
+-- This function only updates the cloud discovery projection. It must not be
+-- treated as the source of user memory truth. Encrypted PKM blobs, manifests,
+-- mutation events, and local cache write-through remain authoritative; this
+-- projection is repairable from those sources when cloud sync lags or recovers.
 
 CREATE OR REPLACE FUNCTION merge_pkm_domain_summary(
     p_user_id      TEXT,

--- a/consent-protocol/docs/reference/personal-knowledge-model.md
+++ b/consent-protocol/docs/reference/personal-knowledge-model.md
@@ -36,6 +36,25 @@ Until that migration lands, do not describe One-owned PKM as current-state runti
 - `pkm_upgrade_steps`
   Per-domain resumable checkpoints for generic PKM upgrades. No plaintext or key material is stored here.
 
+## Authority and sync model
+
+PKM is local-first and encrypted-first. The user-memory authority is:
+
+1. encrypted domain payloads in `pkm_blobs`
+2. per-domain structure and version truth in `pkm_manifests`
+3. append-only mutation history in `pkm_events`
+4. client-side cache write-through after vault unlock
+
+`pkm_index` is a cloud discovery projection. It can summarize available domains,
+safe counters, freshness, and coarse capability flags, but it is not the source
+of user memory truth. If local-only, offline, or on-device runtime paths are
+active, the app may read from local encrypted cache and reconcile cloud
+projection later.
+
+Cloud writes to `pkm_index.domain_summaries` must therefore be treated as sync
+projection updates. They should be atomic and repairable, but they must not make
+local saves fail solely because the cloud projection is temporarily unavailable.
+
 ## Storage rules
 
 - New writes are PKM-only.

--- a/consent-protocol/hushh_mcp/services/personal_knowledge_model_service.py
+++ b/consent-protocol/hushh_mcp/services/personal_knowledge_model_service.py
@@ -1419,7 +1419,10 @@ class PersonalKnowledgeModelService:
         """Atomically merge a sanitized PKM discovery summary for one domain.
 
         Uses a single PostgreSQL upsert (merge_pkm_domain_summary RPC) so the
-        read-modify-write is done at the DB level with no race window.
+        cloud discovery projection has no read-modify-write race window. This
+        does not make pkm_index the user-memory authority; encrypted blobs,
+        manifests, mutation events, and local cache write-through remain the
+        source of truth for local-first and on-device flows.
         """
         domain = self._canonicalize_domain_key(domain)
         if not domain:

--- a/docs/reference/architecture/cache-coherence.md
+++ b/docs/reference/architecture/cache-coherence.md
@@ -120,6 +120,10 @@ Do:
 - Centralize invalidation/write-through in `CacheSyncService`.
 - Write through encrypted blob keys when CRUD payloads already include ciphertext.
 - Patch cached PKM metadata in-place when safe summary fields are provided.
+- Treat backend `pkm_index` updates as cloud discovery projections. Local memory,
+  secure device cache, and encrypted-domain write-through remain first-class
+  state for local-first and on-device flows; failed projection sync should
+  invalidate or retry the projection lane, not erase local encrypted cache.
 - Keep `CacheContext` as a state mirror only.
 - Use `invalidateUser(userId)` when purging a full user session.
 - Keep domain blob + metadata reconciliation aligned with PKM index semantics.


### PR DESCRIPTION
## Summary

Follow-up to #530. The atomic `merge_pkm_domain_summary` RPC is the right cloud-side consistency fix, but the merged contract needed one explicit boundary: `pkm_index` is a repairable cloud discovery projection, not the source of user-memory truth.

This patch documents that boundary in the migration, backend service docstring, PKM reference, and cache-coherence reference.

## Why It Matters

Hussh is on-device-first with cloud sync. Local encrypted domain data, manifests, mutation events, and cache write-through must remain authoritative for user memory. Cloud summary projection can be atomic and useful, but local-only/offline/on-device flows must not fail just because the cloud projection is unavailable or lagging.

## Verification

- `cd consent-protocol && python3 -m pytest tests/services/test_pkm_service_store_domain_data.py -q`
- `cd hushh-webapp && npm run verify:cache`
- `./bin/hushh db verify-release-contract`
- `./bin/hushh docs verify`
- `bash scripts/ci/check-dco-signoff.sh origin/main HEAD`
