### PR TITLE
fix(ticker-cache): log malformed rows instead of silently dropping them

### DIFF
--- a/consent-protocol/hushh_mcp/services/ticker_cache.py
+++ b/consent-protocol/hushh_mcp/services/ticker_cache.py
@@ -15,6 +15,10 @@ Design
   - results capped by limit
 
 If cache is empty (startup race), routes can fall back to DB.
+
+Canonical attach point
+----------------------
+hushh_mcp.services.ticker_cache.TickerCache.load_from_db  (invoked at startup)
 """
 
 from __future__ import annotations
@@ -137,6 +141,7 @@ class TickerCache:
             data = legacy_res.data or []
 
         rows: List[TickerRow] = []
+        skipped = 0
         for r in data:
             try:
                 ticker = (r.get("ticker") or "").upper().strip()
@@ -159,8 +164,20 @@ class TickerCache:
                         tradable=bool(r.get("tradable", True)),
                     )
                 )
-            except Exception:
-                continue
+            except Exception as exc:
+                skipped += 1
+                logger.warning(
+                    "[TickerCache] Skipping malformed row ticker=%r: %s",
+                    r.get("ticker"),
+                    exc,
+                )
+
+        if skipped:
+            logger.warning(
+                "[TickerCache] Skipped %d malformed rows out of %d total during load",
+                skipped,
+                len(data),
+            )
 
         with self._lock:
             self._rows = rows

--- a/consent-protocol/tests/test_ticker_cache_malformed_row_logging.py
+++ b/consent-protocol/tests/test_ticker_cache_malformed_row_logging.py
@@ -1,0 +1,119 @@
+"""HTTP proof: malformed ticker rows are logged, not silently dropped.
+
+Canonical attach point:
+  hushh_mcp.services.ticker_cache.TickerCache.load_from_db
+  (exercised via GET /api/tickers/all?refresh=true)
+
+Before this fix, a bad row in the DB result would hit
+  except Exception:
+      continue
+with no log output at all -- making data-quality regressions invisible.
+
+After the fix the handler logs at WARNING level with the row's ticker key
+and the exception, and emits a summary warning with the skip count.
+"""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routes import tickers as tickers_module
+from hushh_mcp.services.ticker_cache import TickerCache
+
+# ---------------------------------------------------------------------------
+# Unit-level: verify TickerCache.load_from_db() behaviour directly
+# ---------------------------------------------------------------------------
+
+def _make_mock_db(rows):
+    """Return a mock db client whose table().select().order().execute() returns rows."""
+    execute_result = MagicMock()
+    execute_result.data = rows
+    order_mock = MagicMock()
+    order_mock.execute.return_value = execute_result
+    select_mock = MagicMock()
+    select_mock.order.return_value = order_mock
+    table_mock = MagicMock()
+    table_mock.select.return_value = select_mock
+    db = MagicMock()
+    db.table.return_value = table_mock
+    return db
+
+
+def test_malformed_rows_are_skipped_and_good_rows_loaded(caplog):
+    """Good rows land in cache; bad rows are counted and warned about."""
+    good_row = {"ticker": "AAPL", "title": "Apple Inc.", "metadata_confidence": 0.9, "tradable": True}
+    # This row will raise ValueError because metadata_confidence is not castable
+    bad_row = {"ticker": "BAD1", "title": "Bad Corp", "metadata_confidence": "not-a-float"}
+
+    mock_db = _make_mock_db([good_row, bad_row])
+
+    cache = TickerCache()
+    with patch(
+        "hushh_mcp.services.ticker_cache.TickerDBService",
+    ) as MockSvc:
+        instance = MockSvc.return_value
+        instance._get_db.return_value = mock_db
+        with caplog.at_level(logging.WARNING, logger="hushh_mcp.services.ticker_cache"):
+            count = cache.load_from_db()
+
+    assert count == 1, "Only the good row should be loaded"
+    assert cache.size() == 1
+    assert cache.get_by_ticker("AAPL") is not None
+    assert cache.get_by_ticker("BAD1") is None
+
+    # Warning must mention the bad ticker and the skip summary
+    warning_text = " ".join(caplog.messages)
+    assert "BAD1" in warning_text
+    assert "Skipped" in warning_text
+
+
+def test_all_good_rows_no_warning_emitted(caplog):
+    """When every row is valid, no warning is logged."""
+    rows = [
+        {"ticker": "MSFT", "title": "Microsoft", "metadata_confidence": 0.95, "tradable": True},
+        {"ticker": "GOOG", "title": "Alphabet", "metadata_confidence": 0.8, "tradable": True},
+    ]
+    mock_db = _make_mock_db(rows)
+
+    cache = TickerCache()
+    with patch("hushh_mcp.services.ticker_cache.TickerDBService") as MockSvc:
+        instance = MockSvc.return_value
+        instance._get_db.return_value = mock_db
+        with caplog.at_level(logging.WARNING, logger="hushh_mcp.services.ticker_cache"):
+            count = cache.load_from_db()
+
+    assert count == 2
+    skip_warnings = [m for m in caplog.messages if "Skipped" in m]
+    assert skip_warnings == [], "No skip warning expected when all rows are valid"
+
+
+# ---------------------------------------------------------------------------
+# HTTP proof: GET /api/tickers/all?refresh=true exercises load_from_db
+# ---------------------------------------------------------------------------
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(tickers_module.router)
+    return app
+
+
+def test_http_all_refresh_loads_cache_and_returns_tickers():
+    """GET /api/tickers/all?refresh=true returns loaded tickers via the cache."""
+    good_rows = [
+        {"ticker": "TSLA", "title": "Tesla", "metadata_confidence": 0.7, "tradable": True},
+    ]
+    mock_db = _make_mock_db(good_rows)
+
+    with patch("hushh_mcp.services.ticker_cache.TickerDBService") as MockSvc:
+        instance = MockSvc.return_value
+        instance._get_db.return_value = mock_db
+
+        app = _make_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/api/tickers/all?refresh=true")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert any(t["ticker"] == "TSLA" for t in data)


### PR DESCRIPTION
## Problem

`TickerCache.load_from_db()` contained a bare `except Exception: continue` that swallowed every row-level parse error with **zero log output**.

```python
# BEFORE
except Exception:
    continue   # silent -- no log, no counter
```

A corrupted ticker column, a type mismatch after a schema migration, or a bad `metadata_confidence` value could silently shrink the in-memory cache. The startup log would still show `Loaded N tickers` but N would be lower than expected with no explanation.

## Fix

Track a `skipped` counter. On each bad row, log `WARNING` with the raw ticker key and the exception. After the loop emit a summary `WARNING` with the skip count vs. total rows so on-call can see the blast radius at a glance.

```python
# AFTER
except Exception as exc:
    skipped += 1
    logger.warning(
        "[TickerCache] Skipping malformed row ticker=%r: %s",
        r.get("ticker"),
        exc,
    )

if skipped:
    logger.warning(
        "[TickerCache] Skipped %d malformed rows out of %d total during load",
        skipped,
        len(data),
    )
```

Good rows are still loaded normally. No functional change for clean data.

## Canonical attach point

```
hushh_mcp.services.ticker_cache.TickerCache.load_from_db
(exercised via GET /api/tickers/all?refresh=true)
```

## TestClient HTTP proof

`tests/test_ticker_cache_malformed_row_logging.py` -- three cases:
- Mix of good + bad rows: good rows loaded, bad ticker appears in WARNING log, `Skipped` summary present
- All good rows: no skip warning emitted
- HTTP `GET /api/tickers/all?refresh=true`: 200 with the expected ticker in response

## Checklist

- [x] Canonical attach point in module docstring
- [x] TestClient HTTP proof test added
- [x] `ruff check --fix` clean
- [x] DCO sign-off (`git commit -s`)
- [x] Single-concern PR