### PR TITLE
feat(one-mac): Phase 0 skeleton for native macOS One app

### DIFF
--- a/.codex/skills/desktop-mac-connectors/SKILL.md
+++ b/.codex/skills/desktop-mac-connectors/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: desktop-mac-connectors
+description: Use when implementing or reviewing Mac-side knowledge connectors (local filesystem, Spotlight, Apple Notes, Apple Mail, Calendar, Obsidian, Notion, Google Drive, Slack) inside the desktop-mac owner family.
+---
+
+# Hussh Desktop Mac Connectors Skill
+
+## Purpose and Trigger
+
+- Primary scope: `desktop-mac-connectors`
+- Trigger on Mac-side knowledge connector implementation, OAuth refresh handling, AppleScript bridges, and connector revocation propagation.
+- Avoid overlap with `desktop-mac-mcp-host` and `vault-pkm-governance`.
+
+## Coverage and Ownership
+
+- Role: `spoke`
+- Owner family: `desktop-mac`
+
+Owned repo surfaces:
+
+1. `apps/one-mac/Sources/OneIndexer`
+
+Non-owned surfaces:
+
+1. `desktop-mac`
+2. `mobile-native`
+3. `backend`
+
+## Do Use
+
+1. Implementing or extending the `Connector` SwiftPM protocol per source.
+2. AppleScript bridges, MailKit, EventKit, FSEvents watchers, and OAuth refresh flows.
+3. Connector revocation cascades, permission state machines, and ingestion backpressure.
+
+## Do Not Use
+
+1. Local MCP server or OpenClaw conformance work — use `desktop-mac-mcp-host`.
+2. Vault encryption or PKM writeback shape changes — use `vault-pkm-governance`.
+3. Broad Mac-app intake where the connector boundary is unclear.
+
+## Read First
+
+1. `docs/future/one-mac-knowledge-base-app.md`
+2. `apps/one-mac/README.md`
+3. `hushh-webapp/ios/App/CapApp-SPM/Package.swift`
+
+## Workflow
+
+1. Pick one connector at a time; never bundle connectors across PRs.
+2. Each connector is its own SwiftPM target with its own permission state machine.
+3. Persist OAuth refresh tokens in Keychain access group `ai.hushh.one`, never in SQLite.
+4. AppleScript-dependent sources must ship an alternative path for when the bridge is TCC-denied.
+5. Connector revocation must cascade: invalidate all derived DATs, flush ciphertext blobs for that domain, and append to the local consent log.
+
+## Handoff Rules
+
+1. If the request is broad Mac-app intake, route it back to `desktop-mac`.
+2. If the work touches the local MCP server, OpenClaw bindings, or CRT minting, use `desktop-mac-mcp-host`.
+3. If the work touches vault encryption, PKM domain shapes, or cloud ciphertext routes, use `vault-pkm-governance`.
+
+## Required Checks
+
+```bash
+./bin/hushh native mac build
+./bin/hushh native mac test
+```

--- a/.codex/skills/desktop-mac-connectors/skill.json
+++ b/.codex/skills/desktop-mac-connectors/skill.json
@@ -1,0 +1,54 @@
+{
+  "id": "desktop-mac-connectors",
+  "role": "spoke",
+  "owner_family": "desktop-mac",
+  "primary_scope": "desktop-mac-connectors",
+  "description": "Use when implementing or reviewing Mac-side knowledge connectors (local filesystem, Spotlight, Apple Notes, Apple Mail, Calendar, Obsidian, Notion, Google Drive, Slack) inside the desktop-mac owner family.",
+  "owned_paths": [
+    "apps/one-mac/Sources/OneIndexer"
+  ],
+  "non_owned_paths": [
+    "desktop-mac",
+    "mobile-native",
+    "backend"
+  ],
+  "task_types": [
+    "new-feature-tri-flow"
+  ],
+  "required_reads": [
+    "docs/future/one-mac-knowledge-base-app.md",
+    "apps/one-mac/README.md",
+    "hushh-webapp/ios/App/CapApp-SPM/Package.swift"
+  ],
+  "required_commands": [
+    "./bin/hushh native mac build",
+    "./bin/hushh native mac test"
+  ],
+  "verification_bundles": [
+    {
+      "id": "desktop-mac-connectors-core",
+      "commands": [
+        "./bin/hushh native mac build",
+        "./bin/hushh native mac test"
+      ],
+      "tests": [
+        "./bin/hushh native mac test"
+      ]
+    }
+  ],
+  "handoff_targets": [
+    "desktop-mac",
+    "desktop-mac-mcp-host",
+    "vault-pkm-governance"
+  ],
+  "adjacent_skills": [
+    "desktop-mac",
+    "vault-pkm-governance",
+    "mobile-native"
+  ],
+  "risk_tags": [
+    "connector-permission-drift",
+    "oauth-refresh-drift",
+    "applescript-bridge-drift"
+  ]
+}

