### PR TITLE
fix: harden consent and vault request validation

### DIFF
--- a/consent-protocol/api/routes/consent.py
+++ b/consent-protocol/api/routes/consent.py
@@ -211,54 +211,54 @@ async def _hydrate_pending_requester_labels(pending_items: list[dict]) -> list[d
 
 
 class CancelConsentRequest(BaseModel):
-    userId: str
-    requestId: str
+    userId: str = Field(min_length=1, max_length=128)
+    requestId: str = Field(min_length=1, max_length=128)
 
 
 class PendingConsentOpenedRequest(BaseModel):
-    userId: str
-    requestId: str | None = None
-    bundleId: str | None = None
-    openedVia: str | None = None
+    userId: str = Field(min_length=1, max_length=128)
+    requestId: str | None = Field(default=None, max_length=128)
+    bundleId: str | None = Field(default=None, max_length=128)
+    openedVia: str | None = Field(default=None, max_length=64)
 
 
 class GenericConsentRequestCreate(BaseModel):
-    subject_user_id: str
-    requester_actor_type: str = "ria"
-    subject_actor_type: str = "investor"
-    scope_template_id: str
-    selected_scope: str | None = None
-    duration_mode: str = "preset"
-    duration_hours: int | None = None
-    firm_id: str | None = None
-    reason: str | None = None
+    subject_user_id: str = Field(min_length=1, max_length=128)
+    requester_actor_type: str = Field(default="ria", max_length=64)
+    subject_actor_type: str = Field(default="investor", max_length=64)
+    scope_template_id: str = Field(min_length=1, max_length=256)
+    selected_scope: str | None = Field(default=None, max_length=256)
+    duration_mode: str = Field(default="preset", max_length=64)
+    duration_hours: int | None = Field(default=None, ge=1, le=8760)
+    firm_id: str | None = Field(default=None, max_length=128)
+    reason: str | None = Field(default=None, max_length=1000)
 
 
 class RelationshipDisconnectRequest(BaseModel):
-    investor_user_id: str | None = None
-    ria_profile_id: str | None = None
+    investor_user_id: str | None = Field(default=None, max_length=128)
+    ria_profile_id: str | None = Field(default=None, max_length=128)
 
 
 class RefreshExportUploadRequest(BaseModel):
-    userId: str
-    consentToken: str
-    encryptedData: str
-    encryptedIv: str
-    encryptedTag: str
-    wrappedExportKey: str
-    wrappedKeyIv: str
-    wrappedKeyTag: str
-    senderPublicKey: str
-    wrappingAlg: str | None = None
-    connectorKeyId: str | None = None
-    sourceContentRevision: int | None = None
-    sourceManifestRevision: int | None = None
+    userId: str = Field(min_length=1, max_length=128)
+    consentToken: str = Field(min_length=1, max_length=2048)
+    encryptedData: str = Field(min_length=1)
+    encryptedIv: str = Field(min_length=1, max_length=256)
+    encryptedTag: str = Field(min_length=1, max_length=256)
+    wrappedExportKey: str = Field(min_length=1, max_length=8192)
+    wrappedKeyIv: str = Field(min_length=1, max_length=256)
+    wrappedKeyTag: str = Field(min_length=1, max_length=256)
+    senderPublicKey: str = Field(min_length=1, max_length=8192)
+    wrappingAlg: str | None = Field(default=None, max_length=64)
+    connectorKeyId: str | None = Field(default=None, max_length=128)
+    sourceContentRevision: int | None = Field(default=None, ge=1)
+    sourceManifestRevision: int | None = Field(default=None, ge=1)
 
 
 class RefreshExportFailureRequest(BaseModel):
-    userId: str
-    consentToken: str
-    lastError: str | None = None
+    userId: str = Field(min_length=1, max_length=128)
+    consentToken: str = Field(min_length=1, max_length=2048)
+    lastError: str | None = Field(default=None, max_length=2000)
 
 
 @router.get("/pending")

--- a/consent-protocol/api/utils/firebase_auth.py
+++ b/consent-protocol/api/utils/firebase_auth.py
@@ -6,11 +6,14 @@ Used by endpoints that require identity verification (Firebase Auth boundary).
 
 from __future__ import annotations
 
+import logging
 from typing import Optional
 
 from fastapi import HTTPException
 
 from api.utils.firebase_admin import ensure_firebase_auth_admin, get_firebase_auth_app
+
+logger = logging.getLogger(__name__)
 
 
 def verify_firebase_bearer(authorization: Optional[str]) -> str:
@@ -29,9 +32,9 @@ def verify_firebase_bearer(authorization: Optional[str]) -> str:
     if not id_token:
         raise HTTPException(status_code=401, detail="Missing bearer token")
 
-    try:
-        from firebase_admin import auth as firebase_auth
+    from firebase_admin import auth as firebase_auth
 
+    try:
         firebase_app = get_firebase_auth_app()
         decoded = firebase_auth.verify_id_token(id_token, app=firebase_app)
         uid = decoded.get("uid")
@@ -40,6 +43,22 @@ def verify_firebase_bearer(authorization: Optional[str]) -> str:
         return uid
     except HTTPException:
         raise
-    except Exception:
-        # Do not leak details
-        raise HTTPException(status_code=401, detail="Invalid Firebase ID token")
+    except ValueError as exc:
+        logger.warning("firebase.verify_id_token value_error: %s", exc)
+        raise HTTPException(status_code=401, detail="Invalid Firebase ID token") from None
+    except (
+        firebase_auth.InvalidIdTokenError,
+        firebase_auth.ExpiredIdTokenError,
+        firebase_auth.RevokedIdTokenError,
+        firebase_auth.UserDisabledError,
+    ):
+        raise HTTPException(status_code=401, detail="Invalid Firebase ID token") from None
+    except firebase_auth.CertificateFetchError as exc:
+        logger.error("firebase.verify_id_token certificate_fetch_failed: %s", exc)
+        raise HTTPException(
+            status_code=503,
+            detail="Authentication service temporarily unavailable",
+        ) from None
+    except Exception as exc:
+        logger.exception("firebase.verify_id_token unexpected_error: %s", exc)
+        raise HTTPException(status_code=500, detail="Internal server error") from None

--- a/consent-protocol/bin/consent-protocol
+++ b/consent-protocol/bin/consent-protocol
@@ -20,7 +20,7 @@ Commands:
   format-check
   fix
   typecheck
-  test
+  test [pytest args...]   # default: whole tests/ tree
   test-ci
   security
   accuracy
@@ -107,10 +107,16 @@ case "$COMMAND" in
     exec "$PYTHON_BIN" -m mypy --config-file pyproject.toml --ignore-missing-imports "$@"
     ;;
   test)
-    if command -v uv >/dev/null 2>&1; then
-      run_test_env uv run pytest tests/ -v --tb=short "$@"
+    pytest_targets=()
+    if [ "$#" -eq 0 ]; then
+      pytest_targets=(tests/)
     else
-      run_test_env "$PYTHON_BIN" -m pytest tests/ -v --tb=short "$@"
+      pytest_targets=("$@")
+    fi
+    if command -v uv >/dev/null 2>&1; then
+      run_test_env uv run pytest -v --tb=short "${pytest_targets[@]}"
+    else
+      run_test_env "$PYTHON_BIN" -m pytest -v --tb=short "${pytest_targets[@]}"
     fi
     ;;
   test-ci)

--- a/consent-protocol/tests/test_consent_model_bounds.py
+++ b/consent-protocol/tests/test_consent_model_bounds.py
@@ -1,0 +1,104 @@
+import pytest
+from pydantic import ValidationError
+
+from api.routes.consent import (
+    CancelConsentRequest,
+    GenericConsentRequestCreate,
+    PendingConsentOpenedRequest,
+    RefreshExportFailureRequest,
+    RefreshExportUploadRequest,
+    RelationshipDisconnectRequest,
+)
+
+
+def _upload_valid(**overrides):
+    base = {
+        "userId": "user_1",
+        "consentToken": "token_1",
+        "encryptedData": "ciphertext",
+        "encryptedIv": "iv",
+        "encryptedTag": "tag",
+        "wrappedExportKey": "key",
+        "wrappedKeyIv": "key_iv",
+        "wrappedKeyTag": "key_tag",
+        "senderPublicKey": "public_key",
+    }
+    return {**base, **overrides}
+
+
+def test_cancel_consent_request_rejects_empty_and_long_ids():
+    CancelConsentRequest(userId="u" * 128, requestId="r" * 128)
+    with pytest.raises(ValidationError):
+        CancelConsentRequest(userId="", requestId="request")
+    with pytest.raises(ValidationError):
+        CancelConsentRequest(userId="user", requestId="r" * 129)
+
+
+def test_pending_consent_opened_request_bounds_optional_strings():
+    PendingConsentOpenedRequest(userId="user", openedVia="o" * 64)
+    with pytest.raises(ValidationError):
+        PendingConsentOpenedRequest(userId="user", requestId="r" * 129)
+    with pytest.raises(ValidationError):
+        PendingConsentOpenedRequest(userId="user", bundleId="b" * 129)
+    with pytest.raises(ValidationError):
+        PendingConsentOpenedRequest(userId="user", openedVia="o" * 65)
+
+
+def test_generic_consent_request_bounds_actor_duration_and_text():
+    GenericConsentRequestCreate(
+        subject_user_id="user",
+        scope_template_id="template",
+        requester_actor_type="investor",
+        duration_hours=8760,
+        reason="r" * 1000,
+    )
+    with pytest.raises(ValidationError):
+        GenericConsentRequestCreate(subject_user_id="", scope_template_id="template")
+    with pytest.raises(ValidationError):
+        GenericConsentRequestCreate(
+            subject_user_id="user",
+            scope_template_id="template",
+            duration_hours=0,
+        )
+    with pytest.raises(ValidationError):
+        GenericConsentRequestCreate(
+            subject_user_id="user",
+            scope_template_id="template",
+            reason="r" * 1001,
+        )
+
+
+def test_relationship_disconnect_request_bounds_optional_ids():
+    RelationshipDisconnectRequest(investor_user_id="i" * 128, ria_profile_id="r" * 128)
+    with pytest.raises(ValidationError):
+        RelationshipDisconnectRequest(investor_user_id="i" * 129)
+    with pytest.raises(ValidationError):
+        RelationshipDisconnectRequest(ria_profile_id="r" * 129)
+
+
+def test_refresh_export_upload_request_bounds_large_fields():
+    RefreshExportUploadRequest(
+        **_upload_valid(
+            consentToken="t" * 2048,
+            wrappedExportKey="k" * 8192,
+            senderPublicKey="s" * 8192,
+            sourceContentRevision=1,
+            sourceManifestRevision=1,
+        )
+    )
+    with pytest.raises(ValidationError):
+        RefreshExportUploadRequest(**_upload_valid(consentToken=""))
+    with pytest.raises(ValidationError):
+        RefreshExportUploadRequest(**_upload_valid(wrappedExportKey="k" * 8193))
+    with pytest.raises(ValidationError):
+        RefreshExportUploadRequest(**_upload_valid(sourceContentRevision=0))
+
+
+def test_refresh_export_failure_request_bounds_error_text():
+    RefreshExportFailureRequest(userId="user", consentToken="t" * 2048, lastError="e" * 2000)
+    with pytest.raises(ValidationError):
+        RefreshExportFailureRequest(userId="", consentToken="token")
+    with pytest.raises(ValidationError):
+        RefreshExportFailureRequest(userId="user", consentToken="t" * 2049)
+    with pytest.raises(ValidationError):
+        RefreshExportFailureRequest(userId="user", consentToken="token", lastError="e" * 2001)

