### PR TITLE
Fix RIA submit reuse of license verification

### DIFF
--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -88,6 +88,7 @@ _RIA_KAI_SPECIALIZED_SCOPES: tuple[str, ...] = (
     "attr.financial.runtime.*",
 )
 _RIA_KAI_SPECIALIZED_SCOPE_SET = set(_RIA_KAI_SPECIALIZED_SCOPES)
+_RIA_LICENSE_VERIFICATION_REUSE_TTL = timedelta(hours=24)
 
 
 class RIAIAMPolicyError(Exception):
@@ -740,6 +741,114 @@ class RIAIAMService:
             logger.warning("verify_ria_license: failed to store audit for %s", normalized)
 
         return response
+
+    @staticmethod
+    def _parse_json_mapping(value: Any) -> dict[str, Any]:
+        if isinstance(value, dict):
+            return value
+        if isinstance(value, str):
+            try:
+                parsed = json.loads(value)
+            except Exception:
+                return {}
+            return parsed if isinstance(parsed, dict) else {}
+        return {}
+
+    @classmethod
+    def _name_lookup_from_license_verification_payload(
+        cls,
+        payload: dict[str, Any],
+        *,
+        license_number: str | None,
+        submitted_individual_crd: str | None,
+    ) -> NameVerificationResult | None:
+        broker_status = str(payload.get("status") or "").strip().upper()
+        if broker_status == "NOT_FOUND":
+            return None
+
+        matched_name = cls._normalize_optional_text(payload.get("verifiedName"))
+        returned_crd = cls._normalize_optional_text(payload.get("crdNumber"))
+        normalized_returned_crd = cls._normalize_crd_text(returned_crd)
+        normalized_license = cls._normalize_crd_text(license_number)
+        normalized_submitted_crd = cls._normalize_crd_text(submitted_individual_crd)
+
+        if not matched_name or not normalized_returned_crd:
+            return None
+        if normalized_license and normalized_returned_crd != normalized_license:
+            return None
+        if normalized_submitted_crd and normalized_returned_crd != normalized_submitted_crd:
+            return None
+
+        disclosures = payload.get("disclosures")
+        disclosures_count = None
+        if isinstance(disclosures, dict):
+            disclosures_count = disclosures.get("count")
+
+        return NameVerificationResult(
+            status="verified",
+            matched_name=matched_name,
+            crd_number=returned_crd,
+            current_firm=cls._normalize_optional_text(payload.get("currentFirm")),
+            sec_number=cls._normalize_optional_text(payload.get("secNumber")),
+            provider="broker_intelligence_license_verification",
+            metadata={
+                "provider": "broker_intelligence_license_verification",
+                "source": "ria_license_verifications",
+                "regulator_status": broker_status or None,
+                "disclosures_count": disclosures_count,
+            },
+        )
+
+    async def _lookup_recent_license_verification_result(
+        self,
+        *,
+        user_id: str,
+        license_number: str | None,
+        submitted_individual_crd: str | None,
+    ) -> NameVerificationResult | None:
+        normalized_license = self._normalize_crd_text(license_number)
+        normalized_submitted_crd = self._normalize_crd_text(submitted_individual_crd)
+        lookup_license = normalized_license or normalized_submitted_crd
+        if not lookup_license:
+            return None
+
+        try:
+            pool = await get_pool()
+            async with pool.acquire() as conn:
+                row = await conn.fetchrow(
+                    """
+                    SELECT raw_response
+                    FROM ria_license_verifications
+                    WHERE user_id = $1
+                      AND license_number = $2
+                      AND status = 'completed'
+                      AND verification_source = 'broker_intelligence'
+                      AND created_at >= $3
+                    ORDER BY created_at DESC
+                    LIMIT 1
+                    """,
+                    user_id,
+                    lookup_license,
+                    datetime.now(timezone.utc) - _RIA_LICENSE_VERIFICATION_REUSE_TTL,
+                )
+        except Exception:
+            logger.warning(
+                "ria.submit_license_verification_lookup_failed user_id=%s",
+                user_id,
+                exc_info=True,
+            )
+            return None
+
+        if row is None:
+            return None
+
+        raw_response = row["raw_response"] if "raw_response" in row else None
+        payload = self._parse_json_mapping(raw_response)
+        return self._name_lookup_from_license_verification_payload(
+            payload,
+            license_number=lookup_license,
+            submitted_individual_crd=normalized_submitted_crd,
+        )
 
     @staticmethod
     def _advisory_status_from_row(row: Any) -> str:
@@ -2323,11 +2432,19 @@ class RIAIAMService:
         normalized_display_name = str(prepared["display_name"])
         normalized_requested_capabilities = list(prepared["requested_capabilities"])
         submitted_individual_crd = self._normalize_optional_text(prepared.get("individual_crd"))
