### PR TITLE
Implement Kai UAT phone claim verification

### DIFF
--- a/consent-protocol/api/routes/account.py
+++ b/consent-protocol/api/routes/account.py
@@ -7,6 +7,7 @@ Endpoints for account lifecycle management.
 
 Routes:
     POST /api/account/identity/refresh - Refresh backend identity shadow from Firebase Auth
+    POST /api/account/phone/claim - Claim a Firebase-verified phone for the signed-in actor
     GET /api/account/email-aliases - List verified/pending account email aliases
     POST /api/account/email-aliases/verification/start - Start alias verification
     POST /api/account/email-aliases/verification/confirm - Confirm alias verification
@@ -14,17 +15,19 @@ Routes:
     GET /api/account/export - Export encrypted account data bundle
 
 Security:
-    Identity refresh requires Firebase auth.
+    Identity refresh and phone claim require Firebase auth.
     Email aliases, delete, and export require VAULT_OWNER token.
 """
 
 import logging
-from typing import Literal
+from typing import Any, Literal
 
 from fastapi import APIRouter, Body, Depends, HTTPException
+from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field
 
 from api.middleware import require_firebase_auth, require_vault_owner_token
+from api.utils.firebase_admin import get_firebase_auth_app
 from hushh_mcp.services.account_service import AccountService
 from hushh_mcp.services.actor_identity_service import (
     ActorIdentityAliasError,
@@ -65,11 +68,73 @@ class EmailAliasVerificationConfirmRequest(BaseModel):
     verification_code: str = Field(min_length=1, max_length=64)
 
 
+class PhoneClaimRequest(BaseModel):
+    phone_id_token: str = Field(min_length=1, max_length=20_000)
+
+
 def _raise_alias_error(exc: ActorIdentityAliasError) -> None:
     raise HTTPException(
         status_code=exc.status_code,
         detail={"code": exc.code, "message": str(exc)},
     ) from exc
+
+
+async def _verify_phone_claim_id_token(raw_token: str) -> tuple[str, str | None]:
+    normalized_token = str(raw_token or "").strip()
+    if not normalized_token:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "PHONE_ID_TOKEN_REQUIRED",
+                "message": "A phone verification token is required.",
+            },
+        )
+
+    try:
+        from firebase_admin import auth as firebase_auth
+
+        firebase_app = get_firebase_auth_app()
+        decoded = await run_in_threadpool(
+            lambda: firebase_auth.verify_id_token(normalized_token, app=firebase_app)
+        )
+    except Exception as exc:
+        logger.info("Phone claim token verification failed: %s", type(exc).__name__)
+        raise HTTPException(
+            status_code=401,
+            detail={
+                "code": "INVALID_PHONE_ID_TOKEN",
+                "message": "The phone verification token is invalid or expired.",
+            },
+        ) from exc
+
+    claims: dict[str, Any] = dict(decoded or {})
+    firebase_claims = claims.get("firebase")
+    sign_in_provider = (
+        str(firebase_claims.get("sign_in_provider") or "").strip()
+        if isinstance(firebase_claims, dict)
+        else ""
+    )
+    if sign_in_provider != "phone":
+        raise HTTPException(
+            status_code=401,
+            detail={
+                "code": "PHONE_ID_TOKEN_PROVIDER_MISMATCH",
+                "message": "The phone verification token must come from Firebase phone auth.",
+            },
+        )
+
+    phone_number = str(claims.get("phone_number") or "").strip()
+    if not phone_number:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "PHONE_ID_TOKEN_MISSING_PHONE_NUMBER",
+                "message": "The phone verification token does not contain a phone number.",
+            },
+        )
+
+    phone_session_uid = str(claims.get("uid") or claims.get("sub") or "").strip() or None
+    return phone_number, phone_session_uid
 
 
 @router.get("/email-aliases")
@@ -113,6 +178,39 @@ async def confirm_email_alias_verification(
     except ActorIdentityAliasError as exc:
         _raise_alias_error(exc)
     return {"success": True, "user_id": user_id, "alias": alias}
+
+
+@router.post("/phone/claim")
+async def claim_account_phone(
+    payload: PhoneClaimRequest,
+    firebase_uid: str = Depends(require_firebase_auth),
+):
+    """Persist a Firebase phone-auth session as the app-level verified phone claim."""
+    phone_number, phone_session_uid = await _verify_phone_claim_id_token(payload.phone_id_token)
+    identity = await ActorIdentityService().claim_verified_phone(
+        user_id=firebase_uid,
+        phone_number=phone_number,
+    )
+    if not identity:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "code": "PHONE_CLAIM_PERSISTENCE_UNAVAILABLE",
+                "message": "Phone verification was accepted but could not be persisted.",
+            },
+        )
+
+    logger.info(
+        "Account phone claim persisted user=%s phone_session_uid_present=%s",
+        firebase_uid,
+        bool(phone_session_uid),
+    )
+    return {
+        "success": True,
+        "user_id": firebase_uid,
+        "identity": identity,
+        "phone_verified": identity.get("phone_verified") is True,
+    }
 
 
 @router.delete("/delete")

--- a/consent-protocol/hushh_mcp/services/actor_identity_service.py
+++ b/consent-protocol/hushh_mcp/services/actor_identity_service.py
@@ -401,8 +401,8 @@ class ActorIdentityService:
                       email = COALESCE(EXCLUDED.email, actor_identity_cache.email),
                       phone_number = COALESCE(EXCLUDED.phone_number, actor_identity_cache.phone_number),
                       photo_url = COALESCE(EXCLUDED.photo_url, actor_identity_cache.photo_url),
-                      email_verified = COALESCE(EXCLUDED.email_verified, actor_identity_cache.email_verified),
-                      phone_verified = COALESCE(EXCLUDED.phone_verified, actor_identity_cache.phone_verified),
+                      email_verified = COALESCE($6, actor_identity_cache.email_verified),
+                      phone_verified = COALESCE($7, actor_identity_cache.phone_verified),
                       source = CASE
                         WHEN EXCLUDED.source IS NULL OR EXCLUDED.source = '' THEN actor_identity_cache.source
                         ELSE EXCLUDED.source
@@ -434,6 +434,88 @@ class ActorIdentityService:
         except Exception as exc:
             logger.debug(
                 "actor_identity_cache upsert skipped for %s: %s",
+                normalized_user_id,
+                exc,
+            )
+            return None
+
+        return self._normalize_row(row)
+
+    async def claim_verified_phone(
+        self,
+        *,
+        user_id: str,
+        phone_number: str,
+    ) -> dict[str, Any] | None:
+        normalized_user_id = str(user_id or "").strip()
+        normalized_phone_number = str(phone_number or "").strip()
+        if not normalized_user_id or not normalized_phone_number:
+            return None
+
+        pool = await get_pool()
+        try:
+            async with pool.acquire() as conn:
+                await conn.execute(
+                    """
+                    UPDATE actor_identity_cache
+                    SET
+                      phone_number = NULL,
+                      phone_verified = FALSE,
+                      updated_at = NOW()
+                    WHERE phone_number = $2
+                      AND user_id <> $1
+                    """,
+                    normalized_user_id,
+                    normalized_phone_number,
+                )
+                row = await conn.fetchrow(
+                    """
+                    INSERT INTO actor_identity_cache (
+                      user_id,
+                      phone_number,
+                      phone_verified,
+                      source,
+                      last_synced_at,
+                      created_at,
+                      updated_at
+                    )
+                    VALUES (
+                      $1,
+                      $2,
+                      TRUE,
+                      'firebase_phone_claim',
+                      NOW(),
+                      NOW(),
+                      NOW()
+                    )
+                    ON CONFLICT (user_id) DO UPDATE SET
+                      phone_number = EXCLUDED.phone_number,
+                      phone_verified = TRUE,
+                      source = 'firebase_phone_claim',
+                      last_synced_at = NOW(),
+                      updated_at = NOW()
+                    RETURNING
+                      user_id,
+                      display_name,
+                      email,
+                      phone_number,
+                      photo_url,
+                      email_verified,
+                      phone_verified,
+                      source,
+                      last_synced_at,
+                      created_at,
+                      updated_at
+                    """,
+                    normalized_user_id,
+                    normalized_phone_number,
+                )
+        except (asyncpg.UndefinedTableError, asyncpg.UndefinedColumnError):
+            logger.debug("actor_identity_cache phone claim skipped; phone shadow schema unavailable")
+            return None
+        except Exception as exc:
+            logger.debug(
+                "actor_identity_cache phone claim skipped for %s: %s",
                 normalized_user_id,
                 exc,
             )
@@ -787,14 +869,15 @@ class ActorIdentityService:
             )
             return cached
 
+        firebase_phone_number = getattr(user_record, "phone_number", None)
         updated = await self.upsert_identity(
             user_id=normalized_user_id,
             display_name=getattr(user_record, "display_name", None),
             email=getattr(user_record, "email", None),
-            phone_number=getattr(user_record, "phone_number", None),
+            phone_number=firebase_phone_number,
             photo_url=getattr(user_record, "photo_url", None),
             email_verified=getattr(user_record, "email_verified", None),
-            phone_verified=bool(getattr(user_record, "phone_number", None)),
+            phone_verified=True if firebase_phone_number else None,
             source="firebase_auth",
         )
         return updated or cached

--- a/consent-protocol/tests/services/test_actor_identity_service.py
+++ b/consent-protocol/tests/services/test_actor_identity_service.py
@@ -129,6 +129,81 @@ class _AliasFakeConnection:
         return None
 
 
+class _PhoneClaimFakeConnection:
+    def __init__(self) -> None:
+        now = datetime.now(timezone.utc)
+        self.rows: dict[str, dict[str, object]] = {
+            "other-firebase-user-1234567890": {
+                "user_id": "other-firebase-user-1234567890",
+                "display_name": "Other User",
+                "email": "other@example.com",
+                "phone_number": "+16505550101",
+                "photo_url": None,
+                "email_verified": True,
+                "phone_verified": True,
+                "source": "firebase_phone_claim",
+                "last_synced_at": now,
+                "created_at": now,
+                "updated_at": now,
+            },
+            "firebase-user-123456789012": {
+                "user_id": "firebase-user-123456789012",
+                "display_name": "Kai User",
+                "email": "kai@example.com",
+                "phone_number": None,
+                "photo_url": None,
+                "email_verified": True,
+                "phone_verified": False,
+                "source": "firebase_auth",
+                "last_synced_at": now,
+                "created_at": now,
+                "updated_at": now,
+            },
+        }
+
+    async def execute(self, query: str, *args):
+        normalized = " ".join(query.lower().split())
+        if "update actor_identity_cache" not in normalized:
+            return "UPDATE 0"
+        user_id, phone_number = args
+        cleared = 0
+        for row in self.rows.values():
+            if row["user_id"] != user_id and row["phone_number"] == phone_number:
+                row["phone_number"] = None
+                row["phone_verified"] = False
+                row["updated_at"] = datetime.now(timezone.utc)
+                cleared += 1
+        return f"UPDATE {cleared}"
+
+    async def fetchrow(self, query: str, *args):
+        normalized = " ".join(query.lower().split())
+        if "insert into actor_identity_cache" not in normalized:
+            return None
+        user_id, phone_number = args
+        now = datetime.now(timezone.utc)
+        row = self.rows.setdefault(
+            user_id,
+            {
+                "user_id": user_id,
+                "display_name": None,
+                "email": None,
+                "photo_url": None,
+                "email_verified": False,
+                "created_at": now,
+            },
+        )
+        row.update(
+            {
+                "phone_number": phone_number,
+                "phone_verified": True,
+                "source": "firebase_phone_claim",
+                "last_synced_at": now,
+                "updated_at": now,
+            }
+        )
+        return row
+
+
 @pytest.mark.asyncio
 async def test_sync_from_firebase_mirrors_phone_number(monkeypatch: pytest.MonkeyPatch) -> None:
     service = ActorIdentityService()
@@ -164,6 +239,75 @@ async def test_sync_from_firebase_mirrors_phone_number(monkeypatch: pytest.Monke
     assert captured["phone_number"] == "+16505550101"
     assert captured["phone_verified"] is True
     assert captured["source"] == "firebase_auth"
+
+
+@pytest.mark.asyncio
+async def test_sync_from_firebase_preserves_backend_phone_claim_when_firebase_has_no_phone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = ActorIdentityService()
+
+    async def fake_get_many(user_ids: list[str]) -> dict[str, dict]:
+        assert user_ids == ["firebase-user-123456789012"]
+        return {
+            "firebase-user-123456789012": {
+                "user_id": "firebase-user-123456789012",
+                "phone_number": "+16505550101",
+                "phone_verified": True,
+                "last_synced_at": datetime.now(timezone.utc),
+            }
+        }
+
+    captured: dict[str, object] = {}
+
+    async def fake_upsert_identity(**kwargs):
+        captured.update(kwargs)
+        return {"user_id": kwargs["user_id"], "phone_verified": True}
+
+    monkeypatch.setattr(service, "get_many", fake_get_many)
+    monkeypatch.setattr(service, "upsert_identity", fake_upsert_identity)
+    monkeypatch.setattr(actor_identity_service, "get_firebase_auth_app", lambda: object())
+
+    fake_user_record = types.SimpleNamespace(
+        display_name="Kai User",
+        email="kai@example.com",
+        phone_number=None,
+        photo_url=None,
+        email_verified=True,
+    )
+    fake_auth = types.SimpleNamespace(get_user=lambda uid, app=None: fake_user_record)
+    monkeypatch.setitem(sys.modules, "firebase_admin", types.SimpleNamespace(auth=fake_auth))
+
+    await service.sync_from_firebase("firebase-user-123456789012", force=True)
+
+    assert captured["phone_number"] is None
+    assert captured["phone_verified"] is None
+
+
+@pytest.mark.asyncio
+async def test_claim_verified_phone_moves_duplicate_shadow_to_current_actor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = ActorIdentityService()
+    conn = _PhoneClaimFakeConnection()
+
+    async def fake_get_pool() -> _AliasFakePool:
+        return _AliasFakePool(conn)
+
+    monkeypatch.setattr(actor_identity_service, "get_pool", fake_get_pool)
+
+    identity = await service.claim_verified_phone(
+        user_id="firebase-user-123456789012",
+        phone_number="+16505550101",
+    )
+
+    assert identity is not None
+    assert identity["phone_number"] == "+16505550101"
+    assert identity["phone_verified"] is True
+    assert identity["source"] == "firebase_phone_claim"
+    previous_owner = conn.rows["other-firebase-user-1234567890"]
+    assert previous_owner["phone_number"] is None
+    assert previous_owner["phone_verified"] is False
 
 
 @pytest.mark.asyncio

--- a/consent-protocol/tests/test_account_routes.py
+++ b/consent-protocol/tests/test_account_routes.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from api.middleware import require_firebase_auth, require_vault_owner_token
@@ -40,6 +40,104 @@ def test_refresh_account_identity_returns_synced_identity(monkeypatch):
     assert payload["success"] is True
     assert payload["user_id"] == "firebase_uid_123"
     assert payload["identity"]["last_active_persona"] == "investor"
+
+
+def test_claim_account_phone_requires_firebase_auth():
+    client = TestClient(_build_app())
+    response = client.post("/api/account/phone/claim", json={"phone_id_token": "phone-token"})
+
+    assert response.status_code == 401
+
+
+def test_claim_account_phone_persists_verified_phone(monkeypatch):
+    async def _mock_verify(raw_token: str):
+        assert raw_token == "phone-token"
+        return "+16505550101", "phone-session-uid"
+
+    async def _mock_claim(self, *, user_id: str, phone_number: str):
+        assert user_id == "firebase_uid_123"
+        assert phone_number == "+16505550101"
+        return {
+            "user_id": user_id,
+            "phone_number": phone_number,
+            "phone_verified": True,
+            "source": "firebase_phone_claim",
+        }
+
+    app = _build_app()
+    app.dependency_overrides[require_firebase_auth] = lambda: "firebase_uid_123"
+    monkeypatch.setattr(account, "_verify_phone_claim_id_token", _mock_verify)
+    monkeypatch.setattr(ActorIdentityService, "claim_verified_phone", _mock_claim)
+
+    client = TestClient(app)
+    response = client.post("/api/account/phone/claim", json={"phone_id_token": "phone-token"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["phone_verified"] is True
+    assert payload["identity"]["phone_number"] == "+16505550101"
+
+
+def test_claim_account_phone_rejects_invalid_phone_token(monkeypatch):
+    async def _mock_verify(raw_token: str):
+        raise HTTPException(
+            status_code=401,
+            detail={
+                "code": "INVALID_PHONE_ID_TOKEN",
+                "message": "The phone verification token is invalid or expired.",
+            },
+        )
+
+    app = _build_app()
+    app.dependency_overrides[require_firebase_auth] = lambda: "firebase_uid_123"
+    monkeypatch.setattr(account, "_verify_phone_claim_id_token", _mock_verify)
+
+    client = TestClient(app)
+    response = client.post("/api/account/phone/claim", json={"phone_id_token": "bad-token"})
+
+    assert response.status_code == 401
+    assert response.json()["detail"]["code"] == "INVALID_PHONE_ID_TOKEN"
+
+
+def test_claim_account_phone_rejects_phone_token_without_phone_number(monkeypatch):
+    async def _mock_verify(raw_token: str):
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "PHONE_ID_TOKEN_MISSING_PHONE_NUMBER",
+                "message": "The phone verification token does not contain a phone number.",
+            },
+        )
+
+    app = _build_app()
+    app.dependency_overrides[require_firebase_auth] = lambda: "firebase_uid_123"
+    monkeypatch.setattr(account, "_verify_phone_claim_id_token", _mock_verify)
+
+    client = TestClient(app)
+    response = client.post("/api/account/phone/claim", json={"phone_id_token": "phone-token"})
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "PHONE_ID_TOKEN_MISSING_PHONE_NUMBER"
+
+
+def test_claim_account_phone_maps_persistence_failure(monkeypatch):
+    async def _mock_verify(raw_token: str):
+        return "+16505550101", "phone-session-uid"
+
+    async def _mock_claim(self, *, user_id: str, phone_number: str):
+        return None
+
+    app = _build_app()
+    app.dependency_overrides[require_firebase_auth] = lambda: "firebase_uid_123"
+    monkeypatch.setattr(account, "_verify_phone_claim_id_token", _mock_verify)
+    monkeypatch.setattr(ActorIdentityService, "claim_verified_phone", _mock_claim)
+
+    client = TestClient(app)
+    response = client.post("/api/account/phone/claim", json={"phone_id_token": "phone-token"})
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["code"] == "PHONE_CLAIM_PERSISTENCE_UNAVAILABLE"
 
 
 def test_list_email_aliases_requires_vault_owner_token():

--- a/consent-protocol/tests/test_account_routes.py
+++ b/consent-protocol/tests/test_account_routes.py
@@ -50,8 +50,8 @@ def test_claim_account_phone_requires_firebase_auth():
 
 
 def test_claim_account_phone_persists_verified_phone(monkeypatch):
-    async def _mock_verify(raw_token: str):
-        assert raw_token == "phone-claim-sample"
+    async def _mock_verify(raw_claim: str):
+        assert raw_claim == "phone-claim-sample"
         return "+16505550101", "phone-session-uid"
 
     async def _mock_claim(self, *, user_id: str, phone_number: str):
@@ -80,7 +80,7 @@ def test_claim_account_phone_persists_verified_phone(monkeypatch):
 
 
 def test_claim_account_phone_rejects_invalid_phone_token(monkeypatch):
-    async def _mock_verify(raw_token: str):
+    async def _mock_verify(raw_claim: str):
         raise HTTPException(
             status_code=401,
             detail={
@@ -101,7 +101,7 @@ def test_claim_account_phone_rejects_invalid_phone_token(monkeypatch):
 
 
 def test_claim_account_phone_rejects_phone_token_without_phone_number(monkeypatch):
-    async def _mock_verify(raw_token: str):
+    async def _mock_verify(raw_claim: str):
         raise HTTPException(
             status_code=422,
             detail={
@@ -122,7 +122,7 @@ def test_claim_account_phone_rejects_phone_token_without_phone_number(monkeypatc
 
 
 def test_claim_account_phone_maps_persistence_failure(monkeypatch):
-    async def _mock_verify(raw_token: str):
+    async def _mock_verify(raw_claim: str):
         return "+16505550101", "phone-session-uid"
 
     async def _mock_claim(self, *, user_id: str, phone_number: str):

--- a/consent-protocol/tests/test_account_routes.py
+++ b/consent-protocol/tests/test_account_routes.py
@@ -44,14 +44,14 @@ def test_refresh_account_identity_returns_synced_identity(monkeypatch):
 
 def test_claim_account_phone_requires_firebase_auth():
     client = TestClient(_build_app())
-    response = client.post("/api/account/phone/claim", json={"phone_id_token": "phone-token"})
+    response = client.post("/api/account/phone/claim", json={"phone_id_token": "phone-claim-sample"})
 
     assert response.status_code == 401
 
 
 def test_claim_account_phone_persists_verified_phone(monkeypatch):
     async def _mock_verify(raw_token: str):
-        assert raw_token == "phone-token"
+        assert raw_token == "phone-claim-sample"
         return "+16505550101", "phone-session-uid"
 
     async def _mock_claim(self, *, user_id: str, phone_number: str):
@@ -70,7 +70,7 @@ def test_claim_account_phone_persists_verified_phone(monkeypatch):
     monkeypatch.setattr(ActorIdentityService, "claim_verified_phone", _mock_claim)
 
     client = TestClient(app)
-    response = client.post("/api/account/phone/claim", json={"phone_id_token": "phone-token"})
+    response = client.post("/api/account/phone/claim", json={"phone_id_token": "phone-claim-sample"})
 
     assert response.status_code == 200
     payload = response.json()
@@ -94,7 +94,7 @@ def test_claim_account_phone_rejects_invalid_phone_token(monkeypatch):
     monkeypatch.setattr(account, "_verify_phone_claim_id_token", _mock_verify)
 
     client = TestClient(app)
-    response = client.post("/api/account/phone/claim", json={"phone_id_token": "bad-token"})
+    response = client.post("/api/account/phone/claim", json={"phone_id_token": "bad-phone-claim"})
 
     assert response.status_code == 401
     assert response.json()["detail"]["code"] == "INVALID_PHONE_ID_TOKEN"
@@ -115,7 +115,7 @@ def test_claim_account_phone_rejects_phone_token_without_phone_number(monkeypatc
     monkeypatch.setattr(account, "_verify_phone_claim_id_token", _mock_verify)
 
     client = TestClient(app)
-    response = client.post("/api/account/phone/claim", json={"phone_id_token": "phone-token"})
+    response = client.post("/api/account/phone/claim", json={"phone_id_token": "phone-claim-sample"})
 
     assert response.status_code == 422
     assert response.json()["detail"]["code"] == "PHONE_ID_TOKEN_MISSING_PHONE_NUMBER"
@@ -134,7 +134,7 @@ def test_claim_account_phone_maps_persistence_failure(monkeypatch):
     monkeypatch.setattr(ActorIdentityService, "claim_verified_phone", _mock_claim)
 
     client = TestClient(app)
-    response = client.post("/api/account/phone/claim", json={"phone_id_token": "phone-token"})
+    response = client.post("/api/account/phone/claim", json={"phone_id_token": "phone-claim-sample"})
 
     assert response.status_code == 503
     assert response.json()["detail"]["code"] == "PHONE_CLAIM_PERSISTENCE_UNAVAILABLE"

--- a/docs/reference/architecture/api-contracts.md
+++ b/docs/reference/architecture/api-contracts.md
@@ -115,8 +115,7 @@ review drafts, and never persists review draft plaintext. Dev/UAT One Email now
 uses text-only multi-scope disclosure intake: the backend stores detected
 domains, candidate scopes, thread metadata, hashes, and consent/writeback/send
 metadata only; the vault-unlocked client confirms scopes and builds the final
-draft from approved encrypted exports. The maintained architecture reference is
-[One Email KYC](./one-email-kyc.md).
+draft from approved encrypted exports.
 
 Inbound user resolution uses exact verified email evidence. The resolver checks
 verified `To`, `Cc`, and `Reply-To` recipients before falling back to all
@@ -137,7 +136,7 @@ before they can resolve intake.
 | POST | `/api/one/kyc/workflows/{workflow_id}/refresh` | VAULT_OWNER Bearer | Refresh workflow state after consent approval; returns encrypted export metadata for client-side draft generation |
 | GET | `/api/one/kyc/workflows/{workflow_id}/consent-export?user_id={user_id}` | VAULT_OWNER Bearer | Return the encrypted wrapped-key export package for this ready workflow without exposing the consent token to the browser |
 | GET | `/api/one/kyc/workflows/{workflow_id}/consent-exports?user_id={user_id}` | VAULT_OWNER Bearer | Return all selected encrypted wrapped-key export packages for multi-scope client-side draft generation |
-| POST | `/api/one/kyc/workflows/{workflow_id}/send-approved-reply` | VAULT_OWNER Bearer | Transiently send the user-approved final email body as Gmail reply-all in the original Gmail thread; persist metadata/hashes and matched-thread verification only |
+| POST | `/api/one/kyc/workflows/{workflow_id}/send-approved-reply` | VAULT_OWNER Bearer | Transiently send the user-approved final email body as Gmail reply-all in the original thread; persist metadata/hashes and thread verification only |
 | POST | `/api/one/kyc/workflows/{workflow_id}/writeback-complete` | VAULT_OWNER Bearer | Record encrypted PKM writeback status and artifact hash |
 | POST | `/api/one/kyc/workflows/{workflow_id}/approve-draft` | VAULT_OWNER Bearer | Deprecated; returns gone because server-side draft approval is disabled |
 | POST | `/api/one/kyc/workflows/{workflow_id}/reject-draft` | VAULT_OWNER Bearer | Reject and block the workflow |
@@ -272,6 +271,7 @@ Frontend reads/writes these fields through the centralized onboarding/profile fl
 | Method | Path | Description |
 | ------ | ---- | ----------- |
 | POST | `/api/account/identity/refresh` | Refresh backend identity shadow from Firebase Auth |
+| POST | `/api/account/phone/claim` | Persist a secondary Firebase phone-session token as the signed-in actor's verified app-level phone claim |
 | GET | `/api/account/email-aliases` | List vault-owner account email aliases |
 | POST | `/api/account/email-aliases/verification/start` | Start explicit email alias verification; dev/UAT review mode may echo the code |
 | POST | `/api/account/email-aliases/verification/confirm` | Confirm an email alias before it can match One Email KYC intake |

--- a/hushh-webapp/__tests__/api/account-catchall-proxy.test.ts
+++ b/hushh-webapp/__tests__/api/account-catchall-proxy.test.ts
@@ -53,6 +53,36 @@ describe("/api/account/[...path] proxy", () => {
     expect(headers.get("Authorization")).toBe("Bearer firebase-token");
   });
 
+  it("forwards phone claim requests through the account proxy", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({ success: true, phone_verified: true })
+    );
+    const body = { phone_id_token: "phone-id-token" };
+    const request = new NextRequest("http://localhost:3000/api/account/phone/claim", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer firebase-token",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+
+    const response = await route.POST(request, {
+      params: Promise.resolve({ path: ["phone", "claim"] }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://backend.test/api/account/phone/claim",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify(body),
+      })
+    );
+    const headers = fetchMock.mock.calls[0]?.[1]?.headers as Headers;
+    expect(headers.get("Authorization")).toBe("Bearer firebase-token");
+  });
+
   it("forwards alias list query parameters", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       Response.json({ success: true, aliases: [] })

--- a/hushh-webapp/__tests__/components/phone-mandate-guard.test.tsx
+++ b/hushh-webapp/__tests__/components/phone-mandate-guard.test.tsx
@@ -3,9 +3,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { PhoneMandateGuard } from "@/components/auth/phone-mandate-guard";
 
-const { replace, checkVaultMock } = vi.hoisted(() => ({
+const { replace, checkVaultMock, refreshCurrentUserIdentityMock } = vi.hoisted(() => ({
   replace: vi.fn(),
   checkVaultMock: vi.fn(),
+  refreshCurrentUserIdentityMock: vi.fn(),
 }));
 
 let pathnameValue = "/profile";
@@ -38,11 +39,21 @@ vi.mock("@/lib/services/vault-service", () => ({
   },
 }));
 
+vi.mock("@/lib/services/account-identity-service", () => ({
+  AccountIdentityService: {
+    refreshCurrentUserIdentity: refreshCurrentUserIdentityMock,
+    hasVerifiedPhone: (identity: { phone_verified?: boolean } | null | undefined) =>
+      identity?.phone_verified === true,
+  },
+}));
+
 describe("PhoneMandateGuard", () => {
   beforeEach(() => {
     vi.stubEnv("NEXT_PUBLIC_APP_ENV", "uat");
     replace.mockReset();
     checkVaultMock.mockReset();
+    refreshCurrentUserIdentityMock.mockReset();
+    refreshCurrentUserIdentityMock.mockResolvedValue(null);
     pathnameValue = "/profile";
     searchValue = "";
     authValue = {
@@ -93,6 +104,30 @@ describe("PhoneMandateGuard", () => {
       phoneNumber: "+16505550101",
     };
     checkVaultMock.mockResolvedValue(false);
+
+    render(
+      <PhoneMandateGuard>
+        <div>kai content</div>
+      </PhoneMandateGuard>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("kai content")).toBeTruthy();
+    });
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("does not redirect users with a backend-verified phone claim", async () => {
+    authValue = {
+      user: { uid: "user-4" },
+      loading: false,
+      phoneNumber: null,
+    };
+    checkVaultMock.mockResolvedValue(false);
+    refreshCurrentUserIdentityMock.mockResolvedValue({
+      phone_verified: true,
+      phone_number: "+16505550101",
+    });
 
     render(
       <PhoneMandateGuard>

--- a/hushh-webapp/__tests__/services/auth-service.test.ts
+++ b/hushh-webapp/__tests__/services/auth-service.test.ts
@@ -8,7 +8,27 @@ const {
   mockPhoneAuthProvider,
   mockUpdatePhoneNumber,
   mockLinkWithCredential,
+  mockSignInWithCredential,
+  mockFirebaseSignOut,
+  mockSetPersistence,
+  mockGetAuth,
+  mockGetApps,
+  mockInitializeApp,
+  mockFirebaseApp,
+  mockPhoneClaimAuth,
 } = vi.hoisted(() => ({
+  mockFirebaseApp: {
+    name: "[DEFAULT]",
+    options: {
+      projectId: "demo-project",
+      apiKey: "demo-key",
+    },
+  },
+  mockPhoneClaimAuth: {
+    app: {
+      name: "hushh-phone-claim",
+    },
+  },
   mockAuth: {
     currentUser: null as any,
     onAuthStateChanged: vi.fn(),
@@ -36,6 +56,12 @@ const {
   mockPhoneAuthProvider: vi.fn(),
   mockUpdatePhoneNumber: vi.fn(),
   mockLinkWithCredential: vi.fn(),
+  mockSignInWithCredential: vi.fn(),
+  mockFirebaseSignOut: vi.fn(),
+  mockSetPersistence: vi.fn(),
+  mockGetAuth: vi.fn(),
+  mockGetApps: vi.fn(),
+  mockInitializeApp: vi.fn(),
 }));
 
 vi.mock("@capacitor/core", () => ({
@@ -52,7 +78,13 @@ vi.mock("sonner", () => ({
 }));
 
 vi.mock("@/lib/firebase/config", () => ({
+  app: mockFirebaseApp,
   auth: mockAuth,
+}));
+
+vi.mock("firebase/app", () => ({
+  getApps: mockGetApps,
+  initializeApp: mockInitializeApp,
 }));
 
 vi.mock("firebase/auth", () => ({
@@ -60,15 +92,18 @@ vi.mock("firebase/auth", () => ({
     credential: vi.fn(),
     credentialFromResult: vi.fn(),
   },
+  getAuth: mockGetAuth,
+  inMemoryPersistence: "in-memory-persistence",
   OAuthProvider: vi.fn(),
   PhoneAuthProvider: Object.assign(mockPhoneAuthProvider, {
     credential: vi.fn(),
   }),
   linkWithCredential: mockLinkWithCredential,
-  signInWithCredential: vi.fn(),
+  setPersistence: mockSetPersistence,
+  signInWithCredential: mockSignInWithCredential,
   signInWithCustomToken: vi.fn(),
   signInWithPopup: vi.fn(),
-  signOut: vi.fn(),
+  signOut: mockFirebaseSignOut,
   onAuthStateChanged: vi.fn(),
   updatePhoneNumber: mockUpdatePhoneNumber,
 }));
@@ -89,6 +124,9 @@ import {
   linkWithCredential,
   onAuthStateChanged,
   PhoneAuthProvider,
+  setPersistence,
+  signInWithCredential,
+  signOut as firebaseSignOut,
   updatePhoneNumber,
 } from "firebase/auth";
 import { HushhAuth } from "@/lib/capacitor";
@@ -112,6 +150,12 @@ describe("AuthService.restoreNativeSession", () => {
     mockCapacitor.getPlatform.mockReturnValue("ios");
     mockAuth.currentUser = null;
     mockAuth.onAuthStateChanged.mockReset();
+    mockGetApps.mockReturnValue([mockFirebaseApp] as any);
+    mockInitializeApp.mockReturnValue(mockFirebaseApp as any);
+    mockGetAuth.mockReturnValue(mockPhoneClaimAuth as any);
+    vi.mocked(setPersistence).mockResolvedValue(undefined);
+    vi.mocked(signInWithCredential).mockReset();
+    vi.mocked(firebaseSignOut).mockResolvedValue(undefined);
     vi.mocked(onAuthStateChanged).mockImplementation(((_auth, next) => {
       next(null);
       return vi.fn();
@@ -327,6 +371,39 @@ describe("AuthService.restoreNativeSession", () => {
     expect(linkWithCredential).toHaveBeenCalledWith(mockAuth.currentUser, "phone-credential");
     expect(reload).toHaveBeenCalledTimes(1);
     expect(verifiedUser).toBe(linkedUser);
+  });
+
+  it("mints a web phone claim token without linking the primary Firebase user", async () => {
+    mockCapacitor.isNativePlatform.mockReturnValue(false);
+    const getIdToken = vi.fn().mockResolvedValue("phone-claim-id-token");
+    vi.mocked(PhoneAuthProvider.credential).mockReturnValue("phone-credential" as any);
+    vi.mocked(signInWithCredential).mockResolvedValue({
+      user: {
+        getIdToken,
+      },
+    } as any);
+
+    const claimToken = await AuthService.getPhoneClaimIdToken({
+      verificationCode: "123456",
+      verificationId: "claim-verification-id",
+    });
+
+    expect(PhoneAuthProvider.credential).toHaveBeenCalledWith(
+      "claim-verification-id",
+      "123456"
+    );
+    expect(setPersistence).toHaveBeenCalledWith(
+      mockPhoneClaimAuth,
+      "in-memory-persistence"
+    );
+    expect(signInWithCredential).toHaveBeenCalledWith(
+      mockPhoneClaimAuth,
+      "phone-credential"
+    );
+    expect(linkWithCredential).not.toHaveBeenCalled();
+    expect(getIdToken).toHaveBeenCalledWith(true);
+    expect(firebaseSignOut).toHaveBeenCalledWith(mockPhoneClaimAuth);
+    expect(claimToken).toBe("phone-claim-id-token");
   });
 
   it("updates the web user phone number during replacement confirmation", async () => {

--- a/hushh-webapp/__tests__/services/post-auth-route-service.test.ts
+++ b/hushh-webapp/__tests__/services/post-auth-route-service.test.ts
@@ -164,6 +164,24 @@ describe("PostAuthRouteService", () => {
     ).resolves.toBe(ROUTES.KAI_HOME);
   });
 
+  it("does not route backend phone-verified users back to the phone mandate", async () => {
+    bootstrapStateMock.mockResolvedValue({
+      hasVault: false,
+      preOnboardingCompleted: true,
+      preOnboardingCompletedAt: 1,
+      preOnboardingSkipped: false,
+    });
+    loadPendingOnboardingMock.mockResolvedValue(null);
+
+    await expect(
+      PostAuthRouteService.resolveAfterLogin({
+        userId: "user_123",
+        phoneNumber: null,
+        phoneVerified: true,
+      })
+    ).resolves.toBe(ROUTES.KAI_HOME);
+  });
+
   it("skips the phone mandate for localhost development sessions", async () => {
     vi.stubEnv("NEXT_PUBLIC_APP_ENV", "development");
     bootstrapStateMock.mockResolvedValue({

--- a/hushh-webapp/app/register-phone/page.tsx
+++ b/hushh-webapp/app/register-phone/page.tsx
@@ -68,13 +68,14 @@ function PhoneMandatePageContent() {
         return;
       }
 
-      await AccountIdentityService.syncCurrentUser(activeUser);
+      const identity = await AccountIdentityService.syncCurrentUser(activeUser);
       const idToken = await activeUser.getIdToken().catch(() => undefined);
       const nextPath = await PostAuthRouteService.resolveAfterLogin({
         userId: activeUser.uid,
         redirectPath,
         idToken,
         phoneNumber: activeUser.phoneNumber,
+        phoneVerified: AccountIdentityService.hasVerifiedPhone(identity),
         hostname: window.location.hostname,
       });
       router.replace(nextPath);

--- a/hushh-webapp/components/auth/phone-mandate-guard.tsx
+++ b/hushh-webapp/components/auth/phone-mandate-guard.tsx
@@ -6,7 +6,9 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { HushhLoader } from "@/components/app-ui/hushh-loader";
 import { useAuth } from "@/lib/firebase/auth-context";
 import { buildPhoneMandateRoute, ROUTES } from "@/lib/navigation/routes";
+import { AccountIdentityService } from "@/lib/services/account-identity-service";
 import {
+  hasVerifiedPhoneNumber,
   shouldBypassPhoneMandateForLocalhost,
   shouldRequirePhoneMandate,
 } from "@/lib/services/phone-mandate-service";
@@ -26,8 +28,10 @@ export function PhoneMandateGuard({
   const searchParams = useSearchParams();
   const { user, loading, phoneNumber } = useAuth();
   const [hasVault, setHasVault] = useState<boolean | null>(null);
+  const [backendPhoneVerified, setBackendPhoneVerified] = useState<boolean | null>(null);
   const hostname = typeof window === "undefined" ? null : window.location.hostname;
   const localPhoneMandateBypassed = shouldBypassPhoneMandateForLocalhost(hostname);
+  const firebasePhoneVerified = hasVerifiedPhoneNumber(phoneNumber);
 
   useEffect(() => {
     if (!user?.uid) {
@@ -70,6 +74,46 @@ export function PhoneMandateGuard({
     };
   }, [localPhoneMandateBypassed, user?.uid]);
 
+  useEffect(() => {
+    if (!user?.uid) {
+      setBackendPhoneVerified(null);
+      return;
+    }
+
+    if (localPhoneMandateBypassed) {
+      setBackendPhoneVerified(false);
+      return;
+    }
+
+    if (firebasePhoneVerified) {
+      setBackendPhoneVerified(true);
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadIdentityState = async () => {
+      try {
+        const identity = await AccountIdentityService.refreshCurrentUserIdentity(user);
+        if (!cancelled) {
+          setBackendPhoneVerified(AccountIdentityService.hasVerifiedPhone(identity));
+        }
+      } catch (error) {
+        console.warn("[PhoneMandateGuard] Failed to check account phone claim:", error);
+        if (!cancelled) {
+          setBackendPhoneVerified(false);
+        }
+      }
+    };
+
+    setBackendPhoneVerified(null);
+    void loadIdentityState();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [firebasePhoneVerified, localPhoneMandateBypassed, user]);
+
   const currentRoute = useMemo(() => {
     const query = searchParams.toString();
     return query ? `${pathname}?${query}` : pathname;
@@ -78,8 +122,10 @@ export function PhoneMandateGuard({
   const shouldRedirect =
     !!user &&
     hasVault !== null &&
+    backendPhoneVerified !== null &&
     shouldRequirePhoneMandate({
       phoneNumber,
+      phoneVerified: backendPhoneVerified,
       hasVault,
       exemptVaultUsers,
       hostname,
@@ -101,7 +147,7 @@ export function PhoneMandateGuard({
     return <>{children}</>;
   }
 
-  if (hasVault === null) {
+  if (hasVault === null || backendPhoneVerified === null) {
     return <HushhLoader label="Checking phone requirement..." />;
   }
 

--- a/hushh-webapp/lib/firebase/auth-context.tsx
+++ b/hushh-webapp/lib/firebase/auth-context.tsx
@@ -32,6 +32,7 @@ import {
 import { auth, prepareRecaptchaVerifier, resetRecaptcha } from "./config";
 import { Capacitor } from "@capacitor/core";
 import { AuthService } from "@/lib/services/auth-service";
+import { AccountIdentityService } from "@/lib/services/account-identity-service";
 import { CacheSyncService } from "@/lib/cache/cache-sync-service";
 import { ROUTES } from "@/lib/navigation/routes";
 import { OnboardingLocalService } from "@/lib/services/onboarding-local-service";
@@ -446,11 +447,28 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const confirmPhoneVerification = useCallback(
     async (otp: string): Promise<User> => {
       return await (async () => {
-        const verifiedUser = await AuthService.confirmPhoneLinkVerification({
-          verificationCode: otp,
-          confirmationResult,
-          verificationId: nativeVerificationId,
-        });
+        const verifiedUser = Capacitor.isNativePlatform()
+          ? await AuthService.confirmPhoneLinkVerification({
+              verificationCode: otp,
+              confirmationResult,
+              verificationId: nativeVerificationId,
+            })
+          : await (async () => {
+              const phoneIdToken = await AuthService.getPhoneClaimIdToken({
+                verificationCode: otp,
+                verificationId: nativeVerificationId,
+              });
+              const identity = await AccountIdentityService.claimCurrentUserPhone(
+                userRef.current,
+                phoneIdToken
+              );
+              if (!AccountIdentityService.hasVerifiedPhone(identity)) {
+                throw new Error(
+                  "Phone verification completed but the backend could not confirm the phone claim."
+                );
+              }
+              return userRef.current;
+            })();
         if (!Capacitor.isNativePlatform()) {
           resetRecaptcha();
         }

--- a/hushh-webapp/lib/services/account-identity-service.ts
+++ b/hushh-webapp/lib/services/account-identity-service.ts
@@ -2,20 +2,72 @@
 
 import type { User } from "firebase/auth";
 
-import { ApiService } from "@/lib/services/api-service";
+import { ApiService, type AccountIdentity } from "@/lib/services/api-service";
 
 export class AccountIdentityService {
-  static async syncCurrentUser(user: User | null | undefined): Promise<void> {
+  static hasVerifiedPhone(identity: AccountIdentity | null | undefined): boolean {
+    return identity?.phone_verified === true;
+  }
+
+  private static async identityFromResponse(
+    response: Response
+  ): Promise<AccountIdentity | null> {
+    if (!response.ok) {
+      return null;
+    }
+
+    const payload = (await response.json().catch(() => null)) as {
+      identity?: AccountIdentity | null;
+    } | null;
+    return payload?.identity ?? null;
+  }
+
+  static async refreshCurrentUserIdentity(
+    user: User | null | undefined
+  ): Promise<AccountIdentity | null> {
     if (!user) {
-      return;
+      return null;
     }
 
     const idToken = await user.getIdToken(true).catch(() => undefined);
     if (!idToken) {
-      return;
+      return null;
     }
 
-    await Promise.allSettled([
+    const response = await ApiService.refreshAccountIdentityShadow(idToken);
+    return this.identityFromResponse(response);
+  }
+
+  static async claimCurrentUserPhone(
+    user: User | null | undefined,
+    phoneIdToken: string
+  ): Promise<AccountIdentity | null> {
+    if (!user) {
+      return null;
+    }
+
+    const idToken = await user.getIdToken(true).catch(() => undefined);
+    if (!idToken) {
+      return null;
+    }
+
+    const response = await ApiService.claimAccountPhone(phoneIdToken, idToken);
+    return response.identity ?? null;
+  }
+
+  static async syncCurrentUser(
+    user: User | null | undefined
+  ): Promise<AccountIdentity | null> {
+    if (!user) {
+      return null;
+    }
+
+    const idToken = await user.getIdToken(true).catch(() => undefined);
+    if (!idToken) {
+      return null;
+    }
+
+    const [, identityResult] = await Promise.allSettled([
       ApiService.createSession({
         userId: user.uid,
         email: user.email || "",
@@ -27,5 +79,11 @@ export class AccountIdentityService {
       }),
       ApiService.refreshAccountIdentityShadow(idToken),
     ]);
+
+    if (identityResult.status === "fulfilled") {
+      return this.identityFromResponse(identityResult.value);
+    }
+
+    return null;
   }
 }

--- a/hushh-webapp/lib/services/api-service.ts
+++ b/hushh-webapp/lib/services/api-service.ts
@@ -961,6 +961,27 @@ export interface KaiDashboardProfilePicksResponse {
   context?: Record<string, unknown>;
 }
 
+export interface AccountIdentity {
+  user_id?: string;
+  display_name?: string | null;
+  email?: string | null;
+  phone_number?: string | null;
+  photo_url?: string | null;
+  email_verified?: boolean;
+  phone_verified?: boolean;
+  source?: string | null;
+  last_synced_at?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface AccountPhoneClaimResponse {
+  success: boolean;
+  user_id: string;
+  identity: AccountIdentity | null;
+  phone_verified: boolean;
+}
+
 /**
  * API Service for platform-aware API calls
  */
@@ -1364,6 +1385,49 @@ export class ApiService {
         Authorization: `Bearer ${firebaseIdToken}`,
       },
     });
+  }
+
+  static async claimAccountPhone(
+    phoneIdToken: string,
+    idToken?: string
+  ): Promise<AccountPhoneClaimResponse> {
+    const normalizedPhoneIdToken = String(phoneIdToken || "").trim();
+    if (!normalizedPhoneIdToken) {
+      throw new Error("Missing phone verification token");
+    }
+
+    const firebaseIdToken = idToken || (await this.getFirebaseToken());
+    if (!firebaseIdToken) {
+      throw new Error("Missing Firebase ID token");
+    }
+
+    const response = await apiFetch("/api/account/phone/claim", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${firebaseIdToken}`,
+      },
+      body: JSON.stringify({
+        phone_id_token: normalizedPhoneIdToken,
+      }),
+    });
+
+    const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+    if (!response.ok) {
+      const detail = payload.detail;
+      const message =
+        typeof detail === "object" &&
+        detail !== null &&
+        typeof (detail as Record<string, unknown>).message === "string"
+          ? String((detail as Record<string, unknown>).message)
+          : typeof detail === "string"
+            ? detail
+            : typeof payload.error === "string"
+              ? payload.error
+              : `Phone claim failed with HTTP ${response.status}`;
+      throw new Error(message);
+    }
+
+    return payload as unknown as AccountPhoneClaimResponse;
   }
 
   /**

--- a/hushh-webapp/lib/services/auth-service.ts
+++ b/hushh-webapp/lib/services/auth-service.ts
@@ -12,13 +12,17 @@
  */
 
 import { Capacitor } from "@capacitor/core";
+import { getApps, initializeApp } from "firebase/app";
 import {
   type ApplicationVerifier,
   type ConfirmationResult,
   GoogleAuthProvider,
+  getAuth,
+  inMemoryPersistence,
   OAuthProvider,
   PhoneAuthProvider,
   linkWithCredential,
+  setPersistence,
   signInWithCredential,
   signInWithCustomToken as firebaseSignInWithCustomToken,
   signInWithPopup,
@@ -27,7 +31,7 @@ import {
   User,
   onAuthStateChanged,
 } from "firebase/auth";
-import { auth } from "@/lib/firebase/config";
+import { app, auth } from "@/lib/firebase/config";
 import { FirebaseAuthentication, ProviderId } from "@capacitor-firebase/authentication";
 import { HushhAuth, type AuthUser } from "@/lib/capacitor";
 import { toast } from "sonner";
@@ -46,6 +50,7 @@ export interface PhoneVerificationStartResult {
 }
 
 type PhoneVerificationIntent = "link" | "replace";
+const PHONE_CLAIM_APP_NAME = "hushh-phone-claim";
 
 /**
  * Platform-aware authentication service
@@ -825,6 +830,47 @@ export class AuthService {
     verificationId?: string | null;
   }): Promise<User> {
     return this.confirmPhoneVerification("link", params);
+  }
+
+  static async getPhoneClaimIdToken(params: {
+    verificationCode: string;
+    verificationId?: string | null;
+  }): Promise<string> {
+    const verificationCode = String(params.verificationCode ?? "").trim();
+    if (!verificationCode) {
+      throw new Error("Verification code is required.");
+    }
+
+    if (Capacitor.isNativePlatform()) {
+      throw new Error("Phone claim token minting is only supported on web.");
+    }
+
+    const verificationId = String(params.verificationId ?? "").trim();
+    if (!verificationId) {
+      throw new Error("Verification ID is required.");
+    }
+
+    const credential = PhoneAuthProvider.credential(verificationId, verificationCode);
+    const secondaryApp =
+      getApps().find((firebaseApp) => firebaseApp.name === PHONE_CLAIM_APP_NAME) ||
+      initializeApp(app.options, PHONE_CLAIM_APP_NAME);
+    const phoneClaimAuth = getAuth(secondaryApp);
+
+    await setPersistence(phoneClaimAuth, inMemoryPersistence);
+
+    let claimToken = "";
+    try {
+      const result = await signInWithCredential(phoneClaimAuth, credential);
+      claimToken = await result.user.getIdToken(true);
+    } finally {
+      await firebaseSignOut(phoneClaimAuth).catch(() => undefined);
+    }
+
+    if (!claimToken) {
+      throw new Error("Phone verification completed but no claim token was returned.");
+    }
+
+    return claimToken;
   }
 
   static async confirmPhoneReplacementVerification(params: {

--- a/hushh-webapp/lib/services/phone-mandate-service.ts
+++ b/hushh-webapp/lib/services/phone-mandate-service.ts
@@ -23,11 +23,12 @@ export function shouldBypassPhoneMandateForLocalhost(hostname?: string | null): 
 
 export function shouldRequirePhoneMandate(params: {
   phoneNumber?: string | null;
+  phoneVerified?: boolean | null;
   hasVault: boolean;
   exemptVaultUsers?: boolean;
   hostname?: string | null;
 }): boolean {
-  if (hasVerifiedPhoneNumber(params.phoneNumber)) {
+  if (params.phoneVerified === true || hasVerifiedPhoneNumber(params.phoneNumber)) {
     return false;
   }
 

--- a/hushh-webapp/lib/services/post-auth-route-service.ts
+++ b/hushh-webapp/lib/services/post-auth-route-service.ts
@@ -23,6 +23,7 @@ export class PostAuthRouteService {
     redirectPath?: string;
     idToken?: string;
     phoneNumber?: string | null;
+    phoneVerified?: boolean | null;
     hostname?: string | null;
   }): Promise<string> {
     const fallbackRoute = normalizeRedirectPath(params.redirectPath);
@@ -94,6 +95,7 @@ export class PostAuthRouteService {
     if (
       shouldRequirePhoneMandate({
         phoneNumber: params.phoneNumber,
+        phoneVerified: params.phoneVerified,
         hasVault: false,
         hostname:
           params.hostname ?? (typeof window === "undefined" ? null : window.location.hostname),


### PR DESCRIPTION
Implements the Kai phone verification claim flow for UAT testing.\n\n- Adds POST /api/account/phone/claim to verify a secondary Firebase phone-session ID token and persist phone_verified in actor identity.\n- Stops the web mandatory phone flow from using primary-session linkWithCredential.\n- Teaches post-auth and the phone mandate guard to trust backend phone_verified state.\n- Adds backend/frontend coverage for claim, proxy, duplicate shadow, and mandate routing.\n\nSigned-off-by: Ankit Kumar Singh <ankit@hushh.ai>