### PR TITLE
fix(security): bind TrustLink HMAC to session context

### DIFF
--- a/consent-protocol/hushh_mcp/trust/link.py
+++ b/consent-protocol/hushh_mcp/trust/link.py
@@ -16,11 +16,12 @@ def create_trust_link(
     scope: ConsentScope,
     signed_by_user: UserID,
     expires_in_ms: int = DEFAULT_TRUST_LINK_EXPIRY_MS,
+    session_id: str = "",
 ) -> TrustLink:
     created_at = int(time.time() * 1000)
     expires_at = created_at + expires_in_ms
 
-    raw = f"{from_agent}|{to_agent}|{scope}|{created_at}|{expires_at}|{signed_by_user}"
+    raw = f"{from_agent}|{to_agent}|{scope}|{created_at}|{expires_at}|{signed_by_user}|{session_id}"
     signature = _sign(raw)
 
     return TrustLink(
@@ -31,18 +32,39 @@ def create_trust_link(
         expires_at=expires_at,
         signed_by_user=signed_by_user,
         signature=signature,
+        session_id=session_id,
     )
 
 
 # ========== TrustLink Verifier ==========
 
 
-def verify_trust_link(link: TrustLink) -> bool:
+def verify_trust_link(link: TrustLink, expected_session_id: str | None = None) -> bool:
+    """Verify a TrustLink's HMAC signature and optionally enforce session binding.
+
+    Args:
+        link: The TrustLink to verify.
+        expected_session_id: The server-derived session context for the current
+            request. When provided (and non-empty), the link is rejected unless
+            ``link.session_id`` matches exactly. Pass this on every session-bound
+            surface to prevent cross-session replay of captured TrustLinks.
+
+    Returns:
+        True only when the link is unexpired, the HMAC is valid, and (if
+        ``expected_session_id`` is supplied) the session IDs match.
+    """
     now = int(time.time() * 1000)
     if now > link.expires_at:
         return False
 
-    raw = f"{link.from_agent}|{link.to_agent}|{link.scope}|{link.created_at}|{link.expires_at}|{link.signed_by_user}"
+    # Server-side session enforcement: reject if caller supplied a session
+    # context that differs from the one embedded in the link. This prevents
+    # an attacker from replaying a legitimately signed TrustLink (with a
+    # valid session_id and valid signature) across a different session.
+    if expected_session_id is not None and link.session_id != expected_session_id:
+        return False
+
+    raw = f"{link.from_agent}|{link.to_agent}|{link.scope}|{link.created_at}|{link.expires_at}|{link.signed_by_user}|{link.session_id}"
     expected_sig = _sign(raw)
 
     return hmac.compare_digest(link.signature, expected_sig)
@@ -51,8 +73,23 @@ def verify_trust_link(link: TrustLink) -> bool:
 # ========== Scope Validator ==========
 
 
-def is_trusted_for_scope(link: TrustLink, required_scope: ConsentScope) -> bool:
-    return link.scope == required_scope and verify_trust_link(link)
+def is_trusted_for_scope(
+    link: TrustLink,
+    required_scope: ConsentScope,
+    expected_session_id: str | None = None,
+) -> bool:
+    """Return True when the link covers ``required_scope`` and passes verification.
+
+    Args:
+        link: The TrustLink to check.
+        required_scope: The scope that must be present on the link.
+        expected_session_id: Forwarded to ``verify_trust_link``; see its
+            docstring for semantics. Pass the server-derived session context
+            on session-bound surfaces.
+    """
+    return link.scope == required_scope and verify_trust_link(
+        link, expected_session_id=expected_session_id
+    )
 
 
 # ========== Internal Signer ==========

--- a/consent-protocol/hushh_mcp/types.py
+++ b/consent-protocol/hushh_mcp/types.py
@@ -37,6 +37,7 @@ class TrustLink(BaseModel):
     expires_at: int
     signed_by_user: UserID
     signature: str
+    session_id: str = ""
 
 
 # ==================== Vault Structures ====================

--- a/consent-protocol/mcp_modules/tools/definitions.py
+++ b/consent-protocol/mcp_modules/tools/definitions.py
@@ -363,6 +363,14 @@ def get_tool_definitions(allowed_tool_names: set[str] | None = None) -> list[Too
                             "Examples: United States, USA, UK."
                         ),
                     },
+                    "session_id": {
+                        "type": "string",
+                        "description": (
+                            "Optional session identifier for the current connection. "
+                            "When provided, the TrustLink HMAC is bound to this session, "
+                            "preventing replay across different streams."
+                        ),
+                    },
                 },
                 "required": ["from_agent", "to_agent", "scope", "user_id"],
             },

--- a/consent-protocol/mcp_modules/tools/utility_tools.py
+++ b/consent-protocol/mcp_modules/tools/utility_tools.py
@@ -111,16 +111,43 @@ async def handle_delegate(args: dict) -> list[TextContent]:
     # Parse scope using centralized resolver
     scope = resolve_scope_to_enum(scope_str)
 
+    session_id = str(args.get("session_id") or "").strip()
+
+    # Fail closed: delegation without a session context cannot provide replay
+    # protection. An empty session_id means any captured TrustLink could be
+    # accepted on any subsequent session, so we reject the request outright.
+    if not session_id:
+        return [
+            TextContent(
+                type="text",
+                text=json.dumps(
+                    {
+                        "error": (
+                            "session_id is required for session-bound TrustLink delegation. "
+                            "Provide the current debate or consent session identifier."
+                        ),
+                        "code": "SESSION_ID_REQUIRED",
+                        "status": "rejected",
+                    }
+                ),
+            )
+        ]
+
     # Create TrustLink
     trust_link = create_trust_link(
         from_agent=AgentID(from_agent),
         to_agent=AgentID(to_agent),
         scope=scope,
         signed_by_user=UserID(user_id),
+        session_id=session_id,
     )
 
-    # Verify the TrustLink
-    is_valid = verify_trust_link(trust_link)
+    # Verify against the current server session context. Supplying
+    # expected_session_id means the sanity check enforces session binding in
+    # addition to HMAC integrity. Every session-bound verification site must
+    # supply the server-derived session context here; never omit it and rely
+    # on the None-bypass default.
+    is_valid = verify_trust_link(trust_link, expected_session_id=session_id)
 
     logger.info(f"🔗 TrustLink CREATED: {from_agent} → {to_agent} (scope={scope_str})")
 

