### PR TITLE
Fix RIA onboarding verify-license timeout budget

### DIFF
--- a/deploy/frontend.cloudbuild.yaml
+++ b/deploy/frontend.cloudbuild.yaml
@@ -100,11 +100,11 @@ steps:
           "--port=8080"
           "--memory=512Mi"
           "--cpu=1"
-          "--timeout=60"
+          "--timeout=120"
           "--max-instances=10"
           "--min-instances=1"
           "--labels=managed-by=hushh-github-actions,deploy-env=${_DEPLOY_ENV},deploy-source=${_DEPLOY_SOURCE},deploy-sha=${_DEPLOY_SHA},github-run-id=${_GITHUB_RUN_ID}"
-          "--set-env-vars=NEXT_PUBLIC_APP_ENV=${_APP_ENV},HUSHH_DEPLOY_ENV=${_DEPLOY_ENV},HUSHH_DEPLOY_SOURCE=${_DEPLOY_SOURCE},HUSHH_DEPLOY_SHA=${_DEPLOY_SHA},HUSHH_DEPLOY_RUN_ID=${_GITHUB_RUN_ID}"
+          "--set-env-vars=NEXT_PUBLIC_APP_ENV=${_APP_ENV},HUSHH_DEPLOY_ENV=${_DEPLOY_ENV},HUSHH_DEPLOY_SOURCE=${_DEPLOY_SOURCE},HUSHH_DEPLOY_SHA=${_DEPLOY_SHA},HUSHH_DEPLOY_RUN_ID=${_GITHUB_RUN_ID},RIA_ONBOARDING_PROXY_TIMEOUT_MS=90000"
           "--set-secrets=BACKEND_URL=BACKEND_URL:latest,DEVELOPER_API_URL=BACKEND_URL:latest,FIREBASE_ADMIN_CREDENTIALS_JSON=FIREBASE_ADMIN_CREDENTIALS_JSON:latest"
         )
 

--- a/scripts/ci/runtime-contract-check.sh
+++ b/scripts/ci/runtime-contract-check.sh
@@ -5,6 +5,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 backend_helper="$REPO_ROOT/hushh-webapp/app/api/_utils/backend.ts"
 frontend_cloudbuild="$REPO_ROOT/deploy/frontend.cloudbuild.yaml"
+ria_proxy_route="$REPO_ROOT/hushh-webapp/app/api/ria/[...path]/route.ts"
 
 if grep -q 'consent-protocol-rpphvsc3tq-uc.a.run.app' "$backend_helper"; then
   echo "❌ backend route helper still hardcodes a production backend fallback."
@@ -28,6 +29,37 @@ fi
 
 if ! grep -q -- '--set-env-vars=NEXT_PUBLIC_APP_ENV=' "$frontend_cloudbuild"; then
   echo "❌ frontend Cloud Run deploy must inject NEXT_PUBLIC_APP_ENV at runtime."
+  exit 1
+fi
+
+frontend_timeout_seconds="$(
+  grep -Eo -- '--timeout=[0-9]+' "$frontend_cloudbuild" | head -n 1 | cut -d= -f2
+)"
+if [ -z "$frontend_timeout_seconds" ]; then
+  echo "❌ frontend Cloud Run deploy must declare an explicit request timeout."
+  exit 1
+fi
+
+if [ "$frontend_timeout_seconds" -lt 120 ]; then
+  echo "❌ frontend Cloud Run timeout must be at least 120s for long-running RIA verification."
+  exit 1
+fi
+
+if ! grep -q 'process.env.RIA_ONBOARDING_PROXY_TIMEOUT_MS' "$ria_proxy_route"; then
+  echo "❌ RIA onboarding proxy must read RIA_ONBOARDING_PROXY_TIMEOUT_MS."
+  exit 1
+fi
+
+onboarding_proxy_timeout_ms="$(
+  grep -Eo 'RIA_ONBOARDING_PROXY_TIMEOUT_MS=[0-9]+' "$frontend_cloudbuild" | head -n 1 | cut -d= -f2
+)"
+if [ -z "$onboarding_proxy_timeout_ms" ]; then
+  echo "❌ frontend Cloud Run deploy must inject RIA_ONBOARDING_PROXY_TIMEOUT_MS."
+  exit 1
+fi
+
+if [ "$((frontend_timeout_seconds * 1000))" -le "$onboarding_proxy_timeout_ms" ]; then
+  echo "❌ frontend Cloud Run timeout must be greater than the RIA onboarding proxy timeout."
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- raise frontend Cloud Run request timeout from 60s to 120s
- inject `RIA_ONBOARDING_PROXY_TIMEOUT_MS=90000` into frontend runtime env
- extend the runtime contract check so future deploys cannot make the Cloud Run timeout shorter than the RIA onboarding proxy budget

## Evidence
- UAT logs showed `hushh-webapp` returned 504 at exactly 60.000s while `consent-protocol` completed the same verify-license request successfully after ~63.963s
- live UAT frontend currently has timeout 60 and no `RIA_ONBOARDING_PROXY_TIMEOUT_MS` env

## Tests
- `bash scripts/ci/no-ria-feature-flags.sh`
- `bash scripts/ci/runtime-contract-check.sh`
- temp-worktree negative test: reducing `--timeout=120` back to `--timeout=60` makes `runtime-contract-check.sh` fail
- `uv run python .codex/skills/agent-orchestration-governance/scripts/agent_orchestration_check.py`
- `uv run python .codex/skills/agent-orchestration-governance/scripts/agent_fleet_audit.py --text`
- `uv run python .codex/skills/agent-orchestration-governance/scripts/agent_router_smoke.py`
- `bash scripts/ci/check-dco-signoff.sh origin/main HEAD`

## Notes
- This is frontend deploy/runtime budget only. It intentionally does not include the unrelated local backend RIA work in the stale feature branch.
- Direct local `gcloud run services update` on UAT was blocked by IAM: `run.services.update` denied for `ankit@hushh.ai`, so UAT rollout should proceed through the GitHub deploy workflow after merge.
