### PR TITLE
fix(consent): enforce strict token expiry boundaries

### DIFF
--- a/consent-protocol/hushh_mcp/consent/token.py
+++ b/consent-protocol/hushh_mcp/consent/token.py
@@ -183,7 +183,7 @@ def validate_token(
                     None,
                 )
 
-        if int(time.time() * 1000) > int(expires_at_str):
+        if int(time.time() * 1000) >= int(expires_at_str):
             return False, "Token expired", None
 
         # Commercial-flag gate (issue #30).

--- a/consent-protocol/hushh_mcp/consent/token.py
+++ b/consent-protocol/hushh_mcp/consent/token.py
@@ -130,7 +130,9 @@ def validate_token(
 
     try:
         prefix, signed_part = token_str.split(":", 1)
-        encoded, signature = signed_part.split(".")
+        if "." not in signed_part:
+            return False, "Malformed token", None
+        encoded, signature = signed_part.split(".", 1)
 
         if prefix != CONSENT_TOKEN_PREFIX:
             return False, "Invalid token prefix", None

--- a/consent-protocol/tests/test_token.py
+++ b/consent-protocol/tests/test_token.py
@@ -48,6 +48,22 @@ def test_token_expiry():
     assert valid is False
     assert reason == "Token expired"
 
+def test_token_expiry_boundary():
+    token_obj = issue_token(
+        USER_ID,
+        AGENT_ID,
+        VALID_SCOPE,
+        expires_in_ms=0,
+    )
+
+    valid, reason, _ = validate_token(token_obj.token, VALID_SCOPE)
+
+    assert valid is False
+    
+    
+    
+    assert reason == "Token expired"
+
 
 def test_token_revocation():
     token_obj = issue_token(USER_ID, AGENT_ID, VALID_SCOPE)

--- a/consent-protocol/tests/test_token.py
+++ b/consent-protocol/tests/test_token.py
@@ -48,6 +48,7 @@ def test_token_expiry():
     assert valid is False
     assert reason == "Token expired"
 
+
 def test_token_expiry_boundary():
     token_obj = issue_token(
         USER_ID,
@@ -59,10 +60,29 @@ def test_token_expiry_boundary():
     valid, reason, _ = validate_token(token_obj.token, VALID_SCOPE)
 
     assert valid is False
-    
-    
-    
     assert reason == "Token expired"
+
+
+def test_token_missing_signature_separator_is_malformed():
+    token_obj = issue_token(USER_ID, AGENT_ID, VALID_SCOPE)
+    prefix, signed_part = token_obj.token.split(":", 1)
+    encoded, _ = signed_part.split(".", 1)
+
+    valid, reason, parsed = validate_token(f"{prefix}:{encoded}", VALID_SCOPE)
+
+    assert valid is False
+    assert reason == "Malformed token"
+    assert parsed is None
+
+
+def test_token_extra_signature_separator_fails_without_crashing():
+    token_obj = issue_token(USER_ID, AGENT_ID, VALID_SCOPE)
+
+    valid, reason, parsed = validate_token(f"{token_obj.token}.extra", VALID_SCOPE)
+
+    assert valid is False
+    assert reason == "Invalid signature"
+    assert parsed is None
 
 
 def test_token_revocation():


### PR DESCRIPTION
## Summary

Enforces strict consent token expiry semantics by invalidating tokens at the exact expiration boundary.

Adds regression coverage for boundary-condition expiry validation.

## Problem

Consent token validation previously used:

```python
if int(time.time() * 1000) > int(expires_at_str):
```

This allowed tokens to remain valid when the current timestamp exactly matched the token expiration timestamp.

As a result, tokens configured with `expires_in_ms=0` still validated successfully at the boundary condition.

This created inconsistent expiry semantics and introduced an unintended off-by-one validity window for consent tokens.

## Solution

Updated expiry validation logic to enforce strict boundary semantics:

```python
>=
```

instead of:

```python
>
```

Added a dedicated regression test:

```python
test_token_expiry_boundary()
```

to verify tokens expiring exactly at the current timestamp are treated as expired.

## Files Updated

* `consent-protocol/hushh_mcp/consent/token.py`
* `consent-protocol/tests/test_token.py`

## Validation

Verified with:

```bash
python -m pytest consent-protocol/tests/test_token.py -v
```

Results:

* 7 tests passed
* expiry boundary regression test passes successfully

<img width="1099" height="587" alt="image" src="https://github.com/user-attachments/assets/34990a2b-e50c-425d-9771-a43b804a2d16" />

## Impact

This change improves consent token correctness and removes ambiguous expiry behavior at exact timestamp boundaries.
