### PR TITLE
fix(developer): add max_length guards to query params in developer API

### DIFF
--- a/consent-protocol/api/routes/developer.py
+++ b/consent-protocol/api/routes/developer.py
@@ -744,7 +744,7 @@ async def get_tool_catalog(
 async def get_user_scopes(
     user_id: str,
     request: Request,
-    token: Optional[str] = Query(None),
+    token: Optional[str] = Query(None, max_length=2048),
     authorization: Optional[str] = Header(None),
     detail: Literal["compact", "verbose"] = Query(default="compact"),
 ):
@@ -771,10 +771,10 @@ async def get_user_scopes(
 @developer_api_router.get("/consent-status", response_model=DeveloperConsentStatusResponse)
 async def get_consent_status(
     request: Request,
-    user_id: str = Query(..., alias="user_id"),
-    scope: str | None = Query(default=None),
-    request_id: str | None = Query(default=None),
-    token: Optional[str] = Query(None),
+    user_id: str = Query(..., alias="user_id", max_length=128),
+    scope: str | None = Query(default=None, max_length=500),
+    request_id: str | None = Query(default=None, max_length=200),
+    token: Optional[str] = Query(None, max_length=2048),
     authorization: Optional[str] = Header(None),
 ):
     principal = _resolve_principal(

--- a/consent-protocol/tests/routes/test_developer_query_bounds.py
+++ b/consent-protocol/tests/routes/test_developer_query_bounds.py
@@ -1,0 +1,167 @@
+"""Hermetic tests: developer API query-param length bounds return 422.
+
+FastAPI validates max_length before the handler fires — no auth, no DB, no LLM.
+
+Covered endpoints:
+    GET /api/v1/user-scopes/{user_id}   token (max 2048)
+    GET /api/v1/consent-status          user_id (max 128), scope (max 500),
+                                        request_id (max 200), token (max 2048)
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routes.developer import developer_api_router
+
+
+def _build_app() -> TestClient:
+    app = FastAPI()
+    app.include_router(developer_api_router)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+client = _build_app()
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+_OVER_2048 = "x" * 2049
+_OVER_128 = "u" * 129
+_OVER_500 = "s" * 501
+_OVER_200 = "r" * 201
+
+
+def _status(response) -> int:
+    return response.status_code
+
+
+# ===========================================================================
+# GET /api/v1/user-scopes/{user_id}  — token param
+# ===========================================================================
+
+
+class TestUserScopesTokenBound:
+    def test_token_over_2048_returns_422(self):
+        resp = client.get(
+            "/api/v1/user-scopes/uid_abc",
+            params={"token": _OVER_2048},
+        )
+        assert _status(resp) == 422
+
+    def test_token_at_2048_not_rejected_by_length(self):
+        resp = client.get(
+            "/api/v1/user-scopes/uid_abc",
+            params={"token": "x" * 2048},
+        )
+        # 422 only if FastAPI rejects — a different status means length check passed
+        assert _status(resp) != 422 or "token" not in str(resp.json())
+
+    def test_no_token_allowed(self):
+        resp = client.get("/api/v1/user-scopes/uid_abc")
+        assert _status(resp) != 422
+
+
+# ===========================================================================
+# GET /api/v1/consent-status — user_id, scope, request_id, token
+# ===========================================================================
+
+
+class TestConsentStatusQueryBounds:
+    _base = "/api/v1/consent-status"
+
+    # --- user_id ---
+
+    def test_user_id_over_128_returns_422(self):
+        resp = client.get(self._base, params={"user_id": _OVER_128})
+        assert _status(resp) == 422
+
+    def test_user_id_at_128_not_rejected(self):
+        resp = client.get(self._base, params={"user_id": "u" * 128})
+        assert _status(resp) != 422
+
+    def test_user_id_short_not_rejected(self):
+        resp = client.get(self._base, params={"user_id": "uid_1"})
+        assert _status(resp) != 422
+
+    # --- scope ---
+
+    def test_scope_over_500_returns_422(self):
+        resp = client.get(
+            self._base,
+            params={"user_id": "uid_1", "scope": _OVER_500},
+        )
+        assert _status(resp) == 422
+
+    def test_scope_at_500_not_rejected(self):
+        resp = client.get(
+            self._base,
+            params={"user_id": "uid_1", "scope": "s" * 500},
+        )
+        assert _status(resp) != 422
+
+    def test_scope_absent_not_rejected(self):
+        resp = client.get(self._base, params={"user_id": "uid_1"})
+        assert _status(resp) != 422
+
+    # --- request_id ---
+
+    def test_request_id_over_200_returns_422(self):
+        resp = client.get(
+            self._base,
+            params={"user_id": "uid_1", "request_id": _OVER_200},
+        )
+        assert _status(resp) == 422
+
+    def test_request_id_at_200_not_rejected(self):
+        resp = client.get(
+            self._base,
+            params={"user_id": "uid_1", "request_id": "r" * 200},
+        )
+        assert _status(resp) != 422
+
+    def test_request_id_absent_not_rejected(self):
+        resp = client.get(self._base, params={"user_id": "uid_1"})
+        assert _status(resp) != 422
+
+    # --- token ---
+
+    def test_token_over_2048_returns_422(self):
+        resp = client.get(
+            self._base,
+            params={"user_id": "uid_1", "token": _OVER_2048},
+        )
+        assert _status(resp) == 422
+
+    def test_token_at_2048_not_rejected_by_length(self):
+        resp = client.get(
+            self._base,
+            params={"user_id": "uid_1", "token": "x" * 2048},
+        )
+        assert _status(resp) != 422 or "token" not in str(resp.json())
+
+    def test_token_absent_not_rejected(self):
+        resp = client.get(self._base, params={"user_id": "uid_1"})
+        assert _status(resp) != 422
+
+    # --- combined over-length ---
+
+    def test_both_scope_and_request_id_over_limit_returns_422(self):
+        resp = client.get(
+            self._base,
+            params={
+                "user_id": "uid_1",
+                "scope": _OVER_500,
+                "request_id": _OVER_200,
+            },
+        )
+        assert _status(resp) == 422
+
+    def test_user_id_and_token_over_limit_returns_422(self):
+        resp = client.get(
+            self._base,
+            params={"user_id": _OVER_128, "token": _OVER_2048},
+        )
+        assert _status(resp) == 422


### PR DESCRIPTION
## Summary

- Adds `max_length` constraints to four query parameters in `api/routes/developer.py` that previously accepted arbitrarily long strings
- `GET /api/v1/user-scopes/{user_id}`: `token` → `max_length=2048`
- `GET /api/v1/consent-status`: `user_id` → `max_length=128`, `scope` → `max_length=500`, `request_id` → `max_length=200`, `token` → `max_length=2048`
- FastAPI returns 422 before the handler fires — no auth, DB, or service layer touched on rejection

## Test plan

- [x] `python3 -m pytest tests/routes/test_developer_query_bounds.py -x -q` — 17 passed, 0 failed
- [x] `ruff check --fix` and `ruff format` — clean
- Hermetic tests: isolated FastAPI app with only `developer_api_router` included; no mocks needed

Signed-off-by: Anshul Jain <anshul23102@iiitd.ac.in>