### PR TITLE
fix(ria): remove IAM hint leak from schema-not-ready 503 responses

### DIFF
--- a/consent-protocol/api/routes/ria.py
+++ b/consent-protocol/api/routes/ria.py
@@ -239,7 +239,7 @@ async def submit_onboarding(
             business_latitude=payload.business_latitude,
             business_longitude=payload.business_longitude,
         )
-    except IAMSchemaNotReadyError as exc:
+    except IAMSchemaNotReadyError:
         logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
@@ -277,7 +277,7 @@ async def verify_onboarding_license(
             license_number=payload.license_number,
             regulator=payload.regulator,
         )
-    except IAMSchemaNotReadyError as exc:
+    except IAMSchemaNotReadyError:
         logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
@@ -289,7 +289,7 @@ async def onboarding_status(firebase_uid: str = Depends(require_firebase_auth)):
     service = RIAIAMService()
     try:
         return await service.get_ria_onboarding_status(firebase_uid)
-    except IAMSchemaNotReadyError as exc:
+    except IAMSchemaNotReadyError:
         logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
 
@@ -299,7 +299,7 @@ async def ria_home(firebase_uid: str = Depends(require_firebase_auth)):
     service = RIAIAMService()
     try:
         return await service.get_ria_home(firebase_uid)
-    except IAMSchemaNotReadyError as exc:
+    except IAMSchemaNotReadyError:
         logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
 
@@ -309,7 +309,7 @@ async def ria_firms(firebase_uid: str = Depends(require_firebase_auth)):
     service = RIAIAMService()
     try:
         return {"items": await service.list_ria_firms(firebase_uid)}
-    except IAMSchemaNotReadyError as exc:
+    except IAMSchemaNotReadyError:
         logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
 
