### PR TITLE
fix(kai/llm): prevent internal error detail leaking to SSE clients (CWE-209)

### DIFF
--- a/consent-protocol/hushh_mcp/operons/kai/llm.py
+++ b/consent-protocol/hushh_mcp/operons/kai/llm.py
@@ -898,7 +898,7 @@ async def stream_gemini_response(
                                     "token_source": "response",
                                 }
                     except Exception as e:
-                        logger.warning(f"[Gemini Streaming] Skipped chunk for {agent_name}: {e}")
+                        logger.warning("[Gemini Streaming] Skipped chunk for %s: %s", agent_name, e)
                         continue
 
             yield {
@@ -906,7 +906,7 @@ async def stream_gemini_response(
                 "text": full_text,
                 "agent": agent_name,
             }
-            logger.info(f"[Gemini Streaming] Complete for {agent_name}, {token_count} tokens")
+            logger.info("[Gemini Streaming] Complete for %s, %s tokens", agent_name, token_count)
             return
         except Exception as e:
             retryable = _is_retryable_stream_error(e)
@@ -923,10 +923,10 @@ async def stream_gemini_response(
                 await asyncio.sleep(delay_seconds)
                 continue
 
-            logger.error(f"[Gemini Streaming] Error for {agent_name}: {e}", exc_info=True)
+            logger.error("[Gemini Streaming] Error for %s: %s", agent_name, e, exc_info=True)
             yield {
                 "type": "error",
-                "message": str(e),
+                "message": "Streaming analysis encountered an internal error.",
                 "agent": agent_name,
             }
             return
@@ -949,14 +949,16 @@ async def analyze_fundamental_streaming(
     valid, reason, token = validate_token(consent_token, ConsentScope("agent.kai.analyze"))
 
     if not valid:
-        yield {"type": "error", "message": f"Permission denied: {reason}"}
+        logger.warning("[Fundamental Streaming] Consent validation failed for %s: %s", ticker, reason)
+        yield {"type": "error", "message": "Consent token is invalid or insufficient for this operation."}
         return
 
     if not _require_gemini_ready():
-        yield {"type": "error", "message": _gemini_unavailable_reason or "Gemini unavailable"}
+        logger.warning("[Fundamental Streaming] Gemini not ready for %s", ticker)
+        yield {"type": "error", "message": "The analysis service is temporarily unavailable."}
         return
 
-    logger.info(f"[Fundamental Streaming] Starting for {ticker}")
+    logger.info("[Fundamental Streaming] Starting for %s", ticker)
 
     # Build context (same as non-streaming version)
     latest_10k = sec_data.get("latest_10k", {})

--- a/consent-protocol/hushh_mcp/operons/kai/llm.py
+++ b/consent-protocol/hushh_mcp/operons/kai/llm.py
@@ -808,10 +808,10 @@ async def stream_gemini_response(
     This is more reliable than async iteration which may not yield correctly.
     """
     if not _require_gemini_ready():
-        logger.error("[Gemini Streaming] No client configured!")
+        logger.error("[Gemini Streaming] No client configured: %s", _gemini_unavailable_reason)
         yield {
             "type": "error",
-            "message": _gemini_unavailable_reason or "Gemini client not configured",
+            "message": "The analysis service is temporarily unavailable.",
         }
         return
 

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -14,3 +14,4 @@ tests/test_ria_iam_service_architecture.py
 tests/test_kai_optimize_realtime_contract.py
 tests/test_portfolio_stream_quality_rules.py
 tests/test_stream_path_query_bounds_cwe400.py
+tests/test_llm_operon_stream_error_leak.py

--- a/consent-protocol/tests/test_llm_operon_stream_error_leak.py
+++ b/consent-protocol/tests/test_llm_operon_stream_error_leak.py
@@ -24,6 +24,10 @@ async def _collect(gen) -> list[dict]:
 
 # ---------------------------------------------------------------------------
 # stream_gemini_response - exception leak (CWE-209)
+#
+# stream_gemini_response() uses the module-level _gemini_client object; it
+# does NOT accept a `model` parameter. Tests patch the module-level client
+# and _require_gemini_ready so the function exercises the real exception path.
 # ---------------------------------------------------------------------------
 
 
@@ -32,28 +36,26 @@ class TestStreamGeminiResponseExceptionLeak:
 
     def test_exception_message_not_in_error_payload(self) -> None:
         """Sentinel exception message must not leak into error frame."""
+        from hushh_mcp.operons.kai import llm as llm_mod
         from hushh_mcp.operons.kai.llm import stream_gemini_response
 
         sentinel = "SENTINEL_INTERNAL_GEMINI_DETAIL_xk9z"
 
-        fake_model = MagicMock()
-        # Make generate_content_async raise with the sentinel message
-        fake_model.generate_content_async = AsyncMock(
+        fake_client = MagicMock()
+        fake_client.aio.models.generate_content_stream = AsyncMock(
             side_effect=RuntimeError(sentinel)
         )
 
-        async def run():
-            frames = []
-            async for frame in stream_gemini_response(
-                model=fake_model,
+        # Patch the module-level client so _require_gemini_ready returns True
+        # and the actual generation path raises with the sentinel.
+        with patch.object(llm_mod, "_gemini_client", fake_client), \
+             patch.object(llm_mod, "GEMINI_AVAILABLE", True), \
+             patch.object(llm_mod, "_gemini_model_name", "gemini-flash"), \
+             patch("hushh_mcp.operons.kai.llm.types", MagicMock()):
+            frames = asyncio.run(_collect(stream_gemini_response(
                 prompt="analyze AAPL",
                 agent_name="bull",
-                max_attempts=1,
-            ):
-                frames.append(frame)
-            return frames
-
-        frames = asyncio.get_event_loop().run_until_complete(run())
+            )))
 
         error_frames = [f for f in frames if f.get("type") == "error"]
         assert error_frames, "Expected at least one error frame"
@@ -66,28 +68,48 @@ class TestStreamGeminiResponseExceptionLeak:
 
     def test_error_frame_has_static_message(self) -> None:
         """Error frame message must be the approved static string."""
+        from hushh_mcp.operons.kai import llm as llm_mod
         from hushh_mcp.operons.kai.llm import stream_gemini_response
 
-        fake_model = MagicMock()
-        fake_model.generate_content_async = AsyncMock(
+        fake_client = MagicMock()
+        fake_client.aio.models.generate_content_stream = AsyncMock(
             side_effect=RuntimeError("some internal failure")
         )
 
-        async def run():
-            frames = []
-            async for frame in stream_gemini_response(
-                model=fake_model,
+        with patch.object(llm_mod, "_gemini_client", fake_client), \
+             patch.object(llm_mod, "GEMINI_AVAILABLE", True), \
+             patch.object(llm_mod, "_gemini_model_name", "gemini-flash"), \
+             patch("hushh_mcp.operons.kai.llm.types", MagicMock()):
+            frames = asyncio.run(_collect(stream_gemini_response(
                 prompt="analyze AAPL",
                 agent_name="bear",
-                max_attempts=1,
-            ):
-                frames.append(frame)
-            return frames
+            )))
 
-        frames = asyncio.get_event_loop().run_until_complete(run())
         error_frames = [f for f in frames if f.get("type") == "error"]
         assert error_frames
         assert error_frames[0]["message"] == "Streaming analysis encountered an internal error."
+
+    def test_gemini_unavailable_message_is_generic(self) -> None:
+        """When Gemini client is not ready, the error message must be static, not the internal reason."""
+        from hushh_mcp.operons.kai import llm as llm_mod
+        from hushh_mcp.operons.kai.llm import stream_gemini_response
+
+        sentinel = "SENTINEL_UNAVAIL_REASON_init_failed_7x2"
+
+        with patch.object(llm_mod, "_gemini_unavailable_reason", sentinel), \
+             patch("hushh_mcp.operons.kai.llm._require_gemini_ready", return_value=False):
+            frames = asyncio.run(_collect(stream_gemini_response(
+                prompt="analyze AAPL",
+                agent_name="bull",
+            )))
+
+        error_frames = [f for f in frames if f.get("type") == "error"]
+        assert error_frames, "Expected an error frame when Gemini is unavailable"
+        for frame in error_frames:
+            assert sentinel not in frame.get("message", ""), (
+                f"Internal unavailable reason leaked: {frame!r}"
+            )
+        assert error_frames[0]["message"] == "The analysis service is temporarily unavailable."
 
 
 # ---------------------------------------------------------------------------
@@ -108,18 +130,12 @@ class TestAnalyzeFundamentalStreamingConsentLeak:
             "hushh_mcp.operons.kai.llm.validate_token",
             return_value=(False, sentinel, None),
         ):
-            async def run():
-                frames = []
-                async for frame in analyze_fundamental_streaming(
-                    ticker="AAPL",
-                    user_id="user-test",
-                    consent_token="bad-token",  # noqa: S106
-                    sec_data={},
-                ):
-                    frames.append(frame)
-                return frames
-
-            frames = asyncio.get_event_loop().run_until_complete(run())
+            frames = asyncio.run(_collect(analyze_fundamental_streaming(
+                ticker="AAPL",
+                user_id="user-test",
+                consent_token="bad-token",  # noqa: S106
+                sec_data={},
+            )))
 
         error_frames = [f for f in frames if f.get("type") == "error"]
         assert error_frames, "Expected an error frame on consent failure"
@@ -138,18 +154,12 @@ class TestAnalyzeFundamentalStreamingConsentLeak:
             "hushh_mcp.operons.kai.llm.validate_token",
             return_value=(False, "token expired", None),
         ):
-            async def run():
-                frames = []
-                async for frame in analyze_fundamental_streaming(
-                    ticker="AAPL",
-                    user_id="user-test",
-                    consent_token="expired",  # noqa: S106
-                    sec_data={},
-                ):
-                    frames.append(frame)
-                return frames
-
-            frames = asyncio.get_event_loop().run_until_complete(run())
+            frames = asyncio.run(_collect(analyze_fundamental_streaming(
+                ticker="AAPL",
+                user_id="user-test",
+                consent_token="expired",  # noqa: S106
+                sec_data={},
+            )))
 
         error_frames = [f for f in frames if f.get("type") == "error"]
         assert error_frames
@@ -169,6 +179,7 @@ class TestAnalyzeFundamentalStreamingGeminiLeak:
 
     def test_gemini_unavailable_reason_not_leaked(self) -> None:
         """Sentinel Gemini reason must not appear in error frame."""
+        from hushh_mcp.operons.kai import llm as llm_mod
         from hushh_mcp.operons.kai.llm import analyze_fundamental_streaming
 
         sentinel = "SENTINEL_GEMINI_INIT_REASON_7x2q"
@@ -179,23 +190,13 @@ class TestAnalyzeFundamentalStreamingGeminiLeak:
         ), patch(
             "hushh_mcp.operons.kai.llm._require_gemini_ready",
             return_value=False,
-        ), patch(
-            "hushh_mcp.operons.kai.llm._gemini_unavailable_reason",
-            sentinel,
-        ):
-
-            async def run():
-                frames = []
-                async for frame in analyze_fundamental_streaming(
-                    ticker="TSLA",
-                    user_id="user-test",
-                    consent_token="good-token",  # noqa: S106
-                    sec_data={},
-                ):
-                    frames.append(frame)
-                return frames
-
-            frames = asyncio.get_event_loop().run_until_complete(run())
+        ), patch.object(llm_mod, "_gemini_unavailable_reason", sentinel):
+            frames = asyncio.run(_collect(analyze_fundamental_streaming(
+                ticker="TSLA",
+                user_id="user-test",
+                consent_token="good-token",  # noqa: S106
+                sec_data={},
+            )))
 
         error_frames = [f for f in frames if f.get("type") == "error"]
         assert error_frames, "Expected an error frame when Gemini is unavailable"
@@ -208,6 +209,7 @@ class TestAnalyzeFundamentalStreamingGeminiLeak:
 
     def test_gemini_unavailable_static_message(self) -> None:
         """Gemini-unavailable error frame must use the approved static message."""
+        from hushh_mcp.operons.kai import llm as llm_mod
         from hushh_mcp.operons.kai.llm import analyze_fundamental_streaming
 
         with patch(
@@ -216,23 +218,13 @@ class TestAnalyzeFundamentalStreamingGeminiLeak:
         ), patch(
             "hushh_mcp.operons.kai.llm._require_gemini_ready",
             return_value=False,
-        ), patch(
-            "hushh_mcp.operons.kai.llm._gemini_unavailable_reason",
-            "api key invalid",
-        ):
-
-            async def run():
-                frames = []
-                async for frame in analyze_fundamental_streaming(
-                    ticker="TSLA",
-                    user_id="user-test",
-                    consent_token="good-token",  # noqa: S106
-                    sec_data={},
-                ):
-                    frames.append(frame)
-                return frames
-
-            frames = asyncio.get_event_loop().run_until_complete(run())
+        ), patch.object(llm_mod, "_gemini_unavailable_reason", "api key invalid"):
+            frames = asyncio.run(_collect(analyze_fundamental_streaming(
+                ticker="TSLA",
+                user_id="user-test",
+                consent_token="good-token",  # noqa: S106
+                sec_data={},
+            )))
 
         error_frames = [f for f in frames if f.get("type") == "error"]
         assert error_frames

--- a/consent-protocol/tests/test_llm_operon_stream_error_leak.py
+++ b/consent-protocol/tests/test_llm_operon_stream_error_leak.py
@@ -1,0 +1,242 @@
+"""Regression tests - CWE-209 in hushh_mcp/operons/kai/llm.py.
+
+Verifies that internal exception detail and consent-validation reason strings
+are NOT forwarded to SSE callers through stream_gemini_response and
+analyze_fundamental_streaming.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _collect(gen) -> list[dict]:
+    frames = []
+    async for frame in gen:
+        frames.append(frame)
+    return frames
+
+
+# ---------------------------------------------------------------------------
+# stream_gemini_response - exception leak (CWE-209)
+# ---------------------------------------------------------------------------
+
+
+class TestStreamGeminiResponseExceptionLeak:
+    """Internal exception detail must not appear in yielded error frames."""
+
+    def test_exception_message_not_in_error_payload(self) -> None:
+        """Sentinel exception message must not leak into error frame."""
+        from hushh_mcp.operons.kai.llm import stream_gemini_response
+
+        sentinel = "SENTINEL_INTERNAL_GEMINI_DETAIL_xk9z"
+
+        fake_model = MagicMock()
+        # Make generate_content_async raise with the sentinel message
+        fake_model.generate_content_async = AsyncMock(
+            side_effect=RuntimeError(sentinel)
+        )
+
+        async def run():
+            frames = []
+            async for frame in stream_gemini_response(
+                model=fake_model,
+                prompt="analyze AAPL",
+                agent_name="bull",
+                max_attempts=1,
+            ):
+                frames.append(frame)
+            return frames
+
+        frames = asyncio.get_event_loop().run_until_complete(run())
+
+        error_frames = [f for f in frames if f.get("type") == "error"]
+        assert error_frames, "Expected at least one error frame"
+
+        for frame in error_frames:
+            msg = frame.get("message", "")
+            assert sentinel not in msg, (
+                f"Internal exception detail leaked into error frame: {msg!r}"
+            )
+
+    def test_error_frame_has_static_message(self) -> None:
+        """Error frame message must be the approved static string."""
+        from hushh_mcp.operons.kai.llm import stream_gemini_response
+
+        fake_model = MagicMock()
+        fake_model.generate_content_async = AsyncMock(
+            side_effect=RuntimeError("some internal failure")
+        )
+
+        async def run():
+            frames = []
+            async for frame in stream_gemini_response(
+                model=fake_model,
+                prompt="analyze AAPL",
+                agent_name="bear",
+                max_attempts=1,
+            ):
+                frames.append(frame)
+            return frames
+
+        frames = asyncio.get_event_loop().run_until_complete(run())
+        error_frames = [f for f in frames if f.get("type") == "error"]
+        assert error_frames
+        assert error_frames[0]["message"] == "Streaming analysis encountered an internal error."
+
+
+# ---------------------------------------------------------------------------
+# analyze_fundamental_streaming - consent reason leak (CWE-209)
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeFundamentalStreamingConsentLeak:
+    """validate_token reason must not appear in yielded error frames."""
+
+    def test_consent_reason_not_in_error_payload(self) -> None:
+        """Sentinel consent-failure reason must not leak into error frame."""
+        from hushh_mcp.operons.kai.llm import analyze_fundamental_streaming
+
+        sentinel = "SENTINEL_CONSENT_REASON_abc123"
+
+        with patch(
+            "hushh_mcp.operons.kai.llm.validate_token",
+            return_value=(False, sentinel, None),
+        ):
+            async def run():
+                frames = []
+                async for frame in analyze_fundamental_streaming(
+                    ticker="AAPL",
+                    user_id="user-test",
+                    consent_token="bad-token",  # noqa: S106
+                    sec_data={},
+                ):
+                    frames.append(frame)
+                return frames
+
+            frames = asyncio.get_event_loop().run_until_complete(run())
+
+        error_frames = [f for f in frames if f.get("type") == "error"]
+        assert error_frames, "Expected an error frame on consent failure"
+
+        for frame in error_frames:
+            msg = frame.get("message", "")
+            assert sentinel not in msg, (
+                f"Consent failure reason leaked into error frame: {msg!r}"
+            )
+
+    def test_consent_error_static_message(self) -> None:
+        """Consent error frame must use the approved static message."""
+        from hushh_mcp.operons.kai.llm import analyze_fundamental_streaming
+
+        with patch(
+            "hushh_mcp.operons.kai.llm.validate_token",
+            return_value=(False, "token expired", None),
+        ):
+            async def run():
+                frames = []
+                async for frame in analyze_fundamental_streaming(
+                    ticker="AAPL",
+                    user_id="user-test",
+                    consent_token="expired",  # noqa: S106
+                    sec_data={},
+                ):
+                    frames.append(frame)
+                return frames
+
+            frames = asyncio.get_event_loop().run_until_complete(run())
+
+        error_frames = [f for f in frames if f.get("type") == "error"]
+        assert error_frames
+        assert (
+            error_frames[0]["message"]
+            == "Consent token is invalid or insufficient for this operation."
+        )
+
+
+# ---------------------------------------------------------------------------
+# analyze_fundamental_streaming - Gemini unavailable reason leak (CWE-209)
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeFundamentalStreamingGeminiLeak:
+    """Internal Gemini-unavailable reason must not appear in yielded error frames."""
+
+    def test_gemini_unavailable_reason_not_leaked(self) -> None:
+        """Sentinel Gemini reason must not appear in error frame."""
+        from hushh_mcp.operons.kai.llm import analyze_fundamental_streaming
+
+        sentinel = "SENTINEL_GEMINI_INIT_REASON_7x2q"
+
+        with patch(
+            "hushh_mcp.operons.kai.llm.validate_token",
+            return_value=(True, None, MagicMock()),
+        ), patch(
+            "hushh_mcp.operons.kai.llm._require_gemini_ready",
+            return_value=False,
+        ), patch(
+            "hushh_mcp.operons.kai.llm._gemini_unavailable_reason",
+            sentinel,
+        ):
+
+            async def run():
+                frames = []
+                async for frame in analyze_fundamental_streaming(
+                    ticker="TSLA",
+                    user_id="user-test",
+                    consent_token="good-token",  # noqa: S106
+                    sec_data={},
+                ):
+                    frames.append(frame)
+                return frames
+
+            frames = asyncio.get_event_loop().run_until_complete(run())
+
+        error_frames = [f for f in frames if f.get("type") == "error"]
+        assert error_frames, "Expected an error frame when Gemini is unavailable"
+
+        for frame in error_frames:
+            msg = frame.get("message", "")
+            assert sentinel not in msg, (
+                f"Gemini unavailable reason leaked into error frame: {msg!r}"
+            )
+
+    def test_gemini_unavailable_static_message(self) -> None:
+        """Gemini-unavailable error frame must use the approved static message."""
+        from hushh_mcp.operons.kai.llm import analyze_fundamental_streaming
+
+        with patch(
+            "hushh_mcp.operons.kai.llm.validate_token",
+            return_value=(True, None, MagicMock()),
+        ), patch(
+            "hushh_mcp.operons.kai.llm._require_gemini_ready",
+            return_value=False,
+        ), patch(
+            "hushh_mcp.operons.kai.llm._gemini_unavailable_reason",
+            "api key invalid",
+        ):
+
+            async def run():
+                frames = []
+                async for frame in analyze_fundamental_streaming(
+                    ticker="TSLA",
+                    user_id="user-test",
+                    consent_token="good-token",  # noqa: S106
+                    sec_data={},
+                ):
+                    frames.append(frame)
+                return frames
+
+            frames = asyncio.get_event_loop().run_until_complete(run())
+
+        error_frames = [f for f in frames if f.get("type") == "error"]
+        assert error_frames
+        assert (
+            error_frames[0]["message"]
+            == "The analysis service is temporarily unavailable."
+        )


### PR DESCRIPTION
## Problem

`hushh_mcp/operons/kai/llm.py` had three places where internal detail was
forwarded verbatim into SSE error frames that reach browser clients:

1. `stream_gemini_response` - yielded `str(e)` (raw exception message) in
   the `"error"` frame on every unretried failure.
2. `analyze_fundamental_streaming` - yielded the consent-validation `reason`
   string (e.g. `"token expired"`, `"scope mismatch"`) via
   `f"Permission denied: {reason}"`.
3. `analyze_fundamental_streaming` - yielded `_gemini_unavailable_reason`
   (internal init failure detail such as an API-key error) or the literal
   fallback `"Gemini unavailable"`.

Any of these could expose stack details, configuration strings, or internal
service state to unauthenticated downstream consumers of the SSE stream.

CWE: CWE-209 Information Exposure Through Error Messages

## Changes

| File | Change |
|------|--------|
| `hushh_mcp/operons/kai/llm.py` | Replace all three leaking payloads with static opaque strings; convert four f-string `logger.*` calls to `%`-style lazy formatting (ruff G004) |
| `tests/test_llm_operon_stream_error_leak.py` | 5 sentinel-injection regression tests - inject a distinctive string into the mock, assert it is absent from every yielded frame |

## Test approach

Sentinel-injection pattern: each test patches the leaking source (exception
message / consent reason / Gemini reason) with a unique sentinel string, runs
the generator to exhaustion, and asserts the sentinel does not appear in any
yielded frame's `"message"` field.

## Checklist
- [x] ruff clean (`ruff check --fix` passes, zero remaining errors)
- [x] DCO sign-off (`git commit -s`)
- [x] No em dashes in code or comments
- [x] No AI/tool attribution in commit or PR