### PR TITLE
fix(a11y): add semantic status role and aria-live to HushhLoader

### DIFF
--- a/hushh-webapp/components/app-ui/hushh-loader.tsx
+++ b/hushh-webapp/components/app-ui/hushh-loader.tsx
@@ -27,7 +27,16 @@ export function HushhLoader({
   className,
 }: HushhLoaderProps) {
   if (variant === "compact") {
-    return <span className={cn("inline-block text-muted-foreground", className)}>…</span>;
+    return (
+    <span
+      role="status"
+      aria-live="polite"
+      aria-label={label}
+      className={cn("inline-block text-muted-foreground", className)}
+    >
+      …
+    </span>
+  );
   }
 
   const isFullscreen = variant === "fullscreen";
@@ -36,6 +45,9 @@ export function HushhLoader({
 
   return (
     <div
+      role="status"
+      aria-live="polite"
+      aria-label={label}
       className={cn(
         "flex items-center justify-center",
         isFullscreen


### PR DESCRIPTION
## Summary

Adds semantic loading accessibility semantics to the shared `HushhLoader`
primitive by introducing `role="status"`, `aria-live="polite"`, and
accessible labels for screen readers.

This improves async/loading feedback across every surface that renders
`HushhLoader` without changing runtime behavior, visual UI, or component APIs.

## Surface ownership

- `components/app-ui/hushh-loader.tsx`

## What changed

### Main loader variants (`fullscreen`, `page`, `inline`)
Added:

- `role="status"`
- `aria-live="polite"`
- `aria-label={label}`

to the shared outer container.

This allows assistive technologies to announce loading state transitions
naturally when the loader mounts or its label changes.

### Compact variant
Added:

- `role="status"`
- `aria-live="polite"`
- `aria-label={label}`

to the compact inline `<span>` variant.

The compact loader visually renders only `"…"`, which is not meaningful for
screen readers. `aria-label` exposes the actual loading label instead.

## Why this matters

`HushhLoader` is a shared infrastructure primitive used across route loading,
async fetch states, gated flows, and inline loading surfaces throughout the app.

Before this change:

- loading states had no semantic meaning
- screen readers received no async feedback
- compact loaders announced only `"ellipsis"`

After this change:

- loading states are announced consistently
- async transitions become accessible without manual focus management
- all existing loader consumers benefit automatically

## What did NOT change

- No visual UI changes
- No animation changes
- No prop API changes
- No runtime/business logic changes
- No new dependencies
- No loading flow behavior changes

## Accessibility rationale

- `role="status"` is the semantic ARIA role intended for loading/progress messaging
- `aria-live="polite"` avoids interrupting current speech output while still announcing updates
- Explicit `aria-live` is retained for broader VoiceOver compatibility

## Regression risk

**Minimal.**

All changes are additive ARIA attributes only. The component structure,
rendering behavior, styling, and APIs remain unchanged.

## Validation

npx tsc --noEmit
npm run lint