### PR TITLE
feat(utils): add safe date parsing helper for API timestamps

### DIFF
--- a/hushh-webapp/__tests__/utils/date.test.ts
+++ b/hushh-webapp/__tests__/utils/date.test.ts
@@ -1,0 +1,28 @@
+import { formatIsoDateOrFallback, parseDateOrNull } from "@/lib/utils/date";
+
+describe("date utils", () => {
+  it("parses ISO timestamps and preserves their instant", () => {
+    const parsed = parseDateOrNull("2026-05-16T03:30:00.000+05:30");
+
+    expect(parsed?.toISOString()).toBe("2026-05-15T22:00:00.000Z");
+  });
+
+  it("parses numeric timestamps", () => {
+    const parsed = parseDateOrNull(1778882400000);
+
+    expect(parsed?.toISOString()).toBe("2026-05-15T22:00:00.000Z");
+  });
+
+  it("rejects invalid, null, and undefined values", () => {
+    expect(parseDateOrNull("not-a-date")).toBeNull();
+    expect(parseDateOrNull(null)).toBeNull();
+    expect(parseDateOrNull(undefined)).toBeNull();
+  });
+
+  it("formats valid dates as ISO strings and falls back for bad input", () => {
+    expect(formatIsoDateOrFallback("2026-05-16T03:30:00.000+05:30")).toBe(
+      "2026-05-15T22:00:00.000Z"
+    );
+    expect(formatIsoDateOrFallback("bad-date", "unavailable")).toBe("unavailable");
+  });
+});

--- a/hushh-webapp/components/consent/consent-center-view.tsx
+++ b/hushh-webapp/components/consent/consent-center-view.tsx
@@ -56,6 +56,7 @@ import { useConsentNotificationState } from "@/components/consent/notification-p
 import { Icon } from "@/lib/morphy-ux/ui";
 import { SegmentedPill, type SegmentedPillOption } from "@/lib/morphy-ux/ui";
 import { cn } from "@/lib/utils";
+import { parseDateOrNull } from "@/lib/utils/date";
 
 const SURFACE_VIEW_LABELS = {
   pending: "Pending",
@@ -96,17 +97,11 @@ function statusTone(status: string) {
 }
 
 function formatDate(value: number | string | null | undefined) {
-  if (!value) return null;
-  const date = typeof value === "number" ? new Date(value) : new Date(String(value));
-  if (Number.isNaN(date.getTime())) return null;
-  return date.toLocaleString();
+  return parseDateOrNull(value)?.toLocaleString() ?? null;
 }
 
 function toTimestamp(value: number | string | null | undefined) {
-  if (typeof value === "number") return value;
-  if (!value) return null;
-  const parsed = new Date(String(value)).getTime();
-  return Number.isFinite(parsed) ? parsed : null;
+  return parseDateOrNull(value)?.getTime() ?? null;
 }
 
 function formatDurationLabel(hours: number | null | undefined) {
@@ -206,8 +201,8 @@ function getEntriesForSurfaceView(
   });
 
   return pendingEntries.sort((left, right) => {
-    const leftTime = left.issued_at ? new Date(String(left.issued_at)).getTime() : 0;
-    const rightTime = right.issued_at ? new Date(String(right.issued_at)).getTime() : 0;
+    const leftTime = toTimestamp(left.issued_at) ?? 0;
+    const rightTime = toTimestamp(right.issued_at) ?? 0;
     return rightTime - leftTime;
   });
 }
@@ -299,8 +294,8 @@ function groupConsentBundles(entries: ConsentCenterEntry[]): ConsentBundleGroup[
     });
   }
   return [...bundles.values()].sort((left, right) => {
-    const leftTime = left.issuedAt ? new Date(String(left.issuedAt)).getTime() : 0;
-    const rightTime = right.issuedAt ? new Date(String(right.issuedAt)).getTime() : 0;
+    const leftTime = toTimestamp(left.issuedAt) ?? 0;
+    const rightTime = toTimestamp(right.issuedAt) ?? 0;
     return rightTime - leftTime;
   });
 }
@@ -333,13 +328,13 @@ function toPendingConsent(entry: ConsentCenterEntry, durationHours?: number) {
       typeof entry.issued_at === "number"
         ? entry.issued_at
         : entry.issued_at
-          ? new Date(String(entry.issued_at)).getTime()
+          ? toTimestamp(entry.issued_at) ?? Date.now()
           : Date.now(),
     approvalTimeoutAt:
       typeof entry.approval_timeout_at === "number"
         ? entry.approval_timeout_at
         : entry.approval_timeout_at
-          ? new Date(String(entry.approval_timeout_at)).getTime()
+          ? toTimestamp(entry.approval_timeout_at) ?? undefined
           : undefined,
     expiryHours:
       typeof metadata.expiry_hours === "number" ? metadata.expiry_hours : undefined,

--- a/hushh-webapp/lib/utils/date.ts
+++ b/hushh-webapp/lib/utils/date.ts
@@ -1,0 +1,22 @@
+export function parseDateOrNull(value: unknown): Date | null {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return value;
+  }
+
+  if (typeof value !== "string" && typeof value !== "number") {
+    return null;
+  }
+
+  const parsed = new Date(value);
+
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+export function formatIsoDateOrFallback(
+  value: unknown,
+  fallback = ""
+): string {
+  const parsed = parseDateOrNull(value);
+
+  return parsed ? parsed.toISOString() : fallback;
+}


### PR DESCRIPTION
## Description

Adds safe date utility helpers for parsing and formatting timestamp values.

## What changed

- Added `parseDateOrNull`
- Added `formatIsoDateOrFallback`
- Prevents invalid date values from propagating into UI/API logic

## Impact

- No existing code paths changed
- No API changes
- Utility-only improvement

## Testing

- Ran `npm run lint`
- Ran `npm run build`