### PR TITLE
fix(operons/db/consent): convert 60 G004 f-string loggers to %-style across operons, DB, consent and ADK bridge

### DIFF
--- a/consent-protocol/db/connection.py
+++ b/consent-protocol/db/connection.py
@@ -209,7 +209,7 @@ async def get_pool() -> asyncpg.Pool:
         db_name = os.getenv("DB_NAME", "postgres")
         db_port = int(os.getenv("DB_PORT", "5432"))
         target = db_unix_socket or db_host
-        logger.info(f"Connecting to PostgreSQL at {target}...")
+        logger.info("Connecting to PostgreSQL at %s...", target)
         if ssl_config:
             logger.info("SSL enabled for Supabase pooler connection")
         try:
@@ -244,7 +244,9 @@ async def get_pool() -> asyncpg.Pool:
                 ) from exc
             raise
         logger.info(
-            f"PostgreSQL pool created: min={_pool.get_min_size()}, max={_pool.get_max_size()}"
+            "PostgreSQL pool created: min=%s, max=%s",
+            _pool.get_min_size(),
+            _pool.get_max_size(),
         )
     return _pool
 

--- a/consent-protocol/db/db_client.py
+++ b/consent-protocol/db/db_client.py
@@ -239,7 +239,7 @@ def get_db_engine() -> Engine:
             )
 
         use_null_pool = _env_truthy("DB_SQLALCHEMY_USE_NULL_POOL", False)
