### PR TITLE
feat: remove all RIA bypass verification code

### DIFF
--- a/.claude/skills/senior-engineering/SKILL.md
+++ b/.claude/skills/senior-engineering/SKILL.md
@@ -1,0 +1,280 @@
+# Senior Engineering: Hushh Consent Protocol & RIA System
+
+> Deep architectural reference for the hushh consent protocol, RIA verification, and dual-persona system. Read this before making changes to any RIA, verification, persona, or onboarding code.
+
+---
+
+## System Overview
+
+Hushh is a consent-first financial data platform with two actor personas: **Investor** and **RIA** (Registered Investment Advisor). The platform enforces regulatory verification before granting RIAs access to investor data.
+
+### Monorepo Structure
+
+```
+hushh-research/
+  consent-protocol/       # Python FastAPI backend (the "consent protocol")
+    api/routes/           # REST endpoints
+      ria.py              # All /api/ria/* routes
+      account.py          # Account lifecycle (delete, export)
+    hushh_mcp/services/   # Core business logic
+      ria_iam_service.py  # RIA IAM: onboarding, verification, persona, clients, picks
+      ria_verification.py # Verification adapters (Stage1 lookup, IAPD, broker)
+      account_service.py  # Account deletion across 43+ tables
+      actor_identity_service.py  # Firebase identity sync
+    db/                   # Migrations, connection pooling (asyncpg)
+    scripts/              # Admin tools (e.g., admin_delete_user_by_email.py)
+
+  hushh-webapp/           # Next.js 14+ frontend (App Router)
+    app/
+      ria/
+        page.tsx          # RIA home dashboard
+        onboarding/
+          page.tsx        # 4-step onboarding wizard (capabilities, display_name, legal_identity, review)
+      api/ria/[...path]/route.ts  # Catch-all proxy to Python backend
+    lib/
+      services/ria-service.ts     # Frontend RIA API client
+      persona/persona-context.tsx # React context for persona state
+    components/ria/
+      ria-page-shell.tsx  # Layout + verification gate + status panel
+```
+
+---
+
+## Architecture Layers
+
+### 1. Frontend (Next.js)
+
+**Proxy layer**: All `/api/ria/*` requests hit `app/api/ria/[...path]/route.ts`, a catch-all proxy that forwards to the Python backend at `getPythonApiUrl()`. Key behaviors:
+- Onboarding endpoints (`submit`, `verify-name`) get 90s timeout (`RIA_ONBOARDING_PROXY_TIMEOUT_MS`)
+- Status endpoint has 30s hot-cache with deduplication
+- Standard endpoints get 12s timeout
+
+**Persona context** (`lib/persona/persona-context.tsx`):
+- `PersonaProvider` wraps the app and exposes `usePersonaState()` hook
+- Provides: `activePersona`, `primaryNavPersona`, `riaCapability`, `riaSwitchAvailable`, `riaSetupAvailable`, `riaEntryRoute`
+- Calls `RiaService.getPersonaState()` and `RiaService.getOnboardingStatus()` from the backend
+- Caches persona state client-side with `CacheService` (session-scoped TTL)
+
+**RIA Service** (`lib/services/ria-service.ts`):
+- `verifyOnboardingName(idToken, { query, crd_number? })`: POST `/api/ria/onboarding/verify-name`
+- `submitOnboarding(idToken, payload)`: POST `/api/ria/onboarding/submit` with `force_live_verification` flag
+- `getPersonaState(idToken, { userId, force })`: GET `/api/ria/persona-state`
+- `getOnboardingStatus(idToken, { userId, force })`: GET `/api/ria/onboarding/status`
+- `switchPersona(idToken, target)`: POST `/api/ria/persona/switch`
+
+**Onboarding wizard** (`app/ria/onboarding/page.tsx`, ~1400 lines):
+- 4 steps: `capabilities` -> `display_name` -> `legal_identity/advisory_firm/broker_firm` -> `review`
+- Name verification in `handleVerifyName()`:
+  1. Calls `RiaService.verifyOnboardingName(idToken, { query, crd_number? })`
+  2. 90s timeout with AbortController
+  3. Stale response detection via `verificationRequestIdRef` (incremented per request)
+  4. Post-verification: if status=verified but no CRD, downgrades to not_verified
+  5. If user-entered CRD doesn't match returned CRD, downgrades to not_verified
+- `nameVerificationSatisfied` logic: requires verified status + non-empty CRD + matching query and CRD
+
+**Verification gate** (`components/ria/ria-page-shell.tsx`):
+- `isRiaVerified(status)`: checks against `{"active", "verified", "finra_verified"}`
+- `RiaVerificationGate`: blocks children if not verified (shows "complete advisor verification first")
+
+### 2. Backend Routes (`consent-protocol/api/routes/ria.py`)
+
+Key endpoints:
+- `POST /api/ria/onboarding/submit` -> `RIAIAMService.submit_ria_onboarding()`
+- `POST /api/ria/onboarding/verify-name` -> `RIAIAMService.verify_ria_name()`
+- `GET /api/ria/onboarding/status` -> `RIAIAMService.get_ria_onboarding_status()`
+- `GET /api/ria/home` -> `RIAIAMService.get_ria_home()`
+- `GET /api/ria/clients` -> requires `_require_ria_verified` dependency (403 if not verified)
+- `POST /api/ria/requests` -> requires `_require_ria_verified`
+- `POST /api/ria/invites` -> requires `_require_ria_verified`
+
+Auth: All routes require `require_firebase_auth` (Firebase ID token in Authorization header). Client-facing routes also require `_require_ria_verified` (fail-closed 403).
+
+### 3. Backend Service (`consent-protocol/hushh_mcp/services/ria_iam_service.py`, ~3000+ lines)
+
+**RIAIAMService** is the central service class:
+
+**Persona state**: Built by `_build_persona_state()` method which queries `actor_profiles`, `ria_profiles`, and `runtime_persona_state` tables. Returns:
+- `personas`: list of available personas (e.g., ["investor", "ria"])
+- `active_persona` / `last_active_persona`
+- `primary_nav_persona`
+- `ria_switch_available`: true if user has verified RIA profile
+- `ria_setup_available`: true if user can begin RIA onboarding
+- `iam_schema_ready`: true if all IAM tables exist
+- Server-side cache with 30s TTL (`_PERSONA_STATE_CACHE`)
+
+**Onboarding submission** (`submit_ria_onboarding()`):
+1. Prepares inputs via `_prepare_professional_onboarding_inputs()`
+2. Runs Stage 1 name verification via `_verify_ria_name_result()`
+3. If `provider_unavailable` -> 503 error
+4. If not `verified` or no CRD -> 400 error
+5. If CRD mismatch -> 400 error
+6. On success: creates/updates `actor_profiles`, `ria_profiles`, `ria_firms`, `ria_firm_memberships`, `ria_verification_events`, `marketplace_public_profiles`
+7. Sets verification_status to `verified`, verification_provider to the provider label
+
+**Verification check** (`require_ria_verified()`):
+- Queries `ria_profiles` for `advisory_status` or `verification_status`
+- Checks against `_RIA_VERIFIED_STATUSES = {"active", "verified", "finra_verified"}`
+- If not in set -> 403 `RIAIAMPolicyError`
+
+### 4. Verification Adapters (`consent-protocol/hushh_mcp/services/ria_verification.py`)
+
+**RIAIntelligenceStage1LookupAdapter** (primary, used for onboarding name verification):
+- Calls `hushh-ria-intelligence-api` at `/v1/ria/profile/stage1`
+- Request: `{"query": name, "context": {"targetName": name, "crdNumber": crd}}`
+- Response parsed for: `profile.existsOnFinra`, `profile.fullName`, `profile.crdNumber`, `profile.currentFirm`, `profile.secNumber`, `profile.suggestedNames`, `profile.reasonIfNotExists`
+- Verification rules:
+  - `existsOnFinra` + non-empty CRD = `verified`
+  - CRD mismatch = `not_verified`
+  - Missing CRD = `not_verified`
+  - API error = `provider_unavailable`
+- Cache: keyed by `normalized_name|crd:normalized_crd`, TTL 300s, only caches verified/not_verified
+
+**IapdVerificationAdapter** (legacy, used for firm-level verification):
+- Calls external IAPD API at `IAPD_VERIFY_BASE_URL/verify-advisory`
+- Used in the `VerificationGateway` / `FinraVerificationAdapter` chain
+
+**FinraVerificationAdapter** (backward-compat wrapper):
+- Tries IAPD adapter first, falls back to Intelligence adapter
+- Used by `VerificationGateway`
+
+**Production guards** (`validate_regulated_runtime_configuration()`):
+- In production: requires `IAPD_VERIFY_BASE_URL`, `IAPD_VERIFY_API_KEY` to be set
+- In production: FAILS if any bypass env vars are truthy
+- In production: FAILS if `RIA_DEV_ALLOWLIST` is set
+
+---
+
+## Verification Status Lifecycle
+
+```
+draft -> submitted -> verified | not_verified | provider_unavailable
+                                     |
+                              (CRD-backed Stage1)
+                                     |
+                              advisory_status = "verified"
+                              verification_status = "verified"
+```
+
+Valid "verified" statuses throughout the system: `active`, `verified`, `finra_verified`
+
+These statuses grant:
+- Access through `require_ria_verified()` backend gate
+- Access through `RiaVerificationGate` frontend component
+- `verification_badge = 'verified'` in marketplace_public_profiles
+
+---
+
+## Database Schema (Key Tables)
+
+### IAM Tables (required for RIA features)
+- `actor_profiles`: user_id, personas[], last_active_persona, investor_marketplace_opt_in
+- `ria_profiles`: user_id, display_name, legal_name, finra_crd, sec_iard, verification_status, verification_provider, requested_capabilities[], individual_legal_name, individual_crd, advisory_firm_*, broker_firm_*, advisory_status, brokerage_status
+- `ria_firms`: legal_name, finra_firm_crd, sec_iard, website_url
+- `ria_firm_memberships`: ria_profile_id, firm_id, role_title, membership_status, is_primary
+- `ria_verification_events`: ria_profile_id, provider, outcome, checked_at, expires_at, reference_metadata (audit trail)
+- `marketplace_public_profiles`: user_id, profile_type, display_name, verification_badge, is_discoverable
+- `advisor_investor_relationships`: RIA-to-investor consent/relationship tracking
+- `ria_client_invites`: invite management
+- `consent_scope_templates`: what data RIAs can request access to
+- `runtime_persona_state`: persists last active persona across sessions
+
+### Other Key Tables
+- `vault_keys`: user encryption keys
+- `pkm_*`: Personal Knowledge Management (user data store)
+- `kai_*`: Kai financial platform tables (plaid, funding, gmail, etc.)
+- `consent_audit`, `consent_exports`: consent tracking
+
+### Schema Readiness
+- `_ensure_iam_schema_ready()` checks all tables in `_IAM_REQUIRED_TABLES` exist
+- Uses TTL-aware cache (300s) so new migrations are picked up within 5 minutes
+- If schema not ready: returns `IAMSchemaNotReadyError` (503) with migration hint
+
+---
+
+## Tri-Flow Architecture (Web + iOS + Android)
+
+The verification and persona systems serve three client surfaces:
+1. **Web** (Next.js): Full onboarding wizard, proxy routes
+2. **iOS**: Native app hitting the same `/api/ria/*` backend endpoints
+3. **Android**: Same backend endpoints
+
+The `ria-page-shell.tsx` includes `nativeTest` props for native app testing markers (`routeId`, `marker`, `authState`, `dataState`, `errorCode`). This is how native apps detect page states.
+
+---
+
+## Account Lifecycle
+
+**Delete** (`AccountService.delete_account(user_id, target="both")`):
+- Cascades across 43+ table categories
+- Supports partial deletion: `target="investor"` or `target="ria"` or `target="both"`
+- Route: `DELETE /api/account/delete` requires `VAULT_OWNER` token (Unlock to Delete pattern)
+
+**Export** (`AccountService.export_data(user_id)`):
+- Returns encrypted/private-user-bound payloads
+- No plaintext PKM content in export
+
+**Admin deletion** (`scripts/admin_delete_user_by_email.py`):
+- Looks up Firebase UID by email
+- Scans 30+ tables for user data
+- Supports dry-run mode (default)
+- Production guard: requires `--allow-production` flag
+- Optional Firebase Auth deletion: `--delete-firebase` flag
+
+---
+
+## Environment & Configuration
+
+### Key Environment Variables
+- `APP_ENV` / `ENVIRONMENT` / `HUSHH_ENV` / `ENV`: Runtime environment detection
+- `PYTHON_API_URL`: Backend URL for Next.js proxy
+- `RIA_INTELLIGENCE_BASE_URL`: Stage1 lookup API base URL
+- `RIA_INTELLIGENCE_API_KEY`: API key for Stage1 lookup
+- `IAPD_VERIFY_BASE_URL` / `IAPD_VERIFY_API_KEY`: IAPD verification API
+- `FIREBASE_ADMIN_CREDENTIALS_JSON`: Firebase Admin SDK config
+- `RIA_ONBOARDING_PROXY_TIMEOUT_MS`: Proxy timeout for onboarding (default 90s)
+
+### Production Guards
+- `validate_regulated_runtime_configuration()` runs at startup in production
+- Ensures verification APIs are configured
+- Prevents any bypass flags from reaching production
+
+---
+
+## Common Patterns
+
+### Error Handling
+- `IAMSchemaNotReadyError`: 503, means IAM tables don't exist yet
+- `RIAIAMPolicyError`: 400/403, policy violations (unverified, invalid input)
+- `provider_unavailable`: external API down, returns 503 to frontend
+
+### Caching
+- Server-side persona state: 30s TTL in `_PERSONA_STATE_CACHE`
+- Stage1 verification results: 300s TTL, keyed by `normalized_name|crd:normalized_crd`
+- IAM schema readiness: 300s TTL in `_TABLE_EXISTS_CACHE`
+- Frontend: `CacheService` with session-scoped TTL
+- Next.js proxy: 30s hot-cache for onboarding status GET with auth dedup
+
+### Connection Management
+- Backend uses `asyncpg` connection pool via `get_pool()`
+- `_PooledAsyncpgConnection` wrapper for pool release on `conn.close()`
+- All service methods follow: `conn = await self._conn()` -> `try/finally conn.close()`
+
+---
+
+## Critical Rules for Making Changes
+
+1. **Every RIA must pass Stage 1 CRD-backed verification.** No bypass paths. No dev shortcuts. The product rule is absolute: provide your CRD, get verified against FINRA, or you cannot onboard as an RIA.
+
+2. **Verification status values must be consistent across all layers**: backend `_RIA_VERIFIED_STATUSES`, frontend `_VERIFIED_STATUSES` in ria-page-shell, `isAdvisoryAccessReady()` in onboarding, SQL queries in marketplace/verification_badge logic.
+
+3. **Changes touch both repos.** RIA features span `consent-protocol/` (Python) and `hushh-webapp/` (TypeScript). Always trace the full path: frontend UI -> proxy route -> backend route -> service method -> verification adapter -> database.
+
+4. **The proxy is transparent.** The catch-all route at `app/api/ria/[...path]/route.ts` just forwards requests. Business logic lives entirely in the Python backend.
+
+5. **Database schema changes require migration + verification.** Use `python db/migrate.py --iam` and `python db/verify/verify_iam_schema.py`. The system degrades gracefully (503) when schema is missing.
+
+6. **Native apps share the same backend.** iOS and Android hit the same `/api/ria/*` endpoints. Frontend-only changes don't affect native flows, but backend changes affect all three surfaces.
+
+7. **Always run the production guard after env changes.** `validate_regulated_runtime_configuration()` should pass. It prevents bypass flags from reaching production.
+
+8. **Persona state is the source of truth** for what a user can do. The backend builds it; the frontend caches and consumes it. Never make authorization decisions purely on the frontend.

