### PR TITLE
chore: add maintainer harvest attribution governance

### DIFF
--- a/.codex/skills/github-contribution-governance/SKILL.md
+++ b/.codex/skills/github-contribution-governance/SKILL.md
@@ -34,6 +34,7 @@ Non-owned surfaces:
 3. Diagnose why a commit, branch, or PR is not showing on the GitHub contribution graph.
 4. Keep daily contribution work on a PR path into `main`, `develop`, or the repository default branch.
 5. Check that GitHub attributes pushed commits to the intended account via the GitHub API.
+6. Build maintainer-harvest attribution plans that separate official GitHub commit credit from public acknowledgement and internal impact credit.
 
 ## Do Not Use
 
@@ -69,6 +70,16 @@ Non-owned surfaces:
    - amend/rebase those commits with the verified email and force-push the feature branch before merge
    - create a new correctly-authored follow-up commit and merge it
    Do not rewrite shared history without explicit branch-level approval.
+10. For maintainer-harvest PRs, decide attribution before the commit lands:
+   - use `Co-authored-by:` trailers only when contributor code or tests are
+     materially reused in the actual landing commit
+   - use public GitHub no-reply identities derived from the contributor's
+     public user id and login, or another verified address provided by the
+     contributor
+   - never expose private emails from `gh api user/emails`
+   - if only the idea/direction is used, record public acknowledgement and
+     internal dashboard harvest credit instead of co-authoring
+   - never rewrite `main` to retrofit co-author credit after merge
 
 ## Handoff Rules
 

--- a/.codex/skills/pr-governance-review/SKILL.md
+++ b/.codex/skills/pr-governance-review/SKILL.md
@@ -100,12 +100,19 @@ Load these only when the decision needs them:
 10. If a PR title/body claims one contract but the changed files touch another, stop the merge path until the PR is retitled/rescoped, patched to the claimed contract, or closed/requested-changes.
 11. If a PR says it is stacked, depends on a prior PR, or will have a different diff after another PR lands, do not review it as a merge candidate until it is rebased to `main` or explicitly scoped as a harvest/reference PR.
 12. Treat local worktree overlap as a merge blocker. If an open PR touches files with uncommitted maintainer changes, resolve local ownership first: commit/stash/rebase the maintainer branch, harvest only unique PR value, or request a contributor rebase. Do not merge a GitHub-green head over active local governance/product work.
-13. Run the Founder Wiki North-Star Probe for material PRs that touch product direction, One/Kai/Nav, PCHP, BYOA/BYOK, MLX/on-device posture, consent/vault/PKM, World Model, voice/action, Aha Moment, user-facing workflows, or founder-language claims. Use `.codex/skills/codex-skill-authoring/references/founder-wiki-north-star-probe.md` as the contract:
+13. Before creating a maintainer-harvest commit, run the contributor
+    attribution gate. Prefer direct contributor PR merge when the head is safe.
+    If maintainers materially reuse contributor code or tests, add valid
+    `Co-authored-by:` trailers to the actual landing commit using public
+    GitHub no-reply identities when verified. If only the idea or direction is
+    used, do not add a co-author trailer; include a contributor
+    acknowledgement in the PR body and source-PR closeout instead.
+14. Run the Founder Wiki North-Star Probe for material PRs that touch product direction, One/Kai/Nav, PCHP, BYOA/BYOK, MLX/on-device posture, consent/vault/PKM, World Model, voice/action, Aha Moment, user-facing workflows, or founder-language claims. Use `.codex/skills/codex-skill-authoring/references/founder-wiki-north-star-probe.md` as the contract:
    - repo code/contracts/tests/CI remain current-state truth
    - founder wiki pages define north-star and future-state alignment
    - conflicts are `current_state_vs_north_star_drift`
    - private wiki evidence stays local-only and must not be cited in public GitHub comments
-14. For high-volume PR train work, spawn/read from the required read-only
+15. For high-volume PR train work, spawn/read from the required read-only
     subagent taskforce before producing the operator dossier. High-volume means
     more than `20` PRs scanned or discussed, more than `5` PRs acted on in one
     session, any mixed frontend/backend/security/devex/observability train, any
@@ -114,11 +121,11 @@ Load these only when the decision needs them:
     Use the delegation router to choose lanes and record whether evidence lanes
     were used:
    `python3 .codex/skills/agent-orchestration-governance/scripts/delegation_router.py --workflow pr-governance-review --phase start --prompt "<request>" --paths "<paths>" --text`
