### PR TITLE
fix(marketplace): remove IAM error hint leak on schema-not-ready responses

### DIFF
--- a/consent-protocol/api/routes/marketplace.py
+++ b/consent-protocol/api/routes/marketplace.py
@@ -2,21 +2,24 @@
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import JSONResponse
 
 from hushh_mcp.services.ria_iam_service import IAMSchemaNotReadyError, RIAIAMService
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/api/marketplace", tags=["Marketplace"])
 
 
-def _iam_schema_not_ready_response(message: str | None = None) -> JSONResponse:
+def _iam_schema_not_ready_response() -> JSONResponse:
     return JSONResponse(
         status_code=503,
         content={
-            "error": message or "IAM schema is not ready",
+            "error": "IAM service is temporarily unavailable.",
             "code": "IAM_SCHEMA_NOT_READY",
-            "hint": "Run `python db/migrate.py --iam` and `python db/verify/verify_iam_schema.py`.",
         },
     )
 
@@ -38,7 +41,8 @@ async def list_marketplace_rias(
         )
         return {"items": items}
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("marketplace.list_rias: IAM schema not ready", exc_info=True)
+        return _iam_schema_not_ready_response()
 
 
 @router.get("/investors")
@@ -51,7 +55,8 @@ async def list_marketplace_investors(
         items = await service.search_marketplace_investors(query=query, limit=limit)
         return {"items": items}
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("marketplace.list_investors: IAM schema not ready", exc_info=True)
+        return _iam_schema_not_ready_response()
 
 
 @router.get("/ria/{ria_id}")
@@ -63,4 +68,5 @@ async def get_marketplace_ria(ria_id: str):
             raise HTTPException(status_code=404, detail="RIA profile not found")
         return profile
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("marketplace.get_ria: IAM schema not ready", exc_info=True)
+        return _iam_schema_not_ready_response()

--- a/consent-protocol/tests/test_marketplace_iam_hint_leak.py
+++ b/consent-protocol/tests/test_marketplace_iam_hint_leak.py
@@ -1,0 +1,109 @@
+"""Tests: marketplace IAM schema error must not leak internal hints or exc detail.
+
+Covers the three public marketplace endpoints that catch IAMSchemaNotReadyError:
+  GET /api/marketplace/rias
+  GET /api/marketplace/investors
+  GET /api/marketplace/ria/{ria_id}
+
+Each endpoint must return 503 with an opaque message -- no migration commands,
+no file paths, no raw exception text.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+INTERNAL_STRINGS = [
+    "db/migrate.py",
+    "verify_iam_schema",
+    "python ",
+    "--iam",
+    "hint",
+    "schema is not ready",
+]
+
+
+def _make_app():
+    from fastapi import FastAPI
+    from api.routes.marketplace import router
+
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+@pytest.fixture()
+def client():
+    return TestClient(_make_app(), raise_server_exceptions=False)
+
+
+def _patch_iam_not_ready(method_name: str):
+    from hushh_mcp.services.ria_iam_service import IAMSchemaNotReadyError
+
+    target = f"api.routes.marketplace.RIAIAMService.{method_name}"
+    return patch(target, new_callable=AsyncMock, side_effect=IAMSchemaNotReadyError("schema missing"))
+
+
+class TestListRiasIAMLeak:
+    def test_returns_503(self, client):
+        with _patch_iam_not_ready("search_marketplace_rias"):
+            resp = client.get("/api/marketplace/rias")
+        assert resp.status_code == 503
+
+    def test_no_hint_field(self, client):
+        with _patch_iam_not_ready("search_marketplace_rias"):
+            resp = client.get("/api/marketplace/rias")
+        assert "hint" not in resp.json()
+
+    def test_no_internal_strings(self, client):
+        with _patch_iam_not_ready("search_marketplace_rias"):
+            resp = client.get("/api/marketplace/rias")
+        body = resp.text.lower()
+        for s in INTERNAL_STRINGS:
+            assert s not in body, f"Leaked internal string in /rias response: {s!r}"
+
+    def test_code_field_present(self, client):
+        with _patch_iam_not_ready("search_marketplace_rias"):
+            resp = client.get("/api/marketplace/rias")
+        assert resp.json().get("code") == "IAM_SCHEMA_NOT_READY"
+
+
+class TestListInvestorsIAMLeak:
+    def test_returns_503(self, client):
+        with _patch_iam_not_ready("search_marketplace_investors"):
+            resp = client.get("/api/marketplace/investors")
+        assert resp.status_code == 503
+
+    def test_no_hint_field(self, client):
+        with _patch_iam_not_ready("search_marketplace_investors"):
+            resp = client.get("/api/marketplace/investors")
+        assert "hint" not in resp.json()
+
+    def test_no_internal_strings(self, client):
+        with _patch_iam_not_ready("search_marketplace_investors"):
+            resp = client.get("/api/marketplace/investors")
+        body = resp.text.lower()
+        for s in INTERNAL_STRINGS:
+            assert s not in body, f"Leaked internal string in /investors response: {s!r}"
+
+
+class TestGetRiaIAMLeak:
+    def test_returns_503(self, client):
+        with _patch_iam_not_ready("get_marketplace_ria_profile"):
+            resp = client.get("/api/marketplace/ria/some-id")
+        assert resp.status_code == 503
+
+    def test_no_hint_field(self, client):
+        with _patch_iam_not_ready("get_marketplace_ria_profile"):
+            resp = client.get("/api/marketplace/ria/some-id")
+        assert "hint" not in resp.json()
+
+    def test_no_internal_strings(self, client):
+        with _patch_iam_not_ready("get_marketplace_ria_profile"):
+            resp = client.get("/api/marketplace/ria/some-id")
+        body = resp.text.lower()
+        for s in INTERNAL_STRINGS:
+            assert s not in body, f"Leaked internal string in /ria profile response: {s!r}"


### PR DESCRIPTION
## Summary

- `_iam_schema_not_ready_response` in `api/routes/marketplace.py` accepted a `message` parameter and embedded raw `IAMSchemaNotReadyError` detail directly into the JSON body
- The response also included a `hint` field containing internal migration commands (`db/migrate.py --iam`, `verify_iam_schema.py`) and file paths
- All three routes are publicly accessible without authentication (`GET /api/marketplace/rias`, `GET /api/marketplace/investors`, `GET /api/marketplace/ria/{ria_id}`)

## Changes

- Remove the `message` parameter from `_iam_schema_not_ready_response`; it now returns a fixed opaque error string
- Drop the `hint` field from the 503 response body
- Move exception detail to `logger.warning(..., exc_info=True)` at each call site
- Add `import logging` and module-level logger

## Tests

`consent-protocol/tests/test_marketplace_iam_hint_leak.py` -- 10 tests across all three routes verifying:
- 503 status is returned
- `hint` field is absent from the response body
- Internal strings (`db/migrate.py`, `verify_iam_schema`, `--iam`, `python `) do not appear anywhere in the response

## CWE

CWE-209: Generation of Error Message Containing Sensitive Information