### PR TITLE
feat(ui): add accessible skip-to-content keyboard navigation link

### DIFF
--- a/hushh-webapp/__tests__/components/skip-to-content.test.tsx
+++ b/hushh-webapp/__tests__/components/skip-to-content.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { SkipToContent } from "@/components/app-ui/skip-to-content";
+
+describe("SkipToContent - A11y Keyboard Navigation", () => {
+  it("generates correct default fallback href", () => {
+    const element = SkipToContent({});
+    expect(element.props.href).toBe("#main-content");
+  });
+
+  it("accepts custom target IDs for dynamic routing", () => {
+    const element = SkipToContent({ targetId: "dashboard-view" });
+    expect(element.props.href).toBe("#dashboard-view");
+  });
+
+  it("contains mandatory screen-reader utility classes for visual hiding", () => {
+    const element = SkipToContent({});
+    expect(element.props.className).toContain("sr-only");
+    expect(element.props.className).toContain("focus:not-sr-only");
+  });
+
+  it("preserves additional user-injected class names", () => {
+    const element = SkipToContent({ className: "custom-testing-class" });
+    expect(element.props.className).toContain("custom-testing-class");
+  });
+});

--- a/hushh-webapp/components/app-ui/skip-to-content.tsx
+++ b/hushh-webapp/components/app-ui/skip-to-content.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { cn } from "@/lib/morphy-ux/cn";
+
+export interface SkipToContentProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  targetId?: string;
+}
+
+/**
+ * WCAG 2.1 Accessibility Requirement: Keyboard Navigation
+ * Visually hidden by default. Becomes visible only when focused via keyboard (Tab).
+ * Allows users to bypass repetitive navigation links.
+ */
+export function SkipToContent({ 
+  targetId = "main-content", 
+  className, 
+  ...props 
+}: SkipToContentProps) {
+  return (
+    <a
+      href={`#${targetId}`}
+      className={cn(
+        // Hidden by default, but still accessible to the DOM focus tree
+        "sr-only",
+        // When focused via 'Tab', it overrides sr-only and styles itself as a prominent button
+        "focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-[100]",
+        "focus:px-4 focus:py-2 focus:bg-primary focus:text-primary-foreground",
+        "focus:rounded-md focus:shadow-md focus:outline-none focus:ring-2 focus:ring-ring",
+        "transition-all duration-200 ease-in-out",
+        className
+      )}
+      {...props}
+    >
+      Skip to main content
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary (Frontend Craft)
Aligning with the maintainers' guidance to prioritize **Accessibility improvements** and **Keyboard/focus behavior**, this PR introduces a highly isolated WCAG 2.1 compliance component.

The `SkipToContent` component allows users navigating via keyboard (or screen readers) to press `Tab` upon page load to bypass repetitive navigation headers. It remains visually hidden (`sr-only`) until focused, at which point it renders as a high-contrast floating action button. 

## Scope & Blast Radius
**Zero.** This PR is 100% additive. No existing business logic, authentication states, routing contracts, or protected UI folders were modified. It simply establishes the toolkit for layout components to easily adopt keyboard bypass links.

## Test plan
- [x] Local build passes strict typechecking.
- [x] Added `__tests__/components/skip-to-content.test.tsx` to assert semantic class toggling and dynamic `href` generation.
- [x] Avoids `verify-design-system` collisions by living in the application-specific `app-ui` directory.