### PR TITLE
Normalize empty PKM reads after vault creation

### DIFF
--- a/hushh-webapp/__tests__/api/pkm/proxy-route.test.ts
+++ b/hushh-webapp/__tests__/api/pkm/proxy-route.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/app/api/_utils/backend", () => ({
+  getPythonApiUrl: () => "http://backend.test",
+}));
+
+type PkmRouteModule = {
+  GET: (req: NextRequest, ctx: { params: Promise<{ path: string[] }> }) => Promise<Response>;
+};
+
+let pkmRoute: PkmRouteModule;
+
+beforeEach(async () => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  pkmRoute = await import("../../../app/api/pkm/[...path]/route");
+});
+
+function createRequest(url: string): NextRequest {
+  return new NextRequest(url, {
+    method: "GET",
+    headers: {
+      Authorization: "Bearer vault_owner_token",
+    },
+  });
+}
+
+describe("/api/pkm/[...path] proxy", () => {
+  it("normalizes missing metadata to an empty bootstrap payload", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ detail: "No PKM data found for user" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    const response = await pkmRoute.GET(
+      createRequest("http://localhost:3000/api/pkm/metadata/user-1"),
+      { params: Promise.resolve({ path: ["metadata", "user-1"] }) }
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-hushh-empty-state")).toBe("pkm-metadata");
+    expect(payload).toMatchObject({
+      user_id: "user-1",
+      domains: [],
+      total_attributes: 0,
+      upgrade_status: "current",
+    });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://backend.test/api/pkm/metadata/user-1",
+      expect.objectContaining({ method: "GET" })
+    );
+  });
+
+  it("normalizes missing domain data to a null encrypted blob", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ detail: "No ria data found for user" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    const response = await pkmRoute.GET(
+      createRequest("http://localhost:3000/api/pkm/domain-data/user-1/ria"),
+      { params: Promise.resolve({ path: ["domain-data", "user-1", "ria"] }) }
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-hushh-empty-state")).toBe("pkm-domain-data");
+    expect(payload).toEqual({
+      encrypted_blob: null,
+      storage_mode: "domain",
+      data_version: null,
+      updated_at: null,
+      manifest_revision: null,
+      segment_ids: [],
+    });
+  });
+});

--- a/hushh-webapp/__tests__/components/vault-flow-create-validation.test.tsx
+++ b/hushh-webapp/__tests__/components/vault-flow-create-validation.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { VaultFlow } from "@/components/vault/vault-flow";
+
+const checkVaultMock = vi.fn();
+const unlockVaultMock = vi.fn();
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: {
+    isNativePlatform: () => false,
+  },
+}));
+
+vi.mock("@/lib/services/vault-service", () => ({
+  VaultService: {
+    checkVault: (...args: unknown[]) => checkVaultMock(...args),
+  },
+}));
+
+vi.mock("@/lib/vault/vault-context", () => ({
+  useVault: () => ({
+    unlockVault: unlockVaultMock,
+  }),
+}));
+
+vi.mock("@/lib/services/vault-method-service", () => ({
+  VaultMethodService: {},
+}));
+
+vi.mock("@/lib/services/vault-method-prompt-local-service", () => ({
+  VaultMethodPromptLocalService: {},
+}));
+
+vi.mock("@/lib/utils/native-download", () => ({
+  downloadTextFile: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/clipboard", () => ({
+  copyToClipboard: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/browser-navigation", () => ({
+  reloadWindow: vi.fn(),
+}));
+
+describe("VaultFlow create validation", () => {
+  const user = { uid: "user-1" } as Parameters<typeof VaultFlow>[0]["user"];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    checkVaultMock.mockResolvedValue(false);
+  });
+
+  it("explains why Create Vault is disabled for short or mismatched passphrases", async () => {
+    render(<VaultFlow user={user} onSuccess={vi.fn()} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /continue to vault setup/i }));
+
+    const passphraseInput = screen.getByLabelText("Passphrase");
+    const confirmInput = screen.getByLabelText("Confirm Passphrase");
+    const createButton = screen.getByRole("button", { name: "Create Vault" }) as HTMLButtonElement;
+
+    fireEvent.change(passphraseInput, { target: { value: "short" } });
+    expect(await screen.findByText("Minimum 8 characters required.")).toBeTruthy();
+    expect(createButton.disabled).toBe(true);
+
+    fireEvent.change(passphraseInput, { target: { value: "long-enough" } });
+    fireEvent.change(confirmInput, { target: { value: "different" } });
+    expect(await screen.findByText("Passphrases do not match.")).toBeTruthy();
+    expect(createButton.disabled).toBe(true);
+  });
+});

