### PR TITLE
consent-protocol: Firebase bearer errors, pytest COUNT repeat, test CLI

### DIFF
--- a/consent-protocol/CONTRIBUTING.md
+++ b/consent-protocol/CONTRIBUTING.md
@@ -58,7 +58,7 @@ Or run individually:
 ./bin/consent-protocol lint          # Lint
 ./bin/consent-protocol format-check  # Format check
 ./bin/consent-protocol typecheck     # Type check
-./bin/consent-protocol test          # Tests
+./bin/consent-protocol test          # Tests (default tests/; optional args, e.g. tests/test_foo.py COUNT=5)
 ./bin/consent-protocol security      # Security scan
 ```
 

--- a/consent-protocol/README.md
+++ b/consent-protocol/README.md
@@ -243,7 +243,7 @@ Migration authority:
 ./bin/consent-protocol lint         # Lint with ruff
 ./bin/consent-protocol format       # Format code
 ./bin/consent-protocol typecheck    # Type check with mypy
-./bin/consent-protocol test         # Run tests with pytest
+./bin/consent-protocol test         # Run tests with pytest (default: tests/; pass paths/flags, e.g. tests/test_foo.py COUNT=5)
 ./bin/consent-protocol security     # Security scan with bandit
 ./bin/consent-protocol ci           # Run all checks (same as CI)
 ```

--- a/consent-protocol/api/utils/firebase_auth.py
+++ b/consent-protocol/api/utils/firebase_auth.py
@@ -6,11 +6,14 @@ Used by endpoints that require identity verification (Firebase Auth boundary).
 
 from __future__ import annotations
 
+import logging
 from typing import Optional
 
 from fastapi import HTTPException
 
 from api.utils.firebase_admin import ensure_firebase_auth_admin, get_firebase_auth_app
+
+logger = logging.getLogger(__name__)
 
 
 def verify_firebase_bearer(authorization: Optional[str]) -> str:
@@ -29,9 +32,9 @@ def verify_firebase_bearer(authorization: Optional[str]) -> str:
     if not id_token:
         raise HTTPException(status_code=401, detail="Missing bearer token")
 
-    try:
-        from firebase_admin import auth as firebase_auth
+    from firebase_admin import auth as firebase_auth
 
+    try:
         firebase_app = get_firebase_auth_app()
         decoded = firebase_auth.verify_id_token(id_token, app=firebase_app)
         uid = decoded.get("uid")
@@ -40,6 +43,24 @@ def verify_firebase_bearer(authorization: Optional[str]) -> str:
         return uid
     except HTTPException:
         raise
-    except Exception:
-        # Do not leak details
-        raise HTTPException(status_code=401, detail="Invalid Firebase ID token")
+    except ValueError as exc:
+        # Malformed token input per Admin SDK contract.
+        logger.warning("firebase.verify_id_token value_error: %s", exc)
+        raise HTTPException(status_code=401, detail="Invalid Firebase ID token") from None
+    except (
+        firebase_auth.InvalidIdTokenError,
+        firebase_auth.ExpiredIdTokenError,
+        firebase_auth.RevokedIdTokenError,
+        firebase_auth.UserDisabledError,
+    ):
+        raise HTTPException(status_code=401, detail="Invalid Firebase ID token") from None
+    except firebase_auth.CertificateFetchError as exc:
+        # Public key fetch failed — not a client token problem.
+        logger.error("firebase.verify_id_token certificate_fetch_failed: %s", exc)
+        raise HTTPException(
+            status_code=503,
+            detail="Authentication service temporarily unavailable",
+        ) from None
+    except Exception as exc:
+        logger.exception("firebase.verify_id_token unexpected_error: %s", exc)
+        raise HTTPException(status_code=500, detail="Internal server error") from None

--- a/consent-protocol/bin/consent-protocol
+++ b/consent-protocol/bin/consent-protocol
@@ -20,7 +20,7 @@ Commands:
   format-check
   fix
   typecheck
-  test
+  test [pytest args...]   # default: whole tests/ tree
   test-ci
   security
   accuracy
@@ -107,10 +107,16 @@ case "$COMMAND" in
     exec "$PYTHON_BIN" -m mypy --config-file pyproject.toml --ignore-missing-imports "$@"
     ;;
   test)
-    if command -v uv >/dev/null 2>&1; then
-      run_test_env uv run pytest tests/ -v --tb=short "$@"
+    pytest_targets=()
+    if [ "$#" -eq 0 ]; then
+      pytest_targets=(tests/)
     else
