### PR TITLE
fix(kai/chat): enforce conversation ownership in _get_or_create_conversation

### DIFF
--- a/consent-protocol/hushh_mcp/services/kai_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/kai_chat_service.py
@@ -758,10 +758,16 @@ class KaiChatService:
         user_id: str,
         conversation_id: Optional[str],
     ) -> Conversation:
-        """Get existing conversation or create a new one."""
+        """Get existing conversation or create a new one.
+
+        The caller-supplied conversation_id is verified against the requesting
+        user_id before use. An ID that belongs to a different user is silently
+        ignored and a new conversation is created, so that neither the existence
+        of the ID nor its ownership is revealed to the caller.
+        """
         if conversation_id:
             conversation = await self.chat_db.get_conversation(conversation_id)
-            if conversation:
+            if conversation and conversation.user_id == user_id:
                 return conversation
 
         # Create new conversation

--- a/consent-protocol/tests/test_kai_chat_conversation_ownership.py
+++ b/consent-protocol/tests/test_kai_chat_conversation_ownership.py
@@ -1,0 +1,81 @@
+"""Regression tests for conversation ownership enforcement in KaiChatService.
+
+_get_or_create_conversation must verify that a caller-supplied conversation_id
+belongs to the requesting user before returning it. Without this check a user
+could supply another user's conversation_id and inject messages into, or read
+context from, a conversation they do not own.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hushh_mcp.services.chat_db_service import ChatDBService
+from hushh_mcp.services.kai_chat_service import KaiChatService
+
+
+async def _make_service() -> tuple[KaiChatService, ChatDBService]:
+    """Return a KaiChatService wired to a fresh in-memory ChatDBService."""
+    svc = object.__new__(KaiChatService)
+    # Minimal init: only the fields used by _get_or_create_conversation
+    chat_db = ChatDBService()
+    svc._chat_db = chat_db
+    svc._pkm_service = None
+    svc._attribute_learner = None
+    return svc, chat_db
+
+
+@pytest.mark.asyncio
+async def test_owner_can_resume_their_own_conversation() -> None:
+    """A user can resume a conversation they created by providing its ID."""
+    svc, chat_db = await _make_service()
+
+    owner_conv = await chat_db.create_conversation(user_id="user-owner", title="my chat")
+    assert owner_conv is not None
+
+    resumed = await svc._get_or_create_conversation("user-owner", owner_conv.id)
+
+    assert resumed.id == owner_conv.id
+    assert resumed.user_id == "user-owner"
+
+
+@pytest.mark.asyncio
+async def test_non_owner_cannot_access_another_users_conversation() -> None:
+    """Providing another user's conversation_id must result in a new conversation."""
+    svc, chat_db = await _make_service()
+
+    victim_conv = await chat_db.create_conversation(user_id="user-victim", title="victim chat")
+    assert victim_conv is not None
+
+    attacker_conv = await svc._get_or_create_conversation("user-attacker", victim_conv.id)
+
+    # A new conversation must have been created for the attacker, not the victim's one
+    assert attacker_conv.id != victim_conv.id, (
+        "Attacker received the victim's conversation; ownership not enforced"
+    )
+    assert attacker_conv.user_id == "user-attacker"
+    # The victim's conversation must remain untouched
+    assert victim_conv.user_id == "user-victim"
+
+
+@pytest.mark.asyncio
+async def test_unknown_conversation_id_creates_new_conversation() -> None:
+    """An ID that does not exist in the store creates a new conversation."""
+    svc, _ = await _make_service()
+
+    conv = await svc._get_or_create_conversation("user-1", "00000000-0000-0000-0000-000000000000")
+
+    assert conv is not None
+    assert conv.user_id == "user-1"
+    assert conv.id != "00000000-0000-0000-0000-000000000000"
+
+
+@pytest.mark.asyncio
+async def test_none_conversation_id_creates_new_conversation() -> None:
+    """When no conversation_id is supplied a new conversation is always created."""
+    svc, _ = await _make_service()
+
+    conv = await svc._get_or_create_conversation("user-new", None)
+
+    assert conv is not None
+    assert conv.user_id == "user-new"


### PR DESCRIPTION
## Summary

`_get_or_create_conversation` in `hushh_mcp/services/kai_chat_service.py` fetches a conversation by ID without checking that it belongs to the requesting user. A caller who knows any valid conversation UUID can supply it as the `conversation_id` field in a `POST /api/kai/chat` request. Their message is then processed against that conversation's context and history.

## Root Cause

Line 763 of `kai_chat_service.py` calls `self.chat_db.get_conversation(conversation_id)` with no user filter. `ChatDBService.get_conversation` returns any conversation matching the ID regardless of which user created it. The ownership check was missing from the helper used by both `process_message` and `analyze_portfolio_loser`.

## Impact

A user who obtains another user's conversation UUID can inject messages into that conversation's context window and receive responses shaped by the other user's conversation history. The UUIDs are randomly generated and hard to guess in practice, but the protection should be enforced in code, not assumed from entropy.

## Fix Approach

Add a `conversation.user_id == user_id` check after the fetch. When the IDs do not match, treat the result as if the conversation does not exist and create a new conversation for the caller. This avoids revealing whether the supplied ID exists or who owns it, matching the behavior for a non-existent ID.

Both call sites (`process_message` and `analyze_portfolio_loser`) go through the same helper, so one change covers both paths.

## Files Changed

- `hushh_mcp/services/kai_chat_service.py`: add ownership check in `_get_or_create_conversation` before returning an existing conversation
- `tests/test_kai_chat_conversation_ownership.py`: four new tests covering owner resuming own conversation, attacker being silently given a new conversation, unknown ID, and None ID

## How to Verify

1. Run `pytest consent-protocol/tests/test_kai_chat_conversation_ownership.py -v` and confirm all 4 tests pass.
2. On the old code, `test_non_owner_cannot_access_another_users_conversation` fails because the attacker receives the victim's conversation object. With this fix it passes.
3. Call `POST /api/kai/chat` with a valid token for user A, supplying user B's `conversation_id`. Confirm the response creates a new conversation for user A rather than continuing user B's.

## Test Coverage

`tests/test_kai_chat_conversation_ownership.py` covers:
- `test_owner_can_resume_their_own_conversation`: owner receives their own conversation when supplying its ID
- `test_non_owner_cannot_access_another_users_conversation`: attacker receives a brand-new conversation when supplying victim's ID
- `test_unknown_conversation_id_creates_new_conversation`: non-existent ID results in a new conversation
- `test_none_conversation_id_creates_new_conversation`: no ID also creates a new conversation

Tests exercise `_get_or_create_conversation` directly through the real `ChatDBService` in-memory store, not through mocks.

## Checklist

- [x] Branch is based on latest main with no merge conflicts
- [x] CI passes fully (all required checks green)
- [x] Fix is on a reachable code path in the running application
- [x] No unrelated files are modified
- [x] Tests cover the real product path and fail without this fix
- [x] No em dashes, no double hyphens, no AI or tool mentions anywhere in this PR

## Impact Map (Required)

- Routes touched:
  - `POST /api/kai/chat` (via `process_message`)
  - `POST /api/kai/chat/analyze-loser` (via `analyze_portfolio_loser`)

- API / schema / type changes:
  - None; behavior change only for mismatched user_id/conversation_id combinations

- Cache keys touched:
  - None

- World-model domain summary effects:
  - None

- Mobile parity impacts:
  - None

- Docs updated (exact files):
  - None

- Verification commands executed:
  - `pytest consent-protocol/tests/test_kai_chat_conversation_ownership.py -v`

## Tri-Flow Architecture Check

- [x] **Web**: route change only; valid client usage is unaffected
- [ ] **iOS**: n/a
- [ ] **Android**: n/a

## Testing

- [x] Tested on Web (Chrome/Safari)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## Privacy and Consent

- [x] Does this change access user data? Yes, it restricts access to prevent cross-user data exposure.
- [x] If yes, have you implemented `checkConsentToken()`? The route already enforces VAULT_OWNER token.

## Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed