### PR TITLE
fix(api): preserve upstream success status in Kai proxy responses

### DIFF
--- a/hushh-webapp/__tests__/api/kai/proxy-route.test.ts
+++ b/hushh-webapp/__tests__/api/kai/proxy-route.test.ts
@@ -54,6 +54,31 @@ describe("/api/kai/[...path] proxy", () => {
     expect(headers.get("Content-Type")).toBe("application/json");
   });
 
+  it("preserves upstream success status codes for JSON responses", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ created: true }), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    const req = createRequest("http://localhost:3000/api/kai/chat", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer vault_owner_token",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ user_id: "user_123", message: "hello" }),
+    });
+
+    const res = await kaiRoute.POST(req, {
+      params: Promise.resolve({ path: ["chat"] }),
+    });
+
+    expect(res.status).toBe(201);
+    await expect(res.json()).resolves.toEqual({ created: true });
+  });
+
   it("forwards Authorization for import multipart path without overriding multipart content-type", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ success: true }), {

--- a/hushh-webapp/app/api/kai/[...path]/route.ts
+++ b/hushh-webapp/app/api/kai/[...path]/route.ts
@@ -271,7 +271,7 @@ async function proxyRequest(request: NextRequest, params: { path: string[] }) {
       return withRequestIdJson(requestId, data, { status: response.status });
     }
 
-    return withRequestIdJson(requestId, data);
+    return withRequestIdJson(requestId, data, { status: response.status });
   } catch (error) {
     console.error(
       `[Kai API] request_id=${requestId} proxy_error path=${path}`,


### PR DESCRIPTION
# Description

This PR fixes the Kai API proxy so it preserves upstream **successful** HTTP status codes for JSON responses (for example, `201 Created`) instead of always returning `200`.  
Why: callers can rely on status semantics from backend contracts, and flattening to `200` can break that behavior.

## 📌 Impact Map (Required)

- Routes touched:
  - [ ] None
  - [x] Listed below:
    - `hushh-webapp/app/api/kai/[...path]/route.ts`

- API / schema / type changes:
  - [ ] None
  - [x] Listed below:
    - No payload/schema shape changes.
    - Response behavior change: successful JSON proxy responses now return upstream status code.

- Cache keys touched:
  - [x] None
  - [ ] Listed below:

- World-model domain summary effects:
  - [x] None
  - [ ] Listed below:

- Mobile parity impacts:
  - [x] None
  - [ ] Listed below:

- Docs updated (exact files):
  - [x] None
  - [ ] Listed below:

- Verification commands executed:
  - [ ] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm test` (targeted: `npm --prefix "hushh-webapp" run test -- __tests__/api/kai/proxy-route.test.ts`)
  - [ ] `cd hushh-webapp && npm run build`
  - [ ] `cd hushh-webapp && npm run ios:test`
  - [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000`

## 🛑 Tri-Flow Architecture Check

_Every feature must be implemented across all three layers or explicitly marked as not applicable._

- [x] **Web**: Next.js implementation (`app/api/...`)
- [x] **iOS**: Not applicable (no Capacitor/native plugin contract change)
- [x] **Android**: Not applicable (no Capacitor/native plugin contract change)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari) _(route unit test coverage via Vitest)_
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [ ] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

No UI change; backend proxy contract fix with regression test only.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? **No new access introduced**
- [x] If yes, have you implemented `checkConsentToken()`? **Not applicable**

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed (no dependency change in this PR)