-15. If subagents are unavailable, record `Subagent taskforce: unavailable` and
+16. If subagents are unavailable, record `Subagent taskforce: unavailable` and
     manually cover the same evidence lanes. If they are available, skipping
     them for high-volume train work is a process violation unless a concrete
     runtime blocker is recorded.
-16. Keep final authority local to the parent/governor. Do not delegate branch switching, approval, merge, deploy, credential handling, or final decision.
+17. Keep final authority local to the parent/governor. Do not delegate branch switching, approval, merge, deploy, credential handling, or final decision.
 
 ### Decision Order
 
@@ -333,9 +340,15 @@ Default blockers include:
 6. If a PR can be corrected safely by maintainers without changing product intent, prefer `patch_then_merge` over contributor round trips. Use a `## Changes Requested` record when the change needs contributor clarity, split/rebase, proof, or direction correction.
 7. Public duplicate language is allowed only for exact or manually confirmed semantic duplicates. Shared files alone mean sequencing/rebase, not duplicate.
 8. Maintainer patches must be explained in the post-merge note: who patched, what changed, what original PR value was kept, what was converted into existing canonical docs/scripts/runtime surfaces, what was dropped or deferred, why this was the smallest safe path, and what happened to related PRs.
-9. Do not include a separate successful-merge evidence section such as `### Merge Confidence`, `### Proof`, or `### Verification`; GitHub already shows checks. Use `### Why It Matters` in post-merge comments.
-10. Do not publish maintainer-only sequencing, CI dumps, or report bookkeeping in GitHub comments.
-11. Final handoffs for state-changing PR work must include direct links to every affected PR and any maintainer-authored merge/patch/closure/comment links. Counts are allowed only after the linked PR list; never replace the list with a count.
+9. Maintainer-harvest PR bodies must include `## Contributor Acknowledgements`
+   with source PR links, source authors, accepted value, dropped/deferred
+   pieces, and whether official GitHub commit credit is expected through
+   `Co-authored-by:` trailers. The source PR closeout must use contributor-
+   enabling language: "your contribution was harvested into..." rather than
+   implying discarded work.
+10. Do not include a separate successful-merge evidence section such as `### Merge Confidence`, `### Proof`, or `### Verification`; GitHub already shows checks. Use `### Why It Matters` in post-merge comments.
+11. Do not publish maintainer-only sequencing, CI dumps, or report bookkeeping in GitHub comments.
+12. Final handoffs for state-changing PR work must include direct links to every affected PR and any maintainer-authored merge/patch/closure/comment links. Counts are allowed only after the linked PR list; never replace the list with a count.
 
 Detailed comment/report format lives in `references/comment-and-report-contract.md`.
 
@@ -360,6 +373,10 @@ After any merge, close, requested-changes, maintainer patch, or revert:
    `python3 .codex/skills/pr-governance-review/scripts/contributor_impact_report.py --repo hushh-labs/hushh-research --days 14 --text > tmp/contributor-impact-dashboard.md`
 3. Keep live reports live-only. Merged/closed evidence belongs in GitHub comments, final handoff, or separate audit artifacts.
 4. Include contributor-impact delta when the PR materially affects trust/security, consent/vault, One/Kai/Nav direction, PKM/memory, user utility, runtime quality, or proof/test posture.
+5. Past maintainer harvests must not rewrite `main` for retroactive GitHub
+   graph credit. Preserve public acknowledgement and ensure the dashboard
+   records `harvested_source` internal impact credit for every source PR whose
+   value landed through a maintainer patch.
 
 ## Handoff Rules
 
@@ -386,6 +403,7 @@ python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo
 python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --prs 488,489 --text
 python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --live-report --scan-mode hybrid --limit 100 --candidate-limit 40 --text --output tmp/pr-governance-live-report.md
 python3 -m py_compile .codex/skills/pr-governance-review/scripts/contributor_impact_report.py
+python3 .codex/skills/pr-governance-review/scripts/test_contributor_impact_report.py
 python3 .codex/skills/pr-governance-review/scripts/contributor_impact_report.py --repo hushh-labs/hushh-research --days 14 --text
 ./bin/hushh codex audit --text
 ./bin/hushh docs verify

--- a/.codex/skills/pr-governance-review/references/operator-batch-output-contract.md
+++ b/.codex/skills/pr-governance-review/references/operator-batch-output-contract.md
@@ -50,7 +50,13 @@ sequence in the sections below.
    - `new_closed_superseded_comment`
    - `no_comment_review_only`
    Include the intended headline, for example `## Merged: Consent Center State UX`.
