### PR TITLE
feat: add KAI Circle ranking for One Location recipients

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -125,7 +125,7 @@ def _iso(value: Any) -> str | None:
     if isinstance(value, datetime):
         if value.tzinfo is None:
             value = value.replace(tzinfo=timezone.utc)
-        return value.astimezone(timezone.utc).isoformat()
+        return str(value.astimezone(timezone.utc).isoformat())
     return str(value)
 
 
@@ -536,6 +536,770 @@ class OneLocationAgentService:
             "canReceiveLocation": bool(row.get("key_id")),
         }
 
+    def _optional_signal_rows(
+        self,
+        *,
+        signal_name: str,
+        sql: str,
+        params: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        try:
+            return self._execute_many(sql, params or {})
+        except Exception as exc:
+            logger.debug(
+                "one.location.kai_circle_signal_unavailable signal=%s error=%s",
+                signal_name,
+                exc,
+            )
+            return []
+
+    @staticmethod
+    def _recommendation_signal() -> dict[str, Any]:
+        return {
+            "score": 0,
+            "reasons": {},
+            "needs_action": False,
+            "trusted": False,
+            "professional": False,
+            "relationship_type": None,
+            "profile_headline": None,
+            "verification_badge": None,
+            "last_interaction_at": None,
+        }
+
+    @staticmethod
+    def _signal_time_value(value: Any) -> float:
+        if value is None:
+            return 0.0
+        if isinstance(value, datetime):
+            parsed = value
+        else:
+            raw = str(value).strip()
+            if not raw:
+                return 0.0
+            if raw.endswith("Z"):
+                raw = f"{raw[:-1]}+00:00"
+            try:
+                parsed = datetime.fromisoformat(raw)
+            except ValueError:
+                return 0.0
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc).timestamp()
+
+    @classmethod
+    def _remember_signal_time(cls, signal: dict[str, Any], *values: Any) -> None:
+        current = signal.get("last_interaction_at")
+        current_score = cls._signal_time_value(current)
+        for value in values:
+            value_score = cls._signal_time_value(value)
+            if value_score > current_score:
+                signal["last_interaction_at"] = value
+                current_score = value_score
+
+    @staticmethod
+    def _safe_recommendation_text(value: Any, *, max_length: int = 96) -> str | None:
+        text = " ".join(str(value or "").split())
+        if not text:
+            return None
+        if len(text) <= max_length:
+            return text
+        return f"{text[: max_length - 1].rstrip()}..."
+
+    @classmethod
+    def _add_recommendation_reason(
+        cls,
+        signal: dict[str, Any],
+        *,
+        code: str,
+        label: str,
+        weight: int,
+    ) -> None:
+        reasons: dict[str, dict[str, Any]] = signal.setdefault("reasons", {})
+        existing = reasons.get(code)
+        normalized_weight = max(0, int(weight))
+        if existing and int(existing.get("weight") or 0) >= normalized_weight:
+            return
+        if existing:
+            signal["score"] -= int(existing.get("weight") or 0)
+        reasons[code] = {
+            "code": code,
+            "label": cls._safe_recommendation_text(label, max_length=72) or label,
+            "weight": normalized_weight,
+        }
+        signal["score"] += normalized_weight
+
+    @classmethod
+    def _safe_metadata_terms(cls, value: Any, *, max_terms: int = 4) -> list[str]:
+        metadata = _loads_json(value)
+        if not isinstance(metadata, dict):
+            return []
+        allowed_keys = {
+            "category",
+            "categories",
+            "focus",
+            "focus_area",
+            "focus_areas",
+            "industry",
+            "industries",
+            "interest",
+            "interests",
+            "investment_style",
+            "investment_styles",
+            "marketplace_categories",
+            "sector",
+            "sectors",
+            "specialties",
+            "specialty",
+        }
+        terms: list[str] = []
+
+        def add_term(raw_value: Any) -> None:
+            if isinstance(raw_value, str):
+                candidates = raw_value.split(",") if "," in raw_value else [raw_value]
+            elif isinstance(raw_value, (list, tuple, set)):
+                candidates = list(raw_value)
+            else:
+                candidates = [raw_value]
+            for candidate in candidates:
+                term = cls._safe_recommendation_text(candidate, max_length=36)
+                if term and term.lower() not in {existing.lower() for existing in terms}:
+                    terms.append(term)
+
+        for key, item in metadata.items():
+            normalized_key = str(key or "").strip().lower()
+            if normalized_key in COORDINATE_METADATA_KEYS or normalized_key not in allowed_keys:
+                continue
+            add_term(item)
+            if len(terms) >= max_terms:
+                break
+        return terms[:max_terms]
+
+    def _add_one_location_history_signals(
+        self,
+        *,
+        owner_user_id: str,
+        recipient_ids: set[str],
+        signals: dict[str, dict[str, Any]],
+    ) -> None:
+        grant_rows = self._optional_signal_rows(
+            signal_name="one_location_grants",
+            sql="""
+            SELECT owner_user_id, recipient_user_id, status, created_at, updated_at,
+                   expires_at, revoked_at
+            FROM one_location_share_grants
+            WHERE owner_user_id = :owner_user_id OR recipient_user_id = :owner_user_id
+            ORDER BY created_at DESC
+            LIMIT 100
+            """,
+            params={"owner_user_id": owner_user_id},
+        )
+        for row in grant_rows:
+            other_user_id = (
+                str(row.get("recipient_user_id") or "")
+                if row.get("owner_user_id") == owner_user_id
+                else str(row.get("owner_user_id") or "")
+            )
+            if other_user_id not in recipient_ids:
+                continue
+            signal = signals[other_user_id]
+            status = str(row.get("status") or "").lower()
+            if status == "active":
+                self._add_recommendation_reason(
+                    signal,
+                    code="active_location_share",
+                    label="Active location share",
+                    weight=46,
+                )
+                signal["trusted"] = True
+                signal["relationship_type"] = (
+                    signal.get("relationship_type") or "Active One Location share"
+                )
+                signal["verification_badge"] = (
+                    signal.get("verification_badge") or "Location trusted"
+                )
+            elif status in {"expired", "revoked"}:
+                self._add_recommendation_reason(
+                    signal,
+                    code="prior_location_share",
+                    label="Prior location sharing history",
+                    weight=30,
+                )
+                signal["trusted"] = True
+                signal["relationship_type"] = (
+                    signal.get("relationship_type") or "Prior One Location share"
+                )
+            self._remember_signal_time(
+                signal,
+                row.get("updated_at"),
+                row.get("created_at"),
+                row.get("expires_at"),
+                row.get("revoked_at"),
+            )
+
+        request_rows = self._optional_signal_rows(
+            signal_name="one_location_requests",
+            sql="""
+            SELECT owner_user_id, requester_user_id, referred_by_user_id, status,
+                   requested_at, resolved_at
+            FROM one_location_access_requests
+            WHERE owner_user_id = :owner_user_id OR requester_user_id = :owner_user_id
+            ORDER BY requested_at DESC
+            LIMIT 100
+            """,
+            params={"owner_user_id": owner_user_id},
+        )
+        for row in request_rows:
+            current_user_is_owner = row.get("owner_user_id") == owner_user_id
+            other_user_id = (
+                str(row.get("requester_user_id") or "")
+                if current_user_is_owner
+                else str(row.get("owner_user_id") or "")
+            )
+            if other_user_id not in recipient_ids:
+                continue
+            signal = signals[other_user_id]
+            status = str(row.get("status") or "").lower()
+            if status == "pending" and current_user_is_owner:
+                self._add_recommendation_reason(
+                    signal,
+                    code="pending_location_request",
+                    label="Asked to receive your location",
+                    weight=44,
+                )
+                signal["needs_action"] = True
+                signal["relationship_type"] = (
+                    signal.get("relationship_type") or "Pending location request"
+                )
+            elif status == "pending":
+                self._add_recommendation_reason(
+                    signal,
+                    code="outbound_location_request",
+                    label="Waiting on their approval",
+                    weight=22,
+                )
+            elif status == "approved":
+                self._add_recommendation_reason(
+                    signal,
+                    code="approved_location_request",
+                    label="Approved location request history",
+                    weight=28,
+                )
+                signal["trusted"] = True
+            self._remember_signal_time(signal, row.get("resolved_at"), row.get("requested_at"))
+
+        referral_rows = self._optional_signal_rows(
+            signal_name="one_location_referrals",
+            sql="""
+            SELECT owner_user_id, referring_user_id, referred_user_id, status,
+                   created_at, resolved_at
+            FROM one_location_referrals
+            WHERE owner_user_id = :owner_user_id
+               OR referring_user_id = :owner_user_id
+               OR referred_user_id = :owner_user_id
+            ORDER BY created_at DESC
+            LIMIT 100
+            """,
+            params={"owner_user_id": owner_user_id},
+        )
+        for row in referral_rows:
+            for candidate_field in ("owner_user_id", "referring_user_id", "referred_user_id"):
+                candidate_id = str(row.get(candidate_field) or "")
+                if candidate_id == owner_user_id or candidate_id not in recipient_ids:
+                    continue
+                signal = signals[candidate_id]
+                self._add_recommendation_reason(
+                    signal,
+                    code="location_referral_signal",
+                    label="Connected through a trusted referral",
+                    weight=24,
+                )
+                signal["trusted"] = True
+                signal["relationship_type"] = signal.get("relationship_type") or "Location referral"
+                self._remember_signal_time(signal, row.get("resolved_at"), row.get("created_at"))
+
+    def _add_prior_consent_signals(
+        self,
+        *,
+        owner_user_id: str,
+        recipient_ids: set[str],
+        signals: dict[str, dict[str, Any]],
+    ) -> None:
+        rows = self._optional_signal_rows(
+            signal_name="consent_audit",
+            sql="""
+            SELECT user_id, agent_id, action, issued_at
+            FROM consent_audit
+            WHERE user_id = :owner_user_id OR agent_id = :owner_user_id
+            ORDER BY issued_at DESC
+            LIMIT 100
+            """,
+            params={"owner_user_id": owner_user_id},
+        )
+        for row in rows:
+            if row.get("user_id") == owner_user_id:
+                other_user_id = str(row.get("agent_id") or "")
+            elif row.get("agent_id") == owner_user_id:
+                other_user_id = str(row.get("user_id") or "")
+            else:
+                other_user_id = ""
+            if other_user_id not in recipient_ids:
+                continue
+            action = str(row.get("action") or "").strip().lower()
+            if action not in {"consent_granted", "approved", "granted"}:
+                continue
+            signal = signals[other_user_id]
+            self._add_recommendation_reason(
+                signal,
+                code="prior_consent_relationship",
+                label="Prior consent approval",
+                weight=26,
+            )
+            signal["trusted"] = True
+            signal["relationship_type"] = (
+                signal.get("relationship_type") or "Prior consent relationship"
+            )
+            self._remember_signal_time(signal, row.get("issued_at"))
+
+    def _add_mutual_kai_relationship_signals(
+        self,
+        *,
+        owner_user_id: str,
+        recipient_ids: set[str],
+        signals: dict[str, dict[str, Any]],
+    ) -> None:
+        rows = self._optional_signal_rows(
+            signal_name="mutual_kai_relationships",
+            sql="""
+            SELECT rel.investor_user_id, rel.status, rel.created_at, rel.updated_at,
+                   rp.user_id AS ria_user_id
+            FROM advisor_investor_relationships rel
+            JOIN ria_profiles rp ON rp.id = rel.ria_profile_id
+            WHERE rel.status IN ('approved', 'request_pending', 'discovered')
+            ORDER BY COALESCE(rel.updated_at, rel.created_at) DESC
+            LIMIT 500
+            """,
+            params={"owner_user_id": owner_user_id},
+        )
+        adjacency: dict[str, set[str]] = {}
+        latest_by_pair: dict[tuple[str, str], Any] = {}
+        for row in rows:
+            investor_user_id = str(row.get("investor_user_id") or "")
+            ria_user_id = str(row.get("ria_user_id") or "")
+            if not investor_user_id or not ria_user_id:
+                continue
+            adjacency.setdefault(investor_user_id, set()).add(ria_user_id)
+            adjacency.setdefault(ria_user_id, set()).add(investor_user_id)
+            latest = row.get("updated_at") or row.get("created_at")
+            latest_by_pair[(investor_user_id, ria_user_id)] = latest
+            latest_by_pair[(ria_user_id, investor_user_id)] = latest
+
+        owner_neighbors = adjacency.get(owner_user_id, set())
+        if not owner_neighbors:
+            return
+        for recipient_id in recipient_ids:
+            if recipient_id == owner_user_id:
+                continue
+            shared_neighbors = owner_neighbors.intersection(adjacency.get(recipient_id, set()))
+            if not shared_neighbors:
+                continue
+            signal = signals[recipient_id]
+            self._add_recommendation_reason(
+                signal,
+                code="mutual_kai_relationship",
+                label="Mutual KAI relationship",
+                weight=18,
+            )
+            signal["professional"] = True
+            signal["relationship_type"] = signal.get("relationship_type") or "Mutual KAI connection"
+            for neighbor_id in shared_neighbors:
+                self._remember_signal_time(
+                    signal,
+                    latest_by_pair.get((owner_user_id, neighbor_id)),
+                    latest_by_pair.get((recipient_id, neighbor_id)),
+                )
+
+    def _add_professional_network_signals(
+        self,
+        *,
+        owner_user_id: str,
+        recipient_ids: set[str],
+        signals: dict[str, dict[str, Any]],
+    ) -> None:
+        rows = self._optional_signal_rows(
+            signal_name="advisor_investor_relationships",
+            sql="""
+            SELECT
+              rel.investor_user_id,
+              rel.status,
+              rel.granted_scope,
+              rel.consent_granted_at,
+              rel.created_at,
+              rel.updated_at,
+              rp.user_id AS ria_user_id,
+              rp.display_name AS ria_display_name,
+              rp.verification_status AS ria_verification_status,
+              share.status AS relationship_share_status,
+              share.granted_at AS relationship_share_granted_at
+            FROM advisor_investor_relationships rel
+            JOIN ria_profiles rp ON rp.id = rel.ria_profile_id
+            LEFT JOIN relationship_share_grants share
+              ON share.relationship_id = rel.id
+             AND share.status = 'active'
+            WHERE rel.investor_user_id = :owner_user_id
+               OR rp.user_id = :owner_user_id
+            ORDER BY COALESCE(rel.consent_granted_at, rel.updated_at, rel.created_at) DESC
+            LIMIT 100
+            """,
+            params={"owner_user_id": owner_user_id},
+        )
+        for row in rows:
+            if row.get("investor_user_id") == owner_user_id:
+                other_user_id = str(row.get("ria_user_id") or "")
+                relationship_label = "Advisor relationship"
+            else:
+                other_user_id = str(row.get("investor_user_id") or "")
+                relationship_label = "Investor relationship"
+            if other_user_id not in recipient_ids:
+                continue
+            signal = signals[other_user_id]
+            status = str(row.get("status") or "").lower()
+            share_status = str(row.get("relationship_share_status") or "").lower()
+            if status == "approved" or share_status == "active":
+                self._add_recommendation_reason(
+                    signal,
+                    code="approved_professional_relationship",
+                    label="Approved advisor/investor relationship",
+                    weight=38,
+                )
+                signal["trusted"] = True
+            elif status == "request_pending":
+                self._add_recommendation_reason(
+                    signal,
+                    code="pending_professional_relationship",
+                    label="Pending advisor/investor relationship",
+                    weight=20,
+                )
+            else:
+                self._add_recommendation_reason(
+                    signal,
+                    code="professional_graph_proximity",
+                    label="Advisor/investor network connection",
+                    weight=16,
+                )
+            signal["professional"] = True
+            signal["relationship_type"] = signal.get("relationship_type") or relationship_label
+            if str(row.get("ria_verification_status") or "").lower() in {"verified", "active"}:
+                signal["verification_badge"] = signal.get("verification_badge") or "RIA verified"
+            self._remember_signal_time(
+                signal,
+                row.get("relationship_share_granted_at"),
+                row.get("consent_granted_at"),
+                row.get("updated_at"),
+                row.get("created_at"),
+            )
+
+    def _add_organization_membership_signals(
+        self,
+        *,
+        owner_user_id: str,
+        recipient_ids: set[str],
+        signals: dict[str, dict[str, Any]],
+    ) -> None:
+        rows = self._optional_signal_rows(
+            signal_name="ria_firm_memberships",
+            sql="""
+            SELECT
+              peer_rp.user_id AS peer_user_id,
+              firm.legal_name AS firm_name,
+              peer_membership.role_title AS peer_role_title,
+              owner_membership.updated_at AS owner_membership_updated_at,
+              peer_membership.updated_at AS peer_membership_updated_at
+            FROM ria_profiles owner_rp
+            JOIN ria_firm_memberships owner_membership
+              ON owner_membership.ria_profile_id = owner_rp.id
+             AND owner_membership.membership_status = 'active'
+            JOIN ria_firm_memberships peer_membership
+              ON peer_membership.firm_id = owner_membership.firm_id
+             AND peer_membership.membership_status = 'active'
+            JOIN ria_profiles peer_rp ON peer_rp.id = peer_membership.ria_profile_id
+            JOIN ria_firms firm ON firm.id = owner_membership.firm_id
+            WHERE owner_rp.user_id = :owner_user_id
+              AND peer_rp.user_id <> :owner_user_id
+            ORDER BY COALESCE(peer_membership.updated_at, owner_membership.updated_at) DESC
+            LIMIT 100
+            """,
+            params={"owner_user_id": owner_user_id},
+        )
+        for row in rows:
+            peer_user_id = str(row.get("peer_user_id") or "")
+            if peer_user_id not in recipient_ids:
+                continue
+            signal = signals[peer_user_id]
+            firm_label = self._safe_recommendation_text(row.get("firm_name"), max_length=48)
+            reason_label = f"Same organization: {firm_label}" if firm_label else "Same organization"
+            self._add_recommendation_reason(
+                signal,
+                code="organization_membership",
+                label=reason_label,
+                weight=20,
+            )
+            signal["professional"] = True
+            signal["relationship_type"] = signal.get("relationship_type") or "Same organization"
+            if not signal.get("profile_headline"):
+                signal["profile_headline"] = self._safe_recommendation_text(
+                    row.get("peer_role_title"),
+                    max_length=80,
+                )
+            self._remember_signal_time(
+                signal,
+                row.get("peer_membership_updated_at"),
+                row.get("owner_membership_updated_at"),
+            )
+
+    def _add_marketplace_profile_signals(
+        self,
+        *,
+        owner_user_id: str,
+        recipient_ids: set[str],
+        signals: dict[str, dict[str, Any]],
+    ) -> None:
+        rows = self._optional_signal_rows(
+            signal_name="marketplace_public_profiles",
+            sql="""
+            SELECT user_id, profile_type, headline, strategy_summary,
+                   verification_badge, metadata, updated_at, created_at
+            FROM marketplace_public_profiles
+            WHERE is_discoverable = TRUE
+            ORDER BY updated_at DESC
+            LIMIT 200
+            """,
+            params={"owner_user_id": owner_user_id},
+        )
+        owner_terms: set[str] = set()
+        for row in rows:
+            if str(row.get("user_id") or "") == owner_user_id:
+                owner_terms = {
+                    term.lower()
+                    for term in self._safe_metadata_terms(row.get("metadata"), max_terms=6)
+                }
+                break
+        for row in rows:
+            user_id = str(row.get("user_id") or "")
+            if user_id not in recipient_ids:
+                continue
+            signal = signals[user_id]
+            recipient_terms = self._safe_metadata_terms(row.get("metadata"), max_terms=6)
+            shared_terms = [term for term in recipient_terms if term.lower() in owner_terms][:2]
+            profile_type = str(row.get("profile_type") or "").strip().lower()
+            profile_label = (
+                "RIA marketplace profile"
+                if profile_type == "ria"
+                else "Investor marketplace profile"
+            )
+            self._add_recommendation_reason(
+                signal,
+                code="marketplace_public_profile",
+                label=profile_label,
+                weight=24,
+            )
+            signal["professional"] = True
+            signal["relationship_type"] = signal.get("relationship_type") or "Marketplace profile"
+            signal["profile_headline"] = signal.get(
+                "profile_headline"
+            ) or self._safe_recommendation_text(
+                row.get("headline") or row.get("strategy_summary"),
+                max_length=112,
+            )
+            signal["verification_badge"] = signal.get(
+                "verification_badge"
+            ) or self._safe_recommendation_text(
+                row.get("verification_badge") or "Marketplace discoverable",
+                max_length=48,
+            )
+            if shared_terms:
+                self._add_recommendation_reason(
+                    signal,
+                    code="shared_marketplace_categories",
+                    label=f"Shared marketplace focus: {', '.join(shared_terms)}",
+                    weight=18,
+                )
+            self._remember_signal_time(signal, row.get("updated_at"), row.get("created_at"))
+
+    def _add_persona_signals(
+        self,
+        *,
+        owner_user_id: str,
+        recipient_ids: set[str],
+        signals: dict[str, dict[str, Any]],
+    ) -> None:
+        rows = self._optional_signal_rows(
+            signal_name="runtime_persona_state",
+            sql="""
+            SELECT user_id, last_active_persona, updated_at
+            FROM runtime_persona_state
+            WHERE user_id <> :owner_user_id
+            ORDER BY updated_at DESC
+            LIMIT 200
+            """,
+            params={"owner_user_id": owner_user_id},
+        )
+        for row in rows:
+            user_id = str(row.get("user_id") or "")
+            if user_id not in recipient_ids:
+                continue
+            persona = str(row.get("last_active_persona") or "").lower()
+            if persona not in {"ria", "investor"}:
+                continue
+            signal = signals[user_id]
+            self._add_recommendation_reason(
+                signal,
+                code=f"{persona}_persona",
+                label="KAI advisor persona" if persona == "ria" else "KAI investor persona",
+                weight=12,
+            )
+            signal["professional"] = True
+            self._remember_signal_time(signal, row.get("updated_at"))
+
+    def _apply_kai_circle_recommendations(
+        self,
+        *,
+        owner_user_id: str,
+        recipients: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        if not recipients:
+            return []
+        recipient_ids = {str(recipient.get("userId") or "") for recipient in recipients}
+        recipient_ids.discard("")
+        signals = {recipient_id: self._recommendation_signal() for recipient_id in recipient_ids}
+
+        for recipient in recipients:
+            recipient_id = str(recipient.get("userId") or "")
+            signal = signals.get(recipient_id)
+            if not signal:
+                continue
+            if recipient.get("canReceiveLocation"):
+                self._add_recommendation_reason(
+                    signal,
+                    code="location_key_ready",
+                    label="Ready for encrypted location sharing",
+                    weight=28,
+                )
+            else:
+                self._add_recommendation_reason(
+                    signal,
+                    code="recipient_key_missing",
+                    label="Needs to open One Location once",
+                    weight=4,
+                )
+
+        self._add_one_location_history_signals(
+            owner_user_id=owner_user_id,
+            recipient_ids=recipient_ids,
+            signals=signals,
+        )
+        self._add_prior_consent_signals(
+            owner_user_id=owner_user_id,
+            recipient_ids=recipient_ids,
+            signals=signals,
+        )
+        self._add_mutual_kai_relationship_signals(
+            owner_user_id=owner_user_id,
+            recipient_ids=recipient_ids,
+            signals=signals,
+        )
+        self._add_professional_network_signals(
+            owner_user_id=owner_user_id,
+            recipient_ids=recipient_ids,
+            signals=signals,
+        )
+        self._add_organization_membership_signals(
+            owner_user_id=owner_user_id,
+            recipient_ids=recipient_ids,
+            signals=signals,
+        )
+        self._add_marketplace_profile_signals(
+            owner_user_id=owner_user_id,
+            recipient_ids=recipient_ids,
+            signals=signals,
+        )
+        self._add_persona_signals(
+            owner_user_id=owner_user_id,
+            recipient_ids=recipient_ids,
+            signals=signals,
+        )
+
+        enriched: list[dict[str, Any]] = []
+        for recipient in recipients:
+            recipient_id = str(recipient.get("userId") or "")
+            signal = signals.get(recipient_id) or self._recommendation_signal()
+            reasons = sorted(
+                signal.get("reasons", {}).values(),
+                key=lambda item: (-int(item.get("weight") or 0), str(item.get("code") or "")),
+            )[:4]
+            score = max(0, min(100, int(signal.get("score") or 0)))
+            can_receive = bool(recipient.get("canReceiveLocation"))
+            if not can_receive:
+                category = "needs_setup"
+                tier = "setup_needed"
+                trust_level = "setup_needed"
+                category_label = "Needs setup"
+                summary = "They need to open One Location once before encrypted sharing."
+            elif signal.get("needs_action"):
+                category = "needs_action"
+                tier = "needs_action"
+                trust_level = "medium"
+                category_label = "Needs action"
+                summary = "They are waiting on your location-sharing decision."
+            elif signal.get("trusted"):
+                category = "trusted_circle"
+                tier = "trusted_circle"
+                trust_level = "high"
+                category_label = "Trusted Circle"
+                summary = "Existing trust or sharing history makes this a strong match."
+            elif signal.get("professional"):
+                category = "professional_network"
+                tier = "kai_network"
+                trust_level = "medium"
+                category_label = "Professional Network"
+                summary = "KAI marketplace, advisor, investor, or persona signals matched."
+            else:
+                category = "location_ready"
+                tier = "available"
+                trust_level = "new"
+                category_label = "Location ready"
+                summary = "Verified KAI member with recipient encryption ready."
+
+            enriched.append(
+                {
+                    **recipient,
+                    "recommendationScore": score,
+                    "recommendationTier": tier,
+                    "recommendationCategory": category,
+                    "recommendationCategoryLabel": category_label,
+                    "recommendationReasons": reasons,
+                    "recommendationSummary": summary,
+                    "trustLevel": trust_level,
+                    "relationshipType": signal.get("relationship_type"),
+                    "profileHeadline": signal.get("profile_headline"),
+                    "verificationBadge": signal.get("verification_badge")
+                    or ("Location ready" if can_receive else None),
+                    "lastInteractionAt": _iso(signal.get("last_interaction_at")),
+                }
+            )
+
+        enriched.sort(
+            key=lambda item: (
+                -int(item.get("recommendationScore") or 0),
+                0 if item.get("canReceiveLocation") else 1,
+                str(item.get("displayName") or "").lower(),
+                str(item.get("userId") or ""),
+            )
+        )
+        for index, recipient in enumerate(enriched, start=1):
+            recipient["recommendationRank"] = index
+        return enriched
+
     @staticmethod
     def _grant_payload(row: dict[str, Any] | None) -> dict[str, Any] | None:
         if not row:
@@ -831,15 +1595,18 @@ class OneLocationAgentService:
                 "event_types": sorted(ONE_LOCATION_ACTIVITY_EVENT_TYPES),
             },
         )
