### PR TITLE
test(settings): preserve empty trailing row stability

### DIFF
--- a/hushh-webapp/__tests__/components/settings-ui.test.tsx
+++ b/hushh-webapp/__tests__/components/settings-ui.test.tsx
@@ -108,4 +108,15 @@ describe("SettingsSegmentedTabs", () => {
     fireEvent.click(inactive);
     expect(handleValueChange).toHaveBeenCalledWith("kai");
   });
+    it("preserves row rendering stability when trailing content is omitted", () => {
+    render(
+      <SettingsRow
+        title="Privacy status"
+        description="All systems operational"
+      />
+    );
+
+    expect(screen.getByText("Privacy status")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /privacy status/i })).toBeNull();
+  });
 });


### PR DESCRIPTION
## Motivation

Settings rows should preserve stable rendering behavior when optional trailing content is omitted.

Regression coverage helps ensure simplified settings layouts remain non-interactive and visually stable without introducing unintended button wrappers or affordances.

## What's covered

`__tests__/components/settings-ui.test.tsx`

Added regression coverage for empty trailing content handling in settings rows.

### Key scenarios

* preserves row rendering stability when trailing content is omitted
* validates non-interactive settings rows render correctly without trailing controls
* ensures button wrappers are not introduced for passive informational rows
* strengthens deterministic settings row rendering behavior
* preserves existing interactive row and segmented tab coverage

## Validation

* npm run test -- settings-ui
* npm run lint
* npm run typecheck

## Notes

* no production behavior changes
* regression coverage only
* DCO sign-off included
