### PR TITLE
fix(data-table): remove disabled pagination Previous/Next from keyboard tab order

### DIFF
--- a/hushh-webapp/components/app-ui/data-table.tsx
+++ b/hushh-webapp/components/app-ui/data-table.tsx
@@ -442,6 +442,7 @@ export function DataTable<TData, TValue>({
                   <PaginationPrevious
                     href="#"
                     aria-disabled={!table.getCanPreviousPage()}
+                    tabIndex={!table.getCanPreviousPage() ? -1 : undefined}
                     className={cn(
                       !table.getCanPreviousPage() && "pointer-events-none opacity-50"
                     )}
@@ -485,6 +486,7 @@ export function DataTable<TData, TValue>({
                   <PaginationNext
                     href="#"
                     aria-disabled={!table.getCanNextPage()}
+                    tabIndex={!table.getCanNextPage() ? -1 : undefined}
                     className={cn(!table.getCanNextPage() && "pointer-events-none opacity-50")}
                     onClick={(event) => {
                       event.preventDefault();


### PR DESCRIPTION
## Summary

`aria-disabled` on an `<a>` element does not remove it from the keyboard
Tab sequence. Disabled pagination Previous/Next controls could therefore
still receive keyboard focus despite being inert.

## Change

Adds `tabIndex={-1}` to `PaginationPrevious` and `PaginationNext` when
their corresponding pagination action is unavailable.

`aria-disabled` is intentionally preserved so assistive technologies can
continue announcing disabled state semantics in browse/virtual cursor mode.

## Scope

Two attribute additions in `components/app-ui/data-table.tsx`.

No visual changes.
No API changes.
No pagination primitive changes.
No runtime behavior changes outside keyboard focus behavior for disabled controls.

## Validation

```bash id="u4r7x1"
npx vitest run
```
