### PR TITLE
feat: add idle refresh orchestration infrastructure

### DIFF
--- a/hushh-webapp/hooks/use-idle-refresh.ts
+++ b/hushh-webapp/hooks/use-idle-refresh.ts
@@ -1,0 +1,64 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+
+type IdleRefreshOptions = {
+  idleMs?: number;
+  enabled?: boolean;
+};
+
+export function useIdleRefresh(
+  onRefresh: () => void | Promise<void>,
+  { idleMs = 60000, enabled = true }: IdleRefreshOptions = {}
+) {
+  const timeoutRef = useRef<number | null>(null);
+
+  const resetIdleTimer = useCallback(() => {
+    if (timeoutRef.current) {
+      window.clearTimeout(timeoutRef.current);
+    }
+
+    timeoutRef.current = window.setTimeout(() => {
+      void onRefresh();
+    }, idleMs);
+  }, [idleMs, onRefresh]);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        void onRefresh();
+        resetIdleTimer();
+      }
+    };
+
+    const handleActivity = () => {
+      resetIdleTimer();
+    };
+
+    resetIdleTimer();
+
+    window.addEventListener("focus", handleVisibilityChange);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    window.addEventListener("mousemove", handleActivity);
+    window.addEventListener("keydown", handleActivity);
+    window.addEventListener("touchstart", handleActivity);
+
+    return () => {
+      if (timeoutRef.current) {
+        window.clearTimeout(timeoutRef.current);
+      }
+
+      window.removeEventListener("focus", handleVisibilityChange);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+
+      window.removeEventListener("mousemove", handleActivity);
+      window.removeEventListener("keydown", handleActivity);
+      window.removeEventListener("touchstart", handleActivity);
+    };
+  }, [enabled, onRefresh, resetIdleTimer]);
+}


### PR DESCRIPTION
# Description

Added idle refresh orchestration infrastructure through a reusable `useIdleRefresh` hook.

This PR introduces lightweight idle-aware refresh orchestration primitives that standardize visibility-aware refresh triggering, inactivity timeout coordination, focus-based refresh recovery, and cleanup-safe idle lifecycle management across frontend surfaces.

The infrastructure provides a reusable foundation for future stale-data refresh systems, background synchronization flows, reconnect-aware refresh handling, async state reconciliation, and runtime resilience coordination while helping keep frontend state synchronized after periods of inactivity or tab visibility changes.

The implementation focuses on frontend runtime resilience, async coordination consistency, and reusable lifecycle orchestration without modifying existing business logic, backend behavior, cache contracts, or routing flows.

No backend logic, API contracts, authentication behavior, consent policies, storage behavior, cache keys, routing logic, or persistence layers were modified.

## 📌 Impact Map (Required)

* Routes touched:

  * [x] None directly
  * [x] Shared frontend infrastructure only

* API / schema / type changes:

  * [x] None

* Cache keys touched:

  * [x] None

* World-model domain summary effects:

  * [x] None

* Mobile parity impacts:

  * [x] None

* Docs updated (exact files):

  * [x] None

* Verification commands executed:

  * [x] `cd hushh-webapp && npm run lint`
  * [x] `cd hushh-webapp && npm run typecheck`
  * [x] `cd hushh-webapp && npm run verify:design-system`
  * [x] `cd hushh-webapp && npm run build`

## 🛑 Tri-Flow Architecture Check

* [x] Web: Idle refresh orchestration infrastructure hook
* [ ] iOS: N/A
* [ ] Android: N/A

## 🧪 Testing

* [x] Tested on Web
* [ ] Tested on iOS Simulator/Device
* [ ] Tested on Android Emulator/Device
* [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Introduces reusable idle-aware refresh orchestration primitives for future async synchronization and stale-state recovery flows.

## 🛡️ Privacy & Consent

* [x] No new data collection
* [x] No persistence changes
* [x] No consent logic changes
* [x] No authentication or authorization changes

## 📜 Licensing

* [x] First-party changes remain Apache-2.0 compatible
* [x] No new third-party dependencies added

