### PR TITLE
fix(pkm): replace f-string loggers with %-style formatting (ruff G004)

### DIFF
--- a/consent-protocol/api/routes/pkm_routes_shared.py
+++ b/consent-protocol/api/routes/pkm_routes_shared.py
@@ -278,7 +278,7 @@ async def get_risk_profile_from_index(user_id: str) -> tuple[str, list[dict], di
 
             return risk_profile, cached_holdings, portfolio_allocation
     except Exception as e:
-        logger.warning(f"[PKM Context] Failed to get context from index: {e}")
+        logger.warning("[PKM Context] Failed to get context from index: %s", e)
 
     # Fallback defaults if no cache exists
     return "balanced", [], {"equities_pct": 70, "bonds_pct": 20, "cash_pct": 10}
@@ -325,7 +325,7 @@ async def fetch_decisions(user_id: str, limit: int = 50) -> list[DecisionRecord]
         records.sort(key=lambda x: x.created_at if x.created_at else "", reverse=True)
         return records[:limit]
     except Exception as e:
-        logger.warning(f"[PKM Context] Failed to fetch decisions: {e}")
+        logger.warning("[PKM Context] Failed to fetch decisions: %s", e)
         return []
 
 
@@ -1250,7 +1250,7 @@ async def get_metadata(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error getting metadata for user {user_id}: {e}")
+        logger.error("pkm.metadata.error user_id=%s: %s", user_id, e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve PKM metadata",

--- a/consent-protocol/tests/test_pkm_shared_g004_loggers.py
+++ b/consent-protocol/tests/test_pkm_shared_g004_loggers.py
@@ -32,14 +32,14 @@ def client() -> TestClient:
 
 def test_metadata_endpoint_reachable(client: TestClient) -> None:
     """GET /api/pkm/metadata/{user_id} must reach the handler (not 404/405)."""
-    resp = client.get(f"/metadata/{VALID_UID}")
+    resp = client.get(f"/api/pkm/metadata/{VALID_UID}")
     # Handler may fail due to missing DB; we only assert the route resolves.
     assert resp.status_code in {200, 500, 503}
 
 
 def test_metadata_endpoint_wrong_user_is_403(client: TestClient) -> None:
     """Token user_id mismatch must produce 403."""
-    resp = client.get("/metadata/other-uid")
+    resp = client.get("/api/pkm/metadata/other-uid")
     assert resp.status_code == 403
 
 

--- a/consent-protocol/tests/test_pkm_shared_g004_loggers.py
+++ b/consent-protocol/tests/test_pkm_shared_g004_loggers.py
@@ -1,0 +1,68 @@
+"""
+HTTP proof tests for G004 logger fixes in pkm_routes_shared.
+
+Three logger calls used f-string interpolation (ruff G004).  They are now
+converted to %-style lazy formatting so ruff passes clean and the logger
+short-circuits the string build when the level is suppressed.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import api.routes.pkm_routes_shared as pkm_mod
+from api.middleware import require_vault_owner_token
+
+VALID_UID = "test-uid"
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(pkm_mod.router)
+    app.dependency_overrides[require_vault_owner_token] = lambda: {
+        "user_id": VALID_UID,
+        "token": "fake-token",
+        "scope": "vault.owner",
+    }
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_metadata_endpoint_reachable(client: TestClient) -> None:
+    """GET /api/pkm/metadata/{user_id} must reach the handler (not 404/405)."""
+    resp = client.get(f"/metadata/{VALID_UID}")
+    # Handler may fail due to missing DB; we only assert the route resolves.
+    assert resp.status_code in {200, 500, 503}
+
+
+def test_metadata_endpoint_wrong_user_is_403(client: TestClient) -> None:
+    """Token user_id mismatch must produce 403."""
+    resp = client.get("/metadata/other-uid")
+    assert resp.status_code == 403
+
+
+def test_no_f_string_loggers_in_module() -> None:
+    """Static check: none of the three fixed logger calls use f-strings."""
+    import ast
+    import pathlib
+
+    src = pathlib.Path(pkm_mod.__file__).read_text()
+    tree = ast.parse(src)
+
+    f_string_loggers: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr in {"warning", "error", "info"}):
+            continue
+        # Check if any argument is a JoinedStr (f-string)
+        for arg in node.args:
+            if isinstance(arg, ast.JoinedStr):
+                f_string_loggers.append(node.lineno)
+
+    assert f_string_loggers == [], (
+        f"G004: f-string logger calls found at lines {f_string_loggers}"
+    )


### PR DESCRIPTION
## What

Three `logger.warning/error` calls in `pkm_routes_shared.py` used f-string
interpolation, which violates ruff rule **G004** and builds the message string
even when the log level is disabled.

## Changes

| File | Lines | Change |
|------|-------|--------|
| `api/routes/pkm_routes_shared.py` | 251, 298, 1108 | f-string → `%`-style lazy formatting; line 1108 also gets a structured `key=value` prefix |
| `tests/test_pkm_shared_g004_loggers.py` | new | TestClient proof + AST static check that no f-string loggers remain |

## Why

- ruff G004 flags f-string logger arguments because the string is built eagerly regardless of whether the logger level is active, wasting CPU on suppressed levels.
- Consistent `%`-style formatting is also easier to parse in structured log pipelines.

## Test plan

- [ ] `pytest tests/test_pkm_shared_g004_loggers.py` passes (including the AST static check)
- [ ] `python3 -m ruff check consent-protocol/` passes clean