### PR TITLE
fix(middleware): stop leaking token validation reasons in HTTP responses (CWE-209)

### DIFF
--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -19,3 +19,4 @@ tests/test_stream_path_query_bounds_cwe400.py
 tests/performance/test_market_cache_instrumentation.py
 tests/test_llm_operon_stream_error_leak.py
 tests/test_stream_agent_thinking_gemini_error_cwe209.py
+tests/test_middleware_token_reason_leak.py


### PR DESCRIPTION
## Problem

`require_vault_owner_token` (line 173) and `require_consent_scope` (line 196) in `api/middleware.py` both raised:

```python
raise _auth_error(f"Invalid token: {reason}")
```

The `reason` string comes directly from `validate_token_with_db` and can contain:
- Internal scope names (`"Scope mismatch: token has 'pkm.read', but 'vault.owner' required"`)
- Token state details (`"Token revoked"`, `"Token expired"`)
- Potentially database DSNs or connection strings if an exception bubbles up

Any unauthenticated caller can observe these strings in the HTTP response body, creating a CWE-209 information-disclosure vulnerability and a CWE-203 timing/oracle side-channel (different failure modes produce different messages).

## Fix

Replace both `f"Invalid token: {reason}"` strings with the opaque sentinel `"Token validation failed."`. The existing `logger.warning("Token validation failed: %s", reason)` calls are preserved, so server-side diagnostics are unchanged.

```diff
-raise _auth_error(f"Invalid token: {reason}")
+raise _auth_error("Token validation failed.")
```

Applied in two locations:
- `require_vault_owner_token` (line 211)
- `require_consent_scope` inner function `_require_scope_token` (line 237)

## Tests

`tests/test_middleware_token_reason_leak.py` - 6 hermetic tests:

| Test | What it checks |
|------|---------------|
| `test_vault_owner_token_hides_reason_in_detail` | Scope-mismatch reason absent from detail |
| `test_vault_owner_token_returns_generic_message` | Exact opaque string returned |
| `test_vault_owner_token_hides_db_dsn_in_detail` | DB DSN absent from detail |
| `test_consent_scope_hides_reason_in_detail` | Same for `require_consent_scope` |
| `test_consent_scope_returns_generic_message` | Exact opaque string for scoped dep |
| `test_distinct_reasons_produce_identical_detail` | Four different reasons produce one detail value (no oracle) |

All 6 pass. 21 pre-existing middleware tests unaffected.

## References

- CWE-209: Generation of Error Message Containing Sensitive Information
- CWE-203: Observable Discrepancy
- Same fix pattern as previous PRs for `db_proxy.py`, `kai/analyze.py`, `kai/stream.py`, `consent.py`