### PR TITLE
fix(db-proxy,consent): replace token reason and scope echoes with opaque messages (CWE-209)

### DIFF
--- a/consent-protocol/tests/test_dbproxy_consent_cwe209_remaining.py
+++ b/consent-protocol/tests/test_dbproxy_consent_cwe209_remaining.py
@@ -1,0 +1,234 @@
+# tests/test_dbproxy_consent_cwe209_remaining.py
+"""
+Regression tests for remaining CWE-209 information-exposure fixes in:
+  api/routes/db_proxy.py   -- require_vault_owner_consent_header (line 132)
+                           -- validate_vault_owner_token (lines 714, 732)
+  api/routes/consent.py    -- approve_consent (line 450)
+                           -- revoke_consent_by_scope (line 1101)
+                           -- refresh_consent_export (line 1327)
+
+In all five locations the original code echoed internal token-validation
+reason strings or caller-supplied scope values back in HTTP error responses.
+Fixes replace them with static opaque messages while logging the full detail
+server-side.
+
+Verification strategy: inject a distinctive sentinel string into the mocked
+return value and assert it does NOT appear in the HTTP response body.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+_SENTINEL = "LEAKED_INTERNAL_DETAIL_sentinel_xyzzy_99"
+_GOOD_USER_ID = "firebase_uid_stub_28chars_abc"
+
+
+@contextmanager
+def _client():
+    from server import app
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# db_proxy.py — require_vault_owner_consent_header
+# ---------------------------------------------------------------------------
+
+def test_vault_consent_header_invalid_token_does_not_echo_reason():
+    """
+    An invalid VAULT_OWNER token must not echo the internal validation reason.
+    """
+    import hushh_mcp.consent.token as tok_mod
+
+    async def _bad_token(token, scope=None):
+        return False, _SENTINEL, None
+
+    with patch.object(tok_mod, "validate_token_with_db", side_effect=_bad_token):
+        with _client() as client:
+            r = client.get(
+                f"/vault/data/{_GOOD_USER_ID}",
+                headers={"X-Hushh-Consent": "Bearer fake_token_value"},
+            )
+            assert r.status_code == 401, r.text
+            assert _SENTINEL not in r.text, (
+                f"CWE-209: internal reason exposed in response: {r.text!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# db_proxy.py — validate_vault_owner_token (inside vault routes)
+# ---------------------------------------------------------------------------
+
+def test_vault_route_invalid_consent_token_does_not_echo_reason():
+    """
+    Invalid consent token on a vault route must not echo the validation reason.
+    """
+    import hushh_mcp.consent.token as tok_mod
+
+    async def _bad_token(token, scope=None):
+        return False, _SENTINEL, None
+
+    with patch.object(tok_mod, "validate_token_with_db", side_effect=_bad_token):
+        with _client() as client:
+            r = client.get(
+                f"/vault/data/{_GOOD_USER_ID}",
+                headers={
+                    "Authorization": f"Bearer {_GOOD_USER_ID}",
+                    "X-Hushh-Consent": f"Bearer consent_tok_{_GOOD_USER_ID}",
+                },
+            )
+            assert r.status_code in (401, 403, 404, 500), r.text
+            assert _SENTINEL not in r.text, (
+                f"CWE-209: internal reason exposed in response: {r.text!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# consent.py — scope_resolution_failed (approve_consent line 450)
+# ---------------------------------------------------------------------------
+
+def test_approve_consent_scope_error_does_not_echo_scope():
+    """
+    When scope resolution fails in approve_consent, the scope string must
+    not appear in the error response.
+    """
+    from unittest.mock import AsyncMock
+
+    from fastapi import FastAPI
+
+    sentinel_scope = f"SENTINEL_SCOPE_{_SENTINEL}"
+
+    import api.routes.consent as consent_mod
+    from api.middleware import require_vault_owner_token
+    from hushh_mcp.services.consent_db import ConsentDBService
+
+    app = FastAPI()
+    app.include_router(consent_mod.router)
+    app.dependency_overrides[require_vault_owner_token] = lambda: {"user_id": _GOOD_USER_ID}
+
+    def _bad_resolve(scope_str):
+        raise ValueError(f"cannot resolve {scope_str}")
+
+    with patch.object(
+        ConsentDBService,
+        "get_pending_by_request_id",
+        new=AsyncMock(
+            return_value={
+                "scope": sentinel_scope,
+                "user_id": _GOOD_USER_ID,
+                "developer": "dev_app",
+                "status": "pending",
+                "metadata": {},
+            }
+        ),
+    ):
+        with patch.object(consent_mod, "resolve_scope_to_enum", side_effect=_bad_resolve):
+            client = TestClient(app, raise_server_exceptions=False)
+            r = client.post(
+                "/api/consent/pending/approve",
+                json={
+                    "requestId": "req_12345",
+                    "userId": _GOOD_USER_ID,
+                },
+            )
+            assert r.status_code in (400, 401, 403, 422, 500), r.text
+            assert sentinel_scope not in r.text, (
+                f"CWE-209: scope echoed in error: {r.text!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# consent.py — No active consent for scope (revoke_consent_by_scope line 1101)
+# ---------------------------------------------------------------------------
+
+def test_revoke_by_scope_not_found_does_not_echo_scope():
+    """
+    When no active consent exists for the requested scope, the scope value
+    must not appear verbatim in the 404 response body.
+    """
+    from unittest.mock import AsyncMock
+
+    from fastapi import FastAPI
+
+    sentinel_scope = f"SENTINEL_scope_{_SENTINEL}"
+
+    import api.routes.consent as consent_mod
+    from api.middleware import require_vault_owner_token
+    from hushh_mcp.services.consent_db import ConsentDBService
+
+    app = FastAPI()
+    app.include_router(consent_mod.router)
+    app.dependency_overrides[require_vault_owner_token] = lambda: {"user_id": _GOOD_USER_ID}
+
+    with patch.object(ConsentDBService, "get_active_tokens", new=AsyncMock(return_value=[])):
+        with patch.object(
+            ConsentDBService, "get_active_internal_tokens", new=AsyncMock(return_value=[])
+        ):
+            client = TestClient(app, raise_server_exceptions=False)
+            r = client.post(
+                "/api/consent/revoke",
+                json={"userId": _GOOD_USER_ID, "scope": sentinel_scope},
+            )
+            assert r.status_code in (400, 401, 403, 404, 422, 500), r.text
+            assert sentinel_scope not in r.text, (
+                f"CWE-209: scope echoed in error: {r.text!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# consent.py — export refresh invalid token (line 1327)
+# ---------------------------------------------------------------------------
+
+def test_export_refresh_invalid_token_does_not_echo_reason():
+    """
+    Invalid consent token during export refresh must not expose the validation reason.
+    """
+    import api.middleware as mw_mod
+    import hushh_mcp.consent.token as tok_mod
+
+    async def _bad_token(token, scope=None):
+        return False, _SENTINEL, None
+
+    with patch.object(tok_mod, "validate_token_with_db", side_effect=_bad_token):
+        with patch.dict(
+            __import__("server").app.dependency_overrides,
+            {mw_mod.require_vault_owner_token: lambda: {"user_id": _GOOD_USER_ID}},
+        ):
+            with _client() as client:
+                r = client.post(
+                    "/api/consent/export/refresh",
+                    json={
+                        "userId": _GOOD_USER_ID,
+                        "consentToken": "fake_consent_token_value",
+                    },
+                )
+                assert r.status_code in (401, 403, 422, 500), r.text
+                assert _SENTINEL not in r.text, (
+                    f"CWE-209: internal reason exposed in response: {r.text!r}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Verify opaque messages are present in known error responses
+# ---------------------------------------------------------------------------
+
+def test_vault_invalid_token_returns_opaque_message():
+    """The 401 detail for invalid vault token must be an opaque static string."""
+    import hushh_mcp.consent.token as tok_mod
+
+    async def _bad_token(token, scope=None):
+        return False, "Token expired", None
+
+    with patch.object(tok_mod, "validate_token_with_db", side_effect=_bad_token):
+        with _client() as client:
+            r = client.get(
+                f"/vault/data/{_GOOD_USER_ID}",
+                headers={"X-Hushh-Consent": "Bearer bad_token"},
+            )
+            assert r.status_code == 401, r.text
+            # The specific internal reason must not appear
+            assert "Token expired" not in r.text, r.text

--- a/consent-protocol/tests/test_dbproxy_consent_cwe209_remaining.py
+++ b/consent-protocol/tests/test_dbproxy_consent_cwe209_remaining.py
@@ -1,16 +1,23 @@
 # tests/test_dbproxy_consent_cwe209_remaining.py
 """
 Regression tests for remaining CWE-209 information-exposure fixes in:
