### PR TITLE
fix(ria): add typed Pydantic request model to POST /ria/financial-verification-jobs

### DIFF
--- a/consent-protocol/api/routes/crd_scraper.py
+++ b/consent-protocol/api/routes/crd_scraper.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
@@ -30,6 +30,26 @@ class CrdScrapeJobRequest(BaseModel):
     @classmethod
     def normalize_crd(cls, value: str) -> str:
         return str(normalize_crd_number(value))
+
+
+class FinancialVerificationJobRequest(BaseModel):
+    """Typed request body for POST /api/ria/financial-verification-jobs.
+
+    Canonical attach point:
+        api.routes.crd_scraper.create_financial_verification_job
+        -> POST /api/ria/financial-verification-jobs
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    crdNumber: str = Field(
+        ...,
+        min_length=1,
+        max_length=10,
+        description="CRD registration number (digits only, max 10 characters).",
+    )
+    userId: Optional[str] = Field(default=None, min_length=1, max_length=128)
+    requestId: Optional[str] = Field(default=None, min_length=1, max_length=128)
 
 
 def get_crd_scrape_proxy_service() -> CrdScrapeProxyService:
@@ -71,13 +91,13 @@ async def get_crd_scrape_job(
 @router.post("/financial-verification-jobs")
 @limiter.limit("10/minute")
 async def create_financial_verification_job(
-    payload: dict[str, Any],
+    payload: FinancialVerificationJobRequest,
     request: Request,
     service: CrdScrapeProxyService = Depends(get_crd_scrape_proxy_service),
 ) -> JSONResponse:
     result = await _call_provider(
         service.create_financial_verification_job(
-            payload=payload,
+            payload=payload.model_dump(exclude_none=True),
             request_id=_request_id(request),
         )
     )

--- a/consent-protocol/tests/test_crd_scraper_request_validation.py
+++ b/consent-protocol/tests/test_crd_scraper_request_validation.py
@@ -1,0 +1,73 @@
+"""
+Tests that FinancialVerificationJobRequest rejects unknown extra fields.
+
+Canonical attach point:
+    api.routes.crd_scraper.create_financial_verification_job
+    -> POST /api/ria/financial-verification-jobs
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import api.routes.crd_scraper as crd_module
+from api.routes.crd_scraper import router
+from hushh_mcp.services.crd_scrape_proxy_service import CrdScrapeProviderResponse
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+class TestCrdScraperRequestValidation:
+    """Verifies that the typed model rejects unknown fields and accepts valid ones."""
+
+    def test_unknown_extra_field_returns_422(self):
+        client = TestClient(_build_app(), raise_server_exceptions=False)
+
+        resp = client.post(
+            "/api/ria/financial-verification-jobs",
+            json={"crdNumber": "12345", "unknown_extra_key": "should_be_rejected"},
+        )
+
+        assert resp.status_code == 422
+
+    def test_valid_request_is_forwarded(self, monkeypatch):
+        mock_service = AsyncMock()
+        mock_service.create_financial_verification_job = AsyncMock(
+            return_value=CrdScrapeProviderResponse(
+                status_code=202,
+                payload={"jobId": "job_001", "status": "queued"},
+            )
+        )
+
+        monkeypatch.setattr(
+            crd_module, "get_crd_scrape_proxy_service", lambda: mock_service
+        )
+
+        client = TestClient(_build_app(), raise_server_exceptions=True)
+        resp = client.post(
+            "/api/ria/financial-verification-jobs",
+            json={"crdNumber": "12345"},
+        )
+
+        assert resp.status_code != 422
+        mock_service.create_financial_verification_job.assert_called_once()
+        call_kwargs = mock_service.create_financial_verification_job.call_args.kwargs
+        assert call_kwargs["payload"]["crdNumber"] == "12345"
+        assert "unknown_extra_key" not in call_kwargs["payload"]
+
+    def test_missing_crd_number_returns_422(self):
+        client = TestClient(_build_app(), raise_server_exceptions=False)
+
+        resp = client.post(
+            "/api/ria/financial-verification-jobs",
+            json={"userId": "user_abc"},
+        )
+
+        assert resp.status_code == 422


### PR DESCRIPTION
## What

`POST /api/ria/financial-verification-jobs` accepted `payload: dict[str, Any]`, meaning any arbitrary JSON object was forwarded to the upstream RIA Intelligence API with no structural validation. This adds `FinancialVerificationJobRequest(BaseModel)` with `model_config = ConfigDict(extra="forbid")` and typed fields for the known payload keys (`crdNumber` required, `userId` and `requestId` optional). The handler now passes `payload.model_dump(exclude_none=True)` to the service layer.

## Canonical attach point

`api.routes.crd_scraper.create_financial_verification_job -> POST /api/ria/financial-verification-jobs`

## Proof

`tests/test_crd_scraper_request_validation.py` uses TestClient to confirm that an unknown extra field returns 422, that a valid payload is forwarded correctly, and that a request missing `crdNumber` also returns 422.

## Test plan

- [ ] Ruff clean
- [ ] DCO signed
- [ ] Rebased on upstream/main
- [ ] TestClient proof added