### PR TITLE
feat: add One Location activity dashboard

### DIFF
--- a/consent-protocol/api/routes/one/location.py
+++ b/consent-protocol/api/routes/one/location.py
@@ -11,7 +11,7 @@ import hmac
 import os
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, status
 from pydantic import BaseModel, ConfigDict, Field
 
 from api.middleware import require_vault_owner_token
@@ -145,6 +145,22 @@ def _require_retention_auth(request: Request) -> None:
 async def get_location_state(token_data: dict = Depends(require_vault_owner_token)):
     try:
         return _service().list_state(user_id=_user_id(token_data))
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+
+
+@router.get("/location/activity")
+async def get_location_activity(
+    range_key: str = Query(default="30d", alias="range", pattern="^(7d|30d|90d|all)$"),
+    limit: int = Query(default=40, ge=1, le=100),
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    try:
+        return _service().list_activity(
+            user_id=_user_id(token_data),
+            range_key=range_key,
+            limit=limit,
+        )
     except Exception as exc:
         raise _handle_error(exc) from exc
 

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -70,6 +70,41 @@ PUBLIC_INVITE_FINGERPRINT_THROTTLE_MINUTES = _bounded_int_env(
 PUBLIC_INVITE_MAX_SUBMISSIONS_PER_FINGERPRINT_WINDOW = _bounded_int_env(
     "ONE_LOCATION_PUBLIC_INVITE_MAX_SUBMISSIONS_PER_FINGERPRINT_WINDOW", 3, 1, 20
 )
+ONE_LOCATION_ACTIVITY_RANGES = {
+    "7d": 7,
+    "30d": 30,
+    "90d": 90,
+}
+ONE_LOCATION_ACTIVITY_EVENT_TYPES = {
+    "location_share_created",
+    "location_share_viewed",
+    "location_share_revoked",
+    "location_share_expired",
+    "location_access_request",
+    "location_access_approved",
+    "location_access_denied",
+    "location_referral_invite",
+    "location_public_invite_created",
+    "location_public_invite_revoked",
+    "location_public_invite_submitted",
+}
+ONE_LOCATION_SHARE_ACTIVITY_TYPES = {
+    "location_share_created",
+    "location_share_viewed",
+    "location_share_revoked",
+    "location_share_expired",
+}
+ONE_LOCATION_REQUEST_ACTIVITY_TYPES = {
+    "location_access_request",
+    "location_access_approved",
+    "location_access_denied",
+    "location_referral_invite",
+}
+ONE_LOCATION_PUBLIC_ACTIVITY_TYPES = {
+    "location_public_invite_created",
+    "location_public_invite_revoked",
+    "location_public_invite_submitted",
+}
 
 
 class OneLocationAgentError(RuntimeError):
@@ -266,6 +301,44 @@ def _one_location_url(**query: str | None) -> str:
     suffix = f"?{'&'.join(params)}" if params else ""
     path = f"/one/location{suffix}"
     return f"{base}{path}" if base else path
+
+
+def _activity_since(range_key: str) -> datetime | None:
+    days = ONE_LOCATION_ACTIVITY_RANGES.get(range_key)
+    if not days:
+        return None
+    start = _utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+    return start - timedelta(days=days - 1)
+
+
+def _activity_kind(event_type: str) -> str:
+    if event_type in ONE_LOCATION_SHARE_ACTIVITY_TYPES:
+        return "share"
+    if event_type in ONE_LOCATION_REQUEST_ACTIVITY_TYPES:
+        return "request"
+    return "public"
+
+
+def _activity_bucket_key(value: datetime, range_key: str) -> str:
+    if range_key in {"90d", "all"}:
+        return value.strftime("%Y-%m")
+    return value.strftime("%Y-%m-%d")
+
+
+def _activity_bucket_label(value: datetime, range_key: str) -> str:
+    if range_key in {"90d", "all"}:
+        return value.strftime("%b %Y")
+    try:
+        return value.strftime("%b %-d")
+    except ValueError:
+        return value.strftime("%b %#d")
+
+
+def format_activity_time(value: datetime) -> str:
+    try:
+        return value.strftime("%b %-d, %H:%M UTC")
+    except ValueError:
+        return value.strftime("%b %#d, %H:%M UTC")
 
 
 class OneLocationAgentService:
@@ -596,6 +669,263 @@ class OneLocationAgentService:
             "message": str(row.get("message") or "") or None,
             "submittedAt": _iso(row.get("submitted_at")),
             "resolvedAt": _iso(row.get("resolved_at")),
+        }
+
+    @staticmethod
+    def _activity_display_label(
+        value: Any,
+        *,
+        fallback: str = "KAI member",
+    ) -> str:
+        label = str(value or "").strip()
+        return label or fallback
+
+    @classmethod
+    def _activity_event_payload(
+        cls,
+        row: dict[str, Any],
+        *,
+        user_id: str,
+        range_key: str,
+    ) -> dict[str, Any] | None:
+        event_type = str(row.get("event_type") or "")
+        if event_type not in ONE_LOCATION_ACTIVITY_EVENT_TYPES:
+            return None
+        occurred_at = _parse_datetime(row.get("created_at"), field_name="created_at")
+        owner_user_id = str(row.get("owner_user_id") or "")
+        owner_label = cls._activity_display_label(
+            row.get("owner_display_name"),
+            fallback="A trusted person",
+        )
+        actor_label = cls._activity_display_label(
+            row.get("actor_display_name"),
+            fallback="KAI member",
+        )
+        recipient_label = cls._activity_display_label(
+            row.get("recipient_display_name"),
+            fallback="KAI member",
+        )
+        visitor_label = cls._activity_display_label(
+            row.get("visitor_display_name"),
+            fallback="Public request",
+        )
+        event_id = str(row.get("id") or f"{event_type}:{_iso(occurred_at)}")
+        kind = _activity_kind(event_type)
+        detail = {
+            "share": "Private sharing",
+            "request": "Approval workflow",
+            "public": "Request link",
+        }[kind]
+
+        title = "One Location activity"
+        if event_type == "location_share_created":
+            title = (
+                f"Shared with {recipient_label}"
+                if owner_user_id == user_id
+                else f"{owner_label} shared with you"
+            )
+        elif event_type == "location_share_viewed":
+            title = (
+                f"Viewed by {actor_label}"
+                if owner_user_id == user_id
+                else f"You viewed {owner_label}'s update"
+            )
+        elif event_type == "location_share_revoked":
+            title = (
+                f"Sharing stopped with {recipient_label}"
+                if owner_user_id == user_id
+                else f"{owner_label} stopped sharing"
+            )
+        elif event_type == "location_share_expired":
+            title = (
+                f"Share expired for {recipient_label}"
+                if owner_user_id == user_id
+                else f"{owner_label}'s share expired"
+            )
+        elif event_type == "location_access_request":
+            title = (
+                f"Request from {actor_label}"
+                if owner_user_id == user_id
+                else f"Request sent to {owner_label}"
+            )
+        elif event_type == "location_access_approved":
+            title = (
+                f"Approved request for {recipient_label}"
+                if owner_user_id == user_id
+                else f"{owner_label} approved your request"
+            )
+        elif event_type == "location_access_denied":
+            title = (
+                f"Denied request from {recipient_label or actor_label}"
+                if owner_user_id == user_id
+                else f"{owner_label} denied your request"
+            )
+        elif event_type == "location_referral_invite":
+            title = f"Referral added for {recipient_label}"
+        elif event_type == "location_public_invite_created":
+            title = "Request link created"
+        elif event_type == "location_public_invite_revoked":
+            title = "Request link closed"
+        elif event_type == "location_public_invite_submitted":
+            title = f"Response from {visitor_label}"
+
+        return {
+            "id": event_id,
+            "kind": kind,
+            "eventType": event_type,
+            "occurredAt": _iso(occurred_at),
+            "bucketKey": _activity_bucket_key(occurred_at, range_key),
+            "bucketLabel": _activity_bucket_label(occurred_at, range_key),
+            "title": title,
+            "detail": f"{detail} - {format_activity_time(occurred_at)}",
+        }
+
+    def list_activity(
+        self,
+        *,
+        user_id: str,
+        range_key: str = "30d",
+        limit: int = 40,
+    ) -> dict[str, Any]:
+        if not user_id:
+            raise OneLocationAgentError(
+                "LOCATION_AUTH_REQUIRED", "A user is required.", status_code=401
+            )
+        normalized_range = range_key if range_key in {"7d", "30d", "90d", "all"} else "30d"
+        since_at = _activity_since(normalized_range)
+        bounded_limit = max(1, min(int(limit or 40), 100))
+        rows = self._execute_many(
+            """
+            SELECT
+              e.id,
+              e.owner_user_id,
+              e.actor_user_id,
+              e.recipient_user_id,
+              e.event_type,
+              e.metadata,
+              e.created_at,
+              owner.display_name AS owner_display_name,
+              actor.display_name AS actor_display_name,
+              recipient.display_name AS recipient_display_name,
+              submission.visitor_display_name AS visitor_display_name
+            FROM one_location_events e
+            LEFT JOIN actor_identity_cache owner ON owner.user_id = e.owner_user_id
+            LEFT JOIN actor_identity_cache actor ON actor.user_id = e.actor_user_id
+            LEFT JOIN actor_identity_cache recipient ON recipient.user_id = e.recipient_user_id
+            LEFT JOIN one_location_public_invite_submissions submission
+              ON submission.id::text = e.metadata->>'submission_id'
+            WHERE e.event_type = ANY(:event_types)
+              AND (:since_at IS NULL OR e.created_at >= :since_at)
+              AND (
+                e.owner_user_id = :user_id
+                OR e.actor_user_id = :user_id
+                OR e.recipient_user_id = :user_id
+              )
+            ORDER BY e.created_at DESC
+            LIMIT :limit
+            """,
+            {
+                "user_id": user_id,
+                "since_at": since_at,
+                "limit": bounded_limit,
+                "event_types": sorted(ONE_LOCATION_ACTIVITY_EVENT_TYPES),
+            },
+        )
+        active_row = self._execute_one(
+            """
+            SELECT COUNT(*)::int AS active_share_count
+            FROM one_location_share_grants
+            WHERE owner_user_id = :user_id
+              AND status = 'active'
+            """,
+            {"user_id": user_id},
+        ) or {}
+
+        events = [
+            payload
+            for row in rows
+            if (
+                payload := self._activity_event_payload(
+                    row,
+                    user_id=user_id,
+                    range_key=normalized_range,
+                )
+            )
+        ]
+        bucket_map: dict[str, dict[str, Any]] = {}
+        for event in events:
+            key = str(event["bucketKey"])
+            bucket = bucket_map.setdefault(
+                key,
+                {
+                    "key": key,
+                    "label": event["bucketLabel"],
+                    "shares": 0,
+                    "requests": 0,
+                    "views": 0,
+                    "publicActivity": 0,
+                    "total": 0,
+                },
+            )
+            event_type = str(event.get("eventType") or "")
+            if event["kind"] == "share":
+                bucket["shares"] += 1
+            if event["kind"] == "request":
+                bucket["requests"] += 1
+            if event_type == "location_share_viewed":
+                bucket["views"] += 1
+            if event["kind"] == "public":
+                bucket["publicActivity"] += 1
+            bucket["total"] += 1
+
+        shared_with = {
+            str(row.get("recipient_user_id") or "")
+            for row in rows
+            if str(row.get("event_type") or "") == "location_share_created"
+            and str(row.get("owner_user_id") or "") == user_id
+            and str(row.get("recipient_user_id") or "")
+        }
+        summary = {
+            "sharedWithCount": len(shared_with),
+            "activeShareCount": int(active_row.get("active_share_count") or 0),
+            "requestsReceivedCount": sum(
+                1
+                for row in rows
+                if str(row.get("event_type") or "") == "location_access_request"
+                and str(row.get("owner_user_id") or "") == user_id
+            ),
+            "requestsSentCount": sum(
+                1
+                for row in rows
+                if str(row.get("event_type") or "") == "location_access_request"
+                and str(row.get("actor_user_id") or "") == user_id
+                and str(row.get("owner_user_id") or "") != user_id
+            ),
+            "viewsCount": sum(
+                1
+                for row in rows
+                if str(row.get("event_type") or "") == "location_share_viewed"
+            ),
+            "publicLinkCount": sum(
+                1
+                for row in rows
+                if str(row.get("event_type") or "") == "location_public_invite_created"
+                and str(row.get("owner_user_id") or "") == user_id
+            ),
+            "publicResponseCount": sum(
+                1
+                for row in rows
+                if str(row.get("event_type") or "") == "location_public_invite_submitted"
+                and str(row.get("owner_user_id") or "") == user_id
+            ),
+            "totalEvents": len(events),
+        }
+
+        return {
+            "range": normalized_range,
+            "summary": summary,
+            "buckets": [bucket_map[key] for key in sorted(bucket_map.keys())][-8:],
+            "events": events[:bounded_limit],
         }
 
     def _expire_stale_grants(self, user_id: str) -> None:

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -278,6 +278,41 @@ class FourUserMemoryService(OneLocationAgentService):
                         {**submission, "request_status": request.get("status") if request else None}
                     )
             return rows[:50]
