### PR TITLE
feat(profile): add Delete Account option to profile root page

### DIFF
--- a/hushh-webapp/app/profile/page.tsx
+++ b/hushh-webapp/app/profile/page.tsx
@@ -3062,6 +3062,17 @@ function ProfilePageContent() {
                 onClick={() => void handleSignOut()}
               />
             </SettingsGroup>
+
+            <SettingsGroup>
+              <SettingsRow
+                icon={Trash2}
+                title="Delete account"
+                description="Permanently delete your account and all data."
+                tone="destructive"
+                chevron
+                onClick={() => void handleDeleteClick()}
+              />
+            </SettingsGroup>
           </div>
         </SurfaceStack>
       </AppPageContentRegion>


### PR DESCRIPTION
# Description

Surface the existing delete account flow directly on the profile root page, below the Sign Out button. The option was buried 2 levels deep (Profile → Security → Danger Zone) and users could not find it.

Added a single `<SettingsRow>` with `tone="destructive"` reusing the existing `handleDeleteClick()` function. No new files, components, or backend changes.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below:
  - `/profile` — added a SettingsRow to the root panel content (no route change, same page)

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] Listed below:
  - Web: SettingsRow visible on profile root ✅
  - iOS/Android (Capacitor): Same Next.js page renders in WebView — no native plugin change needed. The underlying `handleDeleteClick()` already handles native via `AccountService` which uses Capacitor plugins on native.

- Docs updated (exact files):
  - [x] None — no public behavior or contract change, just surfacing an existing flow

- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck` (via CI)
  - [x] `cd hushh-webapp && npm test` (via CI)
  - [x] `cd hushh-webapp && npm run build` (via CI — Web Next.js check passed)

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Uses existing `handleDeleteClick()` → vault unlock → `AccountService.deleteAccount()` flow
- [x] **iOS**: Same WebView page; `AccountService` routes through Capacitor `HushhVault` plugin on native
- [x] **Android**: Same WebView page; same Capacitor plugin path

## 🧪 Testing

- [x] Tested on Web (CI build passed)
- [ ] Tested on iOS Simulator/Device — N/A, no native-specific change
- [ ] Tested on Android Emulator/Device — N/A, no native-specific change
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Not captured pre-merge. The change is 11 lines of JSX adding one `SettingsRow` below the existing Sign Out group.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? — No, it only surfaces an existing UI path
- [ ] If yes, have you implemented `checkConsentToken()`? — N/A

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed — no dependency changes