### PR TITLE
fix(developer-api): fix IDOR on /user-scopes and /consent-status — require active consent grant before returning user data

### DIFF
--- a/consent-protocol/api/routes/developer.py
+++ b/consent-protocol/api/routes/developer.py
@@ -753,7 +753,18 @@ async def get_user_scopes(
         token=token,
         authorization=authorization,
     )
-
+    consent_service = ConsentDBService()
+    active_grants = await consent_service.get_active_tokens(
+        user_id, agent_id=principal.agent_id
+    )
+    if not active_grants:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error_code": "CONSENT_REQUIRED",
+                "message": "No active consent grant exists for this user and developer app.",
+            },
+    )
     available_domains, scopes, scope_entries = await _get_user_scope_snapshot(
         user_id,
         detail=detail,
@@ -781,6 +792,18 @@ async def get_consent_status(
         request=request,
         token=token,
         authorization=authorization,
+    )
+    consent_service = ConsentDBService()
+    active_grants = await consent_service.get_active_tokens(
+        user_id, agent_id=principal.agent_id
+    )
+    if not active_grants:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error_code": "CONSENT_REQUIRED",
+                "message": "No active consent grant exists for this user and developer app.",
+            },
     )
     normalized_scope = normalize_scope(scope) if scope else None
 

--- a/consent-protocol/tests/test_developer_api_routes.py
+++ b/consent-protocol/tests/test_developer_api_routes.py
@@ -79,6 +79,62 @@ def test_user_scopes_requires_developer_key(monkeypatch):
     assert detail["error_code"] == "DEVELOPER_TOKEN_REQUIRED"
 
 
+def test_user_scopes_returns_403_when_no_consent_grant(monkeypatch):
+    """Consent gate: valid developer token but no active grant for this user → 403."""
+
+    class _NoGrantConsentDBService:
+        async def get_active_tokens(
+            self,
+            user_id: str,
+            agent_id: str | None = None,
+            scope: str | None = None,
+        ) -> list[dict]:
+            return []  # no active grants
+
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("DEVELOPER_API_ENABLED", "true")
+    monkeypatch.setattr(developer, "ConsentDBService", _NoGrantConsentDBService)
+    monkeypatch.setattr(
+        developer, "authenticate_developer_principal", lambda **_: _fake_principal()
+    )
+
+    client = TestClient(_build_app())
+    response = client.get("/api/v1/user-scopes/user_123?token=hdk_demo")
+
+    assert response.status_code == 403
+    detail = response.json()["detail"]
+    assert detail["error_code"] == "CONSENT_REQUIRED"
+
+
+def test_consent_status_returns_403_when_no_consent_grant(monkeypatch):
+    """Consent gate: valid developer token but no active grant for this user → 403."""
+
+    class _NoGrantConsentDBService:
+        async def get_active_tokens(
+            self,
+            user_id: str,
+            agent_id: str | None = None,
+            scope: str | None = None,
+        ) -> list[dict]:
+            return []  # no active grants
+
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("DEVELOPER_API_ENABLED", "true")
+    monkeypatch.setattr(developer, "ConsentDBService", _NoGrantConsentDBService)
+    monkeypatch.setattr(
+        developer, "authenticate_developer_principal", lambda **_: _fake_principal()
+    )
+
+    client = TestClient(_build_app())
+    response = client.get(
+        "/api/v1/consent-status?token=hdk_demo&user_id=user_123&scope=attr.financial.*"
+    )
+
+    assert response.status_code == 403
+    detail = response.json()["detail"]
+    assert detail["error_code"] == "CONSENT_REQUIRED"
+
+
 class _EmptyScopeGenerator:
     async def get_available_scopes(self, user_id: str) -> list[str]:
         return []
@@ -98,6 +154,22 @@ class _EmptyPkmService:
         return _EmptyIndex()
 
 
+class _FakeConsentDBServiceWithGrant:
+    """Simulates a developer that already holds an active consent grant for the user.
+
+    Used by tests that exercise token auth / PKM snapshot logic and don't care
+    about the consent-gate itself — they just need it to pass.
+    """
+
+    async def get_active_tokens(
+        self,
+        user_id: str,
+        agent_id: str | None = None,
+        scope: str | None = None,
+    ) -> list[dict]:
+        return [{"scope": "attr.*", "agent_id": agent_id}]
+
+
 def test_user_scopes_accepts_authorization_bearer_header(monkeypatch):
     monkeypatch.setenv("ENVIRONMENT", "development")
     monkeypatch.setenv("DEVELOPER_API_ENABLED", "true")
@@ -114,6 +186,7 @@ def test_user_scopes_accepts_authorization_bearer_header(monkeypatch):
         _fake_authenticate_token,
     )
     monkeypatch.setattr(developer, "get_pkm_service", lambda: _EmptyPkmService())
