### PR TITLE
fix(security): CWE-400/CWE-209 — bound decisions path param + suppress support error echo

### DIFF
--- a/consent-protocol/api/routes/kai/decisions.py
+++ b/consent-protocol/api/routes/kai/decisions.py
@@ -7,9 +7,9 @@ Write operations remain client-side via POST /api/pkm/store-domain.
 """
 
 import logging
-from typing import Dict, List
+from typing import Annotated, Dict, List
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
 from pydantic import BaseModel
 
 from api.middleware import require_vault_owner_token
@@ -18,6 +18,14 @@ from hushh_mcp.services.personal_knowledge_model_service import get_pkm_service
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+# ---------------------------------------------------------------------------
+# Path-parameter bounds (CWE-400 Uncontrolled Resource Consumption)
+# Attach point: GET /api/kai/decisions/{user_id}
+# ---------------------------------------------------------------------------
+_USER_ID_MAX_LEN: int = 128
+
+UserId = Annotated[str, Path(min_length=1, max_length=_USER_ID_MAX_LEN)]
 
 
 # ============================================================================
@@ -37,7 +45,7 @@ class DecisionHistoryResponse(BaseModel):
 
 @router.get("/decisions/{user_id}", response_model=DecisionHistoryResponse)
 async def get_decision_history(
-    user_id: str,
+    user_id: UserId,
     limit: int = Query(default=50, le=100),
     offset: int = Query(default=0, ge=0),
     token_data: dict = Depends(require_vault_owner_token),

--- a/consent-protocol/api/routes/kai/support.py
+++ b/consent-protocol/api/routes/kai/support.py
@@ -22,7 +22,7 @@ router = APIRouter(tags=["Kai Support"])
 
 
 class SupportMessageRequest(BaseModel):
-    user_id: str
+    user_id: str = Field(min_length=1, max_length=128)
     kind: Literal["bug_report", "support_request", "developer_reachout"]
     subject: str = Field(min_length=3, max_length=140)
     message: str = Field(min_length=10, max_length=8000)
@@ -80,11 +80,12 @@ async def send_support_message(
             "from_email": cfg.from_email,
         }
     except SupportEmailNotConfiguredError as exc:
+        logger.warning("kai.support.not_configured user_id=%s", payload.user_id)
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail={
                 "code": "SUPPORT_EMAIL_NOT_CONFIGURED",
-                "message": str(exc),
+                "message": "Support messaging is temporarily unavailable. Please try again later.",
             },
         ) from exc
     except Exception as exc:
@@ -93,6 +94,6 @@ async def send_support_message(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail={
                 "code": "SUPPORT_MESSAGE_FAILED",
-                "message": str(exc),
+                "message": "An unexpected error occurred while sending your support message.",
             },
         ) from exc

--- a/consent-protocol/tests/test_decisions_support_bounds_cwe209.py
+++ b/consent-protocol/tests/test_decisions_support_bounds_cwe209.py
@@ -1,0 +1,306 @@
+"""
+Regression tests for CWE-400 and CWE-209 fixes in kai/decisions.py and kai/support.py.
+
+CWE-400 — Uncontrolled Resource Consumption:
+  - GET /api/kai/decisions/{user_id}: user_id path param now bounded to 128 chars.
+
+CWE-209 — Information Exposure Through Error Messages:
+  - POST /api/kai/support/message: generic Exception and
+    SupportEmailNotConfiguredError handlers no longer echo internal error
+    detail (str(exc)) back to the caller.
+
+CWE-400 (body field):
+  - POST /api/kai/support/message: SupportMessageRequest.user_id now bounded
+    to max_length=128, preventing oversized allocation.
+
+Attach points:
+  - GET  /api/kai/decisions/{user_id}   (api/routes/kai/decisions.py)
+  - POST /api/kai/support/message       (api/routes/kai/support.py)
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from api.main import app
+from fastapi.testclient import TestClient
+
+from api.middleware import require_vault_owner_token
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_GOOD_USER_ID = "user_abc123"
+_LONG_USER_ID = "u" * 129  # exceeds max_length=128
+
+_VALID_TOKEN_DATA = {"user_id": _GOOD_USER_ID, "scope": "VAULT_OWNER"}
+
+
+@contextmanager
+def _override_vault_owner(token_data: dict):
+    async def _stub():
+        return token_data
+
+    with patch.dict(app.dependency_overrides, {require_vault_owner_token: _stub}):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# GET /api/kai/decisions/{user_id} — CWE-400 path param bounds
+# ---------------------------------------------------------------------------
+
+
+class TestDecisionsPathBounds:
+    def test_valid_user_id_returns_200(self):
+        mock_decisions = [{"id": "d1", "label": "buy"}]
+        pkm_mock = MagicMock()
+        pkm_mock.get_recent_decision_records = AsyncMock(return_value=mock_decisions)
+        with _override_vault_owner(_VALID_TOKEN_DATA):
+            with patch(
+                "api.routes.kai.decisions.get_pkm_service", return_value=pkm_mock
+            ):
+                client = TestClient(app, raise_server_exceptions=False)
+                resp = client.get(
+                    f"/api/kai/decisions/{_GOOD_USER_ID}",
+                    headers={"Authorization": "Bearer tok"},
+                )
+        assert resp.status_code == 200
+
+    def test_oversized_user_id_rejected_422(self):
+        with _override_vault_owner(_VALID_TOKEN_DATA):
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.get(
+                f"/api/kai/decisions/{_LONG_USER_ID}",
+                headers={"Authorization": "Bearer tok"},
+            )
+        assert resp.status_code == 422
+
+    def test_empty_user_id_rejected_404_or_422(self):
+        with _override_vault_owner(_VALID_TOKEN_DATA):
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.get(
+                "/api/kai/decisions/",
+                headers={"Authorization": "Bearer tok"},
+            )
+        # FastAPI 404 (no route) or 422 (min_length violation)
+        assert resp.status_code in (404, 422)
+
+    def test_exactly_128_chars_accepted(self):
+        uid128 = "u" * 128
+        token_data = {"user_id": uid128, "scope": "VAULT_OWNER"}
+        pkm_mock = MagicMock()
+        pkm_mock.get_recent_decision_records = AsyncMock(return_value=[])
+        pkm_mock.get_index_v2 = AsyncMock(return_value=None)
+        pkm_mock._extract_decision_records = MagicMock(return_value=[])
+        with _override_vault_owner(token_data):
+            with patch(
+                "api.routes.kai.decisions.get_pkm_service", return_value=pkm_mock
+            ):
+                client = TestClient(app, raise_server_exceptions=False)
+                resp = client.get(
+                    f"/api/kai/decisions/{uid128}",
+                    headers={"Authorization": "Bearer tok"},
+                )
+        assert resp.status_code == 200
+
+    def test_exactly_129_chars_rejected_422(self):
+        uid129 = "u" * 129
+        with _override_vault_owner(_VALID_TOKEN_DATA):
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.get(
+                f"/api/kai/decisions/{uid129}",
+                headers={"Authorization": "Bearer tok"},
+            )
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# POST /api/kai/support/message — CWE-400 body field + CWE-209 error echo
+# ---------------------------------------------------------------------------
+
+_VALID_SUPPORT_PAYLOAD = {
+    "user_id": _GOOD_USER_ID,
+    "kind": "bug_report",
+    "subject": "Test subject",
+    "message": "This is a valid support message body with enough length.",
+}
+
+
+class TestSupportMessageBounds:
+    def test_valid_payload_accepted(self):
+        from api.middleware import require_firebase_auth
+
+        queue_result = {
+            "delivery_status": "queued",
+            "job_id": "job-1",
+        }
+        cfg_mock = MagicMock()
+        cfg_mock.configured = True
+        cfg_mock.delivery_mode = "queue"
+        cfg_mock.effective_recipient = "support@hushh.ai"
+        cfg_mock.support_to_email = "support@hushh.ai"
+        cfg_mock.from_email = "no-reply@hushh.ai"
+
+        email_svc_mock = MagicMock()
+        email_svc_mock.config = cfg_mock
+
+        queue_svc_mock = MagicMock()
+        queue_svc_mock.enqueue = AsyncMock(return_value=queue_result)
+
+        async def _stub_firebase():
+            return _GOOD_USER_ID
+
+        with patch.dict(
+            app.dependency_overrides, {require_firebase_auth: _stub_firebase}
+        ):
+            with patch(
+                "api.routes.kai.support.get_support_email_service",
+                return_value=email_svc_mock,
+            ):
+                with patch(
+                    "api.routes.kai.support.get_email_delivery_queue_service",
+                    return_value=queue_svc_mock,
+                ):
+                    client = TestClient(app, raise_server_exceptions=False)
+                    resp = client.post(
+                        "/api/kai/support/message", json=_VALID_SUPPORT_PAYLOAD
+                    )
+        assert resp.status_code == 202
+
+    def test_oversized_user_id_rejected_422(self):
+        from api.middleware import require_firebase_auth
+
+        payload = {**_VALID_SUPPORT_PAYLOAD, "user_id": "u" * 129}
+
+        async def _stub_firebase():
+            return "u" * 129
+
+        with patch.dict(
+            app.dependency_overrides, {require_firebase_auth: _stub_firebase}
+        ):
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.post("/api/kai/support/message", json=payload)
+        assert resp.status_code == 422
+
+    def test_exactly_128_char_user_id_accepted_at_model_level(self):
+        """Pydantic model accepts user_id of exactly 128 chars."""
+
+        from api.routes.kai.support import SupportMessageRequest
+
+        req = SupportMessageRequest(
+            user_id="u" * 128,
+            kind="bug_report",
+            subject="Valid subject",
+            message="Valid message with enough content here for the field.",
+        )
+        assert len(req.user_id) == 128
+
+    def test_129_char_user_id_rejected_at_model_level(self):
+        from pydantic import ValidationError
+
+        from api.routes.kai.support import SupportMessageRequest
+
+        with pytest.raises(ValidationError):
+            SupportMessageRequest(
+                user_id="u" * 129,
+                kind="bug_report",
+                subject="Valid subject",
+                message="Valid message with enough content here for the field.",
+            )
+
+
+# ---------------------------------------------------------------------------
+# CWE-209 — error echo suppression in support handler
+# ---------------------------------------------------------------------------
+
+
+class TestSupportCWE209:
+    """Verify that internal exception details are never echoed back to callers."""
+
+    _SENTINEL = "INTERNAL_SECRET_xK7q9pBnZm_LEAK_MARKER"
+
+    def _make_support_client(self, firebase_uid: str):
+        from api.middleware import require_firebase_auth
+
+        async def _stub():
+            return firebase_uid
+
+        app.dependency_overrides[require_firebase_auth] = _stub
+        return TestClient(app, raise_server_exceptions=False)
+
+    def _cleanup(self):
+        from api.middleware import require_firebase_auth
+
+        app.dependency_overrides.pop(require_firebase_auth, None)
+
+    def test_generic_exception_does_not_echo_detail(self):
+        """str(exc) must NOT appear in the HTTP response body."""
+        from api.middleware import require_firebase_auth
+
+        cfg_mock = MagicMock()
+        cfg_mock.configured = True
+
+        email_svc_mock = MagicMock()
+        email_svc_mock.config = cfg_mock
+
+        sentinel = self._SENTINEL
+
+        queue_svc_mock = MagicMock()
+        queue_svc_mock.enqueue = AsyncMock(
+            side_effect=RuntimeError(sentinel)
+        )
+
+        async def _stub_firebase():
+            return _GOOD_USER_ID
+
+        with patch.dict(
+            app.dependency_overrides, {require_firebase_auth: _stub_firebase}
+        ):
+            with patch(
+                "api.routes.kai.support.get_support_email_service",
+                return_value=email_svc_mock,
+            ):
+                with patch(
+                    "api.routes.kai.support.get_email_delivery_queue_service",
+                    return_value=queue_svc_mock,
+                ):
+                    client = TestClient(app, raise_server_exceptions=False)
+                    resp = client.post(
+                        "/api/kai/support/message", json=_VALID_SUPPORT_PAYLOAD
+                    )
+
+        assert resp.status_code == 500
+        assert sentinel not in resp.text, (
+            "Internal exception detail must not be echoed back to the caller (CWE-209)"
+        )
+
+    def test_not_configured_error_does_not_echo_detail(self):
+        """SupportEmailNotConfiguredError detail must not leak server config info."""
+        from api.middleware import require_firebase_auth
+        from hushh_mcp.services.support_email_service import SupportEmailNotConfiguredError
+
+        sentinel = self._SENTINEL
+
+        # Raise directly from get_support_email_service
+        with patch(
+            "api.routes.kai.support.get_support_email_service",
+            side_effect=SupportEmailNotConfiguredError(sentinel),
+        ):
+            async def _stub_firebase():
+                return _GOOD_USER_ID
+
+            with patch.dict(
+                app.dependency_overrides, {require_firebase_auth: _stub_firebase}
+            ):
+                client = TestClient(app, raise_server_exceptions=False)
+                resp = client.post(
+                    "/api/kai/support/message", json=_VALID_SUPPORT_PAYLOAD
+                )
+
+        assert resp.status_code == 503
+        assert sentinel not in resp.text, (
+            "SupportEmailNotConfiguredError detail must not be echoed back (CWE-209)"
+        )


