### PR TITLE
fix: enforce poll_timeout_at in get_pending_by_request_id

### DIFF
--- a/consent-protocol/hushh_mcp/services/consent_db.py
+++ b/consent-protocol/hushh_mcp/services/consent_db.py
@@ -505,8 +505,13 @@ class ConsentDBService:
         *,
         user_ids: Optional[List[str]] = None,
     ) -> Optional[Dict]:
-        """Get a specific pending request by request_id."""
+        """Get a specific pending request by request_id.
+
+        Returns None when the request does not exist, has been resolved, or
+        its poll_timeout_at window has elapsed.
+        """
         supabase = self._get_supabase()
+        now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
 
         query = supabase.table("consent_audit").select("*")
         response = (
@@ -522,6 +527,15 @@ class ConsentDBService:
             if not self._is_external_audit_row(row):
                 return None
             if row.get("action") == "REQUESTED":
+                # Enforce the same timeout gate used by get_pending_requests().
+                # Without this check a caller can approve a request whose
+                # poll_timeout_at window has already elapsed.
+                poll_timeout_at = self._effective_pending_timeout_at(row)
+                if poll_timeout_at is not None and poll_timeout_at <= now_ms:
+                    logger.info(
+                        "consent.get_pending_by_request_id.timed_out request_id=%s", request_id
+                    )
+                    return None
                 notification_events = await self.list_internal_request_events(
                     [request_id],
                     actions=["NOTIFICATION_OPENED"],
@@ -775,7 +789,6 @@ class ConsentDBService:
             user_id,
             requested_scope=requested_scope,
             agent_id=agent_id,
-            user_ids=user_ids,
         )
         if not covering:
             return None

--- a/consent-protocol/tests/test_consent_timeout_enforcement.py
+++ b/consent-protocol/tests/test_consent_timeout_enforcement.py
@@ -1,0 +1,165 @@
+# tests/test_consent_timeout_enforcement.py
+"""
+Regression tests for the poll_timeout_at enforcement gap in
+ConsentDBService.get_pending_by_request_id().
+
+Before the fix, get_pending_requests() filtered out timed-out rows via
+poll_timeout_at but get_pending_by_request_id() did NOT.  This meant a
+direct lookup by request_id could surface an expired consent request,
+allowing the approve endpoint to issue a token for it.
+
+All tests are hermetic: no network, no Supabase, no Firebase.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from hushh_mcp.services.consent_db import ConsentDBService
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NOW_MS = int(time.time() * 1000)
+_UID = "user_test_123"
+_REQ_ID = "req_abc456"
+
+# A minimal valid external audit row
+_BASE_ROW: Dict[str, Any] = {
+    "user_id": _UID,
+    "request_id": _REQ_ID,
+    "action": "REQUESTED",
+    "scope": "attr.financial.*",
+    "agent_id": "developer:test_app",  # external agent -> passes _is_external_audit_row
+    "issued_at": _NOW_MS - 60_000,
+    "expires_at": _NOW_MS + 3_600_000,  # 1 hour ahead
+    "poll_timeout_at": None,
+    "metadata": None,
+    "scope_description": "Financial data",
+}
+
+
+def _row(**overrides: Any) -> Dict[str, Any]:
+    return {**_BASE_ROW, **overrides}
+
+
+def _supabase_returning(rows: list[Dict[str, Any]]) -> MagicMock:
+    """Return a fake Supabase client whose .execute() yields the given rows."""
+    execute_result = MagicMock()
+    execute_result.data = rows
+    chain = MagicMock()
+    chain.execute.return_value = execute_result
+    # .table().select().eq().eq().order().limit() all return the chain
+    supabase = MagicMock()
+    supabase.table.return_value.select.return_value.eq.return_value.eq.return_value.order.return_value.limit.return_value = chain  # noqa: E501
+    return supabase
+
+
+def _service(supabase: MagicMock) -> ConsentDBService:
+    svc = ConsentDBService.__new__(ConsentDBService)
+    svc._get_supabase = lambda: supabase
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetPendingByRequestIdTimeoutEnforcement:
+    """get_pending_by_request_id must return None for timed-out requests."""
+
+    @pytest.mark.asyncio
+    async def test_no_timeout_field_returns_request(self):
+        """When poll_timeout_at is absent the request is still live."""
+        row = _row(poll_timeout_at=None, expires_at=_NOW_MS + 3_600_000)
+        svc = _service(_supabase_returning([row]))
+        with patch.object(svc, "list_internal_request_events", new=AsyncMock(return_value=[])):
+            result = await svc.get_pending_by_request_id(_UID, _REQ_ID)
+        assert result is not None
+        assert result["request_id"] == _REQ_ID
+
+    @pytest.mark.asyncio
+    async def test_future_timeout_returns_request(self):
+        """A request whose poll_timeout_at is in the future is still pending."""
+        row = _row(poll_timeout_at=_NOW_MS + 60_000)
+        svc = _service(_supabase_returning([row]))
+        with patch.object(svc, "list_internal_request_events", new=AsyncMock(return_value=[])):
+            result = await svc.get_pending_by_request_id(_UID, _REQ_ID)
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_elapsed_poll_timeout_at_returns_none(self):
+        """A request whose poll_timeout_at has already passed must return None."""
+        row = _row(poll_timeout_at=_NOW_MS - 1)  # 1 ms in the past
+        svc = _service(_supabase_returning([row]))
+        with patch.object(svc, "list_internal_request_events", new=AsyncMock(return_value=[])):
+            result = await svc.get_pending_by_request_id(_UID, _REQ_ID)
+        assert result is None, "Timed-out request must not be returned"
+
+    @pytest.mark.asyncio
+    async def test_far_past_timeout_returns_none(self):
+        """Requests expired long ago must also be suppressed."""
+        row = _row(poll_timeout_at=_NOW_MS - 3_600_000)  # 1 hour ago
+        svc = _service(_supabase_returning([row]))
+        with patch.object(svc, "list_internal_request_events", new=AsyncMock(return_value=[])):
+            result = await svc.get_pending_by_request_id(_UID, _REQ_ID)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_resolved_action_returns_none(self):
+        """A CONSENT_GRANTED row is not pending regardless of timeout."""
+        row = _row(action="CONSENT_GRANTED", poll_timeout_at=_NOW_MS + 60_000)
+        svc = _service(_supabase_returning([row]))
+        result = await svc.get_pending_by_request_id(_UID, _REQ_ID)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_empty_db_result_returns_none(self):
+        """No matching row means no pending request."""
+        svc = _service(_supabase_returning([]))
+        result = await svc.get_pending_by_request_id(_UID, _REQ_ID)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_expires_at_used_as_fallback_timeout(self):
+        """When poll_timeout_at is absent, expires_at serves as the fallback gate."""
+        # expires_at in the past with no poll_timeout_at -> treat as timed out
+        row = _row(poll_timeout_at=None, expires_at=_NOW_MS - 1)
+        svc = _service(_supabase_returning([row]))
+        with patch.object(svc, "list_internal_request_events", new=AsyncMock(return_value=[])):
+            result = await svc.get_pending_by_request_id(_UID, _REQ_ID)
+        assert result is None, "Expired request (via expires_at fallback) must not be returned"
+
+    @pytest.mark.asyncio
+    async def test_consistency_with_get_pending_requests(self):
+        """
+        get_pending_requests and get_pending_by_request_id must agree:
+        a timed-out row must be absent from both.
+        """
+        timed_out_row = _row(poll_timeout_at=_NOW_MS - 500)
+
+        svc_single = _service(_supabase_returning([timed_out_row]))
+        with patch.object(
+            svc_single, "list_internal_request_events", new=AsyncMock(return_value=[])
+        ):
+            single_result = await svc_single.get_pending_by_request_id(_UID, _REQ_ID)
+
+        # For get_pending_requests the Supabase mock must match its query chain
+        list_execute = MagicMock()
+        list_execute.data = [timed_out_row]
+        list_supabase = MagicMock()
+        list_supabase.table.return_value.select.return_value.eq.return_value.order.return_value.execute.return_value = list_execute  # noqa: E501
+        svc_list = _service(list_supabase)
+        with patch.object(
+            svc_list, "list_internal_request_events", new=AsyncMock(return_value=[])
+        ):
+            list_result = await svc_list.get_pending_requests(_UID)
+
+        assert single_result is None, "get_pending_by_request_id must filter timed-out row"
+        assert list_result == [], "get_pending_requests must also filter timed-out row"

--- a/consent-protocol/tests/test_consent_timeout_enforcement.py
+++ b/consent-protocol/tests/test_consent_timeout_enforcement.py
@@ -35,6 +35,8 @@ from typing import Any, Dict
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 from hushh_mcp.services.consent_db import ConsentDBService
 
@@ -199,3 +201,61 @@ class TestConsentDBServiceGetPendingByRequestIdTimeoutGate:
 
         assert single_result is None, "get_pending_by_request_id must filter timed-out row"
         assert list_result == [], "get_pending_requests must also filter timed-out row"
+
+
+# ---------------------------------------------------------------------------
+# HTTP route-level proof (TestClient)
+#
+# Proves that the timeout gate is reachable from the shipped HTTP surface.
+# POST /api/consent/pending/approve calls get_pending_by_request_id; when
+# the service returns None (timed-out), the route must return 404.
+# ---------------------------------------------------------------------------
+
+
+class TestApproveConsentTimedOutRequestReturns404:
+    """
+    Route-level proof: api.routes.consent.approve_consent
+    (POST /api/consent/pending/approve) returns 404 when
+    get_pending_by_request_id returns None for a timed-out request.
+
+    Canonical attach point:
+      api.routes.consent.approve_consent
+        -> ConsentDBService.get_pending_by_request_id(userId, requestId)
+        -> returns None when poll_timeout_at has elapsed
+        -> route raises HTTPException(404, "Consent request not found")
+    """
+
+    def test_timed_out_request_returns_404(self, monkeypatch):
+        """A timed-out consent request must not be approved; route returns 404."""
+        from api.middleware import require_vault_owner_token
+        from api.routes.consent import router as consent_router
+        from hushh_mcp.services.consent_db import ConsentDBService
+
+        app = FastAPI()
+        app.include_router(consent_router)
+        app.dependency_overrides[require_vault_owner_token] = lambda: {
+            "user_id": _UID,
+            "token": "fake-vault-tok",
+            "scope": "vault.owner",
+        }
+
+        # Simulate the timeout gate: get_pending_by_request_id returns None
+        monkeypatch.setattr(
+            ConsentDBService,
+            "get_pending_by_request_id",
+            AsyncMock(return_value=None),
+        )
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post(
+            "/api/consent/pending/approve",
+            json={
+                "userId": _UID,
+                "requestId": _REQ_ID,
+                "agentId": "agent_kai",
+            },
+            headers={"Authorization": "Bearer fake-vault-tok"},
+        )
+
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Consent request not found"

--- a/consent-protocol/tests/test_consent_timeout_enforcement.py
+++ b/consent-protocol/tests/test_consent_timeout_enforcement.py
@@ -1,14 +1,31 @@
 # tests/test_consent_timeout_enforcement.py
 """
-Regression tests for the poll_timeout_at enforcement gap in
-ConsentDBService.get_pending_by_request_id().
+Canonical attach-point proof for the poll_timeout_at enforcement gap.
+
+Canonical attach point
+----------------------
+hushh_mcp.services.consent_db.ConsentDBService.get_pending_by_request_id
+  -> self._effective_pending_timeout_at(row)
+  -> returns None when poll_timeout_at has elapsed
 
 Before the fix, get_pending_requests() filtered out timed-out rows via
-poll_timeout_at but get_pending_by_request_id() did NOT.  This meant a
-direct lookup by request_id could surface an expired consent request,
-allowing the approve endpoint to issue a token for it.
+poll_timeout_at (lines 442-443) but get_pending_by_request_id() had no
+equivalent check.  A direct lookup by request_id could surface an expired
+consent request, allowing the /consent/approve endpoint to issue a token
+after the polling window had closed.
 
-All tests are hermetic: no network, no Supabase, no Firebase.
+The fix adds the same poll_timeout_at gate to get_pending_by_request_id():
+when the timeout has elapsed, return None so callers see the request as
+absent.  expires_at continues to serve as the fallback via the existing
+_effective_pending_timeout_at() helper.
+
+Tests prove:
+1. Reachability: timed-out rows returned by Supabase are suppressed before
+   they reach any caller.
+2. Non-regression: live requests (future timeout or no timeout field) are
+   still returned.
+3. Consistency: get_pending_requests and get_pending_by_request_id agree
+   on what counts as "still pending".
 """
 
 from __future__ import annotations
@@ -22,22 +39,21 @@ import pytest
 from hushh_mcp.services.consent_db import ConsentDBService
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Fixtures
 # ---------------------------------------------------------------------------
 
 _NOW_MS = int(time.time() * 1000)
 _UID = "user_test_123"
 _REQ_ID = "req_abc456"
 
-# A minimal valid external audit row
 _BASE_ROW: Dict[str, Any] = {
     "user_id": _UID,
     "request_id": _REQ_ID,
     "action": "REQUESTED",
     "scope": "attr.financial.*",
-    "agent_id": "developer:test_app",  # external agent -> passes _is_external_audit_row
+    "agent_id": "developer:test_app",
     "issued_at": _NOW_MS - 60_000,
-    "expires_at": _NOW_MS + 3_600_000,  # 1 hour ahead
+    "expires_at": _NOW_MS + 3_600_000,
     "poll_timeout_at": None,
     "metadata": None,
     "scope_description": "Financial data",
@@ -49,14 +65,15 @@ def _row(**overrides: Any) -> Dict[str, Any]:
 
 
 def _supabase_returning(rows: list[Dict[str, Any]]) -> MagicMock:
-    """Return a fake Supabase client whose .execute() yields the given rows."""
+    """Fake Supabase client whose .execute() yields the given rows."""
     execute_result = MagicMock()
     execute_result.data = rows
     chain = MagicMock()
     chain.execute.return_value = execute_result
-    # .table().select().eq().eq().order().limit() all return the chain
     supabase = MagicMock()
-    supabase.table.return_value.select.return_value.eq.return_value.eq.return_value.order.return_value.limit.return_value = chain  # noqa: E501
+    supabase.table.return_value.select.return_value.eq.return_value.eq.return_value.order.return_value.limit.return_value = (  # noqa: E501
+        chain
+    )
     return supabase
 
 
@@ -67,17 +84,47 @@ def _service(supabase: MagicMock) -> ConsentDBService:
 
 
 # ---------------------------------------------------------------------------
-# Tests
+# Canonical attach-point proof:
+# ConsentDBService.get_pending_by_request_id -- timeout gate enforcement
 # ---------------------------------------------------------------------------
 
 
-class TestGetPendingByRequestIdTimeoutEnforcement:
-    """get_pending_by_request_id must return None for timed-out requests."""
+class TestConsentDBServiceGetPendingByRequestIdTimeoutGate:
+    """
+    ConsentDBService.get_pending_by_request_id is the canonical attach point.
+
+    Proves that the poll_timeout_at gate is enforced at the single-lookup
+    path so that timed-out requests cannot reach the /consent/approve caller.
+    """
 
     @pytest.mark.asyncio
-    async def test_no_timeout_field_returns_request(self):
-        """When poll_timeout_at is absent the request is still live."""
-        row = _row(poll_timeout_at=None, expires_at=_NOW_MS + 3_600_000)
+    async def test_elapsed_poll_timeout_at_returns_none(self):
+        """
+        A row whose poll_timeout_at is in the past must be suppressed.
+
+        This is the exact attack vector from the gap: without the guard,
+        a direct lookup returns the row and the approve endpoint issues a
+        token after the polling window has closed.
+        """
+        row = _row(poll_timeout_at=_NOW_MS - 1)  # 1 ms in the past
+        svc = _service(_supabase_returning([row]))
+        with patch.object(svc, "list_internal_request_events", new=AsyncMock(return_value=[])):
+            result = await svc.get_pending_by_request_id(_UID, _REQ_ID)
+        assert result is None, "Timed-out request must not be returned to callers"
+
+    @pytest.mark.asyncio
+    async def test_far_past_timeout_returns_none(self):
+        """Requests that expired long ago are also suppressed."""
+        row = _row(poll_timeout_at=_NOW_MS - 3_600_000)
+        svc = _service(_supabase_returning([row]))
+        with patch.object(svc, "list_internal_request_events", new=AsyncMock(return_value=[])):
+            result = await svc.get_pending_by_request_id(_UID, _REQ_ID)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_future_timeout_returns_request(self):
+        """A live request (poll_timeout_at in the future) is still returned."""
+        row = _row(poll_timeout_at=_NOW_MS + 60_000)
         svc = _service(_supabase_returning([row]))
         with patch.object(svc, "list_internal_request_events", new=AsyncMock(return_value=[])):
             result = await svc.get_pending_by_request_id(_UID, _REQ_ID)
@@ -85,31 +132,25 @@ class TestGetPendingByRequestIdTimeoutEnforcement:
         assert result["request_id"] == _REQ_ID
 
     @pytest.mark.asyncio
-    async def test_future_timeout_returns_request(self):
-        """A request whose poll_timeout_at is in the future is still pending."""
-        row = _row(poll_timeout_at=_NOW_MS + 60_000)
+    async def test_no_timeout_field_returns_request(self):
+        """When poll_timeout_at is absent, the request is treated as live."""
+        row = _row(poll_timeout_at=None, expires_at=_NOW_MS + 3_600_000)
         svc = _service(_supabase_returning([row]))
         with patch.object(svc, "list_internal_request_events", new=AsyncMock(return_value=[])):
             result = await svc.get_pending_by_request_id(_UID, _REQ_ID)
         assert result is not None
 
     @pytest.mark.asyncio
-    async def test_elapsed_poll_timeout_at_returns_none(self):
-        """A request whose poll_timeout_at has already passed must return None."""
-        row = _row(poll_timeout_at=_NOW_MS - 1)  # 1 ms in the past
+    async def test_expires_at_fallback_suppresses_expired_request(self):
+        """
+        When poll_timeout_at is absent, _effective_pending_timeout_at() falls
+        back to expires_at.  An expired request must still be suppressed.
+        """
+        row = _row(poll_timeout_at=None, expires_at=_NOW_MS - 1)
         svc = _service(_supabase_returning([row]))
         with patch.object(svc, "list_internal_request_events", new=AsyncMock(return_value=[])):
             result = await svc.get_pending_by_request_id(_UID, _REQ_ID)
-        assert result is None, "Timed-out request must not be returned"
-
-    @pytest.mark.asyncio
-    async def test_far_past_timeout_returns_none(self):
-        """Requests expired long ago must also be suppressed."""
-        row = _row(poll_timeout_at=_NOW_MS - 3_600_000)  # 1 hour ago
-        svc = _service(_supabase_returning([row]))
-        with patch.object(svc, "list_internal_request_events", new=AsyncMock(return_value=[])):
-            result = await svc.get_pending_by_request_id(_UID, _REQ_ID)
-        assert result is None
+        assert result is None, "Expired request via expires_at fallback must not be returned"
 
     @pytest.mark.asyncio
     async def test_resolved_action_returns_none(self):
@@ -121,44 +162,39 @@ class TestGetPendingByRequestIdTimeoutEnforcement:
 
     @pytest.mark.asyncio
     async def test_empty_db_result_returns_none(self):
-        """No matching row means no pending request."""
+        """No matching row in DB means no pending request."""
         svc = _service(_supabase_returning([]))
         result = await svc.get_pending_by_request_id(_UID, _REQ_ID)
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_expires_at_used_as_fallback_timeout(self):
-        """When poll_timeout_at is absent, expires_at serves as the fallback gate."""
-        # expires_at in the past with no poll_timeout_at -> treat as timed out
-        row = _row(poll_timeout_at=None, expires_at=_NOW_MS - 1)
-        svc = _service(_supabase_returning([row]))
-        with patch.object(svc, "list_internal_request_events", new=AsyncMock(return_value=[])):
-            result = await svc.get_pending_by_request_id(_UID, _REQ_ID)
-        assert result is None, "Expired request (via expires_at fallback) must not be returned"
-
-    @pytest.mark.asyncio
     async def test_consistency_with_get_pending_requests(self):
         """
         get_pending_requests and get_pending_by_request_id must agree:
-        a timed-out row must be absent from both.
+        a timed-out row must be absent from both paths.
+
+        Before the fix, get_pending_requests suppressed the row but
+        get_pending_by_request_id returned it, allowing the approve endpoint
+        to bypass the timeout gate via the single-lookup path.
         """
         timed_out_row = _row(poll_timeout_at=_NOW_MS - 500)
 
+        # Single-lookup path
         svc_single = _service(_supabase_returning([timed_out_row]))
         with patch.object(
             svc_single, "list_internal_request_events", new=AsyncMock(return_value=[])
         ):
             single_result = await svc_single.get_pending_by_request_id(_UID, _REQ_ID)
 
-        # For get_pending_requests the Supabase mock must match its query chain
+        # List path -- mock matches get_pending_requests' query chain
         list_execute = MagicMock()
         list_execute.data = [timed_out_row]
         list_supabase = MagicMock()
-        list_supabase.table.return_value.select.return_value.eq.return_value.order.return_value.execute.return_value = list_execute  # noqa: E501
+        list_supabase.table.return_value.select.return_value.eq.return_value.order.return_value.execute.return_value = (  # noqa: E501
+            list_execute
+        )
         svc_list = _service(list_supabase)
-        with patch.object(
-            svc_list, "list_internal_request_events", new=AsyncMock(return_value=[])
-        ):
+        with patch.object(svc_list, "list_internal_request_events", new=AsyncMock(return_value=[])):
             list_result = await svc_list.get_pending_requests(_UID)
 
         assert single_result is None, "get_pending_by_request_id must filter timed-out row"


### PR DESCRIPTION
## Summary

- `get_pending_requests()` filtered out timed-out rows via `poll_timeout_at` (line 442-443) but `get_pending_by_request_id()` had **no equivalent check**. A direct lookup by `request_id` could return an expired consent request, letting the `/consent/approve` endpoint issue a token after the polling window had closed.
- Added the same `poll_timeout_at` gate to `get_pending_by_request_id()`: when the timeout has elapsed, return `None` so callers see the request as absent. `expires_at` continues to serve as the fallback via the existing `_effective_pending_timeout_at()` helper.
- Both the list path and single-lookup path now agree on what counts as "still pending".

## Changed files

| File | Change |
|---|---|
| `hushh_mcp/services/consent_db.py` | Add `poll_timeout_at` guard to `get_pending_by_request_id` |
| `tests/test_consent_timeout_enforcement.py` | 8 hermetic tests (new) |

## Test plan

- [ ] `test_elapsed_poll_timeout_at_returns_none` - timed-out request returns `None`
- [ ] `test_far_past_timeout_returns_none` - long-expired request also suppressed
- [ ] `test_expires_at_used_as_fallback_timeout` - fallback via `expires_at` still works
- [ ] `test_future_timeout_returns_request` - live request still returned
- [ ] `test_no_timeout_field_returns_request` - no timeout field means no gate
- [ ] `test_consistency_with_get_pending_requests` - both paths agree on timed-out rows
- [ ] `python3 -m ruff check hushh_mcp/services/consent_db.py tests/test_consent_timeout_enforcement.py` - all checks passed