### PR TITLE
fix: align SettingsDetailPanel safe-area handling with app token

### DIFF
--- a/hushh-webapp/components/app-ui/settings-ui.tsx
+++ b/hushh-webapp/components/app-ui/settings-ui.tsx
@@ -390,7 +390,7 @@ export function SettingsDetailPanel({
               </DrawerDescription>
             ) : null}
           </DrawerHeader>
-          <div className="flex-1 overflow-y-auto bg-[color:var(--app-card-surface-default-solid)] px-3 pb-[calc(env(safe-area-inset-bottom)+2rem)] pt-3 sm:px-4 sm:pt-4">
+          <div className="flex-1 overflow-y-auto bg-[color:var(--app-card-surface-default-solid)] px-3 pb-[calc(var(--app-safe-area-bottom-effective,env(safe-area-inset-bottom,0px))+2rem)] pt-3 sm:px-4 sm:pt-4">
             {children}
           </div>
         </DrawerContent>


### PR DESCRIPTION
# Description

Aligned `SettingsDetailPanel` safe-area padding handling with the existing app-level safe-area token infrastructure by replacing direct `env(safe-area-inset-bottom)` usage with the shared `--app-safe-area-bottom-effective` token fallback chain.

This keeps spacing behavior consistent with the rest of the app and improves fallback handling for browsers/WebViews where direct `env()` values may not resolve reliably.

## 📌 Impact Map (Required)

* Routes touched:

  * [x] None

* API / schema / type changes:

  * [x] None

* Cache keys touched:

  * [x] None

* World-model domain summary effects:

  * [x] None

* Mobile parity impacts:

  * [x] None

* Docs updated (exact files):

  * [x] None

* Verification commands executed:

  * [x] `cd hushh-webapp && npx tsc --noEmit`
  * [x] `cd hushh-webapp && npx eslint components/app-ui/settings-ui.tsx`
  * [ ] `cd hushh-webapp && npm test`
  * [ ] `cd hushh-webapp && npm run build`
  * [ ] `cd hushh-webapp && npm run ios:test`
  * [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000`

## 🛑 Tri-Flow Architecture Check

* [x] Not applicable — frontend spacing and safe-area token alignment only

## 🧪 Testing

* [x] Tested on Web (Chrome DevTools responsive mode)
* [ ] Tested on iOS Simulator/Device
* [ ] Tested on Android Emulator/Device
* [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

* [x] Does not access user data

## 📜 Licensing

* [x] First-party changes remain Apache-2.0 compatible
* [x] No dependency changes introduced
