### PR TITLE
feat: add optimistic mutation state infrastructure

### DIFF
--- a/hushh-webapp/hooks/use-optimistic-mutation.ts
+++ b/hushh-webapp/hooks/use-optimistic-mutation.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+type OptimisticMutationConfig = {
+  apply: () => void;
+  rollback: () => void;
+  commit: () => Promise<void>;
+};
+
+export function useOptimisticMutation() {
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<unknown>(null);
+
+  const runOptimisticMutation = useCallback(
+    async ({ apply, rollback, commit }: OptimisticMutationConfig) => {
+      setPending(true);
+      setError(null);
+
+      apply();
+
+      try {
+        await commit();
+      } catch (nextError) {
+        rollback();
+        setError(nextError);
+        throw nextError;
+      } finally {
+        setPending(false);
+      }
+    },
+    []
+  );
+
+  const resetOptimisticMutation = useCallback(() => {
+    setPending(false);
+    setError(null);
+  }, []);
+
+  return {
+    pending,
+    error,
+    runOptimisticMutation,
+    resetOptimisticMutation,
+  };
+}


### PR DESCRIPTION
# Description

Added optimistic mutation state infrastructure through a reusable `useOptimisticMutation` hook.

This PR introduces a lightweight optimistic mutation utility that standardizes optimistic UI execution, rollback handling, mutation lifecycle tracking, and async failure recovery patterns across frontend surfaces.

The infrastructure provides a reusable foundation for future optimistic interaction flows while preserving safe rollback behavior during failed async mutations. The implementation focuses on frontend runtime resilience, perceived responsiveness, and async UX consistency without modifying existing business logic or backend behavior.

No backend logic, API contracts, authentication behavior, consent policies, storage behavior, cache keys, routing logic, or persistence layers were modified.

## 📌 Impact Map (Required)

* Routes touched:

  * [x] None directly
  * [x] Shared frontend infrastructure only

* API / schema / type changes:

  * [x] None

* Cache keys touched:

  * [x] None

* World-model domain summary effects:

  * [x] None

* Mobile parity impacts:

  * [x] None

* Docs updated (exact files):

  * [x] None

* Verification commands executed:

  * [x] `cd hushh-webapp && npm run lint`
  * [x] `cd hushh-webapp && npm run typecheck`
  * [x] `cd hushh-webapp && npm run verify:design-system`
  * [x] `cd hushh-webapp && npm run build`

## 🛑 Tri-Flow Architecture Check

* [x] Web: Optimistic mutation infrastructure hook
* [ ] iOS: N/A
* [ ] Android: N/A

## 🧪 Testing

* [x] Tested on Web
* [ ] Tested on iOS Simulator/Device
* [ ] Tested on Android Emulator/Device
* [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Introduces reusable optimistic mutation primitives for future async interaction flows.

## 🛡️ Privacy & Consent

* [x] No new data collection
* [x] No persistence changes
* [x] No consent logic changes
* [x] No authentication or authorization changes

## 📜 Licensing

* [x] First-party changes remain Apache-2.0 compatible
* [x] No new third-party dependencies added
