### PR TITLE
fix: harden db_proxy auth responses against information disclosure

### DIFF
--- a/consent-protocol/api/routes/db_proxy.py
+++ b/consent-protocol/api/routes/db_proxy.py
@@ -743,11 +743,13 @@ async def validate_vault_owner_token(consent_token: str, user_id: str) -> None:
 
     if token_obj.scope != ConsentScope.VAULT_OWNER:
         logger.warning(
-            f"Insufficient scope: {token_obj.scope.value} (requires {ConsentScope.VAULT_OWNER.value})"
+            "vault.scope_mismatch token_scope=%s required=%s",
+            token_obj.scope.value,
+            ConsentScope.VAULT_OWNER.value,
         )
         raise HTTPException(
             status_code=403,
-            detail=f"Insufficient scope: {token_obj.scope.value}. VAULT_OWNER scope required.",
+            detail="Insufficient permissions.",
         )
 
     if str(token_obj.user_id) != user_id:

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -19,3 +19,4 @@ tests/test_stream_path_query_bounds_cwe400.py
 tests/performance/test_market_cache_instrumentation.py
 tests/test_llm_operon_stream_error_leak.py
 tests/test_stream_agent_thinking_gemini_error_cwe209.py
+tests/test_db_proxy_vault_owner_scope_disclosure.py

--- a/consent-protocol/tests/test_db_proxy_vault_owner_scope_disclosure.py
+++ b/consent-protocol/tests/test_db_proxy_vault_owner_scope_disclosure.py
@@ -1,0 +1,60 @@
+"""
+Regression test for CWE-209 scope disclosure in db_proxy.validate_vault_owner_token.
+
+Canonical attach point: api.routes.db_proxy.validate_vault_owner_token
+  -> raises HTTPException(403) when token_obj.scope != ConsentScope.VAULT_OWNER
+
+Before the fix, the 403 detail echoed the token's actual scope value
+(f"Insufficient scope: {scope}. VAULT_OWNER scope required."), letting an
+unauthenticated caller probe what scope a compromised token holds
+(CWE-209 / CWE-203 oracle). The fix replaces this with a static opaque
+message; the actual scope is logged server-side only.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes import db_proxy
+from hushh_mcp.constants import ConsentScope
+
+
+class TestValidateVaultOwnerTokenScopeDisclosure:
+    @pytest.mark.asyncio
+    async def test_insufficient_scope_returns_opaque_detail(self, monkeypatch):
+        """403 detail must not include the token's actual scope value."""
+
+        async def _wrong_scope(token, scope):
+            return (
+                True,
+                None,
+                SimpleNamespace(user_id="user_123", scope=ConsentScope.PKM_READ),
+            )
+
+        monkeypatch.setattr(db_proxy, "validate_token_with_db", _wrong_scope)
+
+        with pytest.raises(HTTPException) as exc:
+            await db_proxy.validate_vault_owner_token("weak-token", "user_123")
+
+        assert exc.value.status_code == 403
+        assert exc.value.detail == "Insufficient permissions."
+        assert "pkm.read" not in str(exc.value.detail).lower()
+        assert "vault.owner" not in str(exc.value.detail).lower()
+
+    @pytest.mark.asyncio
+    async def test_correct_scope_passes_without_error(self, monkeypatch):
+        """A token with the correct VAULT_OWNER scope must not raise."""
+
+        async def _correct_scope(token, scope):
+            return (
+                True,
+                None,
+                SimpleNamespace(user_id="user_123", scope=ConsentScope.VAULT_OWNER),
+            )
+
+        monkeypatch.setattr(db_proxy, "validate_token_with_db", _correct_scope)
+
+        await db_proxy.validate_vault_owner_token("good-token", "user_123")


### PR DESCRIPTION
## Summary

Narrows db_proxy auth response hardening to the core CWE-209 issue: scope disclosure in 403 responses.

## Problem

When a token lacks VAULT_OWNER scope, validate_vault_owner_token() returned:
```
detail=f"Insufficient scope: {token_obj.scope.value}. VAULT_OWNER scope required."
```

This leaks the token's actual scope to the client, enabling CWE-209 (information disclosure) and CWE-203 (oracle attack) where unauthenticated probing reveals what scopes a compromised token holds.

## Fix

- Returns opaque detail: "Insufficient permissions."
- Logs actual scope server-side: "vault.scope_mismatch token_scope=%s required=%s"
- Canonical attach point: api.routes.db_proxy.validate_vault_owner_token (line 744-751)

## Test plan

- Token with wrong scope returns 403 with opaque message
- Actual scope is logged but not exposed to client
- All checks passing
