### PR TITLE
feat(privacy): implement user-agent masker to strip browser fingerprinting build tokens

### DIFF
--- a/src/utils/privacy/agentMasker.js
+++ b/src/utils/privacy/agentMasker.js
@@ -1,0 +1,74 @@
+"use strict";
+
+/**
+ * Neutral User-Agent string returned when the input is missing, null,
+ * undefined, empty, or not a string.
+ *
+ * Structurally valid, contains zero fingerprinting signal.
+ */
+const GENERIC_UA = "Mozilla/5.0 (compatible; Generic Browser)";
+
+/**
+ * Three-pass masking strategy (applied in order):
+ *
+ *  Pass 1 — 4-segment versions  X.Y.Z.W  →  X.0
+ *            Targets precise build IDs such as Chrome/121.0.6167.85
+ *            and Edg/121.0.2277.128.
+ *
+ *  Pass 2 — 3-segment versions  X.Y.Z    →  X.0
+ *            Catches OPR/105.0.4970 and similar 3-part tokens after
+ *            Pass 1 has already handled the 4-part ones.
+ *
+ *  Pass 3 — Known variable 2-segment browser names  X.Y  →  X.0
+ *            Normalises Firefox/123.5, FxiOS/28.2, CriOS/109.0 etc.
+ *            Deliberately excludes static constant tokens such as
+ *            AppleWebKit/537.36, Gecko/20100101, and Safari/537.36
+ *            — those carry no per-user entropy and are left unchanged.
+ */
+const _PASS1 = /\/(\d+)\.\d+\.\d+\.\d+/g;         // 4-segment  → X.0
+const _PASS2 = /\/(\d+)\.\d+\.\d+/g;               // 3-segment  → X.0
+const _PASS3 =
+  /\b(Chrome|Firefox|Edg|Edge|OPR|Opera|FxiOS|CriOS|SamsungBrowser|YaBrowser)\/(\d+)\.\d+\b/g;
+
+/**
+ * maskUserAgent(userAgentString)
+ *
+ * Converts a granular, version-specific User-Agent string into a generic,
+ * high-level browser identifier to protect clients against browser
+ * fingerprinting.
+ *
+ * Masking rules:
+ *   - 4-part versions  (X.Y.Z.W)  stripped to  X.0
+ *   - 3-part versions  (X.Y.Z)    stripped to  X.0
+ *   - Known browser 2-part versions  (X.Y)  normalised to  X.0
+ *   - Static constant tokens (AppleWebKit/537.36, Gecko/20100101,
+ *     Safari/537.36) are left exactly as they are.
+ *
+ * Safe-fallback: null / undefined / non-string / empty → GENERIC_UA
+ *
+ * @param  {string} userAgentString
+ * @returns {string}  masked UA string
+ */
+function maskUserAgent(userAgentString) {
+  if (
+    userAgentString === null ||
+    userAgentString === undefined ||
+    typeof userAgentString !== "string" ||
+    userAgentString.trim() === ""
+  ) {
+    return GENERIC_UA;
+  }
+
+  // Reset regex lastIndex state (global flag safety)
+  _PASS1.lastIndex = 0;
+  _PASS2.lastIndex = 0;
+  _PASS3.lastIndex = 0;
+
+  return userAgentString
+    .trim()
+    .replace(_PASS1, "/$1.0")
+    .replace(_PASS2, "/$1.0")
+    .replace(_PASS3, "$1/$2.0");
+}
+
+module.exports = { maskUserAgent, GENERIC_UA };

