### PR TITLE
ci(backup-posture): skip job on forks where GCP secret is absent

### DIFF
--- a/.github/workflows/prod-supabase-backup-posture.yml
+++ b/.github/workflows/prod-supabase-backup-posture.yml
@@ -17,6 +17,7 @@ env:
 jobs:
   backup-posture:
     name: Daily Logical Backup Posture Check
+    if: github.repository == 'hushh-labs/hushh-research'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 


### PR DESCRIPTION
## Summary

- The Prod Supabase Backup Posture workflow uses `google-github-actions/auth@v2` with `credentials_json: ${{ secrets.GCP_SA_KEY }}`
- `GCP_SA_KEY` is only configured in the canonical `hushh-labs/hushh-research` repo; contributor forks do not have it
- Every scheduled run in a fork fails immediately at the auth step with: `must specify exactly one of workload_identity_provider or credentials_json`
- Adding `if: github.repository == 'hushh-labs/hushh-research'` to the job causes it to be skipped (neutral) on forks and unchanged in production

## What changed

One line added to `.github/workflows/prod-supabase-backup-posture.yml`. No script or application code touched.

## Test plan

- [ ] Workflow continues to run on schedule in `hushh-labs/hushh-research`
- [ ] Workflow shows as skipped (not failed) on contributor forks after this merges