### PR TITLE
fix(cache): skip PKM cache writes for missing user consent

### DIFF
--- a/hushh-webapp/__tests__/services/pkm-domain-resource-cache-consent.test.ts
+++ b/hushh-webapp/__tests__/services/pkm-domain-resource-cache-consent.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const secureReadMock = vi.fn();
+const secureWriteMock = vi.fn();
+const loadDomainDataWithBlobMock = vi.fn();
+const peekCachedDomainBlobMock = vi.fn();
+
+vi.mock("@/lib/services/secure-resource-cache-service", () => ({
+  SecureResourceCacheService: {
+    read: (...args: unknown[]) => secureReadMock(...args),
+    write: (...args: unknown[]) => secureWriteMock(...args),
+    invalidateResourcePrefix: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/services/personal-knowledge-model-service", () => ({
+  PersonalKnowledgeModelService: {
+    loadDomainDataWithBlob: (...args: unknown[]) => loadDomainDataWithBlobMock(...args),
+    peekCachedDomainBlob: (...args: unknown[]) => peekCachedDomainBlobMock(...args),
+  },
+}));
+
+import { PkmDomainResourceService } from "@/lib/pkm/pkm-domain-resource";
+import { CacheService, CACHE_KEYS } from "@/lib/services/cache-service";
+
+function makeSnapshot() {
+  return {
+    key: {
+      userId: "user-1",
+      domain: "financial",
+      segmentIds: [],
+      contentRevision: 1,
+    },
+    data: {
+      profile: {
+        onboarding: {
+          completed: true,
+        },
+      },
+    },
+    manifestRevision: 2,
+    updatedAt: "2026-05-11T00:00:00.000Z",
+    audit: {
+      cacheTier: "device" as const,
+      source: "secure_cache" as const,
+      refreshedAt: "2026-05-11T00:00:00.000Z",
+    },
+  };
+}
+
+describe("PkmDomainResourceService cache consent guard", () => {
+  beforeEach(() => {
+    CacheService.getInstance().clear();
+    vi.clearAllMocks();
+    peekCachedDomainBlobMock.mockReturnValue(null);
+  });
+
+  it("does not write secure-cache hydration results into memory cache without user consent", async () => {
+    secureReadMock.mockResolvedValueOnce(makeSnapshot());
+
+    const result = await PkmDomainResourceService.hydrateFromSecureCache({
+      userId: "user-1",
+      domain: "financial",
+      vaultKey: "vault-key",
+    });
+
+    expect(result?.data).toEqual(makeSnapshot().data);
+    expect(CacheService.getInstance().get(CACHE_KEYS.DOMAIN_DATA("user-1", "financial"))).toBeNull();
+    expect(
+      CacheService.getInstance().get(CACHE_KEYS.PKM_DOMAIN_RESOURCE("user-1", "financial", "all"))
+    ).toBeNull();
+  });
+
+  it("does not write network PKM results into memory or secure cache without user consent", async () => {
+    loadDomainDataWithBlobMock.mockResolvedValueOnce({
+      data: makeSnapshot().data,
+      blob: {
+        ciphertext: "ciphertext",
+        iv: "iv",
+        tag: "tag",
+        dataVersion: 1,
+        manifestRevision: 2,
+        updatedAt: "2026-05-11T00:00:00.000Z",
+      },
+    });
+
+    const result = await PkmDomainResourceService.refresh({
+      userId: "user-1",
+      domain: "financial",
+      vaultKey: "vault-key",
+    });
+
+    expect(result?.data).toEqual(makeSnapshot().data);
+    expect(secureWriteMock).not.toHaveBeenCalled();
+    expect(CacheService.getInstance().get(CACHE_KEYS.DOMAIN_DATA("user-1", "financial"))).toBeNull();
+    expect(
+      CacheService.getInstance().get(CACHE_KEYS.PKM_DOMAIN_RESOURCE("user-1", "financial", "all"))
+    ).toBeNull();
+  });
+});

--- a/hushh-webapp/lib/pkm/pkm-domain-resource.ts
+++ b/hushh-webapp/lib/pkm/pkm-domain-resource.ts
@@ -48,6 +48,10 @@ interface PreparedDomainWriteContext {
   expectedDataVersion: number | undefined;
 }
 
+function hasUserConsent(params: { vaultOwnerToken?: string | null }): boolean {
+  return Boolean(String(params.vaultOwnerToken || "").trim());
+}
+
 function normalizeSegmentIds(segmentIds?: string[]): string[] {
   return [...new Set((segmentIds || []).map((segmentId) => String(segmentId || "").trim().toLowerCase()).filter(Boolean))];
 }
@@ -125,7 +129,11 @@ function hydrateMemory(params: {
   domain: string;
   segmentIds?: string[];
   snapshot: PkmDomainResourceSnapshot;
+  canWriteCache?: boolean;
 }): PkmDomainResourceSnapshot {
+  if (params.canWriteCache === false) {
+    return params.snapshot;
+  }
   const cache = CacheService.getInstance();
   const cacheKey = toCacheKey(params);
   cache.set(cacheKey, params.snapshot, CACHE_TTL.SESSION);
@@ -169,6 +177,7 @@ export class PkmDomainResourceService {
       userId: params.userId,
       domain: params.domain,
       segmentIds: params.segmentIds,
+      canWriteCache: hasUserConsent(params),
       snapshot: {
         ...snapshot,
         audit: {
@@ -347,15 +356,18 @@ export class PkmDomainResourceService {
           userId: params.userId,
           domain: params.domain,
           segmentIds: params.segmentIds,
+          canWriteCache: hasUserConsent(params),
           snapshot,
         });
-        await SecureResourceCacheService.write({
-          userId: params.userId,
-          resourceKey: toDeviceResourceKey(params),
-          value: snapshot,
-          ttlMs: DEVICE_TTL_MS,
-          vaultKey: params.vaultKey!,
-        });
+        if (hasUserConsent(params)) {
+          await SecureResourceCacheService.write({
+            userId: params.userId,
+            resourceKey: toDeviceResourceKey(params),
+            value: snapshot,
+            ttlMs: DEVICE_TTL_MS,
+            vaultKey: params.vaultKey!,
+          });
+        }
         return snapshot;
       })
       .catch((error) => {


### PR DESCRIPTION
## Description

Adds a safeguard to skip PKM cache writes when the required user consent context is missing.

## Why

Recent governance and review discussions reinforced that PKM memory and cache operations must remain inside canonical vault and consent-gated flows.

Without this validation, cache writes could occur with incomplete consent state, creating inconsistencies between PKM memory access and cache synchronization behavior.

## What changed

- Added consent validation before PKM cache writes
- Added safe skip behavior for missing consent context
- Preserved the existing PKM, vault, and cache flow contracts
- Avoided introducing any standalone memory or cache subsystem

## Impact

- No schema changes
- No API changes
- No runtime storage changes
- Tightens consent enforcement for existing PKM cache writes

## Testing

- Ran `npm run lint`
- Ran `npm run build`
- Verified cache writes are skipped when consent context is unavailable
- Verified valid consent-backed cache writes continue functioning

## Notes

This PR intentionally limits scope to the canonical PKM cache flow and does not introduce new memory agents, generated stores, or parallel cache paths.