### PR TITLE
Fix profile PKM metadata load without vault

### DIFF
--- a/hushh-webapp/__tests__/lib/profile/profile-pkm-metadata-policy.test.ts
+++ b/hushh-webapp/__tests__/lib/profile/profile-pkm-metadata-policy.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const emptyMetadataMock = vi.fn((userId: string) => ({
+  userId,
+  domains: [],
+  totalAttributes: 0,
+  modelCompleteness: 0,
+  modelVersion: 4,
+  storedModelVersion: 4,
+  effectiveModelVersion: 4,
+  targetModelVersion: 4,
+  upgradeStatus: "current",
+  upgradableDomains: [],
+  lastUpgradedAt: null,
+  suggestedDomains: [],
+  lastUpdated: null,
+}));
+const getMetadataMock = vi.fn();
+
+vi.mock("@/lib/services/personal-knowledge-model-service", () => ({
+  PersonalKnowledgeModelService: {
+    emptyMetadata: (...args: [string]) => emptyMetadataMock(...args),
+    getMetadata: (...args: unknown[]) => getMetadataMock(...args),
+  },
+}));
+
+import { loadProfilePkmMetadataForVaultState } from "@/lib/profile/profile-pkm-metadata-policy";
+
+describe("loadProfilePkmMetadataForVaultState", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses local empty metadata when the profile already knows no vault exists", async () => {
+    const result = await loadProfilePkmMetadataForVaultState({
+      userId: "user-without-vault",
+      hasVault: false,
+      vaultOwnerToken: null,
+    });
+
+    expect(result).toMatchObject({
+      userId: "user-without-vault",
+      domains: [],
+      totalAttributes: 0,
+    });
+    expect(emptyMetadataMock).toHaveBeenCalledWith("user-without-vault");
+    expect(getMetadataMock).not.toHaveBeenCalled();
+  });
+
+  it("fetches network metadata only when a vault exists", async () => {
+    getMetadataMock.mockResolvedValueOnce({
+      userId: "user-with-vault",
+      domains: [{ key: "financial" }],
+      totalAttributes: 1,
+    });
+
+    const result = await loadProfilePkmMetadataForVaultState({
+      userId: "user-with-vault",
+      hasVault: true,
+      force: true,
+      vaultOwnerToken: "vault-owner-token",
+    });
+
+    expect(result).toMatchObject({
+      userId: "user-with-vault",
+      totalAttributes: 1,
+    });
+    expect(getMetadataMock).toHaveBeenCalledWith(
+      "user-with-vault",
+      true,
+      "vault-owner-token",
+    );
+    expect(emptyMetadataMock).not.toHaveBeenCalled();
+  });
+});

--- a/hushh-webapp/app/profile/page.tsx
+++ b/hushh-webapp/app/profile/page.tsx
@@ -139,6 +139,7 @@ import {
   buildPkmSectionPreviewPresentation,
   type PkmSectionPreviewPresentation,
 } from "@/lib/profile/pkm-section-preview";
+import { loadProfilePkmMetadataForVaultState } from "@/lib/profile/profile-pkm-metadata-policy";
 import { maskPhoneNumber } from "@/lib/services/phone-mandate-service";
 import type { DomainManifest } from "@/lib/personal-knowledge-model/manifest";
 import { GmailReceiptsService } from "@/lib/services/gmail-receipts-service";
@@ -959,17 +960,23 @@ function ProfilePageContent() {
 
   const refreshPkmMetadata = useCallback(
     async (force = false) => {
-      if (!user?.uid) return;
-      const metadata = await PersonalKnowledgeModelService.getMetadata(
-        user.uid,
+      if (!user?.uid || hasVault === null) return;
+      const metadata = await loadProfilePkmMetadataForVaultState({
+        userId: user.uid,
+        hasVault,
         force,
-        vaultOwnerToken ?? undefined,
-      );
+        vaultOwnerToken,
+      });
       setPkmMetadata(metadata);
       setPkmError(null);
+      if (!hasVault) {
+        setDomainManifests({});
+        setDomainManifestErrors({});
+        setLoadingDomainManifests({});
+      }
       return metadata;
     },
-    [user?.uid, vaultOwnerToken],
+    [hasVault, user?.uid, vaultOwnerToken],
   );
 
   const refreshDomainManifest = useCallback(
@@ -1130,11 +1137,12 @@ function ProfilePageContent() {
 
         const idToken = await user.getIdToken();
         const [metadata, center] = await Promise.all([
-          PersonalKnowledgeModelService.getMetadata(
-            user.uid,
-            false,
-            vaultOwnerToken ?? undefined,
-          ),
+          loadProfilePkmMetadataForVaultState({
+            userId: user.uid,
+            hasVault,
+            force: false,
+            vaultOwnerToken,
+          }),
           ConsentCenterService.getCenter({
             idToken,
             userId: user.uid,
@@ -1148,6 +1156,11 @@ function ProfilePageContent() {
         setConsentCenter(center);
         setPkmError(null);
         setConsentCenterError(null);
+        if (!hasVault) {
+          setDomainManifests({});
+          setDomainManifestErrors({});
+          setLoadingDomainManifests({});
+        }
         completeStep();
       } catch (error) {
         console.error("Failed to load profile manager data:", error);

--- a/hushh-webapp/lib/profile/profile-pkm-metadata-policy.ts
+++ b/hushh-webapp/lib/profile/profile-pkm-metadata-policy.ts
@@ -1,0 +1,26 @@
+import {
+  PersonalKnowledgeModelService,
+  type PersonalKnowledgeModelMetadata,
+} from "@/lib/services/personal-knowledge-model-service";
+
+export async function loadProfilePkmMetadataForVaultState({
+  userId,
+  hasVault,
+  force = false,
+  vaultOwnerToken,
+}: {
+  userId: string;
+  hasVault: boolean;
+  force?: boolean;
+  vaultOwnerToken?: string | null;
+}): Promise<PersonalKnowledgeModelMetadata> {
+  if (!hasVault) {
+    return PersonalKnowledgeModelService.emptyMetadata(userId);
+  }
+
+  return PersonalKnowledgeModelService.getMetadata(
+    userId,
+    force,
+    vaultOwnerToken ?? undefined,
+  );
+}


### PR DESCRIPTION
## Summary
- Skip the Profile PKM metadata network fetch when the vault check already resolved that the user has no vault.
- Return local empty PKM metadata for the no-vault state and clear stale domain manifest state.
- Add a focused regression for the no-vault metadata policy.

## Verification
- /Users/ankitkumarsingh/Documents/New project 2/hushh-research/hushh-webapp: npx tsc --noEmit --pretty false --incremental false
- /tmp/hushh-profile-pkm-no-vault/hushh-webapp: npx tsc --noEmit --pretty false --incremental false with linked local node_modules
- Node behavioral check: no-vault path returns empty metadata without calling getMetadata; vault path delegates to getMetadata
- git diff --check

## Notes
- Vitest could not start locally because the worker pool timed out before loading any test file; no tests executed in that failing run.
- This keeps the backend /api/pkm/metadata/{user_id} 404 contract intact for real no-data states.