-        active_row = self._execute_one(
-            """
+        active_row = (
+            self._execute_one(
+                """
             SELECT COUNT(*)::int AS active_share_count
             FROM one_location_share_grants
             WHERE owner_user_id = :user_id
               AND status = 'active'
             """,
-            {"user_id": user_id},
-        ) or {}
+                {"user_id": user_id},
+            )
+            or {}
+        )
 
         events = [
             payload
@@ -902,9 +1669,7 @@ class OneLocationAgentService:
                 and str(row.get("owner_user_id") or "") != user_id
             ),
             "viewsCount": sum(
-                1
-                for row in rows
-                if str(row.get("event_type") or "") == "location_share_viewed"
+                1 for row in rows if str(row.get("event_type") or "") == "location_share_viewed"
             ),
             "publicLinkCount": sum(
                 1
@@ -1259,7 +2024,11 @@ class OneLocationAgentService:
             """,
             {"owner_user_id": owner_user_id, "limit": max(1, min(int(limit), 100))},
         )
-        return [payload for row in rows if (payload := self._recipient_payload(row))]
+        recipients = [payload for row in rows if (payload := self._recipient_payload(row))]
+        return self._apply_kai_circle_recommendations(
+            owner_user_id=owner_user_id,
+            recipients=recipients,
+        )
 
     def _recipient_key_row(
         self, *, recipient_user_id: str, recipient_key_id: str | None = None

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -195,6 +195,11 @@ class FourUserMemoryService(OneLocationAgentService):
         self.public_submissions: dict[str, dict] = {}
         self.events: dict[str, dict] = {}
         self.notifications: list[dict] = []
+        self.professional_relationships: list[dict] = []
+        self.organization_memberships: list[dict] = []
+        self.consent_audit_rows: list[dict] = []
+        self.marketplace_profiles: dict[str, dict] = {}
+        self.persona_states: dict[str, dict] = {}
 
     def _send_metadata_notification(self, **kwargs) -> None:
         assert _contains_plaintext_location_key(kwargs.get("data") or {}) is False
@@ -252,6 +257,99 @@ class FourUserMemoryService(OneLocationAgentService):
                     }
                 )
             return rows
