### PR TITLE
feat(consent): implement 3-bit consent state compactor for dense flag transfer

### DIFF
--- a/src/utils/consent/stateCompactor.js
+++ b/src/utils/consent/stateCompactor.js
@@ -1,0 +1,67 @@
+"use strict";
+
+/**
+ * Bit-position assignments for the three consent flag keys.
+ *
+ *   functional  → bit 2  (value 4)
+ *   analytics   → bit 1  (value 2)
+ *   marketing   → bit 0  (value 1)
+ *
+ * This ordering puts the highest-sensitivity flag in the most-significant
+ * position, making the bitmask human-readable at a glance:
+ *
+ *   7  (111)  all granted
+ *   5  (101)  functional + marketing, no analytics
+ *   0  (000)  all denied  (maximum-security fallback)
+ */
+const BIT = Object.freeze({
+  functional: 4,   // bit 2
+  analytics:  2,   // bit 1
+  marketing:  1,   // bit 0
+});
+
+/**
+ * compactConsentFlags(flagsObject)
+ *
+ * Compresses a consent preference object into a single 3-bit integer for
+ * efficient state transfers and compact storage.
+ *
+ * Bit layout:
+ *   bit 2 (4) — functional
+ *   bit 1 (2) — analytics
+ *   bit 0 (1) — marketing
+ *
+ * Mapping examples:
+ *   { functional: true,  analytics: true,  marketing: true  }  →  7  (0b111)
+ *   { functional: true,  analytics: false, marketing: true  }  →  5  (0b101)
+ *   { functional: false, analytics: true,  marketing: false }  →  2  (0b010)
+ *   { functional: false, analytics: false, marketing: false }  →  0  (0b000)
+ *
+ * Safe-fallback rules:
+ *   - null / undefined / non-plain-object input  →  0 (maximum-restriction posture)
+ *   - missing key                                →  0 for that bit
+ *   - non-boolean truthy/falsy value             →  treated as Boolean(value)
+ *
+ * @param  {object|*} flagsObject
+ * @returns {number}  Integer in the range [0, 7]
+ */
+function compactConsentFlags(flagsObject) {
+  if (
+    flagsObject === null ||
+    flagsObject === undefined ||
+    typeof flagsObject !== "object" ||
+    Array.isArray(flagsObject)
+  ) {
+    return 0;
+  }
+
+  let result = 0;
+  for (const [key, bit] of Object.entries(BIT)) {
+    if (flagsObject[key]) {
+      result |= bit;
+    }
+  }
+  return result;
+}
+
+module.exports = { compactConsentFlags, BIT };

