### PR TITLE
fix(pkm): reject memory reads when vault context is missing

### DIFF
--- a/hushh-webapp/__tests__/voice/voice-turn-orchestrator.test.ts
+++ b/hushh-webapp/__tests__/voice/voice-turn-orchestrator.test.ts
@@ -344,6 +344,46 @@ describe("VoiceTurnOrchestrator", () => {
     );
   });
 
+  it("rejects durable memory reads when vault runtime context is missing", async () => {
+    const retrieveDurableSpy = vi.spyOn(voiceMemoryStore, "retrieveDurable");
+    const onDebug = vi.fn();
+
+    const orchestrator = new VoiceTurnOrchestrator({
+      userId: "user_1",
+      vaultOwnerToken: "vault_token",
+      vaultKey: "vault_key_material",
+      getAppRuntimeState: () => undefined,
+      getVoiceContext: () => undefined,
+      onVoiceResponse: vi.fn().mockResolvedValue({
+        shortTermMemoryWrite: false,
+      }),
+      speak: vi.fn().mockResolvedValue(undefined),
+      onStageChange: vi.fn(),
+      onDebug,
+      onAssistantText: vi.fn(),
+    });
+
+    await orchestrator.processTranscript({
+      transcript: "Analyze NVDA",
+      source: "microphone",
+    });
+
+    expect(retrieveDurableSpy).not.toHaveBeenCalled();
+    expect(onDebug).toHaveBeenCalledWith(
+      "durable_memory_read_rejected",
+      expect.objectContaining({
+        reason: "missing_vault_context",
+      })
+    );
+    expect(planKaiVoiceIntentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plannerV2: expect.objectContaining({
+          memoryRetrieved: [],
+        }),
+      })
+    );
+  });
+
   it("passes execution_allowed and needs_confirmation through to dispatch", async () => {
     const onVoiceResponse = vi.fn().mockResolvedValue({
       shortTermMemoryWrite: false,

--- a/hushh-webapp/lib/voice/voice-turn-orchestrator.ts
+++ b/hushh-webapp/lib/voice/voice-turn-orchestrator.ts
@@ -117,6 +117,34 @@ function createNoopGroundedPlan(): GroundedVoicePlan {
   };
 }
 
+type DurableMemoryReadAccess =
+  | {
+      ok: true;
+      vaultUnlocked: boolean;
+      vaultKey?: string | null;
+    }
+  | {
+      ok: false;
+      reason: "missing_vault_context" | "missing_vault_key";
+    };
+
+function resolveDurableMemoryReadAccess(
+  appRuntimeState: AppRuntimeState | undefined,
+  vaultKey?: string | null
+): DurableMemoryReadAccess {
+  if (!appRuntimeState?.vault) {
+    return { ok: false, reason: "missing_vault_context" };
+  }
+  if (appRuntimeState.vault.unlocked && !String(vaultKey || "").trim()) {
+    return { ok: false, reason: "missing_vault_key" };
+  }
+  return {
+    ok: true,
+    vaultUnlocked: appRuntimeState.vault.unlocked,
+    vaultKey,
+  };
+}
+
 export type VoiceTurnOrchestratorConfig = {
   userId: string;
   vaultOwnerToken: string;
@@ -295,13 +323,23 @@ export class VoiceTurnOrchestrator {
     });
 
     const memoryShort: ShortTermTurn[] = voiceMemoryStore.getShortTerm(this.config.userId, 20);
-    const memoryRetrieved: DurableMemoryItem[] = await voiceMemoryStore.retrieveDurable({
-      userId: this.config.userId,
-      query: cleanTranscript,
-      limit: 8,
-      vaultUnlocked: Boolean(appRuntimeState?.vault.unlocked),
-      vaultKey: this.config.vaultKey,
-    });
+    const durableMemoryReadAccess = resolveDurableMemoryReadAccess(appRuntimeState, this.config.vaultKey);
+    const memoryRetrieved: DurableMemoryItem[] = durableMemoryReadAccess.ok
+      ? await voiceMemoryStore.retrieveDurable({
+          userId: this.config.userId,
+          query: cleanTranscript,
+          limit: 8,
+          vaultUnlocked: durableMemoryReadAccess.vaultUnlocked,
+          vaultKey: durableMemoryReadAccess.vaultKey,
+        })
+      : [];
+
+    if (!durableMemoryReadAccess.ok) {
+      this.config.onDebug?.("durable_memory_read_rejected", {
+        turn_id: turnId,
+        reason: durableMemoryReadAccess.reason,
+      });
+    }
 
     this.config.onDebug?.("orchestrator_turn_started", {
       turn_id: turnId,


### PR DESCRIPTION
## Description

Adds a guard to reject PKM memory reads when the required vault context is unavailable.

## Why

Recent governance and review feedback emphasized that all memory access must continue flowing through the canonical vault-gated PKM path instead of bypassing encrypted consent and cache boundaries.

Without this safeguard, memory reads could proceed with incomplete or invalid vault state.

## What changed

- Added validation for required vault context before memory reads
- Added safe failure behavior when vault state is missing
- Preserved existing PKM, consent, and cache flow contracts

## Impact

- No schema changes
- No new storage systems
- No parallel memory services introduced
- Tightens safety around existing PKM access flow

## Testing

- Ran `npm run lint`
- Ran `npm run build`
- Verified memory reads fail safely without vault context
- Verified valid vault-backed flows continue working

## Notes

This PR intentionally limits scope to the canonical PKM access path and does not introduce standalone memory agents or generated runtime stores.