### PR TITLE
Fix RIA onboarding official location prefill

### DIFF
--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -176,6 +176,42 @@ def _broker_pin_zip(payload: dict[str, Any]) -> str | None:
     )
 
 
+def _broker_state(payload: dict[str, Any]) -> str | None:
+    return _first_text_value(
+        payload.get("state"),
+        payload.get("businessState"),
+        payload.get("business_state"),
+        payload.get("region"),
+    )
+
+
+def _broker_area_locality(payload: dict[str, Any]) -> str | None:
+    return _first_text_value(
+        payload.get("areaLocality"),
+        payload.get("area_locality"),
+        payload.get("businessArea"),
+        payload.get("business_area"),
+        payload.get("locality"),
+    )
+
+
+def _broker_street_address(payload: dict[str, Any]) -> str | None:
+    return _first_text_value(
+        payload.get("fullStreetAddress"),
+        payload.get("full_street_address"),
+        payload.get("streetAddress"),
+        payload.get("street_address"),
+        payload.get("businessAddress"),
+        payload.get("business_address"),
+        payload.get("address"),
+    )
+
+
+def _broker_official_location(payload: dict[str, Any]) -> dict[str, Any] | None:
+    value = payload.get("officialLocation") or payload.get("official_location")
+    return value if isinstance(value, dict) else None
+
+
 def _title_case_city(value: str) -> str:
     small_words = {"of", "and", "the"}
     parts: list[str] = []
@@ -897,13 +933,43 @@ class RIAIAMService:
         )
         city = _broker_city(broker_data)
         pin_zip = _broker_pin_zip(broker_data)