--- a/hushh-webapp/__tests__/services/pkm-cache.test.ts
+++ b/hushh-webapp/__tests__/services/pkm-cache.test.ts
@@ -191,6 +191,40 @@ describe("PKM cache behavior", () => {
     expect(apiFetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("short-caches missing domain data so empty PKM domains do not refetch immediately", async () => {
+    apiFetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          encrypted_blob: null,
+          storage_mode: "domain",
+          data_version: null,
+          updated_at: null,
+          manifest_revision: null,
+          segment_ids: [],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+
+    const first = await PersonalKnowledgeModelService.getDomainData(
+      "user-1",
+      "ria",
+      "vault-owner-token"
+    );
+    const second = await PersonalKnowledgeModelService.getDomainData(
+      "user-1",
+      "ria",
+      "vault-owner-token"
+    );
+
+    expect(first).toBeNull();
+    expect(second).toBeNull();
+    expect(apiFetchMock).toHaveBeenCalledTimes(1);
+    expect(
+      CacheService.getInstance().peek(CACHE_KEYS.ENCRYPTED_DOMAIN_BLOB("user-1", "ria"))?.data
+    ).toBeNull();
+  });
+
   it("supports targeted segment reads for manifest-backed paths", async () => {
     apiFetchMock.mockImplementation(async (url: string) => {
       if (url.includes("/api/pkm/domain-data/user-1/health")) {

--- a/hushh-webapp/app/api/pkm/[...path]/route.ts
+++ b/hushh-webapp/app/api/pkm/[...path]/route.ts
@@ -7,6 +7,7 @@ import {
   withRequestIdJson,
 } from "@/app/api/_utils/request-id";
 import { createHotGetJsonCache } from "@/app/api/_utils/hot-get-json-cache";
+import { CURRENT_PKM_MODEL_VERSION } from "@/lib/personal-knowledge-model/upgrade-contracts";
 
 export const dynamic = "force-dynamic";
 const metadataHotGet = createHotGetJsonCache({
@@ -18,6 +19,80 @@ const PKM_PROXY_WRITE_TIMEOUT_MS = Number.parseInt(
   process.env.PKM_PROXY_WRITE_TIMEOUT_MS ?? "180000",
   10
 );
+
+type PkmProxyResult = {
+  status: number;
+  payload: unknown;
+  correlationId: string | null;
+  traceId: string | null;
+  emptyState?: "pkm-metadata" | "pkm-domain-data";
+};
+
+function decodePathSegment(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function emptyMetadataPayload(pathStr: string) {
+  const encodedUserId = pathStr.slice("metadata/".length).split("/")[0] || "";
+  const userId = decodePathSegment(encodedUserId);
+  return {
+    user_id: userId,
+    domains: [],
+    total_attributes: 0,
+    model_completeness: 0,
+    model_version: CURRENT_PKM_MODEL_VERSION,
+    stored_model_version: CURRENT_PKM_MODEL_VERSION,
+    effective_model_version: CURRENT_PKM_MODEL_VERSION,
+    target_model_version: CURRENT_PKM_MODEL_VERSION,
+    upgrade_status: "current",
+    upgradable_domains: [],
+    last_upgraded_at: null,
+    suggested_domains: [],
+    last_updated: null,
+  };
+}
+
+function emptyDomainDataPayload() {
+  return {
+    encrypted_blob: null,
+    storage_mode: "domain",
+    data_version: null,
+    updated_at: null,
+    manifest_revision: null,
+    segment_ids: [],
+  };
+}
+
+function normalizeEmptyPkmGet(
+  method: "GET" | "POST" | "PUT" | "DELETE",
+  pathStr: string,
+  result: PkmProxyResult
+): PkmProxyResult {
+  if (method !== "GET" || result.status !== 404) {
+    return result;
+  }
+  if (pathStr.startsWith("metadata/")) {
+    return {
+      ...result,
+      status: 200,
+      payload: emptyMetadataPayload(pathStr),
+      emptyState: "pkm-metadata",
+    };
+  }
+  if (pathStr.startsWith("domain-data/")) {
+    return {
+      ...result,
+      status: 200,
+      payload: emptyDomainDataPayload(),
+      emptyState: "pkm-domain-data",
+    };
+  }
+  return result;
+}
 
 async function proxyPkmRequest(
   request: NextRequest,
@@ -65,7 +140,7 @@ async function proxyPkmRequest(
       }
     }
 
-    const load = (async () => {
+    const load = (async (): Promise<PkmProxyResult> => {
       const timeoutMs =
         method === "POST" || method === "PUT" || method === "DELETE"
           ? PKM_PROXY_WRITE_TIMEOUT_MS
@@ -95,7 +170,7 @@ async function proxyPkmRequest(
       metadataHotGet.setInflight(hotCacheKey, load);
     }
 
-    const result = await load;
+    const result = normalizeEmptyPkmGet(method, pathStr, await load);
     if (hotCacheKey && result.status < 500) {
       metadataHotGet.write(hotCacheKey, result);
     } else if (hotCacheKey && result.status >= 500) {
@@ -113,6 +188,9 @@ async function proxyPkmRequest(
     }
     if (result.traceId) {
       responseHeaders["x-cloud-trace-context"] = result.traceId;
+    }
+    if (result.emptyState) {
+      responseHeaders["x-hushh-empty-state"] = result.emptyState;
     }
     return withRequestIdJson(requestId, result.payload, {
       status: result.status,

--- a/hushh-webapp/app/profile/page.tsx
+++ b/hushh-webapp/app/profile/page.tsx
@@ -3682,7 +3682,7 @@ function ProfilePageContent() {
             setShowVaultCreation(false);
             setHasVault(true);
             VaultService.setVaultCheckCache(user.uid, true);
-            toast.success("Vault created.");
+            toast.success("Vault created and unlocked.");
           }}
         />
       )}

--- a/hushh-webapp/components/vault/vault-flow.tsx
+++ b/hushh-webapp/components/vault/vault-flow.tsx
@@ -111,6 +111,17 @@ export function VaultFlow({
     isGeneratedVaultMode && availableGeneratedMethod === vaultMode;
   const shouldShowPassphraseUnlock =
     !hasActiveGeneratedWrapper || unlockWithPassphraseFallback;
+  const createPassphraseTooShort =
+    step === "create" && passphrase.length > 0 && passphrase.length < 8;
+  const createPassphraseMismatch =
+    step === "create" &&
+    confirmPassphrase.length > 0 &&
+    passphrase !== confirmPassphrase;
+  const createPassphraseHelperText = createPassphraseTooShort
+    ? "Minimum 8 characters required."
+    : createPassphraseMismatch
+      ? "Passphrases do not match."
+      : null;
 
   const generatedUnlockLabel =
     vaultMode === "generated_default_web_prf" ||
@@ -648,6 +659,11 @@ export function VaultFlow({
                   onChange={(e) => setConfirmPassphrase(e.target.value)}
                   className="h-11 px-3 text-base sm:h-12 sm:px-4 sm:text-lg"
                 />
+                {createPassphraseHelperText && (
+                  <p className="text-xs font-medium text-destructive" role="status">
+                    {createPassphraseHelperText}
+                  </p>
+                )}
               </div>
               <div className="rounded-xl border border-border/60 bg-muted/20 p-2.5 text-[11px] text-muted-foreground sm:p-3 sm:text-sm">
                 <p className="font-semibold text-foreground">Passphrase requirements</p>

--- a/hushh-webapp/lib/services/personal-knowledge-model-service.ts
+++ b/hushh-webapp/lib/services/personal-knowledge-model-service.ts
@@ -2704,9 +2704,12 @@ export class PersonalKnowledgeModelService {
     const canUseCache = normalizedSegmentIds.length === 0;
     const cacheKey = CACHE_KEYS.ENCRYPTED_DOMAIN_BLOB(userId, domain);
     if (canUseCache) {
-      const cached = cache.get<EncryptedDomainBlob>(cacheKey);
-      if (cached) {
-        return cached;
+      const cached = cache.peek<EncryptedDomainBlob | null>(cacheKey);
+      if (cached?.isFresh) {
+        return cached.data;
+      }
+      if (cached?.isStale) {
+        cache.invalidate(cacheKey);
       }
     }
 
@@ -2833,7 +2836,7 @@ export class PersonalKnowledgeModelService {
       if (encryptedBlob && canUseCache) {
         cache.set(cacheKey, encryptedBlob, CACHE_TTL.SESSION);
       } else if (!encryptedBlob && canUseCache) {
-        cache.invalidate(cacheKey);
+        cache.set(cacheKey, null, CACHE_TTL.SHORT);
       }
 
       return encryptedBlob;


### PR DESCRIPTION
## Summary
- Normalize expected empty PKM metadata/domain-data reads in the web proxy so new vault users do not see noisy browser 404s.
- Short-cache missing encrypted domain blobs on the frontend PKM client.
- Add live passphrase validation helper text and clarify vault creation success copy.

## Tests
- cd hushh-webapp && npx vitest run __tests__/api/pkm/proxy-route.test.ts __tests__/services/pkm-cache.test.ts __tests__/components/vault-flow-create-validation.test.tsx
- cd hushh-webapp && npm run typecheck
- curl -I http://localhost:3002/profile

## UAT
- Frontend-only deploy after merge.
- Backend PKM semantics remain unchanged.