### PR TITLE
refactor(api): centralize safe upstream response parsing

### DIFF
--- a/hushh-webapp/app/api/_utils/safe-response.ts
+++ b/hushh-webapp/app/api/_utils/safe-response.ts
@@ -1,0 +1,15 @@
+export async function safeParseResponse(response: Response) {
+  const contentType = response.headers.get("content-type") || "";
+
+  if (!contentType.includes("application/json")) {
+    const text = await response.text().catch(() => "");
+    return text ? { error: text } : {};
+  }
+
+  try {
+    return await response.json();
+  } catch {
+    const text = await response.text().catch(() => "");
+    return text ? { error: text } : {};
+  }
+}

--- a/hushh-webapp/app/api/consent/export-refresh/fail/route.ts
+++ b/hushh-webapp/app/api/consent/export-refresh/fail/route.ts
@@ -4,9 +4,26 @@ import { getPythonApiUrl } from "@/app/api/_utils/backend";
 
 const BACKEND_URL = getPythonApiUrl();
 
+async function safeParseResponse(response: Response) {
+  const contentType = response.headers.get("content-type") || "";
+
+  if (!contentType.includes("application/json")) {
+    const text = await response.text().catch(() => "");
+    return text ? { error: text } : {};
+  }
+
+  try {
+    return await response.json();
+  } catch {
+    const text = await response.text().catch(() => "");
+    return text ? { error: text } : {};
+  }
+}
+
 export async function POST(request: NextRequest) {
   try {
     const authHeader = request.headers.get("Authorization");
+
     if (!authHeader) {
       return NextResponse.json(
         { error: "Authorization header required" },
@@ -15,20 +32,30 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const response = await fetch(`${BACKEND_URL}/api/consent/export-refresh/fail`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: authHeader,
-      },
-      body: JSON.stringify(body),
+
+    const response = await fetch(
+      `${BACKEND_URL}/api/consent/export-refresh/fail`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: authHeader,
+        },
+        body: JSON.stringify(body),
+      }
+    );
+
+    const payload = await safeParseResponse(response);
+
+    return NextResponse.json(payload, {
+      status: response.status,
     });
-    const payload = await response
-      .json()
-      .catch(async () => ({ error: await response.text().catch(() => "") }));
-    return NextResponse.json(payload, { status: response.status });
   } catch (error) {
     console.error("[API] export-refresh/fail error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
   }
 }

--- a/hushh-webapp/app/api/consent/export-refresh/fail/route.ts
+++ b/hushh-webapp/app/api/consent/export-refresh/fail/route.ts
@@ -1,24 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-
+import { safeParseResponse } from "@/app/api/_utils/safe-response";
 import { getPythonApiUrl } from "@/app/api/_utils/backend";
 
 const BACKEND_URL = getPythonApiUrl();
 
-async function safeParseResponse(response: Response) {
-  const contentType = response.headers.get("content-type") || "";
 
-  if (!contentType.includes("application/json")) {
-    const text = await response.text().catch(() => "");
-    return text ? { error: text } : {};
-  }
-
-  try {
-    return await response.json();
-  } catch {
-    const text = await response.text().catch(() => "");
-    return text ? { error: text } : {};
-  }
-}
 
 export async function POST(request: NextRequest) {
   try {

--- a/hushh-webapp/app/api/consent/export-refresh/jobs/route.ts
+++ b/hushh-webapp/app/api/consent/export-refresh/jobs/route.ts
@@ -1,17 +1,24 @@
 import { NextRequest, NextResponse } from "next/server";
-
+import { safeParseResponse } from "@/app/api/_utils/safe-response";
 import { getPythonApiUrl } from "@/app/api/_utils/backend";
 
 const BACKEND_URL = getPythonApiUrl();
 
+
+
 export async function GET(request: NextRequest) {
   try {
     const userId = request.nextUrl.searchParams.get("userId") || "";
+
     if (!userId) {
-      return NextResponse.json({ error: "userId is required" }, { status: 400 });
+      return NextResponse.json(
+        { error: "userId is required" },
+        { status: 400 }
+      );
     }
 
     const authHeader = request.headers.get("Authorization");
+
     if (!authHeader) {
       return NextResponse.json(
         { error: "Authorization header required" },
@@ -27,12 +34,18 @@ export async function GET(request: NextRequest) {
         },
       }
     );
-    const payload = await response
-      .json()
-      .catch(async () => ({ error: await response.text().catch(() => "") }));
-    return NextResponse.json(payload, { status: response.status });
+
+    const payload = await safeParseResponse(response);
+
+    return NextResponse.json(payload, {
+      status: response.status,
+    });
   } catch (error) {
     console.error("[API] export-refresh/jobs error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
   }
 }

--- a/hushh-webapp/app/api/consent/export-refresh/upload/route.ts
+++ b/hushh-webapp/app/api/consent/export-refresh/upload/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-
+import { safeParseResponse } from "@/app/api/_utils/safe-response";
 import { getPythonApiUrl } from "@/app/api/_utils/backend";
 
 const BACKEND_URL = getPythonApiUrl();
@@ -23,9 +23,7 @@ export async function POST(request: NextRequest) {
       },
       body: JSON.stringify(body),
     });
-    const payload = await response
-      .json()
-      .catch(async () => ({ error: await response.text().catch(() => "") }));
+    const payload = await safeParseResponse(response);
     return NextResponse.json(payload, { status: response.status });
   } catch (error) {
     console.error("[API] export-refresh/upload error:", error);


### PR DESCRIPTION
## Summary

Centralizes safe upstream response parsing into a shared reusable API utility.

Removes duplicated defensive parsing logic across export refresh consent routes and standardizes malformed upstream response handling.

## Problem

Several consent export refresh proxy routes implemented inline response parsing fallback logic such as:

```ts
response.json().catch(async () => ({
  error: await response.text().catch(() => "")
}))
```

This caused:

* duplicated defensive parsing logic across routes
* inconsistent upstream response handling
* reduced maintainability
* fragile inline parsing behavior
* weaker standardization of proxy resilience patterns

## Solution

Introduced a shared reusable helper:

```ts
app/api/_utils/safe-response.ts
```

with:

```ts
safeParseResponse(response)
```

The helper:

* validates upstream content type
* safely parses JSON responses
* gracefully falls back to text responses
* preserves upstream debugging detail
* centralizes defensive parsing behavior

Migrated export refresh routes to use the shared utility.

## Files Updated

* `app/api/_utils/safe-response.ts`
* `app/api/consent/export-refresh/upload/route.ts`
* `app/api/consent/export-refresh/fail/route.ts`
* `app/api/consent/export-refresh/jobs/route.ts`

## Validation

Verified:

* valid JSON responses preserve existing behavior
* malformed upstream JSON is handled consistently
* text-based upstream responses are safely preserved
* duplicated parsing logic was removed successfully
* linting passes with zero warnings

## Impact

This refactor improves API maintainability, parsing consistency, and resilience across upstream proxy routes.
