### PR TITLE
fix(developer): deduplicate _STATIC_REQUESTABLE_SCOPES and add unit tests

### DIFF
--- a/consent-protocol/api/routes/developer.py
+++ b/consent-protocol/api/routes/developer.py
@@ -36,7 +36,7 @@ router = APIRouter()
 developer_api_router = APIRouter(prefix="/api/v1", tags=["Developer API"])
 portal_router = APIRouter(prefix="/api/developer", tags=["Developer Portal"])
 
-_STATIC_REQUESTABLE_SCOPES = ("pkm.read", "pkm.write", "pkm.read", "pkm.write")
+_STATIC_REQUESTABLE_SCOPES: frozenset[str] = frozenset({"pkm.read", "pkm.write"})
 _MIN_PUBLIC_EXPIRY_HOURS = 24
 _MAX_PUBLIC_EXPIRY_HOURS = 24 * 90
 _MIN_PUBLIC_APPROVAL_TIMEOUT_MINUTES = 5

--- a/consent-protocol/tests/test_developer_api_routes.py
+++ b/consent-protocol/tests/test_developer_api_routes.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from api.routes import developer
+from api.routes.developer import _STATIC_REQUESTABLE_SCOPES, _is_supported_scope
 
 _CONNECTOR_PUBLIC_KEY = "U29tZUNvbm5lY3RvclB1YmxpY0tleURhdGE="
 _CONNECTOR_KEY_ID = "connector_demo"
@@ -1256,3 +1257,44 @@ def test_rotate_access_token_returns_new_raw_token(monkeypatch):
     payload = response.json()
     assert payload["raw_token"] == "hdk_rotated_secret"  # noqa: S105
     assert payload["active_token"]["token_prefix"] == "hdk_rotated"  # noqa: S105
+
+
+# ===========================================================================
+# _STATIC_REQUESTABLE_SCOPES and _is_supported_scope unit tests
+# ===========================================================================
+
+
+def test_static_requestable_scopes_has_no_duplicates():
+    scopes_list = list(_STATIC_REQUESTABLE_SCOPES)
+    assert len(scopes_list) == len(set(scopes_list)), (
+        "Duplicate entries in _STATIC_REQUESTABLE_SCOPES"
+    )
+
+
+def test_static_requestable_scopes_is_frozenset():
+    assert isinstance(_STATIC_REQUESTABLE_SCOPES, frozenset)
+
+
+def test_is_supported_scope_accepts_pkm_read():
+    assert _is_supported_scope("pkm.read") is True
+
+
+def test_is_supported_scope_accepts_pkm_write():
+    assert _is_supported_scope("pkm.write") is True
+
+
+def test_is_supported_scope_accepts_dynamic_attr_scope():
+    assert _is_supported_scope("attr.financial.holdings") is True
+    assert _is_supported_scope("attr.food.*") is True
+
+
+def test_is_supported_scope_rejects_unknown_static_scope():
+    assert _is_supported_scope("vault.owner") is False
+
+
+def test_is_supported_scope_rejects_empty_string():
+    assert _is_supported_scope("") is False
+
+
+def test_is_supported_scope_rejects_arbitrary_string():
+    assert _is_supported_scope("admin.all") is False


### PR DESCRIPTION
## Problem

`_STATIC_REQUESTABLE_SCOPES` in `api/routes/developer.py` was defined as a tuple with every scope listed twice:

```python
_STATIC_REQUESTABLE_SCOPES = ("pkm.read", "pkm.write", "pkm.read", "pkm.write")
```

Functionally harmless (Python `in` checks membership, not count), but the duplicates make it ambiguous how many scopes are intended and suggest a copy-paste error where two additional scopes were meant to appear.

## Changes

- Changed to `frozenset[str]` - the correct type for an unordered set of unique string values where membership testing is the only operation.
- Deduplicates to `{"pkm.read", "pkm.write"}` - the two unique values present.
- Adds 8 unit tests to `tests/test_developer_api_routes.py` covering:
  - No-duplicate invariant on `_STATIC_REQUESTABLE_SCOPES`
  - Type is `frozenset`
  - `pkm.read` and `pkm.write` are accepted
  - Dynamic `attr.*` scopes are accepted
  - `vault.owner`, `""`, `admin.all` are rejected

## Test plan

- [x] `ruff check --fix` + `ruff format` clean
- [x] All 32 tests pass (24 existing + 8 new)