### PR TITLE
feat: add API timeout retry recovery UX

### DIFF
--- a/hushh-webapp/components/consent/consent-center-page.tsx
+++ b/hushh-webapp/components/consent/consent-center-page.tsx
@@ -1,6 +1,4 @@
 "use client";
-import { ApiRetryState } from "@/components/system/api-retry-state";
-
 
 import Link from "next/link";
 import { useDeferredValue, useEffect, useMemo, useState } from "react";
@@ -23,6 +21,7 @@ import {
   SettingsRow,
   SettingsSegmentedTabs,
 } from "@/components/profile/settings-ui";
+import { ApiRetryState } from "@/components/system/api-retry-state";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { useAuth } from "@/hooks/use-auth";
@@ -579,8 +578,8 @@ export function ConsentCenterPage() {
   const deferredQuery = useDeferredValue(searchValue.trim());
   const [mutationTick, setMutationTick] = useState(0);
   const retryConsentCenter = () => {
-  setMutationTick((value) => value + 1);
-};
+    setMutationTick((value) => value + 1);
+  };
   const summaryCacheKey = user?.uid
     ? CACHE_KEYS.CONSENT_CENTER_SUMMARY(user.uid, `${actor}:${mode}`)
     : "consent_center_summary_guest";
@@ -722,6 +721,14 @@ export function ConsentCenterPage() {
     () => (tab === "relationships" ? relationshipItems : listData?.items || []),
     [listData?.items, relationshipItems, tab]
   );