-9. `Per-PR Assessment`: one compact but complete block per PR:
+9. `Contributor Attribution`: for every maintainer-harvest source PR, state
+   whether the landing commit will use `Co-authored-by:` trailers
+   (`code_or_test_reused`), public acknowledgement only
+   (`idea_or_direction_used`), or no credit because the material is not used.
+   Include source PR link, author, accepted value, dropped/deferred pieces, and
+   whether GitHub official contributor graph credit is expected.
+10. `Per-PR Assessment`: one compact but complete block per PR:
    - direct link
    - lane
    - lean/core risk
@@ -61,12 +67,12 @@ sequence in the sections below.
    - planned action: merge, patch/rebase, harvest/close, request changes, or hold
    - comment action: expected public comment/edit behavior
    - `Smallest proof`: smallest authoritative check before that action
-10. `Output`: intended end state if the batch is legitimate.
-11. `Execution`: exact order, split by merge train, patch train, closure/request-changes wave, and hold/deep-review items.
-12. `Decision Questions`: only unresolved user-owned choices, each with current truth, recommended path, risk if accepted blindly, and recommended option first.
-13. `Stop Conditions`: what pauses, splits, or blocks the batch.
-14. `Verification`: smallest authoritative local and GitHub checks.
-15. `After-Merge Kickoff`: how the next independent train will be discovered after report refresh.
+11. `Output`: intended end state if the batch is legitimate.
+12. `Execution`: exact order, split by merge train, patch train, closure/request-changes wave, and hold/deep-review items.
+13. `Decision Questions`: only unresolved user-owned choices, each with current truth, recommended path, risk if accepted blindly, and recommended option first.
+14. `Stop Conditions`: what pauses, splits, or blocks the batch.
+15. `Verification`: smallest authoritative local and GitHub checks.
+16. `After-Merge Kickoff`: how the next independent train will be discovered after report refresh.
 
 Hyperlink rule: any chat answer, execution update, or final handoff generated
 from this contract must hyperlink every PR it mentions. Counts-only summaries
@@ -126,23 +132,27 @@ even when the report already exists on disk:
    Repass/correction waves must prefer edited maintainer records over new
    comments. If a new comment is needed, state why the previous maintainer
    record could not be edited.
-6. Check-failure intake filter: PRs with non-green/missing required gates or
+6. Contributor attribution: maintainer-harvest batches must distinguish
+   official GitHub commit credit from public acknowledgement and internal
+   dashboard credit. Do not promise GitHub contributor graph credit unless the
+   actual landing commit contains valid `Co-authored-by:` trailers.
+7. Check-failure intake filter: PRs with non-green/missing required gates or
    current failing auxiliary checks are excluded from train planning and should
    appear only under `Check Failure Holds` unless this is a CI repair pass.
-7. Stop conditions: stale head, lost CI Status Gate, conflict, exact-file
+8. Stop conditions: stale head, lost CI Status Gate, conflict, exact-file
    overlap, new trust-boundary finding, missing caller/reachability proof,
    Playwright gap for UI-visible changes, or north-star drift.
-8. Train graph: every PR must expose `collision_group_id`,
+9. Train graph: every PR must expose `collision_group_id`,
    `collision_reasons`, `can_queue_with`, `must_wait_for`,
    `queue_cohort_id`, `parallel_patch_train_id`, patch attachment fields, and
    whether a north-star probe is required.
-9. Subagent taskforce: for high-volume train work, every dossier must state the
+10. Subagent taskforce: for high-volume train work, every dossier must state the
    read-only evidence lanes used before the recommendation. The default lanes
    are frontend/UI reachability, backend/runtime trust, observability/security,
    devex/repo operations, and decision-wave communications. If a lane was not
    spawned, state the concrete blocker; "not needed" is valid only for
    single-surface or low-volume work.
-10. Train-to-subagent map: every async train must name its subagent evidence
+11. Train-to-subagent map: every async train must name its subagent evidence
    lane, the PRs included in that train, which PRs are parallel outside the
    train, which PRs are sequential inside the train, and which hard edge forces
    the sequence. If two trains need the same files/runtime family, they are not

--- a/.codex/skills/pr-governance-review/references/pr-train-review-sop.md
+++ b/.codex/skills/pr-governance-review/references/pr-train-review-sop.md
@@ -221,6 +221,49 @@ Patch is denied when:
 Denied patch candidates become `changes_requested`, `hold`, or
 `harvest_then_close`, depending on whether there is useful value to preserve.
 
