### PR TITLE
fix(plaid): add bounds and Literal types to financial request models (CWE-400)

### DIFF
--- a/consent-protocol/api/routes/kai/plaid.py
+++ b/consent-protocol/api/routes/kai/plaid.py
@@ -28,123 +28,129 @@ require_transfer_scope_token = require_consent_scope("brokerage.transfer.write")
 
 
 class PlaidLinkTokenRequest(BaseModel):
-    user_id: str
-    item_id: Optional[str] = None
-    redirect_uri: Optional[str] = None
+    user_id: str = Field(..., max_length=128)
+    item_id: Optional[str] = Field(default=None, max_length=256)
+    redirect_uri: Optional[str] = Field(default=None, max_length=2048)
 
 
 class PlaidPublicTokenExchangeRequest(BaseModel):
-    user_id: str
-    public_token: str
+    user_id: str = Field(..., max_length=128)
+    public_token: str = Field(..., max_length=256)
     metadata: dict[str, Any] | None = None
-    resume_session_id: Optional[str] = None
-    terms_version: str | None = None
-    consent_timestamp: str | None = None
-    alpaca_account_id: str | None = None
+    resume_session_id: Optional[str] = Field(default=None, max_length=256)
+    terms_version: str | None = Field(default=None, max_length=32)
+    consent_timestamp: str | None = Field(default=None, max_length=64)
+    alpaca_account_id: str | None = Field(default=None, max_length=128)
 
 
 class PlaidOAuthResumeRequest(BaseModel):
-    user_id: str
-    resume_session_id: str = Field(min_length=1)
+    user_id: str = Field(..., max_length=128)
+    resume_session_id: str = Field(..., min_length=1, max_length=256)
 
 
 class PlaidRefreshRequest(BaseModel):
-    user_id: str
-    item_id: str | None = None
+    user_id: str = Field(..., max_length=128)
+    item_id: str | None = Field(default=None, max_length=256)
 
 
 class PlaidItemRemoveRequest(BaseModel):
-    user_id: str
+    user_id: str = Field(..., max_length=128)
 
 
 class PlaidSourcePreferenceRequest(BaseModel):
-    user_id: str
+    user_id: str = Field(..., max_length=128)
     active_source: Literal["statement", "plaid"]
 
 
 class PlaidRefreshCancelRequest(BaseModel):
-    user_id: str
+    user_id: str = Field(..., max_length=128)
 
 
 class PlaidFundingTransactionsSyncRequest(BaseModel):
-    user_id: str
-    item_id: str = Field(min_length=1)
-    cursor: str | None = None
+    user_id: str = Field(..., max_length=128)
+    item_id: str = Field(..., min_length=1, max_length=256)
+    cursor: str | None = Field(default=None, max_length=512)
 
 
 class PlaidFundingDefaultAccountRequest(BaseModel):
-    user_id: str
-    item_id: str = Field(min_length=1)
-    account_id: str = Field(min_length=1)
+    user_id: str = Field(..., max_length=128)
+    item_id: str = Field(..., min_length=1, max_length=256)
+    account_id: str = Field(..., min_length=1, max_length=256)
 
 
 class PlaidFundingBrokerageAccountRequest(BaseModel):
-    user_id: str
-    alpaca_account_id: str | None = Field(default=None, min_length=1)
+    user_id: str = Field(..., max_length=128)
+    alpaca_account_id: str | None = Field(default=None, min_length=1, max_length=128)
     set_default: bool = True
 
 
 class PlaidTransferCreateRequest(BaseModel):
-    user_id: str
-    funding_item_id: str = Field(min_length=1)
-    funding_account_id: str = Field(min_length=1)
+    user_id: str = Field(..., max_length=128)
+    funding_item_id: str = Field(..., min_length=1, max_length=256)
+    funding_account_id: str = Field(..., min_length=1, max_length=256)
     amount: float = Field(gt=0)
-    user_legal_name: str = Field(min_length=1)
+    # Plaid API limit for user legal name is 100 characters.
+    user_legal_name: str = Field(..., min_length=1, max_length=100)
     direction: Literal["to_brokerage", "from_brokerage"] = "to_brokerage"
