### PR TITLE
fix(webapp): hide global scrollbar while preserving .scrollbar-thin o…

### DIFF
--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1806,3 +1806,58 @@ html.dark .morphy-app-bg {
   background-color: #1c1c1e !important;
   background-image: none !important;
 }
+
+/* ─── Global Invisible Scrollbar ───────────────────────────────────────────────
+ * Scrolling still works; the track/thumb are hidden so they don't bleed
+ * outside the content area or contrast against the dark shell.
+ *
+ * Firefox  → scrollbar-width: none
+ * WebKit / Chromium → ::-webkit-scrollbar { width: 0; height: 0 }
+ *
+ * The .scrollbar-thin utility classes (used by Morphy streaming containers)
+ * are intentionally preserved — they opt back in to a thin visible thumb.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+/* Firefox */
+* {
+  scrollbar-width: none;
+}
+
+/* WebKit / Chromium */
+*::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+  background: transparent;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background: transparent;
+}
+
+/* Opt-in: streaming / morphy containers restore a subtle thin thumb */
+.scrollbar-thin {
+  scrollbar-width: thin;
+  scrollbar-color: oklch(0.35 0.003 264) transparent;
+}
+
+.scrollbar-thin::-webkit-scrollbar {
+  width: 4px;
+  height: 4px;
+}
+
+.scrollbar-thin::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.scrollbar-thin::-webkit-scrollbar-thumb {
+  background-color: oklch(0.35 0.003 264);
+  border-radius: 9999px;
+}
+
+.scrollbar-thin::-webkit-scrollbar-thumb:hover {
+  background-color: oklch(0.45 0.003 264);
+}


### PR DESCRIPTION
# Description

Hide the native OS scrollbar globally across the hushh-webapp shell while preserving full scroll functionality and the existing `.scrollbar-thin` opt-in used by Morphy streaming containers.

**Why:** The app pins `body { overflow: hidden; height: 100dvh }` and delegates scrolling to inner containers. On those panels (Profile / Data / Settings / Connect), the OS-native scrollbar bled a visible grey bar onto the dark `#1c1c1e` shell — visually inconsistent with the app's Apple/iOS design language. Hiding it removes the visual noise without touching any component logic.

**How:**
- `* { scrollbar-width: none }` — Firefox
- `*::-webkit-scrollbar { width: 0; height: 0 }` — WebKit / Chromium (Chrome, Edge, Safari)
- `.scrollbar-thin` re-instated after the global hide so `streaming-text.tsx` and `streaming-accordion.tsx` continue rendering their opt-in subtle thumb

**File changed:** `hushh-webapp/app/globals.css` (+57 lines, purely additive)

---

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None
  - Web-only CSS rule. On native iOS/Android (Capacitor), the WebView already suppresses the native scroll indicator via platform defaults; this CSS is additive and harmless on those surfaces.

- Docs updated (exact files):
  - [x] None — cosmetic CSS only, no contract or API surface changed.

- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck`
  - [ ] `cd hushh-webapp && npm test`
  - [ ] `cd hushh-webapp && npm run build`
  - [ ] `cd hushh-webapp && npm run ios:test`
  - [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000`

---

## 🛑 Tri-Flow Architecture Check

_Every feature must be implemented across all three layers or explicitly marked as not applicable._

- [x] **Web**: CSS applied globally via `hushh-webapp/app/globals.css` — affects all web pages ✅
- [x] **iOS**: Not applicable — WKWebView/Capacitor suppresses scroll indicators natively; CSS is inert on this layer ✅
- [x] **Android**: Not applicable — WebView scroll indicators are controlled by the platform; this CSS has no negative effect ✅

---

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari) — scrollbar hidden, scroll still functional on Profile / Data / Settings panels
- [x] Tested on iOS Simulator/Device
- [x] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

---

## 📸 Screenshots / Video


Before
<img width="1919" height="875" alt="image" src="https://github.com/user-attachments/assets/f20dc07b-291e-4435-81f8-a84e0fcf0a5d" />
After
<img width="1919" height="871" alt="image" src="https://github.com/user-attachments/assets/50242f4e-ad22-4cdd-a692-10a1506f3b92" />



---

## 🛡️ Privacy & Consent

- [x] Does this change access user data? **No** — pure CSS presentation change, no data reads or writes.
- [x] `checkConsentToken()` — Not applicable.

---

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible — CSS only, no third-party dependency added.
- [x] Third-party notice impact reviewed when dependencies changed — No dependency changes.
