### PR TITLE
fix(security): eliminate exception string leaks and add request bounds in Kai analyze

### DIFF
--- a/consent-protocol/api/routes/kai/analyze.py
+++ b/consent-protocol/api/routes/kai/analyze.py
@@ -8,11 +8,12 @@ SECURITY: This endpoint requires VAULT_OWNER token for all data access.
 No Firebase Auth fallback - consistent with Consent-First Architecture.
 """
 
+import json
 import logging
 from typing import Any, Dict, Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from api.middleware import require_vault_owner_token
 from hushh_mcp.operons.kai.fetchers import RealtimeDataUnavailable
@@ -28,13 +29,13 @@ router = APIRouter()
 
 
 class AnalyzeRequest(BaseModel):
-    user_id: str
-    ticker: str
-    consent_token: Optional[str] = None
+    user_id: str = Field(min_length=1, max_length=128)
+    ticker: str = Field(min_length=1, max_length=20)
+    consent_token: Optional[str] = Field(default=None, max_length=2048)
     # Client provides context explicitly (Stateless)
     risk_profile: Literal["conservative", "balanced", "aggressive"] = "balanced"
     processing_mode: Literal["on_device", "hybrid"] = "hybrid"
-    context: Optional[Dict[str, Any]] = None  # Decrypted user profile context
+    context: Optional[Dict[str, Any]] = None  # Decrypted user profile context; validated by service
 
 
 class AnalyzeResponse(BaseModel):
@@ -85,7 +86,9 @@ async def analyze_ticker(
     # Security: Verify token matches requested user
     if token_data["user_id"] != request.user_id:
         logger.warning(
-            f"[Kai] User ID mismatch - token={token_data['user_id']}, request={request.user_id}"
+            "[Kai] User ID mismatch - token=%s, request=%s",
+            token_data["user_id"],
+            request.user_id,
         )
         raise HTTPException(status_code=403, detail="User ID does not match authenticated user")
 
@@ -107,11 +110,9 @@ async def analyze_ticker(
 
         # Convert to dictionary for response
         raw_card = orchestrator.decision_generator.to_json(decision_card)
-        import json
-
         raw_dict = json.loads(raw_card)
 
-        logger.info(f"[Kai] Generated analysis for {request.ticker} ({request.risk_profile})")
+        logger.info("[Kai] Generated analysis for %s (%s)", request.ticker, request.risk_profile)
 
         return AnalyzeResponse(
             decision_id=decision_card.decision_id,
@@ -125,10 +126,12 @@ async def analyze_ticker(
         )
 
     except ValueError as e:
-        logger.error(f"[Kai] Analysis failed: {e}")
-        raise HTTPException(status_code=400, detail=str(e))
+        logger.error("[Kai] Analysis failed: %s", e)
+        raise HTTPException(
+            status_code=400, detail="Invalid analysis request. Check ticker and parameters."
+        )
     except RealtimeDataUnavailable as e:
-        logger.error(f"[Kai] Realtime dependency unavailable: {e.detail}")
+        logger.error("[Kai] Realtime dependency unavailable: %s", e.detail)
         raise HTTPException(
             status_code=503,
             detail={
@@ -138,6 +141,6 @@ async def analyze_ticker(
                 "retryable": e.retryable,
             },
         )
-    except Exception as e:
+    except Exception:
         logger.exception("[Kai] Unexpected error during analysis")
-        raise HTTPException(status_code=500, detail=f"Analysis failed: {str(e)}")
+        raise HTTPException(status_code=500, detail="Analysis is temporarily unavailable.")

--- a/consent-protocol/api/routes/kai/consent.py
+++ b/consent-protocol/api/routes/kai/consent.py
@@ -15,7 +15,7 @@ import uuid
 from typing import Dict, List
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from api.middleware import require_firebase_auth, verify_user_id_match
 from hushh_mcp.consent.token import issue_token
@@ -33,11 +33,11 @@ router = APIRouter()
 
 
 class GrantConsentRequest(BaseModel):
-    user_id: str
-    scopes: List[str] = [
-        "attr.financial.*",
-        "agent.kai.analyze",
-    ]
+    user_id: str = Field(min_length=1, max_length=128)
+    scopes: List[str] = Field(
+        default=["attr.financial.*", "agent.kai.analyze"],
+        max_length=20,
+    )
 
 
 class GrantConsentResponse(BaseModel):
@@ -92,13 +92,13 @@ async def grant_consent(
             )
 
         except Exception as e:
-            logger.error(f"Failed to issue token for scope {scope_str}: {e}")
+            logger.error("Failed to issue token for scope %s: %s", scope_str, e)
             raise HTTPException(status_code=400, detail=f"Invalid scope: {scope_str}")
 
     if not tokens:
         raise HTTPException(status_code=400, detail="No valid scopes provided")
 
-    logger.info(f"[Kai] Consent granted for user: {request.user_id}")
+    logger.info("[Kai] Consent granted for user: %s", request.user_id)
 
     return GrantConsentResponse(
         consent_id=consent_id,

--- a/consent-protocol/api/routes/session.py
+++ b/consent-protocol/api/routes/session.py
@@ -250,7 +250,11 @@ async def lookup_user(
             country=country,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        logger.warning("user_lookup.invalid_identifier: %s", exc)
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid lookup identifier. Provide a valid email, phone number, or user ID.",
+        ) from exc
 
     logger.info("user_lookup.requested kind=%s", lookup_kind)
 


### PR DESCRIPTION
## Summary

- **`kai/analyze.py`** - Two exception handlers were using `detail=str(e)` / `detail=f"Analysis failed: {str(e)}"`, leaking internal orchestrator error messages to API callers. Replaced with static safe messages. Deferred `import json` inside the handler body moved to module level. `AnalyzeRequest` given `user_id` min/max, `ticker` max=20, `consent_token` max=2048. All f-string loggers converted to `%`-style.
- **`kai/consent.py`** - `GrantConsentRequest.scopes` had no item count cap (DoS surface); capped at 20. `user_id` bounded. Logger style fixed.
- **`session.py`** - `user_lookup` `ValueError` handler was returning `detail=str(exc)`, which could expose internal validation messages. Replaced with a static message; original error logged server-side.

## Test plan
- [ ] `POST /kai/analyze` with an invalid ticker still returns 400 with a static message (no exception text)
- [ ] `POST /kai/analyze` with an internal crash returns 500 with `"Analysis is temporarily unavailable."` (no crash detail)
- [ ] `POST /kai/consent/grant` with 21+ scopes returns 422
- [ ] `GET /user/lookup` with no valid identifier returns 400 with the new static message
- [ ] `ruff check` clean on all three files