### PR TITLE
fix(kai): add max_length bounds to user_id path parameters on chat routes (CWE-400)

### DIFF
--- a/consent-protocol/api/routes/kai/chat.py
+++ b/consent-protocol/api/routes/kai/chat.py
@@ -167,7 +167,7 @@ async def get_conversation_history(
 
 @router.get("/chat/conversations/{user_id}")
 async def list_user_conversations(
-    user_id: str,
+    user_id: str = Path(..., max_length=128),
     token_data: dict = Depends(require_vault_owner_token),
     limit: int = Query(default=20, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
@@ -221,7 +221,7 @@ class InitialChatStateResponse(BaseModel):
 
 @router.get("/chat/initial-state/{user_id}", response_model=InitialChatStateResponse)
 async def get_initial_chat_state(
-    user_id: str,
+    user_id: str = Path(..., max_length=128),
     token_data: dict = Depends(require_vault_owner_token),
 ) -> InitialChatStateResponse:
     """


### PR DESCRIPTION
## Problem

GET /chat/conversations/{user_id} and GET /chat/initial-state/{user_id} accepted unbounded user_id path parameters. Without an upper length constraint, callers can supply arbitrarily large strings that are forwarded to conversation listing and state resolution services (CWE-400).

KaiChatRequest.user_id already had max_length=128. The path parameters on these two GET handlers were missing the equivalent bound, creating an inconsistency in the same file.

## Fix

Added Path(max_length=128) to both route handlers:

```python
# Before
async def list_user_conversations(
    user_id: str,
    ...

# After
async def list_user_conversations(
    user_id: str = Path(..., max_length=128),
    ...
```

Same change applied to get_initial_chat_state.

The 128 character limit matches:
- KaiChatRequest.user_id in the same file
- GET /chat/history/{conversation_id} path parameter in the same file
- Firebase UID practical upper bound

## Files Changed

- consent-protocol/api/routes/kai/chat.py (2 path parameter annotations)

## Tests

All 51 existing tests in test_kai_auth_matrix.py pass with no changes required.