### PR TITLE
fix(renaissance): guard response.data None, fix .single() misuse, add exc_info

### DIFF
--- a/consent-protocol/hushh_mcp/services/renaissance_service.py
+++ b/consent-protocol/hushh_mcp/services/renaissance_service.py
@@ -202,7 +202,7 @@ class RenaissanceService:
             return False, None
 
         except Exception as e:
-            logger.error(f"Error checking Renaissance universe: {e}")
+            logger.error("Error checking Renaissance universe: %s", e, exc_info=True)
             return False, None
 
     async def get_tier_weight(self, ticker: str) -> float:
@@ -234,12 +234,12 @@ class RenaissanceService:
                     investment_thesis=row.get("investment_thesis", ""),
                     tier_rank=row.get("tier_rank", 0),
                 )
-                for row in response.data
+                for row in (response.data or [])
                 if self._is_supported_symbol(row["ticker"])
             ]
 
         except Exception as e:
-            logger.error(f"Error getting all investable stocks: {e}")
+            logger.error("Error getting all investable stocks: %s", e, exc_info=True)
             return []
 
     async def get_by_tier(self, tier: str) -> list[RenaissanceStock]:
@@ -263,12 +263,12 @@ class RenaissanceService:
                     investment_thesis=row.get("investment_thesis", ""),
                     tier_rank=row.get("tier_rank", 0),
                 )
-                for row in response.data
+                for row in (response.data or [])
                 if self._is_supported_symbol(row["ticker"])
             ]
 
         except Exception as e:
-            logger.error(f"Error getting tier {tier}: {e}")
+            logger.error("Error getting tier %s: %s", tier, e, exc_info=True)
             return []
 
     async def get_by_sector(self, sector: str) -> list[RenaissanceStock]:
@@ -292,12 +292,12 @@ class RenaissanceService:
                     investment_thesis=row.get("investment_thesis", ""),
                     tier_rank=row.get("tier_rank", 0),
                 )
-                for row in response.data
+                for row in (response.data or [])
                 if self._is_supported_symbol(row["ticker"])
             ]
 
         except Exception as e:
-            logger.error(f"Error getting sector {sector}: {e}")
+            logger.error("Error getting sector %s: %s", sector, e, exc_info=True)
             return []
 
     async def get_avoid_context(self, ticker: str) -> dict:
@@ -315,11 +315,12 @@ class RenaissanceService:
                 self.db.table("renaissance_avoid")
                 .select("*")
                 .eq("ticker", ticker.upper())
-                .single()
+                .limit(1)
                 .execute()
             )
-            if response.data:
-                row = response.data[0] if isinstance(response.data, list) else response.data
+            rows = response.data or []
+            if rows:
+                row = rows[0]
                 return {
                     "is_avoid": True,
                     "ticker": row.get("ticker", ticker.upper()),


### PR DESCRIPTION
## Summary

Three related bugs in `RenaissanceService` that cause silent crashes or make failures undiagnosable in production:

- **`response.data` None-safety** - Supabase `.execute()` can return `data=None` on edge-case responses. Iterating `for row in response.data` raises `TypeError: 'NoneType' is not iterable`. Added `or []` guard to `get_all_investable`, `get_by_tier`, and `get_by_sector`.
- **`.single()` misuse in `get_avoid_context`** - `.single()` returns a plain `dict`, not a `list`, making the `isinstance(response.data, list)` branch unreachable and confusing. Replaced with `.limit(1)` so `response.data` is consistently `list | None` and the isinstance check is removed.
- **Missing `exc_info=True` on all `logger.error` calls** - f-string error logging swallows the full traceback. Switched to `%`-style formatting with `exc_info=True` so stack traces are always emitted to the log sink.

## Files changed

- `consent-protocol/hushh_mcp/services/renaissance_service.py`

## Test plan

- [x] Ruff passes with no changes
- [x] Existing tests unaffected (fixes are in error-path guards)
- [x] Each fix targets a distinct failure mode: TypeError on None iteration, silent wrong-branch in isinstance, traceback loss on exception