### PR TITLE
fix(frontend): add missing htmlFor and id for accessible edit holding form symbol input

### DIFF
--- a/hushh-webapp/components/kai/modals/edit-holding-modal.tsx
+++ b/hushh-webapp/components/kai/modals/edit-holding-modal.tsx
@@ -412,11 +412,12 @@ export function EditHoldingModal({
         <div className="px-4 py-2 space-y-4 max-h-[60vh] overflow-y-auto">
           {/* Symbol */}
           <div>
-            <label className="block text-sm font-medium mb-1">
+            <label htmlFor="holding-symbol" className="block text-sm font-medium mb-1">
               Symbol <span className="text-red-500">*</span>
             </label>
             <div ref={symbolInputWrapRef} className="relative">
               <input
+                id="holding-symbol"
                 type="text"
                 value={formData.symbol}
                 onChange={(e) => handleChange("symbol", e.target.value.toUpperCase())}


### PR DESCRIPTION
# Description

Added missing `htmlFor` and `id` tags for the Symbol input on the Kai edit holding modal (`hushh-webapp/components/kai/modals/edit-holding-modal.tsx`). This is an isolated, narrow frontend accessibility fix for form controls. Branched cleanly from current main to ensure a zero-conflict, single-commit diff.

## 📌 Impact Map (Required)

- Routes touched: `/kai/portfolio` (via edit holding modal)
- API / schema / type changes: None
- Trust boundary touched: None
- Verification commands executed: `npm run typecheck`, `npm run build`

## ✅ Review-Ready Contract

- [x] This PR changes a current reachable app/backend/package/docs surface, or it is explicitly scoped as test/devex hygiene.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.
- [x] Maintainer edits are enabled

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation

## 🧪 Testing

- [x] Tested on Web
- [x] Commits are signed off (`git commit -s`)