### PR TITLE
fix(chat): bound limit/offset query params to prevent resource exhaustion

### DIFF
--- a/consent-protocol/api/routes/kai/chat.py
+++ b/consent-protocol/api/routes/kai/chat.py
@@ -17,7 +17,7 @@ Authentication:
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 
 from api.middleware import require_vault_owner_token
@@ -126,7 +126,7 @@ async def kai_chat(
 async def get_conversation_history(
     conversation_id: str,
     token_data: dict = Depends(require_vault_owner_token),
-    limit: int = 50,
+    limit: int = Query(default=50, ge=1, le=500),
 ) -> ConversationHistoryResponse:
     """
     Get conversation history for a specific conversation.
@@ -157,8 +157,8 @@ async def get_conversation_history(
 async def list_user_conversations(
     user_id: str,
     token_data: dict = Depends(require_vault_owner_token),
-    limit: int = 20,
-    offset: int = 0,
+    limit: int = Query(default=20, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
 ) -> dict:
     """
     List all conversations for a user.

--- a/consent-protocol/tests/routes/test_chat_pagination_bounds.py
+++ b/consent-protocol/tests/routes/test_chat_pagination_bounds.py
@@ -1,0 +1,150 @@
+"""Hermetic tests for pagination bounds on Kai chat history/conversation endpoints.
+
+All tests run without DB, network, or LLM.
+Covers that out-of-range limit/offset values are rejected with 422 before any
+auth or service call is made.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.middleware import require_vault_owner_token
+from api.routes.kai.chat import router
+
+# ---------------------------------------------------------------------------
+# App fixture with auth override
+# ---------------------------------------------------------------------------
+
+_TOKEN_STUB = {"user_id": "user_abc"}
+
+
+async def _stub_auth() -> dict:
+    return _TOKEN_STUB
+
+
+app = FastAPI()
+app.include_router(router, prefix="/api")
+app.dependency_overrides[require_vault_owner_token] = _stub_auth
+client = TestClient(app, raise_server_exceptions=False)
+
+
+def _patch_history_service(messages=None):
+    svc = MagicMock()
+    svc.get_conversation_history = AsyncMock(return_value=messages or [])
+    db = MagicMock()
+    conv = MagicMock()
+    conv.user_id = "user_abc"
+    db.get_conversation = AsyncMock(return_value=conv)
+    svc.chat_db = db
+    return patch("api.routes.kai.chat.get_kai_chat_service", return_value=svc)
+
+
+def _patch_conv_service(conversations=None):
+    svc = MagicMock()
+    svc.chat_db = MagicMock()
+    svc.chat_db.list_conversations = AsyncMock(return_value=conversations or [])
+    return patch("api.routes.kai.chat.get_kai_chat_service", return_value=svc)
+
+
+# ---------------------------------------------------------------------------
+# /chat/history/{conversation_id} - limit bounds
+# ---------------------------------------------------------------------------
+
+
+class TestHistoryLimitBounds:
+    def test_default_limit_returns_200(self):
+        with _patch_history_service():
+            resp = client.get("/api/chat/history/conv_abc")
+        assert resp.status_code == 200
+
+    def test_limit_1_is_valid(self):
+        with _patch_history_service():
+            resp = client.get("/api/chat/history/conv_abc?limit=1")
+        assert resp.status_code == 200
+
+    def test_limit_500_is_valid(self):
+        with _patch_history_service():
+            resp = client.get("/api/chat/history/conv_abc?limit=500")
+        assert resp.status_code == 200
+
+    def test_limit_0_returns_422(self):
+        resp = client.get("/api/chat/history/conv_abc?limit=0")
+        assert resp.status_code == 422
+
+    def test_limit_negative_returns_422(self):
+        resp = client.get("/api/chat/history/conv_abc?limit=-1")
+        assert resp.status_code == 422
+
+    def test_limit_501_returns_422(self):
+        resp = client.get("/api/chat/history/conv_abc?limit=501")
+        assert resp.status_code == 422
+
+    def test_limit_9999_returns_422(self):
+        resp = client.get("/api/chat/history/conv_abc?limit=9999")
+        assert resp.status_code == 422
+
+    def test_limit_non_integer_returns_422(self):
+        resp = client.get("/api/chat/history/conv_abc?limit=abc")
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# /chat/conversations/{user_id} - limit and offset bounds
+# ---------------------------------------------------------------------------
+
+
+class TestConversationLimitBounds:
+    def test_default_params_return_200(self):
+        with _patch_conv_service():
+            resp = client.get("/api/chat/conversations/user_abc")
+        assert resp.status_code == 200
+
+    def test_limit_1_is_valid(self):
+        with _patch_conv_service():
+            resp = client.get("/api/chat/conversations/user_abc?limit=1")
+        assert resp.status_code == 200
+
+    def test_limit_200_is_valid(self):
+        with _patch_conv_service():
+            resp = client.get("/api/chat/conversations/user_abc?limit=200")
+        assert resp.status_code == 200
+
+    def test_limit_0_returns_422(self):
+        resp = client.get("/api/chat/conversations/user_abc?limit=0")
+        assert resp.status_code == 422
+
+    def test_limit_negative_returns_422(self):
+        resp = client.get("/api/chat/conversations/user_abc?limit=-5")
+        assert resp.status_code == 422
+
+    def test_limit_201_returns_422(self):
+        resp = client.get("/api/chat/conversations/user_abc?limit=201")
+        assert resp.status_code == 422
+
+    def test_limit_10000_returns_422(self):
+        resp = client.get("/api/chat/conversations/user_abc?limit=10000")
+        assert resp.status_code == 422
+
+
+class TestConversationOffsetBounds:
+    def test_offset_0_is_valid(self):
+        with _patch_conv_service():
+            resp = client.get("/api/chat/conversations/user_abc?offset=0")
+        assert resp.status_code == 200
+
+    def test_offset_large_positive_is_valid(self):
+        with _patch_conv_service():
+            resp = client.get("/api/chat/conversations/user_abc?offset=99999")
+        assert resp.status_code == 200
+
+    def test_offset_negative_returns_422(self):
+        resp = client.get("/api/chat/conversations/user_abc?offset=-1")
+        assert resp.status_code == 422
+
+    def test_both_out_of_range_returns_422(self):
+        resp = client.get("/api/chat/conversations/user_abc?limit=0&offset=-1")
+        assert resp.status_code == 422


### PR DESCRIPTION
## Summary

- `GET /api/chat/history/{conversation_id}` and `GET /api/chat/conversations/{user_id}` accepted unbounded `limit` and `offset` integers
- A caller could pass `limit=10000000` and trigger a full DB scan or OOM the process - no validation was in place before reaching the service layer
- Added `Query(ge, le)` constraints so FastAPI rejects invalid values with 422 before the handler or any DB call runs

## Bounds applied

| Endpoint | Parameter | Before | After |
|---|---|---|---|
| `/chat/history/{id}` | `limit` | `int = 50` | `Query(default=50, ge=1, le=500)` |
| `/chat/conversations/{user_id}` | `limit` | `int = 20` | `Query(default=20, ge=1, le=200)` |
| `/chat/conversations/{user_id}` | `offset` | `int = 0` | `Query(default=0, ge=0)` |

## Tests

19 hermetic route tests added in `tests/routes/test_chat_pagination_bounds.py`:
- 200 for default params and boundary values (1, 500, 200)
- 422 for 0, negative, one-over-max, and non-integer inputs
- Auth stubbed via `app.dependency_overrides` (no DB, no network, no LLM)

## Files changed

- `consent-protocol/api/routes/kai/chat.py` - add `Query` import and bounds
- `consent-protocol/tests/routes/test_chat_pagination_bounds.py` - new hermetic tests