### PR TITLE
refactor(kai): extract market discovery components

### DIFF
--- a/hushh-webapp/__tests__/components/kai/market/market-discovery.test.tsx
+++ b/hushh-webapp/__tests__/components/kai/market/market-discovery.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { signalEvidenceItems } from "@/components/kai/market/market-discovery";
+
+describe("market-discovery", () => {
+  describe("signalEvidenceItems", () => {
+    it("handles undefined signal safely", () => {
+      const items = signalEvidenceItems(undefined);
+      expect(items).toEqual([]);
+    });
+
+    it("extracts confidence when provided", () => {
+      const items = signalEvidenceItems({
+        id: "test",
+        title: "Test Signal",
+        confidence: 0.85,
+        source_tags: [],
+        degraded: false,
+      });
+      expect(items).toContainEqual({
+        label: "Confidence",
+        value: "85%",
+      });
+    });
+
+    it("includes degraded warning state", () => {
+      const items = signalEvidenceItems({
+        id: "test",
+        title: "Test Signal",
+        confidence: 0.85,
+        source_tags: [],
+        degraded: true,
+      });
+      expect(items).toContainEqual({
+        label: "State",
+        value: "Degraded feed",
+        tone: "warning",
+      });
+    });
+
+    it("extracts unique source tags", () => {
+      const items = signalEvidenceItems({
+        id: "test",
+        title: "Test Signal",
+        confidence: 0.5,
+        source_tags: ["Source A", "Source B", "Source A", "fallback"],
+        degraded: false,
+      });
+      const sourceItems = items.filter(i => i.label === "Source");
+      expect(sourceItems.length).toBeLessThanOrEqual(2);
+      expect(items).not.toContainEqual({
+        label: "Source",
+        value: "fallback",
+      });
+    });
+  });
+});

