### PR TITLE
chore(pr-governance): require maintainer patch conversion notes

### DIFF
--- a/.codex/skills/pr-governance-review/SKILL.md
+++ b/.codex/skills/pr-governance-review/SKILL.md
@@ -204,7 +204,7 @@ Default blockers include:
 5. Post before merge only for `block`, `changes_requested`, `comment_only`, or when contributor action is required.
 6. If a PR can be corrected safely by maintainers without changing product intent, prefer `patch_then_merge` over contributor round trips. Use a `## Changes Requested` record when the change needs contributor clarity, split/rebase, proof, or direction correction.
 7. Public duplicate language is allowed only for exact or manually confirmed semantic duplicates. Shared files alone mean sequencing/rebase, not duplicate.
-8. Maintainer patches must be explained in the post-merge note: who patched, what changed, why this was the smallest safe path, and what happened to related PRs.
+8. Maintainer patches must be explained in the post-merge note: who patched, what changed, what original PR value was kept, what was converted into existing canonical docs/scripts/runtime surfaces, what was dropped or deferred, why this was the smallest safe path, and what happened to related PRs.
 9. Do not include a separate successful-merge evidence section such as `### Merge Confidence`, `### Proof`, or `### Verification`; GitHub already shows checks. Use `### Why It Matters` in post-merge comments.
 10. Do not publish maintainer-only sequencing, CI dumps, or report bookkeeping in GitHub comments.
 11. Final handoffs for state-changing PR work must include direct links to affected PRs and any maintainer-authored merge/patch/closure comment links.

--- a/.codex/skills/pr-governance-review/references/comment-and-report-contract.md
+++ b/.codex/skills/pr-governance-review/references/comment-and-report-contract.md
@@ -51,6 +51,14 @@ Use this reference for GitHub write actions, post-merge closeouts, live report u
 
 Add `### Documentation Updated` only when durable docs changed.
 
+For `### Maintainer Patch`, do not write only that maintainers "normalized" or "patched" the PR. Explain the conversion:
+
+1. what useful original capability was kept
+2. what moved into existing canonical docs, scripts, routes, packages, or runtime owners
+3. what was dropped or deferred because it would create a parallel root, duplicate runtime, or unrelated product decision
+4. why the maintainer patch was lower-friction than asking the contributor to redo the branch
+5. where the accepted usage now lives
+
 ### Changes Requested
 
 ```markdown

--- a/.codex/skills/pr-governance-review/references/review-axes.md
+++ b/.codex/skills/pr-governance-review/references/review-axes.md
@@ -106,7 +106,7 @@ Execution rule:
 - if maintainers can modify the contributor branch, patch that branch directly
 - otherwise create a short-lived branch named `temp/pr-<number>-patch`, apply the fix there, and delete it after the issue is resolved
 - rerun CI on the updated merge candidate
-- then thank the author and explain what was integrated and what was corrected
+- then thank the author and explain the conversion map: what was kept, what moved into existing canonical docs/scripts/routes/packages, what was dropped or deferred, and where the accepted usage now lives
 
 ### 3. `block`
 

--- a/.codex/skills/pr-governance-review/scripts/pr_review_checklist.py
+++ b/.codex/skills/pr-governance-review/scripts/pr_review_checklist.py
@@ -4308,7 +4308,7 @@ def _communication_markdown(report: dict[str, Any]) -> str:
                 report["decision"]["rationale"],
                 "",
                 "### Maintainer Patch",
-                f"Maintainer-owned patch was explicitly chosen for: {finding_ids}.",
+                f"Maintainer-owned patch was explicitly chosen for: {finding_ids}. Explain what useful value was kept, what was converted into existing canonical docs/scripts/runtime surfaces, what was dropped or deferred, and where the accepted usage now lives.",
                 "",
                 "### Outcome",
                 "Post-merge closeout is required after Main Post-Merge Smoke is green.",


### PR DESCRIPTION
## Summary
- edited the existing Vishal PR #805 closeout comment in place to explain the maintainer conversion path
- tightened PR governance so maintainer-patch comments must explain kept value, canonical conversion, dropped/deferred pieces, and accepted usage
- updated generated patch-then-merge guidance to require the same conversion map

## Verification
- python3 -m py_compile .codex/skills/pr-governance-review/scripts/pr_review_checklist.py
- python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py
- bash scripts/ci/orchestrate.sh governance
- npm_config_cache=/private/tmp/hushh-npm-cache-prepr ./bin/hushh codex pre-pr
