### PR TITLE
fix(test): normalize CRLF to LF in read() helper for Windows compatib…

### DIFF
--- a/hushh-webapp/__tests__/components/top-app-bar.contract.test.ts
+++ b/hushh-webapp/__tests__/components/top-app-bar.contract.test.ts
@@ -6,7 +6,9 @@ import { describe, expect, it } from "vitest";
 const WEBAPP_ROOT = path.resolve(__dirname, "../..");
 
 function read(relativePath: string) {
-  return fs.readFileSync(path.join(WEBAPP_ROOT, relativePath), "utf8");
+  return fs
+    .readFileSync(path.join(WEBAPP_ROOT, relativePath), "utf8")
+    .replace(/\r\n/g, "\n");
 }
 
 describe("Top app bar responsive contract", () => {


### PR DESCRIPTION
## Description

On Windows, `git checkout` uses CRLF (`\r\n`) line endings by default.
The `read()` helper in `top-app-bar.contract.test.ts` uses `fs.readFileSync`
and the `.toContain()` assertions check for `\n` — causing the test to fail
on Windows but pass on Linux/macOS.

This fix normalizes CRLF to LF in the `read()` helper so the contract test
passes on all platforms.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Not applicable

- UI browser or Playwright proof:
  - [x] Not applicable

- Verification commands executed:
  - [x] `cd hushh-webapp && npm test`

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface, or it is explicitly scoped as test/devex hygiene.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Test-only change — no production code modified
- [x] **iOS**: Not applicable
- [x] **Android**: Not applicable

## 🧪 Testing

- [x] `cd hushh-webapp && npm test` — 939 tests passed on Windows
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Test-only change — no UI affected. All 939 tests pass on Windows after this fix.

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible