### PR TITLE
fix(pkm): preserve vault owner token on preference writes

### DIFF
--- a/hushh-webapp/__tests__/api/vault-store-preferences.test.ts
+++ b/hushh-webapp/__tests__/api/vault-store-preferences.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mocks = vi.hoisted(() => ({
+  storeUserData: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  storeUserData: mocks.storeUserData,
+}));
+
+describe("POST /api/vault/store-preferences", () => {
+  const originalFetch = global.fetch;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_APP_ENV = "development";
+    global.fetch = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          valid: true,
+          user_id: "firebase-user-123",
+          agent_id: "vault",
+          scope: "vault.owner",
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }
+      )
+    ) as typeof fetch;
+    mocks.storeUserData.mockResolvedValue(true);
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it("passes the validated vault-owner token into each PKM domain write", async () => {
+    const route = await import("../../app/api/vault/store-preferences/route");
+    const request = new NextRequest("http://localhost:3000/api/vault/store-preferences", {
+      method: "POST",
+      body: JSON.stringify({
+        userId: "firebase-user-123",
+        consentToken: "HCT:vault-owner-token",
+        preferences: {
+          preferences: {
+            ciphertext: "ciphertext",
+            iv: "iv",
+            tag: "tag",
+          },
+        },
+      }),
+    });
+
+    const response = await route.POST(request);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.success).toBe(true);
+    expect(mocks.storeUserData).toHaveBeenCalledWith(
+      "firebase-user-123",
+      "preferences",
+      "ciphertext",
+      "iv",
+      "tag",
+      { vaultOwnerToken: "HCT:vault-owner-token" }
+    );
+  });
+
+  it("does not log user ids, field names, or ciphertext while storing", async () => {
+    const route = await import("../../app/api/vault/store-preferences/route");
+    const request = new NextRequest("http://localhost:3000/api/vault/store-preferences", {
+      method: "POST",
+      body: JSON.stringify({
+        userId: "firebase-user-123",
+        consentToken: "HCT:vault-owner-token",
+        preferences: {
+          preferences: {
+            ciphertext: "ciphertext",
+            iv: "iv",
+            tag: "tag",
+          },
+        },
+      }),
+    });
+
+    await route.POST(request);
+
+    const renderedLogs = [...logSpy.mock.calls, ...warnSpy.mock.calls]
+      .flat()
+      .map(String)
+      .join(" ");
+    expect(renderedLogs).not.toContain("firebase-user-123");
+    expect(renderedLogs).not.toContain("preferences");
+    expect(renderedLogs).not.toContain("ciphertext");
+  });
+});

