### PR TITLE
fix: improve TopAppBar back button touch target

### DIFF
--- a/hushh-webapp/components/app-ui/top-app-bar.tsx
+++ b/hushh-webapp/components/app-ui/top-app-bar.tsx
@@ -358,7 +358,7 @@ export function TopAppBar({ className }: TopAppBarProps) {
                 className="pointer-events-none flex h-full shrink-0 items-center justify-start"
                 style={{ width: "var(--top-bar-side-w)" }}
               >
-                <div className="pointer-events-auto flex h-10 w-10 items-center justify-center">
+                <div className="pointer-events-auto flex h-11 w-11 items-center justify-center">
                   {topShellBreadcrumb ? (
                     <ShellActionSurface
                       variant="icon"


### PR DESCRIPTION
# Description

Improved `TopAppBar` back button accessibility by increasing the interactive touch target from `40×40px` to `44×44px`, aligning more closely with WCAG 2.5.5 and Apple Human Interface Guidelines recommendations for minimum touch target sizing on mobile devices.

## 📌 Impact Map (Required)

* Routes touched:

  * [x] None

* API / schema / type changes:

  * [x] None

* Cache keys touched:

  * [x] None

* World-model domain summary effects:

  * [x] None

* Mobile parity impacts:

  * [x] None

* Docs updated (exact files):

  * [x] None

* Verification commands executed:

  * [x] `cd hushh-webapp && npx tsc --noEmit`
  * [x] `cd hushh-webapp && npx eslint components/app-ui/top-app-bar.tsx`
  * [ ] `cd hushh-webapp && npm test`
  * [ ] `cd hushh-webapp && npm run build`
  * [ ] `cd hushh-webapp && npm run ios:test`
  * [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000`

## 🛑 Tri-Flow Architecture Check

* [x] Not applicable — frontend accessibility sizing adjustment only

## 🧪 Testing

* [x] Tested on Web (Chrome DevTools responsive mode)
* [ ] Tested on iOS Simulator/Device
* [ ] Tested on Android Emulator/Device
* [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

* [x] Does not access user data

## 📜 Licensing

* [x] First-party changes remain Apache-2.0 compatible
* [x] No dependency changes introduced
