### PR TITLE
fix: exclude failing checks from PR trains

### DIFF
--- a/.codex/skills/pr-governance-review/SKILL.md
+++ b/.codex/skills/pr-governance-review/SKILL.md
@@ -89,18 +89,23 @@ Load these only when the decision needs them:
    - `block`
    - `harvest_then_close`
    - `close_duplicate`
-6. Green CI never overrides exact file overlap, duplicate product contracts, schema-contract drift, raw-error leakage findings, or current auxiliary check failures introduced by the PR.
-7. The checklist fields `contract_set`, `duplicate_group`, `public_comment_policy`, `lane`, and `live_report_action` are decision records, not decoration.
-8. Treat app/backend reachability as a merge-readiness input. A PR that adds standalone code, tests, helpers, components, or scripts must prove it is used by a canonical app/backend/package path, or it must be classified as test/devex hygiene rather than product/runtime value.
-9. If a PR title/body claims one contract but the changed files touch another, stop the merge path until the PR is retitled/rescoped, patched to the claimed contract, or closed/requested-changes.
-10. If a PR says it is stacked, depends on a prior PR, or will have a different diff after another PR lands, do not review it as a merge candidate until it is rebased to `main` or explicitly scoped as a harvest/reference PR.
-11. Treat local worktree overlap as a merge blocker. If an open PR touches files with uncommitted maintainer changes, resolve local ownership first: commit/stash/rebase the maintainer branch, harvest only unique PR value, or request a contributor rebase. Do not merge a GitHub-green head over active local governance/product work.
-12. Run the Founder Wiki North-Star Probe for material PRs that touch product direction, One/Kai/Nav, PCHP, BYOA/BYOK, MLX/on-device posture, consent/vault/PKM, World Model, voice/action, Aha Moment, user-facing workflows, or founder-language claims. Use `.codex/skills/codex-skill-authoring/references/founder-wiki-north-star-probe.md` as the contract:
+6. A non-green required `CI Status Gate`, missing required gate, or current
+   failing auxiliary check is an intake stop, not a train candidate. Exclude
+   that PR from queue cohorts, patch trains, collision trains, decision waves,
+   and recommended operator batches unless the explicit task is to fix CI.
+   Record it only in the check-failure hold register.
+7. Green CI never overrides exact file overlap, duplicate product contracts, schema-contract drift, raw-error leakage findings, or current auxiliary check failures introduced by the PR.
+8. The checklist fields `contract_set`, `duplicate_group`, `public_comment_policy`, `lane`, and `live_report_action` are decision records, not decoration.
+9. Treat app/backend reachability as a merge-readiness input. A PR that adds standalone code, tests, helpers, components, or scripts must prove it is used by a canonical app/backend/package path, or it must be classified as test/devex hygiene rather than product/runtime value.
+10. If a PR title/body claims one contract but the changed files touch another, stop the merge path until the PR is retitled/rescoped, patched to the claimed contract, or closed/requested-changes.
+11. If a PR says it is stacked, depends on a prior PR, or will have a different diff after another PR lands, do not review it as a merge candidate until it is rebased to `main` or explicitly scoped as a harvest/reference PR.
+12. Treat local worktree overlap as a merge blocker. If an open PR touches files with uncommitted maintainer changes, resolve local ownership first: commit/stash/rebase the maintainer branch, harvest only unique PR value, or request a contributor rebase. Do not merge a GitHub-green head over active local governance/product work.
+13. Run the Founder Wiki North-Star Probe for material PRs that touch product direction, One/Kai/Nav, PCHP, BYOA/BYOK, MLX/on-device posture, consent/vault/PKM, World Model, voice/action, Aha Moment, user-facing workflows, or founder-language claims. Use `.codex/skills/codex-skill-authoring/references/founder-wiki-north-star-probe.md` as the contract:
    - repo code/contracts/tests/CI remain current-state truth
    - founder wiki pages define north-star and future-state alignment
    - conflicts are `current_state_vs_north_star_drift`
    - private wiki evidence stays local-only and must not be cited in public GitHub comments
-13. For high-volume PR train work, spawn/read from the required read-only
+14. For high-volume PR train work, spawn/read from the required read-only
     subagent taskforce before producing the operator dossier. High-volume means
     more than `20` PRs scanned or discussed, more than `5` PRs acted on in one
     session, any mixed frontend/backend/security/devex/observability train, any
@@ -109,11 +114,11 @@ Load these only when the decision needs them:
     Use the delegation router to choose lanes and record whether evidence lanes
     were used:
    `python3 .codex/skills/agent-orchestration-governance/scripts/delegation_router.py --workflow pr-governance-review --phase start --prompt "<request>" --paths "<paths>" --text`
