### PR TITLE
fix(consent-db): convert 8 G004 f-string loggers to %-style in ConsentDBService

### DIFF
--- a/consent-protocol/hushh_mcp/services/consent_db.py
+++ b/consent-protocol/hushh_mcp/services/consent_db.py
@@ -1255,7 +1255,9 @@ class ConsentDBService:
         else:
             # Fallback: return issued_at as ID if response doesn't have id
             logger.warning(
-                f"Inserted {action} event but no ID returned, using issued_at: {issued_at}"
+                "consent_db.insert_event.missing_id action=%s issued_at=%s",
+                action,
+                issued_at,
             )
             return issued_at
 

--- a/consent-protocol/hushh_mcp/services/consent_db.py
+++ b/consent-protocol/hushh_mcp/services/consent_db.py
@@ -9,6 +9,13 @@ CONSENT-FIRST ARCHITECTURE:
     All consent operations go through this service.
     Provides methods for pending requests, active tokens, and audit logs.
 
+Attach points:
+- ConsentDBService.insert_event
+- ConsentDBService.store_consent_export
+- ConsentDBService.get_consent_export
+- ConsentDBService.delete_consent_export
+- ConsentDBService.cleanup_expired_exports
+
 Usage:
     from hushh_mcp.services.consent_db import ConsentDBService
 
@@ -1243,7 +1250,7 @@ class ConsentDBService:
         # Extract event ID from response
         if response.data and len(response.data) > 0:
             event_id = response.data[0].get("id")
-            logger.info(f"Inserted {action} event: {event_id}")
+            logger.info("consent_db.insert_event action=%s event_id=%s", action, event_id)
             return event_id
         else:
             # Fallback: return issued_at as ID if response doesn't have id
@@ -1731,10 +1738,10 @@ class ConsentDBService:
                 on_conflict="consent_token",
             ).execute()
 
-            logger.info(f"Stored consent export for token: {consent_token[:30]}...")
+            logger.info("consent_db.store_export token=%.30s...", consent_token)
             return True
         except Exception as e:
-            logger.error(f"Failed to store consent export: {e}")
+            logger.error("consent_db.store_export.error: %s", e)
             return False
 
     async def get_consent_export(self, consent_token: str) -> Optional[Dict]:
@@ -1763,7 +1770,7 @@ class ConsentDBService:
                 return self._normalize_export_row(response.data[0])
             return None
         except Exception as e:
-            logger.error(f"Failed to get consent export: {e}")
+            logger.error("consent_db.get_export.error: %s", e)
             return None
 
     async def get_consent_export_metadata(self, consent_token: str) -> Optional[Dict[str, Any]]:
@@ -1811,10 +1818,10 @@ class ConsentDBService:
         try:
             supabase.table("consent_exports").delete().eq("consent_token", consent_token).execute()
 
-            logger.info(f"Deleted consent export for token: {consent_token[:30]}...")
+            logger.info("consent_db.delete_export token=%.30s...", consent_token)
             return True
         except Exception as e:
-            logger.error(f"Failed to delete consent export: {e}")
+            logger.error("consent_db.delete_export.error: %s", e)
             return False
 
     async def invalidate_legacy_active_token(
@@ -2026,9 +2033,9 @@ class ConsentDBService:
 
             if response.data is not None:
                 deleted_count = response.data
-                logger.info(f"Cleaned up {deleted_count} expired consent exports")
+                logger.info("consent_db.cleanup_exports deleted=%s", deleted_count)
                 return deleted_count
             return 0
         except Exception as e:
-            logger.error(f"Failed to cleanup expired exports: {e}")
+            logger.error("consent_db.cleanup_exports.error: %s", e)
             return 0

--- a/consent-protocol/tests/test_consent_db_g004.py
+++ b/consent-protocol/tests/test_consent_db_g004.py
@@ -1,0 +1,37 @@
+# tests/test_consent_db_g004.py
+"""
+PR attach points: ConsentDBService.insert_event, store_consent_export,
+                  get_consent_export, delete_consent_export,
+                  cleanup_expired_exports
+                  (hushh_mcp/services/consent_db.py)
+
+AST static check: verifies no f-string logger calls (G004) remain in
+consent_db.py after converting 8 loggers to %-style formatting.
+"""
+
+import ast
+import pathlib
+
+
+def test_no_f_string_loggers_in_consent_db() -> None:
+    """No f-string logger calls (G004) must remain in consent_db.py."""
+    import hushh_mcp.services.consent_db as module
+
+    src = pathlib.Path(module.__file__).read_text()
+    tree = ast.parse(src)
+    bad_lines: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (
+            isinstance(func, ast.Attribute)
+            and func.attr in {"warning", "error", "info", "debug", "exception"}
+        ):
+            continue
+        for arg in node.args:
+            if isinstance(arg, ast.JoinedStr):
+                bad_lines.append(node.lineno)
+    assert bad_lines == [], (
+        f"G004: f-string logger calls found at lines {bad_lines} in consent_db.py"
+    )


### PR DESCRIPTION
## Problem

Eight logger calls in `hushh_mcp/services/consent_db.py` used f-strings as format arguments (ruff **G004**). Eager string interpolation fires at call-site regardless of the configured log level, adding unnecessary overhead to high-frequency consent operations.

## Affected methods

| Method | Loggers fixed |
|--------|-------------|
| `insert_event` | 1 info |
| `store_consent_export` | 1 info + 1 error |
| `get_consent_export` | 1 error |
| `delete_consent_export` | 1 info + 1 error |
| `cleanup_expired_exports` | 1 info + 1 error |

**Total: 8 loggers**

## Fix

All converted to `%`-style lazy formatting. Token values are truncated via format spec (`%.30s`) rather than Python-side slicing, keeping format strings clean:

```python
# before
logger.info(f"Stored consent export for token: {consent_token[:30]}...")
# after
logger.info("consent_db.store_export token=%.30s...", consent_token)
```

## Test

`tests/test_consent_db_g004.py` — AST walk confirms zero `JoinedStr` nodes remain as logger arguments in `consent_db.py`.

## Attach points

- `ConsentDBService.insert_event`
- `ConsentDBService.store_consent_export`
- `ConsentDBService.get_consent_export`
- `ConsentDBService.delete_consent_export`
- `ConsentDBService.cleanup_expired_exports`