### PR TITLE
docs: make train subagents default for PR reviews

### DIFF
--- a/.codex/skills/pr-governance-review/SKILL.md
+++ b/.codex/skills/pr-governance-review/SKILL.md
@@ -261,21 +261,28 @@ GitHub write posture, and post-state-change report refreshes.
    operations, and decision-wave communications. Add a sixth lane only for a
    real independent surface such as mobile/native parity or founder/north-star
    direction. Do not create one subagent per PR.
-2. Default live-report scan mode is `hybrid`: cheap all-open inventory, then deep review of the latest `100` PRs plus up to `40` older high-signal candidates. Use `active` for fastest latest-window reviews and `full` only for audits.
-3. Use four work lanes at the same time:
+2. Map every async train to a dedicated read-only subagent lane by default.
+   The train, not the individual PR, is the delegation unit. Independent trains
+   run in parallel through separate lanes; same-file or same-runtime PRs remain
+   sequential inside their train. If two proposed trains need the same
+   subagent because they share a hard edge, merge them into one collision train
+   instead of pretending they are parallel.
+3. Default live-report scan mode is `hybrid`: cheap all-open inventory, then deep review of the latest `100` PRs plus up to `40` older high-signal candidates. Use `active` for fastest latest-window reviews and `full` only for audits.
+4. Use four work lanes at the same time:
    - `Queue Cohort`: up to `4` independent `merge_now` PRs with exact head SHA match, green `CI Status Gate`, `MERGEABLE` state, no hard collision edges, and no local dirty-file overlap.
    - `Sequential Collision Train`: PRs with hard edges from exact files, lockfiles, schema/migrations, generated contracts, sensitive runtime families, or local dirty-file overlap. Only one PR from the group moves at a time.
    - `Parallel Patch Trains`: maintainer patches with disjoint write sets and disjoint runtime families. Default maximum is `3`.
    - `Decision Waves`: changes-requested or closure records for clearly blocked PRs. These can run while queue validation is pending.
-4. Do not wait for one independent PR to complete before preparing or queueing unrelated PRs. Wait only when a PR depends on the base/result of another PR or shares a hard edge.
-5. Treat CI/Queue Validation/Main Post-Merge Smoke as an asynchronous monitor lane. Do not idle the whole operator loop while checks run.
-6. Do not start merging a dependent train until the previous train has passed Main Post-Merge Smoke and the live report has been refreshed.
-7. Treat "automatic next train" as automatic next-train discovery and review preparation, not blind approval or merge.
-8. A PR can enter a merge train only after current head, current required gate, mergeability, lane, overlap, collision group, and smallest proof are rechecked.
-9. Reports must state scan scope and completeness. If inventory, GitHub, or per-PR scanning fails, name the exact reviewed subset and failed PRs.
-10. Large-scale rhythm:
+5. Do not wait for one independent PR to complete before preparing or queueing unrelated PRs. Wait only when a PR depends on the base/result of another PR or shares a hard edge.
+6. Treat CI/Queue Validation/Main Post-Merge Smoke as an asynchronous monitor lane. Do not idle the whole operator loop while checks run.
+7. Do not start merging a dependent train until the previous train has passed Main Post-Merge Smoke and the live report has been refreshed.
+8. Treat "automatic next train" as automatic next-train discovery and review preparation, not blind approval or merge.
+9. A PR can enter a merge train only after current head, current required gate, mergeability, lane, overlap, collision group, and smallest proof are rechecked.
+10. Reports must state scan scope and completeness. If inventory, GitHub, or per-PR scanning fails, name the exact reviewed subset and failed PRs.
+11. Large-scale rhythm:
    - mass classify open PRs
-   - start specialist read-only evidence lanes for each independent evidence family
+   - build an async train map
+   - start specialist read-only evidence lanes for each independent train
    - close/request changes for clear drifts in waves
    - queue independent proven cohorts
    - sequence only hard collision groups

--- a/.codex/skills/pr-governance-review/references/operator-batch-output-contract.md
+++ b/.codex/skills/pr-governance-review/references/operator-batch-output-contract.md
@@ -16,9 +16,10 @@ sequence in the sections below.
 1. `Batch`: one sentence naming the product/runtime purpose.
 2. `Research Basis`: concise current truth, recommended path, and risk if accepted blindly.
 3. `Delegation Evidence`: router decision, subagent/taskforce lanes used,
