### PR TITLE
fix(consent): harden token signature parsing

### DIFF
--- a/consent-protocol/hushh_mcp/consent/token.py
+++ b/consent-protocol/hushh_mcp/consent/token.py
@@ -130,7 +130,9 @@ def validate_token(
 
     try:
         prefix, signed_part = token_str.split(":", 1)
-        encoded, signature = signed_part.split(".")
+        if "." not in signed_part:
+         return False, "Malformed token", None
+        encoded, signature = signed_part.split(".", 1)
 
         if prefix != CONSENT_TOKEN_PREFIX:
             return False, "Invalid token prefix", None


### PR DESCRIPTION
## Summary

Hardens consent token signature parsing against malformed token payloads.

Prevents unsafe unpacking behavior during token validation by introducing defensive separator validation and bounded splitting.

## Problem

The consent token validator previously used:

```python
encoded, signature = signed_part.split(".")
```

This assumed token payloads always contained exactly one `.` separator.

Malformed tokens such as:

```text
a.b.c
```

could trigger:

```text
ValueError: too many values to unpack
```

resulting in parser instability during token validation.

## Solution

Added defensive validation for missing separators before parsing.

Replaced unrestricted splitting with bounded splitting using:

```python
signed_part.split(".", 1)
```

This safely handles malformed tokens while preserving existing valid token behavior.

## Files Updated

* consent-protocol/hushh_mcp/consent/token.py

## Validation

Verified:

* malformed tokens no longer trigger unpacking exceptions
* missing separators return clean validation failures
* valid tokens preserve existing behavior
* token validation flow remains backward compatible
