### PR TITLE
fix: delete Firebase Auth user on account deletion

### DIFF
--- a/consent-protocol/api/routes/account.py
+++ b/consent-protocol/api/routes/account.py
@@ -137,6 +137,42 @@ async def _verify_phone_claim_id_token(raw_token: str) -> tuple[str, str | None]
     return phone_number, phone_session_uid
 
 
+async def _delete_firebase_auth_user(user_id: str) -> str:
+    """Delete the Firebase Auth identity after backend account data is removed."""
+    try:
+        from firebase_admin import auth as firebase_auth
+    except Exception as exc:
+        logger.exception("Firebase Auth SDK unavailable while deleting %s", user_id)
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "code": "FIREBASE_AUTH_DELETE_FAILED",
+                "message": "Backend account data was deleted, but Firebase Auth identity deletion failed.",
+            },
+        ) from exc
+
+    try:
+        firebase_app = get_firebase_auth_app()
+        if firebase_app is None:
+            raise RuntimeError("Firebase Admin is not configured")
+
+        await run_in_threadpool(lambda: firebase_auth.delete_user(user_id, app=firebase_app))
+        logger.info("Firebase Auth user deleted for %s", user_id)
+        return "deleted"
+    except firebase_auth.UserNotFoundError:
+        logger.info("Firebase Auth user already missing for %s", user_id)
+        return "already_missing"
+    except Exception as exc:
+        logger.exception("Firebase Auth user deletion failed for %s", user_id)
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "code": "FIREBASE_AUTH_DELETE_FAILED",
+                "message": "Backend account data was deleted, but Firebase Auth identity deletion failed.",
+            },
+        ) from exc
+
+
 @router.get("/email-aliases")
 async def list_email_aliases(token_data: dict = Depends(require_vault_owner_token)):
     """List account-owned verified email aliases."""
@@ -233,6 +269,14 @@ async def delete_account(
 
     if not result["success"]:
         raise HTTPException(status_code=500, detail=f"Deletion failed: {result.get('error')}")
+
+    if result.get("account_deleted") is True:
+        firebase_delete_status = await _delete_firebase_auth_user(user_id)
+        details = result.get("details")
+        if not isinstance(details, dict):
+            details = {}
+            result["details"] = details
+        details["firebase_auth_user"] = firebase_delete_status
 
     return result
 

--- a/consent-protocol/tests/test_account_routes.py
+++ b/consent-protocol/tests/test_account_routes.py
@@ -210,14 +210,21 @@ def test_delete_account_requires_vault_owner_token():
 
 
 def test_delete_account_defaults_target_to_both(monkeypatch):
+    deleted_auth_users = []
+
     async def _mock_delete(self, user_id: str, target: str = "both"):
         assert user_id == "user_123"
         assert target == "both"
         return {"success": True, "deleted_target": "both", "account_deleted": True}
 
+    async def _mock_delete_firebase_user(user_id: str):
+        deleted_auth_users.append(user_id)
+        return "deleted"
+
     app = _build_app()
     app.dependency_overrides[require_vault_owner_token] = lambda: {"user_id": "user_123"}
     monkeypatch.setattr(AccountService, "delete_account", _mock_delete)
+    monkeypatch.setattr(account, "_delete_firebase_auth_user", _mock_delete_firebase_user)
 
     client = TestClient(app)
     response = client.delete("/api/account/delete")
@@ -226,17 +233,26 @@ def test_delete_account_defaults_target_to_both(monkeypatch):
     payload = response.json()
     assert payload["success"] is True
     assert payload["account_deleted"] is True
+    assert payload["details"]["firebase_auth_user"] == "deleted"
+    assert deleted_auth_users == ["user_123"]
 
 
 def test_delete_account_forwards_requested_target(monkeypatch):
+    deleted_auth_users = []
+
     async def _mock_delete(self, user_id: str, target: str = "both"):
         assert user_id == "user_123"
         assert target == "investor"
         return {"success": True, "deleted_target": "investor", "remaining_personas": ["ria"]}
 
+    async def _mock_delete_firebase_user(user_id: str):
+        deleted_auth_users.append(user_id)
+        return "deleted"
+
     app = _build_app()
     app.dependency_overrides[require_vault_owner_token] = lambda: {"user_id": "user_123"}
     monkeypatch.setattr(AccountService, "delete_account", _mock_delete)
+    monkeypatch.setattr(account, "_delete_firebase_auth_user", _mock_delete_firebase_user)
 
     client = TestClient(app)
     response = client.request(
@@ -249,6 +265,7 @@ def test_delete_account_forwards_requested_target(monkeypatch):
     payload = response.json()
     assert payload["deleted_target"] == "investor"
     assert payload["remaining_personas"] == ["ria"]
+    assert deleted_auth_users == []
 
 
 def test_delete_account_maps_service_failure_to_500(monkeypatch):


### PR DESCRIPTION
## Summary
- delete the Firebase Auth user when full account deletion succeeds
- keep persona-only deletion scoped to backend/persona data
- return Firebase Auth deletion status under delete-account response details

## Verification
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/ankitkumarsingh/Documents/New\ project\ 2/hushh-research/consent-protocol/.venv/bin/python -m pytest tests/test_account_routes.py -q
- PATH="/Users/ankitkumarsingh/Documents/New project 2/hushh-research/consent-protocol/.venv/bin:$PATH" ./bin/hushh codex pre-pr --report-path /tmp/delete-account-auth-pre-pr.json --text