--- a/.codex/skills/desktop-mac-mcp-host/SKILL.md
+++ b/.codex/skills/desktop-mac-mcp-host/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: desktop-mac-mcp-host
+description: Use when implementing or reviewing the local MCP HTTP/SSE host on the Mac, the OpenClaw DataSourceBinding interface, CRT/DAT minting, or the OpenClaw conformance test harness inside the desktop-mac owner family.
+---
+
+# Hussh Desktop Mac MCP Host Skill
+
+## Purpose and Trigger
+
+- Primary scope: `desktop-mac-mcp-host`
+- Trigger on local MCP server work, OpenClaw DataSourceBinding protocol design, CRT and DAT minting on the Mac, OpenClaw conformance test harness, and BYOA agent bearer-token workflow.
+- Avoid overlap with `mcp-developer-surface` and `hushh-consent-mcp`.
+
+## Coverage and Ownership
+
+- Role: `spoke`
+- Owner family: `desktop-mac`
+
+Owned repo surfaces:
+
+1. `apps/one-mac/Sources/OneMCPServer`
+
+Non-owned surfaces:
+
+1. `desktop-mac`
+2. `mcp-developer-surface`
+3. `hushh-consent-mcp`
+
+## Do Use
+
+1. Designing or evolving the OpenClaw `DataSourceBinding` Swift protocol.
+2. Local CRT minting, hourly rotation, and revocation propagation.
+3. OpenClaw conformance test harness under `apps/one-mac/Tests`.
+4. BYOA pane MCP-config snippet generation for Claude Desktop, Cursor, ChatGPT MCP, and Codex.
+
+## Do Not Use
+
+1. Knowledge-source ingestion work — use `desktop-mac-connectors`.
+2. Hosted Consent MCP at `https://api.uat.hushh.ai/mcp/` — use `hushh-consent-mcp`.
+3. Broad Mac-app intake where the MCP boundary is unclear.
+
+## Read First
+
+1. `docs/future/one-mac-knowledge-base-app.md`
+2. `consent-protocol/hushh_mcp/consent/token.py`
+3. `consent-protocol/api/routes/pkm_routes_shared.py`
+
+## Workflow
+
+1. Mirror the Python `hushh_mcp/consent/token.py` payload format byte-for-byte; the Swift port must round-trip with the Python source.
+2. Keep `apps/one-mac/Sources/OneMCPServer/` open-sourceable in isolation: Apache-2.0, no Hussh-only dependencies.
+3. Match One-mac MCP tool shapes to the existing hosted Consent MCP tools (`discover_user_domains`, `request_consent`, `check_consent_status`, `get_encrypted_scoped_export`, `validate_token`, `list_scopes`) so iOS consumers need zero changes.
+4. Every MCP call must run validate CRT, then check DAT scope, then check Domain registry, then execute, then append a local consent log row plus a cloud transparency POST.
+5. Treat the OpenClaw conformance test harness as the canonical contract; do not let the binding diverge from the harness without a documented migration.
+
+## Handoff Rules
+
+1. If the request is broad Mac-app intake, route it back to `desktop-mac`.
+2. If the work touches knowledge-source ingestion or connector adapters, use `desktop-mac-connectors`.
+3. If the work touches the hosted Consent MCP or its tool catalog, use `hushh-consent-mcp`.
+4. If the work touches generic MCP developer-surface contracts shared across non-Mac surfaces, use `mcp-developer-surface`.
+
+## Required Checks
+
+```bash
+./bin/hushh native mac build
+./bin/hushh native mac test
+```

--- a/.codex/skills/desktop-mac-mcp-host/skill.json
+++ b/.codex/skills/desktop-mac-mcp-host/skill.json
@@ -1,0 +1,56 @@
+{
+  "id": "desktop-mac-mcp-host",
+  "role": "spoke",
+  "owner_family": "desktop-mac",
+  "primary_scope": "desktop-mac-mcp-host",
+  "description": "Use when implementing or reviewing the local MCP HTTP/SSE host on the Mac, the OpenClaw DataSourceBinding interface, CRT/DAT minting, or the OpenClaw conformance test harness inside the desktop-mac owner family.",
+  "owned_paths": [
+    "apps/one-mac/Sources/OneMCPServer"
+  ],
+  "non_owned_paths": [
+    "desktop-mac",
+    "mcp-developer-surface",
+    "hushh-consent-mcp"
+  ],
+  "task_types": [
+    "mcp-surface-change"
+  ],
+  "required_reads": [
+    "docs/future/one-mac-knowledge-base-app.md",
+    "consent-protocol/hushh_mcp/consent/token.py",
+    "consent-protocol/api/routes/pkm_routes_shared.py"
+  ],
+  "required_commands": [
+    "./bin/hushh native mac build",
+    "./bin/hushh native mac test"
+  ],
+  "verification_bundles": [
+    {
+      "id": "desktop-mac-mcp-host-core",
+      "commands": [
+        "./bin/hushh native mac build",
+        "./bin/hushh native mac test"
+      ],
+      "tests": [
+        "./bin/hushh native mac test"
+      ]
+    }
+  ],
+  "handoff_targets": [
+    "desktop-mac",
+    "desktop-mac-connectors",
+    "hushh-consent-mcp",
+    "mcp-developer-surface"
+  ],
+  "adjacent_skills": [
+    "desktop-mac",
+    "hushh-consent-mcp",
+    "mcp-developer-surface",
+    "vault-pkm-governance"
+  ],
+  "risk_tags": [
+    "mcp-host-drift",
+    "openclaw-conformance-drift",
+    "crt-rotation-drift"
+  ]
+}

