### PR TITLE
Fix One Email KYC recipient identity resolution

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_email_kyc_service.py
+++ b/consent-protocol/hushh_mcp/services/one_email_kyc_service.py
@@ -338,6 +338,10 @@ def _extract_addresses(*values: str | None) -> list[str]:
     return addresses
 
 
+def _without_addresses(values: list[str], excluded: set[str]) -> list[str]:
+    return [value for value in values if value not in excluded]
+
+
 def _extract_name(value: str | None) -> str | None:
     parsed = email.utils.getaddresses([value or ""])
     if not parsed:
@@ -863,12 +867,29 @@ class OneEmailKycService:
             )
             if item != mailbox
         ]
+        recipient_participants = _without_addresses(
+            _extract_addresses(headers.get("to"), headers.get("cc"), headers.get("reply-to")),
+            {mailbox},
+        )
 
         if sender_email == mailbox:
             return {"handled": False, "reason": "self_sent_message", "message_id": gmail_message_id}
 
         is_kyc = self._looks_like_kyc(subject=subject, body=body_text)
-        user_match = self._match_verified_user(participants)
+        recipient_user_match = self._match_verified_user(recipient_participants)
+        if recipient_user_match.get("user_id") or recipient_user_match.get("error_code") in (
+            "ambiguous_identity_resolution",
+            "ambiguous_user_match",
+        ):
+            user_match = {
+                **recipient_user_match,
+                "matched_from": "recipients",
+            }
+        else:
+            user_match = {
+                **self._match_verified_user(participants),
+                "matched_from": "participants",
+            }
         common = {
             "workflow_id": uuid.uuid4().hex,
             "user_id": user_match.get("user_id"),
@@ -890,6 +911,8 @@ class OneEmailKycService:
                 "one_agent_id": _ONE_AGENT_ID,
                 "nav_agent_id": _NAV_AGENT_ID,
                 "kyc_agent_id": _KYC_AGENT_ID,
+                "identity_match_source": user_match.get("matched_from"),
+                "identity_matched_by": user_match.get("matched_by"),
             },
         }
 

--- a/consent-protocol/tests/services/test_one_email_kyc_service.py
+++ b/consent-protocol/tests/services/test_one_email_kyc_service.py
@@ -93,6 +93,7 @@ def _message(
     body: str,
     sender: str = "broker@example.com",
     cc: str = "User <verified@example.com>",
+    subject: str = "Broker API KYC questionnaire",
 ) -> dict:
     return {
         "id": "gmail_msg_1",
@@ -103,7 +104,7 @@ def _message(
                 {"name": "From", "value": f"Broker Ops <{sender}>"},
                 {"name": "To", "value": "one@hushh.ai"},
                 {"name": "Cc", "value": cc},
-                {"name": "Subject", "value": "Broker API KYC questionnaire"},
+                {"name": "Subject", "value": subject},
                 {"name": "Message-ID", "value": "<m1@example.com>"},
             ],
             "mimeType": "multipart/mixed",
@@ -135,11 +136,13 @@ class _FakeDb:
         user_id: str | None = "user_123",
         connector: bool = True,
         alias_rows: list[dict] | None = None,
+        identity_rows: list[dict] | None = None,
     ) -> None:
         self.user_id = user_id
         self.workflows: list[dict] = []
         self.connectors: list[dict] = []
         self.alias_rows = alias_rows or []
+        self.identity_rows = identity_rows
         if user_id and connector:
             self.connectors.append(
                 {
@@ -162,6 +165,10 @@ class _FakeDb:
         normalized = " ".join(sql.lower().split())
         if "from actor_identity_cache" in normalized:
             emails = set(params.get("emails") or [])
+            if self.identity_rows is not None:
+                return SimpleNamespace(
+                    data=[row for row in self.identity_rows if row.get("email") in emails]
+                )
             if not self.user_id or "verified@example.com" not in emails:
                 return SimpleNamespace(data=[])
             return SimpleNamespace(
@@ -565,6 +572,45 @@ async def test_process_message_matches_verified_email_alias_without_relay_infere
     assert result["workflow"]["user_id"] == "user_123"
     assert result["workflow"]["status"] == "needs_scope"
     assert result["workflow"]["consent_request_id"].startswith("okyc_")
+    assert consent_db.events
+
+
+@pytest.mark.asyncio
+async def test_process_message_prefers_verified_recipient_identity_over_sender_identity():
+    db = _FakeDb(
+        user_id="relay_user",
+        identity_rows=[
+            {
+                "user_id": "gmail_user",
+                "email": "kushaltrivedi1711@gmail.com",
+                "email_verified": True,
+            },
+            {
+                "user_id": "relay_user",
+                "email": "jd77v9k4nx@privaterelay.appleid.com",
+                "email_verified": True,
+            },
+        ],
+    )
+    consent_db = _FakeConsentDb()
+    service = _service(db, consent_db)
+
+    result = await service._process_message(
+        _message(
+            sender="kushaltrivedi1711@gmail.com",
+            cc="Kushal Relay <jd77v9k4nx@privaterelay.appleid.com>",
+            subject="KYC check",
+            body="Hey One, can you draft an email that has all my financial information",
+        ),
+        history_id="101relay",
+    )
+
+    workflow = result["workflow"]
+    assert workflow["user_id"] == "relay_user"
+    assert workflow["status"] == "needs_scope"
+    assert workflow["metadata"]["identity_match_source"] == "recipients"
+    assert workflow["metadata"]["identity_matched_by"] == "actor_identity_cache"
+    assert workflow["consent_request_id"].startswith("okyc_")
     assert consent_db.events
 
 

--- a/docs/reference/architecture/api-contracts.md
+++ b/docs/reference/architecture/api-contracts.md
@@ -113,6 +113,13 @@ Pub/Sub OIDC or the One maintenance token, not user Firebase auth. Strict
 client-side ZK means the backend never decrypts consent exports or persists
 review draft plaintext.
 
+Inbound user resolution uses exact verified email evidence. The resolver checks
+verified `To`, `Cc`, and `Reply-To` recipients before falling back to all
+participants, so a broker or alternate sender account does not override the
+vault owner explicitly copied on the request. Apple private relay addresses are
+not inferred to original emails; original addresses must be verified as aliases
+before they can resolve intake.
+
 | Method | Path | Auth | Description |
 | ------ | ---- | ---- | ----------- |
 | POST | `/api/one/email/webhook` | Pub/Sub OIDC | Receive Gmail Pub/Sub notifications for the delegated One mailbox |


### PR DESCRIPTION
## Summary
- prefer verified To/Cc/Reply-To recipients when resolving inbound One Email KYC users
- keep Apple private relay and original email mappings exact; no relay-to-original inference
- add regression coverage for Gmail sender + verified private relay recipient and update API contract docs

## Verification
- cd consent-protocol && uv run pytest tests/services/test_one_email_kyc_service.py -q
- ./bin/hushh docs verify
- git diff --check
- npm_config_cache="$PWD/tmp/npm-cache" NPM_CONFIG_CACHE="$PWD/tmp/npm-cache" ./bin/hushh codex pre-pr
- bash scripts/ci/check-dco-signoff.sh origin/main HEAD

## UAT note
- Current UAT blocked row 4505fd823ab84f21a991d6fe5721b6f7 is expected to remain diagnostic; retest by sending a fresh email after deploy so Gmail emits a new message id.
