### PR TITLE
fix(not-found): render branded HushhLoader during redirect instead of blank screen

### DIFF
--- a/hushh-webapp/app/not-found.tsx
+++ b/hushh-webapp/app/not-found.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { HushhLoader } from "@/components/app-ui/hushh-loader";
 
 export default function AppNotFoundPage() {
   const router = useRouter();
@@ -10,5 +11,5 @@ export default function AppNotFoundPage() {
     router.replace("/");
   }, [router]);
 
-  return null;
+  return <HushhLoader label="Redirecting..." variant="fullscreen" />;
 }


### PR DESCRIPTION
## Summary

AppNotFoundPage rendered `null` while redirecting unmatched routes, causing a blank visual flash before the redirect completed.

This update improves the invalid-route transition experience by rendering the existing branded `HushhLoader` during redirect flow while preserving the existing redirect behavior.

## What's covered

`app/not-found.tsx`

Improved visual loading feedback for invalid route redirects.

## Key improvements

- replaces blank render state with existing `HushhLoader`
- improves redirect transition polish for unmatched routes
- preserves existing `router.replace("/")` behavior
- reuses the existing fullscreen branded loader surface
- introduces no routing or redirect timing changes

## Reachable surfaces

- invalid/unmatched route transitions
- `AppNotFoundPage`
- redirect fallback flow for unknown routes

## Validation

- `npx tsc --noEmit`
- `npm run lint`

## Notes

- frontend-only UX improvement
- no routing/runtime/business logic changes
- no redirect behavior changes
- no backend/schema/cache impacts
- DCO sign-off included