### PR TITLE
fix(security): add missing min_length=1 to pkm and tickers path params (CWE-400)

### DIFF
--- a/consent-protocol/api/routes/pkm.py
+++ b/consent-protocol/api/routes/pkm.py
@@ -160,7 +160,7 @@ async def validate_store_domain(
 
 @router.get("/data/{user_id}", response_model=dict)
 async def get_encrypted_data(
-    user_id: str = Path(..., max_length=128),
+    user_id: str = Path(..., min_length=1, max_length=128),
     token_data: dict = Depends(require_vault_owner_token),
 ):
     return await _get_encrypted_data(user_id, token_data)
@@ -168,7 +168,7 @@ async def get_encrypted_data(
 
 @router.get("/domain-data/{user_id}/{domain}", response_model=DomainDataResponse)
 async def get_domain_data(
-    user_id: str = Path(..., max_length=128),
+    user_id: str = Path(..., min_length=1, max_length=128),
     domain: str = Path(..., max_length=64),
     segment_ids: list[str] | None = Depends(_validated_segment_ids),
     token_data: dict = Depends(require_vault_owner_token),
@@ -178,7 +178,7 @@ async def get_domain_data(
 
 @router.get("/manifest/{user_id}/{domain}", response_model=DomainManifestResponse)
 async def get_domain_manifest(
-    user_id: str = Path(..., max_length=128),
+    user_id: str = Path(..., min_length=1, max_length=128),
     domain: str = Path(..., max_length=64),
     token_data: dict = Depends(require_vault_owner_token),
 ):
@@ -187,7 +187,7 @@ async def get_domain_manifest(
 
 @router.delete("/domain-data/{user_id}/{domain}", response_model=DeleteDomainResponse)
 async def delete_domain_data(
-    user_id: str = Path(..., max_length=128),
+    user_id: str = Path(..., min_length=1, max_length=128),
     domain: str = Path(..., max_length=64),
     token_data: dict = Depends(require_vault_owner_token),
 ):

--- a/consent-protocol/api/routes/tickers.py
+++ b/consent-protocol/api/routes/tickers.py
@@ -82,7 +82,7 @@ async def ticker_cache_status():
 @router.post("/sync-holdings/{user_id}", response_model=dict)
 async def sync_tickers_from_holdings(
     request: SyncHoldingsRequest,
-    user_id: str = Path(..., max_length=128),
+    user_id: str = Path(..., min_length=1, max_length=128),
     token_data: dict = Depends(require_vault_owner_token),
 ):
     """

--- a/consent-protocol/tests/test_pkm_route_path_param_bounds.py
+++ b/consent-protocol/tests/test_pkm_route_path_param_bounds.py
@@ -3,18 +3,26 @@
 user_id and domain path params previously had no max_length constraint,
 allowing arbitrarily long strings to reach service layer logic.
 
+user_id also previously had no min_length, inconsistent with the
+min_length=1, max_length=128 pattern used for the same field elsewhere
+(e.g. api/routes/ria.py). A true empty path segment can never reach this
+validation layer (Starlette 404s on it before FastAPI runs Path checks),
+so the signature itself is asserted as the proof of the bound.
+
 Note: The auth dependency runs before path param validation in FastAPI, so
 tests must stub the vault-owner dependency to reach the validation layer.
 """
 
 from __future__ import annotations
 
+import inspect
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from api import middleware as api_middleware
-from api.routes import pkm
+from api.routes import pkm, tickers
 
 
 def _stub_auth() -> dict:
@@ -69,3 +77,50 @@ class TestDomainBound:
     def test_delete_domain_data_long_domain_returns_422(self, client: TestClient) -> None:
         response = client.delete(f"/api/pkm/domain-data/{_VALID_USER}/{_LONG_65}")
         assert response.status_code == 422
+
+
+class TestUserIdMinLengthConsistency:
+    """user_id path params must declare min_length=1 alongside max_length=128.
+
+    Starlette never routes a truly empty path segment to the handler, so this
+    is asserted on the route signature rather than driven through TestClient.
+    """
+
+    _PKM_FUNCS = (
+        pkm.get_encrypted_data,
+        pkm.get_domain_data,
+        pkm.get_domain_manifest,
+        pkm.delete_domain_data,
+    )
+
+    @staticmethod
+    def _bounds(default) -> tuple[int | None, int | None]:
+        min_length = next(
+            (m.min_length for m in default.metadata if hasattr(m, "min_length")), None
+        )
+        max_length = next(
+            (m.max_length for m in default.metadata if hasattr(m, "max_length")), None
+        )
+        return min_length, max_length
+
+    @pytest.mark.parametrize("func", _PKM_FUNCS, ids=lambda f: f.__name__)
+    def test_pkm_user_id_param_has_min_length(self, func) -> None:
+        default = inspect.signature(func).parameters["user_id"].default
+        assert self._bounds(default) == (1, 128)
+
+    def test_tickers_sync_holdings_user_id_param_has_min_length(self) -> None:
+        default = inspect.signature(tickers.sync_tickers_from_holdings).parameters[
+            "user_id"
+        ].default
+        assert self._bounds(default) == (1, 128)
+
+    def test_sync_holdings_route_reachable_with_valid_user_id(self) -> None:
+        app = FastAPI()
+        app.include_router(tickers.router)
+        app.dependency_overrides[api_middleware.require_vault_owner_token] = _stub_auth
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post(
+            f"/api/tickers/sync-holdings/{_VALID_USER}",
+            json={"holdings": []},
+        )
+        assert response.status_code != 422, response.text


### PR DESCRIPTION
## Problem (CWE-400)

\`user_id\` path parameters on 5 routes had \`max_length=128\` but no \`min_length\`, inconsistent with the \`min_length=1, max_length=128\` pattern used for the same field elsewhere (e.g. \`api/routes/ria.py\`):

- \`GET /api/pkm/data/{user_id}\`
- \`GET /api/pkm/domain-data/{user_id}/{domain}\`
- \`GET /api/pkm/manifest/{user_id}/{domain}\`
- \`DELETE /api/pkm/domain-data/{user_id}/{domain}\`
- \`POST /api/tickers/sync-holdings/{user_id}\`

## Fix

Added \`min_length=1\` to all 5. A true empty path segment never reaches this validation layer (Starlette 404s on it before FastAPI runs Path checks), so this is a defense-in-depth consistency fix rather than closing a directly reachable exploit, matching the bound pattern used on the same field elsewhere in the codebase.

## Tests

Extended \`tests/test_pkm_route_path_param_bounds.py\` with a \`TestUserIdMinLengthConsistency\` class: asserts \`min_length=1, max_length=128\` on the route signatures for all 5 functions, and a reachability test confirming \`sync-holdings\` still works for a valid \`user_id\`.

## Note

This PR's title previously said "Add path param bounds to SSE routes," but the diff has never touched any SSE route file. Per an earlier comment on this PR, the SSE-specific bounds had already landed via other merges, and the actual remaining scope is the PKM/tickers \`min_length\` consistency above. Retitled to match the real diff.