+## Contributor Attribution Gate
+
+Maintainer harvests must enable contributors, not erase them.
+
+Before opening or committing a maintainer-harvest PR:
+
+1. Prefer direct contributor PR merge when the PR is clean, scoped, green,
+   canonical, and safe.
+2. For every harvested source PR, classify the reused material as:
+   - `code_or_test_reused`: actual contributor implementation or test logic is
+     materially copied, translated, or normalized into the landing patch
+   - `idea_or_direction_used`: the PR helped identify the right fix, but the
+     landing implementation is independently authored by the maintainer
+   - `not_used`: reviewed but not part of the landing patch
+3. For `code_or_test_reused`, add valid `Co-authored-by:` trailers to the
+   actual landing commit before merge. Use public GitHub no-reply identities
+   only after verifying the contributor's public GitHub user id; never expose
+   private emails.
+4. For `idea_or_direction_used`, do not add co-author trailers. Add the source
+   PR to `## Contributor Acknowledgements` in the PR body and source-PR
+   closeout.
+5. For `not_used`, list the PR only under dropped/deferred/held work, not as a
+   credited harvest source.
+
+Maintainer-harvest PR bodies must include:
+
+1. `## Contributor Acknowledgements`
+2. direct source PR link
+3. source author
+4. accepted value
+5. attribution class: `code_or_test_reused`, `idea_or_direction_used`, or
+   `not_used`
+6. whether official GitHub commit credit is expected
+7. dropped or deferred pieces
+
+Past maintainer harvests must not rewrite `main` to backfill GitHub graph
+credit. The fair retroactive path is:
+
+1. preserve or add public acknowledgement on the landing PR
+2. keep source PR closeouts contributor-enabling
+3. update the contributor-impact dashboard with `harvested_source` internal
+   credit for source PRs whose value landed through a maintainer patch
+
 ## Developer Operating Loop
 
 Use this loop for every review session:

--- a/.codex/skills/pr-governance-review/scripts/contributor_impact_report.py
+++ b/.codex/skills/pr-governance-review/scripts/contributor_impact_report.py
@@ -27,6 +27,88 @@ GH_FIELDS = (
 )
 
 
+HARVEST_CREDITS: dict[int, list[dict[str, str | int]]] = {
+    1013: [
+        {
+            "source_pr": 808,
+            "author": "imsharukhan",
+            "accepted_value": "Top app bar back affordance touch target.",
+        },
+        {
+            "source_pr": 810,
+            "author": "imsharukhan",
+            "accepted_value": "Settings drawer safe-area bottom padding.",
+        },
+        {
+            "source_pr": 809,
+            "author": "imsharukhan",
+            "accepted_value": "RIA status panel responsive grid.",
+        },
+        {
+            "source_pr": 811,
+            "author": "imsharukhan",
+            "accepted_value": "Onboarding carousel accessible labels.",
+        },
+        {
+            "source_pr": 942,
+            "author": "smirthi-dharma",
+            "accepted_value": "Shared UI accessibility regression coverage.",
+        },
+        {
+            "source_pr": 967,
+            "author": "smirthi-dharma",
+            "accepted_value": "Diagnostic observability log redaction helper.",
+        },
+        {
+            "source_pr": 1001,
+            "author": "smirthi-dharma",
+            "accepted_value": "Reachable observability client redaction attach point.",
+        },
+        {
+            "source_pr": 931,
+            "author": "anshul23102",
+            "accepted_value": "Bounded Kai market-data cache growth control.",
+        },
+        {
+            "source_pr": 924,
+            "author": "anshul23102",
+            "accepted_value": "Bounded Kai market-data lock growth control.",
+        },
+        {
+            "source_pr": 1002,
+            "author": "anshul23102",
+            "accepted_value": "Bounded Kai provider cooldown growth control.",
+        },
+        {
+            "source_pr": 943,
+            "author": "suyashkumar102",
+            "accepted_value": "UID-safe Kai chat auth-mismatch logging.",
+        },
+        {
+            "source_pr": 913,
+            "author": "anshul23102",
+            "accepted_value": "Kai chat pagination query bounds.",
+        },
+        {
+            "source_pr": 934,
+            "author": "anshul23102",
+            "accepted_value": "Marketplace public query filter bounds.",
+        },
+        {
+            "source_pr": 926,
+            "author": "anshul23102",
+            "accepted_value": "RIA client query filter bounds.",
+        },
+    ],
+}
+
+HARVEST_SOURCE_INDEX: dict[int, dict[str, str | int]] = {
+    int(source["source_pr"]): {"landing_pr": landing_pr, **source}
+    for landing_pr, sources in HARVEST_CREDITS.items()
+    for source in sources
+}
+
+
 @dataclass(frozen=True)
 class Window:
     label: str
