### PR TITLE
Add post-onboarding RIA license refresh

### DIFF
--- a/consent-protocol/api/routes/ria.py
+++ b/consent-protocol/api/routes/ria.py
@@ -81,6 +81,12 @@ class RIAOnboardingVerifyLicenseRequest(BaseModel):
     force_live_verification: bool = False
 
 
+class RIAProfileRefreshLicenseRequest(BaseModel):
+    license_number: str = Field(..., min_length=1)
+    regulator: str | None = None
+    force_live_verification: bool = False
+
+
 class RIAConsentRequestCreate(BaseModel):
     subject_user_id: str = Field(..., min_length=1)
     requester_actor_type: str = Field(default="ria")
@@ -285,6 +291,37 @@ async def onboarding_status(firebase_uid: str = Depends(require_firebase_auth)):
         return await service.get_ria_onboarding_status(firebase_uid)
     except IAMSchemaNotReadyError as exc:
         return _iam_schema_not_ready_response(str(exc))
+
+
+@router.post("/profile/refresh-license")
+@limiter.limit("6/minute")
+async def refresh_profile_license(
+    payload: RIAProfileRefreshLicenseRequest,
+    request: Request,
+    firebase_uid: str = Depends(require_firebase_auth),
+):
+    service = RIAIAMService()
+    try:
+        _ = request
+        return await service.refresh_ria_profile_from_license(
+            firebase_uid,
+            license_number=payload.license_number,
+            regulator=payload.regulator,
+            force_live_verification=payload.force_live_verification,
+        )
+    except IAMSchemaNotReadyError as exc:
+        return _iam_schema_not_ready_response(str(exc))
+    except RIAIAMPolicyError as exc:
+        if exc.status_code == 409:
+            return JSONResponse(
+                status_code=409,
+                content={
+                    "error": str(exc),
+                    "code": "RIA_ONBOARDING_REQUIRED",
+                    "route": "/ria/onboarding",
+                },
+            )
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
 
 @router.get("/home")

--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -9,7 +9,7 @@ import os
 import re
 import uuid
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from typing import Any, Literal
 
 import asyncpg
@@ -1366,6 +1366,444 @@ class RIAIAMService:
 
         return response
 
