### PR TITLE
docs: add PR train review SOP

### DIFF
--- a/.codex/skills/pr-governance-review/SKILL.md
+++ b/.codex/skills/pr-governance-review/SKILL.md
@@ -64,6 +64,7 @@ Load these only when the decision needs them:
 2. `.codex/skills/pr-governance-review/references/operator-question-fixtures.json`
 3. `.codex/skills/pr-governance-review/references/blocker-gates.md`
 4. `.codex/skills/pr-governance-review/references/comment-and-report-contract.md`
+5. `.codex/skills/pr-governance-review/references/pr-train-review-sop.md`
 
 ## Workflow
 
@@ -99,9 +100,20 @@ Load these only when the decision needs them:
    - founder wiki pages define north-star and future-state alignment
    - conflicts are `current_state_vs_north_star_drift`
    - private wiki evidence stays local-only and must not be cited in public GitHub comments
-13. For high-risk or mixed-domain batches, run the delegation router and record whether evidence lanes were used:
+13. For high-volume PR train work, spawn/read from the required read-only
+    subagent taskforce before producing the operator dossier. High-volume means
+    more than `20` PRs scanned or discussed, more than `5` PRs acted on in one
+    session, any mixed frontend/backend/security/devex/observability train, any
+    repass of previous `changes_requested`/close/harvest decisions, or any
+    request to maximize throughput, scan the backlog, or run async trains.
+    Use the delegation router to choose lanes and record whether evidence lanes
+    were used:
    `python3 .codex/skills/agent-orchestration-governance/scripts/delegation_router.py --workflow pr-governance-review --phase start --prompt "<request>" --paths "<paths>" --text`
-14. Keep final authority local to the parent/governor. Do not delegate branch switching, approval, merge, deploy, credential handling, or final decision.
+14. If subagents are unavailable, record `Subagent taskforce: unavailable` and
+    manually cover the same evidence lanes. If they are available, skipping
+    them for high-volume train work is a process violation unless a concrete
+    runtime blocker is recorded.
+15. Keep final authority local to the parent/governor. Do not delegate branch switching, approval, merge, deploy, credential handling, or final decision.
 
 ### Decision Order
 
@@ -208,9 +220,9 @@ For backend or trust-runtime PRs:
 ### Changes-Requested Repass Taskforce
 
 For a high-volume repass of previous `changes_requested` decisions, use
-read-only evidence lanes when delegation is available and the batch has
-independent surfaces. The parent session keeps final authority and performs any
-GitHub writes.
+read-only evidence lanes when delegation is available. This is mandatory for
+mass repasses, async PR trains, and backlog-scale train construction; the
+parent session keeps final authority and performs any GitHub writes.
 
 Default lanes:
 
@@ -221,6 +233,11 @@ Default lanes:
 3. `root/tooling governance`: new roots, CI/workflow changes, contributor
    setup paths, repo-governance scripts, checked-in reports, and devex attach
    points.
+4. `observability/security`: diagnostic logging, analytics payload boundaries,
+   secret-scan risk, data minimization, and public-comment safety.
+5. `decision-wave communications`: existing maintainer records, edit-vs-new
+   comment posture, closure/request-changes headings, and public hyperlink
+   completeness.
 
 Each lane must return direct PR links, current head SHA, changed files,
 reachability evidence, canonical attach point if any, accepted value,
@@ -233,20 +250,32 @@ approve, merge, or post/edit comments.
 
 Use trains to maximize throughput without lowering the merge bar:
 
