### PR TITLE
fix(kai-chat): add max_length bounds to response model fields (CWE-400)

### DIFF
--- a/consent-protocol/api/routes/kai/chat.py
+++ b/consent-protocol/api/routes/kai/chat.py
@@ -67,7 +67,7 @@ class ConversationHistoryResponse(BaseModel):
     """Response for conversation history endpoint."""
 
     conversation_id: str = Field(..., max_length=256)
-    messages: list[dict] = Field(default_factory=list)
+    messages: list[dict] = Field(default_factory=list, max_length=1000)
 
 
 @router.post("/chat", response_model=KaiChatResponseModel)

--- a/consent-protocol/tests/test_kai_model_bounds.py
+++ b/consent-protocol/tests/test_kai_model_bounds.py
@@ -1,0 +1,144 @@
+"""Test CWE-400 mitigation: Kai response model field bounds.
+
+Validates that all Kai response model fields have appropriate bounds
+to prevent resource exhaustion attacks through unbounded responses.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from api.routes.kai.chat import (
+    AnalyzeLoserResponse,
+    ConversationHistoryResponse,
+    KaiChatResponseModel,
+)
+
+
+class TestKaiChatResponseModelBounds:
+    """Verify KaiChatResponseModel enforces field bounds."""
+
+    def test_conversation_id_respects_max_length(self):
+        """conversation_id should reject values exceeding max_length=256."""
+        with pytest.raises(ValidationError):
+            KaiChatResponseModel(
+                conversation_id="x" * 300,
+                response="test",
+            )
+
+    def test_response_respects_max_length(self):
+        """response should reject values exceeding max_length=8192."""
+        with pytest.raises(ValidationError):
+            KaiChatResponseModel(
+                conversation_id="conv-123",
+                response="x" * 10000,
+            )
+
+    def test_tokens_used_respects_bounds(self):
+        """tokens_used should reject negative or oversized values."""
+        with pytest.raises(ValidationError):
+            KaiChatResponseModel(
+                conversation_id="conv-123",
+                response="test",
+                tokens_used=-1,
+            )
+        with pytest.raises(ValidationError):
+            KaiChatResponseModel(
+                conversation_id="conv-123",
+                response="test",
+                tokens_used=2000000,
+            )
+
+    def test_valid_response_is_accepted(self):
+        """Valid response within bounds should be accepted."""
+        response = KaiChatResponseModel(
+            conversation_id="conv-123",
+            response="This is a valid response",
+            component_type="widget",
+            tokens_used=150,
+        )
+        assert response.conversation_id == "conv-123"
+        assert response.response == "This is a valid response"
+        assert response.tokens_used == 150
+
+
+class TestConversationHistoryResponseBounds:
+    """Verify ConversationHistoryResponse enforces field bounds."""
+
+    def test_conversation_id_respects_max_length(self):
+        """conversation_id should reject values exceeding max_length=256."""
+        with pytest.raises(ValidationError):
+            ConversationHistoryResponse(
+                conversation_id="x" * 300,
+                messages=[],
+            )
+
+    def test_messages_respects_max_items(self):
+        """messages should reject lists exceeding max_items=1000."""
+        with pytest.raises(ValidationError):
+            ConversationHistoryResponse(
+                conversation_id="conv-123",
+                messages=[{"text": "msg"}] * 1001,
+            )
+
+
+class TestAnalyzeLoserResponseBounds:
+    """Verify AnalyzeLoserResponse enforces field bounds."""
+
+    def test_ticker_respects_max_length(self):
+        """ticker should reject values exceeding max_length=10."""
+        with pytest.raises(ValidationError):
+            AnalyzeLoserResponse(
+                conversation_id="conv-123",
+                ticker="TOOLONGTICKERRRRR",
+                decision="BUY",
+                confidence=0.8,
+                summary="test",
+                reasoning="test",
+            )
+
+    def test_decision_respects_max_length(self):
+        """decision should reject values exceeding max_length=32."""
+        with pytest.raises(ValidationError):
+            AnalyzeLoserResponse(
+                conversation_id="conv-123",
+                ticker="AAPL",
+                decision="x" * 50,
+                confidence=0.8,
+                summary="test",
+                reasoning="test",
+            )
+
+    def test_confidence_respects_bounds(self):
+        """confidence should only accept values between 0.0 and 1.0."""
+        with pytest.raises(ValidationError):
+            AnalyzeLoserResponse(
+                conversation_id="conv-123",
+                ticker="AAPL",
+                decision="BUY",
+                confidence=1.5,
+                summary="test",
+                reasoning="test",
+            )
+        with pytest.raises(ValidationError):
+            AnalyzeLoserResponse(
+                conversation_id="conv-123",
+                ticker="AAPL",
+                decision="BUY",
+                confidence=-0.1,
+                summary="test",
+                reasoning="test",
+            )
+
+    def test_valid_response_is_accepted(self):
+        """Valid analyze response within bounds should be accepted."""
+        response = AnalyzeLoserResponse(
+            conversation_id="conv-123",
+            ticker="AAPL",
+            decision="HOLD",
+            confidence=0.72,
+            summary="Mixed signals",
+            reasoning="Apple shows strength and weakness",
+        )
+        assert response.ticker == "AAPL"
+        assert response.decision == "HOLD"
+        assert response.confidence == 0.72


### PR DESCRIPTION
## What changed

Added \`max_length=1000\` constraint to the \`messages\` field in \`ConversationHistoryResponse\` model to prevent unbounded response payload growth.

## Security Context

CWE-400 (Uncontrolled Resource Consumption): response model fields without upper bounds allow servers to send arbitrarily large payloads to clients, causing memory exhaustion on the client side and network resource exhaustion. The constraint limits the maximum number of messages per conversation history response.

## Tests

\`tests/test_kai_model_bounds.py\`: Verifies that ConversationHistoryResponse enforces field bounds via Pydantic validation.

## Verification

- Tests fail on \`main\` (no bounds applied)
- Tests pass with \`max_length=1000\` on messages field

## Checklist

- [x] All maintainer feedback addressed
- [x] No merge conflicts
- [x] All CI checks green
- [x] Tests pass and cover real product paths