### PR TITLE
[codex] Add KAI location sharing feature

### DIFF
--- a/consent-protocol/api/routes/kai/__init__.py
+++ b/consent-protocol/api/routes/kai/__init__.py
@@ -13,6 +13,7 @@ This package organizes Kai routes into logical modules:
 - support.py: Profile support and bug-report messaging via Gmail API
 - agent_chat.py: Gemini-backed Agent text chat with encrypted durable history
 - agent_realtime.py: Minimal OpenAI Realtime endpoint for the Agent chat and voice surface
+- location.py: KAI location sharing, public bearer links, access requests, and live updates
 
 All sub-routers are aggregated into `kai_router` for backward compatibility.
 """
@@ -27,6 +28,7 @@ from .consent import router as consent_router
 from .decisions import router as decisions_router
 from .gmail import router as gmail_router
 from .health import router as health_router
+from .location import router as location_router
 from .losers import router as losers_router
 from .market_insights import router as market_insights_router
 from .plaid import router as plaid_router
@@ -113,6 +115,17 @@ KAI_ROUTE_CONTRACT_PATHS = [
     "/market/insights/baseline/{user_id}",
     "/market/insights/{user_id}",
     "/stock-preview/{user_id}",
+    "/location/state",
+    "/location/contacts",
+    "/location/contacts/{contact_id}",
+    "/location/shares",
+    "/location/shares/{share_id}",
+    "/location/access-requests/{request_id}/approve",
+    "/location/access-requests/{request_id}/deny",
+    "/location/update-sessions",
+    "/location/updates",
+    "/location/shared",
+    "/location/shared/access-request",
 ]
 
 # Include all sub-routers (no prefix since main router has /api/kai)
@@ -131,6 +144,7 @@ kai_router.include_router(decisions_router)
 kai_router.include_router(losers_router)
 kai_router.include_router(market_insights_router)
 kai_router.include_router(support_router)
+kai_router.include_router(location_router)
 
 # Export for server.py
 router = kai_router

--- a/consent-protocol/api/routes/kai/location.py
+++ b/consent-protocol/api/routes/kai/location.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from pydantic import BaseModel, ConfigDict, Field
+
+from api.middleware import require_vault_owner_token
+from db.db_client import DatabaseExecutionError
+from hushh_mcp.services.kai_location_service import (
+    KaiLocationError,
+    KaiLocationService,
+    database_error_detail,
+    location_error_detail,
+)
+
+router = APIRouter(tags=["Kai Location"])
+
+
+class _CamelModel(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class LocationContactCreateRequest(_CamelModel):
+    display_name: str = Field(alias="displayName", min_length=1, max_length=120)
+    tier: Literal["family", "friend"]
+    auto_approve: bool = Field(default=False, alias="autoApprove")
+
+
+class LocationContactUpdateRequest(_CamelModel):
+    display_name: str | None = Field(default=None, alias="displayName", max_length=120)
+    auto_approve: bool | None = Field(default=None, alias="autoApprove")
+
+
+class LocationShareCreateRequest(_CamelModel):
+    contact_id: str = Field(alias="contactId")
+    point: dict[str, Any]
+    duration_hours: float = Field(default=24, alias="durationHours", gt=0, le=24)
+    live_mode: bool = Field(default=True, alias="liveMode")
+
+
+class LocationAccessRequestCreateRequest(_CamelModel):
+    token: str = Field(min_length=8)
+    requester_label: str | None = Field(default=None, alias="requesterLabel", max_length=120)
+    requester_message: str | None = Field(default=None, alias="requesterMessage", max_length=500)
+
+
+class LocationUpdateRequest(_CamelModel):
+    point: dict[str, Any]
+
+
+def _service() -> KaiLocationService:
+    return KaiLocationService()
+
+
+def _handle_error(exc: Exception) -> HTTPException:
+    if isinstance(exc, KaiLocationError):
+        return HTTPException(status_code=exc.status_code, detail=location_error_detail(exc))
+    if isinstance(exc, DatabaseExecutionError):
+        return HTTPException(status_code=exc.status_code, detail=database_error_detail(exc))
+    return HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail={"code": "LOCATION_API_FAILED", "message": "Location request failed."},
+    )
+
+
+def _owner_user_id(token_data: dict[str, Any]) -> str:
+    return str(token_data.get("user_id") or "").strip()
+
+
+def _extract_bearer_token(authorization: str | None) -> str:
+    if not authorization:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={
+                "code": "LOCATION_UPDATE_TOKEN_MISSING",
+                "message": "Missing Authorization header.",
+            },
+        )
+    stripped = authorization.strip()
+    if not stripped.lower().startswith("bearer "):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={
+                "code": "LOCATION_UPDATE_TOKEN_INVALID",
+                "message": "Expected Bearer location update token.",
+            },
+        )
+    token = stripped[7:].strip()
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={
+                "code": "LOCATION_UPDATE_TOKEN_MISSING",
+                "message": "Missing location update token.",
+            },
+        )
+    return token
+
+
+@router.get("/location/state")
+async def get_location_state(
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    try:
+        return _service().list_owner_state(owner_user_id=_owner_user_id(token_data))
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+
+
+@router.post("/location/contacts")
+async def create_location_contact(
+    payload: LocationContactCreateRequest,
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    try:
+        return {
+            "contact": _service().create_contact(
+                owner_user_id=_owner_user_id(token_data),
+                display_name=payload.display_name,
+                tier=payload.tier,
+                auto_approve=payload.auto_approve,
+            )
+        }
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+
+
+@router.patch("/location/contacts/{contact_id}")
+async def update_location_contact(
+    contact_id: str,
+    payload: LocationContactUpdateRequest,
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    try:
+        return {
+            "contact": _service().update_contact(
+                owner_user_id=_owner_user_id(token_data),
+                contact_id=contact_id,
+                display_name=payload.display_name,
+                auto_approve=payload.auto_approve,
+            )
+        }
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+
+
+@router.delete("/location/contacts/{contact_id}")
+async def revoke_location_contact(
+    contact_id: str,
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    try:
+        return {
+            "contact": _service().revoke_contact(
+                owner_user_id=_owner_user_id(token_data),
+                contact_id=contact_id,
+            )
+        }
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+
+
+@router.post("/location/shares")
+async def create_location_share(
+    payload: LocationShareCreateRequest,
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    try:
+        return _service().create_share(
+            owner_user_id=_owner_user_id(token_data),
+            contact_id=payload.contact_id,
+            point=payload.point,
+            duration_hours=payload.duration_hours,
+            live_mode=payload.live_mode,
+        )
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+
+
+@router.delete("/location/shares/{share_id}")
+async def revoke_location_share(
+    share_id: str,
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    try:
+        return {
+            "share": _service().revoke_share(
+                owner_user_id=_owner_user_id(token_data),
+                share_id=share_id,
+            )
+        }
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+
+
+@router.post("/location/shares/stop-active")
+async def stop_active_location_shares(
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    try:
+        return _service().stop_active_shares(owner_user_id=_owner_user_id(token_data))
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+
+
+@router.post("/location/access-requests/{request_id}/approve")
+async def approve_location_access_request(
+    request_id: str,
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    try:
+        return _service().approve_access_request(
+            owner_user_id=_owner_user_id(token_data),
+            request_id=request_id,
+        )
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+
+
+@router.post("/location/access-requests/{request_id}/deny")
+async def deny_location_access_request(
+    request_id: str,
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    try:
+        return {
+            "accessRequest": _service().deny_access_request(
+                owner_user_id=_owner_user_id(token_data),
+                request_id=request_id,
+            )
+        }
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+
+
+@router.post("/location/update-sessions")
+async def issue_location_update_session(
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    try:
+        return _service().issue_update_session(owner_user_id=_owner_user_id(token_data))
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+
+
+@router.post("/location/updates")
+async def update_location_with_scoped_token(
+    payload: LocationUpdateRequest,
+    authorization: str | None = Header(default=None),
+):
+    try:
+        return _service().update_with_session(
+            session_token=_extract_bearer_token(authorization),
+            point=payload.point,
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+
+
+@router.get("/location/shared")
+async def resolve_shared_location(token: str):
+    try:
+        return _service().resolve_public_share(token=token)
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+
+
+@router.post("/location/shared/access-request")
+async def request_shared_location_access(
+    payload: LocationAccessRequestCreateRequest,
+    request: Request,
+):
+    try:
+        return _service().request_access(
+            token=payload.token,
+            requester_label=payload.requester_label,
+            requester_message=payload.requester_message,
+            metadata={
+                "user_agent": request.headers.get("user-agent"),
+                "source": "public_shared_location_page",
+            },
+        )
+    except Exception as exc:
+        raise _handle_error(exc) from exc

--- a/consent-protocol/db/migrations/060_kai_location_sharing.sql
+++ b/consent-protocol/db/migrations/060_kai_location_sharing.sql
@@ -1,0 +1,140 @@
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS kai_location_contacts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  owner_user_id TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  tier TEXT NOT NULL CHECK (tier IN ('family', 'friend')),
+  auto_approve BOOLEAN NOT NULL DEFAULT FALSE,
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'revoked')),
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  revoked_at TIMESTAMPTZ,
+  CONSTRAINT kai_location_contacts_family_auto_approve_check
+    CHECK (tier = 'family' OR auto_approve = FALSE)
+);
+
+CREATE TABLE IF NOT EXISTS kai_location_latest (
+  owner_user_id TEXT PRIMARY KEY,
+  latitude DOUBLE PRECISION NOT NULL CHECK (latitude >= -90 AND latitude <= 90),
+  longitude DOUBLE PRECISION NOT NULL CHECK (longitude >= -180 AND longitude <= 180),
+  accuracy_m DOUBLE PRECISION CHECK (accuracy_m IS NULL OR accuracy_m >= 0),
+  heading_deg DOUBLE PRECISION CHECK (heading_deg IS NULL OR (heading_deg >= 0 AND heading_deg <= 360)),
+  speed_mps DOUBLE PRECISION CHECK (speed_mps IS NULL OR speed_mps >= 0),
+  captured_at TIMESTAMPTZ NOT NULL,
+  source_platform TEXT NOT NULL DEFAULT 'web'
+    CHECK (source_platform IN ('web', 'ios', 'android', 'native', 'unknown')),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS kai_location_shares (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  owner_user_id TEXT NOT NULL,
+  contact_id UUID REFERENCES kai_location_contacts(id) ON DELETE SET NULL,
+  token_hash TEXT NOT NULL UNIQUE,
+  status TEXT NOT NULL DEFAULT 'active'
+    CHECK (status IN ('active', 'expired', 'deactivated', 'revoked')),
+  live_mode BOOLEAN NOT NULL DEFAULT TRUE,
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_viewed_at TIMESTAMPTZ,
+  deactivated_at TIMESTAMPTZ,
+  revoked_at TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS kai_location_access_requests (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  share_id UUID NOT NULL REFERENCES kai_location_shares(id) ON DELETE CASCADE,
+  owner_user_id TEXT NOT NULL,
+  contact_id UUID REFERENCES kai_location_contacts(id) ON DELETE SET NULL,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'approved', 'denied', 'auto_approved')),
+  requester_label TEXT,
+  requester_message TEXT,
+  requested_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  resolved_at TIMESTAMPTZ,
+  renewed_share_id UUID REFERENCES kai_location_shares(id) ON DELETE SET NULL,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE TABLE IF NOT EXISTS kai_location_update_sessions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  owner_user_id TEXT NOT NULL,
+  session_token_hash TEXT NOT NULL UNIQUE,
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'expired', 'revoked')),
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_used_at TIMESTAMPTZ,
+  revoked_at TIMESTAMPTZ,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  CONSTRAINT kai_location_update_sessions_expiry_window_check
+    CHECK (expires_at <= created_at + INTERVAL '24 hours' + INTERVAL '1 minute')
+);
+
+CREATE TABLE IF NOT EXISTS kai_location_events (
+  id BIGSERIAL PRIMARY KEY,
+  owner_user_id TEXT NOT NULL,
+  contact_id UUID,
+  share_id UUID,
+  request_id UUID,
+  event_type TEXT NOT NULL CHECK (
+    event_type IN (
+      'CONTACT_CREATED',
+      'CONTACT_UPDATED',
+      'CONTACT_REVOKED',
+      'SHARE_CREATED',
+      'SHARE_VIEWED',
+      'SHARE_EXPIRED',
+      'SHARE_DEACTIVATED',
+      'SHARE_REVOKED',
+      'ACCESS_REQUESTED',
+      'ACCESS_APPROVED',
+      'ACCESS_DENIED',
+      'ACCESS_AUTO_APPROVED',
+      'LOCATION_UPDATED',
+      'UPDATE_SESSION_CREATED',
+      'UPDATE_SESSION_REVOKED'
+    )
+  ),
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_kai_location_contacts_owner_tier_status
+  ON kai_location_contacts (owner_user_id, tier, status);
+
+CREATE INDEX IF NOT EXISTS idx_kai_location_shares_owner_status_expiry
+  ON kai_location_shares (owner_user_id, status, expires_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_kai_location_shares_contact_status
+  ON kai_location_shares (contact_id, status);
+
+CREATE INDEX IF NOT EXISTS idx_kai_location_access_requests_owner_status
+  ON kai_location_access_requests (owner_user_id, status, requested_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_kai_location_access_requests_share_status
+  ON kai_location_access_requests (share_id, status);
+
+CREATE INDEX IF NOT EXISTS idx_kai_location_update_sessions_owner_status
+  ON kai_location_update_sessions (owner_user_id, status, expires_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_kai_location_events_owner_created
+  ON kai_location_events (owner_user_id, created_at DESC);
+
+COMMENT ON TABLE kai_location_contacts IS
+  'Owner-created KAI location recipients. Active limits are enforced in the service: 3 family and 7 friends.';
+COMMENT ON TABLE kai_location_latest IS
+  'Latest-only KAI GPS point per owner. No historical coordinate trail is retained by default.';
+COMMENT ON TABLE kai_location_shares IS
+  'Bearer-token KAI location shares. Only SHA-256 token hashes are stored; raw tokens are returned once.';
+COMMENT ON TABLE kai_location_access_requests IS
+  'Requests to renew an expired/deactivated KAI location share.';
+COMMENT ON TABLE kai_location_events IS
+  'KAI location audit events. Event metadata must not contain coordinates.';
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -36,7 +36,8 @@
     "056_public_investor_profiles.sql",
     "057_marketplace_investor_admission.sql",
     "058_marketplace_investor_actions.sql",
-    "059_marketplace_investor_replenisher_runs.sql"
+    "059_marketplace_investor_replenisher_runs.sql",
+    "060_kai_location_sharing.sql"
   ],
   "groups": {
     "iam": [
@@ -61,7 +62,8 @@
       "056_public_investor_profiles.sql",
       "057_marketplace_investor_admission.sql",
       "058_marketplace_investor_actions.sql",
-      "059_marketplace_investor_replenisher_runs.sql"
+      "059_marketplace_investor_replenisher_runs.sql",
+      "060_kai_location_sharing.sql"
     ],
     "pkm": [
       "030_pkm_cutover.sql",

--- a/consent-protocol/hushh_mcp/services/kai_location_service.py
+++ b/consent-protocol/hushh_mcp/services/kai_location_service.py
@@ -1,0 +1,1410 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Any, Literal
+
+from api.utils.fcm_messages import build_push_message
+from api.utils.firebase_admin import ensure_firebase_admin
+from db.db_client import DatabaseExecutionError, get_db
+
+logger = logging.getLogger(__name__)
+
+LocationContactTier = Literal["family", "friend"]
+LocationShareStatus = Literal["active", "expired", "deactivated", "revoked"]
+LocationAccessRequestStatus = Literal["pending", "approved", "denied", "auto_approved"]
+
+MAX_FAMILY_CONTACTS = 3
+MAX_FRIEND_CONTACTS = 7
+MAX_SHARE_HOURS = 24
+FRESH_FIX_WINDOW = timedelta(minutes=10)
+TOKEN_BYTES = 32
+PUBLIC_LIVE_POLL_INTERVAL_MS = 10_000
+PUBLIC_LIVE_STALE_AFTER_SECONDS = 90
+COORDINATE_METADATA_KEYS = {
+    "lat",
+    "latitude",
+    "lng",
+    "lon",
+    "long",
+    "longitude",
+    "accuracy",
+    "accuracy_m",
+    "heading",
+    "speed",
+    "coordinates",
+    "location",
+}
+
+
+class KaiLocationError(RuntimeError):
+    def __init__(self, code: str, message: str, *, status_code: int = 400) -> None:
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+        super().__init__(message)
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _token_hash(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _new_token() -> str:
+    return secrets.token_urlsafe(TOKEN_BYTES)
+
+
+def _iso(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).isoformat()
+    return str(value)
+
+
+def _parse_datetime(value: datetime | str | None, *, field_name: str) -> datetime:
+    if value is None:
+        return _utcnow()
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        raw = str(value).strip()
+        if not raw:
+            return _utcnow()
+        if raw.endswith("Z"):
+            raw = f"{raw[:-1]}+00:00"
+        try:
+            parsed = datetime.fromisoformat(raw)
+        except ValueError as exc:
+            raise KaiLocationError(
+                "LOCATION_TIMESTAMP_INVALID",
+                f"{field_name} must be an ISO-8601 timestamp.",
+                status_code=422,
+            ) from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _validate_point(point: dict[str, Any], *, require_fresh: bool) -> dict[str, Any]:
+    try:
+        latitude = float(point.get("latitude"))
+        longitude = float(point.get("longitude"))
+    except (TypeError, ValueError) as exc:
+        raise KaiLocationError(
+            "LOCATION_POINT_INVALID",
+            "A valid latitude and longitude are required.",
+            status_code=422,
+        ) from exc
+
+    if latitude < -90 or latitude > 90 or longitude < -180 or longitude > 180:
+        raise KaiLocationError(
+            "LOCATION_POINT_INVALID",
+            "Latitude or longitude is outside the valid GPS range.",
+            status_code=422,
+        )
+
+    captured_at = _parse_datetime(
+        point.get("captured_at") or point.get("capturedAt"), field_name="captured_at"
+    )
+    if require_fresh and _utcnow() - captured_at > FRESH_FIX_WINDOW:
+        raise KaiLocationError(
+            "LOCATION_FIX_STALE",
+            "A fresh GPS fix is required before sharing location.",
+            status_code=409,
+        )
+
+    def optional_float(name: str) -> float | None:
+        raw = point.get(name)
+        if raw is None or raw == "":
+            return None
+        try:
+            return float(raw)
+        except (TypeError, ValueError) as exc:
+            raise KaiLocationError(
+                "LOCATION_POINT_INVALID",
+                f"{name} must be a number.",
+                status_code=422,
+            ) from exc
+
+    accuracy_m = optional_float("accuracy_m")
+    if accuracy_m is None:
+        accuracy_m = optional_float("accuracyM")
+    heading_deg = optional_float("heading_deg")
+    if heading_deg is None:
+        heading_deg = optional_float("headingDeg")
+    speed_mps = optional_float("speed_mps")
+    if speed_mps is None:
+        speed_mps = optional_float("speedMps")
+    source_platform = (
+        str(point.get("source_platform") or point.get("sourcePlatform") or "web").strip().lower()
+    )
+    if source_platform not in {"web", "ios", "android", "native", "unknown"}:
+        source_platform = "unknown"
+
+    return {
+        "latitude": latitude,
+        "longitude": longitude,
+        "accuracy_m": accuracy_m,
+        "heading_deg": heading_deg,
+        "speed_mps": speed_mps,
+        "captured_at": captured_at,
+        "source_platform": source_platform,
+    }
+
+
+def _redact_coordinate_metadata(value: Any) -> Any:
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            normalized_key = str(key).strip().lower()
+            if normalized_key in COORDINATE_METADATA_KEYS:
+                continue
+            redacted[str(key)] = _redact_coordinate_metadata(item)
+        return redacted
+    if isinstance(value, list):
+        return [_redact_coordinate_metadata(item) for item in value]
+    return value
+
+
+def _json_param(value: dict[str, Any] | None) -> str:
+    return json.dumps(_redact_coordinate_metadata(value or {}), separators=(",", ":"))
+
+
+def _contact_limit(tier: str) -> int:
+    return MAX_FAMILY_CONTACTS if tier == "family" else MAX_FRIEND_CONTACTS
+
+
+def _build_request_url(request_id: str) -> str:
+    base = (
+        (
+            os.getenv("NEXT_PUBLIC_APP_URL")
+            or os.getenv("APP_PUBLIC_URL")
+            or os.getenv("FRONTEND_BASE_URL")
+            or ""
+        )
+        .strip()
+        .rstrip("/")
+    )
+    path = f"/kai/location?requestId={request_id}"
+    return f"{base}{path}" if base else path
+
+
+def _public_live_payload(
+    *, row: dict[str, Any] | None, latest: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    server_time = _utcnow()
+    share_status = str(row.get("status") or "") if row else "invalid"
+    live_mode = bool(row.get("live_mode")) if row else False
+    stopped_at = None
+    if row:
+        stopped_at = row.get("revoked_at") or row.get("deactivated_at")
+    captured_at = latest.get("capturedAt") if latest else None
+    freshness_seconds = None
+    if captured_at:
+        try:
+            captured = _parse_datetime(captured_at, field_name="captured_at")
+            freshness_seconds = max(0, int((server_time - captured).total_seconds()))
+        except KaiLocationError:
+            freshness_seconds = None
+    return {
+        "transport": "gcp_polling",
+        "pollIntervalMs": PUBLIC_LIVE_POLL_INTERVAL_MS,
+        "staleAfterSeconds": PUBLIC_LIVE_STALE_AFTER_SECONDS,
+        "serverTime": _iso(server_time),
+        "isLive": share_status == "active" and live_mode and latest is not None,
+        "freshnessSeconds": freshness_seconds,
+        "stoppedAt": _iso(stopped_at),
+    }
+
+
+class KaiLocationService:
+    def _execute_one(self, sql: str, params: dict[str, Any]) -> dict[str, Any] | None:
+        result = get_db().execute_raw(sql, params)
+        return result.data[0] if result.data else None
+
+    def _execute_many(self, sql: str, params: dict[str, Any]) -> list[dict[str, Any]]:
+        result = get_db().execute_raw(sql, params)
+        return result.data or []
+
+    @staticmethod
+    def _contact_payload(row: dict[str, Any] | None) -> dict[str, Any] | None:
+        if not row:
+            return None
+        return {
+            "id": str(row.get("id") or ""),
+            "ownerUserId": str(row.get("owner_user_id") or ""),
+            "displayName": str(row.get("display_name") or ""),
+            "tier": str(row.get("tier") or "friend"),
+            "autoApprove": bool(row.get("auto_approve")),
+            "status": str(row.get("status") or "active"),
+            "createdAt": _iso(row.get("created_at")),
+            "updatedAt": _iso(row.get("updated_at")),
+            "revokedAt": _iso(row.get("revoked_at")),
+        }
+
+    @staticmethod
+    def _latest_payload(row: dict[str, Any] | None) -> dict[str, Any] | None:
+        if not row:
+            return None
+        return {
+            "ownerUserId": str(row.get("owner_user_id") or ""),
+            "latitude": float(row.get("latitude")),
+            "longitude": float(row.get("longitude")),
+            "accuracyM": row.get("accuracy_m"),
+            "headingDeg": row.get("heading_deg"),
+            "speedMps": row.get("speed_mps"),
+            "capturedAt": _iso(row.get("captured_at")),
+            "sourcePlatform": str(row.get("source_platform") or "unknown"),
+            "updatedAt": _iso(row.get("updated_at")),
+        }
+
+    @staticmethod
+    def _share_payload(row: dict[str, Any] | None) -> dict[str, Any] | None:
+        if not row:
+            return None
+        return {
+            "id": str(row.get("id") or ""),
+            "ownerUserId": str(row.get("owner_user_id") or ""),
+            "contactId": str(row.get("contact_id") or "") or None,
+            "contactDisplayName": str(row.get("contact_display_name") or "") or None,
+            "contactTier": str(row.get("contact_tier") or "") or None,
+            "contactAutoApprove": bool(row.get("contact_auto_approve"))
+            if row.get("contact_auto_approve") is not None
+            else None,
+            "status": str(row.get("status") or "active"),
+            "liveMode": bool(row.get("live_mode")),
+            "expiresAt": _iso(row.get("expires_at")),
+            "createdAt": _iso(row.get("created_at")),
+            "updatedAt": _iso(row.get("updated_at")),
+            "lastViewedAt": _iso(row.get("last_viewed_at")),
+            "deactivatedAt": _iso(row.get("deactivated_at")),
+            "revokedAt": _iso(row.get("revoked_at")),
+        }
+
+    @staticmethod
+    def _request_payload(row: dict[str, Any] | None) -> dict[str, Any] | None:
+        if not row:
+            return None
+        return {
+            "id": str(row.get("id") or ""),
+            "shareId": str(row.get("share_id") or ""),
+            "ownerUserId": str(row.get("owner_user_id") or ""),
+            "contactId": str(row.get("contact_id") or "") or None,
+            "contactDisplayName": str(row.get("contact_display_name") or "") or None,
+            "contactTier": str(row.get("contact_tier") or "") or None,
+            "status": str(row.get("status") or "pending"),
+            "requesterLabel": str(row.get("requester_label") or "") or None,
+            "requesterMessage": str(row.get("requester_message") or "") or None,
+            "requestedAt": _iso(row.get("requested_at")),
+            "resolvedAt": _iso(row.get("resolved_at")),
+            "renewedShareId": str(row.get("renewed_share_id") or "") or None,
+        }
+
+    def _insert_event(
+        self,
+        *,
+        owner_user_id: str,
+        event_type: str,
+        contact_id: str | None = None,
+        share_id: str | None = None,
+        request_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        try:
+            self._execute_one(
+                """
+                INSERT INTO kai_location_events (
+                  owner_user_id, contact_id, share_id, request_id, event_type, metadata, created_at
+                )
+                VALUES (
+                  :owner_user_id, CAST(:contact_id AS UUID), CAST(:share_id AS UUID),
+                  CAST(:request_id AS UUID), :event_type, CAST(:metadata_json AS JSONB), NOW()
+                )
+                """,
+                {
+                    "owner_user_id": owner_user_id,
+                    "contact_id": contact_id,
+                    "share_id": share_id,
+                    "request_id": request_id,
+                    "event_type": event_type,
+                    "metadata_json": _json_param(metadata),
+                },
+            )
+        except Exception as exc:
+            logger.warning("kai.location.event_insert_failed type=%s error=%s", event_type, exc)
+
+    def _expire_stale_update_sessions(self, owner_user_id: str) -> None:
+        self._execute_many(
+            """
+            UPDATE kai_location_update_sessions
+            SET status = 'expired', updated_at = NOW()
+            WHERE owner_user_id = :owner_user_id
+              AND status = 'active'
+              AND expires_at <= NOW()
+            RETURNING id
+            """,
+            {"owner_user_id": owner_user_id},
+        )
+
+    def _revoke_update_sessions_if_no_active_shares(self, owner_user_id: str) -> None:
+        row = self._execute_one(
+            """
+            SELECT COUNT(*) AS active_count
+            FROM kai_location_shares
+            WHERE owner_user_id = :owner_user_id
+              AND status = 'active'
+              AND expires_at > NOW()
+            """,
+            {"owner_user_id": owner_user_id},
+        )
+        if int(row.get("active_count") or 0) > 0:
+            return
+        revoked = self._execute_many(
+            """
+            UPDATE kai_location_update_sessions
+            SET status = 'revoked', revoked_at = NOW(), updated_at = NOW()
+            WHERE owner_user_id = :owner_user_id
+              AND status = 'active'
+            RETURNING id
+            """,
+            {"owner_user_id": owner_user_id},
+        )
+        for row in revoked:
+            self._insert_event(
+                owner_user_id=owner_user_id,
+                event_type="UPDATE_SESSION_REVOKED",
+                metadata={"session_id": str(row.get("id") or ""), "reason": "no_active_shares"},
+            )
+
+    def upsert_latest_point(
+        self,
+        *,
+        owner_user_id: str,
+        point: dict[str, Any],
+        require_fresh: bool = False,
+    ) -> dict[str, Any]:
+        normalized = _validate_point(point, require_fresh=require_fresh)
+        row = self._execute_one(
+            """
+            INSERT INTO kai_location_latest (
+              owner_user_id, latitude, longitude, accuracy_m, heading_deg, speed_mps,
+              captured_at, source_platform, updated_at
+            )
+            VALUES (
+              :owner_user_id, :latitude, :longitude, :accuracy_m, :heading_deg, :speed_mps,
+              :captured_at, :source_platform, NOW()
+            )
+            ON CONFLICT (owner_user_id) DO UPDATE SET
+              latitude = EXCLUDED.latitude,
+              longitude = EXCLUDED.longitude,
+              accuracy_m = EXCLUDED.accuracy_m,
+              heading_deg = EXCLUDED.heading_deg,
+              speed_mps = EXCLUDED.speed_mps,
+              captured_at = EXCLUDED.captured_at,
+              source_platform = EXCLUDED.source_platform,
+              updated_at = NOW()
+            RETURNING *
+            """,
+            {"owner_user_id": owner_user_id, **normalized},
+        )
+        self._insert_event(
+            owner_user_id=owner_user_id,
+            event_type="LOCATION_UPDATED",
+            metadata={"source_platform": normalized["source_platform"]},
+        )
+        payload = self._latest_payload(row)
+        if not payload:
+            raise KaiLocationError(
+                "LOCATION_UPDATE_FAILED", "Could not store the latest location.", status_code=500
+            )
+        return payload
+
+    def create_contact(
+        self,
+        *,
+        owner_user_id: str,
+        display_name: str,
+        tier: LocationContactTier,
+        auto_approve: bool,
+    ) -> dict[str, Any]:
+        normalized_name = str(display_name or "").strip()
+        if len(normalized_name) < 1 or len(normalized_name) > 120:
+            raise KaiLocationError(
+                "CONTACT_NAME_INVALID", "Recipient name is required.", status_code=422
+            )
+        normalized_tier = str(tier or "").strip().lower()
+        if normalized_tier not in {"family", "friend"}:
+            raise KaiLocationError(
+                "CONTACT_TIER_INVALID", "Recipient tier must be family or friend.", status_code=422
+            )
+        normalized_auto_approve = bool(auto_approve and normalized_tier == "family")
+
+        count_row = self._execute_one(
+            """
+            SELECT COUNT(*) AS active_count
+            FROM kai_location_contacts
+            WHERE owner_user_id = :owner_user_id
+              AND tier = :tier
+              AND status = 'active'
+            """,
+            {"owner_user_id": owner_user_id, "tier": normalized_tier},
+        )
+        if int(count_row.get("active_count") or 0) >= _contact_limit(normalized_tier):
+            raise KaiLocationError(
+                "CONTACT_LIMIT_REACHED",
+                "You can keep up to 3 family members and 7 friends active for location sharing.",
+                status_code=409,
+            )
+
+        row = self._execute_one(
+            """
+            INSERT INTO kai_location_contacts (
+              owner_user_id, display_name, tier, auto_approve, status, metadata, created_at, updated_at
+            )
+            VALUES (
+              :owner_user_id, :display_name, :tier, :auto_approve, 'active',
+              '{}'::jsonb, NOW(), NOW()
+            )
+            RETURNING *
+            """,
+            {
+                "owner_user_id": owner_user_id,
+                "display_name": normalized_name,
+                "tier": normalized_tier,
+                "auto_approve": normalized_auto_approve,
+            },
+        )
+        contact = self._contact_payload(row)
+        if not contact:
+            raise KaiLocationError(
+                "CONTACT_CREATE_FAILED", "Could not create the recipient.", status_code=500
+            )
+        self._insert_event(
+            owner_user_id=owner_user_id,
+            contact_id=contact["id"],
+            event_type="CONTACT_CREATED",
+            metadata={"tier": normalized_tier, "auto_approve": normalized_auto_approve},
+        )
+        return contact
+
+    def update_contact(
+        self,
+        *,
+        owner_user_id: str,
+        contact_id: str,
+        display_name: str | None = None,
+        auto_approve: bool | None = None,
+    ) -> dict[str, Any]:
+        existing = self._execute_one(
+            """
+            SELECT *
+            FROM kai_location_contacts
+            WHERE id = CAST(:contact_id AS UUID)
+              AND owner_user_id = :owner_user_id
+              AND status = 'active'
+            """,
+            {"owner_user_id": owner_user_id, "contact_id": contact_id},
+        )
+        if not existing:
+            raise KaiLocationError("CONTACT_NOT_FOUND", "Recipient was not found.", status_code=404)
+        tier = str(existing.get("tier") or "friend")
+        next_name = str(
+            display_name if display_name is not None else existing.get("display_name") or ""
+        ).strip()
+        if len(next_name) < 1 or len(next_name) > 120:
+            raise KaiLocationError(
+                "CONTACT_NAME_INVALID", "Recipient name is required.", status_code=422
+            )
+        next_auto = (
+            bool(auto_approve) if auto_approve is not None else bool(existing.get("auto_approve"))
+        )
+        if tier != "family":
+            next_auto = False
+        row = self._execute_one(
+            """
+            UPDATE kai_location_contacts
+            SET display_name = :display_name,
+                auto_approve = :auto_approve,
+                updated_at = NOW()
+            WHERE id = CAST(:contact_id AS UUID)
+              AND owner_user_id = :owner_user_id
+            RETURNING *
+            """,
+            {
+                "owner_user_id": owner_user_id,
+                "contact_id": contact_id,
+                "display_name": next_name,
+                "auto_approve": next_auto,
+            },
+        )
+        contact = self._contact_payload(row)
+        if not contact:
+            raise KaiLocationError(
+                "CONTACT_UPDATE_FAILED", "Could not update the recipient.", status_code=500
+            )
+        self._insert_event(
+            owner_user_id=owner_user_id,
+            contact_id=contact_id,
+            event_type="CONTACT_UPDATED",
+            metadata={"auto_approve": next_auto},
+        )
+        return contact
+
+    def revoke_contact(self, *, owner_user_id: str, contact_id: str) -> dict[str, Any]:
+        row = self._execute_one(
+            """
+            UPDATE kai_location_contacts
+            SET status = 'revoked',
+                auto_approve = FALSE,
+                revoked_at = COALESCE(revoked_at, NOW()),
+                updated_at = NOW()
+            WHERE id = CAST(:contact_id AS UUID)
+              AND owner_user_id = :owner_user_id
+              AND status = 'active'
+            RETURNING *
+            """,
+            {"owner_user_id": owner_user_id, "contact_id": contact_id},
+        )
+        if not row:
+            raise KaiLocationError("CONTACT_NOT_FOUND", "Recipient was not found.", status_code=404)
+        revoked_shares = self._execute_many(
+            """
+            UPDATE kai_location_shares
+            SET status = 'revoked',
+                revoked_at = COALESCE(revoked_at, NOW()),
+                updated_at = NOW()
+            WHERE owner_user_id = :owner_user_id
+              AND contact_id = CAST(:contact_id AS UUID)
+              AND status = 'active'
+            RETURNING id
+            """,
+            {"owner_user_id": owner_user_id, "contact_id": contact_id},
+        )
+        for share in revoked_shares:
+            self._insert_event(
+                owner_user_id=owner_user_id,
+                contact_id=contact_id,
+                share_id=str(share.get("id") or ""),
+                event_type="SHARE_REVOKED",
+                metadata={"reason": "contact_revoked"},
+            )
+        self._insert_event(
+            owner_user_id=owner_user_id,
+            contact_id=contact_id,
+            event_type="CONTACT_REVOKED",
+            metadata={"revoked_active_shares": len(revoked_shares)},
+        )
+        self._revoke_update_sessions_if_no_active_shares(owner_user_id)
+        contact = self._contact_payload(row)
+        if not contact:
+            raise KaiLocationError(
+                "CONTACT_REVOKE_FAILED", "Could not revoke the recipient.", status_code=500
+            )
+        return contact
+
+    def list_owner_state(self, *, owner_user_id: str) -> dict[str, Any]:
+        self._expire_stale_update_sessions(owner_user_id)
+        contacts = self._execute_many(
+            """
+            SELECT *
+            FROM kai_location_contacts
+            WHERE owner_user_id = :owner_user_id
+            ORDER BY
+              CASE status WHEN 'active' THEN 0 ELSE 1 END,
+              CASE tier WHEN 'family' THEN 0 ELSE 1 END,
+              created_at DESC
+            """,
+            {"owner_user_id": owner_user_id},
+        )
+        shares = self._execute_many(
+            """
+            SELECT
+              s.*,
+              c.display_name AS contact_display_name,
+              c.tier AS contact_tier,
+              c.auto_approve AS contact_auto_approve
+            FROM kai_location_shares s
+            LEFT JOIN kai_location_contacts c ON c.id = s.contact_id
+            WHERE s.owner_user_id = :owner_user_id
+            ORDER BY s.created_at DESC
+            LIMIT 50
+            """,
+            {"owner_user_id": owner_user_id},
+        )
+        requests = self._execute_many(
+            """
+            SELECT
+              r.*,
+              c.display_name AS contact_display_name,
+              c.tier AS contact_tier
+            FROM kai_location_access_requests r
+            LEFT JOIN kai_location_contacts c ON c.id = r.contact_id
+            WHERE r.owner_user_id = :owner_user_id
+            ORDER BY
+              CASE r.status WHEN 'pending' THEN 0 ELSE 1 END,
+              r.requested_at DESC
+            LIMIT 50
+            """,
+            {"owner_user_id": owner_user_id},
+        )
+        latest = self._execute_one(
+            "SELECT * FROM kai_location_latest WHERE owner_user_id = :owner_user_id",
+            {"owner_user_id": owner_user_id},
+        )
+        return {
+            "contacts": [self._contact_payload(row) for row in contacts],
+            "shares": [self._share_payload(row) for row in shares],
+            "accessRequests": [self._request_payload(row) for row in requests],
+            "latest": self._latest_payload(latest),
+            "limits": {"family": MAX_FAMILY_CONTACTS, "friend": MAX_FRIEND_CONTACTS},
+        }
+
+    def create_share(
+        self,
+        *,
+        owner_user_id: str,
+        contact_id: str,
+        point: dict[str, Any],
+        duration_hours: float = MAX_SHARE_HOURS,
+        live_mode: bool = True,
+    ) -> dict[str, Any]:
+        try:
+            duration = float(duration_hours)
+        except (TypeError, ValueError) as exc:
+            raise KaiLocationError(
+                "SHARE_DURATION_INVALID", "durationHours must be a number.", status_code=422
+            ) from exc
+        if duration <= 0 or duration > MAX_SHARE_HOURS:
+            raise KaiLocationError(
+                "SHARE_DURATION_INVALID",
+                "Location links can be active for at most 24 hours.",
+                status_code=422,
+            )
+
+        contact = self._execute_one(
+            """
+            SELECT *
+            FROM kai_location_contacts
+            WHERE id = CAST(:contact_id AS UUID)
+              AND owner_user_id = :owner_user_id
+              AND status = 'active'
+            """,
+            {"owner_user_id": owner_user_id, "contact_id": contact_id},
+        )
+        if not contact:
+            raise KaiLocationError(
+                "CONTACT_NOT_FOUND",
+                "Create an active recipient before sharing location.",
+                status_code=404,
+            )
+
+        latest = self.upsert_latest_point(
+            owner_user_id=owner_user_id, point=point, require_fresh=True
+        )
+        token = _new_token()
+        row = self._execute_one(
+            """
+            INSERT INTO kai_location_shares (
+              owner_user_id, contact_id, token_hash, status, live_mode,
+              expires_at, created_at, updated_at
+            )
+            VALUES (
+              :owner_user_id, CAST(:contact_id AS UUID), :token_hash, 'active', :live_mode,
+              NOW() + (:duration_hours * INTERVAL '1 hour'), NOW(), NOW()
+            )
+            RETURNING
+              *,
+              :contact_display_name AS contact_display_name,
+              :contact_tier AS contact_tier,
+              :contact_auto_approve AS contact_auto_approve
+            """,
+            {
+                "owner_user_id": owner_user_id,
+                "contact_id": contact_id,
+                "token_hash": _token_hash(token),
+                "live_mode": bool(live_mode),
+                "duration_hours": duration,
+                "contact_display_name": contact.get("display_name"),
+                "contact_tier": contact.get("tier"),
+                "contact_auto_approve": contact.get("auto_approve"),
+            },
+        )
+        share = self._share_payload(row)
+        if not share:
+            raise KaiLocationError(
+                "SHARE_CREATE_FAILED", "Could not create the location share.", status_code=500
+            )
+        self._insert_event(
+            owner_user_id=owner_user_id,
+            contact_id=contact_id,
+            share_id=share["id"],
+            event_type="SHARE_CREATED",
+            metadata={"duration_hours": duration, "live_mode": bool(live_mode)},
+        )
+        return {"share": share, "token": token, "latest": latest}
+
+    def revoke_share(self, *, owner_user_id: str, share_id: str) -> dict[str, Any]:
+        row = self._execute_one(
+            """
+            UPDATE kai_location_shares
+            SET status = 'revoked',
+                revoked_at = COALESCE(revoked_at, NOW()),
+                updated_at = NOW()
+            WHERE id = CAST(:share_id AS UUID)
+              AND owner_user_id = :owner_user_id
+              AND status IN ('active', 'expired', 'deactivated')
+            RETURNING *
+            """,
+            {"owner_user_id": owner_user_id, "share_id": share_id},
+        )
+        if not row:
+            raise KaiLocationError(
+                "SHARE_NOT_FOUND", "Location share was not found.", status_code=404
+            )
+        self._insert_event(
+            owner_user_id=owner_user_id,
+            contact_id=str(row.get("contact_id") or "") or None,
+            share_id=share_id,
+            event_type="SHARE_REVOKED",
+            metadata={"reason": "owner_revoked"},
+        )
+        self._revoke_update_sessions_if_no_active_shares(owner_user_id)
+        share = self._share_payload(row)
+        if not share:
+            raise KaiLocationError(
+                "SHARE_REVOKE_FAILED", "Could not revoke the share.", status_code=500
+            )
+        return share
+
+    def stop_active_shares(self, *, owner_user_id: str) -> dict[str, Any]:
+        rows = self._execute_many(
+            """
+            UPDATE kai_location_shares
+            SET status = 'revoked',
+                revoked_at = COALESCE(revoked_at, NOW()),
+                updated_at = NOW()
+            WHERE owner_user_id = :owner_user_id
+              AND status = 'active'
+            RETURNING *
+            """,
+            {"owner_user_id": owner_user_id},
+        )
+        for row in rows:
+            self._insert_event(
+                owner_user_id=owner_user_id,
+                contact_id=str(row.get("contact_id") or "") or None,
+                share_id=str(row.get("id") or "") or None,
+                event_type="SHARE_REVOKED",
+                metadata={"reason": "owner_stop_live_location"},
+            )
+        self._revoke_update_sessions_if_no_active_shares(owner_user_id)
+        return {
+            "shares": [self._share_payload(row) for row in rows],
+            "stoppedCount": len(rows),
+        }
+
+    def resolve_public_share(self, *, token: str) -> dict[str, Any]:
+        normalized_token = str(token or "").strip()
+        if not normalized_token:
+            return {
+                "state": "invalid",
+                "canRequestAccess": False,
+                "share": None,
+                "latest": None,
+                "live": None,
+            }
+        row = self._execute_one(
+            """
+            SELECT
+              s.*,
+              c.display_name AS contact_display_name,
+              c.tier AS contact_tier,
+              c.auto_approve AS contact_auto_approve,
+              c.status AS contact_status
+            FROM kai_location_shares s
+            LEFT JOIN kai_location_contacts c ON c.id = s.contact_id
+            WHERE s.token_hash = :token_hash
+            LIMIT 1
+            """,
+            {"token_hash": _token_hash(normalized_token)},
+        )
+        if not row:
+            return {
+                "state": "invalid",
+                "canRequestAccess": False,
+                "share": None,
+                "latest": None,
+                "live": None,
+            }
+
+        status_value = str(row.get("status") or "active")
+        share_id = str(row.get("id") or "")
+        owner_user_id = str(row.get("owner_user_id") or "")
+        expires_at = row.get("expires_at")
+        if isinstance(expires_at, datetime) and expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        is_expired = isinstance(expires_at, datetime) and expires_at <= _utcnow()
+
+        if status_value == "active" and is_expired:
+            row = (
+                self._execute_one(
+                    """
+                UPDATE kai_location_shares
+                SET status = 'deactivated',
+                    deactivated_at = COALESCE(deactivated_at, NOW()),
+                    updated_at = NOW()
+                WHERE id = CAST(:share_id AS UUID)
+                RETURNING
+                  *,
+                  :contact_display_name AS contact_display_name,
+                  :contact_tier AS contact_tier,
+                  :contact_auto_approve AS contact_auto_approve
+                """,
+                    {
+                        "share_id": share_id,
+                        "contact_display_name": row.get("contact_display_name"),
+                        "contact_tier": row.get("contact_tier"),
+                        "contact_auto_approve": row.get("contact_auto_approve"),
+                    },
+                )
+                or row
+            )
+            self._insert_event(
+                owner_user_id=owner_user_id,
+                contact_id=str(row.get("contact_id") or "") or None,
+                share_id=share_id,
+                event_type="SHARE_DEACTIVATED",
+                metadata={"reason": "expired_public_open"},
+            )
+            self._revoke_update_sessions_if_no_active_shares(owner_user_id)
+            return {
+                "state": "expired",
+                "canRequestAccess": True,
+                "share": self._share_payload(row),
+                "latest": None,
+                "live": _public_live_payload(row=row, latest=None),
+            }
+
+        if status_value != "active":
+            return {
+                "state": status_value,
+                "canRequestAccess": status_value in {"expired", "deactivated"},
+                "share": self._share_payload(row),
+                "latest": None,
+                "live": _public_live_payload(row=row, latest=None),
+            }
+
+        updated_row = (
+            self._execute_one(
+                """
+            UPDATE kai_location_shares
+            SET last_viewed_at = NOW(), updated_at = NOW()
+            WHERE id = CAST(:share_id AS UUID)
+            RETURNING
+              *,
+              :contact_display_name AS contact_display_name,
+              :contact_tier AS contact_tier,
+              :contact_auto_approve AS contact_auto_approve
+            """,
+                {
+                    "share_id": share_id,
+                    "contact_display_name": row.get("contact_display_name"),
+                    "contact_tier": row.get("contact_tier"),
+                    "contact_auto_approve": row.get("contact_auto_approve"),
+                },
+            )
+            or row
+        )
+        latest = self._execute_one(
+            "SELECT * FROM kai_location_latest WHERE owner_user_id = :owner_user_id",
+            {"owner_user_id": owner_user_id},
+        )
+        latest_payload = self._latest_payload(latest)
+        self._insert_event(
+            owner_user_id=owner_user_id,
+            contact_id=str(updated_row.get("contact_id") or "") or None,
+            share_id=share_id,
+            event_type="SHARE_VIEWED",
+            metadata={"status": "active"},
+        )
+        return {
+            "state": "active",
+            "canRequestAccess": False,
+            "share": self._share_payload(updated_row),
+            "latest": latest_payload,
+            "live": _public_live_payload(row=updated_row, latest=latest_payload),
+        }
+
+    def request_access(
+        self,
+        *,
+        token: str,
+        requester_label: str | None = None,
+        requester_message: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        share_row = self._execute_one(
+            """
+            SELECT
+              s.*,
+              c.display_name AS contact_display_name,
+              c.tier AS contact_tier,
+              c.auto_approve AS contact_auto_approve,
+              c.status AS contact_status
+            FROM kai_location_shares s
+            LEFT JOIN kai_location_contacts c ON c.id = s.contact_id
+            WHERE s.token_hash = :token_hash
+            LIMIT 1
+            """,
+            {"token_hash": _token_hash(str(token or "").strip())},
+        )
+        if not share_row:
+            raise KaiLocationError(
+                "SHARE_NOT_FOUND", "This location link is no longer valid.", status_code=404
+            )
+
+        owner_user_id = str(share_row.get("owner_user_id") or "")
+        share_id = str(share_row.get("id") or "")
+        contact_id = str(share_row.get("contact_id") or "") or None
+        contact_tier = str(share_row.get("contact_tier") or "")
+        share_status = str(share_row.get("status") or "")
+        expires_at = _parse_datetime(share_row.get("expires_at"), field_name="expires_at")
+        contact_active = str(share_row.get("contact_status") or "revoked") == "active"
+        auto_approve = (
+            bool(share_row.get("contact_auto_approve"))
+            and contact_tier == "family"
+            and contact_active
+        )
+
+        if share_status == "revoked":
+            raise KaiLocationError(
+                "SHARE_REVOKED", "This location link has been revoked.", status_code=410
+            )
+        if share_status == "active" and expires_at > _utcnow():
+            raise KaiLocationError(
+                "SHARE_STILL_ACTIVE",
+                "This location link is still active and does not need a new access request.",
+                status_code=409,
+            )
+
+        if auto_approve:
+            request_row = self._execute_one(
+                """
+                INSERT INTO kai_location_access_requests (
+                  share_id, owner_user_id, contact_id, status, requester_label,
+                  requester_message, requested_at, resolved_at, renewed_share_id, metadata
+                )
+                VALUES (
+                  CAST(:share_id AS UUID), :owner_user_id, CAST(:contact_id AS UUID),
+                  'auto_approved', :requester_label, :requester_message, NOW(), NOW(),
+                  CAST(:share_id AS UUID), CAST(:metadata_json AS JSONB)
+                )
+                RETURNING *
+                """,
+                {
+                    "share_id": share_id,
+                    "owner_user_id": owner_user_id,
+                    "contact_id": contact_id,
+                    "requester_label": (requester_label or "").strip()[:120] or None,
+                    "requester_message": (requester_message or "").strip()[:500] or None,
+                    "metadata_json": _json_param(metadata),
+                },
+            )
+            renewed_share = self._execute_one(
+                """
+                UPDATE kai_location_shares
+                SET status = 'active',
+                    expires_at = NOW() + INTERVAL '24 hours',
+                    deactivated_at = NULL,
+                    revoked_at = NULL,
+                    updated_at = NOW()
+                WHERE id = CAST(:share_id AS UUID)
+                RETURNING
+                  *,
+                  :contact_display_name AS contact_display_name,
+                  :contact_tier AS contact_tier,
+                  :contact_auto_approve AS contact_auto_approve
+                """,
+                {
+                    "share_id": share_id,
+                    "contact_display_name": share_row.get("contact_display_name"),
+                    "contact_tier": share_row.get("contact_tier"),
+                    "contact_auto_approve": share_row.get("contact_auto_approve"),
+                },
+            )
+            self._insert_event(
+                owner_user_id=owner_user_id,
+                contact_id=contact_id,
+                share_id=share_id,
+                request_id=str(request_row.get("id") or "") if request_row else None,
+                event_type="ACCESS_AUTO_APPROVED",
+                metadata={"tier": "family"},
+            )
+            public_view = self.resolve_public_share(token=token)
+            return {
+                "status": "auto_approved",
+                "accessRequest": self._request_payload(request_row),
+                "share": self._share_payload(renewed_share),
+                "publicView": public_view,
+            }
+
+        existing = self._execute_one(
+            """
+            SELECT
+              r.*,
+              c.display_name AS contact_display_name,
+              c.tier AS contact_tier
+            FROM kai_location_access_requests r
+            LEFT JOIN kai_location_contacts c ON c.id = r.contact_id
+            WHERE r.share_id = CAST(:share_id AS UUID)
+              AND r.status = 'pending'
+            ORDER BY r.requested_at DESC
+            LIMIT 1
+            """,
+            {"share_id": share_id},
+        )
+        if existing:
+            return {
+                "status": "pending",
+                "accessRequest": self._request_payload(existing),
+                "share": self._share_payload(share_row),
+                "publicView": None,
+            }
+
+        request_row = self._execute_one(
+            """
+            INSERT INTO kai_location_access_requests (
+              share_id, owner_user_id, contact_id, status, requester_label,
+              requester_message, requested_at, metadata
+            )
+            VALUES (
+              CAST(:share_id AS UUID), :owner_user_id, CAST(:contact_id AS UUID),
+              'pending', :requester_label, :requester_message, NOW(),
+              CAST(:metadata_json AS JSONB)
+            )
+            RETURNING
+              *,
+              :contact_display_name AS contact_display_name,
+              :contact_tier AS contact_tier
+            """,
+            {
+                "share_id": share_id,
+                "owner_user_id": owner_user_id,
+                "contact_id": contact_id,
+                "requester_label": (requester_label or "").strip()[:120] or None,
+                "requester_message": (requester_message or "").strip()[:500] or None,
+                "metadata_json": _json_param(metadata),
+                "contact_display_name": share_row.get("contact_display_name"),
+                "contact_tier": share_row.get("contact_tier"),
+            },
+        )
+        request_id = str(request_row.get("id") or "") if request_row else ""
+        self._insert_event(
+            owner_user_id=owner_user_id,
+            contact_id=contact_id,
+            share_id=share_id,
+            request_id=request_id or None,
+            event_type="ACCESS_REQUESTED",
+            metadata={"tier": contact_tier or None, "auto_approve": False},
+        )
+        self._send_location_access_request_notification(
+            owner_user_id=owner_user_id,
+            request_id=request_id,
+            contact_display_name=str(share_row.get("contact_display_name") or "Someone"),
+        )
+        return {
+            "status": "pending",
+            "accessRequest": self._request_payload(request_row),
+            "share": self._share_payload(share_row),
+            "publicView": None,
+        }
+
+    def approve_access_request(self, *, owner_user_id: str, request_id: str) -> dict[str, Any]:
+        request_row = self._execute_one(
+            """
+            SELECT
+              r.*,
+              c.display_name AS contact_display_name,
+              c.tier AS contact_tier
+            FROM kai_location_access_requests r
+            LEFT JOIN kai_location_contacts c ON c.id = r.contact_id
+            WHERE r.id = CAST(:request_id AS UUID)
+              AND r.owner_user_id = :owner_user_id
+              AND r.status = 'pending'
+            LIMIT 1
+            """,
+            {"owner_user_id": owner_user_id, "request_id": request_id},
+        )
+        if not request_row:
+            raise KaiLocationError(
+                "ACCESS_REQUEST_NOT_FOUND", "Pending access request was not found.", status_code=404
+            )
+        share_id = str(request_row.get("share_id") or "")
+        share_row = self._execute_one(
+            """
+            UPDATE kai_location_shares
+            SET status = 'active',
+                expires_at = NOW() + INTERVAL '24 hours',
+                deactivated_at = NULL,
+                updated_at = NOW()
+            WHERE id = CAST(:share_id AS UUID)
+              AND owner_user_id = :owner_user_id
+            RETURNING *
+            """,
+            {"owner_user_id": owner_user_id, "share_id": share_id},
+        )
+        resolved = self._execute_one(
+            """
+            UPDATE kai_location_access_requests
+            SET status = 'approved',
+                resolved_at = NOW(),
+                renewed_share_id = CAST(:share_id AS UUID)
+            WHERE id = CAST(:request_id AS UUID)
+            RETURNING
+              *,
+              :contact_display_name AS contact_display_name,
+              :contact_tier AS contact_tier
+            """,
+            {
+                "request_id": request_id,
+                "share_id": share_id,
+                "contact_display_name": request_row.get("contact_display_name"),
+                "contact_tier": request_row.get("contact_tier"),
+            },
+        )
+        self._insert_event(
+            owner_user_id=owner_user_id,
+            contact_id=str(request_row.get("contact_id") or "") or None,
+            share_id=share_id,
+            request_id=request_id,
+            event_type="ACCESS_APPROVED",
+            metadata={"duration_hours": 24},
+        )
+        return {
+            "accessRequest": self._request_payload(resolved),
+            "share": self._share_payload(share_row),
+        }
+
+    def deny_access_request(self, *, owner_user_id: str, request_id: str) -> dict[str, Any]:
+        resolved = self._execute_one(
+            """
+            UPDATE kai_location_access_requests
+            SET status = 'denied',
+                resolved_at = NOW()
+            WHERE id = CAST(:request_id AS UUID)
+              AND owner_user_id = :owner_user_id
+              AND status = 'pending'
+            RETURNING *
+            """,
+            {"owner_user_id": owner_user_id, "request_id": request_id},
+        )
+        if not resolved:
+            raise KaiLocationError(
+                "ACCESS_REQUEST_NOT_FOUND", "Pending access request was not found.", status_code=404
+            )
+        self._insert_event(
+            owner_user_id=owner_user_id,
+            contact_id=str(resolved.get("contact_id") or "") or None,
+            share_id=str(resolved.get("share_id") or "") or None,
+            request_id=request_id,
+            event_type="ACCESS_DENIED",
+            metadata={},
+        )
+        return self._request_payload(resolved) or {}
+
+    def issue_update_session(self, *, owner_user_id: str) -> dict[str, Any]:
+        active = self._execute_one(
+            """
+            SELECT COUNT(*) AS active_count
+            FROM kai_location_shares
+            WHERE owner_user_id = :owner_user_id
+              AND status = 'active'
+              AND expires_at > NOW()
+            """,
+            {"owner_user_id": owner_user_id},
+        )
+        if int(active.get("active_count") or 0) <= 0:
+            raise KaiLocationError(
+                "NO_ACTIVE_LOCATION_SHARES",
+                "Create an active location share before starting live updates.",
+                status_code=409,
+            )
+        token = _new_token()
+        row = self._execute_one(
+            """
+            INSERT INTO kai_location_update_sessions (
+              owner_user_id, session_token_hash, status, expires_at, created_at, updated_at, metadata
+            )
+            VALUES (
+              :owner_user_id, :session_token_hash, 'active',
+              NOW() + INTERVAL '24 hours', NOW(), NOW(), '{}'::jsonb
+            )
+            RETURNING id, expires_at
+            """,
+            {"owner_user_id": owner_user_id, "session_token_hash": _token_hash(token)},
+        )
+        session_id = str(row.get("id") or "") if row else ""
+        self._insert_event(
+            owner_user_id=owner_user_id,
+            event_type="UPDATE_SESSION_CREATED",
+            metadata={"session_id": session_id},
+        )
+        return {
+            "token": token,
+            "expiresAt": _iso(row.get("expires_at") if row else None),
+            "endpointPath": "/api/kai/location/updates",
+        }
+
+    def update_with_session(self, *, session_token: str, point: dict[str, Any]) -> dict[str, Any]:
+        token = str(session_token or "").strip()
+        if not token:
+            raise KaiLocationError(
+                "LOCATION_UPDATE_TOKEN_MISSING", "Missing location update token.", status_code=401
+            )
+        session = self._execute_one(
+            """
+            SELECT *
+            FROM kai_location_update_sessions
+            WHERE session_token_hash = :session_token_hash
+              AND status = 'active'
+            LIMIT 1
+            """,
+            {"session_token_hash": _token_hash(token)},
+        )
+        if not session:
+            raise KaiLocationError(
+                "LOCATION_UPDATE_TOKEN_INVALID", "Invalid location update token.", status_code=401
+            )
+        owner_user_id = str(session.get("owner_user_id") or "")
+        expires_at = session.get("expires_at")
+        if isinstance(expires_at, datetime) and expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        if isinstance(expires_at, datetime) and expires_at <= _utcnow():
+            self._execute_one(
+                """
+                UPDATE kai_location_update_sessions
+                SET status = 'expired', updated_at = NOW()
+                WHERE id = CAST(:session_id AS UUID)
+                """,
+                {"session_id": str(session.get("id") or "")},
+            )
+            raise KaiLocationError(
+                "LOCATION_UPDATE_TOKEN_EXPIRED", "Location update session expired.", status_code=401
+            )
+
+        active = self._execute_one(
+            """
+            SELECT COUNT(*) AS active_count
+            FROM kai_location_shares
+            WHERE owner_user_id = :owner_user_id
+              AND status = 'active'
+              AND expires_at > NOW()
+            """,
+            {"owner_user_id": owner_user_id},
+        )
+        if int(active.get("active_count") or 0) <= 0:
+            self._revoke_update_sessions_if_no_active_shares(owner_user_id)
+            raise KaiLocationError(
+                "NO_ACTIVE_LOCATION_SHARES", "No active location shares remain.", status_code=403
+            )
+
+        latest = self.upsert_latest_point(
+            owner_user_id=owner_user_id, point=point, require_fresh=False
+        )
+        self._execute_one(
+            """
+            UPDATE kai_location_update_sessions
+            SET last_used_at = NOW(), updated_at = NOW()
+            WHERE id = CAST(:session_id AS UUID)
+            """,
+            {"session_id": str(session.get("id") or "")},
+        )
+        return {"ok": True, "latest": latest}
+
+    def _send_location_access_request_notification(
+        self,
+        *,
+        owner_user_id: str,
+        request_id: str,
+        contact_display_name: str,
+    ) -> None:
+        if not request_id:
+            return
+        try:
+            db = get_db()
+            rows = (
+                db.execute_raw(
+                    "SELECT token, platform FROM user_push_tokens WHERE user_id = :user_id",
+                    {"user_id": owner_user_id},
+                ).data
+                or []
+            )
+            if not rows:
+                return
+            configured, _ = ensure_firebase_admin()
+            if not configured:
+                return
+            from firebase_admin import messaging
+
+            request_url = _build_request_url(request_id)
+            message_data = {
+                "type": "location_access_request",
+                "request_id": request_id,
+                "user_id": owner_user_id,
+                "request_url": request_url,
+                "deep_link": f"/kai/location?requestId={request_id}",
+                "notification_tag": f"location-access-request:{request_id}",
+                "notification_category": "LOCATION_ACCESS_REQUEST",
+            }
+            seen: set[str] = set()
+            for row in rows:
+                token = str(row.get("token") or "").strip()
+                if not token or token in seen:
+                    continue
+                seen.add(token)
+                platform = str(row.get("platform") or "").strip().lower()
+                message = build_push_message(
+                    messaging,
+                    token=token,
+                    platform=platform,
+                    data=message_data,
+                    title="Location access request",
+                    body=f"{contact_display_name or 'Someone'} is asking to view your KAI location again.",
+                    request_url=request_url,
+                    notification_tag=message_data["notification_tag"],
+                    show_alert=True,
+                )
+                try:
+                    messaging.send(message)
+                except (messaging.UnregisteredError, messaging.SenderIdMismatchError):
+                    db.execute_raw(
+                        "DELETE FROM user_push_tokens WHERE token = :token", {"token": token}
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Location access FCM send failed user=%s: %s", owner_user_id, exc
+                    )
+        except Exception as exc:
+            logger.warning("Location access notification skipped user=%s: %s", owner_user_id, exc)
+
+
+def location_error_detail(exc: KaiLocationError) -> dict[str, str]:
+    return {"code": exc.code, "message": exc.message}
+
+
+def database_error_detail(exc: DatabaseExecutionError) -> dict[str, str]:
+    return {
+        "code": exc.code,
+        "message": exc.details,
+        "hint": exc.hint or "",
+    }

--- a/consent-protocol/ops/monorepo/pre-commit.sh
+++ b/consent-protocol/ops/monorepo/pre-commit.sh
@@ -10,15 +10,17 @@ if git diff --cached --name-only | grep -q "^${SUBTREE_PREFIX}/"; then
 
   echo "[pre-commit] Running quick lint on ${SUBTREE_PREFIX}..."
 
-  if [ ! -x "${SUBTREE_PREFIX}/.venv/bin/python3" ] && ! command -v python3 >/dev/null 2>&1; then
-    echo "[pre-commit] ERROR: python3 not found. Please install Python 3."
-    exit 1
-  fi
-
   if [ -x "${SUBTREE_PREFIX}/.venv/bin/python3" ]; then
     LINT_PYTHON=".venv/bin/python3"
-  else
+  elif [ -x "${SUBTREE_PREFIX}/.venv/Scripts/python.exe" ]; then
+    LINT_PYTHON=".venv/Scripts/python.exe"
+  elif command -v python3 >/dev/null 2>&1; then
     LINT_PYTHON="python3"
+  elif command -v python >/dev/null 2>&1; then
+    LINT_PYTHON="python"
+  else
+    echo "[pre-commit] ERROR: Python 3 not found. Please install Python 3."
+    exit 1
   fi
 
   (

--- a/consent-protocol/ops/monorepo/pre-push.sh
+++ b/consent-protocol/ops/monorepo/pre-push.sh
@@ -204,6 +204,14 @@ else
       while read local_ref local_sha remote_ref remote_sha; do
         [ -z "$local_sha" ] && continue
 
+        case "$local_ref:$remote_ref" in
+          refs/heads/main:*|refs/heads/master:*|*:refs/heads/main|*:refs/heads/master)
+            printf "\n\033[31m[pre-push] BLOCKED\033[0m Direct pushes to main/master are disabled.\n"
+            printf "         Push a feature branch and open a PR instead.\n\n"
+            exit 1
+            ;;
+        esac
+
         if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
           RANGE="$local_sha"
         else
@@ -223,6 +231,13 @@ fi
 
 if [ "$should_check_main" -eq 1 ] && [ -f "$REPO_ROOT/$MAIN_SYNC_SCRIPT" ]; then
   CURRENT_BRANCH_NAME=$(git branch --show-current 2>/dev/null || true)
+  case "$CURRENT_BRANCH_NAME" in
+    "$MAIN_SYNC_BRANCH"|master)
+      printf "\n\033[31m[pre-push] BLOCKED\033[0m Direct pushes from main/master are disabled.\n"
+      printf "         Push a feature branch and open a PR instead.\n\n"
+      exit 1
+      ;;
+  esac
   MAIN_SYNC_MODE="warn"
   case "$CURRENT_BRANCH_NAME" in
     "$MAIN_SYNC_BRANCH")
@@ -255,8 +270,12 @@ if [ -n "$CP_FILES" ]; then
 
   if [ -x "${SUBTREE_PREFIX}/.venv/bin/python3" ]; then
     LINT_PYTHON=".venv/bin/python3"
+  elif [ -x "${SUBTREE_PREFIX}/.venv/Scripts/python.exe" ]; then
+    LINT_PYTHON=".venv/Scripts/python.exe"
   elif command -v python3 >/dev/null 2>&1; then
     LINT_PYTHON="python3"
+  elif command -v python >/dev/null 2>&1; then
+    LINT_PYTHON="python"
   else
     LINT_PYTHON=""
   fi

--- a/consent-protocol/tests/services/test_kai_location_service.py
+++ b/consent-protocol/tests/services/test_kai_location_service.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+
+import pytest
+
+from hushh_mcp.services.kai_location_service import (
+    FRESH_FIX_WINDOW,
+    MAX_FAMILY_CONTACTS,
+    MAX_FRIEND_CONTACTS,
+    MAX_SHARE_HOURS,
+    PUBLIC_LIVE_POLL_INTERVAL_MS,
+    KaiLocationError,
+    KaiLocationService,
+    _json_param,
+    _new_token,
+    _public_live_payload,
+    _redact_coordinate_metadata,
+    _token_hash,
+    _utcnow,
+    _validate_point,
+)
+
+
+def test_location_limits_match_contract() -> None:
+    assert MAX_FAMILY_CONTACTS == 3
+    assert MAX_FRIEND_CONTACTS == 7
+    assert MAX_SHARE_HOURS == 24
+
+
+def test_share_tokens_are_random_and_hash_only() -> None:
+    token = _new_token()
+    hashed = _token_hash(token)
+
+    assert token != hashed
+    assert len(hashed) == 64
+    assert _token_hash(token) == hashed
+
+
+def test_validate_point_rejects_stale_or_out_of_range_coordinates() -> None:
+    stale_point = {
+        "latitude": 37.7749,
+        "longitude": -122.4194,
+        "capturedAt": (_utcnow() - FRESH_FIX_WINDOW - timedelta(seconds=1)).isoformat(),
+    }
+    with pytest.raises(KaiLocationError, match="fresh GPS fix"):
+        _validate_point(stale_point, require_fresh=True)
+
+    with pytest.raises(KaiLocationError, match="valid GPS range"):
+        _validate_point(
+            {"latitude": 91, "longitude": -122.4194, "capturedAt": _utcnow().isoformat()},
+            require_fresh=True,
+        )
+
+
+def test_event_metadata_redacts_coordinates_recursively() -> None:
+    metadata = {
+        "requester": "family",
+        "latitude": 37.7749,
+        "nested": {
+            "safe": "kept",
+            "lng": -122.4194,
+            "items": [{"location": "hidden"}, {"note": "ok"}],
+        },
+    }
+
+    redacted = _redact_coordinate_metadata(metadata)
+    encoded = json.loads(_json_param(metadata))
+
+    assert redacted == {
+        "requester": "family",
+        "nested": {"safe": "kept", "items": [{}, {"note": "ok"}]},
+    }
+    assert encoded == redacted
+
+
+def test_public_live_payload_uses_gcp_polling_contract() -> None:
+    payload = _public_live_payload(
+        row={"status": "active", "live_mode": True},
+        latest={"capturedAt": _utcnow().isoformat()},
+    )
+
+    assert payload["transport"] == "gcp_polling"
+    assert payload["pollIntervalMs"] == PUBLIC_LIVE_POLL_INTERVAL_MS
+    assert payload["isLive"] is True
+    assert isinstance(payload["freshnessSeconds"], int)
+    assert "latitude" not in payload
+    assert "longitude" not in payload
+
+
+class _RequestAccessGuardService(KaiLocationService):
+    def __init__(self, share_row: dict) -> None:
+        self.share_row = share_row
+
+    def _execute_one(self, sql: str, params: dict) -> dict | None:
+        if "FROM kai_location_shares s" in sql and "WHERE s.token_hash" in sql:
+            return self.share_row
+        raise AssertionError("request_access should stop before additional database writes")
+
+
+def test_request_access_rejects_revoked_share_links() -> None:
+    share_link = "share-link"
+    service = _RequestAccessGuardService(
+        {
+            "id": "share-1",
+            "owner_user_id": "owner-1",
+            "contact_id": "contact-1",
+            "status": "revoked",
+            "expires_at": _utcnow() - timedelta(hours=1),
+            "contact_tier": "family",
+            "contact_status": "active",
+            "contact_auto_approve": True,
+        }
+    )
+
+    with pytest.raises(KaiLocationError) as exc_info:
+        service.request_access(token=share_link)
+
+    assert exc_info.value.code == "SHARE_REVOKED"
+    assert exc_info.value.status_code == 410
+
+
+def test_request_access_rejects_still_active_share_links() -> None:
+    share_link = "share-link"
+    service = _RequestAccessGuardService(
+        {
+            "id": "share-1",
+            "owner_user_id": "owner-1",
+            "contact_id": "contact-1",
+            "status": "active",
+            "expires_at": _utcnow() + timedelta(hours=1),
+            "contact_tier": "friend",
+            "contact_status": "active",
+            "contact_auto_approve": False,
+        }
+    )
+
+    with pytest.raises(KaiLocationError) as exc_info:
+        service.request_access(token=share_link)
+
+    assert exc_info.value.code == "SHARE_STILL_ACTIVE"
+    assert exc_info.value.status_code == 409

--- a/docs/reference/architecture/api-contracts.md
+++ b/docs/reference/architecture/api-contracts.md
@@ -33,6 +33,7 @@ POST /api/consent/vault-owner-token  (Firebase Bearer)
 | Firebase ID Token     | Identity verification only       | 1 hour   | `Bearer <firebase-id-token>`   |
 | VAULT_OWNER Token     | Consent + identity for all data  | 24 hours | `Bearer <vault-owner-token>`   |
 | Agent Scoped Token    | Delegated MCP agent access       | 7 days   | `Bearer <consent-token>`       |
+| Location Update Token | Owner-device GPS heartbeat only  | <=24 hours | `Bearer <location-update-token>` |
 | Developer Token       | External API and remote MCP access | N/A    | `?token=<developer-token>`     |
 
 ---
@@ -66,6 +67,8 @@ Client surfaces
 | POST | `/api/validate-token` | Validate a consent token |
 | GET | `/api/app-config/review-mode` | Review mode toggle (enabled only) |
 | POST | `/api/app-config/review-mode/session` | Mint Firebase custom token for `REVIEWER_UID`; non-production smoke may use `REVIEWER_VAULT_PASSPHRASE` |
+| GET | `/api/kai/location/shared?token={bearer-location-token}` | Resolve an active public KAI location share link; expired active links are deactivated on open |
+| POST | `/api/kai/location/shared/access-request` | Request renewed access for an expired/deactivated KAI location share bearer link |
 
 ### Developer API (Developer Token / Developer API Enabled)
 
@@ -217,6 +220,31 @@ RIA relationship bundle note:
 | GET | `/api/kai/dashboard/profile-picks/{user_id}` | Real profile-based picks for dashboard cards (`symbols`, `limit`) |
 | POST | `/api/kai/portfolio/analyze-losers` | Analyze losers vs Renaissance |
 | POST | `/api/kai/portfolio/analyze-losers/stream` | Streaming losers analysis (SSE, deterministic config, cash-excluded investable universe) |
+
+#### Kai Location Sharing
+
+KAI location sharing uses hash-only bearer share tokens for public message links. A
+share can be viewed by anyone with the active bearer URL until its configured
+24-hour-or-less window expires. The public viewer is GCP-friendly live polling:
+the owner device sends scoped GPS heartbeats to the Cloud Run API, Cloud SQL keeps
+only the latest point, and the public shared page polls the bearer-link resolver
+for fresh coordinates, expiry, or owner-side stop/revoke state. Opening an expired
+active share marks it deactivated and returns a request-access state. Audit events
+and push notifications must not include coordinates.
+
+| Method | Path | Auth | Description |
+| ------ | ---- | ---- | ----------- |
+| GET | `/api/kai/location/state` | VAULT_OWNER Bearer | Owner dashboard state: active contacts, shares, pending access requests, latest point, and active update sessions |
+| POST | `/api/kai/location/contacts` | VAULT_OWNER Bearer | Create an owner-managed recipient; service enforces 3 active family contacts and 7 active friend contacts |
+| PATCH | `/api/kai/location/contacts/{contact_id}` | VAULT_OWNER Bearer | Update display name, tier, or family-only auto-approve flag |
+| DELETE | `/api/kai/location/contacts/{contact_id}` | VAULT_OWNER Bearer | Revoke a contact, revoke active shares, and disable future auto-approve renewals |
+| POST | `/api/kai/location/shares` | VAULT_OWNER Bearer | Create a configurable 24-hour-or-less live public bearer share for an active contact; requires a fresh GPS fix |
+| DELETE | `/api/kai/location/shares/{share_id}` | VAULT_OWNER Bearer | Revoke an active location share |
+| POST | `/api/kai/location/shares/stop-active` | VAULT_OWNER Bearer | Stop all active live location shares for the owner and revoke active update sessions when no active shares remain |
+| POST | `/api/kai/location/access-requests/{request_id}/approve` | VAULT_OWNER Bearer | Approve a pending access request and renew the original bearer link for up to 24 hours |
+| POST | `/api/kai/location/access-requests/{request_id}/deny` | VAULT_OWNER Bearer | Deny a pending access request |
+| POST | `/api/kai/location/update-sessions` | VAULT_OWNER Bearer | Issue a scoped owner-device location update token while active shares exist |
+| POST | `/api/kai/location/updates` | Location Update Bearer | Owner-device heartbeat endpoint; updates the latest GPS point only and stops accepting updates after expiry/revoke/no active shares |
 
 #### Kai Plaid Brokerage Connectivity
 

--- a/hushh-webapp/.env.example
+++ b/hushh-webapp/.env.example
@@ -24,6 +24,8 @@ NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=
 # Local development only. When true, Firebase web phone auth only works with
 # fictional phone numbers configured in Firebase Authentication.
 NEXT_PUBLIC_FIREBASE_PHONE_AUTH_DISABLE_APP_VERIFICATION=false
+# Optional backend override for KAI live location routes.
+KAI_LOCATION_API_URL=
 
 # ============================================================================
 # BACKEND

--- a/hushh-webapp/__tests__/api/kai/proxy-route.test.ts
+++ b/hushh-webapp/__tests__/api/kai/proxy-route.test.ts
@@ -8,6 +8,7 @@ vi.mock("@/app/api/_utils/backend", () => ({
 type KaiRouteModule = {
   GET: (req: NextRequest, ctx: { params: Promise<{ path: string[] }> }) => Promise<Response>;
   POST: (req: NextRequest, ctx: { params: Promise<{ path: string[] }> }) => Promise<Response>;
+  PATCH: (req: NextRequest, ctx: { params: Promise<{ path: string[] }> }) => Promise<Response>;
   DELETE: (req: NextRequest, ctx: { params: Promise<{ path: string[] }> }) => Promise<Response>;
 };
 
@@ -52,6 +53,62 @@ describe("/api/kai/[...path] proxy", () => {
     const headers = options?.headers as Headers;
     expect(headers.get("Authorization")).toBe("Bearer vault_owner_token");
     expect(headers.get("Content-Type")).toBe("application/json");
+  });
+
+  it("forwards PATCH requests for KAI location contact updates", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ contact: { id: "contact-1" } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    const req = createRequest("http://localhost:3000/api/kai/location/contacts/contact-1", {
+      method: "PATCH",
+      headers: {
+        Authorization: "Bearer vault_owner_token",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ auto_approve: true }),
+    });
+
+    const res = await kaiRoute.PATCH(req, {
+      params: Promise.resolve({ path: ["location", "contacts", "contact-1"] }),
+    });
+
+    expect(res.status).toBe(200);
+
+    const [url, options] = fetchSpy.mock.calls[0] ?? [];
+    expect(url).toBe("http://backend.test/api/kai/location/contacts/contact-1");
+    expect(options?.method).toBe("PATCH");
+    expect((options?.headers as Headers).get("Authorization")).toBe("Bearer vault_owner_token");
+  });
+
+  it("can route unreleased KAI location paths to a dedicated local backend", async () => {
+    vi.stubEnv("KAI_LOCATION_API_URL", "http://127.0.0.1:8000");
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ contact: { id: "contact-1" } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    const req = createRequest("http://localhost:3000/api/kai/location/contacts", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer vault_owner_token",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ displayName: "Alex", tier: "friend" }),
+    });
+
+    const res = await kaiRoute.POST(req, {
+      params: Promise.resolve({ path: ["location", "contacts"] }),
+    });
+
+    expect(res.status).toBe(200);
+    const [url] = fetchSpy.mock.calls[0] ?? [];
+    expect(url).toBe("http://127.0.0.1:8000/api/kai/location/contacts");
   });
 
   it("forwards Authorization for import multipart path without overriding multipart content-type", async () => {

--- a/hushh-webapp/__tests__/components/kai-location-page.test.tsx
+++ b/hushh-webapp/__tests__/components/kai-location-page.test.tsx
@@ -1,0 +1,231 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  LocationContact,
+  LocationLatestPoint,
+  LocationOwnerState,
+  LocationShare,
+} from "@/lib/location-sharing/types";
+
+const {
+  approveAccessRequestMock,
+  buildMapsUrlsMock,
+  buildSharedLocationUrlMock,
+  copyLocationUrlMock,
+  createContactMock,
+  createShareMock,
+  denyAccessRequestMock,
+  getFreshLocationPointMock,
+  getLocationSharingErrorMessageMock,
+  getOwnerStateMock,
+  issueUpdateSessionMock,
+  isLocationApiUnavailableMock,
+  revokeContactMock,
+  revokeShareMock,
+  shareOrCopyLocationUrlMock,
+  startLiveUpdatesMock,
+  stopActiveSharesMock,
+  stopLiveUpdatesMock,
+  toastErrorMock,
+  toastSuccessMock,
+} = vi.hoisted(() => ({
+  approveAccessRequestMock: vi.fn(),
+  buildMapsUrlsMock: vi.fn(() => ({
+    apple: "https://maps.apple.com/?ll=12.9716,77.5946",
+    google: "https://www.google.com/maps?q=12.9716%2C77.5946",
+    osmEmbed: "https://www.openstreetmap.org/export/embed.html?bbox=77.58,12.96,77.60,12.98",
+  })),
+  buildSharedLocationUrlMock: vi.fn((token: string) => `http://localhost/location/shared?token=${token}`),
+  copyLocationUrlMock: vi.fn(),
+  createContactMock: vi.fn(),
+  createShareMock: vi.fn(),
+  denyAccessRequestMock: vi.fn(),
+  getFreshLocationPointMock: vi.fn(),
+  getLocationSharingErrorMessageMock: vi.fn((error: unknown, fallback: string) =>
+    error instanceof Error ? error.message : fallback
+  ),
+  getOwnerStateMock: vi.fn(),
+  issueUpdateSessionMock: vi.fn(),
+  isLocationApiUnavailableMock: vi.fn(() => false),
+  revokeContactMock: vi.fn(),
+  revokeShareMock: vi.fn(),
+  shareOrCopyLocationUrlMock: vi.fn(),
+  startLiveUpdatesMock: vi.fn(),
+  stopActiveSharesMock: vi.fn(),
+  stopLiveUpdatesMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+}));
+
+vi.mock("@/lib/firebase/auth-context", () => ({
+  useAuth: () => ({
+    user: { uid: "owner-1" },
+    loading: false,
+  }),
+}));
+
+vi.mock("@/lib/vault/vault-context", () => ({
+  useVault: () => ({
+    vaultOwnerToken: "vault-owner-token",
+    isVaultUnlocked: true,
+  }),
+}));
+
+vi.mock("@/components/vault/vault-unlock-dialog", () => ({
+  VaultUnlockDialog: () => null,
+}));
+
+vi.mock("@/lib/morphy-ux/morphy", () => ({
+  morphyToast: {
+    error: toastErrorMock,
+    success: toastSuccessMock,
+  },
+}));
+
+vi.mock("@/lib/location-sharing/service", () => ({
+  buildMapsUrls: buildMapsUrlsMock,
+  buildSharedLocationUrl: buildSharedLocationUrlMock,
+  buildWhatsAppShareUrl: (url: string) => `https://wa.me/?text=${encodeURIComponent(url)}`,
+  copyLocationUrl: copyLocationUrlMock,
+  getFreshLocationPoint: getFreshLocationPointMock,
+  getLocationSharingErrorMessage: getLocationSharingErrorMessageMock,
+  isLocationApiUnavailable: isLocationApiUnavailableMock,
+  shareOrCopyLocationUrl: shareOrCopyLocationUrlMock,
+  KaiLocationSharingService: {
+    approveAccessRequest: approveAccessRequestMock,
+    createContact: createContactMock,
+    createShare: createShareMock,
+    denyAccessRequest: denyAccessRequestMock,
+    getOwnerState: getOwnerStateMock,
+    issueUpdateSession: issueUpdateSessionMock,
+    revokeContact: revokeContactMock,
+    revokeShare: revokeShareMock,
+    startLiveUpdates: startLiveUpdatesMock,
+    stopActiveShares: stopActiveSharesMock,
+    stopLiveUpdates: stopLiveUpdatesMock,
+  },
+}));
+
+const contact: LocationContact = {
+  id: "contact-1",
+  ownerUserId: "owner-1",
+  displayName: "Mom",
+  tier: "family",
+  status: "active",
+  autoApprove: true,
+  createdAt: "2026-05-19T10:00:00.000Z",
+  updatedAt: "2026-05-19T10:00:00.000Z",
+  revokedAt: null,
+};
+
+const point: LocationLatestPoint = {
+  ownerUserId: "owner-1",
+  latitude: 12.9716,
+  longitude: 77.5946,
+  accuracyM: 8,
+  headingDeg: null,
+  speedMps: null,
+  capturedAt: "2026-05-19T10:05:00.000Z",
+  sourcePlatform: "web",
+  updatedAt: "2026-05-19T10:05:00.000Z",
+};
+
+const share: LocationShare = {
+  id: "share-1",
+  ownerUserId: "owner-1",
+  contactId: "contact-1",
+  contactDisplayName: "Mom",
+  contactTier: "family",
+  contactAutoApprove: true,
+  status: "active",
+  liveMode: true,
+  expiresAt: "2026-05-20T10:05:00.000Z",
+  createdAt: "2026-05-19T10:05:00.000Z",
+  updatedAt: "2026-05-19T10:05:00.000Z",
+  lastViewedAt: null,
+  deactivatedAt: null,
+  revokedAt: null,
+};
+
+function ownerState(overrides: Partial<LocationOwnerState> = {}): LocationOwnerState {
+  return {
+    contacts: [contact],
+    shares: [],
+    accessRequests: [],
+    latest: point,
+    limits: { family: 3, friend: 7 },
+    ...overrides,
+  };
+}
+
+describe("KaiLocationPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getOwnerStateMock.mockResolvedValue(ownerState());
+    getFreshLocationPointMock.mockResolvedValue(point);
+    createShareMock.mockImplementation(async () => {
+      getOwnerStateMock.mockResolvedValue(ownerState({ shares: [share] }));
+      return { share, token: "raw-location-token", latest: point };
+    });
+    issueUpdateSessionMock.mockResolvedValue({
+      token: "update-token",
+      expiresAt: "2026-05-19T11:05:00.000Z",
+      endpointPath: "/api/kai/location/updates",
+    });
+    shareOrCopyLocationUrlMock.mockRejectedValue(new Error("share unavailable in jsdom"));
+    stopActiveSharesMock.mockImplementation(async () => {
+      getOwnerStateMock.mockResolvedValue(ownerState({ shares: [] }));
+      return { shares: [], stoppedCount: 1 };
+    });
+    startLiveUpdatesMock.mockResolvedValue({ active: true, mode: "web" });
+    stopLiveUpdatesMock.mockResolvedValue(undefined);
+  });
+
+  it(
+    "creates a live location link, exposes it for messaging, starts updates, and stops access",
+    async () => {
+      const { default: KaiLocationPage } = await import("@/app/kai/location/page");
+
+      render(<KaiLocationPage />);
+
+      await expect(screen.findByText("Mom")).resolves.toBeTruthy();
+
+      fireEvent.click(screen.getByRole("button", { name: /share/i }));
+
+      await waitFor(() => {
+        expect(createShareMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            vaultOwnerToken: "vault-owner-token",
+            contactId: "contact-1",
+            durationHours: 1,
+            liveMode: true,
+            point,
+          })
+        );
+      });
+      await waitFor(() => {
+        expect(startLiveUpdatesMock).toHaveBeenCalledWith({
+          updateToken: "update-token",
+          endpointPath: "/api/kai/location/updates",
+        });
+      });
+
+      const urlInput = await screen.findByDisplayValue(
+        "http://localhost/location/shared?token=raw-location-token"
+      );
+      expect(urlInput).toBeTruthy();
+      expect(screen.getByRole("button", { name: /copy/i })).toBeTruthy();
+      expect(screen.getByRole("button", { name: /whatsapp/i })).toBeTruthy();
+
+      fireEvent.click(screen.getByRole("button", { name: /stop sharing/i }));
+
+      await waitFor(() => {
+        expect(stopActiveSharesMock).toHaveBeenCalledWith("vault-owner-token");
+        expect(stopLiveUpdatesMock).toHaveBeenCalled();
+      });
+      await expect(screen.findByText("No active location shares.")).resolves.toBeTruthy();
+    },
+    60_000
+  );
+});

--- a/hushh-webapp/__tests__/services/location-sharing-contract.test.ts
+++ b/hushh-webapp/__tests__/services/location-sharing-contract.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/services/api-service", () => ({
+  ApiService: {
+    apiFetch: () => Promise.reject(new Error("apiFetch is not used in this contract test")),
+    getAuthHeaders: () => ({}),
+  },
+}));
+
+import {
+  createLocationPointFromPosition,
+  hasCoordinatesInMetadata,
+  isLocationAccessRequestStatus,
+  isLocationContactTier,
+  isLocationShareStatus,
+  isPublicLocationShareState,
+  isValidLocationPoint,
+} from "@/lib/location-sharing/contract";
+import {
+  DEFAULT_PUBLIC_LIVE_POLL_INTERVAL_MS,
+  buildLocationShareMessage,
+  buildMapsUrls,
+  buildOpenStreetMapEmbedUrl,
+  buildSharedLocationUrl,
+  buildWhatsAppShareUrl,
+} from "@/lib/location-sharing/service";
+
+describe("KAI location sharing contract", () => {
+  it("validates bounded enum values", () => {
+    expect(isLocationContactTier("family")).toBe(true);
+    expect(isLocationContactTier("coworker")).toBe(false);
+    expect(isLocationShareStatus("deactivated")).toBe(true);
+    expect(isLocationShareStatus("pending")).toBe(false);
+    expect(isLocationAccessRequestStatus("auto_approved")).toBe(true);
+    expect(isLocationAccessRequestStatus("revoked")).toBe(false);
+    expect(isPublicLocationShareState("invalid")).toBe(true);
+  });
+
+  it("validates latest-only GPS points", () => {
+    expect(
+      isValidLocationPoint({
+        latitude: 37.7749,
+        longitude: -122.4194,
+        accuracyM: 12,
+        capturedAt: "2026-05-19T00:00:00.000Z",
+        sourcePlatform: "web",
+      })
+    ).toBe(true);
+
+    expect(
+      isValidLocationPoint({
+        latitude: 120,
+        longitude: -122.4194,
+        capturedAt: "2026-05-19T00:00:00.000Z",
+        sourcePlatform: "web",
+      })
+    ).toBe(false);
+  });
+
+  it("creates sanitized web location points from browser coordinates", () => {
+    const point = createLocationPointFromPosition(
+      {
+        coords: {
+          latitude: 12.9716,
+          longitude: 77.5946,
+          accuracy: 9,
+          altitude: null,
+          altitudeAccuracy: null,
+          heading: Number.NaN,
+          speed: null,
+        },
+        timestamp: Date.parse("2026-05-19T01:02:03.000Z"),
+      } as GeolocationPosition,
+      "web"
+    );
+
+    expect(point).toMatchObject({
+      latitude: 12.9716,
+      longitude: 77.5946,
+      accuracyM: 9,
+      headingDeg: null,
+      speedMps: null,
+      capturedAt: "2026-05-19T01:02:03.000Z",
+      sourcePlatform: "web",
+    });
+  });
+
+  it("detects coordinate keys inside notification or event metadata", () => {
+    expect(
+      hasCoordinatesInMetadata({
+        requestId: "req_1",
+        nested: [{ note: "safe" }, { longitude: -122.4194 }],
+      })
+    ).toBe(true);
+    expect(hasCoordinatesInMetadata({ requestId: "req_1", route: "/kai/location" })).toBe(false);
+  });
+
+  it("builds bearer share and maps URLs without exposing extra state", () => {
+    const point = { latitude: 37.7749, longitude: -122.4194 };
+    const url = buildSharedLocationUrl("token with spaces");
+    const maps = buildMapsUrls(point);
+    const osm = buildOpenStreetMapEmbedUrl(point);
+    const message = buildLocationShareMessage(url);
+    const whatsAppUrl = buildWhatsAppShareUrl(url);
+
+    expect(url).toContain("/location/shared?token=token%20with%20spaces");
+    expect(message).toContain(url);
+    expect(message).toContain("24 hours");
+    expect(whatsAppUrl).toBe(`https://wa.me/?text=${encodeURIComponent(message)}`);
+    expect(DEFAULT_PUBLIC_LIVE_POLL_INTERVAL_MS).toBe(10_000);
+    expect(maps.google).toBe("https://www.google.com/maps?q=37.7749%2C-122.4194");
+    expect(maps.apple).toContain("https://maps.apple.com/");
+    expect(maps.osmEmbed).toBe(osm);
+    expect(osm).toContain("openstreetmap.org/export/embed.html");
+    expect(osm).toContain("marker=37.7749%2C-122.4194");
+  });
+});

--- a/hushh-webapp/app/api/kai/[...path]/route.ts
+++ b/hushh-webapp/app/api/kai/[...path]/route.ts
@@ -32,6 +32,24 @@ function isGmailPath(path: string): boolean {
   return path === "gmail" || path.startsWith("gmail/");
 }
 
+function normalizeOrigin(value: string | undefined): string | null {
+  const text = String(value || "").trim();
+  if (!text) return null;
+  try {
+    return new URL(text).origin;
+  } catch {
+    return null;
+  }
+}
+
+function resolveKaiApiOrigin(path: string): string {
+  const locationOrigin =
+    path === "location" || path.startsWith("location/")
+      ? normalizeOrigin(process.env.KAI_LOCATION_API_URL || process.env.NEXT_PUBLIC_KAI_LOCATION_API_URL)
+      : null;
+  return locationOrigin || getPythonApiUrl();
+}
+
 function isUpstreamTimeoutError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   const normalizedMessage = error.message.toLowerCase();
@@ -163,12 +181,20 @@ export async function DELETE(
   return proxyRequest(request, params);
 }
 
+export async function PATCH(
+  request: NextRequest,
+  props: { params: Promise<{ path: string[] }> }
+) {
+  const params = await props.params;
+  return proxyRequest(request, params);
+}
+
 async function proxyRequest(request: NextRequest, params: { path: string[] }) {
   const requestId = resolveRequestId(request);
   const path = params.path.join("/");
   // Forward query string to backend
   const queryString = request.nextUrl.search;
-  const url = `${getPythonApiUrl()}/api/kai/${path}${queryString}`;
+  const url = `${resolveKaiApiOrigin(path)}/api/kai/${path}${queryString}`;
 
   // Debug: Check if Authorization header is present
   const authHeader = request.headers.get("authorization");

--- a/hushh-webapp/app/kai/location/page.tsx
+++ b/hushh-webapp/app/kai/location/page.tsx
@@ -1,0 +1,910 @@
+"use client";
+
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Check,
+  Clipboard,
+  ExternalLink,
+  Info,
+  LocateFixed,
+  MapPin,
+  MessageCircle,
+  Plus,
+  Radio,
+  RefreshCw,
+  Send,
+  ShieldCheck,
+  StopCircle,
+  Trash2,
+  X,
+} from "lucide-react";
+
+import { AppPageContentRegion, AppPageShell } from "@/components/app-ui/app-page-shell";
+import {
+  SurfaceCard,
+  SurfaceCardContent,
+  SurfaceCardDescription,
+  SurfaceCardHeader,
+  SurfaceCardTitle,
+} from "@/components/app-ui/surfaces";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { PageHeader } from "@/components/app-ui/page-sections";
+import { VaultUnlockDialog } from "@/components/vault/vault-unlock-dialog";
+import { useAuth } from "@/lib/firebase/auth-context";
+import {
+  buildMapsUrls,
+  buildSharedLocationUrl,
+  buildWhatsAppShareUrl,
+  copyLocationUrl,
+  getFreshLocationPoint,
+  getLocationSharingErrorMessage,
+  isLocationApiUnavailable,
+  KaiLocationSharingService,
+  shareOrCopyLocationUrl,
+} from "@/lib/location-sharing/service";
+import type {
+  LocationContact,
+  LocationContactTier,
+  LocationLatestPoint,
+  LocationOwnerState,
+  LocationShare,
+} from "@/lib/location-sharing/types";
+import { morphyToast as toast } from "@/lib/morphy-ux/morphy";
+import { cn } from "@/lib/utils";
+import { useVault } from "@/lib/vault/vault-context";
+
+const EMPTY_STATE: LocationOwnerState = {
+  contacts: [],
+  shares: [],
+  accessRequests: [],
+  latest: null,
+  limits: { family: 3, friend: 7 },
+};
+
+const SHARE_DURATION_OPTIONS = [
+  { value: "0.25", label: "15 min" },
+  { value: "1", label: "1 hour" },
+  { value: "8", label: "8 hours" },
+  { value: "24", label: "24 hours" },
+] as const;
+
+function formatDateTime(value: string | null | undefined): string {
+  if (!value) return "Not available";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Not available";
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date);
+}
+
+function formatPoint(point: LocationLatestPoint | null): string {
+  if (!point) return "No GPS fix yet";
+  return `${point.latitude.toFixed(6)}, ${point.longitude.toFixed(6)}`;
+}
+
+function tierLabel(tier: LocationContactTier): string {
+  return tier === "family" ? "Family" : "Friend";
+}
+
+function KaiLocationContent() {
+  const { user, loading: authLoading } = useAuth();
+  const { vaultOwnerToken, isVaultUnlocked } = useVault();
+  const [requestId, setRequestId] = useState<string | null>(null);
+
+  const [state, setState] = useState<LocationOwnerState>(EMPTY_STATE);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [liveRunning, setLiveRunning] = useState(false);
+  const [vaultDialogOpen, setVaultDialogOpen] = useState(false);
+  const [currentPoint, setCurrentPoint] = useState<LocationLatestPoint | null>(null);
+  const [apiNotice, setApiNotice] = useState<string | null>(null);
+  const [shareUrlsById, setShareUrlsById] = useState<Record<string, string>>({});
+  const [shareDurationHours, setShareDurationHours] = useState("1");
+  const [form, setForm] = useState<{
+    displayName: string;
+    tier: LocationContactTier;
+    autoApprove: boolean;
+  }>({
+    displayName: "",
+    tier: "family",
+    autoApprove: true,
+  });
+
+  const activeContacts = useMemo(
+    () => state.contacts.filter((contact) => contact.status === "active"),
+    [state.contacts]
+  );
+  const activeShares = useMemo(
+    () => state.shares.filter((share) => share.status === "active"),
+    [state.shares]
+  );
+  const pendingRequests = useMemo(
+    () => state.accessRequests.filter((request) => request.status === "pending"),
+    [state.accessRequests]
+  );
+  const currentMaps = useMemo(
+    () => (currentPoint ? buildMapsUrls(currentPoint) : null),
+    [currentPoint]
+  );
+  const familyCount = activeContacts.filter((contact) => contact.tier === "family").length;
+  const friendCount = activeContacts.filter((contact) => contact.tier === "friend").length;
+  const limitReached =
+    form.tier === "family"
+      ? familyCount >= state.limits.family
+      : friendCount >= state.limits.friend;
+
+  useEffect(() => {
+    setRequestId(new URLSearchParams(window.location.search).get("requestId"));
+  }, []);
+
+  const refreshState = useCallback(async () => {
+    if (!vaultOwnerToken) {
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      const nextState = await KaiLocationSharingService.getOwnerState(vaultOwnerToken);
+      setState(nextState);
+      setCurrentPoint(nextState.latest);
+      setApiNotice(null);
+    } catch (error) {
+      const message = getLocationSharingErrorMessage(error, "Could not load location sharing.");
+      if (isLocationApiUnavailable(error)) setApiNotice(message);
+      toast.error(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [vaultOwnerToken]);
+
+  useEffect(() => {
+    void refreshState();
+  }, [refreshState]);
+
+  useEffect(() => {
+    return () => {
+      void KaiLocationSharingService.stopLiveUpdates().catch(() => undefined);
+    };
+  }, []);
+
+  const refreshGps = useCallback(async () => {
+    setBusy("gps");
+    try {
+      const point = await getFreshLocationPoint();
+      setCurrentPoint(point);
+      toast.success("Fresh GPS fix ready.");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Location permission was denied.");
+    } finally {
+      setBusy(null);
+    }
+  }, []);
+
+  const startLiveUpdates = useCallback(async () => {
+    if (!vaultOwnerToken) return;
+    setBusy("live");
+    try {
+      const session = await KaiLocationSharingService.issueUpdateSession(vaultOwnerToken);
+      await KaiLocationSharingService.startLiveUpdates({
+        updateToken: session.token,
+        endpointPath: session.endpointPath,
+      });
+      setLiveRunning(true);
+      setApiNotice(null);
+      toast.success("Live location updates are running.");
+    } catch (error) {
+      const message = getLocationSharingErrorMessage(error, "Could not start live location.");
+      if (isLocationApiUnavailable(error)) setApiNotice(message);
+      toast.error(message);
+    } finally {
+      setBusy(null);
+    }
+  }, [vaultOwnerToken]);
+
+  const stopLiveUpdates = useCallback(async () => {
+    setBusy("stop-live");
+    try {
+      await KaiLocationSharingService.stopLiveUpdates();
+      setLiveRunning(false);
+      toast.success("Live location updates stopped.");
+    } finally {
+      setBusy(null);
+    }
+  }, []);
+
+  const stopAllSharing = useCallback(async () => {
+    if (!vaultOwnerToken) return;
+    setBusy("stop-sharing");
+    try {
+      const result = await KaiLocationSharingService.stopActiveShares(vaultOwnerToken);
+      await KaiLocationSharingService.stopLiveUpdates();
+      setLiveRunning(false);
+      setShareUrlsById({});
+      setApiNotice(null);
+      toast.success(
+        result.stoppedCount > 0
+          ? "Live location sharing stopped."
+          : "No active location shares to stop."
+      );
+      await refreshState();
+    } catch (error) {
+      const message = getLocationSharingErrorMessage(
+        error,
+        "Could not stop live location sharing."
+      );
+      if (isLocationApiUnavailable(error)) setApiNotice(message);
+      toast.error(message);
+    } finally {
+      setBusy(null);
+    }
+  }, [refreshState, vaultOwnerToken]);
+
+  const createContact = useCallback(async () => {
+    if (!vaultOwnerToken || limitReached) return;
+    setBusy("contact");
+    try {
+      await KaiLocationSharingService.createContact({
+        vaultOwnerToken,
+        displayName: form.displayName,
+        tier: form.tier,
+        autoApprove: form.autoApprove,
+      });
+      setForm((previous) => ({ ...previous, displayName: "" }));
+      setApiNotice(null);
+      toast.success("Recipient added.");
+      await refreshState();
+    } catch (error) {
+      const message = getLocationSharingErrorMessage(error, "Could not add recipient.");
+      if (isLocationApiUnavailable(error)) setApiNotice(message);
+      toast.error(message);
+    } finally {
+      setBusy(null);
+    }
+  }, [form, limitReached, refreshState, vaultOwnerToken]);
+
+  const revokeContact = useCallback(
+    async (contactId: string) => {
+      if (!vaultOwnerToken) return;
+      setBusy(`contact:${contactId}`);
+      try {
+        await KaiLocationSharingService.revokeContact({ vaultOwnerToken, contactId });
+        toast.success("Recipient revoked.");
+        await refreshState();
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : "Could not revoke recipient.");
+      } finally {
+        setBusy(null);
+      }
+    },
+    [refreshState, vaultOwnerToken]
+  );
+
+  const createShare = useCallback(
+    async (contact: LocationContact) => {
+      if (!vaultOwnerToken) return;
+      setBusy(`share:${contact.id}`);
+      try {
+        const point = currentPoint ?? (await getFreshLocationPoint());
+        setCurrentPoint(point);
+        const result = await KaiLocationSharingService.createShare({
+          vaultOwnerToken,
+          contactId: contact.id,
+          point,
+          durationHours: Number(shareDurationHours) || 1,
+          liveMode: true,
+        });
+        const url = buildSharedLocationUrl(result.token);
+        setShareUrlsById((previous) => ({ ...previous, [result.share.id]: url }));
+        try {
+          const mode = await shareOrCopyLocationUrl(url);
+          toast.success(mode === "shared" ? "Live location link shared." : "Live location link copied.");
+        } catch {
+          toast.success("Live location link created. Copy it from Active Shares.");
+        }
+        setApiNotice(null);
+        await refreshState();
+        if (!liveRunning) {
+          await startLiveUpdates();
+        }
+      } catch (error) {
+        const message = getLocationSharingErrorMessage(error, "Could not create location link.");
+        if (isLocationApiUnavailable(error)) setApiNotice(message);
+        toast.error(message);
+      } finally {
+        setBusy(null);
+      }
+    },
+    [currentPoint, liveRunning, refreshState, shareDurationHours, startLiveUpdates, vaultOwnerToken]
+  );
+
+  const copyKnownShareUrl = useCallback(async (share: LocationShare) => {
+    const url = shareUrlsById[share.id];
+    if (!url) {
+      toast.error("This link token is only shown when a new share is created.");
+      return;
+    }
+    await copyLocationUrl(url);
+    toast.success("Location link copied.");
+  }, [shareUrlsById]);
+
+  const shareKnownUrlOnWhatsApp = useCallback((share: LocationShare) => {
+    const url = shareUrlsById[share.id];
+    if (!url) {
+      toast.error("This link token is only shown when a new share is created.");
+      return;
+    }
+    window.open(buildWhatsAppShareUrl(url), "_blank", "noopener,noreferrer");
+  }, [shareUrlsById]);
+
+  const revokeShare = useCallback(
+    async (shareId: string) => {
+      if (!vaultOwnerToken) return;
+      setBusy(`share-revoke:${shareId}`);
+      try {
+        await KaiLocationSharingService.revokeShare({ vaultOwnerToken, shareId });
+        setApiNotice(null);
+        toast.success("Location share revoked.");
+        await refreshState();
+      } catch (error) {
+        const message = getLocationSharingErrorMessage(error, "Could not revoke location share.");
+        if (isLocationApiUnavailable(error)) setApiNotice(message);
+        toast.error(message);
+      } finally {
+        setBusy(null);
+      }
+    },
+    [refreshState, vaultOwnerToken]
+  );
+
+  const decideRequest = useCallback(
+    async (accessRequestId: string, decision: "approve" | "deny") => {
+      if (!vaultOwnerToken) return;
+      setBusy(`${decision}:${accessRequestId}`);
+      try {
+        if (decision === "approve") {
+          await KaiLocationSharingService.approveAccessRequest({
+            vaultOwnerToken,
+            requestId: accessRequestId,
+          });
+          toast.success("Location access approved for another 24 hours.");
+        } else {
+          await KaiLocationSharingService.denyAccessRequest({
+            vaultOwnerToken,
+            requestId: accessRequestId,
+          });
+          toast.success("Location access denied.");
+        }
+        await refreshState();
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : "Could not update access request.");
+      } finally {
+        setBusy(null);
+      }
+    },
+    [refreshState, vaultOwnerToken]
+  );
+
+  if (authLoading || !user) {
+    return null;
+  }
+
+  const locked = !isVaultUnlocked || !vaultOwnerToken;
+
+  return (
+    <AppPageShell
+      as="div"
+      width="expanded"
+      className="relative pb-32"
+    >
+      <AppPageContentRegion className="space-y-5">
+        <PageHeader
+          eyebrow="KAI"
+          title="Location Sharing"
+          description="Share a live GPS link for up to 24 hours, renew access by consent, and auto-approve only trusted family recipients."
+          icon={MapPin}
+          accent="kai"
+          actions={
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => void refreshState()}
+                isLoading={loading}
+              >
+                <RefreshCw aria-hidden="true" />
+                Refresh
+              </Button>
+              {liveRunning ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void stopLiveUpdates()}
+                  isLoading={busy === "stop-live"}
+                >
+                  <StopCircle aria-hidden="true" />
+                  Pause GPS
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  size="sm"
+                  onClick={() => void startLiveUpdates()}
+                  disabled={locked || activeShares.length === 0}
+                  isLoading={busy === "live"}
+                >
+                  <Radio aria-hidden="true" />
+                  Start live
+                </Button>
+              )}
+              {activeShares.length > 0 ? (
+                <Button
+                  type="button"
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => void stopAllSharing()}
+                  disabled={locked}
+                  isLoading={busy === "stop-sharing"}
+                >
+                  <StopCircle aria-hidden="true" />
+                  Stop sharing
+                </Button>
+              ) : null}
+            </div>
+          }
+        />
+
+        {locked ? (
+          <SurfaceCard tone="warning">
+            <SurfaceCardHeader>
+              <SurfaceCardTitle>Unlock Vault to manage sharing</SurfaceCardTitle>
+              <SurfaceCardDescription>
+                You can refresh GPS now, but adding recipients and creating share links requires
+                your VAULT_OWNER consent token.
+              </SurfaceCardDescription>
+            </SurfaceCardHeader>
+            <SurfaceCardContent>
+              <Button type="button" size="sm" onClick={() => setVaultDialogOpen(true)}>
+                <ShieldCheck aria-hidden="true" />
+                Unlock Vault
+              </Button>
+            </SurfaceCardContent>
+          </SurfaceCard>
+        ) : null}
+
+        {apiNotice ? (
+          <SurfaceCard tone="critical">
+            <SurfaceCardHeader>
+              <SurfaceCardTitle>Live Location API Needs Deployment</SurfaceCardTitle>
+              <SurfaceCardDescription>{apiNotice}</SurfaceCardDescription>
+            </SurfaceCardHeader>
+            <SurfaceCardContent className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex items-start gap-2 text-sm text-muted-foreground">
+                <Info className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+                <span>
+                  The web app is ready, but the configured backend is not serving the KAI
+                  location routes yet.
+                </span>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => void refreshState()}
+                isLoading={loading}
+              >
+                <RefreshCw aria-hidden="true" />
+                Retry backend
+              </Button>
+            </SurfaceCardContent>
+          </SurfaceCard>
+        ) : null}
+
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+          <SurfaceCard>
+            <SurfaceCardHeader>
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <SurfaceCardTitle>Live Location Preview</SurfaceCardTitle>
+                  <SurfaceCardDescription>
+                    A fresh fix is required before creating a new link.
+                  </SurfaceCardDescription>
+                </div>
+                <Badge variant={liveRunning ? "default" : "outline"}>
+                  {liveRunning ? "Live" : "Idle"}
+                </Badge>
+              </div>
+            </SurfaceCardHeader>
+            <SurfaceCardContent className="space-y-4">
+              {currentMaps ? (
+                <div className="overflow-hidden rounded-md border bg-background/50">
+                  <iframe
+                    title="KAI owner live location preview"
+                    src={currentMaps.osmEmbed}
+                    className="h-72 w-full border-0"
+                    loading="lazy"
+                    referrerPolicy="no-referrer"
+                  />
+                </div>
+              ) : (
+                <div className="flex min-h-56 items-center justify-center rounded-md border border-dashed bg-background/50 p-4 text-center">
+                  <div>
+                    <MapPin className="mx-auto size-8 text-muted-foreground" aria-hidden="true" />
+                    <p className="mt-3 text-sm font-medium">No live map yet</p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Refresh GPS to preview the live location before creating a share.
+                    </p>
+                  </div>
+                </div>
+              )}
+              <div className="rounded-md border bg-background/50 p-3">
+                <p className="text-sm font-medium">{formatPoint(currentPoint)}</p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Accuracy: {currentPoint?.accuracyM ? `${Math.round(currentPoint.accuracyM)}m` : "Unknown"} · Fresh:{" "}
+                  {formatDateTime(currentPoint?.capturedAt)}
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => void refreshGps()}
+                isLoading={busy === "gps"}
+              >
+                <LocateFixed aria-hidden="true" />
+                Refresh GPS
+              </Button>
+            </SurfaceCardContent>
+          </SurfaceCard>
+
+          <SurfaceCard>
+            <SurfaceCardHeader>
+              <SurfaceCardTitle>Add Recipient</SurfaceCardTitle>
+              <SurfaceCardDescription>
+                Active limits: {familyCount}/{state.limits.family} family and {friendCount}/
+                {state.limits.friend} friends.
+              </SurfaceCardDescription>
+            </SurfaceCardHeader>
+            <SurfaceCardContent className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_9rem_10rem_auto]">
+              <div className="space-y-2">
+                <Label htmlFor="location-recipient-name">Name</Label>
+                <Input
+                  id="location-recipient-name"
+                  value={form.displayName}
+                  placeholder="Mom, Dad, Alex"
+                  onChange={(event) =>
+                    setForm((previous) => ({ ...previous, displayName: event.target.value }))
+                  }
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Tier</Label>
+                <Select
+                  value={form.tier}
+                  onValueChange={(value) =>
+                    setForm((previous) => ({
+                      ...previous,
+                      tier: value as LocationContactTier,
+                      autoApprove: value === "family" ? previous.autoApprove : false,
+                    }))
+                  }
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="family">Family</SelectItem>
+                    <SelectItem value="friend">Friend</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label>Duration</Label>
+                <Select value={shareDurationHours} onValueChange={setShareDurationHours}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {SHARE_DURATION_OPTIONS.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex items-end gap-3">
+                <label className="flex h-9 items-center gap-2 rounded-md border px-3 text-sm">
+                  <Switch
+                    size="sm"
+                    checked={form.autoApprove}
+                    disabled={form.tier !== "family"}
+                    onCheckedChange={(checked) =>
+                      setForm((previous) => ({ ...previous, autoApprove: checked }))
+                    }
+                  />
+                  Auto
+                </label>
+                <Button
+                  type="button"
+                  onClick={() => void createContact()}
+                  disabled={locked || !form.displayName.trim() || limitReached}
+                  isLoading={busy === "contact"}
+                >
+                  <Plus aria-hidden="true" />
+                  Add
+                </Button>
+              </div>
+              {limitReached ? (
+                <p className="text-xs text-amber-700 sm:col-span-4 dark:text-amber-300">
+                  {tierLabel(form.tier)} recipient limit reached.
+                </p>
+              ) : null}
+              {locked ? (
+                <p className="text-xs text-muted-foreground sm:col-span-4">
+                  Unlock Vault before adding recipients or creating share links.
+                </p>
+              ) : null}
+            </SurfaceCardContent>
+          </SurfaceCard>
+        </div>
+
+        <div className="grid gap-4 xl:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
+          <SurfaceCard>
+            <SurfaceCardHeader>
+              <SurfaceCardTitle>Recipients</SurfaceCardTitle>
+              <SurfaceCardDescription>
+                Share links are bearer links. Anyone with an active link can view until expiry.
+              </SurfaceCardDescription>
+            </SurfaceCardHeader>
+            <SurfaceCardContent className="space-y-2">
+              {activeContacts.length === 0 ? (
+                <p className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+                  Add family or friends before creating a location link.
+                </p>
+              ) : (
+                activeContacts.map((contact) => (
+                  <div
+                    key={contact.id}
+                    className="flex flex-col gap-3 rounded-md border p-3 sm:flex-row sm:items-center sm:justify-between"
+                  >
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="truncate text-sm font-medium">{contact.displayName}</p>
+                        <Badge variant="outline">{tierLabel(contact.tier)}</Badge>
+                        {contact.autoApprove ? (
+                          <Badge className="bg-emerald-600 text-white">
+                            <ShieldCheck aria-hidden="true" />
+                            Auto approve
+                          </Badge>
+                        ) : null}
+                      </div>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Added {formatDateTime(contact.createdAt)}
+                      </p>
+                    </div>
+                    <div className="flex gap-2">
+                      <Button
+                        type="button"
+                        size="sm"
+                        onClick={() => void createShare(contact)}
+                        disabled={locked}
+                        isLoading={busy === `share:${contact.id}`}
+                      >
+                        <Send aria-hidden="true" />
+                        Share
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon-sm"
+                        aria-label={`Revoke ${contact.displayName}`}
+                        onClick={() => void revokeContact(contact.id)}
+                        isLoading={busy === `contact:${contact.id}`}
+                      >
+                        <Trash2 aria-hidden="true" />
+                      </Button>
+                    </div>
+                  </div>
+                ))
+              )}
+            </SurfaceCardContent>
+          </SurfaceCard>
+
+          <SurfaceCard>
+            <SurfaceCardHeader>
+              <SurfaceCardTitle>Pending Access Requests</SurfaceCardTitle>
+              <SurfaceCardDescription>
+                Expired friend links and non-auto family links require your decision.
+              </SurfaceCardDescription>
+            </SurfaceCardHeader>
+            <SurfaceCardContent className="space-y-2">
+              {pendingRequests.length === 0 ? (
+                <p className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+                  No pending requests.
+                </p>
+              ) : (
+                pendingRequests.map((accessRequest) => (
+                  <div
+                    key={accessRequest.id}
+                    className={cn(
+                      "rounded-md border p-3",
+                      requestId === accessRequest.id && "border-primary bg-primary/5"
+                    )}
+                  >
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium">
+                          {accessRequest.contactDisplayName || "Location recipient"}
+                        </p>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          Requested {formatDateTime(accessRequest.requestedAt)}
+                        </p>
+                      </div>
+                      <div className="flex gap-2">
+                        <Button
+                          type="button"
+                          size="sm"
+                          onClick={() => void decideRequest(accessRequest.id, "approve")}
+                          isLoading={busy === `approve:${accessRequest.id}`}
+                        >
+                          <Check aria-hidden="true" />
+                          Approve
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={() => void decideRequest(accessRequest.id, "deny")}
+                          isLoading={busy === `deny:${accessRequest.id}`}
+                        >
+                          <X aria-hidden="true" />
+                          Deny
+                        </Button>
+                      </div>
+                    </div>
+                    {accessRequest.requesterMessage ? (
+                      <p className="mt-2 text-sm text-muted-foreground">
+                        {accessRequest.requesterMessage}
+                      </p>
+                    ) : null}
+                  </div>
+                ))
+              )}
+            </SurfaceCardContent>
+          </SurfaceCard>
+        </div>
+
+        <SurfaceCard>
+          <SurfaceCardHeader>
+            <SurfaceCardTitle>Active Shares</SurfaceCardTitle>
+            <SurfaceCardDescription>
+              Copy or send newly created location URLs through WhatsApp or any message app.
+            </SurfaceCardDescription>
+          </SurfaceCardHeader>
+          <SurfaceCardContent className="space-y-2">
+            {activeShares.length === 0 ? (
+              <p className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+                No active location shares.
+              </p>
+            ) : (
+              activeShares.map((share) => (
+                <div
+                  key={share.id}
+                  className="flex flex-col gap-3 rounded-md border p-3"
+                >
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="truncate text-sm font-medium">
+                          {share.contactDisplayName || "Recipient"}
+                        </p>
+                        <Badge variant="outline">{share.contactTier || "contact"}</Badge>
+                        <Badge>{share.liveMode ? "Live" : "Snapshot"}</Badge>
+                      </div>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Expires {formatDateTime(share.expiresAt)}
+                      </p>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={!shareUrlsById[share.id]}
+                        onClick={() => void copyKnownShareUrl(share)}
+                      >
+                        <Clipboard aria-hidden="true" />
+                        Copy
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={!shareUrlsById[share.id]}
+                        onClick={() => shareKnownUrlOnWhatsApp(share)}
+                      >
+                        <MessageCircle aria-hidden="true" />
+                        WhatsApp
+                      </Button>
+                      {shareUrlsById[share.id] ? (
+                        <Button asChild variant="outline" size="sm">
+                          <a href={shareUrlsById[share.id]} target="_blank" rel="noreferrer">
+                            <ExternalLink aria-hidden="true" />
+                            Open
+                          </a>
+                        </Button>
+                      ) : null}
+                      <Button
+                        type="button"
+                        variant="destructive"
+                        size="sm"
+                        onClick={() => void revokeShare(share.id)}
+                        isLoading={busy === `share-revoke:${share.id}`}
+                      >
+                        <StopCircle aria-hidden="true" />
+                        Stop
+                      </Button>
+                    </div>
+                  </div>
+                  {shareUrlsById[share.id] ? (
+                    <div className="rounded-md border bg-background/50 p-3">
+                      <Label className="text-xs text-muted-foreground">Live location URL</Label>
+                      <Input
+                        readOnly
+                        value={shareUrlsById[share.id]}
+                        className="mt-2 font-mono text-xs"
+                        onFocus={(event) => event.currentTarget.select()}
+                      />
+                    </div>
+                  ) : (
+                    <p className="rounded-md border border-dashed p-3 text-xs text-muted-foreground">
+                      For security, the raw bearer URL is shown only immediately after creating
+                      the share in this browser session.
+                    </p>
+                  )}
+                </div>
+              ))
+            )}
+          </SurfaceCardContent>
+        </SurfaceCard>
+        {user ? (
+          <VaultUnlockDialog
+            user={user}
+            open={vaultDialogOpen}
+            onOpenChange={setVaultDialogOpen}
+            title="Unlock Vault for location sharing"
+            description="Unlock your Vault to add recipients and create KAI location links."
+            enableGeneratedDefault
+            onSuccess={() => {
+              setVaultDialogOpen(false);
+              void refreshState();
+            }}
+          />
+        ) : null}
+      </AppPageContentRegion>
+    </AppPageShell>
+  );
+}
+
+export default function KaiLocationPage() {
+  return (
+    <Suspense fallback={null}>
+      <KaiLocationContent />
+    </Suspense>
+  );
+}

--- a/hushh-webapp/app/location/shared/page.tsx
+++ b/hushh-webapp/app/location/shared/page.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import { ExternalLink, LocateFixed, MapPin, Radio, RefreshCw, Send, ShieldAlert } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  DEFAULT_PUBLIC_LIVE_POLL_INTERVAL_MS,
+  buildMapsUrls,
+  KaiLocationSharingService,
+} from "@/lib/location-sharing/service";
+import type { LocationAccessRequestResponse, LocationPublicView } from "@/lib/location-sharing/types";
+import { morphyToast as toast } from "@/lib/morphy-ux/morphy";
+
+function formatDateTime(value: string | null | undefined): string {
+  if (!value) return "Not available";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Not available";
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date);
+}
+
+function SharedLocationFallback() {
+  return (
+    <main className="min-h-dvh bg-background px-4 py-6 text-foreground sm:px-6">
+      <div className="mx-auto w-full max-w-5xl rounded-md border p-6">
+        <p className="text-sm text-muted-foreground">Loading shared location...</p>
+      </div>
+    </main>
+  );
+}
+
+function BadgeLikeLiveIndicator({ stale }: { stale: boolean }) {
+  return (
+    <span
+      className={
+        stale
+          ? "inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs font-medium text-amber-700 dark:text-amber-300"
+          : "inline-flex items-center gap-1 rounded-md bg-emerald-600 px-2 py-1 text-xs font-medium text-white"
+      }
+    >
+      <Radio className="size-3" aria-hidden="true" />
+      {stale ? "Delayed" : "Live"}
+    </span>
+  );
+}
+
+function SharedLocationContent() {
+  const [token, setToken] = useState<string | null>(null);
+  const [view, setView] = useState<LocationPublicView | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [requesting, setRequesting] = useState(false);
+  const [requestResult, setRequestResult] = useState<LocationAccessRequestResponse | null>(null);
+  const [requesterLabel, setRequesterLabel] = useState("");
+  const [requesterMessage, setRequesterMessage] = useState("");
+
+  const activeLatest = view?.state === "active" && view.latest ? view.latest : null;
+  const activeShare = activeLatest ? view?.share : null;
+  const maps = useMemo(() => (activeLatest ? buildMapsUrls(activeLatest) : null), [activeLatest]);
+  const pollIntervalMs = Math.max(
+    view?.live?.pollIntervalMs ?? DEFAULT_PUBLIC_LIVE_POLL_INTERVAL_MS,
+    5_000
+  );
+  const staleAfterSeconds = view?.live?.staleAfterSeconds ?? 90;
+  const freshnessSeconds = view?.live?.freshnessSeconds;
+  const stale =
+    typeof freshnessSeconds === "number" && freshnessSeconds > staleAfterSeconds;
+
+  useEffect(() => {
+    setToken(new URLSearchParams(window.location.search).get("token") || "");
+  }, []);
+
+  const load = useCallback(async (options?: { silent?: boolean }) => {
+    if (token === null) return;
+    if (!token) {
+      setView({ state: "invalid", canRequestAccess: false, share: null, latest: null });
+      setLoading(false);
+      return;
+    }
+    if (!options?.silent) setLoading(true);
+    try {
+      const nextView = await KaiLocationSharingService.resolvePublicShare(token);
+      setView(nextView);
+    } catch (error) {
+      if (!options?.silent) {
+        toast.error(error instanceof Error ? error.message : "Could not open this location link.");
+        setView({ state: "invalid", canRequestAccess: false, share: null, latest: null });
+      }
+    } finally {
+      if (!options?.silent) setLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    if (token !== null) {
+      void load();
+    }
+  }, [load, token]);
+
+  useEffect(() => {
+    if (token === null || !token || view?.state !== "active") return;
+    const intervalId = window.setInterval(() => {
+      void load({ silent: true });
+    }, pollIntervalMs);
+    return () => window.clearInterval(intervalId);
+  }, [load, pollIntervalMs, token, view?.state]);
+
+  const requestAccess = useCallback(async () => {
+    if (!token) return;
+    setRequesting(true);
+    try {
+      const result = await KaiLocationSharingService.requestAccess({
+        token,
+        requesterLabel,
+        requesterMessage,
+      });
+      setRequestResult(result);
+      if (result.status === "auto_approved" && result.publicView) {
+        setView(result.publicView);
+        toast.success("Location access renewed.");
+      } else {
+        toast.success("Access request sent.");
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not request access.");
+    } finally {
+      setRequesting(false);
+    }
+  }, [requesterLabel, requesterMessage, token]);
+
+  const active = Boolean(activeLatest);
+  const invalidTitle =
+    view?.state === "revoked"
+      ? "Live location stopped"
+      : view?.state === "expired" || view?.state === "deactivated"
+        ? "Location link expired"
+        : "Location link invalid";
+
+  return (
+    <main className="min-h-dvh bg-background px-4 py-6 text-foreground sm:px-6">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-4">
+        <header className="flex flex-col gap-3 border-b pb-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-start gap-3">
+            <div className="flex size-10 shrink-0 items-center justify-center rounded-md border bg-card">
+              <MapPin className="size-5" aria-hidden="true" />
+            </div>
+            <div>
+              <p className="text-xs font-semibold uppercase text-muted-foreground">
+                KAI Location
+              </p>
+              <h1 className="text-2xl font-semibold leading-tight">
+                {active ? "Shared Location" : invalidTitle}
+              </h1>
+              <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+                Location is visible only while this bearer link is active.
+              </p>
+            </div>
+          </div>
+          <Button type="button" variant="outline" size="sm" onClick={() => void load()} isLoading={loading}>
+            <RefreshCw aria-hidden="true" />
+            Refresh
+          </Button>
+        </header>
+
+        {loading ? (
+          <section className="rounded-md border p-6">
+            <p className="text-sm text-muted-foreground">Loading shared location...</p>
+          </section>
+        ) : activeLatest && maps ? (
+          <section className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_22rem]">
+            <div className="overflow-hidden rounded-md border bg-card">
+              <iframe
+                title="KAI shared location map"
+                src={maps.osmEmbed}
+                className="h-[420px] w-full border-0"
+                loading="lazy"
+                referrerPolicy="no-referrer"
+              />
+            </div>
+            <aside className="space-y-4 rounded-md border bg-card p-4">
+              <div className="flex items-center justify-between gap-3 rounded-md border p-3">
+                <div>
+                  <p className="text-xs text-muted-foreground">Live status</p>
+                  <p className="mt-1 text-sm font-medium">
+                    {stale ? "Waiting for update" : "Live"}
+                  </p>
+                </div>
+                <BadgeLikeLiveIndicator stale={stale} />
+              </div>
+              <div>
+                <p className="text-sm font-medium">Coordinates</p>
+                <p className="mt-1 font-mono text-sm">
+                  {activeLatest.latitude.toFixed(6)}, {activeLatest.longitude.toFixed(6)}
+                </p>
+              </div>
+              <div className="grid grid-cols-2 gap-3 text-sm">
+                <div className="rounded-md border p-3">
+                  <p className="text-xs text-muted-foreground">Accuracy</p>
+                  <p className="mt-1 font-medium">
+                    {activeLatest.accuracyM ? `${Math.round(activeLatest.accuracyM)}m` : "Unknown"}
+                  </p>
+                </div>
+                <div className="rounded-md border p-3">
+                  <p className="text-xs text-muted-foreground">Freshness</p>
+                  <p className="mt-1 font-medium">
+                    {typeof freshnessSeconds === "number"
+                      ? `${freshnessSeconds}s ago`
+                      : formatDateTime(activeLatest.capturedAt)}
+                  </p>
+                </div>
+              </div>
+              <div className="rounded-md border p-3 text-sm">
+                <p className="text-xs text-muted-foreground">Expires</p>
+                <p className="mt-1 font-medium">{formatDateTime(activeShare?.expiresAt)}</p>
+              </div>
+              <div className="flex flex-col gap-2">
+                <Button asChild>
+                  <a href={maps.google} target="_blank" rel="noreferrer">
+                    <ExternalLink aria-hidden="true" />
+                    Open in Google Maps
+                  </a>
+                </Button>
+                <Button asChild variant="outline">
+                  <a href={maps.apple} target="_blank" rel="noreferrer">
+                    <LocateFixed aria-hidden="true" />
+                    Open in Apple Maps
+                  </a>
+                </Button>
+              </div>
+            </aside>
+          </section>
+        ) : (
+          <section className="grid gap-4 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+            <div className="rounded-md border bg-card p-5">
+              <ShieldAlert className="size-8 text-amber-600" aria-hidden="true" />
+              <h2 className="mt-4 text-lg font-semibold">{invalidTitle}</h2>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                {view?.state === "revoked"
+                  ? "The KAI owner stopped this live location share. Coordinates are hidden now."
+                  : "The original access window is no longer active. Coordinates are hidden until the KAI owner grants access again."}
+              </p>
+            </div>
+            <div className="rounded-md border bg-card p-5">
+              <h2 className="text-lg font-semibold">Request access again</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Friends and non-auto family recipients require owner approval. Trusted family
+                recipients may renew automatically if the owner enabled it.
+              </p>
+              {view?.canRequestAccess ? (
+                <div className="mt-4 space-y-3">
+                  <div className="space-y-2">
+                    <Label htmlFor="location-requester-name">Your name</Label>
+                    <Input
+                      id="location-requester-name"
+                      value={requesterLabel}
+                      onChange={(event) => setRequesterLabel(event.target.value)}
+                      placeholder="Optional"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="location-requester-message">Message</Label>
+                    <Textarea
+                      id="location-requester-message"
+                      value={requesterMessage}
+                      onChange={(event) => setRequesterMessage(event.target.value)}
+                      placeholder="Optional"
+                      rows={3}
+                    />
+                  </div>
+                  <Button
+                    type="button"
+                    onClick={() => void requestAccess()}
+                    isLoading={requesting}
+                    disabled={requestResult?.status === "pending"}
+                  >
+                    <Send aria-hidden="true" />
+                    {requestResult?.status === "pending" ? "Request sent" : "Request access"}
+                  </Button>
+                </div>
+              ) : (
+                <p className="mt-4 rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+                  This link cannot request renewed access.
+                </p>
+              )}
+            </div>
+          </section>
+        )}
+      </div>
+    </main>
+  );
+}
+
+export default function SharedLocationPage() {
+  return (
+    <Suspense fallback={<SharedLocationFallback />}>
+      <SharedLocationContent />
+    </Suspense>
+  );
+}

--- a/hushh-webapp/components/consent/notification-provider.tsx
+++ b/hushh-webapp/components/consent/notification-provider.tsx
@@ -835,6 +835,35 @@ export function ConsentNotificationProvider({
           requestId: consent.id,
         });
         showConsentToast(consent);
+      } else if (msgType === "location_access_request") {
+        const requestId = data.request_id;
+        const href = requestId
+          ? `${ROUTES.KAI_LOCATION}?requestId=${encodeURIComponent(requestId)}`
+          : ROUTES.KAI_LOCATION;
+        toast(
+          <div className="flex flex-col gap-2">
+            <div className="space-y-0.5">
+              <p className="text-sm font-semibold">Location access request</p>
+              <p className="text-xs text-muted-foreground">
+                Someone asked to view your KAI location again.
+              </p>
+            </div>
+            <button
+              onClick={() => {
+                toast.dismiss(dedupKey);
+                router.push(href, { scroll: false });
+              }}
+              className="rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background transition-colors"
+            >
+              Review
+            </button>
+          </div>,
+          {
+            id: dedupKey,
+            duration: 9000,
+            position: "top-center",
+          }
+        );
       } else if (msgType === "consent_opened") {
         const requestId = data.request_id;
         const bundleId =
@@ -903,7 +932,7 @@ export function ConsentNotificationProvider({
 
     window.addEventListener(FCM_MESSAGE_EVENT, handleFCMMessage);
     return () => window.removeEventListener(FCM_MESSAGE_EVENT, handleFCMMessage);
-  }, [isNativePlatform, isVaultUnlocked, showConsentToast, user?.uid]);
+  }, [isNativePlatform, isVaultUnlocked, router, showConsentToast, user?.uid]);
 
   // ONE-TIME fetch on vault unlock to catch requests that arrived while app was closed.
   // This is the ONLY acceptable HTTP call -- not a poll, just a catch-up.

--- a/hushh-webapp/e2e/kai-location-shared.spec.ts
+++ b/hushh-webapp/e2e/kai-location-shared.spec.ts
@@ -1,0 +1,181 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("KAI shared live location", () => {
+  test("renders live coordinates, updates from polling, and reflects owner stop", async ({
+    page,
+  }) => {
+    test.setTimeout(60_000);
+    let resolveCount = 0;
+
+    await page.route(/\/api\/kai\/location\/shared\?token=live-token$/, async (route) => {
+      resolveCount += 1;
+      const activePayload = {
+        state: "active",
+        canRequestAccess: false,
+        share: {
+          id: "share-1",
+          ownerUserId: "owner-1",
+          contactId: "contact-1",
+          contactDisplayName: "Family",
+          contactTier: "family",
+          contactAutoApprove: true,
+          status: "active",
+          liveMode: true,
+          expiresAt: "2026-05-19T18:00:00.000Z",
+          createdAt: "2026-05-19T17:00:00.000Z",
+          updatedAt: "2026-05-19T17:00:00.000Z",
+          lastViewedAt: null,
+          deactivatedAt: null,
+          revokedAt: null,
+        },
+        latest: {
+          ownerUserId: "owner-1",
+          latitude: resolveCount === 1 ? 12.9716 : 12.972,
+          longitude: resolveCount === 1 ? 77.5946 : 77.5951,
+          accuracyM: 9,
+          headingDeg: null,
+          speedMps: null,
+          capturedAt: "2026-05-19T17:05:00.000Z",
+          sourcePlatform: "web",
+          updatedAt: "2026-05-19T17:05:00.000Z",
+        },
+        live: {
+          transport: "gcp_polling",
+          pollIntervalMs: 5000,
+          staleAfterSeconds: 90,
+          serverTime: "2026-05-19T17:05:05.000Z",
+          isLive: true,
+          freshnessSeconds: 5,
+          stoppedAt: null,
+        },
+      };
+
+      const stoppedPayload = {
+        state: "revoked",
+        canRequestAccess: false,
+        share: {
+          ...activePayload.share,
+          status: "revoked",
+          revokedAt: "2026-05-19T17:05:10.000Z",
+        },
+        latest: null,
+        live: {
+          transport: "gcp_polling",
+          pollIntervalMs: 5000,
+          staleAfterSeconds: 90,
+          serverTime: "2026-05-19T17:05:10.000Z",
+          isLive: false,
+          freshnessSeconds: null,
+          stoppedAt: "2026-05-19T17:05:10.000Z",
+        },
+      };
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(resolveCount >= 3 ? stoppedPayload : activePayload),
+      });
+    });
+
+    await page.goto("/location/shared?token=live-token", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByRole("heading", { name: "Shared Location" })).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByText("12.971600, 77.594600")).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText("Live", { exact: true }).first()).toBeVisible();
+
+    await expect(page.getByText("12.972000, 77.595100")).toBeVisible({
+      timeout: 7000,
+    });
+    await expect(page.getByRole("heading", { name: "Live location stopped" }).first()).toBeVisible(
+      {
+        timeout: 7000,
+      }
+    );
+  });
+
+  test("lets an expired viewer request renewed access", async ({ page }) => {
+    test.setTimeout(60_000);
+
+    await page.route(/\/api\/kai\/location\/shared\?token=expired-token$/, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          state: "expired",
+          canRequestAccess: true,
+          share: {
+            id: "share-1",
+            ownerUserId: "owner-1",
+            contactId: "contact-1",
+            contactDisplayName: "Friend",
+            contactTier: "friend",
+            contactAutoApprove: false,
+            status: "deactivated",
+            liveMode: true,
+            expiresAt: "2026-05-19T17:00:00.000Z",
+            createdAt: "2026-05-19T16:00:00.000Z",
+            updatedAt: "2026-05-19T17:00:00.000Z",
+            lastViewedAt: null,
+            deactivatedAt: "2026-05-19T17:00:01.000Z",
+            revokedAt: null,
+          },
+          latest: null,
+          live: {
+            transport: "gcp_polling",
+            pollIntervalMs: 5000,
+            staleAfterSeconds: 90,
+            serverTime: "2026-05-19T17:05:00.000Z",
+            isLive: false,
+            freshnessSeconds: null,
+            stoppedAt: "2026-05-19T17:00:01.000Z",
+          },
+        }),
+      });
+    });
+    await page.route("**/api/kai/location/shared/access-request", async (route) => {
+      expect(route.request().method()).toBe("POST");
+      expect(await route.request().postDataJSON()).toMatchObject({
+        token: "expired-token",
+        requesterLabel: "Alex",
+        requesterMessage: "Need your live location again",
+      });
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          status: "pending",
+          accessRequest: {
+            id: "request-1",
+            shareId: "share-1",
+            ownerUserId: "owner-1",
+            contactId: "contact-1",
+            contactDisplayName: "Friend",
+            contactTier: "friend",
+            status: "pending",
+            requesterLabel: "Alex",
+            requesterMessage: "Need your live location again",
+            requestedAt: "2026-05-19T17:05:00.000Z",
+            resolvedAt: null,
+            renewedShareId: null,
+          },
+          share: null,
+          publicView: null,
+        }),
+      });
+    });
+
+    await page.goto("/location/shared?token=expired-token", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByRole("heading", { name: "Location link expired" }).first()).toBeVisible(
+      {
+        timeout: 15_000,
+      }
+    );
+    await page.getByLabel("Your name").fill("Alex");
+    await page.getByLabel("Message").fill("Need your live location again");
+    await page.getByRole("button", { name: "Request access" }).click();
+    await expect(page.getByRole("button", { name: "Request sent" })).toBeVisible();
+  });
+});

--- a/hushh-webapp/lib/location-sharing/contract.ts
+++ b/hushh-webapp/lib/location-sharing/contract.ts
@@ -1,0 +1,125 @@
+import type {
+  LocationAccessRequestStatus,
+  LocationContactTier,
+  LocationLatestPoint,
+  LocationShareStatus,
+  LocationSourcePlatform,
+  PublicLocationShareState,
+} from "./types";
+
+const CONTACT_TIERS = new Set<LocationContactTier>(["family", "friend"]);
+const SHARE_STATUSES = new Set<LocationShareStatus>([
+  "active",
+  "expired",
+  "deactivated",
+  "revoked",
+]);
+const ACCESS_REQUEST_STATUSES = new Set<LocationAccessRequestStatus>([
+  "pending",
+  "approved",
+  "denied",
+  "auto_approved",
+]);
+const PUBLIC_STATES = new Set<PublicLocationShareState>([
+  "active",
+  "expired",
+  "deactivated",
+  "revoked",
+  "invalid",
+]);
+const SOURCE_PLATFORMS = new Set<LocationSourcePlatform>([
+  "web",
+  "ios",
+  "android",
+  "native",
+  "unknown",
+]);
+
+export function isLocationContactTier(value: unknown): value is LocationContactTier {
+  return CONTACT_TIERS.has(value as LocationContactTier);
+}
+
+export function isLocationShareStatus(value: unknown): value is LocationShareStatus {
+  return SHARE_STATUSES.has(value as LocationShareStatus);
+}
+
+export function isLocationAccessRequestStatus(
+  value: unknown
+): value is LocationAccessRequestStatus {
+  return ACCESS_REQUEST_STATUSES.has(value as LocationAccessRequestStatus);
+}
+
+export function isPublicLocationShareState(value: unknown): value is PublicLocationShareState {
+  return PUBLIC_STATES.has(value as PublicLocationShareState);
+}
+
+export function isLocationSourcePlatform(value: unknown): value is LocationSourcePlatform {
+  return SOURCE_PLATFORMS.has(value as LocationSourcePlatform);
+}
+
+export function isValidLocationPoint(value: unknown): value is LocationLatestPoint {
+  if (!value || typeof value !== "object") return false;
+  const point = value as Partial<LocationLatestPoint>;
+  return (
+    typeof point.latitude === "number" &&
+    Number.isFinite(point.latitude) &&
+    point.latitude >= -90 &&
+    point.latitude <= 90 &&
+    typeof point.longitude === "number" &&
+    Number.isFinite(point.longitude) &&
+    point.longitude >= -180 &&
+    point.longitude <= 180 &&
+    typeof point.capturedAt === "string" &&
+    isLocationSourcePlatform(point.sourcePlatform)
+  );
+}
+
+export function normalizeLocationSourcePlatform(value: unknown): LocationSourcePlatform {
+  return isLocationSourcePlatform(value) ? value : "unknown";
+}
+
+export function createLocationPointFromPosition(
+  position: GeolocationPosition,
+  sourcePlatform: LocationSourcePlatform = "web"
+): LocationLatestPoint {
+  return {
+    latitude: position.coords.latitude,
+    longitude: position.coords.longitude,
+    accuracyM: Number.isFinite(position.coords.accuracy) ? position.coords.accuracy : null,
+    headingDeg:
+      typeof position.coords.heading === "number" && Number.isFinite(position.coords.heading)
+        ? position.coords.heading
+        : null,
+    speedMps:
+      typeof position.coords.speed === "number" && Number.isFinite(position.coords.speed)
+        ? position.coords.speed
+        : null,
+    capturedAt: new Date(position.timestamp || Date.now()).toISOString(),
+    sourcePlatform,
+  };
+}
+
+export function hasCoordinatesInMetadata(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  const forbidden = new Set([
+    "lat",
+    "latitude",
+    "lng",
+    "lon",
+    "long",
+    "longitude",
+    "accuracy",
+    "accuracy_m",
+    "heading",
+    "speed",
+    "coordinates",
+    "location",
+  ]);
+  if (Array.isArray(value)) {
+    return value.some((item) => hasCoordinatesInMetadata(item));
+  }
+  return Object.entries(value as Record<string, unknown>).some(([key, item]) => {
+    if (forbidden.has(key.trim().toLowerCase())) return true;
+    return hasCoordinatesInMetadata(item);
+  });
+}

--- a/hushh-webapp/lib/location-sharing/service.ts
+++ b/hushh-webapp/lib/location-sharing/service.ts
@@ -1,0 +1,426 @@
+"use client";
+
+import { ApiService } from "@/lib/services/api-service";
+
+import { createLocationPointFromPosition } from "./contract";
+import type {
+  LocationAccessRequest,
+  LocationAccessRequestResponse,
+  LocationContact,
+  LocationContactTier,
+  LocationCreateShareResponse,
+  LocationHeartbeatResult,
+  LocationLatestPoint,
+  LocationOwnerState,
+  LocationPublicView,
+  LocationShare,
+  LocationUpdateSession,
+} from "./types";
+
+const DEFAULT_WATCH_INTERVAL_MS = 30_000;
+export const DEFAULT_PUBLIC_LIVE_POLL_INTERVAL_MS = 10_000;
+let activeWatchId: number | null = null;
+let activeLastSentAt = 0;
+
+export class LocationSharingApiError extends Error {
+  readonly status: number;
+  readonly code: string;
+
+  constructor(message: string, options: { status: number; code: string }) {
+    super(message);
+    this.name = "LocationSharingApiError";
+    this.status = options.status;
+    this.code = options.code;
+  }
+}
+
+function authHeaders(vaultOwnerToken: string): HeadersInit {
+  return {
+    ...ApiService.getAuthHeaders(vaultOwnerToken),
+    "Content-Type": "application/json",
+  };
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+  const payload = (await response.json().catch(() => null)) as unknown;
+  if (!response.ok) {
+    const detail =
+      payload && typeof payload === "object" && "detail" in payload
+        ? (payload as { detail?: unknown }).detail
+        : null;
+    const detailText = typeof detail === "string" ? detail : null;
+    const topLevelMessage =
+      payload && typeof payload === "object" && "message" in payload
+        ? String((payload as { message?: unknown }).message || "")
+        : "";
+    const plainBackendNotFound =
+      response.status === 404 && detailText?.trim().toLowerCase() === "not found";
+    const code =
+      plainBackendNotFound
+        ? "LOCATION_API_NOT_DEPLOYED"
+        : detailText
+          ? "LOCATION_REQUEST_FAILED"
+          : topLevelMessage
+            ? "LOCATION_UPSTREAM_UNAVAILABLE"
+            : detail && typeof detail === "object" && "code" in detail
+              ? String((detail as { code?: unknown }).code || "LOCATION_REQUEST_FAILED")
+              : "LOCATION_REQUEST_FAILED";
+    const message =
+      plainBackendNotFound
+        ? "KAI live location API is not available on the configured backend yet. Deploy the consent-protocol location routes and migration 060, then retry."
+        : detailText ||
+          topLevelMessage ||
+          (detail && typeof detail === "object" && "message" in detail
+            ? String((detail as { message?: unknown }).message || "Location request failed.")
+            : "Location request failed.");
+    throw new LocationSharingApiError(message, { status: response.status, code });
+  }
+  return payload as T;
+}
+
+export function getLocationSharingErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof LocationSharingApiError) return error.message;
+  if (error instanceof Error && error.message.trim()) return error.message;
+  return fallback;
+}
+
+export function isLocationApiUnavailable(error: unknown): boolean {
+  return (
+    error instanceof LocationSharingApiError &&
+    (error.code === "LOCATION_API_NOT_DEPLOYED" ||
+      error.code === "LOCATION_UPSTREAM_UNAVAILABLE" ||
+      error.status === 502 ||
+      error.status === 504)
+  );
+}
+
+export function buildSharedLocationUrl(token: string): string {
+  const base =
+    typeof window !== "undefined"
+      ? window.location.origin
+      : (process.env.NEXT_PUBLIC_APP_URL || "").replace(/\/$/, "");
+  const path = `/location/shared?token=${encodeURIComponent(token)}`;
+  return base ? `${base}${path}` : path;
+}
+
+export function buildLocationShareMessage(url: string): string {
+  return `Here is my KAI live location link. It expires within 24 hours: ${url}`;
+}
+
+export function buildWhatsAppShareUrl(url: string): string {
+  return `https://wa.me/?text=${encodeURIComponent(buildLocationShareMessage(url))}`;
+}
+
+export async function copyLocationUrl(url: string): Promise<void> {
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(url);
+    return;
+  }
+  throw new LocationSharingApiError("Could not copy this location link.", {
+    status: 0,
+    code: "LOCATION_COPY_UNAVAILABLE",
+  });
+}
+
+export function buildMapsUrls(point: Pick<LocationLatestPoint, "latitude" | "longitude">) {
+  const coordinate = `${point.latitude},${point.longitude}`;
+  return {
+    google: `https://www.google.com/maps?q=${encodeURIComponent(coordinate)}`,
+    apple: `https://maps.apple.com/?ll=${encodeURIComponent(coordinate)}&q=${encodeURIComponent(
+      "KAI shared location"
+    )}`,
+    osmEmbed: buildOpenStreetMapEmbedUrl(point),
+  };
+}
+
+export function buildOpenStreetMapEmbedUrl(
+  point: Pick<LocationLatestPoint, "latitude" | "longitude">
+): string {
+  const delta = 0.01;
+  const minLng = point.longitude - delta;
+  const minLat = point.latitude - delta;
+  const maxLng = point.longitude + delta;
+  const maxLat = point.latitude + delta;
+  const bbox = `${minLng},${minLat},${maxLng},${maxLat}`;
+  return `https://www.openstreetmap.org/export/embed.html?bbox=${encodeURIComponent(
+    bbox
+  )}&layer=mapnik&marker=${encodeURIComponent(`${point.latitude},${point.longitude}`)}`;
+}
+
+export async function getFreshLocationPoint(): Promise<LocationLatestPoint> {
+  if (typeof navigator === "undefined" || !navigator.geolocation) {
+    throw new LocationSharingApiError("This device does not expose browser GPS.", {
+      status: 0,
+      code: "GEOLOCATION_UNAVAILABLE",
+    });
+  }
+
+  const position = await new Promise<GeolocationPosition>((resolve, reject) => {
+    navigator.geolocation.getCurrentPosition(resolve, reject, {
+      enableHighAccuracy: true,
+      maximumAge: 0,
+      timeout: 15_000,
+    });
+  });
+
+  return createLocationPointFromPosition(position, "web");
+}
+
+export async function shareOrCopyLocationUrl(url: string): Promise<"shared" | "copied"> {
+  try {
+    if (typeof navigator !== "undefined" && typeof navigator.share === "function") {
+      await navigator.share({
+        title: "KAI live location",
+        text: buildLocationShareMessage(url),
+        url,
+      });
+      return "shared";
+    }
+  } catch {
+    // Clipboard fallback below keeps restricted browser surfaces usable.
+  }
+
+  try {
+    await copyLocationUrl(url);
+    return "copied";
+  } catch {
+    throw new LocationSharingApiError("Could not share or copy this location link.", {
+      status: 0,
+      code: "LOCATION_SHARE_UNAVAILABLE",
+    });
+  }
+}
+
+export const KaiLocationSharingService = {
+  async getOwnerState(vaultOwnerToken: string): Promise<LocationOwnerState> {
+    const response = await ApiService.apiFetch("/api/kai/location/state", {
+      headers: authHeaders(vaultOwnerToken),
+    });
+    return readJson<LocationOwnerState>(response);
+  },
+
+  async createContact(options: {
+    vaultOwnerToken: string;
+    displayName: string;
+    tier: LocationContactTier;
+    autoApprove: boolean;
+  }): Promise<LocationContact> {
+    const response = await ApiService.apiFetch("/api/kai/location/contacts", {
+      method: "POST",
+      headers: authHeaders(options.vaultOwnerToken),
+      body: JSON.stringify({
+        displayName: options.displayName,
+        tier: options.tier,
+        autoApprove: options.tier === "family" && options.autoApprove,
+      }),
+    });
+    const payload = await readJson<{ contact: LocationContact }>(response);
+    return payload.contact;
+  },
+
+  async updateContact(options: {
+    vaultOwnerToken: string;
+    contactId: string;
+    displayName?: string;
+    autoApprove?: boolean;
+  }): Promise<LocationContact> {
+    const response = await ApiService.apiFetch(
+      `/api/kai/location/contacts/${encodeURIComponent(options.contactId)}`,
+      {
+        method: "PATCH",
+        headers: authHeaders(options.vaultOwnerToken),
+        body: JSON.stringify({
+          displayName: options.displayName,
+          autoApprove: options.autoApprove,
+        }),
+      }
+    );
+    const payload = await readJson<{ contact: LocationContact }>(response);
+    return payload.contact;
+  },
+
+  async revokeContact(options: {
+    vaultOwnerToken: string;
+    contactId: string;
+  }): Promise<LocationContact> {
+    const response = await ApiService.apiFetch(
+      `/api/kai/location/contacts/${encodeURIComponent(options.contactId)}`,
+      {
+        method: "DELETE",
+        headers: authHeaders(options.vaultOwnerToken),
+      }
+    );
+    const payload = await readJson<{ contact: LocationContact }>(response);
+    return payload.contact;
+  },
+
+  async createShare(options: {
+    vaultOwnerToken: string;
+    contactId: string;
+    point: LocationLatestPoint;
+    durationHours?: number;
+    liveMode?: boolean;
+  }): Promise<LocationCreateShareResponse> {
+    const response = await ApiService.apiFetch("/api/kai/location/shares", {
+      method: "POST",
+      headers: authHeaders(options.vaultOwnerToken),
+      body: JSON.stringify({
+        contactId: options.contactId,
+        point: options.point,
+        durationHours: options.durationHours ?? 24,
+        liveMode: options.liveMode ?? true,
+      }),
+    });
+    return readJson<LocationCreateShareResponse>(response);
+  },
+
+  async revokeShare(options: {
+    vaultOwnerToken: string;
+    shareId: string;
+  }): Promise<LocationShare> {
+    const response = await ApiService.apiFetch(
+      `/api/kai/location/shares/${encodeURIComponent(options.shareId)}`,
+      {
+        method: "DELETE",
+        headers: authHeaders(options.vaultOwnerToken),
+      }
+    );
+    const payload = await readJson<{ share: LocationShare }>(response);
+    return payload.share;
+  },
+
+  async stopActiveShares(vaultOwnerToken: string): Promise<{
+    shares: LocationShare[];
+    stoppedCount: number;
+  }> {
+    const response = await ApiService.apiFetch("/api/kai/location/shares/stop-active", {
+      method: "POST",
+      headers: authHeaders(vaultOwnerToken),
+    });
+    return readJson<{ shares: LocationShare[]; stoppedCount: number }>(response);
+  },
+
+  async approveAccessRequest(options: {
+    vaultOwnerToken: string;
+    requestId: string;
+  }): Promise<{ accessRequest: LocationAccessRequest; share: LocationShare }> {
+    const response = await ApiService.apiFetch(
+      `/api/kai/location/access-requests/${encodeURIComponent(options.requestId)}/approve`,
+      {
+        method: "POST",
+        headers: authHeaders(options.vaultOwnerToken),
+      }
+    );
+    return readJson<{ accessRequest: LocationAccessRequest; share: LocationShare }>(response);
+  },
+
+  async denyAccessRequest(options: {
+    vaultOwnerToken: string;
+    requestId: string;
+  }): Promise<LocationAccessRequest> {
+    const response = await ApiService.apiFetch(
+      `/api/kai/location/access-requests/${encodeURIComponent(options.requestId)}/deny`,
+      {
+        method: "POST",
+        headers: authHeaders(options.vaultOwnerToken),
+      }
+    );
+    const payload = await readJson<{ accessRequest: LocationAccessRequest }>(response);
+    return payload.accessRequest;
+  },
+
+  async issueUpdateSession(vaultOwnerToken: string): Promise<LocationUpdateSession> {
+    const response = await ApiService.apiFetch("/api/kai/location/update-sessions", {
+      method: "POST",
+      headers: authHeaders(vaultOwnerToken),
+    });
+    return readJson<LocationUpdateSession>(response);
+  },
+
+  async updateLocationWithSession(options: {
+    updateToken: string;
+    point: LocationLatestPoint;
+  }): Promise<LocationHeartbeatResult> {
+    const response = await ApiService.apiFetch("/api/kai/location/updates", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${options.updateToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ point: options.point }),
+    });
+    return readJson<LocationHeartbeatResult>(response);
+  },
+
+  async resolvePublicShare(token: string): Promise<LocationPublicView> {
+    const response = await ApiService.apiFetch(
+      `/api/kai/location/shared?token=${encodeURIComponent(token)}`
+    );
+    return readJson<LocationPublicView>(response);
+  },
+
+  async requestAccess(options: {
+    token: string;
+    requesterLabel?: string;
+    requesterMessage?: string;
+  }): Promise<LocationAccessRequestResponse> {
+    const response = await ApiService.apiFetch("/api/kai/location/shared/access-request", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(options),
+    });
+    return readJson<LocationAccessRequestResponse>(response);
+  },
+
+  async startLiveUpdates(options: {
+    updateToken: string;
+    endpointPath?: string;
+    intervalMs?: number;
+  }): Promise<{ active: boolean; mode: "web" }> {
+    if (typeof navigator === "undefined" || !navigator.geolocation) {
+      throw new LocationSharingApiError("This browser does not expose GPS updates.", {
+        status: 0,
+        code: "GEOLOCATION_UNAVAILABLE",
+      });
+    }
+
+    await this.stopLiveUpdates();
+
+    const intervalMs = Math.max(options.intervalMs ?? DEFAULT_WATCH_INTERVAL_MS, 10_000);
+    activeLastSentAt = 0;
+    activeWatchId = navigator.geolocation.watchPosition(
+      (position) => {
+        const now = Date.now();
+        if (now - activeLastSentAt < intervalMs) return;
+        activeLastSentAt = now;
+        const point = createLocationPointFromPosition(position, "web");
+        void this.updateLocationWithSession({
+          updateToken: options.updateToken,
+          point,
+        }).catch(() => {
+          void this.stopLiveUpdates();
+        });
+      },
+      () => {
+        void this.stopLiveUpdates();
+      },
+      {
+        enableHighAccuracy: true,
+        maximumAge: 0,
+        timeout: 20_000,
+      }
+    );
+    return {
+      active: true,
+      mode: "web",
+    };
+  },
+
+  async stopLiveUpdates(): Promise<void> {
+    if (typeof navigator !== "undefined" && activeWatchId !== null) {
+      navigator.geolocation.clearWatch(activeWatchId);
+    }
+    activeWatchId = null;
+    activeLastSentAt = 0;
+  },
+};

--- a/hushh-webapp/lib/location-sharing/types.ts
+++ b/hushh-webapp/lib/location-sharing/types.ts
@@ -1,0 +1,124 @@
+export type LocationContactTier = "family" | "friend";
+export type LocationContactStatus = "active" | "revoked";
+export type LocationShareStatus = "active" | "expired" | "deactivated" | "revoked";
+export type LocationAccessRequestStatus =
+  | "pending"
+  | "approved"
+  | "denied"
+  | "auto_approved";
+export type LocationSourcePlatform = "web" | "ios" | "android" | "native" | "unknown";
+export type PublicLocationShareState =
+  | "active"
+  | "expired"
+  | "deactivated"
+  | "revoked"
+  | "invalid";
+
+export interface LocationLatestPoint {
+  ownerUserId?: string;
+  latitude: number;
+  longitude: number;
+  accuracyM?: number | null;
+  headingDeg?: number | null;
+  speedMps?: number | null;
+  capturedAt: string;
+  sourcePlatform: LocationSourcePlatform;
+  updatedAt?: string | null;
+}
+
+export interface LocationLiveState {
+  transport: "gcp_polling";
+  pollIntervalMs: number;
+  staleAfterSeconds: number;
+  serverTime: string | null;
+  isLive: boolean;
+  freshnessSeconds: number | null;
+  stoppedAt: string | null;
+}
+
+export interface LocationContact {
+  id: string;
+  ownerUserId: string;
+  displayName: string;
+  tier: LocationContactTier;
+  autoApprove: boolean;
+  status: LocationContactStatus;
+  createdAt: string | null;
+  updatedAt: string | null;
+  revokedAt: string | null;
+}
+
+export interface LocationShare {
+  id: string;
+  ownerUserId: string;
+  contactId: string | null;
+  contactDisplayName: string | null;
+  contactTier: LocationContactTier | null;
+  contactAutoApprove: boolean | null;
+  status: LocationShareStatus;
+  liveMode: boolean;
+  expiresAt: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+  lastViewedAt: string | null;
+  deactivatedAt: string | null;
+  revokedAt: string | null;
+}
+
+export interface LocationAccessRequest {
+  id: string;
+  shareId: string;
+  ownerUserId: string;
+  contactId: string | null;
+  contactDisplayName: string | null;
+  contactTier: LocationContactTier | null;
+  status: LocationAccessRequestStatus;
+  requesterLabel: string | null;
+  requesterMessage: string | null;
+  requestedAt: string | null;
+  resolvedAt: string | null;
+  renewedShareId: string | null;
+}
+
+export interface LocationOwnerState {
+  contacts: LocationContact[];
+  shares: LocationShare[];
+  accessRequests: LocationAccessRequest[];
+  latest: LocationLatestPoint | null;
+  limits: {
+    family: number;
+    friend: number;
+  };
+}
+
+export interface LocationCreateShareResponse {
+  share: LocationShare;
+  token: string;
+  latest: LocationLatestPoint;
+}
+
+export interface LocationPublicView {
+  state: PublicLocationShareState;
+  canRequestAccess: boolean;
+  share: LocationShare | null;
+  latest: LocationLatestPoint | null;
+  live?: LocationLiveState | null;
+}
+
+export interface LocationAccessRequestResponse {
+  status: LocationAccessRequestStatus;
+  accessRequest: LocationAccessRequest | null;
+  share: LocationShare | null;
+  publicView: LocationPublicView | null;
+}
+
+export interface LocationUpdateSession {
+  token: string;
+  expiresAt: string | null;
+  endpointPath: string;
+}
+
+export interface LocationHeartbeatResult {
+  ok: boolean;
+  latest: LocationLatestPoint;
+}

--- a/hushh-webapp/lib/navigation/kai-route-tabs.ts
+++ b/hushh-webapp/lib/navigation/kai-route-tabs.ts
@@ -34,6 +34,7 @@ export function activeKaiRouteTabFromPath(pathname: string): KaiRouteTabId {
     pathname.startsWith(ROUTES.KAI_DASHBOARD) ||
     pathname.startsWith(ROUTES.KAI_INVESTMENTS) ||
     pathname.startsWith(ROUTES.KAI_FUNDING_TRADE) ||
+    pathname.startsWith(ROUTES.KAI_LOCATION) ||
     pathname.startsWith("/kai/dashboard") ||
     pathname.startsWith(ROUTES.KAI_OPTIMIZE)
   ) {

--- a/hushh-webapp/lib/navigation/routes.ts
+++ b/hushh-webapp/lib/navigation/routes.ts
@@ -36,6 +36,7 @@ export const ROUTES = {
   KAI_PORTFOLIO: "/kai/portfolio",
   KAI_INVESTMENTS: "/kai/investments",
   KAI_FUNDING_TRADE: "/kai/funding-trade",
+  KAI_LOCATION: "/kai/location",
   KAI_DASHBOARD: "/kai/portfolio",
   KAI_ANALYSIS: "/kai/analysis",
   KAI_OPTIMIZE: "/kai/optimize",

--- a/hushh-webapp/lib/notifications/fcm-service.ts
+++ b/hushh-webapp/lib/notifications/fcm-service.ts
@@ -724,6 +724,17 @@ function setupNativeListeners(): void {
           } else if (
             data &&
             typeof data.type === "string" &&
+            data.type === "location_access_request"
+          ) {
+            const requestId =
+              typeof data.request_id === "string" ? data.request_id.trim() : "";
+            const href = requestId
+              ? `${ROUTES.KAI_LOCATION}?requestId=${encodeURIComponent(requestId)}`
+              : ROUTES.KAI_LOCATION;
+            requestInternalAppNavigation({ href, scroll: false });
+          } else if (
+            data &&
+            typeof data.type === "string" &&
             data.type === "kai_analysis_complete"
           ) {
             assignWindowLocation(ROUTES.KAI_DASHBOARD);


### PR DESCRIPTION
## Summary
- Add KAI live location backend routes, service logic, database migration 060, and API contract docs.
- Add web owner/share pages, shared-link viewer, location-sharing service helpers, navigation entries, and notification hooks.
- Add local Git hook protections so direct pushes from/to main or master are blocked, while Windows venv Python is supported by the shared hooks.

## Validation
- `python -m ruff check` on the KAI backend route/service/test files
- `python -m ruff format --check` on the KAI backend route/service/test files
- `python -m pytest tests/services/test_kai_location_service.py`
- `npm test -- __tests__/api/kai/proxy-route.test.ts __tests__/services/location-sharing-contract.test.ts __tests__/components/kai-location-page.test.tsx`
- `npm run typecheck`

## Notes
- `kai-location-api-deploy` already has open PR #1361 for backend-only API work; this feature branch is rebased onto latest `origin/main` and includes the full backend plus web experience.