### PR TITLE
docs: promote mulesoft private-space handoff

### DIFF
--- a/.codex/skills/future-planner/SKILL.md
+++ b/.codex/skills/future-planner/SKILL.md
@@ -35,6 +35,7 @@ Non-owned surfaces:
 2. Creating or refining planning-only docs under `docs/future/`.
 3. Assessing future concepts against trust boundaries, PKM, consent, delegation, connector access, UX clarity, and operational complexity.
 4. Turning vague future ideas into explicit R&D notes with promotion criteria.
+5. Removing or rerouting future-roadmap docs once repo evidence proves the capability is implemented.
 
 ## Do Not Use
 
@@ -65,8 +66,9 @@ Non-owned surfaces:
    - connector permissions and on-demand consent
    - user-facing trust-state clarity
 7. Record what already exists, what is missing, what needs new primitives, and what should stay out of scope.
-7. Place the output in `docs/future/` unless the work is already approved for execution or belongs in `docs/vision/`.
-8. Add explicit status and promotion criteria to every future-state concept doc.
+8. If repo evidence proves a future item is now implemented or approved for execution, remove it from `docs/future/` or hand it to `docs-governance` for promotion into the current execution docs. Do not leave implemented capabilities framed as future promises.
+9. Place the output in `docs/future/` unless the work is already approved for execution or belongs in `docs/vision/`.
+10. Add explicit status and promotion criteria to every future-state concept doc.
 
 ## Handoff Rules
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -111,6 +111,22 @@ UAT and production now use the same frontend runtime contract shape:
 - one active measurement ID: `NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID`
 - one active GTM ID: `NEXT_PUBLIC_GTM_ID`
 
+### MuleSoft Managed Omni Gateway connectivity
+
+The MuleSoft Managed Omni Gateway private-space handoff lives in:
+
+- [deploy/mulesoft/README.md](./mulesoft/README.md)
+- [docs/reference/operations/mulesoft-managed-omni-private-space.md](../docs/reference/operations/mulesoft-managed-omni-private-space.md)
+
+Start with the read-only inventory before sending final CIDRs or applying GCP network changes:
+
+```bash
+bash deploy/mulesoft/gcp_private_space_inventory.sh
+```
+
+The provisioning script defaults to `ACTION=plan`; use `ACTION=apply` only after MuleSoft peer VPN values and the private endpoint design are reviewed.
+Non-Prod defaults target the US East Ohio lane in GCP `us-east5`.
+
 ---
 
 ## 📋 Prerequisites

--- a/deploy/mulesoft/README.md
+++ b/deploy/mulesoft/README.md
@@ -1,0 +1,100 @@
+# MuleSoft Managed Omni Gateway Connectivity
+
+This folder contains the guarded Hussh-side handoff for MuleSoft Managed Omni Gateway in CloudHub 2.0 Private Spaces.
+
+The scripts default to read-only or dry-run behavior. Live GCP network changes are externally visible infrastructure changes, so run `ACTION=apply` only after the partner CIDR, DNS, and VPN values have been reviewed.
+
+The canonical current-state handoff is [MuleSoft Managed Omni Gateway Private Space Handoff](../../docs/reference/operations/mulesoft-managed-omni-private-space.md).
+
+## Current Defaults
+
+| Environment | Project | Region | Partner VPC | Hussh service subnet | Proxy-only subnet | MuleSoft CIDRs | Hussh ASN |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `nonprod` | `hushh-pda-uat` | `us-east5` | `hushh-mulesoft-np-ohio-vpc` | `10.88.0.0/24` | `10.88.1.0/24` | `10.81.0.0/22` | `64520` |
+| `prod` | `hushh-pda` | `us-east5` | `hushh-mulesoft-prod-ohio-v2-vpc` | `10.98.0.0/24` | `10.98.1.0/24` | `10.91.0.0/22` | `64521` |
+
+Non-Prod and Prod are aligned to US East Ohio end to end for the MuleSoft private connectivity lane. The earlier Non-Prod `us-central1` foundation remains in GCP but is superseded for partner handoff until cleanup is explicitly approved.
+Reserve `10.82.0.0/22` and `10.92.0.0/22` only for future second Private Spaces if MuleSoft explicitly provisions additional spaces. Do not describe those as active CIDRs for the current Non-Prod or Prod Private Space.
+
+## Read-Only Inventory
+
+Run this before sending final CIDRs or applying any infrastructure:
+
+```bash
+bash deploy/mulesoft/gcp_private_space_inventory.sh
+```
+
+The inventory checks:
+
+- networks, subnets, routes, peerings, addresses, VPNs, routers, and Cloud SQL networking
+- Cloud DNS and Serverless VPC Access API status without enabling disabled APIs
+- overlap between proposed CIDRs and current GCP ranges
+- overlap with MuleSoft disallowed ranges
+
+## MuleSoft Live Verification
+
+After the Anypoint Connected App credentials are available locally, verify the live MuleSoft Private Spaces:
+
+```bash
+bash deploy/mulesoft/verify_mulesoft_private_spaces.sh
+```
+
+The verifier checks the live MuleSoft Private Space region, status, version, CIDR, internal DNS, VPN remote Hussh IPs, and ASNs. It intentionally fails if Prod is still using `10.82.0.0/22`; the approved Prod target is `10.91.0.0/22`.
+
+## Dry-Run Provisioning
+
+Plan Non-Prod:
+
+```bash
+ENV=nonprod ACTION=plan bash deploy/mulesoft/provision_private_space_connectivity.sh
+```
+
+Plan Prod:
+
+```bash
+ENV=prod ACTION=plan bash deploy/mulesoft/provision_private_space_connectivity.sh
+```
+
+## Apply Foundation
+
+Provision the custom VPC, service subnet, proxy-only subnet, Cloud Router, HA VPN gateway shell, private DNS zone, and inbound DNS forwarding policy:
+
+```bash
+ENV=nonprod ACTION=apply PHASE=foundation bash deploy/mulesoft/provision_private_space_connectivity.sh
+ENV=prod ACTION=apply PHASE=foundation bash deploy/mulesoft/provision_private_space_connectivity.sh
+```
+
+This phase does not create VPN tunnels because MuleSoft must first provide peer tunnel values.
+
+## Apply VPN Tunnels
+
+After MuleSoft provides peer details, run with `PHASE=vpn`:
+
+```bash
+ENV=nonprod ACTION=apply PHASE=vpn \
+  MULESOFT_VPN_IP_0=203.0.113.10 \
+  MULESOFT_VPN_IP_1=203.0.113.11 \
+  MULESOFT_ASN=64512 \
+  HUSSH_BGP_IP_0=169.254.10.1 \
+  MULESOFT_BGP_IP_0=169.254.10.2 \
+  HUSSH_BGP_IP_1=169.254.11.1 \
+  MULESOFT_BGP_IP_1=169.254.11.2 \
+  VPN_SHARED_SECRET_0='replace-me' \
+  VPN_SHARED_SECRET_1='replace-me' \
+  bash deploy/mulesoft/provision_private_space_connectivity.sh
+```
+
+Do not commit tunnel secrets, partner peer IPs received under NDA, or generated resolver IPs if the partner marks them confidential.
+
+MuleSoft's downloadable VPN connection guide is the source for `MULESOFT_VPN_IP_*`, `HUSSH_BGP_IP_*`, `MULESOFT_BGP_IP_*`, and `VPN_SHARED_SECRET_*`. Store the downloaded guides under `tmp/mulesoft-vpn-guides/` for local parsing only; do not commit them.
+
+## Private Endpoint
+
+The internal HTTPS endpoint is intentionally not auto-created by the foundation script. It needs a reviewed certificate and backend routing decision:
+
+- private FQDN per environment
+- certificate ownership for that FQDN
+- exact partner API paths to expose
+- Cloud Run ingress posture after public path dependency checks
+
+Until that is approved, MuleSoft should treat internal DNS server IPs as pending until Hussh provisions Cloud DNS inbound forwarding.