-14. If subagents are unavailable, record `Subagent taskforce: unavailable` and
+15. If subagents are unavailable, record `Subagent taskforce: unavailable` and
     manually cover the same evidence lanes. If they are available, skipping
     them for high-volume train work is a process violation unless a concrete
     runtime blocker is recorded.
-15. Keep final authority local to the parent/governor. Do not delegate branch switching, approval, merge, deploy, credential handling, or final decision.
+16. Keep final authority local to the parent/governor. Do not delegate branch switching, approval, merge, deploy, credential handling, or final decision.
 
 ### Decision Order
 
@@ -278,8 +283,9 @@ GitHub write posture, and post-state-change report refreshes.
 7. Do not start merging a dependent train until the previous train has passed Main Post-Merge Smoke and the live report has been refreshed.
 8. Treat "automatic next train" as automatic next-train discovery and review preparation, not blind approval or merge.
 9. A PR can enter a merge train only after current head, current required gate, mergeability, lane, overlap, collision group, and smallest proof are rechecked.
-10. Reports must state scan scope and completeness. If inventory, GitHub, or per-PR scanning fails, name the exact reviewed subset and failed PRs.
-11. Large-scale rhythm:
+10. A PR with non-green required gate, missing required gate, or current failing auxiliary check cannot enter any executable train. Do not spend train-planning time on it; list it under check-failure holds and revisit only after checks are clean or the operator explicitly asks to repair CI.
+11. Reports must state scan scope and completeness. If inventory, GitHub, or per-PR scanning fails, name the exact reviewed subset and failed PRs.
+12. Large-scale rhythm:
    - mass classify open PRs
    - build an async train map
    - start specialist read-only evidence lanes for each independent train

--- a/.codex/skills/pr-governance-review/references/operator-batch-output-contract.md
+++ b/.codex/skills/pr-governance-review/references/operator-batch-output-contract.md
@@ -20,8 +20,12 @@ sequence in the sections below.
    skipped/unavailable rationale, and explicit parent-only authority for branch
    switching, commits, GitHub writes, approvals, merges, deploys, and final
    decisions.
-4. `Input`: every PR with a direct Markdown link and current lane.
-5. `Train Simulation`: execution-grade simulation based on the current PR heads:
+4. `Check Failure Holds`: every reviewed PR excluded because the required gate
+   is not green, the required gate is missing, or a current auxiliary check is
+   failing. These PRs are not train candidates unless the user explicitly asks
+   for CI repair.
+5. `Input`: every PR with a direct Markdown link and current lane.
+6. `Train Simulation`: execution-grade simulation based on the current PR heads:
    - branch evidence: current head SHA, mergeability, CI gate, changed files, exact overlaps, and local dirty-worktree overlap
    - delta summary: files added, edited, deleted, generated, moved, dependencies changed, and routes/contracts touched
    - behavior claim: what the PR claims and whether that behavior is reachable in the current app/backend/package
@@ -30,7 +34,7 @@ sequence in the sections below.
    - action outcome: exact operation per PR if approved
    - comment simulation: expected GitHub comment/edit posture and heading
    - verification timeline: local checks, Playwright for UI-visible changes, GitHub gates, smoke, reports
-6. `Expected Actions`: table or bullets mapping each PR to one of:
+7. `Expected Actions`: table or bullets mapping each PR to one of:
    - `review_only`
    - `hold`
    - `request_changes`
@@ -39,14 +43,14 @@ sequence in the sections below.
    - `maintainer_patch_then_merge`
    - `merge_now`
    - `post_merge_monitor`
-7. `Comment Plan`: table or bullets mapping each PR to one of:
+8. `Comment Plan`: table or bullets mapping each PR to one of:
    - `none_before_merge_then_post_merge_closeout`
    - `edit_existing_maintainer_comment`
    - `new_changes_requested_comment`
    - `new_closed_superseded_comment`
    - `no_comment_review_only`
    Include the intended headline, for example `## Merged: Consent Center State UX`.
-8. `Per-PR Assessment`: one compact but complete block per PR:
+9. `Per-PR Assessment`: one compact but complete block per PR:
    - direct link
    - lane
    - lean/core risk
@@ -57,12 +61,12 @@ sequence in the sections below.
    - planned action: merge, patch/rebase, harvest/close, request changes, or hold
    - comment action: expected public comment/edit behavior
    - `Smallest proof`: smallest authoritative check before that action
