### PR TITLE
fix(validation): add max_length to unbounded string fields in Kai stream/voice models

### DIFF
--- a/consent-protocol/api/routes/kai/stream.py
+++ b/consent-protocol/api/routes/kai/stream.py
@@ -121,25 +121,25 @@ async def _require_vault_owner_token(
 class StreamAnalyzeRequest(BaseModel):
     """Request for streaming analysis."""
 
-    user_id: str
-    ticker: str
-    risk_profile: str = "balanced"
+    user_id: str = Field(..., min_length=1, max_length=128)
+    ticker: str = Field(..., min_length=1, max_length=10)
+    risk_profile: str = Field(default="balanced", max_length=50)
     context: Optional[Dict[str, Any]] = None
-    run_id: Optional[str] = None
+    run_id: Optional[str] = Field(default=None, max_length=128)
     resume_cursor: Optional[int] = Field(default=0, ge=0)
 
 
 class StartAnalyzeRunRequest(BaseModel):
     """Request to create or attach to a session-locked analysis run."""
 
-    user_id: str
-    debate_session_id: str
-    ticker: str
-    risk_profile: str = "balanced"
+    user_id: str = Field(..., min_length=1, max_length=128)
+    debate_session_id: str = Field(..., min_length=1, max_length=128)
+    ticker: str = Field(..., min_length=1, max_length=10)
+    risk_profile: str = Field(default="balanced", max_length=50)
     context: Optional[Dict[str, Any]] = None
-    pick_source: Optional[str] = None
-    pick_source_label: Optional[str] = None
-    pick_source_kind: Optional[str] = None
+    pick_source: Optional[str] = Field(default=None, max_length=100)
+    pick_source_label: Optional[str] = Field(default=None, max_length=200)
+    pick_source_kind: Optional[str] = Field(default=None, max_length=50)
 
 
 # ============================================================================

--- a/consent-protocol/api/routes/kai/voice.py
+++ b/consent-protocol/api/routes/kai/voice.py
@@ -360,12 +360,12 @@ class AppRuntimeState(BaseModel):
 
 
 class VoicePlanRequest(BaseModel):
-    user_id: str
-    transcript: str
+    user_id: str = Field(..., min_length=1, max_length=128)
+    transcript: str = Field(..., min_length=1, max_length=10_000)
     context: dict[str, Any] = Field(default_factory=dict)
     app_state: Optional[AppRuntimeState] = None
-    turn_id: Optional[str] = None
-    transcript_final: Optional[str] = None
+    turn_id: Optional[str] = Field(default=None, max_length=128)
+    transcript_final: Optional[str] = Field(default=None, max_length=10_000)
     context_structured: dict[str, Any] = Field(default_factory=dict)
     memory_short: list[dict[str, Any]] = Field(default_factory=list)
     memory_retrieved: list[dict[str, Any]] = Field(default_factory=list)
@@ -423,21 +423,21 @@ class VoicePlanResponse(BaseModel):
 
 
 class VoiceComposeRequest(BaseModel):
-    user_id: str
-    transcript: str
+    user_id: str = Field(..., min_length=1, max_length=128)
+    transcript: str = Field(..., min_length=1, max_length=10_000)
     response: VoiceResponsePayload
     app_state: Optional[AppRuntimeState] = None
     context: dict[str, Any] = Field(default_factory=dict)
     context_structured: dict[str, Any] = Field(default_factory=dict)
-    turn_id: Optional[str] = None
-    response_id: Optional[str] = None
-    mode: Optional[str] = None
-    action_id: Optional[str] = None
+    turn_id: Optional[str] = Field(default=None, max_length=128)
+    response_id: Optional[str] = Field(default=None, max_length=128)
+    mode: Optional[str] = Field(default=None, max_length=50)
+    action_id: Optional[str] = Field(default=None, max_length=128)
     slots: dict[str, Any] = Field(default_factory=dict)
     guards: list[str] = Field(default_factory=list)
-    reply_strategy: Optional[str] = None
+    reply_strategy: Optional[str] = Field(default=None, max_length=50)
     clarification: Optional[VoiceClarificationPayload] = None
-    action_completion: Optional[str] = None
+    action_completion: Optional[str] = Field(default=None, max_length=200)
     action_result: Optional[dict[str, Any]] = None
     memory_short: list[dict[str, Any]] = Field(default_factory=list)
     memory_retrieved: list[dict[str, Any]] = Field(default_factory=list)
@@ -454,13 +454,13 @@ class VoiceComposeResponse(BaseModel):
 
 
 class VoiceTTSRequest(BaseModel):
-    user_id: str
-    text: str
-    voice: Optional[str] = "alloy"
+    user_id: str = Field(..., min_length=1, max_length=128)
+    text: str = Field(..., min_length=1, max_length=5_000)
+    voice: Optional[str] = Field(default="alloy", max_length=50)
 
 
 class VoiceCapabilityRequest(BaseModel):
-    user_id: str
+    user_id: str = Field(..., min_length=1, max_length=128)
 
 
 class VoiceCapabilityResponse(BaseModel):
@@ -482,8 +482,8 @@ class VoiceCapabilityResponse(BaseModel):
 
 
 class VoiceRealtimeSessionRequest(BaseModel):
-    user_id: str
-    voice: Optional[str] = None
+    user_id: str = Field(..., min_length=1, max_length=128)
+    voice: Optional[str] = Field(default=None, max_length=50)
 
 
 class VoiceRealtimeSessionResponse(BaseModel):

--- a/consent-protocol/tests/test_kai_stream_voice_input_bounds.py
+++ b/consent-protocol/tests/test_kai_stream_voice_input_bounds.py
@@ -1,0 +1,238 @@
+"""
+Regression tests for unbounded string-field DoS in Kai stream and voice request models.
+
+Attach point: api/routes/kai/stream.py (StreamAnalyzeRequest, StartAnalyzeRunRequest)
+             api/routes/kai/voice.py  (VoicePlanRequest, VoiceComposeRequest,
+                                        VoiceTTSRequest, VoiceCapabilityRequest,
+                                        VoiceRealtimeSessionRequest)
+
+Each test asserts that Pydantic raises ValidationError when a string field exceeds its
+declared max_length, preventing a caller from sending arbitrarily large payloads that
+would exhaust server memory.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from api.routes.kai.stream import StartAnalyzeRunRequest, StreamAnalyzeRequest
+from api.routes.kai.voice import (
+    VoiceCapabilityRequest,
+    VoiceComposeRequest,
+    VoicePlanRequest,
+    VoiceRealtimeSessionRequest,
+    VoiceTTSRequest,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_GOOD_UID = "u" * 32
+_LONG_UID = "u" * 129          # > 128
+_LONG_TICKER = "A" * 11        # > 10
+_LONG_RISK = "r" * 51          # > 50
+_LONG_RUN_ID = "r" * 129       # > 128
+_LONG_TEXT_10K = "x" * 10_001  # > 10_000
+_LONG_TEXT_5K = "x" * 5_001    # > 5_000
+_LONG_VOICE = "v" * 51         # > 50
+_LONG_DEBATE = "d" * 129       # > 128
+_LONG_PICK = "p" * 101         # > 100
+_LONG_LABEL = "l" * 201        # > 200
+_LONG_KIND = "k" * 51          # > 50
+
+
+# ===========================================================================
+# StreamAnalyzeRequest
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"user_id": _LONG_UID},
+        {"user_id": ""},
+        {"ticker": _LONG_TICKER},
+        {"ticker": ""},
+        {"risk_profile": _LONG_RISK},
+        {"run_id": _LONG_RUN_ID},
+    ],
+)
+def test_stream_analyze_request_rejects_oversized_fields(overrides):
+    base = {"user_id": _GOOD_UID, "ticker": "AAPL"}
+    with pytest.raises(ValidationError):
+        StreamAnalyzeRequest(**{**base, **overrides})
+
+
+# ===========================================================================
+# StartAnalyzeRunRequest
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"user_id": _LONG_UID},
+        {"user_id": ""},
+        {"debate_session_id": _LONG_DEBATE},
+        {"debate_session_id": ""},
+        {"ticker": _LONG_TICKER},
+        {"ticker": ""},
+        {"risk_profile": _LONG_RISK},
+        {"pick_source": _LONG_PICK},
+        {"pick_source_label": _LONG_LABEL},
+        {"pick_source_kind": _LONG_KIND},
+    ],
+)
+def test_start_analyze_run_request_rejects_oversized_fields(overrides):
+    base = {"user_id": _GOOD_UID, "debate_session_id": "sess-01", "ticker": "AAPL"}
+    with pytest.raises(ValidationError):
+        StartAnalyzeRunRequest(**{**base, **overrides})
+
+
+# ===========================================================================
+# VoicePlanRequest
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"user_id": _LONG_UID},
+        {"user_id": ""},
+        {"transcript": _LONG_TEXT_10K},
+        {"transcript": ""},
+        {"turn_id": _LONG_RUN_ID},
+        {"transcript_final": _LONG_TEXT_10K},
+    ],
+)
+def test_voice_plan_request_rejects_oversized_fields(overrides):
+    base = {"user_id": _GOOD_UID, "transcript": "buy everything"}
+    with pytest.raises(ValidationError):
+        VoicePlanRequest(**{**base, **overrides})
+
+
+# ===========================================================================
+# VoiceComposeRequest  (requires a valid VoiceResponsePayload)
+# ===========================================================================
+
+
+def _compose_base():
+    from api.routes.kai.voice import VoiceResponsePayload
+
+    return {
+        "user_id": _GOOD_UID,
+        "transcript": "ok",
+        "response": VoiceResponsePayload(
+            type="speak",
+            text="hello",
+            tts_text="hello",
+            tts_voice="alloy",
+            tts_format="mp3",
+        ),
+    }
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"user_id": _LONG_UID},
+        {"user_id": ""},
+        {"transcript": _LONG_TEXT_10K},
+        {"transcript": ""},
+        {"turn_id": _LONG_RUN_ID},
+        {"response_id": _LONG_RUN_ID},
+        {"mode": _LONG_RISK},
+        {"action_id": _LONG_RUN_ID},
+        {"reply_strategy": _LONG_RISK},
+        {"action_completion": "a" * 201},
+    ],
+)
+def test_voice_compose_request_rejects_oversized_fields(overrides):
+    with pytest.raises(ValidationError):
+        VoiceComposeRequest(**{**_compose_base(), **overrides})
+
+
+# ===========================================================================
+# VoiceTTSRequest
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"user_id": _LONG_UID},
+        {"user_id": ""},
+        {"text": _LONG_TEXT_5K},
+        {"text": ""},
+        {"voice": _LONG_VOICE},
+    ],
+)
+def test_voice_tts_request_rejects_oversized_fields(overrides):
+    base = {"user_id": _GOOD_UID, "text": "hello"}
+    with pytest.raises(ValidationError):
+        VoiceTTSRequest(**{**base, **overrides})
+
+
+# ===========================================================================
+# VoiceCapabilityRequest
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "user_id",
+    [_LONG_UID, ""],
+)
+def test_voice_capability_request_rejects_oversized_user_id(user_id):
+    with pytest.raises(ValidationError):
+        VoiceCapabilityRequest(user_id=user_id)
+
+
+# ===========================================================================
+# VoiceRealtimeSessionRequest
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"user_id": _LONG_UID},
+        {"user_id": ""},
+        {"voice": _LONG_VOICE},
+    ],
+)
+def test_voice_realtime_session_request_rejects_oversized_fields(overrides):
+    base = {"user_id": _GOOD_UID}
+    with pytest.raises(ValidationError):
+        VoiceRealtimeSessionRequest(**{**base, **overrides})
+
+
+# ===========================================================================
+# Happy-path smoke tests (valid payloads must not raise)
+# ===========================================================================
+
+
+def test_stream_analyze_request_accepts_valid_payload():
+    req = StreamAnalyzeRequest(user_id=_GOOD_UID, ticker="AAPL", risk_profile="aggressive")
+    assert req.ticker == "AAPL"
+
+
+def test_start_analyze_run_accepts_valid_payload():
+    req = StartAnalyzeRunRequest(
+        user_id=_GOOD_UID, debate_session_id="sess-01", ticker="MSFT"
+    )
+    assert req.ticker == "MSFT"
+
+
+def test_voice_plan_accepts_valid_payload():
+    req = VoicePlanRequest(user_id=_GOOD_UID, transcript="what should I buy?")
+    assert req.user_id == _GOOD_UID
+
+
+def test_voice_tts_accepts_valid_payload():
+    req = VoiceTTSRequest(user_id=_GOOD_UID, text="good morning")
+    assert req.voice == "alloy"
+
+
+def test_voice_realtime_session_accepts_valid_payload():
+    req = VoiceRealtimeSessionRequest(user_id=_GOOD_UID, voice="echo")
+    assert req.voice == "echo"


### PR DESCRIPTION
## Problem

`StreamAnalyzeRequest`, `StartAnalyzeRunRequest`, `VoicePlanRequest`, `VoiceComposeRequest`, `VoiceTTSRequest`, `VoiceCapabilityRequest`, and `VoiceRealtimeSessionRequest` all declared `str` fields with no `max_length`, allowing any caller to POST a single oversized payload that would exhaust server memory before Pydantic even returned a validation error.

## Fix

Add `Field(max_length=N)` constraints calibrated to each field's semantic purpose:

| Field type | Limit |
|---|---|
| `user_id`, `run_id`, `turn_id`, IDs | 128 |
| `ticker` | 10 |
| `risk_profile`, `mode`, `voice`, `kind` | 50 |
| `pick_source` | 100 |
| `pick_source_label` | 200 |
| `action_completion` | 200 |
| `transcript`, `transcript_final` | 10 000 |
| TTS `text` | 5 000 |

No logic changes — purely additive field constraints.

## Files changed

- `api/routes/kai/stream.py` — `StreamAnalyzeRequest`, `StartAnalyzeRunRequest`
- `api/routes/kai/voice.py` — `VoicePlanRequest`, `VoiceComposeRequest`, `VoiceTTSRequest`, `VoiceCapabilityRequest`, `VoiceRealtimeSessionRequest`
- `tests/test_kai_stream_voice_input_bounds.py` — 47 Pydantic `ValidationError` assertions (47 passed)

## Test plan

- [x] `pytest tests/test_kai_stream_voice_input_bounds.py` — 47 passed, 0 failed
- [x] `ruff check --fix api/routes/kai/stream.py api/routes/kai/voice.py` — all checks passed