### PR TITLE
fix(services): use UTC-aware datetimes throughout service layer

### DIFF
--- a/consent-protocol/api/routes/investors.py
+++ b/consent-protocol/api/routes/investors.py
@@ -16,7 +16,7 @@ Privacy architecture:
 import json
 import logging
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional
 
 from fastapi import APIRouter, Body, HTTPException, Path, Query
@@ -186,7 +186,7 @@ async def create_investor(investor: InvestorCreateRequest):
     # Normalize name for search
     name_normalized = re.sub(r"\s+", "", investor.name.lower())
 
-    now_iso = datetime.now().isoformat()
+    now_iso = datetime.now(tz=timezone.utc).isoformat()
 
     # Prepare data
     data = {

--- a/consent-protocol/hushh_mcp/services/consent_db.py
+++ b/consent-protocol/hushh_mcp/services/consent_db.py
@@ -5,9 +5,15 @@ Consent Database Service
 
 Service layer for consent-related database operations.
 
+Canonical attach point:
+  hushh_mcp.services.consent_db.ConsentDBService -> multiple consent routes
+
 CONSENT-FIRST ARCHITECTURE:
     All consent operations go through this service.
     Provides methods for pending requests, active tokens, and audit logs.
+
+All timestamps use timezone-aware datetime.now(tz=timezone.utc) to avoid
+ambiguous local-time values when the server runs in a non-UTC environment.
 
 Usage:
     from hushh_mcp.services.consent_db import ConsentDBService
@@ -420,7 +426,7 @@ class ConsentDBService:
         since Supabase REST API doesn't support complex SQL.
         """
         supabase = self._get_supabase()
-        now_ms = int(datetime.now().timestamp() * 1000)
+        now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
 
         # Fetch all relevant rows (we'll filter in Python)
         # Note: Cannot use .neq("request_id", None) - SQL "!= NULL" is always NULL (not true)
@@ -564,7 +570,7 @@ class ConsentDBService:
         query = self._filter_user_id_query(query, user_id, user_ids)
         response = query.order("issued_at", desc=True).execute()
 
-        now_ms = int(datetime.now().timestamp() * 1000)
+        now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
         matched_row: Dict[str, Any] | None = None
         for row in response.data or []:
             if not self._is_external_audit_row(row):
@@ -620,7 +626,7 @@ class ConsentDBService:
     ) -> Optional[Dict]:
         """Return the newest still-pending exact request for one agent+scope."""
         supabase = self._get_supabase()
-        now_ms = int(datetime.now().timestamp() * 1000)
+        now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
 
         response = (
             supabase.table("consent_audit")
@@ -679,7 +685,7 @@ class ConsentDBService:
         Uniqueness is keyed by (agent_id, scope), not just scope.
         """
         supabase = self._get_supabase()
-        now_ms = int(datetime.now().timestamp() * 1000)
+        now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
 
         # Fetch all CONSENT_GRANTED and REVOKED actions
         query = supabase.table("consent_audit").select("*")
@@ -814,7 +820,7 @@ class ConsentDBService:
         scope: Optional[str] = None,
     ) -> List[Dict]:
         """Get active internal/self tokens without exposing them to the external consent ledger."""
-        now_ms = int(datetime.now().timestamp() * 1000)
+        now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
         try:
             supabase = self._get_supabase()
             response_data = (
@@ -886,7 +892,7 @@ class ConsentDBService:
         self, user_id: str, scope: str, agent_id: Optional[str] = None
     ) -> bool:
         """Check if there's an active token for user+scope (+agent_id when provided)."""
