### PR TITLE
Fix RIA stale verified location repair

### DIFF
--- a/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
@@ -440,9 +440,7 @@ describe("RiaOnboardingPage", () => {
       firm_name: "Eissman Wealth Management",
       regulator: "SEC",
       regulator_status: "Active (Investment Adviser Representative)",
-      certifications: [
-        "Series 66 - Uniform Combined State Law Examination",
-      ],
+      certifications: ["Series 66 - Uniform Combined State Law Examination"],
       crd_number: "7413463",
       city: "Kennesaw",
       state: "GA",
@@ -562,6 +560,76 @@ describe("RiaOnboardingPage", () => {
       );
       expect(screen.getByTestId("city").textContent).toBe("New York");
       expect(screen.getByTestId("pin-zip").textContent).toBe("10020-5900");
+    });
+  });
+
+  it("repairs conflicting verified draft location from the license API on load", async () => {
+    mocks.draftService.load.mockResolvedValue({
+      currentStepId: "services",
+      onboardingType: "individual",
+      licenseNumber: "7265726",
+      regulator: "SEC",
+      licenseVerificationStatus: "found",
+      advisorName: "Ria A. Sen",
+      firmName: "Not Currently Registered",
+      regulatorStatus: "Not Currently Registered",
+      certifications: ["SIE", "Series 79TO"],
+      crdNumber: "7265726",
+      city: "Pune",
+      areaLocality: "Downtown, Mission District",
+      pinZip: "30144",
+      fullStreetAddress: "Army Institute of Technology, Pune",
+      servicesOffered: ["Portfolio Management"],
+      feeStructure: ["Fee-only"],
+    });
+    mocks.riaService.verifyOnboardingLicense.mockResolvedValue({
+      status: "found",
+      advisor_name: "Ria Ashley Sen",
+      firm_name: "Not Currently Registered",
+      regulator: "SEC",
+      regulator_status: "Not Currently Registered",
+      certifications: ["SIE", "Series 79TO"],
+      crd_number: "7265726",
+      city: "New York",
+      state: "NY",
+      area_locality: "NY",
+      pin_zip: "10020-5900",
+      full_street_address: "30 ROCKEFELLER PLAZA",
+      official_location: {
+        city: "New York",
+        state: "NY",
+        pin_zip: "10020-5900",
+        address: "30 ROCKEFELLER PLAZA",
+      },
+      scrape_job_id: null,
+    });
+
+    render(<RiaOnboardingPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("step-services")).toBeTruthy();
+    });
+
+    await waitFor(() => {
+      expect(mocks.riaService.verifyOnboardingLicense).toHaveBeenCalledWith(
+        "token-ria-1",
+        expect.objectContaining({
+          license_number: "7265726",
+          regulator: "SEC",
+        }),
+        expect.any(Object),
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("services-city").textContent).toBe("New York");
+      expect(screen.getByTestId("services-area").textContent).toBe("NY");
+      expect(screen.getByTestId("services-address").textContent).toBe(
+        "30 ROCKEFELLER PLAZA",
+      );
+      expect(screen.getByTestId("services-pin-zip").textContent).toBe(
+        "10020-5900",
+      );
     });
   });
 
@@ -685,6 +753,7 @@ describe("RiaOnboardingPage", () => {
       licenseNumber: "111222",
       licenseVerificationStatus: "found",
       advisorName: "Saved Advisor",
+      verifiedLicensePrefillKey: "auto:111222",
       servicesOffered: [],
       feeStructure: [],
     });
