### PR TITLE
fix(vault): fix VaultKeysService per-request cache reset by using class-level cache dict

### DIFF
--- a/consent-protocol/hushh_mcp/services/vault_keys_service.py
+++ b/consent-protocol/hushh_mcp/services/vault_keys_service.py
@@ -5,9 +5,18 @@ Vault Keys Service
 
 Service layer for vault_keys + vault_key_wrappers operations.
 
+Canonical attach point:
+  hushh_mcp.services.vault_keys_service.VaultKeysService
+  -> api.routes.db_proxy -> POST /api/db-proxy/vault/status
+
 This service stores encrypted wrappers for the same vault DEK across enrolled
 unlock methods (passphrase, biometric, passkey/PRF) plus recovery wrapper.
 The backend never sees plaintext vault key material.
+
+Cache design:
+  _vault_state_cache is a class-level dict so the in-memory cache survives
+  per-request instantiation.  A fresh VaultKeysService() on every request
+  previously meant the cache was always empty and every request hit the DB.
 """
 
 from __future__ import annotations
@@ -39,9 +48,12 @@ class VaultKeysService:
 
     VAULT_STATE_CACHE_TTL_SECONDS = 180
 
+    # Class-level cache shared across all VaultKeysService instances so that
+    # per-request instantiation does not discard previously cached vault state.
+    _vault_state_cache: dict[str, tuple[float, Dict[str, Any]]] = {}
+
     def __init__(self):
         self._supabase = None
-        self._vault_state_cache: dict[str, tuple[float, Dict[str, Any]]] = {}
 
     def _get_supabase(self):
         """Get database client (private - ONLY for internal service use)."""

--- a/consent-protocol/tests/test_vault_keys_service_cache.py
+++ b/consent-protocol/tests/test_vault_keys_service_cache.py
@@ -1,0 +1,50 @@
+# tests/test_vault_keys_service_cache.py
+"""
+Canonical attach point:
+  hushh_mcp.services.vault_keys_service.VaultKeysService
+  -> api.routes.db_proxy -> POST /api/db-proxy/vault/status
+
+Proves that two separate VaultKeysService() instances share the same
+class-level cache, so a value written by one instance is readable from
+a second instance (simulating per-request instantiation).
+"""
+
+from hushh_mcp.services.vault_keys_service import VaultKeysService
+
+
+class TestVaultKeysServiceCacheShared:
+    """_vault_state_cache must be class-level and shared across instances."""
+
+    def setup_method(self):
+        # Start each test with a clean cache to avoid cross-test pollution.
+        VaultKeysService._vault_state_cache.clear()
+
+    def test_cache_is_class_attribute(self):
+        svc = VaultKeysService()
+        # The instance must NOT have its own copy of _vault_state_cache.
+        assert "_vault_state_cache" not in svc.__dict__, (
+            "_vault_state_cache must be a class attribute, not an instance attribute"
+        )
+
+    def test_two_instances_share_cache(self):
+        svc_a = VaultKeysService()
+        svc_b = VaultKeysService()
+
+        # Write via instance A.
+        svc_a._set_cached_vault_state("user-123", {"vaultKeyHash": "abc"})
+
+        # Read via instance B -- must see the cached value without a DB hit.
+        cached = svc_b._get_cached_vault_state("user-123")
+        assert cached is not None, "Instance B must see cache written by instance A"
+        assert cached["vaultKeyHash"] == "abc"
+
+    def test_invalidation_visible_across_instances(self):
+        svc_a = VaultKeysService()
+        svc_b = VaultKeysService()
+
+        svc_a._set_cached_vault_state("user-456", {"vaultKeyHash": "xyz"})
+        svc_b._invalidate_vault_state_cache("user-456")
+
+        # After invalidation by B, A must also see the cache as empty.
+        cached = svc_a._get_cached_vault_state("user-456")
+        assert cached is None, "Invalidation by one instance must be visible to all instances"


### PR DESCRIPTION
## What

VaultKeysService.__init__ initialised _vault_state_cache as an instance variable. Because FastAPI creates a new VaultKeysService() for every request, the cache was always empty on each request -- every vault-state read went to the database. Moving _vault_state_cache to a class-level dict means all instances share the same cache, so subsequent requests benefit from the 180-second TTL without an extra DB round-trip.

## Canonical attach point

hushh_mcp.services.vault_keys_service.VaultKeysService -> api.routes.db_proxy -> POST /api/db-proxy/vault/status

## Proof

TestVaultKeysServiceCacheShared proves the cache attribute is on the class (not the instance), that a value set via one VaultKeysService() instance is readable from a second instance, and that invalidation by one instance is reflected in others.

## Test plan

- [ ] Ruff clean
- [ ] DCO signed
- [ ] TestClient proof passes