### PR TITLE
Fix UAT reviewer bootstrap timeout

### DIFF
--- a/hushh-webapp/app/api/app-config/review-mode/route.ts
+++ b/hushh-webapp/app/api/app-config/review-mode/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getPythonApiUrl } from "@/app/api/_utils/backend";
 
-const REQUEST_TIMEOUT_MS = 8000;
+const REQUEST_TIMEOUT_MS = 30000;
 const NO_STORE_HEADERS = { "Cache-Control": "no-store" };
 
 export async function GET(_request: NextRequest) {

--- a/hushh-webapp/app/api/app-config/review-mode/session/route.ts
+++ b/hushh-webapp/app/api/app-config/review-mode/session/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getPythonApiUrl } from "@/app/api/_utils/backend";
 
-const REQUEST_TIMEOUT_MS = 8000;
+const REQUEST_TIMEOUT_MS = 30000;
 const NO_STORE_HEADERS = { "Cache-Control": "no-store" };
 
 export async function POST(request: NextRequest) {


### PR DESCRIPTION
## Summary\n- extend app-review-mode proxy timeout to tolerate UAT backend cold starts\n- keep reviewer-mode session semantics unchanged\n\n## Verification\n- npm run typecheck