+    monkeypatch.setattr(developer, "ConsentDBService", _FakeConsentDBServiceWithGrant)
 
     client = TestClient(_build_app())
     response = client.get(
@@ -163,6 +236,7 @@ def test_user_scopes_authorization_bearer_takes_precedence_over_query(monkeypatc
         _fake_authenticate_token,
     )
     monkeypatch.setattr(developer, "get_pkm_service", lambda: _EmptyPkmService())
+    monkeypatch.setattr(developer, "ConsentDBService", _FakeConsentDBServiceWithGrant)
 
     client = TestClient(_build_app())
     response = client.get(
@@ -186,6 +260,7 @@ def test_user_scopes_query_token_logs_url_leak_warning(monkeypatch, caplog):
         lambda self, *_args, **_kwargs: _fake_principal(),
     )
     monkeypatch.setattr(developer, "get_pkm_service", lambda: _EmptyPkmService())
+    monkeypatch.setattr(developer, "ConsentDBService", _FakeConsentDBServiceWithGrant)
 
     client = TestClient(_build_app())
     with caplog.at_level(_logging.WARNING, logger="api.developer_auth"):
@@ -279,6 +354,7 @@ def test_user_scopes_returns_discovered_domains(monkeypatch):
     monkeypatch.setenv("ENVIRONMENT", "development")
     monkeypatch.setenv("DEVELOPER_API_ENABLED", "true")
     monkeypatch.setattr(developer, "get_pkm_service", lambda: _FakePkmService())
+    monkeypatch.setattr(developer, "ConsentDBService", _FakeConsentDBServiceWithGrant)
     monkeypatch.setattr(
         developer, "authenticate_developer_principal", lambda **_: _fake_principal()
     )
@@ -364,6 +440,7 @@ def test_user_scopes_verbose_returns_path_level_entries(monkeypatch):
     monkeypatch.setenv("ENVIRONMENT", "development")
     monkeypatch.setenv("DEVELOPER_API_ENABLED", "true")
     monkeypatch.setattr(developer, "get_pkm_service", lambda: _FakePkmService())
+    monkeypatch.setattr(developer, "ConsentDBService", _FakeConsentDBServiceWithGrant)
     monkeypatch.setattr(
         developer, "authenticate_developer_principal", lambda **_: _fake_principal()
     )
@@ -777,6 +854,15 @@ def test_request_consent_marks_scope_upgrade_metadata(monkeypatch):
 
 def test_get_consent_status_uses_covering_active_token(monkeypatch):
     class _FakeConsentDBService:
+        async def get_active_tokens(
+            self,
+            user_id: str,
+            agent_id: str | None = None,
+            scope: str | None = None,
+        ) -> list[dict]:
+            # consent gate: simulate an active grant so the endpoint proceeds
+            return [{"scope": "attr.financial.analytics.*", "agent_id": agent_id}]
+
         async def get_covering_active_tokens(
             self,
             user_id: str,


### PR DESCRIPTION
### Description

`GET /user-scopes/{user_id}` and `GET /consent-status` were verifying the developer API token but not checking whether the authenticated developer app had an active consent grant for the requested user. Any developer with a valid token could pass any `user_id` and receive that user's full PKM data domain inventory (financial, email, identity etc.) without the user's knowledge.

Added a consent gate in both endpoints using the already-existing `ConsentDBService.get_active_tokens(user_id, agent_id=principal.agent_id)`. If no active, non-expired, non-revoked grant exists between the developer app and the user, the endpoint now returns `403 CONSENT_REQUIRED` instead of the user's data.

---

### 📌 Impact Map (Required)

* Routes touched:
  * [x] Listed below:
    * `GET /user-scopes/{user_id}` — returns `403 CONSENT_REQUIRED` if no active grant exists
    * `GET /consent-status` — same guard applied
* API / schema / type changes:
  * [x] Listed below:
    * New `403` response on both endpoints: `{ "error_code": "CONSENT_REQUIRED", "message": "No active consent grant exists for this user and developer app." }`
    * No change to existing `200` success response schema
* Cache keys touched:
  * [x] None
* World-model domain summary effects:
  * [x] None
* Mobile parity impacts:
  * [x] None — backend only; mobile clients calling these endpoints on behalf of a developer app should already have completed the consent flow
* Docs updated (exact files):
  * [x] None
* Verification commands executed:
  * [ ] `cd hushh-webapp && npm run typecheck`
  * [ ] `cd hushh-webapp && npm test`
  * [ ] `cd hushh-webapp && npm run build`
  * [ ] `cd hushh-webapp && npm run ios:test`
  * [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000`

---

### 🛑 Tri-Flow Architecture Check

* [x] Web: N/A — Python backend only; developer API is server-to-server
* [x] iOS: N/A
* [x] Android: N/A

---

### 🧪 Testing

* [ ] Tested on Web (Chrome/Safari)
* [ ] Tested on iOS Simulator/Device
* [ ] Tested on Android Emulator/Device
* [x] Commits are signed off (`git commit -s`)

---

### 📸 Screenshots / Video

NA

---

### 🛡️ Privacy & Consent

* [x] Does this change access user data? Yes — `get_active_tokens` reads from `consent_audit` to verify a grant exists, but no user PKM data is exposed unless consent is confirmed.
* [x] If yes, have you implemented `checkConsentToken()`? This PR is the consent enforcement — it adds the missing gate.

---

### 📜 Licensing

* [x] First-party changes remain Apache-2.0 compatible
* [x] Third-party notice impact reviewed when dependencies changed — no dependency changes