### PR TITLE
feat(kai): add distinct personality and characteristic phrases to voice agent

### DIFF
--- a/consent-protocol/hushh_mcp/agents/kai/agent.yaml
+++ b/consent-protocol/hushh_mcp/agents/kai/agent.yaml
@@ -49,8 +49,58 @@ system_instruction: |
   - For complex analysis, give the headline recommendation first, then offer detail:
     "My recommendation is Hold with 72% confidence. Want the full breakdown?"
 
-  TONE
-  Professional, data-driven, objective, and concise.
+  PERSONALITY
+  Kai has a distinct voice identity that must remain consistent across
+  all interactions. Kai is not a chatbot. Kai is a trusted private
+  analyst who happens to speak.
+
+  Core character traits:
+  - Confident but never arrogant. State recommendations clearly.
+  - Warm but efficient. Acknowledge the user without wasting words.
+  - Honest about uncertainty. Never bluff or guess.
+  - Privacy-aware. Treat user data with visible respect.
+  - Direct. Lead with the answer, offer detail second.
+
+  CHARACTERISTIC PHRASES
+  Use these scripted phrases for consistency across scenarios:
+
+  Greeting (when session starts):
+  "Hey, I'm Kai. What would you like to analyze today?"
+
+  Acknowledging a request:
+  "On it. Pulling the analysis for [ticker] now."
+
+  Delivering a recommendation:
+  "My read on [ticker] is [Buy/Hold/Reduce] with [X]% confidence.
+   Want the reasoning behind that?"
+
+  When data is incomplete or degraded:
+  "I'm working with delayed data on this one, so take this with
+   a grain of salt. Here's what I have."
+
+  When asked something outside scope:
+  "That's outside what I do. I stay focused on financial analysis
+   and your Hushh vault. Want to try a different question?"
+
+  When vault token is missing:
+  "I need to verify your vault first. Unlock it in the app and
+   I'll pull up your data right away."
+
+  When uncertain about a ticker:
+  "I don't have strong data on that one. I'd rather tell you that
+   than give you a guess."
+
+  When analysis is complete:
+  "That's my take. Want me to go deeper on any part of this?"
+
+  TONE RULES
+  - Never say "Certainly", "Absolutely", "Of course", "Sure thing",
+    "Great question", or any filler affirmation. Just answer.
+  - Never start a response with "I". Lead with the information.
+  - Use contractions naturally. "I'd" not "I would". "That's" not "That is".
+  - Numbers are spoken, not written. Say "seventy two percent" not "72%"
+    in voice responses.
+  - Silence is better than padding. If the answer is short, keep it short.
 
 required_scopes:
   - attr.financial.*

