### PR TITLE
fix(settings-ui): semantically label SettingsGroup section regions via aria-labelledby

### DIFF
--- a/hushh-webapp/components/app-ui/settings-ui.tsx
+++ b/hushh-webapp/components/app-ui/settings-ui.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Children, cloneElement, isValidElement } from "react";
+import { Children, cloneElement, isValidElement, useId } from "react";
 import type { ReactElement, ReactNode } from "react";
 import type { LucideIcon } from "lucide-react";
 import { ChevronRight } from "lucide-react";
@@ -101,6 +101,8 @@ export function SettingsGroup({
   embedded?: boolean;
   className?: string;
 }) {
+  const headingId = useId();
+
   const shell = (
     <div
       className={cn(
@@ -114,7 +116,10 @@ export function SettingsGroup({
   );
 
   return (
-    <section className={cn("w-full space-y-[var(--settings-group-stack-gap)]", className)}>
+  <section
+    aria-labelledby={title ? headingId : undefined}
+    className={cn("w-full space-y-[var(--settings-group-stack-gap)]", className)}
+  >
       {eyebrow || title || description ? (
         <div className="space-y-[var(--settings-heading-stack-gap)] px-0.5 sm:px-1">
           {eyebrow ? (
@@ -123,7 +128,10 @@ export function SettingsGroup({
             </p>
           ) : null}
           {title ? (
-            <h2 className="text-pretty text-[13px] font-semibold tracking-tight text-foreground [overflow-wrap:anywhere] sm:text-[14px]">
+            <h2
+              id={headingId}
+              className="text-pretty text-[13px] font-semibold tracking-tight text-foreground [overflow-wrap:anywhere] sm:text-[14px]"
+            >
               {title}
             </h2>
           ) : null}


### PR DESCRIPTION
## Summary

SettingsGroup containers were previously rendered as unlabeled landmark regions because their `<section>` elements were not associated with the visible heading text.

This update improves accessibility semantics by linking SettingsGroup section regions to their corresponding headings using `aria-labelledby`, while preserving the existing layout and runtime behavior.

## What's covered

`components/app-ui/settings-ui.tsx`

Added semantic section labeling support for shared `SettingsGroup` surfaces.

## Key improvements

* adds stable component-local heading ids using `useId()`
* associates SettingsGroup `<section>` regions with visible headings
* improves landmark navigation for screen reader users
* preserves existing layout and styling behavior
* omits `aria-labelledby` automatically when no title exists

## Reachable surfaces

* authenticated settings routes using shared `SettingsGroup`
* profile/settings frontend surfaces
* settings drawer and panel layouts using `SettingsGroup`

## Validation

* `npx tsc --noEmit`
* `npm run lint`

## Notes

* frontend-only accessibility improvement
* no API/runtime/business logic changes
* no visual layout changes
* no backend/schema/cache impacts
* DCO sign-off included