### PR TITLE
feat(privacy): create sanitization filter for tracking parameters in URL strings

### DIFF
--- a/src/utils/privacy/urlScrubber.js
+++ b/src/utils/privacy/urlScrubber.js
@@ -1,0 +1,100 @@
+"use strict";
+
+/**
+ * Known marketing / click-tracking query-parameter names and prefixes.
+ * Any parameter whose name matches this pattern is stripped before the
+ * URL is forwarded, logged, or stored.
+ *
+ *   utm_*    — Google Analytics campaign suite (any utm_ prefix)
+ *   gclid    — Google Ads click identifier
+ *   fbclid   — Facebook / Meta click identifier
+ *   msclkid  — Microsoft / Bing Ads click identifier
+ *   ttclid   — TikTok Ads click identifier
+ *   twclid   — Twitter / X Ads click identifier
+ *   dclid    — DoubleClick / Google Display & Video 360
+ *   yclid    — Yandex click identifier
+ *   igshid   — Instagram share identifier
+ *   mc_cid   — Mailchimp campaign identifier
+ *   mc_eid   — Mailchimp email identifier
+ *   srsltid  — Google Shopping result-listing identifier
+ */
+const TRACKING_PATTERN =
+  /^(utm_|gclid|fbclid|msclkid|ttclid|twclid|dclid|yclid|igshid|mc_cid|mc_eid|srsltid)/i;
+
+/**
+ * Synthetic base used only when parsing relative URLs through the WHATWG
+ * URL API.  Chosen to be obviously non-real so it is never confused with a
+ * live origin.
+ */
+const _DUMMY_BASE = "https://__scrubber_placeholder__.invalid";
+
+/**
+ * scrubTrackingParams(urlText)
+ *
+ * Strips marketing and click-tracking query parameters from a URL string
+ * while leaving all functional parameters intact.
+ *
+ * Behaviour summary:
+ *
+ *   Absolute URL  (https://…)   →  parsed, scrubbed, returned as-is
+ *   Relative path (/path?…)     →  parsed with dummy base, path+query+
+ *                                   fragment returned (origin dropped)
+ *   Unparseable string           →  raw input returned unchanged
+ *   Non-string / null / undefined →  empty string returned
+ *   Empty / whitespace-only      →  empty string returned
+ *
+ * The relative-URL fallback is intentionally restricted to inputs that
+ * start with "/" to avoid silently URL-encoding arbitrary plain strings
+ * through the WHATWG relative-URL parser.
+ *
+ * @param  {string} urlText
+ * @returns {string}
+ */
+function scrubTrackingParams(urlText) {
+  if (typeof urlText !== "string") return "";
+
+  const trimmed = urlText.trim();
+  if (!trimmed) return "";
+
+  let parsed;
+  let isRelative = false;
+
+  // ── Attempt 1: parse as an absolute URL ───────────────────────────────────
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    // ── Attempt 2: parse as a relative path (only when starting with /) ─────
+    if (trimmed.startsWith("/")) {
+      try {
+        parsed = new URL(trimmed, _DUMMY_BASE);
+        isRelative = true;
+      } catch {
+        return trimmed; // still unparseable — return raw
+      }
+    } else {
+      // Not an absolute URL and not a recognisable path — return raw unchanged
+      return trimmed;
+    }
+  }
+
+  // ── Strip tracking parameters ─────────────────────────────────────────────
+  const toDelete = [];
+  for (const key of parsed.searchParams.keys()) {
+    if (TRACKING_PATTERN.test(key)) {
+      toDelete.push(key);
+    }
+  }
+  for (const key of toDelete) {
+    parsed.searchParams.delete(key);
+  }
+
+  // ── Reconstruct ───────────────────────────────────────────────────────────
+  if (isRelative) {
+    const qs = parsed.searchParams.toString();
+    return parsed.pathname + (qs ? `?${qs}` : "") + parsed.hash;
+  }
+
+  return parsed.toString();
+}
+
+module.exports = { scrubTrackingParams };

