### PR TITLE
feat(app-ui): add reusable DataTableSkeleton loading state for DataTable surfaces

### DIFF
--- a/hushh-webapp/components/app-ui/data-table-skeleton.tsx
+++ b/hushh-webapp/components/app-ui/data-table-skeleton.tsx
@@ -1,0 +1,59 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+import { cn } from "@/lib/utils"
+
+interface DataTableSkeletonProps {
+  columns?: number
+  rows?: number
+  showSearchBar?: boolean
+  className?: string
+}
+
+export function DataTableSkeleton({
+  columns = 4,
+  rows = 8,
+  showSearchBar = true,
+  className,
+}: DataTableSkeletonProps) {
+  return (
+    <div
+      className={cn("space-y-[var(--data-table-controls-gap,12px)]", className)}
+      aria-busy="true"
+      aria-label="Loading table data"
+    >
+      {showSearchBar && (
+        <div className="flex flex-col gap-3 sm:flex-row">
+          <Skeleton className="h-9 flex-1" />
+        </div>
+      )}
+
+      <div className="overflow-hidden rounded-lg border">
+        <div className="flex gap-4 border-b px-[var(--data-table-cell-px,16px)] py-3">
+          {Array.from({ length: columns }).map((_, i) => (
+            <Skeleton
+              key={i}
+              className="h-3.5"
+              style={{ flex: i === 0 ? 2 : 1 }}
+            />
+          ))}
+        </div>
+
+        {Array.from({ length: rows }).map((_, rowIdx) => (
+          <div
+            key={rowIdx}
+            className="flex gap-4 border-b px-[var(--data-table-cell-px,16px)] py-[var(--data-table-cell-py,12px)] last:border-b-0"
+            style={{ opacity: Math.max(0.3, 1 - rowIdx * 0.09) }}
+          >
+            {Array.from({ length: columns }).map((_, colIdx) => (
+              <Skeleton
+                key={colIdx}
+                className="h-4"
+                style={{ flex: colIdx === 0 ? 2 : 1 }}
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/hushh-webapp/components/app-ui/data-table.tsx
+++ b/hushh-webapp/components/app-ui/data-table.tsx
@@ -52,6 +52,7 @@ import {
 } from "@/components/ui/pagination";
 import { Search } from "lucide-react";
 import { surfaceDataTableShellClassName } from "@/lib/morphy-ux/surfaces";
+import { DataTableSkeleton } from "@/components/app-ui/data-table-skeleton";
 import { cn } from "@/lib/utils";
 
 const TABLE_SWIPE_THRESHOLD_PX = 44;
@@ -89,6 +90,7 @@ interface DataTableProps<TData, TValue> {
   tableContainerClassName?: string;
   tableClassName?: string;
   density?: "default" | "compact";
+  isLoading?: boolean;
   stickyHeader?: boolean;
 }
 
@@ -109,6 +111,7 @@ export function DataTable<TData, TValue>({
   tableContainerClassName,
   tableClassName,
   density = "default",
+  isLoading = false,
   stickyHeader = false,
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = React.useState<SortingState>([]);
@@ -235,6 +238,16 @@ export function DataTable<TData, TValue>({
 
   const compact = density === "compact";
   const resolvedTableShellClassName = cn("w-full", tableContainerClassName);
+
+  if (isLoading) {
+    return (
+      <DataTableSkeleton
+        columns={columns.length}
+        showSearchBar={enableSearch}
+      />
+    )
+  }
+
   return (
     <div
       className="space-y-[var(--data-table-controls-gap)]"


### PR DESCRIPTION
## Summary

Introduces a shared `DataTableSkeleton` primitive built on the existing `Skeleton`
design-system contract. Table-based routes can now render a structured skeleton during
loading instead of flashing empty space. Wired directly into `DataTable` via an
`isLoading` prop for zero-boilerplate usage.

## Changes

- **New:** `components/app-ui/data-table-skeleton.tsx`
  Composable skeleton with `columns`, `rows`, `showSearchBar`, `className` props.
  Mirrors DataTable visual structure (header row + body rows) with opacity fade.
  Uses CSS custom properties to match live table spacing consistently.

- **Edit:** `components/app-ui/data-table.tsx`
  Adds `isLoading?: boolean` prop (defaults to `false`).
  Renders `<DataTableSkeleton />` through an early return when loading.
  Existing DataTable render flow remains unchanged when `isLoading=false`.

## Architecture

New reusable primitive is intentionally placed inside:

`components/app-ui/`

to comply with repository design-system validation boundaries.

Uses `Skeleton` from:

`@/components/ui/skeleton`

which remains a valid design-system contract import.

## Impact

- Reusable loading infrastructure for shared DataTable surfaces
- Eliminates empty-state flashes during async loading
- Zero behavior change for existing DataTable consumers
- Frontend-only UX enhancement
- Accessible via `aria-busy="true"` and `aria-label`

## Testing

- `npx tsc --noEmit` ✅
- `npm run lint` ✅