--- a/consent-protocol/api/routes/ria.py
+++ b/consent-protocol/api/routes/ria.py
@@ -212,34 +212,6 @@ async def verify_onboarding_name(
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
 
-@router.post("/onboarding/dev-activate")
-async def dev_activate_onboarding(
-    payload: RIAOnboardingSubmitRequest,
-    firebase_uid: str = Depends(require_firebase_auth),
-):
-    service = RIAIAMService()
-    try:
-        return await service.activate_ria_dev_onboarding(
-            firebase_uid,
-            display_name=payload.display_name,
-            requested_capabilities=payload.requested_capabilities,
-            individual_legal_name=payload.individual_legal_name or payload.legal_name,
-            individual_crd=payload.individual_crd or payload.finra_crd,
-            advisory_firm_legal_name=payload.advisory_firm_legal_name or payload.primary_firm_name,
-            advisory_firm_iapd_number=payload.advisory_firm_iapd_number or payload.sec_iard,
-            broker_firm_legal_name=payload.broker_firm_legal_name,
-            broker_firm_crd=payload.broker_firm_crd,
-            bio=payload.bio,
-            strategy=payload.strategy,
-            disclosures_url=payload.disclosures_url,
-            primary_firm_role=payload.primary_firm_role,
-        )
-    except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
-    except RIAIAMPolicyError as exc:
-        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
-
-
 @router.get("/onboarding/status")
 async def onboarding_status(firebase_uid: str = Depends(require_firebase_auth)):
     service = RIAIAMService()

--- a/consent-protocol/hushh_mcp/services/consent_center_service.py
+++ b/consent-protocol/hushh_mcp/services/consent_center_service.py
@@ -1078,7 +1078,6 @@ class ConsentCenterService:
                 "primary_nav_persona": "investor",
                 "ria_setup_available": False,
                 "ria_switch_available": False,
-                "dev_ria_bypass_allowed": False,
                 "investor_marketplace_opt_in": False,
                 "iam_schema_ready": False,
                 "mode": "compat_investor",

--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -198,31 +198,16 @@ class RIAIAMService:
         raw = str(os.getenv(name, fallback)).strip().lower()
         return raw in {"1", "true", "yes", "on"}
 
-    def _is_ria_dev_bypass_enabled(self) -> bool:
-        if not self._env_truthy("RIA_DEV_BYPASS_ENABLED"):
-            return False
-        return self._runtime_environment() not in {"prod", "production"}
-
-    def _is_dev_bypass_allowed(self, user_id: str) -> bool:
-        if not self._is_ria_dev_bypass_enabled():
-            return False
-        allowlist_raw = str(os.getenv("RIA_DEV_ALLOWLIST", "")).strip()
-        if not allowlist_raw:
-            return True
-        allowed_ids = {uid.strip() for uid in allowlist_raw.split(",") if uid.strip()}
-        return user_id in allowed_ids
-
     _RIA_VERIFIED_STATUSES: frozenset[str] = frozenset(
-        {"active", "verified", "bypassed", "finra_verified"}
+        {"active", "verified", "finra_verified"}
     )
 
     async def require_ria_verified(self, user_id: str) -> None:
         """Fail-closed check: raises 403 if the RIA is not verified.
 
         Checked before any endpoint that exposes investor data.
+        Every RIA must pass Stage 1 CRD-backed verification — no bypass paths.
         """
-        if self._is_dev_bypass_allowed(user_id):
-            return
         try:
             conn = await self._conn()
         except Exception as exc:
@@ -427,7 +412,6 @@ class RIAIAMService:
         investor_marketplace_opt_in: bool,
         iam_schema_ready: bool,
         mode: Literal["full", "compat_investor"],
-        dev_ria_bypass_allowed: bool = False,
     ) -> dict[str, Any]:
         safe_personas = [persona for persona in personas if persona in _ALLOWED_PERSONAS]
         if not safe_personas:
