### PR TITLE
fix(ria): remove IAM error hint leak from schema-not-ready 503 responses

### DIFF
--- a/consent-protocol/api/routes/ria.py
+++ b/consent-protocol/api/routes/ria.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
@@ -14,6 +16,8 @@ from hushh_mcp.services.ria_iam_service import (
     RIAIAMPolicyError,
     RIAIAMService,
 )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/ria", tags=["RIA"])
 
@@ -183,13 +187,12 @@ class RIAClientDetailResponse(BaseModel):
     pkm_updated_at: str | None = None
 
 
-def _iam_schema_not_ready_response(message: str | None = None) -> JSONResponse:
+def _iam_schema_not_ready_response() -> JSONResponse:
     return JSONResponse(
         status_code=503,
         content={
-            "error": message or "IAM schema is not ready",
+            "error": "IAM service is temporarily unavailable.",
             "code": "IAM_SCHEMA_NOT_READY",
-            "hint": "Run `python db/migrate.py --iam` and `python db/verify/verify_iam_schema.py`.",
         },
     )
 
@@ -234,7 +237,8 @@ async def submit_onboarding(
             business_longitude=payload.business_longitude,
         )
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria: IAM schema not ready", exc_info=True)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -271,7 +275,8 @@ async def verify_onboarding_license(
             regulator=payload.regulator,
         )
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria: IAM schema not ready", exc_info=True)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -282,7 +287,8 @@ async def onboarding_status(firebase_uid: str = Depends(require_firebase_auth)):
     try:
         return await service.get_ria_onboarding_status(firebase_uid)
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria: IAM schema not ready", exc_info=True)
+        return _iam_schema_not_ready_response()
 
 
 @router.get("/home")
@@ -291,7 +297,8 @@ async def ria_home(firebase_uid: str = Depends(require_firebase_auth)):
     try:
         return await service.get_ria_home(firebase_uid)
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria: IAM schema not ready", exc_info=True)
+        return _iam_schema_not_ready_response()
 
 
 @router.get("/firms")
@@ -300,7 +307,8 @@ async def ria_firms(firebase_uid: str = Depends(require_firebase_auth)):
     try:
         return {"items": await service.list_ria_firms(firebase_uid)}
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria: IAM schema not ready", exc_info=True)
+        return _iam_schema_not_ready_response()
 
 
 @router.get("/clients")
@@ -324,7 +332,8 @@ async def ria_clients(
             params["limit"] = limit
         return await service.list_ria_clients(firebase_uid, **params)
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria: IAM schema not ready", exc_info=True)
+        return _iam_schema_not_ready_response()
 
 
 @router.get("/clients/{investor_user_id}", response_model=RIAClientDetailResponse)
@@ -336,7 +345,8 @@ async def ria_client_detail(
     try:
         return await service.get_ria_client_detail(firebase_uid, investor_user_id)
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria: IAM schema not ready", exc_info=True)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -347,7 +357,8 @@ async def ria_requests(firebase_uid: str = Depends(require_firebase_auth)):
     try:
         return {"items": await service.list_outgoing_requests(firebase_uid)}
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria: IAM schema not ready", exc_info=True)
+        return _iam_schema_not_ready_response()
 
 
 @router.get("/request-bundles")
@@ -356,7 +367,8 @@ async def ria_request_bundles(firebase_uid: str = Depends(require_firebase_auth)
     try:
         return {"items": await service.list_ria_request_bundles(firebase_uid)}
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria: IAM schema not ready", exc_info=True)
+        return _iam_schema_not_ready_response()
 
 
 @router.get("/request-scopes")
@@ -365,7 +377,8 @@ async def ria_request_scopes(firebase_uid: str = Depends(require_firebase_auth))
     try:
         return {"items": await service.list_requestable_scope_templates(firebase_uid)}
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria: IAM schema not ready", exc_info=True)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -376,7 +389,8 @@ async def ria_invites(firebase_uid: str = Depends(require_firebase_auth)):
     try:
         return {"items": await service.list_ria_invites(firebase_uid)}
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria: IAM schema not ready", exc_info=True)
+        return _iam_schema_not_ready_response()
 
 
 @router.post("/invites")
@@ -396,7 +410,8 @@ async def create_ria_invites(
             targets=[target.model_dump() for target in payload.targets],
         )
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria: IAM schema not ready", exc_info=True)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -415,7 +430,8 @@ async def update_ria_marketplace_discoverability(
             strategy_summary=payload.strategy_summary,
         )
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria: IAM schema not ready", exc_info=True)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -440,7 +456,8 @@ async def create_ria_request(
             reason=payload.reason,
         )
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria: IAM schema not ready", exc_info=True)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -462,7 +479,8 @@ async def create_ria_request_bundle(
             reason=payload.reason,
         )
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria: IAM schema not ready", exc_info=True)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -537,7 +555,8 @@ async def ria_pick_uploads(firebase_uid: str = Depends(require_firebase_auth)):
     try:
         return await service.get_active_ria_pick_package(firebase_uid)
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria: IAM schema not ready", exc_info=True)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -561,7 +580,8 @@ async def parse_ria_picks_csv(
             )
         }
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria: IAM schema not ready", exc_info=True)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -585,7 +605,8 @@ async def upload_ria_picks(
             retire_legacy=payload.retire_legacy,
         )
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria: IAM schema not ready", exc_info=True)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -599,7 +620,8 @@ async def ria_workspace(
     try:
         return await service.get_ria_workspace(firebase_uid, investor_user_id)
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria: IAM schema not ready", exc_info=True)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
@@ -618,6 +640,7 @@ async def set_ria_client_picks_share(
             enabled=payload.enabled,
         )
     except IAMSchemaNotReadyError as exc:
