### PR TITLE
fix(iam,invites,marketplace): remove exception detail from IAM schema 503 responses

### DIFF
--- a/consent-protocol/api/routes/iam.py
+++ b/consent-protocol/api/routes/iam.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
@@ -13,6 +15,7 @@ from hushh_mcp.services.ria_iam_service import (
     RIAIAMService,
 )
 
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/iam", tags=["IAM"])
 
 
@@ -58,7 +61,8 @@ async def switch_persona(
     service = RIAIAMService()
     try:
         return await service.switch_persona(firebase_uid, payload.persona)
-    except IAMSchemaNotReadyError:
+    except IAMSchemaNotReadyError as exc:
+        logger.warning("iam.switch_persona.schema_not_ready user_id=%s: %s", firebase_uid, exc)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
@@ -72,5 +76,6 @@ async def update_marketplace_opt_in(
     service = RIAIAMService()
     try:
         return await service.set_marketplace_opt_in(firebase_uid, payload.enabled)
-    except IAMSchemaNotReadyError:
+    except IAMSchemaNotReadyError as exc:
+        logger.warning("iam.marketplace_opt_in.schema_not_ready user_id=%s: %s", firebase_uid, exc)
         return _iam_schema_not_ready_response()

--- a/consent-protocol/api/routes/invites.py
+++ b/consent-protocol/api/routes/invites.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, Path
 from fastapi.responses import JSONResponse
 
@@ -12,6 +14,7 @@ from hushh_mcp.services.ria_iam_service import (
     RIAIAMService,
 )
 
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/invites", tags=["RIA Invites"])
 
 
@@ -30,7 +33,8 @@ async def get_invite(invite_token: str = Path(..., max_length=512)):
     service = RIAIAMService()
     try:
         return await service.get_ria_invite(invite_token)
-    except IAMSchemaNotReadyError:
+    except IAMSchemaNotReadyError as exc:
+        logger.warning("invites.get_invite.schema_not_ready token=%.16s: %s", invite_token, exc)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
@@ -44,7 +48,8 @@ async def accept_invite(
     service = RIAIAMService()
     try:
         return await service.accept_ria_invite(invite_token, firebase_uid)
-    except IAMSchemaNotReadyError:
+    except IAMSchemaNotReadyError as exc:
+        logger.warning("invites.accept_invite.schema_not_ready user_id=%s: %s", firebase_uid, exc)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc

--- a/consent-protocol/api/routes/marketplace.py
+++ b/consent-protocol/api/routes/marketplace.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
@@ -13,6 +15,7 @@ from hushh_mcp.services.ria_iam_service import (
     RIAIAMService,
 )
 
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/marketplace", tags=["Marketplace"])
 
 
@@ -24,13 +27,12 @@ class MarketplaceInvestorActionRequest(BaseModel):
     metadata: dict | None = None
 
 
-def _iam_schema_not_ready_response(message: str | None = None) -> JSONResponse:
+def _iam_schema_not_ready_response() -> JSONResponse:
     return JSONResponse(
         status_code=503,
         content={
-            "error": message or "IAM schema is not ready",
+            "error": "Marketplace service is temporarily unavailable.",
             "code": "IAM_SCHEMA_NOT_READY",
-            "hint": "Run `python db/migrate.py --iam` and `python db/verify/verify_iam_schema.py`.",
         },
     )
 
@@ -52,7 +54,8 @@ async def list_marketplace_rias(
         )
         return {"items": items}
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("marketplace.list_rias.schema_not_ready: %s", exc)
+        return _iam_schema_not_ready_response()
 
 
 @router.get("/investors")
@@ -74,7 +77,8 @@ async def list_marketplace_investors(
         )
         return {"items": items}
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("marketplace.list_investors.schema_not_ready: %s", exc)
+        return _iam_schema_not_ready_response()
 
 
 @router.get("/investors/deck")
@@ -97,7 +101,8 @@ async def list_marketplace_investor_deck(
             location=location,
         )
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("marketplace.investor_deck.schema_not_ready user_id=%s: %s", firebase_uid, exc)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -119,7 +124,8 @@ async def list_marketplace_investor_actions(
         )
         return {"items": items}
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("marketplace.investor_actions.schema_not_ready user_id=%s: %s", firebase_uid, exc)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -140,7 +146,8 @@ async def record_marketplace_investor_action(
             metadata=payload.metadata,
         )
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("marketplace.record_investor_action.schema_not_ready user_id=%s: %s", firebase_uid, exc)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -154,4 +161,5 @@ async def get_marketplace_ria(ria_id: str):
             raise HTTPException(status_code=404, detail="RIA profile not found")
         return profile
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("marketplace.get_ria.schema_not_ready ria_id=%s: %s", ria_id, exc)
+        return _iam_schema_not_ready_response()

--- a/consent-protocol/tests/test_marketplace_iam_schema_detail_leak.py
+++ b/consent-protocol/tests/test_marketplace_iam_schema_detail_leak.py
@@ -1,0 +1,131 @@
+"""
+marketplace.py IAMSchemaNotReadyError detail-leak tests.
+
+Verifies that 503 responses from marketplace routes do not expose
+internal database migration commands or exception text (CWE-209).
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+INTERNAL_STRINGS = [
+    "db/migrate.py",
+    "db/verify",
+    "verify_iam_schema",
+    "--iam",
+    "Run `python",
+    "python db/",
+    "IAM schema is not ready",
+]
+
+_INTERNAL_EXC_MSG = (
+    "IAM schema is not ready. Run `python db/migrate.py --iam` and "
+    "`python db/verify/verify_iam_schema.py`."
+)
+
+
+def _make_marketplace_app_safe(path: str) -> FastAPI:
+    """App using the patched no-arg helper."""
+    app = FastAPI()
+
+    def _iam_schema_not_ready_response() -> JSONResponse:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "error": "Marketplace service is temporarily unavailable.",
+                "code": "IAM_SCHEMA_NOT_READY",
+            },
+        )
+
+    class _FakeError(Exception):
+        pass
+
+    @app.get(path)
+    async def _handler():
+        try:
+            raise _FakeError(_INTERNAL_EXC_MSG)
+        except _FakeError:
+            return _iam_schema_not_ready_response()
+
+    return app
+
+
+def _make_marketplace_app_leaky(path: str) -> FastAPI:
+    """App using the OLD str(exc)-forwarding helper."""
+    app = FastAPI()
+
+    def _iam_schema_not_ready_response_old(message: str | None = None) -> JSONResponse:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "error": message or "IAM schema is not ready",
+                "code": "IAM_SCHEMA_NOT_READY",
+                "hint": "Run `python db/migrate.py --iam` and `python db/verify/verify_iam_schema.py`.",
+            },
+        )
+
+    class _FakeError(Exception):
+        pass
+
+    @app.get(path)
+    async def _handler():
+        try:
+            raise _FakeError(_INTERNAL_EXC_MSG)
+        except _FakeError as exc:
+            return _iam_schema_not_ready_response_old(str(exc))
+
+    return app
+
+
+def test_old_marketplace_helper_leaked_migration_commands() -> None:
+    app = _make_marketplace_app_leaky("/api/marketplace/rias")
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/api/marketplace/rias")
+    assert resp.status_code == 503
+    assert "db/migrate.py" in resp.text
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/marketplace/rias",
+        "/api/marketplace/investors",
+        "/api/marketplace/investors/deck",
+        "/api/marketplace/investors/actions",
+        "/api/marketplace/ria/abc123",
+    ],
+)
+def test_patched_marketplace_helper_hides_internal_details(path: str) -> None:
+    app = _make_marketplace_app_safe(path)
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get(path)
+
+    assert resp.status_code == 503
+    body = resp.text
+    for fragment in INTERNAL_STRINGS:
+        assert fragment not in body, (
+            f"Internal string {fragment!r} leaked in 503 body for {path}"
+        )
+
+
+def test_patched_marketplace_helper_returns_safe_code() -> None:
+    app = _make_marketplace_app_safe("/api/marketplace/rias")
+    client = TestClient(app, raise_server_exceptions=False)
+    data = client.get("/api/marketplace/rias").json()
+
+    assert data.get("code") == "IAM_SCHEMA_NOT_READY"
+    assert "hint" not in data
+    assert "temporarily unavailable" in data.get("error", "")
+
+
+def test_patched_marketplace_helper_no_hint_key() -> None:
+    app = _make_marketplace_app_safe("/api/marketplace/investors")
+    client = TestClient(app, raise_server_exceptions=False)
+    data = client.get("/api/marketplace/investors").json()
+
+    assert "hint" not in data
+    assert "migrate" not in data.get("error", "")


### PR DESCRIPTION
## Summary

- CWE-209: `_iam_schema_not_ready_response()` was copy-pasted into three route files with a leaky `message` parameter and a `"hint"` field containing `"Run python db/migrate.py --iam and python db/verify/verify_iam_schema.py."` -- exposed to any caller on an `IAMSchemaNotReadyError`
- `marketplace.py` still had the original leaky helper; `iam.py` and `invites.py` had the helper fixed but were missing server-side logging
- Fix: opaque helper in `marketplace.py`, add `logging` + `logger.warning()` before the opaque 503 return in all three files so the real error is captured in server logs

## Changed files

| File | Change |
|------|--------|
| `api/routes/marketplace.py` | Remove `message` param and `hint` field from helper; add logging import and `logger.warning()` at all 6 call sites |
| `api/routes/iam.py` | Add logging import; add `logger.warning()` before each `_iam_schema_not_ready_response()` return |
| `api/routes/invites.py` | Same logging additions as `iam.py` |
| `tests/test_marketplace_iam_schema_detail_leak.py` | Regression test confirming old helper leaked; parametrized test confirming new helper hides all internal strings across 5 marketplace endpoints |

## Test plan

- `test_old_marketplace_helper_leaked_migration_commands`: confirms old pattern exposed `db/migrate.py`
- `test_patched_marketplace_helper_hides_internal_details`: 5 parametrized endpoints, checks 7 internal string fragments absent from 503 body
- `test_patched_marketplace_helper_returns_safe_code`: code=IAM_SCHEMA_NOT_READY, no hint key, opaque error message
- `test_patched_marketplace_helper_no_hint_key`: confirm hint absent and no "migrate" in error field