### PR TITLE
fix(kai/market): add max_length bounds to query parameters (CWE-400)

### DIFF
--- a/consent-protocol/api/routes/kai/market_insights.py
+++ b/consent-protocol/api/routes/kai/market_insights.py
@@ -2567,10 +2567,11 @@ async def get_market_insights_baseline(
 @router.get("/market/insights/{user_id}")
 async def get_market_insights(
     user_id: str,
-    symbols: str | None = Query(default=None, description="CSV list of symbols, max 8"),
+    symbols: str | None = Query(default=None, max_length=512, description="CSV list of symbols, max 8"),
     days_back: int = Query(default=7, ge=1, le=14),
     pick_source: str | None = Query(
         default=None,
+        max_length=256,
         description="Active market picks source. Only the default source is live today.",
     ),
     token_data: dict = Depends(require_vault_owner_token),
@@ -2625,8 +2626,8 @@ async def get_market_insights(
 @router.get("/stock-preview/{user_id}")
 async def get_stock_preview(
     user_id: str,
-    symbol: str = Query(..., min_length=1, description="Ticker symbol"),
-    pick_source: str | None = Query(default=None),
+    symbol: str = Query(..., min_length=1, max_length=20, description="Ticker symbol"),
+    pick_source: str | None = Query(default=None, max_length=256),
     token_data: dict = Depends(require_vault_owner_token),
 ) -> dict[str, Any]:
     if token_data["user_id"] != user_id:

--- a/consent-protocol/tests/test_kai_market_insights_bounds.py
+++ b/consent-protocol/tests/test_kai_market_insights_bounds.py
@@ -1,0 +1,60 @@
+"""Tests proving market insights route query parameter bounds (CWE-400)."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.middleware import require_vault_owner_token
+from api.routes.kai import market_insights
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+
+    def _mock_require_vault_owner_token():
+        return {"user_id": "user_123", "token": "valid_token"}
+
+    app.dependency_overrides[require_vault_owner_token] = _mock_require_vault_owner_token
+    app.include_router(market_insights.router)
+    return app
+
+
+def test_market_insights_rejects_oversized_symbols_query():
+    client = TestClient(_build_app())
+    response = client.get(
+        "/market/insights/user_123",
+        params={"symbols": "x" * 513},
+    )
+
+    assert response.status_code == 422
+
+
+def test_market_insights_rejects_oversized_pick_source_query():
+    client = TestClient(_build_app())
+    response = client.get(
+        "/market/insights/user_123",
+        params={"pick_source": "x" * 257},
+    )
+
+    assert response.status_code == 422
+
+
+def test_stock_preview_rejects_oversized_symbol_query():
+    client = TestClient(_build_app())
+    response = client.get(
+        "/stock-preview/user_123",
+        params={"symbol": "x" * 21},
+    )
+
+    assert response.status_code == 422
+
+
+def test_stock_preview_rejects_oversized_pick_source_query():
+    client = TestClient(_build_app())
+    response = client.get(
+        "/stock-preview/user_123",
+        params={"symbol": "AAPL", "pick_source": "x" * 257},
+    )
+
+    assert response.status_code == 422


### PR DESCRIPTION
## Problem

Four query parameters across two Kai market insights endpoints had no upper length bound. Arbitrarily large strings could be passed and forwarded into symbol resolution and source normalization logic (CWE-400).

| Endpoint | Parameter | Bound Added |
|---|---|---|
| GET /market/insights/{user_id} | symbols | max_length=512 |
| GET /market/insights/{user_id} | pick_source | max_length=256 |
| GET /stock-preview/{user_id} | symbol | max_length=20 |
| GET /stock-preview/{user_id} | pick_source | max_length=256 |

## Fix

Added max_length constraints to each parameter. Limits reflect practical upper bounds for their semantic meaning: CSV ticker lists, single ticker symbols, and source configuration identifiers.

## Files Changed

- consent-protocol/api/routes/kai/market_insights.py
- consent-protocol/tests/test_kai_market_insights_bounds.py

## Tests

Four tests verify HTTP 422 rejection for oversized inputs on each parameter. All pass.