### PR TITLE
fix(kai/chat): add max_length bounds to ChatRequest fields and conversation_id path param (CWE-400)

### DIFF
--- a/consent-protocol/api/routes/kai/chat.py
+++ b/consent-protocol/api/routes/kai/chat.py
@@ -17,7 +17,7 @@ Authentication:
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
 from pydantic import BaseModel, Field
 
 from api.middleware import require_vault_owner_token
@@ -39,9 +39,9 @@ def _redact_uid(uid: str | None) -> str:
 class KaiChatRequest(BaseModel):
     """Request body for Kai chat endpoint."""
 
-    user_id: str = Field(..., description="User's Firebase UID")
+    user_id: str = Field(..., description="User's Firebase UID", min_length=1, max_length=128)
     message: str = Field(..., description="User's message to Kai", min_length=1, max_length=4000)
-    conversation_id: Optional[str] = Field(None, description="Existing conversation ID to continue")
+    conversation_id: Optional[str] = Field(None, description="Existing conversation ID to continue", max_length=128)
 
 
 class KaiChatResponseModel(BaseModel):
@@ -134,7 +134,7 @@ async def kai_chat(
 
 @router.get("/chat/history/{conversation_id}", response_model=ConversationHistoryResponse)
 async def get_conversation_history(
-    conversation_id: str,
+    conversation_id: str = Path(..., max_length=128),
     token_data: dict = Depends(require_vault_owner_token),
     limit: int = Query(default=50, ge=1, le=500),
 ) -> ConversationHistoryResponse:

--- a/consent-protocol/tests/test_kai_auth_matrix.py
+++ b/consent-protocol/tests/test_kai_auth_matrix.py
@@ -435,6 +435,24 @@ class TestKaiChatKeyEndpoints:
         )
         assert response.status_code not in {401, 403}
 
+    def test_chat_user_id_is_bounded(self, client, vault_owner_token_for_user):
+        token = vault_owner_token_for_user("user_a")
+        response = client.post(
+            "/api/kai/chat",
+            json={"user_id": "u" * 129, "message": "hello"},
+            headers=_auth(token),
+        )
+        assert response.status_code == 422
+
+    def test_chat_conversation_id_is_bounded(self, client, vault_owner_token_for_user):
+        token = vault_owner_token_for_user("user_a")
+        response = client.post(
+            "/api/kai/chat",
+            json={"user_id": "user_a", "message": "hello", "conversation_id": "c" * 129},
+            headers=_auth(token),
+        )
+        assert response.status_code == 422
+
     def test_chat_history_missing_token_returns_401(self, client):
         response = client.get("/api/kai/chat/history/conv_123")
         assert response.status_code == 401
@@ -457,6 +475,16 @@ class TestKaiChatKeyEndpoints:
         response = client.get(
             "/api/kai/chat/history/conv_123",
             params={"limit": 501},
+            headers=_auth(token),
+        )
+        assert response.status_code == 422
+
+    def test_chat_history_conversation_id_is_bounded(
+        self, client, vault_owner_token_for_user, stub_kai_chat_service
+    ):
+        token = vault_owner_token_for_user("user_a")
+        response = client.get(
+            f"/api/kai/chat/history/{'c' * 129}",
             headers=_auth(token),
         )
         assert response.status_code == 422


### PR DESCRIPTION
## Problem

Three fields in \`api/routes/kai/chat.py\` had no upper-length constraint (CWE-400):

| Location | Field | Problem |
|----------|-------|---------|
| \`ChatRequest\` model | \`user_id\` | No \`max_length\` |
| \`ChatRequest\` model | \`conversation_id\` | No \`max_length\` |
| \`GET /chat/history/{conversation_id}\` | path param | No \`max_length\` |

Without bounds, a caller could supply arbitrarily long strings that propagate into conversation-history queries and service-layer logic.

## Fix

- \`user_id: str = Field(..., min_length=1, max_length=128)\`
- \`conversation_id: Optional[str] = Field(None, max_length=128)\`
- Path param: \`conversation_id: str = Path(..., max_length=128)\`

## Checklist
- [x] All three fields bounded
- [x] Consistent with other user_id/conversation_id bounds in the codebase
- [x] CI green