### PR TITLE
chore: route PR trains through integration branch

### DIFF
--- a/.codex/skills/pr-governance-review/references/pr-train-review-sop.md
+++ b/.codex/skills/pr-governance-review/references/pr-train-review-sop.md
@@ -12,7 +12,7 @@ Canonical order for every backlog, batch, repass, decision-wave, or scale pass:
 2. Confirm every requested author or surface scope before scanning. If the operator gives rough handles, resolve exact GitHub logins first and do not substitute similarly named users silently.
 3. Apply the Actionable Intake Filter before deep review: include unattended PRs, PRs with contributor activity after the latest maintainer `changes_requested` record, and PRs whose head SHA/check/mergeability changed; move unchanged PRs with current standardized maintainer records into `Dormant Current Holds`.
 4. Move failing, missing, stale, or auxiliary-failing checks into `Check Failure Holds` unless this is CI repair.
-5. Build the train graph from hard edges: exact files, lockfiles, generated contracts, schema/migrations, concrete shared route/runtime surfaces, dirty-file overlap, stacked/conflicting state, and queue/main dependencies. Treat broad sensitive-runtime labels as risk signals unless they share a concrete file, route, schema, generated contract, or explicit dependency edge.
+5. Build the train graph from hard edges: exact files, lockfiles, generated contracts, schema/migrations, concrete shared route/runtime surfaces, dirty-file overlap, stacked/conflicting state, and train/promotion dependencies. Treat broad sensitive-runtime labels as risk signals unless they share a concrete file, route, schema, generated contract, or explicit dependency edge.
 6. Identify all async trains from that graph, oldest PRs first, not only the next visible batch.
 7. Start one read-only evidence lane per independent train family; the writer-lane exception does not make evidence lanes writable.
 8. Ask one Pre-Wave Operator Question before any comment, close, patch, queue, merge, or deploy checkpoint unless the operator has already given explicit standing approval for this scoped async-train run.
@@ -72,9 +72,9 @@ Move a PR to `Dormant Current Holds` without deep re-review when all are true:
 
 ## Preflight
 
-Fetch main, inspect worktree, confirm no dirty local file overlaps a PR under review, and use only a fresh scoped live report. High-volume (`>20` PRs scanned, `>5` acted on, mixed trains, repasses, or throughput maximization) requires the delegation router and read-only lanes.
+Fetch `origin/integration/pr-train`, inspect worktree, confirm no dirty local file overlaps a PR under review, and use only a fresh scoped live report. High-volume (`>20` PRs scanned, `>5` acted on, mixed trains, repasses, or throughput maximization) requires the delegation router and read-only lanes.
 
-Record the starting developer branch before any worktree, PR checkout, detached HEAD, or temporary review branch operation. If the parent session switches away, the train is not complete until it returns to that branch or reports the exact blocker. Fetch `origin/main` before any state-changing wave or branch switch so decisions are based on current main refs.
+Record the starting developer branch before any worktree, PR checkout, detached HEAD, or temporary review branch operation. If the parent session switches away, the train is not complete until it returns to that branch or reports the exact blocker. Fetch `origin/integration/pr-train` before any PR-train state-changing wave or branch switch so decisions are based on the current train ref. Fetch `origin/main` only for train-to-main promotion, hotfix, or deploy-authority checks.
 
 ## Branch And Worktree Hygiene
 
@@ -85,7 +85,7 @@ Record the starting developer branch before any worktree, PR checkout, detached 
 5. Never leave final governance changes only on a temporary branch. Move or replay accepted changes onto the operator-approved development branch before final handoff.
 6. Do not switch branches with dirty user work unless that work is first preserved with an explicit stash, commit, or operator-approved worktree handoff.
 7. Attempt temporary branch and worktree cleanup before final handoff. If cleanup fails, report the exact branch or worktree, current ref, why it remains, and the next cleanup command.
-8. A final handoff after branch operations must state the current branch, whether `origin/main` was fetched, what temporary branches/worktrees remain, and where the accepted changes live.
+8. A final handoff after branch operations must state the current branch, whether `origin/integration/pr-train` and any required `origin/main` promotion ref were fetched, what temporary branches/worktrees remain, and where the accepted changes live.
 9. Before final handoff, run a read-only worktree inventory:
    `git worktree list --porcelain`, `git worktree prune --dry-run`, and
    `git -C <worktree> status --short --branch` for non-primary worktrees.
@@ -141,13 +141,13 @@ Identify every train in the reviewed scope before any state change:
 
 Large OSS-style contribution queues often contain stacked work. Treat this as a sequencing input, not as automatic drift.
 
-1. Review every PR against current `main`, then check whether it has a proven predecessor in the open PR set.
+1. Review every normal PR against current `integration/pr-train`, then check whether it has a proven predecessor in the open PR set.
 2. Proven stack evidence includes explicit dependency language in the PR title/body, branch ancestry, imports/callers that point to files introduced by another open PR, or tests that only make sense after a named predecessor lands.
 3. Hints such as same author, similar title, nearby creation time, or same broad theme are not enough by themselves.
 4. If a follow-up PR depends on a predecessor, put both in one sequential train, set `must_wait_for`, and process the initializer first.
 5. Do not mark the follow-up as an unattached helper solely because the caller is in its predecessor PR.
 6. If the predecessor is outside the reviewed scope, stale, failing CI, conflicting, or unmerged, hold the dependent PR with `needs_predecessor_repass` rather than approving it.
-7. If no predecessor can be proven, apply the normal current-main reachability gate.
+7. If no predecessor can be proven, apply the normal current-train reachability gate.
 
 ## Write, Queue, And Reporting Detail
 

