### PR TITLE
fix(portfolio-parser): preserve broker-reported gain_loss; fix quantity None

### DIFF
--- a/consent-protocol/hushh_mcp/services/portfolio_parser.py
+++ b/consent-protocol/hushh_mcp/services/portfolio_parser.py
@@ -172,19 +172,36 @@ class PortfolioParser:
             if not ticker:
                 continue
 
+            parsed_quantity = self._parse_number(row.get(qty_col)) if qty_col else None
             holding = Holding(
                 ticker=ticker,
                 name=row.get(name_col) if name_col else None,
-                quantity=self._parse_number(row.get(qty_col)) if qty_col else 0.0,
+                # Fall back to 0.0 when the column is absent or the value is
+                # unparseable; avoids None leaking into a float-typed field.
+                quantity=parsed_quantity if parsed_quantity is not None else 0.0,
                 cost_basis=self._parse_number(row.get(cost_col)) if cost_col else None,
                 current_value=self._parse_number(row.get(value_col)) if value_col else None,
                 current_price=self._parse_number(row.get(price_col)) if price_col else None,
                 gain_loss=self._parse_number(row.get(gain_col)) if gain_col else None,
             )
 
-            # Calculate gain/loss percentage if we have the data
-            if holding.cost_basis and holding.current_value and holding.cost_basis > 0:
+            # Fill in gain_loss and gain_loss_pct only when the CSV did not
+            # already supply them.  Broker-reported values (adjusted cost
+            # basis, wash-sale corrections, dividend offsets) must not be
+            # overwritten with the naive current_value − cost_basis estimate.
+            if (
+                holding.gain_loss is None
+                and holding.cost_basis
+                and holding.current_value
+                and holding.cost_basis > 0
+            ):
                 holding.gain_loss = holding.current_value - holding.cost_basis
+            if (
+                holding.gain_loss_pct is None
+                and holding.gain_loss is not None
+                and holding.cost_basis
+                and holding.cost_basis > 0
+            ):
                 holding.gain_loss_pct = (holding.gain_loss / holding.cost_basis) * 100
 
             holdings.append(holding)

--- a/consent-protocol/tests/services/test_portfolio_parser.py
+++ b/consent-protocol/tests/services/test_portfolio_parser.py
@@ -163,3 +163,72 @@ Apple Inc,100,17500
         parser2 = get_portfolio_parser()
 
         assert parser1 is parser2
+
+    # ------------------------------------------------------------------
+    # Regression tests for gain_loss overwrite and quantity None bugs
+    # ------------------------------------------------------------------
+
+    def test_broker_reported_gain_loss_is_preserved(self, parser):
+        """Broker-supplied gain/loss must not be overwritten by recalculation.
+
+        Brokers often adjust gain/loss for wash sales, dividend reinvestment,
+        return-of-capital distributions, and cost-basis elections that the
+        naive (current_value - cost_basis) formula cannot reproduce.
+        """
+        csv_content = b"""Symbol,Quantity,Cost Basis,Market Value,Gain/Loss
+AAPL,100,10000,15000,3500
+"""
+        portfolio = parser.parse_csv(csv_content)
+
+        aapl = portfolio.holdings[0]
+        # Broker reported 3500, not the naive 15000 - 10000 = 5000.
+        assert aapl.gain_loss == 3500.0, (
+            f"Expected broker-reported gain_loss=3500, got {aapl.gain_loss}"
+        )
+
+    def test_gain_loss_calculated_when_csv_column_absent(self, parser):
+        """gain_loss is derived from cost_basis and current_value when the CSV
+        does not supply a dedicated gain/loss column."""
+        csv_content = b"""Symbol,Quantity,Cost Basis,Market Value
+MSFT,50,12000,14000
+"""
+        portfolio = parser.parse_csv(csv_content)
+
+        msft = portfolio.holdings[0]
+        assert msft.gain_loss == pytest.approx(2000.0)
+        assert msft.gain_loss_pct == pytest.approx((2000.0 / 12000.0) * 100)
+
+    def test_gain_loss_pct_calculated_from_broker_gain_loss(self, parser):
+        """gain_loss_pct is based on the broker-reported gain_loss value,
+        not the recalculated one, when the CSV provides it."""
+        csv_content = b"""Symbol,Quantity,Cost Basis,Market Value,Gain/Loss
+TSLA,10,20000,25000,3000
+"""
+        portfolio = parser.parse_csv(csv_content)
+
+        tsla = portfolio.holdings[0]
+        # gain_loss_pct must use the broker-reported gain_loss (3000), not 5000.
+        assert tsla.gain_loss == 3000.0
+        assert tsla.gain_loss_pct == pytest.approx((3000.0 / 20000.0) * 100)
+
+    def test_quantity_defaults_to_zero_when_value_is_unparseable(self, parser):
+        """A malformed quantity cell must not produce None in a float field;
+        it should fall back to 0.0 so downstream arithmetic does not crash."""
+        csv_content = b"""Symbol,Quantity,Cost Basis,Market Value
+GOOGL,N/A,30000,32000
+"""
+        portfolio = parser.parse_csv(csv_content)
+
+        googl = portfolio.holdings[0]
+        assert googl.quantity == 0.0
+        assert isinstance(googl.quantity, float)
+
+    def test_negative_broker_gain_loss_preserved(self, parser):
+        """A broker-reported loss (negative value) must survive the fill-in logic."""
+        csv_content = b"""Symbol,Quantity,Cost Basis,Market Value,Gain/Loss
+NFLX,5,5000,4000,-800
+"""
+        portfolio = parser.parse_csv(csv_content)
+
+        nflx = portfolio.holdings[0]
+        assert nflx.gain_loss == -800.0


