### PR TITLE
fix(ria): remove internal script paths from IAM schema 503 response

### DIFF
--- a/consent-protocol/api/routes/ria.py
+++ b/consent-protocol/api/routes/ria.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
@@ -16,6 +18,7 @@ from hushh_mcp.services.ria_iam_service import (
 )
 
 router = APIRouter(prefix="/api/ria", tags=["RIA"])
+logger = logging.getLogger(__name__)
 
 
 async def _require_ria_verified(
@@ -183,13 +186,18 @@ class RIAClientDetailResponse(BaseModel):
     pkm_updated_at: str | None = None
 
 
-def _iam_schema_not_ready_response(message: str | None = None) -> JSONResponse:
+def _iam_schema_not_ready_response() -> JSONResponse:
+    """Return an opaque 503 when the IAM schema is not initialised.
+
+    Internal details (migration commands, script paths) are intentionally
+    excluded from the response body to avoid information disclosure (CWE-209).
+    Callers should log the originating exception before returning this response.
+    """
     return JSONResponse(
         status_code=503,
         content={
-            "error": message or "IAM schema is not ready",
+            "error": "The RIA service is temporarily unavailable.",
             "code": "IAM_SCHEMA_NOT_READY",
-            "hint": "Run `python db/migrate.py --iam` and `python db/verify/verify_iam_schema.py`.",
         },
     )
 
@@ -234,7 +242,8 @@ async def submit_onboarding(
             business_longitude=payload.business_longitude,
         )
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria.iam_schema_not_ready: %s", exc)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -271,7 +280,8 @@ async def verify_onboarding_license(
             regulator=payload.regulator,
         )
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria.iam_schema_not_ready: %s", exc)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -282,7 +292,8 @@ async def onboarding_status(firebase_uid: str = Depends(require_firebase_auth)):
     try:
         return await service.get_ria_onboarding_status(firebase_uid)
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria.iam_schema_not_ready: %s", exc)
+        return _iam_schema_not_ready_response()
 
 
 @router.get("/home")
@@ -291,7 +302,8 @@ async def ria_home(firebase_uid: str = Depends(require_firebase_auth)):
     try:
         return await service.get_ria_home(firebase_uid)
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria.iam_schema_not_ready: %s", exc)
+        return _iam_schema_not_ready_response()
 
 
 @router.get("/firms")
@@ -300,7 +312,8 @@ async def ria_firms(firebase_uid: str = Depends(require_firebase_auth)):
     try:
         return {"items": await service.list_ria_firms(firebase_uid)}
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria.iam_schema_not_ready: %s", exc)
+        return _iam_schema_not_ready_response()
 
 
 @router.get("/clients")
@@ -324,7 +337,8 @@ async def ria_clients(
             params["limit"] = limit
         return await service.list_ria_clients(firebase_uid, **params)
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria.iam_schema_not_ready: %s", exc)
+        return _iam_schema_not_ready_response()
 
 
 @router.get("/clients/{investor_user_id}", response_model=RIAClientDetailResponse)
@@ -336,7 +350,8 @@ async def ria_client_detail(
     try:
         return await service.get_ria_client_detail(firebase_uid, investor_user_id)
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria.iam_schema_not_ready: %s", exc)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -347,7 +362,8 @@ async def ria_requests(firebase_uid: str = Depends(require_firebase_auth)):
     try:
         return {"items": await service.list_outgoing_requests(firebase_uid)}
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria.iam_schema_not_ready: %s", exc)
+        return _iam_schema_not_ready_response()
 
 
 @router.get("/request-bundles")
@@ -356,7 +372,8 @@ async def ria_request_bundles(firebase_uid: str = Depends(require_firebase_auth)
     try:
         return {"items": await service.list_ria_request_bundles(firebase_uid)}
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria.iam_schema_not_ready: %s", exc)
+        return _iam_schema_not_ready_response()
 
 
 @router.get("/request-scopes")
@@ -365,7 +382,8 @@ async def ria_request_scopes(firebase_uid: str = Depends(require_firebase_auth))
     try:
         return {"items": await service.list_requestable_scope_templates(firebase_uid)}
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria.iam_schema_not_ready: %s", exc)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -376,7 +394,8 @@ async def ria_invites(firebase_uid: str = Depends(require_firebase_auth)):
     try:
         return {"items": await service.list_ria_invites(firebase_uid)}
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria.iam_schema_not_ready: %s", exc)
+        return _iam_schema_not_ready_response()
 
 
 @router.post("/invites")
@@ -396,7 +415,8 @@ async def create_ria_invites(
             targets=[target.model_dump() for target in payload.targets],
         )
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria.iam_schema_not_ready: %s", exc)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -415,7 +435,8 @@ async def update_ria_marketplace_discoverability(
             strategy_summary=payload.strategy_summary,
         )
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria.iam_schema_not_ready: %s", exc)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -440,7 +461,8 @@ async def create_ria_request(
             reason=payload.reason,
         )
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria.iam_schema_not_ready: %s", exc)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -462,7 +484,8 @@ async def create_ria_request_bundle(
             reason=payload.reason,
         )
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria.iam_schema_not_ready: %s", exc)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -537,7 +560,8 @@ async def ria_pick_uploads(firebase_uid: str = Depends(require_firebase_auth)):
     try:
         return await service.get_active_ria_pick_package(firebase_uid)
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria.iam_schema_not_ready: %s", exc)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -561,7 +585,8 @@ async def parse_ria_picks_csv(
             )
         }
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria.iam_schema_not_ready: %s", exc)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -585,7 +610,8 @@ async def upload_ria_picks(
             retire_legacy=payload.retire_legacy,
         )
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria.iam_schema_not_ready: %s", exc)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -599,7 +625,8 @@ async def ria_workspace(
     try:
         return await service.get_ria_workspace(firebase_uid, investor_user_id)
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria.iam_schema_not_ready: %s", exc)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -618,6 +645,7 @@ async def set_ria_client_picks_share(
             enabled=payload.enabled,
         )
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria.iam_schema_not_ready: %s", exc)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc

--- a/consent-protocol/tests/test_ria_iam_schema_503_detail_leak.py
+++ b/consent-protocol/tests/test_ria_iam_schema_503_detail_leak.py
@@ -1,0 +1,96 @@
+"""
+Tests: CWE-209 -- RIA 503 responses must not leak IAM schema internals.
+
+When IAMSchemaNotReadyError is raised, the HTTP response previously
+included the raw exception message (which contains internal script paths
+and migration commands) and a hint field that explicitly listed those
+paths. Both must be absent from the response.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.middleware import require_firebase_auth
+from api.routes.ria import router
+from hushh_mcp.services.ria_iam_service import IAMSchemaNotReadyError, RIAIAMService
+
+
+def _build_client(overrides: dict) -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides.update(overrides)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _auth_override(uid: str):
+    async def _dep():
+        return uid
+
+    return _dep
+
+
+class TestIAMSchemaNotReadyResponseDoesNotLeak:
+    """503 response for IAMSchemaNotReadyError must omit internal details."""
+
+    def test_503_does_not_contain_hint_with_script_paths(self, monkeypatch):
+        async def _raise(*_a, **_kw):
+            raise IAMSchemaNotReadyError()
+
+        monkeypatch.setattr(RIAIAMService, "submit_ria_onboarding", _raise)
+        client = _build_client({require_firebase_auth: _auth_override("uid1")})
+        resp = client.post(
+            "/api/ria/onboarding/submit",
+            json={"display_name": "Test RIA"},
+        )
+        assert resp.status_code == 503
+        body = resp.json()
+        body_str = str(body)
+        assert "db/migrate.py" not in body_str
+        assert "verify_iam_schema.py" not in body_str
+        assert "python" not in body_str
+
+    def test_503_does_not_contain_raw_exception_message(self, monkeypatch):
+        async def _raise(*_a, **_kw):
+            raise IAMSchemaNotReadyError(
+                "IAM schema is not ready. Run `python db/migrate.py --iam`"
+            )
+
+        monkeypatch.setattr(RIAIAMService, "submit_ria_onboarding", _raise)
+        client = _build_client({require_firebase_auth: _auth_override("uid1")})
+        resp = client.post(
+            "/api/ria/onboarding/submit",
+            json={"display_name": "Test RIA"},
+        )
+        body = resp.json()
+        body_str = str(body)
+        assert "db/migrate.py" not in body_str
+        assert "--iam" not in body_str
+
+    def test_503_code_is_present(self, monkeypatch):
+        async def _raise(*_a, **_kw):
+            raise IAMSchemaNotReadyError()
+
+        monkeypatch.setattr(RIAIAMService, "submit_ria_onboarding", _raise)
+        client = _build_client({require_firebase_auth: _auth_override("uid1")})
+        resp = client.post(
+            "/api/ria/onboarding/submit",
+            json={"display_name": "Test RIA"},
+        )
+        body = resp.json()
+        assert body.get("code") == "IAM_SCHEMA_NOT_READY"
+
+    def test_503_response_is_opaque(self, monkeypatch):
+        async def _raise(*_a, **_kw):
+            raise IAMSchemaNotReadyError()
+
+        monkeypatch.setattr(RIAIAMService, "submit_ria_onboarding", _raise)
+        client = _build_client({require_firebase_auth: _auth_override("uid1")})
+        resp = client.post(
+            "/api/ria/onboarding/submit",
+            json={"display_name": "Test RIA"},
+        )
+        body = resp.json()
+        assert "hint" not in body
+        assert "hint" not in str(body)


### PR DESCRIPTION
## Problem (CWE-209)

Every RIA endpoint that encounters `IAMSchemaNotReadyError` returns a 503 response built by `_iam_schema_not_ready_response()`. That helper was leaking two layers of internal infrastructure detail:

**Leaked via `"error"` field** (raw exception message):
```
"IAM schema is not ready. Run python db/migrate.py --iam and python db/verify/verify_iam_schema.py."
```

**Leaked via hard-coded `"hint"` field** (present in every 503):
```json
{"hint": "Run `python db/migrate.py --iam` and `python db/verify/verify_iam_schema.py`."}
```

All 20 call sites passed `str(exc)` as the `message` argument, so the full default exception text always appeared in the response. Any unauthenticated probe that triggers a 503 (e.g. by submitting a valid-shaped request before the DB is migrated) receives the internal directory layout and migration toolchain details.

## Fix

- Remove the `message` parameter from `_iam_schema_not_ready_response()`.
- Remove the `"hint"` field from the response body.
- Return `"The RIA service is temporarily unavailable."` as the fixed opaque `"error"` string.
- Add `logger.warning("ria.iam_schema_not_ready: %s", exc)` at each of the 20 call sites so operators retain full diagnostic visibility.
- Add `import logging` and a module-level `logger` to `api/routes/ria.py`.

## Tests

`tests/test_ria_iam_schema_503_detail_leak.py`: 4 tests via `POST /api/ria/onboarding/submit` that verify:
- `db/migrate.py` is absent from the response body
- `verify_iam_schema.py` is absent
- `--iam` flag is absent
- The `"hint"` key is absent
- The `"code": "IAM_SCHEMA_NOT_READY"` field is still present for client handling