### PR TITLE
feat: add offline network recovery UX

### DIFF
--- a/hushh-webapp/app/layout.tsx
+++ b/hushh-webapp/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from "next";
+import { NetworkRecoveryBanner } from "@/components/system/network-recovery-banner";
 import { Geist, Geist_Mono, Inter } from "next/font/google";
 import Script from "next/script";
 import "./globals.css";
@@ -102,10 +103,11 @@ export default function RootLayout({
         ) : null}
       </head>
       <RootLayoutClient
-        fontClasses={`${geistSans.variable} ${geistMono.variable} ${headingSans.variable}`}
-      >
-        {children}
-      </RootLayoutClient>
+  fontClasses={`${geistSans.variable} ${geistMono.variable} ${headingSans.variable}`}
+>
+  <NetworkRecoveryBanner />
+  {children}
+</RootLayoutClient>
     </html>
   );
 }

--- a/hushh-webapp/components/system/network-recovery-banner.tsx
+++ b/hushh-webapp/components/system/network-recovery-banner.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { WifiOff } from "lucide-react";
+
+import { useNetworkStatus } from "@/hooks/use-network-status";
+
+export function NetworkRecoveryBanner() {
+  const { isOnline } = useNetworkStatus();
+
+  if (isOnline) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed inset-x-4 bottom-4 z-50 rounded-2xl border border-amber-500/20 bg-amber-500/10 p-4 shadow-[var(--app-card-shadow-feature)] backdrop-blur md:left-auto md:right-6 md:w-[420px]"
+    >
+      <div className="flex items-start gap-3">
+        <div className="rounded-full bg-amber-500/15 p-2">
+          <WifiOff className="h-5 w-5 text-amber-700 dark:text-amber-300" />
+        </div>
+
+        <div className="space-y-1">
+          <p className="text-sm font-semibold text-foreground">
+            You&apos;re offline
+          </p>
+
+          <p className="text-sm leading-6 text-muted-foreground">
+            Some actions may not sync until your connection is restored. We&apos;ll automatically resume when you&apos;re back online.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/hushh-webapp/hooks/use-network-status.ts
+++ b/hushh-webapp/hooks/use-network-status.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useNetworkStatus() {
+  const [isOnline, setIsOnline] = useState(true);
+
+  useEffect(() => {
+    const updateNetworkStatus = () => {
+      setIsOnline(navigator.onLine);
+    };
+
+    updateNetworkStatus();
+
+    window.addEventListener("online", updateNetworkStatus);
+    window.addEventListener("offline", updateNetworkStatus);
+
+    return () => {
+      window.removeEventListener("online", updateNetworkStatus);
+      window.removeEventListener("offline", updateNetworkStatus);
+    };
+  }, []);
+
+  return { isOnline };
+}


### PR DESCRIPTION
# Description

Added a frontend-only offline/network recovery UX layer to improve runtime resilience when users lose connectivity.

This PR introduces:
- a reusable `useNetworkStatus` hook,
- a global `NetworkRecoveryBanner`,
- automatic online/offline state detection,
- a clear user-facing recovery message when the app is offline.

The banner is mounted globally so users receive consistent feedback across routes when network connectivity is unavailable.

No backend behavior, API contracts, schema definitions, cache keys, storage behavior, or consent logic were changed.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below:
    - Global app layout (`app/layout.tsx`)

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] Listed below:
    - Improves mobile/offline recovery visibility with responsive fixed banner layout

- Docs updated (exact files):
  - [x] None

- Verification commands executed:
  - [x] `cd hushh-webapp && npm run lint`
  - [x] `cd hushh-webapp && npm run verify:design-system`
  - [x] `cd hushh-webapp && npm run build`

## 🛑 Tri-Flow Architecture Check

- [x] Web: Global offline/network recovery UX

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Added global offline recovery banner for network interruption states.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Uses browser network status only
- [x] No storage, tracking, backend calls, or consent changes added

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed — no new dependencies added