### PR TITLE
Typed error hierarchy

### DIFF
--- a/consent-protocol/hushh_mcp/agents/kai/agent.py
+++ b/consent-protocol/hushh_mcp/agents/kai/agent.py
@@ -13,6 +13,8 @@ from hushh_mcp.hushh_adk.core import HushhAgent
 from hushh_mcp.hushh_adk.manifest import ManifestLoader
 from hushh_mcp.types import UserID
 
+from .errors import AgentLLMError
+
 # Import tools
 from .tools import (
     perform_fundamental_analysis,
@@ -49,10 +51,13 @@ class KaiAgent(HushhAgent):
     ) -> Dict[str, Any]:
         """
         Agentic Entry Point.
+
+        Raises:
+            PermissionError:  Propagated unchanged from HushhAgent when the
+                              consent token is missing or lacks the required scope.
+            AgentLLMError:    The ADK / Gemini call failed in an unexpected way.
         """
         try:
-            # Execute ADK run
-            # Note: For long running analysis, we might want to stream or notify
             response = self.run(message, user_id=user_id, consent_token=consent_token)
 
             return {
@@ -60,12 +65,21 @@ class KaiAgent(HushhAgent):
                 "is_complete": True,
             }
 
-        except Exception as e:
-            logger.error(f"KaiAgent error: {e}")
-            return {
-                "response": "I encountered an error analyzing the market data.",
-                "error": str(e),
-            }
+        except PermissionError:
+            # Consent/auth failures — re-raise unchanged so the API layer can
+            # map to 401/403 rather than a generic 500.
+            raise
+
+        except Exception as exc:
+            # logger.exception() captures the full traceback automatically.
+            # The old logger.error(f"...{e}") only logged the message string,
+            # discarding the stack entirely.
+            logger.exception(
+                "KaiAgent ADK call failed for user=%s message=%r",
+                user_id,
+                message[:120],
+            )
+            raise AgentLLMError(f"KaiAgent run failed: {exc}") from exc
 
 
 # Singleton

--- a/consent-protocol/hushh_mcp/agents/kai/debate_engine.py
+++ b/consent-protocol/hushh_mcp/agents/kai/debate_engine.py
@@ -63,7 +63,10 @@ def _safe_float(value: Any) -> Optional[float]:
         if parsed != parsed:
             return None
         return parsed
-    except Exception:
+    except (TypeError, ValueError):
+        # Intentionally broad within numeric-parsing scope: any non-castable
+        # input (e.g. dicts, lists, locale strings) is normalised to None
+        # rather than propagating into formatting helpers.
         return None
 
 

--- a/consent-protocol/hushh_mcp/agents/kai/errors.py
+++ b/consent-protocol/hushh_mcp/agents/kai/errors.py
@@ -1,0 +1,67 @@
+"""
+Typed error hierarchy for agent execution failures.
+
+All agent files previously caught bare ``Exception`` and either swallowed it
+silently or logged only the message string (losing the traceback).  This module
+gives callers a stable set of types to ``except`` on so they can distinguish:
+
+  * consent / auth failures: already typed as PermissionError (unchanged)
+  * LLM / ADK call failures: AgentLLMError
+  * data-fetch failures: AgentDataError
+  * orchestration failures: AgentOrchestrationError
+
+All three inherit from ``AgentExecutionError`` so a single broad ``except`` is
+still possible when callers don't care about the sub-type.
+
+Usage
+    from hushh_mcp.agents.kai.errors import AgentExecutionError, AgentLLMError
+
+    try:
+        result = await agent.analyze(ticker, user_id, consent_token)
+    except PermissionError:
+        # consent/auth problem — return 401
+        ...
+    except AgentLLMError:
+        # transient LLM failure — return 503 / retry
+        ...
+    except AgentExecutionError:
+        # any other agent failure — return 500
+        ...
+"""
+
+from __future__ import annotations
+
+
+class AgentExecutionError(Exception):
+    """
+    Base class for all agent-pipeline failures.
+
+    Always raised with ``raise AgentXxxError(...) from original_exc`` so the
+    original traceback is preserved in the ``__cause__`` chain.
+    """
+
+
+class AgentLLMError(AgentExecutionError):
+    """
+    The LLM (Gemini / ADK) call itself failed or returned an unusable response.
+
+    Examples: timeout, 429 rate-limit exhausted after retries, empty generation,
+    malformed tool-call response.
+    """
+
+
+class AgentDataError(AgentExecutionError):
+    """
+    An upstream data fetch (SEC filings, market data, news) failed in an
+    unexpected way — i.e. beyond the known ``RealtimeDataUnavailable`` path
+    that is handled gracefully with a fallback.
+    """
+
+
+class AgentOrchestrationError(AgentExecutionError):
+    """
+    The orchestrator or debate engine failed to coordinate sub-agents.
+
+    Examples: ``asyncio.gather`` returned only exceptions, debate stream
+    produced no output for all agents, decision generator raised unexpectedly.
+    """

