### PR TITLE
test(kai): preserve tracked symbol normalization contract

### DIFF
--- a/hushh-webapp/__tests__/kai/kai-market-preview-symbols.test.ts
+++ b/hushh-webapp/__tests__/kai/kai-market-preview-symbols.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeTrackedSymbols } from "@/components/kai/views/kai-market-preview-view";
+
+describe("Kai market preview symbol normalization", () => {
+  it("normalizes, dedupes, and caps tracked symbols", () => {
+    expect(
+      normalizeTrackedSymbols([
+        " aapl ",
+        "AAPL",
+        "msft",
+        " MSFT ",
+        "goog",
+        "amzn",
+        "nvda",
+        "meta",
+        "tsla",
+        "nflx",
+      ]),
+    ).toEqual(["AAPL", "MSFT", "GOOG", "AMZN", "NVDA", "META", "TSLA", "NFLX"]);
+  });
+
+  it("returns an empty list for invalid symbol input", () => {
+    expect(normalizeTrackedSymbols(null)).toEqual([]);
+    expect(normalizeTrackedSymbols(undefined)).toEqual([]);
+  });
+});

--- a/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
@@ -110,7 +110,7 @@ const MARKET_SIGNAL_CARD_CLASSNAME = cn(
 
 const MARKET_SIGNAL_INSET_CLASSNAME = marketInsetClassName;
 
-function normalizeTrackedSymbols(symbols: string[] | null | undefined): string[] {
+export function normalizeTrackedSymbols(symbols: string[] | null | undefined): string[] {
   if (!Array.isArray(symbols)) return [];
   return symbols
     .map((symbol) => String(symbol || "").trim().toUpperCase())


### PR DESCRIPTION
## Summary

* Added regression coverage for tracked symbol normalization behavior
* Ensured tracked symbols remain trimmed, uppercased, deduplicated, and capped consistently
* Improved stability coverage for Kai market preview symbol processing

## Changes

* Exported `normalizeTrackedSymbols` helper for isolated testing
* Added normalization contract tests for tracked market symbols
* Added invalid-input coverage for null and undefined symbol lists

## Validation

* npm run lint
* npm run typecheck

## Notes

* Test-focused change with minimal helper export
* No UI or behavioral changes introduced
* Current upstream typecheck contains unrelated existing `agent-chat-workspace` dependency/type errors not introduced by this PR