+        if (
+            "FROM one_location_share_grants" in sql
+            and "owner_user_id = :owner_user_id OR recipient_user_id = :owner_user_id" in sql
+        ):
+            owner = params["owner_user_id"]
+            return [
+                grant
+                for grant in sorted(
+                    self.grants.values(),
+                    key=lambda item: item["created_at"],
+                    reverse=True,
+                )
+                if grant["owner_user_id"] == owner or grant["recipient_user_id"] == owner
+            ][:100]
+        if (
+            "FROM one_location_access_requests" in sql
+            and "owner_user_id = :owner_user_id OR requester_user_id = :owner_user_id" in sql
+        ):
+            owner = params["owner_user_id"]
+            return [
+                request
+                for request in sorted(
+                    self.requests.values(),
+                    key=lambda item: item["requested_at"],
+                    reverse=True,
+                )
+                if request["owner_user_id"] == owner or request["requester_user_id"] == owner
+            ][:100]
+        if "FROM one_location_referrals" in sql and "owner_user_id = :owner_user_id" in sql:
+            owner = params["owner_user_id"]
+            return [
+                referral
+                for referral in sorted(
+                    self.referrals.values(),
+                    key=lambda item: item["created_at"],
+                    reverse=True,
+                )
+                if owner
+                in {
+                    referral["owner_user_id"],
+                    referral["referring_user_id"],
+                    referral["referred_user_id"],
+                }
+            ][:100]
+        if "FROM consent_audit" in sql:
+            owner = params["owner_user_id"]
+            return [
+                row
+                for row in sorted(
+                    self.consent_audit_rows,
+                    key=lambda item: item["issued_at"],
+                    reverse=True,
+                )
+                if row.get("user_id") == owner or row.get("agent_id") == owner
+            ][:100]
+        if (
+            "FROM advisor_investor_relationships rel" in sql
+            and "LEFT JOIN relationship_share_grants share" in sql
+        ):
+            owner = params["owner_user_id"]
+            return [
+                row
+                for row in self.professional_relationships
+                if row.get("investor_user_id") == owner or row.get("ria_user_id") == owner
+            ][:100]
+        if "FROM advisor_investor_relationships rel" in sql:
+            return self.professional_relationships[:500]
+        if "FROM ria_profiles owner_rp" in sql:
+            owner = params["owner_user_id"]
+            return [
+                row for row in self.organization_memberships if row.get("owner_user_id") == owner
+            ][:100]
+        if "FROM marketplace_public_profiles" in sql:
+            return [
+                profile
+                for profile in sorted(
+                    self.marketplace_profiles.values(),
+                    key=lambda item: item["updated_at"],
+                    reverse=True,
+                )
+                if profile.get("is_discoverable")
+            ][:200]
+        if "FROM runtime_persona_state" in sql:
+            owner = params["owner_user_id"]
+            return [
+                state
+                for state in sorted(
+                    self.persona_states.values(),
+                    key=lambda item: item["updated_at"],
+                    reverse=True,
+                )
+                if state.get("user_id") != owner
+            ][:200]
         if "FROM one_location_public_invites" in sql:
             return [
                 invite
@@ -500,8 +598,7 @@ class FourUserMemoryService(OneLocationAgentService):
                 "active_share_count": sum(
                     1
                     for grant in self.grants.values()
-                    if grant["owner_user_id"] == params["user_id"]
-                    and grant["status"] == "active"
+                    if grant["owner_user_id"] == params["user_id"] and grant["status"] == "active"
                 )
             }
         if "UPDATE one_location_recipient_keys" in sql:
@@ -789,6 +886,190 @@ def encrypted_envelope(key_id: str, ciphertext: str = "ciphertext") -> dict:
         "sourcePlatform": "web",
         "metadata": {"plaintext": False},
     }
+
+
+def test_kai_circle_recipient_directory_uses_safe_recommendation_signals() -> None:
+    service = FourUserMemoryService()
+    now = datetime.now(timezone.utc)
+    user_a = "user_a"
+    user_b = "user_b"
+    user_c = "user_c"
+    user_d = "user_d"
+    user_e = "user_e"
+    user_f = "user_f"
+    user_g = "user_g"
+    service.identities[user_e] = {
+        "user_id": user_e,
+        "display_name": "User E",
+        "phone_number": "+15550100005",
+        "phone_verified": True,
+    }
+    service.identities[user_f] = {
+        "user_id": user_f,
+        "display_name": "User F",
+        "phone_number": "+15550100006",
+        "phone_verified": True,
+    }
+    service.identities[user_g] = {
+        "user_id": user_g,
+        "display_name": "User G",
+        "phone_number": "+15550100007",
+        "phone_verified": True,
+    }
+
+    for user_id in (user_a, user_b, user_c, user_d, user_f, user_g):
+        service.register_recipient_key(
+            user_id=user_id,
+            key_id=f"key-{user_id}",
+            public_key_jwk={"kty": "EC", "crv": "P-256", "x": user_id, "y": user_id},
+        )
+
+    service.create_grant(
+        owner_user_id=user_a,
+        recipient_user_id=user_b,
+        recipient_key_id=f"key-{user_b}",
+        duration_hours=1,
+    )
+    service.request_access(
+        owner_user_id=user_a,
+        requester_user_id=user_c,
+        message="Can you share your location?",
+    )
+    service.professional_relationships.append(
+        {
+            "investor_user_id": user_a,
+            "ria_user_id": user_d,
+            "status": "discovered",
+            "granted_scope": None,
+            "consent_granted_at": None,
+            "created_at": now - timedelta(days=3),
+            "updated_at": now - timedelta(days=2),
+            "ria_display_name": "User D",
+            "ria_verification_status": "verified",
+            "relationship_share_status": None,
+            "relationship_share_granted_at": None,
+        }
+    )
+    service.professional_relationships.append(
+        {
+            "investor_user_id": user_g,
+            "ria_user_id": user_d,
+            "status": "approved",
+            "granted_scope": "attr.financial.*",
+            "consent_granted_at": now - timedelta(days=2),
+            "created_at": now - timedelta(days=3),
+            "updated_at": now - timedelta(days=1),
+            "ria_display_name": "User D",
+            "ria_verification_status": "verified",
+            "relationship_share_status": "active",
+            "relationship_share_granted_at": now - timedelta(days=1),
+        }
+    )
+    service.organization_memberships.append(
+        {
+            "owner_user_id": user_a,
+            "peer_user_id": user_g,
+            "firm_name": "Hushh Advisors",
+            "peer_role_title": "Advisor partner",
+            "owner_membership_updated_at": now - timedelta(days=2),
+            "peer_membership_updated_at": now - timedelta(days=1),
+        }
+    )
+    service.consent_audit_rows.append(
+        {
+            "user_id": user_a,
+            "agent_id": user_g,
+            "action": "CONSENT_GRANTED",
+            "issued_at": now - timedelta(hours=3),
+        }
+    )
+    service.marketplace_profiles[user_a] = {
+        "user_id": user_a,
+        "profile_type": "investor",
+        "headline": "Long-term family planning",
+        "strategy_summary": "Public owner profile",
+        "verification_badge": "Verified investor",
+        "metadata": {"categories": ["retirement", "tax"], "location": "private"},
+        "is_discoverable": True,
+        "created_at": now - timedelta(days=7),
+        "updated_at": now - timedelta(days=1),
+    }
+    service.marketplace_profiles[user_d] = {
+        "user_id": user_d,
+        "profile_type": "ria",
+        "headline": "Retirement planning specialist",
+        "strategy_summary": "Public advisor profile",
+        "verification_badge": "Verified advisor",
+        "metadata": {"categories": ["estate"]},
+        "is_discoverable": True,
+        "created_at": now - timedelta(days=4),
+        "updated_at": now - timedelta(days=1),
+    }
+    service.marketplace_profiles[user_f] = {
+        "user_id": user_f,
+        "profile_type": "investor",
+        "headline": "Family tax planning",
+        "strategy_summary": "Public investor profile",
+        "verification_badge": "Verified profile",
+        "metadata": {"categories": ["retirement", "family"], "address": "private"},
+        "is_discoverable": True,
+        "created_at": now - timedelta(days=4),
+        "updated_at": now,
+    }
+    service.persona_states[user_d] = {
+        "user_id": user_d,
+        "last_active_persona": "ria",
+        "updated_at": now,
+    }
+
+    recipients = service.list_verified_recipients(owner_user_id=user_a)
+    by_id = {recipient["userId"]: recipient for recipient in recipients}
+
+    assert by_id[user_b]["recommendationCategory"] == "trusted_circle"
+    assert by_id[user_b]["trustLevel"] == "high"
+    assert any(
+        reason["code"] == "active_location_share"
+        for reason in by_id[user_b]["recommendationReasons"]
+    )
+    assert by_id[user_c]["recommendationCategory"] == "needs_action"
+    assert by_id[user_c]["recommendationTier"] == "needs_action"
+    assert any(
+        reason["code"] == "pending_location_request"
+        for reason in by_id[user_c]["recommendationReasons"]
+    )
+    assert by_id[user_d]["recommendationCategory"] == "professional_network"
+    assert by_id[user_d]["relationshipType"] == "Advisor relationship"
+    assert by_id[user_d]["profileHeadline"] == "Retirement planning specialist"
+    assert by_id[user_f]["recommendationCategory"] == "professional_network"
+    assert any(
+        reason["code"] == "shared_marketplace_categories"
+        for reason in by_id[user_f]["recommendationReasons"]
+    )
+    assert by_id[user_g]["recommendationCategory"] == "trusted_circle"
+    assert any(
+        reason["code"] == "prior_consent_relationship"
+        for reason in by_id[user_g]["recommendationReasons"]
+    )
+    assert any(
+        reason["code"] == "organization_membership"
+        for reason in by_id[user_g]["recommendationReasons"]
+    )
+    assert any(
+        reason["code"] == "mutual_kai_relationship"
+        for reason in by_id[user_g]["recommendationReasons"]
+    )
+    assert by_id[user_e]["recommendationCategory"] == "needs_setup"
+    assert by_id[user_e]["canReceiveLocation"] is False
+
+    ranks = [recipient["recommendationRank"] for recipient in recipients]
+    assert ranks == sorted(ranks)
+    encoded = json.dumps(recipients, default=str)
+    assert "latitude" not in encoded
+    assert "longitude" not in encoded
+    assert "15550100002" not in encoded
+    assert "Can you share your location?" not in encoded
+    assert "attr.financial" not in encoded
+    assert "private" not in encoded
 
 
 def test_terminal_location_work_is_deleted_after_twelve_hour_retention() -> None:

--- a/docs/reference/architecture/api-contracts.md
+++ b/docs/reference/architecture/api-contracts.md
@@ -169,8 +169,8 @@ not the product owner for live location.
 
 | Method | Path | Auth | Description |
 | ------ | ---- | ---- | ----------- |
-| GET | `/api/one/location/state` | VAULT_OWNER Bearer | List verified recipient directory, owner grants, received grants, pending requests, and referrals for the authenticated user |
-| GET | `/api/one/location/recipients` | VAULT_OWNER Bearer | List phone-verified users excluding self, with masked labels and active public key metadata only |
+| GET | `/api/one/location/state` | VAULT_OWNER Bearer | List verified recipient directory, KAI Circle recommendation metadata, owner grants, received grants, pending requests, and referrals for the authenticated user |
+| GET | `/api/one/location/recipients` | VAULT_OWNER Bearer | List phone-verified users excluding self, with masked labels, active public key metadata, and safe KAI Circle recommendation signals only |
 | POST | `/api/one/location/recipient-keys` | VAULT_OWNER Bearer | Register the authenticated user's recipient public key; private key remains device-local |
 | POST | `/api/one/location/public-invites` | VAULT_OWNER Bearer | Create a duration-bounded public request link; the raw token is returned once and only its hash is stored |
 | GET | `/api/one/location/public-invites/{public_token}` | Public | Resolve request-link metadata only: safe owner label, status, duration, and expiry |

