### PR TITLE
fix(pkm): add max_length bounds to user_id and domain path parameters (CWE-400)

### DIFF
--- a/consent-protocol/api/routes/pkm.py
+++ b/consent-protocol/api/routes/pkm.py
@@ -5,7 +5,17 @@ Personal Knowledge Model API routes.
 Canonical API surface for PKM.
 """
 
-from fastapi import APIRouter, BackgroundTasks, Body, Depends, Header, HTTPException, Path, Query, status
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Body,
+    Depends,
+    Header,
+    HTTPException,
+    Path,
+    Query,
+    status,
+)
 from pydantic import BaseModel, Field
 
 from api.middleware import require_firebase_auth, require_vault_owner_token

--- a/consent-protocol/api/routes/pkm.py
+++ b/consent-protocol/api/routes/pkm.py
@@ -5,7 +5,7 @@ Personal Knowledge Model API routes.
 Canonical API surface for PKM.
 """
 
-from fastapi import APIRouter, BackgroundTasks, Body, Depends, Header, HTTPException, Query, status
+from fastapi import APIRouter, BackgroundTasks, Body, Depends, Header, HTTPException, Path, Query, status
 from pydantic import BaseModel, Field
 
 from api.middleware import require_firebase_auth, require_vault_owner_token
@@ -159,7 +159,7 @@ async def validate_store_domain(
 
 @router.get("/data/{user_id}", response_model=dict)
 async def get_encrypted_data(
-    user_id: str,
+    user_id: str = Path(..., max_length=128),
     token_data: dict = Depends(require_vault_owner_token),
 ):
     return await _get_encrypted_data(user_id, token_data)
@@ -167,8 +167,8 @@ async def get_encrypted_data(
 
 @router.get("/domain-data/{user_id}/{domain}", response_model=DomainDataResponse)
 async def get_domain_data(
-    user_id: str,
-    domain: str,
+    user_id: str = Path(..., max_length=128),
+    domain: str = Path(..., max_length=64),
     segment_ids: list[str] | None = Query(default=None),
     token_data: dict = Depends(require_vault_owner_token),
 ):
@@ -177,8 +177,8 @@ async def get_domain_data(
 
 @router.get("/manifest/{user_id}/{domain}", response_model=DomainManifestResponse)
 async def get_domain_manifest(
-    user_id: str,
-    domain: str,
+    user_id: str = Path(..., max_length=128),
+    domain: str = Path(..., max_length=64),
     token_data: dict = Depends(require_vault_owner_token),
 ):
     return await _get_domain_manifest(user_id, domain, token_data)
@@ -186,8 +186,8 @@ async def get_domain_manifest(
 
 @router.delete("/domain-data/{user_id}/{domain}", response_model=DeleteDomainResponse)
 async def delete_domain_data(
-    user_id: str,
-    domain: str,
+    user_id: str = Path(..., max_length=128),
+    domain: str = Path(..., max_length=64),
     token_data: dict = Depends(require_vault_owner_token),
 ):
     return await _delete_domain_data(user_id, domain, token_data)

--- a/consent-protocol/tests/test_pkm_route_path_param_bounds.py
+++ b/consent-protocol/tests/test_pkm_route_path_param_bounds.py
@@ -1,0 +1,70 @@
+"""Tests for CWE-400 path parameter bounds on api/routes/pkm.py.
+
+user_id and domain path params previously had no max_length constraint,
+allowing arbitrarily long strings to reach service layer logic.
+
+Note: The auth dependency runs before path param validation in FastAPI, so
+tests must stub the vault-owner dependency to reach the validation layer.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api import middleware as api_middleware
+from api.routes import pkm
+
+
+def _stub_auth() -> dict:
+    return {"user_id": "stub-user", "scope": "vault.owner"}
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(pkm.router)
+    app.dependency_overrides[api_middleware.require_vault_owner_token] = _stub_auth
+    return app
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(_build_app(), raise_server_exceptions=False)
+
+
+_LONG_129 = "u" * 129
+_LONG_65 = "d" * 65
+_VALID_USER = "stub-user"
+_VALID_DOMAIN = "finance"
+
+
+class TestUserIdBound:
+    def test_get_encrypted_data_long_user_id_returns_422(self, client: TestClient) -> None:
+        response = client.get(f"/api/pkm/data/{_LONG_129}")
+        assert response.status_code == 422
+
+    def test_get_domain_data_long_user_id_returns_422(self, client: TestClient) -> None:
+        response = client.get(f"/api/pkm/domain-data/{_LONG_129}/{_VALID_DOMAIN}")
+        assert response.status_code == 422
+
+    def test_get_manifest_long_user_id_returns_422(self, client: TestClient) -> None:
+        response = client.get(f"/api/pkm/manifest/{_LONG_129}/{_VALID_DOMAIN}")
+        assert response.status_code == 422
+
+    def test_delete_domain_data_long_user_id_returns_422(self, client: TestClient) -> None:
+        response = client.delete(f"/api/pkm/domain-data/{_LONG_129}/{_VALID_DOMAIN}")
+        assert response.status_code == 422
+
+
+class TestDomainBound:
+    def test_get_domain_data_long_domain_returns_422(self, client: TestClient) -> None:
+        response = client.get(f"/api/pkm/domain-data/{_VALID_USER}/{_LONG_65}")
+        assert response.status_code == 422
+
+    def test_get_manifest_long_domain_returns_422(self, client: TestClient) -> None:
+        response = client.get(f"/api/pkm/manifest/{_VALID_USER}/{_LONG_65}")
+        assert response.status_code == 422
+
+    def test_delete_domain_data_long_domain_returns_422(self, client: TestClient) -> None:
+        response = client.delete(f"/api/pkm/domain-data/{_VALID_USER}/{_LONG_65}")
+        assert response.status_code == 422


### PR DESCRIPTION
## Problem

Four PKM route handlers accepted unbounded \`user_id\` (\`str\`) and \`domain\` (\`str\`) path parameters with no \`max_length\` constraint:

| Endpoint | Unbounded params |
|----------|-----------------|
| \`GET /api/pkm/data/{user_id}\` | \`user_id\` |
| \`GET /api/pkm/domain-data/{user_id}/{domain}\` | \`user_id\`, \`domain\` |
| \`GET /api/pkm/manifest/{user_id}/{domain}\` | \`user_id\`, \`domain\` |
| \`DELETE /api/pkm/domain-data/{user_id}/{domain}\` | \`user_id\`, \`domain\` |

Without a length bound, a caller could supply arbitrarily long strings, forcing unnecessary memory allocation and forwarding oversized values into service-layer logic (CWE-400: Uncontrolled Resource Consumption).

## Fix

Annotate every affected path parameter with \`Path(..., max_length=...)\`:
- \`user_id\` → \`max_length=128\`
- \`domain\` → \`max_length=64\`

FastAPI enforces these constraints at deserialization time and returns 422 before any service code executes.

## Tests

\`tests/test_pkm_route_path_param_bounds.py\` asserts that all four endpoints return 422 for \`user_id\` > 128 chars and for \`domain\` > 64 chars (auth dependency stubbed to isolate the path-param validation layer).

## Checklist
- [x] Path param bounds enforced on all four handlers
- [x] Unit tests added
- [x] CI green