### PR TITLE
Allow RIA onboarding past phone mandate

### DIFF
--- a/hushh-webapp/__tests__/components/phone-mandate-guard.test.tsx
+++ b/hushh-webapp/__tests__/components/phone-mandate-guard.test.tsx
@@ -141,6 +141,27 @@ describe("PhoneMandateGuard", () => {
     expect(replace).not.toHaveBeenCalled();
   });
 
+  it("keeps RIA onboarding reachable without asking for phone verification again", async () => {
+    pathnameValue = "/ria/onboarding";
+    authValue = {
+      user: { uid: "ria-user" },
+      loading: false,
+      phoneNumber: null,
+    };
+    checkVaultMock.mockResolvedValue(false);
+
+    render(
+      <PhoneMandateGuard>
+        <div>ria onboarding content</div>
+      </PhoneMandateGuard>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("ria onboarding content")).toBeTruthy();
+    });
+    expect(replace).not.toHaveBeenCalled();
+  });
+
   it("keeps localhost development users in the app without requiring phone verification", async () => {
     vi.stubEnv("NEXT_PUBLIC_APP_ENV", "development");
     checkVaultMock.mockResolvedValue(false);

--- a/hushh-webapp/components/auth/phone-mandate-guard.tsx
+++ b/hushh-webapp/components/auth/phone-mandate-guard.tsx
@@ -129,6 +129,7 @@ export function PhoneMandateGuard({
       hasVault,
       exemptVaultUsers,
       hostname,
+      pathname,
     });
 
   useEffect(() => {

--- a/hushh-webapp/lib/services/phone-mandate-service.ts
+++ b/hushh-webapp/lib/services/phone-mandate-service.ts
@@ -21,14 +21,23 @@ export function shouldBypassPhoneMandateForLocalhost(hostname?: string | null): 
   );
 }
 
+export function shouldBypassPhoneMandateForRoute(pathname?: string | null): boolean {
+  return String(pathname ?? "").trim() === ROUTES.RIA_ONBOARDING;
+}
+
 export function shouldRequirePhoneMandate(params: {
   phoneNumber?: string | null;
   phoneVerified?: boolean | null;
   hasVault: boolean;
   exemptVaultUsers?: boolean;
   hostname?: string | null;
+  pathname?: string | null;
 }): boolean {
   if (params.phoneVerified === true || hasVerifiedPhoneNumber(params.phoneNumber)) {
+    return false;
+  }
+
+  if (shouldBypassPhoneMandateForRoute(params.pathname)) {
     return false;
   }
 


### PR DESCRIPTION
## Summary
- exempt `/ria/onboarding` from the global phone mandate so RIA setup no longer asks for phone verification before the advisor onboarding flow
- keep the phone mandate unchanged for profile and other protected routes
- add a guard regression test for the RIA onboarding route

## Current truth
- UAT backend/frontend RIA verify-license now returns official location/certification data for CRD 7413463.
- Browser verification found a separate UI blocker: the signed-in UAT browser was redirected to `/register-phone?redirect=%2Fria%2Fonboarding` before the RIA flow could load.
- This matches the product boundary that RIA onboarding should not ask for email/phone again; auth already owns identity.

## Tests
- `npm run typecheck`
- `git diff --check`

## Local runner note
- `npx vitest run __tests__/components/phone-mandate-guard.test.tsx --environment=jsdom --pool=threads --no-file-parallelism --maxWorkers=1` hit this checkout's existing Vitest worker-start issue before importing tests: `Timeout waiting for worker to respond`.
- Retried with `--pool=forks`; same worker-start issue. CI web check should run this in the normal GitHub runner.
