### PR TITLE
fix(developer): add max_length to request body fields + opaque scope error (CWE-400/CWE-209)

### DIFF
--- a/consent-protocol/api/routes/developer.py
+++ b/consent-protocol/api/routes/developer.py
@@ -183,7 +183,7 @@ class DeveloperConsentRequest(BaseModel):
     reason: str | None = Field(default=None, max_length=1000)
     expiry_hours: int = 24
     approval_timeout_minutes: int = 24 * 60
-    connector_public_key: str = Field(min_length=16)
+    connector_public_key: str = Field(min_length=16, max_length=8192)
     connector_key_id: str = Field(min_length=1, max_length=128)
     connector_wrapping_alg: str = Field(min_length=1, max_length=128)
     offer: DeveloperConsentOffer | None = None
@@ -1069,11 +1069,12 @@ async def request_consent(
 
     normalized_scope = normalize_scope(payload.scope)
     if not _is_supported_scope(normalized_scope):
+        logger.warning("request_consent.unsupported_scope scope=%s", payload.scope)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail={
                 "error_code": "INVALID_SCOPE",
-                "message": f"Unsupported scope: {payload.scope}",
+                "message": "Unsupported scope.",
                 "valid_scopes": [descriptor.name for descriptor in _scope_catalog()],
             },
         )

--- a/consent-protocol/tests/test_developer_request_body_bounds.py
+++ b/consent-protocol/tests/test_developer_request_body_bounds.py
@@ -21,6 +21,7 @@ from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
@@ -36,7 +37,7 @@ _GOOD_KEY = "A" * 64   # 64-char base64 blob, valid pubkey placeholder
 _GOOD_TOKEN = "tok_" + "x" * 32
 
 
-def _stub_principal():
+def _stub_principal(**_kwargs):
     """Minimal DeveloperPrincipal-like stub."""
     p = MagicMock()
     p.app_id = "test_app_id"
@@ -46,21 +47,23 @@ def _stub_principal():
 
 @contextmanager
 def _dev_client():
-    from api.developer_auth import (
-        authenticate_developer_principal,
-        try_authenticate_developer_principal,
-    )
-    from server import app
+    """Mount only developer.router on a minimal FastAPI app so the MCP
+    session-manager lifespan (single-start-per-process) is never touched.
 
-    with patch.dict(
-        app.dependency_overrides,
-        {
-            authenticate_developer_principal: _stub_principal,
-            try_authenticate_developer_principal: _stub_principal,
-        },
-    ):
-        with TestClient(app, raise_server_exceptions=False) as client:
-            yield client
+    authenticate_developer_principal is called directly inside the route
+    handlers rather than via Depends(), so it must be patched at the
+    module level instead of through app.dependency_overrides.
+    """
+    import api.routes.developer as developer_mod
+
+    app = FastAPI()
+    app.include_router(developer_mod.router)
+
+    with patch.object(developer_mod, "authenticate_developer_principal", side_effect=_stub_principal):
+        with patch.object(
+            developer_mod, "try_authenticate_developer_principal", side_effect=_stub_principal
+        ):
+            yield TestClient(app, raise_server_exceptions=False)
 
 
 # ---------------------------------------------------------------------------

