### PR TITLE
fix(gmail): add user_id max_length and cap page at le=1_000

### DIFF
--- a/consent-protocol/api/routes/kai/gmail.py
+++ b/consent-protocol/api/routes/kai/gmail.py
@@ -1,11 +1,17 @@
-"""Kai Gmail receipts connector routes."""
+"""Kai Gmail receipts connector routes.
+
+Canonical attach points
+-----------------------
+api.routes.kai.gmail.gmail_status   -> GET /gmail/status/{user_id}
+api.routes.kai.gmail.gmail_receipts -> GET /gmail/receipts/{user_id}
+"""
 
 from __future__ import annotations
 
 import logging
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, status
 from pydantic import BaseModel, Field
 from sqlalchemy.exc import OperationalError as SqlalchemyOperationalError
 
@@ -185,7 +191,7 @@ async def gmail_connect_complete(
 
 @router.get("/gmail/status/{user_id}")
 async def gmail_status(
-    user_id: str,
+    user_id: str = Path(..., min_length=1, max_length=128),
     firebase_uid: str = Depends(require_firebase_auth),
 ):
     verify_user_id_match(firebase_uid, user_id)
@@ -270,8 +276,8 @@ async def gmail_sync_run(
 
 @router.get("/gmail/receipts/{user_id}")
 async def gmail_receipts(
-    user_id: str,
-    page: int = Query(1, ge=1),
+    user_id: str = Path(..., min_length=1, max_length=128),
+    page: int = Query(1, ge=1, le=1_000),
     per_page: int = Query(25, ge=1, le=100),
     firebase_uid: str = Depends(require_firebase_auth),
     token_data: dict = Depends(require_vault_owner_token),

--- a/consent-protocol/tests/test_gmail_path_param_bounds.py
+++ b/consent-protocol/tests/test_gmail_path_param_bounds.py
@@ -1,0 +1,91 @@
+"""HTTP proof: Gmail routes enforce user_id max_length and page le=1_000.
+
+Canonical attach points:
+  api.routes.kai.gmail.gmail_status   -> GET /gmail/status/{user_id}
+  api.routes.kai.gmail.gmail_receipts -> GET /gmail/receipts/{user_id}
+
+Before this fix both routes had unbounded user_id path params and
+gmail_receipts had page: int = Query(1, ge=1) with no upper bound.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.middleware import require_firebase_auth, require_vault_owner_token, verify_user_id_match
+from api.routes.kai import gmail as gmail_module
+
+_UID = "test-uid"
+_TOKEN_STUB = {"user_id": _UID, "token": "tok", "scope": "vault.owner"}
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(gmail_module.router)
+    app.dependency_overrides[require_firebase_auth] = lambda: _UID
+    app.dependency_overrides[require_vault_owner_token] = lambda: _TOKEN_STUB
+    # verify_user_id_match is a sync callable dependency, stub it to no-op
+    app.dependency_overrides[verify_user_id_match] = lambda: None
+    return app
+
+
+# ---------------------------------------------------------------------------
+# GET /gmail/status/{user_id}  -- unbounded user_id
+# ---------------------------------------------------------------------------
+
+def test_status_user_id_too_long_returns_422():
+    app = _make_app()
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get(f"/gmail/status/{'U' * 129}")
+    assert resp.status_code == 422
+
+
+def test_status_valid_user_id_reaches_handler():
+    fake_status = {"connected": True}
+    with patch(
+        "hushh_mcp.services.gmail_receipts_service.get_gmail_receipts_service",
+    ) as mock_factory:
+        svc = MagicMock()
+        svc.get_status = AsyncMock(return_value=fake_status)
+        mock_factory.return_value = svc
+
+        app = _make_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(f"/gmail/status/{_UID}")
+
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# GET /gmail/receipts/{user_id}  -- unbounded user_id + page cap
+# ---------------------------------------------------------------------------
+
+def test_receipts_user_id_too_long_returns_422():
+    app = _make_app()
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get(f"/gmail/receipts/{'U' * 129}?page=1")
+    assert resp.status_code == 422
+
+
+def test_receipts_page_above_cap_returns_422():
+    app = _make_app()
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get(f"/gmail/receipts/{_UID}?page=1001")
+    assert resp.status_code == 422
+
+
+def test_receipts_page_at_cap_passes():
+    fake_receipts = {"items": [], "total": 0}
+    with patch(
+        "hushh_mcp.services.gmail_receipts_service.get_gmail_receipts_service",
+    ) as mock_factory:
+        svc = MagicMock()
+        svc.list_receipts = AsyncMock(return_value=fake_receipts)
+        mock_factory.return_value = svc
+
+        app = _make_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(f"/gmail/receipts/{_UID}?page=1000")
+
+    assert resp.status_code == 200


### PR DESCRIPTION
## Problem

Two Gmail routes had **unbounded `user_id` path params** and `gmail_receipts` had a **page param with no upper bound**:

```python
# BEFORE
@router.get("/gmail/status/{user_id}")
async def gmail_status(user_id: str, ...):     # no Path() bounds

@router.get("/gmail/receipts/{user_id}")
async def gmail_receipts(
    user_id: str,                              # no Path() bounds
    page: int = Query(1, ge=1),                # no le= cap
    ...
```

An oversized `user_id` propagates into service calls and logs without HTTP rejection. An unbounded `page` allows callers to trigger arbitrarily large DB offsets (e.g. `page=10_000_000` with `per_page=100` -> 1-billion-row offset).

## Fix

Add `Path(min_length=1, max_length=128)` to both `user_id` params and `le=1_000` to `page`:

```python
# AFTER
user_id: str = Path(..., min_length=1, max_length=128)
page: int = Query(1, ge=1, le=1_000)
```

## Canonical attach points

```
api.routes.kai.gmail.gmail_status   -> GET /gmail/status/{user_id}
api.routes.kai.gmail.gmail_receipts -> GET /gmail/receipts/{user_id}
```

## TestClient HTTP proof

`tests/test_gmail_path_param_bounds.py` -- five cases:
- `status/{129-char uid}` -> `422`
- `status/{valid-uid}` -> `200` (service mocked)
- `receipts/{129-char uid}` -> `422`
- `receipts/{uid}?page=1001` -> `422`
- `receipts/{uid}?page=1000` -> `200` (service mocked)

## Checklist

- [x] Canonical attach points in module docstring
- [x] TestClient HTTP proof test added
- [x] `ruff check --fix` clean
- [x] DCO sign-off (`git commit -s`)
- [x] Single-concern PR