-   direct lane handoff summaries, skipped/unavailable rationale, and explicit
-   parent-only authority for branch switching, commits, GitHub writes,
-   approvals, merges, deploys, and final decisions.
+   async train-to-subagent map, direct lane handoff summaries,
+   skipped/unavailable rationale, and explicit parent-only authority for branch
+   switching, commits, GitHub writes, approvals, merges, deploys, and final
+   decisions.
 4. `Input`: every PR with a direct Markdown link and current lane.
 5. `Train Simulation`: execution-grade simulation based on the current PR heads:
    - branch evidence: current head SHA, mergeability, CI gate, changed files, exact overlaps, and local dirty-worktree overlap
@@ -79,7 +80,9 @@ deterministic sections, even if some are empty:
    freshness, hard collisions, canonical attach points, unresolved risks, and
    whether subagents were used, unavailable, or blocked. For high-volume train
    work, this section is mandatory and cannot be replaced by a parent-only
-   summary unless the runtime cannot spawn subagents.
+   summary unless the runtime cannot spawn subagents. The dossier must map each
+   async train to exactly one read-only subagent lane unless that train is a
+   low-volume single-surface exception or the runtime cannot spawn subagents.
 3. `Queue Cohort`: independent `merge_now` PRs that can be queued together,
    capped at the configured cohort size.
 4. `Collision Groups`: hard-edge groups and the required sequence.
@@ -130,6 +133,11 @@ even when the report already exists on disk:
    devex/repo operations, and decision-wave communications. If a lane was not
    spawned, state the concrete blocker; "not needed" is valid only for
    single-surface or low-volume work.
+9. Train-to-subagent map: every async train must name its subagent evidence
+   lane, the PRs included in that train, which PRs are parallel outside the
+   train, which PRs are sequential inside the train, and which hard edge forces
+   the sequence. If two trains need the same files/runtime family, they are not
+   independent trains.
 
 If the evidence is incomplete, say exactly what is incomplete and present only
 the train subset that is safe from the verified evidence. Do not imply the whole
@@ -177,8 +185,11 @@ Use this rhythm for scale:
 1. Mass classify open PRs through the live report. Default to hybrid scan:
    cheap all-open inventory plus the latest `100` deep reviews and up to `40`
    older high-signal deep reviews.
-2. Start read-only subagent lanes for the independent evidence families before
-   train selection. Use broad lanes, not one subagent per PR.
+2. Build an async train map, then start one read-only subagent lane per
+   independent train before final train selection. Use broad lanes, not one
+   subagent per PR. If the train has same-file or same-runtime collisions, the
+   subagent analyzes the full collision group and returns the required internal
+   sequence.
 3. Convert clear drifts into closure or changes-requested waves.
 4. Queue independent `merge_now` PRs as a cohort, capped at `4`.
 5. While PR Validation, Queue Validation, or Main Post-Merge Smoke runs, review the next independent operator batch.

--- a/.codex/skills/pr-governance-review/references/pr-train-review-sop.md
+++ b/.codex/skills/pr-governance-review/references/pr-train-review-sop.md
@@ -73,6 +73,21 @@ Add a sixth lane only when the batch has a real independent surface not covered
 above, such as mobile/native parity or founder/north-star product direction.
 Avoid one subagent per PR; the unit is an evidence family, not a ticket.
 
+Default mapping: every async train gets its own read-only subagent lane. A
+train can contain multiple PRs when they share the same product/runtime family.
+Independent trains run at the same time; PRs inside a train are sequenced when
+they share files, generated contracts, schema, lockfiles, sensitive runtime, or
+queue/main dependencies. Do not collapse multiple independent trains into one
+subagent if doing so would hide collisions, comment posture, or proof gaps.
+
+Examples:
+
+1. frontend/UI hold or patch train -> one frontend/UI reachability subagent
+2. backend trust/cache train -> one backend/runtime trust subagent
+3. observability redaction train -> one observability/security subagent
+4. devex hook or dependency train -> one devex/repo-operations subagent
+5. changes-requested/closure wave -> one decision-wave communications subagent
+
 Each lane must return:
 
 1. direct PR hyperlinks
