### PR TITLE
fix(data-table): announce active row selection state to assistive technologies

### DIFF
--- a/hushh-webapp/components/app-ui/data-table.tsx
+++ b/hushh-webapp/components/app-ui/data-table.tsx
@@ -339,6 +339,7 @@ export function DataTable<TData, TValue>({
                 <TableRow
                   key={row.id}
                   data-state={row.getIsSelected() && "selected"}
+                  aria-selected={row.getIsSelected() || undefined}
                   className={cn(
                     onRowClick
                       ? "cursor-pointer transition-[background-color,transform] duration-200 ease-out hover:-translate-y-px hover:bg-foreground/[0.045] active:translate-y-0 active:bg-foreground/[0.065]"


### PR DESCRIPTION
## Summary

Selectable DataTable rows exposed visual selection state through `data-state="selected"` only, providing no semantic selected-state feedback for assistive technologies.

This update improves accessibility semantics by exposing row selection state through `aria-selected` while preserving the existing table behavior and layout.

## What's covered

`components/app-ui/data-table.tsx`

Added semantic row-selection state support for shared DataTable rows.

## Key improvements

- adds `aria-selected` to selectable table rows
- mirrors the existing visual selected row state
- omits the attribute automatically when rows are not selected
- preserves existing row selection behavior
- introduces no new selection logic or state

## Reachable surfaces

- authenticated routes rendering selectable `DataTable` components
- RIA table views
- shared selectable table surfaces using row selection

## Validation

- `npx tsc --noEmit`
- `npm run lint`

## Notes

- frontend-only accessibility improvement
- no runtime/business logic changes
- no layout or interaction changes
- no backend/schema/cache impacts
- DCO sign-off included