--- a/src/utils/consent/stateCompactor.test.js
+++ b/src/utils/consent/stateCompactor.test.js
@@ -1,0 +1,216 @@
+"use strict";
+
+/**
+ * Canonical unit test for src/utils/consent/stateCompactor.js
+ *
+ * Directly exercises the real production module — no mocks, no stubs.
+ * Exits with code 0 on complete success; code 1 on any assertion failure.
+ */
+
+const assert = require("assert");
+const { compactConsentFlags } = require("./stateCompactor");
+
+let totalPassed = 0;
+let totalFailed = 0;
+
+function runTest(label, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${label}`);
+    totalPassed++;
+  } catch (err) {
+    console.error(`  FAIL  ${label}`);
+    console.error(`        ${err.message}`);
+    totalFailed++;
+  }
+}
+
+// ── Suite 1: Exact bitwise output — all flag combinations ─────────────────────
+
+console.log("\n[Suite 1] Exact bitwise integer output for all 8 flag combinations");
+
+runTest(
+  "all true  → 7  (0b111 — full consent granted)",
+  () => assert.strictEqual(
+    compactConsentFlags({ functional: true, analytics: true, marketing: true }),
+    7
+  )
+);
+
+runTest(
+  "all false → 0  (0b000 — maximum-restriction posture)",
+  () => assert.strictEqual(
+    compactConsentFlags({ functional: false, analytics: false, marketing: false }),
+    0
+  )
+);
+
+runTest(
+  "functional=true,  analytics=false, marketing=true  → 5  (0b101)",
+  () => assert.strictEqual(
+    compactConsentFlags({ functional: true, analytics: false, marketing: true }),
+    5
+  )
+);
+
+runTest(
+  "functional=true,  analytics=true,  marketing=false → 6  (0b110)",
+  () => assert.strictEqual(
+    compactConsentFlags({ functional: true, analytics: true, marketing: false }),
+    6
+  )
+);
+
+runTest(
+  "functional=true,  analytics=false, marketing=false → 4  (0b100)",
+  () => assert.strictEqual(
+    compactConsentFlags({ functional: true, analytics: false, marketing: false }),
+    4
+  )
+);
+
+runTest(
+  "functional=false, analytics=true,  marketing=true  → 3  (0b011)",
+  () => assert.strictEqual(
+    compactConsentFlags({ functional: false, analytics: true, marketing: true }),
+    3
+  )
+);
+
+runTest(
+  "functional=false, analytics=true,  marketing=false → 2  (0b010)",
+  () => assert.strictEqual(
+    compactConsentFlags({ functional: false, analytics: true, marketing: false }),
+    2
+  )
+);
+
+runTest(
+  "functional=false, analytics=false, marketing=true  → 1  (0b001)",
+  () => assert.strictEqual(
+    compactConsentFlags({ functional: false, analytics: false, marketing: true }),
+    1
+  )
+);
+
+// ── Suite 2: Missing keys default to 0 (secure posture) ───────────────────────
+
+console.log("\n[Suite 2] Missing keys default to 0 (secure fallback)");
+
+runTest(
+  "empty object {} → 0 (all keys missing → all bits 0)",
+  () => assert.strictEqual(compactConsentFlags({}), 0)
+);
+
+runTest(
+  "only functional:true provided → 4 (analytics + marketing missing → 0)",
+  () => assert.strictEqual(
+    compactConsentFlags({ functional: true }),
+    4
+  )
+);
+
+runTest(
+  "only marketing:true provided → 1 (functional + analytics missing → 0)",
+  () => assert.strictEqual(
+    compactConsentFlags({ marketing: true }),
+    1
+  )
+);
+
+runTest(
+  "unknown extra key does not corrupt the result",
+  () => assert.strictEqual(
+    compactConsentFlags({ functional: true, unknown: true, analytics: false, marketing: true }),
+    5,
+    "Extra keys must be ignored — result must still be 0b101"
+  )
+);
+
+// ── Suite 3: Type-safety and safe-fallback inputs ─────────────────────────────
+
+console.log("\n[Suite 3] Null / undefined / non-object inputs → 0 without throwing");
+
+runTest(
+  "null → 0",
+  () => assert.strictEqual(compactConsentFlags(null), 0)
+);
+
+runTest(
+  "undefined → 0",
+  () => assert.strictEqual(compactConsentFlags(undefined), 0)
+);
+
+runTest(
+  "array input → 0",
+  () => assert.strictEqual(compactConsentFlags([true, true, true]), 0)
+);
+
+runTest(
+  "string input → 0",
+  () => assert.strictEqual(compactConsentFlags("all-on"), 0)
+);
+
+runTest(
+  "number input → 0",
+  () => assert.strictEqual(compactConsentFlags(7), 0)
+);
+
+runTest(
+  "boolean input → 0",
+  () => assert.strictEqual(compactConsentFlags(true), 0)
+);
+
+// ── Suite 4: Non-boolean flag values treated as Boolean(value) ────────────────
+
+console.log("\n[Suite 4] Non-boolean truthy/falsy values are coerced to Boolean");
+
+runTest(
+  "truthy string 'yes' for functional counts as true → bit 2 set",
+  () => assert.strictEqual(
+    compactConsentFlags({ functional: "yes", analytics: false, marketing: false }),
+    4
+  )
+);
+
+runTest(
+  "falsy 0 for analytics counts as false → bit 1 not set",
+  () => assert.strictEqual(
+    compactConsentFlags({ functional: false, analytics: 0, marketing: true }),
+    1
+  )
+);
+
+runTest(
+  "truthy 1 for marketing counts as true → bit 0 set",
+  () => assert.strictEqual(
+    compactConsentFlags({ functional: false, analytics: false, marketing: 1 }),
+    1
+  )
+);
+
+runTest(
+  "null individual flag value counts as false",
+  () => assert.strictEqual(
+    compactConsentFlags({ functional: null, analytics: true, marketing: null }),
+    2
+  )
+);
+
+// ── Final result ──────────────────────────────────────────────────────────────
+
+const divider = "─".repeat(62);
+console.log(`\n${divider}`);
+
+if (totalFailed === 0) {
+  console.log(
+    `[PASS] All ${totalPassed} assertions passed.` +
+    ` Consent state compactor contract fully verified.`
+  );
+  process.exit(0);
+} else {
+  console.error(
+    `[FAIL] ${totalFailed} of ${totalPassed + totalFailed} assertions failed.`
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
## Description

Adds \`compactConsentFlags(flagsObject)\` to \`src/utils/consent/stateCompactor.js\`, encoding a \`{ functional, analytics, marketing }\` boolean object into a single 3-bit integer for efficient state transfers and compact storage.

**Bit layout:**
| Bit | Value | Flag |
|---|---|---|
| bit 2 | 4 | `functional` |
| bit 1 | 2 | `analytics` |
| bit 0 | 1 | `marketing` |

**Key mappings:**
| Input | Output | Binary |
|---|---|---|
| `{ functional:T, analytics:T, marketing:T }` | `7` | `0b111` |
| `{ functional:T, analytics:F, marketing:T }` | `5` | `0b101` |
| `{ functional:F, analytics:T, marketing:F }` | `2` | `0b010` |
| `{ functional:F, analytics:F, marketing:F }` | `0` | `0b000` |

Safe fallback: `null`, `undefined`, non-object inputs → `0` (maximum-restriction posture).

---

## 📌 Impact Map (Required)

- Routes touched: [x] None — utility layer only
- API / schema / type changes: [x] None
- Cache keys touched: [x] None
- World-model domain summary effects: [x] None
- Mobile parity impacts: [x] None — pure Node.js utility
- Docs updated: [x] None — contract documented in JSDoc
- Verification commands executed: [x] `node src/utils/consent/stateCompactor.test.js`

---

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: importable by any Next.js API route or server action
- [ ] **iOS**: N/A
- [ ] **Android**: N/A

---

## 🧪 Testing

**Live terminal proof — 22/22 assertions, exit code 0:**

```
$ node src/utils/consent/stateCompactor.test.js

[Suite 1] Exact bitwise integer output for all 8 flag combinations
  PASS  all true  → 7  (0b111 — full consent granted)
  PASS  all false → 0  (0b000 — maximum-restriction posture)
  PASS  functional=true,  analytics=false, marketing=true  → 5  (0b101)
  PASS  functional=true,  analytics=true,  marketing=false → 6  (0b110)
  PASS  functional=true,  analytics=false, marketing=false → 4  (0b100)
  PASS  functional=false, analytics=true,  marketing=true  → 3  (0b011)
  PASS  functional=false, analytics=true,  marketing=false → 2  (0b010)
  PASS  functional=false, analytics=false, marketing=true  → 1  (0b001)

[Suite 2] Missing keys default to 0 (secure fallback)
  PASS  empty object {} → 0 (all keys missing → all bits 0)
  PASS  only functional:true provided → 4 (analytics + marketing missing → 0)
  PASS  only marketing:true provided → 1 (functional + analytics missing → 0)
  PASS  unknown extra key does not corrupt the result

[Suite 3] Null / undefined / non-object inputs → 0 without throwing
  PASS  null → 0
  PASS  undefined → 0
  PASS  array input → 0
  PASS  string input → 0
  PASS  number input → 0
  PASS  boolean input → 0

[Suite 4] Non-boolean truthy/falsy values are coerced to Boolean
  PASS  truthy string 'yes' for functional counts as true → bit 2 set
  PASS  falsy 0 for analytics counts as false → bit 1 not set
  PASS  truthy 1 for marketing counts as true → bit 0 set
  PASS  null individual flag value counts as false

──────────────────────────────────────────────────────────────
[PASS] All 22 assertions passed. Consent state compactor contract fully verified.

Exit code: 0
```

| Suite | Cases | What is proven |
|---|---|---|
| 1 — All 8 combinations | 8 | Every possible bitwise output exhaustively verified |
| 2 — Missing key fallback | 4 | Empty object, single key, extra unknown key ignored |
| 3 — Type safety | 6 | `null`/`undefined`/`array`/`string`/`number`/`boolean` → `0` |
| 4 — Truthy/falsy coercion | 4 | String `"yes"`, `0`, `1`, `null` per-flag |

- [x] Commits signed off (`Signed-off-by` trailer present)

---

## 🛡️ Privacy & Consent

- [x] Utility encodes consent preference state for compact transfer — missing keys default to `0` (denied) maintaining maximum-restriction posture.

## 📜 Licensing

- [x] Apache-2.0 compatible
- [x] Zero new dependencies — pure bitwise operations