### PR TITLE
fix(theme-toggle): increase ThemeToggleCompact trigger touch target to WCAG minimum

### DIFF
--- a/hushh-webapp/components/theme-toggle.tsx
+++ b/hushh-webapp/components/theme-toggle.tsx
@@ -127,7 +127,7 @@ export function ThemeToggleCompact({ className }: { className?: string }) {
           type="button"
           aria-label={`Theme: ${activeOption.label}. Click to change.`}
           className={cn(
-            "inline-flex h-9 w-9 items-center justify-center rounded-full border backdrop-blur-xl transition-[background-color,border-color,color] duration-150",
+            "inline-flex h-11 w-11 items-center justify-center rounded-full border backdrop-blur-xl transition-[background-color,border-color,color] duration-150",
             isDark
               ? "border-white/8 bg-black/85 text-zinc-100 hover:bg-neutral-900"
               : "border-slate-200 bg-white/85 text-slate-700 hover:bg-white",


### PR DESCRIPTION
## Summary

ThemeToggleCompact rendered a 36×36px trigger button, falling below the recommended 44×44px minimum touch target size for mobile accessibility.

This update improves touch accessibility by increasing the compact theme toggle trigger size to 44px while preserving the existing layout, styling, and theme-switching behavior.

## What's covered

`components/theme-toggle.tsx`

Improved mobile touch target sizing for `ThemeToggleCompact`.

## Key improvements

- increases the compact trigger size from 36px to 44px
- improves mobile tap target accessibility
- preserves existing layout and styling behavior
- keeps icon alignment and dropdown interaction unchanged
- leaves theme-switching logic untouched

## Reachable surfaces

- onboarding top-right theme toggle
- surfaces rendering `ThemeToggleCompact`
- pre-auth onboarding chrome

## Validation

- `npx tsc --noEmit`
- `npm run lint`

## Notes

- frontend-only accessibility improvement
- no runtime/business logic changes
- no dropdown/menu behavior changes
- no backend/schema/cache impacts
- DCO sign-off included