### PR TITLE
test(streaming): preserve SSE event ordering across fragmented chunks

### DIFF
--- a/hushh-webapp/__tests__/streaming/sse-parser.test.ts
+++ b/hushh-webapp/__tests__/streaming/sse-parser.test.ts
@@ -60,4 +60,25 @@ describe("parseSSEBlocks", () => {
     const result = parseSSEBlocks(": ping\n\n\n");
     expect(result.events).toHaveLength(0);
   });
+    it("preserves SSE event ordering across fragmented chunks", () => {
+    const first =
+      'event: stage\nid: 1\ndata: {"schema_version":"1.0","stream_id":"strm_order","stream_kind":"portfolio_import","seq":1,"event":"stage","terminal":false,"payload":{"stage":"one"}}\n\n' +
+      'event: chunk\nid: 2\ndata: {"schema_version":"1.0","stream_id":"strm_order","stream_kind":"portfolio_import","seq":2,';
+
+    const firstResult = parseSSEBlocks(first);
+
+    expect(firstResult.events).toHaveLength(1);
+    expect(firstResult.events[0]?.event).toBe("stage");
+    expect(firstResult.remainder).toContain("event: chunk");
+
+    const second =
+      '"event":"chunk","terminal":false,"payload":{"text":"two"}}\n\n' +
+      'event: done\nid: 3\ndata: {"schema_version":"1.0","stream_id":"strm_order","stream_kind":"portfolio_import","seq":3,"event":"done","terminal":true,"payload":{"status":"complete"}}\n\n';
+
+    const secondResult = parseSSEBlocks(second, firstResult.remainder);
+
+    expect(secondResult.remainder).toBe("");
+    expect(secondResult.events.map((event) => event.id)).toEqual(["2", "3"]);
+    expect(secondResult.events.map((event) => event.event)).toEqual(["chunk", "done"]);
+  });
 });


### PR DESCRIPTION

## Motivation

`parseSSEBlocks()` incrementally reconstructs streaming SSE events across fragmented transport chunks.

A regression in remainder stitching or event sequencing could silently reorder stream events, corrupt incremental UI updates, or break downstream stream consumers relying on deterministic event ordering.

This PR adds regression coverage for fragmented SSE ordering continuity.

## What's covered

`__tests__/streaming/sse-parser.test.ts`

Added fragmented SSE ordering coverage for `parseSSEBlocks`.

### Key scenarios

* verifies partially fragmented SSE frames preserve ordering across chunk boundaries
* validates incomplete frames remain buffered in `remainder`
* ensures resumed parsing reconstructs subsequent events in deterministic order
* confirms event ids and event names remain sequence-stable after chunk recovery
* strengthens transport-level stream continuity guarantees

## Checklist

* npm run test -- sse-parser
* npm run lint
* npm run typecheck
* No production behavior changes
* Pure regression contract coverage
* DCO sign-off included