-        name_lookup = await self._verify_ria_name_result(
-            normalized_display_name,
-            crd_number=submitted_individual_crd,
-            use_cache=not force_live_verification,
-        )
+        name_lookup: NameVerificationResult | None = None
+        if not force_live_verification:
+            name_lookup = await self._lookup_recent_license_verification_result(
+                user_id=user_id,
+                license_number=license_number,
+                submitted_individual_crd=submitted_individual_crd,
+            )
+        if name_lookup is None:
+            name_lookup = await self._verify_ria_name_result(
+                normalized_display_name,
+                crd_number=submitted_individual_crd,
+                use_cache=not force_live_verification,
+            )
         if name_lookup.status == "provider_unavailable":
             raise RIAIAMPolicyError(
                 name_lookup.reason or "RIA name verification provider unavailable.",

--- a/consent-protocol/tests/test_ria_iam_service_architecture.py
+++ b/consent-protocol/tests/test_ria_iam_service_architecture.py
@@ -182,6 +182,42 @@ def test_regulated_runtime_guard_rejects_prod_bypass(monkeypatch):
         raise AssertionError("Expected production runtime guard to reject bypass flags")
 
 
+def test_license_verification_payload_maps_to_submit_name_lookup():
+    result = RIAIAMService._name_lookup_from_license_verification_payload(
+        {
+            "verifiedName": "Advisor Alpha",
+            "crdNumber": "12345",
+            "currentFirm": "Advisor Alpha LLC",
+            "status": "ACTIVE",
+            "disclosures": {"count": 0},
+        },
+        license_number="12345",
+        submitted_individual_crd="12345",
+    )
+
+    assert result is not None
+    assert result.status == "verified"
+    assert result.matched_name == "Advisor Alpha"
+    assert result.crd_number == "12345"
+    assert result.current_firm == "Advisor Alpha LLC"
+    assert result.provider == "broker_intelligence_license_verification"
+
+
+def test_license_verification_payload_rejects_crd_mismatch():
+    result = RIAIAMService._name_lookup_from_license_verification_payload(
+        {
+            "verifiedName": "Advisor Alpha",
+            "crdNumber": "99999",
+            "currentFirm": "Advisor Alpha LLC",
+            "status": "ACTIVE",
+        },
+        license_number="12345",
+        submitted_individual_crd="12345",
+    )
+
+    assert result is None
+
+
 @pytest.mark.asyncio
 async def test_verify_ria_name_serializes_verified_stage1_lookup(monkeypatch):
     service = RIAIAMService()
@@ -319,6 +355,94 @@ async def test_submit_ria_onboarding_reverifies_stage1_before_granting_access(mo
         requested_capabilities=["advisory"],
         individual_crd="12345",
         force_live_verification=True,
+        strategy="Long-term planning",
+    )
+
+    assert result["verification_status"] == "verified"
+    assert result["advisory_status"] == "verified"
+    assert result["professional_access_granted"] is True
+    assert result["individual_crd"] == "12345"
+
+
+@pytest.mark.asyncio
+async def test_submit_ria_onboarding_reuses_recent_license_verification(monkeypatch):
+    service = RIAIAMService()
+
+    class _FakeTransaction:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class _FakeConn:
+        def transaction(self):
+            return _FakeTransaction()
+
+        async def fetchrow(self, query: str, *_args):
+            if "INSERT INTO ria_profiles" in query:
+                return {"id": "ria-profile-1", "user_id": "user-1", "display_name": "Advisor Alpha"}
+            if "INSERT INTO ria_firms" in query:
+                return {"id": "firm-1"}
+            return None
+
+        async def execute(self, *_args, **_kwargs):
+            return None
+
+        async def close(self):
+            return None
+
+    async def _fake_conn():
+        return _FakeConn()
+
+    async def _fake_schema_ready(_conn):
+        return None
+
+    async def _fake_vault_user_row(_conn, _user_id):
+        return None
+
+    async def _fake_runtime_persona(_conn, _user_id, _persona):
+        return None
+
+    async def _fake_license_lookup_result(
+        *,
+        user_id: str,
+        license_number: str | None,
+        submitted_individual_crd: str | None,
+    ):
+        assert user_id == "user-1"
+        assert license_number == "12345"
+        assert submitted_individual_crd == "12345"
+        return NameVerificationResult(
+            status="verified",
+            matched_name="Advisor Alpha",
+            crd_number="12345",
+            current_firm="Advisor Alpha LLC",
+            sec_number=None,
+            provider="broker_intelligence_license_verification",
+        )
+
+    async def _unexpected_verify_name_result(*_args, **_kwargs):
+        raise AssertionError("submit should reuse the recent license verification audit")
+
+    monkeypatch.setattr(service, "_conn", _fake_conn)
+    monkeypatch.setattr(service, "_ensure_iam_schema_ready", _fake_schema_ready)
+    monkeypatch.setattr(service, "_ensure_vault_user_row", _fake_vault_user_row)
+    monkeypatch.setattr(service, "_set_runtime_last_persona", _fake_runtime_persona)
+    monkeypatch.setattr(
+        service,
+        "_lookup_recent_license_verification_result",
+        _fake_license_lookup_result,
+    )
+    monkeypatch.setattr(service, "_verify_ria_name_result", _unexpected_verify_name_result)
+
+    result = await service.submit_ria_onboarding(
+        "user-1",
+        display_name="Advisor Alpha",
+        requested_capabilities=["advisory"],
+        individual_crd="12345",
+        license_number="12345",
+        force_live_verification=False,
         strategy="Long-term planning",
     )
 


### PR DESCRIPTION
## Summary
- Reuse a same-user, same-CRD recent broker-intelligence license verification audit during RIA onboarding submit when live verification is not forced.
- Keep Stage 1 live verification as the fallback and preserve force_live_verification semantics.
- Add backend regressions for payload mapping, CRD mismatch rejection, and submit avoiding a second provider call after license verification.

## Tests
- APP_SIGNING_KEY=local-test-signing-key-32-characters-minimum VAULT_DATA_KEY=0000000000000000000000000000000000000000000000000000000000000000 uv run pytest --noconftest tests/test_ria_iam_service_architecture.py tests/test_ria_onboarding_v2.py tests/test_ria_iam_routes.py -q