### PR TITLE
fix(exceptions): chain all bare raises in except blocks (B904, 52 sites, 18 files)

### DIFF
--- a/consent-protocol/api/middleware.py
+++ b/consent-protocol/api/middleware.py
@@ -157,7 +157,7 @@ async def require_firebase_auth(
         raise
     except Exception as e:
         logger.warning("Firebase auth failed: %s", e)
-        raise _auth_error("Invalid Firebase ID token")
+        raise _auth_error("Invalid Firebase ID token") from e
 
 
 def verify_user_id_match(firebase_uid: str, requested_user_id: str) -> None:

--- a/consent-protocol/api/routes/agents.py
+++ b/consent-protocol/api/routes/agents.py
@@ -103,7 +103,7 @@ async def kai_chat(request: ChatRequest):
         # str(e) from a Gemini/DB call can leak model IDs, internal endpoints,
         # API key fragments, table/column names, or file paths with user IDs.
         logger.error("kai_chat.error user=%s: %s", request.userId, e)
-        raise HTTPException(status_code=500, detail="Internal error processing chat")
+        raise HTTPException(status_code=500, detail="Internal error processing chat") from e
 
 
 @router.get("/agents/kai/info")

--- a/consent-protocol/api/routes/consent.py
+++ b/consent-protocol/api/routes/consent.py
@@ -552,7 +552,7 @@ async def approve_consent(
     try:
         _body = ConsentApprovalPayload.model_validate(await request.json())
     except ValidationError as exc:
-        raise HTTPException(status_code=422, detail=exc.errors(include_url=False))
+        raise HTTPException(status_code=422, detail=exc.errors(include_url=False)) from exc
 
     # Granular field-level validation: agent_id in payload must match
     # X-Client-Id header when both are supplied.  A mismatch indicates the
@@ -618,7 +618,7 @@ async def approve_consent(
         _consent_scope = resolve_scope_to_enum(requested_scope)
     except Exception as e:
         logger.error("consent.scope_resolution_failed scope=%r: %s", requested_scope, e)
-        raise HTTPException(status_code=400, detail="Invalid consent scope")
+        raise HTTPException(status_code=400, detail="Invalid consent scope") from e
 
     # Optional metadata on pending request (used for expiry hints)
     metadata = pending_request.get("metadata", {})
@@ -1279,7 +1279,7 @@ async def issue_vault_owner_token(request: Request):
         raise
     except Exception:
         logger.exception("vault_owner.issue_failed")
-        raise HTTPException(status_code=500, detail="Failed to issue vault owner token")
+        raise HTTPException(status_code=500, detail="Failed to issue vault owner token") from None
 
 
 @router.post("/revoke")
@@ -1393,7 +1393,7 @@ async def revoke_consent(
     except Exception as e:
         logger.error("consent.revoke_failed: %s", type(e).__name__)
         logger.exception("consent.revoke_failed_trace")
-        raise HTTPException(status_code=500, detail="Internal error")
+        raise HTTPException(status_code=500, detail="Internal error") from e
 
 
 @router.get("/data")

--- a/consent-protocol/api/routes/crd_scraper.py
+++ b/consent-protocol/api/routes/crd_scraper.py
@@ -112,7 +112,7 @@ async def _call_provider(coro: Any) -> CrdScrapeProviderResponse:
         raise HTTPException(
             status_code=422,
             detail={"code": "CRD_INVALID_REQUEST", "message": "Invalid request parameters."},
-        )
+        ) from None
     except CrdScrapeProxyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 

--- a/consent-protocol/api/routes/db_proxy.py
+++ b/consent-protocol/api/routes/db_proxy.py
@@ -335,7 +335,7 @@ async def vault_bootstrap_state(
     except ValueError:
         raise HTTPException(
             status_code=400, detail={"error": "Validation error", "code": "VAULT_VALIDATION_ERROR"}
-        )
+        ) from None
     except Exception as e:
         logger.error("vault/bootstrap-state error user=%s", _mask_user_id(user_id), exc_info=True)
         _raise_database_http_exception(e)
@@ -381,7 +381,7 @@ async def vault_pre_vault_state(
     except ValueError:
         raise HTTPException(
             status_code=400, detail={"error": "Validation error", "code": "VAULT_VALIDATION_ERROR"}
-        )
+        ) from None
     except Exception as e:
         logger.error("vault/pre-vault-state error user=%s", _mask_user_id(user_id), exc_info=True)
         _raise_database_http_exception(e)
@@ -474,7 +474,7 @@ async def vault_setup(
                     "error": message,
                     "code": "VAULT_ALREADY_EXISTS",
                 },
-            )
+            ) from e
         if "primaryMethod + primaryWrapperId" in message:
             raise HTTPException(
                 status_code=400,
@@ -482,10 +482,10 @@ async def vault_setup(
                     "error": message,
                     "code": "VAULT_PRIMARY_WRAPPER_NOT_FOUND",
                 },
-            )
+            ) from e
         raise HTTPException(
             status_code=400, detail={"error": message, "code": "VAULT_VALIDATION_ERROR"}
-        )
+        ) from e
     except Exception as e:
         logger.error(
             "vault/setup error user=%s wrappers=%s methods=%s: %s",
@@ -540,10 +540,10 @@ async def vault_wrapper_upsert(
             raise HTTPException(
                 status_code=400,
                 detail={"error": message, "code": "VAULT_PASSKEY_RP_MISMATCH"},
-            )
+            ) from e
         raise HTTPException(
             status_code=400, detail={"error": message, "code": "VAULT_VALIDATION_ERROR"}
-        )
+        ) from e
     except Exception as e:
         logger.error(
             "vault/wrapper/upsert error user=%s method=%s: %s",
@@ -604,7 +604,7 @@ async def vault_wrapper_delete(
             code = "VAULT_PASSPHRASE_REQUIRED"
         elif "Fallback primary method/wrapper" in message:
             code = "VAULT_PRIMARY_WRAPPER_NOT_FOUND"
-        raise HTTPException(status_code=400, detail={"error": message, "code": code})
+        raise HTTPException(status_code=400, detail={"error": message, "code": code}) from e
     except Exception as e:
         logger.error(
             "vault/wrapper/delete error user=%s method=%s: %s",
@@ -645,10 +645,10 @@ async def vault_primary_set(
             raise HTTPException(
                 status_code=400,
                 detail={"error": message, "code": "VAULT_PRIMARY_WRAPPER_NOT_FOUND"},
-            )
+            ) from e
         raise HTTPException(
             status_code=400, detail={"error": message, "code": "VAULT_VALIDATION_ERROR"}
-        )
+        ) from e
     except Exception as e:
         logger.error(
             "vault/primary/set error user=%s primary=%s: %s",
@@ -787,9 +787,9 @@ async def get_vault_status(
         return status
 
     except ValueError:
-        raise HTTPException(status_code=401, detail="Unauthorized")
+        raise HTTPException(status_code=401, detail="Unauthorized") from None
     except HTTPException:
         raise
     except Exception:
         logger.error("vault.status.error", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error")
+        raise HTTPException(status_code=500, detail="Internal server error") from None

--- a/consent-protocol/api/routes/health.py
+++ b/consent-protocol/api/routes/health.py
@@ -181,7 +181,7 @@ async def issue_app_review_mode_session(request: Request):
             status_code=500,
             detail="Failed to issue review session token",
             headers=NO_STORE_HEADERS,
-        )
+        ) from None
 
     client_ip = request.client.host if request.client else "unknown"
     logger.info(

--- a/consent-protocol/api/routes/investors.py
+++ b/consent-protocol/api/routes/investors.py
@@ -157,7 +157,7 @@ async def get_investor(investor_id: int):
         raise
     except Exception:
         logger.error("investor.fetch.error investor_id=%s", investor_id, exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error")
+        raise HTTPException(status_code=500, detail="Internal server error") from None
 
 
 @router.get("/cik/{cik}", response_model=InvestorProfile)
@@ -241,7 +241,7 @@ async def create_investor(
 
     except Exception:
         logger.error("investor.create.error", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error")
+        raise HTTPException(status_code=500, detail="Internal server error") from None
 
 
 @router.post("/bulk", status_code=201)

--- a/consent-protocol/api/routes/kai/analyze.py
+++ b/consent-protocol/api/routes/kai/analyze.py
@@ -129,7 +129,7 @@ async def analyze_ticker(
         logger.error("[Kai] Analysis failed: %s", e)
         raise HTTPException(
             status_code=400, detail="Invalid analysis request. Check ticker and parameters."
-        )
+        ) from e
     except RealtimeDataUnavailable as e:
         logger.error("[Kai] Realtime dependency unavailable: %s", e.detail)
         raise HTTPException(
@@ -140,7 +140,7 @@ async def analyze_ticker(
                 "dependency": e.source,
                 "retryable": e.retryable,
             },
-        )
+        ) from e
     except Exception:
         logger.exception("[Kai] Unexpected error during analysis")
-        raise HTTPException(status_code=500, detail="Analysis is temporarily unavailable.")
+        raise HTTPException(status_code=500, detail="Analysis is temporarily unavailable.") from None

--- a/consent-protocol/api/routes/kai/chat.py
+++ b/consent-protocol/api/routes/kai/chat.py
@@ -388,4 +388,4 @@ async def analyze_portfolio_loser(
 
     except Exception:
         logger.error("kai.chat.analyze_loser.error ticker=%s", ticker, exc_info=True)
-        raise HTTPException(status_code=500, detail="Analysis is temporarily unavailable.")
+        raise HTTPException(status_code=500, detail="Analysis is temporarily unavailable.") from None

--- a/consent-protocol/api/routes/kai/consent.py
+++ b/consent-protocol/api/routes/kai/consent.py
@@ -166,7 +166,7 @@ async def grant_consent(
             logger.warning(
                 "grant_consent.invalid_scope user_id=%s scope=%s", request.user_id, scope_str
             )
-            raise HTTPException(status_code=400, detail="Invalid scope requested.")
+            raise HTTPException(status_code=400, detail="Invalid scope requested.") from None
         except Exception as e:
             logger.error(
                 "grant_consent.token_issue_failed user_id=%s scope=%s: %s",
@@ -174,7 +174,7 @@ async def grant_consent(
                 scope_str,
                 e,
             )
-            raise HTTPException(status_code=500, detail="Failed to issue consent token.")
+            raise HTTPException(status_code=500, detail="Failed to issue consent token.") from e
 
     if not tokens:
         raise HTTPException(status_code=400, detail="No valid scopes provided")

--- a/consent-protocol/api/routes/kai/voice.py
+++ b/consent-protocol/api/routes/kai/voice.py
@@ -658,7 +658,7 @@ async def kai_voice_realtime_session(
             },
             finalize=True,
         )
-        raise HTTPException(status_code=error.status_code, detail=error.message)
+        raise HTTPException(status_code=error.status_code, detail=error.message) from error
     except HTTPException:
         raise
     except Exception as error:
@@ -674,7 +674,7 @@ async def kai_voice_realtime_session(
             finalize=True,
         )
         logger.exception("[Kai Voice] realtime session failed turn_id=%s: %s", turn_id, error)
-        raise HTTPException(status_code=500, detail="Realtime session creation failed")
+        raise HTTPException(status_code=500, detail="Realtime session creation failed") from error
 
 
 @router.post("/voice/capability", response_model=VoiceCapabilityResponse)
@@ -1083,7 +1083,7 @@ async def kai_voice_plan(
             },
             finalize=True,
         )
-        raise HTTPException(status_code=error.status_code, detail=error.message)
+        raise HTTPException(status_code=error.status_code, detail=error.message) from error
     except HTTPException as error:
         if error.status_code == 499:
             raise
@@ -1110,7 +1110,7 @@ async def kai_voice_plan(
             finalize=True,
         )
         logger.exception("[Kai Voice] planning failed turn_id=%s: %s", turn_id, error)
-        raise HTTPException(status_code=500, detail="Voice intent planning failed")
+        raise HTTPException(status_code=500, detail="Voice intent planning failed") from error
 
 
 @router.post("/voice/compose", response_model=VoiceComposeResponse)
@@ -1242,7 +1242,7 @@ async def kai_voice_compose(
             },
             finalize=True,
         )
-        raise HTTPException(status_code=error.status_code, detail=error.message)
+        raise HTTPException(status_code=error.status_code, detail=error.message) from error
     except HTTPException as error:
         if error.status_code == 499:
             raise
@@ -1269,7 +1269,7 @@ async def kai_voice_compose(
             finalize=True,
         )
         logger.exception("[Kai Voice] composition failed turn_id=%s: %s", turn_id, error)
-        raise HTTPException(status_code=500, detail="Voice response composition failed")
+        raise HTTPException(status_code=500, detail="Voice response composition failed") from error
 
 
 @router.post("/voice/tts")
@@ -1732,7 +1732,7 @@ async def kai_voice_tts(
             },
             finalize=True,
         )
-        raise HTTPException(status_code=error.status_code, detail=error.message)
+        raise HTTPException(status_code=error.status_code, detail=error.message) from error
     except Exception as error:
         _trace_voice_stage(
             turn_id,
@@ -1777,4 +1777,4 @@ async def kai_voice_tts(
             finalize=True,
         )
         logger.exception("[Kai Voice] TTS failed turn_id=%s: %s", turn_id, error)
-        raise HTTPException(status_code=500, detail="Voice synthesis failed")
+        raise HTTPException(status_code=500, detail="Voice synthesis failed") from error

--- a/consent-protocol/api/routes/notifications.py
+++ b/consent-protocol/api/routes/notifications.py
@@ -34,7 +34,7 @@ async def register_push_token(request: Request):
     try:
         body = await request.json()
     except Exception:
-        raise HTTPException(status_code=400, detail="Invalid JSON body")
+        raise HTTPException(status_code=400, detail="Invalid JSON body") from None
 
     user_id = body.get("user_id") or body.get("userId")
     token = body.get("token")
@@ -61,7 +61,7 @@ async def register_push_token(request: Request):
         token_id = service.upsert_user_push_token(user_id=user_id, token=token, platform=platform)
     except Exception as e:
         logger.error("Push token registration failed: %s", e)
-        raise HTTPException(status_code=500, detail="Failed to register token")
+        raise HTTPException(status_code=500, detail="Failed to register token") from e
 
     logger.info("Push token registered for user=%s platform=%s", user_id, platform)
     return {"ok": True, "user_id": user_id, "platform": platform, "id": token_id}
@@ -97,7 +97,7 @@ async def unregister_push_token(request: Request):
         deleted = service.delete_user_push_tokens(user_id=user_id, platform=platform)
     except Exception as e:
         logger.error("Push token unregister failed: %s", e)
-        raise HTTPException(status_code=500, detail="Failed to unregister token(s)")
+        raise HTTPException(status_code=500, detail="Failed to unregister token(s)") from e
 
     logger.info(
         "Push token(s) unregistered for user=%s platform=%s deleted=%d", user_id, platform, deleted

--- a/consent-protocol/api/routes/pkm_routes_shared.py
+++ b/consent-protocol/api/routes/pkm_routes_shared.py
@@ -1282,7 +1282,7 @@ async def get_metadata(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve PKM metadata",
-        )
+        ) from e
 
 
 class PkmUpgradeDomainStateResponse(BaseModel):

--- a/consent-protocol/api/routes/session.py
+++ b/consent-protocol/api/routes/session.py
@@ -63,11 +63,11 @@ async def issue_session_token(
 
     except ValueError as e:
         logger.warning("session_token.invalid_token: %s", e)
-        raise HTTPException(status_code=401, detail="Invalid token")
+        raise HTTPException(status_code=401, detail="Invalid token") from e
 
     except Exception as e:
         logger.error("session_token.internal_error: %s", e)
-        raise HTTPException(status_code=500, detail="Internal server error")
+        raise HTTPException(status_code=500, detail="Internal server error") from e
 
     try:
         # Issue token with session scope
@@ -104,7 +104,7 @@ async def issue_session_token(
         )
     except Exception as e:
         logger.error("session_token.issue_failed: %s", e)
-        raise HTTPException(status_code=500, detail="Failed to issue session token")
+        raise HTTPException(status_code=500, detail="Failed to issue session token") from e
 
 
 @router.post("/consent/logout")
@@ -159,7 +159,7 @@ async def logout_session(
         raise
     except Exception as e:
         logger.error("session.logout.failed user=%s error=%s", request.userId, e)
-        raise HTTPException(status_code=500, detail="Failed to revoke session tokens")
+        raise HTTPException(status_code=500, detail="Failed to revoke session tokens") from e
 
 
 @router.get("/consent/history")
@@ -204,7 +204,7 @@ async def get_consent_history(
         }
     except Exception as e:
         logger.error("consent_history.fetch_failed: %s", e)
-        raise HTTPException(status_code=500, detail="Failed to fetch consent history")
+        raise HTTPException(status_code=500, detail="Failed to fetch consent history") from e
 
 
 @router.get("/consent/active")
@@ -248,7 +248,7 @@ async def get_active_consents(
         return {"grouped": grouped, "active": active_tokens}
     except Exception as e:
         logger.error("consent_active.fetch_failed: %s", e)
-        raise HTTPException(status_code=500, detail="Failed to fetch active consents")
+        raise HTTPException(status_code=500, detail="Failed to fetch active consents") from e
 
 
 @router.get("/user/lookup")
@@ -353,4 +353,4 @@ async def lookup_user(
 
     except Exception as e:
         logger.error("user_lookup.error: %s", e)
-        raise HTTPException(status_code=500, detail="Failed to look up user")
+        raise HTTPException(status_code=500, detail="Failed to look up user") from e

--- a/consent-protocol/api/routes/tickers.py
+++ b/consent-protocol/api/routes/tickers.py
@@ -46,7 +46,7 @@ async def search_tickers(
         return results
     except Exception:
         logger.error("ticker.search.error", exc_info=True)
-        raise HTTPException(status_code=500, detail="Ticker search is temporarily unavailable.")
+        raise HTTPException(status_code=500, detail="Ticker search is temporarily unavailable.") from None
 
 
 @router.get("/all", response_model=List[dict])
@@ -66,7 +66,7 @@ async def all_tickers(refresh: bool = Query(False)):
         return ticker_cache.all()
     except Exception:
         logger.error("ticker.all.error", exc_info=True)
-        raise HTTPException(status_code=500, detail="Ticker listing is temporarily unavailable.")
+        raise HTTPException(status_code=500, detail="Ticker listing is temporarily unavailable.") from None
 
 
 @router.get("/cache-status")
@@ -104,4 +104,4 @@ async def sync_tickers_from_holdings(
         return {"success": True, **result}
     except Exception:
         logger.error("ticker.sync_holdings.error user_id=%s", user_id, exc_info=True)
-        raise HTTPException(status_code=500, detail="Ticker sync is temporarily unavailable.")
+        raise HTTPException(status_code=500, detail="Ticker sync is temporarily unavailable.") from None

--- a/consent-protocol/hushh_mcp/agents/kai/orchestrator.py
+++ b/consent-protocol/hushh_mcp/agents/kai/orchestrator.py
@@ -144,7 +144,7 @@ class KaiOrchestrator(HushhAgent):
 
         except asyncio.TimeoutError:
             logger.error(f"[Kai] Analysis timeout for {ticker}")
-            raise TimeoutError(f"Analysis exceeded {ANALYSIS_TIMEOUT}s timeout")
+            raise TimeoutError(f"Analysis exceeded {ANALYSIS_TIMEOUT}s timeout") from None
         except Exception as e:
             logger.error(f"[Kai] Analysis failed for {ticker}: {e}")
             raise

--- a/consent-protocol/hushh_mcp/operons/kai/storage.py
+++ b/consent-protocol/hushh_mcp/operons/kai/storage.py
@@ -131,7 +131,7 @@ def retrieve_decision_card(
         return decision_card
     except Exception as e:
         logger.error("[Storage Operon] decryption_failed")
-        raise ValueError(f"Failed to decrypt decision card: {e}")
+        raise ValueError(f"Failed to decrypt decision card: {e}") from e
 
 
 # ============================================================================

--- a/consent-protocol/hushh_mcp/services/one_email_kyc_service.py
+++ b/consent-protocol/hushh_mcp/services/one_email_kyc_service.py
@@ -524,7 +524,7 @@ def _decode_workflow_cursor(cursor: str | None) -> tuple[str, str] | None:
             "Email request cursor is invalid.",
             status_code=400,
             code="ONE_KYC_CURSOR_INVALID",
-        )
+        ) from None
     created_at = _clean_text(payload.get("created_at") if isinstance(payload, dict) else None)
     workflow_id = _clean_text(payload.get("workflow_id") if isinstance(payload, dict) else None)
     if not created_at or not workflow_id:

--- a/consent-protocol/hushh_mcp/services/portfolio_import_service.py
+++ b/consent-protocol/hushh_mcp/services/portfolio_import_service.py
@@ -2149,7 +2149,7 @@ Statement text (first 12000 chars):
 
             except Exception as e:
                 logger.error(f"Vertex AI init failed: {e}")
-                raise ValueError(f"Could not initialize Gemini client: {e}")
+                raise ValueError(f"Could not initialize Gemini client: {e}") from e
 
         # Encode PDF as base64
         pdf_base64 = base64.b64encode(pdf_bytes).decode("utf-8")

--- a/consent-protocol/hushh_mcp/vault/encrypt.py
+++ b/consent-protocol/hushh_mcp/vault/encrypt.py
@@ -25,7 +25,7 @@ def validate_key_hex(key_hex: str) -> None:
     try:
         bytes.fromhex(key_hex)
     except ValueError:
-        raise ValueError("AES-256 key must be valid hexadecimal")
+        raise ValueError("AES-256 key must be valid hexadecimal") from None
 
 
 def encrypt_data(plaintext: str, key_hex: str) -> EncryptedPayload:
@@ -49,7 +49,7 @@ def encrypt_data(plaintext: str, key_hex: str) -> EncryptedPayload:
             algorithm=ALGORITHM_NAME,
         )
     except Exception as e:
-        raise RuntimeError(f"Encryption failed: {str(e)}")
+        raise RuntimeError(f"Encryption failed: {str(e)}") from e
 
 
 # ==================== Decrypt ====================
@@ -71,6 +71,6 @@ def decrypt_data(payload: EncryptedPayload, key_hex: str) -> str:
         return decrypted.decode("utf-8")
 
     except InvalidTag:
-        raise ValueError("Decryption failed: Invalid authentication tag. Possible tampering.")
+        raise ValueError("Decryption failed: Invalid authentication tag. Possible tampering.") from None
     except Exception as e:
-        raise RuntimeError(f"Decryption failed: {str(e)}")
+        raise RuntimeError(f"Decryption failed: {str(e)}") from e

--- a/consent-protocol/hussh_sdk/agent.py
+++ b/consent-protocol/hussh_sdk/agent.py
@@ -221,7 +221,7 @@ class HusshAgent:
                         "data": {"domain": domain, "grant_id": grant_id},
                     }
                 )
-                raise ConsentRevokedError(domain)
+                raise ConsentRevokedError(domain) from error
             raise
         context = context_response.get("context", {}).get(domain)
         if context is None:

--- a/consent-protocol/tests/test_b904_exception_chaining.py
+++ b/consent-protocol/tests/test_b904_exception_chaining.py
@@ -1,0 +1,87 @@
+"""
+Regression tests for B904 — `raise` inside `except` clause without `from`.
+
+Attach point: api/, hushh_mcp/, hussh_sdk/ — raise statements inside except
+blocks were missing `from err` / `from None`, which hides the original exception
+context and makes tracebacks misleading (the implicit __context__ chain is set but
+the intent is ambiguous; `__cause__` is left unset).
+
+Each parametrised case AST-walks the source file and asserts that no `raise`
+statement inside an `except` handler is missing an explicit `cause`.
+"""
+
+import ast
+import pathlib
+import textwrap
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+
+
+def _raise_without_cause(path: pathlib.Path) -> list[int]:
+    """Return line numbers of bare raises inside except handlers that lack 'from'."""
+    source = path.read_text()
+    tree = ast.parse(source, filename=str(path))
+
+    violations = []
+
+    class Visitor(ast.NodeVisitor):
+        def __init__(self):
+            self._in_handler = 0
+
+        def visit_ExceptHandler(self, node):
+            self._in_handler += 1
+            self.generic_visit(node)
+            self._in_handler -= 1
+
+        def visit_Raise(self, node):
+            if self._in_handler and node.exc is not None and node.cause is None:
+                violations.append(node.lineno)
+            self.generic_visit(node)
+
+    Visitor().visit(tree)
+    return violations
+
+
+FILES = [
+    "api/middleware.py",
+    "api/routes/agents.py",
+    "api/routes/consent.py",
+    "api/routes/crd_scraper.py",
+    "api/routes/db_proxy.py",
+    "api/routes/health.py",
+    "api/routes/investors.py",
+    "api/routes/kai/analyze.py",
+    "api/routes/kai/chat.py",
+    "api/routes/kai/consent.py",
+    "api/routes/kai/voice.py",
+    "api/routes/notifications.py",
+    "api/routes/pkm_routes_shared.py",
+    "api/routes/session.py",
+    "api/routes/tickers.py",
+    "hushh_mcp/agents/kai/orchestrator.py",
+    "hushh_mcp/operons/kai/storage.py",
+    "hushh_mcp/services/one_email_kyc_service.py",
+    "hushh_mcp/services/portfolio_import_service.py",
+    "hushh_mcp/vault/encrypt.py",
+    "hussh_sdk/agent.py",
+]
+
+
+@pytest.mark.parametrize("rel_path", FILES)
+def test_no_bare_raise_in_except(rel_path):
+    path = REPO_ROOT / rel_path
+    violations = _raise_without_cause(path)
+    assert violations == [], (
+        f"{rel_path} still has bare raises inside except handlers at lines: "
+        + ", ".join(str(n) for n in violations)
+        + "\n"
+        + textwrap.dedent(
+            """
+            Fix: append ' from e' (or ' from None') to each raise:
+                except SomeError as e:
+                    raise HTTPException(...) from e   # <-- add 'from e'
+            """
+        )
+    )


### PR DESCRIPTION
## Summary

59 `raise` statements across 21 files inside `except` handlers had no explicit cause, leaving `__cause__` unset. Python sets `__context__` implicitly, but an unset `__cause__` signals the chaining is accidental rather than intentional, which makes tracebacks misleading for debuggers and log aggregators (ruff B904).

```python
# Before
except SomeError as e:
    raise HTTPException(...)

# After
except SomeError as e:
    raise HTTPException(...) from e
```

Bare `except:` / `except Exception:` blocks where the original PR intentionally suppresses internals (e.g. token-minting failures) use `from None` instead, preserving the existing opaque-error behavior while still marking the chain as deliberate.

## Maintainer Feedback Addressed

The automated review repeated generic blockers (`direct_chain_of_thought_persistence`, `backend_contract_without_caller_change`, `existing_capability_overlap_requires_review`) with no line-level detail. Since the branch had drifted 459 files behind `integration/pr-train`, including a prior conflict-resolution merge that pulled in a large amount of unrelated reverted work, I rebuilt the branch clean from the current base instead of resolving the conflict in place:

- Dropped all unrelated reverted content (deleted services, reverted migrations, reverted CWE fixes) that had entered the branch through merge history.
- Dropped three commits that had been added in a previous pass to chase unrelated CI failures (Kai stream/voice input bounds, chat request field bounds with a Gemini-error sentinel fix, and a stream inactivity-timeout restoration). All three production fixes are already on `integration/pr-train` via other merged work, so re-adding them here would mix unrelated files into a PR scoped for exception chaining.
- Re-scanned with `ruff check --select B904` against the current base: the true count is 59 sites across 21 files (the original description said 52/18; `api/routes/crd_scraper.py`, `hushh_mcp/services/one_email_kyc_service.py`, and `hussh_sdk/agent.py` gained new violations since the PR was opened).
- Fixed every site, verifying the chained variable resolves to the correct enclosing exception, including multi-line `raise(...)` calls and a nested try/except inside an except handler.

## How to Verify

```bash
cd consent-protocol
uv run ruff check --select B904 .
uv run pytest tests/test_b904_exception_chaining.py -v
uv run pytest $(grep -v '^#' scripts/test-ci.manifest.txt | grep -v '^$')
```

## Checklist

- [x] Rebuilt clean from current `integration/pr-train`, no merge conflicts
- [x] `ruff check --select B904 .`: 0 violations (was 59 across 21 files)
- [x] `tests/test_b904_exception_chaining.py`: 21/21 passing
- [x] Full backend-check manifest: 264/264 passing, no regressions
- [x] Ruff and mypy clean on every touched file
- [x] No unrelated files touched
- [x] CI green
