### PR TITLE
fix(consent): enforce scope presence before PKM cache hydration

### DIFF
--- a/hushh-webapp/__tests__/services/pkm-domain-resource-consent.test.ts
+++ b/hushh-webapp/__tests__/services/pkm-domain-resource-consent.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const secureReadMock = vi.fn();
+const secureWriteMock = vi.fn();
+const loadDomainDataWithBlobMock = vi.fn();
+const peekCachedDomainBlobMock = vi.fn();
+
+vi.mock("@/lib/services/secure-resource-cache-service", () => ({
+  SecureResourceCacheService: {
+    read: (...args: unknown[]) => secureReadMock(...args),
+    write: (...args: unknown[]) => secureWriteMock(...args),
+    invalidateResourcePrefix: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/services/personal-knowledge-model-service", () => ({
+  PersonalKnowledgeModelService: {
+    loadDomainDataWithBlob: (...args: unknown[]) => loadDomainDataWithBlobMock(...args),
+    peekCachedDomainBlob: (...args: unknown[]) => peekCachedDomainBlobMock(...args),
+  },
+}));
+
+import { PkmDomainResourceService } from "@/lib/pkm/pkm-domain-resource";
+import { CacheService } from "@/lib/services/cache-service";
+
+describe("PkmDomainResourceService consent-gated cache hydration", () => {
+  beforeEach(() => {
+    CacheService.getInstance().clear();
+    vi.clearAllMocks();
+    peekCachedDomainBlobMock.mockReturnValue(null);
+  });
+
+  it("does not hydrate secure PKM cache without a vault owner scope token", async () => {
+    const result = await PkmDomainResourceService.hydrateFromSecureCache({
+      userId: "user-1",
+      domain: "financial",
+      vaultKey: "vault-key",
+    });
+
+    expect(result).toBeNull();
+    expect(secureReadMock).not.toHaveBeenCalled();
+  });
+
+  it("does not refresh and hydrate PKM cache without a vault owner scope token", async () => {
+    const result = await PkmDomainResourceService.getStaleFirst({
+      userId: "user-1",
+      domain: "financial",
+      vaultKey: "vault-key",
+      backgroundRefresh: false,
+    });
+
+    expect(result).toBeNull();
+    expect(secureReadMock).not.toHaveBeenCalled();
+    expect(loadDomainDataWithBlobMock).not.toHaveBeenCalled();
+    expect(secureWriteMock).not.toHaveBeenCalled();
+  });
+});

--- a/hushh-webapp/lib/pkm/pkm-domain-resource.ts
+++ b/hushh-webapp/lib/pkm/pkm-domain-resource.ts
@@ -155,7 +155,7 @@ export class PkmDomainResourceService {
   static async hydrateFromSecureCache(
     params: PkmDomainResourceParams
   ): Promise<PkmDomainResourceSnapshot | null> {
-    if (!params.vaultKey) {
+    if (!params.vaultKey || !hasUserConsent(params)) {
       return null;
     }
     const resourceKey = toDeviceResourceKey(params);
@@ -311,7 +311,7 @@ export class PkmDomainResourceService {
   static async refresh(
     params: PkmDomainResourceParams
   ): Promise<PkmDomainResourceSnapshot | null> {
-    if (!params.userId || !params.domain || !params.vaultKey) {
+    if (!params.userId || !params.domain || !params.vaultKey || !hasUserConsent(params)) {
       return null;
     }
 

--- a/hushh-webapp/lib/vault/vault-context.tsx
+++ b/hushh-webapp/lib/vault/vault-context.tsx
@@ -206,7 +206,7 @@ export function VaultProvider({ children }: VaultProviderProps) {
   }, [user?.uid, vaultKey, vaultOwnerToken]);
 
   useEffect(() => {
-    if (!user?.uid || !vaultKey) {
+    if (!user?.uid || !vaultKey || !vaultOwnerToken) {
       return;
     }
 
@@ -225,10 +225,11 @@ export function VaultProvider({ children }: VaultProviderProps) {
           userId: user.uid,
           domain: "financial",
           vaultKey,
+          vaultOwnerToken,
         })
       )
       .catch(() => null);
-  }, [user?.uid, vaultKey]);
+  }, [user?.uid, vaultKey, vaultOwnerToken]);
 
   useEffect(() => {
     if (!user?.uid || !vaultKey || !vaultOwnerToken) {


### PR DESCRIPTION
## Description

Adds a consent-scope guard before PKM cache hydration so memory-related cache flows only proceed when the required consent scope is present.

## Why

Recent review feedback emphasized that memory intelligence must enter through the canonical PKM, vault, consent, and cache contracts.

This change helps prevent PKM cache hydration from running with incomplete or unchecked consent scope state.

## What changed

- Added validation for required consent scope before PKM cache hydration
- Added safe fallback behavior when scope context is missing
- Preserved the existing PKM/vault/cache flow
- Avoided introducing any parallel memory service or generated runtime store

## Impact

- No schema changes
- No new storage systems
- No standalone agent flow introduced
- Strengthens consent enforcement in the existing PKM cache path

## Testing

- Ran `npm run lint`
- Ran `npm run build`
- Verified cache hydration is skipped when required consent scope is missing
- Verified valid consent-scoped hydration continues working

## Notes

This PR is intentionally scoped to the existing PKM cache hydration path and keeps memory access within canonical consent-gated boundaries.