### PR TITLE
fix(auth): replace reCAPTCHA container element to prevent double-render

### DIFF
--- a/hushh-webapp/lib/firebase/config.ts
+++ b/hushh-webapp/lib/firebase/config.ts
@@ -59,7 +59,7 @@ export function getRecaptchaVerifier(containerId: string): RecaptchaVerifier {
   if (typeof window === "undefined") {
     throw new Error("RecaptchaVerifier can only be used in browser");
   }
-  
+
   // Always create a new verifier to avoid stale state
   if (recaptchaVerifier) {
     try {
@@ -76,8 +76,21 @@ export function getRecaptchaVerifier(containerId: string): RecaptchaVerifier {
   if (!container) {
     throw new Error(`reCAPTCHA container '${containerId}' not found in DOM`);
   }
-  container.replaceChildren();
-  
+
+  // Replace the container element entirely with a fresh node.
+  // Google's reCAPTCHA library tracks which DOM elements have been rendered
+  // in an internal registry keyed by element reference. Clearing children
+  // or calling .clear() does not remove the element from that registry,
+  // so re-rendering on the same element throws
+  // "reCAPTCHA has already been rendered in this element".
+  // Swapping in a brand-new element with the same id sidesteps the registry.
+  const freshContainer = document.createElement("div");
+  freshContainer.id = containerId;
+  for (const cls of Array.from(container.classList)) {
+    freshContainer.classList.add(cls);
+  }
+  container.replaceWith(freshContainer);
+
   recaptchaVerifier = new RecaptchaVerifier(auth, containerId, {
     size: "invisible",
     callback: () => {
@@ -88,7 +101,7 @@ export function getRecaptchaVerifier(containerId: string): RecaptchaVerifier {
       resetRecaptcha();
     },
   });
-  
+
   return recaptchaVerifier;
 }
 
@@ -110,6 +123,18 @@ export function resetRecaptcha() {
     }
     recaptchaVerifier = null;
     recaptchaWidgetId = null;
+  }
+
+  // Also replace the container element so Google's internal registry
+  // does not retain a reference to the old element.
+  const container = document.getElementById("recaptcha-container");
+  if (container) {
+    const freshContainer = document.createElement("div");
+    freshContainer.id = "recaptcha-container";
+    for (const cls of Array.from(container.classList)) {
+      freshContainer.classList.add(cls);
+    }
+    container.replaceWith(freshContainer);
   }
 }
 


### PR DESCRIPTION
# Description

Fix "reCAPTCHA has already been rendered in this element" error when clicking "Send verification code" on the phone verification flow.

## Root Cause

Google's reCAPTCHA library maintains an internal registry keyed by **DOM element reference**. The previous code called `.clear()` and `container.replaceChildren()` before re-creating the `RecaptchaVerifier`, but neither removes the element from Google's internal registry. When `verifier.render()` is called again on the same DOM element, Google's library throws.

## Fix

Replace the container with a brand-new DOM element (preserving the same `id` and CSS classes) before creating a new `RecaptchaVerifier`. Applied to both `getRecaptchaVerifier()` and `resetRecaptcha()` in `lib/firebase/config.ts`.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None — no route changes, this is infrastructure-level Firebase config

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] Listed below:
  - **Web**: Fixed — reCAPTCHA container is now replaced with a fresh DOM element before re-rendering
  - **iOS/Android**: N/A — Native platforms use `FirebaseAuthentication.linkWithPhoneNumber()` via Capacitor plugin, which does not use reCAPTCHA. The `prepareRecaptchaVerifier()` call is gated behind `!Capacitor.isNativePlatform()` in `auth-context.tsx`.

- Docs updated (exact files):
  - [x] None — internal implementation fix, no public behavior or contract change

- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck` (via CI)
  - [x] `cd hushh-webapp && npm test` (via CI)
  - [x] `cd hushh-webapp && npm run build` (via CI — Web Next.js check passed)

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Fixed — `getRecaptchaVerifier()` and `resetRecaptcha()` now swap the container DOM element
- [x] **iOS**: N/A — uses native `FirebaseAuthentication` plugin, no reCAPTCHA involved
- [x] **Android**: N/A — uses native `FirebaseAuthentication` plugin, no reCAPTCHA involved

## 🧪 Testing

- [x] Tested on Web (CI build passed)
- [ ] Tested on iOS Simulator/Device — N/A, reCAPTCHA is web-only
- [ ] Tested on Android Emulator/Device — N/A, reCAPTCHA is web-only
- [x] Commits are signed off (`git commit -s`)
- [ ] Unit test for container replacement — follow-up PR pending

## 📸 Screenshots / Video

Error before fix:
```
[PhoneVerificationFlow] Failed to start verification: Error: reCAPTCHA has already been rendered in this element
    at recaptcha__en.js:80:198
```

After fix: reCAPTCHA renders cleanly on repeated "Send verification code" clicks.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? — No, this is reCAPTCHA DOM lifecycle management
- [ ] If yes, have you implemented `checkConsentToken()`? — N/A

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed — no dependency changes