@@ -334,7 +334,7 @@ async def ria_clients(
         if limit != 50:
             params["limit"] = limit
         return await service.list_ria_clients(firebase_uid, **params)
-    except IAMSchemaNotReadyError as exc:
+    except IAMSchemaNotReadyError:
         logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
 
@@ -347,7 +347,7 @@ async def ria_client_detail(
     service = RIAIAMService()
     try:
         return await service.get_ria_client_detail(firebase_uid, investor_user_id)
-    except IAMSchemaNotReadyError as exc:
+    except IAMSchemaNotReadyError:
         logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
@@ -359,7 +359,7 @@ async def ria_requests(firebase_uid: str = Depends(require_firebase_auth)):
     service = ConsentCenterService()
     try:
         return {"items": await service.list_outgoing_requests(firebase_uid)}
-    except IAMSchemaNotReadyError as exc:
+    except IAMSchemaNotReadyError:
         logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
 
@@ -369,7 +369,7 @@ async def ria_request_bundles(firebase_uid: str = Depends(require_firebase_auth)
     service = RIAIAMService()
     try:
         return {"items": await service.list_ria_request_bundles(firebase_uid)}
-    except IAMSchemaNotReadyError as exc:
+    except IAMSchemaNotReadyError:
         logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
 
@@ -379,7 +379,7 @@ async def ria_request_scopes(firebase_uid: str = Depends(require_firebase_auth))
     service = RIAIAMService()
     try:
         return {"items": await service.list_requestable_scope_templates(firebase_uid)}
-    except IAMSchemaNotReadyError as exc:
+    except IAMSchemaNotReadyError:
         logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
@@ -391,7 +391,7 @@ async def ria_invites(firebase_uid: str = Depends(require_firebase_auth)):
     service = RIAIAMService()
     try:
         return {"items": await service.list_ria_invites(firebase_uid)}
-    except IAMSchemaNotReadyError as exc:
+    except IAMSchemaNotReadyError:
         logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
 
@@ -412,7 +412,7 @@ async def create_ria_invites(
             reason=payload.reason,
             targets=[target.model_dump() for target in payload.targets],
         )
-    except IAMSchemaNotReadyError as exc:
+    except IAMSchemaNotReadyError:
         logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
@@ -432,7 +432,7 @@ async def update_ria_marketplace_discoverability(
             headline=payload.headline,
             strategy_summary=payload.strategy_summary,
         )
-    except IAMSchemaNotReadyError as exc:
+    except IAMSchemaNotReadyError:
         logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
@@ -458,7 +458,7 @@ async def create_ria_request(
             firm_id=payload.firm_id,
             reason=payload.reason,
         )
-    except IAMSchemaNotReadyError as exc:
+    except IAMSchemaNotReadyError:
         logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
@@ -481,7 +481,7 @@ async def create_ria_request_bundle(
             firm_id=payload.firm_id,
             reason=payload.reason,
         )
-    except IAMSchemaNotReadyError as exc:
+    except IAMSchemaNotReadyError:
         logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
@@ -557,7 +557,7 @@ async def ria_pick_uploads(firebase_uid: str = Depends(require_firebase_auth)):
     service = RIAIAMService()
     try:
         return await service.get_active_ria_pick_package(firebase_uid)
-    except IAMSchemaNotReadyError as exc:
+    except IAMSchemaNotReadyError:
         logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
@@ -582,7 +582,7 @@ async def parse_ria_picks_csv(
                 screening_sections=payload.screening_sections,
             )
         }
-    except IAMSchemaNotReadyError as exc:
+    except IAMSchemaNotReadyError:
         logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
@@ -607,7 +607,7 @@ async def upload_ria_picks(
             source_manifest_revision=payload.source_manifest_revision,
             retire_legacy=payload.retire_legacy,
         )
-    except IAMSchemaNotReadyError as exc:
+    except IAMSchemaNotReadyError:
         logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
@@ -622,7 +622,7 @@ async def ria_workspace(
     service = RIAIAMService()
     try:
         return await service.get_ria_workspace(firebase_uid, investor_user_id)
-    except IAMSchemaNotReadyError as exc:
+    except IAMSchemaNotReadyError:
         logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
@@ -642,7 +642,7 @@ async def set_ria_client_picks_share(
             investor_user_id=investor_user_id,
             enabled=payload.enabled,
         )
-    except IAMSchemaNotReadyError as exc:
+    except IAMSchemaNotReadyError:
         logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:

--- a/consent-protocol/api/routes/ria.py
+++ b/consent-protocol/api/routes/ria.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request
@@ -16,6 +17,8 @@ from hushh_mcp.services.ria_iam_service import (
     RIAIAMPolicyError,
     RIAIAMService,
 )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/ria", tags=["RIA"])
 
@@ -82,13 +85,6 @@ class RIAOnboardingVerifyNameRequest(BaseModel):
 class RIAOnboardingVerifyLicenseRequest(BaseModel):
     license_number: str = Field(..., min_length=1)
     regulator: str | None = None
-    force_live_verification: bool = False
-
-
-class RIAProfileRefreshLicenseRequest(BaseModel):
-    license_number: str = Field(..., min_length=1)
-    regulator: str | None = None
-    force_live_verification: bool = False
 
 
 class RIAConsentRequestCreate(BaseModel):
@@ -198,7 +194,7 @@ def _iam_schema_not_ready_response() -> JSONResponse:
     return JSONResponse(
         status_code=503,
         content={
-            "error": "RIA verification service is temporarily unavailable",
+            "error": "IAM service is temporarily unavailable.",
             "code": "IAM_SCHEMA_NOT_READY",
         },
     )
@@ -243,7 +239,8 @@ async def submit_onboarding(
             business_latitude=payload.business_latitude,
             business_longitude=payload.business_longitude,
         )
-    except IAMSchemaNotReadyError:
+    except IAMSchemaNotReadyError as exc:
+        logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
@@ -279,9 +276,9 @@ async def verify_onboarding_license(
             firebase_uid,
             license_number=payload.license_number,
             regulator=payload.regulator,
-            force_live_verification=payload.force_live_verification,
         )
-    except IAMSchemaNotReadyError:
+    except IAMSchemaNotReadyError as exc:
+        logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
@@ -292,39 +289,9 @@ async def onboarding_status(firebase_uid: str = Depends(require_firebase_auth)):
     service = RIAIAMService()
     try:
         return await service.get_ria_onboarding_status(firebase_uid)
-    except IAMSchemaNotReadyError:
+    except IAMSchemaNotReadyError as exc:
+        logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
-
-
-@router.post("/profile/refresh-license")
-@limiter.limit("6/minute")
-async def refresh_profile_license(
-    payload: RIAProfileRefreshLicenseRequest,
-    request: Request,
-    firebase_uid: str = Depends(require_firebase_auth),
-):
-    service = RIAIAMService()
-    try:
-        _ = request
-        return await service.refresh_ria_profile_from_license(
-            firebase_uid,
-            license_number=payload.license_number,
-            regulator=payload.regulator,
-            force_live_verification=payload.force_live_verification,
-        )
-    except IAMSchemaNotReadyError:
-        return _iam_schema_not_ready_response()
-    except RIAIAMPolicyError as exc:
-        if exc.status_code == 409:
-            return JSONResponse(
-                status_code=409,
-                content={
-                    "error": str(exc),
-                    "code": "RIA_ONBOARDING_REQUIRED",
-                    "route": "/ria/onboarding",
-                },
-            )
-        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
 
 @router.get("/home")
@@ -332,7 +299,8 @@ async def ria_home(firebase_uid: str = Depends(require_firebase_auth)):
     service = RIAIAMService()
     try:
         return await service.get_ria_home(firebase_uid)
-    except IAMSchemaNotReadyError:
+    except IAMSchemaNotReadyError as exc:
+        logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
 
 
@@ -341,7 +309,8 @@ async def ria_firms(firebase_uid: str = Depends(require_firebase_auth)):
     service = RIAIAMService()
     try:
         return {"items": await service.list_ria_firms(firebase_uid)}
-    except IAMSchemaNotReadyError:
+    except IAMSchemaNotReadyError as exc:
+        logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
 
 
@@ -365,7 +334,8 @@ async def ria_clients(
         if limit != 50:
             params["limit"] = limit
         return await service.list_ria_clients(firebase_uid, **params)
-    except IAMSchemaNotReadyError:
+    except IAMSchemaNotReadyError as exc:
+        logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
 
 
@@ -377,7 +347,8 @@ async def ria_client_detail(
     service = RIAIAMService()
     try:
         return await service.get_ria_client_detail(firebase_uid, investor_user_id)
-    except IAMSchemaNotReadyError:
+    except IAMSchemaNotReadyError as exc:
+        logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
@@ -388,7 +359,8 @@ async def ria_requests(firebase_uid: str = Depends(require_firebase_auth)):
     service = ConsentCenterService()
     try:
         return {"items": await service.list_outgoing_requests(firebase_uid)}
-    except IAMSchemaNotReadyError:
+    except IAMSchemaNotReadyError as exc:
+        logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
 
 
@@ -397,7 +369,8 @@ async def ria_request_bundles(firebase_uid: str = Depends(require_firebase_auth)
     service = RIAIAMService()
     try:
         return {"items": await service.list_ria_request_bundles(firebase_uid)}
-    except IAMSchemaNotReadyError:
+    except IAMSchemaNotReadyError as exc:
+        logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
 
 
@@ -406,7 +379,8 @@ async def ria_request_scopes(firebase_uid: str = Depends(require_firebase_auth))
     service = RIAIAMService()
     try:
         return {"items": await service.list_requestable_scope_templates(firebase_uid)}
-    except IAMSchemaNotReadyError:
+    except IAMSchemaNotReadyError as exc:
+        logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
@@ -417,7 +391,8 @@ async def ria_invites(firebase_uid: str = Depends(require_firebase_auth)):
     service = RIAIAMService()
     try:
         return {"items": await service.list_ria_invites(firebase_uid)}
-    except IAMSchemaNotReadyError:
+    except IAMSchemaNotReadyError as exc:
+        logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
 
 
@@ -437,7 +412,8 @@ async def create_ria_invites(
             reason=payload.reason,
             targets=[target.model_dump() for target in payload.targets],
         )
-    except IAMSchemaNotReadyError:
+    except IAMSchemaNotReadyError as exc:
+        logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
@@ -456,7 +432,8 @@ async def update_ria_marketplace_discoverability(
             headline=payload.headline,
             strategy_summary=payload.strategy_summary,
         )
-    except IAMSchemaNotReadyError:
+    except IAMSchemaNotReadyError as exc:
+        logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
@@ -481,7 +458,8 @@ async def create_ria_request(
             firm_id=payload.firm_id,
             reason=payload.reason,
         )
-    except IAMSchemaNotReadyError:
+    except IAMSchemaNotReadyError as exc:
+        logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
@@ -503,7 +481,8 @@ async def create_ria_request_bundle(
             firm_id=payload.firm_id,
             reason=payload.reason,
         )
-    except IAMSchemaNotReadyError:
+    except IAMSchemaNotReadyError as exc:
+        logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
@@ -578,7 +557,8 @@ async def ria_pick_uploads(firebase_uid: str = Depends(require_firebase_auth)):
     service = RIAIAMService()
     try:
         return await service.get_active_ria_pick_package(firebase_uid)
-    except IAMSchemaNotReadyError:
+    except IAMSchemaNotReadyError as exc:
+        logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
@@ -602,7 +582,8 @@ async def parse_ria_picks_csv(
                 screening_sections=payload.screening_sections,
             )
         }
-    except IAMSchemaNotReadyError:
+    except IAMSchemaNotReadyError as exc:
+        logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
@@ -626,7 +607,8 @@ async def upload_ria_picks(
             source_manifest_revision=payload.source_manifest_revision,
             retire_legacy=payload.retire_legacy,
         )
-    except IAMSchemaNotReadyError:
+    except IAMSchemaNotReadyError as exc:
+        logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
@@ -640,7 +622,8 @@ async def ria_workspace(
     service = RIAIAMService()
     try:
         return await service.get_ria_workspace(firebase_uid, investor_user_id)
-    except IAMSchemaNotReadyError:
+    except IAMSchemaNotReadyError as exc:
+        logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
@@ -659,7 +642,8 @@ async def set_ria_client_picks_share(
             investor_user_id=investor_user_id,
             enabled=payload.enabled,
         )
-    except IAMSchemaNotReadyError:
+    except IAMSchemaNotReadyError as exc:
+        logger.warning("ria: IAM schema not ready", exc_info=True)
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc

--- a/consent-protocol/tests/test_ria_iam_hint_leak.py
+++ b/consent-protocol/tests/test_ria_iam_hint_leak.py
@@ -1,0 +1,107 @@
+"""Tests: RIA route IAM schema error must not leak internal hints or exc detail.
+
+Covers a sample of the RIA routes that catch IAMSchemaNotReadyError:
+  POST /api/ria/onboarding/submit
+  GET  /api/ria/onboarding/status
+  GET  /api/ria/home
+  GET  /api/ria/clients
+  GET  /api/ria/invites
+
+Each must return 503 with an opaque message -- no migration commands,
+no file paths, no raw exception text.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.middleware import require_firebase_auth
+
+INTERNAL_STRINGS = [
+    "db/migrate.py",
+    "verify_iam_schema",
+    "python ",
+    "--iam",
+    "hint",
+    "schema is not ready",
+]
+
+
+def _make_app():
+    from fastapi import FastAPI
+    from api.routes.ria import router
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[require_firebase_auth] = lambda: "stub-uid"
+    return app
+
+
+@pytest.fixture()
+def client():
+    return TestClient(_make_app(), raise_server_exceptions=False)
+
+
+def _patch_not_ready(method_name: str):
+    from hushh_mcp.services.ria_iam_service import IAMSchemaNotReadyError
+
+    target = f"api.routes.ria.RIAIAMService.{method_name}"
+    return patch(target, new_callable=AsyncMock, side_effect=IAMSchemaNotReadyError())
+
+
+def _assert_opaque_503(resp):
+    assert resp.status_code == 503
+    body = resp.json()
+    assert "hint" not in body
+    text = resp.text.lower()
+    for s in INTERNAL_STRINGS:
+        assert s not in text, f"Leaked internal string: {s!r}"
+    assert body.get("code") == "IAM_SCHEMA_NOT_READY"
+
+
+class TestOnboardingSubmitIAMLeak:
+    def test_opaque_503(self, client):
+        with _patch_not_ready("submit_ria_onboarding"):
+            resp = client.post(
+                "/api/ria/onboarding/submit",
+                json={"display_name": "Test Advisor"},
+            )
+        _assert_opaque_503(resp)
+
+
+class TestOnboardingStatusIAMLeak:
+    def test_opaque_503(self, client):
+        with _patch_not_ready("get_ria_onboarding_status"):
+            resp = client.get("/api/ria/onboarding/status")
+        _assert_opaque_503(resp)
+
+
+class TestRiaHomeIAMLeak:
+    def test_opaque_503(self, client):
+        with _patch_not_ready("get_ria_home"):
+            resp = client.get("/api/ria/home")
+        _assert_opaque_503(resp)
+
+
+class TestRiaInvitesIAMLeak:
+    def test_opaque_503(self, client):
+        with _patch_not_ready("list_ria_invites"):
+            resp = client.get("/api/ria/invites")
+        _assert_opaque_503(resp)
+
+
+class TestRiaRequestBundlesIAMLeak:
+    def test_opaque_503(self, client):
+        with _patch_not_ready("list_ria_request_bundles"):
+            resp = client.get("/api/ria/request-bundles")
+        _assert_opaque_503(resp)
+
+
+class TestRiaPicksIAMLeak:
+    def test_opaque_503(self, client):
+        with _patch_not_ready("get_active_ria_pick_package"):
+            resp = client.get("/api/ria/picks")
+        _assert_opaque_503(resp)

--- a/consent-protocol/tests/test_ria_iam_hint_leak.py
+++ b/consent-protocol/tests/test_ria_iam_hint_leak.py
@@ -32,6 +32,7 @@ INTERNAL_STRINGS = [
 
 def _make_app():
     from fastapi import FastAPI
+
     from api.routes.ria import router
 
     app = FastAPI()


### PR DESCRIPTION
## Summary

- `_iam_schema_not_ready_response` in `api/routes/ria.py` was called with `str(exc)` at 20 handler sites
- `IAMSchemaNotReadyError.__str__` embeds the full default message including internal migration commands (`db/migrate.py --iam`, `verify_iam_schema.py`)
- The response also included a `hint` field exposing those same commands to callers

## Changes

- Changed the helper to accept no arguments and return a fixed opaque error string with no hint field
- Routed each exc_info to a warning-level log
- Updated all 20 `IAMSchemaNotReadyError` catch blocks

## Security

Fixes information disclosure (CWE-209): internal system paths and migration command names were returned to API callers.

## Test plan

- [ ] Run `pytest consent-protocol/tests/test_ria_iam_hint_leak.py`
- [ ] Verify 503 responses no longer contain `hint` field or migration command strings
- [ ] Confirm warning logs still capture the underlying exception

Closes #1759