### PR TITLE
fix(world-model): add per-item max_length=128 to segment_ids query param (CWE-400)

### DIFF
--- a/consent-protocol/api/routes/world_model.py
+++ b/consent-protocol/api/routes/world_model.py
@@ -16,10 +16,10 @@ api.routes.world_model.get_world_model_domain_data  -> GET /api/world-model/doma
 """
 
 import logging
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Path, Query, Request, Response
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, StringConstraints
 
 from api.middleware import require_vault_owner_token
 from api.routes.pkm_routes_shared import (
@@ -157,7 +157,9 @@ async def get_world_model_data(
 async def get_world_model_domain_data(
     user_id: str = Path(..., min_length=1, max_length=128),
     domain: str = Path(..., min_length=1, max_length=200),
-    segment_ids: list[str] | None = Query(default=None),
+    segment_ids: list[Annotated[str, StringConstraints(max_length=128)]] | None = Query(
+        default=None
+    ),
     token_data: dict = Depends(require_vault_owner_token),
 ):
     return await _get_domain_data(user_id, domain, segment_ids, token_data)

--- a/consent-protocol/tests/test_world_model_segment_bounds.py
+++ b/consent-protocol/tests/test_world_model_segment_bounds.py
@@ -1,0 +1,37 @@
+"""Verify CWE-400: segment_ids query parameter is bounded in world-model routes."""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.middleware import require_vault_owner_token
+from api.routes import world_model
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(world_model.router)
+    app.dependency_overrides[require_vault_owner_token] = lambda: {
+        "user_id": "test_user_123",
+        "token": "test",
+    }
+    return app
+
+
+def test_world_model_domain_data_rejects_oversized_segment_id():
+    """GET /world-model/domain-data must reject segment_ids item > 128 characters (CWE-400)."""
+    client = TestClient(_build_app())
+    response = client.get(
+        "/api/world-model/domain-data/test_user_123/financial",
+        params={"segment_ids": "x" * 129},
+    )
+    assert response.status_code == 422
+
+
+def test_world_model_domain_data_accepts_valid_segment_ids():
+    """GET /world-model/domain-data must accept segment_ids within 128 characters."""
+    client = TestClient(_build_app())
+    response = client.get(
+        "/api/world-model/domain-data/test_user_123/financial",
+        params={"segment_ids": "seg_abc"},
+    )
+    assert response.status_code in {200, 400, 404, 500, 503}


### PR DESCRIPTION
## Problem

`GET /world-model/domain-data/{user_id}/{domain}` accepted segment_ids items with no per-item length bound:

```python
segment_ids: list[str] | None = Query(default=None)
```

Applying `max_length` directly to a `list[str]` Query parameter constrains the list count, not the length of each string item. Each segment identifier was forwarded to the PKM data layer with no upper bound (CWE-400).

## Fix

Use `Annotated[str, StringConstraints(max_length=128)]` to enforce a per-item length limit:

```python
segment_ids: list[Annotated[str, StringConstraints(max_length=128)]] | None = Query(default=None)
```

128 characters aligns with segment ID limits across the rest of the PKM API surface.

## Files Changed

- `consent-protocol/api/routes/world_model.py` (1 parameter, 2 import additions)
- `consent-protocol/tests/test_world_model_segment_bounds.py` (new)

## Tests

- A segment_ids item of 129 characters returns HTTP 422
- A valid segment_ids item passes validation