### PR TITLE
Pass official RIA location into onboarding

### DIFF
--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -80,6 +80,52 @@ _RIA_KAI_SPECIALIZED_DESCRIPTION = (
     "Advisor-side Kai and explorer access for portfolio, profile, analysis history, "
     "and runtime context."
 )
+
+
+def _first_text_value(*values: Any) -> str | None:
+    for value in values:
+        if value is None:
+            continue
+        normalized = str(value).strip()
+        if normalized:
+            return normalized
+    return None
+
+
+def _broker_city(payload: dict[str, Any]) -> str | None:
+    return _first_text_value(
+        payload.get("city"),
+        payload.get("businessCity"),
+        payload.get("business_city"),
+    )
+
+
+def _broker_pin_zip(payload: dict[str, Any]) -> str | None:
+    return _first_text_value(
+        payload.get("pinZip"),
+        payload.get("pin_zip"),
+        payload.get("zip"),
+        payload.get("zipCode"),
+        payload.get("postalCode"),
+        payload.get("postal_code"),
+    )
+
+
+def _broker_exams(payload: dict[str, Any]) -> list[str]:
+    exams = payload.get("exams")
+    if not isinstance(exams, list):
+        return []
+    normalized: list[str] = []
+    for item in exams:
+        if isinstance(item, dict):
+            value = _first_text_value(item.get("name"), item.get("examName"))
+        else:
+            value = _first_text_value(item)
+        if value and value not in normalized:
+            normalized.append(value)
+    return normalized
+
+
 _RIA_KAI_SPECIALIZED_PRESENTATIONS: tuple[str, ...] = ("kai", "explorer")
 _RIA_KAI_SPECIALIZED_SCOPES: tuple[str, ...] = (
     "attr.financial.portfolio.*",
@@ -704,17 +750,15 @@ class RIAIAMService:
             "regulator_status": broker_data.get("status"),
             "license_expiry": None,
             "certifications": [],
-            "city": None,
-            "pin_zip": None,
+            "city": _broker_city(broker_data),
+            "pin_zip": _broker_pin_zip(broker_data),
             "crd_number": broker_data.get("crdNumber") or normalized,
             "sec_number": None,
             "employment_history": broker_data.get("employmentHistory", []),
             "disclosures_count": broker_data.get("disclosures", {}).get("count", 0)
             if isinstance(broker_data.get("disclosures"), dict)
             else 0,
-            "exams_passed": [
-                e.get("name", "") for e in broker_data.get("exams", []) if isinstance(e, dict)
-            ],
+            "exams_passed": _broker_exams(broker_data),
             "provider": "ria_intelligence_combined",
             "scrape_job_id": scrape_data.get("jobId"),
             "broker_intelligence_summary": broker_data.get("summary"),

--- a/consent-protocol/tests/test_ria_onboarding_v2.py
+++ b/consent-protocol/tests/test_ria_onboarding_v2.py
@@ -34,6 +34,7 @@ sys.modules.setdefault("api.middlewares.rate_limit", rate_limit_module)
 from api.middleware import require_firebase_auth  # noqa: E402
 from api.routes import ria as ria_module  # noqa: E402
 from hushh_mcp.services.crd_scrape_proxy_service import (  # noqa: E402
+    CrdScrapeProviderResponse,
     CrdScrapeProxyService,
 )
 from hushh_mcp.services.ria_iam_service import (  # noqa: E402
@@ -124,6 +125,54 @@ def test_verify_license_not_found(monkeypatch) -> None:
 
     assert response.status_code == 200
     assert response.json()["status"] == "not_found"
+
+
+def test_verify_license_passes_through_city_pin_zip_and_string_exams(monkeypatch) -> None:
+    """The service should preserve source-backed location fields from broker intelligence."""
+
+    class _FakeProxy:
+        async def broker_intelligence(self, *, query: str, request_id: str | None = None):
+            assert query == "7413463"
+            return CrdScrapeProviderResponse(
+                200,
+                {
+                    "verifiedName": "Andrew Garrett Kirkland",
+                    "currentFirm": "Eissman Wealth Management",
+                    "status": "Investment Adviser Representative",
+                    "crdNumber": "7413463",
+                    "city": "Kennesaw",
+                    "pinZip": "30144",
+                    "exams": ["Series 65"],
+                    "disclosures": {"count": 1},
+                    "employmentHistory": [],
+                    "summary": "Official PDF-backed location resolved.",
+                },
+            )
+
+        async def create_job(self, *, crd_number: str, request_id: str | None = None):
+            assert crd_number == "7413463"
+            return CrdScrapeProviderResponse(
+                202,
+                {"jobId": "crd_scrape_location_123", "status": "queued"},
+            )
+
+    monkeypatch.setattr(
+        "hushh_mcp.services.crd_scrape_proxy_service.CrdScrapeProxyService",
+        lambda: _FakeProxy(),
+    )
+
+    result = asyncio.run(
+        RIAIAMService().verify_ria_license(
+            _TEST_UID,
+            license_number="7413463",
+            regulator="SEC",
+        )
+    )
+
+    assert result["status"] == "found"
+    assert result["city"] == "Kennesaw"
+    assert result["pin_zip"] == "30144"
+    assert result["exams_passed"] == ["Series 65"]
 
 
 def test_verify_license_invalid_number_422() -> None:

--- a/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
@@ -157,13 +157,19 @@ vi.mock("@/components/ria/onboarding/onboarding-step-license-details", () => ({
   OnboardingStepLicenseDetails: ({
     advisorName,
     firmName,
+    city,
+    pinZip,
   }: {
     advisorName: string;
     firmName: string;
+    city: string;
+    pinZip: string;
   }) => (
     <div data-testid="step-license-details">
       <span data-testid="advisor-name">{advisorName}</span>
       <span data-testid="firm-name">{firmName}</span>
+      <span data-testid="city">{city}</span>
+      <span data-testid="pin-zip">{pinZip}</span>
     </div>
   ),
 }));
@@ -319,6 +325,8 @@ describe("RiaOnboardingPage", () => {
       firm_name: "Acme Wealth",
       regulator: "SEC",
       regulator_status: "ACTIVE",
+      city: "Kennesaw",
+      pin_zip: "30144",
       crd_number: "123456",
       scrape_job_id: null,
     });
@@ -368,6 +376,8 @@ describe("RiaOnboardingPage", () => {
 
     expect(screen.getByTestId("advisor-name").textContent).toBe("Jane Doe");
     expect(screen.getByTestId("firm-name").textContent).toBe("Acme Wealth");
+    expect(screen.getByTestId("city").textContent).toBe("Kennesaw");
+    expect(screen.getByTestId("pin-zip").textContent).toBe("30144");
   });
 
   it("handles not_found and stays on license step", async () => {

--- a/hushh-webapp/app/ria/onboarding/page.tsx
+++ b/hushh-webapp/app/ria/onboarding/page.tsx
@@ -30,6 +30,7 @@ import {
   isIAMSchemaNotReadyError,
   RiaApiError,
   RiaService,
+  type CrdScrapeJobResult,
   type RiaLicenseVerificationResult,
   type RiaOnboardingStatus,
 } from "@/lib/services/ria-service";
@@ -39,6 +40,27 @@ import { trackGrowthFunnelStepCompleted } from "@/lib/observability/growth";
 
 const LICENSE_VERIFICATION_TIMEOUT_MS = 90_000;
 const SCRAPE_POLL_INTERVAL_MS = 5_000;
+
+function textValue(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function locationPatchFromCrdReport(
+  report: NonNullable<CrdScrapeJobResult["report"]>
+): Pick<RiaOnboardingDraft, "city" | "pinZip"> {
+  const officialLocation = report.officialLocation;
+  const firmHistoryLocation =
+    (report.firmHistory?.find(
+      (entry) =>
+        typeof entry?.city === "string" && typeof entry?.state === "string"
+    ) ?? {}) as Record<string, unknown>;
+
+  return {
+    city:
+      textValue(officialLocation?.city) || textValue(firmHistoryLocation.city),
+    pinZip: textValue(officialLocation?.pinZip),
+  };
+}
 
 function isAdvisoryAccessReady(status?: string | null): boolean {
   return status === "active" || status === "verified";
@@ -260,12 +282,15 @@ export default function RiaOnboardingPage() {
               scrapePollingRef.current = null;
             }
             if (result.report) {
+              const locationPatch = locationPatchFromCrdReport(result.report);
               updateDraft({
                 firmName:
                   draft.firmName ||
                   (result.report.firmHistory?.[0] as Record<string, string>)
                     ?.firmName ||
                   "",
+                city: draft.city || locationPatch.city,
+                pinZip: draft.pinZip || locationPatch.pinZip,
                 certifications:
                   draft.certifications.length > 0
                     ? draft.certifications
@@ -286,7 +311,7 @@ export default function RiaOnboardingPage() {
         }
       }, SCRAPE_POLL_INTERVAL_MS);
     },
-    [draft.firmName, draft.certifications, updateDraft]
+    [draft.firmName, draft.city, draft.pinZip, draft.certifications, updateDraft]
   );
 
   async function handleVerifyLicense() {

--- a/hushh-webapp/lib/services/ria-service.ts
+++ b/hushh-webapp/lib/services/ria-service.ts
@@ -138,6 +138,13 @@ export interface CrdScrapeJobResult {
     barredStatus?: string;
     registrationStatus?: string;
     disclosuresCount?: number;
+    officialLocation?: {
+      city?: string | null;
+      state?: string | null;
+      pinZip?: string | null;
+      location?: string | null;
+      address?: string | null;
+    } | null;
     firmHistory?: Array<Record<string, unknown>>;
     officialReports?: Array<Record<string, unknown>>;
     sources?: Array<Record<string, unknown>>;


### PR DESCRIPTION
## Summary
- pass city and pin_zip from the RIA intelligence provider into verify-license responses
- hydrate onboarding city / PIN ZIP fields from CRD scrape officialLocation when polling finishes
- preserve string exam names from broker intelligence responses

## Verification
- consent-protocol targeted RIA onboarding test passed with test-only env values set locally
- hushh-webapp TypeScript check passed: npx tsc --noEmit --pretty false --incremental false
- git diff --check

## Notes
- Vitest worker startup is still blocked in this checkout before tests import: [vitest-pool] Timeout waiting for worker to respond.