@@ -447,7 +431,6 @@ class RIAIAMService:
             "primary_nav_persona": safe_last,
             "ria_setup_available": ria_setup_available,
             "ria_switch_available": ria_switch_available,
-            "dev_ria_bypass_allowed": bool(dev_ria_bypass_allowed and iam_schema_ready),
             "investor_marketplace_opt_in": bool(investor_marketplace_opt_in),
             "iam_schema_ready": iam_schema_ready,
             "mode": mode,
@@ -506,7 +489,6 @@ class RIAIAMService:
         return RIAIAMService._normalize_legacy_verification_status(status) in {
             "verified",
             "active",
-            "bypassed",
         }
 
     @staticmethod
@@ -516,8 +498,6 @@ class RIAIAMService:
             "ria_intelligence",
             "ria_intelligence_stage1",
             "iapd",
-            "dev_allowlist",
-            "advisory_bypass",
         }:
             return provider
         return "regulatory_verification"
@@ -845,7 +825,7 @@ class RIAIAMService:
                         investor_marketplace_opt_in=False,
                         iam_schema_ready=False,
                         mode="compat_investor",
-                        dev_ria_bypass_allowed=False,
+
                     )
                     self._write_cached_persona_state(user_id, response)
                     return response
@@ -870,7 +850,7 @@ class RIAIAMService:
                     investor_marketplace_opt_in=bool(row["investor_marketplace_opt_in"]),
                     iam_schema_ready=True,
                     mode="full",
-                    dev_ria_bypass_allowed=self._is_dev_bypass_allowed(user_id),
+
                 )
                 self._write_cached_persona_state(user_id, response)
                 return response
@@ -900,7 +880,7 @@ class RIAIAMService:
                         investor_marketplace_opt_in=False,
                         iam_schema_ready=False,
                         mode="compat_investor",
-                        dev_ria_bypass_allowed=False,
+
                     )
                     self._write_cached_persona_state(user_id, response)
                     return response
@@ -916,7 +896,7 @@ class RIAIAMService:
                         investor_marketplace_opt_in=bool(current["investor_marketplace_opt_in"]),
                         iam_schema_ready=True,
                         mode="full",
-                        dev_ria_bypass_allowed=self._is_dev_bypass_allowed(user_id),
+    
                     )
                     self._write_cached_persona_state(user_id, response)
                     return response
@@ -947,7 +927,7 @@ class RIAIAMService:
                     investor_marketplace_opt_in=bool(row["investor_marketplace_opt_in"]),
                     iam_schema_ready=True,
                     mode="full",
-                    dev_ria_bypass_allowed=self._is_dev_bypass_allowed(user_id),
+
                 )
                 self._write_cached_persona_state(user_id, response)
                 return response
@@ -2478,7 +2458,7 @@ class RIAIAMService:
                     UPDATE marketplace_public_profiles
                     SET
                       verification_badge = CASE
-                        WHEN $2 IN ('finra_verified', 'active', 'bypassed') THEN 'verified'
+                        WHEN $2 IN ('finra_verified', 'active', 'verified') THEN 'verified'
                         ELSE 'pending'
                       END,
                       updated_at = NOW()
@@ -2525,7 +2505,7 @@ class RIAIAMService:
                       $2,
                       COALESCE(NULLIF($3, ''), NULLIF($4, ''), 'Registered Investment Advisor'),
                       NULLIF($4, ''),
-                      CASE WHEN $5 IN ('finra_verified', 'active', 'bypassed') THEN 'verified' ELSE 'pending' END,
+                      CASE WHEN $5 IN ('finra_verified', 'active', 'verified') THEN 'verified' ELSE 'pending' END,
                       TRUE,
                       NOW()
                     )
@@ -2587,271 +2567,16 @@ class RIAIAMService:
         finally:
             await conn.close()
 
-    async def activate_ria_dev_onboarding(
-        self,
-        user_id: str,
-        *,
-        display_name: str,
-        requested_capabilities: list[str] | tuple[str, ...] | None = None,
-        individual_legal_name: str | None = None,
-        individual_crd: str | None = None,
-        advisory_firm_legal_name: str | None = None,
-        advisory_firm_iapd_number: str | None = None,
-        broker_firm_legal_name: str | None = None,
-        broker_firm_crd: str | None = None,
-        legal_name: str | None = None,
-        finra_crd: str | None = None,
-        sec_iard: str | None = None,
-        bio: str | None = None,
-        strategy: str | None = None,
-        disclosures_url: str | None = None,
-        primary_firm_name: str | None = None,
-        primary_firm_role: str | None = None,
-    ) -> dict[str, Any]:
-        if not self._is_dev_bypass_allowed(user_id):
-            raise RIAIAMPolicyError(
-                "RIA dev activation is not allowed for this account", status_code=403
-            )
-        if not display_name.strip():
-            raise RIAIAMPolicyError("display_name is required", status_code=400)
+    async def _removed_activate_ria_dev_onboarding(self) -> None:
+        """Dev bypass onboarding has been permanently removed.
 
-        normalized_requested_capabilities: list[str] = []
-        for capability in requested_capabilities or []:
-            candidate = str(capability or "").strip().lower()
-            if not candidate:
-                continue
-            if candidate not in _ALLOWED_PROFESSIONAL_CAPABILITIES:
-                raise RIAIAMPolicyError(
-                    "requested_capabilities contains unsupported capability",
-                    status_code=400,
-                )
-            if candidate not in normalized_requested_capabilities:
-                normalized_requested_capabilities.append(candidate)
-        if not normalized_requested_capabilities:
-            normalized_requested_capabilities = ["advisory"]
-
-        effective_legal_name = (
-            self._normalize_optional_text(individual_legal_name)
-            or self._normalize_optional_text(legal_name)
-            or display_name.strip()
+        Every RIA must complete Stage 1 CRD-backed verification.
+        Use submit_ria_onboarding() instead.
+        """
+        raise RIAIAMPolicyError(
+            "Dev bypass onboarding is no longer available. All RIAs must complete CRD-backed verification.",
+            status_code=410,
         )
