### PR TITLE
fix(doctor): surface .env.example copy hint when env files are missing

### DIFF
--- a/scripts/env/doctor.sh
+++ b/scripts/env/doctor.sh
@@ -158,17 +158,17 @@ if [ -f "$BACKEND_SOURCE" ]; then
   add_check "backend_source_file" "pass" "${BACKEND_SOURCE#$REPO_ROOT/}"
 else
   if [ "$PROFILE" = "local" ]; then
-    add_check "backend_source_file" "fail" "Missing ${BACKEND_SOURCE#$REPO_ROOT/}"
+    add_check "backend_source_file" "fail" "Missing ${BACKEND_SOURCE#$REPO_ROOT/} — run: cp ${BACKEND_SOURCE#$REPO_ROOT/}.example ${BACKEND_SOURCE#$REPO_ROOT/}"
     SOURCE_READY=false
   else
-    add_check "backend_source_file" "warn" "Missing ${BACKEND_SOURCE#$REPO_ROOT/}; local backend is not required for $PROFILE"
+    add_check "backend_source_file" "warn" "Missing ${BACKEND_SOURCE#$REPO_ROOT/}; local backend is not required for $PROFILE — run: cp ${BACKEND_SOURCE#$REPO_ROOT/}.example ${BACKEND_SOURCE#$REPO_ROOT/} when ready"
   fi
 fi
 
 if [ -f "$FRONTEND_SOURCE" ]; then
   add_check "frontend_source_file" "pass" "${FRONTEND_SOURCE#$REPO_ROOT/}"
 else
-  add_check "frontend_source_file" "fail" "Missing ${FRONTEND_SOURCE#$REPO_ROOT/}"
+  add_check "frontend_source_file" "fail" "Missing ${FRONTEND_SOURCE#$REPO_ROOT/} — run: cp ${FRONTEND_SOURCE#$REPO_ROOT/}.example ${FRONTEND_SOURCE#$REPO_ROOT/}"
   SOURCE_READY=false
 fi
 


### PR DESCRIPTION
# Description

Improved developer onboarding experience by making environment setup failures actionable. 

Previously, when running `./bin/hushh doctor`, the script would report missing `.env` files as a `FAIL` without providing the next step. This created friction for new contributors who had to manually search the codebase for template files. This PR updates the doctor logic to print the exact `cp` (copy) command needed to hydrate the environment from bundled `.example` templates.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- World-model domain summary effects:
  - [x] None (Internal CLI tooling only)

- Mobile parity impacts:
  - [x] None

- Docs updated (exact files):
  - [x] None (Self-documenting CLI output improved)

- Verification commands executed:
  - [x] `./bin/hushh doctor --mode local`
  - [x] `bash scripts/env/doctor.sh` (unit verification)

## 🛑 Tri-Flow Architecture Check

- [x] **Not Applicable**: This is a root-level developer utility fix and does not affect the runtime protocol layers.

## 🧪 Testing

- [x] Tested on Web (Verified via Git Bash on Windows to ensure path compatibility)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

<img width="1344" height="734" alt="image" src="https://github.com/user-attachments/assets/18f1ecb9-db95-4f28-8ea9-af5e98821e6b" />
<img width="1307" height="324" alt="image" src="https://github.com/user-attachments/assets/34b87b1b-7a9a-4b85-9b35-8a33b6acf62f" />


## 🛡️ Privacy & Consent

- [x] Does this change access user data? No.
- [ ] If yes, have you implemented `checkConsentToken()`?

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed