### PR TITLE
fix(ria): add max_length bounds to /clients query params

### DIFF
--- a/consent-protocol/api/routes/ria.py
+++ b/consent-protocol/api/routes/ria.py
@@ -246,8 +246,8 @@ async def ria_firms(firebase_uid: str = Depends(require_firebase_auth)):
 
 @router.get("/clients")
 async def ria_clients(
-    q: str | None = Query(default=None),
-    status: str | None = Query(default=None),
+    q: str | None = Query(default=None, max_length=200),
+    status: str | None = Query(default=None, max_length=50),
     page: int = Query(default=1, ge=1),
     limit: int = Query(default=50, ge=1, le=100),
     firebase_uid: str = Depends(_require_ria_verified),

--- a/consent-protocol/tests/routes/test_ria_client_query_bounds.py
+++ b/consent-protocol/tests/routes/test_ria_client_query_bounds.py
@@ -1,0 +1,157 @@
+"""Hermetic tests: RIA /clients query-string length bounds.
+
+FastAPI validates Query(max_length=...) and returns 422 before the handler
+is reached, so no real DB or network is needed.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.middleware import require_firebase_auth
+from api.routes import ria
+from hushh_mcp.services.ria_iam_service import RIAIAMService
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(ria.router)
+    # Bypass Firebase auth - tests focus on query-param validation only.
+    app.dependency_overrides[require_firebase_auth] = lambda: "test_ria_uid"
+    return app
+
+
+@pytest.fixture(scope="module")
+def client(monkeypatch_session=None):
+    """Module-scoped test client; stubs out RIA verification and client listing."""
+    app = _build_app()
+
+    async def _noop_verify(self, uid: str) -> None:  # noqa: ARG002
+        return None
+
+    async def _empty_clients(self, uid: str, **kwargs) -> dict:  # noqa: ARG002
+        return {"items": [], "total": 0}
+
+    # Patch at class level so they apply regardless of how _build_app imports.
+    RIAIAMService.require_ria_verified = _noop_verify  # type: ignore[method-assign]
+    RIAIAMService.list_ria_clients = _empty_clients  # type: ignore[method-assign]
+
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get(client: TestClient, **params) -> object:
+    return client.get("/api/ria/clients", params={k: v for k, v in params.items() if v is not None})
+
+
+# ---------------------------------------------------------------------------
+# q param - max_length=200
+# ---------------------------------------------------------------------------
+
+
+class TestQParam:
+    def test_q_exactly_200_chars_accepted(self, client):
+        resp = _get(client, q="a" * 200)
+        assert resp.status_code == 200
+
+    def test_q_201_chars_rejected(self, client):
+        resp = _get(client, q="a" * 201)
+        assert resp.status_code == 422
+
+    def test_q_empty_string_accepted(self, client):
+        resp = _get(client, q="")
+        assert resp.status_code == 200
+
+    def test_q_omitted_accepted(self, client):
+        resp = _get(client)
+        assert resp.status_code == 200
+
+    def test_q_normal_search_term_accepted(self, client):
+        resp = _get(client, q="John Doe")
+        assert resp.status_code == 200
+
+    def test_q_very_long_string_rejected(self, client):
+        resp = _get(client, q="x" * 500)
+        assert resp.status_code == 422
+
+    def test_q_422_body_mentions_q(self, client):
+        resp = _get(client, q="z" * 201)
+        assert resp.status_code == 422
+        body = resp.json()
+        detail = str(body.get("detail", ""))
+        assert (
+            "q" in detail.lower()
+            or "string_too_long" in detail.lower()
+            or "max_length" in detail.lower()
+        )
+
+
+# ---------------------------------------------------------------------------
+# status param - max_length=50
+# ---------------------------------------------------------------------------
+
+
+class TestStatusParam:
+    def test_status_exactly_50_chars_accepted(self, client):
+        resp = _get(client, status="s" * 50)
+        assert resp.status_code == 200
+
+    def test_status_51_chars_rejected(self, client):
+        resp = _get(client, status="s" * 51)
+        assert resp.status_code == 422
+
+    def test_status_omitted_accepted(self, client):
+        resp = _get(client)
+        assert resp.status_code == 200
+
+    def test_status_active_accepted(self, client):
+        resp = _get(client, status="active")
+        assert resp.status_code == 200
+
+    def test_status_pending_accepted(self, client):
+        resp = _get(client, status="pending")
+        assert resp.status_code == 200
+
+    def test_status_very_long_rejected(self, client):
+        resp = _get(client, status="x" * 200)
+        assert resp.status_code == 422
+
+    def test_status_422_body_mentions_status(self, client):
+        resp = _get(client, status="y" * 51)
+        assert resp.status_code == 422
+        body = resp.json()
+        detail = str(body.get("detail", ""))
+        assert "status" in detail.lower() or "string_too_long" in detail.lower()
+
+
+# ---------------------------------------------------------------------------
+# Combined params
+# ---------------------------------------------------------------------------
+
+
+class TestCombinedParams:
+    def test_both_at_limit_accepted(self, client):
+        resp = _get(client, q="a" * 200, status="s" * 50)
+        assert resp.status_code == 200
+
+    def test_q_over_limit_status_fine_rejected(self, client):
+        resp = _get(client, q="a" * 201, status="active")
+        assert resp.status_code == 422
+
+    def test_q_fine_status_over_limit_rejected(self, client):
+        resp = _get(client, q="hello", status="s" * 51)
+        assert resp.status_code == 422
+
+    def test_both_over_limit_rejected(self, client):
+        resp = _get(client, q="a" * 201, status="s" * 51)
+        assert resp.status_code == 422
+
+    def test_with_pagination_params_accepted(self, client):
+        resp = _get(client, q="Smith", status="active", page=2, limit=25)
+        assert resp.status_code == 200


### PR DESCRIPTION
## Problem

`GET /api/ria/clients` accepts two unbounded string query parameters:

```python
q: str | None = Query(default=None)      # no length limit
status: str | None = Query(default=None) # no length limit
```

An attacker (or misconfigured client) can send arbitrarily long strings
for either field. These values are forwarded to `RIAIAMService.list_ria_clients`
and logged, which opens the door to:

- Log-line bloat / log injection
- Oversized payloads reaching downstream services
- No 422 signal to legitimate callers about valid input ranges

## Fix

Apply `max_length` constraints that match the semantic domain of each field:

```python
q: str | None = Query(default=None, max_length=200)
status: str | None = Query(default=None, max_length=50)
```

FastAPI validates these before the handler body executes and returns `422
Unprocessable Entity` automatically - zero handler code changes required.

## Tests

`tests/routes/test_ria_client_query_bounds.py` - 19 hermetic tests, no DB,
no network, no LLM:

| Class | Coverage |
|---|---|
| `TestQParam` | exact limit (200) accepted, 201 rejected, empty/omitted OK, 422 body content |
| `TestStatusParam` | exact limit (50) accepted, 51 rejected, common values OK, 422 body content |
| `TestCombinedParams` | both-at-limit, mixed over/under, both-over, pagination coexistence |

All 19 pass in 0.34 s.

## Checklist
- [x] `ruff check --fix` + `ruff format` clean
- [x] DCO sign-off (`git commit -s`)
- [x] Pure hermetic tests (no I/O)
- [x] No breaking API changes (tightening validation is additive for correct clients)