--- a/src/utils/privacy/agentMasker.test.js
+++ b/src/utils/privacy/agentMasker.test.js
@@ -1,0 +1,331 @@
+"use strict";
+
+/**
+ * Canonical unit test for src/utils/privacy/agentMasker.js
+ *
+ * Directly exercises the real production module — no mocks, no stubs.
+ * Exits with code 0 on complete success; code 1 on any assertion failure.
+ */
+
+const assert = require("assert");
+const { maskUserAgent, GENERIC_UA } = require("./agentMasker");
+
+let totalPassed = 0;
+let totalFailed = 0;
+
+function runTest(label, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${label}`);
+    totalPassed++;
+  } catch (err) {
+    console.error(`  FAIL  ${label}`);
+    console.error(`        ${err.message}`);
+    totalFailed++;
+  }
+}
+
+// ── Real-world User-Agent fixtures ────────────────────────────────────────────
+
+const CHROME_WIN =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
+  "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.6167.85 Safari/537.36";
+
+const CHROME_MAC =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
+  "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.6099.234 Safari/537.36";
+
+const EDGE_WIN =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
+  "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 " +
+  "Safari/537.36 Edg/121.0.2277.128";
+
+const FIREFOX_WIN =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:123.0) " +
+  "Gecko/20100101 Firefox/123.0";
+
+const OPERA_WIN =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
+  "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 " +
+  "Safari/537.36 OPR/105.0.4970.48";
+
+const SAMSUNG_MOBILE =
+  "Mozilla/5.0 (Linux; Android 13; SM-S908B) " +
+  "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.5615.136 " +
+  "Mobile Safari/537.36 SamsungBrowser/21.0.1.1";
+
+const FIREFOX_IOS =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 16_5 like Mac OS X) " +
+  "AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/114.1 Mobile/15E148";
+
+const CHROME_IOS =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 16_5 like Mac OS X) " +
+  "AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/114.0.5735.99 " +
+  "Mobile/15E148 Safari/604.1";
+
+// ── Suite 1: Chrome — 4-segment build ID stripped ─────────────────────────────
+
+console.log("\n[Suite 1] Chrome — precise build version stripped to major.0");
+
+runTest(
+  "Chrome Windows UA: build ID .6167.85 is removed",
+  () => {
+    const result = maskUserAgent(CHROME_WIN);
+    assert.ok(!result.includes("121.0.6167"),
+      `Specific build must be stripped. Got: ${result}`);
+    assert.ok(result.includes("Chrome/121.0"),
+      `Major.0 token must be present. Got: ${result}`);
+  }
+);
+
+runTest(
+  "Chrome macOS UA: .6099.234 build stripped to Chrome/120.0",
+  () => {
+    const result = maskUserAgent(CHROME_MAC);
+    assert.ok(!result.includes("120.0.6099"),
+      `Specific build must be stripped. Got: ${result}`);
+    assert.ok(result.includes("Chrome/120.0"),
+      `Chrome/120.0 must be present. Got: ${result}`);
+  }
+);
+
+runTest(
+  "Chrome UA: AppleWebKit/537.36 constant is preserved unchanged",
+  () => {
+    const result = maskUserAgent(CHROME_WIN);
+    assert.ok(result.includes("AppleWebKit/537.36"),
+      `Static AppleWebKit token must be preserved. Got: ${result}`);
+  }
+);
+
+runTest(
+  "Chrome UA: trailing Safari/537.36 constant is preserved unchanged",
+  () => {
+    const result = maskUserAgent(CHROME_WIN);
+    assert.ok(result.includes("Safari/537.36"),
+      `Static Safari compatibility token must be preserved. Got: ${result}`);
+  }
+);
+
+runTest(
+  "Chrome UA: Mozilla/5.0 prefix is preserved",
+  () => {
+    const result = maskUserAgent(CHROME_WIN);
+    assert.ok(result.startsWith("Mozilla/5.0"),
+      `Mozilla/5.0 prefix must be preserved. Got: ${result}`);
+  }
+);
+
+// ── Suite 2: Edge — 4-segment build ID stripped ───────────────────────────────
+
+console.log("\n[Suite 2] Edge — precise build version stripped");
+
+runTest(
+  "Edge UA: Edg/121.0.2277.128 stripped to Edg/121.0",
+  () => {
+    const result = maskUserAgent(EDGE_WIN);
+    assert.ok(!result.includes("2277"),
+      `Edge minor build must be stripped. Got: ${result}`);
+    assert.ok(result.includes("Edg/121.0"),
+      `Edg/121.0 must remain. Got: ${result}`);
+  }
+);
+
+runTest(
+  "Edge UA: Chrome/121.0.0.0 in Edge UA is also masked to Chrome/121.0",
+  () => {
+    const result = maskUserAgent(EDGE_WIN);
+    assert.ok(result.includes("Chrome/121.0"),
+      `Embedded Chrome token must be stripped too. Got: ${result}`);
+  }
+);
+
+// ── Suite 3: Firefox — 2-segment normalisation ────────────────────────────────
+
+console.log("\n[Suite 3] Firefox — 2-segment version handled correctly");
+
+runTest(
+  "Firefox/123.0 (standard release) remains Firefox/123.0",
+  () => {
+    const result = maskUserAgent(FIREFOX_WIN);
+    assert.ok(result.includes("Firefox/123.0"),
+      `Firefox major.0 must be present. Got: ${result}`);
+  }
+);
+
+runTest(
+  "Firefox UA: Gecko/20100101 constant is preserved unchanged",
+  () => {
+    const result = maskUserAgent(FIREFOX_WIN);
+    assert.ok(result.includes("Gecko/20100101"),
+      `Static Gecko token must be preserved. Got: ${result}`);
+  }
+);
+
+runTest(
+  "Hypothetical Firefox/123.5 minor version stripped to 123.0",
+  () => {
+    const ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:123.5) Gecko/20100101 Firefox/123.5";
+    const result = maskUserAgent(ua);
+    assert.ok(!result.includes("Firefox/123.5"),
+      `Firefox/123.5 must be masked. Got: ${result}`);
+    assert.ok(result.includes("Firefox/123.0"),
+      `Firefox/123.0 must appear. Got: ${result}`);
+  }
+);
+
+// ── Suite 4: Opera — 3/4-segment stripping ────────────────────────────────────
+
+console.log("\n[Suite 4] Opera / OPR — 4-segment build stripped");
+
+runTest(
+  "OPR/105.0.4970.48 stripped to OPR/105.0",
+  () => {
+    const result = maskUserAgent(OPERA_WIN);
+    assert.ok(!result.includes("4970"),
+      `OPR build number must be stripped. Got: ${result}`);
+    assert.ok(result.includes("OPR/105.0"),
+      `OPR/105.0 must remain. Got: ${result}`);
+  }
+);
+
+// ── Suite 5: Mobile browsers ──────────────────────────────────────────────────
+
+console.log("\n[Suite 5] Mobile browsers — version tokens stripped correctly");
+
+runTest(
+  "SamsungBrowser/21.0.1.1 stripped to SamsungBrowser/21.0",
+  () => {
+    const result = maskUserAgent(SAMSUNG_MOBILE);
+    assert.ok(!result.includes("21.0.1.1"),
+      `SamsungBrowser build must be stripped. Got: ${result}`);
+    assert.ok(result.includes("SamsungBrowser/21.0"),
+      `SamsungBrowser/21.0 must remain. Got: ${result}`);
+  }
+);
+
+runTest(
+  "FxiOS/114.1 (Firefox for iOS) normalised to FxiOS/114.0",
+  () => {
+    const result = maskUserAgent(FIREFOX_IOS);
+    assert.ok(result.includes("FxiOS/114.0"),
+      `FxiOS must be normalised. Got: ${result}`);
+  }
+);
+
+runTest(
+  "CriOS/114.0.5735.99 (Chrome for iOS) stripped to CriOS/114.0",
+  () => {
+    const result = maskUserAgent(CHROME_IOS);
+    assert.ok(!result.includes("5735"),
+      `CriOS build must be stripped. Got: ${result}`);
+    assert.ok(result.includes("CriOS/114.0"),
+      `CriOS/114.0 must remain. Got: ${result}`);
+  }
+);
+
+// ── Suite 6: Output contains no specific patch or build numbers ───────────────
+
+console.log("\n[Suite 6] Masked output contains zero fingerprinting build tokens");
+
+runTest(
+  "Masked Chrome UA has no 3-or-more-segment version anywhere",
+  () => {
+    const result = maskUserAgent(CHROME_WIN);
+    const threeSegment = /\/\d+\.\d+\.\d+/.test(result);
+    assert.ok(!threeSegment,
+      `Masked output must not contain X.Y.Z version tokens. Got: ${result}`);
+  }
+);
+
+runTest(
+  "Masked Edge UA has no 3-or-more-segment version anywhere",
+  () => {
+    const result = maskUserAgent(EDGE_WIN);
+    const threeSegment = /\/\d+\.\d+\.\d+/.test(result);
+    assert.ok(!threeSegment,
+      `Masked output must not contain X.Y.Z version tokens. Got: ${result}`);
+  }
+);
+
+runTest(
+  "Masked Opera UA has no 3-or-more-segment version anywhere",
+  () => {
+    const result = maskUserAgent(OPERA_WIN);
+    const threeSegment = /\/\d+\.\d+\.\d+/.test(result);
+    assert.ok(!threeSegment,
+      `Masked output must not contain X.Y.Z version tokens. Got: ${result}`);
+  }
+);
+
+// ── Suite 7: Bad-input boundary handling ─────────────────────────────────────
+
+console.log("\n[Suite 7] Bad-input boundaries → GENERIC_UA fallback without throwing");
+
+runTest(
+  "null → GENERIC_UA",
+  () => assert.strictEqual(maskUserAgent(null), GENERIC_UA)
+);
+
+runTest(
+  "undefined → GENERIC_UA",
+  () => assert.strictEqual(maskUserAgent(undefined), GENERIC_UA)
+);
+
+runTest(
+  "empty string → GENERIC_UA",
+  () => assert.strictEqual(maskUserAgent(""), GENERIC_UA)
+);
+
+runTest(
+  "whitespace-only string → GENERIC_UA",
+  () => assert.strictEqual(maskUserAgent("   "), GENERIC_UA)
+);
+
+runTest(
+  "number input → GENERIC_UA",
+  () => assert.strictEqual(maskUserAgent(42), GENERIC_UA)
+);
+
+runTest(
+  "boolean input → GENERIC_UA",
+  () => assert.strictEqual(maskUserAgent(true), GENERIC_UA)
+);
+
+runTest(
+  "array input → GENERIC_UA",
+  () => assert.strictEqual(maskUserAgent(["Mozilla/5.0"]), GENERIC_UA)
+);
+
+runTest(
+  "object input → GENERIC_UA",
+  () => assert.strictEqual(maskUserAgent({ ua: "Mozilla" }), GENERIC_UA)
+);
+
+runTest(
+  "GENERIC_UA constant is a non-empty string starting with Mozilla/5.0",
+  () => {
+    assert.ok(typeof GENERIC_UA === "string" && GENERIC_UA.length > 0,
+      "GENERIC_UA must be a non-empty string");
+    assert.ok(GENERIC_UA.startsWith("Mozilla/5.0"),
+      "GENERIC_UA must start with Mozilla/5.0 for structural validity");
+  }
+);
+
+// ── Final result ──────────────────────────────────────────────────────────────
+
+const divider = "─".repeat(62);
+console.log(`\n${divider}`);
+
+if (totalFailed === 0) {
+  console.log(
+    `[PASS] All ${totalPassed} assertions passed.` +
+    ` User-Agent masker contract fully verified.`
+  );
+  process.exit(0);
+} else {
+  console.error(
+    `[FAIL] ${totalFailed} of ${totalPassed + totalFailed} assertions failed.`
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
## Description

Adds `maskUserAgent(userAgentString)` to `src/utils/privacy/agentMasker.js` — converts granular, build-specific UA strings into generic high-level identifiers to protect clients against browser fingerprinting.

**Three-pass masking strategy:**
1. **4-segment versions** `X.Y.Z.W` → `X.0` (e.g. `Chrome/121.0.6167.85` → `Chrome/121.0`)
2. **3-segment versions** `X.Y.Z` → `X.0` (e.g. `OPR/105.0.4970` → `OPR/105.0`)
3. **Known variable 2-segment browser names** `X.Y` → `X.0` (e.g. `Firefox/123.5` → `Firefox/123.0`)

Static constant tokens (`AppleWebKit/537.36`, `Gecko/20100101`, `Safari/537.36`) are left unchanged — they carry no per-user entropy.

**Safe-fallback:** `null` / `undefined` / non-string / empty → `"Mozilla/5.0 (compatible; Generic Browser)"`

---

## 📌 Impact Map (Required)

- Routes touched: [x] None — utility layer only
- API / schema / type changes: [x] None
- Cache keys touched: [x] None
- Mobile parity impacts: [x] None — pure Node.js utility
- Docs updated: [x] None — contract documented in JSDoc
- Verification: [x] `node src/utils/privacy/agentMasker.test.js`

---

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: importable by any Next.js API route or middleware
- [ ] iOS / Android: N/A

---

## 🧪 Testing — 26/26 assertions, exit code 0

```
$ node src/utils/privacy/agentMasker.test.js

[Suite 1] Chrome — precise build version stripped to major.0
  PASS  Chrome Windows UA: build ID .6167.85 is removed
  PASS  Chrome macOS UA: .6099.234 build stripped to Chrome/120.0
  PASS  Chrome UA: AppleWebKit/537.36 constant is preserved unchanged
  PASS  Chrome UA: trailing Safari/537.36 constant is preserved unchanged
  PASS  Chrome UA: Mozilla/5.0 prefix is preserved

[Suite 2] Edge — precise build version stripped
  PASS  Edge UA: Edg/121.0.2277.128 stripped to Edg/121.0
  PASS  Edge UA: Chrome/121.0.0.0 in Edge UA is also masked to Chrome/121.0

[Suite 3] Firefox — 2-segment version handled correctly
  PASS  Firefox/123.0 (standard release) remains Firefox/123.0
  PASS  Firefox UA: Gecko/20100101 constant is preserved unchanged
  PASS  Hypothetical Firefox/123.5 minor version stripped to 123.0

[Suite 4] Opera / OPR — 4-segment build stripped
  PASS  OPR/105.0.4970.48 stripped to OPR/105.0

[Suite 5] Mobile browsers — version tokens stripped correctly
  PASS  SamsungBrowser/21.0.1.1 stripped to SamsungBrowser/21.0
  PASS  FxiOS/114.1 (Firefox for iOS) normalised to FxiOS/114.0
  PASS  CriOS/114.0.5735.99 (Chrome for iOS) stripped to CriOS/114.0

[Suite 6] Masked output contains zero fingerprinting build tokens
  PASS  Masked Chrome UA has no 3-or-more-segment version anywhere
  PASS  Masked Edge UA has no 3-or-more-segment version anywhere
  PASS  Masked Opera UA has no 3-or-more-segment version anywhere

[Suite 7] Bad-input boundaries → GENERIC_UA fallback without throwing
  PASS  null → GENERIC_UA
  PASS  undefined → GENERIC_UA
  PASS  empty string → GENERIC_UA
  PASS  whitespace-only string → GENERIC_UA
  PASS  number input → GENERIC_UA
  PASS  boolean input → GENERIC_UA
  PASS  array input → GENERIC_UA
  PASS  object input → GENERIC_UA
  PASS  GENERIC_UA constant is a non-empty string starting with Mozilla/5.0

──────────────────────────────────────────────────────────────
[PASS] All 26 assertions passed. User-Agent masker contract fully verified.

Exit code: 0
```

| Suite | Cases | What is proven |
|---|---|---|
| 1 — Chrome | 5 | 4-segment build stripped; AppleWebKit/Safari/Mozilla constants preserved |
| 2 — Edge | 2 | `Edg/` and embedded `Chrome/` in Edge UA both stripped |
| 3 — Firefox | 3 | Standard release unchanged; hypothetical minor stripped; Gecko constant preserved |
| 4 — Opera | 1 | OPR 4-segment build stripped |
| 5 — Mobile | 3 | SamsungBrowser, FxiOS, CriOS all stripped correctly |
| 6 — Zero residual fingerprint | 3 | Regex confirms no X.Y.Z patterns survive in masked output |
| 7 — Bad-input safety | 9 | `null`/`undefined`/empty/whitespace/number/boolean/array/object + GENERIC_UA shape |

- [x] `Signed-off-by` trailer present (`git commit -s`)
- [x] **1 commit · 2 files · based on current `main`** — zero stacked diff