+    async def refresh_ria_profile_from_license(
+        self,
+        user_id: str,
+        *,
+        license_number: str,
+        regulator: str | None = None,
+        force_live_verification: bool = False,
+    ) -> dict[str, Any]:
+        normalized_license = self._normalize_crd_text(license_number)
+        if not normalized_license:
+            raise RIAIAMPolicyError("license_number is required.", status_code=400)
+
+        normalized_regulator = self._normalize_optional_text(regulator) or "SEC"
+        conn = await self._conn()
+        try:
+            await self._ensure_iam_schema_ready(conn)
+            profile = await conn.fetchrow(
+                """
+                SELECT id, user_id, display_name, legal_name, finra_crd, sec_iard
+                FROM ria_profiles
+                WHERE user_id = $1
+                """,
+                user_id,
+            )
+        except asyncpg.exceptions.UndefinedTableError as exc:
+            raise IAMSchemaNotReadyError() from exc
+        finally:
+            await conn.close()
+
+        if profile is None:
+            raise RIAIAMPolicyError(
+                "Complete RIA onboarding before refreshing license data.",
+                status_code=409,
+            )
+
+        verification = await self.verify_ria_license(
+            user_id,
+            license_number=normalized_license,
+            regulator=normalized_regulator,
+            force_live_verification=force_live_verification,
+        )
+
+        status = str(verification.get("status") or "").strip().lower()
+        profile_id = profile["id"]
+        provider = (
+            self._normalize_optional_text(verification.get("provider"))
+            or "ria_intelligence_combined"
+        )
+        refreshed_at = datetime.now(timezone.utc)
+        verification_expires_at = refreshed_at + timedelta(days=30)
+
+        if status != "found":
+            conn = await self._conn()
+            try:
+                async with conn.transaction():
+                    await self._ensure_iam_schema_ready(conn)
+                    await conn.execute(
+                        """
+                        INSERT INTO ria_license_verifications
+                          (user_id, license_number, regulator, verification_source, raw_response, status)
+                        VALUES ($1, $2, $3, $4, $5::jsonb, $6)
+                        """,
+                        user_id,
+                        normalized_license,
+                        normalized_regulator,
+                        "profile_refresh",
+                        json.dumps(
+                            {
+                                "response": verification,
+                                "applied_fields": [],
+                                "reason": "provider_did_not_return_found_status",
+                            },
+                            default=str,
+                        ),
+                        "pending",
+                    )
+                    await conn.execute(
+                        """
+                        INSERT INTO ria_verification_events (
+                          ria_profile_id,
+                          provider,
+                          outcome,
+                          checked_at,
+                          expires_at,
+                          reference_metadata
+                        )
+                        VALUES ($1, $2, $3, NOW(), NULL, $4::jsonb)
+                        """,
+                        profile_id,
+                        provider,
+                        status or "not_found",
+                        json.dumps(
+                            {
+                                "event_type": "profile_license_refresh",
+                                "response": verification,
+                                "updated": False,
+                            },
+                            default=str,
+                        ),
+                    )
+            except asyncpg.exceptions.UndefinedTableError as exc:
+                raise IAMSchemaNotReadyError() from exc
+            finally:
+                await conn.close()
+
+            return {
+                "updated": False,
+                "status": status or "not_found",
+                "message": "License could not be verified. No profile fields were changed.",
+                "ria_profile_id": str(profile_id),
+                "applied_fields": [],
+                "verification": verification,
+            }
+
+        official_name = self._normalize_optional_text(verification.get("advisor_name"))
+        official_crd = self._normalize_crd_text(
+            self._normalize_optional_text(verification.get("crd_number")) or normalized_license
+        )
+        sec_number = self._normalize_optional_text(verification.get("sec_number"))
+        firm_name = self._normalize_optional_text(verification.get("firm_name"))
+        regulator_status = self._normalize_optional_text(verification.get("regulator_status"))
+        license_expiry_date = self._coerce_date(verification.get("license_expiry"))
+        raw_certifications = verification.get("certifications")
+        certifications = (
+            [str(item).strip() for item in raw_certifications if str(item or "").strip()]
+            if isinstance(raw_certifications, list)
+            else []
+        )
+
+        official_location = verification.get("official_location")
+        official_location = official_location if isinstance(official_location, dict) else {}
+        business_city = self._normalize_optional_text(
+            verification.get("city") or official_location.get("city")
+        )
+        business_pin_zip = self._normalize_optional_text(
+            verification.get("pin_zip")
+            or official_location.get("pin_zip")
+            or official_location.get("pinZip")
+        )
+        business_area = self._normalize_optional_text(
+            verification.get("area_locality")
+            or official_location.get("area_locality")
+            or official_location.get("areaLocality")
+            or verification.get("state")
+            or official_location.get("state")
+        )
+        business_address = self._normalize_optional_text(
+            verification.get("full_street_address")
+            or verification.get("business_address")
+            or official_location.get("address")
+            or official_location.get("streetAddress")
+            or official_location.get("fullStreetAddress")
+        )
+
+        applied_fields: list[str] = [
+            "verification_status",
+            "verification_provider",
+            "verification_expires_at",
+            "advisory_status",
+            "advisory_provider",
+            "advisory_verification_expires_at",
+            "license_number",
+            "regulator",
+        ]
+        if official_name:
+            applied_fields.extend(["display_name", "legal_name", "individual_legal_name"])
+        if official_crd:
+            applied_fields.extend(["finra_crd", "individual_crd"])
+        if sec_number:
+            applied_fields.extend(["sec_iard", "advisory_firm_iapd_number"])
+        if firm_name:
+            applied_fields.append("advisory_firm_legal_name")
+        if regulator_status:
+            applied_fields.append("regulator_status")
+        if license_expiry_date:
+            applied_fields.append("license_expiry_date")
+        if certifications:
+            applied_fields.append("certifications")
+        if any([business_city, business_area, business_address, business_pin_zip]):
+            applied_fields.extend(
+                [
+                    key
+                    for key, value in {
+                        "business_city": business_city,
+                        "business_area": business_area,
+                        "business_address": business_address,
+                        "business_pin_zip": business_pin_zip,
+                    }.items()
+                    if value
+                ]
+            )
+
+        next_profile = {
+            "display_name": official_name or profile["display_name"],
+            "legal_name": official_name or profile["legal_name"],
+            "finra_crd": official_crd or profile["finra_crd"],
+            "sec_iard": sec_number or profile["sec_iard"],
+            "license_number": official_crd or normalized_license,
+            "regulator": normalized_regulator,
+            "regulator_status": regulator_status,
+            "license_expiry_date": license_expiry_date.isoformat() if license_expiry_date else None,
+            "certifications": certifications,
+            "advisory_firm_legal_name": firm_name,
+            "business_city": business_city,
+            "business_area": business_area,
+            "business_address": business_address,
+            "business_pin_zip": business_pin_zip,
+        }
+
+        conn = await self._conn()
+        try:
+            async with conn.transaction():
+                await self._ensure_iam_schema_ready(conn)
+                current_profile = await conn.fetchrow(
+                    """
+                    SELECT id
+                    FROM ria_profiles
+                    WHERE user_id = $1
+                    """,
+                    user_id,
+                )
+                if current_profile is None:
+                    raise RIAIAMPolicyError(
+                        "Complete RIA onboarding before refreshing license data.",
+                        status_code=409,
+                    )
+                profile_id = current_profile["id"]
+
+                await conn.execute(
+                    """
+                    UPDATE ria_profiles
+                    SET
+                      display_name = COALESCE(NULLIF($2, ''), display_name),
+                      legal_name = COALESCE(NULLIF($2, ''), legal_name),
+                      finra_crd = COALESCE(NULLIF($3, ''), finra_crd),
+                      sec_iard = COALESCE(NULLIF($4, ''), sec_iard),
+                      verification_status = 'verified',
+                      verification_provider = $5,
+                      verification_expires_at = $6,
+                      requested_capabilities = CASE
+                        WHEN 'advisory' = ANY(COALESCE(requested_capabilities, ARRAY[]::text[]))
+                          THEN requested_capabilities
+                        ELSE array_append(COALESCE(requested_capabilities, ARRAY[]::text[]), 'advisory')
+                      END,
+                      individual_legal_name = COALESCE(NULLIF($2, ''), individual_legal_name),
+                      individual_crd = COALESCE(NULLIF($3, ''), individual_crd),
+                      advisory_firm_legal_name = COALESCE(NULLIF($7, ''), advisory_firm_legal_name),
+                      advisory_firm_iapd_number = COALESCE(NULLIF($4, ''), advisory_firm_iapd_number),
+                      advisory_status = 'verified',
+                      advisory_provider = $5,
+                      advisory_verification_expires_at = $6,
+                      license_number = COALESCE(NULLIF($8, ''), license_number),
+                      regulator = COALESCE(NULLIF($9, ''), regulator),
+                      regulator_status = COALESCE(NULLIF($10, ''), regulator_status),
+                      license_expiry_date = COALESCE($11, license_expiry_date),
+                      certifications = CASE
+                        WHEN $12::text[] = '{}' THEN certifications
+                        ELSE $12::text[]
+                      END,
+                      updated_at = NOW()
+                    WHERE id = $1
+                    """,
+                    profile_id,
+                    official_name or "",
+                    official_crd or "",
+                    sec_number or "",
+                    provider,
+                    verification_expires_at,
+                    firm_name or "",
+                    official_crd or normalized_license,
+                    normalized_regulator,
+                    regulator_status or "",
+                    license_expiry_date,
+                    certifications,
+                )
+
+                if firm_name:
+                    firm_row = await conn.fetchrow(
+                        """
+                        INSERT INTO ria_firms (legal_name)
+                        VALUES ($1)
+                        ON CONFLICT (legal_name) DO UPDATE
+                        SET updated_at = NOW()
+                        RETURNING id
+                        """,
+                        firm_name,
+                    )
+                    if firm_row:
+                        await conn.execute(
+                            """
+                            INSERT INTO ria_firm_memberships (
+                              ria_profile_id,
+                              firm_id,
+                              role_title,
+                              membership_status,
+                              is_primary
+                            )
+                            VALUES ($1, $2, NULL, 'active', TRUE)
+                            ON CONFLICT (ria_profile_id, firm_id) DO UPDATE
+                            SET
+                              membership_status = 'active',
+                              is_primary = TRUE,
+                              updated_at = NOW()
+                            """,
+                            profile_id,
+                            firm_row["id"],
+                        )
+
+                if any([business_city, business_area, business_address, business_pin_zip]):
+                    await conn.execute(
+                        """
+                        INSERT INTO ria_business_contacts (
+                          user_id,
+                          city,
+                          area_locality,
+                          full_street_address,
+                          pin_zip
+                        )
+                        VALUES ($1, $2, $3, $4, $5)
+                        ON CONFLICT (user_id) DO UPDATE
+                        SET
+                          city = COALESCE(NULLIF(EXCLUDED.city, ''), ria_business_contacts.city),
+                          area_locality = COALESCE(NULLIF(EXCLUDED.area_locality, ''), ria_business_contacts.area_locality),
+                          full_street_address = COALESCE(NULLIF(EXCLUDED.full_street_address, ''), ria_business_contacts.full_street_address),
+                          pin_zip = COALESCE(NULLIF(EXCLUDED.pin_zip, ''), ria_business_contacts.pin_zip),
+                          updated_at = NOW()
+                        """,
+                        user_id,
+                        business_city or "",
+                        business_area or "",
+                        business_address or "",
+                        business_pin_zip or "",
+                    )
+
+                await conn.execute(
+                    """
+                    INSERT INTO marketplace_public_profiles (
+                      user_id,
+                      profile_type,
+                      display_name,
+                      headline,
+                      strategy_summary,
+                      verification_badge,
+                      is_discoverable,
+                      updated_at
+                    )
+                    VALUES (
+                      $1,
+                      'ria',
+                      COALESCE(NULLIF($2, ''), 'Registered Investment Advisor'),
+                      'Registered Investment Advisor',
+                      NULL,
+                      'verified',
+                      TRUE,
+                      NOW()
+                    )
+                    ON CONFLICT (user_id) DO UPDATE
+                    SET
+                      profile_type = 'ria',
+                      display_name = COALESCE(NULLIF(EXCLUDED.display_name, ''), marketplace_public_profiles.display_name),
+                      verification_badge = 'verified',
+                      updated_at = NOW()
+                    """,
+                    user_id,
+                    official_name or "",
+                )
+
+                await conn.execute(
+                    """
+                    INSERT INTO ria_license_verifications
+                      (user_id, license_number, regulator, verification_source, raw_response, status)
+                    VALUES ($1, $2, $3, $4, $5::jsonb, $6)
+                    """,
+                    user_id,
+                    official_crd or normalized_license,
+                    normalized_regulator,
+                    "profile_refresh",
+                    json.dumps(
+                        {
+                            "response": verification,
+                            "applied_fields": sorted(set(applied_fields)),
+                            "preserved_user_authored_fields": [
+                                "bio",
+                                "strategy",
+                                "services_offered",
+                                "fee_structure",
+                                "min_engagement_amount",
+                                "custom_headline",
+                                "email",
+                                "phone",
+                            ],
+                        },
+                        default=str,
+                    ),
+                    "completed",
+                )
+
+                await conn.execute(
+                    """
+                    INSERT INTO ria_verification_events (
+                      ria_profile_id,
+                      provider,
+                      outcome,
+                      checked_at,
+                      expires_at,
+                      reference_metadata
+                    )
+                    VALUES ($1, $2, 'verified', NOW(), $3, $4::jsonb)
+                    """,
+                    profile_id,
+                    provider,
+                    verification_expires_at,
+                    json.dumps(
+                        {
+                            "event_type": "profile_license_refresh",
+                            "response": verification,
+                            "updated": True,
+                            "applied_fields": sorted(set(applied_fields)),
+                        },
+                        default=str,
+                    ),
+                )
+        except asyncpg.exceptions.UndefinedTableError as exc:
+            raise IAMSchemaNotReadyError() from exc
+        finally:
+            await conn.close()
+
+        self._invalidate_cached_persona_state(user_id)
+        return {
+            "updated": True,
+            "status": "found",
+            "message": "Official RIA data updated.",
+            "ria_profile_id": str(profile_id),
+            "applied_fields": sorted(set(applied_fields)),
+            "profile": next_profile,
+            "verification": verification,
+        }
+
     @staticmethod
     def _has_usable_license_location(response: dict[str, Any]) -> bool:
         official_location = response.get("official_location")