--- a/.codex/skills/pr-governance-review/scripts/pr_ancestry_health.py
+++ b/.codex/skills/pr-governance-review/scripts/pr_ancestry_health.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Audit open PR ancestry health against the current base branch.
+
+This is intentionally separate from the main review checklist so operators can
+freeze a PR train and classify branch hygiene before spending review time on a
+contaminated diff.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import urllib.parse
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from typing import Any
+
+
+DEFAULT_REPO = "hushh-labs/hushh-research"
+
+
+@dataclass(frozen=True)
+class Thresholds:
+    max_ahead: int
+    max_behind: int
+    max_changed_files: int
+    allow_codex: bool
+    allow_claude: bool
+
+
+def _run_gh_api(path: str) -> Any:
+    output = subprocess.check_output(["gh", "api", path], text=True)
+    return json.loads(output)
+
+
+def _pulls(repo: str, *, limit: int) -> list[dict[str, Any]]:
+    pulls: list[dict[str, Any]] = []
+    page = 1
+    per_page = min(100, max(1, limit))
+    while len(pulls) < limit:
+        batch = _run_gh_api(f"repos/{repo}/pulls?state=open&per_page={per_page}&page={page}")
+        if not batch:
+            break
+        pulls.extend(batch)
+        if len(batch) < per_page:
+            break
+        page += 1
+    return pulls[:limit]
+
+
+def _pull(repo: str, number: int) -> dict[str, Any]:
+    return _run_gh_api(f"repos/{repo}/pulls/{number}")
+
+
+def _compare(repo: str, base: str, owner: str, ref: str) -> dict[str, Any]:
+    spec = f"{base}...{owner}:{ref}"
+    encoded = urllib.parse.quote(spec, safe=":")
+    return _run_gh_api(f"repos/{repo}/compare/{encoded}")
+
+
+def _classify(row: dict[str, Any], thresholds: Thresholds, *, repo_owner: str) -> tuple[str, list[str]]:
+    reasons: list[str] = []
+    status = row.get("status")
+    ahead = int(row.get("ahead") or 0)
+    behind = int(row.get("behind") or 0)
+    changed_files = int(row.get("changed_files") or 0)
+    codex_files = int(row.get("codex_files") or 0)
+    claude_files = int(row.get("claude_files") or 0)
+
+    if row.get("base") != "main":
+        return "stacked_or_non_main", ["base is not main"]
+
+    if status != "ahead":
+        reasons.append(f"compare status is {status}")
+    if ahead > thresholds.max_ahead:
+        reasons.append(f"ahead commits {ahead} > {thresholds.max_ahead}")
+    if behind > thresholds.max_behind:
+        reasons.append(f"behind commits {behind} > {thresholds.max_behind}")
+    if changed_files >= thresholds.max_changed_files:
+        reasons.append(f"changed files hit {changed_files} cap/threshold")
+    if claude_files and not thresholds.allow_claude:
+        reasons.append(f".claude files present: {claude_files}")
+    if codex_files and not thresholds.allow_codex:
+        reasons.append(f".codex files present: {codex_files}")
+
+    if not reasons:
+        return "clean_for_review", []
+
+    if row.get("head_owner") == repo_owner:
+        return "rebase_or_recreate_required", reasons
+    return "contributor_recreate_required", reasons
+
+
+def audit(
+    repo: str,
+    *,
+    limit: int,
+    thresholds: Thresholds,
+    base_ref: str | None = None,
+    pr_numbers: list[int] | None = None,
+) -> dict[str, Any]:
+    rows: list[dict[str, Any]] = []
+    errors: list[dict[str, Any]] = []
+    repo_owner = repo.split("/", 1)[0]
+    pulls = [_pull(repo, number) for number in pr_numbers] if pr_numbers else _pulls(repo, limit=limit)
+    for pr in pulls:
+        head_repo = pr.get("head", {}).get("repo") or {}
+        head_owner = (head_repo.get("owner") or pr.get("head", {}).get("user") or {}).get("login")
+        head_ref = pr.get("head", {}).get("ref")
+        pr_base = pr.get("base", {}).get("ref")
+        compare_base = base_ref or pr_base
+        row = {
+            "number": pr.get("number"),
+            "url": pr.get("html_url"),
+            "title": pr.get("title"),
+            "head_owner": head_owner,
+            "head_ref": head_ref,
+            "base": pr_base,
+            "compare_base": compare_base,
+            "head_sha": (pr.get("head", {}).get("sha") or "")[:10],
+            "draft": bool(pr.get("draft")),
+            "created_at": pr.get("created_at"),
+            "updated_at": pr.get("updated_at"),
+        }
+        try:
+            compare = _compare(repo, str(compare_base), str(head_owner), str(head_ref))
+            files = [item.get("filename", "") for item in compare.get("files", [])]
+            row.update(
+                status=compare.get("status"),
+                ahead=compare.get("ahead_by"),
+                behind=compare.get("behind_by"),
+                merge_base=((compare.get("merge_base_commit") or {}).get("sha") or "")[:10],
+                changed_files=len(files),
+                codex_files=sum(1 for path in files if path.startswith(".codex/")),
+                claude_files=sum(1 for path in files if path.startswith(".claude/")),
+            )
+            bucket, reasons = _classify(row, thresholds, repo_owner=repo_owner)
+            row["bucket"] = bucket
+            row["reasons"] = reasons
+            rows.append(row)
+        except subprocess.CalledProcessError as exc:
+            row["bucket"] = "compare_error"
+            row["error"] = exc.output.strip()[:500]
+            errors.append(row)
+            rows.append(row)
+
+    buckets = Counter(row["bucket"] for row in rows)
+    merge_bases = Counter(row.get("merge_base") for row in rows if row.get("merge_base"))
+    by_owner: dict[str, Counter[str]] = defaultdict(Counter)
+    for row in rows:
+        by_owner[str(row.get("head_owner"))][str(row.get("bucket"))] += 1
+
+    return {
+        "repo": repo,
+        "limit": limit,
+        "base_ref": base_ref,
+        "pr_numbers": pr_numbers or [],
+        "thresholds": thresholds.__dict__,
+        "counts": dict(buckets),
+        "merge_bases": dict(merge_bases.most_common(10)),
+        "by_owner": {owner: dict(counter) for owner, counter in sorted(by_owner.items())},
+        "errors": errors,
+        "prs": rows,
+    }
+
+
+def _print_text(result: dict[str, Any]) -> None:
+    print(f"Repo: {result['repo']}")
+    print(f"PRs scanned: {len(result['prs'])}")
+    print("Buckets:")
+    for bucket, count in sorted(result["counts"].items()):
+        print(f"- {bucket}: {count}")
+    print("Top merge bases:")
+    for merge_base, count in result["merge_bases"].items():
+        print(f"- {merge_base}: {count}")
+    print("Blocked/recreate candidates:")
+    for row in result["prs"]:
+        if row["bucket"] in {"rebase_or_recreate_required", "contributor_recreate_required"}:
+            reason = "; ".join(row.get("reasons") or [])
+            print(
+                f"- #{row['number']} {row['url']} "
+                f"{row['bucket']} ahead={row.get('ahead')} behind={row.get('behind')} "
+                f"files={row.get('changed_files')} codex={row.get('codex_files')} "
+                f"claude={row.get('claude_files')} reason={reason}"
+            )
+    print("Clean candidates:")
+    for row in result["prs"]:
+        if row["bucket"] == "clean_for_review":
+            print(f"- #{row['number']} {row['url']} ahead={row.get('ahead')} files={row.get('changed_files')}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Audit PR branch ancestry health.")
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument(
+        "--base-ref",
+        help=(
+            "Override the PR base ref used for GitHub compare. Use this for "
+            "preview-branch impact audits before changing main."
+        ),
+    )
+    parser.add_argument("--limit", type=int, default=100)
+    parser.add_argument(
+        "--pr",
+        action="append",
+        type=int,
+        default=[],
+        help="Audit a specific PR number. Can be repeated; when set, --limit is ignored.",
+    )
+    parser.add_argument("--max-ahead", type=int, default=50)
+    parser.add_argument("--max-behind", type=int, default=10)
+    parser.add_argument("--max-changed-files", type=int, default=300)
+    parser.add_argument("--allow-codex", action="store_true")
+    parser.add_argument("--allow-claude", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    thresholds = Thresholds(
+        max_ahead=args.max_ahead,
+        max_behind=args.max_behind,
+        max_changed_files=args.max_changed_files,
+        allow_codex=args.allow_codex,
+        allow_claude=args.allow_claude,
+    )
+    result = audit(
+        args.repo,
+        limit=args.limit,
+        thresholds=thresholds,
+        base_ref=args.base_ref,
+        pr_numbers=args.pr,
+    )
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        _print_text(result)
+
+    unsafe = result["counts"].get("rebase_or_recreate_required", 0)
+    unsafe += result["counts"].get("contributor_recreate_required", 0)
+    unsafe += result["counts"].get("compare_error", 0)
+    return 2 if unsafe else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,17 @@ jobs:
           GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: bash scripts/ci/check-dco-signoff.sh
 
+  pr-base-policy:
+    name: "PR Base Policy"
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify PR target branch policy
+        run: python3 scripts/ci/verify-pr-base-policy.py
+
   repo-governance:
     name: "Governance"
     runs-on: ubuntu-latest
@@ -289,8 +300,8 @@ jobs:
         run: bash scripts/ci/subtree-sync-check.sh
 
   main-freshness-gate:
-    name: "Main Freshness Gate"
-    if: github.event_name == 'pull_request' && github.base_ref == 'main'
+    name: "Base Freshness Gate"
+    if: github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'integration/pr-train')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -299,10 +310,10 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Verify branch freshness against origin/main
+      - name: Verify branch freshness against PR base
         env:
           MAIN_SYNC_REMOTE: origin
