### PR TITLE
feat(app-ui): add responsive column visibility support for DataTable mobile layouts

### DIFF
--- a/hushh-webapp/components/app-ui/data-table.tsx
+++ b/hushh-webapp/components/app-ui/data-table.tsx
@@ -90,6 +90,7 @@ interface DataTableProps<TData, TValue> {
   tableClassName?: string;
   density?: "default" | "compact";
   stickyHeader?: boolean;
+  mobileHiddenColumns?: string[];
 }
 
 export function DataTable<TData, TValue>({
@@ -110,6 +111,7 @@ export function DataTable<TData, TValue>({
   tableClassName,
   density = "default",
   stickyHeader = false,
+  mobileHiddenColumns,
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = React.useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
@@ -314,7 +316,8 @@ export function DataTable<TData, TValue>({
                       compact
                         ? "px-[max(10px,calc(var(--data-table-cell-px)-2px))] py-2 text-[11px] uppercase tracking-[0.16em] text-muted-foreground"
                         : "px-[var(--data-table-cell-px)] py-[calc(var(--data-table-cell-py)-1px)]",
-                      header.column.getCanSort() ? "cursor-pointer" : ""
+                      header.column.getCanSort() ? "cursor-pointer" : "",
+                      mobileHiddenColumns?.includes(header.id) && "hidden sm:table-cell"
                     )}
                     onClick={header.column.getToggleSortingHandler()}
                   >
@@ -353,7 +356,8 @@ export function DataTable<TData, TValue>({
                       className={cn(
                         compact
                           ? "px-[max(10px,calc(var(--data-table-cell-px)-2px))] py-2.5 align-middle"
-                          : "px-[var(--data-table-cell-px)] py-[var(--data-table-cell-py)]"
+                          : "px-[var(--data-table-cell-px)] py-[var(--data-table-cell-py)]",
+                        mobileHiddenColumns?.includes(cell.column.id) && "hidden sm:table-cell"
                       )}
                     >
                       {flexRender(


### PR DESCRIPTION
## Summary

Shared DataTable layouts can become visually crowded on narrow mobile viewports when all columns remain visible simultaneously, reducing readability and forcing excessive horizontal compression.

This update introduces optional responsive column visibility support for DataTable mobile layouts through a consumer-controlled `mobileHiddenColumns` prop while preserving all existing table behavior and desktop layouts.

## What's covered

`components/app-ui/data-table.tsx`

Added responsive mobile column visibility support for shared DataTable surfaces.

## Key improvements

- introduces optional `mobileHiddenColumns` DataTable prop
- allows consumers to hide lower-priority columns on mobile viewports
- uses CSS-only responsive visibility handling
- preserves sorting, filtering, and pagination behavior
- keeps desktop table layouts unchanged
- remains fully opt-in per DataTable instance

## Reachable surfaces

- shared DataTable mobile layouts
- authenticated table-based routes
- mobile RIA/admin/client table surfaces
- responsive table-heavy interfaces

## Validation

- `npx tsc --noEmit`
- `npm run lint`

## Notes

- frontend-only responsive UX improvement
- no runtime/business logic changes
- no table data-flow changes
- no backend/schema/cache impacts
- CSS-only responsive enhancement
- DCO sign-off included