### PR TITLE
 fix(sync): abort sync pipeline on vault validation failure

### DIFF
--- a/hushh-webapp/__tests__/services/kai-profile-sync-service.test.ts
+++ b/hushh-webapp/__tests__/services/kai-profile-sync-service.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hasRunningTaskMock = vi.fn();
+const syncOnboardingAndNavStateMock = vi.fn();
+const markSyncedMock = vi.fn();
+const markNavSyncedMock = vi.fn();
+const getVaultStateMock = vi.fn();
+const assertVaultKeyMatchesStateMock = vi.fn();
+
+vi.mock("@/lib/services/app-background-task-service", () => ({
+  AppBackgroundTaskService: {
+    hasRunningTask: (...args: unknown[]) => hasRunningTaskMock(...args),
+  },
+}));
+
+vi.mock("@/lib/services/kai-profile-service", () => ({
+  computeRiskScore: vi.fn(() => 3),
+  mapRiskProfile: vi.fn(() => "balanced"),
+  KaiProfileService: {
+    syncOnboardingAndNavState: (...args: unknown[]) => syncOnboardingAndNavStateMock(...args),
+  },
+}));
+
+vi.mock("@/lib/services/kai-nav-tour-local-service", () => ({
+  KaiNavTourLocalService: {
+    load: vi.fn(async () => null),
+    markSynced: (...args: unknown[]) => markNavSyncedMock(...args),
+  },
+}));
+
+vi.mock("@/lib/services/pre-vault-onboarding-service", () => ({
+  PreVaultOnboardingService: {
+    load: vi.fn(async () => null),
+    markCompleted: vi.fn(async () => undefined),
+    markSynced: (...args: unknown[]) => markSyncedMock(...args),
+  },
+}));
+
+vi.mock("@/lib/services/vault-service", () => ({
+  VaultService: {
+    getVaultState: (...args: unknown[]) => getVaultStateMock(...args),
+    assertVaultKeyMatchesState: (...args: unknown[]) => assertVaultKeyMatchesStateMock(...args),
+  },
+}));
+
+import { KaiProfileSyncService } from "@/lib/services/kai-profile-sync-service";
+
+describe("KaiProfileSyncService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hasRunningTaskMock.mockReturnValue(false);
+    getVaultStateMock.mockResolvedValue({ vaultKeyHash: "hash" });
+    assertVaultKeyMatchesStateMock.mockResolvedValue(undefined);
+    syncOnboardingAndNavStateMock.mockResolvedValue({});
+    markSyncedMock.mockResolvedValue(undefined);
+    markNavSyncedMock.mockResolvedValue(undefined);
+  });
+
+  it("validates the vault key before syncing pending state into PKM", async () => {
+    await expect(
+      KaiProfileSyncService.syncPendingToVault({
+        userId: "user-1",
+        vaultKey: "vault-key",
+        vaultOwnerToken: "vault-owner-token",
+        pendingState: {
+          hasPending: true,
+          onboardingPayload: {
+            completed: true,
+            skippedPreferences: true,
+          },
+        },
+      })
+    ).resolves.toEqual({ synced: true });
+
+    expect(getVaultStateMock).toHaveBeenCalledWith("user-1");
+    expect(assertVaultKeyMatchesStateMock).toHaveBeenCalledWith(
+      { vaultKeyHash: "hash" },
+      "vault-key"
+    );
+    expect(syncOnboardingAndNavStateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-1",
+        vaultKey: "vault-key",
+        vaultOwnerToken: "vault-owner-token",
+        onboarding: {
+          completed: true,
+          skippedPreferences: true,
+        },
+      })
+    );
+    expect(markSyncedMock).toHaveBeenCalledWith("user-1");
+    expect(markNavSyncedMock).not.toHaveBeenCalled();
+  });
+
+  it("aborts the sync pipeline when vault validation fails", async () => {
+    const validationError = new Error("Vault key integrity check failed.");
+    assertVaultKeyMatchesStateMock.mockRejectedValue(validationError);
+
+    await expect(
+      KaiProfileSyncService.syncPendingToVault({
+        userId: "user-1",
+        vaultKey: "wrong-vault-key",
+        vaultOwnerToken: "vault-owner-token",
+        pendingState: {
+          hasPending: true,
+          onboardingPayload: {
+            completed: true,
+            skippedPreferences: true,
+          },
+        },
+      })
+    ).rejects.toThrow("Vault key integrity check failed.");
+
+    expect(getVaultStateMock).toHaveBeenCalledWith("user-1");
+    expect(assertVaultKeyMatchesStateMock).toHaveBeenCalledWith(
+      { vaultKeyHash: "hash" },
+      "wrong-vault-key"
+    );
+    expect(syncOnboardingAndNavStateMock).not.toHaveBeenCalled();
+    expect(markSyncedMock).not.toHaveBeenCalled();
+    expect(markNavSyncedMock).not.toHaveBeenCalled();
+  });
+});

