### PR TITLE
perf(market-cache-store): move ensure_table to startup, remove from p…

### DIFF
--- a/consent-protocol/hushh_mcp/services/market_cache_store.py
+++ b/consent-protocol/hushh_mcp/services/market_cache_store.py
@@ -124,7 +124,6 @@ class MarketCacheStoreService:
         return str(value)
 
     async def get_entry(self, cache_key: str) -> MarketCacheStoreEntry | None:
-        await self.ensure_table()
         pool = await get_pool()
         async with pool.acquire() as conn:
             row = await conn.fetchrow(
@@ -166,8 +165,6 @@ class MarketCacheStoreService:
         stale_ttl_seconds: int,
         provider_status: dict[str, Any] | None = None,
     ) -> None:
-        await self.ensure_table()
-
         now = datetime.now(timezone.utc)
         fresh_until = now.timestamp() + max(1, int(fresh_ttl_seconds))
         stale_until = now.timestamp() + max(1, int(stale_ttl_seconds))
@@ -210,7 +207,6 @@ class MarketCacheStoreService:
             )
 
     async def delete_expired(self, *, max_rows: int = 500) -> int:
-        await self.ensure_table()
         pool = await get_pool()
         async with pool.acquire() as conn:
             rows = await conn.fetch(

--- a/consent-protocol/server.py
+++ b/consent-protocol/server.py
@@ -481,6 +481,14 @@ async def shutdown_remote_mcp_transport():
 
 
 @app.on_event("startup")
+async def startup_market_cache_store_table():
+    """Ensure the L2 market cache table exists before any request hits it."""
+    from hushh_mcp.services.market_cache_store import get_market_cache_store_service
+
+    await get_market_cache_store_service().ensure_table()
+
+
+@app.on_event("startup")
 async def startup_market_insights_refresh():
     """Warm shared market caches, then keep them refreshed in the background."""
     await warm_market_insights_startup_once()

--- a/consent-protocol/server.py
+++ b/consent-protocol/server.py
@@ -485,7 +485,21 @@ async def startup_market_cache_store_table():
     """Ensure the L2 market cache table exists before any request hits it."""
     from hushh_mcp.services.market_cache_store import get_market_cache_store_service
 
-    await get_market_cache_store_service().ensure_table()
+    try:
+        await get_market_cache_store_service().ensure_table()
+    except Exception as exc:
+        if _require_database_on_startup():
+            logger.critical(
+                "startup.market_cache_store_table_failed environment=%s reason=%s",
+                _environment(),
+                exc,
+            )
+            raise
+        logger.warning(
+            "startup.market_cache_store_table_skipped environment=%s reason=%s",
+            _environment(),
+            exc,
+        )
 
 
 @app.on_event("startup")

--- a/consent-protocol/tests/services/test_market_cache_store.py
+++ b/consent-protocol/tests/services/test_market_cache_store.py
@@ -1,5 +1,8 @@
 from datetime import datetime, timezone
 from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from hushh_mcp.services.market_cache_store import MarketCacheStoreService
 
@@ -22,3 +25,139 @@ def test_normalize_json_value_serializes_nested_non_json_payloads():
     assert normalized["rows"][0]["price"] == 123.45
     assert normalized["rows"][0]["bad_number"] is None
     assert sorted(normalized["rows"][0]["source_tags"]) == ["alpha", "beta"]
+
+# Opt-9: ensure_table removed from per-request hot paths
+
+def _make_service_with_table_ready() -> MarketCacheStoreService:
+    """Return a service instance that considers the table already initialised."""
+    service = MarketCacheStoreService()
+    service._table_ready = True
+    return service
+
+
+def _mock_pool_with_conn(fetchrow_return=None, fetch_return=None):
+    """Build a mock asyncpg pool + connection sufficient for hot-path tests."""
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value=fetchrow_return)
+    conn.fetch = AsyncMock(return_value=fetch_return or [])
+    conn.execute = AsyncMock(return_value=None)
+    conn.__aenter__ = AsyncMock(return_value=conn)
+    conn.__aexit__ = AsyncMock(return_value=None)
+
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=conn)
+
+    return pool, conn
+
+
+@pytest.mark.asyncio
+async def test_get_entry_does_not_call_ensure_table_when_table_is_ready():
+    """`get_entry` must NOT call `ensure_table` — it is guaranteed ready at startup."""
+    service = _make_service_with_table_ready()
+
+    ensure_calls = []
+
+    async def spy_ensure_table():
+        ensure_calls.append(1)
+
+    service.ensure_table = spy_ensure_table
+
+    pool, conn = _mock_pool_with_conn(fetchrow_return=None)
+
+    with patch("hushh_mcp.services.market_cache_store.get_pool", AsyncMock(return_value=pool)):
+        result = await service.get_entry("some-key")
+
+    assert ensure_calls == [], (
+        "get_entry called ensure_table; after opt-9 this must never happen on the hot path"
+    )
+    assert result is None  # fetchrow returned None → entry not found
+
+
+@pytest.mark.asyncio
+async def test_set_entry_does_not_call_ensure_table_when_table_is_ready():
+    """`set_entry` must NOT call `ensure_table` — it is guaranteed ready at startup."""
+    service = _make_service_with_table_ready()
+
+    ensure_calls = []
+
+    async def spy_ensure_table():
+        ensure_calls.append(1)
+
+    service.ensure_table = spy_ensure_table
+
+    pool, conn = _mock_pool_with_conn()
+
+    with patch("hushh_mcp.services.market_cache_store.get_pool", AsyncMock(return_value=pool)):
+        await service.set_entry(
+            cache_key="test-key",
+            payload={"price": 100},
+            fresh_ttl_seconds=60,
+            stale_ttl_seconds=120,
+        )
+
+    assert ensure_calls == [], (
+        "set_entry called ensure_table; after opt-9 this must never happen on the hot path"
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_expired_does_not_call_ensure_table_when_table_is_ready():
+    """`delete_expired` must NOT call `ensure_table` — it is guaranteed ready at startup."""
+    service = _make_service_with_table_ready()
+
+    ensure_calls = []
+
+    async def spy_ensure_table():
+        ensure_calls.append(1)
+
+    service.ensure_table = spy_ensure_table
+
+    pool, conn = _mock_pool_with_conn(fetch_return=[])
+
+    with patch("hushh_mcp.services.market_cache_store.get_pool", AsyncMock(return_value=pool)):
+        deleted = await service.delete_expired()
+
+    assert ensure_calls == [], (
+        "delete_expired called ensure_table; after opt-9 this must never happen on the hot path"
+    )
+    assert deleted == 0
+
+
+@pytest.mark.asyncio
+async def test_ensure_table_is_idempotent_once_table_is_ready():
+    """After `_table_ready=True`, calling `ensure_table` directly must be a no-op (no DB call)."""
+    service = _make_service_with_table_ready()
+
+    pool_calls = []
+
+    async def spy_get_pool():
+        pool_calls.append(1)
+        return MagicMock()
+
+    with patch("hushh_mcp.services.market_cache_store.get_pool", spy_get_pool):
+        await service.ensure_table()
+
+    assert pool_calls == [], (
+        "ensure_table hit the DB even though _table_ready was True; "
+        "the early-return guard is broken"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ensure_table_sets_table_ready_flag_on_first_call():
+    """On first call (cold start), `ensure_table` must set `_table_ready=True`."""
+    service = MarketCacheStoreService()
+    assert service._table_ready is False
+
+    conn = AsyncMock()
+    conn.execute = AsyncMock(return_value=None)
+    conn.__aenter__ = AsyncMock(return_value=conn)
+    conn.__aexit__ = AsyncMock(return_value=None)
+
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=conn)
+
+    with patch("hushh_mcp.services.market_cache_store.get_pool", AsyncMock(return_value=pool)):
+        await service.ensure_table()
+
+    assert service._table_ready is True

--- a/consent-protocol/tests/test_server_startup_guards.py
+++ b/consent-protocol/tests/test_server_startup_guards.py
@@ -104,3 +104,46 @@ def test_schema_guard_still_fails_when_required_tables_are_missing(
         RuntimeError, match="Required runtime tables are missing: runtime_persona_state"
     ):
         asyncio.run(server.startup_required_schema_guard())
+
+
+def test_market_cache_table_startup_warns_and_continues_in_development(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    class _FailingMarketCacheStore:
+        async def ensure_table(self):
+            raise ConnectionRefusedError("db offline")
+
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.delenv("REQUIRE_DATABASE_ON_STARTUP", raising=False)
+    monkeypatch.setattr(
+        "hushh_mcp.services.market_cache_store.get_market_cache_store_service",
+        lambda: _FailingMarketCacheStore(),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        asyncio.run(server.startup_market_cache_store_table())
+
+    assert "startup.market_cache_store_table_skipped" in caplog.text
+
+
+def test_market_cache_table_startup_fails_when_database_required(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    class _FailingMarketCacheStore:
+        async def ensure_table(self):
+            raise ConnectionRefusedError("db offline")
+
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.delenv("REQUIRE_DATABASE_ON_STARTUP", raising=False)
+    monkeypatch.setattr(
+        "hushh_mcp.services.market_cache_store.get_market_cache_store_service",
+        lambda: _FailingMarketCacheStore(),
+    )
+
+    with caplog.at_level(logging.CRITICAL):
+        with pytest.raises(ConnectionRefusedError, match="db offline"):
+            asyncio.run(server.startup_market_cache_store_table())
+
+    assert "startup.market_cache_store_table_failed" in caplog.text


### PR DESCRIPTION
# Description

`ensure_table` was called at the top of every `get_entry`, `set_entry`, and `delete_expired`
invocation on `MarketCacheStoreService`. Even though the double-checked lock made repeated calls
cheap once `_table_ready = True`, the lock acquire-and-release still executed on every cache
read/write in production.

**Fix:** added a `startup_market_cache_store_table` FastAPI startup event handler in `server.py`
that calls `ensure_table()` once at worker boot — before any request is served. Removed the three
`await self.ensure_table()` calls from the per-request hot paths in `market_cache_store.py`.

**Files changed:**
- `consent-protocol/server.py` — new `@app.on_event("startup")` handler
- `consent-protocol/hushh_mcp/services/market_cache_store.py` — removed `ensure_table` from `get_entry`, `set_entry`, `delete_expired`
- `consent-protocol/tests/services/test_market_cache_store.py` — 5 new tests asserting the hot paths never call `ensure_table` and that cold-start initialisation still works correctly

---

## 📌 Impact Map (Required)

* Routes touched:
   * [x] None — internal service change, no route contract touched
* API / schema / type changes:
   * [x] None
* Cache keys touched:
   * [x] None — `kai_market_cache_entries` table and all existing keys are unchanged
* World-model domain summary effects:
   * [x] None
* Mobile parity impacts:
   * [x] None — backend-only change, no client contract touched
* Docs updated (exact files):
   * [x] None
* Verification commands executed:
   * [ ] `cd hushh-webapp && npm run typecheck`
   * [ ] `cd hushh-webapp && npm test`
   * [ ] `cd hushh-webapp && npm run build`
   * [ ] `cd hushh-webapp && npm run ios:test`
   * [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000`

---

## 🛑 Tri-Flow Architecture Check

_Every feature must be implemented across all three layers or explicitly marked as not applicable._

* [ ] **Web**: N/A — change is in `consent-protocol` Python backend only
* [ ] **iOS**: N/A — no Swift Capacitor Plugin changes required
* [ ] **Android**: N/A — no Kotlin Capacitor Plugin changes required

---

## 🧪 Testing

* [ ] Tested on Web (Chrome/Safari)
* [ ] Tested on iOS Simulator/Device
* [ ] Tested on Android Emulator/Device
* [x] Commits are signed off (`git commit -s`)

---

## 📸 Screenshots / Video

<img width="1920" height="1140" alt="image" src="https://github.com/user-attachments/assets/2de17405-6ef2-4a9d-9bc8-3875b023bf23" />
<img width="1920" height="1140" alt="image" src="https://github.com/user-attachments/assets/4852859d-606d-4aac-9804-b77b5ede2e02" />


---

## 🛡️ Privacy & Consent

* [x] Does this change access user data? **No** — startup initialisation refactor only
* [ ] If yes, have you implemented `checkConsentToken()`? N/A

---

## 📜 Licensing

* [x] First-party changes remain Apache-2.0 compatible
* [x] Third-party notice impact reviewed when dependencies changed — no dependency changes