### PR TITLE
feat(sync): add deterministic sync checkpoint metadata for PKM replay…

### DIFF
--- a/hushh-webapp/__tests__/services/pkm-prepared-blob-store.test.ts
+++ b/hushh-webapp/__tests__/services/pkm-prepared-blob-store.test.ts
@@ -146,4 +146,64 @@ describe("PersonalKnowledgeModelService.storeMergedDomainWithPreparedBlob", () =
     expect(typeof payload.manifest.upgraded_at).toBe("string");
     expect(typeof payload.summary.upgraded_at).toBe("string");
   });
+
+  it("forwards sync checkpoint metadata in the normalized PKM store payload", async () => {
+    const apiFetchSpy = vi.spyOn(ApiService, "apiFetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          success: true,
+          data_version: 12,
+          updated_at: "2026-04-01T00:00:00Z",
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }
+      )
+    );
+
+    await PersonalKnowledgeModelService.storeDomainData({
+      userId: "user-1",
+      domain: "financial",
+      encryptedBlob: {
+        ciphertext: "cipher",
+        iv: "iv",
+        tag: "tag",
+      },
+      summary: {},
+      expectedDataVersion: 11,
+      syncCheckpoint: {
+        schemaVersion: "pkm_sync_checkpoint.v1",
+        checkpointKey:
+          "pkm_sync_checkpoint.v1|merged_domain|financial|attempt:0|expected:11|current_manifest:2|target_manifest:3|upgrade:none",
+        domain: "financial",
+        source: "merged_domain",
+        attempt: 0,
+        expectedDataVersion: 11,
+        currentManifestVersion: 2,
+        targetManifestVersion: 3,
+        upgradedInSession: false,
+        conflictRetry: false,
+        upgradeRunId: null,
+      },
+      vaultOwnerToken: "vault-owner-token",
+    });
+
+    const [, requestInit] = apiFetchSpy.mock.calls[0] || [];
+    const payload = JSON.parse(String((requestInit as RequestInit | undefined)?.body || "{}"));
+    expect(payload.sync_checkpoint).toEqual({
+      schema_version: "pkm_sync_checkpoint.v1",
+      checkpoint_key:
+        "pkm_sync_checkpoint.v1|merged_domain|financial|attempt:0|expected:11|current_manifest:2|target_manifest:3|upgrade:none",
+      domain: "financial",
+      source: "merged_domain",
+      attempt: 0,
+      expected_data_version: 11,
+      current_manifest_version: 2,
+      target_manifest_version: 3,
+      upgraded_in_session: false,
+      conflict_retry: false,
+      upgrade_run_id: null,
+    });
+  });
 });

