### PR TITLE
Feat/async action status infrastructure

### DIFF
--- a/hushh-webapp/components/consent/consent-center-page.tsx
+++ b/hushh-webapp/components/consent/consent-center-page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { AsyncActionStatus } from "@/components/system/async-action-status";
 import { SessionExpiryRecovery } from "@/components/system/session-expiry-recovery";
 import { StaleCacheTimestamp } from "@/components/system/stale-cache-timestamp";
 import Link from "next/link";
@@ -738,6 +739,8 @@ export function ConsentCenterPage() {
   const showFullRetryState = Boolean(consentLoadError && !hasVisibleConsentListData);
   const showSessionRecovery = Boolean(!authLoading && !user && showFullRetryState);
   const visibleSnapshot = tab === "relationships" ? centerResource.snapshot : listResource.snapshot;
+  const isConsentActionRefreshing =
+    summaryResource.refreshing || listResource.refreshing || centerResource.refreshing;
   const accessibilityStatusMessage = activeListLoading
     ? "Consent entries are loading."
     : activeListRefreshing
@@ -1048,6 +1051,14 @@ export function ConsentCenterPage() {
                   <AccessibilityStatusAnnouncer message={accessibilityStatusMessage} />
 
                   {showSessionRecovery ? <SessionExpiryRecovery /> : null}
+
+                  {isConsentActionRefreshing && items.length > 0 ? (
+                    <AsyncActionStatus
+                      state="loading"
+                      label="Refreshing consent state..."
+                      compact
+                    />
+                  ) : null}
 
                   {showCompactRetryState ? (
                     <ApiRetryState

--- a/hushh-webapp/components/system/async-action-status.tsx
+++ b/hushh-webapp/components/system/async-action-status.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { AlertTriangle, CheckCircle2, Loader2, RefreshCcw } from "lucide-react";
+
+type AsyncActionStatusState = "idle" | "loading" | "success" | "error" | "retrying";
+
+type AsyncActionStatusProps = {
+  state: AsyncActionStatusState;
+  label?: string;
+  compact?: boolean;
+};
+
+const STATUS_COPY: Record<Exclude<AsyncActionStatusState, "idle">, string> = {
+  loading: "Working…",
+  retrying: "Retrying…",
+  success: "Completed",
+  error: "Action failed",
+};
+
+export function AsyncActionStatus({
+  state,
+  label,
+  compact = false,
+}: AsyncActionStatusProps) {
+  if (state === "idle") return null;
+
+  const text = label || STATUS_COPY[state];
+
+  const Icon =
+    state === "success"
+      ? CheckCircle2
+      : state === "error"
+        ? AlertTriangle
+        : state === "retrying"
+          ? RefreshCcw
+          : Loader2;
+
+  return (
+    <div
+      role="status"
+      aria-live={state === "error" ? "assertive" : "polite"}
+      className={
+        compact
+          ? "inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-2.5 py-1 text-xs font-medium text-muted-foreground"
+          : "flex items-center gap-2 rounded-[var(--app-card-radius-compact)] border border-border/60 bg-background/70 px-3 py-2 text-sm font-medium text-muted-foreground"
+      }
+    >
+      <Icon
+        className={
+          state === "loading" || state === "retrying"
+            ? "h-4 w-4 animate-spin"
+            : state === "success"
+              ? "h-4 w-4 text-emerald-600"
+              : state === "error"
+                ? "h-4 w-4 text-amber-600"
+                : "h-4 w-4"
+        }
+      />
+      <span>{text}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
# Description

Added reusable async action status infrastructure and integrated it into the Consent Center refresh lifecycle.

This PR introduces a shared `AsyncActionStatus` component for rendering consistent async loading, retrying, success, and failure states across frontend runtime flows. The component supports compact and inline variants, accessibility-friendly status semantics, and reusable async feedback rendering for future async UI operations.

The Consent Center now surfaces compact async refresh indicators while consent resources are refreshing, improving runtime transparency and user feedback consistency during async recovery and refresh operations.

This improves resilience UX, async state consistency, and frontend trust visibility without changing backend behavior or consent authorization logic.

No backend logic, API contracts, schema definitions, cache keys, storage behavior, authentication behavior, or consent authorization rules were changed.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below:
    - `/consents`

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None — async status infrastructure uses responsive inline/compact primitives

- Docs updated (exact files):
  - [x] None

- Verification commands executed:
  - [x] `cd hushh-webapp && npm run lint`
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm run verify:design-system`
  - [x] `cd hushh-webapp && npm run build`

## 🛑 Tri-Flow Architecture Check

- [x] Web: Async action status infrastructure and consent refresh indicators
- [ ] iOS: N/A
- [ ] Android: N/A

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Added reusable async action status infrastructure with compact refresh indicators for consent async flows.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] No new storage, tracking, backend calls, or consent logic added
- [x] Uses existing frontend async resource state only

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed — no new dependencies added