-          MAIN_SYNC_BRANCH: main
+          MAIN_SYNC_BRANCH: ${{ github.base_ref }}
           MAIN_SYNC_MODE: warn
           MAIN_SYNC_CURRENT_BRANCH: ${{ github.head_ref || github.ref_name }}
         run: sh scripts/git/check-main-sync.sh
@@ -312,6 +323,7 @@ jobs:
     needs:
       - secret-scan
       - dco-check
+      - pr-base-policy
       - repo-governance
       - paths
       - web-check
@@ -327,6 +339,7 @@ jobs:
         run: |
           SECRET_SCAN="${{ needs['secret-scan'].result }}"
           DCO="${{ needs['dco-check'].result }}"
+          PR_BASE_POLICY="${{ needs['pr-base-policy'].result }}"
           REPO_GOVERNANCE="${{ needs['repo-governance'].result }}"
           PATHS="${{ needs.paths.result }}"
           WEB="${{ needs['web-check'].result }}"
@@ -336,6 +349,7 @@ jobs:
 
           printf 'secret-scan=%s\n' "$SECRET_SCAN"
           printf 'dco-check=%s\n' "$DCO"
+          printf 'pr-base-policy=%s\n' "$PR_BASE_POLICY"
           printf 'repo-governance=%s\n' "$REPO_GOVERNANCE"
           printf 'paths=%s\n' "$PATHS"
           printf 'web-check=%s\n' "$WEB"
@@ -344,7 +358,7 @@ jobs:
           printf 'main-freshness-gate=%s\n' "$MAIN_FRESHNESS"
 
           fail=0
-          for result in "$SECRET_SCAN" "$DCO" "$REPO_GOVERNANCE" "$PATHS" "$WEB" "$PROTOCOL" "$INTEGRATION" "$MAIN_FRESHNESS"; do
+          for result in "$SECRET_SCAN" "$DCO" "$PR_BASE_POLICY" "$REPO_GOVERNANCE" "$PATHS" "$WEB" "$PROTOCOL" "$INTEGRATION" "$MAIN_FRESHNESS"; do
             if [ "$result" = "failure" ] || [ "$result" = "cancelled" ] || [ "$result" = "timed_out" ]; then
               fail=1
             fi

--- a/.github/workflows/queue-validation.yml
+++ b/.github/workflows/queue-validation.yml
@@ -2,7 +2,7 @@ name: "Queue Validation"
 
 on:
   merge_group:
-    branches: [main]
+    branches: [main, integration/pr-train]
 
 permissions:
   contents: read
@@ -39,10 +39,14 @@ jobs:
         id: scan-range
         shell: bash
         run: |
