### PR TITLE
feat(privacy): implement canonical data minimizer for consent payload filtering

### DIFF
--- a/src/utils/privacy/dataMinimizer.js
+++ b/src/utils/privacy/dataMinimizer.js
@@ -1,0 +1,53 @@
+"use strict";
+
+/**
+ * minimizePayload(payloadObject, allowedKeysArray)
+ *
+ * Enforces data-minimization protocol: returns a shallow copy of
+ * payloadObject that contains ONLY the keys listed in allowedKeysArray.
+ * Any key not in the allowlist is silently dropped from the output.
+ *
+ * This is the canonical data-minimization boundary before any consent
+ * payload, session object, or API response leaves the service layer.
+ *
+ * Safe-fallback rules — all return {} without throwing:
+ *   - payloadObject is null / undefined / not a plain object
+ *   - allowedKeysArray is null / undefined / not an array / empty array
+ *   - allowedKeysArray contains non-string entries (they are skipped)
+ *
+ * @param  {object}   payloadObject    — source object to be filtered
+ * @param  {string[]} allowedKeysArray — whitelist of permitted keys
+ * @returns {object}                   — minimized shallow copy
+ */
+function minimizePayload(payloadObject, allowedKeysArray) {
+  // Guard: payloadObject must be a plain, non-null, non-array object
+  if (
+    payloadObject === null ||
+    payloadObject === undefined ||
+    typeof payloadObject !== "object" ||
+    Array.isArray(payloadObject)
+  ) {
+    return {};
+  }
+
+  // Guard: allowedKeysArray must be a non-empty array
+  if (
+    !Array.isArray(allowedKeysArray) ||
+    allowedKeysArray.length === 0
+  ) {
+    return {};
+  }
+
+  const result = {};
+  for (const key of allowedKeysArray) {
+    // Skip non-string entries in the whitelist
+    if (typeof key !== "string") continue;
+
+    if (Object.prototype.hasOwnProperty.call(payloadObject, key)) {
+      result[key] = payloadObject[key];
+    }
+  }
+  return result;
+}
+
+module.exports = { minimizePayload };

--- a/src/utils/privacy/dataMinimizer.test.js
+++ b/src/utils/privacy/dataMinimizer.test.js
@@ -1,0 +1,228 @@
+"use strict";
+
+/**
+ * Canonical unit test for src/utils/privacy/dataMinimizer.js
+ *
+ * Directly exercises the real production module — no mocks, no stubs.
+ * Exits with code 0 on complete success; code 1 on any assertion failure.
+ */
+
+const assert = require("assert");
+const { minimizePayload } = require("./dataMinimizer");
+
+let totalPassed = 0;
+let totalFailed = 0;
+
+function runTest(label, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${label}`);
+    totalPassed++;
+  } catch (err) {
+    console.error(`  FAIL  ${label}`);
+    console.error(`        ${err.message}`);
+    totalFailed++;
+  }
+}
+
+// ── Suite 1: Standard key stripping ───────────────────────────────────────────
+
+console.log("\n[Suite 1] Standard key stripping — only allowed keys pass through");
+
+runTest(
+  "allowed key is included in output",
+  () => {
+    const result = minimizePayload({ userId: "u1", email: "a@b.com" }, ["userId"]);
+    assert.ok(Object.prototype.hasOwnProperty.call(result, "userId"),
+      "'userId' must be present in the minimized output");
+  }
+);
+
+runTest(
+  "disallowed key is stripped from output",
+  () => {
+    const result = minimizePayload({ userId: "u1", email: "a@b.com" }, ["userId"]);
+    assert.ok(!Object.prototype.hasOwnProperty.call(result, "email"),
+      "'email' must be stripped — it is not in the allowlist");
+  }
+);
+
+runTest(
+  "multiple allowed keys all pass through",
+  () => {
+    const payload = { userId: "u1", scope: "vault.owner", token: "HCT:abc", secret: "x" };
+    const result = minimizePayload(payload, ["userId", "scope"]);
+    assert.deepStrictEqual(result, { userId: "u1", scope: "vault.owner" });
+  }
+);
+
+runTest(
+  "output contains exactly the intersection of payload keys and allowlist",
+  () => {
+    const payload = { a: 1, b: 2, c: 3, d: 4 };
+    const result = minimizePayload(payload, ["a", "c"]);
+    assert.deepStrictEqual(Object.keys(result).sort(), ["a", "c"]);
+  }
+);
+
+runTest(
+  "allowed key not present in payload is silently omitted (not undefined-injected)",
+  () => {
+    const result = minimizePayload({ userId: "u1" }, ["userId", "missingKey"]);
+    assert.ok(!Object.prototype.hasOwnProperty.call(result, "missingKey"),
+      "Key absent from payload must not appear in output — even as undefined");
+    assert.strictEqual(result.userId, "u1");
+  }
+);
+
+// ── Suite 2: Case preservation ────────────────────────────────────────────────
+
+console.log("\n[Suite 2] Case preservation — key names are matched and preserved exactly");
+
+runTest(
+  "camelCase key preserved exactly",
+  () => {
+    const result = minimizePayload({ userId: "u1", UserID: "u2" }, ["userId"]);
+    assert.strictEqual(result.userId, "u1");
+    assert.ok(!result.UserID, "'UserID' must not be included when allowlist has 'userId'");
+  }
+);
+
+runTest(
+  "uppercase key matched only when allowlist entry is uppercase",
+  () => {
+    const result = minimizePayload({ USER_ID: "u1", userId: "u2" }, ["USER_ID"]);
+    assert.strictEqual(result.USER_ID, "u1");
+    assert.ok(!result.userId);
+  }
+);
+
+runTest(
+  "value types are preserved — number, boolean, null, object",
+  () => {
+    const payload = { count: 42, active: false, ref: null, meta: { v: 1 } };
+    const result = minimizePayload(payload, ["count", "active", "ref", "meta"]);
+    assert.strictEqual(result.count, 42);
+    assert.strictEqual(result.active, false);
+    assert.strictEqual(result.ref, null);
+    assert.deepStrictEqual(result.meta, { v: 1 });
+  }
+);
+
+// ── Suite 3: Immutability — original payload is not mutated ───────────────────
+
+console.log("\n[Suite 3] Immutability — original payload reference is not modified");
+
+runTest(
+  "output is a new object — not the same reference as input",
+  () => {
+    const payload = { userId: "u1", secret: "s" };
+    const result = minimizePayload(payload, ["userId"]);
+    assert.notStrictEqual(result, payload,
+      "minimizePayload must return a new object, not the original reference");
+  }
+);
+
+runTest(
+  "original payload is unmodified after minimization",
+  () => {
+    const payload = { userId: "u1", secret: "s" };
+    minimizePayload(payload, ["userId"]);
+    assert.ok(Object.prototype.hasOwnProperty.call(payload, "secret"),
+      "The original payload must still contain 'secret' after minimization");
+  }
+);
+
+// ── Suite 4: Empty and invalid argument safety ────────────────────────────────
+
+console.log("\n[Suite 4] Empty and invalid arguments → {} without throwing");
+
+runTest(
+  "null payloadObject → {}",
+  () => assert.deepStrictEqual(minimizePayload(null, ["userId"]), {})
+);
+
+runTest(
+  "undefined payloadObject → {}",
+  () => assert.deepStrictEqual(minimizePayload(undefined, ["userId"]), {})
+);
+
+runTest(
+  "array payloadObject → {}",
+  () => assert.deepStrictEqual(minimizePayload(["a", "b"], ["0"]), {})
+);
+
+runTest(
+  "string payloadObject → {}",
+  () => assert.deepStrictEqual(minimizePayload("payload", ["length"]), {})
+);
+
+runTest(
+  "number payloadObject → {}",
+  () => assert.deepStrictEqual(minimizePayload(42, ["toString"]), {})
+);
+
+runTest(
+  "null allowedKeysArray → {}",
+  () => assert.deepStrictEqual(minimizePayload({ userId: "u1" }, null), {})
+);
+
+runTest(
+  "undefined allowedKeysArray → {}",
+  () => assert.deepStrictEqual(minimizePayload({ userId: "u1" }, undefined), {})
+);
+
+runTest(
+  "empty allowedKeysArray [] → {}",
+  () => assert.deepStrictEqual(minimizePayload({ userId: "u1" }, []), {})
+);
+
+runTest(
+  "non-array allowedKeysArray (string) → {}",
+  () => assert.deepStrictEqual(minimizePayload({ userId: "u1" }, "userId"), {})
+);
+
+runTest(
+  "non-array allowedKeysArray (object) → {}",
+  () => assert.deepStrictEqual(minimizePayload({ userId: "u1" }, { 0: "userId" }), {})
+);
+
+runTest(
+  "both arguments null → {}",
+  () => assert.deepStrictEqual(minimizePayload(null, null), {})
+);
+
+runTest(
+  "empty payload {} with valid allowlist → {}",
+  () => assert.deepStrictEqual(minimizePayload({}, ["userId"]), {})
+);
+
+runTest(
+  "non-string entries in allowedKeysArray are skipped",
+  () => {
+    const result = minimizePayload(
+      { userId: "u1", 0: "zero", true: "boolkey" },
+      [42, null, "userId", true]
+    );
+    assert.deepStrictEqual(result, { userId: "u1" },
+      "Non-string allowlist entries must be skipped; only 'userId' should pass");
+  }
+);
+
+// ── Final result ──────────────────────────────────────────────────────────────
+
+const divider = "─".repeat(62);
+console.log(`\n${divider}`);
+
+if (totalFailed === 0) {
+  console.log(
+    `[PASS] All ${totalPassed} assertions passed.` +
+    ` Data minimizer contract fully verified.`
+  );
+  process.exit(0);
+} else {
+  console.error(
+    `[FAIL] ${totalFailed} of ${totalPassed + totalFailed} assertions failed.`
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
## Description

Adds \`minimizePayload(payloadObject, allowedKeysArray)\` to \`src/utils/privacy/dataMinimizer.js\` — the canonical data-minimization boundary before any consent payload, session object, or API response leaves the service layer.

Returns a **shallow copy** of the input object containing **only** the keys in the allowlist. All other keys are silently dropped.

---

## 📌 Impact Map (Required)

- Routes touched: [x] None — utility layer only
- API / schema / type changes: [x] None
- Cache keys touched: [x] None
- Mobile parity impacts: [x] None — pure Node.js utility
- Docs updated: [x] None — contract documented in JSDoc
- Verification commands executed: [x] \`node src/utils/privacy/dataMinimizer.test.js\`

---

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: importable by any Next.js API route or server action
- [ ] **iOS**: N/A
- [ ] **Android**: N/A

---

## 🧪 Testing

**Live terminal proof — 23/23 assertions, exit code 0:**

```
$ node src/utils/privacy/dataMinimizer.test.js

[Suite 1] Standard key stripping — only allowed keys pass through
  PASS  allowed key is included in output
  PASS  disallowed key is stripped from output
  PASS  multiple allowed keys all pass through
  PASS  output contains exactly the intersection of payload keys and allowlist
  PASS  allowed key not present in payload is silently omitted (not undefined-injected)

[Suite 2] Case preservation — key names are matched and preserved exactly
  PASS  camelCase key preserved exactly
  PASS  uppercase key matched only when allowlist entry is uppercase
  PASS  value types are preserved — number, boolean, null, object

[Suite 3] Immutability — original payload reference is not modified
  PASS  output is a new object — not the same reference as input
  PASS  original payload is unmodified after minimization

[Suite 4] Empty and invalid arguments → {} without throwing
  PASS  null payloadObject → {}
  PASS  undefined payloadObject → {}
  PASS  array payloadObject → {}
  PASS  string payloadObject → {}
  PASS  number payloadObject → {}
  PASS  null allowedKeysArray → {}
  PASS  undefined allowedKeysArray → {}
  PASS  empty allowedKeysArray [] → {}
  PASS  non-array allowedKeysArray (string) → {}
  PASS  non-array allowedKeysArray (object) → {}
  PASS  both arguments null → {}
  PASS  empty payload {} with valid allowlist → {}
  PASS  non-string entries in allowedKeysArray are skipped

──────────────────────────────────────────────────────────────
[PASS] All 23 assertions passed. Data minimizer contract fully verified.

Exit code: 0
```

| Suite | Cases | What is proven |
|---|---|---|
| 1 — Key stripping | 5 | Include/strip logic, multi-key intersection, absent-key omission |
| 2 — Case preservation | 3 | Exact key matching, value-type fidelity |
| 3 — Immutability | 2 | New object reference returned; original never mutated |
| 4 — Invalid argument safety | 13 | All null/undefined/wrong-type inputs return `{}` without throwing |

- [x] Commits signed off (`Signed-off-by` trailer present)
- [x] **1 commit, 2 files, based on current `main`** — no stacked diff

---

## 🛡️ Privacy & Consent

- [x] Enforces data-minimization — only explicitly allowed fields leave the boundary. Missing or invalid allowlist defaults to `{}` (maximum-restriction posture).

## 📜 Licensing

- [x] Apache-2.0 compatible
- [x] Zero new dependencies — pure native Object operations