### PR TITLE
fix(crd-scraper): add max_length=128 to job_id path params (CWE-400)

### DIFF
--- a/consent-protocol/api/routes/crd_scraper.py
+++ b/consent-protocol/api/routes/crd_scraper.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Path, Request
 from fastapi.responses import JSONResponse
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
 
@@ -15,6 +15,11 @@ from hushh_mcp.services.crd_scrape_proxy_service import (
 )
 
 router = APIRouter(prefix="/api/ria", tags=["RIA", "CRD Scraper"])
+
+# Max length for job ID path parameters. UUIDs are 36 chars; allow extra headroom.
+_JOB_ID_MAX_LEN = 128
+
+JobId = Annotated[str, Path(min_length=1, max_length=_JOB_ID_MAX_LEN)]
 
 
 class CrdScrapeJobRequest(BaseModel):
@@ -55,7 +60,7 @@ async def create_crd_scrape_job(
 @router.get("/crd-scrape-jobs/{job_id}")
 @limiter.limit("60/minute")
 async def get_crd_scrape_job(
-    job_id: str,
+    job_id: JobId,
     request: Request,
     service: CrdScrapeProxyService = Depends(get_crd_scrape_proxy_service),
 ) -> JSONResponse:
@@ -87,7 +92,7 @@ async def create_financial_verification_job(
 @router.get("/financial-verification-jobs/{job_id}")
 @limiter.limit("60/minute")
 async def get_financial_verification_job(
-    job_id: str,
+    job_id: JobId,
     request: Request,
     service: CrdScrapeProxyService = Depends(get_crd_scrape_proxy_service),
 ) -> JSONResponse:

--- a/consent-protocol/tests/test_crd_scraper_job_id_bounds_cwe400.py
+++ b/consent-protocol/tests/test_crd_scraper_job_id_bounds_cwe400.py
@@ -1,0 +1,67 @@
+"""Regression tests - CWE-400 in api/routes/crd_scraper.py job ID path params.
+
+GET /api/ria/crd-scrape-jobs/{job_id} and
+GET /api/ria/financial-verification-jobs/{job_id} previously accepted an
+unbounded string path parameter. An attacker could send a megabyte-long job
+ID forcing string materialisation and logging in every middleware layer.
+
+These tests verify that:
+  - a normally-sized job ID (UUID-like) is accepted (422 only from downstream)
+  - a job ID exceeding max_length=128 is rejected with HTTP 422 before any
+    service call is made
+
+Attach point: api/routes/crd_scraper.py::get_crd_scrape_job,
+              api/routes/crd_scraper.py::get_financial_verification_job
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app, raise_server_exceptions=False)
+
+_VALID_JOB_ID = "a" * 36
+_OVERLONG_JOB_ID = "x" * 129  # exceeds max_length=128
+
+
+class TestCrdScrapeJobIdBounds:
+    """GET /api/ria/crd-scrape-jobs/{job_id} path param bounds."""
+
+    def test_valid_job_id_not_rejected_by_bounds(self) -> None:
+        """A normally-sized job ID must not produce a 422 from path validation."""
+        resp = client.get(f"/api/ria/crd-scrape-jobs/{_VALID_JOB_ID}")
+        # 422 would mean validation failure; any other status means bounds passed
+        assert resp.status_code != 422, (
+            f"Valid job_id was rejected by path validation: {resp.text}"
+        )
+
+    def test_overlong_job_id_rejected_with_422(self) -> None:
+        """A job ID exceeding 128 chars must be rejected with 422."""
+        resp = client.get(f"/api/ria/crd-scrape-jobs/{_OVERLONG_JOB_ID}")
+        assert resp.status_code == 422, (
+            f"Overlong job_id was not rejected (got {resp.status_code})"
+        )
+
+    def test_empty_job_id_path_not_routed(self) -> None:
+        """An empty job_id segment should not match the path (404 or 405)."""
+        resp = client.get("/api/ria/crd-scrape-jobs/")
+        assert resp.status_code in {404, 405, 307, 308}
+
+
+class TestFinancialVerificationJobIdBounds:
+    """GET /api/ria/financial-verification-jobs/{job_id} path param bounds."""
+
+    def test_valid_job_id_not_rejected_by_bounds(self) -> None:
+        """A normally-sized job ID must not produce a 422 from path validation."""
+        resp = client.get(f"/api/ria/financial-verification-jobs/{_VALID_JOB_ID}")
+        assert resp.status_code != 422, (
+            f"Valid job_id was rejected by path validation: {resp.text}"
+        )
+
+    def test_overlong_job_id_rejected_with_422(self) -> None:
+        """A job ID exceeding 128 chars must be rejected with 422."""
+        resp = client.get(f"/api/ria/financial-verification-jobs/{_OVERLONG_JOB_ID}")
+        assert resp.status_code == 422, (
+            f"Overlong job_id was not rejected (got {resp.status_code})"
+        )


### PR DESCRIPTION
## Problem

Two CRD-scraper endpoints accepted an unbounded string path parameter:

| Endpoint | Handler |
|----------|---------|
| `GET /api/ria/crd-scrape-jobs/{job_id}` | `get_crd_scrape_job` |
| `GET /api/ria/financial-verification-jobs/{job_id}` | `get_financial_verification_job` |

Without a `max_length` guard, a caller can send an arbitrarily long `job_id`
that is materialised in every middleware layer (logging, tracing, rate-limiter
key hashing, request-ID propagation) before reaching the service - a classic
CWE-400 uncontrolled resource consumption vector.

CWE: CWE-400 Uncontrolled Resource Consumption

## Changes

| File | Change |
|------|--------|
| `api/routes/crd_scraper.py` | Add `JobId = Annotated[str, Path(min_length=1, max_length=128)]` alias; apply to both path handlers; add `Annotated` to `typing` imports and `Path` to `fastapi` imports |
| `tests/test_crd_scraper_job_id_bounds_cwe400.py` | 5 regression tests: valid UUID-sized ID accepted, overlong ID rejected with 422, empty segment not routed |

## Chosen bound

UUIDs are 36 characters. `max_length=128` gives comfortable headroom for
non-UUID opaque job identifiers while still providing a meaningful cap.

## Checklist
- [x] ruff clean (`ruff check --fix` passes, zero remaining errors)
- [x] DCO sign-off (`git commit -s`)
- [x] No em dashes in code or comments
- [x] No AI/tool attribution in commit or PR