### PR TITLE
feat: add One Location contact sync invites

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -17,6 +17,7 @@ const {
   mockCreatePublicInvite,
   mockGetState,
   mockSyncCurrentUser,
+  mockSyncOneLocationContactSignals,
   mockTrackEvent,
   mockRouterPush,
   mockSearchParamsGet,
@@ -35,6 +36,7 @@ const {
   mockCreatePublicInvite: vi.fn(),
   mockGetState: vi.fn(),
   mockSyncCurrentUser: vi.fn(),
+  mockSyncOneLocationContactSignals: vi.fn(),
   mockTrackEvent: vi.fn(),
   mockRouterPush: vi.fn(),
   mockSearchParamsGet: vi.fn(),
@@ -91,6 +93,10 @@ vi.mock("@/lib/one-location/service", () => ({
   },
 }));
 
+vi.mock("@/lib/one-location/contact-signals", () => ({
+  syncOneLocationContactSignals: mockSyncOneLocationContactSignals,
+}));
+
 vi.mock("@/lib/services/account-identity-service", () => ({
   AccountIdentityService: {
     syncCurrentUser: mockSyncCurrentUser,
@@ -101,6 +107,7 @@ vi.mock("sonner", () => ({
   toast: {
     success: vi.fn(),
     error: vi.fn(),
+    info: vi.fn(),
   },
 }));
 
@@ -272,6 +279,13 @@ describe("OneLocationAgentPage", () => {
     });
     mockGetState.mockResolvedValue(locationState());
     mockSyncCurrentUser.mockResolvedValue({ user_id: "user_a" });
+    mockSyncOneLocationContactSignals.mockResolvedValue({
+      matches: [],
+      matchedUserIds: [],
+      totalContacts: 0,
+      inviteCandidateCount: 0,
+      sourcePlatform: "ios",
+    });
   });
 
   it("renders the One-owned encrypted location control surface", async () => {
@@ -632,6 +646,71 @@ describe("OneLocationAgentPage", () => {
         success_count: 2,
         failure_count: 0,
       }),
+    );
+  });
+
+  it("adds mobile contact matches as a ranking reason without showing phone digits", async () => {
+    mockUseRequireAuth.mockReturnValue({
+      loading: false,
+      isAuthenticated: true,
+      userId: "user_a",
+      user: { uid: "user_a", getIdToken: vi.fn().mockResolvedValue("id-token") },
+    });
+    mockSyncOneLocationContactSignals.mockResolvedValueOnce({
+      matches: [
+        {
+          user_id: "user_d",
+          kind: "investor",
+          display_name: "Investor D",
+          phone_last4: "9911",
+          profile: {},
+        },
+      ],
+      matchedUserIds: ["user_d"],
+      totalContacts: 8,
+      inviteCandidateCount: 7,
+      sourcePlatform: "ios",
+    });
+
+    render(<OneLocationAgentPageContent />);
+
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole("button", { name: /Sync Contacts/i }));
+
+    await waitFor(() =>
+      expect(mockSyncOneLocationContactSignals).toHaveBeenCalledWith({
+        idToken: "id-token",
+      }),
+    );
+    expect(await screen.findByText("In your contacts")).toBeTruthy();
+    expect(screen.getByText(/1 matched \/ 7 invite-ready/i)).toBeTruthy();
+    expect(screen.queryByText(/9911|8012|4455/)).toBeNull();
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      "one_location_contact_signal_synced",
+      expect.objectContaining({
+        route_id: "one_location",
+        result: "success",
+        source_platform: "ios",
+        contact_count_bucket: "1_10",
+        matched_count: 1,
+        invite_candidate_count: 7,
+      }),
+    );
+  });
+
+  it("creates an approval-first invite path for contacts who are not KAI users", async () => {
+    render(<OneLocationAgentPageContent />);
+
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole("button", { name: /Invite Contacts/i }));
+
+    await waitFor(() => expect(mockCreatePublicInvite).toHaveBeenCalledTimes(1));
+    expect(mockCreatePublicInvite).toHaveBeenCalledWith({
+      vaultOwnerToken: "vault-token",
+      durationHours: 1,
+    });
+    expect(JSON.stringify(mockTrackEvent.mock.calls)).not.toMatch(
+      /8012|9911|latitude|longitude|28\.6139|77\.209/u,
     );
   });
 