-1. Default live-report scan mode is `hybrid`: cheap all-open inventory, then deep review of the latest `100` PRs plus up to `40` older high-signal candidates. Use `active` for fastest latest-window reviews and `full` only for audits.
-2. Use four work lanes at the same time:
+For developer-facing train review, follow the standard operating procedure in
+`references/pr-train-review-sop.md`. That SOP is the reusable review loop for
+mass scanning, train graph construction, async queue/patch/decision lanes,
+GitHub write posture, and post-state-change report refreshes.
+
+1. For high-volume train work, start the required read-only subagent taskforce
+   before selecting trains. The default taskforce covers frontend/UI
+   reachability, backend/runtime trust, observability/security, devex/repo
+   operations, and decision-wave communications. Add a sixth lane only for a
+   real independent surface such as mobile/native parity or founder/north-star
+   direction. Do not create one subagent per PR.
+2. Default live-report scan mode is `hybrid`: cheap all-open inventory, then deep review of the latest `100` PRs plus up to `40` older high-signal candidates. Use `active` for fastest latest-window reviews and `full` only for audits.
+3. Use four work lanes at the same time:
    - `Queue Cohort`: up to `4` independent `merge_now` PRs with exact head SHA match, green `CI Status Gate`, `MERGEABLE` state, no hard collision edges, and no local dirty-file overlap.
    - `Sequential Collision Train`: PRs with hard edges from exact files, lockfiles, schema/migrations, generated contracts, sensitive runtime families, or local dirty-file overlap. Only one PR from the group moves at a time.
    - `Parallel Patch Trains`: maintainer patches with disjoint write sets and disjoint runtime families. Default maximum is `3`.
    - `Decision Waves`: changes-requested or closure records for clearly blocked PRs. These can run while queue validation is pending.
-3. Do not wait for one independent PR to complete before preparing or queueing unrelated PRs. Wait only when a PR depends on the base/result of another PR or shares a hard edge.
-4. Treat CI/Queue Validation/Main Post-Merge Smoke as an asynchronous monitor lane. Do not idle the whole operator loop while checks run.
-5. Do not start merging a dependent train until the previous train has passed Main Post-Merge Smoke and the live report has been refreshed.
-6. Treat "automatic next train" as automatic next-train discovery and review preparation, not blind approval or merge.
-7. A PR can enter a merge train only after current head, current required gate, mergeability, lane, overlap, collision group, and smallest proof are rechecked.
-8. Reports must state scan scope and completeness. If inventory, GitHub, or per-PR scanning fails, name the exact reviewed subset and failed PRs.
-9. Large-scale rhythm:
+4. Do not wait for one independent PR to complete before preparing or queueing unrelated PRs. Wait only when a PR depends on the base/result of another PR or shares a hard edge.
+5. Treat CI/Queue Validation/Main Post-Merge Smoke as an asynchronous monitor lane. Do not idle the whole operator loop while checks run.
+6. Do not start merging a dependent train until the previous train has passed Main Post-Merge Smoke and the live report has been refreshed.
+7. Treat "automatic next train" as automatic next-train discovery and review preparation, not blind approval or merge.
+8. A PR can enter a merge train only after current head, current required gate, mergeability, lane, overlap, collision group, and smallest proof are rechecked.
+9. Reports must state scan scope and completeness. If inventory, GitHub, or per-PR scanning fails, name the exact reviewed subset and failed PRs.
+10. Large-scale rhythm:
    - mass classify open PRs
+   - start specialist read-only evidence lanes for each independent evidence family
    - close/request changes for clear drifts in waves
    - queue independent proven cohorts
    - sequence only hard collision groups

--- a/.codex/skills/pr-governance-review/references/operator-batch-output-contract.md
+++ b/.codex/skills/pr-governance-review/references/operator-batch-output-contract.md
@@ -1,6 +1,9 @@
 # Operator Batch Output Contract
 
 Use this when answering "next batch", "plan this batch", or any high-volume PR wave question.
+Use `pr-train-review-sop.md` as the standard operating procedure before
+producing this dossier. The SOP defines how to scan, graph, classify, execute,
+monitor, and refresh PR trains; this contract defines how to present the result.
 
 ## Required Chat Shape
 
@@ -12,8 +15,12 @@ sequence in the sections below.
 
 1. `Batch`: one sentence naming the product/runtime purpose.
 2. `Research Basis`: concise current truth, recommended path, and risk if accepted blindly.
