### PR TITLE
fix(broker-funding): replace non-deterministic uuid4() fallback with deterministic idempotency key to prevent duplicate trade orders

### DIFF
--- a/consent-protocol/hushh_mcp/services/broker_funding_service.py
+++ b/consent-protocol/hushh_mcp/services/broker_funding_service.py
@@ -108,6 +108,30 @@ def _utcnow_iso() -> str:
     return _utcnow().isoformat().replace("+00:00", "Z")
 
 
+_TRADE_IDEMPOTENCY_WINDOW_SECONDS = 300  # 5-minute dedup window for retries
+
+
+def _deterministic_trade_idempotency_key(
+    user_id: str,
+    symbol: str,
+    side: str,
+    notional_text: str,
+    *,
+    window_seconds: int = _TRADE_IDEMPOTENCY_WINDOW_SECONDS,
+) -> str:
+    """Generate a stable idempotency key from trade request fields + a time bucket.
+
+    Retries within `window_seconds` produce the same key and are deduplicated.
+    New requests after the window produce a different key and are treated as
+    distinct orders. This replaces the uuid4() fallback which generated a new key
+    on every call, defeating deduplication for callers that omit the key.
+    """
+    bucket = int(_utcnow().timestamp()) // window_seconds
+    raw = f"{user_id}:{symbol}:{side}:{notional_text}:{bucket}"
+    digest = hashlib.sha256(raw.encode()).hexdigest()[:32]
+    return f"funded_trade_{digest}"
+
+
 def _clean_text(value: Any, *, default: str = "") -> str:
     if not isinstance(value, str):
         return default
@@ -3791,8 +3815,13 @@ class BrokerFundingService:
             account_id=funding_account_id,
         )
 
-        resolved_trade_idempotency = (
-            _clean_text(trade_idempotency_key) or f"funded_trade_{uuid.uuid4().hex}"
+        resolved_trade_idempotency = _clean_text(trade_idempotency_key) or (
+            _deterministic_trade_idempotency_key(
+                user_id,
+                cleaned_symbol,
+                cleaned_side,
+                notional_text,
+            )
         )
         deduped_intent = self._fetch_trade_intent_by_idempotency(
             user_id=user_id,


### PR DESCRIPTION
### Description

`trade_idempotency_key` is optional in `create_funded_trade_intent`. When omitted, the fallback was `uuid4()` — a different value on every call — making the deduplication check (`_fetch_trade_intent_by_idempotency`) useless for retries. On a flaky connection, a client retry would bypass dedup and submit a second duplicate trade to Alpaca. For sell orders, this means a user could silently sell twice their intended position.

Added `_deterministic_trade_idempotency_key()` which derives a stable key from `user_id + symbol + side + notional_usd` combined with a 5-minute time bucket (SHA-256). Retries within the window hash to the same key and are correctly deduplicated. After the window, the key rotates so genuinely new trades are treated as distinct orders. `hashlib` was already imported — no new dependencies.

---

### 📌 Impact Map (Required)

* Routes touched:
  * [x] Listed below:
    * `POST /kai/plaid/funded-trade` — behaviour change only when `trade_idempotency_key` is **not** supplied; no change when key is provided
* API / schema / type changes:
  * [x] None
* Cache keys touched:
  * [x] None
* World-model domain summary effects:
  * [x] None
* Mobile parity impacts:
  * [x] None — Python backend only; mobile clients that already supply `trade_idempotency_key` are unaffected
* Docs updated (exact files):
  * [x] None
* Verification commands executed:
  * [ ] `cd hushh-webapp && npm run typecheck`
  * [ ] `cd hushh-webapp && npm test`
  * [ ] `cd hushh-webapp && npm run build`
  * [ ] `cd hushh-webapp && npm run ios:test`
  * [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000`

---

### 🛑 Tri-Flow Architecture Check

* [x] Web: N/A — Python backend only
* [x] iOS: N/A
* [x] Android: N/A

---

### 🧪 Testing

* [ ] Tested on Web (Chrome/Safari)
* [ ] Tested on iOS Simulator/Device
* [ ] Tested on Android Emulator/Device
* [x] Commits are signed off (`git commit -s`)

---

### 📸 Screenshots / Video

NA

---

### 🛡️ Privacy & Consent

* [x] Does this change access user data? No — idempotency key generation only; no user data read or written beyond what the function already did.
* [ ] If yes, have you implemented `checkConsentToken()`? N/A

---

### 📜 Licensing

* [x] First-party changes remain Apache-2.0 compatible
* [x] Third-party notice impact reviewed when dependencies changed — no new dependencies (`hashlib` already imported)