### PR TITLE
Add official PDF fallback for RIA location

### DIFF
--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -6,6 +6,7 @@ import io
 import json
 import logging
 import os
+import re
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -80,6 +81,70 @@ _RIA_KAI_SPECIALIZED_DESCRIPTION = (
     "Advisor-side Kai and explorer access for portfolio, profile, analysis history, "
     "and runtime context."
 )
+_OFFICIAL_LOCATION_REPORT_URLS: tuple[str, ...] = (
+    "https://reports.adviserinfo.sec.gov/reports/individual/individual_{crd}.pdf",
+    "https://files.brokercheck.finra.org/individual/individual_{crd}.pdf",
+)
+_US_STATE_CODES = {
+    "AL",
+    "AK",
+    "AZ",
+    "AR",
+    "CA",
+    "CO",
+    "CT",
+    "DE",
+    "FL",
+    "GA",
+    "HI",
+    "ID",
+    "IL",
+    "IN",
+    "IA",
+    "KS",
+    "KY",
+    "LA",
+    "ME",
+    "MD",
+    "MA",
+    "MI",
+    "MN",
+    "MS",
+    "MO",
+    "MT",
+    "NE",
+    "NV",
+    "NH",
+    "NJ",
+    "NM",
+    "NY",
+    "NC",
+    "ND",
+    "OH",
+    "OK",
+    "OR",
+    "PA",
+    "RI",
+    "SC",
+    "SD",
+    "TN",
+    "TX",
+    "UT",
+    "VT",
+    "VA",
+    "WA",
+    "WV",
+    "WI",
+    "WY",
+    "DC",
+}
+_OFFICIAL_ADDRESS_RE = re.compile(
+    r"(?P<address>\d{1,6}\s+[A-Z0-9][A-Z0-9 .,#'&/-]{4,120}?)\s+"
+    r"(?P<city>[A-Z][A-Z .'-]{1,60}?),\s*"
+    r"(?P<state>AL|AK|AZ|AR|CA|CO|CT|DE|FL|GA|HI|ID|IL|IN|IA|KS|KY|LA|ME|MD|MA|MI|MN|MS|MO|MT|NE|NV|NH|NJ|NM|NY|NC|ND|OH|OK|OR|PA|RI|SC|SD|TN|TX|UT|VT|VA|WA|WV|WI|WY|DC)\s+"
+    r"(?P<pin_zip>\d{5}(?:-\d{4})?)\b",
+    re.IGNORECASE,
+)
 
 
 def _first_text_value(*values: Any) -> str | None:
@@ -109,6 +174,88 @@ def _broker_pin_zip(payload: dict[str, Any]) -> str | None:
         payload.get("postalCode"),
         payload.get("postal_code"),
     )
+
+
+def _title_case_city(value: str) -> str:
+    small_words = {"of", "and", "the"}
+    parts: list[str] = []
+    for word in value.strip().lower().split():
+        parts.append(word if word in small_words else word.capitalize())
+    return " ".join(parts)
+
+
+def _official_location_from_text(text: str, source_url: str) -> dict[str, str] | None:
+    normalized = " ".join(str(text or "").replace("\xa0", " ").split())
+    if not normalized:
+        return None
+
+    for match in _OFFICIAL_ADDRESS_RE.finditer(normalized):
+        state = match.group("state").upper()
+        if state not in _US_STATE_CODES:
+            continue
+        city = _title_case_city(match.group("city"))
+        pin_zip = match.group("pin_zip")
+        address = " ".join(match.group("address").split()).strip(" ,")
+        return {
+            "city": city,
+            "state": state,
+            "pin_zip": pin_zip,
+            "address": address,
+            "location": f"{city}, {state}",
+            "source_url": source_url,
+        }
+    return None
+
+
+def _official_location_from_pdf(content: bytes, source_url: str) -> dict[str, str] | None:
+    import pdfplumber
+
+    with pdfplumber.open(io.BytesIO(content)) as pdf:
+        parts: list[str] = []
+        for page in pdf.pages[:8]:
+            parts.append(page.extract_text() or "")
+            if sum(len(part) for part in parts) > 20_000:
+                break
+    return _official_location_from_text(" ".join(parts), source_url)
+
+
+async def _official_pdf_location_for_crd(crd_number: str) -> dict[str, str] | None:
+    import httpx
+
+    normalized = re.sub(r"\D+", "", str(crd_number or ""))
+    if not normalized:
+        return None
+
+    timeout = httpx.Timeout(connect=6.0, read=24.0, write=6.0, pool=6.0)
+    headers = {
+        "User-Agent": "hushh-ria-onboarding/1.0 (+https://hushh.ai)",
+        "Accept": "application/pdf,*/*",
+    }
+    async with httpx.AsyncClient(
+        timeout=timeout,
+        follow_redirects=True,
+        headers=headers,
+    ) as client:
+        for template in _OFFICIAL_LOCATION_REPORT_URLS:
+            source_url = template.format(crd=normalized)
+            try:
+                response = await client.get(source_url)
+                response.raise_for_status()
+                location = await asyncio.to_thread(
+                    _official_location_from_pdf,
+                    response.content,
+                    source_url,
+                )
+            except Exception:
+                logger.info(
+                    "verify_ria_license: official PDF location fallback failed for %s",
+                    normalized,
+                    exc_info=True,
+                )
+                continue
+            if location:
+                return location
+    return None
 
 
 def _broker_exams(payload: dict[str, Any]) -> list[str]:
