### PR TITLE
test(persona): preserve empty RIA route mismatch handling

### DIFF
--- a/hushh-webapp/__tests__/components/persona-bootstrap-redirect.test.tsx
+++ b/hushh-webapp/__tests__/components/persona-bootstrap-redirect.test.tsx
@@ -80,4 +80,16 @@ describe("PersonaBootstrapRedirect", () => {
       screen.queryByText("Your active role and current route are out of sync")
     ).toBeNull();
   });
+    it("keeps mismatch dialog visible when RIA entry route is empty", () => {
+    personaStateValue = {
+      ...personaStateValue,
+      riaEntryRoute: "",
+    };
+
+    render(<PersonaBootstrapRedirect />);
+
+    expect(
+      screen.getByText("Your active role and current route are out of sync")
+    ).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Motivation

Persona bootstrap routing should preserve stable mismatch handling behavior even when optional RIA entry route state is empty.

Regression coverage helps ensure persona synchronization safeguards remain active during incomplete or partially initialized navigation state scenarios.

## What's covered

`__tests__/components/persona-bootstrap-redirect.test.tsx`

Added regression coverage for empty RIA entry route handling.

### Key scenarios

* keeps mismatch dialog visible when RIA entry route is empty
* validates persona mismatch protection remains active during incomplete route state
* strengthens deterministic persona bootstrap redirect behavior
* preserves existing persona transition suppression coverage

## Validation

* npm run test -- persona-bootstrap-redirect
* npm run lint
* npm run typecheck

## Notes

* no production behavior changes
* regression coverage only
* DCO sign-off included
