### PR TITLE
Repair Gemini extra-data import JSON

### DIFF
--- a/consent-protocol/hushh_mcp/kai_import/extract_v2.py
+++ b/consent-protocol/hushh_mcp/kai_import/extract_v2.py
@@ -49,13 +49,37 @@ def parse_json_strict_v2(
     if not candidate:
         raise ImportStrictParseError("IMPORT_JSON_INVALID", "Empty model response.")
 
+    repair_actions: list[str] = []
+    repair_applied = False
     try:
         parsed = _to_object(json.loads(candidate))
     except json.JSONDecodeError as exc:
-        raise ImportStrictParseError(
-            "IMPORT_JSON_INVALID",
-            f"Model returned invalid JSON: {exc.msg}",
-        ) from exc
+        if exc.msg != "Extra data":
+            raise ImportStrictParseError(
+                "IMPORT_JSON_INVALID",
+                f"Model returned invalid JSON: {exc.msg}",
+            ) from exc
+
+        try:
+            parsed_value, parsed_end = json.JSONDecoder().raw_decode(candidate)
+            parsed = _to_object(parsed_value)
+        except json.JSONDecodeError as repair_exc:
+            raise ImportStrictParseError(
+                "IMPORT_JSON_INVALID",
+                f"Model returned invalid JSON: {repair_exc.msg}",
+            ) from repair_exc
+        except ImportStrictParseError as repair_exc:
+            raise repair_exc from exc
+
+        trailing = candidate[parsed_end:].strip()
+        if trailing:
+            repair_applied = True
+            repair_actions.extend(
+                [
+                    "accepted_first_json_object",
+                    "discarded_trailing_content",
+                ]
+            )
 
     if required_keys:
         missing = sorted(k for k in required_keys if k not in parsed)
@@ -72,11 +96,11 @@ def parse_json_strict_v2(
             )
 
     diagnostics = {
-        "mode": "strict_json_only",
+        "mode": "strict_json_with_extra_data_repair" if repair_applied else "strict_json_only",
         "raw_length": len(candidate),
-        "repair_attempted": False,
-        "repair_applied": False,
-        "repair_actions": [],
+        "repair_attempted": repair_applied,
+        "repair_applied": repair_applied,
+        "repair_actions": repair_actions,
     }
     return parsed, diagnostics
 

--- a/consent-protocol/tests/test_portfolio_import_strict_parse_v2.py
+++ b/consent-protocol/tests/test_portfolio_import_strict_parse_v2.py
@@ -32,6 +32,20 @@ def test_parse_json_strict_v2_accepts_exact_required_shape() -> None:
     assert diagnostics["mode"] == "strict_json_only"
 
 
+def test_parse_json_strict_v2_accepts_first_object_when_model_appends_extra_data() -> None:
+    parsed, diagnostics = parse_json_strict_v2(
+        '{"a": 1, "b": []}\n{"a": 2, "b": []}',
+        required_keys={"a", "b"},
+    )
+    assert parsed == {"a": 1, "b": []}
+    assert diagnostics["mode"] == "strict_json_with_extra_data_repair"
+    assert diagnostics["repair_applied"] is True
+    assert diagnostics["repair_actions"] == [
+        "accepted_first_json_object",
+        "discarded_trailing_content",
+    ]
+
+
 def test_run_stream_pass_v2_emits_thinking_without_polluting_json_response() -> None:
     async def run_case() -> tuple[list[dict[str, object]], dict[str, object], object]:
         events: list[dict[str, object]] = []


### PR DESCRIPTION
## Summary\n- tolerate Gemini 3.5 Flash responses that contain one valid JSON object followed by trailing extra data\n- keep required top-level schema validation before accepting repaired output\n- add a strict parse regression test for the extra-data response shape\n\n## Verification\n- python3 -m pytest tests/test_portfolio_import_strict_parse_v2.py tests/test_kai_stream_contract.py tests/test_portfolio_stream_progress_realism.py -q\n- ./scripts/ci/subtree-sync-check.sh\n- ./bin/hushh protocol check-sync