### PR TITLE
feat(kai): surface market evidence affordances

### DIFF
--- a/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
@@ -230,12 +230,147 @@ function signalConfidenceTone(signal: {
   return "bg-[var(--app-card-surface-compact)] text-muted-foreground";
 }
 
-function visibleSignalSourceTags(signal: KaiHomeSignal | undefined): string[] {
-  if (!Array.isArray(signal?.source_tags)) return [];
-  return signal.source_tags
+type MarketEvidenceItem = {
+  label: string;
+  value: string;
+  tone?: "neutral" | "warning";
+};
+
+function uniqueMarketEvidenceItems(items: Array<MarketEvidenceItem | null | undefined>): MarketEvidenceItem[] {
+  const seen = new Set<string>();
+  return items.filter((item): item is MarketEvidenceItem => {
+    if (!item) return false;
+    const value = item.value.trim();
+    if (!value || isUnavailableText(value)) return false;
+    const key = `${item.label}:${value}`.toLowerCase();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function visibleMarketSourceTags(tags: string[] | null | undefined): string[] {
+  if (!Array.isArray(tags)) return [];
+  return tags
     .map((tag) => String(tag || "").trim())
     .filter(Boolean)
-    .filter((tag) => !/fallback|unavailable|cache|derived/i.test(tag));
+    .filter((tag) => !/fallback|unavailable|cache|derived/i.test(tag))
+    .filter((tag, index, arr) => arr.findIndex((candidate) => candidate.toLowerCase() === tag.toLowerCase()) === index);
+}
+
+function formatEvidenceTimestamp(value: string | null | undefined): string | null {
+  const text = String(value || "").trim();
+  if (!text) return null;
+  const date = new Date(text);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function confidenceEvidenceItem(value: number | null | undefined): MarketEvidenceItem | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  const pct = Math.max(0, Math.min(100, Math.round(value * 100)));
+  return {
+    label: "Confidence",
+    value: `${pct}%`,
+  };
+}
+
+function signalEvidenceItems(signal: KaiHomeSignal | undefined): MarketEvidenceItem[] {
+  if (!signal) return [];
+  return uniqueMarketEvidenceItems([
+    confidenceEvidenceItem(signal.confidence),
+    ...visibleMarketSourceTags(signal.source_tags)
+      .slice(0, 2)
+      .map((tag) => ({
+        label: "Source",
+        value: tag,
+      })),
+    signal.degraded
+      ? {
+          label: "State",
+          value: "Degraded feed",
+          tone: "warning",
+        }
+      : null,
+  ]);
+}
+
+function spotlightEvidenceItems(
+  row: NonNullable<KaiHomeInsightsV2["spotlights"]>[number]
+): MarketEvidenceItem[] {
+  const asOf = formatEvidenceTimestamp(row.as_of);
+  return uniqueMarketEvidenceItems([
+    confidenceEvidenceItem(row.confidence),
+    row.recommendation_source
+      ? {
+          label: "Recommendation",
+          value: row.recommendation_source,
+        }
+      : null,
+    row.headline_source
+      ? {
+          label: "Coverage",
+          value: row.headline_source,
+        }
+      : null,
+    ...visibleMarketSourceTags(row.source_tags)
+      .slice(0, 2)
+      .map((tag) => ({
+        label: "Source",
+        value: tag,
+      })),
+    asOf
+      ? {
+          label: "Quote as of",
+          value: asOf,
+        }
+      : null,
+    row.degraded
+      ? {
+          label: "State",
+          value: "Degraded feed",
+          tone: "warning",
+        }
+      : null,
+  ]);
+}
+
+function MarketEvidenceStrip({
+  items,
+  compact = false,
+}: {
+  items: MarketEvidenceItem[];
+  compact?: boolean;
+}) {
+  if (!items.length) return null;
+
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap gap-2 rounded-[calc(var(--app-card-radius-compact)-4px)] border border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-compact)]",
+        compact ? "px-2.5 py-2" : "px-3 py-2.5"
+      )}
+      aria-label="Evidence used for this market read"
+    >
+      {items.slice(0, compact ? 3 : 4).map((item) => (
+        <span
+          key={`${item.label}:${item.value}`}
+          className={cn(
+            "inline-flex min-w-0 items-center gap-1 text-[11px] leading-4 text-muted-foreground",
+            item.tone === "warning" && "text-amber-700 dark:text-amber-300"
+          )}
+        >
+          <span className="shrink-0 font-semibold text-foreground/72">{item.label}</span>
+          <span className="truncate">{item.value}</span>
+        </span>
+      ))}
+    </div>
+  );
 }
 
 function deriveSignalSupportingItems(
@@ -620,6 +755,7 @@ function SpotlightFeatureTile({
   const _confidenceLabel = spotlightConfidenceLabel(row);
   const summary = summarizeSpotlight(row);
   const context = spotlightContextLabel(row);
+  const evidenceItems = spotlightEvidenceItems(row);
   const companyName = String(row.company_name || row.symbol || "Unknown").trim();
   const price = formatSpotlightPrice(row.price);
   const decisionTone =
@@ -667,6 +803,7 @@ function SpotlightFeatureTile({
 
         <p className="text-2xl font-semibold tracking-tight text-foreground">{price}</p>
         <p className="line-clamp-2 text-sm leading-6 text-muted-foreground">{summary}</p>
+        <MarketEvidenceStrip items={evidenceItems} compact />
       </div>
 
       <div className="mt-4 flex items-center justify-between gap-3 border-t border-[color:var(--app-card-border-standard)] pt-3">
@@ -2040,19 +2177,8 @@ export function KaiMarketPreviewView() {
                     </div>
                   ) : null}
 
-                  {visibleSignalSourceTags(scenarioSignal).length ? (
-                    <div className="flex flex-wrap gap-2">
-                      {visibleSignalSourceTags(scenarioSignal).slice(0, 3).map((tag) => (
-                        <Badge
-                          key={tag}
-                          variant="outline"
-                          className="border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-compact)] text-[10px] font-medium text-foreground/72"
-                        >
-                          {tag}
-                        </Badge>
-                      ))}
-                    </div>
-                  ) : null}
+                  <MarketEvidenceStrip items={signalEvidenceItems(scenarioSignal)} />
+
                 </div>
 
                 {primarySignalGroups.length ? (
@@ -2116,6 +2242,7 @@ export function KaiMarketPreviewView() {
                               {signal.summary ? (
                                 <p className="text-xs leading-5 text-muted-foreground">{signal.summary}</p>
                               ) : null}
+                              <MarketEvidenceStrip items={signalEvidenceItems(signal)} compact />
                               {evidence.length ? (
                                 <div className="grid gap-2">
                                   {evidence.slice(0, 1).map((line) => (


### PR DESCRIPTION

# Description

Adds compact trust/evidence affordances to the Kai Market surface so market reads and spotlight recommendations show where their claims come from without adding a new API or changing data access.

This PR surfaces existing payload evidence such as confidence, recommendation source, coverage source, source tags, quote timestamp, and degraded-feed state directly inside the market UI. It also removes a duplicate source-chip treatment from the primary signal card so the page stays calmer and more scannable.

## 📌 Impact Map (Required)

- Routes touched:
  - [ ] None
  - [x] Listed below:
    - `/kai` market surface via `hushh-webapp/components/kai/views/kai-market-preview-view.tsx`

- API / schema / type changes:
  - [x] None
  - [ ] Listed below:

- Cache keys touched:
  - [x] None
  - [ ] Listed below:

- World-model domain summary effects:
  - [x] None
  - [ ] Listed below:

- Mobile parity impacts:
  - [ ] None
  - [x] Listed below:
    - UI-only responsive React change shared by web and Capacitor shells; no native plugin/API parity work required.

- Docs updated (exact files):
  - [x] None
  - [ ] Listed below:

- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck`
  - [ ] `cd hushh-webapp && npm test`
  - [ ] `cd hushh-webapp && npm run build`
  - [ ] `cd hushh-webapp && npm run ios:test`
  - [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000`
  - Additional:
    - [x] `cd hushh-webapp && npm run lint`
    - [x] `cd hushh-webapp && npm run verify:design-system`
    - [x] `cd hushh-webapp && npm run verify:service-boundary`
    - [x] `cd hushh-webapp && npm run verify:docs`

## 🛑 Tri-Flow Architecture Check

_Every feature must be implemented across all three layers or explicitly marked as not applicable._

- [x] **Web**: Next.js implementation (`app/api/...`)
  - N/A: this is a React UI-only change using existing market payload fields.
- [x] **iOS**: Swift Capacitor Plugin (`ios/App/App/Plugins/...`)
  - N/A: no native plugin or API contract change.
- [x] **Android**: Kotlin Capacitor Plugin (`android/app/.../plugins/...`)
  - N/A: no native plugin or API contract change.

## 🧪 Testing

- [ ] Tested on Web (Chrome/Safari)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Does this change access user data?
  - No. It only renders evidence fields already present in the existing Kai market payload.
- [ ] If yes, have you implemented `checkConsentToken()`?

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed
  - No dependency changes.
```