-9. `Output`: intended end state if the batch is legitimate.
-10. `Execution`: exact order, split by merge train, patch train, closure/request-changes wave, and hold/deep-review items.
-11. `Decision Questions`: only unresolved user-owned choices, each with current truth, recommended path, risk if accepted blindly, and recommended option first.
-12. `Stop Conditions`: what pauses, splits, or blocks the batch.
-13. `Verification`: smallest authoritative local and GitHub checks.
-14. `After-Merge Kickoff`: how the next independent train will be discovered after report refresh.
+10. `Output`: intended end state if the batch is legitimate.
+11. `Execution`: exact order, split by merge train, patch train, closure/request-changes wave, and hold/deep-review items.
+12. `Decision Questions`: only unresolved user-owned choices, each with current truth, recommended path, risk if accepted blindly, and recommended option first.
+13. `Stop Conditions`: what pauses, splits, or blocks the batch.
+14. `Verification`: smallest authoritative local and GitHub checks.
+15. `After-Merge Kickoff`: how the next independent train will be discovered after report refresh.
 
 Hyperlink rule: any chat answer, execution update, or final handoff generated
 from this contract must hyperlink every PR it mentions. Counts-only summaries
@@ -83,12 +87,14 @@ deterministic sections, even if some are empty:
    summary unless the runtime cannot spawn subagents. The dossier must map each
    async train to exactly one read-only subagent lane unless that train is a
    low-volume single-surface exception or the runtime cannot spawn subagents.
-3. `Queue Cohort`: independent `merge_now` PRs that can be queued together,
+3. `Check Failure Holds`: PRs removed from train consideration because current
+   required or auxiliary checks are not clean.
+4. `Queue Cohort`: independent `merge_now` PRs that can be queued together,
    capped at the configured cohort size.
-4. `Collision Groups`: hard-edge groups and the required sequence.
-5. `Parallel Patch Trains`: disjoint maintainer patch trains with attachment
+5. `Collision Groups`: hard-edge groups and the required sequence.
+6. `Parallel Patch Trains`: disjoint maintainer patch trains with attachment
    point, patch files, dropped/deferred pieces, and proof.
-6. `Decision Waves`: PRs ready for changes-requested or closure records while
+7. `Decision Waves`: PRs ready for changes-requested or closure records while
    queue validation runs.
 
 Decision waves must list the exact linked PRs in the wave and the exact public
@@ -120,20 +126,23 @@ even when the report already exists on disk:
    Repass/correction waves must prefer edited maintainer records over new
    comments. If a new comment is needed, state why the previous maintainer
    record could not be edited.
-6. Stop conditions: stale head, lost CI Status Gate, conflict, exact-file
+6. Check-failure intake filter: PRs with non-green/missing required gates or
+   current failing auxiliary checks are excluded from train planning and should
+   appear only under `Check Failure Holds` unless this is a CI repair pass.
+7. Stop conditions: stale head, lost CI Status Gate, conflict, exact-file
    overlap, new trust-boundary finding, missing caller/reachability proof,
    Playwright gap for UI-visible changes, or north-star drift.
-7. Train graph: every PR must expose `collision_group_id`,
+8. Train graph: every PR must expose `collision_group_id`,
    `collision_reasons`, `can_queue_with`, `must_wait_for`,
    `queue_cohort_id`, `parallel_patch_train_id`, patch attachment fields, and
    whether a north-star probe is required.
-8. Subagent taskforce: for high-volume train work, every dossier must state the
+9. Subagent taskforce: for high-volume train work, every dossier must state the
    read-only evidence lanes used before the recommendation. The default lanes
    are frontend/UI reachability, backend/runtime trust, observability/security,
    devex/repo operations, and decision-wave communications. If a lane was not
    spawned, state the concrete blocker; "not needed" is valid only for
    single-surface or low-volume work.
-9. Train-to-subagent map: every async train must name its subagent evidence
+10. Train-to-subagent map: every async train must name its subagent evidence
    lane, the PRs included in that train, which PRs are parallel outside the
    train, which PRs are sequential inside the train, and which hard edge forces
    the sequence. If two trains need the same files/runtime family, they are not
@@ -148,13 +157,16 @@ report exists on disk; the chat handoff must remain reviewable on its own.
 ## Batch Selection Rules
 
 1. Use `Recommended Operator Batches` before `Contract Intake Sets`.