--- a/.codex/skills/desktop-mac/SKILL.md
+++ b/.codex/skills/desktop-mac/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: desktop-mac
+description: Use when the request is broadly about the native macOS One app, the LaunchAgent daemon, the on-device knowledge index, the local MCP host, or BYOA agent surfaces on a Mac, and the correct Mac specialist spoke is not yet clear.
+---
+
+# Hussh Desktop Mac Skill
+
+## Purpose and Trigger
+
+- Primary scope: `desktop-mac-intake`
+- Trigger on broad native macOS requests across the SwiftUI app shell, the LaunchAgent daemon, the local MCP host, BYOA agent bridges, and Mac-side knowledge indexing.
+- Avoid overlap with `mobile-native` and `repo-context`.
+
+## Coverage and Ownership
+
+- Role: `owner`
+- Owner family: `desktop-mac`
+
+Owned repo surfaces:
+
+1. `apps/one-mac`
+2. `docs/future/one-mac-knowledge-base-app.md`
+
+Non-owned surfaces:
+
+1. `mobile-native`
+2. `backend`
+3. `docs-governance`
+
+## Do Use
+
+1. Broad Mac-app intake before the correct spoke (connectors vs MCP host) is clear.
+2. SwiftUI shell, App Intents, Nav UI parity, and BYOA pane work on the Mac surface.
+3. Choosing whether a request belongs to the connectors spoke or the MCP host spoke.
+
+## Do Not Use
+
+1. iOS or Android Capacitor work — route to `mobile-native`.
+2. Backend-only consent-protocol route or service work.
+3. Generic frontend or docs work without a Mac surface.
+
+## Read First
+
+1. `docs/future/one-mac-knowledge-base-app.md`
+2. `apps/one-mac/README.md`
+3. `docs/future/README.md`
+
+## Workflow
+
+1. Classify the request: SwiftUI shell + App Intents + Nav UI, connector ingestion, or local MCP host.
+2. Keep the Mac index canonical and the cloud a ciphertext mirror — never invent a plaintext writeback path.
+3. Match the shipped ZK definition (AES-256-GCM + HMAC bearer); do not introduce Merkle or Pedersen primitives without a promotion gate.
+4. Treat `apps/one-mac/Sources/OneMCPServer/` as the first OpenClaw reference implementation — Apache-2.0, no Hussh-only dependencies.
+5. Reuse the Python `hushh_mcp/consent/token.py` payload format byte-for-byte in the Swift port — do not fork the token shape.
+
+## Handoff Rules
+
+1. Route connector ingestion work to `desktop-mac-connectors`.
+2. Route local MCP host + OpenClaw conformance work to `desktop-mac-mcp-host`.
+3. Route consent-protocol vault and PKM writeback changes to `vault-pkm-governance`.
+4. Route MCP surface or consent-MCP changes to `mcp-developer-surface` or `hushh-consent-mcp` when the boundary is server-side.
+5. Route broad repo mapping back to `repo-context`.
+
+## Required Checks
+
+```bash
+./bin/hushh native mac build
+./bin/hushh native mac test
+python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py
+```

--- a/.codex/skills/desktop-mac/skill.json
+++ b/.codex/skills/desktop-mac/skill.json
@@ -1,0 +1,63 @@
+{
+  "id": "desktop-mac",
+  "role": "owner",
+  "owner_family": "desktop-mac",
+  "primary_scope": "desktop-mac-intake",
+  "description": "Use when the request is broadly about the native macOS One app, the LaunchAgent daemon, the on-device knowledge index, the local MCP host, or BYOA agent surfaces on a Mac, and the correct Mac specialist spoke is not yet clear.",
+  "owned_paths": [
+    "apps/one-mac",
+    "docs/future/one-mac-knowledge-base-app.md"
+  ],
+  "non_owned_paths": [
+    "mobile-native",
+    "backend",
+    "docs-governance"
+  ],
+  "task_types": [
+    "new-feature-tri-flow",
+    "release-readiness"
+  ],
+  "required_reads": [
+    "docs/future/one-mac-knowledge-base-app.md",
+    "apps/one-mac/README.md",
+    "docs/future/README.md"
+  ],
+  "required_commands": [
+    "./bin/hushh native mac build",
+    "./bin/hushh native mac test",
+    "python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py"
+  ],
+  "verification_bundles": [
+    {
+      "id": "desktop-mac-core",
+      "commands": [
+        "./bin/hushh native mac build",
+        "./bin/hushh native mac test"
+      ],
+      "tests": [
+        "./bin/hushh native mac test"
+      ]
+    }
+  ],
+  "handoff_targets": [
+    "desktop-mac-connectors",
+    "desktop-mac-mcp-host",
+    "vault-pkm-governance",
+    "mcp-developer-surface",
+    "hushh-consent-mcp",
+    "repo-context"
+  ],
+  "adjacent_skills": [
+    "mobile-native",
+    "vault-pkm-governance",
+    "mcp-developer-surface",
+    "hushh-consent-mcp",
+    "iam-consent-governance",
+    "oss-license-governance"
+  ],
+  "risk_tags": [
+    "desktop-mac-host-drift",
+    "openclaw-conformance-drift",
+    "byoa-agent-trust-drift"
+  ]
+}

