### PR TITLE
fix: harden native profile consent flow

### DIFF
--- a/hushh-webapp/scripts/testing/signed-in-ui-flows.mjs
+++ b/hushh-webapp/scripts/testing/signed-in-ui-flows.mjs
@@ -125,8 +125,8 @@ export const UI_FLOWS = [
     steps: [
       { type: "click_bottom_nav", label: "Profile" },
       { type: "wait_beacon", routeIds: ["/profile"] },
-      { type: "click_button", name: "access & sharing" },
-      { type: "click_button", name: "consent center" },
+      { type: "click_button", name: "^access & sharing", regex: true },
+      { type: "click_button", name: "^consent center", regex: true },
       { type: "wait_beacon", routeIds: ["/consents"] },
     ],
   },


### PR DESCRIPTION
## Summary\n- make the shared signed-in native UI flow match Profile settings rows by anchored label prefix instead of exact button text\n- verified the previously failing shell-consents flow on the connected iPhone\n\n## Verification\n- npm run lint\n- IOS_UI_FLOW_FILTER=shell-consents npm run ios:device:ui:test