-          DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
-          git fetch origin "$DEFAULT_BRANCH" --quiet || true
-          if git rev-parse "origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then
-            LOG_OPTS="--ancestry-path origin/$DEFAULT_BRANCH..${{ github.sha }}"
+          BASE_REF="${{ github.event.merge_group.base_ref }}"
+          BASE_REF="${BASE_REF#refs/heads/}"
+          if [ -z "$BASE_REF" ]; then
+            BASE_REF="${{ github.event.repository.default_branch }}"
+          fi
+          git fetch origin "$BASE_REF" --quiet || true
+          if git rev-parse "origin/$BASE_REF" >/dev/null 2>&1; then
+            LOG_OPTS="--ancestry-path origin/$BASE_REF..${{ github.sha }}"
           else
             LOG_OPTS="${{ github.sha }}"
           fi
@@ -180,7 +184,7 @@ jobs:
         run: bash scripts/ci/subtree-sync-check.sh
 
   main-freshness-gate:
-    name: "Main Freshness Gate"
+    name: "Base Freshness Gate"
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -189,13 +193,18 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.sha }}
 
-      - name: Verify queue freshness against origin/main
+      - name: Verify queue freshness against merge-group base
         env:
           MAIN_SYNC_REMOTE: origin
-          MAIN_SYNC_BRANCH: main
           MAIN_SYNC_MODE: block
           MAIN_SYNC_CURRENT_BRANCH: ${{ github.ref_name }}
-        run: sh scripts/git/check-main-sync.sh
+          QUEUE_BASE_REF: ${{ github.event.merge_group.base_ref }}
+        run: |
+          base="${QUEUE_BASE_REF#refs/heads/}"
+          if [ -z "$base" ]; then
+            base="main"
+          fi
+          MAIN_SYNC_BRANCH="$base" sh scripts/git/check-main-sync.sh
 
   ci-status:
     name: "CI Status Gate"

--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -1,4 +1,11 @@
 {
+  "branch_flow": {
+    "train_branch": "integration/pr-train",
+    "promotion_branch": "main",
+    "main_allowed_head_branches": [
+      "integration/pr-train"
+    ]
+  },
   "main": {
     "required_status_check": "CI Status Gate",
     "required_approving_reviews": 1,
@@ -8,20 +15,24 @@
     "review_bypass_users": [
       "kushaltrivedi5",
       "RGlodAkshat",
-      "ankitkumarsingh1702"
+      "ankitkumarsingh1702",
+      "azfx"
     ],
     "merge_queue_required": true,
+    "merge_queue_ruleset_name": "main merge queue",
     "merge_queue_bypass_team_name": "Allowed Maintainers to Approve",
     "merge_queue_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_bypass_users": [
       "kushaltrivedi5",
       "RGlodAkshat",
-      "ankitkumarsingh1702"
+      "ankitkumarsingh1702",
+      "azfx"
     ],
     "protected_pipeline_edit_users": [
       "kushaltrivedi5",
       "RGlodAkshat",
-      "ankitkumarsingh1702"
+      "ankitkumarsingh1702",
+      "azfx"
     ],
     "protected_pipeline_paths": [
       ".github/workflows/",
@@ -29,6 +40,29 @@
       "scripts/ci/",
       "deploy/",
       "config/ci-governance.json"
+    ]
+  },
+  "pr_train": {
+    "required_status_check": "CI Status Gate",
+    "required_approving_reviews": 1,
+    "require_last_push_approval": true,
+    "require_strict_status_checks": true,
+    "require_conversation_resolution": true,
+    "review_bypass_users": [
+      "kushaltrivedi5",
+      "RGlodAkshat",
+      "ankitkumarsingh1702",
+      "azfx"
+    ],
+    "merge_queue_required": true,
+    "merge_queue_ruleset_name": "integration pr train merge queue",
+    "merge_queue_bypass_team_name": "Allowed Maintainers to Approve",
+    "merge_queue_bypass_team_slug": "allowed-maintainers-to-approve",
+    "merge_queue_bypass_users": [
+      "kushaltrivedi5",
+      "RGlodAkshat",
+      "ankitkumarsingh1702",
+      "azfx"
     ]
   },
   "uat": {

--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -18,6 +18,7 @@
       "ankitkumarsingh1702",
       "azfx"
     ],
+    "review_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_required": true,
     "merge_queue_ruleset_name": "main merge queue",
     "merge_queue_bypass_team_name": "Allowed Maintainers to Approve",
@@ -54,6 +55,7 @@
       "ankitkumarsingh1702",
       "azfx"
     ],
+    "review_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_required": true,
     "merge_queue_ruleset_name": "integration pr train merge queue",
     "merge_queue_bypass_team_name": "Allowed Maintainers to Approve",

--- a/docs/reference/operations/branch-governance.md
+++ b/docs/reference/operations/branch-governance.md
@@ -6,34 +6,38 @@
 ```mermaid
 flowchart LR
   feature["feature / fix / dev branches"]
+  train["integration/pr-train"]
   main["main"]
   green["Green main SHA"]
   uat["UAT deploy<br/>manual exact SHA"]
   prod["Production deploy<br/>manual chosen SHA"]
-  feature --> main --> green
+  feature --> train --> main --> green
   green --> uat
   green --> prod
 ```
 
-This repo now runs on one integration branch plus SHA-based environment deployment:
+This repo now runs on a dedicated PR-train branch, a protected promotion branch, and SHA-based environment deployment:
 
 | Lane | Purpose | Default policy |
 |---|---|---|
-| `main` | Team integration branch | Every feature PR targets `main` |
+| `integration/pr-train` | Normal PR intake and async train landing | Every feature/fix/docs PR targets `integration/pr-train` |
+| `main` | Promotion branch for deployable history | Only `integration/pr-train` may open normal promotion PRs into `main` |
 | UAT | Hosted validation environment | Manual deploy of an exact green `main` SHA |
 | Production | Live user traffic | Manual deploy of an approved green `main` SHA |
 
 ## Working Rules
 
