### PR TITLE
fix(frontend): add missing htmlFor and id for accessible form label

### DIFF
--- a/hushh-webapp/app/profile/receipts/page.tsx
+++ b/hushh-webapp/app/profile/receipts/page.tsx
@@ -1031,11 +1031,12 @@ export default function ProfileReceiptsPage() {
                   </Badge>
                 </div>
 
-                <label className="space-y-2">
+                <label htmlFor="receipt-summary-draft" className="space-y-2">
                   <span className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
                     Shopping summary
                   </span>
                   <textarea
+                    id="receipt-summary-draft"
                     value={receiptSummaryDraft}
                     onChange={(event) => setReceiptSummaryDraft(event.target.value)}
                     rows={5}


### PR DESCRIPTION
# Description

Added missing `htmlFor` on the `<label>` and matching `id` on the `<textarea>` for the shopping summary input on the receipts profile page (`hushh-webapp/app/profile/receipts/page.tsx`). This is a standard frontend accessibility improvement.

## 📌 Impact Map (Required)

- Routes touched: `/profile/receipts`
- API / schema / type changes: None
- Trust boundary touched: None
- Verification commands executed: `npm run typecheck`, `npm run build`

## ✅ Review-Ready Contract

- [x] This PR changes a current reachable app/backend/package/docs surface, or it is explicitly scoped as test/devex hygiene.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.
- [x] Maintainer edits are enabled

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation

## 🧪 Testing

- [x] Tested on Web
- [x] Commits are signed off (`git commit -s`)