### PR TITLE
[codex] Improve Agent chat context and popup UX

### DIFF
--- a/consent-protocol/api/routes/kai/agent_chat.py
+++ b/consent-protocol/api/routes/kai/agent_chat.py
@@ -29,7 +29,7 @@ class AgentChatStreamRequest(BaseModel):
     user_id: str = Field(..., min_length=1)
     message: str = Field(..., min_length=1, max_length=8000)
     conversation_id: Optional[str] = None
-    pkm_context: Optional[str] = Field(default=None, max_length=6000)
+    pkm_context: Optional[str] = Field(default=None, max_length=20000)
 
 
 class AgentChatRenameRequest(BaseModel):
@@ -302,9 +302,10 @@ async def stream_agent_chat(
             )
 
     headers = {
-        "Cache-Control": "no-cache",
+        "Cache-Control": "no-cache, no-transform",
         "Connection": "keep-alive",
         "X-Accel-Buffering": "no",
+        "X-Content-Type-Options": "nosniff",
         "X-Agent-Conversation-Id": turn.conversation_id,
         "X-Agent-Model": turn.model,
     }

--- a/consent-protocol/hushh_mcp/services/agent_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/agent_chat_service.py
@@ -27,8 +27,9 @@ AGENT_SYSTEM_PROMPT = """You are Agent, the Kai-focused financial assistant insi
 
 Current capability boundary:
 - Focus on markets, portfolio context, stock analysis, Kai workflows, consent/privacy surfaces, and how the Hussh app works.
-- Use the provided PKM compact context when it is relevant, especially when the user asks what Kai knows about them or shares preferences.
-- Treat PKM compact context as user-owned memory summaries, not as exhaustive truth. Do not invent personal facts outside that context and the current conversation.
+- Use the provided PKM context when it is relevant, especially when the user asks what Kai knows about them or shares preferences.
+- The PKM context may contain decrypted session-only details supplied by the frontend after vault unlock. Treat it as user-authorized memory for this turn, not as exhaustive truth. Do not invent personal facts outside that context and the current conversation.
+- If PKM context is present and the user asks to show, summarize, or reason over PKM, answer from that context. Do not claim Agent cannot access PKM.
 - When the user explicitly asks to save, remember, or add durable personal context to PKM, use the frontend PKM tool. Do not say Agent cannot save to PKM.
 - Normal finance and app questions should be answered as streaming text. Use concise GitHub-flavored Markdown with headings, lists, links, code, or tables when structure makes the answer easier to scan.
 - When the stream includes a planned frontend app action, keep the reply to a short receipt. The frontend owns the actual navigation/action state.
@@ -932,9 +933,9 @@ class AgentChatService:
             )
         clean_pkm_context = str(pkm_context or "").strip()
         planning_context = (
-            clean_pkm_context[:2000]
+            clean_pkm_context[:4000]
             if clean_pkm_context
-            else "No PKM compact context was provided for this turn."
+            else "No PKM context was provided for this turn."
         )
         contents.append(
             genai_types.Content(
@@ -942,7 +943,7 @@ class AgentChatService:
                 parts=[
                     genai_types.Part(
                         text=(
-                            "PKM compact context for routing only:\n"
+                            "PKM context for routing only:\n"
                             f"{planning_context}\n\n"
                             f"Latest user message:\n{user_message}"
                         )
@@ -977,9 +978,9 @@ class AgentChatService:
             )
         clean_pkm_context = str(pkm_context or "").strip()
         pkm_context_text = (
-            clean_pkm_context[:6000]
+            clean_pkm_context[:20000]
             if clean_pkm_context
-            else "No PKM compact context was provided for this turn."
+            else "No PKM context was provided for this turn."
         )
         return f"PKM context:\n{pkm_context_text}\n\nAction context:\n{action_context}"
 

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -27,6 +27,7 @@ import remarkGfm from "remark-gfm";
 import { Button } from "@/components/ui/button";
 import { AgentHistorySidebar } from "@/components/agent/agent-history-sidebar";
 import { AgentPkmReviewPanel } from "@/components/agent/agent-pkm-review-panel";
+import { StreamingCursor } from "@/lib/morphy-ux/streaming-cursor";
 import { useAuth } from "@/hooks/use-auth";
 import {
   executeAgentGatewayAction,
@@ -34,6 +35,7 @@ import {
 } from "@/lib/agent/agent-action-runtime";
 import {
   addToPKM,
+  clearAgentPkmContext,
   formatAgentPkmSaveSummary,
   getAutoSavePkmCards,
   getIgnoredPkmCards,
@@ -117,6 +119,7 @@ const EMPTY_PKM_CONTEXT: AgentPkmContext = {
   totalAttributes: 0,
   updatedAt: null,
 };
+const AGENT_STREAM_RENDER_FRAME_MS = 32;
 
 const EXPLICIT_PKM_SAVE_PATTERN =
   /\b(?:add|save|store|remember)\b[\s\S]{0,140}\b(?:pkm|personal knowledge|memory|memories)\b|\b(?:add|save|store|remember)\s+(?:this|that)\b/i;
@@ -228,13 +231,108 @@ function AgentMarkdown({ text }: { text: string }) {
   );
 }
 
+function useAnimatedAssistantText(targetText: string, active: boolean) {
+  const [displayedText, setDisplayedText] = useState(active ? "" : targetText);
+  const displayedTextRef = useRef(displayedText);
+  const targetTextRef = useRef(targetText);
+
+  useEffect(() => {
+    displayedTextRef.current = displayedText;
+  }, [displayedText]);
+
+  useEffect(() => {
+    targetTextRef.current = targetText;
+
+    if (!active && !targetText.startsWith(displayedTextRef.current)) {
+      displayedTextRef.current = targetText;
+      setDisplayedText(targetText);
+    }
+  }, [active, targetText]);
+
+  useEffect(() => {
+    let frame = 0;
+    let lastPaintAt = 0;
+
+    const tick = (now: number) => {
+      const target = targetTextRef.current;
+      const current = displayedTextRef.current;
+
+      if (!target.startsWith(current)) {
+        displayedTextRef.current = target;
+        setDisplayedText(target);
+        return;
+      }
+
+      if (current.length >= target.length) {
+        return;
+      }
+
+      if (lastPaintAt && now - lastPaintAt < AGENT_STREAM_RENDER_FRAME_MS) {
+        frame = window.requestAnimationFrame(tick);
+        return;
+      }
+
+      const elapsedMs = lastPaintAt ? Math.max(12, now - lastPaintAt) : AGENT_STREAM_RENDER_FRAME_MS;
+      lastPaintAt = now;
+      const backlog = target.length - current.length;
+      const charsPerSecond = backlog > 900 ? 2600 : backlog > 260 ? 1500 : 620;
+      const step = Math.max(
+        1,
+        Math.min(backlog, Math.ceil((charsPerSecond * elapsedMs) / 1000))
+      );
+      const nextText = target.slice(0, current.length + step);
+      displayedTextRef.current = nextText;
+      setDisplayedText(nextText);
+
+      if (nextText.length < target.length) {
+        frame = window.requestAnimationFrame(tick);
+      }
+    };
+
+    const target = targetTextRef.current;
+    const current = displayedTextRef.current;
+    if (target && (!target.startsWith(current) || current.length < target.length)) {
+      frame = window.requestAnimationFrame(tick);
+    }
+
+    return () => {
+      if (frame) {
+        window.cancelAnimationFrame(frame);
+      }
+    };
+  }, [active, targetText]);
+
+  return {
+    displayedText,
+    isAnimating: active || displayedText.length < targetText.length,
+  };
+}
+
+function AgentThinkingDots() {
+  return (
+    <span className="inline-flex items-center gap-1 py-1 text-muted-foreground" aria-label="Agent is thinking">
+      <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-160ms] motion-reduce:animate-none" />
+      <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-80ms] motion-reduce:animate-none" />
+      <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-current motion-reduce:animate-none" />
+    </span>
+  );
+}
+
 function AgentBubble({ message }: { message: AgentMessage }) {
   const isUser = message.role === "user";
   const isStreaming = message.status === "streaming";
   const isError = message.status === "error";
+  const animated = useAnimatedAssistantText(message.text, !isUser && isStreaming);
+  const assistantText = isUser ? message.text : animated.displayedText;
+  const showStreamingAffordance = !isUser && animated.isAnimating;
 
   return (
-    <div className={cn("flex gap-3", isUser ? "justify-end" : "justify-start")}>
+    <div
+      className={cn(
+        "flex gap-3 animate-in fade-in slide-in-from-bottom-1 duration-200 motion-reduce:animate-none",
+        isUser ? "justify-end" : "justify-start"
+      )}
+    >
       {!isUser ? (
         <div className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-primary/10 text-primary">
           <Bot className="h-4 w-4" />
@@ -242,6 +340,7 @@ function AgentBubble({ message }: { message: AgentMessage }) {
       ) : null}
       <div className={cn("max-w-[78%]", isUser && "order-first")}>
         <div
+          aria-live={!isUser && isStreaming ? "polite" : undefined}
           className={cn(
             "rounded-lg px-4 py-3 text-sm leading-6 shadow-sm",
             isUser
@@ -252,11 +351,18 @@ function AgentBubble({ message }: { message: AgentMessage }) {
         >
           {isUser ? (
             <span className="whitespace-pre-wrap break-words">{message.text}</span>
+          ) : assistantText ? (
+            <AgentMarkdown text={assistantText} />
           ) : (
-            <AgentMarkdown text={message.text} />
+            <AgentThinkingDots />
           )}
-          {isStreaming ? (
-            <span className="ml-1 inline-block h-4 w-1 animate-pulse bg-current align-middle" />
+          {showStreamingAffordance ? (
+            <StreamingCursor
+              isStreaming={isStreaming}
+              color={isError ? "error" : "primary"}
+              size="md"
+              className="ml-1"
+            />
           ) : null}
         </div>
         <p className={cn("mt-1 text-xs text-muted-foreground", isUser && "text-right")}>
@@ -439,6 +545,13 @@ export function AgentChatWorkspace({
     }
     pkmAbortControllersRef.current.clear();
   }, []);
+
+  useEffect(() => {
+    if (user?.uid && isVaultUnlocked && vaultKey) {
+      return;
+    }
+    clearAgentPkmContext(user?.uid);
+  }, [isVaultUnlocked, user?.uid, vaultKey]);
   const routeQuery = searchParams?.toString() || "";
   const pathnameWithQuery = routeQuery ? `${pathname || ""}?${routeQuery}` : pathname || "";
   const routeInfo = useMemo(
@@ -1003,6 +1116,7 @@ export function AgentChatWorkspace({
           void loadAgentPkmContext({
             userId: user.uid,
             vaultOwnerToken: token,
+            vaultKey,
             forceRefresh: true,
           }).catch(() => undefined);
           toast.success("Saved to PKM.");
@@ -1075,6 +1189,36 @@ export function AgentChatWorkspace({
     let assistantHasToken = false;
     let turnPkmContext = EMPTY_PKM_CONTEXT;
     let pkmAddToolHandled = false;
+    let pendingAssistantDelta = "";
+    let assistantFlushFrame: number | null = null;
+
+    const flushAssistantDelta = () => {
+      assistantFlushFrame = null;
+      const delta = pendingAssistantDelta;
+      pendingAssistantDelta = "";
+      if (!delta) return;
+      assistantHasToken = true;
+      updateMessage(assistantMessageId, (message) => ({
+        ...message,
+        text: message.ephemeral ? delta : `${message.text}${delta}`,
+        status: "streaming",
+        ephemeral: false,
+      }));
+    };
+
+    const queueAssistantDelta = (delta: string) => {
+      pendingAssistantDelta += delta;
+      if (assistantFlushFrame !== null) return;
+      assistantFlushFrame = window.requestAnimationFrame(flushAssistantDelta);
+    };
+
+    const cancelAssistantFlush = () => {
+      if (assistantFlushFrame !== null) {
+        window.cancelAnimationFrame(assistantFlushFrame);
+        assistantFlushFrame = null;
+      }
+      pendingAssistantDelta = "";
+    };
 
     const upsertToolStatusMessage = (
       messageText: string,
@@ -1235,6 +1379,7 @@ export function AgentChatWorkspace({
             void loadAgentPkmContext({
               userId,
               vaultOwnerToken: token,
+              vaultKey,
               forceRefresh: true,
             }).catch(() => undefined);
             toast.success("Saved to PKM.");
@@ -1401,6 +1546,7 @@ export function AgentChatWorkspace({
             void loadAgentPkmContext({
               userId,
               vaultOwnerToken: token,
+              vaultKey,
               forceRefresh: true,
             }).catch(() => undefined);
           }
@@ -1492,6 +1638,8 @@ export function AgentChatWorkspace({
         agentPkmContext = await loadAgentPkmContext({
           userId,
           vaultOwnerToken: token,
+          vaultKey,
+          message: text,
         });
         turnPkmContext = agentPkmContext;
         if (streamAbortController.signal.aborted) return;
@@ -1499,6 +1647,9 @@ export function AgentChatWorkspace({
           appendDebugEvent(debugTurnId, "pkm_context_loaded", {
             domain_count: agentPkmContext.domains.length,
             total_attributes: agentPkmContext.totalAttributes,
+            detail_count: agentPkmContext.detailCount || 0,
+            source: agentPkmContext.source || "metadata",
+            mode: agentPkmContext.mode || "summary",
             updated_at: agentPkmContext.updatedAt,
           });
         }
@@ -1550,16 +1701,11 @@ export function AgentChatWorkspace({
           },
           onToken: (delta) => {
             if (streamAbortController.signal.aborted) return;
-            assistantHasToken = true;
-            updateMessage(assistantMessageId, (message) => ({
-              ...message,
-              text: message.ephemeral ? delta : `${message.text}${delta}`,
-              status: "streaming",
-              ephemeral: false,
-            }));
+            queueAssistantDelta(delta);
           },
           onComplete: ({ conversationId: nextConversationId }) => {
             if (streamAbortController.signal.aborted) return;
+            flushAssistantDelta();
             if (nextConversationId) {
               setConversationId(nextConversationId);
             }
@@ -1572,6 +1718,7 @@ export function AgentChatWorkspace({
           },
           onError: (message) => {
             if (streamAbortController.signal.aborted) return;
+            flushAssistantDelta();
             updateMessage(assistantMessageId, (current) => ({
               ...current,
               text: current.text || message,
@@ -1583,6 +1730,7 @@ export function AgentChatWorkspace({
         },
       });
       if (streamAbortController.signal.aborted) return;
+      flushAssistantDelta();
       updateMessage(assistantMessageId, (message) => {
         if (message.status === "error") return message;
         return {
@@ -1603,6 +1751,7 @@ export function AgentChatWorkspace({
       setIsStreaming(false);
     } catch (error) {
       if (streamAbortController.signal.aborted) return;
+      flushAssistantDelta();
       const message =
         error instanceof Error && error.message
           ? error.message
@@ -1616,6 +1765,7 @@ export function AgentChatWorkspace({
       setIsChatLoading(false);
       setIsStreaming(false);
     } finally {
+      cancelAssistantFlush();
       if (streamAbortControllerRef.current === streamAbortController) {
         streamAbortControllerRef.current = null;
       }

--- a/hushh-webapp/components/agent/agent-popover-provider.tsx
+++ b/hushh-webapp/components/agent/agent-popover-provider.tsx
@@ -4,7 +4,9 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from "react";
@@ -20,9 +22,14 @@ import { cn } from "@/lib/utils";
 type AgentPopoverContextValue = {
   expanded: boolean;
   hasOpened: boolean;
+  motionState: AgentPopoverMotionState;
   openAgent: () => void;
   minimizeAgent: () => void;
 };
+
+type AgentPopoverMotionState = "idle" | "opening" | "closing";
+
+const AGENT_POPOVER_TRANSITION_MS = 360;
 
 const AgentPopoverContext = createContext<AgentPopoverContextValue | null>(null);
 
@@ -41,24 +48,63 @@ export function useOptionalAgentPopover() {
 export function AgentPopoverProvider({ children }: { children: ReactNode }) {
   const [expanded, setExpanded] = useState(false);
   const [hasOpened, setHasOpened] = useState(false);
+  const [motionState, setMotionState] =
+    useState<AgentPopoverMotionState>("idle");
+  const animationFrameRef = useRef<number | null>(null);
+  const motionTimerRef = useRef<number | null>(null);
+
+  const clearMotionHandles = useCallback(() => {
+    if (animationFrameRef.current !== null) {
+      window.cancelAnimationFrame(animationFrameRef.current);
+      animationFrameRef.current = null;
+    }
+
+    if (motionTimerRef.current !== null) {
+      window.clearTimeout(motionTimerRef.current);
+      motionTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => clearMotionHandles, [clearMotionHandles]);
 
   const openAgent = useCallback(() => {
+    if (expanded && motionState !== "closing") return;
+
+    clearMotionHandles();
     setHasOpened(true);
-    setExpanded(true);
-  }, []);
+    setMotionState("opening");
+
+    animationFrameRef.current = window.requestAnimationFrame(() => {
+      animationFrameRef.current = null;
+      setExpanded(true);
+      motionTimerRef.current = window.setTimeout(() => {
+        motionTimerRef.current = null;
+        setMotionState("idle");
+      }, AGENT_POPOVER_TRANSITION_MS);
+    });
+  }, [clearMotionHandles, expanded, motionState]);
 
   const minimizeAgent = useCallback(() => {
+    if (!expanded && motionState !== "opening") return;
+
+    clearMotionHandles();
+    setMotionState("closing");
     setExpanded(false);
-  }, []);
+    motionTimerRef.current = window.setTimeout(() => {
+      motionTimerRef.current = null;
+      setMotionState("idle");
+    }, AGENT_POPOVER_TRANSITION_MS);
+  }, [clearMotionHandles, expanded, motionState]);
 
   const value = useMemo<AgentPopoverContextValue>(
     () => ({
       expanded,
       hasOpened,
+      motionState,
       openAgent,
       minimizeAgent,
     }),
-    [expanded, hasOpened, minimizeAgent, openAgent]
+    [expanded, hasOpened, minimizeAgent, motionState, openAgent]
   );
 
   return (
@@ -72,9 +118,12 @@ export function AgentPopoverProvider({ children }: { children: ReactNode }) {
 function AgentPopoverSurface() {
   const { isAuthenticated } = useAuth();
   const pathname = usePathname();
-  const { expanded, hasOpened, openAgent, minimizeAgent } = useAgentPopover();
+  const { expanded, hasOpened, motionState, openAgent, minimizeAgent } =
+    useAgentPopover();
   const isLegacyAgentRoute = pathname === ROUTES.AGENT;
   const canShowAgent = isAuthenticated && !isLegacyAgentRoute;
+  const isCollapsing = motionState === "closing";
+  const surfaceVisible = expanded || motionState !== "idle";
 
   const handleNavigationActionComplete = useCallback(() => {
     window.setTimeout(() => {
@@ -91,17 +140,18 @@ function AgentPopoverSurface() {
       {hasOpened ? (
         <div
           className={cn(
-            "pointer-events-none fixed inset-0 z-[460] transition-opacity duration-200",
-            expanded ? "opacity-100" : "opacity-0"
+            "pointer-events-none fixed inset-0 z-[460] transition-opacity duration-300 motion-reduce:transition-none",
+            surfaceVisible ? "opacity-100" : "opacity-0"
           )}
           aria-hidden={!expanded}
         >
           <section
             className={cn(
-              "pointer-events-auto fixed bottom-[calc(max(var(--app-safe-area-bottom-effective),0.5rem)+0.5rem)] left-2 right-2 top-[calc(max(var(--app-safe-area-top-effective),0.5rem)+0.5rem)] flex min-h-0 flex-col overflow-hidden rounded-lg border border-border/70 bg-background/95 shadow-2xl backdrop-blur-xl transition-[opacity,transform] duration-200 sm:left-4 sm:right-4 lg:left-auto lg:right-4 lg:w-[min(72rem,calc(100vw-2rem))]",
+              "pointer-events-auto fixed bottom-[calc(max(var(--app-safe-area-bottom-effective),0.5rem)+0.5rem)] left-2 right-2 top-[calc(max(var(--app-safe-area-top-effective),0.5rem)+0.5rem)] flex min-h-0 origin-bottom-right flex-col overflow-hidden rounded-lg border border-border/70 bg-background/95 shadow-2xl backdrop-blur-xl transition-[border-radius,filter,opacity,transform] duration-[360ms] ease-[cubic-bezier(0.22,1,0.36,1)] will-change-transform motion-reduce:transform-none motion-reduce:transition-none sm:left-4 sm:right-4 lg:left-auto lg:right-4 lg:w-[min(72rem,calc(100vw-2rem))]",
               expanded
-                ? "translate-y-0 scale-100 opacity-100"
-                : "pointer-events-none translate-y-6 scale-[0.98] opacity-0"
+                ? "translate-x-0 translate-y-0 scale-100 opacity-100 blur-0"
+                : "pointer-events-none translate-x-3 translate-y-[calc(100%-5.75rem)] scale-[0.2] opacity-0 blur-sm",
+              isCollapsing && "rounded-2xl ring-1 ring-primary/25"
             )}
             role="dialog"
             aria-label="Agent"
@@ -127,10 +177,11 @@ function AgentPopoverSurface() {
         type="button"
         variant="secondary"
         className={cn(
-          "fixed right-4 z-[130] h-11 gap-2 rounded-full border border-border/70 bg-background/90 px-4 shadow-lg backdrop-blur-md transition-[opacity,transform] duration-200",
-          expanded
-            ? "pointer-events-none translate-y-2 opacity-0"
-            : "translate-y-0 opacity-100"
+          "fixed right-4 z-[130] h-11 gap-2 rounded-full border border-border/70 bg-background/90 px-4 shadow-lg backdrop-blur-md transition-[box-shadow,opacity,transform] duration-300 ease-out motion-reduce:transform-none motion-reduce:transition-none",
+          expanded && !isCollapsing
+            ? "pointer-events-none translate-y-3 scale-95 opacity-0"
+            : "translate-y-0 scale-100 opacity-100",
+          isCollapsing && "ring-1 ring-primary/30 shadow-primary/20"
         )}
         style={{
           bottom:

--- a/hushh-webapp/lib/agent/agent-pkm-context-store.ts
+++ b/hushh-webapp/lib/agent/agent-pkm-context-store.ts
@@ -1,0 +1,320 @@
+"use client";
+
+import {
+  PersonalKnowledgeModelService,
+  type PersonalKnowledgeModelMetadata,
+} from "@/lib/services/personal-knowledge-model-service";
+
+type AgentPkmWorkingSet = {
+  userId: string;
+  metadata: PersonalKnowledgeModelMetadata | null;
+  fullBlob: Record<string, unknown>;
+  loadedAt: number;
+  metadataUpdatedAt: string | null;
+};
+
+export type AgentPkmWorkingContextMode = "relevant" | "broad";
+
+export type AgentPkmWorkingContext = {
+  text: string;
+  domains: string[];
+  totalAttributes: number;
+  updatedAt: string | null;
+  detailCount: number;
+  source: "decrypted_session_pkm";
+  mode: AgentPkmWorkingContextMode;
+};
+
+const SESSION_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_MAX_CONTEXT_CHARS = 16000;
+const MAX_DETAIL_LINES = 180;
+const MAX_VALUE_CHARS = 260;
+const MAX_ARRAY_ITEMS = 8;
+const MAX_DEPTH = 5;
+
+const workingSets = new Map<string, AgentPkmWorkingSet>();
+
+function compactWhitespace(value: unknown): string {
+  return String(value ?? "").replace(/\s+/g, " ").trim();
+}
+
+function clip(value: unknown, maxChars = MAX_VALUE_CHARS): string {
+  const text = compactWhitespace(value);
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, Math.max(0, maxChars - 1)).trimEnd()}...`;
+}
+
+function titleize(value: string): string {
+  return value
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (match) => match.toUpperCase())
+    .trim();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function tokenize(value: string): Set<string> {
+  const tokens = value
+    .toLowerCase()
+    .split(/[^a-z0-9$.\-]+/g)
+    .map((token) => token.trim())
+    .filter((token) => token.length >= 3);
+  return new Set(tokens);
+}
+
+function containsAny(text: string, patterns: RegExp[]): boolean {
+  return patterns.some((pattern) => pattern.test(text));
+}
+
+function shouldUseBroadContext(message: string): boolean {
+  const text = message.toLowerCase();
+  return containsAny(text, [
+    /\b(?:show|summari[sz]e|explain|list|display|read)\b.*\b(?:all|everything|entire|full)\b.*\b(?:pkm|personal knowledge|memory|memories|what kai knows)\b/,
+    /\b(?:what|which)\b.*\b(?:is|are|stuff|details|data|information)\b.*\b(?:in|inside)\b.*\b(?:my )?(?:pkm|personal knowledge|memory|memories)\b/,
+    /\b(?:can you|could you)?\s*(?:see|access|read|summari[sz]e|explain)\b.*\b(?:my )?(?:pkm|personal knowledge|memory|memories)\b/,
+    /\bwhat\b.*\b(?:kai|agent|you)\b.*\bknow\b.*\b(?:about me|from my pkm)\b/,
+  ]);
+}
+
+function formatPrimitive(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string") return clip(value);
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return null;
+}
+
+function primitiveArraySummary(values: unknown[]): string | null {
+  const primitives = values
+    .map(formatPrimitive)
+    .filter((value): value is string => Boolean(value))
+    .slice(0, MAX_ARRAY_ITEMS);
+  if (primitives.length === 0) return null;
+  const suffix = values.length > primitives.length ? `, +${values.length - primitives.length} more` : "";
+  return clip(`${primitives.join(", ")}${suffix}`);
+}
+
+type FlattenedPkmLine = {
+  domain: string;
+  path: string;
+  value: string;
+  text: string;
+  score: number;
+};
+
+function flattenDomain(
+  domain: string,
+  value: unknown,
+  promptTokens: Set<string>,
+  path = domain,
+  depth = 0,
+  lines: FlattenedPkmLine[] = []
+): FlattenedPkmLine[] {
+  if (lines.length >= MAX_DETAIL_LINES * 2 || depth > MAX_DEPTH) {
+    return lines;
+  }
+
+  const primitive = formatPrimitive(value);
+  if (primitive) {
+    const text = `${path}: ${primitive}`;
+    lines.push({
+      domain,
+      path,
+      value: primitive,
+      text,
+      score: scoreLine(domain, path, primitive, promptTokens),
+    });
+    return lines;
+  }
+
+  if (Array.isArray(value)) {
+    const summary = primitiveArraySummary(value);
+    if (summary) {
+      const text = `${path}: ${summary}`;
+      lines.push({
+        domain,
+        path,
+        value: summary,
+        text,
+        score: scoreLine(domain, path, summary, promptTokens),
+      });
+      return lines;
+    }
+    value.slice(0, MAX_ARRAY_ITEMS).forEach((item, index) => {
+      flattenDomain(domain, item, promptTokens, `${path}[${index}]`, depth + 1, lines);
+    });
+    return lines;
+  }
+
+  if (!isRecord(value)) {
+    return lines;
+  }
+
+  for (const [key, child] of Object.entries(value)) {
+    if (lines.length >= MAX_DETAIL_LINES * 2) break;
+    flattenDomain(domain, child, promptTokens, path ? `${path}.${key}` : key, depth + 1, lines);
+  }
+  return lines;
+}
+
+function scoreLine(
+  domain: string,
+  path: string,
+  value: string,
+  promptTokens: Set<string>
+): number {
+  if (promptTokens.size === 0) return 0;
+  const haystack = tokenize(`${domain} ${path} ${value}`);
+  let score = 0;
+  for (const token of promptTokens) {
+    if (haystack.has(token)) score += 4;
+    if (path.toLowerCase().includes(token)) score += 3;
+    if (domain.toLowerCase().includes(token)) score += 2;
+  }
+  return score;
+}
+
+function domainSummaryLines(metadata: PersonalKnowledgeModelMetadata | null): string[] {
+  if (!metadata?.domains?.length) return [];
+  return metadata.domains
+    .filter((domain) => domain.attributeCount > 0 || domain.readableSummary)
+    .map((domain) => {
+      const summary =
+        clip(domain.readableSummary, 220) ||
+        clip(domain.summary?.readable_summary, 220) ||
+        `${domain.attributeCount || 0} saved details`;
+      const highlights = Array.isArray(domain.readableHighlights)
+        ? domain.readableHighlights.map((item) => clip(item, 100)).filter(Boolean).slice(0, 3)
+        : [];
+      return [
+        `- ${domain.displayName || titleize(domain.key)} (${domain.key})`,
+        summary ? `summary: ${summary}` : null,
+        highlights.length > 0 ? `highlights: ${highlights.join("; ")}` : null,
+        domain.lastUpdated ? `updated: ${domain.lastUpdated}` : null,
+      ]
+        .filter(Boolean)
+        .join(" | ");
+    });
+}
+
+function buildContextText(params: {
+  workingSet: AgentPkmWorkingSet;
+  message: string;
+  maxChars: number;
+}): AgentPkmWorkingContext {
+  const { workingSet } = params;
+  const maxChars = Math.max(2000, params.maxChars || DEFAULT_MAX_CONTEXT_CHARS);
+  const mode: AgentPkmWorkingContextMode = shouldUseBroadContext(params.message)
+    ? "broad"
+    : "relevant";
+  const promptTokens = tokenize(params.message);
+  const domainKeys = Array.from(
+    new Set([
+      ...(workingSet.metadata?.domains.map((domain) => domain.key).filter(Boolean) || []),
+      ...Object.keys(workingSet.fullBlob || {}),
+    ])
+  );
+
+  const allLines = domainKeys.flatMap((domain) =>
+    flattenDomain(domain, (workingSet.fullBlob || {})[domain], promptTokens)
+  );
+  const selectedLines =
+    mode === "broad"
+      ? allLines.slice(0, MAX_DETAIL_LINES)
+      : allLines
+          .filter((line) => line.score > 0)
+          .sort((a, b) => b.score - a.score || a.path.length - b.path.length)
+          .slice(0, MAX_DETAIL_LINES);
+  const detailLines = selectedLines.length > 0 ? selectedLines : allLines.slice(0, 40);
+
+  const lines = [
+    "Agent PKM context:",
+    "Source: decrypted client-side from the user's unlocked vault for this session.",
+    "Boundary: use this as user-authorized memory for this turn; do not claim PKM is inaccessible when relevant details are present.",
+    "Do not mention internal paths unless the user asks for raw structure.",
+    `Mode: ${mode}`,
+    `Total saved details: ${workingSet.metadata?.totalAttributes || 0}`,
+    `Domains available: ${domainKeys.length > 0 ? domainKeys.join(", ") : "none"}`,
+    workingSet.metadataUpdatedAt ? `Updated at: ${workingSet.metadataUpdatedAt}` : null,
+    "",
+    "Domain summaries:",
+    ...domainSummaryLines(workingSet.metadata).slice(0, 12),
+    "",
+    detailLines.length > 0 ? "Decrypted PKM details:" : "Decrypted PKM details: none available.",
+    ...detailLines.map((line) => `- ${line.text}`),
+  ].filter((line): line is string => line !== null);
+
+  let text = lines.join("\n");
+  if (text.length > maxChars) {
+    text = `${text.slice(0, maxChars - 80).trimEnd()}\n\n[PKM context clipped to the current prompt budget.]`;
+  }
+
+  return {
+    text,
+    domains: domainKeys,
+    totalAttributes: workingSet.metadata?.totalAttributes || detailLines.length,
+    updatedAt: workingSet.metadataUpdatedAt,
+    detailCount: detailLines.length,
+    source: "decrypted_session_pkm",
+    mode,
+  };
+}
+
+export class AgentPkmContextStore {
+  static clear(userId?: string): void {
+    if (userId) {
+      workingSets.delete(userId);
+      return;
+    }
+    workingSets.clear();
+  }
+
+  static invalidateUser(userId: string): void {
+    workingSets.delete(userId);
+  }
+
+  static async load(params: {
+    userId: string;
+    vaultKey: string;
+    vaultOwnerToken: string;
+    message?: string;
+    forceRefresh?: boolean;
+    maxChars?: number;
+  }): Promise<AgentPkmWorkingContext> {
+    const metadata = await PersonalKnowledgeModelService.getMetadata(
+      params.userId,
+      params.forceRefresh === true,
+      params.vaultOwnerToken
+    );
+    const cached = workingSets.get(params.userId);
+    const metadataUpdatedAt = metadata.lastUpdated || null;
+    const cacheFresh =
+      cached &&
+      Date.now() - cached.loadedAt < SESSION_TTL_MS &&
+      cached.metadataUpdatedAt === metadataUpdatedAt;
+
+    const workingSet =
+      !params.forceRefresh && cacheFresh
+        ? cached
+        : {
+            userId: params.userId,
+            metadata,
+            fullBlob: await PersonalKnowledgeModelService.loadFullBlob({
+              userId: params.userId,
+              vaultKey: params.vaultKey,
+              vaultOwnerToken: params.vaultOwnerToken,
+            }),
+            loadedAt: Date.now(),
+            metadataUpdatedAt,
+          };
+
+    workingSets.set(params.userId, workingSet);
+
+    return buildContextText({
+      workingSet,
+      message: params.message || "",
+      maxChars: params.maxChars || DEFAULT_MAX_CONTEXT_CHARS,
+    });
+  }
+}

--- a/hushh-webapp/lib/agent/agent-pkm-memory.ts
+++ b/hushh-webapp/lib/agent/agent-pkm-memory.ts
@@ -11,6 +11,7 @@ import {
   PkmWriteCoordinator,
   type PkmWriteCoordinatorResult,
 } from "@/lib/services/pkm-write-coordinator";
+import { AgentPkmContextStore } from "@/lib/agent/agent-pkm-context-store";
 
 export type AgentPkmDomainChoice = {
   domain_key: string;
@@ -77,6 +78,9 @@ export type AgentPkmContext = {
   domains: string[];
   totalAttributes: number;
   updatedAt: string | null;
+  detailCount?: number;
+  source?: "metadata" | "decrypted_session_pkm";
+  mode?: "summary" | "relevant" | "broad";
 };
 
 export type AgentPkmSaveResult = {
@@ -313,6 +317,9 @@ export async function addToPKM(params: {
   }
 
   const savedResults = results.filter((result) => result.success);
+  if (savedResults.length > 0) {
+    AgentPkmContextStore.invalidateUser(params.userId);
+  }
   return {
     attempted: results.length,
     saved: savedResults.length,
@@ -389,14 +396,39 @@ export function buildAgentPkmContextFromMetadata(
 export async function loadAgentPkmContext(params: {
   userId: string;
   vaultOwnerToken: string;
+  vaultKey?: string | null;
+  message?: string;
   forceRefresh?: boolean;
+  maxChars?: number;
 }): Promise<AgentPkmContext> {
+  if (params.vaultKey) {
+    try {
+      return await AgentPkmContextStore.load({
+        userId: params.userId,
+        vaultKey: params.vaultKey,
+        vaultOwnerToken: params.vaultOwnerToken,
+        message: params.message,
+        forceRefresh: params.forceRefresh,
+        maxChars: params.maxChars,
+      });
+    } catch {
+      AgentPkmContextStore.invalidateUser(params.userId);
+    }
+  }
   const metadata = await PersonalKnowledgeModelService.getMetadata(
     params.userId,
     params.forceRefresh === true,
     params.vaultOwnerToken
   );
-  return buildAgentPkmContextFromMetadata(metadata);
+  return {
+    ...buildAgentPkmContextFromMetadata(metadata),
+    source: "metadata",
+    mode: "summary",
+  };
+}
+
+export function clearAgentPkmContext(userId?: string): void {
+  AgentPkmContextStore.clear(userId);
 }
 
 export function formatAgentPkmSaveSummary(result: AgentPkmSaveResult): string {


### PR DESCRIPTION
## Summary

- Adds a session-memory PKM context store so Agent chat can use decrypted PKM context while the vault is unlocked without repeatedly rebuilding the full context.
- Updates Agent chat streaming/PKM handling so relevant PKM context is loaded per prompt, refreshed after saves, and included with clearer backend prompt guidance.
- Improves the Agent popover minimize UX with an opening/closing motion state and a smooth collapse animation into the Agent chip.

## Validation

- `cd hushh-webapp && npm run typecheck`
- `cd hushh-webapp && npm run verify:design-system`
- `cd hushh-webapp && npm run verify:cache`
- `cd hushh-webapp && npm run verify:docs`
- `cd hushh-webapp && npx eslint components/agent/agent-chat-workspace.tsx components/agent/agent-popover-provider.tsx --max-warnings=0`
- `cd consent-protocol && .venv/bin/python -m pytest tests/test_agent_chat_routes.py tests/services/test_agent_chat_service.py -q`
- `git diff --check`
- `python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py`

## Notes

- Local `npm run verify:routes` remains blocked by missing maintainer-only reviewer env (`REVIEWER_UID`, `REVIEWER_VAULT_PASSPHRASE`), so it was not used as a PR gate here.
- The unrelated untracked backup archive in the local workspace was intentionally excluded from this PR.
