### PR TITLE
Repair stale RIA location prefill drafts

### DIFF
--- a/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
@@ -498,6 +498,73 @@ describe("RiaOnboardingPage", () => {
     expect(screen.getByTestId("services-pin-zip").textContent).toBe("30144");
   });
 
+  it("repairs stale verified draft location from the license API on load", async () => {
+    mocks.draftService.load.mockResolvedValue({
+      currentStepId: "license_details",
+      onboardingType: "individual",
+      licenseNumber: "7265726",
+      regulator: "SEC",
+      licenseVerificationStatus: "found",
+      advisorName: "Ria A. Sen",
+      firmName: "Not Currently Registered",
+      regulatorStatus: "Not Currently Registered",
+      certifications: ["SIE", "Series 79TO"],
+      crdNumber: "7265726",
+      city: "",
+      areaLocality: "",
+      pinZip: "",
+      fullStreetAddress: "",
+      servicesOffered: ["Portfolio Management"],
+      feeStructure: ["Fee-only"],
+    });
+    mocks.riaService.verifyOnboardingLicense.mockResolvedValue({
+      status: "found",
+      advisor_name: "Ria Ashley Sen",
+      firm_name: "Not Currently Registered",
+      regulator: "SEC",
+      regulator_status: "Not Currently Registered",
+      certifications: ["SIE", "Series 79TO"],
+      crd_number: "7265726",
+      city: "New York",
+      state: "NY",
+      area_locality: "NY",
+      pin_zip: "10020-5900",
+      full_street_address: "30 ROCKEFELLER PLAZA",
+      official_location: {
+        city: "New York",
+        state: "NY",
+        pin_zip: "10020-5900",
+        address: "30 ROCKEFELLER PLAZA",
+      },
+      scrape_job_id: null,
+    });
+
+    render(<RiaOnboardingPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("step-license-details")).toBeTruthy();
+    });
+
+    await waitFor(() => {
+      expect(mocks.riaService.verifyOnboardingLicense).toHaveBeenCalledWith(
+        "token-ria-1",
+        expect.objectContaining({
+          license_number: "7265726",
+          regulator: "SEC",
+        }),
+        expect.any(Object),
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("advisor-name").textContent).toBe(
+        "Ria Ashley Sen",
+      );
+      expect(screen.getByTestId("city").textContent).toBe("New York");
+      expect(screen.getByTestId("pin-zip").textContent).toBe("10020-5900");
+    });
+  });
+
   it("handles not_found and stays on license step", async () => {
     mocks.riaService.verifyOnboardingLicense.mockResolvedValue({
       status: "not_found",

--- a/hushh-webapp/app/ria/onboarding/page.tsx
+++ b/hushh-webapp/app/ria/onboarding/page.tsx
@@ -73,6 +73,16 @@ function isAdvisoryAccessReady(status?: string | null): boolean {
   return status === "active" || status === "verified";
 }
 
+function shouldRepairVerifiedPrefill(draft: RiaOnboardingDraft): boolean {
+  if (draft.licenseVerificationStatus !== "found") return false;
+  if (!draft.licenseNumber.trim() || !draft.advisorName.trim()) return false;
+  return !(
+    draft.city.trim() &&
+    draft.pinZip.trim() &&
+    draft.fullStreetAddress.trim()
+  );
+}
+
 export default function RiaOnboardingPage() {
   const router = useRouter();
   const { user, phoneNumber } = useAuth();
@@ -91,6 +101,10 @@ export default function RiaOnboardingPage() {
 
   const verificationAbortRef = useRef<AbortController | null>(null);
   const scrapePollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const stalePrefillRepairRef = useRef<{
+    inFlight: boolean;
+    lastKey: string | null;
+  }>({ inFlight: false, lastKey: null });
 
   const advisoryVerificationStatus =
     status?.advisory_status || status?.verification_status || "draft";
@@ -331,6 +345,81 @@ export default function RiaOnboardingPage() {
     },
     [applyPrefill],
   );
+
+  useEffect(() => {
+    if (!user || !draftReady || iamUnavailable || loading) return;
+    if (!shouldRepairVerifiedPrefill(draft)) return;
+
+    const currentUser = user;
+    const licenseNumber = draft.licenseNumber.trim();
+    const regulator = draft.regulator.trim();
+    const repairKey = `${regulator || "auto"}:${licenseNumber}`;
+    if (
+      stalePrefillRepairRef.current.inFlight ||
+      stalePrefillRepairRef.current.lastKey === repairKey
+    ) {
+      return;
+    }
+
+    let cancelled = false;
+    const controller = new AbortController();
+    const timeoutId = setTimeout(
+      () => controller.abort(),
+      LICENSE_VERIFICATION_TIMEOUT_MS,
+    );
+
+    stalePrefillRepairRef.current = {
+      inFlight: true,
+      lastKey: repairKey,
+    };
+
+    async function repairStalePrefill() {
+      try {
+        const idToken = await currentUser.getIdToken();
+        const result = await RiaService.verifyOnboardingLicense(
+          idToken,
+          {
+            license_number: licenseNumber,
+            regulator: regulator || undefined,
+          },
+          { signal: controller.signal },
+        );
+
+        if (cancelled || controller.signal.aborted) return;
+
+        if (result.status === "found") {
+          applyPrefill((current) =>
+            buildRiaLicensePrefillPatch(current, result, licenseNumber),
+          );
+
+          if (result.scrape_job_id) {
+            startScrapePolling(result.scrape_job_id);
+          }
+        }
+      } catch {
+        // Background repair is best-effort; the user can still edit or re-verify.
+      } finally {
+        clearTimeout(timeoutId);
+        stalePrefillRepairRef.current.inFlight = false;
+      }
+    }
+
+    void repairStalePrefill();
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timeoutId);
+      controller.abort();
+    };
+  }, [
+    applyPrefill,
+    draft,
+    draftReady,
+    iamUnavailable,
+    loading,
+    startScrapePolling,
+    user,
+  ]);
 
   async function handleVerifyLicense() {
     if (!user || !draft.licenseNumber.trim()) return;


### PR DESCRIPTION
## Summary
- Auto-repair verified RIA onboarding drafts that still have blank city, ZIP, or street address by re-reading the license API in the background.
- Reuses the existing license prefill mapper so official backend location fields populate the same editable draft fields.
- Adds a focused regression for stale CRD 7265726 drafts filling New York / 10020-5900 from the API response.

## Test Plan
- cd hushh-webapp && npm ci
- cd hushh-webapp && npx tsc --noEmit --pretty false --incremental false --project tsconfig.json
- cd hushh-webapp && npm exec vitest -- run __tests__/app/ria/onboarding-page.test.tsx --pool forks --maxWorkers 1 --no-file-parallelism --reporter dot --hookTimeout 20000 --testTimeout 20000
- cd hushh-webapp && npx eslint app/ria/onboarding/page.tsx __tests__/app/ria/onboarding-page.test.tsx --max-warnings=0
- cd hushh-webapp && npm run verify:docs
- git diff --check

Note: npm run verify:routes is gated locally by missing maintainer-only REVIEWER_UID / REVIEWER_VAULT_PASSPHRASE and should run in the maintained CI/env overlay.