### PR TITLE
fix(onboarding): add aria-current="step" to active PreviewCarouselStep slide

### DIFF
--- a/hushh-webapp/components/onboarding/PreviewCarouselStep.tsx
+++ b/hushh-webapp/components/onboarding/PreviewCarouselStep.tsx
@@ -223,6 +223,7 @@ export function PreviewCarouselStep({ onContinue }: { onContinue: () => void }) 
                 {slides.map((slide, idx) => (
                   <CarouselItem
                     key={idx}
+                    aria-current={idx === selectedIndex ? "step" : undefined}
                     className="basis-full pl-0 flex items-center justify-center"
                   >
                     <div className="flex w-full min-h-[clamp(24rem,50vh,31rem)] items-center justify-center px-4 sm:px-6 md:px-8 py-3">


### PR DESCRIPTION
## Summary

The onboarding carousel currently provides no programmatic indication of
the active onboarding step for assistive technologies.

The decorative dot indicators are intentionally `aria-hidden`, so the
semantic active-state signal belongs on the active `CarouselItem`, which
already exposes slide semantics through `role="group"` and
`aria-roledescription="slide"`.

## Change

Adds:

```tsx
aria-current={idx === selectedIndex ? "step" : undefined}
```

to each `CarouselItem` in `PreviewCarouselStep`.

The active slide receives `aria-current="step"`; inactive slides receive
no attribute.

`selectedIndex` is intentionally used instead of `displayIndex` because
it reflects the true active carousel position during transitions.

## Scope

Single attribute addition in
`components/onboarding/PreviewCarouselStep.tsx`.

No visual changes.
No animation changes.
No API changes.
No Carousel primitive changes.
No dependency changes.

## Validation

```bash id="m1v7r3"
npx vitest run
```
