### PR TITLE
Add Gemini Agent chat memory flow

### DIFF
--- a/consent-protocol/api/middleware.py
+++ b/consent-protocol/api/middleware.py
@@ -7,7 +7,7 @@ Provides reusable dependency functions for route protection:
 """
 
 import logging
-from typing import Optional, cast
+from typing import Any, Optional, cast
 
 from fastapi import BackgroundTasks, Header, HTTPException, Request, status
 from fastapi.concurrency import run_in_threadpool
@@ -33,7 +33,7 @@ def _auth_error(detail: str) -> HTTPException:
 
 
 def _extract_token(
-    value: Optional[str],
+    value: Optional[str] | Any,
     *,
     allow_raw: bool = False,
     missing_detail: str = "Missing Authorization header",
@@ -42,7 +42,7 @@ def _extract_token(
     Centralized token extraction. Forces strict 'Bearer ' compliance by default,
     but allows raw JWTs for custom headers when explicitly requested.
     """
-    if not value or not value.strip():
+    if not isinstance(value, str) or not value.strip():
         raise _auth_error(missing_detail)
 
     stripped = value.strip()
@@ -59,7 +59,14 @@ def _extract_token(
 
 
 def _token_data_dict(token: str, token_obj) -> dict:
-    scope_value = token_obj.scope_str if token_obj.scope_str else token_obj.scope.value
+    raw_scope = getattr(token_obj, "scope", "")
+    scope_value = (
+        token_obj.scope_str
+        if getattr(token_obj, "scope_str", None)
+        else raw_scope.value
+        if hasattr(raw_scope, "value")
+        else str(raw_scope)
+    )
     return {
         "user_id": token_obj.user_id,
         "agent_id": token_obj.agent_id,
@@ -197,7 +204,9 @@ async def require_vault_owner_token(
         HTTPException 401 if token is missing or invalid
         HTTPException 403 if token scope is insufficient
     """
-    header_value = hushh_consent if hushh_consent is not None else authorization
+    header_value = (
+        hushh_consent if isinstance(hushh_consent, str) and hushh_consent.strip() else authorization
+    )
 
     # Explicitly allow raw tokens here to support the custom X-Hushh-Consent header
     token = _extract_token(

--- a/consent-protocol/api/routes/account.py
+++ b/consent-protocol/api/routes/account.py
@@ -113,10 +113,7 @@ def _configured_uat_phone_test_numbers() -> set[str]:
         return set()
     return {
         normalized
-        for normalized in (
-            _normalize_phone_number(part)
-            for part in re.split(r"[,;\n]+", raw)
-        )
+        for normalized in (_normalize_phone_number(part) for part in re.split(r"[,;\n]+", raw))
         if normalized
     }
 

--- a/consent-protocol/api/routes/consent.py
+++ b/consent-protocol/api/routes/consent.py
@@ -55,6 +55,29 @@ _CONSENT_STORAGE_ERROR_PATTERNS = (
 _CONNECTOR_WRAPPING_ALG = "X25519-AES256-GCM"
 
 
+async def _owned_consent_identifiers(user_id: str) -> list[str]:
+    try:
+        identifiers = await ActorIdentityService().list_account_identifiers(user_id)
+    except Exception as exc:
+        logger.debug(
+            "consent.identifier_expansion_skipped user_id=%s error=%s",
+            user_id,
+            exc,
+        )
+        identifiers = []
+    return identifiers or [user_id]
+
+
+def _identifier_filter_kwargs(user_id: str, identifiers: list[str]) -> dict[str, list[str]]:
+    normalized_user_id = str(user_id or "").strip()
+    normalized_identifiers = [
+        str(item or "").strip() for item in identifiers if str(item or "").strip()
+    ]
+    if set(normalized_identifiers) <= {normalized_user_id}:
+        return {}
+    return {"user_ids": normalized_identifiers}
+
+
 def _clean_text(value: object | None) -> str:
     return str(value or "").strip()
 
@@ -277,7 +300,11 @@ async def get_pending_consents(
 
     service = ConsentDBService()
     try:
-        pending_from_db = await service.get_pending_requests(userId)
+        owned_identifiers = await _owned_consent_identifiers(userId)
+        pending_from_db = await service.get_pending_requests(
+            userId,
+            **_identifier_filter_kwargs(userId, owned_identifiers),
+        )
         pending_from_db = await _hydrate_pending_requester_labels(pending_from_db)
         logger.info("consent.pending_fetched count=%s", len(pending_from_db))
         return {"pending": pending_from_db}
@@ -301,11 +328,13 @@ async def mark_pending_consent_opened(
         raise HTTPException(status_code=403, detail="User ID does not match authenticated user")
 
     service = ConsentDBService()
+    owned_identifiers = await _owned_consent_identifiers(body.userId)
     opened = await service.mark_pending_request_opened(
         user_id=body.userId,
         request_id=body.requestId,
         bundle_id=body.bundleId,
         opened_via=body.openedVia,
+        **_identifier_filter_kwargs(body.userId, owned_identifiers),
     )
     if opened is None:
         return {"ok": True, "acknowledged": False}
@@ -436,10 +465,16 @@ async def approve_consent(
 
     # Get pending request from database
     service = ConsentDBService()
-    pending_request = await service.get_pending_by_request_id(userId, requestId)
+    owned_identifiers = await _owned_consent_identifiers(userId)
+    pending_request = await service.get_pending_by_request_id(
+        userId,
+        requestId,
+        **_identifier_filter_kwargs(userId, owned_identifiers),
+    )
 
     if not pending_request:
         raise HTTPException(status_code=404, detail="Consent request not found")
+    subject_user_id = str(pending_request.get("user_id") or userId).strip() or userId
 
     # Issue consent token - map scope to ConsentScope enum using centralized resolver
     requested_scope = pending_request["scope"]
@@ -480,6 +515,7 @@ async def approve_consent(
         userId,
         agent_id=pending_request["developer"],
         requested_scope=requested_scope,
+        **_identifier_filter_kwargs(userId, owned_identifiers),
     )
     if existing_token and is_developer_request:
         existing_export = await service.get_consent_export_metadata(
@@ -533,6 +569,18 @@ async def approve_consent(
 
         reuse_metadata = dict(metadata) if isinstance(metadata, dict) else {}
         reuse_metadata["reused_consent_token"] = True
+        if subject_user_id != userId:
+            await service.insert_event(
+                user_id=subject_user_id,
+                agent_id=pending_request["developer"],
+                scope=requested_scope,
+                action="CONSENT_GRANTED",
+                token_id=existing_token.get("token_id"),
+                request_id=requestId,
+                scope_description=get_scope_description(requested_scope),
+                expires_at=existing_token.get("expires_at"),
+                metadata=reuse_metadata,
+            )
         await service.insert_event(
             user_id=userId,
             agent_id=pending_request["developer"],
@@ -660,6 +708,17 @@ async def approve_consent(
     granted_event_metadata = dict(metadata) if isinstance(metadata, dict) else {}
 
     # Log CONSENT_GRANTED with the normalized requested scope string.
+    if subject_user_id != userId:
+        await service.insert_event(
+            user_id=subject_user_id,
+            agent_id=pending_request["developer"],
+            scope=requested_scope,
+            action="CONSENT_GRANTED",
+            token_id=token.token,
+            request_id=requestId,
+            expires_at=token.expires_at,
+            metadata=granted_event_metadata,
+        )
     await service.insert_event(
         user_id=userId,
         agent_id=pending_request["developer"],
@@ -677,6 +736,7 @@ async def approve_consent(
         userId,
         agent_id=pending_request["developer"],
         requested_scope=requested_scope,
+        **_identifier_filter_kwargs(userId, owned_identifiers),
     )
     for index, superseded_token in enumerate(superseded_tokens):
         superseded_scope = str(superseded_token.get("scope") or "").strip()
@@ -695,7 +755,7 @@ async def approve_consent(
             "superseded_by_token_id": token.token,
         }
         await service.insert_event(
-            user_id=userId,
+            user_id=str(superseded_token.get("user_id") or subject_user_id),
             agent_id=pending_request["developer"],
             scope=superseded_scope,
             action="REVOKED",
@@ -751,10 +811,16 @@ async def deny_consent(
 
     # Get pending request from database
     service = ConsentDBService()
-    pending_request = await service.get_pending_by_request_id(userId, requestId)
+    owned_identifiers = await _owned_consent_identifiers(userId)
+    pending_request = await service.get_pending_by_request_id(
+        userId,
+        requestId,
+        **_identifier_filter_kwargs(userId, owned_identifiers),
+    )
 
     if not pending_request:
         raise HTTPException(status_code=404, detail="Consent request not found")
+    subject_user_id = str(pending_request.get("user_id") or userId).strip() or userId
 
     metadata = pending_request.get("metadata", {})
     developer_label = (
@@ -763,7 +829,7 @@ async def deny_consent(
 
     # Log CONSENT_DENIED to database
     await service.insert_event(
-        user_id=userId,
+        user_id=subject_user_id,
         agent_id=pending_request["developer"],
         scope=pending_request["scope"],
         action="CONSENT_DENIED",
@@ -802,12 +868,20 @@ async def cancel_consent(
     logger.info("consent.cancel_requested")
 
     service = ConsentDBService()
-    pending_request = await service.get_pending_by_request_id(payload.userId, payload.requestId)
+    owned_identifiers = await _owned_consent_identifiers(payload.userId)
+    pending_request = await service.get_pending_by_request_id(
+        payload.userId,
+        payload.requestId,
+        **_identifier_filter_kwargs(payload.userId, owned_identifiers),
+    )
     if not pending_request:
         raise HTTPException(status_code=404, detail="Consent request not found")
+    subject_user_id = (
+        str(pending_request.get("user_id") or payload.userId).strip() or payload.userId
+    )
 
     await service.insert_event(
-        user_id=payload.userId,
+        user_id=subject_user_id,
         agent_id=pending_request["developer"],
         scope=pending_request["scope"],
         action="CANCELLED",
@@ -1085,7 +1159,11 @@ async def revoke_consent(
 
         # Get the active token for this scope from the correct ledger.
         service = ConsentDBService()
-        active_tokens = await service.get_active_tokens(userId)
+        owned_identifiers = await _owned_consent_identifiers(userId)
+        active_tokens = await service.get_active_tokens(
+            userId,
+            **_identifier_filter_kwargs(userId, owned_identifiers),
+        )
         internal_tokens = await service.get_active_internal_tokens(userId)
         all_active_tokens = [*internal_tokens, *active_tokens]
         logger.info("consent.revoke_active_token_count=%s", len(all_active_tokens))
@@ -1125,8 +1203,9 @@ async def revoke_consent(
         logger.info("consent.revoke_persist_event")
 
         # Log REVOKED event to database (link to original request_id for trail)
+        subject_user_id = str(token_to_revoke.get("user_id") or userId).strip() or userId
         await service.insert_event(
-            user_id=userId,
+            user_id=subject_user_id,
             agent_id=agent_id,
             scope=scope,
             action="REVOKED",

--- a/consent-protocol/api/routes/kai/agent_chat.py
+++ b/consent-protocol/api/routes/kai/agent_chat.py
@@ -29,6 +29,11 @@ class AgentChatStreamRequest(BaseModel):
     user_id: str = Field(..., min_length=1)
     message: str = Field(..., min_length=1, max_length=8000)
     conversation_id: Optional[str] = None
+    pkm_context: Optional[str] = Field(default=None, max_length=6000)
+
+
+class AgentChatRenameRequest(BaseModel):
+    title: str = Field(..., min_length=1, max_length=160)
 
 
 class AgentChatConversationModel(BaseModel):
@@ -61,6 +66,11 @@ class AgentChatConversationsResponse(BaseModel):
 class AgentChatHistoryResponse(BaseModel):
     conversation_id: str
     messages: list[AgentChatMessageModel]
+
+
+class AgentChatDeleteResponse(BaseModel):
+    conversation_id: str
+    deleted: bool
 
 
 def _event(event: str, data: dict[str, Any]) -> str:
@@ -110,13 +120,16 @@ async def _save_assistant_message(
     status_value: Literal["complete", "interrupted", "error"],
     error_code: str | None = None,
 ) -> None:
-    if not text.strip():
+    message_text = text.strip()
+    if not message_text and status_value == "error":
+        message_text = "Agent chat failed. Please try again."
+    if not message_text:
         return
     await service.add_message(
         conversation_id=turn.conversation_id,
         user_id=user_id,
         role="assistant",
-        content=text,
+        content=message_text,
         status=status_value,
         model=turn.model,
         error_code=error_code,
@@ -139,7 +152,11 @@ async def stream_agent_chat(
             message=body.message,
             conversation_id=body.conversation_id,
         )
-        action_plan: AgentChatActionPlan | None = service.plan_action(body.message)
+        action_plan: AgentChatActionPlan | None = await service.plan_action_with_gemini(
+            user_message=body.message,
+            history=turn.history,
+            pkm_context=body.pkm_context,
+        )
     except Exception as error:
         logger.exception("agent_chat.prepare_failed user_id=%s: %s", body.user_id, error)
         raise HTTPException(status_code=500, detail="Agent chat could not be started") from error
@@ -179,6 +196,7 @@ async def stream_agent_chat(
                 user_message=body.message,
                 history=turn.history,
                 action_plan=action_plan,
+                pkm_context=body.pkm_context,
             ):
                 if await request.is_disconnected():
                     text = "".join(chunks)
@@ -263,6 +281,43 @@ async def list_agent_chat_conversations(
         user_id=user_id,
         conversations=[_conversation_model(conversation) for conversation in conversations],
     )
+
+
+@router.patch(
+    "/agent/chat/conversations/{conversation_id}", response_model=AgentChatConversationModel
+)
+async def rename_agent_chat_conversation(
+    conversation_id: str,
+    body: AgentChatRenameRequest,
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    user_id = str(token_data.get("user_id") or "")
+    conversation = await get_agent_chat_service().rename_conversation(
+        conversation_id,
+        user_id=user_id,
+        title=body.title,
+    )
+    if conversation is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Conversation not found")
+    return _conversation_model(conversation)
+
+
+@router.delete(
+    "/agent/chat/conversations/{conversation_id}",
+    response_model=AgentChatDeleteResponse,
+)
+async def delete_agent_chat_conversation(
+    conversation_id: str,
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    user_id = str(token_data.get("user_id") or "")
+    deleted = await get_agent_chat_service().delete_conversation(
+        conversation_id,
+        user_id=user_id,
+    )
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Conversation not found")
+    return AgentChatDeleteResponse(conversation_id=conversation_id, deleted=True)
 
 
 @router.get("/agent/chat/history/{conversation_id}", response_model=AgentChatHistoryResponse)

--- a/consent-protocol/api/routes/kai/location.py
+++ b/consent-protocol/api/routes/kai/location.py
@@ -72,19 +72,28 @@ def _extract_bearer_token(authorization: str | None) -> str:
     if not authorization:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail={"code": "LOCATION_UPDATE_TOKEN_MISSING", "message": "Missing Authorization header."},
+            detail={
+                "code": "LOCATION_UPDATE_TOKEN_MISSING",
+                "message": "Missing Authorization header.",
+            },
         )
     stripped = authorization.strip()
     if not stripped.lower().startswith("bearer "):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail={"code": "LOCATION_UPDATE_TOKEN_INVALID", "message": "Expected Bearer location update token."},
+            detail={
+                "code": "LOCATION_UPDATE_TOKEN_INVALID",
+                "message": "Expected Bearer location update token.",
+            },
         )
     token = stripped[7:].strip()
     if not token:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail={"code": "LOCATION_UPDATE_TOKEN_MISSING", "message": "Missing location update token."},
+            detail={
+                "code": "LOCATION_UPDATE_TOKEN_MISSING",
+                "message": "Missing location update token.",
+            },
         )
     return token
 

--- a/consent-protocol/hushh_mcp/services/actor_identity_service.py
+++ b/consent-protocol/hushh_mcp/services/actor_identity_service.py
@@ -569,6 +569,46 @@ class ActorIdentityService:
             return []
         return [self._normalize_alias_row(row) for row in rows]
 
+    async def list_account_identifiers(self, user_id: str) -> list[str]:
+        """
+        Return identifiers that are verified or first-party known for this account.
+
+        Consent review surfaces authenticate the user by Firebase UID, but external
+        developer requests can arrive keyed by a Firebase email/phone or a verified
+        alias. Keep this set conservative: only the UID, verified Firebase-auth
+        shadow values, and verified account-owned email aliases are accepted.
+        """
+        normalized_user_id = str(user_id or "").strip()
+        if not normalized_user_id:
+            return []
+
+        identifiers: list[str] = [normalized_user_id]
+
+        def _append(value: Any, *, email: bool = False) -> None:
+            normalized = str(value or "").strip()
+            if email:
+                normalized = normalized.lower()
+            if normalized and normalized not in identifiers:
+                identifiers.append(normalized)
+
+        identity = await self.sync_from_firebase(normalized_user_id)
+        if not identity:
+            identity = (await self.get_many([normalized_user_id])).get(normalized_user_id) or {}
+
+        if identity.get("email_verified"):
+            _append(identity.get("email"), email=True)
+        if identity.get("phone_verified"):
+            _append(identity.get("phone_number"))
+
+        for alias in await self.list_verified_email_aliases(normalized_user_id):
+            if str(alias.get("verification_status") or "").strip().lower() != "verified":
+                continue
+            if alias.get("revoked_at") is not None:
+                continue
+            _append(alias.get("email_normalized") or alias.get("email"), email=True)
+
+        return identifiers
+
     async def request_email_alias_verification(
         self,
         *,

--- a/consent-protocol/hushh_mcp/services/agent_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/agent_chat_service.py
@@ -27,11 +27,37 @@ AGENT_SYSTEM_PROMPT = """You are Agent, the Kai-focused financial assistant insi
 
 Current capability boundary:
 - Focus on markets, portfolio context, stock analysis, Kai workflows, consent/privacy surfaces, and how the Hussh app works.
+- Use the provided PKM compact context when it is relevant, especially when the user asks what Kai knows about them or shares preferences.
+- Treat PKM compact context as user-owned memory summaries, not as exhaustive truth. Do not invent personal facts outside that context and the current conversation.
 - Normal finance and app questions should be answered as plain streaming text.
 - When the stream includes a planned frontend app action, acknowledge that the app is starting or opening it. Do not claim destructive account changes, trades, approvals, revocations, or data deletion.
 - Destructive, account-changing, trading, approval, revocation, and manual-only actions must be blocked and explained safely.
 - Keep answers concise, practical, and clear. Financial answers are educational, not personalized investment advice.
 """
+
+AGENT_ACTION_PLANNER_PROMPT = """You are Agent's action router inside Hussh.
+
+Decide whether the latest user message needs a frontend app function.
+
+Call exactly one function only when the user clearly asks Agent to do one of these:
+- start stock analysis for a ticker or public company
+- open a Hussh/Kai app surface
+- perform a destructive, account-changing, consent approval/revocation, trading, or manual-only action that must be blocked
+
+Do not call a function for normal finance questions, explanations, brainstorming, or general chat.
+When unsure, do not call a function.
+"""
+
+_APP_SURFACE_ACTIONS: dict[str, tuple[str, str]] = {
+    "consent_center": ("route.consents", "Open Consent Center"),
+    "pkm": ("route.profile_pkm_agent_lab", "Open PKM"),
+    "profile": ("route.profile", "Open Profile"),
+    "portfolio_import": ("route.kai_import", "Open Portfolio Import"),
+    "portfolio_dashboard": ("route.kai_dashboard", "Open Portfolio Dashboard"),
+    "analysis_history": ("route.analysis_history", "Open Analysis History"),
+    "optimize": ("route.kai_optimize", "Open Optimize Surface"),
+    "market_home": ("route.kai_home", "Open Market Home"),
+}
 
 MessageRole = Literal["user", "assistant", "system", "tool"]
 MessageStatus = Literal["complete", "interrupted", "error"]
@@ -77,6 +103,14 @@ _NAVIGATION_ACTION_PATTERNS: list[tuple[re.Pattern[str], str, str]] = [
         ),
         "route.consents",
         "Open Consent Center",
+    ),
+    (
+        re.compile(
+            r"\b(?:open|go to|show|take me to|navigate to)\b.*\b(?:pkm|personal knowledge|memory lab|saved memory|saved memories)\b",
+            re.IGNORECASE,
+        ),
+        "route.profile_pkm_agent_lab",
+        "Open PKM",
     ),
     (
         re.compile(
@@ -259,6 +293,77 @@ def _resolve_ticker(raw: str) -> str | None:
     return None
 
 
+def _schema_string(description: str, *, enum: list[str] | None = None) -> genai_types.Schema:
+    return genai_types.Schema(
+        type=genai_types.Type.STRING,
+        description=description,
+        enum=enum,
+    )
+
+
+def _schema_object(
+    properties: dict[str, genai_types.Schema],
+    *,
+    required: list[str] | None = None,
+) -> genai_types.Schema:
+    return genai_types.Schema(
+        type=genai_types.Type.OBJECT,
+        properties=properties,
+        required=required or [],
+    )
+
+
+def _agent_action_tool() -> genai_types.Tool:
+    return genai_types.Tool(
+        function_declarations=[
+            genai_types.FunctionDeclaration(
+                name="start_stock_analysis",
+                description=(
+                    "Start Kai's frontend stock analysis workflow for a requested ticker "
+                    "or public company."
+                ),
+                parameters=_schema_object(
+                    {
+                        "symbol": _schema_string(
+                            "Ticker symbol if known, for example NVDA or AAPL."
+                        ),
+                        "company": _schema_string(
+                            "Company or asset name if the user gave a name instead of a ticker."
+                        ),
+                    }
+                ),
+            ),
+            genai_types.FunctionDeclaration(
+                name="open_app_surface",
+                description="Open a safe Hussh or Kai frontend surface.",
+                parameters=_schema_object(
+                    {
+                        "surface": _schema_string(
+                            "Frontend surface to open.",
+                            enum=list(_APP_SURFACE_ACTIONS.keys()),
+                        )
+                    },
+                    required=["surface"],
+                ),
+            ),
+            genai_types.FunctionDeclaration(
+                name="block_manual_action",
+                description=(
+                    "Use when the user asks Agent to perform a destructive, account-changing, "
+                    "consent approval/revocation, trading, or manual-only action."
+                ),
+                parameters=_schema_object(
+                    {
+                        "reason": _schema_string(
+                            "Short safe reason explaining why Agent cannot perform the action."
+                        )
+                    }
+                ),
+            ),
+        ]
+    )
+
+
 class AgentChatService:
     """Owns Agent chat LLM streaming and backend-decryptable encrypted history."""
 
@@ -388,6 +493,54 @@ class AgentChatService:
             },
         )
         return self._conversation_from_row((result.data or [])[0])
+
+    async def rename_conversation(
+        self,
+        conversation_id: str,
+        *,
+        user_id: str,
+        title: str,
+    ) -> AgentChatConversation | None:
+        encrypted_title = self._encrypt_text(_trim_title(title))
+        result = await self._execute_raw(
+            """
+            UPDATE agent_chat_conversations
+            SET
+              title_ciphertext = :title_ciphertext,
+              title_iv = :title_iv,
+              title_tag = :title_tag,
+              title_algorithm = :title_algorithm,
+              updated_at = now()
+            WHERE id = :conversation_id AND user_id = :user_id
+            RETURNING *
+            """,
+            {
+                "conversation_id": conversation_id,
+                "user_id": user_id,
+                "title_ciphertext": encrypted_title.ciphertext,
+                "title_iv": encrypted_title.iv,
+                "title_tag": encrypted_title.tag,
+                "title_algorithm": encrypted_title.algorithm,
+            },
+        )
+        rows = result.data or []
+        if not rows:
+            return None
+        return self._conversation_from_row(rows[0])
+
+    async def delete_conversation(self, conversation_id: str, *, user_id: str) -> bool:
+        result = await self._execute_raw(
+            """
+            DELETE FROM agent_chat_conversations
+            WHERE id = :conversation_id AND user_id = :user_id
+            RETURNING id
+            """,
+            {
+                "conversation_id": conversation_id,
+                "user_id": user_id,
+            },
+        )
+        return bool(result.data or [])
 
     async def get_or_create_conversation(
         self,
@@ -563,19 +716,22 @@ class AgentChatService:
         user_message: str,
         history: list[AgentChatMessage],
         action_plan: AgentChatActionPlan | None = None,
+        pkm_context: str | None = None,
     ) -> AsyncGenerator[str, None]:
-        prompt = self._build_prompt(
+        contents = self._build_contents(
             user_message=user_message,
             history=history,
             action_plan=action_plan,
+            pkm_context=pkm_context,
         )
         config = genai_types.GenerateContentConfig(
+            system_instruction=AGENT_SYSTEM_PROMPT,
             temperature=0.7,
             max_output_tokens=4096,
         )
         stream = await self.client.aio.models.generate_content_stream(
             model=self.model,
-            contents=prompt,
+            contents=contents,
             config=config,
         )
         async for chunk in stream:
@@ -583,25 +739,55 @@ class AgentChatService:
             if text:
                 yield text
 
+    async def plan_action_with_gemini(
+        self,
+        *,
+        user_message: str,
+        history: list[AgentChatMessage],
+        pkm_context: str | None = None,
+    ) -> AgentChatActionPlan | None:
+        deterministic_block = self._plan_blocked_action(user_message)
+        if deterministic_block is not None:
+            return deterministic_block
+
+        try:
+            response = await self.client.aio.models.generate_content(
+                model=self.model,
+                contents=self._build_action_planning_contents(
+                    user_message=user_message,
+                    history=history,
+                    pkm_context=pkm_context,
+                ),
+                config=genai_types.GenerateContentConfig(
+                    system_instruction=AGENT_ACTION_PLANNER_PROMPT,
+                    temperature=0.0,
+                    max_output_tokens=256,
+                    tools=[_agent_action_tool()],
+                    automatic_function_calling=genai_types.AutomaticFunctionCallingConfig(
+                        disable=True
+                    ),
+                    tool_config=genai_types.ToolConfig(
+                        function_calling_config=genai_types.FunctionCallingConfig(mode="AUTO")
+                    ),
+                ),
+            )
+            for function_call in self._function_calls_from_response(response):
+                action_plan = self._action_plan_from_function_call(function_call)
+                if action_plan is not None:
+                    return action_plan
+        except Exception:
+            logger.exception("agent_chat.function_planning_failed")
+
+        return self.plan_action(user_message)
+
     def plan_action(self, user_message: str) -> AgentChatActionPlan | None:
         message = " ".join(str(user_message or "").split())
         if not message:
             return None
 
-        for pattern in _BLOCKED_ACTION_PATTERNS:
-            if pattern.search(message):
-                return AgentChatActionPlan(
-                    call_id=_tool_call_id(),
-                    action_id=None,
-                    label="Blocked Manual Action",
-                    execution="blocked",
-                    slots={},
-                    message=(
-                        "I can't perform destructive, account-changing, consent approval, "
-                        "revocation, or trading actions from Agent. Please do that manually."
-                    ),
-                    reason="manual_or_destructive_action",
-                )
+        blocked_action = self._plan_blocked_action(message)
+        if blocked_action is not None:
+            return blocked_action
 
         for pattern in _ANALYSIS_PATTERNS:
             match = pattern.search(message)
@@ -631,20 +817,104 @@ class AgentChatService:
                 )
         return None
 
-    def _build_prompt(
+    def _plan_blocked_action(self, user_message: str) -> AgentChatActionPlan | None:
+        message = " ".join(str(user_message or "").split())
+        for pattern in _BLOCKED_ACTION_PATTERNS:
+            if pattern.search(message):
+                return AgentChatActionPlan(
+                    call_id=_tool_call_id(),
+                    action_id=None,
+                    label="Blocked Manual Action",
+                    execution="blocked",
+                    slots={},
+                    message=(
+                        "I can't perform destructive, account-changing, consent approval, "
+                        "revocation, or trading actions from Agent. Please do that manually."
+                    ),
+                    reason="manual_or_destructive_action",
+                )
+        return None
+
+    def _build_contents(
         self,
         *,
         user_message: str,
         history: list[AgentChatMessage],
         action_plan: AgentChatActionPlan | None = None,
-    ) -> str:
-        history_lines = []
+        pkm_context: str | None = None,
+    ) -> list[genai_types.Content]:
+        contents: list[genai_types.Content] = []
         for message in history[-20:]:
             if message.role not in {"user", "assistant"}:
                 continue
-            role = "User" if message.role == "user" else "Agent"
-            history_lines.append(f"{role}: {message.content[:4000]}")
-        history_text = "\n".join(history_lines) if history_lines else "No prior messages."
+            role = "user" if message.role == "user" else "model"
+            contents.append(
+                genai_types.Content(
+                    role=role,
+                    parts=[genai_types.Part(text=message.content[:4000])],
+                )
+            )
+        contents.append(
+            genai_types.Content(
+                role="user",
+                parts=[
+                    genai_types.Part(
+                        text=(
+                            f"{self._build_turn_context(action_plan=action_plan, pkm_context=pkm_context)}\n\n"
+                            f"Latest user message:\n{user_message}"
+                        )
+                    )
+                ],
+            )
+        )
+        return contents
+
+    def _build_action_planning_contents(
+        self,
+        *,
+        user_message: str,
+        history: list[AgentChatMessage],
+        pkm_context: str | None = None,
+    ) -> list[genai_types.Content]:
+        contents: list[genai_types.Content] = []
+        for message in history[-8:]:
+            if message.role not in {"user", "assistant"}:
+                continue
+            role = "user" if message.role == "user" else "model"
+            contents.append(
+                genai_types.Content(
+                    role=role,
+                    parts=[genai_types.Part(text=message.content[:1500])],
+                )
+            )
+        clean_pkm_context = str(pkm_context or "").strip()
+        planning_context = (
+            clean_pkm_context[:2000]
+            if clean_pkm_context
+            else "No PKM compact context was provided for this turn."
+        )
+        contents.append(
+            genai_types.Content(
+                role="user",
+                parts=[
+                    genai_types.Part(
+                        text=(
+                            "PKM compact context for routing only:\n"
+                            f"{planning_context}\n\n"
+                            f"Latest user message:\n{user_message}"
+                        )
+                    )
+                ],
+            )
+        )
+        return contents
+
+    def _build_turn_context(
+        self,
+        *,
+        action_plan: AgentChatActionPlan | None = None,
+        pkm_context: str | None = None,
+    ) -> str:
         action_context = "No frontend app action is planned for this turn."
         if action_plan and action_plan.execution == "frontend":
             action_context = (
@@ -662,13 +932,80 @@ class AgentChatService:
                 f"- message: {action_plan.message}\n"
                 "Instruction: explain the block clearly and suggest the safe manual path."
             )
-        return (
-            f"{AGENT_SYSTEM_PROMPT}\n\n"
-            f"Conversation history:\n{history_text}\n\n"
-            f"Action context:\n{action_context}\n\n"
-            f"User: {user_message}\n\n"
-            "Agent:"
+        clean_pkm_context = str(pkm_context or "").strip()
+        pkm_context_text = (
+            clean_pkm_context[:6000]
+            if clean_pkm_context
+            else "No PKM compact context was provided for this turn."
         )
+        return f"PKM context:\n{pkm_context_text}\n\nAction context:\n{action_context}"
+
+    def _function_calls_from_response(self, response: Any) -> list[Any]:
+        response_calls = getattr(response, "function_calls", None)
+        if response_calls:
+            return list(response_calls)
+
+        calls: list[Any] = []
+        candidates = getattr(response, "candidates", None) or []
+        for candidate in candidates:
+            content = getattr(candidate, "content", None)
+            for part in getattr(content, "parts", None) or []:
+                function_call = getattr(part, "function_call", None)
+                if function_call is not None:
+                    calls.append(function_call)
+        return calls
+
+    def _action_plan_from_function_call(self, function_call: Any) -> AgentChatActionPlan | None:
+        name = str(getattr(function_call, "name", "") or "").strip()
+        args = dict(getattr(function_call, "args", None) or {})
+        call_id = str(getattr(function_call, "id", "") or "").strip() or _tool_call_id()
+
+        if name == "start_stock_analysis":
+            ticker = _resolve_ticker(
+                str(args.get("symbol") or args.get("company") or args.get("target") or "")
+            )
+            if not ticker:
+                return None
+            return AgentChatActionPlan(
+                call_id=call_id,
+                action_id="analysis.start",
+                label=f"Start analysis for {ticker}",
+                execution="frontend",
+                slots={"symbol": ticker},
+                message=f"Starting Kai analysis for {ticker}.",
+            )
+
+        if name == "open_app_surface":
+            surface = str(args.get("surface") or "").strip()
+            action = _APP_SURFACE_ACTIONS.get(surface)
+            if action is None:
+                return None
+            action_id, label = action
+            return AgentChatActionPlan(
+                call_id=call_id,
+                action_id=action_id,
+                label=label,
+                execution="frontend",
+                slots={},
+                message=f"{label} in the app.",
+            )
+
+        if name == "block_manual_action":
+            reason = str(args.get("reason") or "").strip() or "manual_or_destructive_action"
+            return AgentChatActionPlan(
+                call_id=call_id,
+                action_id=None,
+                label="Blocked Manual Action",
+                execution="blocked",
+                slots={},
+                message=(
+                    "I can't perform destructive, account-changing, consent approval, "
+                    "revocation, or trading actions from Agent. Please do that manually."
+                ),
+                reason=reason[:160],
+            )
+
+        return None
 
     def _chunk_text(self, chunk: Any) -> str:
         text_value = getattr(chunk, "text", None)

--- a/consent-protocol/hushh_mcp/services/consent_center_service.py
+++ b/consent-protocol/hushh_mcp/services/consent_center_service.py
@@ -32,6 +32,7 @@ class ConsentCenterService:
         self._consent_db = ConsentDBService()
         self._identity = ActorIdentityService()
         self._ria = RIAIAMService()
+        self._owned_identifier_cache: dict[str, list[str]] = {}
 
     @staticmethod
     def _metadata(value: Any) -> dict[str, Any]:
@@ -151,6 +152,33 @@ class ConsentCenterService:
             entry.get("status"),
         ]
         return any(needle in str(value or "").lower() for value in haystacks)
+
+    async def _owned_user_identifiers(self, user_id: str) -> list[str]:
+        normalized_user_id = str(user_id or "").strip()
+        if normalized_user_id in self._owned_identifier_cache:
+            return self._owned_identifier_cache[normalized_user_id]
+        try:
+            identifiers = await self._identity.list_account_identifiers(normalized_user_id)
+        except Exception as exc:
+            logger.debug(
+                "consent_center.identifier_expansion_skipped user_id=%s error=%s",
+                normalized_user_id,
+                exc,
+            )
+            identifiers = []
+        resolved = identifiers or [normalized_user_id]
+        self._owned_identifier_cache[normalized_user_id] = resolved
+        return resolved
+
+    @staticmethod
+    def _identifier_filter_kwargs(user_id: str, identifiers: list[str]) -> dict[str, list[str]]:
+        normalized_user_id = str(user_id or "").strip()
+        normalized_identifiers = [
+            str(item or "").strip() for item in identifiers if str(item or "").strip()
+        ]
+        if set(normalized_identifiers) <= {normalized_user_id}:
+            return {}
+        return {"user_ids": normalized_identifiers}
 
     async def _hydrate_entry_identities(
         self, entries: list[dict[str, Any]]
@@ -913,19 +941,33 @@ class ConsentCenterService:
         }
 
     async def _load_investor_pending_entries(self, user_id: str) -> list[dict[str, Any]]:
-        pending = await self._consent_db.get_pending_requests(user_id)
+        identifiers = await self._owned_user_identifiers(user_id)
+        pending = await self._consent_db.get_pending_requests(
+            user_id,
+            **self._identifier_filter_kwargs(user_id, identifiers),
+        )
         return await self._hydrate_entry_identities(
             [self._normalize_pending(item) for item in pending]
         )
 
     async def _load_investor_active_entries(self, user_id: str) -> list[dict[str, Any]]:
-        active = await self._consent_db.get_active_tokens(user_id)
+        identifiers = await self._owned_user_identifiers(user_id)
+        active = await self._consent_db.get_active_tokens(
+            user_id,
+            **self._identifier_filter_kwargs(user_id, identifiers),
+        )
         return await self._hydrate_entry_identities(
             [self._normalize_active(item) for item in active]
         )
 
     async def _load_investor_previous_entries(self, user_id: str) -> list[dict[str, Any]]:
-        history_result = await self._consent_db.get_audit_log(user_id, page=1, limit=5000)
+        identifiers = await self._owned_user_identifiers(user_id)
+        history_result = await self._consent_db.get_audit_log(
+            user_id,
+            page=1,
+            limit=5000,
+            **self._identifier_filter_kwargs(user_id, identifiers),
+        )
         return await self._hydrate_entry_identities(
             [self._normalize_history(item) for item in history_result.get("items", [])]
         )
@@ -1090,10 +1132,30 @@ class ConsentCenterService:
         need_active = include_all or normalized_surface in {None, "active"}
         need_history = include_all or normalized_surface in {None, "previous"}
 
-        pending = await self._consent_db.get_pending_requests(user_id) if need_incoming else []
-        active = await self._consent_db.get_active_tokens(user_id) if need_active else []
+        identifiers = await self._owned_user_identifiers(user_id)
+        pending = (
+            await self._consent_db.get_pending_requests(
+                user_id,
+                **self._identifier_filter_kwargs(user_id, identifiers),
+            )
+            if need_incoming
+            else []
+        )
+        active = (
+            await self._consent_db.get_active_tokens(
+                user_id,
+                **self._identifier_filter_kwargs(user_id, identifiers),
+            )
+            if need_active
+            else []
+        )
         history_result = (
-            await self._consent_db.get_audit_log(user_id, page=1, limit=100)
+            await self._consent_db.get_audit_log(
+                user_id,
+                page=1,
+                limit=100,
+                **self._identifier_filter_kwargs(user_id, identifiers),
+            )
             if need_history
             else {"items": []}
         )

--- a/consent-protocol/hushh_mcp/services/consent_db.py
+++ b/consent-protocol/hushh_mcp/services/consent_db.py
@@ -33,7 +33,7 @@ Usage:
 import json
 import logging
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 from db.db_client import DatabaseExecutionError, get_db
 from hushh_mcp.consent.scope_generator import get_scope_generator
@@ -62,6 +62,32 @@ class ConsentDBService:
     @staticmethod
     def _normalize_agent_id(agent_id: Optional[str]) -> str:
         return str(agent_id or "").strip().lower()
+
+    @staticmethod
+    def _normalize_user_identifiers(
+        primary_user_id: str,
+        user_ids: Iterable[str] | None = None,
+    ) -> list[str]:
+        identifiers: list[str] = []
+        for value in [primary_user_id, *(list(user_ids or []))]:
+            normalized = str(value or "").strip()
+            if "@" in normalized:
+                normalized = normalized.lower()
+            if normalized and normalized not in identifiers:
+                identifiers.append(normalized)
+        return identifiers
+
+    @classmethod
+    def _filter_user_id_query(
+        cls,
+        query: Any,
+        primary_user_id: str,
+        user_ids: Iterable[str] | None = None,
+    ) -> Any:
+        identifiers = cls._normalize_user_identifiers(primary_user_id, user_ids)
+        if len(identifiers) <= 1:
+            return query.eq("user_id", identifiers[0] if identifiers else primary_user_id)
+        return query.in_("user_id", identifiers)
 
     @classmethod
     def _is_internal_event(
@@ -266,6 +292,8 @@ class ConsentDBService:
         is_scope_upgrade = bool(metadata.get("is_scope_upgrade"))
         return {
             "id": row.get("request_id"),
+            "userId": row.get("user_id"),
+            "subjectUserId": row.get("user_id"),
             "developer": row.get("agent_id"),
             "agent_id": row.get("agent_id"),
             "requesterLabel": cls._requester_label(row.get("agent_id"), metadata),
@@ -378,7 +406,12 @@ class ConsentDBService:
     # Pending Requests
     # =========================================================================
 
-    async def get_pending_requests(self, user_id: str) -> List[Dict]:
+    async def get_pending_requests(
+        self,
+        user_id: str,
+        *,
+        user_ids: Iterable[str] | None = None,
+    ) -> List[Dict]:
         """
         Get pending consent requests for a user.
         A request is pending if it has REQUESTED action with no resolution.
@@ -392,13 +425,9 @@ class ConsentDBService:
         # Fetch all relevant rows (we'll filter in Python)
         # Note: Cannot use .neq("request_id", None) - SQL "!= NULL" is always NULL (not true)
         # Instead, fetch all rows and filter request_id IS NOT NULL in Python
-        response = (
-            supabase.table("consent_audit")
-            .select("*")
-            .eq("user_id", user_id)
-            .order("issued_at", desc=True)
-            .execute()
-        )
+        query = supabase.table("consent_audit").select("*")
+        query = self._filter_user_id_query(query, user_id, user_ids)
+        response = query.order("issued_at", desc=True).execute()
 
         # Post-process to get latest per request_id (DISTINCT ON equivalent)
         latest_per_request = {}
@@ -454,18 +483,20 @@ class ConsentDBService:
 
         return results
 
-    async def get_pending_by_request_id(self, user_id: str, request_id: str) -> Optional[Dict]:
+    async def get_pending_by_request_id(
+        self,
+        user_id: str,
+        request_id: str,
+        *,
+        user_ids: Iterable[str] | None = None,
+    ) -> Optional[Dict]:
         """Get a specific pending request by request_id."""
         supabase = self._get_supabase()
 
+        query = supabase.table("consent_audit").select("*")
+        query = self._filter_user_id_query(query, user_id, user_ids)
         response = (
-            supabase.table("consent_audit")
-            .select("*")
-            .eq("user_id", user_id)
-            .eq("request_id", request_id)
-            .order("issued_at", desc=True)
-            .limit(1)
-            .execute()
+            query.eq("request_id", request_id).order("issued_at", desc=True).limit(1).execute()
         )
 
         if response.data and len(response.data) > 0:
@@ -488,6 +519,7 @@ class ConsentDBService:
                 )
                 return {
                     "request_id": pending.get("id"),
+                    "user_id": pending.get("subjectUserId"),
                     "developer": pending.get("developer"),
                     "agent_id": pending.get("agent_id"),
                     "requester_label": pending.get("requesterLabel"),
@@ -516,6 +548,7 @@ class ConsentDBService:
         request_id: str | None = None,
         bundle_id: str | None = None,
         opened_via: str | None = None,
+        user_ids: Iterable[str] | None = None,
     ) -> Dict[str, Any] | None:
         normalized_request_id = str(request_id or "").strip()
         normalized_bundle_id = str(bundle_id or "").strip()
@@ -523,13 +556,9 @@ class ConsentDBService:
             return None
 
         supabase = self._get_supabase()
-        response = (
-            supabase.table("consent_audit")
-            .select("*")
-            .eq("user_id", user_id)
-            .order("issued_at", desc=True)
-            .execute()
-        )
+        query = supabase.table("consent_audit").select("*")
+        query = self._filter_user_id_query(query, user_id, user_ids)
+        response = query.order("issued_at", desc=True).execute()
 
         now_ms = int(datetime.now().timestamp() * 1000)
         matched_row: Dict[str, Any] | None = None
@@ -562,7 +591,7 @@ class ConsentDBService:
         resolved_metadata = self._parse_metadata(matched_row.get("metadata"))
         resolved_bundle_id = str(resolved_metadata.get("bundle_id") or "").strip() or None
         await self.insert_event(
-            user_id=user_id,
+            user_id=str(matched_row.get("user_id") or user_id),
             agent_id="self",
             scope=str(matched_row.get("scope") or ""),
             action="NOTIFICATION_OPENED",
@@ -636,6 +665,7 @@ class ConsentDBService:
         user_id: str,
         agent_id: Optional[str] = None,
         scope: Optional[str] = None,
+        user_ids: Iterable[str] | None = None,
     ) -> List[Dict]:
         """
         Get active consent tokens for a user.
@@ -648,11 +678,10 @@ class ConsentDBService:
         now_ms = int(datetime.now().timestamp() * 1000)
 
         # Fetch all CONSENT_GRANTED and REVOKED actions
+        query = supabase.table("consent_audit").select("*")
+        query = self._filter_user_id_query(query, user_id, user_ids)
         response = (
-            supabase.table("consent_audit")
-            .select("*")
-            .eq("user_id", user_id)
-            .in_("action", ["CONSENT_GRANTED", "REVOKED"])
+            query.in_("action", ["CONSENT_GRANTED", "REVOKED"])
             .order("issued_at", desc=True)
             .execute()
         )
@@ -694,7 +723,7 @@ class ConsentDBService:
                             "id": token_id[:20] + "..."
                             if token_id and len(token_id) > 20
                             else str(row.get("id")),
-                            "user_id": user_id,
+                            "user_id": row.get("user_id") or user_id,
                             "scope": row.get("scope"),
                             "developer": row.get("agent_id"),
                             "agent_id": row.get("agent_id"),
@@ -715,12 +744,14 @@ class ConsentDBService:
         *,
         requested_scope: str,
         agent_id: Optional[str] = None,
+        user_ids: Iterable[str] | None = None,
     ) -> Optional[Dict[str, Any]]:
         """Return the best active token whose granted scope covers the requested scope."""
         covering = await self.get_covering_active_tokens(
             user_id,
             requested_scope=requested_scope,
             agent_id=agent_id,
+            user_ids=user_ids,
         )
         if not covering:
             return None
@@ -732,9 +763,14 @@ class ConsentDBService:
         *,
         requested_scope: str,
         agent_id: Optional[str] = None,
+        user_ids: Iterable[str] | None = None,
     ) -> List[Dict[str, Any]]:
         """Return all active covering tokens ordered by most-specific coverage."""
-        active_tokens = await self.get_active_tokens(user_id, agent_id=agent_id)
+        active_tokens = await self.get_active_tokens(
+            user_id,
+            agent_id=agent_id,
+            user_ids=user_ids,
+        )
         covering = [
             token
             for token in active_tokens
@@ -748,11 +784,16 @@ class ConsentDBService:
         *,
         requested_scope: str,
         agent_id: Optional[str] = None,
+        user_ids: Iterable[str] | None = None,
     ) -> List[Dict[str, Any]]:
         """
         Return active narrower tokens that would be superseded by a newly approved broader scope.
         """
-        active_tokens = await self.get_active_tokens(user_id, agent_id=agent_id)
+        active_tokens = await self.get_active_tokens(
+            user_id,
+            agent_id=agent_id,
+            user_ids=user_ids,
+        )
         superseded = []
         for token in active_tokens:
             granted_scope = str(token.get("scope") or "")
@@ -938,31 +979,28 @@ class ConsentDBService:
     # Audit Log
     # =========================================================================
 
-    async def get_audit_log(self, user_id: str, page: int = 1, limit: int = 50) -> Dict:
+    async def get_audit_log(
+        self,
+        user_id: str,
+        page: int = 1,
+        limit: int = 50,
+        *,
+        user_ids: Iterable[str] | None = None,
+    ) -> Dict:
         """Get paginated audit log for a user."""
         supabase = self._get_supabase()
         offset = (page - 1) * limit
         now_ms = int(datetime.now().timestamp() * 1000)
 
         # Get paginated results (TableQuery uses .limit/.offset, not .range)
-        response = (
-            supabase.table("consent_audit")
-            .select("*")
-            .eq("user_id", user_id)
-            .order("issued_at", desc=True)
-            .limit(limit)
-            .offset(offset)
-            .execute()
-        )
+        query = supabase.table("consent_audit").select("*")
+        query = self._filter_user_id_query(query, user_id, user_ids)
+        response = query.order("issued_at", desc=True).limit(limit).offset(offset).execute()
 
         # Get total count via separate query (capped at 5000 for display)
-        count_response = (
-            supabase.table("consent_audit")
-            .select("id")
-            .eq("user_id", user_id)
-            .limit(5000)
-            .execute()
-        )
+        count_query = supabase.table("consent_audit").select("id,agent_id,action,scope")
+        count_query = self._filter_user_id_query(count_query, user_id, user_ids)
+        count_response = count_query.limit(5000).execute()
         filtered_rows = [row for row in (response.data or []) if self._is_external_audit_row(row)]
         total = len(
             [row for row in (count_response.data or []) if self._is_external_audit_row(row)]

--- a/consent-protocol/hushh_mcp/services/kai_location_service.py
+++ b/consent-protocol/hushh_mcp/services/kai_location_service.py
@@ -113,7 +113,9 @@ def _validate_point(point: dict[str, Any], *, require_fresh: bool) -> dict[str, 
             status_code=422,
         )
 
-    captured_at = _parse_datetime(point.get("captured_at") or point.get("capturedAt"), field_name="captured_at")
+    captured_at = _parse_datetime(
+        point.get("captured_at") or point.get("capturedAt"), field_name="captured_at"
+    )
     if require_fresh and _utcnow() - captured_at > FRESH_FIX_WINDOW:
         raise KaiLocationError(
             "LOCATION_FIX_STALE",
@@ -143,7 +145,9 @@ def _validate_point(point: dict[str, Any], *, require_fresh: bool) -> dict[str, 
     speed_mps = optional_float("speed_mps")
     if speed_mps is None:
         speed_mps = optional_float("speedMps")
-    source_platform = str(point.get("source_platform") or point.get("sourcePlatform") or "web").strip().lower()
+    source_platform = (
+        str(point.get("source_platform") or point.get("sourcePlatform") or "web").strip().lower()
+    )
     if source_platform not in {"web", "ios", "android", "native", "unknown"}:
         source_platform = "unknown"
 
@@ -182,16 +186,22 @@ def _contact_limit(tier: str) -> int:
 
 def _build_request_url(request_id: str) -> str:
     base = (
-        os.getenv("NEXT_PUBLIC_APP_URL")
-        or os.getenv("APP_PUBLIC_URL")
-        or os.getenv("FRONTEND_BASE_URL")
-        or ""
-    ).strip().rstrip("/")
+        (
+            os.getenv("NEXT_PUBLIC_APP_URL")
+            or os.getenv("APP_PUBLIC_URL")
+            or os.getenv("FRONTEND_BASE_URL")
+            or ""
+        )
+        .strip()
+        .rstrip("/")
+    )
     path = f"/kai/location?requestId={request_id}"
     return f"{base}{path}" if base else path
 
 
-def _public_live_payload(*, row: dict[str, Any] | None, latest: dict[str, Any] | None = None) -> dict[str, Any]:
+def _public_live_payload(
+    *, row: dict[str, Any] | None, latest: dict[str, Any] | None = None
+) -> dict[str, Any]:
     server_time = _utcnow()
     share_status = str(row.get("status") or "") if row else "invalid"
     live_mode = bool(row.get("live_mode")) if row else False
@@ -268,7 +278,9 @@ class KaiLocationService:
             "contactId": str(row.get("contact_id") or "") or None,
             "contactDisplayName": str(row.get("contact_display_name") or "") or None,
             "contactTier": str(row.get("contact_tier") or "") or None,
-            "contactAutoApprove": bool(row.get("contact_auto_approve")) if row.get("contact_auto_approve") is not None else None,
+            "contactAutoApprove": bool(row.get("contact_auto_approve"))
+            if row.get("contact_auto_approve") is not None
+            else None,
             "status": str(row.get("status") or "active"),
             "liveMode": bool(row.get("live_mode")),
             "expiresAt": _iso(row.get("expires_at")),
@@ -412,7 +424,9 @@ class KaiLocationService:
         )
         payload = self._latest_payload(row)
         if not payload:
-            raise KaiLocationError("LOCATION_UPDATE_FAILED", "Could not store the latest location.", status_code=500)
+            raise KaiLocationError(
+                "LOCATION_UPDATE_FAILED", "Could not store the latest location.", status_code=500
+            )
         return payload
 
     def create_contact(
@@ -425,10 +439,14 @@ class KaiLocationService:
     ) -> dict[str, Any]:
         normalized_name = str(display_name or "").strip()
         if len(normalized_name) < 1 or len(normalized_name) > 120:
-            raise KaiLocationError("CONTACT_NAME_INVALID", "Recipient name is required.", status_code=422)
+            raise KaiLocationError(
+                "CONTACT_NAME_INVALID", "Recipient name is required.", status_code=422
+            )
         normalized_tier = str(tier or "").strip().lower()
         if normalized_tier not in {"family", "friend"}:
-            raise KaiLocationError("CONTACT_TIER_INVALID", "Recipient tier must be family or friend.", status_code=422)
+            raise KaiLocationError(
+                "CONTACT_TIER_INVALID", "Recipient tier must be family or friend.", status_code=422
+            )
         normalized_auto_approve = bool(auto_approve and normalized_tier == "family")
 
         count_row = self._execute_one(
@@ -468,7 +486,9 @@ class KaiLocationService:
         )
         contact = self._contact_payload(row)
         if not contact:
-            raise KaiLocationError("CONTACT_CREATE_FAILED", "Could not create the recipient.", status_code=500)
+            raise KaiLocationError(
+                "CONTACT_CREATE_FAILED", "Could not create the recipient.", status_code=500
+            )
         self._insert_event(
             owner_user_id=owner_user_id,
             contact_id=contact["id"],
@@ -498,10 +518,16 @@ class KaiLocationService:
         if not existing:
             raise KaiLocationError("CONTACT_NOT_FOUND", "Recipient was not found.", status_code=404)
         tier = str(existing.get("tier") or "friend")
-        next_name = str(display_name if display_name is not None else existing.get("display_name") or "").strip()
+        next_name = str(
+            display_name if display_name is not None else existing.get("display_name") or ""
+        ).strip()
         if len(next_name) < 1 or len(next_name) > 120:
-            raise KaiLocationError("CONTACT_NAME_INVALID", "Recipient name is required.", status_code=422)
-        next_auto = bool(auto_approve) if auto_approve is not None else bool(existing.get("auto_approve"))
+            raise KaiLocationError(
+                "CONTACT_NAME_INVALID", "Recipient name is required.", status_code=422
+            )
+        next_auto = (
+            bool(auto_approve) if auto_approve is not None else bool(existing.get("auto_approve"))
+        )
         if tier != "family":
             next_auto = False
         row = self._execute_one(
@@ -523,7 +549,9 @@ class KaiLocationService:
         )
         contact = self._contact_payload(row)
         if not contact:
-            raise KaiLocationError("CONTACT_UPDATE_FAILED", "Could not update the recipient.", status_code=500)
+            raise KaiLocationError(
+                "CONTACT_UPDATE_FAILED", "Could not update the recipient.", status_code=500
+            )
         self._insert_event(
             owner_user_id=owner_user_id,
             contact_id=contact_id,
@@ -579,7 +607,9 @@ class KaiLocationService:
         self._revoke_update_sessions_if_no_active_shares(owner_user_id)
         contact = self._contact_payload(row)
         if not contact:
-            raise KaiLocationError("CONTACT_REVOKE_FAILED", "Could not revoke the recipient.", status_code=500)
+            raise KaiLocationError(
+                "CONTACT_REVOKE_FAILED", "Could not revoke the recipient.", status_code=500
+            )
         return contact
 
     def list_owner_state(self, *, owner_user_id: str) -> dict[str, Any]:
@@ -651,9 +681,15 @@ class KaiLocationService:
         try:
             duration = float(duration_hours)
         except (TypeError, ValueError) as exc:
-            raise KaiLocationError("SHARE_DURATION_INVALID", "durationHours must be a number.", status_code=422) from exc
+            raise KaiLocationError(
+                "SHARE_DURATION_INVALID", "durationHours must be a number.", status_code=422
+            ) from exc
         if duration <= 0 or duration > MAX_SHARE_HOURS:
-            raise KaiLocationError("SHARE_DURATION_INVALID", "Location links can be active for at most 24 hours.", status_code=422)
+            raise KaiLocationError(
+                "SHARE_DURATION_INVALID",
+                "Location links can be active for at most 24 hours.",
+                status_code=422,
+            )
 
         contact = self._execute_one(
             """
@@ -666,9 +702,15 @@ class KaiLocationService:
             {"owner_user_id": owner_user_id, "contact_id": contact_id},
         )
         if not contact:
-            raise KaiLocationError("CONTACT_NOT_FOUND", "Create an active recipient before sharing location.", status_code=404)
+            raise KaiLocationError(
+                "CONTACT_NOT_FOUND",
+                "Create an active recipient before sharing location.",
+                status_code=404,
+            )
 
-        latest = self.upsert_latest_point(owner_user_id=owner_user_id, point=point, require_fresh=True)
+        latest = self.upsert_latest_point(
+            owner_user_id=owner_user_id, point=point, require_fresh=True
+        )
         token = _new_token()
         row = self._execute_one(
             """
@@ -699,7 +741,9 @@ class KaiLocationService:
         )
         share = self._share_payload(row)
         if not share:
-            raise KaiLocationError("SHARE_CREATE_FAILED", "Could not create the location share.", status_code=500)
+            raise KaiLocationError(
+                "SHARE_CREATE_FAILED", "Could not create the location share.", status_code=500
+            )
         self._insert_event(
             owner_user_id=owner_user_id,
             contact_id=contact_id,
@@ -724,7 +768,9 @@ class KaiLocationService:
             {"owner_user_id": owner_user_id, "share_id": share_id},
         )
         if not row:
-            raise KaiLocationError("SHARE_NOT_FOUND", "Location share was not found.", status_code=404)
+            raise KaiLocationError(
+                "SHARE_NOT_FOUND", "Location share was not found.", status_code=404
+            )
         self._insert_event(
             owner_user_id=owner_user_id,
             contact_id=str(row.get("contact_id") or "") or None,
@@ -735,7 +781,9 @@ class KaiLocationService:
         self._revoke_update_sessions_if_no_active_shares(owner_user_id)
         share = self._share_payload(row)
         if not share:
-            raise KaiLocationError("SHARE_REVOKE_FAILED", "Could not revoke the share.", status_code=500)
+            raise KaiLocationError(
+                "SHARE_REVOKE_FAILED", "Could not revoke the share.", status_code=500
+            )
         return share
 
     def stop_active_shares(self, *, owner_user_id: str) -> dict[str, Any]:
@@ -768,7 +816,13 @@ class KaiLocationService:
     def resolve_public_share(self, *, token: str) -> dict[str, Any]:
         normalized_token = str(token or "").strip()
         if not normalized_token:
-            return {"state": "invalid", "canRequestAccess": False, "share": None, "latest": None, "live": None}
+            return {
+                "state": "invalid",
+                "canRequestAccess": False,
+                "share": None,
+                "latest": None,
+                "live": None,
+            }
         row = self._execute_one(
             """
             SELECT
@@ -785,7 +839,13 @@ class KaiLocationService:
             {"token_hash": _token_hash(normalized_token)},
         )
         if not row:
-            return {"state": "invalid", "canRequestAccess": False, "share": None, "latest": None, "live": None}
+            return {
+                "state": "invalid",
+                "canRequestAccess": False,
+                "share": None,
+                "latest": None,
+                "live": None,
+            }
 
         status_value = str(row.get("status") or "active")
         share_id = str(row.get("id") or "")
@@ -796,8 +856,9 @@ class KaiLocationService:
         is_expired = isinstance(expires_at, datetime) and expires_at <= _utcnow()
 
         if status_value == "active" and is_expired:
-            row = self._execute_one(
-                """
+            row = (
+                self._execute_one(
+                    """
                 UPDATE kai_location_shares
                 SET status = 'deactivated',
                     deactivated_at = COALESCE(deactivated_at, NOW()),
@@ -809,13 +870,15 @@ class KaiLocationService:
                   :contact_tier AS contact_tier,
                   :contact_auto_approve AS contact_auto_approve
                 """,
-                {
-                    "share_id": share_id,
-                    "contact_display_name": row.get("contact_display_name"),
-                    "contact_tier": row.get("contact_tier"),
-                    "contact_auto_approve": row.get("contact_auto_approve"),
-                },
-            ) or row
+                    {
+                        "share_id": share_id,
+                        "contact_display_name": row.get("contact_display_name"),
+                        "contact_tier": row.get("contact_tier"),
+                        "contact_auto_approve": row.get("contact_auto_approve"),
+                    },
+                )
+                or row
+            )
             self._insert_event(
                 owner_user_id=owner_user_id,
                 contact_id=str(row.get("contact_id") or "") or None,
@@ -841,8 +904,9 @@ class KaiLocationService:
                 "live": _public_live_payload(row=row, latest=None),
             }
 
-        updated_row = self._execute_one(
-            """
+        updated_row = (
+            self._execute_one(
+                """
             UPDATE kai_location_shares
             SET last_viewed_at = NOW(), updated_at = NOW()
             WHERE id = CAST(:share_id AS UUID)
@@ -852,13 +916,15 @@ class KaiLocationService:
               :contact_tier AS contact_tier,
               :contact_auto_approve AS contact_auto_approve
             """,
-            {
-                "share_id": share_id,
-                "contact_display_name": row.get("contact_display_name"),
-                "contact_tier": row.get("contact_tier"),
-                "contact_auto_approve": row.get("contact_auto_approve"),
-            },
-        ) or row
+                {
+                    "share_id": share_id,
+                    "contact_display_name": row.get("contact_display_name"),
+                    "contact_tier": row.get("contact_tier"),
+                    "contact_auto_approve": row.get("contact_auto_approve"),
+                },
+            )
+            or row
+        )
         latest = self._execute_one(
             "SELECT * FROM kai_location_latest WHERE owner_user_id = :owner_user_id",
             {"owner_user_id": owner_user_id},
@@ -903,7 +969,9 @@ class KaiLocationService:
             {"token_hash": _token_hash(str(token or "").strip())},
         )
         if not share_row:
-            raise KaiLocationError("SHARE_NOT_FOUND", "This location link is no longer valid.", status_code=404)
+            raise KaiLocationError(
+                "SHARE_NOT_FOUND", "This location link is no longer valid.", status_code=404
+            )
 
         owner_user_id = str(share_row.get("owner_user_id") or "")
         share_id = str(share_row.get("id") or "")
@@ -912,10 +980,16 @@ class KaiLocationService:
         share_status = str(share_row.get("status") or "")
         expires_at = _parse_datetime(share_row.get("expires_at"), field_name="expires_at")
         contact_active = str(share_row.get("contact_status") or "revoked") == "active"
-        auto_approve = bool(share_row.get("contact_auto_approve")) and contact_tier == "family" and contact_active
+        auto_approve = (
+            bool(share_row.get("contact_auto_approve"))
+            and contact_tier == "family"
+            and contact_active
+        )
 
         if share_status == "revoked":
-            raise KaiLocationError("SHARE_REVOKED", "This location link has been revoked.", status_code=410)
+            raise KaiLocationError(
+                "SHARE_REVOKED", "This location link has been revoked.", status_code=410
+            )
         if share_status == "active" and expires_at > _utcnow():
             raise KaiLocationError(
                 "SHARE_STILL_ACTIVE",
@@ -1072,7 +1146,9 @@ class KaiLocationService:
             {"owner_user_id": owner_user_id, "request_id": request_id},
         )
         if not request_row:
-            raise KaiLocationError("ACCESS_REQUEST_NOT_FOUND", "Pending access request was not found.", status_code=404)
+            raise KaiLocationError(
+                "ACCESS_REQUEST_NOT_FOUND", "Pending access request was not found.", status_code=404
+            )
         share_id = str(request_row.get("share_id") or "")
         share_row = self._execute_one(
             """
@@ -1114,7 +1190,10 @@ class KaiLocationService:
             event_type="ACCESS_APPROVED",
             metadata={"duration_hours": 24},
         )
-        return {"accessRequest": self._request_payload(resolved), "share": self._share_payload(share_row)}
+        return {
+            "accessRequest": self._request_payload(resolved),
+            "share": self._share_payload(share_row),
+        }
 
     def deny_access_request(self, *, owner_user_id: str, request_id: str) -> dict[str, Any]:
         resolved = self._execute_one(
@@ -1130,7 +1209,9 @@ class KaiLocationService:
             {"owner_user_id": owner_user_id, "request_id": request_id},
         )
         if not resolved:
-            raise KaiLocationError("ACCESS_REQUEST_NOT_FOUND", "Pending access request was not found.", status_code=404)
+            raise KaiLocationError(
+                "ACCESS_REQUEST_NOT_FOUND", "Pending access request was not found.", status_code=404
+            )
         self._insert_event(
             owner_user_id=owner_user_id,
             contact_id=str(resolved.get("contact_id") or "") or None,
@@ -1187,7 +1268,9 @@ class KaiLocationService:
     def update_with_session(self, *, session_token: str, point: dict[str, Any]) -> dict[str, Any]:
         token = str(session_token or "").strip()
         if not token:
-            raise KaiLocationError("LOCATION_UPDATE_TOKEN_MISSING", "Missing location update token.", status_code=401)
+            raise KaiLocationError(
+                "LOCATION_UPDATE_TOKEN_MISSING", "Missing location update token.", status_code=401
+            )
         session = self._execute_one(
             """
             SELECT *
@@ -1199,7 +1282,9 @@ class KaiLocationService:
             {"session_token_hash": _token_hash(token)},
         )
         if not session:
-            raise KaiLocationError("LOCATION_UPDATE_TOKEN_INVALID", "Invalid location update token.", status_code=401)
+            raise KaiLocationError(
+                "LOCATION_UPDATE_TOKEN_INVALID", "Invalid location update token.", status_code=401
+            )
         owner_user_id = str(session.get("owner_user_id") or "")
         expires_at = session.get("expires_at")
         if isinstance(expires_at, datetime) and expires_at.tzinfo is None:
@@ -1213,7 +1298,9 @@ class KaiLocationService:
                 """,
                 {"session_id": str(session.get("id") or "")},
             )
-            raise KaiLocationError("LOCATION_UPDATE_TOKEN_EXPIRED", "Location update session expired.", status_code=401)
+            raise KaiLocationError(
+                "LOCATION_UPDATE_TOKEN_EXPIRED", "Location update session expired.", status_code=401
+            )
 
         active = self._execute_one(
             """
@@ -1227,9 +1314,13 @@ class KaiLocationService:
         )
         if int(active.get("active_count") or 0) <= 0:
             self._revoke_update_sessions_if_no_active_shares(owner_user_id)
