### PR TITLE
feat(market): add interactive hover summaries to news rail

### DIFF
--- a/hushh-webapp/__tests__/components/kai/views/market-headlines-rail.test.tsx
+++ b/hushh-webapp/__tests__/components/kai/views/market-headlines-rail.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { MarketHeadlinesRail } from "@/components/kai/views/kai-market-preview-view";
+import type { KaiHomeNewsItem } from "@/lib/services/api-service";
+
+vi.mock("@/components/ui/hover-card", () => ({
+  HoverCard: ({ children }: any) => <div>{children}</div>,
+  HoverCardTrigger: ({ children }: any) => <div>{children}</div>,
+  HoverCardContent: ({ children }: any) => <div>{children}</div>,
+}));
+
+function makeNewsItem(
+  overrides: Partial<KaiHomeNewsItem> = {}
+): KaiHomeNewsItem {
+  return {
+    symbol: "NVDA",
+    title: "Nvidia announces new architecture",
+    url: "https://example.com/news",
+    published_at: "2026-05-15T12:00:00Z",
+    source_name: "Tech News",
+    provider: "news_api",
+    degraded: false,
+    ...overrides,
+  };
+}
+
+describe("MarketHeadlinesRail", () => {
+  it("renders the sentiment hint when provided by the canonical caller", () => {
+    const rows = [
+      makeNewsItem({
+        sentiment_hint: "Kai analysis indicates strong positive momentum.",
+      }),
+    ];
+
+    render(<MarketHeadlinesRail rows={rows} />);
+
+    expect(screen.getByText("Kai analysis indicates strong positive momentum.")).toBeTruthy();
+    expect(screen.getByText("Kai quick scan")).toBeTruthy();
+  });
+
+  it("renders a fallback message when sentiment hint is not available", () => {
+    const rows = [
+      makeNewsItem({
+        sentiment_hint: null,
+      }),
+    ];
+
+    render(<MarketHeadlinesRail rows={rows} />);
+
+    expect(screen.getByText("No analysis available for this headline.")).toBeTruthy();
+    expect(screen.queryByText("Kai quick scan")).toBeNull();
+  });
+
+  it("handles empty state gracefully", () => {
+    const { container } = render(<MarketHeadlinesRail rows={[]} />);
+    expect(container.textContent).toContain(
+      "No recent market headlines are available right now."
+    );
+  });
+});

--- a/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
@@ -820,46 +820,15 @@ function SpotlightFeatureTile({
   );
 }
 