--- a/deploy/mulesoft/gcp_private_space_inventory.sh
+++ b/deploy/mulesoft/gcp_private_space_inventory.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CLOUDSDK_CORE_DISABLE_PROMPTS=1
+
+NONPROD_PROJECT="${NONPROD_PROJECT:-hushh-pda-uat}"
+PROD_PROJECT="${PROD_PROJECT:-hushh-pda}"
+REGION="${REGION:-}"
+NONPROD_REGION="${NONPROD_REGION:-${REGION:-us-east5}}"
+PROD_REGION="${PROD_REGION:-${REGION:-us-east5}}"
+NONPROD_MULESOFT_CIDR="${NONPROD_MULESOFT_CIDR:-10.81.0.0/22}"
+NONPROD_MULESOFT_EXTRA_CIDRS="${NONPROD_MULESOFT_EXTRA_CIDRS:-}"
+PROD_MULESOFT_CIDR="${PROD_MULESOFT_CIDR:-10.91.0.0/22}"
+PROD_MULESOFT_EXTRA_CIDRS="${PROD_MULESOFT_EXTRA_CIDRS:-}"
+NONPROD_HUSSH_SERVICE_CIDR="${NONPROD_HUSSH_SERVICE_CIDR:-10.88.0.0/24}"
+NONPROD_HUSSH_PROXY_CIDR="${NONPROD_HUSSH_PROXY_CIDR:-10.88.1.0/24}"
+NONPROD_HUSSH_SERVICE_SUBNET_NAME="${NONPROD_HUSSH_SERVICE_SUBNET_NAME:-hushh-mulesoft-np-services-us-east5}"
+NONPROD_HUSSH_PROXY_SUBNET_NAME="${NONPROD_HUSSH_PROXY_SUBNET_NAME:-hushh-mulesoft-np-proxy-us-east5}"
+PROD_HUSSH_SERVICE_CIDR="${PROD_HUSSH_SERVICE_CIDR:-10.98.0.0/24}"
+PROD_HUSSH_PROXY_CIDR="${PROD_HUSSH_PROXY_CIDR:-10.98.1.0/24}"
+PROD_HUSSH_SERVICE_SUBNET_NAME="${PROD_HUSSH_SERVICE_SUBNET_NAME:-hushh-mulesoft-prod-services-v2-us-east5}"
+PROD_HUSSH_PROXY_SUBNET_NAME="${PROD_HUSSH_PROXY_SUBNET_NAME:-hushh-mulesoft-prod-proxy-v2-us-east5}"
+NONPROD_DB_INSTANCE="${NONPROD_DB_INSTANCE:-hushh-uat-pg}"
+PROD_DB_INSTANCE="${PROD_DB_INSTANCE:-hushh-vault-db}"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "ERROR: required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+log() {
+  echo "[mulesoft-inventory] $*"
+}
+
+run_or_note() {
+  local label="$1"
+  shift
+  echo
+  log "${label}"
+  if ! "$@"; then
+    log "WARN: ${label} failed or is not enabled for this project"
+  fi
+}
+
+api_enabled() {
+  local project="$1"
+  local service="$2"
+  gcloud services list \
+    --project "${project}" \
+    --enabled \
+    --filter="config.name=${service}" \
+    --format="value(config.name)" | grep -qx "${service}"
+}
+
+write_json_or_empty() {
+  local path="$1"
+  shift
+  if "$@" > "${path}" 2>/dev/null; then
+    return
+  fi
+  printf '[]\n' > "${path}"
+}
+
+inspect_project() {
+  local env_name="$1"
+  local project="$2"
+  local db_instance="$3"
+  local tmp_dir="$4"
+  local region="$5"
+  local prefix="${tmp_dir}/${env_name}"
+
+  log "Inspecting ${env_name}: project=${project}, region=${region}"
+
+  write_json_or_empty "${prefix}-subnets.json" \
+    gcloud compute networks subnets list --project "${project}" --format=json
+  write_json_or_empty "${prefix}-routes.json" \
+    gcloud compute routes list --project "${project}" --format=json
+  write_json_or_empty "${prefix}-addresses.json" \
+    gcloud compute addresses list --project "${project}" --format=json
+  write_json_or_empty "${prefix}-peerings.json" \
+    gcloud compute networks peerings list --network=default --project "${project}" --format=json
+  write_json_or_empty "${prefix}-routers.json" \
+    gcloud compute routers list --project "${project}" --regions="${region}" --format=json
+  write_json_or_empty "${prefix}-vpn-gateways.json" \
+    gcloud compute vpn-gateways list --project "${project}" --regions="${region}" --format=json
+  write_json_or_empty "${prefix}-vpn-tunnels.json" \
+    gcloud compute vpn-tunnels list --project "${project}" --regions="${region}" --format=json
+
+  run_or_note "${env_name} networks" \
+    gcloud compute networks list --project "${project}" --format="table(name,autoCreateSubnetworks,routingConfig.routingMode)"
+  run_or_note "${env_name} subnets" \
+    gcloud compute networks subnets list --project "${project}" --format="table(name,region,network,ipCidrRange,purpose,role,privateIpGoogleAccess)"
+  run_or_note "${env_name} routes" \
+    gcloud compute routes list --project "${project}" --format="table(name,destRange,nextHopGateway,nextHopVpnTunnel,priority)"
+  run_or_note "${env_name} peerings" \
+    gcloud compute networks peerings list --network=default --project "${project}" --format="table(name,peerNetwork,state,exportCustomRoutes,importCustomRoutes)"
+  run_or_note "${env_name} Cloud SQL ${db_instance}" \
+    gcloud sql instances describe "${db_instance}" --project "${project}" --format="table(name,region,settings.ipConfiguration.privateNetwork,ipAddresses[].type,ipAddresses[].ipAddress)"
+  run_or_note "${env_name} Cloud Run consent-protocol" \
+    gcloud run services describe consent-protocol --project "${project}" --region "${region}" --format="table(metadata.annotations['run.googleapis.com/ingress'],status.url,spec.template.metadata.annotations['run.googleapis.com/cloudsql-instances'])"
+  run_or_note "${env_name} Cloud Run hushh-webapp" \
+    gcloud run services describe hushh-webapp --project "${project}" --region "${region}" --format="table(metadata.annotations['run.googleapis.com/ingress'],status.url)"
+
+  if api_enabled "${project}" "dns.googleapis.com"; then
+    run_or_note "${env_name} Cloud DNS zones" \
+      gcloud dns managed-zones list --project "${project}" --format="table(name,dnsName,visibility,privateVisibilityConfig.networks[].networkUrl)"
+    run_or_note "${env_name} Cloud DNS policies" \
+      gcloud dns policies list --project "${project}" --format="table(name,enableInboundForwarding,networks[].networkUrl)"
+  else
+    log "${env_name} Cloud DNS API is not enabled"
+  fi
+
+  if api_enabled "${project}" "vpcaccess.googleapis.com"; then
+    run_or_note "${env_name} Serverless VPC Access connectors" \
+      gcloud compute networks vpc-access connectors list --project "${project}" --region "${region}" --format="table(name,region,network,ipCidrRange,state)"
+  else
+    log "${env_name} Serverless VPC Access API is not enabled"
+  fi
+}
+
+check_overlaps() {
+  local tmp_dir="$1"
+  python3 - "$tmp_dir" <<'PY'
+import ipaddress
+import json
+import os
+import pathlib
+import sys
+
+tmp_dir = pathlib.Path(sys.argv[1])
+
+proposed = {
+    "nonprod_mulesoft": os.environ.get("NONPROD_MULESOFT_CIDR", "10.81.0.0/22"),
+    "prod_mulesoft": os.environ.get("PROD_MULESOFT_CIDR", "10.91.0.0/22"),
+    "nonprod_hussh_service": os.environ.get("NONPROD_HUSSH_SERVICE_CIDR", "10.88.0.0/24"),
+    "nonprod_hussh_proxy": os.environ.get("NONPROD_HUSSH_PROXY_CIDR", "10.88.1.0/24"),
+    "prod_hussh_service": os.environ.get("PROD_HUSSH_SERVICE_CIDR", "10.98.0.0/24"),
+    "prod_hussh_proxy": os.environ.get("PROD_HUSSH_PROXY_CIDR", "10.98.1.0/24"),
+}
+
+for idx, cidr in enumerate(filter(None, os.environ.get("NONPROD_MULESOFT_EXTRA_CIDRS", "").split(",")), start=1):
+    proposed[f"nonprod_mulesoft_extra_{idx}"] = cidr.strip()
+
+for idx, cidr in enumerate(filter(None, os.environ.get("PROD_MULESOFT_EXTRA_CIDRS", "").split(",")), start=1):
+    proposed[f"prod_mulesoft_extra_{idx}"] = cidr.strip()
+
+disallowed = {
+    "mulesoft_disallowed_100_64": "100.64.0.0/10",
+    "mulesoft_disallowed_198_19": "198.19.0.0/16",
+    "mulesoft_disallowed_multicast": "224.0.0.0/4",
+    "mulesoft_disallowed_link_local": "169.254.0.0/16",
+    "mulesoft_disallowed_loopback": "127.0.0.0/8",
+    "mulesoft_disallowed_docker": "172.17.0.0/16",
+    "mulesoft_disallowed_this_network": "0.0.0.0/8",
+}
+
+current = {}
+for path in tmp_dir.glob("*-subnets.json"):
+    env = path.name.removesuffix("-subnets.json")
+    for item in json.loads(path.read_text() or "[]"):
+        cidr = item.get("ipCidrRange")
+        name = item.get("name") or "subnet"
+        if cidr:
+            current[f"{env}_subnet_{name}"] = {
+                "type": "subnet",
+                "env": env,
+                "name": name,
+                "cidr": cidr,
+            }
+
+for path in tmp_dir.glob("*-routes.json"):
+    env = path.name.removesuffix("-routes.json")
+    for item in json.loads(path.read_text() or "[]"):
+        cidr = item.get("destRange")
+        name = item.get("name") or "route"
+        if cidr and cidr != "0.0.0.0/0":
+            current[f"{env}_route_{name}"] = {
+                "type": "route",
+                "env": env,
+                "name": name,
+                "cidr": cidr,
+            }
+
+expected_existing_subnets = {
+    "nonprod_hussh_service": [
+        ("nonprod", os.environ.get("NONPROD_HUSSH_SERVICE_SUBNET_NAME", "hushh-mulesoft-np-services-us-east5")),
+        ("nonprod", "hushh-mulesoft-np-services-us-central1"),
+    ],
+    "nonprod_hussh_proxy": [
+        ("nonprod", os.environ.get("NONPROD_HUSSH_PROXY_SUBNET_NAME", "hushh-mulesoft-np-proxy-us-east5")),
+        ("nonprod", "hushh-mulesoft-np-proxy-us-central1"),
+    ],
+    "prod_hussh_service": [
+        ("prod", os.environ.get("PROD_HUSSH_SERVICE_SUBNET_NAME", "hushh-mulesoft-prod-services-v2-us-east5")),
+    ],
+    "prod_hussh_proxy": [
+        ("prod", os.environ.get("PROD_HUSSH_PROXY_SUBNET_NAME", "hushh-mulesoft-prod-proxy-v2-us-east5")),
+    ],
+}
+
+def is_expected_existing_foundation(pname: str, item: dict, pcidr: str) -> bool:
+    expected_subnets = expected_existing_subnets.get(pname)
+    if not expected_subnets:
+        return False
+
+    if item["cidr"] != pcidr:
+        return False
+
+    if item["type"] == "subnet" and any(
+        item["env"] == expected_env and item["name"] == expected_subnet
+        for expected_env, expected_subnet in expected_subnets
+    ):
+        return True
+
+    # GCP creates an opaque local route for each subnet. An exact route match for
+    # the expected subnet CIDR is normal after the foundation has been applied.
+    return item["type"] == "route" and any(
+        item["env"] == expected_env for expected_env, _ in expected_subnets
+    )
+
+failures = []
+for pname, pcidr in proposed.items():
+    pnet = ipaddress.ip_network(pcidr)
+    for dname, dcidr in disallowed.items():
+        if pnet.overlaps(ipaddress.ip_network(dcidr)):
+            failures.append(f"{pname} {pcidr} overlaps {dname} {dcidr}")
+    for cname, item in current.items():
+        ccidr = item["cidr"]
+        try:
+            cnet = ipaddress.ip_network(ccidr)
+        except ValueError:
+            continue
+        if is_expected_existing_foundation(pname, item, pcidr):
+            continue
+        if pnet.overlaps(cnet):
+            failures.append(f"{pname} {pcidr} overlaps current {cname} {ccidr}")
+
+print()
+print("[mulesoft-inventory] Proposed CIDR overlap check")
+if failures:
+    for failure in failures:
+        print(f"ERROR: {failure}")
+    sys.exit(1)
+
+for name, cidr in proposed.items():
+    print(f"OK: {name} {cidr}")
+PY
+}
+
+require_cmd gcloud
+require_cmd python3
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+log "gcloud account/project"
+gcloud config list --format="value(core.account,core.project)"
+
+inspect_project "nonprod" "${NONPROD_PROJECT}" "${NONPROD_DB_INSTANCE}" "${TMP_DIR}" "${NONPROD_REGION}"
+inspect_project "prod" "${PROD_PROJECT}" "${PROD_DB_INSTANCE}" "${TMP_DIR}" "${PROD_REGION}"
+check_overlaps "${TMP_DIR}"

