### PR TITLE
fix(webhooks): omit raw JSON parse error from webhook 400 responses

### DIFF
--- a/consent-protocol/api/routes/kai/gmail.py
+++ b/consent-protocol/api/routes/kai/gmail.py
@@ -363,9 +363,10 @@ async def gmail_webhook(request: Request):
     try:
         payload = await request.json()
     except Exception as exc:
+        logger.warning("kai.gmail.webhook.invalid_json: %s", exc)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail={"code": "GMAIL_WEBHOOK_INVALID_JSON", "message": str(exc)},
+            detail={"code": "GMAIL_WEBHOOK_INVALID_JSON", "message": "Webhook payload is not valid JSON."},
         ) from exc
 
     if not isinstance(payload, dict):

--- a/consent-protocol/api/routes/kai/plaid.py
+++ b/consent-protocol/api/routes/kai/plaid.py
@@ -842,9 +842,10 @@ async def plaid_webhook(request: Request):
         raw_body = await request.body()
         payload = json.loads(raw_body.decode("utf-8"))
     except Exception as exc:
+        logger.warning("kai.plaid.webhook.invalid_json: %s", exc)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail={"code": "PLAID_WEBHOOK_INVALID_JSON", "message": str(exc)},
+            detail={"code": "PLAID_WEBHOOK_INVALID_JSON", "message": "Webhook payload is not valid JSON."},
         ) from exc
 
     if not isinstance(payload, dict):

--- a/consent-protocol/api/routes/one/email.py
+++ b/consent-protocol/api/routes/one/email.py
@@ -194,9 +194,10 @@ async def one_email_webhook(request: Request):
     try:
         payload = await request.json()
     except Exception as exc:
+        logger.warning("one_email.webhook.invalid_json: %s", exc)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail={"code": "ONE_EMAIL_WEBHOOK_INVALID_JSON", "message": str(exc)},
+            detail={"code": "ONE_EMAIL_WEBHOOK_INVALID_JSON", "message": "Webhook payload is not valid JSON."},
         ) from exc
     if not isinstance(payload, dict):
         raise HTTPException(

--- a/consent-protocol/tests/test_webhook_json_parse_exception_leak.py
+++ b/consent-protocol/tests/test_webhook_json_parse_exception_leak.py
@@ -1,0 +1,114 @@
+"""
+Webhook JSON parse error detail-leak tests (CWE-209).
+
+Verifies that when one_email, gmail, and plaid webhook endpoints receive a
+malformed JSON body, the raw Python exception text (e.g. JSONDecodeError with
+line/column offsets or partial payload content) is not forwarded to the caller.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI, HTTPException, Request, status
+from fastapi.testclient import TestClient
+
+
+def _make_webhook_app_safe(path: str, code: str) -> FastAPI:
+    """App with the patched opaque error response."""
+    import logging
+
+    app = FastAPI()
+    logger = logging.getLogger(__name__)
+
+    @app.post(path)
+    async def _handler(request: Request):
+        try:
+            await request.json()
+        except Exception as exc:
+            logger.warning("webhook.invalid_json: %s", exc)
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={"code": code, "message": "Webhook payload is not valid JSON."},
+            ) from exc
+
+    return app
+
+
+def _make_webhook_app_leaky(path: str, code: str) -> FastAPI:
+    """App with the OLD str(exc)-forwarding response."""
+    app = FastAPI()
+
+    @app.post(path)
+    async def _handler(request: Request):
+        try:
+            await request.json()
+        except Exception as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={"code": code, "message": str(exc)},
+            ) from exc
+
+    return app
+
+
+MALFORMED_BODY = b"{this is not valid json: true,}"
+
+
+@pytest.mark.parametrize(
+    "path,code",
+    [
+        ("/one/email/webhook", "ONE_EMAIL_WEBHOOK_INVALID_JSON"),
+        ("/gmail/webhook", "GMAIL_WEBHOOK_INVALID_JSON"),
+        ("/plaid/webhook", "PLAID_WEBHOOK_INVALID_JSON"),
+    ],
+)
+def test_old_webhook_handler_leaks_parse_error(path: str, code: str) -> None:
+    app = _make_webhook_app_leaky(path, code)
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.post(path, content=MALFORMED_BODY, headers={"Content-Type": "application/json"})
+
+    assert resp.status_code == 400
+    # Old handler forwards raw json parse error -- confirm it leaks
+    assert resp.json().get("detail", {}).get("message") != "Webhook payload is not valid JSON."
+
+
+@pytest.mark.parametrize(
+    "path,code",
+    [
+        ("/one/email/webhook", "ONE_EMAIL_WEBHOOK_INVALID_JSON"),
+        ("/gmail/webhook", "GMAIL_WEBHOOK_INVALID_JSON"),
+        ("/plaid/webhook", "PLAID_WEBHOOK_INVALID_JSON"),
+    ],
+)
+def test_patched_webhook_handler_hides_parse_error(path: str, code: str) -> None:
+    app = _make_webhook_app_safe(path, code)
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.post(path, content=MALFORMED_BODY, headers={"Content-Type": "application/json"})
+
+    assert resp.status_code == 400
+    detail = resp.json().get("detail", {})
+    assert detail.get("code") == code
+    assert detail.get("message") == "Webhook payload is not valid JSON."
+    # Confirm no raw parse error fragments appear
+    raw = resp.text
+    assert "Expecting" not in raw  # JSONDecodeError prefix
+    assert "line " not in raw
+    assert "column " not in raw
+    assert "char " not in raw
+
+
+@pytest.mark.parametrize(
+    "path,code",
+    [
+        ("/one/email/webhook", "ONE_EMAIL_WEBHOOK_INVALID_JSON"),
+        ("/gmail/webhook", "GMAIL_WEBHOOK_INVALID_JSON"),
+        ("/plaid/webhook", "PLAID_WEBHOOK_INVALID_JSON"),
+    ],
+)
+def test_patched_webhook_handler_returns_correct_code(path: str, code: str) -> None:
+    app = _make_webhook_app_safe(path, code)
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.post(path, content=MALFORMED_BODY, headers={"Content-Type": "application/json"})
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["code"] == code

--- a/consent-protocol/tests/test_webhook_json_parse_exception_leak.py
+++ b/consent-protocol/tests/test_webhook_json_parse_exception_leak.py
@@ -1,114 +1,73 @@
 """
 Webhook JSON parse error detail-leak tests (CWE-209).
 
-Verifies that when one_email, gmail, and plaid webhook endpoints receive a
+Verifies that when the one_email, gmail, and plaid webhook endpoints receive a
 malformed JSON body, the raw Python exception text (e.g. JSONDecodeError with
 line/column offsets or partial payload content) is not forwarded to the caller.
+
+These tests mount the real product routers from api.routes so the actual route
+handlers are exercised, rather than a reimplementation of the handler logic.
+Each webhook parses the request body before any auth or signature check, so a
+malformed body reaches the JSON-parse branch under test directly.
 """
 
 from __future__ import annotations
 
 import pytest
-from fastapi import FastAPI, HTTPException, Request, status
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-
-def _make_webhook_app_safe(path: str, code: str) -> FastAPI:
-    """App with the patched opaque error response."""
-    import logging
-
-    app = FastAPI()
-    logger = logging.getLogger(__name__)
-
-    @app.post(path)
-    async def _handler(request: Request):
-        try:
-            await request.json()
-        except Exception as exc:
-            logger.warning("webhook.invalid_json: %s", exc)
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail={"code": code, "message": "Webhook payload is not valid JSON."},
-            ) from exc
-
-    return app
-
-
-def _make_webhook_app_leaky(path: str, code: str) -> FastAPI:
-    """App with the OLD str(exc)-forwarding response."""
-    app = FastAPI()
-
-    @app.post(path)
-    async def _handler(request: Request):
-        try:
-            await request.json()
-        except Exception as exc:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail={"code": code, "message": str(exc)},
-            ) from exc
-
-    return app
-
-
+# Raw bytes that are not valid JSON. A leaky handler echoes JSONDecodeError text
+# such as "Expecting property name enclosed in double quotes: line 1 column 2".
 MALFORMED_BODY = b"{this is not valid json: true,}"
 
+# (real mounted path, expected opaque error code)
+_WEBHOOK_CASES = [
+    ("/api/one/email/webhook", "ONE_EMAIL_WEBHOOK_INVALID_JSON"),
+    ("/api/kai/gmail/webhook", "GMAIL_WEBHOOK_INVALID_JSON"),
+    ("/api/kai/plaid/webhook", "PLAID_WEBHOOK_INVALID_JSON"),
+]
 
-@pytest.mark.parametrize(
-    "path,code",
-    [
-        ("/one/email/webhook", "ONE_EMAIL_WEBHOOK_INVALID_JSON"),
-        ("/gmail/webhook", "GMAIL_WEBHOOK_INVALID_JSON"),
-        ("/plaid/webhook", "PLAID_WEBHOOK_INVALID_JSON"),
-    ],
-)
-def test_old_webhook_handler_leaks_parse_error(path: str, code: str) -> None:
-    app = _make_webhook_app_leaky(path, code)
-    client = TestClient(app, raise_server_exceptions=False)
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    """Test app with the real webhook routers mounted at their product paths."""
+    from api.routes.kai import gmail, plaid
+    from api.routes.one import email
+
+    app = FastAPI()
+    # gmail and plaid routers are mounted under the /api/kai prefix in production
+    # (api/routes/kai/__init__.py); email.router already carries its /api/one
+    # prefix. Reproduce the production mount points here.
+    app.include_router(gmail.router, prefix="/api/kai")
+    app.include_router(plaid.router, prefix="/api/kai")
+    app.include_router(email.router)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.mark.parametrize("path,code", _WEBHOOK_CASES)
+def test_webhook_malformed_json_returns_opaque_message(
+    client: TestClient, path: str, code: str
+) -> None:
+    """The real handler must return the static opaque message and code on bad JSON."""
     resp = client.post(path, content=MALFORMED_BODY, headers={"Content-Type": "application/json"})
 
-    assert resp.status_code == 400
-    # Old handler forwards raw json parse error -- confirm it leaks
-    assert resp.json().get("detail", {}).get("message") != "Webhook payload is not valid JSON."
-
-
-@pytest.mark.parametrize(
-    "path,code",
-    [
-        ("/one/email/webhook", "ONE_EMAIL_WEBHOOK_INVALID_JSON"),
-        ("/gmail/webhook", "GMAIL_WEBHOOK_INVALID_JSON"),
-        ("/plaid/webhook", "PLAID_WEBHOOK_INVALID_JSON"),
-    ],
-)
-def test_patched_webhook_handler_hides_parse_error(path: str, code: str) -> None:
-    app = _make_webhook_app_safe(path, code)
-    client = TestClient(app, raise_server_exceptions=False)
-    resp = client.post(path, content=MALFORMED_BODY, headers={"Content-Type": "application/json"})
-
-    assert resp.status_code == 400
+    assert resp.status_code == 400, resp.text
     detail = resp.json().get("detail", {})
     assert detail.get("code") == code
     assert detail.get("message") == "Webhook payload is not valid JSON."
-    # Confirm no raw parse error fragments appear
+
+
+@pytest.mark.parametrize("path,code", _WEBHOOK_CASES)
+def test_webhook_malformed_json_does_not_leak_parser_internals(
+    client: TestClient, path: str, code: str
+) -> None:
+    """No JSONDecodeError fragments (offsets, prefixes) may appear in the response."""
+    resp = client.post(path, content=MALFORMED_BODY, headers={"Content-Type": "application/json"})
+
+    assert resp.status_code == 400, resp.text
     raw = resp.text
-    assert "Expecting" not in raw  # JSONDecodeError prefix
+    assert "Expecting" not in raw  # JSONDecodeError message prefix
     assert "line " not in raw
     assert "column " not in raw
     assert "char " not in raw
-
-
-@pytest.mark.parametrize(
-    "path,code",
-    [
-        ("/one/email/webhook", "ONE_EMAIL_WEBHOOK_INVALID_JSON"),
-        ("/gmail/webhook", "GMAIL_WEBHOOK_INVALID_JSON"),
-        ("/plaid/webhook", "PLAID_WEBHOOK_INVALID_JSON"),
-    ],
-)
-def test_patched_webhook_handler_returns_correct_code(path: str, code: str) -> None:
-    app = _make_webhook_app_safe(path, code)
-    client = TestClient(app, raise_server_exceptions=False)
-    resp = client.post(path, content=MALFORMED_BODY, headers={"Content-Type": "application/json"})
-
-    assert resp.status_code == 400
-    assert resp.json()["detail"]["code"] == code


### PR DESCRIPTION
## Summary

- CWE-209: three webhook endpoints called `str(exc)` on a bare `Exception` catch around `request.json()`, forwarding the raw Python `JSONDecodeError` (which includes line number, column offset, and a substring of the malformed input) to the caller
- Affected: `POST /one/email/webhook`, `POST /gmail/webhook`, `POST /plaid/webhook`
- Fix: replace `str(exc)` with a static opaque message; log the original error server-side via `logger.warning()` so it still appears in server logs

## Changed files

| File | Change |
|------|--------|
| `api/routes/one/email.py` | `ONE_EMAIL_WEBHOOK_INVALID_JSON` message: `str(exc)` -> opaque; add `logger.warning()` |
| `api/routes/kai/gmail.py` | `GMAIL_WEBHOOK_INVALID_JSON` message: `str(exc)` -> opaque; add `logger.warning()` |
| `api/routes/kai/plaid.py` | `PLAID_WEBHOOK_INVALID_JSON` message: `str(exc)` -> opaque; add `logger.warning()` |
| `tests/test_webhook_json_parse_exception_leak.py` | Regression + parametrized tests for all three endpoints |

## Test plan

- `test_old_webhook_handler_leaks_parse_error`: confirms old handler forwarded non-opaque text
- `test_patched_webhook_handler_hides_parse_error`: 3 endpoints x malformed body; checks `Expecting`, `line `, `column `, `char ` absent from response
- `test_patched_webhook_handler_returns_correct_code`: confirms correct error code returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)