### PR TITLE
fix(vault-web): close parallel all-zero key and zero-salt coercion bug

### DIFF
--- a/hushh-webapp/__tests__/streaming/sse-parser-oom.test.ts
+++ b/hushh-webapp/__tests__/streaming/sse-parser-oom.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import { parseSSEChunk } from "@/lib/streaming/sse-parser";
+
+describe("parseSSEChunk - Memory Limit Circuit Breaker", () => {
+  it("processes normal chunks correctly under the limit", () => {
+    const chunk = "data: {\"test\": 1}\n\n";
+    const result = parseSSEChunk(chunk, "");
+    
+    expect(result.parsedEvents).toHaveLength(1);
+    expect(result.leftoverBuffer).toBe("");
+  });
+
+  it("safely triggers the circuit breaker on strings exceeding 1MB", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    
+    // Create a massive chunk slightly over 1MB without any newlines
+    const massiveChunkSize = (1024 * 1024) + 10;
+    const maliciousChunk = "A".repeat(massiveChunkSize);
+    
+    const result = parseSSEChunk(maliciousChunk, "");
+    
+    // The buffer should be wiped clean, not appended to
+    expect(result.leftoverBuffer).toBe("");
+    expect(result.parsedEvents).toHaveLength(0);
+    
+    // Ensure the system logged the warning
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("SSE Buffer overflow threshold reached")
+    );
+    
+    consoleSpy.mockRestore();
+  });
+
+  it("prevents cumulative buffer growth over 1MB", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    
+    const existingBuffer = "A".repeat(1024 * 1020); // 1020 KB
+    const newChunk = "B".repeat(1024 * 5); // 5 KB (pushes total over 1024 KB)
+    
+    const result = parseSSEChunk(newChunk, existingBuffer);
+    
+    expect(result.leftoverBuffer).toBe("");
+    expect(consoleSpy).toHaveBeenCalled();
+    
+    consoleSpy.mockRestore();
+  });
+
+  it("skips empty JSON string payloads without throwing", () => {
+    const emptyPayloadChunk = "data: \n\ndata: {\"valid\": true}\n\n";
+    const result = parseSSEChunk(emptyPayloadChunk, "");
+    
+    // Should skip the empty "data: " and only parse the valid object
+    expect(result.parsedEvents).toHaveLength(1);
+    expect(result.parsedEvents[0]).toEqual({ valid: true });
+  });
+});

--- a/hushh-webapp/lib/streaming/sse-parser.ts
+++ b/hushh-webapp/lib/streaming/sse-parser.ts
@@ -54,11 +54,9 @@ export function parseSSEChunk(chunk: string, existingBuffer: string = ''): SSEBl
  * Legacy wrapper to support existing imports.
  * @deprecated Use parseSSEChunk with buffer state for robust streaming.
  */
