### PR TITLE
feat: add One Location stale retry telemetry

### DIFF
--- a/docs/reference/operations/observability-event-matrix.md
+++ b/docs/reference/operations/observability-event-matrix.md
@@ -85,6 +85,20 @@ Every emitted observability event carries centrally added shared params:
 | `gmail_sync_result` | Gmail sync queue/already-running result | `action`, `result` | `hushh-webapp/lib/services/gmail-receipts-service.ts` | sync queue health | GA DebugView |
 | `gmail_receipts_loaded` | Receipt list load result | `result` | `hushh-webapp/lib/services/gmail-receipts-service.ts` | receipts UX quality | GA DebugView |
 
+## One Location
+
+One Location events are metadata-only. They must never include coordinates, ciphertext, raw grant IDs, public tokens, phone values, names, addresses, or decrypted map values.
+
+| Event | Business purpose | Required params | Primary emitter | Destination use | Proof path |
+| --- | --- | --- | --- | --- | --- |
+| `one_location_recommendation_selected` | KAI Circle recipient selection quality without identity payloads | `route_id`, `action`, `selection_surface`, `result`, `selected_count`, `can_receive_location` | `hushh-webapp/app/one/location/page.tsx` | recommendation UX tuning | `npm run verify:analytics`, One Location component tests |
+| `one_location_share_review_opened` | Safety review exposure before sensitive private sharing | `route_id`, `result`, `selected_count`, `duration_bucket`, review warning booleans | `hushh-webapp/app/one/location/page.tsx` | review friction and safety posture | `npm run verify:analytics`, One Location component tests |
+| `one_location_share_confirmed` | Private encrypted share outcome counts only | `route_id`, `result`, `selected_count`, `success_count`, `failure_count`, `duration_bucket`, `review_required` | `hushh-webapp/app/one/location/page.tsx` | share success/error rate | `npm run verify:analytics`, One Location component tests |
+| `one_location_request_sent` | Approval-first location request outcome counts only | `route_id`, `result`, `selected_count`, `success_count`, `failure_count`, `has_note` | `hushh-webapp/app/one/location/page.tsx` | request-flow success/error rate | `npm run verify:analytics`, One Location component tests |
+| `one_location_public_link_created` | Approval-first public request link creation without public live-location access | `route_id`, `result`, `duration_bucket`, `copied_to_clipboard`, `active_invite_count` | `hushh-webapp/app/one/location/page.tsx` | request-link UX and safety tracking | `npm run verify:analytics`, One Location component tests |
+| `one_location_contact_signal_synced` | Optional contact-signal matching quality without phone payloads | `route_id`, `result`, `source_platform`, `contact_count_bucket`, `matched_count`, `invite_candidate_count` | `hushh-webapp/app/one/location/page.tsx` | KAI Circle cold-start tuning | `npm run verify:analytics`, One Location component tests |
+| `one_location_foreground_retry` | Failed foreground live publish/view attempt with retry and backoff metadata | `route_id`, `operation`, `trigger`, `result`, `attempt_count`, `retry_count`, `backoff_bucket`, `duration_ms_bucket` | `hushh-webapp/app/one/location/page.tsx` | live-location reliability and One API transient health | `npm run verify:analytics`, One Location component tests |
+
 ## Growth Funnel Canonical Events
 
 | Event | Business purpose | Required params | Primary emitter | Destination use | Proof path |

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -7,11 +7,13 @@ const {
   mockUseVault,
   mockEnsureKey,
   mockEncryptLocationForRecipient,
+  mockDecryptLocationEnvelope,
   mockRegisterKey,
   mockGetPermissionState,
   mockCaptureCurrentPosition,
   mockCreateGrant,
   mockStoreEnvelope,
+  mockViewEnvelope,
   mockRevokeGrant,
   mockRequestAccess,
   mockCreatePublicInvite,
@@ -27,11 +29,13 @@ const {
   mockUseVault: vi.fn(),
   mockEnsureKey: vi.fn(),
   mockEncryptLocationForRecipient: vi.fn(),
+  mockDecryptLocationEnvelope: vi.fn(),
   mockRegisterKey: vi.fn(),
   mockGetPermissionState: vi.fn(),
   mockCaptureCurrentPosition: vi.fn(),
   mockCreateGrant: vi.fn(),
   mockStoreEnvelope: vi.fn(),
+  mockViewEnvelope: vi.fn(),
   mockRevokeGrant: vi.fn(),
   mockRequestAccess: vi.fn(),
   mockCreatePublicInvite: vi.fn(),
@@ -64,6 +68,7 @@ vi.mock("@/lib/vault/vault-context", () => ({
 
 vi.mock("@/lib/observability/client", () => ({
   trackEvent: mockTrackEvent,
+  toDurationBucket: () => "lt_100ms",
 }));
 
 vi.mock("@/components/vault/vault-lock-guard", () => ({
@@ -73,7 +78,7 @@ vi.mock("@/components/vault/vault-lock-guard", () => ({
 vi.mock("@/lib/one-location/encryption", () => ({
   ensureLocationRecipientKey: mockEnsureKey,
   encryptLocationForRecipient: mockEncryptLocationForRecipient,
-  decryptLocationEnvelope: vi.fn(),
+  decryptLocationEnvelope: mockDecryptLocationEnvelope,
 }));
 
 vi.mock("@/lib/one-location/service", () => ({
@@ -85,7 +90,7 @@ vi.mock("@/lib/one-location/service", () => ({
     createGrant: mockCreateGrant,
     storeEnvelope: mockStoreEnvelope,
     captureCurrentPosition: mockCaptureCurrentPosition,
-    viewEnvelope: vi.fn(),
+    viewEnvelope: mockViewEnvelope,
     revokeGrant: mockRevokeGrant,
     requestAccess: mockRequestAccess,
     approveRequest: vi.fn(),
@@ -285,6 +290,7 @@ function locationActivity() {
 describe("OneLocationAgentPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.localStorage.clear();
     mockSearchParamsGet.mockReturnValue(null);
     mockUseRequireAuth.mockReturnValue({
       loading: false,
@@ -336,6 +342,30 @@ describe("OneLocationAgentPage", () => {
       sourcePlatform: "web",
     });
     mockStoreEnvelope.mockResolvedValue({});
+    mockViewEnvelope.mockResolvedValue({
+      grant: {},
+      envelope: {
+        recipientKeyId: "key_a",
+        algorithm: "ECDH-P256-AES256-GCM",
+        ciphertext: "ciphertext",
+        iv: "iv",
+        senderEphemeralPublicKeyJwk: {
+          kty: "EC",
+          crv: "P-256",
+          x: "x",
+          y: "y",
+        },
+        capturedAt: "2026-05-20T07:30:00.000Z",
+        sourcePlatform: "web",
+      },
+    });
+    mockDecryptLocationEnvelope.mockResolvedValue({
+      latitude: 28.6139,
+      longitude: 77.209,
+      accuracyM: 18,
+      capturedAt: "2026-05-20T07:30:00.000Z",
+      sourcePlatform: "web",
+    });
     mockRevokeGrant.mockResolvedValue({});
     mockRequestAccess.mockResolvedValue({});
     mockCreatePublicInvite.mockResolvedValue({
@@ -457,6 +487,68 @@ describe("OneLocationAgentPage", () => {
     expect(screen.queryByText(/8012|4455|9911/)).toBeNull();
   });
 
+  it("warns the recipient when the decrypted location update is stale", async () => {
+    const staleGrant = {
+      id: "grant_stale",
+      ownerUserId: "user_a",
+      recipientUserId: "user_b",
+      ownerDisplayName: "Trusted A",
+      recipientKeyId: "key_b",
+      status: "active",
+      consentScope: "cap.location.live.view",
+      capabilityScopes: ["cap.location.live.view"],
+      durationHours: 1,
+      expiresAt: "2099-05-20T08:00:00.000Z",
+    };
+    mockUseRequireAuth.mockReturnValue({
+      loading: false,
+      isAuthenticated: true,
+      userId: "user_b",
+      user: { uid: "user_b" },
+    });
+    window.localStorage.setItem(
+      "one_location_opened_grants_v1:user_b",
+      JSON.stringify(["grant_stale"]),
+    );
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      ownerGrants: [],
+      receivedGrants: [staleGrant],
+    });
+    mockViewEnvelope.mockResolvedValueOnce({
+      grant: staleGrant,
+      envelope: {
+        recipientKeyId: "key_b",
+        algorithm: "ECDH-P256-AES256-GCM",
+        ciphertext: "ciphertext",
+        iv: "iv",
+        senderEphemeralPublicKeyJwk: {
+          kty: "EC",
+          crv: "P-256",
+          x: "x",
+          y: "y",
+        },
+        capturedAt: "2000-01-01T00:00:00.000Z",
+        sourcePlatform: "web",
+      },
+    });
+    mockDecryptLocationEnvelope.mockResolvedValueOnce({
+      latitude: 28.6139,
+      longitude: 77.209,
+      accuracyM: 18,
+      capturedAt: "2000-01-01T00:00:00.000Z",
+      sourcePlatform: "web",
+    });
+
+    render(<OneLocationAgentPageContent />);
+
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    await waitFor(() => expect(mockViewEnvelope).toHaveBeenCalled());
+    expect(
+      await screen.findByText("Location update may be stale. Ask them to refresh sharing."),
+    ).toBeTruthy();
+  });
+
   it("tracks public request-link creation without location or identity payloads", async () => {
     render(<OneLocationAgentPageContent />);
 
@@ -539,6 +631,47 @@ describe("OneLocationAgentPage", () => {
         success_count: 1,
         failure_count: 0,
       }),
+    );
+  });
+
+  it("retries transient foreground publish failures and tracks backoff metadata", async () => {
+    mockGetState.mockResolvedValueOnce({
+      ...locationState(),
+      ownerGrants: [],
+    });
+    mockStoreEnvelope
+      .mockRejectedValueOnce(
+        Object.assign(new Error("One API unavailable"), { status: 503 }),
+      )
+      .mockResolvedValueOnce({});
+
+    render(<OneLocationAgentPageContent />);
+
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole("button", { name: /Review Share/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /Confirm & Share Location/i }),
+    );
+
+    await waitFor(() => expect(mockStoreEnvelope).toHaveBeenCalledTimes(2));
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      "one_location_foreground_retry",
+      expect.objectContaining({
+        route_id: "one_location",
+        operation: "publish",
+        trigger: "manual",
+        result: "expected_error",
+        attempt_count: 1,
+        retry_count: 1,
+        backoff_bucket: "lt_500ms",
+        error_class: "one_api_unavailable",
+      }),
+    );
+    const retryCall = mockTrackEvent.mock.calls.find(
+      ([eventName]) => eventName === "one_location_foreground_retry",
+    );
+    expect(JSON.stringify(retryCall)).not.toMatch(
+      /8012|9911|latitude|longitude|28\.6139|77\.209|ciphertext|grant_new/u,
     );
   });
 

--- a/hushh-webapp/__tests__/services/observability-schema.test.ts
+++ b/hushh-webapp/__tests__/services/observability-schema.test.ts
@@ -114,6 +114,39 @@ describe("observability schema", () => {
     expect(result.sanitized.success_count).toBe(2);
   });
 
+  it("accepts One Location foreground retry metadata without location payloads", () => {
+    const result = validateAndSanitizeEvent(
+      "one_location_foreground_retry",
+      {
+        env: "uat",
+        platform: "web",
+        event_category: "system",
+        app_version: "2.1.0",
+        route_id: "one_location",
+        operation: "publish",
+        trigger: "foreground_interval",
+        result: "expected_error",
+        attempt_count: 1,
+        retry_count: 1,
+        backoff_bucket: "lt_500ms",
+        duration_ms_bucket: "300ms_1s",
+        error_class: "one_api_unavailable",
+        grant_id: "one_location_grant_identifier_forbidden",
+        latitude: "28.6139",
+        longitude: "77.209",
+        public_token: "public_token_value_forbidden",
+      } as any,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.droppedKeys).toContain("grant_id");
+    expect(result.droppedKeys).toContain("public_token");
+    expect(result.sanitized.operation).toBe("publish");
+    expect(result.sanitized.trigger).toBe("foreground_interval");
+    expect(result.sanitized.backoff_bucket).toBe("lt_500ms");
+    expect(result.sanitized.error_class).toBe("one_api_unavailable");
+  });
+
   it("accepts phone verification lifecycle metadata without phone values", () => {
     const result = validateAndSanitizeEvent("phone_verification_started", {
       env: "uat",

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -91,7 +91,7 @@ import type {
 } from "@/lib/one-location/types";
 import { AccountIdentityService } from "@/lib/services/account-identity-service";
 import { CONSENT_STATE_CHANGED_EVENT } from "@/lib/consent/consent-events";
-import { trackEvent } from "@/lib/observability/client";
+import { toDurationBucket, trackEvent } from "@/lib/observability/client";
 import { useVault } from "@/lib/vault/vault-context";
 import { cn } from "@/lib/utils";
 
@@ -104,6 +104,8 @@ const DURATION_OPTIONS = [
 ];
 
 const LIVE_LOCATION_UPDATE_INTERVAL_MS = 20_000;
+const LIVE_LOCATION_STALE_THRESHOLD_MS = LIVE_LOCATION_UPDATE_INTERVAL_MS * 3;
+const FOREGROUND_RETRY_DELAYS_MS = [450, 900] as const;
 
 type BusyState =
   | "load"
@@ -141,6 +143,14 @@ type OneLocationSelectionSurface =
   | "select_menu";
 
 type OneLocationDurationBucket = "15m" | "30m" | "1h" | "4h" | "24h" | "custom";
+type OneLocationForegroundOperation = "publish" | "view";
+type OneLocationForegroundTrigger = "manual" | "foreground_interval";
+type OneLocationBackoffBucket =
+  | "none"
+  | "lt_500ms"
+  | "500ms_1s"
+  | "1s_3s"
+  | "gte_3s";
 
 type OneLocationContactSignalStatus =
   | "idle"
@@ -615,6 +625,87 @@ function isTransientOneApiError(error: unknown): boolean {
   return status === 502 || status === 503 || status === 504;
 }
 
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
+
+function oneLocationBackoffBucket(delayMs: number): OneLocationBackoffBucket {
+  if (delayMs <= 0) return "none";
+  if (delayMs < 500) return "lt_500ms";
+  if (delayMs < 1000) return "500ms_1s";
+  if (delayMs < 3000) return "1s_3s";
+  return "gte_3s";
+}
+
+function oneLocationFailureClass(error: unknown): string {
+  if (isTransientOneApiError(error)) return "one_api_unavailable";
+  const name =
+    error && typeof error === "object" && "name" in error
+      ? String((error as { name?: unknown }).name || "").toLowerCase()
+      : "";
+  const message =
+    error instanceof Error
+      ? error.message.toLowerCase()
+      : String((error as { message?: unknown })?.message || error || "").toLowerCase();
+  if (name === "aborterror" || message.includes("abort")) return "aborted";
+  if (message.includes("network") || message.includes("fetch")) return "network";
+  if (message.includes("permission") || message.includes("location")) return "permission";
+  if (
+    message.includes("key") ||
+    message.includes("encrypt") ||
+    message.includes("decrypt")
+  ) {
+    return "encryption";
+  }
+  return "unknown";
+}
+
+function isRetryableForegroundError(error: unknown): boolean {
+  const failureClass = oneLocationFailureClass(error);
+  return failureClass === "one_api_unavailable" || failureClass === "network";
+}
+
+async function runOneLocationForegroundAttempt<T>(params: {
+  operation: OneLocationForegroundOperation;
+  trigger: OneLocationForegroundTrigger;
+  task: () => Promise<T>;
+}): Promise<T> {
+  const startedAt = Date.now();
+  let attemptIndex = 0;
+
+  for (;;) {
+    try {
+      return await params.task();
+    } catch (error) {
+      const retryDelayMs = FOREGROUND_RETRY_DELAYS_MS[attemptIndex] ?? 0;
+      const shouldRetry =
+        retryDelayMs > 0 && isRetryableForegroundError(error);
+      const retryCount = shouldRetry
+        ? attemptIndex + 1
+        : Math.min(attemptIndex, FOREGROUND_RETRY_DELAYS_MS.length);
+
+      trackEvent("one_location_foreground_retry", {
+        route_id: "one_location",
+        operation: params.operation,
+        trigger: params.trigger,
+        result: shouldRetry ? "expected_error" : "error",
+        attempt_count: attemptIndex + 1,
+        retry_count: retryCount,
+        backoff_bucket: oneLocationBackoffBucket(retryDelayMs),
+        duration_ms_bucket: toDurationBucket(Date.now() - startedAt),
+        error_class: oneLocationFailureClass(error),
+      });
+
+      if (!shouldRetry) {
+        throw error;
+      }
+
+      attemptIndex += 1;
+      await wait(retryDelayMs);
+    }
+  }
+}
+
 function oneLocationErrorMessage(error: unknown, fallback: string): string {
   if (isTransientOneApiError(error)) {
     return "One is still catching up. Please refresh once, then check this page before retrying.";
@@ -622,8 +713,15 @@ function oneLocationErrorMessage(error: unknown, fallback: string): string {
   return error instanceof Error ? error.message : fallback;
 }
 
+function isLocationPointStale(point: PlainLocationPoint): boolean {
+  const capturedAt = new Date(point.capturedAt).getTime();
+  if (!Number.isFinite(capturedAt)) return false;
+  return Date.now() - capturedAt > LIVE_LOCATION_STALE_THRESHOLD_MS;
+}
+
 function LocalMapPreview({ point }: { point: PlainLocationPoint }) {
   const captured = formatDateTime(point.capturedAt);
+  const isStale = isLocationPointStale(point);
   return (
     <div className="overflow-hidden rounded-[var(--app-card-radius-standard)] border border-border/70 bg-[color:var(--app-card-surface-default-solid)]">
       <div className="relative h-44 bg-[linear-gradient(to_right,rgba(15,23,42,0.08)_1px,transparent_1px),linear-gradient(to_bottom,rgba(15,23,42,0.08)_1px,transparent_1px)] bg-[length:28px_28px] dark:bg-[linear-gradient(to_right,rgba(255,255,255,0.10)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.10)_1px,transparent_1px)]">
@@ -655,6 +753,17 @@ function LocalMapPreview({ point }: { point: PlainLocationPoint }) {
           <div className="text-foreground">{captured}</div>
         </div>
       </div>
+      {isStale ? (
+        <div
+          role="status"
+          className="mx-3 mb-3 flex items-start gap-2 rounded-[12px] border border-amber-500/35 bg-amber-500/10 px-3 py-2 text-[12px] font-medium text-amber-800 dark:text-amber-100"
+        >
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+          <span>
+            Location update may be stale. Ask them to refresh sharing.
+          </span>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -1370,6 +1479,21 @@ export function OneLocationAgentPageContent() {
     [vaultOwnerToken],
   );
 
+  const publishEnvelopeWithRetry = useCallback(
+    async (
+      grant: OneLocationGrant,
+      recipient: OneLocationRecipient,
+      trigger: OneLocationForegroundTrigger,
+      pointOverride?: PlainLocationPoint,
+    ) =>
+      runOneLocationForegroundAttempt({
+        operation: "publish",
+        trigger,
+        task: () => publishEnvelope(grant, recipient, pointOverride),
+      }),
+    [publishEnvelope],
+  );
+
   const handleShare = useCallback(async () => {
     if (
       !vaultOwnerToken ||
@@ -1391,7 +1515,7 @@ export function OneLocationAgentPageContent() {
           recipientKeyId: recipient.keyId,
           durationHours: Number(durationHours),
         });
-        await publishEnvelope(grant, recipient, point);
+        await publishEnvelopeWithRetry(grant, recipient, "manual", point);
         successCount += 1;
       }
       trackEvent("one_location_share_confirmed", {
@@ -1431,7 +1555,7 @@ export function OneLocationAgentPageContent() {
   }, [
     durationHours,
     permission?.state,
-    publishEnvelope,
+    publishEnvelopeWithRetry,
     refresh,
     setupNeededSelectedRecipients.length,
     shareReviewOpen,
@@ -1448,7 +1572,7 @@ export function OneLocationAgentPageContent() {
       }
       setBusy("publish");
       try {
-        await publishEnvelope(grant, recipient);
+        await publishEnvelopeWithRetry(grant, recipient, "manual");
         toast.success("Encrypted location update published.");
         await refresh();
       } catch (error) {
@@ -1459,22 +1583,33 @@ export function OneLocationAgentPageContent() {
         setBusy(null);
       }
     },
-    [publishEnvelope, recipientForGrant, refresh],
+    [publishEnvelopeWithRetry, recipientForGrant, refresh],
   );
 
   const viewGrantEnvelope = useCallback(
-    async (grant: OneLocationGrant, options?: { silent?: boolean }) => {
+    async (
+      grant: OneLocationGrant,
+      options?: { silent?: boolean; trigger?: OneLocationForegroundTrigger },
+    ) => {
       if (!auth.userId || !vaultOwnerToken) return;
+      const activeUserId = auth.userId;
       const silent = Boolean(options?.silent);
+      const trigger = options?.trigger ?? (silent ? "foreground_interval" : "manual");
       if (!silent) setBusy("view");
       try {
-        const response = await OneLocationService.viewEnvelope({
-          vaultOwnerToken,
-          grantId: grant.id,
-        });
-        const point = await decryptLocationEnvelope({
-          userId: auth.userId,
-          envelope: response.envelope,
+        const point = await runOneLocationForegroundAttempt({
+          operation: "view",
+          trigger,
+          task: async () => {
+            const response = await OneLocationService.viewEnvelope({
+              vaultOwnerToken,
+              grantId: grant.id,
+            });
+            return decryptLocationEnvelope({
+              userId: activeUserId,
+              envelope: response.envelope,
+            });
+          },
         });
         setDecryptedPoints((current) => ({ ...current, [grant.id]: point }));
       } catch (error) {
@@ -1528,7 +1663,12 @@ export function OneLocationAgentPageContent() {
         for (const grant of activeOwnerGrants) {
           const recipient = recipientForGrant(grant);
           if (!recipient?.keyId || !recipient.publicKeyJwk) continue;
-          await publishEnvelope(grant, recipient, point);
+          await publishEnvelopeWithRetry(
+            grant,
+            recipient,
+            "foreground_interval",
+            point,
+          );
         }
       } catch (error) {
         console.warn(
@@ -1550,7 +1690,7 @@ export function OneLocationAgentPageContent() {
     activeOwnerGrants,
     busy,
     permission?.state,
-    publishEnvelope,
+    publishEnvelopeWithRetry,
     recipientForGrant,
     vaultOwnerToken,
   ]);
@@ -1570,7 +1710,10 @@ export function OneLocationAgentPageContent() {
       try {
         await Promise.allSettled(
           activeVisibleReceivedGrants.map((grant) =>
-            viewGrantEnvelope(grant, { silent: true }),
+            viewGrantEnvelope(grant, {
+              silent: true,
+              trigger: "foreground_interval",
+            }),
           ),
         );
       } finally {
@@ -1918,7 +2061,7 @@ export function OneLocationAgentPageContent() {
           requestId: request.id,
           durationHours: Number(durationHours),
         });
-        await publishEnvelope(response.grant, requester);
+        await publishEnvelopeWithRetry(response.grant, requester, "manual");
         toast.success("Request approved and encrypted update published.");
         await refresh();
       } catch (error) {
@@ -1929,7 +2072,7 @@ export function OneLocationAgentPageContent() {
         setBusy(null);
       }
     },
-    [durationHours, publishEnvelope, recipients, refresh, vaultOwnerToken],
+    [durationHours, publishEnvelopeWithRetry, recipients, refresh, vaultOwnerToken],
   );
 
   const handleDeny = useCallback(

--- a/hushh-webapp/lib/observability/events.ts
+++ b/hushh-webapp/lib/observability/events.ts
@@ -81,6 +81,7 @@ export type ObservabilityEventName =
   | "one_location_request_sent"
   | "one_location_public_link_created"
   | "one_location_contact_signal_synced"
+  | "one_location_foreground_retry"
   | "growth_funnel_step_completed"
   | "investor_activation_completed"
   | "ria_activation_completed"
@@ -213,6 +214,7 @@ const EVENT_CATEGORY_BY_NAME: Record<
   one_location_request_sent: "feature",
   one_location_public_link_created: "feature",
   one_location_contact_signal_synced: "feature",
+  one_location_foreground_retry: "system",
   growth_funnel_step_completed: "funnel",
   investor_activation_completed: "funnel",
   ria_activation_completed: "funnel",
@@ -438,6 +440,17 @@ export interface EventPayloadMap {
     contact_count_bucket: "0" | "1_10" | "11_50" | "51_250" | "251_plus";
     matched_count: number;
     invite_candidate_count: number;
+  };
+  one_location_foreground_retry: {
+    route_id: RouteId;
+    operation: "publish" | "view";
+    trigger: "manual" | "foreground_interval";
+    result: EventResult;
+    attempt_count: number;
+    retry_count: number;
+    backoff_bucket: "none" | "lt_500ms" | "500ms_1s" | "1s_3s" | "gte_3s";
+    duration_ms_bucket: DurationBucket;
+    error_class?: string;
   };
   growth_funnel_step_completed: {
     journey: GrowthJourney;

--- a/hushh-webapp/lib/observability/schema.ts
+++ b/hushh-webapp/lib/observability/schema.ts
@@ -116,6 +116,17 @@ const EVENT_ALLOWED_KEYS: Record<ObservabilityEventName, readonly string[]> = {
     "matched_count",
     "invite_candidate_count",
   ],
+  one_location_foreground_retry: [
+    ...BASE_ALLOWED_KEYS,
+    "operation",
+    "trigger",
+    "result",
+    "attempt_count",
+    "retry_count",
+    "backoff_bucket",
+    "duration_ms_bucket",
+    "error_class",
+  ],
   growth_funnel_step_completed: [
     ...BASE_ALLOWED_KEYS,
     "journey",


### PR DESCRIPTION
﻿## Summary

Adds the next Issue #1738 reliability slice on top of #1841:

- shows a recipient-side stale location warning when the locally decrypted point is older than the live update threshold
- retries transient foreground publish/view failures with bounded backoff
- emits metadata-only retry telemetry for One Location live publish/view attempts
- documents the new governed observability event and expands tests around privacy-safe payloads

## Privacy posture

- No backend schema or persistence changes.
- No plaintext coordinates, ciphertext, grant IDs, public tokens, names, phone values, or decrypted map values are emitted in analytics.
- The stale warning is computed only on the recipient client after successful local decrypt.

## Validation

- `cd hushh-webapp && npm run test -- __tests__/components/one-location-agent-page.test.tsx __tests__/services/observability-schema.test.ts` -> 28 passed
- `cd hushh-webapp && npm run verify:analytics` -> 19 passed
- `cd hushh-webapp && npm run typecheck` -> passed
- `cd hushh-webapp && npx eslint app/one/location/page.tsx lib/observability/events.ts lib/observability/schema.ts __tests__/components/one-location-agent-page.test.tsx __tests__/services/observability-schema.test.ts` -> passed
- `cd hushh-webapp && npm run verify:docs` -> passed
- `./bin/hushh docs verify` -> passed
- `git diff --check` -> passed

## Local blocker

- `cd hushh-webapp && npm run verify:routes` could not run locally because `REVIEWER_UID` and `REVIEWER_VAULT_PASSPHRASE` are not present in this maintainer-only environment.

Refs #1738
