### PR TITLE
fix(run-manager): eliminate TOCTOU race in KaiAnalyzeRunManager.cancel_run

### DIFF
--- a/consent-protocol/api/routes/kai/run_manager.py
+++ b/consent-protocol/api/routes/kai/run_manager.py
@@ -312,7 +312,7 @@ class KaiAnalyzeRunManager:
             run.updated_at = _now_iso()
         async with run.condition:
             run.condition.notify_all()
-        return asyncio.run
+        return run
 
     async def stream_run_events(
         self,

--- a/consent-protocol/api/routes/kai/run_manager.py
+++ b/consent-protocol/api/routes/kai/run_manager.py
@@ -303,14 +303,16 @@ class KaiAnalyzeRunManager:
             return self._runs_by_id.get(run_id)
 
     async def cancel_run(self, *, run_id: str, user_id: str) -> Optional[AnalyzeRunRecord]:
-        run = await self.get_run(run_id)
-        if run is None or run.user_id != user_id:
-            return None
-        run.cancel_event.set()
-        run.updated_at = _now_iso()
+        async with self._lock:
+            await self._prune_locked()
+            run = self._runs_by_id.get(run_id)
+            if run is None or run.user_id != user_id:
+                return None
+            run.cancel_event.set()
+            run.updated_at = _now_iso()
         async with run.condition:
             run.condition.notify_all()
-        return run
+        return asyncio.run
 
     async def stream_run_events(
         self,


### PR DESCRIPTION
### Description

`cancel_run` in `KaiAnalyzeRunManager` had a time-of-check/time-of-use (TOCTOU) race condition. It called `get_run()` — which acquires `self._lock`, reads the run, then **releases the lock** — and only then mutated the run object outside any lock:

**Before:**
```python
async def cancel_run(self, *, run_id: str, user_id: str) -> Optional[AnalyzeRunRecord]:
    run = await self.get_run(run_id)           # lock acquired + released
    if run is None or run.user_id != user_id:
        return None
    run.cancel_event.set()                     # ← race window: _prune_locked can
    run.updated_at = _now_iso()                #   evict this run between here
    async with run.condition:                  #   and get_run's return
        run.condition.notify_all()
    return run
```

Between `get_run`'s return and `run.cancel_event.set()`, any concurrent request that called `start_or_get_active`, `get_active`, or `get_run` would trigger `_prune_locked()` (inside the lock). If the run was eligible for pruning, it would be evicted from `_runs_by_id` — but the local `run` reference would still have its `cancel_event` set, and the worker task would continue running indefinitely, burning LLM API tokens.

**After** :
```python
async def cancel_run(self, *, run_id: str, user_id: str) -> Optional[AnalyzeRunRecord]:
    async with self._lock:                     # single lock covers lookup + mutation
        await self._prune_locked()
        run = self._runs_by_id.get(run_id)
        if run is None or run.user_id != user_id:
            return None
        run.cancel_event.set()
        run.updated_at = _now_iso()
    async with run.condition:                  # notify outside lock (correct)
        run.condition.notify_all()
    return run                         
```

This matches the pattern already used correctly in `start_or_get_active`, which holds `self._lock` across the full check-then-act sequence.

---

### 📌 Impact Map (Required)

* Routes touched:
  * [x] Listed below:
    * `POST /kai/analyze/cancel` (or equivalent cancel endpoint) — behaviour change on cancellation under concurrent load; no change to happy-path or response schema
* API / schema / type changes:
  * [x] None
* Cache keys touched:
  * [x] None
* World-model domain summary effects:
  * [x] None
* Mobile parity impacts:
  * [x] None — Python backend only; no client-facing response change
* Docs updated (exact files):
  * [x] None
* Verification commands executed:
  * [ ] `cd hushh-webapp && npm run typecheck`
  * [ ] `cd hushh-webapp && npm test`
  * [ ] `cd hushh-webapp && npm run build`
  * [ ] `cd hushh-webapp && npm run ios:test`
  * [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000`

---

### 🛑 Tri-Flow Architecture Check

* [x] Web: N/A — Python backend concurrency fix only
* [x] iOS: N/A
* [x] Android: N/A

---

### 🧪 Testing

* [ ] Tested on Web (Chrome/Safari)
* [ ] Tested on iOS Simulator/Device
* [ ] Tested on Android Emulator/Device
* [x] Commits are signed off (`git commit -s`)

---

### 📸 Screenshots / Video

NA

---

### 🛡️ Privacy & Consent

* [ ] Does this change access user data? **No** — concurrency fix only; no data access added or modified.
* [ ] If yes, have you implemented `checkConsentToken()`? N/A

---

### 📜 Licensing

* [x] First-party changes remain Apache-2.0 compatible
* [x] Third-party notice impact reviewed when dependencies changed — no dependency changes