### PR TITLE
fix(db): guard get_pool() with asyncio.Lock to prevent duplicate pool creation

### DIFF
--- a/consent-protocol/db/connection.py
+++ b/consent-protocol/db/connection.py
@@ -22,6 +22,7 @@ Connection Method:
     - DB_NAME: Database name (default postgres)
 """
 
+import asyncio
 import hashlib
 import logging
 import os
@@ -49,8 +50,19 @@ _DB_CONNECTION_ERROR_PATTERNS = (
     "ssl syscall error: eof detected",
 )
 
-# Database connection pool (singleton)
+# Database connection pool (singleton) and its init lock.
+# The lock ensures only one coroutine runs the create_pool() call even when
+# multiple requests arrive before the pool is ready.
 _pool: Optional[asyncpg.Pool] = None
+_pool_lock: asyncio.Lock | None = None
+
+
+def _get_pool_lock() -> asyncio.Lock:
+    """Return the per-event-loop pool init lock, creating it on first call."""
+    global _pool_lock
+    if _pool_lock is None:
+        _pool_lock = asyncio.Lock()
+    return _pool_lock
 
 
 class DatabaseUnavailableError(RuntimeError):
@@ -166,6 +178,10 @@ def _get_database_url() -> str:
 async def get_pool() -> asyncpg.Pool:
     """Get or create the connection pool.
 
+    Thread-safe via an asyncio.Lock: concurrent coroutines that arrive before
+    the pool is ready all wait on the lock, then the first one creates the
+    pool and the rest return the already-created instance.
+
     Returns:
         asyncpg.Pool: The database connection pool
 
@@ -174,7 +190,15 @@ async def get_pool() -> asyncpg.Pool:
     """
     global _pool
 
-    if _pool is None:
+    if _pool is not None:
+        return _pool
+
+    async with _get_pool_lock():
+        # Re-check inside the lock: another coroutine may have created the
+        # pool while we were waiting.
+        if _pool is not None:
+            return _pool
+
         database_url = _get_database_url()
         ssl_config = get_database_ssl()
         connect_timeout_seconds = _get_connect_timeout_seconds()

--- a/consent-protocol/tests/test_db_pool_init_race.py
+++ b/consent-protocol/tests/test_db_pool_init_race.py
@@ -14,7 +14,6 @@ database by patching asyncpg.create_pool.
 """
 
 import asyncio
