### PR TITLE
Fix RIA UAT business contact schema contract

### DIFF
--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -80,7 +80,6 @@
       "updated_at"
     ],
     "ria_business_contacts": [
-      "id",
       "user_id",
       "email",
       "email_verified",


### PR DESCRIPTION
## Summary
- remove the unused `id` requirement from the UAT schema contract for `ria_business_contacts`
- keep the contract aligned with migration 053, which models the table as a 1:1 `user_id` table

## Verification
- `./bin/hushh db verify-release-contract`
- `consent-protocol/.venv/bin/python scripts/ops/db_migration_release_guard.py --contract-file consent-protocol/db/contracts/uat_integrated_schema.json --skip-db-check --report-path tmp/uat-db-contract-hotfix-local.json`
- `DB_PROXY_PORT=6544 PATH="$PWD/consent-protocol/.venv/bin:$PATH" ./bin/hushh db verify-uat-schema --report-path tmp/uat-db-contract-hotfix-live.json`

Note: local `./bin/hushh codex pre-pr` was blocked by unrelated untracked docs/skill files in this working tree; GitHub should validate the clean pushed branch.