### PR TITLE
fix(frontend): add missing aria-label to icon-only buttons in manage portfolio view

### DIFF
--- a/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
+++ b/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
@@ -642,33 +642,35 @@ export function ManagePortfolioView() {
                             </div>
                             <div className="flex items-center gap-3 ml-4 border-l border-primary/10 pl-4">
                               <div className="flex flex-col items-center gap-1">
-                                <Button
-                                  variant="none"
-                                  effect="glass"
-                                  size="icon-sm"
-                                  className={cn(
-                                    "h-10 w-10 text-muted-foreground hover:text-primary transition-all duration-300 rounded-xl",
-                                    holding.pending_delete && "pointer-events-none opacity-50"
-                                  )}
-                                  onClick={() => handleEditHolding(actualIndex)}
-                                  icon={{ icon: Pencil }}
-                                />
+                                  <Button
+                                    variant="none"
+                                    effect="glass"
+                                    size="icon-sm"
+                                    className={cn(
+                                      "h-10 w-10 text-muted-foreground hover:text-primary transition-all duration-300 rounded-xl",
+                                      holding.pending_delete && "pointer-events-none opacity-50"
+                                    )}
+                                    onClick={() => handleEditHolding(actualIndex)}
+                                    icon={{ icon: Pencil }}
+                                    aria-label={`Edit ${holding.symbol} holding`}
+                                  />
                                 <Kbd className="text-[8px] px-1 h-3.5">EDIT</Kbd>
                               </div>
                               <div className="flex flex-col items-center gap-1">
-                                <Button
-                                  variant="none"
-                                  effect="glass"
-                                  size="icon-sm"
-                                  className={cn(
-                                    "h-10 w-10 transition-all duration-300 rounded-xl",
-                                    holding.pending_delete
-                                      ? "text-emerald-500 hover:text-emerald-600 hover:bg-emerald-50"
-                                      : "text-red-400 hover:text-red-500 hover:bg-red-50"
-                                  )}
-                                  onClick={() => handleDeleteHolding(actualIndex)}
-                                  icon={{ icon: holding.pending_delete ? Undo2 : Trash2 }}
-                                />
+                                  <Button
+                                    variant="none"
+                                    effect="glass"
+                                    size="icon-sm"
+                                    className={cn(
+                                      "h-10 w-10 transition-all duration-300 rounded-xl",
+                                      holding.pending_delete
+                                        ? "text-emerald-500 hover:text-emerald-600 hover:bg-emerald-50"
+                                        : "text-red-400 hover:text-red-500 hover:bg-red-50"
+                                    )}
+                                    onClick={() => handleDeleteHolding(actualIndex)}
+                                    icon={{ icon: holding.pending_delete ? Undo2 : Trash2 }}
+                                    aria-label={holding.pending_delete ? `Undo delete ${holding.symbol}` : `Delete ${holding.symbol} holding`}
+                                  />
                                 <Kbd className="text-[8px] px-1 h-3.5">
                                   {holding.pending_delete ? "UNDO" : "DEL"}
                                 </Kbd>


### PR DESCRIPTION
# Description
Added missing `aria-label` attributes to the icon-only "Edit" and "Delete/Undo" buttons in the manage portfolio view. This is a tiny, safe accessibility improvement that ensures screen readers can announce the button actions clearly without affecting any logic or rendering.

## 📌 Impact Map (Required)
- Routes touched:
  - [x] Listed below: `/kai/manage-portfolio-view` (UI component only)
- API / schema / type changes: [x] None
- Cache keys touched: [x] None
- Runtime DB data-plane changes: [x] None
- World-model domain summary effects: [x] None
- Mobile parity impacts: [x] None
- Docs updated (exact files): [x] None
- Top-level / devex / config / generated / ignore files touched: [x] None
- Trust boundary touched: [x] None
- Caller / proxy / backend pairing: [x] Not applicable
- Rollback or safe-failure behavior: [x] Not applicable
- UI browser or Playwright proof: [x] Not applicable
- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm run build`

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] Reachable production attach point: `ManagePortfolioView` component.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation (`app/api/...`)

## 🧪 Testing
- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video
No visual changes made (purely an accessibility markup fix for screen readers).

## 🛡️ Privacy & Consent
- [x] Does this change access user data? **No**
- [x] Sensitive surface touched: **none**

## 📜 Licensing
- [x] First-party changes remain Apache-2.0 compatible