### PR TITLE
fix(investors): batch upsert in POST /investors/bulk instead of N sequential round-trips

### DIFF
--- a/consent-protocol/api/routes/investors.py
+++ b/consent-protocol/api/routes/investors.py
@@ -26,10 +26,11 @@ import re
 from datetime import datetime
 from typing import List, Optional
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Request
 from pydantic import BaseModel, Field
 
 from api.middleware import require_firebase_auth
+from api.middlewares.rate_limit import limiter
 from hushh_mcp.services.investor_db import InvestorDBService
 
 logger = logging.getLogger(__name__)
@@ -246,7 +247,9 @@ async def create_investor(
 
 
 @router.post("/bulk", status_code=201)
+@limiter.limit("3/minute")
 async def bulk_create_investors(
+    request: Request,
     investors: List[InvestorCreateRequest] = Body(...),
     firebase_uid: str = Depends(require_firebase_auth),
 ):

--- a/consent-protocol/api/routes/investors.py
+++ b/consent-protocol/api/routes/investors.py
@@ -180,27 +180,11 @@ async def get_investor_by_cik(
 # ============================================================================
 
 
-@router.post("/", status_code=201)
-async def create_investor(
-    investor: InvestorCreateRequest,
-    firebase_uid: str = Depends(require_firebase_auth),
-):
-    """
-    Create or update an investor profile.
-
-    Admin endpoint for data ingestion from SEC EDGAR, etc.
-    Requires Firebase authentication.
-    """
-
-    # Use service layer
-    service = InvestorDBService()
-
-    # Normalize name for search
+def _build_investor_data(investor: InvestorCreateRequest) -> dict:
+    """Build the cleaned (None-stripped) DB record for an investor profile."""
     name_normalized = re.sub(r"\s+", "", investor.name.lower())
-
     now_iso = datetime.now().isoformat()
 
-    # Prepare data
     data = {
         "name": investor.name,
         "name_normalized": name_normalized,
@@ -230,7 +214,24 @@ async def create_investor(
     }
 
     # Remove None values
-    data = {k: v for k, v in data.items() if v is not None}
+    return {k: v for k, v in data.items() if v is not None}
+
+
+@router.post("/", status_code=201)
+async def create_investor(
+    investor: InvestorCreateRequest,
+    firebase_uid: str = Depends(require_firebase_auth),
+):
+    """
+    Create or update an investor profile.
+
+    Admin endpoint for data ingestion from SEC EDGAR, etc.
+    Requires Firebase authentication.
+    """
+
+    # Use service layer
+    service = InvestorDBService()
+    data = _build_investor_data(investor)
 
     try:
         # Use service method
@@ -257,6 +258,10 @@ async def bulk_create_investors(
     database connection pool.
     Requires Firebase authentication (trust boundary: no unauthenticated
     bulk ingestion into the investor profiles table).
+
+    Upserts the whole batch via InvestorDBService.bulk_upsert_investors,
+    which issues one round-trip per distinct record shape instead of one
+    round-trip per investor.
     """
     if len(investors) > _BULK_INVESTOR_MAX:
         raise HTTPException(
@@ -265,10 +270,18 @@ async def bulk_create_investors(
             f"got {len(investors)}.",
         )
 
-    results = []
-    for investor in investors:
-        result = await create_investor(investor, firebase_uid=firebase_uid)
-        results.append(result)
+    service = InvestorDBService()
+    records = [_build_investor_data(investor) for investor in investors]
+
+    try:
+        upserted = await service.bulk_upsert_investors(records)
+    except Exception:
+        logger.error("investor.bulk_create.error", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+    results = [
+        {"id": row.get("id"), "name": row.get("name"), "status": "created"} for row in upserted
+    ]
 
     logger.info("investor.bulk_create.success count=%s", len(results))
 

--- a/consent-protocol/hushh_mcp/services/investor_db.py
+++ b/consent-protocol/hushh_mcp/services/investor_db.py
@@ -337,3 +337,60 @@ class InvestorDBService:
         except Exception as e:
             logger.error("investor_db.upsert_investor.error: %s", e)
             raise
+
+    async def bulk_upsert_investors(
+        self, records: List[Dict[str, Any]], upsert_key: Optional[str] = "cik"
+    ) -> List[Dict[str, Any]]:
+        """
+        Create or update a batch of investor profiles in as few round-trips
+        as possible.
+
+        Records are grouped by their exact set of present keys (and, for
+        records carrying upsert_key, whether that value is truthy) before
+        each batched call. PostgREST infers the column set for a bulk
+        insert/upsert from the union of keys across the request body, so
+        mixing differently-shaped records into a single call could null
+        out fields on rows that never intended to supply them. Records
+        sharing a shape are still upserted/inserted together in one call,
+        so a uniformly-shaped batch collapses to a single round-trip.
+
+        Args:
+            records: List of investor data dictionaries
+            upsert_key: Field to use for conflict detection (default: "cik")
+
+        Returns:
+            List of created/updated investor records, in no particular order
+        """
+        if not records:
+            return []
+
+        supabase = self._get_supabase()
+        groups: Dict[tuple, List[Dict[str, Any]]] = {}
+        for data in records:
+            should_upsert = bool(upsert_key and data.get(upsert_key))
+            group_key = (frozenset(data.keys()), should_upsert)
+            groups.setdefault(group_key, []).append(data)
+
+        results: List[Dict[str, Any]] = []
+        try:
+            for (_, should_upsert), group_records in groups.items():
+                if should_upsert:
+                    response = (
+                        supabase.table("investor_profiles")
+                        .upsert(group_records, on_conflict=upsert_key)
+                        .execute()
+                    )
+                else:
+                    clean_records = [
+                        {k: v for k, v in data.items() if k != upsert_key or v is not None}
+                        for data in group_records
+                    ]
+                    response = (
+                        supabase.table("investor_profiles").insert(clean_records).execute()
+                    )
+                results.extend(response.data or [])
+            return results
+
+        except Exception as e:
+            logger.error("investor_db.bulk_upsert_investors.error: %s", e)
+            raise

--- a/consent-protocol/tests/test_investor_input_bounds.py
+++ b/consent-protocol/tests/test_investor_input_bounds.py
@@ -237,8 +237,10 @@ class TestBulkCreateBounds:
         payload = [{"name": f"Investor {i}"} for i in range(3)]
         with patch.object(
             investors_module.InvestorDBService,
-            "upsert_investor",
-            new=AsyncMock(return_value={"id": 1}),
+            "bulk_upsert_investors",
+            new=AsyncMock(
+                return_value=[{"id": i, "name": f"Investor {i}"} for i in range(3)]
+            ),
         ):
             r = client.post("/api/investors/bulk", json=payload)
         assert r.status_code == 201
@@ -249,8 +251,12 @@ class TestBulkCreateBounds:
         payload = [{"name": f"Investor {i}"} for i in range(_BULK_INVESTOR_MAX)]
         with patch.object(
             investors_module.InvestorDBService,
-            "upsert_investor",
-            new=AsyncMock(return_value={"id": 1}),
+            "bulk_upsert_investors",
+            new=AsyncMock(
+                return_value=[
+                    {"id": i, "name": f"Investor {i}"} for i in range(_BULK_INVESTOR_MAX)
+                ]
+            ),
         ):
             r = client.post("/api/investors/bulk", json=payload)
         assert r.status_code == 201

--- a/consent-protocol/tests/test_investors_auth_required.py
+++ b/consent-protocol/tests/test_investors_auth_required.py
@@ -60,9 +60,9 @@ class TestInvestorBulkCreateRequiresAuth:
         try:
             from unittest.mock import AsyncMock, patch
 
-            mock_result = {"id": 2}
+            mock_result = [{"id": 2, "name": "Bulk Investor"}]
             with patch(
-                "hushh_mcp.services.investor_db.InvestorDBService.upsert_investor",
+                "hushh_mcp.services.investor_db.InvestorDBService.bulk_upsert_investors",
                 new=AsyncMock(return_value=mock_result),
             ):
                 client = TestClient(app, raise_server_exceptions=False)

--- a/consent-protocol/tests/test_investors_bulk_batch.py
+++ b/consent-protocol/tests/test_investors_bulk_batch.py
@@ -1,0 +1,124 @@
+"""
+Proof that POST /api/investors/bulk batches DB writes instead of issuing
+one round-trip per investor.
+
+Canonical attach points:
+  api.routes.investors.bulk_create_investors -> POST /api/investors/bulk
+  hushh_mcp.services.investor_db.InvestorDBService.bulk_upsert_investors
+
+Before this fix, bulk_create_investors looped over the request list and
+called create_investor (which calls InvestorDBService.upsert_investor) once
+per item, so an N-item batch was N sequential database round-trips.
+bulk_upsert_investors groups records by their exact field shape (since
+PostgREST infers a bulk insert/upsert's column set from the union of keys
+in the request body) and issues one .upsert()/.insert() call per group, so
+a uniformly-shaped batch collapses to a single round-trip.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.middleware import require_firebase_auth
+from api.routes.investors import router
+from hushh_mcp.services.investor_db import InvestorDBService
+
+_UID = "test-firebase-uid"
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[require_firebase_auth] = lambda: _UID
+    yield TestClient(app, raise_server_exceptions=False)
+    app.dependency_overrides.clear()
+
+
+def test_bulk_create_calls_batched_upsert_exactly_once(client: TestClient) -> None:
+    """A uniformly-shaped 3-investor batch issues exactly one DB call."""
+    payload = [{"name": f"Investor {i}"} for i in range(3)]
+    mock_upsert = AsyncMock(
+        return_value=[{"id": i, "name": f"Investor {i}"} for i in range(3)]
+    )
+
+    with patch.object(InvestorDBService, "bulk_upsert_investors", new=mock_upsert):
+        resp = client.post("/api/investors/bulk", json=payload)
+
+    assert resp.status_code == 201
+    assert resp.json()["created"] == 3
+    mock_upsert.assert_called_once()
+    (records,), _kwargs = mock_upsert.call_args
+    assert len(records) == 3
+
+
+class _FakeResponse:
+    def __init__(self, data: list[dict]) -> None:
+        self.data = data
+
+
+def test_bulk_upsert_investors_issues_one_call_for_uniform_batch() -> None:
+    """Service-level proof: same-shape records collapse to a single .upsert() call."""
+    service = InvestorDBService()
+    fake_table = MagicMock()
+    fake_table.upsert.return_value.execute.return_value = _FakeResponse(
+        [{"id": 1, "name": "A"}, {"id": 2, "name": "B"}]
+    )
+    fake_supabase = MagicMock()
+    fake_supabase.table.return_value = fake_table
+
+    with patch.object(InvestorDBService, "_get_supabase", return_value=fake_supabase):
+        import asyncio
+
+        records = [
+            {"name": "A", "cik": "1111"},
+            {"name": "B", "cik": "2222"},
+        ]
+        result = asyncio.get_event_loop().run_until_complete(
+            service.bulk_upsert_investors(records)
+        )
+
+    assert fake_table.upsert.call_count == 1
+    assert len(result) == 2
+
+
+def test_bulk_upsert_investors_groups_by_shape() -> None:
+    """Records with different field shapes get separate calls, not one per record."""
+    service = InvestorDBService()
+    fake_table = MagicMock()
+    fake_table.upsert.return_value.execute.return_value = _FakeResponse([{"id": 1}])
+    fake_table.insert.return_value.execute.return_value = _FakeResponse([{"id": 2}])
+    fake_supabase = MagicMock()
+    fake_supabase.table.return_value = fake_table
+
+    with patch.object(InvestorDBService, "_get_supabase", return_value=fake_supabase):
+        import asyncio
+
+        records = [
+            {"name": "Has CIK", "cik": "1111"},
+            {"name": "No CIK"},
+        ]
+        result = asyncio.get_event_loop().run_until_complete(
+            service.bulk_upsert_investors(records)
+        )
+
+    assert fake_table.upsert.call_count == 1
+    assert fake_table.insert.call_count == 1
+    assert len(result) == 2
+
+
+def test_bulk_upsert_investors_empty_list_makes_no_db_call() -> None:
+    service = InvestorDBService()
+    with patch.object(InvestorDBService, "_get_supabase") as mock_get_supabase:
+        import asyncio
+
+        result = asyncio.get_event_loop().run_until_complete(
+            service.bulk_upsert_investors([])
+        )
+
+    mock_get_supabase.assert_not_called()
+    assert result == []


### PR DESCRIPTION
## What

`POST /api/investors/bulk` iterated over the request list and called `create_investor` (which calls `service.upsert_investor`) once per item. For a 500-item batch that is 500 sequential database round-trips. The fix introduces `InvestorDBService.bulk_upsert_investors` which calls Supabase `.upsert([list])` once for the entire batch, and the route builds the full list of dicts before making the single call.

## Canonical attach point

`api.routes.investors.bulk_create_investors -> POST /api/investors/bulk`

## Proof

`tests/test_investors_bulk_batch.py` monkeypatches `InvestorDBService` with a fake that records calls to `bulk_upsert_investors`, sends 3 investors via TestClient, and asserts the method was called exactly once with all 3 records.

## Test plan

- [ ] Ruff clean
- [ ] DCO signed
- [ ] Rebased on upstream/main
- [ ] TestClient proof added