### PR TITLE
fix(pkm): add run_id/domain Path bounds to upgrade routes + opaque ValueError detail

### DIFF
--- a/consent-protocol/api/routes/pkm.py
+++ b/consent-protocol/api/routes/pkm.py
@@ -241,7 +241,7 @@ async def update_upgrade_run_status(
     run_id: str = Path(..., min_length=1, max_length=128),
     token_data: dict = Depends(require_vault_owner_token),
 ):
-    return await _update_upgrade_run_status(run_id, request, token_data)
+    return await _update_upgrade_run_status(request, run_id, token_data)
 
 
 @router.post("/upgrade/runs/{run_id}/steps/{domain}", response_model=PkmUpgradeStatusResponse)
@@ -251,7 +251,7 @@ async def update_upgrade_step(
     domain: str = Path(..., min_length=1, max_length=200),
     token_data: dict = Depends(require_vault_owner_token),
 ):
-    return await _update_upgrade_step(run_id, domain, request, token_data)
+    return await _update_upgrade_step(request, run_id, domain, token_data)
 
 
 @router.post("/upgrade/runs/{run_id}/complete", response_model=PkmUpgradeStatusResponse)
@@ -260,7 +260,7 @@ async def complete_upgrade_run(
     run_id: str = Path(..., min_length=1, max_length=128),
     token_data: dict = Depends(require_vault_owner_token),
 ):
-    return await _complete_upgrade_run(run_id, request, token_data)
+    return await _complete_upgrade_run(request, run_id, token_data)
 
 
 @router.post("/upgrade/runs/{run_id}/fail", response_model=PkmUpgradeStatusResponse)
@@ -269,7 +269,7 @@ async def fail_upgrade_run(
     run_id: str = Path(..., min_length=1, max_length=128),
     token_data: dict = Depends(require_vault_owner_token),
 ):
-    return await _fail_upgrade_run(run_id, request, token_data)
+    return await _fail_upgrade_run(request, run_id, token_data)
 
 
 @router.get("/domain-registry", response_model=DomainRegistryResponse)

