### PR TITLE
fix(investors): require Firebase auth on admin create and bulk-create endpoints

### DIFF
--- a/consent-protocol/api/routes/investors.py
+++ b/consent-protocol/api/routes/investors.py
@@ -19,9 +19,10 @@ import re
 from datetime import datetime
 from typing import List, Optional
 
-from fastapi import APIRouter, Body, HTTPException, Path, Query
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query
 from pydantic import BaseModel, Field
 
+from api.middleware import require_firebase_auth
 from hushh_mcp.services.investor_db import InvestorDBService
 
 logger = logging.getLogger(__name__)
@@ -173,11 +174,15 @@ async def get_investor_by_cik(
 
 
 @router.post("/", status_code=201)
-async def create_investor(investor: InvestorCreateRequest):
+async def create_investor(
+    investor: InvestorCreateRequest,
+    _: str = Depends(require_firebase_auth),
+):
     """
     Create or update an investor profile.
 
     Admin endpoint for data ingestion from SEC EDGAR, etc.
+    Requires Firebase authentication.
     """
 
     # Use service layer
@@ -235,6 +240,7 @@ async def create_investor(investor: InvestorCreateRequest):
 @router.post("/bulk", status_code=201)
 async def bulk_create_investors(
     investors: List[InvestorCreateRequest] = Body(...),
+    _: str = Depends(require_firebase_auth),
 ):
     """
     Bulk create investor profiles from list.

--- a/consent-protocol/tests/test_investor_input_bounds.py
+++ b/consent-protocol/tests/test_investor_input_bounds.py
@@ -24,8 +24,11 @@ from api.routes.investors import _BULK_INVESTOR_MAX, router
 def _build_client() -> TestClient:
     from fastapi import FastAPI
 
+    from api.middleware import require_firebase_auth
+
     app = FastAPI()
     app.include_router(router)
+    app.dependency_overrides[require_firebase_auth] = lambda: "test_uid"
     return TestClient(app, raise_server_exceptions=False)
 
 

--- a/consent-protocol/tests/test_public_routes_cwe209_exception_detail.py
+++ b/consent-protocol/tests/test_public_routes_cwe209_exception_detail.py
@@ -44,8 +44,11 @@ def _tickers_client() -> TestClient:
 
 
 def _investors_client() -> TestClient:
+    from api.middleware import require_firebase_auth
+
     app = FastAPI()
     app.include_router(investors_router)
+    app.dependency_overrides[require_firebase_auth] = lambda: "test_uid"
     return TestClient(app, raise_server_exceptions=False)
 
 


### PR DESCRIPTION
## Problem

POST /api/investors/ and POST /api/investors/bulk are admin data-ingestion endpoints that write investor profiles to the database. Neither route had authentication, allowing any unauthenticated caller to trigger database writes (CWE-639 authorization bypass).

## Fix

Added \`require_firebase_auth\` dependency to both handlers:

```python
async def create_investor(
    investor: InvestorCreateRequest,
    _: str = Depends(require_firebase_auth),
): ...

async def bulk_create_investors(
    investors: List[InvestorCreateRequest] = Body(...),
    _: str = Depends(require_firebase_auth),
): ...
```

## Files Changed

- \`consent-protocol/api/routes/investors.py\` (2 endpoints hardened)
- \`consent-protocol/tests/test_investor_input_bounds.py\` (test fixture updated)
- \`consent-protocol/tests/test_public_routes_cwe209_exception_detail.py\` (test fixture updated)

## Tests

All 60 investor-related tests pass. Two test fixtures updated to inject the Firebase auth dependency so they continue to exercise route behavior without network calls.