### PR TITLE
chore(ui): add noopener to external links

### DIFF
--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -1573,7 +1573,7 @@ export default function MarketplacePage() {
                 ) : null}
                 {selectedAdvisor.disclosures_url ? (
                   <Button asChild variant="none" effect="fade" size="sm">
-                    <a href={selectedAdvisor.disclosures_url} target="_blank" rel="noreferrer">
+                    <a href={selectedAdvisor.disclosures_url} target="_blank" rel="noopener noreferrer">
                       Public disclosure
                       <ArrowUpRight className="ml-2 h-4 w-4" />
                     </a>
@@ -1659,7 +1659,7 @@ export default function MarketplacePage() {
                   <div className="flex flex-wrap gap-2">
                     {selectedInvestorEvidenceLinks.map((url) => (
                       <Button key={url} asChild variant="none" effect="fade" size="sm">
-                        <a href={url} target="_blank" rel="noreferrer">
+                        <a href={url} target="_blank" rel="noopener noreferrer">
                           SEC source
                           <ArrowUpRight className="ml-2 h-4 w-4" />
                         </a>

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -227,7 +227,7 @@ function AgentMarkdown({ text }: { text: string }) {
             <a
               href={href || "#"}
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
               className="font-medium text-primary underline-offset-4 hover:underline"
             >
               {children}

--- a/hushh-webapp/components/onboarding/AuthLegalDialog.tsx
+++ b/hushh-webapp/components/onboarding/AuthLegalDialog.tsx
@@ -51,7 +51,7 @@ export function AuthLegalDialog({ docType, onOpenChange }: AuthLegalDialogProps)
                 <a
                   href={content.url}
                   target="_blank"
-                  rel="noreferrer"
+                  rel="noopener noreferrer"
                   className="inline-flex items-center gap-1 rounded-full border border-border px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
                 >
                   Open in browser


### PR DESCRIPTION
## Summary

Adds explicit `noopener` to external links opened with `target="_blank"`.

## Changes

* Updated `rel="noreferrer"` to `rel="noopener noreferrer"` in:

  * `components/onboarding/AuthLegalDialog.tsx`
  * `components/agent/agent-chat-workspace.tsx`
  * `app/marketplace/page.tsx`

## Why

Using `rel="noopener noreferrer"` is a widely adopted security best practice for links opened in a new tab. This helps prevent access to `window.opener` while preserving existing behavior.

## Impact

* No functional changes
* No UI changes
* Improves external link security posture
* Low-risk, targeted update

## Testing

* Verified changes are limited to link attributes only
* No application logic modified
