### PR TITLE
feat(app-ui): replace inline "No results" with composable DataTableEmptyState

### DIFF
--- a/hushh-webapp/components/app-ui/data-table.tsx
+++ b/hushh-webapp/components/app-ui/data-table.tsx
@@ -51,6 +51,7 @@ import {
   PaginationPrevious,
 } from "@/components/ui/pagination";
 import { Search } from "lucide-react";
+import { DataTableEmptyState } from "@/components/ui/data-table-empty-state";
 import { surfaceDataTableShellClassName } from "@/lib/morphy-ux/surfaces";
 import { cn } from "@/lib/utils";
 
@@ -366,11 +367,12 @@ export function DataTable<TData, TValue>({
               ))
             ) : (
               <TableRow>
-                <TableCell
-                  colSpan={columns.length}
-                  className="h-24 px-[var(--data-table-cell-px)] text-center"
-                >
-                  No results.
+                <TableCell colSpan={columns.length} className="p-0">
+                  <DataTableEmptyState
+                    isFiltered={
+                      !!globalFilter || columnFilters.length > 0
+                    }
+                  />
                 </TableCell>
               </TableRow>
             )}

--- a/hushh-webapp/components/ui/data-table-empty-state.tsx
+++ b/hushh-webapp/components/ui/data-table-empty-state.tsx
@@ -1,0 +1,44 @@
+import { SearchX, TableIcon } from "lucide-react"
+import {
+  Empty,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+  EmptyDescription,
+} from "@/components/ui/empty"
+import { cn } from "@/lib/utils"
+
+interface DataTableEmptyStateProps {
+  isFiltered?: boolean
+  title?: string
+  description?: string
+  className?: string
+}
+
+export function DataTableEmptyState({
+  isFiltered = false,
+  title,
+  description,
+  className,
+}: DataTableEmptyStateProps) {
+  const resolvedTitle =
+    title ?? (isFiltered ? "No matching results" : "No data yet")
+
+  const resolvedDescription =
+    description ??
+    (isFiltered
+      ? "Try adjusting your search or filter to find what you're looking for."
+      : "Data will appear here once it becomes available.")
+
+  return (
+    <Empty className={cn("border-none py-8 sm:py-10", className)}>
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          {isFiltered ? <SearchX /> : <TableIcon />}
+        </EmptyMedia>
+        <EmptyTitle>{resolvedTitle}</EmptyTitle>
+        <EmptyDescription>{resolvedDescription}</EmptyDescription>
+      </EmptyHeader>
+    </Empty>
+  )
+}


### PR DESCRIPTION
## Summary

Shared DataTable surfaces currently render a hardcoded inline "No results." string when tables are empty, creating inconsistent empty-state UX and providing no distinction between filtered-empty and truly empty datasets.

This update introduces a reusable `DataTableEmptyState` component built on top of the existing shared `Empty` primitives to provide composable, context-aware empty-state rendering across DataTable surfaces.

## What's covered

- `components/ui/data-table-empty-state.tsx`
- `components/app-ui/data-table.tsx`

Added reusable empty-state rendering support for shared DataTable layouts.

## Key improvements

- introduces reusable `DataTableEmptyState` primitive
- replaces hardcoded inline "No results." rendering
- differentiates filtered-empty vs true-empty table states
- reuses existing shared Empty component system
- preserves all current filtering and search behavior
- improves empty-state consistency across table surfaces

## Reachable surfaces

- shared DataTable empty states
- authenticated table-based routes
- filtered/searchable table surfaces
- RIA/admin/client DataTable flows

## Validation

- `npx tsc --noEmit`
- `npm run lint`

## Notes

- frontend-only UX improvement
- no runtime/business logic changes
- no filtering/search behavior changes
- no backend/schema/cache impacts
- built entirely on existing shared UI primitives
- DCO sign-off included