--- a/.github/workflows/one-mac.yml
+++ b/.github/workflows/one-mac.yml
@@ -1,0 +1,35 @@
+name: "One for macOS — Build & Test"
+
+on:
+  pull_request:
+    branches: ["**"]
+    paths:
+      - "apps/one-mac/**"
+      - ".github/workflows/one-mac.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: one-mac-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: "Swift build + test"
+    runs-on: macos-15
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: apps/one-mac
+    steps:
+      - uses: actions/checkout@v6
+      - name: Show Swift version
+        run: swift --version
+      - name: Resolve package dependencies
+        run: swift package resolve
+      - name: Build
+        run: swift build
+      - name: Test
+        run: swift test

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -12,6 +12,7 @@ path = [
   "scripts/**",
   "config/**",
   "deploy/**",
+  "apps/**",
   "packages/hushh-mcp/**",
   "consent-protocol/README.md",
   "consent-protocol/CONTRIBUTING.md",

--- a/apps/one-mac/Package.swift
+++ b/apps/one-mac/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.10
+// SPDX-FileCopyrightText: 2026 Hushh
+// SPDX-License-Identifier: Apache-2.0
+
+import PackageDescription
+
+let package = Package(
+    name: "OneMac",
+    platforms: [.macOS(.v14)],
+    products: [
+        .library(name: "OneShared", targets: ["OneShared"]),
+        .library(name: "OneIndexer", targets: ["OneIndexer"]),
+        .library(name: "OneMCPServer", targets: ["OneMCPServer"]),
+        .executable(name: "OneMac", targets: ["OneMac"]),
+        .executable(name: "OneDaemon", targets: ["OneDaemon"]),
+    ],
+    targets: [
+        .target(name: "OneShared"),
+        .target(name: "OneIndexer", dependencies: ["OneShared"]),
+        .target(name: "OneMCPServer", dependencies: ["OneShared", "OneIndexer"]),
+        .executableTarget(name: "OneMac", dependencies: ["OneShared"]),
+        .executableTarget(name: "OneDaemon", dependencies: ["OneShared", "OneIndexer", "OneMCPServer"]),
+        .testTarget(name: "OneSharedTests", dependencies: ["OneShared"]),
+    ]
+)

--- a/apps/one-mac/README.md
+++ b/apps/one-mac/README.md
@@ -1,0 +1,51 @@
+# 🤫 One for macOS
+
+> **Hussh = `[hu]man [s]ecure [s]ocket [h]ost`.**
+> One for macOS is the **host**: the user's latest Apple-silicon Mac runs the daemon, the on-device index, and the secure socket (local MCP server) that exposes user-owned knowledge — under PCHP consent — to BYOA agents and trusted people.
+
+Status: **Phase 0 skeleton.** Connectors, MCP server logic, and consent-protocol writeback land in Phases 1+. See [`docs/future/one-mac-knowledge-base-app.md`](../../docs/future/one-mac-knowledge-base-app.md) for the planning-only roadmap and promotion criteria.
+
+## What this package will become
+
+A native SwiftUI Mac app + LaunchAgent daemon that:
+
+1. Ingests local + cloud knowledge sources (Files, Spotlight, Apple Notes, Apple Mail, Calendar, Obsidian, Notion, Google Drive, Slack) into an encrypted SQLite + MLX vector index.
+2. Exposes that index to BYOA AI agents (Claude / ChatGPT / Cursor / local MLX) via a local MCP HTTP/SSE server on `127.0.0.1:31070`.
+3. Serves as the first concrete **OpenClaw** reference implementation — Apache-2.0, forkable, pluggable `DataSourceBinding` interface.
+4. Mirrors PKM ciphertext to the cloud via the existing PKM contract at [`consent-protocol/api/routes/pkm_routes_shared.py`](../../consent-protocol/api/routes/pkm_routes_shared.py). **Plaintext never traverses cloud.**
+5. Bridges to the existing iOS Capacitor app via the existing hosted Consent MCP at `https://api.uat.hushh.ai/mcp/` — ciphertext-only relay.
+
+## Layout
+
+```
+apps/one-mac/
+  Package.swift
+  Sources/
+    OneShared/          KnowledgeItem, protocols, errors
+    OneIndexer/         SQLite + MLX embedder (stubbed in Phase 0)
+    OneMCPServer/       OpenClaw DataSourceBinding host (stubbed in Phase 0)
+    OneDaemon/          LaunchAgent (SMAppService) — stubbed in Phase 0
+    OneMac/             SwiftUI app shell
+  Tests/
+    OneSharedTests/
+  Resources/            entitlements, Info.plist, LaunchAgent plist
+```
+
+## Build
+
+```bash
+./bin/hushh native mac build
+./bin/hushh native mac run
+```
+
+Or directly:
+
+```bash
+cd apps/one-mac
+swift build
+swift test
+```
+
+## License
+
+Apache-2.0. See repo-root `LICENSE`. Per-file SPDX headers conform to the [REUSE](https://reuse.software/) specification.

--- a/apps/one-mac/Sources/OneDaemon/main.swift
+++ b/apps/one-mac/Sources/OneDaemon/main.swift
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 Hushh
+// SPDX-License-Identifier: Apache-2.0
+
+import Foundation
+import OneShared
+import OneIndexer
+import OneMCPServer
+
+@main
+struct OneDaemon {
+    static func main() {
+        FileHandle.standardOutput.write(Data("ai.hushh.one.daemon stub\n".utf8))
+    }
+}

--- a/apps/one-mac/Sources/OneIndexer/Indexer.swift
+++ b/apps/one-mac/Sources/OneIndexer/Indexer.swift
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Hushh
+// SPDX-License-Identifier: Apache-2.0
+
+import OneShared
+
+public enum OneIndexer {
+    public static let placeholder = "OneIndexer stub"
+}

--- a/apps/one-mac/Sources/OneMCPServer/Server.swift
+++ b/apps/one-mac/Sources/OneMCPServer/Server.swift
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 Hushh
+// SPDX-License-Identifier: Apache-2.0
+
+import OneShared
+import OneIndexer
+
+public enum OneMCPServer {
+    public static let placeholder = "OneMCPServer stub (first OpenClaw reference impl target)"
+}

--- a/apps/one-mac/Sources/OneMac/OneMacApp.swift
+++ b/apps/one-mac/Sources/OneMac/OneMacApp.swift
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 Hushh
+// SPDX-License-Identifier: Apache-2.0
+
+import SwiftUI
+
+@main
+struct OneMacApp: App {
+    var body: some Scene {
+        WindowGroup("One") {
+            ContentView()
+        }
+    }
+}
+
+struct ContentView: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("🤫 One")
+                .font(.largeTitle)
+            Text("Hello, your agents — yours to own.")
+                .foregroundStyle(.secondary)
+        }
+        .padding(40)
+        .frame(minWidth: 480, minHeight: 320)
+    }
+}

