### PR TITLE
Add One Location public request links

### DIFF
--- a/consent-protocol/api/routes/one/location.py
+++ b/consent-protocol/api/routes/one/location.py
@@ -1,7 +1,7 @@
 """One Location Agent routes.
 
-The route contract is intentionally authenticated and ciphertext-only. Public
-bearer links and server-readable latitude/longitude do not belong here.
+Live-location reads are authenticated and ciphertext-only. Public invite routes
+are request-only and never return coordinates, ciphertext, or grants.
 """
 
 from __future__ import annotations
@@ -58,6 +58,16 @@ class ReferralRequest(_CamelModel):
     message: str | None = Field(default=None, max_length=500)
 
 
+class CreatePublicInviteRequest(_CamelModel):
+    duration_hours: float = Field(default=1, alias="durationHours", gt=0, le=24)
+
+
+class SubmitPublicInviteRequest(_CamelModel):
+    visitor_display_name: str = Field(alias="visitorDisplayName", min_length=2, max_length=120)
+    phone_number: str = Field(alias="phoneNumber", min_length=8, max_length=32)
+    message: str | None = Field(default=None, max_length=500)
+
+
 def _service() -> OneLocationAgentService:
     return OneLocationAgentService()
 
@@ -92,6 +102,60 @@ async def list_verified_location_recipients(
     try:
         return {
             "recipients": _service().list_verified_recipients(owner_user_id=_user_id(token_data))
+        }
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+
+
+@router.post("/location/public-invites")
+async def create_public_location_invite(
+    payload: CreatePublicInviteRequest,
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    try:
+        return _service().create_public_invite(
+            owner_user_id=_user_id(token_data),
+            duration_hours=payload.duration_hours,
+        )
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+
+
+@router.get("/location/public-invites/{public_token}")
+async def resolve_public_location_invite(public_token: str):
+    try:
+        return _service().resolve_public_invite(public_token=public_token)
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+
+
+@router.post("/location/public-invites/{public_token}/submit")
+async def submit_public_location_invite(
+    public_token: str,
+    payload: SubmitPublicInviteRequest,
+):
+    try:
+        return _service().submit_public_invite_request(
+            public_token=public_token,
+            visitor_display_name=payload.visitor_display_name,
+            phone_number=payload.phone_number,
+            message=payload.message,
+        )
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+
+
+@router.delete("/location/public-invites/{invite_id}")
+async def revoke_public_location_invite(
+    invite_id: str,
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    try:
+        return {
+            "invite": _service().revoke_public_invite(
+                owner_user_id=_user_id(token_data),
+                invite_id=invite_id,
+            )
         }
     except Exception as exc:
         raise _handle_error(exc) from exc

--- a/consent-protocol/api/routes/one/location.py
+++ b/consent-protocol/api/routes/one/location.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, ConfigDict, Field
 
 from api.middleware import require_vault_owner_token
@@ -76,6 +76,16 @@ def _user_id(token_data: dict[str, Any]) -> str:
     return str(token_data.get("user_id") or "").strip()
 
 
+def _request_fingerprint_hash(request: Request) -> str | None:
+    from hushh_mcp.services.one_location_agent_service import _hash_public_value
+
+    forwarded_for = str(request.headers.get("x-forwarded-for") or "").split(",")[0].strip()
+    client_host = forwarded_for or (request.client.host if request.client else "")
+    user_agent = str(request.headers.get("user-agent") or "")[:160]
+    fingerprint_source = "|".join(item for item in (client_host, user_agent) if item)
+    return _hash_public_value(fingerprint_source) if fingerprint_source else None
+
+
 def _handle_error(exc: Exception) -> HTTPException:
     if isinstance(exc, OneLocationAgentError):
         return HTTPException(status_code=exc.status_code, detail=location_error_detail(exc))
@@ -133,6 +143,7 @@ async def resolve_public_location_invite(public_token: str):
 async def submit_public_location_invite(
     public_token: str,
     payload: SubmitPublicInviteRequest,
+    request: Request,
 ):
     try:
         return _service().submit_public_invite_request(
@@ -140,6 +151,7 @@ async def submit_public_location_invite(
             visitor_display_name=payload.visitor_display_name,
             phone_number=payload.phone_number,
             message=payload.message,
+            submitter_fingerprint_hash=_request_fingerprint_hash(request),
         )
     except Exception as exc:
         raise _handle_error(exc) from exc

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 63,
+  "expected_migration_version": 64,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/db/migrations/064_one_location_public_invites.sql
+++ b/consent-protocol/db/migrations/064_one_location_public_invites.sql
@@ -1,0 +1,86 @@
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS one_location_public_invites (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  owner_user_id TEXT NOT NULL,
+  public_code_hash TEXT NOT NULL UNIQUE,
+  status TEXT NOT NULL DEFAULT 'active'
+    CHECK (status IN ('active', 'expired', 'revoked')),
+  duration_hours NUMERIC(6, 2) NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  revoked_at TIMESTAMPTZ,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  CONSTRAINT one_location_public_invites_duration_bounds
+    CHECK (duration_hours > 0 AND duration_hours <= 24)
+);
+
+CREATE TABLE IF NOT EXISTS one_location_public_invite_submissions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  invite_id UUID NOT NULL REFERENCES one_location_public_invites(id) ON DELETE CASCADE,
+  owner_user_id TEXT NOT NULL,
+  visitor_display_name TEXT NOT NULL,
+  visitor_phone_hash TEXT NOT NULL,
+  visitor_phone_last4 TEXT,
+  matched_user_id TEXT,
+  request_id UUID REFERENCES one_location_access_requests(id) ON DELETE SET NULL,
+  status TEXT NOT NULL DEFAULT 'pending_identity'
+    CHECK (
+      status IN (
+        'pending_identity',
+        'identity_pending_key',
+        'matched_request_pending',
+        'approved',
+        'denied',
+        'cancelled'
+      )
+    ),
+  message TEXT,
+  submitted_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  resolved_at TIMESTAMPTZ,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_one_location_public_invites_owner_status_expiry
+  ON one_location_public_invites (owner_user_id, status, expires_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_one_location_public_invites_hash
+  ON one_location_public_invites (public_code_hash);
+
+CREATE INDEX IF NOT EXISTS idx_one_location_public_invite_submissions_owner_status
+  ON one_location_public_invite_submissions (owner_user_id, status, submitted_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_one_location_public_invite_submissions_invite
+  ON one_location_public_invite_submissions (invite_id, submitted_at DESC);
+
+ALTER TABLE one_location_events
+  DROP CONSTRAINT IF EXISTS one_location_events_event_type_check;
+
+ALTER TABLE one_location_events
+  ADD CONSTRAINT one_location_events_event_type_check CHECK (
+    event_type IN (
+      'location_recipient_key_registered',
+      'location_share_created',
+      'location_envelope_updated',
+      'location_share_viewed',
+      'location_share_revoked',
+      'location_share_expired',
+      'location_access_request',
+      'location_access_approved',
+      'location_access_denied',
+      'location_referral_invite',
+      'location_public_invite_created',
+      'location_public_invite_revoked',
+      'location_public_invite_submitted'
+    )
+  );
+
+COMMENT ON TABLE one_location_public_invites IS
+  'Shareable public request links for One Location Agent. Tokens are hash-only and never grant location access.';
+COMMENT ON TABLE one_location_public_invite_submissions IS
+  'Metadata-only public request submissions. Public viewers never receive coordinates or encrypted envelopes from this path.';
+
+COMMIT;

--- a/consent-protocol/db/migrations/064_one_location_public_invites.sql
+++ b/consent-protocol/db/migrations/064_one_location_public_invites.sql
@@ -56,6 +56,16 @@ CREATE INDEX IF NOT EXISTS idx_one_location_public_invite_submissions_owner_stat
 CREATE INDEX IF NOT EXISTS idx_one_location_public_invite_submissions_invite
   ON one_location_public_invite_submissions (invite_id, submitted_at DESC);
 
+CREATE UNIQUE INDEX IF NOT EXISTS idx_one_location_public_invite_submissions_phone_once
+  ON one_location_public_invite_submissions (invite_id, visitor_phone_hash);
+
+CREATE INDEX IF NOT EXISTS idx_one_location_public_invite_submissions_fingerprint_window
+  ON one_location_public_invite_submissions (
+    invite_id,
+    (metadata->>'submitter_fingerprint_hash'),
+    submitted_at DESC
+  );
+
 ALTER TABLE one_location_events
   DROP CONSTRAINT IF EXISTS one_location_events_event_type_check;
 

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -40,7 +40,8 @@
     "060_kai_location_sharing.sql",
     "061_one_location_agent.sql",
     "062_consent_exports_export_key_guard.sql",
-    "063_pkm_default_available_visibility.sql"
+    "063_pkm_default_available_visibility.sql",
+    "064_one_location_public_invites.sql"
   ],
   "groups": {
     "iam": [
@@ -67,7 +68,8 @@
       "058_marketplace_investor_actions.sql",
       "059_marketplace_investor_replenisher_runs.sql",
       "060_kai_location_sharing.sql",
-      "061_one_location_agent.sql"
+      "061_one_location_agent.sql",
+      "064_one_location_public_invites.sql"
     ],
     "pkm": [
       "030_pkm_cutover.sql",

--- a/consent-protocol/hushh_mcp/services/account_service.py
+++ b/consent-protocol/hushh_mcp/services/account_service.py
@@ -134,6 +134,16 @@ class AccountService:
                    OR recipient_user_id = :user_id
                 """
             ),
+            "one_location_public_invite_submissions": text(
+                """
+                DELETE FROM one_location_public_invite_submissions
+                WHERE owner_user_id = :user_id
+                   OR matched_user_id = :user_id
+                """
+            ),
+            "one_location_public_invites": text(
+                "DELETE FROM one_location_public_invites WHERE owner_user_id = :user_id"
+            ),
             "one_location_recipient_keys": text(
                 "DELETE FROM one_location_recipient_keys WHERE user_id = :user_id"
             ),
@@ -429,6 +439,8 @@ class AccountService:
             "one_location_referrals": False,
             "one_location_access_requests": False,
             "one_location_envelopes": False,
+            "one_location_public_invite_submissions": False,
+            "one_location_public_invites": False,
             "one_location_share_grants": False,
             "one_location_recipient_keys": False,
             "runtime_persona_state": False,
@@ -621,6 +633,8 @@ class AccountService:
                 for table_name in (
                     "one_location_events",
                     "one_location_referrals",
+                    "one_location_public_invite_submissions",
+                    "one_location_public_invites",
                     "one_location_access_requests",
                     "one_location_envelopes",
                     "one_location_share_grants",

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import logging
 import os
+import secrets
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -168,6 +169,29 @@ def _mask_phone(value: Any) -> str | None:
     if len(digits) <= 4:
         return f"***{digits}"
     return f"{'*' * max(3, len(digits) - 4)}{digits[-4:]}"
+
+
+def _normalize_phone_digits(value: Any) -> str:
+    return "".join(ch for ch in str(value or "") if ch.isdigit())
+
+
+def _hash_public_value(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _public_invite_url(token: str) -> str:
+    base = (
+        (
+            os.getenv("NEXT_PUBLIC_APP_URL")
+            or os.getenv("APP_PUBLIC_URL")
+            or os.getenv("FRONTEND_BASE_URL")
+            or ""
+        )
+        .strip()
+        .rstrip("/")
+    )
+    path = f"/location/request/{token}"
+    return f"{base}{path}" if base else path
 
 
 def _identity_display_label(row: dict[str, Any] | None, fallback: str = "A trusted person") -> str:
@@ -365,6 +389,34 @@ class OneLocationAgentService:
             logger.debug("one.location.identity_lookup_failed user=%s error=%s", user_id, exc)
             return None
 
+    def _identity_row_by_phone_digits(self, phone_digits: str) -> dict[str, Any] | None:
+        local_digits = phone_digits[-10:] if len(phone_digits) >= 10 else phone_digits
+        try:
+            return self._execute_one(
+                """
+                SELECT user_id, display_name, phone_number, phone_verified
+                FROM actor_identity_cache
+                WHERE phone_verified = TRUE
+                  AND (
+                    regexp_replace(COALESCE(phone_number, ''), '[^0-9]', '', 'g') = :phone_digits
+                    OR RIGHT(
+                      regexp_replace(COALESCE(phone_number, ''), '[^0-9]', '', 'g'),
+                      :local_digits_length
+                    ) = :local_digits
+                  )
+                ORDER BY last_synced_at DESC NULLS LAST, updated_at DESC NULLS LAST
+                LIMIT 1
+                """,
+                {
+                    "phone_digits": phone_digits,
+                    "local_digits": local_digits,
+                    "local_digits_length": len(local_digits),
+                },
+            )
+        except Exception as exc:
+            logger.debug("one.location.phone_identity_lookup_failed error=%s", exc)
+            return None
+
     @staticmethod
     def _recipient_payload(row: dict[str, Any] | None) -> dict[str, Any] | None:
         if not row:
@@ -459,6 +511,44 @@ class OneLocationAgentService:
             "requestId": str(row.get("request_id") or "") or None,
             "status": str(row.get("status") or "pending_owner_approval"),
             "createdAt": _iso(row.get("created_at")),
+            "resolvedAt": _iso(row.get("resolved_at")),
+        }
+
+    @staticmethod
+    def _public_invite_payload(row: dict[str, Any] | None) -> dict[str, Any] | None:
+        if not row:
+            return None
+        owner_label = str(row.get("owner_display_name") or "").strip()
+        owner_masked_phone = _mask_phone(row.get("owner_phone_number"))
+        return {
+            "id": str(row.get("id") or ""),
+            "ownerUserId": str(row.get("owner_user_id") or ""),
+            "ownerDisplayName": owner_label or None,
+            "ownerMaskedPhone": owner_masked_phone,
+            "status": str(row.get("status") or "active"),
+            "durationHours": float(row.get("duration_hours") or 0),
+            "expiresAt": _iso(row.get("expires_at")),
+            "createdAt": _iso(row.get("created_at")),
+            "updatedAt": _iso(row.get("updated_at")),
+            "revokedAt": _iso(row.get("revoked_at")),
+        }
+
+    @staticmethod
+    def _public_submission_payload(row: dict[str, Any] | None) -> dict[str, Any] | None:
+        if not row:
+            return None
+        return {
+            "id": str(row.get("id") or ""),
+            "inviteId": str(row.get("invite_id") or ""),
+            "ownerUserId": str(row.get("owner_user_id") or ""),
+            "visitorDisplayName": str(row.get("visitor_display_name") or ""),
+            "visitorMaskedPhone": _mask_phone(row.get("visitor_phone_last4")),
+            "matchedUserId": str(row.get("matched_user_id") or "") or None,
+            "requestId": str(row.get("request_id") or "") or None,
+            "requestStatus": str(row.get("request_status") or "") or None,
+            "status": str(row.get("status") or "pending_identity"),
+            "message": str(row.get("message") or "") or None,
+            "submittedAt": _iso(row.get("submitted_at")),
             "resolvedAt": _iso(row.get("resolved_at")),
         }
 
@@ -899,6 +989,250 @@ class OneLocationAgentService:
             "envelope": self._envelope_payload(row),
         }
 
+    def _expire_public_invite(self, row: dict[str, Any] | None) -> dict[str, Any] | None:
+        if not row or str(row.get("status") or "") != "active":
+            return row
+        expires_at = _parse_datetime(row.get("expires_at"), field_name="expires_at")
+        if expires_at > _utcnow():
+            return row
+        updated = self._execute_one(
+            """
+            UPDATE one_location_public_invites
+            SET status = 'expired', updated_at = NOW()
+            WHERE id = CAST(:invite_id AS UUID)
+              AND status = 'active'
+            RETURNING *
+            """,
+            {"invite_id": str(row.get("id") or "")},
+        )
+        return updated or {**row, "status": "expired"}
+
+    def create_public_invite(
+        self,
+        *,
+        owner_user_id: str,
+        duration_hours: float,
+    ) -> dict[str, Any]:
+        if not owner_user_id:
+            raise OneLocationAgentError(
+                "LOCATION_AUTH_REQUIRED", "A user is required.", status_code=401
+            )
+        try:
+            duration = normalize_duration_hours(duration_hours)
+        except ValueError as exc:
+            raise OneLocationAgentError(
+                "LOCATION_DURATION_INVALID",
+                str(exc),
+                status_code=422,
+            ) from exc
+        raw_token = secrets.token_urlsafe(32)
+        token_hash = _hash_public_value(raw_token)
+        expires_at = _utcnow() + timedelta(hours=duration)
+        row = self._execute_one(
+            """
+            INSERT INTO one_location_public_invites (
+              owner_user_id, public_code_hash, status, duration_hours,
+              expires_at, created_at, updated_at, metadata
+            )
+            VALUES (
+              :owner_user_id, :public_code_hash, 'active', :duration_hours,
+              :expires_at, NOW(), NOW(), '{}'::jsonb
+            )
+            RETURNING *
+            """,
+            {
+                "owner_user_id": owner_user_id,
+                "public_code_hash": token_hash,
+                "duration_hours": duration,
+                "expires_at": expires_at,
+            },
+        )
+        invite = self._public_invite_payload(row)
+        if not invite:
+            raise OneLocationAgentError(
+                "LOCATION_PUBLIC_INVITE_CREATE_FAILED",
+                "Could not create the public request link.",
+                status_code=500,
+            )
+        self._insert_event(
+            owner_user_id=owner_user_id,
+            actor_user_id=owner_user_id,
+            event_type="location_public_invite_created",
+            metadata={"invite_id": invite["id"], "duration_hours": duration},
+        )
+        return {
+            "invite": invite,
+            "publicToken": raw_token,
+            "publicUrl": _public_invite_url(raw_token),
+        }
+
+    def resolve_public_invite(self, *, public_token: str) -> dict[str, Any]:
+        normalized_token = str(public_token or "").strip()
+        if len(normalized_token) < 16:
+            raise OneLocationAgentError(
+                "LOCATION_PUBLIC_INVITE_INVALID",
+                "This request link is invalid.",
+                status_code=404,
+            )
+        row = self._execute_one(
+            """
+            SELECT
+              i.*,
+              owner.display_name AS owner_display_name,
+              owner.phone_number AS owner_phone_number
+            FROM one_location_public_invites i
+            LEFT JOIN actor_identity_cache owner ON owner.user_id = i.owner_user_id
+            WHERE i.public_code_hash = :public_code_hash
+            LIMIT 1
+            """,
+            {"public_code_hash": _hash_public_value(normalized_token)},
+        )
+        row = self._expire_public_invite(row)
+        invite = self._public_invite_payload(row)
+        if not invite or invite["status"] != "active":
+            raise OneLocationAgentError(
+                "LOCATION_PUBLIC_INVITE_NOT_ACTIVE",
+                "This request link is no longer active.",
+                status_code=410 if invite else 404,
+            )
+        return {"invite": invite}
+
+    def submit_public_invite_request(
+        self,
+        *,
+        public_token: str,
+        visitor_display_name: str,
+        phone_number: str,
+        message: str | None = None,
+    ) -> dict[str, Any]:
+        invite = self.resolve_public_invite(public_token=public_token)["invite"]
+        display_name = str(visitor_display_name or "").strip()
+        if len(display_name) < 2:
+            raise OneLocationAgentError(
+                "LOCATION_PUBLIC_VISITOR_NAME_REQUIRED",
+                "Enter your name before requesting location access.",
+                status_code=422,
+            )
+        phone_digits = _normalize_phone_digits(phone_number)
+        if len(phone_digits) < 8 or len(phone_digits) > 15:
+            raise OneLocationAgentError(
+                "LOCATION_PUBLIC_VISITOR_PHONE_INVALID",
+                "Enter a valid phone number before requesting location access.",
+                status_code=422,
+            )
+        message_value = (message or "").strip()[:500] or None
+        owner_user_id = invite["ownerUserId"]
+        matched_identity = self._identity_row_by_phone_digits(phone_digits)
+        matched_user_id = str(matched_identity.get("user_id") or "") if matched_identity else None
+        status_value = "pending_identity"
+        request: dict[str, Any] | None = None
+        if matched_user_id == owner_user_id:
+            matched_user_id = None
+        if matched_user_id:
+            try:
+                request = self.request_access(
+                    requester_user_id=matched_user_id,
+                    owner_user_id=owner_user_id,
+                    message=message_value or f"Public request from {display_name}",
+                    notify_owner=False,
+                )
+                status_value = "matched_request_pending"
+            except OneLocationAgentError as exc:
+                if exc.code != "LOCATION_RECIPIENT_UNAVAILABLE":
+                    raise
+                status_value = "identity_pending_key"
+        row = self._execute_one(
+            """
+            INSERT INTO one_location_public_invite_submissions (
+              invite_id, owner_user_id, visitor_display_name, visitor_phone_hash,
+              visitor_phone_last4, matched_user_id, request_id, status, message,
+              submitted_at, metadata
+            )
+            VALUES (
+              CAST(:invite_id AS UUID), :owner_user_id, :visitor_display_name,
+              :visitor_phone_hash, :visitor_phone_last4, :matched_user_id,
+              CAST(:request_id AS UUID), :status, :message, NOW(), '{}'::jsonb
+            )
+            RETURNING *
+            """,
+            {
+                "invite_id": invite["id"],
+                "owner_user_id": owner_user_id,
+                "visitor_display_name": display_name[:120],
+                "visitor_phone_hash": _hash_public_value(phone_digits),
+                "visitor_phone_last4": phone_digits[-4:],
+                "matched_user_id": matched_user_id,
+                "request_id": request["id"] if request else None,
+                "status": status_value,
+                "message": message_value,
+            },
+        )
+        submission = self._public_submission_payload(row)
+        if not submission:
+            raise OneLocationAgentError(
+                "LOCATION_PUBLIC_SUBMISSION_FAILED",
+                "Could not send the public location request.",
+                status_code=500,
+            )
+        self._insert_event(
+            owner_user_id=owner_user_id,
+            actor_user_id=matched_user_id,
+            recipient_user_id=matched_user_id,
+            request_id=request["id"] if request else None,
+            event_type="location_public_invite_submitted",
+            metadata={
+                "invite_id": invite["id"],
+                "submission_id": submission["id"],
+                "matched": bool(matched_user_id),
+                "request_created": bool(request),
+            },
+        )
+        self._send_metadata_notification(
+            user_id=owner_user_id,
+            notification_type="location_public_invite_submitted",
+            title="Public location request",
+            body=f"{display_name[:80]} requested location access from your link.",
+            notification_tag=f"one-location-public-request:{submission['id']}",
+            request_url=_one_location_url(requestId=request["id"] if request else None),
+            data={
+                "submission_id": submission["id"],
+                "invite_id": invite["id"],
+                "request_id": request["id"] if request else None,
+                "visitor_display_label": display_name[:80],
+                "visitor_masked_phone": _mask_phone(phone_digits),
+                "matched_user_id": matched_user_id,
+                "status": status_value,
+            },
+        )
+        return {"submission": submission, "request": request}
+
+    def revoke_public_invite(self, *, owner_user_id: str, invite_id: str) -> dict[str, Any]:
+        row = self._execute_one(
+            """
+            UPDATE one_location_public_invites
+            SET status = 'revoked', revoked_at = NOW(), updated_at = NOW()
+            WHERE id = CAST(:invite_id AS UUID)
+              AND owner_user_id = :owner_user_id
+              AND status = 'active'
+            RETURNING *
+            """,
+            {"owner_user_id": owner_user_id, "invite_id": invite_id},
+        )
+        if not row:
+            raise OneLocationAgentError(
+                "LOCATION_PUBLIC_INVITE_NOT_FOUND",
+                "Active public request link was not found.",
+                status_code=404,
+            )
+        invite = self._public_invite_payload(row) or {}
+        self._insert_event(
+            owner_user_id=owner_user_id,
+            actor_user_id=owner_user_id,
+            event_type="location_public_invite_revoked",
+            metadata={"invite_id": invite_id},
+        )
+        return invite
+
     def list_state(self, *, user_id: str) -> dict[str, Any]:
         self._expire_stale_grants(user_id)
         recipients = self.list_verified_recipients(owner_user_id=user_id)
@@ -956,6 +1290,30 @@ class OneLocationAgentService:
             """,
             {"user_id": user_id},
         )
+        public_invites = self._execute_many(
+            """
+            SELECT *
+            FROM one_location_public_invites
+            WHERE owner_user_id = :user_id
+            ORDER BY created_at DESC
+            LIMIT 20
+            """,
+            {"user_id": user_id},
+        )
+        public_submissions = self._execute_many(
+            """
+            SELECT
+              submission.*,
+              req.status AS request_status
+            FROM one_location_public_invite_submissions submission
+            LEFT JOIN one_location_access_requests req ON req.id = submission.request_id
+            WHERE submission.owner_user_id = :user_id
+               OR submission.matched_user_id = :user_id
+            ORDER BY submission.submitted_at DESC
+            LIMIT 50
+            """,
+            {"user_id": user_id},
+        )
         return {
             "recipients": recipients,
             "ownerGrants": [
@@ -966,6 +1324,16 @@ class OneLocationAgentService:
             ],
             "requests": [payload for row in requests if (payload := self._request_payload(row))],
             "referrals": [payload for row in referrals if (payload := self._referral_payload(row))],
+            "publicInvites": [
+                payload
+                for row in public_invites
+                if (payload := self._public_invite_payload(self._expire_public_invite(row)))
+            ],
+            "publicInviteSubmissions": [
+                payload
+                for row in public_submissions
+                if (payload := self._public_submission_payload(row))
+            ],
             "capabilityScopes": LOCATION_CAPABILITY_SCOPES,
         }
 
@@ -1020,6 +1388,7 @@ class OneLocationAgentService:
         owner_user_id: str,
         message: str | None = None,
         referred_by_user_id: str | None = None,
+        notify_owner: bool = True,
     ) -> dict[str, Any]:
         if requester_user_id == owner_user_id:
             raise OneLocationAgentError(
@@ -1094,23 +1463,24 @@ class OneLocationAgentService:
         )
         requester_identity = self._identity_row(requester_user_id)
         requester_label = _identity_display_label(requester_identity, fallback="Someone")
-        self._send_metadata_notification(
-            user_id=owner_user_id,
-            notification_type="location_access_request",
-            title="Location access request",
-            body=f"{requester_label} is asking to view your location.",
-            notification_tag=f"one-location-request:{request['id']}",
-            request_url=_one_location_url(requestId=request["id"]),
-            data={
-                "request_id": request["id"],
-                "requester_user_id": requester_user_id,
-                "requester_display_label": requester_label,
-                "requester_masked_phone": _mask_phone(requester_identity.get("phone_number"))
-                if requester_identity
-                else None,
-                "referred_by_user_id": referred_by_user_id,
-            },
-        )
+        if notify_owner:
+            self._send_metadata_notification(
+                user_id=owner_user_id,
+                notification_type="location_access_request",
+                title="Location access request",
+                body=f"{requester_label} is asking to view your location.",
+                notification_tag=f"one-location-request:{request['id']}",
+                request_url=_one_location_url(requestId=request["id"]),
+                data={
+                    "request_id": request["id"],
+                    "requester_user_id": requester_user_id,
+                    "requester_display_label": requester_label,
+                    "requester_masked_phone": _mask_phone(requester_identity.get("phone_number"))
+                    if requester_identity
+                    else None,
+                    "referred_by_user_id": referred_by_user_id,
+                },
+            )
         return request
 
     def approve_request(

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -45,6 +45,32 @@ COORDINATE_METADATA_KEYS = {
 }
 
 
+def _bounded_int_env(name: str, default: int, minimum: int, maximum: int) -> int:
+    try:
+        value = int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        value = default
+    return max(minimum, min(value, maximum))
+
+
+PUBLIC_INVITE_DEFAULT_OWNER_LABEL = "A trusted person"
+PUBLIC_INVITE_MAX_SUBMISSIONS_PER_TOKEN = _bounded_int_env(
+    "ONE_LOCATION_PUBLIC_INVITE_MAX_SUBMISSIONS_PER_TOKEN", 25, 1, 100
+)
+PUBLIC_INVITE_MAX_SUBMISSIONS_PER_PHONE = _bounded_int_env(
+    "ONE_LOCATION_PUBLIC_INVITE_MAX_SUBMISSIONS_PER_PHONE", 1, 1, 5
+)
+PUBLIC_INVITE_PHONE_THROTTLE_MINUTES = _bounded_int_env(
+    "ONE_LOCATION_PUBLIC_INVITE_PHONE_THROTTLE_MINUTES", 15, 1, 1440
+)
+PUBLIC_INVITE_FINGERPRINT_THROTTLE_MINUTES = _bounded_int_env(
+    "ONE_LOCATION_PUBLIC_INVITE_FINGERPRINT_THROTTLE_MINUTES", 10, 1, 1440
+)
+PUBLIC_INVITE_MAX_SUBMISSIONS_PER_FINGERPRINT_WINDOW = _bounded_int_env(
+    "ONE_LOCATION_PUBLIC_INVITE_MAX_SUBMISSIONS_PER_FINGERPRINT_WINDOW", 3, 1, 20
+)
+
+
 class OneLocationAgentError(RuntimeError):
     def __init__(self, code: str, message: str, *, status_code: int = 400) -> None:
         self.code = code
@@ -190,7 +216,7 @@ def _public_invite_url(token: str) -> str:
         .strip()
         .rstrip("/")
     )
-    path = f"/location/request/{token}"
+    path = f"/one/location/request/{token}"
     return f"{base}{path}" if base else path
 
 
@@ -515,16 +541,25 @@ class OneLocationAgentService:
         }
 
     @staticmethod
-    def _public_invite_payload(row: dict[str, Any] | None) -> dict[str, Any] | None:
+    def _public_invite_payload(
+        row: dict[str, Any] | None, *, public: bool = False
+    ) -> dict[str, Any] | None:
         if not row:
             return None
-        owner_label = str(row.get("owner_display_name") or "").strip()
-        owner_masked_phone = _mask_phone(row.get("owner_phone_number"))
-        return {
+        metadata = _loads_json(row.get("metadata")) or {}
+        safe_label = ""
+        if isinstance(metadata, dict):
+            safe_label = str(metadata.get("owner_safe_label") or "").strip()
+        if public:
+            return {
+                "status": str(row.get("status") or "active"),
+                "durationHours": float(row.get("duration_hours") or 0),
+                "expiresAt": _iso(row.get("expires_at")),
+                "ownerLabel": safe_label or PUBLIC_INVITE_DEFAULT_OWNER_LABEL,
+            }
+        payload = {
             "id": str(row.get("id") or ""),
             "ownerUserId": str(row.get("owner_user_id") or ""),
-            "ownerDisplayName": owner_label or None,
-            "ownerMaskedPhone": owner_masked_phone,
             "status": str(row.get("status") or "active"),
             "durationHours": float(row.get("duration_hours") or 0),
             "expiresAt": _iso(row.get("expires_at")),
@@ -532,11 +567,21 @@ class OneLocationAgentService:
             "updatedAt": _iso(row.get("updated_at")),
             "revokedAt": _iso(row.get("revoked_at")),
         }
+        if safe_label:
+            payload["ownerLabel"] = safe_label
+        return payload
 
     @staticmethod
-    def _public_submission_payload(row: dict[str, Any] | None) -> dict[str, Any] | None:
+    def _public_submission_payload(
+        row: dict[str, Any] | None, *, public: bool = False
+    ) -> dict[str, Any] | None:
         if not row:
             return None
+        if public:
+            return {
+                "status": str(row.get("status") or "pending_identity"),
+                "submittedAt": _iso(row.get("submitted_at")),
+            }
         return {
             "id": str(row.get("id") or ""),
             "inviteId": str(row.get("invite_id") or ""),
@@ -1066,7 +1111,7 @@ class OneLocationAgentService:
             "publicUrl": _public_invite_url(raw_token),
         }
 
-    def resolve_public_invite(self, *, public_token: str) -> dict[str, Any]:
+    def _public_invite_row_for_token(self, *, public_token: str) -> dict[str, Any]:
         normalized_token = str(public_token or "").strip()
         if len(normalized_token) < 16:
             raise OneLocationAgentError(
@@ -1076,26 +1121,90 @@ class OneLocationAgentService:
             )
         row = self._execute_one(
             """
-            SELECT
-              i.*,
-              owner.display_name AS owner_display_name,
-              owner.phone_number AS owner_phone_number
+            SELECT i.*
             FROM one_location_public_invites i
-            LEFT JOIN actor_identity_cache owner ON owner.user_id = i.owner_user_id
             WHERE i.public_code_hash = :public_code_hash
             LIMIT 1
             """,
             {"public_code_hash": _hash_public_value(normalized_token)},
         )
         row = self._expire_public_invite(row)
-        invite = self._public_invite_payload(row)
-        if not invite or invite["status"] != "active":
+        if not row or str(row.get("status") or "") != "active":
             raise OneLocationAgentError(
                 "LOCATION_PUBLIC_INVITE_NOT_ACTIVE",
                 "This request link is no longer active.",
-                status_code=410 if invite else 404,
+                status_code=410 if row else 404,
             )
+        return row
+
+    def resolve_public_invite(self, *, public_token: str) -> dict[str, Any]:
+        row = self._public_invite_row_for_token(public_token=public_token)
+        invite = self._public_invite_payload(row, public=True)
         return {"invite": invite}
+
+    def _check_public_submission_limits(
+        self,
+        *,
+        invite_id: str,
+        visitor_phone_hash: str,
+        submitter_fingerprint_hash: str | None,
+    ) -> None:
+        row = self._execute_one(
+            """
+            SELECT
+              COUNT(*)::int AS total_submissions,
+              COUNT(*) FILTER (
+                WHERE visitor_phone_hash = :visitor_phone_hash
+              )::int AS phone_submissions,
+              COUNT(*) FILTER (
+                WHERE visitor_phone_hash = :visitor_phone_hash
+                  AND submitted_at >= NOW() - (:phone_window_minutes * INTERVAL '1 minute')
+              )::int AS recent_phone_submissions,
+              COUNT(*) FILTER (
+                WHERE :submitter_fingerprint_hash IS NOT NULL
+                  AND metadata->>'submitter_fingerprint_hash' = :submitter_fingerprint_hash
+                  AND submitted_at >= NOW() - (:fingerprint_window_minutes * INTERVAL '1 minute')
+              )::int AS recent_fingerprint_submissions
+            FROM one_location_public_invite_submissions
+            WHERE invite_id = CAST(:invite_id AS UUID)
+            """,
+            {
+                "invite_id": invite_id,
+                "visitor_phone_hash": visitor_phone_hash,
+                "submitter_fingerprint_hash": submitter_fingerprint_hash,
+                "phone_window_minutes": PUBLIC_INVITE_PHONE_THROTTLE_MINUTES,
+                "fingerprint_window_minutes": PUBLIC_INVITE_FINGERPRINT_THROTTLE_MINUTES,
+            },
+        ) or {}
+        total_submissions = int(row.get("total_submissions") or 0)
+        phone_submissions = int(row.get("phone_submissions") or 0)
+        recent_phone_submissions = int(row.get("recent_phone_submissions") or 0)
+        recent_fingerprint_submissions = int(row.get("recent_fingerprint_submissions") or 0)
+        if total_submissions >= PUBLIC_INVITE_MAX_SUBMISSIONS_PER_TOKEN:
+            raise OneLocationAgentError(
+                "LOCATION_PUBLIC_INVITE_SUBMISSION_LIMIT",
+                "This request link has reached its submission limit.",
+                status_code=429,
+            )
+        if (
+            phone_submissions >= PUBLIC_INVITE_MAX_SUBMISSIONS_PER_PHONE
+            or recent_phone_submissions >= PUBLIC_INVITE_MAX_SUBMISSIONS_PER_PHONE
+        ):
+            raise OneLocationAgentError(
+                "LOCATION_PUBLIC_INVITE_ALREADY_SUBMITTED",
+                "This phone number has already sent a request for this link.",
+                status_code=429,
+            )
+        if (
+            submitter_fingerprint_hash
+            and recent_fingerprint_submissions
+            >= PUBLIC_INVITE_MAX_SUBMISSIONS_PER_FINGERPRINT_WINDOW
+        ):
+            raise OneLocationAgentError(
+                "LOCATION_PUBLIC_INVITE_THROTTLED",
+                "Too many requests were sent recently. Try again later.",
+                status_code=429,
+            )
 
     def submit_public_invite_request(
         self,
@@ -1104,8 +1213,10 @@ class OneLocationAgentService:
         visitor_display_name: str,
         phone_number: str,
         message: str | None = None,
+        submitter_fingerprint_hash: str | None = None,
     ) -> dict[str, Any]:
-        invite = self.resolve_public_invite(public_token=public_token)["invite"]
+        invite_row = self._public_invite_row_for_token(public_token=public_token)
+        invite = self._public_invite_payload(invite_row) or {}
         display_name = str(visitor_display_name or "").strip()
         if len(display_name) < 2:
             raise OneLocationAgentError(
@@ -1120,6 +1231,12 @@ class OneLocationAgentService:
                 "Enter a valid phone number before requesting location access.",
                 status_code=422,
             )
+        visitor_phone_hash = _hash_public_value(phone_digits)
+        self._check_public_submission_limits(
+            invite_id=str(invite_row.get("id") or ""),
+            visitor_phone_hash=visitor_phone_hash,
+            submitter_fingerprint_hash=submitter_fingerprint_hash,
+        )
         message_value = (message or "").strip()[:500] or None
         owner_user_id = invite["ownerUserId"]
         matched_identity = self._identity_row_by_phone_digits(phone_digits)
@@ -1151,7 +1268,8 @@ class OneLocationAgentService:
             VALUES (
               CAST(:invite_id AS UUID), :owner_user_id, :visitor_display_name,
               :visitor_phone_hash, :visitor_phone_last4, :matched_user_id,
-              CAST(:request_id AS UUID), :status, :message, NOW(), '{}'::jsonb
+              CAST(:request_id AS UUID), :status, :message, NOW(),
+              CAST(:metadata_json AS JSONB)
             )
             RETURNING *
             """,
@@ -1159,12 +1277,18 @@ class OneLocationAgentService:
                 "invite_id": invite["id"],
                 "owner_user_id": owner_user_id,
                 "visitor_display_name": display_name[:120],
-                "visitor_phone_hash": _hash_public_value(phone_digits),
+                "visitor_phone_hash": visitor_phone_hash,
                 "visitor_phone_last4": phone_digits[-4:],
                 "matched_user_id": matched_user_id,
                 "request_id": request["id"] if request else None,
                 "status": status_value,
                 "message": message_value,
+                "metadata_json": _json_param(
+                    {
+                        "intake_only": True,
+                        "submitter_fingerprint_hash": submitter_fingerprint_hash,
+                    }
+                ),
             },
         )
         submission = self._public_submission_payload(row)
@@ -1185,6 +1309,7 @@ class OneLocationAgentService:
                 "submission_id": submission["id"],
                 "matched": bool(matched_user_id),
                 "request_created": bool(request),
+                "intake_only": True,
             },
         )
         self._send_metadata_notification(
@@ -1204,7 +1329,7 @@ class OneLocationAgentService:
                 "status": status_value,
             },
         )
-        return {"submission": submission, "request": request}
+        return {"submission": self._public_submission_payload(row, public=True)}
 
     def revoke_public_invite(self, *, owner_user_id: str, invite_id: str) -> dict[str, Any]:
         row = self._execute_one(

--- a/consent-protocol/tests/services/test_account_service_cleanup_tables.py
+++ b/consent-protocol/tests/services/test_account_service_cleanup_tables.py
@@ -94,6 +94,8 @@ async def test_full_account_deletion_covers_account_owned_tables(monkeypatch):
         "DELETE FROM one_kyc_workflows",
         "DELETE FROM one_location_events",
         "DELETE FROM one_location_referrals",
+        "DELETE FROM one_location_public_invite_submissions",
+        "DELETE FROM one_location_public_invites",
         "DELETE FROM one_location_access_requests",
         "DELETE FROM one_location_envelopes",
         "DELETE FROM one_location_share_grants",

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -191,6 +191,8 @@ class FourUserMemoryService(OneLocationAgentService):
         self.envelopes: dict[str, dict] = {}
         self.requests: dict[str, dict] = {}
         self.referrals: dict[str, dict] = {}
+        self.public_invites: dict[str, dict] = {}
+        self.public_submissions: dict[str, dict] = {}
         self.notifications: list[dict] = []
 
     def _send_metadata_notification(self, **kwargs) -> None:
@@ -249,6 +251,32 @@ class FourUserMemoryService(OneLocationAgentService):
                     }
                 )
             return rows
+        if "FROM one_location_public_invites" in sql:
+            return [
+                invite
+                for invite in sorted(
+                    self.public_invites.values(),
+                    key=lambda item: item["created_at"],
+                    reverse=True,
+                )
+                if invite["owner_user_id"] == params["user_id"]
+            ][:20]
+        if "FROM one_location_public_invite_submissions submission" in sql:
+            rows = []
+            for submission in sorted(
+                self.public_submissions.values(),
+                key=lambda item: item["submitted_at"],
+                reverse=True,
+            ):
+                if (
+                    submission["owner_user_id"] == params["user_id"]
+                    or submission.get("matched_user_id") == params["user_id"]
+                ):
+                    request = self.requests.get(submission.get("request_id") or "")
+                    rows.append(
+                        {**submission, "request_status": request.get("status") if request else None}
+                    )
+            return rows[:50]
         if "UPDATE one_location_share_grants" in sql and "status = 'revoked'" in sql:
             revoked = []
             for grant in self.grants.values():
@@ -267,6 +295,16 @@ class FourUserMemoryService(OneLocationAgentService):
         if "INSERT INTO one_location_events" in sql:
             return None
         if "UPDATE one_location_recipient_keys" in sql:
+            return None
+        if "FROM actor_identity_cache" in sql and "regexp_replace" in sql:
+            phone_digits = params["phone_digits"]
+            local_digits = params["local_digits"]
+            for identity in self.identities.values():
+                digits = "".join(ch for ch in identity["phone_number"] if ch.isdigit())
+                if identity["phone_verified"] and (
+                    digits == phone_digits or digits.endswith(local_digits)
+                ):
+                    return identity
             return None
         if "INSERT INTO one_location_recipient_keys" in sql:
             user_id = params["user_id"]
@@ -430,6 +468,66 @@ class FourUserMemoryService(OneLocationAgentService):
             }
             self.referrals[referral_id] = row
             return row
+        if "INSERT INTO one_location_public_invites" in sql:
+            invite_id = str(uuid.uuid4())
+            row = {
+                "id": invite_id,
+                "owner_user_id": params["owner_user_id"],
+                "public_code_hash": params["public_code_hash"],
+                "status": "active",
+                "duration_hours": params["duration_hours"],
+                "expires_at": params["expires_at"],
+                "created_at": datetime.now(timezone.utc),
+                "updated_at": datetime.now(timezone.utc),
+                "revoked_at": None,
+            }
+            self.public_invites[invite_id] = row
+            return row
+        if "FROM one_location_public_invites i" in sql:
+            for invite in self.public_invites.values():
+                if invite["public_code_hash"] == params["public_code_hash"]:
+                    owner = self.identities.get(invite["owner_user_id"], {})
+                    return {
+                        **invite,
+                        "owner_display_name": owner.get("display_name"),
+                        "owner_phone_number": owner.get("phone_number"),
+                    }
+            return None
+        if "UPDATE one_location_public_invites" in sql and "status = 'expired'" in sql:
+            invite = self.public_invites.get(params["invite_id"])
+            if invite and invite["status"] == "active":
+                invite["status"] = "expired"
+                return invite
+            return None
+        if "INSERT INTO one_location_public_invite_submissions" in sql:
+            submission_id = str(uuid.uuid4())
+            row = {
+                "id": submission_id,
+                "invite_id": params["invite_id"],
+                "owner_user_id": params["owner_user_id"],
+                "visitor_display_name": params["visitor_display_name"],
+                "visitor_phone_hash": params["visitor_phone_hash"],
+                "visitor_phone_last4": params["visitor_phone_last4"],
+                "matched_user_id": params.get("matched_user_id"),
+                "request_id": params.get("request_id"),
+                "status": params["status"],
+                "message": params.get("message"),
+                "submitted_at": datetime.now(timezone.utc),
+                "resolved_at": None,
+            }
+            self.public_submissions[submission_id] = row
+            return row
+        if "UPDATE one_location_public_invites" in sql and "status = 'revoked'" in sql:
+            invite = self.public_invites.get(params["invite_id"])
+            if (
+                invite
+                and invite["owner_user_id"] == params["owner_user_id"]
+                and invite["status"] == "active"
+            ):
+                invite["status"] = "revoked"
+                invite["revoked_at"] = datetime.now(timezone.utc)
+                return invite
+            return None
         if "SET status = 'revoked'" in sql and "owner_user_id = :owner_user_id" in sql:
             grant = self.grants.get(params["grant_id"])
             if (
@@ -553,3 +651,55 @@ def test_four_user_location_workflow_contract() -> None:
     )
     assert "latitude" not in serialized_state
     assert "longitude" not in serialized_state
+
+
+def test_public_invite_is_request_only_and_token_hash_only() -> None:
+    service = FourUserMemoryService()
+    service.register_recipient_key(
+        user_id="user_b",
+        key_id="key-user_b",
+        public_key_jwk={"kty": "EC", "crv": "P-256", "x": "user_b", "y": "user_b"},
+    )
+
+    created = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
+    token = created["publicToken"]
+
+    assert created["publicUrl"].endswith(token)
+    assert token not in json.dumps(service.public_invites, default=str)
+
+    resolved = service.resolve_public_invite(public_token=token)
+    assert resolved["invite"]["ownerUserId"] == "user_a"
+    assert "latitude" not in json.dumps(resolved)
+    assert "longitude" not in json.dumps(resolved)
+
+    submitted = service.submit_public_invite_request(
+        public_token=token,
+        visitor_display_name="User B",
+        phone_number="+1 555 010 0002",
+        message="Please share for pickup.",
+    )
+
+    assert submitted["submission"]["status"] == "matched_request_pending"
+    assert submitted["request"]["status"] == "pending"
+    assert submitted["request"]["requesterUserId"] == "user_b"
+    assert "latitude" not in json.dumps(service.public_submissions, default=str)
+    assert "longitude" not in json.dumps(service.notifications, default=str)
+    assert {item["notification_type"] for item in service.notifications} >= {
+        "location_public_invite_submitted"
+    }
+
+
+def test_public_invite_submission_without_key_never_creates_access() -> None:
+    service = FourUserMemoryService()
+    created = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
+
+    submitted = service.submit_public_invite_request(
+        public_token=created["publicToken"],
+        visitor_display_name="User C",
+        phone_number="+1 555 010 0003",
+    )
+
+    assert submitted["submission"]["status"] == "identity_pending_key"
+    assert submitted["submission"]["matchedUserId"] == "user_c"
+    assert submitted["request"] is None
+    assert service.requests == {}

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -499,6 +499,31 @@ class FourUserMemoryService(OneLocationAgentService):
                 invite["status"] = "expired"
                 return invite
             return None
+        if "COUNT(*)::int AS total_submissions" in sql:
+            invite_submissions = [
+                submission
+                for submission in self.public_submissions.values()
+                if submission["invite_id"] == params["invite_id"]
+            ]
+            phone_submissions = [
+                submission
+                for submission in invite_submissions
+                if submission["visitor_phone_hash"] == params["visitor_phone_hash"]
+            ]
+            fingerprint = params.get("submitter_fingerprint_hash")
+            fingerprint_submissions = [
+                submission
+                for submission in invite_submissions
+                if fingerprint
+                and (submission.get("metadata") or {}).get("submitter_fingerprint_hash")
+                == fingerprint
+            ]
+            return {
+                "total_submissions": len(invite_submissions),
+                "phone_submissions": len(phone_submissions),
+                "recent_phone_submissions": len(phone_submissions),
+                "recent_fingerprint_submissions": len(fingerprint_submissions),
+            }
         if "INSERT INTO one_location_public_invite_submissions" in sql:
             submission_id = str(uuid.uuid4())
             row = {
@@ -514,6 +539,7 @@ class FourUserMemoryService(OneLocationAgentService):
                 "message": params.get("message"),
                 "submitted_at": datetime.now(timezone.utc),
                 "resolved_at": None,
+                "metadata": json.loads(params.get("metadata_json") or "{}"),
             }
             self.public_submissions[submission_id] = row
             return row
@@ -665,12 +691,19 @@ def test_public_invite_is_request_only_and_token_hash_only() -> None:
     token = created["publicToken"]
 
     assert created["publicUrl"].endswith(token)
+    assert created["publicUrl"].startswith("/one/location/request/")
     assert token not in json.dumps(service.public_invites, default=str)
 
     resolved = service.resolve_public_invite(public_token=token)
-    assert resolved["invite"]["ownerUserId"] == "user_a"
-    assert "latitude" not in json.dumps(resolved)
-    assert "longitude" not in json.dumps(resolved)
+    assert resolved["invite"]["ownerLabel"] == "A trusted person"
+    serialized_resolve = json.dumps(resolved)
+    assert "ownerUserId" not in serialized_resolve
+    assert "ownerDisplayName" not in serialized_resolve
+    assert "ownerMaskedPhone" not in serialized_resolve
+    assert "grant" not in serialized_resolve
+    assert "ciphertext" not in serialized_resolve
+    assert "latitude" not in serialized_resolve
+    assert "longitude" not in serialized_resolve
 
     submitted = service.submit_public_invite_request(
         public_token=token,
@@ -680,10 +713,13 @@ def test_public_invite_is_request_only_and_token_hash_only() -> None:
     )
 
     assert submitted["submission"]["status"] == "matched_request_pending"
-    assert submitted["request"]["status"] == "pending"
-    assert submitted["request"]["requesterUserId"] == "user_b"
+    assert "request" not in submitted
+    assert len(service.requests) == 1
+    assert next(iter(service.requests.values()))["status"] == "pending"
+    assert next(iter(service.requests.values()))["requester_user_id"] == "user_b"
     assert "latitude" not in json.dumps(service.public_submissions, default=str)
     assert "longitude" not in json.dumps(service.notifications, default=str)
+    assert token not in json.dumps(service.notifications, default=str)
     assert {item["notification_type"] for item in service.notifications} >= {
         "location_public_invite_submitted"
     }
@@ -700,6 +736,36 @@ def test_public_invite_submission_without_key_never_creates_access() -> None:
     )
 
     assert submitted["submission"]["status"] == "identity_pending_key"
-    assert submitted["submission"]["matchedUserId"] == "user_c"
-    assert submitted["request"] is None
+    assert "matchedUserId" not in submitted["submission"]
+    assert "request" not in submitted
     assert service.requests == {}
+
+
+def test_public_invite_submission_limits_bound_duplicate_phone_requests() -> None:
+    service = FourUserMemoryService()
+    service.register_recipient_key(
+        user_id="user_b",
+        key_id="key-user_b",
+        public_key_jwk={"kty": "EC", "crv": "P-256", "x": "user_b", "y": "user_b"},
+    )
+    created = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
+
+    service.submit_public_invite_request(
+        public_token=created["publicToken"],
+        visitor_display_name="User B",
+        phone_number="+1 555 010 0002",
+        submitter_fingerprint_hash="fingerprint-hash",
+    )
+
+    with pytest.raises(OneLocationAgentError) as duplicate:
+        service.submit_public_invite_request(
+            public_token=created["publicToken"],
+            visitor_display_name="User B",
+            phone_number="+1 555 010 0002",
+            submitter_fingerprint_hash="fingerprint-hash",
+        )
+
+    assert duplicate.value.code == "LOCATION_PUBLIC_INVITE_ALREADY_SUBMITTED"
+    assert duplicate.value.status_code == 429
+    assert len(service.public_submissions) == 1
+    assert len(service.requests) == 1

--- a/consent-protocol/tests/test_one_location_public_invite_migration.py
+++ b/consent-protocol/tests/test_one_location_public_invite_migration.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MIGRATIONS_DIR = REPO_ROOT / "db" / "migrations"
+MANIFEST_PATH = REPO_ROOT / "db" / "release_migration_manifest.json"
+SCHEMA_CONTRACT_PATH = REPO_ROOT / "db" / "contracts" / "uat_integrated_schema.json"
+
+
+def test_one_location_public_invite_migration_sequence_is_current_and_unique() -> None:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    schema_contract = json.loads(SCHEMA_CONTRACT_PATH.read_text(encoding="utf-8"))
+    ordered = manifest["ordered_migrations"]
+    migration_name = "064_one_location_public_invites.sql"
+
+    assert migration_name in ordered
+    assert (MIGRATIONS_DIR / migration_name).exists()
+    assert ordered.index(migration_name) > ordered.index("063_pkm_default_available_visibility.sql")
+    assert "062_one_location_public_invites.sql" not in ordered
+    assert "062_one_location_public_invites.sql" not in {
+        path.name for path in MIGRATIONS_DIR.glob("*one_location_public_invites.sql")
+    }
+    assert len(ordered) == len(set(ordered))
+    assert schema_contract["expected_migration_version"] == 64
+    assert migration_name in manifest["groups"]["iam"]
+
+
+def test_one_location_public_invite_migration_has_hash_only_and_abuse_indexes() -> None:
+    sql = (MIGRATIONS_DIR / "064_one_location_public_invites.sql").read_text(encoding="utf-8")
+
+    assert "public_code_hash" in sql
+    assert "public_code TEXT" not in sql
+    assert "public_token" not in sql
+    assert "idx_one_location_public_invite_submissions_phone_once" in sql
+    assert "idx_one_location_public_invite_submissions_fingerprint_window" in sql

--- a/consent-protocol/tests/test_one_location_routes.py
+++ b/consent-protocol/tests/test_one_location_routes.py
@@ -130,3 +130,50 @@ def test_four_user_one_location_api_flow_is_authenticated_and_ciphertext_only(mo
     )
     assert "latitude" not in serialized
     assert "longitude" not in serialized
+
+
+def test_public_location_invite_route_creates_request_without_returning_location(
+    monkeypatch,
+) -> None:
+    service = FourUserMemoryService()
+    current_user = {"user_id": "user_a"}
+    client = _client(service, current_user, monkeypatch)
+
+    _register_key(client, current_user, "user_b")
+    current_user["user_id"] = "user_a"
+
+    invite_response = client.post(
+        "/api/one/location/public-invites",
+        json={"durationHours": 1},
+    )
+    assert invite_response.status_code == 200
+    token = invite_response.json()["publicToken"]
+
+    resolve_response = client.get(f"/api/one/location/public-invites/{token}")
+    assert resolve_response.status_code == 200
+    assert resolve_response.json()["invite"]["ownerUserId"] == "user_a"
+
+    submit_response = client.post(
+        f"/api/one/location/public-invites/{token}/submit",
+        json={
+            "visitorDisplayName": "User B",
+            "phoneNumber": "+1 555 010 0002",
+            "message": "Can you share?",
+        },
+    )
+    assert submit_response.status_code == 200
+    payload = submit_response.json()
+    assert payload["submission"]["status"] == "matched_request_pending"
+    assert payload["request"]["status"] == "pending"
+
+    serialized = json.dumps(
+        {
+            "invite": invite_response.json(),
+            "resolve": resolve_response.json(),
+            "submit": payload,
+            "notifications": service.notifications,
+        },
+        default=str,
+    )
+    assert "latitude" not in serialized
+    assert "longitude" not in serialized

--- a/consent-protocol/tests/test_one_location_routes.py
+++ b/consent-protocol/tests/test_one_location_routes.py
@@ -151,7 +151,11 @@ def test_public_location_invite_route_creates_request_without_returning_location
 
     resolve_response = client.get(f"/api/one/location/public-invites/{token}")
     assert resolve_response.status_code == 200
-    assert resolve_response.json()["invite"]["ownerUserId"] == "user_a"
+    resolve_payload = resolve_response.json()
+    assert resolve_payload["invite"]["ownerLabel"] == "A trusted person"
+    assert "ownerUserId" not in json.dumps(resolve_payload)
+    assert "ownerDisplayName" not in json.dumps(resolve_payload)
+    assert "ownerMaskedPhone" not in json.dumps(resolve_payload)
 
     submit_response = client.post(
         f"/api/one/location/public-invites/{token}/submit",
@@ -164,7 +168,9 @@ def test_public_location_invite_route_creates_request_without_returning_location
     assert submit_response.status_code == 200
     payload = submit_response.json()
     assert payload["submission"]["status"] == "matched_request_pending"
-    assert payload["request"]["status"] == "pending"
+    assert "request" not in payload
+    assert len(service.requests) == 1
+    assert next(iter(service.requests.values()))["status"] == "pending"
 
     serialized = json.dumps(
         {
@@ -175,5 +181,18 @@ def test_public_location_invite_route_creates_request_without_returning_location
         },
         default=str,
     )
+    assert token not in json.dumps(
+        {
+            "resolve": resolve_response.json(),
+            "submit": payload,
+            "notifications": service.notifications,
+        },
+        default=str,
+    )
+    assert "grant" not in json.dumps(payload)
+    assert "ciphertext" not in serialized
     assert "latitude" not in serialized
     assert "longitude" not in serialized
+    assert "map" not in serialized
+    assert "address" not in serialized
+    assert "reverse_geocode" not in serialized

--- a/docs/reference/architecture/api-contracts.md
+++ b/docs/reference/architecture/api-contracts.md
@@ -156,10 +156,13 @@ resolve intake.
 ### One Location Agent
 
 One Location Agent is One-owned live-location sharing for trusted people. The
-route family is authenticated and ciphertext-only. Public bearer links,
-server-readable latitude/longitude, reverse geocoding, map thumbnails, and
-movement trails do not belong in this contract. The maintained architecture
-reference is [One Location Agent](./one-location-agent.md).
+route family is authenticated and ciphertext-only for all live-location reads.
+Public bearer links that reveal location, server-readable latitude/longitude,
+reverse geocoding, map thumbnails, and movement trails do not belong in this
+contract. Scope-2 public links are request-only: they collect visitor metadata
+and route the workflow back to owner approval; they never reveal live location.
+The maintained architecture reference is
+[One Location Agent](./one-location-agent.md).
 
 The older KAI location route family is transitional prototype history and is
 not the product owner for live location.
@@ -169,6 +172,10 @@ not the product owner for live location.
 | GET | `/api/one/location/state` | VAULT_OWNER Bearer | List verified recipient directory, owner grants, received grants, pending requests, and referrals for the authenticated user |
 | GET | `/api/one/location/recipients` | VAULT_OWNER Bearer | List phone-verified users excluding self, with masked labels and active public key metadata only |
 | POST | `/api/one/location/recipient-keys` | VAULT_OWNER Bearer | Register the authenticated user's recipient public key; private key remains device-local |
+| POST | `/api/one/location/public-invites` | VAULT_OWNER Bearer | Create a duration-bounded public request link; the raw token is returned once and only its hash is stored |
+| GET | `/api/one/location/public-invites/{public_token}` | Public | Resolve request-link metadata only: owner label, status, duration, and expiry |
+| POST | `/api/one/location/public-invites/{public_token}/submit` | Public | Submit visitor name, phone, and optional message as metadata-only request intent; creates an owner approval request only for matched verified/keyed Hussh users |
+| DELETE | `/api/one/location/public-invites/{invite_id}` | VAULT_OWNER Bearer | Revoke an active public request link |
 | POST | `/api/one/location/grants` | VAULT_OWNER Bearer | Create a duration-bounded owner-approved grant for one verified recipient identity/key |
 | POST | `/api/one/location/grants/{grant_id}/envelopes` | VAULT_OWNER Bearer | Store the owner-device encrypted latest-location envelope; backend receives ciphertext and metadata only |
 | GET | `/api/one/location/grants/{grant_id}/envelope` | VAULT_OWNER Bearer | Return ciphertext only to the exact approved recipient while grant is active |

--- a/docs/reference/architecture/api-contracts.md
+++ b/docs/reference/architecture/api-contracts.md
@@ -173,8 +173,8 @@ not the product owner for live location.
 | GET | `/api/one/location/recipients` | VAULT_OWNER Bearer | List phone-verified users excluding self, with masked labels and active public key metadata only |
 | POST | `/api/one/location/recipient-keys` | VAULT_OWNER Bearer | Register the authenticated user's recipient public key; private key remains device-local |
 | POST | `/api/one/location/public-invites` | VAULT_OWNER Bearer | Create a duration-bounded public request link; the raw token is returned once and only its hash is stored |
-| GET | `/api/one/location/public-invites/{public_token}` | Public | Resolve request-link metadata only: owner label, status, duration, and expiry |
-| POST | `/api/one/location/public-invites/{public_token}/submit` | Public | Submit visitor name, phone, and optional message as metadata-only request intent; creates an owner approval request only for matched verified/keyed Hussh users |
+| GET | `/api/one/location/public-invites/{public_token}` | Public | Resolve request-link metadata only: safe owner label, status, duration, and expiry |
+| POST | `/api/one/location/public-invites/{public_token}/submit` | Public | Submit visitor name, phone, and optional message as metadata-only request intent; creates an owner approval request only for matched verified/keyed Hussh users; response stays submission-only |
 | DELETE | `/api/one/location/public-invites/{invite_id}` | VAULT_OWNER Bearer | Revoke an active public request link |
 | POST | `/api/one/location/grants` | VAULT_OWNER Bearer | Create a duration-bounded owner-approved grant for one verified recipient identity/key |
 | POST | `/api/one/location/grants/{grant_id}/envelopes` | VAULT_OWNER Bearer | Store the owner-device encrypted latest-location envelope; backend receives ciphertext and metadata only |

--- a/docs/reference/architecture/one-location-agent.md
+++ b/docs/reference/architecture/one-location-agent.md
@@ -2,7 +2,7 @@
 
 Status: v1 implementation contract
 Owner: One + IAM/consent governance
-Last updated: 2026-05-20
+Last updated: 2026-05-21
 
 ## Visual Map
 
@@ -75,12 +75,19 @@ reverse geocode, map, notify, or inspect latitude/longitude.
 
 ## Authorization Contract
 
-All One Location Agent routes require a VAULT_OWNER bearer token.
+All live-location grant, envelope, approval, revocation, and state routes
+require a VAULT_OWNER bearer token. Scope-2 public invite routes are the only
+public exceptions, and they are request-only. They may resolve safe owner/link
+metadata and accept visitor name/phone/message, but they never return
+coordinates, ciphertext, grants, map embeds, or share authority.
 
 - `actor_identity_cache.phone_verified = true` is eligibility only.
 - Each recipient needs a separate active grant.
 - Expiry and revocation block reads before ciphertext is returned.
 - Referrals create access requests only; they never forward access.
+- Public invite submissions create access requests only when the visitor maps
+  to a verified Hussh user with active recipient key material; otherwise they
+  remain metadata-only intent for follow-up.
 - Consent/audit records are metadata-only.
 
 Capability scopes:
@@ -99,8 +106,32 @@ envelope publishing, ciphertext viewing, revocation, access requests, request
 resolution, and referrals. Tools validate their capability scope per invocation
 and delegate persistence to `OneLocationAgentService`.
 
-The agent refuses public bearer links, plaintext server coordinates, and
-referrals that grant access without owner approval.
+The agent refuses public bearer links that reveal location, plaintext server
+coordinates, and referrals or public submissions that grant access without owner
+approval.
+
+## Public Request Links
+
+Scope-2 public sharing is a request-link workflow, not a public live-location
+viewer.
+
+1. The authenticated owner creates a duration-bounded public request link from
+   `/one/location`.
+2. The backend returns the raw token once and stores only its hash.
+3. The public page `/location/request/{token}` asks the visitor for name, phone,
+   and optional message.
+4. The public page submits metadata only. It never displays a map or location.
+5. If the phone maps to a verified/keyed Hussh user, One creates a normal
+   pending access request for owner approval.
+6. If the phone does not have usable Hussh identity/key material, the submission
+   stays pending identity/key setup.
+7. Owner approval still creates a fresh recipient-scoped grant and the owner
+   device still encrypts the coordinate envelope for that recipient.
+
+Public invite tables store token hashes, status, expiry, visitor display name,
+phone hash/last4, matched user id when available, and request linkage. They must
+not store raw phone numbers, raw invite tokens, coordinates, addresses, map
+previews, or movement/freshness trails.
 
 ## Notification Contract
 
@@ -143,6 +174,7 @@ The implementation must prove:
 - expired/revoked grants block reads
 - referrals create requests but no access
 - notification and audit metadata contain no coordinates
+- public request links store token hashes only and never reveal location
 - web, iOS, and Android have foreground permission parity
 - A/B/C/D flow is covered at service, authenticated API route, and browser
   crypto levels

--- a/docs/reference/architecture/one-location-agent.md
+++ b/docs/reference/architecture/one-location-agent.md
@@ -118,20 +118,24 @@ viewer.
 1. The authenticated owner creates a duration-bounded public request link from
    `/one/location`.
 2. The backend returns the raw token once and stores only its hash.
-3. The public page `/location/request/{token}` asks the visitor for name, phone,
+3. The public page `/one/location/request/{token}` asks the visitor for name, phone,
    and optional message.
-4. The public page submits metadata only. It never displays a map or location.
-5. If the phone maps to a verified/keyed Hussh user, One creates a normal
+4. The public resolve response exposes only a safe owner label, status,
+   duration, and expiry. By default the safe label is "a trusted person".
+5. The public page submits metadata only. It never displays a map or location.
+6. If the phone maps to a verified/keyed Hussh user, One creates a normal
    pending access request for owner approval.
-6. If the phone does not have usable Hussh identity/key material, the submission
+7. If the phone does not have usable Hussh identity/key material, the submission
    stays pending identity/key setup.
-7. Owner approval still creates a fresh recipient-scoped grant and the owner
+8. Owner approval still creates a fresh recipient-scoped grant and the owner
    device still encrypts the coordinate envelope for that recipient.
 
 Public invite tables store token hashes, status, expiry, visitor display name,
 phone hash/last4, matched user id when available, and request linkage. They must
 not store raw phone numbers, raw invite tokens, coordinates, addresses, map
-previews, or movement/freshness trails.
+previews, or movement/freshness trails. Public submissions are bounded per token,
+throttled per phone/fingerprint hash, and never return request internals, grants,
+ciphertext, or location payloads to the anonymous caller.
 
 ## Notification Contract
 

--- a/docs/reference/architecture/runtime-db-data-plane-contract.json
+++ b/docs/reference/architecture/runtime-db-data-plane-contract.json
@@ -279,14 +279,16 @@
         "one_location_access_requests",
         "one_location_envelopes",
         "one_location_events",
+        "one_location_public_invite_submissions",
+        "one_location_public_invites",
         "one_location_recipient_keys",
         "one_location_referrals",
         "one_location_share_grants"
       ],
-      "primary_access_path": "One Location Agent verified-recipient directory, recipient public key registration, owner-approved grants, encrypted envelope writes, authenticated recipient ciphertext reads, referrals, revocation, expiry, and metadata-only audit",
+      "primary_access_path": "One Location Agent verified-recipient directory, recipient public key registration, owner-approved grants, encrypted envelope writes, authenticated recipient ciphertext reads, public request invites, referrals, revocation, expiry, and metadata-only audit",
       "retention_policy": "Active grants and ciphertext envelopes are short-lived by scoped duration; expired or terminal workflow rows are retained only for bounded operational review before compaction.",
       "deletion_behavior": "Delete rows where the deleting account is owner, recipient, requester, referrer, referred user, or key owner; revoke active grants before deletion where possible.",
-      "trust_boundary": "Coordinates exist only on owner and recipient devices. Backend stores recipient public keys, grant metadata, ciphertext envelopes, and audit metadata; it must not store latitude, longitude, addresses, map previews, or movement trails.",
+      "trust_boundary": "Coordinates exist only on owner and recipient devices. Backend stores recipient public keys, grant metadata, ciphertext envelopes, public invite token hashes, request metadata, and audit metadata; it must not store latitude, longitude, addresses, map previews, or movement trails. Public invite links can request access only and never reveal location.",
       "plaintext_posture": "ciphertext_coordinates_and_metadata_only",
       "expected_row_growth": "medium_per_user_share"
     },

--- a/docs/reference/architecture/runtime-db-data-plane-contract.json
+++ b/docs/reference/architecture/runtime-db-data-plane-contract.json
@@ -288,7 +288,7 @@
       "primary_access_path": "One Location Agent verified-recipient directory, recipient public key registration, owner-approved grants, encrypted envelope writes, authenticated recipient ciphertext reads, public request invites, referrals, revocation, expiry, and metadata-only audit",
       "retention_policy": "Active grants and ciphertext envelopes are short-lived by scoped duration; expired or terminal workflow rows are retained only for bounded operational review before compaction.",
       "deletion_behavior": "Delete rows where the deleting account is owner, recipient, requester, referrer, referred user, or key owner; revoke active grants before deletion where possible.",
-      "trust_boundary": "Coordinates exist only on owner and recipient devices. Backend stores recipient public keys, grant metadata, ciphertext envelopes, public invite token hashes, request metadata, and audit metadata; it must not store latitude, longitude, addresses, map previews, or movement trails. Public invite links can request access only and never reveal location.",
+      "trust_boundary": "Coordinates exist only on owner and recipient devices. Backend stores recipient public keys, grant metadata, ciphertext envelopes, public invite token hashes, request metadata, hashed public-intake throttling metadata, and audit metadata; it must not store latitude, longitude, addresses, map previews, movement trails, or raw public tokens. Public invite links can request access only and never reveal location, grants, ciphertext, or owner identity beyond a safe label.",
       "plaintext_posture": "ciphertext_coordinates_and_metadata_only",
       "expected_row_growth": "medium_per_user_share"
     },

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -66,6 +66,8 @@ vi.mock("@/lib/one-location/service", () => ({
     approveRequest: vi.fn(),
     denyRequest: vi.fn(),
     referRecipient: vi.fn(),
+    createPublicInvite: vi.fn(),
+    revokePublicInvite: vi.fn(),
   },
 }));
 
@@ -116,6 +118,8 @@ function locationState() {
     receivedGrants: [],
     requests: [],
     referrals: [],
+    publicInvites: [],
+    publicInviteSubmissions: [],
     capabilityScopes: [
       "cap.location.live.share",
       "cap.location.live.view",
@@ -198,13 +202,14 @@ describe("OneLocationAgentPage", () => {
     );
   });
 
-  it("does not render public-link sharing controls", async () => {
+  it("renders a public request-link control that does not promise public location", async () => {
     render(<OneLocationAgentPageContent />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
 
+    expect(screen.getByText("Create request link")).toBeTruthy();
+    expect(screen.getByText("Public link responses")).toBeTruthy();
     expect(screen.queryByText(/public live-location link/i)).toBeNull();
-    expect(screen.queryByText(/share link/i)).toBeNull();
     expect(screen.queryByText(/whatsapp/i)).toBeNull();
   });
 

--- a/hushh-webapp/__tests__/services/location-agent-service.test.ts
+++ b/hushh-webapp/__tests__/services/location-agent-service.test.ts
@@ -150,6 +150,59 @@ describe("OneLocationService", () => {
     });
   });
 
+  it("creates public request links without sending location coordinates", async () => {
+    mockApiJson.mockResolvedValueOnce({
+      invite: { id: "invite_1", status: "active" },
+      publicToken: "token_1",
+      publicUrl: "/location/request/token_1",
+    });
+
+    await OneLocationService.createPublicInvite({
+      vaultOwnerToken: "vault-token",
+      durationHours: 1,
+    });
+
+    const body = String(mockApiJson.mock.calls[0]?.[1]?.body || "");
+    expect(mockApiJson).toHaveBeenCalledWith(
+      "/api/one/location/public-invites",
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer vault-token",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ durationHours: 1 }),
+      },
+    );
+    expect(body).not.toContain("latitude");
+    expect(body).not.toContain("longitude");
+  });
+
+  it("submits public invite requests without an auth token or coordinates", async () => {
+    mockApiJson.mockResolvedValueOnce({
+      submission: { id: "submission_1", status: "pending_identity" },
+      request: null,
+    });
+
+    await OneLocationService.submitPublicInviteRequest({
+      publicToken: "public-token",
+      visitorDisplayName: "Relative",
+      phoneNumber: "+917023488012",
+      message: "Please share.",
+    });
+
+    const [, options] = mockApiJson.mock.calls[0] || [];
+    const body = String(options?.body || "");
+    expect(mockApiJson.mock.calls[0]?.[0]).toBe(
+      "/api/one/location/public-invites/public-token/submit",
+    );
+    expect(options?.headers).toEqual({ "Content-Type": "application/json" });
+    expect(body).toContain("Relative");
+    expect(body).not.toContain("latitude");
+    expect(body).not.toContain("longitude");
+    expect(body).not.toContain("Authorization");
+  });
+
   it("delegates foreground capture to the Capacitor location plugin", async () => {
     mockGetCurrentPosition.mockResolvedValueOnce({
       latitude: 1,

--- a/hushh-webapp/__tests__/services/location-agent-service.test.ts
+++ b/hushh-webapp/__tests__/services/location-agent-service.test.ts
@@ -154,7 +154,7 @@ describe("OneLocationService", () => {
     mockApiJson.mockResolvedValueOnce({
       invite: { id: "invite_1", status: "active" },
       publicToken: "token_1",
-      publicUrl: "/location/request/token_1",
+      publicUrl: "/one/location/request/token_1",
     });
 
     await OneLocationService.createPublicInvite({

--- a/hushh-webapp/__tests__/services/observability-route-map.test.ts
+++ b/hushh-webapp/__tests__/services/observability-route-map.test.ts
@@ -55,6 +55,7 @@ describe("observability route map", () => {
     expect(resolveRouteId("/profile/receipts")).toBe("profile_receipts");
     expect(resolveRouteId("/profile/gmail/oauth/return")).toBe("profile_gmail_oauth_return");
     expect(resolveRouteId("/one/location")).toBe("one_location");
+    expect(resolveRouteId("/location/request/sample")).toBe("one_location_public_request");
     expect(resolveRouteId("/agent")).toBe("agent");
     expect(resolveRouteId("/portfolio/shared")).toBe("portfolio_shared");
     expect(resolveRouteId("/ria/clients")).toBe("ria_clients");
@@ -116,6 +117,9 @@ describe("observability route map", () => {
     );
     expect(normalizeApiPathToTemplate("/api/one/location/grants/grant_123/envelope")).toBe(
       "/api/one/location/grants/{grant_id}/envelope"
+    );
+    expect(normalizeApiPathToTemplate("/api/one/location/public-invites/public_token_123/submit")).toBe(
+      "/api/one/location/public-invites/{public_token}/submit"
     );
   });
 

--- a/hushh-webapp/__tests__/services/observability-route-map.test.ts
+++ b/hushh-webapp/__tests__/services/observability-route-map.test.ts
@@ -55,7 +55,7 @@ describe("observability route map", () => {
     expect(resolveRouteId("/profile/receipts")).toBe("profile_receipts");
     expect(resolveRouteId("/profile/gmail/oauth/return")).toBe("profile_gmail_oauth_return");
     expect(resolveRouteId("/one/location")).toBe("one_location");
-    expect(resolveRouteId("/location/request/sample")).toBe("one_location_public_request");
+    expect(resolveRouteId("/one/location/request/sample")).toBe("one_location_public_request");
     expect(resolveRouteId("/agent")).toBe("agent");
     expect(resolveRouteId("/portfolio/shared")).toBe("portfolio_shared");
     expect(resolveRouteId("/ria/clients")).toBe("ria_clients");

--- a/hushh-webapp/app/location/request/[token]/page.tsx
+++ b/hushh-webapp/app/location/request/[token]/page.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useParams } from "next/navigation";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Clock3,
+  Loader2,
+  Send,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Textarea } from "@/components/ui/textarea";
+import { OneLocationService } from "@/lib/one-location/service";
+import type {
+  OneLocationPublicInvite,
+  OneLocationPublicInviteSubmission,
+} from "@/lib/one-location/types";
+
+function formatDateTime(value?: string | null): string {
+  if (!value) return "Not set";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date);
+}
+
+function ownerLabel(invite: OneLocationPublicInvite | null): string {
+  if (!invite) return "A trusted person";
+  return (
+    [invite.ownerDisplayName, invite.ownerMaskedPhone]
+      .filter(Boolean)
+      .join(" - ") || "A trusted person"
+  );
+}
+
+export default function PublicLocationRequestPage() {
+  const params = useParams<{ token?: string }>();
+  const publicToken = useMemo(
+    () => String(params?.token || "").trim(),
+    [params?.token],
+  );
+  const [invite, setInvite] = useState<OneLocationPublicInvite | null>(null);
+  const [submission, setSubmission] =
+    useState<OneLocationPublicInviteSubmission | null>(null);
+  const [visitorDisplayName, setVisitorDisplayName] = useState("");
+  const [phoneNumber, setPhoneNumber] = useState("");
+  const [message, setMessage] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadInvite = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response =
+          await OneLocationService.resolvePublicInvite(publicToken);
+        if (!cancelled) setInvite(response.invite);
+      } catch (loadError) {
+        if (!cancelled) {
+          setError(
+            loadError instanceof Error
+              ? loadError.message
+              : "This request link is unavailable.",
+          );
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    if (publicToken) {
+      void loadInvite();
+    } else {
+      setError("This request link is invalid.");
+      setLoading(false);
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [publicToken]);
+
+  const handleSubmit = async () => {
+    if (!visitorDisplayName.trim() || !phoneNumber.trim()) {
+      toast.error("Enter your name and phone number.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const response = await OneLocationService.submitPublicInviteRequest({
+        publicToken,
+        visitorDisplayName: visitorDisplayName.trim(),
+        phoneNumber: phoneNumber.trim(),
+        message: message.trim() || undefined,
+      });
+      setSubmission(response.submission);
+      toast.success("Request sent.");
+    } catch (submitError) {
+      toast.error(
+        submitError instanceof Error
+          ? submitError.message
+          : "Could not send request.",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const submittedCopy =
+    submission?.status === "matched_request_pending"
+      ? "Request sent. The owner must approve before encrypted location appears in your One Location Agent."
+      : "Request sent. Sign in with this phone and open One Location Agent once so the owner can approve encrypted sharing.";
+
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto flex min-h-screen w-full max-w-2xl flex-col justify-center px-5 py-10">
+        <div className="space-y-6 rounded-[var(--app-card-radius-standard)] border border-border/70 bg-[color:var(--app-card-surface-default-solid)] p-5 shadow-[var(--shadow-xs)] sm:p-7">
+          <div className="flex items-start gap-4">
+            <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-amber-500/10 text-amber-700 dark:text-amber-200">
+              {error ? (
+                <AlertTriangle className="h-5 w-5" aria-hidden="true" />
+              ) : submission ? (
+                <CheckCircle2 className="h-5 w-5" aria-hidden="true" />
+              ) : (
+                <Clock3 className="h-5 w-5" aria-hidden="true" />
+              )}
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="text-xs font-semibold uppercase tracking-[0.22em] text-amber-600 dark:text-amber-300">
+                One Location
+              </div>
+              <h1 className="mt-2 text-3xl font-semibold tracking-normal sm:text-4xl">
+                Request location access
+              </h1>
+              <p className="mt-3 text-sm leading-6 text-muted-foreground">
+                {loading
+                  ? "Checking request link."
+                  : error
+                    ? error
+                    : `${ownerLabel(invite)} will decide before location is shared.`}
+              </p>
+            </div>
+          </div>
+
+          {loading ? (
+            <div className="space-y-3">
+              <Skeleton className="h-11 rounded-xl" />
+              <Skeleton className="h-11 rounded-xl" />
+              <Skeleton className="h-24 rounded-xl" />
+              <Skeleton className="h-10 w-36 rounded-xl" />
+            </div>
+          ) : null}
+
+          {!loading && invite && !submission ? (
+            <div className="space-y-4">
+              <div className="flex flex-wrap items-center gap-2 text-sm">
+                <Badge variant="secondary">
+                  Expires {formatDateTime(invite.expiresAt)}
+                </Badge>
+                <Badge variant="outline">
+                  {invite.durationHours}h request window
+                </Badge>
+              </div>
+              <Input
+                value={visitorDisplayName}
+                onChange={(event) => setVisitorDisplayName(event.target.value)}
+                placeholder="Your name"
+                maxLength={120}
+              />
+              <Input
+                value={phoneNumber}
+                onChange={(event) => setPhoneNumber(event.target.value)}
+                placeholder="Phone number"
+                inputMode="tel"
+                maxLength={32}
+              />
+              <Textarea
+                value={message}
+                onChange={(event) => setMessage(event.target.value)}
+                placeholder="Optional message"
+                rows={4}
+                maxLength={500}
+              />
+              <Button onClick={() => void handleSubmit()} disabled={submitting}>
+                {submitting ? (
+                  <Loader2
+                    className="mr-2 h-4 w-4 animate-spin"
+                    aria-hidden="true"
+                  />
+                ) : (
+                  <Send className="mr-2 h-4 w-4" aria-hidden="true" />
+                )}
+                Send Request
+              </Button>
+            </div>
+          ) : null}
+
+          {submission ? (
+            <div className="rounded-[var(--app-card-radius-standard)] border border-emerald-500/30 bg-emerald-500/10 p-4 text-sm leading-6 text-emerald-800 dark:text-emerald-100">
+              {submittedCopy}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -14,6 +14,8 @@ import {
   AlertTriangle,
   CheckCircle2,
   Clock3,
+  Copy,
+  ExternalLink,
   KeyRound,
   Loader2,
   LocateFixed,
@@ -69,6 +71,8 @@ import { OneLocationService } from "@/lib/one-location/service";
 import type {
   OneLocationAccessRequest,
   OneLocationGrant,
+  OneLocationPublicInvite,
+  OneLocationPublicInviteSubmission,
   OneLocationRecipient,
   OneLocationState,
   PlainLocationPoint,
@@ -97,6 +101,8 @@ type BusyState =
   | "deny"
   | "refer"
   | "revoke"
+  | "publicInvite"
+  | "publicRevoke"
   | null;
 
 function formatDateTime(value?: string | null): string {
@@ -149,6 +155,23 @@ function requestLabel(request: OneLocationAccessRequest): string {
       .filter(Boolean)
       .join(" - ") || request.requesterUserId
   );
+}
+
+function publicSubmissionLabel(
+  submission: OneLocationPublicInviteSubmission,
+): string {
+  return (
+    [submission.visitorDisplayName, submission.visitorMaskedPhone]
+      .filter(Boolean)
+      .join(" - ") || "Public request"
+  );
+}
+
+function publicInviteUrlLabel(value: string): string {
+  if (!value) return "";
+  if (/^https?:\/\//i.test(value)) return value;
+  if (typeof window === "undefined") return value;
+  return new URL(value, window.location.origin).toString();
 }
 
 function statusVariant(
@@ -367,6 +390,7 @@ export function OneLocationAgentPageContent() {
   const [referralTargets, setReferralTargets] = useState<
     Record<string, string>
   >({});
+  const [publicInviteUrl, setPublicInviteUrl] = useState("");
   const [decryptedPoints, setDecryptedPoints] = useState<
     Record<string, PlainLocationPoint>
   >({});
@@ -430,6 +454,17 @@ export function OneLocationAgentPageContent() {
       grant.status === "active" &&
       !isOneLocationGrantOpened(auth.userId, grant.id),
   ).length;
+  const activePublicInvites = useMemo(
+    () =>
+      (state?.publicInvites ?? []).filter(
+        (invite) => invite.status === "active",
+      ),
+    [state?.publicInvites],
+  );
+  const publicSubmissions = useMemo(
+    () => state?.publicInviteSubmissions ?? [],
+    [state?.publicInviteSubmissions],
+  );
 
   const openLocationShareFromNotification = useCallback(
     (grantId: string) => {
@@ -896,6 +931,89 @@ export function OneLocationAgentPageContent() {
     }
   }, [refresh, requestMessage, selectedRequestOwner, vaultOwnerToken]);
 
+  const handleCreatePublicInvite = useCallback(async () => {
+    if (!vaultOwnerToken) return;
+    setBusy("publicInvite");
+    try {
+      const response = await OneLocationService.createPublicInvite({
+        vaultOwnerToken,
+        durationHours: Number(durationHours),
+      });
+      const url = publicInviteUrlLabel(response.publicUrl);
+      setPublicInviteUrl(url);
+      if (navigator.clipboard && url) {
+        await navigator.clipboard.writeText(url).catch(() => undefined);
+      }
+      toast.success(
+        "Public request link created. You still approve before sharing.",
+      );
+      await refresh();
+    } catch (error) {
+      toast.error(
+        oneLocationErrorMessage(error, "Could not create public request link."),
+      );
+    } finally {
+      setBusy(null);
+    }
+  }, [durationHours, refresh, vaultOwnerToken]);
+
+  const handleCopyPublicInvite = useCallback(async () => {
+    if (!publicInviteUrl) return;
+    try {
+      await navigator.clipboard.writeText(publicInviteUrl);
+      toast.success("Request link copied.");
+    } catch {
+      toast.error("Could not copy the request link.");
+    }
+  }, [publicInviteUrl]);
+
+  const handleSharePublicInvite = useCallback(async () => {
+    if (!publicInviteUrl) return;
+    const text =
+      "Please request access to my live location here. I approve before anything is shared.";
+    try {
+      if (navigator.share) {
+        await navigator.share({
+          title: "Request my location",
+          text,
+          url: publicInviteUrl,
+        });
+        return;
+      }
+      await navigator.clipboard.writeText(publicInviteUrl);
+      toast.success("Request link copied.");
+    } catch (error) {
+      if ((error as Error)?.name === "AbortError") return;
+      toast.error("Could not open the share sheet.");
+    }
+  }, [publicInviteUrl]);
+
+  const handleRevokePublicInvite = useCallback(
+    async (invite: OneLocationPublicInvite) => {
+      if (!vaultOwnerToken) return;
+      setBusy("publicRevoke");
+      try {
+        await OneLocationService.revokePublicInvite({
+          vaultOwnerToken,
+          inviteId: invite.id,
+        });
+        setPublicInviteUrl("");
+        toast.success("Public request link revoked.");
+        await refresh();
+      } catch (error) {
+        toast.error(
+          oneLocationErrorMessage(
+            error,
+            "Could not revoke public request link.",
+          ),
+        );
+      } finally {
+        setBusy(null);
+      }
+    },
+    [refresh, vaultOwnerToken],
+  );
+
   const handleApprove = useCallback(
     async (request: OneLocationAccessRequest) => {
       if (!vaultOwnerToken) return;
@@ -1213,6 +1331,89 @@ export function OneLocationAgentPageContent() {
                   </ActionButton>
                 </div>
               </SettingsGroup>
+
+              <SettingsGroup
+                eyebrow="Public"
+                title="Create request link"
+                description="Share a request link with family or friends. The link asks for their details and never shows your location until you approve an encrypted grant."
+              >
+                <div className="space-y-4 px-[var(--settings-row-px)] py-[var(--settings-row-py)]">
+                  <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_160px]">
+                    <div className="rounded-[var(--app-card-radius-standard)] border border-border/70 bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+                      {publicInviteUrl ||
+                        "Create a fresh request link to copy or share."}
+                    </div>
+                    <Select
+                      value={durationHours}
+                      onValueChange={setDurationHours}
+                    >
+                      <SelectTrigger className="w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {DURATION_OPTIONS.map((option) => (
+                          <SelectItem key={option.value} value={option.value}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <ActionButton
+                      busy={busy}
+                      busyKey="publicInvite"
+                      onClick={() => void handleCreatePublicInvite()}
+                      disabled={!vaultOwnerToken}
+                    >
+                      <ExternalLink
+                        className="mr-2 h-4 w-4"
+                        aria-hidden="true"
+                      />
+                      Create Request Link
+                    </ActionButton>
+                    <Button
+                      variant="outline"
+                      onClick={() => void handleSharePublicInvite()}
+                      disabled={!publicInviteUrl}
+                    >
+                      <Send className="mr-2 h-4 w-4" aria-hidden="true" />
+                      Share
+                    </Button>
+                    <Button
+                      variant="outline"
+                      onClick={() => void handleCopyPublicInvite()}
+                      disabled={!publicInviteUrl}
+                    >
+                      <Copy className="mr-2 h-4 w-4" aria-hidden="true" />
+                      Copy
+                    </Button>
+                  </div>
+                </div>
+                {activePublicInvites.length
+                  ? activePublicInvites.map((invite) => (
+                      <SettingsRow
+                        key={invite.id}
+                        icon={ExternalLink}
+                        title="Active request link"
+                        description={`Requests expire ${formatDateTime(invite.expiresAt)} - ${invite.durationHours}h`}
+                        stackTrailingOnMobile
+                        trailing={
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() =>
+                              void handleRevokePublicInvite(invite)
+                            }
+                            disabled={busy === "publicRevoke"}
+                          >
+                            Revoke
+                          </Button>
+                        }
+                      />
+                    ))
+                  : null}
+              </SettingsGroup>
             </div>
 
             <div className="space-y-6">
@@ -1401,6 +1602,38 @@ export function OneLocationAgentPageContent() {
                     icon={Clock3}
                     title="No pending requests"
                     description="Referral and direct access requests wait here."
+                  />
+                )}
+              </SettingsGroup>
+
+              <SettingsGroup
+                eyebrow="Public"
+                title="Public link responses"
+                description="People who use your public request link appear here. Location still waits for owner approval."
+              >
+                {publicSubmissions.length ? (
+                  publicSubmissions.map((submission) => (
+                    <SettingsRow
+                      key={submission.id}
+                      icon={Clock3}
+                      title={publicSubmissionLabel(submission)}
+                      description={
+                        submission.message ||
+                        `Status ${submission.status} - ${formatDateTime(submission.submittedAt)}`
+                      }
+                      stackTrailingOnMobile
+                      trailing={
+                        <Badge variant={statusVariant(submission.status)}>
+                          {submission.requestStatus || submission.status}
+                        </Badge>
+                      }
+                    />
+                  ))
+                ) : (
+                  <EmptyState
+                    icon={ExternalLink}
+                    title="No public responses"
+                    description="Responses from your request link show up here without exposing your location."
                   />
                 )}
               </SettingsGroup>

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -970,7 +970,7 @@ export function OneLocationAgentPageContent() {
   const handleSharePublicInvite = useCallback(async () => {
     if (!publicInviteUrl) return;
     const text =
-      "Please request access to my live location here. I approve before anything is shared.";
+      "Please send a One Location request here. I approve before anything is shared.";
     try {
       if (navigator.share) {
         await navigator.share({

--- a/hushh-webapp/app/one/location/request/[token]/page.tsx
+++ b/hushh-webapp/app/one/location/request/[token]/page.tsx
@@ -35,12 +35,7 @@ function formatDateTime(value?: string | null): string {
 }
 
 function ownerLabel(invite: OneLocationPublicInvite | null): string {
-  if (!invite) return "A trusted person";
-  return (
-    [invite.ownerDisplayName, invite.ownerMaskedPhone]
-      .filter(Boolean)
-      .join(" - ") || "A trusted person"
-  );
+  return invite?.ownerLabel || "a trusted person";
 }
 
 export default function PublicLocationRequestPage() {

--- a/hushh-webapp/components/consent/notification-provider.tsx
+++ b/hushh-webapp/components/consent/notification-provider.tsx
@@ -368,7 +368,8 @@ function isOneLocationWorkflowNotificationType(
     value === "location_share_expired" ||
     value === "location_access_request" ||
     value === "location_access_denied" ||
-    value === "location_referral_invite"
+    value === "location_referral_invite" ||
+    value === "location_public_invite_submitted"
   );
 }
 
@@ -398,11 +399,20 @@ function oneLocationReferringLabel(data: Record<string, string>): string {
   );
 }
 
+function oneLocationVisitorLabel(data: Record<string, string>): string {
+  return (
+    String(data.visitor_display_label || "").trim() ||
+    String(data.visitor_label || "").trim() ||
+    "Someone"
+  );
+}
+
 function oneLocationNotificationId(data: Record<string, string>): string {
   return (
     String(data.grant_id || "").trim() ||
     String(data.approved_grant_id || "").trim() ||
     String(data.request_id || "").trim() ||
+    String(data.submission_id || "").trim() ||
     String(data.referral_id || "").trim() ||
     String(data.notification_tag || "").trim()
   );
@@ -656,6 +666,7 @@ export function ConsentNotificationProvider({
       const grantId = String(data.grant_id || data.approved_grant_id || "").trim();
       const requestId = String(data.request_id || "").trim();
       const referralId = String(data.referral_id || "").trim();
+      const submissionId = String(data.submission_id || "").trim();
       const id = oneLocationNotificationId(data);
       if (!id) return;
 
@@ -671,6 +682,7 @@ export function ConsentNotificationProvider({
         ownerLabel: oneLocationOwnerLabel(data),
         requesterLabel: oneLocationRequesterLabel(data),
         referringLabel: oneLocationReferringLabel(data),
+        visitorLabel: oneLocationVisitorLabel(data),
       });
       const routeHref = buildOneLocationWorkflowHref({
         grantId,
@@ -689,11 +701,12 @@ export function ConsentNotificationProvider({
           grantId: grantId || null,
           requestId: requestId || null,
           referralId: referralId || null,
+          submissionId: submissionId || null,
         },
       });
       dispatchConsentStateChanged({
         source: "one_location_notification",
-        requestId: requestId || grantId || referralId,
+        requestId: requestId || grantId || referralId || submissionId,
         notificationType: msgType,
       });
       if (!created) return;
@@ -1027,7 +1040,13 @@ export function ConsentNotificationProvider({
       const msgType = data.type;
 
       // Dedup: skip if we've already processed this exact message
-      const msgId = data.message_id || data.request_id || data.bundle_id || data.grant_id || "";
+      const msgId =
+        data.message_id ||
+        data.request_id ||
+        data.bundle_id ||
+        data.grant_id ||
+        data.submission_id ||
+        "";
       const dedupKey = `${msgType}:${msgId}`;
       if (msgId && toastedIdsRef.current.has(dedupKey)) return;
       if (msgId) toastedIdsRef.current.add(dedupKey);

--- a/hushh-webapp/lib/navigation/routes.ts
+++ b/hushh-webapp/lib/navigation/routes.ts
@@ -169,7 +169,8 @@ export function isPublicRoute(pathname: string): boolean {
     pathname === ROUTES.LOGIN ||
     pathname === ROUTES.PHONE_MANDATE ||
     pathname === ROUTES.LOGOUT ||
-    pathname === ROUTES.PROFILE
+    pathname === ROUTES.PROFILE ||
+    pathname.startsWith(`${ROUTES.ONE_LOCATION}/request/`)
   );
 }
 

--- a/hushh-webapp/lib/observability/route-map.ts
+++ b/hushh-webapp/lib/observability/route-map.ts
@@ -20,6 +20,7 @@ export const ROUTE_ID_VALUES = [
   "marketplace_ria_profile",
   "one_kyc",
   "one_location",
+  "one_location_public_request",
   "portfolio_shared",
   "ria_home",
   "ria_onboarding",
@@ -73,6 +74,7 @@ export function resolveRouteId(pathname: string): RouteId {
   }
   if (pathname === ROUTES.ONE_KYC) return "one_kyc";
   if (pathname === ROUTES.ONE_LOCATION) return "one_location";
+  if (pathname.startsWith("/location/request/")) return "one_location_public_request";
   if (pathname === "/portfolio/shared") return "portfolio_shared";
   if (pathname === ROUTES.RIA_HOME) return "ria_home";
   if (pathname === ROUTES.RIA_ONBOARDING) return "ria_onboarding";
@@ -171,6 +173,18 @@ const API_TEMPLATE_RULES: Array<{ regex: RegExp; template: string }> = [
   {
     regex: /^\/api\/one\/location\/grants\/[^/?]+\/refer(?:\?.*)?$/i,
     template: "/api/one/location/grants/{grant_id}/refer",
+  },
+  {
+    regex: /^\/api\/one\/location\/public-invites(?:\?.*)?$/i,
+    template: "/api/one/location/public-invites",
+  },
+  {
+    regex: /^\/api\/one\/location\/public-invites\/[^/?]+\/submit(?:\?.*)?$/i,
+    template: "/api/one/location/public-invites/{public_token}/submit",
+  },
+  {
+    regex: /^\/api\/one\/location\/public-invites\/[^/?]+(?:\?.*)?$/i,
+    template: "/api/one/location/public-invites/{public_invite_id}",
   },
   {
     regex: /^\/api\/kai\/agent\/chat\/stream(?:\?.*)?$/i,

--- a/hushh-webapp/lib/observability/route-map.ts
+++ b/hushh-webapp/lib/observability/route-map.ts
@@ -74,7 +74,7 @@ export function resolveRouteId(pathname: string): RouteId {
   }
   if (pathname === ROUTES.ONE_KYC) return "one_kyc";
   if (pathname === ROUTES.ONE_LOCATION) return "one_location";
-  if (pathname.startsWith("/location/request/")) return "one_location_public_request";
+  if (pathname.startsWith("/one/location/request/")) return "one_location_public_request";
   if (pathname === "/portfolio/shared") return "portfolio_shared";
   if (pathname === ROUTES.RIA_HOME) return "ria_home";
   if (pathname === ROUTES.RIA_ONBOARDING) return "ria_onboarding";

--- a/hushh-webapp/lib/one-location/notifications.ts
+++ b/hushh-webapp/lib/one-location/notifications.ts
@@ -20,7 +20,8 @@ export type OneLocationWorkflowNotificationType =
   | "location_share_expired"
   | "location_access_request"
   | "location_access_denied"
-  | "location_referral_invite";
+  | "location_referral_invite"
+  | "location_public_invite_submitted";
 
 const WORKFLOW_COPY: Record<
   OneLocationWorkflowNotificationType,
@@ -53,6 +54,10 @@ const WORKFLOW_COPY: Record<
   location_referral_invite: {
     title: "Location referral pending",
     fallbackDescription: "A trusted person referred you into a location request flow.",
+  },
+  location_public_invite_submitted: {
+    title: "Public location request",
+    fallbackDescription: "Someone requested location access from your public link.",
   },
 };
 
@@ -178,11 +183,13 @@ export function locationWorkflowNotificationCopy(params: {
   ownerLabel?: string | null;
   requesterLabel?: string | null;
   referringLabel?: string | null;
+  visitorLabel?: string | null;
 }): { title: string; description: string } {
   const copy = WORKFLOW_COPY[params.type];
   const ownerLabel = String(params.ownerLabel || "").trim() || "A trusted person";
   const requesterLabel = String(params.requesterLabel || "").trim() || "Someone";
   const referringLabel = String(params.referringLabel || "").trim() || "A trusted person";
+  const visitorLabel = String(params.visitorLabel || "").trim() || "Someone";
 
   switch (params.type) {
     case "location_share_created":
@@ -215,6 +222,11 @@ export function locationWorkflowNotificationCopy(params: {
       return {
         title: copy.title,
         description: `${referringLabel} referred you into a location request for ${ownerLabel}.`,
+      };
+    case "location_public_invite_submitted":
+      return {
+        title: copy.title,
+        description: `${visitorLabel} requested location access from your public link.`,
       };
     default:
       return { title: copy.title, description: copy.fallbackDescription };

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -4,6 +4,8 @@ import type {
   OneLocationAccessRequest,
   OneLocationEncryptedEnvelope,
   OneLocationGrant,
+  OneLocationPublicInvite,
+  OneLocationPublicInviteSubmission,
   OneLocationRecipient,
   OneLocationReferral,
   OneLocationState,
@@ -93,6 +95,73 @@ export class OneLocationService {
     return apiJsonWithRetry<OneLocationState>("/api/one/location/state", {
       headers: jsonAuthHeaders(vaultOwnerToken),
     });
+  }
+
+  static async createPublicInvite(params: {
+    vaultOwnerToken: string;
+    durationHours: number;
+  }): Promise<{
+    invite: OneLocationPublicInvite;
+    publicToken: string;
+    publicUrl: string;
+  }> {
+    return apiJsonWithRetry(
+      "/api/one/location/public-invites",
+      {
+        method: "POST",
+        headers: jsonAuthHeaders(params.vaultOwnerToken),
+        body: JSON.stringify({ durationHours: params.durationHours }),
+      },
+      1,
+    );
+  }
+
+  static async resolvePublicInvite(publicToken: string): Promise<{
+    invite: OneLocationPublicInvite;
+  }> {
+    return apiJsonWithRetry(
+      `/api/one/location/public-invites/${encodeURIComponent(publicToken)}`,
+      {},
+      1,
+    );
+  }
+
+  static async submitPublicInviteRequest(params: {
+    publicToken: string;
+    visitorDisplayName: string;
+    phoneNumber: string;
+    message?: string;
+  }): Promise<{
+    submission: OneLocationPublicInviteSubmission;
+    request: OneLocationAccessRequest | null;
+  }> {
+    return apiJsonWithRetry(
+      `/api/one/location/public-invites/${encodeURIComponent(params.publicToken)}/submit`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          visitorDisplayName: params.visitorDisplayName,
+          phoneNumber: params.phoneNumber,
+          message: params.message,
+        }),
+      },
+      1,
+    );
+  }
+
+  static async revokePublicInvite(params: {
+    vaultOwnerToken: string;
+    inviteId: string;
+  }): Promise<OneLocationPublicInvite> {
+    const response = await apiJson<{ invite: OneLocationPublicInvite }>(
+      `/api/one/location/public-invites/${encodeURIComponent(params.inviteId)}`,
+      {
+        method: "DELETE",
+        headers: jsonAuthHeaders(params.vaultOwnerToken),
+      },
+    );
+    return response.invite;
   }
 
   static async createGrant(params: {

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -133,7 +133,7 @@ export class OneLocationService {
     message?: string;
   }): Promise<{
     submission: OneLocationPublicInviteSubmission;
-    request: OneLocationAccessRequest | null;
+    request?: OneLocationAccessRequest | null;
   }> {
     return apiJsonWithRetry(
       `/api/one/location/public-invites/${encodeURIComponent(params.publicToken)}/submit`,

--- a/hushh-webapp/lib/one-location/types.ts
+++ b/hushh-webapp/lib/one-location/types.ts
@@ -1,4 +1,9 @@
-export type LocationSourcePlatform = "web" | "ios" | "android" | "native" | "unknown";
+export type LocationSourcePlatform =
+  | "web"
+  | "ios"
+  | "android"
+  | "native"
+  | "unknown";
 
 export type OneLocationRecipient = {
   userId: string;
@@ -58,12 +63,49 @@ export type OneLocationReferral = {
   resolvedAt?: string | null;
 };
 
+export type OneLocationPublicInvite = {
+  id: string;
+  ownerUserId: string;
+  ownerDisplayName?: string | null;
+  ownerMaskedPhone?: string | null;
+  status: "active" | "expired" | "revoked" | string;
+  durationHours: number;
+  expiresAt?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  revokedAt?: string | null;
+};
+
+export type OneLocationPublicInviteSubmission = {
+  id: string;
+  inviteId: string;
+  ownerUserId: string;
+  visitorDisplayName: string;
+  visitorMaskedPhone?: string | null;
+  matchedUserId?: string | null;
+  requestId?: string | null;
+  requestStatus?: string | null;
+  status:
+    | "pending_identity"
+    | "identity_pending_key"
+    | "matched_request_pending"
+    | "approved"
+    | "denied"
+    | "cancelled"
+    | string;
+  message?: string | null;
+  submittedAt?: string | null;
+  resolvedAt?: string | null;
+};
+
 export type OneLocationState = {
   recipients: OneLocationRecipient[];
   ownerGrants: OneLocationGrant[];
   receivedGrants: OneLocationGrant[];
   requests: OneLocationAccessRequest[];
   referrals: OneLocationReferral[];
+  publicInvites: OneLocationPublicInvite[];
+  publicInviteSubmissions: OneLocationPublicInviteSubmission[];
   capabilityScopes: string[];
 };
 

--- a/hushh-webapp/lib/one-location/types.ts
+++ b/hushh-webapp/lib/one-location/types.ts
@@ -66,6 +66,7 @@ export type OneLocationReferral = {
 export type OneLocationPublicInvite = {
   id: string;
   ownerUserId: string;
+  ownerLabel?: string | null;
   ownerDisplayName?: string | null;
   ownerMaskedPhone?: string | null;
   status: "active" | "expired" | "revoked" | string;


### PR DESCRIPTION
﻿## Summary
- Add One Location scope-2 public request links that let a location owner create a time-bound request URL without exposing live coordinates publicly.
- Add backend invite/submission storage, owner approval flow, cleanup coverage, API contracts, and data-plane classification.
- Add the public request page, One Location Agent controls, service/types wiring, and notification handling for request/approval workflows.

## Validation
- Local pre-commit hook passed: consent-protocol ruff check + ruff format check.
- DCO check passed for this branch commit.
- Pre-push branch freshness gate passed against origin/main.
- Local runtime smoke passed before publish: frontend 3000, backend health 8000, Cloud SQL proxy 6543, One Location tables reachable.
