### PR TITLE
Expand SEC 13F replenisher date parsing

### DIFF
--- a/consent-protocol/hushh_mcp/services/marketplace_investor_replenisher.py
+++ b/consent-protocol/hushh_mcp/services/marketplace_investor_replenisher.py
@@ -753,16 +753,27 @@ def candidates_from_13f_dataset_archive(
                 )
                 if not filing_date:
                     continue
+                business_address = {
+                    "street1": _clean_text(_field(row, "FILINGMANAGER_STREET1")),
+                    "street2": _clean_text(_field(row, "FILINGMANAGER_STREET2")),
+                    "city": _clean_text(_field(row, "FILINGMANAGER_CITY")),
+                    "state": _clean_text(_field(row, "FILINGMANAGER_STATEORCOUNTRY")),
+                    "zip": _clean_text(_field(row, "FILINGMANAGER_ZIPCODE")),
+                    "source": "SEC Form 13F cover page",
+                }
+                business_address = {key: value for key, value in business_address.items() if value}
                 accession_value = accession or ""
                 curation_tier = "showcase" if len(candidates) < showcase_slots else "qualified"
                 quality_score = 90 if curation_tier == "showcase" else 86
+                if business_address:
+                    quality_score += 3
                 candidates.append(
                     InvestorCandidate(
                         name=name,
                         cik=cik,
                         firm=name.title() if name.isupper() else name,
-                        location_hint="SEC 13F public filer",
-                        business_address={"source": "SEC Form 13F data set"},
+                        location_hint=_location_hint(business_address) or "SEC 13F public filer",
+                        business_address=business_address or {"source": "SEC Form 13F data set"},
                         investment_style=["public_13f", "institutional_filer"],
                         biography=(
                             "Official SEC-backed investor discovery profile derived from the "
@@ -886,11 +897,13 @@ def _parse_date(value: Any) -> date | None:
     text = str(value or "").strip()
     if not text:
         return None
-    for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%Y%m%d"):
-        try:
-            return datetime.strptime(text[:10], fmt).date()
-        except ValueError:
-            continue
+    candidates = [text, text[:10], text[:11]]
+    for candidate in candidates:
+        for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%Y%m%d", "%d-%b-%Y"):
+            try:
+                return datetime.strptime(candidate, fmt).date()
+            except ValueError:
+                continue
     return None
 
 

--- a/consent-protocol/tests/services/test_marketplace_investor_replenisher.py
+++ b/consent-protocol/tests/services/test_marketplace_investor_replenisher.py
@@ -111,12 +111,12 @@ def test_13f_dataset_archive_produces_public_sec_candidates():
         zf.writestr(
             "SUBMISSION.tsv",
             "ACCESSION_NUMBER\tCIK\tSUBMISSIONTYPE\tFILING_DATE\n"
-            "0000000001-26-000001\t1\t13F-HR\t2026-02-28\n",
+            "0000000001-26-000001\t1\t13F-HR\t31-DEC-2025\n",
         )
         zf.writestr(
             "COVERPAGE.tsv",
-            "ACCESSION_NUMBER\tFILINGMANAGER_NAME\n"
-            "0000000001-26-000001\tExample Capital Management\n",
+            "ACCESSION_NUMBER\tFILINGMANAGER_NAME\tFILINGMANAGER_STREET1\tFILINGMANAGER_CITY\tFILINGMANAGER_STATEORCOUNTRY\tFILINGMANAGER_ZIPCODE\n"
+            "0000000001-26-000001\tExample Capital Management\t100 Main St\tKirkland\tWA\t98033\n",
         )
 
     candidates = candidates_from_13f_dataset_archive(
@@ -129,5 +129,7 @@ def test_13f_dataset_archive_produces_public_sec_candidates():
     assert len(candidates) == 1
     assert candidates[0].cik == "0000000001"
     assert candidates[0].curation_tier == "showcase"
-    assert candidates[0].last_13f_date == date(2026, 2, 28)
+    assert candidates[0].last_13f_date == date(2025, 12, 31)
+    assert candidates[0].location_hint == "Kirkland, WA 98033"
+    assert candidates[0].business_address["street1"] == "100 Main St"
     assert candidates[0].source_urls[0].endswith("example_form13f.zip")


### PR DESCRIPTION
## Summary
- parse SEC 13F dataset dates like 31-DEC-2025
- preserve manager street/city/state/ZIP from 13F cover rows for location hints
- verify real SEC 13F archive can produce 100+ candidates without fake data

## Tests
- APP_SIGNING_KEY=... VAULT_DATA_KEY=... PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest --noconftest tests/services/test_marketplace_investor_replenisher.py tests/services/test_marketplace_investor_discovery.py tests/test_ria_iam_routes.py -q
- APP_SIGNING_KEY=... VAULT_DATA_KEY=... uv run ruff check hushh_mcp/services/marketplace_investor_replenisher.py tests/services/test_marketplace_investor_replenisher.py
- real SEC archive parse smoke produced 120 candidates