### PR TITLE
fix(kai-chat-service): replace f-string loggers with %-style formatting (ruff G004)

### DIFF
--- a/consent-protocol/hushh_mcp/services/kai_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/kai_chat_service.py
@@ -10,6 +10,12 @@ This service handles:
 5. Persistent chat history
 6. Proactive onboarding (portfolio import prompts)
 7. Intent classification for workflow triggers
+
+Canonical attach points
+-----------------------
+hushh_mcp.services.kai_chat_service.KaiChatService.process_message       -> POST /kai/chat
+hushh_mcp.services.kai_chat_service.KaiChatService.get_initial_chat_state -> GET /kai/chat/initial-state/{user_id}
+hushh_mcp.services.kai_chat_service.KaiChatService.analyze_portfolio_loser -> POST /kai/chat/analyze-loser
 """
 
 import asyncio
@@ -472,7 +478,7 @@ class KaiChatService:
             )
 
         except Exception as e:
-            logger.error(f"Error processing message: {e}")
+            logger.error("kai_chat_service.process_message.error: %s", e)
             # Return a graceful error response
             return KaiChatResponse(
                 conversation_id=conversation_id or "error",
@@ -616,7 +622,7 @@ class KaiChatService:
             }
 
         except Exception as e:
-            logger.error(f"Error checking data completeness: {e}")
+            logger.error("kai_chat_service.check_data_completeness.error: %s", e)
             return {
                 "has_portfolio": False,
                 "missing_attributes": [],
@@ -855,7 +861,7 @@ class KaiChatService:
             return response.text.strip(), tokens
 
         except Exception as e:
-            logger.error(f"Error generating response: {e}")
+            logger.error("kai_chat_service.generate_response.error: %s", e)
             return "I'm having trouble generating a response right now. Please try again.", None
 
     def _build_generation_prompt(
@@ -1090,7 +1096,7 @@ class KaiChatService:
             }
 
         except Exception as e:
-            logger.error(f"Error getting initial chat state: {e}")
+            logger.error("kai_chat_service.get_initial_chat_state.error: %s", e)
             # Return safe defaults for new user
             return {
                 "is_new_user": True,
@@ -1233,7 +1239,7 @@ REASONING: [2-3 sentences]
                 saved = True
 
             except Exception as e:
-                logger.warning(f"Failed to save analysis to PKM: {e}")
+                logger.warning("kai_chat_service.save_analysis_to_pkm.error: %s", e)
 
             # Store in chat history
             await self.chat_db.add_message(
@@ -1271,7 +1277,7 @@ REASONING: [2-3 sentences]
             }
 
         except Exception as e:
-            logger.error(f"Error analyzing loser {ticker}: {e}")
+            logger.error("kai_chat_service.analyze_portfolio_loser.error ticker=%s: %s", ticker, e)
             raise
 
 

--- a/consent-protocol/tests/test_kai_chat_service_g004_loggers.py
+++ b/consent-protocol/tests/test_kai_chat_service_g004_loggers.py
@@ -1,0 +1,79 @@
+"""
+HTTP proof tests for G004 logger fixes in hushh_mcp/services/kai_chat_service.py.
+
+Canonical attach points
+-----------------------
+hushh_mcp.services.kai_chat_service.KaiChatService.process_message        -> POST /kai/chat
+hushh_mcp.services.kai_chat_service.KaiChatService.get_initial_chat_state -> GET /kai/chat/initial-state/{user_id}
+hushh_mcp.services.kai_chat_service.KaiChatService.analyze_portfolio_loser -> POST /kai/chat/analyze-loser
+
+Six logger calls used f-string interpolation (ruff G004).  They are now
+converted to %-style lazy formatting so ruff passes clean.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import api.routes.kai.chat as chat_mod
+from api.middleware import require_vault_owner_token
+
+VALID_UID = "test-uid"
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(chat_mod.router)
+    app.dependency_overrides[require_vault_owner_token] = lambda: {
+        "user_id": VALID_UID,
+        "token": "fake-token",
+        "scope": "vault.owner",
+    }
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_chat_endpoint_reachable(client: TestClient) -> None:
+    """POST /chat must reach the handler (not 404/405)."""
+    resp = client.post(
+        "/chat",
+        json={"user_id": VALID_UID, "message": "Hello Kai"},
+    )
+    assert resp.status_code in {200, 400, 422, 500, 503}
+
+
+def test_initial_state_endpoint_reachable(client: TestClient) -> None:
+    """GET /chat/initial-state/{user_id} must reach the handler."""
+    resp = client.get(f"/chat/initial-state/{VALID_UID}")
+    assert resp.status_code in {200, 400, 422, 500, 503}
+
+
+def test_no_f_string_loggers_in_service() -> None:
+    """Static check: no logger calls use f-strings in kai_chat_service.py."""
+    import ast
+    import pathlib
+
+    import hushh_mcp.services.kai_chat_service as svc_mod
+
+    src = pathlib.Path(svc_mod.__file__).read_text()
+    tree = ast.parse(src)
+
+    f_string_loggers: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (
+            isinstance(func, ast.Attribute)
+            and func.attr in {"warning", "error", "info", "debug", "exception"}
+        ):
+            continue
+        for arg in node.args:
+            if isinstance(arg, ast.JoinedStr):
+                f_string_loggers.append(node.lineno)
+
+    assert f_string_loggers == [], (
+        f"G004: f-string logger calls found at lines {f_string_loggers}"
+    )


### PR DESCRIPTION
## What

Six `logger.error/warning` calls in `hushh_mcp/services/kai_chat_service.py`
used f-string interpolation, violating ruff **G004**.

## Changes

| File | Lines | Change |
|------|-------|--------|
| `hushh_mcp/services/kai_chat_service.py` | 475, 619, 858, 1093, 1236, 1274 | f-string → `%`-style with structured `module.method.event` prefixes |
| `tests/test_kai_chat_service_g004_loggers.py` | new | TestClient probes for chat and initial-state endpoints + AST static check |

## Why

ruff G004 flags f-string logger arguments because they are built eagerly
regardless of the effective log level. `%`-style formatting short-circuits
when the level is suppressed. Structured prefixes make log-pipeline filtering
consistent across the codebase.

## Test plan

- [ ] `pytest tests/test_kai_chat_service_g004_loggers.py` passes
- [ ] `python3 -m ruff check consent-protocol/` passes clean