### PR TITLE
feat: add request cancellation infrastructure

### DIFF
--- a/hushh-webapp/hooks/use-abortable-request.ts
+++ b/hushh-webapp/hooks/use-abortable-request.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+
+type AbortableRequestRunner<T> = (signal: AbortSignal) => Promise<T>;
+
+export function useAbortableRequest() {
+  const controllerRef = useRef<AbortController | null>(null);
+
+  const abortCurrentRequest = useCallback(() => {
+    controllerRef.current?.abort();
+    controllerRef.current = null;
+  }, []);
+
+  const runAbortableRequest = useCallback(
+    async <T,>(runner: AbortableRequestRunner<T>): Promise<T> => {
+      abortCurrentRequest();
+
+      const controller = new AbortController();
+      controllerRef.current = controller;
+
+      try {
+        return await runner(controller.signal);
+      } finally {
+        if (controllerRef.current === controller) {
+          controllerRef.current = null;
+        }
+      }
+    },
+    [abortCurrentRequest]
+  );
+
+  useEffect(() => {
+    return () => {
+      abortCurrentRequest();
+    };
+  }, [abortCurrentRequest]);
+
+  return {
+    abortCurrentRequest,
+    runAbortableRequest,
+  };
+}


### PR DESCRIPTION
# Description

Added global request cancellation infrastructure through a reusable `useAbortableRequest` hook.

This PR introduces a lightweight AbortController-based utility hook that standardizes cancellable async request behavior across frontend surfaces. The infrastructure enables future request flows to safely cancel stale or unmounted async operations while preserving consistent cleanup semantics.

The implementation focuses on frontend runtime resilience and establishes a reusable foundation for future async request orchestration, stale-request prevention, and navigation-safe async execution.

No backend logic, API contracts, authentication behavior, consent policies, storage behavior, cache keys, or routing logic were modified.

## 📌 Impact Map (Required)

* Routes touched:

  * [x] None directly
  * [x] Shared infrastructure only

* API / schema / type changes:

  * [x] None

* Cache keys touched:

  * [x] None

* World-model domain summary effects:

  * [x] None

* Mobile parity impacts:

  * [x] None

* Docs updated (exact files):

  * [x] None

* Verification commands executed:

  * [x] `cd hushh-webapp && npm run lint`
  * [x] `cd hushh-webapp && npm run typecheck`
  * [x] `cd hushh-webapp && npm run verify:design-system`
  * [x] `cd hushh-webapp && npm run build`

## 🛑 Tri-Flow Architecture Check

* [x] Web: Abortable request infrastructure hook
* [ ] iOS: N/A
* [ ] Android: N/A

## 🧪 Testing

* [x] Tested on Web
* [ ] Tested on iOS Simulator/Device
* [ ] Tested on Android Emulator/Device
* [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Introduces reusable request cancellation primitives for future async frontend flows.

## 🛡️ Privacy & Consent

* [x] No new data collection
* [x] No new persistence layer
* [x] No consent model changes
* [x] No authentication or authorization changes

## 📜 Licensing

* [x] First-party changes remain Apache-2.0 compatible
* [x] No new third-party dependencies added

