### PR TITLE
fix(decisions): cap offset at 10_000 to prevent O(N) DB amplification

### DIFF
--- a/consent-protocol/api/routes/kai/decisions.py
+++ b/consent-protocol/api/routes/kai/decisions.py
@@ -4,12 +4,16 @@ Kai Decision Endpoints — reads decision projections from PKM mutation events.
 
 Legacy summary parsing is retained only as a fallback for older records.
 Write operations remain client-side via POST /api/pkm/store-domain.
+
+Canonical attach points
+-----------------------
+api.routes.kai.decisions.get_decision_history -> GET /kai/decisions/{user_id}
 """
 
 import logging
 from typing import Dict, List
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
 from pydantic import BaseModel
 
 from api.middleware import require_vault_owner_token
@@ -37,9 +41,9 @@ class DecisionHistoryResponse(BaseModel):
 
 @router.get("/decisions/{user_id}", response_model=DecisionHistoryResponse)
 async def get_decision_history(
-    user_id: str,
-    limit: int = Query(default=50, le=100),
-    offset: int = Query(default=0, ge=0),
+    user_id: str = Path(..., min_length=1, max_length=128),
+    limit: int = Query(default=50, ge=1, le=100),
+    offset: int = Query(default=0, ge=0, le=10_000),
     token_data: dict = Depends(require_vault_owner_token),
 ):
     """

--- a/consent-protocol/tests/test_decisions_offset_cap.py
+++ b/consent-protocol/tests/test_decisions_offset_cap.py
@@ -1,0 +1,68 @@
+"""
+HTTP proof tests for offset cap + user_id Path bounds on the decisions endpoint.
+
+Canonical attach point
+----------------------
+api.routes.kai.decisions.get_decision_history -> GET /kai/decisions/{user_id}
+
+Two bugs fixed:
+1. offset had no upper bound (ge=0 only) — a caller could send offset=1_000_000,
+   causing the service to be asked for limit+offset=1_000_100 records, then
+   discard all but `limit` of them in Python (O(N) amplification).
+2. user_id path param had no max_length — arbitrary-length strings reached the DB.
+
+Fix: offset now has le=10_000; user_id has min_length=1, max_length=128.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import api.routes.kai.decisions as decisions_mod
+from api.middleware import require_vault_owner_token
+
+VALID_UID = "test-uid"
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(decisions_mod.router)
+    app.dependency_overrides[require_vault_owner_token] = lambda: {
+        "user_id": VALID_UID,
+        "token": "fake-token",
+        "scope": "vault.owner",
+    }
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_decisions_endpoint_reachable(client: TestClient) -> None:
+    """GET /decisions/{user_id} must reach the handler."""
+    resp = client.get(f"/decisions/{VALID_UID}")
+    assert resp.status_code in {200, 400, 403, 422, 500, 503}
+
+
+def test_decisions_offset_over_cap_returns_422(client: TestClient) -> None:
+    """offset > 10_000 must be rejected with 422."""
+    resp = client.get(f"/decisions/{VALID_UID}", params={"offset": 10_001})
+    assert resp.status_code == 422
+
+
+def test_decisions_offset_at_cap_accepted(client: TestClient) -> None:
+    """offset == 10_000 must pass validation (may fail for other reasons)."""
+    resp = client.get(f"/decisions/{VALID_UID}", params={"offset": 10_000})
+    assert resp.status_code != 422
+
+
+def test_decisions_overlong_user_id_returns_422(client: TestClient) -> None:
+    """user_id longer than 128 chars must be rejected with 422."""
+    resp = client.get(f"/decisions/{'x' * 129}")
+    assert resp.status_code == 422
+
+
+def test_decisions_valid_params_reach_handler(client: TestClient) -> None:
+    """limit=10, offset=5 must reach the handler."""
+    resp = client.get(f"/decisions/{VALID_UID}", params={"limit": 10, "offset": 5})
+    assert resp.status_code in {200, 400, 403, 500, 503}


### PR DESCRIPTION
## What

`get_decision_history` in `kai/decisions.py` had two bugs:

### Bug 1: Unbounded offset → O(N) DB amplification

```python
# before
offset: int = Query(default=0, ge=0)          # no upper bound
...
decisions = await pkm_service.get_recent_decision_records(
    user_id,
    limit=limit + offset,                      # amplified fetch!
)
decisions = decisions[offset : offset + limit] # then discard offset rows
```

With `offset=1_000_000` and `limit=100` the service is asked for
**1,000,100 rows** from the database, 1,000,000 of which are immediately
discarded in Python. A caller can trivially trigger a multi-million-row
DB scan with a single authenticated request.

**Fix**: `le=10_000` caps the worst-case DB fetch at `10_100` rows.

### Bug 2: Unbounded `user_id` path param

`user_id: str` had no `min_length` / `max_length`, so arbitrarily long
strings reached the DB query layer.

**Fix**: `Path(min_length=1, max_length=128)`.

## Changes

| File | Change |
|------|--------|
| `api/routes/kai/decisions.py` | `offset` → `le=10_000`; `user_id` → `Path(max_length=128)`; `limit` → `ge=1` |
| `tests/test_decisions_offset_cap.py` | TestClient proof — 422 on `offset=10_001` and on overlong `user_id` |

## Test plan

- [ ] `pytest tests/test_decisions_offset_cap.py` passes
- [ ] `python3 -m ruff check consent-protocol/` passes clean
- [ ] `GET /decisions/{user_id}?offset=10001` returns 422
- [ ] `GET /decisions/{'x'*129}` returns 422