### PR TITLE
fix(consent): standardize malformed JSON handling

### DIFF
--- a/hushh-webapp/app/api/consent/cancel/route.ts
+++ b/hushh-webapp/app/api/consent/cancel/route.ts
@@ -14,7 +14,14 @@ const BACKEND_URL = getPythonApiUrl();
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = await request.json().catch(() => null);
+
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+     return NextResponse.json(
+      { error: "Invalid JSON payload" },
+      { status: 400 }
+  );
+  }
     const { userId, requestId } = body;
 
     if (!userId || !requestId) {

--- a/hushh-webapp/app/api/consent/logout/route.ts
+++ b/hushh-webapp/app/api/consent/logout/route.ts
@@ -14,7 +14,14 @@ const BACKEND_URL = getPythonApiUrl();
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = await request.json().catch(() => null);
+
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+     return NextResponse.json(
+      { error: "Invalid JSON payload" },
+      { status: 400 }
+  );
+  }
     const { userId } = body;
 
     if (!userId) {

--- a/hushh-webapp/app/api/consent/revoke/route.ts
+++ b/hushh-webapp/app/api/consent/revoke/route.ts
@@ -13,7 +13,14 @@ const BACKEND_URL = getPythonApiUrl();
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = await request.json().catch(() => null);
+
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+     return NextResponse.json(
+      { error: "Invalid JSON payload" },
+      { status: 400 }
+  );
+  }
     const { userId, scope } = body;
     const authHeader = request.headers.get("authorization") || request.headers.get("Authorization");
 

--- a/hushh-webapp/app/api/consent/session-token/route.ts
+++ b/hushh-webapp/app/api/consent/session-token/route.ts
@@ -16,7 +16,14 @@ const BACKEND_URL = getPythonApiUrl();
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = await request.json().catch(() => null);
+
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+     return NextResponse.json(
+      { error: "Invalid JSON payload" },
+      { status: 400 }
+  );
+  }
     const { userId } = body;
 
     // Get Authorization header from request


### PR DESCRIPTION
 **Summary**

Standardizes malformed JSON handling across consent API routes.

 **Problem**
Several consent routes used raw `await request.json()` parsing, which could throw on malformed payloads and incorrectly fall through to generic 500 responses.

Other routes in the codebase already used guarded parsing patterns, resulting in inconsistent API behavior.

** Fix**
* Added guarded JSON parsing using `.catch(() => null)`
* Added validation for invalid/non-object payloads
* Returns explicit `400 Bad Request` responses for malformed JSON bodies
* Prevents array payloads from bypassing validation

**Routes Updated**

* `/api/consent/cancel`
* `/api/consent/logout`
* `/api/consent/revoke`
* `/api/consent/session-token`

 **Validation**

Tested malformed payloads against updated endpoints and verified:

* malformed JSON → `400 Bad Request`
* valid payloads → existing behavior preserved
