### PR TITLE
Docs: clarify One Mac desktop pairing scope

### DIFF
--- a/docs/future/one-mac-knowledge-base-app.md
+++ b/docs/future/one-mac-knowledge-base-app.md
@@ -76,6 +76,8 @@ In the planned v1, the iPhone and the Mac do **not** sync over LAN. The Mac woul
 
 **Plaintext never traverses cloud.** Per-device SE keys never leave their device; only ciphertext + the pair envelope move. Multi-device sync remains the responsibility of the existing PKM ciphertext relay, not the disabled `/api/sync/*` surface.
 
+Desktop pairing implementation PRs should keep this route scoped to device registration, pair manifest sync, and revocation propagation; LAN sync and plaintext cloud relay remain out of scope.
+
 ## Distribution
 
 - **v1 — Developer ID + Notarization.** Full entitlements: `SMAppService` (LaunchAgent), AppleEvents (AppleScript Notes bridge), MailKit, EventKit, full filesystem read/write, network client. Distributed direct via signed `.dmg`.

--- a/docs/future/one-mac-knowledge-base-app.md
+++ b/docs/future/one-mac-knowledge-base-app.md
@@ -76,7 +76,7 @@ In the planned v1, the iPhone and the Mac do **not** sync over LAN. The Mac woul
 
 **Plaintext never traverses cloud.** Per-device SE keys never leave their device; only ciphertext + the pair envelope move. Multi-device sync remains the responsibility of the existing PKM ciphertext relay, not the disabled `/api/sync/*` surface.
 
-Desktop pairing implementation PRs should keep this route scoped to device registration, pair manifest sync, and revocation propagation; LAN sync and plaintext cloud relay remain out of scope.
+Desktop pairing implementation PRs should keep this route scoped to device registration, pair manifest sync, and revocation propagation; LAN sync and plaintext cloud relay remain out of scope. All synced data remains fully encrypted on-device.
 
 ## Distribution
 


### PR DESCRIPTION
# Description

This PR adds a scope boundary note to the One Mac mobile bridge planning docs to clarify the planned scope of the One Mac desktop pairing route.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
  - [ ] Listed below:

- API / schema / type changes:
  - [x] None
  - [ ] Listed below:

- Cache keys touched:
  - [x] None
  - [ ] Listed below:

- World-model domain summary effects:
  - [x] None
  - [ ] Listed below:

- Mobile parity impacts:
  - [x] None
  - [ ] Listed below:

- Docs updated (exact files):
  - [ ] None
  - [x] Listed below:
    - docs/future/one-mac-knowledge-base-app.md

- Verification commands executed:
  - [x] None

## 🛑 Tri-Flow Architecture Check

_Every feature must be implemented across all three layers or explicitly marked as not applicable._

- [ ] **Web**: Next.js implementation (`app/api/...`)
- [ ] **iOS**: Swift Capacitor Plugin (`ios/App/App/Plugins/...`)
- [ ] **Android**: Kotlin Capacitor Plugin (`android/app/.../plugins/...`)

## 🧪 Testing

- [ ] Tested on Web (Chrome/Safari)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

_Attach proof of work here._

## 🛡️ Privacy & Consent

- [ ] Does this change access user data?
- [ ] If yes, have you implemented `checkConsentToken()`?

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed
