### PR TITLE
feat: revamp Agent Kai KYC and vault flows

### DIFF
--- a/consent-protocol/api/routes/db_proxy.py
+++ b/consent-protocol/api/routes/db_proxy.py
@@ -20,7 +20,7 @@ import logging
 import os
 import re
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from pydantic import BaseModel
 
 from api.middleware import require_firebase_auth, verify_user_id_match
@@ -102,6 +102,44 @@ def _raise_database_http_exception(exc: Exception) -> None:
                 **({"hint": hint} if hint else {}),
             },
         ) from exc
+
+
+async def require_vault_owner_consent_header(
+    hushh_consent: str | None = Header(None, alias="X-Hushh-Consent"),
+) -> dict:
+    """Require a VAULT_OWNER token in the explicit dual-auth consent header."""
+    raw_header = (hushh_consent or "").strip()
+    if not raw_header:
+        raise HTTPException(
+            status_code=401,
+            detail="Missing X-Hushh-Consent header",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    token = raw_header.removeprefix("Bearer ").strip()
+    if not token:
+        raise HTTPException(
+            status_code=401,
+            detail="Missing X-Hushh-Consent bearer token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    valid, reason, token_obj = await validate_token_with_db(token, ConsentScope.VAULT_OWNER)
+    if not valid or token_obj is None:
+        raise HTTPException(
+            status_code=401,
+            detail=f"Invalid token: {reason}",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    scope = getattr(token_obj, "scope", None)
+    return {
+        "user_id": token_obj.user_id,
+        "agent_id": getattr(token_obj, "agent_id", None),
+        "scope": getattr(token_obj, "scope_str", None) or getattr(scope, "value", scope),
+        "token": token,
+        "token_obj": token_obj,
+    }
 
 
 # ============================================================================
@@ -198,6 +236,15 @@ class VaultWrapperUpsertRequest(BaseModel):
     passkeyProvider: str | None = None
     passkeyDeviceLabel: str | None = None
     passkeyLastUsedAt: int | None = None
+
+
+class VaultWrapperDeleteRequest(BaseModel):
+    userId: str
+    vaultKeyHash: str
+    method: str
+    wrapperId: str | None = None
+    fallbackPrimaryMethod: str | None = "passphrase"
+    fallbackPrimaryWrapperId: str | None = "default"
 
 
 class VaultPrimaryMethodSetRequest(BaseModel):
@@ -486,6 +533,68 @@ async def vault_wrapper_upsert(
     except Exception as e:
         logger.error(
             "vault/wrapper/upsert error user=%s method=%s: %s",
+            _mask_user_id(request.userId),
+            request.method,
+            e,
+        )
+        _raise_database_http_exception(e)
+        raise HTTPException(status_code=500, detail="Database error")
+
+
+@router.post("/vault/wrapper/delete", response_model=SuccessResponse)
+async def vault_wrapper_delete(
+    http_request: Request,
+    request: VaultWrapperDeleteRequest,
+    firebase_uid: str = Depends(require_firebase_auth),
+    vault_owner_token: dict = Depends(require_vault_owner_consent_header),
+):
+    """Remove an enrolled non-passphrase vault wrapper."""
+    verify_user_id_match(firebase_uid, request.userId)
+    token_user_id = str(vault_owner_token.get("user_id") or "")
+    if token_user_id != request.userId:
+        logger.warning(
+            "vault/wrapper/delete token mismatch token=%s request=%s",
+            _mask_user_id(token_user_id),
+            _mask_user_id(request.userId),
+        )
+        raise HTTPException(
+            status_code=403,
+            detail="VAULT_OWNER token userId does not match requested userId",
+        )
+    _check_client_version_or_raise(http_request)
+    logger.info(
+        "vault/wrapper/delete request user=%s method=%s",
+        _mask_user_id(request.userId),
+        request.method,
+    )
+
+    try:
+        service = VaultKeysService()
+        await service.delete_wrapper(
+            user_id=request.userId,
+            vault_key_hash=request.vaultKeyHash,
+            method=request.method,
+            wrapper_id=request.wrapperId,
+            fallback_primary_method=request.fallbackPrimaryMethod,
+            fallback_primary_wrapper_id=request.fallbackPrimaryWrapperId,
+        )
+        return SuccessResponse(success=True)
+
+    except ValueError as e:
+        message = str(e)
+        code = "VAULT_VALIDATION_ERROR"
+        if "vaultKeyHash mismatch" in message:
+            code = "VAULT_KEY_HASH_MISMATCH"
+        elif "Vault wrapper not found" in message:
+            code = "VAULT_WRAPPER_NOT_FOUND"
+        elif "Passphrase wrapper cannot be removed" in message:
+            code = "VAULT_PASSPHRASE_REQUIRED"
+        elif "Fallback primary method/wrapper" in message:
+            code = "VAULT_PRIMARY_WRAPPER_NOT_FOUND"
+        raise HTTPException(status_code=400, detail={"error": message, "code": code})
+    except Exception as e:
+        logger.error(
+            "vault/wrapper/delete error user=%s method=%s: %s",
             _mask_user_id(request.userId),
             request.method,
             e,

--- a/consent-protocol/api/routes/developer.py
+++ b/consent-protocol/api/routes/developer.py
@@ -483,9 +483,7 @@ def _compact_scope_entries(
 ) -> tuple[list[str], list[str], list[dict]]:
     compact_entries: list[dict] = []
     seen_scopes: set[str] = set()
-    discovered_domains = {
-        str(domain).strip().lower() for domain in available_domains if str(domain).strip()
-    }
+    discovered_domains = set()
 
     for entry in scope_entries:
         if not isinstance(entry, dict):
@@ -497,8 +495,6 @@ def _compact_scope_entries(
         source_kind = str(entry.get("source_kind") or "").strip()
         wildcard = entry.get("wildcard") is True
         domain = str(entry.get("domain") or "").strip().lower() or None
-        if domain:
-            discovered_domains.add(domain)
 
         # Default developer discovery should expose requestable top-level consent
         # surfaces only. Deep path-level manifest rows remain available via verbose
@@ -512,6 +508,8 @@ def _compact_scope_entries(
 
         compact_entries.append(entry)
         seen_scopes.add(scope)
+        if domain:
+            discovered_domains.add(domain)
 
     compact_scopes = sorted(
         {

--- a/consent-protocol/api/routes/pkm_routes_shared.py
+++ b/consent-protocol/api/routes/pkm_routes_shared.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/pkm", tags=["pkm"])
 
 _COMPACT_SCOPE_SOURCE_KINDS = {"pkm_index", "pkm_manifests.top_level_scope_paths"}
+_INTERNAL_ONLY_PKM_DOMAINS = {"kyc_connector", "kyc_workflow"}
 
 
 def _isoformat_or_none(value):
@@ -141,25 +142,42 @@ class StockContextResponse(BaseModel):
 def _summary_attribute_count(summary: dict | None) -> int:
     if not isinstance(summary, dict):
         return 0
-    for key in ("attribute_count", "holdings_count", "item_count"):
+    for key in (
+        "attribute_count",
+        "holdings_count",
+        "item_count",
+        "externalizable_path_count",
+        "path_count",
+    ):
         value = summary.get(key)
         if isinstance(value, bool) or value is None:
             continue
         if isinstance(value, int):
-            return max(0, value)
+            if value > 0:
+                return value
+            continue
         if isinstance(value, float):
             if value != value:
                 continue
-            return max(0, int(value))
+            parsed = int(value)
+            if parsed > 0:
+                return parsed
+            continue
         if isinstance(value, str):
             text = value.strip()
             if not text:
                 continue
             try:
-                return max(0, int(float(text)))
+                parsed = int(float(text))
+                if parsed > 0:
+                    return parsed
             except Exception:
                 continue
     return 0
+
+
+def _is_internal_only_pkm_domain(domain: str | None) -> bool:
+    return str(domain or "").strip().lower() in _INTERNAL_ONLY_PKM_DOMAINS
 
 
 def _summary_text(summary: dict | None, key: str) -> Optional[str]:
@@ -969,6 +987,8 @@ async def get_metadata(
             degraded_domains: List[DomainMetadata] = []
             for row in domain_rows:
                 domain_key = str(row.get("domain") or "")
+                if _is_internal_only_pkm_domain(domain_key):
+                    continue
                 manifest = await pkm_service.get_domain_manifest(user_id, domain_key)
                 degraded_domains.append(
                     DomainMetadata(
@@ -1035,6 +1055,8 @@ async def get_metadata(
 
         domains: List[DomainMetadata] = []
         for domain in metadata.domains:
+            if _is_internal_only_pkm_domain(domain.domain_key):
+                continue
             domains.append(
                 DomainMetadata(
                     key=domain.domain_key,
@@ -1055,7 +1077,7 @@ async def get_metadata(
                 )
             )
 
-        total_attrs = metadata.total_attributes or sum(d.attribute_count for d in domains)
+        total_attrs = sum(d.attribute_count for d in domains)
 
         common_domains = {"financial", "health", "travel", "subscriptions", "food"}
         user_domain_keys = {domain.key for domain in domains}

--- a/consent-protocol/docs/reference/env-vars.md
+++ b/consent-protocol/docs/reference/env-vars.md
@@ -152,7 +152,7 @@ Notes:
 
 - These maintainer-only overlay vars are loaded by backend scripts and release verification at process start.
 - Changing them requires restarting the backend or rerunning the script; they are not hot-reloaded into an already running process.
-- `REVIEWER_UID` is the canonical non-production reviewer/test user id. The current fixture resolves to `s3xmA4lNSAQFrIaOytnSGAOzXlL2` from Firebase Auth email `jd77v9k4nx@privaterelay.appleid.com`.
+- `REVIEWER_UID` is the canonical non-production reviewer/test user id. The current fixture resolves to `UWHGeUyfUAbmEl5xwIPoWJ7Cyft2` from Firebase Auth email `kushaltrivedi1711@gmail.com`.
 - `REVIEWER_VAULT_PASSPHRASE` is the canonical vault unlock secret for reviewer smoke and must remain in ignored local env files or Secret Manager/runtime overlays.
 - `UAT_SMOKE_*` and `KAI_TEST_*` are deprecated one-release aliases for existing maintainer scripts.
 - UAT analytics smoke reuses the existing reviewer test fixture; do not create new Firebase users, reviewer users, app environments, or one-off analytics fixtures for validation.

--- a/consent-protocol/hushh_mcp/consent/scope_generator.py
+++ b/consent-protocol/hushh_mcp/consent/scope_generator.py
@@ -39,6 +39,10 @@ class DynamicScopeGenerator:
         "schema_version",
         "updated_at",
     }
+    _INTERNAL_ONLY_DOMAINS = {
+        "kyc_connector",
+        "kyc_workflow",
+    }
 
     def __init__(self):
         self._supabase = None
@@ -145,6 +149,10 @@ class DynamicScopeGenerator:
                 segments.append(normalized_part)
         return ".".join(segments)
 
+    @classmethod
+    def _is_internal_only_domain(cls, domain: str | None) -> bool:
+        return cls._normalize_domain_key(domain) in cls._INTERNAL_ONLY_DOMAINS
+
     @staticmethod
     def _coerce_json_dict(value: object) -> dict:
         if isinstance(value, dict):
@@ -222,10 +230,14 @@ class DynamicScopeGenerator:
             domain_summaries = {}
 
         catalog: dict[str, dict[str, set[str]]] = {
-            domain: {"paths": set(), "wildcards": set()} for domain in available_domains
+            domain: {"paths": set(), "wildcards": set()}
+            for domain in available_domains
+            if not self._is_internal_only_domain(domain)
         }
 
         for domain in available_domains:
+            if self._is_internal_only_domain(domain):
+                continue
             summary = domain_summaries.get(domain)
             if not isinstance(summary, dict):
                 continue
@@ -265,7 +277,7 @@ class DynamicScopeGenerator:
             if not isinstance(row, dict):
                 continue
             domain = self._normalize_domain_key(row.get("domain"))
-            if not domain:
+            if not domain or self._is_internal_only_domain(domain):
                 continue
             entry = catalog.setdefault(domain, {"paths": set(), "wildcards": set()})
             for top_level_path in row.get("top_level_scope_paths") or []:
@@ -285,7 +297,7 @@ class DynamicScopeGenerator:
                 continue
             domain = self._normalize_domain_key(row.get("domain"))
             json_path = self._normalize_scope_path(row.get("json_path"))
-            if not domain or not json_path:
+            if not domain or self._is_internal_only_domain(domain) or not json_path:
                 continue
             entry = catalog.setdefault(domain, {"paths": set(), "wildcards": set()})
             entry["paths"].add(json_path)
@@ -437,9 +449,14 @@ class DynamicScopeGenerator:
                 }
 
         for domain in sorted(known_domains):
+            domain_internal = self._is_internal_only_domain(domain)
             domain_top_levels = all_consumer_top_levels_by_domain.get(domain, set())
             enabled_top_levels = enabled_consumer_top_levels_by_domain.get(domain, set())
-            if domain_top_levels and enabled_top_levels != domain_top_levels:
+            if (
+                not domain_internal
+                and domain_top_levels
+                and enabled_top_levels != domain_top_levels
+            ):
                 continue
             _upsert_scope_entry(
                 {
@@ -453,9 +470,11 @@ class DynamicScopeGenerator:
                     "exposure_eligibility": True,
                     "manifest_revision": None,
                     "meta_reference": "domain wildcard derived from discovered PKM domains",
-                    "consumer_visible": True,
-                    "internal_only": False,
-                    "visibility_reason": "consumer_shareable",
+                    "consumer_visible": not domain_internal,
+                    "internal_only": domain_internal,
+                    "visibility_reason": "internal_runtime_domain"
+                    if domain_internal
+                    else "consumer_shareable",
                 }
             )
 
@@ -466,6 +485,7 @@ class DynamicScopeGenerator:
             domain = self._normalize_domain_key(row.get("domain"))
             if not domain:
                 continue
+            domain_internal = self._is_internal_only_domain(domain)
             manifest_version = row.get("manifest_version")
             top_level_paths = [
                 self._normalize_scope_path(path)
@@ -488,9 +508,15 @@ class DynamicScopeGenerator:
                         "manifest_revision": registry_meta.get("manifest_revision")
                         or manifest_version,
                         "meta_reference": "manifest top-level scope path",
-                        "consumer_visible": registry_meta.get("consumer_visible") is not False,
-                        "internal_only": registry_meta.get("internal_only") is True,
-                        "visibility_reason": registry_meta.get("visibility_reason"),
+                        "consumer_visible": False
+                        if domain_internal
+                        else registry_meta.get("consumer_visible") is not False,
+                        "internal_only": True
+                        if domain_internal
+                        else registry_meta.get("internal_only") is True,
+                        "visibility_reason": "internal_runtime_domain"
+                        if domain_internal
+                        else registry_meta.get("visibility_reason"),
                     }
                 )
             for raw_path in row.get("externalizable_paths") or []:
@@ -515,9 +541,15 @@ class DynamicScopeGenerator:
                         "manifest_revision": registry_meta.get("manifest_revision")
                         or manifest_version,
                         "meta_reference": "externalizable manifest path",
-                        "consumer_visible": registry_meta.get("consumer_visible") is not False,
-                        "internal_only": registry_meta.get("internal_only") is True,
-                        "visibility_reason": registry_meta.get("visibility_reason"),
+                        "consumer_visible": False
+                        if domain_internal
+                        else registry_meta.get("consumer_visible") is not False,
+                        "internal_only": True
+                        if domain_internal
+                        else registry_meta.get("internal_only") is True,
+                        "visibility_reason": "internal_runtime_domain"
+                        if domain_internal
+                        else registry_meta.get("visibility_reason"),
                     }
                 )
 
@@ -530,6 +562,7 @@ class DynamicScopeGenerator:
             path = self._normalize_scope_path(row.get("json_path"))
             if not domain or not path:
                 continue
+            domain_internal = self._is_internal_only_domain(domain)
             top_level = path.split(".", 1)[0]
             registry_meta = registry_by_top_level.get((domain, top_level), {})
             if registry_meta.get("exposure_enabled") is False:
@@ -549,9 +582,15 @@ class DynamicScopeGenerator:
                     "exposure_eligibility": True,
                     "manifest_revision": registry_meta.get("manifest_revision"),
                     "meta_reference": "manifest path row marked exposure eligible",
-                    "consumer_visible": registry_meta.get("consumer_visible") is not False,
-                    "internal_only": registry_meta.get("internal_only") is True,
-                    "visibility_reason": registry_meta.get("visibility_reason"),
+                    "consumer_visible": False
+                    if domain_internal
+                    else registry_meta.get("consumer_visible") is not False,
+                    "internal_only": True
+                    if domain_internal
+                    else registry_meta.get("internal_only") is True,
+                    "visibility_reason": "internal_runtime_domain"
+                    if domain_internal
+                    else registry_meta.get("visibility_reason"),
                 }
             )
 

--- a/consent-protocol/hushh_mcp/services/actor_identity_service.py
+++ b/consent-protocol/hushh_mcp/services/actor_identity_service.py
@@ -511,7 +511,9 @@ class ActorIdentityService:
                     normalized_phone_number,
                 )
         except (asyncpg.UndefinedTableError, asyncpg.UndefinedColumnError):
-            logger.debug("actor_identity_cache phone claim skipped; phone shadow schema unavailable")
+            logger.debug(
+                "actor_identity_cache phone claim skipped; phone shadow schema unavailable"
+            )
             return None
         except Exception as exc:
             logger.debug(

--- a/consent-protocol/hushh_mcp/services/one_email_kyc_service.py
+++ b/consent-protocol/hushh_mcp/services/one_email_kyc_service.py
@@ -150,6 +150,39 @@ _DYNAMIC_SCOPE_TERMS: dict[str, tuple[str, ...]] = {
     "work": ("work", "job", "career", "employment", "company"),
     "education": ("education", "school", "university", "degree"),
 }
+_SCOPE_MATCH_STOPWORDS = frozenset(
+    {
+        "and",
+        "are",
+        "can",
+        "create",
+        "data",
+        "draft",
+        "entities",
+        "entity",
+        "for",
+        "from",
+        "get",
+        "has",
+        "here",
+        "id",
+        "information",
+        "into",
+        "items",
+        "kind",
+        "observations",
+        "one",
+        "preference",
+        "preferences",
+        "that",
+        "the",
+        "this",
+        "updated",
+        "with",
+        "you",
+        "your",
+    }
+)
 
 
 def _runtime_environment() -> str:
@@ -512,6 +545,22 @@ def _message_text(message: dict[str, Any]) -> str:
     return "\n".join(plain or html_parts)
 
 
+def _strip_quoted_reply_text(body: str) -> str:
+    lines = str(body or "").splitlines()
+    kept: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith(">"):
+            break
+        if re.match(r"^On .+ wrote:$", stripped):
+            break
+        if stripped in {"--", "-----Original Message-----"}:
+            break
+        kept.append(line)
+    text = "\n".join(kept).strip()
+    return text or str(body or "")
+
+
 def _has_attachments(message: dict[str, Any]) -> bool:
     payload = message.get("payload") if isinstance(message.get("payload"), dict) else {}
     for part in _iter_payload_parts(payload):
@@ -568,11 +617,19 @@ def _scope_terms_from_entry(entry: dict[str, Any]) -> set[str]:
     path = _clean_text(entry.get("path")).lower()
     label = _clean_text(entry.get("label")).lower()
     for item in (domain, path, label, scope.removeprefix("attr.")):
+        normalized_item = item.replace("_", " ").replace(".", " ").strip()
+        tokens = [token for token in re.split(r"[^a-z0-9]+", normalized_item) if len(token) >= 3]
+        for size in (3, 2):
+            for index in range(0, max(len(tokens) - size + 1, 0)):
+                phrase_tokens = tokens[index : index + size]
+                if all(token in _SCOPE_MATCH_STOPWORDS for token in phrase_tokens):
+                    continue
+                terms.add(" ".join(phrase_tokens))
         for token in re.split(r"[^a-z0-9_]+", item.replace(".", " ")):
-            if len(token) >= 3:
+            if len(token) >= 3 and token not in _SCOPE_MATCH_STOPWORDS:
                 terms.add(token.replace("_", " "))
-        compact = item.replace("_", " ").replace(".", " ").strip()
-        if len(compact) >= 3:
+        compact = normalized_item
+        if len(compact) >= 3 and compact not in _SCOPE_MATCH_STOPWORDS:
             terms.add(compact)
     for term in _DYNAMIC_SCOPE_TERMS.get(domain, ()):
         terms.add(term)
@@ -1170,9 +1227,14 @@ class OneEmailKycService:
             ]
             if not matched_terms:
                 continue
+            domain_terms = {_clean_text(domain).lower(), *_DYNAMIC_SCOPE_TERMS.get(domain, ())}
             score = max(len(term.split()) for term in matched_terms)
-            if _clean_text(entry.get("path")):
-                score += 1
+            if any(term in domain_terms for term in matched_terms):
+                score += 8
+            if scope == get_scope_generator().generate_domain_wildcard(domain):
+                score += 4
+            elif entry.get("wildcard") is True:
+                score += 2
             candidates.append(
                 (
                     score,
@@ -1189,8 +1251,12 @@ class OneEmailKycService:
                     ),
                 )
             )
+        ranked = sorted(candidates, key=lambda item: -item[0])
+        if not ranked:
+            return []
+        top_score = ranked[0][0]
         return _dedupe_scope_candidates(
-            [candidate for _score, candidate in sorted(candidates, key=lambda item: -item[0])]
+            [candidate for score, candidate in ranked if score == top_score][:6]
         )
 
     async def _process_message(
@@ -1207,8 +1273,14 @@ class OneEmailKycService:
         gmail_message_id = _clean_text(message.get("id"))
         gmail_thread_id = _clean_text(message.get("threadId"))
         rfc_message_id = _clean_text(headers.get("message-id")) or None
-        body_text = _message_text(message)
-        body_hash = hashlib.sha256(body_text.encode("utf-8")).hexdigest() if body_text else None
+        raw_body_text = _message_text(message)
+        body_text = _strip_quoted_reply_text(raw_body_text)
+        body_hash = (
+            hashlib.sha256(raw_body_text.encode("utf-8")).hexdigest() if raw_body_text else None
+        )
+        request_body_hash = (
+            hashlib.sha256(body_text.encode("utf-8")).hexdigest() if body_text else None
+        )
         snippet = None
         mailbox = self.config.mailbox_email
         participants = [
@@ -1268,6 +1340,8 @@ class OneEmailKycService:
             "metadata": {
                 "source": _KYC_REQUEST_SOURCE,
                 "body_sha256": body_hash,
+                "request_body_sha256": request_body_hash,
+                "quoted_reply_text_stripped": body_text != raw_body_text,
                 "classification": (
                     "kyc_financial"
                     if is_kyc and is_financial
@@ -1541,6 +1615,12 @@ class OneEmailKycService:
             "financial_profile": ("financial profile", "financial information", "net worth"),
             "portfolio": ("portfolio", "holdings", "investment holdings"),
             "financial_documents": ("statement", "statements", "financial documents"),
+            "seat_preferences": (
+                "seat preference",
+                "seat preferences",
+                "preferred seat",
+                "preferred seats",
+            ),
             "favorite_locations": (
                 "favorite location",
                 "favorite locations",
@@ -1559,6 +1639,8 @@ class OneEmailKycService:
         ]
         if "favorite_locations" in fields and "locations" in fields:
             fields.remove("locations")
+        if "seat_preferences" in fields and "preferences" in fields:
+            fields.remove("preferences")
         if not fields:
             fields.append("identity_profile")
         return fields

--- a/consent-protocol/hushh_mcp/services/personal_knowledge_model_service.py
+++ b/consent-protocol/hushh_mcp/services/personal_knowledge_model_service.py
@@ -946,10 +946,12 @@ class PersonalKnowledgeModelService:
             summary.get("attribute_count"),
             summary.get("holdings_count"),
             summary.get("item_count"),
+            summary.get("externalizable_path_count"),
+            summary.get("path_count"),
         )
         for candidate in candidates:
             parsed = self._to_non_negative_int(candidate)
-            if parsed is not None:
+            if parsed is not None and parsed > 0:
                 return parsed
         return 0
 

--- a/consent-protocol/hushh_mcp/services/vault_keys_service.py
+++ b/consent-protocol/hushh_mcp/services/vault_keys_service.py
@@ -995,6 +995,159 @@ class VaultKeysService:
         self._invalidate_vault_state_cache(user_id_clean)
         return True
 
+    async def delete_wrapper(
+        self,
+        *,
+        user_id: str,
+        vault_key_hash: str,
+        method: str,
+        wrapper_id: Optional[str] = None,
+        fallback_primary_method: Optional[str] = "passphrase",
+        fallback_primary_wrapper_id: Optional[str] = "default",
+    ) -> bool:
+        """Remove a non-passphrase wrapper after proving the caller has the vault key."""
+        supabase = self._get_supabase()
+        user_id_clean = (user_id or "").strip()
+        if not user_id_clean:
+            raise ValueError("userId is required")
+
+        vault_key_hash_clean = self._clean_base64ish(vault_key_hash) or ""
+        if not vault_key_hash_clean:
+            raise ValueError("vaultKeyHash is required")
+
+        method_norm = self._normalize_method(method)
+        wrapper_norm = self._normalize_wrapper_id(wrapper_id)
+        if method_norm == "passphrase":
+            raise ValueError("Passphrase wrapper cannot be removed")
+
+        def row_get(row: Any, key: str) -> Any:
+            if isinstance(row, dict):
+                return row.get(key)
+            return getattr(row, "_mapping", {}).get(key)
+
+        with supabase.engine.begin() as conn:
+            vault_row = conn.execute(
+                text(
+                    """
+                    SELECT vault_key_hash, primary_method, primary_wrapper_id
+                    FROM vault_keys
+                    WHERE user_id = :user_id
+                    FOR UPDATE
+                    """
+                ),
+                {"user_id": user_id_clean},
+            ).fetchone()
+            if vault_row is None:
+                raise ValueError("Vault not found")
+
+            existing_hash = self._clean_base64ish(row_get(vault_row, "vault_key_hash")) or ""
+            if existing_hash != vault_key_hash_clean:
+                raise ValueError("vaultKeyHash mismatch")
+
+            wrappers = conn.execute(
+                text(
+                    """
+                    SELECT method, wrapper_id
+                    FROM vault_key_wrappers
+                    WHERE user_id = :user_id
+                    FOR UPDATE
+                    """
+                ),
+                {"user_id": user_id_clean},
+            ).fetchall()
+            if not any(
+                row_get(row, "method") == method_norm
+                and self._normalize_wrapper_id(row_get(row, "wrapper_id")) == wrapper_norm
+                for row in wrappers
+            ):
+                raise ValueError("Vault wrapper not found")
+
+            if len(wrappers) <= 1:
+                raise ValueError("Cannot remove the only vault unlock method")
+
+            has_passphrase = any(
+                row_get(row, "method") == "passphrase"
+                and self._normalize_wrapper_id(row_get(row, "wrapper_id")) == "default"
+                for row in wrappers
+            )
+            if not has_passphrase:
+                raise ValueError(
+                    "Passphrase wrapper is missing; repair passphrase before removing quick unlock"
+                )
+
+            primary_method = self._normalize_method(
+                row_get(vault_row, "primary_method") or "passphrase"
+            )
+            primary_wrapper = self._normalize_wrapper_id(row_get(vault_row, "primary_wrapper_id"))
+            deleting_primary = primary_method == method_norm and primary_wrapper == wrapper_norm
+
+            if deleting_primary:
+                fallback_method = self._normalize_method(fallback_primary_method or "passphrase")
+                fallback_wrapper = self._normalize_wrapper_id(fallback_primary_wrapper_id)
+                if fallback_method == method_norm and fallback_wrapper == wrapper_norm:
+                    raise ValueError("Fallback primary cannot be the wrapper being removed")
+
+                fallback_exists = any(
+                    row_get(row, "method") == fallback_method
+                    and self._normalize_wrapper_id(row_get(row, "wrapper_id")) == fallback_wrapper
+                    for row in wrappers
+                )
+                if not fallback_exists:
+                    raise ValueError("Fallback primary method/wrapper must be an enrolled wrapper")
+
+                now_ms = int(datetime.now().timestamp() * 1000)
+                updated_primary = conn.execute(
+                    text(
+                        """
+                        UPDATE vault_keys
+                        SET primary_method = :fallback_method,
+                            primary_wrapper_id = :fallback_wrapper,
+                            updated_at = :updated_at
+                        WHERE user_id = :user_id
+                          AND primary_method = :primary_method
+                          AND primary_wrapper_id = :primary_wrapper
+                        RETURNING user_id
+                        """
+                    ),
+                    {
+                        "user_id": user_id_clean,
+                        "fallback_method": fallback_method,
+                        "fallback_wrapper": fallback_wrapper,
+                        "updated_at": now_ms,
+                        "primary_method": primary_method,
+                        "primary_wrapper": primary_wrapper,
+                    },
+                ).fetchone()
+                if updated_primary is None:
+                    raise RuntimeError("Failed to switch primary method before wrapper removal.")
+
+            deleted_wrapper = conn.execute(
+                text(
+                    """
+                    DELETE FROM vault_key_wrappers
+                    WHERE user_id = :user_id
+                      AND method = :method
+                      AND wrapper_id = :wrapper_id
+                    RETURNING method
+                    """
+                ),
+                {
+                    "user_id": user_id_clean,
+                    "method": method_norm,
+                    "wrapper_id": wrapper_norm,
+                },
+            ).fetchone()
+            if deleted_wrapper is None:
+                raise RuntimeError("Failed to remove vault wrapper.")
+
+        logger.info(
+            "✅ Removed wrapper '%s' for user %s",
+            method_norm,
+            self._mask_user_id(user_id_clean),
+        )
+        self._invalidate_vault_state_cache(user_id_clean)
+        return True
+
     async def get_vault_status(self, user_id: str, consent_token: str) -> Dict[str, Any]:
         """Get status for all vault domains."""
         # Validate consent token

--- a/consent-protocol/scripts/local_sync_email_reviewer_from_kai_user.py
+++ b/consent-protocol/scripts/local_sync_email_reviewer_from_kai_user.py
@@ -65,12 +65,13 @@ def _resolve_users(
     source_user = auth.get_user(source_uid)
     target_user = auth.get_user_by_email(target_email)
 
-    auth.update_user(
-        target_user.uid,
-        display_name=source_user.display_name or "Kai Test Reviewer",
-        photo_url=source_user.photo_url,
-        password=target_password,
-    )
+    update_kwargs = {
+        "display_name": source_user.display_name or "Kai Test Reviewer",
+        "photo_url": source_user.photo_url,
+    }
+    if target_password:
+        update_kwargs["password"] = target_password
+    auth.update_user(target_user.uid, **update_kwargs)
 
     _log(
         f"Firebase target user ready: target_uid={target_user.uid} display_name={source_user.display_name or 'Kai Test Reviewer'}"
@@ -104,6 +105,7 @@ DELETE_TARGET_SQL = [
     "DELETE FROM ria_profiles WHERE user_id = $1",
     "DELETE FROM marketplace_public_profiles WHERE user_id = $1",
     "DELETE FROM runtime_persona_state WHERE user_id = $1",
+    "DELETE FROM one_kyc_client_connectors WHERE user_id = $1",
     "DELETE FROM actor_profiles WHERE user_id = $1",
     "DELETE FROM vault_key_wrappers WHERE user_id = $1",
     "DELETE FROM vault_keys WHERE user_id = $1",
@@ -547,6 +549,40 @@ async def _mirror_local_surface(conn: asyncpg.Connection, users: MirrorUsers) ->
             users.target_email,
         )
 
+        await conn.execute(
+            """
+            INSERT INTO one_kyc_client_connectors (
+              connector_id,
+              user_id,
+              connector_key_id,
+              connector_public_key,
+              connector_wrapping_alg,
+              public_key_fingerprint,
+              status,
+              created_at,
+              updated_at,
+              rotated_at,
+              revoked_at
+            )
+            SELECT
+              gen_random_uuid(),
+              $2,
+              connector_key_id,
+              connector_public_key,
+              connector_wrapping_alg,
+              public_key_fingerprint,
+              status,
+              created_at,
+              updated_at,
+              rotated_at,
+              revoked_at
+            FROM one_kyc_client_connectors
+            WHERE user_id = $1
+            """,
+            users.source_uid,
+            users.target_uid,
+        )
+
 
 async def _print_counts(conn: asyncpg.Connection, users: MirrorUsers) -> None:
     for table in [
@@ -561,6 +597,7 @@ async def _print_counts(conn: asyncpg.Connection, users: MirrorUsers) -> None:
         "marketplace_public_profiles",
         "ria_profiles",
         "runtime_persona_state",
+        "one_kyc_client_connectors",
     ]:
         count = await conn.fetchval(
             f"SELECT COUNT(*) FROM {table} WHERE user_id = $1", users.target_uid
@@ -604,7 +641,10 @@ def main() -> int:
     parser.add_argument(
         "--target-password",
         default="12345678",
-        help="Password to set on the target Firebase reviewer user.",
+        help=(
+            "Password to set on the target Firebase reviewer user. Pass an empty string "
+            "from callers that only need identity/vault mirroring."
+        ),
     )
     args = parser.parse_args()
     return asyncio.run(_run(args))

--- a/consent-protocol/tests/services/test_one_email_kyc_service.py
+++ b/consent-protocol/tests/services/test_one_email_kyc_service.py
@@ -690,6 +690,167 @@ async def test_process_message_matches_dynamic_available_scope_for_email_helper_
 
 
 @pytest.mark.asyncio
+async def test_dynamic_scope_detection_prefers_intent_domain_over_stopword_path_matches():
+    service = _service(_FakeDb(), _FakeConsentDb())
+
+    async def available_entries(user_id: str):
+        assert user_id == "user_123"
+        return [
+            {
+                "scope": (
+                    "attr.financial.analysis_history.aapl.items.raw_card.key_metrics."
+                    "fundamental.research_and_development_billions"
+                ),
+                "domain": "financial",
+                "path": (
+                    "analysis_history.aapl.items.raw_card.key_metrics.fundamental."
+                    "research_and_development_billions"
+                ),
+                "wildcard": False,
+                "label": "Research And Development Billions",
+                "consumer_visible": True,
+                "internal_only": False,
+            },
+            {
+                "scope": "attr.shopping.*",
+                "domain": "shopping",
+                "path": None,
+                "wildcard": True,
+                "label": "Shopping Domain",
+                "consumer_visible": True,
+                "internal_only": False,
+            },
+            {
+                "scope": "attr.shopping.receipts_memory",
+                "domain": "shopping",
+                "path": "receipts_memory",
+                "wildcard": False,
+                "label": "Receipts Memory",
+                "consumer_visible": True,
+                "internal_only": False,
+            },
+        ]
+
+    service._available_one_email_scope_entries = available_entries  # type: ignore[method-assign]
+
+    candidates = await service._detect_available_scope_candidates(
+        user_id="user_123",
+        subject="Get my information",
+        body="Hey One, can you get my shopping information and create a draft here.",
+    )
+
+    assert [candidate["scope"] for candidate in candidates] == ["attr.shopping.*"]
+
+
+@pytest.mark.asyncio
+async def test_dynamic_scope_detection_prefers_seat_preferences_over_generic_preferences():
+    service = _service(_FakeDb(), _FakeConsentDb())
+
+    async def available_entries(user_id: str):
+        assert user_id == "user_123"
+        return [
+            {
+                "scope": "attr.financial.profile.preferences",
+                "domain": "financial",
+                "path": "profile.preferences",
+                "wildcard": False,
+                "label": "Profile Preferences",
+                "consumer_visible": True,
+                "internal_only": False,
+            },
+            {
+                "scope": "attr.location.preferences.*",
+                "domain": "location",
+                "path": "preferences",
+                "wildcard": True,
+                "label": "Preferences",
+                "consumer_visible": True,
+                "internal_only": False,
+            },
+            {
+                "scope": "attr.travel.seat_preferences.*",
+                "domain": "travel",
+                "path": "seat_preferences",
+                "wildcard": True,
+                "label": "Seat Preferences",
+                "consumer_visible": True,
+                "internal_only": False,
+            },
+            {
+                "scope": "attr.travel.seat_preferences.entities.travel_preference_seat_001",
+                "domain": "travel",
+                "path": "seat_preferences.entities.travel_preference_seat_001",
+                "wildcard": False,
+                "label": "Seat Preferences Entities Travel Preference Seat 001",
+                "consumer_visible": True,
+                "internal_only": False,
+            },
+        ]
+
+    service._available_one_email_scope_entries = available_entries  # type: ignore[method-assign]
+
+    candidates = await service._detect_available_scope_candidates(
+        user_id="user_123",
+        subject="Get my information",
+        body="Hey One, can you get my seat preferences and create a draft here.",
+    )
+
+    assert [candidate["scope"] for candidate in candidates] == ["attr.travel.seat_preferences.*"]
+
+
+@pytest.mark.asyncio
+async def test_reply_classification_ignores_quoted_prior_thread_text():
+    db = _FakeDb()
+    consent_db = _FakeConsentDb()
+    service = _service(db, consent_db)
+
+    async def available_entries(user_id: str):
+        assert user_id == "user_123"
+        return [
+            {
+                "scope": "attr.shopping.*",
+                "domain": "shopping",
+                "path": None,
+                "wildcard": True,
+                "label": "Shopping Domain",
+                "consumer_visible": True,
+                "internal_only": False,
+            },
+            {
+                "scope": "attr.travel.seat_preferences.*",
+                "domain": "travel",
+                "path": "seat_preferences",
+                "wildcard": True,
+                "label": "Seat Preferences",
+                "consumer_visible": True,
+                "internal_only": False,
+            },
+        ]
+
+    service._available_one_email_scope_entries = available_entries  # type: ignore[method-assign]
+
+    result = await service._process_message(
+        _message(
+            subject="Re: Get my information",
+            body=(
+                "can you get my seat preferences\n\n"
+                "On Thu, 14 May 2026 at 04:57, Kushal Trivedi wrote:\n"
+                "> can you retrieve my shopping preferences and share here.\n"
+            ),
+        ),
+        history_id="101reply",
+    )
+
+    workflow = result["workflow"]
+    assert workflow["requested_scope"] == "attr.travel.seat_preferences.*"
+    assert workflow["required_fields"] == ["seat_preferences"]
+    assert workflow["metadata"]["quoted_reply_text_stripped"] is True
+    assert [item["scope"] for item in workflow["metadata"]["candidate_scopes"]] == [
+        "attr.travel.seat_preferences.*"
+    ]
+
+
+@pytest.mark.asyncio
 async def test_select_scopes_creates_bundled_multi_scope_consent_requests():
     db = _FakeDb()
     consent_db = _FakeConsentDb()

--- a/consent-protocol/tests/test_account_routes.py
+++ b/consent-protocol/tests/test_account_routes.py
@@ -44,7 +44,9 @@ def test_refresh_account_identity_returns_synced_identity(monkeypatch):
 
 def test_claim_account_phone_requires_firebase_auth():
     client = TestClient(_build_app())
-    response = client.post("/api/account/phone/claim", json={"phone_id_token": "phone-claim-sample"})
+    response = client.post(
+        "/api/account/phone/claim", json={"phone_id_token": "phone-claim-sample"}
+    )
 
     assert response.status_code == 401
 
@@ -70,7 +72,9 @@ def test_claim_account_phone_persists_verified_phone(monkeypatch):
     monkeypatch.setattr(ActorIdentityService, "claim_verified_phone", _mock_claim)
 
     client = TestClient(app)
-    response = client.post("/api/account/phone/claim", json={"phone_id_token": "phone-claim-sample"})
+    response = client.post(
+        "/api/account/phone/claim", json={"phone_id_token": "phone-claim-sample"}
+    )
 
     assert response.status_code == 200
     payload = response.json()
@@ -115,7 +119,9 @@ def test_claim_account_phone_rejects_phone_token_without_phone_number(monkeypatc
     monkeypatch.setattr(account, "_verify_phone_claim_id_token", _mock_verify)
 
     client = TestClient(app)
-    response = client.post("/api/account/phone/claim", json={"phone_id_token": "phone-claim-sample"})
+    response = client.post(
+        "/api/account/phone/claim", json={"phone_id_token": "phone-claim-sample"}
+    )
 
     assert response.status_code == 422
     assert response.json()["detail"]["code"] == "PHONE_ID_TOKEN_MISSING_PHONE_NUMBER"
@@ -134,7 +140,9 @@ def test_claim_account_phone_maps_persistence_failure(monkeypatch):
     monkeypatch.setattr(ActorIdentityService, "claim_verified_phone", _mock_claim)
 
     client = TestClient(app)
-    response = client.post("/api/account/phone/claim", json={"phone_id_token": "phone-claim-sample"})
+    response = client.post(
+        "/api/account/phone/claim", json={"phone_id_token": "phone-claim-sample"}
+    )
 
     assert response.status_code == 503
     assert response.json()["detail"]["code"] == "PHONE_CLAIM_PERSISTENCE_UNAVAILABLE"

--- a/consent-protocol/tests/test_db_proxy_vault_owner_token.py
+++ b/consent-protocol/tests/test_db_proxy_vault_owner_token.py
@@ -3,10 +3,17 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
 
 from api.routes import db_proxy
 from hushh_mcp.constants import ConsentScope
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(db_proxy.router)
+    return app
 
 
 @pytest.mark.asyncio
@@ -63,3 +70,23 @@ async def test_validate_vault_owner_token_user_mismatch_returns_403(monkeypatch)
 
     assert exc.value.status_code == 403
     assert exc.value.detail == "Token userId does not match requested userId"
+
+
+def test_vault_wrapper_delete_requires_vault_owner_unlock_proof_with_firebase_auth():
+    app = _build_app()
+    app.dependency_overrides[db_proxy.require_firebase_auth] = lambda: "user_123"
+    client = TestClient(app)
+
+    response = client.post(
+        "/db/vault/wrapper/delete",
+        headers={"Authorization": "Bearer firebase-id-token"},
+        json={
+            "userId": "user_123",
+            "vaultKeyHash": "hash-1",
+            "method": "generated_default_web_prf",
+            "wrapperId": "cred-1",
+        },
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Missing X-Hushh-Consent header"

--- a/consent-protocol/tests/test_developer_api_routes.py
+++ b/consent-protocol/tests/test_developer_api_routes.py
@@ -253,6 +253,21 @@ def test_user_scopes_returns_discovered_domains(monkeypatch):
                     "visibility_reason": "structural_top_level_path",
                 },
                 {
+                    "scope": "attr.kyc_workflow.*",
+                    "domain": "kyc_workflow",
+                    "path": None,
+                    "wildcard": True,
+                    "source_kind": "pkm_index",
+                    "registry_handle": None,
+                    "label": "KYC Workflow Domain",
+                    "exposure_eligibility": True,
+                    "manifest_revision": 2,
+                    "meta_reference": "internal runtime domain",
+                    "consumer_visible": False,
+                    "internal_only": True,
+                    "visibility_reason": "internal_runtime_domain",
+                },
+                {
                     "scope": "attr.financial.profile.risk_tolerance",
                     "domain": "financial",
                     "path": "profile.risk_tolerance",
@@ -267,7 +282,7 @@ def test_user_scopes_returns_discovered_domains(monkeypatch):
             ]
 
     class _FakeIndex:
-        available_domains = ["financial"]
+        available_domains = ["financial", "kyc_workflow"]
 
     class _FakePkmService:
         scope_generator = _FakeScopeGenerator()

--- a/consent-protocol/tests/test_mcp_email_uid_resolution.py
+++ b/consent-protocol/tests/test_mcp_email_uid_resolution.py
@@ -37,13 +37,13 @@ class _FakeAsyncClient:
         assert url.endswith("/api/user/lookup")
         assert headers == {"X-MCP-Developer-Token": "dev-token"}
 
-        if identifier == "jd77v9k4nx@privaterelay.appleid.com":
+        if identifier == "kushaltrivedi1711@gmail.com":
             return _FakeResponse(
                 {
                     "exists": True,
-                    "user_id": "s3xmA4lNSAQFrIaOytnSGAOzXlL2",
-                    "email": "jd77v9k4nx@privaterelay.appleid.com",
-                    "display_name": "Kai Test User",
+                    "user_id": "UWHGeUyfUAbmEl5xwIPoWJ7Cyft2",
+                    "email": "kushaltrivedi1711@gmail.com",
+                    "display_name": "Kushal Trivedi",
                 }
             )
 
@@ -77,12 +77,12 @@ def test_consent_tools_resolve_email_to_uid_uses_header_token(monkeypatch):
     monkeypatch.setattr(consent_tools.httpx, "AsyncClient", _FakeAsyncClient)
 
     resolved_uid, email, display_name = asyncio.run(
-        consent_tools.resolve_email_to_uid("jd77v9k4nx@privaterelay.appleid.com")
+        consent_tools.resolve_email_to_uid("kushaltrivedi1711@gmail.com")
     )
 
-    assert resolved_uid == "s3xmA4lNSAQFrIaOytnSGAOzXlL2"
-    assert email == "jd77v9k4nx@privaterelay.appleid.com"
-    assert display_name == "Kai Test User"
+    assert resolved_uid == "UWHGeUyfUAbmEl5xwIPoWJ7Cyft2"
+    assert email == "kushaltrivedi1711@gmail.com"
+    assert display_name == "Kushal Trivedi"
 
 
 def test_consent_tools_resolve_phone_to_uid_uses_header_token(monkeypatch):
@@ -102,11 +102,9 @@ def test_data_tools_resolve_email_to_uid_uses_header_token(monkeypatch):
     monkeypatch.setenv("HUSHH_DEVELOPER_TOKEN", "dev-token")
     monkeypatch.setattr(consent_tools.httpx, "AsyncClient", _FakeAsyncClient)
 
-    resolved_uid = asyncio.run(
-        data_tools.resolve_email_to_uid("jd77v9k4nx@privaterelay.appleid.com")
-    )
+    resolved_uid = asyncio.run(data_tools.resolve_email_to_uid("kushaltrivedi1711@gmail.com"))
 
-    assert resolved_uid == "s3xmA4lNSAQFrIaOytnSGAOzXlL2"
+    assert resolved_uid == "UWHGeUyfUAbmEl5xwIPoWJ7Cyft2"
 
 
 def test_data_tools_resolve_phone_to_uid_uses_header_token(monkeypatch):

--- a/consent-protocol/tests/test_vault_keys_metadata.py
+++ b/consent-protocol/tests/test_vault_keys_metadata.py
@@ -13,6 +13,9 @@ class _FakeSQLResult:
             return None
         return self._rows[0]
 
+    def fetchall(self):
+        return self._rows
+
 
 class _FakeSQLConnection:
     def __init__(self, supabase):
@@ -21,6 +24,67 @@ class _FakeSQLConnection:
     def execute(self, statement, params):
         sql = " ".join(str(statement).strip().split()).lower()
         db = self._supabase.db
+
+        if "select vault_key_hash, primary_method, primary_wrapper_id from vault_keys" in sql:
+            rows = [
+                {
+                    "vault_key_hash": row.get("vault_key_hash"),
+                    "primary_method": row.get("primary_method"),
+                    "primary_wrapper_id": row.get("primary_wrapper_id"),
+                }
+                for row in db["vault_keys"]
+                if row.get("user_id") == params["user_id"]
+            ]
+            return _FakeSQLResult(rows=rows, rowcount=len(rows))
+
+        if "select method, wrapper_id from vault_key_wrappers" in sql:
+            rows = [
+                {"method": row.get("method"), "wrapper_id": row.get("wrapper_id")}
+                for row in db["vault_key_wrappers"]
+                if row.get("user_id") == params["user_id"]
+            ]
+            return _FakeSQLResult(rows=rows, rowcount=len(rows))
+
+        if "update vault_keys set primary_method" in sql:
+            if db.get("_update_raises"):
+                raise RuntimeError("forced primary update failure")
+            updated = []
+            for row in db["vault_keys"]:
+                if (
+                    row.get("user_id") == params["user_id"]
+                    and row.get("primary_method") == params["primary_method"]
+                    and row.get("primary_wrapper_id") == params["primary_wrapper"]
+                ):
+                    row.update(
+                        {
+                            "primary_method": params["fallback_method"],
+                            "primary_wrapper_id": params["fallback_wrapper"],
+                            "updated_at": params["updated_at"],
+                        }
+                    )
+                    updated.append({"user_id": row["user_id"]})
+            return _FakeSQLResult(rows=updated, rowcount=len(updated))
+
+        if (
+            "delete from vault_key_wrappers" in sql
+            and "and method = :method" in sql
+            and "and wrapper_id = :wrapper_id" in sql
+        ):
+            if db.get("_delete_raises"):
+                raise RuntimeError("forced wrapper delete failure")
+            keep = []
+            deleted = []
+            for row in db["vault_key_wrappers"]:
+                if (
+                    row.get("user_id") == params["user_id"]
+                    and row.get("method") == params["method"]
+                    and row.get("wrapper_id") == params["wrapper_id"]
+                ):
+                    deleted.append({"method": row.get("method")})
+                    continue
+                keep.append(row)
+            db["vault_key_wrappers"] = keep
+            return _FakeSQLResult(rows=deleted, rowcount=len(deleted))
 
         if "insert into vault_keys" in sql:
             incoming = dict(params)
@@ -102,14 +166,16 @@ class _FakeTransactionContext:
 
     def __enter__(self):
         self._snapshot = {
-            table: [dict(row) for row in rows] for table, rows in self._supabase.db.items()
+            table: [dict(row) for row in rows] if isinstance(rows, list) else rows
+            for table, rows in self._supabase.db.items()
         }
         return _FakeSQLConnection(self._supabase)
 
     def __exit__(self, exc_type, exc, _tb):
         if exc_type is not None:
             self._supabase.db = {
-                table: [dict(row) for row in rows] for table, rows in self._snapshot.items()
+                table: [dict(row) for row in rows] if isinstance(rows, list) else rows
+                for table, rows in self._snapshot.items()
             }
         return False
 
@@ -180,13 +246,15 @@ class _FakeQuery:
             return _FakeResponse(self._filtered_rows())
 
         if self._op == "delete":
+            if self.db.get("_delete_raises"):
+                raise RuntimeError("forced wrapper delete failure")
             keep = []
             for row in self.db[self.table_name]:
                 if all(row.get(key) == value for key, value in self._filters.items()):
                     continue
                 keep.append(row)
             self.db[self.table_name] = keep
-            return _FakeResponse([])
+            return _FakeResponse(None if self.db.get("_delete_returns_none") else [])
 
         if self._op == "update":
             for row in self.db[self.table_name]:
@@ -516,6 +584,204 @@ async def test_setup_vault_state_requires_passphrase_wrapper():
                     "passkeyRpId": "localhost",
                 }
             ],
+        )
+
+
+@pytest.mark.asyncio
+async def test_delete_wrapper_removes_primary_passkey_and_falls_back_to_passphrase():
+    fake = _FakeSupabase()
+    fake.db["vault_keys"].append(
+        {
+            "user_id": "user-1",
+            "vault_key_hash": "vault-hash",
+            "primary_method": "generated_default_web_prf",
+            "primary_wrapper_id": "cred-1",
+            "recovery_encrypted_vault_key": "recovery-enc",
+            "recovery_salt": "recovery-salt",
+            "recovery_iv": "recovery-iv",
+        }
+    )
+    fake.db["vault_key_wrappers"] = [
+        {
+            "user_id": "user-1",
+            "method": "passphrase",
+            "wrapper_id": "default",
+            "encrypted_vault_key": "enc-pass",
+            "salt": "salt-pass",
+            "iv": "iv-pass",
+        },
+        {
+            "user_id": "user-1",
+            "method": "generated_default_web_prf",
+            "wrapper_id": "cred-1",
+            "encrypted_vault_key": "enc-prf",
+            "salt": "salt-prf",
+            "iv": "iv-prf",
+            "passkey_credential_id": "cred-1",
+            "passkey_prf_salt": "prf-salt",
+            "passkey_rp_id": "localhost",
+        },
+    ]
+
+    service = VaultKeysService()
+    service._supabase = fake
+
+    result = await service.delete_wrapper(
+        user_id="user-1",
+        vault_key_hash="vault-hash",
+        method="generated_default_web_prf",
+        wrapper_id="cred-1",
+    )
+
+    assert result is True
+    assert fake.db["vault_keys"][0]["primary_method"] == "passphrase"
+    assert fake.db["vault_keys"][0]["primary_wrapper_id"] == "default"
+    assert [row["method"] for row in fake.db["vault_key_wrappers"]] == ["passphrase"]
+
+
+@pytest.mark.asyncio
+async def test_delete_wrapper_accepts_minimal_delete_response_after_verify():
+    fake = _FakeSupabase()
+    fake.db["_delete_returns_none"] = True
+    fake.db["vault_keys"].append(
+        {
+            "user_id": "user-1",
+            "vault_key_hash": "vault-hash",
+            "primary_method": "passphrase",
+            "primary_wrapper_id": "default",
+        }
+    )
+    fake.db["vault_key_wrappers"] = [
+        {
+            "user_id": "user-1",
+            "method": "passphrase",
+            "wrapper_id": "default",
+            "encrypted_vault_key": "enc-pass",
+            "salt": "salt-pass",
+            "iv": "iv-pass",
+        },
+        {
+            "user_id": "user-1",
+            "method": "generated_default_web_prf",
+            "wrapper_id": "cred-1",
+            "encrypted_vault_key": "enc-prf",
+            "salt": "salt-prf",
+            "iv": "iv-prf",
+            "passkey_credential_id": "cred-1",
+            "passkey_prf_salt": "prf-salt",
+            "passkey_rp_id": "localhost",
+        },
+    ]
+
+    service = VaultKeysService()
+    service._supabase = fake
+
+    result = await service.delete_wrapper(
+        user_id="user-1",
+        vault_key_hash="vault-hash",
+        method="generated_default_web_prf",
+        wrapper_id="cred-1",
+    )
+
+    assert result is True
+    assert [row["method"] for row in fake.db["vault_key_wrappers"]] == ["passphrase"]
+
+
+@pytest.mark.asyncio
+async def test_delete_wrapper_rolls_back_primary_when_delete_fails():
+    fake = _FakeSupabase()
+    fake.db["_delete_raises"] = True
+    fake.db["vault_keys"].append(
+        {
+            "user_id": "user-1",
+            "vault_key_hash": "vault-hash",
+            "primary_method": "generated_default_web_prf",
+            "primary_wrapper_id": "cred-1",
+        }
+    )
+    fake.db["vault_key_wrappers"] = [
+        {
+            "user_id": "user-1",
+            "method": "passphrase",
+            "wrapper_id": "default",
+            "encrypted_vault_key": "enc-pass",
+            "salt": "salt-pass",
+            "iv": "iv-pass",
+        },
+        {
+            "user_id": "user-1",
+            "method": "generated_default_web_prf",
+            "wrapper_id": "cred-1",
+            "encrypted_vault_key": "enc-prf",
+            "salt": "salt-prf",
+            "iv": "iv-prf",
+        },
+    ]
+
+    service = VaultKeysService()
+    service._supabase = fake
+
+    with pytest.raises(RuntimeError, match="forced wrapper delete failure"):
+        await service.delete_wrapper(
+            user_id="user-1",
+            vault_key_hash="vault-hash",
+            method="generated_default_web_prf",
+            wrapper_id="cred-1",
+        )
+
+    assert fake.db["vault_keys"][0]["primary_method"] == "generated_default_web_prf"
+    assert fake.db["vault_keys"][0]["primary_wrapper_id"] == "cred-1"
+    assert {row["method"] for row in fake.db["vault_key_wrappers"]} == {
+        "passphrase",
+        "generated_default_web_prf",
+    }
+
+
+@pytest.mark.asyncio
+async def test_delete_wrapper_rejects_passphrase_removal():
+    fake = _FakeSupabase()
+    fake.db["vault_keys"].append(
+        {
+            "user_id": "user-1",
+            "vault_key_hash": "vault-hash",
+            "primary_method": "passphrase",
+            "primary_wrapper_id": "default",
+        }
+    )
+
+    service = VaultKeysService()
+    service._supabase = fake
+
+    with pytest.raises(ValueError, match="Passphrase wrapper cannot be removed"):
+        await service.delete_wrapper(
+            user_id="user-1",
+            vault_key_hash="vault-hash",
+            method="passphrase",
+            wrapper_id="default",
+        )
+
+
+@pytest.mark.asyncio
+async def test_delete_wrapper_rejects_stale_vault_key_hash():
+    fake = _FakeSupabase()
+    fake.db["vault_keys"].append(
+        {
+            "user_id": "user-1",
+            "vault_key_hash": "vault-hash",
+            "primary_method": "generated_default_web_prf",
+            "primary_wrapper_id": "cred-1",
+        }
+    )
+
+    service = VaultKeysService()
+    service._supabase = fake
+
+    with pytest.raises(ValueError, match="vaultKeyHash mismatch"):
+        await service.delete_wrapper(
+            user_id="user-1",
+            vault_key_hash="stale-hash",
+            method="generated_default_web_prf",
+            wrapper_id="cred-1",
         )
 
 

--- a/contracts/kai/kai-action-gateway.vnext.json
+++ b/contracts/kai/kai-action-gateway.vnext.json
@@ -60,7 +60,7 @@
     {
       "schema_version": "kai.local_action_contract.v1",
       "surface_id": "one_kyc",
-      "surface_title": "One KYC",
+      "surface_title": "Email",
       "docs_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md",
         "docs/reference/architecture/one-email-kyc.md",
@@ -1123,19 +1123,19 @@
     {
       "action_id": "route.one_kyc",
       "surface_id": "one_kyc",
-      "label": "Open One KYC",
+      "label": "Open Email",
       "aliases": [
-        "open kyc",
-        "open one kyc",
-        "show kyc workflows",
-        "show broker requests"
+        "open email",
+        "open email helper",
+        "show email requests",
+        "show requests"
       ],
       "search_keywords": [
-        "kyc",
+        "email",
         "one",
-        "broker"
+        "request"
       ],
-      "meaning": "Navigates to One broker request review.",
+      "meaning": "Navigates to One email request review.",
       "speaker_persona": "kyc",
       "delegate_agent_id": "kyc",
       "reachability": {
@@ -1198,15 +1198,15 @@
       "label": "Manage Verified Emails",
       "aliases": [
         "manage verified emails",
-        "add broker email",
+        "add email address",
         "show matching emails"
       ],
       "search_keywords": [
-        "kyc",
         "email",
-        "broker"
+        "address",
+        "match"
       ],
-      "meaning": "Opens the verified email address panel used to match broker KYC requests.",
+      "meaning": "Opens the verified email address panel used to match email requests.",
       "speaker_persona": "kyc",
       "delegate_agent_id": "kyc",
       "reachability": {
@@ -1266,17 +1266,17 @@
     {
       "action_id": "kyc.workflow.sync_status",
       "surface_id": "one_kyc",
-      "label": "Sync KYC Status",
+      "label": "Sync Email Status",
       "aliases": [
-        "sync kyc",
-        "refresh kyc status"
+        "sync email",
+        "refresh request status"
       ],
       "search_keywords": [
-        "kyc",
+        "email",
         "sync",
         "consent"
       ],
-      "meaning": "Refreshes the selected One KYC workflow status after consent approval.",
+      "meaning": "Refreshes the selected email request status after consent approval.",
       "speaker_persona": "kyc",
       "delegate_agent_id": "kyc",
       "reachability": {
@@ -1335,17 +1335,17 @@
     {
       "action_id": "kyc.draft.review",
       "surface_id": "one_kyc",
-      "label": "Review KYC Draft",
+      "label": "Review Email Draft",
       "aliases": [
-        "review kyc draft",
-        "show kyc draft"
+        "review email draft",
+        "show email draft"
       ],
       "search_keywords": [
-        "kyc",
+        "email",
         "draft",
         "review"
       ],
-      "meaning": "Reads or focuses the current approval-gated KYC draft.",
+      "meaning": "Reads or focuses the current approval-gated email draft.",
       "speaker_persona": "kyc",
       "delegate_agent_id": "kyc",
       "reachability": {
@@ -1404,17 +1404,17 @@
     {
       "action_id": "kyc.draft.request_redraft",
       "surface_id": "one_kyc",
-      "label": "Request KYC Redraft",
+      "label": "Request Email Redraft",
       "aliases": [
-        "redraft kyc",
-        "revise kyc draft"
+        "redraft email",
+        "revise email draft"
       ],
       "search_keywords": [
-        "kyc",
+        "email",
         "redraft",
         "revise"
       ],
-      "meaning": "Requests a new KYC draft revision from typed or spoken user instructions.",
+      "meaning": "Requests a new email draft revision from typed or spoken user instructions.",
       "speaker_persona": "kyc",
       "delegate_agent_id": "kyc",
       "reachability": {
@@ -1474,17 +1474,17 @@
     {
       "action_id": "kyc.draft.approve_send",
       "surface_id": "one_kyc",
-      "label": "Approve KYC Send",
+      "label": "Approve Email Send",
       "aliases": [
-        "approve kyc send",
-        "send kyc reply"
+        "approve email send",
+        "send email reply"
       ],
       "search_keywords": [
-        "kyc",
+        "email",
         "send",
         "approve"
       ],
-      "meaning": "Sends the KYC draft only after explicit user approval.",
+      "meaning": "Sends the email draft only after explicit user approval.",
       "speaker_persona": "kyc",
       "delegate_agent_id": "kyc",
       "reachability": {
@@ -1545,17 +1545,17 @@
     {
       "action_id": "kyc.draft.reject",
       "surface_id": "one_kyc",
-      "label": "Reject KYC Draft",
+      "label": "Reject Email Draft",
       "aliases": [
-        "reject kyc draft",
-        "block kyc workflow"
+        "reject email draft",
+        "block email request"
       ],
       "search_keywords": [
-        "kyc",
+        "email",
         "reject",
         "block"
       ],
-      "meaning": "Rejects the current KYC draft and blocks the workflow.",
+      "meaning": "Rejects the current email draft and blocks the workflow.",
       "speaker_persona": "kyc",
       "delegate_agent_id": "kyc",
       "reachability": {

--- a/contracts/kai/voice-action-manifest.v1.json
+++ b/contracts/kai/voice-action-manifest.v1.json
@@ -426,15 +426,15 @@
     },
     {
       "id": "route.one_kyc",
-      "label": "Open One KYC",
-      "meaning": "Navigates to One broker request review.",
+      "label": "Open Email",
+      "meaning": "Navigates to One email request review.",
       "speaker_persona": "kyc",
       "delegate_agent_id": "kyc",
       "aliases": [
-        "open kyc",
-        "open one kyc",
-        "show kyc workflows",
-        "show broker requests"
+        "open email",
+        "open email helper",
+        "show email requests",
+        "show requests"
       ],
       "scope": {
         "routes": [
@@ -467,12 +467,12 @@
     {
       "id": "kyc.aliases.manage",
       "label": "Manage Verified Emails",
-      "meaning": "Opens the verified email address panel used to match broker KYC requests.",
+      "meaning": "Opens the verified email address panel used to match email requests.",
       "speaker_persona": "kyc",
       "delegate_agent_id": "kyc",
       "aliases": [
         "manage verified emails",
-        "add broker email",
+        "add email address",
         "show matching emails"
       ],
       "scope": {
@@ -504,13 +504,13 @@
     },
     {
       "id": "kyc.workflow.sync_status",
-      "label": "Sync KYC Status",
-      "meaning": "Refreshes the selected One KYC workflow status after consent approval.",
+      "label": "Sync Email Status",
+      "meaning": "Refreshes the selected email request status after consent approval.",
       "speaker_persona": "kyc",
       "delegate_agent_id": "kyc",
       "aliases": [
-        "sync kyc",
-        "refresh kyc status"
+        "sync email",
+        "refresh request status"
       ],
       "scope": {
         "routes": [
@@ -541,13 +541,13 @@
     },
     {
       "id": "kyc.draft.review",
-      "label": "Review KYC Draft",
-      "meaning": "Reads or focuses the current approval-gated KYC draft.",
+      "label": "Review Email Draft",
+      "meaning": "Reads or focuses the current approval-gated email draft.",
       "speaker_persona": "kyc",
       "delegate_agent_id": "kyc",
       "aliases": [
-        "review kyc draft",
-        "show kyc draft"
+        "review email draft",
+        "show email draft"
       ],
       "scope": {
         "routes": [
@@ -578,13 +578,13 @@
     },
     {
       "id": "kyc.draft.request_redraft",
-      "label": "Request KYC Redraft",
-      "meaning": "Requests a new KYC draft revision from typed or spoken user instructions.",
+      "label": "Request Email Redraft",
+      "meaning": "Requests a new email draft revision from typed or spoken user instructions.",
       "speaker_persona": "kyc",
       "delegate_agent_id": "kyc",
       "aliases": [
-        "redraft kyc",
-        "revise kyc draft"
+        "redraft email",
+        "revise email draft"
       ],
       "scope": {
         "routes": [
@@ -615,13 +615,13 @@
     },
     {
       "id": "kyc.draft.approve_send",
-      "label": "Approve KYC Send",
-      "meaning": "Sends the KYC draft only after explicit user approval.",
+      "label": "Approve Email Send",
+      "meaning": "Sends the email draft only after explicit user approval.",
       "speaker_persona": "kyc",
       "delegate_agent_id": "kyc",
       "aliases": [
-        "approve kyc send",
-        "send kyc reply"
+        "approve email send",
+        "send email reply"
       ],
       "scope": {
         "routes": [
@@ -653,13 +653,13 @@
     },
     {
       "id": "kyc.draft.reject",
-      "label": "Reject KYC Draft",
-      "meaning": "Rejects the current KYC draft and blocks the workflow.",
+      "label": "Reject Email Draft",
+      "meaning": "Rejects the current email draft and blocks the workflow.",
       "speaker_persona": "kyc",
       "delegate_agent_id": "kyc",
       "aliases": [
-        "reject kyc draft",
-        "block kyc workflow"
+        "reject email draft",
+        "block email request"
       ],
       "scope": {
         "routes": [

--- a/docs/guides/mobile.md
+++ b/docs/guides/mobile.md
@@ -560,6 +560,7 @@ Native plugins call Python backend directly, bypassing Next.js:
 | Vault Get        | `POST /db/vault/get`                 | `GET /api/vault/get`                      | Python  |
 | Vault Setup      | `POST /db/vault/setup`               | `POST /api/vault/setup`                   | Python  |
 | Vault Wrapper Upsert | `POST /db/vault/wrapper/upsert`   | `POST /api/vault/wrapper/upsert`          | Python  |
+| Vault Wrapper Delete | `POST /db/vault/wrapper/delete`   | `POST /api/vault/wrapper/delete`          | Python  |
 | Vault Primary Set | `POST /db/vault/primary/set`        | `POST /api/vault/primary/set`             | Python  |
 | Food Get         | `POST /api/food/preferences`         | `GET /api/vault/food/preferences`         | Python  |
 | Professional Get | `POST /api/professional/preferences` | `GET /api/vault/professional/preferences` | Python  |

--- a/docs/reference/architecture/api-contracts.md
+++ b/docs/reference/architecture/api-contracts.md
@@ -300,13 +300,18 @@ Vault setup/get now use a multi-wrapper `VaultState` contract:
   - `iv`
   - `passkeyCredentialId` (nullable)
   - `passkeyPrfSalt` (nullable)
+  - `passkeyRpId` (nullable)
+  - `passkeyProvider` (nullable)
+  - `passkeyDeviceLabel` (nullable, friendly label captured at enrollment when available)
+  - `passkeyLastUsedAt` (nullable)
 
 Method-management semantics:
 - Passphrase wrapper is mandatory for every vault.
 - Recovery wrapper is mandatory for every vault.
 - Optional quick methods (native biometric/web PRF passkey) add wrappers for the same DEK.
 - Primary method only controls default unlock UX; fallback wrappers remain valid.
-- Additional endpoints: `POST /db/vault/wrapper/upsert`, `POST /db/vault/primary/set`.
+- Wrapper deletion is a vault-key-verified mutation: `POST /db/vault/wrapper/delete` requires `vaultKeyHash`, refuses passphrase removal, and moves primary unlock to an enrolled fallback when the removed wrapper was primary.
+- Additional endpoints: `POST /db/vault/wrapper/upsert`, `POST /db/vault/wrapper/delete`, `POST /db/vault/primary/set`.
 
 Security invariant:
 - No plaintext-at-rest path is allowed.

--- a/docs/reference/architecture/pkm-cutover-runbook.md
+++ b/docs/reference/architecture/pkm-cutover-runbook.md
@@ -42,7 +42,7 @@ This is the bounded runbook for cutting Kai from legacy encrypted storage to the
 
 ## Local/UAT drill user
 
-- `REVIEWER_UID=s3xmA4lNSAQFrIaOytnSGAOzXlL2`
+- `REVIEWER_UID=UWHGeUyfUAbmEl5xwIPoWJ7Cyft2`
 - passphrase is stored only in ignored local/UAT env files and secret storage
 - never commit the real passphrase into tracked examples or production env
 

--- a/hushh-webapp/__tests__/api/vault-wrapper-delete-proxy.test.ts
+++ b/hushh-webapp/__tests__/api/vault-wrapper-delete-proxy.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+describe("POST /api/vault/wrapper/delete", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.NEXT_PUBLIC_APP_ENV = "development";
+    process.env.PYTHON_API_URL = "http://backend.test";
+    global.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    ) as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    delete process.env.PYTHON_API_URL;
+  });
+
+  it("rejects body-only vault owner tokens before proxying", async () => {
+    const route = await import("../../app/api/vault/wrapper/delete/route");
+    const request = new NextRequest("http://localhost:3000/api/vault/wrapper/delete", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer DEV_TOKEN",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        userId: "user-1",
+        vaultKeyHash: "vault-hash",
+        method: "generated_default_web_prf",
+        wrapperId: "cred-1",
+        vaultOwnerToken: "vault-owner-token",
+      }),
+    });
+
+    const response = await route.POST(request);
+    const payload = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(payload.code).toBe("VAULT_OWNER_TOKEN_REQUIRED");
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("forwards Firebase identity and vault-owner unlock proof as separate headers", async () => {
+    const route = await import("../../app/api/vault/wrapper/delete/route");
+    const request = new NextRequest("http://localhost:3000/api/vault/wrapper/delete", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer DEV_TOKEN",
+        "X-Hushh-Consent": "vault-owner-token",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        userId: "user-1",
+        vaultKeyHash: "vault-hash",
+        method: "generated_default_web_prf",
+        wrapperId: "cred-1",
+      }),
+    });
+
+    const response = await route.POST(request);
+
+    expect(response.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://backend.test/db/vault/wrapper/delete",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer DEV_TOKEN",
+          "X-Hushh-Consent": "Bearer vault-owner-token",
+        }),
+      })
+    );
+  });
+});

--- a/hushh-webapp/__tests__/components/pkm-data-manager.test.tsx
+++ b/hushh-webapp/__tests__/components/pkm-data-manager.test.tsx
@@ -163,7 +163,7 @@ describe("PkmDomainDetailPanel", () => {
     expect(screen.getByText("$412,000")).toBeTruthy();
     expect(screen.queryByText("saved_data")).toBeNull();
     const dialogContent = document.querySelector('[data-slot="dialog-content"]');
-    expect(dialogContent?.className).toContain("sm:max-w-[min(26rem,calc(100vw-8rem))]");
+    expect(dialogContent?.className).toContain("sm:max-w-[min(42rem,calc(100vw-4rem))]");
     expect(screen.getByRole("button", { name: "Close" })).toBeTruthy();
   });
 });

--- a/hushh-webapp/__tests__/lib/one-kyc-workflow-state.test.ts
+++ b/hushh-webapp/__tests__/lib/one-kyc-workflow-state.test.ts
@@ -42,6 +42,20 @@ describe("one KYC workflow state helpers", () => {
     ]);
   });
 
+  it("does not treat every detected candidate as selected before user review", () => {
+    const current = workflow({
+      requested_scope: "attr.shopping.*",
+      metadata: {
+        candidate_scopes: [
+          { scope: "attr.shopping.*", domain: "shopping", label: "Shopping" },
+          { scope: "attr.shopping.receipts_memory.*", domain: "shopping", label: "Receipts" },
+        ],
+      },
+    });
+
+    expect(selectedScopesForWorkflow(current, {})).toEqual(["attr.shopping.*"]);
+  });
+
   it("drops local decrypted draft state once a workflow leaves ready review", () => {
     const ready = workflow({ workflow_id: "ready" });
     const sent = workflow({

--- a/hushh-webapp/__tests__/services/pkm-profile-presentation.test.ts
+++ b/hushh-webapp/__tests__/services/pkm-profile-presentation.test.ts
@@ -4,6 +4,8 @@ import {
   buildPkmDomainPresentation,
   buildPkmDomainPermissionPresentation,
   buildPkmDomainUpgradePresentation,
+  buildPkmProfileSummaryPresentation,
+  isConsumerVisiblePkmDomain,
 } from "@/lib/profile/pkm-profile-presentation";
 
 const domain = {
@@ -162,5 +164,44 @@ describe("pkm profile presentation", () => {
     });
 
     expect(presentation.highlights).toEqual(["Latest import synced from brokerage statement"]);
+  });
+
+  it("hides internal runtime domains and uses manifest-backed counts for consumer rows", () => {
+    expect(
+      isConsumerVisiblePkmDomain({
+        ...domain,
+        key: "kyc_workflow",
+        displayName: "Kyc Workflow",
+      })
+    ).toBe(false);
+
+    const presentation = buildPkmDomainPresentation({
+      domain: {
+        ...domain,
+        key: "travel",
+        displayName: "Travel",
+        attributeCount: 0,
+        summary: {
+          path_count: 18,
+          last_content_at: "2026-04-16T05:54:38Z",
+          readable_source_label: "PKM Upgrade",
+        },
+        readableSourceLabel: "PKM Upgrade",
+      },
+      activeGrants: [],
+      manifest: null,
+      upgradeState: null,
+    });
+
+    expect(presentation.detailCount).toBe(18);
+    expect(presentation.sourceLabels).toEqual(["Saved memory"]);
+
+    const summary = buildPkmProfileSummaryPresentation({
+      metadata: null,
+      domains: [presentation],
+      activeGrants: [],
+    });
+    expect(summary.totalDomains).toBe(1);
+    expect(summary.totalAttributes).toBe(18);
   });
 });

--- a/hushh-webapp/__tests__/services/pkm-section-preview.test.ts
+++ b/hushh-webapp/__tests__/services/pkm-section-preview.test.ts
@@ -52,12 +52,46 @@ describe("buildPkmSectionPreviewPresentation", () => {
       topLevelScopePath: "receipts_memory",
       value: {
         receipts_memory: {
-          readable_summary: "You often return to Uber and Wonder.",
-          inferred_preferences: ["rideshare", "late-night food"],
-          observed_facts: ["Frequent Uber rides", "Repeat Wonder orders"],
+          readable_summary: {
+            text: "You often return to Uber and Wonder.",
+            highlights: ["97 receipts reviewed"],
+          },
+          inferred_preferences: {
+            preference_signals: {
+              items: [
+                {
+                  label: "rideshare",
+                  confidence: 0.91,
+                  basis_codes: ["merchant_affinity"],
+                },
+              ],
+            },
+          },
+          observed_facts: {
+            recent_highlights: {
+              items: [
+                {
+                  merchant_label: "Uber",
+                  amount: 24.51,
+                  currency: "USD",
+                  purchased_at: "2026-04-15T10:00:00Z",
+                },
+              ],
+            },
+            merchant_affinity: {
+              items: [
+                {
+                  merchant_label: "Wonder",
+                  receipt_count_365d: 4,
+                  affinity_score: 0.82,
+                },
+              ],
+            },
+          },
           provenance: {
             source_kind: "gmail_receipts",
-            updated_at: "2026-04-16T05:54:08.696Z",
+            receipt_count_used: 97,
+            latest_receipt_updated_at: "2026-04-16T05:54:08.696Z",
           },
           schema_version: 4,
         },
@@ -66,10 +100,16 @@ describe("buildPkmSectionPreviewPresentation", () => {
 
     expect(presentation.title).toBe("Receipts memory");
     expect(presentation.summary).toBe("You often return to Uber and Wonder.");
+    expect(presentation.stats).toEqual([
+      { label: "Receipts", value: "97" },
+      { label: "Purchases", value: "1" },
+      { label: "Preferences", value: "1" },
+    ]);
     expect(presentation.groups.map((group) => group.title)).toEqual([
-      "Inferred preferences",
-      "Observed facts",
-      "Source",
+      "Receipt highlights",
+      "Recent purchases",
+      "Merchant patterns",
+      "Preference signals",
     ]);
   });
 });

--- a/hushh-webapp/__tests__/services/vault-method-service.test.ts
+++ b/hushh-webapp/__tests__/services/vault-method-service.test.ts
@@ -5,6 +5,7 @@ vi.mock("@/lib/services/vault-service", () => ({
     getVaultState: vi.fn(),
     hashVaultKey: vi.fn(),
     upsertVaultWrapper: vi.fn(),
+    deleteVaultWrapper: vi.fn(),
     setPrimaryVaultMethod: vi.fn(),
     canUseGeneratedDefaultVault: vi.fn(),
   },
@@ -29,6 +30,7 @@ describe("VaultMethodService.changePassphrase", () => {
   const getVaultStateMock = vi.mocked(VaultService.getVaultState);
   const hashVaultKeyMock = vi.mocked(VaultService.hashVaultKey);
   const upsertWrapperMock = vi.mocked(VaultService.upsertVaultWrapper);
+  const deleteWrapperMock = vi.mocked(VaultService.deleteVaultWrapper);
   const setPrimaryMock = vi.mocked(VaultService.setPrimaryVaultMethod);
   const rewrapMock = vi.mocked(rewrapVaultKeyWithPassphrase);
 
@@ -82,7 +84,7 @@ describe("VaultMethodService.changePassphrase", () => {
           method: "passphrase",
           wrapperId: "default",
         }),
-      })
+      }),
     );
     expect(setPrimaryMock).not.toHaveBeenCalled();
     expect(result).toEqual({
@@ -100,7 +102,11 @@ describe("VaultMethodService.changePassphrase", () => {
       keepPrimaryMethod: false,
     });
 
-    expect(setPrimaryMock).toHaveBeenCalledWith("uid-1", "passphrase", "default");
+    expect(setPrimaryMock).toHaveBeenCalledWith(
+      "uid-1",
+      "passphrase",
+      "default",
+    );
     expect(result).toEqual({
       primaryMethod: "passphrase",
       passphraseUpdated: true,
@@ -109,7 +115,7 @@ describe("VaultMethodService.changePassphrase", () => {
 
   it("maps RP mismatch errors to actionable message", async () => {
     upsertWrapperMock.mockRejectedValueOnce(
-      new Error("wrapper rp id is not allowed for this environment")
+      new Error("wrapper rp id is not allowed for this environment"),
     );
 
     await expect(
@@ -118,7 +124,79 @@ describe("VaultMethodService.changePassphrase", () => {
         currentVaultKey:
           "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
         newPassphrase: "new-passphrase-123",
-      })
+      }),
     ).rejects.toThrow(/older domain/i);
+  });
+
+  describe("removeMethod", () => {
+    it("removes a passkey wrapper and falls back to passphrase when primary", async () => {
+      const result = await VaultMethodService.removeMethod({
+        userId: "uid-1",
+        currentVaultKey:
+          "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        vaultOwnerToken: "vault-owner-token-1",
+        method: "generated_default_native_passkey_prf",
+        wrapperId: "cred-1",
+      });
+
+      expect(deleteWrapperMock).toHaveBeenCalledWith({
+        userId: "uid-1",
+        vaultKeyHash: "vault-hash",
+        method: "generated_default_native_passkey_prf",
+        vaultOwnerToken: "vault-owner-token-1",
+        wrapperId: "cred-1",
+        fallbackPrimaryMethod: "passphrase",
+        fallbackPrimaryWrapperId: "default",
+      });
+      expect(result).toEqual({ primaryMethod: "passphrase" });
+    });
+
+    it("rejects passphrase removal", async () => {
+      await expect(
+        VaultMethodService.removeMethod({
+          userId: "uid-1",
+          currentVaultKey:
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+          vaultOwnerToken: "vault-owner-token-1",
+          method: "passphrase",
+          wrapperId: "default",
+        }),
+      ).rejects.toThrow(/cannot be removed/i);
+
+      expect(deleteWrapperMock).not.toHaveBeenCalled();
+    });
+
+    it("requires a passphrase fallback before removing quick unlock", async () => {
+      getVaultStateMock.mockResolvedValueOnce({
+        vaultKeyHash: "vault-hash",
+        primaryMethod: "generated_default_native_passkey_prf",
+        primaryWrapperId: "cred-1",
+        recoveryEncryptedVaultKey: "r1",
+        recoverySalt: "r2",
+        recoveryIv: "r3",
+        wrappers: [
+          {
+            method: "generated_default_native_passkey_prf",
+            wrapperId: "cred-1",
+            encryptedVaultKey: "e1",
+            salt: "s1",
+            iv: "i1",
+          },
+        ],
+      });
+
+      await expect(
+        VaultMethodService.removeMethod({
+          userId: "uid-1",
+          currentVaultKey:
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+          vaultOwnerToken: "vault-owner-token-1",
+          method: "generated_default_native_passkey_prf",
+          wrapperId: "cred-1",
+        }),
+      ).rejects.toThrow(/passphrase unlock must be repaired/i);
+
+      expect(deleteWrapperMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
+++ b/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
@@ -59,6 +59,19 @@ describe("top shell breadcrumbs", () => {
       ],
     });
 
+    const accountParams = new URLSearchParams();
+    accountParams.set("panel", "account");
+
+    expect(resolveTopShellBreadcrumb("/profile", accountParams)).toEqual({
+      backHref: "/profile",
+      width: "profile",
+      align: "center",
+      items: [
+        { label: "Profile", href: "/profile" },
+        { label: "Account", href: undefined },
+      ],
+    });
+
     const detailParams = new URLSearchParams();
     detailParams.set("panel", "security");
     detailParams.set("detail", "vault");
@@ -84,6 +97,19 @@ describe("top shell breadcrumbs", () => {
       items: [
         { label: "Profile", href: "/profile" },
         { label: "Preferences", href: undefined },
+      ],
+    });
+  });
+
+  it("routes receipts back to the Gmail profile panel", () => {
+    expect(resolveTopShellBreadcrumb("/profile/receipts")).toEqual({
+      backHref: "/profile?panel=gmail",
+      width: "profile",
+      align: "center",
+      items: [
+        { label: "Profile", href: "/profile?panel=gmail" },
+        { label: "Gmail receipts", href: "/profile?panel=gmail" },
+        { label: "Receipts" },
       ],
     });
   });

--- a/hushh-webapp/android/app/src/main/java/com/hushh/app/plugins/HushhVault/HushhVaultPlugin.kt
+++ b/hushh-webapp/android/app/src/main/java/com/hushh/app/plugins/HushhVault/HushhVaultPlugin.kt
@@ -617,6 +617,63 @@ class HushhVaultPlugin : Plugin() {
     }
 
     @PluginMethod
+    fun deleteVaultWrapper(call: PluginCall) {
+        val userId = call.getString("userId")
+        val vaultKeyHash = call.getString("vaultKeyHash")
+        val method = call.getString("method")
+        val wrapperId = call.getString("wrapperId") ?: "default"
+        val fallbackPrimaryMethod = call.getString("fallbackPrimaryMethod") ?: "passphrase"
+        val fallbackPrimaryWrapperId = call.getString("fallbackPrimaryWrapperId") ?: "default"
+        val vaultOwnerToken = call.getString("vaultOwnerToken")
+        if (userId == null || vaultKeyHash == null || method == null || vaultOwnerToken == null) {
+            call.reject("Missing required parameters")
+            return
+        }
+
+        val authToken = call.getString("authToken")
+        val backendUrl = getBackendUrl(call)
+
+        Thread {
+            try {
+                val json = JSONObject().apply {
+                    put("userId", userId)
+                    put("vaultKeyHash", vaultKeyHash)
+                    put("method", method)
+                    put("wrapperId", wrapperId)
+                    put("fallbackPrimaryMethod", fallbackPrimaryMethod)
+                    put("fallbackPrimaryWrapperId", fallbackPrimaryWrapperId)
+                }
+                val requestBody = json.toString().toRequestBody("application/json".toMediaType())
+                val requestBuilder = Request.Builder()
+                    .url("$backendUrl/db/vault/wrapper/delete")
+                    .post(requestBody)
+                    .addHeader("Content-Type", "application/json")
+                    .addHeader("X-Hushh-Client-Version", getClientVersion(call))
+                if (authToken != null) {
+                    requestBuilder.addHeader("Authorization", "Bearer $authToken")
+                }
+                requestBuilder.addHeader("X-Hushh-Consent", "Bearer $vaultOwnerToken")
+                val response = httpClient.newCall(requestBuilder.build()).execute()
+                val success = response.isSuccessful
+                val responseBody = response.body?.string().orEmpty()
+                val errorSnippet = responseBody.take(300)
+                activity.runOnUiThread {
+                    if (!success) {
+                        val detail = if (errorSnippet.isBlank()) "no response body" else errorSnippet
+                        call.reject("Failed to remove wrapper: HTTP ${response.code} - ${detail}")
+                        return@runOnUiThread
+                    }
+                    call.resolve(JSObject().put("success", true))
+                }
+            } catch (e: Exception) {
+                activity.runOnUiThread {
+                    call.reject("Failed to remove wrapper: ${e.message}")
+                }
+            }
+        }.start()
+    }
+
+    @PluginMethod
     fun isPasskeyAvailable(call: PluginCall) {
         val rpId = call.getString("rpId")?.trim().orEmpty()
         val activity = activity

--- a/hushh-webapp/app/api/vault/wrapper/delete/route.ts
+++ b/hushh-webapp/app/api/vault/wrapper/delete/route.ts
@@ -1,0 +1,102 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getPythonApiUrl } from "@/app/api/_utils/backend";
+import { validateFirebaseToken } from "@/lib/auth/validate";
+import { isDevelopment } from "@/lib/config";
+
+export const dynamic = "force-dynamic";
+
+const PYTHON_API_URL = getPythonApiUrl();
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const {
+      userId,
+      vaultKeyHash,
+      method,
+      wrapperId,
+      fallbackPrimaryMethod,
+      fallbackPrimaryWrapperId,
+    } = body as {
+      userId?: string;
+      vaultKeyHash?: string;
+      method?: string;
+      wrapperId?: string;
+      fallbackPrimaryMethod?: string;
+      fallbackPrimaryWrapperId?: string;
+    };
+
+    if (!userId || !vaultKeyHash || !method) {
+      return NextResponse.json(
+        { error: "Missing required wrapper delete fields" },
+        { status: 400 },
+      );
+    }
+
+    const vaultOwnerHeader = request.headers.get("X-Hushh-Consent");
+    if (!vaultOwnerHeader) {
+      return NextResponse.json(
+        {
+          error: "Vault unlock proof required",
+          code: "VAULT_OWNER_TOKEN_REQUIRED",
+        },
+        { status: 401 },
+      );
+    }
+    const normalizedVaultOwnerHeader = vaultOwnerHeader.startsWith("Bearer ")
+      ? vaultOwnerHeader
+      : `Bearer ${vaultOwnerHeader}`;
+
+    const authHeader = request.headers.get("Authorization");
+    if (authHeader) {
+      const validation = await validateFirebaseToken(authHeader);
+      if (!validation.valid && !isDevelopment()) {
+        return NextResponse.json(
+          { error: "Authentication failed", code: "AUTH_INVALID" },
+          { status: 401 },
+        );
+      }
+    }
+
+    const clientVersion =
+      request.headers.get("x-hushh-client-version") ||
+      request.headers.get("x-client-version") ||
+      process.env.NEXT_PUBLIC_CLIENT_VERSION ||
+      "2.0.0";
+
+    const response = await fetch(`${PYTHON_API_URL}/db/vault/wrapper/delete`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-hushh-client-version": clientVersion,
+        "X-Hushh-Consent": normalizedVaultOwnerHeader,
+        ...(authHeader ? { Authorization: authHeader } : {}),
+      },
+      body: JSON.stringify({
+        userId,
+        vaultKeyHash,
+        method,
+        wrapperId,
+        fallbackPrimaryMethod,
+        fallbackPrimaryWrapperId,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorPayload = await response
+        .json()
+        .catch(async () => ({ error: await response.text().catch(() => "") }));
+      return NextResponse.json(errorPayload, { status: response.status });
+    }
+
+    const result = await response.json();
+    return NextResponse.json({ success: !!result.success });
+  } catch (error) {
+    console.error("Vault wrapper delete error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/hushh-webapp/app/one/kyc/layout.tsx
+++ b/hushh-webapp/app/one/kyc/layout.tsx
@@ -2,9 +2,9 @@ import type { Metadata } from "next";
 import type { ReactNode } from "react";
 
 export const metadata: Metadata = {
-  title: "One KYC",
+  title: "Email",
   description:
-    "Review broker KYC requests and send replies only after approval.",
+    "Review email requests and send replies only after approval.",
 };
 
 export default function OneKycLayout({ children }: { children: ReactNode }) {

--- a/hushh-webapp/app/one/kyc/page.tsx
+++ b/hushh-webapp/app/one/kyc/page.tsx
@@ -141,12 +141,12 @@ function OneKycWorkspace() {
   const voiceSurfaceMetadata = useMemo(
     () => ({
       screenId: "one_kyc",
-      title: "One KYC",
-      purpose: "Approval-gated broker KYC request review for one@hushh.ai.",
+      title: "Email",
+      purpose: "Approval-gated email request review for one@hushh.ai.",
       sections: [
         {
           id: "one_kyc_inbox",
-          title: "One KYC",
+          title: "Requests",
         },
         {
           id: "one_kyc_detail",
@@ -160,7 +160,7 @@ function OneKycWorkspace() {
       controls: [
         {
           id: "one-kyc-open",
-          label: "Open One KYC",
+          label: "Open Email",
           type: "route",
           actionId: "route.one_kyc",
         },
@@ -255,7 +255,7 @@ function OneKycWorkspace() {
       setSelectedId((current) => current || initialId || response.workflows[0]?.workflow_id || null);
     } catch (err) {
       setConnectorReady(false);
-      setError(err instanceof Error ? err.message : "Unable to load One requests.");
+      setError(err instanceof Error ? err.message : "Unable to load email requests.");
     } finally {
       setLoading(false);
     }
@@ -523,7 +523,7 @@ function OneKycWorkspace() {
             return;
           }
         } else if (action === "reject") {
-          next = await OneKycService.rejectDraft({ ...input, reason: "Rejected from One KYC." });
+          next = await OneKycService.rejectDraft({ ...input, reason: "Rejected from Email." });
         } else {
           next = await OneKycService.refreshWorkflow(input);
         }
@@ -598,8 +598,8 @@ function OneKycWorkspace() {
       <AppPageHeaderRegion>
         <PageHeader
           eyebrow="One"
-          title="One KYC"
-          description="Review broker KYC emails, choose what to share, and send replies only after you approve."
+          title="Email"
+          description="Review emails that ask for your data, choose what to share, and send replies only after you approve."
           icon={ShieldCheck}
           accent="neutral"
           actions={
@@ -611,7 +611,7 @@ function OneKycWorkspace() {
         />
       </AppPageHeaderRegion>
 
-      <AppPageContentRegion className="mx-auto grid w-full max-w-5xl items-start gap-4 lg:grid-cols-2">
+      <AppPageContentRegion className="mx-auto grid w-full max-w-5xl items-start gap-4 lg:grid-cols-[minmax(0,1.35fr)_minmax(18rem,0.65fr)]">
         {error ? (
           <div className="lg:col-span-2 rounded-[var(--app-card-radius-standard)] border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
             {error}
@@ -620,7 +620,7 @@ function OneKycWorkspace() {
 
         <div className="space-y-4">
           <SettingsGroup
-            title="Broker requests"
+            title="Requests"
           >
             {loading ? (
               <div className="px-[var(--settings-row-px)] py-[var(--settings-row-py)]">
@@ -630,14 +630,14 @@ function OneKycWorkspace() {
               <SettingsRow
                 icon={Inbox}
                 title="No matched requests"
-                description="New broker emails appear here after One matches them to one of your verified addresses."
+                description="New emails appear here after One matches them to one of your verified addresses."
               />
             ) : (
               workflows.map((workflow) => (
                 <SettingsRow
                   key={workflow.workflow_id}
                   icon={statusIcon(workflow.status)}
-                  title={workflow.subject || "KYC request"}
+                  title={workflow.subject || "Email request"}
                   description={[
                     workflow.counterparty_label || workflow.sender_email || "Counterparty",
                     selectedScopeLabels(workflow).join(", ") || workflow.requested_scope || "Scope pending",
@@ -661,46 +661,6 @@ function OneKycWorkspace() {
 
         <div className="space-y-4">
           <SettingsGroup
-            title="Current request"
-          >
-            {selected ? (
-              <>
-                <SettingsRow
-                  icon={statusIcon(selected.status)}
-                  title={selected.subject || "KYC request"}
-                  description={selected.counterparty_label || selected.sender_email || "Counterparty"}
-                  trailing={
-                    <Badge variant={statusVariant(selected.status)}>
-                      {STATUS_LABELS[selected.status] || selected.status}
-                    </Badge>
-                  }
-                  chevron
-                  onClick={() => setDetailOpen(true)}
-                  voiceControlId="one-kyc-open-selected"
-                />
-                <SettingsRow
-                  icon={ShieldCheck}
-                  title="Consent"
-                  description={selectedScopeLabels(selected).join(", ") || selected.requested_scope || "No scopes selected yet"}
-                  trailing={<Badge variant="outline">{detectedDomains(selected).join(", ") || "KYC"}</Badge>}
-                />
-                <SettingsRow
-                  icon={Clock3}
-                  title="Thread status"
-                  description={threadStatusLabel(selected)}
-                  trailing={selected.status === "waiting_on_counterparty" ? <CheckCircle2 className="size-4 text-emerald-600" /> : null}
-                />
-              </>
-            ) : (
-              <SettingsRow
-                icon={Inbox}
-                title="No workflow selected"
-                description="Select a broker request from the inbox."
-              />
-            )}
-          </SettingsGroup>
-
-          <SettingsGroup
             title="Matching emails"
           >
             <SettingsRow
@@ -709,7 +669,7 @@ function OneKycWorkspace() {
               description={
                 verifiedAliases.length
                   ? verifiedAliases.map((alias) => alias.email).join(", ")
-                  : "Add an address brokers already use for you."
+                  : "Add an address people already use for you."
               }
               trailing={<Badge variant="secondary">{verifiedAliases.length}</Badge>}
               chevron
@@ -724,12 +684,14 @@ function OneKycWorkspace() {
         <SettingsDetailPanel
           open={detailOpen && Boolean(selected)}
           onOpenChange={setDetailOpen}
-          title={selected?.subject || "One request"}
+          title={selected?.subject || "Email request"}
           description={selected?.counterparty_label || selected?.sender_email || "Review the selected request."}
+          desktopMaxWidthClassName="sm:!max-w-[960px]"
+          desktopMaxWidth="min(960px, calc(100vw - 3rem))"
         >
           {!selected ? null : (
             <div className="space-y-4">
-              <SettingsGroup embedded title="Workflow">
+              <SettingsGroup embedded title="Request">
                 <SettingsRow
                   icon={statusIcon(selected.status)}
                   title="Status"
@@ -748,7 +710,7 @@ function OneKycWorkspace() {
                 />
                 <SettingsRow
                   icon={ShieldCheck}
-                  title="Scopes"
+                  title="Data to share"
                   description={selectedScopeLabels(selected).join(", ") || selected.requested_scope || "-"}
                 />
                 <SettingsRow
@@ -782,8 +744,8 @@ function OneKycWorkspace() {
               {selected.status === "needs_scope" ? (
                 <SettingsGroup
                   embedded
-                  title="Recommended scopes"
-                  description="Confirm the workflow scopes before any encrypted export is prepared."
+                  title="Recommended data"
+                  description="Confirm what One should request before any encrypted export is prepared."
                 >
                   {scopeCandidates(selected).map((candidate) => {
                     const checked = selectedScopesForWorkflow(
@@ -883,7 +845,7 @@ function OneKycWorkspace() {
               ) : null}
 
               {selected.last_error_message ? (
-                <SettingsGroup embedded title="Workflow issue">
+                <SettingsGroup embedded title="Request issue">
                   <SettingsRow
                     icon={AlertTriangle}
                     title="Attention needed"
@@ -968,7 +930,7 @@ function OneKycWorkspace() {
           open={aliasPanelOpen}
           onOpenChange={setAliasPanelOpen}
           title="Verified emails"
-          description="Add addresses brokers already use so One can match requests without extra work."
+          description="Add addresses people already use so One can match requests without extra work."
         >
           <div className="space-y-4">
             <SettingsGroup embedded title="Ready to match">
@@ -987,7 +949,7 @@ function OneKycWorkspace() {
                 <SettingsRow
                   icon={MailPlus}
                   title="No verified emails yet"
-                  description="Add the email address your broker uses for KYC requests."
+                  description="Add the email address people already use for requests."
                 />
               )}
             </SettingsGroup>
@@ -1013,7 +975,7 @@ function OneKycWorkspace() {
               description={
                 aliasChallenge
                   ? `Use the code sent for ${aliasChallenge.email}.`
-                  : "Use an address where brokers may send KYC requests."
+                  : "Use an address where people may send requests."
               }
             >
               <div className="space-y-3 px-[var(--settings-row-px)] py-[var(--settings-row-py)]">

--- a/hushh-webapp/app/one/kyc/page.voice-action-contract.json
+++ b/hushh-webapp/app/one/kyc/page.voice-action-contract.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "kai.local_action_contract.v1",
   "surface_id": "one_kyc",
-  "surface_title": "One KYC",
+  "surface_title": "Email",
   "docs_references": [
     "docs/reference/kai/kai-action-gateway-vnext.md",
     "docs/reference/architecture/one-email-kyc.md",
@@ -20,15 +20,15 @@
   "actions": [
     {
       "action_id": "route.one_kyc",
-      "label": "Open One KYC",
-      "meaning": "Navigates to One broker request review.",
+      "label": "Open Email",
+      "meaning": "Navigates to One email request review.",
       "aliases": [
-        "open kyc",
-        "open one kyc",
-        "show kyc workflows",
-        "show broker requests"
+        "open email",
+        "open email helper",
+        "show email requests",
+        "show requests"
       ],
-      "search_keywords": ["kyc", "one", "broker"],
+      "search_keywords": ["email", "one", "request"],
       "reachability": {
         "hidden_navigable": false
       },
@@ -46,13 +46,13 @@
     {
       "action_id": "kyc.aliases.manage",
       "label": "Manage Verified Emails",
-      "meaning": "Opens the verified email address panel used to match broker KYC requests.",
+      "meaning": "Opens the verified email address panel used to match email requests.",
       "aliases": [
         "manage verified emails",
-        "add broker email",
+        "add email address",
         "show matching emails"
       ],
-      "search_keywords": ["kyc", "email", "broker"],
+      "search_keywords": ["email", "address", "match"],
       "guard_ids": ["auth_required"],
       "risk_level": "medium",
       "execution_policy": "manual_only",
@@ -65,10 +65,10 @@
     },
     {
       "action_id": "kyc.workflow.sync_status",
-      "label": "Sync KYC Status",
-      "meaning": "Refreshes the selected One KYC workflow status after consent approval.",
-      "aliases": ["sync kyc", "refresh kyc status"],
-      "search_keywords": ["kyc", "sync", "consent"],
+      "label": "Sync Email Status",
+      "meaning": "Refreshes the selected email request status after consent approval.",
+      "aliases": ["sync email", "refresh request status"],
+      "search_keywords": ["email", "sync", "consent"],
       "guard_ids": ["auth_required"],
       "risk_level": "medium",
       "execution_policy": "manual_only",
@@ -81,10 +81,10 @@
     },
     {
       "action_id": "kyc.draft.review",
-      "label": "Review KYC Draft",
-      "meaning": "Reads or focuses the current approval-gated KYC draft.",
-      "aliases": ["review kyc draft", "show kyc draft"],
-      "search_keywords": ["kyc", "draft", "review"],
+      "label": "Review Email Draft",
+      "meaning": "Reads or focuses the current approval-gated email draft.",
+      "aliases": ["review email draft", "show email draft"],
+      "search_keywords": ["email", "draft", "review"],
       "guard_ids": ["auth_required"],
       "risk_level": "medium",
       "execution_policy": "manual_only",
@@ -97,10 +97,10 @@
     },
     {
       "action_id": "kyc.draft.request_redraft",
-      "label": "Request KYC Redraft",
-      "meaning": "Requests a new KYC draft revision from typed or spoken user instructions.",
-      "aliases": ["redraft kyc", "revise kyc draft"],
-      "search_keywords": ["kyc", "redraft", "revise"],
+      "label": "Request Email Redraft",
+      "meaning": "Requests a new email draft revision from typed or spoken user instructions.",
+      "aliases": ["redraft email", "revise email draft"],
+      "search_keywords": ["email", "redraft", "revise"],
       "guard_ids": ["auth_required"],
       "risk_level": "medium",
       "execution_policy": "confirm_required",
@@ -113,10 +113,10 @@
     },
     {
       "action_id": "kyc.draft.approve_send",
-      "label": "Approve KYC Send",
-      "meaning": "Sends the KYC draft only after explicit user approval.",
-      "aliases": ["approve kyc send", "send kyc reply"],
-      "search_keywords": ["kyc", "send", "approve"],
+      "label": "Approve Email Send",
+      "meaning": "Sends the email draft only after explicit user approval.",
+      "aliases": ["approve email send", "send email reply"],
+      "search_keywords": ["email", "send", "approve"],
       "guard_ids": ["auth_required", "explicit_confirmation_required"],
       "risk_level": "high",
       "execution_policy": "manual_only",
@@ -129,10 +129,10 @@
     },
     {
       "action_id": "kyc.draft.reject",
-      "label": "Reject KYC Draft",
-      "meaning": "Rejects the current KYC draft and blocks the workflow.",
-      "aliases": ["reject kyc draft", "block kyc workflow"],
-      "search_keywords": ["kyc", "reject", "block"],
+      "label": "Reject Email Draft",
+      "meaning": "Rejects the current email draft and blocks the workflow.",
+      "aliases": ["reject email draft", "block email request"],
+      "search_keywords": ["email", "reject", "block"],
       "guard_ids": ["auth_required"],
       "risk_level": "medium",
       "execution_policy": "confirm_required",

--- a/hushh-webapp/app/profile/page.tsx
+++ b/hushh-webapp/app/profile/page.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import styles from "./page.module.css";
-import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import type { ReadonlyURLSearchParams } from "next/navigation";
 import {
@@ -55,10 +62,22 @@ import {
   PkmDomainDetailPanel,
   ProfileStateNotice,
 } from "@/components/profile/pkm-data-manager";
-import { ProfileStackNavigator, type ProfileStackEntry } from "@/components/profile/profile-stack-navigator";
+import {
+  ProfileStackNavigator,
+  type ProfileStackEntry,
+} from "@/components/profile/profile-stack-navigator";
 import { ProfileKaiPreferencesPanel } from "@/components/profile/profile-kai-preferences-panel";
 import { ThemeToggle } from "@/components/theme-toggle";
-import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -114,6 +133,7 @@ import {
   buildPkmDomainPermissionPresentation,
   buildPkmDomainUpgradePresentation,
   buildPkmProfileSummaryPresentation,
+  isConsumerVisiblePkmDomain,
 } from "@/lib/profile/pkm-profile-presentation";
 import {
   buildPkmSectionPreviewPresentation,
@@ -123,7 +143,7 @@ import { maskPhoneNumber } from "@/lib/services/phone-mandate-service";
 import type { DomainManifest } from "@/lib/personal-knowledge-model/manifest";
 import { GmailReceiptsService } from "@/lib/services/gmail-receipts-service";
 import { UserLocalStateService } from "@/lib/services/user-local-state-service";
-import { VaultService } from "@/lib/services/vault-service";
+import { VaultService, type VaultWrapper } from "@/lib/services/vault-service";
 import {
   VaultMethodService,
   type VaultCapabilityMatrix,
@@ -190,7 +210,7 @@ function cloneManifest(manifest: DomainManifest | null): DomainManifest | null {
 function applyManifestExposureChange(
   manifest: DomainManifest | null | undefined,
   target: { scopeHandle?: string | null; topLevelScopePath: string },
-  exposureEnabled: boolean
+  exposureEnabled: boolean,
 ): DomainManifest | null | undefined {
   if (!manifest) return manifest;
   const nextManifest = cloneManifest(manifest);
@@ -206,7 +226,8 @@ function applyManifestExposureChange(
       const matchesHandle =
         target.scopeHandle && entry.scope_handle === target.scopeHandle;
       const matchesPath =
-        String(projection.top_level_scope_path || "").trim() === target.topLevelScopePath;
+        String(projection.top_level_scope_path || "").trim() ===
+        target.topLevelScopePath;
       if (!matchesHandle && !matchesPath) {
         return entry;
       }
@@ -219,7 +240,9 @@ function applyManifestExposureChange(
   }
 
   if (!updated && Array.isArray(nextManifest.top_level_scope_paths)) {
-    updated = nextManifest.top_level_scope_paths.includes(target.topLevelScopePath);
+    updated = nextManifest.top_level_scope_paths.includes(
+      target.topLevelScopePath,
+    );
   }
 
   return updated ? nextManifest : manifest;
@@ -231,17 +254,20 @@ const SUPPORT_KIND_COPY: Record<
 > = {
   bug_report: {
     title: "Report a bug",
-    description: "Tell us what broke, what you expected, and anything we should look at.",
+    description:
+      "Tell us what broke, what you expected, and anything we should look at.",
     subject: "Bug report",
   },
   support_request: {
     title: "Contact support",
-    description: "Ask for help with your account, portfolio flows, or something unclear in the app.",
+    description:
+      "Ask for help with your account, portfolio flows, or something unclear in the app.",
     subject: "Support request",
   },
   developer_reachout: {
     title: "Reach the developer",
-    description: "Share product feedback, implementation notes, or a direct engineering question.",
+    description:
+      "Share product feedback, implementation notes, or a direct engineering question.",
     subject: "Developer feedback",
   },
 };
@@ -261,7 +287,10 @@ function normalizeProfilePanel(value: string | null): ProfilePanel | null {
   return null;
 }
 
-function normalizeProfileDetail(panel: ProfilePanel | null, value: string | null): ProfileDetail | null {
+function normalizeProfileDetail(
+  panel: ProfilePanel | null,
+  value: string | null,
+): ProfileDetail | null {
   const detail = String(value || "").trim();
   if (!panel || !detail) return null;
 
@@ -280,20 +309,32 @@ function normalizeProfileDetail(panel: ProfilePanel | null, value: string | null
   ) {
     return detail;
   }
-  if (panel === "security" && (detail === "vault" || detail === "session" || detail === "danger")) {
+  if (
+    panel === "security" &&
+    (detail === "vault" || detail === "session" || detail === "danger")
+  ) {
     return detail;
   }
-  if (panel === "gmail" && (detail === "gmail-connection" || detail === "gmail-actions")) {
+  if (
+    panel === "gmail" &&
+    (detail === "gmail-connection" || detail === "gmail-actions")
+  ) {
     return detail;
   }
-  if (panel === "support" && (detail === "support-routing" || detail.startsWith("support-compose:"))) {
+  if (
+    panel === "support" &&
+    (detail === "support-routing" || detail.startsWith("support-compose:"))
+  ) {
     return detail as ProfileDetail;
   }
 
   return null;
 }
 
-function buildProfileHref(params: { panel?: ProfilePanel | null; detail?: ProfileDetail | null }) {
+function buildProfileHref(params: {
+  panel?: ProfilePanel | null;
+  detail?: ProfileDetail | null;
+}) {
   const next = new URLSearchParams();
   if (params.panel) {
     next.set("panel", params.panel);
@@ -307,7 +348,7 @@ function buildProfileHref(params: { panel?: ProfilePanel | null; detail?: Profil
 
 function formatProfileInventoryBadge(
   summary: ReturnType<typeof buildPkmProfileSummaryPresentation> | null,
-  params: { loading: boolean; ready: boolean; failed: boolean }
+  params: { loading: boolean; ready: boolean; failed: boolean },
 ) {
   if (!params.ready) {
     if (params.failed) return "Unavailable";
@@ -375,7 +416,12 @@ function ProviderIcon({ providerId }: { providerId: string }) {
 
   if (providerId === "apple") {
     return (
-      <svg className="h-4 w-4 shrink-0" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+      <svg
+        className="h-4 w-4 shrink-0"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        aria-hidden
+      >
         <path d="M17.05 20.28c-.98.95-2.05.88-3.08.38-1.07-.52-2.07-.51-3.2 0-1.01.43-2.1.49-2.98-.38C5.22 17.63 2.7 12 5.45 8.04c1.47-2.09 3.8-2.31 5.33-1.18 1.1.75 3.3.73 4.45-.04 2.1-1.31 3.55-.95 4.5 1.14-.15.08.2.14 0 .2-2.63 1.34-3.35 6.03.95 7.84-.46 1.4-1.25 2.89-2.26 4.4l-.07.08-.05-.2zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.17 2.22-1.8 4.19-3.74 4.25z" />
       </svg>
     );
@@ -385,7 +431,8 @@ function ProviderIcon({ providerId }: { providerId: string }) {
 }
 
 function readableMethod(method: VaultMethod | null): string {
-  if (method === "generated_default_native_biometric") return "Device biometric";
+  if (method === "generated_default_native_biometric")
+    return "Device biometric";
   if (method === "generated_default_native_passkey_prf") return "Passkey";
   if (method === "generated_default_web_prf") return "Passkey";
   if (method === "passphrase") return "Passphrase";
@@ -393,17 +440,54 @@ function readableMethod(method: VaultMethod | null): string {
 }
 
 function readableQuickMethod(method: VaultMethod | null): string {
-  if (method === "generated_default_native_biometric") return "device biometric";
+  if (method === "generated_default_native_biometric")
+    return "device biometric";
   if (method === "generated_default_native_passkey_prf") return "passkey";
   if (method === "generated_default_web_prf") return "passkey";
   return "quick unlock";
 }
 
-function formatMethodList(methods: VaultMethod[]): string {
-  return methods.map((method) => readableMethod(method)).join(", ");
+function isPasskeyVaultMethod(method: VaultMethod | null): boolean {
+  return (
+    method === "generated_default_web_prf" ||
+    method === "generated_default_native_passkey_prf"
+  );
 }
 
-function resolveProfileRouteState(searchParams: ReadonlyURLSearchParams): ProfileRouteState {
+const VAULT_INLINE_CONTROL_CLASS =
+  "inline-flex h-8 w-[7.5rem] items-center justify-center whitespace-nowrap rounded-full px-3 text-xs font-medium";
+const VAULT_INLINE_BADGE_CLASS =
+  "inline-flex h-8 w-[7.5rem] items-center justify-center whitespace-nowrap rounded-full px-3 text-xs font-medium";
+
+function vaultWrapperKey(
+  wrapper: Pick<VaultWrapper, "method" | "wrapperId">,
+): string {
+  return `${wrapper.method}:${wrapper.wrapperId ?? "default"}`;
+}
+
+function formatPasskeyIdentifier(wrapper: VaultWrapper): string {
+  const raw = wrapper.passkeyCredentialId || wrapper.wrapperId || "";
+  if (!raw) return "Identifier unavailable";
+  const compact = raw.replace(/\s+/g, "");
+  if (compact.length <= 10) return `Identifier ${compact}`;
+  return `Identifier ending ${compact.slice(-6)}`;
+}
+
+function formatPasskeyLabel(wrapper: VaultWrapper): string {
+  if (wrapper.passkeyDeviceLabel) return wrapper.passkeyDeviceLabel;
+  if (wrapper.passkeyProvider === "webauthn_prf") return "Browser passkey";
+  if (wrapper.passkeyProvider === "native_passkey") return "Device passkey";
+  return "Saved passkey";
+}
+
+function describePasskeyWrapper(wrapper: VaultWrapper): string {
+  const parts = [formatPasskeyLabel(wrapper), formatPasskeyIdentifier(wrapper)];
+  return parts.join(" / ");
+}
+
+function resolveProfileRouteState(
+  searchParams: ReadonlyURLSearchParams,
+): ProfileRouteState {
   let panel = normalizeProfilePanel(searchParams.get("panel"));
 
   if (!panel) {
@@ -423,7 +507,7 @@ function resolveProfileRouteState(searchParams: ReadonlyURLSearchParams): Profil
 
 function profileRouteRequiresUnlockedVault(
   panel: ProfilePanel | null,
-  detail: ProfileDetail | null
+  detail: ProfileDetail | null,
 ): boolean {
   if (panel === "my-data" || panel === "access" || panel === "gmail") {
     return true;
@@ -461,7 +545,8 @@ function ProfilePageContent() {
     "profile_data" | "delete_account"
   >("profile_data");
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-  const [deleteTarget, setDeleteTarget] = useState<AccountDeletionTarget>("both");
+  const [deleteTarget, setDeleteTarget] =
+    useState<AccountDeletionTarget>("both");
   const [isDeleting, setIsDeleting] = useState(false);
   const [pendingProfileTarget, setPendingProfileTarget] = useState<{
     panel: ProfilePanel;
@@ -469,13 +554,22 @@ function ProfilePageContent() {
     mode: "push" | "replace";
   } | null>(null);
   const [hasVault, setHasVault] = useState<boolean | null>(null);
-  const [pkmMetadata, setPkmMetadata] = useState<PersonalKnowledgeModelMetadata | null>(null);
+  const [pkmMetadata, setPkmMetadata] =
+    useState<PersonalKnowledgeModelMetadata | null>(null);
   const [loadingPkmMetadata, setLoadingPkmMetadata] = useState(true);
   const [pkmError, setPkmError] = useState<string | null>(null);
-  const [domainManifests, setDomainManifests] = useState<Record<string, DomainManifest | null | undefined>>({});
-  const [loadingDomainManifests, setLoadingDomainManifests] = useState<Record<string, boolean>>({});
-  const [domainManifestErrors, setDomainManifestErrors] = useState<Record<string, string | null>>({});
-  const [pendingPermissionToggles, setPendingPermissionToggles] = useState<Record<string, boolean>>({});
+  const [domainManifests, setDomainManifests] = useState<
+    Record<string, DomainManifest | null | undefined>
+  >({});
+  const [loadingDomainManifests, setLoadingDomainManifests] = useState<
+    Record<string, boolean>
+  >({});
+  const [domainManifestErrors, setDomainManifestErrors] = useState<
+    Record<string, string | null>
+  >({});
+  const [pendingPermissionToggles, setPendingPermissionToggles] = useState<
+    Record<string, boolean>
+  >({});
   const [domainPreview, setDomainPreview] = useState<{
     open: boolean;
     permissionKey: string | null;
@@ -493,22 +587,34 @@ function ProfilePageContent() {
     loading: false,
     error: null,
   });
-  const [consentCenter, setConsentCenter] = useState<ConsentCenterResponse | null>(null);
+  const [consentCenter, setConsentCenter] =
+    useState<ConsentCenterResponse | null>(null);
   const [loadingConsentCenter, setLoadingConsentCenter] = useState(true);
-  const [consentCenterError, setConsentCenterError] = useState<string | null>(null);
+  const [consentCenterError, setConsentCenterError] = useState<string | null>(
+    null,
+  );
   const [initialized, setInitialized] = useState(false);
   const [vaultMethod, setVaultMethod] = useState<VaultMethod | null>(null);
   const [capabilityMatrix, setCapabilityMatrix] =
     useState<VaultCapabilityMatrix | null>(null);
-  const [enrolledVaultMethods, setEnrolledVaultMethods] = useState<VaultMethod[]>([]);
+  const [enrolledVaultWrappers, setEnrolledVaultWrappers] = useState<
+    VaultWrapper[]
+  >([]);
+  const [primaryVaultWrapperId, setPrimaryVaultWrapperId] = useState<
+    string | null
+  >(null);
   const [availableQuickMethod, setAvailableQuickMethod] =
     useState<VaultMethod | null>(null);
-  const [availableQuickWrapperId, setAvailableQuickWrapperId] = useState<string | null>(null);
+  const [availableQuickWrapperId, setAvailableQuickWrapperId] = useState<
+    string | null
+  >(null);
   const [effectiveVaultMethod, setEffectiveVaultMethod] =
     useState<VaultMethod | null>(null);
   const [loadingVaultMethod, setLoadingVaultMethod] = useState(false);
   const [switchingVaultMethod, setSwitchingVaultMethod] = useState(false);
   const [passphraseDialogOpen, setPassphraseDialogOpen] = useState(false);
+  const [passkeyRemovalTarget, setPasskeyRemovalTarget] =
+    useState<VaultWrapper | null>(null);
   const [newPassphrase, setNewPassphrase] = useState("");
   const [confirmPassphrase, setConfirmPassphrase] = useState("");
   const [marketplaceOptIn, setMarketplaceOptIn] = useState(false);
@@ -528,10 +634,13 @@ function ProfilePageContent() {
   const activePanel = profileRouteState.panel;
   const activeDetail = profileRouteState.detail;
   const shouldRequestVaultUnlock = searchParams.get("unlock_vault") === "1";
-  useScrollReset(`${pathname}:${activePanel ?? "root"}:${activeDetail ?? "root"}`, {
-    enabled: true,
-    behavior: "auto",
-  });
+  useScrollReset(
+    `${pathname}:${activePanel ?? "root"}:${activeDetail ?? "root"}`,
+    {
+      enabled: true,
+      behavior: "auto",
+    },
+  );
 
   const provider = getProvider(user);
   const gmailRouteHref = `${pathname}?${searchParamsString}`;
@@ -542,12 +651,15 @@ function ProfilePageContent() {
     routeHref: gmailRouteHref,
     refreshKey: gmailRouteHref,
   });
-  const gmailActionsBusy = gmail.refreshingStatus || gmail.syncingRun || gmailActionBusy !== null;
+  const gmailActionsBusy =
+    gmail.refreshingStatus || gmail.syncingRun || gmailActionBusy !== null;
   const personaList = personaState?.personas ?? ["investor"];
   const hasInvestorPersona = personaList.includes("investor");
   const hasRiaPersona = personaList.includes("ria");
   const hasDualPersona = hasInvestorPersona && hasRiaPersona;
-  const effectiveDeleteTarget: AccountDeletionTarget = hasDualPersona ? deleteTarget : "both";
+  const effectiveDeleteTarget: AccountDeletionTarget = hasDualPersona
+    ? deleteTarget
+    : "both";
   const vaultAccess = useMemo(
     () =>
       resolveVaultAvailabilityState({
@@ -556,7 +668,7 @@ function ProfilePageContent() {
         vaultKey,
         vaultOwnerToken,
       }),
-    [hasVault, isVaultUnlocked, vaultKey, vaultOwnerToken]
+    [hasVault, isVaultUnlocked, vaultKey, vaultOwnerToken],
   );
   const routeBlockedByVault =
     hasVault === true &&
@@ -570,33 +682,44 @@ function ProfilePageContent() {
         action: gmailActionBusy,
         errorText: gmail.statusError,
       }),
-    [gmail.loadingStatus, gmail.status, gmail.statusError, gmailActionBusy]
+    [gmail.loadingStatus, gmail.status, gmail.statusError, gmailActionBusy],
   );
   const upgradeStatesByDomain = useMemo<Record<string, PkmUpgradeDomainState>>(
     () =>
       Object.fromEntries(
-        (pkmMetadata?.upgradableDomains || []).map((entry) => [entry.domain, entry])
+        (pkmMetadata?.upgradableDomains || []).map((entry) => [
+          entry.domain,
+          entry,
+        ]),
       ),
-    [pkmMetadata?.upgradableDomains]
+    [pkmMetadata?.upgradableDomains],
   );
 
   const domainPresentations = useMemo(
     () =>
-      (pkmMetadata?.domains || []).map((domain) =>
-        buildPkmDomainPresentation({
-          domain,
-          activeGrants: consentCenter?.active_grants || [],
-          manifest: domainManifests[domain.key],
-          upgradeState: upgradeStatesByDomain[domain.key] || null,
-        })
-      ),
-    [consentCenter?.active_grants, domainManifests, pkmMetadata?.domains, upgradeStatesByDomain]
+      (pkmMetadata?.domains || [])
+        .filter(isConsumerVisiblePkmDomain)
+        .map((domain) =>
+          buildPkmDomainPresentation({
+            domain,
+            activeGrants: consentCenter?.active_grants || [],
+            manifest: domainManifests[domain.key],
+            upgradeState: upgradeStatesByDomain[domain.key] || null,
+          }),
+        ),
+    [
+      consentCenter?.active_grants,
+      domainManifests,
+      pkmMetadata?.domains,
+      upgradeStatesByDomain,
+    ],
   );
 
   const pkmMetadataReady = pkmMetadata !== null;
   const consentCenterReady = consentCenter !== null;
   const pkmMetadataFailed = Boolean(pkmError) && !pkmMetadataReady;
-  const consentCenterFailed = Boolean(consentCenterError) && !consentCenterReady;
+  const consentCenterFailed =
+    Boolean(consentCenterError) && !consentCenterReady;
 
   const profileSummary = useMemo(
     () =>
@@ -615,26 +738,35 @@ function ProfilePageContent() {
       pendingConsents,
       pkmMetadata,
       pkmMetadataReady,
-    ]
+    ],
   );
 
   const accessConnections = useMemo(
     () => buildPkmAccessConnections(domainPresentations),
-    [domainPresentations]
+    [domainPresentations],
   );
 
   const selectedDomain = useMemo(() => {
-    if (activePanel !== "my-data" || !activeDetail?.startsWith("domain:")) return null;
+    if (activePanel !== "my-data" || !activeDetail?.startsWith("domain:"))
+      return null;
     const domainKey = activeDetail.slice("domain:".length);
-    return domainPresentations.find((domain) => domain.key === domainKey) || null;
+    return (
+      domainPresentations.find((domain) => domain.key === domainKey) || null
+    );
   }, [activeDetail, activePanel, domainPresentations]);
 
   const selectedDomainMetadata = useMemo(() => {
     if (!selectedDomain) return null;
-    return (pkmMetadata?.domains || []).find((domain) => domain.key === selectedDomain.key) || null;
+    return (
+      (pkmMetadata?.domains || []).find(
+        (domain) => domain.key === selectedDomain.key,
+      ) || null
+    );
   }, [pkmMetadata?.domains, selectedDomain]);
 
-  const selectedDomainManifest = selectedDomain ? domainManifests[selectedDomain.key] ?? null : null;
+  const selectedDomainManifest = selectedDomain
+    ? (domainManifests[selectedDomain.key] ?? null)
+    : null;
   const selectedDomainUpgrade = useMemo(() => {
     if (!selectedDomain || !selectedDomainMetadata) return null;
     if (vaultAccess.needsUnlock && hasVault) {
@@ -694,9 +826,13 @@ function ProfilePageContent() {
   }, [selectedDomain?.key]);
 
   const selectedConnection = useMemo(() => {
-    if (activePanel !== "access" || !activeDetail?.startsWith("connection:")) return null;
+    if (activePanel !== "access" || !activeDetail?.startsWith("connection:"))
+      return null;
     const connectionId = activeDetail.slice("connection:".length);
-    return accessConnections.find((connection) => connection.id === connectionId) || null;
+    return (
+      accessConnections.find((connection) => connection.id === connectionId) ||
+      null
+    );
   }, [accessConnections, activeDetail, activePanel]);
 
   const updateProfileView = useMemo(
@@ -706,11 +842,12 @@ function ProfilePageContent() {
           panel?: ProfilePanel | null;
           detail?: ProfileDetail | null;
         },
-        mode: "push" | "replace" = "push"
+        mode: "push" | "replace" = "push",
       ) => {
         const href = buildProfileHref({
           panel: typeof next.panel === "undefined" ? activePanel : next.panel,
-          detail: typeof next.detail === "undefined" ? activeDetail : next.detail,
+          detail:
+            typeof next.detail === "undefined" ? activeDetail : next.detail,
         });
         if (mode === "push") {
           router.push(href, { scroll: false });
@@ -718,7 +855,7 @@ function ProfilePageContent() {
           router.replace(href, { scroll: false });
         }
       },
-    [activeDetail, activePanel, router]
+    [activeDetail, activePanel, router],
   );
 
   useEffect(() => {
@@ -751,9 +888,6 @@ function ProfilePageContent() {
         VaultMethodService.getCurrentMethod(targetUserId),
         VaultService.getVaultState(targetUserId),
       ]);
-      const nextEnrolledMethods = Array.from(
-        new Set(vaultState.wrappers.map((wrapper) => wrapper.method))
-      ) as VaultMethod[];
       const nextRecommendedMethod =
         capability.recommendedMethod !== "passphrase"
           ? capability.recommendedMethod
@@ -776,14 +910,16 @@ function ProfilePageContent() {
 
       setCapabilityMatrix(capability);
       setVaultMethod(currentMethod);
-      setEnrolledVaultMethods(nextEnrolledMethods);
+      setEnrolledVaultWrappers(vaultState.wrappers);
+      setPrimaryVaultWrapperId(vaultState.primaryWrapperId ?? "default");
       setAvailableQuickMethod(quickWrapper?.method ?? null);
       setAvailableQuickWrapperId(quickWrapper?.wrapperId ?? null);
       setEffectiveVaultMethod(nextEffectiveMethod);
     } catch (error) {
       console.warn("[ProfilePage] Failed to resolve vault method:", error);
       setVaultMethod(null);
-      setEnrolledVaultMethods([]);
+      setEnrolledVaultWrappers([]);
+      setPrimaryVaultWrapperId(null);
       setAvailableQuickMethod(null);
       setAvailableQuickWrapperId(null);
       setEffectiveVaultMethod(null);
@@ -796,7 +932,8 @@ function ProfilePageContent() {
     if (authLoading || !user?.uid) return;
     if (hasVault !== true) {
       setVaultMethod(null);
-      setEnrolledVaultMethods([]);
+      setEnrolledVaultWrappers([]);
+      setPrimaryVaultWrapperId(null);
       setAvailableQuickMethod(null);
       setAvailableQuickWrapperId(null);
       setEffectiveVaultMethod(null);
@@ -826,56 +963,78 @@ function ProfilePageContent() {
       const metadata = await PersonalKnowledgeModelService.getMetadata(
         user.uid,
         force,
-        vaultOwnerToken ?? undefined
+        vaultOwnerToken ?? undefined,
       );
       setPkmMetadata(metadata);
       setPkmError(null);
       return metadata;
     },
-    [user?.uid, vaultOwnerToken]
+    [user?.uid, vaultOwnerToken],
   );
 
   const refreshDomainManifest = useCallback(
     async (domainKey: string, force = false) => {
       if (!user?.uid || !vaultOwnerToken) return null;
-      setLoadingDomainManifests((current) => ({ ...current, [domainKey]: true }));
+      setLoadingDomainManifests((current) => ({
+        ...current,
+        [domainKey]: true,
+      }));
       try {
         const manifest = await PersonalKnowledgeModelService.getDomainManifest(
           user.uid,
           domainKey,
           vaultOwnerToken,
-          force
+          force,
         );
-        setDomainManifests((current) => ({ ...current, [domainKey]: manifest }));
-        setDomainManifestErrors((current) => ({ ...current, [domainKey]: null }));
+        setDomainManifests((current) => ({
+          ...current,
+          [domainKey]: manifest,
+        }));
+        setDomainManifestErrors((current) => ({
+          ...current,
+          [domainKey]: null,
+        }));
         return manifest;
       } catch (error) {
         const message =
-          error instanceof Error ? error.message : "Couldn't load sharing controls for this domain.";
-        setDomainManifestErrors((current) => ({ ...current, [domainKey]: message }));
+          error instanceof Error
+            ? error.message
+            : "Couldn't load sharing controls for this domain.";
+        setDomainManifestErrors((current) => ({
+          ...current,
+          [domainKey]: message,
+        }));
         return null;
       } finally {
-        setLoadingDomainManifests((current) => ({ ...current, [domainKey]: false }));
+        setLoadingDomainManifests((current) => ({
+          ...current,
+          [domainKey]: false,
+        }));
       }
     },
-    [user?.uid, vaultOwnerToken]
+    [user?.uid, vaultOwnerToken],
   );
 
   const refreshVisibleDomainManifests = useCallback(
     async (force = false) => {
       if (!user?.uid || !vaultOwnerToken) return;
-      const domainKeys = (pkmMetadata?.domains || []).map((domain) => domain.key);
+      const domainKeys = (pkmMetadata?.domains || [])
+        .filter(isConsumerVisiblePkmDomain)
+        .map((domain) => domain.key);
       if (domainKeys.length === 0) return;
-      await Promise.all(domainKeys.map((domainKey) => refreshDomainManifest(domainKey, force)));
+      await Promise.all(
+        domainKeys.map((domainKey) => refreshDomainManifest(domainKey, force)),
+      );
     },
-    [pkmMetadata?.domains, refreshDomainManifest, user?.uid, vaultOwnerToken]
+    [pkmMetadata?.domains, refreshDomainManifest, user?.uid, vaultOwnerToken],
   );
 
   useEffect(() => {
     if (!user?.uid) return;
 
     const handleUpgradeCompleted = (event: Event) => {
-      const detail = (event as CustomEvent<PkmUpgradeCompletedEventDetail>).detail;
+      const detail = (event as CustomEvent<PkmUpgradeCompletedEventDetail>)
+        .detail;
       if (detail?.userId !== user.uid) {
         return;
       }
@@ -884,21 +1043,40 @@ function ProfilePageContent() {
         setLoadingPkmMetadata(true);
         try {
           const nextMetadata = await refreshPkmMetadata(true);
-          if (vaultOwnerToken && !vaultAccess.needsVaultCreation && !vaultAccess.needsUnlock) {
-            const domainKeys = (nextMetadata?.domains || []).map((domain) => domain.key);
-            await Promise.all(domainKeys.map((domainKey) => refreshDomainManifest(domainKey, true)));
+          if (
+            vaultOwnerToken &&
+            !vaultAccess.needsVaultCreation &&
+            !vaultAccess.needsUnlock
+          ) {
+            const domainKeys = (nextMetadata?.domains || [])
+              .filter(isConsumerVisiblePkmDomain)
+              .map((domain) => domain.key);
+            await Promise.all(
+              domainKeys.map((domainKey) =>
+                refreshDomainManifest(domainKey, true),
+              ),
+            );
           }
         } catch (error) {
-          console.warn("[ProfilePage] Failed to refresh PKM after upgrade completion.", error);
+          console.warn(
+            "[ProfilePage] Failed to refresh PKM after upgrade completion.",
+            error,
+          );
         } finally {
           setLoadingPkmMetadata(false);
         }
       })();
     };
 
-    window.addEventListener(PKM_UPGRADE_COMPLETED_EVENT, handleUpgradeCompleted);
+    window.addEventListener(
+      PKM_UPGRADE_COMPLETED_EVENT,
+      handleUpgradeCompleted,
+    );
     return () => {
-      window.removeEventListener(PKM_UPGRADE_COMPLETED_EVENT, handleUpgradeCompleted);
+      window.removeEventListener(
+        PKM_UPGRADE_COMPLETED_EVENT,
+        handleUpgradeCompleted,
+      );
     };
   }, [
     refreshPkmMetadata,
@@ -923,7 +1101,7 @@ function ProfilePageContent() {
       setConsentCenter(nextCenter);
       setConsentCenterError(null);
     },
-    [user]
+    [user],
   );
 
   const { handleRevoke } = useConsentActions({
@@ -955,7 +1133,7 @@ function ProfilePageContent() {
           PersonalKnowledgeModelService.getMetadata(
             user.uid,
             false,
-            vaultOwnerToken ?? undefined
+            vaultOwnerToken ?? undefined,
           ),
           ConsentCenterService.getCenter({
             idToken,
@@ -975,7 +1153,9 @@ function ProfilePageContent() {
         console.error("Failed to load profile manager data:", error);
         if (!cancelled) {
           const message =
-            error instanceof Error ? error.message : "Failed to load profile knowledge view.";
+            error instanceof Error
+              ? error.message
+              : "Failed to load profile knowledge view.";
           setPkmError(message);
           setConsentCenterError(message);
           completeStep();
@@ -1058,7 +1238,7 @@ function ProfilePageContent() {
 
       const result = await AccountService.deleteAccount(
         resolution.token,
-        effectiveDeleteTarget
+        effectiveDeleteTarget,
       );
 
       CacheSyncService.onAccountDeleted(user.uid);
@@ -1083,7 +1263,7 @@ function ProfilePageContent() {
       toast.success(
         deletedTarget === "ria"
           ? "RIA workspace deleted. Your investor account is still active."
-          : "Investor profile deleted. Your RIA workspace is still active."
+          : "Investor profile deleted. Your RIA workspace is still active.",
       );
 
       if (result.remaining_personas?.includes("ria")) {
@@ -1134,7 +1314,7 @@ function ProfilePageContent() {
       const idToken = await user.getIdToken();
       const result = await RiaService.setInvestorMarketplaceOptIn(
         idToken,
-        !marketplaceOptIn
+        !marketplaceOptIn,
       );
       setMarketplaceOptIn(Boolean(result.investor_marketplace_opt_in));
       CacheSyncService.onMarketplaceVisibilityChanged(user.uid);
@@ -1142,10 +1322,13 @@ function ProfilePageContent() {
       toast.success(
         result.investor_marketplace_opt_in
           ? "Investor marketplace profile is now discoverable."
-          : "Investor marketplace profile is now hidden."
+          : "Investor marketplace profile is now hidden.",
       );
     } catch (error) {
-      console.error("[ProfilePage] Failed to update marketplace opt-in:", error);
+      console.error(
+        "[ProfilePage] Failed to update marketplace opt-in:",
+        error,
+      );
       toast.error("Couldn't update marketplace visibility.");
     } finally {
       setSavingMarketplaceOptIn(false);
@@ -1161,16 +1344,20 @@ function ProfilePageContent() {
         panel: "support",
         detail: `support-compose:${kind}`,
       },
-      "push"
+      "push",
     );
   }
 
-  function requestVaultUnlock(reason: "profile_data" | "delete_account" = "profile_data") {
+  function requestVaultUnlock(
+    reason: "profile_data" | "delete_account" = "profile_data",
+  ) {
     setVaultUnlockReason(reason);
     setShowVaultUnlock(true);
   }
 
-  function openVaultBackedPanel(panel: Extract<ProfilePanel, "my-data" | "access" | "gmail" | "security">) {
+  function openVaultBackedPanel(
+    panel: Extract<ProfilePanel, "my-data" | "access" | "gmail" | "security">,
+  ) {
     if (vaultAccess.needsVaultCreation) {
       router.push(ROUTES.KAI_IMPORT);
       return;
@@ -1216,7 +1403,7 @@ function ProfilePageContent() {
       toast.success(
         result.delivery_mode === "test"
           ? `Sent in test mode to ${result.recipient}.`
-          : `Sent to ${result.recipient}.`
+          : `Sent to ${result.recipient}.`,
       );
       updateProfileView({ panel: "support", detail: null }, "replace");
       setSupportMessage("");
@@ -1225,7 +1412,7 @@ function ProfilePageContent() {
       toast.error(
         error instanceof Error
           ? error.message
-          : "We couldn't send your message right now."
+          : "We couldn't send your message right now.",
       );
     } finally {
       setSendingSupportMessage(false);
@@ -1259,7 +1446,8 @@ function ProfilePageContent() {
       assignWindowLocation(payload.authorize_url);
     } catch (error) {
       const message = sanitizeGmailUserMessage(error, {
-        fallback: "We couldn't start Gmail connection right now. Please try again in a moment.",
+        fallback:
+          "We couldn't start Gmail connection right now. Please try again in a moment.",
       });
       console.error("[ProfilePage] Failed to start Gmail OAuth:", error);
       toast.error(message);
@@ -1277,7 +1465,8 @@ function ProfilePageContent() {
       toast.success("Gmail disconnected. Your saved receipts will stay here.");
     } catch (error) {
       const message = sanitizeGmailUserMessage(error, {
-        fallback: "We couldn't disconnect Gmail right now. Please try again in a moment.",
+        fallback:
+          "We couldn't disconnect Gmail right now. Please try again in a moment.",
       });
       console.error("[ProfilePage] Failed to disconnect Gmail:", error);
       toast.error(message);
@@ -1298,7 +1487,8 @@ function ProfilePageContent() {
       toast.message("Syncing your receipts now.");
     } catch (error) {
       const message = sanitizeGmailUserMessage(error, {
-        fallback: "We couldn't sync your receipts. Please try again in a moment.",
+        fallback:
+          "We couldn't sync your receipts. Please try again in a moment.",
         authFallback: "Reconnect Gmail to continue syncing your receipts.",
       });
       console.error("[ProfilePage] Failed to start Gmail sync:", error);
@@ -1326,14 +1516,16 @@ function ProfilePageContent() {
       });
 
       setVaultMethod(result.method);
-      toast.success(`Vault method updated to ${readableMethod(result.method)}.`);
+      toast.success(
+        `Vault method updated to ${readableMethod(result.method)}.`,
+      );
       await refreshVaultMethodState(user.uid);
     } catch (error) {
       console.error("[ProfilePage] Failed to switch vault method:", error);
       toast.error(
         error instanceof Error
           ? error.message
-          : "We could not update your unlock preference."
+          : "We could not update your unlock preference.",
       );
     } finally {
       setSwitchingVaultMethod(false);
@@ -1342,7 +1534,7 @@ function ProfilePageContent() {
 
   async function setQuickMethodAsDefault(
     targetMethod: VaultMethod,
-    wrapperId?: string | null
+    wrapperId?: string | null,
   ) {
     if (!user?.uid) return;
 
@@ -1357,17 +1549,22 @@ function ProfilePageContent() {
       await VaultService.setPrimaryVaultMethod(
         user.uid,
         targetMethod,
-        wrapperId ?? "default"
+        wrapperId ?? "default",
       );
       setVaultMethod(targetMethod);
-      toast.success(`Primary unlock updated to ${readableMethod(targetMethod)}.`);
+      toast.success(
+        `Primary unlock updated to ${readableMethod(targetMethod)}.`,
+      );
       await refreshVaultMethodState(user.uid);
     } catch (error) {
-      console.error("[ProfilePage] Failed to set quick unlock as default:", error);
+      console.error(
+        "[ProfilePage] Failed to set quick unlock as default:",
+        error,
+      );
       toast.error(
         error instanceof Error
           ? error.message
-          : "We could not update your preferred unlock method."
+          : "We could not update your preferred unlock method.",
       );
     } finally {
       setSwitchingVaultMethod(false);
@@ -1385,7 +1582,11 @@ function ProfilePageContent() {
 
     setSwitchingVaultMethod(true);
     try {
-      await VaultService.setPrimaryVaultMethod(user.uid, "passphrase", "default");
+      await VaultService.setPrimaryVaultMethod(
+        user.uid,
+        "passphrase",
+        "default",
+      );
       setVaultMethod("passphrase");
       toast.success("Primary unlock updated to passphrase.");
       await refreshVaultMethodState(user.uid);
@@ -1394,7 +1595,48 @@ function ProfilePageContent() {
       toast.error(
         error instanceof Error
           ? error.message
-          : "We could not update your preferred unlock method."
+          : "We could not update your preferred unlock method.",
+      );
+    } finally {
+      setSwitchingVaultMethod(false);
+    }
+  }
+
+  async function removePasskeyWrapper(wrapper: VaultWrapper) {
+    if (!user?.uid) return;
+
+    if (!vaultAccess.canMutateSecureData || !vaultKey) {
+      toast.info("Unlock your vault to remove a passkey.");
+      requestVaultUnlock("profile_data");
+      return;
+    }
+    if (!vaultOwnerToken) {
+      toast.info("Unlock your vault to remove a passkey.");
+      requestVaultUnlock("profile_data");
+      return;
+    }
+
+    setSwitchingVaultMethod(true);
+    try {
+      const result = await VaultMethodService.removeMethod({
+        userId: user.uid,
+        currentVaultKey: vaultKey,
+        vaultOwnerToken,
+        method: wrapper.method,
+        wrapperId: wrapper.wrapperId ?? "default",
+        fallbackPrimaryMethod: "passphrase",
+        fallbackPrimaryWrapperId: "default",
+      });
+      setVaultMethod(result.primaryMethod);
+      toast.success("Passkey removed. Passphrase unlock is still available.");
+      setPasskeyRemovalTarget(null);
+      await refreshVaultMethodState(user.uid);
+    } catch (error) {
+      console.error("[ProfilePage] Failed to remove passkey wrapper:", error);
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "We could not remove this passkey.",
       );
     } finally {
       setSwitchingVaultMethod(false);
@@ -1429,21 +1671,20 @@ function ProfilePageContent() {
       toast.error(
         error instanceof Error
           ? error.message
-          : "We could not update your passphrase."
+          : "We could not update your passphrase.",
       );
     } finally {
       setSwitchingVaultMethod(false);
     }
   }
 
-  const deleteButtonLabel =
-    vaultAccess.needsUnlock
-      ? hasDualPersona
-        ? "Unlock to manage deletion"
-        : "Unlock to delete account"
-      : hasDualPersona
-        ? "Delete account or persona"
-        : "Delete account";
+  const deleteButtonLabel = vaultAccess.needsUnlock
+    ? hasDualPersona
+      ? "Unlock to manage deletion"
+      : "Unlock to delete account"
+    : hasDualPersona
+      ? "Delete account or persona"
+      : "Delete account";
   const deleteRowDescription = hasDualPersona
     ? "Choose whether to remove Investor, RIA, or the full account."
     : "This action cannot be undone.";
@@ -1482,8 +1723,6 @@ function ProfilePageContent() {
       : "Unlock your vault to access profile settings.";
 
   const displayedUnlockMethod = effectiveVaultMethod ?? vaultMethod;
-  const unlockMethodDiffersFromStoredDefault =
-    Boolean(vaultMethod && effectiveVaultMethod && vaultMethod !== effectiveVaultMethod);
   const recommendedQuickMethod =
     capabilityMatrix?.recommendedMethod &&
     capabilityMatrix.recommendedMethod !== "passphrase"
@@ -1493,19 +1732,46 @@ function ProfilePageContent() {
     vaultMethod === "passphrase" && availableQuickMethod
       ? availableQuickMethod
       : null;
+  const enrolledPasskeyWrappers = enrolledVaultWrappers.filter((wrapper) =>
+    isPasskeyVaultMethod(wrapper.method),
+  );
+  const passphraseWrapper = enrolledVaultWrappers.find(
+    (wrapper) => wrapper.method === "passphrase",
+  );
+  const activePrimaryWrapperId = primaryVaultWrapperId ?? "default";
+  const canSwitchDefaultToPassphrase = Boolean(
+    vaultAccess.canMutateSecureData &&
+    vaultMethod &&
+    vaultMethod !== "passphrase" &&
+    passphraseWrapper,
+  );
+  const canSwitchDefaultToQuick = Boolean(
+    vaultAccess.canMutateSecureData &&
+    vaultMethod === "passphrase" &&
+    quickMethodReadyOnCurrentDevice,
+  );
+  const defaultUnlockDescription =
+    vaultMethod === "passphrase"
+      ? "Passphrase opens your vault by default."
+      : vaultMethod
+        ? `${readableMethod(vaultMethod)} opens your vault by default.`
+        : "Default unlock is not set.";
   const canEditKaiPreferences = Boolean(
-    user?.uid && vaultAccess.hasVault && vaultAccess.canMutateSecureData
+    user?.uid && vaultAccess.hasVault && vaultAccess.canMutateSecureData,
   );
 
-  const marketplaceStatusText =
-    loadingMarketplaceOptIn
-      ? "Checking visibility…"
-      : marketplaceOptIn
-        ? "Discoverable to RIAs"
-        : "Hidden from marketplace search";
-  const phoneSummaryText = phoneNumber ? maskPhoneNumber(phoneNumber) : "No phone number linked yet";
+  const marketplaceStatusText = loadingMarketplaceOptIn
+    ? "Checking visibility…"
+    : marketplaceOptIn
+      ? "Discoverable to RIAs"
+      : "Hidden from marketplace search";
+  const phoneSummaryText = phoneNumber
+    ? maskPhoneNumber(phoneNumber)
+    : "No phone number linked yet";
   const emailVerified = Boolean(user?.emailVerified);
-  const emailVerificationText = emailVerified ? "Verified email" : "Email not verified";
+  const emailVerificationText = emailVerified
+    ? "Verified email"
+    : "Email not verified";
 
   const gmailStatusLabel = gmailPresentation.badgeLabel;
   const gmailStatusSummary = useMemo(
@@ -1515,7 +1781,7 @@ function ProfilePageContent() {
         loading: gmail.loadingStatus || gmailActionBusy === "sync",
         errorText: gmail.statusError,
       }),
-    [gmail.loadingStatus, gmail.status, gmail.statusError, gmailActionBusy]
+    [gmail.loadingStatus, gmail.status, gmail.statusError, gmailActionBusy],
   );
   const gmailSettingsDescription = gmailPresentation.description;
   const gmailLastSyncText = gmailPresentation.latestSyncText;
@@ -1540,20 +1806,20 @@ function ProfilePageContent() {
     activePanel === "support" && activeDetail?.startsWith("support-compose:")
       ? (activeDetail.slice("support-compose:".length) as SupportMessageKind)
       : null;
-  const securitySummaryText =
-    vaultAccess.needsVaultCreation
-      ? "Vault not created yet"
-      : loadingVaultMethod
-        ? "Loading methods…"
-        : vaultAccess.needsUnlock
-          ? "Locked"
-          : readableMethod(displayedUnlockMethod);
+  const securitySummaryText = vaultAccess.needsVaultCreation
+    ? "Vault not created yet"
+    : loadingVaultMethod
+      ? "Loading methods…"
+      : vaultAccess.needsUnlock
+        ? "Locked"
+        : readableMethod(displayedUnlockMethod);
   const profileVoiceSurfaceMetadata = useMemo(() => {
     const controls = [
       {
         id: "profile_my_data",
         label: "Personal Knowledge Model",
-        purpose: "opens your saved domains, source summaries, and sharing controls.",
+        purpose:
+          "opens your saved domains, source summaries, and sharing controls.",
         actionId: "route.profile_my_data",
         role: "card",
         voiceAliases: ["personal knowledge model", "my data", "pkm"],
@@ -1665,19 +1931,21 @@ function ProfilePageContent() {
           ? ["Report a bug", "Get support", "Reach developer"]
           : activePanel === "account"
             ? [phoneNumber ? "Change phone number" : "Add phone number"]
-          : activePanel === "security"
-            ? [
-                vaultAccess.needsVaultCreation ? "Create your vault" : "Unlock vault",
-                "Change passphrase",
-                "Delete account",
-              ]
-            : [
-                "Open Account",
-                "Open Personal Knowledge Model",
-                "Open Access & sharing",
-                "Open Gmail receipts",
-                "Open Support",
-              ];
+            : activePanel === "security"
+              ? [
+                  vaultAccess.needsVaultCreation
+                    ? "Create your vault"
+                    : "Unlock vault",
+                  "Change passphrase",
+                  "Delete account",
+                ]
+              : [
+                  "Open Account",
+                  "Open Personal Knowledge Model",
+                  "Open Access & sharing",
+                  "Open Gmail receipts",
+                  "Open Support",
+                ];
 
     return {
       surfaceDefinition: {
@@ -1700,17 +1968,41 @@ function ProfilePageContent() {
         purpose:
           "This surface manages account identity, profile data, access, preferences, Gmail receipts, support, and vault security.",
         sections: [
-          { id: "account", title: "Account", purpose: "Email, phone, and sign-in identity." },
+          {
+            id: "account",
+            title: "Account",
+            purpose: "Email, phone, and sign-in identity.",
+          },
           {
             id: "my-data",
             title: "Personal Knowledge Model",
             purpose: "Saved domains, source summaries, and sharing controls.",
           },
-          { id: "access", title: "Access & sharing", purpose: "Consent-backed access and sharing." },
-          { id: "preferences", title: "Preferences", purpose: "Shell and Kai preferences." },
-          { id: "security", title: "Security", purpose: "Vault and destructive account actions." },
-          { id: "gmail", title: "Gmail receipts", purpose: "Receipt sync and Gmail connector state." },
-          { id: "support", title: "Support & feedback", purpose: "Support routing and compose flows." },
+          {
+            id: "access",
+            title: "Access & sharing",
+            purpose: "Consent-backed access and sharing.",
+          },
+          {
+            id: "preferences",
+            title: "Preferences",
+            purpose: "Shell and Kai preferences.",
+          },
+          {
+            id: "security",
+            title: "Security",
+            purpose: "Vault and destructive account actions.",
+          },
+          {
+            id: "gmail",
+            title: "Gmail receipts",
+            purpose: "Receipt sync and Gmail connector state.",
+          },
+          {
+            id: "support",
+            title: "Support & feedback",
+            purpose: "Support routing and compose flows.",
+          },
         ],
         actions: availableActions.map((action) => ({
           id: action.toLowerCase().replace(/[^a-z0-9]+/g, "_"),
@@ -1740,7 +2032,8 @@ function ProfilePageContent() {
       activeSection: activePanel || "profile",
       activeTab: activePanel || "profile",
       visibleModules,
-      focusedWidget: activeControl?.label || (activeDetail ?? activePanel ?? "Profile"),
+      focusedWidget:
+        activeControl?.label || (activeDetail ?? activePanel ?? "Profile"),
       modalState: passphraseDialogOpen
         ? "passphrase_dialog"
         : showVaultUnlock
@@ -1818,11 +2111,23 @@ function ProfilePageContent() {
     if (hasVault) {
       requestVaultUnlock("profile_data");
     } else {
-      toast.error("Create your vault first before unlocking secure profile data.");
+      toast.error(
+        "Create your vault first before unlocking secure profile data.",
+      );
     }
 
-    router.replace(buildProfileHref({ panel: activePanel, detail: activeDetail }), { scroll: false });
-  }, [activeDetail, activePanel, authLoading, hasVault, router, shouldRequestVaultUnlock]);
+    router.replace(
+      buildProfileHref({ panel: activePanel, detail: activeDetail }),
+      { scroll: false },
+    );
+  }, [
+    activeDetail,
+    activePanel,
+    authLoading,
+    hasVault,
+    router,
+    shouldRequestVaultUnlock,
+  ]);
 
   useEffect(() => {
     if (authLoading || !user?.uid || !hasVault || !vaultAccess.needsUnlock) {
@@ -1837,10 +2142,20 @@ function ProfilePageContent() {
         detail: activeDetail ?? null,
         mode: "replace",
       });
-      router.replace(buildProfileHref({ panel: null, detail: null }), { scroll: false });
+      router.replace(buildProfileHref({ panel: null, detail: null }), {
+        scroll: false,
+      });
     }
     requestVaultUnlock("profile_data");
-  }, [activeDetail, activePanel, authLoading, hasVault, router, user?.uid, vaultAccess.needsUnlock]);
+  }, [
+    activeDetail,
+    activePanel,
+    authLoading,
+    hasVault,
+    router,
+    user?.uid,
+    vaultAccess.needsUnlock,
+  ]);
 
   if (authLoading || !user) {
     return null;
@@ -1865,7 +2180,7 @@ function ProfilePageContent() {
         panel: "preferences",
         detail: "kai-preferences",
       },
-      "push"
+      "push",
     );
   };
 
@@ -1879,8 +2194,10 @@ function ProfilePageContent() {
   const openMyDataPanel = () => openVaultBackedPanel("my-data");
   const openAccessPanel = () => openVaultBackedPanel("access");
   const openGmailPanel = () => openVaultBackedPanel("gmail");
-  const openAccountPanel = () => updateProfileView({ panel: "account", detail: null }, "push");
-  const openPreferencesPanel = () => updateProfileView({ panel: "preferences", detail: null }, "push");
+  const openAccountPanel = () =>
+    updateProfileView({ panel: "account", detail: null }, "push");
+  const openPreferencesPanel = () =>
+    updateProfileView({ panel: "preferences", detail: null }, "push");
   const openSecurityPanel = () => openVaultBackedPanel("security");
 
   const handlePreviewDomainPermission = async (
@@ -1890,7 +2207,7 @@ function ProfilePageContent() {
       label: string;
       description: string;
       topLevelScopePath: string;
-    }
+    },
   ) => {
     if (!user?.uid || !vaultKey || !vaultOwnerToken) {
       requestVaultUnlock("profile_data");
@@ -1938,7 +2255,9 @@ function ProfilePageContent() {
       }));
     } catch (error) {
       const message =
-        error instanceof Error ? error.message : "Couldn't load saved values for this section.";
+        error instanceof Error
+          ? error.message
+          : "Couldn't load saved values for this section.";
       setDomainPreview((current) => ({
         ...current,
         open: true,
@@ -1962,7 +2281,7 @@ function ProfilePageContent() {
       topLevelScopePath: string;
       exposureEnabled: boolean;
     },
-    nextValue: boolean
+    nextValue: boolean,
   ) => {
     if (!user?.uid || !vaultOwnerToken) {
       requestVaultUnlock("profile_data");
@@ -1982,11 +2301,17 @@ function ProfilePageContent() {
         scopeHandle: permission.scopeHandle,
         topLevelScopePath: permission.topLevelScopePath,
       },
-      nextValue
+      nextValue,
     );
 
-    setPendingPermissionToggles((current) => ({ ...current, [permissionKey]: true }));
-    setDomainManifests((current) => ({ ...current, [domainKey]: optimisticManifest ?? previousManifest }));
+    setPendingPermissionToggles((current) => ({
+      ...current,
+      [permissionKey]: true,
+    }));
+    setDomainManifests((current) => ({
+      ...current,
+      [domainKey]: optimisticManifest ?? previousManifest,
+    }));
     setDomainManifestErrors((current) => ({ ...current, [domainKey]: null }));
 
     try {
@@ -2010,11 +2335,19 @@ function ProfilePageContent() {
       }));
       await Promise.all([refreshConsentCenter(true), refreshPkmMetadata(true)]);
       toast.success(
-        nextValue ? "Sharing section is available for future approvals." : "Sharing section is now hidden."
+        nextValue
+          ? "Sharing section is available for future approvals."
+          : "Sharing section is now hidden.",
       );
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Couldn't update sharing right now.";
-      setDomainManifests((current) => ({ ...current, [domainKey]: previousManifest }));
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Couldn't update sharing right now.";
+      setDomainManifests((current) => ({
+        ...current,
+        [domainKey]: previousManifest,
+      }));
 
       if (error instanceof PkmScopeExposureError && error.status === 409) {
         await Promise.all([
@@ -2022,7 +2355,9 @@ function ProfilePageContent() {
           refreshConsentCenter(true),
           refreshPkmMetadata(true),
         ]);
-        toast.error("Sharing changed elsewhere. The latest version has been reloaded.");
+        toast.error(
+          "Sharing changed elsewhere. The latest version has been reloaded.",
+        );
       } else {
         void refreshDomainManifest(domainKey, true);
         toast.error(message || "Couldn't update sharing right now.");
@@ -2046,19 +2381,22 @@ function ProfilePageContent() {
       kind: "bug_report",
       icon: Bug,
       label: "Report bug",
-      description: "Broken flow, confusing UI, or something off in the product.",
+      description:
+        "Broken flow, confusing UI, or something off in the product.",
     },
     {
       kind: "support_request",
       icon: LifeBuoy,
       label: "Get support",
-      description: "Need help with onboarding, portfolio data, or account setup.",
+      description:
+        "Need help with onboarding, portfolio data, or account setup.",
     },
     {
       kind: "developer_reachout",
       icon: Code2,
       label: "Reach developer",
-      description: "Direct product or engineering feedback routed through support.",
+      description:
+        "Direct product or engineering feedback routed through support.",
     },
   ];
 
@@ -2078,7 +2416,9 @@ function ProfilePageContent() {
       loadingManifestsByDomain={loadingDomainManifests}
       manifestErrorsByDomain={domainManifestErrors}
       upgradeStatesByDomain={upgradeStatesByDomain}
-      onOpenSharing={() => updateProfileView({ panel: "access", detail: null }, "push")}
+      onOpenSharing={() =>
+        updateProfileView({ panel: "access", detail: null }, "push")
+      }
       onOpenImport={() => router.push(ROUTES.KAI_IMPORT)}
       onRefresh={() => {
         void refreshPkmMetadata(true);
@@ -2091,7 +2431,7 @@ function ProfilePageContent() {
             panel: "my-data",
             detail: `domain:${domain.key}`,
           },
-          "push"
+          "push",
         )
       }
     />
@@ -2112,7 +2452,7 @@ function ProfilePageContent() {
               panel: "access",
               detail: `connection:${connection.id}`,
             },
-            "push"
+            "push",
           )
         }
         onRevokeAccess={async (scope) => {
@@ -2151,7 +2491,9 @@ function ProfilePageContent() {
     </div>
   );
 
-  const handleAccountPhoneCompleted = async (verifiedUser?: typeof user | null) => {
+  const handleAccountPhoneCompleted = async (
+    verifiedUser?: typeof user | null,
+  ) => {
     const activeUser = verifiedUser ?? user;
     await AccountIdentityService.syncCurrentUser(activeUser);
     updateProfileView({ panel: "account", detail: null }, "replace");
@@ -2162,7 +2504,9 @@ function ProfilePageContent() {
       <div className="flex flex-wrap gap-2">
         <Badge variant="secondary">{provider.name}</Badge>
         <Badge variant="secondary">{emailVerificationText}</Badge>
-        <Badge variant="secondary">{phoneNumber ? "Phone verified" : "Phone required"}</Badge>
+        <Badge variant="secondary">
+          {phoneNumber ? "Phone verified" : "Phone required"}
+        </Badge>
       </div>
       <SettingsGroup title="Identity">
         <SettingsRow
@@ -2174,14 +2518,22 @@ function ProfilePageContent() {
           icon={Mail}
           title="Email"
           description={user.email || "Not available"}
-          trailing={<Badge variant="secondary">{emailVerified ? "Verified" : "Unverified"}</Badge>}
+          trailing={
+            <Badge variant="secondary">
+              {emailVerified ? "Verified" : "Unverified"}
+            </Badge>
+          }
           stackTrailingOnMobile
         />
         <SettingsRow
           icon={Phone}
           title="Phone number"
           description={phoneSummaryText}
-          trailing={<Badge variant="secondary">{phoneNumber ? "Verified" : "Required"}</Badge>}
+          trailing={
+            <Badge variant="secondary">
+              {phoneNumber ? "Verified" : "Required"}
+            </Badge>
+          }
           stackTrailingOnMobile
         />
         <SettingsRow
@@ -2200,7 +2552,9 @@ function ProfilePageContent() {
               : "Add a verified phone number to this account."
           }
           chevron
-          onClick={() => updateProfileView({ panel: "account", detail: "phone" }, "push")}
+          onClick={() =>
+            updateProfileView({ panel: "account", detail: "phone" }, "push")
+          }
         />
       </SettingsGroup>
     </div>
@@ -2211,7 +2565,9 @@ function ProfilePageContent() {
       <div className="flex flex-wrap gap-2">
         <Badge variant="secondary">Appearance</Badge>
         <Badge variant="secondary">
-          {canEditKaiPreferences ? "Secure preferences ready" : "Unlock required"}
+          {canEditKaiPreferences
+            ? "Secure preferences ready"
+            : "Unlock required"}
         </Badge>
         <Badge variant="secondary">Device controls soon</Badge>
       </div>
@@ -2231,7 +2587,11 @@ function ProfilePageContent() {
               ? "Risk profile and horizon."
               : "Unlock to edit secure Kai preferences."
           }
-          trailing={canEditKaiPreferences ? <Badge variant="secondary">Ready</Badge> : null}
+          trailing={
+            canEditKaiPreferences ? (
+              <Badge variant="secondary">Ready</Badge>
+            ) : null
+          }
           chevron
           stackTrailingOnMobile
           onClick={openKaiPreferences}
@@ -2243,7 +2603,12 @@ function ProfilePageContent() {
           trailing={<Badge variant="secondary">Coming soon</Badge>}
           chevron
           stackTrailingOnMobile
-          onClick={() => updateProfileView({ panel: "preferences", detail: "device" }, "push")}
+          onClick={() =>
+            updateProfileView(
+              { panel: "preferences", detail: "device" },
+              "push",
+            )
+          }
         />
       </SettingsGroup>
     </div>
@@ -2253,10 +2618,16 @@ function ProfilePageContent() {
     <div className="space-y-4">
       <div className="flex flex-wrap gap-2">
         <Badge variant="secondary">
-          {vaultAccess.hasVault ? (vaultAccess.needsUnlock ? "Vault locked" : "Vault unlocked") : "No vault"}
+          {vaultAccess.hasVault
+            ? vaultAccess.needsUnlock
+              ? "Vault locked"
+              : "Vault unlocked"
+            : "No vault"}
         </Badge>
         {displayedUnlockMethod ? (
-          <Badge variant="secondary">{readableMethod(displayedUnlockMethod)}</Badge>
+          <Badge variant="secondary">
+            {readableMethod(displayedUnlockMethod)}
+          </Badge>
         ) : null}
       </div>
       <SettingsGroup>
@@ -2265,7 +2636,9 @@ function ProfilePageContent() {
           title="Vault methods"
           description="Passphrase, passkey, and unlock method."
           chevron
-          onClick={() => updateProfileView({ panel: "security", detail: "vault" }, "push")}
+          onClick={() =>
+            updateProfileView({ panel: "security", detail: "vault" }, "push")
+          }
         />
         <SettingsRow
           icon={Trash2}
@@ -2273,7 +2646,9 @@ function ProfilePageContent() {
           description="Delete Investor, RIA, or the full account."
           chevron
           tone="destructive"
-          onClick={() => updateProfileView({ panel: "security", detail: "danger" }, "push")}
+          onClick={() =>
+            updateProfileView({ panel: "security", detail: "danger" }, "push")
+          }
         />
       </SettingsGroup>
     </div>
@@ -2300,7 +2675,12 @@ function ProfilePageContent() {
           title="Support routing"
           description="Reply address and routing."
           chevron
-          onClick={() => updateProfileView({ panel: "support", detail: "support-routing" }, "push")}
+          onClick={() =>
+            updateProfileView(
+              { panel: "support", detail: "support-routing" },
+              "push",
+            )
+          }
         />
       </SettingsGroup>
     </div>
@@ -2322,14 +2702,24 @@ function ProfilePageContent() {
           trailing={<Badge variant="secondary">{gmailStatusLabel}</Badge>}
           chevron
           stackTrailingOnMobile
-          onClick={() => updateProfileView({ panel: "gmail", detail: "gmail-connection" }, "push")}
+          onClick={() =>
+            updateProfileView(
+              { panel: "gmail", detail: "gmail-connection" },
+              "push",
+            )
+          }
         />
         <SettingsRow
           icon={RefreshCw}
           title="Actions"
           description="Connect, sync, receipts, or disconnect."
           chevron
-          onClick={() => updateProfileView({ panel: "gmail", detail: "gmail-actions" }, "push")}
+          onClick={() =>
+            updateProfileView(
+              { panel: "gmail", detail: "gmail-actions" },
+              "push",
+            )
+          }
         />
       </SettingsGroup>
     </div>
@@ -2359,40 +2749,55 @@ function ProfilePageContent() {
 
         {vaultAccess.hasVault && !loadingVaultMethod ? (
           <>
-            <SettingsRow
-              icon={Fingerprint}
-              title="Unlock here"
-              description={
-                unlockMethodDiffersFromStoredDefault
-                  ? `This device or domain is using ${readableMethod(displayedUnlockMethod)} right now.`
-                  : "This is the unlock method available in your current environment."
-              }
-              trailing={
-                <Badge variant="secondary">
-                  {displayedUnlockMethod === "passphrase" ? "Passphrase unlock" : "Quick unlock"}
-                </Badge>
-              }
-              stackTrailingOnMobile
-            />
             {vaultMethod ? (
               <SettingsRow
                 icon={KeyRound}
-                title="Stored default"
-                description="Primary vault preference stored with your account."
-                trailing={<Badge variant="secondary">{readableMethod(vaultMethod)}</Badge>}
+                title="Default unlock"
+                description={defaultUnlockDescription}
+                trailing={
+                  <div className="flex flex-wrap items-center justify-start gap-2 sm:justify-end">
+                    <Badge
+                      variant="secondary"
+                      className={VAULT_INLINE_BADGE_CLASS}
+                    >
+                      {readableMethod(vaultMethod)}
+                    </Badge>
+                    {canSwitchDefaultToPassphrase ? (
+                      <Button
+                        variant="none"
+                        effect="fade"
+                        size="sm"
+                        className={VAULT_INLINE_CONTROL_CLASS}
+                        disabled={switchingVaultMethod}
+                        onClick={() => void preferPassphraseUnlock()}
+                      >
+                        Use passphrase
+                      </Button>
+                    ) : null}
+                    {canSwitchDefaultToQuick &&
+                    quickMethodReadyOnCurrentDevice ? (
+                      <Button
+                        variant="none"
+                        effect="fade"
+                        size="sm"
+                        className={VAULT_INLINE_CONTROL_CLASS}
+                        disabled={switchingVaultMethod}
+                        onClick={() =>
+                          void setQuickMethodAsDefault(
+                            quickMethodReadyOnCurrentDevice,
+                            availableQuickWrapperId,
+                          )
+                        }
+                      >
+                        Use{" "}
+                        {readableQuickMethod(quickMethodReadyOnCurrentDevice)}
+                      </Button>
+                    ) : null}
+                  </div>
+                }
                 stackTrailingOnMobile
               />
             ) : null}
-            <SettingsRow
-              icon={Monitor}
-              title="Enrolled methods"
-              description={
-                enrolledVaultMethods.length > 0
-                  ? formatMethodList(enrolledVaultMethods)
-                  : "No quick unlock methods enrolled yet."
-              }
-            />
-
             {!vaultAccess.canMutateSecureData ? (
               <SettingsRow
                 icon={KeyRound}
@@ -2403,42 +2808,91 @@ function ProfilePageContent() {
               />
             ) : null}
 
-            {vaultMethod === "passphrase" && recommendedQuickMethod ? (
+            {vaultAccess.canMutateSecureData && recommendedQuickMethod ? (
               <SettingsRow
-                icon={KeyRound}
+                icon={Fingerprint}
                 title={
-                  quickMethodReadyOnCurrentDevice
-                    ? `Use ${readableQuickMethod(quickMethodReadyOnCurrentDevice)} by default`
-                    : `Enable ${readableQuickMethod(recommendedQuickMethod)}`
+                  enrolledPasskeyWrappers.length > 0
+                    ? `Add another ${readableQuickMethod(recommendedQuickMethod)}`
+                    : `Add ${readableQuickMethod(recommendedQuickMethod)}`
                 }
                 description={
-                  quickMethodReadyOnCurrentDevice
-                    ? "Switch your primary unlock to the quick method already enrolled here."
-                    : "Enroll and switch to the recommended quick unlock method."
+                  isPasskeyVaultMethod(recommendedQuickMethod)
+                    ? "Create a saved passkey for this device or browser."
+                    : "Enable this device's secure quick unlock."
                 }
                 disabled={switchingVaultMethod}
                 chevron
-                onClick={() =>
-                  quickMethodReadyOnCurrentDevice
-                    ? void setQuickMethodAsDefault(
-                        quickMethodReadyOnCurrentDevice,
-                        availableQuickWrapperId
-                      )
-                    : void switchToQuickMethod(recommendedQuickMethod)
-                }
+                onClick={() => void switchToQuickMethod(recommendedQuickMethod)}
               />
             ) : null}
 
-            {vaultMethod && vaultMethod !== "passphrase" ? (
-              <SettingsRow
-                icon={RefreshCw}
-                title="Prefer passphrase unlock"
-                description="Make passphrase the stored default again."
-                disabled={switchingVaultMethod}
-                chevron
-                onClick={() => void preferPassphraseUnlock()}
-              />
-            ) : null}
+            {enrolledPasskeyWrappers.map((wrapper, index) => {
+              const wrapperId = wrapper.wrapperId ?? "default";
+              const isPrimary =
+                vaultMethod === wrapper.method &&
+                activePrimaryWrapperId === wrapperId;
+              return (
+                <SettingsRow
+                  key={vaultWrapperKey(wrapper)}
+                  icon={Fingerprint}
+                  title={
+                    enrolledPasskeyWrappers.length > 1
+                      ? `Passkey ${index + 1}`
+                      : "Passkey"
+                  }
+                  description={describePasskeyWrapper(wrapper)}
+                  trailing={
+                    vaultAccess.canMutateSecureData ? (
+                      <div className="flex flex-wrap items-center justify-start gap-2 sm:justify-end">
+                        {isPrimary ? (
+                          <Badge
+                            variant="secondary"
+                            className={VAULT_INLINE_BADGE_CLASS}
+                          >
+                            Default
+                          </Badge>
+                        ) : (
+                          <Button
+                            variant="none"
+                            effect="fade"
+                            size="sm"
+                            className={VAULT_INLINE_CONTROL_CLASS}
+                            disabled={switchingVaultMethod}
+                            onClick={() =>
+                              void setQuickMethodAsDefault(
+                                wrapper.method,
+                                wrapperId,
+                              )
+                            }
+                          >
+                            Set default
+                          </Button>
+                        )}
+                        <Button
+                          variant="none"
+                          effect="fade"
+                          size="sm"
+                          className={`${VAULT_INLINE_CONTROL_CLASS} text-destructive hover:text-destructive`}
+                          disabled={switchingVaultMethod}
+                          onClick={() => setPasskeyRemovalTarget(wrapper)}
+                        >
+                          Remove
+                        </Button>
+                      </div>
+                    ) : (
+                      <Badge
+                        variant="secondary"
+                        className={VAULT_INLINE_BADGE_CLASS}
+                      >
+                        {isPrimary ? "Default" : "Saved"}
+                      </Badge>
+                    )
+                  }
+                  stackTrailingOnMobile
+                />
+              );
+            })}
 
             {vaultMethod ? (
               <SettingsRow
@@ -2576,7 +3030,9 @@ function ProfilePageContent() {
   const supportComposeContent = supportComposeKind ? (
     <SurfaceCard>
       <SurfaceCardHeader>
-        <SurfaceCardTitle>{SUPPORT_KIND_COPY[supportComposeKind].title}</SurfaceCardTitle>
+        <SurfaceCardTitle>
+          {SUPPORT_KIND_COPY[supportComposeKind].title}
+        </SurfaceCardTitle>
         <SurfaceCardDescription>
           {SUPPORT_KIND_COPY[supportComposeKind].description}
         </SurfaceCardDescription>
@@ -2647,8 +3103,12 @@ function ProfilePageContent() {
           <PhoneVerificationFlow
             mode={phoneNumber ? "replace" : "link"}
             currentPhoneNumber={phoneNumber}
-            startVerification={phoneNumber ? startPhoneReplacement : startPhoneVerification}
-            confirmVerification={phoneNumber ? confirmPhoneReplacement : confirmPhoneVerification}
+            startVerification={
+              phoneNumber ? startPhoneReplacement : startPhoneVerification
+            }
+            confirmVerification={
+              phoneNumber ? confirmPhoneReplacement : confirmPhoneVerification
+            }
             onCompleted={handleAccountPhoneCompleted}
             onCancel={popProfileStack}
             confirmLabel="Save phone number"
@@ -2687,8 +3147,12 @@ function ProfilePageContent() {
                 canManagePermissions: false,
               }
             }
-            manifestLoading={Boolean(selectedDomain && loadingDomainManifests[selectedDomain.key])}
-            manifestError={selectedDomain ? domainManifestErrors[selectedDomain.key] : null}
+            manifestLoading={Boolean(
+              selectedDomain && loadingDomainManifests[selectedDomain.key],
+            )}
+            manifestError={
+              selectedDomain ? domainManifestErrors[selectedDomain.key] : null
+            }
             pendingPermissionKeys={selectedDomainPermissions
               .filter((permission) => pendingPermissionToggles[permission.key])
               .map((permission) => permission.key)}
@@ -2708,7 +3172,11 @@ function ProfilePageContent() {
               void handlePreviewDomainPermission(selectedDomain.key, permission)
             }
             onTogglePermission={(permission, nextValue) =>
-              void handleToggleDomainPermission(selectedDomain.key, permission, nextValue)
+              void handleToggleDomainPermission(
+                selectedDomain.key,
+                permission,
+                nextValue,
+              )
             }
           />
         ),
@@ -2729,9 +3197,9 @@ function ProfilePageContent() {
         content: (
           <PkmAccessConnectionDetailPanel
             connection={selectedConnection}
-              onRevokeAccess={async (scope) => {
-                await handleRevoke(scope);
-              }}
+            onRevokeAccess={async (scope) => {
+              await handleRevoke(scope);
+            }}
           />
         ),
       });
@@ -2874,9 +3342,7 @@ function ProfilePageContent() {
 
   const profileRootContent = (
     <>
-      <AppPageHeaderRegion
-        className={styles.profilePageHeaderRegion}
-      >
+      <AppPageHeaderRegion className={styles.profilePageHeaderRegion}>
         <header
           className="flex w-full min-w-0 flex-col items-center gap-2.5 px-4 text-center sm:px-6"
           data-slot="page-header"
@@ -2963,9 +3429,9 @@ function ProfilePageContent() {
                       ? "Checking saved domains."
                       : pkmMetadataFailed
                         ? "Saved data is unavailable."
-                    : vaultAccess.needsUnlock
-                      ? "Unlock to review domains and sharing."
-                      : "Domains, counts, and sharing."
+                        : vaultAccess.needsUnlock
+                          ? "Unlock to review domains and sharing."
+                          : "Domains, counts, and sharing."
                 }
                 trailing={<Badge variant="secondary">{myDataRootBadge}</Badge>}
                 chevron={!vaultAccess.needsVaultCreation}
@@ -2983,9 +3449,9 @@ function ProfilePageContent() {
                       ? "Checking current sharing state."
                       : consentCenterFailed
                         ? "Sharing is unavailable."
-                    : vaultAccess.needsUnlock
-                      ? "Unlock to review live access."
-                      : "Who can read what."
+                        : vaultAccess.needsUnlock
+                          ? "Unlock to review live access."
+                          : "Who can read what."
                 }
                 trailing={<Badge variant="secondary">{accessRootBadge}</Badge>}
                 chevron={!vaultAccess.needsVaultCreation}
@@ -3011,13 +3477,13 @@ function ProfilePageContent() {
               />
               <SettingsRow
                 icon={ClipboardCheck}
-                title="One KYC"
+                title="Email"
                 description={
                   vaultAccess.needsVaultCreation
                     ? "Create your vault first."
                     : vaultAccess.needsUnlock
-                      ? "Unlock to review broker requests."
-                      : "Broker requests and approval drafts."
+                      ? "Unlock to review email requests."
+                      : "Requests and approval drafts."
                 }
                 trailing={<Badge variant="secondary">Preview</Badge>}
                 chevron={!vaultAccess.needsVaultCreation}
@@ -3054,7 +3520,9 @@ function ProfilePageContent() {
                 title="Support & feedback"
                 description="Help, bugs, and product feedback."
                 chevron
-                onClick={() => updateProfileView({ panel: "support", detail: null }, "push")}
+                onClick={() =>
+                  updateProfileView({ panel: "support", detail: null }, "push")
+                }
               />
               {canShowPkmAgentLab ? (
                 <SettingsRow
@@ -3109,7 +3577,10 @@ function ProfilePageContent() {
         dataState: authLoading ? "loading" : "loaded",
       }}
     >
-      <ProfileStackNavigator rootContent={profileRootContent} entries={profileStackEntries} />
+      <ProfileStackNavigator
+        rootContent={profileRootContent}
+        entries={profileStackEntries}
+      />
 
       {hasVault === true && (
         <VaultUnlockDialog
@@ -3134,7 +3605,7 @@ function ProfilePageContent() {
                   panel: pendingProfileTarget.panel,
                   detail: pendingProfileTarget.detail,
                 },
-                pendingProfileTarget.mode
+                pendingProfileTarget.mode,
               );
               setPendingProfileTarget(null);
             }
@@ -3146,11 +3617,15 @@ function ProfilePageContent() {
         />
       )}
 
-      <Dialog open={passphraseDialogOpen} onOpenChange={setPassphraseDialogOpen}>
+      <Dialog
+        open={passphraseDialogOpen}
+        onOpenChange={setPassphraseDialogOpen}
+      >
         <DialogContent className="w-[calc(100%-1rem)] max-h-[calc(100svh-1rem)] overflow-y-auto sm:max-w-md">
           <DialogTitle>Change passphrase</DialogTitle>
           <DialogDescription>
-            Set a new passphrase for Vault unlock. Your passkey and biometric methods stay active.
+            Set a new passphrase for Vault unlock. Your passkey and biometric
+            methods stay active.
           </DialogDescription>
           <div className="space-y-3 pt-2">
             <Input
@@ -3193,6 +3668,49 @@ function ProfilePageContent() {
         </DialogContent>
       </Dialog>
 
+      <AlertDialog
+        open={Boolean(passkeyRemovalTarget)}
+        onOpenChange={(open) => {
+          if (!open) setPasskeyRemovalTarget(null);
+        }}
+      >
+        <AlertDialogContent className="w-[calc(100%-1rem)] sm:max-w-lg">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove passkey?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This removes the saved passkey from One. It may still remain in
+              your password manager, and passphrase unlock will stay available.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {passkeyRemovalTarget ? (
+            <p className="rounded-2xl bg-muted/50 px-4 py-3 text-sm leading-6 text-muted-foreground">
+              {describePasskeyWrapper(passkeyRemovalTarget)}
+            </p>
+          ) : null}
+          <AlertDialogFooter className="flex-col-reverse gap-2 sm:flex-row">
+            <AlertDialogCancel
+              className="w-full sm:w-auto"
+              disabled={switchingVaultMethod}
+            >
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              variant="default"
+              className="app-critical-action w-full opacity-90 transition-opacity hover:opacity-100 sm:w-auto"
+              disabled={switchingVaultMethod || !passkeyRemovalTarget}
+              onClick={(event) => {
+                event.preventDefault();
+                if (passkeyRemovalTarget) {
+                  void removePasskeyWrapper(passkeyRemovalTarget);
+                }
+              }}
+            >
+              {switchingVaultMethod ? "Removing..." : "Remove passkey"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
       <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
         <AlertDialogContent className="w-[calc(100%-1rem)] sm:max-w-lg">
           <AlertDialogHeader>
@@ -3208,7 +3726,9 @@ function ProfilePageContent() {
             <div className="space-y-3">
               <SettingsSegmentedTabs
                 value={deleteTarget}
-                onValueChange={(value) => setDeleteTarget(value as AccountDeletionTarget)}
+                onValueChange={(value) =>
+                  setDeleteTarget(value as AccountDeletionTarget)
+                }
                 options={[
                   { value: "investor", label: "Investor" },
                   { value: "ria", label: "RIA" },
@@ -3225,7 +3745,10 @@ function ProfilePageContent() {
             </div>
           ) : null}
           <AlertDialogFooter className="flex-col-reverse gap-2 sm:flex-row">
-            <AlertDialogCancel className="w-full sm:w-auto" disabled={isDeleting}>
+            <AlertDialogCancel
+              className="w-full sm:w-auto"
+              disabled={isDeleting}
+            >
               Cancel
             </AlertDialogCancel>
             <AlertDialogAction
@@ -3248,7 +3771,6 @@ function ProfilePageContent() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-
     </AppPageShell>
   );
 }

--- a/hushh-webapp/app/ria/clients/[userId]/accounts/[accountId]/page.tsx
+++ b/hushh-webapp/app/ria/clients/[userId]/accounts/[accountId]/page.tsx
@@ -6,7 +6,7 @@ const nativeStaticExportUserId =
   process.env.REVIEWER_UID ||
   process.env.UAT_SMOKE_USER_ID ||
   process.env.KAI_TEST_USER_ID ||
-  "s3xmA4lNSAQFrIaOytnSGAOzXlL2";
+  "UWHGeUyfUAbmEl5xwIPoWJ7Cyft2";
 
 export async function generateStaticParams(): Promise<Array<{ userId: string; accountId: string }>> {
   if (process.env.CAPACITOR_BUILD !== "true") {

--- a/hushh-webapp/app/ria/clients/[userId]/page.tsx
+++ b/hushh-webapp/app/ria/clients/[userId]/page.tsx
@@ -6,7 +6,7 @@ const nativeStaticExportUserId =
   process.env.REVIEWER_UID ||
   process.env.UAT_SMOKE_USER_ID ||
   process.env.KAI_TEST_USER_ID ||
-  "s3xmA4lNSAQFrIaOytnSGAOzXlL2";
+  "UWHGeUyfUAbmEl5xwIPoWJ7Cyft2";
 
 export async function generateStaticParams(): Promise<Array<{ userId: string }>> {
   if (process.env.CAPACITOR_BUILD !== "true") {

--- a/hushh-webapp/app/ria/clients/[userId]/requests/[requestId]/page.tsx
+++ b/hushh-webapp/app/ria/clients/[userId]/requests/[requestId]/page.tsx
@@ -6,7 +6,7 @@ const nativeStaticExportUserId =
   process.env.REVIEWER_UID ||
   process.env.UAT_SMOKE_USER_ID ||
   process.env.KAI_TEST_USER_ID ||
-  "s3xmA4lNSAQFrIaOytnSGAOzXlL2";
+  "UWHGeUyfUAbmEl5xwIPoWJ7Cyft2";
 
 export async function generateStaticParams(): Promise<Array<{ userId: string; requestId: string }>> {
   if (process.env.CAPACITOR_BUILD !== "true") {

--- a/hushh-webapp/components/app-ui/settings-ui.tsx
+++ b/hushh-webapp/components/app-ui/settings-ui.tsx
@@ -372,12 +372,16 @@ export function SettingsDetailPanel({
   title,
   description,
   children,
+  desktopMaxWidthClassName,
+  desktopMaxWidth,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   title: ReactNode;
   description?: ReactNode;
   children: ReactNode;
+  desktopMaxWidthClassName?: string;
+  desktopMaxWidth?: string;
 }) {
   const isMobile = useIsMobile();
   if (isMobile) {
@@ -404,7 +408,14 @@ export function SettingsDetailPanel({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange} modal>
-      <DialogContent className="w-[calc(100%-1.5rem)] max-w-[720px] overflow-hidden p-0">
+      <DialogContent
+        data-settings-detail-panel="true"
+        style={desktopMaxWidth ? { maxWidth: desktopMaxWidth } : undefined}
+        className={cn(
+          "w-[calc(100%-1.5rem)] overflow-hidden p-0",
+          desktopMaxWidthClassName || "sm:!max-w-[720px]"
+        )}
+      >
         <DialogHeader className="sticky top-0 z-10 border-b border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-default-solid)] px-6 py-4 text-left">
           <DialogTitle className="text-base font-semibold tracking-tight">
             {title}

--- a/hushh-webapp/components/profile/pkm-data-manager.tsx
+++ b/hushh-webapp/components/profile/pkm-data-manager.tsx
@@ -573,7 +573,7 @@ export function PkmDomainDetailPanel({
       <Dialog open={previewOpen} onOpenChange={onPreviewOpenChange}>
         <DialogContent
           showCloseButton={false}
-          className="w-[calc(100%-2.5rem)] max-h-[calc(100svh-2rem)] gap-0 overflow-hidden p-0 sm:max-w-[min(26rem,calc(100vw-8rem))] lg:max-w-[min(27rem,calc(100vw-12rem))]"
+          className="w-[calc(100%-2.5rem)] max-h-[calc(100svh-2rem)] gap-0 overflow-hidden p-0 sm:max-w-[min(42rem,calc(100vw-4rem))] lg:max-w-[min(48rem,calc(100vw-6rem))]"
         >
           <div className="sticky top-0 z-20 grid grid-cols-[minmax(0,1fr)_2.5rem] items-start gap-4 border-b border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-default-solid)] px-8 pb-4 pt-5 sm:px-9">
             <DialogHeader className="min-w-0 flex-1 text-left">

--- a/hushh-webapp/components/profile/pkm-section-preview.tsx
+++ b/hushh-webapp/components/profile/pkm-section-preview.tsx
@@ -26,7 +26,7 @@ function PreviewFieldList({
           </dt>
           <dd
             className={cn(
-              "min-w-0 text-sm leading-6 text-foreground",
+              "min-w-0 break-words text-sm leading-6 text-foreground",
               field.tone === "muted" ? "text-muted-foreground" : null
             )}
           >

--- a/hushh-webapp/contracts/kai/kai-action-gateway.vnext.json
+++ b/hushh-webapp/contracts/kai/kai-action-gateway.vnext.json
@@ -60,7 +60,7 @@
     {
       "schema_version": "kai.local_action_contract.v1",
       "surface_id": "one_kyc",
-      "surface_title": "One KYC",
+      "surface_title": "Email",
       "docs_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md",
         "docs/reference/architecture/one-email-kyc.md",
@@ -1123,19 +1123,19 @@
     {
       "action_id": "route.one_kyc",
       "surface_id": "one_kyc",
-      "label": "Open One KYC",
+      "label": "Open Email",
       "aliases": [
-        "open kyc",
-        "open one kyc",
-        "show kyc workflows",
-        "show broker requests"
+        "open email",
+        "open email helper",
+        "show email requests",
+        "show requests"
       ],
       "search_keywords": [
-        "kyc",
+        "email",
         "one",
-        "broker"
+        "request"
       ],
-      "meaning": "Navigates to One broker request review.",
+      "meaning": "Navigates to One email request review.",
       "speaker_persona": "kyc",
       "delegate_agent_id": "kyc",
       "reachability": {
@@ -1198,15 +1198,15 @@
       "label": "Manage Verified Emails",
       "aliases": [
         "manage verified emails",
-        "add broker email",
+        "add email address",
         "show matching emails"
       ],
       "search_keywords": [
-        "kyc",
         "email",
-        "broker"
+        "address",
+        "match"
       ],
-      "meaning": "Opens the verified email address panel used to match broker KYC requests.",
+      "meaning": "Opens the verified email address panel used to match email requests.",
       "speaker_persona": "kyc",
       "delegate_agent_id": "kyc",
       "reachability": {
@@ -1266,17 +1266,17 @@
     {
       "action_id": "kyc.workflow.sync_status",
       "surface_id": "one_kyc",
-      "label": "Sync KYC Status",
+      "label": "Sync Email Status",
       "aliases": [
-        "sync kyc",
-        "refresh kyc status"
+        "sync email",
+        "refresh request status"
       ],
       "search_keywords": [
-        "kyc",
+        "email",
         "sync",
         "consent"
       ],
-      "meaning": "Refreshes the selected One KYC workflow status after consent approval.",
+      "meaning": "Refreshes the selected email request status after consent approval.",
       "speaker_persona": "kyc",
       "delegate_agent_id": "kyc",
       "reachability": {
@@ -1335,17 +1335,17 @@
     {
       "action_id": "kyc.draft.review",
       "surface_id": "one_kyc",
-      "label": "Review KYC Draft",
+      "label": "Review Email Draft",
       "aliases": [
-        "review kyc draft",
-        "show kyc draft"
+        "review email draft",
+        "show email draft"
       ],
       "search_keywords": [
-        "kyc",
+        "email",
         "draft",
         "review"
       ],
-      "meaning": "Reads or focuses the current approval-gated KYC draft.",
+      "meaning": "Reads or focuses the current approval-gated email draft.",
       "speaker_persona": "kyc",
       "delegate_agent_id": "kyc",
       "reachability": {
@@ -1404,17 +1404,17 @@
     {
       "action_id": "kyc.draft.request_redraft",
       "surface_id": "one_kyc",
-      "label": "Request KYC Redraft",
+      "label": "Request Email Redraft",
       "aliases": [
-        "redraft kyc",
-        "revise kyc draft"
+        "redraft email",
+        "revise email draft"
       ],
       "search_keywords": [
-        "kyc",
+        "email",
         "redraft",
         "revise"
       ],
-      "meaning": "Requests a new KYC draft revision from typed or spoken user instructions.",
+      "meaning": "Requests a new email draft revision from typed or spoken user instructions.",
       "speaker_persona": "kyc",
       "delegate_agent_id": "kyc",
       "reachability": {
@@ -1474,17 +1474,17 @@
     {
       "action_id": "kyc.draft.approve_send",
       "surface_id": "one_kyc",
-      "label": "Approve KYC Send",
+      "label": "Approve Email Send",
       "aliases": [
-        "approve kyc send",
-        "send kyc reply"
+        "approve email send",
+        "send email reply"
       ],
       "search_keywords": [
-        "kyc",
+        "email",
         "send",
         "approve"
       ],
-      "meaning": "Sends the KYC draft only after explicit user approval.",
+      "meaning": "Sends the email draft only after explicit user approval.",
       "speaker_persona": "kyc",
       "delegate_agent_id": "kyc",
       "reachability": {
@@ -1545,17 +1545,17 @@
     {
       "action_id": "kyc.draft.reject",
       "surface_id": "one_kyc",
-      "label": "Reject KYC Draft",
+      "label": "Reject Email Draft",
       "aliases": [
-        "reject kyc draft",
-        "block kyc workflow"
+        "reject email draft",
+        "block email request"
       ],
       "search_keywords": [
-        "kyc",
+        "email",
         "reject",
         "block"
       ],
-      "meaning": "Rejects the current KYC draft and blocks the workflow.",
+      "meaning": "Rejects the current email draft and blocks the workflow.",
       "speaker_persona": "kyc",
       "delegate_agent_id": "kyc",
       "reachability": {

--- a/hushh-webapp/contracts/kai/voice-action-manifest.v1.json
+++ b/hushh-webapp/contracts/kai/voice-action-manifest.v1.json
@@ -426,15 +426,15 @@
     },
     {
       "id": "route.one_kyc",
-      "label": "Open One KYC",
-      "meaning": "Navigates to One broker request review.",
+      "label": "Open Email",
+      "meaning": "Navigates to One email request review.",
       "speaker_persona": "kyc",
       "delegate_agent_id": "kyc",
       "aliases": [
-        "open kyc",
-        "open one kyc",
-        "show kyc workflows",
-        "show broker requests"
+        "open email",
+        "open email helper",
+        "show email requests",
+        "show requests"
       ],
       "scope": {
         "routes": [
@@ -467,12 +467,12 @@
     {
       "id": "kyc.aliases.manage",
       "label": "Manage Verified Emails",
-      "meaning": "Opens the verified email address panel used to match broker KYC requests.",
+      "meaning": "Opens the verified email address panel used to match email requests.",
       "speaker_persona": "kyc",
       "delegate_agent_id": "kyc",
       "aliases": [
         "manage verified emails",
-        "add broker email",
+        "add email address",
         "show matching emails"
       ],
       "scope": {
@@ -504,13 +504,13 @@
     },
     {
       "id": "kyc.workflow.sync_status",
-      "label": "Sync KYC Status",
-      "meaning": "Refreshes the selected One KYC workflow status after consent approval.",
+      "label": "Sync Email Status",
+      "meaning": "Refreshes the selected email request status after consent approval.",
       "speaker_persona": "kyc",
       "delegate_agent_id": "kyc",
       "aliases": [
-        "sync kyc",
-        "refresh kyc status"
+        "sync email",
+        "refresh request status"
       ],
       "scope": {
         "routes": [
@@ -541,13 +541,13 @@
     },
     {
       "id": "kyc.draft.review",
-      "label": "Review KYC Draft",
-      "meaning": "Reads or focuses the current approval-gated KYC draft.",
+      "label": "Review Email Draft",
+      "meaning": "Reads or focuses the current approval-gated email draft.",
       "speaker_persona": "kyc",
       "delegate_agent_id": "kyc",
       "aliases": [
-        "review kyc draft",
-        "show kyc draft"
+        "review email draft",
+        "show email draft"
       ],
       "scope": {
         "routes": [
@@ -578,13 +578,13 @@
     },
     {
       "id": "kyc.draft.request_redraft",
-      "label": "Request KYC Redraft",
-      "meaning": "Requests a new KYC draft revision from typed or spoken user instructions.",
+      "label": "Request Email Redraft",
+      "meaning": "Requests a new email draft revision from typed or spoken user instructions.",
       "speaker_persona": "kyc",
       "delegate_agent_id": "kyc",
       "aliases": [
-        "redraft kyc",
-        "revise kyc draft"
+        "redraft email",
+        "revise email draft"
       ],
       "scope": {
         "routes": [
@@ -615,13 +615,13 @@
     },
     {
       "id": "kyc.draft.approve_send",
-      "label": "Approve KYC Send",
-      "meaning": "Sends the KYC draft only after explicit user approval.",
+      "label": "Approve Email Send",
+      "meaning": "Sends the email draft only after explicit user approval.",
       "speaker_persona": "kyc",
       "delegate_agent_id": "kyc",
       "aliases": [
-        "approve kyc send",
-        "send kyc reply"
+        "approve email send",
+        "send email reply"
       ],
       "scope": {
         "routes": [
@@ -653,13 +653,13 @@
     },
     {
       "id": "kyc.draft.reject",
-      "label": "Reject KYC Draft",
-      "meaning": "Rejects the current KYC draft and blocks the workflow.",
+      "label": "Reject Email Draft",
+      "meaning": "Rejects the current email draft and blocks the workflow.",
       "speaker_persona": "kyc",
       "delegate_agent_id": "kyc",
       "aliases": [
-        "reject kyc draft",
-        "block kyc workflow"
+        "reject email draft",
+        "block email request"
       ],
       "scope": {
         "routes": [

--- a/hushh-webapp/docs/plugin-api-reference.md
+++ b/hushh-webapp/docs/plugin-api-reference.md
@@ -147,6 +147,25 @@ This plugin owns mobile-facing `Cryptographic Primitives` such as key derivation
 | recoveryIv | string | Yes | Recovery IV |
 | authToken | string | No | Firebase ID token |
 
+### deleteVaultWrapper
+Removes an enrolled non-passphrase vault wrapper. If the removed wrapper is the primary unlock method, the backend switches primary unlock to the provided enrolled fallback before removal.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| userId | string | Yes | User ID |
+| vaultKeyHash | string | Yes | Hash of the unlocked vault key |
+| method | string | Yes | Wrapper method to remove |
+| wrapperId | string | No | Wrapper identifier (default: `default`) |
+| fallbackPrimaryMethod | string | No | Enrolled fallback method (default: `passphrase`) |
+| fallbackPrimaryWrapperId | string | No | Enrolled fallback wrapper ID (default: `default`) |
+| authToken | string | No | Firebase ID token |
+| vaultOwnerToken | string | Yes | Fresh VAULT_OWNER token from the unlocked vault session |
+
+**Returns:**
+| Field | Type | Description |
+|-------|------|-------------|
+| success | boolean | Whether the wrapper was removed |
+
 ### isPasskeyAvailable
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|

--- a/hushh-webapp/ios/App/App/Plugins/HushhVaultPlugin.swift
+++ b/hushh-webapp/ios/App/App/Plugins/HushhVaultPlugin.swift
@@ -23,6 +23,7 @@ public class HushhVaultPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "getVault", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setupVault", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "upsertVaultWrapper", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "deleteVaultWrapper", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setPrimaryVaultMethod", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "isPasskeyAvailable", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "registerPasskeyPrf", returnType: CAPPluginReturnPromise),
@@ -541,6 +542,49 @@ public class HushhVaultPlugin: CAPPlugin, CAPBridgedPlugin {
         }
     }
 
+    @objc func deleteVaultWrapper(_ call: CAPPluginCall) {
+        guard let userId = call.getString("userId"),
+              let vaultKeyHash = call.getString("vaultKeyHash"),
+              let method = call.getString("method"),
+              let vaultOwnerToken = call.getString("vaultOwnerToken"),
+              !vaultOwnerToken.isEmpty else {
+            call.reject("Missing required parameters")
+            return
+        }
+
+        let authToken = call.getString("authToken")
+        let backendUrl = resolvedBackendUrl(call)
+        let urlStr = "\(backendUrl)/db/vault/wrapper/delete"
+        let wrapperId = call.getString("wrapperId") ?? "default"
+        let fallbackPrimaryMethod = call.getString("fallbackPrimaryMethod") ?? "passphrase"
+        let fallbackPrimaryWrapperId = call.getString("fallbackPrimaryWrapperId") ?? "default"
+        let body: [String: Any] = [
+            "userId": userId,
+            "vaultKeyHash": vaultKeyHash,
+            "method": method,
+            "wrapperId": wrapperId,
+            "fallbackPrimaryMethod": fallbackPrimaryMethod,
+            "fallbackPrimaryWrapperId": fallbackPrimaryWrapperId
+        ]
+
+        performRequest(
+            urlStr: urlStr,
+            body: body,
+            authToken: authToken,
+            vaultOwnerToken: vaultOwnerToken
+        ) { json, error in
+            if let error = error {
+                call.reject(error)
+                return
+            }
+            if let success = json?["success"] as? Bool, success {
+                call.resolve(["success": true])
+                return
+            }
+            call.reject("Failed to remove wrapper: invalid success response")
+        }
+    }
+
     @objc func isPasskeyAvailable(_ call: CAPPluginCall) {
         guard #available(iOS 18.0, *) else {
             call.resolve([
@@ -972,7 +1016,13 @@ public class HushhVaultPlugin: CAPPlugin, CAPBridgedPlugin {
     }
     
     // MARK: - HTTP Helper
-    private func performRequest(urlStr: String, body: [String: Any], authToken: String?, completion: @escaping ([String: Any]?, String?) -> Void) {
+    private func performRequest(
+        urlStr: String,
+        body: [String: Any],
+        authToken: String?,
+        vaultOwnerToken: String? = nil,
+        completion: @escaping ([String: Any]?, String?) -> Void
+    ) {
         guard let url = URL(string: urlStr) else {
             completion(nil, "Invalid URL")
             return
@@ -984,6 +1034,9 @@ public class HushhVaultPlugin: CAPPlugin, CAPBridgedPlugin {
         request.addValue(clientVersionHeaderValue, forHTTPHeaderField: "X-Hushh-Client-Version")
         if let token = authToken {
             request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        if let token = vaultOwnerToken, !token.isEmpty {
+            request.addValue("Bearer \(token)", forHTTPHeaderField: "X-Hushh-Consent")
         }
         
         do {

--- a/hushh-webapp/lib/capacitor/index.ts
+++ b/hushh-webapp/lib/capacitor/index.ts
@@ -66,17 +66,17 @@ export interface HushhAuthPlugin {
 
   /**
    * Sign in with Apple using native iOS AuthenticationServices or Firebase OAuthProvider
-   * 
+   *
    * iOS: Uses ASAuthorizationController (native Apple Sign-In sheet)
    * Android/Web: Uses Firebase OAuthProvider (web-based OAuth flow)
-   * 
+   *
    * Returns ID token for Firebase credential exchange
    * Note: Apple may return hidden email (relay address) if user chose to hide it
    */
   signInWithApple(): Promise<{
     idToken: string;
     accessToken?: string;
-    rawNonce?: string;  // iOS only - needed for JS SDK sync if required
+    rawNonce?: string; // iOS only - needed for JS SDK sync if required
     user: AuthUser;
   }>;
 
@@ -149,7 +149,7 @@ export interface HushhConsentPlugin {
    * Mirrors: verify_trust_link() in link.py
    */
   verifyTrustLink(
-    options: VerifyTrustLinkOptions
+    options: VerifyTrustLinkOptions,
   ): Promise<VerifyTrustLinkResult>;
 
   // ==================== Backend API Methods ====================
@@ -362,6 +362,17 @@ export interface HushhVaultPlugin {
     authToken?: string;
   }): Promise<{ success: boolean }>;
 
+  deleteVaultWrapper(options: {
+    userId: string;
+    vaultKeyHash: string;
+    method: string;
+    wrapperId?: string;
+    fallbackPrimaryMethod?: string;
+    fallbackPrimaryWrapperId?: string;
+    authToken?: string;
+    vaultOwnerToken?: string;
+  }): Promise<{ success: boolean }>;
+
   setPrimaryVaultMethod(options: {
     userId: string;
     primaryMethod: string;
@@ -476,14 +487,14 @@ export interface HushhKeychainPlugin {
    * Store a value requiring biometric authentication to retrieve
    */
   setBiometric(
-    options: KeychainSetOptions & { promptMessage: string }
+    options: KeychainSetOptions & { promptMessage: string },
   ): Promise<void>;
 
   /**
    * Retrieve a biometric-protected value
    */
   getBiometric(
-    options: KeychainGetOptions & { promptMessage: string }
+    options: KeychainGetOptions & { promptMessage: string },
   ): Promise<KeychainGetResult>;
 }
 
@@ -492,7 +503,7 @@ export const HushhKeychain = registerPlugin<HushhKeychainPlugin>(
   {
     web: () =>
       import("./plugins/keychain-web").then((m) => new m.HushhKeychainWeb()),
-  }
+  },
 );
 
 // ==================== HushhSettingsPlugin ====================
@@ -514,7 +525,7 @@ export interface HushhSettingsData {
 export interface HushhSettingsPlugin {
   getSettings(): Promise<HushhSettingsData>;
   updateSettings(
-    options: Partial<HushhSettingsData>
+    options: Partial<HushhSettingsData>,
   ): Promise<{ success: boolean }>;
   resetSettings(): Promise<{ success: boolean }>;
   shouldUseLocalAgents(): Promise<{ value: boolean }>;
@@ -526,7 +537,7 @@ export const HushhSettingsNative = registerPlugin<HushhSettingsPlugin>(
   {
     web: () =>
       import("./plugins/settings-web").then((m) => new m.HushhSettingsWeb()),
-  }
+  },
 );
 
 // ==================== HushhDatabasePlugin ====================
@@ -561,7 +572,7 @@ export const HushhDatabase = registerPlugin<HushhDatabasePlugin>(
   {
     web: () =>
       import("./plugins/database-web").then((m) => new m.HushhDatabaseWeb()),
-  }
+  },
 );
 
 // ==================== HushhAgentPlugin ====================
@@ -704,9 +715,9 @@ export const HushhNotifications = registerPlugin<HushhNotificationsPlugin>(
   {
     web: () =>
       import("./plugins/notifications-web").then(
-        (m) => new m.HushhNotificationsWeb()
+        (m) => new m.HushhNotificationsWeb(),
       ),
-  }
+  },
 );
 
 // ==================== HushhPersonalKnowledgeModelPlugin ====================

--- a/hushh-webapp/lib/capacitor/plugins/vault-web.ts
+++ b/hushh-webapp/lib/capacitor/plugins/vault-web.ts
@@ -47,7 +47,7 @@ export class HushhVaultWeb extends WebPlugin {
     let saltBytes: Uint8Array;
     if (options.salt) {
       saltBytes = new Uint8Array(
-        options.salt.match(/.{1,2}/g)!.map((byte) => parseInt(byte, 16))
+        options.salt.match(/.{1,2}/g)!.map((byte) => parseInt(byte, 16)),
       );
     } else {
       saltBytes = crypto.getRandomValues(new Uint8Array(16));
@@ -59,7 +59,7 @@ export class HushhVaultWeb extends WebPlugin {
       encoder.encode(options.passphrase),
       "PBKDF2",
       false,
-      ["deriveBits"]
+      ["deriveBits"],
     );
 
     // Derive the key
@@ -71,7 +71,7 @@ export class HushhVaultWeb extends WebPlugin {
         hash: "SHA-256",
       },
       keyMaterial,
-      256 // 32 bytes
+      256, // 32 bytes
     );
 
     // Convert to hex string
@@ -97,7 +97,7 @@ export class HushhVaultWeb extends WebPlugin {
    */
   async encryptData(options: EncryptDataOptions): Promise<EncryptedPayload> {
     const keyBytes = new Uint8Array(
-      options.keyHex.match(/.{1,2}/g)!.map((byte) => parseInt(byte, 16))
+      options.keyHex.match(/.{1,2}/g)!.map((byte) => parseInt(byte, 16)),
     );
 
     const key = await crypto.subtle.importKey(
@@ -105,7 +105,7 @@ export class HushhVaultWeb extends WebPlugin {
       keyBytes,
       { name: "AES-GCM", length: 256 },
       false,
-      ["encrypt"]
+      ["encrypt"],
     );
 
     // 12-byte IV (96 bits) as per NIST recommendation
@@ -115,7 +115,7 @@ export class HushhVaultWeb extends WebPlugin {
     const encrypted = await crypto.subtle.encrypt(
       { name: "AES-GCM", iv },
       key,
-      encoder.encode(options.plaintext)
+      encoder.encode(options.plaintext),
     );
 
     // Web Crypto returns ciphertext + tag concatenated
@@ -139,7 +139,7 @@ export class HushhVaultWeb extends WebPlugin {
    */
   async decryptData(options: DecryptDataOptions): Promise<DecryptDataResult> {
     const keyBytes = new Uint8Array(
-      options.keyHex.match(/.{1,2}/g)!.map((byte) => parseInt(byte, 16))
+      options.keyHex.match(/.{1,2}/g)!.map((byte) => parseInt(byte, 16)),
     );
 
     const key = await crypto.subtle.importKey(
@@ -147,17 +147,17 @@ export class HushhVaultWeb extends WebPlugin {
       keyBytes,
       { name: "AES-GCM", length: 256 },
       false,
-      ["decrypt"]
+      ["decrypt"],
     );
 
     const ciphertext = Uint8Array.from(atob(options.payload.ciphertext), (c) =>
-      c.charCodeAt(0)
+      c.charCodeAt(0),
     );
     const tag = Uint8Array.from(atob(options.payload.tag), (c) =>
-      c.charCodeAt(0)
+      c.charCodeAt(0),
     );
     const iv = Uint8Array.from(atob(options.payload.iv), (c) =>
-      c.charCodeAt(0)
+      c.charCodeAt(0),
     );
 
     // Concatenate ciphertext + tag for Web Crypto
@@ -168,7 +168,7 @@ export class HushhVaultWeb extends WebPlugin {
     const decrypted = await crypto.subtle.decrypt(
       { name: "AES-GCM", iv },
       key,
-      combined
+      combined,
     );
 
     const decoder = new TextDecoder();
@@ -208,10 +208,10 @@ export class HushhVaultWeb extends WebPlugin {
    * Get preferences - in web mode, calls the API route
    */
   async getPreferences(
-    options: GetPreferencesOptions
+    options: GetPreferencesOptions,
   ): Promise<GetPreferencesResult> {
     const response = await fetch(
-      `/api/vault/${options.domain}?userId=${options.userId}`
+      `/api/vault/${options.domain}?userId=${options.userId}`,
     );
 
     if (!response.ok) {
@@ -247,7 +247,7 @@ export class HushhVaultWeb extends WebPlugin {
         createdAt: pref.created_at,
         updatedAt: pref.updated_at,
         consentTokenId: pref.consent_token_id,
-      })
+      }),
     );
 
     return { preferences };
@@ -279,10 +279,13 @@ export class HushhVaultWeb extends WebPlugin {
       if (options.authToken) {
         headers.Authorization = `Bearer ${options.authToken}`;
       }
-      const response = await fetch(`/api/vault/check?userId=${options.userId}`, {
-        headers,
-        signal: AbortSignal.timeout(15000),
-      });
+      const response = await fetch(
+        `/api/vault/check?userId=${options.userId}`,
+        {
+          headers,
+          signal: AbortSignal.timeout(15000),
+        },
+      );
       if (!response.ok) return { exists: false };
       const data = await response.json();
       return { exists: data.hasVault || false };
@@ -380,6 +383,32 @@ export class HushhVaultWeb extends WebPlugin {
     return { success: true };
   }
 
+  async deleteVaultWrapper(options: {
+    userId: string;
+    vaultKeyHash: string;
+    method: string;
+    wrapperId?: string;
+    fallbackPrimaryMethod?: string;
+    fallbackPrimaryWrapperId?: string;
+    authToken?: string;
+    vaultOwnerToken?: string;
+  }): Promise<{ success: boolean }> {
+    const headers: HeadersInit = { "Content-Type": "application/json" };
+    if (options.authToken) {
+      headers.Authorization = `Bearer ${options.authToken}`;
+    }
+    if (options.vaultOwnerToken) {
+      headers["X-Hushh-Consent"] = `Bearer ${options.vaultOwnerToken}`;
+    }
+    const response = await fetch("/api/vault/wrapper/delete", {
+      method: "POST",
+      headers,
+      body: JSON.stringify(options),
+    });
+    if (!response.ok) throw new Error("Failed to remove wrapper");
+    return { success: true };
+  }
+
   async setPrimaryVaultMethod(options: {
     userId: string;
     primaryMethod: string;
@@ -398,7 +427,10 @@ export class HushhVaultWeb extends WebPlugin {
   async isPasskeyAvailable(_options?: {
     rpId?: string;
   }): Promise<{ available: boolean; reason?: string }> {
-    return { available: false, reason: "Native passkey plugin path unavailable in web fallback" };
+    return {
+      available: false,
+      reason: "Native passkey plugin path unavailable in web fallback",
+    };
   }
 
   async registerPasskeyPrf(_options: {
@@ -454,7 +486,7 @@ export class HushhVaultWeb extends WebPlugin {
     }
     const response = await fetch(
       `/api/consent/pending?userId=${options.userId}`,
-      { headers }
+      { headers },
     );
     if (!response.ok) throw new Error("Failed to fetch pending");
     const data = await response.json();
@@ -471,7 +503,7 @@ export class HushhVaultWeb extends WebPlugin {
     }
     const response = await fetch(
       `/api/consent/active?userId=${options.userId}`,
-      { headers }
+      { headers },
     );
     if (!response.ok) throw new Error("Failed to fetch active");
     const data = await response.json();
@@ -492,7 +524,7 @@ export class HushhVaultWeb extends WebPlugin {
     const limit = options.limit || 50;
     const response = await fetch(
       `/api/consent/history?userId=${options.userId}&page=${page}&limit=${limit}`,
-      { headers }
+      { headers },
     );
     if (!response.ok) throw new Error("Failed to fetch history");
     const data = await response.json();

--- a/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
@@ -30,6 +30,7 @@ function normalizeInternalHref(
 }
 
 function profilePanelLabel(panel: string | null): string | null {
+  if (panel === "account") return "Account";
   if (panel === "my-data") return "My Data";
   if (panel === "access") return "Access & sharing";
   if (panel === "preferences") return "Preferences";
@@ -206,7 +207,7 @@ export function resolveTopShellBreadcrumb(
       align: "center",
       items: [
         { label: "Profile", href: ROUTES.PROFILE },
-        { label: "One KYC" },
+        { label: "Email" },
       ],
     };
   }
@@ -269,6 +270,20 @@ export function resolveTopShellBreadcrumb(
         { label: "Profile", href: privacyHref },
         { label: "Privacy", href: privacyHref },
         { label: "PKM Agent" },
+      ],
+    };
+  }
+
+  if (pathname === ROUTES.PROFILE_RECEIPTS) {
+    const gmailHref = profilePanelHref("gmail");
+    return {
+      backHref: gmailHref,
+      width: "profile",
+      align: "center",
+      items: [
+        { label: "Profile", href: gmailHref },
+        { label: "Gmail receipts", href: gmailHref },
+        { label: "Receipts" },
       ],
     };
   }

--- a/hushh-webapp/lib/one-kyc/workflow-state.ts
+++ b/hushh-webapp/lib/one-kyc/workflow-state.ts
@@ -33,11 +33,14 @@ export function selectedScopesForWorkflow(
   if (Array.isArray(workflow.requested_scopes) && workflow.requested_scopes.length) {
     return workflow.requested_scopes;
   }
+  if (workflow.requested_scope) {
+    return [workflow.requested_scope];
+  }
   const recommended = scopeCandidates(workflow)
     .filter((candidate) => candidate.recommended !== false)
     .map((candidate) => candidate.scope);
   if (recommended.length) return recommended;
-  return workflow.requested_scope ? [workflow.requested_scope] : [];
+  return [];
 }
 
 export function selectedScopeLabels(workflow: OneKycWorkflow): string[] {

--- a/hushh-webapp/lib/profile/pkm-profile-presentation.ts
+++ b/hushh-webapp/lib/profile/pkm-profile-presentation.ts
@@ -96,6 +96,11 @@ export type PkmProfileSummaryPresentation = {
   attentionItems: string[];
 };
 
+const CONSUMER_HIDDEN_DOMAIN_KEYS = new Set([
+  "kyc_connector",
+  "kyc_workflow",
+]);
+
 const INTERNAL_ONLY_TOP_LEVEL_SCOPE_PATHS = new Set([
   "domain_intent",
   "schema_version",
@@ -131,13 +136,64 @@ function daysSince(value: string | null | undefined): number | null {
   return Math.max(0, (Date.now() - timestamp) / (1000 * 60 * 60 * 24));
 }
 
+function parseTimestamp(value: string | null | undefined): number | null {
+  const text = String(value || "").trim();
+  if (!text) return null;
+  const timestamp = new Date(text).getTime();
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function newestTimestamp(values: Array<string | null | undefined>): string | null {
+  const newest = values
+    .map((value) => {
+      const timestamp = parseTimestamp(value);
+      return timestamp === null ? null : { value: String(value), timestamp };
+    })
+    .filter((entry): entry is { value: string; timestamp: number } => Boolean(entry))
+    .sort((left, right) => right.timestamp - left.timestamp)[0];
+  return newest?.value || null;
+}
+
+function toNonNegativeInteger(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    return Math.floor(value);
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed) && parsed >= 0) return Math.floor(parsed);
+  }
+  return null;
+}
+
+function resolveDomainDetailCount(domain: DomainSummary): number {
+  const summary = domain.summary || {};
+  const candidates = [
+    toNonNegativeInteger(domain.attributeCount),
+    toNonNegativeInteger(summary.item_count),
+    toNonNegativeInteger(summary.attribute_count),
+    toNonNegativeInteger(summary.externalizable_path_count),
+    toNonNegativeInteger(summary.path_count),
+  ];
+  return candidates.find((count): count is number => typeof count === "number" && count > 0) ?? 0;
+}
+
+export function isConsumerVisiblePkmDomain(domain: DomainSummary): boolean {
+  const key = normalizeToken(domain.key);
+  if (!key || CONSUMER_HIDDEN_DOMAIN_KEYS.has(key)) return false;
+  if (domain.summary?.internal_only === true || domain.summary?.consumer_visible === false) {
+    return false;
+  }
+  return true;
+}
+
 function inferSourceLabels(
   domain: DomainSummary,
   presentation: NaturalDomainPresentation
 ): string[] {
   const labels = new Set<string>();
-  if (presentation.sourceLabel) {
-    labels.add(presentation.sourceLabel);
+  const readableSourceLabel = presentation.sourceLabel?.trim();
+  if (readableSourceLabel && !/^pkm upgrade$/i.test(readableSourceLabel)) {
+    labels.add(readableSourceLabel);
   }
 
   const key = normalizeToken(domain.key);
@@ -171,10 +227,11 @@ function inferSourceLabels(
 
 function toStatus(
   domain: DomainSummary,
-  presentation: NaturalDomainPresentation
+  presentation: NaturalDomainPresentation,
+  detailCount: number
 ): { status: PkmDomainStatus; statusLabel: string } {
   const ageDays = daysSince(presentation.updatedAt);
-  if (domain.attributeCount <= 0) {
+  if (detailCount <= 0) {
     return { status: "missing", statusLabel: "Missing" };
   }
   if (ageDays !== null && ageDays >= 30) {
@@ -240,7 +297,18 @@ export function buildPkmDomainPresentation(params: {
   });
 
   const sourceLabels = inferSourceLabels(params.domain, presentation);
-  const { status, statusLabel } = toStatus(params.domain, presentation);
+  const detailCount = resolveDomainDetailCount(params.domain);
+  const updatedAt = newestTimestamp([
+    presentation.updatedAt,
+    typeof params.domain.summary?.last_content_at === "string"
+      ? params.domain.summary.last_content_at
+      : null,
+    typeof params.domain.summary?.updated_at === "string"
+      ? params.domain.summary.updated_at
+      : null,
+    params.domain.lastUpdated,
+  ]);
+  const { status, statusLabel } = toStatus(params.domain, { ...presentation, updatedAt }, detailCount);
   const attentionFlags: string[] = [];
   if (status === "missing") attentionFlags.push("Needs data");
   if (status === "stale") attentionFlags.push("Refresh recommended");
@@ -266,8 +334,8 @@ export function buildPkmDomainPresentation(params: {
     highlights: presentation.highlights.filter(isConsumerHighlightUseful).slice(0, 4),
     sections: presentation.sections,
     sourceLabels,
-    updatedAt: presentation.updatedAt,
-    detailCount: params.domain.attributeCount,
+    updatedAt,
+    detailCount,
     status,
     statusLabel,
     accessEntries,
@@ -360,8 +428,8 @@ export function buildPkmProfileSummaryPresentation(params: {
   return {
     metadataResolved: params.metadataResolved ?? params.metadata !== null,
     sharingResolved: params.sharingResolved ?? true,
-    totalDomains: params.metadata?.domains.length ?? 0,
-    totalAttributes: params.metadata?.totalAttributes ?? 0,
+    totalDomains: params.domains.length,
+    totalAttributes: params.domains.reduce((total, domain) => total + domain.detailCount, 0),
     totalSourceCount,
     activeGrantCount: params.activeGrants.length,
     sharedDomainCount,

--- a/hushh-webapp/lib/profile/pkm-section-preview.ts
+++ b/hushh-webapp/lib/profile/pkm-section-preview.ts
@@ -157,6 +157,73 @@ function arrayToStrings(value: unknown[]): string[] {
     .filter((item): item is string => Boolean(item));
 }
 
+function toItemsArray(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value;
+  if (isPlainObject(value) && Array.isArray(value.items)) return value.items;
+  return [];
+}
+
+function getNestedRecord(record: Record<string, unknown>, path: string): Record<string, unknown> | null {
+  let current: unknown = record;
+  for (const segment of path.split(".")) {
+    if (!isPlainObject(current)) return null;
+    current = current[segment];
+  }
+  return isPlainObject(current) ? current : null;
+}
+
+function getNestedItems(record: Record<string, unknown>, path: string): unknown[] {
+  const nested = getNestedRecord(record, path);
+  return nested ? toItemsArray(nested) : [];
+}
+
+function formatPercent(value: unknown): string | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  const normalized = value <= 1 ? value * 100 : value;
+  return `${Math.round(normalized)}%`;
+}
+
+function formatAmountValue(amount: unknown, currency: unknown): string | null {
+  if (typeof amount !== "number" || !Number.isFinite(amount)) return null;
+  const code = typeof currency === "string" && currency.trim() ? currency.trim().toUpperCase() : "USD";
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: code,
+      maximumFractionDigits: 2,
+    }).format(amount);
+  } catch {
+    return `${code} ${amount.toFixed(2)}`;
+  }
+}
+
+function receiptPreviewEntity(
+  key: string,
+  value: Record<string, unknown>,
+  fallbackTitle: string
+): PkmSectionPreviewEntity {
+  const fields = objectToFields(value);
+  const amount = formatAmountValue(value.amount, value.currency);
+  const confidence = formatPercent(value.confidence);
+  const affinity = formatPercent(value.affinity_score);
+  const fieldMap = new Map(fields.map((field) => [field.label, field]));
+  if (amount) {
+    fieldMap.set("Amount", { label: "Amount", value: amount });
+    fieldMap.delete("Currency");
+  }
+  if (confidence) fieldMap.set("Confidence", { label: "Confidence", value: confidence });
+  if (affinity) fieldMap.set("Affinity Score", { label: "Affinity Score", value: affinity });
+
+  const sections = buildEntitySections(value);
+  return {
+    key,
+    title: extractEntityTitle(value, fallbackTitle),
+    subtitle: extractEntitySubtitle(value),
+    fields: Array.from(fieldMap.values()).filter((field) => field.value !== extractEntityTitle(value, fallbackTitle)),
+    sections,
+  };
+}
+
 function objectToFields(record: Record<string, unknown>): PkmSectionPreviewField[] {
   return Object.entries(record)
     .filter(([key, value]) => !HIDDEN_CONSUMER_KEYS.has(key) && !Array.isArray(value) && !isPlainObject(value))
@@ -341,42 +408,96 @@ function buildReceiptsPreview(
   record: Record<string, unknown>
 ): PkmSectionPreviewPresentation {
   const groups: PkmSectionPreviewGroup[] = [];
-  const inferred = Array.isArray(record.inferred_preferences)
-    ? arrayToStrings(record.inferred_preferences)
-    : [];
-  if (inferred.length > 0) {
+
+  const readableSummary =
+    typeof record.readable_summary === "string"
+      ? record.readable_summary.trim()
+      : isPlainObject(record.readable_summary) && typeof record.readable_summary.text === "string"
+        ? record.readable_summary.text.trim()
+        : maybeSummary(record);
+  const readableHighlights =
+    isPlainObject(record.readable_summary) && Array.isArray(record.readable_summary.highlights)
+      ? arrayToStrings(record.readable_summary.highlights)
+      : [];
+  if (readableHighlights.length > 0) {
     groups.push({
-      kind: "chips",
-      title: "Inferred preferences",
-      items: inferred,
+      kind: readableHighlights.every((item) => item.length <= 42) ? "chips" : "list",
+      title: "Receipt highlights",
+      items: readableHighlights,
     });
   }
-  const observed = Array.isArray(record.observed_facts) ? arrayToStrings(record.observed_facts) : [];
-  if (observed.length > 0) {
+
+  const recentHighlights = getNestedItems(record, "observed_facts.recent_highlights")
+    .filter(isPlainObject)
+    .map((item, index) => receiptPreviewEntity(`recent-${index + 1}`, item, `Receipt ${index + 1}`));
+  if (recentHighlights.length > 0) {
+    groups.push({
+      kind: "entities",
+      title: "Recent purchases",
+      items: recentHighlights,
+    });
+  }
+
+  const merchantAffinity = getNestedItems(record, "observed_facts.merchant_affinity")
+    .filter(isPlainObject)
+    .map((item, index) => receiptPreviewEntity(`merchant-${index + 1}`, item, `Merchant ${index + 1}`));
+  if (merchantAffinity.length > 0) {
+    groups.push({
+      kind: "entities",
+      title: "Merchant patterns",
+      items: merchantAffinity,
+    });
+  }
+
+  const preferenceSignals = getNestedItems(record, "inferred_preferences.preference_signals")
+    .filter(isPlainObject)
+    .map((item, index) => receiptPreviewEntity(`preference-${index + 1}`, item, `Preference ${index + 1}`));
+  const legacyInferred = Array.isArray(record.inferred_preferences)
+    ? arrayToStrings(record.inferred_preferences)
+    : [];
+  if (preferenceSignals.length > 0) {
+    groups.push({
+      kind: "entities",
+      title: "Preference signals",
+      items: preferenceSignals,
+    });
+  } else if (legacyInferred.length > 0) {
+    groups.push({
+      kind: "chips",
+      title: "Preference signals",
+      items: legacyInferred,
+    });
+  }
+
+  const legacyObserved = Array.isArray(record.observed_facts) ? arrayToStrings(record.observed_facts) : [];
+  if (legacyObserved.length > 0) {
     groups.push({
       kind: "list",
       title: "Observed facts",
-      items: observed,
+      items: legacyObserved,
     });
   }
-  if (isPlainObject(record.provenance)) {
-    const provenanceFields = objectToFields(record.provenance);
-    if (provenanceFields.length > 0) {
-      groups.push({
-        kind: "fields",
-        title: "Source",
-        fields: provenanceFields,
-      });
-    }
+
+  const provenance = isPlainObject(record.provenance) ? record.provenance : {};
+  const receiptCount =
+    typeof provenance.receipt_count_used === "number" && Number.isFinite(provenance.receipt_count_used)
+      ? String(provenance.receipt_count_used)
+      : null;
+  const stats: PkmSectionPreviewStat[] = [];
+  if (receiptCount) stats.push({ label: "Receipts", value: receiptCount });
+  if (recentHighlights.length > 0) {
+    stats.push({ label: "Purchases", value: String(recentHighlights.length) });
   }
+  const preferenceCount = preferenceSignals.length || legacyInferred.length;
+  if (preferenceCount > 0) {
+    stats.push({ label: "Preferences", value: String(preferenceCount) });
+  }
+
   return {
     title,
     description,
-    summary: maybeSummary(record),
-    stats: [
-      { label: "Signals", value: String(observed.length) },
-      { label: "Preferences", value: String(inferred.length) },
-    ],
+    summary: readableSummary,
+    stats,
     groups,
   };
 }

--- a/hushh-webapp/lib/services/one-kyc-client-zk-service.ts
+++ b/hushh-webapp/lib/services/one-kyc-client-zk-service.ts
@@ -221,6 +221,20 @@ function extractApprovedValues(params: {
       "destinations",
     ],
     locations: ["locations", "places", "destinations", "favorite_locations"],
+    seat_preferences: [
+      "seat_preferences",
+      "seatPreferences",
+      "seat_preference",
+      "seatPreference",
+      "preferred_seat",
+      "preferredSeat",
+      "preferred_seats",
+      "preferredSeats",
+      "travel_preference_seat",
+      "travelPreferenceSeat",
+      "summary",
+      "observations",
+    ],
     preferences: ["preferences", "favorites", "favourites"],
   };
   const domain = scopeDomain(params.scope);

--- a/hushh-webapp/lib/services/vault-bootstrap-service.ts
+++ b/hushh-webapp/lib/services/vault-bootstrap-service.ts
@@ -107,7 +107,10 @@ async function canUseNativeBiometricVault(): Promise<boolean> {
     const result = await HushhKeychain.isBiometricAvailable();
     return result.available;
   } catch (error) {
-    console.warn("[VaultBootstrapService] Native biometric availability check failed:", error);
+    console.warn(
+      "[VaultBootstrapService] Native biometric availability check failed:",
+      error,
+    );
     return false;
   }
 }
@@ -119,13 +122,64 @@ function resolveRpId(): string {
   });
 }
 
+function resolveWebPasskeyDeviceLabel(): string {
+  if (typeof navigator === "undefined") return "Browser passkey";
+
+  const nav = navigator as Navigator & {
+    userAgentData?: {
+      brands?: Array<{ brand?: string; version?: string }>;
+      platform?: string;
+    };
+  };
+  const brands = nav.userAgentData?.brands || [];
+  const brand =
+    brands.find(
+      (item) =>
+        item.brand && !/chromium|not.a\/brand|not a brand/i.test(item.brand),
+    )?.brand || "";
+  const platform = nav.userAgentData?.platform || "";
+  const ua = navigator.userAgent || "";
+
+  let browser = brand;
+  if (!browser) {
+    if (/Edg\//.test(ua)) browser = "Edge";
+    else if (/Chrome\//.test(ua)) browser = "Chrome";
+    else if (/Safari\//.test(ua) && !/Chrome\//.test(ua)) browser = "Safari";
+    else if (/Firefox\//.test(ua)) browser = "Firefox";
+  }
+
+  let device = platform;
+  if (!device) {
+    if (/Macintosh|Mac OS X/i.test(ua)) device = "Mac";
+    else if (/iPhone/i.test(ua)) device = "iPhone";
+    else if (/iPad/i.test(ua)) device = "iPad";
+    else if (/Android/i.test(ua)) device = "Android";
+    else if (/Windows/i.test(ua)) device = "Windows";
+  }
+
+  if (browser && device) return `${browser} passkey on ${device}`;
+  if (browser) return `${browser} passkey`;
+  if (device) return `Passkey on ${device}`;
+  return "Browser passkey";
+}
+
+function resolveNativePasskeyDeviceLabel(): string {
+  const platform = Capacitor.getPlatform();
+  if (platform === "ios") return "iOS passkey";
+  if (platform === "android") return "Android passkey";
+  return "Device passkey";
+}
+
 async function canUseNativePasskeyVault(): Promise<boolean> {
   if (!Capacitor.isNativePlatform()) return false;
   try {
     const result = await HushhVault.isPasskeyAvailable({ rpId: resolveRpId() });
     return !!result.available;
   } catch (error) {
-    console.warn("[VaultBootstrapService] Native passkey availability check failed:", error);
+    console.warn(
+      "[VaultBootstrapService] Native passkey availability check failed:",
+      error,
+    );
     return false;
   }
 }
@@ -243,10 +297,14 @@ export class VaultBootstrapService {
         passkeyPrfSalt: registered.prfSalt,
         passkeyRpId: rpId,
         passkeyProvider: "native_passkey",
+        passkeyDeviceLabel: resolveNativePasskeyDeviceLabel(),
       };
     }
 
-    const prfRegistration = await registerWithPrf(params.userId, params.displayName);
+    const prfRegistration = await registerWithPrf(
+      params.userId,
+      params.displayName,
+    );
     const rpId = resolveRpId();
 
     return {
@@ -257,12 +315,13 @@ export class VaultBootstrapService {
       passkeyPrfSalt: prfRegistration.prfSalt,
       passkeyRpId: rpId,
       passkeyProvider: "webauthn_prf",
+      passkeyDeviceLabel: resolveWebPasskeyDeviceLabel(),
     };
   }
 
   static async clearGeneratedDefaultMaterial(
     userId: string,
-    mode?: GeneratedVaultKeyMode | null
+    mode?: GeneratedVaultKeyMode | null,
   ): Promise<void> {
     if (mode !== "generated_default_native_biometric") return;
 
@@ -271,12 +330,15 @@ export class VaultBootstrapService {
         key: keychainSecretKey(userId),
       });
     } catch (error) {
-      console.warn("[VaultBootstrapService] Failed to clear native biometric secret:", error);
+      console.warn(
+        "[VaultBootstrapService] Failed to clear native biometric secret:",
+        error,
+      );
     }
   }
 
   static async unlockGeneratedDefaultVault(
-    input: GeneratedVaultUnlockInput
+    input: GeneratedVaultUnlockInput,
   ): Promise<string | null> {
     const mode = normalizeKeyMode(input);
     if (!mode) return null;
@@ -295,7 +357,7 @@ export class VaultBootstrapService {
         secret.value,
         input.encryptedVaultKey,
         input.salt,
-        input.iv
+        input.iv,
       );
     }
 
@@ -313,7 +375,7 @@ export class VaultBootstrapService {
         auth.vaultKeyHex,
         input.encryptedVaultKey,
         input.salt,
-        input.iv
+        input.iv,
       );
     }
 
@@ -324,14 +386,14 @@ export class VaultBootstrapService {
     const auth = await authenticateWithPrf(
       input.userId,
       input.passkeyPrfSalt,
-      input.passkeyCredentialId ?? undefined
+      input.passkeyCredentialId ?? undefined,
     );
 
     return unlockVaultWithPassphrase(
       auth.vaultKeyHex,
       input.encryptedVaultKey,
       input.salt,
-      input.iv
+      input.iv,
     );
   }
 }

--- a/hushh-webapp/lib/services/vault-method-service.ts
+++ b/hushh-webapp/lib/services/vault-method-service.ts
@@ -21,7 +21,9 @@ export type VaultCapabilityMatrix = {
 function ensureVaultKeyHex(value: string): string {
   const normalized = value.trim().toLowerCase();
   if (!/^[0-9a-f]{64}$/.test(normalized)) {
-    throw new Error("Vault key in memory is invalid. Unlock vault again and retry.");
+    throw new Error(
+      "Vault key in memory is invalid. Unlock vault again and retry.",
+    );
   }
   return normalized;
 }
@@ -35,17 +37,19 @@ function normalizeVaultMethodError(error: unknown): Error {
     lowered.includes("rp id is not allowed")
   ) {
     return new Error(
-      "This passkey was enrolled under an older domain. Use passphrase once, then enroll passkey again for kai.hushh.ai."
+      "This passkey was enrolled under an older domain. Use passphrase once, then enroll passkey again for kai.hushh.ai.",
     );
   }
 
   if (lowered.includes("client_upgrade_required")) {
-    return new Error("Client upgrade required. Please update the app and retry.");
+    return new Error(
+      "Client upgrade required. Please update the app and retry.",
+    );
   }
 
   if (lowered.includes("passphrase wrapper missing")) {
     return new Error(
-      "Passphrase wrapper is missing for this vault. Use passphrase/recovery flow once to repair wrapper enrollment."
+      "Passphrase wrapper is missing for this vault. Use passphrase/recovery flow once to repair wrapper enrollment.",
     );
   }
 
@@ -142,10 +146,11 @@ export class VaultMethodService {
         return { method: "passphrase" };
       }
 
-      const material = await VaultBootstrapService.provisionGeneratedMethodMaterial({
-        userId: params.userId,
-        displayName: params.displayName,
-      });
+      const material =
+        await VaultBootstrapService.provisionGeneratedMethodMaterial({
+          userId: params.userId,
+          displayName: params.displayName,
+        });
 
       if (material.mode !== params.targetMethod) {
         throw new Error("Requested method is not supported on this device.");
@@ -182,7 +187,7 @@ export class VaultMethodService {
         await VaultService.setPrimaryVaultMethod(
           params.userId,
           material.mode,
-          material.passkeyCredentialId ?? "default"
+          material.passkeyCredentialId ?? "default",
         );
         trackEvent("profile_method_switch_result", {
           result: "success",
@@ -195,7 +200,7 @@ export class VaultMethodService {
         ) {
           await VaultBootstrapService.clearGeneratedDefaultMaterial(
             params.userId,
-            material.mode as GeneratedVaultKeyMode
+            material.mode as GeneratedVaultKeyMode,
           );
         }
         throw error;
@@ -250,7 +255,7 @@ export class VaultMethodService {
         await VaultService.setPrimaryVaultMethod(
           params.userId,
           "passphrase",
-          "default"
+          "default",
         );
         return { primaryMethod: "passphrase", passphraseUpdated: true };
       }
@@ -258,6 +263,77 @@ export class VaultMethodService {
       return {
         primaryMethod: state.primaryMethod,
         passphraseUpdated: true,
+      };
+    } catch (error) {
+      throw normalizeVaultMethodError(error);
+    }
+  }
+
+  static async removeMethod(params: {
+    userId: string;
+    currentVaultKey: string;
+    vaultOwnerToken: string;
+    method: VaultMethod;
+    wrapperId?: string;
+    fallbackPrimaryMethod?: VaultMethod;
+    fallbackPrimaryWrapperId?: string;
+  }): Promise<{ primaryMethod: VaultMethod }> {
+    try {
+      if (params.method === "passphrase") {
+        throw new Error("Passphrase unlock cannot be removed.");
+      }
+
+      const canonicalVaultKey = ensureVaultKeyHex(params.currentVaultKey);
+      const state = await VaultService.getVaultState(params.userId);
+      const vaultKeyHash = await VaultService.hashVaultKey(canonicalVaultKey);
+
+      if (state.vaultKeyHash && state.vaultKeyHash !== vaultKeyHash) {
+        throw new Error("Vault key mismatch detected. Unlock vault again.");
+      }
+
+      const wrapperId = params.wrapperId ?? "default";
+      const targetWrapper = state.wrappers.find(
+        (wrapper) =>
+          wrapper.method === params.method &&
+          (wrapper.wrapperId ?? "default") === wrapperId,
+      );
+      if (!targetWrapper) {
+        throw new Error("This unlock method is no longer enrolled.");
+      }
+
+      const fallbackPrimaryMethod =
+        params.fallbackPrimaryMethod ?? "passphrase";
+      const fallbackPrimaryWrapperId =
+        params.fallbackPrimaryWrapperId ?? "default";
+      const fallbackWrapper = state.wrappers.find(
+        (wrapper) =>
+          wrapper.method === fallbackPrimaryMethod &&
+          (wrapper.wrapperId ?? "default") === fallbackPrimaryWrapperId,
+      );
+      if (!fallbackWrapper) {
+        throw new Error(
+          "Passphrase unlock must be repaired before removing this method.",
+        );
+      }
+
+      await VaultService.deleteVaultWrapper({
+        userId: params.userId,
+        vaultKeyHash,
+        method: params.method,
+        vaultOwnerToken: params.vaultOwnerToken,
+        wrapperId,
+        fallbackPrimaryMethod,
+        fallbackPrimaryWrapperId,
+      });
+
+      const removingPrimary =
+        state.primaryMethod === params.method &&
+        (state.primaryWrapperId ?? "default") === wrapperId;
+
+      return {
+        primaryMethod: removingPrimary
+          ? fallbackPrimaryMethod
+          : state.primaryMethod,
       };
     } catch (error) {
       throw normalizeVaultMethodError(error);

--- a/hushh-webapp/lib/services/vault-service.ts
+++ b/hushh-webapp/lib/services/vault-service.ts
@@ -117,7 +117,7 @@ export class VaultService {
         JSON.stringify({
           exists,
           cachedAt: Date.now(),
-        })
+        }),
       );
     } catch {
       // Ignore session persistence failures.
@@ -126,13 +126,15 @@ export class VaultService {
 
   private static readBootstrapVaultCheck(userId: string): boolean | null {
     const cached = CacheService.getInstance().get<{ hasVault?: unknown }>(
-      CACHE_KEYS.PRE_VAULT_BOOTSTRAP(userId)
+      CACHE_KEYS.PRE_VAULT_BOOTSTRAP(userId),
     );
     if (!cached) return null;
     return typeof cached.hasVault === "boolean" ? cached.hasVault : null;
   }
 
-  private static async resolveVaultCheckFallback(userId: string): Promise<boolean | null> {
+  private static async resolveVaultCheckFallback(
+    userId: string,
+  ): Promise<boolean | null> {
     const cached = this.readBootstrapVaultCheck(userId);
     if (cached !== null) {
       return cached;
@@ -152,7 +154,11 @@ export class VaultService {
     const trimmed = value.trim();
     if (!trimmed) return undefined;
     const normalized = trimmed.toLowerCase();
-    if (normalized === "null" || normalized === "undefined" || normalized === "none") {
+    if (
+      normalized === "null" ||
+      normalized === "undefined" ||
+      normalized === "none"
+    ) {
       return undefined;
     }
     return trimmed;
@@ -205,7 +211,9 @@ export class VaultService {
     return "passphrase";
   }
 
-  private static normalizeWrapper(wrapper: Partial<VaultWrapper>): VaultWrapper {
+  private static normalizeWrapper(
+    wrapper: Partial<VaultWrapper>,
+  ): VaultWrapper {
     const maybeWrapper = wrapper as Partial<VaultWrapper> & {
       encrypted_vault_key?: string;
       wrapper_id?: string;
@@ -219,32 +227,36 @@ export class VaultService {
     const passkeyLastUsedAtRaw =
       wrapper.passkeyLastUsedAt ?? maybeWrapper.passkey_last_used_at;
     const passkeyLastUsedAt =
-      typeof passkeyLastUsedAtRaw === "number" ? passkeyLastUsedAtRaw : undefined;
+      typeof passkeyLastUsedAtRaw === "number"
+        ? passkeyLastUsedAtRaw
+        : undefined;
     return {
       method: this.normalizeMethod(wrapper.method),
       wrapperId:
-        this.normalizeNullableString(wrapper.wrapperId ?? maybeWrapper.wrapper_id) ??
-        "default",
+        this.normalizeNullableString(
+          wrapper.wrapperId ?? maybeWrapper.wrapper_id,
+        ) ?? "default",
       encryptedVaultKey:
         this.normalizeNullableString(
-          wrapper.encryptedVaultKey ?? maybeWrapper.encrypted_vault_key
+          wrapper.encryptedVaultKey ?? maybeWrapper.encrypted_vault_key,
         ) ?? "",
-      salt: this.normalizeNullableString(wrapper.salt ?? maybeWrapper.salt) ?? "",
+      salt:
+        this.normalizeNullableString(wrapper.salt ?? maybeWrapper.salt) ?? "",
       iv: this.normalizeNullableString(wrapper.iv ?? maybeWrapper.iv) ?? "",
       passkeyCredentialId: this.normalizeNullableString(
-        wrapper.passkeyCredentialId ?? maybeWrapper.passkey_credential_id
+        wrapper.passkeyCredentialId ?? maybeWrapper.passkey_credential_id,
       ),
       passkeyPrfSalt: this.normalizeNullableString(
-        wrapper.passkeyPrfSalt ?? maybeWrapper.passkey_prf_salt
+        wrapper.passkeyPrfSalt ?? maybeWrapper.passkey_prf_salt,
       ),
       passkeyRpId: this.normalizeNullableString(
-        wrapper.passkeyRpId ?? maybeWrapper.passkey_rp_id
+        wrapper.passkeyRpId ?? maybeWrapper.passkey_rp_id,
       ),
       passkeyProvider: this.normalizeNullableString(
-        wrapper.passkeyProvider ?? maybeWrapper.passkey_provider
+        wrapper.passkeyProvider ?? maybeWrapper.passkey_provider,
       ),
       passkeyDeviceLabel: this.normalizeNullableString(
-        wrapper.passkeyDeviceLabel ?? maybeWrapper.passkey_device_label
+        wrapper.passkeyDeviceLabel ?? maybeWrapper.passkey_device_label,
       ),
       passkeyLastUsedAt,
     };
@@ -296,7 +308,9 @@ export class VaultService {
       try {
         const iterated = Array.from(input as Iterable<unknown>);
         if (iterated.length) {
-          return iterated.filter((value) => value && typeof value === "object") as Partial<VaultWrapper>[];
+          return iterated.filter(
+            (value) => value && typeof value === "object",
+          ) as Partial<VaultWrapper>[];
         }
       } catch {
         // continue to object heuristics
@@ -341,7 +355,7 @@ export class VaultService {
 
     // Map/object fallback: { passphrase: {...}, generated_default_web_prf: {...} }.
     const objectValues = Object.values(record).filter(
-      (value) => value && typeof value === "object"
+      (value) => value && typeof value === "object",
     ) as Partial<VaultWrapper>[];
 
     return objectValues;
@@ -349,15 +363,20 @@ export class VaultService {
 
   private static normalizeVaultState(vault: Partial<VaultState>): VaultState {
     const wrappers = this.extractWrappers(vault.wrappers).map((wrapper) =>
-      this.normalizeWrapper(wrapper)
+      this.normalizeWrapper(wrapper),
     );
     const normalizedWrappers = wrappers.filter(
-      (wrapper) => !!wrapper.encryptedVaultKey && !!wrapper.salt && !!wrapper.iv
+      (wrapper) =>
+        !!wrapper.encryptedVaultKey && !!wrapper.salt && !!wrapper.iv,
     );
-    if (!normalizedWrappers.some((wrapper) => wrapper.method === "passphrase")) {
-      const methods = Array.from(new Set(normalizedWrappers.map((wrapper) => wrapper.method)));
+    if (
+      !normalizedWrappers.some((wrapper) => wrapper.method === "passphrase")
+    ) {
+      const methods = Array.from(
+        new Set(normalizedWrappers.map((wrapper) => wrapper.method)),
+      );
       throw new Error(
-        `Vault state is invalid: passphrase wrapper missing (wrappers=${normalizedWrappers.length}, methods=${methods.join(",") || "none"}).`
+        `Vault state is invalid: passphrase wrapper missing (wrappers=${normalizedWrappers.length}, methods=${methods.join(",") || "none"}).`,
       );
     }
 
@@ -376,7 +395,7 @@ export class VaultService {
 
   private static findWrapperByMethod(
     state: VaultState,
-    method: VaultMethod
+    method: VaultMethod,
   ): VaultWrapper | null {
     return state.wrappers.find((wrapper) => wrapper.method === method) ?? null;
   }
@@ -390,7 +409,7 @@ export class VaultService {
 
   private static async buildApiError(
     response: Response,
-    fallbackMessage: string
+    fallbackMessage: string,
   ): Promise<Error> {
     let message = fallbackMessage;
     let code: string | undefined;
@@ -405,16 +424,18 @@ export class VaultService {
               ? (parsed.detail as Record<string, unknown>)
               : null;
           const directCode = this.normalizeNullableString(
-            typeof parsed.code === "string" ? parsed.code : undefined
+            typeof parsed.code === "string" ? parsed.code : undefined,
           );
           const directError = this.normalizeNullableString(
-            typeof parsed.error === "string" ? parsed.error : undefined
+            typeof parsed.error === "string" ? parsed.error : undefined,
           );
           const detailCode = this.normalizeNullableString(
-            detail && typeof detail.code === "string" ? detail.code : undefined
+            detail && typeof detail.code === "string" ? detail.code : undefined,
           );
           const detailError = this.normalizeNullableString(
-            detail && typeof detail.error === "string" ? detail.error : undefined
+            detail && typeof detail.error === "string"
+              ? detail.error
+              : undefined,
           );
 
           code = detailCode || directCode || undefined;
@@ -436,39 +457,44 @@ export class VaultService {
     options?: {
       wrapperId?: string;
       preferCurrentRpId?: boolean;
-    }
+    },
   ): VaultWrapper | null {
     const all = state.wrappers.filter((wrapper) => wrapper.method === method);
     if (!all.length) return null;
 
-    const shouldPreferRp =
-      this.isPasskeyMethod(method) ? (options?.preferCurrentRpId ?? true) : false;
+    const shouldPreferRp = this.isPasskeyMethod(method)
+      ? (options?.preferCurrentRpId ?? true)
+      : false;
     const rpId = shouldPreferRp ? this.getCurrentRpId() : null;
 
     const requestedWrapperId = this.normalizeNullableString(options?.wrapperId);
     if (requestedWrapperId) {
       const requested =
-        all.find((wrapper) => (wrapper.wrapperId ?? "default") === requestedWrapperId) ??
-        null;
+        all.find(
+          (wrapper) => (wrapper.wrapperId ?? "default") === requestedWrapperId,
+        ) ?? null;
       if (!requested) return null;
       if (!shouldPreferRp || !rpId) return requested;
       const wrapperRpId = this.normalizeNullableString(requested.passkeyRpId);
       if (!wrapperRpId || wrapperRpId === rpId) return requested;
       return (
-        all.find((wrapper) => this.normalizeNullableString(wrapper.passkeyRpId) === rpId) ?? null
+        all.find(
+          (wrapper) =>
+            this.normalizeNullableString(wrapper.passkeyRpId) === rpId,
+        ) ?? null
       );
     }
 
     if (shouldPreferRp && rpId) {
       const rpMatch = all.find(
-        (wrapper) => this.normalizeNullableString(wrapper.passkeyRpId) === rpId
+        (wrapper) => this.normalizeNullableString(wrapper.passkeyRpId) === rpId,
       );
       if (rpMatch) return rpMatch;
 
       // If wrappers are explicitly pinned to other RP IDs, fail closed and fall
       // back to passphrase/recovery rather than triggering cross-device QR UX.
       const hasExplicitRpIds = all.some(
-        (wrapper) => !!this.normalizeNullableString(wrapper.passkeyRpId)
+        (wrapper) => !!this.normalizeNullableString(wrapper.passkeyRpId),
       );
       if (hasExplicitRpIds) {
         return null;
@@ -498,7 +524,7 @@ export class VaultService {
     }
     const digest = await crypto.subtle.digest(
       "SHA-256",
-      new TextEncoder().encode(normalized)
+      new TextEncoder().encode(normalized),
     );
     return Array.from(new Uint8Array(digest))
       .map((byte) => byte.toString(16).padStart(2, "0"))
@@ -517,7 +543,7 @@ export class VaultService {
       params.secretMaterial,
       wrapper.encryptedVaultKey,
       wrapper.salt,
-      wrapper.iv
+      wrapper.iv,
     );
     if (!decrypted) return null;
 
@@ -527,7 +553,7 @@ export class VaultService {
 
   static async assertVaultKeyMatchesState(
     state: VaultState,
-    vaultKeyHex: string
+    vaultKeyHex: string,
   ): Promise<void> {
     const normalizedKey = this.normalizeVaultKeyHex(vaultKeyHex);
     if (!normalizedKey) {
@@ -562,10 +588,13 @@ export class VaultService {
     const hasPrimaryWrapper = state.wrappers.some(
       (wrapper) =>
         wrapper.method === state.primaryMethod &&
-        (wrapper.wrapperId ?? "default") === (state.primaryWrapperId ?? "default")
+        (wrapper.wrapperId ?? "default") ===
+          (state.primaryWrapperId ?? "default"),
     );
     if (!hasPrimaryWrapper) {
-      throw new Error("primaryMethod + primaryWrapperId must reference an enrolled wrapper.");
+      throw new Error(
+        "primaryMethod + primaryWrapperId must reference an enrolled wrapper.",
+      );
     }
   }
 
@@ -637,7 +666,7 @@ export class VaultService {
   static async getOrIssueVaultOwnerToken(
     userId: string,
     currentToken: string | null = null,
-    currentExpiresAt: number | null = null
+    currentExpiresAt: number | null = null,
   ): Promise<{
     token: string;
     expiresAt: number;
@@ -651,7 +680,7 @@ export class VaultService {
         console.log(
           "[VaultService] Reusing valid VAULT_OWNER token (expires in",
           Math.round((currentExpiresAt - now) / 1000 / 60),
-          "minutes)"
+          "minutes)",
         );
         return {
           token: currentToken,
@@ -660,7 +689,7 @@ export class VaultService {
         };
       }
       console.log(
-        "[VaultService] Cached token expired or expiring soon, issuing new one"
+        "[VaultService] Cached token expired or expiring soon, issuing new one",
       );
     }
 
@@ -671,7 +700,7 @@ export class VaultService {
     if (this.shouldDebugVaultOwner()) {
       console.log(
         "[VaultService] VAULT_OWNER debug snapshot (before token acquisition):",
-        await this.debugAuthSnapshot()
+        await this.debugAuthSnapshot(),
       );
     }
 
@@ -687,7 +716,9 @@ export class VaultService {
       if (fallback) return fallback;
 
       // 3) Native plugin fallback
-      const hushh = await HushhAuth.getIdToken().catch(() => ({ idToken: null }));
+      const hushh = await HushhAuth.getIdToken().catch(() => ({
+        idToken: null,
+      }));
       if (hushh?.idToken) return hushh.idToken;
 
       return undefined;
@@ -707,9 +738,7 @@ export class VaultService {
       const hint = snapshot
         ? ` Debug: ${JSON.stringify(snapshot)}`
         : " Enable debug by setting localStorage.debug_vault_owner=true";
-      throw new Error(
-        `No Firebase ID token available (native).${hint}`
-      );
+      throw new Error(`No Firebase ID token available (native).${hint}`);
     }
 
     return this.issueVaultOwnerToken(userId, firebaseIdToken);
@@ -726,7 +755,7 @@ export class VaultService {
    */
   static async issueVaultOwnerToken(
     userId: string,
-    firebaseIdToken: string
+    firebaseIdToken: string,
   ): Promise<{
     token: string;
     expiresAt: number;
@@ -793,7 +822,7 @@ export class VaultService {
           const authToken = await this.getFirebaseToken();
           console.log(
             "🔐 [VaultService] Got auth token:",
-            authToken ? "yes" : "no"
+            authToken ? "yes" : "no",
           );
           const result = await HushhVault.hasVault({ userId, authToken });
           console.log("🔐 [VaultService] hasVault result:", result);
@@ -821,17 +850,20 @@ export class VaultService {
           if (!response.ok) {
             const payload = await response.json().catch(() => undefined);
             const message =
-              typeof (payload as { error?: unknown } | undefined)?.error === "string"
+              typeof (payload as { error?: unknown } | undefined)?.error ===
+              "string"
                 ? (payload as { error: string }).error
                 : `Vault check failed: ${response.status}`;
             const error = Object.assign(new Error(message), {
               status: response.status,
               code:
-                typeof (payload as { code?: unknown } | undefined)?.code === "string"
+                typeof (payload as { code?: unknown } | undefined)?.code ===
+                "string"
                   ? (payload as { code: string }).code
                   : undefined,
               hint:
-                typeof (payload as { hint?: unknown } | undefined)?.hint === "string"
+                typeof (payload as { hint?: unknown } | undefined)?.hint ===
+                "string"
                   ? (payload as { hint: string }).hint
                   : undefined,
             });
@@ -846,7 +878,7 @@ export class VaultService {
             throw error;
           }
           console.warn(
-            "⚠️ [VaultService] checkVault served via bootstrap-state fallback"
+            "⚠️ [VaultService] checkVault served via bootstrap-state fallback",
           );
           hasVault = fallbackHasVault;
         }
@@ -907,21 +939,26 @@ export class VaultService {
             console.warn(
               "[VaultService] Native getVault returned wrapper payload with zero extractable wrappers",
               {
-                wrapperType: wrapperProbe == null ? "nullish" : typeof wrapperProbe,
+                wrapperType:
+                  wrapperProbe == null ? "nullish" : typeof wrapperProbe,
                 wrapperShape,
                 hasVault: hasVaultCheckResult,
-              }
+              },
             );
           }
           try {
-            const normalized = this.normalizeVaultState(result as Partial<VaultState>);
+            const normalized = this.normalizeVaultState(
+              result as Partial<VaultState>,
+            );
             this.setCachedVaultState(userId, normalized);
             return normalized;
           } catch (error) {
             const message =
-              error instanceof Error ? error.message : "Vault state normalization failed.";
+              error instanceof Error
+                ? error.message
+                : "Vault state normalization failed.";
             throw new Error(
-              `${message} [platform=${Capacitor.getPlatform()} source=native wrapperShape=${wrapperShape} extracted=${extractedCount} hasVault=${hasVaultCheckResult}]`
+              `${message} [platform=${Capacitor.getPlatform()} source=native wrapperShape=${wrapperShape} extracted=${extractedCount} hasVault=${hasVaultCheckResult}]`,
             );
           }
         } catch (error) {
@@ -941,12 +978,14 @@ export class VaultService {
       if (!response.ok) {
         const errorPayload = (await response
           .json()
-          .catch(async () => ({ error: await response.text().catch(() => "") }))) as {
+          .catch(async () => ({
+            error: await response.text().catch(() => ""),
+          }))) as {
           error?: string;
           message?: string;
         };
         throw new Error(
-          errorPayload.error || errorPayload.message || "Failed to get vault"
+          errorPayload.error || errorPayload.message || "Failed to get vault",
         );
       }
       const payload = (await response.json()) as Partial<VaultState>;
@@ -960,10 +999,13 @@ export class VaultService {
         } catch {
           hasVaultCheckResult = "error";
         }
-        console.warn("[VaultService] Web getVault payload has zero extractable wrappers", {
-          wrapperShape,
-          hasVault: hasVaultCheckResult,
-        });
+        console.warn(
+          "[VaultService] Web getVault payload has zero extractable wrappers",
+          {
+            wrapperShape,
+            hasVault: hasVaultCheckResult,
+          },
+        );
       }
       try {
         const normalized = this.normalizeVaultState(payload);
@@ -972,9 +1014,11 @@ export class VaultService {
         return normalized;
       } catch (error) {
         const message =
-          error instanceof Error ? error.message : "Vault state normalization failed.";
+          error instanceof Error
+            ? error.message
+            : "Vault state normalization failed.";
         throw new Error(
-          `${message} [platform=web source=api wrapperShape=${wrapperShape} extracted=${extractedCount} hasVault=${hasVaultCheckResult}]`
+          `${message} [platform=web source=api wrapperShape=${wrapperShape} extracted=${extractedCount} hasVault=${hasVaultCheckResult}]`,
         );
       }
     })();
@@ -997,7 +1041,10 @@ export class VaultService {
   /**
    * Create or replace full vault state (breaking contract v5.0).
    */
-  static async setupVaultState(userId: string, vaultState: VaultState): Promise<void> {
+  static async setupVaultState(
+    userId: string,
+    vaultState: VaultState,
+  ): Promise<void> {
     const normalized = this.normalizeVaultState(vaultState);
     this.assertVaultStateForSetup(normalized);
 
@@ -1031,7 +1078,8 @@ export class VaultService {
     const authToken = await this.getFirebaseToken();
     const headers: HeadersInit = {
       "Content-Type": "application/json",
-      "x-hushh-client-version": process.env.NEXT_PUBLIC_CLIENT_VERSION || "2.0.0",
+      "x-hushh-client-version":
+        process.env.NEXT_PUBLIC_CLIENT_VERSION || "2.0.0",
     };
     if (authToken) {
       headers.Authorization = `Bearer ${authToken}`;
@@ -1096,7 +1144,8 @@ export class VaultService {
     const authToken = await this.getFirebaseToken();
     const headers: HeadersInit = {
       "Content-Type": "application/json",
-      "x-hushh-client-version": process.env.NEXT_PUBLIC_CLIENT_VERSION || "2.0.0",
+      "x-hushh-client-version":
+        process.env.NEXT_PUBLIC_CLIENT_VERSION || "2.0.0",
     };
     if (authToken) headers.Authorization = `Bearer ${authToken}`;
 
@@ -1120,7 +1169,83 @@ export class VaultService {
       }),
     });
     if (!response.ok) {
-      throw await this.buildApiError(response, "Failed to upsert vault wrapper.");
+      throw await this.buildApiError(
+        response,
+        "Failed to upsert vault wrapper.",
+      );
+    }
+    this.invalidateVaultStateCache(params.userId);
+  }
+
+  static async deleteVaultWrapper(params: {
+    userId: string;
+    vaultKeyHash: string;
+    method: VaultMethod;
+    vaultOwnerToken: string;
+    wrapperId?: string;
+    fallbackPrimaryMethod?: VaultMethod;
+    fallbackPrimaryWrapperId?: string;
+  }): Promise<void> {
+    const normalizedMethod = this.normalizeMethod(params.method);
+    const normalizedWrapperId =
+      this.normalizeNullableString(params.wrapperId) ?? "default";
+    const fallbackPrimaryMethod = this.normalizeMethod(
+      params.fallbackPrimaryMethod ?? "passphrase",
+    );
+    const fallbackPrimaryWrapperId =
+      this.normalizeNullableString(params.fallbackPrimaryWrapperId) ??
+      "default";
+
+    if (normalizedMethod === "passphrase") {
+      throw new Error("Passphrase unlock cannot be removed.");
+    }
+
+    if (Capacitor.isNativePlatform()) {
+      const authToken = await this.getFirebaseToken();
+      const result = await HushhVault.deleteVaultWrapper({
+        userId: params.userId,
+        vaultKeyHash: params.vaultKeyHash,
+        method: normalizedMethod,
+        wrapperId: normalizedWrapperId,
+        fallbackPrimaryMethod,
+        fallbackPrimaryWrapperId,
+        authToken,
+        vaultOwnerToken: params.vaultOwnerToken,
+      });
+      if (!result?.success) {
+        throw new Error("Native vault wrapper removal failed.");
+      }
+      this.invalidateVaultStateCache(params.userId);
+      return;
+    }
+
+    const url = this.getApiUrl("/api/vault/wrapper/delete");
+    const authToken = await this.getFirebaseToken();
+    const headers: HeadersInit = {
+      "Content-Type": "application/json",
+      "x-hushh-client-version":
+        process.env.NEXT_PUBLIC_CLIENT_VERSION || "2.0.0",
+    };
+    if (authToken) headers.Authorization = `Bearer ${authToken}`;
+    headers["X-Hushh-Consent"] = `Bearer ${params.vaultOwnerToken}`;
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        userId: params.userId,
+        vaultKeyHash: params.vaultKeyHash,
+        method: normalizedMethod,
+        wrapperId: normalizedWrapperId,
+        fallbackPrimaryMethod,
+        fallbackPrimaryWrapperId,
+      }),
+    });
+    if (!response.ok) {
+      throw await this.buildApiError(
+        response,
+        "Failed to remove vault wrapper.",
+      );
     }
     this.invalidateVaultStateCache(params.userId);
   }
@@ -1128,7 +1253,7 @@ export class VaultService {
   static async setPrimaryVaultMethod(
     userId: string,
     primaryMethod: VaultMethod,
-    primaryWrapperId?: string
+    primaryWrapperId?: string,
   ): Promise<void> {
     const normalizedMethod = this.normalizeMethod(primaryMethod);
     const normalizedWrapperId =
@@ -1153,7 +1278,8 @@ export class VaultService {
     const authToken = await this.getFirebaseToken();
     const headers: HeadersInit = {
       "Content-Type": "application/json",
-      "x-hushh-client-version": process.env.NEXT_PUBLIC_CLIENT_VERSION || "2.0.0",
+      "x-hushh-client-version":
+        process.env.NEXT_PUBLIC_CLIENT_VERSION || "2.0.0",
     };
     if (authToken) headers.Authorization = `Bearer ${authToken}`;
 
@@ -1169,7 +1295,7 @@ export class VaultService {
     if (!response.ok) {
       throw await this.buildApiError(
         response,
-        "Failed to set primary vault method."
+        "Failed to set primary vault method.",
       );
     }
     this.invalidateVaultStateCache(userId);
@@ -1194,7 +1320,7 @@ export class VaultService {
     passphrase: string,
     encryptedKey: string,
     salt: string,
-    iv: string
+    iv: string,
   ): Promise<string> {
     // Always use the web-crypto unlock path for deterministic cross-platform
     // vault-key decoding (native plugin decrypt is UTF-8 text-oriented).
@@ -1211,7 +1337,7 @@ export class VaultService {
     key: string,
     encryptedKey: string,
     salt: string,
-    iv: string
+    iv: string,
   ): Promise<string> {
     const decrypted = await webUnlockRecall(key, encryptedKey, salt, iv);
     const normalized = this.normalizeVaultKeyHex(decrypted);
@@ -1223,9 +1349,8 @@ export class VaultService {
   }
 
   static async canUseGeneratedDefaultVault(): Promise<GeneratedVaultSupport> {
-    const { VaultBootstrapService } = await import(
-      "@/lib/services/vault-bootstrap-service"
-    );
+    const { VaultBootstrapService } =
+      await import("@/lib/services/vault-bootstrap-service");
     return VaultBootstrapService.canUseGeneratedDefaultVault();
   }
 
@@ -1233,19 +1358,18 @@ export class VaultService {
     userId: string;
     displayName: string;
   }): Promise<GeneratedVaultProvisionResult> {
-    const { VaultBootstrapService } = await import(
-      "@/lib/services/vault-bootstrap-service"
-    );
+    const { VaultBootstrapService } =
+      await import("@/lib/services/vault-bootstrap-service");
     return VaultBootstrapService.provisionGeneratedDefaultVault(params);
   }
 
   static async unlockGeneratedDefaultVault(
-    input: GeneratedVaultUnlockInput
+    input: GeneratedVaultUnlockInput,
   ): Promise<string | null> {
-    const { VaultBootstrapService } = await import(
-      "@/lib/services/vault-bootstrap-service"
-    );
-    const decrypted = await VaultBootstrapService.unlockGeneratedDefaultVault(input);
+    const { VaultBootstrapService } =
+      await import("@/lib/services/vault-bootstrap-service");
+    const decrypted =
+      await VaultBootstrapService.unlockGeneratedDefaultVault(input);
     if (!decrypted) return null;
     const normalized = this.normalizeVaultKeyHex(decrypted);
     if (!normalized) {

--- a/hushh-webapp/scripts/testing/verify-signed-in-routes.mjs
+++ b/hushh-webapp/scripts/testing/verify-signed-in-routes.mjs
@@ -559,7 +559,7 @@ async function navigateViaShell(page, spec) {
     case "/one/kyc":
       await clickBottomNav(page, "Profile");
       await waitForRouteBeacon(page, ["/profile"]);
-      await page.getByRole("button", { name: /one kyc|kyc agent/i }).click();
+      await page.getByRole("button", { name: /^email\b|one kyc|kyc agent/i }).click();
       return true;
     case "/consents":
       await clickBottomNav(page, "Profile");
@@ -666,7 +666,8 @@ function collectPageIssues(page) {
     if (failureText.includes("ERR_ABORTED")) return;
     if (
       failureText.includes("ERR_BLOCKED_BY_ORB") &&
-      url.startsWith("https://www.googletagmanager.com/")
+      (url.startsWith("https://www.googletagmanager.com/") ||
+        url.startsWith("https://lh3.googleusercontent.com/"))
     ) {
       return;
     }


### PR DESCRIPTION
## Summary
- revamps the Agent Kai / One email KYC disclosure flow with dynamic scope handling and PKM-profile presentation updates
- adds vault wrapper delete support across web, Next proxy, backend, iOS, and Android with Firebase identity plus explicit VAULT_OWNER unlock proof
- hardens vault wrapper deletion with transactional primary-wrapper mutation and rollback-by-transaction semantics
- refreshes generated Kai voice action gateway artifacts after the One KYC contract change

## Scope note
This is the Train 0 landing PR for the current agent-kai-revamp batch. It intentionally combines Agent Kai / One KYC, vault-wrapper deletion, PKM profile display, and generated voice contracts so later backend/vault/PKM PR trains can rebase against one canonical surface.

## Verification
- python3 -m py_compile consent-protocol/api/routes/db_proxy.py consent-protocol/hushh_mcp/services/vault_keys_service.py
- cd consent-protocol && python3 -m pytest tests/test_db_proxy_vault_owner_token.py tests/test_vault_keys_metadata.py -q
- cd consent-protocol && python3 -m pytest tests/services/test_one_email_kyc_service.py tests/test_developer_api_routes.py tests/test_mcp_email_uid_resolution.py tests/test_vault_keys_metadata.py tests/test_db_proxy_vault_owner_token.py -q
- cd hushh-webapp && npm run test -- __tests__/api/vault-wrapper-delete-proxy.test.ts __tests__/services/vault-method-service.test.ts
- cd hushh-webapp && npm run test -- __tests__/components/pkm-data-manager.test.tsx __tests__/services/pkm-section-preview.test.ts __tests__/services/pkm-profile-presentation.test.ts
- cd hushh-webapp && npm run typecheck
- cd hushh-webapp && npm run verify:voice-gateway
- cd hushh-webapp && npm run verify:capacitor:static
- ./bin/hushh docs verify
- NPM_CONFIG_CACHE=/tmp/hushh-npm-cache-prepr ./bin/hushh codex pre-pr

Local pre-PR mirror passed. Open Dependabot alerts remain repository-wide and non-blocking in this lane.