--- a/consent-protocol/tests/test_developer_request_body_bounds.py
+++ b/consent-protocol/tests/test_developer_request_body_bounds.py
@@ -1,0 +1,232 @@
+# tests/test_developer_request_body_bounds.py
+"""
+Regression tests for CWE-400 / CWE-209 fixes in api/routes/developer.py.
+
+CWE-400: DeveloperConsentRequest and DeveloperScopedExportRequest previously had
+no max_length on several string fields (user_id, scope, reason, connector_public_key,
+consent_token, expected_scope), allowing arbitrarily large payloads to reach the
+DB and crypto layers.
+
+CWE-209: POST /api/v1/request-consent echoed the caller-supplied scope value in
+the "INVALID_SCOPE" error message; replaced with a static opaque string.
+
+Attach points:
+  POST /api/v1/request-consent   DeveloperConsentRequest
+  POST /api/v1/scoped-export     DeveloperScopedExportRequest
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from api.routes.developer import DeveloperConsentRequest, DeveloperScopedExportRequest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_GOOD_USER_ID = "firebase_uid_stub_28chars_abc"
+_GOOD_SCOPE = "pkm.read"
+_GOOD_KEY = "A" * 64   # 64-char base64 blob, valid pubkey placeholder
+_GOOD_TOKEN = "tok_" + "x" * 32
+
+
+def _stub_principal():
+    """Minimal DeveloperPrincipal-like stub."""
+    p = MagicMock()
+    p.app_id = "test_app_id"
+    p.app_display_name = "Test App"
+    return p
+
+
+@contextmanager
+def _dev_client():
+    from api.developer_auth import (
+        authenticate_developer_principal,
+        try_authenticate_developer_principal,
+    )
+    from server import app
+
+    with patch.dict(
+        app.dependency_overrides,
+        {
+            authenticate_developer_principal: _stub_principal,
+            try_authenticate_developer_principal: _stub_principal,
+        },
+    ):
+        with TestClient(app, raise_server_exceptions=False) as client:
+            yield client
+
+
+# ---------------------------------------------------------------------------
+# Model-level ValidationError tests (no HTTP layer needed)
+# ---------------------------------------------------------------------------
+
+def test_consent_request_rejects_oversized_user_id():
+    with pytest.raises(ValidationError):
+        DeveloperConsentRequest(
+            user_id="u" * 129,
+            scope=_GOOD_SCOPE,
+            connector_public_key=_GOOD_KEY,
+            connector_key_id="kid_1",
+            connector_wrapping_alg="RSA-OAEP",
+        )
+
+
+def test_consent_request_rejects_oversized_scope():
+    with pytest.raises(ValidationError):
+        DeveloperConsentRequest(
+            user_id=_GOOD_USER_ID,
+            scope="s" * 513,
+            connector_public_key=_GOOD_KEY,
+            connector_key_id="kid_1",
+            connector_wrapping_alg="RSA-OAEP",
+        )
+
+
+def test_consent_request_rejects_oversized_reason():
+    with pytest.raises(ValidationError):
+        DeveloperConsentRequest(
+            user_id=_GOOD_USER_ID,
+            scope=_GOOD_SCOPE,
+            reason="r" * 2049,
+            connector_public_key=_GOOD_KEY,
+            connector_key_id="kid_1",
+            connector_wrapping_alg="RSA-OAEP",
+        )
+
+
+def test_consent_request_rejects_oversized_connector_public_key():
+    with pytest.raises(ValidationError):
+        DeveloperConsentRequest(
+            user_id=_GOOD_USER_ID,
+            scope=_GOOD_SCOPE,
+            connector_public_key="K" * 8193,  # exceeds max_length=8192
+            connector_key_id="kid_1",
+            connector_wrapping_alg="RSA-OAEP",
+        )
+
+
+def test_consent_request_accepts_valid_payload():
+    # Should NOT raise; confirms our bounds are not too strict
+    req = DeveloperConsentRequest(
+        user_id=_GOOD_USER_ID,
+        scope=_GOOD_SCOPE,
+        connector_public_key=_GOOD_KEY,
+        connector_key_id="kid_1",
+        connector_wrapping_alg="RSA-OAEP",
+    )
+    assert req.user_id == _GOOD_USER_ID
+
+
+def test_scoped_export_request_rejects_oversized_user_id():
+    with pytest.raises(ValidationError):
+        DeveloperScopedExportRequest(
+            user_id="u" * 129,
+            consent_token=_GOOD_TOKEN,
+        )
+
+
+def test_scoped_export_request_rejects_oversized_consent_token():
+    with pytest.raises(ValidationError):
+        DeveloperScopedExportRequest(
+            user_id=_GOOD_USER_ID,
+            consent_token="t" * 2049,  # exceeds max_length=2048
+        )
+
+
+def test_scoped_export_request_rejects_oversized_expected_scope():
+    with pytest.raises(ValidationError):
+        DeveloperScopedExportRequest(
+            user_id=_GOOD_USER_ID,
+            consent_token=_GOOD_TOKEN,
+            expected_scope="s" * 513,
+        )
+
+
+def test_scoped_export_request_accepts_valid_payload():
+    req = DeveloperScopedExportRequest(
+        user_id=_GOOD_USER_ID,
+        consent_token=_GOOD_TOKEN,
+        expected_scope=_GOOD_SCOPE,
+    )
+    assert req.consent_token == _GOOD_TOKEN
+
+
+# ---------------------------------------------------------------------------
+# HTTP-level tests via TestClient
+# ---------------------------------------------------------------------------
+
+def test_request_consent_http_rejects_oversized_scope():
+    with _dev_client() as client:
+        r = client.post(
+            "/api/v1/request-consent",
+            json={
+                "user_id": _GOOD_USER_ID,
+                "scope": "s" * 513,
+                "connector_public_key": _GOOD_KEY,
+                "connector_key_id": "kid_1",
+                "connector_wrapping_alg": "RSA-OAEP",
+            },
+        )
+        assert r.status_code == 422, r.text
+
+
+def test_request_consent_http_rejects_oversized_user_id():
+    with _dev_client() as client:
+        r = client.post(
+            "/api/v1/request-consent",
+            json={
+                "user_id": "u" * 129,
+                "scope": _GOOD_SCOPE,
+                "connector_public_key": _GOOD_KEY,
+                "connector_key_id": "kid_1",
+                "connector_wrapping_alg": "RSA-OAEP",
+            },
+        )
+        assert r.status_code == 422, r.text
+
+
+def test_scoped_export_http_rejects_oversized_consent_token():
+    with _dev_client() as client:
+        r = client.post(
+            "/api/v1/scoped-export",
+            json={
+                "user_id": _GOOD_USER_ID,
+                "consent_token": "t" * 2049,
+            },
+        )
+        assert r.status_code == 422, r.text
+
+
+# ---------------------------------------------------------------------------
+# CWE-209: invalid scope error must NOT echo back user-supplied scope value
+# ---------------------------------------------------------------------------
+
+def test_invalid_scope_error_does_not_echo_scope_value():
+    """
+    When an unsupported scope is submitted, the error message must not
+    contain the caller-supplied scope string (CWE-209).
+    """
+    sentinel = "SENTINEL_SCOPE_xyzzy_12345"
+    with _dev_client() as client:
+        r = client.post(
+            "/api/v1/request-consent",
+            json={
+                "user_id": _GOOD_USER_ID,
+                "scope": sentinel,
+                "connector_public_key": _GOOD_KEY,
+                "connector_key_id": "kid_1",
+                "connector_wrapping_alg": "RSA-OAEP",
+            },
+        )
+        # 400 = unsupported scope (or 422 = validation; either way sentinel not in body)
+        assert r.status_code in (400, 422), r.text
+        assert sentinel not in r.text, (
+            f"CWE-209: error response echoes caller-supplied scope: {r.text!r}"
+        )


### PR DESCRIPTION
## Summary

`DeveloperConsentRequest` and `DeveloperScopedExportRequest` in `api/routes/developer.py` lacked upper bounds on several string fields, and the `INVALID_SCOPE` error in `request_consent` echoed the caller-supplied scope value back in the response (CWE-400 / CWE-209).

- `connector_public_key` had `min_length=16` but no `max_length`, leaving it unbounded.
- `request_consent`'s 400 response built its message with `f"Unsupported scope: {payload.scope}"`, returning the raw value to the caller.

`user_id`, `scope`, `reason` (on `DeveloperConsentRequest`) and `user_id`, `consent_token`, `expected_scope` (on `DeveloperScopedExportRequest`) already had bounds from a prior pass.

## Maintainer Feedback Addressed

The automated review repeated generic blockers (`backend_contract_without_caller_change`, `existing_capability_overlap_requires_review`, `local_worktree_overlap`, `pr_claim_changed_surface_mismatch`) with no line-level detail across every review cycle. Since the branch was far behind `integration/pr-train`, I independently audited the PR's named surface against the current base instead of relying on that feedback:

- Rebased onto current `integration/pr-train`; no conflicts.
- Added `max_length=8192` to `connector_public_key`, the one field this PR's stated scope covers that was still unbounded.
- Implemented the CWE-209 fix that the PR claimed but had never actually landed: `request_consent` now logs the requested scope server-side and returns a static `"Unsupported scope."` message instead of echoing the value.
- Fixed the regression test file: 3 of 13 tests failed because of test bugs, not production bugs (full-app `TestClient` reused across tests hitting the MCP session manager's once-per-process limit, and a `dependency_overrides` entry that was a no-op because the route calls `authenticate_developer_principal` directly rather than through `Depends()`).

## How to Verify

```bash
cd consent-protocol
uv run pytest tests/test_developer_request_body_bounds.py -v
uv run ruff check api/routes/developer.py tests/test_developer_request_body_bounds.py
uv run mypy api/routes/developer.py tests/test_developer_request_body_bounds.py --ignore-missing-imports --config-file pyproject.toml
```

Each oversized-field test confirms a 422/400 at the model or HTTP layer; the scope-echo test injects a sentinel string and asserts it never appears in the response body.

## Checklist

- [x] Rebased onto current `integration/pr-train`, no merge conflicts
- [x] `connector_public_key` max_length gap closed (CWE-400)
- [x] Scope echo in `request_consent` replaced with opaque message (CWE-209)
- [x] `tests/test_developer_request_body_bounds.py`: 13/13 passing
- [x] Ruff and mypy clean on touched files
- [x] No unrelated files touched
- [x] CI green
