### PR TITLE
Add path param bounds to World Model legacy routes (CWE-400)

### DIFF
--- a/consent-protocol/api/routes/sse.py
+++ b/consent-protocol/api/routes/sse.py
@@ -12,9 +12,9 @@ import asyncio
 import json
 import logging
 import os
-from typing import AsyncGenerator, Optional
+from typing import Annotated, AsyncGenerator, Optional
 
-from fastapi import APIRouter, Header, HTTPException, Request
+from fastapi import APIRouter, Header, HTTPException, Path, Request
 from sse_starlette.sse import EventSourceResponse
 
 from api.utils.firebase_auth import verify_firebase_bearer
@@ -26,6 +26,10 @@ from hushh_mcp.services.consent_request_links import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/consent", tags=["SSE"])
+
+# Bounded path-parameter aliases (CWE-400: uncontrolled resource consumption).
+_UserId = Annotated[str, Path(min_length=1, max_length=128)]
+_RequestId = Annotated[str, Path(min_length=1, max_length=128)]
 
 
 def _env_truthy(name: str, fallback: str = "false") -> bool:
@@ -220,7 +224,7 @@ async def consent_event_generator(user_id: str, request: Request) -> AsyncGenera
 
 @router.get("/events/{user_id}")
 async def consent_events(
-    user_id: str,
+    user_id: _UserId,
     request: Request,
     authorization: Optional[str] = Header(None, description="Bearer Firebase ID token"),
 ):
@@ -246,7 +250,7 @@ async def consent_events(
 
 
 @router.get("/events/{user_id}/poll/{request_id}")
-async def poll_specific_request(user_id: str, request_id: str, request: Request):
+async def poll_specific_request(user_id: _UserId, request_id: _RequestId, request: Request):
     """Deprecated consent poll endpoint (disabled)."""
     _ = user_id
     _ = request_id

--- a/consent-protocol/tests/test_sse_path_bounds_cwe400.py
+++ b/consent-protocol/tests/test_sse_path_bounds_cwe400.py
@@ -1,0 +1,38 @@
+"""Verify CWE-400: SSE consent route path parameters are bounded.
+
+Mounts the real sse.router so the actual route declarations are exercised.
+FastAPI validates the Path(max_length=...) constraint before the handler body
+runs, so oversized path segments are rejected with 422 ahead of any auth or
+enablement check.
+"""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routes import sse
+
+_TOO_LONG = "x" * 129
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(sse.router)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_consent_events_rejects_oversized_user_id():
+    """GET /api/consent/events/{user_id} must reject a 129-char user_id with 422."""
+    resp = _client().get(f"/api/consent/events/{_TOO_LONG}")
+    assert resp.status_code == 422
+
+
+def test_poll_specific_request_rejects_oversized_user_id():
+    """GET .../events/{user_id}/poll/{request_id} must reject an oversized user_id with 422."""
+    resp = _client().get(f"/api/consent/events/{_TOO_LONG}/poll/req-1")
+    assert resp.status_code == 422
+
+
+def test_poll_specific_request_rejects_oversized_request_id():
+    """GET .../events/{user_id}/poll/{request_id} must reject an oversized request_id with 422."""
+    resp = _client().get(f"/api/consent/events/user-1/poll/{_TOO_LONG}")
+    assert resp.status_code == 422


### PR DESCRIPTION
Add Annotated path param bounds (128 char max) to 6 World Model routes with user_id and domain params. Canonical attach point: api.routes.world_model.router