--- a/hushh-webapp/__tests__/services/pkm-write-coordinator.test.ts
+++ b/hushh-webapp/__tests__/services/pkm-write-coordinator.test.ts
@@ -101,13 +101,14 @@ function stubWriteContext(overrides?: {
   baseFullBlob?: Record<string, unknown>;
   domainData?: Record<string, unknown>;
   expectedDataVersion?: number;
+  currentEncryptedDomain?: Record<string, unknown> | null;
 }) {
   prepareDomainWriteContextMock.mockResolvedValue({
     baseFullBlob: overrides?.baseFullBlob ?? { existing: { foo: "bar" } },
     domainData: overrides?.domainData ?? { items: [] },
     expectedDataVersion: overrides?.expectedDataVersion ?? 1,
   });
-  pkmGetDomainDataMock.mockResolvedValue(null);
+  pkmGetDomainDataMock.mockResolvedValue(overrides?.currentEncryptedDomain ?? null);
 }
 
 const BUILD_CALLBACK = vi.fn().mockImplementation(() => ({
@@ -177,8 +178,75 @@ describe("PkmWriteCoordinator", () => {
           domain: BASE_PARAMS.domain,
           domainData: { favorite: "sushi" },
           summary: { item_count: 1 },
+          syncCheckpoint: expect.objectContaining({
+            schemaVersion: "pkm_sync_checkpoint.v1",
+            source: "merged_domain",
+            domain: BASE_PARAMS.domain,
+            attempt: 0,
+            expectedDataVersion: 1,
+            conflictRetry: false,
+          }),
         })
       );
+      expect(result.syncCheckpoint).toMatchObject({
+        schemaVersion: "pkm_sync_checkpoint.v1",
+        source: "merged_domain",
+        domain: BASE_PARAMS.domain,
+        attempt: 0,
+        expectedDataVersion: 1,
+        resultDataVersion: 2,
+        conflictRetry: false,
+      });
+    });
+
+    it("uses current encrypted data version and manifest revision in deterministic sync checkpoints", async () => {
+      stubNoUpgradeNeeded();
+      stubWriteContext({
+        expectedDataVersion: 3,
+        currentEncryptedDomain: {
+          ciphertext: "cipher",
+          iv: "iv",
+          tag: "tag",
+          dataVersion: 7,
+        },
+      });
+      pkmGetDomainManifestMock.mockResolvedValue({
+        domain: "food",
+        manifest_version: 4,
+        domain_contract_version: 2,
+        readable_summary_version: 1,
+      });
+      pkmStoreMergedDomainWithPreparedBlobMock.mockResolvedValue({
+        success: true,
+        conflict: false,
+        dataVersion: 8,
+        fullBlob: { food: { favorite: "sushi" } },
+      });
+
+      const result = await PkmWriteCoordinator.saveMergedDomain({
+        ...BASE_PARAMS,
+        build: () => ({
+          domainData: { favorite: "sushi" },
+          summary: { item_count: 1 },
+          manifest: {
+            domain: "food",
+            manifest_version: 5,
+            summary_projection: {},
+            top_level_scope_paths: [],
+            externalizable_paths: [],
+            paths: [],
+          },
+        }),
+      });
+
+      expect(result.syncCheckpoint).toMatchObject({
+        checkpointKey:
+          "pkm_sync_checkpoint.v1|merged_domain|food|attempt:0|expected:7|current_manifest:4|target_manifest:5|upgrade:none",
+        expectedDataVersion: 7,
+        resultDataVersion: 8,
+        currentManifestVersion: 4,
+        targetManifestVersion: 5,
+      });
     });
   });
 

--- a/hushh-webapp/lib/capacitor/personal-knowledge-model.ts
+++ b/hushh-webapp/lib/capacitor/personal-knowledge-model.ts
@@ -6,6 +6,21 @@
 
 import { registerPlugin } from "@capacitor/core";
 