--- a/consent-protocol/hushh_mcp/agents/kai/fundamental_agent.py
+++ b/consent-protocol/hushh_mcp/agents/kai/fundamental_agent.py
@@ -20,6 +20,8 @@ from typing import Any, Dict, List, Optional
 from hushh_mcp.agents.base_agent import HushhAgent
 from hushh_mcp.constants import GEMINI_MODEL
 
+from .errors import AgentLLMError
+
 logger = logging.getLogger(__name__)
 
 
@@ -157,6 +159,7 @@ class FundamentalAgent(HushhAgent):
                     "[Fundamental] Gemini unavailable, using deterministic analysis: %s",
                     get_gemini_unavailable_reason(),
                 )
+            last_exc: Exception | None = None
             for attempt in range(2):
                 try:
                     gemini_analysis = await analyze_stock_with_gemini(
@@ -168,15 +171,31 @@ class FundamentalAgent(HushhAgent):
                         quant_metrics=quant_metrics,
                         user_context=context,
                     )
+                    last_exc = None
                     break  # Success
-                except Exception as e:
+                except Exception as exc:
+                    last_exc = exc
                     logger.warning(
-                        f"[Fundamental] Gemini analysis failed (attempt {attempt + 1}/2): {e}"
+                        "[Fundamental] Gemini analysis failed (attempt %d/2) for %s: %s",
+                        attempt + 1,
+                        ticker,
+                        exc,
                     )
-                    if attempt == 1:
-                        logger.warning(
-                            "[Fundamental] Max retries reached. Falling back to deterministic."
-                        )
+            if last_exc is not None:
+                # All retries exhausted — log full traceback then fall through
+                # to deterministic analysis rather than raising, since
+                # fundamental analysis has a valid non-LLM fallback path.
+                logger.exception(
+                    "[Fundamental] Gemini analysis exhausted all retries for %s — "
+                    "falling back to deterministic analysis",
+                    ticker,
+                    # exc_info is attached automatically by logger.exception;
+                    # we pass last_exc explicitly so the correct frame is linked.
+                    # Python's logger.exception() uses sys.exc_info() from the
+                    # current exception context; since we're outside the except
+                    # block we bind it manually via exc_info.
+                    exc_info=last_exc,
+                )
 
         # Step 3: Traditional Analysis (Fallback or baseline metrics)
         from hushh_mcp.operons.kai.analysis import analyze_fundamentals

--- a/consent-protocol/hushh_mcp/agents/kai/fundamental_agent.py
+++ b/consent-protocol/hushh_mcp/agents/kai/fundamental_agent.py
@@ -20,8 +20,6 @@ from typing import Any, Dict, List, Optional
 from hushh_mcp.agents.base_agent import HushhAgent
 from hushh_mcp.constants import GEMINI_MODEL
 
-from .errors import AgentLLMError
-
 logger = logging.getLogger(__name__)
 
 

--- a/consent-protocol/hushh_mcp/agents/kai/orchestrator.py
+++ b/consent-protocol/hushh_mcp/agents/kai/orchestrator.py
@@ -24,6 +24,7 @@ from hushh_mcp.constants import GEMINI_MODEL, ConsentScope
 from .config import ANALYSIS_TIMEOUT, ProcessingMode, RiskProfile
 from .debate_engine import DebateEngine
 from .decision_generator import DecisionCard, DecisionGenerator
+from .errors import AgentOrchestrationError
 from .fundamental_agent import FundamentalAgent
 from .sentiment_agent import SentimentAgent
 from .valuation_agent import ValuationAgent
@@ -103,8 +104,10 @@ class KaiOrchestrator(HushhAgent):
             DecisionCard with complete analysis
 
         Raises:
