### PR TITLE
security: block privileged scope self-grant in Kai consent endpoint

### DIFF
--- a/consent-protocol/api/routes/kai/consent.py
+++ b/consent-protocol/api/routes/kai/consent.py
@@ -43,6 +43,26 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+# Privileged scopes that must never be self-issued via this Firebase-auth
+# endpoint, even though they are valid ConsentScope enum members accepted
+# by _validate_scope's Kai-contract check below.
+_SCOPE_BLOCKLIST: frozenset[str] = frozenset({
+    "vault.owner",
+    "agent.nav.revoke",
+    "pkm.write",
+})
+
+
+def _assert_scope_allowed(scope_str: str) -> None:
+    """Raise HTTPException 403 if scope is privileged and cannot be granted here."""
+    if scope_str in _SCOPE_BLOCKLIST:
+        logger.warning("kai.consent.grant blocked privileged scope=%s", scope_str)
+        raise HTTPException(
+            status_code=403,
+            detail="This scope cannot be granted via this endpoint.",
+        )
+
+
 # Allowed dynamic scope prefixes for Kai consent grants.
 # Only financial data and Kai agent scopes may be issued at this boundary.
 # Broader PKM domains (health, food, travel, etc.) are outside the Kai
@@ -133,6 +153,10 @@ async def grant_consent(
     last_token_issued = None
 
     for scope_str in request.scopes:
+        # Block privileged scopes before the Kai-contract check, since
+        # _validate_scope intentionally accepts any ConsentScope enum value.
+        _assert_scope_allowed(scope_str)
+
         try:
             _validate_scope(scope_str)
             # issue_token accepts both ConsentScope enum values and dynamic

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -6,6 +6,7 @@ tests/test_developer_api_routes.py
 tests/quality/test_kai_route_auth_compliance.py
 tests/test_kai_auth_matrix.py
 tests/test_kai_consent_grant_dynamic_scopes.py
+tests/test_kai_consent_grant_scope_escalation.py
 tests/services/test_pkm_service_store_domain_data.py
 tests/test_pkm_upgrade_routes.py
 tests/test_pkm_upgrade_service.py

--- a/consent-protocol/tests/test_kai_consent_grant_scope_escalation.py
+++ b/consent-protocol/tests/test_kai_consent_grant_scope_escalation.py
@@ -1,0 +1,98 @@
+"""Prove that privileged scopes cannot be self-granted via POST /kai/consent/grant."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routes.kai import consent as consent_module
+
+_app = FastAPI()
+_app.include_router(consent_module.router, prefix="/kai")
+
+
+class TestScopeBlocklist:
+    """Canonical attach point: POST /kai/consent/grant scope validation."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        _app.dependency_overrides.clear()
+        yield
+        _app.dependency_overrides.clear()
+
+    def _client(self):
+        return TestClient(_app, raise_server_exceptions=False)
+
+    def _post_grant(self, scopes):
+        _app.dependency_overrides[consent_module.require_firebase_auth] = lambda: "user_123"
+
+        with patch.object(consent_module, "verify_user_id_match"):
+            resp = self._client().post(
+                "/kai/consent/grant",
+                json={"user_id": "user_123", "scopes": scopes},
+            )
+        return resp
+
+    def test_vault_owner_blocked(self):
+        """vault.owner scope must be rejected with 403 and not echoed in the response."""
+        resp = self._post_grant(["vault.owner"])
+        assert resp.status_code == 403
+        assert "vault.owner" not in resp.json().get("detail", "")
+
+    def test_agent_nav_revoke_blocked(self):
+        """agent.nav.revoke scope must be rejected with 403 and not echoed in the response."""
+        resp = self._post_grant(["agent.nav.revoke"])
+        assert resp.status_code == 403
+        assert "agent.nav.revoke" not in resp.json().get("detail", "")
+
+    def test_pkm_write_blocked(self):
+        """pkm.write scope must be rejected with 403 and not echoed in the response."""
+        resp = self._post_grant(["pkm.write"])
+        assert resp.status_code == 403
+        assert "pkm.write" not in resp.json().get("detail", "")
+
+    def test_safe_attr_scope_accepted(self):
+        """Safe attr.financial.* scopes must still be accepted."""
+        _app.dependency_overrides[consent_module.require_firebase_auth] = lambda: "user_123"
+
+        with patch.object(consent_module, "verify_user_id_match"), \
+             patch.object(consent_module, "issue_token") as mock_issue:
+            mock_token = MagicMock()
+            mock_token.token = "fake_token"  # noqa: S105
+            mock_token.expires_at = 9999999999
+            mock_issue.return_value = mock_token
+
+            with patch.object(consent_module.ConsentDBService, "insert_internal_event"):
+                resp = self._client().post(
+                    "/kai/consent/grant",
+                    json={"user_id": "user_123", "scopes": ["attr.financial.*"]},
+                )
+
+        assert resp.status_code == 200
+        assert "tokens" in resp.json()
+
+    def test_kai_agent_scope_accepted(self):
+        """Safe agent.kai.* scopes must still be accepted."""
+        _app.dependency_overrides[consent_module.require_firebase_auth] = lambda: "user_123"
+
+        with patch.object(consent_module, "verify_user_id_match"), \
+             patch.object(consent_module, "issue_token") as mock_issue:
+            mock_token = MagicMock()
+            mock_token.token = "fake_token"  # noqa: S105
+            mock_token.expires_at = 9999999999
+            mock_issue.return_value = mock_token
+
+            with patch.object(consent_module.ConsentDBService, "insert_internal_event"):
+                resp = self._client().post(
+                    "/kai/consent/grant",
+                    json={"user_id": "user_123", "scopes": ["agent.kai.analyze"]},
+                )
+
+        assert resp.status_code == 200
+        assert "tokens" in resp.json()
+
+    def test_out_of_contract_attr_domain_still_rejected(self):
+        """attr.health.* must still be rejected by the existing Kai-contract check."""
+        resp = self._post_grant(["attr.health.*"])
+        assert resp.status_code == 400


### PR DESCRIPTION
## Summary

Narrows to the core privilege escalation risk: blocking self-issuance of privileged scopes.

## Problem

Kai /consent/grant endpoint was not checking whether requested scopes should be restricted to admin-only assignment. A user could request vault.owner, agent.nav.revoke, or pkm.write for themselves.

## Fix

- Adds _SCOPE_BLOCKLIST = {'vault.owner', 'agent.nav.revoke', 'pkm.write'}
- Calls _assert_scope_allowed() before token issuance (line 93)
- Returns 403 with opaque message if blocklist scope requested
- Canonical attach point: api.routes.kai.consent lines 30-42

## Test plan

- Token request for vault.owner returns 403
- Token request for agent.nav.revoke returns 403
- Token request for pkm.write returns 403
- Allowed scopes (attr.financial.*, agent.kai.analyze) still grant normally