-      run_test_env "$PYTHON_BIN" -m pytest tests/ -v --tb=short "$@"
+      pytest_targets=("$@")
+    fi
+    if command -v uv >/dev/null 2>&1; then
+      run_test_env uv run pytest -v --tb=short "${pytest_targets[@]}"
+    else
+      run_test_env "$PYTHON_BIN" -m pytest -v --tb=short "${pytest_targets[@]}"
     fi
     ;;
   test-ci)

--- a/consent-protocol/hushh_repeat_session.py
+++ b/consent-protocol/hushh_repeat_session.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Hushh
+"""Pytest plugin: trailing ``COUNT=N`` repeats the session N times (default 1)."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+
+import pytest
+from _pytest.config import ExitCode
+
+_COUNT = re.compile(r"(?i)^count=(\d+)$")
+_N = 1
+
+
+def pytest_load_initial_conftests(
+    early_config: pytest.Config,  # noqa: ARG001
+    parser: object,  # noqa: ARG001
+    args: list[str],
+) -> None:
+    global _N
+    _N = 1
+    if not args:
+        return
+    m = _COUNT.fullmatch(args[-1])
+    if not m:
+        return
+    n = int(m.group(1), 10)
+    if n < 1:
+        raise pytest.UsageError(f"COUNT must be >= 1; got: {args[-1]}")
+    args.pop()
+    _N = n
+
+
+@pytest.hookimpl(hookwrapper=True, trylast=True)
+def pytest_cmdline_main(config: pytest.Config):
+    outcome = yield
+    if _N <= 1:
+        return
+    try:
+        rc = outcome.get_result()
+    except BaseException:
+        raise
+    if rc not in (0, ExitCode.OK):
+        return
+    stripped = list(config.invocation_params.args)
+    if stripped and _COUNT.fullmatch(stripped[-1]):
+        stripped = stripped[:-1]
+    env = os.environ.copy()
+    env.pop("PYTEST_ADDOPTS", None)
+    for _ in range(2, _N + 1):
+        proc = subprocess.run(  # noqa: S603
+            [sys.executable, "-m", "pytest", *stripped],
+            cwd=config.invocation_params.dir,
+            env=env,
+            check=False,
+        )
+        if proc.returncode not in (0, int(ExitCode.OK)):
+            outcome.force_result(proc.returncode)
+            return

--- a/consent-protocol/pyproject.toml
+++ b/consent-protocol/pyproject.toml
@@ -163,6 +163,6 @@ pythonpath = ["."]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
-addopts = "-v --tb=short"
+addopts = "-p hushh_repeat_session -v --tb=short"
 asyncio_mode = "auto"  # Enable pytest-asyncio auto mode
 asyncio_default_fixture_loop_scope = "function"  # Set event loop scope

--- a/consent-protocol/tests/test_firebase_auth_split.py
+++ b/consent-protocol/tests/test_firebase_auth_split.py
@@ -48,6 +48,69 @@ def test_verify_firebase_bearer_returns_500_when_auth_admin_missing(monkeypatch)
     assert exc.value.detail == "Firebase Admin not configured"
 
 
+def test_verify_firebase_bearer_certificate_fetch_returns_503(monkeypatch):
+    import firebase_admin.auth as firebase_auth
+
+    monkeypatch.setattr(
+        "api.utils.firebase_auth.ensure_firebase_auth_admin",
+        lambda: (True, "test-project"),
+    )
+    monkeypatch.setattr("api.utils.firebase_auth.get_firebase_auth_app", lambda: object())
+
+    def _raise_cert(*_a, **_kw):
+        raise firebase_auth.CertificateFetchError("fetch failed", cause=RuntimeError("network"))
+
+    monkeypatch.setattr(firebase_auth, "verify_id_token", _raise_cert)
+
+    with pytest.raises(HTTPException) as excinfo:
+        verify_firebase_bearer("Bearer some-token")
+
+    assert excinfo.value.status_code == 503
+    assert "temporarily unavailable" in excinfo.value.detail.lower()
+
+
+def test_verify_firebase_bearer_invalid_id_token_returns_401(monkeypatch):
+    import firebase_admin.auth as firebase_auth
+
+    monkeypatch.setattr(
+        "api.utils.firebase_auth.ensure_firebase_auth_admin",
+        lambda: (True, "test-project"),
+    )
+    monkeypatch.setattr("api.utils.firebase_auth.get_firebase_auth_app", lambda: object())
+
+    def _raise_invalid(*_a, **_kw):
+        raise firebase_auth.InvalidIdTokenError("bad token")
+
+    monkeypatch.setattr(firebase_auth, "verify_id_token", _raise_invalid)
+
+    with pytest.raises(HTTPException) as excinfo:
+        verify_firebase_bearer("Bearer some-token")
+
+    assert excinfo.value.status_code == 401
+    assert excinfo.value.detail == "Invalid Firebase ID token"
+
+
+def test_verify_firebase_bearer_unexpected_error_returns_500(monkeypatch):
+    import firebase_admin.auth as firebase_auth
+
+    monkeypatch.setattr(
+        "api.utils.firebase_auth.ensure_firebase_auth_admin",
+        lambda: (True, "test-project"),
+    )
+    monkeypatch.setattr("api.utils.firebase_auth.get_firebase_auth_app", lambda: object())
+
+    def _raise_runtime(*_a, **_kw):
+        raise RuntimeError("surprise")
+
+    monkeypatch.setattr(firebase_auth, "verify_id_token", _raise_runtime)
+
+    with pytest.raises(HTTPException) as excinfo:
+        verify_firebase_bearer("Bearer some-token")
+
+    assert excinfo.value.status_code == 500
+    assert excinfo.value.detail == "Internal server error"
+
+
 def test_ensure_firebase_admin_uses_default_service_account(monkeypatch):
     import firebase_admin
     from firebase_admin import credentials


### PR DESCRIPTION
## Description

**Firebase bearer (`verify_firebase_bearer`)**  
Tightened HTTP behavior: invalid/malformed Firebase ID token → **401** with a stable client message; **`CertificateFetchError`** → **503** with a generic message and error-level logging; other unexpected errors → **500** with `logger.exception`, without leaking internals in JSON responses.

**Tests**  
Regression coverage added/extended in `consent-protocol/tests/test_firebase_auth_split.py`.

**Pytest session repeat**  
Added `consent-protocol/hushh_repeat_session.py` and load it via `pyproject.toml` `addopts` (`-p hushh_repeat_session`). Optional trailing **`COUNT=N`** on the pytest argv repeats the full session (first run in-process, further runs via subprocess). Stops on first failure.

**Developer UX**  
`./bin/consent-protocol test` now defaults to `tests/` when given no extra args; with args, it forwards them to pytest (so you can target a file and optional `COUNT=N`).

**Docs**  
Short notes in `consent-protocol/README.md` and `consent-protocol/CONTRIBUTING.md`.

---

## Impact map (required)

- **Routes touched:** **None** (no edits under `api/routes/`). Behavior may change for any route that calls `verify_firebase_bearer` (status codes / bodies only).

- **API / schema / type changes:** **Listed below**  
  - Response **status codes** and **error message strings** for Firebase bearer verification failures (401 vs 503 vs 500) as above. No OpenAPI/schema file edits in this PR.

- **Cache keys touched:** **None**

- **World-model domain summary effects:** **None**

- **Mobile parity impacts:** **None** (consent-protocol backend only)

- **Docs updated (exact files):** **Listed below**  
  - `consent-protocol/README.md`  
  - `consent-protocol/CONTRIBUTING.md`

- **Verification commands executed:** Check what you actually ran, for example:  
  - [ ] `cd hushh-webapp && npm run typecheck` — **N/A / not run** (no webapp changes)  
  - [ ] `cd hushh-webapp && npm test` — **N/A / not run**  
  - [ ] `cd hushh-webapp && npm run build` — **N/A / not run**  
  - [ ] `cd hushh-webapp && npm run ios:test` — **N/A / not run**  
  - [ ] `python scripts/ops/kai-system-audit.py ...` — **N/A / not run** unless you ran it  

  Add a line like: **Ran** `cd consent-protocol && ./bin/consent-protocol format-check`, `./bin/consent-protocol lint` (if you did), `./bin/consent-protocol test tests/test_firebase_auth_split.py …` (and `COUNT=…` if you did).

---

## Tri-flow architecture check

This PR is **consent-protocol (Python) only** — not a tri-flow UI feature.

- [ ] **Web** — **N/A** (no Next.js changes)  
- [ ] **iOS** — **N/A** (no Capacitor/iOS changes)  
- [ ] **Android** — **N/A** (no Android plugin changes)

---

## Testing

- [ ] **Web** — N/A  
- [ ] **iOS** — N/A  
- [ ] **Android** — N/A  
- [x] **Commits are signed off** (`git commit -s`) — check this if your commit has `Signed-off-by`

---

## Screenshots / video

**N/A** — backend + tests + tooling; no UI change.

---

## Privacy & consent

- [ ] **Does this change access user data?** — **No** (error handling for token verification only; no new data access paths)  
- [ ] **`checkConsentToken()`** — **N/A** (not applicable to this diff)

---

## Licensing

- [x] **First-party changes remain Apache-2.0 compatible**  
- [x] **Third-party notice impact** — **N/A** (no dependency changes in this PR)
