### PR TITLE
docs: record official harvest coauthor attribution

### DIFF
--- a/.codex/skills/github-contribution-governance/SKILL.md
+++ b/.codex/skills/github-contribution-governance/SKILL.md
@@ -80,6 +80,12 @@ Non-owned surfaces:
    - if only the idea/direction is used, record public acknowledgement and
      internal dashboard harvest credit instead of co-authoring
    - never rewrite `main` to retrofit co-author credit after merge
+11. If a maintainer harvest already merged without co-author trailers and the
+    operator explicitly wants external GitHub credit, use a transparent
+    non-empty follow-up attribution commit with valid `Co-authored-by:`
+    trailers and a repo ledger entry. Make clear that this credits the
+    follow-up commit; it does not change the original merge commit, line blame,
+    or additions/deletions.
 
 ## Handoff Rules
 

--- a/.codex/skills/pr-governance-review/SKILL.md
+++ b/.codex/skills/pr-governance-review/SKILL.md
@@ -65,6 +65,7 @@ Load these only when the decision needs them:
 3. `.codex/skills/pr-governance-review/references/blocker-gates.md`
 4. `.codex/skills/pr-governance-review/references/comment-and-report-contract.md`
 5. `.codex/skills/pr-governance-review/references/pr-train-review-sop.md`
+6. `.codex/skills/pr-governance-review/references/maintainer-harvest-attribution-ledger.md`
 
 ## Workflow
 
@@ -106,7 +107,11 @@ Load these only when the decision needs them:
     `Co-authored-by:` trailers to the actual landing commit using public
     GitHub no-reply identities when verified. If only the idea or direction is
     used, do not add a co-author trailer; include a contributor
-    acknowledgement in the PR body and source-PR closeout instead.
+    acknowledgement in the PR body and source-PR closeout instead. For an
+    already-merged maintainer harvest, a transparent non-empty attribution
+    follow-up commit can add external GitHub co-author credit only for that
+    follow-up commit; it must not claim to rewrite original line blame or
+    landing-commit authorship.
 14. Run the Founder Wiki North-Star Probe for material PRs that touch product direction, One/Kai/Nav, PCHP, BYOA/BYOK, MLX/on-device posture, consent/vault/PKM, World Model, voice/action, Aha Moment, user-facing workflows, or founder-language claims. Use `.codex/skills/codex-skill-authoring/references/founder-wiki-north-star-probe.md` as the contract:
    - repo code/contracts/tests/CI remain current-state truth
    - founder wiki pages define north-star and future-state alignment