-3. `Input`: every PR with a direct Markdown link and current lane.
-4. `Train Simulation`: execution-grade simulation based on the current PR heads:
+3. `Delegation Evidence`: router decision, subagent/taskforce lanes used,
+   direct lane handoff summaries, skipped/unavailable rationale, and explicit
+   parent-only authority for branch switching, commits, GitHub writes,
+   approvals, merges, deploys, and final decisions.
+4. `Input`: every PR with a direct Markdown link and current lane.
+5. `Train Simulation`: execution-grade simulation based on the current PR heads:
    - branch evidence: current head SHA, mergeability, CI gate, changed files, exact overlaps, and local dirty-worktree overlap
    - delta summary: files added, edited, deleted, generated, moved, dependencies changed, and routes/contracts touched
    - behavior claim: what the PR claims and whether that behavior is reachable in the current app/backend/package
@@ -22,7 +29,7 @@ sequence in the sections below.
    - action outcome: exact operation per PR if approved
    - comment simulation: expected GitHub comment/edit posture and heading
    - verification timeline: local checks, Playwright for UI-visible changes, GitHub gates, smoke, reports
-5. `Expected Actions`: table or bullets mapping each PR to one of:
+6. `Expected Actions`: table or bullets mapping each PR to one of:
    - `review_only`
    - `hold`
    - `request_changes`
@@ -31,14 +38,14 @@ sequence in the sections below.
    - `maintainer_patch_then_merge`
    - `merge_now`
    - `post_merge_monitor`
-6. `Comment Plan`: table or bullets mapping each PR to one of:
+7. `Comment Plan`: table or bullets mapping each PR to one of:
    - `none_before_merge_then_post_merge_closeout`
    - `edit_existing_maintainer_comment`
    - `new_changes_requested_comment`
    - `new_closed_superseded_comment`
    - `no_comment_review_only`
    Include the intended headline, for example `## Merged: Consent Center State UX`.
-7. `Per-PR Assessment`: one compact but complete block per PR:
+8. `Per-PR Assessment`: one compact but complete block per PR:
    - direct link
    - lane
    - lean/core risk
@@ -49,12 +56,12 @@ sequence in the sections below.
    - planned action: merge, patch/rebase, harvest/close, request changes, or hold
    - comment action: expected public comment/edit behavior
    - `Smallest proof`: smallest authoritative check before that action
-8. `Output`: intended end state if the batch is legitimate.
-9. `Execution`: exact order, split by merge train, patch train, closure/request-changes wave, and hold/deep-review items.
-10. `Decision Questions`: only unresolved user-owned choices, each with current truth, recommended path, risk if accepted blindly, and recommended option first.
-11. `Stop Conditions`: what pauses, splits, or blocks the batch.
-12. `Verification`: smallest authoritative local and GitHub checks.
-13. `After-Merge Kickoff`: how the next independent train will be discovered after report refresh.
+9. `Output`: intended end state if the batch is legitimate.
+10. `Execution`: exact order, split by merge train, patch train, closure/request-changes wave, and hold/deep-review items.
+11. `Decision Questions`: only unresolved user-owned choices, each with current truth, recommended path, risk if accepted blindly, and recommended option first.
+12. `Stop Conditions`: what pauses, splits, or blocks the batch.
+13. `Verification`: smallest authoritative local and GitHub checks.
+14. `After-Merge Kickoff`: how the next independent train will be discovered after report refresh.
 
 Hyperlink rule: any chat answer, execution update, or final handoff generated
 from this contract must hyperlink every PR it mentions. Counts-only summaries
@@ -67,12 +74,18 @@ deterministic sections, even if some are empty:
 
 1. `Scan Scope`: scan mode, active limit, candidate limit, all-open inventory
    count when known, reviewed PRs, failed PRs, and completeness.
-2. `Queue Cohort`: independent `merge_now` PRs that can be queued together,
+2. `Subagent Taskforce`: evidence lanes started before train selection,
+   including lane owner, inspected surfaces, PR links, current head SHA
+   freshness, hard collisions, canonical attach points, unresolved risks, and
+   whether subagents were used, unavailable, or blocked. For high-volume train
+   work, this section is mandatory and cannot be replaced by a parent-only
+   summary unless the runtime cannot spawn subagents.
+3. `Queue Cohort`: independent `merge_now` PRs that can be queued together,
    capped at the configured cohort size.
