### PR TITLE
feat(infra): docker-compose stack with profile-based services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ iwebtechno-code/
 hushh-adk-agents/
 consent-protocol-old/
 hushh_starter_idea.md
+graphify-out/
 
 # Editor/IDE
 .idea/

--- a/README.md
+++ b/README.md
@@ -139,6 +139,16 @@ Prefer the devcontainer if you want a reproducible setup with Node 20, Python 3.
 Dev Containers: Reopen in Container
 ```
 
+If you specifically need a Docker-backed local backend helper, keep it inside the
+root CLI:
+
+```bash
+./bin/hushh compose up dev
+```
+
+This starts the backend support stack only. The frontend still uses the
+canonical `./bin/hushh web` path.
+
 ## Documentation
 
 - [Getting Started](./docs/guides/getting-started.md)

--- a/bin/hushh
+++ b/bin/hushh
@@ -21,6 +21,7 @@ Core commands:
   terminal <stack|web|backend> [...]
   web [--mode <local|uat|prod>] [-- <next-dev args>]
   backend [--mode local] [--reload|--no-reload]
+  compose <init|up|down|nuke|logs|ps|config|health>
   native <ios|android> [--mode <local|uat|prod>] [--fresh]
   native mac <build|run|test>
   lint
@@ -37,10 +38,12 @@ Operational commands:
   db verify-release-contract
   db verify-uat-schema
   db report-prod-posture [--json]
+  compose <subcommand>
   protocol <subcommand>
   sync <main|check-main>
 
 Run:
+  ./bin/hushh compose --help
   ./bin/hushh protocol --help
   ./bin/hushh sync --help
   ./bin/hushh codex --help
@@ -83,6 +86,20 @@ sync_usage() {
 Usage:
   ./bin/hushh sync main
   ./bin/hushh sync check-main
+EOF
+}
+
+compose_usage() {
+  cat <<'EOF'
+Usage:
+  ./bin/hushh compose init
+  ./bin/hushh compose up [backend|cache|mail|db|dev]
+  ./bin/hushh compose down
+  ./bin/hushh compose nuke
+  ./bin/hushh compose logs [service]
+  ./bin/hushh compose ps
+  ./bin/hushh compose config
+  ./bin/hushh compose health
 EOF
 }
 
@@ -445,6 +462,14 @@ run_docs() {
       die "Unknown docs subcommand: $1"
       ;;
   esac
+}
+
+run_compose() {
+  [ "$#" -ge 1 ] || {
+    compose_usage
+    exit 1
+  }
+  exec bash "$REPO_ROOT/scripts/runtime/compose_stack.sh" "$@"
 }
 
 run_codex() {
@@ -838,6 +863,9 @@ EOF
     ;;
   docs)
     run_docs "$@"
+    ;;
+  compose)
+    run_compose "$@"
     ;;
   env)
     run_env "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,109 @@
+# Hussh local container stack.
+#
+# This is an opt-in contributor/devex surface. The canonical repo CLI remains
+# ./bin/hushh; use ./bin/hushh compose ... instead of calling docker compose
+# directly for normal repo work.
+#
+# Profiles:
+#   backend - FastAPI backend only, using consent-protocol/.env
+#   cache   - Redis only
+#   mail    - Mailhog only
+#   db      - local Postgres only; not wired into backend by default
+#   dev     - backend + Redis + Mailhog
+
+name: hushh-dev
+
+services:
+  backend:
+    profiles: ["backend", "dev"]
+    build:
+      context: ./consent-protocol
+      dockerfile: Dockerfile
+    image: hushh/backend:local
+    env_file:
+      - ./consent-protocol/.env
+    environment:
+      PORT: "8000"
+      APP_FRONTEND_ORIGIN: "http://localhost:3000"
+      CORS_ALLOWED_ORIGINS: "http://localhost:3000,http://localhost:8025"
+    ports:
+      - "8000:8000"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=3).read()",
+        ]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    restart: unless-stopped
+    networks:
+      - hushh
+
+  redis:
+    profiles: ["cache", "dev"]
+    image: redis:7-alpine
+    command:
+      [
+        "redis-server",
+        "--appendonly",
+        "yes",
+        "--maxmemory",
+        "256mb",
+        "--maxmemory-policy",
+        "allkeys-lru",
+      ]
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+    networks:
+      - hushh
+
+  mailhog:
+    profiles: ["mail", "dev"]
+    image: mailhog/mailhog:latest
+    ports:
+      - "1025:1025"
+      - "8025:8025"
+    restart: unless-stopped
+    networks:
+      - hushh
+
+  db:
+    profiles: ["db"]
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: "postgres"
+      POSTGRES_PASSWORD: "postgres"
+      POSTGRES_DB: "hushh"
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+    networks:
+      - hushh
+
+volumes:
+  redis-data:
+  db-data:
+
+networks:
+  hushh:
+    driver: bridge

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -152,6 +152,27 @@ When you do need the full local stack:
 
 That separate-terminal backend + frontend flow is the preferred maintainer path. Use `./bin/hushh terminal stack --mode local` only if you deliberately want one visible terminal window to own both processes.
 
+### Optional Container Backend Support
+
+Use the Docker-backed helper only when you intentionally want local backend
+support services in containers:
+
+```bash
+./bin/hushh compose init
+./bin/hushh compose up dev
+```
+
+The `dev` compose profile starts the backend, Redis, and Mailhog. It does not
+replace `./bin/hushh web`, and it does not switch the repo to a Docker-first
+workflow. The local Postgres profile is standalone and opt-in:
+
+```bash
+./bin/hushh compose up db
+```
+
+The backend continues to follow `consent-protocol/.env` unless an operator
+explicitly changes those values.
+
 The local backend path is the only place that uses:
 
 - `CLOUDSQL_INSTANCE_CONNECTION_NAME=hushh-pda-uat:us-central1:hushh-uat-pg`

--- a/docs/reference/operations/cli.md
+++ b/docs/reference/operations/cli.md
@@ -30,6 +30,7 @@ Use package-local commands only when you are working inside a package on purpose
 <repo-root>/bin/hushh terminal web --mode local
 <repo-root>/bin/hushh terminal web --mode uat
 <repo-root>/bin/hushh backend
+<repo-root>/bin/hushh compose up dev
 <repo-root>/bin/hushh native ios --mode local --fresh
 <repo-root>/bin/hushh lint
 <repo-root>/bin/hushh test
@@ -56,6 +57,12 @@ Use package-local commands only when you are working inside a package on purpose
 <repo-root>/bin/hushh db verify-release-contract
 <repo-root>/bin/hushh db verify-uat-schema
 <repo-root>/bin/hushh db report-prod-posture
+<repo-root>/bin/hushh compose init
+<repo-root>/bin/hushh compose up backend
+<repo-root>/bin/hushh compose up cache
+<repo-root>/bin/hushh compose up mail
+<repo-root>/bin/hushh compose up db
+<repo-root>/bin/hushh compose down
 <repo-root>/bin/hushh protocol sync
 <repo-root>/bin/hushh protocol push
 <repo-root>/bin/hushh protocol setup
@@ -72,6 +79,8 @@ Use package-local commands only when you are working inside a package on purpose
 - `./bin/hushh web` defaults to `local`; use `--mode uat` or `--mode prod` only when you explicitly want a hosted backend target.
 - Use `./bin/hushh terminal backend --mode local --reload` and `./bin/hushh terminal web --mode <mode>` as the preferred visible-terminal dev flow.
 - Use `./bin/hushh terminal stack --mode local` only when you explicitly want one combined terminal window to own both processes.
+- Use `./bin/hushh compose ...` only for opt-in local container support. It does not replace the default frontend/backend development flow.
+- The `dev` compose profile starts backend + Redis + Mailhog. The local Postgres profile is standalone unless an operator explicitly changes backend env values.
 - Use `uv` as the canonical Python install surface for `consent-protocol`; `requirements*.txt` are generated compatibility artifacts, not contributor commands.
 - Treat `./bin/hushh db verify-release-contract`, `./bin/hushh db verify-uat-schema`, and `./bin/hushh db report-prod-posture` as the authoritative DB governance surface.
 - Use `./bin/hushh codex data-model-audit` before treating new tables, durable caches, or runtime DB family changes as production-ready.

--- a/scripts/runtime/compose_stack.sh
+++ b/scripts/runtime/compose_stack.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR/../.." rev-parse --show-toplevel)"
+COMPOSE_FILE="$REPO_ROOT/docker-compose.yml"
+BACKEND_ENV="$REPO_ROOT/consent-protocol/.env"
+
+VALID_PROFILES=(backend cache mail db dev)
+
+die() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./bin/hushh compose init
+  ./bin/hushh compose up [backend|cache|mail|db|dev]
+  ./bin/hushh compose down
+  ./bin/hushh compose nuke
+  ./bin/hushh compose logs [service]
+  ./bin/hushh compose ps
+  ./bin/hushh compose config
+  ./bin/hushh compose health
+
+Defaults:
+  up defaults to dev, which starts backend + Redis + Mailhog.
+
+Notes:
+  - This is an opt-in local container stack for contributor/devex work.
+  - The frontend remains on the canonical ./bin/hushh web path.
+  - The local db profile is standalone unless you explicitly point backend env
+    values at it; backend otherwise follows consent-protocol/.env.
+EOF
+}
+
+need_docker() {
+  command -v docker >/dev/null 2>&1 || die "docker is not installed or not on PATH"
+  docker compose version >/dev/null 2>&1 || die "docker compose v2 is required"
+}
+
+is_valid_profile() {
+  local profile="$1"
+  for valid in "${VALID_PROFILES[@]}"; do
+    [ "$profile" = "$valid" ] && return 0
+  done
+  return 1
+}
+
+require_profile() {
+  local profile="$1"
+  is_valid_profile "$profile" || die "unknown compose profile '$profile' (valid: ${VALID_PROFILES[*]})"
+}
+
+require_backend_env_if_needed() {
+  local profile="$1"
+  case "$profile" in
+    backend|dev)
+      [ -f "$BACKEND_ENV" ] || die "missing consent-protocol/.env; run ./bin/hushh bootstrap first"
+      ;;
+  esac
+}
+
+compose() {
+  docker compose -f "$COMPOSE_FILE" "$@"
+}
+
+all_profiles_args() {
+  printf '%s\n' --profile dev --profile db
+}
+
+cmd_init() {
+  need_docker
+  [ -f "$COMPOSE_FILE" ] || die "missing docker-compose.yml"
+  if [ -f "$BACKEND_ENV" ]; then
+    echo "ok: consent-protocol/.env present"
+  else
+    echo "warn: consent-protocol/.env missing; backend/dev profile needs ./bin/hushh bootstrap"
+  fi
+  docker --version
+  docker compose version
+}
+
+cmd_up() {
+  local profile="${1:-dev}"
+  require_profile "$profile"
+  need_docker
+  require_backend_env_if_needed "$profile"
+  compose --profile "$profile" up -d --build
+}
+
+cmd_down() {
+  need_docker
+  compose --profile dev --profile db down
+}
+
+cmd_nuke() {
+  need_docker
+  printf 'This will stop compose services and remove local compose volumes. Type nuke to continue: '
+  read -r answer
+  [ "$answer" = "nuke" ] || {
+    echo "aborted"
+    exit 0
+  }
+  compose --profile dev --profile db down -v
+}
+
+cmd_logs() {
+  need_docker
+  if [ "$#" -gt 0 ]; then
+    compose --profile dev --profile db logs -f --tail=200 "$@"
+  else
+    compose --profile dev --profile db logs -f --tail=100
+  fi
+}
+
+cmd_ps() {
+  need_docker
+  compose --profile dev --profile db ps
+}
+
+cmd_config() {
+  need_docker
+  compose --profile dev --profile db config
+}
+
+cmd_health() {
+  local backend_url="http://localhost:8000/health"
+  local mailhog_url="http://localhost:8025"
+  echo "backend  $backend_url"
+  curl -fsS "$backend_url" || echo "backend not reachable"
+  echo
+  echo "mailhog  $mailhog_url"
+  curl -fsSI "$mailhog_url" | head -1 || echo "mailhog not reachable"
+}
+
+cmd="${1:-help}"
+shift || true
+
+case "$cmd" in
+  init) cmd_init "$@" ;;
+  up) cmd_up "$@" ;;
+  down) cmd_down "$@" ;;
+  nuke) cmd_nuke "$@" ;;
+  logs) cmd_logs "$@" ;;
+  ps) cmd_ps "$@" ;;
+  config) cmd_config "$@" ;;
+  health) cmd_health "$@" ;;
+  help|-h|--help) usage ;;
+  *) usage; exit 1 ;;
+esac


### PR DESCRIPTION
## Summary
- Normalizes this PR to an opt-in local container support path owned by `./bin/hushh compose`.
- Adds a minimal `docker-compose.yml` for backend, Redis, Mailhog, and standalone local Postgres profiles.
- Adds `scripts/runtime/compose_stack.sh` behind the root CLI and documents the flow in existing README, getting-started, and CLI references.
- Adds `graphify-out/` to `.gitignore` for generated local graph artifacts.

## Maintainer normalization
This intentionally drops the earlier root `run.sh`, `docs-site`, `CLAUDE.md`, Phoenix/OpenInference observability changes, pre-push hook, pgAdmin, frontend Docker path, and dependency/runtime changes.

Those may be discussed separately if they become canonical repo decisions. They are not part of this safe first compose slice.

## Verification
- `bash -n bin/hushh scripts/runtime/compose_stack.sh`
- `./bin/hushh compose --help`
- `./bin/hushh --help`
- `./bin/hushh docs verify`
- `bash scripts/ci/orchestrate.sh governance`
- `bash scripts/ci/orchestrate.sh secret`

Docker runtime verification was not run in the maintainer Codex environment because Docker is not installed there. The compose path fails closed with a clear Docker prerequisite check.