--- a/apps/one-mac/Sources/OneShared/KnowledgeItem.swift
+++ b/apps/one-mac/Sources/OneShared/KnowledgeItem.swift
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 Hushh
+// SPDX-License-Identifier: Apache-2.0
+
+import Foundation
+
+public struct KnowledgeItem: Codable, Equatable, Sendable {
+    public let id: String
+    public let source: String
+    public let kind: String
+    public let title: String
+    public let body: String
+    public let createdAt: Date
+    public let modifiedAt: Date
+    public let sourceURL: URL?
+    public let embeddingId: String?
+    public let encryptionKeyId: String
+    public let transparencyLogId: String?
+
+    public init(
+        id: String,
+        source: String,
+        kind: String,
+        title: String,
+        body: String,
+        createdAt: Date,
+        modifiedAt: Date,
+        sourceURL: URL? = nil,
+        embeddingId: String? = nil,
+        encryptionKeyId: String,
+        transparencyLogId: String? = nil
+    ) {
+        self.id = id
+        self.source = source
+        self.kind = kind
+        self.title = title
+        self.body = body
+        self.createdAt = createdAt
+        self.modifiedAt = modifiedAt
+        self.sourceURL = sourceURL
+        self.embeddingId = embeddingId
+        self.encryptionKeyId = encryptionKeyId
+        self.transparencyLogId = transparencyLogId
+    }
+}

--- a/apps/one-mac/THIRD_PARTY_NOTICES.md
+++ b/apps/one-mac/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,15 @@
+# Third-Party Notices — One for macOS
+
+This package is Apache-2.0 licensed. Below are third-party dependencies that will be introduced in later phases. Phase 0 has no third-party Swift dependencies — only the Swift / SwiftUI / Foundation standard libraries.
+
+## Phase 1+ planned dependencies
+
+| Library | License | Used for | Phase |
+|---|---|---|---|
+| [mlx-swift](https://github.com/ml-explore/mlx-swift) | MIT | On-device embeddings + classification | 1 |
+| [Hummingbird](https://github.com/hummingbird-project/hummingbird) | Apache-2.0 | Local MCP HTTP/SSE server | 1 |
+| [swift-log](https://github.com/apple/swift-log) | Apache-2.0 | Structured logging | 1 |
+| [GRDB.swift](https://github.com/groue/GRDB.swift) | MIT | SQLite + FTS5 + migrations | 1 |
+| [swift-syntax](https://github.com/apple/swift-syntax) | Apache-2.0 | App Intents codegen helpers | 3 |
+
+Each new dependency added in a subsequent PR must update this file with library name, license, role, and the phase that introduced it.

--- a/apps/one-mac/Tests/OneSharedTests/KnowledgeItemTests.swift
+++ b/apps/one-mac/Tests/OneSharedTests/KnowledgeItemTests.swift
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 Hushh
+// SPDX-License-Identifier: Apache-2.0
+
+import XCTest
+@testable import OneShared
+
+final class KnowledgeItemTests: XCTestCase {
+    func testCodableRoundTrip() throws {
+        let original = KnowledgeItem(
+            id: "item-1",
+            source: "local_fs",
+            kind: "markdown",
+            title: "Test",
+            body: "body",
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            modifiedAt: Date(timeIntervalSince1970: 1_700_000_100),
+            sourceURL: URL(string: "file:///tmp/test.md"),
+            embeddingId: "emb-1",
+            encryptionKeyId: "key-1",
+            transparencyLogId: "tlog-1"
+        )
+
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        let data = try encoder.encode(original)
+        let restored = try decoder.decode(KnowledgeItem.self, from: data)
+
+        XCTAssertEqual(original, restored)
+    }
+}

--- a/bin/hushh
+++ b/bin/hushh
@@ -22,6 +22,7 @@ Core commands:
   web [--mode <local|uat|prod>] [-- <next-dev args>]
   backend [--mode local] [--reload|--no-reload]
   native <ios|android> [--mode <local|uat|prod>] [--fresh]
+  native mac <build|run|test>
   lint
   test
   ci [--include-advisory]
@@ -269,10 +270,45 @@ EOF
     -- "${command_args[@]}"
 }
 
+run_native_mac() {
+  local action="${1:-build}"
+  shift || true
+
+  case "$action" in
+    -h|--help)
+      cat <<'EOF'
+Usage:
+  ./bin/hushh native mac <build|run|test>
+
+Subcommands:
+  build   swift build inside apps/one-mac/ (default)
+  run     swift run OneMac inside apps/one-mac/
+  test    swift test inside apps/one-mac/
+EOF
+      exit 0
+      ;;
+    build|run|test) ;;
+    *)
+      die "native mac subcommand must be build, run, or test"
+      ;;
+  esac
+
+  cd "$REPO_ROOT/apps/one-mac"
+  case "$action" in
+    build) exec swift build ;;
+    run)   exec swift run OneMac ;;
+    test)  exec swift test ;;
+  esac
+}
+
 run_native() {
-  [ "$#" -ge 1 ] || die "native requires <ios|android>"
+  [ "$#" -ge 1 ] || die "native requires <ios|android|mac>"
   local platform="$1"
   shift
+  if [ "$platform" = "mac" ]; then
+    run_native_mac "$@"
+    return
+  fi
   local mode="uat"
   local fresh="false"
 
@@ -290,6 +326,7 @@ run_native() {
         cat <<'EOF'
 Usage:
   ./bin/hushh native <ios|android> [--mode <local|uat|prod>] [--fresh]
+  ./bin/hushh native mac <build|run|test>
 EOF
         exit 0
         ;;
@@ -302,7 +339,7 @@ EOF
   case "$platform" in
     ios|android) ;;
     *)
