### PR TITLE
Show recovery UI when profile, consents, or marketplace routes crash

### DIFF
--- a/hushh-webapp/app/consents/error.tsx
+++ b/hushh-webapp/app/consents/error.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect } from "react";
+import { Button } from "@/lib/morphy-ux/button";
+import { Card } from "@/lib/morphy-ux/card";
+import { AlertTriangle } from "lucide-react";
+
+/**
+ * Consents route error boundary.
+ *
+ * Catches render errors in /consents and shows a Morphy-styled recovery UI
+ * instead of the default Next.js white-screen error page.
+ */
+export default function ConsentsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[ConsentsError] Uncaught error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center px-6">
+      <Card
+        preset="default"
+        effect="glass"
+        glassAccent="soft"
+        className="mx-auto w-full max-w-sm text-center"
+      >
+        <div className="flex flex-col items-center gap-4">
+          <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-red-500/12 to-orange-500/12 dark:from-red-400/16 dark:to-orange-400/16">
+            <AlertTriangle className="h-7 w-7 text-red-500 dark:text-red-400" />
+          </div>
+          <div className="space-y-1.5">
+            <h2 className="text-lg font-semibold tracking-tight">
+              Something went wrong
+            </h2>
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              An unexpected error occurred while loading your consents. You can
+              try again or return to the home screen.
+            </p>
+          </div>
+          <div className="flex gap-3 pt-1">
+            <Button
+              variant="muted"
+              effect="glass"
+              size="sm"
+              onClick={reset}
+            >
+              Try again
+            </Button>
+            <Button
+              variant="blue-gradient"
+              effect="fill"
+              size="sm"
+              onClick={() => {
+                window.location.href = "/kai";
+              }}
+            >
+              Go home
+            </Button>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/hushh-webapp/app/marketplace/error.tsx
+++ b/hushh-webapp/app/marketplace/error.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect } from "react";
+import { Button } from "@/lib/morphy-ux/button";
+import { Card } from "@/lib/morphy-ux/card";
+import { AlertTriangle } from "lucide-react";
+
+/**
+ * Marketplace route error boundary.
+ *
+ * Catches render errors in /marketplace and shows a Morphy-styled recovery UI
+ * instead of the default Next.js white-screen error page.
+ */
+export default function MarketplaceError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[MarketplaceError] Uncaught error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center px-6">
+      <Card
+        preset="default"
+        effect="glass"
+        glassAccent="soft"
+        className="mx-auto w-full max-w-sm text-center"
+      >
+        <div className="flex flex-col items-center gap-4">
+          <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-red-500/12 to-orange-500/12 dark:from-red-400/16 dark:to-orange-400/16">
+            <AlertTriangle className="h-7 w-7 text-red-500 dark:text-red-400" />
+          </div>
+          <div className="space-y-1.5">
+            <h2 className="text-lg font-semibold tracking-tight">
+              Something went wrong
+            </h2>
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              An unexpected error occurred while loading the marketplace. You can
+              try again or return to the home screen.
+            </p>
+          </div>
+          <div className="flex gap-3 pt-1">
+            <Button
+              variant="muted"
+              effect="glass"
+              size="sm"
+              onClick={reset}
+            >
+              Try again
+            </Button>
+            <Button
+              variant="blue-gradient"
+              effect="fill"
+              size="sm"
+              onClick={() => {
+                window.location.href = "/kai";
+              }}
+            >
+              Go home
+            </Button>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/hushh-webapp/app/profile/error.tsx
+++ b/hushh-webapp/app/profile/error.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect } from "react";
+import { Button } from "@/lib/morphy-ux/button";
+import { Card } from "@/lib/morphy-ux/card";
+import { AlertTriangle } from "lucide-react";
+
+/**
+ * Profile route error boundary.
+ *
+ * Catches render errors in /profile and shows a Morphy-styled recovery UI
+ * instead of the default Next.js white-screen error page.
+ */
+export default function ProfileError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[ProfileError] Uncaught error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center px-6">
+      <Card
+        preset="default"
+        effect="glass"
+        glassAccent="soft"
+        className="mx-auto w-full max-w-sm text-center"
+      >
+        <div className="flex flex-col items-center gap-4">
+          <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-red-500/12 to-orange-500/12 dark:from-red-400/16 dark:to-orange-400/16">
+            <AlertTriangle className="h-7 w-7 text-red-500 dark:text-red-400" />
+          </div>
+          <div className="space-y-1.5">
+            <h2 className="text-lg font-semibold tracking-tight">
+              Something went wrong
+            </h2>
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              An unexpected error occurred while loading your profile. You can
+              try again or return to the home screen.
+            </p>
+          </div>
+          <div className="flex gap-3 pt-1">
+            <Button
+              variant="muted"
+              effect="glass"
+              size="sm"
+              onClick={reset}
+            >
+              Try again
+            </Button>
+            <Button
+              variant="blue-gradient"
+              effect="fill"
+              size="sm"
+              onClick={() => {
+                window.location.href = "/kai";
+              }}
+            >
+              Go home
+            </Button>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
# Description

Show recovery UI when profile, consents, or marketplace routes crash by adding Next.js `error.tsx` boundary files.

Currently, a runtime render error on any of these routes shows the default Next.js error screen — a blank white page with no recovery path. For a consent-first financial platform, an unrecoverable crash on pages where users manage data permissions or profile settings is a trust-breaking experience. 

This change adds `error.tsx` files for the `/profile`, `/consents`, and `/marketplace` route segments. Each uses the existing Morphy design system (glass `Card`, `Button`, `AlertTriangle` icon) to show a branded recovery UI with "Try again" and "Go home" actions. The `/kai` layout already wraps its routes in a `RouteErrorBoundary`; this change extends that safety net to every other primary route.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below:
    - `/profile`
    - `/consents`
    - `/marketplace`

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None (Morphy components render identically on Capacitor WebView)

- Docs updated:
  - [x] None

- Verification commands executed:
  - [x] `cd hushh-webapp && npx tsc --noEmit` — passes

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Error boundaries catch rendering errors and display recovery UI natively
- [x] **iOS**: Renders identically in Capacitor WebView
- [x] **Android**: Renders identically in Capacitor WebView

## 🧪 Testing

- [x] Tested on Web (Forced render errors to verify recovery UI)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Does this change access user data? **No**

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No new dependencies added
