### PR TITLE
fix(consent): prevent duplicate consent relationship creation under concurrent requests

### DIFF
--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -3592,76 +3592,14 @@ class RIAIAMService:
             json.dumps(metadata),
         )
 
-        relationship = await conn.fetchrow(
-            """
-            SELECT id
-            FROM advisor_investor_relationships
-            WHERE investor_user_id = $1
-              AND ria_profile_id = $2
-              AND (
-                (firm_id IS NULL AND $3::uuid IS NULL)
-                OR firm_id = $3::uuid
-              )
-            LIMIT 1
-            """,
-            subject_user_id,
-            ria["id"],
-            firm_id,
+        relationship_id = await self._upsert_advisor_investor_relationship(
+            conn,
+            investor_user_id=subject_user_id,
+            ria_profile_id=str(ria["id"]),
+            firm_id=firm_id,
+            request_id=request_id,
+            scope=chosen_scope,
         )
-
-        relationship_id: str | None = None
-        if relationship is None:
-            relationship_row = await conn.fetchrow(
-                """
-                INSERT INTO advisor_investor_relationships (
-                  investor_user_id,
-                  ria_profile_id,
-                  firm_id,
-                  status,
-                  last_request_id,
-                  granted_scope,
-                  created_at,
-                  updated_at
-                )
-                VALUES (
-                  $1,
-                  $2,
-                  $3::uuid,
-                  'request_pending',
-                  $4,
-                  $5,
-                  NOW(),
-                  NOW()
-                )
-                RETURNING id
-                """,
-                subject_user_id,
-                ria["id"],
-                firm_id,
-                request_id,
-                chosen_scope,
-            )
-            relationship_id = (
-                str(relationship_row["id"])
-                if relationship_row and relationship_row["id"] is not None
-                else None
-            )
-        else:
-            await conn.execute(
-                """
-                UPDATE advisor_investor_relationships
-                SET
-                  status = 'request_pending',
-                  last_request_id = $2,
-                  granted_scope = COALESCE(granted_scope, $3),
-                  updated_at = NOW()
-                WHERE id = $1
-                """,
-                relationship["id"],
-                request_id,
-                chosen_scope,
-            )
-            relationship_id = str(relationship["id"])
 
         return {
             "request_id": request_id,
@@ -3676,6 +3614,99 @@ class RIAIAMService:
             "status": "REQUESTED",
             "metadata": metadata,
         }
+
+    async def _upsert_advisor_investor_relationship(
+        self,
+        conn,
+        *,
+        investor_user_id: str,
+        ria_profile_id: str,
+        firm_id: str | None,
+        request_id: str,
+        scope: str,
+    ) -> str | None:
+        if firm_id:
+            row = await conn.fetchrow(
+                """
+                INSERT INTO advisor_investor_relationships (
+                  investor_user_id,
+                  ria_profile_id,
+                  firm_id,
+                  status,
+                  last_request_id,
+                  granted_scope,
+                  created_at,
+                  updated_at
+                )
+                VALUES (
+                  $1,
+                  $2::uuid,
+                  $3::uuid,
+                  'request_pending',
+                  $4,
+                  $5,
+                  NOW(),
+                  NOW()
+                )
+                ON CONFLICT (investor_user_id, ria_profile_id, firm_id)
+                  WHERE firm_id IS NOT NULL
+                DO UPDATE SET
+                  status = 'request_pending',
+                  last_request_id = EXCLUDED.last_request_id,
+                  granted_scope = COALESCE(
+                    advisor_investor_relationships.granted_scope,
+                    EXCLUDED.granted_scope
+                  ),
+                  updated_at = NOW()
+                RETURNING id
+                """,
+                investor_user_id,
+                ria_profile_id,
+                firm_id,
+                request_id,
+                scope,
+            )
+        else:
+            row = await conn.fetchrow(
+                """
+                INSERT INTO advisor_investor_relationships (
+                  investor_user_id,
+                  ria_profile_id,
+                  firm_id,
+                  status,
+                  last_request_id,
+                  granted_scope,
+                  created_at,
+                  updated_at
+                )
+                VALUES (
+                  $1,
+                  $2::uuid,
+                  NULL,
+                  'request_pending',
+                  $3,
+                  $4,
+                  NOW(),
+                  NOW()
+                )
+                ON CONFLICT (investor_user_id, ria_profile_id)
+                  WHERE firm_id IS NULL
+                DO UPDATE SET
+                  status = 'request_pending',
+                  last_request_id = EXCLUDED.last_request_id,
+                  granted_scope = COALESCE(
+                    advisor_investor_relationships.granted_scope,
+                    EXCLUDED.granted_scope
+                  ),
+                  updated_at = NOW()
+                RETURNING id
+                """,
+                investor_user_id,
+                ria_profile_id,
+                request_id,
+                scope,
+            )
+        return str(row["id"]) if row and row["id"] is not None else None
 
     async def create_ria_consent_bundle(
         self,
@@ -7579,75 +7610,14 @@ class RIAIAMService:
                     json.dumps(metadata),
                 )
 
-                relationship = await conn.fetchrow(
-                    """
-                    SELECT id
-                    FROM advisor_investor_relationships
-                    WHERE investor_user_id = $1
-                      AND ria_profile_id = $2
-                      AND (
-                        (firm_id IS NULL AND $3::uuid IS NULL)
-                        OR firm_id = $3::uuid
-                      )
-                    LIMIT 1
-                    """,
-                    investor_user_id,
-                    ria["id"],
-                    firm_id,
+                relationship_id = await self._upsert_advisor_investor_relationship(
+                    conn,
+                    investor_user_id=investor_user_id,
+                    ria_profile_id=str(ria["id"]),
+                    firm_id=firm_id,
+                    request_id=request_id,
+                    scope=chosen_scope,
                 )
-                relationship_id: str | None = None
-                if relationship is None:
-                    relationship_row = await conn.fetchrow(
-                        """
-                        INSERT INTO advisor_investor_relationships (
-                          investor_user_id,
-                          ria_profile_id,
-                          firm_id,
-                          status,
-                          last_request_id,
-                          granted_scope,
-                          created_at,
-                          updated_at
-                        )
-                        VALUES (
-                          $1,
-                          $2,
-                          $3::uuid,
-                          'request_pending',
-                          $4,
-                          $5,
-                          NOW(),
-                          NOW()
-                        )
-                        RETURNING id
-                        """,
-                        investor_user_id,
-                        ria["id"],
-                        firm_id,
-                        request_id,
-                        chosen_scope,
-                    )
-                    relationship_id = (
-                        str(relationship_row["id"])
-                        if relationship_row and relationship_row["id"] is not None
-                        else None
-                    )
-                else:
-                    await conn.execute(
-                        """
-                        UPDATE advisor_investor_relationships
-                        SET
-                          status = 'request_pending',
-                          last_request_id = $2,
-                          granted_scope = COALESCE(granted_scope, $3),
-                          updated_at = NOW()
-                        WHERE id = $1
-                        """,
-                        relationship["id"],
-                        request_id,
-                        chosen_scope,
-                    )
-                    relationship_id = str(relationship["id"])
 
                 created = {
                     "request_id": request_id,

--- a/consent-protocol/tests/test_ria_iam_service_architecture.py
+++ b/consent-protocol/tests/test_ria_iam_service_architecture.py
@@ -1297,6 +1297,77 @@ async def test_sync_relationship_from_consent_action_uses_active_tokens_over_lat
 
 
 @pytest.mark.asyncio
+async def test_relationship_request_upsert_uses_no_firm_partial_conflict_target():
+    captured: dict[str, object] = {}
+
+    class _FakeConn:
+        async def fetchrow(self, query: str, *args):
+            captured["query"] = query
+            captured["args"] = args
+            return {"id": "relationship_no_firm"}
+
+    service = RIAIAMService()
+
+    relationship_id = await service._upsert_advisor_investor_relationship(
+        _FakeConn(),
+        investor_user_id="investor_1",
+        ria_profile_id="11111111-1111-1111-1111-111111111111",
+        firm_id=None,
+        request_id="req_1",
+        scope="attr.financial.*",
+    )
+
+    query = str(captured["query"])
+    assert relationship_id == "relationship_no_firm"
+    assert "SELECT id" not in query
+    assert "ON CONFLICT (investor_user_id, ria_profile_id)" in query
+    assert "WHERE firm_id IS NULL" in query
+    assert "DO UPDATE SET" in query
+    assert captured["args"] == (
+        "investor_1",
+        "11111111-1111-1111-1111-111111111111",
+        "req_1",
+        "attr.financial.*",
+    )
+
+
+@pytest.mark.asyncio
+async def test_relationship_request_upsert_uses_with_firm_partial_conflict_target():
+    captured: dict[str, object] = {}
+
+    class _FakeConn:
+        async def fetchrow(self, query: str, *args):
+            captured["query"] = query
+            captured["args"] = args
+            return {"id": "relationship_with_firm"}
+
+    service = RIAIAMService()
+
+    relationship_id = await service._upsert_advisor_investor_relationship(
+        _FakeConn(),
+        investor_user_id="investor_1",
+        ria_profile_id="11111111-1111-1111-1111-111111111111",
+        firm_id="22222222-2222-2222-2222-222222222222",
+        request_id="req_1",
+        scope="attr.financial.*",
+    )
+
+    query = str(captured["query"])
+    assert relationship_id == "relationship_with_firm"
+    assert "SELECT id" not in query
+    assert "ON CONFLICT (investor_user_id, ria_profile_id, firm_id)" in query
+    assert "WHERE firm_id IS NOT NULL" in query
+    assert "DO UPDATE SET" in query
+    assert captured["args"] == (
+        "investor_1",
+        "11111111-1111-1111-1111-111111111111",
+        "22222222-2222-2222-2222-222222222222",
+        "req_1",
+        "attr.financial.*",
+    )
+
+
+@pytest.mark.asyncio
 async def test_queue_ria_invite_email_delivery_records_queue_and_success_metadata(monkeypatch):
     import hushh_mcp.services.ria_iam_service as ria_module
 


### PR DESCRIPTION
## Description

Prevents duplicate consent relationship creation when concurrent requests attempt to create the same relationship at the same time.

## Why

Consent relationships define trust and permission boundaries between users, vault access, PKM flows, and downstream memory/cache behavior. Under concurrent request conditions, duplicate relationship creation can lead to inconsistent state, repeated notifications, duplicated audit entries, or ambiguous consent ownership.

This change ensures relationship creation remains idempotent and safe when the same consent relationship is submitted more than once in parallel.

## What changed

- Added duplicate-creation protection for consent relationship creation
- Ensured concurrent requests resolve to a single canonical relationship
- Preserved existing consent ownership and validation rules
- Avoided introducing new relationship storage or parallel consent flows

## Impact

- No API contract changes
- No schema-breaking changes
- No changes to valid single-request behavior
- Improves consistency and concurrency safety for consent relationship creation

## Testing

- Ran `npm run lint`
- Ran `npm run build`
- Verified concurrent duplicate relationship requests do not create multiple records
- Verified existing valid relationship creation continues functioning correctly

## Notes

This PR intentionally focuses on concurrency safety within the existing consent relationship flow and does not modify vault, PKM, cache, or standalone memory architecture.