### PR TITLE
fix(services): convert G004 f-string loggers in attribute_learner, investor_db, vault_keys, portfolio_parser

### DIFF
--- a/consent-protocol/hushh_mcp/services/attribute_learner.py
+++ b/consent-protocol/hushh_mcp/services/attribute_learner.py
@@ -138,10 +138,10 @@ class AttributeLearner:
             return attributes
 
         except json.JSONDecodeError as e:
-            logger.warning(f"Failed to parse attribute extraction response: {e}")
+            logger.warning("attribute_learner.extract.json_decode_error: %s", e)
             return []
         except Exception as e:
-            logger.error(f"Error extracting attributes: {e}")
+            logger.error("attribute_learner.extract.error: %s", e)
             return []
 
     async def extract_and_store(
@@ -202,10 +202,13 @@ class AttributeLearner:
                             }
                         )
                         logger.info(
-                            f"Recorded learned attribute inference: {domain}.{key} for user {user_id}"
+                            "attribute_learner.stored domain=%s key=%s user_id=%s",
+                            domain,
+                            key,
+                            user_id,
                         )
             except Exception as e:
-                logger.error(f"Error storing inferred attribute event for {domain}: {e}")
+                logger.error("attribute_learner.store.error domain=%s: %s", domain, e)
 
         return stored
 

--- a/consent-protocol/hushh_mcp/services/investor_db.py
+++ b/consent-protocol/hushh_mcp/services/investor_db.py
@@ -335,5 +335,5 @@ class InvestorDBService:
             raise Exception("Failed to upsert investor profile")
 
         except Exception as e:
-            logger.error(f"Error upserting investor: {e}")
+            logger.error("investor_db.upsert_investor.error: %s", e)
             raise

--- a/consent-protocol/hushh_mcp/services/portfolio_parser.py
+++ b/consent-protocol/hushh_mcp/services/portfolio_parser.py
@@ -119,7 +119,7 @@ class PortfolioParser:
                 return self._parse_generic_csv(content, filename)
 
         except Exception as e:
-            logger.error(f"Error parsing CSV: {e}")
+            logger.error("portfolio_parser.parse_csv.error filename=%r: %s", filename, e)
             return Portfolio(holdings=[], broker=broker, source_filename=filename)
 
     def _detect_broker(self, content: str) -> BrokerType:

--- a/consent-protocol/hushh_mcp/services/vault_keys_service.py
+++ b/consent-protocol/hushh_mcp/services/vault_keys_service.py
@@ -1247,7 +1247,7 @@ class VaultKeysService:
                     prefs_summary.get("field_count", 0) if isinstance(prefs_summary, dict) else 0
                 )
         except Exception as e:  # pragma: no cover
-            logger.warning(f"Failed to check pkm_index for vault status: {e}")
+            logger.warning("vault_keys.get_vault_status.pkm_index_check_failed: %s", e)
 
         domains = {
             "kai": {
@@ -1260,6 +1260,6 @@ class VaultKeysService:
         total_active = 1 if kai_has_data else 0
         total = 1
 
-        logger.info(f"✅ Vault status for {user_id}: {total_active}/{total} domains active")
+        logger.info("vault_keys.vault_status user_id=%s active=%d/%d", user_id, total_active, total)
 
         return {"domains": domains, "totalActive": total_active, "total": total}

--- a/consent-protocol/tests/test_services_g004_batch.py
+++ b/consent-protocol/tests/test_services_g004_batch.py
@@ -1,0 +1,61 @@
+# tests/test_services_g004_batch.py
+"""
+PR attach points:
+- AttributeLearner.extract_attributes / extract_and_store  (attribute_learner.py)
+- InvestorDBService.upsert_investor                        (investor_db.py)
+- VaultKeysService.get_vault_status                        (vault_keys_service.py)
+- PortfolioParser.parse_csv                                (portfolio_parser.py)
+
+AST static check: verifies no f-string logger calls (G004) remain in
+each of the four service modules.
+"""
+
+import ast
+import pathlib
+
+
+def _f_string_logger_lines(module) -> list[int]:
+    src = pathlib.Path(module.__file__).read_text()
+    tree = ast.parse(src)
+    bad: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (
+            isinstance(func, ast.Attribute)
+            and func.attr in {"warning", "error", "info", "debug", "exception"}
+        ):
+            continue
+        for arg in node.args:
+            if isinstance(arg, ast.JoinedStr):
+                bad.append(node.lineno)
+    return bad
+
+
+def test_no_g004_in_attribute_learner() -> None:
+    import hushh_mcp.services.attribute_learner as module
+
+    bad = _f_string_logger_lines(module)
+    assert bad == [], f"G004 f-string loggers at lines {bad} in attribute_learner.py"
+
+
+def test_no_g004_in_investor_db() -> None:
+    import hushh_mcp.services.investor_db as module
+
+    bad = _f_string_logger_lines(module)
+    assert bad == [], f"G004 f-string loggers at lines {bad} in investor_db.py"
+
+
+def test_no_g004_in_vault_keys_service() -> None:
+    import hushh_mcp.services.vault_keys_service as module
+
+    bad = _f_string_logger_lines(module)
+    assert bad == [], f"G004 f-string loggers at lines {bad} in vault_keys_service.py"
+
+
+def test_no_g004_in_portfolio_parser() -> None:
+    import hushh_mcp.services.portfolio_parser as module
+
+    bad = _f_string_logger_lines(module)
+    assert bad == [], f"G004 f-string loggers at lines {bad} in portfolio_parser.py"


### PR DESCRIPTION
## Problem

Four service modules contained f-string logger arguments (ruff **G004**): string interpolation fires at the call-site even when the log level is disabled, wasting CPU on every hot-path log statement.

## Affected files

| File | Loggers fixed |
|------|--------------|
| `hushh_mcp/services/attribute_learner.py` | 4 |
| `hushh_mcp/services/investor_db.py` | 1 |
| `hushh_mcp/services/vault_keys_service.py` | 2 |
| `hushh_mcp/services/portfolio_parser.py` | 1 |

**Total: 8 loggers converted** from `logger.error(f"...")` to `logger.error("...", arg1, arg2)`.

## Changes

All f-string arguments replaced with `%`-style lazy formatting using structured `key=value` context where applicable. No behaviour change — only the interpolation now happens inside the logging framework (and only when the level is active).

## Test

`tests/test_services_g004_batch.py` — one AST-walk assertion per module that confirms zero `JoinedStr` nodes remain as logger arguments.

## Attach points

- `AttributeLearner.extract_attributes` / `extract_and_store`
- `InvestorDBService.upsert_investor`
- `VaultKeysService.get_vault_status`
- `PortfolioParser.parse_csv`