### PR TITLE
test: harden Kai import E2E navigation

### DIFF
--- a/hushh-webapp/scripts/testing/run-kai-import-e2e.mjs
+++ b/hushh-webapp/scripts/testing/run-kai-import-e2e.mjs
@@ -357,7 +357,48 @@ async function clickBottomNav(page, label) {
     return;
   }
 
-  throw new Error(`Cannot find bottom navigation item "${label}" at ${page.url()}`);
+  const link = await firstVisible(
+    page.getByRole("link", { name: new RegExp(`^${label}$`, "i") })
+  );
+  if (await link.isVisible().catch(() => false)) {
+    await link.click();
+    return;
+  }
+
+  const radio = page.getByRole("radio", { name: new RegExp(`^${label}$`, "i") }).first();
+  if (await radio.isVisible().catch(() => false)) {
+    await radio.evaluate((node) => {
+      if (node instanceof HTMLElement) node.click();
+    });
+    return;
+  }
+
+  const tab = page.getByRole("tab", { name: new RegExp(`^${label}$`, "i") }).first();
+  if (await tab.isVisible().catch(() => false)) {
+    await tab.evaluate((node) => {
+      if (node instanceof HTMLElement) node.click();
+    });
+    return;
+  }
+
+  const text = page.getByText(new RegExp(`^${label}$`, "i")).first();
+  if (await text.waitFor({ state: "visible", timeout: 2500 }).then(() => true).catch(() => false)) {
+    await text.click({ force: true });
+    return;
+  }
+
+  const visibleTourIds = await page
+    .locator("[data-tour-id]")
+    .evaluateAll((nodes) =>
+      nodes
+        .filter((node) => node instanceof HTMLElement && node.offsetParent !== null)
+        .map((node) => node.getAttribute("data-tour-id"))
+        .filter(Boolean)
+    )
+    .catch(() => []);
+  throw new Error(
+    `Cannot find bottom navigation item "${label}" at ${page.url()}. Visible tour ids: ${visibleTourIds.join(", ")}`
+  );
 }
 
 async function ensureInvestorPersona(page) {


### PR DESCRIPTION
## Summary
- align the Kai import E2E bottom-nav selector with the signed-in route verifier fallbacks
- add visible tour-id diagnostics when a bottom nav item cannot be found

## Verification
- HUSHH_APP_ORIGIN=https://uat.kai.hushh.ai HUSHH_VIEWPORT_FILTER=phone HUSHH_ROUTE_FILTER=/kai/import node ./scripts/testing/verify-signed-in-routes.mjs
- HUSHH_APP_ORIGIN=https://uat.kai.hushh.ai KAI_IMPORT_E2E_FILE='/Users/kushaltrivedi/Downloads/Jan312026SchwabHu$$h.pdf' npm run e2e:kai-import:uat
- npm run lint