--- a/.codex/skills/pr-governance-review/references/maintainer-harvest-attribution-ledger.md
+++ b/.codex/skills/pr-governance-review/references/maintainer-harvest-attribution-ledger.md
@@ -1,0 +1,54 @@
+# Maintainer Harvest Attribution Ledger
+
+This ledger records maintainer harvests where useful contributor value landed
+through a maintainer-normalized patch instead of a direct source-PR merge.
+
+The goal is fairness without rewriting history:
+
+1. internal Hussh impact credit remains attached to the source PRs
+2. public PR closeouts name the source PRs and accepted value
+3. GitHub-visible co-author credit is added to the actual maintainer landing
+   commit when the attribution decision is made before merge
+4. after a maintainer harvest has already merged without co-author trailers, the
+   only safe external-credit path is a transparent, non-empty follow-up commit
+   with valid `Co-authored-by:` trailers
+
+Do not claim that a follow-up attribution commit changes the original merge
+commit's authorship, line blame, or additions/deletions. It creates a real
+GitHub-visible co-authored record and keeps the prior harvest auditable.
+
+## 2026-05-14: PR #1013 Async PR Train Patch Wave One
+
+Original maintainer landing PR:
+[PR #1013](https://github.com/hushh-labs/hushh-research/pull/1013)
+
+Original merge commit:
+`c150264ae87c12d681210fe43a917a601ab6f57a`
+
+Attribution status:
+
+- The original #1013 merge commit was not co-authored.
+- Source PRs keep internal `harvested_source` impact credit.
+- This non-empty follow-up attribution commit provides GitHub-visible
+  co-author credit for the source contributors listed below once it lands on
+  `main`.
+- Future maintainer harvests should put valid co-author trailers on the actual
+  landing commit before merge when contributor code or test logic is materially
+  reused.
+
+| Source PR | Contributor | Accepted Value |
+| --- | --- | --- |
+| [PR #808](https://github.com/hushh-labs/hushh-research/pull/808) | `imsharukhan` | Top app bar back affordance touch target. |
+| [PR #810](https://github.com/hushh-labs/hushh-research/pull/810) | `imsharukhan` | Settings drawer safe-area bottom padding. |
+| [PR #809](https://github.com/hushh-labs/hushh-research/pull/809) | `imsharukhan` | RIA status panel responsive grid. |
+| [PR #811](https://github.com/hushh-labs/hushh-research/pull/811) | `imsharukhan` | Onboarding carousel accessible labels. |
+| [PR #942](https://github.com/hushh-labs/hushh-research/pull/942) | `smirthi-dharma` | Shared UI accessibility regression coverage. |
+| [PR #967](https://github.com/hushh-labs/hushh-research/pull/967) | `smirthi-dharma` | Diagnostic observability log redaction helper. |
+| [PR #1001](https://github.com/hushh-labs/hushh-research/pull/1001) | `smirthi-dharma` | Reachable observability client redaction attach point. |
+| [PR #931](https://github.com/hushh-labs/hushh-research/pull/931) | `anshul23102` | Bounded Kai market-data cache growth control. |
+| [PR #924](https://github.com/hushh-labs/hushh-research/pull/924) | `anshul23102` | Bounded Kai market-data lock growth control. |
+| [PR #1002](https://github.com/hushh-labs/hushh-research/pull/1002) | `anshul23102` | Bounded Kai provider cooldown growth control. |
+| [PR #943](https://github.com/hushh-labs/hushh-research/pull/943) | `suyashkumar102` | UID-safe Kai chat auth-mismatch logging. |
+| [PR #913](https://github.com/hushh-labs/hushh-research/pull/913) | `anshul23102` | Kai chat pagination query bounds. |
+| [PR #934](https://github.com/hushh-labs/hushh-research/pull/934) | `anshul23102` | Marketplace public query filter bounds. |
+| [PR #926](https://github.com/hushh-labs/hushh-research/pull/926) | `anshul23102` | RIA client query filter bounds. |

--- a/.codex/skills/pr-governance-review/references/pr-train-review-sop.md
+++ b/.codex/skills/pr-governance-review/references/pr-train-review-sop.md
@@ -263,6 +263,11 @@ credit. The fair retroactive path is:
 2. keep source PR closeouts contributor-enabling
 3. update the contributor-impact dashboard with `harvested_source` internal
    credit for source PRs whose value landed through a maintainer patch
+4. if the operator explicitly requests external GitHub credit, add a
+   transparent non-empty follow-up attribution commit with valid
+   `Co-authored-by:` trailers and an auditable ledger entry; do not claim this
+   changes the original merge commit's authorship, line blame, or
+   additions/deletions
 
 ## Developer Operating Loop
 

--- a/.codex/skills/pr-governance-review/scripts/contributor_impact_report.py
+++ b/.codex/skills/pr-governance-review/scripts/contributor_impact_report.py
@@ -1192,7 +1192,9 @@ def _harvest_attribution_lines(records: list[dict[str, Any]]) -> list[str]:
             "- No maintainer-harvest source credits detected in this window.",
         ]
     lines = [
-        "These are internal Hussh impact credits for contributor PRs whose useful value was harvested into a maintainer patch. They do not change GitHub's official contributor graph for already-merged commits.",
+        "These are Hussh impact credits for contributor PRs whose useful value was harvested into a maintainer patch. Internal impact credit stays on the source PRs. External GitHub credit requires valid co-author trailers on a real commit.",
+        "",
+        "For [PR #1013](https://github.com/hushh-labs/hushh-research/pull/1013), the original merge commit was not co-authored. GitHub-visible co-author credit is provided by the transparent harvest attribution ledger follow-up commit once that commit lands; it does not change #1013's original authorship, line blame, or additions/deletions.",
         "",
         "| Source PR | Contributor | Landing PR | Accepted Value | Official GitHub Commit Credit |",
         "| --- | --- | --- | --- | --- |",
@@ -1205,7 +1207,7 @@ def _harvest_attribution_lines(records: list[dict[str, Any]]) -> list[str]:
         lines.append(
             f"| {_link(item)} | `{_cell(item['author'])}` | {_pr_link(landing) if landing else 'n/a'} | "
             f"{_cell(item.get('harvestAcceptedValue') or item['reason'])} | "
-            "No, because the landed commit was not co-authored. |"
+            "Contributor is co-authored on the harvest attribution ledger follow-up once it lands; original landing merge is unchanged. |"
         )
     return lines
 
@@ -1276,7 +1278,7 @@ def _report_text(
         f"- Harvested source PRs credited internally: `{kpis['harvested_source_prs']}`.",
         f"- Governance intervention load: `{kpis['governance_intervention_load']}` across duplicate, drift, and revert/correction work.",
         "- KPI model: combines DORA-style throughput/stability, SPACE-style multidimensional productivity, Hussh north-star impact, and internal maintainer-harvest source credit. Raw PR count is never the winner by itself.",
-        "- GitHub official contributor credit still follows Git commit authorship and valid `Co-authored-by` trailers; comments and PR references are internal/public acknowledgement only.",
+        "- GitHub official contributor credit still follows Git commit authorship and valid `Co-authored-by` trailers; comments and PR references are internal/public acknowledgement only. For already-merged harvests, external credit requires a transparent non-empty follow-up commit and does not rewrite original line blame.",
         "",
         "## GitHub Coverage Audit",
         "",

--- a/.codex/skills/pr-governance-review/scripts/test_contributor_impact_report.py
+++ b/.codex/skills/pr-governance-review/scripts/test_contributor_impact_report.py
@@ -52,6 +52,23 @@ def test_harvested_source_gets_internal_credit() -> None:
     _assert(leaderboard[0]["harvested"] == 1, "leaderboard must count harvest credits")
 
 
+def test_harvest_attribution_names_external_ledger_boundary() -> None:
+    records = report._analysis(
+        [_fake_pr(808, "imsharukhan", "fix: improve TopAppBar back button touch target")]
+    )
+
+    lines = "\n".join(report._harvest_attribution_lines(records))
+    _assert(
+        "co-authored on the harvest attribution ledger follow-up once it lands" in lines,
+        "harvest report must name the external GitHub attribution path",
+    )
+    _assert(
+        "does not change #1013's original authorship, line blame, or additions/deletions" in lines,
+        "harvest report must not imply original merge history changed",
+    )
+
+
 if __name__ == "__main__":
     test_harvested_source_gets_internal_credit()
+    test_harvest_attribution_names_external_ledger_boundary()
     print("contributor impact tests passed")

--- a/.codex/skills/pr-governance-review/skill.json
+++ b/.codex/skills/pr-governance-review/skill.json
@@ -31,7 +31,8 @@
     ".codex/skills/pr-governance-review/references/operator-question-fixtures.json",
     ".codex/skills/pr-governance-review/references/blocker-gates.md",
     ".codex/skills/pr-governance-review/references/comment-and-report-contract.md",
-    ".codex/skills/pr-governance-review/references/pr-train-review-sop.md"
+    ".codex/skills/pr-governance-review/references/pr-train-review-sop.md",
+    ".codex/skills/pr-governance-review/references/maintainer-harvest-attribution-ledger.md"
   ],
   "required_commands": [
     "python3 -m py_compile .codex/skills/pr-governance-review/scripts/pr_review_checklist.py",


### PR DESCRIPTION
## Summary

Adds a transparent maintainer-harvest attribution ledger for the source PRs harvested into [PR #1013](https://github.com/hushh-labs/hushh-research/pull/1013).

This preserves the internal `harvested_source` dashboard credit and adds external GitHub-visible co-author attribution through this real follow-up commit. It does not claim that the original #1013 merge commit, line blame, additions, or deletions changed.

## Source Contributors

- `imsharukhan`: [PR #808](https://github.com/hushh-labs/hushh-research/pull/808), [PR #810](https://github.com/hushh-labs/hushh-research/pull/810), [PR #809](https://github.com/hushh-labs/hushh-research/pull/809), [PR #811](https://github.com/hushh-labs/hushh-research/pull/811)
- `smirthi-dharma`: [PR #942](https://github.com/hushh-labs/hushh-research/pull/942), [PR #967](https://github.com/hushh-labs/hushh-research/pull/967), [PR #1001](https://github.com/hushh-labs/hushh-research/pull/1001)
- `anshul23102`: [PR #931](https://github.com/hushh-labs/hushh-research/pull/931), [PR #924](https://github.com/hushh-labs/hushh-research/pull/924), [PR #1002](https://github.com/hushh-labs/hushh-research/pull/1002), [PR #913](https://github.com/hushh-labs/hushh-research/pull/913), [PR #934](https://github.com/hushh-labs/hushh-research/pull/934), [PR #926](https://github.com/hushh-labs/hushh-research/pull/926)
- `suyashkumar102`: [PR #943](https://github.com/hushh-labs/hushh-research/pull/943)

## GitHub Attribution Check

The commit footer has contiguous valid trailers for:

- `Co-authored-by: imsharukhan <170163028+imsharukhan@users.noreply.github.com>`
- `Co-authored-by: smirthi-dharma <180732717+smirthi-dharma@users.noreply.github.com>`
- `Co-authored-by: anshul23102 <167362756+anshul23102@users.noreply.github.com>`
- `Co-authored-by: suyashkumar102 <247820734+suyashkumar102@users.noreply.github.com>`

GitHub GraphQL resolves the pushed commit authors to `kushaltrivedi5`, `imsharukhan`, `smirthi-dharma`, `anshul23102`, and `suyashkumar102`.

## Verification

- `git log -1 --pretty=%B | git interpret-trailers --parse`
- `python3 -m py_compile .codex/skills/pr-governance-review/scripts/contributor_impact_report.py .codex/skills/pr-governance-review/scripts/test_contributor_impact_report.py`
- `python3 .codex/skills/pr-governance-review/scripts/test_contributor_impact_report.py`
- `python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py`
- `python3 .codex/skills/codex-skill-authoring/scripts/truth_first_smoke.py`
- `git diff --check`

_codex skills used: `github-contribution-governance`, `pr-governance-review`, `codex-skill-authoring`_