### PR TITLE
fix(frontend): add missing accessibility attributes to form inputs and buttons

### DIFF
--- a/hushh-webapp/components/kai/modals/edit-holding-modal.tsx
+++ b/hushh-webapp/components/kai/modals/edit-holding-modal.tsx
@@ -473,11 +473,12 @@ export function EditHoldingModal({
 
           {/* Name */}
           <div>
-            <label className="block text-sm font-medium mb-1">
+            <label htmlFor="holding-name" className="block text-sm font-medium mb-1">
               Company Name <span className="text-red-500">*</span>
             </label>
             <div ref={nameInputWrapRef} className="relative">
               <input
+                id="holding-name"
                 type="text"
                 value={formData.name}
                 onChange={(e) => handleChange("name", e.target.value)}
@@ -533,10 +534,11 @@ export function EditHoldingModal({
           {/* Quantity & Price Row */}
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="block text-sm font-medium mb-1">
+              <label htmlFor="holding-quantity" className="block text-sm font-medium mb-1">
                 Quantity <span className="text-red-500">*</span>
               </label>
 	              <input
+                id="holding-quantity"
                 type="number"
                 value={formData.quantity || ""}
                 onChange={(e) => handleChange("quantity", parseFloat(e.target.value) || 0)}
@@ -556,10 +558,11 @@ export function EditHoldingModal({
             </div>
 
             <div>
-              <label className="block text-sm font-medium mb-1">
+              <label htmlFor="holding-price" className="block text-sm font-medium mb-1">
                 Price <span className="text-red-500">*</span>
               </label>
 	              <input
+                id="holding-price"
                 type="number"
                 value={formData.price || ""}
                 onChange={(e) => handleChange("price", parseFloat(e.target.value) || 0)}
@@ -581,10 +584,11 @@ export function EditHoldingModal({
 
           {/* Market Value (calculated, read-only) */}
           <div>
-            <label className="block text-sm text-muted-foreground font-medium mb-1">
+            <label htmlFor="holding-market-value" className="block text-sm text-muted-foreground font-medium mb-1">
               Market Value (Auto-calculated)
             </label>
             <input
+              id="holding-market-value"
               type="text"
               value={`$${formData.market_value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}
               readOnly
@@ -600,10 +604,11 @@ export function EditHoldingModal({
 
           {/* Cost Basis */}
           <div>
-            <label className="block text-sm font-medium mb-1">
+            <label htmlFor="holding-cost-basis" className="block text-sm font-medium mb-1">
               Cost Basis (Total)
             </label>
             <input
+              id="holding-cost-basis"
               type="number"
               value={formData.cost_basis || ""}
               onChange={(e) => handleChange("cost_basis", parseFloat(e.target.value) || 0)}
@@ -619,11 +624,12 @@ export function EditHoldingModal({
 
           {/* Acquisition Date */}
           <div>
-            <label className="block text-sm font-medium mb-1">
+            <label htmlFor="holding-acquisition-date" className="block text-sm font-medium mb-1">
               Acquisition Date
             </label>
             <div className="relative">
               <input
+                id="holding-acquisition-date"
                 type="text"
                 value={formatAcquisitionDate(formData.acquisition_date)}
                 placeholder="MM/DD/YYYY"

--- a/hushh-webapp/components/kai/views/analysis-history-dashboard.tsx
+++ b/hushh-webapp/components/kai/views/analysis-history-dashboard.tsx
@@ -1140,6 +1140,7 @@ export function AnalysisHistoryDashboard({
                       className="h-9 w-9 shrink-0 border border-transparent text-red-600 hover:border-red-500/30 hover:bg-red-500/10 dark:text-red-400"
                       onClick={() => setPendingDelete({ kind: "entry", entry })}
                       title="Delete this version"
+                      aria-label="Delete this version"
                     >
                       <Icon icon={Trash2} size="sm" />
                     </Button>


### PR DESCRIPTION
# Description
A bulk accessibility cleanup across multiple components:
1. **`edit-holding-modal.tsx`**: Added missing `id` and `htmlFor` pairings to the remaining 6 form inputs (Name, Quantity, Price, Market Value, Cost Basis, Acquisition Date) so screen readers can correctly associate the labels with their input fields.
2. **`analysis-history-dashboard.tsx`**: Added missing `aria-label` to the "Delete Version" icon-only button for screen reader context.

These are safe, markup-only changes that do not alter application logic or visual rendering.

## 📌 Impact Map (Required)
- Routes touched:
  - [x] Listed below: UI Modals and Dashboards
- API / schema / type changes: [x] None
- Cache keys touched: [x] None
- Runtime DB data-plane changes: [x] None
- World-model domain summary effects: [x] None
- Mobile parity impacts: [x] None
- Docs updated (exact files): [x] None
- Top-level / devex / config / generated / ignore files touched: [x] None
- Trust boundary touched: [x] None
- Caller / proxy / backend pairing: [x] Not applicable
- Rollback or safe-failure behavior: [x] Not applicable
- UI browser or Playwright proof: [x] Not applicable
- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm run lint`
  - [x] `cd hushh-webapp && npm run build`

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] Reachable production attach point: `EditHoldingModal` and `AnalysisHistoryDashboard`.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `integration/pr-train`.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation (`app/api/...`)

## 🧪 Testing
- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video
No visual changes made (purely an accessibility markup fix for screen readers).

## 🛡️ Privacy & Consent
- [x] Does this change access user data? **No**
- [x] Sensitive surface touched: **none**

## 📜 Licensing
- [x] First-party changes remain Apache-2.0 compatible