-1. Start all development branches from `main`.
-2. Merge all feature/fix/docs work back into `main`.
-3. Continue follow-up fixes on the active development branch by default; do not create extra temporary branches for routine polish, validation follow-up, or same-lane fixes.
-4. Create a new branch only when isolation is materially required, such as a post-merge hotfix from `main`, a deploy blocker that must land independently, or unrelated in-flight changes on the current branch.
-5. After an isolated hotfix lands, return local work to the normal development branch or `main` and delete the temporary branch after rollout validation.
-6. Do not use `deploy_uat` or `deploy` as release branches; they are retired from the deployment path.
-7. UAT deploys only from a successful `Main Post-Merge Smoke` run on `main` and uses an explicitly chosen exact green commit SHA.
-8. Production deploys only from a manually chosen SHA that is reachable from `origin/main` and already green in CI.
-9. Do not open release PRs into environment branches; the deployment source of truth is `main`.
+1. Start all development branches from the current `integration/pr-train` unless an isolated `main` hotfix is explicitly required.
+2. Merge all normal feature/fix/docs work into `integration/pr-train`.
+3. Promote `integration/pr-train` into `main` through a PR after the train is green and ancestry-clean.
+4. Do not open direct feature, contributor, or agent PRs into `main`; CI blocks them unless the head branch is `integration/pr-train`.
+5. Continue follow-up fixes on the active development branch by default; do not create extra temporary branches for routine polish, validation follow-up, or same-lane fixes.
+6. Create a new branch only when isolation is materially required, such as a post-merge hotfix from `main`, a deploy blocker that must land independently, or unrelated in-flight changes on the current branch.
+7. After an isolated hotfix lands, return local work to the normal development branch or `integration/pr-train` and delete the temporary branch after rollout validation.
+8. Do not use `deploy_uat` or `deploy` as release branches; they are retired from the deployment path.
+9. UAT deploys only from a successful `Main Post-Merge Smoke` run on `main` and uses an explicitly chosen exact green commit SHA.
+10. Production deploys only from a manually chosen SHA that is reachable from `origin/main` and already green in CI.
+11. Do not open release PRs into environment branches; the deployment source of truth is `main`.
 
 ## Codex Branch Preservation Gate
 
@@ -44,15 +48,17 @@ Coding agents must run this gate before CI, deploy, PR, hotfix, or validation wo
 3. Do not create temporary branches for routine follow-up work, UAT validation fixes, PR polish, or local hardening.
 4. Use a temporary branch only when branch isolation is explicitly requested, an isolated `main` hotfix is required, or unrelated in-flight work makes the preserved branch unsafe for the fix.
 5. If a temporary branch is used, delete it locally and remotely after merge and rollout validation when safe, then switch back to the preserved developer branch.
-6. If a fix lands on `main`, merge or rebase the landed `origin/main` commits into the preserved developer branch before handoff.
-7. Do not end a task detached, on `main`, or on a temporary branch unless the user explicitly requested that final state or a concrete conflict blocks restoration.
+6. If a normal fix lands on `integration/pr-train`, merge or rebase the landed train commits into the preserved developer branch before handoff.
+7. If an emergency hotfix lands on `main`, merge or rebase the landed `origin/main` commits into `integration/pr-train` and the preserved developer branch before handoff.
+8. Do not end a task detached, on `main`, or on a temporary branch unless the user explicitly requested that final state or a concrete conflict blocks restoration.
 
 ## Branch Types and Retention
 
 | Branch type | Naming pattern | Retention |
 |---|---|---|
 | Developer branch | `feature/*`, `feat/*`, `agent_*`, developer-owned names | Keep while active |
-| Hotfix branch | `fix/*` | Delete after merge to `main` and successful UAT validation |
+| PR train branch | `integration/pr-train` | Durable protected intake branch |
+| Hotfix branch | `fix/*` | Delete after merge to `main`, sync back to `integration/pr-train`, and successful UAT validation |
 | Deployment artifact | exact green `main` SHA | Keep in Git history and deployment logs |
 | Local backup branch | `backup/*`, `publishable/*` | Audit unique commits, salvage if needed, then delete |
 
@@ -60,7 +66,7 @@ Before deleting a local backup branch, classify its unique commits as:
 
 1. already represented in `main`
 2. obsolete and safe to drop
-3. still valuable and worth promoting onto a fresh salvage branch from current `main`
+3. still valuable and worth promoting onto a fresh salvage branch from current `integration/pr-train`
 
 ## Deployment Lanes
 
@@ -90,13 +96,26 @@ Before deleting a local backup branch, classify its unique commits as:
 1. Preserve the active developer branch before switching away.
 2. Create the hotfix branch from the latest `main` only when an isolated hotfix is materially required.
 3. Merge the hotfix into `main`.
-4. If hosted validation is required, manually deploy that same green `main` SHA to UAT.
-5. Delete the hotfix branch locally and remotely after merge and rollout validation when safe.
-6. Switch back to the preserved developer branch and merge or rebase the landed `origin/main` commits into it.
-7. If another blocker appears after that rollout, create a new hotfix branch from the updated `main` only when the same isolation criteria still applies.
-8. Do not reuse an already-merged hotfix branch for a second fix.
+4. Immediately sync the landed hotfix back into `integration/pr-train` so the train branch does not drift behind the promotion branch.
+5. If hosted validation is required, manually deploy that same green `main` SHA to UAT.
+6. Delete the hotfix branch locally and remotely after merge and rollout validation when safe.
+7. Switch back to the preserved developer branch and merge or rebase the landed train/main commits into it.
+8. If another blocker appears after that rollout, create a new hotfix branch from the updated `main` only when the same isolation criteria still applies.
+9. Do not reuse an already-merged hotfix branch for a second fix.
 
 ## GitHub Admin Checklist
+
+### `integration/pr-train`
+
+1. Require pull requests before merge.
+2. Require the `CI Status Gate` status check.
+3. Require strict/up-to-date checks.
+4. Require conversation resolution before merge.
+5. Enable merge queue for `integration/pr-train`.
+6. Block force-pushes.
+7. Block branch deletion.
+8. Require at least 1 independent PR approval and approval of the most recent push.
+9. Use this branch as the only normal PR landing branch.
 
 ### `main`
 
