### PR TITLE
fix(ria): add max_length=64 to tier query parameter on universe endpoint (CWE-400)

### DIFF
--- a/consent-protocol/api/routes/ria.py
+++ b/consent-protocol/api/routes/ria.py
@@ -511,7 +511,7 @@ async def create_ria_request_bundle(
 
 @router.get("/universe")
 async def renaissance_universe(
-    tier: str | None = Query(None),
+    tier: str | None = Query(None, max_length=64),
     firebase_uid: str = Depends(require_firebase_auth),
 ):
     """Return the Renaissance investable universe (default Kai stock list)."""

--- a/consent-protocol/tests/test_ria_bounds.py
+++ b/consent-protocol/tests/test_ria_bounds.py
@@ -1,0 +1,39 @@
+"""Test resource exhaustion bounds (CWE-400) on RIA routes."""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.middleware import require_firebase_auth
+from api.routes import ria
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(ria.router)
+    app.dependency_overrides[require_firebase_auth] = lambda: "test_user_123"
+    return app
+
+
+def test_renaissance_universe_rejects_oversized_tier():
+    """Verify /ria/universe tier parameter enforces max_length=64."""
+    app = _build_app()
+    client = TestClient(app)
+
+    oversized_tier = "x" * 65
+    response = client.get(
+        "/api/ria/universe",
+        params={"tier": oversized_tier},
+    )
+    assert response.status_code == 422
+
+
+def test_renaissance_universe_within_bounds_accepts_request():
+    """Verify /ria/universe with valid bounds passes validation."""
+    app = _build_app()
+    client = TestClient(app)
+
+    response = client.get(
+        "/api/ria/universe",
+        params={"tier": "alpha"},
+    )
+    assert response.status_code in [200, 500, 503]


### PR DESCRIPTION
## Problem

`GET /ria/universe` accepted an unbounded `tier` query parameter:

```python
tier: str | None = Query(None)
```

The value is passed to `service.get_by_tier(tier.upper())` without any length validation. A caller can supply an arbitrarily large string, which is processed and forwarded to downstream service calls (CWE-400).

## Fix

```python
tier: str | None = Query(None, max_length=64)
```

64 characters accommodates all valid Renaissance tier classification identifiers (e.g. `"ALPHA"`, `"BETA"`, `"TIER_1"`) with substantial headroom.

## Files Changed

- `consent-protocol/api/routes/ria.py` (1 line)
- `consent-protocol/tests/test_ria_bounds.py` (new)

## Tests

- Oversized `tier` (65 chars) returns HTTP 422
- Valid `tier` value passes validation