### PR TITLE
fix(domain-registry): convert 7 G004 f-string loggers to %-style in DomainRegistryService

### DIFF
--- a/consent-protocol/hushh_mcp/services/domain_registry_service.py
+++ b/consent-protocol/hushh_mcp/services/domain_registry_service.py
@@ -4,6 +4,14 @@ Domain Registry Service - Dynamic domain discovery and management.
 
 This service manages the domain_registry table which tracks all domains
 dynamically without hardcoded enums. Domains are auto-registered on first use.
+
+Attach points:
+- DomainRegistryService.auto_register_domain
+- DomainRegistryService.get_domain
+- DomainRegistryService.list_domains
+- DomainRegistryService.get_user_domains
+- DomainRegistryService.update_domain
+- DomainRegistryService.delete_domain
 """
 
 import logging
@@ -342,7 +350,7 @@ class DomainRegistryService:
                 self._cache_time = datetime.utcnow()
                 return domain_info
         except Exception as e:
-            logger.warning(f"RPC auto_register_domain failed, falling back to direct insert: {e}")
+            logger.warning("domain_registry.auto_register.rpc_failed domain=%s, falling back: %s", domain_key, e)
 
         # Fallback: Direct upsert
         try:
@@ -372,7 +380,7 @@ class DomainRegistryService:
                 self._cache_time = datetime.utcnow()
                 return domain_info
         except Exception as e:
-            logger.error(f"Error registering domain {domain_key}: {e}")
+            logger.error("domain_registry.auto_register.error domain=%s: %s", domain_key, e)
 
         # Return minimal info if all else fails
         return DomainInfo(
@@ -405,7 +413,7 @@ class DomainRegistryService:
             self._cache[domain_key] = domain_info
             return domain_info
         except Exception as e:
-            logger.error(f"Error getting domain {domain_key}: {e}")
+            logger.error("domain_registry.get_domain.error domain=%s: %s", domain_key, e)
             return None
 
     async def list_domains(self, include_empty: bool = False) -> list[DomainInfo]:
@@ -432,7 +440,7 @@ class DomainRegistryService:
 
             return domains
         except Exception as e:
-            logger.error(f"Error listing domains: {e}")
+            logger.error("domain_registry.list_domains.error: %s", e)
             return []
 
     async def get_user_domains(self, user_id: str) -> list[DomainInfo]:
@@ -469,7 +477,7 @@ class DomainRegistryService:
                     domains.append(domain_info)
             return sorted(domains, key=lambda d: d.display_name)
         except Exception as e:
-            logger.error(f"Error getting user domains for {user_id}: {e}")
+            logger.error("domain_registry.get_user_domains.error user_id=%s: %s", user_id, e)
             return []
 
     async def update_domain(
@@ -503,7 +511,7 @@ class DomainRegistryService:
             self._invalidate_cache()
             return True
         except Exception as e:
-            logger.error(f"Error updating domain {domain_key}: {e}")
+            logger.error("domain_registry.update_domain.error domain=%s: %s", domain_key, e)
             return False
 
     async def delete_domain(self, domain_key: str) -> bool:
@@ -519,7 +527,7 @@ class DomainRegistryService:
             self._invalidate_cache()
             return True
         except Exception as e:
-            logger.error(f"Error deleting domain {domain_key}: {e}")
+            logger.error("domain_registry.delete_domain.error domain=%s: %s", domain_key, e)
             return False
 
     def _row_to_domain_info(self, row: dict) -> DomainInfo:

--- a/consent-protocol/tests/test_domain_registry_g004.py
+++ b/consent-protocol/tests/test_domain_registry_g004.py
@@ -1,0 +1,35 @@
+# tests/test_domain_registry_g004.py
+"""
+PR attach points: DomainRegistryService methods
+                  (hushh_mcp/services/domain_registry_service.py)
+
+AST static check: verifies no f-string logger calls (G004) remain in
+domain_registry_service.py after the fix.
+"""
+
+import ast
+import pathlib
+
+
+def test_no_f_string_loggers_in_domain_registry_service() -> None:
+    """No f-string logger calls (G004) must remain in domain_registry_service.py."""
+    import hushh_mcp.services.domain_registry_service as module
+
+    src = pathlib.Path(module.__file__).read_text()
+    tree = ast.parse(src)
+    bad_lines: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (
+            isinstance(func, ast.Attribute)
+            and func.attr in {"warning", "error", "info", "debug", "exception"}
+        ):
+            continue
+        for arg in node.args:
+            if isinstance(arg, ast.JoinedStr):
+                bad_lines.append(node.lineno)
+    assert bad_lines == [], (
+        f"G004: f-string logger calls found at lines {bad_lines} in domain_registry_service.py"
+    )


### PR DESCRIPTION
## Problem

Seven logger calls in `hushh_mcp/services/domain_registry_service.py` used f-strings as the format argument (ruff **G004**):

```python
# before — string interpolation fires even when log level is suppressed
logger.warning(f"RPC auto_register_domain failed, falling back to direct insert: {e}")
logger.error(f"Error registering domain {domain_key}: {e}")
logger.error(f"Error getting domain {domain_key}: {e}")
logger.error(f"Error listing domains: {e}")
logger.error(f"Error getting user domains for {user_id}: {e}")
logger.error(f"Error updating domain {domain_key}: {e}")
logger.error(f"Error deleting domain {domain_key}: {e}")
```

## Fix

All seven converted to `%`-style lazy formatting with structured `key=value` context:

```python
logger.warning("domain_registry.auto_register.rpc_failed domain=%s, falling back: %s", domain_key, e)
logger.error("domain_registry.auto_register.error domain=%s: %s", domain_key, e)
# … etc.
```

## Test

`tests/test_domain_registry_g004.py` — AST walk over the compiled module source confirms zero `JoinedStr` arguments remain in any logger call.

## Attach points

- `DomainRegistryService.auto_register_domain`
- `DomainRegistryService.get_domain`
- `DomainRegistryService.list_domains`
- `DomainRegistryService.get_user_domains`
- `DomainRegistryService.update_domain`
- `DomainRegistryService.delete_domain`