### PR TITLE
test(streaming): add malformed frame and continuation recovery coverage

### DIFF
--- a/hushh-webapp/__tests__/streaming/sse-parser.test.ts
+++ b/hushh-webapp/__tests__/streaming/sse-parser.test.ts
@@ -61,3 +61,102 @@ describe("parseSSEBlocks", () => {
     expect(result.events).toHaveLength(0);
   });
 });
+
+describe("parseSSEBlocks – malformed frame and continuation recovery", () => {
+  it("normalizes CRLF line endings before parsing", () => {
+    const crlfChunk =
+      "event: stage\r\n" +
+      "id: 10\r\n" +
+      'data: {"schema_version":"1.0","stream_id":"strm_crlf","stream_kind":"portfolio_import","seq":10,"event":"stage","terminal":false,"payload":{"stage":"done"}}\r\n\r\n';
+
+    const result = parseSSEBlocks(crlfChunk);
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]?.event).toBe("stage");
+    expect(result.events[0]?.id).toBe("10");
+    expect(result.remainder).toBe("");
+  });
+
+  it("parses two complete event blocks from a single chunk", () => {
+    const makeBlock = (seq: number, event: string): string =>
+      `event: ${event}\nid: ${seq}\n` +
+      `data: {"schema_version":"1.0","stream_id":"strm_multi","stream_kind":"stock_analyze","seq":${seq},"event":"${event}","terminal":false,"payload":{}}\n\n`;
+
+    const result = parseSSEBlocks(makeBlock(1, "stage") + makeBlock(2, "chunk"));
+
+    expect(result.events).toHaveLength(2);
+    expect(result.events[0]?.event).toBe("stage");
+    expect(result.events[1]?.event).toBe("chunk");
+    expect(result.remainder).toBe("");
+  });
+
+  it("ignores a block that has an event line but no data line", () => {
+    const result = parseSSEBlocks("event: stage\nid: 5\n\n");
+
+    expect(result.events).toHaveLength(0);
+    expect(result.remainder).toBe("");
+  });
+
+  it("ignores a block that has a data line but no event line", () => {
+    const result = parseSSEBlocks(
+      'data: {"schema_version":"1.0","stream_id":"s","stream_kind":"portfolio_import","seq":1,"event":"stage","terminal":false,"payload":{}}\n\n'
+    );
+
+    expect(result.events).toHaveLength(0);
+  });
+
+  it("produces no events and clears remainder for a whitespace-only chunk", () => {
+    const result = parseSSEBlocks("   \n\n   ");
+
+    expect(result.events).toHaveLength(0);
+    expect(result.remainder.trim()).toBe("");
+  });
+
+  it("parses a frame correctly when no id line is present", () => {
+    const result = parseSSEBlocks(
+      "event: stage\n" +
+        'data: {"schema_version":"1.0","stream_id":"strm_noid","stream_kind":"portfolio_optimize","seq":1,"event":"stage","terminal":false,"payload":{"stage":"ready"}}\n\n'
+    );
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]?.id).toBeUndefined();
+    expect(result.events[0]?.event).toBe("stage");
+  });
+
+  it("reassembles a frame split across three consecutive chunks", () => {
+    const part1 = 'event: chunk\nid: 7\ndata: {"schema_version":"1.0",';
+    const part2 = '"stream_id":"strm_split","stream_kind":"stock_analyze",';
+    const part3 =
+      '"seq":7,"event":"chunk","terminal":false,"payload":{"text":"hi"}}\n\n';
+
+    const r1 = parseSSEBlocks(part1);
+    expect(r1.events).toHaveLength(0);
+
+    const r2 = parseSSEBlocks(part2, r1.remainder);
+    expect(r2.events).toHaveLength(0);
+
+    const r3 = parseSSEBlocks(part3, r2.remainder);
+    expect(r3.events).toHaveLength(1);
+    expect(r3.events[0]?.event).toBe("chunk");
+    expect(r3.remainder).toBe("");
+  });
+
+  it("joins multiple data lines with a newline character", () => {
+    const result = parseSSEBlocks("event: chunk\ndata: line_a\ndata: line_b\n\n");
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]?.data).toBe("line_a\nline_b");
+  });
+
+  it("passes an empty chunk through without discarding the existing remainder", () => {
+    const partial = "event: stage\nid: 99\ndata: partial_payload";
+
+    const r1 = parseSSEBlocks(partial);
+    expect(r1.events).toHaveLength(0);
+    expect(r1.remainder).toContain("event: stage");
+
+    const r2 = parseSSEBlocks("", r1.remainder);
+    expect(r2.events).toHaveLength(0);
+    expect(r2.remainder).toContain("event: stage");
+  });
+});


### PR DESCRIPTION
Summary

Streaming parser recovery behavior must remain stable across malformed,
partial, and multi-frame SSE chunks to avoid parser-state corruption and
stream continuation regressions.

This regression coverage strengthens confidence around frame recovery,
chunk reassembly, and malformed-block handling behavior.

What's covered

__tests__/streaming/sse-parser.test.ts

Added deterministic regression coverage for:
- CRLF line-ending normalization
- multi-event chunk parsing
- malformed event/data block handling
- whitespace-only chunk behavior
- missing id-field parsing
- multi-chunk frame reassembly
- multi-line data joining
- empty chunk remainder preservation

Validation

npx vitest __tests__/streaming/sse-parser.test.ts
npx tsc --noEmit
npm run lint

Notes

- regression coverage only
- no production behavior changes
- no dependency changes
- isolated reviewer-safe diff
- DCO sign-off included