### PR TITLE
test(api-client): extend apiJson error extraction contract coverage

### DIFF
--- a/hushh-webapp/__tests__/services/api-client.test.ts
+++ b/hushh-webapp/__tests__/services/api-client.test.ts
@@ -51,4 +51,97 @@ describe("apiJson", () => {
       message: "Request failed: 500",
     });
   });
+
+  it("prefers the top-level error field over the message field", async () => {
+    mockApiFetch.mockResolvedValueOnce(
+      jsonResponse({ error: "error field wins", message: "message field loses" }, 400)
+    );
+
+    await expect(apiJson("/api/test")).rejects.toMatchObject({
+      message: "error field wins",
+      status: 400,
+    } satisfies Partial<ApiError>);
+  });
+
+  it("uses the top-level message field when error field is absent", async () => {
+    mockApiFetch.mockResolvedValueOnce(jsonResponse({ message: "standalone message" }, 422));
+
+    await expect(apiJson("/api/test")).rejects.toMatchObject({
+      message: "standalone message",
+      status: 422,
+    } satisfies Partial<ApiError>);
+  });
+
+  it("skips a whitespace-only error field and falls back to the message field", async () => {
+    mockApiFetch.mockResolvedValueOnce(
+      jsonResponse({ error: "   ", message: "real message" }, 400)
+    );
+
+    await expect(apiJson("/api/test")).rejects.toMatchObject({
+      message: "real message",
+    } satisfies Partial<ApiError>);
+  });
+
+  it("skips a whitespace-only detail string and falls back to the status code", async () => {
+    mockApiFetch.mockResolvedValueOnce(jsonResponse({ detail: "   " }, 400));
+
+    await expect(apiJson("/api/test")).rejects.toMatchObject({
+      message: "Request failed: 400",
+    } satisfies Partial<ApiError>);
+  });
+
+  it("uses the nested detail.error field when detail.message is absent", async () => {
+    mockApiFetch.mockResolvedValueOnce(
+      jsonResponse({ detail: { error: "nested error text" } }, 500)
+    );
+
+    await expect(apiJson("/api/test")).rejects.toMatchObject({
+      message: "nested error text",
+      status: 500,
+    } satisfies Partial<ApiError>);
+  });
+
+  it("uses the nested detail.code when no readable detail message exists when message and error are absent", async () => {
+    mockApiFetch.mockResolvedValueOnce(
+      jsonResponse({ detail: { code: "ERR_UNAVAILABLE" } }, 503)
+    );
+
+    await expect(apiJson("/api/test")).rejects.toMatchObject({
+      message: "ERR_UNAVAILABLE",
+      status: 503,
+    } satisfies Partial<ApiError>);
+  });
+
+  it("preserves the raw payload on the thrown ApiError", async () => {
+    const payload = { detail: { code: "ERR_PRESERVED", retryable: true } };
+    mockApiFetch.mockResolvedValueOnce(jsonResponse(payload, 503));
+
+    const error = await apiJson("/api/test").catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect((error as ApiError).payload).toEqual(payload);
+  });
+
+  it("returns the parsed JSON body on a successful 200 response", async () => {
+    const body = { ok: true, value: 42 };
+    mockApiFetch.mockResolvedValueOnce(jsonResponse(body, 200));
+
+    const result = await apiJson<typeof body>("/api/test");
+
+    expect(result).toEqual(body);
+  });
+
+  it("falls back to the status code when content-type is not JSON", async () => {
+    mockApiFetch.mockResolvedValueOnce(
+      new Response("plain text error", {
+        status: 502,
+        headers: { "content-type": "text/plain" },
+      })
+    );
+
+    await expect(apiJson("/api/test")).rejects.toMatchObject({
+      message: "Request failed: 502",
+      status: 502,
+    } satisfies Partial<ApiError>);
+  });
 });


### PR DESCRIPTION
Summary

apiJson error extraction behavior must remain stable across structured,
malformed, whitespace-only, and non-JSON payloads to avoid regressions
in caller-facing API error contracts.

This regression coverage strengthens confidence around field-selection
order, fallback behavior, and ApiError payload preservation.

What's covered

__tests__/services/api-client.test.ts

Added deterministic regression coverage for:
- top-level error/message selection precedence
- whitespace-only field fallback behavior
- nested detail.error extraction
- nested detail.code fallback behavior
- raw ApiError payload preservation
- successful JSON response handling
- non-JSON content-type fallback behavior

Validation

npx vitest __tests__/services/api-client.test.ts
npx tsc --noEmit
npm run lint

Notes

- regression coverage only
- no production behavior changes
- no dependency changes
- isolated reviewer-safe diff
- DCO sign-off included