### PR TITLE
chore(repo): add editorconfig for consistent formatting

### DIFF
--- a/hushh-webapp/.editorconfig
+++ b/hushh-webapp/.editorconfig
@@ -1,0 +1,24 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.ts]
+indent_size = 2
+
+[*.tsx]
+indent_size = 2
+
+[*.json]
+indent_size = 2
+
+[*.yml]
+indent_size = 2


### PR DESCRIPTION
## Description

Adds a repository-level `.editorconfig` to enforce consistent formatting across editors and environments.

## What changed

- Standardized indentation to 2 spaces
- Standardized line endings to LF
- Enabled final newline consistency
- Disabled trailing whitespace trimming for Markdown files

## Impact

- No runtime changes
- No API changes
- Developer experience improvement only

## Testing

- Verified only `.editorconfig` was added