### PR TITLE
fix(losers): replace f-string loggers with %-style formatting (ruff G004)

### DIFF
--- a/consent-protocol/api/routes/kai/losers.py
+++ b/consent-protocol/api/routes/kai/losers.py
@@ -395,7 +395,7 @@ async def analyze_portfolio_losers(
 
     client = genai.Client(http_options=HttpOptions(api_version="v1"))
     model_to_use = GEMINI_MODEL
-    logger.info(f"Optimize Portfolio: Using Vertex AI with model {model_to_use}")
+    logger.info("Optimize Portfolio: Using Vertex AI with model %s", model_to_use)
     cash_positions_excluded, cash_value_excluded = _summarize_excluded_cash_positions(
         request.holdings or []
     )
@@ -870,7 +870,7 @@ async def analyze_portfolio_losers_stream(
 
                 client = genai.Client(http_options=HttpOptions(api_version="v1"))
                 model_to_use = GEMINI_MODEL
-                logger.info(f"Optimize Portfolio Stream: Using Vertex AI with model {model_to_use}")
+                logger.info("Optimize Portfolio Stream: Using Vertex AI with model %s", model_to_use)
 
                 # Configure for deterministic JSON reliability.
                 config_kwargs: dict[str, Any] = {
@@ -1029,7 +1029,7 @@ async def analyze_portfolio_losers_stream(
                 except Exception as parse_error:
                     salvage_candidate = _extract_likely_json_object(full_response)
                     if not salvage_candidate or salvage_candidate == full_response:
-                        logger.error(f"Failed to parse LLM response: {parse_error}")
+                        logger.error("losers.parse_llm_response.error: %s", parse_error)
                         yield stream.event(
                             "error",
                             {
@@ -1054,7 +1054,7 @@ async def analyze_portfolio_losers_stream(
                         )
                         diagnostics["salvage_applied"] = True
                     except Exception as salvage_error:
-                        logger.error(f"Failed to parse LLM response after salvage: {salvage_error}")
+                        logger.error("losers.parse_llm_response.salvage_error: %s", salvage_error)
                         yield stream.event(
                             "error",
                             {
@@ -1079,7 +1079,7 @@ async def analyze_portfolio_losers_stream(
 
                     yield stream.event("complete", payload, terminal=True)
                 except Exception as payload_error:
-                    logger.error(f"Failed to finalize parsed payload: {payload_error}")
+                    logger.error("losers.finalize_payload.error: %s", payload_error)
                     yield stream.event(
                         "error",
                         {

--- a/consent-protocol/api/routes/kai/losers.py
+++ b/consent-protocol/api/routes/kai/losers.py
@@ -1097,7 +1097,8 @@ async def analyze_portfolio_losers_stream(
 
         except asyncio.TimeoutError:
             logger.warning(
-                f"[Losers Analysis] Hard timeout ({HARD_TIMEOUT_SECONDS}s) reached, stopping LLM"
+                "losers.analyze_stream.timeout: %s",
+                HARD_TIMEOUT_SECONDS,
             )
             yield stream.event(
                 "error",

--- a/consent-protocol/tests/test_losers_g004_loggers.py
+++ b/consent-protocol/tests/test_losers_g004_loggers.py
@@ -1,0 +1,64 @@
+"""
+HTTP proof tests for G004 logger fixes in kai/losers.py.
+
+Five logger calls used f-string interpolation (ruff G004).  They are now
+converted to %-style lazy formatting so ruff passes clean.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import api.routes.kai.losers as losers_mod
+from api.middleware import require_vault_owner_token
+
+VALID_UID = "test-uid"
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(losers_mod.router)
+    app.dependency_overrides[require_vault_owner_token] = lambda: {
+        "user_id": VALID_UID,
+        "token": "fake-token",
+        "scope": "vault.owner",
+    }
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_analyze_losers_endpoint_reachable(client: TestClient) -> None:
+    """POST /portfolio/analyze-losers must reach the handler (not 404/405)."""
+    payload = {
+        "user_id": VALID_UID,
+        "holdings": [],
+    }
+    resp = client.post("/portfolio/analyze-losers", json=payload)
+    # Handler may fail due to missing LLM/DB; we only assert the route resolves.
+    assert resp.status_code in {200, 400, 422, 500, 503}
+
+
+def test_no_f_string_loggers_in_module() -> None:
+    """Static check: none of the fixed logger calls use f-strings."""
+    import ast
+    import pathlib
+
+    src = pathlib.Path(losers_mod.__file__).read_text()
+    tree = ast.parse(src)
+
+    f_string_loggers: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr in {"warning", "error", "info", "debug"}):
+            continue
+        for arg in node.args:
+            if isinstance(arg, ast.JoinedStr):
+                f_string_loggers.append(node.lineno)
+
+    assert f_string_loggers == [], (
+        f"G004: f-string logger calls found at lines {f_string_loggers}"
+    )

--- a/consent-protocol/tests/test_losers_g004_loggers.py
+++ b/consent-protocol/tests/test_losers_g004_loggers.py
@@ -13,14 +13,19 @@ from fastapi.testclient import TestClient
 
 import api.routes.kai.losers as losers_mod
 from api.middleware import require_vault_owner_token
+from api.routes.kai import router as kai_router
 
 VALID_UID = "test-uid"
 
 
 @pytest.fixture(scope="module")
 def client() -> TestClient:
+    # kai_router is the exact object server.py mounts via
+    # app.include_router(kai_router); it carries the /api/kai prefix that
+    # losers_mod.router alone does not, so hitting it here proves the route
+    # is reachable on the canonical production path.
     app = FastAPI()
-    app.include_router(losers_mod.router)
+    app.include_router(kai_router)
     app.dependency_overrides[require_vault_owner_token] = lambda: {
         "user_id": VALID_UID,
         "token": "fake-token",
@@ -30,12 +35,12 @@ def client() -> TestClient:
 
 
 def test_analyze_losers_endpoint_reachable(client: TestClient) -> None:
-    """POST /portfolio/analyze-losers must reach the handler (not 404/405)."""
+    """POST /api/kai/portfolio/analyze-losers must reach the handler (not 404/405)."""
     payload = {
         "user_id": VALID_UID,
         "holdings": [],
     }
-    resp = client.post("/portfolio/analyze-losers", json=payload)
+    resp = client.post("/api/kai/portfolio/analyze-losers", json=payload)
     # Handler may fail due to missing LLM/DB; we only assert the route resolves.
     assert resp.status_code in {200, 400, 422, 500, 503}
 


### PR DESCRIPTION
## What

Six `logger.info/error` calls in `kai/losers.py` used f-string interpolation,
violating ruff **G004** and building the message string even when the level is
disabled.

## Changes

| File | Lines | Change |
|------|-------|--------|
| `api/routes/kai/losers.py` | 394, 869, 1028, 1053, 1078, 1124 | f-string → `%`-style; error-level calls also get structured `key.` prefixes |
| `tests/test_losers_g004_loggers.py` | new | TestClient proof + AST static check that no f-string loggers remain |

## Why

ruff G004 flags f-string logger arguments because the string is built eagerly
regardless of whether the logger level is active, wasting CPU on suppressed
levels. `%`-style formatting short-circuits when the level is off.

## Test plan

- [ ] `pytest tests/test_losers_g004_loggers.py` passes (AST static check included)
- [ ] `python3 -m ruff check consent-protocol/` passes clean