--- a/hushh-webapp/__tests__/lib/observability/one-location-contact-sync-schema.test.ts
+++ b/hushh-webapp/__tests__/lib/observability/one-location-contact-sync-schema.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { validateAndSanitizeEvent } from "@/lib/observability/schema";
+
+describe("one location contact sync analytics schema", () => {
+  it("accepts aggregate contact sync metadata without contact payloads", () => {
+    const result = validateAndSanitizeEvent(
+      "one_location_contact_signal_synced",
+      {
+        env: "uat",
+        platform: "ios",
+        event_category: "feature",
+        app_version: "2.1.0",
+        route_id: "one_location",
+        result: "success",
+        source_platform: "ios",
+        contact_count_bucket: "11_50",
+        matched_count: 3,
+        invite_candidate_count: 21,
+        phone_number: "+16505550101",
+        contact_name: "Avery Stone",
+        phone_last4: "0101",
+      } as any,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.droppedKeys).toContain("phone_number");
+    expect(result.droppedKeys).toContain("contact_name");
+    expect(result.droppedKeys).toContain("phone_last4");
+    expect(result.sanitized.event_category).toBe("feature");
+    expect(result.sanitized.route_id).toBe("one_location");
+    expect(result.sanitized.contact_count_bucket).toBe("11_50");
+    expect(result.sanitized.matched_count).toBe(3);
+  });
+});

