### PR TITLE
fix: improve HushhLoader screen reader accessibility

### DIFF
--- a/hushh-webapp/components/app-ui/hushh-loader.tsx
+++ b/hushh-webapp/components/app-ui/hushh-loader.tsx
@@ -36,6 +36,9 @@ export function HushhLoader({
 
   return (
     <div
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
       className={cn(
         "flex items-center justify-center",
         isFullscreen


### PR DESCRIPTION
# Description

Improved accessibility support for `HushhLoader` by adding ARIA live region semantics to loading states. This allows screen readers to properly announce loading activity without changing visual behavior or business logic.

## 📌 Impact Map (Required)

* Routes touched:

  * [x] None

* API / schema / type changes:

  * [x] None

* Cache keys touched:

  * [x] None

* World-model domain summary effects:

  * [x] None

* Mobile parity impacts:

  * [x] None

* Docs updated (exact files):

  * [x] None

* Verification commands executed:

  * [x] `cd hushh-webapp && npx tsc --noEmit`
  * [ ] `cd hushh-webapp && npm test`
  * [ ] `cd hushh-webapp && npm run build`
  * [ ] `cd hushh-webapp && npm run ios:test`
  * [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000`

## 🛑 Tri-Flow Architecture Check

* [x] Not applicable — frontend accessibility attribute update only

## 🧪 Testing

* [x] Commits are signed off (`git commit -s`)
* [x] Verified no TypeScript errors introduced
* [x] Verified no ESLint issues introduced

## 📸 Screenshots / Video

N/A — accessibility-only change with no visual UI modifications.

## 🛡️ Privacy & Consent

* [x] Does not access user data

## 📜 Licensing

* [x] First-party changes remain Apache-2.0 compatible
* [x] No dependency changes introduced
