### PR TITLE
Add Kai BYOK runtime contract

### DIFF
--- a/consent-protocol/api/routes/kai/agent_chat.py
+++ b/consent-protocol/api/routes/kai/agent_chat.py
@@ -16,6 +16,7 @@ from hushh_mcp.services.agent_chat_service import (
     AgentChatActionPlan,
     AgentChatConversation,
     AgentChatMessage,
+    AgentRuntimeContractError,
     PreparedAgentChatTurn,
     get_agent_chat_service,
 )
@@ -30,6 +31,8 @@ class AgentChatStreamRequest(BaseModel):
     message: str = Field(..., min_length=1, max_length=8000)
     conversation_id: Optional[str] = Field(default=None, max_length=128)
     pkm_context: Optional[str] = Field(default=None, max_length=20000)
+    runtime_credential: Optional[str] = Field(default=None, max_length=12000, exclude=True)
+    runtime_credential_mode: Optional[str] = Field(default=None, max_length=64)
 
 
 class AgentChatRenameRequest(BaseModel):
@@ -149,6 +152,10 @@ async def stream_agent_chat(
     _assert_user(token_data, body.user_id)
     service = get_agent_chat_service()
     try:
+        service.prepare_runtime_contract(
+            runtime_credential=body.runtime_credential,
+            runtime_credential_mode=body.runtime_credential_mode,
+        )
         turn = await service.prepare_turn(
             user_id=body.user_id,
             message=body.message,
@@ -159,6 +166,21 @@ async def stream_agent_chat(
             history=turn.history,
             pkm_context=body.pkm_context,
         )
+    except AgentRuntimeContractError as error:
+        logger.warning(
+            "agent_chat.runtime_contract_failed user_id=%s error_code=%s mode=%s credential_supplied=%s",
+            body.user_id,
+            error.error_code,
+            body.runtime_credential_mode,
+            bool((body.runtime_credential or "").strip()),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": error.error_code,
+                "message": error.message,
+            },
+        ) from error
     except Exception as error:
         logger.exception("agent_chat.prepare_failed user_id=%s: %s", body.user_id, error)
         raise HTTPException(status_code=500, detail="Agent chat could not be started") from error

--- a/consent-protocol/hushh_mcp/services/agent_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/agent_chat_service.py
@@ -65,6 +65,8 @@ _APP_SURFACE_ACTIONS: dict[str, tuple[str, str]] = {
 MessageRole = Literal["user", "assistant", "system", "tool"]
 MessageStatus = Literal["complete", "interrupted", "error"]
 AgentActionExecution = Literal["frontend", "blocked"]
+AgentRuntimeCredentialMode = Literal["byok", "hushh_managed_vertex"]
+DEFAULT_AGENT_RUNTIME_CREDENTIAL_MODE: AgentRuntimeCredentialMode = "hushh_managed_vertex"
 
 _STOCK_ALIAS_TO_TICKER = {
     "alphabet": "GOOGL",
@@ -247,6 +249,19 @@ class AgentChatActionPlan:
             "message": self.message,
             "reason": self.reason,
         }
+
+
+@dataclass(frozen=True)
+class AgentRuntimeContract:
+    mode: AgentRuntimeCredentialMode
+    credential_supplied: bool
+
+
+class AgentRuntimeContractError(ValueError):
+    def __init__(self, *, error_code: str, message: str):
+        super().__init__(message)
+        self.error_code = error_code
+        self.message = message
 
 
 def _iso(value: Any) -> str | None:
@@ -437,6 +452,35 @@ class AgentChatService:
                 raise RuntimeError("Gemini API key is not configured")
             self._client = genai.Client(api_key=api_key)
         return self._client
+
+    def prepare_runtime_contract(
+        self,
+        *,
+        runtime_credential: str | None = None,
+        runtime_credential_mode: str | None = None,
+    ) -> AgentRuntimeContract:
+        mode_value = (runtime_credential_mode or DEFAULT_AGENT_RUNTIME_CREDENTIAL_MODE).strip()
+        if mode_value not in {"byok", "hushh_managed_vertex"}:
+            raise AgentRuntimeContractError(
+                error_code="AGENT_RUNTIME_MODE_INVALID",
+                message="Agent runtime credential mode is invalid.",
+            )
+
+        mode = mode_value
+        secret = (runtime_credential or "").strip()
+        if mode == "byok" and not secret:
+            raise AgentRuntimeContractError(
+                error_code="AGENT_RUNTIME_CREDENTIAL_MISSING",
+                message=(
+                    "Kai needs your Gemini key to continue. Add or update it in "
+                    "Profile > Runtime keys, or switch Kai to Hushh managed Gemini."
+                ),
+            )
+
+        return AgentRuntimeContract(
+            mode=mode,
+            credential_supplied=bool(secret),
+        )
 
     async def _execute_raw(self, sql: str, params: dict[str, Any] | None = None):
         return await asyncio.to_thread(self.db.execute_raw, sql, params or {})

--- a/consent-protocol/tests/services/test_agent_chat_service.py
+++ b/consent-protocol/tests/services/test_agent_chat_service.py
@@ -7,6 +7,7 @@ from hushh_mcp.services.agent_chat_service import (
     DEFAULT_AGENT_CHAT_MODEL,
     AgentChatMessage,
     AgentChatService,
+    AgentRuntimeContractError,
 )
 
 
@@ -24,6 +25,57 @@ def test_agent_chat_service_allows_env_model_override(monkeypatch, test_vault_ke
     service = AgentChatService(vault_key_hex=test_vault_key)
 
     assert service.model == "gemini-2.5-flash"
+
+
+def test_agent_chat_runtime_contract_defaults_to_hushh_managed(test_vault_key):
+    service = AgentChatService(vault_key_hex=test_vault_key)
+
+    contract = service.prepare_runtime_contract()
+
+    assert contract.mode == "hushh_managed_vertex"
+    assert contract.credential_supplied is False
+
+
+def test_agent_chat_runtime_contract_accepts_byok_with_runtime_credential(test_vault_key):
+    service = AgentChatService(vault_key_hex=test_vault_key)
+
+    contract = service.prepare_runtime_contract(
+        runtime_credential=" USER_GEMINI_KEY ",
+        runtime_credential_mode="byok",
+    )
+
+    assert contract.mode == "byok"
+    assert contract.credential_supplied is True
+
+
+def test_agent_chat_runtime_contract_rejects_missing_byok_credential(test_vault_key):
+    service = AgentChatService(vault_key_hex=test_vault_key)
+
+    try:
+        service.prepare_runtime_contract(
+            runtime_credential=" ",
+            runtime_credential_mode="byok",
+        )
+    except AgentRuntimeContractError as error:
+        assert error.error_code == "AGENT_RUNTIME_CREDENTIAL_MISSING"
+        assert "Gemini key" in error.message
+    else:  # pragma: no cover - defensive assertion clarity
+        raise AssertionError("Expected AgentRuntimeContractError")
+
+
+def test_agent_chat_runtime_contract_rejects_invalid_mode(test_vault_key):
+    service = AgentChatService(vault_key_hex=test_vault_key)
+
+    try:
+        service.prepare_runtime_contract(
+            runtime_credential="USER_GEMINI_KEY",
+            runtime_credential_mode="unsupported",
+        )
+    except AgentRuntimeContractError as error:
+        assert error.error_code == "AGENT_RUNTIME_MODE_INVALID"
+        assert error.message == "Agent runtime credential mode is invalid."
+    else:  # pragma: no cover - defensive assertion clarity
+        raise AssertionError("Expected AgentRuntimeContractError")
 
 
 def test_agent_chat_service_decrypts_encrypted_conversation_and_message(test_vault_key):

--- a/consent-protocol/tests/test_agent_chat_routes.py
+++ b/consent-protocol/tests/test_agent_chat_routes.py
@@ -8,6 +8,7 @@ from hushh_mcp.services.agent_chat_service import (
     AgentChatActionPlan,
     AgentChatConversation,
     AgentChatMessage,
+    AgentRuntimeContractError,
     PreparedAgentChatTurn,
 )
 
@@ -16,6 +17,8 @@ class _FakeAgentChatService:
     def __init__(self):
         self.saved_messages: list[dict] = []
         self.next_action_plan: AgentChatActionPlan | None = None
+        self.prepared_turns = 0
+        self.runtime_contract_calls: list[dict] = []
         self.stream_action_plans: list[AgentChatActionPlan | None] = []
         self.stream_tokens = ["Hello", " from Gemini"]
         self.stream_error: Exception | None = None
@@ -56,10 +59,38 @@ class _FakeAgentChatService:
             ),
         ]
 
+    def prepare_runtime_contract(
+        self,
+        *,
+        runtime_credential: str | None = None,
+        runtime_credential_mode: str | None = None,
+    ):
+        self.runtime_contract_calls.append(
+            {
+                "runtime_credential": runtime_credential,
+                "runtime_credential_mode": runtime_credential_mode,
+            }
+        )
+        if runtime_credential_mode == "byok" and not (runtime_credential or "").strip():
+            raise AgentRuntimeContractError(
+                error_code="AGENT_RUNTIME_CREDENTIAL_MISSING",
+                message=(
+                    "Kai needs your Gemini key to continue. Add or update it in "
+                    "Profile > Runtime keys, or switch Kai to Hushh managed Gemini."
+                ),
+            )
+        if runtime_credential_mode not in {None, "byok", "hushh_managed_vertex"}:
+            raise AgentRuntimeContractError(
+                error_code="AGENT_RUNTIME_MODE_INVALID",
+                message="Agent runtime credential mode is invalid.",
+            )
+        return None
+
     async def prepare_turn(self, *, user_id: str, message: str, conversation_id: str | None = None):
         assert user_id == "user-1"
         assert message == "Hello Agent"
         assert conversation_id is None
+        self.prepared_turns += 1
         return PreparedAgentChatTurn(
             conversation_id="conversation-1",
             user_message_id="message-user-2",
@@ -170,6 +201,12 @@ def test_agent_chat_stream_sends_token_events_and_saves_assistant(monkeypatch):
     assert 'event: token\ndata: {"token": "Hello"}' in response.text
     assert 'event: token\ndata: {"token": " from Gemini"}' in response.text
     assert 'event: complete\ndata: {"conversation_id": "conversation-1"' in response.text
+    assert service.runtime_contract_calls == [
+        {
+            "runtime_credential": None,
+            "runtime_credential_mode": None,
+        }
+    ]
     assert service.stream_action_plans == [None]
     assert service.saved_messages == [
         {
@@ -182,6 +219,86 @@ def test_agent_chat_stream_sends_token_events_and_saves_assistant(monkeypatch):
             "error_code": None,
         }
     ]
+
+
+def test_agent_chat_stream_accepts_hushh_managed_runtime_mode_without_user_key(monkeypatch):
+    service = _FakeAgentChatService()
+    monkeypatch.setattr(agent_chat, "get_agent_chat_service", lambda: service)
+    client = _client(service)
+
+    response = client.post(
+        "/agent/chat/stream",
+        json={
+            "user_id": "user-1",
+            "message": "Hello Agent",
+            "runtime_credential_mode": "hushh_managed_vertex",
+        },
+    )
+
+    assert response.status_code == 200
+    assert service.prepared_turns == 1
+    assert service.runtime_contract_calls == [
+        {
+            "runtime_credential": None,
+            "runtime_credential_mode": "hushh_managed_vertex",
+        }
+    ]
+
+
+def test_agent_chat_stream_rejects_byok_without_runtime_credential(monkeypatch):
+    service = _FakeAgentChatService()
+    monkeypatch.setattr(agent_chat, "get_agent_chat_service", lambda: service)
+    client = _client(service)
+
+    response = client.post(
+        "/agent/chat/stream",
+        json={
+            "user_id": "user-1",
+            "message": "Hello Agent",
+            "runtime_credential_mode": "byok",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == {
+        "code": "AGENT_RUNTIME_CREDENTIAL_MISSING",
+        "message": (
+            "Kai needs your Gemini key to continue. Add or update it in "
+            "Profile > Runtime keys, or switch Kai to Hushh managed Gemini."
+        ),
+    }
+    assert service.prepared_turns == 0
+    assert service.saved_messages == []
+
+
+def test_agent_chat_stream_rejects_invalid_runtime_mode_without_leaking_key(
+    monkeypatch,
+    caplog,
+):
+    service = _FakeAgentChatService()
+    monkeypatch.setattr(agent_chat, "get_agent_chat_service", lambda: service)
+    client = _client(service)
+    raw_key = "USER_GEMINI_KEY_SHOULD_NOT_LEAK"
+
+    response = client.post(
+        "/agent/chat/stream",
+        json={
+            "user_id": "user-1",
+            "message": "Hello Agent",
+            "runtime_credential": raw_key,
+            "runtime_credential_mode": "unsupported",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == {
+        "code": "AGENT_RUNTIME_MODE_INVALID",
+        "message": "Agent runtime credential mode is invalid.",
+    }
+    assert raw_key not in response.text
+    assert raw_key not in caplog.text
+    assert service.prepared_turns == 0
+    assert service.saved_messages == []
 
 
 def test_agent_chat_stream_saves_short_frontend_action_receipt(monkeypatch):


### PR DESCRIPTION
# Description

Adds the second BYOK slice for Kai Agent: the backend runtime contract.

This PR builds on PR #1870, which established the encrypted PKM credential boundary and Profile UI for runtime keys. This slice teaches the Kai Agent stream route to accept and validate runtime credential intent safely, without yet executing BYOK Gemini calls.

The goal is to prove the backend request/error contract before wiring provider client creation or frontend PKM secret passing.

## PR Stack

### PR1: BYOK Credential Boundary - merged

PR #1870 added the encrypted runtime_secrets PKM domain and Profile Runtime keys UI. It proved that user-owned model keys can be saved, masked, revealed after vault unlock, replaced, and deleted through the existing encrypted PKM domain flow. It did not change Kai Agent runtime execution.

### PR2: Backend Runtime Contract - this PR

This PR adds backend understanding of runtime credential mode for Kai Agent chat. The stream route now accepts runtime_credential and runtime_credential_mode, validates them before creating a chat turn, defaults to Hushh-managed Gemini, and returns clean errors for invalid BYOK state. It does not create Gemini clients from user keys yet.

### PR3: Kai BYOK Execution - next

PR3 will wire Hussh SDK runtime resolution and Gemini client creation. BYOK mode will resolve the user credential and create a Gemini client from that key only, while Hushh-managed mode preserves the existing managed Gemini path. This PR will include no-env-fallback tests and redacted runtime evidence tests.

### PR4: Frontend Streaming Wiring - after PR3

PR4 will connect the web Agent chat flow to the encrypted PKM runtime secret. The frontend will read the decrypted key after vault unlock and pass it to the backend for that run only. It will also add friendly missing/invalid key UX in the chat surface.

## What Changed

- POST /api/kai/agent/chat/stream accepts:
  - runtime_credential
  - runtime_credential_mode

- Adds backend runtime contract validation:
  - missing mode defaults to hushh_managed_vertex
  - hushh_managed_vertex does not require a user key
  - byok requires runtime_credential
  - invalid modes return a clean 400

- Adds safe error handling:
  - missing BYOK credential returns a friendly message
  - invalid mode returns a stable error code
  - raw runtime credential is not returned in tested errors/logs

## Explicitly Out Of Scope

- No PKM reads in backend.
- No Gemini client creation from user key.
- No Hussh SDK runtime resolver usage.
- No agent.yaml model behavior changes.
- No frontend Agent chat wiring.
- No removal of the existing Hushh-managed Gemini execution path.

## Verification

- [x] cd consent-protocol && uv run ruff check api/routes/kai/agent_chat.py hushh_mcp/services/agent_chat_service.py tests/test_agent_chat_routes.py tests/services/test_agent_chat_service.py
- [x] cd consent-protocol && uv run python -m pytest tests/test_agent_chat_routes.py tests/services/test_agent_chat_service.py -q

## Privacy & Consent

- [x] Runtime credential is excluded from Pydantic serialization.
- [x] Raw credential is not returned in error responses.
- [x] Tests assert raw credential does not leak in invalid-mode response/log capture.
- [x] BYOK missing credential fails before a chat turn is persisted.