--- a/hushh-webapp/__tests__/services/db-store-user-data.test.ts
+++ b/hushh-webapp/__tests__/services/db-store-user-data.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  class MockApiError extends Error {
+    constructor(
+      message: string,
+      public readonly status: number,
+      public readonly payload?: unknown
+    ) {
+      super(message);
+      this.name = "ApiError";
+    }
+  }
+
+  return {
+    apiJson: vi.fn(),
+    ApiError: MockApiError,
+  };
+});
+
+vi.mock("@/lib/services/api-client", () => ({
+  apiJson: mocks.apiJson,
+  ApiError: mocks.ApiError,
+}));
+
+import { storeUserData } from "@/lib/db";
+
+describe("storeUserData", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it("forwards the vault-owner token to the PKM store-domain proxy", async () => {
+    mocks.apiJson.mockResolvedValueOnce({ success: true });
+
+    const stored = await storeUserData(
+      "firebase-user-123",
+      "preferences",
+      "ciphertext",
+      "iv",
+      "tag",
+      { vaultOwnerToken: "HCT:vault-owner-token" }
+    );
+
+    expect(stored).toBe(true);
+    expect(mocks.apiJson).toHaveBeenCalledWith("/api/pkm/store-domain", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer HCT:vault-owner-token",
+      },
+      body: JSON.stringify({
+        user_id: "firebase-user-123",
+        domain: "preferences",
+        encrypted_blob: {
+          ciphertext: "ciphertext",
+          iv: "iv",
+          tag: "tag",
+          algorithm: "aes-256-gcm",
+        },
+        summary: {},
+      }),
+    });
+  });
+
+  it("fails closed when no vault-owner token is available", async () => {
+    const stored = await storeUserData(
+      "firebase-user-123",
+      "preferences",
+      "ciphertext",
+      "iv",
+      "tag"
+    );
+
+    expect(stored).toBe(false);
+    expect(mocks.apiJson).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[db] storeUserData failed: missing vault-owner token"
+    );
+  });
+
+  it("does not log user ids, domains, or ciphertext on API failure", async () => {
+    mocks.apiJson.mockRejectedValueOnce(
+      new mocks.ApiError("Forbidden", 403, { detail: "nope" })
+    );
+
+    const stored = await storeUserData(
+      "firebase-user-123",
+      "preferences",
+      "ciphertext",
+      "iv",
+      "tag",
+      { vaultOwnerToken: "HCT:vault-owner-token" }
+    );
+
+    expect(stored).toBe(false);
+    const renderedLogs = errorSpy.mock.calls.flat().map(String).join(" ");
+    expect(renderedLogs).toContain("[db] storeUserData failed:");
+    expect(renderedLogs).not.toContain("firebase-user-123");
+    expect(renderedLogs).not.toContain("preferences");
+    expect(renderedLogs).not.toContain("ciphertext");
+  });
+});

--- a/hushh-webapp/app/api/vault/store-preferences/route.ts
+++ b/hushh-webapp/app/api/vault/store-preferences/route.ts
@@ -90,9 +90,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    console.log(
-      `✅ Consent validated: ${validation.agent_id} → ${validation.scope}`
-    );
+    console.log("✅ Consent validated for encrypted preference write");
 
     // =========================================================================
     // VAULT WRITE: Now authorized
@@ -104,8 +102,9 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    console.log("📦 Storing preferences");
-    console.log(`📋 Fields to store: ${Object.keys(preferences).join(", ")}`);
+    console.log(
+      `📦 Storing ${Object.keys(preferences).length} encrypted preference field(s)`
+    );
 
     // Dynamically store each preference field
     const storePromises = [];
@@ -122,7 +121,7 @@ export async function POST(request: NextRequest) {
 
       // Validate encrypted structure
       if (!encrypted.ciphertext || !encrypted.iv || !encrypted.tag) {
-        console.warn(`⚠️ Skipping invalid field: ${key}`, encrypted);
+        console.warn("⚠️ Skipping invalid encrypted preference field");
         continue;
       }
 
@@ -132,14 +131,15 @@ export async function POST(request: NextRequest) {
           key,
           encrypted.ciphertext,
           encrypted.iv,
-          encrypted.tag
+          encrypted.tag,
+          { vaultOwnerToken: consentToken }
         )
       );
     }
 
     await Promise.all(storePromises);
 
