### PR TITLE
fix(investors): gate admin write endpoints behind Firebase auth

### DIFF
--- a/consent-protocol/api/routes/investors.py
+++ b/consent-protocol/api/routes/investors.py
@@ -19,9 +19,10 @@ import re
 from datetime import datetime
 from typing import List, Optional
 
-from fastapi import APIRouter, Body, HTTPException, Path, Query
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query
 from pydantic import BaseModel, Field
 
+from api.middleware import require_firebase_auth
 from hushh_mcp.services.investor_db import InvestorDBService
 
 logger = logging.getLogger(__name__)
@@ -173,11 +174,17 @@ async def get_investor_by_cik(
 
 
 @router.post("/", status_code=201)
-async def create_investor(investor: InvestorCreateRequest):
+async def create_investor(
+    investor: InvestorCreateRequest,
+    firebase_uid: str = Depends(require_firebase_auth),
+):
     """
     Create or update an investor profile.
 
     Admin endpoint for data ingestion from SEC EDGAR, etc.
+
+    Requires Firebase ID token. Without this guard any unauthenticated caller
+    can overwrite or poison public investor profile records.
     """
 
     # Use service layer
@@ -235,6 +242,7 @@ async def create_investor(investor: InvestorCreateRequest):
 @router.post("/bulk", status_code=201)
 async def bulk_create_investors(
     investors: List[InvestorCreateRequest] = Body(...),
+    firebase_uid: str = Depends(require_firebase_auth),
 ):
     """
     Bulk create investor profiles from list.
@@ -242,6 +250,9 @@ async def bulk_create_investors(
     Used for initial data seeding from JSON file.
     Capped at _BULK_INVESTOR_MAX records per request to protect the
     database connection pool.
+
+    Requires Firebase ID token. Without this guard an unauthenticated caller
+    can write up to _BULK_INVESTOR_MAX fake records per request.
     """
     if len(investors) > _BULK_INVESTOR_MAX:
         raise HTTPException(
@@ -252,7 +263,7 @@ async def bulk_create_investors(
 
     results = []
     for investor in investors:
-        result = await create_investor(investor)
+        result = await create_investor(investor, firebase_uid=firebase_uid)
         results.append(result)
 
     logger.info(f"Bulk created {len(results)} investor profiles")

--- a/consent-protocol/tests/test_investor_write_auth.py
+++ b/consent-protocol/tests/test_investor_write_auth.py
@@ -22,7 +22,6 @@ import pytest
 
 from api.routes.investors import bulk_create_investors, create_investor
 
-
 # ---------------------------------------------------------------------------
 # Structural tests: verify the dependency is wired at the function level
 # ---------------------------------------------------------------------------

--- a/consent-protocol/tests/test_investor_write_auth.py
+++ b/consent-protocol/tests/test_investor_write_auth.py
@@ -1,0 +1,149 @@
+"""Tests for authentication guard on investor write endpoints.
+
+POST /api/investors/ and POST /api/investors/bulk are admin data-ingestion
+endpoints. Before this fix they had no authentication dependency, meaning any
+unauthenticated HTTP client could create or overwrite investor profile records
+in the public investor table and contaminate the identity-resolution layer.
+
+Fix: Both handlers now declare `firebase_uid: str = Depends(require_firebase_auth)`.
+FastAPI injects the dependency before the handler body runs; a missing or invalid
+Bearer token causes a 401 before any database write is attempted.
+
+Canonical attach:
+  api.routes.investors.create_investor      -> POST /api/investors/
+  api.routes.investors.bulk_create_investors -> POST /api/investors/bulk
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from api.routes.investors import bulk_create_investors, create_investor
+
+
+# ---------------------------------------------------------------------------
+# Structural tests: verify the dependency is wired at the function level
+# ---------------------------------------------------------------------------
+
+
+class TestCreateInvestorHasAuthDependency:
+    """create_investor must declare require_firebase_auth as a Depends parameter."""
+
+    def test_firebase_uid_parameter_exists(self):
+        sig = inspect.signature(create_investor)
+        assert "firebase_uid" in sig.parameters, (
+            "create_investor must have a 'firebase_uid' parameter"
+        )
+
+    def test_firebase_uid_has_depends(self):
+        from fastapi import params as fastapi_params
+
+        sig = inspect.signature(create_investor)
+        param = sig.parameters["firebase_uid"]
+        assert isinstance(param.default, fastapi_params.Depends), (
+            "firebase_uid default must be a FastAPI Depends object"
+        )
+
+    def test_depends_wraps_require_firebase_auth(self):
+        from api.middleware import require_firebase_auth
+
+        sig = inspect.signature(create_investor)
+        param = sig.parameters["firebase_uid"]
+        assert param.default.dependency is require_firebase_auth, (
+            "firebase_uid Depends must wrap require_firebase_auth"
+        )
+
+
+class TestBulkCreateInvestorsHasAuthDependency:
+    """bulk_create_investors must declare require_firebase_auth as a Depends parameter."""
+
+    def test_firebase_uid_parameter_exists(self):
+        sig = inspect.signature(bulk_create_investors)
+        assert "firebase_uid" in sig.parameters, (
+            "bulk_create_investors must have a 'firebase_uid' parameter"
+        )
+
+    def test_firebase_uid_has_depends(self):
+        from fastapi import params as fastapi_params
+
+        sig = inspect.signature(bulk_create_investors)
+        param = sig.parameters["firebase_uid"]
+        assert isinstance(param.default, fastapi_params.Depends), (
+            "firebase_uid default must be a FastAPI Depends object"
+        )
+
+    def test_depends_wraps_require_firebase_auth(self):
+        from api.middleware import require_firebase_auth
+
+        sig = inspect.signature(bulk_create_investors)
+        param = sig.parameters["firebase_uid"]
+        assert param.default.dependency is require_firebase_auth, (
+            "firebase_uid Depends must wrap require_firebase_auth"
+        )
+
+
+# ---------------------------------------------------------------------------
+# HTTP integration tests: 401 without a Bearer token
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def test_client():
+    """Minimal FastAPI test client with only the investors router mounted."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from api.routes.investors import router
+
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestCreateInvestorRequiresAuth:
+    """POST /api/investors/ must return 401 when no Bearer token is provided."""
+
+    def test_no_auth_header_returns_401(self, test_client):
+        resp = test_client.post(
+            "/api/investors/",
+            json={"name": "Warren Buffett"},
+        )
+        assert resp.status_code == 401
+
+    def test_invalid_bearer_token_returns_401(self, test_client):
+        resp = test_client.post(
+            "/api/investors/",
+            json={"name": "Warren Buffett"},
+            headers={"Authorization": "Bearer not-a-real-token"},
+        )
+        assert resp.status_code == 401
+
+    def test_response_does_not_reveal_db_state_on_missing_auth(self, test_client):
+        """Error detail must not leak schema or stack-trace information."""
+        resp = test_client.post(
+            "/api/investors/",
+            json={"name": "Warren Buffett"},
+        )
+        detail = resp.json().get("detail", "")
+        assert "investor" not in str(detail).lower() or "auth" in str(detail).lower()
+
+
+class TestBulkCreateInvestorsRequiresAuth:
+    """POST /api/investors/bulk must return 401 when no Bearer token is provided."""
+
+    def test_no_auth_header_returns_401(self, test_client):
+        resp = test_client.post(
+            "/api/investors/bulk",
+            json=[{"name": "Warren Buffett"}],
+        )
+        assert resp.status_code == 401
+
+    def test_invalid_bearer_token_returns_401(self, test_client):
+        resp = test_client.post(
+            "/api/investors/bulk",
+            json=[{"name": "Warren Buffett"}],
+            headers={"Authorization": "Bearer not-a-real-token"},
+        )
+        assert resp.status_code == 401


### PR DESCRIPTION
## Problem

`POST /api/investors/` and `POST /api/investors/bulk` are admin data-ingestion
endpoints that write to the public `investor_profiles` table. Before this fix
neither handler declared any authentication dependency.

Any unauthenticated HTTP client could:
- Overwrite legitimate investor records (name, CIK, AUM, holdings, biography)
- Inject fake investor profiles that surface in identity-resolution search
- Poison the SEC-filing data layer used across the app to match user consents to real investors

The table is advertised as read-only public data derived from SEC filings; the
missing auth guard turned it into an open write endpoint.

## Fix

Both handlers now declare `firebase_uid: str = Depends(require_firebase_auth)`.
FastAPI injects the dependency before the handler body runs; a missing or
invalid Bearer token returns 401 before any database write is attempted.

`bulk_create_investors` already delegated to `create_investor` in a loop, so
the forwarded `firebase_uid` satisfies the inner call without a second token
round-trip.

```python
@router.post("/", status_code=201)
async def create_investor(
    investor: InvestorCreateRequest,
    firebase_uid: str = Depends(require_firebase_auth),
):
    ...

@router.post("/bulk", status_code=201)
async def bulk_create_investors(
    investors: List[InvestorCreateRequest] = Body(...),
    firebase_uid: str = Depends(require_firebase_auth),
):
    ...
```

## Tests

`tests/test_investor_write_auth.py` -- 11 tests, all passing.

**Structural (import-time, no network):**
- `create_investor` has a `firebase_uid` parameter
- That parameter's default is a `fastapi.params.Depends` instance
- The `Depends` wraps `require_firebase_auth` (identity check, not just type)
- Same three checks repeated for `bulk_create_investors`

**HTTP integration (real `TestClient`, no mocks):**
- `POST /api/investors/` with no auth header returns 401
- `POST /api/investors/` with an invalid Bearer token returns 401
- Error detail does not leak internal schema or DB state
- `POST /api/investors/bulk` with no auth header returns 401
- `POST /api/investors/bulk` with an invalid Bearer token returns 401

```
tests/test_investor_write_auth.py ...........  11 passed in 4.75s
```

## Affected surface

| File | Change |
|------|--------|
| `api/routes/investors.py` | Added `Depends(require_firebase_auth)` to `create_investor` and `bulk_create_investors` |
| `tests/test_investor_write_auth.py` | New test file, 11 tests |

Read-only endpoints (`GET /search`, `GET /{id}`, `GET /cik/{cik}`, `GET /stats`)
are intentionally left unauthenticated -- they serve public SEC data and the
existing comment block explicitly documents that design.