@@ -365,6 +447,18 @@ def _author(pr: dict[str, Any]) -> str:
     return author.get("login") or "unknown"
 
 
+def _harvest_credit(pr_number: int) -> dict[str, str | int] | None:
+    return HARVEST_SOURCE_INDEX.get(pr_number)
+
+
+def _pr_url(number: int) -> str:
+    return f"https://github.com/{DEFAULT_REPO}/pull/{number}"
+
+
+def _pr_link(number: int) -> str:
+    return f"[#{number}]({_pr_url(number)})"
+
+
 def _label_names(pr: dict[str, Any]) -> list[str]:
     return [label.get("name", "") for label in pr.get("labels") or [] if isinstance(label, dict)]
 
@@ -446,6 +540,8 @@ def _lifecycle(pr: dict[str, Any]) -> str:
     curated = CURATED_NOTES.get(int(pr["number"]), {})
     if curated.get("lifecycle"):
         return str(curated["lifecycle"])
+    if _harvest_credit(int(pr["number"])) and not pr.get("mergedAt"):
+        return "harvested_source"
     title = pr.get("title", "").lower()
     comments = _comments_text(pr).lower()
     if pr.get("mergedAt"):
@@ -467,6 +563,12 @@ def _impact_reason(pr: dict[str, Any], vectors: list[str], lifecycle: str) -> st
     curated = CURATED_NOTES.get(int(pr["number"]), {})
     if curated.get("note"):
         return str(curated["note"])
+    harvest = _harvest_credit(int(pr["number"]))
+    if lifecycle == "harvested_source" and harvest:
+        return (
+            f"Harvested into #{harvest['landing_pr']}: "
+            f"{harvest['accepted_value']}"
+        )
     if lifecycle == "revert_correction":
         return "Corrected a prior surface that was no longer aligned with the current architecture."
     if "trust/security" in vectors:
@@ -492,6 +594,7 @@ def _impact_score(pr: dict[str, Any]) -> int:
         "patched_then_merged": 14,
         "revert_correction": 18,
         "merged_then_reverted": -8,
+        "harvested_source": 12,
         "closed_duplicate": 8,
         "closed_drift": 5,
         "changes_requested": 3,
@@ -510,7 +613,7 @@ def _impact_score(pr: dict[str, Any]) -> int:
         score -= 5
     if "buy" in haystack or "not-buy" in haystack or "sell" in haystack:
         score -= 14
-    if "duplicate" in haystack or "superseded" in haystack:
+    if lifecycle != "harvested_source" and ("duplicate" in haystack or "superseded" in haystack):
         score -= 6
     if "ipl" in haystack or "arena" in haystack:
         score -= 18