-        effective_finra_crd = self._normalize_optional_text(
-            individual_crd
-        ) or self._normalize_optional_text(finra_crd)
-        effective_sec_iard = self._normalize_optional_text(
-            advisory_firm_iapd_number
-        ) or self._normalize_optional_text(sec_iard)
-        effective_primary_firm_name = self._normalize_optional_text(
-            advisory_firm_legal_name
-        ) or self._normalize_optional_text(primary_firm_name)
-        effective_broker_firm_name = self._normalize_optional_text(broker_firm_legal_name)
-        effective_broker_firm_crd = self._normalize_optional_text(broker_firm_crd)
-
-        conn = await self._conn()
-        try:
-            async with conn.transaction():
-                await self._ensure_vault_user_row(conn, user_id)
-                await self._ensure_iam_schema_ready(conn)
-                await conn.execute(
-                    """
-                    INSERT INTO actor_profiles (
-                        user_id,
-                        personas,
-                        last_active_persona,
-                        investor_marketplace_opt_in
-                    )
-                    VALUES ($1, ARRAY['investor','ria']::text[], 'ria', FALSE)
-                    ON CONFLICT (user_id) DO UPDATE
-                    SET
-                      personas = CASE
-                        WHEN 'ria' = ANY(actor_profiles.personas) THEN actor_profiles.personas
-                        ELSE array_append(actor_profiles.personas, 'ria')
-                      END,
-                      last_active_persona = 'ria',
-                      updated_at = NOW()
-                    """,
-                    user_id,
-                )
-                await self._set_runtime_last_persona(conn, user_id, "ria")
-
-                ria = await conn.fetchrow(
-                    """
-                    INSERT INTO ria_profiles (
-                      user_id,
-                      display_name,
-                      legal_name,
-                      finra_crd,
-                      sec_iard,
-                      verification_status,
-                      verification_provider,
-                      bio,
-                      strategy,
-                      disclosures_url
-                    )
-                    VALUES (
-                      $1,
-                      $2,
-                      NULLIF($3, ''),
-                      NULLIF($4, ''),
-                      NULLIF($5, ''),
-                      'active',
-                      'dev_allowlist',
-                      NULLIF($6, ''),
-                      NULLIF($7, ''),
-                      NULLIF($8, '')
-                    )
-                    ON CONFLICT (user_id) DO UPDATE
-                    SET
-                      display_name = EXCLUDED.display_name,
-                      legal_name = EXCLUDED.legal_name,
-                      finra_crd = EXCLUDED.finra_crd,
-                      sec_iard = EXCLUDED.sec_iard,
-                      verification_status = 'active',
-                      verification_provider = 'dev_allowlist',
-                      verification_expires_at = NULL,
-                      bio = EXCLUDED.bio,
-                      strategy = EXCLUDED.strategy,
-                      disclosures_url = EXCLUDED.disclosures_url,
-                      updated_at = NOW()
-                    RETURNING id, user_id, display_name
-                    """,
-                    user_id,
-                    display_name.strip(),
-                    effective_legal_name,
-                    effective_finra_crd or "",
-                    effective_sec_iard or "",
-                    (bio or "").strip(),
-                    (strategy or "").strip(),
-                    (disclosures_url or "").strip(),
-                )
-                if ria is None:
-                    raise RuntimeError("Failed to create RIA profile")
-
-                firm_id: str | None = None
-                if effective_primary_firm_name and effective_primary_firm_name.strip():
-                    firm_row = await conn.fetchrow(
-                        """
-                        INSERT INTO ria_firms (legal_name)
-                        VALUES ($1)
-                        ON CONFLICT (legal_name) DO UPDATE
-                        SET updated_at = NOW()
-                        RETURNING id
-                        """,
-                        effective_primary_firm_name.strip(),
-                    )
-                    if firm_row:
-                        firm_id = str(firm_row["id"])
-                        await conn.execute(
-                            """
-                            INSERT INTO ria_firm_memberships (
-                              ria_profile_id,
-                              firm_id,
-                              role_title,
-                              membership_status,
-                              is_primary
-                            )
-                            VALUES ($1, $2, NULLIF($3, ''), 'active', TRUE)
-                            ON CONFLICT (ria_profile_id, firm_id) DO UPDATE
-                            SET
-                              role_title = EXCLUDED.role_title,
-                              membership_status = 'active',
-                              is_primary = TRUE,
-                              updated_at = NOW()
-                            """,
-                            ria["id"],
-                            firm_row["id"],
-                            (primary_firm_role or "").strip(),
-                        )
-
-                await conn.execute(
-                    """
-                    INSERT INTO ria_verification_events (
-                      ria_profile_id,
-                      provider,
-                      outcome,
-                      checked_at,
-                      expires_at,
-                      reference_metadata
-                    )
-                    VALUES ($1, 'dev_allowlist', 'bypassed', NOW(), NULL, $2::jsonb)
-                    """,
-                    ria["id"],
-                    json.dumps({"source": "dev_allowlist", "user_id": user_id}),
-                )
-
-                await conn.execute(
-                    """
-                    INSERT INTO marketplace_public_profiles (
-                      user_id,
-                      profile_type,
-                      display_name,
-                      headline,
-                      strategy_summary,
-                      verification_badge,
-                      is_discoverable,
-                      updated_at
-                    )
-                    VALUES (
-                      $1,
-                      'ria',
-                      $2,
-                      COALESCE(NULLIF($3, ''), NULLIF($4, ''), 'Registered Investment Advisor'),
-                      NULLIF($4, ''),
-                      'dev_allowlist',
-                      TRUE,
-                      NOW()
-                    )
-                    ON CONFLICT (user_id) DO UPDATE
-                    SET
-                      profile_type = 'ria',
-                      display_name = EXCLUDED.display_name,
-                      headline = EXCLUDED.headline,
-                      strategy_summary = EXCLUDED.strategy_summary,
-                      verification_badge = EXCLUDED.verification_badge,
-                      is_discoverable = TRUE,
-                      updated_at = NOW()
-                    """,
-                    user_id,
-                    display_name.strip(),
-                    (bio or "").strip(),
-                    (strategy or "").strip(),
-                )
-
-                return {
-                    "ria_profile_id": str(ria["id"]),
-                    "user_id": str(ria["user_id"]),
-                    "display_name": str(ria["display_name"]),
-                    "verification_status": "active",
-                    "advisory_status": "active",
-                    "brokerage_status": (
-                        "draft" if "brokerage" in normalized_requested_capabilities else "draft"
-                    ),
-                    "requested_capabilities": normalized_requested_capabilities,
-                    "verification_outcome": "dev_allowlist",
-                    "verification_message": "RIA activated for an allowlisted development account",
-                    "brokerage_outcome": (
-                        "not_requested"
-                        if "brokerage" not in normalized_requested_capabilities
-                        else "unsupported"
-                    ),
-                    "brokerage_message": (
-                        "Brokerage capability was not requested."
-                        if "brokerage" not in normalized_requested_capabilities
-                        else "Brokerage verification is not yet enabled in this onboarding path."
-                    ),
-                    "professional_access_granted": True,
-                    "individual_legal_name": effective_legal_name,
-                    "individual_crd": effective_finra_crd,
-                    "advisory_firm_legal_name": effective_primary_firm_name,
-                    "advisory_firm_iapd_number": effective_sec_iard,
-                    "broker_firm_legal_name": effective_broker_firm_name,
-                    "broker_firm_crd": effective_broker_firm_crd,
-                    "firm_id": firm_id,
-                }
-        except asyncpg.exceptions.UndefinedTableError as exc:
-            raise IAMSchemaNotReadyError() from exc
-        finally:
-            await conn.close()
 
     async def get_ria_onboarding_status(self, user_id: str) -> dict[str, Any]:
         conn = await self._conn()
@@ -2923,7 +2648,7 @@ class RIAIAMService:
                 return {
                     "exists": False,
                     "verification_status": "draft",
-                    "dev_ria_bypass_allowed": self._is_dev_bypass_allowed(user_id),
+
                 }
 
             latest_event = await conn.fetchrow(
@@ -2992,7 +2717,6 @@ class RIAIAMService:
                 "verification_status": ria["verification_status"],
                 "verification_provider": ria["verification_provider"],
                 "verification_expires_at": ria["verification_expires_at"],
-                "dev_ria_bypass_allowed": self._is_dev_bypass_allowed(user_id),
                 "latest_verification_event": event,
             }
         except asyncpg.exceptions.UndefinedTableError as exc:
@@ -3043,7 +2767,7 @@ class RIAIAMService:
             onboarding.get("advisory_status") or onboarding.get("verification_status") or "draft"
         )
 
-        if verification_status in {"active", "verified", "bypassed"}:
+        if verification_status in {"active", "verified"}:
             primary_action = {
                 "label": "Open clients",
                 "href": "/ria/clients",

--- a/consent-protocol/hushh_mcp/services/ria_verification.py
+++ b/consent-protocol/hushh_mcp/services/ria_verification.py
@@ -692,23 +692,6 @@ class IapdVerificationAdapter:
         advisory_firm_iapd_number: str,
         force_live: bool = False,
     ) -> VerificationResult:
-        if (
-            not force_live
-            and not _is_production()
-            and (
-                _env_truthy("ADVISORY_VERIFICATION_BYPASS_ENABLED")
-                or _env_truthy("RIA_DEV_BYPASS_ENABLED")
-            )
-        ):
-            return VerificationResult(
-                verified=True,
-                rejected=False,
-                outcome="bypassed",
-                message="Advisory verification bypassed in this non-production environment.",
-                expires_at=datetime.now(timezone.utc) + timedelta(days=1),
-                metadata={"provider": "advisory_bypass", "reason": "bypass_enabled"},
-            )
-
         if not self._base_url or not self._api_key:
             return VerificationResult(
                 verified=False,
@@ -810,16 +793,6 @@ class BrokerVerificationAdapter:
         broker_firm_legal_name: str,
         broker_firm_crd: str,
     ) -> VerificationResult:
-        if not _is_production() and _env_truthy("BROKER_VERIFICATION_BYPASS_ENABLED"):
-            return VerificationResult(
-                verified=True,
-                rejected=False,
-                outcome="bypassed",
-                message="Broker verification bypassed in this non-production environment.",
-                expires_at=datetime.now(timezone.utc) + timedelta(days=1),
-                metadata={"provider": "broker_bypass", "reason": "bypass_enabled"},
-            )
-
         if not self._base_url or not self._api_key:
             if self._public_fallback_enabled:
                 return VerificationResult(

--- a/consent-protocol/scripts/setup_kai_test_marketplace_profiles.py
+++ b/consent-protocol/scripts/setup_kai_test_marketplace_profiles.py
@@ -181,18 +181,18 @@ def main() -> int:
     log("Step 2: Enriching investor marketplace profile via DB...")
     _enrich_investor_marketplace_profile(config)
 
-    # ─── Step 3: Ensure RIA profile via dev-activate ───
+    # ─── Step 3: Ensure RIA profile via onboarding submit ───
     log("Step 3: Checking RIA onboarding status...")
     ria_status = api("GET", backend_url, "/api/ria/onboarding/status", auth_headers)
     verification_status = str(ria_status.get("verification_status") or "")
     log(f"  Current RIA verification_status={verification_status}")
 
-    if verification_status not in {"active", "finra_verified", "bypassed"}:
-        log("  Activating RIA profile via dev-activate...")
+    if verification_status not in {"active", "finra_verified", "verified"}:
+        log("  Submitting RIA profile via onboarding/submit...")
         ria_activate = api(
             "POST",
             backend_url,
-            "/api/ria/onboarding/dev-activate",
+            "/api/ria/onboarding/submit",
             auth_headers,
             {
                 "display_name": "Kai Advisory Partners",
@@ -203,6 +203,7 @@ def main() -> int:
                 "advisory_firm_iapd_number": "801-99999",
                 "bio": "Full-service advisory practice focused on high-conviction quality compounders and tax-aware portfolio management.",
                 "strategy": "Long-term quality compounders with disciplined position sizing and downside protection through diversification.",
+                "force_live_verification": True,
             },
         )
         log(f"  RIA activation: verification_status={ria_activate.get('verification_status')}")

--- a/consent-protocol/scripts/uat_kai_regression_smoke.py
+++ b/consent-protocol/scripts/uat_kai_regression_smoke.py
@@ -1104,7 +1104,7 @@ class UatKaiSmoke:
             headers=self._firebase_auth_headers(),
         ).json()
         verification_status = str(status_response.get("verification_status") or "")
-        if verification_status in {"active", "finra_verified", "bypassed"}:
+        if verification_status in {"active", "finra_verified", "verified"}:
             return status_response
         payload = {
             "display_name": "Kai Test Advisory",
@@ -1114,10 +1114,11 @@ class UatKaiSmoke:
             "advisory_firm_legal_name": "Kai Test Advisory LLC",
             "advisory_firm_iapd_number": "123456",
             "strategy": "Long-term quality compounders",
+            "force_live_verification": True,
         }
         response = self._request(
             "POST",
-            "/api/ria/onboarding/dev-activate",
+            "/api/ria/onboarding/submit",
             headers={**self._firebase_auth_headers(), "Content-Type": "application/json"},
             json_body=payload,
         )

--- a/consent-protocol/tests/test_ria_iam_service_architecture.py
+++ b/consent-protocol/tests/test_ria_iam_service_architecture.py
@@ -148,7 +148,7 @@ def test_name_first_inputs_allow_missing_manual_regulatory_identity():
 def test_ria_verified_status_helper_matches_expected_statuses():
     assert RIAIAMService._is_verified_ria_status("verified") is True
     assert RIAIAMService._is_verified_ria_status("active") is True
-    assert RIAIAMService._is_verified_ria_status("bypassed") is True
+    assert RIAIAMService._is_verified_ria_status("bypassed") is False
     assert RIAIAMService._is_verified_ria_status("submitted") is False
 
 
@@ -362,68 +362,10 @@ async def test_submit_ria_onboarding_rejects_entered_crd_mismatch(monkeypatch):
         )
 
 
-@pytest.mark.asyncio
-async def test_dev_activation_records_allowed_bypass_event(monkeypatch):
+def test_dev_activation_method_removed():
+    """activate_ria_dev_onboarding was fully removed — method must not exist."""
     service = RIAIAMService()
-    executed: list[tuple[str, tuple[object, ...]]] = []
-
-    class _FakeTransaction:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            return False
-
-    class _FakeConn:
-        def transaction(self):
-            return _FakeTransaction()
-
-        async def fetchrow(self, query: str, *_args):
-            if "INSERT INTO ria_profiles" in query:
-                return {"id": "ria-profile-1", "user_id": "user-1", "display_name": "Advisor Alpha"}
-            return None
-
-        async def execute(self, query: str, *args):
-            executed.append((query, args))
-            return None
-
-        async def close(self):
-            return None
-
-    async def _fake_conn():
-        return _FakeConn()
-
-    async def _fake_schema_ready(_conn):
-        return None
-
-    async def _fake_vault_user_row(_conn, _user_id):
-        return None
-
-    async def _fake_runtime_persona(_conn, _user_id, _persona):
-        return None
-
-    monkeypatch.setenv("RIA_DEV_BYPASS_ENABLED", "true")
-    monkeypatch.setenv("ENVIRONMENT", "development")
-    monkeypatch.delenv("RIA_DEV_ALLOWLIST", raising=False)
-    monkeypatch.setattr(service, "_conn", _fake_conn)
-    monkeypatch.setattr(service, "_ensure_iam_schema_ready", _fake_schema_ready)
-    monkeypatch.setattr(service, "_ensure_vault_user_row", _fake_vault_user_row)
-    monkeypatch.setattr(service, "_set_runtime_last_persona", _fake_runtime_persona)
-
-    result = await service.activate_ria_dev_onboarding(
-        "user-1",
-        display_name="Advisor Alpha",
-        requested_capabilities=["advisory"],
-    )
-
-    assert result["verification_status"] == "active"
-    assert result["verification_outcome"] == "dev_allowlist"
-    event_queries = [
-        query for query, _args in executed if "INSERT INTO ria_verification_events" in query
-    ]
-    assert event_queries
-    assert "'bypassed'" in event_queries[0]
-    assert "'dev_allowlist', 'dev_allowlist'" not in event_queries[0]
+    assert not hasattr(service, "activate_ria_dev_onboarding")
 
 
 def test_renaissance_service_exposes_generic_security_list_descriptors():

--- a/consent-protocol/tests/test_ria_verification_hardening.py
+++ b/consent-protocol/tests/test_ria_verification_hardening.py
@@ -23,54 +23,20 @@ def _build_app() -> FastAPI:
 
 
 # ---------------------------------------------------------------------------
-# Backend: dev allowlist respects RIA_DEV_ALLOWLIST
+# Backend: bypass has been permanently removed
 # ---------------------------------------------------------------------------
 
 
-def test_dev_bypass_allowed_when_no_allowlist_set(monkeypatch):
-    monkeypatch.setenv("RIA_DEV_BYPASS_ENABLED", "true")
-    monkeypatch.setenv("ENVIRONMENT", "development")
-    monkeypatch.delenv("RIA_DEV_ALLOWLIST", raising=False)
+def test_bypassed_status_not_in_verified_statuses():
+    """Ensure 'bypassed' is not treated as a verified RIA status."""
+    assert "bypassed" not in RIAIAMService._RIA_VERIFIED_STATUSES
 
+
+def test_no_dev_bypass_method_exists():
+    """Ensure the dev bypass methods have been removed."""
     service = RIAIAMService()
