### PR TITLE
fix(sse): remove per-user queue from _consent_notify_queues on disconnect

### DIFF
--- a/consent-protocol/api/consent_listener.py
+++ b/consent-protocol/api/consent_listener.py
@@ -43,6 +43,10 @@ MIN_FINAL_REMINDER_WINDOW_MS = 2 * 60 * 60 * 1000
 _CONSENT_NOTIFY_QUEUE_MAXSIZE = 100
 _consent_notify_queues: Dict[str, asyncio.Queue] = {}
 _consent_notify_queues_lock = asyncio.Lock()
+# One user can have multiple concurrent SSE connections (multiple browser
+# tabs, web + mobile). They share the same per-user queue, so it must only be
+# torn down once the last connection for that user disconnects.
+_consent_notify_queue_refcounts: Dict[str, int] = {}
 
 # Diagnostic: set when listener is running and when NOTIFY is received
 _listener_active = False
@@ -136,20 +140,34 @@ async def _push_to_consent_queue(user_id: str, data: Dict[str, Any]) -> None:
 
 
 def get_consent_queue(user_id: str) -> asyncio.Queue:
-    """Get or create the asyncio queue for this user (used by SSE generator)."""
+    """Get or create the asyncio queue for this user (used by SSE generator).
+
+    Call once per SSE connection. Increments the connection refcount for the
+    user so remove_consent_queue() knows whether other connections are still
+    relying on this queue before tearing it down.
+    """
     if user_id not in _consent_notify_queues:
         _consent_notify_queues[user_id] = asyncio.Queue(maxsize=_CONSENT_NOTIFY_QUEUE_MAXSIZE)
+    _consent_notify_queue_refcounts[user_id] = _consent_notify_queue_refcounts.get(user_id, 0) + 1
     return _consent_notify_queues[user_id]
 
 
 def remove_consent_queue(user_id: str) -> None:
-    """Remove the per-user SSE queue after the client disconnects.
+    """Release one SSE connection's hold on the per-user queue.
 
-    Called from the finally block of consent_event_generator so that
-    _consent_notify_queues does not grow without bound across repeated
-    connect/disconnect cycles.
+    Called from the finally block of consent_event_generator when a
+    connection closes. A user can have multiple concurrent SSE connections
+    (multiple tabs, web + mobile) sharing the same queue, so the queue is only
+    removed from _consent_notify_queues once the last connection releases it.
+    This is what bounds memory across repeated connect/disconnect cycles
+    without breaking notifications for connections that are still open.
     """
-    _consent_notify_queues.pop(user_id, None)
+    remaining = _consent_notify_queue_refcounts.get(user_id, 0) - 1
+    if remaining <= 0:
+        _consent_notify_queue_refcounts.pop(user_id, None)
+        _consent_notify_queues.pop(user_id, None)
+    else:
+        _consent_notify_queue_refcounts[user_id] = remaining
 
 
 def get_consent_listener_status() -> dict:

--- a/consent-protocol/api/consent_listener.py
+++ b/consent-protocol/api/consent_listener.py
@@ -142,6 +142,16 @@ def get_consent_queue(user_id: str) -> asyncio.Queue:
     return _consent_notify_queues[user_id]
 
 
+def remove_consent_queue(user_id: str) -> None:
+    """Remove the per-user SSE queue after the client disconnects.
+
+    Called from the finally block of consent_event_generator so that
+    _consent_notify_queues does not grow without bound across repeated
+    connect/disconnect cycles.
+    """
+    _consent_notify_queues.pop(user_id, None)
+
+
 def get_consent_listener_status() -> dict:
     """Return status for GET /debug/consent-listener (listener_active, queue_count, notify_received_count)."""
     return {

--- a/consent-protocol/api/routes/sse.py
+++ b/consent-protocol/api/routes/sse.py
@@ -226,6 +226,11 @@ async def consent_event_generator(user_id: str, request: Request) -> AsyncGenera
     except Exception as e:
         logger.error("consent_sse.error user_id=%s error=%s", user_id, e)
         raise
+    finally:
+        from api.consent_listener import remove_consent_queue
+
+        remove_consent_queue(user_id)
+        logger.info("consent_sse.closed user_id=[redacted]")
 
 
 @router.get("/events/{user_id}")

--- a/consent-protocol/tests/test_sse_queue_cleanup.py
+++ b/consent-protocol/tests/test_sse_queue_cleanup.py
@@ -29,10 +29,11 @@ import pytest
 
 
 def _reset_queues() -> None:
-    """Clear the module-level dict between tests to prevent cross-test bleed."""
+    """Clear the module-level dicts between tests to prevent cross-test bleed."""
     from api import consent_listener
 
     consent_listener._consent_notify_queues.clear()
+    consent_listener._consent_notify_queue_refcounts.clear()
 
 
 def _make_fake_consent_db_module() -> ModuleType:
@@ -110,6 +111,30 @@ class TestRemoveConsentQueue:
         assert len(_consent_notify_queues) == 3
         remove_consent_queue("u2")
         assert len(_consent_notify_queues) == 2
+
+    def test_concurrent_connections_for_same_user_share_queue_until_last_disconnects(self):
+        """A user can have multiple concurrent SSE connections (multiple tabs,
+        web + mobile). They share one queue. Disconnecting one connection must
+        not tear down the queue out from under the other still-open one.
+        """
+        from api.consent_listener import (
+            _consent_notify_queues,
+            get_consent_queue,
+            remove_consent_queue,
+        )
+
+        first = get_consent_queue("user-multi")
+        second = get_consent_queue("user-multi")
+        assert first is second
+
+        remove_consent_queue("user-multi")
+        assert "user-multi" in _consent_notify_queues, (
+            "queue was removed while a second connection for the same user "
+            "is still open"
+        )
+
+        remove_consent_queue("user-multi")
+        assert "user-multi" not in _consent_notify_queues
 
 
 # ---------------------------------------------------------------------------

--- a/consent-protocol/tests/test_sse_queue_cleanup.py
+++ b/consent-protocol/tests/test_sse_queue_cleanup.py
@@ -1,0 +1,234 @@
+"""Tests for SSE consent queue cleanup on disconnect (memory leak fix).
+
+_consent_notify_queues in api/consent_listener.py accumulated one entry per
+unique user_id every time an SSE client connected and never freed them. The
+fix adds:
+
+  1. remove_consent_queue(user_id) in api/consent_listener.py
+  2. A finally block in consent_event_generator() that calls it after the
+     generator exits (disconnect, cancellation, or exception).
+
+Canonical attach:
+  api/routes/sse.py              -- consent_event_generator, the live SSE path
+  api/consent_listener.py        -- _consent_notify_queues, get/remove helpers
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _reset_queues() -> None:
+    """Clear the module-level dict between tests to prevent cross-test bleed."""
+    from api import consent_listener
+
+    consent_listener._consent_notify_queues.clear()
+
+
+def _make_fake_consent_db_module() -> ModuleType:
+    """Return a fake hushh_mcp.services.consent_db module with a stub service."""
+    mod = types.ModuleType("hushh_mcp.services.consent_db")
+    svc = MagicMock()
+    svc.get_recent_consent_events = AsyncMock(return_value=[])
+    mod.ConsentDBService = MagicMock(return_value=svc)
+    return mod
+
+
+def _make_failing_consent_db_module() -> ModuleType:
+    """Return a fake module whose ConsentDBService raises on get_recent_consent_events."""
+    mod = types.ModuleType("hushh_mcp.services.consent_db")
+    svc = MagicMock()
+    svc.get_recent_consent_events = AsyncMock(side_effect=RuntimeError("db exploded"))
+    mod.ConsentDBService = MagicMock(return_value=svc)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for remove_consent_queue
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveConsentQueue:
+    """remove_consent_queue removes the entry and is safe when absent."""
+
+    def setup_method(self):
+        _reset_queues()
+
+    def test_removes_existing_entry(self):
+        from api.consent_listener import (
+            _consent_notify_queues,
+            get_consent_queue,
+            remove_consent_queue,
+        )
+
+        get_consent_queue("user-1")
+        assert "user-1" in _consent_notify_queues
+
+        remove_consent_queue("user-1")
+        assert "user-1" not in _consent_notify_queues
+
+    def test_noop_when_user_not_present(self):
+        from api.consent_listener import remove_consent_queue
+
+        # Must not raise KeyError or any other exception.
+        remove_consent_queue("nonexistent-user")
+
+    def test_does_not_remove_other_users(self):
+        from api.consent_listener import (
+            _consent_notify_queues,
+            get_consent_queue,
+            remove_consent_queue,
+        )
+
+        get_consent_queue("user-a")
+        get_consent_queue("user-b")
+        remove_consent_queue("user-a")
+
+        assert "user-a" not in _consent_notify_queues
+        assert "user-b" in _consent_notify_queues
+
+    def test_queue_count_decrements(self):
+        from api.consent_listener import (
+            _consent_notify_queues,
+            get_consent_queue,
+            remove_consent_queue,
+        )
+
+        for uid in ("u1", "u2", "u3"):
+            get_consent_queue(uid)
+
+        assert len(_consent_notify_queues) == 3
+        remove_consent_queue("u2")
+        assert len(_consent_notify_queues) == 2
+
+
+# ---------------------------------------------------------------------------
+# Source-structure test: finally block is present
+# ---------------------------------------------------------------------------
+
+
+class TestGeneratorHasFinallyBlock:
+    """Structural test: consent_event_generator contains the cleanup finally block."""
+
+    def test_remove_consent_queue_called_in_finally(self):
+        import ast
+        import inspect
+
+        from api.routes.sse import consent_event_generator
+
+        src = inspect.getsource(consent_event_generator)
+        tree = ast.parse(src)
+
+        # Walk the AST and find Try nodes that have a finally body containing
+        # a call to remove_consent_queue.
+        found = False
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Try):
+                continue
+            for stmt in node.finalbody:
+                # Look for import-then-call or direct call to remove_consent_queue
+                src_segment = ast.unparse(stmt)
+                if "remove_consent_queue" in src_segment:
+                    found = True
+                    break
+            if found:
+                break
+
+        assert found, (
+            "consent_event_generator must contain a finally block that calls "
+            "remove_consent_queue(user_id) to prevent _consent_notify_queues memory leak"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: generator cleans up in every exit path
+# ---------------------------------------------------------------------------
+
+
+class TestGeneratorCleansUpOnExit:
+    """consent_event_generator removes the queue in every exit path."""
+
+    def setup_method(self):
+        _reset_queues()
+
+    @pytest.mark.asyncio
+    async def test_queue_removed_after_normal_disconnect(self):
+        """Queue entry is gone after the generator exits via is_disconnected."""
+        from api import consent_listener
+        from api.routes.sse import consent_event_generator
+
+        call_count = {"n": 0}
+
+        async def is_disconnected():
+            call_count["n"] += 1
+            # Disconnect immediately on the first poll.
+            return True
+
+        request = MagicMock()
+        request.is_disconnected = is_disconnected
+
+        fake_db_mod = _make_fake_consent_db_module()
+        with patch.dict(sys.modules, {"hushh_mcp.services.consent_db": fake_db_mod}):
+            gen = consent_event_generator("disconnect-user", request)
+            async for _ in gen:
+                pass
+
+        assert "disconnect-user" not in consent_listener._consent_notify_queues
+
+    @pytest.mark.asyncio
+    async def test_queue_removed_after_exception(self):
+        """Queue entry is removed even when the DB service raises."""
+        from api import consent_listener
+        from api.routes.sse import consent_event_generator
+
+        request = MagicMock()
+        request.is_disconnected = AsyncMock(return_value=False)
+
+        failing_mod = _make_failing_consent_db_module()
+        with patch.dict(sys.modules, {"hushh_mcp.services.consent_db": failing_mod}):
+            gen = consent_event_generator("exc-user", request)
+            with pytest.raises(RuntimeError, match="db exploded"):
+                async for _ in gen:
+                    pass
+
+        assert "exc-user" not in consent_listener._consent_notify_queues
+
+    @pytest.mark.asyncio
+    async def test_queue_removed_after_cancellation(self):
+        """Queue entry is removed even when the generator task is cancelled."""
+        from api import consent_listener
+        from api.routes.sse import consent_event_generator
+
+        request = MagicMock()
+        # Never disconnect naturally so the while-loop blocks on queue.get().
+        request.is_disconnected = AsyncMock(return_value=False)
+
+        fake_db_mod = _make_fake_consent_db_module()
+
+        async def run_gen():
+            with patch.dict(sys.modules, {"hushh_mcp.services.consent_db": fake_db_mod}):
+                gen = consent_event_generator("cancel-user", request)
+                async for _ in gen:
+                    pass
+
+        task = asyncio.create_task(run_gen())
+        # Let the generator reach the asyncio.wait_for(...) inside the while loop.
+        await asyncio.sleep(0.05)
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+        # The finally block must have run by now.
+        assert "cancel-user" not in consent_listener._consent_notify_queues


### PR DESCRIPTION
## Problem

`consent_event_generator()` in `api/routes/sse.py` calls `get_consent_queue(user_id)`, which inserts an `asyncio.Queue` into the module-level `_consent_notify_queues` dict. There was no cleanup path.

Every unique user who opened an SSE connection left a dead queue in the dict permanently. On repeated connect/disconnect cycles (mobile app backgrounding, page refreshes, network interruptions) this causes unbounded memory growth (CWE-400).

## Fix

Add `remove_consent_queue(user_id)` to `api/consent_listener.py` and call it from a `finally` block at the end of `consent_event_generator()` so the entry is always removed when the generator exits, regardless of whether the client disconnects cleanly or an exception occurs.

A user can have multiple concurrent SSE connections for the same `user_id` (multiple browser tabs, web + mobile), and they all share the same queue via `get_consent_queue()`. An earlier version of this fix removed the queue unconditionally on any single connection's disconnect, which would have silently broken notification delivery for any other still-open connection for that user. `get_consent_queue`/`remove_consent_queue` now ref-count connections per user, so the queue is only torn down once the last connection for that user releases it.

## Tests

`tests/test_sse_queue_cleanup.py`: tests verify that:
- A queue entry is inserted when the generator runs
- The entry is removed from `_consent_notify_queues` after the generator exits (clean disconnect)
- The entry is also removed when the generator is cancelled (network drop)
- Two concurrent connections for the same user share one queue, and disconnecting one does not remove the queue while the other is still open; it is only removed once both have disconnected

Supersedes #1669 (stale branch with diverged tests unrelated to this fix).
