### PR TITLE
fix(consent): block cache reuse across different consent tokens

### DIFF
--- a/hushh-webapp/__tests__/services/consent-center-service.test.ts
+++ b/hushh-webapp/__tests__/services/consent-center-service.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiFetchMock = vi.fn();
+
+vi.mock("@/lib/services/api-service", () => ({
+  ApiService: {
+    apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+  },
+}));
+
+import { ConsentCenterService } from "@/lib/services/consent-center-service";
+import { CacheService } from "@/lib/services/cache-service";
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function centerPayload(marker: string) {
+  return {
+    user_id: "user-1",
+    persona_state: {
+      user_id: "user-1",
+      personas: ["investor"],
+      last_active_persona: "investor",
+      active_persona: "investor",
+      primary_nav_persona: "investor",
+      ria_setup_available: false,
+      ria_switch_available: false,
+      dev_ria_bypass_allowed: false,
+      investor_marketplace_opt_in: false,
+      iam_schema_ready: true,
+      mode: "full",
+    },
+    summary: {
+      incoming_requests: 0,
+      outgoing_requests: 0,
+      active_grants: marker === "token-a" ? 1 : 2,
+      invites: 0,
+      history: 0,
+      developer_requests: 0,
+      ria_roster: {
+        total: 0,
+        approved: 0,
+        pending: 0,
+        invited: 0,
+      },
+    },
+    incoming_requests: [],
+    outgoing_requests: [],
+    active_grants: [{ id: marker }],
+    history: [],
+    invites: [],
+    developer_requests: [],
+    requestor_groups: {
+      pending: [],
+      active: [],
+      previous: [],
+    },
+  };
+}
+
+describe("ConsentCenterService cache isolation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    CacheService.getInstance().clear();
+  });
+
+  it("does not reuse cached consent center data across different bearer tokens", async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(jsonResponse(centerPayload("token-a")))
+      .mockResolvedValueOnce(jsonResponse(centerPayload("token-b")));
+
+    const first = await ConsentCenterService.getCenter({
+      idToken: "consent-token-a",
+      userId: "user-1",
+      actor: "investor",
+      view: "active",
+    });
+    const second = await ConsentCenterService.getCenter({
+      idToken: "consent-token-b",
+      userId: "user-1",
+      actor: "investor",
+      view: "active",
+    });
+    const firstAgain = await ConsentCenterService.getCenter({
+      idToken: "consent-token-a",
+      userId: "user-1",
+      actor: "investor",
+      view: "active",
+    });
+
+    expect(first.active_grants[0]?.id).toBe("token-a");
+    expect(second.active_grants[0]?.id).toBe("token-b");
+    expect(firstAgain.active_grants[0]?.id).toBe("token-a");
+    expect(apiFetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not reuse cached consent summaries across different bearer tokens", async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          user_id: "user-1",
+          actor: "investor",
+          mode: "consents",
+          counts: { pending: 0, active: 1, previous: 0 },
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          user_id: "user-1",
+          actor: "investor",
+          mode: "consents",
+          counts: { pending: 0, active: 2, previous: 0 },
+        })
+      );
+
+    const first = await ConsentCenterService.getSummary({
+      idToken: "consent-token-a",
+      userId: "user-1",
+      actor: "investor",
+    });
+    const second = await ConsentCenterService.getSummary({
+      idToken: "consent-token-b",
+      userId: "user-1",
+      actor: "investor",
+    });
+    const firstAgain = await ConsentCenterService.getSummary({
+      idToken: "consent-token-a",
+      userId: "user-1",
+      actor: "investor",
+    });
+
+    expect(first.counts.active).toBe(1);
+    expect(second.counts.active).toBe(2);
+    expect(firstAgain.counts.active).toBe(1);
+    expect(apiFetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not reuse cached consent lists across different bearer tokens", async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          user_id: "user-1",
+          actor: "investor",
+          mode: "consents",
+          surface: "active",
+          query: "",
+          page: 1,
+          limit: 20,
+          total: 1,
+          has_more: false,
+          items: [{ id: "token-a" }],
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          user_id: "user-1",
+          actor: "investor",
+          mode: "consents",
+          surface: "active",
+          query: "",
+          page: 1,
+          limit: 20,
+          total: 1,
+          has_more: false,
+          items: [{ id: "token-b" }],
+        })
+      );
+
+    const first = await ConsentCenterService.listEntries({
+      idToken: "consent-token-a",
+      userId: "user-1",
+      actor: "investor",
+      surface: "active",
+    });
+    const second = await ConsentCenterService.listEntries({
+      idToken: "consent-token-b",
+      userId: "user-1",
+      actor: "investor",
+      surface: "active",
+    });
+    const firstAgain = await ConsentCenterService.listEntries({
+      idToken: "consent-token-a",
+      userId: "user-1",
+      actor: "investor",
+      surface: "active",
+    });
+
+    expect(first.items[0]?.id).toBe("token-a");
+    expect(second.items[0]?.id).toBe("token-b");
+    expect(firstAgain.items[0]?.id).toBe("token-a");
+    expect(apiFetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/hushh-webapp/lib/cache/cache-sync-service.ts
+++ b/hushh-webapp/lib/cache/cache-sync-service.ts
@@ -419,6 +419,8 @@ export class CacheSyncService {
     cache.invalidate(CACHE_KEYS.CONSENT_CENTER(userId, "all"));
     cache.invalidate(CACHE_KEYS.CONSENT_CENTER_SUMMARY(userId, "investor"));
     cache.invalidate(CACHE_KEYS.CONSENT_CENTER_SUMMARY(userId, "ria"));
+    cache.invalidatePattern(`consent_center_${userId}_`);
+    cache.invalidatePattern(`consent_center_summary_${userId}_`);
     cache.invalidatePattern(`consent_center_preview_${userId}_`);
     cache.invalidate(CACHE_KEYS.RIA_HOME(userId));
     cache.invalidate(CACHE_KEYS.RIA_ROSTER_SUMMARY(userId));
@@ -444,6 +446,8 @@ export class CacheSyncService {
     cache.invalidate(CACHE_KEYS.CONSENT_CENTER(userId, "all"));
     cache.invalidate(CACHE_KEYS.CONSENT_CENTER_SUMMARY(userId, "investor"));
     cache.invalidate(CACHE_KEYS.CONSENT_CENTER_SUMMARY(userId, "ria"));
+    cache.invalidatePattern(`consent_center_${userId}_`);
+    cache.invalidatePattern(`consent_center_summary_${userId}_`);
     cache.invalidatePattern(`consent_center_preview_${userId}_`);
     cache.invalidate(CACHE_KEYS.RIA_HOME(userId));
     cache.invalidate(CACHE_KEYS.RIA_ROSTER_SUMMARY(userId));

--- a/hushh-webapp/lib/services/consent-center-service.ts
+++ b/hushh-webapp/lib/services/consent-center-service.ts
@@ -224,9 +224,24 @@ interface ErrorPayload {
 }
 
 export class ConsentCenterService {
+  private static tokenCachePartition(token: string): string {
+    const input = String(token || "");
+    if (!input) {
+      return "token:none";
+    }
+
+    let hash = 2166136261;
+    for (let index = 0; index < input.length; index += 1) {
+      hash ^= input.charCodeAt(index);
+      hash = Math.imul(hash, 16777619);
+    }
+    return `token:${input.length}:${(hash >>> 0).toString(36)}`;
+  }
+
   static async getCenter(options: FetchCenterOptions): Promise<ConsentCenterResponse> {
     const { idToken, userId, actor = "investor", view = "incoming", force = false } = options;
-    const cacheKey = CACHE_KEYS.CONSENT_CENTER(userId, `${actor}:${view}`);
+    const tokenPartition = this.tokenCachePartition(idToken);
+    const cacheKey = CACHE_KEYS.CONSENT_CENTER(userId, `${actor}:${view}:${tokenPartition}`);
     const cache = CacheService.getInstance();
 
     if (!force) {
@@ -260,7 +275,7 @@ export class ConsentCenterService {
     payload.self_activity_summary = payload.self_activity_summary || null;
 
     cache.set(cacheKey, payload, CACHE_TTL.SHORT);
-    cache.set(CACHE_KEYS.CONSENT_CENTER(userId, "all"), payload, CACHE_TTL.SHORT);
+    cache.set(CACHE_KEYS.CONSENT_CENTER(userId, `all:${tokenPartition}`), payload, CACHE_TTL.SHORT);
     return payload;
   }
 
@@ -291,7 +306,11 @@ export class ConsentCenterService {
   }): Promise<ConsentCenterPageSummary> {
     const actor = options.actor || "investor";
     const mode = options.mode || "consents";
-    const cacheKey = CACHE_KEYS.CONSENT_CENTER_SUMMARY(options.userId, `${actor}:${mode}`);
+    const tokenPartition = this.tokenCachePartition(options.idToken);
+    const cacheKey = CACHE_KEYS.CONSENT_CENTER_SUMMARY(
+      options.userId,
+      `${actor}:${mode}:${tokenPartition}`
+    );
     const cache = CacheService.getInstance();
     if (!options.force) {
       const cached = cache.get<ConsentCenterPageSummary>(cacheKey);
@@ -330,16 +349,17 @@ export class ConsentCenterService {
     const previewTop = typeof options.top === "number" ? Math.max(1, Math.min(options.top, 10)) : null;
     const page = previewTop ? 1 : options.page || 1;
     const limit = previewTop ?? (options.limit || CONSENT_CENTER_PAGE_SIZE);
+    const tokenPartition = this.tokenCachePartition(options.idToken);
     const cacheKey = previewTop
       ? CACHE_KEYS.CONSENT_CENTER_PREVIEW(
           options.userId,
-          `${actor}:${mode}`,
+          `${actor}:${mode}:${tokenPartition}`,
           options.surface,
           previewTop
         )
       : CACHE_KEYS.CONSENT_CENTER_LIST(
           options.userId,
-          `${actor}:${mode}`,
+          `${actor}:${mode}:${tokenPartition}`,
           options.surface,
           q,
           page,


### PR DESCRIPTION
## Description

Prevents cache reuse across different consent tokens to ensure PKM, cache, and sync flows remain strictly bound to the active consent scope.

## Why

Cache entries created under one consent token should not be reused when a different consent context is active. Reusing cache across consent boundaries can lead to incorrect memory reads, stale data exposure, or violations of the canonical vault and consent contracts.

This change strengthens isolation between consent-scoped data paths while preserving existing PKM, cache, and vault ownership rules.

## What changed

- Added validation to ensure cache entries are tied to the active consent token
- Blocked reuse of cache entries across differing consent contexts
- Enforced strict consent-scope isolation for cache reads
- Preserved existing cache and PKM flow contracts

## Impact

- No API changes
- No schema changes
- No new cache system introduced
- Improves correctness and safety of consent-scoped cache usage

## Testing

- Ran `npm run lint`
- Ran `npm run build`
- Verified cache is not reused across different consent tokens
- Verified valid same-token cache reuse continues to function correctly

## Notes

This PR intentionally focuses on strengthening existing consent and cache boundaries and does not introduce new memory systems, parallel cache layers, or standalone runtime services.