### PR TITLE
fix(marketplace): add max_length bounds to unauthenticated query params

### DIFF
--- a/consent-protocol/api/routes/marketplace.py
+++ b/consent-protocol/api/routes/marketplace.py
@@ -23,10 +23,10 @@ def _iam_schema_not_ready_response(message: str | None = None) -> JSONResponse:
 
 @router.get("/rias")
 async def list_marketplace_rias(
-    query: str | None = Query(default=None),
+    query: str | None = Query(default=None, max_length=200),
     limit: int = Query(default=20, ge=1, le=50),
-    firm: str | None = Query(default=None),
-    verification_status: str | None = Query(default=None),
+    firm: str | None = Query(default=None, max_length=200),
+    verification_status: str | None = Query(default=None, max_length=50),
 ):
     service = RIAIAMService()
     try:
@@ -43,7 +43,7 @@ async def list_marketplace_rias(
 
 @router.get("/investors")
 async def list_marketplace_investors(
-    query: str | None = Query(default=None),
+    query: str | None = Query(default=None, max_length=200),
     limit: int = Query(default=20, ge=1, le=50),
 ):
     service = RIAIAMService()

--- a/consent-protocol/tests/routes/test_marketplace_query_bounds.py
+++ b/consent-protocol/tests/routes/test_marketplace_query_bounds.py
@@ -1,0 +1,161 @@
+"""Hermetic tests: marketplace query-string length bounds.
+
+GET /api/marketplace/rias and /api/marketplace/investors accept string
+query params that are now bounded by max_length.  FastAPI validates these
+before the handler fires and returns 422, so no DB or network needed.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routes import marketplace
+from hushh_mcp.services.ria_iam_service import RIAIAMService
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(marketplace.router)
+    return app
+
+
+@pytest.fixture(scope="module")
+def client():
+    """Module-scoped client; stubs out IAM service so no DB is hit."""
+
+    async def _empty_rias(self, **kwargs) -> list:  # noqa: ARG002
+        return []
+
+    async def _empty_investors(self, **kwargs) -> list:  # noqa: ARG002
+        return []
+
+    RIAIAMService.search_marketplace_rias = _empty_rias  # type: ignore[method-assign]
+    RIAIAMService.search_marketplace_investors = _empty_investors  # type: ignore[method-assign]
+
+    return TestClient(_build_app())
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _rias(client: TestClient, **params) -> object:
+    return client.get(
+        "/api/marketplace/rias", params={k: v for k, v in params.items() if v is not None}
+    )
+
+
+def _investors(client: TestClient, **params) -> object:
+    return client.get(
+        "/api/marketplace/investors", params={k: v for k, v in params.items() if v is not None}
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /rias - query param (max_length=200)
+# ---------------------------------------------------------------------------
+
+
+class TestRiasQueryParam:
+    def test_query_200_chars_accepted(self, client):
+        assert _rias(client, query="a" * 200).status_code == 200
+
+    def test_query_201_chars_rejected(self, client):
+        assert _rias(client, query="a" * 201).status_code == 422
+
+    def test_query_omitted_accepted(self, client):
+        assert _rias(client).status_code == 200
+
+    def test_query_normal_term_accepted(self, client):
+        assert _rias(client, query="Smith Advisory").status_code == 200
+
+    def test_query_very_long_rejected(self, client):
+        assert _rias(client, query="x" * 500).status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /rias - firm param (max_length=200)
+# ---------------------------------------------------------------------------
+
+
+class TestRiasFirmParam:
+    def test_firm_200_chars_accepted(self, client):
+        assert _rias(client, firm="f" * 200).status_code == 200
+
+    def test_firm_201_chars_rejected(self, client):
+        assert _rias(client, firm="f" * 201).status_code == 422
+
+    def test_firm_omitted_accepted(self, client):
+        assert _rias(client).status_code == 200
+
+    def test_firm_normal_value_accepted(self, client):
+        assert _rias(client, firm="Vanguard").status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# GET /rias - verification_status param (max_length=50)
+# ---------------------------------------------------------------------------
+
+
+class TestRiasVerificationStatusParam:
+    def test_status_50_chars_accepted(self, client):
+        assert _rias(client, verification_status="s" * 50).status_code == 200
+
+    def test_status_51_chars_rejected(self, client):
+        assert _rias(client, verification_status="s" * 51).status_code == 422
+
+    def test_status_omitted_accepted(self, client):
+        assert _rias(client).status_code == 200
+
+    def test_status_verified_accepted(self, client):
+        assert _rias(client, verification_status="verified").status_code == 200
+
+    def test_status_very_long_rejected(self, client):
+        assert _rias(client, verification_status="x" * 200).status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /rias - combined params
+# ---------------------------------------------------------------------------
+
+
+class TestRiasCombined:
+    def test_all_at_limit_accepted(self, client):
+        resp = _rias(client, query="a" * 200, firm="f" * 200, verification_status="s" * 50)
+        assert resp.status_code == 200
+
+    def test_query_over_limit_rejected(self, client):
+        assert (
+            _rias(client, query="a" * 201, firm="ok", verification_status="ok").status_code == 422
+        )
+
+    def test_firm_over_limit_rejected(self, client):
+        assert _rias(client, query="ok", firm="f" * 201).status_code == 422
+
+    def test_status_over_limit_rejected(self, client):
+        assert _rias(client, verification_status="s" * 51).status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /investors - query param (max_length=200)
+# ---------------------------------------------------------------------------
+
+
+class TestInvestorsQueryParam:
+    def test_query_200_chars_accepted(self, client):
+        assert _investors(client, query="a" * 200).status_code == 200
+
+    def test_query_201_chars_rejected(self, client):
+        assert _investors(client, query="a" * 201).status_code == 422
+
+    def test_query_omitted_accepted(self, client):
+        assert _investors(client).status_code == 200
+
+    def test_query_normal_term_accepted(self, client):
+        assert _investors(client, query="John Doe").status_code == 200
+
+    def test_query_very_long_rejected(self, client):
+        assert _investors(client, query="y" * 500).status_code == 422


### PR DESCRIPTION
## Problem

`GET /api/marketplace/rias` and `GET /api/marketplace/investors` are **public endpoints with no authentication**. All string query parameters were unbounded:

```python
query: str | None = Query(default=None)               # no limit
firm: str | None = Query(default=None)                # no limit
verification_status: str | None = Query(default=None) # no limit
```

Without auth, any client can send arbitrarily large strings. These values flow directly into `RIAIAMService.search_marketplace_rias` and `search_marketplace_investors`, which forward them to downstream services and log them - creating a low-effort DoS surface.

This is higher severity than the authenticated RIA clients endpoint fixed in #926, because these endpoints require **no token at all**.

## Fix

Applied `max_length` constraints before each handler fires:

```python
# /api/marketplace/rias
query: str | None = Query(default=None, max_length=200)
firm: str | None = Query(default=None, max_length=200)
verification_status: str | None = Query(default=None, max_length=50)

# /api/marketplace/investors
query: str | None = Query(default=None, max_length=200)
```

FastAPI validates these parameters and returns `422 Unprocessable Entity` automatically - zero handler changes required.

## Tests

`tests/routes/test_marketplace_query_bounds.py` - 23 hermetic tests, no DB, no network, no LLM:

| Class | Coverage |
|---|---|
| `TestRiasQueryParam` | exact limit (200) accepted, 201 rejected, omitted/normal OK, very long rejected |
| `TestRiasFirmParam` | exact limit (200) accepted, 201 rejected, omitted/normal OK |
| `TestRiasVerificationStatusParam` | exact limit (50) accepted, 51 rejected, omitted/status values OK |
| `TestRiasCombined` | all at limit, query/firm/status over-limit combinations |
| `TestInvestorsQueryParam` | same boundary checks on investors endpoint |

All 23 pass in 0.41 s.

## Checklist
- [x] `ruff check --fix` + `ruff format` clean
- [x] DCO sign-off (`git commit -s`)
- [x] Pure hermetic tests (no I/O)
- [x] No breaking changes (tightening validation is additive for correct callers)