### PR TITLE
fix(stream): apply existing bounds constants to POST body models (CWE-400)

### DIFF
--- a/consent-protocol/api/routes/kai/stream.py
+++ b/consent-protocol/api/routes/kai/stream.py
@@ -121,25 +121,25 @@ async def _require_vault_owner_token(
 class StreamAnalyzeRequest(BaseModel):
     """Request for streaming analysis."""
 
-    user_id: str
-    ticker: str
-    risk_profile: str = "balanced"
+    user_id: str = Field(..., min_length=1, max_length=_USER_ID_MAX_LEN)
+    ticker: str = Field(..., min_length=1, max_length=_TICKER_RAW_MAX_LEN)
+    risk_profile: str = Field(default="balanced", max_length=_RISK_PROFILE_MAX_LEN)
     context: Optional[Dict[str, Any]] = None
-    run_id: Optional[str] = None
+    run_id: Optional[str] = Field(default=None, max_length=_RUN_ID_MAX_LEN)
     resume_cursor: Optional[int] = Field(default=0, ge=0)
 
 
 class StartAnalyzeRunRequest(BaseModel):
     """Request to create or attach to a session-locked analysis run."""
 
-    user_id: str
-    debate_session_id: str
-    ticker: str
-    risk_profile: str = "balanced"
+    user_id: str = Field(..., min_length=1, max_length=_USER_ID_MAX_LEN)
+    debate_session_id: str = Field(..., min_length=1, max_length=_DEBATE_SESSION_ID_MAX_LEN)
+    ticker: str = Field(..., min_length=1, max_length=_TICKER_RAW_MAX_LEN)
+    risk_profile: str = Field(default="balanced", max_length=_RISK_PROFILE_MAX_LEN)
     context: Optional[Dict[str, Any]] = None
-    pick_source: Optional[str] = None
-    pick_source_label: Optional[str] = None
-    pick_source_kind: Optional[str] = None
+    pick_source: Optional[str] = Field(default=None, max_length=_RUN_ID_MAX_LEN)
+    pick_source_label: Optional[str] = Field(default=None, max_length=256)
+    pick_source_kind: Optional[str] = Field(default=None, max_length=64)
 
 
 # ============================================================================

--- a/consent-protocol/tests/test_stream_analyze_request_bounds.py
+++ b/consent-protocol/tests/test_stream_analyze_request_bounds.py
@@ -21,15 +21,14 @@ import pytest
 from pydantic import ValidationError
 
 from api.routes.kai.stream import (
-    StartAnalyzeRunRequest,
-    StreamAnalyzeRequest,
     _DEBATE_SESSION_ID_MAX_LEN,
     _RISK_PROFILE_MAX_LEN,
     _RUN_ID_MAX_LEN,
     _TICKER_RAW_MAX_LEN,
     _USER_ID_MAX_LEN,
+    StartAnalyzeRunRequest,
+    StreamAnalyzeRequest,
 )
-
 
 # ---------------------------------------------------------------------------
 # StreamAnalyzeRequest bounds

--- a/consent-protocol/tests/test_stream_analyze_request_bounds.py
+++ b/consent-protocol/tests/test_stream_analyze_request_bounds.py
@@ -1,0 +1,162 @@
+"""Tests for input bounds on stream analyze request models (CWE-400).
+
+POST /kai/analyze/stream and POST /kai/analyze/run/start accept
+StreamAnalyzeRequest and StartAnalyzeRunRequest respectively, then forward
+the caller-supplied ticker and user_id into LLM inference and audit-log writes.
+
+Before this fix neither model declared max_length on any string field.
+The file already defined module-level constants (_USER_ID_MAX_LEN,
+_TICKER_RAW_MAX_LEN, etc.) that were correctly applied to GET Query parameters
+but were not applied to the POST body models, leaving an inconsistency:
+a caller could send an oversized body while the same values would be rejected
+on the query-param versions of the same endpoints.
+
+Fix: StreamAnalyzeRequest and StartAnalyzeRunRequest now declare Field bounds
+that match the constants already present at the top of the module.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from api.routes.kai.stream import (
+    StartAnalyzeRunRequest,
+    StreamAnalyzeRequest,
+    _DEBATE_SESSION_ID_MAX_LEN,
+    _RISK_PROFILE_MAX_LEN,
+    _RUN_ID_MAX_LEN,
+    _TICKER_RAW_MAX_LEN,
+    _USER_ID_MAX_LEN,
+)
+
+
+# ---------------------------------------------------------------------------
+# StreamAnalyzeRequest bounds
+# ---------------------------------------------------------------------------
+
+
+class TestStreamAnalyzeRequestBounds:
+    def test_oversized_user_id_rejected(self):
+        with pytest.raises(ValidationError):
+            StreamAnalyzeRequest(
+                user_id="u" * (_USER_ID_MAX_LEN + 1),
+                ticker="AAPL",
+            )
+
+    def test_oversized_ticker_rejected(self):
+        with pytest.raises(ValidationError):
+            StreamAnalyzeRequest(
+                user_id="uid123",
+                ticker="X" * (_TICKER_RAW_MAX_LEN + 1),
+            )
+
+    def test_oversized_risk_profile_rejected(self):
+        with pytest.raises(ValidationError):
+            StreamAnalyzeRequest(
+                user_id="uid123",
+                ticker="AAPL",
+                risk_profile="r" * (_RISK_PROFILE_MAX_LEN + 1),
+            )
+
+    def test_oversized_run_id_rejected(self):
+        with pytest.raises(ValidationError):
+            StreamAnalyzeRequest(
+                user_id="uid123",
+                ticker="AAPL",
+                run_id="r" * (_RUN_ID_MAX_LEN + 1),
+            )
+
+    def test_valid_request_accepted(self):
+        req = StreamAnalyzeRequest(user_id="uid123", ticker="AAPL")
+        assert req.ticker == "AAPL"
+        assert req.risk_profile == "balanced"
+
+    def test_bounds_match_module_constants(self):
+        """Ensure the Field bounds reference the same module-level constants used
+        by the Query parameters, so GET and POST paths are consistent."""
+        from pydantic.fields import FieldInfo
+
+        field: FieldInfo = StreamAnalyzeRequest.model_fields["user_id"]
+        max_len_values = [
+            c.max_length for c in field.metadata if hasattr(c, "max_length")
+        ]
+        assert max_len_values, "user_id must have a max_length constraint"
+        assert _USER_ID_MAX_LEN in max_len_values, (
+            f"user_id max_length should be {_USER_ID_MAX_LEN}; found {max_len_values}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# StartAnalyzeRunRequest bounds
+# ---------------------------------------------------------------------------
+
+
+class TestStartAnalyzeRunRequestBounds:
+    def test_oversized_user_id_rejected(self):
+        with pytest.raises(ValidationError):
+            StartAnalyzeRunRequest(
+                user_id="u" * (_USER_ID_MAX_LEN + 1),
+                debate_session_id="sess123",
+                ticker="AAPL",
+            )
+
+    def test_oversized_debate_session_id_rejected(self):
+        with pytest.raises(ValidationError):
+            StartAnalyzeRunRequest(
+                user_id="uid123",
+                debate_session_id="d" * (_DEBATE_SESSION_ID_MAX_LEN + 1),
+                ticker="AAPL",
+            )
+
+    def test_oversized_ticker_rejected(self):
+        with pytest.raises(ValidationError):
+            StartAnalyzeRunRequest(
+                user_id="uid123",
+                debate_session_id="sess123",
+                ticker="X" * (_TICKER_RAW_MAX_LEN + 1),
+            )
+
+    def test_oversized_risk_profile_rejected(self):
+        with pytest.raises(ValidationError):
+            StartAnalyzeRunRequest(
+                user_id="uid123",
+                debate_session_id="sess123",
+                ticker="AAPL",
+                risk_profile="r" * (_RISK_PROFILE_MAX_LEN + 1),
+            )
+
+    def test_oversized_pick_source_rejected(self):
+        with pytest.raises(ValidationError):
+            StartAnalyzeRunRequest(
+                user_id="uid123",
+                debate_session_id="sess123",
+                ticker="AAPL",
+                pick_source="p" * (_RUN_ID_MAX_LEN + 1),
+            )
+
+    def test_oversized_pick_source_label_rejected(self):
+        with pytest.raises(ValidationError):
+            StartAnalyzeRunRequest(
+                user_id="uid123",
+                debate_session_id="sess123",
+                ticker="AAPL",
+                pick_source_label="l" * 257,
+            )
+
+    def test_oversized_pick_source_kind_rejected(self):
+        with pytest.raises(ValidationError):
+            StartAnalyzeRunRequest(
+                user_id="uid123",
+                debate_session_id="sess123",
+                ticker="AAPL",
+                pick_source_kind="k" * 65,
+            )
+
+    def test_valid_request_accepted(self):
+        req = StartAnalyzeRunRequest(
+            user_id="uid123",
+            debate_session_id="sess-abc",
+            ticker="AAPL",
+        )
+        assert req.ticker == "AAPL"


### PR DESCRIPTION
## Problem

`api/routes/kai/stream.py` defines five module-level constants that declare
the maximum allowed sizes for fields arriving at these endpoints:

```python
_USER_ID_MAX_LEN: int = 128
_TICKER_RAW_MAX_LEN: int = 20
_RISK_PROFILE_MAX_LEN: int = 64
_DEBATE_SESSION_ID_MAX_LEN: int = 256
_RUN_ID_MAX_LEN: int = 128
```

These constants are correctly applied to GET Query parameters throughout the
file. The POST body models for the same endpoints were left unprotected:

```python
class StreamAnalyzeRequest(BaseModel):
    user_id: str           # no max_length
    ticker: str            # no max_length
    risk_profile: str = "balanced"  # no max_length
    run_id: Optional[str] = None    # no max_length

class StartAnalyzeRunRequest(BaseModel):
    user_id: str           # no max_length
    debate_session_id: str # no max_length
    ticker: str            # no max_length
    pick_source: Optional[str] = None  # no max_length
    pick_source_label: Optional[str] = None  # no max_length
    pick_source_kind: Optional[str] = None   # no max_length
```

An authenticated caller using the POST path could supply oversized strings that
would be rejected on the GET path (CWE-400 inconsistent enforcement).
`ticker` and `user_id` are forwarded into LLM inference calls and audit-log
writes, so oversized values propagate deeper than a simple string copy.

## Fix

Apply the existing module constants to `StreamAnalyzeRequest` and
`StartAnalyzeRunRequest` using `Field(max_length=...)`. For
`pick_source_label` and `pick_source_kind` (no existing constant), added
`max_length=256` and `max_length=64` respectively -- these values land in
audit-log metadata.

## Tests

`tests/test_stream_analyze_request_bounds.py` -- 14 tests, all passing.

- Oversized `user_id`, `ticker`, `risk_profile`, `run_id` rejected in `StreamAnalyzeRequest`
- Oversized `user_id`, `debate_session_id`, `ticker`, `risk_profile`,
  `pick_source`, `pick_source_label`, `pick_source_kind` rejected in
  `StartAnalyzeRunRequest`
- `test_bounds_match_module_constants`: verifies the `user_id` Field uses
  `_USER_ID_MAX_LEN` specifically, confirming GET and POST paths are consistent

```
tests/test_stream_analyze_request_bounds.py ..............  14 passed in 6.04s
```

## Affected surface

| File | Change |
|------|--------|
| `api/routes/kai/stream.py` | Added `Field(max_length=...)` to `StreamAnalyzeRequest` and `StartAnalyzeRunRequest` using existing module constants |
| `tests/test_stream_analyze_request_bounds.py` | New file, 14 tests |