### PR TITLE
fix(consent): add max_length bound to unbounded encryptedData in RefreshExportUploadRequest

### DIFF
--- a/consent-protocol/api/routes/consent.py
+++ b/consent-protocol/api/routes/consent.py
@@ -265,7 +265,7 @@ class RelationshipDisconnectRequest(BaseModel):
 class RefreshExportUploadRequest(BaseModel):
     userId: str = Field(min_length=1, max_length=128)
     consentToken: str = Field(min_length=1, max_length=2048)
-    encryptedData: str = Field(min_length=1)
+    encryptedData: str = Field(min_length=1, max_length=10_000_000)
     encryptedIv: str = Field(min_length=1, max_length=256)
     encryptedTag: str = Field(min_length=1, max_length=256)
     wrappedExportKey: str = Field(min_length=1, max_length=8192)

--- a/consent-protocol/tests/test_refresh_export_upload_bounds.py
+++ b/consent-protocol/tests/test_refresh_export_upload_bounds.py
@@ -1,0 +1,56 @@
+"""
+Tests that RefreshExportUploadRequest enforces max_length on encryptedData.
+
+Canonical attach point:
+    api.routes.consent.RefreshExportUploadRequest (consumed by upload_refresh_export)
+    -> POST /api/consent/refresh-export/upload
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from api.routes.consent import RefreshExportUploadRequest
+
+_VALID_BASE = dict(
+    userId="user_abc",
+    consentToken="tok_" + "x" * 20,
+    encryptedIv="a" * 16,
+    encryptedTag="b" * 16,
+    wrappedExportKey="c" * 44,
+    wrappedKeyIv="d" * 16,
+    wrappedKeyTag="e" * 16,
+    senderPublicKey="f" * 44,
+)
+
+
+class TestRefreshExportUploadBounds:
+    """Verifies that encryptedData is rejected when it exceeds 10 MB."""
+
+    def test_oversized_encrypted_data_raises_validation_error(self):
+        oversized = "x" * 10_000_001
+        with pytest.raises(ValidationError) as exc_info:
+            RefreshExportUploadRequest(**_VALID_BASE, encryptedData=oversized)
+
+        errors = exc_info.value.errors()
+        field_errors = [e for e in errors if "encryptedData" in str(e.get("loc", ""))]
+        assert field_errors, f"Expected encryptedData error, got: {errors}"
+
+    def test_max_allowed_encrypted_data_is_accepted(self):
+        at_limit = "x" * 10_000_000
+        model = RefreshExportUploadRequest(**_VALID_BASE, encryptedData=at_limit)
+        assert len(model.encryptedData) == 10_000_000
+
+    def test_empty_encrypted_data_is_rejected(self):
+        with pytest.raises(ValidationError) as exc_info:
+            RefreshExportUploadRequest(**_VALID_BASE, encryptedData="")
+
+        errors = exc_info.value.errors()
+        field_errors = [e for e in errors if "encryptedData" in str(e.get("loc", ""))]
+        assert field_errors
+
+    def test_normal_encrypted_data_is_accepted(self):
+        normal = "x" * 1000
+        model = RefreshExportUploadRequest(**_VALID_BASE, encryptedData=normal)
+        assert model.encryptedData == normal


### PR DESCRIPTION
## What

`RefreshExportUploadRequest.encryptedData` had `min_length=1` but no `max_length`, leaving it unbounded. Every other field in the same model that carries binary-encoded data (`encryptedIv`, `encryptedTag`, `wrappedExportKey`, `senderPublicKey`, etc.) already has a `max_length`. The fix adds `max_length=10_000_000` to match the practical upper bound for an AES-256-GCM-encrypted PKM export payload.

## Canonical attach point

`api.routes.consent.RefreshExportUploadRequest` (consumed by `upload_refresh_export`) -> `POST /api/consent/refresh-export/upload`

## Proof

`tests/test_refresh_export_upload_bounds.py` validates that passing `"x" * 10_000_001` raises a `ValidationError` with an `encryptedData` field error, that exactly `10_000_000` characters are accepted, and that an empty string is also rejected.

## Test plan

- [ ] Ruff clean
- [ ] DCO signed
- [ ] Rebased on upstream/main
- [ ] TestClient proof added