### PR DESCRIPTION
## Summary

Fixes two classes of security defects in `api/routes/kai/decisions.py` and `api/routes/kai/support.py`.

### CWE-400 : Uncontrolled Resource Consumption

**`api/routes/kai/decisions.py`**

`GET /api/kai/decisions/{user_id}` accepted an unbounded `user_id` path parameter (`str` with no length constraint). A caller could send an arbitrarily long string, causing excessive allocation and string-handling work before any auth check short-circuits it.

Fix: apply `Annotated[str, Path(min_length=1, max_length=128)]` via a module-level `UserId` alias — consistent with the pattern used in `world_model.py`, `marketplace.py`, `sse.py`, and `market_insights.py`.

**`api/routes/kai/support.py`**

`SupportMessageRequest.user_id` was a bare `str` with no length bound, while every other field in the model already had `Field(max_length=...)`. This left one unbounded allocation vector in an otherwise well-bounded model.

Fix: `user_id: str = Field(min_length=1, max_length=128)`.

### CWE-209 : Information Exposure Through Error Messages

**`api/routes/kai/support.py`** -- two handlers echoed `str(exc)` verbatim into HTTP response bodies:

1. **Generic `Exception` handler** (line 96): `"message": str(exc)` could expose internal runtime detail — stack context, database error strings, third-party SDK messages — to any caller.
2. **`SupportEmailNotConfiguredError` handler** (line 87): `"message": str(exc)` leaked server infrastructure details including environment variable names (`SUPPORT_EMAIL_SERVICE_ACCOUNT_JSON`, `FIREBASE_ADMIN_CREDENTIALS_JSON`, etc.) to unauthenticated observers.

Fix: replace both with static opaque messages; add `logger.warning` for the `SupportEmailNotConfiguredError` path to preserve internal observability.

## Attach points

| Route | File | Fix |
|---|---|---|
| `GET /api/kai/decisions/{user_id}` | `api/routes/kai/decisions.py` | CWE-400 path param |
| `POST /api/kai/support/message` | `api/routes/kai/support.py` | CWE-400 body field + CWE-209 x2 |

## Test plan

`tests/test_decisions_support_bounds_cwe209.py` -- 11 regression cases:

- [x] Valid `user_id` (128 chars) accepted at model level and via HTTP
- [x] Oversized `user_id` (129 chars) rejected with 422 at model level and via HTTP
- [x] Empty path segment returns 404/422
- [x] Boundary value (exactly 128 chars) accepted end-to-end for decisions endpoint
- [x] Sentinel-injection: `RuntimeError(sentinel)` raised inside handler, sentinel string must NOT appear in 500 response body
- [x] Sentinel-injection: `SupportEmailNotConfiguredError(sentinel)` raised, sentinel must NOT appear in 503 response body