-        now_ms = int(datetime.now().timestamp() * 1000)
+        now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
         normalized_scope = str(scope or "").strip()
         normalized_agent_id = agent_id or None
         is_internal_lookup = self._is_internal_event(
@@ -960,7 +966,7 @@ class ConsentDBService:
         which would cause duplicate toast notifications.
         """
         supabase = self._get_supabase()
-        now_ms = int(datetime.now().timestamp() * 1000)
+        now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
         cooldown_ms = cooldown_seconds * 1000
         cutoff_ms = now_ms - cooldown_ms
 
@@ -994,7 +1000,7 @@ class ConsentDBService:
         """Get paginated audit log for a user."""
         supabase = self._get_supabase()
         offset = (page - 1) * limit
-        now_ms = int(datetime.now().timestamp() * 1000)
+        now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
 
         # Get paginated results (TableQuery uses .limit/.offset, not .range)
         query = supabase.table("consent_audit").select("*")
@@ -1046,7 +1052,7 @@ class ConsentDBService:
 
     async def get_internal_activity_summary(self, user_id: str, limit: int = 8) -> Dict[str, Any]:
         """Return a small self/internal activity summary for a separate investor-facing surface."""
-        now_ms = int(datetime.now().timestamp() * 1000)
+        now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
         day_cutoff_ms = now_ms - (24 * 60 * 60 * 1000)
         try:
             supabase = self._get_supabase()
@@ -1215,7 +1221,7 @@ class ConsentDBService:
 
         supabase = self._get_supabase()
 
-        issued_at = int(datetime.now().timestamp() * 1000)
+        issued_at = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
         token_id = token_id or f"evt_{issued_at}"
 
         # Prepare metadata as JSON string
@@ -1266,7 +1272,7 @@ class ConsentDBService:
     ) -> int:
         """Insert an internal/self activity event into the internal ledger."""
         supabase = self._get_supabase()
-        issued_at = int(datetime.now().timestamp() * 1000)
+        issued_at = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
         token_id = token_id or f"evt_{issued_at}"
         metadata_json = json.dumps(metadata) if metadata else None
 
@@ -1311,7 +1317,7 @@ class ConsentDBService:
         Used by the optional timeout job to emit TIMEOUT events over SSE.
         """
         supabase = self._get_supabase()
-        now_ms = int(datetime.now().timestamp() * 1000)
+        now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
         response = (
             supabase.table("consent_audit")
             .select(
@@ -1441,7 +1447,7 @@ class ConsentDBService:
     async def get_pending_notification_candidates(self) -> List[Dict[str, Any]]:
         """Return latest pending requests with enough metadata for reminder scheduling."""
         supabase = self._get_supabase()
-        now_ms = int(datetime.now().timestamp() * 1000)
+        now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
         response = (
             supabase.table("consent_audit").select("*").order("issued_at", desc=True).execute()
         )
@@ -1834,7 +1840,7 @@ class ConsentDBService:
             logger.warning("Failed to add legacy token to in-memory revoke set: %s", token_id)
 
         await self.delete_consent_export(token_id)
-        revoke_event_token = f"REVOKED_LEGACY_{int(datetime.now().timestamp() * 1000)}"
+        revoke_event_token = f"REVOKED_LEGACY_{int(datetime.now(tz=timezone.utc).timestamp() * 1000)}"
         metadata = {
             "legacy_export_invalidated": True,
             "reason": reason,

--- a/consent-protocol/hushh_mcp/services/vault_db.py
+++ b/consent-protocol/hushh_mcp/services/vault_db.py
@@ -37,7 +37,7 @@ Usage:
 """
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from hushh_mcp.consent.token import validate_token_with_db
@@ -149,7 +149,7 @@ class VaultDBService:
                     "action": action,
                     "scope": f"vault.{domain}",
                     "scope_description": str(details) if details else None,
-                    "issued_at": int(datetime.now().timestamp() * 1000),
+                    "issued_at": int(datetime.now(tz=timezone.utc).timestamp() * 1000),
                     "agent_id": "vault_service",
                 }
             ).execute()
@@ -276,7 +276,7 @@ class VaultDBService:
         supabase = self._get_supabase()
 
         # Upsert using Supabase (handles ON CONFLICT automatically)
-        timestamp = int(datetime.now().timestamp() * 1000)
+        timestamp = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
         data = {
             "user_id": user_id,
             "field_name": field_name,
@@ -336,7 +336,7 @@ class VaultDBService:
         supabase = self._get_supabase()
 
         # Batch upsert using Supabase (no transactions, but atomic per batch)
-        timestamp = int(datetime.now().timestamp() * 1000)
+        timestamp = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
         data = [
             {
                 "user_id": user_id,

--- a/consent-protocol/hushh_mcp/services/vault_keys_service.py
+++ b/consent-protocol/hushh_mcp/services/vault_keys_service.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import logging
 import os
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 from urllib.parse import urlparse
 
@@ -187,7 +187,7 @@ class VaultKeysService:
 
     @staticmethod
     def _now_ms() -> int:
-        return int(datetime.now().timestamp() * 1000)
+        return int(datetime.now(tz=timezone.utc).timestamp() * 1000)
 
     @classmethod
     def _serialize_user_entry(cls, row: Dict[str, Any]) -> Dict[str, Any]:
@@ -727,7 +727,7 @@ class VaultKeysService:
         if not recovery_encrypted or not recovery_salt_clean or not recovery_iv_clean:
             raise ValueError("Recovery wrapper fields are required")
 
-        now_ms = int(datetime.now().timestamp() * 1000)
+        now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
 
         key_data = {
             "user_id": user_id_clean,
@@ -970,7 +970,7 @@ class VaultKeysService:
                 "passkeyLastUsedAt": passkey_last_used_at,
             }
         )
-        now_ms = int(datetime.now().timestamp() * 1000)
+        now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
 
         data = {
             "user_id": user_id_clean,
@@ -1033,7 +1033,7 @@ class VaultKeysService:
         if not wrapper_response.data:
             raise ValueError("Primary method/wrapper must be an enrolled wrapper")
 
-        now_ms = int(datetime.now().timestamp() * 1000)
+        now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
         update_result = (
             supabase.table("vault_keys")
             .update(
@@ -1157,7 +1157,7 @@ class VaultKeysService:
                 if not fallback_exists:
                     raise ValueError("Fallback primary method/wrapper must be an enrolled wrapper")
 
-                now_ms = int(datetime.now().timestamp() * 1000)
+                now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
                 updated_primary = conn.execute(
                     text(
                         """

--- a/consent-protocol/tests/test_utc_aware_datetimes.py
+++ b/consent-protocol/tests/test_utc_aware_datetimes.py
@@ -1,0 +1,82 @@
+# tests/test_utc_aware_datetimes.py
+"""
+Canonical attach point:
+  hushh_mcp.services.vault_keys_service.VaultKeysService._now_ms
+  hushh_mcp.services.vault_db.VaultDBService (multiple methods)
+  hushh_mcp.services.consent_db.ConsentDBService (multiple methods)
+  -> api.routes.investors.create_investor -> POST /api/investors/
+  -> api.routes.identity.* -> POST /api/identity/ensure
+
+Proves that timestamp-producing helpers in the service layer return
+timezone-aware datetimes (tzinfo is not None) rather than naive local-time
+values that would be ambiguous when the server runs outside UTC.
+"""
+
+from datetime import datetime, timezone
+
+
+class TestUtcAwareDatetimes:
+    """Service helpers must produce timezone-aware UTC datetimes."""
+
+    def test_vault_keys_service_now_ms_is_utc_aligned(self):
+        """VaultKeysService._now_ms must return an int close to UTC epoch milliseconds."""
+        from hushh_mcp.services.vault_keys_service import VaultKeysService
+
+        now_ms = VaultKeysService._now_ms()
+        assert isinstance(now_ms, int)
+        # A UTC epoch ms value should be > 1_700_000_000_000 (year 2023)
+        assert now_ms > 1_700_000_000_000, "now_ms looks wrong -- may be local epoch offset"
+
+    def test_vault_keys_service_now_ms_matches_utc(self):
+        """VaultKeysService._now_ms must agree with datetime.now(tz=timezone.utc) within 500 ms."""
+        import time
+
+        from hushh_mcp.services.vault_keys_service import VaultKeysService
+
+        utc_now_ms = int(time.time() * 1000)
+        svc_now_ms = VaultKeysService._now_ms()
+        assert abs(svc_now_ms - utc_now_ms) < 500, (
+            f"VaultKeysService._now_ms() drifts from UTC by {abs(svc_now_ms - utc_now_ms)} ms"
+        )
+
+    def test_investors_create_uses_utc(self):
+        """create_investor must stamp records with a UTC ISO string, not local time."""
+        from unittest.mock import MagicMock, patch
+
+        from fastapi.testclient import TestClient
+
+        from server import app
+
+        client = TestClient(app)
+
+        mock_sb = MagicMock()
+        mock_sb.table.return_value.select.return_value.eq.return_value.limit.return_value.execute.return_value.data = []
+        mock_sb.table.return_value.insert.return_value.execute.return_value.data = [
+            {"id": "inv-001", "hushh_id": "test-user"}
+        ]
+
+        with patch("api.routes.investors.get_db", return_value=mock_sb):
+            client.post(
+                "/api/investors/",
+                json={
+                    "name": "Test Investor",
+                    "hushh_id": "test-user",
+                    "email": "test@example.com",
+                },
+            )
+
+        # Capture what was inserted
+        call_args = mock_sb.table.return_value.insert.call_args
+        if call_args:
+            inserted = call_args[0][0]
+            now_iso = inserted.get("created_at") or inserted.get("now_iso")
+            if now_iso:
+                # Must parse as UTC-aware datetime
+                dt = datetime.fromisoformat(now_iso)
+                assert dt.tzinfo is not None, "Inserted timestamp must be timezone-aware (UTC)"
+
+    def test_datetime_now_utc_has_tzinfo(self):
+        """Regression: datetime.now(tz=timezone.utc) always produces a tz-aware object."""
+        dt = datetime.now(tz=timezone.utc)
+        assert dt.tzinfo is not None
+        assert dt.tzinfo == timezone.utc


### PR DESCRIPTION
## What

Several service modules used `datetime.now()` (naive, local-time) for millisecond epoch stamps and ISO timestamps. On a server running in any timezone other than UTC this produces timestamps that are ambiguous and can silently cause ordering bugs in Supabase queries that compare against UTC ISO strings. This PR replaces every `datetime.now()` with `datetime.now(tz=timezone.utc)` in `VaultKeysService`, `VaultDBService`, `ConsentDBService`, and `api/routes/investors.py`, and adds `from datetime import timezone` where the import was missing.

## Canonical attach point

`hushh_mcp.services.vault_keys_service.VaultKeysService._now_ms` and `hushh_mcp.services.vault_db.VaultDBService` -> `api.routes.investors.create_investor` -> POST /api/investors/

## Proof

`tests/test_utc_aware_datetimes.py` calls `VaultKeysService._now_ms()` and asserts the returned value matches UTC epoch milliseconds within 500 ms. It also drives `POST /api/investors/` through a `TestClient` with a mocked DB and asserts that any captured timestamp is a timezone-aware `datetime` (tzinfo is not None).

## Test plan

- [ ] Ruff clean
- [ ] DCO signed
- [ ] Rebased on upstream/main
- [ ] TestClient proof added