### PR TITLE
chore: harden partner gateway public docs

### DIFF
--- a/.codex/skills/repo-operations/SKILL.md
+++ b/.codex/skills/repo-operations/SKILL.md
@@ -56,12 +56,13 @@ Non-owned surfaces:
 1. Record current branch/worktree state and preserve the user's development branch before branch, CI, deploy, PR, hotfix, or validation work.
 2. Prefer live verification over assumptions for GitHub, CI, deploy, ruleset, and runtime state.
 3. Use `./bin/hushh` as the canonical repo command surface and `gh` for live repository state.
-4. For PR work, verify pre-PR, DCO, current head SHA, required gates, queue state, and post-merge smoke.
-5. For core workflow chains, monitor until terminal success or a concrete blocker; queued or in-progress authority runs mean the task is not done.
-6. For merge/deploy requests, keep merge-to-main and deploy-to-UAT as separate operator cadences.
-7. For DB migration/contract changes, run the DB release gate before calling UAT ready.
-8. For local runtime/server work, follow `branch-runtime-ops.md` for visible terminal defaults, inline override, restart, and health-probe rules.
-9. For UAT runtime failures, start with the repo RCA command before editing or redeploying.
+4. When an operational request names an external platform, connector, gateway, marketplace, or MCP-enabled integration, discover available MCP/app tools first through the active tool discovery surface before falling back to direct CLI/API calls. Use the discovered tool only for capabilities it actually exposes; do not hardcode connector assumptions into this skill.
+5. For PR work, verify pre-PR, DCO, current head SHA, required gates, queue state, and post-merge smoke.
+6. For core workflow chains, monitor until terminal success or a concrete blocker; queued or in-progress authority runs mean the task is not done.
+7. For merge/deploy requests, keep merge-to-main and deploy-to-UAT as separate operator cadences.
+8. For DB migration/contract changes, run the DB release gate before calling UAT ready.
+9. For local runtime/server work, follow `branch-runtime-ops.md` for visible terminal defaults, inline override, restart, and health-probe rules.
+10. For UAT runtime failures, start with the repo RCA command before editing or redeploying.
 
 ## Handoff Rules
 

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,12 @@ blogs/
 # Local planning artifacts
 docs/project-plans/
 
+# Private partner gateway handoff material
+deploy/mulesoft/
+docs/reference/operations/mulesoft-managed-omni-private-space.md
+**/mulesoft-vpn-guides/
+**/*mulesoft*vpn*guide*
+
 # Python
 __pycache__/
 *.pyc
@@ -130,13 +136,6 @@ Personal_Tasks/
 *.key
 *credentials*.json
 *secret*.json
-
-# Private partner gateway handoff material
-deploy/mulesoft/
-docs/reference/operations/mulesoft-managed-omni-private-space.md
-**/vpn-guides/
-**/*vpn*guide*
-**/*private-space*handoff*
 
 # Local validation scripts
 test_kai_endpoints.py

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -113,7 +113,9 @@ UAT and production now use the same frontend runtime contract shape:
 
 ### Partner gateway connectivity
 
-Private partner gateway handoff files are not stored in this public repo. Keep live VPN, private DNS, endpoint, and peer material in approved secret-managed operational systems only.
+Partner gateway handoff material for MuleSoft Managed Omni Gateway lives outside the public repository. Do not commit VPN guides, tunnel values, private CIDRs, internal DNS details, Cloud Router state, peer IPs, or provisioning scripts for this lane.
+
+When operating this lane, use the private ops workspace and check available MCP connectors before falling back to direct platform APIs. Public docs may describe the trust boundary and governance model only.
 
 ---
 

--- a/docs/future/hussh-one-infra/salesforce-mulesoft-brief.md
+++ b/docs/future/hussh-one-infra/salesforce-mulesoft-brief.md
@@ -90,13 +90,13 @@ They must not become:
 - the PCHP replacement
 - a broad plaintext data lake for user memory
 
-## Managed Omni Gateway Private Space Handoff
+## Managed Omni Gateway Private Space Boundary
 
-For the current MuleSoft setup discussion, use Managed Omni Gateway in CloudHub 2.0 Private Spaces rather than a self-managed gateway inside Hussh GCP.
+For MuleSoft setup discussions, use Managed Omni Gateway in CloudHub 2.0 Private Spaces rather than a self-managed gateway inside Hussh GCP.
 
-Live partner gateway handoff values are not stored in this public repo. Keep private CIDRs, VPN endpoints, DNS resolver IPs, tunnel values, and peer material in approved secret-managed operational systems only.
+The concrete private-space handoff values are intentionally not stored in this public repository. Keep VPN guides, tunnel values, private CIDRs, internal DNS resolver details, peer IPs, Cloud Router state, and provisioning scripts in the private ops workspace only.
 
-This handoff is network readiness, not consent authority. MuleSoft may route approved partner requests to Hussh; Hussh still validates app, actor, user, scope, expiry, revocation, and audit state before returning a consent status or encrypted scoped export.
+This lane is network readiness, not consent authority. MuleSoft may route approved partner requests to Hussh; Hussh still validates app, actor, user, scope, expiry, revocation, and audit state before returning a consent status or encrypted scoped export.
 
 ## Enterprise Glossary
 

--- a/docs/reference/operations/ci.md
+++ b/docs/reference/operations/ci.md
@@ -308,7 +308,7 @@ Practical maintainer rule:
 1. `main` is the only integration branch for day-to-day development.
 2. A successful `Main Post-Merge Smoke` run produces the only deployable source of truth: the green `main` SHA.
 3. UAT deploys only by an explicit manual dispatch of that green `main` SHA through `.github/workflows/deploy-uat.yml`.
-4. Manual UAT dispatch is limited to `kushaltrivedi5`, `Akash-292`, `RGlodAkshat`, and `ankitkumarsingh1702`.
+4. Manual UAT dispatch is limited to `kushaltrivedi5`, `RGlodAkshat`, `ankitkumarsingh1702`, and `azfx`.
 5. Production deploys only through a manual SHA dispatch in `.github/workflows/deploy-production.yml`, and only `kushaltrivedi5` may trigger it.
 6. Manual UAT or production redeploys must use a SHA that is reachable from `origin/main` and already green in post-merge smoke.
 7. Feature or hotfix branches never deploy directly; they merge through `main`.


### PR DESCRIPTION
## Summary
- keeps live MuleSoft/private gateway handoff values out of the public repo
- narrows ignore rules to partner gateway handoff material
- documents MCP/private-ops lookup before direct platform API fallback
- aligns UAT dispatch operator list with current maintainer access

## Verification
- git diff --cached --check
- targeted rg scan for live VPN endpoints, CIDRs, PSK wording, and MuleSoft MCP secrets