### PR TITLE
test(runtime): enforce retry delay floor

### DIFF
--- a/hushh-webapp/__tests__/services/retry-delay.test.ts
+++ b/hushh-webapp/__tests__/services/retry-delay.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MINIMUM_RETRY_DELAY_MS,
+  RETRY_DELAY_CONSTRAINT_ERROR,
+  enforceMinimumRetryDelayMs,
+  evaluateRetryIntervalConstraint,
+} from "@/lib/runtime/retry-delay";
+
+describe("retry delay constraints", () => {
+  it("accepts elapsed retry intervals at the minimum boundary", () => {
+    const initialExecutionTime = 1_716_500_000_000;
+    const result = evaluateRetryIntervalConstraint(
+      initialExecutionTime,
+      initialExecutionTime + MINIMUM_RETRY_DELAY_MS
+    );
+
+    expect(result).toEqual({
+      isDelayGateCompliant: true,
+      elapsedMs: MINIMUM_RETRY_DELAY_MS,
+      errorLabel: null,
+    });
+  });
+
+  it("rejects rapid-fire retry intervals below the minimum boundary", () => {
+    const initialExecutionTime = 1_716_500_000_000;
+    const result = evaluateRetryIntervalConstraint(
+      initialExecutionTime,
+      initialExecutionTime + 50
+    );
+
+    expect(result).toEqual({
+      isDelayGateCompliant: false,
+      elapsedMs: 50,
+      errorLabel: RETRY_DELAY_CONSTRAINT_ERROR,
+    });
+  });
+
+  it("normalizes configured retry delays before runtime scheduling uses them", () => {
+    expect(enforceMinimumRetryDelayMs(750)).toBe(MINIMUM_RETRY_DELAY_MS);
+    expect(enforceMinimumRetryDelayMs(2000)).toBe(2000);
+    expect(enforceMinimumRetryDelayMs(Number.NaN)).toBe(
+      MINIMUM_RETRY_DELAY_MS
+    );
+  });
+});

--- a/hushh-webapp/lib/runtime/retry-delay.ts
+++ b/hushh-webapp/lib/runtime/retry-delay.ts
@@ -1,0 +1,42 @@
+export const MINIMUM_RETRY_DELAY_MS = 1000;
+export const RETRY_DELAY_CONSTRAINT_ERROR =
+  "CONSTRAINT_VIOLATION_IMMEDIATE_RETRY_FLOOD";
+
+export interface RetryIntervalEvaluation {
+  isDelayGateCompliant: boolean;
+  elapsedMs: number;
+  errorLabel: string | null;
+}
+
+export function evaluateRetryIntervalConstraint(
+  initialExecutionTime: number,
+  retryExecutionTime: number,
+  minimumDelayMs = MINIMUM_RETRY_DELAY_MS
+): RetryIntervalEvaluation {
+  const elapsedMs = retryExecutionTime - initialExecutionTime;
+
+  if (elapsedMs < minimumDelayMs) {
+    return {
+      isDelayGateCompliant: false,
+      elapsedMs,
+      errorLabel: RETRY_DELAY_CONSTRAINT_ERROR,
+    };
+  }
+
+  return {
+    isDelayGateCompliant: true,
+    elapsedMs,
+    errorLabel: null,
+  };
+}
+
+export function enforceMinimumRetryDelayMs(
+  requestedDelayMs: number,
+  minimumDelayMs = MINIMUM_RETRY_DELAY_MS
+): number {
+  if (!Number.isFinite(requestedDelayMs)) {
+    return minimumDelayMs;
+  }
+
+  return Math.max(minimumDelayMs, requestedDelayMs);
+}

--- a/hushh-webapp/lib/services/debate-run-manager.ts
+++ b/hushh-webapp/lib/services/debate-run-manager.ts
@@ -8,11 +8,12 @@ import {
   type AnalysisHistoryEntry,
 } from "@/lib/services/kai-history-service";
 import { AppBackgroundTaskService } from "@/lib/services/app-background-task-service";
+import { enforceMinimumRetryDelayMs } from "@/lib/runtime/retry-delay";
 import { getSessionItem, setSessionItem } from "@/lib/utils/session-storage";
 
 const RUN_MANAGER_STORAGE_KEY = "kai_debate_run_manager_v1";
 const RUN_MANAGER_SESSION_KEY = "kai_debate_session_id_v1";
-const RETRY_DELAYS_MS = [750, 2000, 4500];
+const RETRY_DELAYS_MS = [750, 2000, 4500].map(enforceMinimumRetryDelayMs);
 const FINANCIAL_WRITE_WAIT_TIMEOUT_MS = 20_000;
 const FINANCIAL_WRITE_POLL_MS = 400;
 


### PR DESCRIPTION
# Description

This PR now hardens the web runtime retry-delay contract instead of adding a standalone root script.

It adds `hushh-webapp/lib/runtime/retry-delay.ts`, wires the minimum-delay guard into `hushh-webapp/lib/services/debate-run-manager.ts`, and covers the production helper with package-level Vitest in `hushh-webapp/__tests__/services/retry-delay.test.ts`.

## Impact Map

- Routes touched: None
- API / schema / type changes: Adds an internal web runtime helper type for retry-delay evaluation
- Cache keys touched: None
- World-model domain summary effects: None
- Mobile parity impacts: None
- Docs updated: None

## Verification

- Local targeted command attempted: `cd hushh-webapp && npm run test -- __tests__/services/retry-delay.test.ts`
- Local result: blocked because this checkout does not have `vitest` installed in `node_modules`
- CI proof expected from PR Validation / Web package checks on head `4c13d55705a84ac57955a24dd3c5a192a3127c69`

## Privacy & Consent

- Does this change access user data? No
- Consent token impact: None

## Licensing

- First-party changes remain Apache-2.0 compatible
- No dependency changes