+export interface PkmSyncCheckpointPluginMetadata {
+  schemaVersion: "pkm_sync_checkpoint.v1";
+  checkpointKey: string;
+  domain: string;
+  source: string;
+  attempt: number;
+  expectedDataVersion: number | null;
+  resultDataVersion?: number | null;
+  currentManifestVersion: number | null;
+  targetManifestVersion: number | null;
+  upgradedInSession: boolean;
+  conflictRetry: boolean;
+  upgradeRunId?: string | null;
+}
+
 export interface HushhPersonalKnowledgeModelPlugin {
   getMetadata(options: { userId: string; vaultOwnerToken?: string }): Promise<{
     userId: string;
@@ -106,6 +121,7 @@ export interface HushhPersonalKnowledgeModelPlugin {
       newReadableSummaryVersion?: number;
       retryCount?: number;
     };
+    syncCheckpoint?: PkmSyncCheckpointPluginMetadata;
     vaultOwnerToken?: string;
   }): Promise<{
     success: boolean;

--- a/hushh-webapp/lib/services/personal-knowledge-model-service.ts
+++ b/hushh-webapp/lib/services/personal-knowledge-model-service.ts
@@ -118,6 +118,21 @@ export interface PkmUpgradeContext {
   retryCount?: number;
 }
 
+export interface PkmSyncCheckpointMetadata {
+  schemaVersion: "pkm_sync_checkpoint.v1";
+  checkpointKey: string;
+  domain: string;
+  source: string;
+  attempt: number;
+  expectedDataVersion: number | null;
+  resultDataVersion?: number | null;
+  currentManifestVersion: number | null;
+  targetManifestVersion: number | null;
+  upgradedInSession: boolean;
+  conflictRetry: boolean;
+  upgradeRunId?: string | null;
+}
+
 type DecryptedFullBlobCacheEntry = {
   marker: string;
   blob: Record<string, unknown>;
@@ -1370,6 +1385,7 @@ export class PersonalKnowledgeModelService {
     portfolioData?: CachedPortfolioData;
     expectedDataVersion?: number;
     upgradeContext?: PkmUpgradeContext;
+    syncCheckpoint?: PkmSyncCheckpointMetadata;
     vaultOwnerToken?: string;
   }): Promise<StoreDomainDataResult> {
     const metadataTimestamp = new Date().toISOString();
@@ -1435,6 +1451,7 @@ export class PersonalKnowledgeModelService {
         writeProjections: params.writeProjections,
         expectedDataVersion: params.expectedDataVersion,
         upgradeContext: params.upgradeContext,
+        syncCheckpoint: params.syncCheckpoint,
         vaultOwnerToken: this.getVaultOwnerToken(params.vaultOwnerToken),
       });
 
@@ -1499,6 +1516,22 @@ export class PersonalKnowledgeModelService {
         prior_readable_summary_version: params.upgradeContext.priorReadableSummaryVersion,
         new_readable_summary_version: params.upgradeContext.newReadableSummaryVersion,
         retry_count: params.upgradeContext.retryCount,
+      };
+    }
+    if (params.syncCheckpoint) {
+      payload.sync_checkpoint = {
+        schema_version: params.syncCheckpoint.schemaVersion,
+        checkpoint_key: params.syncCheckpoint.checkpointKey,
+        domain: params.syncCheckpoint.domain,
+        source: params.syncCheckpoint.source,
+        attempt: params.syncCheckpoint.attempt,
+        expected_data_version: params.syncCheckpoint.expectedDataVersion,
+        result_data_version: params.syncCheckpoint.resultDataVersion,
+        current_manifest_version: params.syncCheckpoint.currentManifestVersion,
+        target_manifest_version: params.syncCheckpoint.targetManifestVersion,
+        upgraded_in_session: params.syncCheckpoint.upgradedInSession,
+        conflict_retry: params.syncCheckpoint.conflictRetry,
+        upgrade_run_id: params.syncCheckpoint.upgradeRunId,
       };
     }
 
@@ -2246,6 +2279,7 @@ export class PersonalKnowledgeModelService {
     writeProjections?: PkmWriteProjection[];
     expectedDataVersion?: number;
     upgradeContext?: PkmUpgradeContext;
+    syncCheckpoint?: PkmSyncCheckpointMetadata;
     vaultOwnerToken?: string;
     cacheFullBlob?: boolean;
   }): Promise<{
@@ -2298,6 +2332,7 @@ export class PersonalKnowledgeModelService {
       portfolioData,
       expectedDataVersion: params.expectedDataVersion,
       upgradeContext: params.upgradeContext,
+      syncCheckpoint: params.syncCheckpoint,
       vaultOwnerToken: params.vaultOwnerToken,
     });
 