-2. Exact file overlap creates sequencing, not duplicate closure.
-3. Same broad contract label is not enough to batch.
-4. Same author is a convenience only after product/runtime contract grouping.
-5. Batch can mean merge train, patch train, close wave, request-changes wave, or deep-review wave.
-6. Do not mix independent high-risk runtime decisions just to increase throughput.
-7. A merge train can proceed while the next independent batch is reviewed, but two dependent trains must not merge concurrently.
-8. "Automatic next train" means automatic next-train discovery and review preparation; approval, merge, deploy, and close decisions remain explicit operator actions.
+2. Exclude PRs with non-green/missing required gates or current failing
+   auxiliary checks before building batches. Do not let them shape collision
+   groups or recommended operator batches unless the task is CI repair.
+3. Exact file overlap creates sequencing, not duplicate closure.
+4. Same broad contract label is not enough to batch.
+5. Same author is a convenience only after product/runtime contract grouping.
+6. Batch can mean merge train, patch train, close wave, request-changes wave, or deep-review wave.
+7. Do not mix independent high-risk runtime decisions just to increase throughput.
+8. A merge train can proceed while the next independent batch is reviewed, but two dependent trains must not merge concurrently.
+9. "Automatic next train" means automatic next-train discovery and review preparation; approval, merge, deploy, and close decisions remain explicit operator actions.
 
 ## Good Output Standard
 
@@ -185,16 +197,19 @@ Use this rhythm for scale:
 1. Mass classify open PRs through the live report. Default to hybrid scan:
    cheap all-open inventory plus the latest `100` deep reviews and up to `40`
    older high-signal deep reviews.
-2. Build an async train map, then start one read-only subagent lane per
+2. Move current check failures into `Check Failure Holds`; do not spend
+   train-planning or subagent time on them unless the operator asks for CI
+   repair.
+3. Build an async train map, then start one read-only subagent lane per
    independent train before final train selection. Use broad lanes, not one
    subagent per PR. If the train has same-file or same-runtime collisions, the
    subagent analyzes the full collision group and returns the required internal
    sequence.
-3. Convert clear drifts into closure or changes-requested waves.
-4. Queue independent `merge_now` PRs as a cohort, capped at `4`.
-5. While PR Validation, Queue Validation, or Main Post-Merge Smoke runs, review the next independent operator batch.
-6. After smoke passes, refresh the live report and contributor-impact dashboard.
-7. Select the next independent `Recommended Operator Batches` item and produce a fresh `Per-PR Assessment`.
+4. Convert clear drifts into closure or changes-requested waves.
+5. Queue independent `merge_now` PRs as a cohort, capped at `4`.
+6. While PR Validation, Queue Validation, or Main Post-Merge Smoke runs, review the next independent operator batch.
+7. After smoke passes, refresh the live report and contributor-impact dashboard.
+8. Select the next independent `Recommended Operator Batches` item and produce a fresh `Per-PR Assessment`.
 
 Never let throughput hide dependency order. Shared files, lockfiles, shared
 runtime contracts, generated contracts, schema/migration surfaces,

--- a/.codex/skills/pr-governance-review/references/pr-train-review-sop.md
+++ b/.codex/skills/pr-governance-review/references/pr-train-review-sop.md
@@ -126,6 +126,24 @@ If GitHub or a per-PR scan fails, the report must say:
 
 Do not imply the whole backlog was audited when only a subset was reviewed.
 
+## Check Failure Intake Filter
+
+Do not spend train-construction time on PRs whose current checks are not clean.
+This is the first filter before queue, patch, collision, or decision-wave
+planning.
+
+A PR is excluded from executable trains when any of these are true:
+
+1. required `CI Status Gate` is missing, pending, skipped, cancelled, failing, or unknown
+2. required `CI Status Gate` is green but a current auxiliary check is failing
+3. the PR is behind with failing checks and needs contributor rebase/regeneration
+4. the only actionable work is to repair CI, and the operator did not ask for a CI-fix train
+
+Excluded PRs go into `Check Failure Holds` or the blocked/waiting register. They
+do not appear in `Queue Cohort`, `Sequential Collision Train`, `Parallel Patch
+Trains`, `Decision Waves`, or `Recommended Operator Batches`. Revisit them only
+after checks are clean or after the operator explicitly asks to debug/fix CI.
+
 ## Train Graph
 
 Build trains from hard dependency edges, not vibes.
@@ -159,6 +177,7 @@ Classify every reviewed PR into exactly one lane.
 | Parallel Patch Train | maintainer patches with disjoint write sets and proven attach points | yes, up to 3 by default |
 | Decision Wave | changes-requested or closure comments for blocked PRs | yes, while queue validation runs |
 | Hold/Rebase | conflicts, stale branches, unclear product intent, or missing proof | no merge action |
+| Check Failure Hold | non-green required gate or failing current auxiliary check | no train action |
 
 ## Queue Cohort Rules
 
@@ -166,12 +185,13 @@ A PR can enter a queue cohort only when all are true:
 
 1. exact head SHA is locked
 2. required `CI Status Gate` is green on that head
