### PR TITLE
Fix UAT portfolio import stream affinity

### DIFF
--- a/consent-protocol/api/routes/kai/portfolio.py
+++ b/consent-protocol/api/routes/kai/portfolio.py
@@ -3175,6 +3175,13 @@ def _portfolio_import_stream_factory(
     )
 
 
+class _AlwaysConnectedImportStreamRequest:
+    """Disconnect shim for initial upload streams proxied through Next.js."""
+
+    async def is_disconnected(self) -> bool:
+        return False
+
+
 @router.post("/portfolio/import/run/start")
 async def start_portfolio_import_run(
     file: UploadFile,
@@ -3353,6 +3360,6 @@ async def import_portfolio_stream(
         _IMPORT_RUN_MANAGER.stream_run_events(
             run=run,
             start_cursor=0,
-            request=request,
+            request=_AlwaysConnectedImportStreamRequest(),
         )
     )

--- a/consent-protocol/tests/test_kai_stream_contract.py
+++ b/consent-protocol/tests/test_kai_stream_contract.py
@@ -155,6 +155,13 @@ def test_portfolio_statement_import_stream_route_stays_available():
     assert "_IMPORT_RUN_MANAGER.stream_run_events(" in portfolio_source
 
 
+def test_portfolio_statement_import_compat_stream_does_not_use_multipart_request_disconnect():
+    portfolio_source = (_ROOT / "api/routes/kai/portfolio.py").read_text(encoding="utf-8")
+
+    assert "class _AlwaysConnectedImportStreamRequest" in portfolio_source
+    assert "request=_AlwaysConnectedImportStreamRequest()" in portfolio_source
+
+
 def test_portfolio_import_defaults_to_gemini_35_flash_with_env_override():
     constants_source = (_ROOT / "hushh_mcp/constants.py").read_text(encoding="utf-8")
     portfolio_source = (_ROOT / "api/routes/kai/portfolio.py").read_text(encoding="utf-8")

--- a/hushh-webapp/components/kai/kai-flow.tsx
+++ b/hushh-webapp/components/kai/kai-flow.tsx
@@ -1897,93 +1897,18 @@ export function KaiFlow({
         formData.append("user_id", userId);
 
         const runImportRequest = async (importToken: string): Promise<Response> => {
-          if (Capacitor.isNativePlatform()) {
-            return ApiService.importPortfolioStream({
-              formData,
-              vaultOwnerToken: importToken,
-              signal: abortControllerRef.current?.signal,
-            });
+          // Fresh web uploads must keep start + stream on one backend request.
+          // UAT Cloud Run can route `/run/start` and `/run/{id}/stream` to different
+          // instances, while the portfolio import run manager is still in-memory.
+          // The direct stream endpoint starts the run and streams from the same instance.
+          if (!Capacitor.isNativePlatform()) {
+            activeImportRunIdRef.current = null;
           }
-
-          const startResponse = await ApiService.startPortfolioImportRun({
-            formData,
-            vaultOwnerToken: importToken,
-            signal: abortControllerRef.current?.signal,
-          });
-          if (startResponse.status === 409) {
-            const conflict = (await startResponse.json().catch(() => null)) as
-              | {
-                  detail?: {
-                    active_run?: { run_id?: unknown; latest_cursor?: unknown };
-                  };
-                }
-              | null;
-            const runIdFromConflict =
-              typeof conflict?.detail?.active_run?.run_id === "string"
-                ? conflict.detail.active_run.run_id.trim()
-                : "";
-            if (!runIdFromConflict) {
-              throw new Error(
-                "Another import is running, but its run id could not be resolved."
-              );
-            }
-            // Explicit upload action should always start a fresh run, not attach.
-            await ApiService.cancelPortfolioImportRun({
-              runId: runIdFromConflict,
-              userId,
-              vaultOwnerToken: importToken,
-            });
-            await new Promise((resolve) => window.setTimeout(resolve, 150));
-            const retryStart = await ApiService.startPortfolioImportRun({
-              formData,
-              vaultOwnerToken: importToken,
-              signal: abortControllerRef.current?.signal,
-            });
-            if (!retryStart.ok) {
-              return retryStart;
-            }
-            const retryPayload = (await retryStart.json()) as {
-              run?: { run_id?: unknown };
-            };
-            const retryRunId =
-              typeof retryPayload?.run?.run_id === "string"
-                ? retryPayload.run.run_id.trim()
-                : "";
-            if (!retryRunId) {
-              throw new Error("Import run started but no run id was returned.");
-            }
-            activeImportRunIdRef.current = retryRunId;
-            activeImportCursorRef.current = 0;
-            persistBackgroundSnapshot("running");
-            return ApiService.streamPortfolioImportRun({
-              runId: retryRunId,
-              userId,
-              vaultOwnerToken: importToken,
-              cursor: 0,
-              signal: abortControllerRef.current?.signal,
-            });
-          }
-          if (!startResponse.ok) {
-            return startResponse;
-          }
-          const startedPayload = (await startResponse.json()) as {
-            run?: { run_id?: unknown };
-          };
-          const runId =
-            typeof startedPayload?.run?.run_id === "string"
-              ? startedPayload.run.run_id.trim()
-              : "";
-          if (!runId) {
-            throw new Error("Import run started but no run id was returned.");
-          }
-          activeImportRunIdRef.current = runId;
           activeImportCursorRef.current = 0;
           persistBackgroundSnapshot("running");
-          return ApiService.streamPortfolioImportRun({
-            runId,
-            userId,
+          return ApiService.importPortfolioStream({
+            formData,
             vaultOwnerToken: importToken,
-            cursor: 0,
             signal: abortControllerRef.current?.signal,
           });
         };


### PR DESCRIPTION
## Summary
- route fresh Kai portfolio uploads through the direct SSE import endpoint so Cloud Run does not split start/stream requests across instances
- keep import streaming alive for the compatibility upload endpoint by avoiding multipart request disconnect checks
- add stream contract coverage for the compatibility endpoint behavior

## Verification
- cd hushh-webapp && npm test -- __tests__/api/kai/proxy-route.test.ts __tests__/components/import-progress-view.test.tsx
- cd hushh-webapp && npm run typecheck
- cd consent-protocol && python3 -m pytest tests/test_kai_stream_contract.py tests/test_portfolio_stream_progress_realism.py -q
- ./bin/hushh protocol check-sync
- ./scripts/ci/subtree-sync-check.sh
- ./bin/hushh codex pre-pr