### PR TITLE
fix(consent): drop unknown extra fields in ConsentApprovalPayload instead of storing them

### DIFF
--- a/consent-protocol/api/routes/consent.py
+++ b/consent-protocol/api/routes/consent.py
@@ -411,7 +411,7 @@ class ConsentApprovalPayload(BaseModel):
     Integrated by Abdul Gaffar — canonical field-level validation logic.
     """
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="ignore")
 
     version: int = Field(default=1, ge=1, le=2)
 

--- a/consent-protocol/tests/test_consent_approval_extra_fields.py
+++ b/consent-protocol/tests/test_consent_approval_extra_fields.py
@@ -1,0 +1,56 @@
+"""
+Tests that ConsentApprovalPayload silently drops unknown extra fields.
+
+Canonical attach point:
+    api.routes.consent.ConsentApprovalPayload (consumed by approve_consent)
+    -> POST /api/consent/pending/approve
+"""
+
+from __future__ import annotations
+
+from api.routes.consent import ConsentApprovalPayload
+
+
+class TestConsentApprovalExtraIgnored:
+    """Verifies that extra fields are silently dropped instead of being stored."""
+
+    def test_extra_fields_not_in_model_fields_set(self):
+        payload = ConsentApprovalPayload(
+            userId="user_abc",
+            requestId="req_001",
+            unknown_field="should_be_dropped",
+            another_extra=12345,
+        )
+
+        assert "unknown_field" not in payload.model_fields_set
+        assert "another_extra" not in payload.model_fields_set
+
+    def test_valid_fields_are_preserved(self):
+        payload = ConsentApprovalPayload(
+            userId="user_abc",
+            requestId="req_001",
+            version=2,
+        )
+
+        assert payload.userId == "user_abc"
+        assert payload.requestId == "req_001"
+        assert payload.version == 2
+
+    def test_extra_fields_absent_from_model_dump(self):
+        payload = ConsentApprovalPayload(
+            userId="user_abc",
+            requestId="req_001",
+            injected_key="injected_value",
+        )
+
+        dumped = payload.model_dump()
+        assert "injected_key" not in dumped
+
+    def test_model_accepts_minimal_valid_payload(self):
+        payload = ConsentApprovalPayload(
+            userId="user_abc",
+            requestId="req_001",
+        )
+
+        assert payload.userId == "user_abc"
+        assert payload.requestId == "req_001"


### PR DESCRIPTION
## What

`ConsentApprovalPayload` used `model_config = ConfigDict(extra="allow")`, which meant any unknown key sent by a caller was silently stored in the model and available via `model_dump()`. This is a data hygiene issue: callers can inject arbitrary keys that propagate through the approval flow. Changing `extra` to `"ignore"` drops unknown keys at parse time without raising an error, consistent with the principle of least surprise and matching behaviour in similar models across the codebase.

## Canonical attach point

`api.routes.consent.ConsentApprovalPayload` (consumed by `approve_consent`) -> `POST /api/consent/pending/approve`

## Proof

`tests/test_consent_approval_extra_fields.py` constructs the model with extra keys and asserts they are absent from `model_fields_set` and from `model_dump()`. Valid declared fields are verified to be preserved.

## Test plan

- [ ] Ruff clean
- [ ] DCO signed
- [ ] Rebased on upstream/main
- [ ] TestClient proof added