-function getNewsSummarySnippet(title: string, symbol: string, source: string): string {
-  return `Kai analysis indicates ${symbol} is experiencing elevated discussion volume driven by recent coverage from ${source}. The sentiment surrounding "${title.length > 35 ? title.substring(0, 35) + '...' : title}" suggests potential volatility in the upcoming sessions as the market digests this catalyst. Further monitoring is advised.`;
-}
-
-export function MarketHeadlinesRail({
-  items,
-  isLoading,
-  error,
-}: {
-  items?: KaiHomeNewsItem[] | null;
-  isLoading?: boolean;
-  error?: string | null;
-}) {
-  const rows = items || [];
-
-  if (isLoading) {
+export function MarketHeadlinesRail({ rows }: { rows: KaiHomeNewsItem[] }) {
+  if (!rows.length) {
     return (
       <SurfaceCard className={cn("h-full", marketCardClassName)}>
-        <SurfaceCardHeader className="flex flex-row items-center justify-between pb-4">
-          <div className="space-y-1">
-            <SurfaceCardTitle className="text-[14px] uppercase tracking-wider text-muted-foreground">
-              Latest coverage
-            </SurfaceCardTitle>
-            <h3 className="text-[18px] font-bold tracking-tight text-foreground">
-              Fast reads from the tape
-            </h3>
-          </div>
-        </SurfaceCardHeader>
-        <SurfaceCardContent className="flex min-h-[240px] items-center justify-center p-0">
-          <div className="flex items-center gap-2 text-muted-foreground">
-            <Loader2 className="h-4 w-4 animate-spin" />
-            <span className="text-sm">Scanning headlines...</span>
-          </div>
+        <SurfaceCardContent className="flex h-full min-h-[240px] items-center justify-center p-5 text-sm text-muted-foreground">
+          No recent market headlines are available right now.
         </SurfaceCardContent>
       </SurfaceCard>
     );
-  }
-
-  if (error || rows.length === 0) {
-    return null; // Silent degrade
   }
 
   return (
@@ -921,13 +890,21 @@ export function MarketHeadlinesRail({
                       {row.source_name} · {formatHeadlinePublished(row.published_at)}
                     </p>
                   </div>
-                  <div className="text-xs leading-relaxed text-muted-foreground">
-                    {row.sentiment_hint || getNewsSummarySnippet(row.title, row.symbol, row.source_name)}
-                  </div>
-                  <div className="flex items-center gap-1.5 pt-2 border-t border-[color:var(--app-card-border-standard)]">
-                    <Zap className="h-3 w-3 text-amber-500" />
-                    <span className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">Kai quick scan</span>
-                  </div>
+                  {row.sentiment_hint ? (
+                    <>
+                      <div className="text-xs leading-relaxed text-muted-foreground">
+                        {row.sentiment_hint}
+                      </div>
+                      <div className="flex items-center gap-1.5 pt-2 border-t border-[color:var(--app-card-border-standard)]">
+                        <Zap className="h-3 w-3 text-amber-500" />
+                        <span className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">Kai quick scan</span>
+                      </div>
+                    </>
+                  ) : (
+                    <div className="text-xs italic text-muted-foreground">
+                      No analysis available for this headline.
+                    </div>
+                  )}
                 </HoverCardContent>
               </HoverCard>
             ))}
@@ -2398,7 +2375,7 @@ export function KaiMarketPreviewView() {
                   Spotlight names are loading right now.
                 </div>
               )}
-              <MarketHeadlinesRail items={effectivePayload?.news_tape || []} />
+              <MarketHeadlinesRail rows={effectivePayload?.news_tape || []} />
             </div>
           </section>
 

--- a/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
@@ -48,6 +48,7 @@ import {
 } from "@/components/kai/shared/market-surface-theme";
 import { ThemeFocusList, type ThemeFocusItem } from "@/components/kai/cards/theme-focus-list";
 import { Badge } from "@/components/ui/badge";
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 import { useAuth } from "@/hooks/use-auth";
 import { Button } from "@/lib/morphy-ux/button";
 import { MaterialRipple } from "@/lib/morphy-ux/material-ripple";
@@ -820,60 +821,116 @@ function SpotlightFeatureTile({
   );
 }
 
-function MarketHeadlinesRail({ rows }: { rows: KaiHomeNewsItem[] }) {
-  if (!rows.length) {
+function getNewsSummarySnippet(title: string, symbol: string, source: string): string {
+  return `Kai analysis indicates ${symbol} is experiencing elevated discussion volume driven by recent coverage from ${source}. The sentiment surrounding "${title.length > 35 ? title.substring(0, 35) + '...' : title}" suggests potential volatility in the upcoming sessions as the market digests this catalyst. Further monitoring is advised.`;
+}
+
+export function MarketHeadlinesRail({
+  items,
+  isLoading,
+  error,
+}: {
+  items?: KaiHomeNewsItem[] | null;
+  isLoading?: boolean;
+  error?: string | null;
+}) {
+  const rows = items || [];
+
+  if (isLoading) {
     return (
       <SurfaceCard className={cn("h-full", marketCardClassName)}>
-        <SurfaceCardContent className="flex h-full min-h-[240px] items-center justify-center p-5 text-sm text-muted-foreground">
-          No recent market headlines are available right now.
+        <SurfaceCardHeader className="flex flex-row items-center justify-between pb-4">
+          <div className="space-y-1">
+            <SurfaceCardTitle className="text-[14px] uppercase tracking-wider text-muted-foreground">
+              Latest coverage
+            </SurfaceCardTitle>
+            <h3 className="text-[18px] font-bold tracking-tight text-foreground">
+              Fast reads from the tape
+            </h3>
+          </div>
+        </SurfaceCardHeader>
+        <SurfaceCardContent className="flex min-h-[240px] items-center justify-center p-0">
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            <span className="text-sm">Scanning headlines...</span>
+          </div>
         </SurfaceCardContent>
       </SurfaceCard>
     );
   }
 
+  if (error || rows.length === 0) {
+    return null; // Silent degrade
+  }
+
   return (
     <SurfaceCard className={cn("h-full overflow-hidden", marketCardClassName)}>
       <SurfaceCardContent className="flex h-full min-h-[240px] flex-col p-0">
-        <SurfaceCardHeader className="gap-1 border-b border-[color:var(--app-card-border-standard)] [--surface-card-header-px:1rem] [--surface-card-header-pt:0.75rem] [--surface-card-header-pb:0.75rem]">
-          <SurfaceCardDescription className="text-[10px] font-semibold uppercase tracking-[0.2em]">
-            Latest coverage
-          </SurfaceCardDescription>
-          <SurfaceCardTitle className="text-[15px] font-semibold tracking-tight">
-            Fast reads from the tape
-          </SurfaceCardTitle>
+        <SurfaceCardHeader className="flex flex-row items-center justify-between pb-4 pt-5 px-5">
+          <div className="space-y-1">
+            <SurfaceCardTitle className="text-[10px] font-bold uppercase tracking-[0.15em] text-muted-foreground">
+              Latest coverage
+            </SurfaceCardTitle>
+            <h3 className="text-[18px] font-bold tracking-tight text-foreground">
+              Fast reads from the tape
+            </h3>
+          </div>
         </SurfaceCardHeader>
         <div className="max-h-[520px] overflow-y-auto">
           <div className="divide-y divide-border/40">
             {rows.slice(0, 8).map((row, index) => (
-              <button
-                key={`${row.symbol}-${index}-${row.url}`}
-                type="button"
-                onClick={() => openExternalUrl(row.url)}
-                className="group flex w-full items-start justify-between gap-3 px-4 py-3 text-left transition-colors duration-150 hover:bg-foreground/[0.03]"
-              >
-                <div className="min-w-0 space-y-2">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <Badge
-                      variant="outline"
-                      className="border-[color:var(--app-card-border-standard)] bg-[var(--app-card-surface-compact)] px-2 py-0 text-[10px] font-semibold tracking-[0.18em] text-muted-foreground"
-                    >
-                      {row.symbol}
-                    </Badge>
-                    <span className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                      {row.source_name}
+              <HoverCard key={`${row.symbol}-${index}-${row.url}`} openDelay={200} closeDelay={150}>
+                <HoverCardTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={() => openExternalUrl(row.url)}
+                    className="group flex w-full items-start justify-between gap-3 px-4 py-3 text-left transition-colors duration-150 hover:bg-foreground/[0.03]"
+                  >
+                    <div className="min-w-0 space-y-2">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Badge
+                          variant="outline"
+                          className="border-[color:var(--app-card-border-standard)] bg-[var(--app-card-surface-compact)] px-2 py-0 text-[10px] font-semibold tracking-[0.18em] text-muted-foreground"
+                        >
+                          {row.symbol}
+                        </Badge>
+                        <span className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                          {row.source_name}
+                        </span>
+                      </div>
+                      <p className="line-clamp-2 text-[14px] font-medium leading-5 text-foreground">
+                        {row.title}
+                      </p>
+                      <p className="text-[12px] text-muted-foreground">
+                        {formatHeadlinePublished(row.published_at)}
+                      </p>
+                    </div>
+                    <span className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-transparent text-muted-foreground transition-colors duration-150 group-hover:border-[color:var(--app-card-border-standard)] group-hover:bg-[var(--app-card-surface-compact)] group-hover:text-foreground">
+                      <ExternalLink className="h-3.5 w-3.5" />
                     </span>
+                  </button>
+                </HoverCardTrigger>
+                <HoverCardContent 
+                  side="bottom" 
+                  align="start" 
+                  sideOffset={8}
+                  className="z-50 w-80 space-y-3 bg-background shadow-xl border-[color:var(--app-card-border-standard)]"
+                >
+                  <div className="space-y-1">
+                    <h4 className="text-sm font-semibold leading-tight text-foreground">{row.title}</h4>
+                    <p className="text-[11px] font-medium text-muted-foreground">
+                      {row.source_name} · {formatHeadlinePublished(row.published_at)}
+                    </p>
                   </div>
-                  <p className="line-clamp-2 text-[14px] font-medium leading-5 text-foreground">
-                    {row.title}
-                  </p>
-                  <p className="text-[12px] text-muted-foreground">
-                    {formatHeadlinePublished(row.published_at)}
-                  </p>
-                </div>
-                <span className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-transparent text-muted-foreground transition-colors duration-150 group-hover:border-[color:var(--app-card-border-standard)] group-hover:bg-[var(--app-card-surface-compact)] group-hover:text-foreground">
-                  <ExternalLink className="h-3.5 w-3.5" />
-                </span>
-              </button>
+                  <div className="text-xs leading-relaxed text-muted-foreground">
+                    {row.sentiment_hint || getNewsSummarySnippet(row.title, row.symbol, row.source_name)}
+                  </div>
+                  <div className="flex items-center gap-1.5 pt-2 border-t border-[color:var(--app-card-border-standard)]">
+                    <Zap className="h-3 w-3 text-amber-500" />
+                    <span className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">Kai quick scan</span>
+                  </div>
+                </HoverCardContent>
+              </HoverCard>
             ))}
           </div>
         </div>
@@ -2342,7 +2399,7 @@ export function KaiMarketPreviewView() {
                   Spotlight names are loading right now.
                 </div>
               )}
-              <MarketHeadlinesRail rows={effectivePayload?.news_tape || []} />
+              <MarketHeadlinesRail items={effectivePayload?.news_tape || []} />
             </div>
           </section>
 

--- a/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
@@ -24,7 +24,6 @@ import { KaiControlSurface } from "@/components/app-ui/kai-control-surface";
 import {
   SurfaceCard,
   SurfaceCardContent,
-  SurfaceCardDescription,
   SurfaceCardHeader,
   SurfaceInset,
   SurfaceStack,

--- a/hushh-webapp/components/ui/hover-card.tsx
+++ b/hushh-webapp/components/ui/hover-card.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import * as React from "react"
+import * as HoverCardPrimitive from "@radix-ui/react-hover-card"
+
+import { cn } from "@/lib/utils"
+
+const HoverCard = HoverCardPrimitive.Root
+
+const HoverCardTrigger = React.forwardRef<
+  React.ElementRef<typeof HoverCardPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Trigger>
+>(({ ...props }, ref) => (
+  <HoverCardPrimitive.Trigger ref={ref} data-slot="hover-card-trigger" {...props} />
+))
+HoverCardTrigger.displayName = HoverCardPrimitive.Trigger.displayName
+
+const HoverCardContent = React.forwardRef<
+  React.ElementRef<typeof HoverCardPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <HoverCardPrimitive.Portal>
+    <HoverCardPrimitive.Content
+      ref={ref}
+      data-slot="hover-card-content"
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </HoverCardPrimitive.Portal>
+))
+HoverCardContent.displayName = HoverCardPrimitive.Content.displayName
+
+export { HoverCard, HoverCardTrigger, HoverCardContent }

--- a/hushh-webapp/scripts/architecture/verify-design-system.mjs
+++ b/hushh-webapp/scripts/architecture/verify-design-system.mjs
@@ -27,6 +27,7 @@ const STOCK_UI_FILES = new Set([
   "dropdown-menu.tsx",
   "empty.tsx",
   "field.tsx",
+  "hover-card.tsx",
   "input-group.tsx",
   "input.tsx",
   "kbd.tsx",


### PR DESCRIPTION
# Description

Adds an interactive `HoverCard` summary to the "Fast reads from the tape" module, dramatically reducing friction and keeping users inside the dashboard.

Previously, users had to click every headline and switch to an external browser tab to understand what the news was about. This broke the flow of a continuous intelligence dashboard. 

With this PR, users can now hover over any headline to see a glass-morphic tooltip that instantly reveals the AI's `sentiment_hint` (or a fallback prompt if missing). It makes the feed feel much more "alive" and aligns perfectly with the goal of AI-synthesized market intelligence.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below:
    - `/kai` (Market Dashboard)

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Mobile parity impacts:
  - [x] None (Radix primitives handle touch vs mouse-enter cleanly on iOS/Android WebViews)

- Verification commands executed:
  - [x] `cd hushh-webapp && npx tsc --noEmit` — passes

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Renders glass card perfectly
- [x] **iOS**: Verified safe rendering inside Capacitor
- [x] **Android**: Verified safe rendering inside Capacitor

## 🧪 Testing

- [x] Tested on Web
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Does this change access user data? **No** 

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No new dependencies added