-export function parseSSEBlocks(chunk: string, existingBuffer: string = '') {
-  // Call our new, safe function
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function parseSSEBlocks(chunk: string, existingBuffer: string = ''): { events: any[]; remainder: string } {
   const result = parseSSEChunk(chunk, existingBuffer);
-  
-  // Translate the new property names back into the old names the app expects
   return {
     events: result.parsedEvents,
     remainder: result.leftoverBuffer

--- a/hushh-webapp/lib/streaming/sse-parser.ts
+++ b/hushh-webapp/lib/streaming/sse-parser.ts
@@ -1,45 +1,38 @@
-import type { ParsedSSEFrame } from "./kai-stream-types";
 
-export interface ParseSSEBlocksResult {
-  events: ParsedSSEFrame[];
-  remainder: string;
+
+export interface SSEBlockResult {
+  parsedEvents: any[];
+  leftoverBuffer: string;
 }
 
-export function parseSSEBlocks(chunk: string, remainder = ""): ParseSSEBlocksResult {
-  const normalized = (remainder + chunk).replace(/\r\n/g, "\n");
-  const blocks = normalized.split("\n\n");
-  const nextRemainder = blocks.pop() ?? "";
 
-  const events: ParsedSSEFrame[] = [];
-  for (const rawBlock of blocks) {
-    if (!rawBlock.trim()) continue;
 
-    let eventName: string | undefined;
-    let eventId: string | undefined;
-    const dataLines: string[] = [];
+export function parseSSEChunk(chunk: string, existingBuffer: string = ''): SSEBlockResult {
+  const combined = existingBuffer + chunk;
+  
+ 
+  const blocks = combined.split('\n\n');
 
-    const lines = rawBlock.split("\n");
-    for (const line of lines) {
-      if (!line || line.startsWith(":")) continue;
-      if (line.startsWith("event:")) {
-        eventName = line.slice(6).trim();
-      } else if (line.startsWith("id:")) {
-        eventId = line.slice(3).trim();
-      } else if (line.startsWith("data:")) {
-        dataLines.push(line.slice(5).trimStart());
+  const isComplete = combined.endsWith('\n\n');
+  const leftoverBuffer = isComplete ? '' : (blocks.pop() || '');
+
+  const parsedEvents = blocks
+    .map(block => block.trim())
+    .filter(block => block.startsWith('data: '))
+    .map(block => {
+      const jsonStr = block.replace(/^data:\s*/, '');
+      
+      // Standard SSE end-of-stream marker
+      if (jsonStr === '[DONE]') return null;
+      
+      try {
+        return JSON.parse(jsonStr);
+      } catch (e) {
+        console.warn('SSE JSON Parse skip (fragmented frame):', jsonStr);
+        return null;
       }
-    }
+    })
+    .filter(Boolean); // Removes the nulls
 
-    if (!eventName || dataLines.length === 0) {
-      continue;
-    }
-
-    events.push({
-      event: eventName,
-      id: eventId,
-      data: dataLines.join("\n"),
-    });
-  }
-
-  return { events, remainder: nextRemainder };
+  return { parsedEvents, leftoverBuffer };
 }

--- a/hushh-webapp/lib/streaming/sse-parser.ts
+++ b/hushh-webapp/lib/streaming/sse-parser.ts
@@ -54,6 +54,13 @@ export function parseSSEChunk(chunk: string, existingBuffer: string = ''): SSEBl
  * Legacy wrapper to support existing imports.
  * @deprecated Use parseSSEChunk with buffer state for robust streaming.
  */
-export function parseSSEBlocks(chunk: string) {
-  return parseSSEChunk(chunk, '').parsedEvents;
+export function parseSSEBlocks(chunk: string, existingBuffer: string = '') {
+  // Call our new, safe function
+  const result = parseSSEChunk(chunk, existingBuffer);
+  
+  // Translate the new property names back into the old names the app expects
+  return {
+    events: result.parsedEvents,
+    remainder: result.leftoverBuffer
+  };
 }

--- a/hushh-webapp/lib/streaming/sse-parser.ts
+++ b/hushh-webapp/lib/streaming/sse-parser.ts
@@ -1,38 +1,52 @@
-
+// hushh-webapp/lib/streaming/sse-parser.ts
 
 export interface SSEBlockResult {
-  parsedEvents: any[];
+  parsedEvents: Record<string, unknown>[];
   leftoverBuffer: string;
 }
 
+// 1MB hard limit on unparsed chunks to prevent OOM tab crashes
+const MAX_BUFFER_SIZE = 1024 * 1024;
 
-
+/**
+ * Robustly parses SSE chunks. If a network chunk ends mid-message, 
+ * it saves the fragment to be prepended to the next chunk.
+ */
 export function parseSSEChunk(chunk: string, existingBuffer: string = ''): SSEBlockResult {
+  // Circuit Breaker: Prevent infinite memory growth on malformed streams
+  if (existingBuffer.length + chunk.length > MAX_BUFFER_SIZE) {
+    console.error('SSE Buffer overflow threshold reached. Forcefully dropping fragment to prevent OOM crash.');
+    return { parsedEvents: [], leftoverBuffer: '' };
+  }
+
   const combined = existingBuffer + chunk;
   
- 
+  // SSE events are separated by double newlines
   const blocks = combined.split('\n\n');
 
+  // If the chunk didn't end with double newlines, the last block is incomplete
   const isComplete = combined.endsWith('\n\n');
-  const leftoverBuffer = isComplete ? '' : (blocks.pop() || '');
+  const leftoverBuffer = isComplete ? '' : (blocks.pop() ?? '');
 
-  const parsedEvents = blocks
-    .map(block => block.trim())
-    .filter(block => block.startsWith('data: '))
-    .map(block => {
-      const jsonStr = block.replace(/^data:\s*/, '');
+  const parsedEvents: Record<string, unknown>[] = [];
+
+  for (const block of blocks) {
+    const trimmedBlock = block.trim();
+    if (trimmedBlock.startsWith('data: ')) {
+      const jsonStr = trimmedBlock.replace(/^data:\s*/, '');
       
-      // Standard SSE end-of-stream marker
-      if (jsonStr === '[DONE]') return null;
-      
+      if (jsonStr === '[DONE]') continue;
+      if (jsonStr.trim().length === 0) continue; // Skip empty payloads to save CPU cycles
+
       try {
-        return JSON.parse(jsonStr);
+        const parsed = JSON.parse(jsonStr) as Record<string, unknown>;
+        parsedEvents.push(parsed);
       } catch (e) {
-        console.warn('SSE JSON Parse skip (fragmented frame):', jsonStr);
-        return null;
+        // We don't log 'e' to avoid unsafe-assignment errors in CI
+        console.warn('SSE JSON Parse skip (fragment):', jsonStr);
       }
-    })
-    .filter(Boolean); // Removes the nulls
+    }
+  }
 
   return { parsedEvents, leftoverBuffer };
 }

--- a/hushh-webapp/lib/streaming/sse-parser.ts
+++ b/hushh-webapp/lib/streaming/sse-parser.ts
@@ -50,3 +50,10 @@ export function parseSSEChunk(chunk: string, existingBuffer: string = ''): SSEBl
 
   return { parsedEvents, leftoverBuffer };
 }
+/**
+ * Legacy wrapper to support existing imports.
+ * @deprecated Use parseSSEChunk with buffer state for robust streaming.
+ */
+export function parseSSEBlocks(chunk: string) {
+  return parseSSEChunk(chunk, '').parsedEvents;
+}

--- a/hushh-webapp/lib/streaming/sse-parser.ts
+++ b/hushh-webapp/lib/streaming/sse-parser.ts
@@ -1,4 +1,10 @@
 // hushh-webapp/lib/streaming/sse-parser.ts
+import type { ParsedSSEFrame } from "./kai-stream-types";
+
+export interface ParseSSEBlocksResult {
+  events: ParsedSSEFrame[];
+  remainder: string;
+}
 
 export interface SSEBlockResult {
   parsedEvents: Record<string, unknown>[];
@@ -9,55 +15,75 @@ export interface SSEBlockResult {
 const MAX_BUFFER_SIZE = 1024 * 1024;
 
 /**
+ * Robustly parses standard SSE chunks into discrete frames.
+ * Handles fragmentation by keeping a remainder buffer.
+ */
+export function parseSSEBlocks(chunk: string, existingBuffer: string = ''): ParseSSEBlocksResult {
+  if (existingBuffer.length + chunk.length > MAX_BUFFER_SIZE) {
+    console.error('SSE Buffer overflow threshold reached. Forcefully dropping fragment to prevent OOM crash.');
+    return { events: [], remainder: '' };
+  }
+
+  const combined = existingBuffer + chunk;
+  const blocks = combined.split('\n\n');
+
+  const isComplete = combined.endsWith('\n\n');
+  const remainder = isComplete ? '' : (blocks.pop() ?? '');
+
+  const events: ParsedSSEFrame[] = [];
+
+  for (const block of blocks) {
+    const trimmedBlock = block.trim();
+    if (!trimmedBlock) continue;
+
+    const lines = trimmedBlock.split('\n');
+    let eventName: string | undefined = undefined;
+    let dataStr = '';
+    let idStr: string | undefined = undefined;
+
+    for (const line of lines) {
+      if (line.startsWith('event:')) {
+        eventName = line.replace(/^event:\s*/, '');
+      } else if (line.startsWith('data:')) {
+        const dataPart = line.replace(/^data:\s*/, '');
+        dataStr = dataStr ? dataStr + '\n' + dataPart : dataPart;
+      } else if (line.startsWith('id:')) {
+        idStr = line.replace(/^id:\s*/, '');
+      }
+    }
+
+    if (eventName !== undefined || dataStr) {
+      const frame: Record<string, string> = { data: dataStr };
+      if (eventName !== undefined) frame.event = eventName;
+      if (idStr !== undefined) frame.id = idStr;
+      
+      events.push(frame as unknown as ParsedSSEFrame);
+    }
+  }
+
+  return { events, remainder };
+}
+
+/**
+ * Convenience function for JSON-only streams without event types.
  * Robustly parses SSE chunks. If a network chunk ends mid-message, 
  * it saves the fragment to be prepended to the next chunk.
  */
 export function parseSSEChunk(chunk: string, existingBuffer: string = ''): SSEBlockResult {
-  // Circuit Breaker: Prevent infinite memory growth on malformed streams
-  if (existingBuffer.length + chunk.length > MAX_BUFFER_SIZE) {
-    console.error('SSE Buffer overflow threshold reached. Forcefully dropping fragment to prevent OOM crash.');
-    return { parsedEvents: [], leftoverBuffer: '' };
-  }
-
-  const combined = existingBuffer + chunk;
-  
-  // SSE events are separated by double newlines
-  const blocks = combined.split('\n\n');
-
-  // If the chunk didn't end with double newlines, the last block is incomplete
-  const isComplete = combined.endsWith('\n\n');
-  const leftoverBuffer = isComplete ? '' : (blocks.pop() ?? '');
-
+  const result = parseSSEBlocks(chunk, existingBuffer);
   const parsedEvents: Record<string, unknown>[] = [];
 
-  for (const block of blocks) {
-    const trimmedBlock = block.trim();
-    if (trimmedBlock.startsWith('data: ')) {
-      const jsonStr = trimmedBlock.replace(/^data:\s*/, '');
-      
-      if (jsonStr === '[DONE]') continue;
-      if (jsonStr.trim().length === 0) continue; // Skip empty payloads to save CPU cycles
+  for (const frame of result.events) {
+    if (frame.data === '[DONE]') continue;
+    if (frame.data.trim().length === 0) continue;
 
-      try {
-        const parsed = JSON.parse(jsonStr) as Record<string, unknown>;
-        parsedEvents.push(parsed);
-      } catch (_e) { // Changed 'e' to '_e' to pass strict linting
-        console.warn('SSE JSON Parse skip (fragment):', jsonStr);
-      }
+    try {
+      const parsed = JSON.parse(frame.data) as Record<string, unknown>;
+      parsedEvents.push(parsed);
+    } catch (_e) {
+      console.warn('SSE JSON Parse skip (fragment):', frame.data);
     }
   }
 
-  return { parsedEvents, leftoverBuffer };
-}
-
-/**
- * Legacy wrapper to support existing imports.
- * @deprecated Use parseSSEChunk with buffer state for robust streaming.
- */
-export function parseSSEBlocks(chunk: string, existingBuffer: string = ''): { events: any[]; remainder: string } {
-  const result = parseSSEChunk(chunk, existingBuffer);
-  return {
-    events: result.parsedEvents,
-    remainder: result.leftoverBuffer
-  };
+  return { parsedEvents, leftoverBuffer: result.remainder };
 }

--- a/hushh-webapp/lib/streaming/sse-parser.ts
+++ b/hushh-webapp/lib/streaming/sse-parser.ts
@@ -41,8 +41,7 @@ export function parseSSEChunk(chunk: string, existingBuffer: string = ''): SSEBl
       try {
         const parsed = JSON.parse(jsonStr) as Record<string, unknown>;
         parsedEvents.push(parsed);
-      } catch (e) {
-        // We don't log 'e' to avoid unsafe-assignment errors in CI
+      } catch (_e) { // Changed 'e' to '_e' to pass strict linting
         console.warn('SSE JSON Parse skip (fragment):', jsonStr);
       }
     }
@@ -50,11 +49,11 @@ export function parseSSEChunk(chunk: string, existingBuffer: string = ''): SSEBl
 
   return { parsedEvents, leftoverBuffer };
 }
+
 /**
  * Legacy wrapper to support existing imports.
  * @deprecated Use parseSSEChunk with buffer state for robust streaming.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function parseSSEBlocks(chunk: string, existingBuffer: string = ''): { events: any[]; remainder: string } {
   const result = parseSSEChunk(chunk, existingBuffer);
   return {


### PR DESCRIPTION
Context & The Bug:
This PR closes the identical critical security bug addressed in PR #8 (lib/vault/encrypt.ts), but within its parallel implementation: lib/capacitor/plugins/vault-web.ts. This file serves as the Capacitor web fallback and handles every browser-mode user's vault encryption path.

The underlying issue stems from the pattern keyHex.match(/.{1,2}/g)!.map((byte) => parseInt(byte, 16)). For non-hex characters, parseInt("zz", 16) evaluates to NaN, and new Uint8Array([NaN, ...]) silently coerces NaN to 0.

This left three sites vulnerable in the web implementation:

encryptData: Malformed hex resulted in an all-zero AES-256 encryption key.

decryptData: Malformed hex resulted in an all-zero AES-256 decryption key.

deriveKey: Malformed hex produced a zero-filled PBKDF2 salt of arbitrary length, neutralizing PBKDF2's primary defense against rainbow-table precomputation attacks.

Changes Made:

Encryption/Decryption Guardrails: encryptData and decryptData now call validateVaultKeyHex (the helper exported from encrypt.ts in PR #8) strictly before any cryptographic operations occur.

Salt Parsing: deriveKey now utilizes a new local parseHexString helper that actively rejects non-string, empty, odd-length, and non-hex inputs with clear Type/Range errors.

Cross-Implementation Parity Testing: Added a comprehensive validation suite (__tests__/lib/capacitor/vault-web-validation.test.ts) that asserts encrypt.ts and vault-web.ts reject the exact same malformed inputs, ensuring the two implementations cannot drift in their security posture without CI catching it.

Verification:

[x] npm run typecheck passes cleanly.

[x] npm run lint yields 0 warnings.

[x] npx vitest run __tests__/lib/capacitor/vault-web-validation.test.ts passes (13/13 tests).

[x] npm run test:ci passes with no regressions across the suite.

Note on Stacked PRs:
This branch was created from the previous fix. Once earlier PRs in the chain merge to main, this PR's diff against main will collapse to just the vault-web.ts and validation test files. This PR relies on the validateVaultKeyHex export established in PR #8.