### PR TITLE
feat(app): replace silent 404 redirect with branded not-found page

### DIFF
--- a/hushh-webapp/app/not-found.tsx
+++ b/hushh-webapp/app/not-found.tsx
@@ -1,14 +1,40 @@
 "use client";
 
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { HomeIcon } from "lucide-react";
+import {
+  Empty,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+} from "@/components/ui/empty";
+import { Button } from "@/components/ui/button";
 
 export default function AppNotFoundPage() {
-  const router = useRouter();
+  return (
+    <div className="flex min-h-[60vh] w-full items-center justify-center p-6">
+      <Empty>
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <HomeIcon />
+          </EmptyMedia>
 
-  useEffect(() => {
-    router.replace("/");
-  }, [router]);
+          <EmptyTitle>Page not found</EmptyTitle>
 
-  return null;
+          <EmptyDescription>
+            The page you&apos;re looking for doesn&apos;t exist or may have
+            been moved.
+          </EmptyDescription>
+        </EmptyHeader>
+
+        <EmptyContent>
+          <Button asChild>
+            <Link href="/">Go home</Link>
+          </Button>
+        </EmptyContent>
+      </Empty>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary

Invalid route navigation currently redirects silently back to the home route, creating a blank visual transition with no user-facing explanation or recovery guidance.

This update replaces the silent redirect experience with a branded not-found surface built entirely from existing shared Empty primitives, providing clear navigation recovery UX while preserving routing safety.

## What's covered

`app/not-found.tsx`

Introduced a branded not-found experience for invalid route navigation.

## Key improvements

- replaces blank redirect flow with visible branded not-found UI
- reuses existing shared Empty design-system primitives
- adds clear navigation recovery messaging
- provides direct "Go home" CTA for recovery navigation
- preserves existing routing safety behavior
- introduces no new routes or routing infrastructure

## Reachable surfaces

- invalid/unmatched route navigation
- application-level not-found flow
- recovery navigation for broken or outdated links

## Validation

- `npx tsc --noEmit`
- `npm run lint`

## Notes

- frontend-only UX improvement
- no backend/auth/runtime changes
- no routing infrastructure changes
- no backend/schema/cache impacts
- built entirely on existing shared UI primitives
- DCO sign-off included