+  const activeListError =
+    tab === "relationships" ? centerResource.error : listResource.error;
+  const consentLoadError = activeListError || summaryResource.error;
+  const hasVisibleConsentListData =
+    items.length > 0 ||
+    (tab === "relationships" ? Boolean(centerResource.data) : Boolean(listData));
+  const showCompactRetryState = Boolean(consentLoadError && hasVisibleConsentListData);
+  const showFullRetryState = Boolean(consentLoadError && !hasVisibleConsentListData);
   const selectedEntry = useMemo(() => {
     if (!items.length) return null;
     if (selectedId) {
@@ -989,7 +996,6 @@ export function ConsentCenterPage() {
 
             <SettingsGroup embedded>
               <div className="px-4 py-4">
-            
                 <div className="relative">
                   <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                   <Input
@@ -1015,58 +1021,67 @@ export function ConsentCenterPage() {
             <section data-testid="consent-manager-list">
               <SettingsGroup embedded>
                 <div className="space-y-2 px-2 py-2">
-  {listResource.error || centerResource.error || summaryResource.error ? (
-    <ApiRetryState
-      title="Unable to refresh consent data"
-      description="Consent data could not be loaded right now. Retry to refresh the latest consent state."
-      onRetry={retryConsentCenter}
-    />
-  ) : null}
+                  {showCompactRetryState ? (
+                    <ApiRetryState
+                      variant="compact"
+                      title="Showing saved consent data"
+                      description="The latest refresh failed. You can keep reviewing cached data or retry."
+                      onRetry={retryConsentCenter}
+                    />
+                  ) : null}
 
-  {listResource.loading && items.length === 0 ? (
-  <div className="px-3 py-6 text-sm text-muted-foreground">
-    Loading consent entries…
-  </div>
-) : null}
-                  {!listResource.loading && tab !== "relationships" && items.length === 0 ? (
+                  {showFullRetryState ? (
+                    <ApiRetryState
+                      title="Unable to refresh consent data"
+                      description="Consent data could not be loaded right now. Retry to fetch the latest consent state."
+                      onRetry={retryConsentCenter}
+                    />
+                  ) : null}
+
+                  {listResource.loading && items.length === 0 && !showFullRetryState ? (
+                    <div className="px-3 py-6 text-sm text-muted-foreground">
+                      Loading consent entries…
+                    </div>
+                  ) : null}
+                  {!listResource.loading && !showFullRetryState && tab !== "relationships" && items.length === 0 ? (
                     <div className="px-3 py-8 text-sm text-muted-foreground">
                       No {tab} entries match this view right now.
                     </div>
                   ) : null}
-                  {!centerResource.loading && tab === "relationships" && items.length === 0 ? (
+                  {!centerResource.loading && !showFullRetryState && tab === "relationships" && items.length === 0 ? (
                     <div className="px-3 py-8 text-sm text-muted-foreground">
                       No relationship entries match this view right now.
                     </div>
                   ) : null}
-                 {tab === "history" && items.length > 0 ? (
-  <ConsentAuditTimeline
-    entries={items}
-    selectedId={selectedId}
-    onSelect={(entry) =>
-      setParam({
-        requestId: entry.request_id || entry.id,
-      })
-    }
-    resolveCounterpartLabel={resolveCounterpartLabel}
-    summarizeEntry={entrySummary}
-  />
-) : (
-  items.map((entry) => (
-    <ConsentEntryRow
-      key={entry.id}
-      entry={entry}
-      selected={
-        selectedEntry?.id === entry.id ||
-        selectedEntry?.request_id === entry.request_id
-      }
-      onSelect={() =>
-        setParam({
-          requestId: entry.request_id || entry.id,
-        })
-      }
-    />
-  ))
-)}
+                  {tab === "history" && items.length > 0 ? (
+                    <ConsentAuditTimeline
+                      entries={items}
+                      selectedId={selectedId}
+                      onSelect={(entry) =>
+                        setParam({
+                          requestId: entry.request_id || entry.id,
+                        })
+                      }
+                      resolveCounterpartLabel={resolveCounterpartLabel}
+                      summarizeEntry={entrySummary}
+                    />
+                  ) : (
+                    items.map((entry) => (
+                      <ConsentEntryRow
+                        key={entry.id}
+                        entry={entry}
+                        selected={
+                          selectedEntry?.id === entry.id ||
+                          selectedEntry?.request_id === entry.request_id
+                        }
+                        onSelect={() =>
+                          setParam({
+                            requestId: entry.request_id || entry.id,
+                          })
+                        }
+                      />
+                    ))
+                  )}
                 </div>
 
                 {tab !== "relationships" && listData ? (

--- a/hushh-webapp/components/consent/consent-center-page.tsx
+++ b/hushh-webapp/components/consent/consent-center-page.tsx
@@ -1,4 +1,6 @@
 "use client";
+import { ApiRetryState } from "@/components/system/api-retry-state";
+
 
 import Link from "next/link";
 import { useDeferredValue, useEffect, useMemo, useState } from "react";
@@ -576,6 +578,9 @@ export function ConsentCenterPage() {
   const [searchValue, setSearchValue] = useState(searchParams.get("q") || "");
   const deferredQuery = useDeferredValue(searchValue.trim());
   const [mutationTick, setMutationTick] = useState(0);
+  const retryConsentCenter = () => {
+  setMutationTick((value) => value + 1);
+};
   const summaryCacheKey = user?.uid
     ? CACHE_KEYS.CONSENT_CENTER_SUMMARY(user.uid, `${actor}:${mode}`)
     : "consent_center_summary_guest";
@@ -984,6 +989,7 @@ export function ConsentCenterPage() {
 
             <SettingsGroup embedded>
               <div className="px-4 py-4">
+            
                 <div className="relative">
                   <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                   <Input
@@ -1009,11 +1015,19 @@ export function ConsentCenterPage() {
             <section data-testid="consent-manager-list">
               <SettingsGroup embedded>
                 <div className="space-y-2 px-2 py-2">
-                  {listResource.loading && items.length === 0 ? (
-                    <div className="px-3 py-6 text-sm text-muted-foreground">
-                      Loading consent entries…
-                    </div>
-                  ) : null}
+  {listResource.error || centerResource.error || summaryResource.error ? (
+    <ApiRetryState
+      title="Unable to refresh consent data"
+      description="Consent data could not be loaded right now. Retry to refresh the latest consent state."
+      onRetry={retryConsentCenter}
+    />
+  ) : null}
+
+  {listResource.loading && items.length === 0 ? (
+  <div className="px-3 py-6 text-sm text-muted-foreground">
+    Loading consent entries…
+  </div>
+) : null}
                   {!listResource.loading && tab !== "relationships" && items.length === 0 ? (
                     <div className="px-3 py-8 text-sm text-muted-foreground">
                       No {tab} entries match this view right now.
@@ -1024,32 +1038,35 @@ export function ConsentCenterPage() {
                       No relationship entries match this view right now.
                     </div>
                   ) : null}
-                  {tab === "history" && items.length > 0 ? (
-                    <ConsentAuditTimeline
-                      entries={items}
-                      selectedId={selectedId}
-                      onSelect={(entry) =>
-                        setParam({
-                          requestId: entry.request_id || entry.id,
-                        })
-                      }
-                      resolveCounterpartLabel={resolveCounterpartLabel}
-                      summarizeEntry={entrySummary}
-                    />
-                  ) : (
-                    items.map((entry) => (
-                      <ConsentEntryRow
-                        key={entry.id}
-                        entry={entry}
-                        selected={selectedEntry?.id === entry.id}
-                        onSelect={() =>
-                          setParam({
-                            requestId: entry.request_id || entry.id,
-                          })
-                        }
-                      />
-                    ))
-                  )}
+                 {tab === "history" && items.length > 0 ? (
+  <ConsentAuditTimeline
+    entries={items}
+    selectedId={selectedId}
+    onSelect={(entry) =>
+      setParam({
+        requestId: entry.request_id || entry.id,
+      })
+    }
+    resolveCounterpartLabel={resolveCounterpartLabel}
+    summarizeEntry={entrySummary}
+  />
+) : (
+  items.map((entry) => (
+    <ConsentEntryRow
+      key={entry.id}
+      entry={entry}
+      selected={
+        selectedEntry?.id === entry.id ||
+        selectedEntry?.request_id === entry.request_id
+      }
+      onSelect={() =>
+        setParam({
+          requestId: entry.request_id || entry.id,
+        })
+      }
+    />
+  ))
+)}
                 </div>
 
                 {tab !== "relationships" && listData ? (

--- a/hushh-webapp/components/system/api-retry-state.tsx
+++ b/hushh-webapp/components/system/api-retry-state.tsx
@@ -7,14 +7,34 @@ import { Button } from "@/lib/morphy-ux/button";
 type ApiRetryStateProps = {
   title?: string;
   description?: string;
+  variant?: "full" | "compact";
   onRetry: () => void;
 };
 
 export function ApiRetryState({
   title = "Unable to load data",
   description = "The request took too long or failed. Try again to refresh this section.",
+  variant = "full",
   onRetry,
 }: ApiRetryStateProps) {
+  if (variant === "compact") {
+    return (
+      <div className="flex items-center justify-between gap-3 rounded-[var(--app-card-radius-compact)] border border-amber-500/20 bg-amber-500/10 px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2 text-sm">
+          <AlertTriangle className="h-4 w-4 shrink-0 text-amber-700 dark:text-amber-300" />
+          <div className="min-w-0">
+            <p className="font-medium text-foreground">{title}</p>
+            <p className="text-xs text-muted-foreground">{description}</p>
+          </div>
+        </div>
+        <Button variant="none" effect="fade" size="sm" onClick={onRetry}>
+          <RefreshCcw className="mr-2 h-4 w-4" />
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
   return (
     <div className="rounded-[var(--app-card-radius-compact)] border border-amber-500/20 bg-amber-500/10 p-4">
       <div className="flex items-start gap-3">

--- a/hushh-webapp/components/system/api-retry-state.tsx
+++ b/hushh-webapp/components/system/api-retry-state.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { AlertTriangle, RefreshCcw } from "lucide-react";
+
+import { Button } from "@/lib/morphy-ux/button";
+
+type ApiRetryStateProps = {
+  title?: string;
+  description?: string;
+  onRetry: () => void;
+};
+
+export function ApiRetryState({
+  title = "Unable to load data",
+  description = "The request took too long or failed. Try again to refresh this section.",
+  onRetry,
+}: ApiRetryStateProps) {
+  return (
+    <div className="rounded-[var(--app-card-radius-compact)] border border-amber-500/20 bg-amber-500/10 p-4">
+      <div className="flex items-start gap-3">
+        <div className="rounded-full bg-amber-500/15 p-2">
+          <AlertTriangle className="h-5 w-5 text-amber-700 dark:text-amber-300" />
+        </div>
+
+        <div className="min-w-0 flex-1 space-y-2">
+          <div>
+            <p className="text-sm font-semibold text-foreground">{title}</p>
+            <p className="mt-1 text-sm leading-6 text-muted-foreground">
+              {description}
+            </p>
+          </div>
+
+          <Button variant="none" effect="fade" size="sm" onClick={onRetry}>
+            <RefreshCcw className="mr-2 h-4 w-4" />
+            Retry
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# Description

Added a reusable API retry recovery UX component and integrated it into the Consent Center loading/error flow.

This PR introduces a frontend-only `ApiRetryState` component to help users recover from failed or delayed API loading states. When Consent Center data fails to refresh, users now receive a clear recovery message and a direct retry action instead of being left with a silent or unclear failure state.

No backend logic, API contracts, schema definitions, cache keys, storage behavior, or consent authorization logic were changed.

## 📌 Impact Map (Required)

* Routes touched:

  * [x] Listed below:

    * `/consents`

* API / schema / type changes:

  * [x] None

* Cache keys touched:

  * [x] None

* World-model domain summary effects:

  * [x] None

* Mobile parity impacts:

  * [x] None — responsive retry card uses existing app spacing and button patterns

* Docs updated (exact files):

  * [x] None

* Verification commands executed:

  * [x] `cd hushh-webapp && npm run lint`
  * [x] `cd hushh-webapp && npm run verify:design-system`
  * [x] `cd hushh-webapp && npm run build`

## 🛑 Tri-Flow Architecture Check

* [x] Web: Consent Center API retry recovery UX

## 🧪 Testing

* [x] Tested on Web (Chrome/Safari)
* [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Added reusable API retry recovery card for Consent Center failure states.

## 🛡️ Privacy & Consent

* [x] Does this change access user data? No
* [x] Uses existing frontend resource error states only
* [x] No new storage, tracking, backend calls, or consent logic added

## 📜 Licensing

* [x] First-party changes remain Apache-2.0 compatible
* [x] Third-party notice impact reviewed when dependencies changed — no new dependencies added