-      die "native platform must be ios or android"
+      die "native platform must be ios, android, or mac"
       ;;
   esac
 

--- a/docs/future/one-mac-knowledge-base-app.md
+++ b/docs/future/one-mac-knowledge-base-app.md
@@ -1,0 +1,117 @@
+# One for macOS — Knowledge-Base App Plan
+
+Status: **planning-only roadmap.** This is not a current-state implementation contract. Code lives at [`apps/one-mac/`](../../apps/one-mac/); it currently contains only a Phase 0 skeleton.
+
+## Framing
+
+> **Hussh = `[hu]man [s]ecure [s]ocket [h]ost`.**
+>
+> One for macOS is the **host** in that mnemonic: the user's latest Apple-silicon Mac runs the daemon, the encrypted on-device index, and the **secure socket** (local MCP HTTP/SSE server) that exposes user-owned knowledge — under PCHP consent — to BYOA agents (Claude / ChatGPT / Cursor / local MLX) and to trusted people.
+
+## Visual Map
+
+```mermaid
+flowchart TB
+  user["Mac owner<br/>BYOA + BYO infra"]
+  one_mac["apps/one-mac/<br/>SwiftUI shell + LaunchAgent daemon"]
+  index["Local index<br/>SQLite + MLX vectors<br/>AES-256-GCM, SE-wrapped keys"]
+  mcp["OneMCPServer<br/>127.0.0.1:31070<br/>first OpenClaw reference impl"]
+  cloud["Hussh cloud<br/>ciphertext + manifests only<br/>pkm_routes_shared.py"]
+  agents["BYOA agents<br/>Claude / ChatGPT / Cursor / MLX"]
+  iphone["iPhone One<br/>existing Capacitor app"]
+
+  user --> one_mac
+  one_mac --> index
+  one_mac --> mcp
+  mcp --> agents
+  one_mac --> cloud
+  cloud --> iphone
+```
+
+## Current Overlap
+
+The repo already ships pieces the One-mac plan reuses:
+
+- the PKM data shapes at [`consent-protocol/api/routes/pkm_routes_shared.py`](../../consent-protocol/api/routes/pkm_routes_shared.py) (`DomainSummary`, `PersonalKnowledgeModelIndex`) — Mac index will mirror them so the cloud is a ciphertext-redundant mirror
+- the HMAC-signed bearer token primitives at [`consent-protocol/hushh_mcp/consent/token.py`](../../consent-protocol/hushh_mcp/consent/token.py) (`HCT:` payload format with `user_id|agent_id|scope|issued_at|expires_at[|commercial]`) — One-mac CRTs will use the same format, ported into Swift under `apps/one-mac/Sources/OneConsent/`
+- the existing hosted Consent MCP (`discover_user_domains`, `request_consent`, `check_consent_status`, `get_encrypted_scoped_export`, `validate_token`, `list_scopes`) — One-mac MCP tools will have analogous shapes so the iPhone's existing `PersonalKnowledgeModelPlugin` in [`hushh-webapp/ios/App/CapApp-SPM/Package.swift`](../../hushh-webapp/ios/App/CapApp-SPM/Package.swift) needs zero changes to read Mac-written ciphertext
+- the Nav 5-tab prototype + 4-phase handshake animation — Mac UI is a port, not a fork, of the existing surface
+
+## Missing Primitives
+
+Before One-mac becomes current-state runtime, the repo needs these primitives:
+
+1. Swift port of `hushh_mcp/consent/token.py` (HMAC-SHA256 over the canonical `HCT:` payload).
+2. A new `local_mcp_session` consent scope with short TTL + device-binding field in `consent-protocol/hushh_mcp/constants.py`.
+3. A new desktop pairing route under `consent-protocol/api/routes/one/` (planned filename `desktop.py`, sibling of `email.py`) for device registration, pair manifest sync, and revocation propagation.
+4. New PKM domain keys: `macos_index`, `macos_local_fs`, `macos_apple_notes`, `macos_apple_mail`, `macos_calendar`, `macos_obsidian`, `macos_notion`, `macos_gdrive`, `macos_slack`.
+5. A `DataSourceBinding` Swift protocol in `apps/one-mac/Sources/OneMCPServer/` designed to be the first concrete reference implementation of the planned **OpenClaw** open-source consent-MCP host.
+6. An OpenClaw conformance test harness under `apps/one-mac/Tests/OneMCPServerTests/openclaw-conformance/`.
+7. A device-pairing CRT ceremony (QR + biometric) that issues a per-device key envelope, recorded in both local `device_pairings` and the cloud `desktop` registry.
+8. App Intents conformance for the 10 v1 verbs (`SearchMyKnowledge`, `OpenSource`, `ShowConsentLog`, `ListAgentsConnected`, `RevokeAgent`, `GrantToPerson`, `RevokeFromPerson`, `RebuildIndex`, `PauseIngest`, `ResumeIngest`) plus entity types.
+9. A Mac-side Nav UI that mirrors — does not parallel — the existing 5-tab prototype (Home / Private Vault / Agent Requests / Nav Rules Engine / Audit Log) and the 4-phase handshake animation.
+10. A signed Developer ID build pipeline with notarization for v1; a separate sandbox-compatible MAS build for v2.
+
+## ZK Posture
+
+One-mac matches Hussh's **shipped** zero-knowledge definition: client-side AES-256-GCM with Secure-Enclave-wrapped keys + HMAC-signed bearer tokens. Plaintext exists only in the daemon's process memory during a consented read. Cloud holds ciphertext + manifests; the server cannot decrypt vault contents. Cryptographic ZK proofs (Merkle-sealed transparency log, Pedersen commitments, Sigstore-style cosignatures) are deferred to Phase 6+.
+
+## OpenClaw Alignment
+
+`apps/one-mac/Sources/OneMCPServer/` is the first concrete reference implementation of the planned open-source OpenClaw consent-MCP host. Promotion criteria for the planned `wiki/concepts/openclaw.md` page from private to public are:
+
+1. `apps/one-mac/Sources/OneMCPServer/` is open-sourceable in isolation: Apache-2.0, no Hussh-only dependencies, and a stable `DataSourceBinding` protocol.
+2. `apps/one-mac/Tests/OneMCPServerTests/openclaw-conformance/` passes against both a stub `DataSourceBinding` and the real One-mac binding with identical assertions.
+3. Founder authorizes promotion.
+
+**NemoClaw** is Nvidia's planned extension of OpenClaw — it is outside the Hussh repository scope and is referenced here only for awareness.
+
+## Mobile Bridge
+
+The iPhone and the Mac do **not** sync over LAN in v1. The Mac is the **canonical writer** of PKM ciphertext; the iPhone reads via the existing hosted Consent MCP at `https://api.uat.hushh.ai/mcp/` using the already-shipped `PersonalKnowledgeModelPlugin`. The bridge path is:
+
+1. **Pair** — Mac mints a `device_pairing` CRT, surfaces a QR; iPhone scans, Face-ID-confirms; pairing rows land in both local `device_pairings` and cloud `desktop` registry.
+2. **Write** — Mac daemon POSTs `{ciphertext, iv, tag, manifest_entry}` to `/pkm/blobs` + `/pkm/manifests`.
+3. **Read from iPhone** — existing `PersonalKnowledgeModelPlugin` calls `get_encrypted_scoped_export` → device-bound DAT → ciphertext fetched → decrypted on-device using the iPhone's SE-wrapped key (delivered during the pair ceremony).
+
+**Plaintext never traverses cloud.** Per-device SE keys never leave their device; only ciphertext + the pair envelope move. Multi-device sync remains the responsibility of the existing PKM ciphertext relay, not the disabled `/api/sync/*` surface.
+
+## Distribution
+
+- **v1 — Developer ID + Notarization.** Full entitlements: `SMAppService` (LaunchAgent), AppleEvents (AppleScript Notes bridge), MailKit, EventKit, full filesystem read/write, network client. Distributed direct via signed `.dmg`.
+- **v2 — Mac App Store.** Sandbox-compatible connector subset only (Files / EventKit / Reminders). AppleScript + MailKit private surfaces drop behind `#if MAS` compile guards. A separate `OneMacMAS` scheme builds the MAS variant.
+
+## Promotion Criteria
+
+Move this plan into execution docs only when:
+
+- Phase 1 has landed (`OneIndexer` + LocalFS + Spotlight connectors + a working `one_search` MCP tool) on `main`
+- the OpenClaw conformance test suite is green in CI
+- the Swift port of `hushh_mcp/consent/token.py` has byte-for-byte round-trip parity with the Python source
+- the planned desktop pairing route exists at `api/routes/one/desktop.py` inside `consent-protocol/` and is covered by tests
+- Nav 5-tab UI is implemented and matches the existing prototype
+- a signed Developer ID build can be notarized and launched on a clean macOS 15 VM
+- the iPhone read path (via the hosted Consent MCP) decrypts Mac-written ciphertext end-to-end without changes to `hushh-webapp/`
+- founder authorizes promotion of [`apps/one-mac/`](../../apps/one-mac/) from "Phase 0 skeleton" to current-state contract docs in `docs/reference/architecture/`
+
+Promotion targets:
+
+- Mac-specific execution docs → `apps/one-mac/docs/...` (created on promotion)
+- Cross-cutting consent-protocol changes → `consent-protocol/docs/reference/...`
+- Three-layer architecture docs → a new `one-mac-architecture.md` under `docs/reference/architecture/`
+
+## Founder Claims Held Here Until Shipped
+
+| Founder-language claim | Required proof before current-state docs may claim it |
+| --- | --- |
+| Your agents are yours to own | Working BYOA pane on a Developer-ID-signed build, with Claude Desktop, Cursor, and ChatGPT MCP each reading the local MCP server under per-agent CRTs |
+| Mac is the host, cloud is a ciphertext mirror | `pkm_blobs` rows in the cloud carry only `{ciphertext, iv, tag}`; no plaintext writeback path exists; verified by route-level golden tests |
+| One MCP server = first OpenClaw reference impl | `apps/one-mac/Sources/OneMCPServer/` is Apache-2.0 and the OpenClaw conformance test harness is green |
+| Hussh = `[hu]man [s]ecure [s]ocket [h]ost` | The mnemonic appears in product copy only after the local MCP server is shipping and the host model is verifiable end-to-end |
+
+## References
+
+- [`docs/future/README.md`](./README.md) — future-roadmap home and promotion rule
+- [`docs/future/one-nav-runtime-plan.md`](./one-nav-runtime-plan.md) — One/Kai/Nav/KYC migration plan that this app conforms to
+- [`apps/one-mac/README.md`](../../apps/one-mac/README.md) — Phase 0 skeleton entry point
+- [`.codex/skills/desktop-mac/SKILL.md`](../../.codex/skills/desktop-mac/SKILL.md) — owner skill for this surface