-        return _iam_schema_not_ready_response(str(exc))
+        logger.warning("ria: IAM schema not ready", exc_info=True)
+        return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc

--- a/consent-protocol/tests/test_ria_iam_hint_leak.py
+++ b/consent-protocol/tests/test_ria_iam_hint_leak.py
@@ -1,0 +1,107 @@
+"""Tests: RIA route IAM schema error must not leak internal hints or exc detail.
+
+Covers a sample of the RIA routes that catch IAMSchemaNotReadyError:
+  POST /api/ria/onboarding/submit
+  GET  /api/ria/onboarding/status
+  GET  /api/ria/home
+  GET  /api/ria/clients
+  GET  /api/ria/invites
+
+Each must return 503 with an opaque message -- no migration commands,
+no file paths, no raw exception text.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.middleware import require_firebase_auth
+
+INTERNAL_STRINGS = [
+    "db/migrate.py",
+    "verify_iam_schema",
+    "python ",
+    "--iam",
+    "hint",
+    "schema is not ready",
+]
+
+
+def _make_app():
+    from fastapi import FastAPI
+    from api.routes.ria import router
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[require_firebase_auth] = lambda: "stub-uid"
+    return app
+
+
+@pytest.fixture()
+def client():
+    return TestClient(_make_app(), raise_server_exceptions=False)
+
+
+def _patch_not_ready(method_name: str):
+    from hushh_mcp.services.ria_iam_service import IAMSchemaNotReadyError
+
+    target = f"api.routes.ria.RIAIAMService.{method_name}"
+    return patch(target, new_callable=AsyncMock, side_effect=IAMSchemaNotReadyError())
+
+
+def _assert_opaque_503(resp):
+    assert resp.status_code == 503
+    body = resp.json()
+    assert "hint" not in body
+    text = resp.text.lower()
+    for s in INTERNAL_STRINGS:
+        assert s not in text, f"Leaked internal string: {s!r}"
+    assert body.get("code") == "IAM_SCHEMA_NOT_READY"
+
+
+class TestOnboardingSubmitIAMLeak:
+    def test_opaque_503(self, client):
+        with _patch_not_ready("submit_ria_onboarding"):
+            resp = client.post(
+                "/api/ria/onboarding/submit",
+                json={"display_name": "Test Advisor"},
+            )
+        _assert_opaque_503(resp)
+
+
+class TestOnboardingStatusIAMLeak:
+    def test_opaque_503(self, client):
+        with _patch_not_ready("get_ria_onboarding_status"):
+            resp = client.get("/api/ria/onboarding/status")
+        _assert_opaque_503(resp)
+
+
+class TestRiaHomeIAMLeak:
+    def test_opaque_503(self, client):
+        with _patch_not_ready("get_ria_home"):
+            resp = client.get("/api/ria/home")
+        _assert_opaque_503(resp)
+
+
+class TestRiaInvitesIAMLeak:
+    def test_opaque_503(self, client):
+        with _patch_not_ready("list_ria_invites"):
+            resp = client.get("/api/ria/invites")
+        _assert_opaque_503(resp)
+
+
+class TestRiaRequestBundlesIAMLeak:
+    def test_opaque_503(self, client):
+        with _patch_not_ready("list_ria_request_bundles"):
+            resp = client.get("/api/ria/request-bundles")
+        _assert_opaque_503(resp)
+
+
+class TestRiaPicksIAMLeak:
+    def test_opaque_503(self, client):
+        with _patch_not_ready("get_active_ria_pick_package"):
+            resp = client.get("/api/ria/picks")
+        _assert_opaque_503(resp)


### PR DESCRIPTION
## Summary

- `_iam_schema_not_ready_response` in `api/routes/ria.py` accepted a `message` parameter and embedded raw `IAMSchemaNotReadyError` detail directly into the JSON body
- `IAMSchemaNotReadyError.__str__` returns a message that includes migration commands (`db/migrate.py --iam`, `verify_iam_schema.py`) by default
- The response also included a `hint` field containing those same internal migration commands
- 20 handler sites across all RIA routes passed `str(exc)` as the message argument

## Changes

- Remove the `message` parameter from `_iam_schema_not_ready_response`; it now returns a fixed opaque error string
- Drop the `hint` field from the 503 response body
- Add `logger.warning("ria: IAM schema not ready", exc_info=True)` before each of the 20 return sites
- Add `import logging` and module-level logger

## Tests

`consent-protocol/tests/test_ria_iam_hint_leak.py` -- 6 tests covering representative routes:
- `POST /api/ria/onboarding/submit`
- `GET /api/ria/onboarding/status`
- `GET /api/ria/home`
- `GET /api/ria/invites`
- `GET /api/ria/request-bundles`
- `GET /api/ria/picks`

Each test verifies 503 status, absence of `hint` field, and absence of internal strings (`db/migrate.py`, `verify_iam_schema`, `--iam`, `python `).

## CWE

CWE-209: Generation of Error Message Containing Sensitive Information