### PR TITLE
fix(security): CWE-400 — bound unbounded query/path params in kai streaming handlers

### DIFF
--- a/consent-protocol/api/routes/kai/stream.py
+++ b/consent-protocol/api/routes/kai/stream.py
@@ -14,9 +14,9 @@ import os
 import re
 import time
 from datetime import datetime, timezone
-from typing import Any, AsyncGenerator, Dict, Optional
+from typing import Annotated, Any, AsyncGenerator, Dict, Optional
 
-from fastapi import APIRouter, Header, HTTPException, Request
+from fastapi import APIRouter, Header, HTTPException, Path, Query, Request
 from pydantic import BaseModel, Field
 from sse_starlette.sse import EventSourceResponse
 
@@ -49,6 +49,22 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["Kai Streaming"])
 _TICKER_SYMBOL_RE = re.compile(r"^[A-Z][A-Z0-9.\-]{0,5}$")
 _RUN_MANAGER = KaiAnalyzeRunManager()
+
+# ---------------------------------------------------------------------------
+# Input bounds (CWE-400 — Uncontrolled Resource Consumption)
+# Attach points:
+#   GET  /api/kai/analyze/stream
+#   GET  /api/kai/analyze/run/active
+#   GET  /api/kai/analyze/run/{run_id}/stream
+#   POST /api/kai/analyze/run/{run_id}/cancel
+# ---------------------------------------------------------------------------
+_USER_ID_MAX_LEN: int = 128
+_TICKER_RAW_MAX_LEN: int = 20   # regex further constrains to <=6 after normalization
+_RISK_PROFILE_MAX_LEN: int = 64
+_DEBATE_SESSION_ID_MAX_LEN: int = 256
+_RUN_ID_MAX_LEN: int = 128
+
+RunId = Annotated[str, Path(min_length=1, max_length=_RUN_ID_MAX_LEN)]
 
 
 def _normalize_ticker_or_422(raw_ticker: str) -> str:
