### PR TITLE
fix: require Firebase auth on POST /api/consent/logout

### DIFF
--- a/consent-protocol/tests/test_logout_auth.py
+++ b/consent-protocol/tests/test_logout_auth.py
@@ -1,0 +1,129 @@
+# tests/test_logout_auth.py
+"""
+Regression tests for the missing authentication on POST /api/consent/logout.
+
+Before the fix the endpoint had no authentication: any caller could pass any
+userId and receive {"status": "success"} without proving their identity.
+
+After the fix the endpoint:
+1. Requires a valid Firebase ID token in the Authorization header.
+2. Validates that request.userId matches the authenticated Firebase UID.
+3. Returns 401 for missing/invalid tokens and 403 for user mismatches.
+
+All tests are hermetic: no network, no DB, no Firebase calls.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from api.routes import session
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(session.router)
+    return app
+
+
+def _logout_payload(user_id: str = "user_123") -> dict[str, str]:
+    return {"userId": user_id}
+
+
+# ---------------------------------------------------------------------------
+# Authentication requirement
+# ---------------------------------------------------------------------------
+
+
+def test_logout_missing_auth_header_returns_401(monkeypatch):
+    """Logout without any Authorization header must be rejected."""
+
+    def _raise_missing(_: str | None) -> str:
+        raise HTTPException(status_code=401, detail="Missing Authorization header")
+
+    monkeypatch.setattr(session, "verify_firebase_bearer", _raise_missing)
+
+    client = TestClient(_build_app(), raise_server_exceptions=False)
+    response = client.post("/api/consent/logout", json=_logout_payload())
+
+    assert response.status_code == 401
+
+
+def test_logout_invalid_firebase_token_returns_401(monkeypatch):
+    """Logout with an invalid Firebase token must be rejected."""
+
+    def _raise_invalid(_: str | None) -> str:
+        raise ValueError("malformed firebase token")
+
+    monkeypatch.setattr(session, "verify_firebase_bearer", _raise_invalid)
+
+    client = TestClient(_build_app(), raise_server_exceptions=False)
+    response = client.post(
+        "/api/consent/logout",
+        json=_logout_payload(),
+        headers={"Authorization": "Bearer bad-token"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid token"
+
+
+def test_logout_unexpected_verifier_failure_returns_500(monkeypatch):
+    """Unexpected verifier exception must return 500, not expose internals."""
+
+    def _raise_unexpected(_: str | None) -> str:
+        raise RuntimeError("firebase verifier unavailable")
+
+    monkeypatch.setattr(session, "verify_firebase_bearer", _raise_unexpected)
+
+    client = TestClient(_build_app(), raise_server_exceptions=False)
+    response = client.post(
+        "/api/consent/logout",
+        json=_logout_payload(),
+        headers={"Authorization": "Bearer any-token"},
+    )
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Internal server error"
+
+
+# ---------------------------------------------------------------------------
+# User ownership check
+# ---------------------------------------------------------------------------
+
+
+def test_logout_user_mismatch_returns_403(monkeypatch):
+    """Attempting to log out a different user must be rejected with 403."""
+    monkeypatch.setattr(session, "verify_firebase_bearer", lambda _: "other_user")
+
+    client = TestClient(_build_app(), raise_server_exceptions=False)
+    response = client.post(
+        "/api/consent/logout",
+        json=_logout_payload("user_123"),  # trying to logout user_123
+        headers={"Authorization": "Bearer valid-token"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "userId mismatch"
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_logout_valid_auth_and_matching_user_returns_success(monkeypatch):
+    """Authenticated logout for the correct user must succeed."""
+    monkeypatch.setattr(session, "verify_firebase_bearer", lambda _: "user_123")
+
+    client = TestClient(_build_app(), raise_server_exceptions=False)
+    response = client.post(
+        "/api/consent/logout",
+        json=_logout_payload("user_123"),
+        headers={"Authorization": "Bearer valid-token"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "success"

--- a/consent-protocol/tests/test_logout_auth.py
+++ b/consent-protocol/tests/test_logout_auth.py
@@ -1,16 +1,21 @@
 # tests/test_logout_auth.py
 """
-Regression tests for the missing authentication on POST /api/consent/logout.
+Route-level caller proof for the missing authentication fix on POST /api/consent/logout.
 
-Before the fix the endpoint had no authentication: any caller could pass any
+Canonical attach point
+----------------------
+api.routes.session.logout_session
+  -> POST /api/consent/logout
+  -> requires Authorization: Bearer <firebase-id-token>
+  -> verifies request.userId == firebase-verified UID
+  -> 401 for missing/invalid token, 403 for userId mismatch
+
+Before the fix this endpoint had no authentication: any caller could pass any
 userId and receive {"status": "success"} without proving their identity.
 
-After the fix the endpoint:
-1. Requires a valid Firebase ID token in the Authorization header.
-2. Validates that request.userId matches the authenticated Firebase UID.
-3. Returns 401 for missing/invalid tokens and 403 for user mismatches.
-
-All tests are hermetic: no network, no DB, no Firebase calls.
+All tests exercise the route through TestClient (real HTTP stack) with
+api.routes.session.verify_firebase_bearer monkeypatched.
+No network, no DB, no Firebase calls.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

`POST /api/consent/logout` had **no authentication at all**. Any unauthenticated caller could:
```bash
curl -X POST /api/consent/logout -d '{"userId": "<any-uid>"}'
# → {"status": "success", "message": "Session tokens marked for revocation"}
```

The endpoint was already a no-op stub (did not actually revoke any token), but the lack of auth also means an adversary could:
- Trigger spurious logout logs for any user
- Race a real logout before a user can complete sensitive operations (DoS on consent flow)
- Harvest valid userId strings by brute-forcing UUIDs (timing/response oracle)

**Fix**: add Firebase ID token verification matching the same pattern used by `issue_session_token`:
1. Extract and verify the `Authorization: Bearer <firebase-id-token>` header
2. Reject 401 for missing / invalid tokens (generic message, reason logged server-side)
3. Reject 403 when `request.userId` does not match the verified Firebase UID
4. A doc comment records that full session-token revocation requires additional DB-backed work (storing issued token strings at issuance time)

## Changed files

| File | Change |
|---|---|
| `api/routes/session.py` | Firebase auth + userId ownership check on logout |
| `tests/test_logout_auth.py` | 5 new hermetic tests |

## Test plan

- [ ] Missing `Authorization` header returns 401
- [ ] Invalid Firebase token returns 401 with generic message
- [ ] Unexpected verifier exception returns 500 without leaking internals
- [ ] `userId` mismatch with verified UID returns 403
- [ ] Valid authenticated logout for own userId returns 200 with success status
- [ ] `python3 -m ruff check api/routes/session.py tests/test_logout_auth.py` - all checks passed