### PR TITLE
fix: restore RIA Stage 1 query-only lookup

### DIFF
--- a/consent-protocol/hushh_mcp/services/ria_verification.py
+++ b/consent-protocol/hushh_mcp/services/ria_verification.py
@@ -449,7 +449,6 @@ class RIAIntelligenceStage1LookupAdapter:
         self,
         *,
         query: str,
-        crd_number: str | None = None,
     ) -> tuple[dict[str, Any] | None, NameVerificationResult | None]:
         request_url = self._verify_url or (
             f"{self._base_url}{self._endpoint_path}" if self._base_url else ""
@@ -466,11 +465,7 @@ class RIAIntelligenceStage1LookupAdapter:
         if self._api_key:
             headers["Authorization"] = f"Bearer {self._api_key}"
 
-        context: dict[str, Any] = {"targetName": query}
-        normalized_crd = _normalize_crd(crd_number)
-        if normalized_crd:
-            context["crdNumber"] = normalized_crd
-        request_body: dict[str, Any] = {"query": query, "context": context}
+        request_body: dict[str, Any] = {"query": query}
 
         try:
             async with httpx.AsyncClient(
@@ -581,7 +576,6 @@ class RIAIntelligenceStage1LookupAdapter:
 
         payload, error = await self._request_payload(
             query=normalized_query,
-            crd_number=normalized_input_crd,
         )
         if error is not None:
             return error

--- a/consent-protocol/tests/test_ria_verification_intelligence.py
+++ b/consent-protocol/tests/test_ria_verification_intelligence.py
@@ -341,7 +341,7 @@ def test_iapd_adapter_never_bypasses_even_with_bypass_env(monkeypatch):
     assert result.outcome != "bypassed"
 
 
-def test_stage1_lookup_returns_verified_when_crd_present(monkeypatch):
+def test_stage1_lookup_sends_query_only_even_when_input_crd_present(monkeypatch):
     monkeypatch.setenv("RIA_INTELLIGENCE_VERIFY_BASE_URL", "https://ria-intelligence.example")
     monkeypatch.delenv("RIA_INTELLIGENCE_VERIFY_URL", raising=False)
 
@@ -350,13 +350,7 @@ def test_stage1_lookup_returns_verified_when_crd_present(monkeypatch):
         assert request.headers["content-type"] == "application/json"
         payload = request.read()
         body = json.loads(payload)
-        assert body == {
-            "query": "Akash Katla",
-            "context": {
-                "targetName": "Akash Katla",
-                "crdNumber": "1234567",
-            },
-        }
+        assert body == {"query": "Akash Katla"}
         return httpx.Response(status_code=200, json=_stage1_payload())
 
     adapter = RIAIntelligenceStage1LookupAdapter(transport=httpx.MockTransport(handler))


### PR DESCRIPTION
## Summary
- restore the RIA Stage 1 provider contract to query-only payloads
- keep backend CRD validation based on the provider-returned CRD instead of sending CRD/context to Stage 1
- tighten regression coverage so a supplied legacy CRD still results in exact `{"query": ...}` provider payload

## Verification
- `cd consent-protocol && ./.venv/bin/python -m pytest tests/test_ria_verification_intelligence.py tests/test_ria_iam_routes.py tests/test_ria_iam_service_architecture.py -q`
- `python3 -m py_compile scripts/ci/verify-cloudrun-revision-provenance.py scripts/ops/verify_uat_release.py`
- `git diff --check`
- `bash scripts/ci/check-dco-signoff.sh origin/main HEAD`

## RCA
- UAT revision `consent-protocol-00140-vdp` has valid deploy provenance, but semantic smoke still failed because `1dc83f35` reintroduced the wrapped Stage 1 payload. The live provider returned `400` for the wrapped payload. This hotfix restores the known-good query-only contract and keeps the UAT semantic smoke as the deploy gate.