### PR TITLE
Improve One Email KYC multi-scope replies

### DIFF
--- a/consent-protocol/api/routes/one/email.py
+++ b/consent-protocol/api/routes/one/email.py
@@ -40,6 +40,10 @@ class ApprovedReplyRequest(WorkflowUserRequest):
     pkm_writeback_artifact_hash: str = Field(pattern="^[a-f0-9]{64}$")
 
 
+class ScopeSelectionRequest(WorkflowUserRequest):
+    selected_scopes: list[str] = Field(min_length=1, max_length=8)
+
+
 class WritebackCompleteRequest(WorkflowUserRequest):
     artifact_hash: str = Field(pattern="^[a-f0-9]{64}$")
     status: str = Field(default="succeeded", pattern="^(succeeded|failed)$")
@@ -259,6 +263,28 @@ async def one_kyc_refresh_workflow(
         raise _to_http_exception(exc, operation="refresh_workflow") from exc
 
 
+@router.post("/kyc/workflows/{workflow_id}/scope-selection")
+async def one_kyc_select_scopes(
+    workflow_id: str,
+    payload: ScopeSelectionRequest,
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    _verified_vault_user_id(token_data, payload.user_id)
+    try:
+        return await _service().select_scopes(
+            user_id=payload.user_id,
+            workflow_id=workflow_id,
+            selected_scopes=payload.selected_scopes,
+        )
+    except Exception as exc:
+        logger.exception(
+            "one.kyc.scope_selection_failed user_id=%s workflow_id=%s",
+            payload.user_id,
+            workflow_id,
+        )
+        raise _to_http_exception(exc, operation="scope_selection") from exc
+
+
 @router.post("/kyc/workflows/{workflow_id}/approve-draft")
 async def one_kyc_approve_draft(
     workflow_id: str,
@@ -354,6 +380,27 @@ async def one_kyc_get_workflow_consent_export(
             workflow_id,
         )
         raise _to_http_exception(exc, operation="workflow_consent_export") from exc
+
+
+@router.get("/kyc/workflows/{workflow_id}/consent-exports")
+async def one_kyc_get_workflow_consent_exports(
+    workflow_id: str,
+    user_id: str,
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    _verified_vault_user_id(token_data, user_id)
+    try:
+        return await _service().get_workflow_consent_exports(
+            user_id=user_id,
+            workflow_id=workflow_id,
+        )
+    except Exception as exc:
+        logger.exception(
+            "one.kyc.workflow_consent_exports_failed user_id=%s workflow_id=%s",
+            user_id,
+            workflow_id,
+        )
+        raise _to_http_exception(exc, operation="workflow_consent_exports") from exc
 
 
 @router.post("/kyc/workflows/{workflow_id}/writeback-complete")

--- a/consent-protocol/docs/reference/agent-development.md
+++ b/consent-protocol/docs/reference/agent-development.md
@@ -415,10 +415,12 @@ The broker/KYC email lane is One-led, not Kai-owned:
 - `one@hushh.ai` is the Workspace user mailbox.
 - `POST /api/one/email/webhook` receives Gmail Pub/Sub notifications.
 - `POST /api/one/email/watch/renew` renews the mailbox watch.
-- workflow state lives in `one_kyc_workflows` and stores metadata, hashes, send status, and encrypted PKM writeback receipts; `draft_body` is legacy and must stay null/redacted in strict client-side ZK mode.
-- One creates a scoped `agent_kyc` consent request with the user's registered public client connector metadata.
-- `/one/kyc` requires vault unlock so the frontend can own the connector private key, decrypt approved exports locally, build review drafts locally, approve send, or reject.
-- outbound Gmail send is blocked until `draft_status=ready`, `status=waiting_on_user`, and the vault owner approves the final body; the backend handles that body transiently only for Gmail send.
+- workflow state lives in `one_kyc_workflows` and stores metadata, hashes, send status, Gmail thread verification, and encrypted PKM writeback receipts; `draft_body` is legacy and must stay null/redacted in strict client-side ZK mode.
+- One performs text-only request detection for identity/KYC and financial disclosure signals, stores candidate scopes only, and waits for the vault owner to confirm or narrow scopes in `/one/kyc`.
+- One creates one `agent_kyc` consent request per selected scope with a shared bundle id and the user's registered public client connector metadata.
+- `/one/kyc` requires vault unlock so the frontend can own the connector private key, decrypt approved exports locally, build deterministic review drafts locally, approve send, or reject.
+- outbound Gmail send is blocked until every selected scope is granted/current, `draft_status=ready`, `status=waiting_on_user`, and the vault owner approves the final body; the backend handles that body transiently only for Gmail reply-all send.
+- if a selected scope is denied, One does not send an external counterparty reply and surfaces an internal-only explanation to the user.
 
 Do not store raw email bodies, raw vault contents, broad decrypted PKM, tokens, or chain-of-thought in this lane.
 

--- a/consent-protocol/hushh_mcp/services/one_email_kyc_service.py
+++ b/consent-protocol/hushh_mcp/services/one_email_kyc_service.py
@@ -50,7 +50,21 @@ _GMAIL_WATCH_URL = "https://gmail.googleapis.com/gmail/v1/users/me/watch"
 _DEFAULT_ONE_EMAIL_ADDRESS = "one@hushh.ai"
 _ONE_EMAIL_DISPLAY_NAME = "One"
 _DEFAULT_KYC_SCOPE = "attr.identity.*"
+_IDENTITY_SCOPE = _DEFAULT_KYC_SCOPE
+_FINANCIAL_FULL_SCOPE = "attr.financial.*"
+_FINANCIAL_PORTFOLIO_SCOPE = "attr.financial.portfolio.*"
+_FINANCIAL_PROFILE_SCOPE = "attr.financial.profile.*"
+_FINANCIAL_DOCUMENTS_SCOPE = "attr.financial.documents.*"
 _ALLOWED_KYC_DATA_SCOPES = frozenset({_DEFAULT_KYC_SCOPE})
+_ALLOWED_ONE_EMAIL_DATA_SCOPES = frozenset(
+    {
+        _IDENTITY_SCOPE,
+        _FINANCIAL_FULL_SCOPE,
+        _FINANCIAL_PORTFOLIO_SCOPE,
+        _FINANCIAL_PROFILE_SCOPE,
+        _FINANCIAL_DOCUMENTS_SCOPE,
+    }
+)
 _CONNECTOR_WRAPPING_ALG = "X25519-AES256-GCM"
 _ONE_AGENT_ID = "agent_one"
 _NAV_AGENT_ID = "agent_nav"
@@ -221,6 +235,44 @@ def _validate_kyc_data_scope(scope: str) -> str:
     return normalized
 
 
+def _validate_one_email_data_scope(scope: str) -> str:
+    normalized = _clean_text(scope)
+    if normalized not in _ALLOWED_ONE_EMAIL_DATA_SCOPES:
+        raise OneEmailKycError(
+            "One email requested scope is not approved for this lane.",
+            status_code=400,
+            code="ONE_KYC_SCOPE_NOT_ALLOWED",
+            payload={
+                "scope": normalized,
+                "allowed_scopes": sorted(_ALLOWED_ONE_EMAIL_DATA_SCOPES),
+            },
+        )
+    return normalized
+
+
+def _scope_description(scope: str) -> str:
+    if scope == _IDENTITY_SCOPE:
+        return "One needs approval to retrieve scoped identity data for this request."
+    if scope == _FINANCIAL_FULL_SCOPE:
+        return "One needs approval to retrieve scoped financial data for this request."
+    if scope == _FINANCIAL_PORTFOLIO_SCOPE:
+        return "One needs approval to retrieve scoped portfolio data for this request."
+    if scope == _FINANCIAL_PROFILE_SCOPE:
+        return "One needs approval to retrieve scoped financial profile data for this request."
+    if scope == _FINANCIAL_DOCUMENTS_SCOPE:
+        return "One needs approval to retrieve scoped financial document metadata for this request."
+    return f"One needs approval to retrieve {scope} for this request."
+
+
+def _dedupe(values: Iterable[str]) -> list[str]:
+    result: list[str] = []
+    for value in values:
+        cleaned = _clean_text(value)
+        if cleaned and cleaned not in result:
+            result.append(cleaned)
+    return result
+
+
 def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
 
@@ -244,10 +296,27 @@ def _kyc_consent_request_id(workflow_id: str) -> str:
     return f"{_KYC_REQUEST_ID_PREFIX}{_clean_text(workflow_id)[:suffix_limit]}"
 
 
+def _kyc_scope_consent_request_id(workflow_id: str, index: int) -> str:
+    suffix = str(max(1, int(index)))
+    prefix = f"{_KYC_REQUEST_ID_PREFIX}{suffix}_"
+    suffix_limit = _CONSENT_REQUEST_ID_MAX_LENGTH - len(prefix)
+    return f"{prefix}{_clean_text(workflow_id)[:suffix_limit]}"
+
+
+def _kyc_consent_bundle_id(workflow_id: str) -> str:
+    return f"okycb_{_clean_text(workflow_id)[:26]}"
+
+
 def _kyc_consent_request_url(consent_request_id: str | None) -> str | None:
     if not consent_request_id:
         return None
     return build_consent_request_url(request_id=consent_request_id, view="incoming")
+
+
+def _kyc_consent_bundle_url(bundle_id: str | None) -> str | None:
+    if not bundle_id:
+        return None
+    return build_consent_request_url(bundle_id=bundle_id, view="incoming")
 
 
 def _public_key_fingerprint(public_key: str) -> str:
@@ -378,6 +447,100 @@ def _message_text(message: dict[str, Any]) -> str:
         elif mime_type == "text/html":
             html_parts.append(_strip_html(data))
     return "\n".join(plain or html_parts)
+
+
+def _has_attachments(message: dict[str, Any]) -> bool:
+    payload = message.get("payload") if isinstance(message.get("payload"), dict) else {}
+    for part in _iter_payload_parts(payload):
+        filename = _clean_text(part.get("filename"))
+        body = part.get("body") if isinstance(part.get("body"), dict) else {}
+        if filename or _clean_text(body.get("attachmentId")):
+            return True
+    return False
+
+
+def _scope_candidate(
+    *,
+    scope: str,
+    domain: str,
+    label: str,
+    description: str,
+    reason: str,
+    recommended: bool = True,
+    sensitivity: str = "standard",
+) -> dict[str, Any]:
+    return {
+        "scope": scope,
+        "domain": domain,
+        "label": label,
+        "description": description,
+        "reason": reason,
+        "recommended": recommended,
+        "sensitivity": sensitivity,
+    }
+
+
+def _dedupe_scope_candidates(candidates: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[str] = set()
+    result: list[dict[str, Any]] = []
+    for candidate in candidates:
+        scope = _clean_text(candidate.get("scope"))
+        if not scope or scope in seen:
+            continue
+        seen.add(scope)
+        result.append(candidate)
+    return result
+
+
+def _workflow_consent_requests(workflow: dict[str, Any]) -> list[dict[str, str]]:
+    metadata = workflow.get("metadata", {})
+    raw_requests = metadata.get("consent_requests") if isinstance(metadata, dict) else None
+    requests: list[dict[str, str]] = []
+    if isinstance(raw_requests, list):
+        for item in raw_requests:
+            if not isinstance(item, dict):
+                continue
+            request_id = _clean_text(item.get("request_id"))
+            scope = _clean_text(item.get("scope"))
+            if request_id and scope:
+                requests.append({"request_id": request_id, "scope": scope})
+    if requests:
+        return requests
+    request_id = _clean_text(workflow.get("consent_request_id"))
+    scope = _clean_text(workflow.get("requested_scope"))
+    if request_id and scope:
+        return [{"request_id": request_id, "scope": scope}]
+    return []
+
+
+def _workflow_selected_scopes(workflow: dict[str, Any]) -> list[str]:
+    metadata = workflow.get("metadata", {})
+    raw = metadata.get("selected_scopes") if isinstance(metadata, dict) else None
+    if not isinstance(raw, list):
+        raw = metadata.get("requested_scopes") if isinstance(metadata, dict) else None
+    values = [str(item) for item in raw] if isinstance(raw, list) else []
+    if not values and workflow.get("consent_request_id"):
+        values = [_clean_text(workflow.get("requested_scope"))]
+    return [_validate_one_email_data_scope(scope) for scope in _dedupe(values)]
+
+
+def _scope_requires_more_data(instructions: str) -> bool:
+    haystack = instructions.lower()
+    indicators = (
+        "financial",
+        "finance",
+        "portfolio",
+        "holdings",
+        "net worth",
+        "statement",
+        "documents",
+        "identity",
+        "date of birth",
+        "address",
+        "tax",
+        "phone",
+    )
+    return any(item in haystack for item in indicators)
 
 
 def _metadata_from_row(row: dict[str, Any]) -> dict[str, Any]:
@@ -774,6 +937,17 @@ class OneEmailKycService:
             if existing.get("status") == "needs_scope" and (
                 not existing.get("consent_request_id") or has_stale_consent_url
             ):
+                existing_metadata = existing.get("metadata", {})
+                if (
+                    isinstance(existing_metadata, dict)
+                    and existing_metadata.get("scope_selection_required")
+                    and not existing_metadata.get("selected_scopes")
+                ):
+                    return {
+                        "handled": True,
+                        "reason": "scope_selection_pending",
+                        "workflow": existing,
+                    }
                 workflow = await self._ensure_consent_request(existing)
                 return {
                     "handled": True,
@@ -876,6 +1050,10 @@ class OneEmailKycService:
             return {"handled": False, "reason": "self_sent_message", "message_id": gmail_message_id}
 
         is_kyc = self._looks_like_kyc(subject=subject, body=body_text)
+        is_financial = self._looks_like_financial_request(subject=subject, body=body_text)
+        scope_candidates = self._detect_scope_candidates(subject=subject, body=body_text)
+        candidate_scopes = [candidate["scope"] for candidate in scope_candidates]
+        has_attachments = _has_attachments(message)
         recipient_user_match = self._match_verified_user(recipient_participants)
         if recipient_user_match.get("user_id") or recipient_user_match.get("error_code") in (
             "ambiguous_identity_resolution",
@@ -906,15 +1084,41 @@ class OneEmailKycService:
             "metadata": {
                 "source": _KYC_REQUEST_SOURCE,
                 "body_sha256": body_hash,
-                "classification": "kyc" if is_kyc else "unsupported",
-                "request_summary": "Broker-style KYC intake email",
+                "classification": (
+                    "kyc_financial"
+                    if is_kyc and is_financial
+                    else "kyc"
+                    if is_kyc
+                    else "financial"
+                    if is_financial
+                    else "unsupported"
+                ),
+                "request_summary": "One text-only disclosure request",
                 "one_agent_id": _ONE_AGENT_ID,
                 "nav_agent_id": _NAV_AGENT_ID,
                 "kyc_agent_id": _KYC_AGENT_ID,
                 "identity_match_source": user_match.get("matched_from"),
                 "identity_matched_by": user_match.get("matched_by"),
+                "detected_domains": sorted(
+                    {str(candidate.get("domain")) for candidate in scope_candidates}
+                ),
+                "candidate_scopes": scope_candidates,
+                "scope_selection_required": True,
+                "selected_scopes": [],
+                "text_only_intake_v1": True,
+                "attachments_present": has_attachments,
+                "attachments_note": (
+                    "Attachments were detected but One Email text-only intake does not parse them yet."
+                    if has_attachments
+                    else None
+                ),
             },
         }
+        common["metadata"]["reply_thread"] = self._reply_thread_metadata(
+            headers=headers,
+            sender_email=sender_email,
+            matched_user_emails=user_match.get("matched_emails") or [],
+        )
 
         if not user_match.get("user_id"):
             workflow = self._insert_workflow(
@@ -928,24 +1132,30 @@ class OneEmailKycService:
             )
             return {"handled": True, "workflow": workflow, "blocked": True}
 
-        if not is_kyc:
+        if not (is_kyc or is_financial):
             workflow = self._insert_workflow(
                 **common,
                 status="blocked",
                 required_fields=[],
                 requested_scope=None,
                 last_error_code="unsupported_email_task",
-                last_error_message="One email intake only handles KYC-style requests in this lane.",
+                last_error_message=(
+                    "One email intake only handles KYC, compliance, and financial disclosure "
+                    "requests in this lane."
+                ),
             )
             return {"handled": True, "workflow": workflow, "blocked": True}
 
+        required_fields = self._extract_required_fields(subject=subject, body=body_text)
         connector = self._get_active_client_connector(user_match.get("user_id"))
         if not connector:
             workflow = self._insert_workflow(
                 **common,
                 status="needs_client_connector",
-                required_fields=self._extract_required_fields(subject=subject, body=body_text),
-                requested_scope=self.config.default_kyc_scope,
+                required_fields=required_fields,
+                requested_scope=candidate_scopes[0]
+                if candidate_scopes
+                else self.config.default_kyc_scope,
                 last_error_code="kyc_client_connector_missing",
                 last_error_message=(
                     "Unlock the KYC workspace once so One can register a client-held connector key."
@@ -953,7 +1163,6 @@ class OneEmailKycService:
             )
             return {"handled": True, "workflow": workflow, "blocked": False}
 
-        required_fields = self._extract_required_fields(subject=subject, body=body_text)
         workflow_common = {
             **common,
             "metadata": {
@@ -967,11 +1176,12 @@ class OneEmailKycService:
             **workflow_common,
             status="needs_scope",
             required_fields=required_fields,
-            requested_scope=self.config.default_kyc_scope,
+            requested_scope=candidate_scopes[0]
+            if candidate_scopes
+            else self.config.default_kyc_scope,
             last_error_code=None,
             last_error_message=None,
         )
-        workflow = await self._ensure_consent_request(workflow, connector=connector)
         return {"handled": True, "workflow": workflow, "blocked": False}
 
     def _looks_like_kyc(self, *, subject: str, body: str) -> bool:
@@ -992,6 +1202,106 @@ class OneEmailKycService:
         )
         return any(pattern in haystack for pattern in patterns)
 
+    def _looks_like_financial_request(self, *, subject: str, body: str) -> bool:
+        haystack = f"{subject}\n{body}".lower()
+        patterns = (
+            "financial information",
+            "finance information",
+            "portfolio",
+            "holdings",
+            "account balance",
+            "net worth",
+            "assets",
+            "investment",
+            "brokerage statement",
+            "financial profile",
+            "financial data",
+            "all my financial",
+        )
+        return any(pattern in haystack for pattern in patterns)
+
+    def _detect_scope_candidates(self, *, subject: str, body: str) -> list[dict[str, Any]]:
+        haystack = f"{subject}\n{body}".lower()
+        candidates: list[dict[str, Any]] = []
+        if self._looks_like_kyc(subject=subject, body=body):
+            candidates.append(
+                _scope_candidate(
+                    scope=_IDENTITY_SCOPE,
+                    domain="identity",
+                    label="Identity profile",
+                    description="Name, contact, address, tax, and identity details relevant to KYC.",
+                    reason="The email contains KYC or compliance language.",
+                )
+            )
+        if self._looks_like_financial_request(subject=subject, body=body):
+            if "all my financial" in haystack or "all financial" in haystack:
+                candidates.append(
+                    _scope_candidate(
+                        scope=_FINANCIAL_FULL_SCOPE,
+                        domain="financial",
+                        label="Full financial profile",
+                        description="All approved financial PKM fields available for this user.",
+                        reason="The email asks for all financial information.",
+                        sensitivity="high",
+                    )
+                )
+            else:
+                if any(term in haystack for term in ("portfolio", "holdings", "investment")):
+                    candidates.append(
+                        _scope_candidate(
+                            scope=_FINANCIAL_PORTFOLIO_SCOPE,
+                            domain="financial",
+                            label="Portfolio holdings",
+                            description="Approved portfolio and holdings information.",
+                            reason="The email asks for portfolio or investment information.",
+                            sensitivity="high",
+                        )
+                    )
+                if any(term in haystack for term in ("financial profile", "net worth", "assets")):
+                    candidates.append(
+                        _scope_candidate(
+                            scope=_FINANCIAL_PROFILE_SCOPE,
+                            domain="financial",
+                            label="Financial profile",
+                            description="Approved financial profile fields.",
+                            reason="The email asks for financial profile details.",
+                            sensitivity="high",
+                        )
+                    )
+                if "statement" in haystack or "document" in haystack:
+                    candidates.append(
+                        _scope_candidate(
+                            scope=_FINANCIAL_DOCUMENTS_SCOPE,
+                            domain="financial",
+                            label="Financial documents",
+                            description="Approved financial document metadata.",
+                            reason="The email asks for financial statements or documents.",
+                            sensitivity="high",
+                        )
+                    )
+                if not any(candidate.get("domain") == "financial" for candidate in candidates):
+                    candidates.append(
+                        _scope_candidate(
+                            scope=_FINANCIAL_PORTFOLIO_SCOPE,
+                            domain="financial",
+                            label="Financial overview",
+                            description="Approved portfolio and financial profile summary.",
+                            reason="The email asks for financial information.",
+                            sensitivity="high",
+                        )
+                    )
+        if not candidates:
+            candidates.append(
+                _scope_candidate(
+                    scope=self.config.default_kyc_scope,
+                    domain="identity",
+                    label="Identity profile",
+                    description="Name, contact, address, tax, and identity details relevant to KYC.",
+                    reason="Fallback for KYC-style One email workflow.",
+                )
+            )
+        return _dedupe_scope_candidates(candidates)
+
     def _extract_required_fields(self, *, subject: str, body: str) -> list[str]:
         haystack = f"{subject}\n{body}".lower()
         known_fields = {
@@ -1005,6 +1315,9 @@ class OneEmailKycService:
             "employment": ("employment", "occupation", "employer"),
             "source_of_funds": ("source of funds", "source of wealth"),
             "brokerage_profile": ("brokerage", "broker account", "trading experience"),
+            "financial_profile": ("financial profile", "financial information", "net worth"),
+            "portfolio": ("portfolio", "holdings", "investment holdings"),
+            "financial_documents": ("statement", "statements", "financial documents"),
         }
         fields = [
             field
@@ -1014,6 +1327,44 @@ class OneEmailKycService:
         if not fields:
             fields.append("identity_profile")
         return fields
+
+    def _reply_thread_metadata(
+        self,
+        *,
+        headers: dict[str, str],
+        sender_email: str | None,
+        matched_user_emails: list[str],
+    ) -> dict[str, Any]:
+        mailbox = self.config.mailbox_email
+        reply_to = _extract_addresses(headers.get("reply-to"))
+        original_to = _extract_addresses(headers.get("to"))
+        original_cc = _extract_addresses(headers.get("cc"))
+        excluded = {mailbox, *[email.lower() for email in matched_user_emails if email]}
+        to_addresses = reply_to or ([sender_email] if sender_email else [])
+        cc_candidates = [*([] if reply_to else []), *original_to, *original_cc]
+        if reply_to and sender_email:
+            cc_candidates.append(sender_email)
+        cc_addresses = _dedupe(
+            address
+            for address in cc_candidates
+            if address and address not in excluded and address not in to_addresses
+        )
+        to_addresses = _dedupe(
+            address for address in to_addresses if address and address not in excluded
+        )
+        references = _clean_text(headers.get("references")) or None
+        message_id = _clean_text(headers.get("message-id")) or None
+        return {
+            "reply_to": reply_to,
+            "original_to": original_to,
+            "original_cc": original_cc,
+            "reply_all_to": to_addresses,
+            "reply_all_cc": cc_addresses,
+            "references": references,
+            "original_subject": _clean_text(headers.get("subject")) or None,
+            "original_message_id": message_id,
+            "matched_user_emails": matched_user_emails,
+        }
 
     def _counterparty_label(self, sender_email: str | None, from_header: str | None) -> str:
         name = _extract_name(from_header)
@@ -1035,7 +1386,18 @@ class OneEmailKycService:
         )
         if len(user_ids) == 1:
             matched_by = "actor_verified_email_alias" if alias_rows else "actor_identity_cache"
-            return {"user_id": user_ids[0], "matched_by": matched_by}
+            matched_emails = sorted(
+                {
+                    str(row.get("email_normalized") or row.get("email") or "").strip().lower()
+                    for row in rows
+                    if str(row.get("user_id") or "").strip() == user_ids[0]
+                }
+            )
+            return {
+                "user_id": user_ids[0],
+                "matched_by": matched_by,
+                "matched_emails": [email for email in matched_emails if email],
+            }
         if len(user_ids) > 1:
             return {
                 "user_id": None,
@@ -1047,7 +1409,11 @@ class OneEmailKycService:
 
         firebase_matches = self._find_firebase_users_by_email(unique_emails)
         if len(firebase_matches) == 1:
-            return {"user_id": firebase_matches[0], "matched_by": "firebase_auth"}
+            return {
+                "user_id": firebase_matches[0],
+                "matched_by": "firebase_auth",
+                "matched_emails": unique_emails,
+            }
         if len(firebase_matches) > 1:
             return {
                 "user_id": None,
@@ -1118,27 +1484,32 @@ class OneEmailKycService:
         workflow: dict[str, Any],
         connector: dict[str, Any],
         consent_request_id: str,
+        scope: str,
         required_fields: list[str],
+        bundle_id: str | None = None,
+        bundle_label: str | None = None,
+        bundle_scope_count: int | None = None,
     ) -> None:
+        requested_scope = _validate_one_email_data_scope(scope)
         expires_at = _epoch_ms_now() + 24 * 60 * 60 * 1000
         reason = (
-            f"One needs approval to retrieve scoped identity data for a KYC request from "
+            f"One needs approval to retrieve {requested_scope} for a request from "
             f"{workflow.get('counterparty_label') or 'the broker'}."
         )
         await self.consent_db.insert_event(
             user_id=workflow["user_id"],
             agent_id=_KYC_AGENT_ID,
-            scope=workflow["requested_scope"],
+            scope=requested_scope,
             action="REQUESTED",
             request_id=consent_request_id,
-            scope_description="One KYC needs a scoped identity export to draft the broker reply.",
+            scope_description=_scope_description(requested_scope),
             expires_at=expires_at,
             poll_timeout_at=expires_at,
             metadata={
                 "request_source": _KYC_REQUEST_SOURCE,
                 "requester_actor_type": "developer",
-                "requester_label": "One KYC",
-                "developer_app_display_name": "One KYC",
+                "requester_label": "One",
+                "developer_app_display_name": "One",
                 "requester_entity_id": _KYC_AGENT_ID,
                 "connector_public_key": connector["connector_public_key"],
                 "connector_key_id": connector["connector_key_id"],
@@ -1152,11 +1523,63 @@ class OneEmailKycService:
                 "required_fields": required_fields,
                 "workflow_url": f"{frontend_origin()}/one/kyc?workflowId={workflow['workflow_id']}",
                 "request_url": _kyc_consent_request_url(consent_request_id),
+                "bundle_id": bundle_id,
+                "bundle_label": bundle_label,
+                "bundle_scope_count": bundle_scope_count,
                 "speaker_persona": "one",
                 "delegate_agent_id": "kyc",
                 "consent_reviewer_agent_id": _NAV_AGENT_ID,
             },
         )
+
+    async def _create_scope_consent_requests(
+        self,
+        *,
+        workflow: dict[str, Any],
+        connector: dict[str, Any],
+        selected_scopes: list[str],
+    ) -> dict[str, Any]:
+        scopes = [_validate_one_email_data_scope(scope) for scope in _dedupe(selected_scopes)]
+        if not scopes:
+            raise OneEmailKycError(
+                "Select at least one scope before One can request consent.",
+                status_code=400,
+                code="ONE_KYC_SCOPE_SELECTION_REQUIRED",
+            )
+        bundle_id = _kyc_consent_bundle_id(workflow["workflow_id"])
+        bundle_label = f"One request for {workflow.get('counterparty_label') or 'the counterparty'}"
+        consent_requests: list[dict[str, Any]] = []
+        for index, scope in enumerate(scopes, start=1):
+            request_id = (
+                _kyc_consent_request_id(workflow["workflow_id"])
+                if len(scopes) == 1
+                else _kyc_scope_consent_request_id(workflow["workflow_id"], index)
+            )
+            await self._create_consent_request(
+                workflow={**workflow, "requested_scope": scope},
+                connector=connector,
+                consent_request_id=request_id,
+                scope=scope,
+                required_fields=workflow.get("required_fields") or [],
+                bundle_id=bundle_id,
+                bundle_label=bundle_label,
+                bundle_scope_count=len(scopes),
+            )
+            consent_requests.append(
+                {
+                    "request_id": request_id,
+                    "scope": scope,
+                    "status": "requested",
+                    "request_url": _kyc_consent_request_url(request_id),
+                }
+            )
+        return {
+            "bundle_id": bundle_id,
+            "bundle_label": bundle_label,
+            "bundle_url": _kyc_consent_bundle_url(bundle_id),
+            "consent_requests": consent_requests,
+            "selected_scopes": scopes,
+        }
 
     async def _ensure_consent_request(
         self,
@@ -1193,27 +1616,140 @@ class OneEmailKycService:
                 },
             )
 
-        consent_request_id = _kyc_consent_request_id(workflow["workflow_id"])
-        await self._create_consent_request(
+        selected_scopes = _workflow_selected_scopes(workflow)
+        metadata = workflow.get("metadata", {})
+        if (
+            not selected_scopes
+            and isinstance(metadata, dict)
+            and metadata.get("scope_selection_required")
+        ):
+            return self._update_workflow(
+                workflow["workflow_id"],
+                status="needs_scope"
+                if workflow.get("status") == "needs_client_connector"
+                else workflow.get("status"),
+                last_error_code=None,
+                last_error_message=None,
+                metadata={
+                    **metadata,
+                    "client_connector_key_id": connector["connector_key_id"],
+                    "client_connector_fingerprint": connector.get("public_key_fingerprint"),
+                    "strict_client_zk": True,
+                    "scope_selection_required": True,
+                },
+            )
+
+        selected_scopes = selected_scopes or [
+            _validate_one_email_data_scope(
+                workflow.get("requested_scope") or self.config.default_kyc_scope
+            )
+        ]
+        bundle = await self._create_scope_consent_requests(
             workflow=workflow,
             connector=connector,
-            consent_request_id=consent_request_id,
-            required_fields=workflow.get("required_fields") or [],
+            selected_scopes=selected_scopes,
         )
+        consent_request_id = bundle["consent_requests"][0]["request_id"]
         return self._update_workflow(
             workflow["workflow_id"],
             status="needs_scope"
             if workflow.get("status") == "needs_client_connector"
             else workflow.get("status"),
             consent_request_id=consent_request_id,
+            requested_scope=bundle["selected_scopes"][0],
             metadata={
                 **workflow.get("metadata", {}),
-                "consent_request_url": _kyc_consent_request_url(consent_request_id),
+                "consent_request_url": bundle["bundle_url"]
+                or _kyc_consent_request_url(consent_request_id),
+                "consent_bundle_id": bundle["bundle_id"],
+                "consent_bundle_label": bundle["bundle_label"],
+                "consent_requests": bundle["consent_requests"],
+                "client_connector_key_id": connector["connector_key_id"],
+                "client_connector_fingerprint": connector.get("public_key_fingerprint"),
+                "strict_client_zk": True,
+                "scope_selection_required": False,
+                "selected_scopes": bundle["selected_scopes"],
+                "requested_scopes": bundle["selected_scopes"],
+            },
+        )
+
+    async def select_scopes(
+        self,
+        *,
+        user_id: str,
+        workflow_id: str,
+        selected_scopes: list[str],
+    ) -> dict[str, Any]:
+        workflow = await self.get_workflow(user_id=user_id, workflow_id=workflow_id)
+        if workflow.get("status") not in {"needs_scope", "needs_client_connector"}:
+            raise OneEmailKycError(
+                "Scopes can only be selected before consent is resolved.",
+                status_code=409,
+                code="ONE_KYC_SCOPE_SELECTION_NOT_ALLOWED",
+            )
+        metadata = workflow.get("metadata", {})
+        candidate_scopes = (
+            [
+                _clean_text(candidate.get("scope"))
+                for candidate in metadata.get("candidate_scopes", [])
+                if isinstance(candidate, dict)
+            ]
+            if isinstance(metadata, dict)
+            else []
+        )
+        selected = [_validate_one_email_data_scope(scope) for scope in _dedupe(selected_scopes)]
+        if not selected:
+            raise OneEmailKycError(
+                "Select at least one scope for this One request.",
+                status_code=400,
+                code="ONE_KYC_SCOPE_SELECTION_REQUIRED",
+            )
+        if candidate_scopes:
+            invalid = [scope for scope in selected if scope not in candidate_scopes]
+            if invalid:
+                raise OneEmailKycError(
+                    "Selected scopes must come from One's detected candidate scopes.",
+                    status_code=400,
+                    code="ONE_KYC_SCOPE_SELECTION_INVALID",
+                    payload={"invalid_scopes": invalid, "candidate_scopes": candidate_scopes},
+                )
+        existing = _workflow_consent_requests(workflow)
+        if existing and _workflow_selected_scopes(workflow) == selected:
+            return workflow
+        connector = self._get_active_client_connector(user_id)
+        if not connector:
+            return self._update_workflow(
+                workflow_id,
+                status="needs_client_connector",
+                last_error_code="kyc_client_connector_missing",
+                last_error_message=(
+                    "Unlock the KYC workspace once so One can register a client-held connector key."
+                ),
+                metadata={
+                    **metadata,
+                    "selected_scopes": selected,
+                    "requested_scopes": selected,
+                    "scope_selection_required": False,
+                    "client_connector_required": True,
+                },
+            )
+        prepared = self._update_workflow(
+            workflow_id,
+            status="needs_scope",
+            requested_scope=selected[0],
+            last_error_code=None,
+            last_error_message=None,
+            metadata={
+                **metadata,
+                "selected_scopes": selected,
+                "requested_scopes": selected,
+                "scope_selection_required": False,
                 "client_connector_key_id": connector["connector_key_id"],
                 "client_connector_fingerprint": connector.get("public_key_fingerprint"),
                 "strict_client_zk": True,
             },
         )
+        return await self._ensure_consent_request(prepared, connector=connector)
 
     async def list_workflows(self, *, user_id: str) -> dict[str, Any]:
         sql = """
@@ -1243,17 +1779,32 @@ class OneEmailKycService:
         workflow = await self.get_workflow(user_id=user_id, workflow_id=workflow_id)
         if workflow["status"] == "needs_client_connector":
             workflow = await self._ensure_consent_request(workflow)
-        if workflow["status"] not in {"needs_scope", "needs_documents"} or not workflow.get(
-            "consent_request_id"
-        ):
+        if workflow["status"] not in {"needs_scope", "needs_documents"}:
             return workflow
-        status = await self.consent_db.get_request_status(user_id, workflow["consent_request_id"])
+        consent_requests = _workflow_consent_requests(workflow)
+        metadata = workflow.get("metadata", {})
+        if not consent_requests:
+            if isinstance(metadata, dict) and metadata.get("scope_selection_required"):
+                return workflow
+            return workflow
+        if len(consent_requests) > 1 or (
+            isinstance(metadata, dict) and metadata.get("consent_requests")
+        ):
+            return await self._refresh_selected_scope_workflow(
+                workflow=workflow,
+                consent_requests=consent_requests,
+            )
+
+        status = await self.consent_db.get_request_status(
+            user_id, consent_requests[0]["request_id"]
+        )
         action = _clean_text(status.get("action") if status else None).upper()
         if action == "CONSENT_GRANTED":
             token_id = _clean_text(status.get("token_id") if status else None)
             export_package = await self._get_validated_consent_export(
                 workflow=workflow,
                 consent_token=token_id,
+                expected_scope=consent_requests[0]["scope"],
             )
             if not export_package:
                 return self._update_workflow(
@@ -1289,6 +1840,98 @@ class OneEmailKycService:
             )
         return workflow
 
+    async def _refresh_selected_scope_workflow(
+        self,
+        *,
+        workflow: dict[str, Any],
+        consent_requests: list[dict[str, str]],
+    ) -> dict[str, Any]:
+        statuses: list[dict[str, Any]] = []
+        exports: list[dict[str, Any]] = []
+        denied: list[dict[str, str]] = []
+        pending: list[str] = []
+        for request in consent_requests:
+            request_id = request["request_id"]
+            scope = _validate_one_email_data_scope(request["scope"])
+            status = await self.consent_db.get_request_status(workflow["user_id"], request_id)
+            action = _clean_text(status.get("action") if status else None).upper()
+            statuses.append(
+                {"request_id": request_id, "scope": scope, "action": action or "PENDING"}
+            )
+            if action in {"CONSENT_DENIED", "DENIED", "REVOKED"}:
+                denied.append({"request_id": request_id, "scope": scope})
+                continue
+            if action != "CONSENT_GRANTED":
+                pending.append(request_id)
+                continue
+            token_id = _clean_text(status.get("token_id") if status else None)
+            export_package = await self._get_validated_consent_export(
+                workflow=workflow,
+                consent_token=token_id,
+                expected_scope=scope,
+            )
+            if not export_package:
+                pending.append(request_id)
+                continue
+            exports.append(
+                {
+                    "request_id": request_id,
+                    "scope": scope,
+                    "metadata": self._public_export_metadata(export_package),
+                }
+            )
+        metadata = {
+            **_redact_sensitive_workflow_metadata(workflow.get("metadata", {})),
+            "consent_statuses": statuses,
+        }
+        if denied:
+            return self._update_workflow(
+                workflow["workflow_id"],
+                status="blocked",
+                draft_status="not_ready",
+                last_error_code="consent_not_granted",
+                last_error_message=(
+                    "One cannot reply externally because at least one selected scope was denied."
+                ),
+                metadata={
+                    **metadata,
+                    "denied_scopes": [item["scope"] for item in denied],
+                    "external_reply_blocked": True,
+                    "internal_user_explanation": (
+                        "The selected disclosure was denied, so One did not send an external reply."
+                    ),
+                },
+            )
+        if pending or len(exports) != len(consent_requests):
+            return self._update_workflow(
+                workflow["workflow_id"],
+                last_error_code="scoped_export_pending" if exports else None,
+                last_error_message=(
+                    "One is waiting for all selected scoped encrypted exports." if exports else None
+                ),
+                metadata=metadata,
+            )
+        export_metadata = [
+            item["metadata"] | {"request_id": item["request_id"]} for item in exports
+        ]
+        return self._update_workflow(
+            workflow["workflow_id"],
+            status="waiting_on_user",
+            draft_status="ready",
+            draft_subject=self._reply_subject(workflow.get("subject")),
+            draft_body=None,
+            last_error_code=None,
+            last_error_message=None,
+            metadata={
+                **metadata,
+                "consent_exports": export_metadata,
+                "consent_export": export_metadata[0] if export_metadata else None,
+                "client_draft_required": True,
+                "draft_revision": int((workflow.get("metadata") or {}).get("draft_revision") or 0)
+                + 1,
+            },
+        )
+
     async def get_workflow_consent_export(
         self,
         *,
@@ -1318,9 +1961,11 @@ class OneEmailKycService:
                 code="ONE_KYC_CONSENT_NOT_ACTIVE",
             )
         token_id = _clean_text(status.get("token_id") if status else None)
+        expected_scope = _clean_text(workflow.get("requested_scope"))
         export_package = await self._get_validated_consent_export(
             workflow=workflow,
             consent_token=token_id,
+            expected_scope=expected_scope,
         )
         if not export_package:
             raise OneEmailKycError(
@@ -1331,18 +1976,72 @@ class OneEmailKycService:
         self._validate_send_export_binding(workflow=workflow, export_package=export_package)
         return self._public_encrypted_export(export_package)
 
+    async def get_workflow_consent_exports(
+        self,
+        *,
+        user_id: str,
+        workflow_id: str,
+    ) -> dict[str, Any]:
+        workflow = await self.get_workflow(user_id=user_id, workflow_id=workflow_id)
+        if workflow.get("status") != "waiting_on_user" or workflow.get("draft_status") != "ready":
+            raise OneEmailKycError(
+                "KYC workflow exports are only available for a ready client draft.",
+                status_code=409,
+                code="ONE_KYC_EXPORT_NOT_READY",
+            )
+        exports: list[dict[str, Any]] = []
+        for request in _workflow_consent_requests(workflow):
+            request_id = request["request_id"]
+            scope = _validate_one_email_data_scope(request["scope"])
+            status = await self.consent_db.get_request_status(user_id, request_id)
+            if _clean_text(status.get("action") if status else None).upper() != "CONSENT_GRANTED":
+                raise OneEmailKycError(
+                    "KYC consent is not active enough to load every encrypted export.",
+                    status_code=409,
+                    code="ONE_KYC_CONSENT_NOT_ACTIVE",
+                    payload={"request_id": request_id, "scope": scope},
+                )
+            token_id = _clean_text(status.get("token_id") if status else None)
+            export_package = await self._get_validated_consent_export(
+                workflow=workflow,
+                consent_token=token_id,
+                expected_scope=scope,
+            )
+            if not export_package:
+                raise OneEmailKycError(
+                    "KYC consent export is unavailable.",
+                    status_code=404,
+                    code="ONE_KYC_EXPORT_UNAVAILABLE",
+                    payload={"request_id": request_id, "scope": scope},
+                )
+            self._validate_send_export_binding(
+                workflow=workflow,
+                export_package=export_package,
+                expected_scope=scope,
+            )
+            public_export = self._public_encrypted_export(export_package)
+            public_export["request_id"] = request_id
+            public_export["scope"] = scope
+            exports.append(public_export)
+        return {"status": "success", "exports": exports}
+
     async def _get_validated_consent_export(
         self,
         *,
         workflow: dict[str, Any],
         consent_token: str | None,
+        expected_scope: str | None = None,
     ) -> dict[str, Any] | None:
         if not consent_token:
             return None
         export_package = await self.consent_db.get_consent_export(consent_token)
         if not export_package:
             return None
-        self._validate_consent_export(workflow=workflow, export_package=export_package)
+        self._validate_consent_export(
+            workflow=workflow,
+            export_package=export_package,
+            expected_scope=expected_scope,
+        )
         return export_package
 
     def _public_encrypted_export(self, export_package: dict[str, Any]) -> dict[str, Any]:
@@ -1366,9 +2065,12 @@ class OneEmailKycService:
         *,
         workflow: dict[str, Any],
         export_package: dict[str, Any],
+        expected_scope: str | None = None,
     ) -> None:
-        expected_scope = _validate_kyc_data_scope(_clean_text(workflow.get("requested_scope")))
-        if _clean_text(export_package.get("scope")) != expected_scope:
+        expected = _validate_one_email_data_scope(
+            _clean_text(expected_scope) or _clean_text(workflow.get("requested_scope"))
+        )
+        if _clean_text(export_package.get("scope")) != expected:
             raise OneEmailKycError(
                 "KYC scoped export does not match the requested workflow scope.",
                 status_code=409,
@@ -1436,9 +2138,22 @@ class OneEmailKycService:
         workflow: dict[str, Any],
         export_package: dict[str, Any],
         consent_export_revision: int | None = None,
+        expected_scope: str | None = None,
     ) -> None:
         metadata = workflow.get("metadata", {})
         workflow_export = metadata.get("consent_export") if isinstance(metadata, dict) else None
+        if expected_scope and isinstance(metadata, dict):
+            exports = metadata.get("consent_exports")
+            if isinstance(exports, list):
+                workflow_export = next(
+                    (
+                        item
+                        for item in exports
+                        if isinstance(item, dict)
+                        and _clean_text(item.get("scope")) == _clean_text(expected_scope)
+                    ),
+                    workflow_export,
+                )
         if not isinstance(workflow_export, dict):
             raise OneEmailKycError(
                 "KYC workflow is not bound to the approved export revision.",
@@ -1563,6 +2278,40 @@ class OneEmailKycService:
             return value[:500]
         return f"Re: {value}"[:500]
 
+    def _thread_safe_subject(
+        self,
+        workflow: dict[str, Any],
+        *,
+        approved_subject: str | None,
+    ) -> str:
+        metadata = workflow.get("metadata", {})
+        reply_thread = metadata.get("reply_thread") if isinstance(metadata, dict) else {}
+        original_subject = (
+            _clean_text(reply_thread.get("original_subject"))
+            if isinstance(reply_thread, dict)
+            else ""
+        )
+        return (
+            _truncate(original_subject, 500)
+            or _truncate(approved_subject, 500)
+            or workflow.get("draft_subject")
+            or self._reply_subject(workflow.get("subject"))
+        )
+
+    def _reply_references(self, workflow: dict[str, Any]) -> tuple[str | None, str | None]:
+        metadata = workflow.get("metadata", {})
+        reply_thread = metadata.get("reply_thread") if isinstance(metadata, dict) else {}
+        message_id = _clean_text(workflow.get("rfc_message_id")) or (
+            _clean_text(reply_thread.get("original_message_id"))
+            if isinstance(reply_thread, dict)
+            else ""
+        )
+        raw_references = (
+            _clean_text(reply_thread.get("references")) if isinstance(reply_thread, dict) else ""
+        )
+        references = _dedupe([*(raw_references.split() if raw_references else []), message_id])
+        return message_id or None, " ".join(references) or None
+
     async def approve_draft(self, *, user_id: str, workflow_id: str) -> dict[str, Any]:
         raise OneEmailKycError(
             "KYC draft approval now requires a client-generated approved reply body.",
@@ -1582,6 +2331,13 @@ class OneEmailKycService:
         pkm_writeback_artifact_hash: str | None = None,
     ) -> dict[str, Any]:
         workflow = await self.get_workflow(user_id=user_id, workflow_id=workflow_id)
+        metadata = workflow.get("metadata", {})
+        if isinstance(metadata, dict) and metadata.get("external_reply_blocked"):
+            raise OneEmailKycError(
+                "One cannot send an external reply because the selected disclosure was denied.",
+                status_code=409,
+                code="ONE_KYC_EXTERNAL_REPLY_BLOCKED",
+            )
         if (
             workflow.get("draft_status") == "sent"
             or workflow.get("status") == "waiting_on_counterparty"
@@ -1606,10 +2362,9 @@ class OneEmailKycService:
                 status_code=400,
                 code="ONE_KYC_APPROVED_BODY_TOO_LONG",
             )
-        subject = (
-            _truncate(approved_subject, 500)
-            or workflow.get("draft_subject")
-            or self._reply_subject(workflow.get("subject"))
+        subject = self._thread_safe_subject(
+            workflow,
+            approved_subject=approved_subject,
         )
         writeback_artifact_hash = _truncate(pkm_writeback_artifact_hash, 128)
         if not re.fullmatch(r"[a-f0-9]{64}", writeback_artifact_hash or ""):
@@ -1672,6 +2427,8 @@ class OneEmailKycService:
                 **pending.get("metadata", {}),
                 "send_status": "sent",
                 "sent_message_id": send_result.get("id"),
+                "sent_thread_id": send_result.get("threadId"),
+                "thread_match_status": send_result.get("thread_match_status"),
                 "sent_at": _utcnow().isoformat(),
             },
         )
@@ -1682,37 +2439,44 @@ class OneEmailKycService:
         *,
         consent_export_revision: int | None = None,
     ) -> None:
-        request_id = _clean_text(workflow.get("consent_request_id"))
         user_id = _clean_text(workflow.get("user_id"))
-        if not request_id or not user_id:
+        requests = _workflow_consent_requests(workflow)
+        if not requests or not user_id:
             raise OneEmailKycError(
                 "KYC draft has no active consent request to revalidate.",
                 status_code=409,
                 code="ONE_KYC_CONSENT_REVALIDATION_MISSING",
             )
-        status = await self.consent_db.get_request_status(user_id, request_id)
-        if _clean_text(status.get("action") if status else None).upper() != "CONSENT_GRANTED":
-            raise OneEmailKycError(
-                "KYC consent is not active enough to send this draft.",
-                status_code=409,
-                code="ONE_KYC_CONSENT_NOT_ACTIVE",
+        for request in requests:
+            request_id = request["request_id"]
+            scope = _validate_one_email_data_scope(request["scope"])
+            status = await self.consent_db.get_request_status(user_id, request_id)
+            if _clean_text(status.get("action") if status else None).upper() != "CONSENT_GRANTED":
+                raise OneEmailKycError(
+                    "KYC consent is not active enough to send this draft.",
+                    status_code=409,
+                    code="ONE_KYC_CONSENT_NOT_ACTIVE",
+                    payload={"request_id": request_id, "scope": scope},
+                )
+            token_id = _clean_text(status.get("token_id") if status else None)
+            export_package = await self._get_validated_consent_export(
+                workflow=workflow,
+                consent_token=token_id,
+                expected_scope=scope,
             )
-        token_id = _clean_text(status.get("token_id") if status else None)
-        export_package = await self._get_validated_consent_export(
-            workflow=workflow,
-            consent_token=token_id,
-        )
-        if not export_package:
-            raise OneEmailKycError(
-                "KYC consent export is unavailable, so One cannot send this draft.",
-                status_code=409,
-                code="ONE_KYC_EXPORT_UNAVAILABLE",
+            if not export_package:
+                raise OneEmailKycError(
+                    "KYC consent export is unavailable, so One cannot send this draft.",
+                    status_code=409,
+                    code="ONE_KYC_EXPORT_UNAVAILABLE",
+                    payload={"request_id": request_id, "scope": scope},
+                )
+            self._validate_send_export_binding(
+                workflow=workflow,
+                export_package=export_package,
+                consent_export_revision=consent_export_revision,
+                expected_scope=scope,
             )
-        self._validate_send_export_binding(
-            workflow=workflow,
-            export_package=export_package,
-            consent_export_revision=consent_export_revision,
-        )
 
     async def redraft(
         self,
@@ -1736,6 +2500,45 @@ class OneEmailKycService:
                 status_code=400,
                 code="ONE_KYC_REDRAFT_INSTRUCTIONS_REQUIRED",
             )
+        selected_scopes = _workflow_selected_scopes(workflow)
+        if _scope_requires_more_data(cleaned_instructions):
+            scope_candidates = self._detect_scope_candidates(
+                subject=workflow.get("subject") or "",
+                body=cleaned_instructions,
+            )
+            requested_new_scopes = [
+                candidate["scope"]
+                for candidate in scope_candidates
+                if candidate.get("scope") not in selected_scopes
+            ]
+            if requested_new_scopes:
+                return self._update_workflow(
+                    workflow_id,
+                    status="needs_scope",
+                    draft_status="not_ready",
+                    last_error_code="scope_selection_required",
+                    last_error_message=(
+                        "The redraft asks for data outside the approved scopes. Select additional scopes first."
+                    ),
+                    metadata={
+                        **workflow.get("metadata", {}),
+                        "scope_selection_required": True,
+                        "redraft_requested_scopes": requested_new_scopes,
+                        "candidate_scopes": _dedupe_scope_candidates(
+                            [
+                                *(
+                                    workflow.get("metadata", {}).get("candidate_scopes")
+                                    if isinstance(
+                                        workflow.get("metadata", {}).get("candidate_scopes"), list
+                                    )
+                                    else []
+                                ),
+                                *scope_candidates,
+                            ]
+                        ),
+                        "client_draft_required": True,
+                    },
+                )
         source_value = source if source in {"text", "voice"} else "text"
         metadata = workflow.get("metadata", {})
         revision = int(metadata.get("draft_revision") or 1) + 1
@@ -1887,32 +2690,69 @@ class OneEmailKycService:
         approved_subject: str,
         approved_body: str,
     ) -> dict[str, Any]:
-        recipient = _clean_text(workflow.get("sender_email"))
-        if not recipient:
+        metadata = workflow.get("metadata", {})
+        reply_thread = metadata.get("reply_thread") if isinstance(metadata, dict) else {}
+        to_addresses = reply_thread.get("reply_all_to") if isinstance(reply_thread, dict) else None
+        cc_addresses = reply_thread.get("reply_all_cc") if isinstance(reply_thread, dict) else None
+        recipients = (
+            _dedupe(str(item) for item in to_addresses) if isinstance(to_addresses, list) else []
+        )
+        if not recipients:
+            recipient = _clean_text(workflow.get("sender_email"))
+            if recipient:
+                recipients = [recipient]
+        cc = _dedupe(str(item) for item in cc_addresses) if isinstance(cc_addresses, list) else []
+        if not recipients:
             raise OneEmailKycError(
                 "KYC workflow has no sender email to reply to.",
                 status_code=409,
                 code="ONE_KYC_REPLY_RECIPIENT_MISSING",
             )
         msg = EmailMessage()
-        msg["To"] = recipient
+        msg["To"] = ", ".join(recipients)
+        if cc:
+            msg["Cc"] = ", ".join(cc)
         msg["From"] = f"{_ONE_EMAIL_DISPLAY_NAME} <{self.config.mailbox_email}>"
         msg["Subject"] = approved_subject
-        rfc_message_id = _clean_text(workflow.get("rfc_message_id"))
+        rfc_message_id, references = self._reply_references(workflow)
         if rfc_message_id:
             msg["In-Reply-To"] = rfc_message_id
-            msg["References"] = rfc_message_id
+        if references:
+            msg["References"] = references
         msg.set_content(approved_body)
         encoded = base64.urlsafe_b64encode(msg.as_bytes()).decode("utf-8")
         payload: dict[str, Any] = {"raw": encoded}
         thread_id = _clean_text(workflow.get("gmail_thread_id"))
         if thread_id:
             payload["threadId"] = thread_id
-        return self._post_json_sync(
+        send_result = self._post_json_sync(
             f"{_GMAIL_MESSAGES_URL}/send",
             json_payload=payload,
             scopes=(_GMAIL_SEND_SCOPE,),
         )
+        sent_thread_id = _clean_text(send_result.get("threadId"))
+        sent_id = _clean_text(send_result.get("id"))
+        if sent_id:
+            try:
+                fetched = self._fetch_message(sent_id)
+                sent_thread_id = _clean_text(fetched.get("threadId")) or sent_thread_id
+            except Exception as exc:
+                logger.warning(
+                    "one_email_kyc.sent_thread_verification_failed workflow_id=%s reason=%s",
+                    workflow.get("workflow_id"),
+                    exc,
+                )
+        if thread_id and sent_thread_id:
+            thread_match_status = "matched" if sent_thread_id == thread_id else "mismatched"
+        elif thread_id:
+            thread_match_status = "unknown"
+        else:
+            thread_match_status = "not_applicable"
+        return {
+            **send_result,
+            "threadId": sent_thread_id or send_result.get("threadId"),
+            "thread_match_status": thread_match_status,
+        }
 
     def _get_mailbox_state(self) -> dict[str, Any] | None:
         sql = """
@@ -2068,6 +2908,7 @@ class OneEmailKycService:
         allowed = {
             "status",
             "consent_request_id",
+            "requested_scope",
             "draft_subject",
             "draft_status",
             "send_attempt_id",
@@ -2102,6 +2943,10 @@ class OneEmailKycService:
               consent_request_id = CASE
                 WHEN :set_consent_request_id THEN :consent_request_id
                 ELSE consent_request_id
+              END,
+              requested_scope = CASE
+                WHEN :set_requested_scope THEN :requested_scope
+                ELSE requested_scope
               END,
               draft_subject = CASE
                 WHEN :set_draft_subject THEN :draft_subject
@@ -2206,8 +3051,14 @@ class OneEmailKycService:
             "counterparty_label": row.get("counterparty_label"),
             "required_fields": required_fields,
             "requested_scope": row.get("requested_scope"),
+            "requested_scopes": metadata.get("requested_scopes") or metadata.get("selected_scopes"),
+            "selected_scopes": metadata.get("selected_scopes"),
+            "candidate_scopes": metadata.get("candidate_scopes"),
             "consent_request_id": consent_request_id,
+            "consent_requests": metadata.get("consent_requests"),
+            "consent_bundle_id": metadata.get("consent_bundle_id"),
             "consent_export": metadata.get("consent_export"),
+            "consent_exports": metadata.get("consent_exports"),
             "consent_request_url": (
                 _kyc_consent_request_url(consent_request_id)
                 if _is_legacy_consent_request_url(metadata.get("consent_request_url"))
@@ -2221,6 +3072,8 @@ class OneEmailKycService:
             "send_attempt_id": row.get("send_attempt_id") or metadata.get("send_attempt_id"),
             "send_status": row.get("send_status") or metadata.get("send_status"),
             "sent_message_id": row.get("sent_message_id") or metadata.get("sent_message_id"),
+            "sent_thread_id": metadata.get("sent_thread_id"),
+            "thread_match_status": metadata.get("thread_match_status"),
             "sent_at": _iso(row.get("sent_at")) or metadata.get("sent_at"),
             "client_draft_hash": row.get("client_draft_hash") or metadata.get("client_draft_hash"),
             "approved_send_hash": row.get("approved_send_hash")

--- a/consent-protocol/tests/services/test_one_email_kyc_service.py
+++ b/consent-protocol/tests/services/test_one_email_kyc_service.py
@@ -334,6 +334,14 @@ def _service(db: _FakeDb, consent_db: _FakeConsentDb) -> OneEmailKycService:
     return service
 
 
+async def _select_identity_scope(service: OneEmailKycService, workflow: dict) -> dict:
+    return await service.select_scopes(
+        user_id=workflow["user_id"],
+        workflow_id=workflow["workflow_id"],
+        selected_scopes=["attr.identity.*"],
+    )
+
+
 def test_decode_pubsub_notification_normalizes_numeric_history_id():
     service = _service(_FakeDb(), _FakeConsentDb())
     payload = {
@@ -379,15 +387,21 @@ async def test_process_message_creates_scoped_kyc_consent_without_storing_raw_bo
     workflow = result["workflow"]
     assert workflow["status"] == "needs_scope"
     assert workflow["requested_scope"] == "attr.identity.*"
-    assert workflow["consent_request_id"].startswith("okyc_")
-    assert len(workflow["consent_request_id"]) <= 32
+    assert workflow["consent_request_id"] is None
+    assert workflow["metadata"]["scope_selection_required"] is True
+    assert workflow["metadata"]["candidate_scopes"][0]["scope"] == "attr.identity.*"
     assert workflow["required_fields"] == ["full_name", "date_of_birth", "address"]
+    assert consent_db.events == []
+    assert raw_body_marker not in json.dumps(db.workflows, default=str)
+
+    selected = await _select_identity_scope(service, workflow)
+    assert selected["consent_request_id"].startswith("okyc_")
+    assert len(selected["consent_request_id"]) <= 32
     assert consent_db.events[0]["agent_id"] == "agent_kyc"
     assert consent_db.events[0]["scope"] == "attr.identity.*"
-    assert consent_db.events[0]["request_id"] == workflow["consent_request_id"]
+    assert consent_db.events[0]["request_id"] == selected["consent_request_id"]
     assert consent_db.events[0]["metadata"]["requester_actor_type"] == "developer"
     assert consent_db.events[0]["metadata"]["connector_public_key"] == _CONNECTOR_PUBLIC_B64
-    assert raw_body_marker not in json.dumps(db.workflows, default=str)
 
 
 @pytest.mark.asyncio
@@ -433,7 +447,9 @@ async def test_register_client_connector_repairs_waiting_workflow():
     )
 
     assert refreshed["status"] == "needs_scope"
-    assert refreshed["consent_request_id"].startswith("okyc_")
+    assert refreshed["consent_request_id"] is None
+    selected = await _select_identity_scope(service, refreshed)
+    assert selected["consent_request_id"].startswith("okyc_")
     assert consent_db.events[0]["metadata"]["connector_public_key"] == _CONNECTOR_PUBLIC_B64
     assert consent_db.events[0]["metadata"]["connector_key_id"] == "one-kyc-key"
 
@@ -571,7 +587,9 @@ async def test_process_message_matches_verified_email_alias_without_relay_infere
 
     assert result["workflow"]["user_id"] == "user_123"
     assert result["workflow"]["status"] == "needs_scope"
-    assert result["workflow"]["consent_request_id"].startswith("okyc_")
+    assert result["workflow"]["consent_request_id"] is None
+    selected = await _select_identity_scope(service, result["workflow"])
+    assert selected["consent_request_id"].startswith("okyc_")
     assert consent_db.events
 
 
@@ -610,8 +628,63 @@ async def test_process_message_prefers_verified_recipient_identity_over_sender_i
     assert workflow["status"] == "needs_scope"
     assert workflow["metadata"]["identity_match_source"] == "recipients"
     assert workflow["metadata"]["identity_matched_by"] == "actor_identity_cache"
-    assert workflow["consent_request_id"].startswith("okyc_")
+    assert workflow["consent_request_id"] is None
+    assert "attr.financial.*" in [
+        item["scope"] for item in workflow["metadata"]["candidate_scopes"]
+    ]
+    selected = await service.select_scopes(
+        user_id=workflow["user_id"],
+        workflow_id=workflow["workflow_id"],
+        selected_scopes=["attr.financial.*"],
+    )
+    assert selected["consent_request_id"].startswith("okyc_")
     assert consent_db.events
+
+
+@pytest.mark.asyncio
+async def test_select_scopes_creates_bundled_multi_scope_consent_requests():
+    db = _FakeDb()
+    consent_db = _FakeConsentDb()
+    service = _service(db, consent_db)
+
+    result = await service._process_message(
+        _message(
+            subject="Broker API KYC and financial questionnaire",
+            body=(
+                "Please complete KYC and include all financial information for broker API "
+                "onboarding. Required: full name, date of birth, portfolio."
+            ),
+        ),
+        history_id="101multi",
+    )
+
+    workflow = result["workflow"]
+    assert workflow["metadata"]["scope_selection_required"] is True
+    assert [item["scope"] for item in workflow["metadata"]["candidate_scopes"]] == [
+        "attr.identity.*",
+        "attr.financial.*",
+    ]
+
+    selected = await service.select_scopes(
+        user_id="user_123",
+        workflow_id=workflow["workflow_id"],
+        selected_scopes=["attr.identity.*", "attr.financial.*"],
+    )
+
+    assert selected["status"] == "needs_scope"
+    assert selected["requested_scope"] == "attr.identity.*"
+    assert selected["requested_scopes"] == ["attr.identity.*", "attr.financial.*"]
+    assert selected["metadata"]["scope_selection_required"] is False
+    assert selected["consent_bundle_id"].startswith("okycb_")
+    assert "/consents?tab=incoming" in selected["consent_request_url"]
+    assert "bundleId=" in selected["consent_request_url"]
+    assert len(consent_db.events) == 2
+    bundle_ids = {event["metadata"]["bundle_id"] for event in consent_db.events}
+    assert bundle_ids == {selected["consent_bundle_id"]}
+    assert [event["scope"] for event in consent_db.events] == [
+        "attr.identity.*",
+        "attr.financial.*",
+    ]
 
 
 @pytest.mark.asyncio
@@ -661,7 +734,8 @@ async def test_refresh_workflow_marks_client_draft_ready_without_decrypting_expo
         _message(body="Broker KYC questionnaire asking for full name."),
         history_id="102",
     )
-    request_id = result["workflow"]["consent_request_id"]
+    workflow_with_consent = await _select_identity_scope(service, result["workflow"])
+    request_id = workflow_with_consent["consent_request_id"]
     consent_db.status_by_request[request_id] = {
         "action": "CONSENT_GRANTED",
         "token_id": "token_123",
@@ -678,7 +752,7 @@ async def test_refresh_workflow_marks_client_draft_ready_without_decrypting_expo
 
     workflow = await service.refresh_workflow(
         user_id="user_123",
-        workflow_id=result["workflow"]["workflow_id"],
+        workflow_id=workflow_with_consent["workflow_id"],
     )
 
     assert workflow["status"] == "waiting_on_user"
@@ -691,12 +765,121 @@ async def test_refresh_workflow_marks_client_draft_ready_without_decrypting_expo
 
     export_package = await service.get_workflow_consent_export(
         user_id="user_123",
-        workflow_id=result["workflow"]["workflow_id"],
+        workflow_id=workflow_with_consent["workflow_id"],
     )
     assert export_package["status"] == "success"
     assert export_package["encrypted_data"]
     assert export_package["wrapped_key_bundle"]["connector_key_id"] == "one-kyc-key"
     assert "token_123" not in json.dumps(export_package, default=str)
+
+
+@pytest.mark.asyncio
+async def test_refresh_workflow_marks_multi_scope_exports_ready():
+    db = _FakeDb()
+    consent_db = _FakeConsentDb()
+    service = _service(db, consent_db)
+    result = await service._process_message(
+        _message(
+            subject="Broker API KYC and financial questionnaire",
+            body="Broker KYC questionnaire asking for full name and all financial information.",
+        ),
+        history_id="102multi",
+    )
+    selected = await service.select_scopes(
+        user_id="user_123",
+        workflow_id=result["workflow"]["workflow_id"],
+        selected_scopes=["attr.identity.*", "attr.financial.*"],
+    )
+    requests = selected["metadata"]["consent_requests"]
+    consent_db.status_by_request[requests[0]["request_id"]] = {
+        "action": "CONSENT_GRANTED",
+        "token_id": "token_identity_multi",
+    }
+    consent_db.export_by_token["token_identity_multi"] = _encrypted_export(
+        {"identity": {"full_name": "Test Reviewer"}},
+        scope="attr.identity.*",
+        export_revision=1,
+    )
+
+    pending = await service.refresh_workflow(
+        user_id="user_123",
+        workflow_id=selected["workflow_id"],
+    )
+    assert pending["status"] == "needs_scope"
+
+    consent_db.status_by_request[requests[1]["request_id"]] = {
+        "action": "CONSENT_GRANTED",
+        "token_id": "token_financial_multi",
+    }
+    consent_db.export_by_token["token_financial_multi"] = _encrypted_export(
+        {"financial": {"portfolio": [{"ticker": "UAT", "value": "test only"}]}},
+        scope="attr.financial.*",
+        export_revision=7,
+    )
+
+    ready = await service.refresh_workflow(
+        user_id="user_123",
+        workflow_id=selected["workflow_id"],
+    )
+    assert ready["status"] == "waiting_on_user"
+    assert ready["draft_status"] == "ready"
+    assert ready["draft_body"] is None
+    assert len(ready["metadata"]["consent_exports"]) == 2
+
+    export_response = await service.get_workflow_consent_exports(
+        user_id="user_123",
+        workflow_id=selected["workflow_id"],
+    )
+    assert [item["scope"] for item in export_response["exports"]] == [
+        "attr.identity.*",
+        "attr.financial.*",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_denied_selected_scope_blocks_external_reply():
+    db = _FakeDb()
+    consent_db = _FakeConsentDb()
+    service = _service(db, consent_db)
+    result = await service._process_message(
+        _message(
+            subject="Broker API KYC and financial questionnaire",
+            body="Broker KYC questionnaire asking for full name and all financial information.",
+        ),
+        history_id="102denied",
+    )
+    selected = await service.select_scopes(
+        user_id="user_123",
+        workflow_id=result["workflow"]["workflow_id"],
+        selected_scopes=["attr.identity.*", "attr.financial.*"],
+    )
+    requests = selected["metadata"]["consent_requests"]
+    consent_db.status_by_request[requests[0]["request_id"]] = {
+        "action": "CONSENT_GRANTED",
+        "token_id": "token_identity_denied",
+    }
+    consent_db.export_by_token["token_identity_denied"] = _encrypted_export(
+        {"identity": {"full_name": "Test Reviewer"}},
+        scope="attr.identity.*",
+    )
+    consent_db.status_by_request[requests[1]["request_id"]] = {"action": "CONSENT_DENIED"}
+
+    blocked = await service.refresh_workflow(
+        user_id="user_123",
+        workflow_id=selected["workflow_id"],
+    )
+
+    assert blocked["status"] == "blocked"
+    assert blocked["metadata"]["external_reply_blocked"] is True
+    with pytest.raises(OneEmailKycError) as exc:
+        await service.send_approved_reply(
+            user_id="user_123",
+            workflow_id=selected["workflow_id"],
+            approved_subject="Re: Broker API KYC and financial questionnaire",
+            approved_body="Approved body",
+            pkm_writeback_artifact_hash="a" * 64,
+        )
+    assert exc.value.code == "ONE_KYC_EXTERNAL_REPLY_BLOCKED"
 
 
 @pytest.mark.asyncio
@@ -708,7 +891,8 @@ async def test_refresh_workflow_rejects_export_for_wrong_client_connector_key():
         _message(body="Broker KYC questionnaire asking for full name and date of birth."),
         history_id="103",
     )
-    request_id = result["workflow"]["consent_request_id"]
+    workflow_with_consent = await _select_identity_scope(service, result["workflow"])
+    request_id = workflow_with_consent["consent_request_id"]
     consent_db.status_by_request[request_id] = {
         "action": "CONSENT_GRANTED",
         "token_id": "token_missing",
@@ -730,7 +914,7 @@ async def test_refresh_workflow_rejects_export_for_wrong_client_connector_key():
     with pytest.raises(OneEmailKycError) as exc:
         await service.refresh_workflow(
             user_id="user_123",
-            workflow_id=result["workflow"]["workflow_id"],
+            workflow_id=workflow_with_consent["workflow_id"],
         )
 
     assert exc.value.code == "ONE_KYC_CONNECTOR_KEY_MISMATCH"
@@ -745,7 +929,8 @@ async def test_redraft_records_instruction_hash_without_storing_plaintext():
         _message(body="Broker KYC questionnaire asking for full name."),
         history_id="104",
     )
-    request_id = result["workflow"]["consent_request_id"]
+    workflow_with_consent = await _select_identity_scope(service, result["workflow"])
+    request_id = workflow_with_consent["consent_request_id"]
     consent_db.status_by_request[request_id] = {
         "action": "CONSENT_GRANTED",
         "token_id": "token_redraft",
@@ -755,7 +940,7 @@ async def test_redraft_records_instruction_hash_without_storing_plaintext():
     )
     workflow = await service.refresh_workflow(
         user_id="user_123",
-        workflow_id=result["workflow"]["workflow_id"],
+        workflow_id=workflow_with_consent["workflow_id"],
     )
 
     redrafted = await service.redraft(
@@ -780,10 +965,14 @@ async def test_send_approved_reply_revalidates_consent_and_sends_transient_body(
     consent_db = _FakeConsentDb()
     service = _service(db, consent_db)
     result = await service._process_message(
-        _message(body="Broker KYC questionnaire asking for full name."),
+        _message(
+            body="Broker KYC questionnaire asking for full name.",
+            cc="User <verified@example.com>, Broker Assistant <assistant@example.com>",
+        ),
         history_id="105",
     )
-    request_id = result["workflow"]["consent_request_id"]
+    workflow_with_consent = await _select_identity_scope(service, result["workflow"])
+    request_id = workflow_with_consent["consent_request_id"]
     consent_db.status_by_request[request_id] = {
         "action": "CONSENT_GRANTED",
         "token_id": "token_send",
@@ -793,15 +982,16 @@ async def test_send_approved_reply_revalidates_consent_and_sends_transient_body(
     )
     workflow = await service.refresh_workflow(
         user_id="user_123",
-        workflow_id=result["workflow"]["workflow_id"],
+        workflow_id=workflow_with_consent["workflow_id"],
     )
     sent_payloads = []
 
     def _capture_send(url, *, json_payload, scopes):
         sent_payloads.append(json_payload)
-        return {"id": "gmail_sent_1"}
+        return {"id": "gmail_sent_1", "threadId": "gmail_thread_1"}
 
     service._post_json_sync = _capture_send
+    service._fetch_message = lambda message_id: {"id": message_id, "threadId": "gmail_thread_1"}
 
     sent = await service.send_approved_reply(
         user_id="user_123",
@@ -822,6 +1012,14 @@ async def test_send_approved_reply_revalidates_consent_and_sends_transient_body(
         base64.urlsafe_b64decode((raw + ("=" * (-len(raw) % 4))).encode("utf-8"))
     )
     assert parsed["From"] == "One <one@hushh.ai>"
+    assert parsed["To"] == "broker@example.com"
+    assert parsed["Cc"] == "assistant@example.com"
+    assert parsed["Subject"] == "Broker API KYC questionnaire"
+    assert parsed["In-Reply-To"] == "<m1@example.com>"
+    assert parsed["References"] == "<m1@example.com>"
+    assert sent_payloads[0]["threadId"] == "gmail_thread_1"
+    assert sent["sent_thread_id"] == "gmail_thread_1"
+    assert sent["thread_match_status"] == "matched"
     assert parsed.get_payload() == "Approved KYC reply body\n"
     assert "Approved KYC reply body" not in json.dumps(db.workflows, default=str)
 
@@ -835,7 +1033,8 @@ async def test_send_approved_reply_rejects_when_bound_export_revision_changes():
         _message(body="Broker KYC questionnaire asking for full name."),
         history_id="106",
     )
-    request_id = result["workflow"]["consent_request_id"]
+    workflow_with_consent = await _select_identity_scope(service, result["workflow"])
+    request_id = workflow_with_consent["consent_request_id"]
     consent_db.status_by_request[request_id] = {
         "action": "CONSENT_GRANTED",
         "token_id": "token_revision",
@@ -846,7 +1045,7 @@ async def test_send_approved_reply_rejects_when_bound_export_revision_changes():
     )
     workflow = await service.refresh_workflow(
         user_id="user_123",
-        workflow_id=result["workflow"]["workflow_id"],
+        workflow_id=workflow_with_consent["workflow_id"],
     )
     consent_db.export_by_token["token_revision"] = _encrypted_export(
         {"identity": {"full_name": "Test Reviewer"}},
@@ -875,7 +1074,8 @@ async def test_send_approved_reply_clears_writeback_pending_when_gmail_send_fail
         _message(body="Broker KYC questionnaire asking for full name."),
         history_id="106a",
     )
-    request_id = result["workflow"]["consent_request_id"]
+    workflow_with_consent = await _select_identity_scope(service, result["workflow"])
+    request_id = workflow_with_consent["consent_request_id"]
     consent_db.status_by_request[request_id] = {
         "action": "CONSENT_GRANTED",
         "token_id": "token_send_failed",
@@ -885,7 +1085,7 @@ async def test_send_approved_reply_clears_writeback_pending_when_gmail_send_fail
     )
     workflow = await service.refresh_workflow(
         user_id="user_123",
-        workflow_id=result["workflow"]["workflow_id"],
+        workflow_id=workflow_with_consent["workflow_id"],
     )
 
     def _fail_send(url, *, json_payload, scopes):
@@ -920,7 +1120,8 @@ async def test_writeback_complete_updates_metadata_without_plaintext():
         _message(body="Broker KYC questionnaire asking for full name."),
         history_id="106b",
     )
-    request_id = result["workflow"]["consent_request_id"]
+    workflow_with_consent = await _select_identity_scope(service, result["workflow"])
+    request_id = workflow_with_consent["consent_request_id"]
     consent_db.status_by_request[request_id] = {
         "action": "CONSENT_GRANTED",
         "token_id": "token_writeback",
@@ -930,7 +1131,7 @@ async def test_writeback_complete_updates_metadata_without_plaintext():
     )
     workflow = await service.refresh_workflow(
         user_id="user_123",
-        workflow_id=result["workflow"]["workflow_id"],
+        workflow_id=workflow_with_consent["workflow_id"],
     )
     service._post_json_sync = lambda url, *, json_payload, scopes: {"id": "gmail_sent_writeback"}
     sent = await service.send_approved_reply(
@@ -965,7 +1166,8 @@ async def test_writeback_complete_requires_declared_artifact_hash_match():
         _message(body="Broker KYC questionnaire asking for full name."),
         history_id="106bb",
     )
-    request_id = result["workflow"]["consent_request_id"]
+    workflow_with_consent = await _select_identity_scope(service, result["workflow"])
+    request_id = workflow_with_consent["consent_request_id"]
     consent_db.status_by_request[request_id] = {
         "action": "CONSENT_GRANTED",
         "token_id": "token_writeback_mismatch",
@@ -975,7 +1177,7 @@ async def test_writeback_complete_requires_declared_artifact_hash_match():
     )
     workflow = await service.refresh_workflow(
         user_id="user_123",
-        workflow_id=result["workflow"]["workflow_id"],
+        workflow_id=workflow_with_consent["workflow_id"],
     )
     service._post_json_sync = lambda url, *, json_payload, scopes: {"id": "gmail_sent_writeback"}
     sent = await service.send_approved_reply(

--- a/consent-protocol/tests/test_one_email_routes.py
+++ b/consent-protocol/tests/test_one_email_routes.py
@@ -114,6 +114,38 @@ def test_one_kyc_send_approved_reply_forwards_transient_body(monkeypatch):
     ]
 
 
+def test_one_kyc_scope_selection_uses_authenticated_user(monkeypatch):
+    calls: list[dict] = []
+
+    class _Service:
+        async def select_scopes(self, **kwargs):
+            calls.append(kwargs)
+            return {
+                "workflow_id": kwargs["workflow_id"],
+                "user_id": kwargs["user_id"],
+                "status": "needs_scope",
+                "requested_scopes": kwargs["selected_scopes"],
+            }
+
+    monkeypatch.setattr(one_email, "_service", lambda: _Service())
+    client = _build_app(user_id="user_123")
+
+    response = client.post(
+        "/api/one/kyc/workflows/workflow_123/scope-selection",
+        json={"user_id": "user_123", "selected_scopes": ["attr.identity.*", "attr.financial.*"]},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["requested_scopes"] == ["attr.identity.*", "attr.financial.*"]
+    assert calls == [
+        {
+            "user_id": "user_123",
+            "workflow_id": "workflow_123",
+            "selected_scopes": ["attr.identity.*", "attr.financial.*"],
+        }
+    ]
+
+
 def test_one_kyc_client_connector_registration_uses_vault_user(monkeypatch):
     calls: list[dict] = []
 
@@ -173,5 +205,36 @@ def test_one_kyc_workflow_consent_export_uses_vault_user_without_consent_token(m
 
     assert response.status_code == 200
     assert response.json()["encrypted_data"] == "ciphertext"
+    assert "consent_token" not in response.text
+    assert calls == [{"user_id": "user_123", "workflow_id": "workflow_123"}]
+
+
+def test_one_kyc_workflow_consent_exports_uses_vault_user_without_consent_token(monkeypatch):
+    calls: list[dict] = []
+
+    class _Service:
+        async def get_workflow_consent_exports(self, **kwargs):
+            calls.append(kwargs)
+            return {
+                "status": "success",
+                "exports": [
+                    {
+                        "request_id": "okyc_1",
+                        "scope": "attr.identity.*",
+                        "encrypted_data": "ciphertext",
+                        "iv": "iv",
+                        "tag": "tag",
+                        "wrapped_key_bundle": {"connector_key_id": "one-kyc-test"},
+                    }
+                ],
+            }
+
+    monkeypatch.setattr(one_email, "_service", lambda: _Service())
+    client = _build_app(user_id="user_123")
+
+    response = client.get("/api/one/kyc/workflows/workflow_123/consent-exports?user_id=user_123")
+
+    assert response.status_code == 200
+    assert response.json()["exports"][0]["scope"] == "attr.identity.*"
     assert "consent_token" not in response.text
     assert calls == [{"user_id": "user_123", "workflow_id": "workflow_123"}]

--- a/docs/reference/architecture/api-contracts.md
+++ b/docs/reference/architecture/api-contracts.md
@@ -110,8 +110,12 @@ Client surfaces
 One mailbox intake is One-led and approval-gated. KYC workspace routes require
 a VAULT_OWNER token plus a matching `user_id`; mailbox maintenance routes use
 Pub/Sub OIDC or the One maintenance token, not user Firebase auth. Strict
-client-side ZK means the backend never decrypts consent exports or persists
-review draft plaintext.
+client-side ZK means the backend never decrypts consent exports, never builds
+review drafts, and never persists review draft plaintext. Dev/UAT One Email now
+uses text-only multi-scope disclosure intake: the backend stores detected
+domains, candidate scopes, thread metadata, hashes, and consent/writeback/send
+metadata only; the vault-unlocked client confirms scopes and builds the final
+draft from approved encrypted exports.
 
 Inbound user resolution uses exact verified email evidence. The resolver checks
 verified `To`, `Cc`, and `Reply-To` recipients before falling back to all
@@ -128,9 +132,11 @@ before they can resolve intake.
 | POST | `/api/one/kyc/client-connector` | VAULT_OWNER Bearer | Register public client connector metadata after vault unlock; private key remains client/vault-only |
 | GET | `/api/one/kyc/workflows?user_id={user_id}` | VAULT_OWNER Bearer | List One KYC workflows for the vault owner |
 | GET | `/api/one/kyc/workflows/{workflow_id}?user_id={user_id}` | VAULT_OWNER Bearer | Read one workflow and metadata-only draft state for the vault owner |
+| POST | `/api/one/kyc/workflows/{workflow_id}/scope-selection` | VAULT_OWNER Bearer | Confirm or narrow backend-detected candidate scopes before consent requests are created |
 | POST | `/api/one/kyc/workflows/{workflow_id}/refresh` | VAULT_OWNER Bearer | Refresh workflow state after consent approval; returns encrypted export metadata for client-side draft generation |
 | GET | `/api/one/kyc/workflows/{workflow_id}/consent-export?user_id={user_id}` | VAULT_OWNER Bearer | Return the encrypted wrapped-key export package for this ready workflow without exposing the consent token to the browser |
-| POST | `/api/one/kyc/workflows/{workflow_id}/send-approved-reply` | VAULT_OWNER Bearer | Transiently send the user-approved final email body through Gmail; persist metadata/hashes only |
+| GET | `/api/one/kyc/workflows/{workflow_id}/consent-exports?user_id={user_id}` | VAULT_OWNER Bearer | Return all selected encrypted wrapped-key export packages for multi-scope client-side draft generation |
+| POST | `/api/one/kyc/workflows/{workflow_id}/send-approved-reply` | VAULT_OWNER Bearer | Transiently send the user-approved final email body as Gmail reply-all in the original thread; persist metadata/hashes and thread verification only |
 | POST | `/api/one/kyc/workflows/{workflow_id}/writeback-complete` | VAULT_OWNER Bearer | Record encrypted PKM writeback status and artifact hash |
 | POST | `/api/one/kyc/workflows/{workflow_id}/approve-draft` | VAULT_OWNER Bearer | Deprecated; returns gone because server-side draft approval is disabled |
 | POST | `/api/one/kyc/workflows/{workflow_id}/reject-draft` | VAULT_OWNER Bearer | Reject and block the workflow |

--- a/docs/reference/iam/consent-scope-catalog.md
+++ b/docs/reference/iam/consent-scope-catalog.md
@@ -62,6 +62,23 @@ These are UX bundles, not a second authorization system. Bundles expand into can
 | `health_wellness` | Health & Wellness | `attr.health.*` |
 | `lifestyle_preferences` | Lifestyle Preferences | `attr.food.*`, `attr.travel.*`, `attr.entertainment.*`, `attr.shopping.*` |
 
+## One Email Disclosure Bundles
+
+One Email KYC/dev-UAT disclosure workflows use the same bundle metadata pattern
+for user-confirmed candidate scopes. One detects text-only requested domains,
+the vault owner confirms or narrows the recommendation, and each selected
+canonical scope becomes its own consent request under one `bundle_id`.
+
+Representative selected scopes:
+
+1. `attr.identity.*` for KYC/compliance identity disclosures.
+2. `attr.financial.*` for explicit full financial-information requests.
+3. `attr.financial.portfolio.*`, `attr.financial.profile.*`, or `attr.financial.documents.*` for narrower financial requests.
+
+Denied selected scopes block external reply-all. Missing fields inside an
+approved export are described in the client-generated draft; the backend never
+decrypts or drafts from the scoped data.
+
 ## Duration Policy
 
 1. Presets: `24h`, `7d`, `30d`, `90d`

--- a/hushh-webapp/__tests__/services/one-kyc-client-zk-service.test.ts
+++ b/hushh-webapp/__tests__/services/one-kyc-client-zk-service.test.ts
@@ -101,6 +101,44 @@ describe("OneKycClientZkService", () => {
     expect(draft.body).not.toContain("address:");
   });
 
+  it("builds multi-scope drafts without appending redraft instructions as outgoing text", async () => {
+    const workflow: OneKycWorkflow = {
+      ...baseWorkflow,
+      required_fields: ["full_name", "portfolio", "financial_profile"],
+      requested_scopes: ["attr.identity.*", "attr.financial.*"],
+    };
+
+    const draft = await OneKycClientZkService.buildDraft({
+      workflow,
+      instructions: "add financial information",
+      exportPayloads: [
+        {
+          scope: "attr.identity.*",
+          payload: {
+            identity: {
+              full_name: "Ada Lovelace",
+            },
+          },
+        },
+        {
+          scope: "attr.financial.*",
+          payload: {
+            financial: {
+              portfolio: [{ ticker: "UAT", value: "test only" }],
+            },
+          },
+        },
+      ],
+    });
+
+    expect(draft.body).toContain("full name: Ada Lovelace");
+    expect(draft.body).toContain("portfolio: ticker: UAT; value: test only");
+    expect(draft.body).toContain("approved export did not contain");
+    expect(draft.body).toContain("financial profile");
+    expect(draft.body).not.toContain("User requested adjustment");
+    expect(draft.scopeSummaries).toHaveLength(2);
+  });
+
   it("rejects consent exports wrapped to a different connector before decrypting", async () => {
     await expect(
       OneKycClientZkService.decryptScopedExport({

--- a/hushh-webapp/__tests__/services/one-kyc-service.test.ts
+++ b/hushh-webapp/__tests__/services/one-kyc-service.test.ts
@@ -97,6 +97,45 @@ describe("OneKycService", () => {
     );
   });
 
+  it("submits user-selected scopes before consent creation", async () => {
+    await OneKycService.selectScopes({
+      userId: "user_1",
+      vaultOwnerToken: "vault-token",
+      workflowId: "wf_1",
+      selectedScopes: ["attr.identity.*", "attr.financial.*"],
+    });
+
+    expect(mockApiJson).toHaveBeenCalledWith("/api/one/kyc/workflows/wf_1/scope-selection", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer vault-token",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        user_id: "user_1",
+        selected_scopes: ["attr.identity.*", "attr.financial.*"],
+      }),
+    });
+  });
+
+  it("loads all encrypted consent exports for multi-scope drafts", async () => {
+    await OneKycService.getWorkflowConsentExports({
+      userId: "user_1",
+      vaultOwnerToken: "vault-token",
+      workflowId: "wf_1",
+    });
+
+    expect(mockApiJson).toHaveBeenCalledWith(
+      "/api/one/kyc/workflows/wf_1/consent-exports?user_id=user_1",
+      {
+        headers: {
+          Authorization: "Bearer vault-token",
+          "Content-Type": "application/json",
+        },
+      }
+    );
+  });
+
   it("marks encrypted PKM writeback completion separately from Gmail send", async () => {
     await OneKycService.writebackComplete({
       userId: "user_1",

--- a/hushh-webapp/app/one/kyc/page.tsx
+++ b/hushh-webapp/app/one/kyc/page.tsx
@@ -31,9 +31,10 @@ import {
   type KycWorkflowCheckKey,
   type KycWorkflowStatus,
 } from "@/lib/services/kyc-pkm-write-service";
-import { OneKycClientZkService, sha256Hex, type KycDraftBuildResult } from "@/lib/services/one-kyc-client-zk-service";
+import { OneKycClientZkService, type KycDraftBuildResult } from "@/lib/services/one-kyc-client-zk-service";
 import {
   OneKycService,
+  type OneKycScopeCandidate,
   type OneKycWorkflow,
   type OneKycWorkflowStatus,
 } from "@/lib/services/one-kyc-service";
@@ -76,6 +77,10 @@ function OneKycWorkspace() {
   const [error, setError] = useState<string | null>(null);
   const [redraftInstructions, setRedraftInstructions] = useState("");
   const [localDrafts, setLocalDrafts] = useState<Record<string, KycDraftBuildResult>>({});
+  const [localExportPayloads, setLocalExportPayloads] = useState<
+    Record<string, Array<{ scope?: string | null; payload: Record<string, unknown> }>>
+  >({});
+  const [selectedScopesByWorkflow, setSelectedScopesByWorkflow] = useState<Record<string, string[]>>({});
   const [connectorReady, setConnectorReady] = useState(false);
   const [emailAliases, setEmailAliases] = useState<AccountEmailAlias[]>([]);
   const [aliasEmail, setAliasEmail] = useState("");
@@ -209,21 +214,30 @@ function OneKycWorkspace() {
           vaultKey,
           vaultOwnerToken,
         });
-        const exportPackage = await OneKycService.getWorkflowConsentExport({
+        const exportResponse = await OneKycService.getWorkflowConsentExports({
           userId: auth.userId,
           vaultOwnerToken,
           workflowId: selected.workflow_id,
         });
-        const exportPayload = await OneKycClientZkService.decryptScopedExport({
-          exportPackage,
-          connector,
-        });
+        const exportPayloads = await Promise.all(
+          exportResponse.exports.map(async (exportPackage) => ({
+            scope: exportPackage.scope,
+            payload: await OneKycClientZkService.decryptScopedExport({
+              exportPackage,
+              connector,
+            }),
+          }))
+        );
         const draft = await OneKycClientZkService.buildDraft({
           workflow: selected,
-          exportPayload,
+          exportPayloads,
         });
         if (!cancelled) {
           setLocalDrafts((current) => ({ ...current, [selected.workflow_id]: draft }));
+          setLocalExportPayloads((current) => ({
+            ...current,
+            [selected.workflow_id]: exportPayloads,
+          }));
         }
       } catch (err) {
         if (!cancelled) {
@@ -333,33 +347,27 @@ function OneKycWorkspace() {
             setError("Prepare the KYC draft before revising it.");
             return;
           }
-          const body = `${localDraft.body}
-
----
-User requested adjustment: ${redraftInstructions.trim()}`.slice(0, 6000);
-          setLocalDrafts((current) => ({
-            ...current,
-            [workflow.workflow_id]: {
-              ...localDraft,
-              body,
-              draftHash: "",
-            },
-          }));
-          const draftHash = await sha256Hex(body);
-          setLocalDrafts((current) => ({
-            ...current,
-            [workflow.workflow_id]: {
-              ...localDraft,
-              body,
-              draftHash,
-            },
-          }));
           const next = await OneKycService.redraft({
             ...input,
             instructions: redraftInstructions.trim(),
             source: "text",
           });
           updateWorkflow(next);
+          if (next.status === "waiting_on_user") {
+            const exportPayloads = localExportPayloads[workflow.workflow_id] || [];
+            const draft = await OneKycClientZkService.buildDraft({
+              workflow: next,
+              exportPayloads,
+              instructions: redraftInstructions.trim(),
+            });
+            setLocalDrafts((current) => ({ ...current, [workflow.workflow_id]: draft }));
+          } else {
+            setLocalDrafts((current) => {
+              const nextDrafts = { ...current };
+              delete nextDrafts[workflow.workflow_id];
+              return nextDrafts;
+            });
+          }
           setRedraftInstructions("");
           return;
         }
@@ -400,7 +408,9 @@ User requested adjustment: ${redraftInstructions.trim()}`.slice(0, 6000);
             approvedBody: localDraft.body,
             clientDraftHash: localDraft.draftHash,
             consentExportRevision:
-              typeof workflow.consent_export?.export_revision === "number"
+              Array.isArray(workflow.consent_exports) && workflow.consent_exports.length > 1
+                ? null
+                : typeof workflow.consent_export?.export_revision === "number"
                 ? workflow.consent_export.export_revision
                 : typeof workflow.metadata?.consent_export === "object" &&
                     workflow.metadata.consent_export !== null &&
@@ -461,6 +471,7 @@ User requested adjustment: ${redraftInstructions.trim()}`.slice(0, 6000);
     [
       auth.user,
       auth.userId,
+      localExportPayloads,
       localDrafts,
       redraftInstructions,
       updateWorkflow,
@@ -468,6 +479,43 @@ User requested adjustment: ${redraftInstructions.trim()}`.slice(0, 6000);
       vaultOwnerToken,
     ]
   );
+
+  const submitScopeSelection = useCallback(
+    async (workflow: OneKycWorkflow) => {
+      if (!auth.userId || !vaultOwnerToken) return;
+      const selectedScopes = selectedScopesForWorkflow(workflow, selectedScopesByWorkflow);
+      if (!selectedScopes.length) {
+        setError("Select at least one scope before requesting consent.");
+        return;
+      }
+      setBusy("scope");
+      setError(null);
+      try {
+        const next = await OneKycService.selectScopes({
+          userId: auth.userId,
+          vaultOwnerToken,
+          workflowId: workflow.workflow_id,
+          selectedScopes,
+        });
+        updateWorkflow(next);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Scope selection failed.");
+      } finally {
+        setBusy(null);
+      }
+    },
+    [auth.userId, selectedScopesByWorkflow, updateWorkflow, vaultOwnerToken]
+  );
+
+  const toggleScope = useCallback((workflow: OneKycWorkflow, scope: string) => {
+    setSelectedScopesByWorkflow((current) => {
+      const selectedScopes = selectedScopesForWorkflow(workflow, current);
+      const nextScopes = selectedScopes.includes(scope)
+        ? selectedScopes.filter((item) => item !== scope)
+        : [...selectedScopes, scope];
+      return { ...current, [workflow.workflow_id]: nextScopes };
+    });
+  }, []);
 
   return (
     <AppPageShell
@@ -618,8 +666,10 @@ User requested adjustment: ${redraftInstructions.trim()}`.slice(0, 6000);
                 <div className="grid gap-3 sm:grid-cols-2">
                   <Info label="Status" value={STATUS_LABELS[selected.status] || selected.status} />
                   <Info label="Counterparty" value={selected.counterparty_label || selected.sender_email || "-"} />
-                  <Info label="Scope" value={selected.requested_scope || "-"} />
+                  <Info label="Intent" value={detectedDomains(selected).join(", ") || "-"} />
+                  <Info label="Scopes" value={selectedScopeLabels(selected).join(", ") || selected.requested_scope || "-"} />
                   <Info label="Updated" value={selected.updated_at ? new Date(selected.updated_at).toLocaleString() : "-"} />
+                  <Info label="Thread" value={threadStatusLabel(selected)} />
                 </div>
 
                 <div className="space-y-2">
@@ -639,13 +689,81 @@ User requested adjustment: ${redraftInstructions.trim()}`.slice(0, 6000);
                   </div>
                 ) : null}
 
-                {selected.status === "needs_scope" && selected.consent_request_url ? (
-                  <Button asChild>
-                    <a href={selected.consent_request_url} data-voice-control-id="one-kyc-open-consent">
-                      <ShieldCheck className="size-4" />
-                      Review consent
-                    </a>
-                  </Button>
+                {selected.status === "needs_scope" ? (
+                  <div className="space-y-3 rounded-md border bg-background/60 p-3">
+                    <div className="space-y-1">
+                      <p className="text-sm font-medium">Recommended scopes</p>
+                      <p className="text-xs text-muted-foreground">
+                        Confirm the scopes One should request before any encrypted export is prepared.
+                      </p>
+                    </div>
+                    <div className="space-y-2">
+                      {scopeCandidates(selected).map((candidate) => {
+                        const checked = selectedScopesForWorkflow(
+                          selected,
+                          selectedScopesByWorkflow
+                        ).includes(candidate.scope);
+                        return (
+                          <label
+                            key={candidate.scope}
+                            className="flex items-start gap-3 rounded-md border p-3 text-sm"
+                          >
+                            <input
+                              type="checkbox"
+                              className="mt-1"
+                              checked={checked}
+                              onChange={() => toggleScope(selected, candidate.scope)}
+                              disabled={Boolean(selected.consent_request_url)}
+                            />
+                            <span className="space-y-1">
+                              <span className="block font-medium">
+                                {candidate.label || candidate.scope}
+                              </span>
+                              <span className="block text-xs text-muted-foreground">
+                                {candidate.description || candidate.scope}
+                              </span>
+                              <span className="block text-xs text-muted-foreground">
+                                {candidate.reason || "Detected from the email text."}
+                              </span>
+                            </span>
+                          </label>
+                        );
+                      })}
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      {!selected.consent_request_url ? (
+                        <Button
+                          type="button"
+                          onClick={() => void submitScopeSelection(selected)}
+                          disabled={
+                            Boolean(busy) ||
+                            selectedScopesForWorkflow(selected, selectedScopesByWorkflow).length === 0
+                          }
+                        >
+                          <ShieldCheck className="size-4" />
+                          Request consent
+                        </Button>
+                      ) : (
+                        <Button asChild>
+                          <a href={selected.consent_request_url} data-voice-control-id="one-kyc-open-consent">
+                            <ShieldCheck className="size-4" />
+                            Review consent
+                          </a>
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                ) : null}
+
+                {selected.metadata?.reply_thread ? (
+                  <div className="space-y-2 rounded-md border bg-background/60 p-3">
+                    <p className="text-sm font-medium">Reply preview</p>
+                    <Info
+                      label="To"
+                      value={replyThreadValue(selected, "reply_all_to") || selected.sender_email || "-"}
+                    />
+                    <Info label="Cc" value={replyThreadValue(selected, "reply_all_cc") || "-"} />
+                  </div>
                 ) : null}
 
                 {selectedDraft ? (
@@ -659,7 +777,7 @@ User requested adjustment: ${redraftInstructions.trim()}`.slice(0, 6000);
                     </pre>
                     {selectedDraft.missingFields.length > 0 ? (
                       <p className="text-sm text-amber-700 dark:text-amber-200">
-                        Missing approved fields: {selectedDraft.missingFields.map((field) => field.replaceAll("_", " ")).join(", ")}
+                        Approved export did not contain: {selectedDraft.missingFields.map((field) => field.replaceAll("_", " ")).join(", ")}
                       </p>
                     ) : null}
                   </div>
@@ -758,6 +876,76 @@ function Info({ label, value }: { label: string; value: string }) {
       <p className="mt-1 break-words text-sm">{value}</p>
     </div>
   );
+}
+
+function scopeCandidates(workflow: OneKycWorkflow): OneKycScopeCandidate[] {
+  const direct = workflow.candidate_scopes;
+  if (Array.isArray(direct) && direct.length) return direct;
+  const metadataCandidates = workflow.metadata?.candidate_scopes;
+  if (Array.isArray(metadataCandidates)) {
+    return metadataCandidates.filter(
+      (candidate): candidate is OneKycScopeCandidate =>
+        Boolean(candidate && typeof candidate === "object" && "scope" in candidate)
+    );
+  }
+  return workflow.requested_scope
+    ? [
+        {
+          scope: workflow.requested_scope,
+          domain: workflow.requested_scope.includes("financial") ? "financial" : "identity",
+          label: workflow.requested_scope,
+        },
+      ]
+    : [];
+}
+
+function selectedScopesForWorkflow(
+  workflow: OneKycWorkflow,
+  localSelections: Record<string, string[]>
+): string[] {
+  const local = localSelections[workflow.workflow_id];
+  if (local) return local;
+  if (Array.isArray(workflow.selected_scopes) && workflow.selected_scopes.length) {
+    return workflow.selected_scopes;
+  }
+  if (Array.isArray(workflow.requested_scopes) && workflow.requested_scopes.length) {
+    return workflow.requested_scopes;
+  }
+  const recommended = scopeCandidates(workflow)
+    .filter((candidate) => candidate.recommended !== false)
+    .map((candidate) => candidate.scope);
+  if (recommended.length) return recommended;
+  return workflow.requested_scope ? [workflow.requested_scope] : [];
+}
+
+function selectedScopeLabels(workflow: OneKycWorkflow): string[] {
+  const selectedScopes = new Set(selectedScopesForWorkflow(workflow, {}));
+  return scopeCandidates(workflow)
+    .filter((candidate) => selectedScopes.has(candidate.scope))
+    .map((candidate) => candidate.label || candidate.scope);
+}
+
+function detectedDomains(workflow: OneKycWorkflow): string[] {
+  const fromCandidates = scopeCandidates(workflow)
+    .map((candidate) => candidate.domain)
+    .filter(Boolean);
+  if (fromCandidates.length) return Array.from(new Set(fromCandidates));
+  const metadata = workflow.metadata?.detected_domains;
+  return Array.isArray(metadata) ? metadata.map(String) : [];
+}
+
+function replyThreadValue(workflow: OneKycWorkflow, key: "reply_all_to" | "reply_all_cc"): string {
+  const thread = workflow.metadata?.reply_thread;
+  if (!thread || typeof thread !== "object") return "";
+  const value = (thread as Record<string, unknown>)[key];
+  return Array.isArray(value) ? value.map(String).join(", ") : "";
+}
+
+function threadStatusLabel(workflow: OneKycWorkflow): string {
+  if (workflow.thread_match_status === "matched") return "Reply threaded";
+  if (workflow.thread_match_status === "mismatched") return "Sent in new thread";
+  if (workflow.thread_match_status === "unknown") return "Thread verification pending";
+  return workflow.gmail_thread_id || "-";
 }
 
 function emptyKycCheck(): KycWorkflowCheck {

--- a/hushh-webapp/lib/services/one-kyc-client-zk-service.ts
+++ b/hushh-webapp/lib/services/one-kyc-client-zk-service.ts
@@ -34,6 +34,7 @@ export type KycScopedExportPackage = {
     connector_key_id?: string;
   };
   scope?: string;
+  request_id?: string;
   export_revision?: number;
   export_generated_at?: string;
   export_refresh_status?: string;
@@ -44,7 +45,17 @@ export type KycDraftBuildResult = {
   body: string;
   approvedValues: Record<string, string>;
   missingFields: string[];
+  scopeSummaries: Array<{
+    scope: string;
+    approvedFields: string[];
+    missingFields: string[];
+  }>;
   draftHash: string;
+};
+
+type KycDraftExportPayload = {
+  scope?: string | null;
+  payload: Record<string, unknown>;
 };
 
 function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
@@ -148,6 +159,7 @@ function findApprovedValue(value: unknown, aliases: string[]): string | null {
 function extractApprovedValues(params: {
   payload: Record<string, unknown>;
   requiredFields: string[];
+  scope?: string | null;
 }): { approvedValues: Record<string, string>; missingFields: string[] } {
   const aliases: Record<string, string[]> = {
     full_name: ["full_name", "fullName", "legal_name", "legalName", "name", "display_name"],
@@ -161,19 +173,50 @@ function extractApprovedValues(params: {
     source_of_funds: ["source_of_funds", "sourceOfFunds", "source_of_wealth"],
     brokerage_profile: ["brokerage_profile", "brokerageProfile", "trading_experience"],
     identity_profile: ["identity", "profile", "identity_profile", "identityProfile"],
+    financial_profile: [
+      "financial_profile",
+      "financialProfile",
+      "financial_information",
+      "financialInformation",
+      "net_worth",
+      "netWorth",
+      "assets",
+      "liabilities",
+    ],
+    portfolio: ["portfolio", "holdings", "investment_holdings", "investments", "positions"],
+    financial_documents: ["financial_documents", "financialDocuments", "statements", "documents"],
   };
+  const isFinancialScope = String(params.scope || "").startsWith("attr.financial");
+  const sourceKey = isFinancialScope ? "financial" : "identity";
   const source =
-    params.payload.identity && typeof params.payload.identity === "object"
-      ? (params.payload.identity as Record<string, unknown>)
+    params.payload[sourceKey] && typeof params.payload[sourceKey] === "object"
+      ? (params.payload[sourceKey] as Record<string, unknown>)
       : params.payload;
   const approvedValues: Record<string, string> = {};
   const missingFields: string[] = [];
-  for (const field of params.requiredFields.length ? params.requiredFields : ["identity_profile"]) {
+  const fields = fieldsForScope(params.scope, params.requiredFields);
+  for (const field of fields) {
     const value = findApprovedValue(source, aliases[field] || [field]);
     if (value) approvedValues[field] = value;
     else missingFields.push(field);
   }
   return { approvedValues, missingFields };
+}
+
+const FINANCIAL_FIELDS = new Set(["financial_profile", "portfolio", "financial_documents"]);
+
+function fieldsForScope(scope: string | null | undefined, requiredFields: string[]): string[] {
+  const normalizedScope = String(scope || "");
+  const requested = requiredFields.length ? requiredFields : ["identity_profile"];
+  if (normalizedScope.startsWith("attr.financial")) {
+    const financialRequested = requested.filter((field) => FINANCIAL_FIELDS.has(field));
+    if (financialRequested.length) return financialRequested;
+    if (normalizedScope.includes("portfolio")) return ["portfolio"];
+    if (normalizedScope.includes("documents")) return ["financial_documents"];
+    return ["financial_profile"];
+  }
+  const identityRequested = requested.filter((field) => !FINANCIAL_FIELDS.has(field));
+  return identityRequested.length ? identityRequested : ["identity_profile"];
 }
 
 function replySubject(subject: string | null | undefined): string {
@@ -399,27 +442,61 @@ export class OneKycClientZkService {
 
   static async buildDraft(params: {
     workflow: OneKycWorkflow;
-    exportPayload: Record<string, unknown>;
+    exportPayload?: Record<string, unknown>;
+    exportPayloads?: KycDraftExportPayload[];
     instructions?: string;
   }): Promise<KycDraftBuildResult> {
-    const { approvedValues, missingFields } = extractApprovedValues({
-      payload: params.exportPayload,
-      requiredFields: params.workflow.required_fields,
-    });
+    const payloads =
+      params.exportPayloads && params.exportPayloads.length
+        ? params.exportPayloads
+        : params.exportPayload
+          ? [{ scope: params.workflow.requested_scope, payload: params.exportPayload }]
+          : [];
+    const approvedValues: Record<string, string> = {};
+    const missingFields: string[] = [];
+    const scopeSummaries: KycDraftBuildResult["scopeSummaries"] = [];
+    for (const item of payloads) {
+      const scope = item.scope || params.workflow.requested_scope || "attr.identity.*";
+      const extracted = extractApprovedValues({
+        payload: item.payload,
+        requiredFields: params.workflow.required_fields,
+        scope,
+      });
+      Object.assign(approvedValues, extracted.approvedValues);
+      for (const field of extracted.missingFields) {
+        if (!missingFields.includes(field)) missingFields.push(field);
+      }
+      scopeSummaries.push({
+        scope,
+        approvedFields: Object.keys(extracted.approvedValues),
+        missingFields: extracted.missingFields,
+      });
+    }
     const counterparty = params.workflow.counterparty_label || "there";
     const fieldLines = Object.entries(approvedValues)
       .map(([field, value]) => `- ${field.replaceAll("_", " ")}: ${value}`)
       .join("\n");
-    const instructionText = params.instructions?.trim()
-      ? `\nUser requested adjustment: ${params.instructions.trim()}\n`
-      : "";
-    const body = `Hi ${counterparty},
+    const missingLines = missingFields
+      .map((field) => `- ${field.replaceAll("_", " ")}`)
+      .join("\n");
+    const compact = params.instructions?.toLowerCase().includes("shorter");
+    const body = compact
+      ? `Hi ${counterparty},
 
 I am replying on behalf of the account holder through One.
 
-The user approved a scoped KYC workflow for this request. One prepared the following approved information for your review:
-${fieldLines || "- Approved identity export available for review."}
-${instructionText}
+Approved scoped information:
+${fieldLines || "- No requested values were present in the approved export."}
+${missingLines ? `\nApproved export did not contain:\n${missingLines}\n` : ""}
+Best,
+One`
+      : `Hi ${counterparty},
+
+I am replying on behalf of the account holder through One.
+
+The account holder approved the following scoped information through One:
+${fieldLines || "- No requested values were present in the approved export."}
+${missingLines ? `\nThe approved export did not contain these requested fields:\n${missingLines}\n` : ""}
 Please let us know if you need anything else for this KYC review.
 
 Best,
@@ -429,6 +506,7 @@ One`.slice(0, 6000);
       body,
       approvedValues,
       missingFields,
+      scopeSummaries,
       draftHash: await sha256Hex(body),
     };
   }

--- a/hushh-webapp/lib/services/one-kyc-service.ts
+++ b/hushh-webapp/lib/services/one-kyc-service.ts
@@ -14,6 +14,23 @@ export type OneKycWorkflowStatus =
   | "completed"
   | "blocked";
 
+export interface OneKycScopeCandidate {
+  scope: string;
+  domain: string;
+  label?: string;
+  description?: string;
+  reason?: string;
+  recommended?: boolean;
+  sensitivity?: string;
+}
+
+export interface OneKycConsentRequest {
+  request_id: string;
+  scope: string;
+  status?: string;
+  request_url?: string | null;
+}
+
 export interface OneKycWorkflow {
   workflow_id: string;
   user_id: string | null;
@@ -28,15 +45,23 @@ export interface OneKycWorkflow {
   counterparty_label?: string | null;
   required_fields: string[];
   requested_scope?: string | null;
+  requested_scopes?: string[] | null;
+  selected_scopes?: string[] | null;
+  candidate_scopes?: OneKycScopeCandidate[] | null;
   consent_request_id?: string | null;
+  consent_requests?: OneKycConsentRequest[] | null;
+  consent_bundle_id?: string | null;
   consent_request_url?: string | null;
   workflow_url?: string | null;
   draft_subject?: string | null;
   draft_body?: string | null;
   draft_status?: "not_ready" | "ready" | "sent" | "rejected" | null;
   consent_export?: Record<string, unknown> | null;
+  consent_exports?: Array<Record<string, unknown>> | null;
   send_status?: "not_started" | "sending" | "sent" | "failed" | null;
   sent_message_id?: string | null;
+  sent_thread_id?: string | null;
+  thread_match_status?: "matched" | "mismatched" | "unknown" | "not_applicable" | null;
   sent_at?: string | null;
   pkm_writeback_status?: "not_started" | "pending" | "succeeded" | "failed" | null;
   pkm_writeback_artifact_hash?: string | null;
@@ -63,6 +88,16 @@ export interface OneKycClientConnectorResponse {
     public_key_fingerprint?: string | null;
     status?: string | null;
   } | null;
+}
+
+export interface KycScopedExportPackageWithRequest extends KycScopedExportPackage {
+  request_id?: string;
+  scope?: string;
+}
+
+export interface OneKycWorkflowConsentExportsResponse {
+  status: string;
+  exports: KycScopedExportPackageWithRequest[];
 }
 
 type AuthInput = {
@@ -110,6 +145,22 @@ export class OneKycService {
         method: "POST",
         headers: authHeaders(vaultOwnerToken),
         body: JSON.stringify({ user_id: userId }),
+      }
+    );
+  }
+
+  static selectScopes({
+    userId,
+    vaultOwnerToken,
+    workflowId,
+    selectedScopes,
+  }: AuthInput & { workflowId: string; selectedScopes: string[] }): Promise<OneKycWorkflow> {
+    return apiJson<OneKycWorkflow>(
+      `/api/one/kyc/workflows/${encodeURIComponent(workflowId)}/scope-selection`,
+      {
+        method: "POST",
+        headers: authHeaders(vaultOwnerToken),
+        body: JSON.stringify({ user_id: userId, selected_scopes: selectedScopes }),
       }
     );
   }
@@ -222,6 +273,20 @@ export class OneKycService {
     const query = new URLSearchParams({ user_id: userId });
     return apiJson<KycScopedExportPackage>(
       `/api/one/kyc/workflows/${encodeURIComponent(workflowId)}/consent-export?${query.toString()}`,
+      {
+        headers: authHeaders(vaultOwnerToken),
+      }
+    );
+  }
+
+  static getWorkflowConsentExports({
+    userId,
+    vaultOwnerToken,
+    workflowId,
+  }: AuthInput & { workflowId: string }): Promise<OneKycWorkflowConsentExportsResponse> {
+    const query = new URLSearchParams({ user_id: userId });
+    return apiJson<OneKycWorkflowConsentExportsResponse>(
+      `/api/one/kyc/workflows/${encodeURIComponent(workflowId)}/consent-exports?${query.toString()}`,
       {
         headers: authHeaders(vaultOwnerToken),
       }


### PR DESCRIPTION
## Summary

- Adds text-only multi-scope One Email KYC/disclosure detection for identity and financial requests.
- Adds explicit scope-selection API/UI before consent creation, with one bundled consent request per selected scope.
- Keeps strict client-side ZK: backend stores metadata/hashes only and frontend decrypts encrypted exports and builds deterministic drafts locally.
- Sends approved replies as Gmail reply-all using original thread metadata and records sent thread verification.
- Documents the updated API, agent, and consent-scope contracts.

## Validation

- `cd consent-protocol && python3 -m pytest tests/services/test_one_email_kyc_service.py tests/test_one_email_routes.py -q`
- `cd hushh-webapp && npm run test -- __tests__/services/one-kyc-service.test.ts __tests__/services/one-kyc-client-zk-service.test.ts`
- `cd hushh-webapp && npm run typecheck`
- `cd hushh-webapp && npm run lint -- app/one/kyc/page.tsx lib/services/one-kyc-service.ts lib/services/one-kyc-client-zk-service.ts __tests__/services/one-kyc-service.test.ts __tests__/services/one-kyc-client-zk-service.test.ts`
- `cd consent-protocol && python3 -m ruff check hushh_mcp/services/one_email_kyc_service.py api/routes/one/email.py tests/services/test_one_email_kyc_service.py tests/test_one_email_routes.py`
- `./bin/hushh docs verify`
- `cd hushh-webapp && npm run verify:voice-gateway`
- `./bin/hushh doctor --mode local` ran with existing local env activation/runtime-key warnings.

## Notes

- Full `cd consent-protocol && python3 -m pytest -q` was interrupted after the KYC suite and roughly half of the backend suite had passed because it hung outside the changed KYC surface.
- `./bin/hushh protocol sync` was required by pre-push; conflicts were resolved and the branch now carries the upstream sync merge commit.
- After PR merge, run `./bin/hushh protocol push` to sync consent-protocol upstream.
