### PR TITLE
hardening(streaming): add SSE frame size and stream frame count guards

### DIFF
--- a/hushh-webapp/__tests__/streaming/kai-stream-client.test.ts
+++ b/hushh-webapp/__tests__/streaming/kai-stream-client.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  consumeCanonicalKaiStream,
+  MAX_FRAMES_PER_STREAM,
+} from "@/lib/streaming/kai-stream-client";
+import type { KaiStreamEnvelope } from "@/lib/streaming/kai-stream-types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEnvelopeSSEText(seq: number, terminal: boolean): string {
+  const envelope: KaiStreamEnvelope = {
+    schema_version: "1.0",
+    stream_id: "strm_test",
+    stream_kind: "portfolio_import",
+    seq,
+    event: "stage",
+    terminal,
+    payload: { stage: "processing" },
+  };
+  return `event: stage\nid: ${seq}\ndata: ${JSON.stringify(envelope)}\n\n`;
+}
+
+/**
+ * Build a single Uint8Array chunk containing `count` SSE frames.
+ * Batching into one chunk avoids thousands of async read() round-trips,
+ * keeping frame-count tests fast without reducing coverage.
+ */
+function makeChunk(count: number, terminalOnLast = false): Uint8Array {
+  const text = Array.from({ length: count }, (_, i) =>
+    makeEnvelopeSSEText(i + 1, terminalOnLast && i === count - 1)
+  ).join("");
+  return new TextEncoder().encode(text);
+}
+
+function makeStreamResponse(chunks: Uint8Array[]): {
+  response: Response;
+  cancelSpy: ReturnType<typeof vi.fn>;
+} {
+  let index = 0;
+  const cancelSpy = vi.fn(async () => {});
+  const reader = {
+    read: vi.fn(async () => {
+      if (index >= chunks.length) return { done: true as const, value: undefined };
+      return { done: false as const, value: chunks[index++]! };
+    }),
+    cancel: cancelSpy,
+    releaseLock: vi.fn(),
+    closed: Promise.resolve(undefined),
+  };
+  const response = {
+    ok: true,
+    status: 200,
+    body: { getReader: () => reader },
+  } as unknown as Response;
+  return { response, cancelSpy };
+}
+
+// ---------------------------------------------------------------------------
+// happy path
+// ---------------------------------------------------------------------------
+
+describe("consumeCanonicalKaiStream — happy path", () => {
+  it("delivers all envelopes to onEnvelope in order", async () => {
+    const { response } = makeStreamResponse([makeChunk(3, true)]);
+    const received: KaiStreamEnvelope[] = [];
+    await consumeCanonicalKaiStream(response, (env) => received.push(env));
+    expect(received).toHaveLength(3);
+    expect(received[0]?.seq).toBe(1);
+    expect(received[2]?.terminal).toBe(true);
+  });
+
+  it("resolves without error when stream ends with a terminal envelope", async () => {
+    const { response } = makeStreamResponse([makeChunk(1, true)]);
+    await expect(consumeCanonicalKaiStream(response, () => {})).resolves.toBeUndefined();
+  });
+
+  it("rejects a non-ok response before reading any body", async () => {
+    const response = { ok: false, status: 503 } as Response;
+    await expect(consumeCanonicalKaiStream(response, () => {})).rejects.toThrow("503");
+  });
+
+  it("rejects when response body is null", async () => {
+    const response = { ok: true, status: 200, body: null } as unknown as Response;
+    await expect(consumeCanonicalKaiStream(response, () => {})).rejects.toThrow(
+      /no response stream/i
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MAX_FRAMES_PER_STREAM guard (CWE-400)
+// ---------------------------------------------------------------------------
+
+describe("consumeCanonicalKaiStream — MAX_FRAMES_PER_STREAM guard", () => {
+  it("rejects when frame count exceeds MAX_FRAMES_PER_STREAM", async () => {
+    // All frames arrive in one chunk — one read() call, deterministic count
+    const { response, cancelSpy } = makeStreamResponse([
+      makeChunk(MAX_FRAMES_PER_STREAM + 1, false),
+    ]);
+
+    await expect(
+      consumeCanonicalKaiStream(response, () => {}, { requireTerminal: false })
+    ).rejects.toThrow(/exceeded maximum frame count/i);
+
+    expect(cancelSpy).toHaveBeenCalled();
+  });
+
+  it("includes MAX_FRAMES_PER_STREAM value in the thrown error message", async () => {
+    const { response } = makeStreamResponse([makeChunk(MAX_FRAMES_PER_STREAM + 1, false)]);
+
+    await expect(
+      consumeCanonicalKaiStream(response, () => {}, { requireTerminal: false })
+    ).rejects.toThrow(String(MAX_FRAMES_PER_STREAM));
+  });
+
+  it("accepts a stream with exactly MAX_FRAMES_PER_STREAM frames", async () => {
+    const { response } = makeStreamResponse([makeChunk(MAX_FRAMES_PER_STREAM, true)]);
+    const received: KaiStreamEnvelope[] = [];
+
+    await expect(
+      consumeCanonicalKaiStream(response, (env) => received.push(env))
+    ).resolves.toBeUndefined();
+
+    expect(received).toHaveLength(MAX_FRAMES_PER_STREAM);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AbortSignal
+// ---------------------------------------------------------------------------
+
+describe("consumeCanonicalKaiStream — AbortSignal", () => {
+  it("rejects with AbortError when signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const { response } = makeStreamResponse([makeChunk(1, true)]);
+
+    await expect(
+      consumeCanonicalKaiStream(response, () => {}, { signal: controller.signal })
+    ).rejects.toThrow(/aborted/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// terminal frame enforcement
+// ---------------------------------------------------------------------------
+
+describe("consumeCanonicalKaiStream — terminal frame enforcement", () => {
+  it("rejects when requireTerminal=true (default) and no terminal frame arrives", async () => {
+    const { response } = makeStreamResponse([makeChunk(2, false)]);
+    await expect(consumeCanonicalKaiStream(response, () => {})).rejects.toThrow(/terminal/i);
+  });
+
+  it("resolves when requireTerminal=false and no terminal frame arrives", async () => {
+    const { response } = makeStreamResponse([makeChunk(2, false)]);
+    await expect(
+      consumeCanonicalKaiStream(response, () => {}, { requireTerminal: false })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/hushh-webapp/__tests__/streaming/sse-parser.test.ts
+++ b/hushh-webapp/__tests__/streaming/sse-parser.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { parseSSEBlocks } from "@/lib/streaming/sse-parser";
+import { MAX_FRAME_BYTES, parseSSEBlocks } from "@/lib/streaming/sse-parser";
 import { isKaiStreamEnvelope } from "@/lib/streaming/kai-stream-types";
 
 describe("parseSSEBlocks", () => {
@@ -59,5 +59,34 @@ describe("parseSSEBlocks", () => {
   it("ignores blocks without event and data", () => {
     const result = parseSSEBlocks(": ping\n\n\n");
     expect(result.events).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseSSEBlocks — MAX_FRAME_BYTES size guard (CWE-400)
+// ---------------------------------------------------------------------------
+
+describe("parseSSEBlocks — MAX_FRAME_BYTES size guard", () => {
+  it("throws when frame data exceeds MAX_FRAME_BYTES", () => {
+    const oversizeData = "x".repeat(MAX_FRAME_BYTES + 1);
+    const input = `event: stage\nid: 1\ndata: ${oversizeData}\n\n`;
+    expect(() => parseSSEBlocks(input)).toThrow(/exceeds maximum allowed size/i);
+  });
+
+  it("does not throw for a normal-sized production envelope", () => {
+    const input =
+      "event: stage\n" +
+      "id: 99\n" +
+      'data: {"schema_version":"1.0","stream_id":"strm_prod","stream_kind":"portfolio_import","seq":99,"event":"stage","terminal":false,"payload":{"stage":"complete"}}\n\n';
+    expect(() => parseSSEBlocks(input)).not.toThrow();
+  });
+
+  it("throws only on the oversized frame, not subsequent frames", () => {
+    const oversizeData = "y".repeat(MAX_FRAME_BYTES + 100);
+    const badFrame = `event: stage\nid: 1\ndata: ${oversizeData}\n\n`;
+    const goodFrame =
+      "event: stage\nid: 2\n" +
+      'data: {"schema_version":"1.0","stream_id":"s","stream_kind":"portfolio_import","seq":2,"event":"stage","terminal":false,"payload":{}}\n\n';
+    expect(() => parseSSEBlocks(badFrame + goodFrame)).toThrow(/exceeds maximum allowed size/i);
   });
 });

--- a/hushh-webapp/lib/streaming/kai-stream-client.ts
+++ b/hushh-webapp/lib/streaming/kai-stream-client.ts
@@ -1,6 +1,13 @@
 import { isKaiStreamEnvelope, type KaiStreamEnvelope } from "./kai-stream-types";
 import { parseSSEBlocks } from "./sse-parser";
 
+/**
+ * Maximum number of SSE frames accepted per stream connection (CWE-400).
+ * Prevents a runaway stream from consuming unbounded memory across the
+ * lifetime of a single connection.
+ */
+export const MAX_FRAMES_PER_STREAM = 10_000;
+
 interface ConsumeOptions {
   signal?: AbortSignal;
   idleTimeoutMs?: number;
@@ -26,6 +33,7 @@ export async function consumeCanonicalKaiStream(
   let buffer = "";
   let lastActivity = Date.now();
   let sawTerminal = false;
+  let totalFrames = 0;
 
   while (true) {
     if (options.signal?.aborted) {
@@ -46,6 +54,14 @@ export async function consumeCanonicalKaiStream(
     const parsed = parseSSEBlocks(chunk, buffer);
     buffer = parsed.remainder;
 
+    totalFrames += parsed.events.length;
+    if (totalFrames > MAX_FRAMES_PER_STREAM) {
+      reader.cancel();
+      throw new Error(
+        `Stream exceeded maximum frame count of ${MAX_FRAMES_PER_STREAM}`
+      );
+    }
+
     for (const frame of parsed.events) {
       const raw = JSON.parse(frame.data) as unknown;
       if (!isKaiStreamEnvelope(raw)) {
@@ -63,6 +79,12 @@ export async function consumeCanonicalKaiStream(
 
   if (buffer.trim()) {
     const parsed = parseSSEBlocks("\n\n", buffer);
+    totalFrames += parsed.events.length;
+    if (totalFrames > MAX_FRAMES_PER_STREAM) {
+      throw new Error(
+        `Stream exceeded maximum frame count of ${MAX_FRAMES_PER_STREAM}`
+      );
+    }
     for (const frame of parsed.events) {
       const raw = JSON.parse(frame.data) as unknown;
       if (!isKaiStreamEnvelope(raw)) {

--- a/hushh-webapp/lib/streaming/sse-parser.ts
+++ b/hushh-webapp/lib/streaming/sse-parser.ts
@@ -5,6 +5,13 @@ export interface ParseSSEBlocksResult {
   remainder: string;
 }
 
+/**
+ * Maximum byte length of a single SSE frame data payload (CWE-400).
+ * Prevents a malicious or runaway backend from crashing the browser tab
+ * by sending an unbounded JSON frame into the parser.
+ */
+export const MAX_FRAME_BYTES = 1 * 1024 * 1024; // 1 MB
+
 export function parseSSEBlocks(chunk: string, remainder = ""): ParseSSEBlocksResult {
   const normalized = (remainder + chunk).replace(/\r\n/g, "\n");
   const blocks = normalized.split("\n\n");
@@ -34,10 +41,18 @@ export function parseSSEBlocks(chunk: string, remainder = ""): ParseSSEBlocksRes
       continue;
     }
 
+    const rawData = dataLines.join("\n");
+    const byteLength = new TextEncoder().encode(rawData).length;
+    if (byteLength > MAX_FRAME_BYTES) {
+      throw new Error(
+        `SSE frame data exceeds maximum allowed size of ${MAX_FRAME_BYTES} bytes`
+      );
+    }
+
     events.push({
       event: eventName,
       id: eventId,
-      data: dataLines.join("\n"),
+      data: rawData,
     });
   }
 


### PR DESCRIPTION
## Summary

Adds defensive SSE stream boundary guards to protect the client against oversized frame payloads and runaway stream lifetimes (CWE-400 hardening).

## Changes

### `lib/streaming/sse-parser.ts`

- adds `MAX_FRAME_BYTES`
- validates UTF-8 byte size before emitting parsed frames
- rejects oversized frame payloads before JSON parsing

### `lib/streaming/kai-stream-client.ts`

- adds `MAX_FRAMES_PER_STREAM`
- tracks total processed frames across stream lifetime
- cancels the reader and throws when limits are exceeded
- applies enforcement during both active reads and trailing buffer flushes

## Tests Added

### `sse-parser.test.ts`

- oversized frame rejection
- valid production envelope acceptance
- oversized-frame termination behavior

### `kai-stream-client.test.ts`

- ordered envelope delivery
- frame count limit enforcement
- `reader.cancel()` verification
- exact-boundary acceptance
- abort signal handling
- terminal frame enforcement

## Why This Matters

Previously:
- individual SSE frames had no payload boundary
- stream lifetime had no frame-count ceiling

A malformed or runaway backend stream could:
- allocate extremely large parse buffers
- process unbounded frame counts over connection lifetime

This PR introduces lightweight defensive limits while preserving the existing stream contract and parsing flow.

## Validation

```bash
npx vitest run __tests__/streaming/sse-parser.test.ts __tests__/streaming/kai-stream-client.test.ts
npx tsc --noEmit
npm run lint