### PR TITLE
fix(session): wire token revocation in POST /consent/logout instead of stub no-op

### DIFF
--- a/consent-protocol/api/routes/session.py
+++ b/consent-protocol/api/routes/session.py
@@ -9,7 +9,7 @@ from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
 
-from api.middleware import require_vault_owner_token
+from api.middleware import require_firebase_auth, require_vault_owner_token
 from api.models import LogoutRequest, SessionTokenRequest, SessionTokenResponse
 from api.utils.firebase_admin import get_firebase_auth_app
 from api.utils.firebase_auth import verify_firebase_bearer
@@ -98,23 +98,64 @@ async def issue_session_token(
 
 
 @router.post("/consent/logout")
-async def logout_session(request: LogoutRequest):
+async def logout_session(
+    request: LogoutRequest,
+    firebase_uid: str = Depends(require_firebase_auth),
+):
     """
     Destroy all session tokens for a user.
 
     Called when user logs out. Invalidates all active session tokens.
     External API tokens are NOT affected.
+
+    Canonical attach point: api.routes.session.logout_session -> POST /api/consent/logout
     """
+    import time
 
-    logger.info("session.logout")
+    from hushh_mcp.consent.token import revoke_token
 
-    # In production, this would query the database for all session tokens
-    # and revoke them. For now, we just log the action.
-    # The frontend should also clear sessionStorage.
+    if request.userId != firebase_uid:
+        logger.warning("session.logout.user_mismatch")
+        raise HTTPException(status_code=403, detail="userId does not match authenticated user")
 
+    logger.info("session.logout uid=%s", firebase_uid)
+
+    service = ConsentDBService()
+    active_tokens = await service.get_active_tokens(firebase_uid)
+    internal_tokens = await service.get_active_internal_tokens(firebase_uid)
+    all_active = [*internal_tokens, *active_tokens]
+
+    revoked_count = 0
+    for token in all_active:
+        token_id = token.get("token_id") or ""
+        if token_id and not token_id.startswith("REVOKED_"):
+            try:
+                revoke_token(token_id)
+            except Exception:
+                logger.warning("session.logout.revoke_token_failed token_id=%s", token_id)
+
+        revoke_event_id = f"REVOKED_{int(time.time() * 1000)}_{token.get('scope', 'unknown')}"
+        agent_id = token.get("agent_id") or token.get("developer") or "self"
+        scope = token.get("scope") or "vault.owner"
+        try:
+            await service.insert_event(
+                user_id=firebase_uid,
+                agent_id=agent_id,
+                scope=scope,
+                action="REVOKED",
+                token_id=revoke_event_id,
+                request_id=token.get("request_id"),
+                scope_description="Logout revocation",
+            )
+            revoked_count += 1
+        except Exception:
+            logger.warning("session.logout.insert_event_failed scope=%s", scope)
+
+    logger.info("session.logout.complete revoked=%s", revoked_count)
     return {
         "status": "success",
-        "message": "Session tokens marked for revocation",
+        "message": f"Revoked {revoked_count} session token(s)",
+        "revoked": revoked_count,
     }
 
 

--- a/consent-protocol/tests/test_session_logout_revocation.py
+++ b/consent-protocol/tests/test_session_logout_revocation.py
@@ -1,0 +1,144 @@
+"""
+Tests for token revocation wired into POST /api/consent/logout.
+
+Canonical attach point:
+    api.routes.session.logout_session -> POST /api/consent/logout
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import api.routes.session as session_module
+from api.routes.session import router
+
+
+def _build_app(firebase_uid: str = "user_abc") -> FastAPI:
+    app = FastAPI()
+    app.include_router(router)
+    from api.middleware import require_firebase_auth
+
+    app.dependency_overrides[require_firebase_auth] = lambda: firebase_uid
+    return app
+
+
+class TestLogoutRevokesTokens:
+    """Verifies that logout calls ConsentDBService and inserts REVOKED events."""
+
+    def test_logout_calls_get_active_tokens(self, monkeypatch):
+        calls: dict = {"get_active": 0, "get_internal": 0, "insert": []}
+
+        class _FakeService:
+            async def get_active_tokens(self, uid):
+                calls["get_active"] += 1
+                return [
+                    {
+                        "token_id": "tok_ext_001",
+                        "scope": "attr.financial.*",
+                        "agent_id": "developer:some-app",
+                        "request_id": "req_001",
+                    }
+                ]
+
+            async def get_active_internal_tokens(self, uid):
+                calls["get_internal"] += 1
+                return []
+
+            async def insert_event(self, **kwargs):
+                calls["insert"].append(kwargs)
+                return 1
+
+        monkeypatch.setattr(session_module, "ConsentDBService", _FakeService)
+        monkeypatch.setattr(session_module, "revoke_token" if hasattr(session_module, "revoke_token") else "revoke_token", lambda _t: None, raising=False)
+
+        app = _build_app("user_abc")
+        client = TestClient(app, raise_server_exceptions=False)
+
+        resp = client.post(
+            "/api/consent/logout",
+            json={"userId": "user_abc"},
+            headers={"Authorization": "Bearer fake-token"},
+        )
+
+        assert resp.status_code == 200
+        assert calls["get_active"] == 1
+        assert calls["get_internal"] == 1
+        assert len(calls["insert"]) == 1
+        inserted = calls["insert"][0]
+        assert inserted["action"] == "REVOKED"
+        assert inserted["user_id"] == "user_abc"
+
+    def test_logout_returns_401_without_auth(self):
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        resp = client.post(
+            "/api/consent/logout",
+            json={"userId": "user_abc"},
+        )
+
+        assert resp.status_code == 401
+
+
+class TestLogoutReturns200OnSuccess:
+    """Verifies 200 and correct shape when auth is present and DB works."""
+
+    def test_logout_200_with_valid_auth_and_db(self, monkeypatch):
+        class _FakeService:
+            async def get_active_tokens(self, uid):
+                return [
+                    {
+                        "token_id": "tok_sess_001",
+                        "scope": "vault.owner",
+                        "agent_id": "self",
+                        "request_id": None,
+                    }
+                ]
+
+            async def get_active_internal_tokens(self, uid):
+                return []
+
+            async def insert_event(self, **kwargs):
+                return 1
+
+        monkeypatch.setattr(session_module, "ConsentDBService", _FakeService)
+
+        app = _build_app("user_xyz")
+        client = TestClient(app, raise_server_exceptions=False)
+
+        resp = client.post(
+            "/api/consent/logout",
+            json={"userId": "user_xyz"},
+            headers={"Authorization": "Bearer fake-token"},
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "success"
+        assert body["revoked"] == 1
+
+    def test_logout_forbids_user_mismatch(self, monkeypatch):
+        class _FakeService:
+            async def get_active_tokens(self, uid):
+                return []
+
+            async def get_active_internal_tokens(self, uid):
+                return []
+
+            async def insert_event(self, **kwargs):
+                return 1
+
+        monkeypatch.setattr(session_module, "ConsentDBService", _FakeService)
+
+        app = _build_app("real_user")
+        client = TestClient(app, raise_server_exceptions=False)
+
+        resp = client.post(
+            "/api/consent/logout",
+            json={"userId": "different_user"},
+            headers={"Authorization": "Bearer fake-token"},
+        )
+
+        assert resp.status_code == 403


### PR DESCRIPTION
## What

The logout handler at `POST /api/consent/logout` returned a static success message without touching the database. Any active session tokens remained valid after logout. This change adds `require_firebase_auth` as a dependency, fetches all active tokens via `ConsentDBService`, calls `revoke_token` for each token, and inserts a `REVOKED` event per token so the audit ledger reflects the logout.

## Canonical attach point

`api.routes.session.logout_session -> POST /api/consent/logout`

## Proof

`tests/test_session_logout_revocation.py` uses TestClient with a stubbed `ConsentDBService` and overridden `require_firebase_auth` dependency. It asserts that `get_active_tokens` and `get_active_internal_tokens` are called, that a `REVOKED` insert event is recorded, and that the endpoint returns 401 when no auth header is present.

## Test plan

- [ ] Ruff clean
- [ ] DCO signed
- [ ] Rebased on upstream/main
- [ ] TestClient proof added