+        if "FROM one_location_events e" in sql:
+            user_id = params["user_id"]
+            since_at = params.get("since_at")
+            event_types = set(params.get("event_types") or [])
+            rows = []
+            for event in sorted(
+                self.events.values(),
+                key=lambda item: item["created_at"],
+                reverse=True,
+            ):
+                if event_types and event.get("event_type") not in event_types:
+                    continue
+                if since_at and event.get("created_at") and event["created_at"] < since_at:
+                    continue
+                if user_id not in {
+                    event.get("owner_user_id"),
+                    event.get("actor_user_id"),
+                    event.get("recipient_user_id"),
+                }:
+                    continue
+                owner = self.identities.get(event.get("owner_user_id") or "", {})
+                actor = self.identities.get(event.get("actor_user_id") or "", {})
+                recipient = self.identities.get(event.get("recipient_user_id") or "", {})
+                metadata = event.get("metadata") or {}
+                submission = self.public_submissions.get(metadata.get("submission_id") or "")
+                rows.append(
+                    {
+                        **event,
+                        "owner_display_name": owner.get("display_name"),
+                        "actor_display_name": actor.get("display_name"),
+                        "recipient_display_name": recipient.get("display_name"),
+                        "visitor_display_name": (submission or {}).get("visitor_display_name"),
+                    }
+                )
+            return rows[: params.get("limit", 40)]
         if "UPDATE one_location_share_grants" in sql and "status = 'revoked'" in sql:
             revoked = []
             for grant in self.grants.values():