-        if found and (not city or not pin_zip):
-            official_location = await _official_pdf_location_for_crd(
+        state = _broker_state(broker_data)
+        area_locality = _broker_area_locality(broker_data)
+        full_street_address = _broker_street_address(broker_data)
+        official_location: dict[str, Any] | None = _broker_official_location(broker_data)
+        if official_location:
+            city = city or official_location.get("city")
+            pin_zip = pin_zip or official_location.get("pin_zip") or official_location.get("pinZip")
+            state = state or official_location.get("state")
+            area_locality = (
+                area_locality
+                or official_location.get("area_locality")
+                or official_location.get("areaLocality")
+                or official_location.get("state")
+                or official_location.get("location")
+            )
+            full_street_address = (
+                full_street_address
+                or official_location.get("address")
+                or official_location.get("streetAddress")
+                or official_location.get("fullStreetAddress")
+            )
+        if found and (not city or not pin_zip or not state or not full_street_address):
+            pdf_location = await _official_pdf_location_for_crd(
                 str(broker_data.get("crdNumber") or normalized)
             )
-            if official_location:
-                city = city or official_location.get("city")
-                pin_zip = pin_zip or official_location.get("pin_zip")
+            if pdf_location:
+                official_location = {**pdf_location, **(official_location or {})}
+                city = city or pdf_location.get("city")
+                pin_zip = pin_zip or pdf_location.get("pin_zip")
+                state = state or pdf_location.get("state")
+                area_locality = (
+                    area_locality
+                    or pdf_location.get("area_locality")
+                    or pdf_location.get("state")
+                    or pdf_location.get("location")
+                )
+                full_street_address = full_street_address or pdf_location.get("address")
 
         broker_exams = _broker_exams(broker_data)
         response: dict[str, Any] = {
@@ -918,6 +984,11 @@ class RIAIAMService:
             "certifications": broker_exams,
             "city": city,
             "pin_zip": pin_zip,
+            "state": state,
+            "area_locality": area_locality,
+            "full_street_address": full_street_address,
+            "business_address": full_street_address,
+            "official_location": official_location,
             "crd_number": broker_data.get("crdNumber") or normalized,
             "sec_number": None,
             "employment_history": broker_data.get("employmentHistory", []),

--- a/consent-protocol/tests/test_ria_onboarding_v2.py
+++ b/consent-protocol/tests/test_ria_onboarding_v2.py
@@ -163,6 +163,22 @@ def test_verify_license_passes_through_city_pin_zip_and_string_exams(monkeypatch
         lambda: _FakeProxy(),
     )
 
+    async def _mock_official_location(crd_number: str):
+        assert crd_number == "7413463"
+        return {
+            "city": "Kennesaw",
+            "state": "GA",
+            "pin_zip": "30144",
+            "address": "114 Townpark Drive, Ste. 175",
+            "location": "Kennesaw, GA",
+            "source_url": "https://reports.adviserinfo.sec.gov/reports/individual/individual_7413463.pdf",
+        }
+
+    monkeypatch.setattr(
+        "hushh_mcp.services.ria_iam_service._official_pdf_location_for_crd",
+        _mock_official_location,
+    )
+
     result = asyncio.run(
         RIAIAMService().verify_ria_license(
             _TEST_UID,
@@ -174,6 +190,10 @@ def test_verify_license_passes_through_city_pin_zip_and_string_exams(monkeypatch
     assert result["status"] == "found"
     assert result["city"] == "Kennesaw"
     assert result["pin_zip"] == "30144"
+    assert result["state"] == "GA"
+    assert result["area_locality"] == "GA"
+    assert result["full_street_address"] == "114 Townpark Drive, Ste. 175"
+    assert result["official_location"]["source_url"].endswith("individual_7413463.pdf")
     assert result["certifications"] == ["Series 65"]
     assert result["exams_passed"] == ["Series 65"]
 
@@ -208,6 +228,8 @@ def test_verify_license_fills_missing_location_from_official_pdf(monkeypatch) ->
             "city": "Kennesaw",
             "state": "GA",
             "pin_zip": "30144",
+            "address": "114 Townpark Drive, Ste. 175",
+            "location": "Kennesaw, GA",
             "source_url": "https://reports.adviserinfo.sec.gov/reports/individual/individual_7413463.pdf",
         }
 
@@ -231,6 +253,9 @@ def test_verify_license_fills_missing_location_from_official_pdf(monkeypatch) ->
     assert result["status"] == "found"
     assert result["city"] == "Kennesaw"
     assert result["pin_zip"] == "30144"
+    assert result["state"] == "GA"
+    assert result["area_locality"] == "GA"
+    assert result["full_street_address"] == "114 Townpark Drive, Ste. 175"
     assert result["certifications"] == ["Series 66"]
     assert result["exams_passed"] == ["Series 66"]
 
@@ -340,8 +365,17 @@ def test_verify_ria_license_exposes_summary_and_exams_as_prefill(monkeypatch) ->
     async def _mock_get_pool():
         raise RuntimeError("no database in unit test")
 
+    async def _mock_official_location(crd_number: str):
+        assert crd_number == "7413463"
+        return None
+
     monkeypatch.setattr(CrdScrapeProxyService, "broker_intelligence", _mock_broker_intelligence)
     monkeypatch.setattr(CrdScrapeProxyService, "create_job", _mock_create_job)
+    monkeypatch.setattr(
+        ria_iam_service_module,
+        "_official_pdf_location_for_crd",
+        _mock_official_location,
+    )
     monkeypatch.setattr(ria_iam_service_module, "get_pool", _mock_get_pool)
 
     payload = asyncio.run(

--- a/hushh-webapp/__tests__/lib/ria/ria-onboarding-prefill.test.ts
+++ b/hushh-webapp/__tests__/lib/ria/ria-onboarding-prefill.test.ts
@@ -42,6 +42,78 @@ describe("ria-onboarding-prefill", () => {
     expect(patch.individualCrd).toBe("7413463");
   });
 
+  it("prepopulates official PDF-backed location from the license verification response", () => {
+    const draft = createEmptyRiaOnboardingDraft();
+    const result: RiaLicenseVerificationResult = {
+      status: "found",
+      advisor_name: "Andrew Garrett Kirkland",
+      firm_name: "Financial Advocates Advisory Services",
+      regulator: "SEC",
+      regulator_status: "Investment Adviser Representative",
+      crd_number: "7413463",
+      provider: "ria_intelligence_combined",
+      city: "Kennesaw",
+      state: "GA",
+      area_locality: "GA",
+      pin_zip: "30144",
+      full_street_address: "114 Townpark Drive, Ste. 175",
+      official_location: {
+        city: "Kennesaw",
+        state: "GA",
+        pin_zip: "30144",
+        address: "114 Townpark Drive, Ste. 175",
+        source_url:
+          "https://reports.adviserinfo.sec.gov/reports/individual/individual_7413463.pdf",
+      },
+    };
+
+    const patch = buildRiaLicensePrefillPatch(draft, result, "7413463");
+
+    expect(patch.city).toBe("Kennesaw");
+    expect(patch.areaLocality).toBe("GA");
+    expect(patch.pinZip).toBe("30144");
+    expect(patch.fullStreetAddress).toBe("114 Townpark Drive, Ste. 175");
+    expect(patch.bio).toContain("Primary location: Kennesaw, GA.");
+  });
+
+  it("replaces stale draft location as one set when official scrape data disagrees", () => {
+    const draft = {
+      ...createEmptyRiaOnboardingDraft(),
+      advisorName: "Andrew Garrett Kirkland",
+      firmName: "Financial Advocates Advisory Services",
+      regulatorStatus: "Active",
+      crdNumber: "7413463",
+      city: "Pune",
+      areaLocality: "Maharashtra",
+      pinZip: "411015",
+      fullStreetAddress: "Army Institute of Technology, Pune",
+    };
+    const result: CrdScrapeJobResult = {
+      jobId: "crd_scrape_test",
+      status: "completed",
+      crdNumber: "7413463",
+      reportAvailable: true,
+      report: {
+        fullName: "Andrew Garrett Kirkland",
+        registrationStatus: "active",
+        officialLocation: {
+          city: "Kennesaw",
+          state: "GA",
+          pinZip: "30144",
+          address: "114 Townpark Drive, Ste. 175",
+        },
+      },
+    };
+
+    const patch = buildRiaScrapePrefillPatch(draft, result);
+
+    expect(patch.city).toBe("Kennesaw");
+    expect(patch.areaLocality).toBe("GA");
+    expect(patch.pinZip).toBe("30144");
+    expect(patch.fullStreetAddress).toBe("114 Townpark Drive, Ste. 175");
+    expect(patch.bio).toContain("Primary location: Kennesaw, GA.");
+  });
+
   it("prepopulates official scrape location, exams, fees, minimums, and bio fallback", () => {
     const draft = {
       ...createEmptyRiaOnboardingDraft(),

--- a/hushh-webapp/components/ria/onboarding/onboarding-step-services.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-step-services.tsx
@@ -212,7 +212,7 @@ export function OnboardingStepServices({
               type="text"
               value={areaLocality}
               onChange={(e) => onAreaLocalityChange(e.target.value)}
-              placeholder="Downtown, Mission District"
+              placeholder="Area or state"
               className="h-11 w-full rounded-[22px] border border-border/70 bg-background/75 px-4 text-sm text-foreground outline-none focus:border-[#0071E3] focus:ring-1 focus:ring-[#0071E3]/30 transition-colors"
             />
           </div>
@@ -240,7 +240,7 @@ export function OnboardingStepServices({
             inputMode="numeric"
             value={pinZip}
             onChange={(e) => onPinZipChange(e.target.value)}
-            placeholder="30144"
+            placeholder="PIN / ZIP"
             className="h-11 w-full rounded-[22px] border border-border/70 bg-background/75 px-4 text-sm text-foreground outline-none focus:border-[#0071E3] focus:ring-1 focus:ring-[#0071E3]/30 transition-colors"
           />
         </div>

--- a/hushh-webapp/lib/ria/ria-onboarding-prefill.ts
+++ b/hushh-webapp/lib/ria/ria-onboarding-prefill.ts
@@ -90,6 +90,96 @@ function pickExistingOrNext(existing: string, next: string): string {
   return existing.trim() || next.trim();
 }
 
+type LocationPrefill = {
+  city: string;
+  areaLocality: string;
+  pinZip: string;
+  fullStreetAddress: string;
+};
+
+function emptyLocationPrefill(): LocationPrefill {
+  return { city: "", areaLocality: "", pinZip: "", fullStreetAddress: "" };
+}
+
+function hasLocationPrefill(location: LocationPrefill): boolean {
+  return Boolean(
+    location.city ||
+      location.areaLocality ||
+      location.pinZip ||
+      location.fullStreetAddress
+  );
+}
+
+function normalizeLocationPart(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function locationValueConflicts(existing: string, next: string): boolean {
+  const current = normalizeLocationPart(existing);
+  const incoming = normalizeLocationPart(next);
+  return Boolean(current && incoming && current !== incoming);
+}
+
+function shouldReplaceDraftLocation(
+  draft: RiaOnboardingDraft,
+  location: LocationPrefill,
+  crdNumber: string
+): boolean {
+  if (!hasLocationPrefill(location)) return false;
+
+  const currentCrd = (draft.crdNumber || draft.individualCrd || "").trim();
+  const hasDraftLocation = Boolean(
+    draft.city.trim() ||
+      draft.areaLocality.trim() ||
+      draft.pinZip.trim() ||
+      draft.fullStreetAddress.trim()
+  );
+
+  if (hasDraftLocation && currentCrd && crdNumber && currentCrd !== crdNumber) {
+    return true;
+  }
+
+  return (
+    locationValueConflicts(draft.city, location.city) ||
+    locationValueConflicts(draft.areaLocality, location.areaLocality) ||
+    locationValueConflicts(draft.pinZip, location.pinZip) ||
+    locationValueConflicts(draft.fullStreetAddress, location.fullStreetAddress)
+  );
+}
+
+function buildLocationPatch(
+  draft: RiaOnboardingDraft,
+  location: LocationPrefill,
+  crdNumber: string
+): Pick<
+  Partial<RiaOnboardingDraft>,
+  "city" | "areaLocality" | "pinZip" | "fullStreetAddress"
+> {
+  if (!hasLocationPrefill(location)) return {};
+  const replace = shouldReplaceDraftLocation(draft, location, crdNumber);
+  if (replace) {
+    return {
+      city: location.city,
+      areaLocality: location.areaLocality,
+      pinZip: location.pinZip,
+      fullStreetAddress: location.fullStreetAddress,
+    };
+  }
+
+  return {
+    city: pickExistingOrNext(draft.city, location.city),
+    areaLocality: pickExistingOrNext(draft.areaLocality, location.areaLocality),
+    pinZip: pickExistingOrNext(draft.pinZip, location.pinZip),
+    fullStreetAddress: pickExistingOrNext(
+      draft.fullStreetAddress,
+      location.fullStreetAddress
+    ),
+  };
+}
+
 function collectText(value: unknown, depth = 0, output: string[] = []): string[] {
   if (output.length > 80 || depth > 4 || value == null) return output;
   if (typeof value === "string") {
@@ -219,15 +309,12 @@ function extractBestFirmHistory(
     )[0] || null;
 }
 
-function extractOfficialLocation(scrapeResult: CrdScrapeJobResult | null | undefined): {
-  city: string;
-  areaLocality: string;
-  pinZip: string;
-  fullStreetAddress: string;
-} {
+function extractOfficialLocation(
+  scrapeResult: CrdScrapeJobResult | null | undefined
+): LocationPrefill {
   const official = scrapeResult?.report?.officialLocation;
   if (!official || typeof official !== "object" || Array.isArray(official)) {
-    return { city: "", areaLocality: "", pinZip: "", fullStreetAddress: "" };
+    return emptyLocationPrefill();
   }
   const record = official as Record<string, unknown>;
   const city = cleanString(record.city as Textish);
@@ -244,6 +331,42 @@ function extractOfficialLocation(scrapeResult: CrdScrapeJobResult | null | undef
       cleanString(record.address as Textish) ||
       cleanString(record.streetAddress as Textish) ||
       cleanString(record.fullStreetAddress as Textish),
+  };
+}
+
+function extractLicenseLocation(
+  result: RiaLicenseVerificationResult
+): LocationPrefill {
+  const official =
+    result.official_location &&
+    typeof result.official_location === "object" &&
+    !Array.isArray(result.official_location)
+      ? (result.official_location as Record<string, unknown>)
+      : {};
+  const city =
+    cleanString(result.city) ||
+    cleanString(official.city as Textish) ||
+    cleanString(official.businessCity as Textish);
+  const state = cleanString(result.state) || cleanString(official.state as Textish);
+  return {
+    city,
+    areaLocality:
+      cleanString(result.area_locality) ||
+      state ||
+      cleanString(official.areaLocality as Textish) ||
+      cleanString(official.location as Textish),
+    pinZip:
+      cleanString(result.pin_zip) ||
+      cleanString(official.pin_zip as Textish) ||
+      cleanString(official.pinZip as Textish) ||
+      cleanString(official.zip as Textish) ||
+      cleanString(official.postalCode as Textish),
+    fullStreetAddress:
+      cleanString(result.full_street_address) ||
+      cleanString(result.business_address) ||
+      cleanString(official.address as Textish) ||
+      cleanString(official.streetAddress as Textish) ||
+      cleanString(official.fullStreetAddress as Textish),
   };
 }
 
@@ -295,6 +418,13 @@ export function buildRiaLicensePrefillPatch(
   const firmName = cleanString(result.firm_name) || draft.firmName;
   const regulatorStatus = cleanString(result.regulator_status) || draft.regulatorStatus;
   const crdNumber = cleanString(result.crd_number) || submittedLicense || draft.crdNumber;
+  const locationPatch = buildLocationPatch(
+    draft,
+    extractLicenseLocation(result),
+    crdNumber
+  );
+  const prefillCity = locationPatch.city ?? draft.city;
+  const prefillAreaLocality = locationPatch.areaLocality ?? draft.areaLocality;
   const certifications = uniqueStrings([
     ...draft.certifications,
     ...extractCertifications(result, null),
@@ -325,8 +455,8 @@ export function buildRiaLicensePrefillPatch(
       firmName,
       crdNumber,
       regulatorStatus,
-      city: draft.city,
-      areaLocality: draft.areaLocality,
+      city: prefillCity,
+      areaLocality: prefillAreaLocality,
       certifications,
       summary:
         cleanString(result.bio) ||
@@ -343,8 +473,7 @@ export function buildRiaLicensePrefillPatch(
     regulatorStatus,
     licenseExpiry: cleanString(result.license_expiry) || draft.licenseExpiry,
     certifications,
-    city: pickExistingOrNext(draft.city, cleanString(result.city)),
-    pinZip: pickExistingOrNext(draft.pinZip, cleanString(result.pin_zip)),
+    ...locationPatch,
     crdNumber,
     secNumber: cleanString(result.sec_number) || draft.secNumber,
     servicesOffered: services,
@@ -372,19 +501,30 @@ export function buildRiaScrapePrefillPatch(
 
   const bestFirm = extractBestFirmHistory(result, draft.firmName);
   const officialLocation = extractOfficialLocation(result);
+  const scrapedLocation: LocationPrefill = {
+    city: officialLocation.city || cleanString(bestFirm?.city as Textish),
+    areaLocality:
+      officialLocation.areaLocality || cleanString(bestFirm?.state as Textish),
+    pinZip: officialLocation.pinZip,
+    fullStreetAddress: officialLocation.fullStreetAddress,
+  };
+  const crdNumber = draft.crdNumber || cleanString(result.crdNumber);
+  const locationPatch = buildLocationPatch(draft, scrapedLocation, crdNumber);
+  const hasLocationPatchField = (
+    key: "city" | "areaLocality" | "pinZip" | "fullStreetAddress"
+  ) => Object.prototype.hasOwnProperty.call(locationPatch, key);
   const city =
-    officialLocation.city ||
-    cleanString(bestFirm?.city as Textish) ||
-    draft.city;
+    hasLocationPatchField("city")
+      ? locationPatch.city || ""
+      : scrapedLocation.city || draft.city;
   const areaLocality =
-    officialLocation.areaLocality ||
-    cleanString(bestFirm?.state as Textish) ||
-    draft.areaLocality;
+    hasLocationPatchField("areaLocality")
+      ? locationPatch.areaLocality || ""
+      : scrapedLocation.areaLocality || draft.areaLocality;
   const firmName =
     draft.firmName ||
     cleanString(bestFirm?.firmName as Textish) ||
     cleanString(bestFirm?.firm as Textish);
-  const crdNumber = draft.crdNumber || cleanString(result.crdNumber);
   const certifications = uniqueStrings([
     ...draft.certifications,
     ...extractCertifications(null, result),
@@ -416,13 +556,7 @@ export function buildRiaScrapePrefillPatch(
     advisorName: draft.advisorName || cleanString(report.fullName),
     firmName,
     certifications,
-    city: pickExistingOrNext(draft.city, city),
-    areaLocality: pickExistingOrNext(draft.areaLocality, areaLocality),
-    pinZip: pickExistingOrNext(draft.pinZip, officialLocation.pinZip),
-    fullStreetAddress: pickExistingOrNext(
-      draft.fullStreetAddress,
-      officialLocation.fullStreetAddress
-    ),
+    ...locationPatch,
     servicesOffered: services,
     feeStructure: fees,
     minEngagementAmount:

--- a/hushh-webapp/lib/services/ria-service.ts
+++ b/hushh-webapp/lib/services/ria-service.ts
@@ -121,6 +121,11 @@ export interface RiaLicenseVerificationResult {
   certifications?: string[];
   city?: string | null;
   pin_zip?: string | null;
+  state?: string | null;
+  area_locality?: string | null;
+  full_street_address?: string | null;
+  business_address?: string | null;
+  official_location?: Record<string, unknown> | null;
   crd_number?: string | null;
   sec_number?: string | null;
   employment_history?: Array<Record<string, unknown>>;


### PR DESCRIPTION
## Summary
- pass official PDF/provider address, state, and full location fields through verify-license
- merge RIA onboarding location as one trusted set so stale draft data cannot mix with official CRD data
- replace fake location placeholders with neutral editable placeholders

## Tests
- npx vitest run __tests__/lib/ria/ria-onboarding-prefill.test.ts --environment=node --pool=threads --no-file-parallelism --maxWorkers=1
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest --noconftest tests/test_ria_onboarding_v2.py tests/test_crd_scraper_routes.py -q
- npm run typecheck
- python3 scripts/ci/test_resolve_deploy_scope.py
- git diff --check

## Notes
- This change touches backend and frontend, so UAT deploy should use scope=all. Frontend-only changes can now rely on the existing scope=auto resolver to avoid rebuilding backend.