### PR TITLE
fix(agent-chat): add max_length=128 to path params on 4 agent chat routes (CWE-400)

### DIFF
--- a/consent-protocol/api/routes/kai/agent_chat.py
+++ b/consent-protocol/api/routes/kai/agent_chat.py
@@ -1,13 +1,20 @@
-"""Agent text chat routes backed by Gemini streaming."""
+"""Agent text chat routes backed by Gemini streaming.
+
+Canonical attach points for the CWE-400 path-param bound fix:
+  list_agent_chat_conversations    -> GET  /api/kai/agent/chat/conversations/{user_id}
+  rename_agent_chat_conversation   -> PATCH /api/kai/agent/chat/conversations/{conversation_id}
+  delete_agent_chat_conversation   -> DELETE /api/kai/agent/chat/conversations/{conversation_id}
+  get_agent_chat_history           -> GET  /api/kai/agent/chat/history/{conversation_id}
+"""
 
 from __future__ import annotations
 
 import asyncio
 import json
 import logging
-from typing import Any, Literal, Optional
+from typing import Annotated, Any, Literal, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, status
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
@@ -25,6 +32,12 @@ from hushh_mcp.services.agent_chat_service import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["Agent Chat"])
+
+# Annotated path-parameter types with HTTP-layer size guards (CWE-400).
+# Unbounded path strings propagate into DB lookups and service calls before
+# any auth short-circuit, so a 128-char cap is enforced at the route level.
+_UserId = Annotated[str, Path(min_length=1, max_length=128)]
+_ConversationId = Annotated[str, Path(min_length=1, max_length=128)]
 
 
 class AgentChatStreamRequest(BaseModel):
