### PR TITLE
fix(security): replace token[:30] log prefix with SHA-256 hash fingerprint

### DIFF
--- a/consent-protocol/hushh_mcp/services/consent_db.py
+++ b/consent-protocol/hushh_mcp/services/consent_db.py
@@ -30,6 +30,7 @@ Usage:
     )
 """
 
+import hashlib
 import json
 import logging
 from datetime import datetime, timezone
@@ -41,6 +42,11 @@ from hushh_mcp.consent.scope_helpers import scope_matches
 from hushh_mcp.services.consent_request_links import build_consent_request_url
 
 logger = logging.getLogger(__name__)
+
+
+def _token_fingerprint(token: str) -> str:
+    """Return a 12-char SHA-256 fingerprint for safe log messages."""
+    return hashlib.sha256(token.encode()).hexdigest()[:12]
 
 
 class ConsentDBService:
@@ -1701,8 +1707,8 @@ class ConsentDBService:
         normalized_bundle = self._normalize_wrapped_key_bundle(wrapped_key_bundle)
         if normalized_bundle is None:
             logger.error(
-                "Refusing to store consent export without a wrapped key bundle token=%s",
-                consent_token[:30],
+                "Refusing to store consent export without a wrapped key bundle token_fp=%s",
+                _token_fingerprint(consent_token),
             )
             return False
 
@@ -1731,7 +1737,7 @@ class ConsentDBService:
                 on_conflict="consent_token",
             ).execute()
 
-            logger.info(f"Stored consent export for token: {consent_token[:30]}...")
+            logger.info("Stored consent export for token_fp=%s", _token_fingerprint(consent_token))
             return True
         except Exception as e:
             logger.error(f"Failed to store consent export: {e}")
@@ -1811,7 +1817,7 @@ class ConsentDBService:
         try:
             supabase.table("consent_exports").delete().eq("consent_token", consent_token).execute()
 
-            logger.info(f"Deleted consent export for token: {consent_token[:30]}...")
+            logger.info("Deleted consent export for token_fp=%s", _token_fingerprint(consent_token))
             return True
         except Exception as e:
             logger.error(f"Failed to delete consent export: {e}")

--- a/consent-protocol/tests/test_token_log_fingerprint.py
+++ b/consent-protocol/tests/test_token_log_fingerprint.py
@@ -1,0 +1,95 @@
+# tests/test_token_log_fingerprint.py
+"""
+Canonical attach point:
+  hushh_mcp.services.consent_db._token_fingerprint
+  -> hushh_mcp.services.consent_db.ConsentDBService.store_consent_export
+  -> api.routes.consent.approve_consent -> POST /api/consent/{requestId}/approve
+
+Proves that log statements in ConsentDBService no longer emit raw token
+prefix slices; instead they emit a 12-character SHA-256 hex fingerprint that
+cannot be used to reconstruct or brute-force the original token value.
+"""
+
+import hashlib
+import logging
+
+from hushh_mcp.services.consent_db import _token_fingerprint
+
+_SAMPLE_TOKEN_STR = "hushh_consent:abc123def456.sig"  # noqa: S105
+_SAMPLE_TOKEN_SECRET = "hushh_consent:realsecretvalue.invalidsig"  # noqa: S105
+_SAMPLE_TOKEN_DELETE = "hushh_consent:secretdeletetoken.fakesig"  # noqa: S105
+
+
+class TestTokenLogFingerprint:
+    """_token_fingerprint must return a 12-char hex digest, not the raw prefix."""
+
+    def test_fingerprint_is_twelve_hex_chars(self):
+        fp = _token_fingerprint(_SAMPLE_TOKEN_STR)
+        assert len(fp) == 12
+        assert all(c in "0123456789abcdef" for c in fp)
+
+    def test_fingerprint_matches_sha256(self):
+        expected = hashlib.sha256(_SAMPLE_TOKEN_STR.encode()).hexdigest()[:12]
+        assert _token_fingerprint(_SAMPLE_TOKEN_STR) == expected
+
+    def test_raw_prefix_not_equal_to_fingerprint(self):
+        fp = _token_fingerprint(_SAMPLE_TOKEN_STR)
+        raw_prefix = _SAMPLE_TOKEN_STR[:12]
+        assert fp != raw_prefix, "Fingerprint must not equal raw token prefix"
+
+    def test_store_consent_export_logs_fingerprint_not_raw(self, caplog):
+        """store_consent_export must log the fingerprint, not the raw token value."""
+        consent_str = _SAMPLE_TOKEN_SECRET
+        fp = _token_fingerprint(consent_str)
+
+        from unittest.mock import MagicMock, patch
+
+        service_path = "hushh_mcp.services.consent_db.ConsentDBService._get_supabase"
+        with caplog.at_level(logging.ERROR, logger="hushh_mcp.services.consent_db"):
+            with patch(service_path) as mock_sb:
+                # Force the wrapped-key-bundle guard to log by passing None bundle
+                mock_sb.return_value = MagicMock()
+                import asyncio
+
+                from hushh_mcp.services.consent_db import ConsentDBService
+
+                svc = ConsentDBService()
+                result = asyncio.run(
+                    svc.store_consent_export(
+                        user_id="user-1",
+                        consent_token=consent_str,
+                        encrypted_data="enc",
+                        iv="iv",
+                        tag="tag",
+                        wrapped_key_bundle=None,
+                        expires_at_ms=9999999999999,
+                    )
+                )
+
+        assert result is False
+        log_text = " ".join(caplog.messages)
+        assert "realsecretvalue" not in log_text, "Raw token must not appear in logs"
+        assert fp in log_text, "SHA-256 fingerprint must appear in logs"
+
+    def test_delete_consent_export_logs_fingerprint_not_raw(self, caplog):
+        """delete_consent_export must log fingerprint, not the raw token prefix."""
+        consent_str = _SAMPLE_TOKEN_DELETE
+        fp = _token_fingerprint(consent_str)
+
+        from unittest.mock import MagicMock, patch
+
+        with caplog.at_level(logging.INFO, logger="hushh_mcp.services.consent_db"):
+            with patch(
+                "hushh_mcp.services.consent_db.ConsentDBService._get_supabase"
+            ) as mock_sb:
+                mock_sb.return_value = MagicMock()
+                import asyncio
+
+                from hushh_mcp.services.consent_db import ConsentDBService
+
+                svc = ConsentDBService()
+                asyncio.run(svc.delete_consent_export(consent_token=consent_str))
+
+        log_text = " ".join(caplog.messages)
+        assert "secretdeletetoken" not in log_text, "Raw token slice must not appear in logs"
+        assert fp in log_text, "SHA-256 fingerprint must appear in logs"


### PR DESCRIPTION
## What

Log statements in `ConsentDBService` used a raw 30-character token prefix (`consent_token[:30]`) in three places: the wrapped-key-bundle guard, the store-success message, and the delete-success message. A raw prefix is a partial credential: it can be used in brute-force or dictionary attacks against the full token. This PR replaces all three occurrences with a 12-character SHA-256 hex fingerprint (`hashlib.sha256(token.encode()).hexdigest()[:12]`) that is irreversible and unique enough for log correlation without leaking the credential.

## Canonical attach point

`hushh_mcp.services.consent_db.ConsentDBService.store_consent_export` and `delete_consent_export` -> called by `api.routes.consent.approve_consent` -> POST /api/consent/{requestId}/approve

## Proof

`tests/test_token_log_fingerprint.py` captures log output when `store_consent_export` is called with a `None` wrapped-key-bundle (triggering the error path) and when `delete_consent_export` runs against a mock Supabase client. Both tests assert that the raw token string is absent from the captured log and that the 12-char SHA-256 fingerprint is present.

## Test plan

- [ ] Ruff clean
- [ ] DCO signed
- [ ] Rebased on upstream/main
- [ ] TestClient proof added