--- a/consent-protocol/tests/test_firebase_auth_split.py
+++ b/consent-protocol/tests/test_firebase_auth_split.py
@@ -48,6 +48,69 @@ def test_verify_firebase_bearer_returns_500_when_auth_admin_missing(monkeypatch)
     assert exc.value.detail == "Firebase Admin not configured"
 
 
+def test_verify_firebase_bearer_certificate_fetch_returns_503(monkeypatch):
+    import firebase_admin.auth as firebase_auth
+
+    monkeypatch.setattr(
+        "api.utils.firebase_auth.ensure_firebase_auth_admin",
+        lambda: (True, "test-project"),
+    )
+    monkeypatch.setattr("api.utils.firebase_auth.get_firebase_auth_app", lambda: object())
+
+    def _raise_cert(*_args, **_kwargs):
+        raise firebase_auth.CertificateFetchError("fetch failed", cause=RuntimeError("network"))
+
+    monkeypatch.setattr(firebase_auth, "verify_id_token", _raise_cert)
+
+    with pytest.raises(HTTPException) as exc:
+        verify_firebase_bearer("Bearer some-token")
+
+    assert exc.value.status_code == 503
+    assert "temporarily unavailable" in exc.value.detail.lower()
+
+
+def test_verify_firebase_bearer_invalid_id_token_returns_401(monkeypatch):
+    import firebase_admin.auth as firebase_auth
+
+    monkeypatch.setattr(
+        "api.utils.firebase_auth.ensure_firebase_auth_admin",
+        lambda: (True, "test-project"),
+    )
+    monkeypatch.setattr("api.utils.firebase_auth.get_firebase_auth_app", lambda: object())
+
+    def _raise_invalid(*_args, **_kwargs):
+        raise firebase_auth.InvalidIdTokenError("bad token")
+
+    monkeypatch.setattr(firebase_auth, "verify_id_token", _raise_invalid)
+
+    with pytest.raises(HTTPException) as exc:
+        verify_firebase_bearer("Bearer some-token")
+
+    assert exc.value.status_code == 401
+    assert exc.value.detail == "Invalid Firebase ID token"
+
+
+def test_verify_firebase_bearer_unexpected_error_returns_500(monkeypatch):
+    import firebase_admin.auth as firebase_auth
+
+    monkeypatch.setattr(
+        "api.utils.firebase_auth.ensure_firebase_auth_admin",
+        lambda: (True, "test-project"),
+    )
+    monkeypatch.setattr("api.utils.firebase_auth.get_firebase_auth_app", lambda: object())
+
+    def _raise_runtime(*_args, **_kwargs):
+        raise RuntimeError("surprise")
+
+    monkeypatch.setattr(firebase_auth, "verify_id_token", _raise_runtime)
+
+    with pytest.raises(HTTPException) as exc:
+        verify_firebase_bearer("Bearer some-token")
+
+    assert exc.value.status_code == 500
+    assert exc.value.detail == "Internal server error"
+
+
 def test_ensure_firebase_admin_uses_default_service_account(monkeypatch):
     import firebase_admin
     from firebase_admin import credentials

--- a/hushh-webapp/__tests__/api/consent-vault-json-validation.test.ts
+++ b/hushh-webapp/__tests__/api/consent-vault-json-validation.test.ts
@@ -1,0 +1,39 @@
+import { NextRequest } from "next/server";
+
+import { POST as cancelConsent } from "@/app/api/consent/cancel/route";
+import { POST as logoutConsent } from "@/app/api/consent/logout/route";
+import { POST as revokeConsent } from "@/app/api/consent/revoke/route";
+import { POST as issueSessionToken } from "@/app/api/consent/session-token/route";
+import { POST as setupVault } from "@/app/api/vault/setup/route";
+
+function malformedPost(path: string): NextRequest {
+  return new NextRequest(`http://localhost:3000${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: "{not-json",
+  });
+}
+
+async function expectInvalidJson(response: Response) {
+  expect(response.status).toBe(400);
+  await expect(response.json()).resolves.toEqual({
+    error: "Invalid JSON payload",
+  });
+}
+
+describe("malformed JSON route handling", () => {
+  it("rejects malformed vault setup payloads before backend work", async () => {
+    await expectInvalidJson(
+      await setupVault(malformedPost("/api/vault/setup")),
+    );
+  });
+
+  it.each([
+    ["/api/consent/cancel", cancelConsent],
+    ["/api/consent/logout", logoutConsent],
+    ["/api/consent/revoke", revokeConsent],
+    ["/api/consent/session-token", issueSessionToken],
+  ])("rejects malformed consent payloads for %s", async (path, handler) => {
+    await expectInvalidJson(await handler(malformedPost(path)));
+  });
+});

--- a/hushh-webapp/app/api/_utils/json-body.ts
+++ b/hushh-webapp/app/api/_utils/json-body.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function readJsonObject(
+  request: NextRequest,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const body = await request.json();
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return null;
+    }
+    return body as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+export function invalidJsonPayloadResponse(): NextResponse {
+  return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 });
+}

--- a/hushh-webapp/app/api/consent/cancel/route.ts
+++ b/hushh-webapp/app/api/consent/cancel/route.ts
@@ -9,18 +9,28 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { getPythonApiUrl } from "@/app/api/_utils/backend";
+import {
+  invalidJsonPayloadResponse,
+  readJsonObject,
+} from "@/app/api/_utils/json-body";
 
 const BACKEND_URL = getPythonApiUrl();
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = (await readJsonObject(request)) as {
+      userId?: string;
+      requestId?: string;
+    } | null;
+    if (!body) {
+      return invalidJsonPayloadResponse();
+    }
     const { userId, requestId } = body;
 
     if (!userId || !requestId) {
       return NextResponse.json(
         { error: "userId and requestId are required" },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
@@ -29,7 +39,7 @@ export async function POST(request: NextRequest) {
     if (!authHeader) {
       return NextResponse.json(
         { error: "Authorization header required" },
-        { status: 401 }
+        { status: 401 },
       );
     }
 
@@ -49,7 +59,7 @@ export async function POST(request: NextRequest) {
       console.error("[API] Backend error:", error);
       return NextResponse.json(
         { error: "Failed to cancel consent" },
-        { status: response.status }
+        { status: response.status },
       );
     }
 
@@ -59,7 +69,7 @@ export async function POST(request: NextRequest) {
     console.error("[API] Cancel consent error:", error);
     return NextResponse.json(
       { error: "Internal server error" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/hushh-webapp/app/api/consent/logout/route.ts
+++ b/hushh-webapp/app/api/consent/logout/route.ts
@@ -9,18 +9,25 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { getPythonApiUrl } from "@/app/api/_utils/backend";
+import {
+  invalidJsonPayloadResponse,
+  readJsonObject,
+} from "@/app/api/_utils/json-body";
 
 const BACKEND_URL = getPythonApiUrl();
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = (await readJsonObject(request)) as { userId?: string } | null;
+    if (!body) {
+      return invalidJsonPayloadResponse();
+    }
     const { userId } = body;
 
     if (!userId) {
       return NextResponse.json(
         { error: "userId is required" },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
@@ -37,7 +44,7 @@ export async function POST(request: NextRequest) {
       console.error("[API] Backend error:", error);
       return NextResponse.json(
         { error: "Failed to destroy session tokens" },
-        { status: response.status }
+        { status: response.status },
       );
     }
 
@@ -49,7 +56,7 @@ export async function POST(request: NextRequest) {
     console.error("[API] Logout error:", error);
     return NextResponse.json(
       { error: "Internal server error" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/hushh-webapp/app/api/consent/revoke/route.ts
+++ b/hushh-webapp/app/api/consent/revoke/route.ts
@@ -8,25 +8,37 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { getPythonApiUrl } from "@/app/api/_utils/backend";
+import {
+  invalidJsonPayloadResponse,
+  readJsonObject,
+} from "@/app/api/_utils/json-body";
 
 const BACKEND_URL = getPythonApiUrl();
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = (await readJsonObject(request)) as {
+      userId?: string;
+      scope?: string;
+    } | null;
+    if (!body) {
+      return invalidJsonPayloadResponse();
+    }
     const { userId, scope } = body;
-    const authHeader = request.headers.get("authorization") || request.headers.get("Authorization");
+    const authHeader =
+      request.headers.get("authorization") ||
+      request.headers.get("Authorization");
 
     if (!userId || !scope) {
       return NextResponse.json(
         { error: "userId and scope are required" },
-        { status: 400 }
+        { status: 400 },
       );
     }
     if (!authHeader) {
       return NextResponse.json(
         { error: "Missing Authorization header" },
-        { status: 401 }
+        { status: 401 },
       );
     }
 
@@ -37,7 +49,10 @@ export async function POST(request: NextRequest) {
 
     const response = await fetch(backendUrl, {
       method: "POST",
-      headers: { "Content-Type": "application/json", Authorization: authHeader },
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: authHeader,
+      },
       body: JSON.stringify({ userId, scope }),
     });
 
@@ -49,7 +64,7 @@ export async function POST(request: NextRequest) {
       console.error("[API] Backend error:", responseText);
       return NextResponse.json(
         { error: responseText || "Failed to revoke consent" },
-        { status: response.status }
+        { status: response.status },
       );
     }
 
@@ -64,7 +79,7 @@ export async function POST(request: NextRequest) {
     console.error("[API] Revoke consent error:", error);
     return NextResponse.json(
       { error: `Internal server error: ${error}` },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/hushh-webapp/app/api/consent/session-token/route.ts
+++ b/hushh-webapp/app/api/consent/session-token/route.ts
@@ -11,12 +11,19 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { getPythonApiUrl } from "@/app/api/_utils/backend";
+import {
+  invalidJsonPayloadResponse,
+  readJsonObject,
+} from "@/app/api/_utils/json-body";
 
 const BACKEND_URL = getPythonApiUrl();
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = (await readJsonObject(request)) as { userId?: string } | null;
+    if (!body) {
+      return invalidJsonPayloadResponse();
+    }
     const { userId } = body;
 
     // Get Authorization header from request
@@ -25,14 +32,14 @@ export async function POST(request: NextRequest) {
     if (!userId) {
       return NextResponse.json(
         { error: "userId is required" },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
     if (!authHeader) {
       return NextResponse.json(
         { error: "Authorization header is required" },
-        { status: 401 }
+        { status: 401 },
       );
     }
 
@@ -52,7 +59,7 @@ export async function POST(request: NextRequest) {
       console.error("[API] Backend error:", error);
       return NextResponse.json(
         { error: "Failed to issue session token" },
-        { status: response.status }
+        { status: response.status },
       );
     }
 
@@ -64,7 +71,7 @@ export async function POST(request: NextRequest) {
     console.error("[API] Session token error:", error);
     return NextResponse.json(
       { error: "Internal server error" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/hushh-webapp/app/api/vault/setup/route.ts
+++ b/hushh-webapp/app/api/vault/setup/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { getPythonApiUrl } from "@/app/api/_utils/backend";
+import {
+  invalidJsonPayloadResponse,
+  readJsonObject,
+} from "@/app/api/_utils/json-body";
 import { validateFirebaseToken } from "@/lib/auth/validate";
 import { isDevelopment, logSecurityEvent } from "@/lib/config";
 
@@ -24,7 +28,19 @@ type VaultWrapper = {
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = (await readJsonObject(request)) as {
+      userId?: string;
+      vaultKeyHash?: string;
+      primaryMethod?: string;
+      primaryWrapperId?: string;
+      recoveryEncryptedVaultKey?: string;
+      recoverySalt?: string;
+      recoveryIv?: string;
+      wrappers?: VaultWrapper[];
+    } | null;
+    if (!body) {
+      return invalidJsonPayloadResponse();
+    }
     const {
       userId,
       vaultKeyHash,
@@ -34,16 +50,7 @@ export async function POST(request: NextRequest) {
       recoverySalt,
       recoveryIv,
       wrappers,
-    } = body as {
-      userId?: string;
-      vaultKeyHash?: string;
-      primaryMethod?: string;
-      primaryWrapperId?: string;
-      recoveryEncryptedVaultKey?: string;
-      recoverySalt?: string;
-      recoveryIv?: string;
-      wrappers?: VaultWrapper[];
-    };
+    } = body;
 
     if (
       !userId ||
@@ -57,14 +64,14 @@ export async function POST(request: NextRequest) {
     ) {
       return NextResponse.json(
         { error: "Missing required vault state fields" },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
     if (!wrappers.some((wrapper) => wrapper.method === "passphrase")) {
       return NextResponse.json(
         { error: "Passphrase wrapper is required" },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
@@ -74,7 +81,7 @@ export async function POST(request: NextRequest) {
       if (!validation.valid && !isDevelopment()) {
         return NextResponse.json(
           { error: "Authentication failed", code: "AUTH_INVALID" },
-          { status: 401 }
+          { status: 401 },
         );
       }
     }
@@ -108,7 +115,7 @@ export async function POST(request: NextRequest) {
       const errorText = await response.text();
       return NextResponse.json(
         { error: errorText || "Backend error" },
-        { status: response.status }
+        { status: response.status },
       );
     }
 
@@ -119,7 +126,7 @@ export async function POST(request: NextRequest) {
     console.error("Vault setup error:", error);
     return NextResponse.json(
       { error: "Internal server error" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }


### PR DESCRIPTION
## Summary

Maintainer harvest for the next async PR train candidates:

- Harvests Firebase bearer error classification from #582 while intentionally dropping the global pytest repeat plugin.
- Harvests malformed JSON handling from #632 and #633 into existing Next.js API routes through a shared object-only JSON reader.
- Harvests bounded consent request model validation from #1119 while avoiding route-level actor semantic narrowing that would change existing API error shape.
- Holds #1114 out of the merge path because its final diff does not exercise production scope enforcement.

## Source PRs

- #582: Firebase bearer error classification and CLI test target forwarding
- #632: vault setup malformed JSON handling
- #633: consent API malformed JSON handling
- #1119: consent request model bounds

## Verification

- `python3 -m py_compile consent-protocol/api/utils/firebase_auth.py consent-protocol/api/routes/consent.py consent-protocol/tests/test_firebase_auth_split.py consent-protocol/tests/test_consent_model_bounds.py`
- `cd consent-protocol && TESTING=true APP_SIGNING_KEY=test_secret_key_for_ci_only_32chars_min VAULT_DATA_KEY=0000000000000000000000000000000000000000000000000000000000000000 HUSHH_DEVELOPER_TOKEN=test_hushh_developer_token_for_ci python3 -m pytest tests/test_firebase_auth_split.py tests/test_consent_model_bounds.py -q`
- `cd hushh-webapp && npm run test -- __tests__/api/consent-vault-json-validation.test.ts`
- `cd hushh-webapp && npm run typecheck`
- `cd hushh-webapp && npx prettier --check app/api/_utils/json-body.ts app/api/vault/setup/route.ts app/api/consent/cancel/route.ts app/api/consent/logout/route.ts app/api/consent/revoke/route.ts app/api/consent/session-token/route.ts __tests__/api/consent-vault-json-validation.test.ts`
- `git diff --check`