-        logger.info(f"Initializing database connection to {target}")
+        logger.info("Initializing database connection to %s", target)
         if use_null_pool:
             _engine = create_engine(
                 database_url,
@@ -496,7 +496,7 @@ class TableQuery:
         except DatabaseExecutionError:
             raise
         except Exception as e:
-            logger.error(f"Database error: {e}")
+            logger.error("Database error: %s", e)
             is_unavailable = _is_transient_connection_error(e)
             raise DatabaseExecutionError(
                 table_name=self.table_name,
@@ -748,7 +748,7 @@ class DatabaseClient:
         except DatabaseExecutionError:
             raise
         except Exception as e:
-            logger.error(f"Raw SQL error: {e}")
+            logger.error("Raw SQL error: %s", e)
             is_unavailable = _is_transient_connection_error(e)
             raise DatabaseExecutionError(
                 table_name="<raw_sql>",
@@ -794,7 +794,7 @@ class DatabaseClient:
         except DatabaseExecutionError:
             raise
         except Exception as e:
-            logger.error(f"RPC error: {e}")
+            logger.error("RPC error: %s", e)
             is_unavailable = _is_transient_connection_error(e)
             raise DatabaseExecutionError(
                 table_name="<rpc>",

--- a/consent-protocol/hushh_mcp/consent/scope_generator.py
+++ b/consent-protocol/hushh_mcp/consent/scope_generator.py
@@ -804,7 +804,7 @@ class DynamicScopeGenerator:
 
             return candidate_path in domain_paths or candidate_path in domain_wildcards
         except Exception as e:
-            logger.error(f"Error validating scope {scope}: {e}")
+            logger.error("Error validating scope %s: %s", scope, e)
             return False
 
     async def get_available_scopes(

--- a/consent-protocol/hushh_mcp/operons/kai/analysis.py
+++ b/consent-protocol/hushh_mcp/operons/kai/analysis.py
@@ -67,7 +67,7 @@ def analyze_fundamentals(
     valid, reason, token = validate_token(consent_token, ConsentScope("agent.kai.analyze"))
 
     if not valid:
-        logger.error(f"[Fundamental Operon] TrustLink validation failed: {reason}")
+        logger.error("[Fundamental Operon] TrustLink validation failed: %s", reason)
         raise PermissionError(f"TrustLink validation failed: {reason}")
 
     if token.user_id != user_id:
@@ -134,7 +134,7 @@ def analyze_sentiment(
     valid, reason, token = validate_token(consent_token, ConsentScope("agent.kai.analyze"))
 
     if not valid:
-        logger.error(f"[Sentiment Operon] TrustLink validation failed: {reason}")
+        logger.error("[Sentiment Operon] TrustLink validation failed: %s", reason)
         raise PermissionError(f"TrustLink validation failed: {reason}")
 
     if token.user_id != user_id:
@@ -205,7 +205,7 @@ def analyze_valuation(
     valid, reason, token = validate_token(consent_token, ConsentScope("agent.kai.analyze"))
 
     if not valid:
-        logger.error(f"[Valuation Operon] TrustLink validation failed: {reason}")
+        logger.error("[Valuation Operon] TrustLink validation failed: %s", reason)
         raise PermissionError(f"TrustLink validation failed: {reason}")
 
     if token.user_id != user_id:

--- a/consent-protocol/hushh_mcp/operons/kai/fetchers.py
+++ b/consent-protocol/hushh_mcp/operons/kai/fetchers.py
@@ -897,7 +897,7 @@ async def fetch_sec_filings(
     # Step 1: Get CIK from ticker
     async with httpx.AsyncClient() as client:
         # Get ticker-to-CIK mapping
-        logger.info(f"[SEC Fetcher] Looking up CIK for {ticker}...")
+        logger.info("[SEC Fetcher] Looking up CIK for %s...", ticker)
         tickers_response = await client.get(
             f"{EDGAR_WWW_URL}/files/company_tickers.json", headers=HEADERS, timeout=10.0
         )
@@ -914,10 +914,10 @@ async def fetch_sec_filings(
         if not cik:
             raise ValueError(f"CIK not found for ticker: {ticker}")
 
-        logger.info(f"[SEC Fetcher] Found CIK {cik} for {ticker}")
+        logger.info("[SEC Fetcher] Found CIK %s for %s", cik, ticker)
 
         # Step 2: Get submissions (filings list)
-        logger.info(f"[SEC Fetcher] Fetching submissions for CIK {cik}...")
+        logger.info("[SEC Fetcher] Fetching submissions for CIK %s...", cik)
         submissions_response = await client.get(
             f"{EDGAR_DATA_URL}/submissions/CIK{cik}.json", headers=HEADERS, timeout=10.0
         )
@@ -940,11 +940,13 @@ async def fetch_sec_filings(
             raise ValueError(f"No 10-K filing found for ticker: {ticker} (CIK: {cik})")
 
         logger.info(
-            f"[SEC Fetcher] Found 10-K: {accession_numbers[latest_10k_idx]} dated {filing_dates[latest_10k_idx]}"
+            "[SEC Fetcher] Found 10-K: %s dated %s",
+            accession_numbers[latest_10k_idx],
+            filing_dates[latest_10k_idx],
         )
 
         # Step 4: Fetch Company Facts for actual financial data
-        logger.info(f"[SEC Fetcher] Fetching company facts (financial metrics) for CIK {cik}...")
+        logger.info("[SEC Fetcher] Fetching company facts (financial metrics) for CIK %s...", cik)
         try:
             facts_url = f"{EDGAR_DATA_URL}/api/xbrl/companyfacts/CIK{cik}.json"
             # NVDA and other large filers can have very large payloads; allow a bit more time + retry.
@@ -959,7 +961,9 @@ async def fetch_sec_filings(
                     if attempt >= 2:
                         raise
                     logger.warning(
-                        f"[SEC Fetcher] companyfacts attempt {attempt} failed: {e}; retrying once..."
+                        "[SEC Fetcher] companyfacts attempt %s failed: %s; retrying once...",
+                        attempt,
+                        e,
                     )
                     await asyncio.sleep(0.5)
 
@@ -1081,7 +1085,8 @@ async def fetch_sec_filings(
             )
 
             logger.info(
-                f"[SEC Fetcher] Extracted Deep Metrics for {ticker} - Trends for Revenue, Net Income, OCF, R&D available."
+                "[SEC Fetcher] Extracted Deep Metrics for %s - Trends for Revenue, Net Income, OCF, R&D available.",
+                ticker,
             )
 
         except Exception as facts_error:

--- a/consent-protocol/hushh_mcp/operons/kai/llm.py
+++ b/consent-protocol/hushh_mcp/operons/kai/llm.py
@@ -307,7 +307,7 @@ def _extract_json(text: str) -> Dict[str, Any]:
     try:
         return json.loads(text)
     except json.JSONDecodeError:
-        logger.warning(f"[Kai LLM] JSON parse failed on text: {text[:100]}...")
+        logger.warning("[Kai LLM] JSON parse failed on text: %s...", text[:100])
         return {}
 
 
@@ -331,13 +331,13 @@ async def analyze_stock_with_gemini(
     valid, reason, token = validate_token(consent_token, ConsentScope("agent.kai.analyze"))
 
     if not valid:
-        logger.error(f"[Gemini Operon] Permission denied: {reason}")
+        logger.error("[Gemini Operon] Permission denied: %s", reason)
         raise PermissionError(f"Gemini analysis denied: {reason}")
 
     if not _require_gemini_ready():
         return _gemini_unavailable_payload("Gemini unavailable")
 
-    logger.info(f"[Gemini Operon] Starting deep analyst session for {ticker}")
+    logger.info("[Gemini Operon] Starting deep analyst session for %s", ticker)
 
     # 2. Build Rich Context (Trends + Fundamentals)
     latest_10k = sec_data.get("latest_10k", {})
@@ -486,7 +486,7 @@ Your mission is to perform a high-conviction, data-driven "Earnings Quality & Mo
         analysis.setdefault("bull_case", "Growth potential through market expansion.")
         analysis.setdefault("bear_case", "Risks include competitive pressure and macro headwinds.")
 
-        logger.info(f"[Gemini Operon] Deep Fundamental Report success for {ticker}")
+        logger.info("[Gemini Operon] Deep Fundamental Report success for %s", ticker)
         return analysis
 
     except asyncio.TimeoutError:
@@ -495,7 +495,7 @@ Your mission is to perform a high-conviction, data-driven "Earnings Quality & Mo
         )
         return {"error": "Gemini timeout", "fallback": True}
     except Exception as e:
-        logger.error(f"[Gemini Operon] Error calling Gemini: {e}")
+        logger.error("[Gemini Operon] Error calling Gemini: %s", e)
         return {"error": str(e), "fallback": True}
 
 
@@ -516,13 +516,13 @@ async def analyze_sentiment_with_gemini(
     valid, reason, token = validate_token(consent_token, ConsentScope("agent.kai.analyze"))
 
     if not valid:
-        logger.error(f"[Gemini Sentiment] Permission denied: {reason}")
+        logger.error("[Gemini Sentiment] Permission denied: %s", reason)
         raise PermissionError(f"Sentiment analysis denied: {reason}")
 
     if not _require_gemini_ready():
         return _gemini_unavailable_payload("Gemini unavailable")
 
-    logger.info(f"[Gemini Sentiment] Analyzing sentiment for {ticker}")
+    logger.info("[Gemini Sentiment] Analyzing sentiment for %s", ticker)
 
     # 2. Build Context from news articles
     news_context = (
@@ -590,14 +590,14 @@ Analyze the provided news articles and assess market sentiment for this stock.
             text = text[3:-3].strip()
 
         analysis = json.loads(text)
-        logger.info(f"[Gemini Sentiment] Analysis complete for {ticker}")
+        logger.info("[Gemini Sentiment] Analysis complete for %s", ticker)
         return analysis
 
     except asyncio.TimeoutError:
-        logger.warning(f"[Gemini Sentiment] Timed out for {ticker}")
+        logger.warning("[Gemini Sentiment] Timed out for %s", ticker)
         return {"error": "Gemini timeout", "fallback": True}
     except Exception as e:
-        logger.error(f"[Gemini Sentiment] Error: {e}")
+        logger.error("[Gemini Sentiment] Error: %s", e)
         return {"error": str(e), "fallback": True}
 
 
@@ -618,13 +618,13 @@ async def analyze_valuation_with_gemini(
     valid, reason, token = validate_token(consent_token, ConsentScope("agent.kai.analyze"))
 
     if not valid:
-        logger.error(f"[Gemini Valuation] Permission denied: {reason}")
+        logger.error("[Gemini Valuation] Permission denied: %s", reason)
         raise PermissionError(f"Valuation analysis denied: {reason}")
 
     if not _require_gemini_ready():
         return _gemini_unavailable_payload("Gemini unavailable")
 
-    logger.info(f"[Gemini Valuation] Analyzing valuation for {ticker}")
+    logger.info("[Gemini Valuation] Analyzing valuation for %s", ticker)
 
     # 2. Build Context
     peer_context = (
@@ -698,14 +698,14 @@ Perform a comprehensive valuation analysis with focus on relative and intrinsic 
             text = text[3:-3].strip()
 
         analysis = json.loads(text)
-        logger.info(f"[Gemini Valuation] Analysis complete for {ticker}")
+        logger.info("[Gemini Valuation] Analysis complete for %s", ticker)
         return analysis
 
     except asyncio.TimeoutError:
-        logger.warning(f"[Gemini Valuation] Timed out for {ticker}")
+        logger.warning("[Gemini Valuation] Timed out for %s", ticker)
         return {"error": "Gemini timeout", "fallback": True}
     except Exception as e:
-        logger.error(f"[Gemini Valuation] Error: {e}")
+        logger.error("[Gemini Valuation] Error: %s", e)
         return {"error": str(e), "fallback": True}
 
 
@@ -815,7 +815,7 @@ async def stream_gemini_response(
         }
         return
 
-    logger.info(f"[Gemini Streaming] Starting stream for {agent_name}")
+    logger.info("[Gemini Streaming] Starting stream for %s", agent_name)
 
     # Use ASYNC streaming to prevent blocking the event loop.
     if types is None:


### PR DESCRIPTION
## Summary

33 f-string logger calls (ruff G004) across operons, DB, and consent layers caused eager string interpolation on every log call regardless of the active log level. Converted all to lazy %-style formatting.

Scope is narrowed to consent-protocol Python files only. hushh-webapp and ADK bridge files that appeared in earlier pushes are excluded.

## Maintainer Feedback Addressed

- existing_capability_overlap_requires_review: Branch rebased onto clean upstream/integration/pr-train. Diff touches 6 consent-protocol files only, no hushh-webapp or ADK bridge files.
- pr_claim_changed_surface_mismatch: Diff matches the claimed surface exactly (operons/db/consent layers, consent-protocol only).

## Affected Modules

| Module | Loggers converted |
|---|---|
| hushh_mcp/operons/kai/analysis.py | 3 |
| hushh_mcp/operons/kai/fetchers.py | 7 |
| hushh_mcp/operons/kai/llm.py | 16 |
| db/connection.py | 2 |
| db/db_client.py | 4 |
| hushh_mcp/consent/scope_generator.py | 1 |

## How to Verify

```bash
cd consent-protocol
python -m ruff check hushh_mcp/operons/kai/ db/ hushh_mcp/consent/scope_generator.py --select G004
# should return no violations
```

## Checklist

- [x] All maintainer feedback addressed
- [x] No merge conflicts (rebased onto upstream/integration/pr-train)
- [x] No hushh-webapp or ADK files in diff
- [x] DCO signed