### PR TITLE
fix(data-table): remove disabled pagination Previous/Next from keyboard tab order

### DIFF
--- a/hushh-webapp/components/app-ui/data-table.tsx
+++ b/hushh-webapp/components/app-ui/data-table.tsx
@@ -420,6 +420,7 @@ export function DataTable<TData, TValue>({
                   <PaginationPrevious
                     href="#"
                     aria-disabled={!table.getCanPreviousPage()}
+                    tabIndex={!table.getCanPreviousPage() ? -1 : undefined}
                     className={cn(
                       !table.getCanPreviousPage() && "pointer-events-none opacity-50"
                     )}
@@ -455,6 +456,7 @@ export function DataTable<TData, TValue>({
                   <PaginationNext
                     href="#"
                     aria-disabled={!table.getCanNextPage()}
+                    tabIndex={!table.getCanNextPage() ? -1 : undefined}
                     className={cn(!table.getCanNextPage() && "pointer-events-none opacity-50")}
                     onClick={(event) => {
                       event.preventDefault();


### PR DESCRIPTION
## Summary

Disabled DataTable pagination Previous and Next controls remained keyboard-focusable because `aria-disabled` alone does not remove elements from the browser tab order.

This update improves keyboard navigation behavior by removing disabled pagination controls from the tab sequence while preserving the existing pagination behavior, styling, and interaction flow.

## What's covered

`components/app-ui/data-table.tsx`

Improved keyboard accessibility behavior for shared DataTable pagination controls.

## Key improvements

- removes disabled pagination controls from keyboard tab order
- preserves normal tab navigation for enabled pagination controls
- keeps existing disabled visual styling unchanged
- preserves existing pagination click behavior
- leaves active pagination interaction flow unchanged

## Reachable surfaces

- authenticated routes rendering paginated `DataTable` surfaces
- RIA table views
- marketplace/admin/client table flows using shared pagination controls

## Validation

- `npx tsc --noEmit`
- `npm run lint`

## Notes

- frontend-only accessibility improvement
- no runtime/business logic changes
- no layout or pagination behavior changes
- no backend/schema/cache impacts
- DCO sign-off included