@@ -708,6 +777,7 @@ describe("RiaOnboardingPage", () => {
       regulatorStatus: "ACTIVE",
       crdNumber: "7265726",
       individualCrd: "7265726",
+      verifiedLicensePrefillKey: "sec:7265726",
       servicesOffered: ["Portfolio Management"],
       feeStructure: ["Fee-only"],
       contactEmail: "ria-e2e@example.invalid",

--- a/hushh-webapp/app/ria/onboarding/page.tsx
+++ b/hushh-webapp/app/ria/onboarding/page.tsx
@@ -67,6 +67,7 @@ const REGULATOR_PREFILL_RESET: Partial<RiaOnboardingDraft> = {
   brokerFirmCrd: "",
   headline: "",
   strategySummary: "",
+  verifiedLicensePrefillKey: "",
 };
 
 function isAdvisoryAccessReady(status?: string | null): boolean {
@@ -76,11 +77,32 @@ function isAdvisoryAccessReady(status?: string | null): boolean {
 function shouldRepairVerifiedPrefill(draft: RiaOnboardingDraft): boolean {
   if (draft.licenseVerificationStatus !== "found") return false;
   if (!draft.licenseNumber.trim() || !draft.advisorName.trim()) return false;
-  return !(
-    draft.city.trim() &&
-    draft.pinZip.trim() &&
-    draft.fullStreetAddress.trim()
-  );
+  return draft.verifiedLicensePrefillKey !== buildVerifiedPrefillKey(draft);
+}
+
+function buildVerifiedPrefillKey(
+  draft: Pick<RiaOnboardingDraft, "regulator" | "licenseNumber">,
+): string {
+  const regulator = draft.regulator.trim().toLowerCase() || "auto";
+  return `${regulator}:${draft.licenseNumber.trim()}`;
+}
+
+function buildVerifiedLicensePrefillPatch(
+  current: RiaOnboardingDraft,
+  result: RiaLicenseVerificationResult,
+  licenseNumber: string,
+): Partial<RiaOnboardingDraft> {
+  const patch = buildRiaLicensePrefillPatch(current, result, licenseNumber);
+  return {
+    ...patch,
+    verifiedLicensePrefillKey:
+      result.status === "found"
+        ? buildVerifiedPrefillKey({
+            regulator: patch.regulator || current.regulator,
+            licenseNumber,
+          })
+        : current.verifiedLicensePrefillKey,
+  };
 }
 
 export default function RiaOnboardingPage() {
@@ -353,7 +375,7 @@ export default function RiaOnboardingPage() {
     const currentUser = user;
     const licenseNumber = draft.licenseNumber.trim();
     const regulator = draft.regulator.trim();
-    const repairKey = `${regulator || "auto"}:${licenseNumber}`;
+    const repairKey = buildVerifiedPrefillKey(draft);
     if (
       stalePrefillRepairRef.current.inFlight ||
       stalePrefillRepairRef.current.lastKey === repairKey
@@ -389,7 +411,7 @@ export default function RiaOnboardingPage() {
 
         if (result.status === "found") {
           applyPrefill((current) =>
-            buildRiaLicensePrefillPatch(current, result, licenseNumber),
+            buildVerifiedLicensePrefillPatch(current, result, licenseNumber),
           );
 
           if (result.scrape_job_id) {
@@ -456,7 +478,7 @@ export default function RiaOnboardingPage() {
 
       if (result.status === "found") {
         applyPrefill((current) =>
-          buildRiaLicensePrefillPatch(
+          buildVerifiedLicensePrefillPatch(
             current,
             result,
             draft.licenseNumber.trim(),
@@ -472,7 +494,7 @@ export default function RiaOnboardingPage() {
         }, 600);
       } else if (result.status === "pending" && result.scrape_job_id) {
         applyPrefill((current) =>
-          buildRiaLicensePrefillPatch(
+          buildVerifiedLicensePrefillPatch(
             current,
             result,
             draft.licenseNumber.trim(),

--- a/hushh-webapp/lib/ria/ria-onboarding-flow.ts
+++ b/hushh-webapp/lib/ria/ria-onboarding-flow.ts
@@ -35,7 +35,12 @@ export type RiaOnboardingDraft = {
   fullStreetAddress: string;
   latitude: number | null;
   longitude: number | null;
-  licenseVerificationStatus: "idle" | "verifying" | "found" | "not_found" | "error";
+  licenseVerificationStatus:
+    | "idle"
+    | "verifying"
+    | "found"
+    | "not_found"
+    | "error";
   scrapeJobId: string | null;
   requestedCapabilities: RiaCapability[];
   displayName: string;
@@ -47,6 +52,7 @@ export type RiaOnboardingDraft = {
   brokerFirmCrd: string;
   headline: string;
   strategySummary: string;
+  verifiedLicensePrefillKey: string;
 };
 
 export type RiaOnboardingStep = {
@@ -74,11 +80,18 @@ function sanitizeText(value: unknown): string {
   return typeof value === "string" ? value : "";
 }
 
-export function isRiaOnboardingStepId(value: unknown): value is RiaOnboardingStepId {
-  return typeof value === "string" && STEP_ORDER.includes(value as RiaOnboardingStepId);
+export function isRiaOnboardingStepId(
+  value: unknown,
+): value is RiaOnboardingStepId {
+  return (
+    typeof value === "string" &&
+    STEP_ORDER.includes(value as RiaOnboardingStepId)
+  );
 }
 
-function normalizeRiaOnboardingStepId(value: unknown): RiaOnboardingStepId | null {
+function normalizeRiaOnboardingStepId(
+  value: unknown,
+): RiaOnboardingStepId | null {
   if (isRiaOnboardingStepId(value)) return value;
   if (value === LEGACY_CONTACT_LOCATION_STEP_ID) return "services";
   return null;
@@ -132,10 +145,17 @@ export function createEmptyRiaOnboardingDraft(): RiaOnboardingDraft {
     brokerFirmCrd: "",
     headline: "",
     strategySummary: "",
+    verifiedLicensePrefillKey: "",
   };
 }
 
-const VALID_VERIFICATION_STATUSES = ["idle", "verifying", "found", "not_found", "error"];
+const VALID_VERIFICATION_STATUSES = [
+  "idle",
+  "verifying",
+  "found",
+  "not_found",
+  "error",
+];
 const VALID_ONBOARDING_TYPES = ["", "individual", "firm"];
 
 function sanitizeStringArray(value: unknown): string[] {
@@ -144,7 +164,7 @@ function sanitizeStringArray(value: unknown): string[] {
 }
 
 export function normalizeRiaOnboardingDraft(
-  value: Partial<RiaOnboardingDraft> | null | undefined
+  value: Partial<RiaOnboardingDraft> | null | undefined,
 ): RiaOnboardingDraft {
   const base = createEmptyRiaOnboardingDraft();
   const v = value as Record<string, unknown> | null | undefined;
@@ -152,7 +172,8 @@ export function normalizeRiaOnboardingDraft(
     currentStepId:
       normalizeRiaOnboardingStepId(v?.currentStepId) || base.currentStepId,
     onboardingType:
-      typeof v?.onboardingType === "string" && VALID_ONBOARDING_TYPES.includes(v.onboardingType)
+      typeof v?.onboardingType === "string" &&
+      VALID_ONBOARDING_TYPES.includes(v.onboardingType)
         ? (v.onboardingType as RiaOnboardingType)
         : base.onboardingType,
     licenseNumber: sanitizeText(v?.licenseNumber),
@@ -195,12 +216,13 @@ export function normalizeRiaOnboardingDraft(
     brokerFirmCrd: sanitizeText(v?.brokerFirmCrd),
     headline: sanitizeText(v?.headline),
     strategySummary: sanitizeText(v?.strategySummary),
+    verifiedLicensePrefillKey: sanitizeText(v?.verifiedLicensePrefillKey),
   };
 }
 
 export function buildRiaOnboardingSteps(
   _draft: RiaOnboardingDraft,
-  _options?: RiaOnboardingFlowOptions
+  _options?: RiaOnboardingFlowOptions,
 ): RiaOnboardingStep[] {
   return [
     {
@@ -244,7 +266,7 @@ export function buildRiaOnboardingSteps(
 export function canContinueRiaOnboardingStep(
   stepId: RiaOnboardingStepId,
   draft: RiaOnboardingDraft,
-  options?: RiaOnboardingFlowOptions
+  options?: RiaOnboardingFlowOptions,
 ): boolean {
   switch (stepId) {
     case "welcome":
@@ -272,10 +294,11 @@ export function getOnboardingTypeLabel(type: RiaOnboardingType): string {
 export function resolveRiaOnboardingStepId(
   draft: RiaOnboardingDraft,
   preferredStepId?: RiaOnboardingStepId | null,
-  options?: RiaOnboardingFlowOptions
+  options?: RiaOnboardingFlowOptions,
 ): RiaOnboardingStepId {
   const steps = buildRiaOnboardingSteps(draft, options);
-  const normalizedPreferredStepId = normalizeRiaOnboardingStepId(preferredStepId);
+  const normalizedPreferredStepId =
+    normalizeRiaOnboardingStepId(preferredStepId);
   if (
     normalizedPreferredStepId &&
     steps.some((step) => step.id === normalizedPreferredStepId)
@@ -290,12 +313,13 @@ export function resolveRiaOnboardingStepId(
 
 export function findFirstIncompleteRiaOnboardingStepId(
   draft: RiaOnboardingDraft,
-  options?: RiaOnboardingFlowOptions
+  options?: RiaOnboardingFlowOptions,
 ): RiaOnboardingStepId {
   const steps = buildRiaOnboardingSteps(draft, options);
   const incomplete = steps.find(
     (step) =>
-      step.id !== "review" && !canContinueRiaOnboardingStep(step.id, draft, options)
+      step.id !== "review" &&
+      !canContinueRiaOnboardingStep(step.id, draft, options),
   );
   return incomplete?.id || "review";
 }
@@ -303,8 +327,10 @@ export function findFirstIncompleteRiaOnboardingStepId(
 export function getRiaOnboardingStepIndex(
   draft: RiaOnboardingDraft,
   currentStepId: RiaOnboardingStepId,
-  options?: RiaOnboardingFlowOptions
+  options?: RiaOnboardingFlowOptions,
 ): number {
-  const index = buildRiaOnboardingSteps(draft, options).findIndex((step) => step.id === currentStepId);
+  const index = buildRiaOnboardingSteps(draft, options).findIndex(
+    (step) => step.id === currentStepId,
+  );
   return index >= 0 ? index : 0;
 }


### PR DESCRIPTION
## Summary
- refresh older verified RIA onboarding drafts once per license when they lack the new verified prefill marker
- repair conflicting stale business location values from the live license API instead of keeping old local draft values
- persist a verified prefill marker so user edits are not re-clobbered on every reload

## Tests
- cd hushh-webapp && npx tsc --noEmit --pretty false --incremental false --project tsconfig.json
- cd hushh-webapp && npm exec vitest -- run __tests__/app/ria/onboarding-page.test.tsx --pool forks --maxWorkers 1 --no-file-parallelism --reporter dot --hookTimeout 20000 --testTimeout 20000
- cd hushh-webapp && npx eslint app/ria/onboarding/page.tsx lib/ria/ria-onboarding-flow.ts __tests__/app/ria/onboarding-page.test.tsx --max-warnings=0
- cd hushh-webapp && npm run verify:docs
- git diff --check

## Known local blocker
- cd hushh-webapp && npm run verify:routes requires maintainer-only REVIEWER_UID and REVIEWER_VAULT_PASSPHRASE locally; CI/secret-backed verification should cover this lane.
