### PR TITLE
test: harden native UI flow contracts

### DIFF
--- a/hushh-webapp/ios/App/App/NativeUiTestRunnerScript.swift
+++ b/hushh-webapp/ios/App/App/NativeUiTestRunnerScript.swift
@@ -148,12 +148,16 @@ enum NativeUiTestRunnerScript {
     var current = normalizeRoute(routeId);
     for (var i = 0; i < allowedRouteIds.length; i += 1) {
       var allowed = allowedRouteIds[i];
+      var normalizedAllowed = normalizeRoute(allowed);
+      if (current === normalizedAllowed) return true;
       if (allowed.includes("[") && allowed.includes("]")) {
-        var prefix = allowed.split("[")[0];
-        if (current.startsWith(normalizeRoute(prefix))) return true;
+        var escaped = normalizedAllowed.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        var pattern = new RegExp(
+          "^" + escaped.replace(/\\\[[^\\\]]+\\\]/g, "[^/]+") + "(?:$|[/?#])"
+        );
+        if (pattern.test(current)) return true;
         continue;
       }
-      if (current === normalizeRoute(allowed)) return true;
     }
     return false;
   }

--- a/hushh-webapp/scripts/native/native-ui-test-runner-source.js
+++ b/hushh-webapp/scripts/native/native-ui-test-runner-source.js
@@ -144,12 +144,16 @@
     var current = normalizeRoute(routeId);
     for (var i = 0; i < allowedRouteIds.length; i += 1) {
       var allowed = allowedRouteIds[i];
+      var normalizedAllowed = normalizeRoute(allowed);
+      if (current === normalizedAllowed) return true;
       if (allowed.includes("[") && allowed.includes("]")) {
-        var prefix = allowed.split("[")[0];
-        if (current.startsWith(normalizeRoute(prefix))) return true;
+        var escaped = normalizedAllowed.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        var pattern = new RegExp(
+          "^" + escaped.replace(/\\\[[^\\\]]+\\\]/g, "[^/]+") + "(?:$|[/?#])"
+        );
+        if (pattern.test(current)) return true;
         continue;
       }
-      if (current === normalizeRoute(allowed)) return true;
     }
     return false;
   }

--- a/hushh-webapp/scripts/testing/export-reviewer-test-env.mjs
+++ b/hushh-webapp/scripts/testing/export-reviewer-test-env.mjs
@@ -15,6 +15,8 @@ const identity = resolveReviewerTestIdentity({
 });
 
 process.stdout.write(`export REVIEWER_UID=${JSON.stringify(identity.reviewerUid)}\n`);
+process.stdout.write(`export NEXT_PUBLIC_REVIEWER_UID=${JSON.stringify(identity.reviewerUid)}\n`);
+process.stdout.write(`export NEXT_PUBLIC_KAI_TEST_USER_ID=${JSON.stringify(identity.reviewerUid)}\n`);
 process.stdout.write(
   `export REVIEWER_VAULT_PASSPHRASE=${JSON.stringify(identity.reviewerVaultPassphrase)}\n`
 );

--- a/hushh-webapp/scripts/testing/signed-in-ui-flows.mjs
+++ b/hushh-webapp/scripts/testing/signed-in-ui-flows.mjs
@@ -5,7 +5,7 @@
  * Step types:
  * - ensure_persona: { persona: "ria" | "investor" }
  * - click_bottom_nav: { label: string }
- * - click_button: { name: string }  // case-insensitive exact match
+ * - click_button: { name: string, regex?: boolean }  // case-insensitive exact match unless regex=true
  * - click_voice_control: { controlId: string }
  * - click_testid: { testId: string }
  * - clear_import_background: {}
@@ -138,14 +138,14 @@ export const UI_FLOWS = [
       { type: "ensure_persona", persona: "ria" },
       { type: "click_bottom_nav", label: "Picks" },
       { type: "wait_beacon", routeIds: ["/ria/picks"] },
-      { type: "click_button", name: "kai list" },
-      { type: "assert_url_includes", value: "source=kai" },
-      { type: "click_button", name: "my list" },
+      { type: "click_button", name: "^my list", regex: true },
       { type: "assert_url_includes", value: "source=my" },
-      { type: "click_button", name: "top picks" },
-      { type: "assert_url_includes", value: "category=top-picks" },
+      { type: "click_button", name: "^kai list", regex: true },
+      { type: "assert_url_includes", value: "source=kai" },
       { type: "click_button", name: "avoid" },
       { type: "assert_url_includes", value: "category=avoid" },
+      { type: "click_button", name: "top picks" },
+      { type: "assert_url_includes", value: "category=top-picks" },
       { type: "click_button", name: "screening" },
       { type: "assert_url_includes", value: "category=screening" },
     ],
@@ -156,7 +156,7 @@ export const UI_FLOWS = [
     description: "RIA workspace -> taxable brokerage account",
     steps: [
       { type: "open_ria_workspace" },
-      { type: "click_button", name: "taxable brokerage" },
+      { type: "click_button", name: "^taxable brokerage", regex: true },
       {
         type: "wait_beacon",
         routeIds: ["/ria/clients/[userId]/accounts/[accountId]"],


### PR DESCRIPTION
## Summary
- tighten native dynamic-route matching so parameterized routes require concrete path segments
- expose reviewer UID through public test env for native reviewer builds, matching web test-profile behavior
- make signed-in iPhone flow clicks deterministic for RIA picks and workspace account labels

## Verification
- npm run lint
- npm run verify:capacitor:reports
- npm run ios:device:ui:test
- ./bin/hushh codex pre-pr