--- a/hushh-webapp/__tests__/lib/one-location/contact-signals.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/contact-signals.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockBuildMarketplaceContactLookups, mockMatchMarketplaceContacts } =
+  vi.hoisted(() => ({
+    mockBuildMarketplaceContactLookups: vi.fn(),
+    mockMatchMarketplaceContacts: vi.fn(),
+  }));
+
+vi.mock("@/lib/marketplace/contact-matching", () => ({
+  buildMarketplaceContactLookups: mockBuildMarketplaceContactLookups,
+}));
+
+vi.mock("@/lib/services/ria-service", () => ({
+  RiaService: {
+    matchMarketplaceContacts: mockMatchMarketplaceContacts,
+  },
+}));
+
+import { syncOneLocationContactSignals } from "@/lib/one-location/contact-signals";
+
+describe("one location contact signals", () => {
+  beforeEach(() => {
+    mockBuildMarketplaceContactLookups.mockReset();
+    mockMatchMarketplaceContacts.mockReset();
+  });
+
+  it("uses hashed contact lookups and strips phone digits from returned matches", async () => {
+    mockBuildMarketplaceContactLookups.mockResolvedValue({
+      totalContacts: 3,
+      sourcePlatform: "android",
+      lookups: [
+        {
+          hash: "a".repeat(64),
+          last4: "0101",
+          displayName: "Avery Stone",
+        },
+        {
+          hash: "b".repeat(64),
+          last4: "9911",
+          displayName: "Investor D",
+        },
+      ],
+    });
+    mockMatchMarketplaceContacts.mockResolvedValue([
+      {
+        user_id: "user_d",
+        kind: "investor",
+        display_name: "Investor D",
+        phone_last4: "9911",
+        profile: {},
+      },
+    ]);
+
+    const result = await syncOneLocationContactSignals({
+      idToken: "id-token",
+      contactLimit: 20,
+      matchLimit: 5,
+    });
+
+    expect(mockBuildMarketplaceContactLookups).toHaveBeenCalledWith({
+      limit: 20,
+    });
+    expect(mockMatchMarketplaceContacts).toHaveBeenCalledWith("id-token", {
+      phone_lookups: [
+        { hash: "a".repeat(64), last4: "0101" },
+        { hash: "b".repeat(64), last4: "9911" },
+      ],
+      limit: 5,
+    });
+    expect(result).toMatchObject({
+      matchedUserIds: ["user_d"],
+      totalContacts: 3,
+      inviteCandidateCount: 2,
+      sourcePlatform: "android",
+    });
+    expect(result.matches[0]).not.toHaveProperty("phone_last4");
+    expect(JSON.stringify(result)).not.toContain("9911");
+    expect(JSON.stringify(result)).not.toContain("0101");
+  });
+
+  it("returns invite candidates without calling the matcher when contacts have no phones", async () => {
+    mockBuildMarketplaceContactLookups.mockResolvedValue({
+      totalContacts: 4,
+      sourcePlatform: "ios",
+      lookups: [],
+    });
+
+    const result = await syncOneLocationContactSignals({ idToken: "id-token" });
+
+    expect(mockMatchMarketplaceContacts).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      matches: [],
+      matchedUserIds: [],
+      totalContacts: 4,
+      inviteCandidateCount: 4,
+      sourcePlatform: "ios",
+    });
+  });
+});

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -14,6 +14,7 @@ import {
   AlertTriangle,
   CheckCircle2,
   Clock3,
+  ContactRound,
   Copy,
   ExternalLink,
   KeyRound,
@@ -70,6 +71,10 @@ import {
   recordOneLocationShareNotification,
 } from "@/lib/one-location/notifications";
 import { OneLocationService } from "@/lib/one-location/service";
+import {
+  syncOneLocationContactSignals,
+  type OneLocationContactSignalResult,
+} from "@/lib/one-location/contact-signals";
 import type {
   OneLocationAccessRequest,
   OneLocationGrant,
@@ -106,6 +111,8 @@ type BusyState =
   | "deny"
   | "refer"
   | "revoke"
+  | "contactSync"
+  | "contactInvite"
   | "publicInvite"
   | "publicRevoke"
   | null;
@@ -130,6 +137,36 @@ type OneLocationSelectionSurface =
   | "select_menu";
 
 type OneLocationDurationBucket = "15m" | "30m" | "1h" | "4h" | "24h" | "custom";
+
+type OneLocationContactSignalStatus =
+  | "idle"
+  | "scanning"
+  | "matched"
+  | "empty"
+  | "unavailable"
+  | "denied"
+  | "error";
+
+type OneLocationContactSignalState = {
+  status: OneLocationContactSignalStatus;
+  matchedUserIds: string[];
+  matchedCount: number;
+  totalContacts: number;
+  inviteCandidateCount: number;
+  sourcePlatform?: OneLocationContactSignalResult["sourcePlatform"];
+  error?: string | null;
+  syncedAt?: string | null;
+};
+
+const INITIAL_CONTACT_SIGNAL_STATE: OneLocationContactSignalState = {
+  status: "idle",
+  matchedUserIds: [],
+  matchedCount: 0,
+  totalContacts: 0,
+  inviteCandidateCount: 0,
+  error: null,
+  syncedAt: null,
+};
 
 function formatDateTime(value?: string | null): string {
   if (!value) return "Not set";
@@ -232,7 +269,27 @@ function recommendationSearchText(recipient: OneLocationRecipient): string {
 
 function rankRecipientsForRecommendation(
   recipients: OneLocationRecipient[],
+  contactMatchedUserIds: Set<string> = new Set(),
 ): OneLocationRecipient[] {
+  if (contactMatchedUserIds.size > 0) {
+    return [...recipients].sort((a, b) => {
+      const aScore =
+        (a.recommendationScore ?? 0) +
+        (contactMatchedUserIds.has(a.userId) ? 8 : 0);
+      const bScore =
+        (b.recommendationScore ?? 0) +
+        (contactMatchedUserIds.has(b.userId) ? 8 : 0);
+      if (aScore !== bScore) return bScore - aScore;
+      const aRank = a.recommendationRank ?? Number.MAX_SAFE_INTEGER;
+      const bRank = b.recommendationRank ?? Number.MAX_SAFE_INTEGER;
+      if (aRank !== bRank) return aRank - bRank;
+      if (a.canReceiveLocation !== b.canReceiveLocation) {
+        return a.canReceiveLocation ? -1 : 1;
+      }
+      return recipientLabel(a).localeCompare(recipientLabel(b));
+    });
+  }
+
   return [...recipients].sort((a, b) => {
     const aRank = a.recommendationRank ?? Number.MAX_SAFE_INTEGER;
     const bRank = b.recommendationRank ?? Number.MAX_SAFE_INTEGER;
@@ -244,6 +301,34 @@ function rankRecipientsForRecommendation(
       return a.canReceiveLocation ? -1 : 1;
     }
     return recipientLabel(a).localeCompare(recipientLabel(b));
+  });
+}
+
+function enrichRecipientsWithContactSignal(
+  recipients: OneLocationRecipient[],
+  contactMatchedUserIds: Set<string>,
+): OneLocationRecipient[] {
+  if (contactMatchedUserIds.size === 0) return recipients;
+
+  return recipients.map((recipient) => {
+    if (!contactMatchedUserIds.has(recipient.userId)) return recipient;
+    const reasons = recipient.recommendationReasons ?? [];
+    const hasContactReason = reasons.some(
+      (reason) => reason.code === "mobile_contact_signal",
+    );
+    return {
+      ...recipient,
+      recommendationTier: recipient.recommendationTier || "contacts",
+      recommendationReasons: hasContactReason
+        ? reasons
+        : [
+            { code: "mobile_contact_signal", label: "In your contacts" },
+            ...reasons,
+          ],
+      recommendationSummary:
+        recipient.recommendationSummary ||
+        "Matched from your private mobile contact scan",
+    };
   });
 }
 
@@ -429,6 +514,58 @@ function oneLocationEventResult(
   failureCount: number,
 ): "success" | "error" {
   return successCount > 0 && failureCount === 0 ? "success" : "error";
+}
+
+function contactCountBucket(
+  count: number,
+): "0" | "1_10" | "11_50" | "51_250" | "251_plus" {
+  if (count <= 0) return "0";
+  if (count <= 10) return "1_10";
+  if (count <= 50) return "11_50";
+  if (count <= 250) return "51_250";
+  return "251_plus";
+}
+
+function contactSignalStatusLabel(status: OneLocationContactSignalStatus): string {
+  switch (status) {
+    case "scanning":
+      return "Scanning";
+    case "matched":
+      return "Signal active";
+    case "empty":
+      return "No matches yet";
+    case "unavailable":
+      return "Mobile only";
+    case "denied":
+      return "Permission needed";
+    case "error":
+      return "Needs retry";
+    default:
+      return "Optional signal";
+  }
+}
+
+function contactSignalSummary(state: OneLocationContactSignalState): string {
+  switch (state.status) {
+    case "matched":
+      return `${state.matchedCount} KAI match${
+        state.matchedCount === 1 ? "" : "es"
+      } added as a ranking signal.`;
+    case "empty":
+      return state.totalContacts > 0
+        ? "No KAI users matched from this scan."
+        : "No contact numbers were available to match.";
+    case "unavailable":
+      return "Open One on iOS or Android to scan contacts.";
+    case "denied":
+      return "Allow contacts to use this optional ranking signal.";
+    case "error":
+      return state.error || "Contact signal could not be refreshed.";
+    case "scanning":
+      return "Checking contacts privately on this device.";
+    default:
+      return "Contacts stay on-device; only hashed lookups are used for matching.";
+  }
 }
 
 function grantCounterpartyLabel(grant: OneLocationGrant): string {
@@ -788,6 +925,8 @@ export function OneLocationAgentPageContent() {
   const [selectedRequestOwnerIds, setSelectedRequestOwnerIds] = useState<
     string[]
   >([]);
+  const [contactSignal, setContactSignal] =
+    useState<OneLocationContactSignalState>(INITIAL_CONTACT_SIGNAL_STATE);
   const [durationHours, setDurationHours] = useState("1");
   const [requestMessage, setRequestMessage] = useState("");
   const [referralTargets, setReferralTargets] = useState<
@@ -806,9 +945,21 @@ export function OneLocationAgentPageContent() {
     () => state?.recipients ?? [],
     [state?.recipients],
   );
+  const contactMatchedUserIds = useMemo(
+    () => new Set(contactSignal.matchedUserIds),
+    [contactSignal.matchedUserIds],
+  );
+  const contactSignalRecipients = useMemo(
+    () => enrichRecipientsWithContactSignal(recipients, contactMatchedUserIds),
+    [contactMatchedUserIds, recipients],
+  );
   const rankedRecipients = useMemo(
-    () => rankRecipientsForRecommendation(recipients),
-    [recipients],
+    () =>
+      rankRecipientsForRecommendation(
+        contactSignalRecipients,
+        contactMatchedUserIds,
+      ),
+    [contactMatchedUserIds, contactSignalRecipients],
   );
   const visibleRecipients = useMemo(() => {
     const query = recipientSearch.trim().toLowerCase();
@@ -822,8 +973,8 @@ export function OneLocationAgentPageContent() {
     [visibleRecipients],
   );
   const selectedShareRecipients = useMemo(
-    () => recipientSelectionFromIds(recipients, selectedRecipientIds),
-    [recipients, selectedRecipientIds],
+    () => recipientSelectionFromIds(contactSignalRecipients, selectedRecipientIds),
+    [contactSignalRecipients, selectedRecipientIds],
   );
   const shareReadySelectedRecipients = useMemo(
     () => selectedShareRecipients.filter(isShareReadyRecipient),
@@ -837,8 +988,9 @@ export function OneLocationAgentPageContent() {
     [selectedShareRecipients],
   );
   const selectedRequestOwners = useMemo(
-    () => recipientSelectionFromIds(recipients, selectedRequestOwnerIds),
-    [recipients, selectedRequestOwnerIds],
+    () =>
+      recipientSelectionFromIds(contactSignalRecipients, selectedRequestOwnerIds),
+    [contactSignalRecipients, selectedRequestOwnerIds],
   );
   const pendingOwnerRequests = useMemo(
     () =>
@@ -990,7 +1142,11 @@ export function OneLocationAgentPageContent() {
         setPermission(nextPermission);
         setState(nextState);
         const rankedNextRecipients = rankRecipientsForRecommendation(
-          nextState.recipients,
+          enrichRecipientsWithContactSignal(
+            nextState.recipients,
+            contactMatchedUserIds,
+          ),
+          contactMatchedUserIds,
         );
         const firstRecommendedRecipient = rankedNextRecipients[0];
         const nextRecipientIds = new Set(
@@ -1037,7 +1193,13 @@ export function OneLocationAgentPageContent() {
     })();
     refreshInFlightRef.current = task;
     return task;
-  }, [auth.user, auth.userId, isVaultUnlocked, vaultOwnerToken]);
+  }, [
+    auth.user,
+    auth.userId,
+    contactMatchedUserIds,
+    isVaultUnlocked,
+    vaultOwnerToken,
+  ]);
 
   useEffect(() => {
     if (!auth.loading) {
@@ -1398,6 +1560,96 @@ export function OneLocationAgentPageContent() {
     [refresh, vaultOwnerToken],
   );
 
+  const handleSyncContactSignal = useCallback(async () => {
+    if (!auth.user?.getIdToken) {
+      const message = "Sign in before syncing contacts.";
+      setContactSignal((current) => ({
+        ...current,
+        status: "error",
+        error: message,
+      }));
+      toast.error(message);
+      return;
+    }
+
+    setBusy("contactSync");
+    setContactSignal((current) => ({
+      ...current,
+      status: "scanning",
+      error: null,
+    }));
+
+    try {
+      const idToken = await auth.user.getIdToken();
+      const result = await syncOneLocationContactSignals({ idToken });
+      const nextStatus: OneLocationContactSignalStatus =
+        result.matchedUserIds.length > 0 ? "matched" : "empty";
+      setContactSignal({
+        status: nextStatus,
+        matchedUserIds: result.matchedUserIds,
+        matchedCount: result.matchedUserIds.length,
+        totalContacts: result.totalContacts,
+        inviteCandidateCount: result.inviteCandidateCount,
+        sourcePlatform: result.sourcePlatform,
+        error: null,
+        syncedAt: new Date().toISOString(),
+      });
+      trackEvent("one_location_contact_signal_synced", {
+        route_id: "one_location",
+        result: "success",
+        source_platform: result.sourcePlatform,
+        contact_count_bucket: contactCountBucket(result.totalContacts),
+        matched_count: result.matchedUserIds.length,
+        invite_candidate_count: result.inviteCandidateCount,
+      });
+      if (result.matchedUserIds.length > 0) {
+        toast.success(
+          `${peopleCountLabel(
+            result.matchedUserIds.length,
+          )} added as a contact signal.`,
+        );
+      } else {
+        toast.info("No KAI users matched from this contact scan.");
+      }
+    } catch (error) {
+      const message = oneLocationErrorMessage(
+        error,
+        "Could not sync contacts.",
+      );
+      const normalized = message.toLowerCase();
+      const status: OneLocationContactSignalStatus =
+        normalized.includes("denied") || normalized.includes("permission")
+          ? "denied"
+          : normalized.includes("native") ||
+              normalized.includes("mobile") ||
+              normalized.includes("unavailable") ||
+              normalized.includes("web view")
+            ? "unavailable"
+            : "error";
+      setContactSignal((current) => ({
+        ...current,
+        status,
+        error: message,
+        syncedAt: new Date().toISOString(),
+      }));
+      trackEvent("one_location_contact_signal_synced", {
+        route_id: "one_location",
+        result: status === "denied" || status === "unavailable" ? "expected_error" : "error",
+        source_platform: contactSignal.sourcePlatform ?? "unknown",
+        contact_count_bucket: contactCountBucket(contactSignal.totalContacts),
+        matched_count: contactSignal.matchedCount,
+        invite_candidate_count: contactSignal.inviteCandidateCount,
+      });
+      if (status === "unavailable") {
+        toast.info("Contact sync is available in the iOS and Android app.");
+      } else {
+        toast.error(message);
+      }
+    } finally {
+      setBusy(null);
+    }
+  }, [auth.user, contactSignal]);
+
   const handleRequestAccess = useCallback(async () => {
     if (!vaultOwnerToken || !selectedRequestOwners.length) return;
     setBusy("request");
@@ -1518,6 +1770,65 @@ export function OneLocationAgentPageContent() {
       toast.error("Could not open the share sheet.");
     }
   }, [publicInviteUrl]);
+
+  const handleShareContactInvite = useCallback(async () => {
+    if (!vaultOwnerToken) return;
+    setBusy("contactInvite");
+    try {
+      let url = publicInviteUrl;
+      if (!url) {
+        const response = await OneLocationService.createPublicInvite({
+          vaultOwnerToken,
+          durationHours: Number(durationHours),
+        });
+        url = publicInviteUrlLabel(response.publicUrl);
+        setPublicInviteUrl(url);
+        trackEvent("one_location_public_link_created", {
+          route_id: "one_location",
+          result: "success",
+          duration_bucket: oneLocationDurationBucket(durationHours),
+          copied_to_clipboard: false,
+          active_invite_count: activePublicInvites.length + 1,
+        });
+        await refresh();
+      }
+
+      const text =
+        "Join my KAI Circle on One Location. Send me a request here; I approve before anything is shared.";
+      if (navigator.share && url) {
+        await navigator.share({
+          title: "Join my KAI Circle",
+          text,
+          url,
+        });
+        return;
+      }
+      if (navigator.clipboard && url) {
+        await navigator.clipboard.writeText(`${text} ${url}`);
+        toast.success("Invite link copied.");
+        return;
+      }
+      toast.info("Create a request link, then share it with your contacts.");
+    } catch (error) {
+      if ((error as Error)?.name === "AbortError") return;
+      trackEvent("one_location_public_link_created", {
+        route_id: "one_location",
+        result: "error",
+        duration_bucket: oneLocationDurationBucket(durationHours),
+        copied_to_clipboard: false,
+        active_invite_count: activePublicInvites.length,
+      });
+      toast.error(oneLocationErrorMessage(error, "Could not prepare invite."));
+    } finally {
+      setBusy(null);
+    }
+  }, [
+    activePublicInvites.length,
+    durationHours,
+    publicInviteUrl,
+    refresh,
+    vaultOwnerToken,
+  ]);
 
   const handleRevokePublicInvite = useCallback(
     async (invite: OneLocationPublicInvite) => {
@@ -2003,6 +2314,62 @@ export function OneLocationAgentPageContent() {
                         </div>
                       );
                     })}
+                  </div>
+
+                  <div className="rounded-[14px] border border-black/[0.04] bg-white/70 p-3 shadow-sm dark:border-white/[0.08] dark:bg-white/[0.06]">
+                    <div className="flex items-start gap-3">
+                      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#eaf9ef] text-[#2dbd5a] dark:bg-emerald-400/15 dark:text-emerald-200">
+                        <ContactRound className="h-4 w-4" aria-hidden="true" />
+                      </span>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <h3 className="text-[14px] font-bold tracking-tight text-[#1c1c1e] dark:text-white">
+                            Mobile contact signal
+                          </h3>
+                          <span className="rounded-full bg-[#f2f2f7] px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-[#636366] dark:bg-white/10 dark:text-white/65">
+                            {contactSignalStatusLabel(contactSignal.status)}
+                          </span>
+                        </div>
+                        <p className="mt-1 text-[12px] leading-5 text-[#8e8e93] dark:text-white/55">
+                          {contactSignalSummary(contactSignal)}
+                        </p>
+                        {contactSignal.status === "matched" ||
+                        contactSignal.status === "empty" ? (
+                          <p className="mt-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-[#8e8e93] dark:text-white/45">
+                            {contactSignal.matchedCount} matched /{" "}
+                            {contactSignal.inviteCandidateCount} invite-ready
+                          </p>
+                        ) : null}
+                      </div>
+                    </div>
+                    <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                      <ActionButton
+                        busy={busy}
+                        busyKey="contactSync"
+                        onClick={() => void handleSyncContactSignal()}
+                        disabled={!auth.user || busy === "contactInvite"}
+                        variant="outline"
+                        className="h-10 rounded-[12px] border-black/[0.06] bg-white text-[13px] font-semibold text-[#1c1c1e] shadow-sm hover:bg-[#f2f2f7] dark:border-white/[0.08] dark:bg-white/10 dark:text-white dark:hover:bg-white/15"
+                      >
+                        {busy !== "contactSync" ? (
+                          <ContactRound className="mr-2 h-4 w-4" aria-hidden="true" />
+                        ) : null}
+                        Sync Contacts
+                      </ActionButton>
+                      <ActionButton
+                        busy={busy}
+                        busyKey="contactInvite"
+                        onClick={() => void handleShareContactInvite()}
+                        disabled={!vaultOwnerToken || busy === "contactSync"}
+                        variant="outline"
+                        className="h-10 rounded-[12px] border-black/[0.06] bg-white text-[13px] font-semibold text-[#007aff] shadow-sm hover:bg-[#f2f2f7] dark:border-white/[0.08] dark:bg-white/10 dark:text-[#76b7ff] dark:hover:bg-white/15"
+                      >
+                        {busy !== "contactInvite" ? (
+                          <Send className="mr-2 h-4 w-4" aria-hidden="true" />
+                        ) : null}
+                        Invite Contacts
+                      </ActionButton>
+                    </div>
                   </div>
 
                   <div className={onePanelClassName}>

--- a/hushh-webapp/lib/observability/events.ts
+++ b/hushh-webapp/lib/observability/events.ts
@@ -80,6 +80,7 @@ export type ObservabilityEventName =
   | "one_location_share_confirmed"
   | "one_location_request_sent"
   | "one_location_public_link_created"
+  | "one_location_contact_signal_synced"
   | "growth_funnel_step_completed"
   | "investor_activation_completed"
   | "ria_activation_completed"
@@ -211,6 +212,7 @@ const EVENT_CATEGORY_BY_NAME: Record<
   one_location_share_confirmed: "feature",
   one_location_request_sent: "feature",
   one_location_public_link_created: "feature",
+  one_location_contact_signal_synced: "feature",
   growth_funnel_step_completed: "funnel",
   investor_activation_completed: "funnel",
   ria_activation_completed: "funnel",
@@ -428,6 +430,14 @@ export interface EventPayloadMap {
     duration_bucket: "15m" | "30m" | "1h" | "4h" | "24h" | "custom";
     copied_to_clipboard: boolean;
     active_invite_count: number;
+  };
+  one_location_contact_signal_synced: {
+    route_id: RouteId;
+    result: EventResult | "expected_error";
+    source_platform: "web" | "ios" | "android" | "native" | "unknown";
+    contact_count_bucket: "0" | "1_10" | "11_50" | "51_250" | "251_plus";
+    matched_count: number;
+    invite_candidate_count: number;
   };
   growth_funnel_step_completed: {
     journey: GrowthJourney;

--- a/hushh-webapp/lib/observability/schema.ts
+++ b/hushh-webapp/lib/observability/schema.ts
@@ -108,6 +108,14 @@ const EVENT_ALLOWED_KEYS: Record<ObservabilityEventName, readonly string[]> = {
     "copied_to_clipboard",
     "active_invite_count",
   ],
+  one_location_contact_signal_synced: [
+    ...BASE_ALLOWED_KEYS,
+    "result",
+    "source_platform",
+    "contact_count_bucket",
+    "matched_count",
+    "invite_candidate_count",
+  ],
   growth_funnel_step_completed: [
     ...BASE_ALLOWED_KEYS,
     "journey",

--- a/hushh-webapp/lib/one-location/contact-signals.ts
+++ b/hushh-webapp/lib/one-location/contact-signals.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { buildMarketplaceContactLookups } from "@/lib/marketplace/contact-matching";
+import {
+  RiaService,
+  type MarketplaceContactMatch,
+} from "@/lib/services/ria-service";
+
+export type OneLocationContactSignalResult = {
+  matches: MarketplaceContactMatch[];
+  matchedUserIds: string[];
+  totalContacts: number;
+  inviteCandidateCount: number;
+  sourcePlatform: "web" | "ios" | "android" | "native";
+};
+
+export async function syncOneLocationContactSignals({
+  idToken,
+  contactLimit = 500,
+  matchLimit = 50,
+}: {
+  idToken: string;
+  contactLimit?: number;
+  matchLimit?: number;
+}): Promise<OneLocationContactSignalResult> {
+  const lookupResult = await buildMarketplaceContactLookups({
+    limit: contactLimit,
+  });
+
+  if (lookupResult.lookups.length === 0) {
+    return {
+      matches: [],
+      matchedUserIds: [],
+      totalContacts: lookupResult.totalContacts,
+      inviteCandidateCount: lookupResult.totalContacts,
+      sourcePlatform: lookupResult.sourcePlatform,
+    };
+  }
+
+  const matches = await RiaService.matchMarketplaceContacts(idToken, {
+    phone_lookups: lookupResult.lookups.map(({ hash, last4 }) => ({
+      hash,
+      last4,
+    })),
+    limit: matchLimit,
+  });
+  const privacySafeMatches = matches.map((match) => {
+    const safeMatch = { ...match };
+    delete safeMatch.phone_last4;
+    return safeMatch as MarketplaceContactMatch;
+  });
+  const matchedUserIds = Array.from(
+    new Set(
+      privacySafeMatches
+        .map((match) => String(match.user_id || "").trim())
+        .filter(Boolean),
+    ),
+  );
+
+  return {
+    matches: privacySafeMatches,
+    matchedUserIds,
+    totalContacts: lookupResult.totalContacts,
+    inviteCandidateCount: Math.max(
+      0,
+      lookupResult.totalContacts - matchedUserIds.length,
+    ),
+    sourcePlatform: lookupResult.sourcePlatform,
+  };
+}


### PR DESCRIPTION
## Summary  Adds the first One Location mobile-contact sync ranking slice on top of the current KAI Circle feature train. Contact sync is optional, additive, and privacy bounded: contacts stay device-side, the existing hashed marketplace matcher is reused, and the One Location UI never shows phone digits or phone-derived identity labels.  This also gives non-KAI contacts an approval-first invite path by reusing the existing One Location public request-link flow. The invite asks the other person to send a request; it does not expose live location until the owner approves.  Refs #1745 Refs #1747 Refs #1749  ## Reviewer-Agent Readiness  - Draft PR by design: this is a dependent feature-train slice and should not be treated as an independent `main` merge candidate yet. - Base branch: `one-location-phase4-polish-analytics` (#1772). - Merge sequence: #1769 -> #1770 -> #1771 -> #1772 -> this PR. - Retarget plan: when #1772 lands, retarget this PR to the landed branch or `main`, rerun the same checks, and add logged-in browser proof. - Current head: `7ea1b69`.  ## Impact Map  - Route/UI: `hushh-webapp/app/one/location/page.tsx`   - Adds a Mobile contact sync panel inside the canonical `/one/location` surface.   - Adds `Sync Contacts` for optional native contact matching.   - Adds `Invite Contacts` using the approval-first public request-link flow.   - Uses contact matches as one ranking input only; it does not replace existing trust, recent-share, professional-network, readiness, or setup inputs. - Service/helper: `hushh-webapp/lib/one-location/contact-signals.ts`   - Reuses `buildMarketplaceContactLookups` and `RiaService.matchMarketplaceContacts`.   - Strips `phone_last4` from returned matches before the result can reach the One Location UI. - Observability:   - Adds `one_location_contact_signal_synced` with aggregate/bucketed fields only.   - Does not log names, phone digits, user ids, coordinates, or invite URLs. - Tests:   - Adds route/component proof for contact sync UI and invite flow.   - Adds contact-sync helper tests.   - Adds focused observability schema proof for contact-sync analytics.  ## Privacy Boundary  - Contact sync is user-triggered, optional, and additive. - Web fallback remains safe: contacts are unavailable in web and the UI reports that sync is mobile-only. - Matching uses the existing hashed contact lookup flow; no raw contact numbers are added to One Location UI state. - Visible identity labels remain display-name/recommendation based; phone-last-four and masked phone values are not used as trust anchors. - Non-KAI invite flow remains approval-first and request-only; public links never reveal live location.  ## Tri-Flow Architecture Check  - Web: `/one/location` shows the contact-sync panel and safe mobile-only fallback. - iOS: uses the existing `HushhContacts` native plugin contract. - Android: uses the existing `HushhContacts` native plugin contract. - Service boundary: no new route or DB schema in this slice; it reuses the existing marketplace contact matcher through the web service layer.  ## Verification  Automated checks run locally with bundled Node because system `node.exe` is blocked by Windows access policy on this machine:  - `git diff --check` - `cd hushh-webapp && node node_modules/typescript/bin/tsc --noEmit` - `cd hushh-webapp && node node_modules/eslint/bin/eslint.js app/one/location/page.tsx lib/one-location/contact-signals.ts lib/observability/events.ts lib/observability/schema.ts __tests__/components/one-location-agent-page.test.tsx __tests__/lib/one-location/contact-signals.test.ts __tests__/lib/observability/one-location-contact-sync-schema.test.ts --max-warnings=0` - `cd hushh-webapp && node node_modules/vitest/vitest.mjs run __tests__/components/one-location-agent-page.test.tsx __tests__/lib/one-location/contact-signals.test.ts __tests__/lib/observability/one-location-contact-sync-schema.test.ts --reporter=dot` - `cd hushh-webapp && node scripts/architecture/verify-service-layer-boundary.mjs` - `cd hushh-webapp && node scripts/native/verify-native-plugin-contracts.mjs`  Focused result: 3 Vitest files green, 19 tests green. Service-layer boundary green. Native plugin contract parity green.  ## Browser Proof Status  Authenticated Chrome proof captured locally on June 2, 2026 (IST) against `http://127.0.0.1:3000/one/location` in Chrome profile `Person 1`.  Proof checks captured:  - Route loaded in the signed-in local browser state with the expected `/one/location` route visible. - Contact sync panel visible on the canonical `/one/location` page. - `Sync Contacts` and `Invite Contacts` controls visible. - Web fallback shows contact sync is available in the iOS and Android app. - KAI Circle list uses display names and recommendation/readiness labels; no phone-last-four or masked-phone trust labels were visible. - Existing share/request/stop-sharing UI from predecessor slices remains reachable.  Local proof artifacts for manual attachment:  - `output/playwright/pr1834-person1-one-location-2026-06-01T19-32-03-593Z.png` - `output/playwright/pr1834-person1-one-location-contact-sync-2026-06-01T19-32-47-107Z.png` - `output/playwright/pr1834-person1-one-location-sync-fallback-2026-06-01T19-33-08-989Z.png` - `output/playwright/pr1834-person1-one-location-2026-06-01T19-32-03-593Z.json`