@@ -2348,6 +2383,7 @@ export class PersonalKnowledgeModelService {
     writeProjections?: PkmWriteProjection[];
     expectedDataVersion?: number;
     upgradeContext?: PkmUpgradeContext;
+    syncCheckpoint?: PkmSyncCheckpointMetadata;
     vaultOwnerToken?: string;
   }): Promise<{
     success: boolean;
@@ -2384,6 +2420,7 @@ export class PersonalKnowledgeModelService {
     writeProjections?: PkmWriteProjection[];
     expectedDataVersion?: number;
     upgradeContext?: PkmUpgradeContext;
+    syncCheckpoint?: PkmSyncCheckpointMetadata;
     vaultOwnerToken?: string;
     cacheFullBlob?: boolean;
   }): Promise<{
@@ -2440,6 +2477,7 @@ export class PersonalKnowledgeModelService {
       portfolioData,
       expectedDataVersion: params.expectedDataVersion,
       upgradeContext: params.upgradeContext,
+      syncCheckpoint: params.syncCheckpoint,
       vaultOwnerToken: params.vaultOwnerToken,
     });
 

--- a/hushh-webapp/lib/services/pkm-write-coordinator.ts
+++ b/hushh-webapp/lib/services/pkm-write-coordinator.ts
@@ -11,6 +11,7 @@ import { PkmDomainResourceService } from "@/lib/pkm/pkm-domain-resource";
 import type {
   EncryptedDomainBlob,
   PkmMergeDecision,
+  PkmSyncCheckpointMetadata,
   PkmUpgradeContext,
   PkmWriteProjection,
 } from "@/lib/services/personal-knowledge-model-service";
@@ -57,8 +58,55 @@ export type PkmWriteCoordinatorResult = {
   message?: string;
   dataVersion?: number;
   updatedAt?: string;
+  syncCheckpoint?: PkmSyncCheckpointMetadata;
   fullBlob: Record<string, unknown>;
 };
