### PR TITLE
fix(kai): add input bounds to Plaid, stream, and chat request models

### DIFF
--- a/consent-protocol/api/routes/kai/chat.py
+++ b/consent-protocol/api/routes/kai/chat.py
@@ -280,11 +280,13 @@ async def get_initial_chat_state(
 class AnalyzeLoserRequest(BaseModel):
     """Request body for analyze-loser endpoint."""
 
-    user_id: str = Field(..., description="User's Firebase UID")
+    user_id: str = Field(..., description="User's Firebase UID", min_length=1, max_length=128)
     symbol: str = Field(
         ..., description="Stock ticker symbol to analyze", min_length=1, max_length=10
     )
-    conversation_id: Optional[str] = Field(default=None, description="Existing conversation ID")
+    conversation_id: Optional[str] = Field(
+        None, description="Existing conversation ID", max_length=128
+    )
 
 
 class AnalyzeLoserResponse(BaseModel):

--- a/consent-protocol/tests/test_plaid_stream_chat_request_bounds.py
+++ b/consent-protocol/tests/test_plaid_stream_chat_request_bounds.py
@@ -55,11 +55,11 @@ class TestPlaidLinkTokenRequest:
 
     def test_user_id_too_long_raises(self):
         with pytest.raises(ValidationError):
-            PlaidLinkTokenRequest(user_id="u" * 129)
+            PlaidLinkTokenRequest(user_id="u" * 257)
 
     def test_item_id_too_long_raises(self):
         with pytest.raises(ValidationError):
-            PlaidLinkTokenRequest(user_id="u1", item_id="i" * 129)
+            PlaidLinkTokenRequest(user_id="u1", item_id="i" * 513)
 
     def test_redirect_uri_too_long_raises(self):
         with pytest.raises(ValidationError):
@@ -81,7 +81,7 @@ class TestPlaidPublicTokenExchangeRequest:
 
     def test_user_id_too_long_raises(self):
         with pytest.raises(ValidationError):
-            PlaidPublicTokenExchangeRequest(user_id="u" * 129, public_token="tok")  # noqa: S106
+            PlaidPublicTokenExchangeRequest(user_id="u" * 257, public_token="tok")  # noqa: S106
 
     def test_public_token_empty_raises(self):
         with pytest.raises(ValidationError):
@@ -89,14 +89,14 @@ class TestPlaidPublicTokenExchangeRequest:
 
     def test_public_token_too_long_raises(self):
         with pytest.raises(ValidationError):
-            PlaidPublicTokenExchangeRequest(user_id="u1", public_token="t" * 513)  # noqa: S106
+            PlaidPublicTokenExchangeRequest(user_id="u1", public_token="t" * 1025)  # noqa: S106
 
     def test_resume_session_id_too_long_raises(self):
         with pytest.raises(ValidationError):
             PlaidPublicTokenExchangeRequest(
                 user_id="u1",
                 public_token="t",  # noqa: S106
-                resume_session_id="r" * 129,
+                resume_session_id="r" * 257,
             )
 
     def test_terms_version_too_long_raises(self):
@@ -104,7 +104,7 @@ class TestPlaidPublicTokenExchangeRequest:
             PlaidPublicTokenExchangeRequest(
                 user_id="u1",
                 public_token="t",  # noqa: S106
-                terms_version="v" * 51,
+                terms_version="v" * 65,
             )
 
     def test_alpaca_account_id_too_long_raises(self):
@@ -112,7 +112,7 @@ class TestPlaidPublicTokenExchangeRequest:
             PlaidPublicTokenExchangeRequest(
                 user_id="u1",
                 public_token="t",  # noqa: S106
-                alpaca_account_id="a" * 129,
+                alpaca_account_id="a" * 257,
             )
 
 
@@ -128,7 +128,7 @@ class TestPlaidOAuthResumeRequest:
 
     def test_user_id_too_long_raises(self):
         with pytest.raises(ValidationError):
-            PlaidOAuthResumeRequest(user_id="u" * 129, resume_session_id="s")
+            PlaidOAuthResumeRequest(user_id="u" * 257, resume_session_id="s")
 
     def test_resume_session_id_empty_raises(self):
         with pytest.raises(ValidationError):
@@ -136,7 +136,7 @@ class TestPlaidOAuthResumeRequest:
 
     def test_resume_session_id_too_long_raises(self):
         with pytest.raises(ValidationError):
-            PlaidOAuthResumeRequest(user_id="u1", resume_session_id="s" * 129)
+            PlaidOAuthResumeRequest(user_id="u1", resume_session_id="s" * 257)
 
 
 # ---------------------------------------------------------------------------
@@ -151,17 +151,17 @@ class TestPlaidRefreshRequest:
 
     def test_user_id_too_long_raises(self):
         with pytest.raises(ValidationError):
-            PlaidRefreshRequest(user_id="u" * 129)
+            PlaidRefreshRequest(user_id="u" * 257)
 
     def test_item_id_too_long_raises(self):
         with pytest.raises(ValidationError):
-            PlaidRefreshRequest(user_id="u1", item_id="i" * 129)
+            PlaidRefreshRequest(user_id="u1", item_id="i" * 513)
 
 
 class TestPlaidRefreshCancelRequest:
     def test_user_id_too_long_raises(self):
         with pytest.raises(ValidationError):
-            PlaidRefreshCancelRequest(user_id="u" * 129)
+            PlaidRefreshCancelRequest(user_id="u" * 257)
 
 
 # ---------------------------------------------------------------------------
@@ -176,15 +176,15 @@ class TestPlaidFundingTransactionsSyncRequest:
 
     def test_user_id_too_long_raises(self):
         with pytest.raises(ValidationError):
-            PlaidFundingTransactionsSyncRequest(user_id="u" * 129, item_id="i")
+            PlaidFundingTransactionsSyncRequest(user_id="u" * 257, item_id="i")
 
     def test_item_id_too_long_raises(self):
         with pytest.raises(ValidationError):
-            PlaidFundingTransactionsSyncRequest(user_id="u1", item_id="i" * 129)
+            PlaidFundingTransactionsSyncRequest(user_id="u1", item_id="i" * 513)
 
     def test_cursor_too_long_raises(self):
         with pytest.raises(ValidationError):
-            PlaidFundingTransactionsSyncRequest(user_id="u1", item_id="i1", cursor="c" * 513)
+            PlaidFundingTransactionsSyncRequest(user_id="u1", item_id="i1", cursor="c" * 2049)
 
 
 # ---------------------------------------------------------------------------
@@ -209,7 +209,7 @@ class TestPlaidTransferCreateRequest:
 
     def test_user_id_too_long_raises(self):
         with pytest.raises(ValidationError):
-            PlaidTransferCreateRequest(**self._valid(user_id="u" * 129))
+            PlaidTransferCreateRequest(**self._valid(user_id="u" * 257))
 
     def test_user_legal_name_too_long_raises(self):
         with pytest.raises(ValidationError):
@@ -217,15 +217,15 @@ class TestPlaidTransferCreateRequest:
 
     def test_network_too_long_raises(self):
         with pytest.raises(ValidationError):
-            PlaidTransferCreateRequest(**self._valid(network="n" * 51))
+            PlaidTransferCreateRequest(**self._valid(network="n" * 65))
 
     def test_description_too_long_raises(self):
         with pytest.raises(ValidationError):
-            PlaidTransferCreateRequest(**self._valid(description="d" * 257))
+            PlaidTransferCreateRequest(**self._valid(description="d" * 513))
 
     def test_idempotency_key_too_long_raises(self):
         with pytest.raises(ValidationError):
-            PlaidTransferCreateRequest(**self._valid(idempotency_key="k" * 129))
+            PlaidTransferCreateRequest(**self._valid(idempotency_key="k" * 257))
 
     def test_redirect_uri_too_long_raises(self):
         with pytest.raises(ValidationError):
@@ -244,7 +244,7 @@ class TestPlaidFundingEscalationRequest:
 
     def test_user_id_too_long_raises(self):
         with pytest.raises(ValidationError):
-            PlaidFundingEscalationRequest(user_id="u" * 129, notes="n")
+            PlaidFundingEscalationRequest(user_id="u" * 257, notes="n")
 
     def test_notes_empty_raises(self):
         with pytest.raises(ValidationError):
@@ -252,15 +252,15 @@ class TestPlaidFundingEscalationRequest:
 
     def test_notes_too_long_raises(self):
         with pytest.raises(ValidationError):
-            PlaidFundingEscalationRequest(user_id="u1", notes="n" * 4001)
+            PlaidFundingEscalationRequest(user_id="u1", notes="n" * 2049)
 
     def test_notes_at_max_passes(self):
-        r = PlaidFundingEscalationRequest(user_id="u1", notes="n" * 4000)
-        assert len(r.notes) == 4000
+        r = PlaidFundingEscalationRequest(user_id="u1", notes="n" * 2048)
+        assert len(r.notes) == 2048
 
     def test_transfer_id_too_long_raises(self):
         with pytest.raises(ValidationError):
-            PlaidFundingEscalationRequest(user_id="u1", notes="n", transfer_id="t" * 129)
+            PlaidFundingEscalationRequest(user_id="u1", notes="n", transfer_id="t" * 257)
 
 
 # ---------------------------------------------------------------------------
@@ -271,7 +271,7 @@ class TestPlaidFundingEscalationRequest:
 class TestAlpacaConnectStartRequest:
     def test_user_id_too_long_raises(self):
         with pytest.raises(ValidationError):
-            AlpacaConnectStartRequest(user_id="u" * 129)
+            AlpacaConnectStartRequest(user_id="u" * 257)
 
     def test_redirect_uri_too_long_raises(self):
         with pytest.raises(ValidationError):
@@ -289,7 +289,7 @@ class TestAlpacaConnectCompleteRequest:
 
     def test_code_too_long_raises(self):
         with pytest.raises(ValidationError):
-            AlpacaConnectCompleteRequest(user_id="u1", state="s", code="c" * 513)
+            AlpacaConnectCompleteRequest(user_id="u1", state="s", code="c" * 2049)
 
 
 # ---------------------------------------------------------------------------
@@ -323,17 +323,17 @@ class TestPlaidFundedTradeCreateRequest:
 
     def test_brokerage_account_id_too_long_raises(self):
         with pytest.raises(ValidationError):
-            PlaidFundedTradeCreateRequest(**self._valid(brokerage_account_id="b" * 129))
+            PlaidFundedTradeCreateRequest(**self._valid(brokerage_account_id="b" * 513))
 
     def test_trade_idempotency_key_too_long_raises(self):
         with pytest.raises(ValidationError):
-            PlaidFundedTradeCreateRequest(**self._valid(trade_idempotency_key="k" * 129))
+            PlaidFundedTradeCreateRequest(**self._valid(trade_idempotency_key="k" * 257))
 
 
 class TestPlaidFundedTradeRefreshRequest:
     def test_user_id_too_long_raises(self):
         with pytest.raises(ValidationError):
-            PlaidFundedTradeRefreshRequest(user_id="u" * 129)
+            PlaidFundedTradeRefreshRequest(user_id="u" * 257)
 
 
 # ---------------------------------------------------------------------------
@@ -391,7 +391,7 @@ class TestStartAnalyzeRunRequest:
 
     def test_debate_session_id_too_long_raises(self):
         with pytest.raises(ValidationError):
-            StartAnalyzeRunRequest(user_id="u1", debate_session_id="s" * 129, ticker="AAPL")
+            StartAnalyzeRunRequest(user_id="u1", debate_session_id="s" * 257, ticker="AAPL")
 
     def test_ticker_too_long_raises(self):
         with pytest.raises(ValidationError):

--- a/consent-protocol/tests/test_plaid_stream_chat_request_bounds.py
+++ b/consent-protocol/tests/test_plaid_stream_chat_request_bounds.py
@@ -95,24 +95,24 @@ class TestPlaidPublicTokenExchangeRequest:
         with pytest.raises(ValidationError):
             PlaidPublicTokenExchangeRequest(
                 user_id="u1",
-                public_token="t",
-                resume_session_id="r" * 129,  # noqa: S106
+                public_token="t",  # noqa: S106
+                resume_session_id="r" * 129,
             )
 
     def test_terms_version_too_long_raises(self):
         with pytest.raises(ValidationError):
             PlaidPublicTokenExchangeRequest(
                 user_id="u1",
-                public_token="t",
-                terms_version="v" * 51,  # noqa: S106
+                public_token="t",  # noqa: S106
+                terms_version="v" * 51,
             )
 
     def test_alpaca_account_id_too_long_raises(self):
         with pytest.raises(ValidationError):
             PlaidPublicTokenExchangeRequest(
                 user_id="u1",
-                public_token="t",
-                alpaca_account_id="a" * 129,  # noqa: S106
+                public_token="t",  # noqa: S106
+                alpaca_account_id="a" * 129,
             )
 
 

--- a/consent-protocol/tests/test_plaid_stream_chat_request_bounds.py
+++ b/consent-protocol/tests/test_plaid_stream_chat_request_bounds.py
@@ -1,0 +1,464 @@
+"""
+Tests for input bounds on Plaid, stream-analyze, and Kai chat request models.
+
+Covers:
+- PlaidLinkTokenRequest
+- PlaidPublicTokenExchangeRequest
+- PlaidOAuthResumeRequest
+- PlaidRefreshRequest / PlaidRefreshCancelRequest
+- PlaidSourcePreferenceRequest
+- PlaidFundingTransactionsSyncRequest
+- PlaidFundingDefaultAccountRequest
+- PlaidFundingBrokerageAccountRequest
+- PlaidTransferCreateRequest
+- PlaidFundingReconciliationRequest
+- PlaidFundingEscalationRequest
+- AlpacaConnectStartRequest / AlpacaConnectCompleteRequest
+- PlaidFundedTradeCreateRequest / PlaidFundedTradeRefreshRequest
+- StreamAnalyzeRequest / StartAnalyzeRunRequest
+- KaiChatRequest / AnalyzeLoserRequest
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from api.routes.kai.chat import AnalyzeLoserRequest, KaiChatRequest
+from api.routes.kai.plaid import (
+    AlpacaConnectCompleteRequest,
+    AlpacaConnectStartRequest,
+    PlaidFundedTradeCreateRequest,
+    PlaidFundedTradeRefreshRequest,
+    PlaidFundingEscalationRequest,
+    PlaidFundingTransactionsSyncRequest,
+    PlaidLinkTokenRequest,
+    PlaidOAuthResumeRequest,
+    PlaidPublicTokenExchangeRequest,
+    PlaidRefreshCancelRequest,
+    PlaidRefreshRequest,
+    PlaidTransferCreateRequest,
+)
+from api.routes.kai.stream import StartAnalyzeRunRequest, StreamAnalyzeRequest
+
+# ---------------------------------------------------------------------------
+# PlaidLinkTokenRequest
+# ---------------------------------------------------------------------------
+
+
+class TestPlaidLinkTokenRequest:
+    def test_valid_passes(self):
+        r = PlaidLinkTokenRequest(user_id="u1")
+        assert r.user_id == "u1"
+
+    def test_user_id_empty_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidLinkTokenRequest(user_id="")
+
+    def test_user_id_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidLinkTokenRequest(user_id="u" * 129)
+
+    def test_item_id_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidLinkTokenRequest(user_id="u1", item_id="i" * 129)
+
+    def test_redirect_uri_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidLinkTokenRequest(user_id="u1", redirect_uri="h" * 2049)
+
+
+# ---------------------------------------------------------------------------
+# PlaidPublicTokenExchangeRequest
+# ---------------------------------------------------------------------------
+
+
+_PLAID_TOKEN = "tok123"  # noqa: S105
+
+
+class TestPlaidPublicTokenExchangeRequest:
+    def test_valid_passes(self):
+        r = PlaidPublicTokenExchangeRequest(user_id="u1", public_token=_PLAID_TOKEN)  # noqa: S106
+        assert r.public_token == _PLAID_TOKEN  # noqa: S105
+
+    def test_user_id_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidPublicTokenExchangeRequest(user_id="u" * 129, public_token="tok")  # noqa: S106
+
+    def test_public_token_empty_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidPublicTokenExchangeRequest(user_id="u1", public_token="")  # noqa: S106
+
+    def test_public_token_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidPublicTokenExchangeRequest(user_id="u1", public_token="t" * 513)  # noqa: S106
+
+    def test_resume_session_id_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidPublicTokenExchangeRequest(
+                user_id="u1",
+                public_token="t",
+                resume_session_id="r" * 129,  # noqa: S106
+            )
+
+    def test_terms_version_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidPublicTokenExchangeRequest(
+                user_id="u1",
+                public_token="t",
+                terms_version="v" * 51,  # noqa: S106
+            )
+
+    def test_alpaca_account_id_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidPublicTokenExchangeRequest(
+                user_id="u1",
+                public_token="t",
+                alpaca_account_id="a" * 129,  # noqa: S106
+            )
+
+
+# ---------------------------------------------------------------------------
+# PlaidOAuthResumeRequest
+# ---------------------------------------------------------------------------
+
+
+class TestPlaidOAuthResumeRequest:
+    def test_valid_passes(self):
+        r = PlaidOAuthResumeRequest(user_id="u1", resume_session_id="sess1")
+        assert r.resume_session_id == "sess1"
+
+    def test_user_id_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidOAuthResumeRequest(user_id="u" * 129, resume_session_id="s")
+
+    def test_resume_session_id_empty_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidOAuthResumeRequest(user_id="u1", resume_session_id="")
+
+    def test_resume_session_id_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidOAuthResumeRequest(user_id="u1", resume_session_id="s" * 129)
+
+
+# ---------------------------------------------------------------------------
+# PlaidRefreshRequest / PlaidRefreshCancelRequest
+# ---------------------------------------------------------------------------
+
+
+class TestPlaidRefreshRequest:
+    def test_valid_passes(self):
+        r = PlaidRefreshRequest(user_id="u1")
+        assert r.item_id is None
+
+    def test_user_id_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidRefreshRequest(user_id="u" * 129)
+
+    def test_item_id_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidRefreshRequest(user_id="u1", item_id="i" * 129)
+
+
+class TestPlaidRefreshCancelRequest:
+    def test_user_id_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidRefreshCancelRequest(user_id="u" * 129)
+
+
+# ---------------------------------------------------------------------------
+# PlaidFundingTransactionsSyncRequest
+# ---------------------------------------------------------------------------
+
+
+class TestPlaidFundingTransactionsSyncRequest:
+    def test_valid_passes(self):
+        r = PlaidFundingTransactionsSyncRequest(user_id="u1", item_id="item1")
+        assert r.cursor is None
+
+    def test_user_id_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidFundingTransactionsSyncRequest(user_id="u" * 129, item_id="i")
+
+    def test_item_id_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidFundingTransactionsSyncRequest(user_id="u1", item_id="i" * 129)
+
+    def test_cursor_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidFundingTransactionsSyncRequest(user_id="u1", item_id="i1", cursor="c" * 513)
+
+
+# ---------------------------------------------------------------------------
+# PlaidTransferCreateRequest
+# ---------------------------------------------------------------------------
+
+
+class TestPlaidTransferCreateRequest:
+    def _valid(self, **kw) -> dict:
+        base = dict(
+            user_id="u1",
+            funding_item_id="fi1",
+            funding_account_id="fa1",
+            amount=100.0,
+            user_legal_name="Alice Smith",
+        )
+        return {**base, **kw}
+
+    def test_valid_passes(self):
+        r = PlaidTransferCreateRequest(**self._valid())
+        assert r.network == "ach"
+
+    def test_user_id_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidTransferCreateRequest(**self._valid(user_id="u" * 129))
+
+    def test_user_legal_name_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidTransferCreateRequest(**self._valid(user_legal_name="n" * 257))
+
+    def test_network_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidTransferCreateRequest(**self._valid(network="n" * 51))
+
+    def test_description_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidTransferCreateRequest(**self._valid(description="d" * 257))
+
+    def test_idempotency_key_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidTransferCreateRequest(**self._valid(idempotency_key="k" * 129))
+
+    def test_redirect_uri_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidTransferCreateRequest(**self._valid(redirect_uri="h" * 2049))
+
+
+# ---------------------------------------------------------------------------
+# PlaidFundingEscalationRequest
+# ---------------------------------------------------------------------------
+
+
+class TestPlaidFundingEscalationRequest:
+    def test_valid_passes(self):
+        r = PlaidFundingEscalationRequest(user_id="u1", notes="Transfer stuck")
+        assert r.severity == "normal"
+
+    def test_user_id_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidFundingEscalationRequest(user_id="u" * 129, notes="n")
+
+    def test_notes_empty_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidFundingEscalationRequest(user_id="u1", notes="")
+
+    def test_notes_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidFundingEscalationRequest(user_id="u1", notes="n" * 4001)
+
+    def test_notes_at_max_passes(self):
+        r = PlaidFundingEscalationRequest(user_id="u1", notes="n" * 4000)
+        assert len(r.notes) == 4000
+
+    def test_transfer_id_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidFundingEscalationRequest(user_id="u1", notes="n", transfer_id="t" * 129)
+
+
+# ---------------------------------------------------------------------------
+# AlpacaConnect requests
+# ---------------------------------------------------------------------------
+
+
+class TestAlpacaConnectStartRequest:
+    def test_user_id_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            AlpacaConnectStartRequest(user_id="u" * 129)
+
+    def test_redirect_uri_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            AlpacaConnectStartRequest(user_id="u1", redirect_uri="h" * 2049)
+
+
+class TestAlpacaConnectCompleteRequest:
+    def test_valid_passes(self):
+        r = AlpacaConnectCompleteRequest(user_id="u1", state="s1", code="c1")
+        assert r.state == "s1"
+
+    def test_state_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            AlpacaConnectCompleteRequest(user_id="u1", state="s" * 513, code="c")
+
+    def test_code_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            AlpacaConnectCompleteRequest(user_id="u1", state="s", code="c" * 513)
+
+
+# ---------------------------------------------------------------------------
+# PlaidFundedTradeCreateRequest
+# ---------------------------------------------------------------------------
+
+
+class TestPlaidFundedTradeCreateRequest:
+    def _valid(self, **kw) -> dict:
+        base = dict(
+            user_id="u1",
+            funding_item_id="fi1",
+            funding_account_id="fa1",
+            symbol="AAPL",
+            user_legal_name="Alice Smith",
+            notional_usd=100.0,
+        )
+        return {**base, **kw}
+
+    def test_valid_passes(self):
+        r = PlaidFundedTradeCreateRequest(**self._valid())
+        assert r.side == "buy"
+
+    def test_symbol_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidFundedTradeCreateRequest(**self._valid(symbol="A" * 21))
+
+    def test_user_legal_name_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidFundedTradeCreateRequest(**self._valid(user_legal_name="n" * 257))
+
+    def test_brokerage_account_id_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidFundedTradeCreateRequest(**self._valid(brokerage_account_id="b" * 129))
+
+    def test_trade_idempotency_key_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidFundedTradeCreateRequest(**self._valid(trade_idempotency_key="k" * 129))
+
+
+class TestPlaidFundedTradeRefreshRequest:
+    def test_user_id_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            PlaidFundedTradeRefreshRequest(user_id="u" * 129)
+
+
+# ---------------------------------------------------------------------------
+# StreamAnalyzeRequest
+# ---------------------------------------------------------------------------
+
+
+class TestStreamAnalyzeRequest:
+    def test_valid_passes(self):
+        r = StreamAnalyzeRequest(user_id="u1", ticker="AAPL")
+        assert r.risk_profile == "balanced"
+
+    def test_user_id_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            StreamAnalyzeRequest(user_id="u" * 129, ticker="AAPL")
+
+    def test_ticker_empty_raises(self):
+        with pytest.raises(ValidationError):
+            StreamAnalyzeRequest(user_id="u1", ticker="")
+
+    def test_ticker_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            StreamAnalyzeRequest(user_id="u1", ticker="A" * 21)
+
+    def test_risk_profile_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            StreamAnalyzeRequest(user_id="u1", ticker="AAPL", risk_profile="r" * 65)
+
+    def test_run_id_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            StreamAnalyzeRequest(user_id="u1", ticker="AAPL", run_id="r" * 129)
+
+    def test_resume_cursor_negative_raises(self):
+        with pytest.raises(ValidationError):
+            StreamAnalyzeRequest(user_id="u1", ticker="AAPL", resume_cursor=-1)
+
+
+# ---------------------------------------------------------------------------
+# StartAnalyzeRunRequest
+# ---------------------------------------------------------------------------
+
+
+class TestStartAnalyzeRunRequest:
+    def test_valid_passes(self):
+        r = StartAnalyzeRunRequest(user_id="u1", debate_session_id="sess1", ticker="AAPL")
+        assert r.ticker == "AAPL"
+
+    def test_user_id_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            StartAnalyzeRunRequest(user_id="u" * 129, debate_session_id="s", ticker="AAPL")
+
+    def test_debate_session_id_empty_raises(self):
+        with pytest.raises(ValidationError):
+            StartAnalyzeRunRequest(user_id="u1", debate_session_id="", ticker="AAPL")
+
+    def test_debate_session_id_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            StartAnalyzeRunRequest(user_id="u1", debate_session_id="s" * 129, ticker="AAPL")
+
+    def test_ticker_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            StartAnalyzeRunRequest(user_id="u1", debate_session_id="s1", ticker="A" * 21)
+
+    def test_pick_source_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            StartAnalyzeRunRequest(
+                user_id="u1", debate_session_id="s1", ticker="AAPL", pick_source="p" * 257
+            )
+
+    def test_pick_source_kind_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            StartAnalyzeRunRequest(
+                user_id="u1", debate_session_id="s1", ticker="AAPL", pick_source_kind="k" * 65
+            )
+
+
+# ---------------------------------------------------------------------------
+# KaiChatRequest
+# ---------------------------------------------------------------------------
+
+
+class TestKaiChatRequest:
+    def test_valid_passes(self):
+        r = KaiChatRequest(user_id="u1", message="Hello")
+        assert r.conversation_id is None
+
+    def test_user_id_empty_raises(self):
+        with pytest.raises(ValidationError):
+            KaiChatRequest(user_id="", message="Hello")
+
+    def test_user_id_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            KaiChatRequest(user_id="u" * 129, message="Hello")
+
+    def test_message_empty_raises(self):
+        with pytest.raises(ValidationError):
+            KaiChatRequest(user_id="u1", message="")
+
+    def test_message_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            KaiChatRequest(user_id="u1", message="m" * 4001)
+
+    def test_conversation_id_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            KaiChatRequest(user_id="u1", message="Hello", conversation_id="c" * 129)
+
+
+# ---------------------------------------------------------------------------
+# AnalyzeLoserRequest
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeLoserRequest:
+    def test_valid_passes(self):
+        r = AnalyzeLoserRequest(user_id="u1", symbol="AAPL")
+        assert r.symbol == "AAPL"
+
+    def test_user_id_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            AnalyzeLoserRequest(user_id="u" * 129, symbol="AAPL")
+
+    def test_symbol_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            AnalyzeLoserRequest(user_id="u1", symbol="A" * 11)
+
+    def test_conversation_id_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            AnalyzeLoserRequest(user_id="u1", symbol="AAPL", conversation_id="c" * 129)

--- a/consent-protocol/tests/test_plaid_stream_chat_route_bounds.py
+++ b/consent-protocol/tests/test_plaid_stream_chat_route_bounds.py
@@ -1,0 +1,251 @@
+"""
+Route-level bounds proof for the Plaid, stream-analyze, and chat surfaces.
+
+The Pydantic-only tests in test_plaid_stream_chat_request_bounds.py confirm
+model validation in isolation. These tests exercise each touched KAI route
+through FastAPI's TestClient, proving two things per surface:
+
+  1. Oversized payloads are rejected with 422 before business logic runs.
+  2. Properly bounded payloads reach the auth layer (not a 422), confirming
+     the existing caller contract is intact.
+
+Stream and the two canonical Plaid connection endpoints resolve auth inside
+the handler body (authorization: str | None = Header(None)), so FastAPI
+validates the request body before any auth logic executes. Chat uses
+Depends(require_vault_owner_token); the dependency is overridden here so
+body validation runs without a real auth call.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+_PROTO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_router(rel_path: str, module_name: str):
+    path = _PROTO_ROOT / rel_path
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Stream  (POST /analyze/stream)
+# Auth is resolved inside the handler body via _require_vault_owner_token(),
+# not as a FastAPI Depends, so the body is validated before any auth call.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def stream_client():
+    mod = _load_router("api/routes/kai/stream.py", "api.routes.kai.stream")
+    app = FastAPI()
+    app.include_router(mod.router)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestStreamRouteOversizedPayload:
+    def test_oversized_user_id_rejected(self, stream_client):
+        resp = stream_client.post(
+            "/analyze/stream",
+            json={"user_id": "u" * 129, "ticker": "AAPL"},
+        )
+        assert resp.status_code == 422
+
+    def test_oversized_ticker_rejected(self, stream_client):
+        resp = stream_client.post(
+            "/analyze/stream",
+            json={"user_id": "u1", "ticker": "A" * 21},
+        )
+        assert resp.status_code == 422
+
+    def test_oversized_risk_profile_rejected(self, stream_client):
+        resp = stream_client.post(
+            "/analyze/stream",
+            json={"user_id": "u1", "ticker": "AAPL", "risk_profile": "r" * 65},
+        )
+        assert resp.status_code == 422
+
+    def test_oversized_run_id_rejected(self, stream_client):
+        resp = stream_client.post(
+            "/analyze/stream",
+            json={"user_id": "u1", "ticker": "AAPL", "run_id": "r" * 129},
+        )
+        assert resp.status_code == 422
+
+
+class TestStreamRouteValidCallerShape:
+    def test_valid_body_reaches_auth_layer(self, stream_client):
+        resp = stream_client.post(
+            "/analyze/stream",
+            json={"user_id": "u1", "ticker": "AAPL"},
+        )
+        assert resp.status_code != 422, (
+            f"Valid body must not fail body validation. Got {resp.status_code}: {resp.text[:200]}"
+        )
+
+    def test_valid_body_with_optional_fields_reaches_auth_layer(self, stream_client):
+        resp = stream_client.post(
+            "/analyze/stream",
+            json={
+                "user_id": "u1",
+                "ticker": "AAPL",
+                "risk_profile": "aggressive",
+                "resume_cursor": 0,
+            },
+        )
+        assert resp.status_code != 422, (
+            f"Valid body with optional fields must not fail body validation. "
+            f"Got {resp.status_code}: {resp.text[:200]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Plaid  (POST /plaid/link-token and POST /plaid/exchange-public-token)
+# Both endpoints resolve auth inside the handler body (Header, not Depends),
+# so the request body is validated by FastAPI before _resolve_plaid_connection_user
+# is called.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def plaid_client():
+    mod = _load_router("api/routes/kai/plaid.py", "api.routes.kai.plaid")
+    app = FastAPI()
+    app.include_router(mod.router)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestPlaidRouteOversizedPayload:
+    def test_link_token_oversized_user_id_rejected(self, plaid_client):
+        resp = plaid_client.post(
+            "/plaid/link-token",
+            json={"user_id": "u" * 129},
+        )
+        assert resp.status_code == 422
+
+    def test_link_token_oversized_redirect_uri_rejected(self, plaid_client):
+        resp = plaid_client.post(
+            "/plaid/link-token",
+            json={"user_id": "u1", "redirect_uri": "h" * 2049},
+        )
+        assert resp.status_code == 422
+
+    def test_exchange_token_oversized_user_id_rejected(self, plaid_client):
+        resp = plaid_client.post(
+            "/plaid/exchange-public-token",
+            json={"user_id": "u" * 129, "public_token": "tok"},
+        )
+        assert resp.status_code == 422
+
+    def test_exchange_token_oversized_public_token_rejected(self, plaid_client):
+        resp = plaid_client.post(
+            "/plaid/exchange-public-token",
+            json={"user_id": "u1", "public_token": "t" * 513},
+        )
+        assert resp.status_code == 422
+
+
+class TestPlaidRouteValidCallerShape:
+    def test_valid_link_token_body_not_422(self, plaid_client):
+        resp = plaid_client.post(
+            "/plaid/link-token",
+            json={"user_id": "u1"},
+        )
+        assert resp.status_code != 422, (
+            f"Valid link-token body must not fail body validation. "
+            f"Got {resp.status_code}: {resp.text[:200]}"
+        )
+
+    def test_valid_exchange_token_body_not_422(self, plaid_client):
+        resp = plaid_client.post(
+            "/plaid/exchange-public-token",
+            json={"user_id": "u1", "public_token": "public-sandbox-token"},
+        )
+        assert resp.status_code != 422, (
+            f"Valid exchange-public-token body must not fail body validation. "
+            f"Got {resp.status_code}: {resp.text[:200]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Chat  (POST /chat)
+# Uses Depends(require_vault_owner_token). The dependency is overridden so
+# FastAPI validates the request body without making a real auth call.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def chat_client():
+    mod = _load_router("api/routes/kai/chat.py", "api.routes.kai.chat")
+    from api.middleware import require_vault_owner_token
+
+    app = FastAPI()
+    app.include_router(mod.router)
+    app.dependency_overrides[require_vault_owner_token] = lambda: {"user_id": "u1"}
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestChatRouteOversizedPayload:
+    def test_oversized_user_id_rejected(self, chat_client):
+        resp = chat_client.post(
+            "/chat",
+            json={"user_id": "u" * 129, "message": "hello"},
+        )
+        assert resp.status_code == 422
+
+    def test_empty_user_id_rejected(self, chat_client):
+        resp = chat_client.post(
+            "/chat",
+            json={"user_id": "", "message": "hello"},
+        )
+        assert resp.status_code == 422
+
+    def test_oversized_message_rejected(self, chat_client):
+        resp = chat_client.post(
+            "/chat",
+            json={"user_id": "u1", "message": "m" * 4001},
+        )
+        assert resp.status_code == 422
+
+    def test_empty_message_rejected(self, chat_client):
+        resp = chat_client.post(
+            "/chat",
+            json={"user_id": "u1", "message": ""},
+        )
+        assert resp.status_code == 422
+
+    def test_oversized_conversation_id_rejected(self, chat_client):
+        resp = chat_client.post(
+            "/chat",
+            json={"user_id": "u1", "message": "hello", "conversation_id": "c" * 129},
+        )
+        assert resp.status_code == 422
+
+
+class TestChatRouteValidCallerShape:
+    def test_valid_chat_body_not_422(self, chat_client):
+        resp = chat_client.post(
+            "/chat",
+            json={"user_id": "u1", "message": "Hello Kai"},
+        )
+        assert resp.status_code != 422, (
+            f"Valid chat body must not fail body validation. "
+            f"Got {resp.status_code}: {resp.text[:200]}"
+        )
+
+    def test_valid_chat_body_with_conversation_id_not_422(self, chat_client):
+        resp = chat_client.post(
+            "/chat",
+            json={"user_id": "u1", "message": "Hello", "conversation_id": "conv-123"},
+        )
+        assert resp.status_code != 422, (
+            f"Valid chat body with conversation_id must not fail body validation. "
+            f"Got {resp.status_code}: {resp.text[:200]}"
+        )

--- a/consent-protocol/tests/test_plaid_stream_chat_route_bounds.py
+++ b/consent-protocol/tests/test_plaid_stream_chat_route_bounds.py
@@ -126,7 +126,7 @@ class TestPlaidRouteOversizedPayload:
     def test_link_token_oversized_user_id_rejected(self, plaid_client):
         resp = plaid_client.post(
             "/plaid/link-token",
-            json={"user_id": "u" * 129},
+            json={"user_id": "u" * 257},
         )
         assert resp.status_code == 422
 
@@ -140,14 +140,14 @@ class TestPlaidRouteOversizedPayload:
     def test_exchange_token_oversized_user_id_rejected(self, plaid_client):
         resp = plaid_client.post(
             "/plaid/exchange-public-token",
-            json={"user_id": "u" * 129, "public_token": "tok"},
+            json={"user_id": "u" * 257, "public_token": "tok"},
         )
         assert resp.status_code == 422
 
     def test_exchange_token_oversized_public_token_rejected(self, plaid_client):
         resp = plaid_client.post(
             "/plaid/exchange-public-token",
-            json={"user_id": "u1", "public_token": "t" * 513},
+            json={"user_id": "u1", "public_token": "t" * 1025},
         )
         assert resp.status_code == 422
 


### PR DESCRIPTION
## Problem

Every `user_id`, `str`, and free-text field across the Plaid funding, Alpaca, stream-analyze, and Kai chat request models was completely unbounded,  no `min_length` or `max_length` constraints,  allowing arbitrarily large strings
to pass Pydantic validation and reach downstream services.

Notable examples:
- `PlaidPublicTokenExchangeRequest.public_token` : no upper bound; Plaid tokens  are at most a few hundred characters but the field accepted megabytes
- `PlaidTransferCreateRequest.user_legal_name` : legal name field with no cap
- `PlaidFundingEscalationRequest.notes` : free-text notes field with no cap
- `PlaidFundedTradeCreateRequest.symbol` : stock symbol with no max (bounded to 20)
- `StreamAnalyzeRequest.ticker` : ticker with no max (bounded to 20)
- All `user_id` fields : no `max_length` across 15+ models

## Models fixed

`PlaidLinkTokenRequest`, `PlaidPublicTokenExchangeRequest`,
`PlaidOAuthResumeRequest`, `PlaidRefreshRequest`, `PlaidRefreshCancelRequest`,
`PlaidSourcePreferenceRequest`, `PlaidFundingTransactionsSyncRequest`,
`PlaidFundingDefaultAccountRequest`, `PlaidFundingBrokerageAccountRequest`,
`PlaidTransferCreateRequest`, `PlaidFundingReconciliationRequest`,
`PlaidFundingEscalationRequest`, `AlpacaConnectStartRequest`,
`AlpacaConnectCompleteRequest`, `PlaidFundedTradeCreateRequest`,
`PlaidFundedTradeRefreshRequest`, `StreamAnalyzeRequest`,
`StartAnalyzeRunRequest`, `KaiChatRequest`, `AnalyzeLoserRequest`

## Tests

`tests/test_plaid_stream_chat_request_bounds.py`, 72 hermetic Pydantic-only
tests, no I/O, all passing.