### PR TITLE
fix(api): return consistent opaque error payload for validation failures

### DIFF
--- a/consent-protocol/server.py
+++ b/consent-protocol/server.py
@@ -11,6 +11,7 @@ import os
 import time
 
 from fastapi import FastAPI, HTTPException, Request  # noqa: E402
+from fastapi.exceptions import RequestValidationError  # noqa: E402
 from fastapi.middleware.cors import CORSMiddleware  # noqa: E402
 from fastapi.responses import JSONResponse, RedirectResponse  # noqa: E402
 
@@ -133,6 +134,19 @@ app.middleware("http")(observability_middleware)
 # Rate limiting
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # type: ignore[arg-type]
+
+
+@app.exception_handler(RequestValidationError)
+async def request_validation_exception_handler(_request: Request, _exc: RequestValidationError):
+    return JSONResponse(
+        status_code=422,
+        content={
+            "detail": {
+                "error": "Validation error",
+                "code": "VALIDATION_ERROR",
+            }
+        },
+    )
 
 
 def _database_error_payload(

--- a/consent-protocol/tests/test_api_validation_opaque_errors.py
+++ b/consent-protocol/tests/test_api_validation_opaque_errors.py
@@ -1,0 +1,50 @@
+"""Regression tests for opaque FastAPI request-validation responses."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from server import app
+
+EXPECTED_VALIDATION_BODY = {
+    "detail": {
+        "error": "Validation error",
+        "code": "VALIDATION_ERROR",
+    }
+}
+
+
+def test_body_validation_failure_returns_consistent_opaque_payload() -> None:
+    client = TestClient(app, raise_server_exceptions=False)
+    sentinel = "SENTINEL_INTERNAL_VALIDATION_VALUE_" + ("x" * 2100)
+
+    response = client.post(
+        "/api/validate-token",
+        json={
+            "token": sentinel,
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json() == EXPECTED_VALIDATION_BODY
+    assert sentinel not in response.text
+    assert "token" not in response.text
+
+
+def test_query_validation_failure_returns_consistent_opaque_payload() -> None:
+    client = TestClient(app, raise_server_exceptions=False)
+    sentinel = "SENTINEL_QUERY_VALUE_" + ("x" * 160)
+
+    response = client.get(
+        "/api/kai/analyze/stream",
+        params={
+            "ticker": "AAPL",
+            "user_id": sentinel,
+        },
+        headers={"Authorization": "Bearer dummy-token"},
+    )
+
+    assert response.status_code == 422
+    assert response.json() == EXPECTED_VALIDATION_BODY
+    assert sentinel not in response.text
+    assert "user_id" not in response.text


### PR DESCRIPTION
## Description

Returns a consistent opaque error payload for request validation failures to ensure client-facing responses remain predictable and do not expose internal validation implementation details.

## Why

Validation failures are expected operational outcomes and should provide enough information for clients to handle errors without revealing backend internals, validation library behavior, schema structure, file paths, or implementation-specific details.

Today, validation responses may vary across endpoints depending on where the failure occurs. This change standardizes the error contract and improves consistency across API surfaces.

## What changed

- Standardized validation failure responses to a consistent opaque error payload
- Removed exposure of internal validation details from client-facing responses
- Preserved existing validation logic and request processing behavior
- Maintained existing observability and backend diagnostics workflows

## Impact

- No schema changes
- No authentication changes
- No business logic changes
- Improves consistency and safety of validation error responses

## Testing

- Ran `npm run lint`
- Ran `npm run build`
- Verified validation failures return a consistent opaque payload
- Verified internal validation details are not exposed to clients
- Verified existing endpoint behavior remains unchanged for valid requests

## Notes

This PR intentionally focuses on response consistency and error-safety only. It does not modify validation rules, API ownership contracts, PKM behavior, consent flows, vault logic, or backend architecture.