@@ -1436,6 +1874,25 @@ class RIAIAMService:
         if parsed is None:
             return None
         return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    @staticmethod
+    def _coerce_date(value: Any) -> date | None:
+        if isinstance(value, datetime):
+            return value.date()
+        if isinstance(value, date):
+            return value
+        if isinstance(value, str):
+            candidate = value.strip()
+            if not candidate:
+                return None
+            try:
+                return datetime.fromisoformat(candidate.replace("Z", "+00:00")).date()
+            except ValueError:
+                try:
+                    return date.fromisoformat(candidate[:10])
+                except ValueError:
+                    return None
+        return None
 
     @classmethod
     def _add_license_cache_metadata(
@@ -3861,6 +4318,53 @@ class RIAIAMService:
             if event and "reference_metadata" in event:
                 event["reference_metadata"] = self._parse_metadata(event["reference_metadata"])
 
+            v2_profile: dict[str, Any] = {}
+            try:
+                v2_row = await conn.fetchrow(
+                    """
+                    SELECT
+                      license_number,
+                      regulator,
+                      regulator_status,
+                      license_expiry_date,
+                      certifications,
+                      onboarding_type,
+                      services_offered,
+                      fee_structure,
+                      min_engagement_amount,
+                      min_engagement_currency
+                    FROM ria_profiles
+                    WHERE id = $1
+                    """,
+                    ria["id"],
+                )
+                v2_profile = dict(v2_row) if v2_row else {}
+            except asyncpg.exceptions.UndefinedColumnError:
+                logger.warning("ria_profiles v2 columns unavailable during onboarding status")
+
+            business_contact: dict[str, Any] = {}
+            try:
+                contact_row = await conn.fetchrow(
+                    """
+                    SELECT
+                      city,
+                      area_locality,
+                      full_street_address,
+                      pin_zip,
+                      latitude,
+                      longitude
+                    FROM ria_business_contacts
+                    WHERE user_id = $1
+                    """,
+                    user_id,
+                )
+                business_contact = dict(contact_row) if contact_row else {}
+            except (
+                asyncpg.exceptions.UndefinedTableError,
+                asyncpg.exceptions.UndefinedColumnError,
+            ):
+                logger.warning("ria_business_contacts unavailable during onboarding status")
+
             if used_legacy_capabilities_fallback:
                 requested_capabilities = ["advisory"]
                 individual_legal_name = ria["legal_name"]
@@ -3913,6 +4417,22 @@ class RIAIAMService:
                 "verification_status": ria["verification_status"],
                 "verification_provider": ria["verification_provider"],
                 "verification_expires_at": ria["verification_expires_at"],
+                "license_number": v2_profile.get("license_number"),
+                "regulator": v2_profile.get("regulator"),
+                "regulator_status": v2_profile.get("regulator_status"),
+                "license_expiry_date": v2_profile.get("license_expiry_date"),
+                "certifications": list(v2_profile.get("certifications") or []),
+                "onboarding_type": v2_profile.get("onboarding_type"),
+                "services_offered": list(v2_profile.get("services_offered") or []),
+                "fee_structure": list(v2_profile.get("fee_structure") or []),
+                "min_engagement_amount": v2_profile.get("min_engagement_amount"),
+                "min_engagement_currency": v2_profile.get("min_engagement_currency"),
+                "business_city": business_contact.get("city"),
+                "business_area": business_contact.get("area_locality"),
+                "business_address": business_contact.get("full_street_address"),
+                "business_pin_zip": business_contact.get("pin_zip"),
+                "business_latitude": business_contact.get("latitude"),
+                "business_longitude": business_contact.get("longitude"),
                 "latest_verification_event": event,
             }
         except asyncpg.exceptions.UndefinedTableError as exc:

--- a/consent-protocol/tests/test_ria_iam_service_architecture.py
+++ b/consent-protocol/tests/test_ria_iam_service_architecture.py
@@ -567,6 +567,156 @@ async def test_submit_ria_onboarding_uses_provider_returned_crd(monkeypatch):
     assert result["individual_crd"] == "99999"
 
 
