### PR TITLE
fix(sse): bounded per-user notification queue with ref-counted cleanup

### DIFF
--- a/consent-protocol/api/consent_listener.py
+++ b/consent-protocol/api/consent_listener.py
@@ -37,8 +37,17 @@ FINAL_REMINDER_LEAD_MS = 30 * 60 * 1000
 MIN_FINAL_REMINDER_WINDOW_MS = 2 * 60 * 60 * 1000
 
 # Per-user queues for SSE generators (no polling). Key = user_id.
+# Each queue is bounded so a stalled or slow SSE consumer cannot accumulate an
+# unbounded backlog of notifications and exhaust memory. When a queue is full,
+# the oldest pending event is dropped to make room for the newest.
+_CONSENT_NOTIFY_QUEUE_MAXSIZE = 100
 _consent_notify_queues: Dict[str, asyncio.Queue] = {}
 _consent_notify_queues_lock = asyncio.Lock()
+# Reference count: number of active SSE connections holding a queue reference.
+# The queue is only removed from _consent_notify_queues when the count
+# drops to zero, so a single disconnect does not evict a queue that another
+# concurrent same-user connection is still reading from.
+_consent_queue_refcount: Dict[str, int] = {}
 
 # Diagnostic: set when listener is running and when NOTIFY is received
 _listener_active = False
@@ -117,14 +126,50 @@ async def _push_to_consent_queue(user_id: str, data: Dict[str, Any]) -> None:
         try:
             q.put_nowait(data)
         except asyncio.QueueFull:
-            pass
+            # Queue is full because the SSE consumer is not draining fast
+            # enough. Drop the oldest pending event and enqueue the newest so
+            # the consumer always receives the most recent consent state.
+            try:
+                q.get_nowait()
+            except asyncio.QueueEmpty:
+                pass
+            try:
+                q.put_nowait(data)
+            except asyncio.QueueFull:
+                pass
+            logger.warning(
+                "consent notify queue full; dropped oldest event to bound memory"
+            )
 
 
 def get_consent_queue(user_id: str) -> asyncio.Queue:
-    """Get or create the asyncio queue for this user (used by SSE generator)."""
+    """Get or create the asyncio queue for this user and increment the ref count.
+
+    Each SSE connection that calls this must later call release_consent_queue
+    in its finally block so the queue is removed only when the last connection
+    for that user disconnects.
+    """
     if user_id not in _consent_notify_queues:
-        _consent_notify_queues[user_id] = asyncio.Queue()
+        _consent_notify_queues[user_id] = asyncio.Queue(
+            maxsize=_CONSENT_NOTIFY_QUEUE_MAXSIZE
+        )
+    _consent_queue_refcount[user_id] = _consent_queue_refcount.get(user_id, 0) + 1
     return _consent_notify_queues[user_id]
+
+
+def release_consent_queue(user_id: str) -> None:
+    """Decrement the ref count for this user and remove the queue when it reaches zero.
+
+    Called from the finally block of consent_event_generator on disconnect.
+    If another SSE connection for the same user_id is still active, the ref
+    count stays above zero and the queue is preserved for that connection.
+    """
+    count = _consent_queue_refcount.get(user_id, 0) - 1
+    if count <= 0:
+        _consent_queue_refcount.pop(user_id, None)
+        _consent_notify_queues.pop(user_id, None)
+    else:
+        _consent_queue_refcount[user_id] = count
 
 
 def get_consent_listener_status() -> dict:

--- a/consent-protocol/api/routes/sse.py
+++ b/consent-protocol/api/routes/sse.py
@@ -153,7 +153,7 @@ async def consent_event_generator(user_id: str, request: Request) -> AsyncGenera
     """
     from datetime import datetime
 
-    from api.consent_listener import get_consent_queue
+    from api.consent_listener import get_consent_queue, release_consent_queue
     from hushh_mcp.services.consent_db import ConsentDBService
 
     logger.info("consent_sse.open user_id=%s", user_id)
@@ -216,6 +216,9 @@ async def consent_event_generator(user_id: str, request: Request) -> AsyncGenera
     except Exception as e:
         logger.error("consent_sse.error user_id=%s error=%s", user_id, e)
         raise
+    finally:
+        release_consent_queue(user_id)
+        logger.info("consent_sse.closed user_id=[redacted]")
 
 
 @router.get("/events/{user_id}")

--- a/consent-protocol/tests/test_sse_queue_cleanup.py
+++ b/consent-protocol/tests/test_sse_queue_cleanup.py
@@ -1,0 +1,132 @@
+"""Tests for SSE consent queue cleanup on disconnect (memory leak fix).
+
+The fix uses reference counting so a single disconnect does not evict the
+queue while another concurrent same-user SSE connection is still reading.
+
+  get_consent_queue(user_id)   -- increments refcount, creates queue on first call
+  release_consent_queue(user_id) -- decrements refcount, removes queue when it hits 0
+
+Canonical attach:
+  api/routes/sse.py          -- consent_event_generator calls release in finally
+  api/consent_listener.py    -- _consent_notify_queues, _consent_queue_refcount
+"""
+
+def _reset() -> None:
+    from api import consent_listener
+    consent_listener._consent_notify_queues.clear()
+    consent_listener._consent_queue_refcount.clear()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for ref-counted queue helpers
+# ---------------------------------------------------------------------------
+
+
+class TestRefCountedQueueHelpers:
+    def setup_method(self):
+        _reset()
+
+    def test_first_get_creates_queue_and_sets_refcount_to_1(self):
+        from api.consent_listener import (
+            _consent_notify_queues,
+            _consent_queue_refcount,
+            get_consent_queue,
+        )
+        get_consent_queue("user-a")
+        assert "user-a" in _consent_notify_queues
+        assert _consent_queue_refcount["user-a"] == 1
+
+    def test_second_get_for_same_user_increments_refcount(self):
+        from api.consent_listener import _consent_queue_refcount, get_consent_queue
+        get_consent_queue("user-a")
+        get_consent_queue("user-a")
+        assert _consent_queue_refcount["user-a"] == 2
+
+    def test_second_get_returns_same_queue_object(self):
+        from api.consent_listener import get_consent_queue
+        q1 = get_consent_queue("user-a")
+        q2 = get_consent_queue("user-a")
+        assert q1 is q2
+
+    def test_release_with_one_ref_removes_queue(self):
+        from api.consent_listener import (
+            _consent_notify_queues,
+            _consent_queue_refcount,
+            get_consent_queue,
+            release_consent_queue,
+        )
+        get_consent_queue("user-a")
+        release_consent_queue("user-a")
+        assert "user-a" not in _consent_notify_queues
+        assert "user-a" not in _consent_queue_refcount
+
+    def test_release_with_two_refs_preserves_queue_for_second_connection(self):
+        """Two connections hold refs; first disconnect must not remove the queue."""
+        from api.consent_listener import (
+            _consent_notify_queues,
+            _consent_queue_refcount,
+            get_consent_queue,
+            release_consent_queue,
+        )
+        get_consent_queue("user-a")
+        get_consent_queue("user-a")
+        assert _consent_queue_refcount["user-a"] == 2
+
+        release_consent_queue("user-a")
+        assert "user-a" in _consent_notify_queues, (
+            "Queue must survive first disconnect when a second connection is still active"
+        )
+        assert _consent_queue_refcount["user-a"] == 1
+
+    def test_release_twice_removes_queue_after_both_disconnects(self):
+        from api.consent_listener import (
+            _consent_notify_queues,
+            _consent_queue_refcount,
+            get_consent_queue,
+            release_consent_queue,
+        )
+        get_consent_queue("user-a")
+        get_consent_queue("user-a")
+        release_consent_queue("user-a")
+        release_consent_queue("user-a")
+        assert "user-a" not in _consent_notify_queues
+        assert "user-a" not in _consent_queue_refcount
+
+    def test_release_noop_when_user_never_registered(self):
+        from api.consent_listener import _consent_notify_queues, release_consent_queue
+        release_consent_queue("nonexistent-user")
+        assert "nonexistent-user" not in _consent_notify_queues
+
+    def test_independent_users_do_not_interfere(self):
+        from api.consent_listener import (
+            _consent_notify_queues,
+            get_consent_queue,
+            release_consent_queue,
+        )
+        get_consent_queue("user-a")
+        get_consent_queue("user-b")
+        release_consent_queue("user-a")
+        assert "user-a" not in _consent_notify_queues
+        assert "user-b" in _consent_notify_queues
+        release_consent_queue("user-b")
+        assert "user-b" not in _consent_notify_queues
+
+    def test_notify_queue_receives_events_after_first_of_two_disconnects(self):
+        """Second connection can still receive events after the first disconnects."""
+        from api.consent_listener import (
+            get_consent_queue,
+            release_consent_queue,
+        )
+        q = get_consent_queue("user-a")
+        get_consent_queue("user-a")
+
+        q.put_nowait({"request_id": "req-001"})
+        release_consent_queue("user-a")
+
+        from api import consent_listener
+        still_alive = consent_listener._consent_notify_queues.get("user-a")
+        assert still_alive is not None, "Queue must still exist for the second connection"
+        item = still_alive.get_nowait()
+        assert item["request_id"] == "req-001"
+        release_consent_queue("user-a")
+        release_consent_queue("user-a")


### PR DESCRIPTION
## What changed

Added bounded queue size (maxsize=100) and ref-counting cleanup to per-user SSE notification queues to prevent memory exhaustion from stalled consumers.

## Security Context

CWE-400 (Uncontrolled Resource Consumption): unbounded SSE notification queues allow stalled or slow consumers to accumulate unlimited backlog, exhausting server memory. Combined maxsize bounding (drops oldest when full) with ref-counting (queue removed only when last connection for that user disconnects).

## Tests

Verifies that queue is removed on last connection disconnect and that multiple concurrent connections for same user share the same queue reference.

## Checklist

- [x] All maintainer feedback addressed
- [x] No merge conflicts
- [x] All CI checks green
- [x] Tests pass and cover real product paths