@@ -2412,9 +2428,9 @@ def _stream_factory(
 @router.get("/analyze/stream")
 async def analyze_stream(
     request: Request,
-    ticker: str,
-    user_id: str,
-    risk_profile: str = "balanced",
+    ticker: str = Query(min_length=1, max_length=_TICKER_RAW_MAX_LEN),
+    user_id: str = Query(min_length=1, max_length=_USER_ID_MAX_LEN),
+    risk_profile: str = Query(default="balanced", max_length=_RISK_PROFILE_MAX_LEN),
     authorization: Optional[str] = Header(None, description="Bearer VAULT_OWNER consent token"),
 ):
     """
@@ -2591,8 +2607,8 @@ async def analyze_run_start(
 
 @router.get("/analyze/run/active")
 async def analyze_run_active(
-    user_id: str,
-    debate_session_id: str,
+    user_id: str = Query(min_length=1, max_length=_USER_ID_MAX_LEN),
+    debate_session_id: str = Query(min_length=1, max_length=_DEBATE_SESSION_ID_MAX_LEN),
     authorization: Optional[str] = Header(None, description="Bearer VAULT_OWNER consent token"),
 ):
     """Get active run for a given user/session.
@@ -2607,8 +2623,8 @@ async def analyze_run_active(
 @router.get("/analyze/run/{run_id}/stream")
 async def analyze_run_stream(
     request: Request,
-    run_id: str,
-    user_id: str,
+    run_id: RunId,
+    user_id: str = Query(min_length=1, max_length=_USER_ID_MAX_LEN),
     cursor: Optional[int] = 0,
     authorization: Optional[str] = Header(None, description="Bearer VAULT_OWNER consent token"),
 ):
@@ -2648,8 +2664,8 @@ async def analyze_run_stream(
 
 @router.post("/analyze/run/{run_id}/cancel")
 async def analyze_run_cancel(
-    run_id: str,
-    user_id: str,
+    run_id: RunId,
+    user_id: str = Query(min_length=1, max_length=_USER_ID_MAX_LEN),
     authorization: Optional[str] = Header(None, description="Bearer VAULT_OWNER consent token"),
 ):
     """Cancel an active run."""

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -13,3 +13,4 @@ tests/test_adk_a2a_compliance_script.py
 tests/test_ria_iam_service_architecture.py
 tests/test_kai_optimize_realtime_contract.py
 tests/test_portfolio_stream_quality_rules.py
+tests/test_stream_path_query_bounds_cwe400.py

--- a/consent-protocol/tests/test_stream_path_query_bounds_cwe400.py
+++ b/consent-protocol/tests/test_stream_path_query_bounds_cwe400.py
@@ -1,0 +1,256 @@
+"""
+Regression tests for CWE-400 fixes in api/routes/kai/stream.py.
+
+CWE-400 — Uncontrolled Resource Consumption:
+  All four streaming/run handlers accepted unbounded string parameters that
+  could be exploited to trigger excessive allocation before auth logic runs.
+  This test suite verifies that FastAPI now enforces length constraints and
+  returns HTTP 422 for oversized inputs.
+
+Endpoints under test:
+  GET  /api/kai/analyze/stream          ticker, user_id, risk_profile (Query)
+  GET  /api/kai/analyze/run/active      user_id, debate_session_id (Query)
+  GET  /api/kai/analyze/run/{run_id}/stream   run_id (Path), user_id (Query)
+  POST /api/kai/analyze/run/{run_id}/cancel   run_id (Path), user_id (Query)
+
+Attach point: api/routes/kai/stream.py
+"""
+
+from __future__ import annotations
+
+from api.main import app
+from fastapi.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_GOOD_USER_ID = "user_stream_test"
+_GOOD_RUN_ID = "run-abc-123"
+_GOOD_TICKER = "AAPL"
+_GOOD_SESSION = "sess-xyz-456"
+
+# Exceeds _USER_ID_MAX_LEN=128
+_LONG_STR_129 = "x" * 129
+
+# Exceeds _TICKER_RAW_MAX_LEN=20
+_LONG_TICKER = "A" * 21
+
+# Exceeds _RUN_ID_MAX_LEN=128
+_LONG_RUN_ID = "r" * 129
+
+# Exceeds _DEBATE_SESSION_ID_MAX_LEN=256
+_LONG_SESSION = "s" * 257
+
+# Exceeds _RISK_PROFILE_MAX_LEN=64
+_LONG_RISK = "balanced" * 9  # 72 chars
+
+
+def _auth_headers():
+    return {"Authorization": "Bearer dummy-token"}
+
+
+
+# ---------------------------------------------------------------------------
+# GET /api/kai/analyze/stream
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeStreamQueryBounds:
+    def test_oversized_user_id_rejected_422(self):
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(
+            "/api/kai/analyze/stream",
+            params={
+                "ticker": _GOOD_TICKER,
+                "user_id": _LONG_STR_129,
+            },
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 422
+
+    def test_oversized_ticker_rejected_422(self):
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(
+            "/api/kai/analyze/stream",
+            params={
+                "ticker": _LONG_TICKER,
+                "user_id": _GOOD_USER_ID,
+            },
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 422
+
+    def test_oversized_risk_profile_rejected_422(self):
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(
+            "/api/kai/analyze/stream",
+            params={
+                "ticker": _GOOD_TICKER,
+                "user_id": _GOOD_USER_ID,
+                "risk_profile": _LONG_RISK,
+            },
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 422
+
+    def test_empty_ticker_rejected_422(self):
+        """min_length=1 means empty string is rejected."""
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(
+            "/api/kai/analyze/stream",
+            params={
+                "ticker": "",
+                "user_id": _GOOD_USER_ID,
+            },
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 422
+
+    def test_valid_params_reach_auth_layer(self):
+        """Valid bounded params pass validation; auth raises 401/403 without a real token."""
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(
+            "/api/kai/analyze/stream",
+            params={
+                "ticker": _GOOD_TICKER,
+                "user_id": _GOOD_USER_ID,
+            },
+            headers=_auth_headers(),
+        )
+        # 422 would mean validation failed; anything else means bounds passed
+        assert resp.status_code != 422
+
+
+# ---------------------------------------------------------------------------
+# GET /api/kai/analyze/run/active
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeRunActiveQueryBounds:
+    def test_oversized_user_id_rejected_422(self):
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(
+            "/api/kai/analyze/run/active",
+            params={
+                "user_id": _LONG_STR_129,
+                "debate_session_id": _GOOD_SESSION,
+            },
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 422
+
+    def test_oversized_debate_session_id_rejected_422(self):
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(
+            "/api/kai/analyze/run/active",
+            params={
+                "user_id": _GOOD_USER_ID,
+                "debate_session_id": _LONG_SESSION,
+            },
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 422
+
+    def test_valid_params_reach_auth_layer(self):
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(
+            "/api/kai/analyze/run/active",
+            params={
+                "user_id": _GOOD_USER_ID,
+                "debate_session_id": _GOOD_SESSION,
+            },
+            headers=_auth_headers(),
+        )
+        assert resp.status_code != 422
+
+    def test_exactly_128_char_user_id_passes_validation(self):
+        uid128 = "u" * 128
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(
+            "/api/kai/analyze/run/active",
+            params={
+                "user_id": uid128,
+                "debate_session_id": _GOOD_SESSION,
+            },
+            headers=_auth_headers(),
+        )
+        assert resp.status_code != 422
+
+
+# ---------------------------------------------------------------------------
+# GET /api/kai/analyze/run/{run_id}/stream
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeRunStreamBounds:
+    def test_oversized_run_id_rejected_422(self):
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(
+            f"/api/kai/analyze/run/{_LONG_RUN_ID}/stream",
+            params={"user_id": _GOOD_USER_ID},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 422
+
+    def test_oversized_user_id_rejected_422(self):
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(
+            f"/api/kai/analyze/run/{_GOOD_RUN_ID}/stream",
+            params={"user_id": _LONG_STR_129},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 422
+
+    def test_valid_params_reach_auth_layer(self):
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(
+            f"/api/kai/analyze/run/{_GOOD_RUN_ID}/stream",
+            params={"user_id": _GOOD_USER_ID},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code != 422
+
+    def test_exactly_128_char_run_id_passes_validation(self):
+        run_id_128 = "r" * 128
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(
+            f"/api/kai/analyze/run/{run_id_128}/stream",
+            params={"user_id": _GOOD_USER_ID},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code != 422
+
+
+# ---------------------------------------------------------------------------
+# POST /api/kai/analyze/run/{run_id}/cancel
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeRunCancelBounds:
+    def test_oversized_run_id_rejected_422(self):
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post(
+            f"/api/kai/analyze/run/{_LONG_RUN_ID}/cancel",
+            params={"user_id": _GOOD_USER_ID},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 422
+
+    def test_oversized_user_id_rejected_422(self):
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post(
+            f"/api/kai/analyze/run/{_GOOD_RUN_ID}/cancel",
+            params={"user_id": _LONG_STR_129},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 422
+
+    def test_valid_params_reach_auth_layer(self):
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post(
+            f"/api/kai/analyze/run/{_GOOD_RUN_ID}/cancel",
+            params={"user_id": _GOOD_USER_ID},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code != 422

--- a/consent-protocol/tests/test_stream_path_query_bounds_cwe400.py
+++ b/consent-protocol/tests/test_stream_path_query_bounds_cwe400.py
@@ -1,7 +1,7 @@
 """
 Regression tests for CWE-400 fixes in api/routes/kai/stream.py.
 
-CWE-400 — Uncontrolled Resource Consumption:
+CWE-400 -- Uncontrolled Resource Consumption:
   All four streaming/run handlers accepted unbounded string parameters that
   could be exploited to trigger excessive allocation before auth logic runs.
   This test suite verifies that FastAPI now enforces length constraints and
@@ -18,8 +18,25 @@ Attach point: api/routes/kai/stream.py
 
 from __future__ import annotations
 
-from api.main import app
+import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
+
+from api.routes.kai import router as kai_router
+
+# ---------------------------------------------------------------------------
+# App fixture: minimal FastAPI app with the Kai router (prefix /api/kai).
+# Avoids importing the full server application and matches the pattern used
+# by test_kai_auth_matrix.py in the CI manifest.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(kai_router)
+    return TestClient(app, raise_server_exceptions=False)
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -46,9 +63,8 @@ _LONG_SESSION = "s" * 257
 _LONG_RISK = "balanced" * 9  # 72 chars
 
 
-def _auth_headers():
+def _auth_headers() -> dict[str, str]:
     return {"Authorization": "Bearer dummy-token"}
-
 
 
 # ---------------------------------------------------------------------------
@@ -57,8 +73,7 @@ def _auth_headers():
 
 
 class TestAnalyzeStreamQueryBounds:
-    def test_oversized_user_id_rejected_422(self):
-        client = TestClient(app, raise_server_exceptions=False)
+    def test_oversized_user_id_rejected_422(self, client: TestClient):
         resp = client.get(
             "/api/kai/analyze/stream",
             params={
@@ -69,8 +84,7 @@ class TestAnalyzeStreamQueryBounds:
         )
         assert resp.status_code == 422
 
-    def test_oversized_ticker_rejected_422(self):
-        client = TestClient(app, raise_server_exceptions=False)
+    def test_oversized_ticker_rejected_422(self, client: TestClient):
         resp = client.get(
             "/api/kai/analyze/stream",
             params={
@@ -81,8 +95,7 @@ class TestAnalyzeStreamQueryBounds:
         )
         assert resp.status_code == 422
 
-    def test_oversized_risk_profile_rejected_422(self):
-        client = TestClient(app, raise_server_exceptions=False)
+    def test_oversized_risk_profile_rejected_422(self, client: TestClient):
         resp = client.get(
             "/api/kai/analyze/stream",
             params={
@@ -94,9 +107,8 @@ class TestAnalyzeStreamQueryBounds:
         )
         assert resp.status_code == 422
 
-    def test_empty_ticker_rejected_422(self):
+    def test_empty_ticker_rejected_422(self, client: TestClient):
         """min_length=1 means empty string is rejected."""
-        client = TestClient(app, raise_server_exceptions=False)
         resp = client.get(
             "/api/kai/analyze/stream",
             params={
@@ -107,9 +119,8 @@ class TestAnalyzeStreamQueryBounds:
         )
         assert resp.status_code == 422
 
-    def test_valid_params_reach_auth_layer(self):
+    def test_valid_params_reach_auth_layer(self, client: TestClient):
         """Valid bounded params pass validation; auth raises 401/403 without a real token."""
-        client = TestClient(app, raise_server_exceptions=False)
         resp = client.get(
             "/api/kai/analyze/stream",
             params={
@@ -128,8 +139,7 @@ class TestAnalyzeStreamQueryBounds:
 
 
 class TestAnalyzeRunActiveQueryBounds:
-    def test_oversized_user_id_rejected_422(self):
-        client = TestClient(app, raise_server_exceptions=False)
+    def test_oversized_user_id_rejected_422(self, client: TestClient):
         resp = client.get(
             "/api/kai/analyze/run/active",
             params={
@@ -140,8 +150,7 @@ class TestAnalyzeRunActiveQueryBounds:
         )
         assert resp.status_code == 422
 
-    def test_oversized_debate_session_id_rejected_422(self):
-        client = TestClient(app, raise_server_exceptions=False)
+    def test_oversized_debate_session_id_rejected_422(self, client: TestClient):
         resp = client.get(
             "/api/kai/analyze/run/active",
             params={
@@ -152,8 +161,7 @@ class TestAnalyzeRunActiveQueryBounds:
         )
         assert resp.status_code == 422
 
-    def test_valid_params_reach_auth_layer(self):
-        client = TestClient(app, raise_server_exceptions=False)
+    def test_valid_params_reach_auth_layer(self, client: TestClient):
         resp = client.get(
             "/api/kai/analyze/run/active",
             params={
@@ -164,9 +172,8 @@ class TestAnalyzeRunActiveQueryBounds:
         )
         assert resp.status_code != 422
 
-    def test_exactly_128_char_user_id_passes_validation(self):
+    def test_exactly_128_char_user_id_passes_validation(self, client: TestClient):
         uid128 = "u" * 128
-        client = TestClient(app, raise_server_exceptions=False)
         resp = client.get(
             "/api/kai/analyze/run/active",
             params={
@@ -184,8 +191,7 @@ class TestAnalyzeRunActiveQueryBounds:
 
 
 class TestAnalyzeRunStreamBounds:
-    def test_oversized_run_id_rejected_422(self):
-        client = TestClient(app, raise_server_exceptions=False)
+    def test_oversized_run_id_rejected_422(self, client: TestClient):
         resp = client.get(
             f"/api/kai/analyze/run/{_LONG_RUN_ID}/stream",
             params={"user_id": _GOOD_USER_ID},
@@ -193,8 +199,7 @@ class TestAnalyzeRunStreamBounds:
         )
         assert resp.status_code == 422
 
-    def test_oversized_user_id_rejected_422(self):
-        client = TestClient(app, raise_server_exceptions=False)
+    def test_oversized_user_id_rejected_422(self, client: TestClient):
         resp = client.get(
             f"/api/kai/analyze/run/{_GOOD_RUN_ID}/stream",
             params={"user_id": _LONG_STR_129},
@@ -202,8 +207,7 @@ class TestAnalyzeRunStreamBounds:
         )
         assert resp.status_code == 422
 
-    def test_valid_params_reach_auth_layer(self):
-        client = TestClient(app, raise_server_exceptions=False)
+    def test_valid_params_reach_auth_layer(self, client: TestClient):
         resp = client.get(
             f"/api/kai/analyze/run/{_GOOD_RUN_ID}/stream",
             params={"user_id": _GOOD_USER_ID},
@@ -211,9 +215,8 @@ class TestAnalyzeRunStreamBounds:
         )
         assert resp.status_code != 422
 
-    def test_exactly_128_char_run_id_passes_validation(self):
+    def test_exactly_128_char_run_id_passes_validation(self, client: TestClient):
         run_id_128 = "r" * 128
-        client = TestClient(app, raise_server_exceptions=False)
         resp = client.get(
             f"/api/kai/analyze/run/{run_id_128}/stream",
             params={"user_id": _GOOD_USER_ID},
@@ -228,8 +231,7 @@ class TestAnalyzeRunStreamBounds:
 
 
 class TestAnalyzeRunCancelBounds:
-    def test_oversized_run_id_rejected_422(self):
-        client = TestClient(app, raise_server_exceptions=False)
+    def test_oversized_run_id_rejected_422(self, client: TestClient):
         resp = client.post(
             f"/api/kai/analyze/run/{_LONG_RUN_ID}/cancel",
             params={"user_id": _GOOD_USER_ID},
@@ -237,8 +239,7 @@ class TestAnalyzeRunCancelBounds:
         )
         assert resp.status_code == 422
 
-    def test_oversized_user_id_rejected_422(self):
-        client = TestClient(app, raise_server_exceptions=False)
+    def test_oversized_user_id_rejected_422(self, client: TestClient):
         resp = client.post(
             f"/api/kai/analyze/run/{_GOOD_RUN_ID}/cancel",
             params={"user_id": _LONG_STR_129},
@@ -246,8 +247,7 @@ class TestAnalyzeRunCancelBounds:
         )
         assert resp.status_code == 422
 
-    def test_valid_params_reach_auth_layer(self):
-        client = TestClient(app, raise_server_exceptions=False)
+    def test_valid_params_reach_auth_layer(self, client: TestClient):
         resp = client.post(
             f"/api/kai/analyze/run/{_GOOD_RUN_ID}/cancel",
             params={"user_id": _GOOD_USER_ID},


### PR DESCRIPTION
## Summary

Four streaming/run handlers in `api/routes/kai/stream.py` accepted bare `str` parameters with no FastAPI-enforced length constraints. Any caller could send arbitrarily large strings that cause excessive memory allocation and string processing **before** the vault token auth check even runs, a classic pre-auth amplification vector.

### Affected handlers and parameters

| Handler | Route | Params fixed |
|---|---|---|
| `analyze_stream` | `GET /api/kai/analyze/stream` | `ticker` (Query, max 20), `user_id` (Query, max 128), `risk_profile` (Query, max 64) |
| `analyze_run_active` | `GET /api/kai/analyze/run/active` | `user_id` (Query, max 128), `debate_session_id` (Query, max 256) |
| `analyze_run_stream` | `GET /api/kai/analyze/run/{run_id}/stream` | `run_id` (Path, max 128), `user_id` (Query, max 128) |
| `analyze_run_cancel` | `POST /api/kai/analyze/run/{run_id}/cancel` | `run_id` (Path, max 128), `user_id` (Query, max 128) |

### Fix pattern

- **Query params**: `str = Query(min_length=1, max_length=N)` -- FastAPI validates before the handler body executes.
- **Path params** (`run_id`): `RunId = Annotated[str, Path(min_length=1, max_length=128)]` type alias - consistent with the `UserId` pattern in `world_model.py`, `marketplace.py`, `market_insights.py`, and `sse.py`.

**Note on `ticker`**: the existing `_normalize_ticker_or_422()` function enforces a strict 6-character regex **after** the string is received. The new `max_length=20` cap stops oversized allocation before that normalization runs.

### Why this matters

`GET /api/kai/analyze/stream` is the most critical, it opens a long-lived SSE connection and the `user_id` and `ticker` flow into multiple downstream calls (token validation, PKM service, consensus log). An unbounded ticker or user_id could amplify work at every step.

## Attach point

`api/routes/kai/stream.py`, module docstring attach block added above the constants section.

## Test plan

`tests/test_stream_path_query_bounds_cwe400.py`, 17 regression cases:

- [x] Oversized `user_id` (129 chars) rejected 422 across all four endpoints
- [x] Oversized `ticker` (21 chars) rejected 422 on analyze/stream
- [x] Oversized `risk_profile` (72 chars) rejected 422
- [x] Empty ticker rejected 422 (min_length=1)
- [x] Oversized `debate_session_id` (257 chars) rejected 422
- [x] Oversized `run_id` path param (129 chars) rejected 422
- [x] Boundary-exact values (128-char user_id, 128-char run_id) pass validation and reach auth layer
- [x] Valid inputs pass validation (status != 422), confirming bounds don't over-reject