### PR TITLE
Fix RIA license-first submit verification

### DIFF
--- a/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
@@ -501,6 +501,56 @@ describe("RiaOnboardingPage", () => {
     });
   });
 
+  it("does not force a second live verification after license verification", async () => {
+    mocks.draftService.load.mockResolvedValue({
+      currentStepId: "review",
+      onboardingType: "individual",
+      licenseNumber: "7265726",
+      licenseVerificationStatus: "found",
+      advisorName: "Ria Ashley Sen",
+      firmName: "Not Currently Registered",
+      regulator: "SEC",
+      regulatorStatus: "ACTIVE",
+      crdNumber: "7265726",
+      individualCrd: "7265726",
+      servicesOffered: ["Portfolio Management"],
+      feeStructure: ["Fee-only"],
+      contactEmail: "ria-e2e@example.invalid",
+    });
+    mocks.riaService.submitOnboarding.mockResolvedValue({
+      requested_capabilities: ["advisory"],
+      verification_status: "verified",
+      advisory_status: "active",
+      individual_legal_name: "Ria Ashley Sen",
+      individual_crd: "7265726",
+      advisory_firm_legal_name: "Not Currently Registered",
+    });
+    mocks.riaService.setRiaMarketplaceDiscoverability.mockResolvedValue({
+      enabled: true,
+    });
+
+    render(<RiaOnboardingPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("step-review")).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("continue-btn"));
+    });
+
+    await waitFor(() => {
+      expect(mocks.riaService.submitOnboarding).toHaveBeenCalledWith(
+        "token-ria-1",
+        expect.objectContaining({
+          license_number: "7265726",
+          individual_crd: "7265726",
+          force_live_verification: false,
+        })
+      );
+    });
+  });
+
   it("redirects to RIA home if already verified when submit clicked", async () => {
     mocks.riaService.getOnboardingStatus.mockResolvedValue({
       exists: true,

--- a/hushh-webapp/app/ria/onboarding/page.tsx
+++ b/hushh-webapp/app/ria/onboarding/page.tsx
@@ -395,6 +395,7 @@ export default function RiaOnboardingPage() {
 
     try {
       const idToken = await user.getIdToken();
+      const shouldForceLiveVerification = !licenseVerificationSatisfied;
       const result = await RiaService.submitOnboarding(idToken, {
         display_name: draft.advisorName.trim() || draft.displayName.trim(),
         requested_capabilities: draft.requestedCapabilities,
@@ -404,7 +405,7 @@ export default function RiaOnboardingPage() {
         advisory_firm_iapd_number: draft.advisoryFirmIapdNumber.trim() || undefined,
         bio: draft.bio.trim() || undefined,
         strategy: draft.strategySummary.trim() || undefined,
-        force_live_verification: true,
+        force_live_verification: shouldForceLiveVerification,
         license_number: draft.licenseNumber.trim() || undefined,
         regulator: draft.regulator.trim() || undefined,
         onboarding_type: draft.onboardingType,


### PR DESCRIPTION
## Summary\n- Keep the final RIA onboarding submit from forcing a second live provider lookup when the license step already verified the CRD/advisor.\n- Add a regression assertion for the license-first submit payload.\n\n## Verification\n- npm run typecheck\n- Targeted Vitest command attempted locally but the local Vitest worker pool timed out before executing tests: `Timeout waiting for worker to respond`.\n\n## UAT Evidence Before Patch\n- Fresh UAT frontend deploy run 25964024015 succeeded for SHA f509f2df9d32a533c69d3a7ab1c47730db6fcea6.\n- Browser E2E reached final review and called `/api/ria/onboarding/submit`, but UAT returned a fast 503 from the second live submit verification path.\n