### PR TITLE
test: fix Pydantic V2 deprecations and session test dependency override

### DIFF
--- a/consent-protocol/tests/test_session_error_status_codes.py
+++ b/consent-protocol/tests/test_session_error_status_codes.py
@@ -34,8 +34,7 @@ def _make_app() -> FastAPI:
         patch("api.utils.firebase_admin.get_firebase_auth_app", return_value=MagicMock()),
     ):
         # Override the dependency so every request is pre-authenticated
-        from api.middleware import require_vault_owner_token
-        from api.routes.session import router
+        from api.routes.session import require_vault_owner_token, router
 
         app.dependency_overrides[require_vault_owner_token] = lambda: _FAKE_TOKEN_DATA
         app.include_router(router)

--- a/consent-protocol/tests/test_trust.py
+++ b/consent-protocol/tests/test_trust.py
@@ -37,7 +37,7 @@ def test_expired_trust_link():
 def test_signature_tampering():
     link = create_trust_link(DELEGATOR, DELEGATEE, SCOPE_VALID, USER_ID)
 
-    tampered = link.copy(update={"signature": "bad_signature_here"})
+    tampered = link.model_copy(update={"signature": "bad_signature_here"})
 
     assert verify_trust_link(tampered) is False
     assert is_trusted_for_scope(tampered, SCOPE_VALID) is False

--- a/consent-protocol/tests/test_vault.py
+++ b/consent-protocol/tests/test_vault.py
@@ -68,7 +68,7 @@ def test_decryption_fails_with_tampered_data(test_vault_key):
     encrypted = encrypt_data(plaintext, test_vault_key)
 
     # Tamper with ciphertext
-    corrupted = encrypted.copy(
+    corrupted = encrypted.model_copy(
         update={"ciphertext": base64.b64encode(b"malicious content").decode("utf-8")}
     )
 
@@ -83,9 +83,10 @@ def test_encrypted_payload_structure(test_vault_key):
     plaintext = "test data"
     encrypted = encrypt_data(plaintext, test_vault_key)
 
-    assert "ciphertext" in encrypted.dict()
-    assert "iv" in encrypted.dict()
-    assert "tag" in encrypted.dict()
+    dump = encrypted.model_dump()
+    assert "ciphertext" in dump
+    assert "iv" in dump
+    assert "tag" in dump
 
 
 def test_different_ivs_produce_different_ciphertext(test_vault_key):


### PR DESCRIPTION
## Summary

Three test-only fixes, no production code touched:

- **test_trust.py**: `link.copy(update=...)` replaced with `link.model_copy(update=...)`. Pydantic V2 removed the `copy()` alias.
- **test_vault.py**: same `model_copy()` migration, plus `.dict()` replaced with `.model_dump()` (three call sites).
- **test_session_error_status_codes.py**: import `require_vault_owner_token` from `api.routes.session` instead of `api.middleware`. The session router re-exports the dependency, and `app.dependency_overrides` keying must match the exact callable object the router registered; importing from the wrong module made the override a silent no-op.

## What changed

Three files under `consent-protocol/tests/`. No routes, services, or models changed.

## Test plan

- [ ] `pytest tests/test_trust.py` passes without Pydantic deprecation warnings
- [ ] `pytest tests/test_vault.py` passes without Pydantic deprecation warnings
- [ ] `pytest tests/test_session_error_status_codes.py` passes with the dependency override actually in effect