### PR TITLE
security(exceptions): remove user_id from VaultKeyNotFoundError response

### DIFF
--- a/consent-protocol/api/exceptions.py
+++ b/consent-protocol/api/exceptions.py
@@ -95,7 +95,7 @@ class VaultKeyNotFoundError(VaultError):
     error_code = "VAULT_KEY_NOT_FOUND"
 
     def __init__(self, user_id: str):
-        super().__init__(message="Vault key not found for user", details={"user_id": user_id})
+        super().__init__(message="Vault key not found for user")
 
 
 class AgentError(HushhBaseException):


### PR DESCRIPTION
## Summary

`VaultKeyNotFoundError` currently forwards `user_id` into the exception `details` payload.

`HushhBaseException.to_dict()` serializes the `details` object directly into the HTTP response body, which exposes internal user identifiers to API consumers when vault-key bootstrap failures occur.

## Change

Removes `user_id` from the serialized exception details payload while preserving the existing constructor signature.

```diff
- super().__init__(message="Vault key not found for user", details={"user_id": user_id})
+ super().__init__(message="Vault key not found for user")
```

The `user_id` parameter is intentionally retained to preserve full call-site compatibility and avoid downstream code changes.

## Why This Approach

The change isolates the fix to response serialization behavior only.

Existing behavior remains unchanged for:

* exception type
* constructor usage
* error handling flow
* business logic
* vault bootstrap semantics

The generic error message already communicates the failure condition without exposing internal identifiers.

## Impact

* Prevents internal `user_id` leakage in HTTP error responses
* No API contract changes
* No call-site changes
* No business-logic changes
* Aligns exception behavior with existing sanitization patterns

## Standards

CWE-209 — Generation of Error Message Containing Sensitive Information

## Risk

LOW — single-line security hardening change with preserved constructor compatibility and no runtime behavior changes.
