### PR TITLE
fix(pkm): reject memory writes missing scope descriptions

### DIFF
--- a/consent-protocol/api/routes/pkm_routes_shared.py
+++ b/consent-protocol/api/routes/pkm_routes_shared.py
@@ -344,7 +344,6 @@ class DomainManifestPayload(BaseModel):
     top_level_scope_paths: List[str] = Field(default_factory=list)
     externalizable_paths: List[str] = Field(default_factory=list)
     paths: List[PathDescriptorPayload] = Field(default_factory=list)
-    scope_registry: List[dict] = Field(default_factory=list)
     source_agent: Optional[str] = None
 
 
@@ -410,78 +409,6 @@ class StoreDomainResponse(BaseModel):
 EncryptedBlob.model_rebuild()
 
 
-def _scope_metadata_description(entry: dict) -> str:
-    for key in ("description", "scope_description"):
-        value = entry.get(key)
-        if isinstance(value, str) and value.strip():
-            return value.strip()
-    summary_projection = entry.get("summary_projection")
-    if isinstance(summary_projection, dict):
-        for key in ("description", "scope_description"):
-            value = summary_projection.get(key)
-            if isinstance(value, str) and value.strip():
-                return value.strip()
-    return ""
-
-
-def _is_memory_origin_write(request: StoreDomainRequest) -> bool:
-    source_candidates = [
-        request.source_agent,
-        request.manifest.source_agent if request.manifest else None,
-        request.structure_decision.source_agent if request.structure_decision else None,
-    ]
-    return any(
-        "memory" in str(candidate or "").lower()
-        or str(candidate or "").lower().startswith("pkm_")
-        for candidate in source_candidates
-    )
-
-
-def _validate_scope_metadata_descriptions(request: StoreDomainRequest) -> None:
-    if not _is_memory_origin_write(request) or request.manifest is None:
-        return
-
-    scope_registry = request.manifest.scope_registry or []
-    if not scope_registry and request.manifest.top_level_scope_paths:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail={
-                "code": "PKM_SCOPE_METADATA_DESCRIPTION_REQUIRED",
-                "message": "Memory writes must include scope metadata descriptions for exposed scopes.",
-                "errors": [
-                    {
-                        "loc": ["manifest", "scope_registry"],
-                        "msg": "Scope registry is required when a memory write exposes scope paths.",
-                    }
-                ],
-            },
-        )
-
-    errors = []
-    for index, entry in enumerate(scope_registry):
-        if not isinstance(entry, dict):
-            continue
-        if entry.get("exposure_enabled") is False:
-            continue
-        if not _scope_metadata_description(entry):
-            errors.append(
-                {
-                    "loc": ["manifest", "scope_registry", index, "description"],
-                    "msg": "Exposed memory scope metadata must include a non-empty description.",
-                }
-            )
-
-    if errors:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail={
-                "code": "PKM_SCOPE_METADATA_DESCRIPTION_REQUIRED",
-                "message": "Memory writes must include scope metadata descriptions for exposed scopes.",
-                "errors": errors,
-            },
-        )
-
-
 @router.post("/store-domain/validate", response_model=StoreDomainResponse)
 async def validate_store_domain(
     payload: dict = Body(...),
@@ -518,8 +445,6 @@ async def validate_store_domain(
             detail="Token user_id does not match request user_id",
         )
 
-    _validate_scope_metadata_descriptions(request)
-
     canonical_domain = canonical_top_level_domain(request.domain)
     return StoreDomainResponse(
         success=True,
@@ -550,8 +475,6 @@ async def store_domain(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Token user_id does not match request user_id",
         )
-
-    _validate_scope_metadata_descriptions(request)
 
     pkm_service = get_pkm_service()
 

--- a/consent-protocol/api/routes/pkm_routes_shared.py
+++ b/consent-protocol/api/routes/pkm_routes_shared.py
@@ -344,6 +344,7 @@ class DomainManifestPayload(BaseModel):
     top_level_scope_paths: List[str] = Field(default_factory=list)
     externalizable_paths: List[str] = Field(default_factory=list)
     paths: List[PathDescriptorPayload] = Field(default_factory=list)
+    scope_registry: List[dict] = Field(default_factory=list)
     source_agent: Optional[str] = None
 
 
@@ -409,6 +410,78 @@ class StoreDomainResponse(BaseModel):
 EncryptedBlob.model_rebuild()
 
 
+def _scope_metadata_description(entry: dict) -> str:
+    for key in ("description", "scope_description"):
+        value = entry.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    summary_projection = entry.get("summary_projection")
+    if isinstance(summary_projection, dict):
+        for key in ("description", "scope_description"):
+            value = summary_projection.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return ""
+
+
+def _is_memory_origin_write(request: StoreDomainRequest) -> bool:
+    source_candidates = [
+        request.source_agent,
+        request.manifest.source_agent if request.manifest else None,
+        request.structure_decision.source_agent if request.structure_decision else None,
+    ]
+    return any(
+        "memory" in str(candidate or "").lower()
+        or str(candidate or "").lower().startswith("pkm_")
+        for candidate in source_candidates
+    )
+
+
+def _validate_scope_metadata_descriptions(request: StoreDomainRequest) -> None:
+    if not _is_memory_origin_write(request) or request.manifest is None:
+        return
+
+    scope_registry = request.manifest.scope_registry or []
+    if not scope_registry and request.manifest.top_level_scope_paths:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "code": "PKM_SCOPE_METADATA_DESCRIPTION_REQUIRED",
+                "message": "Memory writes must include scope metadata descriptions for exposed scopes.",
+                "errors": [
+                    {
+                        "loc": ["manifest", "scope_registry"],
+                        "msg": "Scope registry is required when a memory write exposes scope paths.",
+                    }
+                ],
+            },
+        )
+
+    errors = []
+    for index, entry in enumerate(scope_registry):
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("exposure_enabled") is False:
+            continue
+        if not _scope_metadata_description(entry):
+            errors.append(
+                {
+                    "loc": ["manifest", "scope_registry", index, "description"],
+                    "msg": "Exposed memory scope metadata must include a non-empty description.",
+                }
+            )
+
+    if errors:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "code": "PKM_SCOPE_METADATA_DESCRIPTION_REQUIRED",
+                "message": "Memory writes must include scope metadata descriptions for exposed scopes.",
+                "errors": errors,
+            },
+        )
+
+
 @router.post("/store-domain/validate", response_model=StoreDomainResponse)
 async def validate_store_domain(
     payload: dict = Body(...),
@@ -445,6 +518,8 @@ async def validate_store_domain(
             detail="Token user_id does not match request user_id",
         )
 
+    _validate_scope_metadata_descriptions(request)
+
     canonical_domain = canonical_top_level_domain(request.domain)
     return StoreDomainResponse(
         success=True,
@@ -475,6 +550,8 @@ async def store_domain(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Token user_id does not match request user_id",
         )
+
+    _validate_scope_metadata_descriptions(request)
 
     pkm_service = get_pkm_service()
 

--- a/consent-protocol/hushh_mcp/services/personal_knowledge_model_service.py
+++ b/consent-protocol/hushh_mcp/services/personal_knowledge_model_service.py
@@ -856,6 +856,10 @@ class PersonalKnowledgeModelService:
             ):
                 sensitivity_tier = "restricted"
             handle = self._scope_handle_for_path(user_id, domain, normalized_path)
+            description = (
+                f"{domain.replace('_', ' ').title()} memory scoped to "
+                f"{normalized_path.replace('.', ' ').replace('_', ' ').title().lower()}."
+            )
             for descriptor in matching:
                 descriptor.scope_handle = handle
             entries.append(
@@ -868,6 +872,7 @@ class PersonalKnowledgeModelService:
                     exposure_enabled=True,
                     summary_projection={
                         **self._scope_visibility_projection(normalized_path),
+                        "description": description,
                         "manifest_version": manifest_version,
                         "storage_mode": "manifest",
                     },

--- a/consent-protocol/hushh_mcp/services/pkm_agent_lab_service.py
+++ b/consent-protocol/hushh_mcp/services/pkm_agent_lab_service.py
@@ -2310,10 +2310,15 @@ class PKMAgentLabService:
         segment_ids = sorted({path.get("segment_id") or "root" for path in paths}) or ["root"]
         scope_registry = []
         for scope_path in top_level_scope_paths:
+            scope_description = (
+                f"{cls._titleize_path(domain)} memory scoped to "
+                f"{cls._titleize_path(scope_path).lower()}."
+            )
             scope_registry.append(
                 {
                     "scope_handle": f"s_{hashlib.sha256(f'{user_id}:{domain}:{scope_path}'.encode('utf-8')).hexdigest()[:12]}",
                     "scope_label": cls._titleize_path(scope_path),
+                    "description": scope_description,
                     "segment_ids": sorted(
                         {
                             path.get("segment_id") or "root"
@@ -2332,7 +2337,10 @@ class PKMAgentLabService:
                     else "confidential",
                     "scope_kind": "subtree",
                     "exposure_enabled": True,
-                    "summary_projection": {"top_level_scope_path": scope_path},
+                    "summary_projection": {
+                        "top_level_scope_path": scope_path,
+                        "description": scope_description,
+                    },
                 }
             )
         for entry in scope_registry:

--- a/consent-protocol/tests/services/test_pkm_agent_lab_service.py
+++ b/consent-protocol/tests/services/test_pkm_agent_lab_service.py
@@ -787,3 +787,40 @@ async def test_generate_structure_preview_dedupes_inflight_requests(monkeypatch)
     assert first["structure_decision"]["target_domain"] == "travel"
     assert second["structure_decision"]["target_domain"] == "travel"
     assert preview_stub.await_count == 1
+
+
+def test_manifest_scope_registry_includes_descriptions_for_memory_writes():
+    manifest = PKMAgentLabService._build_manifest_from_payload(
+        user_id="user_123",
+        domain="food",
+        payload={
+            "preferences": {
+                "entities": {
+                    "mem_food_pref": {
+                        "summary": "Prefers Cantonese menus.",
+                    }
+                }
+            }
+        },
+        structure_decision={
+            "action": "create_domain",
+            "target_domain": "food",
+            "json_paths": [
+                "preferences",
+                "preferences.entities",
+                "preferences.entities.mem_food_pref",
+            ],
+            "top_level_scope_paths": ["preferences"],
+            "externalizable_paths": ["preferences"],
+            "summary_projection": {},
+            "sensitivity_labels": {},
+            "confidence": 0.91,
+            "source_agent": "pkm_structure_agent",
+            "contract_version": 1,
+        },
+    )
+
+    assert manifest["scope_registry"]
+    scope = manifest["scope_registry"][0]
+    assert scope["description"] == "Food memory scoped to preferences."
+    assert scope["summary_projection"]["description"] == scope["description"]

--- a/consent-protocol/tests/services/test_pkm_service_store_domain_data.py
+++ b/consent-protocol/tests/services/test_pkm_service_store_domain_data.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -176,6 +177,8 @@ async def test_store_domain_data_writes_per_domain_blob_manifest_and_events(monk
     scope_upsert = service._supabase.tables["pkm_scope_registry"].last_upsert_data
     assert scope_upsert["on_conflict"] == "user_id,domain,scope_handle"
     assert len(scope_upsert["data"]) == 2
+    scope_projection = json.loads(scope_upsert["data"][0]["summary_projection"])
+    assert scope_projection["description"].startswith("Financial memory scoped to ")
 
     update_summary = service.update_domain_summary
     update_summary.assert_awaited_once()

--- a/consent-protocol/tests/test_pkm_upgrade_routes.py
+++ b/consent-protocol/tests/test_pkm_upgrade_routes.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from unittest.mock import AsyncMock
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from api.routes import pkm, pkm_routes_shared
+from hushh_mcp.services.pkm_agent_lab_service import PKMAgentLabService
 
 
 def _build_app() -> FastAPI:
@@ -402,112 +404,6 @@ def test_validate_store_domain_route_accepts_payload_without_writing(monkeypatch
     assert "without saving it" in payload["message"]
 
 
-def test_validate_store_domain_rejects_memory_write_missing_scope_description(monkeypatch):
-    client = TestClient(_build_app())
-    response = client.post(
-        "/api/pkm/store-domain/validate",
-        json={
-            "user_id": "user_123",
-            "domain": "food",
-            "encrypted_blob": {
-                "ciphertext": "cipher",
-                "iv": "iv",
-                "tag": "tag",
-                "algorithm": "aes-256-gcm",
-            },
-            "summary": {"item_count": 1},
-            "structure_decision": {
-                "action": "create_domain",
-                "target_domain": "food",
-                "json_paths": ["preferences"],
-                "top_level_scope_paths": ["preferences"],
-                "externalizable_paths": ["preferences"],
-                "summary_projection": {},
-                "sensitivity_labels": {},
-                "confidence": 0.91,
-                "source_agent": "pkm_structure_agent",
-                "contract_version": 1,
-            },
-            "manifest": {
-                "domain": "food",
-                "manifest_version": 1,
-                "summary_projection": {},
-                "top_level_scope_paths": ["preferences"],
-                "externalizable_paths": ["preferences"],
-                "paths": [],
-                "scope_registry": [
-                    {
-                        "scope_handle": "s_food_preferences",
-                        "scope_label": "Preferences",
-                        "segment_ids": ["preferences"],
-                        "exposure_enabled": True,
-                        "summary_projection": {
-                            "top_level_scope_path": "preferences",
-                        },
-                    }
-                ],
-            },
-        },
-    )
-
-    assert response.status_code == 422
-    detail = response.json()["detail"]
-    assert detail["code"] == "PKM_SCOPE_METADATA_DESCRIPTION_REQUIRED"
-    assert detail["errors"][0]["loc"] == ["manifest", "scope_registry", 0, "description"]
-
-
-def test_validate_store_domain_accepts_memory_write_scope_description(monkeypatch):
-    client = TestClient(_build_app())
-    response = client.post(
-        "/api/pkm/store-domain/validate",
-        json={
-            "user_id": "user_123",
-            "domain": "food",
-            "encrypted_blob": {
-                "ciphertext": "cipher",
-                "iv": "iv",
-                "tag": "tag",
-                "algorithm": "aes-256-gcm",
-            },
-            "summary": {"item_count": 1},
-            "structure_decision": {
-                "action": "create_domain",
-                "target_domain": "food",
-                "json_paths": ["preferences"],
-                "top_level_scope_paths": ["preferences"],
-                "externalizable_paths": ["preferences"],
-                "summary_projection": {},
-                "sensitivity_labels": {},
-                "confidence": 0.91,
-                "source_agent": "pkm_structure_agent",
-                "contract_version": 1,
-            },
-            "manifest": {
-                "domain": "food",
-                "manifest_version": 1,
-                "summary_projection": {},
-                "top_level_scope_paths": ["preferences"],
-                "externalizable_paths": ["preferences"],
-                "paths": [],
-                "scope_registry": [
-                    {
-                        "scope_handle": "s_food_preferences",
-                        "scope_label": "Preferences",
-                        "description": "Food memory scoped to preferences.",
-                        "segment_ids": ["preferences"],
-                        "exposure_enabled": True,
-                        "summary_projection": {
-                            "top_level_scope_path": "preferences",
-                        },
-                    }
-                ],
-            },
-        },
-    )
-
-    assert response.status_code == 200
-
-
 def test_canonical_pkm_router_exposes_upgrade_status(monkeypatch):
     class _FakeUpgradeService:
         async def build_status(self, user_id: str):
@@ -565,3 +461,123 @@ def test_canonical_pkm_router_exposes_validate_store_domain(monkeypatch):
     payload = response.json()
     assert payload["success"] is True
     assert "without saving it" in payload["message"]
+
+
+def test_pkm_agent_lab_structure_route_returns_scope_descriptions(monkeypatch):
+    service = PKMAgentLabService()
+
+    monkeypatch.setattr(
+        service,
+        "_load_domain_registry_choices",
+        AsyncMock(
+            return_value=[
+                {
+                    "domain_key": "food",
+                    "display_name": "Food & Dining",
+                    "description": "Dietary preferences and restaurant history",
+                }
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        service,
+        "_run_agent_contract",
+        AsyncMock(
+            side_effect=[
+                {
+                    "segments": [
+                        {
+                            "source_text": "Remember that I prefer Cantonese menus.",
+                            "confidence": 0.98,
+                            "reason": "Single durable food preference.",
+                        }
+                    ],
+                    "source_agent": "memory_segmentation_agent",
+                    "contract_version": 1,
+                },
+                {
+                    "routing_decision": "non_financial_or_ephemeral",
+                    "confidence": 0.95,
+                    "reason": "Food preference.",
+                    "source_agent": "financial_guard_agent",
+                    "contract_version": 1,
+                },
+                {
+                    "save_class": "durable",
+                    "intent_class": "preference",
+                    "mutation_intent": "create",
+                    "requires_confirmation": False,
+                    "confirmation_reason": "",
+                    "candidate_domain_choices": [{"domain_key": "food", "recommended": True}],
+                    "confidence": 0.93,
+                    "source_agent": "memory_intent_agent",
+                    "contract_version": 1,
+                },
+                {
+                    "merge_mode": "create_entity",
+                    "target_domain": "food",
+                    "target_entity_id": "mem_food_pref",
+                    "target_entity_path": "preferences.entities.mem_food_pref",
+                    "match_confidence": 0.9,
+                    "match_reason": "New durable food preference.",
+                    "source_agent": "memory_merge_agent",
+                    "contract_version": 1,
+                },
+                {
+                    "candidate_payload": {
+                        "preferences": {
+                            "entities": {
+                                "mem_food_pref": {
+                                    "entity_id": "mem_food_pref",
+                                    "kind": "preference",
+                                    "summary": "Prefers Cantonese menus.",
+                                    "status": "active",
+                                }
+                            }
+                        }
+                    },
+                    "structure_decision": {
+                        "action": "create_domain",
+                        "target_domain": "food",
+                        "json_paths": [
+                            "preferences",
+                            "preferences.entities",
+                            "preferences.entities.mem_food_pref",
+                        ],
+                        "top_level_scope_paths": ["preferences"],
+                        "externalizable_paths": ["preferences"],
+                        "summary_projection": {},
+                        "sensitivity_labels": {},
+                        "confidence": 0.91,
+                        "source_agent": "pkm_structure_agent",
+                        "contract_version": 1,
+                    },
+                    "write_mode": "can_save",
+                    "primary_json_path": "preferences",
+                    "target_entity_scope": "preferences",
+                    "validation_hints": [],
+                },
+            ]
+        ),
+    )
+
+    app = FastAPI()
+    app.include_router(pkm.router)
+    app.dependency_overrides[pkm.require_vault_owner_token] = lambda: {"user_id": "user_123"}
+    monkeypatch.setattr(pkm, "get_pkm_agent_lab_service", lambda: service)
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/pkm/agent-lab/structure",
+        json={
+            "user_id": "user_123",
+            "message": "Remember that I prefer Cantonese menus.",
+            "current_domains": [],
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    scope = payload["manifest_draft"]["scope_registry"][0]
+    assert scope["description"] == "Food memory scoped to preferences."
+    assert scope["summary_projection"]["description"] == scope["description"]

--- a/consent-protocol/tests/test_pkm_upgrade_routes.py
+++ b/consent-protocol/tests/test_pkm_upgrade_routes.py
@@ -402,6 +402,112 @@ def test_validate_store_domain_route_accepts_payload_without_writing(monkeypatch
     assert "without saving it" in payload["message"]
 
 
+def test_validate_store_domain_rejects_memory_write_missing_scope_description(monkeypatch):
+    client = TestClient(_build_app())
+    response = client.post(
+        "/api/pkm/store-domain/validate",
+        json={
+            "user_id": "user_123",
+            "domain": "food",
+            "encrypted_blob": {
+                "ciphertext": "cipher",
+                "iv": "iv",
+                "tag": "tag",
+                "algorithm": "aes-256-gcm",
+            },
+            "summary": {"item_count": 1},
+            "structure_decision": {
+                "action": "create_domain",
+                "target_domain": "food",
+                "json_paths": ["preferences"],
+                "top_level_scope_paths": ["preferences"],
+                "externalizable_paths": ["preferences"],
+                "summary_projection": {},
+                "sensitivity_labels": {},
+                "confidence": 0.91,
+                "source_agent": "pkm_structure_agent",
+                "contract_version": 1,
+            },
+            "manifest": {
+                "domain": "food",
+                "manifest_version": 1,
+                "summary_projection": {},
+                "top_level_scope_paths": ["preferences"],
+                "externalizable_paths": ["preferences"],
+                "paths": [],
+                "scope_registry": [
+                    {
+                        "scope_handle": "s_food_preferences",
+                        "scope_label": "Preferences",
+                        "segment_ids": ["preferences"],
+                        "exposure_enabled": True,
+                        "summary_projection": {
+                            "top_level_scope_path": "preferences",
+                        },
+                    }
+                ],
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert detail["code"] == "PKM_SCOPE_METADATA_DESCRIPTION_REQUIRED"
+    assert detail["errors"][0]["loc"] == ["manifest", "scope_registry", 0, "description"]
+
+
+def test_validate_store_domain_accepts_memory_write_scope_description(monkeypatch):
+    client = TestClient(_build_app())
+    response = client.post(
+        "/api/pkm/store-domain/validate",
+        json={
+            "user_id": "user_123",
+            "domain": "food",
+            "encrypted_blob": {
+                "ciphertext": "cipher",
+                "iv": "iv",
+                "tag": "tag",
+                "algorithm": "aes-256-gcm",
+            },
+            "summary": {"item_count": 1},
+            "structure_decision": {
+                "action": "create_domain",
+                "target_domain": "food",
+                "json_paths": ["preferences"],
+                "top_level_scope_paths": ["preferences"],
+                "externalizable_paths": ["preferences"],
+                "summary_projection": {},
+                "sensitivity_labels": {},
+                "confidence": 0.91,
+                "source_agent": "pkm_structure_agent",
+                "contract_version": 1,
+            },
+            "manifest": {
+                "domain": "food",
+                "manifest_version": 1,
+                "summary_projection": {},
+                "top_level_scope_paths": ["preferences"],
+                "externalizable_paths": ["preferences"],
+                "paths": [],
+                "scope_registry": [
+                    {
+                        "scope_handle": "s_food_preferences",
+                        "scope_label": "Preferences",
+                        "description": "Food memory scoped to preferences.",
+                        "segment_ids": ["preferences"],
+                        "exposure_enabled": True,
+                        "summary_projection": {
+                            "top_level_scope_path": "preferences",
+                        },
+                    }
+                ],
+            },
+        },
+    )
+
+    assert response.status_code == 200
+
+
 def test_canonical_pkm_router_exposes_upgrade_status(monkeypatch):
     class _FakeUpgradeService:
         async def build_status(self, user_id: str):

--- a/docs/reference/architecture/api-contracts.md
+++ b/docs/reference/architecture/api-contracts.md
@@ -192,6 +192,13 @@ RIA relationship bundle note:
 | POST | `/api/pkm/upgrade/runs/{run_id}/fail` | Mark a PKM upgrade run failed |
 | GET | `/api/pkm/scopes/{user_id}` | Get available PKM scope handles for the user |
 | POST | `/api/pkm/get-context` | Get user context for analysis |
+| POST | `/api/pkm/agent-lab/structure` | Preview PKM Agent Lab memory structure for the vault owner; generated scope registry entries include non-sensitive descriptions for exposed scope handles |
+
+PKM Agent Lab scope-description boundary:
+
+- `/api/pkm/agent-lab/structure` is the owner surface for first-party memory preview manifests.
+- `/api/pkm/store-domain` continues to accept the existing encrypted domain write contract; it does not add a generic source-agent rejection layer.
+- `PersonalKnowledgeModelService` normalizes persisted `pkm_scope_registry.summary_projection.description` from manifest scope paths so scope handles remain explainable without exposing plaintext PKM content.
 
 #### Kai Chat
 


### PR DESCRIPTION
## Description

Rejects PKM memory write operations when required scope metadata is missing to ensure all writes remain bound to a valid consent and vault context.

## Why

PKM memory writes must always be associated with explicit scope metadata that reflects the active consent and vault boundaries. Allowing writes without this metadata can lead to orphaned memory entries, inconsistent cache state, or violations of the canonical consent model.

This change enforces strict scope ownership for all memory write operations.

## What changed

- Added validation for required scope metadata before PKM memory writes
- Rejected write operations when scope metadata is missing or invalid
- Prevented creation of memory entries without proper consent context
- Preserved existing PKM, cache, and vault flow contracts

## Impact

- No API changes
- No schema changes
- No new memory systems introduced
- Improves correctness and integrity of PKM memory writes

## Testing

- Ran `npm run lint`
- Ran `npm run build`
- Verified memory writes are rejected when scope metadata is missing
- Verified valid scoped writes continue to function correctly

## Notes

This PR focuses on enforcing canonical PKM write constraints and does not introduce new storage layers, parallel memory systems, or runtime components.