### PR TITLE
fix(portfolio): add max_length guards to user_id and run_id path/query params (CWE-400)

### DIFF
--- a/consent-protocol/api/routes/kai/portfolio.py
+++ b/consent-protocol/api/routes/kai/portfolio.py
@@ -2,6 +2,8 @@
 """
 Kai Portfolio API Route - Portfolio import and analysis endpoints.
 
+Attach point: api/routes/kai/portfolio.py
+
 Handles:
 - File upload (CSV/PDF) for brokerage statements
 - Portfolio summary retrieval
@@ -12,6 +14,13 @@ Authentication:
 - All endpoints require VAULT_OWNER token (consent-first architecture)
 - Token contains user_id, proving both identity and consent
 - Firebase is only used for bootstrap (issuing VAULT_OWNER token)
+
+Path/query-parameter length guards (CWE-400):
+  Several route handlers accept ``user_id`` and ``run_id`` as bare ``str``
+  path or query parameters.  Without an upper bound FastAPI forwards
+  arbitrarily large strings to log statements and DB queries.
+  ``_USER_ID_MAX_LEN`` and ``_RUN_ID_MAX_LEN`` cap these values before they
+  propagate downstream.
 """
 
 import asyncio
@@ -23,9 +32,19 @@ import re
 import time
 from collections import Counter
 from datetime import datetime, timezone
-from typing import Any, AsyncGenerator, Optional
+from typing import Annotated, Any, AsyncGenerator, Optional
 
-from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request, UploadFile, status
+from fastapi import (
+    APIRouter,
+    Depends,
+    Form,
+    HTTPException,
+    Path,
+    Query,
+    Request,
+    UploadFile,
+    status,
+)
 from pydantic import BaseModel, Field
 from sse_starlette.sse import EventSourceResponse
 
@@ -75,6 +94,16 @@ _PICK_TICKER_RE = re.compile(r"^[A-Z][A-Z0-9.\-]{0,9}$")
 _MAX_PROFILE_PICKS = 8
 _MAX_IMPORT_FILE_BYTES = 25 * 1024 * 1024
 _MAX_IMPORT_FILE_SIZE_MESSAGE = "File too large. Maximum size is 25MB."
+
+# CWE-400: upper bounds for path/query string parameters.
+# Firebase UIDs are 28 chars; 128 is a safe ceiling.
+# Run IDs are UUID4 (36 chars); 128 gives room for future formats.
+_USER_ID_MAX_LEN: int = 128
+_RUN_ID_MAX_LEN: int = 128
+
+# Reusable Annotated types for route parameters.
+UserId = Annotated[str, Path(max_length=_USER_ID_MAX_LEN)]
+RunId = Annotated[str, Path(max_length=_RUN_ID_MAX_LEN)]
 
 _NUMERIC_STRIP_RE = re.compile(r"[$,\s]")
 _FILENAME_DATE_RE = re.compile(r"(20\d{2}-\d{2}-\d{2})")
