### PR TITLE
fix(ria): refresh incomplete license location cache

### DIFF
--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -1160,7 +1160,10 @@ class RIAIAMService:
 
         # Store audit trail
         try:
-            audit_payload = dict(broker_data)
+            audit_payload = self._license_verification_cache_payload(
+                broker_data=broker_data,
+                response=response,
+            )
             if official_profile:
                 audit_payload["official_profile"] = official_profile
                 audit_payload["broker_status_code"] = broker_status_code
@@ -1183,6 +1186,58 @@ class RIAIAMService:
             logger.warning("verify_ria_license: failed to store audit for %s", normalized)
 
         return response
+
+    @staticmethod
+    def _has_usable_license_location(response: dict[str, Any]) -> bool:
+        official_location = response.get("official_location")
+        official_address = (
+            official_location.get("address") if isinstance(official_location, dict) else None
+        )
+        return bool(
+            _first_text_value(response.get("city"))
+            and _first_text_value(response.get("pin_zip"))
+            and _first_text_value(response.get("state"), response.get("area_locality"))
+            and _first_text_value(response.get("full_street_address"), official_address)
+        )
+
+    @classmethod
+    def _license_verification_cache_payload(
+        cls,
+        *,
+        broker_data: dict[str, Any],
+        response: dict[str, Any],
+    ) -> dict[str, Any]:
+        payload = dict(broker_data if isinstance(broker_data, dict) else {})
+        alias_pairs = (
+            ("advisor_name", "verifiedName"),
+            ("firm_name", "currentFirm"),
+            ("regulator_status", "status"),
+            ("crd_number", "crdNumber"),
+            ("city", "city"),
+            ("pin_zip", "pin_zip"),
+            ("state", "state"),
+            ("area_locality", "area_locality"),
+            ("full_street_address", "full_street_address"),
+            ("business_address", "business_address"),
+            ("official_location", "official_location"),
+        )
+        for response_key, payload_key in alias_pairs:
+            value = response.get(response_key)
+            if value and not payload.get(payload_key):
+                payload[payload_key] = value
+
+        certifications = response.get("certifications")
+        if isinstance(certifications, list) and certifications and not payload.get("exams"):
+            payload["exams"] = certifications
+
+        summary = _first_text_value(
+            response.get("broker_intelligence_summary"),
+            response.get("bio"),
+        )
+        if summary and not payload.get("summary"):
+            payload["summary"] = summary
+
+        return payload
 
     @staticmethod
     def _coerce_utc_datetime(value: Any) -> datetime | None:
@@ -1399,6 +1454,13 @@ class RIAIAMService:
             allow_slow_fallbacks=False,
         )
         if response.get("status") != "found":