--- a/src/utils/privacy/urlScrubber.test.js
+++ b/src/utils/privacy/urlScrubber.test.js
@@ -1,0 +1,282 @@
+"use strict";
+
+/**
+ * Canonical unit test for src/utils/privacy/urlScrubber.js
+ *
+ * Directly exercises the real production module — no mocks, no stubs.
+ * Exits with code 0 on complete success; code 1 on any assertion failure.
+ */
+
+const assert = require("assert");
+const { scrubTrackingParams } = require("./urlScrubber");
+
+let totalPassed = 0;
+let totalFailed = 0;
+
+function runTest(label, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${label}`);
+    totalPassed++;
+  } catch (err) {
+    console.error(`  FAIL  ${label}`);
+    console.error(`        ${err.message}`);
+    totalFailed++;
+  }
+}
+
+// ── Suite 1: Tracking parameters are stripped ─────────────────────────────────
+
+console.log("\n[Suite 1] Tracking parameters are stripped from the URL");
+
+runTest(
+  "gclid (Google Ads) is removed from absolute URL",
+  () => {
+    const result = scrubTrackingParams("https://example.com/page?gclid=abc123");
+    assert.ok(!result.includes("gclid"),
+      `gclid must be stripped. Got: ${result}`);
+    assert.ok(result.startsWith("https://example.com"),
+      `Origin must be preserved. Got: ${result}`);
+  }
+);
+
+runTest(
+  "fbclid (Facebook) is removed from absolute URL",
+  () => {
+    const result = scrubTrackingParams("https://example.com/page?fbclid=xyz789");
+    assert.ok(!result.includes("fbclid"),
+      `fbclid must be stripped. Got: ${result}`);
+  }
+);
+
+runTest(
+  "utm_source is removed",
+  () => {
+    const result = scrubTrackingParams("https://example.com/?utm_source=newsletter");
+    assert.ok(!result.includes("utm_source"),
+      `utm_source must be stripped. Got: ${result}`);
+  }
+);
+
+runTest(
+  "all utm_* parameters are removed in a single pass",
+  () => {
+    const url = "https://example.com/landing"
+      + "?utm_source=google&utm_medium=cpc&utm_campaign=spring"
+      + "&utm_content=banner&utm_term=shoes";
+    const result = scrubTrackingParams(url);
+    assert.ok(!result.includes("utm_"),
+      `All utm_ params must be stripped. Got: ${result}`);
+    assert.ok(result.startsWith("https://example.com/landing"),
+      `Path must be preserved. Got: ${result}`);
+  }
+);
+
+runTest(
+  "msclkid (Microsoft Ads) is removed",
+  () => {
+    const result = scrubTrackingParams("https://example.com/?msclkid=ms456");
+    assert.ok(!result.includes("msclkid"),
+      `msclkid must be stripped. Got: ${result}`);
+  }
+);
+
+runTest(
+  "ttclid (TikTok Ads) is removed",
+  () => {
+    const result = scrubTrackingParams("https://example.com/?ttclid=tt789");
+    assert.ok(!result.includes("ttclid"),
+      `ttclid must be stripped. Got: ${result}`);
+  }
+);
+
+runTest(
+  "mc_cid and mc_eid (Mailchimp) are both removed",
+  () => {
+    const result = scrubTrackingParams("https://example.com/?mc_cid=abc&mc_eid=def");
+    assert.ok(!result.includes("mc_cid"),
+      `mc_cid must be stripped. Got: ${result}`);
+    assert.ok(!result.includes("mc_eid"),
+      `mc_eid must be stripped. Got: ${result}`);
+  }
+);
+
+// ── Suite 2: Functional parameters are preserved ──────────────────────────────
+
+console.log("\n[Suite 2] Functional (non-tracking) parameters survive scrubbing");
+
+runTest(
+  "standard search param 'q' is preserved alongside stripped gclid",
+  () => {
+    const result = scrubTrackingParams("https://example.com/search?q=privacy&gclid=abc");
+    assert.ok(result.includes("q=privacy"),
+      `'q' param must survive. Got: ${result}`);
+    assert.ok(!result.includes("gclid"),
+      `gclid must be stripped. Got: ${result}`);
+  }
+);
+
+runTest(
+  "'id', 'page', and 'sort' all survive when utm_ is stripped",
+  () => {
+    const result = scrubTrackingParams(
+      "https://example.com/items?id=42&page=3&sort=asc&utm_source=google"
+    );
+    assert.ok(result.includes("id=42"),    `'id' must survive. Got: ${result}`);
+    assert.ok(result.includes("page=3"),   `'page' must survive. Got: ${result}`);
+    assert.ok(result.includes("sort=asc"), `'sort' must survive. Got: ${result}`);
+    assert.ok(!result.includes("utm_"),    `utm_ must be stripped. Got: ${result}`);
+  }
+);
+
+runTest(
+  "URL with no tracking params is returned byte-for-byte unchanged",
+  () => {
+    const clean = "https://example.com/dashboard?user=alice&tab=settings";
+    assert.strictEqual(scrubTrackingParams(clean), clean,
+      "A URL without tracking params must be returned identical");
+  }
+);
+
+runTest(
+  "URL with no query string at all is returned unchanged",
+  () => {
+    const clean = "https://example.com/about";
+    assert.strictEqual(scrubTrackingParams(clean), clean,
+      "A URL with no query string must not be mutated");
+  }
+);
+
+runTest(
+  "URL fragment (#anchor) is preserved after tracking param is stripped",
+  () => {
+    const result = scrubTrackingParams(
+      "https://example.com/docs?gclid=abc#section-2"
+    );
+    assert.ok(result.includes("#section-2"),
+      `Fragment must be preserved. Got: ${result}`);
+    assert.ok(!result.includes("gclid"),
+      `gclid must be stripped. Got: ${result}`);
+  }
+);
+
+// ── Suite 3: Relative URL handling ────────────────────────────────────────────
+
+console.log("\n[Suite 3] Relative URLs are scrubbed correctly");
+
+runTest(
+  "relative path: tracking param stripped, functional param preserved, path intact",
+  () => {
+    const result = scrubTrackingParams("/page?gclid=abc123&q=test");
+    assert.ok(!result.includes("gclid"),   `gclid must be stripped. Got: ${result}`);
+    assert.ok(result.includes("q=test"),   `'q' must survive. Got: ${result}`);
+    assert.ok(result.startsWith("/page"),  `path must be preserved. Got: ${result}`);
+  }
+);
+
+runTest(
+  "relative path with only tracking params → bare path, no trailing '?'",
+  () => {
+    const result = scrubTrackingParams("/landing?utm_source=email&utm_medium=cpc");
+    assert.ok(!result.includes("utm_"),  `utm_ must be stripped. Got: ${result}`);
+    assert.ok(!result.includes("?"),     `trailing '?' must be dropped. Got: ${result}`);
+    assert.strictEqual(result, "/landing");
+  }
+);
+
+runTest(
+  "relative path with fragment: tracking stripped, fragment preserved",
+  () => {
+    const result = scrubTrackingParams("/docs?fbclid=xyz#intro");
+    assert.ok(!result.includes("fbclid"), `fbclid must be stripped. Got: ${result}`);
+    assert.ok(result.includes("#intro"),  `fragment must survive. Got: ${result}`);
+  }
+);
+
+// ── Suite 4: Mixed tracking + functional parameters ───────────────────────────
+
+console.log("\n[Suite 4] Mixed params — tracking stripped, routing params preserved");
+
+runTest(
+  "tracking param first, functional param second",
+  () => {
+    const result = scrubTrackingParams("https://example.com/?gclid=abc&ref=homepage");
+    assert.ok(!result.includes("gclid"),        `gclid must be stripped. Got: ${result}`);
+    assert.ok(result.includes("ref=homepage"),  `'ref' must survive. Got: ${result}`);
+  }
+);
+
+runTest(
+  "functional param first, tracking param last",
+  () => {
+    const result = scrubTrackingParams("https://example.com/?ref=homepage&fbclid=xyz");
+    assert.ok(!result.includes("fbclid"),       `fbclid must be stripped. Got: ${result}`);
+    assert.ok(result.includes("ref=homepage"),  `'ref' must survive. Got: ${result}`);
+  }
+);
+
+runTest(
+  "interleaved tracking and functional params — only tracking removed",
+  () => {
+    const result = scrubTrackingParams(
+      "https://example.com/?a=1&utm_source=x&b=2&gclid=y&c=3"
+    );
+    assert.ok(result.includes("a=1"),          `'a' must survive. Got: ${result}`);
+    assert.ok(result.includes("b=2"),          `'b' must survive. Got: ${result}`);
+    assert.ok(result.includes("c=3"),          `'c' must survive. Got: ${result}`);
+    assert.ok(!result.includes("utm_source"),  `utm_source must be stripped. Got: ${result}`);
+    assert.ok(!result.includes("gclid"),       `gclid must be stripped. Got: ${result}`);
+  }
+);
+
+// ── Suite 5: Bad-input boundary handling ─────────────────────────────────────
+
+console.log("\n[Suite 5] Bad-input boundaries → safe return without throwing");
+
+runTest("null → empty string",
+  () => assert.strictEqual(scrubTrackingParams(null), ""));
+
+runTest("undefined → empty string",
+  () => assert.strictEqual(scrubTrackingParams(undefined), ""));
+
+runTest("empty string → empty string",
+  () => assert.strictEqual(scrubTrackingParams(""), ""));
+
+runTest("whitespace-only string → empty string",
+  () => assert.strictEqual(scrubTrackingParams("   "), ""));
+
+runTest("number input → empty string",
+  () => assert.strictEqual(scrubTrackingParams(42), ""));
+
+runTest("boolean input → empty string",
+  () => assert.strictEqual(scrubTrackingParams(true), ""));
+
+runTest("array input → empty string",
+  () => assert.strictEqual(scrubTrackingParams(["https://example.com"]), ""));
+
+runTest(
+  "unparseable plain string → raw input returned unchanged (not URL-encoded)",
+  () => {
+    const junk = "not a url at all !!!";
+    assert.strictEqual(scrubTrackingParams(junk), junk,
+      "Unparseable strings must be returned raw — not empty, not mutated");
+  }
+);
+
+// ── Final result ──────────────────────────────────────────────────────────────
+
+const divider = "─".repeat(62);
+console.log(`\n${divider}`);
+
+if (totalFailed === 0) {
+  console.log(
+    `[PASS] All ${totalPassed} assertions passed.` +
+    ` URL tracking-param scrubber contract fully verified.`
+  );
+  process.exit(0);
+} else {
+  console.error(
+    `[FAIL] ${totalFailed} of ${totalPassed + totalFailed} assertions failed.`
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
## Description

Adds `scrubTrackingParams(urlText)` to `src/utils/privacy/urlScrubber.js` — strips marketing/click-tracking query parameters from URL strings while preserving all functional routing parameters.

**Trackers removed:** `utm_*`, `gclid`, `fbclid`, `msclkid`, `ttclid`, `twclid`, `dclid`, `yclid`, `igshid`, `mc_cid`, `mc_eid`, `srsltid`

**Safe-fallback rules:**
- Non-string / `null` / `undefined` → `""`
- Whitespace-only → `""`
- Absolute URL → scrubbed, full URL returned
- Relative path (`/path?…`) → scrubbed, path+query+fragment returned
- Unparseable string → raw input returned unchanged (never URL-encoded)

---

## 📌 Impact Map (Required)

- Routes touched: [x] None — utility layer only
- API / schema / type changes: [x] None
- Cache keys touched: [x] None
- Mobile parity impacts: [x] None — pure Node.js utility
- Docs updated: [x] None — full contract in JSDoc
- Verification: [x] `node src/utils/privacy/urlScrubber.test.js`

---

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: importable by any Next.js API route or server action
- [ ] iOS / Android: N/A

---

## 🧪 Testing — 26/26 assertions, exit code 0

```
$ node src/utils/privacy/urlScrubber.test.js

[Suite 1] Tracking parameters are stripped from the URL
  PASS  gclid (Google Ads) is removed from absolute URL
  PASS  fbclid (Facebook) is removed from absolute URL
  PASS  utm_source is removed
  PASS  all utm_* parameters are removed in a single pass
  PASS  msclkid (Microsoft Ads) is removed
  PASS  ttclid (TikTok Ads) is removed
  PASS  mc_cid and mc_eid (Mailchimp) are both removed

[Suite 2] Functional (non-tracking) parameters survive scrubbing
  PASS  standard search param 'q' is preserved alongside stripped gclid
  PASS  'id', 'page', and 'sort' all survive when utm_ is stripped
  PASS  URL with no tracking params is returned byte-for-byte unchanged
  PASS  URL with no query string at all is returned unchanged
  PASS  URL fragment (#anchor) is preserved after tracking param is stripped

[Suite 3] Relative URLs are scrubbed correctly
  PASS  relative path: tracking param stripped, functional param preserved, path intact
  PASS  relative path with only tracking params → bare path, no trailing '?'
  PASS  relative path with fragment: tracking stripped, fragment preserved

[Suite 4] Mixed params — tracking stripped, routing params preserved
  PASS  tracking param first, functional param second
  PASS  functional param first, tracking param last
  PASS  interleaved tracking and functional params — only tracking removed

[Suite 5] Bad-input boundaries → safe return without throwing
  PASS  null → empty string
  PASS  undefined → empty string
  PASS  empty string → empty string
  PASS  whitespace-only string → empty string
  PASS  number input → empty string
  PASS  boolean input → empty string
  PASS  array input → empty string
  PASS  unparseable plain string → raw input returned unchanged (not URL-encoded)

──────────────────────────────────────────────────────────────
[PASS] All 26 assertions passed. URL tracking-param scrubber contract fully verified.

Exit code: 0
```

| Suite | Cases | What is proven |
|---|---|---|
| 1 — Tracking stripped | 7 | `gclid`, `fbclid`, `utm_*`, `msclkid`, `ttclid`, `mc_cid`/`mc_eid` |
| 2 — Functional preserved | 5 | `q`, `id/page/sort`, clean URL unchanged, no-query URL, fragment |
| 3 — Relative URLs | 3 | Path scrubbed, bare path when all params removed, fragment kept |
| 4 — Mixed params | 3 | Leading/trailing/interleaved tracking removed, routing kept |
| 5 — Bad-input safety | 8 | `null`/`undefined`/empty/whitespace/number/boolean/array/junk |

- [x] `Signed-off-by` trailer present (`git commit -s`)
- [x] **1 commit · 2 files · based on current `main`** — zero stacked diff