-            ValueError: If consent token is invalid
-            TimeoutError: If analysis exceeds timeout
+            ValueError:                  Consent token is invalid or user mismatch.
+            TimeoutError:                Analysis exceeded ANALYSIS_TIMEOUT.
+            AgentOrchestrationError:     Debate or decision-generation stage failed
+                                         after all agent analyses completed.
         """
         start_time = datetime.utcnow()
         logger.info(f"[Kai] Starting analysis for {ticker}")
@@ -145,9 +148,22 @@ class KaiOrchestrator(HushhAgent):
         except asyncio.TimeoutError:
             logger.error(f"[Kai] Analysis timeout for {ticker}")
             raise TimeoutError(f"Analysis exceeded {ANALYSIS_TIMEOUT}s timeout")
-        except Exception as e:
-            logger.error(f"[Kai] Analysis failed for {ticker}: {e}")
+
+        except (ValueError, PermissionError):
+            # Consent/validation errors — re-raise unchanged so callers see 401/403.
             raise
+
+        except Exception as exc:
+            # Unexpected failure in debate or decision-generation stage.
+            # logger.exception() attaches the full traceback automatically.
+            logger.exception(
+                "[Kai] Orchestration failed for ticker=%s user=%s",
+                ticker,
+                self.user_id,
+            )
+            raise AgentOrchestrationError(
+                f"Kai orchestration failed for {ticker}: {exc}"
+            ) from exc
 
     async def _validate_consent(self, consent_token: str):
         """Validate that the consent token allows access to Kai analysis."""
@@ -188,9 +204,18 @@ class KaiOrchestrator(HushhAgent):
         # agent failure invisible in logs (e.g. auth errors behind network errors).
         exceptions = [(i, r) for i, r in enumerate(results) if isinstance(r, Exception)]
         if exceptions:
-            for i, e in exceptions:
-                logger.error(f"[Kai] Agent {i} failed: {e}")
-            raise exceptions[0][1]  # raise first; all others are now logged
+            for i, exc in exceptions:
+                # logger.exception() requires being inside an except block to attach
+                # the traceback automatically.  Since we're iterating a list, we use
+                # logger.error with exc_info=exc instead — same effect, any context.
+                logger.error(
+                    "[Kai] Agent %d failed for ticker=%s: %s",
+                    i,
+                    ticker,
+                    exc,
+                    exc_info=exc,
+                )
+            raise exceptions[0][1]  # raise first; all others are now logged with tracebacks
 
         return results
 

--- a/consent-protocol/hushh_mcp/agents/kai/sentiment_agent.py
+++ b/consent-protocol/hushh_mcp/agents/kai/sentiment_agent.py
@@ -17,6 +17,8 @@ from typing import Any, Dict, List, Optional
 from hushh_mcp.agents.base_agent import HushhAgent
 from hushh_mcp.constants import GEMINI_MODEL
 
+from .errors import AgentDataError, AgentLLMError
+
 logger = logging.getLogger(__name__)
 
 
@@ -77,6 +79,11 @@ class SentimentAgent(HushhAgent):
 
         Returns:
             SentimentInsight with analysis results
+
+        Raises:
+            PermissionError:  Token missing or insufficient scope (re-raised as-is).
+            AgentDataError:   News fetch failed in an unexpected way.
+            AgentLLMError:    Deterministic fallback analysis also failed.
         """
         if not consent_token:
             raise PermissionError("Sentiment analysis requires a consent token")
@@ -94,22 +101,32 @@ class SentimentAgent(HushhAgent):
         realtime_news_detail: str | None = None
         try:
             news_articles = await fetch_market_news(ticker, user_id, consent_token)
-        except PermissionError as e:
-            logger.error(f"[Sentiment] News access denied: {e}")
+        except PermissionError:
+            # Re-raise consent errors unchanged — callers must see the 403.
             raise
         except RealtimeDataUnavailable as e:
             realtime_news_detail = e.detail
             logger.warning(f"[Sentiment] Realtime news unavailable for {ticker}: {e.detail}")
-        except Exception as e:
-            logger.error(f"[Sentiment] News fetch failed: {e}")
-            raise
+        except Exception as exc:
+            # Unexpected fetch failure — log full traceback, then re-raise as typed error.
+            logger.exception(
+                "[Sentiment] News fetch failed unexpectedly for ticker=%s user=%s",
+                ticker,
+                user_id,
+            )
+            raise AgentDataError(f"News fetch failed for {ticker}: {exc}") from exc
 
         market_data: Optional[Dict[str, Any]] = None
         try:
             # Reuse quote cache pipeline so sentiment reasoning is anchored to latest price context.
             market_data = await fetch_market_data(ticker, user_id, consent_token)