-import importlib
 import sys
 import types
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/consent-protocol/tests/test_db_pool_init_race.py
+++ b/consent-protocol/tests/test_db_pool_init_race.py
@@ -1,0 +1,133 @@
+# tests/test_db_pool_init_race.py
+"""
+Regression tests for the db/connection.py pool initialisation race condition.
+
+Before the fix, two coroutines that called get_pool() concurrently when
+_pool was still None would both enter the create_pool() branch and create
+two independent pools.  One pool is silently abandoned, leaking the minimum
+number of open DB connections it allocated (min_size=2 by default).
+
+After the fix an asyncio.Lock guards the initialisation block so only one
+coroutine runs create_pool(); the others wait and then return the already
+created instance.  This test verifies that guarantee without touching a real
+database by patching asyncpg.create_pool.
+"""
+
+import asyncio
+import importlib
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _make_fake_pool(pool_id: int) -> MagicMock:
+    pool = MagicMock()
+    pool.pool_id = pool_id
+    pool.get_min_size.return_value = 2
+    pool.get_max_size.return_value = 10
+    pool.close = AsyncMock()
+    return pool
+
+
+def _fresh_module() -> types.ModuleType:
+    """Import a clean copy of db.connection with no cached state."""
+    for key in list(sys.modules.keys()):
+        if key.startswith("db.connection") or key == "db.connection":
+            del sys.modules[key]
+    with (
+        patch("dotenv.load_dotenv"),
+        patch("hushh_mcp.runtime_settings.hydrate_runtime_environment"),
+    ):
+        import db.connection as mod
+    return mod
+
+
+class TestPoolInitLockPreventsDoublCreate:
+    """get_pool() must call create_pool() exactly once under concurrent load."""
+
+    def test_concurrent_callers_share_single_pool(self):
+        """
+        Ten coroutines racing on get_pool() must all receive the same pool
+        object and create_pool() must be called exactly once.
+        """
+        mod = _fresh_module()
+
+        call_count = 0
+        created_pool = _make_fake_pool(1)
+
+        async def fake_create_pool(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            # Yield control to let other coroutines reach the lock.
+            await asyncio.sleep(0)
+            return created_pool
+
+        async def run():
+            with (
+                patch.object(mod, "_get_database_url", return_value="postgresql://fake/db"),
+                patch.object(mod, "get_database_ssl", return_value=None),
+                patch.object(mod, "_get_connect_timeout_seconds", return_value=10),
+                patch("asyncpg.create_pool", side_effect=fake_create_pool),
+            ):
+                tasks = [asyncio.create_task(mod.get_pool()) for _ in range(10)]
+                results = await asyncio.gather(*tasks)
+            return results
+
+        results = asyncio.run(run())
+
+        assert call_count == 1, (
+            f"create_pool() called {call_count} times; expected exactly 1. "
+            "Concurrent callers must share the init lock."
+        )
+        pool_ids = {r.pool_id for r in results}
+        assert pool_ids == {1}, "All callers must receive the same pool instance."
+
+    def test_second_call_returns_cached_pool_without_create(self):
+        """
+        A second call after the pool is already initialised must return the
+        cached instance immediately without calling create_pool() again.
+        """
+        mod = _fresh_module()
+
+        first_pool = _make_fake_pool(1)
+        second_pool = _make_fake_pool(2)
+        call_count = 0
+
+        async def fake_create_pool(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return first_pool if call_count == 1 else second_pool
+
+        async def run():
+            with (
+                patch.object(mod, "_get_database_url", return_value="postgresql://fake/db"),
+                patch.object(mod, "get_database_ssl", return_value=None),
+                patch.object(mod, "_get_connect_timeout_seconds", return_value=10),
+                patch("asyncpg.create_pool", side_effect=fake_create_pool),
+            ):
+                pool_a = await mod.get_pool()
+                pool_b = await mod.get_pool()
+            return pool_a, pool_b
+
+        pool_a, pool_b = asyncio.run(run())
+
+        assert call_count == 1, "create_pool() must not be called on the second get_pool() call."
+        assert pool_a is pool_b, "Both calls must return the same pool object."
+
+    def test_pool_lock_is_not_none_after_first_get_pool(self):
+        """The module-level lock must be created on first use."""
+        mod = _fresh_module()
+
+        async def run():
+            with (
+                patch.object(mod, "_get_database_url", return_value="postgresql://fake/db"),
+                patch.object(mod, "get_database_ssl", return_value=None),
+                patch.object(mod, "_get_connect_timeout_seconds", return_value=10),
+                patch("asyncpg.create_pool", side_effect=AsyncMock(return_value=_make_fake_pool(1))),
+            ):
+                await mod.get_pool()
+            return mod._pool_lock
+
+        lock = asyncio.run(run())
+        assert lock is not None, "_pool_lock must be set after get_pool() is called."
+        assert isinstance(lock, asyncio.Lock)


### PR DESCRIPTION
## Problem

`db/connection.py::get_pool()` uses a module-level singleton (`_pool`) but
has no lock around the initialisation block. Under concurrent startup load
(multiple requests arriving before the pool is ready), two or more coroutines
can both observe `_pool is None`, both await `asyncpg.create_pool()`, and both
assign to `_pool`. The second write silently overwrites the first.

**Impact:**
- The abandoned pool holds `min_size=2` open connections that are never
  returned to the database server, leaking connections on every burst.
- Under high concurrency the leak compounds: N concurrent callers create N
  pools, abandoning N-1 of them. Each leaked pool holds at least 2 open
  connections. With `min_size=2` and `max_size=10`, a burst of 5 concurrent
  cold-start requests can leak 8 connections before the first request returns.
- Supabase session-pooler has a hard connection cap. Leaked pools push the
  application toward that cap and can trigger `too many clients` errors.

## Root cause

```python
# Before fix: no lock, no double-check
if _pool is None:
    _pool = await asyncpg.create_pool(...)  # any concurrent caller also enters here
```

## Fix

Double-checked locking with an `asyncio.Lock`:

```python
if _pool is not None:          # fast path, no lock needed
    return _pool

async with _get_pool_lock():   # only one coroutine initialises
    if _pool is not None:      # re-check after acquiring lock
        return _pool
    _pool = await asyncpg.create_pool(...)
```

The lock is created lazily on first call so it belongs to the running event
loop and does not break module-level import.

## Tests

`tests/test_db_pool_init_race.py` adds three regression tests:

1. **10 concurrent callers share one pool** - `create_pool()` called exactly
   once regardless of concurrency.
2. **Repeated calls return the cached instance** - no second `create_pool()`
   call after the pool is initialised.
3. **Lock is created on first use** - `_pool_lock` is an `asyncio.Lock`
   instance after the first `get_pool()` call.

All three pass locally (`pytest tests/test_db_pool_init_race.py -v`).

## Affected surface

`db/connection.py` - used by every route that touches the database.
No behavioural change to any route, service, or migration script.