### PR TITLE
fix(vault): invalidate stale PKM session state after vault rekey events

### DIFF
--- a/hushh-webapp/__tests__/services/cache-sync-mutation-cascade.test.ts
+++ b/hushh-webapp/__tests__/services/cache-sync-mutation-cascade.test.ts
@@ -137,6 +137,26 @@ describe("CacheSyncService mutation cascades", () => {
     expect(invalidatedKeys).toContain(CACHE_KEYS.KAI_FINANCIAL_RESOURCE(userId));
   });
 
+  it("onVaultRekeyed invalidates stale PKM session state and domain prefixes", () => {
+    cache.set(CACHE_KEYS.PKM_METADATA(userId), { userId }, CACHE_TTL.SESSION);
+    cache.set(CACHE_KEYS.PKM_BLOB(userId), { ciphertext: "old" }, CACHE_TTL.SESSION);
+    cache.set(CACHE_KEYS.PKM_DECRYPTED_BLOB(userId), { financial: {} }, CACHE_TTL.SESSION);
+    cache.set(CACHE_KEYS.ENCRYPTED_DOMAIN_BLOB(userId, "financial"), { ciphertext: "old" }, CACHE_TTL.SESSION);
+    cache.set(CACHE_KEYS.DOMAIN_DATA(userId, "financial"), { holdings: [] }, CACHE_TTL.SESSION);
+    cache.set(CACHE_KEYS.DOMAIN_MANIFEST(userId, "financial"), { domain: "financial" }, CACHE_TTL.SESSION);
+    cache.set(CACHE_KEYS.PORTFOLIO_DATA(userId), { holdings: [] }, CACHE_TTL.SESSION);
+
+    CacheSyncService.onVaultRekeyed(userId);
+
+    expect(cache.get(CACHE_KEYS.PKM_METADATA(userId))).toBeNull();
+    expect(cache.get(CACHE_KEYS.PKM_BLOB(userId))).toBeNull();
+    expect(cache.get(CACHE_KEYS.PKM_DECRYPTED_BLOB(userId))).toBeNull();
+    expect(cache.get(CACHE_KEYS.ENCRYPTED_DOMAIN_BLOB(userId, "financial"))).toBeNull();
+    expect(cache.get(CACHE_KEYS.DOMAIN_DATA(userId, "financial"))).toBeNull();
+    expect(cache.get(CACHE_KEYS.DOMAIN_MANIFEST(userId, "financial"))).toBeNull();
+    expect(cache.get(CACHE_KEYS.PORTFOLIO_DATA(userId))).toBeNull();
+  });
+
   // ---------- 9. onPkmDomainStored (financial) ----------
   it("onPkmDomainStored for financial domain sets PORTFOLIO_DATA and DOMAIN_DATA to SESSION and invalidates PKM_DECRYPTED_BLOB", () => {
     const portfolioData = {

--- a/hushh-webapp/__tests__/services/vault-method-service.test.ts
+++ b/hushh-webapp/__tests__/services/vault-method-service.test.ts
@@ -68,6 +68,8 @@ describe("VaultMethodService.changePassphrase", () => {
   });
 
   it("updates passphrase wrapper without changing primary method by default", async () => {
+    const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+
     const result = await VaultMethodService.changePassphrase({
       userId: "uid-1",
       currentVaultKey:
@@ -89,6 +91,15 @@ describe("VaultMethodService.changePassphrase", () => {
       primaryMethod: "generated_default_native_passkey_prf",
       passphraseUpdated: true,
     });
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "vault-rekeyed",
+        detail: {
+          userId: "uid-1",
+          reason: "vault_passphrase_changed",
+        },
+      })
+    );
   });
 
   it("can set passphrase as primary when keepPrimaryMethod is false", async () => {

--- a/hushh-webapp/lib/cache/cache-sync-service.ts
+++ b/hushh-webapp/lib/cache/cache-sync-service.ts
@@ -411,6 +411,28 @@ export class CacheSyncService {
     }
   }
 
+  static onVaultRekeyed(userId: string): void {
+    const cache = CacheService.getInstance();
+    cache.invalidateMany([
+      CACHE_KEYS.VAULT_CHECK(userId),
+      CACHE_KEYS.VAULT_STATUS(userId),
+      CACHE_KEYS.PKM_METADATA(userId),
+      CACHE_KEYS.PKM_BLOB(userId),
+      CACHE_KEYS.PKM_DECRYPTED_BLOB(userId),
+      CACHE_KEYS.PKM_UPGRADE_STATUS(userId),
+      CACHE_KEYS.PORTFOLIO_DATA(userId),
+      CACHE_KEYS.ANALYSIS_HISTORY(userId),
+      CACHE_KEYS.KAI_FINANCIAL_RESOURCE(userId),
+    ]);
+    cache.invalidatePattern(`domain_manifest_${userId}_`);
+    cache.invalidatePattern(`domain_data_${userId}_`);
+    cache.invalidatePattern(`domain_blob_${userId}_`);
+    cache.invalidatePattern(`pkm_domain_resource_${userId}_`);
+    cache.invalidatePattern(`stock_context_${userId}_`);
+    this.invalidateKaiFinancialResource(userId);
+    this.onKaiMarketContextChanged(userId);
+  }
+
   static onConsentMutated(userId: string): void {
     const cache = CacheService.getInstance();
     cache.invalidate(CACHE_KEYS.ACTIVE_CONSENTS(userId));

--- a/hushh-webapp/lib/services/personal-knowledge-model-service.ts
+++ b/hushh-webapp/lib/services/personal-knowledge-model-service.ts
@@ -244,6 +244,27 @@ export class PersonalKnowledgeModelService {
   private static migrationInflight = new Map<string, Promise<void>>();
   private static readonly TICKER_SYNC_THROTTLE_MS = 5 * 60 * 1000;
 
+  static invalidateSessionStateAfterVaultRekey(userId: string): void {
+    CacheSyncService.onVaultRekeyed(userId);
+    for (const map of [
+      this.metadataInflight,
+      this.encryptedDataInflight,
+      this.domainDataInflight,
+      this.domainManifestInflight,
+      this.tickerSyncInflight,
+      this.migrationInflight,
+    ]) {
+      for (const key of map.keys()) {
+        if (key.includes(userId)) {
+          map.delete(key);
+        }
+      }
+    }
+    this.tickerSyncSignatureByUser.delete(userId);
+    this.tickerSyncLastAt.delete(userId);
+    void DeviceResourceCacheService.invalidateResourcePrefix(userId, "pkm:").catch(() => undefined);
+  }
+
   private static async pause(ms: number): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, ms));
   }

--- a/hushh-webapp/lib/services/vault-method-service.ts
+++ b/hushh-webapp/lib/services/vault-method-service.ts
@@ -52,6 +52,20 @@ function normalizeVaultMethodError(error: unknown): Error {
   return error instanceof Error ? error : new Error(message);
 }
 
+function dispatchVaultRekeyed(userId: string, reason: string): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.dispatchEvent(
+    new CustomEvent("vault-rekeyed", {
+      detail: {
+        userId,
+        reason,
+      },
+    })
+  );
+}
+
 export class VaultMethodService {
   static async getCurrentMethod(userId: string): Promise<VaultMethod> {
     const state = await VaultService.getVaultState(userId);
@@ -136,6 +150,7 @@ export class VaultMethodService {
         });
 
         await VaultService.setPrimaryVaultMethod(params.userId, "passphrase");
+        dispatchVaultRekeyed(params.userId, "vault_method_switched_to_passphrase");
         trackEvent("profile_method_switch_result", {
           result: "success",
         });
@@ -184,6 +199,7 @@ export class VaultMethodService {
           material.mode,
           material.passkeyCredentialId ?? "default"
         );
+        dispatchVaultRekeyed(params.userId, "vault_method_switched_to_generated");
         trackEvent("profile_method_switch_result", {
           result: "success",
         });
@@ -252,9 +268,11 @@ export class VaultMethodService {
           "passphrase",
           "default"
         );
+        dispatchVaultRekeyed(params.userId, "vault_passphrase_changed");
         return { primaryMethod: "passphrase", passphraseUpdated: true };
       }
 
+      dispatchVaultRekeyed(params.userId, "vault_passphrase_changed");
       return {
         primaryMethod: state.primaryMethod,
         passphraseUpdated: true,

--- a/hushh-webapp/lib/vault/vault-context.tsx
+++ b/hushh-webapp/lib/vault/vault-context.tsx
@@ -33,6 +33,7 @@ import { useAuth } from "@/lib/firebase/auth-context";
 import { CacheSyncService } from "@/lib/cache/cache-sync-service";
 import { trackGrowthFunnelStepCompleted } from "@/lib/observability/growth";
 import { ConsentExportRefreshOrchestrator } from "@/lib/services/consent-export-refresh-orchestrator";
+import { PersonalKnowledgeModelService } from "@/lib/services/personal-knowledge-model-service";
 import { PkmUpgradeOrchestrator } from "@/lib/services/pkm-upgrade-orchestrator";
 import { UnlockWarmOrchestrator } from "@/lib/services/unlock-warm-orchestrator";
 import { VaultService } from "@/lib/services/vault-service";
@@ -152,6 +153,28 @@ export function VaultProvider({ children }: VaultProviderProps) {
     return () =>
       window.removeEventListener("vault-lock-requested", handleLockRequest);
   }, [lockVault]);
+
+  useEffect(() => {
+    const handleVaultRekeyed = (event: Event) => {
+      const customEvent = event as CustomEvent<{
+        userId?: string;
+        reason?: string;
+      }>;
+      if (customEvent.detail?.userId && customEvent.detail.userId !== user?.uid) {
+        return;
+      }
+      if (user?.uid) {
+        PersonalKnowledgeModelService.invalidateSessionStateAfterVaultRekey(user.uid);
+      }
+      console.log(
+        `[VaultProvider] Vault rekeyed; invalidating PKM session state: ${customEvent.detail?.reason ?? "vault_rekeyed"}`
+      );
+      lockVault();
+    };
+
+    window.addEventListener("vault-rekeyed", handleVaultRekeyed);
+    return () => window.removeEventListener("vault-rekeyed", handleVaultRekeyed);
+  }, [lockVault, user?.uid]);
 
   useEffect(() => {
     if (!user?.uid || !vaultKey || !vaultOwnerToken) {


### PR DESCRIPTION
## Description

Invalidates stale PKM session state after vault rekey events to ensure memory access continues using the latest encrypted vault context.

## Why

Vault rekey operations can invalidate previously derived PKM session state. Without explicit invalidation, stale session data may continue flowing through cache or memory access paths after encryption boundaries have changed.

This change strengthens the canonical vault-gated PKM flow and keeps session state aligned with current vault identity and encryption context.

## What changed

- Added invalidation for stale PKM session state after vault rekey events
- Prevented reuse of outdated vault-backed memory session context
- Preserved existing consent, cache, and PKM ownership contracts
- Avoided introducing any parallel memory or session subsystem

## Impact

- No schema changes
- No API changes
- No standalone memory runtime introduced
- Improves PKM session consistency after vault rekey operations

## Testing

- Ran `npm run lint`
- Ran `npm run build`
- Verified stale session state is invalidated after rekey events
- Verified valid vault-backed PKM flows continue functioning correctly

## Notes

This PR intentionally limits scope to the canonical vault/PKM session lifecycle and does not introduce new storage systems or generated runtime artifacts.