### PR TITLE
fix(agents): replace f-string loggers with %-style formatting (ruff G004)

### DIFF
--- a/consent-protocol/api/routes/agents.py
+++ b/consent-protocol/api/routes/agents.py
@@ -4,6 +4,11 @@ Agent chat endpoints for Kai Financial agent.
 
 Note: Food & Dining and Professional Profile agents have been deprecated
 in favor of the dynamic world model architecture.
+
+Canonical attach points
+-----------------------
+api.routes.agents.validate_token_endpoint -> POST /api/validate-token
+api.routes.agents.kai_chat                -> POST /api/agents/kai/chat
 """
 
 import logging
@@ -37,7 +42,7 @@ async def validate_token_endpoint(request: ValidateTokenRequest):
 
         if not valid:
             # SECURITY: Return generic message, log detailed reason server-side
-            logger.warning(f"Token validation failed: {reason}")
+            logger.warning("agents.validate_token.failed: %s", reason)
             return {"valid": False, "reason": "Token validation failed"}
 
         if token_obj is None:
@@ -52,7 +57,7 @@ async def validate_token_endpoint(request: ValidateTokenRequest):
         }
     except Exception as e:
         # SECURITY: Never expose exception details to client (CodeQL fix)
-        logger.error(f"Token validation error: {e}")
+        logger.error("agents.validate_token.error: %s", e)
         return {"valid": False, "reason": "Token validation failed"}
 
 
@@ -73,7 +78,7 @@ async def kai_chat(request: ChatRequest):
 
     Orchestrates multi-agent investment analysis (fundamental, sentiment, valuation).
     """
-    logger.info(f"📈 Kai Agent: user={request.userId}, msg='{request.message[:50]}...'")
+    logger.info("agents.kai_chat user=%s msg=%.50r", request.userId, request.message)
 
     try:
         result = get_kai_agent().handle_message(

--- a/consent-protocol/tests/test_agents_g004_loggers.py
+++ b/consent-protocol/tests/test_agents_g004_loggers.py
@@ -1,0 +1,65 @@
+"""
+HTTP proof tests for G004 logger fixes in api/routes/agents.py.
+
+Canonical attach points
+-----------------------
+api.routes.agents.validate_token_endpoint -> POST /api/validate-token
+api.routes.agents.kai_chat                -> POST /api/agents/kai/chat
+
+Three logger calls used f-string interpolation (ruff G004).  They are now
+converted to %-style lazy formatting so ruff passes clean.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import api.routes.agents as agents_mod
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(agents_mod.router)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_validate_token_endpoint_reachable(client: TestClient) -> None:
+    """POST /api/validate-token must reach the handler (not 404/405)."""
+    resp = client.post("/validate-token", json={"token": "invalid-token"})
+    # Handler returns a JSON dict (no HTTPException), so 200 even for invalid tokens.
+    assert resp.status_code == 200
+    assert "valid" in resp.json()
+
+
+def test_validate_token_returns_false_for_bad_token(client: TestClient) -> None:
+    resp = client.post("/validate-token", json={"token": "bad"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data.get("valid") is False
+
+
+def test_no_f_string_loggers_in_module() -> None:
+    """Static check: none of the fixed logger calls use f-strings."""
+    import ast
+    import pathlib
+
+    src = pathlib.Path(agents_mod.__file__).read_text()
+    tree = ast.parse(src)
+
+    f_string_loggers: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr in {"warning", "error", "info", "debug"}):
+            continue
+        for arg in node.args:
+            if isinstance(arg, ast.JoinedStr):
+                f_string_loggers.append(node.lineno)
+
+    assert f_string_loggers == [], (
+        f"G004: f-string logger calls found at lines {f_string_loggers}"
+    )


### PR DESCRIPTION
## What

Three `logger.warning/error/info` calls in `api/routes/agents.py` used f-string
interpolation, violating ruff **G004**.

## Changes

| File | Lines | Change |
|------|-------|--------|
| `api/routes/agents.py` | 40, 55, 76 | f-string → `%`-style; error/warning calls get structured `key.` prefixes; info call uses `%.50r` instead of manual `[:50]` slice |
| `tests/test_agents_g004_loggers.py` | new | TestClient proof for `/validate-token` + AST static check |

## Why

ruff G004 flags f-string logger arguments because they are evaluated eagerly
regardless of the effective log level. `%`-style formatting short-circuits
string construction when the level is suppressed.

## Test plan

- [ ] `pytest tests/test_agents_g004_loggers.py` passes
- [ ] `python3 -m ruff check consent-protocol/` passes clean