+            return None
+        if not self._has_usable_license_location(response):
+            logger.info(
+                "ria.verify_license_cache_incomplete_location user_id=%s license_number=%s",
+                user_id,
+                license_number,
+            )
             return None
         return self._add_license_cache_metadata(
             response,

--- a/consent-protocol/tests/test_ria_onboarding_v2.py
+++ b/consent-protocol/tests/test_ria_onboarding_v2.py
@@ -222,7 +222,9 @@ def test_verify_ria_license_returns_recent_cache_without_provider(monkeypatch) -
         "status": "Investment Adviser Representative",
         "crdNumber": "7413463",
         "city": "Kennesaw",
+        "state": "GA",
         "pinZip": "30144",
+        "fullStreetAddress": "114 Townpark Drive, Ste. 175",
         "exams": ["Series 65"],
         "disclosures": {"count": 1},
         "employmentHistory": [],
@@ -272,10 +274,112 @@ def test_verify_ria_license_returns_recent_cache_without_provider(monkeypatch) -
     assert result["status"] == "found"
     assert result["advisor_name"] == "Andrew Garrett Kirkland"
     assert result["firm_name"] == "Eissman Wealth Management"
+    assert result["city"] == "Kennesaw"
+    assert result["pin_zip"] == "30144"
+    assert result["full_street_address"] == "114 Townpark Drive, Ste. 175"
     assert result["cache_hit"] is True
     assert result["cached_at"].endswith("Z")
     assert result["cache_expires_at"].endswith("Z")
     assert result["cache_ttl_seconds"] == 24 * 60 * 60
+
+
+def test_verify_ria_license_ignores_incomplete_location_cache(monkeypatch) -> None:
+    cached_at = datetime.now(timezone.utc) - timedelta(minutes=5)
+    cached_payload = {
+        "verifiedName": "Andrew Garrett Kirkland",
+        "currentFirm": "Eissman Wealth Management",
+        "status": "Investment Adviser Representative",
+        "crdNumber": "7413463",
+        "exams": ["Series 66"],
+        "summary": "Cached profile without a source-backed business location.",
+    }
+    calls = {"broker": 0, "scrape": 0, "execute": 0}
+    captured_audit: dict[str, Any] = {}
+
+    class _FakeConn:
+        async def fetchrow(self, query: str, *args):
+            assert "status = 'completed'" in query
+            assert args[0] == _TEST_UID
+            assert args[1] == "7413463"
+            return {
+                "raw_response": json.dumps(cached_payload),
+                "regulator": "SEC",
+                "created_at": cached_at,
+            }
+
+        async def execute(self, _query, *args):
+            calls["execute"] += 1
+            captured_audit["payload"] = json.loads(args[4])
+            captured_audit["status"] = args[5]
+            return "INSERT 0 1"
+
+    async def _fake_get_pool():
+        return _FakePool(_FakeConn())
+
+    class _FakeProxy:
+        async def broker_intelligence(self, *, query: str, request_id: str | None = None):
+            _ = request_id
+            calls["broker"] += 1
+            assert query == "7413463"
+            return CrdScrapeProviderResponse(
+                200,
+                {
+                    "verifiedName": "Andrew Garrett Kirkland",
+                    "currentFirm": "Eissman Wealth Management",
+                    "status": "Investment Adviser Representative",
+                    "crdNumber": "7413463",
+                    "exams": ["Series 66"],
+                },
+            )
+
+        async def create_job(self, *, crd_number: str, request_id: str | None = None):
+            _ = request_id
+            calls["scrape"] += 1
+            assert crd_number == "7413463"
+            return CrdScrapeProviderResponse(202, {"jobId": "crd_scrape_location_refresh"})
+
+    async def _mock_official_location(crd_number: str):
+        assert crd_number == "7413463"
+        return {
+            "city": "Kennesaw",
+            "state": "GA",
+            "pin_zip": "30144",
+            "address": "114 Townpark Drive, Ste. 175",
+            "location": "Kennesaw, GA",
+            "source_url": "https://reports.adviserinfo.sec.gov/reports/individual/individual_7413463.pdf",
+        }
+
+    monkeypatch.setattr(ria_iam_service_module, "get_pool", _fake_get_pool)
+    monkeypatch.setattr(
+        "hushh_mcp.services.crd_scrape_proxy_service.CrdScrapeProxyService",
+        lambda: _FakeProxy(),
+    )
+    monkeypatch.setattr(
+        "hushh_mcp.services.ria_iam_service._official_pdf_location_for_crd",
+        _mock_official_location,
+    )
+
+    result = asyncio.run(
+        RIAIAMService().verify_ria_license(
+            _TEST_UID,
+            license_number="7413463",
+            regulator="SEC",
+        )
+    )
+
+    assert result["status"] == "found"
+    assert result["cache_hit"] is False
+    assert result["city"] == "Kennesaw"
+    assert result["pin_zip"] == "30144"
+    assert result["full_street_address"] == "114 Townpark Drive, Ste. 175"
+    assert calls == {"broker": 1, "scrape": 1, "execute": 1}
+    assert captured_audit["status"] == "completed"
+    assert captured_audit["payload"]["city"] == "Kennesaw"
+    assert captured_audit["payload"]["pin_zip"] == "30144"
+    assert captured_audit["payload"]["full_street_address"] == "114 Townpark Drive, Ste. 175"
+    assert captured_audit["payload"]["official_location"]["source_url"].endswith(
+        "individual_7413463.pdf"
+    )
 
 
 def test_verify_ria_license_force_live_bypasses_recent_cache(monkeypatch) -> None:


### PR DESCRIPTION
## Summary\n- Treat recent RIA license verification cache entries without usable business location fields as stale.\n- Persist enriched PDF/provider-derived location fields into the cache/audit payload so future UI-equivalent calls keep the address.\n- Add regression coverage for stale cached CRD 7413463 data missing city/ZIP/address.\n\n## Tests\n- cd consent-protocol && .venv/bin/pytest tests/test_ria_onboarding_v2.py -q\n- cd consent-protocol && .venv/bin/ruff check hushh_mcp/services/ria_iam_service.py tests/test_ria_onboarding_v2.py\n- npm --prefix hushh-webapp run typecheck\n- git diff --check