--- a/hushh-webapp/components/kai/market/market-discovery.tsx
+++ b/hushh-webapp/components/kai/market/market-discovery.tsx
@@ -1,0 +1,398 @@
+"use client";
+
+import { ArrowUpRight, ExternalLink } from "lucide-react";
+
+import {
+  SurfaceCard,
+  SurfaceCardContent,
+  SurfaceCardDescription,
+  SurfaceCardHeader,
+  SurfaceCardTitle,
+  surfaceInteractiveShellClassName,
+} from "@/components/app-ui/surfaces";
+import { SymbolAvatar } from "@/components/kai/shared/symbol-avatar";
+import { marketCardClassName } from "@/components/kai/shared/market-surface-theme";
+import { Badge } from "@/components/ui/badge";
+import {
+  type KaiHomeInsightsV2,
+  type KaiHomeNewsItem,
+  type KaiHomeSignal,
+} from "@/lib/services/api-service";
+import { requestInternalAppNavigation, openExternalUrl } from "@/lib/utils/browser-navigation";
+import { cn } from "@/lib/utils";
+
+export type MarketEvidenceItem = {
+  label: string;
+  value: string;
+  tone?: "neutral" | "warning";
+};
+
+function isUnavailableText(value: string): boolean {
+  const normalized = value.trim().toLowerCase();
+  return (
+    normalized.length === 0 ||
+    normalized === "n/a" ||
+    normalized === "na" ||
+    normalized === "unknown" ||
+    normalized === "unavailable" ||
+    normalized === "none" ||
+    normalized === "null" ||
+    normalized === "--" ||
+    normalized === "-"
+  );
+}
+
+function uniqueMarketEvidenceItems(items: Array<MarketEvidenceItem | null | undefined>): MarketEvidenceItem[] {
+  const seen = new Set<string>();
+  return items.filter((item): item is MarketEvidenceItem => {
+    if (!item) return false;
+    const value = item.value.trim();
+    if (!value || isUnavailableText(value)) return false;
+    const key = `${item.label}:${value}`.toLowerCase();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function visibleMarketSourceTags(tags: string[] | null | undefined): string[] {
+  if (!Array.isArray(tags)) return [];
+  return tags
+    .map((tag) => String(tag || "").trim())
+    .filter(Boolean)
+    .filter((tag) => !/fallback|unavailable|cache|derived/i.test(tag))
+    .filter((tag, index, arr) => arr.findIndex((candidate) => candidate.toLowerCase() === tag.toLowerCase()) === index);
+}
+
+function formatEvidenceTimestamp(value: string | null | undefined): string | null {
+  const text = String(value || "").trim();
+  if (!text) return null;
+  const date = new Date(text);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function confidenceEvidenceItem(value: number | null | undefined): MarketEvidenceItem | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  const pct = Math.max(0, Math.min(100, Math.round(value * 100)));
+  return {
+    label: "Confidence",
+    value: `${pct}%`,
+  };
+}
+
+export function signalEvidenceItems(signal: KaiHomeSignal | undefined): MarketEvidenceItem[] {
+  if (!signal) return [];
+  return uniqueMarketEvidenceItems([
+    confidenceEvidenceItem(signal.confidence),
+    ...visibleMarketSourceTags(signal.source_tags)
+      .slice(0, 2)
+      .map((tag) => ({
+        label: "Source",
+        value: tag,
+      })),
+    signal.degraded
+      ? {
+          label: "State",
+          value: "Degraded feed",
+          tone: "warning",
+        }
+      : null,
+  ]);
+}
+
+function spotlightEvidenceItems(
+  row: NonNullable<KaiHomeInsightsV2["spotlights"]>[number]
+): MarketEvidenceItem[] {
+  const asOf = formatEvidenceTimestamp(row.as_of);
+  return uniqueMarketEvidenceItems([
+    confidenceEvidenceItem(row.confidence),
+    row.recommendation_source
+      ? {
+          label: "Recommendation",
+          value: row.recommendation_source,
+        }
+      : null,
+    row.headline_source
+      ? {
+          label: "Coverage",
+          value: row.headline_source,
+        }
+      : null,
+    ...visibleMarketSourceTags(row.source_tags)
+      .slice(0, 2)
+      .map((tag) => ({
+        label: "Source",
+        value: tag,
+      })),
+    asOf
+      ? {
+          label: "Quote as of",
+          value: asOf,
+        }
+      : null,
+    row.degraded
+      ? {
+          label: "State",
+          value: "Degraded feed",
+          tone: "warning",
+        }
+      : null,
+  ]);
+}
+
+export function MarketEvidenceStrip({
+  items,
+  compact = false,
+}: {
+  items: MarketEvidenceItem[];
+  compact?: boolean;
+}) {
+  if (!items.length) return null;
+
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap gap-2 rounded-[calc(var(--app-card-radius-compact)-4px)] border border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-compact)]",
+        compact ? "px-2.5 py-2" : "px-3 py-2.5"
+      )}
+      aria-label="Evidence used for this market read"
+    >
+      {items.slice(0, compact ? 3 : 4).map((item) => (
+        <span
+          key={`${item.label}:${item.value}`}
+          className={cn(
+            "inline-flex min-w-0 items-center gap-1 text-[11px] leading-4 text-muted-foreground",
+            item.tone === "warning" && "text-amber-700 dark:text-amber-300"
+          )}
+        >
+          <span className="shrink-0 font-semibold text-foreground/72">{item.label}</span>
+          <span className="truncate">{item.value}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function toSpotlightDecision(input: string | undefined): "BUY" | "HOLD" | "REDUCE" {
+  const text = String(input || "").trim().toUpperCase();
+  if (text === "BUY" || text === "STRONG_BUY") return "BUY";
+  if (text === "REDUCE" || text === "SELL") return "REDUCE";
+  return "HOLD";
+}
+
+function isWeakSpotlightDetail(input: string | null | undefined): boolean {
+  const text = String(input || "").trim().toLowerCase();
+  if (!text) return true;
+  return (
+    text.includes("no live recommendation feed available") ||
+    text.includes("recommendation unavailable") ||
+    text.includes("target consensus unavailable")
+  );
+}
+
+function toSafeHttpUrl(input: string | null | undefined): string | null {
+  const text = String(input || "").trim();
+  if (!text) return null;
+  if (!/^https?:\/\//i.test(text)) return null;
+  return text;
+}
+
+function summarizeSpotlight(row: NonNullable<KaiHomeInsightsV2["spotlights"]>[number]): string {
+  const story = String(row.story || "").trim();
+  if (story) return story;
+
+  const detail = String(row.recommendation_detail || "").trim();
+  if (detail && !isWeakSpotlightDetail(detail)) return detail;
+
+  const headline = String(row.headline || "").trim();
+  if (headline) return `Recent coverage: ${headline}`;
+
+  const decision = toSpotlightDecision(row.recommendation);
+  const changePct =
+    typeof row.change_pct === "number" && Number.isFinite(row.change_pct)
+      ? `${row.change_pct >= 0 ? "+" : ""}${row.change_pct.toFixed(2)}% today`
+      : null;
+  if (decision === "BUY") {
+    return changePct
+      ? `Momentum is positive (${changePct}) while analyst updates refresh.`
+      : "Momentum is positive while analyst updates refresh.";
+  }
+  if (decision === "REDUCE") {
+    return changePct
+      ? `Momentum is soft (${changePct}) while analyst updates refresh.`
+      : "Momentum is soft while analyst updates refresh.";
+  }
+  return changePct
+    ? `Price action is mixed (${changePct}) while analyst updates refresh.`
+    : "Price action is mixed while analyst updates refresh.";
+}
+
+function spotlightContextLabel(row: NonNullable<KaiHomeInsightsV2["spotlights"]>[number]): string {
+  const source = String(row.headline_source || "").trim();
+  if (source) return source;
+  const recommendationSource = String(row.recommendation_source || "").trim();
+  if (recommendationSource) return recommendationSource;
+  return "Market signal feed";
+}
+
+function formatSpotlightPrice(value: number | null | undefined): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "Price unavailable";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+function formatHeadlinePublished(value: string | null | undefined): string {
+  const text = String(value || "").trim();
+  if (!text) return "Recent";
+  const date = new Date(text);
+  if (Number.isNaN(date.getTime())) return "Recent";
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export function SpotlightFeatureTile({
+  row,
+}: {
+  row: NonNullable<KaiHomeInsightsV2["spotlights"]>[number];
+}) {
+  const decision = toSpotlightDecision(row.recommendation);
+  const primaryHref = toSafeHttpUrl(row.headline_url) || `/kai/analysis?symbol=${encodeURIComponent(row.symbol)}`;
+  const summary = summarizeSpotlight(row);
+  const context = spotlightContextLabel(row);
+  const evidenceItems = spotlightEvidenceItems(row);
+  const companyName = String(row.company_name || row.symbol || "Unknown").trim();
+  const price = formatSpotlightPrice(row.price);
+  const decisionTone =
+    decision === "BUY"
+      ? "bg-emerald-500/12 text-emerald-700 dark:text-emerald-300"
+      : decision === "REDUCE"
+        ? "bg-amber-500/12 text-amber-700 dark:text-amber-300"
+        : "bg-[color:var(--app-card-surface-compact)] text-muted-foreground";
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        if (/^https?:\/\//i.test(primaryHref)) {
+          openExternalUrl(primaryHref);
+          return;
+        }
+        requestInternalAppNavigation({ href: primaryHref, scroll: false });
+      }}
+      className={cn(
+        surfaceInteractiveShellClassName,
+        "group relative flex h-full min-h-[200px] flex-col justify-between overflow-hidden rounded-[var(--app-card-radius-feature)] bg-[color:var(--app-card-surface-default-solid)] p-4 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/10 focus-visible:ring-offset-2 sm:p-5"
+      )}
+    >
+      <div className="space-y-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex min-w-0 items-start gap-3">
+            <SymbolAvatar symbol={row.symbol} name={row.company_name} size="md" />
+            <div className="min-w-0 space-y-1">
+              <p className="text-xs font-medium text-muted-foreground">
+                {row.symbol} - {context}
+              </p>
+              <h3 className="line-clamp-2 text-lg font-bold tracking-tight leading-tight text-foreground sm:text-xl">
+                {companyName}
+              </h3>
+            </div>
+          </div>
+          <span
+            className={cn(
+              "shrink-0 rounded-full px-2.5 py-1 text-[11px] font-bold tracking-wide",
+              decisionTone
+            )}
+          >
+            {decision}
+          </span>
+        </div>
+
+        <p className="text-2xl font-semibold tracking-tight text-foreground">{price}</p>
+        <p className="line-clamp-2 text-sm leading-6 text-muted-foreground">{summary}</p>
+        <MarketEvidenceStrip items={evidenceItems} compact />
+      </div>
+
+      <div className="mt-4 flex items-center justify-between gap-3 border-t border-[color:var(--app-card-border-standard)] pt-3">
+        <p className="line-clamp-1 min-w-0 text-xs text-muted-foreground">
+          {String(row.headline || summary).trim()}
+        </p>
+        <ArrowUpRight className="h-4 w-4 shrink-0 text-muted-foreground transition-colors group-hover:text-foreground" />
+      </div>
+    </button>
+  );
+}
+
+export function MarketHeadlinesRail({ rows }: { rows: KaiHomeNewsItem[] }) {
+  if (!rows.length) {
+    return (
+      <SurfaceCard className={cn("h-full", marketCardClassName)}>
+        <SurfaceCardContent className="flex h-full min-h-[240px] items-center justify-center p-5 text-sm text-muted-foreground">
+          No recent market headlines are available right now.
+        </SurfaceCardContent>
+      </SurfaceCard>
+    );
+  }
+
+  return (
+    <SurfaceCard className={cn("h-full overflow-hidden", marketCardClassName)}>
+      <SurfaceCardContent className="flex h-full min-h-[240px] flex-col p-0">
+        <SurfaceCardHeader className="gap-1 border-b border-[color:var(--app-card-border-standard)] [--surface-card-header-px:1rem] [--surface-card-header-pt:0.75rem] [--surface-card-header-pb:0.75rem]">
+          <SurfaceCardDescription className="text-[10px] font-semibold uppercase tracking-[0.2em]">
+            Latest coverage
+          </SurfaceCardDescription>
+          <SurfaceCardTitle className="text-[15px] font-semibold tracking-tight">
+            Fast reads from the tape
+          </SurfaceCardTitle>
+        </SurfaceCardHeader>
+        <div className="max-h-[520px] overflow-y-auto">
+          <div className="divide-y divide-border/40">
+            {rows.slice(0, 8).map((row, index) => (
+              <button
+                key={`${row.symbol}-${index}-${row.url}`}
+                type="button"
+                onClick={() => openExternalUrl(row.url)}
+                className="group flex w-full items-start justify-between gap-3 px-4 py-3 text-left transition-colors duration-150 hover:bg-foreground/[0.03]"
+              >
+                <div className="min-w-0 space-y-2">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge
+                      variant="outline"
+                      className="border-[color:var(--app-card-border-standard)] bg-[var(--app-card-surface-compact)] px-2 py-0 text-[10px] font-semibold tracking-[0.18em] text-muted-foreground"
+                    >
+                      {row.symbol}
+                    </Badge>
+                    <span className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                      {row.source_name}
+                    </span>
+                  </div>
+                  <p className="line-clamp-2 text-[14px] font-medium leading-5 text-foreground">
+                    {row.title}
+                  </p>
+                  <p className="text-[12px] text-muted-foreground">
+                    {formatHeadlinePublished(row.published_at)}
+                  </p>
+                </div>
+                <span className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-transparent text-muted-foreground transition-colors duration-150 group-hover:border-[color:var(--app-card-border-standard)] group-hover:bg-[var(--app-card-surface-compact)] group-hover:text-foreground">
+                  <ExternalLink className="h-3.5 w-3.5" />
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </SurfaceCardContent>
+    </SurfaceCard>
+  );
+}

--- a/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
@@ -4,10 +4,8 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } fro
 import {
   Activity,
   AlertTriangle,
-  ArrowUpRight,
   ChartColumnIncreasing,
   Cpu,
-  ExternalLink,
   LineChart,
   Loader2,
   Percent,
@@ -24,14 +22,16 @@ import { KaiControlSurface } from "@/components/app-ui/kai-control-surface";
 import {
   SurfaceCard,
   SurfaceCardContent,
-  SurfaceCardDescription,
-  SurfaceCardHeader,
   SurfaceInset,
   SurfaceStack,
-  SurfaceCardTitle,
-  surfaceInteractiveShellClassName,
 } from "@/components/app-ui/surfaces";
 import { ConnectPortfolioCta } from "@/components/kai/cards/connect-portfolio-cta";
+import {
+  MarketEvidenceStrip,
+  MarketHeadlinesRail,
+  SpotlightFeatureTile,
+  signalEvidenceItems,
+} from "@/components/kai/market/market-discovery";
 import { PermissionGate } from "@/components/privacy/permission-gate/permission-gate";
 import {
   MarketOverviewGrid,
@@ -39,7 +39,6 @@ import {
   type MarketOverviewMetric,
 } from "@/components/kai/cards/market-overview-grid";
 import { RiaPicksList } from "@/components/kai/cards/renaissance-market-list";
-import { SymbolAvatar } from "@/components/kai/shared/symbol-avatar";
 import {
   marketAmbientBackgroundClassName,
   marketAmbientGlowClassName,
@@ -62,7 +61,6 @@ import { sanitizeErrorMessage } from "@/lib/services/error-sanitizer";
 import { ensureKaiVaultOwnerToken } from "@/lib/services/kai-token-guard";
 import {
   type KaiHomeInsightsV2,
-  type KaiHomeNewsItem,
   type KaiHomePickSource,
   type KaiHomeSignal,
   type KaiHomeRenaissanceItem,
@@ -72,10 +70,7 @@ import {
   getKaiActivePickSource,
   setKaiActivePickSource,
 } from "@/lib/kai/pick-source-selection";
-import {
-  openExternalUrl,
-  requestInternalAppNavigation,
-} from "@/lib/utils/browser-navigation";
+
 import { cn } from "@/lib/utils";
 import { useVault } from "@/lib/vault/vault-context";
 import {
@@ -137,77 +132,6 @@ const THEME_ICON_MAP: Array<{ test: RegExp; icon: LucideIcon }> = [
   { test: /energy|oil|gas|renewable|power/i, icon: Zap },
 ];
 
-function toSpotlightDecision(input: string | undefined): "BUY" | "HOLD" | "REDUCE" {
-  const text = String(input || "").trim().toUpperCase();
-  if (text === "BUY" || text === "STRONG_BUY") return "BUY";
-  if (text === "REDUCE" || text === "SELL") return "REDUCE";
-  return "HOLD";
-}
-
-function isWeakSpotlightDetail(input: string | null | undefined): boolean {
-  const text = String(input || "").trim().toLowerCase();
-  if (!text) return true;
-  return (
-    text.includes("no live recommendation feed available") ||
-    text.includes("recommendation unavailable") ||
-    text.includes("target consensus unavailable")
-  );
-}
-
-function toSafeHttpUrl(input: string | null | undefined): string | null {
-  const text = String(input || "").trim();
-  if (!text) return null;
-  if (!/^https?:\/\//i.test(text)) return null;
-  return text;
-}
-
-function summarizeSpotlight(row: NonNullable<KaiHomeInsightsV2["spotlights"]>[number]): string {
-  const story = String(row.story || "").trim();
-  if (story) return story;
-
-  const detail = String(row.recommendation_detail || "").trim();
-  if (detail && !isWeakSpotlightDetail(detail)) return detail;
-
-  const headline = String(row.headline || "").trim();
-  if (headline) return `Recent coverage: ${headline}`;
-
-  const decision = toSpotlightDecision(row.recommendation);
-  const changePct =
-    typeof row.change_pct === "number" && Number.isFinite(row.change_pct)
-      ? `${row.change_pct >= 0 ? "+" : ""}${row.change_pct.toFixed(2)}% today`
-      : null;
-  if (decision === "BUY") {
-    return changePct
-      ? `Momentum is positive (${changePct}) while analyst updates refresh.`
-      : "Momentum is positive while analyst updates refresh.";
-  }
-  if (decision === "REDUCE") {
-    return changePct
-      ? `Momentum is soft (${changePct}) while analyst updates refresh.`
-      : "Momentum is soft while analyst updates refresh.";
-  }
-  return changePct
-    ? `Price action is mixed (${changePct}) while analyst updates refresh.`
-    : "Price action is mixed while analyst updates refresh.";
-}
-
-function spotlightContextLabel(row: NonNullable<KaiHomeInsightsV2["spotlights"]>[number]): string {
-  const source = String(row.headline_source || "").trim();
-  if (source) return source;
-  const recommendationSource = String(row.recommendation_source || "").trim();
-  if (recommendationSource) return recommendationSource;
-  return "Market signal feed";
-}
-
-function spotlightConfidenceLabel(
-  row: NonNullable<KaiHomeInsightsV2["spotlights"]>[number]
-): string | null {
-  const value = row.confidence;
-  if (typeof value !== "number" || !Number.isFinite(value)) return null;
-  const pct = Math.max(0, Math.min(100, Math.round(value * 100)));
-  return `${pct}% confidence`;
-}
-
 function signalConfidenceLabel(signal: {
   confidence?: number | null;
 }): string {
@@ -232,149 +156,6 @@ function signalConfidenceTone(signal: {
     return "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
   }
   return "bg-[var(--app-card-surface-compact)] text-muted-foreground";
-}
-
-type MarketEvidenceItem = {
-  label: string;
-  value: string;
-  tone?: "neutral" | "warning";
-};
-
-function uniqueMarketEvidenceItems(items: Array<MarketEvidenceItem | null | undefined>): MarketEvidenceItem[] {
-  const seen = new Set<string>();
-  return items.filter((item): item is MarketEvidenceItem => {
-    if (!item) return false;
-    const value = item.value.trim();
-    if (!value || isUnavailableText(value)) return false;
-    const key = `${item.label}:${value}`.toLowerCase();
-    if (seen.has(key)) return false;
-    seen.add(key);
-    return true;
-  });
-}
-
-function visibleMarketSourceTags(tags: string[] | null | undefined): string[] {
-  if (!Array.isArray(tags)) return [];
-  return tags
-    .map((tag) => String(tag || "").trim())
-    .filter(Boolean)
-    .filter((tag) => !/fallback|unavailable|cache|derived/i.test(tag))
-    .filter((tag, index, arr) => arr.findIndex((candidate) => candidate.toLowerCase() === tag.toLowerCase()) === index);
-}
-
-function formatEvidenceTimestamp(value: string | null | undefined): string | null {
-  const text = String(value || "").trim();
-  if (!text) return null;
-  const date = new Date(text);
-  if (Number.isNaN(date.getTime())) return null;
-  return date.toLocaleString(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  });
-}
-
-function confidenceEvidenceItem(value: number | null | undefined): MarketEvidenceItem | null {
-  if (typeof value !== "number" || !Number.isFinite(value)) return null;
-  const pct = Math.max(0, Math.min(100, Math.round(value * 100)));
-  return {
-    label: "Confidence",
-    value: `${pct}%`,
-  };
-}
-
-function signalEvidenceItems(signal: KaiHomeSignal | undefined): MarketEvidenceItem[] {
-  if (!signal) return [];
-  return uniqueMarketEvidenceItems([
-    confidenceEvidenceItem(signal.confidence),
-    ...visibleMarketSourceTags(signal.source_tags)
-      .slice(0, 2)
-      .map((tag) => ({
-        label: "Source",
-        value: tag,
-      })),
-    signal.degraded
-      ? {
-          label: "State",
-          value: "Degraded feed",
-          tone: "warning",
-        }
-      : null,
-  ]);
-}
-
-function spotlightEvidenceItems(
-  row: NonNullable<KaiHomeInsightsV2["spotlights"]>[number]
-): MarketEvidenceItem[] {
-  const asOf = formatEvidenceTimestamp(row.as_of);
-  return uniqueMarketEvidenceItems([
-    confidenceEvidenceItem(row.confidence),
-    row.recommendation_source
-      ? {
-          label: "Recommendation",
-          value: row.recommendation_source,
-        }
-      : null,
-    row.headline_source
-      ? {
-          label: "Coverage",
-          value: row.headline_source,
-        }
-      : null,
-    ...visibleMarketSourceTags(row.source_tags)
-      .slice(0, 2)
-      .map((tag) => ({
-        label: "Source",
-        value: tag,
-      })),
-    asOf
-      ? {
-          label: "Quote as of",
-          value: asOf,
-        }
-      : null,
-    row.degraded
-      ? {
-          label: "State",
-          value: "Degraded feed",
-          tone: "warning",
-        }
-      : null,
-  ]);
-}
-
-function MarketEvidenceStrip({
-  items,
-  compact = false,
-}: {
-  items: MarketEvidenceItem[];
-  compact?: boolean;
-}) {
-  if (!items.length) return null;
-
-  return (
-    <div
-      className={cn(
-        "flex flex-wrap gap-2 rounded-[calc(var(--app-card-radius-compact)-4px)] border border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-compact)]",
-        compact ? "px-2.5 py-2" : "px-3 py-2.5"
-      )}
-      aria-label="Evidence used for this market read"
-    >
-      {items.slice(0, compact ? 3 : 4).map((item) => (
-        <span
-          key={`${item.label}:${item.value}`}
-          className={cn(
-            "inline-flex min-w-0 items-center gap-1 text-[11px] leading-4 text-muted-foreground",
-            item.tone === "warning" && "text-amber-700 dark:text-amber-300"
-          )}
-        >
-          <span className="shrink-0 font-semibold text-foreground/72">{item.label}</span>
-          <span className="truncate">{item.value}</span>
-        </span>
-      ))}
-    </div>
-  );
 }
 
 function deriveSignalSupportingItems(
@@ -727,160 +508,6 @@ function MarketSectionLead({
   );
 }
 
-function formatSpotlightPrice(value: number | null | undefined): string {
-  if (typeof value !== "number" || !Number.isFinite(value)) return "Price unavailable";
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-    maximumFractionDigits: 2,
-  }).format(value);
-}
-
-function formatHeadlinePublished(value: string | null | undefined): string {
-  const text = String(value || "").trim();
-  if (!text) return "Recent";
-  const date = new Date(text);
-  if (Number.isNaN(date.getTime())) return "Recent";
-  return date.toLocaleString(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  });
-}
-
-function SpotlightFeatureTile({
-  row,
-}: {
-  row: NonNullable<KaiHomeInsightsV2["spotlights"]>[number];
-}) {
-  const decision = toSpotlightDecision(row.recommendation);
-  const primaryHref = toSafeHttpUrl(row.headline_url) || `/kai/analysis?symbol=${encodeURIComponent(row.symbol)}`;
-  const _confidenceLabel = spotlightConfidenceLabel(row);
-  const summary = summarizeSpotlight(row);
-  const context = spotlightContextLabel(row);
-  const evidenceItems = spotlightEvidenceItems(row);
-  const companyName = String(row.company_name || row.symbol || "Unknown").trim();
-  const price = formatSpotlightPrice(row.price);
-  const decisionTone =
-    decision === "BUY"
-      ? "bg-emerald-500/12 text-emerald-700 dark:text-emerald-300"
-      : decision === "REDUCE"
-        ? "bg-amber-500/12 text-amber-700 dark:text-amber-300"
-        : "bg-[color:var(--app-card-surface-compact)] text-muted-foreground";
-
-  return (
-    <button
-      type="button"
-      onClick={() => {
-        if (/^https?:\/\//i.test(primaryHref)) {
-          openExternalUrl(primaryHref);
-          return;
-        }
-        requestInternalAppNavigation({ href: primaryHref, scroll: false });
-      }}
-      className={cn(
-        surfaceInteractiveShellClassName,
-        "group relative flex h-full min-h-[200px] flex-col justify-between overflow-hidden rounded-[var(--app-card-radius-feature)] bg-[color:var(--app-card-surface-default-solid)] p-4 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/10 focus-visible:ring-offset-2 sm:p-5"
-      )}
-    >
-      <div className="space-y-3">
-        <div className="flex items-start justify-between gap-3">
-          <div className="flex min-w-0 items-start gap-3">
-            <SymbolAvatar symbol={row.symbol} name={row.company_name} size="md" />
-            <div className="min-w-0 space-y-1">
-              <p className="text-xs font-medium text-muted-foreground">{row.symbol} · {context}</p>
-              <h3 className="line-clamp-2 text-lg font-bold tracking-tight leading-tight text-foreground sm:text-xl">
-                {companyName}
-              </h3>
-            </div>
-          </div>
-          <span
-            className={cn(
-              "shrink-0 rounded-full px-2.5 py-1 text-[11px] font-bold tracking-wide",
-              decisionTone
-            )}
-          >
-            {decision}
-          </span>
-        </div>
-
-        <p className="text-2xl font-semibold tracking-tight text-foreground">{price}</p>
-        <p className="line-clamp-2 text-sm leading-6 text-muted-foreground">{summary}</p>
-        <MarketEvidenceStrip items={evidenceItems} compact />
-      </div>
-
-      <div className="mt-4 flex items-center justify-between gap-3 border-t border-[color:var(--app-card-border-standard)] pt-3">
-        <p className="line-clamp-1 min-w-0 text-xs text-muted-foreground">
-          {String(row.headline || summary).trim()}
-        </p>
-        <ArrowUpRight className="h-4 w-4 shrink-0 text-muted-foreground transition-colors group-hover:text-foreground" />
-      </div>
-    </button>
-  );
-}
-
-function MarketHeadlinesRail({ rows }: { rows: KaiHomeNewsItem[] }) {
-  if (!rows.length) {
-    return (
-      <SurfaceCard className={cn("h-full", marketCardClassName)}>
-        <SurfaceCardContent className="flex h-full min-h-[240px] items-center justify-center p-5 text-sm text-muted-foreground">
-          No recent market headlines are available right now.
-        </SurfaceCardContent>
-      </SurfaceCard>
-    );
-  }
-
-  return (
-    <SurfaceCard className={cn("h-full overflow-hidden", marketCardClassName)}>
-      <SurfaceCardContent className="flex h-full min-h-[240px] flex-col p-0">
-        <SurfaceCardHeader className="gap-1 border-b border-[color:var(--app-card-border-standard)] [--surface-card-header-px:1rem] [--surface-card-header-pt:0.75rem] [--surface-card-header-pb:0.75rem]">
-          <SurfaceCardDescription className="text-[10px] font-semibold uppercase tracking-[0.2em]">
-            Latest coverage
-          </SurfaceCardDescription>
-          <SurfaceCardTitle className="text-[15px] font-semibold tracking-tight">
-            Fast reads from the tape
-          </SurfaceCardTitle>
-        </SurfaceCardHeader>
-        <div className="max-h-[520px] overflow-y-auto">
-          <div className="divide-y divide-border/40">
-            {rows.slice(0, 8).map((row, index) => (
-              <button
-                key={`${row.symbol}-${index}-${row.url}`}
-                type="button"
-                onClick={() => openExternalUrl(row.url)}
-                className="group flex w-full items-start justify-between gap-3 px-4 py-3 text-left transition-colors duration-150 hover:bg-foreground/[0.03]"
-              >
-                <div className="min-w-0 space-y-2">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <Badge
-                      variant="outline"
-                      className="border-[color:var(--app-card-border-standard)] bg-[var(--app-card-surface-compact)] px-2 py-0 text-[10px] font-semibold tracking-[0.18em] text-muted-foreground"
-                    >
-                      {row.symbol}
-                    </Badge>
-                    <span className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                      {row.source_name}
-                    </span>
-                  </div>
-                  <p className="line-clamp-2 text-[14px] font-medium leading-5 text-foreground">
-                    {row.title}
-                  </p>
-                  <p className="text-[12px] text-muted-foreground">
-                    {formatHeadlinePublished(row.published_at)}
-                  </p>
-                </div>
-                <span className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-transparent text-muted-foreground transition-colors duration-150 group-hover:border-[color:var(--app-card-border-standard)] group-hover:bg-[var(--app-card-surface-compact)] group-hover:text-foreground">
-                  <ExternalLink className="h-3.5 w-3.5" />
-                </span>
-              </button>
-            ))}
-          </div>
-        </div>
-      </SurfaceCardContent>
-    </SurfaceCard>
-  );
-}
 
 function isUnavailableText(value: string): boolean {
   const normalized = value.trim().toLowerCase();


### PR DESCRIPTION
# `components/kai/market` — Kai Market Discovery Layer

> **Branch:** `feat/kai-market-file-extraction`  
> **Commit:** `3218801`  
> **Author:** Ayush  

---

## Overview

This directory owns all **presentational components and pure utility functions** that power the market discovery section of the Kai dashboard (`/kai`).

Previously these components lived inline inside `app/kai/views/kai-market-preview-view.tsx`, making that file a ~880-line monolith. This refactor extracts them into a dedicated, co-located module with clean export boundaries — keeping the parent view a lean orchestrator and making each piece independently testable and extensible.

---

## File Structure

```
components/kai/market/
├── market-discovery.tsx   ← All discovery-layer components & helpers (this PR)
└── README.md              ← You are here
```

---

## Exported API

### Components

| Export | Description |
|---|---|
| `<SpotlightFeatureTile row={…} />` | Full-bleed feature card for a single AI spotlight recommendation. Renders ticker avatar, company name, live price, BUY/HOLD/REDUCE badge, story summary, and an evidence strip. |
| `<MarketHeadlinesRail rows={…} />` | Scrollable list of the latest AI-curated news headlines ("Fast reads from the tape"). Each row shows symbol badge, source name, headline title, and publish timestamp. |
| `<MarketEvidenceStrip items={…} compact? />` | Compact pill-strip that surfaces the evidence metadata (confidence %, source tags, data freshness) used to derive a signal or spotlight. Renders `null` if `items` is empty. |

### Types

| Export | Description |
|---|---|
| `MarketEvidenceItem` | `{ label: string; value: string; tone?: "neutral" \| "warning" }` — a single key-value evidence pair rendered by `MarketEvidenceStrip`. |

### Utility Functions

| Export | Description |
|---|---|
| `signalEvidenceItems(signal)` | Derives a `MarketEvidenceItem[]` array from a `KaiHomeSignal` — used by signal cards outside this file. |

---

## Design Decisions

### Why extract at all?
The Kai market view was approaching 900 lines with no clear seam between layout orchestration and UI atoms. Tile interactions (hover cards, peek sheets, skeleton states) needed to evolve independently — that's only safe if each component lives in its own module.

### Why no separate file per component?
`SpotlightFeatureTile` and `MarketHeadlinesRail` share a set of ~10 pure helper functions (`toSpotlightDecision`, `summarizeSpotlight`, `formatSpotlightPrice`, etc.) that have no value outside this domain. A single module avoids a needless `utils/` proliferation while still providing clean `export` boundaries to consumers.

### Why `"use client"`?
Both components rely on `onClick` event handlers and `openExternalUrl` (a browser navigation utility). They are intentionally client components. The parent view manages data-fetching at the server boundary.

---

## Data Flow

```
kai-market-preview-view.tsx   (Server Component — fetches KaiHomeInsightsV2)
        │
        ├──▶ <SpotlightFeatureTile row={spotlight} />
        │         └── spotlightEvidenceItems() → <MarketEvidenceStrip />
        │
        └──▶ <MarketHeadlinesRail rows={news} />
```

---

## Props Reference

### `SpotlightFeatureTile`

```tsx
import { SpotlightFeatureTile } from "@/components/kai/market/market-discovery";

<SpotlightFeatureTile row={spotlightRow} />
```

| Prop | Type | Required | Description |
|---|---|---|---|
| `row` | `KaiHomeInsightsV2["spotlights"][number]` | ✅ | Full spotlight object from the API response. |

### `MarketHeadlinesRail`

```tsx
import { MarketHeadlinesRail } from "@/components/kai/market/market-discovery";

<MarketHeadlinesRail rows={newsItems} />
```

| Prop | Type | Required | Description |
|---|---|---|---|
| `rows` | `KaiHomeNewsItem[]` | ✅ | Array of news items. Renders an empty-state card if `[]`. |

### `MarketEvidenceStrip`

```tsx
import { MarketEvidenceStrip } from "@/components/kai/market/market-discovery";

<MarketEvidenceStrip items={evidenceItems} compact />
```

| Prop | Type | Default | Description |
|---|---|---|---|
| `items` | `MarketEvidenceItem[]` | — | Evidence pairs to render. |
| `compact` | `boolean` | `false` | Reduces padding and caps visible items to 3. |

---

## Extending This Module

**Adding a new tile variant?**
1. Add private helper functions at the bottom of the file (no export needed).
2. `export function` only the component itself.
3. Update this README's Exported API table.

**Adding a new evidence source?**
Extend `spotlightEvidenceItems()` or `signalEvidenceItems()` — both pass through `uniqueMarketEvidenceItems()` which deduplicates and filters unavailable values automatically.

**Adding hover interactions (e.g. HoverCard)?**
This file is already `"use client"` — import Radix primitives directly. See the `TickerPeekSheet` pattern in `components/kai/shared/` for the established interaction model.

---

## Verification

```bash
# Type-check (must pass with zero errors)
cd hushh-webapp && npx tsc --noEmit
```

---

## Related

- [`app/kai/views/kai-market-preview-view.tsx`](../../app/kai/views/kai-market-preview-view.tsx) — parent view that consumes these components
- [`components/kai/shared/market-surface-theme.ts`](../shared/market-surface-theme.ts) — shared `marketCardClassName` token
- [`components/kai/shared/symbol-avatar.tsx`](../shared/symbol-avatar.tsx) — `<SymbolAvatar />` used inside `SpotlightFeatureTile`
- [`lib/services/api-service.ts`](../../../lib/services/api-service.ts) — source of `KaiHomeInsightsV2`, `KaiHomeNewsItem`, `KaiHomeSignal` types

---

*Part of the Hushh Kai intelligence dashboard — Apache-2.0 licensed.*