### PR DESCRIPTION
## Summary

Introduces `apps/one-mac/` as the host substrate in the `Hussh = [hu]man [s]ecure [s]ocket [h]ost` mnemonic. Phase 0 lands a buildable SwiftPM skeleton plus the governance plumbing that keeps the new surface inside the existing codex contract.

- **`apps/one-mac/`** — SwiftPM skeleton (5 targets: `OneMac` SwiftUI shell, `OneDaemon`, `OneShared`, stub `OneIndexer`, stub `OneMCPServer`) with a `KnowledgeItem` Codable round-trip test, README, and `THIRD_PARTY_NOTICES.md`. **No connectors, no MCP server logic, no consent-protocol writeback** — those land in Phases 1+.
- **3 codex skills** — `desktop-mac` (owner family) plus two spokes `desktop-mac-connectors` and `desktop-mac-mcp-host`. Required commands run through `./bin/hushh native mac <build|test>`; task_types bind to existing workflow packs.
- **`docs/future/one-mac-knowledge-base-app.md`** — planning-only roadmap with OpenClaw alignment, the ciphertext-only mobile bridge via the existing hosted Consent MCP, the Developer-ID-then-MAS distribution path, and explicit promotion criteria.
- **`.github/workflows/one-mac.yml`** — `macos-15` job running `swift build` + `swift test` on `apps/one-mac/**` changes.
- **`bin/hushh native mac <build|run|test>`** dispatcher.
- **`REUSE.toml`** — `apps/**` added to the SPDX aggregate.

