### PR TITLE
fix: correct isinstance check order in _to_http_exception for Plaid webhook verification

### DIFF
--- a/consent-protocol/api/routes/kai/plaid.py
+++ b/consent-protocol/api/routes/kai/plaid.py
@@ -152,7 +152,7 @@ def _verify_user(token_data: dict[str, Any], requested_user_id: str) -> None:
 
 
 def _to_http_exception(error: Exception) -> HTTPException:
-    if isinstance(error, FundingOrchestrationError):
+    if isinstance(error, PlaidWebhookVerificationError):
         return HTTPException(
             status_code=error.status_code,
             detail={
@@ -160,8 +160,8 @@ def _to_http_exception(error: Exception) -> HTTPException:
                 "message": str(error),
                 "details": error.details,
             },
-        )
-    if isinstance(error, PlaidWebhookVerificationError):
+        )    
+    if isinstance(error, FundingOrchestrationError):
         return HTTPException(
             status_code=error.status_code,
             detail={


### PR DESCRIPTION
### Description

`PlaidWebhookVerificationError` is a subclass of `FundingOrchestrationError`. In `_to_http_exception` (`consent-protocol/api/routes/kai/plaid.py`), the `isinstance(error, FundingOrchestrationError)` check was ordered **before** the `isinstance(error, PlaidWebhookVerificationError)` check. Because Python's `isinstance` matches the first truthy branch, the `PlaidWebhookVerificationError` arm was dead code — it could never execute.

This fix reorders the two checks so the more-specific subclass is evaluated first, restoring the intended branch separation. While the accidental behaviour was *currently* correct (both branches returned the same 401 response structure), the dead branch was a silent landmine: any future maintainer adding special handling to the `PlaidWebhookVerificationError` branch (distinct alerting, stricter response body, rate-limiting forged requests) would find their code silently ignored on the live payment webhook path.

**Before:**
```python
if isinstance(error, FundingOrchestrationError):   # always matched — subclass caught here
    ...
if isinstance(error, PlaidWebhookVerificationError):  # dead code, never reached
    ...
```

**After:**
```python
if isinstance(error, PlaidWebhookVerificationError):  # specific subclass checked first
    ...
if isinstance(error, FundingOrchestrationError):      # base class catches the rest
    ...
```

---

### 📌 Impact Map (Required)

* Routes touched:
  * [x] Listed below:
    * `POST /plaid/webhook` — error handling path only; no behavioural change to happy path
* API / schema / type changes:
  * [x] None
* Cache keys touched:
  * [x] None
* World-model domain summary effects:
  * [x] None
* Mobile parity impacts:
  * [x] None — backend-only change; no client-facing response change
* Docs updated (exact files):
  * [x] None
* Verification commands executed:
  * [ ] `cd hushh-webapp && npm run typecheck`
  * [ ] `cd hushh-webapp && npm test`
  * [ ] `cd hushh-webapp && npm run build`
  * [ ] `cd hushh-webapp && npm run ios:test`
  * [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000`

---

### 🛑 Tri-Flow Architecture Check

* [x] Web: N/A — Python backend only (`consent-protocol/api/routes/kai/plaid.py`)
* [x] iOS: N/A
* [x] Android: N/A

---

### 🧪 Testing

* [ ] Tested on Web (Chrome/Safari)
* [ ] Tested on iOS Simulator/Device
* [ ] Tested on Android Emulator/Device
* [x] Commits are signed off (`git commit -s`)

---

### 📸 Screenshots / Video

NA

---

### 🛡️ Privacy & Consent

* [ ] Does this change access user data? **No** — error handler logic only; no data access added or modified.
* [ ] If yes, have you implemented `checkConsentToken()`? N/A

---

### 📜 Licensing

* [x] First-party changes remain Apache-2.0 compatible
* [x] Third-party notice impact reviewed when dependencies changed — no dependency changes