### PR TITLE
feat: add cross-app empty state infrastructure

### DIFF
--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { EmptyState } from "@/components/system/empty-state";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
@@ -1007,14 +1008,22 @@ export default function MarketplacePage() {
               </RiaSurface>
             );
           })}
-
           {!loading && activeCards.length === 0 ? (
-            <RiaSurface className="col-span-full p-6 text-center">
-              <h3 className="text-lg font-semibold tracking-tight text-foreground">No profiles</h3>
-              <p className="mt-2 text-sm leading-6 text-muted-foreground">
-                Try a broader search.
-              </p>
-            </RiaSurface>
+            <EmptyState
+              title="No matching profiles found"
+              description={`We couldn't find any ${
+                directoryKind === "rias" ? "advisors" : "investors"
+              } matching your current search.`}
+              actionLabel={query ? "Clear search" : "Reset discovery"}
+              onAction={() => {
+                if (query) {
+                  setQuery("");
+                  return;
+                }
+
+                resetSwipeDeck();
+              }}
+            />
           ) : null}
         </div>
       ) : null}

--- a/hushh-webapp/components/system/empty-state.tsx
+++ b/hushh-webapp/components/system/empty-state.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import type { LucideIcon } from "lucide-react";
+import { SearchX } from "lucide-react";
+
+import { Button } from "@/lib/morphy-ux/button";
+
+type EmptyStateProps = {
+  title: string;
+  description: string;
+  icon?: LucideIcon;
+  actionLabel?: string;
+  onAction?: () => void;
+  compact?: boolean;
+};
+
+export function EmptyState({
+  title,
+  description,
+  icon: Icon = SearchX,
+  actionLabel,
+  onAction,
+  compact = false,
+}: EmptyStateProps) {
+  return (
+    <div
+      className={
+        compact
+          ? "rounded-[var(--app-card-radius-compact)] border border-[color:var(--app-card-border-standard)]/50 bg-[color:var(--app-card-surface-compact)]/55 px-4 py-5 text-center"
+          : "rounded-[var(--app-card-radius-compact)] border border-[color:var(--app-card-border-standard)]/50 bg-[color:var(--app-card-surface-compact)]/55 px-6 py-8 text-center"
+      }
+    >
+      <div className="mx-auto flex max-w-md flex-col items-center gap-4">
+        <div className="rounded-full bg-muted p-3">
+          <Icon className="h-5 w-5 text-muted-foreground" />
+        </div>
+
+        <div className="space-y-2">
+          <h3 className="text-base font-semibold tracking-tight text-foreground">
+            {title}
+          </h3>
+          <p className="text-sm leading-6 text-muted-foreground">
+            {description}
+          </p>
+        </div>
+
+        {actionLabel && onAction ? (
+          <Button variant="none" effect="fade" size="sm" onClick={onAction}>
+            {actionLabel}
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# Description

Added reusable cross-app empty state infrastructure and applied it to the Marketplace no-results experience.

This PR introduces a shared `EmptyState` component under `components/system` for consistent empty, no-results, and recovery states across the app. The Marketplace route now uses this reusable component when no advisor or investor profiles match the current discovery state.

This improves UX consistency, reduces duplicated empty-state markup, and creates a reusable foundation for future empty states across Consent, Marketplace, Kai, Portfolio, and other app surfaces.

No backend behavior, API contracts, schema definitions, cache keys, storage behavior, or consent logic were changed.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below:
    - `/marketplace`

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None — responsive empty-state layout uses existing app spacing and button primitives

- Docs updated (exact files):
  - [x] None

- Verification commands executed:
  - [x] `cd hushh-webapp && npm run lint`
  - [x] `cd hushh-webapp && npm run verify:design-system`
  - [x] `cd hushh-webapp && npm run build`

## 🛑 Tri-Flow Architecture Check

- [x] Web: Cross-app empty-state infrastructure


## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Added reusable empty-state component and applied it to Marketplace no-results state.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] No new storage, tracking, backend calls, or consent logic added

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed — no new dependencies added