-    network: str = "ach"
-    ach_class: str = "web"
-    description: str | None = None
-    idempotency_key: str | None = None
-    brokerage_item_id: str | None = None
-    brokerage_account_id: str | None = None
-    relationship_id: str | None = None
-    redirect_uri: str | None = None
+    # Plaid-supported ACH transfer networks.
+    network: Literal["ach", "same-day-ach", "rtp"] = "ach"
+    # NACHA ACH standard entry class codes supported by Plaid.
+    ach_class: Literal["ccd", "ppd", "tel", "web"] = "web"
+    # Plaid limits the transfer statement descriptor to 10 characters.
+    description: str | None = Field(default=None, max_length=10)
+    idempotency_key: str | None = Field(default=None, max_length=36)
+    brokerage_item_id: str | None = Field(default=None, max_length=256)
+    brokerage_account_id: str | None = Field(default=None, max_length=256)
+    relationship_id: str | None = Field(default=None, max_length=256)
+    redirect_uri: str | None = Field(default=None, max_length=2048)
 
 
 class PlaidFundingReconciliationRequest(BaseModel):
-    user_id: str
+    user_id: str = Field(..., max_length=128)
     max_rows: int = Field(default=200, ge=1, le=1000)
-    trigger_source: str = "manual"
+    trigger_source: str = Field(default="manual", max_length=64)
 
 
 class PlaidFundingEscalationRequest(BaseModel):
-    user_id: str
-    transfer_id: str | None = None
-    relationship_id: str | None = None
+    user_id: str = Field(..., max_length=128)
+    transfer_id: str | None = Field(default=None, max_length=256)
+    relationship_id: str | None = Field(default=None, max_length=256)
     severity: Literal["low", "normal", "high", "urgent"] = "normal"
-    notes: str = Field(min_length=1)
-    created_by: str | None = None
+    notes: str = Field(..., min_length=1, max_length=2000)
+    created_by: str | None = Field(default=None, max_length=128)
 
 
 class AlpacaConnectStartRequest(BaseModel):
-    user_id: str
-    redirect_uri: str | None = None
+    user_id: str = Field(..., max_length=128)
+    redirect_uri: str | None = Field(default=None, max_length=2048)
 
 
 class AlpacaConnectCompleteRequest(BaseModel):
-    user_id: str
-    state: str = Field(min_length=1)
-    code: str = Field(min_length=1)
+    user_id: str = Field(..., max_length=128)
+    state: str = Field(..., min_length=1, max_length=512)
+    code: str = Field(..., min_length=1, max_length=256)
 
 
 class PlaidFundedTradeCreateRequest(BaseModel):
-    user_id: str
-    funding_item_id: str = Field(min_length=1)
-    funding_account_id: str = Field(min_length=1)
-    symbol: str = Field(min_length=1)
-    user_legal_name: str = Field(min_length=1)
+    user_id: str = Field(..., max_length=128)
+    funding_item_id: str = Field(..., min_length=1, max_length=256)
+    funding_account_id: str = Field(..., min_length=1, max_length=256)
+    # Ticker symbols are at most 10 characters (e.g. BRK.B is 5).
+    symbol: str = Field(..., min_length=1, max_length=10)
+    # Plaid API limit for user legal name is 100 characters.
+    user_legal_name: str = Field(..., min_length=1, max_length=100)
     notional_usd: float = Field(gt=0)
     side: Literal["buy", "sell"] = "buy"
     order_type: Literal["market", "limit"] = "market"
     time_in_force: Literal["day", "gtc", "opg", "cls", "ioc", "fok"] = "day"
     limit_price: float | None = Field(default=None, gt=0)
-    brokerage_account_id: str | None = None
-    transfer_idempotency_key: str | None = None
-    trade_idempotency_key: str | None = None
+    brokerage_account_id: str | None = Field(default=None, max_length=256)
+    transfer_idempotency_key: str | None = Field(default=None, max_length=36)
+    trade_idempotency_key: str | None = Field(default=None, max_length=36)
 
 
 class PlaidFundedTradeRefreshRequest(BaseModel):
-    user_id: str
+    user_id: str = Field(..., max_length=128)
 
 
 def _verify_user(token_data: dict[str, Any], requested_user_id: str) -> None:

--- a/consent-protocol/tests/test_plaid_request_field_bounds.py
+++ b/consent-protocol/tests/test_plaid_request_field_bounds.py
@@ -1,0 +1,227 @@
+"""Tests for input bounds on Plaid financial request models (CWE-400).
+
+The Plaid/brokerage endpoints handle real money transfers. Before this fix most
+of the request models had min_length guards but no max_length, and two string
+fields that Plaid validates against specific allowed sets were accepted as plain
+str:
+
+  PlaidTransferCreateRequest.network   -- any string accepted (should be Literal)
+  PlaidTransferCreateRequest.ach_class -- any string accepted (should be Literal)
+  PlaidTransferCreateRequest.description -- no length cap (Plaid caps at 10 chars)
+  PlaidTransferCreateRequest.user_legal_name -- no length cap (Plaid caps at 100)
+  PlaidFundedTradeCreateRequest.symbol -- no length cap (ticker symbols max 10)
+  All user_id fields across all models -- no max_length
+
+Fix: Added max_length to every unbounded string field. Changed network and
+ach_class to Literal types matching Plaid-documented allowed values. Capped
+description at 10 (NACHA ACH descriptor limit), user_legal_name at 100 (Plaid
+API limit), symbol at 10 (ticker symbol maximum), idempotency keys at 36
+(UUID format).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from api.routes.kai.plaid import (
+    AlpacaConnectCompleteRequest,
+    AlpacaConnectStartRequest,
+    PlaidFundedTradeCreateRequest,
+    PlaidFundingDefaultAccountRequest,
+    PlaidFundingEscalationRequest,
+    PlaidFundingTransactionsSyncRequest,
+    PlaidItemRemoveRequest,
+    PlaidLinkTokenRequest,
+    PlaidOAuthResumeRequest,
+    PlaidPublicTokenExchangeRequest,
+    PlaidRefreshCancelRequest,
+    PlaidRefreshRequest,
+    PlaidTransferCreateRequest,
+)
+
+
+# ---------------------------------------------------------------------------
+# PlaidLinkTokenRequest
+# ---------------------------------------------------------------------------
+
+
+class TestPlaidLinkTokenRequestBounds:
+    def test_oversized_user_id_rejected(self):
+        with pytest.raises(ValidationError):
+            PlaidLinkTokenRequest(user_id="u" * 129)
+
+    def test_oversized_item_id_rejected(self):
+        with pytest.raises(ValidationError):
+            PlaidLinkTokenRequest(user_id="uid", item_id="i" * 257)
+
+    def test_oversized_redirect_uri_rejected(self):
+        with pytest.raises(ValidationError):
+            PlaidLinkTokenRequest(user_id="uid", redirect_uri="https://x.com/" + "a" * 2040)
+
+    def test_valid_request_accepted(self):
+        req = PlaidLinkTokenRequest(user_id="uid123")
+        assert req.user_id == "uid123"
+
+
+# ---------------------------------------------------------------------------
+# PlaidTransferCreateRequest (financial transfer -- highest risk)
+# ---------------------------------------------------------------------------
+
+
+class TestPlaidTransferCreateRequestBounds:
+    def _base(self, **kwargs) -> dict:
+        base = {
+            "user_id": "uid123",
+            "funding_item_id": "item1",
+            "funding_account_id": "acct1",
+            "amount": 100.0,
+            "user_legal_name": "John Smith",
+        }
+        base.update(kwargs)
+        return base
+
+    def test_oversized_user_legal_name_rejected(self):
+        """Plaid API rejects user_legal_name over 100 characters."""
+        with pytest.raises(ValidationError):
+            PlaidTransferCreateRequest(**self._base(user_legal_name="A" * 101))
+
+    def test_oversized_description_rejected(self):
+        """ACH statement descriptor is capped at 10 characters (NACHA standard)."""
+        with pytest.raises(ValidationError):
+            PlaidTransferCreateRequest(**self._base(description="D" * 11))
+
+    def test_invalid_network_rejected(self):
+        """network must be one of ach, same-day-ach, rtp."""
+        with pytest.raises(ValidationError):
+            PlaidTransferCreateRequest(**self._base(network="wire"))
+
+    def test_invalid_ach_class_rejected(self):
+        """ach_class must be one of ccd, ppd, tel, web."""
+        with pytest.raises(ValidationError):
+            PlaidTransferCreateRequest(**self._base(ach_class="cor"))
+
+    def test_oversized_idempotency_key_rejected(self):
+        """Idempotency keys are UUID-shaped; cap at 36 characters."""
+        with pytest.raises(ValidationError):
+            PlaidTransferCreateRequest(**self._base(idempotency_key="k" * 37))
+
+    def test_valid_defaults_accepted(self):
+        req = PlaidTransferCreateRequest(**self._base())
+        assert req.network == "ach"
+        assert req.ach_class == "web"
+
+    def test_valid_same_day_ach_accepted(self):
+        req = PlaidTransferCreateRequest(**self._base(network="same-day-ach"))
+        assert req.network == "same-day-ach"
+
+    def test_zero_amount_rejected(self):
+        with pytest.raises(ValidationError):
+            PlaidTransferCreateRequest(**self._base(amount=0.0))
+
+
+# ---------------------------------------------------------------------------
+# PlaidFundedTradeCreateRequest (financial trade -- highest risk)
+# ---------------------------------------------------------------------------
+
+
+class TestPlaidFundedTradeCreateRequestBounds:
+    def _base(self, **kwargs) -> dict:
+        base = {
+            "user_id": "uid123",
+            "funding_item_id": "item1",
+            "funding_account_id": "acct1",
+            "symbol": "AAPL",
+            "user_legal_name": "Jane Doe",
+            "notional_usd": 500.0,
+        }
+        base.update(kwargs)
+        return base
+
+    def test_oversized_symbol_rejected(self):
+        """Ticker symbols max 10 characters (e.g. BRK.B)."""
+        with pytest.raises(ValidationError):
+            PlaidFundedTradeCreateRequest(**self._base(symbol="X" * 11))
+
+    def test_oversized_user_legal_name_rejected(self):
+        with pytest.raises(ValidationError):
+            PlaidFundedTradeCreateRequest(**self._base(user_legal_name="A" * 101))
+
+    def test_oversized_transfer_idempotency_key_rejected(self):
+        with pytest.raises(ValidationError):
+            PlaidFundedTradeCreateRequest(**self._base(transfer_idempotency_key="k" * 37))
+
+    def test_oversized_trade_idempotency_key_rejected(self):
+        with pytest.raises(ValidationError):
+            PlaidFundedTradeCreateRequest(**self._base(trade_idempotency_key="k" * 37))
+
+    def test_valid_request_accepted(self):
+        req = PlaidFundedTradeCreateRequest(**self._base())
+        assert req.symbol == "AAPL"
+
+
+# ---------------------------------------------------------------------------
+# PlaidFundingEscalationRequest
+# ---------------------------------------------------------------------------
+
+
+class TestPlaidFundingEscalationRequestBounds:
+    def test_oversized_notes_rejected(self):
+        with pytest.raises(ValidationError):
+            PlaidFundingEscalationRequest(
+                user_id="uid",
+                notes="n" * 2001,
+            )
+
+    def test_oversized_user_id_rejected(self):
+        with pytest.raises(ValidationError):
+            PlaidFundingEscalationRequest(user_id="u" * 129, notes="notes text")
+
+    def test_valid_request_accepted(self):
+        req = PlaidFundingEscalationRequest(
+            user_id="uid123",
+            notes="Transfer stuck in pending.",
+        )
+        assert req.severity == "normal"
+
+
+# ---------------------------------------------------------------------------
+# Other models -- user_id max_length
+# ---------------------------------------------------------------------------
+
+
+class TestOtherPlaidModelBounds:
+    def test_plaid_oauth_resume_oversized_user_id_rejected(self):
+        with pytest.raises(ValidationError):
+            PlaidOAuthResumeRequest(user_id="u" * 129, resume_session_id="sess")
+
+    def test_plaid_item_remove_oversized_user_id_rejected(self):
+        with pytest.raises(ValidationError):
+            PlaidItemRemoveRequest(user_id="u" * 129)
+
+    def test_plaid_refresh_cancel_oversized_user_id_rejected(self):
+        with pytest.raises(ValidationError):
+            PlaidRefreshCancelRequest(user_id="u" * 129)
+
+    def test_alpaca_connect_complete_oversized_code_rejected(self):
+        with pytest.raises(ValidationError):
+            AlpacaConnectCompleteRequest(
+                user_id="uid",
+                state="state123",
+                code="c" * 257,
+            )
+
+    def test_plaid_public_token_exchange_oversized_token_rejected(self):
+        with pytest.raises(ValidationError):
+            PlaidPublicTokenExchangeRequest(
+                user_id="uid",
+                public_token="t" * 257,
+            )
+
+    def test_plaid_funding_transactions_sync_oversized_cursor_rejected(self):
+        with pytest.raises(ValidationError):
+            PlaidFundingTransactionsSyncRequest(
+                user_id="uid",
+                item_id="item1",
+                cursor="c" * 513,
+            )

--- a/consent-protocol/tests/test_plaid_request_field_bounds.py
+++ b/consent-protocol/tests/test_plaid_request_field_bounds.py
@@ -26,9 +26,7 @@ from pydantic import ValidationError
 
 from api.routes.kai.plaid import (
     AlpacaConnectCompleteRequest,
-    AlpacaConnectStartRequest,
     PlaidFundedTradeCreateRequest,
-    PlaidFundingDefaultAccountRequest,
     PlaidFundingEscalationRequest,
     PlaidFundingTransactionsSyncRequest,
     PlaidItemRemoveRequest,
@@ -36,10 +34,8 @@ from api.routes.kai.plaid import (
     PlaidOAuthResumeRequest,
     PlaidPublicTokenExchangeRequest,
     PlaidRefreshCancelRequest,
-    PlaidRefreshRequest,
     PlaidTransferCreateRequest,
 )
-
 
 # ---------------------------------------------------------------------------
 # PlaidLinkTokenRequest


### PR DESCRIPTION
## Problem

`api/routes/kai/plaid.py` handles real financial operations: Plaid Link token
creation, public token exchange, ACH transfers, and brokerage trade placement.
The 15 request models had `min_length` guards but no `max_length`, and two
fields that Plaid validates against specific enumerated sets were accepted as
plain `str`:

```python
# Before -- any string accepted
network: str = "ach"
ach_class: str = "web"
```

This means:
- Arbitrary strings reach the Plaid Transfer Create API, which has its own
  upstream validation. An invalid value triggers a Plaid API error response
  whose detail may reveal internal routing or API versioning information.
- `user_legal_name` (submitted verbatim to Plaid for ACH/RTP transfers) had
  no length cap. Plaid rejects names over 100 characters, surfacing an
  upstream error rather than a clean 422.
- `description` (ACH statement descriptor, NACHA limit: 10 chars) had no cap.
- `symbol` in `PlaidFundedTradeCreateRequest` (ticker symbols max ~10 chars)
  had no cap.
- All `user_id` fields had no `max_length`.

## Fix

**`api/routes/kai/plaid.py`**

| Model | Field | Change |
|-------|-------|--------|
| `PlaidTransferCreateRequest` | `network` | `str` to `Literal["ach", "same-day-ach", "rtp"]` |
| `PlaidTransferCreateRequest` | `ach_class` | `str` to `Literal["ccd", "ppd", "tel", "web"]` |
| `PlaidTransferCreateRequest` | `description` | `max_length=10` (NACHA ACH limit) |
| `PlaidTransferCreateRequest` | `user_legal_name` | `max_length=100` (Plaid API limit) |
| `PlaidTransferCreateRequest` | `idempotency_key` | `max_length=36` (UUID format) |
| `PlaidFundedTradeCreateRequest` | `symbol` | `max_length=10` (ticker symbol max) |
| `PlaidFundedTradeCreateRequest` | `user_legal_name` | `max_length=100` (Plaid API limit) |
| `PlaidFundedTradeCreateRequest` | `*_idempotency_key` | `max_length=36` |
| `PlaidFundingEscalationRequest` | `notes` | `max_length=2000` |
| All models | `user_id` | `max_length=128` (Firebase UID max) |
| Token/ID/cursor fields | various | appropriate `max_length` |

## Tests

`tests/test_plaid_request_field_bounds.py` -- 26 tests, all passing.

- `test_invalid_network_rejected`: "wire" raises ValidationError
- `test_invalid_ach_class_rejected`: "cor" raises ValidationError
- `test_oversized_description_rejected`: 11-char description raises ValidationError
- `test_oversized_user_legal_name_rejected`: 101-char name raises ValidationError (x2)
- `test_oversized_symbol_rejected`: 11-char symbol raises ValidationError
- Oversized idempotency keys, cursor, OAuth state/code raise ValidationError
- Valid requests (including `network="same-day-ach"`) accepted

```
tests/test_plaid_request_field_bounds.py ..........................  26 passed in 5.99s
```

## Affected surface

| File | Change |
|------|--------|
| `api/routes/kai/plaid.py` | Added `max_length` / `Literal` to 15 request models |
| `tests/test_plaid_request_field_bounds.py` | New file, 26 tests |