@@ -460,6 +495,15 @@ class FourUserMemoryService(OneLocationAgentService):
                 "created_at": datetime.now(timezone.utc),
             }
             return None
+        if "COUNT(*)::int AS active_share_count" in sql:
+            return {
+                "active_share_count": sum(
+                    1
+                    for grant in self.grants.values()
+                    if grant["owner_user_id"] == params["user_id"]
+                    and grant["status"] == "active"
+                )
+            }
         if "UPDATE one_location_recipient_keys" in sql:
             return None
         if "FROM actor_identity_cache" in sql and "regexp_replace" in sql:
@@ -1003,6 +1047,63 @@ def test_four_user_location_workflow_contract() -> None:
     )
     assert "latitude" not in serialized_state
     assert "longitude" not in serialized_state
+
+
+def test_one_location_activity_summary_uses_existing_metadata_events() -> None:
+    service = FourUserMemoryService()
+
+    for user_id in ("user_a", "user_b", "user_c"):
+        service.register_recipient_key(
+            user_id=user_id,
+            key_id=f"key-{user_id}",
+            public_key_jwk={"kty": "EC", "crv": "P-256", "x": user_id, "y": user_id},
+        )
+
+    grant = service.create_grant(
+        owner_user_id="user_a",
+        recipient_user_id="user_b",
+        recipient_key_id="key-user_b",
+        duration_hours=1,
+    )
+    service.store_encrypted_envelope(
+        owner_user_id="user_a",
+        grant_id=grant["id"],
+        envelope=encrypted_envelope("key-user_b", "ciphertext-for-b"),
+    )
+    service.view_latest_envelope(recipient_user_id="user_b", grant_id=grant["id"])
+    service.request_access(
+        requester_user_id="user_c",
+        owner_user_id="user_a",
+        message="Can you share?",
+    )
+    created = service.create_public_invite(owner_user_id="user_a", duration_hours=1)
+    service.submit_public_invite_request(
+        public_token=created["publicToken"],
+        visitor_display_name="User B",
+        phone_number="+1 555 010 0002",
+    )
+
+    activity = service.list_activity(user_id="user_a", range_key="30d")
+
+    assert activity["range"] == "30d"
+    assert activity["summary"]["sharedWithCount"] == 1
+    assert activity["summary"]["activeShareCount"] == 1
+    assert activity["summary"]["requestsReceivedCount"] >= 1
+    assert activity["summary"]["viewsCount"] == 1
+    assert activity["summary"]["publicLinkCount"] == 1
+    assert activity["summary"]["publicResponseCount"] == 1
+    titles = {event["title"] for event in activity["events"]}
+    assert "Shared with User B" in titles
+    assert "Viewed by User B" in titles
+    assert "Request from User C" in titles
+    assert "Request link created" in titles
+    assert "Response from User B" in titles
+    serialized = json.dumps(activity, default=str)
+    assert "ciphertext" not in serialized
+    assert "latitude" not in serialized
+    assert "longitude" not in serialized
+    assert "0100002" not in serialized
+    assert "0002" not in serialized
 
 
 def test_public_invite_is_request_only_and_token_hash_only() -> None:

--- a/consent-protocol/tests/test_one_location_routes.py
+++ b/consent-protocol/tests/test_one_location_routes.py
@@ -118,6 +118,18 @@ def test_four_user_one_location_api_flow_is_authenticated_and_ciphertext_only(mo
     revoke_b = client.delete(f"/api/one/location/grants/{grant_b['id']}")
     assert revoke_b.status_code == 200
 
+    activity_response = client.get("/api/one/location/activity?range=30d")
+    assert activity_response.status_code == 200
+    activity_payload = activity_response.json()
+    assert activity_payload["summary"]["sharedWithCount"] >= 1
+    assert activity_payload["summary"]["viewsCount"] >= 1
+    assert any(
+        event["title"] == "Shared with User B"
+        for event in activity_payload["events"]
+    )
+    assert "0002" not in json.dumps(activity_payload, default=str)
+    assert "ciphertext" not in json.dumps(activity_payload, default=str)
+
     current_user["user_id"] = user_b
     view_b_after_revoke = client.get(f"/api/one/location/grants/{grant_b['id']}/envelope")
     assert view_b_after_revoke.status_code == 410
@@ -133,6 +145,7 @@ def test_four_user_one_location_api_flow_is_authenticated_and_ciphertext_only(mo
                 store_d.json(),
                 view_d_after.json(),
                 revoke_b.json(),
+                activity_payload,
             ],
             "notifications": service.notifications,
         },

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -15,6 +15,7 @@ const {
   mockRevokeGrant,
   mockRequestAccess,
   mockCreatePublicInvite,
+  mockGetActivity,
   mockGetState,
   mockSyncCurrentUser,
   mockSyncOneLocationContactSignals,
@@ -34,6 +35,7 @@ const {
   mockRevokeGrant: vi.fn(),
   mockRequestAccess: vi.fn(),
   mockCreatePublicInvite: vi.fn(),
+  mockGetActivity: vi.fn(),
   mockGetState: vi.fn(),
   mockSyncCurrentUser: vi.fn(),
   mockSyncOneLocationContactSignals: vi.fn(),
@@ -78,6 +80,7 @@ vi.mock("@/lib/one-location/service", () => ({
   OneLocationService: {
     registerRecipientKey: mockRegisterKey,
     getPermissionState: mockGetPermissionState,
+    getActivity: mockGetActivity,
     getState: mockGetState,
     createGrant: mockCreateGrant,
     storeEnvelope: mockStoreEnvelope,
@@ -218,6 +221,67 @@ function locationState() {
   };
 }
 
+function locationActivity() {
+  return {
+    range: "30d",
+    summary: {
+      sharedWithCount: 1,
+      activeShareCount: 1,
+      requestsReceivedCount: 1,
+      requestsSentCount: 1,
+      viewsCount: 1,
+      publicLinkCount: 1,
+      publicResponseCount: 1,
+      totalEvents: 5,
+    },
+    buckets: [
+      {
+        key: "2026-05-20",
+        label: "May 20",
+        shares: 2,
+        requests: 2,
+        views: 1,
+        publicActivity: 1,
+        total: 5,
+      },
+    ],
+    events: [
+      {
+        id: "event_viewed",
+        kind: "share",
+        eventType: "location_share_viewed",
+        occurredAt: "2026-05-20T07:45:00.000Z",
+        title: "Viewed by Trusted B",
+        detail: "Private sharing - May 20, 07:45 UTC",
+      },
+      {
+        id: "event_shared",
+        kind: "share",
+        eventType: "location_share_created",
+        occurredAt: "2026-05-20T07:30:00.000Z",
+        title: "Shared with Trusted B",
+        detail: "Private sharing - May 20, 07:30 UTC",
+      },
+      {
+        id: "event_request",
+        kind: "request",
+        eventType: "location_access_request",
+        occurredAt: "2026-05-20T07:25:00.000Z",
+        title: "Request from Advisor C",
+        detail: "Approval workflow - May 20, 07:25 UTC",
+      },
+      {
+        id: "event_public",
+        kind: "public",
+        eventType: "location_public_invite_submitted",
+        occurredAt: "2026-05-20T07:20:00.000Z",
+        title: "Response from Visitor Alpha",
+        detail: "Request link - May 20, 07:20 UTC",
+      },
+    ],
+  };
+}
+
 describe("OneLocationAgentPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -278,6 +342,7 @@ describe("OneLocationAgentPage", () => {
       publicUrl: "/one/location/request/invite_1",
     });
     mockGetState.mockResolvedValue(locationState());
+    mockGetActivity.mockResolvedValue(locationActivity());
     mockSyncCurrentUser.mockResolvedValue({ user_id: "user_a" });
     mockSyncOneLocationContactSignals.mockResolvedValue({
       matches: [],
@@ -370,6 +435,26 @@ describe("OneLocationAgentPage", () => {
     expect(screen.getByText("Public link responses")).toBeTruthy();
     expect(screen.queryByText(/public live-location link/i)).toBeNull();
     expect(screen.queryByText(/whatsapp/i)).toBeNull();
+  });
+
+  it("renders activity history from the One Location activity API without phone-derived labels", async () => {
+    render(<OneLocationAgentPageContent />);
+
+    await waitFor(() =>
+      expect(mockGetActivity).toHaveBeenCalledWith({
+        vaultOwnerToken: "vault-token",
+        range: "30d",
+      }),
+    );
+
+    expect(screen.getByRole("heading", { name: "Location activity" })).toBeTruthy();
+    expect(screen.getByText("Activity history")).toBeTruthy();
+    expect(await screen.findByText("Viewed by Trusted B")).toBeTruthy();
+    expect(screen.getByText("Shared with Trusted B")).toBeTruthy();
+    expect(screen.getByText("Request from Advisor C")).toBeTruthy();
+    expect(screen.getByText("Response from Visitor Alpha")).toBeTruthy();
+    expect(screen.getByLabelText(/One Location activity chart/i)).toBeTruthy();
+    expect(screen.queryByText(/8012|4455|9911/)).toBeNull();
   });
 
   it("tracks public request-link creation without location or identity payloads", async () => {

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -75,8 +75,12 @@ import {
   syncOneLocationContactSignals,
   type OneLocationContactSignalResult,
 } from "@/lib/one-location/contact-signals";
+import { OneLocationActivityDashboard } from "@/components/one-location/activity-dashboard";
+import { buildOneLocationActivityFallback } from "@/lib/one-location/activity";
 import type {
   OneLocationAccessRequest,
+  OneLocationActivityRange,
+  OneLocationActivityResponse,
   OneLocationGrant,
   OneLocationPublicInvite,
   OneLocationPublicInviteSubmission,
@@ -927,6 +931,12 @@ export function OneLocationAgentPageContent() {
   >([]);
   const [contactSignal, setContactSignal] =
     useState<OneLocationContactSignalState>(INITIAL_CONTACT_SIGNAL_STATE);
+  const [activityRange, setActivityRange] =
+    useState<OneLocationActivityRange>("30d");
+  const [activitySnapshot, setActivitySnapshot] =
+    useState<OneLocationActivityResponse | null>(null);
+  const [activityLoading, setActivityLoading] = useState(false);
+  const [activityError, setActivityError] = useState<string | null>(null);
   const [durationHours, setDurationHours] = useState("1");
   const [requestMessage, setRequestMessage] = useState("");
   const [referralTargets, setReferralTargets] = useState<
@@ -1040,6 +1050,41 @@ export function OneLocationAgentPageContent() {
     () => state?.publicInviteSubmissions ?? [],
     [state?.publicInviteSubmissions],
   );
+  const fallbackActivity = useMemo(
+    () => buildOneLocationActivityFallback(state, auth.userId, activityRange),
+    [activityRange, auth.userId, state],
+  );
+  const locationActivity = activitySnapshot ?? fallbackActivity;
+
+  useEffect(() => {
+    if (!auth.userId || !vaultOwnerToken || !state) {
+      setActivitySnapshot(null);
+      setActivityLoading(false);
+      return;
+    }
+    let active = true;
+    setActivityLoading(true);
+    setActivityError(null);
+    OneLocationService.getActivity({
+      vaultOwnerToken,
+      range: activityRange,
+    })
+      .then((activity) => {
+        if (!active) return;
+        setActivitySnapshot(activity);
+      })
+      .catch(() => {
+        if (!active) return;
+        setActivitySnapshot(null);
+        setActivityError("Showing current page activity while history sync catches up.");
+      })
+      .finally(() => {
+        if (active) setActivityLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [activityRange, auth.userId, state, vaultOwnerToken]);
 
   const openLocationShareFromNotification = useCallback(
     (grantId: string) => {
@@ -2685,6 +2730,17 @@ export function OneLocationAgentPageContent() {
             </div>
 
             <div className="space-y-6">
+              <OneLocationActivityDashboard
+                activity={locationActivity}
+                range={activityRange}
+                loading={activityLoading}
+                error={activityError}
+                onRangeChange={(value) => {
+                  setActivityRange(value);
+                  setActivitySnapshot(null);
+                }}
+              />
+
               <section className="space-y-2 px-1">
                 {sectionLabel("People who can see me")}
                 <div className={onePanelClassName}>

--- a/hushh-webapp/components/one-location/activity-dashboard.tsx
+++ b/hushh-webapp/components/one-location/activity-dashboard.tsx
@@ -1,0 +1,297 @@
+import type { LucideIcon } from "lucide-react";
+import { BarChart3, CalendarDays, Clock3, Loader2 } from "lucide-react";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type {
+  OneLocationActivityKind,
+  OneLocationActivityRange,
+  OneLocationActivityResponse,
+} from "@/lib/one-location/types";
+import { cn } from "@/lib/utils";
+
+const ACTIVITY_RANGE_OPTIONS: {
+  value: OneLocationActivityRange;
+  label: string;
+}[] = [
+  { value: "7d", label: "7 days" },
+  { value: "30d", label: "30 days" },
+  { value: "90d", label: "90 days" },
+  { value: "all", label: "All time" },
+];
+
+const activityPanelClassName =
+  "overflow-hidden rounded-[20px] border border-black/[0.05] bg-white shadow-[0_1px_2px_rgba(0,0,0,0.04),0_10px_30px_rgba(15,23,42,0.05)] dark:border-white/[0.08] dark:bg-[#1c1c1e]/90 dark:shadow-[0_12px_38px_rgba(0,0,0,0.28)]";
+
+function activityRangeLabel(range: OneLocationActivityRange): string {
+  return (
+    ACTIVITY_RANGE_OPTIONS.find((option) => option.value === range)?.label ||
+    "Selected range"
+  );
+}
+
+function activityEventToneClassName(kind: OneLocationActivityKind): string {
+  if (kind === "share") {
+    return "bg-[#eaf9ef] text-[#2dbd5a] dark:bg-emerald-400/15 dark:text-emerald-200";
+  }
+  if (kind === "request") {
+    return "bg-[#eaf3ff] text-[#007aff] dark:bg-[#0a84ff]/15 dark:text-[#76b7ff]";
+  }
+  return "bg-[#fff3e6] text-[#ff9500] dark:bg-orange-400/15 dark:text-orange-200";
+}
+
+function ActivitySectionLabel({ title }: { title: string }) {
+  return (
+    <div
+      role="heading"
+      aria-level={2}
+      className="ml-1 flex items-center gap-1.5 text-[12px] font-semibold uppercase tracking-[0.08em] text-[#8e8e93] dark:text-white/45"
+    >
+      {title}
+    </div>
+  );
+}
+
+function ActivityMetricTile({
+  label,
+  value,
+  detail,
+}: {
+  label: string;
+  value: number;
+  detail: string;
+}) {
+  return (
+    <div className="rounded-[14px] border border-black/[0.04] bg-[#f7f7fa] p-3 dark:border-white/[0.08] dark:bg-white/[0.07]">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[#8e8e93] dark:text-white/45">
+        {label}
+      </p>
+      <p className="mt-1 text-[24px] font-bold leading-none text-[#1c1c1e] dark:text-white">
+        {value}
+      </p>
+      <p className="mt-1 text-[11px] font-medium text-[#8e8e93] dark:text-white/55">
+        {detail}
+      </p>
+    </div>
+  );
+}
+
+function EmptyActivityState({
+  icon: Icon,
+  title,
+  description,
+}: {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-2 rounded-[14px] border border-dashed border-black/[0.08] bg-[#f7f7fa] p-5 text-center dark:border-white/[0.12] dark:bg-white/[0.05]">
+      <Icon className="h-5 w-5 text-[#8e8e93]" aria-hidden="true" />
+      <p className="text-[14px] font-semibold text-[#1c1c1e] dark:text-white">
+        {title}
+      </p>
+      <p className="max-w-[320px] text-[12px] leading-5 text-[#8e8e93] dark:text-white/55">
+        {description}
+      </p>
+    </div>
+  );
+}
+
+export function OneLocationActivityDashboard({
+  activity,
+  range,
+  loading,
+  error,
+  onRangeChange,
+}: {
+  activity: OneLocationActivityResponse;
+  range: OneLocationActivityRange;
+  loading: boolean;
+  error: string | null;
+  onRangeChange: (value: OneLocationActivityRange) => void;
+}) {
+  const maxBucketTotal = Math.max(
+    1,
+    ...activity.buckets.map((bucket) => bucket.total),
+  );
+  const recentEvents = activity.events.slice(0, 5);
+
+  return (
+    <section className="space-y-2 px-1">
+      <ActivitySectionLabel title="Location activity" />
+      <div className={cn(activityPanelClassName, "space-y-4 p-3.5")}>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="flex min-w-0 items-start gap-3">
+            <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#eaf3ff] text-[#007aff] dark:bg-[#0a84ff]/15 dark:text-[#76b7ff]">
+              {loading ? (
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+              ) : (
+                <BarChart3 className="h-4 w-4" aria-hidden="true" />
+              )}
+            </span>
+            <div className="min-w-0">
+              <h3 className="text-[15px] font-bold tracking-tight text-[#1c1c1e] dark:text-white">
+                Activity history
+              </h3>
+              <p className="mt-1 text-[12px] leading-5 text-[#8e8e93] dark:text-white/55">
+                {error ||
+                  `${activityRangeLabel(range)} of shares, requests, views, and link responses.`}
+              </p>
+            </div>
+          </div>
+          <Select
+            value={range}
+            onValueChange={(value) =>
+              onRangeChange(value as OneLocationActivityRange)
+            }
+          >
+            <SelectTrigger className="h-9 w-full rounded-[12px] border-black/[0.04] bg-white text-[13px] shadow-sm sm:w-[132px] dark:border-white/[0.08] dark:bg-white/[0.07]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {ACTIVITY_RANGE_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="grid gap-2 sm:grid-cols-3">
+          <ActivityMetricTile
+            label="Shared with"
+            value={activity.summary.sharedWithCount}
+            detail={`${activity.summary.activeShareCount} active now`}
+          />
+          <ActivityMetricTile
+            label="Requests"
+            value={
+              activity.summary.requestsReceivedCount +
+              activity.summary.requestsSentCount
+            }
+            detail={`${activity.summary.requestsReceivedCount} in / ${activity.summary.requestsSentCount} out`}
+          />
+          <ActivityMetricTile
+            label="Views"
+            value={activity.summary.viewsCount}
+            detail={`${activity.summary.publicResponseCount} public responses`}
+          />
+        </div>
+
+        {activity.buckets.length ? (
+          <div
+            aria-label={`One Location activity chart for ${activityRangeLabel(
+              range,
+            )}`}
+            className="rounded-[14px] border border-black/[0.04] bg-white/70 p-3 dark:border-white/[0.08] dark:bg-white/[0.04]"
+          >
+            <div className="flex h-32 items-end gap-2">
+              {activity.buckets.map((bucket) => {
+                const height = Math.max(12, (bucket.total / maxBucketTotal) * 100);
+                return (
+                  <div
+                    key={bucket.key}
+                    className="flex min-w-0 flex-1 flex-col items-center gap-1"
+                  >
+                    <div className="flex h-24 w-full items-end">
+                      <div
+                        className="flex w-full flex-col justify-end overflow-hidden rounded-t-[8px] bg-[#e5e5ea] dark:bg-white/10"
+                        style={{ height: `${height}%` }}
+                        title={`${bucket.label}: ${bucket.total} activities`}
+                      >
+                        {bucket.publicActivity > 0 ? (
+                          <span
+                            className="block bg-[#ff9500]"
+                            style={{
+                              flexGrow: bucket.publicActivity,
+                              minHeight: 3,
+                            }}
+                          />
+                        ) : null}
+                        {bucket.requests > 0 ? (
+                          <span
+                            className="block bg-[#007aff]"
+                            style={{ flexGrow: bucket.requests, minHeight: 3 }}
+                          />
+                        ) : null}
+                        {bucket.shares > 0 ? (
+                          <span
+                            className="block bg-[#34c759]"
+                            style={{ flexGrow: bucket.shares, minHeight: 3 }}
+                          />
+                        ) : null}
+                      </div>
+                    </div>
+                    <span className="max-w-full truncate text-[10px] font-semibold text-[#8e8e93] dark:text-white/45">
+                      {bucket.label}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+            <div className="mt-3 flex flex-wrap gap-2 text-[11px] font-semibold text-[#8e8e93] dark:text-white/50">
+              <span className="inline-flex items-center gap-1">
+                <span className="h-2 w-2 rounded-full bg-[#34c759]" />
+                Shares
+              </span>
+              <span className="inline-flex items-center gap-1">
+                <span className="h-2 w-2 rounded-full bg-[#007aff]" />
+                Requests
+              </span>
+              <span className="inline-flex items-center gap-1">
+                <span className="h-2 w-2 rounded-full bg-[#ff9500]" />
+                Links
+              </span>
+            </div>
+          </div>
+        ) : (
+          <EmptyActivityState
+            icon={CalendarDays}
+            title="No activity in this range"
+            description="Shares, requests, views, and request-link responses will appear here."
+          />
+        )}
+
+        {recentEvents.length ? (
+          <div className="space-y-2">
+            <p className="ml-1 text-[11px] font-semibold uppercase tracking-[0.08em] text-[#8e8e93] dark:text-white/45">
+              Recent history
+            </p>
+            <div className="space-y-2">
+              {recentEvents.map((event) => (
+                <div
+                  key={event.id}
+                  className="flex items-start gap-3 rounded-[14px] bg-[#f7f7fa] p-3 dark:bg-white/[0.07]"
+                >
+                  <span
+                    className={cn(
+                      "mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full",
+                      activityEventToneClassName(event.kind),
+                    )}
+                  >
+                    <Clock3 className="h-4 w-4" aria-hidden="true" />
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-[14px] font-semibold text-[#1c1c1e] dark:text-white">
+                      {event.title}
+                    </p>
+                    <p className="mt-0.5 truncate text-[12px] font-medium text-[#8e8e93] dark:text-white/55">
+                      {event.detail}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/hushh-webapp/lib/one-location/activity.ts
+++ b/hushh-webapp/lib/one-location/activity.ts
@@ -1,0 +1,364 @@
+import type {
+  OneLocationAccessRequest,
+  OneLocationActivityBucket,
+  OneLocationActivityEvent,
+  OneLocationActivityKind,
+  OneLocationActivityRange,
+  OneLocationActivityResponse,
+  OneLocationGrant,
+  OneLocationPublicInviteSubmission,
+  OneLocationState,
+} from "@/lib/one-location/types";
+
+function formatDateTime(value?: string | null): string {
+  if (!value) return "Not set";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date);
+}
+
+function safeLabel(value?: string | null, fallback = "KAI member"): string {
+  return String(value || "").trim() || fallback;
+}
+
+function grantCounterpartyLabel(grant: OneLocationGrant): string {
+  return safeLabel(grant.recipientDisplayName);
+}
+
+function receivedGrantOwnerLabel(grant: OneLocationGrant): string {
+  return safeLabel(
+    grant.ownerDisplayName || grant.recipientDisplayName,
+    "A trusted person",
+  );
+}
+
+function requestLabel(request: OneLocationAccessRequest): string {
+  return safeLabel(request.requesterDisplayName, "Someone from KAI");
+}
+
+function publicSubmissionLabel(
+  submission: OneLocationPublicInviteSubmission,
+): string {
+  return safeLabel(submission.visitorDisplayName, "Public request");
+}
+
+function parseActivityDate(value?: string | null): Date | null {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function activityRangeStart(range: OneLocationActivityRange): Date | null {
+  if (range === "all") return null;
+  const days = range === "7d" ? 7 : range === "30d" ? 30 : 90;
+  const start = new Date();
+  start.setHours(0, 0, 0, 0);
+  start.setDate(start.getDate() - days + 1);
+  return start;
+}
+
+function isDateInActivityRange(
+  value: string | null | undefined,
+  range: OneLocationActivityRange,
+): boolean {
+  const date = parseActivityDate(value);
+  if (!date) return false;
+  const start = activityRangeStart(range);
+  return !start || date >= start;
+}
+
+function activityTimestamp(value: string | null | undefined): string | null {
+  const date = parseActivityDate(value);
+  return date ? date.toISOString() : null;
+}
+
+function activityBucketKey(
+  date: Date,
+  range: OneLocationActivityRange,
+): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  if (range === "90d" || range === "all") {
+    return `${year}-${month}`;
+  }
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function activityBucketLabel(
+  date: Date,
+  range: OneLocationActivityRange,
+): string {
+  if (range === "90d" || range === "all") {
+    return new Intl.DateTimeFormat(undefined, {
+      month: "short",
+      year: "numeric",
+    }).format(date);
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+  }).format(date);
+}
+
+function activityBucketStartValue(
+  date: Date,
+  range: OneLocationActivityRange,
+): number {
+  if (range === "90d" || range === "all") {
+    return new Date(date.getFullYear(), date.getMonth(), 1).getTime();
+  }
+  return new Date(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate(),
+  ).getTime();
+}
+
+function emptyActivity(range: OneLocationActivityRange): OneLocationActivityResponse {
+  return {
+    range,
+    summary: {
+      sharedWithCount: 0,
+      activeShareCount: 0,
+      requestsReceivedCount: 0,
+      requestsSentCount: 0,
+      viewsCount: 0,
+      publicLinkCount: 0,
+      publicResponseCount: 0,
+      totalEvents: 0,
+    },
+    events: [],
+    buckets: [],
+  };
+}
+
+export function buildOneLocationActivityFallback(
+  state: OneLocationState | null,
+  currentUserId: string | null | undefined,
+  range: OneLocationActivityRange,
+): OneLocationActivityResponse {
+  if (!state) return emptyActivity(range);
+
+  const recipientLabels = new Map(
+    state.recipients.map((recipient) => [
+      recipient.userId,
+      safeLabel(recipient.displayName),
+    ]),
+  );
+  const labelForUser = (userId?: string | null, fallback = "KAI member") =>
+    safeLabel(userId ? recipientLabels.get(userId) : null, fallback);
+  const events: OneLocationActivityEvent[] = [];
+  const addEvent = ({
+    id,
+    kind,
+    occurredAt,
+    title,
+    detail,
+  }: {
+    id: string;
+    kind: OneLocationActivityKind;
+    occurredAt?: string | null;
+    title: string;
+    detail: string;
+  }) => {
+    const timestamp = activityTimestamp(occurredAt);
+    if (!timestamp || !isDateInActivityRange(timestamp, range)) return;
+    events.push({ id, kind, occurredAt: timestamp, title, detail });
+  };
+
+  for (const grant of state.ownerGrants) {
+    const startedAt = grant.createdAt || grant.updatedAt || grant.expiresAt;
+    addEvent({
+      id: `owner-grant-created:${grant.id}`,
+      kind: "share",
+      occurredAt: startedAt,
+      title: `Shared with ${grantCounterpartyLabel(grant)}`,
+      detail: `${grant.status} - ${formatDateTime(startedAt)} - ${grant.durationHours}h`,
+    });
+    if (grant.status !== "active") {
+      const stoppedAt = grant.revokedAt || grant.updatedAt || grant.expiresAt;
+      addEvent({
+        id: `owner-grant-stopped:${grant.id}`,
+        kind: "share",
+        occurredAt: stoppedAt,
+        title: `Sharing stopped with ${grantCounterpartyLabel(grant)}`,
+        detail: `${grant.status} - ${formatDateTime(stoppedAt)}`,
+      });
+    }
+  }
+
+  for (const grant of state.receivedGrants) {
+    const startedAt = grant.createdAt || grant.updatedAt || grant.expiresAt;
+    addEvent({
+      id: `received-grant:${grant.id}`,
+      kind: "share",
+      occurredAt: startedAt,
+      title: `Location shared by ${receivedGrantOwnerLabel(grant)}`,
+      detail: `${grant.status} - ${formatDateTime(startedAt)}`,
+    });
+  }
+
+  for (const request of state.requests) {
+    if (request.ownerUserId === currentUserId) {
+      addEvent({
+        id: `request-received:${request.id}`,
+        kind: "request",
+        occurredAt: request.requestedAt,
+        title: `Request from ${requestLabel(request)}`,
+        detail: `${request.status} - ${formatDateTime(request.requestedAt)}`,
+      });
+    } else if (request.requesterUserId === currentUserId) {
+      addEvent({
+        id: `request-sent:${request.id}`,
+        kind: "request",
+        occurredAt: request.requestedAt,
+        title: `Request sent to ${labelForUser(request.ownerUserId)}`,
+        detail: `${request.status} - ${formatDateTime(request.requestedAt)}`,
+      });
+    }
+    if (request.resolvedAt) {
+      addEvent({
+        id: `request-resolved:${request.id}`,
+        kind: "request",
+        occurredAt: request.resolvedAt,
+        title:
+          request.ownerUserId === currentUserId
+            ? `Request decided for ${requestLabel(request)}`
+            : `Request update from ${labelForUser(request.ownerUserId)}`,
+        detail: `${request.status} - ${formatDateTime(request.resolvedAt)}`,
+      });
+    }
+  }
+
+  for (const invite of state.publicInvites) {
+    addEvent({
+      id: `public-link-created:${invite.id}`,
+      kind: "public",
+      occurredAt: invite.createdAt || invite.updatedAt || invite.expiresAt,
+      title: "Request link created",
+      detail: `${invite.status} - expires ${formatDateTime(invite.expiresAt)}`,
+    });
+    if (invite.status !== "active") {
+      const closedAt = invite.revokedAt || invite.updatedAt || invite.expiresAt;
+      addEvent({
+        id: `public-link-closed:${invite.id}`,
+        kind: "public",
+        occurredAt: closedAt,
+        title: "Request link closed",
+        detail: `${invite.status} - ${formatDateTime(closedAt)}`,
+      });
+    }
+  }
+
+  for (const submission of state.publicInviteSubmissions) {
+    addEvent({
+      id: `public-response:${submission.id}`,
+      kind: "public",
+      occurredAt: submission.submittedAt || submission.resolvedAt,
+      title: `Response from ${publicSubmissionLabel(submission)}`,
+      detail: `${submission.requestStatus || submission.status} - ${formatDateTime(
+        submission.submittedAt,
+      )}`,
+    });
+    if (submission.resolvedAt) {
+      addEvent({
+        id: `public-response-resolved:${submission.id}`,
+        kind: "public",
+        occurredAt: submission.resolvedAt,
+        title: `Response decided for ${publicSubmissionLabel(submission)}`,
+        detail: `${submission.requestStatus || submission.status} - ${formatDateTime(
+          submission.resolvedAt,
+        )}`,
+      });
+    }
+  }
+
+  const buckets = new Map<
+    string,
+    OneLocationActivityBucket & { sortValue: number }
+  >();
+  for (const event of events) {
+    const date = parseActivityDate(event.occurredAt);
+    if (!date) continue;
+    const key = activityBucketKey(date, range);
+    const bucket =
+      buckets.get(key) ||
+      ({
+        key,
+        label: activityBucketLabel(date, range),
+        sortValue: activityBucketStartValue(date, range),
+        shares: 0,
+        requests: 0,
+        views: 0,
+        publicActivity: 0,
+        total: 0,
+      } satisfies OneLocationActivityBucket & { sortValue: number });
+    if (event.kind === "share") bucket.shares += 1;
+    if (event.kind === "request") bucket.requests += 1;
+    if (event.kind === "public") bucket.publicActivity += 1;
+    bucket.total += 1;
+    buckets.set(key, bucket);
+  }
+
+  const sharedWithCount = new Set(
+    state.ownerGrants
+      .filter((grant) =>
+        isDateInActivityRange(
+          grant.createdAt || grant.updatedAt || grant.expiresAt,
+          range,
+        ),
+      )
+      .map((grant) => grant.recipientUserId),
+  ).size;
+  const sortedEvents = [...events].sort(
+    (a, b) =>
+      new Date(b.occurredAt).getTime() - new Date(a.occurredAt).getTime(),
+  );
+  const sortedBuckets = [...buckets.values()]
+    .sort((a, b) => a.sortValue - b.sortValue)
+    .slice(-8)
+    .map(({ sortValue: _sortValue, ...bucket }) => bucket);
+
+  return {
+    range,
+    events: sortedEvents,
+    buckets: sortedBuckets,
+    summary: {
+      sharedWithCount,
+      activeShareCount: state.ownerGrants.filter(
+        (grant) => grant.status === "active",
+      ).length,
+      requestsReceivedCount: state.requests.filter(
+        (request) =>
+          request.ownerUserId === currentUserId &&
+          isDateInActivityRange(request.requestedAt, range),
+      ).length,
+      requestsSentCount: state.requests.filter(
+        (request) =>
+          request.requesterUserId === currentUserId &&
+          request.ownerUserId !== currentUserId &&
+          isDateInActivityRange(request.requestedAt, range),
+      ).length,
+      viewsCount: 0,
+      publicLinkCount: state.publicInvites.filter((invite) =>
+        isDateInActivityRange(
+          invite.createdAt || invite.updatedAt || invite.expiresAt,
+          range,
+        ),
+      ).length,
+      publicResponseCount: state.publicInviteSubmissions.filter((submission) =>
+        isDateInActivityRange(
+          submission.submittedAt || submission.resolvedAt,
+          range,
+        ),
+      ).length,
+      totalEvents: sortedEvents.length,
+    },
+  };
+}

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -2,6 +2,8 @@ import { HushhLocation } from "@/lib/capacitor";
 import { ApiError, apiJson } from "@/lib/services/api-client";
 import type {
   OneLocationAccessRequest,
+  OneLocationActivityRange,
+  OneLocationActivityResponse,
   OneLocationEncryptedEnvelope,
   OneLocationGrant,
   OneLocationPublicInvite,
@@ -95,6 +97,19 @@ export class OneLocationService {
     return apiJsonWithRetry<OneLocationState>("/api/one/location/state", {
       headers: jsonAuthHeaders(vaultOwnerToken),
     });
+  }
+
+  static async getActivity(params: {
+    vaultOwnerToken: string;
+    range: OneLocationActivityRange;
+  }): Promise<OneLocationActivityResponse> {
+    const searchParams = new URLSearchParams({ range: params.range });
+    return apiJsonWithRetry<OneLocationActivityResponse>(
+      `/api/one/location/activity?${searchParams.toString()}`,
+      {
+        headers: jsonAuthHeaders(params.vaultOwnerToken),
+      },
+    );
   }
 
   static async createPublicInvite(params: {

--- a/hushh-webapp/lib/one-location/types.ts
+++ b/hushh-webapp/lib/one-location/types.ts
@@ -145,6 +145,49 @@ export type OneLocationState = {
   capabilityScopes: string[];
 };
 
+export type OneLocationActivityRange = "7d" | "30d" | "90d" | "all";
+
+export type OneLocationActivityKind = "share" | "request" | "public";
+
+export type OneLocationActivityEvent = {
+  id: string;
+  kind: OneLocationActivityKind;
+  eventType?: string;
+  occurredAt: string;
+  bucketKey?: string;
+  bucketLabel?: string;
+  title: string;
+  detail: string;
+};
+
+export type OneLocationActivityBucket = {
+  key: string;
+  label: string;
+  shares: number;
+  requests: number;
+  views: number;
+  publicActivity: number;
+  total: number;
+};
+
+type OneLocationActivitySummary = {
+  sharedWithCount: number;
+  activeShareCount: number;
+  requestsReceivedCount: number;
+  requestsSentCount: number;
+  viewsCount: number;
+  publicLinkCount: number;
+  publicResponseCount: number;
+  totalEvents: number;
+};
+
+export type OneLocationActivityResponse = {
+  range: OneLocationActivityRange;
+  summary: OneLocationActivitySummary;
+  buckets: OneLocationActivityBucket[];
+  events: OneLocationActivityEvent[];
+};
+
 export type PlainLocationPoint = {
   latitude: number;
   longitude: number;


### PR DESCRIPTION
﻿## Summary

Adds the next One Location activity-history slice on top of #1834.

This PR adds a compact `/one/location` activity dashboard backed by the existing One Location event metadata records. The dashboard gives users a date-range view of private shares, requests, views, request links, and public link responses without changing the share/request write flow.

## Stack

- Base: `one-location-contact-signal-invites` (#1834)
- Head: `one-location-activity-analytics-view`
- Issue: #1738
- Status: Draft while #1834 remains the lower stacked PR.
- Review compare base: #1834 / `one-location-contact-signal-invites`, not `main` directly.
- Retarget plan: after #1834 lands, retarget this PR to the next current base before final review.

## Reviewer-Agent Readiness

- Canonical attach point: existing `/one/location` route and existing One Location backend route/service surface.
- Current slice only: activity history/dashboard for One Location.
- No parallel route, no parallel service, and no new persistence table.
- Additive API only: `GET /api/one/location/activity?range=7d|30d|90d|all`.
- Existing share, request approval, request-link, and stop-sharing write flows are not changed in this PR.

## Impact Map

- Web: adds the activity dashboard section, range filter, summary metrics, chart, history rows, and current-state fallback.
- Backend: derives activity from existing `one_location_events` metadata records.
- Tests: adds focused route/service/component coverage for the activity response and rendered dashboard.
- iOS/Android: no native surface changes in this slice; the backend endpoint is additive for future tri-flow reuse.

## Privacy Boundary

- Activity response is metadata-only and available to the signed-in user only.
- No raw coordinate fields, raw request-link values, phone digits, or phone-derived identity labels are returned by the new endpoint or shown in the dashboard.
- The dashboard does not bypass existing share, request, stop-sharing, permission, or public-request states.

## Validation

- Protocol route/service pytest suites -> 23 tests green
- Protocol route/service `py_compile` -> clean
- Protocol `ruff check .` -> green
- Protocol `mypy --config-file pyproject.toml --ignore-missing-imports` -> green
- Web `tsc --noEmit` -> green
- Web focused `eslint` for changed One Location files -> green
- Web focused `vitest` for One Location page -> 17 tests green
- `git diff --check` -> clean with CRLF normalization warnings only
- GitHub PR Validation on `e90201d2` -> all blocking jobs green