+@pytest.mark.asyncio
+async def test_refresh_ria_profile_from_license_updates_official_fields_only(monkeypatch):
+    service = RIAIAMService()
+    executed: list[tuple[str, tuple]] = []
+
+    class DummyTx:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class DummyConn:
+        def transaction(self):
+            return DummyTx()
+
+        async def fetchrow(self, query, *args):
+            _ = args
+            if "FROM ria_profiles" in query:
+                return {
+                    "id": "ria-1",
+                    "user_id": "user-1",
+                    "display_name": "User Authored Name",
+                    "legal_name": "Old Legal Name",
+                    "finra_crd": "11111",
+                    "sec_iard": "801-OLD",
+                }
+            if "INSERT INTO ria_firms" in query:
+                return {"id": "firm-1"}
+            return None
+
+        async def execute(self, query, *args):
+            executed.append((query, args))
+            return "OK"
+
+        async def close(self):
+            return None
+
+    async def _fake_conn():
+        return DummyConn()
+
+    async def _fake_schema_ready(_conn):
+        return None
+
+    async def _fake_verify_license(_user_id, **kwargs):
+        assert kwargs["license_number"] == "7413463"
+        return {
+            "status": "found",
+            "advisor_name": "Andrew Garrett Kirkland",
+            "firm_name": "Financial Advocates Advisory Services",
+            "regulator": "SEC",
+            "regulator_status": "ACTIVE",
+            "certifications": ["SIE", "Series 7TO"],
+            "city": "Kennesaw",
+            "state": "GA",
+            "pin_zip": "30144",
+            "full_street_address": "123 Main St",
+            "crd_number": "7413463",
+            "provider": "ria_intelligence_combined",
+        }
+
+    monkeypatch.setattr(service, "_conn", _fake_conn)
+    monkeypatch.setattr(service, "_ensure_iam_schema_ready", _fake_schema_ready)
+    monkeypatch.setattr(service, "verify_ria_license", _fake_verify_license)
+
+    result = await service.refresh_ria_profile_from_license(
+        "user-1",
+        license_number="7413463",
+        regulator="SEC",
+        force_live_verification=True,
+    )
+
+    assert result["updated"] is True
+    assert result["profile"]["business_city"] == "Kennesaw"
+    assert "services_offered" not in result["applied_fields"]
+    update_profile_queries = [query for query, _args in executed if "UPDATE ria_profiles" in query]
+    assert update_profile_queries
+    profile_update = update_profile_queries[0]
+    assert "bio =" not in profile_update
+    assert "strategy =" not in profile_update
+    assert "services_offered =" not in profile_update
+    assert "fee_structure =" not in profile_update
+    assert "min_engagement_amount =" not in profile_update
+
+
+@pytest.mark.asyncio
+async def test_refresh_ria_profile_from_license_preserves_profile_on_provider_failure(
+    monkeypatch,
+):
+    service = RIAIAMService()
+    executed: list[str] = []
+
+    class DummyTx:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class DummyConn:
+        def transaction(self):
+            return DummyTx()
+
+        async def fetchrow(self, query, *args):
+            _ = args
+            if "FROM ria_profiles" in query:
+                return {
+                    "id": "ria-1",
+                    "user_id": "user-1",
+                    "display_name": "User Authored Name",
+                    "legal_name": "Old Legal Name",
+                    "finra_crd": "11111",
+                    "sec_iard": "801-OLD",
+                }
+            return None
+
+        async def execute(self, query, *args):
+            _ = args
+            executed.append(query)
+            return "OK"
+
+        async def close(self):
+            return None
+
+    async def _fake_conn():
+        return DummyConn()
+
+    async def _fake_schema_ready(_conn):
+        return None
+
+    async def _fake_verify_license(_user_id, **_kwargs):
+        return {
+            "status": "not_found",
+            "provider": "ria_intelligence_combined",
+        }
+
+    monkeypatch.setattr(service, "_conn", _fake_conn)
+    monkeypatch.setattr(service, "_ensure_iam_schema_ready", _fake_schema_ready)
+    monkeypatch.setattr(service, "verify_ria_license", _fake_verify_license)
+
+    result = await service.refresh_ria_profile_from_license(
+        "user-1",
+        license_number="0000000",
+    )
+
+    assert result["updated"] is False
+    assert result["applied_fields"] == []
+    assert not any("UPDATE ria_profiles" in query for query in executed)
+
+
 def test_dev_activation_method_removed():
     """activate_ria_dev_onboarding was fully removed — method must not exist."""
     service = RIAIAMService()

--- a/consent-protocol/tests/test_ria_onboarding_v2.py
+++ b/consent-protocol/tests/test_ria_onboarding_v2.py
@@ -1021,6 +1021,81 @@ def test_verify_license_provider_timeout(monkeypatch) -> None:
 
 
 # ===================================================================
+# Route: POST /api/ria/profile/refresh-license
+# ===================================================================
+
+
+def test_refresh_license_profile_route_maps_payload(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    async def _mock_refresh(
+        self,
+        user_id,
+        *,
+        license_number,
+        regulator=None,
+        force_live_verification=False,
+    ):
+        captured.update(
+            {
+                "user_id": user_id,
+                "license_number": license_number,
+                "regulator": regulator,
+                "force_live_verification": force_live_verification,
+            }
+        )
+        return {
+            "updated": True,
+            "status": "found",
+            "message": "Official RIA data updated.",
+            "applied_fields": ["finra_crd"],
+        }
+
+    monkeypatch.setattr(RIAIAMService, "refresh_ria_profile_from_license", _mock_refresh)
+
+    client = TestClient(_authed_app())
+    response = client.post(
+        "/api/ria/profile/refresh-license",
+        json={
+            "license_number": "7413463",
+            "regulator": "SEC",
+            "force_live_verification": True,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["updated"] is True
+    assert captured == {
+        "user_id": _TEST_UID,
+        "license_number": "7413463",
+        "regulator": "SEC",
+        "force_live_verification": True,
+    }
+
+
+def test_refresh_license_profile_route_requires_existing_ria(monkeypatch) -> None:
+    async def _mock_refresh(self, user_id, **_kwargs):
+        assert user_id == _TEST_UID
+        raise RIAIAMPolicyError(
+            "Complete RIA onboarding before refreshing license data.",
+            status_code=409,
+        )
+
+    monkeypatch.setattr(RIAIAMService, "refresh_ria_profile_from_license", _mock_refresh)
+
+    client = TestClient(_authed_app(), raise_server_exceptions=False)
+    response = client.post(
+        "/api/ria/profile/refresh-license",
+        json={"license_number": "7413463"},
+    )
+
+    assert response.status_code == 409
+    payload = response.json()
+    assert payload["code"] == "RIA_ONBOARDING_REQUIRED"
+    assert payload["route"] == "/ria/onboarding"
+
+
+# ===================================================================
 # Route: POST /api/ria/onboarding/submit  (v2 extension)
 # ===================================================================
 

--- a/hushh-webapp/__tests__/lib/profile/profile-ria-regulatory-row.test.ts
+++ b/hushh-webapp/__tests__/lib/profile/profile-ria-regulatory-row.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getProfileRiaRefreshLicenseNumber,
+  resolveProfileRiaRegulatoryRow,
+} from "@/lib/profile/profile-ria-regulatory-row";
+
+describe("resolveProfileRiaRegulatoryRow", () => {
+  it("disables the regulatory row while status is loading", () => {
+    expect(
+      resolveProfileRiaRegulatoryRow({
+        loading: true,
+        status: null,
+        error: null,
+      }),
+    ).toMatchObject({
+      action: "wait",
+      title: "Regulatory profile",
+      badge: "Checking",
+      disabled: true,
+    });
+  });
+
+  it("routes users without an RIA profile back to onboarding", () => {
+    expect(
+      resolveProfileRiaRegulatoryRow({
+        loading: false,
+        status: { exists: false, verification_status: "draft" },
+        error: null,
+      }),
+    ).toMatchObject({
+      action: "onboarding",
+      badge: "Setup",
+      disabled: false,
+    });
+  });
+
+  it("prefers stored license number for an existing RIA profile", () => {
+    const state = resolveProfileRiaRegulatoryRow({
+      loading: false,
+      status: {
+        exists: true,
+        verification_status: "verified",
+        license_number: "7413463",
+        individual_crd: "1111111",
+      },
+      error: null,
+    });
+
+    expect(state).toMatchObject({
+      action: "refresh",
+      badge: "Update",
+      disabled: false,
+    });
+    expect(state.description).toContain("7413463");
+  });
+
+  it("falls back to individual CRD for refresh prefill", () => {
+    expect(
+      getProfileRiaRefreshLicenseNumber({
+        exists: true,
+        verification_status: "verified",
+        individual_crd: "7265726",
+      }),
+    ).toBe("7265726");
+  });
+});

--- a/hushh-webapp/__tests__/services/ria-service-refresh-license.test.ts
+++ b/hushh-webapp/__tests__/services/ria-service-refresh-license.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiFetchMock = vi.fn();
+
+vi.mock("@/lib/services/api-service", () => ({
+  ApiService: {
+    apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+  },
+}));
+
+vi.mock("@/lib/cache/request-audit-log", () => ({
+  logRequestAudit: vi.fn(),
+}));
+
+vi.mock("@/lib/services/device-resource-cache-service", () => ({
+  DeviceResourceCacheService: {
+    read: vi.fn(),
+    write: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/services/personal-knowledge-model-service", () => ({
+  PersonalKnowledgeModelService: {},
+  PkmScopeExposureError: class PkmScopeExposureError extends Error {},
+}));
+
+vi.mock("@/lib/services/pkm-write-coordinator", () => ({
+  PkmWriteCoordinator: {},
+}));
+
+vi.mock("@/lib/observability/client", () => ({
+  trackEvent: vi.fn(),
+  toEventResult: vi.fn((value) => value),
+  toStatusBucket: vi.fn((value) => value),
+}));
+
+vi.mock("@/lib/observability/growth", () => ({
+  resolveGrowthWorkspaceSource: vi.fn(() => "test"),
+  trackGrowthFunnelStepCompleted: vi.fn(),
+}));
+
+describe("RiaService.refreshLicenseProfile", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    apiFetchMock.mockReset();
+  });
+
+  it("posts the signed-in refresh payload to the profile endpoint", async () => {
+    apiFetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          updated: true,
+          status: "found",
+          message: "Official RIA data updated.",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const { RiaService } = await import("@/lib/services/ria-service");
+    const result = await RiaService.refreshLicenseProfile("id-token", {
+      license_number: "7413463",
+      regulator: "SEC",
+      force_live_verification: true,
+    });
+
+    expect(result.updated).toBe(true);
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      "/api/ria/profile/refresh-license",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer id-token",
+        },
+        body: JSON.stringify({
+          license_number: "7413463",
+          regulator: "SEC",
+          force_live_verification: true,
+        }),
+        signal: undefined,
+      },
+    );
+  });
+});