-    assert service._is_dev_bypass_allowed("any_user_id") is True
-
-
-def test_dev_bypass_allowed_for_listed_user(monkeypatch):
-    monkeypatch.setenv("RIA_DEV_BYPASS_ENABLED", "true")
-    monkeypatch.setenv("ENVIRONMENT", "development")
-    monkeypatch.setenv("RIA_DEV_ALLOWLIST", "user_a,user_b")
-
-    service = RIAIAMService()
-    assert service._is_dev_bypass_allowed("user_a") is True
-    assert service._is_dev_bypass_allowed("user_b") is True
-
-
-def test_dev_bypass_denied_for_unlisted_user(monkeypatch):
-    monkeypatch.setenv("RIA_DEV_BYPASS_ENABLED", "true")
-    monkeypatch.setenv("ENVIRONMENT", "development")
-    monkeypatch.setenv("RIA_DEV_ALLOWLIST", "user_a,user_b")
-
-    service = RIAIAMService()
-    assert service._is_dev_bypass_allowed("user_c") is False
-
-
-def test_dev_bypass_denied_in_production(monkeypatch):
-    monkeypatch.setenv("RIA_DEV_BYPASS_ENABLED", "true")
-    monkeypatch.setenv("ENVIRONMENT", "production")
-    monkeypatch.setenv("RIA_DEV_ALLOWLIST", "user_a")
-
-    service = RIAIAMService()
-    assert service._is_dev_bypass_allowed("user_a") is False
-
-
-def test_dev_bypass_denied_when_flag_off(monkeypatch):
-    monkeypatch.setenv("RIA_DEV_BYPASS_ENABLED", "false")
-    monkeypatch.setenv("ENVIRONMENT", "development")
-    monkeypatch.setenv("RIA_DEV_ALLOWLIST", "user_a")
-
-    service = RIAIAMService()
-    assert service._is_dev_bypass_allowed("user_a") is False
+    assert not hasattr(service, "_is_dev_bypass_allowed")
+    assert not hasattr(service, "_is_ria_dev_bypass_enabled")
 
 
 # ---------------------------------------------------------------------------
@@ -202,7 +168,7 @@ def test_verified_ria_passes_gate(monkeypatch):
 
 def test_onboarding_status_not_gated(monkeypatch):
     async def _mock_status(self, user_id):
-        return {"exists": False, "verification_status": "draft", "dev_ria_bypass_allowed": False}
+        return {"exists": False, "verification_status": "draft"}
 
     monkeypatch.setattr(RIAIAMService, "get_ria_onboarding_status", _mock_status)
 

--- a/consent-protocol/tests/test_ria_verification_intelligence.py
+++ b/consent-protocol/tests/test_ria_verification_intelligence.py
@@ -320,7 +320,8 @@ def test_finra_adapter_reports_configuration_gap_when_providers_unconfigured(mon
     assert "not configured" in result.message.lower()
 
 
-def test_iapd_adapter_honors_advisory_bypass_in_non_production(monkeypatch):
+def test_iapd_adapter_never_bypasses_even_with_bypass_env(monkeypatch):
+    """Bypass was removed — IAPD adapter must fail-closed when unconfigured."""
     monkeypatch.setenv("ENVIRONMENT", "development")
     monkeypatch.setenv("ADVISORY_VERIFICATION_BYPASS_ENABLED", "true")
     monkeypatch.delenv("IAPD_VERIFY_BASE_URL", raising=False)
@@ -336,10 +337,8 @@ def test_iapd_adapter_honors_advisory_bypass_in_non_production(monkeypatch):
         )
     )
 
-    assert result.verified is True
-    assert result.rejected is False
-    assert result.outcome == "bypassed"
-    assert "bypass" in result.message.lower()
+    assert result.verified is False
+    assert result.outcome != "bypassed"
 
 
 def test_stage1_lookup_returns_verified_when_crd_present(monkeypatch):
@@ -539,7 +538,8 @@ def test_stage1_lookup_does_not_cache_provider_unavailable(monkeypatch):
     assert calls["count"] == 2
 
 
-def test_finra_adapter_honors_ria_dev_bypass_alias(monkeypatch):
+def test_finra_adapter_never_bypasses_even_with_dev_bypass_env(monkeypatch):
+    """Bypass was removed — FINRA adapter must fail-closed when unconfigured."""
     monkeypatch.setenv("ENVIRONMENT", "development")
     monkeypatch.setenv("RIA_DEV_BYPASS_ENABLED", "true")
     monkeypatch.delenv("ADVISORY_VERIFICATION_BYPASS_ENABLED", raising=False)
@@ -557,10 +557,8 @@ def test_finra_adapter_honors_ria_dev_bypass_alias(monkeypatch):
         )
     )
 
-    assert result.verified is True
-    assert result.rejected is False
-    assert result.outcome == "bypassed"
-    assert "bypass" in result.message.lower()
+    assert result.verified is False
+    assert result.outcome != "bypassed"
 
 
 def _run(coro):