@@ -109,23 +128,23 @@ Before deleting a local backup branch, classify its unique commits as:
 7. Block branch deletion.
 8. Require at least 1 independent PR approval on `main`; CI status plus merge queue remain required merge gates.
 9. Use review bypass plus the dedicated `Allowed Maintainers to Approve` team for the sanctioned maintainer bypass cohort only; do not rely on overlapping push restrictions.
-10. Keep ordinary development off `main`; use PRs from developer branches.
+10. Keep ordinary development off `main`; only promote from `integration/pr-train` except explicit emergency hotfixes.
 
 Current operating note:
 
 - `enforce_admins` should stay enabled
 - DCO is enforced in CI, not via a separate GitHub branch-protection primitive
 - verify the live setting with `../../../scripts/ci/verify-main-branch-protection.sh`
-- `main` requires 1 independent approval; the external community goes through PR + CI + review + queue
+- `integration/pr-train` and `main` both require 1 independent approval; the external community goes through PR + CI + review + queue on `integration/pr-train`
 - admin ownership does not count as an independent PR approval
 - require approval of the most recent push is enabled, so stale approvals cannot carry newly pushed code
 - a PR author cannot self-approve through GitHub; sanctioned maintainer "self approval" means explicit branch-protection bypass, not a counted GitHub review
-- the current live `main` branch protection review-bypass allowlist is `kushaltrivedi5`, `RGlodAkshat`, and `ankitkumarsingh1702`
-- the current live merge-queue bypass team is `Allowed Maintainers to Approve`, containing those same 3 users only
+- the current live branch protection review-bypass allowlist is `kushaltrivedi5`, `RGlodAkshat`, `ankitkumarsingh1702`, and `azfx`
+- the current live merge-queue bypass team is `Allowed Maintainers to Approve`, containing those same 4 users only
 - the sanctioned review-bypass cohort is intentional policy and should not be reported as governance drift when it matches `config/ci-governance.json`
 - if an admin needs to proceed on a green PR, verify whether the live ruleset allows queue entry; do not assume approval is implicitly satisfied
 - bypass actors may waive review through branch protection and bypass queue through the dedicated owner team path
-- direct pushes to `main` are not the default bypass model; the preferred path is a green PR plus bypass merge
+- direct pushes to `main` are not the default bypass model; the preferred path is a green `integration/pr-train` promotion PR plus bypass merge when justified
 - CI should still gate the landing decision; bypass is for review policy, not for skipping validation
 
 ### Retired release branches

--- a/scripts/ci/repo-governance-check.sh
+++ b/scripts/ci/repo-governance-check.sh
@@ -9,6 +9,7 @@ cd "$REPO_ROOT"
 
 python3 scripts/ci/verify-pr-governance-sections.py
 python3 scripts/ci/verify-protected-pipeline-edits.py
+python3 scripts/ci/verify-pr-base-policy.py --self-test
 python3 scripts/ci/test_resolve_deploy_scope.py
 ./bin/hushh docs verify
 ./bin/hushh codex data-model-audit

--- a/scripts/ci/verify-main-branch-protection.sh
+++ b/scripts/ci/verify-main-branch-protection.sh
@@ -73,6 +73,7 @@ require_conversation_resolution = (
     else bool(branch_policy.get("require_conversation_resolution", False))
 )
 expected_bypass = sorted(branch_policy["review_bypass_users"])
+expected_bypass_team_slug = str(branch_policy.get("review_bypass_team_slug") or "").strip()
 expected_queue_bypass = sorted(branch_policy["merge_queue_bypass_users"])
 expected_queue_bypass_team_name = str(branch_policy.get("merge_queue_bypass_team_name") or "").strip()
 expected_queue_bypass_team_slug = str(branch_policy.get("merge_queue_bypass_team_slug") or "").strip()
@@ -113,6 +114,15 @@ bypass_users = sorted(
         .get("users", [])
     )
     if user.get("login")
+)
+bypass_team_slugs = sorted(
+    team.get("slug", "").strip()
+    for team in (
+        data.get("required_pull_request_reviews", {})
+        .get("bypass_pull_request_allowances", {})
+        .get("teams", [])
+    )
+    if team.get("slug")
 )
 
 merge_queue_bypass = []
@@ -197,6 +207,10 @@ if require_merge_queue and not merge_queue_enabled:
     errors.append("merge queue rule is not enabled on the branch")
 if bypass_users != expected_bypass:
     errors.append(f"review bypass users drifted: expected {expected_bypass}, got {bypass_users}")
