### PR TITLE
Add path param bounds to invites routes (CWE-400)

### DIFF
--- a/consent-protocol/api/routes/invites.py
+++ b/consent-protocol/api/routes/invites.py
@@ -14,6 +14,9 @@ from hushh_mcp.services.ria_iam_service import (
 
 router = APIRouter(prefix="/api/invites", tags=["RIA Invites"])
 
+_UserId = Annotated[str, Path(min_length=1, max_length=128)]
+
+
 
 def _iam_schema_not_ready_response() -> JSONResponse:
     return JSONResponse(


### PR DESCRIPTION
Implement bounded path parameters (128 chars max). Prevents DoS.