### PR TITLE
feat: add global accessibility status announcements

### DIFF
--- a/hushh-webapp/components/consent/consent-center-page.tsx
+++ b/hushh-webapp/components/consent/consent-center-page.tsx
@@ -709,7 +709,6 @@ export function ConsentCenterPage() {
       setRetainedList({ key: listCacheKey, data: listResource.data });
     }
   }, [listCacheKey, listResource.data]);
-
   const summaryData =
     summaryResource.data ??
     (retainedSummary?.key === summaryCacheKey ? retainedSummary.data : null);

--- a/hushh-webapp/components/consent/consent-center-page.tsx
+++ b/hushh-webapp/components/consent/consent-center-page.tsx
@@ -22,6 +22,7 @@ import {
   SettingsRow,
   SettingsSegmentedTabs,
 } from "@/components/profile/settings-ui";
+import { AccessibilityStatusAnnouncer } from "@/components/system/accessibility-status-announcer";
 import { ApiRetryState } from "@/components/system/api-retry-state";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
@@ -725,6 +726,10 @@ export function ConsentCenterPage() {
   );
   const activeListError =
     tab === "relationships" ? centerResource.error : listResource.error;
+  const activeListLoading =
+    tab === "relationships" ? centerResource.loading : listResource.loading;
+  const activeListRefreshing =
+    tab === "relationships" ? centerResource.refreshing : listResource.refreshing;
   const consentLoadError = activeListError || summaryResource.error;
   const hasVisibleConsentListData =
     items.length > 0 ||
@@ -732,6 +737,13 @@ export function ConsentCenterPage() {
   const showCompactRetryState = Boolean(consentLoadError && hasVisibleConsentListData);
   const showFullRetryState = Boolean(consentLoadError && !hasVisibleConsentListData);
   const visibleSnapshot = tab === "relationships" ? centerResource.snapshot : listResource.snapshot;
+  const accessibilityStatusMessage = activeListLoading
+    ? "Consent entries are loading."
+    : activeListRefreshing
+      ? "Consent entries are refreshing."
+      : consentLoadError
+        ? "Consent entries failed to refresh."
+        : "";
   const selectedEntry = useMemo(() => {
     if (!items.length) return null;
     if (selectedId) {
@@ -1032,6 +1044,8 @@ export function ConsentCenterPage() {
             <section data-testid="consent-manager-list">
               <SettingsGroup embedded>
                 <div className="space-y-2 px-2 py-2">
+                  <AccessibilityStatusAnnouncer message={accessibilityStatusMessage} />
+
                   {showCompactRetryState ? (
                     <ApiRetryState
                       variant="compact"

--- a/hushh-webapp/components/system/accessibility-status-announcer.tsx
+++ b/hushh-webapp/components/system/accessibility-status-announcer.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+type AccessibilityStatusAnnouncerProps = {
+  message: string;
+  assertive?: boolean;
+};
+
+export function AccessibilityStatusAnnouncer({
+  message,
+  assertive = false,
+}: AccessibilityStatusAnnouncerProps) {
+  if (!message) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live={assertive ? "assertive" : "polite"}
+      aria-atomic="true"
+      className="sr-only"
+    >
+      {message}
+    </div>
+  );
+}


### PR DESCRIPTION
# Description

Added reusable accessibility status announcement infrastructure and integrated it into the Consent Center loading and recovery flow.

This PR introduces `AccessibilityStatusAnnouncer`, a lightweight reusable accessibility utility that provides screen-reader friendly live announcements for async UI state transitions such as loading, refreshing, and retry failures.

The Consent Center now announces:
- consent loading state
- consent refresh state
- consent refresh failure state

This improves accessibility and runtime UX consistency without changing backend behavior or data flows.

No backend logic, API contracts, schema definitions, cache keys, storage behavior, authentication behavior, or consent authorization logic were changed.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below:
    - `/consents`

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None — accessibility announcer is non-visual and compatible across layouts

- Docs updated (exact files):
  - [x] None

- Verification commands executed:
  - [x] `cd hushh-webapp && npm run lint`
  - [x] `cd hushh-webapp && npm run verify:design-system`
  - [x] `cd hushh-webapp && npm run build`

## 🛑 Tri-Flow Architecture Check

- [x] Web: Accessibility live-region status announcements

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Added reusable accessibility live-region infrastructure for async loading/recovery states.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] No new storage, tracking, backend calls, or consent logic added
- [x] Uses existing frontend resource state only

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed — no new dependencies added