-3. `Collision Groups`: hard-edge groups and the required sequence.
-4. `Parallel Patch Trains`: disjoint maintainer patch trains with attachment
+4. `Collision Groups`: hard-edge groups and the required sequence.
+5. `Parallel Patch Trains`: disjoint maintainer patch trains with attachment
    point, patch files, dropped/deferred pieces, and proof.
-5. `Decision Waves`: PRs ready for changes-requested or closure records while
+6. `Decision Waves`: PRs ready for changes-requested or closure records while
    queue validation runs.
 
 Decision waves must list the exact linked PRs in the wave and the exact public
@@ -111,6 +124,12 @@ even when the report already exists on disk:
    `collision_reasons`, `can_queue_with`, `must_wait_for`,
    `queue_cohort_id`, `parallel_patch_train_id`, patch attachment fields, and
    whether a north-star probe is required.
+8. Subagent taskforce: for high-volume train work, every dossier must state the
+   read-only evidence lanes used before the recommendation. The default lanes
+   are frontend/UI reachability, backend/runtime trust, observability/security,
+   devex/repo operations, and decision-wave communications. If a lane was not
+   spawned, state the concrete blocker; "not needed" is valid only for
+   single-surface or low-volume work.
 
 If the evidence is incomplete, say exactly what is incomplete and present only
 the train subset that is safe from the verified evidence. Do not imply the whole
@@ -158,11 +177,13 @@ Use this rhythm for scale:
 1. Mass classify open PRs through the live report. Default to hybrid scan:
    cheap all-open inventory plus the latest `100` deep reviews and up to `40`
    older high-signal deep reviews.
-2. Convert clear drifts into closure or changes-requested waves.
-3. Queue independent `merge_now` PRs as a cohort, capped at `4`.
-4. While PR Validation, Queue Validation, or Main Post-Merge Smoke runs, review the next independent operator batch.
-5. After smoke passes, refresh the live report and contributor-impact dashboard.
-6. Select the next independent `Recommended Operator Batches` item and produce a fresh `Per-PR Assessment`.
+2. Start read-only subagent lanes for the independent evidence families before
+   train selection. Use broad lanes, not one subagent per PR.
+3. Convert clear drifts into closure or changes-requested waves.
+4. Queue independent `merge_now` PRs as a cohort, capped at `4`.
+5. While PR Validation, Queue Validation, or Main Post-Merge Smoke runs, review the next independent operator batch.
+6. After smoke passes, refresh the live report and contributor-impact dashboard.
+7. Select the next independent `Recommended Operator Batches` item and produce a fresh `Per-PR Assessment`.
 
 Never let throughput hide dependency order. Shared files, lockfiles, shared
 runtime contracts, generated contracts, schema/migration surfaces,

