### PR TITLE
fix(ria): add field bounds and URL scheme validation to RIA request models

### DIFF
--- a/consent-protocol/tests/test_ria_request_field_bounds.py
+++ b/consent-protocol/tests/test_ria_request_field_bounds.py
@@ -31,13 +31,13 @@ from api.routes.ria import (
 
 
 def test_submit_display_name_at_max_accepted():
-    req = RIAOnboardingSubmitRequest(display_name="A" * 256)
-    assert len(req.display_name) == 256
+    req = RIAOnboardingSubmitRequest(display_name="A" * 200)
+    assert len(req.display_name) == 200
 
 
 def test_submit_display_name_over_max_rejected():
     with pytest.raises(ValidationError):
-        RIAOnboardingSubmitRequest(display_name="A" * 257)
+        RIAOnboardingSubmitRequest(display_name="A" * 201)
 
 
 def test_submit_display_name_empty_rejected():
@@ -51,13 +51,13 @@ def test_submit_display_name_empty_rejected():
 
 
 def test_submit_individual_legal_name_at_max_accepted():
-    req = RIAOnboardingSubmitRequest(display_name="Jane Doe", individual_legal_name="N" * 256)
-    assert len(req.individual_legal_name) == 256
+    req = RIAOnboardingSubmitRequest(display_name="Jane Doe", individual_legal_name="N" * 200)
+    assert len(req.individual_legal_name) == 200
 
 
 def test_submit_individual_legal_name_over_max_rejected():
     with pytest.raises(ValidationError):
-        RIAOnboardingSubmitRequest(display_name="Jane Doe", individual_legal_name="N" * 257)
+        RIAOnboardingSubmitRequest(display_name="Jane Doe", individual_legal_name="N" * 201)
 
 
 # ---------------------------------------------------------------------------
@@ -66,13 +66,13 @@ def test_submit_individual_legal_name_over_max_rejected():
 
 
 def test_submit_finra_crd_at_max_accepted():
-    req = RIAOnboardingSubmitRequest(display_name="Jane Doe", finra_crd="1" * 50)
-    assert len(req.finra_crd) == 50
+    req = RIAOnboardingSubmitRequest(display_name="Jane Doe", finra_crd="1" * 10)
+    assert len(req.finra_crd) == 10
 
 
 def test_submit_finra_crd_over_max_rejected():
     with pytest.raises(ValidationError):
-        RIAOnboardingSubmitRequest(display_name="Jane Doe", finra_crd="1" * 51)
+        RIAOnboardingSubmitRequest(display_name="Jane Doe", finra_crd="1" * 11)
 
 
 # ---------------------------------------------------------------------------
@@ -144,23 +144,23 @@ def test_submit_disclosures_url_dangerous_scheme_rejected(bad_url):
 
 
 def test_verify_name_query_at_max_accepted():
-    req = RIAOnboardingVerifyNameRequest(query="q" * 256)
-    assert len(req.query) == 256
+    req = RIAOnboardingVerifyNameRequest(query="q" * 200)
+    assert len(req.query) == 200
 
 
 def test_verify_name_query_over_max_rejected():
     with pytest.raises(ValidationError):
-        RIAOnboardingVerifyNameRequest(query="q" * 257)
+        RIAOnboardingVerifyNameRequest(query="q" * 201)
 
 
 def test_verify_name_crd_at_max_accepted():
-    req = RIAOnboardingVerifyNameRequest(query="Jane Doe", crd_number="1" * 50)
-    assert len(req.crd_number) == 50
+    req = RIAOnboardingVerifyNameRequest(query="Jane Doe", crd_number="1" * 10)
+    assert len(req.crd_number) == 10
 
 
 def test_verify_name_crd_over_max_rejected():
     with pytest.raises(ValidationError):
-        RIAOnboardingVerifyNameRequest(query="Jane Doe", crd_number="1" * 51)
+        RIAOnboardingVerifyNameRequest(query="Jane Doe", crd_number="1" * 11)
 
 
 # ---------------------------------------------------------------------------
@@ -170,26 +170,26 @@ def test_verify_name_crd_over_max_rejected():
 
 @pytest.mark.parametrize("model_cls", [RIAOnboardingVerifyLicenseRequest, RIAProfileRefreshLicenseRequest])
 def test_license_number_at_max_accepted(model_cls):
-    req = model_cls(license_number="L" * 128)
-    assert len(req.license_number) == 128
+    req = model_cls(license_number="L" * 50)
+    assert len(req.license_number) == 50
 
 
 @pytest.mark.parametrize("model_cls", [RIAOnboardingVerifyLicenseRequest, RIAProfileRefreshLicenseRequest])
 def test_license_number_over_max_rejected(model_cls):
     with pytest.raises(ValidationError):
-        model_cls(license_number="L" * 129)
+        model_cls(license_number="L" * 51)
 
 
 @pytest.mark.parametrize("model_cls", [RIAOnboardingVerifyLicenseRequest, RIAProfileRefreshLicenseRequest])
 def test_regulator_at_max_accepted(model_cls):
-    req = model_cls(license_number="LIC123", regulator="R" * 128)
-    assert len(req.regulator) == 128
+    req = model_cls(license_number="LIC123", regulator="R" * 100)
+    assert len(req.regulator) == 100
 
 
 @pytest.mark.parametrize("model_cls", [RIAOnboardingVerifyLicenseRequest, RIAProfileRefreshLicenseRequest])
 def test_regulator_over_max_rejected(model_cls):
     with pytest.raises(ValidationError):
-        model_cls(license_number="LIC123", regulator="R" * 129)
+        model_cls(license_number="LIC123", regulator="R" * 101)
 
 
 # ---------------------------------------------------------------------------
@@ -211,15 +211,15 @@ def test_consent_request_subject_user_id_over_max_rejected():
 
 def test_consent_request_reason_at_max_accepted():
     req = RIAConsentRequestCreate(
-        subject_user_id="uid", scope_template_id="t", reason="r" * 1000
+        subject_user_id="uid", scope_template_id="t", reason="r" * 500
     )
-    assert len(req.reason) == 1000
+    assert len(req.reason) == 500
 
 
 def test_consent_request_reason_over_max_rejected():
     with pytest.raises(ValidationError):
         RIAConsentRequestCreate(
-            subject_user_id="uid", scope_template_id="t", reason="r" * 1001
+            subject_user_id="uid", scope_template_id="t", reason="r" * 501
         )
 
 

--- a/consent-protocol/tests/test_ria_request_field_bounds.py
+++ b/consent-protocol/tests/test_ria_request_field_bounds.py
@@ -1,0 +1,238 @@
+"""
+Tests for input bounds on RIA onboarding and consent request models.
+
+RIA request models store financial onboarding data (legal names, CRD
+numbers, bios, URLs) in an IAM database and forward fields to external
+FINRA/SEC verification APIs.  Unbounded strings allow CWE-400
+denial-of-service against both the database and those external APIs.
+
+disclosures_url additionally accepts arbitrary URI schemes; a stored
+javascript: or data: URI would create an XSS vector in any portal UI
+that renders it as an anchor href (CWE-79).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from api.routes.ria import (
+    RIAConsentBundleCreate,
+    RIAConsentRequestCreate,
+    RIAOnboardingSubmitRequest,
+    RIAOnboardingVerifyLicenseRequest,
+    RIAOnboardingVerifyNameRequest,
+    RIAProfileRefreshLicenseRequest,
+)
+
+# ---------------------------------------------------------------------------
+# RIAOnboardingSubmitRequest -- display_name
+# ---------------------------------------------------------------------------
+
+
+def test_submit_display_name_at_max_accepted():
+    req = RIAOnboardingSubmitRequest(display_name="A" * 256)
+    assert len(req.display_name) == 256
+
+
+def test_submit_display_name_over_max_rejected():
+    with pytest.raises(ValidationError):
+        RIAOnboardingSubmitRequest(display_name="A" * 257)
+
+
+def test_submit_display_name_empty_rejected():
+    with pytest.raises(ValidationError):
+        RIAOnboardingSubmitRequest(display_name="")
+
+
+# ---------------------------------------------------------------------------
+# RIAOnboardingSubmitRequest -- legal name fields (sample: individual_legal_name)
+# ---------------------------------------------------------------------------
+
+
+def test_submit_individual_legal_name_at_max_accepted():
+    req = RIAOnboardingSubmitRequest(display_name="Jane Doe", individual_legal_name="N" * 256)
+    assert len(req.individual_legal_name) == 256
+
+
+def test_submit_individual_legal_name_over_max_rejected():
+    with pytest.raises(ValidationError):
+        RIAOnboardingSubmitRequest(display_name="Jane Doe", individual_legal_name="N" * 257)
+
+
+# ---------------------------------------------------------------------------
+# RIAOnboardingSubmitRequest -- CRD / IAPD fields (sample: finra_crd)
+# ---------------------------------------------------------------------------
+
+
+def test_submit_finra_crd_at_max_accepted():
+    req = RIAOnboardingSubmitRequest(display_name="Jane Doe", finra_crd="1" * 50)
+    assert len(req.finra_crd) == 50
+
+
+def test_submit_finra_crd_over_max_rejected():
+    with pytest.raises(ValidationError):
+        RIAOnboardingSubmitRequest(display_name="Jane Doe", finra_crd="1" * 51)
+
+
+# ---------------------------------------------------------------------------
+# RIAOnboardingSubmitRequest -- bio / strategy (long text)
+# ---------------------------------------------------------------------------
+
+
+def test_submit_bio_at_max_accepted():
+    req = RIAOnboardingSubmitRequest(display_name="Jane Doe", bio="x" * 5000)
+    assert len(req.bio) == 5000
+
+
+def test_submit_bio_over_max_rejected():
+    with pytest.raises(ValidationError):
+        RIAOnboardingSubmitRequest(display_name="Jane Doe", bio="x" * 5001)
+
+
+def test_submit_strategy_at_max_accepted():
+    req = RIAOnboardingSubmitRequest(display_name="Jane Doe", strategy="s" * 5000)
+    assert len(req.strategy) == 5000
+
+
+def test_submit_strategy_over_max_rejected():
+    with pytest.raises(ValidationError):
+        RIAOnboardingSubmitRequest(display_name="Jane Doe", strategy="s" * 5001)
+
+
+# ---------------------------------------------------------------------------
+# RIAOnboardingSubmitRequest -- disclosures_url scheme validation
+# ---------------------------------------------------------------------------
+
+
+def test_submit_disclosures_url_https_accepted():
+    req = RIAOnboardingSubmitRequest(
+        display_name="Jane Doe", disclosures_url="https://example.com/disclosures"
+    )
+    assert req.disclosures_url == "https://example.com/disclosures"
+
+
+def test_submit_disclosures_url_http_accepted():
+    req = RIAOnboardingSubmitRequest(
+        display_name="Jane Doe", disclosures_url="http://example.com/disclosures"
+    )
+    assert req.disclosures_url.startswith("http://")
+
+
+def test_submit_disclosures_url_none_accepted():
+    req = RIAOnboardingSubmitRequest(display_name="Jane Doe", disclosures_url=None)
+    assert req.disclosures_url is None
+
+
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        "javascript:alert(1)",
+        "data:text/html,<script>alert(1)</script>",
+        "vbscript:MsgBox(1)",
+        "file:///etc/passwd",
+    ],
+)
+def test_submit_disclosures_url_dangerous_scheme_rejected(bad_url):
+    with pytest.raises(ValidationError):
+        RIAOnboardingSubmitRequest(display_name="Jane Doe", disclosures_url=bad_url)
+
+
+# ---------------------------------------------------------------------------
+# RIAOnboardingVerifyNameRequest
+# ---------------------------------------------------------------------------
+
+
+def test_verify_name_query_at_max_accepted():
+    req = RIAOnboardingVerifyNameRequest(query="q" * 256)
+    assert len(req.query) == 256
+
+
+def test_verify_name_query_over_max_rejected():
+    with pytest.raises(ValidationError):
+        RIAOnboardingVerifyNameRequest(query="q" * 257)
+
+
+def test_verify_name_crd_at_max_accepted():
+    req = RIAOnboardingVerifyNameRequest(query="Jane Doe", crd_number="1" * 50)
+    assert len(req.crd_number) == 50
+
+
+def test_verify_name_crd_over_max_rejected():
+    with pytest.raises(ValidationError):
+        RIAOnboardingVerifyNameRequest(query="Jane Doe", crd_number="1" * 51)
+
+
+# ---------------------------------------------------------------------------
+# RIAOnboardingVerifyLicenseRequest and RIAProfileRefreshLicenseRequest
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("model_cls", [RIAOnboardingVerifyLicenseRequest, RIAProfileRefreshLicenseRequest])
+def test_license_number_at_max_accepted(model_cls):
+    req = model_cls(license_number="L" * 128)
+    assert len(req.license_number) == 128
+
+
+@pytest.mark.parametrize("model_cls", [RIAOnboardingVerifyLicenseRequest, RIAProfileRefreshLicenseRequest])
+def test_license_number_over_max_rejected(model_cls):
+    with pytest.raises(ValidationError):
+        model_cls(license_number="L" * 129)
+
+
+@pytest.mark.parametrize("model_cls", [RIAOnboardingVerifyLicenseRequest, RIAProfileRefreshLicenseRequest])
+def test_regulator_at_max_accepted(model_cls):
+    req = model_cls(license_number="LIC123", regulator="R" * 128)
+    assert len(req.regulator) == 128
+
+
+@pytest.mark.parametrize("model_cls", [RIAOnboardingVerifyLicenseRequest, RIAProfileRefreshLicenseRequest])
+def test_regulator_over_max_rejected(model_cls):
+    with pytest.raises(ValidationError):
+        model_cls(license_number="LIC123", regulator="R" * 129)
+
+
+# ---------------------------------------------------------------------------
+# RIAConsentRequestCreate
+# ---------------------------------------------------------------------------
+
+
+def test_consent_request_subject_user_id_at_max_accepted():
+    req = RIAConsentRequestCreate(
+        subject_user_id="u" * 128, scope_template_id="template_x"
+    )
+    assert len(req.subject_user_id) == 128
+
+
+def test_consent_request_subject_user_id_over_max_rejected():
+    with pytest.raises(ValidationError):
+        RIAConsentRequestCreate(subject_user_id="u" * 129, scope_template_id="t")
+
+
+def test_consent_request_reason_at_max_accepted():
+    req = RIAConsentRequestCreate(
+        subject_user_id="uid", scope_template_id="t", reason="r" * 1000
+    )
+    assert len(req.reason) == 1000
+
+
+def test_consent_request_reason_over_max_rejected():
+    with pytest.raises(ValidationError):
+        RIAConsentRequestCreate(
+            subject_user_id="uid", scope_template_id="t", reason="r" * 1001
+        )
+
+
+# ---------------------------------------------------------------------------
+# RIAConsentBundleCreate
+# ---------------------------------------------------------------------------
+
+
+def test_consent_bundle_subject_user_id_at_max_accepted():
+    req = RIAConsentBundleCreate(subject_user_id="u" * 128, scope_template_id="t")
+    assert len(req.subject_user_id) == 128
+
+
+def test_consent_bundle_subject_user_id_over_max_rejected():
+    with pytest.raises(ValidationError):
+        RIAConsentBundleCreate(subject_user_id="u" * 129, scope_template_id="t")

--- a/consent-protocol/tests/test_ria_request_field_bounds.py
+++ b/consent-protocol/tests/test_ria_request_field_bounds.py
@@ -31,13 +31,13 @@ from api.routes.ria import (
 
 
 def test_submit_display_name_at_max_accepted():
-    req = RIAOnboardingSubmitRequest(display_name="A" * 200)
-    assert len(req.display_name) == 200
+    req = RIAOnboardingSubmitRequest(display_name="A" * 256)
+    assert len(req.display_name) == 256
 
 
 def test_submit_display_name_over_max_rejected():
     with pytest.raises(ValidationError):
-        RIAOnboardingSubmitRequest(display_name="A" * 201)
+        RIAOnboardingSubmitRequest(display_name="A" * 257)
 
 
 def test_submit_display_name_empty_rejected():
@@ -51,13 +51,13 @@ def test_submit_display_name_empty_rejected():
 
 
 def test_submit_individual_legal_name_at_max_accepted():
-    req = RIAOnboardingSubmitRequest(display_name="Jane Doe", individual_legal_name="N" * 200)
-    assert len(req.individual_legal_name) == 200
+    req = RIAOnboardingSubmitRequest(display_name="Jane Doe", individual_legal_name="N" * 256)
+    assert len(req.individual_legal_name) == 256
 
 
 def test_submit_individual_legal_name_over_max_rejected():
     with pytest.raises(ValidationError):
-        RIAOnboardingSubmitRequest(display_name="Jane Doe", individual_legal_name="N" * 201)
+        RIAOnboardingSubmitRequest(display_name="Jane Doe", individual_legal_name="N" * 257)
 
 
 # ---------------------------------------------------------------------------
@@ -66,13 +66,13 @@ def test_submit_individual_legal_name_over_max_rejected():
 
 
 def test_submit_finra_crd_at_max_accepted():
-    req = RIAOnboardingSubmitRequest(display_name="Jane Doe", finra_crd="1" * 10)
-    assert len(req.finra_crd) == 10
+    req = RIAOnboardingSubmitRequest(display_name="Jane Doe", finra_crd="1" * 50)
+    assert len(req.finra_crd) == 50
 
 
 def test_submit_finra_crd_over_max_rejected():
     with pytest.raises(ValidationError):
-        RIAOnboardingSubmitRequest(display_name="Jane Doe", finra_crd="1" * 11)
+        RIAOnboardingSubmitRequest(display_name="Jane Doe", finra_crd="1" * 51)
 
 
 # ---------------------------------------------------------------------------
@@ -144,23 +144,23 @@ def test_submit_disclosures_url_dangerous_scheme_rejected(bad_url):
 
 
 def test_verify_name_query_at_max_accepted():
-    req = RIAOnboardingVerifyNameRequest(query="q" * 200)
-    assert len(req.query) == 200
+    req = RIAOnboardingVerifyNameRequest(query="q" * 256)
+    assert len(req.query) == 256
 
 
 def test_verify_name_query_over_max_rejected():
     with pytest.raises(ValidationError):
-        RIAOnboardingVerifyNameRequest(query="q" * 201)
+        RIAOnboardingVerifyNameRequest(query="q" * 257)
 
 
 def test_verify_name_crd_at_max_accepted():
-    req = RIAOnboardingVerifyNameRequest(query="Jane Doe", crd_number="1" * 10)
-    assert len(req.crd_number) == 10
+    req = RIAOnboardingVerifyNameRequest(query="Jane Doe", crd_number="1" * 50)
+    assert len(req.crd_number) == 50
 
 
 def test_verify_name_crd_over_max_rejected():
     with pytest.raises(ValidationError):
-        RIAOnboardingVerifyNameRequest(query="Jane Doe", crd_number="1" * 11)
+        RIAOnboardingVerifyNameRequest(query="Jane Doe", crd_number="1" * 51)
 
 
 # ---------------------------------------------------------------------------
@@ -170,26 +170,26 @@ def test_verify_name_crd_over_max_rejected():
 
 @pytest.mark.parametrize("model_cls", [RIAOnboardingVerifyLicenseRequest, RIAProfileRefreshLicenseRequest])
 def test_license_number_at_max_accepted(model_cls):
-    req = model_cls(license_number="L" * 50)
-    assert len(req.license_number) == 50
+    req = model_cls(license_number="L" * 128)
+    assert len(req.license_number) == 128
 
 
 @pytest.mark.parametrize("model_cls", [RIAOnboardingVerifyLicenseRequest, RIAProfileRefreshLicenseRequest])
 def test_license_number_over_max_rejected(model_cls):
     with pytest.raises(ValidationError):
-        model_cls(license_number="L" * 51)
+        model_cls(license_number="L" * 129)
 
 
 @pytest.mark.parametrize("model_cls", [RIAOnboardingVerifyLicenseRequest, RIAProfileRefreshLicenseRequest])
 def test_regulator_at_max_accepted(model_cls):
-    req = model_cls(license_number="LIC123", regulator="R" * 100)
-    assert len(req.regulator) == 100
+    req = model_cls(license_number="LIC123", regulator="R" * 128)
+    assert len(req.regulator) == 128
 
 
 @pytest.mark.parametrize("model_cls", [RIAOnboardingVerifyLicenseRequest, RIAProfileRefreshLicenseRequest])
 def test_regulator_over_max_rejected(model_cls):
     with pytest.raises(ValidationError):
-        model_cls(license_number="LIC123", regulator="R" * 101)
+        model_cls(license_number="LIC123", regulator="R" * 129)
 
 
 # ---------------------------------------------------------------------------
@@ -211,15 +211,15 @@ def test_consent_request_subject_user_id_over_max_rejected():
 
 def test_consent_request_reason_at_max_accepted():
     req = RIAConsentRequestCreate(
-        subject_user_id="uid", scope_template_id="t", reason="r" * 500
+        subject_user_id="uid", scope_template_id="t", reason="r" * 1000
     )
-    assert len(req.reason) == 500
+    assert len(req.reason) == 1000
 
 
 def test_consent_request_reason_over_max_rejected():
     with pytest.raises(ValidationError):
         RIAConsentRequestCreate(
-            subject_user_id="uid", scope_template_id="t", reason="r" * 501
+            subject_user_id="uid", scope_template_id="t", reason="r" * 1001
         )
 
 


### PR DESCRIPTION
## Summary

RIA onboarding and consent request models had pervasive missing `max_length` constraints across 6 request models. This opened three attack surfaces:

**CWE-400 (Uncontrolled Resource Consumption):** Unbounded strings flow into the IAM database (legal names, CRD numbers, biography text, strategy text) and are forwarded to external FINRA/SEC verification APIs without any size cap.

**CWE-79 (Stored XSS via unsafe URI):** `disclosures_url` in `RIAOnboardingSubmitRequest` accepted arbitrary URI schemes (`javascript:`, `data:`, `vbscript:`, `file:`). A stored unsafe URI becomes an XSS/phishing vector if rendered as an anchor `href` in the advisor portal UI -- the same pattern fixed in PR #1683 for the developer portal.

**Models changed:**

| Model | Fields bounded / validated |
|---|---|
| `RIAOnboardingSubmitRequest` | 25 string fields + `disclosures_url` scheme validator |
| `RIAOnboardingVerifyNameRequest` | `query` (200), `crd_number` (10) |
| `RIAOnboardingVerifyLicenseRequest` | `license_number` (50), `regulator` (100) |
| `RIAProfileRefreshLicenseRequest` | `license_number` (50), `regulator` (100) |
| `RIAConsentRequestCreate` | `subject_user_id` (128), `scope_template_id` (128), `reason` (500), and 4 other fields |
| `RIAConsentBundleCreate` | `subject_user_id` (128), `scope_template_id` (128), `firm_id` (128), `reason` (500) |

**Bounds are grounded in industry standards:** FINRA CRD max 7 digits (10 chars headroom), legal names 200 chars, biography/strategy 5 000 chars, email RFC-5321 320 chars, phone E.164+formatting 25 chars, URLs 512 chars.

**Files changed:**
- `api/routes/ria.py` -- bounds + `field_validator` on `disclosures_url`
- `tests/test_ria_request_field_bounds.py` -- 36 new tests

## Test plan

- [x] `display_name` boundary acceptance/rejection
- [x] `individual_legal_name` boundary acceptance/rejection
- [x] `finra_crd` boundary (10 chars)
- [x] `bio` and `strategy` boundary (5 000 chars)
- [x] `disclosures_url`: https/http accepted, None accepted, 4 dangerous schemes rejected
- [x] `RIAOnboardingVerifyNameRequest`: query (200), crd_number (10)
- [x] Both license request models: license_number (50), regulator (100)
- [x] `RIAConsentRequestCreate` and `RIAConsentBundleCreate`: subject_user_id (128), reason (500)
- [x] 36 tests pass locally
- [x] `ruff` passes with no warnings