### PR TITLE
Cache RIA license verification results

### DIFF
--- a/consent-protocol/api/routes/ria.py
+++ b/consent-protocol/api/routes/ria.py
@@ -78,6 +78,7 @@ class RIAOnboardingVerifyNameRequest(BaseModel):
 class RIAOnboardingVerifyLicenseRequest(BaseModel):
     license_number: str = Field(..., min_length=1)
     regulator: str | None = None
+    force_live_verification: bool = False
 
 
 class RIAConsentRequestCreate(BaseModel):
@@ -269,6 +270,7 @@ async def verify_onboarding_license(
             firebase_uid,
             license_number=payload.license_number,
             regulator=payload.regulator,
+            force_live_verification=payload.force_live_verification,
         )
     except IAMSchemaNotReadyError as exc:
         return _iam_schema_not_ready_response(str(exc))

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 53,
+  "expected_migration_version": 54,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/db/migrations/054_ria_license_verification_cache_index.sql
+++ b/consent-protocol/db/migrations/054_ria_license_verification_cache_index.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS idx_ria_license_verifications_cache_lookup
+  ON ria_license_verifications (
+    user_id,
+    license_number,
+    verification_source,
+    status,
+    created_at DESC
+  );
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -30,7 +30,8 @@
     "050_one_kyc_client_connector_registry.sql",
     "051_one_kyc_metadata_token_redaction.sql",
     "052_actor_verified_email_aliases.sql",
-    "053_ria_onboarding_v2_fields.sql"
+    "053_ria_onboarding_v2_fields.sql",
+    "054_ria_license_verification_cache_index.sql"
   ],
   "groups": {
     "iam": [
@@ -50,7 +51,8 @@
       "041_ria_pick_package_metadata.sql",
       "042_ria_pick_single_active_record.sql",
       "043_ria_pick_share_artifacts.sql",
-      "053_ria_onboarding_v2_fields.sql"
+      "053_ria_onboarding_v2_fields.sql",
+      "054_ria_license_verification_cache_index.sql"
     ],
     "pkm": [
       "030_pkm_cutover.sql",

--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -1080,6 +1080,7 @@ class RIAIAMService:
         *,
         license_number: str,
         regulator: str | None = None,
+        force_live_verification: bool = False,
     ) -> dict[str, Any]:
         from hushh_mcp.services.crd_scrape_proxy_service import (
             CrdScrapeProxyService,
@@ -1087,6 +1088,15 @@ class RIAIAMService:
         )
 
         normalized = normalize_crd_number(license_number)
+        if not force_live_verification:
+            cached_response = await self._lookup_recent_license_verification_response(
+                user_id=user_id,
+                license_number=normalized,
+                regulator=regulator,
+            )
+            if cached_response is not None:
+                return cached_response
+
         proxy = CrdScrapeProxyService()
 
         broker_task = asyncio.create_task(proxy.broker_intelligence(query=normalized))
@@ -1123,25 +1133,121 @@ class RIAIAMService:
             scrape_result.payload if scrape_result and scrape_result.status_code < 400 else None
         ) or {}
 
-        broker_status = str(broker_data.get("status", "")).upper()
         broker_status_code = broker_result.status_code if broker_result else None
-        found = (
+        official_profile: dict[str, Any] | None = None
+        broker_status = str(broker_data.get("status", "")).upper()
+        found_from_broker = (
             bool(broker_data.get("verifiedName") or broker_data.get("crdNumber"))
             and broker_status != "NOT_FOUND"
         )
-        official_profile: dict[str, Any] | None = None
         if (
-            not found
+            not found_from_broker
             and not scrape_data.get("jobId")
             and (broker_status in {"", "NOT_FOUND"} or (broker_status_code or 0) >= 400)
         ):
             official_profile = await _official_pdf_profile_for_crd(normalized)
+
+        response = await self._build_ria_license_verification_response(
+            broker_data=broker_data,
+            scrape_data=scrape_data,
+            normalized_license=normalized,
+            regulator=regulator,
+            official_profile=official_profile,
+            allow_slow_fallbacks=True,
+        )
+        found = response["status"] == "found"
+        response = self._add_license_cache_metadata(response, cache_hit=False)
+
+        # Store audit trail
+        try:
+            audit_payload = dict(broker_data)
             if official_profile:
-                found = bool(
-                    official_profile.get("advisor_name")
-                    or official_profile.get("crd_number")
-                    or official_profile.get("official_location")
+                audit_payload["official_profile"] = official_profile
+                audit_payload["broker_status_code"] = broker_status_code
+            pool = await get_pool()
+            async with pool.acquire() as conn:
+                await conn.execute(
+                    """
+                    INSERT INTO ria_license_verifications
+                      (user_id, license_number, regulator, verification_source, raw_response, status)
+                    VALUES ($1, $2, $3, $4, $5::jsonb, $6)
+                    """,
+                    user_id,
+                    normalized,
+                    regulator,
+                    "broker_intelligence",
+                    json.dumps(audit_payload),
+                    "completed" if found else "pending",
                 )
+        except Exception:
+            logger.warning("verify_ria_license: failed to store audit for %s", normalized)
+
+        return response
+
+    @staticmethod
+    def _coerce_utc_datetime(value: Any) -> datetime | None:
+        if isinstance(value, datetime):
+            return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        if isinstance(value, str):
+            try:
+                parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except ValueError:
+                return None
+            return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+        return None
+
+    @classmethod
+    def _isoformat_utc(cls, value: Any) -> str | None:
+        parsed = cls._coerce_utc_datetime(value)
+        if parsed is None:
+            return None
+        return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    @classmethod
+    def _add_license_cache_metadata(
+        cls,
+        response: dict[str, Any],
+        *,
+        cache_hit: bool,
+        cached_at: Any = None,
+    ) -> dict[str, Any]:
+        response["cache_hit"] = cache_hit
+        response["cache_ttl_seconds"] = int(_RIA_LICENSE_VERIFICATION_REUSE_TTL.total_seconds())
+        cached_at_dt = cls._coerce_utc_datetime(cached_at)
+        if cached_at_dt is not None:
+            response["cached_at"] = cls._isoformat_utc(cached_at_dt)
+            response["cache_expires_at"] = cls._isoformat_utc(
+                cached_at_dt + _RIA_LICENSE_VERIFICATION_REUSE_TTL
+            )
+        return response
+
+    async def _build_ria_license_verification_response(
+        self,
+        *,
+        broker_data: dict[str, Any],
+        scrape_data: dict[str, Any],
+        normalized_license: str,
+        regulator: str | None,
+        official_profile: dict[str, Any] | None = None,
+        allow_slow_fallbacks: bool = False,
+    ) -> dict[str, Any]:
+        broker_data = broker_data if isinstance(broker_data, dict) else {}
+        scrape_data = scrape_data if isinstance(scrape_data, dict) else {}
+        if official_profile is None and isinstance(broker_data.get("official_profile"), dict):
+            official_profile = broker_data.get("official_profile")
+            broker_data = {}
+
+        broker_status = str(broker_data.get("status", "")).upper()
+        found = (
+            bool(broker_data.get("verifiedName") or broker_data.get("crdNumber"))
+            and broker_status != "NOT_FOUND"
+        )
+        if official_profile:
+            found = found or bool(
+                official_profile.get("advisor_name")
+                or official_profile.get("crd_number")
+                or official_profile.get("official_location")
+            )
 
         city = _broker_city(broker_data)
         pin_zip = _broker_pin_zip(broker_data)
@@ -1172,9 +1278,13 @@ class RIAIAMService:
                 or official_location.get("streetAddress")
                 or official_location.get("fullStreetAddress")
             )
-        if found and (not city or not pin_zip or not state or not full_street_address):
+        if (
+            allow_slow_fallbacks
+            and found
+            and (not city or not pin_zip or not state or not full_street_address)
+        ):
             pdf_location = await _official_pdf_location_for_crd(
-                str(broker_data.get("crdNumber") or normalized)
+                str(broker_data.get("crdNumber") or normalized_license)
             )
             if pdf_location:
                 official_location = {**pdf_location, **(official_location or {})}
@@ -1209,7 +1319,7 @@ class RIAIAMService:
         broker_summary = broker_data.get("summary") or (
             official_profile.get("summary") if official_profile else None
         )
-        response: dict[str, Any] = {
+        return {
             "status": "found"
             if found
             else ("pending" if scrape_data.get("jobId") else "not_found"),
@@ -1228,7 +1338,7 @@ class RIAIAMService:
             "official_location": official_location,
             "crd_number": broker_data.get("crdNumber")
             or (official_profile.get("crd_number") if official_profile else None)
-            or normalized,
+            or normalized_license,
             "sec_number": None,
             "employment_history": broker_data.get("employmentHistory", []),
             "disclosures_count": broker_data.get("disclosures", {}).get("count", 0)
@@ -1241,31 +1351,60 @@ class RIAIAMService:
             "bio": broker_summary,
         }
 
-        # Store audit trail
+    async def _lookup_recent_license_verification_response(
+        self,
+        *,
+        user_id: str,
+        license_number: str,
+        regulator: str | None = None,
+    ) -> dict[str, Any] | None:
         try:
-            audit_payload = broker_data or {
-                "official_profile": official_profile,
-                "broker_status_code": broker_status_code,
-            }
             pool = await get_pool()
             async with pool.acquire() as conn:
-                await conn.execute(
+                row = await conn.fetchrow(
                     """
-                    INSERT INTO ria_license_verifications
-                      (user_id, license_number, regulator, verification_source, raw_response, status)
-                    VALUES ($1, $2, $3, $4, $5::jsonb, $6)
+                    SELECT raw_response, regulator, created_at
+                    FROM ria_license_verifications
+                    WHERE user_id = $1
+                      AND license_number = $2
+                      AND verification_source = 'broker_intelligence'
+                      AND status = 'completed'
+                      AND created_at >= $3
+                    ORDER BY created_at DESC
+                    LIMIT 1
                     """,
                     user_id,
-                    normalized,
-                    regulator,
-                    "broker_intelligence",
-                    json.dumps(audit_payload),
-                    "completed" if found else "pending",
+                    license_number,
+                    datetime.now(timezone.utc) - _RIA_LICENSE_VERIFICATION_REUSE_TTL,
                 )
         except Exception:
-            logger.warning("verify_ria_license: failed to store audit for %s", normalized)
+            logger.warning(
+                "ria.verify_license_cache_lookup_failed user_id=%s",
+                user_id,
+                exc_info=True,
+            )
+            return None
 
-        return response
+        if row is None:
+            return None
+
+        raw_response = row["raw_response"] if "raw_response" in row else None
+        payload = self._parse_json_mapping(raw_response)
+        cached_regulator = regulator or (row["regulator"] if "regulator" in row else None)
+        response = await self._build_ria_license_verification_response(
+            broker_data=payload,
+            scrape_data={},
+            normalized_license=license_number,
+            regulator=cached_regulator,
+            allow_slow_fallbacks=False,
+        )
+        if response.get("status") != "found":
+            return None
+        return self._add_license_cache_metadata(
+            response,
+            cache_hit=True,
+            cached_at=row["created_at"] if "created_at" in row else None,
+        )
 
     @staticmethod
     def _parse_json_mapping(value: Any) -> dict[str, Any]:

--- a/consent-protocol/tests/test_ria_onboarding_v2.py
+++ b/consent-protocol/tests/test_ria_onboarding_v2.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import sys
 import types
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import httpx
@@ -64,6 +65,25 @@ def _authed_app() -> FastAPI:
     return app
 
 
+class _FakeAcquire:
+    def __init__(self, conn: Any) -> None:
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakePool:
+    def __init__(self, conn: Any) -> None:
+        self._conn = conn
+
+    def acquire(self):
+        return _FakeAcquire(self._conn)
+
+
 # ===================================================================
 # Route: POST /api/ria/onboarding/verify-license
 # ===================================================================
@@ -72,9 +92,17 @@ def _authed_app() -> FastAPI:
 def test_verify_license_found(monkeypatch) -> None:
     """Happy path: broker intelligence returns a verified advisor."""
 
-    async def _mock_verify(self, user_id, *, license_number, regulator=None):
+    async def _mock_verify(
+        self,
+        user_id,
+        *,
+        license_number,
+        regulator=None,
+        force_live_verification=False,
+    ):
         assert user_id == _TEST_UID
         assert license_number == "7413463"
+        assert force_live_verification is False
         return {
             "status": "found",
             "advisor_name": "Andrew Garrett Kirkland",
@@ -106,7 +134,15 @@ def test_verify_license_found(monkeypatch) -> None:
 def test_verify_license_not_found(monkeypatch) -> None:
     """Broker intelligence finds no matching advisor for the given license."""
 
-    async def _mock_verify(self, user_id, *, license_number, regulator=None):
+    async def _mock_verify(
+        self,
+        user_id,
+        *,
+        license_number,
+        regulator=None,
+        force_live_verification=False,
+    ):
+        assert force_live_verification is False
         return {
             "status": "not_found",
             "advisor_name": None,
@@ -127,6 +163,234 @@ def test_verify_license_not_found(monkeypatch) -> None:
 
     assert response.status_code == 200
     assert response.json()["status"] == "not_found"
+
+
+def test_verify_license_passes_force_live_verification(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    async def _mock_verify(
+        self,
+        user_id,
+        *,
+        license_number,
+        regulator=None,
+        force_live_verification=False,
+    ):
+        captured.update(
+            {
+                "user_id": user_id,
+                "license_number": license_number,
+                "regulator": regulator,
+                "force_live_verification": force_live_verification,
+            }
+        )
+        return {
+            "status": "found",
+            "advisor_name": "Andrew Garrett Kirkland",
+            "firm_name": "Renaissance Advisory Group",
+            "crd_number": license_number,
+            "regulator": regulator,
+            "provider": "ria_intelligence_combined",
+        }
+
+    monkeypatch.setattr(RIAIAMService, "verify_ria_license", _mock_verify)
+
+    client = TestClient(_authed_app())
+    response = client.post(
+        "/api/ria/onboarding/verify-license",
+        json={
+            "license_number": "7413463",
+            "regulator": "SEC",
+            "force_live_verification": True,
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured == {
+        "user_id": _TEST_UID,
+        "license_number": "7413463",
+        "regulator": "SEC",
+        "force_live_verification": True,
+    }
+
+
+def test_verify_ria_license_returns_recent_cache_without_provider(monkeypatch) -> None:
+    cached_at = datetime.now(timezone.utc) - timedelta(minutes=5)
+    cached_payload = {
+        "verifiedName": "Andrew Garrett Kirkland",
+        "currentFirm": "Eissman Wealth Management",
+        "status": "Investment Adviser Representative",
+        "crdNumber": "7413463",
+        "city": "Kennesaw",
+        "pinZip": "30144",
+        "exams": ["Series 65"],
+        "disclosures": {"count": 1},
+        "employmentHistory": [],
+        "summary": "Cached official source-backed profile.",
+    }
+
+    class _FakeConn:
+        async def fetchrow(self, query: str, *args):
+            assert "status = 'completed'" in query
+            assert "created_at >= $3" in query
+            assert args[0] == _TEST_UID
+            assert args[1] == "7413463"
+            assert args[2] > datetime.now(timezone.utc) - timedelta(hours=25)
+            return {
+                "raw_response": json.dumps(cached_payload),
+                "regulator": "SEC",
+                "created_at": cached_at,
+            }
+
+        async def execute(self, *_args):
+            raise AssertionError("cache hit must not insert a new audit row")
+
+    async def _fake_get_pool():
+        return _FakePool(_FakeConn())
+
+    class _UnexpectedProxy:
+        async def broker_intelligence(self, **_kwargs):
+            raise AssertionError("cache hit must not call broker intelligence")
+
+        async def create_job(self, **_kwargs):
+            raise AssertionError("cache hit must not create a scrape job")
+
+    monkeypatch.setattr(ria_iam_service_module, "get_pool", _fake_get_pool)
+    monkeypatch.setattr(
+        "hushh_mcp.services.crd_scrape_proxy_service.CrdScrapeProxyService",
+        lambda: _UnexpectedProxy(),
+    )
+
+    result = asyncio.run(
+        RIAIAMService().verify_ria_license(
+            _TEST_UID,
+            license_number="7413463",
+            regulator=None,
+        )
+    )
+
+    assert result["status"] == "found"
+    assert result["advisor_name"] == "Andrew Garrett Kirkland"
+    assert result["firm_name"] == "Eissman Wealth Management"
+    assert result["cache_hit"] is True
+    assert result["cached_at"].endswith("Z")
+    assert result["cache_expires_at"].endswith("Z")
+    assert result["cache_ttl_seconds"] == 24 * 60 * 60
+
+
+def test_verify_ria_license_force_live_bypasses_recent_cache(monkeypatch) -> None:
+    calls = {"broker": 0, "scrape": 0, "fetchrow": 0, "execute": 0}
+
+    class _FakeConn:
+        async def fetchrow(self, *_args):
+            calls["fetchrow"] += 1
+            raise AssertionError("force_live_verification must skip cache lookup")
+
+        async def execute(self, *_args):
+            calls["execute"] += 1
+            return "INSERT 0 1"
+
+    async def _fake_get_pool():
+        return _FakePool(_FakeConn())
+
+    class _FakeProxy:
+        async def broker_intelligence(self, *, query: str, request_id: str | None = None):
+            _ = request_id
+            calls["broker"] += 1
+            assert query == "7413463"
+            return CrdScrapeProviderResponse(
+                200,
+                {
+                    "verifiedName": "Andrew Garrett Kirkland",
+                    "currentFirm": "Eissman Wealth Management",
+                    "status": "Investment Adviser Representative",
+                    "crdNumber": "7413463",
+                    "exams": ["Series 65"],
+                },
+            )
+
+        async def create_job(self, *, crd_number: str, request_id: str | None = None):
+            _ = request_id
+            calls["scrape"] += 1
+            assert crd_number == "7413463"
+            return CrdScrapeProviderResponse(202, {"jobId": "crd_scrape_live"})
+
+    monkeypatch.setattr(ria_iam_service_module, "get_pool", _fake_get_pool)
+    monkeypatch.setattr(
+        "hushh_mcp.services.crd_scrape_proxy_service.CrdScrapeProxyService",
+        lambda: _FakeProxy(),
+    )
+
+    result = asyncio.run(
+        RIAIAMService().verify_ria_license(
+            _TEST_UID,
+            license_number="7413463",
+            regulator="SEC",
+            force_live_verification=True,
+        )
+    )
+
+    assert result["status"] == "found"
+    assert result["cache_hit"] is False
+    assert result["scrape_job_id"] == "crd_scrape_live"
+    assert calls == {"broker": 1, "scrape": 1, "fetchrow": 0, "execute": 1}
+
+
+def test_verify_ria_license_cache_miss_uses_completed_fresh_cutoff(monkeypatch) -> None:
+    calls = {"broker": 0, "scrape": 0, "execute": 0}
+
+    class _FakeConn:
+        async def fetchrow(self, query: str, *args):
+            assert "status = 'completed'" in query
+            assert "created_at >= $3" in query
+            assert args[2] > datetime.now(timezone.utc) - timedelta(hours=25)
+            return None
+
+        async def execute(self, *_args):
+            calls["execute"] += 1
+            return "INSERT 0 1"
+
+    async def _fake_get_pool():
+        return _FakePool(_FakeConn())
+
+    class _FakeProxy:
+        async def broker_intelligence(self, *, query: str, request_id: str | None = None):
+            _ = request_id
+            calls["broker"] += 1
+            assert query == "7413463"
+            return CrdScrapeProviderResponse(
+                200,
+                {
+                    "verifiedName": "Andrew Garrett Kirkland",
+                    "status": "Investment Adviser Representative",
+                    "crdNumber": "7413463",
+                },
+            )
+
+        async def create_job(self, *, crd_number: str, request_id: str | None = None):
+            _ = request_id
+            calls["scrape"] += 1
+            assert crd_number == "7413463"
+            return CrdScrapeProviderResponse(202, {"jobId": "crd_scrape_miss"})
+
+    monkeypatch.setattr(ria_iam_service_module, "get_pool", _fake_get_pool)
+    monkeypatch.setattr(
+        "hushh_mcp.services.crd_scrape_proxy_service.CrdScrapeProxyService",
+        lambda: _FakeProxy(),
+    )
+
+    result = asyncio.run(
+        RIAIAMService().verify_ria_license(
+            _TEST_UID,
+            license_number="7413463",
+            regulator="SEC",
+        )
+    )
+
+    assert result["status"] == "found"
+    assert result["cache_hit"] is False
+    assert result["scrape_job_id"] == "crd_scrape_miss"
+    assert calls == {"broker": 1, "scrape": 1, "execute": 1}
 
 
 def test_verify_license_passes_through_city_pin_zip_and_string_exams(monkeypatch) -> None:
@@ -262,6 +526,7 @@ def test_verify_license_fills_missing_location_from_official_pdf(monkeypatch) ->
 
 def test_verify_license_falls_back_to_official_pdf_when_provider_5xx(monkeypatch) -> None:
     """A transient broker-intelligence 5xx should not become an empty not_found result."""
+    captured_audit: dict[str, Any] = {}
 
     class _FakeProxy:
         async def broker_intelligence(self, *, query: str, request_id: str | None = None):
@@ -305,6 +570,20 @@ def test_verify_license_falls_back_to_official_pdf_when_provider_5xx(monkeypatch
         _mock_official_profile,
     )
 
+    class _FakeConn:
+        async def fetchrow(self, *_args):
+            return None
+
+        async def execute(self, _query, *args):
+            captured_audit["payload"] = json.loads(args[4])
+            captured_audit["status"] = args[5]
+            return "INSERT 0 1"
+
+    async def _fake_get_pool():
+        return _FakePool(_FakeConn())
+
+    monkeypatch.setattr(ria_iam_service_module, "get_pool", _fake_get_pool)
+
     result = asyncio.run(
         RIAIAMService().verify_ria_license(
             _TEST_UID,
@@ -322,6 +601,10 @@ def test_verify_license_falls_back_to_official_pdf_when_provider_5xx(monkeypatch
     assert result["certifications"] == ["Series 66 - Uniform Combined State Law Examination"]
     assert result["exams_passed"] == result["certifications"]
     assert result["broker_intelligence_summary"].startswith("Official IAPD records")
+    assert captured_audit["status"] == "completed"
+    assert captured_audit["payload"]["official_profile"]["advisor_name"] == (
+        "Andrew Garrett Kirkland"
+    )
 
 
 def test_official_location_from_text_extracts_city_and_zip() -> None:
@@ -368,7 +651,15 @@ def test_verify_license_requires_auth() -> None:
 def test_verify_license_partial_data(monkeypatch) -> None:
     """Broker intelligence returns advisor name only, no CRD number."""
 
-    async def _mock_verify(self, user_id, *, license_number, regulator=None):
+    async def _mock_verify(
+        self,
+        user_id,
+        *,
+        license_number,
+        regulator=None,
+        force_live_verification=False,
+    ):
+        assert force_live_verification is False
         return {
             "status": "found",
             "advisor_name": "Jane Doe",
@@ -464,7 +755,15 @@ def test_verify_ria_license_exposes_summary_and_exams_as_prefill(monkeypatch) ->
 def test_verify_license_provider_timeout(monkeypatch) -> None:
     """Service raises RIAIAMPolicyError(status_code=503) on provider timeout."""
 
-    async def _mock_verify(self, user_id, *, license_number, regulator=None):
+    async def _mock_verify(
+        self,
+        user_id,
+        *,
+        license_number,
+        regulator=None,
+        force_live_verification=False,
+    ):
+        assert force_live_verification is False
         raise RIAIAMPolicyError("Provider timed out", status_code=503)
 
     monkeypatch.setattr(RIAIAMService, "verify_ria_license", _mock_verify)

--- a/hushh-webapp/lib/services/ria-service.ts
+++ b/hushh-webapp/lib/services/ria-service.ts
@@ -139,6 +139,10 @@ export interface RiaLicenseVerificationResult {
   services_offered?: string[];
   fee_structure?: string[];
   min_engagement_amount?: number | string | null;
+  cache_hit?: boolean;
+  cache_ttl_seconds?: number;
+  cached_at?: string | null;
+  cache_expires_at?: string | null;
 }
 
 export interface CrdScrapeJobResult {
@@ -1244,7 +1248,11 @@ export class RiaService {
 
   static async verifyOnboardingLicense(
     idToken: string,
-    payload: { license_number: string; regulator?: string },
+    payload: {
+      license_number: string;
+      regulator?: string;
+      force_live_verification?: boolean;
+    },
     options?: { signal?: AbortSignal },
   ): Promise<RiaLicenseVerificationResult> {
     const response = await authFetch("/api/ria/onboarding/verify-license", {


### PR DESCRIPTION
## Summary
- Add 24h cache-first lookup for direct RIA license verification using existing ria_license_verifications audit rows
- Add manual force_live_verification bypass for live refreshes
- Add composite lookup index for cache reads and update frontend response typing

## Verification
- python3 -m py_compile consent-protocol/hushh_mcp/services/ria_iam_service.py consent-protocol/api/routes/ria.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest --noconftest tests/test_ria_onboarding_v2.py -q
- uv run pytest --noconftest tests/test_ria_iam_routes.py tests/test_ria_iam_service_architecture.py -q
- npm run typecheck
- git diff --check