### PR TITLE
fix(marketplace): add missing noopener rel to external links

### DIFF
--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -1573,7 +1573,7 @@ export default function MarketplacePage() {
                 ) : null}
                 {selectedAdvisor.disclosures_url ? (
                   <Button asChild variant="none" effect="fade" size="sm">
-                    <a href={selectedAdvisor.disclosures_url} target="_blank" rel="noreferrer">
+                    <a href={selectedAdvisor.disclosures_url} target="_blank" rel="noopener noreferrer">
                       Public disclosure
                       <ArrowUpRight className="ml-2 h-4 w-4" />
                     </a>
@@ -1659,7 +1659,7 @@ export default function MarketplacePage() {
                   <div className="flex flex-wrap gap-2">
                     {selectedInvestorEvidenceLinks.map((url) => (
                       <Button key={url} asChild variant="none" effect="fade" size="sm">
-                        <a href={url} target="_blank" rel="noreferrer">
+                        <a href={url} target="_blank" rel="noopener noreferrer">
                           SEC source
                           <ArrowUpRight className="ml-2 h-4 w-4" />
                         </a>


### PR DESCRIPTION
# Description

Added the missing `noopener` attribute to external `target="_blank"` anchor links in the Marketplace directory (`hushh-webapp/app/marketplace/page.tsx`). This ensures the new tab runs in a separate process and cannot access `window.opener`, which is a standard performance and security best practice for external links.

Before requesting review, read
[`docs/reference/quality/pr-contributor-readiness.md`](docs/reference/quality/pr-contributor-readiness.md).
Green CI is intake only; merge readiness also requires a reachable attach point,
production-code proof, and a title/body that match the diff.

## 📌 Impact Map (Required)

- Routes touched:
  - [ ] None
  - [x] Listed below: `/marketplace`

- API / schema / type changes:
  - [x] None
  - [ ] Listed below:

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None
  
- Mobile parity impacts:
  - [x] None

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None
  - [ ] Listed below with the existing workflow they attach to:

- Trust boundary touched:
  - [x] None
  - [ ] Auth / consent / vault / PKM / finance / voice-action / KYC / schema / deploy / public ingress listed below:

- Caller / proxy / backend pairing:
  - [x] Not applicable
  - [ ] Listed below with contract proof:

- Rollback or safe-failure behavior:
  - [x] Not applicable
  
- UI browser or Playwright proof:
  - [x] Not applicable
  - [ ] Route/spec/command listed below:

- Verification commands executed:
  - [ ] `./bin/hushh codex pre-pr`
  - [x] `cd hushh-webapp && npm run typecheck`
  - [ ] `cd hushh-webapp && npm test`
  - [x] `cd hushh-webapp && npm run build`
  - [ ] `cd hushh-webapp && npm run ios:test`
  - [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000`

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate:
- [x] This PR changes a current reachable app/backend/package/docs surface, or it is explicitly scoped as test/devex hygiene.
- [x] Reachable production attach point: `hushh-webapp/app/marketplace/page.tsx`
- [ ] New tests import and exercise production code, not only mock components/helpers defined inside the test file.
- [ ] New helpers/components/services are wired to an existing route, caller, package export, generated contract, or documented devex entrypoint.
- [x] Production surface proved: HTML external link safety
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.
- [x] Maintainer edits are enabled, or the reason they cannot be enabled is listed here:
- [ ] If this is one PR in a stack, the predecessor PR is linked here:
- [ ] If this responds to requested changes, the new commit or material explanation is described here:

## 🛑 Tri-Flow Architecture Check

Every cross-platform feature must cover all affected layers or explicitly mark
the layer as not applicable with the reason.

- [x] **Web**: Next.js implementation (`app/api/...`)
- [ ] **iOS**: Swift Capacitor Plugin (`ios/App/App/Plugins/...`)
- [ ] **Android**: Kotlin Capacitor Plugin (`android/app/.../plugins/...`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)
- [ ] If generated files changed, they were regenerated by the canonical repo command listed above

## 📸 Screenshots / Video

Not applicable — this is an HTML attribute change only (no visual difference).

## 🛡️ Privacy & Consent

- [ ] Does this change access user data?
- [ ] If yes, have you implemented `checkConsentToken()`?
- [x] Sensitive surface touched: none
- [ ] Error path, rollback, or safe-failure behavior proved:

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [ ] Third-party notice impact reviewed when dependencies changed