### PR TITLE
fix(docs): remove stale model-version references; add persona max_length

### DIFF
--- a/consent-protocol/api/routes/agents.py
+++ b/consent-protocol/api/routes/agents.py
@@ -71,7 +71,7 @@ async def kai_chat(request: ChatRequest):
     - Sentiment Analysis
     - Valuation Analysis
 
-    Orchestrates tools via Gemini 3 Flash.
+    Orchestrates multi-agent investment analysis (fundamental, sentiment, valuation).
     """
     logger.info(f"📈 Kai Agent: user={request.userId}, msg='{request.message[:50]}...'")
 

--- a/consent-protocol/api/routes/iam.py
+++ b/consent-protocol/api/routes/iam.py
@@ -17,7 +17,7 @@ router = APIRouter(prefix="/api/iam", tags=["IAM"])
 
 
 class PersonaSwitchRequest(BaseModel):
-    persona: str = Field(..., description="Target persona: investor | ria")
+    persona: str = Field(..., description="Target persona: investor | ria", max_length=32)
 
 
 class MarketplaceOptInRequest(BaseModel):

--- a/consent-protocol/api/routes/kai/stream.py
+++ b/consent-protocol/api/routes/kai/stream.py
@@ -887,7 +887,7 @@ async def stream_agent_thinking(
     phase: str,
 ) -> AsyncGenerator[dict, None]:
     """
-    Stream Gemini 3 thinking tokens for an agent analysis.
+    Stream thinking tokens for an agent analysis.
     Yields agent_token events that the frontend can display in real-time.
     """
     logger.info(f"[Kai Stream] Starting stream_agent_thinking for {agent_name}")


### PR DESCRIPTION
## Summary

- **`api/routes/agents.py`** : Docstring for `kai_chat` said *"Orchestrates tools via Gemini 3 Flash."* - the model reference is stale and diverges from the actual implementation. Replaced with a model-neutral description of the agentic flow.
- **`api/routes/kai/stream.py`** : Internal generator docstring said *"Stream Gemini 3 thinking tokens"*; updated to *"Stream thinking tokens for an agent analysis."*
- **`api/routes/iam.py`** : `PersonaSwitchRequest.persona` had no `max_length`, allowing arbitrarily long strings through model validation. Capped at 32 chars (valid values are `"investor"` and `"ria"`).

## Test plan
- [ ] `POST /api/iam/persona/switch` with a `persona` longer than 32 chars returns 422
- [ ] `ruff check` clean on all three files