### PR TITLE
fix(ria): call stage1 provider with query only

### DIFF
--- a/consent-protocol/hushh_mcp/services/ria_verification.py
+++ b/consent-protocol/hushh_mcp/services/ria_verification.py
@@ -465,10 +465,7 @@ class RIAIntelligenceStage1LookupAdapter:
         if self._api_key:
             headers["Authorization"] = f"Bearer {self._api_key}"
 
-        request_body: dict[str, Any] = {
-            "query": query,
-            "context": {"targetName": query},
-        }
+        request_body: dict[str, Any] = {"query": query}
 
         try:
             async with httpx.AsyncClient(

--- a/consent-protocol/tests/test_ria_verification_intelligence.py
+++ b/consent-protocol/tests/test_ria_verification_intelligence.py
@@ -350,10 +350,7 @@ def test_stage1_lookup_returns_verified_when_crd_present(monkeypatch):
         assert request.headers["content-type"] == "application/json"
         payload = request.read()
         body = json.loads(payload)
-        assert body == {
-            "query": "Akash Katla",
-            "context": {"targetName": "Akash Katla"},
-        }
+        assert body == {"query": "Akash Katla"}
         return httpx.Response(status_code=200, json=_stage1_payload())
 
     adapter = RIAIntelligenceStage1LookupAdapter(transport=httpx.MockTransport(handler))


### PR DESCRIPTION
## Summary
- Send only `{ "query": advisorName }` to the RIA Intelligence Stage 1 provider.
- Keep the existing server-side rule that onboarding proceeds only when Stage 1 returns a FINRA-backed CRD.
- Update the Stage 1 adapter unit expectation to match the live UAT provider contract.

## Evidence
- UAT provider direct check: query-only request for `JOSEPH KIRKLAND` returned `200` with CRD `5838118`; the previous `context.targetName` wrapper returned `400`.
- `cd consent-protocol && ./.venv/bin/pytest tests/test_ria_verification_intelligence.py tests/test_ria_iam_service_architecture.py tests/test_ria_iam_routes.py -q`
- `cd consent-protocol && ./.venv/bin/ruff check hushh_mcp/services/ria_verification.py tests/test_ria_verification_intelligence.py`
- `git diff --check`
- `bash scripts/ci/check-dco-signoff.sh origin/main HEAD`

## Local pre-PR note
- `./bin/hushh codex pre-pr` passed DCO, secret scan, docs/governance, runtime config, skill lint, and release contract after adding repo Python/Node to PATH, then stalled in `scripts/ci/web-check.sh` while deleting a duplicated local `node_modules` tree. I stopped that local mirror and restored fresh web dependencies with `npm ci`; remote CI should run from a clean checkout.
