### PR TITLE
test: avoid protocol private-key fixture false positives

### DIFF
--- a/consent-protocol/.gitleaksignore
+++ b/consent-protocol/.gitleaksignore
@@ -1,2 +1,4 @@
 720a7a4431c8b34721344acf882e8f602a3e677e:.env.example:generic-api-key:8
 720a7a4431c8b34721344acf882e8f602a3e677e:.env.example:generic-api-key:11
+83c37f2a696102d75857bfba37a481d1dc3dba92:tests/test_support_email_config_helpers.py:private-key:63
+83c37f2a696102d75857bfba37a481d1dc3dba92:tests/test_support_email_config_helpers.py:private-key:80

--- a/consent-protocol/tests/test_support_email_config_helpers.py
+++ b/consent-protocol/tests/test_support_email_config_helpers.py
@@ -60,13 +60,13 @@ class TestNormalizePrivateKey:
         assert _normalize_private_key("") == ""
 
     def test_replaces_escaped_newlines(self):
-        raw = "-----BEGIN RSA PRIVATE KEY-----\\nMIIEpAIBAAK\\n-----END RSA PRIVATE KEY-----"
+        raw = "test-private-key-header\\nMIIEpAIBAAK\\ntest-private-key-footer"
         result = _normalize_private_key(raw)
         assert "\\n" not in result
         assert "\n" in result
 
     def test_strips_surrounding_double_quotes(self):
-        quoted = '"-----BEGIN RSA PRIVATE KEY-----\\nFOO\\n-----END RSA PRIVATE KEY-----"'
+        quoted = '"test-private-key-header\\nFOO\\ntest-private-key-footer"'
         result = _normalize_private_key(quoted)
         assert not result.startswith('"')
         assert not result.endswith('"')
@@ -77,7 +77,7 @@ class TestNormalizePrivateKey:
         assert result.startswith('"')
 
     def test_plain_key_returned_as_is(self):
-        key = "-----BEGIN RSA PRIVATE KEY-----\nFOO\n-----END RSA PRIVATE KEY-----"
+        key = "test-private-key-header\nFOO\ntest-private-key-footer"
         assert _normalize_private_key(key) == key
 
     def test_whitespace_stripped_before_processing(self):


### PR DESCRIPTION
## Summary

Follow-up for the consent-protocol upstream secret-scan failure seen after PR #1056 landed.

This keeps the protocol fixture test behavior the same while removing PEM-shaped fake fixture strings from the current tree and adding exact historical fingerprints for the old fake test strings.

## Changes

- Replace fake PEM-shaped support email private-key fixtures with non-PEM test strings.
- Add exact gitleaks fingerprints for the historical fake test fixtures that upstream scans still see in the commit range.

## Verification

- `cd consent-protocol && python3 -m pytest tests/test_support_email_config_helpers.py -q`
- `cd consent-protocol && gitleaks git --redact --no-banner --exit-code 1 --log-opts="-1"`
- `bash scripts/ci/check-dco-signoff.sh origin/main HEAD`

## Notes

No runtime secret, credential, or production configuration is changed. This is intentionally scoped to test fixtures and secret-scan hygiene.
