### PR TITLE
feat(app-ui): add sr-only live announcements to DataTable

### DIFF
--- a/hushh-webapp/components/app-ui/data-table.tsx
+++ b/hushh-webapp/components/app-ui/data-table.tsx
@@ -116,7 +116,9 @@ export function DataTable<TData, TValue>({
     []
   );
   const [globalFilter, setGlobalFilter] = React.useState("");
+  const [liveAnnouncement, setLiveAnnouncement] = React.useState("");
   const swipeStartRef = React.useRef<{ x: number; y: number } | null>(null);
+  const isFirstRender = React.useRef(true);
   const normalizedSearchKeys = React.useMemo(
     () =>
       Array.from(
@@ -200,6 +202,20 @@ export function DataTable<TData, TValue>({
     [currentPage, pageCount]
   );
 
+  React.useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    if (filteredCount === 0) {
+      setLiveAnnouncement("No results found.");
+    } else {
+      setLiveAnnouncement(
+        `Showing ${rangeStart} to ${rangeEnd} of ${filteredCount} results.`
+      );
+    }
+  }, [filteredCount, currentPage, pageCount, rangeStart, rangeEnd]);
+
   const handleTouchStart = React.useCallback((event: React.TouchEvent<HTMLDivElement>) => {
     const touch = event.touches[0];
     if (!touch) return;
@@ -242,6 +258,13 @@ export function DataTable<TData, TValue>({
       onTouchStart={handleTouchStart}
       onTouchEnd={handleTouchEnd}
     >
+      <div
+        role="status"
+        aria-live="polite"
+        className="sr-only"
+      >
+        {liveAnnouncement}
+      </div>
       {/* Search and Filter Controls */}
       {(enableSearch || (filterKey && filterOptions)) && (
         <div className="flex flex-col gap-3 sm:flex-row">


### PR DESCRIPTION
## Summary

Adds a visually-hidden `aria-live="polite"` status region to `DataTable`
to announce filter result count changes for screen reader users using the
existing `sr-only` accessibility pattern already used throughout the app.

## Changes

* **Edit:** `components/app-ui/data-table.tsx`

  * Adds `liveAnnouncement` local state
  * Adds `isFirstRender` ref to suppress initial mount announcements
  * Adds `useEffect` that updates screen-reader announcements when:

    * filter results change
    * pagination changes
  * Adds visually-hidden:

    * `role="status"`
    * `aria-live="polite"`
      live region

## Announcement behavior

* Zero results:

  * `"No results found."`

* Results available:

  * `"Showing {start} to {end} of {total} results."`

## Architecture

Changes stay fully within the shared `DataTable` infrastructure layer and reuse
existing accessibility conventions already present in the repository.

* No runtime/business/auth/backend logic touched
* No visible UI changes
* No pagination/filter logic changes
* No loading-state behavior changes
* No new dependencies

## Impact

* shared accessibility infrastructure improvement
* reusable screen-reader pagination/filter announcements
* frontend-only enhancement
* multi-surface DataTable accessibility support
* zero visual regression risk

## Regression risk

Minimal.

The live region is visually hidden and isolated to local component state only.
Existing DataTable behavior remains unchanged.

## Testing

* `npx tsc --noEmit` ✅
* `npm run lint` ✅
