### PR TITLE
fix(data-table): disable browser autocomplete on shared DataTable search input

### DIFF
--- a/hushh-webapp/components/app-ui/data-table.tsx
+++ b/hushh-webapp/components/app-ui/data-table.tsx
@@ -254,6 +254,7 @@ export function DataTable<TData, TValue>({
                 value={globalFilter ?? ""}
                 onChange={(e) => setGlobalFilter(e.target.value)}
                 className="pl-9 cursor-text"
+                autoComplete="off"
               />
             </div>
           ) : null}


### PR DESCRIPTION
## Summary

The shared DataTable search input did not explicitly disable browser autocomplete behavior, causing native suggestion dropdowns to overlap table layouts on some mobile and desktop browser configurations.

This update disables browser autocomplete for the shared DataTable search field while preserving the existing filtering behavior and controlled input flow.

## What's covered

`components/app-ui/data-table.tsx`

Improved search input behavior for shared `DataTable` filtering surfaces.

## Key improvements

- disables native browser autocomplete for the shared table search input
- reduces autocomplete overlay conflicts on responsive/mobile layouts
- preserves existing controlled filtering behavior
- leaves search state management unchanged
- does not affect any other input surfaces

## Reachable surfaces

- authenticated routes rendering searchable `DataTable` components
- RIA table views
- marketplace/admin/client table surfaces using shared search filtering

## Validation

- `npx tsc --noEmit`
- `npm run lint`

## Notes

- frontend-only UX improvement
- no runtime/business logic changes
- no filtering behavior changes
- no backend/schema/cache impacts
- DCO sign-off included