### PR TITLE
feat: add stale cache timestamp infrastructure

### DIFF
--- a/hushh-webapp/components/consent/consent-center-page.tsx
+++ b/hushh-webapp/components/consent/consent-center-page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { StaleCacheTimestamp } from "@/components/system/stale-cache-timestamp";
 import Link from "next/link";
 import { useDeferredValue, useEffect, useMemo, useState } from "react";
 import type { ReadonlyURLSearchParams } from "next/navigation";
@@ -713,6 +714,10 @@ export function ConsentCenterPage() {
     (retainedSummary?.key === summaryCacheKey ? retainedSummary.data : null);
   const listData =
     listResource.data ?? (retainedList?.key === listCacheKey ? retainedList.data : null);
+
+  const consentListUpdatedAt =
+  retainedList?.key === listCacheKey ? Date.now() : null;
+  
   const relationshipItems = useMemo(
     () => filterRelationshipEntries(buildRelationshipEntries(centerResource.data || null), deferredQuery),
     [centerResource.data, deferredQuery]
@@ -1010,6 +1015,12 @@ export function ConsentCenterPage() {
                     data-voice-control-id="consent_search"
                   />
                 </div>
+                <div className="mt-3">
+  <StaleCacheTimestamp
+    updatedAt={consentListUpdatedAt}
+    stale={Boolean(listResource.error && listData?.items?.length)}
+  />
+</div>
                 {((tab === "relationships" ? centerResource.loading || centerResource.refreshing : listResource.loading || listResource.refreshing) && items.length > 0) ? (
                   <div className="mt-3 text-xs text-muted-foreground">
                     Refreshing from the latest consent state…

--- a/hushh-webapp/components/consent/consent-center-page.tsx
+++ b/hushh-webapp/components/consent/consent-center-page.tsx
@@ -715,9 +715,6 @@ export function ConsentCenterPage() {
   const listData =
     listResource.data ?? (retainedList?.key === listCacheKey ? retainedList.data : null);
 
-  const consentListUpdatedAt =
-  retainedList?.key === listCacheKey ? Date.now() : null;
-  
   const relationshipItems = useMemo(
     () => filterRelationshipEntries(buildRelationshipEntries(centerResource.data || null), deferredQuery),
     [centerResource.data, deferredQuery]
@@ -734,6 +731,7 @@ export function ConsentCenterPage() {
     (tab === "relationships" ? Boolean(centerResource.data) : Boolean(listData));
   const showCompactRetryState = Boolean(consentLoadError && hasVisibleConsentListData);
   const showFullRetryState = Boolean(consentLoadError && !hasVisibleConsentListData);
+  const visibleSnapshot = tab === "relationships" ? centerResource.snapshot : listResource.snapshot;
   const selectedEntry = useMemo(() => {
     if (!items.length) return null;
     if (selectedId) {
@@ -1015,12 +1013,14 @@ export function ConsentCenterPage() {
                     data-voice-control-id="consent_search"
                   />
                 </div>
-                <div className="mt-3">
-  <StaleCacheTimestamp
-    updatedAt={consentListUpdatedAt}
-    stale={Boolean(listResource.error && listData?.items?.length)}
-  />
-</div>
+                {visibleSnapshot ? (
+                  <div className="mt-3">
+                    <StaleCacheTimestamp
+                      updatedAt={visibleSnapshot.timestamp}
+                      stale={Boolean(activeListError && items.length > 0)}
+                    />
+                  </div>
+                ) : null}
                 {((tab === "relationships" ? centerResource.loading || centerResource.refreshing : listResource.loading || listResource.refreshing) && items.length > 0) ? (
                   <div className="mt-3 text-xs text-muted-foreground">
                     Refreshing from the latest consent state…

--- a/hushh-webapp/components/system/stale-cache-timestamp.tsx
+++ b/hushh-webapp/components/system/stale-cache-timestamp.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { Clock3 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+type StaleCacheTimestampProps = {
+  updatedAt?: string | number | Date | null;
+  stale?: boolean;
+  label?: string;
+};
+
+function formatRelativeTime(value: string | number | Date) {
+  const timestamp = new Date(value).getTime();
+
+  if (!Number.isFinite(timestamp)) {
+    return "Update time unavailable";
+  }
+
+  const deltaMs = Date.now() - timestamp;
+  const absMs = Math.abs(deltaMs);
+
+  const minuteMs = 60 * 1000;
+  const hourMs = 60 * minuteMs;
+  const dayMs = 24 * hourMs;
+
+  if (absMs < minuteMs) return "Updated just now";
+  if (absMs < hourMs) {
+    const minutes = Math.round(absMs / minuteMs);
+    return `Updated ${minutes}m ago`;
+  }
+  if (absMs < dayMs) {
+    const hours = Math.round(absMs / hourMs);
+    return `Updated ${hours}h ago`;
+  }
+
+  const days = Math.round(absMs / dayMs);
+  return `Updated ${days}d ago`;
+}
+
+export function StaleCacheTimestamp({
+  updatedAt,
+  stale = false,
+  label,
+}: StaleCacheTimestampProps) {
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    const intervalId = window.setInterval(() => {
+      setTick((value) => value + 1);
+    }, 60 * 1000);
+
+    return () => window.clearInterval(intervalId);
+  }, []);
+
+  const text = useMemo(() => {
+    if (!updatedAt) return label || "Using saved data";
+    return formatRelativeTime(updatedAt);
+  }, [label, updatedAt]);
+
+  return (
+    <div
+      className={
+        stale
+          ? "inline-flex items-center gap-2 rounded-full border border-amber-500/20 bg-amber-500/10 px-2.5 py-1 text-xs font-medium text-amber-700 dark:text-amber-300"
+          : "inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-2.5 py-1 text-xs font-medium text-muted-foreground"
+      }
+    >
+      <Clock3 className="h-3.5 w-3.5" />
+      <span>{stale ? `${text} · stale` : text}</span>
+    </div>
+  );
+}


### PR DESCRIPTION

# Description

Added reusable stale-cache timestamp infrastructure and integrated it into the Consent Center experience.

This PR introduces a shared `StaleCacheTimestamp` component for displaying cache freshness and stale-state visibility across async UI flows. The component supports relative timestamp formatting, automatic refresh updates, and stale-state indicators for retained cached data.

The Consent Center now surfaces cache freshness metadata during retry/recovery flows so users can better understand when cached consent data was last updated and whether the current view may be stale.

This improves runtime trust, resilience UX, and cache transparency without changing backend behavior or consent authorization logic.

No backend logic, API contracts, schema definitions, cache keys, storage behavior, authentication behavior, or consent authorization rules were changed.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below:
    - `/consents`

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None — stale timestamp component uses responsive inline layout primitives

- Docs updated (exact files):
  - [x] None

- Verification commands executed:
  - [x] `cd hushh-webapp && npm run lint`
  - [x] `cd hushh-webapp && npm run verify:design-system`
  - [x] `cd hushh-webapp && npm run build`

## 🛑 Tri-Flow Architecture Check

- [x] Web: Stale-cache timestamp infrastructure and consent freshness indicators
- [ ] iOS: N/A
- [ ] Android: N/A

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Added reusable stale-cache timestamp UI with relative freshness indicators and stale-state visibility.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] No new storage, tracking, backend calls, or consent logic added
- [x] Uses existing frontend resource/cache state only

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed — no new dependencies added