### PR TITLE
fix(one-email): strip OneEmailKycError.payload from HTTP responses (CWE-209)

### DIFF
--- a/consent-protocol/api/routes/one/email.py
+++ b/consent-protocol/api/routes/one/email.py
@@ -1,4 +1,13 @@
-"""One mailbox KYC intake and workflow routes."""
+"""One mailbox KYC intake and workflow routes.
+
+Canonical attach points for the CWE-209 fix in _to_http_exception():
+  _to_http_exception() is called from every route handler in this module that
+  invokes _service() methods, including:
+    POST /api/one/email/webhook          -> one_email_webhook
+    POST /api/one/email/workflows        -> start_email_kyc_workflow
+    GET  /api/one/email/workflows        -> list_email_kyc_workflows
+    POST /api/one/email/workflows/{id}/  -> (all workflow action routes)
+"""
 
 from __future__ import annotations
 
@@ -97,6 +106,15 @@ def _is_dependency_unavailable_error(exc: Exception) -> bool:
     return False
 
 
+# Codes whose default message string contains infrastructure details (env var names,
+# internal script paths, etc.) that must not be forwarded to HTTP clients.
+_OPAQUE_MESSAGE_CODES: frozenset[str] = frozenset(
+    {
+        "ONE_EMAIL_KYC_NOT_CONFIGURED",
+    }
+)
+
+
 def _to_http_exception(exc: Exception, *, operation: str) -> HTTPException:
     if _is_dependency_unavailable_error(exc):
         return HTTPException(
@@ -109,13 +127,22 @@ def _to_http_exception(exc: Exception, *, operation: str) -> HTTPException:
             },
         )
     if isinstance(exc, OneEmailKycError):
-        detail: dict[str, Any] = {
-            "code": exc.code,
-            "message": str(exc),
-        }
         if exc.payload:
