### PR TITLE
fix(kai): add size cap to unbounded _MARKET_DATA_CACHE in fetchers

### DIFF
--- a/consent-protocol/hushh_mcp/operons/kai/fetchers.py
+++ b/consent-protocol/hushh_mcp/operons/kai/fetchers.py
@@ -45,6 +45,14 @@ _MARKET_DATA_CACHE_TTL_SECONDS = max(
     60,
     int(os.getenv("KAI_MARKET_DATA_CACHE_TTL_SECONDS", "600") or "600"),
 )
+# Maximum number of ticker entries to keep in the in-process market-data cache.
+# Each entry holds a shallow copy of a market-data dict (~2-10 KB).
+# Default cap: 5 000 entries x ~5 KB ~ 25 MB worst-case.
+# Overridable at startup via the KAI_MARKET_DATA_CACHE_MAX env var.
+_MARKET_DATA_CACHE_MAX: int = max(
+    1,
+    int(os.getenv("KAI_MARKET_DATA_CACHE_MAX", "5000") or "5000"),
+)
 _YFINANCE_TIMEOUT_COOLDOWN_SECONDS = max(
     60,
     int(os.getenv("KAI_YFINANCE_TIMEOUT_COOLDOWN_SECONDS", "180") or "180"),
@@ -126,6 +134,20 @@ def _get_cached_market_data(cache_key: str) -> Dict[str, Any] | None:
 def _set_cached_market_data(cache_key: str, payload: Dict[str, Any], ttl_seconds: int) -> None:
     ttl = max(60, int(ttl_seconds))
     with _MARKET_DATA_CACHE_LOCK:
+        # Fast path: updating an existing key never changes the cache size.
+        if (
+            cache_key not in _MARKET_DATA_CACHE
+            and len(_MARKET_DATA_CACHE) >= _MARKET_DATA_CACHE_MAX
+        ):
+            now = time.time()
+            # Step 1: evict all entries whose TTL has already expired.
+            stale = [k for k, (exp, _) in _MARKET_DATA_CACHE.items() if exp <= now]
+            for k in stale:
+                del _MARKET_DATA_CACHE[k]
+            # Step 2: if still at cap, remove the oldest-inserted entry (FIFO).
+            while len(_MARKET_DATA_CACHE) >= _MARKET_DATA_CACHE_MAX:
+                oldest = next(iter(_MARKET_DATA_CACHE))
+                del _MARKET_DATA_CACHE[oldest]
         _MARKET_DATA_CACHE[cache_key] = (time.time() + ttl, dict(payload))
 
 

--- a/consent-protocol/tests/operons/kai/test_market_data_cache_bounded.py
+++ b/consent-protocol/tests/operons/kai/test_market_data_cache_bounded.py
@@ -1,0 +1,212 @@
+"""Hermetic tests for the bounded _MARKET_DATA_CACHE in fetchers.py.
+
+No DB, no network, no LLM.  All tests manipulate the module-level
+_MARKET_DATA_CACHE / _MARKET_DATA_CACHE_MAX directly via the public
+helpers _get_cached_market_data and _set_cached_market_data.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from hushh_mcp.operons.kai import fetchers
+from hushh_mcp.operons.kai.fetchers import (
+    _get_cached_market_data,
+    _set_cached_market_data,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    """Isolate every test: clear the cache and restore the original cap."""
+    original_max = fetchers._MARKET_DATA_CACHE_MAX
+    fetchers._MARKET_DATA_CACHE.clear()
+    yield
+    fetchers._MARKET_DATA_CACHE.clear()
+    fetchers._MARKET_DATA_CACHE_MAX = original_max
+
+
+# ---------------------------------------------------------------------------
+# Basic get / set
+# ---------------------------------------------------------------------------
+
+
+class TestBasicGetSet:
+    def test_miss_returns_none(self):
+        assert _get_cached_market_data("AAPL|fh:0|pmp:0") is None
+
+    def test_set_then_get_returns_payload(self):
+        _set_cached_market_data("AAPL|fh:0|pmp:0", {"price": 150.0}, ttl_seconds=60)
+        result = _get_cached_market_data("AAPL|fh:0|pmp:0")
+        assert result is not None
+        assert result["price"] == 150.0
+
+    def test_get_returns_independent_copy(self):
+        _set_cached_market_data("AAPL|fh:0|pmp:0", {"price": 150.0}, ttl_seconds=60)
+        r1 = _get_cached_market_data("AAPL|fh:0|pmp:0")
+        r1["mutated"] = True
+        r2 = _get_cached_market_data("AAPL|fh:0|pmp:0")
+        assert "mutated" not in r2
+
+    def test_update_existing_key(self):
+        _set_cached_market_data("AAPL|fh:0|pmp:0", {"price": 100.0}, ttl_seconds=60)
+        _set_cached_market_data("AAPL|fh:0|pmp:0", {"price": 200.0}, ttl_seconds=60)
+        result = _get_cached_market_data("AAPL|fh:0|pmp:0")
+        assert result["price"] == 200.0
+
+    def test_multiple_symbols_stored_independently(self):
+        _set_cached_market_data("AAPL|fh:0|pmp:0", {"price": 150.0}, ttl_seconds=60)
+        _set_cached_market_data("GOOG|fh:0|pmp:0", {"price": 2800.0}, ttl_seconds=60)
+        assert _get_cached_market_data("AAPL|fh:0|pmp:0")["price"] == 150.0
+        assert _get_cached_market_data("GOOG|fh:0|pmp:0")["price"] == 2800.0
+
+
+# ---------------------------------------------------------------------------
+# TTL expiry
+# ---------------------------------------------------------------------------
+
+
+class TestTTLExpiry:
+    def test_expired_entry_returns_none(self):
+        # minimum TTL is clamped to 60s, so we patch the cache directly
+        # with a past expiry to simulate expiration
+        key = "AAPL|fh:0|pmp:0"
+        fetchers._MARKET_DATA_CACHE[key] = (time.time() - 1.0, {"price": 50.0})
+        assert _get_cached_market_data(key) is None
+
+    def test_expired_entry_removed_from_cache(self):
+        key = "AAPL|fh:0|pmp:0"
+        fetchers._MARKET_DATA_CACHE[key] = (time.time() - 1.0, {"price": 50.0})
+        _get_cached_market_data(key)
+        assert key not in fetchers._MARKET_DATA_CACHE
+
+    def test_live_entry_not_evicted(self):
+        key = "TSLA|fh:0|pmp:0"
+        _set_cached_market_data(key, {"price": 700.0}, ttl_seconds=300)
+        assert _get_cached_market_data(key) is not None
+
+
+# ---------------------------------------------------------------------------
+# Size cap - stale eviction first
+# ---------------------------------------------------------------------------
+
+
+class TestSizeCapStaleFirst:
+    def test_stale_entries_evicted_before_live(self):
+        """When cap is reached, expired entries are pruned before live ones."""
+        fetchers._MARKET_DATA_CACHE_MAX = 3
+        # Insert two entries with already-expired TTLs
+        fetchers._MARKET_DATA_CACHE["stale1|fh:0|pmp:0"] = (time.time() - 10, {"v": 1})
+        fetchers._MARKET_DATA_CACHE["stale2|fh:0|pmp:0"] = (time.time() - 10, {"v": 2})
+        fetchers._MARKET_DATA_CACHE["live1|fh:0|pmp:0"] = (time.time() + 600, {"v": 3})
+        # At cap=3, adding a fourth entry should first evict stale entries
+        _set_cached_market_data("live2|fh:0|pmp:0", {"v": 4}, ttl_seconds=300)
+        # live1 must survive (it was not stale)
+        assert _get_cached_market_data("live1|fh:0|pmp:0") is not None
+        assert _get_cached_market_data("live2|fh:0|pmp:0") is not None
+        assert len(fetchers._MARKET_DATA_CACHE) <= 3
+
+    def test_cap_never_exceeded(self):
+        fetchers._MARKET_DATA_CACHE_MAX = 5
+        for i in range(20):
+            _set_cached_market_data(f"SYM{i}|fh:0|pmp:0", {"i": i}, ttl_seconds=300)
+        assert len(fetchers._MARKET_DATA_CACHE) <= 5
+
+
+# ---------------------------------------------------------------------------
+# Size cap - oldest eviction fallback
+# ---------------------------------------------------------------------------
+
+
+class TestSizeCapOldestFallback:
+    def test_oldest_evicted_when_all_live(self):
+        fetchers._MARKET_DATA_CACHE_MAX = 3
+        _set_cached_market_data("first|fh:0|pmp:0", {"v": 1}, ttl_seconds=300)
+        _set_cached_market_data("second|fh:0|pmp:0", {"v": 2}, ttl_seconds=300)
+        _set_cached_market_data("third|fh:0|pmp:0", {"v": 3}, ttl_seconds=300)
+        # fourth write should evict "first" (oldest-inserted)
+        _set_cached_market_data("fourth|fh:0|pmp:0", {"v": 4}, ttl_seconds=300)
+        assert _get_cached_market_data("first|fh:0|pmp:0") is None
+        assert _get_cached_market_data("fourth|fh:0|pmp:0") is not None
+
+    def test_update_in_place_does_not_evict(self):
+        """Updating an existing key must not trigger any eviction."""
+        fetchers._MARKET_DATA_CACHE_MAX = 2
+        _set_cached_market_data("AAPL|fh:0|pmp:0", {"price": 100.0}, ttl_seconds=300)
+        _set_cached_market_data("GOOG|fh:0|pmp:0", {"price": 200.0}, ttl_seconds=300)
+        # Both slots filled; update AAPL - no eviction should happen
+        _set_cached_market_data("AAPL|fh:0|pmp:0", {"price": 110.0}, ttl_seconds=300)
+        assert len(fetchers._MARKET_DATA_CACHE) == 2
+        assert _get_cached_market_data("GOOG|fh:0|pmp:0") is not None
+
+    def test_max_1_keeps_only_latest(self):
+        fetchers._MARKET_DATA_CACHE_MAX = 1
+        _set_cached_market_data("AAPL|fh:0|pmp:0", {"price": 100.0}, ttl_seconds=300)
+        _set_cached_market_data("GOOG|fh:0|pmp:0", {"price": 200.0}, ttl_seconds=300)
+        assert len(fetchers._MARKET_DATA_CACHE) == 1
+        assert _get_cached_market_data("GOOG|fh:0|pmp:0") is not None
+        assert _get_cached_market_data("AAPL|fh:0|pmp:0") is None
+
+
+# ---------------------------------------------------------------------------
+# Concurrency
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrency:
+    def test_concurrent_writes_stay_within_cap(self):
+        cap = 50
+        fetchers._MARKET_DATA_CACHE_MAX = cap
+        errors: list[Exception] = []
+
+        def _worker(start: int) -> None:
+            try:
+                for i in range(start, start + 30):
+                    _set_cached_market_data(f"SYM{i}|fh:0|pmp:0", {"i": i}, ttl_seconds=300)
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=_worker, args=(i * 30,)) for i in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        assert len(fetchers._MARKET_DATA_CACHE) <= cap
+
+    def test_concurrent_reads_and_writes_no_exception(self):
+        fetchers._MARKET_DATA_CACHE_MAX = 20
+        errors: list[Exception] = []
+
+        def _writer() -> None:
+            try:
+                for i in range(50):
+                    _set_cached_market_data(f"SYM{i % 25}|fh:0|pmp:0", {"i": i}, ttl_seconds=300)
+            except Exception as exc:
+                errors.append(exc)
+
+        def _reader() -> None:
+            try:
+                for i in range(50):
+                    _get_cached_market_data(f"SYM{i % 25}|fh:0|pmp:0")
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [
+            *(threading.Thread(target=_writer) for _ in range(4)),
+            *(threading.Thread(target=_reader) for _ in range(4)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors


### PR DESCRIPTION
## Problem

`_MARKET_DATA_CACHE` in `fetchers.py` is a bare module-level dict with no upper bound:

```python
_MARKET_DATA_CACHE: dict[str, tuple[float, Dict[str, Any]]] = {}
```

The TTL logic in `_get_cached_market_data` only evicts a key **when that specific key is read again**. Once a ticker stops being requested, its market-data payload sits in memory indefinitely.

**Worst-case growth** at the default 600s TTL:
- 10 000 tracked tickers × ~5 KB per market-data payload = **~50 MB** of stale data
- A full S&P 500 + Russell 2000 universe: ~3 000 symbols × ~5 KB = ~15 MB

This is a natural companion to #924 which capped `_MARKET_DATA_LOCKS` in the same file.

## Fix

Added `_MARKET_DATA_CACHE_MAX` (default 5 000, env `KAI_MARKET_DATA_CACHE_MAX`) and updated `_set_cached_market_data` with two-step eviction on write:

```python
if cache_key not in _MARKET_DATA_CACHE and len(_MARKET_DATA_CACHE) >= _MARKET_DATA_CACHE_MAX:
    # Step 1: evict all expired entries
    stale = [k for k, (exp, _) in _MARKET_DATA_CACHE.items() if exp <= now]
    for k in stale:
        del _MARKET_DATA_CACHE[k]
    # Step 2: evict oldest-inserted while still at cap
    while len(_MARKET_DATA_CACHE) >= _MARKET_DATA_CACHE_MAX:
        del _MARKET_DATA_CACHE[next(iter(_MARKET_DATA_CACHE))]
```

**Fast path:** updating an existing key skips the eviction check entirely - no extra overhead on cache hits.

**Thread-safety:** all operations stay within the existing `_MARKET_DATA_CACHE_LOCK` (`threading.RLock`).

## Memory

| Scenario | Before | After |
|---|---|---|
| 5 000 tickers | ~25 MB | ~25 MB (cap) |
| 10 000 tickers | ~50 MB | ~25 MB (cap) |
| 50 000 tickers | ~250 MB | ~25 MB (cap) |

## Tests

`tests/operons/kai/test_market_data_cache_bounded.py` - 15 hermetic tests, no DB, no network, no LLM:

| Class | Coverage |
|---|---|
| `TestBasicGetSet` | miss=None, set/get, copy isolation, update, multi-symbol |
| `TestTTLExpiry` | expired=None, evicted from dict, live survives |
| `TestSizeCapStaleFirst` | stale evicted before live, cap never exceeded |
| `TestSizeCapOldestFallback` | oldest evicted when all live, update skips evict, max=1 |
| `TestConcurrency` | 8 writers × 30 keys within cap; 4 writers + 4 readers no exception |

All 15 pass in 3.9 s.

## Checklist
- [x] `ruff check --fix` + `ruff format` clean
- [x] DCO sign-off (`git commit -s`)
- [x] Pure hermetic tests (no I/O)
- [x] Configurable cap via env var