@@ -739,6 +886,15 @@ class RIAIAMService:
             bool(broker_data.get("verifiedName") or broker_data.get("crdNumber"))
             and broker_status != "NOT_FOUND"
         )
+        city = _broker_city(broker_data)
+        pin_zip = _broker_pin_zip(broker_data)
+        if found and (not city or not pin_zip):
+            official_location = await _official_pdf_location_for_crd(
+                str(broker_data.get("crdNumber") or normalized)
+            )
+            if official_location:
+                city = city or official_location.get("city")
+                pin_zip = pin_zip or official_location.get("pin_zip")
 
         response: dict[str, Any] = {
             "status": "found"
@@ -750,8 +906,8 @@ class RIAIAMService:
             "regulator_status": broker_data.get("status"),
             "license_expiry": None,
             "certifications": [],
-            "city": _broker_city(broker_data),
-            "pin_zip": _broker_pin_zip(broker_data),
+            "city": city,
+            "pin_zip": pin_zip,
             "crd_number": broker_data.get("crdNumber") or normalized,
             "sec_number": None,
             "employment_history": broker_data.get("employmentHistory", []),

--- a/consent-protocol/tests/test_ria_onboarding_v2.py
+++ b/consent-protocol/tests/test_ria_onboarding_v2.py
@@ -40,6 +40,7 @@ from hushh_mcp.services.crd_scrape_proxy_service import (  # noqa: E402
 from hushh_mcp.services.ria_iam_service import (  # noqa: E402
     RIAIAMPolicyError,
     RIAIAMService,
+    _official_location_from_text,
 )
 
 # ---------------------------------------------------------------------------
@@ -173,6 +174,80 @@ def test_verify_license_passes_through_city_pin_zip_and_string_exams(monkeypatch
     assert result["city"] == "Kennesaw"
     assert result["pin_zip"] == "30144"
     assert result["exams_passed"] == ["Series 65"]
+
+
+def test_verify_license_fills_missing_location_from_official_pdf(monkeypatch) -> None:
+    """When provider location is blank, use official regulator PDF text as fallback."""
+
+    class _FakeProxy:
+        async def broker_intelligence(self, *, query: str, request_id: str | None = None):
+            assert query == "7413463"
+            return CrdScrapeProviderResponse(
+                200,
+                {
+                    "verifiedName": "Andrew Garrett Kirkland",
+                    "currentFirm": "Not Currently Registered",
+                    "status": "Investment Adviser Representative",
+                    "crdNumber": "7413463",
+                    "city": None,
+                    "pinZip": None,
+                    "exams": ["Series 66"],
+                    "employmentHistory": [],
+                },
+            )
+
+        async def create_job(self, *, crd_number: str, request_id: str | None = None):
+            assert crd_number == "7413463"
+            return CrdScrapeProviderResponse(404, {"detail": "Not Found"})
+
+    async def _mock_official_location(crd_number: str):
+        assert crd_number == "7413463"
+        return {
+            "city": "Kennesaw",
+            "state": "GA",
+            "pin_zip": "30144",
+            "source_url": "https://reports.adviserinfo.sec.gov/reports/individual/individual_7413463.pdf",
+        }
+
+    monkeypatch.setattr(
+        "hushh_mcp.services.crd_scrape_proxy_service.CrdScrapeProxyService",
+        lambda: _FakeProxy(),
+    )
+    monkeypatch.setattr(
+        "hushh_mcp.services.ria_iam_service._official_pdf_location_for_crd",
+        _mock_official_location,
+    )
+
+    result = asyncio.run(
+        RIAIAMService().verify_ria_license(
+            _TEST_UID,
+            license_number="7413463",
+            regulator="SEC",
+        )
+    )
+
+    assert result["status"] == "found"
+    assert result["city"] == "Kennesaw"
+    assert result["pin_zip"] == "30144"
+    assert result["exams_passed"] == ["Series 66"]
+
+
+def test_official_location_from_text_extracts_city_and_zip() -> None:
+    """The fallback parser extracts address fields from official report text."""
+
+    result = _official_location_from_text(
+        "Business Address 114 Townpark Drive, Ste. 175 Kennesaw, GA 30144 Registered Since 09/2021",
+        "https://reports.adviserinfo.sec.gov/reports/individual/individual_7413463.pdf",
+    )
+
+    assert result == {
+        "city": "Kennesaw",
+        "state": "GA",
+        "pin_zip": "30144",
+        "address": "114 Townpark Drive, Ste. 175",
+        "location": "Kennesaw, GA",
+        "source_url": "https://reports.adviserinfo.sec.gov/reports/individual/individual_7413463.pdf",
+    }
 
 
 def test_verify_license_invalid_number_422() -> None:


### PR DESCRIPTION
## Summary
- add a narrow official regulator PDF fallback when RIA intelligence returns blank city or PIN ZIP
- keep provider location fields as the primary source when present
- cover CRD 7413463 extraction and verify-license fallback behavior in tests

## Verification
- consent-protocol targeted RIA onboarding test passed with test-only env values set locally
- hushh-webapp TypeScript check passed
- git diff --check
- live SEC/IAPD PDF extraction for CRD 7413463 returned Kennesaw, GA 30144

## Deploy note
- UAT provider deploy is blocked locally because ankit@hushh.ai lacks Cloud Build submit permission in hushh-pda-uat, so this backend fallback is the UAT unblock while the provider-side fix remains merged in hushh-ria-intelligence-api.