### PR TITLE
fix: improve RiaStatusPanel metric grid responsiveness

### DIFF
--- a/hushh-webapp/components/ria/ria-page-shell.tsx
+++ b/hushh-webapp/components/ria/ria-page-shell.tsx
@@ -219,7 +219,7 @@ export function RiaStatusPanel({
         {actions ? <div className="flex shrink-0 flex-wrap gap-2">{actions}</div> : null}
       </div>
 
-      <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
+      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
         {items.map((item) => (
           <div
             key={`${item.label}-${item.value}`}


### PR DESCRIPTION
# Description

Improved `RiaStatusPanel` grid responsiveness by updating the metric grid breakpoint from `xl` to `lg`, allowing the 4-column layout to activate earlier on medium-to-large laptop screens.

## 📌 Impact Map (Required)

* Routes touched:

  * [x] None

* API / schema / type changes:

  * [x] None

* Cache keys touched:

  * [x] None

* World-model domain summary effects:

  * [x] None

* Mobile parity impacts:

  * [x] None

* Docs updated (exact files):

  * [x] None

* Verification commands executed:

  * [x] `cd hushh-webapp && npx tsc --noEmit`
  * [x] `cd hushh-webapp && npx eslint components/ria/ria-page-shell.tsx`
  * [ ] `cd hushh-webapp && npm test`
  * [ ] `cd hushh-webapp && npm run build`
  * [ ] `cd hushh-webapp && npm run ios:test`
  * [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000`

## 🛑 Tri-Flow Architecture Check

* [x] Not applicable — frontend responsive layout adjustment only

## 🧪 Testing

* [x] Tested on Web (Chrome DevTools responsive mode)
* [ ] Tested on iOS Simulator/Device
* [ ] Tested on Android Emulator/Device
* [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

* [x] Does not access user data

## 📜 Licensing

* [x] First-party changes remain Apache-2.0 compatible
* [x] No dependency changes introduced
