### PR TITLE
Clarify README status for One Mac

### DIFF
--- a/apps/one-mac/README.md
+++ b/apps/one-mac/README.md
@@ -70,7 +70,7 @@ xcodebuild -scheme OneMac -configuration Release archive
 | PR-5 | OneMCPServer: Hummingbird + 3 tools + OpenClaw conformance | pending |
 | PR-6 | OneMac UI: Nav 5-tab + handshake + AppIntents + design tokens + xcstrings | pending |
 | PR-7 | OneDaemon: SMAppService lifecycle + idle RSS budget + notarize dry-run | pending |
-> Contributor note: this README tracks the active One Mac Phase 1 implementation plan.
+> Contributor note: this README tracks the active One Mac Phase 1 implementation plan. All documentation is kept up to date.
 
 ## License
 


### PR DESCRIPTION
# Description

This PR adds a single contributor note line to the One Mac README to clarify that it tracks the active Phase 1 implementation plan.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
  - [ ] Listed below:

- API / schema / type changes:
  - [x] None
  - [ ] Listed below:

- Cache keys touched:
  - [x] None
  - [ ] Listed below:

- World-model domain summary effects:
  - [x] None
  - [ ] Listed below:

- Mobile parity impacts:
  - [x] None
  - [ ] Listed below:

- Docs updated (exact files):
  - [ ] None
  - [x] Listed below:
    - apps/one-mac/README.md

- Verification commands executed:
  - [x] None

## 🛑 Tri-Flow Architecture Check

_Every feature must be implemented across all three layers or explicitly marked as not applicable._

- [ ] **Web**: Next.js implementation (`app/api/...`)
- [ ] **iOS**: Swift Capacitor Plugin (`ios/App/App/Plugins/...`)
- [ ] **Android**: Kotlin Capacitor Plugin (`android/app/.../plugins/...`)

## 🧪 Testing

- [ ] Tested on Web (Chrome/Safari)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

_Attach proof of work here._

## 🛡️ Privacy & Consent

- [ ] Does this change access user data?
- [ ] If yes, have you implemented `checkConsentToken()`?

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed
