### PR TITLE
fix(session): use hmac.compare_digest for developer token comparison (CWE-208)

### DIFF
--- a/consent-protocol/api/routes/session.py
+++ b/consent-protocol/api/routes/session.py
@@ -3,6 +3,7 @@
 Session token and user management endpoints.
 """
 
+import hmac
 import logging
 import os
 from typing import Any, Optional
@@ -239,7 +240,7 @@ async def lookup_user(
     required_token = str(os.getenv("HUSHH_DEVELOPER_TOKEN", "")).strip()
     if not required_token:
         raise HTTPException(status_code=503, detail="Lookup endpoint not configured")
-    if not x_mcp_developer_token or x_mcp_developer_token != required_token:
+    if not x_mcp_developer_token or not hmac.compare_digest(x_mcp_developer_token, required_token):
         raise HTTPException(status_code=403, detail="Forbidden")
 
     try:

--- a/consent-protocol/tests/test_session_developer_token_timing.py
+++ b/consent-protocol/tests/test_session_developer_token_timing.py
@@ -1,0 +1,73 @@
+"""Verify that the HUSHH_DEVELOPER_TOKEN check uses a constant-time comparison.
+
+A plain ``!=`` string comparison leaks token length and prefix information via
+response timing (CWE-208).  The fix replaces it with ``hmac.compare_digest``.
+
+These tests assert the observable security properties:
+- Missing token => 403
+- Wrong token => 403
+- Correct token => request proceeds past the auth gate (400 due to missing
+  lookup params, NOT 403)
+- Source code uses ``hmac.compare_digest`` for the comparison
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routes import session
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(session.router)
+    return app
+
+
+def test_missing_developer_token_returns_403(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HUSHH_DEVELOPER_TOKEN", "correct-secret")
+    client = TestClient(_build_app())
+
+    response = client.get("/api/user/lookup")
+
+    assert response.status_code == 403
+
+
+def test_wrong_developer_token_returns_403(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HUSHH_DEVELOPER_TOKEN", "correct-secret")
+    client = TestClient(_build_app())
+
+    response = client.get(
+        "/api/user/lookup",
+        headers={"X-MCP-Developer-Token": "wrong-secret"},
+    )
+
+    assert response.status_code == 403
+
+
+def test_correct_developer_token_passes_auth_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HUSHH_DEVELOPER_TOKEN", "correct-secret")
+    client = TestClient(_build_app())
+
+    response = client.get(
+        "/api/user/lookup",
+        headers={"X-MCP-Developer-Token": "correct-secret"},
+    )
+
+    # 400 = past the auth gate, rejected for missing lookup params
+    assert response.status_code == 400
+
+
+def test_lookup_uses_constant_time_comparison() -> None:
+    """Assert that the route source calls hmac.compare_digest, not plain != ."""
+    source = inspect.getsource(session)
+    assert "hmac.compare_digest" in source, (
+        "Developer token comparison must use hmac.compare_digest to prevent timing attacks"
+    )
+    # Plain != on the raw token strings must not appear in the lookup handler
+    assert "x_mcp_developer_token != required_token" not in source, (
+        "Plain != comparison leaks timing information; use hmac.compare_digest"
+    )


### PR DESCRIPTION
## Problem

`GET /api/user/lookup` checks the `X-MCP-Developer-Token` header against the `HUSHH_DEVELOPER_TOKEN` environment variable using a plain `!=` comparison:

```python
if not x_mcp_developer_token or x_mcp_developer_token != required_token:
```

Python's `!=` on strings short-circuits on the first differing byte, so the CPU time spent in the comparison varies with how many leading characters match. An attacker who can issue many requests and measure response latency can recover the token one character at a time (CWE-208: Observable Timing Discrepancy / CWE-385: Covert Timing Channel).

All other maintenance-token comparisons in the codebase (`one/location.py`, `one/email.py`) already use `hmac.compare_digest`. This endpoint was inconsistent.

## Fix

Replace the plain `!=` with `hmac.compare_digest`, which runs in constant time regardless of where the strings first differ.

```python
# before
if not x_mcp_developer_token or x_mcp_developer_token != required_token:

# after
if not x_mcp_developer_token or not hmac.compare_digest(x_mcp_developer_token, required_token):
```

## Tests

`tests/test_session_developer_token_timing.py` verifies:
- Missing token returns 403
- Wrong token returns 403
- Correct token passes the auth gate (400 for missing lookup params, not 403)
- Source-level assertion that `hmac.compare_digest` is present and plain `!=` on the raw token is absent

## Checklist
- [x] Constant-time comparison used
- [x] Consistent with other token checks in codebase
- [x] Unit tests added
- [x] CI green