### PR TITLE
fix(developer): reject non-http/https URI schemes in profile URL fields

### DIFF
--- a/consent-protocol/api/routes/developer.py
+++ b/consent-protocol/api/routes/developer.py
@@ -7,7 +7,7 @@ import uuid
 from typing import Any, Literal, Optional, TypedDict, cast
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from api.developer_auth import (
     authenticate_developer_principal,
@@ -265,6 +265,16 @@ class DeveloperPortalProfileUpdateRequest(BaseModel):
     policy_url: str | None = Field(default=None, max_length=512)
     website_url: str | None = Field(default=None, max_length=512)
     brand_image_url: str | None = Field(default=None, max_length=512)
+
+    @field_validator("support_url", "policy_url", "website_url", "brand_image_url", mode="before")
+    @classmethod
+    def _require_safe_url_scheme(cls, v: object) -> object:
+        if v is None:
+            return v
+        url = str(v).strip()
+        if url and not (url.startswith("https://") or url.startswith("http://")):
+            raise ValueError("URL must use https:// or http:// scheme")
+        return url
 
 
 class OwnerProfile(TypedDict):

--- a/consent-protocol/tests/test_developer_portal_url_scheme.py
+++ b/consent-protocol/tests/test_developer_portal_url_scheme.py
@@ -1,0 +1,72 @@
+"""
+Tests for URL scheme validation on DeveloperPortalProfileUpdateRequest.
+
+Developer app profiles store four URL fields (support_url, policy_url,
+website_url, brand_image_url) that are persisted to the database and
+surfaced to end users inside consent flows.  Accepting arbitrary URI
+schemes (javascript:, data:, vbscript:) creates a stored XSS / phishing
+vector when the frontend renders these values as anchor hrefs.
+
+These tests confirm that non-http/https URIs are rejected at the Pydantic
+layer before the profile update handler runs.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from api.routes.developer import DeveloperPortalProfileUpdateRequest
+
+_URL_FIELDS = ("support_url", "policy_url", "website_url", "brand_image_url")
+_SAFE_HTTPS = "https://example.com/page"
+_SAFE_HTTP = "http://example.com/page"
+_DANGEROUS_SCHEMES = [
+    "javascript:alert(1)",
+    "javascript:void(0)",
+    "data:text/html,<script>alert(1)</script>",
+    "vbscript:MsgBox(1)",
+    "file:///etc/passwd",
+    "ftp://internal-server/secret",
+]
+
+
+# ---------------------------------------------------------------------------
+# Accepted values
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("field", _URL_FIELDS)
+def test_https_url_accepted(field):
+    req = DeveloperPortalProfileUpdateRequest(**{field: _SAFE_HTTPS})
+    assert getattr(req, field) == _SAFE_HTTPS
+
+
+@pytest.mark.parametrize("field", _URL_FIELDS)
+def test_http_url_accepted(field):
+    req = DeveloperPortalProfileUpdateRequest(**{field: _SAFE_HTTP})
+    assert getattr(req, field) == _SAFE_HTTP
+
+
+@pytest.mark.parametrize("field", _URL_FIELDS)
+def test_none_accepted(field):
+    req = DeveloperPortalProfileUpdateRequest(**{field: None})
+    assert getattr(req, field) is None
+
+
+@pytest.mark.parametrize("field", _URL_FIELDS)
+def test_omitted_defaults_to_none(field):
+    req = DeveloperPortalProfileUpdateRequest()
+    assert getattr(req, field) is None
+
+
+# ---------------------------------------------------------------------------
+# Rejected values -- dangerous URI schemes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("field", _URL_FIELDS)
+@pytest.mark.parametrize("bad_url", _DANGEROUS_SCHEMES)
+def test_dangerous_scheme_rejected(field, bad_url):
+    with pytest.raises(ValidationError):
+        DeveloperPortalProfileUpdateRequest(**{field: bad_url})


### PR DESCRIPTION
## Summary

`DeveloperPortalProfileUpdateRequest` accepted arbitrary strings for four URL fields:

- `support_url`
- `policy_url`
- `website_url`
- `brand_image_url`

These values are persisted to the developer app registry and surfaced inside consent flows shown to end users (as the developer's privacy policy, support link, and brand identity). Accepting `javascript:`, `data:`, `vbscript:`, or `file:` URIs creates a stored XSS / phishing vector if the frontend renders them as anchor `href` attributes (CWE-79).

**Fix:** Add a `@field_validator` on all four fields that rejects any non-`None` URL whose scheme is not `https://` or `http://`. Existing valid URLs and `None` values are unaffected.

```python
@field_validator("support_url", "policy_url", "website_url", "brand_image_url", mode="before")
@classmethod
def _require_safe_url_scheme(cls, v: object) -> object:
    if v is None:
        return v
    url = str(v).strip()
    if url and not (url.startswith("https://") or url.startswith("http://")):
        raise ValueError("URL must use https:// or http:// scheme")
    return url
```

**Files changed:**
- `api/routes/developer.py` -- add `field_validator` to `DeveloperPortalProfileUpdateRequest`
- `tests/test_developer_portal_url_scheme.py` -- 40 parameterised tests

## Test plan

- [x] `https://` and `http://` URLs accepted on all four fields
- [x] `None` and omitted values accepted on all four fields
- [x] `javascript:`, `data:`, `vbscript:`, `file:`, `ftp:` schemes rejected on all four fields
- [x] 40 tests pass locally
- [x] `ruff` passes with no warnings