### PR TITLE
Fix RIA stale verification prefill

### DIFF
--- a/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
@@ -418,6 +418,86 @@ describe("RiaOnboardingPage", () => {
     expect(screen.getByTestId("pin-zip").textContent).toBe("30144");
   });
 
+  it("clears stale regulator fields before applying a fresh verification result", async () => {
+    mocks.draftService.load.mockResolvedValue({
+      currentStepId: "license_number",
+      onboardingType: "individual",
+      licenseNumber: "7413463",
+      licenseVerificationStatus: "error",
+      advisorName: "Old Advisor",
+      firmName: "Old Firm",
+      city: "Pune",
+      areaLocality: "Downtown, Mission District",
+      pinZip: "30144",
+      fullStreetAddress: "Army Institute of Technology, Pune",
+      bio: "Old stale bio",
+      servicesOffered: ["Portfolio Management"],
+      feeStructure: ["Fee-only"],
+    });
+    mocks.riaService.verifyOnboardingLicense.mockResolvedValue({
+      status: "found",
+      advisor_name: "Andrew Garrett Kirkland",
+      firm_name: "Eissman Wealth Management",
+      regulator: "SEC",
+      regulator_status: "Active (Investment Adviser Representative)",
+      certifications: [
+        "Series 66 - Uniform Combined State Law Examination",
+      ],
+      crd_number: "7413463",
+      city: "Kennesaw",
+      state: "GA",
+      area_locality: "GA",
+      pin_zip: "30144",
+      full_street_address: "114 Townpark Drive, Ste. 175",
+      official_location: {
+        city: "Kennesaw",
+        state: "GA",
+        pin_zip: "30144",
+        address: "114 Townpark Drive, Ste. 175",
+      },
+      bio: "Investment professional at Eissman Wealth Management.",
+      scrape_job_id: null,
+    });
+
+    render(<RiaOnboardingPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("step-license")).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("verify-btn"));
+    });
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId("step-license-details")).toBeTruthy();
+      },
+      { timeout: 3000 },
+    );
+
+    expect(screen.getByTestId("advisor-name").textContent).toBe(
+      "Andrew Garrett Kirkland",
+    );
+    expect(screen.getByTestId("city").textContent).toBe("Kennesaw");
+    expect(screen.getByTestId("pin-zip").textContent).toBe("30144");
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("continue-btn"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("step-services")).toBeTruthy();
+    });
+
+    expect(screen.getByTestId("services-city").textContent).toBe("Kennesaw");
+    expect(screen.getByTestId("services-area").textContent).toBe("GA");
+    expect(screen.getByTestId("services-address").textContent).toBe(
+      "114 Townpark Drive, Ste. 175",
+    );
+    expect(screen.getByTestId("services-pin-zip").textContent).toBe("30144");
+  });
+
   it("handles not_found and stays on license step", async () => {
     mocks.riaService.verifyOnboardingLicense.mockResolvedValue({
       status: "not_found",

--- a/hushh-webapp/app/ria/onboarding/page.tsx
+++ b/hushh-webapp/app/ria/onboarding/page.tsx
@@ -42,6 +42,32 @@ import { trackGrowthFunnelStepCompleted } from "@/lib/observability/growth";
 
 const LICENSE_VERIFICATION_TIMEOUT_MS = 90_000;
 const SCRAPE_POLL_INTERVAL_MS = 5_000;
+const REGULATOR_PREFILL_RESET: Partial<RiaOnboardingDraft> = {
+  advisorName: "",
+  firmName: "",
+  regulatorStatus: "",
+  licenseExpiry: "",
+  certifications: [],
+  city: "",
+  pinZip: "",
+  crdNumber: "",
+  secNumber: "",
+  areaLocality: "",
+  fullStreetAddress: "",
+  latitude: null,
+  longitude: null,
+  bio: "",
+  scrapeJobId: null,
+  displayName: "",
+  individualLegalName: "",
+  individualCrd: "",
+  advisoryFirmName: "",
+  advisoryFirmIapdNumber: "",
+  brokerFirmName: "",
+  brokerFirmCrd: "",
+  headline: "",
+  strategySummary: "",
+};
 
 function isAdvisoryAccessReady(status?: string | null): boolean {
   return status === "active" || status === "verified";
@@ -314,7 +340,10 @@ export default function RiaOnboardingPage() {
     verificationAbortRef.current = controller;
 
     setError(null);
-    updateDraft({ licenseVerificationStatus: "verifying" });
+    updateDraft({
+      ...REGULATOR_PREFILL_RESET,
+      licenseVerificationStatus: "verifying",
+    });
 
     try {
       const idToken = await user.getIdToken();


### PR DESCRIPTION
## Summary
- Clear stale regulator-derived RIA onboarding fields before each live license verification.
- Prevent old draft location/bio/certs from surviving when a fresh SEC/FINRA result returns official data.
- Add regression coverage for stale Pune/Army Institute draft data being replaced by official Kennesaw/SEC PDF data.

## Verification
- npm --prefix hushh-webapp run typecheck
- git diff --check
- npm --prefix hushh-webapp run test -- __tests__/lib/ria/ria-onboarding-prefill.test.ts *(local Vitest worker failed to start: Timeout waiting for worker to respond; CI web gate is expected to run the test lane)*