### PR TITLE
fix(field): add aria-live region for dynamic form error announcements

### DIFF
--- a/hushh-webapp/components/ui/field.tsx
+++ b/hushh-webapp/components/ui/field.tsx
@@ -86,6 +86,7 @@ function Field({
   return (
     <div
       role="group"
+      aria-live="polite"
       data-slot="field"
       data-orientation={orientation}
       className={cn(fieldVariants({ orientation }), className)}


### PR DESCRIPTION
## Summary

`FieldError` already uses `role="alert"` for validation messages, but error content is conditionally mounted and unmounted during validation cycles. In some assistive technology/browser combinations, dynamically inserted error content may not always be announced consistently when the surrounding field container is not itself treated as a live region.

## Change

Adds `aria-live="polite"` to the persistent `Field` wrapper element:

```tsx
aria-live="polite"
```

This allows assistive technologies to observe validation message updates within the field subtree while preserving the existing `FieldError` implementation.

## Why This Approach

`Field` is the canonical shared form-field container used across the application. Labels, descriptions, controls, and validation messages already exist within this boundary.

Adding `aria-live` directly to the existing persistent wrapper:

* avoids structural changes
* avoids introducing additional wrapper elements
* preserves the current error rendering behavior
* improves announcement consistency for dynamically rendered validation states

`aria-live="polite"` was selected to avoid interrupting ongoing screen reader output during form interaction.

## Impact

* Improves screen reader announcement consistency for dynamically rendered validation errors
* Applies automatically to all shared `Field` usages
* No visual changes
* No behavioral changes
* No API changes
* No call-site updates required

## Standards

WCAG 4.1.3 — Status Messages

WAI-ARIA live regions:
https://www.w3.org/TR/wai-aria/#aria-live

## Risk

LOW — single additive accessibility attribute on the persistent `Field` wrapper. No rendering, logic, or validation behavior changes.