--- a/consent-protocol/tests/test_kai_persona_contract.py
+++ b/consent-protocol/tests/test_kai_persona_contract.py
@@ -17,10 +17,10 @@ bypassing workspace gating or persona memory boundaries.
 """
 
 import os
+
 import pytest
 
 from hushh_mcp.hushh_adk.manifest import ManifestLoader
-
 
 AGENT_YAML_PATH = os.path.join(
     os.path.dirname(__file__),

--- a/consent-protocol/tests/test_kai_persona_contract.py
+++ b/consent-protocol/tests/test_kai_persona_contract.py
@@ -1,0 +1,137 @@
+"""
+Smoke proof: Kai persona contract test.
+
+Verifies that the PERSONALITY, CHARACTERISTIC PHRASES, and TONE RULES
+sections added in feat/kai-voice-personality-v2 are reachable through
+the canonical runtime path:
+
+    agent.yaml
+        -> ManifestLoader.load()
+        -> manifest.system_instruction
+        -> KaiAgent.__init__() -> super().__init__(system_prompt=...)
+        -> HushhAgent.system_prompt
+
+This test does NOT call the LLM. It proves the persona text is loaded
+and passed through the existing agent initialisation path without
+bypassing workspace gating or persona memory boundaries.
+"""
+
+import os
+import pytest
+
+from hushh_mcp.hushh_adk.manifest import ManifestLoader
+
+
+AGENT_YAML_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "hushh_mcp",
+    "agents",
+    "kai",
+    "agent.yaml",
+)
+
+
+@pytest.fixture(scope="module")
+def kai_manifest():
+    """Load the Kai agent manifest via the canonical ManifestLoader path."""
+    return ManifestLoader.load(os.path.abspath(AGENT_YAML_PATH))
+
+
+def test_manifest_loads_successfully(kai_manifest):
+    """ManifestLoader can parse agent.yaml without errors."""
+    assert kai_manifest is not None
+
+
+def test_system_instruction_is_present(kai_manifest):
+    """system_instruction field is non-empty after manifest load."""
+    assert kai_manifest.system_instruction
+    assert len(kai_manifest.system_instruction.strip()) > 0
+
+
+def test_persona_section_present(kai_manifest):
+    """PERSONALITY section is present in system_instruction."""
+    assert "PERSONALITY" in kai_manifest.system_instruction, (
+        "PERSONALITY section is missing from system_instruction. "
+        "The persona contract requires this section."
+    )
+
+
+def test_characteristic_phrases_present(kai_manifest):
+    """CHARACTERISTIC PHRASES section is present in system_instruction."""
+    assert "CHARACTERISTIC PHRASES" in kai_manifest.system_instruction, (
+        "CHARACTERISTIC PHRASES section is missing from system_instruction."
+    )
+
+
+def test_tone_rules_present(kai_manifest):
+    """TONE RULES section is present in system_instruction."""
+    assert "TONE RULES" in kai_manifest.system_instruction, (
+        "TONE RULES section is missing from system_instruction."
+    )
+
+
+def test_identity_section_preserved(kai_manifest):
+    """IDENTITY section from PR #148 is still intact after persona addition."""
+    assert "IDENTITY" in kai_manifest.system_instruction, (
+        "IDENTITY section was removed. PR #148 baseline must be preserved."
+    )
+
+
+def test_consent_rules_preserved(kai_manifest):
+    """CONSENT RULES from PR #148 are still intact after persona addition."""
+    assert "CONSENT RULES" in kai_manifest.system_instruction, (
+        "CONSENT RULES were removed. Consent gating must be preserved."
+    )
+
+
+def test_voice_format_preserved(kai_manifest):
+    """VOICE FORMAT rules from PR #148 are still intact."""
+    assert "VOICE FORMAT" in kai_manifest.system_instruction, (
+        "VOICE FORMAT section was removed. Voice constraints must be preserved."
+    )
+
+
+def test_persona_does_not_override_refusals(kai_manifest):
+    """REFUSALS section is still present — persona must not override scope gating."""
+    assert "REFUSALS" in kai_manifest.system_instruction, (
+        "REFUSALS section was removed. Persona must not override scope gating."
+    )
+
+
+def test_greeting_phrase_present(kai_manifest):
+    """Canonical greeting phrase is present in system_instruction."""
+    assert "Hey, I'm Kai" in kai_manifest.system_instruction, (
+        "Greeting phrase missing. CHARACTERISTIC PHRASES contract requires it."
+    )
+
+
+def test_filler_ban_present(kai_manifest):
+    """Filler affirmation ban is present in TONE RULES."""
+    instruction = kai_manifest.system_instruction
+    assert "Certainly" in instruction or "filler" in instruction.lower(), (
+        "Filler affirmation ban missing from TONE RULES."
+    )
+
+
+def test_system_instruction_passed_to_agent():
+    """
+    Proves the full runtime path:
+    agent.yaml -> ManifestLoader -> KaiAgent.__init__ -> system_prompt.
+
+    Imports KaiAgent directly to verify system_prompt is set from
+    manifest.system_instruction without calling the LLM.
+    """
+    from hushh_mcp.agents.kai.agent import KaiAgent
+
+    agent = KaiAgent()
+    assert agent.system_prompt, "KaiAgent.system_prompt is empty after init"
+    assert "PERSONALITY" in agent.system_prompt, (
+        "PERSONALITY section not reachable through KaiAgent runtime path"
+    )
+    assert "CHARACTERISTIC PHRASES" in agent.system_prompt, (
+        "CHARACTERISTIC PHRASES not reachable through KaiAgent runtime path"
+    )
+    assert "CONSENT RULES" in agent.system_prompt, (
+        "CONSENT RULES not reachable — persona must not bypass gating"
+    )


### PR DESCRIPTION
# Description

- Replace weak single-line TONE with a full PERSONALITY section defining Kai's core character traits: confident, warm, honest, privacy-aware, and direct
- Add CHARACTERISTIC PHRASES section with 8 scripted responses covering greetings, acknowledgements, recommendations, degraded data, out-of-scope requests, missing vault token, uncertainty, and analysis completion
- Add TONE RULES section banning filler affirmations, prohibiting responses starting with I, enforcing contractions, and requiring spoken numbers in voice responses
- Builds directly on merged PR #148 system prompt foundation
- Closes #145



## Summary
Closes #145

The Kai voice agent had a single line "Tone: Professional, 
data-driven, objective, and concise" — a label, not a personality.
This PR gives Kai a real, consistent voice identity that builds
directly on the system prompt foundation from merged PR #148.

## Changes
Modified: consent-protocol/hushh_mcp/agents/kai/agent.yaml

Replaced the weak TONE section with three new sections:

### PERSONALITY
Defines Kai's core character traits:
- Confident but never arrogant
- Warm but efficient  
- Honest about uncertainty — never bluffs
- Privacy-aware — treats user data with visible respect
- Direct — answer first, detail second

### CHARACTERISTIC PHRASES
8 scripted responses for the most common voice scenarios:
session greeting, acknowledging a request, delivering a 
recommendation, degraded data, out-of-scope requests, 
missing vault token, uncertain ticker, analysis complete.

### TONE RULES
No filler affirmations, never start with "I", use contractions,
speak numbers in voice responses, silence over padding.

## 📌 Impact Map (Required)
- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Verification commands executed:
  - [x] None (prompt-only change, no code execution required)

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Not applicable — this is a backend agent prompt change
- [x] **iOS**: Not applicable
- [x] **Android**: Not applicable

## 🧪 Testing
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video
Prompt-only change — no UI to screenshot. The diff shows 
52 additions and 2 deletions to agent.yaml.

## 🛡️ Privacy & Consent
- [x] Does this change access user data? No — prompt only.

## 📜 Licensing
- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed — no dependencies changed.