### PR TITLE
fix(voice): guard _VOICE_STAGE_TIMING against unbounded growth

### DIFF
--- a/consent-protocol/api/routes/kai/voice.py
+++ b/consent-protocol/api/routes/kai/voice.py
@@ -32,8 +32,32 @@ _VOICE_KILL_SWITCH_MESSAGE = (
     "Voice actions are temporarily unavailable. I can still respond and guide you."
 )
 _VOICE_STAGE_TIMING: dict[str, dict[str, float]] = {}
+_VOICE_STAGE_TIMING_TTL_MS = 300_000  # 5 minutes — evict stale turns
 
 
+def _evict_stale_voice_stage_timings() -> None:
+    """Remove turn timing entries that were never finalized.
+
+    Guards against unbounded growth when requests crash or
+    are cancelled before _trace_voice_stage is called with
+    finalize=True.
+    """
+    if not _VOICE_STAGE_TIMING:
+        return
+    now_ms = time.perf_counter() * 1000.0
+    stale_turn_ids = [
+        turn_id
+        for turn_id, entry in _VOICE_STAGE_TIMING.items()
+        if now_ms - entry.get("turn_start_ms", now_ms) > _VOICE_STAGE_TIMING_TTL_MS
+    ]
+    for turn_id in stale_turn_ids:
+        _VOICE_STAGE_TIMING.pop(turn_id, None)
+    if stale_turn_ids:
+        logger.debug(
+            "[VOICE_STAGE_TIMING] evicted %d stale turn(s): %s",
+            len(stale_turn_ids),
+            stale_turn_ids[:5],
+        )
 def _voice_runtime_settings() -> VoiceRuntimeSettings:
     return get_voice_runtime_settings()
 
@@ -244,6 +268,7 @@ def _trace_voice_stage(
 ) -> None:
     if not turn_id:
         return
+    _evict_stale_voice_stage_timings()
     now_ms = time.perf_counter() * 1000.0
     current = _VOICE_STAGE_TIMING.get(turn_id)
     if current is None:


### PR DESCRIPTION
The _VOICE_STAGE_TIMING module-level dict accumulated entries indefinitely when requests crashed or were cancelled before _trace_voice_stage was called with finalize=True.

Fix:
- Add _VOICE_STAGE_TIMING_TTL_MS constant (5 minutes)
- Add _evict_stale_voice_stage_timings() which removes entries older than the TTL using time.perf_counter()
- Call eviction at the start of every _trace_voice_stage() call so stale entries are cleaned up on the next incoming request

No external dependencies added — pure stdlib only. Evictions are logged at DEBUG level with turn_id list.

# Description

## Summary

Fixes an unbounded memory growth issue in the voice route layer.

## Problem

`_VOICE_STAGE_TIMING` is a module-level dict that stores per-turn
timing state for voice request tracing. Entries are removed when
`_trace_voice_stage` is called with `finalize=True`.

However if a request crashes, times out, or is cancelled by an
asyncio task before the final trace call, that turn_id remains
in the dict permanently. Under sustained voice load this causes
slow but unbounded memory growth in the FastAPI worker process.

## Fix

- Added `_VOICE_STAGE_TIMING_TTL_MS = 300_000` (5 minute TTL)
- Added `_evict_stale_voice_stage_timings()` — scans the dict
  and removes entries where `time.perf_counter()` shows the turn
  started more than 5 minutes ago
- Called at the top of every `_trace_voice_stage()` invocation
  so eviction piggybacks on normal request traffic

## Why this approach

- Zero new dependencies — pure stdlib (`time.perf_counter`)
- No background thread or asyncio task needed
- Eviction cost is O(n) on dict size which stays small in practice
- 5 minute TTL is safely above the longest possible voice turn
  (OpenAI TTS timeout is 20s, planning timeout is 45s)
- Evictions logged at DEBUG level for observability

## Files changed
- `consent-protocol/api/routes/kai/voice.py`

## Impact Map
- Routes touched: None (internal helper only)
- API / schema / type changes: None
- Cache keys touched: None
- Mobile parity impacts: None