### PR TITLE
fix(cache): skip cache hydration for unresolved PKM identities

### DIFF
--- a/hushh-webapp/__tests__/services/pkm-cache.test.ts
+++ b/hushh-webapp/__tests__/services/pkm-cache.test.ts
@@ -143,6 +143,17 @@ describe("PKM cache behavior", () => {
     expect(result.totalAttributes).toBe(19);
   });
 
+  it("skips cache hydration for unresolved PKM identities", async () => {
+    const userId = "user-unresolved";
+
+    apiFetchMock.mockResolvedValue(new Response("not found", { status: 404 }));
+
+    const result = await PersonalKnowledgeModelService.getMetadata(userId, false, "vault-owner-token");
+
+    expect(result).toEqual(PersonalKnowledgeModelService.emptyMetadata(userId));
+    expect(CacheService.getInstance().peek(CACHE_KEYS.PKM_METADATA(userId))).toBeNull();
+  });
+
   it("reads encrypted user/domain blobs from cache on subsequent calls", async () => {
     apiFetchMock.mockImplementation(async (url: string) => {
       if (url.includes("/api/pkm/data/user-1")) {

--- a/hushh-webapp/lib/services/personal-knowledge-model-service.ts
+++ b/hushh-webapp/lib/services/personal-knowledge-model-service.ts
@@ -1370,6 +1370,8 @@ export class PersonalKnowledgeModelService {
 
         // Handle 404 as valid "no data" response for new users
         if (response.status === 404) {
+          persistToDeviceCache = false;
+          shouldCacheResult = false;
           result = this.emptyMetadata(userId);
         } else if (response.status === 401 || response.status === 403) {
           // Token may be missing/expired/revoked during startup transitions.


### PR DESCRIPTION
## Description

Skips cache hydration when the associated PKM identity cannot be resolved, ensuring cache operations only occur under a valid and verified ownership context.

## Why

PKM cache hydration relies on a valid identity to establish ownership, consent scope, and vault boundaries. Attempting to hydrate cache entries for unresolved identities can lead to unnecessary processing, inconsistent state, incorrect cache population, or downstream failures.

This change ensures cache hydration only proceeds when the canonical PKM identity has been successfully resolved.

## What changed

- Added validation for PKM identity resolution before cache hydration
- Skipped hydration when identity context is unavailable or unresolved
- Preserved existing cache behavior for valid PKM identities
- Maintained existing vault, consent, and PKM ownership contracts

## Impact

- No API changes
- No schema changes
- No cache contract changes
- Improves cache correctness and runtime safety

## Testing

- Ran `npm run lint`
- Ran `npm run build`
- Verified cache hydration is skipped for unresolved PKM identities
- Verified valid PKM identities continue hydrating cache correctly
- Verified no regression in existing cache and sync flows

## Notes

This PR intentionally focuses on cache hydration safety only and does not introduce new cache layers, memory systems, identity providers, or changes to PKM ownership contracts.