### PR TITLE
fix(frontend): add missing aria-label to expand round tabs button

### DIFF
--- a/hushh-webapp/components/kai/views/round-tabs-card.tsx
+++ b/hushh-webapp/components/kai/views/round-tabs-card.tsx
@@ -159,6 +159,7 @@ export function RoundTabsCard({
               size="icon-sm"
               showRipple={false}
               onClick={onToggleCollapse}
+              aria-label={isCollapsed ? "Expand round details" : "Collapse round details"}
             >
               {isCollapsed ? <Icon icon={ChevronDown} size="sm" /> : <Icon icon={ChevronUp} size="sm" />}
             </MorphyButton>


### PR DESCRIPTION
# Description
Added missing `aria-label` to the expand/collapse icon button in the `RoundTabsCard` component. This tiny accessibility fix (1 line) ensures screen readers can announce whether the button expands or collapses the analysis round details without affecting logic or visual design.

## 📌 Impact Map (Required)
- Routes touched:
  - [x] Listed below: `/kai/round-tabs-card` (UI component only)
- API / schema / type changes: [x] None
- Cache keys touched: [x] None
- Runtime DB data-plane changes: [x] None
- World-model domain summary effects: [x] None
- Mobile parity impacts: [x] None
- Docs updated (exact files): [x] None
- Top-level / devex / config / generated / ignore files touched: [x] None
- Trust boundary touched: [x] None
- Caller / proxy / backend pairing: [x] Not applicable
- Rollback or safe-failure behavior: [x] Not applicable
- UI browser or Playwright proof: [x] Not applicable
- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm run build`

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] Reachable production attach point: `RoundTabsCard` component.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `integration/pr-train`.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation (`app/api/...`)

## 🧪 Testing
- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video
No visual changes made (purely an accessibility markup fix for screen readers).

## 🛡️ Privacy & Consent
- [x] Does this change access user data? **No**
- [x] Sensitive surface touched: **none**

## 📜 Licensing
- [x] First-party changes remain Apache-2.0 compatible