### PR TITLE
fix(security): remove TESTING env var bypass from token revocation check

### DIFF
--- a/consent-protocol/hushh_mcp/consent/token.py
+++ b/consent-protocol/hushh_mcp/consent/token.py
@@ -5,7 +5,6 @@ import binascii
 import hashlib
 import hmac
 import logging
-import os
 import threading
 import time
 from typing import Optional, Tuple, Union
@@ -335,13 +334,9 @@ async def validate_token_with_db(
                 str(token_obj.agent_id),
             )
             if not is_active:
-                if str(os.getenv("TESTING", "")).strip().lower() == "true":
-                    logger.info("TESTING mode: skipping DB inactive check for token validation")
-                    return valid, reason, token_obj
-
                 # Add to in-memory set for future fast checks
                 _revoked_tokens.add(token_str)
-                logger.warning(f"Token revoked in DB but not in memory: {token_str[:30]}...")
+                logger.warning("Token revoked in DB but not in memory (fingerprint=%s)", _token_fingerprint(token_str))
                 return False, "Token has been revoked (DB check)", None
     except Exception as e:
         # DB is unreachable — apply fail-closed policy based on token scope.
@@ -382,6 +377,11 @@ def is_token_revoked(token_str: str) -> bool:
 
 
 # ========== Internal Signer ==========
+
+
+def _token_fingerprint(token_str: str) -> str:
+    """Return a short SHA-256 fingerprint of a token for safe log messages."""
+    return hashlib.sha256(token_str.encode()).hexdigest()[:12]
 
 
 def _sign(input_string: str) -> str:

--- a/consent-protocol/tests/test_token_testing_bypass_removed.py
+++ b/consent-protocol/tests/test_token_testing_bypass_removed.py
@@ -1,0 +1,64 @@
+# tests/test_token_testing_bypass_removed.py
+"""
+Canonical attach point:
+  hushh_mcp.consent.token.validate_token_with_db
+  -> api.routes.agents.validate_token_endpoint -> POST /api/validate-token
+
+Proves that even when TESTING=true is set in the environment, a token
+whose is_token_active returns False is correctly rejected by
+validate_token_with_db (i.e. the bypass block no longer exists).
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from hushh_mcp.consent.token import issue_token, validate_token_with_db
+from hushh_mcp.constants import ConsentScope
+
+
+class TestTokenRevocationBypassRemoved:
+    """validate_token_with_db must not bypass revocation when TESTING=true."""
+
+    @pytest.mark.asyncio
+    async def test_revoked_token_still_invalid_when_testing_true(self, monkeypatch):
+        monkeypatch.setenv("TESTING", "true")
+
+        token_obj = issue_token(
+            user_id="user-123",
+            agent_id="agent-abc",
+            scope=ConsentScope.PKM_READ,
+            expires_in_ms=60 * 60 * 1000,
+        )
+        token_str = token_obj.token
+
+        with patch(
+            "hushh_mcp.services.consent_db.ConsentDBService.is_token_active",
+            new=AsyncMock(return_value=False),
+        ):
+            valid, reason, _ = await validate_token_with_db(token_str)
+
+        assert valid is False, "Revoked token must be rejected even when TESTING=true"
+        assert reason is not None
+        assert "revoked" in reason.lower()
+
+    @pytest.mark.asyncio
+    async def test_active_token_still_valid_when_testing_true(self, monkeypatch):
+        monkeypatch.setenv("TESTING", "true")
+
+        token_obj = issue_token(
+            user_id="user-123",
+            agent_id="agent-abc",
+            scope=ConsentScope.PKM_READ,
+            expires_in_ms=60 * 60 * 1000,
+        )
+        token_str = token_obj.token
+
+        with patch(
+            "hushh_mcp.services.consent_db.ConsentDBService.is_token_active",
+            new=AsyncMock(return_value=True),
+        ):
+            valid, reason, result_obj = await validate_token_with_db(token_str)
+
+        assert valid is True
+        assert result_obj is not None


### PR DESCRIPTION
## What

validate_token_with_db contained a block that checked TESTING=true and, when set, returned valid=True for revoked tokens. This bypass allowed test environments to skip DB-side revocation checks entirely, but the TESTING env var is also present in production when operators forget to unset it, or in staging environments that connect to real data. The bypass block is removed; revocation checks now always run when the DB is reachable, regardless of any environment variable.

## Canonical attach point

hushh_mcp.consent.token.validate_token_with_db -> api.routes.agents.validate_token_endpoint -> POST /api/validate-token

## Proof

TestTokenRevocationBypassRemoved mocks ConsentDBService.is_token_active to return False, sets TESTING=true, and asserts the result is valid=False. A second test asserts that a non-revoked token still passes validation.

## Test plan

- [ ] Ruff clean
- [ ] DCO signed
- [ ] TestClient proof passes