### PR TITLE
fix(kai): replace unbounded _PROVIDER_COOLDOWNS with thread-safe bounded _ProviderCooldownStore

### DIFF
--- a/consent-protocol/hushh_mcp/operons/kai/fetchers.py
+++ b/consent-protocol/hushh_mcp/operons/kai/fetchers.py
@@ -30,7 +30,63 @@ from hushh_mcp.constants import ConsentScope
 from hushh_mcp.types import UserID
 
 logger = logging.getLogger(__name__)
-_PROVIDER_COOLDOWNS: dict[str, float] = {}
+_PROVIDER_COOLDOWNS_MAX: int = max(
+    1,
+    int(os.getenv("KAI_PROVIDER_COOLDOWNS_MAX", "1000") or "1000"),
+)
+
+
+class _ProviderCooldownStore:
+    """Thread-safe, size-bounded store for per-provider cooldown expiry times.
+
+    Keys follow the pattern ``provider:symbol`` (e.g. ``yfinance:AAPL``) or
+    ``provider:global`` for global per-provider locks.  The number of unique
+    yfinance-keyed symbols is unbounded without a cap.
+
+    Eviction strategy (triggered only when the store is full and a *new* key
+    arrives):
+    1. Remove all entries whose cooldown has already expired.
+    2. If still at capacity, evict the oldest-inserted entry (FIFO).
+    """
+
+    def __init__(self, max_entries: int = _PROVIDER_COOLDOWNS_MAX) -> None:
+        self._max = max_entries
+        self._store: dict[str, float] = {}
+        self._lock = threading.Lock()
+
+    def in_cooldown(self, key: str) -> bool:
+        now = time.time()
+        with self._lock:
+            until = self._store.get(key)
+            if until is None:
+                return False
+            if until <= now:
+                del self._store[key]
+                return False
+            return True
+
+    def set(self, key: str, until: float) -> None:
+        with self._lock:
+            if key not in self._store and len(self._store) >= self._max:
+                now = time.time()
+                stale = [k for k, exp in self._store.items() if exp <= now]
+                for k in stale:
+                    del self._store[k]
+                while len(self._store) >= self._max:
+                    oldest = next(iter(self._store))
+                    del self._store[oldest]
+            self._store[key] = until
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._store)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._store.clear()
+
+
+_PROVIDER_COOLDOWNS = _ProviderCooldownStore()
 _PROVIDER_COOLDOWN_BY_STATUS: dict[int, int] = {
     401: 15 * 60,
     402: 15 * 60,
@@ -60,14 +116,7 @@ _YAHOO_FAST_TIMEOUT_COOLDOWN_SECONDS = max(
 
 
 def _provider_in_cooldown(key: str) -> bool:
-    now = time.time()
-    until = _PROVIDER_COOLDOWNS.get(key)
-    if until is None:
-        return False
-    if until <= now:
-        _PROVIDER_COOLDOWNS.pop(key, None)
-        return False
-    return True
+    return _PROVIDER_COOLDOWNS.in_cooldown(key)
 
 
 def _mark_provider_cooldown(key: str, status_code: int | None) -> None:
@@ -76,13 +125,13 @@ def _mark_provider_cooldown(key: str, status_code: int | None) -> None:
     duration = _PROVIDER_COOLDOWN_BY_STATUS.get(int(status_code))
     if not duration:
         return
-    _PROVIDER_COOLDOWNS[key] = time.time() + duration
+    _PROVIDER_COOLDOWNS.set(key, time.time() + duration)
 
 
 def _mark_provider_cooldown_for_duration(key: str, duration_seconds: int) -> None:
     if duration_seconds <= 0:
         return
-    _PROVIDER_COOLDOWNS[key] = time.time() + int(duration_seconds)
+    _PROVIDER_COOLDOWNS.set(key, time.time() + int(duration_seconds))
 
 
 def _provider_cooldown_key(provider_name: str, symbol: str) -> str | None:

--- a/consent-protocol/tests/operons/kai/test_provider_cooldowns_bounded.py
+++ b/consent-protocol/tests/operons/kai/test_provider_cooldowns_bounded.py
@@ -1,0 +1,288 @@
+"""Hermetic unit tests for _ProviderCooldownStore in fetchers.py.
+
+No DB, no network, no LLM.
+
+Covered:
+    construction (default and custom capacity)
+    in_cooldown — active, expired, missing
+    set — basic, overwrites, TTL in future
+    size cap — stale-first eviction, then FIFO oldest
+    __len__ and clear
+    concurrency — concurrent writers, concurrent reader+writer
+    integration — _provider_in_cooldown, _mark_provider_cooldown,
+                  _mark_provider_cooldown_for_duration
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from hushh_mcp.operons.kai.fetchers import (
+    _PROVIDER_COOLDOWNS,
+    _PROVIDER_COOLDOWNS_MAX,
+    _mark_provider_cooldown,
+    _mark_provider_cooldown_for_duration,
+    _provider_in_cooldown,
+    _ProviderCooldownStore,
+)
+
+# ---------------------------------------------------------------------------
+# fixture: reset module-level store between tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch):
+    _PROVIDER_COOLDOWNS.clear()
+    original_max = _PROVIDER_COOLDOWNS._max
+    yield
+    _PROVIDER_COOLDOWNS.clear()
+    _PROVIDER_COOLDOWNS._max = original_max
+
+
+# ===========================================================================
+# Construction
+# ===========================================================================
+
+
+class TestConstruction:
+    def test_default_capacity_matches_env_var(self):
+        store = _ProviderCooldownStore()
+        assert store._max == _PROVIDER_COOLDOWNS_MAX
+
+    def test_custom_capacity(self):
+        store = _ProviderCooldownStore(max_entries=5)
+        assert store._max == 5
+
+    def test_initial_length_is_zero(self):
+        assert len(_ProviderCooldownStore()) == 0
+
+
+# ===========================================================================
+# in_cooldown
+# ===========================================================================
+
+
+class TestInCooldown:
+    def test_missing_key_returns_false(self):
+        store = _ProviderCooldownStore()
+        assert store.in_cooldown("finnhub:global") is False
+
+    def test_active_cooldown_returns_true(self):
+        store = _ProviderCooldownStore()
+        store.set("finnhub:global", time.time() + 300)
+        assert store.in_cooldown("finnhub:global") is True
+
+    def test_expired_cooldown_returns_false(self):
+        store = _ProviderCooldownStore()
+        store._store["k"] = time.time() - 1
+        assert store.in_cooldown("k") is False
+
+    def test_expired_entry_removed_from_store(self):
+        store = _ProviderCooldownStore()
+        store._store["k"] = time.time() - 1
+        store.in_cooldown("k")
+        assert "k" not in store._store
+
+    def test_exactly_at_expiry_is_not_in_cooldown(self):
+        store = _ProviderCooldownStore()
+        store._store["k"] = time.time() - 0.001
+        assert store.in_cooldown("k") is False
+
+
+# ===========================================================================
+# set
+# ===========================================================================
+
+
+class TestSet:
+    def test_set_adds_entry(self):
+        store = _ProviderCooldownStore()
+        store.set("yfinance:AAPL", time.time() + 60)
+        assert len(store) == 1
+
+    def test_set_overwrites_existing_key(self):
+        store = _ProviderCooldownStore()
+        store.set("k", time.time() + 60)
+        later = time.time() + 120
+        store.set("k", later)
+        assert store._store["k"] == later
+        assert len(store) == 1
+
+    def test_set_stores_future_expiry(self):
+        store = _ProviderCooldownStore()
+        before = time.time()
+        store.set("k", before + 300)
+        assert store._store["k"] > before + 299
+
+
+# ===========================================================================
+# size cap — eviction
+# ===========================================================================
+
+
+class TestSizeCap:
+    def test_stale_entries_evicted_first(self):
+        store = _ProviderCooldownStore(max_entries=3)
+        for i in range(3):
+            store._store[f"stale_{i}"] = time.time() - 1
+        store.set("fresh", time.time() + 60)
+        assert store.in_cooldown("fresh") is True
+        assert len(store) == 1
+
+    def test_oldest_evicted_when_no_stale(self):
+        store = _ProviderCooldownStore(max_entries=3)
+        store.set("first", time.time() + 60)
+        store.set("second", time.time() + 60)
+        store.set("third", time.time() + 60)
+        store.set("fourth", time.time() + 60)
+        assert len(store) == 3
+        assert store.in_cooldown("first") is False
+        assert store.in_cooldown("fourth") is True
+
+    def test_overwriting_existing_key_does_not_evict(self):
+        store = _ProviderCooldownStore(max_entries=2)
+        store.set("a", time.time() + 60)
+        store.set("b", time.time() + 60)
+        store.set("a", time.time() + 120)
+        assert len(store) == 2
+        assert store.in_cooldown("b") is True
+
+    def test_capacity_one_always_holds_latest(self):
+        store = _ProviderCooldownStore(max_entries=1)
+        for i in range(5):
+            store.set(f"k{i}", time.time() + 60)
+        assert len(store) == 1
+        assert store.in_cooldown("k4") is True
+
+
+# ===========================================================================
+# __len__ and clear
+# ===========================================================================
+
+
+class TestLenAndClear:
+    def test_len_reflects_count(self):
+        store = _ProviderCooldownStore()
+        assert len(store) == 0
+        store.set("a", time.time() + 60)
+        assert len(store) == 1
+        store.set("b", time.time() + 60)
+        assert len(store) == 2
+
+    def test_clear_empties_store(self):
+        store = _ProviderCooldownStore()
+        for i in range(5):
+            store.set(f"k{i}", time.time() + 60)
+        store.clear()
+        assert len(store) == 0
+
+    def test_in_cooldown_after_clear_returns_false(self):
+        store = _ProviderCooldownStore()
+        store.set("k", time.time() + 60)
+        store.clear()
+        assert store.in_cooldown("k") is False
+
+
+# ===========================================================================
+# Concurrency
+# ===========================================================================
+
+
+class TestConcurrency:
+    def test_concurrent_writers_no_error(self):
+        store = _ProviderCooldownStore(max_entries=200)
+        errors: list[Exception] = []
+
+        def _writer(prefix: str) -> None:
+            try:
+                for i in range(60):
+                    store.set(f"{prefix}:{i}", time.time() + 60)
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=_writer, args=(f"t{t}",)) for t in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        assert len(store) <= 200
+
+    def test_concurrent_reads_and_writes(self):
+        store = _ProviderCooldownStore(max_entries=100)
+        store.set("shared", time.time() + 60)
+        errors: list[Exception] = []
+
+        def _reader() -> None:
+            try:
+                for _ in range(100):
+                    store.in_cooldown("shared")
+            except Exception as exc:
+                errors.append(exc)
+
+        def _writer() -> None:
+            try:
+                for i in range(100):
+                    store.set("shared", time.time() + 60 + i)
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=_reader) for _ in range(3)]
+        threads += [threading.Thread(target=_writer) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+
+
+# ===========================================================================
+# Integration — module-level helper functions
+# ===========================================================================
+
+
+class TestIntegration:
+    def test_provider_in_cooldown_false_for_unknown_key(self):
+        assert _provider_in_cooldown("yfinance:TSLA") is False
+
+    def test_mark_provider_cooldown_sets_active_cooldown(self):
+        _mark_provider_cooldown("finnhub:global", 429)
+        assert _provider_in_cooldown("finnhub:global") is True
+
+    def test_mark_provider_cooldown_unknown_status_no_effect(self):
+        _mark_provider_cooldown("pmp:global", 200)
+        assert _provider_in_cooldown("pmp:global") is False
+
+    def test_mark_provider_cooldown_none_status_no_effect(self):
+        _mark_provider_cooldown("finnhub:global", None)
+        assert _provider_in_cooldown("finnhub:global") is False
+
+    def test_mark_provider_cooldown_for_duration_sets_cooldown(self):
+        _mark_provider_cooldown_for_duration("yfinance:AAPL", 300)
+        assert _provider_in_cooldown("yfinance:AAPL") is True
+
+    def test_mark_provider_cooldown_for_duration_zero_no_effect(self):
+        _mark_provider_cooldown_for_duration("yfinance:AAPL", 0)
+        assert _provider_in_cooldown("yfinance:AAPL") is False
+
+    def test_mark_provider_cooldown_for_duration_negative_no_effect(self):
+        _mark_provider_cooldown_for_duration("yfinance:AAPL", -5)
+        assert _provider_in_cooldown("yfinance:AAPL") is False
+
+    def test_module_store_bounded_at_configured_max(self):
+        _PROVIDER_COOLDOWNS._max = 5
+        for i in range(10):
+            _mark_provider_cooldown_for_duration(f"yfinance:SYM{i}", 60)
+        assert len(_PROVIDER_COOLDOWNS) <= 5
+
+    def test_known_status_codes_all_set_cooldown(self):
+        for code in (401, 402, 403, 404, 429):
+            _PROVIDER_COOLDOWNS.clear()
+            _mark_provider_cooldown(f"provider:{code}", code)
+            assert _provider_in_cooldown(f"provider:{code}") is True


### PR DESCRIPTION
## Summary

- `_PROVIDER_COOLDOWNS` in `hushh_mcp/operons/kai/fetchers.py` was a bare `dict[str, float]` with no size cap and no lock — the `yfinance:{symbol}` key pattern meant one stale entry per queried ticker with no eviction, and concurrent reads/writes were unprotected
- Introduces `_ProviderCooldownStore`: a `threading.Lock`-protected, size-bounded store
- Capacity defaults to 1 000 entries; configurable via `KAI_PROVIDER_COOLDOWNS_MAX` env var
- Eviction on overflow: expired cooldown entries first, then oldest-inserted FIFO
- `_provider_in_cooldown`, `_mark_provider_cooldown`, and `_mark_provider_cooldown_for_duration` delegate to the new class; all call sites are unchanged

## Test plan

- [x] `python3 -m pytest tests/operons/kai/test_provider_cooldowns_bounded.py -x -q` — 29 passed, 0 failed
- [x] `ruff check --fix` and `ruff format` — clean
- Tests cover: construction, in_cooldown (active/expired/missing), set, stale-first + FIFO eviction, thread safety (2 concurrency scenarios), integration with all three helper functions including all 5 HTTP status codes

Signed-off-by: Anshul Jain <anshul23102@iiitd.ac.in>