### PR TITLE
fix(session): cap consent history page at 1_000 to prevent offset DOS

### DIFF
--- a/consent-protocol/api/routes/session.py
+++ b/consent-protocol/api/routes/session.py
@@ -1,6 +1,13 @@
 # api/routes/session.py
 """
 Session token and user management endpoints.
+
+Canonical attach point (pagination offset cap):
+    api.routes.session.get_consent_history -> GET /api/session/consent/history
+    page is capped at 1_000 (was 10_000) so the maximum DB offset is
+    page_max * limit_max = 1_000 * 200 = 200_000 rows.  The previous cap
+    of 10_000 allowed offsets of up to 2_000_000 rows, creating a
+    denial-of-service vector via expensive full-table-scan queries.
 """
 
 import logging
@@ -121,7 +128,7 @@ async def logout_session(request: LogoutRequest):
 @router.get("/consent/history")
 async def get_consent_history(
     userId: str = Query(..., max_length=128),
-    page: int = Query(1, ge=1, le=10_000),
+    page: int = Query(1, ge=1, le=1_000),
     limit: int = Query(50, ge=1, le=200),
     token_data: dict = Depends(require_vault_owner_token),
 ):

--- a/consent-protocol/tests/test_consent_history_page_cap.py
+++ b/consent-protocol/tests/test_consent_history_page_cap.py
@@ -1,0 +1,82 @@
+"""
+Tests: GET /api/session/consent/history enforces a page upper bound.
+
+Canonical attach point: api.routes.session.get_consent_history -> GET /api/session/consent/history
+
+Before this fix the page query parameter accepted values up to 10_000.
+With limit=200 that creates a DB offset of 10_000 * 200 = 2_000_000,
+causing a full-table scan on the consent_audit table for every request
+at the high-page boundary - a denial-of-service vector.
+
+Fix: page is now capped at 1_000 (max offset = 1_000 * 200 = 200_000).
+FastAPI returns HTTP 422 for page > 1_000 before any DB call is made.
+
+Route-level proof: TestClient hits the route with page=1_001 and asserts
+HTTP 422 is returned, and with page=1_000 asserts it is not 422.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import api.routes.session as session_module
+from api.middleware import require_vault_owner_token
+
+
+def _stub_vault_owner():
+    return {"user_id": "test-uid", "token": "fake-token", "scope": "vault.owner"}
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(session_module.router)
+    app.dependency_overrides[require_vault_owner_token] = _stub_vault_owner
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestConsentHistoryPageCap:
+    """
+    Canonical attach point: api.routes.session.get_consent_history
+    GET /api/session/consent/history
+
+    Proves FastAPI rejects page > 1_000 with HTTP 422 at the framework
+    layer, before any DB offset computation.
+    """
+
+    _URL = "/api/consent/history"
+
+    def test_page_above_cap_returns_422(self):
+        """page=1_001 must be rejected with 422 - no DB query fires."""
+        resp = _client().get(self._URL, params={"userId": "test-uid", "page": 1001})
+        assert resp.status_code == 422
+
+    def test_page_at_old_max_returns_422(self):
+        """page=10_000 (old allowed max) must now return 422."""
+        resp = _client().get(self._URL, params={"userId": "test-uid", "page": 10_000})
+        assert resp.status_code == 422
+
+    def test_page_at_new_cap_does_not_return_422(self):
+        """page=1_000 is within the new cap and must pass validation."""
+        resp = _client().get(self._URL, params={"userId": "test-uid", "page": 1_000})
+        assert resp.status_code != 422
+
+    def test_page_one_does_not_return_422(self):
+        """page=1 (default) must always pass validation."""
+        resp = _client().get(self._URL, params={"userId": "test-uid", "page": 1})
+        assert resp.status_code != 422
+
+    def test_page_zero_returns_422(self):
+        """page=0 violates ge=1 and must be rejected with 422."""
+        resp = _client().get(self._URL, params={"userId": "test-uid", "page": 0})
+        assert resp.status_code == 422
+
+    def test_limit_above_max_returns_422(self):
+        """limit=201 exceeds le=200 and must be rejected with 422."""
+        resp = _client().get(self._URL, params={"userId": "test-uid", "limit": 201})
+        assert resp.status_code == 422
+
+    def test_limit_at_max_does_not_return_422(self):
+        """limit=200 is at the cap and must pass validation."""
+        resp = _client().get(self._URL, params={"userId": "test-uid", "limit": 200})
+        assert resp.status_code != 422


### PR DESCRIPTION
## What

\`GET /api/session/consent/history\` accepted \`page\` values up to 10,000. With \`limit=200\` this computes a Supabase \`OFFSET\` of 2,000,000 rows on the \`consent_audit\` table. PostgreSQL must skip over those rows even if they don't exist, causing a full-index scan every time. Any authenticated user could trigger this by appending \`?page=10000&limit=200\` to the URL, making it a denial-of-service vector against the database.

## Fix

Lowered the \`page\` query-parameter upper bound from \`le=10_000\` to \`le=1_000\`. Maximum offset is now 200,000 rows (1,000 x 200). FastAPI enforces the bound at the framework layer and returns HTTP 422 before any DB I/O.

## Canonical attach point

\`api.routes.session.get_consent_history\` -> GET /api/session/consent/history

## Proof

\`tests/test_consent_history_page_cap.py\` - TestClient asserts \`page=1_001\` and \`page=10_000\` both return 422, and \`page=1_000\` does not.

## Test plan

- [ ] Ruff clean
- [ ] DCO signed
- [ ] Rebased on upstream/main
- [ ] TestClient route-level proof added