### PR TITLE
fix(data-table): set aria-sort="none" on unsorted sortable column headers

### DIFF
--- a/hushh-webapp/components/app-ui/data-table.tsx
+++ b/hushh-webapp/components/app-ui/data-table.tsx
@@ -318,11 +318,13 @@ export function DataTable<TData, TValue>({
                     tabIndex={header.column.getCanSort() ? 0 : undefined}
                     role={header.column.getCanSort() ? "button" : undefined}
                     aria-sort={
-                      header.column.getIsSorted() === "asc"
-                        ? "ascending"
-                        : header.column.getIsSorted() === "desc"
-                          ? "descending"
-                          : undefined
+                      header.column.getCanSort()
+                        ? header.column.getIsSorted() === "asc"
+                          ? "ascending"
+                          : header.column.getIsSorted() === "desc"
+                            ? "descending"
+                            : "none"
+                        : undefined
                     }
                     onKeyDown={(e) => {
                       if (


### PR DESCRIPTION
## Summary

WAI-ARIA 1.2 requires `aria-sort="none"` on sortable column headers that
are not currently sorted. The previous implementation omitted the attribute
entirely in this state, which prevented assistive technologies from
announcing that the column is sortable.

## Change

* sortable + unsorted → `aria-sort="none"`
* sortable + ascending → `aria-sort="ascending"` (unchanged)
* sortable + descending → `aria-sort="descending"` (unchanged)
* non-sortable → no `aria-sort` attribute (unchanged)

## Scope

Single conditional update in `components/app-ui/data-table.tsx`.

No runtime behavior changes.
No visual changes.
No API changes.
No dependency changes.

## Validation

```bash id="xjlwmk"
npx vitest run
```