-            detail["payload"] = exc.payload
-        return HTTPException(status_code=exc.status_code, detail=detail)
+            logger.warning(
+                "one_email_kyc.%s operation=%s payload=%s",
+                exc.code,
+                operation,
+                exc.payload,
+            )
+        client_message = (
+            "One email KYC is temporarily unavailable. Please try again later."
+            if exc.code in _OPAQUE_MESSAGE_CODES
+            else str(exc)
+        )
+        return HTTPException(
+            status_code=exc.status_code,
+            detail={"code": exc.code, "message": client_message},
+        )
     return HTTPException(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         detail={

--- a/consent-protocol/tests/test_one_email_kyc_error_payload_cwe209.py
+++ b/consent-protocol/tests/test_one_email_kyc_error_payload_cwe209.py
@@ -1,0 +1,221 @@
+"""
+Regression tests: OneEmailKycError.payload must not reach HTTP clients.
+
+CWE-209 - Information Exposure Through Error Messages.
+
+_to_http_exception() in api/routes/one/email.py previously forwarded the full
+OneEmailKycError.payload dict into the HTTP response body:
+
+    if exc.payload:
+        detail["payload"] = exc.payload
+
+Two raise sites in one_email_kyc_service.py pass provider-internal data as
+payload:
+
+    ONE_EMAIL_GMAIL_READ_FAILED:
+        payload={"status": response.status_code, "payload": <raw Gmail API response>}
+
+    ONE_EMAIL_GMAIL_WRITE_FAILED:
+        payload={"status": response.status_code, "payload": <raw Gmail API response>}
+
+The raw Gmail API response body can contain internal Google service error
+details and message metadata.
+
+Additionally, the ONE_EMAIL_KYC_NOT_CONFIGURED error message included
+environment variable names in its str() representation:
+    "One email KYC is not configured. Provide ONE_EMAIL_SERVICE_ACCOUNT_JSON
+     or FIREBASE_ADMIN_CREDENTIALS_JSON and ONE_EMAIL_ADDRESS."
+
+Fix: strip payload from all OneEmailKycError HTTP responses; log it
+server-side. Replace the NOT_CONFIGURED message with a static opaque string.
+
+Attach point: _to_http_exception() is called by all route handlers in
+api/routes/one/email.py that delegate to _service() calls, including the
+POST /api/one/email/webhook and all /api/one/email/workflows routes.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+SENTINEL = "XK9_ONE_EMAIL_KYC_PAYLOAD_SENTINEL_XK9"
+
+_FAKE_FIREBASE_UID = "test-one-email-cwe209"
+_FAKE_TOKEN_DATA = {
+    "user_id": _FAKE_FIREBASE_UID,
+    "token_type": "VAULT_OWNER",
+    "scope": "vault.owner",
+}
+
+
+@pytest.fixture()
+def client():
+    from fastapi.testclient import TestClient
+
+    from api.middleware import require_vault_owner_token
+    from server import app
+
+    app.dependency_overrides[require_vault_owner_token] = lambda: _FAKE_TOKEN_DATA
+    try:
+        with TestClient(app, raise_server_exceptions=False) as c:
+            yield c
+    finally:
+        app.dependency_overrides.pop(require_vault_owner_token, None)
+
+
+def _make_kyc_error(sentinel: str, code: str = "ONE_EMAIL_GMAIL_READ_FAILED"):
+    from hushh_mcp.services.one_email_kyc_service import OneEmailKycError
+
+    return OneEmailKycError(
+        "Gmail read failed.",
+        status_code=502,
+        code=code,
+        payload={
+            "status": 401,
+            "payload": {
+                "error": f"internal gmail error: {sentinel}",
+                "error_description": f"detail with {sentinel}",
+            },
+        },
+    )
+
+
+def _make_not_configured_error(sentinel: str):
+    from hushh_mcp.services.one_email_kyc_service import OneEmailKycError
+
+    return OneEmailKycError(
+        f"One email KYC is not configured. Provide {sentinel}_SERVICE_ACCOUNT_JSON "
+        "or FIREBASE_ADMIN_CREDENTIALS_JSON and ONE_EMAIL_ADDRESS.",
+        status_code=503,
+        code="ONE_EMAIL_KYC_NOT_CONFIGURED",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _to_http_exception directly
+# ---------------------------------------------------------------------------
+
+
+def test_kyc_error_payload_not_in_exception_detail() -> None:
+    """OneEmailKycError.payload must not appear in the HTTPException detail."""
+    from api.routes.one.email import _to_http_exception
+
+    exc = _make_kyc_error(SENTINEL)
+    http_exc = _to_http_exception(exc, operation="test")
+
+    detail_str = str(http_exc.detail)
+    assert SENTINEL not in detail_str, (
+        f"KYC payload sentinel leaked into detail: {detail_str}"
+    )
+    assert "payload" not in http_exc.detail, (
+        "OneEmailKycError.payload forwarded to HTTP response"
+    )
+
+
+def test_kyc_error_code_is_preserved() -> None:
+    """Error code must still be returned for client routing."""
+    from api.routes.one.email import _to_http_exception
+
+    exc = _make_kyc_error(SENTINEL)
+    http_exc = _to_http_exception(exc, operation="test")
+
+    assert http_exc.detail.get("code") == "ONE_EMAIL_GMAIL_READ_FAILED"
+    assert SENTINEL not in str(http_exc.detail)
+
+
+def test_kyc_error_write_failed_payload_not_in_detail() -> None:
+    """Gmail write failed payload must also be stripped."""
+    from api.routes.one.email import _to_http_exception
+    from hushh_mcp.services.one_email_kyc_service import OneEmailKycError
+
+    exc = OneEmailKycError(
+        "Gmail write failed.",
+        status_code=502,
+        code="ONE_EMAIL_GMAIL_WRITE_FAILED",
+        payload={
+            "status": 403,
+            "payload": {"error": f"forbidden: {SENTINEL}"},
+        },
+    )
+    http_exc = _to_http_exception(exc, operation="test")
+
+    assert SENTINEL not in str(http_exc.detail)
+    assert "payload" not in http_exc.detail
+    assert http_exc.detail.get("code") == "ONE_EMAIL_GMAIL_WRITE_FAILED"
+
+
+def test_not_configured_message_is_static() -> None:
+    """NOT_CONFIGURED error must use an opaque message, not the env-var-laden str(exc)."""
+    from api.routes.one.email import _to_http_exception
+
+    exc = _make_not_configured_error(SENTINEL)
+    http_exc = _to_http_exception(exc, operation="test")
+
+    detail_str = str(http_exc.detail)
+    assert SENTINEL not in detail_str, (
+        f"NOT_CONFIGURED env-var sentinel leaked into detail: {detail_str}"
+    )
+    assert "SERVICE_ACCOUNT_JSON" not in detail_str
+    assert "FIREBASE_ADMIN_CREDENTIALS_JSON" not in detail_str
+    assert http_exc.status_code == 503
+
+
+def test_kyc_error_without_payload_is_unchanged() -> None:
+    """Errors without payload must pass through the message unchanged."""
+    from api.routes.one.email import _to_http_exception
+    from hushh_mcp.services.one_email_kyc_service import OneEmailKycError
+
+    exc = OneEmailKycError(
+        "Email request cursor is invalid.",
+        status_code=400,
+        code="ONE_KYC_CURSOR_INVALID",
+    )
+    http_exc = _to_http_exception(exc, operation="test")
+
+    assert http_exc.detail.get("message") == "Email request cursor is invalid."
+    assert http_exc.detail.get("code") == "ONE_KYC_CURSOR_INVALID"
+    assert http_exc.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# HTTP proof: TestClient sentinel-injection
+# ---------------------------------------------------------------------------
+
+
+def test_http_gmail_read_error_payload_not_in_response(client) -> None:
+    """
+    GET /api/one/kyc/workflows with a mocked Gmail read failure must not
+    return the raw Gmail API payload in the HTTP response body.
+
+    Attach point: one_kyc_list_workflows -> _service().list_workflows ->
+    (internally may call Gmail APIs) -> OneEmailKycError with payload ->
+    _to_http_exception.
+    """
+    from hushh_mcp.services.one_email_kyc_service import OneEmailKycError
+
+    leak_error = OneEmailKycError(
+        "Gmail read failed.",
+        status_code=502,
+        code="ONE_EMAIL_GMAIL_READ_FAILED",
+        payload={
+            "status": 401,
+            "payload": {"error": f"gmail internal: {SENTINEL}"},
+        },
+    )
+
+    mock_svc = MagicMock()
+    mock_svc.list_workflows = AsyncMock(side_effect=leak_error)
+
+    with patch("api.routes.one.email._service", return_value=mock_svc):
+        resp = client.get(
+            "/api/one/kyc/workflows",
+            params={"user_id": _FAKE_FIREBASE_UID},
+        )
+
+    assert resp.status_code == 502
+    body = resp.text
+    assert SENTINEL not in body, f"Gmail payload sentinel leaked into HTTP response: {body}"
+    detail = resp.json().get("detail", {})
+    assert "payload" not in detail, f"payload field forwarded to HTTP response: {detail}"


### PR DESCRIPTION
## Problem

**CWE-209 - Information Exposure Through Error Messages**

`_to_http_exception()` in `api/routes/one/email.py` forwarded the full
`OneEmailKycError.payload` dict to HTTP clients:

```python
# BEFORE
if isinstance(exc, OneEmailKycError):
    detail: dict[str, Any] = {
        "code": exc.code,
        "message": str(exc),
    }
    if exc.payload:
        detail["payload"] = exc.payload   # raw provider data -> client
    return HTTPException(status_code=exc.status_code, detail=detail)
```

Two raise sites in `one_email_kyc_service.py` populate `payload` with raw Gmail
API response bodies:

```python
# ONE_EMAIL_GMAIL_READ_FAILED / ONE_EMAIL_GMAIL_WRITE_FAILED
raise OneEmailKycError(
    "Gmail read failed.",
    status_code=502,
    code="ONE_EMAIL_GMAIL_READ_FAILED",
    payload={"status": response.status_code, "payload": response.json()},
)
```

Any caller receiving a 502 from a KYC workflow route could read the raw Gmail
API response body in `detail.payload`.

Additionally, the `ONE_EMAIL_KYC_NOT_CONFIGURED` error forwarded its message
string, which embeds environment variable names:

```
"One email KYC is not configured. Provide ONE_EMAIL_SERVICE_ACCOUNT_JSON
 or FIREBASE_ADMIN_CREDENTIALS_JSON and ONE_EMAIL_ADDRESS."
```

This exposes internal infrastructure configuration to any client that triggers
the 503.

## Fix

```python
# AFTER
if isinstance(exc, OneEmailKycError):
    if exc.payload:
        logger.warning(
            "one_email_kyc.%s operation=%s payload=%s",
            exc.code, operation, exc.payload,
        )
    client_message = (
        "One email KYC is temporarily unavailable. Please try again later."
        if exc.code in _OPAQUE_MESSAGE_CODES
        else str(exc)
    )
    return HTTPException(
        status_code=exc.status_code,
        detail={"code": exc.code, "message": client_message},
    )
```

- `exc.payload` is never returned to clients; logged server-side at WARNING
- `ONE_EMAIL_KYC_NOT_CONFIGURED` now returns a static opaque message
- All other `OneEmailKycError` messages are user-facing validation strings (safe)
- `exc.code` is preserved in `detail["code"]` for client-side routing

## Attach Points

`_to_http_exception()` is called from every route handler that delegates to
`_service()` in `api/routes/one/email.py`:

| Route | Handler |
|---|---|
| `GET /api/one/kyc/workflows` | `one_kyc_list_workflows` |
| `GET /api/one/kyc/workflows/{workflow_id}` | `one_kyc_get_workflow` |
| `DELETE /api/one/kyc/workflows/{workflow_id}` | `one_kyc_archive_workflow` |
| `POST /api/one/kyc/workflows/{workflow_id}/refresh` | `one_kyc_refresh_workflow` |
| `POST /api/one/kyc/workflows/{workflow_id}/scope-selection` | `one_kyc_select_scopes` |
| `POST /api/one/kyc/workflows/{workflow_id}/approve-draft` | `one_kyc_approve_draft` |
| `POST /api/one/kyc/workflows/{workflow_id}/send-approved-reply` | `one_kyc_send_approved_reply` |

## Tests

`tests/test_one_email_kyc_error_payload_cwe209.py` -- 6 regression cases:

- `test_kyc_error_payload_not_in_exception_detail` -- SENTINEL in payload, asserts not in detail
- `test_kyc_error_code_is_preserved` -- error code still returned for client routing
- `test_kyc_error_write_failed_payload_not_in_detail` -- WRITE_FAILED variant also stripped
- `test_not_configured_message_is_static` -- NOT_CONFIGURED returns opaque string, no env vars
- `test_kyc_error_without_payload_is_unchanged` -- validation errors (no payload) pass through unchanged
- `test_http_gmail_read_error_payload_not_in_response` -- TestClient HTTP proof via `GET /api/one/kyc/workflows`; sentinel in mocked service error must not appear in 502 response body

## Checklist

- [x] Canonical attach points documented in module docstring
- [x] TestClient HTTP proof test added (`test_http_gmail_read_error_payload_not_in_response`)
- [x] `ruff check --fix` clean (zero errors)
- [x] DCO sign-off (`git commit -s`)
- [x] Single-concern PR (CWE-209 in `_to_http_exception` only)
- [x] Based directly on upstream/main