--- a/consent-protocol/api/routes/pkm.py
+++ b/consent-protocol/api/routes/pkm.py
@@ -237,8 +237,8 @@ async def start_or_resume_upgrade(
 
 @router.post("/upgrade/runs/{run_id}/status", response_model=PkmUpgradeStatusResponse)
 async def update_upgrade_run_status(
-    run_id: str,
     request: UpdateUpgradeRunRequest,
+    run_id: str = Path(..., min_length=1, max_length=128),
     token_data: dict = Depends(require_vault_owner_token),
 ):
     return await _update_upgrade_run_status(run_id, request, token_data)
@@ -246,9 +246,9 @@ async def update_upgrade_run_status(
 
 @router.post("/upgrade/runs/{run_id}/steps/{domain}", response_model=PkmUpgradeStatusResponse)
 async def update_upgrade_step(
-    run_id: str,
-    domain: str,
     request: UpdateUpgradeStepRequest,
+    run_id: str = Path(..., min_length=1, max_length=128),
+    domain: str = Path(..., min_length=1, max_length=200),
     token_data: dict = Depends(require_vault_owner_token),
 ):
     return await _update_upgrade_step(run_id, domain, request, token_data)
@@ -256,8 +256,8 @@ async def update_upgrade_step(
 
 @router.post("/upgrade/runs/{run_id}/complete", response_model=PkmUpgradeStatusResponse)
 async def complete_upgrade_run(
-    run_id: str,
     request: StartOrResumeUpgradeRequest,
+    run_id: str = Path(..., min_length=1, max_length=128),
     token_data: dict = Depends(require_vault_owner_token),
 ):
     return await _complete_upgrade_run(run_id, request, token_data)
@@ -265,8 +265,8 @@ async def complete_upgrade_run(
 
 @router.post("/upgrade/runs/{run_id}/fail", response_model=PkmUpgradeStatusResponse)
 async def fail_upgrade_run(
-    run_id: str,
     request: UpdateUpgradeRunRequest,
+    run_id: str = Path(..., min_length=1, max_length=128),
     token_data: dict = Depends(require_vault_owner_token),
 ):
     return await _fail_upgrade_run(run_id, request, token_data)

--- a/consent-protocol/api/routes/pkm_routes_shared.py
+++ b/consent-protocol/api/routes/pkm_routes_shared.py
@@ -14,7 +14,7 @@ import uuid
 from datetime import datetime
 from typing import Any, List, Optional
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, status
 from pydantic import BaseModel, Field, ValidationError
 
 from api.middleware import require_vault_owner_token
@@ -1434,8 +1434,8 @@ async def start_or_resume_upgrade(
 
 @router.post("/upgrade/runs/{run_id}/status", response_model=PkmUpgradeStatusResponse)
 async def update_upgrade_run_status(
-    run_id: str,
     request: UpdateUpgradeRunRequest,
+    run_id: str = Path(..., min_length=1, max_length=128),
     token_data: dict = Depends(require_vault_owner_token),
 ):
     if token_data.get("user_id") != request.user_id:
@@ -1459,9 +1459,9 @@ async def update_upgrade_run_status(
 
 @router.post("/upgrade/runs/{run_id}/steps/{domain}", response_model=PkmUpgradeStatusResponse)
 async def update_upgrade_step(
-    run_id: str,
-    domain: str,
     request: UpdateUpgradeStepRequest,
+    run_id: str = Path(..., min_length=1, max_length=128),
+    domain: str = Path(..., min_length=1, max_length=200),
     token_data: dict = Depends(require_vault_owner_token),
 ):
     if token_data.get("user_id") != request.user_id:
@@ -1487,8 +1487,8 @@ async def update_upgrade_step(
 
 @router.post("/upgrade/runs/{run_id}/complete", response_model=PkmUpgradeStatusResponse)
 async def complete_upgrade_run(
-    run_id: str,
     request: StartOrResumeUpgradeRequest,
+    run_id: str = Path(..., min_length=1, max_length=128),
     token_data: dict = Depends(require_vault_owner_token),
 ):
     if token_data.get("user_id") != request.user_id:
@@ -1500,7 +1500,10 @@ async def complete_upgrade_run(
     try:
         payload = await get_pkm_upgrade_service().complete_run(run_id)
     except ValueError as exc:
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+        logger.warning("pkm.complete_upgrade_run.conflict run_id=%s: %s", run_id, exc)
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail="Upgrade run cannot be completed"
+        ) from exc
     if payload is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Upgrade run not found")
     return _build_upgrade_status_response(payload)
@@ -1508,8 +1511,8 @@ async def complete_upgrade_run(
 
 @router.post("/upgrade/runs/{run_id}/fail", response_model=PkmUpgradeStatusResponse)
 async def fail_upgrade_run(
-    run_id: str,
     request: UpdateUpgradeRunRequest,
+    run_id: str = Path(..., min_length=1, max_length=128),
     token_data: dict = Depends(require_vault_owner_token),
 ):
     if token_data.get("user_id") != request.user_id:

--- a/consent-protocol/tests/test_pkm_upgrade_run_id_path_bounds.py
+++ b/consent-protocol/tests/test_pkm_upgrade_run_id_path_bounds.py
@@ -1,0 +1,163 @@
+"""
+HTTP proof tests for run_id / domain Path bounds on PKM upgrade routes.
+
+Canonical attach points
+-----------------------
+api.routes.pkm.update_upgrade_run_status -> POST /api/pkm/upgrade/runs/{run_id}/status
+api.routes.pkm.update_upgrade_step       -> POST /api/pkm/upgrade/runs/{run_id}/steps/{domain}
+api.routes.pkm.complete_upgrade_run      -> POST /api/pkm/upgrade/runs/{run_id}/complete
+api.routes.pkm.fail_upgrade_run          -> POST /api/pkm/upgrade/runs/{run_id}/fail
+
+Tests drive the canonical pkm.router (prefix=/api/pkm) so the proven URL
+is the production surface, not the shared-handler sub-router. Each route
+enforces max_length=128 on run_id (and max_length=200 on domain).
+FastAPI rejects oversized path segments with 422 before the handler runs.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import api.routes.pkm as pkm_mod
+from api.middleware import require_vault_owner_token
+
+VALID_UID = "test-uid"
+OVERLONG_RUN_ID = "x" * 129
+OVERLONG_DOMAIN = "d" * 201
+VALID_RUN_ID = "run-abc123"
+VALID_DOMAIN = "financial"
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    """Mount the canonical pkm.router so tests exercise /api/pkm/upgrade/... URLs."""
+    app = FastAPI()
+    app.include_router(pkm_mod.router)
+    app.dependency_overrides[require_vault_owner_token] = lambda: {
+        "user_id": VALID_UID,
+        "token": "fake-token",
+        "scope": "vault.owner",
+    }
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _status_body(user_id: str = VALID_UID) -> dict:
+    """Body for UpdateUpgradeRunRequest (requires status field)."""
+    return {"user_id": user_id, "status": "in_progress"}
+
+
+def _step_body(user_id: str = VALID_UID) -> dict:
+    """Body for UpdateUpgradeStepRequest (requires status field)."""
+    return {"user_id": user_id, "status": "completed"}
+
+
+def _start_body(user_id: str = VALID_UID) -> dict:
+    """Body for StartOrResumeUpgradeRequest (user_id only required)."""
+    return {"user_id": user_id}
+
+
+# ---------------------------------------------------------------------------
+# update_upgrade_run_status  POST /api/pkm/upgrade/runs/{run_id}/status
+# ---------------------------------------------------------------------------
+
+
+def test_update_upgrade_run_status_overlong_run_id_is_422(client: TestClient) -> None:
+    resp = client.post(
+        f"/api/pkm/upgrade/runs/{OVERLONG_RUN_ID}/status",
+        json=_status_body(),
+    )
+    assert resp.status_code == 422
+
+
+def test_update_upgrade_run_status_empty_run_id_is_404_or_405(client: TestClient) -> None:
+    resp = client.post("/api/pkm/upgrade/runs//status", json=_status_body())
+    assert resp.status_code in {404, 405, 422}
+
+
+def test_update_upgrade_run_status_valid_run_id_passes_path_guard(client: TestClient) -> None:
+    resp = client.post(
+        f"/api/pkm/upgrade/runs/{VALID_RUN_ID}/status",
+        json=_status_body(),
+    )
+    assert resp.status_code != 422, (
+        "A valid run_id must pass the path guard and reach the handler"
+    )
+
+
+# ---------------------------------------------------------------------------
+# update_upgrade_step  POST /api/pkm/upgrade/runs/{run_id}/steps/{domain}
+# ---------------------------------------------------------------------------
+
+
+def test_update_upgrade_step_overlong_run_id_is_422(client: TestClient) -> None:
+    resp = client.post(
+        f"/api/pkm/upgrade/runs/{OVERLONG_RUN_ID}/steps/{VALID_DOMAIN}",
+        json=_step_body(),
+    )
+    assert resp.status_code == 422
+
+
+def test_update_upgrade_step_overlong_domain_is_422(client: TestClient) -> None:
+    resp = client.post(
+        f"/api/pkm/upgrade/runs/{VALID_RUN_ID}/steps/{OVERLONG_DOMAIN}",
+        json=_step_body(),
+    )
+    assert resp.status_code == 422
+
+
+def test_update_upgrade_step_valid_params_pass_path_guard(client: TestClient) -> None:
+    resp = client.post(
+        f"/api/pkm/upgrade/runs/{VALID_RUN_ID}/steps/{VALID_DOMAIN}",
+        json=_step_body(),
+    )
+    assert resp.status_code != 422, (
+        "Valid run_id and domain must pass the path guard and reach the handler"
+    )
+
+
+# ---------------------------------------------------------------------------
+# complete_upgrade_run  POST /api/pkm/upgrade/runs/{run_id}/complete
+# ---------------------------------------------------------------------------
+
+
+def test_complete_upgrade_run_overlong_run_id_is_422(client: TestClient) -> None:
+    resp = client.post(
+        f"/api/pkm/upgrade/runs/{OVERLONG_RUN_ID}/complete",
+        json=_start_body(),
+    )
+    assert resp.status_code == 422
+
+
+def test_complete_upgrade_run_valid_run_id_passes_path_guard(client: TestClient) -> None:
+    resp = client.post(
+        f"/api/pkm/upgrade/runs/{VALID_RUN_ID}/complete",
+        json=_start_body(),
+    )
+    assert resp.status_code != 422, (
+        "Valid run_id must pass the path guard and reach the handler"
+    )
+
+
+# ---------------------------------------------------------------------------
+# fail_upgrade_run  POST /api/pkm/upgrade/runs/{run_id}/fail
+# ---------------------------------------------------------------------------
+
+
+def test_fail_upgrade_run_overlong_run_id_is_422(client: TestClient) -> None:
+    resp = client.post(
+        f"/api/pkm/upgrade/runs/{OVERLONG_RUN_ID}/fail",
+        json=_status_body(),
+    )
+    assert resp.status_code == 422
+
+
+def test_fail_upgrade_run_valid_run_id_passes_path_guard(client: TestClient) -> None:
+    resp = client.post(
+        f"/api/pkm/upgrade/runs/{VALID_RUN_ID}/fail",
+        json=_status_body(),
+    )
+    assert resp.status_code != 422, (
+        "Valid run_id must pass the path guard and reach the handler"
+    )


### PR DESCRIPTION
## What

Four PKM upgrade routes accepted unbounded `run_id` (and `domain`) path
parameters, allowing arbitrarily long strings to reach the database layer.
`complete_upgrade_run` also leaked the internal exception message to the
HTTP caller via `detail=str(exc)` (CWE-209).

## Changes

| File | Change |
|------|--------|
| `api/routes/pkm_routes_shared.py` | `Path(min_length=1, max_length=128)` on `run_id` in all four upgrade routes; `max_length=200` on `domain` in `update_upgrade_step`; opaque `detail` in `complete_upgrade_run` ValueError handler; canonical attach points added to module docstring |
| `tests/test_pkm_upgrade_run_id_path_bounds.py` | TestClient proof — 422 on overlong `run_id`/`domain`, valid segment reaches handler |

## Why

- Unbounded path params let callers write arbitrarily long strings into DB
  key columns with no prior validation.
- `detail=str(exc)` in the ValueError handler of `complete_upgrade_run`
  exposes internal service state (e.g. state machine messages) to callers
  (CWE-209: Information Exposure Through an Error Message).

## Test plan

- [ ] `pytest tests/test_pkm_upgrade_run_id_path_bounds.py` passes
- [ ] `python3 -m ruff check consent-protocol/` passes clean
- [ ] POST with 129-char `run_id` returns 422 on all four routes
- [ ] POST with 201-char `domain` returns 422 on `update_upgrade_step`