### PR TITLE
fix(frontend): add missing aria-label and title to icon-only button in optimize page

### DIFF
--- a/hushh-webapp/app/kai/optimize/page.tsx
+++ b/hushh-webapp/app/kai/optimize/page.tsx
@@ -1228,7 +1228,7 @@ export default function PortfolioHealthPage() {
                                     </div>
                                   </div>
                                 )}
-                                <Button size="sm" variant="muted" className="h-8 w-8 p-0 rounded-xl opacity-0 group-hover:opacity-100 transition-opacity">
+                                <Button size="sm" variant="muted" aria-label="More information" title="More information" className="h-8 w-8 p-0 rounded-xl opacity-0 group-hover:opacity-100 transition-opacity">
                                   <Icon icon={Info} size="xs" />
                                 </Button>
                               </div>


### PR DESCRIPTION
# Description

Added missing `aria-label` and `title` to an icon-only button (`<Button><Icon icon={Info} /></Button>`) in the Kai portfolio optimize page (`hushh-webapp/app/kai/optimize/page.tsx`). This is a standard frontend accessibility improvement to ensure screen readers announce the button's purpose correctly.

## 📌 Impact Map (Required)

- Routes touched: `/kai/optimize`
- API / schema / type changes: None
- Trust boundary touched: None
- Verification commands executed: `npm run typecheck`, `npm run build`

## ✅ Review-Ready Contract

- [x] This PR changes a current reachable app/backend/package/docs surface, or it is explicitly scoped as test/devex hygiene.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.
- [x] Maintainer edits are enabled

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation

## 🧪 Testing

- [x] Tested on Web
- [x] Commits are signed off (`git commit -s`)