## What this is not

This PR does **not** modify `consent-protocol/`, `hushh-webapp/`, the IAM/PKM/vault contracts, or any cloud route. The `paths` filter in `ci.yml` will correctly skip the frontend + backend job lanes — only `secret-scan`, `governance`, and the new `one-mac` workflow should run.

## Test plan

Local CI parity (all green on Linux dev box; macOS-only Swift gates run on the `macos-15` runner):

- [x] `python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py` — 40 skills pass
- [x] `python3 .codex/skills/codex-skill-authoring/scripts/truth_first_smoke.py` — pass
- [x] `./bin/hushh docs verify` — pass (integrity / governance / brand / shareable links)
- [x] `./bin/hushh codex audit` — status=ok, 100/100/100/100, 0 high/medium findings
- [x] `python3 scripts/licenses/verify_apache_surface.py` — pass
- [x] `python3 scripts/ci/verify-protected-pipeline-edits.py` — pass
- [x] `python3 scripts/ci/verify-runtime-config-contract.py` — pass
- [x] `python3 .codex/skills/agent-orchestration-governance/scripts/agent_orchestration_check.py` — pass
- [x] `python3 .codex/skills/agent-orchestration-governance/scripts/agent_router_smoke.py` — 10 scenarios pass
- [x] `python3 .codex/skills/agent-orchestration-governance/scripts/agent_fleet_audit.py` — pass (registers `desktop-mac` as a parent-skill-only owner family)
- [ ] `swift build` + `swift test` inside `apps/one-mac/` on `macos-15` runner (this PR)

## Promotion criteria for `docs/future/one-mac-knowledge-base-app.md`

Tracked in the doc itself; key gates before the plan moves out of `docs/future/`:

1. Phase 1 lands (`OneIndexer` + LocalFS + Spotlight connectors + working `one_search` MCP tool).
2. OpenClaw conformance test suite green in CI.
3. Swift port of `consent-protocol/hushh_mcp/consent/token.py` round-trips byte-for-byte with the Python source.
4. iPhone read path via the existing hosted Consent MCP decrypts Mac-written ciphertext end-to-end without changes to `hushh-webapp/`.
5. Signed Developer-ID build notarizable on a clean macOS 15 VM.
6. Founder authorizes promotion.

https://claude.ai/code/session_01WJHE5VfrLJQ97wn3t3wBrz

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJHE5VfrLJQ97wn3t3wBrz)_