### PR TITLE
fix: preserve public investor evidence json

### DIFF
--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -7958,12 +7958,8 @@ class RIAIAMService:
         source_urls = payload.get("source_urls")
         if not isinstance(source_urls, list):
             source_urls = []
-        evidence = payload.get("evidence")
-        if not isinstance(evidence, dict):
-            evidence = {}
-        business_address = payload.get("business_address")
-        if not isinstance(business_address, dict):
-            business_address = {}
+        evidence = cls._coerce_public_investor_json_object(payload.get("evidence"))
+        business_address = cls._coerce_public_investor_json_object(payload.get("business_address"))
         forms: list[dict[str, str]] = []
         last_13f_date = cls._serialize_marketplace_date(payload.get("last_13f_date"))
         last_form4_date = cls._serialize_marketplace_date(payload.get("last_form4_date"))
@@ -7989,6 +7985,21 @@ class RIAIAMService:
             "metadata": evidence,
             "updated_at": cls._serialize_marketplace_date(payload.get("updated_at")),
         }
+
+    @staticmethod
+    def _coerce_public_investor_json_object(value: Any) -> dict[str, Any]:
+        if isinstance(value, dict):
+            return value
+        if isinstance(value, (bytes, bytearray)):
+            value = value.decode("utf-8", errors="replace")
+        if isinstance(value, str):
+            try:
+                parsed = json.loads(value)
+            except ValueError:
+                return {}
+            if isinstance(parsed, dict):
+                return parsed
+        return {}
 
     @staticmethod
     def _serialize_marketplace_date(value: Any) -> str | None:

--- a/consent-protocol/tests/services/test_marketplace_investor_discovery.py
+++ b/consent-protocol/tests/services/test_marketplace_investor_discovery.py
@@ -34,12 +34,10 @@ class _FakeMarketplaceConn:
                     "title": "Managing Partner",
                     "investor_type": "fund_manager",
                     "location_hint": "Kirkland, WA 98033",
-                    "business_address": {
-                        "street1": "2365 CARILLON POINT",
-                        "city": "KIRKLAND",
-                        "state": "WA",
-                        "zip": "98033",
-                    },
+                    "business_address": (
+                        '{"street1":"2365 CARILLON POINT","city":"KIRKLAND",'
+                        '"state":"WA","zip":"98033"}'
+                    ),
                     "aum_billions": 12.4,
                     "investment_style": ["long_term", "technology"],
                     "risk_tolerance": None,
@@ -50,7 +48,10 @@ class _FakeMarketplaceConn:
                     "insider_company_ticker": None,
                     "data_sources": ["SEC EDGAR", "Form 13F"],
                     "source_urls": ["https://data.sec.gov/submissions/CIK0000123456.json"],
-                    "evidence": {"confidence": "official_sec_record"},
+                    "evidence": (
+                        '{"confidence":"official_sec_record",'
+                        '"latest_known_13f_accession":"0000123456-26-000001"}'
+                    ),
                     "last_13f_date": date(2026, 3, 31),
                     "last_form4_date": None,
                     "updated_at": date(2026, 4, 15),
@@ -102,5 +103,9 @@ def test_marketplace_investors_merge_hushh_users_and_public_sec_profiles(monkeyp
             "https://www.sec.gov/edgar/browse/?CIK=0000123456",
         ]
         assert public_item["evidence"]["business_address"]["zip"] == "98033"
+        assert (
+            public_item["evidence"]["metadata"]["latest_known_13f_accession"]
+            == "0000123456-26-000001"
+        )
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- parse public investor JSONB payloads when asyncpg returns them as serialized JSON strings
- preserve business_address and evidence metadata in /api/marketplace/investors responses
- extend marketplace investor service coverage for serialized JSONB runtime shape

## Tests
- cd consent-protocol && PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest --noconftest tests/services/test_marketplace_investor_discovery.py tests/test_ria_iam_routes.py -q

## UAT plan
- backend-only deploy from green main after merge
- verify GATES FOUNDATION TRUST includes Kirkland, WA 98033 and business_address.zip 98033 in marketplace API evidence