### PR TITLE
fix(kai-subroutes): add max_length to user_id in chat and support models

### DIFF
--- a/consent-protocol/api/routes/kai/agent_chat.py
+++ b/consent-protocol/api/routes/kai/agent_chat.py
@@ -26,9 +26,9 @@ router = APIRouter(tags=["Agent Chat"])
 
 
 class AgentChatStreamRequest(BaseModel):
-    user_id: str = Field(..., min_length=1)
+    user_id: str = Field(..., min_length=1, max_length=128)
     message: str = Field(..., min_length=1, max_length=8000)
-    conversation_id: Optional[str] = None
+    conversation_id: Optional[str] = Field(default=None, max_length=128)
     pkm_context: Optional[str] = Field(default=None, max_length=20000)
 
 

--- a/consent-protocol/api/routes/kai/support.py
+++ b/consent-protocol/api/routes/kai/support.py
@@ -22,7 +22,7 @@ router = APIRouter(tags=["Kai Support"])
 
 
 class SupportMessageRequest(BaseModel):
-    user_id: str
+    user_id: str = Field(..., min_length=1, max_length=128)
     kind: Literal["bug_report", "support_request", "developer_reachout"]
     subject: str = Field(min_length=3, max_length=140)
     message: str = Field(min_length=10, max_length=8000)

--- a/consent-protocol/tests/test_kai_subroutes_user_id_bounds.py
+++ b/consent-protocol/tests/test_kai_subroutes_user_id_bounds.py
@@ -1,0 +1,122 @@
+"""
+Tests for user_id field bounds on kai agent sub-route request models.
+
+AgentChatStreamRequest and SupportMessageRequest both feed user_id into
+downstream service calls (Gemini streaming, email delivery queue).
+Without a max_length constraint any caller can submit an arbitrarily long
+identifier, causing oversized database writes and unbounded log payloads
+(CWE-400).
+
+These tests confirm that Pydantic rejects oversized inputs before they
+reach the handler.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from api.routes.kai.agent_chat import AgentChatStreamRequest
+from api.routes.kai.support import SupportMessageRequest
+
+_USER_ID_MAX = 128
+_CONVERSATION_ID_MAX = 128
+
+
+# ---------------------------------------------------------------------------
+# AgentChatStreamRequest -- user_id
+# ---------------------------------------------------------------------------
+
+
+def test_agent_chat_user_id_at_max_accepted():
+    req = AgentChatStreamRequest(user_id="u" * _USER_ID_MAX, message="hello")
+    assert len(req.user_id) == _USER_ID_MAX
+
+
+def test_agent_chat_user_id_over_max_rejected():
+    with pytest.raises(ValidationError):
+        AgentChatStreamRequest(user_id="u" * (_USER_ID_MAX + 1), message="hello")
+
+
+def test_agent_chat_user_id_empty_rejected():
+    with pytest.raises(ValidationError):
+        AgentChatStreamRequest(user_id="", message="hello")
+
+
+def test_agent_chat_user_id_typical_accepted():
+    req = AgentChatStreamRequest(user_id="user_abc123", message="What is AAPL?")
+    assert req.user_id == "user_abc123"
+
+
+# ---------------------------------------------------------------------------
+# AgentChatStreamRequest -- conversation_id
+# ---------------------------------------------------------------------------
+
+
+def test_agent_chat_conversation_id_none_accepted():
+    req = AgentChatStreamRequest(user_id="uid", message="hello", conversation_id=None)
+    assert req.conversation_id is None
+
+
+def test_agent_chat_conversation_id_omitted_defaults_to_none():
+    req = AgentChatStreamRequest(user_id="uid", message="hello")
+    assert req.conversation_id is None
+
+
+def test_agent_chat_conversation_id_at_max_accepted():
+    req = AgentChatStreamRequest(
+        user_id="uid", message="hello", conversation_id="c" * _CONVERSATION_ID_MAX
+    )
+    assert len(req.conversation_id) == _CONVERSATION_ID_MAX
+
+
+def test_agent_chat_conversation_id_over_max_rejected():
+    with pytest.raises(ValidationError):
+        AgentChatStreamRequest(
+            user_id="uid", message="hello", conversation_id="c" * (_CONVERSATION_ID_MAX + 1)
+        )
+
+
+# ---------------------------------------------------------------------------
+# SupportMessageRequest -- user_id
+# ---------------------------------------------------------------------------
+
+
+def test_support_user_id_at_max_accepted():
+    req = SupportMessageRequest(
+        user_id="u" * _USER_ID_MAX,
+        kind="support_request",
+        subject="Need help",
+        message="Please help me with my account.",
+    )
+    assert len(req.user_id) == _USER_ID_MAX
+
+
+def test_support_user_id_over_max_rejected():
+    with pytest.raises(ValidationError):
+        SupportMessageRequest(
+            user_id="u" * (_USER_ID_MAX + 1),
+            kind="support_request",
+            subject="Need help",
+            message="Please help me with my account.",
+        )
+
+
+def test_support_user_id_empty_rejected():
+    with pytest.raises(ValidationError):
+        SupportMessageRequest(
+            user_id="",
+            kind="bug_report",
+            subject="Found a bug",
+            message="The app crashes on startup every time.",
+        )
+
+
+def test_support_user_id_typical_accepted():
+    req = SupportMessageRequest(
+        user_id="user_abc123",
+        kind="bug_report",
+        subject="App crashes",
+        message="Reproducible crash on the portfolio screen.",
+    )
+    assert req.user_id == "user_abc123"


### PR DESCRIPTION
## Summary

Two kai agent sub-route request models were missing upper bounds on `user_id`, leaving them open to CWE-400 (Uncontrolled Resource Consumption):

**`AgentChatStreamRequest` (`agent_chat.py`)**
- `user_id` had `min_length=1` but no `max_length`. The value is passed directly to the Gemini streaming service and persisted to the conversation database.
- `conversation_id` had no constraints at all; it is used as a database lookup key and written to log lines.

**`SupportMessageRequest` (`support.py`)**
- `user_id` had no constraints, despite every other field in the same model (`subject`, `message`, `user_email`, etc.) having explicit bounds. The value is forwarded to the email delivery queue service and stored in job context.

**Changes:**
- `AgentChatStreamRequest.user_id`: add `max_length=128` to existing `min_length=1`
- `AgentChatStreamRequest.conversation_id`: `Field(default=None, max_length=128)`
- `SupportMessageRequest.user_id`: `Field(..., min_length=1, max_length=128)`

**Files changed:**
- `api/routes/kai/agent_chat.py`
- `api/routes/kai/support.py`
- `tests/test_kai_subroutes_user_id_bounds.py` -- 12 new tests

## Test plan

- [x] `AgentChatStreamRequest.user_id` at exact max (128) accepted
- [x] `AgentChatStreamRequest.user_id` one byte over max rejected
- [x] Empty `user_id` rejected in both models
- [x] `AgentChatStreamRequest.conversation_id` None and omitted accepted
- [x] `AgentChatStreamRequest.conversation_id` at exact max (128) accepted
- [x] `AgentChatStreamRequest.conversation_id` one byte over max rejected
- [x] `SupportMessageRequest.user_id` at exact max (128) accepted
- [x] `SupportMessageRequest.user_id` one byte over max rejected
- [x] All 12 tests pass locally
- [x] `ruff` passes with no warnings