-            raise KaiLocationError("NO_ACTIVE_LOCATION_SHARES", "No active location shares remain.", status_code=403)
+            raise KaiLocationError(
+                "NO_ACTIVE_LOCATION_SHARES", "No active location shares remain.", status_code=403
+            )
 
-        latest = self.upsert_latest_point(owner_user_id=owner_user_id, point=point, require_fresh=False)
+        latest = self.upsert_latest_point(
+            owner_user_id=owner_user_id, point=point, require_fresh=False
+        )
         self._execute_one(
             """
             UPDATE kai_location_update_sessions
@@ -1251,10 +1342,13 @@ class KaiLocationService:
             return
         try:
             db = get_db()
-            rows = db.execute_raw(
-                "SELECT token, platform FROM user_push_tokens WHERE user_id = :user_id",
-                {"user_id": owner_user_id},
-            ).data or []
+            rows = (
+                db.execute_raw(
+                    "SELECT token, platform FROM user_push_tokens WHERE user_id = :user_id",
+                    {"user_id": owner_user_id},
+                ).data
+                or []
+            )
             if not rows:
                 return
             configured, _ = ensure_firebase_admin()
@@ -1293,9 +1387,13 @@ class KaiLocationService:
                 try:
                     messaging.send(message)
                 except (messaging.UnregisteredError, messaging.SenderIdMismatchError):
-                    db.execute_raw("DELETE FROM user_push_tokens WHERE token = :token", {"token": token})
+                    db.execute_raw(
+                        "DELETE FROM user_push_tokens WHERE token = :token", {"token": token}
+                    )
                 except Exception as exc:
-                    logger.warning("Location access FCM send failed user=%s: %s", owner_user_id, exc)
+                    logger.warning(
+                        "Location access FCM send failed user=%s: %s", owner_user_id, exc
+                    )
         except Exception as exc:
             logger.warning("Location access notification skipped user=%s: %s", owner_user_id, exc)
 

--- a/consent-protocol/tests/services/test_actor_identity_service.py
+++ b/consent-protocol/tests/services/test_actor_identity_service.py
@@ -378,6 +378,49 @@ async def test_get_many_tolerates_pre_phone_shadow_schema(
 
 
 @pytest.mark.asyncio
+async def test_list_account_identifiers_uses_verified_account_aliases(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = ActorIdentityService()
+
+    async def fake_sync_from_firebase(user_id: str):
+        assert user_id == "firebase-user-123456789012"
+        return {
+            "email": "Primary@Example.com",
+            "email_verified": True,
+            "phone_number": "+16505550101",
+            "phone_verified": True,
+        }
+
+    async def fake_list_aliases(user_id: str):
+        assert user_id == "firebase-user-123456789012"
+        return [
+            {
+                "email_normalized": "relay@privaterelay.appleid.com",
+                "verification_status": "verified",
+                "revoked_at": None,
+            },
+            {
+                "email_normalized": "pending@example.com",
+                "verification_status": "pending",
+                "revoked_at": None,
+            },
+        ]
+
+    monkeypatch.setattr(service, "sync_from_firebase", fake_sync_from_firebase)
+    monkeypatch.setattr(service, "list_verified_email_aliases", fake_list_aliases)
+
+    identifiers = await service.list_account_identifiers("firebase-user-123456789012")
+
+    assert identifiers == [
+        "firebase-user-123456789012",
+        "primary@example.com",
+        "+16505550101",
+        "relay@privaterelay.appleid.com",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_email_alias_verification_flow_returns_code_only_in_uat_review_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/consent-protocol/tests/services/test_agent_chat_service.py
+++ b/consent-protocol/tests/services/test_agent_chat_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from hushh_mcp.services.agent_chat_service import (
     AGENT_SYSTEM_PROMPT,
     DEFAULT_AGENT_CHAT_MODEL,
@@ -60,7 +62,7 @@ def test_agent_chat_service_decrypts_encrypted_conversation_and_message(test_vau
     assert message.role == "assistant"
 
 
-def test_agent_chat_prompt_is_kai_focused_and_includes_planned_action(test_vault_key):
+def test_agent_chat_contents_use_system_instruction_boundary_and_planned_action(test_vault_key):
     service = AgentChatService(model="gemini-2.5-pro", vault_key_hex=test_vault_key)
     action_plan = service.plan_action("Start analysis of Nvidia")
     assert action_plan is not None
@@ -68,7 +70,7 @@ def test_agent_chat_prompt_is_kai_focused_and_includes_planned_action(test_vault
     assert action_plan.execution == "frontend"
     assert action_plan.slots == {"symbol": "NVDA"}
 
-    prompt = service._build_prompt(
+    contents = service._build_contents(
         user_message="Start analysis of Nvidia",
         history=[
             AgentChatMessage(
@@ -95,16 +97,58 @@ def test_agent_chat_prompt_is_kai_focused_and_includes_planned_action(test_vault
             ),
         ],
         action_plan=action_plan,
+        pkm_context="Saved domains: Financial\n- Financial: prefers long-term portfolio reviews.",
+    )
+    current_turn_text = contents[-1].parts[0].text or ""
+
+    assert "Kai-focused financial assistant" in AGENT_SYSTEM_PROMPT
+    assert contents[0].role == "user"
+    assert contents[0].parts[0].text == "Can you help with stocks?"
+    assert contents[1].role == "model"
+    assert contents[1].parts[0].text == "Yes, I can help with Kai market workflows."
+    assert "Action context:" in current_turn_text
+    assert "PKM context:" in current_turn_text
+    assert "prefers long-term portfolio reviews" in current_turn_text
+    assert "action_id: analysis.start" in current_turn_text
+    assert "slots: {'symbol': 'NVDA'}" in current_turn_text
+    assert "Latest user message:\nStart analysis of Nvidia" in current_turn_text
+    assert AGENT_SYSTEM_PROMPT not in current_turn_text
+
+
+def test_agent_chat_translates_gemini_function_call_to_frontend_analysis(test_vault_key):
+    service = AgentChatService(model="gemini-2.5-pro", vault_key_hex=test_vault_key)
+
+    action_plan = service._action_plan_from_function_call(
+        SimpleNamespace(
+            id="gemini-call-1",
+            name="start_stock_analysis",
+            args={"company": "Nvidia"},
+        )
     )
 
-    assert AGENT_SYSTEM_PROMPT in prompt
-    assert "Kai-focused financial assistant" in prompt
-    assert "User: Can you help with stocks?" in prompt
-    assert "Agent: Yes, I can help with Kai market workflows." in prompt
-    assert "Action context:" in prompt
-    assert "action_id: analysis.start" in prompt
-    assert "slots: {'symbol': 'NVDA'}" in prompt
-    assert "User: Start analysis of Nvidia" in prompt
+    assert action_plan is not None
+    assert action_plan.call_id == "gemini-call-1"
+    assert action_plan.action_id == "analysis.start"
+    assert action_plan.execution == "frontend"
+    assert action_plan.slots == {"symbol": "NVDA"}
+
+
+def test_agent_chat_translates_gemini_function_call_to_frontend_navigation(test_vault_key):
+    service = AgentChatService(model="gemini-2.5-pro", vault_key_hex=test_vault_key)
+
+    action_plan = service._action_plan_from_function_call(
+        SimpleNamespace(
+            id="gemini-call-2",
+            name="open_app_surface",
+            args={"surface": "consent_center"},
+        )
+    )
+
+    assert action_plan is not None
+    assert action_plan.call_id == "gemini-call-2"
+    assert action_plan.action_id == "route.consents"
+    assert action_plan.execution == "frontend"
+    assert action_plan.slots == {}
 
 
 def test_agent_chat_plans_safe_navigation_actions(test_vault_key):
@@ -114,6 +158,17 @@ def test_agent_chat_plans_safe_navigation_actions(test_vault_key):
 
     assert action_plan is not None
     assert action_plan.action_id == "route.consents"
+    assert action_plan.execution == "frontend"
+    assert action_plan.slots == {}
+
+
+def test_agent_chat_plans_pkm_navigation(test_vault_key):
+    service = AgentChatService(model="gemini-2.5-pro", vault_key_hex=test_vault_key)
+
+    action_plan = service.plan_action("Please open my PKM memory lab")
+
+    assert action_plan is not None
+    assert action_plan.action_id == "route.profile_pkm_agent_lab"
     assert action_plan.execution == "frontend"
     assert action_plan.slots == {}
 

--- a/consent-protocol/tests/test_agent_chat_routes.py
+++ b/consent-protocol/tests/test_agent_chat_routes.py
@@ -18,6 +18,8 @@ class _FakeAgentChatService:
         self.next_action_plan: AgentChatActionPlan | None = None
         self.stream_action_plans: list[AgentChatActionPlan | None] = []
         self.stream_tokens = ["Hello", " from Gemini"]
+        self.stream_error: Exception | None = None
+        self.deleted = False
         self.conversation = AgentChatConversation(
             id="conversation-1",
             user_id="user-1",
@@ -71,12 +73,28 @@ class _FakeAgentChatService:
         user_message: str,
         history: list[AgentChatMessage],
         action_plan: AgentChatActionPlan | None = None,
+        pkm_context: str | None = None,
     ):
         assert user_message == "Hello Agent"
         assert history == []
+        assert pkm_context in {None, "Saved domains: Financial"}
         self.stream_action_plans.append(action_plan)
+        if self.stream_error is not None:
+            raise self.stream_error
         for token in self.stream_tokens:
             yield token
+
+    async def plan_action_with_gemini(
+        self,
+        *,
+        user_message: str,
+        history: list[AgentChatMessage],
+        pkm_context: str | None = None,
+    ):
+        assert user_message == "Hello Agent"
+        assert history == []
+        assert pkm_context in {None, "Saved domains: Financial"}
+        return self.next_action_plan
 
     def plan_action(self, message: str):
         assert message == "Hello Agent"
@@ -99,12 +117,25 @@ class _FakeAgentChatService:
     async def list_conversations(self, user_id: str, *, limit: int = 5):
         assert user_id == "user-1"
         assert limit == 1
-        return [self.conversation]
+        return [] if self.deleted else [self.conversation]
 
     async def get_conversation(self, conversation_id: str, *, user_id: str | None = None):
-        if conversation_id == "conversation-1" and user_id == "user-1":
+        if not self.deleted and conversation_id == "conversation-1" and user_id == "user-1":
             return self.conversation
         return None
+
+    async def rename_conversation(self, conversation_id: str, *, user_id: str, title: str):
+        if conversation_id != "conversation-1" or user_id != "user-1" or self.deleted:
+            return None
+        self.conversation.title = title
+        self.conversation.updated_at = "2026-05-18T00:00:02+00:00"
+        return self.conversation
+
+    async def delete_conversation(self, conversation_id: str, *, user_id: str):
+        if conversation_id != "conversation-1" or user_id != "user-1" or self.deleted:
+            return False
+        self.deleted = True
+        return True
 
     async def get_recent_messages(self, conversation_id: str, *, user_id: str, limit: int = 50):
         assert conversation_id == "conversation-1"
@@ -198,6 +229,32 @@ def test_agent_chat_stream_does_not_save_empty_assistant_message(monkeypatch):
     assert service.saved_messages == []
 
 
+def test_agent_chat_stream_saves_error_message_when_stream_fails_before_tokens(monkeypatch):
+    service = _FakeAgentChatService()
+    service.stream_error = RuntimeError("Gemini unavailable")
+    monkeypatch.setattr(agent_chat, "get_agent_chat_service", lambda: service)
+    client = _client(service)
+
+    response = client.post(
+        "/agent/chat/stream",
+        json={"user_id": "user-1", "message": "Hello Agent"},
+    )
+
+    assert response.status_code == 200
+    assert 'event: error\ndata: {"message": "Agent chat failed. Please try again."' in response.text
+    assert service.saved_messages == [
+        {
+            "conversation_id": "conversation-1",
+            "user_id": "user-1",
+            "role": "assistant",
+            "content": "Agent chat failed. Please try again.",
+            "status": "error",
+            "model": "gemini-2.5-pro",
+            "error_code": "AGENT_CHAT_STREAM_FAILED",
+        }
+    ]
+
+
 async def test_agent_chat_stream_saves_partial_interrupted_response(monkeypatch):
     service = _FakeAgentChatService()
     monkeypatch.setattr(agent_chat, "get_agent_chat_service", lambda: service)
@@ -265,3 +322,45 @@ def test_agent_chat_recent_conversation_and_history(monkeypatch):
         "Hello",
         "Hi there",
     ]
+
+
+def test_agent_chat_renames_conversation(monkeypatch):
+    service = _FakeAgentChatService()
+    monkeypatch.setattr(agent_chat, "get_agent_chat_service", lambda: service)
+    client = _client(service)
+
+    response = client.patch(
+        "/agent/chat/conversations/conversation-1",
+        json={"title": "Renamed Kai analysis"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["title"] == "Renamed Kai analysis"
+    assert service.conversation.title == "Renamed Kai analysis"
+
+
+def test_agent_chat_deletes_conversation(monkeypatch):
+    service = _FakeAgentChatService()
+    monkeypatch.setattr(agent_chat, "get_agent_chat_service", lambda: service)
+    client = _client(service)
+
+    response = client.delete("/agent/chat/conversations/conversation-1")
+
+    assert response.status_code == 200
+    assert response.json() == {"conversation_id": "conversation-1", "deleted": True}
+    assert service.deleted is True
+
+
+def test_agent_chat_rename_and_delete_return_not_found_for_other_user(monkeypatch):
+    service = _FakeAgentChatService()
+    monkeypatch.setattr(agent_chat, "get_agent_chat_service", lambda: service)
+    client = _client(service, user_id="other-user")
+
+    renamed = client.patch(
+        "/agent/chat/conversations/conversation-1",
+        json={"title": "Nope"},
+    )
+    deleted = client.delete("/agent/chat/conversations/conversation-1")
+
+    assert renamed.status_code == 404
+    assert deleted.status_code == 404

--- a/consent-protocol/tests/test_consent_handshake.py
+++ b/consent-protocol/tests/test_consent_handshake.py
@@ -36,18 +36,43 @@ class _FakeConsentDBService:
         self.events: list[dict] = []
         self.pending: dict[str, dict] = {}
         self.active: dict[tuple[str, str], dict] = {}  # (agent, scope) -> row
+        self.export_writes: list[dict] = []
 
     # Pending helpers ----------------------------------------------------------
+    @staticmethod
+    def _normalize_identifier(value: object) -> str:
+        normalized = str(value or "").strip()
+        if "@" in normalized:
+            normalized = normalized.lower()
+        return normalized
+
+    @classmethod
+    def _allowed_user_ids(cls, user_id: str, user_ids=None) -> set[str]:
+        values = [user_id, *(list(user_ids or []))]
+        return {
+            cls._normalize_identifier(value) for value in values if cls._normalize_identifier(value)
+        }
+
+    @classmethod
+    def _row_user_id(cls, row: dict, fallback_user_id: str) -> str:
+        return cls._normalize_identifier(row.get("user_id") or fallback_user_id)
+
     def _add_pending(self, request_id: str, row: dict) -> None:
         self.pending[request_id] = row
 
-    async def get_pending_requests(self, user_id: str):
+    async def get_pending_requests(self, user_id: str, *, user_ids=None):
         now_ms = int(time.time() * 1000)
+        allowed_user_ids = self._allowed_user_ids(user_id, user_ids)
         results = []
         for row in self.pending.values():
+            row_user_id = self._row_user_id(row, user_id)
+            if row_user_id not in allowed_user_ids:
+                continue
             results.append(
                 {
                     "id": row["request_id"],
+                    "userId": row_user_id,
+                    "subjectUserId": row_user_id,
                     "developer": row.get("agent_id", row.get("developer")),
                     "scope": row["scope"],
                     "scopeDescription": row.get("scope_description"),
@@ -58,12 +83,16 @@ class _FakeConsentDBService:
             )
         return results
 
-    async def get_pending_by_request_id(self, user_id: str, request_id: str):
+    async def get_pending_by_request_id(self, user_id: str, request_id: str, *, user_ids=None):
         row = self.pending.get(request_id)
         if not row:
             return None
+        row_user_id = self._row_user_id(row, user_id)
+        if row_user_id not in self._allowed_user_ids(user_id, user_ids):
+            return None
         return {
             "request_id": request_id,
+            "user_id": row_user_id,
             "developer": row.get("agent_id", row.get("developer")),
             "scope": row["scope"],
             "metadata": row.get("metadata", {}),
@@ -73,12 +102,27 @@ class _FakeConsentDBService:
         return {"request_id": "req_1"}
 
     # Active helpers -----------------------------------------------------------
-    async def find_covering_active_token(self, *_args, **_kwargs):
+    async def find_covering_active_token(
+        self,
+        user_id,
+        *,
+        requested_scope,
+        agent_id=None,
+        user_ids=None,
+    ):
+        active_tokens = await self.get_active_tokens(user_id, agent_id=agent_id, user_ids=user_ids)
+        for token in active_tokens:
+            if token.get("scope") == requested_scope:
+                return token
         return None
 
-    async def get_active_tokens(self, user_id, agent_id=None, scope=None):
+    async def get_active_tokens(self, user_id, agent_id=None, scope=None, *, user_ids=None):
+        allowed_user_ids = self._allowed_user_ids(user_id, user_ids)
         results = []
         for key, row in self.active.items():
+            row_user_id = self._row_user_id(row, user_id)
+            if row_user_id not in allowed_user_ids:
+                continue
             if agent_id and key[0] != agent_id:
                 continue
             if scope and key[1] != scope:
@@ -92,14 +136,21 @@ class _FakeConsentDBService:
     async def get_superseded_active_tokens(self, *_args, **_kwargs):
         return []
 
-    async def store_consent_export(self, **_kwargs):
+    async def store_consent_export(self, **kwargs):
+        self.export_writes.append(kwargs)
         return True
 
     async def delete_consent_export(self, consent_token):
         return True
 
-    async def get_audit_log(self, user_id, page=1, limit=50):
-        return {"items": self.events, "total": len(self.events), "page": page, "limit": limit}
+    async def get_audit_log(self, user_id, page=1, limit=50, *, user_ids=None):
+        allowed_user_ids = self._allowed_user_ids(user_id, user_ids)
+        items = [
+            event
+            for event in self.events
+            if self._normalize_identifier(event.get("user_id") or user_id) in allowed_user_ids
+        ]
+        return {"items": items, "total": len(items), "page": page, "limit": limit}
 
     async def get_internal_activity_summary(self, user_id, limit=8):
         return {"active_sessions": 0, "recent_operations_24h": 0, "recent": []}
@@ -279,6 +330,221 @@ def test_deny_consent_records_event(monkeypatch):
     denied = [e for e in fake_db.events if e["action"] == "CONSENT_DENIED"]
     assert len(denied) == 1
     assert denied[0]["request_id"] == "req_deny"
+
+
+def test_alias_keyed_pending_request_can_be_denied_by_account_owner(monkeypatch):
+    """The account owner can act on requests keyed by a verified email alias."""
+    fake_db = _FakeConsentDBService()
+    monkeypatch.setattr(consent, "ConsentDBService", lambda: fake_db)
+    monkeypatch.setattr(consent, "RIAIAMService", _NoOpRIAIAMService)
+
+    async def _owned_identifiers(_user_id: str):
+        return ["investor_1", "akshat@example.com", "relay@privaterelay.appleid.com"]
+
+    monkeypatch.setattr(consent, "_owned_consent_identifiers", _owned_identifiers)
+
+    fake_db._add_pending(
+        "req_alias_deny",
+        {
+            "request_id": "req_alias_deny",
+            "user_id": "relay@privaterelay.appleid.com",
+            "agent_id": "developer:app_alias",
+            "scope": "pkm.read",
+            "metadata": {
+                "requester_actor_type": "developer",
+                "developer_app_display_name": "External Agent",
+            },
+        },
+    )
+
+    app = _build_app()
+    client = TestClient(app)
+
+    resp = client.get("/api/consent/pending", params={"userId": "investor_1"})
+    assert resp.status_code == 200
+    assert [item["id"] for item in resp.json()["pending"]] == ["req_alias_deny"]
+
+    resp = client.post(
+        "/api/consent/pending/deny",
+        params={"userId": "investor_1", "requestId": "req_alias_deny"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "denied"
+
+    denied = [event for event in fake_db.events if event["action"] == "CONSENT_DENIED"]
+    assert len(denied) == 1
+    assert denied[0]["user_id"] == "relay@privaterelay.appleid.com"
+    assert denied[0]["request_id"] == "req_alias_deny"
+
+
+def test_alias_keyed_pending_request_reuses_account_active_token(monkeypatch):
+    """Existing UID-keyed grants cover matching requests keyed by a verified alias."""
+    fake_db = _FakeConsentDBService()
+    monkeypatch.setattr(consent, "ConsentDBService", lambda: fake_db)
+    monkeypatch.setattr(consent, "RIAIAMService", _NoOpRIAIAMService)
+
+    async def _owned_identifiers(_user_id: str):
+        return ["investor_1", "relay@privaterelay.appleid.com"]
+
+    monkeypatch.setattr(consent, "_owned_consent_identifiers", _owned_identifiers)
+
+    def _unexpected_issue_token(**_kwargs):
+        raise AssertionError("approval should reuse the account-owned active token")
+
+    monkeypatch.setattr(consent, "issue_token", _unexpected_issue_token)
+
+    fake_db.active[("ria:profile_alias", "pkm.read")] = {
+        "user_id": "investor_1",
+        "agent_id": "ria:profile_alias",
+        "scope": "pkm.read",
+        "token_id": "token_existing_uid",
+        "issued_at": int(time.time() * 1000),
+        "expires_at": int(time.time() * 1000) + 86400000,
+        "request_id": "req_original",
+    }
+    fake_db._add_pending(
+        "req_alias_approve",
+        {
+            "request_id": "req_alias_approve",
+            "user_id": "relay@privaterelay.appleid.com",
+            "agent_id": "ria:profile_alias",
+            "scope": "pkm.read",
+            "metadata": {
+                "requester_actor_type": "ria",
+                "requester_entity_id": "profile_alias",
+                "developer_app_display_name": "Advisor Alias",
+            },
+        },
+    )
+
+    app = _build_app()
+    client = TestClient(app)
+    resp = client.post(
+        "/api/consent/pending/approve",
+        json={"userId": "investor_1", "requestId": "req_alias_approve"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["consent_token"] == "token_existing_uid"  # noqa: S105
+
+    granted = [event for event in fake_db.events if event["action"] == "CONSENT_GRANTED"]
+    assert [event["user_id"] for event in granted] == [
+        "relay@privaterelay.appleid.com",
+        "investor_1",
+    ]
+    assert {event["request_id"] for event in granted} == {"req_alias_approve"}
+
+
+def test_alias_keyed_developer_approval_stores_export_for_canonical_user(monkeypatch):
+    """Alias-keyed developer requests close by alias but store export under the vault owner."""
+    fake_db = _FakeConsentDBService()
+    issued: dict[str, object] = {}
+
+    monkeypatch.setattr(consent, "ConsentDBService", lambda: fake_db)
+    monkeypatch.setattr(consent, "RIAIAMService", _NoOpRIAIAMService)
+
+    async def _owned_identifiers(_user_id: str):
+        return ["investor_1", "relay@privaterelay.appleid.com"]
+
+    def _issue_token(**kwargs):
+        issued.update(kwargs)
+        return SimpleNamespace(
+            token="token_alias_export",  # noqa: S106
+            expires_at=int(time.time() * 1000) + 86400000,
+        )
+
+    monkeypatch.setattr(consent, "_owned_consent_identifiers", _owned_identifiers)
+    monkeypatch.setattr(consent, "issue_token", _issue_token)
+
+    fake_db._add_pending(
+        "req_alias_export",
+        {
+            "request_id": "req_alias_export",
+            "user_id": "relay@privaterelay.appleid.com",
+            "agent_id": "developer:app_alias",
+            "scope": "pkm.read",
+            "metadata": {
+                "requester_actor_type": "developer",
+                "developer_app_display_name": "External Agent",
+                "connector_public_key": "connector-public-key",
+                "connector_key_id": "connector-key-1",
+                "connector_wrapping_alg": "X25519-AES256-GCM",
+            },
+        },
+    )
+
+    app = _build_app()
+    client = TestClient(app)
+    resp = client.post(
+        "/api/consent/pending/approve",
+        json={
+            "userId": "investor_1",
+            "requestId": "req_alias_export",
+            "encryptedData": "ciphertext",
+            "encryptedIv": "iv",
+            "encryptedTag": "tag",
+            "wrappedExportKey": "wrapped",
+            "wrappedKeyIv": "wrapped-iv",
+            "wrappedKeyTag": "wrapped-tag",
+            "senderPublicKey": "sender-public-key",
+            "wrappingAlg": "X25519-AES256-GCM",
+            "connectorKeyId": "connector-key-1",
+        },
+    )
+
+    assert resp.status_code == 200
+    assert issued["user_id"] == "investor_1"
+    assert fake_db.export_writes[0]["user_id"] == "investor_1"
+
+    granted = [event for event in fake_db.events if event["action"] == "CONSENT_GRANTED"]
+    assert [event["user_id"] for event in granted] == [
+        "relay@privaterelay.appleid.com",
+        "investor_1",
+    ]
+    assert {event["request_id"] for event in granted} == {"req_alias_export"}
+
+
+def test_alias_keyed_active_consent_can_be_revoked_by_account_owner(monkeypatch):
+    """Revocation uses the same verified alias ownership filter as consent reads."""
+    fake_db = _FakeConsentDBService()
+    revoked_tokens: list[str] = []
+
+    import hushh_mcp.consent.token as token_module
+
+    monkeypatch.setattr(consent, "ConsentDBService", lambda: fake_db)
+    monkeypatch.setattr(token_module, "revoke_token", lambda token: revoked_tokens.append(token))
+    monkeypatch.setattr(consent, "RIAIAMService", _NoOpRIAIAMService)
+
+    async def _owned_identifiers(_user_id: str):
+        return ["investor_1", "relay@privaterelay.appleid.com"]
+
+    monkeypatch.setattr(consent, "_owned_consent_identifiers", _owned_identifiers)
+
+    fake_db.active[("developer:app_alias", "pkm.read")] = {
+        "user_id": "relay@privaterelay.appleid.com",
+        "agent_id": "developer:app_alias",
+        "scope": "pkm.read",
+        "token_id": "token_alias_active",
+        "issued_at": int(time.time() * 1000),
+        "expires_at": int(time.time() * 1000) + 86400000,
+        "request_id": "req_alias_approve",
+    }
+
+    app = _build_app()
+    client = TestClient(app)
+    resp = client.post(
+        "/api/consent/revoke",
+        json={"userId": "investor_1", "scope": "pkm.read"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "revoked"
+    assert revoked_tokens == ["token_alias_active"]
+
+    revoked = [event for event in fake_db.events if event["action"] == "REVOKED"]
+    assert len(revoked) == 1
+    assert revoked[0]["user_id"] == "relay@privaterelay.appleid.com"
+    assert revoked[0]["request_id"] == "req_alias_approve"
 
 
 def test_cancel_consent_records_event(monkeypatch):

--- a/consent-protocol/tests/test_ria_iam_service_architecture.py
+++ b/consent-protocol/tests/test_ria_iam_service_architecture.py
@@ -915,6 +915,53 @@ async def test_consent_center_list_investor_pending_avoids_monolithic_center(mon
 
 
 @pytest.mark.asyncio
+async def test_consent_center_pending_expands_verified_account_identifiers(monkeypatch):
+    service = ConsentCenterService()
+    captured: dict[str, object] = {}
+
+    async def _identifiers(_user_id: str):
+        return [
+            "firebase_uid_123",
+            "akshat@example.com",
+            "jd77v9k4nx@privaterelay.appleid.com",
+        ]
+
+    class _FakeConsentDBService:
+        async def get_pending_requests(self, user_id: str, *, user_ids=None):
+            captured["user_id"] = user_id
+            captured["user_ids"] = user_ids
+            return [
+                {
+                    "id": "req_alias",
+                    "subjectUserId": "jd77v9k4nx@privaterelay.appleid.com",
+                    "developer": "developer:app_demo",
+                    "scope": "pkm.read",
+                    "scopeDescription": "Read PKM",
+                    "requestedAt": 100,
+                    "pollTimeoutAt": 200,
+                    "metadata": {"developer_app_display_name": "Demo App"},
+                }
+            ]
+
+    async def _hydrate(entries):
+        return entries
+
+    monkeypatch.setattr(service._identity, "list_account_identifiers", _identifiers)
+    service._consent_db = _FakeConsentDBService()
+    monkeypatch.setattr(service, "_hydrate_entry_identities", _hydrate)
+
+    entries = await service._load_investor_pending_entries("firebase_uid_123")
+
+    assert captured["user_id"] == "firebase_uid_123"
+    assert captured["user_ids"] == [
+        "firebase_uid_123",
+        "akshat@example.com",
+        "jd77v9k4nx@privaterelay.appleid.com",
+    ]
+    assert entries[0]["id"] == "req_alias"
+
+
+@pytest.mark.asyncio
 async def test_consent_center_list_preview_top_caps_page_and_limit(monkeypatch):
     service = ConsentCenterService()
 

--- a/docs/reference/architecture/api-contracts.md
+++ b/docs/reference/architecture/api-contracts.md
@@ -200,6 +200,8 @@ RIA relationship bundle note:
 | POST | `/api/kai/chat` | Conversational Kai endpoint |
 | POST | `/api/kai/agent/chat/stream` | Gemini-backed Agent text chat SSE stream; emits `token` plus live `tool_start` / `tool_waiting` / `tool_result` events and stores encrypted text history only |
 | GET | `/api/kai/agent/chat/conversations/{user_id}` | List recent encrypted Agent chat conversations for the vault owner |
+| PATCH | `/api/kai/agent/chat/conversations/{conversation_id}` | Rename an authenticated vault owner's encrypted Agent chat conversation |
+| DELETE | `/api/kai/agent/chat/conversations/{conversation_id}` | Delete an authenticated vault owner's Agent chat conversation and its encrypted messages |
 | GET | `/api/kai/agent/chat/history/{conversation_id}` | Read decrypted Agent chat history for the authenticated conversation owner |
 | POST | `/api/kai/agent/realtime/session` | Create an OpenAI Realtime WebRTC client secret for the vault-unlocked Agent chat and voice surface |
 | GET | `/api/kai/chat/history/{conversation_id}` | Conversation history |

--- a/docs/reference/architecture/runtime-db-data-plane-contract.json
+++ b/docs/reference/architecture/runtime-db-data-plane-contract.json
@@ -98,8 +98,8 @@
       "lifecycle_status": "current",
       "exact_tables": ["agent_chat_conversations", "agent_chat_messages"],
       "primary_access_path": "Gemini-backed Agent text chat streaming, encrypted chat history restore, and LLM context assembly",
-      "retention_policy": "Retain while account exists or until a future user-facing Agent chat deletion/export flow is introduced.",
-      "deletion_behavior": "Delete all user rows on account deletion; do not persist transient tool debug events.",
+      "retention_policy": "Retain while account exists or until the user deletes an Agent chat conversation.",
+      "deletion_behavior": "Delete selected conversation rows with cascading encrypted messages; delete all user rows on account deletion; do not persist transient tool debug events.",
       "trust_boundary": "Message titles and content persist as AES-GCM ciphertext. Backend may decrypt only with vault service key for current Agent LLM context; frontend tool debug events remain live-only and are not stored.",
       "plaintext_posture": "ciphertext_and_metadata",
       "expected_row_growth": "high_per_user_chat"

--- a/docs/reference/iam/runtime-surface.md
+++ b/docs/reference/iam/runtime-surface.md
@@ -105,6 +105,8 @@ Consent-manager surface rules:
    - preview rows: first `5` items from the cached `center/list?surface=pending&page=1&limit=20` payload for the active persona
 7. Internal consent-review links must stay on SPA-native app routing; full document redirects are reserved for true external URLs only.
 8. Long consent lists must use backend-backed pagination metadata and must not rely on a load-all-then-slice page contract.
+9. Investor consent reads expand the authenticated Firebase UID to the account-owned identifier set before filtering `consent_audit`: Firebase UID, verified Firebase-auth email/phone, and verified non-revoked email aliases including Apple relay emails.
+10. Pending approve/deny/cancel and active revoke actions resolve through the same owned identifier set, then write terminal audit rows against the matched request or token subject id.
 
 ### Marketplace
 

--- a/hushh-webapp/__tests__/services/agent-chat-client.test.ts
+++ b/hushh-webapp/__tests__/services/agent-chat-client.test.ts
@@ -5,12 +5,16 @@ vi.mock("@/lib/services/api-service", () => ({
     streamAgentChat: vi.fn(),
     listAgentChatConversations: vi.fn(),
     getAgentChatHistory: vi.fn(),
+    renameAgentChatConversation: vi.fn(),
+    deleteAgentChatConversation: vi.fn(),
   },
 }));
 
 import {
+  deleteAgentChatConversation,
   getAgentChatHistory,
   listAgentChatConversations,
+  renameAgentChatConversation,
   streamAgentChat,
 } from "@/lib/services/agent-chat-client";
 import { ApiService } from "@/lib/services/api-service";
@@ -82,6 +86,7 @@ describe("agent chat client", () => {
       message: "Hello",
       conversationId: undefined,
       vaultOwnerToken: "vault-token",
+      pkmContext: undefined,
       signal: undefined,
     });
   });
@@ -197,5 +202,39 @@ describe("agent chat client", () => {
         vaultOwnerToken: "vault-token",
       })
     ).resolves.toMatchObject([{ id: "message-1", content: "Hello" }]);
+  });
+
+  it("renames and deletes conversations", async () => {
+    vi.spyOn(ApiService, "renameAgentChatConversation").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "conversation-1",
+          title: "Renamed chat",
+          status: "active",
+          message_count: 2,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      )
+    );
+    vi.spyOn(ApiService, "deleteAgentChatConversation").mockResolvedValue(
+      new Response(JSON.stringify({ conversation_id: "conversation-1", deleted: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    );
+
+    await expect(
+      renameAgentChatConversation({
+        conversationId: "conversation-1",
+        title: "Renamed chat",
+        vaultOwnerToken: "vault-token",
+      })
+    ).resolves.toMatchObject({ id: "conversation-1", title: "Renamed chat" });
+    await expect(
+      deleteAgentChatConversation({
+        conversationId: "conversation-1",
+        vaultOwnerToken: "vault-token",
+      })
+    ).resolves.toEqual({ conversation_id: "conversation-1", deleted: true });
   });
 });

--- a/hushh-webapp/app/api/consent/pending/approve/route.ts
+++ b/hushh-webapp/app/api/consent/pending/approve/route.ts
@@ -85,10 +85,26 @@ export async function POST(request: NextRequest) {
     });
 
     if (!response.ok) {
-      const error = await response.text();
-      console.error("[API] Backend error:", error);
+      const errorText = await response.text();
+      console.error("[API] Backend error:", errorText);
+      let message = "Failed to approve consent";
+      try {
+        const parsed = JSON.parse(errorText);
+        const detail = parsed?.detail;
+        if (typeof detail === "string") {
+          message = detail;
+        } else if (typeof detail?.message === "string") {
+          message = detail.message;
+        } else if (typeof parsed?.error === "string") {
+          message = parsed.error;
+        }
+      } catch {
+        if (errorText.trim()) {
+          message = errorText;
+        }
+      }
       return NextResponse.json(
-        { error: "Failed to approve consent" },
+        { error: message },
         { status: response.status }
       );
     }

--- a/hushh-webapp/app/api/kai/[...path]/route.ts
+++ b/hushh-webapp/app/api/kai/[...path]/route.ts
@@ -155,6 +155,14 @@ export async function GET(
   return proxyRequest(request, params);
 }
 
+export async function PATCH(
+  request: NextRequest,
+  props: { params: Promise<{ path: string[] }> }
+) {
+  const params = await props.params;
+  return proxyRequest(request, params);
+}
+
 export async function DELETE(
   request: NextRequest,
   props: { params: Promise<{ path: string[] }> }

--- a/hushh-webapp/components/agent/agent-history-sidebar.tsx
+++ b/hushh-webapp/components/agent/agent-history-sidebar.tsx
@@ -1,0 +1,325 @@
+"use client";
+
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import {
+  Check,
+  MessageSquare,
+  MoreHorizontal,
+  PanelLeftClose,
+  PanelLeftOpen,
+  Pencil,
+  Plus,
+  Trash2,
+  X,
+} from "lucide-react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import type { AgentChatConversation } from "@/lib/services/agent-chat-client";
+import { cn } from "@/lib/utils";
+
+type AgentHistorySidebarProps = {
+  conversations: AgentChatConversation[];
+  activeConversationId: string | null;
+  collapsed: boolean;
+  loading?: boolean;
+  disabled?: boolean;
+  actionPendingId?: string | null;
+  className?: string;
+  onToggleCollapsed: () => void;
+  onCreateNew: () => void;
+  onSelectConversation: (conversationId: string) => void;
+  onRenameConversation: (conversationId: string, title: string) => Promise<void> | void;
+  onDeleteConversation: (conversationId: string) => Promise<void> | void;
+};
+
+function normalizeTitle(title: string): string {
+  return title.trim().replace(/\s+/g, " ");
+}
+
+function conversationLabel(conversation: AgentChatConversation): string {
+  const title = normalizeTitle(conversation.title);
+  return title || "New Agent chat";
+}
+
+export function AgentHistorySidebar({
+  conversations,
+  activeConversationId,
+  collapsed,
+  loading = false,
+  disabled = false,
+  actionPendingId,
+  className,
+  onToggleCollapsed,
+  onCreateNew,
+  onSelectConversation,
+  onRenameConversation,
+  onDeleteConversation,
+}: AgentHistorySidebarProps) {
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState("");
+  const [deleteTarget, setDeleteTarget] = useState<AgentChatConversation | null>(null);
+
+  const renamingConversation = useMemo(
+    () => conversations.find((conversation) => conversation.id === renamingId) || null,
+    [conversations, renamingId]
+  );
+
+  useEffect(() => {
+    if (!renamingConversation) return;
+    setRenameValue(conversationLabel(renamingConversation));
+  }, [renamingConversation]);
+
+  const startRename = (conversation: AgentChatConversation) => {
+    setRenamingId(conversation.id);
+    setRenameValue(conversationLabel(conversation));
+  };
+
+  const cancelRename = () => {
+    setRenamingId(null);
+    setRenameValue("");
+  };
+
+  const submitRename = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!renamingId) return;
+    const nextTitle = normalizeTitle(renameValue);
+    if (!nextTitle) return;
+    await onRenameConversation(renamingId, nextTitle);
+    cancelRename();
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteTarget) return;
+    await onDeleteConversation(deleteTarget.id);
+    setDeleteTarget(null);
+  };
+
+  return (
+    <>
+      <aside
+        className={cn(
+          "flex shrink-0 flex-col overflow-hidden rounded-lg border border-border/70 bg-card shadow-sm transition-[width] duration-200 ease-out",
+          collapsed ? "w-full lg:w-14" : "w-full lg:w-72",
+          className
+        )}
+        aria-label="Agent chat history"
+      >
+        <div
+          className={cn(
+            "flex items-center gap-2 border-b border-border/70 p-2",
+            collapsed && "lg:flex-col"
+          )}
+        >
+          <Button
+            type="button"
+            variant="secondary"
+            className={cn(
+              "min-w-0",
+              collapsed ? "h-9 w-9 px-0" : "flex-1 justify-start px-3"
+            )}
+            onClick={onCreateNew}
+            disabled={disabled}
+            aria-label="Create new Agent chat"
+            title="Create new chat"
+          >
+            <Plus className="h-4 w-4" />
+            {!collapsed ? <span className="truncate">Create New Chat</span> : null}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-9 w-9"
+            onClick={onToggleCollapsed}
+            aria-label={collapsed ? "Expand chat history" : "Collapse chat history"}
+            title={collapsed ? "Expand chat history" : "Collapse chat history"}
+          >
+            {collapsed ? (
+              <PanelLeftOpen className="h-4 w-4" />
+            ) : (
+              <PanelLeftClose className="h-4 w-4" />
+            )}
+          </Button>
+        </div>
+
+        <div
+          className={cn(
+            "min-h-0 flex-1 overflow-y-auto p-2",
+            collapsed && "max-lg:flex max-lg:gap-1 max-lg:overflow-x-auto"
+          )}
+        >
+          {loading ? (
+            <div
+              className={cn(
+                "rounded-md bg-muted/40",
+                collapsed ? "h-9 w-9 shrink-0" : "h-10 w-full"
+              )}
+            />
+          ) : null}
+
+          {!loading && conversations.length === 0 ? (
+            <div
+              className={cn(
+                "grid place-items-center rounded-md border border-dashed border-border/70 text-center text-xs text-muted-foreground",
+                collapsed ? "h-9 w-9 shrink-0" : "min-h-24 px-3"
+              )}
+            >
+              {collapsed ? <MessageSquare className="h-4 w-4" /> : "No chats yet"}
+            </div>
+          ) : null}
+
+          <div className={cn("space-y-1", collapsed && "max-lg:flex max-lg:space-y-0")}>
+            {conversations.map((conversation) => {
+              const title = conversationLabel(conversation);
+              const active = conversation.id === activeConversationId;
+              const pending = actionPendingId === conversation.id;
+              const isRenaming = renamingId === conversation.id;
+
+              return (
+                <div
+                  key={conversation.id}
+                  className={cn(
+                    "group rounded-md transition-colors",
+                    active && "bg-primary/10 text-primary",
+                    !active && "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+                  )}
+                >
+                  {isRenaming && !collapsed ? (
+                    <form
+                      onSubmit={submitRename}
+                      className="flex items-center gap-1 rounded-md bg-background p-1"
+                    >
+                      <Input
+                        value={renameValue}
+                        onChange={(event) => setRenameValue(event.target.value)}
+                        className="h-8 min-w-0 flex-1 text-sm"
+                        maxLength={160}
+                        autoFocus
+                        disabled={pending}
+                        aria-label="Rename chat"
+                      />
+                      <Button
+                        type="submit"
+                        variant="ghost"
+                        size="icon-xs"
+                        disabled={pending || !normalizeTitle(renameValue)}
+                        aria-label="Save chat name"
+                      >
+                        <Check className="h-3.5 w-3.5" />
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-xs"
+                        onClick={cancelRename}
+                        disabled={pending}
+                        aria-label="Cancel rename"
+                      >
+                        <X className="h-3.5 w-3.5" />
+                      </Button>
+                    </form>
+                  ) : (
+                    <div className="flex items-center">
+                      <button
+                        type="button"
+                        className={cn(
+                          "flex h-9 min-w-0 flex-1 items-center gap-2 rounded-md px-2 text-left text-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring/50",
+                          collapsed && "w-9 flex-none justify-center px-0"
+                        )}
+                        onClick={() => onSelectConversation(conversation.id)}
+                        disabled={disabled || pending}
+                        aria-current={active ? "page" : undefined}
+                        title={title}
+                      >
+                        <MessageSquare className="h-4 w-4 shrink-0" />
+                        {!collapsed ? <span className="truncate">{title}</span> : null}
+                      </button>
+                      {!collapsed ? (
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon-xs"
+                              className="mr-1 opacity-70 transition-opacity group-hover:opacity-100"
+                              disabled={disabled || pending}
+                              onClick={(event) => event.stopPropagation()}
+                              aria-label={`Open actions for ${title}`}
+                            >
+                              <MoreHorizontal className="h-3.5 w-3.5" />
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end" sideOffset={6}>
+                            <DropdownMenuItem onSelect={() => startRename(conversation)}>
+                              <Pencil className="h-4 w-4" />
+                              Rename chat
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              variant="destructive"
+                              onSelect={() => setDeleteTarget(conversation)}
+                            >
+                              <Trash2 className="h-4 w-4" />
+                              Delete chat
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      ) : null}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </aside>
+
+      <AlertDialog
+        open={Boolean(deleteTarget)}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null);
+        }}
+      >
+        <AlertDialogContent size="sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete chat?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This removes the selected Agent conversation and its messages.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={Boolean(deleteTarget && actionPendingId === deleteTarget.id)}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              disabled={Boolean(deleteTarget && actionPendingId === deleteTarget.id)}
+              onClick={(event) => {
+                event.preventDefault();
+                void confirmDelete();
+              }}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/hushh-webapp/components/agent/agent-pkm-review-panel.tsx
+++ b/hushh-webapp/components/agent/agent-pkm-review-panel.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { Brain, Check, Loader2, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import type { AgentPkmPreviewCard } from "@/lib/agent/agent-pkm-memory";
+import { cn } from "@/lib/utils";
+
+type AgentPkmReviewPanelProps = {
+  cards: AgentPkmPreviewCard[];
+  saving?: boolean;
+  className?: string;
+  onSave: () => void;
+  onDismiss: () => void;
+};
+
+function cleanText(value: unknown, maxLength = 120): string {
+  const text = String(value || "").trim().replace(/\s+/g, " ");
+  if (!text) return "";
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, Math.max(0, maxLength - 1)).trimEnd()}...`;
+}
+
+function titleize(value: string | null | undefined): string {
+  return String(value || "")
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (match) => match.toUpperCase())
+    .trim();
+}
+
+function cardDomain(card: AgentPkmPreviewCard): string {
+  const structureDecision =
+    card.structure_decision && typeof card.structure_decision === "object"
+      ? card.structure_decision
+      : {};
+  return (
+    String(card.manifest_draft?.domain || "").trim() ||
+    String(structureDecision.target_domain || "").trim() ||
+    String(card.target_domain || "").trim() ||
+    "PKM"
+  );
+}
+
+export function AgentPkmReviewPanel({
+  cards,
+  saving = false,
+  className,
+  onSave,
+  onDismiss,
+}: AgentPkmReviewPanelProps) {
+  if (cards.length === 0) return null;
+
+  return (
+    <div
+      className={cn(
+        "rounded-lg border border-primary/30 bg-primary/5 p-3 text-sm",
+        className
+      )}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex min-w-0 gap-2">
+          <div className="mt-0.5 grid h-8 w-8 shrink-0 place-items-center rounded-full bg-primary/10 text-primary">
+            <Brain className="h-4 w-4" />
+          </div>
+          <div className="min-w-0">
+            <p className="font-medium text-foreground">Save to PKM?</p>
+            <p className="mt-1 text-xs leading-5 text-muted-foreground">
+              Agent found durable context that needs your review before it is stored.
+            </p>
+          </div>
+        </div>
+        <div className="flex shrink-0 gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-8 gap-2"
+            onClick={onDismiss}
+            disabled={saving}
+          >
+            <X className="h-3.5 w-3.5" />
+            Skip
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            className="h-8 gap-2"
+            onClick={onSave}
+            disabled={saving}
+          >
+            {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Check className="h-3.5 w-3.5" />}
+            Save
+          </Button>
+        </div>
+      </div>
+
+      <div className="mt-3 space-y-2">
+        {cards.slice(0, 3).map((card) => (
+          <div key={card.card_id} className="rounded-md border border-border/60 bg-background p-2">
+            <div className="flex flex-wrap items-center gap-2 text-xs">
+              <span className="rounded-md bg-muted px-2 py-1 font-medium text-foreground">
+                {titleize(cardDomain(card))}
+              </span>
+              {card.intent_class ? (
+                <span className="text-muted-foreground">{titleize(card.intent_class)}</span>
+              ) : null}
+            </div>
+            {cleanText(card.source_text) ? (
+              <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                {cleanText(card.source_text)}
+              </p>
+            ) : null}
+            {card.confirmation_reason ? (
+              <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                {cleanText(card.confirmation_reason, 160)}
+              </p>
+            ) : null}
+          </div>
+        ))}
+        {cards.length > 3 ? (
+          <p className="text-xs text-muted-foreground">
+            +{cards.length - 3} more PKM candidate{cards.length - 3 === 1 ? "" : "s"}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/hushh-webapp/components/agent/agent-screen.tsx
+++ b/hushh-webapp/components/agent/agent-screen.tsx
@@ -12,11 +12,24 @@ import {
 import { PageHeader } from "@/components/app-ui/page-sections";
 import { NativeRouteMarker } from "@/components/app-ui/native-route-marker";
 import { Button } from "@/components/ui/button";
+import { AgentHistorySidebar } from "@/components/agent/agent-history-sidebar";
+import { AgentPkmReviewPanel } from "@/components/agent/agent-pkm-review-panel";
 import { useAuth } from "@/hooks/use-auth";
 import {
   executeAgentGatewayAction,
   type AgentActionRuntimeResult,
 } from "@/lib/agent/agent-action-runtime";
+import {
+  addToPKM,
+  formatAgentPkmSaveSummary,
+  getAutoSavePkmCards,
+  getIgnoredPkmCards,
+  getReviewRequiredPkmCards,
+  loadAgentPkmContext,
+  previewAgentPkmMemory,
+  type AgentPkmContext,
+  type AgentPkmPreviewCard,
+} from "@/lib/agent/agent-pkm-memory";
 import { morphyToast as toast } from "@/lib/morphy-ux/morphy";
 import { usePersonaState } from "@/lib/persona/persona-context";
 import { CacheService, CACHE_KEYS } from "@/lib/services/cache-service";
@@ -26,9 +39,12 @@ import {
   type AgentRealtimeVoiceState,
 } from "@/lib/services/agent-realtime-client";
 import {
+  deleteAgentChatConversation,
   getAgentChatHistory,
   listAgentChatConversations,
+  renameAgentChatConversation,
   streamAgentChat,
+  type AgentChatConversation,
   type AgentChatMessage as StoredAgentChatMessage,
   type AgentChatToolEvent,
 } from "@/lib/services/agent-chat-client";
@@ -56,8 +72,23 @@ type AgentDebugEvent = {
   payload: unknown;
 };
 
+type AgentPkmReview = {
+  id: string;
+  turnId: string;
+  sourceMessage: string;
+  cards: AgentPkmPreviewCard[];
+  saving: boolean;
+};
+
 const AGENT_GREETING =
   "Hey, I'm Agent. Ask me about markets, your portfolio, Kai analysis, or consent workflows.";
+
+const EMPTY_PKM_CONTEXT: AgentPkmContext = {
+  text: "",
+  domains: [],
+  totalAttributes: 0,
+  updatedAt: null,
+};
 
 function formatNow(): string {
   return new Intl.DateTimeFormat(undefined, {
@@ -166,6 +197,24 @@ function AgentDebugPanel({
   );
 }
 
+function storedMessageToAgentMessage(message: StoredAgentChatMessage): AgentMessage | null {
+  if (message.role !== "user" && message.role !== "assistant") return null;
+  const createdAt = message.created_at ? new Date(message.created_at) : null;
+  return {
+    id: message.id,
+    role: message.role,
+    text: message.content,
+    timestamp:
+      createdAt && !Number.isNaN(createdAt.getTime())
+        ? new Intl.DateTimeFormat(undefined, {
+            hour: "numeric",
+            minute: "2-digit",
+          }).format(createdAt)
+        : formatNow(),
+    status: message.status === "error" ? "error" : "done",
+  };
+}
+
 export function AgentScreen() {
   const router = useRouter();
   const pathname = usePathname();
@@ -173,6 +222,7 @@ export function AgentScreen() {
   const { user, loading: authLoading } = useAuth();
   const {
     isVaultUnlocked,
+    vaultKey,
     vaultOwnerToken,
     tokenExpiresAt,
     getVaultOwnerToken,
@@ -189,15 +239,20 @@ export function AgentScreen() {
   const setAnalysisParams = useKaiSession((state) => state.setAnalysisParams);
   const [input, setInput] = useState("");
   const [conversationId, setConversationId] = useState<string | null>(null);
+  const [conversations, setConversations] = useState<AgentChatConversation[]>([]);
   const [messages, setMessages] = useState<AgentMessage[]>(() => [createGreetingMessage()]);
   const [isChatLoading, setIsChatLoading] = useState(false);
   const [isLoadingHistory, setIsLoadingHistory] = useState(false);
+  const [isHistorySidebarCollapsed, setIsHistorySidebarCollapsed] = useState(false);
+  const [historyActionPendingId, setHistoryActionPendingId] = useState<string | null>(null);
   const [isVoiceConnecting, setIsVoiceConnecting] = useState(false);
   const [isStreaming, setIsStreaming] = useState(false);
-  const [activeToolCount, setActiveToolCount] = useState(0);
+  const [activeFrontendToolCount, setActiveFrontendToolCount] = useState(0);
+  const [activePkmToolCount, setActivePkmToolCount] = useState(0);
   const [debugOpen, setDebugOpen] = useState(false);
   const [debugEvents, setDebugEvents] = useState<AgentDebugEvent[]>([]);
   const [latestDebugTurnId, setLatestDebugTurnId] = useState<string | null>(null);
+  const [pkmReviews, setPkmReviews] = useState<AgentPkmReview[]>([]);
   const [voiceState, setVoiceState] = useState<AgentRealtimeVoiceState>("idle");
   const [hasPortfolioData, setHasPortfolioData] = useState(false);
   const [backgroundTaskState, setBackgroundTaskState] = useState(() =>
@@ -208,10 +263,21 @@ export function AgentScreen() {
   const voiceUserMessageIdRef = useRef<string | null>(null);
   const voiceAssistantMessageIdRef = useRef<string | null>(null);
   const historyLoadKeyRef = useRef<string | null>(null);
+  const streamAbortControllerRef = useRef<AbortController | null>(null);
+  const pkmAbortControllersRef = useRef<Set<AbortController>>(new Set());
 
   const voiceActive = voiceState !== "idle";
-  const isToolWorking = activeToolCount > 0;
+  const isToolWorking = activeFrontendToolCount > 0;
+  const isPkmMemoryWorking = activePkmToolCount > 0;
   const tokenIsFresh = !tokenExpiresAt || Date.now() < tokenExpiresAt;
+  const abortAgentTurnWork = useCallback(() => {
+    streamAbortControllerRef.current?.abort();
+    streamAbortControllerRef.current = null;
+    for (const controller of pkmAbortControllersRef.current) {
+      controller.abort();
+    }
+    pkmAbortControllersRef.current.clear();
+  }, []);
   const routeQuery = searchParams?.toString() || "";
   const pathnameWithQuery = routeQuery ? `${pathname || ""}?${routeQuery}` : pathname || "";
   const routeInfo = useMemo(
@@ -331,12 +397,19 @@ export function AgentScreen() {
   const canSend =
     hasChatAccess &&
     !isChatLoading &&
-    !isToolWorking &&
+    !isLoadingHistory &&
     !isVoiceConnecting &&
     !isStreaming &&
     !voiceActive &&
     input.trim().length > 0;
   const canToggleVoice = hasChatAccess && (!isVoiceConnecting || voiceActive);
+  const historyInteractionDisabled =
+    isLoadingHistory ||
+    isChatLoading ||
+    isToolWorking ||
+    isVoiceConnecting ||
+    isStreaming ||
+    voiceActive;
   const statusText = useMemo(
     () => {
       if (authLoading) return "Checking access";
@@ -349,6 +422,7 @@ export function AgentScreen() {
       if (isLoadingHistory) return "Loading";
       if (isVoiceConnecting) return "Voice connecting";
       if (isToolWorking) return "Working";
+      if (isPkmMemoryWorking) return "Saving memory";
       if (isChatLoading) return "Thinking";
       if (isStreaming) return "Streaming";
       return "Ready";
@@ -357,6 +431,7 @@ export function AgentScreen() {
       authLoading,
       isChatLoading,
       isLoadingHistory,
+      isPkmMemoryWorking,
       isToolWorking,
       isStreaming,
       isVoiceConnecting,
@@ -370,14 +445,15 @@ export function AgentScreen() {
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
-  }, [messages]);
+  }, [messages, pkmReviews]);
 
   useEffect(() => {
     return () => {
+      abortAgentTurnWork();
       voiceClientRef.current?.close();
       voiceClientRef.current = null;
     };
-  }, []);
+  }, [abortAgentTurnWork]);
 
   useEffect(() => {
     const unsubscribe = AppBackgroundTaskService.subscribe((state) => {
@@ -425,22 +501,27 @@ export function AgentScreen() {
   }, [user?.uid]);
 
   useEffect(() => {
+    abortAgentTurnWork();
     voiceClientRef.current?.close();
     voiceClientRef.current = null;
     setIsChatLoading(false);
     setIsLoadingHistory(false);
     setIsVoiceConnecting(false);
     setIsStreaming(false);
-    setActiveToolCount(0);
+    setActiveFrontendToolCount(0);
+    setActivePkmToolCount(0);
     setDebugEvents([]);
     setLatestDebugTurnId(null);
+    setPkmReviews([]);
     setVoiceState("idle");
     setConversationId(null);
+    setConversations([]);
+    setHistoryActionPendingId(null);
     setMessages([createGreetingMessage()]);
     historyLoadKeyRef.current = null;
     voiceUserMessageIdRef.current = null;
     voiceAssistantMessageIdRef.current = null;
-  }, [user?.uid, isVaultUnlocked]);
+  }, [abortAgentTurnWork, user?.uid, isVaultUnlocked]);
 
   const updateMessage = (
     messageId: string,
@@ -453,6 +534,10 @@ export function AgentScreen() {
 
   const appendMessage = (message: AgentMessage) => {
     setMessages((current) => [...current, message]);
+  };
+
+  const removeMessage = (messageId: string) => {
+    setMessages((current) => current.filter((message) => message.id !== messageId));
   };
 
   const appendDebugEvent = useCallback(
@@ -501,23 +586,6 @@ export function AgentScreen() {
     });
   };
 
-  const storedMessageToAgentMessage = (message: StoredAgentChatMessage): AgentMessage | null => {
-    if (message.role !== "user" && message.role !== "assistant") return null;
-    const createdAt = message.created_at ? new Date(message.created_at) : null;
-    return {
-      id: message.id,
-      role: message.role,
-      text: message.content,
-      timestamp: createdAt && !Number.isNaN(createdAt.getTime())
-        ? new Intl.DateTimeFormat(undefined, {
-            hour: "numeric",
-            minute: "2-digit",
-          }).format(createdAt)
-        : formatNow(),
-      status: message.status === "error" ? "error" : "done",
-    };
-  };
-
   useEffect(() => {
     if (!hasChatAccess || !user?.uid || !vaultOwnerToken) return;
     const loadKey = `${user.uid}:${vaultOwnerToken.slice(0, 12)}`;
@@ -531,10 +599,16 @@ export function AgentScreen() {
         const conversations = await listAgentChatConversations({
           userId: user.uid,
           vaultOwnerToken,
-          limit: 1,
+          limit: 20,
         });
+        if (cancelled) return;
+        setConversations(conversations);
         const latest = conversations[0];
-        if (!latest) return;
+        if (!latest) {
+          setConversationId(null);
+          setMessages([createGreetingMessage()]);
+          return;
+        }
         const history = await getAgentChatHistory({
           conversationId: latest.id,
           vaultOwnerToken,
@@ -545,9 +619,7 @@ export function AgentScreen() {
           .map(storedMessageToAgentMessage)
           .filter((message): message is AgentMessage => Boolean(message));
         setConversationId(latest.id);
-        if (restored.length > 0) {
-          setMessages(restored);
-        }
+        setMessages(restored.length > 0 ? restored : [createGreetingMessage()]);
       } catch {
         if (!cancelled) {
           historyLoadKeyRef.current = null;
@@ -564,6 +636,236 @@ export function AgentScreen() {
       cancelled = true;
     };
   }, [hasChatAccess, user?.uid, vaultOwnerToken]);
+
+  const restoreConversationMessages = useCallback(
+    async (nextConversationId: string, token: string) => {
+      const history = await getAgentChatHistory({
+        conversationId: nextConversationId,
+        vaultOwnerToken: token,
+        limit: 50,
+      });
+      const restored = history
+        .map(storedMessageToAgentMessage)
+        .filter((message): message is AgentMessage => Boolean(message));
+      setConversationId(nextConversationId);
+      setMessages(restored.length > 0 ? restored : [createGreetingMessage()]);
+      setDebugEvents([]);
+      setLatestDebugTurnId(null);
+      setPkmReviews([]);
+    },
+    []
+  );
+
+  const loadConversationList = useCallback(async () => {
+    if (!user?.uid) return [];
+    const token = getVaultOwnerToken();
+    if (!token) return [];
+    const nextConversations = await listAgentChatConversations({
+      userId: user.uid,
+      vaultOwnerToken: token,
+      limit: 20,
+    });
+    setConversations(nextConversations);
+    return nextConversations;
+  }, [getVaultOwnerToken, user?.uid]);
+
+  const handleCreateNewChat = useCallback(() => {
+    abortAgentTurnWork();
+    setConversationId(null);
+    setMessages([createGreetingMessage()]);
+    setInput("");
+    setDebugEvents([]);
+    setLatestDebugTurnId(null);
+    setPkmReviews([]);
+  }, [abortAgentTurnWork]);
+
+  const handleSelectConversation = useCallback(
+    async (nextConversationId: string) => {
+      if (nextConversationId === conversationId || historyInteractionDisabled) return;
+      const token = getVaultOwnerToken();
+      if (!token) {
+        toast.error("Vault access expired. Unlock again to continue.");
+        return;
+      }
+      abortAgentTurnWork();
+      setIsLoadingHistory(true);
+      try {
+        await restoreConversationMessages(nextConversationId, token);
+      } catch {
+        toast.error("Could not load Agent chat.");
+      } finally {
+        setIsLoadingHistory(false);
+      }
+    },
+    [
+      conversationId,
+      abortAgentTurnWork,
+      getVaultOwnerToken,
+      historyInteractionDisabled,
+      restoreConversationMessages,
+    ]
+  );
+
+  const handleRenameConversation = useCallback(
+    async (targetConversationId: string, title: string) => {
+      const token = getVaultOwnerToken();
+      if (!token) {
+        toast.error("Vault access expired. Unlock again to continue.");
+        return;
+      }
+      setHistoryActionPendingId(targetConversationId);
+      try {
+        const renamed = await renameAgentChatConversation({
+          conversationId: targetConversationId,
+          title,
+          vaultOwnerToken: token,
+        });
+        setConversations((current) =>
+          current.map((conversation) =>
+            conversation.id === targetConversationId ? renamed : conversation
+          )
+        );
+        void loadConversationList().catch(() => undefined);
+        toast.success("Agent chat renamed.");
+      } catch {
+        toast.error("Could not rename Agent chat.");
+      } finally {
+        setHistoryActionPendingId(null);
+      }
+    },
+    [getVaultOwnerToken, loadConversationList]
+  );
+
+  const handleDeleteConversation = useCallback(
+    async (targetConversationId: string) => {
+      if (historyInteractionDisabled) return;
+      const token = getVaultOwnerToken();
+      if (!token || !user?.uid) {
+        toast.error("Vault access expired. Unlock again to continue.");
+        return;
+      }
+      if (conversationId === targetConversationId) {
+        abortAgentTurnWork();
+      }
+      setHistoryActionPendingId(targetConversationId);
+      try {
+        await deleteAgentChatConversation({
+          conversationId: targetConversationId,
+          vaultOwnerToken: token,
+        });
+        const nextConversations = await listAgentChatConversations({
+          userId: user.uid,
+          vaultOwnerToken: token,
+          limit: 20,
+        });
+        setConversations(nextConversations);
+        if (conversationId === targetConversationId) {
+          const nextConversation = nextConversations[0];
+          if (nextConversation) {
+            await restoreConversationMessages(nextConversation.id, token);
+          } else {
+            handleCreateNewChat();
+          }
+        }
+        toast.success("Agent chat deleted.");
+      } catch {
+        toast.error("Could not delete Agent chat.");
+      } finally {
+        setHistoryActionPendingId(null);
+      }
+    },
+    [
+      conversationId,
+      abortAgentTurnWork,
+      getVaultOwnerToken,
+      handleCreateNewChat,
+      historyInteractionDisabled,
+      restoreConversationMessages,
+      user?.uid,
+    ]
+  );
+
+  const handleDismissPkmReview = useCallback(
+    (reviewId: string) => {
+      const review = pkmReviews.find((item) => item.id === reviewId);
+      if (review) {
+        appendDebugEvent(review.turnId, "pkm_review_dismissed", {
+          review_id: review.id,
+          candidate_count: review.cards.length,
+        });
+      }
+      setPkmReviews((current) => current.filter((item) => item.id !== reviewId));
+    },
+    [appendDebugEvent, pkmReviews]
+  );
+
+  const handleSavePkmReview = useCallback(
+    async (reviewId: string) => {
+      const review = pkmReviews.find((item) => item.id === reviewId);
+      const token = getVaultOwnerToken();
+      if (!review || !user?.uid || !vaultKey || !token) {
+        toast.error("Unlock your vault before saving to PKM.");
+        return;
+      }
+
+      setPkmReviews((current) =>
+        current.map((item) => (item.id === reviewId ? { ...item, saving: true } : item))
+      );
+      setActivePkmToolCount((count) => count + 1);
+      appendDebugEvent(review.turnId, "pkm_review_save_start", {
+        review_id: review.id,
+        candidate_count: review.cards.length,
+      });
+
+      try {
+        const result = await addToPKM({
+          userId: user.uid,
+          cards: review.cards,
+          sourceMessage: review.sourceMessage,
+          vaultKey,
+          vaultOwnerToken: token,
+          source: "agent_chat_review",
+        });
+        appendDebugEvent(review.turnId, "pkm_review_save_result", result);
+        if (result.saved > 0) {
+          appendMessage({
+            id: `msg-${Date.now()}-pkm-review-saved`,
+            role: "assistant",
+            text: formatAgentPkmSaveSummary(result),
+            timestamp: formatNow(),
+            status: "done",
+            ephemeral: true,
+          });
+          setPkmReviews((current) => current.filter((item) => item.id !== reviewId));
+          void loadAgentPkmContext({
+            userId: user.uid,
+            vaultOwnerToken: token,
+            forceRefresh: true,
+          }).catch(() => undefined);
+          toast.success("Saved to PKM.");
+          return;
+        }
+
+        setPkmReviews((current) =>
+          current.map((item) => (item.id === reviewId ? { ...item, saving: false } : item))
+        );
+        toast.error(formatAgentPkmSaveSummary(result));
+      } catch (error) {
+        const message =
+          error instanceof Error && error.message
+            ? error.message
+            : "Failed to save PKM memory.";
+        appendDebugEvent(review.turnId, "pkm_review_save_failed", { message });
+        setPkmReviews((current) =>
+          current.map((item) => (item.id === reviewId ? { ...item, saving: false } : item))
+        );
+        toast.error(message);
+      } finally {
+        setActivePkmToolCount((count) => Math.max(0, count - 1));
+      }
+    },
+    [appendDebugEvent, getVaultOwnerToken, pkmReviews, user?.uid, vaultKey]
+  );
 
   const ensureVoiceUserMessage = () => {
     if (voiceUserMessageIdRef.current) return voiceUserMessageIdRef.current;
@@ -606,6 +908,7 @@ export function AgentScreen() {
     const assistantMessageId = `msg-${turnId}-assistant`;
     const executedToolCalls = new Set<string>();
     let toolStatusMessageId: string | null = null;
+    let pkmStatusMessageId: string | null = null;
     let assistantHasToken = false;
 
     const upsertToolStatusMessage = (
@@ -643,6 +946,38 @@ export function AgentScreen() {
       }));
     };
 
+    const upsertPkmStatusMessage = (
+      messageText: string,
+      status: AgentMessage["status"] = "streaming"
+    ) => {
+      const cleanText = messageText.trim();
+      if (!cleanText) {
+        if (pkmStatusMessageId) {
+          removeMessage(pkmStatusMessageId);
+          pkmStatusMessageId = null;
+        }
+        return;
+      }
+      if (pkmStatusMessageId) {
+        updateMessage(pkmStatusMessageId, (message) => ({
+          ...message,
+          text: cleanText,
+          status,
+          ephemeral: true,
+        }));
+        return;
+      }
+      pkmStatusMessageId = `msg-${turnId}-pkm-status`;
+      appendMessage({
+        id: pkmStatusMessageId,
+        role: "assistant",
+        text: cleanText,
+        timestamp: formatNow(),
+        status,
+        ephemeral: true,
+      });
+    };
+
     const toolResultStatus = (result: AgentActionRuntimeResult): AgentMessage["status"] => {
       if (result.status === "blocked" || result.status === "failed" || result.status === "invalid") {
         return "error";
@@ -652,7 +987,7 @@ export function AgentScreen() {
 
     const executeFrontendTool = async (toolEvent: AgentChatToolEvent) => {
       if (!toolEvent.actionId) return;
-      setActiveToolCount((count) => count + 1);
+      setActiveFrontendToolCount((count) => count + 1);
       appendDebugEvent(debugTurnId, "frontend_execute_start", toolEvent);
       try {
         const result = await executeAgentGatewayAction({
@@ -680,7 +1015,7 @@ export function AgentScreen() {
         });
         upsertToolStatusMessage(message, "error");
       } finally {
-        setActiveToolCount((count) => Math.max(0, count - 1));
+        setActiveFrontendToolCount((count) => Math.max(0, count - 1));
       }
     };
 
@@ -690,6 +1025,120 @@ export function AgentScreen() {
       if (toolEvent.execution !== "frontend" || !toolEvent.actionId) return;
       executedToolCalls.add(callKey);
       void executeFrontendTool(toolEvent);
+    };
+
+    const runPkmMemoryCapture = async (
+      pkmContext: AgentPkmContext,
+      signal: AbortSignal
+    ) => {
+      if (signal.aborted) return;
+      if (!vaultKey || !token) {
+        appendDebugEvent(debugTurnId, "pkm_memory_skipped", {
+          reason: !vaultKey ? "vault_key_unavailable" : "vault_owner_token_unavailable",
+        });
+        return;
+      }
+
+      setActivePkmToolCount((count) => count + 1);
+      appendDebugEvent(debugTurnId, "pkm_memory_preview_start", {
+        tool: "addToPKM",
+        execution: "frontend",
+        current_domains: pkmContext.domains,
+      });
+      upsertPkmStatusMessage("Checking whether this belongs in PKM...", "streaming");
+
+      try {
+        const preview = await previewAgentPkmMemory({
+          userId,
+          message: text,
+          currentDomains: pkmContext.domains,
+          vaultOwnerToken: token,
+        });
+        if (signal.aborted) return;
+        const cards = preview.cards;
+        const autoSaveCards = getAutoSavePkmCards(cards);
+        const reviewCards = getReviewRequiredPkmCards(cards);
+        const ignoredCards = getIgnoredPkmCards(cards);
+
+        appendDebugEvent(debugTurnId, "pkm_memory_preview_result", {
+          model: preview.model,
+          used_fallback: preview.used_fallback,
+          total_cards: cards.length,
+          auto_save_count: autoSaveCards.length,
+          review_count: reviewCards.length,
+          ignored_count: ignoredCards.length,
+          preview_summary: preview.preview_summary || null,
+          cards,
+        });
+
+        if (autoSaveCards.length > 0) {
+          upsertPkmStatusMessage("Saving durable memory to PKM...", "streaming");
+          appendDebugEvent(debugTurnId, "pkm_memory_save_start", {
+            candidate_count: autoSaveCards.length,
+          });
+          const saveResult = await addToPKM({
+            userId,
+            cards: autoSaveCards,
+            sourceMessage: text,
+            vaultKey,
+            vaultOwnerToken: token,
+            source: "agent_chat_auto",
+          });
+          if (signal.aborted) return;
+          appendDebugEvent(debugTurnId, "pkm_memory_save_result", saveResult);
+          upsertPkmStatusMessage(
+            formatAgentPkmSaveSummary(saveResult),
+            saveResult.saved > 0 ? "done" : "error"
+          );
+          if (saveResult.saved > 0) {
+            void loadAgentPkmContext({
+              userId,
+              vaultOwnerToken: token,
+              forceRefresh: true,
+            }).catch(() => undefined);
+          }
+        }
+
+        if (reviewCards.length > 0) {
+          if (signal.aborted) return;
+          setPkmReviews((current) => [
+            ...current.filter((review) => review.turnId !== debugTurnId),
+            {
+              id: `${debugTurnId}-pkm-review`,
+              turnId: debugTurnId,
+              sourceMessage: text,
+              cards: reviewCards,
+              saving: false,
+            },
+          ]);
+          appendDebugEvent(debugTurnId, "pkm_memory_review_required", {
+            candidate_count: reviewCards.length,
+            cards: reviewCards,
+          });
+          if (autoSaveCards.length === 0) {
+            upsertPkmStatusMessage(
+              "Agent found PKM memory that needs your review before saving.",
+              "done"
+            );
+          }
+        }
+
+        if (autoSaveCards.length === 0 && reviewCards.length === 0) {
+          upsertPkmStatusMessage("", "done");
+        }
+      } catch (error) {
+        if (signal.aborted) return;
+        const message =
+          error instanceof Error && error.message
+            ? error.message
+            : "Agent could not update PKM memory for this turn.";
+        appendDebugEvent(debugTurnId, "pkm_memory_failed", {
+          message,
+        });
+        upsertPkmStatusMessage("Agent could not update PKM memory for this turn.", "error");
+      } finally {
+        setActivePkmToolCount((count) => Math.max(0, count - 1));
+      }
     };
 
     setMessages((current) => [
@@ -724,22 +1173,60 @@ export function AgentScreen() {
       return;
     }
 
+    const streamAbortController = new AbortController();
+    streamAbortControllerRef.current?.abort();
+    streamAbortControllerRef.current = streamAbortController;
+
     try {
+      let agentPkmContext = EMPTY_PKM_CONTEXT;
+      try {
+        agentPkmContext = await loadAgentPkmContext({
+          userId,
+          vaultOwnerToken: token,
+        });
+        if (streamAbortController.signal.aborted) return;
+        if (agentPkmContext.text) {
+          appendDebugEvent(debugTurnId, "pkm_context_loaded", {
+            domain_count: agentPkmContext.domains.length,
+            total_attributes: agentPkmContext.totalAttributes,
+            updated_at: agentPkmContext.updatedAt,
+          });
+        }
+      } catch (error) {
+        appendDebugEvent(debugTurnId, "pkm_context_load_failed", {
+          message:
+            error instanceof Error && error.message
+              ? error.message
+              : "Failed to load compact PKM context.",
+        });
+      }
+
+      const pkmAbortController = new AbortController();
+      pkmAbortControllersRef.current.add(pkmAbortController);
+      void runPkmMemoryCapture(agentPkmContext, pkmAbortController.signal).finally(() => {
+        pkmAbortControllersRef.current.delete(pkmAbortController);
+      });
+
       await streamAgentChat({
         userId,
         message: text,
         conversationId,
         vaultOwnerToken: token,
+        pkmContext: agentPkmContext.text || undefined,
+        signal: streamAbortController.signal,
         handlers: {
           onStart: ({ conversationId: nextConversationId }) => {
+            if (streamAbortController.signal.aborted) return;
             if (nextConversationId) {
               setConversationId(nextConversationId);
             }
           },
           onToolStart: (toolEvent) => {
+            if (streamAbortController.signal.aborted) return;
             appendDebugEvent(debugTurnId, "tool_start", toolEvent);
           },
           onToolWaiting: (toolEvent) => {
+            if (streamAbortController.signal.aborted) return;
             appendDebugEvent(debugTurnId, "tool_waiting", toolEvent);
             upsertToolStatusMessage(
               toolEvent.message || "Working on that in Kai...",
@@ -748,6 +1235,7 @@ export function AgentScreen() {
             executeToolIfNeeded(toolEvent);
           },
           onToolResult: (toolEvent) => {
+            if (streamAbortController.signal.aborted) return;
             appendDebugEvent(debugTurnId, "tool_result", toolEvent);
             if (toolEvent.execution === "blocked" || toolEvent.status === "blocked") {
               upsertToolStatusMessage(
@@ -757,6 +1245,7 @@ export function AgentScreen() {
             }
           },
           onToken: (delta) => {
+            if (streamAbortController.signal.aborted) return;
             assistantHasToken = true;
             updateMessage(assistantMessageId, (message) => ({
               ...message,
@@ -766,6 +1255,7 @@ export function AgentScreen() {
             }));
           },
           onComplete: ({ conversationId: nextConversationId }) => {
+            if (streamAbortController.signal.aborted) return;
             if (nextConversationId) {
               setConversationId(nextConversationId);
             }
@@ -777,6 +1267,7 @@ export function AgentScreen() {
             setIsStreaming(false);
           },
           onError: (message) => {
+            if (streamAbortController.signal.aborted) return;
             updateMessage(assistantMessageId, (current) => ({
               ...current,
               text: current.text || message,
@@ -787,6 +1278,7 @@ export function AgentScreen() {
           },
         },
       });
+      if (streamAbortController.signal.aborted) return;
       updateMessage(assistantMessageId, (message) => {
         if (message.status === "error") return message;
         return {
@@ -795,9 +1287,11 @@ export function AgentScreen() {
           status: "done",
         };
       });
+      void loadConversationList().catch(() => undefined);
       setIsChatLoading(false);
       setIsStreaming(false);
     } catch (error) {
+      if (streamAbortController.signal.aborted) return;
       const message =
         error instanceof Error && error.message
           ? error.message
@@ -807,8 +1301,13 @@ export function AgentScreen() {
         text: current.text || message,
         status: "error",
       }));
+      void loadConversationList().catch(() => undefined);
       setIsChatLoading(false);
       setIsStreaming(false);
+    } finally {
+      if (streamAbortControllerRef.current === streamAbortController) {
+        streamAbortControllerRef.current = null;
+      }
     }
   };
 
@@ -915,7 +1414,7 @@ export function AgentScreen() {
 
   return (
     <AppPageShell
-      width="reading"
+      width="expanded"
       className="px-[var(--page-inline-gutter-standard)] py-[var(--page-block-padding)]"
       nativeTest={{
         routeId: "/agent",
@@ -960,62 +1459,86 @@ export function AgentScreen() {
       </AppPageHeaderRegion>
 
       <AppPageContentRegion className="mt-5">
-        <section className="overflow-hidden rounded-lg border border-border/70 bg-card shadow-sm">
-          <div className="max-h-[min(68vh,680px)] space-y-5 overflow-y-auto p-4 sm:p-5">
-            {accessMessage ? (
-              <div className="rounded-lg border border-border/70 bg-background px-4 py-5 text-sm text-muted-foreground">
-                {accessMessage}
-              </div>
-            ) : null}
+        <div className="flex flex-col gap-3 lg:flex-row">
+          <AgentHistorySidebar
+            conversations={conversations}
+            activeConversationId={conversationId}
+            collapsed={isHistorySidebarCollapsed}
+            loading={isLoadingHistory && conversations.length === 0}
+            disabled={!hasChatAccess || historyInteractionDisabled}
+            actionPendingId={historyActionPendingId}
+            onToggleCollapsed={() => setIsHistorySidebarCollapsed((current) => !current)}
+            onCreateNew={handleCreateNewChat}
+            onSelectConversation={handleSelectConversation}
+            onRenameConversation={handleRenameConversation}
+            onDeleteConversation={handleDeleteConversation}
+          />
 
-            {debugOpen ? (
-              <AgentDebugPanel
-                events={latestDebugEvents}
-                onCopyLatest={handleCopyLatestDebug}
-              />
-            ) : null}
+          <section className="min-w-0 flex-1 overflow-hidden rounded-lg border border-border/70 bg-card shadow-sm">
+            <div className="max-h-[min(68vh,680px)] space-y-5 overflow-y-auto p-4 sm:p-5">
+              {accessMessage ? (
+                <div className="rounded-lg border border-border/70 bg-background px-4 py-5 text-sm text-muted-foreground">
+                  {accessMessage}
+                </div>
+              ) : null}
 
-            {messages.map((message) => (
-              <AgentBubble key={message.id} message={message} />
-            ))}
-            <div ref={messagesEndRef} />
-          </div>
+              {debugOpen ? (
+                <AgentDebugPanel
+                  events={latestDebugEvents}
+                  onCopyLatest={handleCopyLatestDebug}
+                />
+              ) : null}
 
-          <form
-            onSubmit={handleSubmit}
-            className="flex items-center gap-2 border-t border-border/70 bg-background/80 p-3"
-          >
-            <input
-              value={input}
-              onChange={(event) => setInput(event.target.value)}
-              disabled={
-                !hasChatAccess ||
-                isChatLoading ||
-                isToolWorking ||
-                isVoiceConnecting ||
-                isStreaming ||
-                voiceActive
-              }
-              placeholder="Ask Agent about markets, portfolio, analysis..."
-              className="h-11 min-w-0 flex-1 rounded-md border border-border/70 bg-background px-4 text-sm outline-none transition-colors placeholder:text-muted-foreground focus:border-primary/60"
-            />
-            <Button
-              type="button"
-              variant={voiceActive ? "secondary" : "outline"}
-              size="icon"
-              disabled={!canToggleVoice}
-              onClick={handleToggleVoice}
-              aria-label={voiceActive ? "Stop voice session" : "Start voice session"}
-              aria-pressed={voiceActive}
-              title={voiceActive ? "Stop voice session" : "Start voice session"}
+              {messages.map((message) => (
+                <AgentBubble key={message.id} message={message} />
+              ))}
+
+              {pkmReviews.map((review) => (
+                <AgentPkmReviewPanel
+                  key={review.id}
+                  cards={review.cards}
+                  saving={review.saving}
+                  onSave={() => void handleSavePkmReview(review.id)}
+                  onDismiss={() => handleDismissPkmReview(review.id)}
+                />
+              ))}
+              <div ref={messagesEndRef} />
+            </div>
+
+            <form
+              onSubmit={handleSubmit}
+              className="flex items-center gap-2 border-t border-border/70 bg-background/80 p-3"
             >
-              {voiceActive ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />}
-            </Button>
-            <Button type="submit" size="icon" disabled={!canSend} aria-label="Send message">
-              <Send className="h-4 w-4" />
-            </Button>
-          </form>
-        </section>
+              <input
+                value={input}
+                onChange={(event) => setInput(event.target.value)}
+                disabled={
+                  !hasChatAccess ||
+                  isLoadingHistory ||
+                  isVoiceConnecting ||
+                  voiceActive
+                }
+                placeholder="Ask Agent about markets, portfolio, analysis..."
+                className="h-11 min-w-0 flex-1 rounded-md border border-border/70 bg-background px-4 text-sm outline-none transition-colors placeholder:text-muted-foreground focus:border-primary/60"
+              />
+              <Button
+                type="button"
+                variant={voiceActive ? "secondary" : "outline"}
+                size="icon"
+                disabled={!canToggleVoice}
+                onClick={handleToggleVoice}
+                aria-label={voiceActive ? "Stop voice session" : "Start voice session"}
+                aria-pressed={voiceActive}
+                title={voiceActive ? "Stop voice session" : "Start voice session"}
+              >
+                {voiceActive ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />}
+              </Button>
+              <Button type="submit" size="icon" disabled={!canSend} aria-label="Send message">
+                <Send className="h-4 w-4" />
+              </Button>
+            </form>
+          </section>
+        </div>
       </AppPageContentRegion>
     </AppPageShell>
   );

--- a/hushh-webapp/lib/agent/agent-pkm-memory.ts
+++ b/hushh-webapp/lib/agent/agent-pkm-memory.ts
@@ -1,0 +1,411 @@
+"use client";
+
+import type { DomainManifest } from "@/lib/personal-knowledge-model/manifest";
+import { buildReadablePkmMetadata } from "@/lib/personal-knowledge-model/natural-language";
+import { ApiService } from "@/lib/services/api-service";
+import {
+  PersonalKnowledgeModelService,
+  type PersonalKnowledgeModelMetadata,
+} from "@/lib/services/personal-knowledge-model-service";
+import {
+  PkmWriteCoordinator,
+  type PkmWriteCoordinatorResult,
+} from "@/lib/services/pkm-write-coordinator";
+
+export type AgentPkmDomainChoice = {
+  domain_key: string;
+  display_name: string;
+  description: string;
+  recommended: boolean;
+};
+
+export type AgentPkmIntentFrame = {
+  save_class?: string;
+  intent_class?: string;
+  mutation_intent?: string;
+  requires_confirmation?: boolean;
+  confirmation_reason?: string;
+  candidate_domain_choices?: AgentPkmDomainChoice[];
+};
+
+export type AgentPkmPreviewCard = {
+  card_id: string;
+  source_text: string;
+  save_class?: string;
+  intent_class?: string;
+  mutation_intent?: string;
+  merge_mode?: string;
+  target_domain?: string;
+  primary_json_path?: string | null;
+  target_entity_scope?: string | null;
+  target_entity_id?: string | null;
+  write_mode?: "can_save" | "confirm_first" | "do_not_save" | string;
+  requires_confirmation?: boolean;
+  confirmation_reason?: string;
+  candidate_domain_choices?: AgentPkmDomainChoice[];
+  validation_hints?: string[];
+  intent_frame?: AgentPkmIntentFrame;
+  merge_decision?: Record<string, unknown>;
+  candidate_payload?: Record<string, unknown>;
+  structure_decision?: Record<string, unknown>;
+  manifest_draft?: DomainManifest | null;
+};
+
+export type AgentPkmPreviewResponse = {
+  agent_id: string;
+  agent_name: string;
+  model: string;
+  used_fallback: boolean;
+  routing_decision?: string;
+  error?: string | null;
+  intent_frame?: AgentPkmIntentFrame;
+  merge_decision?: Record<string, unknown>;
+  candidate_payload?: Record<string, unknown>;
+  structure_decision?: Record<string, unknown>;
+  write_mode?: string;
+  primary_json_path?: string | null;
+  target_entity_scope?: string | null;
+  validation_hints?: string[];
+  manifest_draft?: DomainManifest | null;
+  preview_cards?: AgentPkmPreviewCard[];
+  preview_summary?: Record<string, unknown>;
+  performance?: Record<string, unknown>;
+};
+
+export type AgentPkmContext = {
+  text: string;
+  domains: string[];
+  totalAttributes: number;
+  updatedAt: string | null;
+};
+
+export type AgentPkmSaveResult = {
+  attempted: number;
+  saved: number;
+  failed: number;
+  domains: string[];
+  results: Array<{
+    cardId: string;
+    domain: string;
+    success: boolean;
+    message?: string;
+    result?: PkmWriteCoordinatorResult;
+  }>;
+};
+
+function toRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function compactText(value: unknown, maxLength: number): string {
+  const text = String(value || "").trim().replace(/\s+/g, " ");
+  if (!text) return "";
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, Math.max(0, maxLength - 1)).trimEnd()}...`;
+}
+
+function titleize(value: string | null | undefined): string {
+  return String(value || "")
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (match) => match.toUpperCase())
+    .trim();
+}
+
+function normalizePreviewCards(response: AgentPkmPreviewResponse): AgentPkmPreviewCard[] {
+  if (Array.isArray(response.preview_cards)) {
+    return response.preview_cards;
+  }
+  if (!response.candidate_payload || !response.structure_decision) {
+    return [];
+  }
+  return [
+    {
+      card_id: "agent_pkm_preview_1",
+      source_text: "",
+      save_class: response.intent_frame?.save_class,
+      intent_class: response.intent_frame?.intent_class,
+      mutation_intent: response.intent_frame?.mutation_intent,
+      target_domain: readString(response.structure_decision.target_domain),
+      primary_json_path: response.primary_json_path ?? null,
+      target_entity_scope: response.target_entity_scope ?? null,
+      write_mode: response.write_mode,
+      requires_confirmation: response.intent_frame?.requires_confirmation,
+      confirmation_reason: response.intent_frame?.confirmation_reason,
+      candidate_domain_choices: response.intent_frame?.candidate_domain_choices,
+      validation_hints: response.validation_hints,
+      intent_frame: response.intent_frame,
+      merge_decision: response.merge_decision,
+      candidate_payload: response.candidate_payload,
+      structure_decision: response.structure_decision,
+      manifest_draft: response.manifest_draft ?? null,
+    },
+  ];
+}
+
+export function getAutoSavePkmCards(cards: readonly AgentPkmPreviewCard[]): AgentPkmPreviewCard[] {
+  return cards.filter((card) => card.write_mode === "can_save");
+}
+
+export function getReviewRequiredPkmCards(
+  cards: readonly AgentPkmPreviewCard[]
+): AgentPkmPreviewCard[] {
+  return cards.filter((card) => card.write_mode === "confirm_first");
+}
+
+export function getIgnoredPkmCards(cards: readonly AgentPkmPreviewCard[]): AgentPkmPreviewCard[] {
+  return cards.filter((card) => card.write_mode === "do_not_save");
+}
+
+export async function previewAgentPkmMemory(params: {
+  userId: string;
+  message: string;
+  currentDomains: string[];
+  vaultOwnerToken: string;
+}): Promise<AgentPkmPreviewResponse & { cards: AgentPkmPreviewCard[] }> {
+  const response = await ApiService.apiFetch("/api/pkm/agent-lab/structure", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${params.vaultOwnerToken}`,
+    },
+    body: JSON.stringify({
+      user_id: params.userId,
+      message: params.message,
+      current_domains: params.currentDomains,
+    }),
+  });
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    throw new Error(detail || `PKM memory preview failed with ${response.status}`);
+  }
+
+  const payload = (await response.json()) as AgentPkmPreviewResponse;
+  return {
+    ...payload,
+    cards: normalizePreviewCards(payload).map((card, index) => ({
+      ...card,
+      card_id: card.card_id || `agent_pkm_preview_${index + 1}`,
+      source_text: card.source_text || params.message,
+    })),
+  };
+}
+
+function resolveCardTargetDomain(card: AgentPkmPreviewCard): string {
+  const structureDecision = toRecord(card.structure_decision);
+  const manifestDraft = card.manifest_draft && typeof card.manifest_draft === "object"
+    ? card.manifest_draft
+    : null;
+  return (
+    readString(manifestDraft?.domain) ||
+    readString(structureDecision.target_domain) ||
+    readString(card.target_domain)
+  );
+}
+
+export async function addToPKM(params: {
+  userId: string;
+  cards: AgentPkmPreviewCard[];
+  sourceMessage: string;
+  vaultKey: string;
+  vaultOwnerToken: string;
+  source?: string;
+}): Promise<AgentPkmSaveResult> {
+  const results: AgentPkmSaveResult["results"] = [];
+
+  for (const card of params.cards) {
+    const candidatePayload = toRecord(card.candidate_payload);
+    const structureDecision = toRecord(card.structure_decision);
+    const manifestDraft =
+      card.manifest_draft && typeof card.manifest_draft === "object"
+        ? card.manifest_draft
+        : null;
+    const targetDomain = resolveCardTargetDomain(card);
+    const cardId = card.card_id || "agent_pkm_card";
+
+    if (Object.keys(candidatePayload).length === 0 || !targetDomain) {
+      results.push({
+        cardId,
+        domain: targetDomain || "unknown",
+        success: false,
+        message: "PKM preview did not produce a valid target domain or payload.",
+      });
+      continue;
+    }
+
+    const summaryProjection = toRecord(structureDecision.summary_projection);
+    const readableMetadata = buildReadablePkmMetadata({
+      domainKey: targetDomain,
+      domainDisplayName: titleize(targetDomain),
+      sourceText: card.source_text || params.sourceMessage,
+      mergeMode:
+        readString(card.merge_mode) ||
+        readString(card.merge_decision?.merge_mode) ||
+        null,
+      intentClass:
+        readString(card.intent_class) ||
+        readString(card.intent_frame?.intent_class) ||
+        null,
+      manifest: manifestDraft,
+      structureDecision,
+      primaryJsonPath: readString(card.primary_json_path) || null,
+      targetEntityScope: readString(card.target_entity_scope) || null,
+    });
+    const nextSummaryProjection = {
+      ...summaryProjection,
+      ...readableMetadata,
+    };
+    const nextStructureDecision = {
+      ...structureDecision,
+      summary_projection: nextSummaryProjection,
+    };
+    const nextManifest =
+      manifestDraft && typeof manifestDraft === "object"
+        ? ({
+            ...manifestDraft,
+            summary_projection: {
+              ...(manifestDraft.summary_projection || {}),
+              ...readableMetadata,
+            },
+          } as DomainManifest)
+        : null;
+
+    try {
+      const result = await PkmWriteCoordinator.savePreparedDomain({
+        userId: params.userId,
+        domain: targetDomain,
+        vaultKey: params.vaultKey,
+        vaultOwnerToken: params.vaultOwnerToken,
+        build: async () => ({
+          domainData: candidatePayload,
+          summary: {
+            ...nextSummaryProjection,
+            message_excerpt: compactText(card.source_text || params.sourceMessage, 160),
+            source: params.source || "agent_chat",
+            card_id: cardId,
+          },
+          mergeDecision: card.merge_decision,
+          structureDecision: nextStructureDecision,
+          manifest: nextManifest || undefined,
+        }),
+      });
+      results.push({
+        cardId,
+        domain: targetDomain,
+        success: result.success,
+        message: result.message,
+        result,
+      });
+    } catch (error) {
+      results.push({
+        cardId,
+        domain: targetDomain,
+        success: false,
+        message: error instanceof Error ? error.message : "Failed to save PKM memory.",
+      });
+    }
+  }
+
+  const savedResults = results.filter((result) => result.success);
+  return {
+    attempted: results.length,
+    saved: savedResults.length,
+    failed: results.length - savedResults.length,
+    domains: Array.from(new Set(savedResults.map((result) => result.domain))).filter(Boolean),
+    results,
+  };
+}
+
+export function buildAgentPkmContextFromMetadata(
+  metadata: PersonalKnowledgeModelMetadata | null
+): AgentPkmContext {
+  if (!metadata) {
+    return {
+      text: "",
+      domains: [],
+      totalAttributes: 0,
+      updatedAt: null,
+    };
+  }
+
+  const domains = metadata.domains
+    .filter((domain) => {
+      const hasSummary = Boolean(compactText(domain.readableSummary, 220));
+      const hasHighlights = Array.isArray(domain.readableHighlights) && domain.readableHighlights.length > 0;
+      return domain.attributeCount > 0 || hasSummary || hasHighlights;
+    })
+    .slice(0, 8);
+
+  if (domains.length === 0) {
+    return {
+      text: "No saved PKM summaries are available yet.",
+      domains: metadata.domains.map((domain) => domain.key).filter(Boolean),
+      totalAttributes: metadata.totalAttributes || 0,
+      updatedAt: metadata.lastUpdated || null,
+    };
+  }
+
+  const lines = [
+    "PKM compact context for Agent (summary metadata only; not the full decrypted PKM):",
+    `Saved domains: ${domains.map((domain) => domain.displayName || domain.key).join(", ")}`,
+    `Total saved details: ${metadata.totalAttributes || 0}`,
+  ];
+
+  for (const domain of domains) {
+    const highlights = Array.isArray(domain.readableHighlights)
+      ? domain.readableHighlights.map((item) => compactText(item, 100)).filter(Boolean).slice(0, 3)
+      : [];
+    const summary =
+      compactText(domain.readableSummary, 240) ||
+      compactText(domain.summary?.readable_summary, 240) ||
+      compactText(domain.summary?.message_excerpt, 160) ||
+      `${domain.attributeCount || 0} saved detail${domain.attributeCount === 1 ? "" : "s"}.`;
+    lines.push(
+      [
+        `- ${domain.displayName || titleize(domain.key)} (${domain.key})`,
+        summary ? `summary: ${summary}` : null,
+        highlights.length > 0 ? `highlights: ${highlights.join("; ")}` : null,
+        domain.lastUpdated ? `updated: ${domain.lastUpdated}` : null,
+      ]
+        .filter(Boolean)
+        .join(" | ")
+    );
+  }
+
+  return {
+    text: lines.join("\n").slice(0, 6000),
+    domains: metadata.domains.map((domain) => domain.key).filter(Boolean),
+    totalAttributes: metadata.totalAttributes || 0,
+    updatedAt: metadata.lastUpdated || null,
+  };
+}
+
+export async function loadAgentPkmContext(params: {
+  userId: string;
+  vaultOwnerToken: string;
+  forceRefresh?: boolean;
+}): Promise<AgentPkmContext> {
+  const metadata = await PersonalKnowledgeModelService.getMetadata(
+    params.userId,
+    params.forceRefresh === true,
+    params.vaultOwnerToken
+  );
+  return buildAgentPkmContextFromMetadata(metadata);
+}
+
+export function formatAgentPkmSaveSummary(result: AgentPkmSaveResult): string {
+  if (result.saved === 0) {
+    return result.failed > 0
+      ? "Agent could not save that PKM memory."
+      : "No PKM memory was saved for this turn.";
+  }
+  const domainText =
+    result.domains.length > 0 ? ` (${result.domains.map(titleize).join(", ")})` : "";
+  return `Saved ${result.saved} PKM memor${result.saved === 1 ? "y" : "ies"}${domainText}.`;
+}

--- a/hushh-webapp/lib/consent/use-consent-actions.ts
+++ b/hushh-webapp/lib/consent/use-consent-actions.ts
@@ -75,6 +75,24 @@ function getScopeDataEndpoint(scope: string): string | null {
   return scopeMap[scope] || null;
 }
 
+function extractConsentActionError(errorText: string): string {
+  try {
+    const parsed = JSON.parse(errorText);
+    if (typeof parsed?.error === "string") {
+      return parsed.error;
+    }
+    if (typeof parsed?.detail === "string") {
+      return parsed.detail;
+    }
+    if (typeof parsed?.detail?.message === "string") {
+      return parsed.detail.message;
+    }
+  } catch {
+    // Fall through to the raw response body.
+  }
+  return errorText || "Failed to approve";
+}
+
 // ============================================================================
 // Hook
 // ============================================================================
@@ -372,7 +390,7 @@ export function useConsentActions(options: UseConsentActionsOptions = {}) {
         if (!response.ok) {
           const errorText = await response.text();
           console.error("[NativeDebug] Approval failed:", errorText);
-          throw new Error(errorText || "Failed to approve");
+          throw new Error(extractConsentActionError(errorText));
         }
 
         return "Consent approved!";

--- a/hushh-webapp/lib/services/agent-chat-client.ts
+++ b/hushh-webapp/lib/services/agent-chat-client.ts
@@ -89,6 +89,7 @@ export async function streamAgentChat(input: {
   message: string;
   conversationId?: string | null;
   vaultOwnerToken: string;
+  pkmContext?: string;
   signal?: AbortSignal;
   handlers?: AgentChatStreamHandlers;
 }): Promise<{ conversationId: string | null; model: string | null; text: string }> {
@@ -97,6 +98,7 @@ export async function streamAgentChat(input: {
     message: input.message,
     conversationId: input.conversationId || undefined,
     vaultOwnerToken: input.vaultOwnerToken,
+    pkmContext: input.pkmContext,
     signal: input.signal,
   });
 
@@ -223,4 +225,27 @@ export async function getAgentChatHistory(input: {
   }
   const payload = (await response.json()) as { messages?: AgentChatMessage[] };
   return Array.isArray(payload.messages) ? payload.messages : [];
+}
+
+export async function renameAgentChatConversation(input: {
+  conversationId: string;
+  title: string;
+  vaultOwnerToken: string;
+}): Promise<AgentChatConversation> {
+  const response = await ApiService.renameAgentChatConversation(input);
+  if (!response.ok) {
+    throw new Error(await readError(response));
+  }
+  return (await response.json()) as AgentChatConversation;
+}
+
+export async function deleteAgentChatConversation(input: {
+  conversationId: string;
+  vaultOwnerToken: string;
+}): Promise<{ conversation_id: string; deleted: boolean }> {
+  const response = await ApiService.deleteAgentChatConversation(input);
+  if (!response.ok) {
+    throw new Error(await readError(response));
+  }
+  return (await response.json()) as { conversation_id: string; deleted: boolean };
 }

--- a/hushh-webapp/lib/services/api-service.ts
+++ b/hushh-webapp/lib/services/api-service.ts
@@ -2486,6 +2486,7 @@ export class ApiService {
     message: string;
     conversationId?: string;
     vaultOwnerToken: string;
+    pkmContext?: string;
     signal?: AbortSignal;
   }): Promise<Response> {
     return ApiService.apiFetchStream("/api/kai/agent/chat/stream", {
@@ -2497,6 +2498,7 @@ export class ApiService {
         user_id: data.userId,
         message: data.message,
         conversation_id: data.conversationId,
+        pkm_context: data.pkmContext,
       }),
       signal: data.signal,
     });
@@ -2533,6 +2535,38 @@ export class ApiService {
       `/api/kai/agent/chat/history/${encodeURIComponent(data.conversationId)}${suffix}`,
       {
         method: "GET",
+        headers: {
+          Authorization: `Bearer ${data.vaultOwnerToken}`,
+        },
+      }
+    );
+  }
+
+  static async renameAgentChatConversation(data: {
+    conversationId: string;
+    title: string;
+    vaultOwnerToken: string;
+  }): Promise<Response> {
+    return apiFetch(
+      `/api/kai/agent/chat/conversations/${encodeURIComponent(data.conversationId)}`,
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${data.vaultOwnerToken}`,
+        },
+        body: JSON.stringify({ title: data.title }),
+      }
+    );
+  }
+
+  static async deleteAgentChatConversation(data: {
+    conversationId: string;
+    vaultOwnerToken: string;
+  }): Promise<Response> {
+    return apiFetch(
+      `/api/kai/agent/chat/conversations/${encodeURIComponent(data.conversationId)}`,
+      {
+        method: "DELETE",
         headers: {
           Authorization: `Bearer ${data.vaultOwnerToken}`,
         },


### PR DESCRIPTION
## Summary
- Wire the Agent chat flow around Gemini-backed streaming, durable chat history, and live tool/debug events.
- Add the Agent history sidebar, chat rename/delete actions, PKM capture/review UI, and frontend chat lifecycle handling.
- Extend backend Agent chat, consent/IAM support, docs, and tests for the new encrypted Agent memory surface.

## Verification
- `REQUIRE_GITHUB_ALERTS_CLEAN=0 ./bin/hushh codex pre-pr --text`
- `scripts/ci/orchestrate.sh protocol && scripts/ci/orchestrate.sh integration`
- `gitleaks git --redact --no-banner --exit-code 1 --config .gitleaks.toml --log-opts="--ancestry-path origin/main..HEAD"`
- `bash scripts/ci/check-dco-signoff.sh origin/main HEAD`

Note: local `gh` is not authenticated, so the GitHub repository alert parity subcheck was non-strict locally; CI will run with repository credentials. The new commit range gitleaks scan passed.