### PR DESCRIPTION
## Bug

Two correctness bugs in `_parse_generic_csv` in `hushh_mcp/services/portfolio_parser.py`.

---

### 1. Broker-reported `gain_loss` silently overwritten (data loss)

**Lines 185–188 (original):**
```python
# Calculate gain/loss percentage if we have the data
if holding.cost_basis and holding.current_value and holding.cost_basis > 0:
    holding.gain_loss = holding.current_value - holding.cost_basis  # ← overwrites CSV value
    holding.gain_loss_pct = (holding.gain_loss / holding.cost_basis) * 100
```

When a CSV contained all three of `cost_basis`, `current_value`, **and** `gain_loss` columns, the broker-supplied `gain_loss` was silently replaced by the naive formula `current_value − cost_basis`.

Brokers adjust gain/loss for:
- Wash-sale disallowances
- Return-of-capital basis reductions
- Dividend reinvestment lots
- Specific-identification cost-basis elections

These adjustments cannot be reproduced by subtraction.  A Schwab CSV that reports `gain_loss = $3 500` for a $10 000→$15 000 position (with $1 500 of wash-sale adjustments) would be overwritten to `$5 000`, producing a materially wrong figure shown to the user.

**Fix:** Add `holding.gain_loss is None` guard so the recalculation is a fallback, not an override:
```python
if holding.gain_loss is None and holding.cost_basis and holding.current_value and holding.cost_basis > 0:
    holding.gain_loss = holding.current_value - holding.cost_basis
if holding.gain_loss_pct is None and holding.gain_loss is not None and holding.cost_basis and holding.cost_basis > 0:
    holding.gain_loss_pct = (holding.gain_loss / holding.cost_basis) * 100
```

---

### 2. `quantity` leaks `None` into a `float` field

**Line 178 (original):**
```python
quantity=self._parse_number(row.get(qty_col)) if qty_col else 0.0,
```

When `qty_col` existed but `_parse_number` returned `None` (cell value was `"N/A"`, `""`, or otherwise unparseable), `holding.quantity` was set to `None` despite the `float = 0.0` type annotation.  Any downstream calculation of the form `price * holding.quantity` would raise `TypeError`.

**Fix:** Explicit `None` guard:
```python
parsed_quantity = self._parse_number(row.get(qty_col)) if qty_col else None
quantity=parsed_quantity if parsed_quantity is not None else 0.0,
```

---

## Verification

```bash
cd consent-protocol
python3 -m pytest tests/services/test_portfolio_parser.py -v
```

**5 new regression tests**, all passing:
| Test | What it verifies |
|---|---|
| `test_broker_reported_gain_loss_is_preserved` | CSV gain_loss=3500 is kept, not replaced by naive 5000 |
| `test_gain_loss_calculated_when_csv_column_absent` | Fallback calculation fires when no gain_loss column |
| `test_gain_loss_pct_calculated_from_broker_gain_loss` | gain_loss_pct uses broker-reported value |
| `test_quantity_defaults_to_zero_when_value_is_unparseable` | "N/A" quantity → 0.0 float, not None |
| `test_negative_broker_reported_loss_preserved` | Negative broker loss survives the guard |

All 18 tests pass (13 pre-existing + 5 new). `ruff check` and `ruff format --check` are clean.