@@ -2134,7 +2163,7 @@ async def import_portfolio(
 
 @router.get("/portfolio/summary/{user_id}", response_model=PortfolioSummaryResponse)
 async def get_portfolio_summary(
-    user_id: str,
+    user_id: UserId,
     token_data: dict = Depends(require_vault_owner_token),
 ) -> PortfolioSummaryResponse:
     """
@@ -2189,7 +2218,7 @@ async def get_portfolio_summary(
 
 @router.get("/dashboard/profile-picks/{user_id}", response_model=DashboardProfilePicksResponse)
 async def get_dashboard_profile_picks(
-    user_id: str,
+    user_id: UserId,
     symbols: Optional[str] = Query(
         default=None,
         description="Optional comma-separated ticker symbols from current holdings context.",
@@ -3217,7 +3246,7 @@ async def start_portfolio_import_run(
 
 @router.get("/portfolio/import/run/active")
 async def get_active_portfolio_import_run(
-    user_id: str,
+    user_id: str = Query(..., max_length=_USER_ID_MAX_LEN),
     token_data: dict = Depends(require_vault_owner_token),
 ):
     if token_data["user_id"] != user_id:
@@ -3231,8 +3260,8 @@ async def get_active_portfolio_import_run(
 @router.get("/portfolio/import/run/{run_id}/stream")
 async def stream_portfolio_import_run(
     request: Request,
-    run_id: str,
-    user_id: str,
+    run_id: RunId,
+    user_id: str = Query(..., max_length=_USER_ID_MAX_LEN),
     cursor: Optional[int] = 0,
     token_data: dict = Depends(require_vault_owner_token),
 ):
@@ -3275,8 +3304,8 @@ async def stream_portfolio_import_run(
 
 @router.post("/portfolio/import/run/{run_id}/cancel")
 async def cancel_portfolio_import_run(
-    run_id: str,
-    user_id: str,
+    run_id: RunId,
+    user_id: str = Query(..., max_length=_USER_ID_MAX_LEN),
     token_data: dict = Depends(require_vault_owner_token),
 ):
     if token_data["user_id"] != user_id:

--- a/consent-protocol/tests/test_portfolio_path_param_bounds.py
+++ b/consent-protocol/tests/test_portfolio_path_param_bounds.py
@@ -1,0 +1,156 @@
+"""
+Regression tests for portfolio route path/query-parameter length enforcement.
+
+Attach point: api/routes/kai/portfolio.py
+
+Bug: Five route handlers accepted ``user_id`` or ``run_id`` as bare ``str``
+parameters with no upper-bound check (CWE-400: Uncontrolled Resource
+Consumption).  FastAPI forwarded arbitrarily large strings to log statements,
+error detail dicts, and downstream service calls.
+
+Affected routes:
+  GET  /portfolio/summary/{user_id}
+  GET  /dashboard/profile-picks/{user_id}
+  GET  /portfolio/import/run/active          (user_id query param)
+  GET  /portfolio/import/run/{run_id}/stream (run_id path + user_id query)
+  POST /portfolio/import/run/{run_id}/cancel (run_id path + user_id query)
+
+Fix: add ``_USER_ID_MAX_LEN = 128`` and ``_RUN_ID_MAX_LEN = 128`` module
+constants.  Path params use ``Annotated[str, Path(max_length=...)]`` via the
+``UserId`` / ``RunId`` type aliases; query params use ``Query(...,
+max_length=...)``.  FastAPI returns HTTP 422 for any value that exceeds the
+limit.
+
+Tests cover:
+- Constants exist and are within reasonable bounds
+- HTTP 422 for oversized user_id on GET /portfolio/summary/{user_id}
+- HTTP 422 for oversized user_id on GET /dashboard/profile-picks/{user_id}
+- HTTP 422 for oversized run_id on GET /portfolio/import/run/{run_id}/stream
+- HTTP 422 for oversized run_id on POST /portfolio/import/run/{run_id}/cancel
+- HTTP 422 for oversized user_id query param on GET /portfolio/import/run/active
+- Valid-length values are NOT rejected with 422 by the length check
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Constant-level checks (no network required)
+# ---------------------------------------------------------------------------
+import api.routes.kai.portfolio as _portfolio_mod
+
+
+def test_user_id_max_len_constant_exists():
+    assert hasattr(_portfolio_mod, "_USER_ID_MAX_LEN"), (
+        "_USER_ID_MAX_LEN constant missing from api/routes/kai/portfolio.py"
+    )
+
+
+def test_run_id_max_len_constant_exists():
+    assert hasattr(_portfolio_mod, "_RUN_ID_MAX_LEN"), (
+        "_RUN_ID_MAX_LEN constant missing from api/routes/kai/portfolio.py"
+    )
+
+
+def test_user_id_max_len_above_firebase_uid():
+    """Must accommodate Firebase UIDs (28 chars)."""
+    assert _portfolio_mod._USER_ID_MAX_LEN >= 28
+
+
+def test_user_id_max_len_not_absurdly_large():
+    assert _portfolio_mod._USER_ID_MAX_LEN <= 1024
+
+
+def test_run_id_max_len_above_uuid4():
+    """Must accommodate UUID4 run IDs (36 chars)."""
+    assert _portfolio_mod._RUN_ID_MAX_LEN >= 36
+
+
+def test_run_id_max_len_not_absurdly_large():
+    assert _portfolio_mod._RUN_ID_MAX_LEN <= 1024
+
+
+# ---------------------------------------------------------------------------
+# HTTP-layer tests (TestClient with stubbed vault-owner auth)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def client():
+    from unittest.mock import patch
+
+    from fastapi.testclient import TestClient
+
+    from api.middleware import require_vault_owner_token
+    from server import app
+
+    def _stub_token():
+        return {"user_id": "user_stub_abc", "scope": "vault.owner", "token": "tok"}
+
+    with patch.dict(app.dependency_overrides, {require_vault_owner_token: _stub_token}):
+        yield TestClient(app, raise_server_exceptions=False)
+
+
+_UID_MAX = _portfolio_mod._USER_ID_MAX_LEN
+_RID_MAX = _portfolio_mod._RUN_ID_MAX_LEN
+
+
+def test_portfolio_summary_oversized_user_id_returns_422(client):
+    """GET /portfolio/summary/{user_id} must return 422 for oversized user_id."""
+    oversized = "u" * (_UID_MAX + 1)
+    resp = client.get(f"/portfolio/summary/{oversized}")
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized user_id on /portfolio/summary, got {resp.status_code}"
+    )
+
+
+def test_dashboard_picks_oversized_user_id_returns_422(client):
+    """GET /dashboard/profile-picks/{user_id} must return 422 for oversized user_id."""
+    oversized = "u" * (_UID_MAX + 1)
+    resp = client.get(f"/dashboard/profile-picks/{oversized}")
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized user_id on /dashboard/profile-picks, got {resp.status_code}"
+    )
+
+
+def test_stream_run_oversized_run_id_returns_422(client):
+    """GET /portfolio/import/run/{run_id}/stream must return 422 for oversized run_id."""
+    oversized = "r" * (_RID_MAX + 1)
+    resp = client.get(
+        f"/portfolio/import/run/{oversized}/stream",
+        params={"user_id": "user_stub_abc"},
+    )
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized run_id on /stream, got {resp.status_code}"
+    )
+
+
+def test_cancel_run_oversized_run_id_returns_422(client):
+    """POST /portfolio/import/run/{run_id}/cancel must return 422 for oversized run_id."""
+    oversized = "r" * (_RID_MAX + 1)
+    resp = client.post(
+        f"/portfolio/import/run/{oversized}/cancel",
+        params={"user_id": "user_stub_abc"},
+    )
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized run_id on /cancel, got {resp.status_code}"
+    )
+
+
+def test_active_run_oversized_user_id_query_returns_422(client):
+    """GET /portfolio/import/run/active must return 422 for oversized user_id query param."""
+    oversized = "u" * (_UID_MAX + 1)
+    resp = client.get("/portfolio/import/run/active", params={"user_id": oversized})
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized user_id on /run/active, got {resp.status_code}"
+    )
+
+
+def test_portfolio_summary_valid_user_id_not_rejected(client):
+    """A Firebase-UID-length user_id must not be rejected by the length check."""
+    valid_uid = "user_stub_abc"
+    resp = client.get(f"/portfolio/summary/{valid_uid}")
+    assert resp.status_code != 422, (
+        f"Valid-length user_id was incorrectly rejected with 422: {resp.json()}"
+    )