--- a/.codex/skills/pr-governance-review/references/pr-train-review-sop.md
+++ b/.codex/skills/pr-governance-review/references/pr-train-review-sop.md
@@ -1,0 +1,267 @@
+# PR Train Review SOP
+
+Use this SOP whenever a developer is reviewing more than one PR, deciding the
+next merge batch, revisiting `changes_requested` PRs, or trying to increase PR
+throughput without weakening merge quality.
+
+The goal is not to merge more PRs blindly. The goal is to turn the open PR
+backlog into a deterministic graph where independent work can move in parallel
+and dependent work is sequenced only where the dependency is real.
+
+## Operator Promise
+
+Every trained reviewer should be able to:
+
+1. inventory the open PR backlog quickly
+2. identify queueable independent PRs
+3. separate hard collisions from soft theme similarity
+4. find maintainer-patch candidates with canonical attach points
+5. issue changes-requested or closure waves without blocking merges
+6. monitor queue and smoke asynchronously
+7. refresh reports after every state change
+
+## Preflight
+
+Before scanning or acting:
+
+1. Fetch current main.
+2. Confirm the local worktree is clean or document every dirty file.
+3. Confirm no local dirty file overlaps an open PR under review.
+4. Use the latest live report only if it names scan scope and freshness.
+5. If the report is stale, regenerate it before giving train advice.
+6. For high-volume train work, start the read-only subagent taskforce before
+   selecting batches. High-volume means any one of:
+   - more than `20` PRs being scanned or discussed
+   - more than `5` PRs being acted on in one operator session
+   - any mixed frontend/backend/security/devex/observability train
+   - any repass of previous `changes_requested`, close, or harvest decisions
+   - any request to maximize throughput, scan the backlog, or run async trains
+
+Commands:
+
+```bash
+git fetch origin main
+git status --short --branch
+python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --live-report --scan-mode hybrid --limit 100 --candidate-limit 40 --text --output tmp/pr-governance-live-report.md
+```
+
+## Required Subagent Taskforce
+
+Mass PR train work must use specialist read-only evidence lanes when the runtime
+supports subagents. Do not treat subagents as optional for backlog-scale review.
+The parent session remains the only authority for branch switching, commits,
+GitHub comments, approvals, merges, queue decisions, deploys, report refreshes,
+and final recommendations.
+
+Start these default lanes before producing the operator dossier:
+
+1. `frontend/UI reachability`: route/component callers, app-ui ownership,
+   visible behavior, accessibility, Playwright-needed proof, and exact-file
+   collisions.
+2. `backend/runtime trust`: API routes, services, cache behavior, auth,
+   consent, vault, PKM, finance, KYC, schema, generated contracts, and runtime
+   collision groups.
+3. `observability/security`: diagnostic logging, analytics payload boundaries,
+   secret-scan risk, data minimization, and public-comment safety.
+4. `devex/repo operations`: hooks, setup paths, CI, workflow files, lockfiles,
+   docs verification, merge queue, and smoke/report refresh paths.
+5. `decision-wave communications`: existing maintainer records, edit-vs-new
+   comment posture, closure/request-changes headings, and public hyperlink
+   completeness.
+
+Add a sixth lane only when the batch has a real independent surface not covered
+above, such as mobile/native parity or founder/north-star product direction.
+Avoid one subagent per PR; the unit is an evidence family, not a ticket.
+
+Each lane must return:
+
+1. direct PR hyperlinks
+2. head SHA and freshness
+3. changed files and hard collisions
+4. current canonical surface or explicit `no_attach_point`
+5. accepted value, dropped/deferred pieces, and smallest proof
+6. recommended lane: `queue_cohort`, `sequential_collision_train`,
+   `parallel_patch_train`, `decision_wave`, or `hold_rebase`
+7. public comment posture: edit existing maintainer record, new record, no
+   comment yet, or post-merge closeout
+8. unresolved risks and stop conditions
+
+If subagents are unavailable, the operator dossier must state
+`Subagent taskforce: unavailable` and manually cover the same lanes. If the work
+is high-volume and subagents are available, skipping them is a process violation
+unless the parent records a concrete blocker such as a runtime outage.
+
+## Scan Modes
+
+Use the smallest scan that answers the question.
+
+| Mode | Command Shape | Use When | Expected Output |
+| --- | --- | --- | --- |
+| Active | `--scan-mode active --limit 100` | latest-window triage or fast review | latest PRs only, no all-open inventory |
+| Hybrid | `--scan-mode hybrid --limit 100 --candidate-limit 40` | default operator train planning | all-open inventory plus active deep review and older high-signal PRs |
+| Wide Hybrid | `--scan-mode hybrid --limit 150 --candidate-limit 75 --per-pr-timeout-seconds 8` | backlog sweep when the operator asks for more trains | larger reviewed subset with bounded latency |
+| Full Audit | `--scan-mode full --per-pr-timeout-seconds 5` | scheduled audit, not interactive chat | every open PR attempted, with explicit failures/timeouts |
+
+If GitHub or a per-PR scan fails, the report must say:
+
+1. total open PRs inventoried, if known
+2. reviewed PRs
+3. failed PRs
+4. whether the result is complete, partial, or fallback-only
+
+Do not imply the whole backlog was audited when only a subset was reviewed.
+
+## Train Graph
+
+Build trains from hard dependency edges, not vibes.
+
+Hard edges force sequencing:
+
+1. exact file overlap
+2. lockfile overlap
+3. schema, migration, or generated-contract overlap
+4. same sensitive runtime family
+5. same public route, backend route, auth, consent, vault, PKM, voice, finance, KYC, deploy, or CI authority surface
+6. local dirty-file overlap
+7. a PR that is stacked, conflicting, or stale against current main
+
+Soft edges do not block parallelism by themselves:
+
+1. same author
+2. same broad theme
+3. similar title wording
+4. nearby UI area without file/runtime collision
+5. both being test-only changes with disjoint files
+
+## Lanes
+
+Classify every reviewed PR into exactly one lane.
+
+| Lane | Meaning | Can Run Async? |
+| --- | --- | --- |
+| Queue Cohort | independent `merge_now` PRs, max 4 at once | yes, as one cohort |
+| Sequential Collision Train | PRs with hard edges | no, one at a time |
+| Parallel Patch Train | maintainer patches with disjoint write sets and proven attach points | yes, up to 3 by default |
+| Decision Wave | changes-requested or closure comments for blocked PRs | yes, while queue validation runs |
+| Hold/Rebase | conflicts, stale branches, unclear product intent, or missing proof | no merge action |
+
+## Queue Cohort Rules
+
+A PR can enter a queue cohort only when all are true:
+
+1. exact head SHA is locked
+2. required `CI Status Gate` is green on that head
+3. PR is non-draft
+4. mergeability is clean
+5. no hard collision edge with another cohort PR
+6. no local dirty-file overlap
+7. no active requested-changes state that still matters
+8. no trust-boundary, generated-contract, schema, or reachability blocker
+
+Queue cohorts are capped at 4. Do not wait for unrelated PRs just because one
+cohort member is in queue validation. While queue checks run, prepare the next
+independent cohort or a decision wave.
+
+## Maintainer Patch Gate
+
+Prefer maintainer patch over contributor round trip when the direction is
+aligned and the patch is bounded.
+
+Patch is allowed only when the reviewer can name:
+
+1. accepted value
+2. canonical attach point
+3. exact maintainer write set
+4. dropped or deferred pieces
+5. smallest proof command
+
+Patch is denied when:
+
+1. code is standalone and only used by its own tests
+2. the PR creates a parallel root for an existing capability
+3. no current app, backend, package, route, generated contract, test contract,
+   or documented devex entrypoint uses it
+4. the maintainer would need to invent product intent to save it
+
+Denied patch candidates become `changes_requested`, `hold`, or
+`harvest_then_close`, depending on whether there is useful value to preserve.
+
+## Developer Operating Loop
+
+Use this loop for every review session:
+
+1. Refresh or generate the live report.
+2. Start the required read-only subagent taskforce for high-volume train work,
+   or record why it is unavailable.
+3. Read `Queue Cohort`, `Collision Groups`, `Parallel Patch Trains`, and
+   `Decision Waves`.
+4. If the report found no executable batches, manually inspect the top blocked
+   PRs for possible maintainer-patch attach points.
+5. Pick the next executable train with the highest value and lowest collision.
+6. Produce the operator dossier from `operator-batch-output-contract.md`.
+7. Ask only decision questions that cannot be answered from repo or GitHub
+   truth.
+8. Execute approved GitHub writes by editing existing maintainer records first.
+9. For merges, enqueue with exact head SHA and monitor queue validation.
+10. After merge, monitor Main Post-Merge Smoke.
+11. Refresh the live report and contributor-impact dashboard.
+12. Start the next independent train while checks for unrelated work are still
+    running.
+
+## Required Dossier For Chat Handoffs
+
+Every developer-facing train recommendation must include:
+
+1. scan scope and completeness
+2. delegation router result, subagent taskforce lanes used/skipped/unavailable,
+   lane handoff summaries, fallback evidence if a lane was unavailable, and
+   the parent-only authority statement
+3. queue cohort, even if empty
+4. collision groups and sequence
+5. parallel patch trains and exact write sets
+6. decision waves and comment posture
+7. direct PR links for every PR mentioned
+8. per-PR head SHA, mergeability, CI gate, changed files, and lane
+9. accepted value, attach point, dropped/deferred pieces, and proof for every
+   maintainer patch
+10. stop conditions
+11. report refresh commands
+
+Do not give a train recommendation as only a list of PR numbers.
+
+## GitHub Write Rules
+
+1. Inspect existing maintainer-authored comments and reviews first.
+2. Edit the existing current-lane maintainer record when possible.
+3. Post a new comment only when no existing maintainer record exists, the old
+   record cannot be edited, or the new record is for a distinct state.
+4. Use direct PR hyperlinks in public and internal handoffs.
+5. After a merge, post exactly one closeout comment after Main Post-Merge Smoke
+   passes.
+
+## Stop Conditions
+
+Stop, split the train, or re-run the scan when:
+
+1. any head SHA changes
+2. CI Status Gate changes from green to pending/failing/stale
+3. mergeability changes to dirty/conflicting
+4. a new hard edge appears
+5. a UI-visible change lacks required Playwright/browser evidence
+6. a trust boundary, schema, migration, generated contract, auth, consent,
+   vault, PKM, voice, finance, KYC, deploy, or CI surface is unclear
+7. the scanner reports incomplete scope that affects the proposed train
+8. the maintainer patch no longer has a canonical attach point
+
+## Post-State-Change Refresh
+
+After merge, close, request changes, maintainer patch, or revert:
+
+```bash
+python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --live-report --scan-mode hybrid --limit 100 --candidate-limit 40 --text --output tmp/pr-governance-live-report.md
+python3 .codex/skills/pr-governance-review/scripts/contributor_impact_report.py --repo hushh-labs/hushh-research --days 14 --text > tmp/contributor-impact-dashboard.md
+```
+
+If GitHub returns transient errors, retry once. If it still fails, run a bounded
+fallback scan, preserve the previous complete report, and state the failure in
+the handoff.

