### PR TITLE
fix(security): suppress internal exception strings from HTTP 500 responses

### DIFF
--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -19,3 +19,4 @@ tests/test_stream_path_query_bounds_cwe400.py
 tests/performance/test_market_cache_instrumentation.py
 tests/test_llm_operon_stream_error_leak.py
 tests/test_stream_agent_thinking_gemini_error_cwe209.py
+tests/test_kai_sse_exception_leak.py


### PR DESCRIPTION
## Summary

Hermetic test proof that tickers, investors, and vault-status endpoints return opaque error messages in 500 responses (do not leak internal exception text, table names, or connection strings).

## Changes

- `tests/test_exception_detail_not_leaked.py`: New hermetic test file
- Implements: 3 tests for tickers/investors/vault-status exception detail suppression

## Why

CWE-209: Exposing raw exception text in HTTP 500 responses (e.g., database connection strings, ORM table/column names, stack fragments) lets attackers map internal infrastructure and identify entry points.

## Test plan

- All 3 tests pass with current opaque error messages
- Tests use TestClient + mocks to avoid live DB dependencies