-        except Exception as e:
-            logger.warning(f"[Sentiment] Market snapshot unavailable for {ticker}: {e}")
+        except Exception as exc:
+            # Market snapshot is best-effort for sentiment; log and continue.
+            logger.warning(
+                "[Sentiment] Market snapshot unavailable for %s (non-fatal): %s",
+                ticker,
+                exc,
+            )
 
         if not news_articles:
             summary = (
@@ -145,6 +162,7 @@ class SentimentAgent(HushhAgent):
                     "[Sentiment] Gemini unavailable, using deterministic analysis: %s",
                     get_gemini_unavailable_reason(),
                 )
+            last_exc: Exception | None = None
             for attempt in range(2):
                 try:
                     gemini_analysis = await analyze_sentiment_with_gemini(
@@ -155,15 +173,23 @@ class SentimentAgent(HushhAgent):
                         market_data=market_data,
                         user_context=context,
                     )
+                    last_exc = None
                     break
-                except Exception as e:
+                except Exception as exc:
+                    last_exc = exc
                     logger.warning(
-                        f"[Sentiment] Gemini analysis failed (attempt {attempt + 1}/2): {e}"
+                        "[Sentiment] Gemini analysis failed (attempt %d/2) for %s: %s",
+                        attempt + 1,
+                        ticker,
+                        exc,
                     )
-                    if attempt == 1:
-                        logger.warning(
-                            "[Sentiment] Max retries reached. Falling back to deterministic."
-                        )
+            if last_exc is not None:
+                logger.exception(
+                    "[Sentiment] Gemini analysis exhausted all retries for %s — "
+                    "falling back to deterministic analysis",
+                    ticker,
+                    exc_info=last_exc,
+                )
 
         # Use Gemini results if available
         if gemini_analysis and "error" not in gemini_analysis:
@@ -183,7 +209,6 @@ class SentimentAgent(HushhAgent):
         from hushh_mcp.operons.kai.analysis import analyze_sentiment
 
         try:
-            # Call the operon directly without tools (deterministic)
             analysis = analyze_sentiment(
                 ticker=ticker,
                 user_id=user_id,
@@ -200,9 +225,16 @@ class SentimentAgent(HushhAgent):
                 confidence=analysis.get("confidence", 0.5),
                 recommendation=analysis.get("recommendation", "neutral"),
             )
-        except Exception as e:
-            logger.error(f"[Sentiment] Deterministic analysis failed: {e}")
-            raise
+        except Exception as exc:
+            # Both Gemini and deterministic paths failed — log full traceback.
+            logger.exception(
+                "[Sentiment] Deterministic analysis also failed for ticker=%s user=%s",
+                ticker,
+                user_id,
+            )
+            raise AgentLLMError(
+                f"All sentiment analysis paths failed for {ticker}: {exc}"
+            ) from exc
 
 
 # Export singleton for use in KaiAgent orchestration

--- a/consent-protocol/hushh_mcp/agents/kai/valuation_agent.py
+++ b/consent-protocol/hushh_mcp/agents/kai/valuation_agent.py
@@ -17,6 +17,8 @@ from typing import Any, Dict, List, Optional
 from hushh_mcp.agents.base_agent import HushhAgent
 from hushh_mcp.constants import GEMINI_MODEL
 
+from .errors import AgentDataError, AgentLLMError
+
 logger = logging.getLogger(__name__)
 
 
@@ -77,6 +79,11 @@ class ValuationAgent(HushhAgent):
 
         Returns:
             ValuationInsight with analysis results
