### PR TITLE
Fix RIA inactive broker location prefill

### DIFF
--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -145,6 +145,29 @@ _OFFICIAL_ADDRESS_RE = re.compile(
     r"(?P<pin_zip>\d{5}(?:-\d{4})?)\b",
     re.IGNORECASE,
 )
+_BROKERCHECK_BRANCH_ROW_RE = re.compile(
+    r"\b(?:B|IA)?\s*"
+    r"\d{2}/\d{4}\s+-\s+(?:Present|\d{2}/\d{4})\s+"
+    r"(?P<firm>[A-Z0-9][A-Z0-9 .,&'/-]{1,120}?)\s+"
+    r"(?P<firm_crd>\d{2,8})\s+"
+    r"(?P<city>[A-Z][A-Z .'-]{1,60}?),\s*"
+    r"(?P<state>AL|AK|AZ|AR|CA|CO|CT|DE|FL|GA|HI|ID|IL|IN|IA|KS|KY|LA|ME|MD|MA|MI|MN|MS|MO|MT|NE|NV|NH|NJ|NM|NY|NC|ND|OH|OK|OR|PA|RI|SC|SD|TN|TX|UT|VT|VA|WA|WV|WI|WY|DC)\b",
+    re.IGNORECASE,
+)
+_BROKERCHECK_SUMMARY_BRANCH_RE = re.compile(
+    r"\b(?:B|IA)\s+"
+    r"(?P<firm>[A-Z0-9][A-Z0-9 .,&'/-]{1,120}?)\s+"
+    r"CRD#\s*(?P<firm_crd>\d{2,8})\s+"
+    r"(?P<city>[A-Z][A-Z .'-]{1,60}?),\s*"
+    r"(?P<state>AL|AK|AZ|AR|CA|CO|CT|DE|FL|GA|HI|ID|IL|IN|IA|KS|KY|LA|ME|MD|MA|MI|MN|MS|MO|MT|NE|NV|NH|NJ|NM|NY|NC|ND|OH|OK|OR|PA|RI|SC|SD|TN|TX|UT|VT|VA|WA|WV|WI|WY|DC)\b",
+    re.IGNORECASE,
+)
+_FIRM_CITY_STATE_ZIP_RE = re.compile(
+    r"^(?P<city>[A-Z][A-Z .'-]{1,60}?),\s*"
+    r"(?P<state>AL|AK|AZ|AR|CA|CO|CT|DE|FL|GA|HI|ID|IL|IN|IA|KS|KY|LA|ME|MD|MA|MI|MN|MS|MO|MT|NE|NV|NH|NJ|NM|NY|NC|ND|OH|OK|OR|PA|RI|SC|SD|TN|TX|UT|VT|VA|WA|WV|WI|WY|DC)\s+"
+    r"(?P<pin_zip>\d{5}(?:-\d{4})?)\b",
+    re.IGNORECASE,
+)
 _OFFICIAL_EXAM_LABELS = {
     "SIE": "SIE - Securities Industry Essentials Examination",
     "Series 7": "Series 7 - General Securities Representative Examination",
@@ -256,6 +279,82 @@ def _official_location_from_text(text: str, source_url: str) -> dict[str, str] |
         city = _title_case_city(match.group("city"))
         pin_zip = match.group("pin_zip")
         address = " ".join(match.group("address").split()).strip(" ,")
+        return {
+            "city": city,
+            "state": state,
+            "pin_zip": pin_zip,
+            "address": address,
+            "location": f"{city}, {state}",
+            "source_url": source_url,
+        }
+    return None
+
+
+def _same_location_part(left: str | None, right: str | None) -> bool:
+    normalized_left = re.sub(r"[^a-z0-9]+", " ", str(left or "").lower()).strip()
+    normalized_right = re.sub(r"[^a-z0-9]+", " ", str(right or "").lower()).strip()
+    return bool(normalized_left and normalized_right and normalized_left == normalized_right)
+
+
+def _brokercheck_branch_location_from_text(
+    text: str,
+    source_url: str,
+) -> dict[str, str] | None:
+    normalized = " ".join(str(text or "").replace("\xa0", " ").split())
+    if not normalized:
+        return None
+
+    for pattern in (_BROKERCHECK_SUMMARY_BRANCH_RE, _BROKERCHECK_BRANCH_ROW_RE):
+        match = pattern.search(normalized)
+        if not match:
+            continue
+        city = _title_case_city(match.group("city"))
+        state = match.group("state").upper()
+        if state not in _US_STATE_CODES:
+            continue
+        return {
+            "city": city,
+            "state": state,
+            "location": f"{city}, {state}",
+            "firm_crd": match.group("firm_crd"),
+            "firm_name": _clean_official_line(match.group("firm")),
+            "source_url": source_url,
+        }
+    return None
+
+
+def _trim_firm_address_line(line: str) -> str:
+    candidate = _clean_official_line(line)
+    for marker in (
+        " This firm ",
+        " Brokerage firms ",
+        " Regulated by ",
+        " Information ",
+        " Are there ",
+        " Business Telephone ",
+    ):
+        if marker in candidate:
+            candidate = candidate.split(marker, 1)[0]
+    return _clean_official_line(candidate)
+
+
+def _firm_location_from_text(text: str, source_url: str) -> dict[str, str] | None:
+    lines = _official_report_lines(text)
+    for idx, line in enumerate(lines):
+        match = _FIRM_CITY_STATE_ZIP_RE.search(line)
+        if not match:
+            continue
+        state = match.group("state").upper()
+        if state not in _US_STATE_CODES:
+            continue
+        address = ""
+        for previous in reversed(lines[max(0, idx - 4) : idx]):
+            previous_address = _trim_firm_address_line(previous)
+            if re.match(r"^\d{1,6}\s+", previous_address):
+                address = previous_address
+                break
+        city = _title_case_city(match.group("city"))
+        pin_zip = match.group("pin_zip")
         return {
             "city": city,
             "state": state,
@@ -397,6 +496,33 @@ def _official_location_from_pdf(content: bytes, source_url: str) -> dict[str, st
     return _official_location_from_text(" ".join(parts), source_url)
 
 
+def _brokercheck_branch_location_from_pdf(
+    content: bytes,
+    source_url: str,
+) -> dict[str, str] | None:
+    import pdfplumber
+
+    with pdfplumber.open(io.BytesIO(content)) as pdf:
+        parts: list[str] = []
+        for page in pdf.pages[:8]:
+            parts.append(page.extract_text() or "")
+            if sum(len(part) for part in parts) > 30_000:
+                break
+    return _brokercheck_branch_location_from_text("\n".join(parts), source_url)
+
+
+def _firm_location_from_pdf(content: bytes, source_url: str) -> dict[str, str] | None:
+    import pdfplumber
+
+    with pdfplumber.open(io.BytesIO(content)) as pdf:
+        parts: list[str] = []
+        for page in pdf.pages[:5]:
+            parts.append(page.extract_text() or "")
+            if sum(len(part) for part in parts) > 20_000:
+                break
+    return _firm_location_from_text("\n".join(parts), source_url)
+
+
 def _official_profile_from_pdf(content: bytes, source_url: str) -> dict[str, Any] | None:
     import pdfplumber
 
@@ -475,6 +601,52 @@ async def _official_pdf_location_for_crd(crd_number: str) -> dict[str, str] | No
                     response.content,
                     source_url,
                 )
+                if not location and "brokercheck.finra.org/individual/" in source_url:
+                    branch_location = await asyncio.to_thread(
+                        _brokercheck_branch_location_from_pdf,
+                        response.content,
+                        source_url,
+                    )
+                    location = branch_location
+                    firm_crd = branch_location.get("firm_crd") if branch_location else None
+                    if firm_crd:
+                        firm_source_url = (
+                            f"https://files.brokercheck.finra.org/firm/firm_{firm_crd}.pdf"
+                        )
+                        try:
+                            firm_response = await client.get(firm_source_url)
+                            firm_response.raise_for_status()
+                            firm_location = await asyncio.to_thread(
+                                _firm_location_from_pdf,
+                                firm_response.content,
+                                firm_source_url,
+                            )
+                        except Exception:
+                            logger.info(
+                                "verify_ria_license: firm PDF location fallback failed for %s",
+                                firm_crd,
+                                exc_info=True,
+                            )
+                            firm_location = None
+                        if (
+                            firm_location
+                            and _same_location_part(
+                                branch_location.get("city"),
+                                firm_location.get("city"),
+                            )
+                            and _same_location_part(
+                                branch_location.get("state"),
+                                firm_location.get("state"),
+                            )
+                        ):
+                            location = {
+                                **branch_location,
+                                **firm_location,
+                                "firm_crd": firm_crd,
+                                "firm_name": branch_location.get("firm_name", ""),
+                                "individual_source_url": source_url,
+                                "source_url": firm_source_url,
+                            }
             except Exception:
                 logger.info(
                     "verify_ria_license: official PDF location fallback failed for %s",

--- a/consent-protocol/tests/test_ria_onboarding_v2.py
+++ b/consent-protocol/tests/test_ria_onboarding_v2.py
@@ -42,6 +42,8 @@ from hushh_mcp.services.crd_scrape_proxy_service import (  # noqa: E402
 from hushh_mcp.services.ria_iam_service import (  # noqa: E402
     RIAIAMPolicyError,
     RIAIAMService,
+    _brokercheck_branch_location_from_text,
+    _firm_location_from_text,
     _official_location_from_text,
 )
 
@@ -729,6 +731,53 @@ def test_official_location_from_text_extracts_city_and_zip() -> None:
     }
 
 
+def test_brokercheck_branch_location_from_text_extracts_inactive_broker_city() -> None:
+    """Inactive broker reports expose branch city/state even without a full address."""
+
+    result = _brokercheck_branch_location_from_text(
+        (
+            "Registration Dates Firm Name CRD# Branch Location "
+            "B 09/2021 - 06/2022 LAZARD FRERES & CO. LLC 2528 NEW YORK, NY "
+            "Employment History"
+        ),
+        "https://files.brokercheck.finra.org/individual/individual_7265726.pdf",
+    )
+
+    assert result == {
+        "city": "New York",
+        "state": "NY",
+        "location": "New York, NY",
+        "firm_crd": "2528",
+        "firm_name": "LAZARD FRERES & CO. LLC",
+        "source_url": "https://files.brokercheck.finra.org/individual/individual_7265726.pdf",
+    }
+
+
+def test_firm_location_from_text_extracts_main_office_zip() -> None:
+    """Firm BrokerCheck PDFs can supply the ZIP missing from inactive individual reports."""
+
+    result = _firm_location_from_text(
+        "\n".join(
+            [
+                "Main Office Location Firm Profile Disclosure Events",
+                "30 ROCKEFELLER PLAZA This firm is classified as a limited liability company.",
+                "NEW YORK, NY 10020-5900",
+                "Mailing Address proceedings and financial matters",
+            ]
+        ),
+        "https://files.brokercheck.finra.org/firm/firm_2528.pdf",
+    )
+
+    assert result == {
+        "city": "New York",
+        "state": "NY",
+        "pin_zip": "10020-5900",
+        "address": "30 ROCKEFELLER PLAZA",
+        "location": "New York, NY",
+        "source_url": "https://files.brokercheck.finra.org/firm/firm_2528.pdf",
+    }
+
+
 def test_verify_license_invalid_number_422() -> None:
     """An empty license_number should be rejected by Pydantic validation (422)."""
     client = TestClient(_authed_app())
@@ -854,6 +903,96 @@ def test_verify_ria_license_exposes_summary_and_exams_as_prefill(monkeypatch) ->
     ]
     assert payload["exams_passed"] == payload["certifications"]
     assert payload["scrape_job_id"] == "crd_scrape_prefill"
+
+
+def test_verify_ria_license_fills_inactive_broker_location_from_official_fallback(
+    monkeypatch,
+) -> None:
+    """Inactive BrokerCheck rows should still prefill city, state, ZIP, and address."""
+
+    captured_audit: dict[str, Any] = {}
+
+    async def _mock_broker_intelligence(self, *, query, request_id=None):
+        assert query == "7265726"
+        return CrdScrapeProviderResponse(
+            status_code=200,
+            payload={
+                "status": "Not Currently Registered",
+                "verifiedName": "Ria Ashley Sen",
+                "currentFirm": "Not Currently Registered",
+                "crdNumber": "7265726",
+                "summary": "Former registered representative.",
+                "exams": [
+                    "Securities Industry Essentials Examination (SIE)",
+                    "Investment Banking Representative Examination (Series 79TO)",
+                ],
+            },
+        )
+
+    async def _mock_create_job(self, *, crd_number, request_id=None):
+        assert crd_number == "7265726"
+        return CrdScrapeProviderResponse(
+            status_code=202,
+            payload={"jobId": "crd_scrape_inactive", "status": "queued"},
+        )
+
+    async def _mock_official_location(crd_number: str):
+        assert crd_number == "7265726"
+        return {
+            "city": "New York",
+            "state": "NY",
+            "pin_zip": "10020-5900",
+            "address": "30 ROCKEFELLER PLAZA",
+            "location": "New York, NY",
+            "source_url": "https://files.brokercheck.finra.org/firm/firm_2528.pdf",
+            "individual_source_url": (
+                "https://files.brokercheck.finra.org/individual/individual_7265726.pdf"
+            ),
+            "firm_crd": "2528",
+            "firm_name": "LAZARD FRERES & CO. LLC",
+        }
+
+    class _FakeConn:
+        async def fetchrow(self, *_args):
+            return None
+
+        async def execute(self, _query: str, *args):
+            captured_audit["payload"] = json.loads(args[4])
+            captured_audit["status"] = args[5]
+
+    async def _mock_get_pool():
+        return _FakePool(_FakeConn())
+
+    monkeypatch.setattr(CrdScrapeProxyService, "broker_intelligence", _mock_broker_intelligence)
+    monkeypatch.setattr(CrdScrapeProxyService, "create_job", _mock_create_job)
+    monkeypatch.setattr(
+        ria_iam_service_module,
+        "_official_pdf_location_for_crd",
+        _mock_official_location,
+    )
+    monkeypatch.setattr(ria_iam_service_module, "get_pool", _mock_get_pool)
+
+    payload = asyncio.run(
+        RIAIAMService().verify_ria_license(
+            _TEST_UID,
+            license_number="7265726",
+            regulator="SEC",
+        )
+    )
+
+    assert payload["status"] == "found"
+    assert payload["advisor_name"] == "Ria Ashley Sen"
+    assert payload["firm_name"] == "Not Currently Registered"
+    assert payload["city"] == "New York"
+    assert payload["state"] == "NY"
+    assert payload["pin_zip"] == "10020-5900"
+    assert payload["full_street_address"] == "30 ROCKEFELLER PLAZA"
+    assert payload["business_address"] == "30 ROCKEFELLER PLAZA"
+    assert payload["official_location"]["individual_source_url"].endswith("individual_7265726.pdf")
+    assert payload["scrape_job_id"] == "crd_scrape_inactive"
+    assert captured_audit["status"] == "completed"
+    assert captured_audit["payload"]["city"] == "New York"
+    assert captured_audit["payload"]["pin_zip"] == "10020-5900"
 
 
 def test_verify_license_provider_timeout(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- prefill inactive BrokerCheck advisor location from official PDFs when the individual report only exposes branch city/state
- fetch the matching firm BrokerCheck PDF to fill ZIP/full address only when firm city/state matches the individual branch location
- cover CRD 7265726-style inactive broker flow and parser helpers

## Tests
- cd consent-protocol && PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest --noconftest tests/test_ria_onboarding_v2.py -q
- cd consent-protocol && uv run ruff check hushh_mcp/services/ria_iam_service.py tests/test_ria_onboarding_v2.py
- cd consent-protocol && uv run python -m py_compile hushh_mcp/services/ria_iam_service.py tests/test_ria_onboarding_v2.py
- git diff --check

## UAT plan
- merge after green CI
- deploy backend-only to UAT with scope=backend
- re-test /api/ria/onboarding/verify-license for CRD 7265726 and confirm city/pin_zip/full_street_address are populated