### PR TITLE
feat(consent): implement strict consent boolean normalizer with secure-default posture

### DIFF
--- a/src/utils/consent/boolNormalizer.js
+++ b/src/utils/consent/boolNormalizer.js
@@ -1,0 +1,49 @@
+"use strict";
+
+/**
+ * The exact string tokens that are treated as an affirmative consent signal.
+ * Comparison is performed case-insensitively on a trimmed copy of the input.
+ *
+ * Anything not in this set — including "false", "no", "off", "0", empty
+ * strings, and all non-string / non-numeric types — resolves to false under
+ * the secure-default posture.
+ */
+const TRUTHY_STRING_TOKENS = new Set(["true", "on", "yes", "1"]);
+
+/**
+ * normalizeConsentBool(value)
+ *
+ * Coerces fuzzy or loosely-typed incoming consent-metadata values into a
+ * strict native JavaScript boolean, applying a secure-default posture:
+ *
+ *   → true   :  true (boolean), 1 (number),
+ *               "true" | "on" | "yes" | "1"  (case-insensitive, trimmed)
+ *
+ *   → false  :  everything else — including false, 0, null, undefined,
+ *               empty string, "false", "no", "off", "0", objects, arrays
+ *
+ * The output is always a native boolean (typeof result === "boolean"),
+ * never a truthy/falsy non-boolean.  No exceptions are thrown.
+ *
+ * @param  {*} value
+ * @returns {boolean}
+ */
+function normalizeConsentBool(value) {
+  // Native boolean — fast-path
+  if (value === true)  return true;
+  if (value === false) return false;
+
+  // Numeric flag — only the integer 1 is affirmative
+  if (value === 1) return true;
+  if (value === 0) return false;
+
+  // String token — trim and lower-case before Set lookup
+  if (typeof value === "string") {
+    return TRUTHY_STRING_TOKENS.has(value.trim().toLowerCase());
+  }
+
+  // Everything else: null, undefined, objects, arrays, NaN, … → false
+  return false;
+}
+
+module.exports = { normalizeConsentBool };

