### PR TITLE
feat: add route-level suspense fallback infrastructure

### DIFF
--- a/hushh-webapp/app/consents/page.tsx
+++ b/hushh-webapp/app/consents/page.tsx
@@ -1,12 +1,12 @@
 import { Suspense } from "react";
 
-import { ConsentCenterPage } from "@/components/consent/consent-center-page";
-import { HushhLoader } from "@/components/app-ui/hushh-loader";
 import { NativeTestBeacon } from "@/components/app-ui/native-test-beacon";
+import { ConsentCenterPage } from "@/components/consent/consent-center-page";
+import { RouteSuspenseFallback } from "@/components/system/route-suspense-fallback";
 
 export default function ConsentsPage() {
   return (
-    <Suspense fallback={<HushhLoader variant="inline" label="Loading consents…" />}>
+    <Suspense fallback={<RouteSuspenseFallback label="Loading consents…" />}>
       <>
         <NativeTestBeacon
           routeId="/consents"

--- a/hushh-webapp/components/system/route-suspense-fallback.tsx
+++ b/hushh-webapp/components/system/route-suspense-fallback.tsx
@@ -1,0 +1,19 @@
+import { HushhLoader } from "@/components/app-ui/hushh-loader";
+
+type RouteSuspenseFallbackProps = {
+  label?: string;
+};
+
+export function RouteSuspenseFallback({
+  label = "Loading page…",
+}: RouteSuspenseFallbackProps) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex min-h-[320px] items-center justify-center px-6 py-12"
+    >
+      <HushhLoader variant="inline" label={label} />
+    </div>
+  );
+}


### PR DESCRIPTION
# Description

Added reusable route-level suspense fallback infrastructure and applied it to the Consent Center route.

This PR introduces `RouteSuspenseFallback`, a shared loading fallback component for route-level Suspense boundaries. The `/consents` route now uses this reusable fallback instead of directly embedding loader markup inside the page.

This improves loading consistency, accessibility, and route transition UX while creating a reusable foundation for future route-level fallback states.

No backend behavior, API contracts, schema definitions, cache keys, storage behavior, or consent authorization logic were changed.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below:
    - `/consents`

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None — route fallback uses responsive centered layout

- Docs updated (exact files):
  - [x] None

- Verification commands executed:
  - [x] `cd hushh-webapp && npm run lint`
  - [x] `cd hushh-webapp && npm run verify:design-system`
  - [x] `cd hushh-webapp && npm run build`

## 🛑 Tri-Flow Architecture Check

- [x] Web: Route-level Suspense fallback infrastructure

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Added reusable route-level fallback infrastructure and applied it to `/consents`.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] No new storage, tracking, backend calls, or consent logic added

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed — no new dependencies added
