### PR TITLE
`fix: surgically update ticker cache rows instead of full table reload on portfolio import`

### DIFF
--- a/consent-protocol/hushh_mcp/services/ticker_cache.py
+++ b/consent-protocol/hushh_mcp/services/ticker_cache.py
@@ -24,7 +24,7 @@ import re
 import threading
 import time
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from hushh_mcp.services.ticker_db import TickerDBService
 
@@ -116,8 +116,53 @@ class TickerCache:
                 "tradable": row.tradable,
             }
 
+    def update_rows(self, rows: List[Dict[str, Any]]) -> int:
+        """
+        Surgically update specific ticker rows in the cache without a full DB reload.
+
+        Called after enrich_symbols() or sync_holdings_symbols() to patch only
+        the rows that were just written, instead of re-fetching the entire table.
+
+        Args:
+            rows: List of dicts with at minimum a 'ticker' key, matching the
+                  shape produced by ticker_db upsert helpers.
+
+        Returns:
+            Number of rows updated/inserted in the cache.
+        """
+        updated = 0
+        with self._lock:
+            for r in rows:
+                ticker = (r.get("ticker") or "").upper().strip()
+                if not ticker:
+                    continue
+                existing = self._row_by_ticker.get(ticker)
+                new_row = TickerRow(
+                    ticker=ticker,
+                    title=r.get("title") or (existing.title if existing else ticker),
+                    cik=r.get("cik") or (existing.cik if existing else None),
+                    exchange=r.get("exchange") or (existing.exchange if existing else None),
+                    sic_code=r.get("sic_code") or (existing.sic_code if existing else None),
+                    sic_description=r.get("sic_description") or (existing.sic_description if existing else None),
+                    sector_primary=r.get("sector_primary") or (existing.sector_primary if existing else None),
+                    industry_primary=r.get("industry_primary") or (existing.industry_primary if existing else None),
+                    sector_tags=r.get("sector_tags") if isinstance(r.get("sector_tags"), list)
+                                else (existing.sector_tags if existing else []),
+                    metadata_confidence=float(r.get("metadata_confidence") or
+                                              (existing.metadata_confidence if existing else 0.0)),
+                    tradable=bool(r.get("tradable", existing.tradable if existing else True)),
+                )
+                if ticker not in self._row_by_ticker:
+                    self._rows.append(new_row)
+                self._row_by_ticker[ticker] = new_row
+                updated += 1
+
+        if updated:
+            logger.debug("[TickerCache] update_rows: patched %d ticker(s) in-place", updated)
+        return updated
+
     def load_from_db(self) -> int:
-        """Load all tickers from DB into memory."""
+        """Load all tickers from DB into memory. Only called at server startup."""
         t0 = time.time()
         svc = TickerDBService()
         db = svc._get_db()

--- a/consent-protocol/hushh_mcp/services/ticker_db.py
+++ b/consent-protocol/hushh_mcp/services/ticker_db.py
@@ -539,7 +539,8 @@ class TickerDBService:
             try:
                 from hushh_mcp.services.ticker_cache import ticker_cache
 
-                ticker_cache.load_from_db()
+                # Patch only the rows that changed — avoids a full table reload.
+                ticker_cache.update_rows(rows_to_upsert)
             except Exception as exc:
                 logger.warning("Ticker cache refresh after enrichment failed: %s", exc)
 
@@ -682,7 +683,9 @@ class TickerDBService:
             try:
                 from hushh_mcp.services.ticker_cache import ticker_cache
 
-                ticker_cache.load_from_db()
+                # Patch only the rows that changed — avoids a full table reload.
+                all_written = rows_to_seed + rows_to_update
+                ticker_cache.update_rows(all_written)
             except Exception as exc:
                 logger.warning("Ticker cache refresh after seed sync failed: %s", exc)
 


### PR DESCRIPTION
# Description

`ticker_cache.load_from_db()` was being called after every portfolio import and symbol enrichment, triggering a full `SELECT *` on the `tickers` table even when only a handful of rows changed. This added an unnecessary heavy DB round-trip on every user portfolio sync.

Added a new `update_rows()` method to `TickerCache` that surgically patches only the rows that were just written to the DB. The two call sites in `ticker_db.py` (`enrich_symbols` and `sync_holdings_symbols`) now call `update_rows()` instead of `load_from_db()`. The startup full-load in `server.py` is untouched — that remains the only place a full table scan is appropriate.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
  - [ ] Listed below:
- API / schema / type changes:
  - [x] None
  - [ ] Listed below:
- Cache keys touched:
  - [ ] None
  - [x] Listed below:
    - `TickerCache._row_by_ticker` — existing dict, now also written to by `update_rows()` in addition to `load_from_db()`
    - `TickerCache._rows` — new rows appended in-place for net-new tickers; existing entries updated in-place
- World-model domain summary effects:
  - [x] None
  - [ ] Listed below:
- Mobile parity impacts:
  - [x] None — cache is server-side only
  - [ ] Listed below:
- Docs updated (exact files):
  - [x] None
  - [ ] Listed below:
- Verification commands executed:
  - [ ] `cd hushh-webapp && npm run typecheck`
  - [ ] `cd hushh-webapp && npm test`
  - [ ] `cd hushh-webapp && npm run build`
  - [ ] `cd hushh-webapp && npm run ios:test`
  - [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000`

## 🛑 Tri-Flow Architecture Check

_Every feature must be implemented across all three layers or explicitly marked as not applicable._

- [ ] **Web**: Next.js implementation (`app/api/...`) — N/A, server-side cache only
- [ ] **iOS**: Swift Capacitor Plugin (`ios/App/App/Plugins/...`) — N/A
- [ ] **Android**: Kotlin Capacitor Plugin (`android/app/.../plugins/...`) — N/A

## 🧪 Testing

- [ ] Tested on Web (Chrome/Safari)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

_No UI change. Attach server logs showing reduced DB round-trips after portfolio import if available._

## 🛡️ Privacy & Consent

- [x] Does this change access user data? **No** — reads/writes to the in-memory cache only; no new data access paths introduced.
- [ ] If yes, have you implemented `checkConsentToken()`? — N/A

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed — no new dependencies added