--- a/consent-protocol/tests/test_delegate_trust_link_callsite_session_binding.py
+++ b/consent-protocol/tests/test_delegate_trust_link_callsite_session_binding.py
@@ -1,0 +1,230 @@
+# tests/test_delegate_trust_link_callsite_session_binding.py
+"""
+Callsite-level proof that the delegate_to_agent production handler enforces
+TrustLink session binding.
+
+# Scope
+The library-level properties (HMAC integrity, expected_session_id comparison)
+are verified by test_trust_link_session_binding.py. This file targets the
+production handler (handle_delegate in mcp_modules/tools/utility_tools.py) and
+proves two additional properties required by the reviewer:
+
+1. Fail-closed on missing session_id: the handler rejects delegation requests
+   that carry no session context, because without session binding any captured
+   TrustLink becomes replayable across future sessions.
+
+2. Server-side session enforcement at the verify callsite: the handler passes
+   expected_session_id from the current server session context to
+   verify_trust_link, so the sanity-check is also session-bound. A TrustLink
+   whose embedded session_id differs from the active session context fails
+   verification even though its HMAC is intact (cross-session replay rejected).
+
+# Why callsite tests matter
+The library correctly accepts expected_session_id, but callers can bypass the
+protection by omitting the parameter (defaulting to None). These tests prove
+that the production callsite never takes that bypass path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import patch
+
+import pytest
+
+from hushh_mcp.trust.link import create_trust_link, verify_trust_link
+from mcp_modules.tools.utility_tools import handle_delegate
+
+# ==========================================
+# Constants
+# ==========================================
+
+_FROM = "agent.orchestrator"
+_TO = "agent.kai"
+_SCOPE_STR = "pkm.read"
+_USER = "user_test_delegate"
+_SESSION_A = "session_abc_111"
+_SESSION_B = "session_xyz_999"
+
+_BASE_ARGS = {
+    "from_agent": _FROM,
+    "to_agent": _TO,
+    "scope": _SCOPE_STR,
+    "user_id": _USER,
+}
+
+
+# ==========================================
+# Helpers
+# ==========================================
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _parse_result(result: list) -> dict:
+    assert len(result) == 1
+    return json.loads(result[0].text)
+
+
+# ==========================================
+# 1. Fail-closed: missing session_id is rejected
+# ==========================================
+
+class TestDelegateFailsClosedWithoutSessionId:
+
+    def test_missing_session_id_returns_error(self) -> None:
+        """Omitting session_id must return SESSION_ID_REQUIRED, not a TrustLink."""
+        args = {**_BASE_ARGS}  # no session_id key
+        result = _run(handle_delegate(args))
+        body = _parse_result(result)
+        assert body.get("code") == "SESSION_ID_REQUIRED"
+        assert body.get("status") == "rejected"
+        assert "trust_link" not in body
+
+    def test_empty_session_id_returns_error(self) -> None:
+        """An explicit empty-string session_id must also be rejected."""
+        args = {**_BASE_ARGS, "session_id": ""}
+        result = _run(handle_delegate(args))
+        body = _parse_result(result)
+        assert body.get("code") == "SESSION_ID_REQUIRED"
+        assert body.get("status") == "rejected"
+        assert "trust_link" not in body
+
+    def test_whitespace_only_session_id_returns_error(self) -> None:
+        """A whitespace-only session_id (after stripping) must be rejected."""
+        args = {**_BASE_ARGS, "session_id": "   "}
+        result = _run(handle_delegate(args))
+        body = _parse_result(result)
+        assert body.get("code") == "SESSION_ID_REQUIRED"
+        assert body.get("status") == "rejected"
+
+
+# ==========================================
+# 2. Happy path: valid session_id produces a verified TrustLink
+# ==========================================
+
+class TestDelegateSucceedsWithSessionId:
+
+    def test_valid_session_id_returns_delegated_status(self) -> None:
+        """A non-empty session_id must produce a delegated TrustLink response."""
+        args = {**_BASE_ARGS, "session_id": _SESSION_A}
+        result = _run(handle_delegate(args))
+        body = _parse_result(result)
+        assert body.get("status") == "delegated"
+        assert "trust_link" in body
+
+    def test_valid_session_id_produces_verified_signature(self) -> None:
+        """signature_verified must be True: the callsite verifies against its own session."""
+        args = {**_BASE_ARGS, "session_id": _SESSION_A}
+        result = _run(handle_delegate(args))
+        body = _parse_result(result)
+        assert body["trust_link"]["signature_verified"] is True
+
+
+# ==========================================
+# 3. Callsite wires expected_session_id: verify is called with server context
+# ==========================================
+
+class TestDelegateCallsiteWiresExpectedSessionId:
+
+    def test_verify_trust_link_called_with_expected_session_id(self) -> None:
+        """
+        The handler must call verify_trust_link(..., expected_session_id=session_id).
+
+        We intercept verify_trust_link to confirm it receives the expected keyword
+        argument.  The spy wraps the real function so behaviour is unchanged.
+        """
+        captured_kwargs: list[dict] = []
+
+        real_verify = verify_trust_link
+
+        def _spy_verify(link, expected_session_id=None):
+            captured_kwargs.append({"expected_session_id": expected_session_id})
+            return real_verify(link, expected_session_id=expected_session_id)
+
+        args = {**_BASE_ARGS, "session_id": _SESSION_A}
+        with patch("mcp_modules.tools.utility_tools.verify_trust_link", side_effect=_spy_verify):
+            _run(handle_delegate(args))
+
+        assert len(captured_kwargs) == 1, "verify_trust_link should be called exactly once"
+        assert captured_kwargs[0]["expected_session_id"] == _SESSION_A, (
+            f"expected_session_id was not wired from server session context; "
+            f"got: {captured_kwargs[0]['expected_session_id']!r}"
+        )
+
+
+# ==========================================
+# 4. Cross-session replay is rejected at the receiving-agent verify step
+#
+# This section proves the end-to-end replay scenario:
+#   - Agent creates a TrustLink bound to session_A (via handle_delegate or
+#     create_trust_link directly)
+#   - A receiving agent in session_B verifies the link with its own session
+#     context (expected_session_id=session_B)
+#   - The link is rejected even though its HMAC is still valid
+#
+# The session context at the verify callsite comes from the SERVER, not from
+# the incoming TrustLink; so an attacker cannot bypass this by replaying the
+# original session_id.
+# ==========================================
+
+class TestCrossSessionReplayRejectedAtReceivingCallsite:
+
+    def _make_session_a_link(self):
+        """Simulate what handle_delegate produces for session_A."""
+        from hushh_mcp.constants import ConsentScope
+        from hushh_mcp.types import AgentID, UserID
+        return create_trust_link(
+            AgentID(_FROM),
+            AgentID(_TO),
+            ConsentScope.PKM_READ,
+            UserID(_USER),
+            session_id=_SESSION_A,
+        )
+
+    def test_session_a_link_passes_own_session_verify(self) -> None:
+        """Sanity: a session_A link is valid when verified with session_A context."""
+        link = self._make_session_a_link()
+        assert verify_trust_link(link, expected_session_id=_SESSION_A) is True
+
+    def test_session_a_link_rejected_when_receiving_agent_is_in_session_b(self) -> None:
+        """
+        Core replay proof: receiving agent in session_B uses its own session
+        context as expected_session_id.  The captured session_A link is rejected
+        even though the HMAC is intact.
+        """
+        link = self._make_session_a_link()
+        # HMAC is still valid; tamper detection alone would pass this link.
+        assert verify_trust_link(link) is True
+
+        # Receiving agent supplies ITS server-derived session, not the link's.
+        assert verify_trust_link(link, expected_session_id=_SESSION_B) is False, (
+            "Cross-session replay was accepted: server must pass expected_session_id "
+            "from its own session context, not from the TrustLink."
+        )
+
+    def test_attacker_cannot_bypass_by_supplying_original_session_id(self) -> None:
+        """
+        If the RECEIVING server derives expected_session_id from its own state
+        (not from the incoming link), the attacker cannot replay by matching
+        session_A context in a session_B environment.
+
+        Simulated here: server_derived_session is independently set to session_B;
+        the attacker-supplied link carries session_A.  Verification fails.
+        """
+        link = self._make_session_a_link()
+
+        # This is what the receiving server knows from its own state.
+        server_derived_session = _SESSION_B
+
+        # Even though the attacker knows link.session_id == _SESSION_A, the
+        # server does NOT use link.session_id as expected_session_id.
+        assert (
+            verify_trust_link(link, expected_session_id=server_derived_session) is False
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/consent-protocol/tests/test_trust_link_session_binding.py
+++ b/consent-protocol/tests/test_trust_link_session_binding.py
@@ -1,0 +1,196 @@
+"""
+TrustLink session-binding tests.
+
+Verifies two properties:
+
+1. session_id is included in the HMAC input, so altering session_id on a
+   captured link breaks the signature.
+
+2. verify_trust_link and is_trusted_for_scope accept an expected_session_id
+   from the server, so a legitimately signed TrustLink (valid signature, valid
+   session_id) cannot be replayed in a different active session, even though
+   its own HMAC is still intact.
+
+Issue: #1426
+"""
+
+from __future__ import annotations
+
+from hushh_mcp.constants import ConsentScope
+from hushh_mcp.trust.link import create_trust_link, is_trusted_for_scope, verify_trust_link
+from hushh_mcp.types import TrustLink
+
+_USER = "user_test"
+_FROM = "agent_orchestrator"
+_TO = "agent_food"
+_SCOPE = ConsentScope.PKM_READ
+_SESSION_A = "sse_session_abc123"
+_SESSION_B = "sse_session_xyz789"
+
+
+# ===========================================================================
+# Backward compatibility: empty session_id still round-trips correctly
+# ===========================================================================
+
+
+def test_no_session_id_round_trips() -> None:
+    link = create_trust_link(_FROM, _TO, _SCOPE, _USER)
+    assert link.session_id == ""
+    assert verify_trust_link(link) is True
+
+
+def test_no_session_id_scope_check_passes() -> None:
+    link = create_trust_link(_FROM, _TO, _SCOPE, _USER)
+    assert is_trusted_for_scope(link, _SCOPE) is True
+
+
+# ===========================================================================
+# Session binding (HMAC integrity): altered session_id breaks signature
+# ===========================================================================
+
+
+def test_session_id_round_trips() -> None:
+    link = create_trust_link(_FROM, _TO, _SCOPE, _USER, session_id=_SESSION_A)
+    assert link.session_id == _SESSION_A
+    assert verify_trust_link(link) is True
+
+
+def test_different_session_id_fails_verification() -> None:
+    """Mutating session_id breaks the HMAC: tamper-detection."""
+    link = create_trust_link(_FROM, _TO, _SCOPE, _USER, session_id=_SESSION_A)
+    replayed = link.model_copy(update={"session_id": _SESSION_B})
+    assert verify_trust_link(replayed) is False
+
+
+def test_empty_session_id_fails_against_bound_link() -> None:
+    """Stripping session_id also breaks the HMAC."""
+    link = create_trust_link(_FROM, _TO, _SCOPE, _USER, session_id=_SESSION_A)
+    stripped = link.model_copy(update={"session_id": ""})
+    assert verify_trust_link(stripped) is False
+
+
+def test_session_bound_link_fails_when_session_stripped_via_scope_check() -> None:
+    link = create_trust_link(_FROM, _TO, _SCOPE, _USER, session_id=_SESSION_A)
+    assert is_trusted_for_scope(link.model_copy(update={"session_id": _SESSION_B}), _SCOPE) is False
+
+
+# ===========================================================================
+# Cross-session replay: valid HMAC, but wrong active session (the real attack)
+#
+# These tests cover the vulnerability the reviewer flagged: an adversary who
+# captures a legitimate TrustLink for session A (valid signature, valid
+# session_id) and attempts to use it on a server that is now in session B.
+# The HMAC is still intact, so tamper-detection alone would let it pass.
+# Only the expected_session_id comparison stops the replay.
+# ===========================================================================
+
+
+def test_cross_session_replay_rejected_by_expected_session_id() -> None:
+    """Full cross-session replay with intact HMAC must fail when server passes expected_session_id."""
+    # Attacker captures this link during session A; signature is valid.
+    link_session_a = create_trust_link(_FROM, _TO, _SCOPE, _USER, session_id=_SESSION_A)
+    assert verify_trust_link(link_session_a) is True  # HMAC is intact
+
+    # Server is now running session B and passes expected_session_id=_SESSION_B.
+    # The link is valid in isolation but must be rejected.
+    assert verify_trust_link(link_session_a, expected_session_id=_SESSION_B) is False
+
+
+def test_cross_session_replay_rejected_via_scope_check() -> None:
+    """is_trusted_for_scope propagates expected_session_id and rejects cross-session replay."""
+    link_session_a = create_trust_link(_FROM, _TO, _SCOPE, _USER, session_id=_SESSION_A)
+    assert is_trusted_for_scope(link_session_a, _SCOPE) is True  # passes without context
+
+    # Session B rejects the same link.
+    assert (
+        is_trusted_for_scope(link_session_a, _SCOPE, expected_session_id=_SESSION_B) is False
+    )
+
+
+def test_same_session_verify_succeeds_with_expected_session_id() -> None:
+    """Providing the correct expected_session_id does not break legitimate verification."""
+    link = create_trust_link(_FROM, _TO, _SCOPE, _USER, session_id=_SESSION_A)
+    assert verify_trust_link(link, expected_session_id=_SESSION_A) is True
+
+
+def test_same_session_scope_check_succeeds_with_expected_session_id() -> None:
+    link = create_trust_link(_FROM, _TO, _SCOPE, _USER, session_id=_SESSION_A)
+    assert is_trusted_for_scope(link, _SCOPE, expected_session_id=_SESSION_A) is True
+
+
+def test_none_expected_session_id_bypasses_check_for_unbound_surfaces() -> None:
+    """Passing None skips the session check: backward-compatible default."""
+    link = create_trust_link(_FROM, _TO, _SCOPE, _USER, session_id=_SESSION_A)
+    assert verify_trust_link(link, expected_session_id=None) is True
+
+
+def test_empty_expected_session_id_rejects_session_bound_link() -> None:
+    """Passing an empty string as expected_session_id rejects a session-bound link."""
+    link = create_trust_link(_FROM, _TO, _SCOPE, _USER, session_id=_SESSION_A)
+    assert verify_trust_link(link, expected_session_id="") is False
+
+
+def test_unbound_link_accepted_when_expected_matches_empty() -> None:
+    """An unbound link (session_id='') passes when the server also expects ''."""
+    link = create_trust_link(_FROM, _TO, _SCOPE, _USER)
+    assert verify_trust_link(link, expected_session_id="") is True
+
+
+# ===========================================================================
+# HMAC uniqueness: same fields, different session_id -> different signature
+# ===========================================================================
+
+
+def test_different_sessions_produce_different_signatures() -> None:
+    link_a = create_trust_link(_FROM, _TO, _SCOPE, _USER, session_id=_SESSION_A)
+    link_b = create_trust_link(_FROM, _TO, _SCOPE, _USER, session_id=_SESSION_B)
+    assert link_a.signature != link_b.signature
+
+
+def test_session_id_vs_no_session_id_produce_different_signatures() -> None:
+    link_bound = create_trust_link(_FROM, _TO, _SCOPE, _USER, session_id=_SESSION_A)
+    link_unbound = create_trust_link(_FROM, _TO, _SCOPE, _USER)
+    assert link_bound.signature != link_unbound.signature
+
+
+# ===========================================================================
+# Existing expiry and tampering tests remain unaffected
+# ===========================================================================
+
+
+def test_expired_link_still_fails() -> None:
+    expired = create_trust_link(
+        _FROM, _TO, _SCOPE, _USER, expires_in_ms=-1000, session_id=_SESSION_A
+    )
+    assert verify_trust_link(expired) is False
+
+
+def test_expired_link_fails_even_with_matching_session() -> None:
+    """Expiry check runs before session check: expired link always rejected."""
+    expired = create_trust_link(
+        _FROM, _TO, _SCOPE, _USER, expires_in_ms=-1000, session_id=_SESSION_A
+    )
+    assert verify_trust_link(expired, expected_session_id=_SESSION_A) is False
+
+
+def test_signature_tampering_still_fails() -> None:
+    link = create_trust_link(_FROM, _TO, _SCOPE, _USER, session_id=_SESSION_A)
+    tampered = link.model_copy(update={"signature": "bad_signature_here"})
+    assert verify_trust_link(tampered) is False
+
+
+# ===========================================================================
+# TrustLink model carries session_id
+# ===========================================================================
+
+
+def test_trust_link_model_stores_session_id() -> None:
+    link = create_trust_link(_FROM, _TO, _SCOPE, _USER, session_id=_SESSION_A)
+    assert isinstance(link, TrustLink)
+    assert link.session_id == _SESSION_A
+
+
+def test_trust_link_model_default_session_id_is_empty() -> None:
+    link = create_trust_link(_FROM, _TO, _SCOPE, _USER)
+    assert isinstance(link, TrustLink)
+    assert link.session_id == ""


### PR DESCRIPTION
## Problem

TrustLink HMAC signatures had no session binding. A captured TrustLink (valid signature, unexpired) could be replayed against a different session than the one it was issued for.

## Fix

`create_trust_link` and `verify_trust_link` (`hushh_mcp/trust/link.py`) now take an optional `session_id`, folded into the signed payload. `verify_trust_link` and `is_trusted_for_scope` accept `expected_session_id` and reject the link if it does not match the embedded `session_id`. Defaults preserve backward compatibility: empty `session_id` plus `None` `expected_session_id` bypasses the check for unbound surfaces.

`handle_delegate` in `mcp_modules/tools/utility_tools.py` is the production call site: it now requires a non-empty `session_id` and fails closed (`SESSION_ID_REQUIRED`) when absent, then verifies with `expected_session_id=session_id`. Added the `session_id` field to the delegate tool's MCP schema in `definitions.py`.

## Tests

`tests/test_trust_link_session_binding.py` (20 tests) and `tests/test_delegate_trust_link_callsite_session_binding.py` (9 tests): round-trip with and without session binding, cross-session replay rejection, signature tampering, expiry interaction, and the real `handle_delegate` call site's fail-closed behavior.

## Note on this revision

This commit was rebuilt clean on current `integration/pr-train`. The previous branch had drifted onto a months-stale snapshot, and its diff had picked up dozens of unrelated reverted fixes: re-widening already-fixed CWE-400 bounds across several `kai` routes, reverting a documented token-issuance-ordering security fix in `consent.py`'s `approve_consent`, widening consent expiry from 30 to 365 days, reverting CWE-209 opaque-message fixes back to raw scope strings in error responses, reverting G004 logging fixes, and introducing an unreachable duplicate `return` in `RIAIAMService._next_action_for_relationship_status` (the test that would have caught it had also been deleted by the same stale diff). None of that belongs in this PR. This commit contains only the TrustLink session-binding surface: `link.py`, `types.py`, `utility_tools.py`, `definitions.py`, and the two new test files.