-3. PR is non-draft
-4. mergeability is clean
-5. no hard collision edge with another cohort PR
-6. no local dirty-file overlap
-7. no active requested-changes state that still matters
-8. no trust-boundary, generated-contract, schema, or reachability blocker
+3. no current auxiliary check is failing
+4. PR is non-draft
+5. mergeability is clean
+6. no hard collision edge with another cohort PR
+7. no local dirty-file overlap
+8. no active requested-changes state that still matters
+9. no trust-boundary, generated-contract, schema, or reachability blocker
 
 Queue cohorts are capped at 4. Do not wait for unrelated PRs just because one
 cohort member is in queue validation. While queue checks run, prepare the next
@@ -209,19 +229,21 @@ Use this loop for every review session:
 2. Convert the candidate batches into an async train map.
 3. Start one read-only subagent lane per async train/evidence family for
    high-volume train work, or record why a lane is unavailable.
-4. Read `Queue Cohort`, `Collision Groups`, `Parallel Patch Trains`, and
+4. Read `Check Failure Holds` first, then ignore those PRs for train planning
+   unless the session is explicitly a CI repair pass.
+5. Read `Queue Cohort`, `Collision Groups`, `Parallel Patch Trains`, and
    `Decision Waves`.
-5. If the report found no executable batches, manually inspect the top blocked
+6. If the report found no executable batches, manually inspect the top blocked
    PRs for possible maintainer-patch attach points.
-6. Pick the next executable train with the highest value and lowest collision.
-7. Produce the operator dossier from `operator-batch-output-contract.md`.
-8. Ask only decision questions that cannot be answered from repo or GitHub
+7. Pick the next executable train with the highest value and lowest collision.
+8. Produce the operator dossier from `operator-batch-output-contract.md`.
+9. Ask only decision questions that cannot be answered from repo or GitHub
    truth.
-9. Execute approved GitHub writes by editing existing maintainer records first.
-10. For merges, enqueue with exact head SHA and monitor queue validation.
-11. After merge, monitor Main Post-Merge Smoke.
-12. Refresh the live report and contributor-impact dashboard.
-13. Start the next independent train while checks for unrelated work are still
+10. Execute approved GitHub writes by editing existing maintainer records first.
+11. For merges, enqueue with exact head SHA and monitor queue validation.
+12. After merge, monitor Main Post-Merge Smoke.
+13. Refresh the live report and contributor-impact dashboard.
+14. Start the next independent train while checks for unrelated work are still
     running.
 
 ## Required Dossier For Chat Handoffs
@@ -236,12 +258,13 @@ Every developer-facing train recommendation must include:
 4. collision groups and sequence
 5. parallel patch trains and exact write sets
 6. decision waves and comment posture
-7. direct PR links for every PR mentioned
-8. per-PR head SHA, mergeability, CI gate, changed files, and lane
-9. accepted value, attach point, dropped/deferred pieces, and proof for every
+7. check-failure holds that were excluded from train planning
+8. direct PR links for every PR mentioned
+9. per-PR head SHA, mergeability, CI gate, changed files, and lane
+10. accepted value, attach point, dropped/deferred pieces, and proof for every
    maintainer patch
-10. stop conditions
-11. report refresh commands
+11. stop conditions
+12. report refresh commands
 
 Do not give a train recommendation as only a list of PR numbers.
 

--- a/.codex/skills/pr-governance-review/scripts/pr_review_checklist.py
+++ b/.codex/skills/pr-governance-review/scripts/pr_review_checklist.py
@@ -25,6 +25,7 @@ DEFAULT_QUEUE_COHORT_SIZE = 4
 DEFAULT_PER_PR_TIMEOUT_SECONDS = 25
 DEFAULT_MAX_PARALLEL_PATCH_TRAINS = 3
 SCAN_MODES = {"active", "hybrid", "full"}