+
+function toNullableVersion(value: unknown): number | null {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function buildSyncCheckpoint(params: {
+  source: "merged_domain" | "prepared_domain";
+  domain: string;
+  attempt: number;
+  context: BaseContext;
+  plan: MergedWritePlan | PreparedWritePlan;
+  resultDataVersion?: number;
+  conflictRetry: boolean;
+}): PkmSyncCheckpointMetadata {
+  const expectedDataVersion = toNullableVersion(
+    params.context.currentEncryptedDomain?.dataVersion ?? params.context.expectedDataVersion
+  );
+  const currentManifestVersion = toNullableVersion(params.context.currentManifest?.manifest_version);
+  const targetManifestVersion = toNullableVersion(params.plan.manifest?.manifest_version);
+  const upgradeRunId = params.context.upgradeContext?.runId || null;
+
+  return {
+    schemaVersion: "pkm_sync_checkpoint.v1",
+    checkpointKey: [
+      "pkm_sync_checkpoint.v1",
+      params.source,
+      params.domain,
+      `attempt:${params.attempt}`,
+      `expected:${expectedDataVersion ?? "none"}`,
+      `current_manifest:${currentManifestVersion ?? "none"}`,
+      `target_manifest:${targetManifestVersion ?? "none"}`,
+      `upgrade:${upgradeRunId ?? "none"}`,
+    ].join("|"),
+    domain: params.domain,
+    source: params.source,
+    attempt: params.attempt,
+    expectedDataVersion,
+    resultDataVersion: toNullableVersion(params.resultDataVersion),
+    currentManifestVersion,
+    targetManifestVersion,
+    upgradedInSession: params.context.upgradedInSession,
+    conflictRetry: params.conflictRetry,
+    upgradeRunId,
+  };
+}
 
 function emptyResult(
   saveState: PkmWriteCoordinatorSaveState,
@@ -221,6 +269,14 @@ export class PkmWriteCoordinator {
         upgradeContext,
       });
       const plan = await params.build(context);
+      const syncCheckpoint = buildSyncCheckpoint({
+        source: "merged_domain",
+        domain: params.domain,
+        attempt,
+        context,
+        plan,
+        conflictRetry: retryingAfterConflict,
+      });
       const result = await PersonalKnowledgeModelService.storeMergedDomainWithPreparedBlob({
         userId: params.userId,
         vaultKey: params.vaultKey,
@@ -233,8 +289,13 @@ export class PkmWriteCoordinator {
         baseFullBlob: context.baseFullBlob,
         expectedDataVersion: context.currentEncryptedDomain?.dataVersion ?? context.expectedDataVersion,
         upgradeContext: context.upgradeContext,
+        syncCheckpoint,
         cacheFullBlob: false,
       });
+      const resultCheckpoint = {
+        ...syncCheckpoint,
+        resultDataVersion: toNullableVersion(result.dataVersion),
+      };
 
       if (result.success) {
         return {
@@ -248,6 +309,7 @@ export class PkmWriteCoordinator {
           message: result.message,
           dataVersion: result.dataVersion,
           updatedAt: result.updatedAt,
+          syncCheckpoint: resultCheckpoint,
           fullBlob: result.fullBlob,
         };
       }
@@ -259,6 +321,7 @@ export class PkmWriteCoordinator {
           message: result.message,
           dataVersion: result.dataVersion,
           updatedAt: result.updatedAt,
+          syncCheckpoint: resultCheckpoint,
           fullBlob: result.fullBlob,
         };
       }
@@ -305,6 +368,14 @@ export class PkmWriteCoordinator {
         upgradeContext,
       });
       const plan = await params.build(context);
+      const syncCheckpoint = buildSyncCheckpoint({
+        source: "prepared_domain",
+        domain: params.domain,
+        attempt,
+        context,
+        plan,
+        conflictRetry: retryingAfterConflict,
+      });
       const result = await PersonalKnowledgeModelService.storePreparedDomainWithPreparedBlob({
         userId: params.userId,
         vaultKey: params.vaultKey,
@@ -319,8 +390,13 @@ export class PkmWriteCoordinator {
         baseFullBlob: context.baseFullBlob,
         expectedDataVersion: context.currentEncryptedDomain?.dataVersion ?? context.expectedDataVersion,
         upgradeContext: context.upgradeContext,
+        syncCheckpoint,
         cacheFullBlob: false,
       });
+      const resultCheckpoint = {
+        ...syncCheckpoint,
+        resultDataVersion: toNullableVersion(result.dataVersion),
+      };
 
       if (result.success) {
         return {
@@ -334,6 +410,7 @@ export class PkmWriteCoordinator {
           message: result.message,
           dataVersion: result.dataVersion,
           updatedAt: result.updatedAt,
+          syncCheckpoint: resultCheckpoint,
           fullBlob: result.fullBlob,
         };
       }
@@ -345,6 +422,7 @@ export class PkmWriteCoordinator {
           message: result.message,
           dataVersion: result.dataVersion,
           updatedAt: result.updatedAt,
+          syncCheckpoint: resultCheckpoint,
           fullBlob: result.fullBlob,
         };
       }


### PR DESCRIPTION
## Description

Adds deterministic sync checkpoint metadata to improve PKM replay safety and consistency during memory synchronization flows.

## Why

PKM synchronization and replay flows depend on stable ordering and reliable checkpoint ownership. Without deterministic checkpoint metadata, replay behavior can become difficult to reason about across cache hydration, consent-scoped sync, and recovery scenarios.

This change strengthens the canonical PKM synchronization path without introducing parallel memory systems or standalone replay services.

## What changed

- Added deterministic checkpoint metadata for PKM sync flows
- Improved replay consistency across synchronization boundaries
- Preserved existing vault, consent, and cache contracts
- Avoided introducing new storage systems or standalone sync runtimes

## Impact

- No schema-breaking changes
- No standalone memory services introduced
- Improves replay and synchronization consistency
- Strengthens canonical PKM sync safety

## Testing

- Ran `npm run lint`
- Ran `npm run build`
- Verified deterministic checkpoint metadata is generated consistently
- Verified existing PKM synchronization flow continues functioning correctly

## Notes

This PR intentionally focuses on the canonical PKM synchronization lifecycle and avoids introducing generated runtime stores, parallel replay systems, or separate memory ownership paths.