--- a/docs/reference/architecture/one-location-agent.md
+++ b/docs/reference/architecture/one-location-agent.md
@@ -137,6 +137,24 @@ previews, or movement/freshness trails. Public submissions are bounded per token
 throttled per phone/fingerprint hash, and never return request internals, grants,
 ciphertext, or location payloads to the anonymous caller.
 
+## KAI Circle Recommendation Contract
+
+Phase 5 KAI Circle improves the authenticated recipient directory ranking. The
+service may use existing One Location sharing history, pending requests,
+referrals, mutual KAI graph proximity, prior consent approvals,
+advisor/investor relationship proximity, active relationship-share grants,
+same-organization RIA firm membership, discoverable marketplace profiles,
+shared public marketplace categories/interests, and runtime persona state as
+safe recommendation signals.
+
+Recommendation metadata can include category, tier, score, short reason labels,
+public profile headline, verification badge, and last interaction timestamp. It
+does not create access, replace consent, or expose coordinates, raw phone
+numbers, invite tokens, grant ids, request ids, raw consent scopes, ciphertext,
+or PKM payloads. Missing optional marketplace, relationship, consent, persona,
+or organization tables must degrade to cold-start location-ready
+recommendations instead of failing the location state API.
+
 ## Notification Contract
 
 Location notifications are best-effort and metadata-only. Payloads may include


