### PR TITLE
fix: process_message fetches 10 history messages but only uses the last 5,this pr fixes that

### DIFF
--- a/consent-protocol/hushh_mcp/services/kai_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/kai_chat_service.py
@@ -315,7 +315,7 @@ class KaiChatService:
             conversation = await self._get_or_create_conversation(user_id, conversation_id)
 
             # 2. Get chat history for context
-            history = await self.chat_db.get_recent_context(conversation.id, max_messages=10)
+            history = await self.chat_db.get_recent_context(conversation.id, max_messages=5)
 
             # 3. Get user's PKM context
             user_context = await self.pkm_service.get_user_metadata(user_id)


### PR DESCRIPTION
# Description

Reduced `max_messages` in `get_recent_context` from `10` to `5` in `KaiChatService.process_message`
(`consent-protocol/hushh_mcp/services/kai_chat_service.py`, line 318).

`_build_system_prompt` was immediately slicing the returned list to `history[-5:]` before injecting
it into the Gemini prompt, so the extra 5 rows fetched from Postgres were deserialized and silently
discarded on every single chat turn. Aligning the fetch limit to actual usage halves the DB row
payload on this hot path with zero behaviour change.

---

## 📌 Impact Map (Required)

* Routes touched:
   * [x] None
* API / schema / type changes:
   * [x] None
* Cache keys touched:
   * [x] None
* World-model domain summary effects:
   * [x] None
* Mobile parity impacts:
   * [x] None — backend-only change, no client contract touched
* Docs updated (exact files):
   * [x] None
* Verification commands executed:
   * [ ] `cd hushh-webapp && npm run typecheck`
   * [ ] `cd hushh-webapp && npm test`
   * [ ] `cd hushh-webapp && npm run build`
   * [ ] `cd hushh-webapp && npm run ios:test`
   * [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000`

---

## 🛑 Tri-Flow Architecture Check

*Every feature must be implemented across all three layers or explicitly marked as not applicable.*

* [ ] **Web:** N/A — change is in `consent-protocol` Python backend only (`app/api/...` not touched)
* [ ] **iOS:** N/A — no Swift Capacitor Plugin changes required
* [ ] **Android:** N/A — no Kotlin Capacitor Plugin changes required

---

## 🧪 Testing

* [ ] Tested on Web (Chrome/Safari)
* [ ] Tested on iOS Simulator/Device
* [ ] Tested on Android Emulator/Device
* [x] Commits are signed off (`git commit -s`)

---

## 📸 Screenshots / Video

N/A — no visual change. Confirm via Postgres slow-query log or `EXPLAIN ANALYZE` on
`get_recent_context`; expected row count drops from 10 → 5 per `/kai/chat` call.

---

## 🛡️ Privacy & Consent

* [x] Does this change access user data? **No** — fetch limit reduced, no new data accessed
* [ ] If yes, have you implemented `checkConsentToken()`? N/A

---

## 📜 Licensing

* [x] First-party changes remain Apache-2.0 compatible
* [x] Third-party notice impact reviewed when dependencies changed — no dependency changes