### PR TITLE
refactor(ui): implement server-side redirect for unknown routes

### DIFF
--- a/hushh-webapp/app/not-found.tsx
+++ b/hushh-webapp/app/not-found.tsx
@@ -1,14 +1,6 @@
-"use client";
+import { redirect } from 'next/navigation';
 
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
-
-export default function AppNotFoundPage() {
-  const router = useRouter();
-
-  useEffect(() => {
-    router.replace("/");
-  }, [router]);
-
-  return null;
+export default function NotFound() {
+  // Server-side redirect to the home page to avoid blank screen flashes
+  redirect('/');
 }


### PR DESCRIPTION
## Summary

- what changed: Updated `app/not-found.tsx` to utilize a direct server-side redirect to `/`. *Note: This PR has been strictly scoped down from #841 to only include the not-found behavior.*
- why it changed: To eliminate the blank screen flash caused by client-side 404 rendering and improve routing performance.
- product justification for redirect: Instead of rendering a dead-end 404 state, redirecting unknown deep-links directly to the root (`/`) ensures users are immediately placed back into the primary app flow, reducing friction for stale links.
- linked issue: #841 (Resubmission)
- acceptance criteria covered: Unknown routes instantly redirect to `/` server-side without flashing blank UI. No unrelated package, proxy, or Kai route changes are included.
- risk area touched: ui / routing
- reviewer focus: `app/not-found.tsx`

## Validation

- [x] commits are signed off with DCO (`git commit -s`)
- [x] `npx tsc --noEmit`
- [x] `npm run lint:ci`
- [x] relevant route or smoke checks
- ran: `npx tsc --noEmit`. 
- smoke test proof: Booted the app locally, navigated to multiple nested unknown routes (e.g., `/fake-route/123`), and verified an instantaneous server-side redirect to `/` with no route looping or screen flashing.
- did not run: `npm run test` (no specific unit tests exist for the native Next.js not-found boundary).
- reviewer should verify: The scope is restricted entirely to the not-found file.

## Notes

- deployment impact: minor change to generic routing fallback.
- follow-up work if any: none
- reviewer callouts or CODEOWNERS you expect to review this: frontend maintainers