### PR TITLE
fix(token): enforce revocation cache size cap; drop exception text from malformed-token reason

### DIFF
--- a/consent-protocol/hushh_mcp/consent/token.py
+++ b/consent-protocol/hushh_mcp/consent/token.py
@@ -46,8 +46,15 @@ class _BoundedRevocationCache:
         with self._lock:
             self._evict_expired_locked(now_ms)
             if len(self._entries) >= self._MAX_SIZE:
+                # TTL eviction alone did not free space — all remaining entries
+                # are still within their grace window.  Evict the one whose
+                # revocation marker will become redundant soonest (smallest
+                # evict_after_ms), because once a token's own expiry passes,
+                # validate_token() rejects it independently of the cache.
+                oldest_key = min(self._entries, key=lambda k: self._entries[k])
+                del self._entries[oldest_key]
                 logger.warning(
-                    "revocation_cache.size_cap_exceeded size=%s max_size=%s",
+                    "revocation_cache.size_cap_hit evicted_oldest size=%s max_size=%s",
                     len(self._entries),
                     self._MAX_SIZE,
                 )
@@ -291,10 +298,10 @@ def validate_token(
         )
         return True, None, token
 
-    except (ValueError, UnicodeDecodeError, binascii.Error) as e:
-        return False, f"Malformed token: {str(e)}", None
+    except (ValueError, UnicodeDecodeError, binascii.Error):
+        return False, "Malformed token", None
     except Exception as e:
-        logger.error(f"Unexpected error during token validation: {e}", exc_info=True)
+        logger.error("Unexpected error during token validation: %s", e, exc_info=True)
         raise
 
 
