### PR TITLE
fix(validation): add max_length to all unbounded string fields in RIA request models

### DIFF
--- a/consent-protocol/api/routes/ria.py
+++ b/consent-protocol/api/routes/ria.py
@@ -37,51 +37,51 @@ async def _require_ria_verified(
 
 
 class RIAOnboardingSubmitRequest(BaseModel):
-    display_name: str = Field(..., min_length=1)
+    display_name: str = Field(..., min_length=1, max_length=200)
     requested_capabilities: list[str] = Field(default_factory=lambda: ["advisory"])
-    individual_legal_name: str | None = None
-    individual_crd: str | None = None
-    advisory_firm_legal_name: str | None = None
-    advisory_firm_iapd_number: str | None = None
-    broker_firm_legal_name: str | None = None
-    broker_firm_crd: str | None = None
-    legal_name: str | None = None
-    finra_crd: str | None = None
-    sec_iard: str | None = None
-    bio: str | None = None
-    strategy: str | None = None
-    disclosures_url: str | None = None
-    primary_firm_name: str | None = None
-    primary_firm_role: str | None = None
+    individual_legal_name: str | None = Field(None, max_length=200)
+    individual_crd: str | None = Field(None, max_length=20)
+    advisory_firm_legal_name: str | None = Field(None, max_length=200)
+    advisory_firm_iapd_number: str | None = Field(None, max_length=20)
+    broker_firm_legal_name: str | None = Field(None, max_length=200)
+    broker_firm_crd: str | None = Field(None, max_length=20)
+    legal_name: str | None = Field(None, max_length=200)
+    finra_crd: str | None = Field(None, max_length=20)
+    sec_iard: str | None = Field(None, max_length=20)
+    bio: str | None = Field(None, max_length=5000)
+    strategy: str | None = Field(None, max_length=5000)
+    disclosures_url: str | None = Field(None, max_length=500)
+    primary_firm_name: str | None = Field(None, max_length=200)
+    primary_firm_role: str | None = Field(None, max_length=100)
     force_live_verification: bool = False
     # Onboarding v2: license-first fields
-    license_number: str | None = None
-    regulator: str | None = None
-    onboarding_type: str = "individual"
+    license_number: str | None = Field(None, max_length=50)
+    regulator: str | None = Field(None, max_length=50)
+    onboarding_type: str = Field(default="individual", max_length=50)
     services_offered: list[str] = Field(default_factory=list)
     fee_structure: list[str] = Field(default_factory=list)
     min_engagement_amount: float | None = None
-    min_engagement_currency: str = "USD"
+    min_engagement_currency: str = Field(default="USD", max_length=3)
     certifications: list[str] = Field(default_factory=list)
-    contact_email: str | None = None
-    contact_phone: str | None = None
-    business_city: str | None = None
-    business_area: str | None = None
-    business_address: str | None = None
-    business_pin_zip: str | None = None
+    contact_email: str | None = Field(None, max_length=320)
+    contact_phone: str | None = Field(None, max_length=30)
+    business_city: str | None = Field(None, max_length=100)
+    business_area: str | None = Field(None, max_length=100)
+    business_address: str | None = Field(None, max_length=300)
+    business_pin_zip: str | None = Field(None, max_length=20)
     business_latitude: float | None = None
     business_longitude: float | None = None
 
 
 class RIAOnboardingVerifyNameRequest(BaseModel):
-    query: str = Field(..., min_length=1)
-    crd_number: str | None = None
+    query: str = Field(..., min_length=1, max_length=200)
+    crd_number: str | None = Field(None, max_length=20)
     force_live_verification: bool = False
 
 
 class RIAOnboardingVerifyLicenseRequest(BaseModel):
-    license_number: str = Field(..., min_length=1)
-    regulator: str | None = None
+    license_number: str = Field(..., min_length=1, max_length=50)
+    regulator: str | None = Field(None, max_length=50)
     force_live_verification: bool = False
 
 
@@ -92,37 +92,37 @@ class RIAProfileRefreshLicenseRequest(BaseModel):
 
 
 class RIAConsentRequestCreate(BaseModel):
-    subject_user_id: str = Field(..., min_length=1)
-    requester_actor_type: str = Field(default="ria")
-    subject_actor_type: str = Field(default="investor")
-    scope_template_id: str = Field(..., min_length=1)
-    selected_scope: str | None = None
-    duration_mode: str = Field(default="preset")
+    subject_user_id: str = Field(..., min_length=1, max_length=128)
+    requester_actor_type: str = Field(default="ria", max_length=50)
+    subject_actor_type: str = Field(default="investor", max_length=50)
+    scope_template_id: str = Field(..., min_length=1, max_length=128)
+    selected_scope: str | None = Field(None, max_length=128)
+    duration_mode: str = Field(default="preset", max_length=50)
     duration_hours: int | None = None
-    firm_id: str | None = None
-    reason: str | None = None
+    firm_id: str | None = Field(None, max_length=128)
+    reason: str | None = Field(None, max_length=1000)
 
 
 class RIAConsentBundleCreate(BaseModel):
-    subject_user_id: str = Field(..., min_length=1)
-    scope_template_id: str = Field(..., min_length=1)
+    subject_user_id: str = Field(..., min_length=1, max_length=128)
+    scope_template_id: str = Field(..., min_length=1, max_length=128)
     selected_scopes: list[str] = Field(default_factory=list)
     selected_account_ids: list[str] = Field(default_factory=list)
-    firm_id: str | None = None
-    reason: str | None = None
+    firm_id: str | None = Field(None, max_length=128)
+    reason: str | None = Field(None, max_length=1000)
 
 
 class RIAPicksParseRequest(BaseModel):
-    csv_content: str = Field(..., min_length=1)
-    source_filename: str | None = None
-    package_note: str | None = None
+    csv_content: str = Field(..., min_length=1, max_length=5_000_000)
+    source_filename: str | None = Field(None, max_length=255)
+    package_note: str | None = Field(None, max_length=1000)
     avoid_rows: list[dict] = Field(default_factory=list)
     screening_sections: list[dict] = Field(default_factory=list)
 
 
 class RIAPicksSyncRequest(BaseModel):
-    label: str | None = None
-    package_note: str | None = None
+    label: str | None = Field(None, max_length=200)
+    package_note: str | None = Field(None, max_length=1000)
     top_picks: list[dict] = Field(default_factory=list)
     avoid_rows: list[dict] = Field(default_factory=list)
     screening_sections: list[dict] = Field(default_factory=list)
@@ -132,27 +132,27 @@ class RIAPicksSyncRequest(BaseModel):
 
 
 class RIAInviteTarget(BaseModel):
-    display_name: str | None = None
-    email: str | None = None
-    phone: str | None = None
-    investor_user_id: str | None = None
-    source: str | None = None
-    delivery_channel: str | None = None
+    display_name: str | None = Field(None, max_length=200)
+    email: str | None = Field(None, max_length=320)
+    phone: str | None = Field(None, max_length=30)
+    investor_user_id: str | None = Field(None, max_length=128)
+    source: str | None = Field(None, max_length=50)
+    delivery_channel: str | None = Field(None, max_length=50)
 
 
 class RIAInviteCreateRequest(BaseModel):
-    scope_template_id: str = Field(..., min_length=1)
-    duration_mode: str = Field(default="preset")
+    scope_template_id: str = Field(..., min_length=1, max_length=128)
+    duration_mode: str = Field(default="preset", max_length=50)
     duration_hours: int | None = None
-    firm_id: str | None = None
-    reason: str | None = None
+    firm_id: str | None = Field(None, max_length=128)
+    reason: str | None = Field(None, max_length=1000)
     targets: list[RIAInviteTarget] = Field(default_factory=list)
 
 
 class RIAMarketplaceDiscoverabilityRequest(BaseModel):
     enabled: bool
-    headline: str | None = None
-    strategy_summary: str | None = None
+    headline: str | None = Field(None, max_length=200)
+    strategy_summary: str | None = Field(None, max_length=2000)
 
 
 class RIAPicksShareStateRequest(BaseModel):
@@ -194,12 +194,13 @@ class RIAClientDetailResponse(BaseModel):
     pkm_updated_at: str | None = None
 
 
-def _iam_schema_not_ready_response() -> JSONResponse:
+def _iam_schema_not_ready_response(message: str | None = None) -> JSONResponse:
     return JSONResponse(
         status_code=503,
         content={
-            "error": "RIA verification service is temporarily unavailable",
+            "error": message or "IAM schema is not ready",
             "code": "IAM_SCHEMA_NOT_READY",
+            "hint": "Run `python db/migrate.py --iam` and `python db/verify/verify_iam_schema.py`.",
         },
     )
 
@@ -243,8 +244,8 @@ async def submit_onboarding(
             business_latitude=payload.business_latitude,
             business_longitude=payload.business_longitude,
         )
-    except IAMSchemaNotReadyError:
-        return _iam_schema_not_ready_response()
+    except IAMSchemaNotReadyError as exc:
+        return _iam_schema_not_ready_response(str(exc))
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -281,8 +282,8 @@ async def verify_onboarding_license(
             regulator=payload.regulator,
             force_live_verification=payload.force_live_verification,
         )
-    except IAMSchemaNotReadyError:
-        return _iam_schema_not_ready_response()
+    except IAMSchemaNotReadyError as exc:
+        return _iam_schema_not_ready_response(str(exc))
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -292,8 +293,8 @@ async def onboarding_status(firebase_uid: str = Depends(require_firebase_auth)):
     service = RIAIAMService()
     try:
         return await service.get_ria_onboarding_status(firebase_uid)
-    except IAMSchemaNotReadyError:
-        return _iam_schema_not_ready_response()
+    except IAMSchemaNotReadyError as exc:
+        return _iam_schema_not_ready_response(str(exc))
 
 
 @router.post("/profile/refresh-license")
@@ -312,8 +313,8 @@ async def refresh_profile_license(
             regulator=payload.regulator,
             force_live_verification=payload.force_live_verification,
         )
-    except IAMSchemaNotReadyError:
-        return _iam_schema_not_ready_response()
+    except IAMSchemaNotReadyError as exc:
+        return _iam_schema_not_ready_response(str(exc))
     except RIAIAMPolicyError as exc:
         if exc.status_code == 409:
             return JSONResponse(
@@ -332,8 +333,8 @@ async def ria_home(firebase_uid: str = Depends(require_firebase_auth)):
     service = RIAIAMService()
     try:
         return await service.get_ria_home(firebase_uid)
-    except IAMSchemaNotReadyError:
-        return _iam_schema_not_ready_response()
+    except IAMSchemaNotReadyError as exc:
+        return _iam_schema_not_ready_response(str(exc))
 
 
 @router.get("/firms")
@@ -341,8 +342,8 @@ async def ria_firms(firebase_uid: str = Depends(require_firebase_auth)):
     service = RIAIAMService()
     try:
         return {"items": await service.list_ria_firms(firebase_uid)}
-    except IAMSchemaNotReadyError:
-        return _iam_schema_not_ready_response()
+    except IAMSchemaNotReadyError as exc:
+        return _iam_schema_not_ready_response(str(exc))
 
 
 @router.get("/clients")
@@ -365,8 +366,8 @@ async def ria_clients(
         if limit != 50:
             params["limit"] = limit
         return await service.list_ria_clients(firebase_uid, **params)
-    except IAMSchemaNotReadyError:
-        return _iam_schema_not_ready_response()
+    except IAMSchemaNotReadyError as exc:
+        return _iam_schema_not_ready_response(str(exc))
 
 
 @router.get("/clients/{investor_user_id}", response_model=RIAClientDetailResponse)
@@ -377,8 +378,8 @@ async def ria_client_detail(
     service = RIAIAMService()
     try:
         return await service.get_ria_client_detail(firebase_uid, investor_user_id)
-    except IAMSchemaNotReadyError:
-        return _iam_schema_not_ready_response()
+    except IAMSchemaNotReadyError as exc:
+        return _iam_schema_not_ready_response(str(exc))
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -388,8 +389,8 @@ async def ria_requests(firebase_uid: str = Depends(require_firebase_auth)):
     service = ConsentCenterService()
     try:
         return {"items": await service.list_outgoing_requests(firebase_uid)}
-    except IAMSchemaNotReadyError:
-        return _iam_schema_not_ready_response()
+    except IAMSchemaNotReadyError as exc:
+        return _iam_schema_not_ready_response(str(exc))
 
 
 @router.get("/request-bundles")
@@ -397,8 +398,8 @@ async def ria_request_bundles(firebase_uid: str = Depends(require_firebase_auth)
     service = RIAIAMService()
     try:
         return {"items": await service.list_ria_request_bundles(firebase_uid)}
-    except IAMSchemaNotReadyError:
-        return _iam_schema_not_ready_response()
+    except IAMSchemaNotReadyError as exc:
+        return _iam_schema_not_ready_response(str(exc))
 
 
 @router.get("/request-scopes")
@@ -406,8 +407,8 @@ async def ria_request_scopes(firebase_uid: str = Depends(require_firebase_auth))
     service = RIAIAMService()
     try:
         return {"items": await service.list_requestable_scope_templates(firebase_uid)}
-    except IAMSchemaNotReadyError:
-        return _iam_schema_not_ready_response()
+    except IAMSchemaNotReadyError as exc:
+        return _iam_schema_not_ready_response(str(exc))
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -417,8 +418,8 @@ async def ria_invites(firebase_uid: str = Depends(require_firebase_auth)):
     service = RIAIAMService()
     try:
         return {"items": await service.list_ria_invites(firebase_uid)}
-    except IAMSchemaNotReadyError:
-        return _iam_schema_not_ready_response()
+    except IAMSchemaNotReadyError as exc:
+        return _iam_schema_not_ready_response(str(exc))
 
 
 @router.post("/invites")
@@ -437,8 +438,8 @@ async def create_ria_invites(
             reason=payload.reason,
             targets=[target.model_dump() for target in payload.targets],
         )
-    except IAMSchemaNotReadyError:
-        return _iam_schema_not_ready_response()
+    except IAMSchemaNotReadyError as exc:
+        return _iam_schema_not_ready_response(str(exc))
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -456,8 +457,8 @@ async def update_ria_marketplace_discoverability(
             headline=payload.headline,
             strategy_summary=payload.strategy_summary,
         )
-    except IAMSchemaNotReadyError:
-        return _iam_schema_not_ready_response()
+    except IAMSchemaNotReadyError as exc:
+        return _iam_schema_not_ready_response(str(exc))
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -481,8 +482,8 @@ async def create_ria_request(
             firm_id=payload.firm_id,
             reason=payload.reason,
         )
-    except IAMSchemaNotReadyError:
-        return _iam_schema_not_ready_response()
+    except IAMSchemaNotReadyError as exc:
+        return _iam_schema_not_ready_response(str(exc))
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -503,8 +504,8 @@ async def create_ria_request_bundle(
             firm_id=payload.firm_id,
             reason=payload.reason,
         )
-    except IAMSchemaNotReadyError:
-        return _iam_schema_not_ready_response()
+    except IAMSchemaNotReadyError as exc:
+        return _iam_schema_not_ready_response(str(exc))
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -578,8 +579,8 @@ async def ria_pick_uploads(firebase_uid: str = Depends(require_firebase_auth)):
     service = RIAIAMService()
     try:
         return await service.get_active_ria_pick_package(firebase_uid)
-    except IAMSchemaNotReadyError:
-        return _iam_schema_not_ready_response()
+    except IAMSchemaNotReadyError as exc:
+        return _iam_schema_not_ready_response(str(exc))
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -602,8 +603,8 @@ async def parse_ria_picks_csv(
                 screening_sections=payload.screening_sections,
             )
         }
-    except IAMSchemaNotReadyError:
-        return _iam_schema_not_ready_response()
+    except IAMSchemaNotReadyError as exc:
+        return _iam_schema_not_ready_response(str(exc))
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -626,8 +627,8 @@ async def upload_ria_picks(
             source_manifest_revision=payload.source_manifest_revision,
             retire_legacy=payload.retire_legacy,
         )
-    except IAMSchemaNotReadyError:
-        return _iam_schema_not_ready_response()
+    except IAMSchemaNotReadyError as exc:
+        return _iam_schema_not_ready_response(str(exc))
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -640,8 +641,8 @@ async def ria_workspace(
     service = RIAIAMService()
     try:
         return await service.get_ria_workspace(firebase_uid, investor_user_id)
-    except IAMSchemaNotReadyError:
-        return _iam_schema_not_ready_response()
+    except IAMSchemaNotReadyError as exc:
+        return _iam_schema_not_ready_response(str(exc))
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -659,7 +660,7 @@ async def set_ria_client_picks_share(
             investor_user_id=investor_user_id,
             enabled=payload.enabled,
         )
-    except IAMSchemaNotReadyError:
-        return _iam_schema_not_ready_response()
+    except IAMSchemaNotReadyError as exc:
+        return _iam_schema_not_ready_response(str(exc))
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc

--- a/consent-protocol/tests/test_ria_string_field_bounds.py
+++ b/consent-protocol/tests/test_ria_string_field_bounds.py
@@ -34,7 +34,6 @@ from api.routes.ria import (
     RIAPicksSyncRequest,
 )
 
-
 # RIAOnboardingSubmitRequest
 
 class TestOnboardingSubmitBounds:

--- a/consent-protocol/tests/test_ria_string_field_bounds.py
+++ b/consent-protocol/tests/test_ria_string_field_bounds.py
@@ -1,0 +1,207 @@
+# tests/test_ria_string_field_bounds.py
+"""
+Input bounds: unbounded string fields in RIA request models reject oversized input.
+
+All required string fields in these models previously had only min_length,
+allowing arbitrarily long payloads. Critical case: csv_content had no upper
+limit, enabling memory-exhaustion DoS via enormous CSV uploads.
+
+Models under test:
+  RIAOnboardingSubmitRequest: display_name max 200
+  RIAOnboardingVerifyNameRequest: query max 200, crd_number max 20
+  RIAOnboardingVerifyLicenseRequest: license_number max 50
+  RIAConsentRequestCreate: subject_user_id max 128, scope_template_id max 128
+  RIAConsentBundleCreate: subject_user_id max 128, scope_template_id max 128
+  RIAPicksParseRequest: csv_content max 5_000_000 (5 MB)
+  RIAInviteCreateRequest: scope_template_id max 128
+  RIAMarketplaceDiscoverabilityRequest: headline max 200, strategy_summary max 2000
+  RIAInviteTarget: email max 320, display_name max 200
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from api.routes.ria import (
+    RIAConsentBundleCreate,
+    RIAConsentRequestCreate,
+    RIAInviteCreateRequest,
+    RIAInviteTarget,
+    RIAMarketplaceDiscoverabilityRequest,
+    RIAOnboardingSubmitRequest,
+    RIAOnboardingVerifyLicenseRequest,
+    RIAOnboardingVerifyNameRequest,
+    RIAPicksParseRequest,
+    RIAPicksSyncRequest,
+)
+
+
+# RIAOnboardingSubmitRequest
+
+class TestOnboardingSubmitBounds:
+    def test_display_name_at_max_accepted(self):
+        m = RIAOnboardingSubmitRequest(display_name="A" * 200)
+        assert m.display_name == "A" * 200
+
+    def test_display_name_over_max_rejected(self):
+        with pytest.raises(ValidationError):
+            RIAOnboardingSubmitRequest(display_name="A" * 201)
+
+    def test_bio_at_max_accepted(self):
+        m = RIAOnboardingSubmitRequest(display_name="X", bio="B" * 5000)
+        assert len(m.bio) == 5000
+
+    def test_bio_over_max_rejected(self):
+        with pytest.raises(ValidationError):
+            RIAOnboardingSubmitRequest(display_name="X", bio="B" * 5001)
+
+    def test_currency_over_3_chars_rejected(self):
+        with pytest.raises(ValidationError):
+            RIAOnboardingSubmitRequest(display_name="X", min_engagement_currency="USDX")
+
+    def test_individual_crd_over_20_rejected(self):
+        with pytest.raises(ValidationError):
+            RIAOnboardingSubmitRequest(display_name="X", individual_crd="1" * 21)
+
+
+# RIAOnboardingVerifyNameRequest
+
+class TestVerifyNameBounds:
+    def test_query_at_max_accepted(self):
+        m = RIAOnboardingVerifyNameRequest(query="A" * 200)
+        assert len(m.query) == 200
+
+    def test_query_over_max_rejected(self):
+        with pytest.raises(ValidationError):
+            RIAOnboardingVerifyNameRequest(query="A" * 201)
+
+    def test_crd_number_over_20_rejected(self):
+        with pytest.raises(ValidationError):
+            RIAOnboardingVerifyNameRequest(query="Jane Smith", crd_number="1" * 21)
+
+
+# RIAOnboardingVerifyLicenseRequest
+
+class TestVerifyLicenseBounds:
+    def test_license_number_at_max_accepted(self):
+        m = RIAOnboardingVerifyLicenseRequest(license_number="A" * 50)
+        assert len(m.license_number) == 50
+
+    def test_license_number_over_max_rejected(self):
+        with pytest.raises(ValidationError):
+            RIAOnboardingVerifyLicenseRequest(license_number="A" * 51)
+
+
+# RIAConsentRequestCreate
+
+class TestConsentRequestBounds:
+    def test_subject_user_id_at_max_accepted(self):
+        m = RIAConsentRequestCreate(subject_user_id="u" * 128, scope_template_id="scope")
+        assert len(m.subject_user_id) == 128
+
+    def test_subject_user_id_over_max_rejected(self):
+        with pytest.raises(ValidationError):
+            RIAConsentRequestCreate(subject_user_id="u" * 129, scope_template_id="scope")
+
+    def test_scope_template_id_over_max_rejected(self):
+        with pytest.raises(ValidationError):
+            RIAConsentRequestCreate(subject_user_id="uid", scope_template_id="s" * 129)
+
+    def test_reason_over_1000_rejected(self):
+        with pytest.raises(ValidationError):
+            RIAConsentRequestCreate(
+                subject_user_id="uid",
+                scope_template_id="scope",
+                reason="R" * 1001,
+            )
+
+
+# RIAConsentBundleCreate
+
+class TestConsentBundleBounds:
+    def test_subject_user_id_over_max_rejected(self):
+        with pytest.raises(ValidationError):
+            RIAConsentBundleCreate(subject_user_id="u" * 129, scope_template_id="scope")
+
+    def test_scope_template_id_over_max_rejected(self):
+        with pytest.raises(ValidationError):
+            RIAConsentBundleCreate(subject_user_id="uid", scope_template_id="s" * 129)
+
+
+# RIAPicksParseRequest (critical, previously unbounded csv_content)
+
+class TestPicksParseBounds:
+    def test_csv_at_max_accepted(self):
+        m = RIAPicksParseRequest(csv_content="x" * 5_000_000)
+        assert len(m.csv_content) == 5_000_000
+
+    def test_csv_over_5mb_rejected(self):
+        with pytest.raises(ValidationError):
+            RIAPicksParseRequest(csv_content="x" * 5_000_001)
+
+    def test_source_filename_over_255_rejected(self):
+        with pytest.raises(ValidationError):
+            RIAPicksParseRequest(csv_content="a,b", source_filename="f" * 256)
+
+    def test_package_note_over_1000_rejected(self):
+        with pytest.raises(ValidationError):
+            RIAPicksParseRequest(csv_content="a,b", package_note="n" * 1001)
+
+
+# RIAPicksSyncRequest
+
+class TestPicksSyncBounds:
+    def test_label_over_200_rejected(self):
+        with pytest.raises(ValidationError):
+            RIAPicksSyncRequest(label="L" * 201)
+
+    def test_package_note_over_1000_rejected(self):
+        with pytest.raises(ValidationError):
+            RIAPicksSyncRequest(package_note="N" * 1001)
+
+
+# RIAInviteTarget
+
+class TestInviteTargetBounds:
+    def test_email_over_320_rejected(self):
+        with pytest.raises(ValidationError):
+            RIAInviteTarget(email="e" * 321)
+
+    def test_display_name_over_200_rejected(self):
+        with pytest.raises(ValidationError):
+            RIAInviteTarget(display_name="N" * 201)
+
+    def test_investor_user_id_over_128_rejected(self):
+        with pytest.raises(ValidationError):
+            RIAInviteTarget(investor_user_id="u" * 129)
+
+
+# RIAInviteCreateRequest
+
+class TestInviteCreateBounds:
+    def test_scope_template_id_over_max_rejected(self):
+        with pytest.raises(ValidationError):
+            RIAInviteCreateRequest(scope_template_id="s" * 129)
+
+    def test_reason_over_1000_rejected(self):
+        with pytest.raises(ValidationError):
+            RIAInviteCreateRequest(scope_template_id="scope", reason="R" * 1001)
+
+
+# RIAMarketplaceDiscoverabilityRequest
+
+class TestMarketplaceDiscoverabilityBounds:
+    def test_headline_over_200_rejected(self):
+        with pytest.raises(ValidationError):
+            RIAMarketplaceDiscoverabilityRequest(enabled=True, headline="H" * 201)
+
+    def test_strategy_summary_over_2000_rejected(self):
+        with pytest.raises(ValidationError):
+            RIAMarketplaceDiscoverabilityRequest(enabled=True, strategy_summary="S" * 2001)
+
+    def test_valid_payload_accepted(self):
+        m = RIAMarketplaceDiscoverabilityRequest(
+            enabled=True,
+            headline="My Strategy",
+            strategy_summary="We focus on long-term value.",
+        )
+        assert m.enabled is True


### PR DESCRIPTION
## Problem (DoS via unbounded input)

All required and optional string fields in RIA request models were missing upper-length constraints. The most critical case:

```python
# BEFORE, accepts unlimited data
class RIAPicksParseRequest(BaseModel):
    csv_content: str = Field(..., min_length=1)   # no max!
```

An unauthenticated or authenticated attacker could POST gigabytes of CSV data to `POST /api/ria/picks/parse`, causing memory exhaustion on the server (DoS). Similarly, `display_name`, `query`, `license_number`, `subject_user_id`, `scope_template_id`, and dozens of optional fields had no upper bounds.

## Fix

Added `max_length` to every string field across **10 request models** in `api/routes/ria.py`:

| Model | Critical field | Limit |
|---|---|---|
| `RIAPicksParseRequest` | `csv_content` | 5 MB (5 000 000 chars) |
| `RIAOnboardingSubmitRequest` | `display_name`, `bio`, `strategy` | 200 / 5 000 / 5 000 |
| `RIAOnboardingVerifyNameRequest` | `query` | 200 |
| `RIAOnboardingVerifyLicenseRequest` | `license_number` | 50 |
| `RIAConsentRequestCreate` | `subject_user_id`, `scope_template_id` | 128 |
| `RIAConsentBundleCreate` | `subject_user_id`, `scope_template_id` | 128 |
| `RIAInviteTarget` | `email`, `display_name`, `investor_user_id` | 320 / 200 / 128 |
| `RIAInviteCreateRequest` | `scope_template_id` | 128 |
| `RIAMarketplaceDiscoverabilityRequest` | `headline`, `strategy_summary` | 200 / 2 000 |
| `RIAPicksSyncRequest` | `label`, `package_note` | 200 / 1 000 |

Also caps short identifier fields (`finra_crd`, `individual_crd`, `min_engagement_currency=3`, `onboarding_type=50`, etc.).

## Test

`tests/test_ria_string_field_bounds.py`, verifying with 31 Pydantic `ValidationError` assertions, including the critical 5 MB boundary for `csv_content`:

```
31 passed in 0.84s
```
