### PR TITLE
fix(attribute-learner): use sentinel to prevent repeated env reads when API key is absent

### DIFF
--- a/consent-protocol/hushh_mcp/services/attribute_learner.py
+++ b/consent-protocol/hushh_mcp/services/attribute_learner.py
@@ -62,19 +62,18 @@ class AttributeLearner:
     then stores it in the PKM for future context.
     """
 
+    _UNSET = object()  # sentinel — distinguishes "not yet initialised" from None (no API key)
+
     def __init__(self):
-        self._client = None
+        self._client = self._UNSET
         self._pkm_service = None
 
     @property
     def client(self):
         """Get the google.genai client (from google-adk)."""
-        if not hasattr(self, "_client") or self._client is None:
+        if self._client is self._UNSET:
             api_key = os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY")
-            if api_key:
-                self._client = genai.Client(api_key=api_key)
-            else:
-                self._client = None
+            self._client = genai.Client(api_key=api_key) if api_key else None
         return self._client
 
     @property


### PR DESCRIPTION
# Description

`AttributeLearner.client` was using `None` for two distinct states — "not yet initialised" and
"no API key configured". Because the guard was `if self._client is None`, the property re-ran
`os.environ.get("GOOGLE_API_KEY")` on **every single call** when no key was present — once per
`extract_attributes` invocation, which fires on every chat turn via the background attribute
learning task.

**Fix:** introduced a class-level `_UNSET` sentinel object. `__init__` sets
`self._client = self._UNSET`. The property now checks `if self._client is self._UNSET`, runs the
env lookup exactly once, and stores either a real `genai.Client` or `None` (no key). Neither state
ever triggers the lookup again. The redundant `hasattr(self, "_client")` guard was also removed
since `_client` is always set by `__init__`.


---

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None — backend-only change, no client contract touched
- Docs updated (exact files):
  - [x] None
- Verification commands executed:
  - [ ] `cd hushh-webapp && npm run typecheck`
  - [ ] `cd hushh-webapp && npm test`
  - [ ] `cd hushh-webapp && npm run build`
  - [ ] `cd hushh-webapp && npm run ios:test`
  - [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000`

---

## 🛑 Tri-Flow Architecture Check

_Every feature must be implemented across all three layers or explicitly marked as not applicable._

- [ ] **Web**: N/A — change is in `consent-protocol` Python backend only
- [ ] **iOS**: N/A — no Swift Capacitor Plugin changes required
- [ ] **Android**: N/A — no Kotlin Capacitor Plugin changes required

---

## 🧪 Testing

- [ ] Tested on Web (Chrome/Safari)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

---

## 📸 Screenshots / Video

N/A — no visual change. Verify by asserting `os.environ.get` is called exactly once on
`AttributeLearner` instantiation regardless of key presence (unit test mock on `os.environ`).

---

## 🛡️ Privacy & Consent

- [x] Does this change access user data? **No** — initialisation logic only, no data access changes
- [ ] If yes, have you implemented `checkConsentToken()`? N/A

---

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed — no dependency changes

---