@@ -524,11 +627,12 @@ def _analysis(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
     for pr in records:
         vectors = _vectors(pr)
         lifecycle = _lifecycle(pr)
+        harvest = _harvest_credit(int(pr["number"]))
         analyzed.append(
             {
                 "number": int(pr["number"]),
                 "title": pr.get("title", ""),
-                "author": _author(pr),
+                "author": str(harvest["author"]) if harvest else _author(pr),
                 "url": pr.get("url", ""),
                 "createdAt": pr.get("createdAt"),
                 "mergedAt": pr.get("mergedAt"),
@@ -541,6 +645,9 @@ def _analysis(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 "additions": int(pr.get("additions") or 0),
                 "deletions": int(pr.get("deletions") or 0),
                 "changedFiles": int(pr.get("changedFiles") or 0),
+                "harvestedInto": int(harvest["landing_pr"]) if harvest else None,
+                "harvestAcceptedValue": str(harvest["accepted_value"]) if harvest else "",
+                "officialGitHubContributorCredit": bool(pr.get("mergedAt")),
             }
         )
     return analyzed
@@ -557,6 +664,7 @@ def _leaderboard(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 "resolved": 0,
                 "merged": 0,
                 "patched": 0,
+                "harvested": 0,
                 "closed": 0,
                 "reverted": 0,
                 "top": [],
@@ -566,6 +674,7 @@ def _leaderboard(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
         row["resolved"] += 1
         row["merged"] += 1 if item["mergedAt"] else 0
         row["patched"] += 1 if item["lifecycle"] == "patched_then_merged" else 0
+        row["harvested"] += 1 if item["lifecycle"] == "harvested_source" else 0
         row["closed"] += 1 if not item["mergedAt"] else 0
         row["reverted"] += 1 if item["lifecycle"] in {"revert_correction", "merged_then_reverted"} else 0
         row["top"].append(item)
@@ -710,6 +819,7 @@ def _kpis(records: list[dict[str, Any]]) -> dict[str, Any]:
         "median_resolution_days": round(_median(resolution_days), 1),
         "contributors_represented": len({item["author"] for item in records}),
         "patched_then_merged_prs": lifecycle_counts["patched_then_merged"],
+        "harvested_source_prs": lifecycle_counts["harvested_source"],
         "closed_duplicate_or_drift_prs": lifecycle_counts["closed_duplicate"] + lifecycle_counts["closed_drift"],
         "reverted_or_corrected_prs": corrected,
         "governance_intervention_load": _percent(governance_interventions, resolved),
@@ -739,13 +849,13 @@ def _topper_lines(records: list[dict[str, Any]], window: Window, limit: int = 10
     lines = [
         f"- Window: {_window_display(window)}",
         "",
-        "| Rank | Contributor | Impact Score | Resolved | Merged | Patched | Closed | Corrected | Top PRs |",
-        "| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+        "| Rank | Contributor | Impact Score | Resolved | Merged | Patched | Harvested | Closed | Corrected | Top PRs |",
+        "| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
     ]
     for idx, row in enumerate(rows, start=1):
         lines.append(
             f"| {idx} | `{_cell(row['author'])}` | {row['score']} | {row['resolved']} | "
-            f"{row['merged']} | {row['patched']} | {row['closed']} | {row['reverted']} | "
+            f"{row['merged']} | {row['patched']} | {row['harvested']} | {row['closed']} | {row['reverted']} | "
             f"{', '.join(_link(item) for item in row['top'])} |"
         )
     return lines
@@ -796,8 +906,8 @@ def _scoreboard_lines(
         f"- Primary: {_window_display(primary_window)}",
         f"- Overall: {_window_display(overall_window)}",
         "",
-        "| Rank | Contributor | Weekly Score | Primary Score | Overall Score | Primary PRs | Primary Merged | Overall PRs | Overall Merged |",
-        "| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+        "| Rank | Contributor | Weekly Score | Primary Score | Overall Score | Primary PRs | Primary Merged | Primary Harvested | Overall PRs | Overall Merged | Overall Harvested |",
+        "| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
     ]
     for idx, author in enumerate(ranked, start=1):
         lines.append(
@@ -807,8 +917,10 @@ def _scoreboard_lines(
             f"{value(overall, author, 'score')} | "
             f"{value(primary, author, 'resolved')} | "
             f"{value(primary, author, 'merged')} | "
+            f"{value(primary, author, 'harvested')} | "
             f"{value(overall, author, 'resolved')} | "
-            f"{value(overall, author, 'merged')} |"
+            f"{value(overall, author, 'merged')} | "
+            f"{value(overall, author, 'harvested')} |"
         )
     return lines
 
@@ -851,6 +963,7 @@ def _kpi_lines(kpis: dict[str, Any]) -> list[str]:
         "median_resolution_days": "Median PR resolution time (days)",
         "contributors_represented": "Contributors represented",
         "patched_then_merged_prs": "Patched-then-merged PRs",
+        "harvested_source_prs": "Harvested source PRs",
         "closed_duplicate_or_drift_prs": "Closed duplicate/drift PRs",
         "reverted_or_corrected_prs": "Reverted/corrected PRs",
         "governance_intervention_load": "Governance intervention load",
@@ -877,6 +990,7 @@ def _kpi_comparison_lines(primary_kpis: dict[str, Any], overall_kpis: dict[str, 
         ("merge_rate", "Merge rate"),
         ("median_resolution_days", "Median PR resolution time"),
         ("contributors_represented", "Contributors represented"),
+        ("harvested_source_prs", "Harvested source PRs"),
         ("trust_security_prs", "Trust/security PRs"),
         ("consent_vault_prs", "Consent/vault PRs"),
         ("one_kai_nav_alignment_prs", "One/Kai/Nav alignment PRs"),
@@ -993,6 +1107,7 @@ def _lifecycle_mix_lines(records: list[dict[str, Any]]) -> list[str]:
     lifecycle_labels = {
         "merged": "Merged",
         "patched_then_merged": "Patched then merged",
+        "harvested_source": "Harvested source",
         "revert_correction": "Revert correction",
         "merged_then_reverted": "Merged then reverted",
         "closed_duplicate": "Closed duplicate",
@@ -1068,6 +1183,33 @@ def _most_impactful(records: list[dict[str, Any]], limit: int = 10) -> list[str]
     return lines or ["- No resolved PRs in this window."]
 
 
+def _harvest_attribution_lines(records: list[dict[str, Any]]) -> list[str]:
+    harvested = [
+        item for item in records if item.get("lifecycle") == "harvested_source"
+    ]
+    if not harvested:
+        return [
+            "- No maintainer-harvest source credits detected in this window.",
+        ]
+    lines = [
+        "These are internal Hussh impact credits for contributor PRs whose useful value was harvested into a maintainer patch. They do not change GitHub's official contributor graph for already-merged commits.",
+        "",
+        "| Source PR | Contributor | Landing PR | Accepted Value | Official GitHub Commit Credit |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for item in sorted(
+        harvested,
+        key=lambda row: (int(row.get("harvestedInto") or 0), int(row["number"])),
+    ):
+        landing = int(item.get("harvestedInto") or 0)
+        lines.append(
+            f"| {_link(item)} | `{_cell(item['author'])}` | {_pr_link(landing) if landing else 'n/a'} | "
+            f"{_cell(item.get('harvestAcceptedValue') or item['reason'])} | "
+            "No, because the landed commit was not co-authored. |"
+        )
+    return lines
+
+
 def _corrections(records: list[dict[str, Any]], limit: int = 10) -> list[str]:
     corrections = [
         item
@@ -1111,6 +1253,7 @@ def _report_text(
         "",
         "- [Executive Summary](#executive-summary)",
         "- [GitHub Coverage Audit](#github-coverage-audit)",
+        "- [Harvest Attribution](#harvest-attribution)",
         "- [KPI Board](#kpi-board)",
         "- [Visual Insights](#visual-insights)",
         "- [Primary And Overall Scoreboard](#primary-and-overall-scoreboard)",
@@ -1130,12 +1273,18 @@ def _report_text(
         f"- Merged PRs: `{kpis['merged_prs']}`.",
         f"- Merge rate: `{kpis['merge_rate']}` with median PR resolution time `{kpis['median_resolution_days']}` days.",
         f"- Contributors represented: `{kpis['contributors_represented']}`.",
+        f"- Harvested source PRs credited internally: `{kpis['harvested_source_prs']}`.",
         f"- Governance intervention load: `{kpis['governance_intervention_load']}` across duplicate, drift, and revert/correction work.",
-        "- KPI model: combines DORA-style throughput/stability, SPACE-style multidimensional productivity, and Hussh north-star impact. Raw PR count is never the winner by itself.",
+        "- KPI model: combines DORA-style throughput/stability, SPACE-style multidimensional productivity, Hussh north-star impact, and internal maintainer-harvest source credit. Raw PR count is never the winner by itself.",
+        "- GitHub official contributor credit still follows Git commit authorship and valid `Co-authored-by` trailers; comments and PR references are internal/public acknowledgement only.",
         "",
         "## GitHub Coverage Audit",
         "",
         *_github_audit_lines(github_insights, overall_window),
+        "",
+        "## Harvest Attribution",
+        "",
+        *_harvest_attribution_lines(records),
         "",
         "## KPI Board",
         "",
@@ -1218,6 +1367,7 @@ def _json_payload(
         "github_insights": github_insights,
         "kpis": _kpis(records),
         "overall_kpis": _kpis(overall_records),
+        "harvest_credits": HARVEST_CREDITS,
         "leaderboard": _leaderboard(records),
         "weekly_top_10": {
             "window": {

--- a/.codex/skills/pr-governance-review/scripts/test_contributor_impact_report.py
+++ b/.codex/skills/pr-governance-review/scripts/test_contributor_impact_report.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("contributor_impact_report.py")
+SPEC = importlib.util.spec_from_file_location("contributor_impact_report", SCRIPT)
+assert SPEC and SPEC.loader
+report = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = report
+SPEC.loader.exec_module(report)
+
+
+def _assert(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def _fake_pr(number: int, author: str, title: str) -> dict[str, object]:
+    return {
+        "number": number,
+        "title": title,
+        "author": {"login": author},
+        "url": f"https://github.com/hushh-labs/hushh-research/pull/{number}",
+        "createdAt": "2026-05-14T00:00:00Z",
+        "closedAt": "2026-05-14T01:00:00Z",
+        "mergedAt": None,
+        "additions": 12,
+        "deletions": 4,
+        "changedFiles": 1,
+        "labels": [],
+        "files": [{"path": "hushh-webapp/components/app-ui/top-app-bar.tsx"}],
+        "comments": [{"body": "Closed as superseded after maintainer harvest."}],
+    }
+
+
+def test_harvested_source_gets_internal_credit() -> None:
+    records = report._analysis(
+        [_fake_pr(808, "imsharukhan", "fix: improve TopAppBar back button touch target")]
+    )
+
+    item = records[0]
+    _assert(item["lifecycle"] == "harvested_source", "source PR must be a harvest lifecycle")
+    _assert(item["author"] == "imsharukhan", "source author must keep credit")
+    _assert(item["harvestedInto"] == 1013, "source PR must link to maintainer landing PR")
+    _assert(item["score"] > 0, "harvested source must receive positive internal impact")
+
+    leaderboard = report._leaderboard(records)
+    _assert(leaderboard[0]["harvested"] == 1, "leaderboard must count harvest credits")
+
+
+if __name__ == "__main__":
+    test_harvested_source_gets_internal_credit()
+    print("contributor impact tests passed")

--- a/.codex/skills/pr-governance-review/skill.json
+++ b/.codex/skills/pr-governance-review/skill.json
@@ -46,6 +46,7 @@
     "python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --prs 488,489 --text",
     "python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --live-report --scan-mode hybrid --limit 100 --candidate-limit 40 --text --output tmp/pr-governance-live-report.md",
     "python3 -m py_compile .codex/skills/pr-governance-review/scripts/contributor_impact_report.py",
+    "python3 .codex/skills/pr-governance-review/scripts/test_contributor_impact_report.py",
     "python3 .codex/skills/pr-governance-review/scripts/contributor_impact_report.py --repo hushh-labs/hushh-research --days 14 --text",
     "./bin/hushh codex audit --text",
     "./bin/hushh docs verify"
@@ -66,6 +67,7 @@
         "python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --prs 488,489 --text",
         "python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --live-report --scan-mode hybrid --limit 100 --candidate-limit 40 --text --output tmp/pr-governance-live-report.md",
         "python3 -m py_compile .codex/skills/pr-governance-review/scripts/contributor_impact_report.py",
+        "python3 .codex/skills/pr-governance-review/scripts/test_contributor_impact_report.py",
         "python3 .codex/skills/pr-governance-review/scripts/contributor_impact_report.py --repo hushh-labs/hushh-research --days 14 --text",
         "./bin/hushh codex audit --text",
         "./bin/hushh docs verify"
@@ -83,6 +85,7 @@
         "python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --prs 488,489 --text",
         "python3 .codex/skills/pr-governance-review/scripts/pr_review_checklist.py --repo hushh-labs/hushh-research --live-report --scan-mode hybrid --limit 100 --candidate-limit 40 --text --output tmp/pr-governance-live-report.md",
         "python3 -m py_compile .codex/skills/pr-governance-review/scripts/contributor_impact_report.py",
+        "python3 .codex/skills/pr-governance-review/scripts/test_contributor_impact_report.py",
         "python3 .codex/skills/pr-governance-review/scripts/contributor_impact_report.py --repo hushh-labs/hushh-research --days 14 --text",
         "./bin/hushh codex audit --text",
         "./bin/hushh docs verify"


### PR DESCRIPTION
## Summary

Adds attribution governance for maintainer-harvest PRs so contributor value is not erased when maintainers land a normalized patch.

## What Changed

- Requires future maintainer-harvest PRs to classify each source PR as `code_or_test_reused`, `idea_or_direction_used`, or `not_used`.
- Requires valid `Co-authored-by:` trailers on the actual landing commit when contributor code/tests are materially reused.
- Keeps acknowledgement-only paths for idea/direction use and explicitly avoids retroactive `main` rewrites for already-merged patches.
- Adds internal `harvested_source` impact credit for the #1013 source PRs in the contributor impact dashboard.
- Adds a focused contributor-impact regression test.

## Verification

- `python3 -m py_compile .codex/skills/pr-governance-review/scripts/contributor_impact_report.py .codex/skills/pr-governance-review/scripts/test_contributor_impact_report.py`
- `python3 .codex/skills/pr-governance-review/scripts/test_contributor_impact_report.py`
- `python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py`
- `python3 .codex/skills/codex-skill-authoring/scripts/truth_first_smoke.py`
- `git diff --check`

_codex skills used: `pr-governance-review`, `github-contribution-governance`, `codex-skill-authoring`_