### PR TITLE
test(voice): add debug drawer toggle dismissal coverage

### DIFF
--- a/hushh-webapp/__tests__/voice/voice-debug-drawer.test.tsx
+++ b/hushh-webapp/__tests__/voice/voice-debug-drawer.test.tsx
@@ -95,4 +95,26 @@ describe("voice-debug-drawer", () => {
     expect(copied).toContain('"event": "session_state_changed"');
     expect(toastSuccessMock).toHaveBeenCalledWith("Voice debug copied");
   });
+  it("keeps the debug drawer dismissible through the trigger toggle", () => {
+    render(
+      <VoiceDebugDrawer
+        enabled
+        currentState="idle"
+        sessionId="vsession_1"
+        route="/kai"
+        screen="kai_market"
+        authStatus="signed_in"
+        vaultStatus="unlocked_valid"
+        voiceAvailabilityReason="available"
+      />
+    );
+
+    const trigger = screen.getByRole("button", { name: /^Voice Debug$/i });
+
+    fireEvent.click(trigger);
+    expect(screen.getByLabelText("Copy voice debug")).toBeTruthy();
+
+    fireEvent.click(trigger);
+    expect(screen.queryByLabelText("Copy voice debug")).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

* Added regression coverage for Voice Debug drawer trigger-toggle dismissal behavior
* Ensured the debug drawer can be opened and closed through its trigger
* Improved interaction stability coverage for drawer accessibility flows

## Changes

* Added trigger toggle dismissal test for `VoiceDebugDrawer`
* Verified the drawer closes correctly after clicking the trigger again
* Preserved all existing component behavior

## Validation

* npm run lint
* npm run typecheck

## Notes

* Test-only change
* No UI or behavioral changes introduced
* Current upstream typecheck contains unrelated existing `agent-chat-workspace` dependency/type errors not introduced by this PR