--- a/hushh-webapp/app/api/ria/[...path]/route.ts
+++ b/hushh-webapp/app/api/ria/[...path]/route.ts
@@ -11,12 +11,20 @@ export const dynamic = "force-dynamic";
 const HOT_GET_CACHE_TTL_MS = 30 * 1000;
 const DEFAULT_PROXY_TIMEOUT_MS = 12_000;
 const ONBOARDING_PROXY_TIMEOUT_MS = Number(
-  process.env.RIA_ONBOARDING_PROXY_TIMEOUT_MS || 90_000
+  process.env.RIA_ONBOARDING_PROXY_TIMEOUT_MS || 90_000,
 );
-const hotGetCache = new Map<string, { status: number; payload: unknown; cachedAt: number }>();
-const hotGetInflight = new Map<string, Promise<{ status: number; payload: unknown }>>();
+const hotGetCache = new Map<
+  string,
+  { status: number; payload: unknown; cachedAt: number }
+>();
+const hotGetInflight = new Map<
+  string,
+  Promise<{ status: number; payload: unknown }>
+>();
 
-function readHotGetCache(key: string): { status: number; payload: unknown } | null {
+function readHotGetCache(
+  key: string,
+): { status: number; payload: unknown } | null {
   const cached = hotGetCache.get(key);
   if (!cached) return null;
   if (Date.now() - cached.cachedAt > HOT_GET_CACHE_TTL_MS) {
@@ -29,7 +37,10 @@ function readHotGetCache(key: string): { status: number; payload: unknown } | nu
   };
 }
 
-function writeHotGetCache(key: string, value: { status: number; payload: unknown }): void {
+function writeHotGetCache(
+  key: string,
+  value: { status: number; payload: unknown },
+): void {
   hotGetCache.set(key, {
     ...value,
     cachedAt: Date.now(),
@@ -39,11 +50,10 @@ function writeHotGetCache(key: string, value: { status: number; payload: unknown
 function resolveProxyTimeoutMs(path: string, method: "GET" | "POST"): number {
   if (
     method === "POST" &&
-    (
-      path.startsWith("onboarding/submit") ||
+    (path.startsWith("onboarding/submit") ||
       path.startsWith("onboarding/verify-name") ||
-      path.startsWith("onboarding/verify-license")
-    )
+      path.startsWith("onboarding/verify-license") ||
+      path.startsWith("profile/refresh-license"))
   ) {
     return ONBOARDING_PROXY_TIMEOUT_MS;
   }
@@ -53,19 +63,27 @@ function resolveProxyTimeoutMs(path: string, method: "GET" | "POST"): number {
 function isTimeoutError(error: unknown): boolean {
   if (!error) return false;
   if (typeof error === "string") {
-    return error.includes("TimeoutError") || error.includes("aborted due to timeout");
+    return (
+      error.includes("TimeoutError") || error.includes("aborted due to timeout")
+    );
   }
-  const candidate = error as { name?: unknown; code?: unknown; message?: unknown };
+  const candidate = error as {
+    name?: unknown;
+    code?: unknown;
+    message?: unknown;
+  };
   if (candidate.name === "TimeoutError") return true;
   if (candidate.code === 23) return true;
   const text = String(candidate.message || error);
-  return text.includes("TimeoutError") || text.includes("aborted due to timeout");
+  return (
+    text.includes("TimeoutError") || text.includes("aborted due to timeout")
+  );
 }
 
 async function proxyRequest(
   request: NextRequest,
   params: { path: string[] },
-  method: "GET" | "POST"
+  method: "GET" | "POST",
 ) {
   const requestId = resolveRequestId(request);
   const path = params.path.join("/");
@@ -82,7 +100,10 @@ async function proxyRequest(
     ...(authHeader ? { Authorization: authHeader } : {}),
     ...(method === "POST" ? { "Content-Type": "application/json" } : {}),
   });
-  const body = method === "POST" ? JSON.stringify(await request.json().catch(() => ({}))) : undefined;
+  const body =
+    method === "POST"
+      ? JSON.stringify(await request.json().catch(() => ({})))
+      : undefined;
 
   if (hotCacheKey) {
     const cached = readHotGetCache(hotCacheKey);
@@ -125,6 +146,10 @@ async function proxyRequest(
 
     const result = await load;
 
+    if (method === "POST" && path === "profile/refresh-license" && authHeader) {
+      hotGetCache.delete(`onboarding/status:${authHeader}`);
+    }
+
     if (hotCacheKey && result.status < 500) {
       writeHotGetCache(hotCacheKey, result);
     }
@@ -133,23 +158,27 @@ async function proxyRequest(
       status: result.status,
     });
   } catch (error) {
-    console.error(`[RIA API] request_id=${requestId} proxy_error path=${path}`, error);
+    console.error(
+      `[RIA API] request_id=${requestId} proxy_error path=${path}`,
+      error,
+    );
     if (isTimeoutError(error)) {
       return withRequestIdJson(
         requestId,
         {
-          error: "RIA request timed out while waiting for backend verification.",
+          error:
+            "RIA request timed out while waiting for backend verification.",
           code: "RIA_PROXY_TIMEOUT",
           timeout_ms: timeoutMs,
           path,
         },
-        { status: 504 }
+        { status: 504 },
       );
     }
     return withRequestIdJson(
       requestId,
       { error: "Failed to proxy RIA request" },
-      { status: 500 }
+      { status: 500 },
     );
   } finally {
     if (hotCacheKey) {
@@ -160,14 +189,14 @@ async function proxyRequest(
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: Promise<{ path: string[] }> }
+  { params }: { params: Promise<{ path: string[] }> },
 ) {
   return proxyRequest(request, await params, "GET");
 }
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: Promise<{ path: string[] }> }
+  { params }: { params: Promise<{ path: string[] }> },
 ) {
   return proxyRequest(request, await params, "POST");
 }

--- a/hushh-webapp/app/profile/page.tsx
+++ b/hushh-webapp/app/profile/page.tsx
@@ -104,6 +104,10 @@ import {
   resolveGmailStatusSummary,
   sanitizeGmailUserMessage,
 } from "@/lib/profile/mail-flow";
+import {
+  getProfileRiaRefreshLicenseNumber,
+  resolveProfileRiaRegulatoryRow,
+} from "@/lib/profile/profile-ria-regulatory-row";
 import { resolveProfileVaultSettingsRow } from "@/lib/profile/profile-vault-settings-row";
 import { usePersonaState } from "@/lib/persona/persona-context";
 import { Icon } from "@/lib/morphy-ux/ui";
@@ -118,7 +122,10 @@ import {
   setOnboardingFlowActiveCookie,
   setOnboardingRequiredCookie,
 } from "@/lib/services/onboarding-route-cookie";
-import { RiaService } from "@/lib/services/ria-service";
+import {
+  RiaService,
+  type RiaOnboardingStatus,
+} from "@/lib/services/ria-service";
 import {
   ConsentCenterService,
   type ConsentCenterResponse,
@@ -623,6 +630,21 @@ function ProfilePageContent() {
   const [marketplaceOptIn, setMarketplaceOptIn] = useState(false);
   const [loadingMarketplaceOptIn, setLoadingMarketplaceOptIn] = useState(true);
   const [savingMarketplaceOptIn, setSavingMarketplaceOptIn] = useState(false);
+  const [riaOnboardingStatus, setRiaOnboardingStatus] =
+    useState<RiaOnboardingStatus | null>(null);
+  const [loadingRiaOnboardingStatus, setLoadingRiaOnboardingStatus] =
+    useState(false);
+  const [riaOnboardingStatusError, setRiaOnboardingStatusError] = useState<
+    string | null
+  >(null);
+  const [showRegulatoryRefresh, setShowRegulatoryRefresh] = useState(false);
+  const [regulatoryLicenseNumber, setRegulatoryLicenseNumber] = useState("");
+  const [regulatoryRegulator, setRegulatoryRegulator] = useState("SEC");
+  const [refreshingRegulatoryProfile, setRefreshingRegulatoryProfile] =
+    useState(false);
+  const [regulatoryRefreshMessage, setRegulatoryRefreshMessage] = useState<
+    string | null
+  >(null);
   const [supportKind, setSupportKind] =
     useState<SupportMessageKind>("support_request");
   const [supportSubject, setSupportSubject] = useState("");
@@ -959,6 +981,44 @@ function ProfilePageContent() {
     setMarketplaceOptIn(Boolean(personaState.investor_marketplace_opt_in));
     setLoadingMarketplaceOptIn(false);
   }, [personaState, user]);
+
+  const refreshRiaOnboardingStatus = useCallback(
+    async (force = false) => {
+      if (!user?.uid || !user.getIdToken || !hasRiaPersona) {
+        setRiaOnboardingStatus(null);
+        setRiaOnboardingStatusError(null);
+        setLoadingRiaOnboardingStatus(false);
+        return null;
+      }
+
+      setLoadingRiaOnboardingStatus(true);
+      setRiaOnboardingStatusError(null);
+      try {
+        const idToken = await user.getIdToken();
+        const nextStatus = await RiaService.getOnboardingStatus(idToken, {
+          userId: user.uid,
+          force,
+        });
+        setRiaOnboardingStatus(nextStatus);
+        return nextStatus;
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Couldn't load RIA regulatory status.";
+        setRiaOnboardingStatusError(message);
+        return null;
+      } finally {
+        setLoadingRiaOnboardingStatus(false);
+      }
+    },
+    [hasRiaPersona, user],
+  );
+
+  useEffect(() => {
+    if (authLoading) return;
+    void refreshRiaOnboardingStatus(false);
+  }, [authLoading, refreshRiaOnboardingStatus]);
 
   const refreshPkmMetadata = useCallback(
     async (force = false) => {
@@ -1829,6 +1889,28 @@ function ProfilePageContent() {
         ? "Locked"
         : readableMethod(displayedUnlockMethod);
   const vaultSettingsRow = resolveProfileVaultSettingsRow(vaultAccess);
+  const shouldShowRiaRegulatoryRow =
+    hasRiaPersona || Boolean(riaOnboardingStatus?.exists);
+  const riaRegulatoryRow = resolveProfileRiaRegulatoryRow({
+    loading: loadingRiaOnboardingStatus,
+    status: riaOnboardingStatus,
+    error: riaOnboardingStatusError,
+  });
+  const currentRiaLicenseNumber =
+    getProfileRiaRefreshLicenseNumber(riaOnboardingStatus);
+  const currentRiaRegulatorMetadata =
+    riaOnboardingStatus?.latest_verification_event?.reference_metadata
+      ?.provider;
+  const currentRiaRegulator =
+    riaOnboardingStatus?.regulator ||
+    (typeof currentRiaRegulatorMetadata === "string"
+      ? currentRiaRegulatorMetadata
+      : null) ||
+    "SEC";
+  const currentRiaFirm =
+    riaOnboardingStatus?.advisory_firm_legal_name ||
+    riaOnboardingStatus?.display_name ||
+    "Official regulator record";
   const profileVoiceSurfaceMetadata = useMemo(() => {
     const controls = [
       {
@@ -1862,6 +1944,25 @@ function ProfilePageContent() {
           "vault security",
         ],
       },
+      ...(shouldShowRiaRegulatoryRow
+        ? [
+            {
+              id: "profile_ria_regulatory",
+              label: "Regulatory profile",
+              purpose:
+                "updates official RIA license, CRD, firm, certification, and business location data.",
+              actionId: "ria.profile.refresh_license",
+              role: "card",
+              voiceAliases: [
+                "update my RIA license",
+                "refresh regulatory profile",
+                "sync CRD data",
+                "update license data",
+                "regulatory profile",
+              ],
+            },
+          ]
+        : []),
       {
         id: "profile_account",
         label: "Account",
@@ -1939,6 +2040,7 @@ function ProfilePageContent() {
       : [
           "Account",
           "Vault",
+          ...(shouldShowRiaRegulatoryRow ? ["Regulatory profile"] : []),
           "Personal Knowledge Model",
           "Access & sharing",
           "Preferences",
@@ -1973,6 +2075,9 @@ function ProfilePageContent() {
               : [
                   "Open Account",
                   vaultSettingsRow.title,
+                  ...(shouldShowRiaRegulatoryRow
+                    ? ["Update license data"]
+                    : []),
                   "Open Personal Knowledge Model",
                   "Open Access & sharing",
                   "Open Gmail receipts",
@@ -2070,13 +2175,15 @@ function ProfilePageContent() {
         ? "passphrase_dialog"
         : showVaultUnlock
           ? "vault_unlock"
-          : supportComposeKind
-            ? "support_compose"
-            : activeDetail
-              ? `${activePanel}_${activeDetail}`
-              : activePanel
-                ? `${activePanel}_panel`
-                : null,
+          : showRegulatoryRefresh
+            ? "ria_license_refresh"
+            : supportComposeKind
+              ? "support_compose"
+              : activeDetail
+                ? `${activePanel}_${activeDetail}`
+                : activePanel
+                  ? `${activePanel}_panel`
+                  : null,
       availableActions,
       activeControlId: activeVoiceControlId,
       lastInteractedControlId: lastVoiceControlId,
@@ -2085,6 +2192,7 @@ function ProfilePageContent() {
         ...(sendingSupportMessage ? ["support_message"] : []),
         ...(switchingVaultMethod ? ["vault_method_update"] : []),
         ...(savingMarketplaceOptIn ? ["marketplace_visibility_update"] : []),
+        ...(refreshingRegulatoryProfile ? ["ria_license_refresh"] : []),
       ],
       screenMetadata: {
         profile_panel: activePanel,
@@ -2100,6 +2208,9 @@ function ProfilePageContent() {
         google_email: gmail.status?.google_email || null,
         pkm_agent_lab_available: canShowPkmAgentLab,
         marketplace_opt_in: marketplaceOptIn,
+        ria_regulatory_profile_visible: shouldShowRiaRegulatoryRow,
+        ria_license_number: currentRiaLicenseNumber || null,
+        ria_regulator: currentRiaRegulator,
         security_summary: securitySummaryText,
         phone_verified: Boolean(phoneNumber),
         email_verified: emailVerified,
@@ -2110,6 +2221,8 @@ function ProfilePageContent() {
     activePanel,
     activeVoiceControlId,
     canShowPkmAgentLab,
+    currentRiaLicenseNumber,
+    currentRiaRegulator,
     gmailActionsBusy,
     gmailLastSyncText,
     gmailPresentation.isConnected,
@@ -2124,9 +2237,12 @@ function ProfilePageContent() {
     phoneNumber,
     profileSummary.totalAttributes,
     profileSummary.totalDomains,
+    refreshingRegulatoryProfile,
     savingMarketplaceOptIn,
     securitySummaryText,
     sendingSupportMessage,
+    shouldShowRiaRegulatoryRow,
+    showRegulatoryRefresh,
     showVaultUnlock,
     supportComposeKind,
     switchingVaultMethod,
@@ -2240,6 +2356,84 @@ function ProfilePageContent() {
       return;
     }
     openSecurityPanel();
+  };
+
+  const openRegulatoryProfileRow = async () => {
+    if (riaRegulatoryRow.action === "wait") return;
+    if (riaRegulatoryRow.action === "onboarding") {
+      router.push(ROUTES.RIA_ONBOARDING);
+      return;
+    }
+
+    const latestStatus =
+      riaOnboardingStatus ?? (await refreshRiaOnboardingStatus(true));
+    if (!latestStatus?.exists) {
+      router.push(ROUTES.RIA_ONBOARDING);
+      return;
+    }
+
+    setRegulatoryLicenseNumber(getProfileRiaRefreshLicenseNumber(latestStatus));
+    setRegulatoryRegulator(latestStatus.regulator || "SEC");
+    setRegulatoryRefreshMessage(null);
+    setShowRegulatoryRefresh(true);
+  };
+
+  const submitRegulatoryProfileRefresh = async () => {
+    if (!user?.uid || !user.getIdToken) return;
+    const nextLicenseNumber = regulatoryLicenseNumber.trim();
+    if (!nextLicenseNumber) {
+      setRegulatoryRefreshMessage("Enter a license or CRD number first.");
+      return;
+    }
+
+    setRefreshingRegulatoryProfile(true);
+    setRegulatoryRefreshMessage(null);
+    try {
+      const idToken = await user.getIdToken();
+      const result = await RiaService.refreshLicenseProfile(idToken, {
+        license_number: nextLicenseNumber,
+        regulator: regulatoryRegulator.trim() || undefined,
+        force_live_verification: true,
+      });
+
+      if (!result.updated) {
+        const message =
+          result.message ||
+          "The regulator did not return a verified profile. No fields were changed.";
+        setRegulatoryRefreshMessage(message);
+        toast.error("Official RIA data was not updated.", {
+          description: message,
+        });
+        return;
+      }
+
+      CacheSyncService.onPersonaStateChanged(user.uid, {
+        preservePersonaState: true,
+      });
+      const nextStatus = await refreshRiaOnboardingStatus(true);
+      if (nextStatus) {
+        setRegulatoryLicenseNumber(
+          getProfileRiaRefreshLicenseNumber(nextStatus),
+        );
+        setRegulatoryRegulator(
+          nextStatus.regulator || regulatoryRegulator || "SEC",
+        );
+      }
+      await refreshPersonaState({ force: true });
+      toast.success("Official RIA data updated.");
+      setShowRegulatoryRefresh(false);
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Couldn't update official RIA data.";
+      setRegulatoryRefreshMessage(message);
+      toast.error("Couldn't update official RIA data.", {
+        description: message,
+      });
+    } finally {
+      setRefreshingRegulatoryProfile(false);
+    }
   };
 
   const handlePreviewDomainPermission = async (
@@ -3548,6 +3742,24 @@ function ProfilePageContent() {
                 voicePurpose={vaultSettingsRow.voicePurpose}
                 onClick={openVaultSettingsRow}
               />
+              {shouldShowRiaRegulatoryRow ? (
+                <SettingsRow
+                  icon={ClipboardCheck}
+                  title={riaRegulatoryRow.title}
+                  description={riaRegulatoryRow.description}
+                  trailing={
+                    <Badge variant="secondary">{riaRegulatoryRow.badge}</Badge>
+                  }
+                  chevron
+                  stackTrailingOnMobile
+                  disabled={riaRegulatoryRow.disabled}
+                  voiceControlId="profile_ria_regulatory"
+                  voiceActionId="ria.profile.refresh_license"
+                  voiceLabel="Regulatory profile"
+                  voicePurpose="Update official RIA license and CRD data from the regulator."
+                  onClick={() => void openRegulatoryProfileRow()}
+                />
+              ) : null}
               <SettingsRow
                 icon={Phone}
                 title="Account"
@@ -3686,6 +3898,95 @@ function ProfilePageContent() {
           }}
         />
       )}
+
+      <Dialog
+        open={showRegulatoryRefresh}
+        onOpenChange={setShowRegulatoryRefresh}
+      >
+        <DialogContent className="w-[calc(100%-1rem)] max-h-[calc(100svh-1rem)] overflow-y-auto sm:max-w-lg">
+          <DialogTitle>Update license data</DialogTitle>
+          <DialogDescription>
+            Refresh official regulator fields. Your bio, services, fees, email,
+            phone, and custom profile copy stay unchanged.
+          </DialogDescription>
+          <div className="space-y-4 pt-2">
+            <div className="rounded-2xl border bg-muted/30 px-4 py-3 text-sm">
+              <p className="font-medium text-foreground">{currentRiaFirm}</p>
+              <p className="mt-1 text-muted-foreground">
+                Current CRD {currentRiaLicenseNumber || "not stored"} -{" "}
+                {currentRiaRegulator}
+              </p>
+            </div>
+
+            <label className="block space-y-1.5">
+              <span className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                License / CRD
+              </span>
+              <Input
+                value={regulatoryLicenseNumber}
+                onChange={(event) =>
+                  setRegulatoryLicenseNumber(event.target.value)
+                }
+                inputMode="numeric"
+                placeholder="Enter license or CRD number"
+                disabled={refreshingRegulatoryProfile}
+              />
+            </label>
+
+            <label className="block space-y-1.5">
+              <span className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                Regulator
+              </span>
+              <Input
+                value={regulatoryRegulator}
+                onChange={(event) => setRegulatoryRegulator(event.target.value)}
+                placeholder="SEC"
+                disabled={refreshingRegulatoryProfile}
+              />
+            </label>
+
+            {regulatoryRefreshMessage ? (
+              <p className="rounded-2xl bg-destructive/10 px-4 py-3 text-sm text-destructive">
+                {regulatoryRefreshMessage}
+              </p>
+            ) : null}
+
+            <div className="flex flex-col-reverse gap-2 pt-1 sm:flex-row sm:items-center sm:justify-end">
+              <Button
+                variant="none"
+                effect="fade"
+                size="default"
+                className="w-full sm:w-auto"
+                onClick={() => setShowRegulatoryRefresh(false)}
+                disabled={refreshingRegulatoryProfile}
+              >
+                Cancel
+              </Button>
+              <Button
+                size="default"
+                className="w-full sm:w-auto"
+                disabled={
+                  refreshingRegulatoryProfile || !regulatoryLicenseNumber.trim()
+                }
+                onClick={() => void submitRegulatoryProfileRefresh()}
+              >
+                {refreshingRegulatoryProfile ? (
+                  <>
+                    <Icon
+                      icon={Loader2}
+                      size="sm"
+                      className="mr-2 animate-spin"
+                    />
+                    Updating...
+                  </>
+                ) : (
+                  "Update official data"
+                )}
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
 
       <Dialog
         open={passphraseDialogOpen}

--- a/hushh-webapp/lib/profile/profile-ria-regulatory-row.ts
+++ b/hushh-webapp/lib/profile/profile-ria-regulatory-row.ts
@@ -1,0 +1,78 @@
+import type { RiaOnboardingStatus } from "@/lib/services/ria-service";
+
+export type ProfileRiaRegulatoryRowAction = "wait" | "onboarding" | "refresh";
+
+export type ProfileRiaRegulatoryRowState = {
+  action: ProfileRiaRegulatoryRowAction;
+  title: string;
+  description: string;
+  badge: string;
+  disabled: boolean;
+};
+
+function preferredLicenseNumber(
+  status: RiaOnboardingStatus | null,
+): string | null {
+  const value =
+    status?.license_number ||
+    status?.individual_crd ||
+    status?.finra_crd ||
+    status?.advisory_firm_iapd_number ||
+    status?.sec_iard ||
+    "";
+  const normalized = String(value).trim();
+  return normalized || null;
+}
+
+export function resolveProfileRiaRegulatoryRow(params: {
+  loading: boolean;
+  status: RiaOnboardingStatus | null;
+  error: string | null;
+}): ProfileRiaRegulatoryRowState {
+  if (params.loading) {
+    return {
+      action: "wait",
+      title: "Regulatory profile",
+      description: "Checking official license data.",
+      badge: "Checking",
+      disabled: true,
+    };
+  }
+
+  if (params.error) {
+    return {
+      action: "refresh",
+      title: "Regulatory profile",
+      description: "Status unavailable. Open to retry official data sync.",
+      badge: "Retry",
+      disabled: false,
+    };
+  }
+
+  if (!params.status?.exists) {
+    return {
+      action: "onboarding",
+      title: "Regulatory profile",
+      description: "Complete onboarding before syncing official license data.",
+      badge: "Setup",
+      disabled: false,
+    };
+  }
+
+  const licenseNumber = preferredLicenseNumber(params.status);
+  return {
+    action: "refresh",
+    title: "Regulatory profile",
+    description: licenseNumber
+      ? `Update license data for CRD ${licenseNumber}.`
+      : "Update official license data from your regulator.",
+    badge: "Update",
+    disabled: false,
+  };
+}
+
+export function getProfileRiaRefreshLicenseNumber(
+  status: RiaOnboardingStatus | null,
+): string {
+  return preferredLicenseNumber(status) || "";
+}

--- a/hushh-webapp/lib/services/ria-service.ts
+++ b/hushh-webapp/lib/services/ria-service.ts
@@ -137,6 +137,22 @@ export interface RiaOnboardingStatus {
   legal_name?: string | null;
   finra_crd?: string | null;
   sec_iard?: string | null;
+  license_number?: string | null;
+  regulator?: string | null;
+  regulator_status?: string | null;
+  license_expiry_date?: string | null;
+  certifications?: string[];
+  onboarding_type?: string | null;
+  services_offered?: string[];
+  fee_structure?: string[];
+  min_engagement_amount?: number | null;
+  min_engagement_currency?: string | null;
+  business_city?: string | null;
+  business_area?: string | null;
+  business_address?: string | null;
+  business_pin_zip?: string | null;
+  business_latitude?: number | null;
+  business_longitude?: number | null;
   latest_verification_event?: {
     outcome: string;
     checked_at: string;
@@ -201,6 +217,16 @@ export interface RiaLicenseVerificationResult {
   cache_ttl_seconds?: number;
   cached_at?: string | null;
   cache_expires_at?: string | null;
+}
+
+export interface RiaLicenseProfileRefreshResult {
+  updated: boolean;
+  status: "found" | "not_found" | "pending" | "error" | string;
+  message?: string | null;
+  ria_profile_id?: string | null;
+  applied_fields?: string[];
+  profile?: Partial<RiaOnboardingStatus> | null;
+  verification?: RiaLicenseVerificationResult | Record<string, unknown> | null;
 }
 
 export interface CrdScrapeJobResult {
@@ -1263,7 +1289,8 @@ export class RiaService {
     const query = new URLSearchParams();
     if (params.status) query.set("status", params.status);
     if (params.action) query.set("action", params.action);
-    if (typeof params.limit === "number") query.set("limit", String(params.limit));
+    if (typeof params.limit === "number")
+      query.set("limit", String(params.limit));
     const response = await authFetch(
       `/api/marketplace/investors/actions${query.toString() ? `?${query.toString()}` : ""}`,
       {
@@ -1271,9 +1298,9 @@ export class RiaService {
         idToken,
       },
     );
-    const payload = await toJsonOrThrow<{ items: MarketplaceInvestorActionRecord[] }>(
-      response,
-    );
+    const payload = await toJsonOrThrow<{
+      items: MarketplaceInvestorActionRecord[];
+    }>(response);
     return payload.items;
   }
 
@@ -1397,6 +1424,24 @@ export class RiaService {
       signal: options?.signal,
     });
     return toJsonOrThrow<RiaLicenseVerificationResult>(response);
+  }
+
+  static async refreshLicenseProfile(
+    idToken: string,
+    payload: {
+      license_number: string;
+      regulator?: string;
+      force_live_verification?: boolean;
+    },
+    options?: { signal?: AbortSignal },
+  ): Promise<RiaLicenseProfileRefreshResult> {
+    const response = await authFetch("/api/ria/profile/refresh-license", {
+      method: "POST",
+      idToken,
+      body: payload,
+      signal: options?.signal,
+    });
+    return toJsonOrThrow<RiaLicenseProfileRefreshResult>(response);
   }
 
   static async getCrdScrapeJobStatus(
@@ -2067,9 +2112,7 @@ export class RiaService {
     return toJsonOrThrow(response);
   }
 
-  static async getRenaissanceAvoid(
-    idToken: string,
-  ): Promise<{
+  static async getRenaissanceAvoid(idToken: string): Promise<{
     items: Array<{
       ticker: string;
       company_name?: string;
@@ -2085,9 +2128,7 @@ export class RiaService {
     return toJsonOrThrow(response);
   }
 
-  static async getRenaissanceScreening(
-    idToken: string,
-  ): Promise<{
+  static async getRenaissanceScreening(idToken: string): Promise<{
     items: Array<{
       section: string;
       rule_index: number;


### PR DESCRIPTION
## Summary
- add POST /api/ria/profile/refresh-license reusing the existing RIA license verifier
- update official RIA profile/contact/verification fields only, while preserving user-authored bio, services, fees, email, phone, and custom marketplace copy
- add Profile Settings regulatory row + modal for RIA users to refresh current CRD/license data
- extend RIA status payload, frontend service, voice metadata, and focused tests

## Verification
- cd consent-protocol && uv run pytest tests/test_ria_onboarding_v2.py tests/test_ria_iam_service_architecture.py -q
- cd consent-protocol && uv run ruff check api/routes/ria.py hushh_mcp/services/ria_iam_service.py tests/test_ria_onboarding_v2.py tests/test_ria_iam_service_architecture.py
- cd hushh-webapp && npx vitest run __tests__/lib/profile/profile-ria-regulatory-row.test.ts __tests__/services/ria-service-refresh-license.test.ts
- cd hushh-webapp && npm run typecheck
- cd hushh-webapp && npm run lint
- curl -I http://127.0.0.1:3004/profile -> 200 OK with local placeholder Firebase config