--- a/src/utils/consent/boolNormalizer.test.js
+++ b/src/utils/consent/boolNormalizer.test.js
@@ -1,0 +1,267 @@
+"use strict";
+
+/**
+ * Canonical unit test for src/utils/consent/boolNormalizer.js
+ *
+ * Directly exercises the real production module — no mocks, no stubs.
+ * Exits with code 0 on complete success; code 1 on any assertion failure.
+ */
+
+const assert = require("assert");
+const { normalizeConsentBool } = require("./boolNormalizer");
+
+let totalPassed = 0;
+let totalFailed = 0;
+
+function runTest(label, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${label}`);
+    totalPassed++;
+  } catch (err) {
+    console.error(`  FAIL  ${label}`);
+    console.error(`        ${err.message}`);
+    totalFailed++;
+  }
+}
+
+// ── Suite 1: Native boolean inputs ────────────────────────────────────────────
+
+console.log("\n[Suite 1] Native boolean inputs — pass through exactly");
+
+runTest(
+  "true  → true",
+  () => assert.strictEqual(normalizeConsentBool(true), true)
+);
+
+runTest(
+  "false → false",
+  () => assert.strictEqual(normalizeConsentBool(false), false)
+);
+
+// ── Suite 2: Numeric inputs ────────────────────────────────────────────────────
+
+console.log("\n[Suite 2] Numeric inputs — 1 is affirmative, 0 is denial");
+
+runTest(
+  "1  → true",
+  () => assert.strictEqual(normalizeConsentBool(1), true)
+);
+
+runTest(
+  "0  → false",
+  () => assert.strictEqual(normalizeConsentBool(0), false)
+);
+
+runTest(
+  "2  → false (only exact 1 is truthy)",
+  () => assert.strictEqual(normalizeConsentBool(2), false)
+);
+
+runTest(
+  "-1 → false",
+  () => assert.strictEqual(normalizeConsentBool(-1), false)
+);
+
+runTest(
+  "0.5 (float) → false",
+  () => assert.strictEqual(normalizeConsentBool(0.5), false)
+);
+
+// ── Suite 3: Truthy string tokens → true ──────────────────────────────────────
+
+console.log("\n[Suite 3] Truthy string tokens → true");
+
+runTest(
+  '"true"  → true',
+  () => assert.strictEqual(normalizeConsentBool("true"), true)
+);
+
+runTest(
+  '"TRUE"  → true  (case-insensitive)',
+  () => assert.strictEqual(normalizeConsentBool("TRUE"), true)
+);
+
+runTest(
+  '"True"  → true  (mixed case)',
+  () => assert.strictEqual(normalizeConsentBool("True"), true)
+);
+
+runTest(
+  '"on"    → true',
+  () => assert.strictEqual(normalizeConsentBool("on"), true)
+);
+
+runTest(
+  '"ON"    → true  (case-insensitive)',
+  () => assert.strictEqual(normalizeConsentBool("ON"), true)
+);
+
+runTest(
+  '"yes"   → true',
+  () => assert.strictEqual(normalizeConsentBool("yes"), true)
+);
+
+runTest(
+  '"YES"   → true  (case-insensitive)',
+  () => assert.strictEqual(normalizeConsentBool("YES"), true)
+);
+
+runTest(
+  '"1"     → true  (numeric string)',
+  () => assert.strictEqual(normalizeConsentBool("1"), true)
+);
+
+runTest(
+  '"  true  " → true  (leading/trailing whitespace trimmed)',
+  () => assert.strictEqual(normalizeConsentBool("  true  "), true)
+);
+
+runTest(
+  '"  ON  "   → true  (whitespace + case)',
+  () => assert.strictEqual(normalizeConsentBool("  ON  "), true)
+);
+
+// ── Suite 4: Falsy string tokens → false ──────────────────────────────────────
+
+console.log("\n[Suite 4] Falsy string tokens → false  (secure-default posture)");
+
+runTest(
+  '"false" → false',
+  () => assert.strictEqual(normalizeConsentBool("false"), false)
+);
+
+runTest(
+  '"FALSE" → false',
+  () => assert.strictEqual(normalizeConsentBool("FALSE"), false)
+);
+
+runTest(
+  '"off"   → false',
+  () => assert.strictEqual(normalizeConsentBool("off"), false)
+);
+
+runTest(
+  '"no"    → false',
+  () => assert.strictEqual(normalizeConsentBool("no"), false)
+);
+
+runTest(
+  '"0"     → false',
+  () => assert.strictEqual(normalizeConsentBool("0"), false)
+);
+
+runTest(
+  'empty string "" → false',
+  () => assert.strictEqual(normalizeConsentBool(""), false)
+);
+
+runTest(
+  'whitespace-only "   " → false',
+  () => assert.strictEqual(normalizeConsentBool("   "), false)
+);
+
+runTest(
+  '"yes " with trailing space → true  (trimmed before lookup)',
+  () => assert.strictEqual(normalizeConsentBool("yes "), true)
+);
+
+runTest(
+  '"random" unrecognised string → false',
+  () => assert.strictEqual(normalizeConsentBool("random"), false)
+);
+
+// ── Suite 5: Null and undefined — secure default → false ─────────────────────
+
+console.log("\n[Suite 5] null / undefined → false  (missing consent = no consent)");
+
+runTest(
+  "null      → false",
+  () => assert.strictEqual(normalizeConsentBool(null), false)
+);
+
+runTest(
+  "undefined → false",
+  () => assert.strictEqual(normalizeConsentBool(undefined), false)
+);
+
+// ── Suite 6: Non-string / non-numeric types → false ───────────────────────────
+
+console.log("\n[Suite 6] Objects, arrays, and other exotic types → false");
+
+runTest(
+  "object {}          → false",
+  () => assert.strictEqual(normalizeConsentBool({}), false)
+);
+
+runTest(
+  "array [true]       → false  (array is not a valid signal)",
+  () => assert.strictEqual(normalizeConsentBool([true]), false)
+);
+
+runTest(
+  "array [1]          → false",
+  () => assert.strictEqual(normalizeConsentBool([1]), false)
+);
+
+runTest(
+  "NaN               → false",
+  () => assert.strictEqual(normalizeConsentBool(NaN), false)
+);
+
+runTest(
+  "Infinity          → false",
+  () => assert.strictEqual(normalizeConsentBool(Infinity), false)
+);
+
+runTest(
+  "function () {}    → false",
+  () => assert.strictEqual(normalizeConsentBool(() => {}), false)
+);
+
+// ── Suite 7: Return type is always a strict native boolean ────────────────────
+
+console.log("\n[Suite 7] Output is always typeof === \"boolean\" — never truthy/falsy non-boolean");
+
+runTest(
+  'typeof normalizeConsentBool("true") === "boolean"',
+  () => assert.strictEqual(typeof normalizeConsentBool("true"), "boolean")
+);
+
+runTest(
+  "typeof normalizeConsentBool(1) === \"boolean\"",
+  () => assert.strictEqual(typeof normalizeConsentBool(1), "boolean")
+);
+
+runTest(
+  "typeof normalizeConsentBool(null) === \"boolean\"",
+  () => assert.strictEqual(typeof normalizeConsentBool(null), "boolean")
+);
+
+runTest(
+  "typeof normalizeConsentBool(undefined) === \"boolean\"",
+  () => assert.strictEqual(typeof normalizeConsentBool(undefined), "boolean")
+);
+
+runTest(
+  "typeof normalizeConsentBool({}) === \"boolean\"",
+  () => assert.strictEqual(typeof normalizeConsentBool({}), "boolean")
+);
+
+// ── Final result ──────────────────────────────────────────────────────────────
+
+const divider = "─".repeat(62);
+console.log(`\n${divider}`);
+
+if (totalFailed === 0) {
+  console.log(
+    `[PASS] All ${totalPassed} assertions passed.` +
+    ` Consent bool normalizer contract fully verified.`
+  );
+  process.exit(0);
+} else {
+  console.error(
+    `[FAIL] ${totalFailed} of ${totalPassed + totalFailed} assertions failed.`
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
## Description

Adds `normalizeConsentBool(value)` to `src/utils/consent/boolNormalizer.js` — coerces fuzzy incoming consent-metadata values into a strict native JavaScript boolean.

**Secure-default posture — everything not explicitly truthy resolves to `false`.**

| Input | Output |
|---|---|
| `true`, `1` | `true` |
| `"true"`, `"on"`, `"yes"`, `"1"` (case-insensitive, trimmed) | `true` |
| `false`, `0` | `false` |
| `null`, `undefined`, `""`, `"false"`, `"no"`, `"off"`, `"0"` | `false` |
| Objects, arrays, NaN, Infinity, functions, any other type | `false` |

Output is always `typeof === "boolean"` — never a truthy/falsy non-boolean.

---

## 📌 Impact Map (Required)

- Routes touched: [x] None — utility layer only
- API / schema / type changes: [x] None
- Cache keys touched: [x] None
- Mobile parity impacts: [x] None — pure Node.js utility
- Docs updated: [x] None — contract documented in JSDoc
- Verification: [x] `node src/utils/consent/boolNormalizer.test.js`

---

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: importable by any Next.js API route or server action
- [ ] iOS / Android: N/A

---

## 🧪 Testing — 39/39 assertions, exit code 0

```
$ node src/utils/consent/boolNormalizer.test.js

[Suite 1] Native boolean inputs — pass through exactly
  PASS  true  → true
  PASS  false → false

[Suite 2] Numeric inputs — 1 is affirmative, 0 is denial
  PASS  1  → true
  PASS  0  → false
  PASS  2  → false (only exact 1 is truthy)
  PASS  -1 → false
  PASS  0.5 (float) → false

[Suite 3] Truthy string tokens → true
  PASS  "true"  → true
  PASS  "TRUE"  → true  (case-insensitive)
  PASS  "True"  → true  (mixed case)
  PASS  "on"    → true
  PASS  "ON"    → true  (case-insensitive)
  PASS  "yes"   → true
  PASS  "YES"   → true  (case-insensitive)
  PASS  "1"     → true  (numeric string)
  PASS  "  true  " → true  (leading/trailing whitespace trimmed)
  PASS  "  ON  "   → true  (whitespace + case)

[Suite 4] Falsy string tokens → false  (secure-default posture)
  PASS  "false" → false
  PASS  "FALSE" → false
  PASS  "off"   → false
  PASS  "no"    → false
  PASS  "0"     → false
  PASS  empty string "" → false
  PASS  whitespace-only "   " → false
  PASS  "yes " with trailing space → true  (trimmed before lookup)
  PASS  "random" unrecognised string → false

[Suite 5] null / undefined → false  (missing consent = no consent)
  PASS  null      → false
  PASS  undefined → false

[Suite 6] Objects, arrays, and other exotic types → false
  PASS  object {}          → false
  PASS  array [true]       → false  (array is not a valid signal)
  PASS  array [1]          → false
  PASS  NaN               → false
  PASS  Infinity          → false
  PASS  function () {}    → false

[Suite 7] Output is always typeof === "boolean" — never truthy/falsy non-boolean
  PASS  typeof normalizeConsentBool("true") === "boolean"
  PASS  typeof normalizeConsentBool(1) === "boolean"
  PASS  typeof normalizeConsentBool(null) === "boolean"
  PASS  typeof normalizeConsentBool(undefined) === "boolean"
  PASS  typeof normalizeConsentBool({}) === "boolean"

──────────────────────────────────────────────────────────────
[PASS] All 39 assertions passed. Consent bool normalizer contract fully verified.

Exit code: 0
```

| Suite | Cases | What is proven |
|---|---|---|
| 1 — Native boolean | 2 | Native `true`/`false` pass through exactly |
| 2 — Numeric | 5 | Only exact `1` is truthy; `0`, `2`, `-1`, `0.5` → false |
| 3 — Truthy strings | 10 | `"true"/"TRUE"/"True"`, `"on"/"ON"`, `"yes"/"YES"`, `"1"`, whitespace trim |
| 4 — Falsy strings | 9 | `"false"`, `"off"`, `"no"`, `"0"`, empty, whitespace, unrecognised |
| 5 — null/undefined | 2 | Missing consent = no consent |
| 6 — Exotic types | 6 | Objects, arrays, `NaN`, `Infinity`, functions → false |
| 7 — Return type | 5 | `typeof` is always `"boolean"` for any input |

- [x] `Signed-off-by` trailer present (`git commit -s`)
- [x] **1 commit · 2 files · based on current `main`** — zero stacked diff
- [x] Zero external dependencies