### PR TITLE
fix(developer): add max_length to connector_public_key in DeveloperConsentRequest (CWE-400)

### DIFF
--- a/consent-protocol/api/routes/developer.py
+++ b/consent-protocol/api/routes/developer.py
@@ -160,7 +160,7 @@ class DeveloperConsentRequest(BaseModel):
     reason: str | None = None
     expiry_hours: int = 24
     approval_timeout_minutes: int = 24 * 60
-    connector_public_key: str = Field(min_length=16)
+    connector_public_key: str = Field(min_length=16, max_length=8192)
     connector_key_id: str = Field(min_length=1, max_length=128)
     connector_wrapping_alg: str = Field(min_length=1, max_length=128)
 

--- a/consent-protocol/tests/test_developer_consent_request_bounds.py
+++ b/consent-protocol/tests/test_developer_consent_request_bounds.py
@@ -1,0 +1,86 @@
+"""Tests for DeveloperConsentRequest connector_public_key field bound (CWE-400).
+
+connector_public_key previously had only a min_length=16 constraint with no
+upper bound, allowing arbitrarily large public-key blobs to reach the vault
+key-wrapping layer. RSA 4096-bit public keys in PEM/DER base64 are at most
+~800 chars; max_length=8192 provides headroom for all common key formats.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from api.routes.developer import DeveloperConsentRequest
+
+_VALID_KEY_AT_MIN = "x" * 16
+_VALID_KEY = "x" * 512
+_OVER_MAX_KEY = "x" * 8193
+_AT_MAX_KEY = "x" * 8192
+
+
+def _base_request(**overrides) -> dict:
+    base = {
+        "user_id": "user_abc",
+        "scope": "pkm.read",
+        "connector_public_key": _VALID_KEY,
+        "connector_key_id": "key-001",
+        "connector_wrapping_alg": "RSA-OAEP",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestConnectorPublicKeyBound:
+    """DeveloperConsentRequest.connector_public_key max_length=8192."""
+
+    def test_key_at_min_length_accepted(self):
+        req = DeveloperConsentRequest(**_base_request(connector_public_key=_VALID_KEY_AT_MIN))
+        assert req.connector_public_key == _VALID_KEY_AT_MIN
+
+    def test_key_at_max_length_accepted(self):
+        req = DeveloperConsentRequest(**_base_request(connector_public_key=_AT_MAX_KEY))
+        assert len(req.connector_public_key) == 8192
+
+    def test_key_over_max_length_rejected(self):
+        with pytest.raises(ValidationError):
+            DeveloperConsentRequest(**_base_request(connector_public_key=_OVER_MAX_KEY))
+
+    def test_key_below_min_length_rejected(self):
+        with pytest.raises(ValidationError):
+            DeveloperConsentRequest(**_base_request(connector_public_key="x" * 15))
+
+    def test_typical_rsa_key_size_accepted(self):
+        rsa_2048_pem_approx_len = 736
+        req = DeveloperConsentRequest(
+            **_base_request(connector_public_key="x" * rsa_2048_pem_approx_len)
+        )
+        assert len(req.connector_public_key) == rsa_2048_pem_approx_len
+
+
+class TestConnectorPublicKeyBoundViaRoute:
+    """POST /api/v1/request-consent rejects oversized connector_public_key with 422."""
+
+    def _client(self) -> TestClient:
+        from api.routes import developer
+        app = FastAPI()
+        app.include_router(developer.router)
+        return TestClient(app, raise_server_exceptions=False)
+
+    def test_oversized_key_rejected_with_422(self):
+        resp = self._client().post(
+            "/api/v1/request-consent",
+            json=_base_request(connector_public_key=_OVER_MAX_KEY),
+        )
+        assert resp.status_code == 422
+
+    def test_valid_key_passes_model_validation(self):
+        resp = self._client().post(
+            "/api/v1/request-consent",
+            json=_base_request(connector_public_key=_VALID_KEY),
+        )
+        assert resp.status_code != 422, (
+            "Valid connector_public_key must pass Pydantic validation"
+        )


### PR DESCRIPTION
## Summary

Adds `max_length=8192` to `connector_public_key` in `DeveloperConsentRequest`. This field previously had only `min_length=16` with no upper bound, allowing unbounded key blobs to reach the vault key-wrapping layer.

RSA 4096-bit public keys in PEM/DER base64 are at most ~800 chars. `max_length=8192` covers all common key formats with headroom.

No other field changed. The diff is one line in `developer.py` plus a test file.

## Maintainer Feedback Addressed

- `local_worktree_overlap`: Branch rebased onto clean `upstream/integration/pr-train`. Previous branch diverged from a stale base, causing the diff to show removal of bounds already in pr-train. Clean rebase eliminates all unrelated changes.
- `backend_contract_without_caller_change`: Only `connector_public_key` is changed. This field had no existing max_length, so no current caller sends a key longer than 8192 chars (RSA 4096-bit keys are ~800 chars).
- `existing_capability_overlap_requires_review`: Removed the expiry_hours and approval_timeout_minutes ge/le additions (those overlap with existing `_validate_public_expiry_hours` and `_validate_public_approval_timeout_minutes` functions). Only `connector_public_key` max_length remains.
- `pr_claim_changed_surface_mismatch`: PR now accurately describes adding max_length to `connector_public_key`. Diff is 1 field + test file.

## How to Verify

```
pytest consent-protocol/tests/test_developer_consent_request_bounds.py -v
```

All 7 tests pass.

## Checklist

- [x] connector_public_key max_length=8192 added
- [x] All other fields unchanged from upstream
- [x] Clean branch from upstream/integration/pr-train (no stale base)
- [x] 7 tests pass (model bounds + route-level 422 proof)