### PR TITLE
test(vault-access-policy): align capability-state regression coverage with current mainline surface

### DIFF
--- a/hushh-webapp/__tests__/lib/vault/vault-access-policy.test.ts
+++ b/hushh-webapp/__tests__/lib/vault/vault-access-policy.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveVaultAvailabilityState,
+  resolveVaultCapabilityState,
+} from "@/lib/vault/vault-access-policy";
+
+// Regression suite for: hushh-webapp/lib/vault/vault-access-policy.ts
+// Covers: resolveVaultCapabilityState, resolveVaultAvailabilityState
+
+describe("resolveVaultCapabilityState", () => {
+  it("returns full read and mutate capability when vault is unlocked with key and owner token", () => {
+    expect(
+      resolveVaultCapabilityState({
+        isVaultUnlocked: true,
+        vaultKey: "vault-key",
+        vaultOwnerToken: "vault-owner-token",
+      })
+    ).toEqual({
+      hasVaultKey: true,
+      hasVaultOwnerToken: true,
+      isUnlocked: true,
+      canReadSecureData: true,
+      canMutateSecureData: true,
+    });
+  });
+
+  it("grants secure-read capability with vault key present but no owner token", () => {
+    expect(
+      resolveVaultCapabilityState({
+        isVaultUnlocked: true,
+        vaultKey: "vault-key",
+        vaultOwnerToken: null,
+      })
+    ).toMatchObject({
+      hasVaultKey: true,
+      hasVaultOwnerToken: false,
+      canReadSecureData: false,
+      canMutateSecureData: false,
+    });
+  });
+
+  it("denies all capability when vault is locked with no credentials", () => {
+    expect(
+      resolveVaultCapabilityState({
+        isVaultUnlocked: false,
+        vaultKey: null,
+        vaultOwnerToken: null,
+      })
+    ).toMatchObject({
+      hasVaultKey: false,
+      hasVaultOwnerToken: false,
+      isUnlocked: false,
+      canReadSecureData: false,
+      canMutateSecureData: false,
+    });
+  });
+
+  it("denies mutate capability when owner token is absent even if vault key is present", () => {
+    expect(
+      resolveVaultCapabilityState({
+        isVaultUnlocked: false,
+        vaultKey: "vault-key",
+        vaultOwnerToken: null,
+      })
+    ).toMatchObject({
+      hasVaultOwnerToken: false,
+      canMutateSecureData: false,
+    });
+  });
+});
+
+describe("resolveVaultAvailabilityState", () => {
+  it("resolves locked vault as unlock-required, not unavailable", () => {
+    expect(
+      resolveVaultAvailabilityState({
+        hasVault: true,
+        isVaultUnlocked: false,
+        vaultKey: null,
+        vaultOwnerToken: null,
+      })
+    ).toMatchObject({
+      hasVault: true,
+      vaultUnknown: false,
+      needsVaultCreation: false,
+      needsUnlock: true,
+      canReadSecureData: false,
+      canMutateSecureData: false,
+    });
+  });
+
+  it("resolves absent vault as creation-required, not unlock-required", () => {
+    expect(
+      resolveVaultAvailabilityState({
+        hasVault: false,
+        isVaultUnlocked: false,
+        vaultKey: null,
+        vaultOwnerToken: null,
+      })
+    ).toMatchObject({
+      hasVault: false,
+      vaultUnknown: false,
+      needsVaultCreation: true,
+      needsUnlock: false,
+      canReadSecureData: false,
+      canMutateSecureData: false,
+    });
+  });
+
+  it("resolves fully unlocked vault as read and mutate capable", () => {
+    expect(
+      resolveVaultAvailabilityState({
+        hasVault: true,
+        isVaultUnlocked: true,
+        vaultKey: "vault-key",
+        vaultOwnerToken: "vault-owner-token",
+      })
+    ).toMatchObject({
+      hasVault: true,
+      vaultUnknown: false,
+      needsVaultCreation: false,
+      needsUnlock: false,
+      canReadSecureData: true,
+      canMutateSecureData: true,
+    });
+  });
+
+  it("resolves unknown vault state as vaultUnknown with all capabilities denied", () => {
+    expect(
+      resolveVaultAvailabilityState({
+        hasVault: null,
+        isVaultUnlocked: false,
+        vaultKey: null,
+        vaultOwnerToken: null,
+      })
+    ).toMatchObject({
+      vaultUnknown: true,
+      needsVaultCreation: false,
+      needsUnlock: false,
+      canReadSecureData: false,
+      canMutateSecureData: false,
+    });
+  });
+
+  it("resolves partial unlock state as unlock-required with all secure capability denied", () => {
+    expect(
+      resolveVaultAvailabilityState({
+        hasVault: true,
+        isVaultUnlocked: true,
+        vaultKey: "vault-key",
+        vaultOwnerToken: null,
+      })
+    ).toMatchObject({
+      hasVault: true,
+      needsUnlock: true,
+      canReadSecureData: false,
+      canMutateSecureData: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Rebuilds the vault access-policy regression coverage directly from current `main`
to remove predecessor-train coupling and validate behaviour against the active
canonical implementation surface.

This PR is test-only and introduces zero production behaviour changes.

## Implementation Surface

```text id="b2ix4o"
hushh-webapp/lib/vault/vault-access-policy.ts
hushh-webapp/__tests__/lib/vault/vault-access-policy.test.ts
```

The regression suite now mirrors the canonical `lib/vault` structure and
targets the active capability-state and availability-state resolution flow.

## Coverage Added

* `resolveVaultCapabilityState` regression coverage
* `resolveVaultAvailabilityState` regression coverage
* unlocked vault capability assertions
* locked vault denial-state assertions
* absent-vault availability coverage
* unknown-state defensive coverage
* partial-unlock capability validation
* secure-data read/mutate capability boundaries

## Why This Matters

`lib/vault/vault-access-policy.ts` defines the canonical vault capability
resolution surface used by hushh-webapp secure-data flows.

This isolated regression suite ensures future changes that weaken capability
resolution, unlock-state handling, or secure-data access boundaries fail CI
immediately with targeted regression failures.

## Validation

```bash id="cnbyei"
npx vitest run __tests__/lib/vault/vault-access-policy.test.ts
npm run lint
npx tsc --noEmit
```

Results:

* regression suite passing
* lint passing
* typecheck currently blocked by unrelated existing workspace dependency/type issues in `components/agent/agent-chat-workspace.tsx`

## Governance Alignment

* rebuilt directly from current `main`
* isolated additive regression coverage only
* no predecessor-train coupling
* no runtime or dependency changes
* canonical implementation surface preserved
