### PR TITLE
fix(world-model): add max_length guards to user_id and domain path params

### DIFF
--- a/consent-protocol/api/routes/world_model.py
+++ b/consent-protocol/api/routes/world_model.py
@@ -5,12 +5,20 @@ These routes preserve older `/api/world-model/*` callers by delegating to the
 canonical PKM implementation under `/api/pkm/*`.
 
 DEPRECATED: Migrate to /api/pkm/* endpoints. These routes will be removed.
+
+Canonical attach points
+-----------------------
+api.routes.world_model.get_user_world_model_domains -> GET /api/world-model/domains/{user_id}
+api.routes.world_model.get_world_model_metadata     -> GET /api/world-model/metadata/{user_id}
+api.routes.world_model.get_world_model_scopes       -> GET /api/world-model/scopes/{user_id}
+api.routes.world_model.get_world_model_data         -> GET /api/world-model/data/{user_id}
+api.routes.world_model.get_world_model_domain_data  -> GET /api/world-model/domain-data/{user_id}/{domain}
 """
 
 import logging
 from typing import Any
 
-from fastapi import APIRouter, Depends, Query, Request, Response
+from fastapi import APIRouter, Depends, Path, Query, Request, Response
 from pydantic import BaseModel
 
 from api.middleware import require_vault_owner_token
@@ -97,7 +105,7 @@ async def get_world_model_domains(
 
 @router.get("/domains/{user_id}", response_model=UserWorldModelDomainsResponse)
 async def get_user_world_model_domains(
-    user_id: str,
+    user_id: str = Path(..., min_length=1, max_length=128),
     token_data: dict = Depends(require_vault_owner_token),
 ):
     metadata = await _get_metadata(user_id, token_data)
@@ -115,7 +123,7 @@ async def get_user_world_model_domains(
 
 @router.get("/metadata/{user_id}", response_model=PersonalKnowledgeModelMetadataResponse)
 async def get_world_model_metadata(
-    user_id: str,
+    user_id: str = Path(..., min_length=1, max_length=128),
     token_data: dict = Depends(require_vault_owner_token),
 ):
     return await _get_metadata(user_id, token_data)
@@ -123,7 +131,7 @@ async def get_world_model_metadata(
 
 @router.get("/scopes/{user_id}", response_model=UserScopesResponse)
 async def get_world_model_scopes(
-    user_id: str,
+    user_id: str = Path(..., min_length=1, max_length=128),
     token_data: dict = Depends(require_vault_owner_token),
 ):
     return await _get_user_scopes(user_id, token_data)
@@ -139,7 +147,7 @@ async def store_world_model_domain(
 
 @router.get("/data/{user_id}", response_model=dict)
 async def get_world_model_data(
-    user_id: str,
+    user_id: str = Path(..., min_length=1, max_length=128),
     token_data: dict = Depends(require_vault_owner_token),
 ):
     return await _get_encrypted_data(user_id, token_data)
@@ -147,8 +155,8 @@ async def get_world_model_data(
 
 @router.get("/domain-data/{user_id}/{domain}", response_model=DomainDataResponse)
 async def get_world_model_domain_data(
-    user_id: str,
-    domain: str,
+    user_id: str = Path(..., min_length=1, max_length=128),
+    domain: str = Path(..., min_length=1, max_length=200),
     segment_ids: list[str] | None = Query(default=None),
     token_data: dict = Depends(require_vault_owner_token),
 ):

--- a/consent-protocol/tests/test_world_model_path_param_bounds.py
+++ b/consent-protocol/tests/test_world_model_path_param_bounds.py
@@ -1,0 +1,102 @@
+"""HTTP proof: world-model routes enforce max_length on user_id and domain.
+
+Canonical attach points:
+  api.routes.world_model.get_user_world_model_domains -> GET /api/world-model/domains/{user_id}
+  api.routes.world_model.get_world_model_domain_data  -> GET /api/world-model/domain-data/{user_id}/{domain}
+
+Before this fix every path parameter was a bare `str` with no size limit.
+After the fix FastAPI rejects overlong ids with 422 before the handler runs.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.middleware import require_vault_owner_token
+from api.routes import world_model
+
+_TOKEN_STUB = {"user_id": "test-uid", "token": "fake-token", "scope": "vault.owner"}
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(world_model.router)
+    app.dependency_overrides[require_vault_owner_token] = lambda: _TOKEN_STUB
+    return app
+
+
+# ---------------------------------------------------------------------------
+# user_id path param bounds
+# ---------------------------------------------------------------------------
+
+def test_domains_user_id_too_long_returns_422():
+    app = _make_app()
+    client = TestClient(app, raise_server_exceptions=False)
+    oversized_uid = "U" * 129
+    resp = client.get(f"/api/world-model/domains/{oversized_uid}")
+    assert resp.status_code == 422
+
+
+def test_metadata_user_id_too_long_returns_422():
+    app = _make_app()
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get(f"/api/world-model/metadata/{'X' * 129}")
+    assert resp.status_code == 422
+
+
+def test_scopes_user_id_too_long_returns_422():
+    app = _make_app()
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get(f"/api/world-model/scopes/{'X' * 129}")
+    assert resp.status_code == 422
+
+
+def test_data_user_id_too_long_returns_422():
+    app = _make_app()
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get(f"/api/world-model/data/{'X' * 129}")
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# domain path param bounds
+# ---------------------------------------------------------------------------
+
+def test_domain_data_domain_too_long_returns_422():
+    app = _make_app()
+    client = TestClient(app, raise_server_exceptions=False)
+    oversized_domain = "d" * 201
+    resp = client.get(f"/api/world-model/domain-data/uid123/{oversized_domain}")
+    assert resp.status_code == 422
+
+
+def test_domain_data_user_id_too_long_returns_422():
+    app = _make_app()
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get(f"/api/world-model/domain-data/{'U' * 129}/finance")
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Valid lengths pass validation and reach the handler
+# ---------------------------------------------------------------------------
+
+def test_domains_valid_uid_reaches_handler():
+    """A valid user_id passes Path validation and delegates to _get_metadata."""
+    fake_meta = MagicMock()
+    fake_meta.domains = []
+    fake_meta.total_attributes = 0
+    fake_meta.last_updated = None
+
+    with patch(
+        "api.routes.world_model._get_metadata",
+        new=AsyncMock(return_value=fake_meta),
+    ):
+        app = _make_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/api/world-model/domains/valid-uid-123")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["user_id"] == "valid-uid-123"


### PR DESCRIPTION
## Problem

Five path parameters across four `/api/world-model/*` routes had **no size constraints** on the path strings:

| Route | Unbounded param(s) |
|---|---|
| `GET /domains/{user_id}` | `user_id: str` |
| `GET /metadata/{user_id}` | `user_id: str` |
| `GET /scopes/{user_id}` | `user_id: str` |
| `GET /data/{user_id}` | `user_id: str` |
| `GET /domain-data/{user_id}/{domain}` | `user_id: str`, `domain: str` |

An arbitrarily long path string reaches service calls and SQL queries with no HTTP-layer rejection -- inconsistent with the `max_length` guards already present on query params throughout the codebase (e.g. `Query(max_length=200)` in marketplace, `Path(max_length=128)` in tickers).

## Fix

Added `Path(min_length=1, max_length=128)` to all `user_id` path params and `Path(min_length=1, max_length=200)` to `domain`, matching existing bounds elsewhere. FastAPI now rejects oversized values with `422 Unprocessable Entity` before the handler body runs.

## Canonical attach points

```
api.routes.world_model.get_user_world_model_domains -> GET /api/world-model/domains/{user_id}
api.routes.world_model.get_world_model_metadata     -> GET /api/world-model/metadata/{user_id}
api.routes.world_model.get_world_model_scopes       -> GET /api/world-model/scopes/{user_id}
api.routes.world_model.get_world_model_data         -> GET /api/world-model/data/{user_id}
api.routes.world_model.get_world_model_domain_data  -> GET /api/world-model/domain-data/{user_id}/{domain}
```

## TestClient HTTP proof

`tests/test_world_model_path_param_bounds.py` -- seven cases:
- 129-char `user_id` on each of the four `user_id` routes -> `422`
- 201-char `domain` on domain-data route -> `422`
- 129-char `user_id` on domain-data route -> `422`
- Valid uid on `/domains/{user_id}` -> `200` (handler reached, `_get_metadata` mocked)

## Checklist

- [x] Canonical attach points in module docstring
- [x] TestClient HTTP proof test added
- [x] `ruff check --fix` clean
- [x] DCO sign-off (`git commit -s`)
- [x] Single-concern PR