### PR TITLE
fix(ria): cap page param at le=1_000 for GET /clients

### DIFF
--- a/consent-protocol/api/routes/ria.py
+++ b/consent-protocol/api/routes/ria.py
@@ -359,7 +359,7 @@ async def ria_firms(firebase_uid: str = Depends(require_firebase_auth)):
 async def ria_clients(
     q: str | None = Query(default=None, max_length=200),
     status: str | None = Query(default=None, max_length=50),
-    page: int = Query(default=1, ge=1),
+    page: int = Query(default=1, ge=1, le=1_000),
     limit: int = Query(default=50, ge=1, le=100),
     firebase_uid: str = Depends(_require_ria_verified),
 ):

--- a/consent-protocol/tests/test_ria_clients_page_cap.py
+++ b/consent-protocol/tests/test_ria_clients_page_cap.py
@@ -1,0 +1,54 @@
+"""HTTP proof: GET /api/ria/clients enforces page le=1_000.
+
+Before this fix, page had no upper bound (ge=1 only).  A caller could
+supply page=10_000_000 and trigger a 10M-row offset in the DB query.
+After the fix FastAPI rejects page > 1_000 with 422 before the handler runs.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.middleware import require_firebase_auth
+from api.routes import ria as ria_module
+
+_UID_STUB = "test-firebase-uid"
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(ria_module.router)
+    # Stub both firebase auth AND the _require_ria_verified dependency
+    app.dependency_overrides[require_firebase_auth] = lambda: _UID_STUB
+    app.dependency_overrides[ria_module._require_ria_verified] = lambda: _UID_STUB
+    return app
+
+
+def test_page_above_cap_returns_422():
+    app = _make_app()
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/api/ria/clients?page=1001")
+    assert resp.status_code == 422
+
+
+def test_page_at_cap_passes_validation():
+    """page=1_000 is the maximum allowed; the handler is reached."""
+    fake_result = {"clients": [], "total": 0}
+    with patch(
+        "hushh_mcp.services.ria_iam_service.RIAIAMService.list_ria_clients",
+        new=AsyncMock(return_value=fake_result),
+    ):
+        app = _make_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/api/ria/clients?page=1000")
+
+    assert resp.status_code == 200
+
+
+def test_page_zero_returns_422():
+    """page < 1 rejected by ge=1."""
+    app = _make_app()
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/api/ria/clients?page=0")
+    assert resp.status_code == 422


### PR DESCRIPTION
## Problem

`GET /api/ria/clients` had `page: int = Query(default=1, ge=1)` with **no upper bound**:

```python
# BEFORE
page: int = Query(default=1, ge=1),      # no le= cap
limit: int = Query(default=50, ge=1, le=100),
```

A caller could supply `page=10_000_000` with `limit=100`, forcing a **1-billion-row DB offset** through `service.list_ria_clients()` with no HTTP-layer rejection.

## Fix

Add `le=1_000`, consistent with the page cap applied to session history in `api/routes/session.py`. Maximum reachable offset is now `1_000 * 100 = 100_000` rows.

```python
# AFTER
page: int = Query(default=1, ge=1, le=1_000),
```

## Canonical attach point

```
api.routes.ria.ria_clients -> GET /api/ria/clients
```

## TestClient HTTP proof

`tests/test_ria_clients_page_cap.py` -- three cases:
- `page=1_001` -> `422`
- `page=0` -> `422` (ge=1 guard)
- `page=1_000` -> `200` (at cap, handler reached, service mocked)

## Checklist

- [x] Canonical attach point in module docstring
- [x] TestClient HTTP proof test added
- [x] `ruff check --fix` clean
- [x] DCO sign-off (`git commit -s`)
- [x] Single-concern PR