### PR TITLE
fix: seed public investor marketplace inventory

### DIFF
--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 55,
+  "expected_migration_version": 56,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",
@@ -424,6 +424,27 @@
       "last_error_code",
       "last_error_message",
       "metadata",
+      "created_at",
+      "updated_at"
+    ],
+    "investor_profiles": [
+      "id",
+      "name",
+      "name_normalized",
+      "cik",
+      "firm",
+      "title",
+      "investor_type",
+      "location_hint",
+      "business_address",
+      "aum_billions",
+      "investment_style",
+      "biography",
+      "data_sources",
+      "source_urls",
+      "evidence",
+      "last_13f_date",
+      "last_form4_date",
       "created_at",
       "updated_at"
     ]

--- a/consent-protocol/db/migrations/056_public_investor_profiles.sql
+++ b/consent-protocol/db/migrations/056_public_investor_profiles.sql
@@ -1,0 +1,183 @@
+-- Public investor discovery inventory for RIA marketplace.
+--
+-- This table stores only public/official-source investor discovery records.
+-- Rows are discovery-only and must not be treated as Hushh users unless a
+-- separate opted-in marketplace_public_profiles row exists.
+
+CREATE TABLE IF NOT EXISTS investor_profiles (
+  id BIGSERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  name_normalized TEXT,
+  cik TEXT UNIQUE,
+  firm TEXT,
+  title TEXT,
+  investor_type TEXT NOT NULL DEFAULT 'institutional_investor',
+  photo_url TEXT,
+  location_hint TEXT,
+  business_address JSONB NOT NULL DEFAULT '{}'::jsonb,
+  aum_billions NUMERIC,
+  top_holdings JSONB NOT NULL DEFAULT '[]'::jsonb,
+  sector_exposure JSONB NOT NULL DEFAULT '{}'::jsonb,
+  investment_style TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  risk_tolerance TEXT,
+  time_horizon TEXT,
+  portfolio_turnover TEXT,
+  recent_buys TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  recent_sells TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  public_quotes JSONB NOT NULL DEFAULT '[]'::jsonb,
+  biography TEXT,
+  education TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  board_memberships TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  peer_investors TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  is_insider BOOLEAN NOT NULL DEFAULT FALSE,
+  insider_company_ticker TEXT,
+  data_sources TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  source_urls TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  evidence JSONB NOT NULL DEFAULT '{}'::jsonb,
+  last_13f_date DATE,
+  last_form4_date DATE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE investor_profiles
+  ADD COLUMN IF NOT EXISTS location_hint TEXT,
+  ADD COLUMN IF NOT EXISTS business_address JSONB NOT NULL DEFAULT '{}'::jsonb,
+  ADD COLUMN IF NOT EXISTS source_urls TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  ADD COLUMN IF NOT EXISTS evidence JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+CREATE INDEX IF NOT EXISTS idx_investor_profiles_name ON investor_profiles(name);
+CREATE INDEX IF NOT EXISTS idx_investor_profiles_firm ON investor_profiles(firm);
+CREATE INDEX IF NOT EXISTS idx_investor_profiles_type ON investor_profiles(investor_type);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_investor_profiles_cik_unique ON investor_profiles(cik);
+CREATE INDEX IF NOT EXISTS idx_investor_profiles_cik ON investor_profiles(cik) WHERE cik IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_investor_profiles_location_hint ON investor_profiles(location_hint);
+CREATE INDEX IF NOT EXISTS idx_investor_profiles_last_13f_date ON investor_profiles(last_13f_date DESC NULLS LAST);
+
+INSERT INTO investor_profiles (
+  name,
+  name_normalized,
+  cik,
+  firm,
+  title,
+  investor_type,
+  location_hint,
+  business_address,
+  investment_style,
+  biography,
+  data_sources,
+  source_urls,
+  evidence,
+  last_13f_date
+) VALUES
+  (
+    'GATES FOUNDATION TRUST',
+    'gatesfoundationtrust',
+    '0001166559',
+    'Gates Foundation Trust',
+    'Public institutional filer',
+    'institutional_investor',
+    'Kirkland, WA 98033',
+    '{"street1":"2365 CARILLON POINT","city":"KIRKLAND","state":"WA","zip":"98033","source":"SEC submissions business address"}'::jsonb,
+    ARRAY['public_13f','foundation_trust'],
+    'Public institutional investor profile seeded from official SEC EDGAR submissions. SEC records list the business and mailing address in Kirkland, Washington 98033.',
+    ARRAY['SEC EDGAR submissions API','SEC Form 13F-HR'],
+    ARRAY['https://data.sec.gov/submissions/CIK0001166559.json','https://www.sec.gov/edgar/browse/?CIK=0001166559'],
+    '{"confidence":"official_sec_record","latest_known_13f_accession":"0001104659-26-062592"}'::jsonb,
+    DATE '2026-05-15'
+  ),
+  (
+    'BERKSHIRE HATHAWAY INC',
+    'berkshirehathawayinc',
+    '0001067983',
+    'Berkshire Hathaway Inc',
+    'Public institutional filer',
+    'institutional_investor',
+    'Omaha, NE 68131',
+    '{"street1":"3555 FARNAM STREET","city":"OMAHA","state":"NE","zip":"68131","source":"SEC submissions business address"}'::jsonb,
+    ARRAY['public_13f','long_term_value'],
+    'Public institutional investor profile seeded from official SEC EDGAR submissions and Form 13F-HR filing context.',
+    ARRAY['SEC EDGAR submissions API','SEC Form 13F-HR'],
+    ARRAY['https://data.sec.gov/submissions/CIK0001067983.json','https://www.sec.gov/edgar/browse/?CIK=0001067983'],
+    '{"confidence":"official_sec_record","latest_known_13f_accession":"0001193125-26-226661"}'::jsonb,
+    DATE '2026-05-15'
+  ),
+  (
+    'Bridgewater Associates, LP',
+    'bridgewaterassociateslp',
+    '0001350694',
+    'Bridgewater Associates, LP',
+    'Public institutional filer',
+    'institutional_investor',
+    'Westport, CT 06880',
+    '{"street1":"ONE NYALA FARMS ROAD","city":"WESTPORT","state":"CT","zip":"06880","source":"SEC submissions business address"}'::jsonb,
+    ARRAY['public_13f','macro'],
+    'Public institutional investor profile seeded from official SEC EDGAR submissions and Form 13F-HR filing context.',
+    ARRAY['SEC EDGAR submissions API','SEC Form 13F-HR'],
+    ARRAY['https://data.sec.gov/submissions/CIK0001350694.json','https://www.sec.gov/edgar/browse/?CIK=0001350694'],
+    '{"confidence":"official_sec_record","latest_known_13f_accession":"0001350694-26-000002"}'::jsonb,
+    DATE '2026-05-15'
+  ),
+  (
+    'Pershing Square Capital Management, L.P.',
+    'pershingsquarecapitalmanagementlp',
+    '0001336528',
+    'Pershing Square Capital Management, L.P.',
+    'Public institutional filer',
+    'institutional_investor',
+    'New York, NY 10019',
+    '{"street1":"787 11TH AVENUE","street2":"9TH FLOOR","city":"NEW YORK","state":"NY","zip":"10019","source":"SEC submissions business address"}'::jsonb,
+    ARRAY['public_13f','active_ownership'],
+    'Public institutional investor profile seeded from official SEC EDGAR submissions and Form 13F-HR filing context.',
+    ARRAY['SEC EDGAR submissions API','SEC Form 13F-HR'],
+    ARRAY['https://data.sec.gov/submissions/CIK0001336528.json','https://www.sec.gov/edgar/browse/?CIK=0001336528'],
+    '{"confidence":"official_sec_record","latest_known_13f_accession":"0001172661-26-002336"}'::jsonb,
+    DATE '2026-05-15'
+  ),
+  (
+    'Scion Asset Management, LLC',
+    'scionassetmanagementllc',
+    '0001649339',
+    'Scion Asset Management, LLC',
+    'Public institutional filer',
+    'institutional_investor',
+    'Saratoga, CA 95070',
+    '{"street1":"20665 4TH STREET","street2":"SUITE 201","city":"SARATOGA","state":"CA","zip":"95070","source":"SEC submissions business address"}'::jsonb,
+    ARRAY['public_13f','concentrated'],
+    'Public institutional investor profile seeded from official SEC EDGAR submissions and Form 13F-HR filing context.',
+    ARRAY['SEC EDGAR submissions API','SEC Form 13F-HR'],
+    ARRAY['https://data.sec.gov/submissions/CIK0001649339.json','https://www.sec.gov/edgar/browse/?CIK=0001649339'],
+    '{"confidence":"official_sec_record","latest_known_13f_accession":"0001649339-25-000007"}'::jsonb,
+    DATE '2025-11-03'
+  ),
+  (
+    'ARK Investment Management LLC',
+    'arkinvestmentmanagementllc',
+    '0001697748',
+    'ARK Investment Management LLC',
+    'Public institutional filer',
+    'institutional_investor',
+    'St. Petersburg, FL 33701',
+    '{"street1":"200 CENTRAL AVENUE","city":"ST. PETERSBURG","state":"FL","zip":"33701","source":"SEC submissions business address"}'::jsonb,
+    ARRAY['public_13f','innovation'],
+    'Public institutional investor profile seeded from official SEC EDGAR submissions and Form 13F-HR filing context.',
+    ARRAY['SEC EDGAR submissions API','SEC Form 13F-HR'],
+    ARRAY['https://data.sec.gov/submissions/CIK0001697748.json','https://www.sec.gov/edgar/browse/?CIK=0001697748'],
+    '{"confidence":"official_sec_record","latest_known_13f_accession":"0001104659-26-059240"}'::jsonb,
+    DATE '2026-05-12'
+  )
+ON CONFLICT (cik) DO UPDATE SET
+  name = EXCLUDED.name,
+  name_normalized = EXCLUDED.name_normalized,
+  firm = EXCLUDED.firm,
+  title = EXCLUDED.title,
+  investor_type = EXCLUDED.investor_type,
+  location_hint = EXCLUDED.location_hint,
+  business_address = EXCLUDED.business_address,
+  investment_style = EXCLUDED.investment_style,
+  biography = EXCLUDED.biography,
+  data_sources = EXCLUDED.data_sources,
+  source_urls = EXCLUDED.source_urls,
+  evidence = EXCLUDED.evidence,
+  last_13f_date = EXCLUDED.last_13f_date,
+  updated_at = NOW();

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -32,7 +32,8 @@
     "052_actor_verified_email_aliases.sql",
     "053_ria_onboarding_v2_fields.sql",
     "054_ria_license_verification_cache_index.sql",
-    "055_agent_chat_encrypted_store.sql"
+    "055_agent_chat_encrypted_store.sql",
+    "056_public_investor_profiles.sql"
   ],
   "groups": {
     "iam": [
@@ -53,7 +54,8 @@
       "042_ria_pick_single_active_record.sql",
       "043_ria_pick_share_artifacts.sql",
       "053_ria_onboarding_v2_fields.sql",
-      "054_ria_license_verification_cache_index.sql"
+      "054_ria_license_verification_cache_index.sql",
+      "056_public_investor_profiles.sql"
     ],
     "pkm": [
       "030_pkm_cutover.sql",

--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -7805,6 +7805,8 @@ class RIAIAMService:
                   firm,
                   title,
                   investor_type,
+                  location_hint,
+                  business_address,
                   aum_billions,
                   investment_style,
                   risk_tolerance,
@@ -7814,6 +7816,8 @@ class RIAIAMService:
                   is_insider,
                   insider_company_ticker,
                   data_sources,
+                  source_urls,
+                  evidence,
                   last_13f_date,
                   last_form4_date,
                   updated_at
@@ -7885,7 +7889,7 @@ class RIAIAMService:
             "public_profile_id": public_profile_id,
             "display_name": display_name,
             "headline": headline,
-            "location_hint": None,
+            "location_hint": cls._clean_public_investor_text(payload.get("location_hint")),
             "strategy_summary": cls._public_investor_strategy_summary(payload),
             "connectable": False,
             "evidence": cls._public_investor_evidence(payload),
@@ -7951,6 +7955,15 @@ class RIAIAMService:
         data_sources = payload.get("data_sources")
         if not isinstance(data_sources, list):
             data_sources = []
+        source_urls = payload.get("source_urls")
+        if not isinstance(source_urls, list):
+            source_urls = []
+        evidence = payload.get("evidence")
+        if not isinstance(evidence, dict):
+            evidence = {}
+        business_address = payload.get("business_address")
+        if not isinstance(business_address, dict):
+            business_address = {}
         forms: list[dict[str, str]] = []
         last_13f_date = cls._serialize_marketplace_date(payload.get("last_13f_date"))
         last_form4_date = cls._serialize_marketplace_date(payload.get("last_form4_date"))
@@ -7962,7 +7975,9 @@ class RIAIAMService:
             "source_type": "public_sec",
             "confidence": "official_public_records",
             "sources": data_sources or ["SEC EDGAR public filings"],
-            "source_urls": [source_url] if source_url else [],
+            "source_urls": list(
+                dict.fromkeys([*source_urls, *([source_url] if source_url else [])])
+            ),
             "forms": forms,
             "cik": cik,
             "investor_type": cls._clean_public_investor_text(payload.get("investor_type")),
@@ -7970,6 +7985,8 @@ class RIAIAMService:
             "insider_company_ticker": cls._clean_public_investor_text(
                 payload.get("insider_company_ticker")
             ),
+            "business_address": business_address,
+            "metadata": evidence,
             "updated_at": cls._serialize_marketplace_date(payload.get("updated_at")),
         }
 

--- a/consent-protocol/tests/services/test_marketplace_investor_discovery.py
+++ b/consent-protocol/tests/services/test_marketplace_investor_discovery.py
@@ -33,6 +33,13 @@ class _FakeMarketplaceConn:
                     "firm": "Public Capital Partners",
                     "title": "Managing Partner",
                     "investor_type": "fund_manager",
+                    "location_hint": "Kirkland, WA 98033",
+                    "business_address": {
+                        "street1": "2365 CARILLON POINT",
+                        "city": "KIRKLAND",
+                        "state": "WA",
+                        "zip": "98033",
+                    },
                     "aum_billions": 12.4,
                     "investment_style": ["long_term", "technology"],
                     "risk_tolerance": None,
@@ -42,6 +49,8 @@ class _FakeMarketplaceConn:
                     "is_insider": False,
                     "insider_company_ticker": None,
                     "data_sources": ["SEC EDGAR", "Form 13F"],
+                    "source_urls": ["https://data.sec.gov/submissions/CIK0000123456.json"],
+                    "evidence": {"confidence": "official_sec_record"},
                     "last_13f_date": date(2026, 3, 31),
                     "last_form4_date": None,
                     "updated_at": date(2026, 4, 15),
@@ -85,7 +94,13 @@ def test_marketplace_investors_merge_hushh_users_and_public_sec_profiles(monkeyp
         assert public_item["public_profile_id"] == "42"
         assert public_item["connectable"] is False
         assert public_item["headline"] == "Managing Partner at Public Capital Partners"
+        assert public_item["location_hint"] == "Kirkland, WA 98033"
         assert public_item["evidence"]["confidence"] == "official_public_records"
         assert public_item["evidence"]["forms"] == [{"form": "13F", "last_filed_at": "2026-03-31"}]
+        assert public_item["evidence"]["source_urls"] == [
+            "https://data.sec.gov/submissions/CIK0000123456.json",
+            "https://www.sec.gov/edgar/browse/?CIK=0000123456",
+        ]
+        assert public_item["evidence"]["business_address"]["zip"] == "98033"
 
     asyncio.run(_run())

--- a/consent-protocol/tests/test_ria_iam_routes.py
+++ b/consent-protocol/tests/test_ria_iam_routes.py
@@ -153,12 +153,13 @@ def test_marketplace_investors_exposes_public_sec_discovery_contract(monkeypatch
                 "public_profile_id": "42",
                 "display_name": "Morgan Public",
                 "headline": "Managing Partner at Public Capital Partners",
-                "location_hint": None,
+                "location_hint": "Kirkland, WA 98033",
                 "strategy_summary": "Public investor profile assembled from public filings.",
                 "connectable": False,
                 "evidence": {
                     "confidence": "official_public_records",
                     "sources": ["SEC EDGAR", "Form 13F"],
+                    "business_address": {"city": "KIRKLAND", "state": "WA", "zip": "98033"},
                 },
                 "is_test_profile": False,
             }
@@ -174,6 +175,7 @@ def test_marketplace_investors_exposes_public_sec_discovery_contract(monkeypatch
     assert item["source_type"] == "public_sec"
     assert item["user_id"] is None
     assert item["connectable"] is False
+    assert item["location_hint"] == "Kirkland, WA 98033"
     assert item["evidence"]["confidence"] == "official_public_records"
 
 

--- a/docs/reference/architecture/runtime-db-data-plane-contract.json
+++ b/docs/reference/architecture/runtime-db-data-plane-contract.json
@@ -192,6 +192,19 @@
       "expected_row_growth": "medium_relationship"
     },
     {
+      "id": "public_investor_reference",
+      "owner": "backend-api-contracts",
+      "data_class": "reference",
+      "lifecycle_status": "current",
+      "exact_tables": ["investor_profiles"],
+      "primary_access_path": "RIA marketplace public discovery cards and official SEC filing evidence",
+      "retention_policy": "Refreshable public reference data; update from official public sources and preserve evidence URLs.",
+      "deletion_behavior": "Not user-delete scoped; remove or correct only when the public-source inventory is withdrawn or superseded.",
+      "trust_boundary": "Official/public investor reference records only; rows do not create signed-in marketplace users and are not connectable without opt-in.",
+      "plaintext_posture": "reference_metadata",
+      "expected_row_growth": "low_reference"
+    },
+    {
       "id": "kai_brokerage_provider_cache",
       "owner": "backend-runtime-governance",
       "data_class": "provider_cache",


### PR DESCRIPTION
## Summary
- Add the integrated investor_profiles schema to the release migration lane.
- Seed discovery-only public SEC investor profiles, including GATES FOUNDATION TRUST with official SEC location Kirkland, WA 98033.
- Surface public profile location_hint, official source URLs, and business-address evidence through /api/marketplace/investors.
- Classify investor_profiles as public reference data in the runtime DB data-plane contract.

## Boundary
- This is official SEC public-record inventory for marketplace discovery.
- It does not claim or scrape the unverified THE GARAGE / 102 15th St W address; live search did not confirm that exact public source.
- Public SEC rows remain connectable=false and do not create fake signed-in users.

## Tests
- python3 scripts/ops/data_model_audit.py
- python3 scripts/ops/verify_release_migration_contract.py
- Targeted pytest with local dummy APP_SIGNING_KEY and VAULT_DATA_KEY env values: tests/services/test_marketplace_investor_discovery.py tests/test_ria_iam_routes.py