--- a/hushh-webapp/lib/services/kai-profile-sync-service.ts
+++ b/hushh-webapp/lib/services/kai-profile-sync-service.ts
@@ -8,6 +8,7 @@ import {
 import { AppBackgroundTaskService } from "@/lib/services/app-background-task-service";
 import { KaiNavTourLocalService } from "@/lib/services/kai-nav-tour-local-service";
 import { PreVaultOnboardingService } from "@/lib/services/pre-vault-onboarding-service";
+import { VaultService } from "@/lib/services/vault-service";
 
 type OnboardingPayload = {
   completed: boolean;
@@ -24,6 +25,18 @@ type NavPayload = {
   completedAt?: string | null;
   skippedAt?: string | null;
 };
+
+const VAULT_VALIDATION_MESSAGES = [
+  "Vault key format is invalid.",
+  "Vault key integrity check failed.",
+];
+
+function isVaultValidationFailure(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return VAULT_VALIDATION_MESSAGES.some((message) => error.message.includes(message));
+}
 
 export type KaiProfilePendingSyncState = {
   hasPending: boolean;
@@ -134,6 +147,9 @@ export class KaiProfileSyncService {
       };
     }
 
+    const vaultState = await VaultService.getVaultState(params.userId);
+    await VaultService.assertVaultKeyMatchesState(vaultState, params.vaultKey);
+
     // Retry with exponential backoff (max 3 attempts)
     const retryDelays = [0, 1000, 3000];
     let lastError: unknown;
@@ -154,6 +170,9 @@ export class KaiProfileSyncService {
         break;
       } catch (error) {
         lastError = error;
+        if (isVaultValidationFailure(error)) {
+          throw error;
+        }
         console.warn(
           `[KaiProfileSyncService] Sync attempt ${attempt + 1}/${retryDelays.length} failed:`,
           error,


### PR DESCRIPTION
## Description

Aborts the PKM sync pipeline when vault validation fails to ensure synchronization only proceeds under a valid and consistent vault context.

## Why

Vault validation establishes the encryption and ownership boundary for PKM operations. If validation fails at any point in the sync pipeline, continuing execution can lead to partial writes, inconsistent cache state, or unauthorized memory propagation.

This change ensures the sync pipeline fails fast and safely when vault validation is not satisfied, preserving the canonical vault, consent, cache, and PKM contracts.

## What changed

- Added vault validation guard at sync pipeline entry and critical stages
- Aborted sync execution on validation failure
- Prevented partial PKM sync commits under invalid vault context
- Preserved existing sync, cache, and consent flow contracts

## Impact

- No API changes
- No schema changes
- No new sync or memory systems introduced
- Improves consistency and safety of PKM synchronization

## Testing

- Ran `npm run lint`
- Ran `npm run build`
- Verified sync pipeline aborts on vault validation failure
- Verified valid vault-backed sync flows continue successfully

## Notes

This PR intentionally focuses on strengthening the canonical PKM sync path and does not introduce parallel sync pipelines, standalone memory systems, or generated runtime stores.