-  api/routes/db_proxy.py   -- require_vault_owner_consent_header (line 132)
-                           -- validate_vault_owner_token (lines 714, 732)
-  api/routes/consent.py    -- approve_consent (line 450)
-                           -- revoke_consent_by_scope (line 1101)
-                           -- refresh_consent_export (line 1327)
+  api/routes/db_proxy.py   -- require_vault_owner_consent_header
+                              (POST /db/vault/wrapper/delete)
+                           -- validate_vault_owner_token
+                              (POST /db/vault/status)
+  api/routes/consent.py    -- approve_consent (POST /api/consent/pending/approve)
+                           -- revoke_consent_by_scope (POST /api/consent/revoke)
+                           -- upload_refreshed_export
+                              (POST /api/consent/export-refresh/upload)
 
 In all five locations the original code echoed internal token-validation
 reason strings or caller-supplied scope values back in HTTP error responses.
 Fixes replace them with static opaque messages while logging the full detail
 server-side.
+
+Each route is exercised by mounting only its router on a minimal FastAPI
+app, never the full server.app, since the MCP session manager backing the
+real app's lifespan can only be started once per process.
 
 Verification strategy: inject a distinctive sentinel string into the mocked
 return value and assert it does NOT appear in the HTTP response body.
@@ -18,20 +25,25 @@ return value and assert it does NOT appear in the HTTP response body.
 
 from __future__ import annotations
 
