### PR TITLE
feat: add degraded network state infrastructure

### DIFF
--- a/hushh-webapp/app/layout.tsx
+++ b/hushh-webapp/app/layout.tsx
@@ -1,3 +1,4 @@
+import { NetworkStatusBanner } from "@/components/system/network-status-banner";
 import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono, Inter } from "next/font/google";
 import Script from "next/script";
@@ -104,6 +105,7 @@ export default function RootLayout({
       <RootLayoutClient
         fontClasses={`${geistSans.variable} ${geistMono.variable} ${headingSans.variable}`}
       >
+        <NetworkStatusBanner />
         {children}
       </RootLayoutClient>
     </html>

--- a/hushh-webapp/components/system/network-status-banner.tsx
+++ b/hushh-webapp/components/system/network-status-banner.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { WifiOff } from "lucide-react";
+
+import { useNetworkStatus } from "@/hooks/use-network-status";
+
+export function NetworkStatusBanner() {
+  const { offline } = useNetworkStatus();
+
+  if (!offline) {
+    return null;
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed inset-x-0 top-0 z-[9999] border-b border-amber-500/20 bg-amber-500/10 px-4 py-2 text-center text-sm text-amber-700 backdrop-blur dark:text-amber-300"
+    >
+      <div className="flex items-center justify-center gap-2">
+        <WifiOff className="h-4 w-4" />
+        <span>You are offline. Some data may be outdated until your connection returns.</span>
+      </div>
+    </div>
+  );
+}

--- a/hushh-webapp/hooks/use-network-status.ts
+++ b/hushh-webapp/hooks/use-network-status.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useNetworkStatus() {
+  const [online, setOnline] = useState(true);
+
+  useEffect(() => {
+    const updateStatus = () => {
+      setOnline(window.navigator.onLine);
+    };
+
+    updateStatus();
+
+    window.addEventListener("online", updateStatus);
+    window.addEventListener("offline", updateStatus);
+
+    return () => {
+      window.removeEventListener("online", updateStatus);
+      window.removeEventListener("offline", updateStatus);
+    };
+  }, []);
+
+  return {
+    online,
+    offline: !online,
+  };
+}


### PR DESCRIPTION
# Description

Added degraded-network state infrastructure through reusable online/offline detection primitives and a global network status banner.

This PR introduces a lightweight `useNetworkStatus` hook along with a reusable `NetworkStatusBanner` component mounted at the root application layout. The implementation provides consistent offline awareness across the web experience and improves runtime resilience by surfacing degraded network conditions to users in real time.

The infrastructure establishes a reusable foundation for future retry coordination, stale-data handling, reconnection flows, and offline-aware UX systems.

No backend logic, API contracts, authentication behavior, cache keys, consent policies, storage behavior, or routing logic were modified.

## 📌 Impact Map (Required)

* Routes touched:

  * [x] Global application layout
  * [x] All web routes receive degraded-network awareness

* API / schema / type changes:

  * [x] None

* Cache keys touched:

  * [x] None

* World-model domain summary effects:

  * [x] None

* Mobile parity impacts:

  * [x] None — responsive fixed-position network banner

* Docs updated (exact files):

  * [x] None

* Verification commands executed:

  * [x] `cd hushh-webapp && npm run lint`
  * [x] `cd hushh-webapp && npm run typecheck`
  * [x] `cd hushh-webapp && npm run verify:design-system`
  * [x] `cd hushh-webapp && npm run build`

## 🛑 Tri-Flow Architecture Check

* [x] Web: Degraded-network state infrastructure
* [ ] iOS: N/A
* [ ] Android: N/A

## 🧪 Testing

* [x] Tested on Web
* [ ] Tested on iOS Simulator/Device
* [ ] Tested on Android Emulator/Device
* [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Adds a global offline-awareness banner for degraded network conditions.

## 🛡️ Privacy & Consent

* [x] No new data collection
* [x] No persistence changes
* [x] No consent logic changes
* [x] No authentication or authorization changes

## 📜 Licensing

* [x] First-party changes remain Apache-2.0 compatible
* [x] No new third-party dependencies added