+if expected_bypass_team_slug and bypass_team_slugs != [expected_bypass_team_slug]:
+    errors.append(
+        f"review bypass team drifted: expected {[expected_bypass_team_slug]}, got {bypass_team_slugs}"
+    )
 if merge_queue_bypass != expected_queue_bypass:
     errors.append(
         f"merge queue bypass actors drifted: expected {expected_queue_bypass}, got {merge_queue_bypass}"
@@ -215,7 +229,8 @@ print(f"Branch protection summary ({branch}): checks={checks}, approvals={approv
       f"enforce_admins={admins_enforced}, allow_force_pushes={force_pushes}, "
       f"allow_deletions={deletions}, conversation_resolution={conversation_resolution}, "
       f"merge_queue_enabled={merge_queue_enabled}, "
-      f"review_bypass_users={bypass_users}, merge_queue_bypass={merge_queue_bypass}, "
+      f"review_bypass_users={bypass_users}, review_bypass_team_slugs={bypass_team_slugs}, "
+      f"merge_queue_bypass={merge_queue_bypass}, "
       f"merge_queue_bypass_team_names={merge_queue_bypass_team_names}, "
       f"merge_queue_bypass_team_slugs={merge_queue_bypass_team_slugs}")
 

--- a/scripts/ci/verify-main-branch-protection.sh
+++ b/scripts/ci/verify-main-branch-protection.sh
@@ -5,6 +5,7 @@ REPO="${GITHUB_REPO:-hushh-labs/hushh-research}"
 BRANCH="${GITHUB_BRANCH:-main}"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 POLICY_FILE="${GITHUB_CI_GOVERNANCE_FILE:-$REPO_ROOT/config/ci-governance.json}"
+POLICY_KEY="${GITHUB_POLICY_KEY:-}"
 REQUIRED_CHECKS="${GITHUB_REQUIRED_CHECKS:-${GITHUB_REQUIRED_CHECK:-}}"
 MIN_APPROVALS="${GITHUB_MIN_APPROVALS:-}"
 REQUIRE_STRICT="${GITHUB_REQUIRE_STRICT:-}"
@@ -21,46 +22,61 @@ if ! gh auth status >/dev/null 2>&1; then
   exit 1
 fi
 
-PROTECTION_JSON="$(gh api "repos/${REPO}/branches/${BRANCH}/protection")"
-RULESETS_JSON="$(gh api "repos/${REPO}/rules/branches/${BRANCH}" || echo '[]')"
-RULESET_LIST_JSON="$(gh api "repos/${REPO}/rulesets?includes_parents=true" || echo '[]')"
-export PROTECTION_JSON RULESETS_JSON RULESET_LIST_JSON POLICY_FILE
+ENCODED_BRANCH="$(BRANCH_TO_ENCODE="$BRANCH" python3 - <<'PY'
+import os
+import urllib.parse
 
-python3 - "$REQUIRED_CHECKS" "$MIN_APPROVALS" "$REQUIRE_STRICT" "$REQUIRE_MERGE_QUEUE" "$REQUIRE_CONVERSATION_RESOLUTION" "$REPO" <<'PY'
+print(urllib.parse.quote(os.environ["BRANCH_TO_ENCODE"], safe=""))
+PY
+)"
+
+PROTECTION_JSON="$(gh api "repos/${REPO}/branches/${ENCODED_BRANCH}/protection")"
+RULESETS_JSON="$(gh api "repos/${REPO}/rules/branches/${ENCODED_BRANCH}" || echo '[]')"
+RULESET_LIST_JSON="$(gh api "repos/${REPO}/rulesets?includes_parents=true" || echo '[]')"
+export PROTECTION_JSON RULESETS_JSON RULESET_LIST_JSON POLICY_FILE BRANCH POLICY_KEY
+
+python3 - "$REQUIRED_CHECKS" "$MIN_APPROVALS" "$REQUIRE_STRICT" "$REQUIRE_MERGE_QUEUE" "$REQUIRE_CONVERSATION_RESOLUTION" "$REPO" "$BRANCH" "$POLICY_KEY" <<'PY'
 import json
 import os
 import subprocess
 import sys
 from pathlib import Path
 
-required_checks_arg, expected_approvals_arg, require_strict_arg, require_merge_queue_arg, require_conversation_resolution_arg, repo = sys.argv[1:]
+required_checks_arg, expected_approvals_arg, require_strict_arg, require_merge_queue_arg, require_conversation_resolution_arg, repo, branch, policy_key_arg = sys.argv[1:]
 policy = json.loads(Path(os.environ["POLICY_FILE"]).read_text(encoding="utf-8"))
+branch_flow = policy.get("branch_flow") or {}
+policy_key = policy_key_arg or ("pr_train" if branch == branch_flow.get("train_branch") else "main")
+if policy_key not in policy:
+    print(f"ERROR: policy key '{policy_key}' is missing from {os.environ['POLICY_FILE']}")
+    sys.exit(1)
+branch_policy = policy[policy_key]
 required_checks = [
     item.strip()
-    for item in (required_checks_arg or policy["main"]["required_status_check"]).split(",")
+    for item in (required_checks_arg or branch_policy["required_status_check"]).split(",")
     if item.strip()
 ]
-expected_approvals = int(expected_approvals_arg or policy["main"]["required_approving_reviews"])
+expected_approvals = int(expected_approvals_arg or branch_policy["required_approving_reviews"])
 require_strict = (
     require_strict_arg.lower() == "true"
     if require_strict_arg
-    else bool(policy["main"].get("require_strict_status_checks", False))
+    else bool(branch_policy.get("require_strict_status_checks", False))
 )
 require_merge_queue = (
     require_merge_queue_arg.lower() == "true"
     if require_merge_queue_arg
-    else bool(policy["main"]["merge_queue_required"])
+    else bool(branch_policy["merge_queue_required"])
 )
-require_last_push_approval = bool(policy["main"].get("require_last_push_approval", False))
+require_last_push_approval = bool(branch_policy.get("require_last_push_approval", False))
 require_conversation_resolution = (
     require_conversation_resolution_arg.lower() == "true"
     if require_conversation_resolution_arg
-    else bool(policy["main"].get("require_conversation_resolution", False))
+    else bool(branch_policy.get("require_conversation_resolution", False))
 )
-expected_bypass = sorted(policy["main"]["review_bypass_users"])
-expected_queue_bypass = sorted(policy["main"]["merge_queue_bypass_users"])
-expected_queue_bypass_team_name = str(policy["main"].get("merge_queue_bypass_team_name") or "").strip()
-expected_queue_bypass_team_slug = str(policy["main"].get("merge_queue_bypass_team_slug") or "").strip()
+expected_bypass = sorted(branch_policy["review_bypass_users"])
+expected_queue_bypass = sorted(branch_policy["merge_queue_bypass_users"])
+expected_queue_bypass_team_name = str(branch_policy.get("merge_queue_bypass_team_name") or "").strip()
+expected_queue_bypass_team_slug = str(branch_policy.get("merge_queue_bypass_team_slug") or "").strip()
+expected_queue_ruleset_name = str(branch_policy.get("merge_queue_ruleset_name") or "").strip()
 data = json.loads(os.environ["PROTECTION_JSON"])
 rulesets = json.loads(os.environ["RULESETS_JSON"])
 ruleset_list = json.loads(os.environ["RULESET_LIST_JSON"])
@@ -116,7 +132,7 @@ for ruleset in ruleset_list:
             text=True,
         ).stdout
     )
-    if detail.get("name") != "main merge queue":
+    if expected_queue_ruleset_name and detail.get("name") != expected_queue_ruleset_name:
         continue
     for actor in detail.get("bypass_actors") or []:
         actor_name = ""
