### PR TITLE
feat(app-ui): add reusable InlineLoadingState primitive for compact async UI sections

### DIFF
--- a/hushh-webapp/app/ria/page.tsx
+++ b/hushh-webapp/app/ria/page.tsx
@@ -6,7 +6,6 @@ import { useRouter } from "next/navigation";
 import {
   BriefcaseBusiness,
   CircleAlert,
-  Loader2,
 } from "lucide-react";
 
 import { RiaCompatibilityState, RiaPageShell, RiaSurface } from "@/components/ria/ria-page-shell";
@@ -17,6 +16,7 @@ import { useStaleResource } from "@/lib/cache/use-stale-resource";
 import { RiaService, type RiaHomeResponse } from "@/lib/services/ria-service";
 import { usePublishVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
 import { ROUTES } from "@/lib/navigation/routes";
+import { InlineLoadingState } from "@/components/app-ui/inline-loading-state";
 import { cn } from "@/lib/utils";
 
 type HeroTone = "neutral" | "warning" | "success" | "critical";
@@ -346,10 +346,7 @@ export default function RiaHomePage() {
 
             <div className="overflow-hidden rounded-[20px] border border-border/60 bg-background/70">
               {homeResource.loading && !homeResource.data ? (
-                <div className="flex items-center gap-2 px-4 py-5 text-sm text-muted-foreground">
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  Pulling readiness, relationships, and picks state.
-                </div>
+                <InlineLoadingState label="Pulling readiness, relationships, and picks state." />
               ) : null}
 
               {!homeResource.loading && queueItems.length === 0 ? (

--- a/hushh-webapp/components/app-ui/inline-loading-state.tsx
+++ b/hushh-webapp/components/app-ui/inline-loading-state.tsx
@@ -1,0 +1,31 @@
+import { Loader2 } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+interface InlineLoadingStateProps {
+  label?: string
+  className?: string
+  iconClassName?: string
+}
+
+export function InlineLoadingState({
+  label = "Loading…",
+  className,
+  iconClassName,
+}: InlineLoadingStateProps) {
+  return (
+    <div
+      role="status"
+      aria-label={label}
+      className={cn(
+        "flex items-center gap-2 px-4 py-5 text-sm text-muted-foreground",
+        className
+      )}
+    >
+      <Loader2
+        className={cn("h-4 w-4 shrink-0 motion-safe:animate-spin", iconClassName)}
+      />
+      <span>{label}</span>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Extracts the repeated `Loader2 + loading text` inline pattern into a shared
`InlineLoadingState` primitive placed under `components/app-ui/` per repository
architecture rules.

## Changes

- **New:** `components/app-ui/inline-loading-state.tsx`
  Composable loading row with `label`, `className`, `iconClassName` props.
  Uses `motion-safe:animate-spin` to respect OS reduced-motion preferences.

- **Edit:** `app/ria/page.tsx`
  Removes inline `Loader2` import and loading `<div>` block.
  Replaces with `<InlineLoadingState label="..." />`.

## Architecture

New file placed in `components/app-ui/` and does not modify `components/ui/`,
keeping repository design-system boundaries intact.

## Impact

- zero behavior change
- zero backend/business logic impact
- reusable compact async loading primitive
- accessible loading semantics with `role="status"` and `aria-label`
- frontend-only UI abstraction improvement

## Testing

- `npx tsc --noEmit` ✅
- `npm run lint` ✅