@@ -380,7 +393,7 @@ async def stream_agent_chat(
 
 @router.get("/agent/chat/conversations/{user_id}", response_model=AgentChatConversationsResponse)
 async def list_agent_chat_conversations(
-    user_id: str,
+    user_id: _UserId,
     token_data: dict = Depends(require_vault_owner_token),
     limit: int = Query(default=5, ge=1, le=20),
 ):
@@ -396,7 +409,7 @@ async def list_agent_chat_conversations(
     "/agent/chat/conversations/{conversation_id}", response_model=AgentChatConversationModel
 )
 async def rename_agent_chat_conversation(
-    conversation_id: str,
+    conversation_id: _ConversationId,
     body: AgentChatRenameRequest,
     token_data: dict = Depends(require_vault_owner_token),
 ):
@@ -416,7 +429,7 @@ async def rename_agent_chat_conversation(
     response_model=AgentChatDeleteResponse,
 )
 async def delete_agent_chat_conversation(
-    conversation_id: str,
+    conversation_id: _ConversationId,
     token_data: dict = Depends(require_vault_owner_token),
 ):
     user_id = str(token_data.get("user_id") or "")
@@ -431,7 +444,7 @@ async def delete_agent_chat_conversation(
 
 @router.get("/agent/chat/history/{conversation_id}", response_model=AgentChatHistoryResponse)
 async def get_agent_chat_history(
-    conversation_id: str,
+    conversation_id: _ConversationId,
     token_data: dict = Depends(require_vault_owner_token),
     limit: int = Query(default=50, ge=1, le=100),
 ):

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -18,3 +18,4 @@ tests/test_stream_path_query_bounds_cwe400.py
 tests/performance/test_market_cache_instrumentation.py
 tests/test_llm_operon_stream_error_leak.py
 tests/test_stream_agent_thinking_gemini_error_cwe209.py
+tests/test_agent_chat_path_param_bounds.py

--- a/consent-protocol/tests/test_agent_chat_path_param_bounds.py
+++ b/consent-protocol/tests/test_agent_chat_path_param_bounds.py
@@ -1,0 +1,108 @@
+"""
+Regression tests: agent chat path parameters must be bounded.
+
+CWE-400 - Uncontrolled Resource Consumption.
+
+Four GET/PATCH/DELETE routes in api/routes/kai/agent_chat.py accepted bare
+string path parameters with no length constraint:
+
+    GET    /api/kai/agent/chat/conversations/{user_id}
+    PATCH  /api/kai/agent/chat/conversations/{conversation_id}
+    DELETE /api/kai/agent/chat/conversations/{conversation_id}
+    GET    /api/kai/agent/chat/history/{conversation_id}
+
+An arbitrarily long string (e.g. 10,000 characters) passed as a path segment
+propagates into DB lookups and service calls without any HTTP-layer rejection.
+This can cause excessive memory allocation and processing work before any auth
+check short-circuits it.
+
+Fix: annotate all four path parameters with Path(min_length=1, max_length=128)
+using the _UserId and _ConversationId aliases defined at module level.
+
+Attach points:
+  list_agent_chat_conversations  -> GET  /api/kai/agent/chat/conversations/{user_id}
+  rename_agent_chat_conversation -> PATCH /api/kai/agent/chat/conversations/{conversation_id}
+  delete_agent_chat_conversation -> DELETE /api/kai/agent/chat/conversations/{conversation_id}
+  get_agent_chat_history         -> GET  /api/kai/agent/chat/history/{conversation_id}
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+_FAKE_TOKEN_DATA = {
+    "user_id": "test-agent-chat-user",
+    "token_type": "VAULT_OWNER",
+    "scope": "vault.owner",
+}
+
+_TOO_LONG = "x" * 129
+_VALID_ID = "valid-agent-chat-id-1"
+
+
+@pytest.fixture(scope="module")
+def client():
+    from api.middleware import require_vault_owner_token
+    from server import app
+
+    app.dependency_overrides[require_vault_owner_token] = lambda: _FAKE_TOKEN_DATA
+    try:
+        with TestClient(app, raise_server_exceptions=False) as c:
+            yield c
+    finally:
+        app.dependency_overrides.pop(require_vault_owner_token, None)
+
+
+def test_list_conversations_rejects_oversized_user_id(client) -> None:
+    """GET /conversations/{user_id} with a 129-char user_id must return 422."""
+    resp = client.get(f"/api/kai/agent/chat/conversations/{_TOO_LONG}")
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized user_id, got {resp.status_code}"
+    )
+
+
+def test_list_conversations_accepts_128_char_user_id(client) -> None:
+    """GET /conversations/{user_id} with a 128-char user_id must not be rejected."""
+    boundary = "a" * 128
+    resp = client.get(f"/api/kai/agent/chat/conversations/{boundary}")
+    # 422 would mean the bounds check rejected it; any other status is OK here
+    assert resp.status_code != 422, (
+        "128-char user_id incorrectly rejected with 422"
+    )
+
+
+def test_rename_conversation_rejects_oversized_conversation_id(client) -> None:
+    """PATCH /conversations/{conversation_id} with a 129-char id must return 422."""
+    resp = client.patch(
+        f"/api/kai/agent/chat/conversations/{_TOO_LONG}",
+        json={"title": "New title"},
+    )
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized conversation_id, got {resp.status_code}"
+    )
+
+
+def test_delete_conversation_rejects_oversized_conversation_id(client) -> None:
+    """DELETE /conversations/{conversation_id} with a 129-char id must return 422."""
+    resp = client.delete(f"/api/kai/agent/chat/conversations/{_TOO_LONG}")
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized conversation_id, got {resp.status_code}"
+    )
+
+
+def test_get_history_rejects_oversized_conversation_id(client) -> None:
+    """GET /history/{conversation_id} with a 129-char id must return 422."""
+    resp = client.get(f"/api/kai/agent/chat/history/{_TOO_LONG}")
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized conversation_id, got {resp.status_code}"
+    )
+
+
+def test_get_history_accepts_128_char_conversation_id(client) -> None:
+    """GET /history/{conversation_id} with a 128-char id must not be rejected at bounds."""
+    boundary = "b" * 128
+    resp = client.get(f"/api/kai/agent/chat/history/{boundary}")
+    assert resp.status_code != 422, (
+        "128-char conversation_id incorrectly rejected with 422"
+    )


### PR DESCRIPTION
## Problem

**CWE-400 - Uncontrolled Resource Consumption**

Four agent chat routes in `api/routes/kai/agent_chat.py` accepted bare `str`
path parameters with no size constraint:

```python
# BEFORE
GET    /api/kai/agent/chat/conversations/{user_id}   -> user_id: str
PATCH  /api/kai/agent/chat/conversations/{conversation_id} -> conversation_id: str
DELETE /api/kai/agent/chat/conversations/{conversation_id} -> conversation_id: str
GET    /api/kai/agent/chat/history/{conversation_id}       -> conversation_id: str
```

An attacker can send an arbitrarily long string (e.g. 10,000 characters) as a
path segment. The string propagates into DB lookups and service calls without
any HTTP-layer rejection, causing excessive allocation and processing work
before any auth check short-circuits it.

This is the same class of defect fixed in `api/routes/kai/chat.py` (PR #1291),
`api/routes/kai/decisions.py` (PR #1454), `api/routes/world_model.py`, and
`api/routes/sse.py`.

## Fix

Introduce module-level `Annotated` type aliases with `Path(min_length=1, max_length=128)`
and apply them to all four handlers:

```python
# AFTER
_UserId = Annotated[str, Path(min_length=1, max_length=128)]
_ConversationId = Annotated[str, Path(min_length=1, max_length=128)]

GET    /api/kai/agent/chat/conversations/{user_id}        -> user_id: _UserId
PATCH  /api/kai/agent/chat/conversations/{conversation_id} -> conversation_id: _ConversationId
DELETE /api/kai/agent/chat/conversations/{conversation_id} -> conversation_id: _ConversationId
GET    /api/kai/agent/chat/history/{conversation_id}      -> conversation_id: _ConversationId
```

FastAPI rejects oversized path segments at the HTTP layer with a 422 before
any handler logic runs.

## Attach Points

| Route | Handler |
|---|---|
| `GET /api/kai/agent/chat/conversations/{user_id}` | `list_agent_chat_conversations` |
| `PATCH /api/kai/agent/chat/conversations/{conversation_id}` | `rename_agent_chat_conversation` |
| `DELETE /api/kai/agent/chat/conversations/{conversation_id}` | `delete_agent_chat_conversation` |
| `GET /api/kai/agent/chat/history/{conversation_id}` | `get_agent_chat_history` |

## Tests

`tests/test_agent_chat_path_param_bounds.py` -- 6 regression cases (module-scoped client):

- `test_list_conversations_rejects_oversized_user_id` -- 129-char user_id returns 422
- `test_list_conversations_accepts_128_char_user_id` -- 128-char user_id passes bounds check
- `test_rename_conversation_rejects_oversized_conversation_id` -- 129-char returns 422
- `test_delete_conversation_rejects_oversized_conversation_id` -- 129-char returns 422
- `test_get_history_rejects_oversized_conversation_id` -- 129-char returns 422
- `test_get_history_accepts_128_char_conversation_id` -- 128-char passes bounds check

## Checklist

- [x] Canonical attach points documented in module docstring
- [x] TestClient HTTP proof tests added (6 cases across all 4 routes)
- [x] `ruff check --fix` clean (zero errors)
- [x] DCO sign-off (`git commit -s`)
- [x] Single-concern PR (path param bounds only)
- [x] Based directly on upstream/main