### PR TITLE
fix(vault): handle malformed JSON payloads gracefully

### DIFF
--- a/hushh-webapp/app/api/vault/setup/route.ts
+++ b/hushh-webapp/app/api/vault/setup/route.ts
@@ -24,7 +24,14 @@ type VaultWrapper = {
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = await request.json().catch(() => null);
+
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return NextResponse.json(
+    { error: "Invalid JSON payload" },
+    { status: 400 }
+  );
+}
     const {
       userId,
       vaultKeyHash,


### PR DESCRIPTION
**Summary**

This PR improves the vault setup API route by gracefully handling malformed JSON payloads.

**Problem**
`await request.json()` could throw when receiving malformed or invalid JSON bodies, causing requests to fall through to the generic 500 error handler.

This incorrectly classified client-side payload issues as server-side failures.

 **Fix**
* Added guarded JSON parsing using `.catch(() => null)`
* Added validation for invalid/non-object payloads
* Returns `400 Bad Request` with a structured error response
* Prevents array payloads from bypassing validation

 **Validation**
Tested:
* malformed JSON payload → returns 400 with `"Invalid JSON payload"`
* empty object payload → existing validation still returns 400 for missing required fields
