### PR TITLE
Fix/frontend disclosure button type train

### DIFF
--- a/hushh-webapp/components/kai/cards/legal-disclosures-card.tsx
+++ b/hushh-webapp/components/kai/cards/legal-disclosures-card.tsx
@@ -126,7 +126,7 @@ function DisclosureItem({ text, index: _index }: DisclosureItemProps) {
         )}
       >
         <CollapsibleTrigger asChild>
-          <button className="w-full p-3 flex items-start gap-3 text-left">
+          <button type="button" className="w-full p-3 flex items-start gap-3 text-left">
             <div
               className={cn(
                 "p-1.5 rounded-lg shrink-0 mt-0.5",


### PR DESCRIPTION
# Description

Added explicit `type="button"` to the collapsible trigger `<button>` in `legal-disclosures-card.tsx`. Without it, the button defaults to `type="submit"`, which can cause unintended form submissions if ever nested inside a `<form>`.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Not applicable

- UI browser or Playwright proof:
  - [x] Not applicable

- Verification commands executed:
  - [x] `./bin/hushh codex pre-pr`

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — `hushh-webapp/components/kai/cards/legal-disclosures-card.tsx`.
- [x] Reachable production attach point: Legal disclosures card rendered in Kai views.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: HTML attribute-only change, no iOS/Android impact.
- [x] **iOS**: Not applicable.
- [x] **Android**: Not applicable.

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

No UI-visible change — attribute-only fix on an existing `<button>` tag.

## 🛡️ Privacy & Consent

- [x] Does not access user data.
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependency changes