+FAILED_CHECK_CONCLUSIONS = {"FAILURE", "ERROR", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED"}
 PATCH_ATTACHMENT_BLOCKER_FINDINGS = {
     "frontend_component_without_reachable_caller",
     "new_agent_without_runtime_wiring",
@@ -1413,12 +1414,11 @@ def _failed_non_required_checks(
     current_checks: list[dict[str, Any]],
     required_status_check: str,
 ) -> list[dict[str, Any]]:
-    failed_states = {"FAILURE", "ERROR", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED"}
     failed: list[dict[str, Any]] = []
     for check in current_checks:
         name = str(check.get("name") or "")
         conclusion = str(check.get("conclusion") or "UNKNOWN").upper()
-        if name != required_status_check and conclusion in failed_states:
+        if name != required_status_check and conclusion in FAILED_CHECK_CONCLUSIONS:
             failed.append(check)
     return failed
 
@@ -3260,6 +3260,8 @@ def _single_pr_live_assessment(report: dict[str, Any]) -> list[str]:
 
 def _is_actionable_live_candidate(report: dict[str, Any]) -> bool:
     pr = report["pr"]
+    if _has_current_check_failure(report):
+        return False
     if report["lane"] in {"harvest_then_close", "close_duplicate"}:
         return True
     if pr.get("is_draft"):
@@ -3307,6 +3309,9 @@ def _blocked_live_register_lines(reports: list[dict[str, Any]]) -> list[str]:
     for report in blocked:
         pr = report["pr"]
         reason = report.get("patch_then_merge_reason") or report["decision"]["rationale"]
+        check_failure_reason = _current_check_failure_reason(report)
+        if check_failure_reason:
+            reason = f"check_failure_hold: {check_failure_reason}. Excluded from executable trains until checks are clean."
         review = pr.get("review_decision") or "none"
         lines.append(
             f"- [#{pr['number']}]({pr['url']}) - review `{review}`, mergeable `{pr.get('mergeable')}`, lane `{report['lane']}`: {reason}"
@@ -4295,12 +4300,32 @@ def _has_local_dirty_overlap(report: dict[str, Any]) -> bool:
     return any(finding.get("id") == "local_worktree_overlap" for finding in report.get("findings", []))
 
 
+def _current_check_failure_reason(report: dict[str, Any]) -> str:
+    required_gate = str(report.get("current_ci_status_gate") or "UNKNOWN").upper()
+    if required_gate != "SUCCESS":
+        return f"required CI Status Gate is `{required_gate}`"
+
+    failed_checks = [
+        str(check.get("name") or "unknown")
+        for check in report.get("current_checks", [])
+        if str(check.get("conclusion") or "UNKNOWN").upper() in FAILED_CHECK_CONCLUSIONS
+    ]
+    if failed_checks:
+        return f"current auxiliary check failure: {', '.join(sorted(failed_checks))}"
+    return ""
+
+
+def _has_current_check_failure(report: dict[str, Any]) -> bool:
+    return bool(_current_check_failure_reason(report))
+
+
 def _queue_eligible(report: dict[str, Any], hard_edges: dict[int, dict[int, list[str]]]) -> bool:
     pr = report["pr"]
     number = pr["number"]
     return (
         report.get("lane") == "merge_now"
         and report.get("current_ci_status_gate") == "SUCCESS"
+        and not _has_current_check_failure(report)
         and pr.get("mergeable") == "MERGEABLE"
         and not pr.get("is_draft")
         and not hard_edges.get(number)
@@ -4338,14 +4363,27 @@ def _build_train_graph(
     queue_cohort_size: int,
     max_parallel_patch_trains: int,
 ) -> OrderedDict[str, Any]:
-    by_number = {report["pr"]["number"]: report for report in reports}
-    hard_edges: dict[int, dict[int, list[str]]] = {
-        number: {} for number in by_number
-    }
     for report in reports:
         _initialize_train_fields(report)
 
-    for left, right in combinations(reports, 2):
+    train_reports = [
+        report for report in reports if not _has_current_check_failure(report)
+    ]
+    check_failure_holds = [
+        OrderedDict(
+            pr=report["pr"]["number"],
+            reason=_current_check_failure_reason(report),
+        )
+        for report in sorted(reports, key=lambda item: item["pr"]["number"])
+        if _has_current_check_failure(report)
+    ]
+
+    by_number = {report["pr"]["number"]: report for report in train_reports}
+    hard_edges: dict[int, dict[int, list[str]]] = {
+        number: {} for number in by_number
+    }
+
+    for left, right in combinations(train_reports, 2):
         reasons = _hard_collision_reasons(left, right)
         if not reasons:
             continue
@@ -4398,7 +4436,7 @@ def _build_train_graph(
 
     queue_candidates = [
         report
-        for report in sorted(reports, key=_report_sort_key)
+        for report in sorted(train_reports, key=_report_sort_key)
         if _queue_eligible(report, hard_edges)
     ]
     queue_cohorts: list[OrderedDict[str, Any]] = []
@@ -4420,7 +4458,7 @@ def _build_train_graph(
         )
 
     queue_number_set = {report["pr"]["number"] for report in queue_candidates}
-    for report in reports:
+    for report in train_reports:
         number = report["pr"]["number"]
         if report.get("lane") != "merge_now":
             continue
@@ -4433,7 +4471,7 @@ def _build_train_graph(
     patch_trains: list[OrderedDict[str, Any]] = []
     claimed_patch_files: set[str] = set()
     claimed_patch_families: set[str] = set()
-    for report in sorted(reports, key=_report_sort_key):
+    for report in sorted(train_reports, key=_report_sort_key):
         if len(patch_trains) >= max_parallel_patch_trains:
             break
         if report.get("lane") != "patch_then_merge":
@@ -4462,12 +4500,12 @@ def _build_train_graph(
     decision_waves: list[OrderedDict[str, Any]] = []
     closure = [
         report["pr"]["number"]
-        for report in sorted(reports, key=_report_sort_key)
+        for report in sorted(train_reports, key=_report_sort_key)
         if report.get("lane") in {"harvest_then_close", "close_duplicate"}
     ]
     changes_requested = [
         report["pr"]["number"]
-        for report in sorted(reports, key=_report_sort_key)
+        for report in sorted(train_reports, key=_report_sort_key)
         if report.get("lane") == "block"
     ]
     if closure:
@@ -4502,6 +4540,7 @@ def _build_train_graph(
         collision_groups=collision_groups,
         parallel_patch_trains=patch_trains,
         decision_waves=decision_waves,
+        check_failure_holds=check_failure_holds,
     )
 
 
@@ -4671,6 +4710,15 @@ def build_batch_report(
                 shared_files=shared,
             )
         )
+    actionable_reports = [
+        report for report in reports if _is_actionable_live_candidate(report)
+    ]
+    actionable_numbers = {report["pr"]["number"] for report in actionable_reports}
+    actionable_overlaps = [
+        overlap
+        for overlap in overlaps
+        if set(overlap.get("pair", [])) <= actionable_numbers
+    ]
 
     surface_counts: dict[str, int] = {}
     root_counts: dict[str, int] = {}
@@ -4706,8 +4754,9 @@ def build_batch_report(
         collision_groups=train_graph["collision_groups"],
         parallel_patch_trains=train_graph["parallel_patch_trains"],
         decision_waves=train_graph["decision_waves"],
+        check_failure_holds=train_graph["check_failure_holds"],
         reports=reports,
-        operator_batches=_operator_batches(reports, overlaps),
+        operator_batches=_operator_batches(actionable_reports, actionable_overlaps),
     )
 
 
@@ -4736,6 +4785,10 @@ def _batch_text_report(batch: dict[str, Any]) -> str:
             )
     else:
         lines.append("Cross-PR file overlaps: none")
+    if batch.get("check_failure_holds"):
+        lines.append("Check failure holds:")
+        for hold in batch["check_failure_holds"]:
+            lines.append(f"- #{hold['pr']}: {hold['reason']}")
     lines.append("")
     for report in batch["reports"]:
         lines.append(_text_report(report))
@@ -4986,6 +5039,21 @@ def _decision_wave_lines(batch: dict[str, Any]) -> list[str]:
     return lines
 
 
+def _check_failure_hold_lines(batch: dict[str, Any]) -> list[str]:
+    lines = ["", "## Check Failure Holds", ""]
+    holds = batch.get("check_failure_holds") or []
+    if not holds:
+        lines.append("- none")
+        return lines
+    lines.append(
+        "- These PRs are excluded from queue cohorts, patch trains, collision trains, decision waves, and recommended operator batches until their current checks are clean."
+    )
+    for hold in holds:
+        number = int(hold["pr"])
+        lines.append(f"- {_linked_prs(batch, [number])}: {hold['reason']}.")
+    return lines
+
+
 def _live_report_text(batch: dict[str, Any]) -> str:
     generated_at = batch["generated_at"]
     actionable_reports = [
@@ -5014,6 +5082,7 @@ def _live_report_text(batch: dict[str, Any]) -> str:
         "- [Collision Groups](#collision-groups)",
         "- [Parallel Patch Trains](#parallel-patch-trains)",
         "- [Decision Waves](#decision-waves)",
+        "- [Check Failure Holds](#check-failure-holds)",
         "- [Actionable Next Queue](#actionable-next-queue)",
         "- [Blocked / Waiting Register](#blocked--waiting-register)",
         "- [Contract Intake Sets](#contract-intake-sets)",
@@ -5067,6 +5136,7 @@ def _live_report_text(batch: dict[str, Any]) -> str:
     lines.extend(_collision_group_lines(batch))
     lines.extend(_parallel_patch_train_lines(batch))
     lines.extend(_decision_wave_lines(batch))
+    lines.extend(_check_failure_hold_lines(batch))
     lines.extend([""])
     lines.extend(_live_actionable_queue_lines(batch["reports"]))
     lines.extend(_blocked_live_register_lines(batch["reports"]))

--- a/.codex/skills/pr-governance-review/scripts/test_pr_review_checklist.py
+++ b/.codex/skills/pr-governance-review/scripts/test_pr_review_checklist.py
@@ -14,6 +14,8 @@ def _fake_report(
     contract_set: str = "general",
     findings: list[dict] | None = None,
     related_files: list[str] | None = None,
+    ci_status_gate: str = "SUCCESS",
+    current_checks: list[dict] | None = None,
 ) -> OrderedDict:
     findings = findings or []
     report = OrderedDict(
@@ -34,7 +36,10 @@ def _fake_report(
         changed_files=files,
         contract_set=contract_set,
         surface_tags=[],
-        current_ci_status_gate="SUCCESS",
+        current_ci_status_gate=ci_status_gate,
+        current_checks=current_checks or [
+            OrderedDict(name="CI Status Gate", conclusion=ci_status_gate)
+        ],
         findings=findings,
         exact_file_overlap=[],
         concept_overlap=[],
@@ -157,6 +162,45 @@ def test_pure_test_report_can_merge_now() -> None:
     _assert(decision["lane"] == "merge_now", "pure test proof with no findings can merge")
 
 
+def test_failing_required_gate_excluded_from_executable_trains() -> None:
+    failing = _fake_report(
+        7,
+        ["docs/failing.md"],
+        lane="merge_now",
+        ci_status_gate="FAILURE",
+    )
+    healthy = _fake_report(8, ["docs/healthy.md"], lane="merge_now")
+    graph = checklist._build_train_graph(
+        [failing, healthy],
+        queue_cohort_size=4,
+        max_parallel_patch_trains=3,
+    )
+    _assert(graph["queue_cohorts"][0]["prs"] == [8], "failing required gate must not enter queue cohort")
+    _assert(graph["check_failure_holds"][0]["pr"] == 7, "failing required gate must be reported as a hold")
+    _assert(not checklist._is_actionable_live_candidate(failing), "failing required gate must not be actionable")
+
+
+def test_failing_auxiliary_check_excluded_from_operator_batches() -> None:
+    aux_failing = _fake_report(
+        9,
+        ["docs/a.md"],
+        lane="merge_now",
+        current_checks=[
+            OrderedDict(name="CI Status Gate", conclusion="SUCCESS"),
+            OrderedDict(name="Markdown Lint", conclusion="FAILURE"),
+        ],
+    )
+    peer = _fake_report(10, ["docs/a.md"], lane="merge_now")
+    graph = checklist._build_train_graph(
+        [aux_failing, peer],
+        queue_cohort_size=4,
+        max_parallel_patch_trains=3,
+    )
+    _assert(not graph["collision_groups"], "aux-failing PR must not create executable collision train")
+    _assert(graph["queue_cohorts"][0]["prs"] == [10], "aux-failing PR must not enter queue cohort")
+    _assert(not checklist._is_actionable_live_candidate(aux_failing), "aux-failing PR must not be actionable")
+
+
 def main() -> int:
     test_same_file_collision()
     test_disjoint_merge_queue_cohort()
@@ -164,6 +208,8 @@ def main() -> int:
     test_patch_gate_blocks_unattached_export()
     test_patch_gate_allows_canonical_attach_point()
     test_pure_test_report_can_merge_now()
+    test_failing_required_gate_excluded_from_executable_trains()
+    test_failing_auxiliary_check_excluded_from_operator_batches()
     print("pr_review_checklist unit tests passed")
     return 0
 


### PR DESCRIPTION
## Summary

Tightens the PR governance SOP so PRs with non-green required gates, missing gates, or failing current auxiliary checks are not considered executable train candidates.

## Changes

- Adds a check-failure intake filter to the PR train SOP and operator output contract.
- Excludes check-failure PRs from queue cohorts, patch trains, collision trains, decision waves, and recommended operator batches unless the task is explicitly CI repair.
- Adds `Check Failure Holds` to live reports and explicit batch reports.
- Adds unit coverage for required-gate failures and auxiliary-check failures.

## Verification

- `python3 -m py_compile .codex/skills/pr-governance-review/scripts/pr_review_checklist.py .codex/skills/pr-governance-review/scripts/test_pr_review_checklist.py`
- `python3 .codex/skills/pr-governance-review/scripts/test_pr_review_checklist.py`
- `python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --prs 629,812,948,912 --text`
- `python3 .codex/skills/codex-skill-authoring/scripts/truth_first_smoke.py`
- `python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py`
- `git diff --check`

_codex skills used: `pr-governance-review`, `agent-orchestration-governance`, `codex-skill-authoring`_