@@ -191,21 +206,22 @@ Denied patch candidates become `changes_requested`, `hold`, or
 Use this loop for every review session:
 
 1. Refresh or generate the live report.
-2. Start the required read-only subagent taskforce for high-volume train work,
-   or record why it is unavailable.
-3. Read `Queue Cohort`, `Collision Groups`, `Parallel Patch Trains`, and
+2. Convert the candidate batches into an async train map.
+3. Start one read-only subagent lane per async train/evidence family for
+   high-volume train work, or record why a lane is unavailable.
+4. Read `Queue Cohort`, `Collision Groups`, `Parallel Patch Trains`, and
    `Decision Waves`.
-4. If the report found no executable batches, manually inspect the top blocked
+5. If the report found no executable batches, manually inspect the top blocked
    PRs for possible maintainer-patch attach points.
-5. Pick the next executable train with the highest value and lowest collision.
-6. Produce the operator dossier from `operator-batch-output-contract.md`.
-7. Ask only decision questions that cannot be answered from repo or GitHub
+6. Pick the next executable train with the highest value and lowest collision.
+7. Produce the operator dossier from `operator-batch-output-contract.md`.
+8. Ask only decision questions that cannot be answered from repo or GitHub
    truth.
-8. Execute approved GitHub writes by editing existing maintainer records first.
-9. For merges, enqueue with exact head SHA and monitor queue validation.
-10. After merge, monitor Main Post-Merge Smoke.
-11. Refresh the live report and contributor-impact dashboard.
-12. Start the next independent train while checks for unrelated work are still
+9. Execute approved GitHub writes by editing existing maintainer records first.
+10. For merges, enqueue with exact head SHA and monitor queue validation.
+11. After merge, monitor Main Post-Merge Smoke.
+12. Refresh the live report and contributor-impact dashboard.
+13. Start the next independent train while checks for unrelated work are still
     running.
 
 ## Required Dossier For Chat Handoffs
@@ -213,9 +229,9 @@ Use this loop for every review session:
 Every developer-facing train recommendation must include:
 
 1. scan scope and completeness
-2. delegation router result, subagent taskforce lanes used/skipped/unavailable,
-   lane handoff summaries, fallback evidence if a lane was unavailable, and
-   the parent-only authority statement
+2. delegation router result, async train-to-subagent map, taskforce lanes
+   used/skipped/unavailable, lane handoff summaries, fallback evidence if a
+   lane was unavailable, and the parent-only authority statement
 3. queue cohort, even if empty
 4. collision groups and sequence
 5. parallel patch trains and exact write sets


### PR DESCRIPTION
## Summary

Follow-up governance tightening for the PR train SOP.

This makes the default reviewer behavior explicit: every high-volume async train gets a dedicated read-only subagent lane. The train/evidence family is the delegation unit, not the individual PR. Independent trains can run together; PRs inside the same train still sequence when they share files, generated contracts, schema, lockfiles, sensitive runtime, or queue/main dependencies.

## What Changed

- Adds train-to-subagent mapping to the PR train SOP.
- Requires the developer operating loop to convert candidate batches into an async train map before final dossier synthesis.
- Requires the operator dossier to show the train-to-subagent map, skipped/unavailable lanes, and parent-only authority.
- Clarifies that trains sharing the same files/runtime family must become one collision train instead of pretending to run in parallel.

## Verification

- `python3 .codex/skills/codex-skill-authoring/scripts/truth_first_smoke.py`
- `python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py`
- `python3 .codex/skills/agent-orchestration-governance/scripts/delegation_router.py --workflow pr-governance-review --phase start --prompt "review async PR trains across frontend backend observability devex and decision waves" --paths "hushh-webapp/components/app-ui/top-app-bar.tsx,consent-protocol/api/routes/kai/chat.py,.github/workflows/ci.yml" --text`
- `git diff --check`

_codex skills used: `pr-governance-review`, `agent-orchestration-governance`, `codex-skill-authoring`_
