### PR TITLE
test(developer-api): rename oversized-token test functions for clarity

### DIFF
--- a/consent-protocol/tests/test_developer_api_routes.py
+++ b/consent-protocol/tests/test_developer_api_routes.py
@@ -111,7 +111,7 @@ def test_consent_status_rejects_oversized_query_params_before_auth(monkeypatch):
     assert response.status_code == 422
 
 
-def test_tool_catalog_rejects_oversized_query_token_before_auth(monkeypatch):
+def test_tool_catalog_rejects_oversized_token_before_auth(monkeypatch):
     monkeypatch.setenv("ENVIRONMENT", "development")
     monkeypatch.setenv("DEVELOPER_API_ENABLED", "true")
 
@@ -121,7 +121,7 @@ def test_tool_catalog_rejects_oversized_query_token_before_auth(monkeypatch):
     assert response.status_code == 422
 
 
-def test_request_consent_rejects_oversized_query_token_before_auth(monkeypatch):
+def test_request_consent_rejects_oversized_token_before_auth(monkeypatch):
     monkeypatch.setenv("ENVIRONMENT", "development")
     monkeypatch.setenv("DEVELOPER_API_ENABLED", "true")
 
@@ -135,7 +135,7 @@ def test_request_consent_rejects_oversized_query_token_before_auth(monkeypatch):
     assert response.status_code == 422
 
 
-def test_scoped_export_rejects_oversized_query_token_before_auth(monkeypatch):
+def test_scoped_export_rejects_oversized_token_before_auth(monkeypatch):
     monkeypatch.setenv("ENVIRONMENT", "development")
     monkeypatch.setenv("DEVELOPER_API_ENABLED", "true")
 


### PR DESCRIPTION
## What changed

Renamed three test functions in \`tests/test_developer_api_routes.py\` to remove the redundant \`_query_\` infix:

- \`test_tool_catalog_rejects_oversized_query_token_before_auth\` → \`test_tool_catalog_rejects_oversized_token_before_auth\`
- \`test_request_consent_rejects_oversized_query_token_before_auth\` → \`test_request_consent_rejects_oversized_token_before_auth\`
- \`test_scoped_export_rejects_oversized_query_token_before_auth\` → \`test_scoped_export_rejects_oversized_token_before_auth\`

The production \`max_length=2048\` constraints on the \`token\` query parameters are already present in \`integration/pr-train\`. This PR only improves test name clarity.

## Verification

- Test behavior is unchanged; only names changed
- No production code modified

## Checklist

- [ ] All maintainer feedback addressed
- [ ] No merge conflicts
- [ ] All CI checks green
- [ ] Tests pass and cover real product paths