-from contextlib import contextmanager
 from unittest.mock import patch
 
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 _SENTINEL = "LEAKED_INTERNAL_DETAIL_sentinel_xyzzy_99"
 _GOOD_USER_ID = "firebase_uid_stub_28chars_abc"
 
 
-@contextmanager
-def _client():
-    from server import app
-    with TestClient(app, raise_server_exceptions=False) as c:
-        yield c
+def _db_proxy_client() -> TestClient:
+    """Mount only db_proxy.router so the MCP session-manager lifespan
+    (which can only start once per process) is never touched."""
+    import api.routes.db_proxy as db_proxy_mod
+    from api.middleware import require_firebase_auth
+
+    app = FastAPI()
+    app.include_router(db_proxy_mod.router)
+    app.dependency_overrides[require_firebase_auth] = lambda: _GOOD_USER_ID
+    return TestClient(app, raise_server_exceptions=False)
 
 
 # ---------------------------------------------------------------------------
@@ -42,49 +54,52 @@ def test_vault_consent_header_invalid_token_does_not_echo_reason():
     """
     An invalid VAULT_OWNER token must not echo the internal validation reason.
     """
-    import hushh_mcp.consent.token as tok_mod
+    import api.routes.db_proxy as db_proxy_mod
 
     async def _bad_token(token, scope=None):
         return False, _SENTINEL, None
 
-    with patch.object(tok_mod, "validate_token_with_db", side_effect=_bad_token):
-        with _client() as client:
-            r = client.get(
-                f"/vault/data/{_GOOD_USER_ID}",
-                headers={"X-Hushh-Consent": "Bearer fake_token_value"},
-            )
-            assert r.status_code == 401, r.text
-            assert _SENTINEL not in r.text, (
-                f"CWE-209: internal reason exposed in response: {r.text!r}"
-            )
+    with patch.object(db_proxy_mod, "validate_token_with_db", side_effect=_bad_token):
+        client = _db_proxy_client()
+        r = client.post(
+            "/db/vault/wrapper/delete",
+            headers={"X-Hushh-Consent": "Bearer fake_token_value"},
+            json={
+                "userId": _GOOD_USER_ID,
+                "vaultKeyHash": "stub_hash",
+                "method": "passphrase",
+            },
+        )
+        assert r.status_code == 401, r.text
+        assert _SENTINEL not in r.text, (
+            f"CWE-209: internal reason exposed in response: {r.text!r}"
+        )
 
 
 # ---------------------------------------------------------------------------