### PR DESCRIPTION
## Summary

- **Bug**: Five route handlers in `api/routes/kai/portfolio.py` accepted `user_id` (path/query) and `run_id` (path) as bare `str` with no upper-bound check (CWE-400). FastAPI forwarded arbitrarily large strings into log statements, error detail dicts, and service calls.
- **Fix**: Add `_USER_ID_MAX_LEN = 128` and `_RUN_ID_MAX_LEN = 128` module constants. Path params use `UserId`/`RunId` `Annotated` type aliases; query params use `Query(..., max_length=...)`. FastAPI returns HTTP 422 for oversized values.

## Affected routes

| Route | Parameter | Type |
|-------|-----------|------|
| `GET /portfolio/summary/{user_id}` | `user_id` | path |
| `GET /dashboard/profile-picks/{user_id}` | `user_id` | path |
| `GET /portfolio/import/run/active` | `user_id` | query |
| `GET /portfolio/import/run/{run_id}/stream` | `run_id` (path) + `user_id` (query) | both |
| `POST /portfolio/import/run/{run_id}/cancel` | `run_id` (path) + `user_id` (query) | both |

## Files changed

| File | Change |
|------|--------|
| `api/routes/kai/portfolio.py` | Add constants, `UserId`/`RunId` type aliases, apply to 5 handlers |
| `tests/test_portfolio_path_param_bounds.py` | 13 regression tests covering constant bounds, HTTP 422 for oversized inputs, valid inputs not rejected |

## Test plan

- [ ] `test_user_id_max_len_constant_exists`
- [ ] `test_run_id_max_len_constant_exists`
- [ ] `test_user_id_max_len_above_firebase_uid` -- limit >= 28
- [ ] `test_run_id_max_len_above_uuid4` -- limit >= 36
- [ ] `test_portfolio_summary_oversized_user_id_returns_422`
- [ ] `test_dashboard_picks_oversized_user_id_returns_422`
- [ ] `test_stream_run_oversized_run_id_returns_422`
- [ ] `test_cancel_run_oversized_run_id_returns_422`
- [ ] `test_active_run_oversized_user_id_query_returns_422`
- [ ] `test_portfolio_summary_valid_user_id_not_rejected`