### PR TITLE
fix(table): add scope="col" to TableHead column header primitive

### DIFF
--- a/hushh-webapp/components/ui/table.tsx
+++ b/hushh-webapp/components/ui/table.tsx
@@ -69,6 +69,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
   return (
     <th
       data-slot="table-head"
+      scope="col"
       className={cn(
         "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-normal sm:whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className


### PR DESCRIPTION
## Summary

`<th>` elements used as column headers should carry `scope="col"` per
HTML 5 spec and WAI-ARIA best practice. This allows assistive technologies
to correctly associate header cells with their data columns.

## Change

Adds `scope="col"` to the shared `TableHead` primitive.

The attribute is applied before the `...props` spread so explicit
call-site overrides remain possible if needed.

## Scope

Single attribute addition in `components/ui/table.tsx`.

No runtime behavior changes.
No visual changes.
No API changes.
No dependency changes.

All existing `TableHead` usages automatically benefit from the semantic
improvement.

## Validation

```bash id="4jlwm7"
npx vitest run
```
