### PR TITLE
chore(codex): add scoped UAT deploy skill

### DIFF
--- a/.codex/skills/codex-skill-authoring/scripts/skill_lint.py
+++ b/.codex/skills/codex-skill-authoring/scripts/skill_lint.py
@@ -71,6 +71,7 @@ EXPECTED_WORKFLOW_IDS = [
     "ci-watch-and-heal",
     "data-model-audit",
     "github-contribution-governance",
+    "uat-scoped-deploy",
     "pre-pr-readiness",
     "security-consent-audit",
     "mobile-parity-check",

--- a/.codex/skills/repo-context/references/ownership-map.md
+++ b/.codex/skills/repo-context/references/ownership-map.md
@@ -51,6 +51,7 @@ Use this reference after the initial scan to choose the correct owner skill firs
 ### `repo-operations`
 
 1. `github-contribution-governance`
+2. `uat-scoped-deploy`
 
 ## Canonical workflow packs
 
@@ -73,5 +74,6 @@ Use this reference after the initial scan to choose the correct owner skill firs
 17. `contributor-onboarding`
 18. `subtree-upstream-governance`
 19. `github-contribution-governance`
+20. `uat-scoped-deploy`
 20. `data-model-audit`
 21. `frontend-native-surface-map`

--- a/.codex/skills/repo-context/scripts/repo_scan.py
+++ b/.codex/skills/repo-context/scripts/repo_scan.py
@@ -78,6 +78,7 @@ REQUIRED_WORKFLOWS = [
     "ci-watch-and-heal",
     "data-model-audit",
     "github-contribution-governance",
+    "uat-scoped-deploy",
     "pre-pr-readiness",
     "security-consent-audit",
     "mobile-parity-check",

--- a/.codex/skills/repo-operations/skill.json
+++ b/.codex/skills/repo-operations/skill.json
@@ -26,7 +26,8 @@
     "release-readiness",
     "mobile-parity-check",
     "docs-sync",
-    "github-contribution-governance"
+    "github-contribution-governance",
+    "uat-scoped-deploy"
   ],
   "required_reads": [
     "docs/reference/operations/README.md",
@@ -72,6 +73,7 @@
     "oss-license-governance",
     "contributor-onboarding",
     "subtree-upstream-governance",
+    "uat-scoped-deploy",
     "backend",
     "security-audit"
   ],
@@ -83,7 +85,8 @@
     "analytics-observability-governance",
     "oss-license-governance",
     "contributor-onboarding",
-    "subtree-upstream-governance"
+    "subtree-upstream-governance",
+    "uat-scoped-deploy"
   ],
   "risk_tags": [
     "ci-drift",

--- a/.codex/skills/uat-scoped-deploy/SKILL.md
+++ b/.codex/skills/uat-scoped-deploy/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: uat-scoped-deploy
+description: Use when choosing, running, or verifying scoped UAT deploys for Hussh Cloud Run services, including frontend-only/backend-only scope, Cloud Build timing proof, Cloud Run region discovery, and service provenance evidence.
+---
+
+# Hussh UAT Scoped Deploy Skill
+
+## Purpose and Trigger
+
+- Primary scope: `uat-scoped-deploy-scope`
+- Trigger on choosing, running, or verifying a scoped UAT deploy for Cloud Run services.
+- Avoid overlap with `repo-context`, broad `repo-operations`, and product implementation owner skills.
+
+## Coverage and Ownership
+
+- Role: `spoke`
+- Owner family: `repo-operations`
+
+Owned repo surfaces:
+
+1. `.github/workflows/deploy-uat.yml`
+2. `deploy`
+
+Non-owned surfaces:
+
+1. `repo-operations`
+2. `frontend`
+3. `backend`
+4. `security-audit`
+
+## Do Use
+
+1. UAT deploys where scope must stay `frontend`, `backend`, or `all`.
+2. Cloud Build timing, skipped-lane, and deploy summary proof.
+3. Cloud Run service evidence: project, region, revision, image, timeout, env, traffic, and request-id logs.
+
+## Do Not Use
+
+1. Production deploys unless the user separately asks for production.
+2. Product code fixes after deploy verification exposes a frontend/backend bug.
+3. Broad CI or release-governance questions not narrowed to UAT deploy scope.
+4. Manual browser-only acceptance without runtime or log evidence.
+
+## Read First
+
+1. `.github/workflows/deploy-uat.yml`
+2. `deploy/README.md`
+3. `deploy/frontend.cloudbuild.yaml`
+4. `deploy/backend.cloudbuild.yaml`
+5. `.codex/skills/uat-scoped-deploy/references/deploy-proof.md`
+
+## Workflow
+
+1. Classify the intended scope from changed paths and user request: `frontend`, `backend`, or `all`.
+2. Use `scope=frontend` for UI/auth-route-only changes and `scope=backend` for protocol/API-only changes.
+3. Trigger UAT from a green `main` SHA; keep merge, post-merge smoke, and UAT deploy as separate evidence.
+4. Watch the GitHub run until terminal success or a concrete blocker; confirm skipped lanes from run steps.
+5. Before Cloud Run `describe`, run the evidence helper to discover the actual project/region tuple.
+6. Capture touched-service revision, image, labels, timeout, traffic, env contracts, request IDs, and logs.
+7. Report run URL, scope, skipped lanes, timings, revisions, and remaining risk; never call queued work done.
+
+## Handoff Rules
+
+1. If the request is still broad or ambiguous, route it back to `repo-operations`.
+2. Route frontend implementation bugs to `frontend` after preserving deploy evidence.
+3. Route backend/API contract bugs to `backend-api-contracts` or `backend`.
+4. Route auth, secret, or consent boundary findings to `security-audit`.
+
+## Required Checks
+
+```bash
+gh run list --workflow deploy-uat.yml --limit 5 --json databaseId,status,conclusion,headSha,event,url
+python3 .codex/skills/uat-scoped-deploy/scripts/cloud_run_service_evidence.py --project hushh-pda-uat --service hushh-webapp --service consent-protocol --format text
+python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py
+```

--- a/.codex/skills/uat-scoped-deploy/references/deploy-proof.md
+++ b/.codex/skills/uat-scoped-deploy/references/deploy-proof.md
@@ -1,0 +1,46 @@
+# UAT Scoped Deploy Proof
+
+## Scope Decision
+
+Use the smallest deploy scope that covers the diff.
+
+1. `frontend`: `hushh-webapp`, Next.js routes, auth gates, UI, frontend env, or frontend Cloud Build only.
+2. `backend`: `consent-protocol`, API behavior, migrations, backend env, or backend Cloud Build only.
+3. `all`: shared deploy contracts, both runtime images, schema plus UI changes, or unknown cross-surface risk.
+
+If a previous run accidentally used `scope=all`, name that as evidence drift and trigger the next run with the exact scope.
+
+## Deploy Command
+
+Use a green `main` SHA:
+
+```bash
+gh workflow run deploy-uat.yml --ref main -f scope=<frontend|backend|all> -f sha=<main-sha>
+```
+
+Then watch:
+
+```bash
+gh run watch <run-id> --exit-status
+```
+
+## Required Evidence
+
+1. GitHub run URL, SHA, scope, and conclusion.
+2. Step proof that untouched lanes were skipped.
+3. Cloud Build duration for each executed lane.
+4. Cloud Run service tuple from discovery: project, service, region.
+5. Latest ready revision, traffic split, image tag, deploy SHA label, GitHub run label, timeout, and key env values.
+6. Live behavior proof for the changed surface, including request IDs and logs for API/runtime fixes.
+
+## Region Tuple Guard
+
+Never run `gcloud run services describe <service> --region <assumed-region>` as the first proof command.
+
+Run:
+
+```bash
+python3 .codex/skills/uat-scoped-deploy/scripts/cloud_run_service_evidence.py --project hushh-pda-uat --service <service> --format text
+```
+
+If the helper cannot find the service, list services in the project and stop with a blocker instead of switching regions by guesswork.

--- a/.codex/skills/uat-scoped-deploy/scripts/cloud_run_service_evidence.py
+++ b/.codex/skills/uat-scoped-deploy/scripts/cloud_run_service_evidence.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Discover Cloud Run service regions before collecting deploy evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+
+SAFE_ENV_KEYS = {
+    "APP_ENV",
+    "HUSHH_ENV",
+    "NODE_ENV",
+    "NEXT_PUBLIC_APP_ENV",
+    "RIA_INTELLIGENCE_CRD_SCRAPER_TIMEOUT_SECONDS",
+    "RIA_ONBOARDING_PROVIDER_TIMEOUT_SECONDS",
+    "RIA_ONBOARDING_PROXY_TIMEOUT_MS",
+}
+
+
+def _gcloud() -> str:
+    return os.environ.get("GCLOUD_BIN") or shutil.which("gcloud") or "/Users/ankitkumarsingh/google-cloud-sdk/bin/gcloud"
+
+
+def _run(args: list[str]) -> Any:
+    result = subprocess.run(args, check=False, text=True, capture_output=True)
+    if result.returncode != 0:
+        raise SystemExit(f"command failed: {' '.join(args)}\n{result.stderr.strip()}")
+    return json.loads(result.stdout or "null")
+
+
+def _list_services(project: str) -> list[dict[str, Any]]:
+    return _run([_gcloud(), "run", "services", "list", "--project", project, "--platform", "managed", "--format", "json"])
+
+
+def _service_location(service: dict[str, Any]) -> str | None:
+    return service.get("location") or service.get("metadata", {}).get("labels", {}).get("cloud.googleapis.com/location")
+
+
+def _describe(project: str, service: str, region: str) -> dict[str, Any]:
+    return _run(
+        [
+            _gcloud(),
+            "run",
+            "services",
+            "describe",
+            service,
+            "--project",
+            project,
+            "--region",
+            region,
+            "--platform",
+            "managed",
+            "--format",
+            "json",
+        ]
+    )
+
+
+def _env_map(service: dict[str, Any]) -> dict[str, str]:
+    containers = service.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
+    env: dict[str, str] = {}
+    for container in containers:
+        for item in container.get("env", []) or []:
+            name = item.get("name", "")
+            if name in SAFE_ENV_KEYS and "value" in item:
+                env[item.get("name", "")] = item["value"]
+    return env
+
+
+def _summarize(project: str, service_name: str, region_hint: str | None, services: list[dict[str, Any]]) -> dict[str, Any]:
+    candidates = [item for item in services if item.get("metadata", {}).get("name") == service_name or item.get("name") == service_name]
+    if region_hint:
+        candidates = [item for item in candidates if _service_location(item) == region_hint]
+    if not candidates:
+        available = sorted(
+            f"{item.get('metadata', {}).get('name') or item.get('name')}:{_service_location(item) or 'unknown'}"
+            for item in services
+        )
+        raise SystemExit(f"service not found for {project}/{service_name}. available={available}")
+    if len(candidates) > 1 and not region_hint:
+        regions = [_service_location(item) for item in candidates]
+        raise SystemExit(f"multiple regions found for {service_name}; rerun with --region. regions={regions}")
+
+    region = _service_location(candidates[0])
+    if not region:
+        raise SystemExit(f"could not determine region for {service_name}")
+    described = _describe(project, service_name, region)
+    metadata = described.get("metadata", {})
+    spec = described.get("spec", {})
+    status = described.get("status", {})
+    labels = metadata.get("labels", {})
+    annotations = metadata.get("annotations", {})
+    containers = spec.get("template", {}).get("spec", {}).get("containers", [])
+    traffic = status.get("traffic") or spec.get("traffic") or []
+    env = _env_map(described)
+    return {
+        "project": project,
+        "service": service_name,
+        "region": region,
+        "latest_ready_revision": status.get("latestReadyRevisionName"),
+        "traffic": traffic,
+        "image": containers[0].get("image") if containers else None,
+        "timeout": spec.get("template", {}).get("spec", {}).get("timeoutSeconds"),
+        "deploy_sha": labels.get("deploy-sha") or labels.get("commit-sha"),
+        "github_run_id": labels.get("github-run-id"),
+        "client_name": annotations.get("run.googleapis.com/client-name"),
+        "env": env,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project", required=True)
+    parser.add_argument("--service", action="append", required=True)
+    parser.add_argument("--region")
+    parser.add_argument("--format", choices=["json", "text"], default="json")
+    args = parser.parse_args()
+
+    services = _list_services(args.project)
+    summaries = [_summarize(args.project, service, args.region, services) for service in args.service]
+    if args.format == "json":
+        print(json.dumps(summaries, indent=2, sort_keys=True))
+        return 0
+    for item in summaries:
+        print(
+            f"{item['project']} {item['service']} {item['region']} "
+            f"revision={item['latest_ready_revision']} image={item['image']} "
+            f"timeout={item['timeout']} deploy_sha={item['deploy_sha']} run={item['github_run_id']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.codex/skills/uat-scoped-deploy/skill.json
+++ b/.codex/skills/uat-scoped-deploy/skill.json
@@ -1,0 +1,65 @@
+{
+  "id": "uat-scoped-deploy",
+  "role": "spoke",
+  "owner_family": "repo-operations",
+  "primary_scope": "uat-scoped-deploy-scope",
+  "description": "Use when choosing, running, or verifying scoped UAT deploys for Hussh Cloud Run services, including frontend-only/backend-only scope, Cloud Build timing proof, Cloud Run region discovery, and service provenance evidence.",
+  "owned_paths": [
+    ".github/workflows/deploy-uat.yml",
+    "deploy"
+  ],
+  "non_owned_paths": [
+    "repo-operations",
+    "frontend",
+    "backend",
+    "security-audit"
+  ],
+  "task_types": [
+    "uat-scoped-deploy"
+  ],
+  "required_reads": [
+    ".github/workflows/deploy-uat.yml",
+    "deploy/README.md",
+    "deploy/frontend.cloudbuild.yaml",
+    "deploy/backend.cloudbuild.yaml",
+    ".codex/skills/uat-scoped-deploy/references/deploy-proof.md"
+  ],
+  "required_commands": [
+    "gh run list --workflow deploy-uat.yml --limit 5 --json databaseId,status,conclusion,headSha,event,url",
+    "python3 .codex/skills/uat-scoped-deploy/scripts/cloud_run_service_evidence.py --project hushh-pda-uat --service hushh-webapp --service consent-protocol --format text",
+    "python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py"
+  ],
+  "verification_bundles": [
+    {
+      "id": "uat-scoped-deploy",
+      "commands": [
+        "gh run list --workflow deploy-uat.yml --limit 5 --json databaseId,status,conclusion,headSha,event,url",
+        "python3 .codex/skills/uat-scoped-deploy/scripts/cloud_run_service_evidence.py --project hushh-pda-uat --service hushh-webapp --service consent-protocol --format text",
+        "python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py"
+      ],
+      "tests": [
+        "python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py"
+      ]
+    }
+  ],
+  "handoff_targets": [
+    "repo-operations",
+    "frontend",
+    "backend",
+    "backend-api-contracts",
+    "security-audit"
+  ],
+  "adjacent_skills": [
+    "repo-operations",
+    "frontend",
+    "backend",
+    "backend-api-contracts",
+    "security-audit"
+  ],
+  "risk_tags": [
+    "deploy-scope-drift",
+    "cloud-run-region-drift",
+    "release-evidence-drift",
+    "uat-runtime-drift"
+  ]
+}

--- a/.codex/workflows/uat-scoped-deploy/PLAYBOOK.md
+++ b/.codex/workflows/uat-scoped-deploy/PLAYBOOK.md
@@ -1,0 +1,24 @@
+# UAT Scoped Deploy
+
+Use this workflow pack when the task matches `uat-scoped-deploy`.
+
+## Goal
+
+Run the smallest safe UAT deploy scope and prove the result with GitHub Actions, Cloud Build, Cloud Run, and behavior evidence.
+
+## Steps
+
+1. Start with `repo-operations`; use `uat-scoped-deploy` after the task is narrowed to UAT deploy scope.
+2. Classify the smallest safe scope: `frontend`, `backend`, or `all`.
+3. Trigger `deploy-uat.yml` from a green `main` SHA with the explicit scope and SHA.
+4. Watch the run to terminal state and record skipped deploy lanes from the job steps.
+5. Discover Cloud Run service regions with the helper before any `gcloud run services describe`.
+6. Capture revision, image, timeout, traffic, labels, and key env contracts for touched services.
+7. Run the relevant live smoke or request-id/log proof before calling the deploy verified.
+
+## Common Drift Risks
+
+1. Falling back to `scope=all` for small frontend or backend changes.
+2. Assuming `us-central1` or another region before listing actual service tuples.
+3. Blending merge proof, deploy proof, and runtime behavior proof into one status.
+4. Stopping at deploy green when the user asked for end-to-end UAT behavior.

--- a/.codex/workflows/uat-scoped-deploy/workflow.json
+++ b/.codex/workflows/uat-scoped-deploy/workflow.json
@@ -1,0 +1,60 @@
+{
+  "id": "uat-scoped-deploy",
+  "title": "UAT Scoped Deploy",
+  "goal": "Run and verify the smallest safe UAT deploy scope while collecting Cloud Build, Cloud Run, and live behavior evidence.",
+  "owner_skill": "repo-operations",
+  "default_spoke": "uat-scoped-deploy",
+  "task_type": "uat-scoped-deploy",
+  "affected_surfaces": [
+    ".github/workflows/deploy-uat.yml",
+    "deploy"
+  ],
+  "required_reads": [
+    ".github/workflows/deploy-uat.yml",
+    "deploy/README.md",
+    "deploy/frontend.cloudbuild.yaml",
+    "deploy/backend.cloudbuild.yaml",
+    ".codex/skills/uat-scoped-deploy/references/deploy-proof.md"
+  ],
+  "required_commands": [
+    "gh run list --workflow deploy-uat.yml --limit 5 --json databaseId,status,conclusion,headSha,event,url",
+    "python3 .codex/skills/uat-scoped-deploy/scripts/cloud_run_service_evidence.py --project hushh-pda-uat --service hushh-webapp --service consent-protocol --format text",
+    "python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py"
+  ],
+  "verification_bundle": {
+    "id": "uat-scoped-deploy",
+    "commands": [
+      "gh run list --workflow deploy-uat.yml --limit 5 --json databaseId,status,conclusion,headSha,event,url",
+      "python3 .codex/skills/uat-scoped-deploy/scripts/cloud_run_service_evidence.py --project hushh-pda-uat --service hushh-webapp --service consent-protocol --format text",
+      "python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py"
+    ],
+    "tests": [
+      "python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py"
+    ]
+  },
+  "deliverables": [
+    "UAT run URL, SHA, requested scope, resolved scope, and conclusion",
+    "Skipped-lane proof for untouched backend or frontend deploy lanes",
+    "Cloud Run project, service, region, revision, image, timeout, traffic, and labels",
+    "Relevant live behavior proof with request IDs or logs"
+  ],
+  "impact_fields": [
+    "Requested scope",
+    "Resolved scope",
+    "Executed deploy lanes",
+    "Skipped deploy lanes",
+    "Cloud Build durations",
+    "Cloud Run service tuples",
+    "Runtime contract evidence",
+    "Live behavior proof"
+  ],
+  "handoff_chain": [
+    "repo-operations"
+  ],
+  "common_failures": [
+    "Using scope=all for frontend-only or backend-only changes",
+    "Describing Cloud Run services with an assumed region",
+    "Treating queued or in-progress deploys as complete",
+    "Reporting deploy success without revision, label, traffic, or log evidence"
+  ]
+}

--- a/docs/reference/operations/README.md
+++ b/docs/reference/operations/README.md
@@ -86,6 +86,7 @@ Top-level owner skills:
 
 Specialist spoke skills live under the same tree and should be used after the correct owner skill or `repo-context` has narrowed the request.
 Use `.codex/skills/github-contribution-governance/` as the repo-operations spoke for GitHub contribution attribution, author-email checks, PR targeting, and green-dot eligibility.
+Use `.codex/skills/uat-scoped-deploy/` as the repo-operations spoke for frontend-only/backend-only UAT deploys, Cloud Build timing proof, and Cloud Run region/provenance evidence.
 Use `.codex/skills/frontend-native-surface-mapper/` before route/API/native/plugin/voice mapping work so the generated frontend/native surface map stays authoritative.
 Workflow packs under `.codex/workflows/` are the canonical recurring task surface for routing and onboarding.
 Use `ci-watch-and-heal` plus `./bin/hushh codex ci-status` when the task depends on live PR checks or GitHub Actions state.

--- a/docs/reference/operations/coding-agent-mcp.md
+++ b/docs/reference/operations/coding-agent-mcp.md
@@ -248,11 +248,12 @@ When working in this repo:
    - `.codex/skills/subtree-upstream-governance/`
 10. Use spoke skills only after the domain is narrowed to a specific frontend, backend, mobile, security, or repo-operations workflow.
 11. Use `.codex/skills/github-contribution-governance/` for GitHub contribution attribution, author-email checks, PR targeting, and green-dot eligibility.
-12. Use `.codex/skills/frontend-native-surface-mapper/` before route/API/native/plugin/voice mapping work.
-13. Use `.codex/skills/codex-skill-authoring/` when creating or retrofitting repo-local Codex skills, adding skill tooling, or tightening the local taxonomy and coverage rules.
-14. Use `.codex/skills/future-planner/` for future-state roadmap concepts, R&D architecture notes, and planning-only assessments that must stay separate from north-star vision and active implementation docs.
-15. Use `.codex/skills/planning-board/` for `Hussh Engineering Core` board work and `.codex/skills/comms-community/` for public/community explanation workflows.
-16. Use `.codex/skills/agent-orchestration-governance/` when changing repo-scoped custom agents, `.codex/config.toml` agent limits, or delegation authority and handoff rules.
+12. Use `.codex/skills/uat-scoped-deploy/` for scoped UAT deploys and Cloud Run region/provenance proof.
+13. Use `.codex/skills/frontend-native-surface-mapper/` before route/API/native/plugin/voice mapping work.
+14. Use `.codex/skills/codex-skill-authoring/` when creating or retrofitting repo-local Codex skills, adding skill tooling, or tightening the local taxonomy and coverage rules.
+15. Use `.codex/skills/future-planner/` for future-state roadmap concepts, R&D architecture notes, and planning-only assessments that must stay separate from north-star vision and active implementation docs.
+16. Use `.codex/skills/planning-board/` for `Hussh Engineering Core` board work and `.codex/skills/comms-community/` for public/community explanation workflows.
+17. Use `.codex/skills/agent-orchestration-governance/` when changing repo-scoped custom agents, `.codex/config.toml` agent limits, or delegation authority and handoff rules.
 
 If a developer has not configured MCP yet:
 


### PR DESCRIPTION
## Summary
- add a repo-local `uat-scoped-deploy` spoke skill under repo operations
- add a workflow pack and deploy proof reference for frontend/backend/all UAT scope discipline
- add a Cloud Run evidence helper that discovers service region before describing runtime metadata

## Verification
- `python3 .codex/skills/codex-skill-authoring/scripts/truth_first_smoke.py`
- `python3 .codex/skills/codex-skill-authoring/scripts/compact_kernel_smoke.py`
- `python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py`
- `python3 .codex/skills/repo-context/scripts/repo_scan.py validate --text`
- `python3 -m py_compile .codex/skills/uat-scoped-deploy/scripts/cloud_run_service_evidence.py .codex/skills/codex-skill-authoring/scripts/skill_lint.py .codex/skills/repo-context/scripts/repo_scan.py`
- `CLOUDSDK_PYTHON=/Users/ankitkumarsingh/.local/bin/python3.13 python3 .codex/skills/uat-scoped-deploy/scripts/cloud_run_service_evidence.py --project hushh-pda-uat --service hushh-webapp --service consent-protocol --format text`