--- a/.codex/skills/pr-governance-review/skill.json
+++ b/.codex/skills/pr-governance-review/skill.json
@@ -30,7 +30,8 @@
     ".codex/skills/pr-governance-review/references/operator-batch-output-contract.md",
     ".codex/skills/pr-governance-review/references/operator-question-fixtures.json",
     ".codex/skills/pr-governance-review/references/blocker-gates.md",
-    ".codex/skills/pr-governance-review/references/comment-and-report-contract.md"
+    ".codex/skills/pr-governance-review/references/comment-and-report-contract.md",
+    ".codex/skills/pr-governance-review/references/pr-train-review-sop.md"
   ],
   "required_commands": [
     "python3 -m py_compile .codex/skills/pr-governance-review/scripts/pr_review_checklist.py",


### PR DESCRIPTION
## Summary

- Adds a reusable PR train review SOP for multi-PR review sessions.
- Wires the SOP into the PR governance skill and operator batch output contract.
- Requires scan scope, queue cohorts, collision groups, patch trains, decision waves, and direct PR links in train handoffs.

## Verification

- python3 .codex/skills/codex-skill-authoring/scripts/truth_first_smoke.py
- python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py
- python3 -m py_compile .codex/skills/pr-governance-review/scripts/pr_review_checklist.py .codex/skills/pr-governance-review/scripts/test_pr_review_checklist.py .codex/skills/pr-governance-review/scripts/contributor_impact_report.py
- ./bin/hushh codex audit --text
- NPM_CONFIG_CACHE=tmp/npm-cache ./bin/hushh codex pre-pr

_codex skills used: pr-governance-review, agent-orchestration-governance, github-contribution-governance, repo-operations_