### PR TITLE
Show RIA verification exams as certifications

### DIFF
--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -896,6 +896,7 @@ class RIAIAMService:
                 city = city or official_location.get("city")
                 pin_zip = pin_zip or official_location.get("pin_zip")
 
+        broker_exams = _broker_exams(broker_data)
         response: dict[str, Any] = {
             "status": "found"
             if found
@@ -905,7 +906,7 @@ class RIAIAMService:
             "regulator": regulator or ("SEC" if found else None),
             "regulator_status": broker_data.get("status"),
             "license_expiry": None,
-            "certifications": [],
+            "certifications": broker_exams,
             "city": city,
             "pin_zip": pin_zip,
             "crd_number": broker_data.get("crdNumber") or normalized,
@@ -914,7 +915,7 @@ class RIAIAMService:
             "disclosures_count": broker_data.get("disclosures", {}).get("count", 0)
             if isinstance(broker_data.get("disclosures"), dict)
             else 0,
-            "exams_passed": _broker_exams(broker_data),
+            "exams_passed": broker_exams,
             "provider": "ria_intelligence_combined",
             "scrape_job_id": scrape_data.get("jobId"),
             "broker_intelligence_summary": broker_data.get("summary"),

--- a/consent-protocol/tests/test_ria_onboarding_v2.py
+++ b/consent-protocol/tests/test_ria_onboarding_v2.py
@@ -173,6 +173,7 @@ def test_verify_license_passes_through_city_pin_zip_and_string_exams(monkeypatch
     assert result["status"] == "found"
     assert result["city"] == "Kennesaw"
     assert result["pin_zip"] == "30144"
+    assert result["certifications"] == ["Series 65"]
     assert result["exams_passed"] == ["Series 65"]
 
 
@@ -229,6 +230,7 @@ def test_verify_license_fills_missing_location_from_official_pdf(monkeypatch) ->
     assert result["status"] == "found"
     assert result["city"] == "Kennesaw"
     assert result["pin_zip"] == "30144"
+    assert result["certifications"] == ["Series 66"]
     assert result["exams_passed"] == ["Series 66"]
 
 

--- a/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
@@ -1,4 +1,10 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -64,11 +70,9 @@ vi.mock("lucide-react", () => ({
 }));
 
 vi.mock("@/components/app-ui/fullscreen-flow-shell", () => ({
-  FullscreenFlowShell: ({
-    children,
-  }: {
-    children: React.ReactNode;
-  }) => <div data-testid="flow-shell">{children}</div>,
+  FullscreenFlowShell: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="flow-shell">{children}</div>
+  ),
 }));
 
 vi.mock("@/components/ria/onboarding/onboarding-shell", () => ({
@@ -117,7 +121,10 @@ vi.mock("@/components/ria/onboarding/onboarding-step-welcome", () => ({
   }) => (
     <div data-testid="step-welcome">
       <span data-testid="welcome-type">{onboardingType}</span>
-      <button data-testid="select-individual" onClick={() => onSelect("individual")}>
+      <button
+        data-testid="select-individual"
+        onClick={() => onSelect("individual")}
+      >
         Individual
       </button>
       <button data-testid="select-firm" onClick={() => onSelect("firm")}>
@@ -157,17 +164,24 @@ vi.mock("@/components/ria/onboarding/onboarding-step-license-details", () => ({
   OnboardingStepLicenseDetails: ({
     advisorName,
     firmName,
+    certifications,
     city,
     pinZip,
   }: {
     advisorName: string;
     firmName: string;
+    certifications: string[];
     city: string;
     pinZip: string;
   }) => (
     <div data-testid="step-license-details">
       <span data-testid="advisor-name">{advisorName}</span>
       <span data-testid="firm-name">{firmName}</span>
+      {certifications.map((certification) => (
+        <span key={certification} data-testid="certification">
+          {certification}
+        </span>
+      ))}
       <span data-testid="city">{city}</span>
       <span data-testid="pin-zip">{pinZip}</span>
     </div>
@@ -195,13 +209,22 @@ vi.mock("@/components/ria/onboarding/onboarding-step-review", () => ({
     <div data-testid="step-review">
       <span data-testid="review-name">{advisorName}</span>
       <span data-testid="advisory-ready">{String(advisoryAccessReady)}</span>
-      <button data-testid="edit-license" onClick={() => onEditSection("license")}>
+      <button
+        data-testid="edit-license"
+        onClick={() => onEditSection("license")}
+      >
         Edit Licence
       </button>
-      <button data-testid="edit-services" onClick={() => onEditSection("services")}>
+      <button
+        data-testid="edit-services"
+        onClick={() => onEditSection("services")}
+      >
         Edit Services
       </button>
-      <button data-testid="edit-contact" onClick={() => onEditSection("contact")}>
+      <button
+        data-testid="edit-contact"
+        onClick={() => onEditSection("contact")}
+      >
         Edit Contact
       </button>
     </div>
@@ -266,7 +289,7 @@ describe("RiaOnboardingPage", () => {
       verification_status: "draft",
     });
     mocks.riaService.setRiaMarketplaceDiscoverability.mockResolvedValue(
-      undefined
+      undefined,
     );
   });
 
@@ -309,7 +332,7 @@ describe("RiaOnboardingPage", () => {
 
   it("shows IAM unavailable banner on schema error", async () => {
     mocks.riaService.getOnboardingStatus.mockRejectedValue(
-      new Error("schema not ready")
+      new Error("schema not ready"),
     );
     render(<RiaOnboardingPage />);
 
@@ -325,6 +348,8 @@ describe("RiaOnboardingPage", () => {
       firm_name: "Acme Wealth",
       regulator: "SEC",
       regulator_status: "ACTIVE",
+      certifications: [],
+      exams_passed: ["Series 66", "SIE"],
       city: "Kennesaw",
       pin_zip: "30144",
       crd_number: "123456",
@@ -363,7 +388,7 @@ describe("RiaOnboardingPage", () => {
       expect(mocks.riaService.verifyOnboardingLicense).toHaveBeenCalledWith(
         "token-ria-1",
         expect.objectContaining({ license_number: "123456" }),
-        expect.any(Object)
+        expect.any(Object),
       );
     });
 
@@ -371,11 +396,14 @@ describe("RiaOnboardingPage", () => {
       () => {
         expect(screen.getByTestId("step-license-details")).toBeTruthy();
       },
-      { timeout: 3000 }
+      { timeout: 3000 },
     );
 
     expect(screen.getByTestId("advisor-name").textContent).toBe("Jane Doe");
     expect(screen.getByTestId("firm-name").textContent).toBe("Acme Wealth");
+    expect(
+      screen.getAllByTestId("certification").map((item) => item.textContent),
+    ).toEqual(["Series 66", "SIE"]);
     expect(screen.getByTestId("city").textContent).toBe("Kennesaw");
     expect(screen.getByTestId("pin-zip").textContent).toBe("30144");
   });
@@ -415,7 +443,7 @@ describe("RiaOnboardingPage", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("verification-status").textContent).toBe(
-        "not_found"
+        "not_found",
       );
     });
 
@@ -424,7 +452,7 @@ describe("RiaOnboardingPage", () => {
 
   it("handles rate limit (429) gracefully", async () => {
     mocks.riaService.verifyOnboardingLicense.mockRejectedValue(
-      new MockRiaApiError("rate limited", 429)
+      new MockRiaApiError("rate limited", 429),
     );
 
     render(<RiaOnboardingPage />);
@@ -453,7 +481,7 @@ describe("RiaOnboardingPage", () => {
 
     await waitFor(() => {
       expect(
-        (screen.getByTestId("license-input") as HTMLInputElement).value
+        (screen.getByTestId("license-input") as HTMLInputElement).value,
       ).toBe("123456");
     });
 
@@ -465,7 +493,7 @@ describe("RiaOnboardingPage", () => {
       expect(mocks.riaService.verifyOnboardingLicense).toHaveBeenCalledWith(
         "token-ria-1",
         expect.objectContaining({ license_number: "123456" }),
-        expect.any(Object)
+        expect.any(Object),
       );
     });
 
@@ -488,7 +516,7 @@ describe("RiaOnboardingPage", () => {
     await waitFor(() => {
       expect(mocks.draftService.save).toHaveBeenCalledWith(
         "user-ria-1",
-        expect.objectContaining({ onboardingType: "firm" })
+        expect.objectContaining({ onboardingType: "firm" }),
       );
     });
   });
@@ -556,7 +584,7 @@ describe("RiaOnboardingPage", () => {
           license_number: "7265726",
           individual_crd: "7265726",
           force_live_verification: false,
-        })
+        }),
       );
     });
   });

--- a/hushh-webapp/app/ria/onboarding/page.tsx
+++ b/hushh-webapp/app/ria/onboarding/page.tsx
@@ -45,15 +45,31 @@ function textValue(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
+function textArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.map(textValue).filter((item): item is string => item.length > 0)
+    : [];
+}
+
+function certificationsFromVerificationResult(
+  result: RiaLicenseVerificationResult,
+): string[] {
+  return Array.from(
+    new Set([
+      ...textArray(result.certifications),
+      ...textArray(result.exams_passed),
+    ]),
+  );
+}
+
 function locationPatchFromCrdReport(
-  report: NonNullable<CrdScrapeJobResult["report"]>
+  report: NonNullable<CrdScrapeJobResult["report"]>,
 ): Pick<RiaOnboardingDraft, "city" | "pinZip"> {
   const officialLocation = report.officialLocation;
-  const firmHistoryLocation =
-    (report.firmHistory?.find(
-      (entry) =>
-        typeof entry?.city === "string" && typeof entry?.state === "string"
-    ) ?? {}) as Record<string, unknown>;
+  const firmHistoryLocation = (report.firmHistory?.find(
+    (entry) =>
+      typeof entry?.city === "string" && typeof entry?.state === "string",
+  ) ?? {}) as Record<string, unknown>;
 
   return {
     city:
@@ -73,7 +89,7 @@ export default function RiaOnboardingPage() {
 
   const [status, setStatus] = useState<RiaOnboardingStatus | null>(null);
   const [draft, setDraft] = useState<RiaOnboardingDraft>(
-    normalizeRiaOnboardingDraft(undefined)
+    normalizeRiaOnboardingDraft(undefined),
   );
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -96,22 +112,22 @@ export default function RiaOnboardingPage() {
 
   const flowOptions = useMemo<RiaOnboardingFlowOptions>(
     () => ({ licenseVerificationSatisfied }),
-    [licenseVerificationSatisfied]
+    [licenseVerificationSatisfied],
   );
 
   const steps = useMemo(
     () => buildRiaOnboardingSteps(draft, flowOptions),
-    [draft, flowOptions]
+    [draft, flowOptions],
   );
   const currentStepIndex = useMemo(
     () => getRiaOnboardingStepIndex(draft, draft.currentStepId, flowOptions),
-    [draft, flowOptions]
+    [draft, flowOptions],
   );
   const currentStep = (steps[currentStepIndex] ?? steps[0])!;
   const canContinue = canContinueRiaOnboardingStep(
     currentStep.id,
     draft,
-    flowOptions
+    flowOptions,
   );
 
   useEffect(() => {
@@ -145,9 +161,8 @@ export default function RiaOnboardingPage() {
 
         const alreadyVerified =
           isAdvisoryAccessReady(
-            nextStatus?.advisory_status || nextStatus?.verification_status
-          ) &&
-          Boolean(nextStatus?.individual_crd || nextStatus?.finra_crd);
+            nextStatus?.advisory_status || nextStatus?.verification_status,
+          ) && Boolean(nextStatus?.individual_crd || nextStatus?.finra_crd);
 
         let resolvedDraft = seeded;
         if (alreadyVerified && nextStatus) {
@@ -164,9 +179,7 @@ export default function RiaOnboardingPage() {
               nextStatus.finra_crd ||
               "",
             firmName:
-              seeded.firmName ||
-              nextStatus.advisory_firm_legal_name ||
-              "",
+              seeded.firmName || nextStatus.advisory_firm_legal_name || "",
             licenseVerificationStatus: "found",
           });
         }
@@ -178,7 +191,7 @@ export default function RiaOnboardingPage() {
             licenseVerificationSatisfied:
               alreadyVerified ||
               resolvedDraft.licenseVerificationStatus === "found",
-          }
+          },
         );
 
         setStatus(nextStatus);
@@ -192,7 +205,7 @@ export default function RiaOnboardingPage() {
             setError(
               loadError instanceof Error
                 ? loadError.message
-                : "Failed to load RIA onboarding."
+                : "Failed to load RIA onboarding.",
             );
           }
         }
@@ -222,7 +235,7 @@ export default function RiaOnboardingPage() {
         clearInterval(scrapePollingRef.current);
       }
     },
-    []
+    [],
   );
 
   const updateDraft = useCallback(
@@ -236,12 +249,12 @@ export default function RiaOnboardingPage() {
           currentStepId: resolveRiaOnboardingStepId(
             next,
             next.currentStepId,
-            flowOptions
+            flowOptions,
           ),
         };
       });
     },
-    [flowOptions]
+    [flowOptions],
   );
 
   function moveToStep(stepId: RiaOnboardingStepId) {
@@ -273,10 +286,7 @@ export default function RiaOnboardingPage() {
       scrapePollingRef.current = setInterval(async () => {
         try {
           const result = await RiaService.getCrdScrapeJobStatus(jobId);
-          if (
-            result.status === "completed" ||
-            result.status === "partial"
-          ) {
+          if (result.status === "completed" || result.status === "partial") {
             if (scrapePollingRef.current) {
               clearInterval(scrapePollingRef.current);
               scrapePollingRef.current = null;
@@ -292,9 +302,7 @@ export default function RiaOnboardingPage() {
                 city: draft.city || locationPatch.city,
                 pinZip: draft.pinZip || locationPatch.pinZip,
                 certifications:
-                  draft.certifications.length > 0
-                    ? draft.certifications
-                    : [],
+                  draft.certifications.length > 0 ? draft.certifications : [],
               });
             }
           } else if (result.status === "failed") {
@@ -311,7 +319,13 @@ export default function RiaOnboardingPage() {
         }
       }, SCRAPE_POLL_INTERVAL_MS);
     },
-    [draft.firmName, draft.city, draft.pinZip, draft.certifications, updateDraft]
+    [
+      draft.firmName,
+      draft.city,
+      draft.pinZip,
+      draft.certifications,
+      updateDraft,
+    ],
   );
 
   async function handleVerifyLicense() {
@@ -326,7 +340,10 @@ export default function RiaOnboardingPage() {
 
     try {
       const idToken = await user.getIdToken();
-      const timeoutId = setTimeout(() => controller.abort(), LICENSE_VERIFICATION_TIMEOUT_MS);
+      const timeoutId = setTimeout(
+        () => controller.abort(),
+        LICENSE_VERIFICATION_TIMEOUT_MS,
+      );
 
       const result: RiaLicenseVerificationResult =
         await RiaService.verifyOnboardingLicense(
@@ -335,13 +352,14 @@ export default function RiaOnboardingPage() {
             license_number: draft.licenseNumber.trim(),
             regulator: draft.regulator || undefined,
           },
-          { signal: controller.signal }
+          { signal: controller.signal },
         );
 
       clearTimeout(timeoutId);
       if (controller.signal.aborted) return;
 
       if (result.status === "found") {
+        const certifications = certificationsFromVerificationResult(result);
         updateDraft({
           licenseVerificationStatus: "found",
           advisorName: result.advisor_name || "",
@@ -349,7 +367,7 @@ export default function RiaOnboardingPage() {
           regulator: result.regulator || draft.regulator || "",
           regulatorStatus: result.regulator_status || "",
           licenseExpiry: result.license_expiry || "",
-          certifications: result.certifications || [],
+          certifications,
           city: result.city || "",
           pinZip: result.pin_zip || "",
           crdNumber: result.crd_number || draft.licenseNumber.trim(),
@@ -399,7 +417,7 @@ export default function RiaOnboardingPage() {
       setError(
         verifyError instanceof Error
           ? verifyError.message
-          : "License verification failed."
+          : "License verification failed.",
       );
     } finally {
       if (!controller.signal.aborted) {
@@ -424,10 +442,16 @@ export default function RiaOnboardingPage() {
       const result = await RiaService.submitOnboarding(idToken, {
         display_name: draft.advisorName.trim() || draft.displayName.trim(),
         requested_capabilities: draft.requestedCapabilities,
-        individual_legal_name: draft.individualLegalName.trim() || draft.advisorName.trim() || undefined,
-        individual_crd: draft.individualCrd.trim() || draft.crdNumber.trim() || undefined,
-        advisory_firm_legal_name: draft.advisoryFirmName.trim() || draft.firmName.trim() || undefined,
-        advisory_firm_iapd_number: draft.advisoryFirmIapdNumber.trim() || undefined,
+        individual_legal_name:
+          draft.individualLegalName.trim() ||
+          draft.advisorName.trim() ||
+          undefined,
+        individual_crd:
+          draft.individualCrd.trim() || draft.crdNumber.trim() || undefined,
+        advisory_firm_legal_name:
+          draft.advisoryFirmName.trim() || draft.firmName.trim() || undefined,
+        advisory_firm_iapd_number:
+          draft.advisoryFirmIapdNumber.trim() || undefined,
         bio: draft.bio.trim() || undefined,
         strategy: draft.strategySummary.trim() || undefined,
         force_live_verification: shouldForceLiveVerification,
@@ -466,18 +490,15 @@ export default function RiaOnboardingPage() {
       ).toLowerCase();
 
       await RiaService.setRiaMarketplaceDiscoverability(idToken, {
-        enabled:
-          advisoryOutcome === "verified" || advisoryOutcome === "active",
+        enabled: advisoryOutcome === "verified" || advisoryOutcome === "active",
         headline: draft.headline.trim() || undefined,
-        strategy_summary: draft.strategySummary.trim() || draft.bio.trim() || undefined,
+        strategy_summary:
+          draft.strategySummary.trim() || draft.bio.trim() || undefined,
       }).catch(() => null);
 
       await refreshPersonaState({ force: true });
 
-      if (
-        advisoryOutcome === "verified" ||
-        advisoryOutcome === "active"
-      ) {
+      if (advisoryOutcome === "verified" || advisoryOutcome === "active") {
         await RiaOnboardingDraftLocalService.clear(user.uid);
         setShouldPersistDraft(false);
         toast.success("Credentials verified", {
@@ -486,8 +507,7 @@ export default function RiaOnboardingPage() {
       } else if (advisoryOutcome === "rejected") {
         toast.error("Verification failed", {
           description:
-            result.verification_message ||
-            "The license could not be verified.",
+            result.verification_message || "The license could not be verified.",
         });
         setError(result.verification_message || "Verification was rejected.");
       } else {
@@ -506,7 +526,8 @@ export default function RiaOnboardingPage() {
         individual_legal_name: result.individual_legal_name || undefined,
         individual_crd: result.individual_crd || undefined,
         advisory_firm_legal_name: result.advisory_firm_legal_name || undefined,
-        advisory_firm_iapd_number: result.advisory_firm_iapd_number || undefined,
+        advisory_firm_iapd_number:
+          result.advisory_firm_iapd_number || undefined,
       }));
 
       moveToStep("review");
@@ -518,7 +539,7 @@ export default function RiaOnboardingPage() {
       setError(
         submitError instanceof Error
           ? submitError.message
-          : "Failed to submit onboarding."
+          : "Failed to submit onboarding.",
       );
       toast.error("Could not submit verification", {
         description:
@@ -545,9 +566,7 @@ export default function RiaOnboardingPage() {
     }
   }
 
-  const isEnriching = Boolean(
-    draft.scrapeJobId && scrapePollingRef.current
-  );
+  const isEnriching = Boolean(draft.scrapeJobId && scrapePollingRef.current);
 
   function renderStep() {
     if (loading) {
@@ -570,8 +589,8 @@ export default function RiaOnboardingPage() {
     if (iamUnavailable) {
       return (
         <div className="rounded-[24px] border border-amber-200 bg-amber-50 px-4 py-6 text-sm text-foreground">
-          RIA onboarding is unavailable in this environment. The backend
-          IAM schema has not been activated yet.
+          RIA onboarding is unavailable in this environment. The backend IAM
+          schema has not been activated yet.
         </div>
       );
     }


### PR DESCRIPTION
## Summary
- map broker-intelligence exams into the onboarding verify-license certifications field
- keep exams_passed for API compatibility while allowing the frontend certification chips to render
- add backend and frontend regression coverage for exams-backed certifications

## Tests
- backend focused RIA onboarding suite: passed
- frontend typecheck: passed
- git diff --check: passed

## Local Vitest note
- Targeted onboarding-page Vitest still fails before test execution with vitest-pool worker startup timeout in this checkout, with both forks and threads pools.