--- a/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
@@ -17,7 +17,6 @@ const mocks = vi.hoisted(() => ({
     getRiaPublicProfile: vi.fn(),
     verifyOnboardingName: vi.fn(),
     submitOnboarding: vi.fn(),
-    activateDevRia: vi.fn(),
     setRiaMarketplaceDiscoverability: vi.fn(),
   },
   draftService: {
@@ -193,7 +192,6 @@ describe("RiaOnboardingPage", () => {
       },
     });
     mocks.usePersonaState.mockReturnValue({
-      devRiaBypassAllowed: false,
       refresh: mocks.refreshPersonaState,
     });
     mocks.draftService.load.mockResolvedValue(null);
@@ -357,49 +355,6 @@ describe("RiaOnboardingPage", () => {
 
     expect(screen.queryByText("Trust summary")).toBeNull();
     expect(screen.queryByText("Deferred for later settings")).toBeNull();
-  });
-
-  it("offers the verification bypass only when the environment allows it", async () => {
-    mocks.usePersonaState.mockReturnValue({
-      devRiaBypassAllowed: true,
-      refresh: mocks.refreshPersonaState,
-    });
-    mocks.riaService.activateDevRia.mockResolvedValue({
-      ria_profile_id: "ria-profile-1",
-      verification_status: "active",
-      advisory_status: "active",
-      brokerage_status: "draft",
-      requested_capabilities: ["advisory"],
-      verification_outcome: "dev_allowlist",
-      verification_message: "RIA activated for an allowlisted development account",
-      brokerage_outcome: "not_requested",
-      brokerage_message: "Brokerage capability was not requested.",
-      professional_access_granted: true,
-      individual_legal_name: "Local Advisor",
-      individual_crd: null,
-      advisory_firm_legal_name: null,
-      advisory_firm_iapd_number: null,
-      broker_firm_legal_name: null,
-      broker_firm_crd: null,
-    });
-
-    render(<RiaOnboardingPage />);
-
-    const input = await screen.findByLabelText("Advisor name");
-    fireEvent.change(input, { target: { value: "Local Advisor" } });
-    fireEvent.click(screen.getByRole("button", { name: "Bypass verification" }));
-
-    await waitFor(() => {
-      expect(mocks.riaService.activateDevRia).toHaveBeenCalledWith(
-        "token-ria-1",
-        expect.objectContaining({
-          display_name: "Local Advisor",
-          requested_capabilities: ["advisory"],
-        })
-      );
-    });
-    expect(mocks.riaService.verifyOnboardingName).not.toHaveBeenCalled();
-    expect(mocks.refreshPersonaState).toHaveBeenCalledWith({ force: true });
   });
 
   it("supports Enter-to-verify and blocks continue after a failed lookup", async () => {

--- a/hushh-webapp/app/api/ria/[...path]/route.ts
+++ b/hushh-webapp/app/api/ria/[...path]/route.ts
@@ -41,7 +41,6 @@ function resolveProxyTimeoutMs(path: string, method: "GET" | "POST"): number {
     method === "POST" &&
     (
       path.startsWith("onboarding/submit") ||
-      path.startsWith("onboarding/dev-activate") ||
       path.startsWith("onboarding/verify-name")
     )
   ) {

--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -82,7 +82,7 @@ function connectionBadgeLabel(status?: string | null) {
 }
 
 function isConnectableAdvisor(status?: string | null) {
-  return ["active", "verified", "finra_verified", "bypassed"].includes(
+  return ["active", "verified", "finra_verified"].includes(
     String(status || "").toLowerCase()
   );
 }

--- a/hushh-webapp/app/marketplace/ria/page-client.tsx
+++ b/hushh-webapp/app/marketplace/ria/page-client.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { BadgeCheck, Building2, ShieldCheck } from "lucide-react";
+import { Building2, ShieldCheck } from "lucide-react";
 
 import { RiaPageShell, RiaSurface } from "@/components/ria/ria-page-shell";
 import { useAuth } from "@/hooks/use-auth";
@@ -29,12 +29,6 @@ function verificationBadge(status: string) {
         label: normalized === "finra_verified" ? "FINRA verified" : "Verified",
         className: "border-emerald-500/20 bg-emerald-500/10 text-emerald-700",
         icon: ShieldCheck,
-      };
-    case "bypassed":
-      return {
-        label: "Active",
-        className: "border-sky-500/20 bg-sky-500/10 text-sky-700",
-        icon: BadgeCheck,
       };
     case "submitted":
       return {
@@ -145,7 +139,7 @@ export default function MarketplaceRiaProfilePageClient({
   const badge = profile ? verificationBadge(profile.verification_status) : null;
   const BadgeIcon = badge?.icon ?? null;
   const isConnectable = profile
-    ? ["active", "verified", "finra_verified", "bypassed"].includes(
+    ? ["active", "verified", "finra_verified"].includes(
         profile.verification_status.toLowerCase()
       )
     : false;

--- a/hushh-webapp/app/ria/onboarding/page.tsx
+++ b/hushh-webapp/app/ria/onboarding/page.tsx
@@ -47,7 +47,6 @@ import { usePersonaState } from "@/lib/persona/persona-context";
 import { trackEvent } from "@/lib/observability/client";
 import {
   trackGrowthFunnelStepCompleted,
-  trackRiaActivationCompleted,
 } from "@/lib/observability/growth";
 
 type NameVerificationState =
@@ -111,7 +110,7 @@ function buildSubmitPayload(draft: RiaOnboardingDraft) {
 }
 
 function isAdvisoryAccessReady(status?: string | null): boolean {
-  return status === "active" || status === "verified" || status === "bypassed";
+  return status === "active" || status === "verified";
 }
 
 function normalizeCrd(value?: string | null): string {
@@ -256,7 +255,7 @@ function ReviewField({
 export default function RiaOnboardingPage() {
   const router = useRouter();
   const { user } = useAuth();
-  const { devRiaBypassAllowed, refresh: refreshPersonaState } = usePersonaState();
+  const { refresh: refreshPersonaState } = usePersonaState();
 
   const [status, setStatus] = useState<RiaOnboardingStatus | null>(null);
   const [draft, setDraft] = useState<RiaOnboardingDraft>(
@@ -671,7 +670,7 @@ export default function RiaOnboardingPage() {
     moveToStep(steps[currentStepIndex + 1]?.id ?? currentStep.id);
   }
 
-  async function finalizeSubmission(mode: "submit" | "dev_activate") {
+  async function finalizeSubmission() {
     if (!user) return;
 
     setSaving(true);
@@ -679,14 +678,11 @@ export default function RiaOnboardingPage() {
     setNotice(null);
     try {
       const idToken = await user.getIdToken();
-      if (mode === "submit" && !nameVerificationSatisfied) {
+      if (!nameVerificationSatisfied) {
         throw new Error("Verify the advisor name and wait for a CRD-backed result before continuing.");
       }
       const payload = buildSubmitPayload(draft);
-      const result =
-        mode === "submit"
-          ? await RiaService.submitOnboarding(idToken, { ...payload, force_live_verification: true })
-          : await RiaService.activateDevRia(idToken, payload);
+      const result = await RiaService.submitOnboarding(idToken, { ...payload, force_live_verification: true });
 
       setStatus((current) => ({
         ...(current || { exists: true }),
@@ -701,9 +697,8 @@ export default function RiaOnboardingPage() {
         verification_status: result.verification_status,
         advisory_status: result.advisory_status,
         brokerage_status: result.brokerage_status,
-        dev_ria_bypass_allowed: mode === "dev_activate" ? true : current?.dev_ria_bypass_allowed,
       }));
-      if (mode === "submit" && result.advisory_status === "verified") {
+      if (result.advisory_status === "verified") {
         setNameVerificationStatus("verified");
         setNameVerificationResult({
           status: "verified",
@@ -731,10 +726,8 @@ export default function RiaOnboardingPage() {
       const advisoryOutcome = (result.advisory_status || result.verification_status || "").toLowerCase();
       const verificationOutcome = (result.verification_outcome || "").toLowerCase();
       const canActivateDiscoverability =
-        mode === "dev_activate" ||
         advisoryOutcome === "verified" ||
-        advisoryOutcome === "active" ||
-        advisoryOutcome === "bypassed";
+        advisoryOutcome === "active";
 
       await RiaService.setRiaMarketplaceDiscoverability(idToken, {
         enabled: canActivateDiscoverability,
@@ -747,30 +740,7 @@ export default function RiaOnboardingPage() {
         setShouldPersistDraft(false);
       }
 
-      if (mode === "dev_activate") {
-        trackEvent("ria_verification_status_changed", {
-          action: "bypassed",
-          result: "success",
-        });
-        trackGrowthFunnelStepCompleted({
-          journey: "ria",
-          step: "workspace_ready",
-          entrySurface: "ria_onboarding",
-          workspaceSource: "developer_activation",
-          dedupeKey: "growth:ria:workspace_ready:developer_activation",
-          dedupeWindowMs: 5_000,
-        });
-        trackRiaActivationCompleted({
-          entrySurface: "ria_onboarding",
-          workspaceSource: "developer_activation",
-          dedupeKey: "growth:ria:activation:developer_activation",
-          dedupeWindowMs: 10_000,
-        });
-        toast.success("Developer activation completed", {
-          description: "The RIA workspace is ready in this environment.",
-        });
-        setNotice("Developer activation completed. The RIA workspace is ready in this environment.");
-      } else if (advisoryOutcome === "rejected") {
+      if (advisoryOutcome === "rejected") {
         trackEvent("ria_verification_status_changed", {
           action: "rejected",
           result: "error",
@@ -795,20 +765,6 @@ export default function RiaOnboardingPage() {
             "Your advisor name resolved to a verified CRD-backed RIA record.",
         });
         setNotice("Verification passed. Your RIA workspace is ready.");
-      } else if (advisoryOutcome === "bypassed") {
-        trackEvent("ria_verification_status_changed", {
-          action: "bypassed",
-          result: "success",
-        });
-        toast.warning("Verification bypass active", {
-          description:
-            result.verification_message ||
-            "This non-production environment is using the advisory verification bypass.",
-        });
-        setNotice(
-          result.verification_message ||
-            "Verification bypass is active in this environment. Your RIA workspace is ready for flow testing."
-        );
       } else if (verificationOutcome === "provider_unavailable") {
         trackEvent("ria_verification_status_changed", {
           action: "submitted",
@@ -862,11 +818,7 @@ export default function RiaOnboardingPage() {
       router.push(ROUTES.RIA_HOME);
       return;
     }
-    await finalizeSubmission("submit");
-  }
-
-  async function handleDevActivate() {
-    await finalizeSubmission("dev_activate");
+    await finalizeSubmission();
   }
 
   function renderQuestion(step: RiaOnboardingStep) {
@@ -1062,16 +1014,6 @@ export default function RiaOnboardingPage() {
                         nameVerificationStatus === "provider_unavailable"
                       ? "Retry verification"
                       : "Verify"}
-                </button>
-              ) : null}
-              {devRiaBypassAllowed && !nameVerificationSatisfied ? (
-                <button
-                  type="button"
-                  onClick={() => void handleDevActivate()}
-                  disabled={saving || displayNameQuery.length === 0}
-                  className="inline-flex min-h-10 items-center rounded-full border border-border bg-background px-4 text-sm font-medium text-foreground hover:bg-muted/40 disabled:cursor-not-allowed disabled:opacity-60"
-                >
-                  {saving ? "Activating..." : "Bypass verification"}
                 </button>
               ) : null}
             </div>
@@ -1354,17 +1296,6 @@ export default function RiaOnboardingPage() {
                 </button>
 
                 <div className="flex flex-wrap gap-2">
-                  {currentStep.id === "review" && devRiaBypassAllowed && !advisoryAccessReady ? (
-                    <button
-                      type="button"
-                      onClick={() => void handleDevActivate()}
-                      disabled={saving}
-                      className="inline-flex min-h-11 items-center rounded-full border border-border bg-background px-4 text-sm font-medium text-foreground hover:bg-muted/40 disabled:opacity-60"
-                    >
-                      {saving ? "Activating..." : "Bypass in Dev / UAT"}
-                    </button>
-                  ) : null}
-
                   <button
                     type="button"
                     onClick={handleContinue}

--- a/hushh-webapp/app/ria/page.tsx
+++ b/hushh-webapp/app/ria/page.tsx
@@ -9,7 +9,7 @@ import {
   Loader2,
 } from "lucide-react";
 
-import { RiaCompatibilityState, RiaDevAllowlistBadge, RiaPageShell, RiaSurface } from "@/components/ria/ria-page-shell";
+import { RiaCompatibilityState, RiaPageShell, RiaSurface } from "@/components/ria/ria-page-shell";
 import { Badge } from "@/components/ui/badge";
 import { useAuth } from "@/hooks/use-auth";
 import { usePersonaState } from "@/lib/persona/persona-context";
@@ -24,7 +24,6 @@ function verificationState(status?: string | null) {
   switch (status) {
     case "active":
     case "verified":
-    case "bypassed":
       return {
         label: "Ready",
         title: "Your advisor workspace is ready.",
@@ -195,12 +194,9 @@ export default function RiaHomePage() {
           >
             <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
               <div className="min-w-0 space-y-3">
-                <div className="flex flex-wrap items-center gap-2">
-                  <Badge className={cn("w-fit", badgeToneClass(verification.tone))}>
-                    {verification.label}
-                  </Badge>
-                  <RiaDevAllowlistBadge />
-                </div>
+                <Badge className={cn("w-fit", badgeToneClass(verification.tone))}>
+                  {verification.label}
+                </Badge>
                 <div className="space-y-2">
                   <h2 className="text-[clamp(1.25rem,3vw,1.85rem)] font-semibold tracking-tight text-foreground">
                     {heroTitle}

--- a/hushh-webapp/components/ria/ria-page-shell.tsx
+++ b/hushh-webapp/components/ria/ria-page-shell.tsx
@@ -240,19 +240,19 @@ export function RiaStatusPanel({
   );
 }
 
-const _VERIFIED_STATUSES = new Set(["active", "verified", "bypassed", "finra_verified"]);
+const _VERIFIED_STATUSES = new Set(["active", "verified", "finra_verified"]);
 
 export function isRiaVerified(status?: string | null): boolean {
   return _VERIFIED_STATUSES.has(String(status || "").toLowerCase());
 }
 
 export function RiaVerificationGate({ children }: { children: ReactNode }) {
-  const { riaOnboardingStatus, devRiaBypassAllowed, loading } = usePersonaState();
+  const { riaOnboardingStatus, loading } = usePersonaState();
   const status = riaOnboardingStatus?.advisory_status || riaOnboardingStatus?.verification_status;
 
   if (loading) return null;
 
-  if (!isRiaVerified(status) && !devRiaBypassAllowed) {
+  if (!isRiaVerified(status)) {
     return (
       <section className="space-y-3">
         <SectionHeader
@@ -274,13 +274,3 @@ export function RiaVerificationGate({ children }: { children: ReactNode }) {
   return <>{children}</>;
 }
 
-export function RiaDevAllowlistBadge() {
-  const { devRiaBypassAllowed } = usePersonaState();
-  if (!devRiaBypassAllowed) return null;
-  return (
-    <span className="inline-flex items-center gap-1 rounded-full border border-amber-500/20 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest text-amber-700 dark:text-amber-300">
-      <ShieldCheck className="h-3 w-3" />
-      Dev allowlist
-    </span>
-  );
-}

--- a/hushh-webapp/lib/observability/events.ts
+++ b/hushh-webapp/lib/observability/events.ts
@@ -270,7 +270,7 @@ export interface EventPayloadMap {
     result: EventResult;
   };
   ria_verification_status_changed: {
-    action: "draft" | "submitted" | "verified" | "active" | "rejected" | "bypassed";
+    action: "draft" | "submitted" | "verified" | "active" | "rejected";
     result: EventResult;
   };
   marketplace_profile_viewed: {

--- a/hushh-webapp/lib/persona/persona-context.tsx
+++ b/hushh-webapp/lib/persona/persona-context.tsx
@@ -37,7 +37,6 @@ interface PersonaContextValue {
   riaCapability: RiaCapability;
   riaSetupAvailable: boolean;
   riaSwitchAvailable: boolean;
-  devRiaBypassAllowed: boolean;
   riaEntryRoute: string;
   refresh: (options?: { force?: boolean }) => Promise<void>;
   switchPersona: (target: Persona) => Promise<PersonaState | null>;
@@ -246,12 +245,6 @@ export function PersonaProvider({ children }: { children: ReactNode }) {
     return personaState.ria_setup_available ?? !riaSwitchAvailable;
   }, [personaState, riaSwitchAvailable]);
 
-  const devRiaBypassAllowed = useMemo(() => {
-    return Boolean(
-      personaState?.dev_ria_bypass_allowed || riaOnboardingStatus?.dev_ria_bypass_allowed
-    );
-  }, [personaState?.dev_ria_bypass_allowed, riaOnboardingStatus?.dev_ria_bypass_allowed]);
-
   const riaEntryRoute = useMemo(() => {
     if (riaCapability === "switch") {
       return ROUTES.RIA_HOME;
@@ -271,14 +264,14 @@ export function PersonaProvider({ children }: { children: ReactNode }) {
       riaCapability,
       riaSetupAvailable,
       riaSwitchAvailable,
-      devRiaBypassAllowed,
+
       riaEntryRoute,
       refresh,
       switchPersona,
     }),
     [
       activePersona,
-      devRiaBypassAllowed,
+
       loading,
       personaTransitionTarget,
       personaState,

--- a/hushh-webapp/lib/services/consent-center-service.ts
+++ b/hushh-webapp/lib/services/consent-center-service.ts
@@ -102,7 +102,6 @@ export interface ConsentCenterResponse {
     primary_nav_persona: "investor" | "ria";
     ria_setup_available: boolean;
     ria_switch_available: boolean;
-    dev_ria_bypass_allowed: boolean;
     investor_marketplace_opt_in: boolean;
     iam_schema_ready: boolean;
     mode: "full" | "compat_investor";

--- a/hushh-webapp/lib/services/ria-service.ts
+++ b/hushh-webapp/lib/services/ria-service.ts
@@ -23,7 +23,6 @@ export interface PersonaState {
   primary_nav_persona: Persona;
   ria_setup_available: boolean;
   ria_switch_available: boolean;
-  dev_ria_bypass_allowed: boolean;
   investor_marketplace_opt_in: boolean;
   iam_schema_ready: boolean;
   mode: "full" | "compat_investor";
@@ -65,7 +64,6 @@ export interface RiaOnboardingStatus {
   advisory_status?: string;
   brokerage_status?: string;
   requested_capabilities?: string[];
-  dev_ria_bypass_allowed?: boolean;
   display_name?: string;
   individual_legal_name?: string | null;
   individual_crd?: string | null;
@@ -1085,49 +1083,6 @@ export class RiaService {
         return toJsonOrThrow<RiaOnboardingStatus>(response);
       },
     });
-  }
-
-  static async activateDevRia(
-    idToken: string,
-    payload: {
-      display_name: string;
-      requested_capabilities: string[];
-      individual_legal_name?: string;
-      individual_crd?: string;
-      advisory_firm_legal_name?: string;
-      advisory_firm_iapd_number?: string;
-      broker_firm_legal_name?: string;
-      broker_firm_crd?: string;
-      bio?: string;
-      strategy?: string;
-      disclosures_url?: string;
-      primary_firm_role?: string;
-    }
-  ): Promise<{
-    ria_profile_id: string;
-    verification_status: string;
-    verification_provider?: string;
-    advisory_status: string;
-    brokerage_status: string;
-    requested_capabilities: string[];
-    verification_outcome: string;
-    verification_message: string;
-    brokerage_outcome: string;
-    brokerage_message: string;
-    professional_access_granted: boolean;
-    individual_legal_name?: string | null;
-    individual_crd?: string | null;
-    advisory_firm_legal_name?: string | null;
-    advisory_firm_iapd_number?: string | null;
-    broker_firm_legal_name?: string | null;
-    broker_firm_crd?: string | null;
-  }> {
-    const response = await authFetch("/api/ria/onboarding/dev-activate", {
-      method: "POST",
-      idToken,
-      body: payload,
-    });
-    return toJsonOrThrow(response);
   }
 
   static async listFirms(idToken: string): Promise<RiaFirmMembership[]> {


### PR DESCRIPTION
## Summary

Permanently removes all RIA bypass verification code from both backend and frontend. All RIA onboarding now requires Stage 1 CRD-backed verification with no exceptions.

### Backend (consent-protocol)
- Removed `_is_dev_bypass_allowed()`, `_is_ria_dev_bypass_enabled()` methods
- Removed `bypassed` from `_RIA_VERIFIED_STATUSES` frozenset
- Stubbed `activate_ria_dev_onboarding()` → 410 Gone
- Removed `/onboarding/dev-activate` route
- Removed IAPD and Broker bypass blocks from verification adapters
- Removed `dev_ria_bypass_allowed` from persona response and onboarding status
- Updated marketplace badge queries

### Frontend (hushh-webapp)
- Removed `devRiaBypassAllowed` from persona context
- Removed `RiaDevAllowlistBadge` component
- Removed bypass buttons from onboarding wizard
- Removed `activateDevRia()` from ria-service.ts
- Removed `bypassed` from all status checks and type unions

### Tests & Scripts
- Replaced bypass-asserting tests with fail-closed assertions
- Migrated test scripts from `dev-activate` to `onboarding/submit`

### Kept intentionally
- Production runtime guard (defense-in-depth)
- Legacy status normalizer (handles old DB rows without granting access)

**21 files changed, +353 -679 (net -326 lines)**