### PR TITLE
[codex] Improve Agent chat and PKM memory cards

### DIFF
--- a/consent-protocol/api/routes/kai/stream.py
+++ b/consent-protocol/api/routes/kai/stream.py
@@ -59,7 +59,7 @@ _RUN_MANAGER = KaiAnalyzeRunManager()
 #   POST /api/kai/analyze/run/{run_id}/cancel
 # ---------------------------------------------------------------------------
 _USER_ID_MAX_LEN: int = 128
-_TICKER_RAW_MAX_LEN: int = 20   # regex further constrains to <=6 after normalization
+_TICKER_RAW_MAX_LEN: int = 20  # regex further constrains to <=6 after normalization
 _RISK_PROFILE_MAX_LEN: int = 64
 _DEBATE_SESSION_ID_MAX_LEN: int = 256
 _RUN_ID_MAX_LEN: int = 128

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -1149,8 +1149,9 @@ class OneLocationAgentService:
         visitor_phone_hash: str,
         submitter_fingerprint_hash: str | None,
     ) -> None:
-        row = self._execute_one(
-            """
+        row = (
+            self._execute_one(
+                """
             SELECT
               COUNT(*)::int AS total_submissions,
               COUNT(*) FILTER (
@@ -1168,14 +1169,16 @@ class OneLocationAgentService:
             FROM one_location_public_invite_submissions
             WHERE invite_id = CAST(:invite_id AS UUID)
             """,
-            {
-                "invite_id": invite_id,
-                "visitor_phone_hash": visitor_phone_hash,
-                "submitter_fingerprint_hash": submitter_fingerprint_hash,
-                "phone_window_minutes": PUBLIC_INVITE_PHONE_THROTTLE_MINUTES,
-                "fingerprint_window_minutes": PUBLIC_INVITE_FINGERPRINT_THROTTLE_MINUTES,
-            },
-        ) or {}
+                {
+                    "invite_id": invite_id,
+                    "visitor_phone_hash": visitor_phone_hash,
+                    "submitter_fingerprint_hash": submitter_fingerprint_hash,
+                    "phone_window_minutes": PUBLIC_INVITE_PHONE_THROTTLE_MINUTES,
+                    "fingerprint_window_minutes": PUBLIC_INVITE_FINGERPRINT_THROTTLE_MINUTES,
+                },
+            )
+            or {}
+        )
         total_submissions = int(row.get("total_submissions") or 0)
         phone_submissions = int(row.get("phone_submissions") or 0)
         recent_phone_submissions = int(row.get("recent_phone_submissions") or 0)

--- a/hushh-webapp/__tests__/lib/pkm-memory-cards.test.ts
+++ b/hushh-webapp/__tests__/lib/pkm-memory-cards.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPkmMemorySnapshot,
+  deletePkmDomainValue,
+  selectRelevantPkmMemoryCards,
+  updatePkmDomainValue,
+} from "@/lib/pkm/pkm-memory-cards";
+import type { PersonalKnowledgeModelMetadata } from "@/lib/services/personal-knowledge-model-service";
+
+const metadata: PersonalKnowledgeModelMetadata = {
+  userId: "user-1",
+  domains: [
+    {
+      key: "professional",
+      displayName: "Professional",
+      icon: "briefcase",
+      color: "#38bdf8",
+      attributeCount: 3,
+      summary: {},
+      availableScopes: ["attr.professional.*"],
+      lastUpdated: "2026-05-20T12:00:00Z",
+      readableSummary: null,
+      readableHighlights: [],
+      readableUpdatedAt: null,
+      readableSourceLabel: "Saved memory",
+      domainContractVersion: 1,
+      readableSummaryVersion: 1,
+      upgradedAt: null,
+    },
+  ],
+  totalAttributes: 3,
+  modelCompleteness: 20,
+  modelVersion: 4,
+  storedModelVersion: 4,
+  effectiveModelVersion: 4,
+  targetModelVersion: 4,
+  upgradeStatus: "current",
+  upgradableDomains: [],
+  lastUpgradedAt: null,
+  suggestedDomains: [],
+  lastUpdated: "2026-05-20T12:00:00Z",
+};
+
+describe("PKM memory cards", () => {
+  it("derives readable memory cards from decrypted PKM", () => {
+    const snapshot = buildPkmMemorySnapshot({
+      metadata,
+      fullBlob: {
+        professional: {
+          profile: {
+            name: "Akshat Kumar",
+            roll_no: "22b4513",
+            university: "IIT Bombay",
+          },
+        },
+      },
+    });
+
+    expect(snapshot.cards.map((card) => card.title)).toEqual(
+      expect.arrayContaining([
+        "Your name is Akshat Kumar",
+        "Roll number: 22b4513",
+        "You study at IIT Bombay",
+      ])
+    );
+    expect(snapshot.domainInsights[0]?.summary).toContain("education");
+  });
+
+  it("selects prompt-relevant cards for Agent context", () => {
+    const snapshot = buildPkmMemorySnapshot({
+      metadata,
+      fullBlob: {
+        professional: {
+          profile: {
+            name: "Akshat Kumar",
+            university: "IIT Bombay",
+          },
+        },
+      },
+    });
+
+    const relevant = selectRelevantPkmMemoryCards(snapshot.cards, "where do I study", 2);
+
+    expect(relevant[0]?.title).toBe("You study at IIT Bombay");
+  });
+
+  it("updates and deletes card values by path without mutating the source object", () => {
+    const domainData = {
+      profile: {
+        name: "Akshat Kumar",
+        roll_no: "22b4513",
+      },
+    };
+
+    const updated = updatePkmDomainValue({
+      domainData,
+      pathSegments: ["profile", "name"],
+      previousValue: "Akshat Kumar",
+      nextValue: "Akshat K.",
+    });
+    const deleted = deletePkmDomainValue({
+      domainData,
+      pathSegments: ["profile", "roll_no"],
+    });
+
+    expect((updated.profile as Record<string, unknown>).name).toBe("Akshat K.");
+    expect((domainData.profile as Record<string, unknown>).name).toBe("Akshat Kumar");
+    expect((deleted.profile as Record<string, unknown>).roll_no).toBeUndefined();
+  });
+});

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -13,9 +13,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
   Bot,
   BriefcaseBusiness,
-  Bug,
   ChevronDown,
-  Copy,
   Mic,
   MicOff,
   Send,
@@ -379,56 +377,6 @@ function AgentBubble({ message }: { message: AgentMessage }) {
   );
 }
 
-function AgentDebugPanel({
-  events,
-  onCopyLatest,
-}: {
-  events: AgentDebugEvent[];
-  onCopyLatest: () => void;
-}) {
-  return (
-    <div className="rounded-lg border border-border/70 bg-background/80 p-3 text-xs">
-      <div className="mb-2 flex items-center justify-between gap-3">
-        <div className="font-medium text-foreground">Tool debug</div>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="h-8 gap-2"
-          onClick={onCopyLatest}
-          disabled={events.length === 0}
-        >
-          <Copy className="h-3.5 w-3.5" />
-          Copy debug
-        </Button>
-      </div>
-      {events.length === 0 ? (
-        <p className="text-muted-foreground">No tool calls for the latest turn.</p>
-      ) : (
-        <div className="max-h-64 space-y-2 overflow-y-auto">
-          {events.map((event) => (
-            <div key={event.id} className="rounded-md border border-border/60 bg-card p-2">
-              <div className="mb-1 flex items-center justify-between gap-3">
-                <span className="font-medium text-foreground">{event.event}</span>
-                <span className="text-muted-foreground">
-                  {new Intl.DateTimeFormat(undefined, {
-                    hour: "numeric",
-                    minute: "2-digit",
-                    second: "2-digit",
-                  }).format(new Date(event.timestamp))}
-                </span>
-              </div>
-              <pre className="max-h-36 overflow-auto whitespace-pre-wrap break-words rounded-md bg-muted/50 p-2 font-mono text-[11px] leading-4 text-muted-foreground">
-                {JSON.stringify(event.payload, null, 2)}
-              </pre>
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
 function AgentPkmActivityLine({ item }: { item: AgentPkmActivity }) {
   return (
     <div
@@ -515,9 +463,6 @@ export function AgentChatWorkspace({
   const [isStreaming, setIsStreaming] = useState(false);
   const [activeFrontendToolCount, setActiveFrontendToolCount] = useState(0);
   const [activePkmToolCount, setActivePkmToolCount] = useState(0);
-  const [debugOpen, setDebugOpen] = useState(false);
-  const [debugEvents, setDebugEvents] = useState<AgentDebugEvent[]>([]);
-  const [latestDebugTurnId, setLatestDebugTurnId] = useState<string | null>(null);
   const [pkmReviews, setPkmReviews] = useState<AgentPkmReview[]>([]);
   const [pkmActivity, setPkmActivity] = useState<AgentPkmActivity[]>([]);
   const [voiceState, setVoiceState] = useState<AgentRealtimeVoiceState>("idle");
@@ -785,8 +730,6 @@ export function AgentChatWorkspace({
     setIsStreaming(false);
     setActiveFrontendToolCount(0);
     setActivePkmToolCount(0);
-    setDebugEvents([]);
-    setLatestDebugTurnId(null);
     setPkmReviews([]);
     setPkmActivity([]);
     setVoiceState("idle");
@@ -814,40 +757,11 @@ export function AgentChatWorkspace({
   };
 
   const appendDebugEvent = useCallback(
-    (turnId: string, event: string, payload: unknown) => {
-      setDebugEvents((current) => [
-        ...current.slice(-79),
-        {
-          id: `${turnId}-${event}-${Date.now()}-${current.length}`,
-          turnId,
-          timestamp: new Date().toISOString(),
-          event,
-          payload,
-        },
-      ]);
+    (_turnId: string, _event: AgentDebugEvent["event"], _payload: AgentDebugEvent["payload"]) => {
+      // Debug events are intentionally kept internal while the Agent debug UI is disabled.
     },
     []
   );
-
-  const latestDebugEvents = useMemo(
-    () =>
-      latestDebugTurnId
-        ? debugEvents.filter((event) => event.turnId === latestDebugTurnId)
-        : [],
-    [debugEvents, latestDebugTurnId]
-  );
-
-  const handleCopyLatestDebug = useCallback(() => {
-    if (!latestDebugTurnId || latestDebugEvents.length === 0) return;
-    const payload = {
-      turn_id: latestDebugTurnId,
-      events: latestDebugEvents,
-    };
-    void navigator.clipboard
-      .writeText(JSON.stringify(payload, null, 2))
-      .then(() => toast.success("Agent debug copied."))
-      .catch(() => toast.error("Could not copy Agent debug."));
-  }, [latestDebugEvents, latestDebugTurnId]);
 
   const addErrorMessage = (text: string) => {
     appendMessage({
@@ -924,8 +838,6 @@ export function AgentChatWorkspace({
       setConversationId(nextConversationId);
       setMessages(restored.length > 0 ? restored : [createGreetingMessage()]);
       setPkmActivity([]);
-      setDebugEvents([]);
-      setLatestDebugTurnId(null);
       setPkmReviews([]);
     },
     []
@@ -950,8 +862,6 @@ export function AgentChatWorkspace({
     setConversationId(null);
     setMessages([createGreetingMessage()]);
     setInput("");
-    setDebugEvents([]);
-    setLatestDebugTurnId(null);
     setPkmReviews([]);
     setPkmActivity([]);
   }, [abortAgentTurnWork]);
@@ -1616,7 +1526,6 @@ export function AgentChatWorkspace({
     setPkmActivity([]);
     setIsChatLoading(true);
     setIsStreaming(true);
-    setLatestDebugTurnId(debugTurnId);
 
     if (!token) {
       updateMessage(assistantMessageId, (message) => ({
@@ -1919,7 +1828,7 @@ export function AgentChatWorkspace({
           </div>
           <div className="min-w-0">
             <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-primary">
-              Agent
+              Kai
             </p>
             <h1
               className={cn(
@@ -1941,18 +1850,6 @@ export function AgentChatWorkspace({
         </div>
 
         <div className="flex shrink-0 items-center gap-2">
-          <Button
-            type="button"
-            variant={debugOpen ? "secondary" : "outline"}
-            size="icon"
-            className="h-9 w-9"
-            onClick={() => setDebugOpen((current) => !current)}
-            aria-label={debugOpen ? "Hide Agent debug" : "Show Agent debug"}
-            aria-pressed={debugOpen}
-            title={debugOpen ? "Hide Agent debug" : "Show Agent debug"}
-          >
-            <Bug className="h-4 w-4" />
-          </Button>
           <span className="hidden rounded-md border border-border/70 bg-background px-3 py-1.5 text-xs font-medium text-muted-foreground sm:inline-flex">
             {statusText}
           </span>
@@ -2004,13 +1901,6 @@ export function AgentChatWorkspace({
               <div className="rounded-lg border border-border/70 bg-background px-4 py-5 text-sm text-muted-foreground">
                 {accessMessage}
               </div>
-            ) : null}
-
-            {debugOpen ? (
-              <AgentDebugPanel
-                events={latestDebugEvents}
-                onCopyLatest={handleCopyLatestDebug}
-              />
             ) : null}
 
             {messages.map((message) => (

--- a/hushh-webapp/components/profile/pkm-natural-panel.tsx
+++ b/hushh-webapp/components/profile/pkm-natural-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { Loader2, Lock, RefreshCw, ShieldAlert, Sparkles, Users } from "lucide-react";
+import { Check, Edit3, Loader2, Lock, RefreshCw, ShieldAlert, Sparkles, Trash2, Users, X } from "lucide-react";
 
 import {
   SurfaceCard,
@@ -13,6 +13,18 @@ import {
 } from "@/components/app-ui/surfaces";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Input } from "@/components/ui/input";
 import { useAuth } from "@/hooks/use-auth";
 import {
   ConsentCenterService,
@@ -29,6 +41,14 @@ import {
   buildNaturalDomainPresentation,
   type NaturalAccessEntry,
 } from "@/lib/personal-knowledge-model/natural-language";
+import {
+  buildPkmMemorySnapshot,
+  deletePkmDomainValue,
+  updatePkmDomainValue,
+  type PkmMemoryCard,
+} from "@/lib/pkm/pkm-memory-cards";
+import { clearAgentPkmContext } from "@/lib/agent/agent-pkm-memory";
+import { PkmWriteCoordinator } from "@/lib/services/pkm-write-coordinator";
 import { useVault } from "@/lib/vault/vault-context";
 
 function formatTimestamp(value: string | null | undefined): string {
@@ -64,14 +84,20 @@ export function PkmNaturalPanel({
   onOpenExplorer,
 }: PkmNaturalPanelProps) {
   const { user, loading } = useAuth();
-  const { isVaultUnlocked, vaultOwnerToken } = useVault();
+  const { isVaultUnlocked, vaultKey, vaultOwnerToken } = useVault();
 
   const [metadata, setMetadata] = useState<PersonalKnowledgeModelMetadata | null>(null);
+  const [fullBlob, setFullBlob] = useState<Record<string, unknown>>({});
   const [manifests, setManifests] = useState<Record<string, DomainManifest | null>>({});
   const [activeGrants, setActiveGrants] = useState<ConsentCenterEntry[]>([]);
   const [bootstrapLoading, setBootstrapLoading] = useState(true);
   const [bootstrapError, setBootstrapError] = useState<string | null>(null);
   const [refreshNonce, setRefreshNonce] = useState(0);
+  const [editingCardId, setEditingCardId] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState("");
+  const [memoryActionId, setMemoryActionId] = useState<string | null>(null);
+  const [memoryActionMessage, setMemoryActionMessage] = useState<string | null>(null);
+  const [memoryActionError, setMemoryActionError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -81,6 +107,7 @@ export function PkmNaturalPanel({
       if (!user) {
         if (!cancelled) {
           setMetadata(null);
+          setFullBlob({});
           setManifests({});
           setActiveGrants([]);
           setBootstrapLoading(false);
@@ -88,9 +115,10 @@ export function PkmNaturalPanel({
         }
         return;
       }
-      if (!isVaultUnlocked || !vaultOwnerToken) {
+      if (!isVaultUnlocked || !vaultOwnerToken || !vaultKey) {
         if (!cancelled) {
           setMetadata(null);
+          setFullBlob({});
           setManifests({});
           setActiveGrants([]);
           setBootstrapLoading(false);
@@ -126,9 +154,15 @@ export function PkmNaturalPanel({
           view: "active",
           force,
         }).catch(() => null);
+        const nextFullBlob = await PersonalKnowledgeModelService.loadFullBlob({
+          userId: user.uid,
+          vaultKey,
+          vaultOwnerToken,
+        });
 
         if (cancelled) return;
         setMetadata(nextMetadata);
+        setFullBlob(nextFullBlob);
         setManifests(Object.fromEntries(manifestPairs));
         setActiveGrants(center?.active_grants || []);
       } catch (nextError) {
@@ -148,7 +182,21 @@ export function PkmNaturalPanel({
     return () => {
       cancelled = true;
     };
-  }, [isVaultUnlocked, loading, refreshNonce, refreshToken, user, vaultOwnerToken]);
+  }, [isVaultUnlocked, loading, refreshNonce, refreshToken, user, vaultKey, vaultOwnerToken]);
+
+  const memorySnapshot = useMemo(
+    () =>
+      buildPkmMemorySnapshot({
+        metadata,
+        fullBlob,
+      }),
+    [fullBlob, metadata]
+  );
+
+  const domainInsightByKey = useMemo(
+    () => new Map(memorySnapshot.domainInsights.map((insight) => [insight.domain, insight])),
+    [memorySnapshot.domainInsights]
+  );
 
   const globalAccessEntries = useMemo(() => {
     return activeGrants
@@ -177,16 +225,146 @@ export function PkmNaturalPanel({
     return metadata.domains.map((domain) => ({
       domain,
       manifest: manifests[domain.key] || null,
-      presentation: buildNaturalDomainPresentation({
-        domain,
-        manifest: manifests[domain.key] || null,
-      }),
+      presentation: (() => {
+        const base = buildNaturalDomainPresentation({
+          domain,
+          manifest: manifests[domain.key] || null,
+        });
+        const insight = domainInsightByKey.get(domain.key);
+        if (!insight) return base;
+        return {
+          ...base,
+          summary: insight.summary || base.summary,
+          highlights: insight.highlights.length > 0 ? insight.highlights : base.highlights,
+          updatedAt: insight.updatedAt || base.updatedAt,
+        };
+      })(),
       accessEntries: buildNaturalAccessEntries({
         domain,
         activeGrants: domainScopedGrants,
       }),
     }));
-  }, [activeGrants, manifests, metadata]);
+  }, [activeGrants, domainInsightByKey, manifests, metadata]);
+
+  async function refreshMetadataAfterMemoryWrite() {
+    if (!user || !vaultOwnerToken) return;
+    const nextMetadata = await PersonalKnowledgeModelService.getMetadata(
+      user.uid,
+      true,
+      vaultOwnerToken
+    );
+    setMetadata(nextMetadata);
+  }
+
+  function domainDataForCard(card: PkmMemoryCard): Record<string, unknown> {
+    const value = fullBlob[card.domain];
+    return value && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+  }
+
+  function memoryWriteSummary(
+    card: PkmMemoryCard,
+    action: "edited" | "deleted",
+    nextDomainData: Record<string, unknown>
+  ) {
+    const now = new Date().toISOString();
+    const nextDomainSnapshot = buildPkmMemorySnapshot({
+      metadata,
+      fullBlob: {
+        [card.domain]: nextDomainData,
+      },
+      maxCards: 128,
+      maxCardsPerDomain: 128,
+    });
+    return {
+      readable_summary: `${card.domainTitle} memory was ${action} from your data view.`,
+      readable_highlights: [`${action === "edited" ? "Updated" : "Removed"} ${card.title}`],
+      readable_updated_at: now,
+      readable_source_label: action === "edited" ? "Edited memory" : "Deleted memory",
+      readable_event_summary: `${action === "edited" ? "Updated" : "Removed"} ${card.title}.`,
+      memory_count: nextDomainSnapshot.cards.filter((item) => item.domain === card.domain).length,
+    };
+  }
+
+  async function persistMemoryCardChange(params: {
+    card: PkmMemoryCard;
+    action: "edited" | "deleted";
+    nextDomainData: Record<string, unknown>;
+  }) {
+    if (!user || !vaultKey || !vaultOwnerToken) return;
+    setMemoryActionId(`${params.card.id}:${params.action}`);
+    setMemoryActionError(null);
+    setMemoryActionMessage(null);
+    try {
+      const result = await PkmWriteCoordinator.saveMergedDomain({
+        userId: user.uid,
+        domain: params.card.domain,
+        vaultKey,
+        vaultOwnerToken,
+        build: () => ({
+          domainData: params.nextDomainData,
+          summary: memoryWriteSummary(params.card, params.action, params.nextDomainData),
+          mergeDecision: {
+            merge_mode: "replace_domain",
+          },
+        }),
+      });
+      if (!result.success) {
+        throw new Error(result.message || "Failed to update saved memory.");
+      }
+      setFullBlob((current) => ({
+        ...current,
+        [params.card.domain]: result.fullBlob[params.card.domain] || params.nextDomainData,
+      }));
+      clearAgentPkmContext(user.uid);
+      await refreshMetadataAfterMemoryWrite();
+      setEditingCardId(null);
+      setEditValue("");
+      setMemoryActionMessage(
+        params.action === "edited" ? "Memory card updated." : "Memory card deleted."
+      );
+    } catch (error) {
+      setMemoryActionError(
+        error instanceof Error ? error.message : "Failed to update saved memory."
+      );
+    } finally {
+      setMemoryActionId(null);
+    }
+  }
+
+  function startEditing(card: PkmMemoryCard) {
+    setEditingCardId(card.id);
+    setEditValue(card.value);
+    setMemoryActionError(null);
+    setMemoryActionMessage(null);
+  }
+
+  async function saveEditedCard(card: PkmMemoryCard) {
+    const nextDomainData = updatePkmDomainValue({
+      domainData: domainDataForCard(card),
+      pathSegments: card.pathSegments,
+      previousValue: card.value,
+      nextValue: editValue,
+    });
+    await persistMemoryCardChange({
+      card,
+      action: "edited",
+      nextDomainData,
+    });
+  }
+
+  async function deleteCard(card: PkmMemoryCard) {
+    const nextDomainData = deletePkmDomainValue({
+      domainData: domainDataForCard(card),
+      pathSegments: card.pathSegments,
+    });
+    await persistMemoryCardChange({
+      card,
+      action: "deleted",
+      nextDomainData,
+    });
+  }
 
   if (loading || bootstrapLoading) {
     return (
@@ -209,7 +387,7 @@ export function PkmNaturalPanel({
     );
   }
 
-  if (!isVaultUnlocked || !vaultOwnerToken) {
+  if (!isVaultUnlocked || !vaultOwnerToken || !vaultKey) {
     return (
       <SurfaceInset className="space-y-2 px-4 py-4 text-sm text-muted-foreground">
         <div className="flex items-center gap-2 font-medium text-foreground">
@@ -258,6 +436,7 @@ export function PkmNaturalPanel({
         <div className="flex flex-wrap gap-2">
           <Badge variant="secondary">{metadata?.domains.length || 0} domains</Badge>
           <Badge variant="secondary">{metadata?.totalAttributes || 0} saved details</Badge>
+          <Badge variant="secondary">{memorySnapshot.totalCards} memory cards</Badge>
           <Badge variant="secondary">{activeGrants.length} active access grants</Badge>
           <Badge variant="secondary">
             Last updated {formatTimestamp(metadata?.lastUpdated || null)}
@@ -300,6 +479,149 @@ export function PkmNaturalPanel({
           </SurfaceCardContent>
         </SurfaceCard>
       ) : null}
+
+      <SurfaceCard accent="violet">
+        <SurfaceCardHeader className="space-y-3">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="space-y-1">
+              <SurfaceCardTitle>Memory cards</SurfaceCardTitle>
+              <SurfaceCardDescription>
+                Decrypted only while your vault is unlocked. Edit or delete cards to update the
+                encrypted PKM domain.
+              </SurfaceCardDescription>
+            </div>
+            <Badge variant="secondary">{memorySnapshot.totalCards} cards</Badge>
+          </div>
+          {memoryActionMessage ? (
+            <div className="rounded-xl border border-emerald-500/25 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-800 dark:text-emerald-100">
+              {memoryActionMessage}
+            </div>
+          ) : null}
+          {memoryActionError ? (
+            <div className="rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {memoryActionError}
+            </div>
+          ) : null}
+        </SurfaceCardHeader>
+        <SurfaceCardContent>
+          {memorySnapshot.cards.length === 0 ? (
+            <div className="rounded-2xl border border-dashed bg-muted/10 px-4 py-4 text-sm text-muted-foreground">
+              No readable memory cards yet. Save a profile fact, preference, project note, receipt,
+              or portfolio detail and it will show up here after vault unlock.
+            </div>
+          ) : (
+            <div className="grid gap-3 lg:grid-cols-2">
+              {memorySnapshot.cards.slice(0, 24).map((card) => {
+                const editing = editingCardId === card.id;
+                const savingEdit = memoryActionId === `${card.id}:edited`;
+                const deleting = memoryActionId === `${card.id}:deleted`;
+                return (
+                  <div key={card.id} className="rounded-2xl border bg-muted/15 p-4">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div className="min-w-0 flex-1 space-y-2">
+                        <div className="flex flex-wrap gap-2">
+                          <Badge variant="secondary">{card.domainTitle}</Badge>
+                          <Badge variant="outline">{Math.round(card.confidence * 100)}%</Badge>
+                          <Badge variant="outline">{card.sourceLabel}</Badge>
+                        </div>
+                        <h3 className="text-sm font-semibold leading-6">{card.title}</h3>
+                        <p className="text-xs text-muted-foreground">{card.detail}</p>
+                        <p className="text-xs text-muted-foreground">
+                          Updated {formatTimestamp(card.updatedAt)}
+                        </p>
+                      </div>
+                      <div className="flex shrink-0 gap-1">
+                        {editing ? (
+                          <>
+                            <Button
+                              variant="none"
+                              effect="fade"
+                              disabled={savingEdit}
+                              onClick={() => void saveEditedCard(card)}
+                              aria-label="Save memory card"
+                            >
+                              {savingEdit ? (
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                              ) : (
+                                <Check className="h-4 w-4" />
+                              )}
+                            </Button>
+                            <Button
+                              variant="none"
+                              effect="fade"
+                              disabled={savingEdit}
+                              onClick={() => {
+                                setEditingCardId(null);
+                                setEditValue("");
+                              }}
+                              aria-label="Cancel memory card edit"
+                            >
+                              <X className="h-4 w-4" />
+                            </Button>
+                          </>
+                        ) : (
+                          <>
+                            <Button
+                              variant="none"
+                              effect="fade"
+                              onClick={() => startEditing(card)}
+                              aria-label="Edit memory card"
+                            >
+                              <Edit3 className="h-4 w-4" />
+                            </Button>
+                            <AlertDialog>
+                              <AlertDialogTrigger asChild>
+                                <Button
+                                  variant="none"
+                                  effect="fade"
+                                  disabled={deleting}
+                                  aria-label="Delete memory card"
+                                >
+                                  {deleting ? (
+                                    <Loader2 className="h-4 w-4 animate-spin" />
+                                  ) : (
+                                    <Trash2 className="h-4 w-4" />
+                                  )}
+                                </Button>
+                              </AlertDialogTrigger>
+                              <AlertDialogContent size="sm">
+                                <AlertDialogHeader>
+                                  <AlertDialogTitle>Delete this memory?</AlertDialogTitle>
+                                  <AlertDialogDescription>
+                                    This removes the selected detail from the encrypted{" "}
+                                    {card.domainTitle} PKM domain.
+                                  </AlertDialogDescription>
+                                </AlertDialogHeader>
+                                <AlertDialogFooter>
+                                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                                  <AlertDialogAction
+                                    variant="destructive"
+                                    onClick={() => void deleteCard(card)}
+                                  >
+                                    Delete
+                                  </AlertDialogAction>
+                                </AlertDialogFooter>
+                              </AlertDialogContent>
+                            </AlertDialog>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                    {editing ? (
+                      <Input
+                        className="mt-3"
+                        value={editValue}
+                        onChange={(event) => setEditValue(event.target.value)}
+                        aria-label="Memory card value"
+                      />
+                    ) : null}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </SurfaceCardContent>
+      </SurfaceCard>
 
       {domainEntries.length === 0 ? (
         <SurfaceInset className="space-y-2 px-4 py-4 text-sm text-muted-foreground">

--- a/hushh-webapp/lib/agent/agent-pkm-context-store.ts
+++ b/hushh-webapp/lib/agent/agent-pkm-context-store.ts
@@ -4,11 +4,17 @@ import {
   PersonalKnowledgeModelService,
   type PersonalKnowledgeModelMetadata,
 } from "@/lib/services/personal-knowledge-model-service";
+import {
+  buildPkmMemorySnapshot,
+  selectRelevantPkmMemoryCards,
+  type PkmMemorySnapshot,
+} from "@/lib/pkm/pkm-memory-cards";
 
 type AgentPkmWorkingSet = {
   userId: string;
   metadata: PersonalKnowledgeModelMetadata | null;
   fullBlob: Record<string, unknown>;
+  memorySnapshot: PkmMemorySnapshot;
   loadedAt: number;
   metadataUpdatedAt: string | null;
 };
@@ -198,6 +204,26 @@ function domainSummaryLines(metadata: PersonalKnowledgeModelMetadata | null): st
     });
 }
 
+function memoryDomainSummaryLines(workingSet: AgentPkmWorkingSet): string[] {
+  if (workingSet.memorySnapshot.domainInsights.length === 0) {
+    return domainSummaryLines(workingSet.metadata);
+  }
+  return workingSet.memorySnapshot.domainInsights
+    .filter((domain) => domain.cardCount > 0 || domain.summary)
+    .map((domain) =>
+      [
+        `- ${domain.title} (${domain.domain})`,
+        `summary: ${clip(domain.summary, 260)}`,
+        domain.highlights.length > 0
+          ? `highlights: ${domain.highlights.map((item) => clip(item, 100)).join("; ")}`
+          : null,
+        domain.updatedAt ? `updated: ${domain.updatedAt}` : null,
+      ]
+        .filter(Boolean)
+        .join(" | ")
+    );
+}
+
 function buildContextText(params: {
   workingSet: AgentPkmWorkingSet;
   message: string;
@@ -219,6 +245,10 @@ function buildContextText(params: {
   const allLines = domainKeys.flatMap((domain) =>
     flattenDomain(domain, (workingSet.fullBlob || {})[domain], promptTokens)
   );
+  const relevantMemoryCards =
+    mode === "broad"
+      ? workingSet.memorySnapshot.cards.slice(0, 42)
+      : selectRelevantPkmMemoryCards(workingSet.memorySnapshot.cards, params.message, 24);
   const selectedLines =
     mode === "broad"
       ? allLines.slice(0, MAX_DETAIL_LINES)
@@ -239,7 +269,16 @@ function buildContextText(params: {
     workingSet.metadataUpdatedAt ? `Updated at: ${workingSet.metadataUpdatedAt}` : null,
     "",
     "Domain summaries:",
-    ...domainSummaryLines(workingSet.metadata).slice(0, 12),
+    ...memoryDomainSummaryLines(workingSet).slice(0, 12),
+    "",
+    relevantMemoryCards.length > 0
+      ? "Memory cards selected from decrypted PKM:"
+      : "Memory cards selected from decrypted PKM: none available.",
+    ...relevantMemoryCards.map((card) =>
+      `- ${card.title} | domain: ${card.domainTitle} | source: ${card.sourceLabel} | confidence: ${Math.round(
+        card.confidence * 100
+      )}% | ${card.detail}`
+    ),
     "",
     detailLines.length > 0 ? "Decrypted PKM details:" : "Decrypted PKM details: none available.",
     ...detailLines.map((line) => `- ${line.text}`),
@@ -253,9 +292,12 @@ function buildContextText(params: {
   return {
     text,
     domains: domainKeys,
-    totalAttributes: workingSet.metadata?.totalAttributes || detailLines.length,
+    totalAttributes:
+      workingSet.metadata?.totalAttributes ||
+      workingSet.memorySnapshot.totalCards ||
+      detailLines.length,
     updatedAt: workingSet.metadataUpdatedAt,
-    detailCount: detailLines.length,
+    detailCount: Math.max(detailLines.length, relevantMemoryCards.length),
     source: "decrypted_session_pkm",
     mode,
   };
@@ -297,17 +339,24 @@ export class AgentPkmContextStore {
     const workingSet =
       !params.forceRefresh && cacheFresh
         ? cached
-        : {
-            userId: params.userId,
-            metadata,
-            fullBlob: await PersonalKnowledgeModelService.loadFullBlob({
+        : await (async (): Promise<AgentPkmWorkingSet> => {
+            const fullBlob = await PersonalKnowledgeModelService.loadFullBlob({
               userId: params.userId,
               vaultKey: params.vaultKey,
               vaultOwnerToken: params.vaultOwnerToken,
-            }),
-            loadedAt: Date.now(),
-            metadataUpdatedAt,
-          };
+            });
+            return {
+              userId: params.userId,
+              metadata,
+              fullBlob,
+              memorySnapshot: buildPkmMemorySnapshot({
+                metadata,
+                fullBlob,
+              }),
+              loadedAt: Date.now(),
+              metadataUpdatedAt,
+            };
+          })();
 
     workingSets.set(params.userId, workingSet);
 

--- a/hushh-webapp/lib/pkm/pkm-memory-cards.ts
+++ b/hushh-webapp/lib/pkm/pkm-memory-cards.ts
@@ -1,0 +1,495 @@
+"use client";
+
+import type {
+  DomainSummary,
+  PersonalKnowledgeModelMetadata,
+} from "@/lib/services/personal-knowledge-model-service";
+
+export type PkmPathSegment = string | number;
+
+export type PkmMemoryCard = {
+  id: string;
+  domain: string;
+  domainTitle: string;
+  title: string;
+  detail: string;
+  value: string;
+  path: string;
+  pathSegments: PkmPathSegment[];
+  sourceLabel: string;
+  updatedAt: string | null;
+  confidence: number;
+  kind: "profile" | "preference" | "financial" | "shopping" | "professional" | "memory";
+  editable: boolean;
+  searchText: string;
+};
+
+export type PkmDomainInsight = {
+  domain: string;
+  title: string;
+  summary: string;
+  highlights: string[];
+  updatedAt: string | null;
+  cardCount: number;
+};
+
+export type PkmMemorySnapshot = {
+  cards: PkmMemoryCard[];
+  domainInsights: PkmDomainInsight[];
+  totalCards: number;
+};
+
+const DEFAULT_MAX_CARDS = 96;
+const DEFAULT_MAX_CARDS_PER_DOMAIN = 24;
+const MAX_VALUE_CHARS = 180;
+const MAX_DEPTH = 6;
+const MAX_ARRAY_ITEMS = 12;
+
+const INTERNAL_KEYS = new Set([
+  "algorithm",
+  "artifact_id",
+  "card_id",
+  "ciphertext",
+  "confidence",
+  "contract_version",
+  "created_at",
+  "domain_contract_version",
+  "domain_intent",
+  "hash",
+  "id",
+  "iv",
+  "last_content_at",
+  "last_structured_at",
+  "manifest_revision",
+  "manifest_version",
+  "path_count",
+  "pkm_contract_version",
+  "readable_projection_version",
+  "readable_summary_version",
+  "schema_version",
+  "source_agent",
+  "tag",
+  "updated_at",
+  "upgraded_at",
+  "version",
+]);
+
+function compact(value: unknown): string {
+  return String(value ?? "").replace(/\s+/g, " ").trim();
+}
+
+function clip(value: unknown, maxChars = MAX_VALUE_CHARS): string {
+  const text = compact(value);
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, Math.max(0, maxChars - 1)).trimEnd()}...`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function titleize(value: string): string {
+  return value
+    .replace(/\[\d+\]/g, " ")
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (match) => match.toUpperCase())
+    .trim();
+}
+
+function normalizeKey(value: unknown): string {
+  return String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function stableId(value: string): string {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) >>> 0;
+  }
+  return hash.toString(36);
+}
+
+function pathToString(pathSegments: readonly PkmPathSegment[]): string {
+  return pathSegments
+    .map((segment) => (typeof segment === "number" ? `[${segment}]` : segment))
+    .join(".")
+    .replace(/\.\[/g, "[");
+}
+
+function parseDomainSummary(metadata: PersonalKnowledgeModelMetadata | null): Map<string, DomainSummary> {
+  return new Map((metadata?.domains || []).map((domain) => [domain.key, domain]));
+}
+
+function shouldSkipKey(key: string): boolean {
+  const normalized = normalizeKey(key);
+  if (!normalized) return true;
+  if (INTERNAL_KEYS.has(normalized)) return true;
+  if (normalized.startsWith("_")) return true;
+  if (normalized.endsWith("_id") && normalized !== "student_id") return true;
+  if (normalized.includes("cipher") || normalized.includes("token")) return true;
+  return false;
+}
+
+function primitiveValue(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string") return clip(value);
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return null;
+}
+
+function classifyCard(domain: string, path: string, value: string): PkmMemoryCard["kind"] {
+  const text = `${domain} ${path} ${value}`.toLowerCase();
+  if (/\b(name|email|phone|roll|student|college|university|school|address|city)\b/.test(text)) {
+    return "profile";
+  }
+  if (/\b(prefer|preference|favorite|favourite|like|dislike|brand|style)\b/.test(text)) {
+    return "preference";
+  }
+  if (/\b(financial|portfolio|stock|ticker|risk|holding|analysis|brokerage|investment)\b/.test(text)) {
+    return "financial";
+  }
+  if (/\b(shopping|receipt|merchant|seller|brand|purchase|subscription|return)\b/.test(text)) {
+    return "shopping";
+  }
+  if (/\b(work|project|professional|job|meeting|company|iit|college|university)\b/.test(text)) {
+    return "professional";
+  }
+  return "memory";
+}
+
+function cardTitle(params: {
+  domain: string;
+  pathSegments: readonly PkmPathSegment[];
+  value: string;
+}): string {
+  const path = pathToString(params.pathSegments).toLowerCase();
+  const lastKey = String(params.pathSegments.at(-1) ?? params.domain);
+  const label = titleize(lastKey);
+  const value = params.value;
+
+  if (/\b(full_?name|display_?name|name)\b/.test(path)) return `Your name is ${value}`;
+  if (/\b(roll|student_?id|roll_?no)\b/.test(path)) return `Roll number: ${value}`;
+  if (/\b(iit|college|university|school|institution|institute)\b/.test(path)) {
+    return `You study at ${value}`;
+  }
+  if (/\b(prefer|preference|favorite|favourite|likes?)\b/.test(path)) {
+    return `You prefer ${value}`;
+  }
+  if (/\bdislikes?\b/.test(path)) return `You dislike ${value}`;
+  if (/\b(ticker|stock|symbol)\b/.test(path)) return `Stock symbol: ${value}`;
+  if (/\b(project|goal|routine|habit)\b/.test(path)) return `${label}: ${value}`;
+  return `${label}: ${value}`;
+}
+
+function cardDetail(domainTitle: string, pathSegments: readonly PkmPathSegment[]): string {
+  const visiblePath = pathSegments
+    .filter((segment) => typeof segment !== "number")
+    .map((segment) => titleize(String(segment)))
+    .filter(Boolean)
+    .slice(0, 4);
+  if (visiblePath.length === 0) return `Stored in ${domainTitle}.`;
+  return `Stored in ${domainTitle} > ${visiblePath.join(" > ")}.`;
+}
+
+function flattenCards(params: {
+  domain: string;
+  domainTitle: string;
+  value: unknown;
+  sourceLabel: string;
+  updatedAt: string | null;
+  depth?: number;
+  pathSegments?: PkmPathSegment[];
+  cards?: PkmMemoryCard[];
+}): PkmMemoryCard[] {
+  const depth = params.depth || 0;
+  const pathSegments = params.pathSegments || [];
+  const cards = params.cards || [];
+  if (depth > MAX_DEPTH || cards.length >= DEFAULT_MAX_CARDS_PER_DOMAIN * 3) return cards;
+
+  const primitive = primitiveValue(params.value);
+  if (primitive) {
+    const path = pathToString(pathSegments);
+    if (!path || primitive.length === 0) return cards;
+    const kind = classifyCard(params.domain, path, primitive);
+    const title = cardTitle({
+      domain: params.domain,
+      pathSegments,
+      value: primitive,
+    });
+    cards.push({
+      id: `${params.domain}:${stableId(`${path}:${primitive}`)}`,
+      domain: params.domain,
+      domainTitle: params.domainTitle,
+      title,
+      detail: cardDetail(params.domainTitle, pathSegments),
+      value: primitive,
+      path,
+      pathSegments: [...pathSegments],
+      sourceLabel: params.sourceLabel,
+      updatedAt: params.updatedAt,
+      confidence: kind === "memory" ? 0.72 : 0.88,
+      kind,
+      editable: true,
+      searchText: `${params.domain} ${params.domainTitle} ${path} ${title} ${primitive}`.toLowerCase(),
+    });
+    return cards;
+  }
+
+  if (Array.isArray(params.value)) {
+    params.value.slice(0, MAX_ARRAY_ITEMS).forEach((item, index) => {
+      flattenCards({
+        ...params,
+        value: item,
+        depth: depth + 1,
+        pathSegments: [...pathSegments, index],
+        cards,
+      });
+    });
+    return cards;
+  }
+
+  if (!isRecord(params.value)) return cards;
+  for (const [key, child] of Object.entries(params.value)) {
+    if (shouldSkipKey(key)) continue;
+    flattenCards({
+      ...params,
+      value: child,
+      depth: depth + 1,
+      pathSegments: [...pathSegments, key],
+      cards,
+    });
+  }
+  return cards;
+}
+
+function tokens(value: string): Set<string> {
+  return new Set(
+    value
+      .toLowerCase()
+      .split(/[^a-z0-9$.\-]+/g)
+      .map((token) => token.trim())
+      .filter((token) => token.length >= 3)
+  );
+}
+
+export function selectRelevantPkmMemoryCards(
+  cards: readonly PkmMemoryCard[],
+  query: string,
+  limit = 18
+): PkmMemoryCard[] {
+  const queryTokens = tokens(query);
+  if (queryTokens.size === 0) return cards.slice(0, limit);
+
+  return cards
+    .map((card) => {
+      let score = 0;
+      for (const token of queryTokens) {
+        if (card.searchText.includes(token)) score += 1;
+        if (card.domain.includes(token)) score += 2;
+        if (card.title.toLowerCase().includes(token)) score += 3;
+      }
+      return { card, score };
+    })
+    .filter((entry) => entry.score > 0)
+    .sort((left, right) => right.score - left.score || right.card.confidence - left.card.confidence)
+    .map((entry) => entry.card)
+    .slice(0, limit);
+}
+
+function domainInsightSummary(params: {
+  domain: DomainSummary | undefined;
+  cards: readonly PkmMemoryCard[];
+  domainKey: string;
+  domainTitle: string;
+}): string {
+  const title = params.domainTitle;
+  const text = params.cards.map((card) => `${card.title} ${card.path}`).join(" ").toLowerCase();
+  const topics: string[] = [];
+  const add = (topic: string, pattern: RegExp) => {
+    if (pattern.test(text) && !topics.includes(topic)) topics.push(topic);
+  };
+
+  add("portfolio holdings", /\b(holding|holdings|portfolio|allocation)\b/);
+  add("analysis history", /\b(analysis|decision|ticker|stock)\b/);
+  add("saved risk profile", /\b(risk|risk_profile|risk bucket)\b/);
+  add("receipts", /\b(receipt|purchase|order)\b/);
+  add("brand preferences", /\b(brand|seller|merchant|preference|prefer)\b/);
+  add("subscriptions", /\b(subscription|renewal)\b/);
+  add("education", /\b(iit|college|university|school|student|roll)\b/);
+  add("projects", /\b(project|work|professional)\b/);
+  add("habits and routines", /\b(habit|routine|workout|sleep|meal)\b/);
+
+  if (topics.length > 0) {
+    return `Your ${title.toLowerCase()} memory includes ${topics.slice(0, 5).join(", ")}.`;
+  }
+
+  const readable = compact(params.domain?.readableSummary || params.domain?.summary?.readable_summary);
+  if (readable) return readable;
+  if (params.cards.length > 0) {
+    return `Your ${title.toLowerCase()} memory has ${params.cards.length} readable detail${
+      params.cards.length === 1 ? "" : "s"
+    } ready for review.`;
+  }
+  return `Your ${title.toLowerCase()} memory is ready for review.`;
+}
+
+function domainInsight(params: {
+  domain: DomainSummary | undefined;
+  domainKey: string;
+  cards: readonly PkmMemoryCard[];
+}): PkmDomainInsight {
+  const domainTitle = params.domain?.displayName || titleize(params.domainKey);
+  const highlights = [
+    ...params.cards
+      .filter((card) => card.kind !== "memory")
+      .map((card) => card.title)
+      .slice(0, 4),
+    ...(params.domain?.readableHighlights || []),
+  ]
+    .map((item) => clip(item, 120))
+    .filter(Boolean)
+    .filter((item, index, all) => all.indexOf(item) === index)
+    .slice(0, 5);
+
+  return {
+    domain: params.domainKey,
+    title: domainTitle,
+    summary: domainInsightSummary({
+      domain: params.domain,
+      cards: params.cards,
+      domainKey: params.domainKey,
+      domainTitle,
+    }),
+    highlights,
+    updatedAt:
+      params.domain?.readableUpdatedAt || params.domain?.lastUpdated || params.cards[0]?.updatedAt || null,
+    cardCount: params.cards.length,
+  };
+}
+
+export function buildPkmMemorySnapshot(params: {
+  metadata: PersonalKnowledgeModelMetadata | null;
+  fullBlob: Record<string, unknown>;
+  maxCards?: number;
+  maxCardsPerDomain?: number;
+}): PkmMemorySnapshot {
+  const maxCards = params.maxCards || DEFAULT_MAX_CARDS;
+  const maxCardsPerDomain = params.maxCardsPerDomain || DEFAULT_MAX_CARDS_PER_DOMAIN;
+  const domainsByKey = parseDomainSummary(params.metadata);
+  const domainKeys = Array.from(
+    new Set([
+      ...(params.metadata?.domains.map((domain) => domain.key).filter(Boolean) || []),
+      ...Object.keys(params.fullBlob || {}),
+    ])
+  );
+
+  const cardsByDomain = new Map<string, PkmMemoryCard[]>();
+  for (const domainKey of domainKeys) {
+    const domain = domainsByKey.get(domainKey);
+    const domainTitle = domain?.displayName || titleize(domainKey);
+    const cards = flattenCards({
+      domain: domainKey,
+      domainTitle,
+      value: params.fullBlob?.[domainKey],
+      sourceLabel: domain?.readableSourceLabel || "Saved memory",
+      updatedAt: domain?.readableUpdatedAt || domain?.lastUpdated || null,
+    }).slice(0, maxCardsPerDomain);
+    cardsByDomain.set(domainKey, cards);
+  }
+
+  const cards = Array.from(cardsByDomain.values()).flat().slice(0, maxCards);
+  const domainInsights = domainKeys.map((domainKey) =>
+    domainInsight({
+      domain: domainsByKey.get(domainKey),
+      domainKey,
+      cards: cardsByDomain.get(domainKey) || [],
+    })
+  );
+
+  return {
+    cards,
+    domainInsights,
+    totalCards: cards.length,
+  };
+}
+
+function cloneRecord(value: Record<string, unknown>): Record<string, unknown> {
+  if (typeof globalThis.structuredClone === "function") {
+    return globalThis.structuredClone(value) as Record<string, unknown>;
+  }
+  return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
+}
+
+function ensureContainer(parent: unknown, segment: PkmPathSegment): Record<string, unknown> | unknown[] | null {
+  if (typeof segment === "number") {
+    return Array.isArray(parent) ? parent : null;
+  }
+  return isRecord(parent) ? parent : null;
+}
+
+function readChild(container: Record<string, unknown> | unknown[], segment: PkmPathSegment): unknown {
+  if (typeof segment === "number") {
+    return Array.isArray(container) ? container[segment] : undefined;
+  }
+  return isRecord(container) ? container[segment] : undefined;
+}
+
+function coerceEditedValue(previous: string, next: string): unknown {
+  if (previous === "true" || previous === "false") {
+    if (/^(true|false)$/i.test(next.trim())) return next.trim().toLowerCase() === "true";
+  }
+  if (/^-?\d+(\.\d+)?$/.test(previous) && /^-?\d+(\.\d+)?$/.test(next.trim())) {
+    return Number(next.trim());
+  }
+  return next;
+}
+
+export function updatePkmDomainValue(params: {
+  domainData: Record<string, unknown>;
+  pathSegments: readonly PkmPathSegment[];
+  previousValue: string;
+  nextValue: string;
+}): Record<string, unknown> {
+  const nextDomainData = cloneRecord(params.domainData);
+  let cursor: unknown = nextDomainData;
+  for (const segment of params.pathSegments.slice(0, -1)) {
+    const container = ensureContainer(cursor, segment);
+    if (!container) return nextDomainData;
+    cursor = readChild(container, segment);
+  }
+  const last = params.pathSegments.at(-1);
+  const container = ensureContainer(cursor, last ?? "");
+  if (!container || last === undefined) return nextDomainData;
+  const value = coerceEditedValue(params.previousValue, params.nextValue);
+  if (typeof last === "number") {
+    if (Array.isArray(container)) container[last] = value;
+  } else if (isRecord(container)) {
+    container[last] = value;
+  }
+  return nextDomainData;
+}
+
+export function deletePkmDomainValue(params: {
+  domainData: Record<string, unknown>;
+  pathSegments: readonly PkmPathSegment[];
+}): Record<string, unknown> {
+  const nextDomainData = cloneRecord(params.domainData);
+  let cursor: unknown = nextDomainData;
+  for (const segment of params.pathSegments.slice(0, -1)) {
+    const container = ensureContainer(cursor, segment);
+    if (!container) return nextDomainData;
+    cursor = readChild(container, segment);
+  }
+  const last = params.pathSegments.at(-1);
+  const container = ensureContainer(cursor, last ?? "");
+  if (!container || last === undefined) return nextDomainData;
+  if (typeof last === "number") {
+    if (Array.isArray(container)) container.splice(last, 1);
+  } else if (isRecord(container)) {
+    delete container[last];
+  }
+  return nextDomainData;
+}

--- a/scripts/ci/github-security-alerts.sh
+++ b/scripts/ci/github-security-alerts.sh
@@ -118,9 +118,10 @@ import json
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Optional
 
 
-def parse_iso8601(value: str | None) -> datetime | None:
+def parse_iso8601(value: Optional[str]) -> Optional[datetime]:
     if not value:
         return None
     normalized = value.strip()
@@ -131,7 +132,7 @@ def parse_iso8601(value: str | None) -> datetime | None:
     return datetime.fromisoformat(normalized).astimezone(timezone.utc)
 
 
-def filter_alerts(alerts: list[dict], cutoff: datetime | None) -> list[dict]:
+def filter_alerts(alerts: list[dict], cutoff: Optional[datetime]) -> list[dict]:
     if cutoff is None:
         return alerts
     filtered: list[dict] = []


### PR DESCRIPTION
## Summary

- Improves the Agent chat header by removing the visible debug toggle and replacing the duplicate eyebrow label with Kai context.
- Adds PKM memory-card derivation utilities, relevance selection, and edit/delete helpers with focused tests.
- Enhances the PKM natural panel to show richer memory cards and support encrypted PKM memory edits/deletes through the existing write coordinator.
- Makes the GitHub security-alert CI helper compatible with Python 3.9 local environments.

## Validation

- `PATH=/tmp/codex-tools-hushh/bin:$HOME/.local/bin:$HOME/.nvm/versions/node/v20.20.2/bin:$PATH ./bin/hushh codex pre-pr`

Notes: local CI reports existing Dependabot alerts as advisory/non-blocking, matching the lane policy. The untracked local backup archive was not staged or pushed.