### PR DESCRIPTION
﻿## Summary
- complete the Phase 5 KAI Circle recommendation slice for the authenticated One Location recipient directory
- rank recipients from safe signals: active/prior One Location history, pending requests, referrals, prior consent approvals, mutual KAI graph proximity, direct advisor/investor graph proximity, relationship-share grants, same-organization RIA firm membership, discoverable marketplace profiles, shared public marketplace categories/interests, and runtime persona state
- keep optional relationship, marketplace, consent, organization, and persona probes fail-soft so missing tables degrade to cold-start location-ready recommendations instead of breaking `/api/one/location/state`
- document the KAI Circle recommendation boundary: ranking only, no consent replacement, no coordinates/raw phones/tokens/grant ids/request ids/raw consent scopes/ciphertext/PKM payloads

## Verification
- `cd consent-protocol && .\.venv\Scripts\python.exe -m ruff check hushh_mcp/services/one_location_agent_service.py tests/services/test_one_location_agent_service.py`
- `cd consent-protocol && .\.venv\Scripts\python.exe -m ruff format --check hushh_mcp/services/one_location_agent_service.py tests/services/test_one_location_agent_service.py`
- `cd consent-protocol && .\.venv\Scripts\python.exe -m mypy --config-file pyproject.toml --ignore-missing-imports hushh_mcp/services/one_location_agent_service.py`
- `cd consent-protocol && .\.venv\Scripts\python.exe -m bandit -r hushh_mcp/services/one_location_agent_service.py -c pyproject.toml -ll`
- `cd consent-protocol && .\.venv\Scripts\python.exe -m pytest tests/services/test_one_location_agent_service.py -q`
- `cd consent-protocol && .\.venv\Scripts\python.exe -m pytest tests/test_one_location_routes.py -q`
- `cd hushh-webapp && npm run verify:docs`
- `git diff --check`

## Notes
- Stacked on #1887 (`one-location-stale-retry-telemetry`) because this is the next Phase 5 slice in the One Location stack.
- `bash scripts/ci/protocol-check.sh` could not run locally because this Windows laptop routes `bash` to WSL and no WSL distro is installed; the PowerShell-friendly Protocol pieces above were run instead.
- Issue #1738 Phase 5 checklist is updated to reflect the completed PR scope.

Refs #1738