-# db_proxy.py — validate_vault_owner_token (inside vault routes)
+# db_proxy.py — validate_vault_owner_token (inside /db/vault/status)
 # ---------------------------------------------------------------------------
 
 def test_vault_route_invalid_consent_token_does_not_echo_reason():
     """
-    Invalid consent token on a vault route must not echo the validation reason.
+    Invalid consent token on the vault status route must not echo the
+    validation reason.
     """
-    import hushh_mcp.consent.token as tok_mod
+    import api.routes.db_proxy as db_proxy_mod
 
     async def _bad_token(token, scope=None):
         return False, _SENTINEL, None
 
-    with patch.object(tok_mod, "validate_token_with_db", side_effect=_bad_token):
-        with _client() as client:
-            r = client.get(
-                f"/vault/data/{_GOOD_USER_ID}",
-                headers={
-                    "Authorization": f"Bearer {_GOOD_USER_ID}",
-                    "X-Hushh-Consent": f"Bearer consent_tok_{_GOOD_USER_ID}",
-                },
-            )
-            assert r.status_code in (401, 403, 404, 500), r.text
-            assert _SENTINEL not in r.text, (
-                f"CWE-209: internal reason exposed in response: {r.text!r}"
-            )
+    with patch.object(db_proxy_mod, "validate_token_with_db", side_effect=_bad_token):
+        client = _db_proxy_client()
+        r = client.post(
+            "/db/vault/status",
+            json={"userId": _GOOD_USER_ID, "consentToken": "fake_token_value"},
+        )
+        assert r.status_code == 401, r.text
+        assert _SENTINEL not in r.text, (
+            f"CWE-209: internal reason exposed in response: {r.text!r}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -187,29 +202,36 @@ def test_export_refresh_invalid_token_does_not_echo_reason():
     """
     Invalid consent token during export refresh must not expose the validation reason.
     """
-    import api.middleware as mw_mod
-    import hushh_mcp.consent.token as tok_mod
+    import api.routes.consent as consent_mod
+    from api.middleware import require_vault_owner_token
 
     async def _bad_token(token, scope=None):
         return False, _SENTINEL, None
 
-    with patch.object(tok_mod, "validate_token_with_db", side_effect=_bad_token):
-        with patch.dict(
-            __import__("server").app.dependency_overrides,
-            {mw_mod.require_vault_owner_token: lambda: {"user_id": _GOOD_USER_ID}},
-        ):
-            with _client() as client:
-                r = client.post(
-                    "/api/consent/export/refresh",
-                    json={
-                        "userId": _GOOD_USER_ID,
-                        "consentToken": "fake_consent_token_value",
-                    },
-                )
-                assert r.status_code in (401, 403, 422, 500), r.text
-                assert _SENTINEL not in r.text, (
-                    f"CWE-209: internal reason exposed in response: {r.text!r}"
-                )
+    app = FastAPI()
+    app.include_router(consent_mod.router)
+    app.dependency_overrides[require_vault_owner_token] = lambda: {"user_id": _GOOD_USER_ID}
+
+    with patch.object(consent_mod, "validate_token_with_db", side_effect=_bad_token):
+        client = TestClient(app, raise_server_exceptions=False)
+        r = client.post(
+            "/api/consent/export-refresh/upload",
+            json={
+                "userId": _GOOD_USER_ID,
+                "consentToken": "fake_consent_token_value",
+                "encryptedData": "stub_data",
+                "encryptedIv": "stub_iv",
+                "encryptedTag": "stub_tag",
+                "wrappedExportKey": "stub_wrapped_key",
+                "wrappedKeyIv": "stub_key_iv",
+                "wrappedKeyTag": "stub_key_tag",
+                "senderPublicKey": "stub_public_key",
+            },
+        )
+        assert r.status_code == 401, r.text
+        assert _SENTINEL not in r.text, (
+            f"CWE-209: internal reason exposed in response: {r.text!r}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -218,17 +240,22 @@ def test_export_refresh_invalid_token_does_not_echo_reason():
 
 def test_vault_invalid_token_returns_opaque_message():
     """The 401 detail for invalid vault token must be an opaque static string."""
-    import hushh_mcp.consent.token as tok_mod
+    import api.routes.db_proxy as db_proxy_mod
 
     async def _bad_token(token, scope=None):
         return False, "Token expired", None
 
-    with patch.object(tok_mod, "validate_token_with_db", side_effect=_bad_token):
-        with _client() as client:
-            r = client.get(
-                f"/vault/data/{_GOOD_USER_ID}",
-                headers={"X-Hushh-Consent": "Bearer bad_token"},
-            )
-            assert r.status_code == 401, r.text
-            # The specific internal reason must not appear
-            assert "Token expired" not in r.text, r.text
+    with patch.object(db_proxy_mod, "validate_token_with_db", side_effect=_bad_token):
+        client = _db_proxy_client()
+        r = client.post(
+            "/db/vault/wrapper/delete",
+            headers={"X-Hushh-Consent": "Bearer bad_token"},
+            json={
+                "userId": _GOOD_USER_ID,
+                "vaultKeyHash": "stub_hash",
+                "method": "passphrase",
+            },
+        )
+        assert r.status_code == 401, r.text
+        # The specific internal reason must not appear
+        assert "Token expired" not in r.text, r.text


### PR DESCRIPTION
## Summary

Five error-path handlers in `db_proxy.py` and `consent.py` previously echoed internal token-validation reason strings or caller-supplied scope values back in HTTP error responses (CWE-209):

| File | Handler | Risk |
|---|---|---|
| `db_proxy.py` | `require_vault_owner_consent_header` | Exposed `validate_token_with_db` internals via the consent header dependency |
| `db_proxy.py` | `validate_vault_owner_token` | Exposed token-validation reason on `/db/vault/status` |
| `consent.py` | `approve_consent` | Echoed a stored scope string back to the caller |
| `consent.py` | `revoke_consent_by_scope` | Echoed the caller-supplied scope |
| `consent.py` | `upload_refreshed_export` | Echoed the token-validation reason on export refresh |

All five now log the full reason/scope server-side at `WARNING` level and return a static opaque detail string to the caller. These production fixes were already present on `integration/pr-train`; this PR's remaining job is the regression test suite proving it.

## Maintainer Feedback Addressed

The automated review flagged generic blockers (`backend_contract_without_caller_change`, `existing_capability_overlap_requires_review`, `local_worktree_overlap`, `pr_claim_changed_surface_mismatch`) with no line-level detail. Since the branch was 69 commits behind `integration/pr-train`, I independently audited each of the five named sites against the current base:

- All five opaque-message fixes were already merged upstream. No production code changes were needed or made.
- The only genuine remaining diff was `tests/test_dbproxy_consent_cwe209_remaining.py`. Of its 6 tests, 4 were broken: two targeted a `/vault/data/{user_id}` path that does not exist in `db_proxy.py` (the router is mounted under `/db` with no such route), and two imported the full `server.app` via `TestClient`, which fails on a second invocation per process because the MCP `StreamableHTTPSessionManager` can only start once.
- Rewrote the 4 broken tests to drive the real routes (`POST /db/vault/wrapper/delete`, `POST /db/vault/status`) and to mount only the relevant router on a minimal `FastAPI()` app instead of the full `server.app`, matching the pattern already used correctly by the other 2 tests in the same file.

## How to Verify

```bash
cd consent-protocol
uv run pytest tests/test_dbproxy_consent_cwe209_remaining.py -v
uv run ruff check tests/test_dbproxy_consent_cwe209_remaining.py
uv run mypy tests/test_dbproxy_consent_cwe209_remaining.py --ignore-missing-imports --config-file pyproject.toml
```

Each test injects a distinctive sentinel string into a mocked `validate_token_with_db`/scope-resolution return value and asserts the sentinel never appears in the HTTP response body, confirmed to fail before the opaque-message fix and pass after.

## Checklist

- [x] All maintainer-flagged sites independently audited against current `integration/pr-train`
- [x] Production fix confirmed already merged; no unrelated files touched
- [x] Regression tests fixed to exercise real routes, not mocks of the route layer
- [x] `tests/test_dbproxy_consent_cwe209_remaining.py`: 6/6 passing
- [x] Ruff and mypy clean on touched file
- [x] Rebased onto current `integration/pr-train`, no merge conflicts
- [x] CI green