-    console.log(`✅ Stored ${storePromises.length} preferences`);
+    console.log(`✅ Stored ${storePromises.length} encrypted preference field(s)`);
 
     return NextResponse.json({
       success: true,

--- a/hushh-webapp/lib/db.ts
+++ b/hushh-webapp/lib/db.ts
@@ -1,11 +1,37 @@
 /**
  * Database Utility Library
  *
- * Handles storage of encrypted user data.
- * Currently a stub implementation to allow build to pass.
- * TODO: Implement backend API call to persist data to Cloud SQL via db_proxy.
+ * Handles storage of encrypted user data via the PKM backend.
+ *
+ * Architecture note:
+ * - storeUserData() proxies to POST /api/pkm/store-domain on the backend.
+ *   The backend stores the ciphertext blob without being able to decrypt it
+ *   (BYOK guarantee — the vault key never leaves the client).
+ *
+ * Removed:
+ * - getAllFoodData() and getAllProfessionalData() were stubs that returned null.
+ *   These domain-specific getters were removed from the backend
+ *   (see db_proxy.py: "NOTE: /food/get and /professional/get removed;
+ *   domain data is via PKM"). Domain data is now read via the PKM
+ *   /api/pkm/domains/{userId} endpoint instead.
  */
 
+const PKM_STORE_TIMEOUT_MS = 30_000;
+
+/**
+ * Persist an encrypted user data field to the PKM backend.
+ *
+ * The `value`, `iv`, and `tag` parameters are the AES-GCM ciphertext
+ * components produced by the client-side vault encryption layer. The
+ * backend stores them opaquely — it cannot decrypt the payload.
+ *
+ * @param userId  - Firebase UID of the data owner
+ * @param key     - PKM domain path (e.g. "financial", "health")
+ * @param value   - Base64-encoded AES-GCM ciphertext
+ * @param iv      - Base64-encoded initialisation vector (12 bytes)
+ * @param tag     - Base64-encoded authentication tag (16 bytes)
+ * @returns true on success, false on failure (caller decides how to handle)
+ */
 export async function storeUserData(
   userId: string,
   key: string,
@@ -13,26 +39,50 @@ export async function storeUserData(
   iv: string,
   tag: string
 ): Promise<boolean> {
-  console.log(`[STUB] storeUserData called for user ${userId}, key ${key}`);
-  console.log(`[STUB] Value size: ${value.length}, IV: ${iv}, Tag: ${tag}`);
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), PKM_STORE_TIMEOUT_MS);
 
-  // Simulate network delay
-  await new Promise((resolve) => setTimeout(resolve, 500));
+    const response = await fetch("/api/pkm/store-domain", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        user_id: userId,
+        domain: key,
+        encrypted_blob: {
+          ciphertext: value,
+          iv,
+          tag,
+          algorithm: "aes-256-gcm",
+        },
+        // Summary is intentionally empty — the caller (store-preferences)
+        // stores encrypted preference blobs, not queryable PKM domain data.
+        summary: {},
+      }),
+      signal: controller.signal,
+    });
 
-  // Return success to allow flow to continue
-  return true;
-}
+    clearTimeout(timeout);
 
-export async function getAllFoodData(
-  userId: string
-): Promise<Record<string, unknown> | null> {
-  console.log(`[STUB] getAllFoodData called for user ${userId}`);
-  return null;
-}
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "");
+      console.error(
+        `[db] storeUserData failed for user ${userId} key ${key}:`,
+        response.status,
+        errorText
+      );
+      return false;
+    }
 
-export async function getAllProfessionalData(
-  userId: string
-): Promise<Record<string, unknown> | null> {
-  console.log(`[STUB] getAllProfessionalData called for user ${userId}`);
-  return null;
+    return true;
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      console.error(
+        `[db] storeUserData timed out after ${PKM_STORE_TIMEOUT_MS}ms for user ${userId} key ${key}`
+      );
+    } else {
+      console.error(`[db] storeUserData error for user ${userId} key ${key}:`, error);
+    }
+    return false;
+  }
 }

--- a/hushh-webapp/lib/db.ts
+++ b/hushh-webapp/lib/db.ts
@@ -25,6 +25,10 @@ interface StoreDomainResponse {
   message?: string;
 }
 