+
+        Raises:
+            PermissionError:  Token missing or insufficient scope (re-raised as-is).
+            AgentDataError:   Market/peer data fetch failed unexpectedly.
+            AgentLLMError:    Both Gemini and deterministic valuation paths failed.
         """
         if not consent_token:
             raise PermissionError("Valuation analysis requires a consent token")
@@ -93,8 +100,8 @@ class ValuationAgent(HushhAgent):
         try:
             market_data = await fetch_market_data(ticker, user_id, consent_token)
             peer_data = await fetch_peer_data(ticker, user_id, consent_token)
-        except PermissionError as e:
-            logger.error(f"[Valuation] Market data access denied: {e}")
+        except PermissionError:
+            # Re-raise consent errors unchanged — callers must see the 403.
             raise
         except RealtimeDataUnavailable as e:
             logger.warning(
@@ -103,9 +110,14 @@ class ValuationAgent(HushhAgent):
                 e.detail,
             )
             return self._build_market_unavailable_fallback(ticker=ticker, detail=e.detail)
-        except Exception as e:
-            logger.error(f"[Valuation] Data fetch failed: {e}")
-            raise
+        except Exception as exc:
+            # Unexpected data-layer failure — log full traceback, then re-raise typed.
+            logger.exception(
+                "[Valuation] Market/peer data fetch failed unexpectedly for ticker=%s user=%s",
+                ticker,
+                user_id,
+            )
+            raise AgentDataError(f"Data fetch failed for {ticker}: {exc}") from exc
 
         # Operon 2: Gemini Deep Valuation Analysis
         from hushh_mcp.operons.kai.llm import (
@@ -121,6 +133,7 @@ class ValuationAgent(HushhAgent):
                     "[Valuation] Gemini unavailable, using deterministic analysis: %s",
                     get_gemini_unavailable_reason(),
                 )
+            last_exc: Exception | None = None
             for attempt in range(2):
                 try:
                     gemini_analysis = await analyze_valuation_with_gemini(
@@ -131,15 +144,23 @@ class ValuationAgent(HushhAgent):
                         peer_data=peer_data,
                         user_context=context,
                     )
+                    last_exc = None
                     break
-                except Exception as e:
+                except Exception as exc:
+                    last_exc = exc
                     logger.warning(
-                        f"[Valuation] Gemini analysis failed (attempt {attempt + 1}/2): {e}"
+                        "[Valuation] Gemini analysis failed (attempt %d/2) for %s: %s",
+                        attempt + 1,
+                        ticker,
+                        exc,
                     )
-                    if attempt == 1:
-                        logger.warning(
-                            "[Valuation] Max retries reached. Falling back to deterministic."
-                        )
+            if last_exc is not None:
+                logger.exception(
+                    "[Valuation] Gemini analysis exhausted all retries for %s — "
+                    "falling back to deterministic analysis",
+                    ticker,
+                    exc_info=last_exc,
+                )
 
         # Use Gemini results if available
         if gemini_analysis and "error" not in gemini_analysis:
@@ -159,7 +180,6 @@ class ValuationAgent(HushhAgent):
         from hushh_mcp.operons.kai.analysis import analyze_valuation
 
         try:
-            # Call the operon directly without tools (deterministic)
             analysis = analyze_valuation(
                 ticker=ticker,
                 user_id=user_id,
@@ -177,9 +197,16 @@ class ValuationAgent(HushhAgent):
                 confidence=analysis.get("confidence", 0.5),
                 recommendation=analysis.get("recommendation", "fair"),
             )
-        except Exception as e:
-            logger.error(f"[Valuation] Deterministic analysis failed: {e}")
-            raise
+        except Exception as exc:
+            # Both Gemini and deterministic paths failed — log full traceback.
+            logger.exception(
+                "[Valuation] Deterministic analysis also failed for ticker=%s user=%s",
+                ticker,
+                user_id,
+            )
+            raise AgentLLMError(
+                f"All valuation analysis paths failed for {ticker}: {exc}"
+            ) from exc
 
     def _build_market_unavailable_fallback(self, ticker: str, detail: str) -> ValuationInsight:
         """Fallback when the symbol cannot be priced reliably in realtime."""


### PR DESCRIPTION
# Description

Fixed silent error swallowing across all Kai agent files. Every `except Exception` block in the agent pipeline was either discarding exceptions entirely or logging only the message string via `logger.error(f"...{e}")`, which drops the full traceback. In an agentic LLM pipeline this means a failed Gemini call, a timeout, or a malformed tool response can silently return a degraded result with no stack trace in logs — making production debugging nearly impossible.

Specific changes:

- **New `errors.py`** — introduces a typed error hierarchy: `AgentExecutionError` (base), `AgentLLMError` (Gemini/ADK call failed), `AgentDataError` (unexpected upstream data fetch failure), `AgentOrchestrationError` (debate or decision-generation stage failed). All are raised with `raise XxxError(...) from original_exc` so the `__cause__` chain is always preserved. Callers can now `except AgentLLMError` to return a 503 vs `except PermissionError` for a 401.

- **`agent.py` (KaiAgent)** — bare `except Exception` now splits into two branches: `PermissionError` re-raised unchanged; everything else logs with `logger.exception()` (captures full traceback automatically) then re-raises as `AgentLLMError`.

- **`fundamental_agent.py`** — Gemini retry loop now tracks `last_exc`; after all retries are exhausted, calls `logger.exception(..., exc_info=last_exc)` to write the full traceback before falling through to the valid deterministic fallback. Previously the traceback was silently discarded.

- **`sentiment_agent.py`** — four sites fixed: news-fetch unexpected failure → `AgentDataError` with full traceback; market-snapshot failure → `logger.warning` and continue (legitimately best-effort); Gemini retry loop → `last_exc` pattern with `logger.exception`; deterministic fallback failure → `AgentLLMError` with `logger.exception`.

- **`valuation_agent.py`** — same pattern as sentiment: data-fetch → `AgentDataError`; Gemini retry → `last_exc` tracking; deterministic fallback → `AgentLLMError`.

- **`orchestrator.py`** — catch-all `except Exception` now uses `logger.exception()` and re-raises as `AgentOrchestrationError`. `ValueError` and `PermissionError` are explicitly re-raised before the catch-all so they are never wrapped. In `_run_agent_analysis`, each parallel agent failure now logs with `exc_info=exc` so every failure in a `gather` gets its own traceback, not just the first.

- **`debate_engine.py`** — bare `except Exception: return None` in `_safe_float` narrowed to `except (TypeError, ValueError)`, which is the only exceptions `float(str(...))` can raise. Prevents `KeyboardInterrupt` or `SystemExit` from being silently swallowed by a formatting helper.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None — all changes are confined to the agent-layer Python classes. No FastAPI route signatures, URL paths, or handler logic was modified.

- API / schema / type changes:
  - [x] Listed below:
    - **New exported types**: `AgentExecutionError`, `AgentLLMError`, `AgentDataError`, `AgentOrchestrationError` from `hushh_mcp.agents.kai.errors`. Additive — no existing import breaks.
    - **`KaiAgent.handle_message`** previously returned `{"response": "...", "error": str(e)}` on failure. It now raises `AgentLLMError` instead. Any caller that was checking `if "error" in result` rather than catching an exception will need to be updated. Grep: `grep -rn "handle_message" consent-protocol/api/`.

- Cache keys touched:
  - [x] None

- World-model domain summary effects:
  - [x] None — no domain summary reads or writes in the modified paths.

- Mobile parity impacts:
  - [x] None — all changes are backend Python. No Capacitor plugin calls these classes directly.

- Docs updated (exact files):
  - [x] None — no public API docs reference internal agent classes. Inline docstrings updated in each modified file.

- Verification commands executed:
  - [ ] `cd hushh-webapp && npm run typecheck`
  - [ ] `cd hushh-webapp && npm test`
  - [ ] `cd hushh-webapp && npm run build`
  - [ ] `cd hushh-webapp && npm run ios:test`
  - [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000`

  > Backend-only change. Relevant verification:
  > ```bash
  > cd consent-protocol
  > uv run pytest tests/agents/ -v
  > uv run pytest tests/test_agent_consent_validation.py tests/test_a2a_delegation_scopes.py -v
  > ```

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: N/A — changes are confined to `consent-protocol/hushh_mcp/agents/kai/`. No Next.js routes modified.
- [x] **iOS**: N/A — no Capacitor plugin calls these agent classes directly.
- [x] **Android**: N/A — same as iOS.

## 🧪 Testing

- [ ] Tested on Web (Chrome/Safari)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

> UI/device testing is not applicable. The change is confined to backend Python agent files. Existing tests in `tests/agents/kai/test_orchestrator_exception_handling.py` cover exception-propagation contracts. A follow-up task should add unit tests for the new typed error hierarchy and the `last_exc` retry-logging path.

## 📸 Screenshots / Video

<img width="1920" height="1140" alt="Windows PowerShell 03-05-2026 00_53_30" src="https://github.com/user-attachments/assets/b863d3b5-0535-4fe7-8927-c8e811bf039e" />
<img width="1920" height="1140" alt="Windows PowerShell 03-05-2026 00_53_41" src="https://github.com/user-attachments/assets/3adda493-a724-426f-9a3e-9fd85cb3dbf7" />


## 🛡️ Privacy & Consent

- [x] Does this change access user data? **No.**
  - No new data is read from the vault or any user store. `consent_token` and `user_id` are forwarded to the same operons as before. The change only affects what happens when those calls *fail* — failures are now surfaced loudly instead of silently degraded.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible — no new dependencies introduced.
- [x] Third-party notice impact reviewed — `requirements.txt` and `pyproject.toml` are unchanged.