--- a/deploy/mulesoft/provision_private_space_connectivity.sh
+++ b/deploy/mulesoft/provision_private_space_connectivity.sh
@@ -1,0 +1,350 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CLOUDSDK_CORE_DISABLE_PROMPTS=1
+
+ENV="${ENV:-nonprod}"
+ACTION="${ACTION:-plan}"
+PHASE="${PHASE:-foundation}"
+REGION="${REGION:-}"
+
+case "${ENV}" in
+  nonprod)
+    REGION="${REGION:-us-east5}"
+    PROJECT_ID="${PROJECT_ID:-hushh-pda-uat}"
+    VPC_NAME="${VPC_NAME:-hushh-mulesoft-np-ohio-vpc}"
+    SERVICE_SUBNET_NAME="${SERVICE_SUBNET_NAME:-hushh-mulesoft-np-services-us-east5}"
+    SERVICE_SUBNET_CIDR="${SERVICE_SUBNET_CIDR:-10.88.0.0/24}"
+    PROXY_SUBNET_NAME="${PROXY_SUBNET_NAME:-hushh-mulesoft-np-proxy-us-east5}"
+    PROXY_SUBNET_CIDR="${PROXY_SUBNET_CIDR:-10.88.1.0/24}"
+    MULESOFT_PRIVATE_SPACE_CIDR="${MULESOFT_PRIVATE_SPACE_CIDR:-10.81.0.0/22}"
+    DNS_ZONE_NAME="${DNS_ZONE_NAME:-hushh-mulesoft-np-ohio-private}"
+    PRIVATE_DNS_DOMAIN="${PRIVATE_DNS_DOMAIN:-np.hushh-gateway.private}"
+    DNS_POLICY_NAME="${DNS_POLICY_NAME:-hushh-mulesoft-np-ohio-inbound-dns}"
+    ROUTER_NAME="${ROUTER_NAME:-hushh-mulesoft-np-router-us-east5}"
+    VPN_GATEWAY_NAME="${VPN_GATEWAY_NAME:-hushh-mulesoft-np-ha-vpn-us-east5}"
+    HUSSH_ASN="${HUSSH_ASN:-64520}"
+    ;;
+  prod)
+    REGION="${REGION:-us-east5}"
+    PROJECT_ID="${PROJECT_ID:-hushh-pda}"
+    VPC_NAME="${VPC_NAME:-hushh-mulesoft-prod-ohio-v2-vpc}"
+    SERVICE_SUBNET_NAME="${SERVICE_SUBNET_NAME:-hushh-mulesoft-prod-services-v2-us-east5}"
+    SERVICE_SUBNET_CIDR="${SERVICE_SUBNET_CIDR:-10.98.0.0/24}"
+    PROXY_SUBNET_NAME="${PROXY_SUBNET_NAME:-hushh-mulesoft-prod-proxy-v2-us-east5}"
+    PROXY_SUBNET_CIDR="${PROXY_SUBNET_CIDR:-10.98.1.0/24}"
+    MULESOFT_PRIVATE_SPACE_CIDR="${MULESOFT_PRIVATE_SPACE_CIDR:-10.91.0.0/22}"
+    DNS_ZONE_NAME="${DNS_ZONE_NAME:-hushh-mulesoft-prod-v2-private}"
+    PRIVATE_DNS_DOMAIN="${PRIVATE_DNS_DOMAIN:-prod.hushh-gateway.private}"
+    DNS_POLICY_NAME="${DNS_POLICY_NAME:-hushh-mulesoft-prod-v2-inbound-dns}"
+    ROUTER_NAME="${ROUTER_NAME:-hushh-mulesoft-prod-router-v2-us-east5}"
+    VPN_GATEWAY_NAME="${VPN_GATEWAY_NAME:-hushh-mulesoft-prod-ha-vpn-v2-us-east5}"
+    HUSSH_ASN="${HUSSH_ASN:-64521}"
+    ;;
+  *)
+    echo "ERROR: ENV must be nonprod or prod" >&2
+    exit 1
+    ;;
+esac
+
+EXTERNAL_VPN_GATEWAY_NAME="${EXTERNAL_VPN_GATEWAY_NAME:-${VPC_NAME}-mulesoft-peer}"
+VPN_TUNNEL_0="${VPN_TUNNEL_0:-${VPC_NAME}-tunnel-0}"
+VPN_TUNNEL_1="${VPN_TUNNEL_1:-${VPC_NAME}-tunnel-1}"
+ROUTER_INTERFACE_0="${ROUTER_INTERFACE_0:-mulesoft-if-0}"
+ROUTER_INTERFACE_1="${ROUTER_INTERFACE_1:-mulesoft-if-1}"
+BGP_PEER_0="${BGP_PEER_0:-mulesoft-peer-0}"
+BGP_PEER_1="${BGP_PEER_1:-mulesoft-peer-1}"
+MULESOFT_ASN="${MULESOFT_ASN:-64512}"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "ERROR: required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+log() {
+  echo "[mulesoft-provision] $*"
+}
+
+format_command() {
+  local formatted=()
+  local redact_next="false"
+  local arg
+
+  for arg in "$@"; do
+    if [[ "${redact_next}" == "true" ]]; then
+      formatted+=("***redacted***")
+      redact_next="false"
+      continue
+    fi
+
+    case "${arg}" in
+      --shared-secret)
+        formatted+=("${arg}")
+        redact_next="true"
+        ;;
+      --shared-secret=*)
+        formatted+=("--shared-secret=***redacted***")
+        ;;
+      *)
+        formatted+=("${arg}")
+        ;;
+    esac
+  done
+
+  printf "%q " "${formatted[@]}"
+}
+
+run() {
+  log "+ $(format_command "$@")"
+  if [[ "${ACTION}" == "apply" ]]; then
+    "$@"
+  fi
+}
+
+ensure_action() {
+  case "${ACTION}" in
+    plan|apply) ;;
+    *)
+      echo "ERROR: ACTION must be plan or apply" >&2
+      exit 1
+      ;;
+  esac
+}
+
+ensure_phase() {
+  case "${PHASE}" in
+    foundation|vpn|all) ;;
+    *)
+      echo "ERROR: PHASE must be foundation, vpn, or all" >&2
+      exit 1
+      ;;
+  esac
+}
+
+require_vpn_vars() {
+  local missing=()
+  for name in \
+    MULESOFT_VPN_IP_0 \
+    MULESOFT_VPN_IP_1 \
+    HUSSH_BGP_IP_0 \
+    MULESOFT_BGP_IP_0 \
+    HUSSH_BGP_IP_1 \
+    MULESOFT_BGP_IP_1 \
+    VPN_SHARED_SECRET_0 \
+    VPN_SHARED_SECRET_1; do
+    if [[ -z "${!name:-}" ]]; then
+      missing+=("${name}")
+    fi
+  done
+
+  if (( ${#missing[@]} > 0 )); then
+    echo "ERROR: PHASE=vpn requires: ${missing[*]}" >&2
+    exit 1
+  fi
+}
+
+router_status_has() {
+  local pattern="$1"
+  gcloud compute routers get-status "${ROUTER_NAME}" \
+    --project "${PROJECT_ID}" \
+    --region "${REGION}" \
+    --format=json 2>/dev/null | grep -q "\"${pattern}\""
+}
+
+ensure_foundation() {
+  run gcloud services enable \
+    compute.googleapis.com \
+    dns.googleapis.com \
+    certificatemanager.googleapis.com \
+    networkservices.googleapis.com \
+    --project "${PROJECT_ID}"
+
+  if ! gcloud compute networks describe "${VPC_NAME}" --project "${PROJECT_ID}" >/dev/null 2>&1; then
+    run gcloud compute networks create "${VPC_NAME}" \
+      --project "${PROJECT_ID}" \
+      --subnet-mode=custom \
+      --bgp-routing-mode=regional
+  else
+    log "VPC already exists: ${VPC_NAME}"
+  fi
+
+  if ! gcloud compute networks subnets describe "${SERVICE_SUBNET_NAME}" --project "${PROJECT_ID}" --region "${REGION}" >/dev/null 2>&1; then
+    run gcloud compute networks subnets create "${SERVICE_SUBNET_NAME}" \
+      --project "${PROJECT_ID}" \
+      --region "${REGION}" \
+      --network "${VPC_NAME}" \
+      --range "${SERVICE_SUBNET_CIDR}" \
+      --enable-private-ip-google-access
+  else
+    log "Service subnet already exists: ${SERVICE_SUBNET_NAME}"
+  fi
+
+  if ! gcloud compute networks subnets describe "${PROXY_SUBNET_NAME}" --project "${PROJECT_ID}" --region "${REGION}" >/dev/null 2>&1; then
+    run gcloud compute networks subnets create "${PROXY_SUBNET_NAME}" \
+      --project "${PROJECT_ID}" \
+      --region "${REGION}" \
+      --network "${VPC_NAME}" \
+      --range "${PROXY_SUBNET_CIDR}" \
+      --purpose=REGIONAL_MANAGED_PROXY \
+      --role=ACTIVE
+  else
+    log "Proxy-only subnet already exists: ${PROXY_SUBNET_NAME}"
+  fi
+
+  if ! gcloud compute routers describe "${ROUTER_NAME}" --project "${PROJECT_ID}" --region "${REGION}" >/dev/null 2>&1; then
+    run gcloud compute routers create "${ROUTER_NAME}" \
+      --project "${PROJECT_ID}" \
+      --region "${REGION}" \
+      --network "${VPC_NAME}" \
+      --asn "${HUSSH_ASN}"
+  else
+    log "Cloud Router already exists: ${ROUTER_NAME}"
+  fi
+
+  if ! gcloud compute vpn-gateways describe "${VPN_GATEWAY_NAME}" --project "${PROJECT_ID}" --region "${REGION}" >/dev/null 2>&1; then
+    run gcloud compute vpn-gateways create "${VPN_GATEWAY_NAME}" \
+      --project "${PROJECT_ID}" \
+      --region "${REGION}" \
+      --network "${VPC_NAME}"
+  else
+    log "HA VPN gateway already exists: ${VPN_GATEWAY_NAME}"
+  fi
+
+  if ! gcloud dns managed-zones describe "${DNS_ZONE_NAME}" --project "${PROJECT_ID}" >/dev/null 2>&1; then
+    run gcloud dns managed-zones create "${DNS_ZONE_NAME}" \
+      --project "${PROJECT_ID}" \
+      --dns-name "${PRIVATE_DNS_DOMAIN}." \
+      --visibility=private \
+      --networks "${VPC_NAME}" \
+      --description "Private DNS for MuleSoft Managed Omni Gateway ${ENV}"
+  else
+    log "Private DNS zone already exists: ${DNS_ZONE_NAME}"
+  fi
+
+  if ! gcloud dns policies describe "${DNS_POLICY_NAME}" --project "${PROJECT_ID}" >/dev/null 2>&1; then
+    run gcloud dns policies create "${DNS_POLICY_NAME}" \
+      --project "${PROJECT_ID}" \
+      --enable-inbound-forwarding \
+      --networks "${VPC_NAME}" \
+      --description "Inbound DNS forwarding for MuleSoft Managed Omni Gateway ${ENV}"
+  else
+    log "Cloud DNS policy already exists: ${DNS_POLICY_NAME}"
+  fi
+
+  log "Foundation target: env=${ENV}, project=${PROJECT_ID}, vpc=${VPC_NAME}, mulesoft_cidr=${MULESOFT_PRIVATE_SPACE_CIDR}"
+}
+
+ensure_vpn() {
+  require_vpn_vars
+
+  if ! gcloud compute external-vpn-gateways describe "${EXTERNAL_VPN_GATEWAY_NAME}" --project "${PROJECT_ID}" >/dev/null 2>&1; then
+    run gcloud compute external-vpn-gateways create "${EXTERNAL_VPN_GATEWAY_NAME}" \
+      --project "${PROJECT_ID}" \
+      --interfaces "0=${MULESOFT_VPN_IP_0},1=${MULESOFT_VPN_IP_1}" \
+      --redundancy-type TWO_IPS_REDUNDANCY
+  else
+    log "External VPN gateway already exists: ${EXTERNAL_VPN_GATEWAY_NAME}"
+  fi
+
+  if ! gcloud compute vpn-tunnels describe "${VPN_TUNNEL_0}" --project "${PROJECT_ID}" --region "${REGION}" >/dev/null 2>&1; then
+    run gcloud compute vpn-tunnels create "${VPN_TUNNEL_0}" \
+      --project "${PROJECT_ID}" \
+      --region "${REGION}" \
+      --vpn-gateway "${VPN_GATEWAY_NAME}" \
+      --interface 0 \
+      --peer-external-gateway "${EXTERNAL_VPN_GATEWAY_NAME}" \
+      --peer-external-gateway-interface 0 \
+      --router "${ROUTER_NAME}" \
+      --ike-version 2 \
+      --shared-secret "${VPN_SHARED_SECRET_0}"
+  else
+    log "VPN tunnel already exists: ${VPN_TUNNEL_0}"
+  fi
+
+  if ! gcloud compute vpn-tunnels describe "${VPN_TUNNEL_1}" --project "${PROJECT_ID}" --region "${REGION}" >/dev/null 2>&1; then
+    run gcloud compute vpn-tunnels create "${VPN_TUNNEL_1}" \
+      --project "${PROJECT_ID}" \
+      --region "${REGION}" \
+      --vpn-gateway "${VPN_GATEWAY_NAME}" \
+      --interface 1 \
+      --peer-external-gateway "${EXTERNAL_VPN_GATEWAY_NAME}" \
+      --peer-external-gateway-interface 1 \
+      --router "${ROUTER_NAME}" \
+      --ike-version 2 \
+      --shared-secret "${VPN_SHARED_SECRET_1}"
+  else
+    log "VPN tunnel already exists: ${VPN_TUNNEL_1}"
+  fi
+
+  if ! router_status_has "${ROUTER_INTERFACE_0}"; then
+    run gcloud compute routers add-interface "${ROUTER_NAME}" \
+      --project "${PROJECT_ID}" \
+      --region "${REGION}" \
+      --interface-name "${ROUTER_INTERFACE_0}" \
+      --ip-address "${HUSSH_BGP_IP_0}" \
+      --mask-length 30 \
+      --vpn-tunnel "${VPN_TUNNEL_0}"
+  else
+    log "Router interface already exists: ${ROUTER_INTERFACE_0}"
+  fi
+
+  if ! router_status_has "${ROUTER_INTERFACE_1}"; then
+    run gcloud compute routers add-interface "${ROUTER_NAME}" \
+      --project "${PROJECT_ID}" \
+      --region "${REGION}" \
+      --interface-name "${ROUTER_INTERFACE_1}" \
+      --ip-address "${HUSSH_BGP_IP_1}" \
+      --mask-length 30 \
+      --vpn-tunnel "${VPN_TUNNEL_1}"
+  else
+    log "Router interface already exists: ${ROUTER_INTERFACE_1}"
+  fi
+
+  if ! router_status_has "${BGP_PEER_0}"; then
+    run gcloud compute routers add-bgp-peer "${ROUTER_NAME}" \
+      --project "${PROJECT_ID}" \
+      --region "${REGION}" \
+      --peer-name "${BGP_PEER_0}" \
+      --interface "${ROUTER_INTERFACE_0}" \
+      --peer-ip-address "${MULESOFT_BGP_IP_0}" \
+      --peer-asn "${MULESOFT_ASN}" \
+      --advertisement-mode=custom \
+      --set-advertisement-ranges="${SERVICE_SUBNET_CIDR}"
+  else
+    log "BGP peer already exists: ${BGP_PEER_0}"
+  fi
+
+  if ! router_status_has "${BGP_PEER_1}"; then
+    run gcloud compute routers add-bgp-peer "${ROUTER_NAME}" \
+      --project "${PROJECT_ID}" \
+      --region "${REGION}" \
+      --peer-name "${BGP_PEER_1}" \
+      --interface "${ROUTER_INTERFACE_1}" \
+      --peer-ip-address "${MULESOFT_BGP_IP_1}" \
+      --peer-asn "${MULESOFT_ASN}" \
+      --advertisement-mode=custom \
+      --set-advertisement-ranges="${SERVICE_SUBNET_CIDR}"
+  else
+    log "BGP peer already exists: ${BGP_PEER_1}"
+  fi
+}
+
+require_cmd gcloud
+ensure_action
+ensure_phase
+
+log "mode: env=${ENV}, action=${ACTION}, phase=${PHASE}, project=${PROJECT_ID}, region=${REGION}"
+
+if [[ "${PHASE}" == "foundation" || "${PHASE}" == "all" ]]; then
+  ensure_foundation
+fi
+
+if [[ "${PHASE}" == "vpn" || "${PHASE}" == "all" ]]; then
+  ensure_vpn
+fi
+
+if [[ "${ACTION}" == "plan" ]]; then
+  log "Plan mode only. Re-run with ACTION=apply after review."
+fi

--- a/deploy/mulesoft/verify_mulesoft_private_spaces.sh
+++ b/deploy/mulesoft/verify_mulesoft_private_spaces.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_FILE="${MULESOFT_ENV_FILE:-${HOME}/.codex/secrets/mulesoft-mcp.env}"
+ANYPOINT_ORG_ID="${ANYPOINT_ORG_ID:-e01e108f-3e47-4f8c-9c62-688593a501d5}"
+ANYPOINT_BASE_URL="${ANYPOINT_BASE_URL:-https://anypoint.mulesoft.com}"
+
+NONPROD_SPACE_ID="${NONPROD_SPACE_ID:-af4e41bb-c477-4cbe-af63-c6f3d980d227}"
+NONPROD_SPACE_NAME="${NONPROD_SPACE_NAME:-hussh-ps-non-prod-east1}"
+NONPROD_SPACE_REGION="${NONPROD_SPACE_REGION:-us-east-2}"
+NONPROD_MULESOFT_CIDR="${NONPROD_MULESOFT_CIDR:-10.81.0.0/22}"
+NONPROD_DNS_RESOLVER="${NONPROD_DNS_RESOLVER:-10.88.0.2}"
+NONPROD_DNS_DOMAIN="${NONPROD_DNS_DOMAIN:-np.hushh-gateway.private}"
+NONPROD_HUSSH_ASN="${NONPROD_HUSSH_ASN:-64520}"
+NONPROD_HUSSH_VPN_IPS="${NONPROD_HUSSH_VPN_IPS:-34.157.35.157,34.157.163.69}"
+
+PROD_SPACE_ID="${PROD_SPACE_ID:-3c663688-2a9c-461a-936d-b3e21294006a}"
+PROD_SPACE_NAME="${PROD_SPACE_NAME:-hussh-ps-prod-east1}"
+PROD_SPACE_REGION="${PROD_SPACE_REGION:-us-east-2}"
+PROD_MULESOFT_CIDR="${PROD_MULESOFT_CIDR:-10.91.0.0/22}"
+PROD_DNS_RESOLVER="${PROD_DNS_RESOLVER:-10.98.0.2}"
+PROD_DNS_DOMAIN="${PROD_DNS_DOMAIN:-prod.hushh-gateway.private}"
+PROD_HUSSH_ASN="${PROD_HUSSH_ASN:-64521}"
+PROD_HUSSH_VPN_IPS="${PROD_HUSSH_VPN_IPS:-34.157.32.171,34.157.160.164}"
+
+REQUIRE_VPN_READY="${REQUIRE_VPN_READY:-false}"
+
+failures=0
+warnings=0
+
+log() {
+  echo "[mulesoft-verify] $*"
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "ERROR: required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+check_equal() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+
+  if [[ "${actual}" == "${expected}" ]]; then
+    log "OK: ${label}=${actual}"
+  else
+    log "ERROR: ${label} expected ${expected}, actual ${actual:-<empty>}"
+    failures=$((failures + 1))
+  fi
+}
+
+warn_if_not_equal() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+
+  if [[ "${actual}" == "${expected}" ]]; then
+    log "OK: ${label}=${actual}"
+  else
+    log "WARN: ${label} expected ${expected}, actual ${actual:-<empty>}"
+    warnings=$((warnings + 1))
+  fi
+}
+
+fetch_token() {
+  curl -sS --fail \
+    -X POST "${ANYPOINT_BASE_URL}/accounts/api/v2/oauth2/token" \
+    -H "Content-Type: application/json" \
+    --data @- <<EOF | jq -r ".access_token"
+{"grant_type":"client_credentials","client_id":"${ANYPOINT_CLIENT_ID}","client_secret":"${ANYPOINT_CLIENT_SECRET}"}
+EOF
+}
+
+fetch_space() {
+  local token="$1"
+  local space_id="$2"
+
+  curl -sS --fail \
+    "${ANYPOINT_BASE_URL}/runtimefabric/api/organizations/${ANYPOINT_ORG_ID}/privatespaces/${space_id}" \
+    -H "Authorization: Bearer ${token}"
+}
+
+fetch_spaces() {
+  local token="$1"
+
+  curl -sS --fail \
+    "${ANYPOINT_BASE_URL}/runtimefabric/api/organizations/${ANYPOINT_ORG_ID}/privatespaces" \
+    -H "Authorization: Bearer ${token}"
+}
+
+verify_space() {
+  local env_name="$1"
+  local space_file="$2"
+  local list_file="$3"
+  local expected_name="$4"
+  local expected_region="$5"
+  local expected_cidr="$6"
+  local expected_dns="$7"
+  local expected_domain="$8"
+  local expected_asn="$9"
+  local expected_hussh_ips="${10}"
+
+  log "Inspecting ${env_name}: ${expected_name}"
+
+  local actual_name actual_region actual_status actual_version actual_cidr actual_dns actual_domain app_count
+  actual_name="$(jq -r ".name // \"\"" "${space_file}")"
+  actual_region="$(jq -r ".region // \"\"" "${space_file}")"
+  actual_status="$(jq -r ".status // \"\"" "${space_file}")"
+  actual_version="$(jq -r ".version // \"\"" "${space_file}")"
+  actual_cidr="$(jq -r ".network.cidrBlock // \"\"" "${space_file}")"
+  actual_dns="$(jq -r ".network.internalDns.dnsServers[0] // \"\"" "${space_file}")"
+  actual_domain="$(jq -r ".network.internalDns.specialDomains[0] // \"\"" "${space_file}")"
+  app_count="$(jq -r ".muleAppDeploymentCount // 0" "${space_file}")"
+
+  check_equal "${env_name}.name" "${expected_name}" "${actual_name}"
+  check_equal "${env_name}.region" "${expected_region}" "${actual_region}"
+  check_equal "${env_name}.status" "Active" "${actual_status}"
+  check_equal "${env_name}.cidr" "${expected_cidr}" "${actual_cidr}"
+  check_equal "${env_name}.dns_resolver" "${expected_dns}" "${actual_dns}"
+  check_equal "${env_name}.dns_domain" "${expected_domain}" "${actual_domain}"
+  log "OK: ${env_name}.version=${actual_version}"
+  log "OK: ${env_name}.muleAppDeploymentCount=${app_count}"
+
+  IFS="," read -r -a ips <<< "${expected_hussh_ips}"
+  for ip in "${ips[@]}"; do
+    local matches vpn_status tunnel_count tunnel_ready remote_asn local_asn
+    matches="$(jq -r \
+      --arg space "${expected_name}" \
+      --arg ip "${ip}" \
+      '[.content[] | select(.name == $space) | .connections.vpns[]?.vpns[]? | select(.remoteIpAddress == $ip)] | length' \
+      "${list_file}")"
+
+    if [[ "${matches}" == "0" ]]; then
+      log "ERROR: ${env_name}.vpn_remote_ip missing ${ip}"
+      failures=$((failures + 1))
+      continue
+    fi
+
+    vpn_status="$(jq -r \
+      --arg space "${expected_name}" \
+      --arg ip "${ip}" \
+      '.content[] | select(.name == $space) | .connections.vpns[]?.vpns[]? | select(.remoteIpAddress == $ip) | .vpnConnectionStatus' \
+      "${list_file}" | head -n 1)"
+    tunnel_count="$(jq -r \
+      --arg space "${expected_name}" \
+      --arg ip "${ip}" \
+      '.content[] | select(.name == $space) | .connections.vpns[]?.vpns[]? | select(.remoteIpAddress == $ip) | (.vpnTunnels // [] | length)' \
+      "${list_file}" | head -n 1)"
+    tunnel_ready="$(jq -r \
+      --arg space "${expected_name}" \
+      --arg ip "${ip}" \
+      '.content[] | select(.name == $space) | .connections.vpns[]?.vpns[]? | select(.remoteIpAddress == $ip) | ((.vpnTunnels // []) | all(((.ptpCidr // "") != "") and ((.psk // "") != "")))' \
+      "${list_file}" | head -n 1)"
+    remote_asn="$(jq -r \
+      --arg space "${expected_name}" \
+      --arg ip "${ip}" \
+      '.content[] | select(.name == $space) | .connections.vpns[]?.vpns[]? | select(.remoteIpAddress == $ip) | .remoteAsn' \
+      "${list_file}" | head -n 1)"
+    local_asn="$(jq -r \
+      --arg space "${expected_name}" \
+      --arg ip "${ip}" \
+      '.content[] | select(.name == $space) | .connections.vpns[]?.vpns[]? | select(.remoteIpAddress == $ip) | .localAsn' \
+      "${list_file}" | head -n 1)"
+
+    check_equal "${env_name}.vpn.${ip}.remote_asn" "${expected_asn}" "${remote_asn}"
+    check_equal "${env_name}.vpn.${ip}.local_asn" "64512" "${local_asn}"
+    warn_if_not_equal "${env_name}.vpn.${ip}.status" "available" "${vpn_status}"
+    warn_if_not_equal "${env_name}.vpn.${ip}.tunnel_count" "2" "${tunnel_count}"
+
+    if [[ "${tunnel_ready}" == "true" ]]; then
+      log "OK: ${env_name}.vpn.${ip}.tunnel_details_present=true"
+    else
+      log "WARN: ${env_name}.vpn.${ip}.tunnel_details_present=false"
+      warnings=$((warnings + 1))
+      if [[ "${REQUIRE_VPN_READY}" == "true" ]]; then
+        failures=$((failures + 1))
+      fi
+    fi
+  done
+}
+
+require_cmd curl
+require_cmd jq
+
+if [[ -f "${ENV_FILE}" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "${ENV_FILE}"
+  set +a
+fi
+
+: "${ANYPOINT_CLIENT_ID:?Set ANYPOINT_CLIENT_ID or provide ${ENV_FILE}}"
+: "${ANYPOINT_CLIENT_SECRET:?Set ANYPOINT_CLIENT_SECRET or provide ${ENV_FILE}}"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+token="$(fetch_token)"
+if [[ -z "${token}" || "${token}" == "null" ]]; then
+  echo "ERROR: Anypoint token request did not return an access token" >&2
+  exit 1
+fi
+
+fetch_spaces "${token}" > "${tmp_dir}/spaces.json"
+fetch_space "${token}" "${NONPROD_SPACE_ID}" > "${tmp_dir}/nonprod.json"
+fetch_space "${token}" "${PROD_SPACE_ID}" > "${tmp_dir}/prod.json"
+
+verify_space \
+  "nonprod" \
+  "${tmp_dir}/nonprod.json" \
+  "${tmp_dir}/spaces.json" \
+  "${NONPROD_SPACE_NAME}" \
+  "${NONPROD_SPACE_REGION}" \
+  "${NONPROD_MULESOFT_CIDR}" \
+  "${NONPROD_DNS_RESOLVER}" \
+  "${NONPROD_DNS_DOMAIN}" \
+  "${NONPROD_HUSSH_ASN}" \
+  "${NONPROD_HUSSH_VPN_IPS}"
+
+verify_space \
+  "prod" \
+  "${tmp_dir}/prod.json" \
+  "${tmp_dir}/spaces.json" \
+  "${PROD_SPACE_NAME}" \
+  "${PROD_SPACE_REGION}" \
+  "${PROD_MULESOFT_CIDR}" \
+  "${PROD_DNS_RESOLVER}" \
+  "${PROD_DNS_DOMAIN}" \
+  "${PROD_HUSSH_ASN}" \
+  "${PROD_HUSSH_VPN_IPS}"
+
+if (( failures > 0 )); then
+  log "FAILED: ${failures} blocking mismatch(es), ${warnings} warning(s)"
+  exit 1
+fi
+
+log "PASSED: 0 blocking mismatches, ${warnings} warning(s)"

--- a/docs/future/hussh-one-infra/salesforce-mulesoft-brief.md
+++ b/docs/future/hussh-one-infra/salesforce-mulesoft-brief.md
@@ -90,6 +90,20 @@ They must not become:
 - the PCHP replacement
 - a broad plaintext data lake for user memory
 
+## Managed Omni Gateway Private Space Handoff
+
+For the current MuleSoft setup discussion, use Managed Omni Gateway in CloudHub 2.0 Private Spaces rather than a self-managed gateway inside Hussh GCP.
+
+Partner intake values live in [MuleSoft Managed Omni Gateway Private Space Handoff](../../reference/operations/mulesoft-managed-omni-private-space.md). The approved starting posture is:
+
+- Private Space region: `US East (Ohio)` for Non-Prod and Prod private connectivity paths, aligned to GCP `us-east5`.
+- Non-Prod Private Space CIDR: `10.81.0.0/22`.
+- Prod Private Space CIDR: `10.91.0.0/22`.
+- Internal DNS server IPs: pending until Hussh provisions Cloud DNS inbound forwarding.
+- VPN: separate Non-Prod and Prod HA VPN connections with Cloud Router/BGP.
+
+This handoff is network readiness, not consent authority. MuleSoft may route approved partner requests to Hussh; Hussh still validates app, actor, user, scope, expiry, revocation, and audit state before returning a consent status or encrypted scoped export.
+
 ## Enterprise Glossary
 
 | Term | Meaning in this planning lane |

--- a/docs/reference/operations/README.md
+++ b/docs/reference/operations/README.md
@@ -36,6 +36,8 @@ flowchart TD
   root --> n14
   n15["Hussh Code Persona"]
   root --> n15
+  n16["MuleSoft Managed Omni Gateway Private Space"]
+  root --> n16
 ```
 
 Use this as the entrypoint for CI, docs governance, delivery, and environment operations.
@@ -114,6 +116,7 @@ Use `github-contribution-governance` when contribution graph visibility, verifie
 - [observability-event-matrix.md](./observability-event-matrix.md): event taxonomy, emitter map, and dashboard contract.
 - [production-db-backup-and-recovery.md](./production-db-backup-and-recovery.md): production DB recovery guide.
 - [hussh-code-persona.md](./hussh-code-persona.md): durable Hussh engineering and Codex product non-deviation contract.
+- [mulesoft-managed-omni-private-space.md](./mulesoft-managed-omni-private-space.md): current MuleSoft Managed Omni Gateway private-space handoff, live GCP foundation, CIDR/DNS/VPN posture, and acceptance criteria.
 - [coding-agent-mcp.md](./coding-agent-mcp.md): MCP host operations for local engineering environments.
 - [subtree-maintainers.md](./subtree-maintainers.md): maintainer-only subtree sync and upstream coordination.
 - [`../../../consent-protocol/scripts/README.md`](../../../consent-protocol/scripts/README.md): maintainer-only backend script map and when to use it.

--- a/docs/reference/operations/mulesoft-managed-omni-private-space.md
+++ b/docs/reference/operations/mulesoft-managed-omni-private-space.md
@@ -1,0 +1,161 @@
+# MuleSoft Managed Omni Gateway Private Space Handoff
+
+Status: execution handoff. This document records the approved network posture, live GCP foundation, live MuleSoft Private Space verification, and remaining VPN/private-endpoint steps for MuleSoft Managed Omni Gateway, formerly Flex Gateway.
+
+## Visual Map
+
+```mermaid
+flowchart LR
+  sf["Salesforce / Agentforce<br/>partner workflow caller"]
+  ms["MuleSoft Managed Omni Gateway<br/>CloudHub 2.0 Private Space"]
+  vpn["HA VPN + Cloud Router/BGP<br/>separate non-prod and prod"]
+  dns["Hussh private DNS<br/>inbound forwarding"]
+  ilb["Internal HTTPS endpoint<br/>approved partner API only"]
+  api["Hussh Developer API / MCP boundary<br/>consent, status, scoped export"]
+  consent["PCHP / Consent Protocol<br/>ask, approve, audit"]
+  pkm["PKM / vault<br/>encrypted memory boundary"]
+
+  sf --> ms
+  ms --> vpn
+  ms --> dns
+  vpn --> ilb --> api --> consent --> pkm
+```
+
+## Current Truth
+
+Hussh UAT and production currently run in GCP `us-central1`:
+
+| Environment | GCP project | Current runtime | Current network truth |
+| --- | --- | --- | --- |
+| Non-Prod / UAT | `hushh-pda-uat` | Cloud Run `consent-protocol`, `hushh-webapp` | MuleSoft Ohio partner VPC, HA VPN gateway shell, Cloud Router, and private DNS inbound forwarding are live; VPN tunnels and private HTTPS endpoint are not live yet |
+| Prod | `hushh-pda` | Cloud Run `consent-protocol`, `hushh-webapp` | MuleSoft Ohio partner VPC, HA VPN gateway shell, Cloud Router, and private DNS inbound forwarding are live; VPN tunnels and private HTTPS endpoint are not live yet |
+
+Salesforce, MuleSoft, Agentforce, and Omni Gateway remain partner integration lanes. They can route, normalize, observe non-sensitive metadata, and enforce gateway policy. They must not become Hussh's consent engine, vault boundary, PKM store, memory store, or audit authority.
+
+## MuleSoft Intake Answers
+
+| MuleSoft request | Hussh answer |
+| --- | --- |
+| Private Space region | `US East (Ohio)` for Non-Prod and Prod private connectivity paths, aligned to GCP `us-east5`. |
+| Non-Prod Private Space CIDR | `10.81.0.0/22` |
+| Prod Private Space CIDR | `10.91.0.0/22` |
+| CIDR guardrails | The CIDRs must not overlap GCP auto-mode `10.128.0.0/9`, Hussh custom VPC ranges, MuleSoft's disallowed ranges, or reserved VPN/on-prem ranges. |
+| Internal DNS server IPs | Pending until Hussh provisions Cloud DNS inbound forwarding. Do not provide public `run.app`, public `hushh.ai`, or metadata resolver IPs as internal DNS. |
+| Internal DNS domains | `np.hushh-gateway.private` and `prod.hushh-gateway.private`, subject to MuleSoft accepting `.private` as a permitted non-public suffix. |
+| VPN | Separate Non-Prod and Prod HA VPN connections with Cloud Router/BGP. Hussh side ASNs: `64520` for Non-Prod, `64521` for Prod. MuleSoft can use its default private ASN unless it conflicts. |
+
+## Hussh Network Defaults
+
+The dedicated partner VPCs should be custom-mode VPCs. Do not reuse the current auto-mode `default` VPC.
+
+| Environment | Project | Region | Partner VPC | Service subnet | Proxy-only subnet | MuleSoft CIDRs | Hussh ASN |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Non-Prod | `hushh-pda-uat` | `us-east5` | `hushh-mulesoft-np-ohio-vpc` | `10.88.0.0/24` | `10.88.1.0/24` | `10.81.0.0/22` | `64520` |
+| Prod | `hushh-pda` | `us-east5` | `hushh-mulesoft-prod-ohio-v2-vpc` | `10.98.0.0/24` | `10.98.1.0/24` | `10.91.0.0/22` | `64521` |
+
+`10.82.0.0/22` and `10.92.0.0/22` are not active targets for the current single Private Space per environment. They are reserved only if MuleSoft explicitly provisions an additional Private Space later.
+
+## Live Non-Prod Foundation
+
+Status as of 2026-06-01: the Non-Prod foundation is live in `hushh-pda-uat`.
+
+| Resource | Live value |
+| --- | --- |
+| VPC | `hushh-mulesoft-np-ohio-vpc` |
+| Service subnet | `hushh-mulesoft-np-services-us-east5`, `10.88.0.0/24`, Private Google Access enabled |
+| Proxy-only subnet | `hushh-mulesoft-np-proxy-us-east5`, `10.88.1.0/24` |
+| Cloud Router | `hushh-mulesoft-np-router-us-east5`, ASN `64520` |
+| HA VPN gateway | `hushh-mulesoft-np-ha-vpn-us-east5` |
+| Hussh VPN interface 0 public IP | `34.157.35.157` |
+| Hussh VPN interface 1 public IP | `34.157.163.69` |
+| Private DNS zone | `hushh-mulesoft-np-ohio-private`, `np.hushh-gateway.private.` |
+| Cloud DNS inbound policy | `hushh-mulesoft-np-ohio-inbound-dns` |
+| Cloud DNS inbound resolver IP | `10.88.0.2` |
+
+## Live Prod Foundation
+
+Status as of 2026-06-01: the Prod foundation is live in `hushh-pda`.
+
+| Resource | Live value |
+| --- | --- |
+| VPC | `hushh-mulesoft-prod-ohio-v2-vpc` |
+| Service subnet | `hushh-mulesoft-prod-services-v2-us-east5`, `10.98.0.0/24`, Private Google Access enabled |
+| Proxy-only subnet | `hushh-mulesoft-prod-proxy-v2-us-east5`, `10.98.1.0/24` |
+| Cloud Router | `hushh-mulesoft-prod-router-v2-us-east5`, ASN `64521` |
+| HA VPN gateway | `hushh-mulesoft-prod-ha-vpn-v2-us-east5` |
+| Hussh VPN interface 0 public IP | `34.157.32.171` |
+| Hussh VPN interface 1 public IP | `34.157.160.164` |
+| Private DNS zone | `hushh-mulesoft-prod-v2-private`, `prod.hushh-gateway.private.` |
+| Cloud DNS inbound policy | `hushh-mulesoft-prod-v2-inbound-dns` |
+| Cloud DNS inbound resolver IP | `10.98.0.2` |
+
+No MuleSoft VPN tunnels, partner firewall allow rules, internal HTTPS endpoint, or private Cloud Run backend binding exists yet in either environment. Those steps require MuleSoft peer values and the approved private endpoint/certificate design.
+
+## Live MuleSoft Verification
+
+Status as of 2026-06-01 from the MuleSoft CloudHub 2.0 Private Space API:
+
+| Environment | Private Space | Region | Status | Version | Live MuleSoft CIDR | DNS resolver | Domain | Blocking note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Non-Prod | `hussh-ps-non-prod-east1` | `us-east-2` | `Active` | `2.0.491-may26-hop1` | `10.81.0.0/22` | `10.88.0.2` | `np.hushh-gateway.private` | Matches target |
+| Prod | `hussh-ps-prod-east1` | `us-east-2` | `Active` | `2.0.491-may26-hop1` | `10.82.0.0/22` | `10.98.0.2` | `prod.hushh-gateway.private` | Does not match target `10.91.0.0/22` |
+
+The existing Prod Private Space has `muleAppDeploymentCount=0`, so the clean correction path is to replace/recreate the Prod Private Space before establishing VPN tunnels. Do not configure GCP Prod VPN tunnels against the current `10.82.0.0/22` Prod space.
+
+## Implementation Sequence
+
+1. Run the read-only inventory:
+
+   ```bash
+   bash deploy/mulesoft/gcp_private_space_inventory.sh
+   ```
+
+2. Review that the proposed MuleSoft and Hussh VPC ranges do not overlap any current subnet, route, peering, VPN, Cloud SQL private network, or reserved partner range.
+3. Provision Non-Prod first with the guarded repo script in `ACTION=plan` mode, then `ACTION=apply` after review.
+4. Provision Cloud DNS private zone and inbound forwarding, then give MuleSoft the generated inbound resolver IPs and approved private domains.
+5. Configure HA VPN tunnels only after MuleSoft provides peer public IPs, remote ASN, tunnel inside IPs, and tunnel secret handling.
+6. Expose only the approved partner API surface through a private internal HTTPS endpoint. Keep existing public Cloud Run ingress unchanged until current public paths are proven independent from the partner path.
+7. Promote the same pattern to Prod only after Non-Prod DNS, routing, auth, consent audit, and negative access tests pass.
+
+## Security Boundary
+
+MuleSoft may receive and log non-sensitive operational metadata:
+
+- tenant or org identifier
+- app identifier
+- actor identifier
+- workflow name
+- requested scope label
+- request ID, response class, and latency
+
+MuleSoft must not store or receive by default:
+
+- vault keys
+- broad PKM or durable One memory
+- decrypted PKM payloads
+- full KYC packages
+- full email archives
+- reusable credentials or consent tokens outside the approved connector boundary
+
+The Hussh runtime remains the authority for consent validation, expiry, revocation, audit, and encrypted scoped export.
+
+## Acceptance Criteria
+
+Non-Prod must pass before Prod:
+
+1. MuleSoft Private Space resolves the private Hussh FQDN through Hussh DNS inbound forwarding.
+2. MuleSoft can reach only the approved private HTTPS health/API endpoint over VPN.
+3. MuleSoft cannot reach Cloud SQL, broad VPC ranges, vault internals, SSH, RDP, or unrelated services.
+4. Hussh audit records show the actor, app, scope, decision, expiry, and response class for partner requests.
+5. Gateway logs contain only non-sensitive metadata.
+6. BGP route exchange is scoped to the approved CIDRs, with no default route advertisement.
+7. VPN failover is tested before production promotion.
+
+## References
+
+- [MuleSoft Private Space setup information](https://docs.mulesoft.com/cloudhub-2/ps-gather-setup-info)
+- [MuleSoft Private Space creation](https://docs.mulesoft.com/cloudhub-2/ps-create-configure)
+- [MuleSoft Omni Gateway overview](https://docs.mulesoft.com/gateway/latest/)
+- [Salesforce and MuleSoft partner brief](../../future/hussh-one-infra/salesforce-mulesoft-brief.md)
+- [Salesforce HLL architecture](../../future/hussh-one-infra/salesforce-hll-architecture.md)
+- [Hussh Architecture View Catalog](../../reference/architecture/architecture-view-catalog.md)


### PR DESCRIPTION
## Summary
- add guarded MuleSoft Managed Omni Gateway private-space deploy scripts and handoff docs
- promote the live MuleSoft private-space handoff into current operations docs instead of docs/future
- tighten future-planner so implemented capabilities leave future-state docs

## Verification
- ./bin/hushh codex pre-pr
- ./bin/hushh docs verify
- python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py .codex/skills/future-planner --json
- bash -n deploy/mulesoft/gcp_private_space_inventory.sh deploy/mulesoft/provision_private_space_connectivity.sh deploy/mulesoft/verify_mulesoft_private_spaces.sh

## Notes
- Based on origin/main to avoid rolling back the already-deployed governance/vault safeguards.
- This carries the current local MuleSoft handoff work without the stale current-branch history.