@@ -341,7 +348,7 @@ async def validate_token_with_db(
 
                 # Add to in-memory set for future fast checks
                 _revoked_tokens.add(token_str)
-                logger.warning(f"Token revoked in DB but not in memory: {token_str[:30]}...")
+                logger.warning("Token found revoked in DB but not in in-memory cache")
                 return False, "Token has been revoked (DB check)", None
     except Exception as e:
         # DB is unreachable — apply fail-closed policy based on token scope.

--- a/consent-protocol/tests/test_revocation_cache_cap.py
+++ b/consent-protocol/tests/test_revocation_cache_cap.py
@@ -1,0 +1,229 @@
+"""
+Regression tests for _BoundedRevocationCache size-cap enforcement.
+
+Attach point: hushh_mcp/consent/token.py (_BoundedRevocationCache.add)
+
+Bug: When TTL eviction freed no space (all entries still within their grace
+window), add() logged a warning but unconditionally inserted the new entry,
+allowing the cache to grow past MAX_SIZE without bound.
+
+Fix: When len >= MAX_SIZE after TTL eviction, evict the entry with the
+smallest evict_after_ms before inserting. That is the entry whose revocation
+marker becomes redundant soonest (its token expires first), and once expired,
+validate_token() rejects it independently of the cache.
+
+Additionally regresses:
+  - CWE-209: validate_token() no longer surfaces exception text in the reason
+    string for malformed tokens (was: f"Malformed token: {str(e)}").
+  - G004: logger calls in the same file converted to %-style.
+"""
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+from hushh_mcp.consent.token import (
+    _BoundedRevocationCache,
+    issue_token,
+    validate_token,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_cache(max_size: int = 5) -> _BoundedRevocationCache:
+    cache = _BoundedRevocationCache()
+    cache._MAX_SIZE = max_size
+    return cache
+
+
+def _future_evict(offset_ms: int = 1_000) -> int:
+    """Return an evict_after_ms value this many ms in the future."""
+    return int(time.time() * 1000) + offset_ms
+
+
+def _populate_cache_no_expiry(cache: _BoundedRevocationCache, n: int) -> list[str]:
+    """
+    Fill the cache with n entries that all have evict_after_ms far in the future
+    so TTL eviction will never remove them.
+    """
+    tokens = []
+    far_future = _future_evict(offset_ms=24 * 60 * 60 * 1000)  # 24 h from now
+    for i in range(n):
+        tok = f"hushh_consent:fake_token_{i}.sig"
+        cache._entries[tok] = far_future + i  # slightly different so min() is deterministic
+        tokens.append(tok)
+    return tokens
+
+
+# ===========================================================================
+# Size-cap enforcement
+# ===========================================================================
+
+
+def test_cache_never_exceeds_max_size():
+    """
+    Adding entries beyond MAX_SIZE must not grow the cache past the cap.
+    Previously the cap was logged but not enforced, allowing unbounded growth.
+    """
+    max_size = 5
+    cache = _make_cache(max_size)
+
+    # Fill to cap with entries that won't expire via TTL
+    _populate_cache_no_expiry(cache, max_size)
+    assert len(cache) == max_size
+
+    # Add one more — should evict the oldest (min evict_after_ms) and stay at cap
+    cache.add("hushh_consent:overflow_token.sig")
+
+    assert len(cache) <= max_size, (
+        f"Cache grew to {len(cache)} entries — size cap not enforced"
+    )
+
+
+def test_cache_evicts_soonest_expiring_entry_when_full():
+    """
+    When the cap is hit, the entry with the smallest evict_after_ms is evicted.
+    """
+    cache = _make_cache(max_size=3)
+    now_ms = int(time.time() * 1000)
+
+    # Insert three entries with known, distinct evict_after_ms values
+    cache._entries["tok_a"] = now_ms + 10_000   # expires soonest
+    cache._entries["tok_b"] = now_ms + 20_000
+    cache._entries["tok_c"] = now_ms + 30_000   # expires latest
+
+    cache.add("hushh_consent:new_token.sig")
+
+    # tok_a should have been evicted (smallest evict_after_ms)
+    assert "tok_a" not in cache._entries, "Expected soonest-expiring entry to be evicted"
+    assert "tok_b" in cache._entries
+    assert "tok_c" in cache._entries
+    assert len(cache) == 3
+
+
+def test_cap_enforced_across_many_additions():
+    """Repeated additions beyond the cap must never cause unbounded growth."""
+    max_size = 10
+    cache = _make_cache(max_size)
+    _populate_cache_no_expiry(cache, max_size)
+
+    for i in range(50):
+        cache.add(f"hushh_consent:extra_token_{i}.sig")
+        assert len(cache) <= max_size, (
+            f"Cache exceeded max_size after {i + 1} overflow additions"
+        )
+
+
+def test_cap_not_triggered_below_max_size():
+    """Additions below the cap must not evict anything."""
+    cache = _make_cache(max_size=10)
+    _populate_cache_no_expiry(cache, 5)
+
+    tokens_before = set(cache._entries.keys())
+    cache.add("hushh_consent:new_token.sig")
+
+    # All original tokens must still be present
+    for tok in tokens_before:
+        assert tok in cache._entries, f"Entry {tok} was unexpectedly evicted"
+
+
+def test_ttl_eviction_runs_before_cap_eviction():
+    """
+    If TTL eviction frees space, the size-cap eviction path must not run.
+    """
+    cache = _make_cache(max_size=3)
+    now_ms = int(time.time() * 1000)
+
+    # Two fresh entries
+    cache._entries["tok_a"] = now_ms + 30_000
+    cache._entries["tok_b"] = now_ms + 30_000
+    # One already expired
+    cache._entries["tok_expired"] = now_ms - 1  # past evict_after_ms
+
+    # Adding a new entry should trigger TTL eviction (removes tok_expired) and
+    # insert without hitting the cap path
+    cache.add("hushh_consent:new_token.sig")
+
+    assert "tok_expired" not in cache._entries
+    assert len(cache) == 3  # tok_a, tok_b, new_token
+
+
+# ===========================================================================
+# validate_token — CWE-209: malformed token reason must not leak exception text
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "bad_token",
+    [
+        "not_a_token",
+        "hushh_consent:!!invalid_base64!!.sig",
+        "hushh_consent:dGVzdA==.bad_sig",
+        "",
+        "hushh_consent:",
+        "hushh_consent:no_dot_separator",
+    ],
+)
+def test_malformed_token_reason_is_opaque(bad_token):
+    """
+    validate_token() must return the static string 'Malformed token' for any
+    structurally broken token — no exception text must leak into the reason.
+    """
+    valid, reason, token_obj = validate_token(bad_token)
+    assert not valid
+    assert token_obj is None
+
+    # Reason must be a single static string with no exception detail embedded
+    if reason and reason != "Token has been revoked":
+        assert reason in {
+            "Malformed token",
+            "Invalid token prefix",
+            "Token expired",
+        }, (
+            f"Malformed token reason leaks implementation detail: {reason!r}"
+        )
+        if reason == "Malformed token":
+            # Must not contain a colon followed by exception text
+            assert ":" not in reason, (
+                f"Reason appears to embed exception text: {reason!r}"
+            )
+
+
+# ===========================================================================
+# validate_token — G004 + logging: no f-string loggers remain
+# ===========================================================================
+
+
+import ast
+import pathlib
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+TOKEN_PY = REPO_ROOT / "hushh_mcp/consent/token.py"
+
+
+def test_no_fstring_loggers_in_token_py():
+    """AST check: no logger calls use JoinedStr (f-string) as first argument."""
+    source = TOKEN_PY.read_text()
+    tree = ast.parse(source, filename=str(TOKEN_PY))
+
+    violations = []
+
+    class Visitor(ast.NodeVisitor):
+        def visit_Call(self, node):
+            func = node.func
+            if isinstance(func, ast.Attribute) and func.attr in (
+                "debug", "info", "warning", "error", "critical", "exception",
+            ):
+                if node.args and isinstance(node.args[0], ast.JoinedStr):
+                    violations.append(node.lineno)
+            self.generic_visit(node)
+
+    Visitor().visit(tree)
+    assert violations == [], (
+        "hushh_mcp/consent/token.py still has f-string logger calls at lines: "
+        + ", ".join(str(n) for n in violations)
+    )

--- a/consent-protocol/tests/test_revocation_cache_cap.py
+++ b/consent-protocol/tests/test_revocation_cache_cap.py
@@ -18,14 +18,14 @@ Additionally regresses:
   - G004: logger calls in the same file converted to %-style.
 """
 
+import ast
+import pathlib
 import time
-from unittest.mock import patch
 
 import pytest
 
 from hushh_mcp.consent.token import (
     _BoundedRevocationCache,
-    issue_token,
     validate_token,
 )
 
@@ -197,9 +197,6 @@ def test_malformed_token_reason_is_opaque(bad_token):
 # validate_token — G004 + logging: no f-string loggers remain
 # ===========================================================================
 
-
-import ast
-import pathlib
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent
 TOKEN_PY = REPO_ROOT / "hushh_mcp/consent/token.py"


### PR DESCRIPTION
## Problem

Three bugs in `hushh_mcp/consent/token.py`:

### 1. Size cap not enforced in `_BoundedRevocationCache.add()` (Memory exhaustion)

PR #850 introduced `_BoundedRevocationCache` and documented:

> "When TTL eviction alone cannot free space, **the oldest-inserted entry is dropped**."

The actual implementation does not do this:

```python
def add(self, token_str: str) -> None:
    now_ms = int(time.time() * 1000)
    with self._lock:
        self._evict_expired_locked(now_ms)
        if len(self._entries) >= self._MAX_SIZE:
            logger.warning(...)   # logs the breach...
        self._entries[token_str] = ...   # ...but still inserts unconditionally
```

Under sustained load where all cached revocations are still within their 24h + 1h grace window, `_evict_expired_locked` removes nothing. The size check then logs a warning but **the new entry is inserted anyway**. The cache grows past `MAX_SIZE = 100_000` without bound, defeating the memory protection entirely.

### 2. CWE-209 in `validate_token()` malformed-token handler

```python
except (ValueError, UnicodeDecodeError, binascii.Error) as e:
    return False, f"Malformed token: {str(e)}", None  # leaks exception detail
```

The reason string (e.g. `"Malformed token: Invalid base64-encoded string: ..."`) is forwarded by callers in `db_proxy` and consent routes to HTTP responses, revealing token structure and format details.

### 3. G004 + log injection

Two f-string logger calls; one also logs `token_str[:30]` (partial token material to log output).

## Fix

**Bug 1**: When `len >= MAX_SIZE` after TTL eviction, evict the entry with the smallest `evict_after_ms` before inserting. That token expires soonest and its revocation marker becomes redundant first — `validate_token()` rejects expired tokens independently of the cache, so the eviction is safe.

```python
if len(self._entries) >= self._MAX_SIZE:
    oldest_key = min(self._entries, key=lambda k: self._entries[k])
    del self._entries[oldest_key]
    logger.warning("revocation_cache.size_cap_hit evicted_oldest ...")
self._entries[token_str] = self._evict_after_ms(token_str, now_ms)
```

**Bug 2**: Return `"Malformed token"` (static) instead of `f"Malformed token: {str(e)}"`.

**Bug 3**: Convert to `%`-style; remove partial token from log message.

## Test plan

- [x] `pytest tests/test_revocation_cache_cap.py` - **12 passed**, 0 failed
- [x] `ruff check hushh_mcp/consent/token.py` - All checks passed

| Test | Covers |
|---|---|
| `test_cache_never_exceeds_max_size` | Core regression — cap cannot be breached |
| `test_cache_evicts_soonest_expiring_entry_when_full` | Correct eviction target |
| `test_cap_enforced_across_many_additions` | 50 overflow insertions stay bounded |
| `test_cap_not_triggered_below_max_size` | No spurious evictions below cap |
| `test_ttl_eviction_runs_before_cap_eviction` | TTL path takes priority |
| `test_malformed_token_reason_is_opaque` (×6) | No exception text in reason |
| `test_no_fstring_loggers_in_token_py` | AST guard against G004 regression |