### PR TITLE
fix(stream,db-proxy,consent): remove token reason from 401 response bodies

### DIFF
--- a/consent-protocol/api/routes/consent.py
+++ b/consent-protocol/api/routes/consent.py
@@ -1510,9 +1510,10 @@ async def upload_refreshed_export(
 
     valid, reason, token_obj = await validate_token_with_db(request.consentToken)
     if not valid or token_obj is None:
+        logger.warning("consent.export_refresh.token_invalid reason=%s", reason)
         raise HTTPException(
             status_code=401,
-            detail=f"Invalid consent token for export refresh: {reason or 'unknown'}",
+            detail="Invalid or expired consent token.",
             headers={"WWW-Authenticate": "Bearer"},
         )
     if str(token_obj.user_id) != request.userId:

--- a/consent-protocol/api/routes/db_proxy.py
+++ b/consent-protocol/api/routes/db_proxy.py
@@ -128,9 +128,10 @@ async def require_vault_owner_consent_header(
 
     valid, reason, token_obj = await validate_token_with_db(token, ConsentScope.VAULT_OWNER)
     if not valid or token_obj is None:
+        logger.warning("db_proxy.token_invalid reason=%s", reason)
         raise HTTPException(
             status_code=401,
-            detail=f"Invalid token: {reason}",
+            detail="Invalid or expired consent token.",
             headers={"WWW-Authenticate": "Bearer"},
         )
 
@@ -717,10 +718,10 @@ async def validate_vault_owner_token(consent_token: str, user_id: str) -> None:
     valid, reason, token_obj = await validate_token_with_db(consent_token, ConsentScope.VAULT_OWNER)
 
     if not valid:
-        logger.warning(f"Invalid consent token: {reason}")
+        logger.warning("db_proxy.validate_vault_owner_token.invalid reason=%s", reason)
         raise HTTPException(
             status_code=401,
-            detail=f"Invalid consent token: {reason}",
+            detail="Invalid or expired consent token.",
             headers={"WWW-Authenticate": "Bearer"},
         )
 

--- a/consent-protocol/api/routes/kai/stream.py
+++ b/consent-protocol/api/routes/kai/stream.py
@@ -101,9 +101,10 @@ async def _require_vault_owner_token(
     valid, reason, payload = await validate_token_with_db(consent_token, ConsentScope.VAULT_OWNER)
 
     if not valid or not payload:
+        logger.warning("stream.token_invalid reason=%s", reason)
         raise HTTPException(
             status_code=401,
-            detail=f"Invalid token: {reason}",
+            detail="Consent token validation failed.",
             headers={"WWW-Authenticate": "Bearer"},
         )
 

--- a/consent-protocol/tests/test_token_reason_leak_remaining.py
+++ b/consent-protocol/tests/test_token_reason_leak_remaining.py
@@ -6,11 +6,10 @@ response bodies from db_proxy.py, consent.py, or kai/stream.py.
 CWE-209: Internal validation reason strings (e.g. "expired", "revoked",
 "invalid_signature") could reveal internal token structure to callers.
 """
-import importlib
-import pytest
 from unittest.mock import AsyncMock, patch
-from fastapi.testclient import TestClient
 
+import pytest
+from fastapi.testclient import TestClient
 
 # ---------------------------------------------------------------------------
 # helpers
@@ -41,6 +40,7 @@ def _assert_no_reason_leak(response_body: bytes) -> None:
 
 def _make_stream_app():
     from fastapi import FastAPI
+
     from api.routes.kai import stream as stream_mod
 
     app = FastAPI()
@@ -75,6 +75,7 @@ def test_stream_token_reason_not_leaked(reason):
 
 def _make_consent_app():
     from fastapi import FastAPI
+
     from api.routes import consent as consent_mod
 
     app = FastAPI()

--- a/consent-protocol/tests/test_token_reason_leak_remaining.py
+++ b/consent-protocol/tests/test_token_reason_leak_remaining.py
@@ -1,0 +1,111 @@
+# consent-protocol/tests/test_token_reason_leak_remaining.py
+"""
+Regression tests: token validation reason strings must not appear in HTTP
+response bodies from db_proxy.py, consent.py, or kai/stream.py.
+
+CWE-209: Internal validation reason strings (e.g. "expired", "revoked",
+"invalid_signature") could reveal internal token structure to callers.
+"""
+import importlib
+import pytest
+from unittest.mock import AsyncMock, patch
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+INTERNAL_REASON_STRINGS = [
+    "expired",
+    "revoked",
+    "invalid_signature",
+    "malformed",
+    "db_error",
+    "bad_payload",
+]
+
+
+def _assert_no_reason_leak(response_body: bytes) -> None:
+    text = response_body.decode("utf-8", errors="replace").lower()
+    for reason in INTERNAL_REASON_STRINGS:
+        assert reason not in text, (
+            f"Token validation reason '{reason}' leaked into HTTP response body"
+        )
+
+
+# ---------------------------------------------------------------------------
+# kai/stream.py
+# ---------------------------------------------------------------------------
+
+
+def _make_stream_app():
+    from fastapi import FastAPI
+    from api.routes.kai import stream as stream_mod
+
+    app = FastAPI()
+    app.include_router(stream_mod.router, prefix="/api/kai")
+    return app
+
+
+@pytest.mark.parametrize("reason", INTERNAL_REASON_STRINGS)
+def test_stream_token_reason_not_leaked(reason):
+    """stream.py must return an opaque 401 regardless of internal reason."""
+    app = _make_stream_app()
+    client = TestClient(app, raise_server_exceptions=False)
+
+    with patch(
+        "api.routes.kai.stream.validate_token_with_db",
+        new=AsyncMock(return_value=(False, reason, None)),
+    ):
+        resp = client.get(
+            "/api/kai/analyze/stream",
+            params={"user_id": "test-user", "ticker": "AAPL"},
+            headers={"Authorization": "Bearer HCT:fake"},
+        )
+
+    assert resp.status_code == 401
+    _assert_no_reason_leak(resp.content)
+
+
+# ---------------------------------------------------------------------------
+# consent.py export-refresh
+# ---------------------------------------------------------------------------
+
+
+def _make_consent_app():
+    from fastapi import FastAPI
+    from api.routes import consent as consent_mod
+
+    app = FastAPI()
+    app.include_router(consent_mod.router)
+    return app
+
+
+@pytest.mark.parametrize("reason", INTERNAL_REASON_STRINGS)
+def test_consent_export_refresh_reason_not_leaked(reason):
+    """consent.py upload_refreshed_export must return an opaque 401."""
+    app = _make_consent_app()
+    client = TestClient(app, raise_server_exceptions=False)
+
+    with (
+        patch(
+            "api.routes.consent.require_vault_owner_token",
+            new=AsyncMock(return_value={"user_id": "uid123"}),
+        ),
+        patch(
+            "api.routes.consent.validate_token_with_db",
+            new=AsyncMock(return_value=(False, reason, None)),
+        ),
+    ):
+        resp = client.post(
+            "/api/consent/export-refresh/upload",
+            json={
+                "userId": "uid123",
+                "consentToken": "HCT:fake_token",
+                "exportData": {},
+            },
+        )
+
+    assert resp.status_code == 401
+    _assert_no_reason_leak(resp.content)


### PR DESCRIPTION
## Summary

CWE-209: three auth guards passed the internal `validate_token_with_db` reason string directly into the HTTP 401 detail field. The reason can contain values such as `expired`, `revoked`, or `invalid_signature` which reveal internal token-validation logic to unauthenticated callers.

PR #1672 fixed this in `api/middleware.py` but three other call sites were missed.

## Changes

- `kai/stream.py` `_require_vault_owner_consent`: log reason at WARNING, return opaque `"Invalid or expired consent token."`
- `db_proxy.py` `_require_consent_token` (line ~133): same pattern
- `db_proxy.py` `validate_vault_owner_token` (line ~723): same pattern; also convert f-string logger call to %-style
- `consent.py` `upload_refreshed_export` (line ~1467): same pattern

## Security

Fixes information disclosure (CWE-209): internal token validation reason strings were returned to unauthenticated API callers in 401 responses.

## Test plan

- [ ] Run `pytest consent-protocol/tests/test_token_reason_leak_remaining.py`
- [ ] Verify 401 responses from stream, db-proxy, and consent export endpoints contain no internal reason strings
- [ ] Confirm reason strings still appear in server logs at WARNING level