### PR TITLE
fix(portfolio): add max_length bounds to path, query, and form params (CWE-400)

### DIFF
--- a/consent-protocol/api/routes/kai/portfolio.py
+++ b/consent-protocol/api/routes/kai/portfolio.py
@@ -26,7 +26,7 @@ from collections import Counter
 from datetime import datetime, timezone
 from typing import Any, AsyncGenerator, Optional
 
-from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request, UploadFile, status
+from fastapi import APIRouter, Depends, Form, HTTPException, Path, Query, Request, UploadFile, status
 from pydantic import BaseModel, Field
 from sse_starlette.sse import EventSourceResponse
 
@@ -2050,7 +2050,7 @@ def _build_pick_rationale(*, tier: str, sector: str, dominant_sector: Optional[s
 @router.post("/portfolio/import", response_model=PortfolioImportResponse)
 async def import_portfolio(
     file: UploadFile,
-    user_id: str = Form(..., description="User's ID"),
+    user_id: str = Form(..., max_length=128, description="User's ID"),
     token_data: dict = Depends(require_vault_owner_token),
 ) -> PortfolioImportResponse:
     """
@@ -2148,7 +2148,7 @@ async def import_portfolio(
 
 @router.get("/portfolio/summary/{user_id}", response_model=PortfolioSummaryResponse)
 async def get_portfolio_summary(
-    user_id: str,
+    user_id: str = Path(..., max_length=128),
     token_data: dict = Depends(require_vault_owner_token),
 ) -> PortfolioSummaryResponse:
     """
@@ -2203,9 +2203,10 @@ async def get_portfolio_summary(
 
 @router.get("/dashboard/profile-picks/{user_id}", response_model=DashboardProfilePicksResponse)
 async def get_dashboard_profile_picks(
-    user_id: str,
+    user_id: str = Path(..., max_length=128),
     symbols: Optional[str] = Query(
         default=None,
+        max_length=2048,
         description="Optional comma-separated ticker symbols from current holdings context.",
     ),
     limit: int = Query(default=4, ge=1, le=_MAX_PROFILE_PICKS),
@@ -3185,7 +3186,7 @@ class _AlwaysConnectedImportStreamRequest:
 @router.post("/portfolio/import/run/start")
 async def start_portfolio_import_run(
     file: UploadFile,
-    user_id: str = Form(..., description="User's ID"),
+    user_id: str = Form(..., max_length=128, description="User's ID"),
     token_data: dict = Depends(require_vault_owner_token),
 ):
     if token_data["user_id"] != user_id:
@@ -3233,7 +3234,7 @@ async def start_portfolio_import_run(
 
 @router.get("/portfolio/import/run/active")
 async def get_active_portfolio_import_run(
-    user_id: str,
+    user_id: str = Query(..., max_length=128),
     token_data: dict = Depends(require_vault_owner_token),
 ):
     if token_data["user_id"] != user_id:
@@ -3247,8 +3248,8 @@ async def get_active_portfolio_import_run(
 @router.get("/portfolio/import/run/{run_id}/stream")
 async def stream_portfolio_import_run(
     request: Request,
-    run_id: str,
-    user_id: str,
+    run_id: str = Path(..., max_length=128),
+    user_id: str = Query(..., max_length=128),
     cursor: Optional[int] = 0,
     token_data: dict = Depends(require_vault_owner_token),
 ):
@@ -3291,8 +3292,8 @@ async def stream_portfolio_import_run(
 
 @router.post("/portfolio/import/run/{run_id}/cancel")
 async def cancel_portfolio_import_run(
-    run_id: str,
-    user_id: str,
+    run_id: str = Path(..., max_length=128),
+    user_id: str = Query(..., max_length=128),
     token_data: dict = Depends(require_vault_owner_token),
 ):
     if token_data["user_id"] != user_id:
@@ -3316,7 +3317,7 @@ async def cancel_portfolio_import_run(
 async def import_portfolio_stream(
     request: Request,
     file: UploadFile,
-    user_id: str = Form(..., description="User's ID"),
+    user_id: str = Form(..., max_length=128, description="User's ID"),
     token_data: dict = Depends(require_vault_owner_token),
 ):
     """Backward-compatible import stream endpoint.

--- a/consent-protocol/api/routes/kai/portfolio.py
+++ b/consent-protocol/api/routes/kai/portfolio.py
@@ -26,7 +26,17 @@ from collections import Counter
 from datetime import datetime, timezone
 from typing import Any, AsyncGenerator, Optional
 
-from fastapi import APIRouter, Depends, Form, HTTPException, Path, Query, Request, UploadFile, status
+from fastapi import (
+    APIRouter,
+    Depends,
+    Form,
+    HTTPException,
+    Path,
+    Query,
+    Request,
+    UploadFile,
+    status,
+)
 from pydantic import BaseModel, Field
 from sse_starlette.sse import EventSourceResponse
 

--- a/consent-protocol/tests/test_portfolio_route_bounds.py
+++ b/consent-protocol/tests/test_portfolio_route_bounds.py
@@ -1,0 +1,99 @@
+# consent-protocol/tests/test_portfolio_route_bounds.py
+"""
+CWE-400 bounds tests for kai/portfolio.py route parameters.
+
+Verifies that oversized path, query, and form params are rejected with 422
+before any business logic is reached.
+"""
+import pytest
+from unittest.mock import AsyncMock
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routes.kai import portfolio as portfolio_mod
+from api import middleware as api_middleware
+
+
+def _stub_auth():
+    return {"user_id": "uid_test_123"}
+
+
+def _make_app():
+    app = FastAPI()
+    app.include_router(portfolio_mod.router, prefix="/api/kai")
+    app.dependency_overrides[api_middleware.require_vault_owner_token] = _stub_auth
+    return app
+
+
+@pytest.fixture(scope="module")
+def client():
+    return TestClient(_make_app(), raise_server_exceptions=False)
+
+
+_LONG_128 = "x" * 129
+
+
+def test_portfolio_summary_user_id_too_long(client):
+    resp = client.get(f"/api/kai/portfolio/summary/{_LONG_128}")
+    assert resp.status_code == 422
+
+
+def test_portfolio_summary_user_id_ok(client):
+    resp = client.get("/api/kai/portfolio/summary/uid_test_123")
+    # Auth passes; 404/500 expected from missing backend, not 422
+    assert resp.status_code != 422
+
+
+def test_dashboard_picks_user_id_too_long(client):
+    resp = client.get(f"/api/kai/dashboard/profile-picks/{_LONG_128}")
+    assert resp.status_code == 422
+
+
+def test_dashboard_picks_symbols_too_long(client):
+    resp = client.get(
+        "/api/kai/dashboard/profile-picks/uid_test_123",
+        params={"symbols": "A" * 2049},
+    )
+    assert resp.status_code == 422
+
+
+def test_dashboard_picks_symbols_ok(client):
+    resp = client.get(
+        "/api/kai/dashboard/profile-picks/uid_test_123",
+        params={"symbols": "AAPL,MSFT,GOOG"},
+    )
+    assert resp.status_code != 422
+
+
+def test_import_run_active_user_id_too_long(client):
+    resp = client.get(
+        "/api/kai/portfolio/import/run/active",
+        params={"user_id": _LONG_128},
+    )
+    assert resp.status_code == 422
+
+
+def test_import_run_stream_run_id_too_long(client):
+    resp = client.get(f"/api/kai/portfolio/import/run/{_LONG_128}/stream?user_id=uid_test_123")
+    assert resp.status_code == 422
+
+
+def test_import_run_stream_user_id_too_long(client):
+    resp = client.get(
+        "/api/kai/portfolio/import/run/run_123/stream",
+        params={"user_id": _LONG_128},
+    )
+    assert resp.status_code == 422
+
+
+def test_cancel_run_run_id_too_long(client):
+    resp = client.post(f"/api/kai/portfolio/import/run/{_LONG_128}/cancel?user_id=uid_test_123")
+    assert resp.status_code == 422
+
+
+def test_cancel_run_user_id_too_long(client):
+    resp = client.post(
+        "/api/kai/portfolio/import/run/run_123/cancel",
+        params={"user_id": _LONG_128},
+    )
+    assert resp.status_code == 422

--- a/consent-protocol/tests/test_portfolio_route_bounds.py
+++ b/consent-protocol/tests/test_portfolio_route_bounds.py
@@ -5,13 +5,13 @@ CWE-400 bounds tests for kai/portfolio.py route parameters.
 Verifies that oversized path, query, and form params are rejected with 422
 before any business logic is reached.
 """
+
 import pytest
-from unittest.mock import AsyncMock
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from api.routes.kai import portfolio as portfolio_mod
 from api import middleware as api_middleware
+from api.routes.kai import portfolio as portfolio_mod
 
 
 def _stub_auth():


### PR DESCRIPTION
## Summary

CWE-400: seven route handler parameters in `api/routes/kai/portfolio.py` accepted unbounded string input, allowing a caller to supply arbitrarily long values that would be passed into downstream services without length restrictions.

## Changes

Added `max_length` constraints to all affected parameters:

| Endpoint | Param | Type | Bound |
|---|---|---|---|
| `GET /portfolio/summary/{user_id}` | `user_id` | Path | 128 |
| `GET /dashboard/profile-picks/{user_id}` | `user_id` | Path | 128 |
| `GET /dashboard/profile-picks/{user_id}` | `symbols` | Query | 2048 |
| `GET /portfolio/import/run/active` | `user_id` | Query | 128 |
| `GET /portfolio/import/run/{run_id}/stream` | `run_id` | Path | 128 |
| `GET /portfolio/import/run/{run_id}/stream` | `user_id` | Query | 128 |
| `POST /portfolio/import/run/{run_id}/cancel` | `run_id` | Path | 128 |
| `POST /portfolio/import/run/{run_id}/cancel` | `user_id` | Query | 128 |
| `POST /portfolio/import/run/start` | `user_id` | Form | 128 |
| `POST /portfolio/import` | `user_id` | Form | 128 |
| `POST /portfolio/import/stream` | `user_id` | Form | 128 |

## Test plan

- [ ] Run `pytest consent-protocol/tests/test_portfolio_route_bounds.py`
- [ ] Verify 422 for user_id > 128 chars on all affected endpoints
- [ ] Verify 422 for symbols > 2048 chars on profile-picks
- [ ] Verify valid-length inputs still return non-422 responses