+type StoreUserDataOptions = {
+  vaultOwnerToken?: string;
+};
+
 /**
  * Persist an encrypted user data field to the PKM backend.
  *
@@ -44,11 +48,20 @@ export async function storeUserData(
   key: string,
   value: string,
   iv: string,
-  tag: string
+  tag: string,
+  options: StoreUserDataOptions = {}
 ): Promise<boolean> {
   try {
+    if (!options.vaultOwnerToken) {
+      console.error("[db] storeUserData failed: missing vault-owner token");
+      return false;
+    }
+
     await apiJson<StoreDomainResponse>("/api/pkm/store-domain", {
       method: "POST",
+      headers: {
+        Authorization: `Bearer ${options.vaultOwnerToken}`,
+      },
       body: JSON.stringify({
         user_id: userId,
         domain: key,
@@ -67,12 +80,12 @@ export async function storeUserData(
   } catch (error) {
     if (error instanceof ApiError) {
       console.error(
-        `[db] storeUserData failed for user ${userId} key ${key}:`,
+        "[db] storeUserData failed:",
         error.status,
         error.message
       );
     } else {
-      console.error(`[db] storeUserData error for user ${userId} key ${key}:`, error);
+      console.error("[db] storeUserData error:", error);
     }
     return false;
   }

--- a/hushh-webapp/lib/db.ts
+++ b/hushh-webapp/lib/db.ts
@@ -7,6 +7,8 @@
  * - storeUserData() proxies to POST /api/pkm/store-domain on the backend.
  *   The backend stores the ciphertext blob without being able to decrypt it
  *   (BYOK guarantee — the vault key never leaves the client).
+ * - Uses ApiService via apiJson() so routing works correctly on both
+ *   web (Next.js proxy) and native platforms (iOS/Android via Capacitor).
  *
  * Removed:
  * - getAllFoodData() and getAllProfessionalData() were stubs that returned null.
@@ -16,7 +18,12 @@
  *   /api/pkm/domains/{userId} endpoint instead.
  */
 
-const PKM_STORE_TIMEOUT_MS = 30_000;
+import { apiJson, ApiError } from "@/lib/services/api-client";
+
+interface StoreDomainResponse {
+  success: boolean;
+  message?: string;
+}
 
 /**
  * Persist an encrypted user data field to the PKM backend.
@@ -40,12 +47,8 @@ export async function storeUserData(
   tag: string
 ): Promise<boolean> {
   try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), PKM_STORE_TIMEOUT_MS);
-
-    const response = await fetch("/api/pkm/store-domain", {
+    await apiJson<StoreDomainResponse>("/api/pkm/store-domain", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         user_id: userId,
         domain: key,
@@ -55,30 +58,18 @@ export async function storeUserData(
           tag,
           algorithm: "aes-256-gcm",
         },
-        // Summary is intentionally empty — the caller (store-preferences)
-        // stores encrypted preference blobs, not queryable PKM domain data.
+        // Summary is intentionally empty — store-preferences stores
+        // encrypted preference blobs, not queryable PKM domain data.
         summary: {},
       }),
-      signal: controller.signal,
     });
-
-    clearTimeout(timeout);
-
-    if (!response.ok) {
-      const errorText = await response.text().catch(() => "");
-      console.error(
-        `[db] storeUserData failed for user ${userId} key ${key}:`,
-        response.status,
-        errorText
-      );
-      return false;
-    }
-
     return true;
   } catch (error) {
-    if (error instanceof DOMException && error.name === "AbortError") {
+    if (error instanceof ApiError) {
       console.error(
-        `[db] storeUserData timed out after ${PKM_STORE_TIMEOUT_MS}ms for user ${userId} key ${key}`
+        `[db] storeUserData failed for user ${userId} key ${key}:`,
+        error.status,
+        error.message
       );
     } else {
       console.error(`[db] storeUserData error for user ${userId} key ${key}:`, error);


### PR DESCRIPTION
## Summary

Maintainer patch for #474. Keeps the contributor direction, but makes the PKM preference write path merge-safe.

## What changed

- forwards the validated VAULT_OWNER consent token into `/api/pkm/store-domain` as `Authorization: Bearer HCT:*`
- removes user id, field-name, and ciphertext logging from the activated vault preference path
- adds targeted tests for token forwarding and log hygiene

## Checks

- `cd hushh-webapp && npm run test -- __tests__/services/db-store-user-data.test.ts __tests__/api/vault-store-preferences.test.ts`
- `cd hushh-webapp && npm run typecheck`

Supersedes #474 because direct maintainer push to the contributor fork was denied despite maintainer modification being enabled.