@@ -194,7 +210,7 @@ if expected_queue_bypass_team_name and merge_queue_bypass_team_names != [expecte
         f"merge queue bypass team name drifted: expected {[expected_queue_bypass_team_name]}, got {merge_queue_bypass_team_names}"
     )
 
-print(f"Branch protection summary: checks={checks}, approvals={approvals}, "
+print(f"Branch protection summary ({branch}): checks={checks}, approvals={approvals}, "
       f"latest_push_approval={last_push_approval}, strict={strict_checks}, "
       f"enforce_admins={admins_enforced}, allow_force_pushes={force_pushes}, "
       f"allow_deletions={deletions}, conversation_resolution={conversation_resolution}, "
@@ -222,4 +238,4 @@ else:
     print(f"Rulesets: {names}")
 PY
 
-echo "✅ Live branch protection matches the documented minimum contract."
+echo "✅ Live branch protection for '${BRANCH}' matches the documented minimum contract."

--- a/scripts/ci/verify-pr-base-policy.py
+++ b/scripts/ci/verify-pr-base-policy.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Hushh
+"""Fail closed on PR target branches that bypass the PR train."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _load_policy(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _event_pr_refs(event_path: str | None) -> tuple[str, str]:
+    if not event_path:
+        return "", ""
+    event_file = Path(event_path)
+    if not event_file.exists():
+        return "", ""
+    payload = json.loads(event_file.read_text(encoding="utf-8"))
+    pull_request = payload.get("pull_request") or {}
+    base = pull_request.get("base") or {}
+    head = pull_request.get("head") or {}
+    return str(base.get("ref") or ""), str(head.get("ref") or "")
+
+
+def evaluate(policy: dict[str, Any], *, base_ref: str, head_ref: str) -> tuple[bool, str]:
+    branch_flow = policy.get("branch_flow") or {}
+    main_branch = str(branch_flow.get("promotion_branch") or "main")
+    train_branch = str(branch_flow.get("train_branch") or "integration/pr-train")
+    allowed_main_heads = set(branch_flow.get("main_allowed_head_branches") or [train_branch])
+
+    if not base_ref:
+        return False, "PR base ref is missing; cannot enforce branch target policy."
+    if base_ref == main_branch and head_ref not in allowed_main_heads:
+        allowed = ", ".join(sorted(allowed_main_heads))
+        return (
+            False,
+            f"Direct PRs into {main_branch} are blocked. Target {train_branch}, "
+            f"or promote {allowed} into {main_branch}.",
+        )
+    return True, f"PR base policy passed for head={head_ref or '<unknown>'} base={base_ref}."
+
+
+def self_test(policy: dict[str, Any]) -> int:
+    branch_flow = policy.get("branch_flow") or {}
+    main_branch = str(branch_flow.get("promotion_branch") or "main")
+    train_branch = str(branch_flow.get("train_branch") or "integration/pr-train")
+    cases = [
+        (main_branch, train_branch, True),
+        (main_branch, "feature/example", False),
+        (train_branch, "feature/example", True),
+        ("feature/stack-base", "feature/follow-up", True),
+    ]
+    failures: list[str] = []
+    for base_ref, head_ref, expected in cases:
+        ok, message = evaluate(policy, base_ref=base_ref, head_ref=head_ref)
+        print(message)
+        if ok != expected:
+            failures.append(f"expected {expected} for head={head_ref} base={base_ref}, got {ok}")
+    if failures:
+        for failure in failures:
+            print(f"ERROR: {failure}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Verify PR target branch policy.")
+    parser.add_argument("--base-ref", default="")
+    parser.add_argument("--head-ref", default="")
+    parser.add_argument("--policy-file", default=str(_repo_root() / "config/ci-governance.json"))
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    policy = _load_policy(Path(args.policy_file))
+    if args.self_test:
+        return self_test(policy)
+
+    base_ref = args.base_ref
+    head_ref = args.head_ref
+    if not base_ref:
+        base_ref, head_ref = _event_pr_refs(os.environ.get("GITHUB_EVENT_PATH"))
+
+    ok, message = evaluate(policy, base_ref=base_ref, head_ref=head_ref)
+    print(message)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/verify-pr-train-governance.sh
+++ b/scripts/ci/verify-pr-train-governance.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Hushh
+
+set -euo pipefail
+
+REPO="${GITHUB_REPO:-hushh-labs/hushh-research}"
+
+GITHUB_REPO="$REPO" GITHUB_BRANCH="main" GITHUB_POLICY_KEY="main" \
+  scripts/ci/verify-main-branch-protection.sh
+
+GITHUB_REPO="$REPO" GITHUB_BRANCH="integration/pr-train" GITHUB_POLICY_KEY="pr_train" \
+  scripts/ci/verify-main-branch-protection.sh
+
+python3 scripts/ci/verify-pr-base-policy.py --base-ref main --head-ref integration/pr-train
+
+if python3 scripts/ci/verify-pr-base-policy.py --base-ref main --head-ref feature/direct-main; then
+  echo "ERROR: direct feature PR into main was allowed unexpectedly." >&2
+  exit 1
+fi
+
+python3 scripts/ci/verify-pr-base-policy.py --base-ref integration/pr-train --head-ref feature/train-entry
+
+echo "✅ PR train branch governance matches the documented contract."


### PR DESCRIPTION
## Summary
- Adds the protected `integration/pr-train` branch as the normal PR intake lane.
- Keeps `main` as the promotion/deploy branch and blocks direct feature PRs into `main`.
- Updates CI freshness checks, merge-group validation, branch governance docs, and PR train SOP.

## Verification
- `scripts/ci/verify-pr-train-governance.sh`
- `python3 -m py_compile scripts/ci/verify-pr-base-policy.py .codex/skills/pr-governance-review/scripts/pr_ancestry_health.py`
- `python3 scripts/ci/verify-pr-base-policy.py --self-test`
- `python3 .codex/skills/pr-governance-review/scripts/pr_ancestry_health.py --repo hushh-labs/hushh-research --base-ref integration/pr-train --pr 1890 --pr 1888 --pr 1878 --pr 1865 --pr 1862 --pr 1859 --json`
