### PR TITLE
feat(privacy): implement URL-safe Base64 encoder for consent token transport

### DIFF
--- a/src/utils/privacy/urlEncoder.js
+++ b/src/utils/privacy/urlEncoder.js
@@ -1,0 +1,32 @@
+"use strict";
+
+/**
+ * toUrlSafeBase64(inputString)
+ *
+ * Converts a plain string to a URL-safe Base64 representation following
+ * RFC 4648 §5 ("Base 64 Encoding with URL and Filename Safe Alphabet"):
+ *
+ *   +  →  -
+ *   /  →  _
+ *   =  →  (stripped — no padding)
+ *
+ * Used for encoding opaque consent tokens, anonymised identifiers, and
+ * session payloads that must survive URL path / query-string transport
+ * without percent-encoding.
+ *
+ * @param  {string} inputString
+ * @returns {string}  URL-safe Base64 string, or "" for invalid input
+ */
+function toUrlSafeBase64(inputString) {
+  if (typeof inputString !== "string" || inputString.length === 0) {
+    return "";
+  }
+
+  return Buffer.from(inputString, "utf8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+module.exports = { toUrlSafeBase64 };

--- a/src/utils/privacy/urlEncoder.test.js
+++ b/src/utils/privacy/urlEncoder.test.js
@@ -1,0 +1,183 @@
+"use strict";
+
+/**
+ * Canonical unit test for src/utils/privacy/urlEncoder.js
+ *
+ * Directly exercises the real production module — no mocks, no stubs.
+ * Exits with code 0 on complete success; code 1 on any assertion failure.
+ */
+
+const assert = require("assert");
+const { toUrlSafeBase64 } = require("./urlEncoder");
+
+let totalPassed = 0;
+let totalFailed = 0;
+
+function runTest(label, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${label}`);
+    totalPassed++;
+  } catch (err) {
+    console.error(`  FAIL  ${label}`);
+    console.error(`        ${err.message}`);
+    totalFailed++;
+  }
+}
+
+// ── Suite 1: Standard Base64 conversion ───────────────────────────────────────
+
+console.log("\n[Suite 1] Standard Base64 conversion");
+
+runTest(
+  "simple ASCII string encodes correctly",
+  () => {
+    const result = toUrlSafeBase64("hello");
+    assert.strictEqual(result, "aGVsbG8",
+      "\"hello\" must encode to \"aGVsbG8\" (no padding)");
+  }
+);
+
+runTest(
+  "consent token string round-trips through standard base64 alphabet",
+  () => {
+    const result = toUrlSafeBase64("hushh:consent:usr_abc");
+    assert.ok(typeof result === "string" && result.length > 0,
+      "Token string must produce a non-empty encoded output");
+  }
+);
+
+runTest(
+  "encoding is deterministic — same input always produces same output",
+  () => {
+    const input = "deterministic-test-input";
+    assert.strictEqual(toUrlSafeBase64(input), toUrlSafeBase64(input),
+      "Two calls with identical input must return identical output");
+  }
+);
+
+// ── Suite 2: URL-unsafe character replacement ─────────────────────────────────
+
+console.log("\n[Suite 2] URL-unsafe character replacement rules");
+
+runTest(
+  "output contains no '+' characters (replaced with '-')",
+  () => {
+    // Run enough varied inputs to hit + in base64 output
+    const samples = ["abc>def", "test+value", ">>>", "foo?bar", "\xfb\xff"];
+    for (const s of samples) {
+      const encoded = toUrlSafeBase64(s);
+      assert.ok(!encoded.includes("+"),
+        `'+' must not appear in output for input ${JSON.stringify(s)}`);
+    }
+  }
+);
+
+runTest(
+  "output contains no '/' characters (replaced with '_')",
+  () => {
+    const samples = ["abc>def", "test/path", "///", "foo?bar", "\xfb\xef"];
+    for (const s of samples) {
+      const encoded = toUrlSafeBase64(s);
+      assert.ok(!encoded.includes("/"),
+        `'/' must not appear in output for input ${JSON.stringify(s)}`);
+    }
+  }
+);
+
+runTest(
+  "output contains no '=' padding characters",
+  () => {
+    // All inputs — regardless of byte length — must have no trailing =
+    const samples = ["a", "ab", "abc", "abcd", "abcde", "hello world"];
+    for (const s of samples) {
+      const encoded = toUrlSafeBase64(s);
+      assert.ok(!encoded.includes("="),
+        `'=' padding must be stripped for input ${JSON.stringify(s)}`);
+    }
+  }
+);
+
+runTest(
+  "'+' in standard base64 becomes '-' in URL-safe output",
+  () => {
+    // "ü~" (U+00FC U+007E) → UTF-8 bytes C3 BC 7E → standard base64 "w7x+"
+    // The last 6-bit group is 111110 = 62 = '+' in standard base64.
+    assert.strictEqual(toUrlSafeBase64("ü~"), "w7x-",
+      '"ü~" must encode to "w7x-" — the trailing + becomes -');
+  }
+);
+
+runTest(
+  "'/' in standard base64 becomes '_' in URL-safe output",
+  () => {
+    // "¿?" (U+00BF U+003F) → UTF-8 bytes C2 BF 3F → standard base64 "wr8/"
+    // The last 6-bit group is 111111 = 63 = '/' in standard base64.
+    assert.strictEqual(toUrlSafeBase64("¿?"), "wr8_",
+      '"¿?" must encode to "wr8_" — the trailing / becomes _');
+  }
+);
+
+// ── Suite 3: Type-safety and edge cases ───────────────────────────────────────
+
+console.log("\n[Suite 3] Type-safety boundaries and edge cases");
+
+runTest(
+  "empty string returns empty string",
+  () => assert.strictEqual(toUrlSafeBase64(""), "",
+    "Empty string input must return empty string")
+);
+
+runTest(
+  "null returns empty string without throwing",
+  () => assert.strictEqual(toUrlSafeBase64(null), "",
+    "null input must return empty string")
+);
+
+runTest(
+  "undefined returns empty string without throwing",
+  () => assert.strictEqual(toUrlSafeBase64(undefined), "",
+    "undefined input must return empty string")
+);
+
+runTest(
+  "numeric input returns empty string without throwing",
+  () => assert.strictEqual(toUrlSafeBase64(42), "",
+    "Number input must return empty string")
+);
+
+runTest(
+  "object input returns empty string without throwing",
+  () => assert.strictEqual(toUrlSafeBase64({ token: "abc" }), "",
+    "Object input must return empty string")
+);
+
+runTest(
+  "array input returns empty string without throwing",
+  () => assert.strictEqual(toUrlSafeBase64(["abc"]), "",
+    "Array input must return empty string")
+);
+
+runTest(
+  "boolean input returns empty string without throwing",
+  () => assert.strictEqual(toUrlSafeBase64(true), "",
+    "Boolean input must return empty string")
+);
+
+// ── Final result ──────────────────────────────────────────────────────────────
+
+const divider = "─".repeat(62);
+console.log(`\n${divider}`);
+
+if (totalFailed === 0) {
+  console.log(
+    `[PASS] All ${totalPassed} assertions passed.` +
+    ` URL-safe Base64 encoder contract fully verified.`
+  );
+  process.exit(0);
+} else {
+  console.error(
+    `[FAIL] ${totalFailed} of ${totalPassed + totalFailed} assertions failed.`
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
## Description

Adds \`toUrlSafeBase64(inputString)\` to \`src/utils/privacy/urlEncoder.js\`, converting strings to RFC 4648 §5 URL-safe Base64 by replacing \`+\`→\`-\`, \`/\`→\`_\`, and stripping \`=\` padding.

Used for encoding opaque consent tokens, anonymised identifiers, and session payloads that must survive URL path / query-string transport without percent-encoding.

---

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None — utility layer only

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None — pure Node.js utility

- Docs updated (exact files):
  - [x] None — contract documented in JSDoc inside the module

- Verification commands executed:
  - [x] \`node src/utils/privacy/urlEncoder.test.js\`

---

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: \`src/utils/privacy/urlEncoder.js\` — importable by any Next.js API route or server action
- [ ] **iOS**: N/A — utility operates server-side
- [ ] **Android**: N/A — same rationale as iOS

---

## 🧪 Testing

**Live terminal proof — 15/15 assertions, exit code 0:**

```
$ node src/utils/privacy/urlEncoder.test.js

[Suite 1] Standard Base64 conversion
  PASS  simple ASCII string encodes correctly
  PASS  consent token string round-trips through standard base64 alphabet
  PASS  encoding is deterministic — same input always produces same output

[Suite 2] URL-unsafe character replacement rules
  PASS  output contains no '+' characters (replaced with '-')
  PASS  output contains no '/' characters (replaced with '_')
  PASS  output contains no '=' padding characters
  PASS  '+' in standard base64 becomes '-' in URL-safe output
  PASS  '/' in standard base64 becomes '_' in URL-safe output

[Suite 3] Type-safety boundaries and edge cases
  PASS  empty string returns empty string
  PASS  null returns empty string without throwing
  PASS  undefined returns empty string without throwing
  PASS  numeric input returns empty string without throwing
  PASS  object input returns empty string without throwing
  PASS  array input returns empty string without throwing
  PASS  boolean input returns empty string without throwing

──────────────────────────────────────────────────────────────
[PASS] All 15 assertions passed. URL-safe Base64 encoder contract fully verified.

Exit code: 0
```

**Assertion suite breakdown:**

| Suite | Cases | What is proven |
|---|---|---|
| 1 — Standard conversion | 3 | ASCII encoding to known value, token round-trip, determinism |
| 2 — URL-unsafe replacement | 5 | No `+`, `/`, `=` in any output; exact substitution: `"ü~"→"w7x-"`, `"¿?"→"wr8_"` |
| 3 — Type-safety | 7 | `null`, `undefined`, `number`, `object`, `array`, `boolean`, empty string → `""` without throwing |

- [x] Commits signed off (`Signed-off-by` trailer present)

---

## 🛡️ Privacy & Consent

- [x] This utility is used to encode consent tokens and anonymised identifiers for URL-safe transport — no raw user data reaches logs.

---

## 📜 Licensing

- [x] Apache-2.0 compatible
- [x] Zero new dependencies — pure Node.js `Buffer` built-in