### PR TITLE
test(streaming): preserve empty remainder after consecutive valid SSE

### DIFF
--- a/hushh-webapp/__tests__/streaming/sse-parser.test.ts
+++ b/hushh-webapp/__tests__/streaming/sse-parser.test.ts
@@ -60,4 +60,19 @@ describe("parseSSEBlocks", () => {
     const result = parseSSEBlocks(": ping\n\n\n");
     expect(result.events).toHaveLength(0);
   });
+    it("preserves empty remainder after consecutive valid SSE frames", () => {
+    const input =
+      'event: stage\n' +
+      'id: 11\n' +
+      'data: {"schema_version":"1.0","stream_id":"strm_empty","stream_kind":"portfolio_import","seq":11,"event":"stage","terminal":false,"payload":{"stage":"loading"}}\n\n' +
+      'event: done\n' +
+      'id: 12\n' +
+      'data: {"schema_version":"1.0","stream_id":"strm_empty","stream_kind":"portfolio_import","seq":12,"event":"done","terminal":true,"payload":{"status":"complete"}}\n\n';
+
+    const result = parseSSEBlocks(input);
+
+    expect(result.remainder).toBe("");
+    expect(result.events).toHaveLength(2);
+    expect(result.events.map((event) => event.id)).toEqual(["11", "12"]);
+  });
 });


### PR DESCRIPTION
## Motivation

`parseSSEBlocks()` incrementally processes consecutive server-sent event frames while maintaining parser remainder state across stream boundaries.

A regression in remainder cleanup handling could leave stale buffered state after fully valid frame sequences, potentially interfering with subsequent incremental stream parsing.

This PR adds regression coverage for empty remainder stability after consecutive valid SSE frames.

## What's covered

`__tests__/streaming/sse-parser.test.ts`

Added parser stability coverage for consecutive valid SSE frame handling.

### Key scenarios

* verifies consecutive valid SSE frames fully clear parser remainder state
* ensures parsed event ordering remains deterministic across sequential frames
* validates no stale buffered remainder persists after complete frame processing
* strengthens parser stability for long-lived incremental streaming flows

## Checklist

* npm run test -- sse-parser
* npm run lint
* npm run typecheck
* No production behavior changes
* Pure regression contract coverage
* DCO sign-off included

