### PR TITLE
fix(popup-text-editor-field): associate accessible label with textarea

### DIFF
--- a/hushh-webapp/components/app-ui/command-fields.tsx
+++ b/hushh-webapp/components/app-ui/command-fields.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useDeferredValue, useEffect, useMemo, useState, type ReactNode } from "react";
+import { useDeferredValue, useEffect, useId, useMemo, useState, type ReactNode } from "react";
 import { Check, ChevronsUpDown, FilePenLine, X } from "lucide-react";
 
 import {
@@ -297,6 +297,7 @@ export function PopupTextEditorField({
 }) {
   const [open, setOpen] = useState(false);
   const [draft, setDraft] = useState(value);
+  const textareaId = useId();
 
   useEffect(() => {
     if (!open) {
@@ -373,7 +374,12 @@ export function PopupTextEditorField({
           </>
         }
       >
+        <label htmlFor={textareaId} className="sr-only">
+          {typeof title === "string" ? title : placeholder}
+        </label>
+
         <Textarea
+          id={textareaId}
           value={draft}
           onChange={(event) => setDraft(event.target.value)}
           placeholder={placeholder}

--- a/hushh-webapp/components/app-ui/command-fields.tsx
+++ b/hushh-webapp/components/app-ui/command-fields.tsx
@@ -377,7 +377,6 @@ export function PopupTextEditorField({
         <label htmlFor={textareaId} className="sr-only">
           {typeof title === "string" ? title : placeholder}
         </label>
-
         <Textarea
           id={textareaId}
           value={draft}


### PR DESCRIPTION
## Summary

Associate a programmatically accessible label with the `Textarea` inside `PopupTextEditorField`.

## Problem

`PopupTextEditorField` renders a dialog containing a `Textarea`, but the textarea has no programmatically associated accessible name.

The field currently relies on a placeholder, which does not satisfy WCAG 1.3.1 requirements because placeholders are not a reliable replacement for labels and may not be consistently announced by assistive technologies.

As a result, screen reader users may encounter an unlabeled text area when the popup editor opens.

## Change

**File:** `hushh-webapp/components/app-ui/command-fields.tsx`

- Import `useId` from React
- Generate a stable textarea id using `useId()`
- Add an `sr-only` label associated with the textarea via `htmlFor`
- Add `id={textareaId}` to the `Textarea`

The label uses:

```tsx
typeof title === "string" ? title : placeholder
```

to provide a meaningful accessible name while preserving existing behavior.

## Impact

- No visual changes
- No behavioral changes
- No API changes
- Improves screen reader support for popup text editing

## Accessibility

This change provides a programmatically associated label for the textarea and improves compatibility with screen readers.

- WCAG 1.3.1 — Info and Relationships
- Resolves unlabeled form control accessibility issues

## Risk

LOW — additive accessibility enhancement only. Uses React's built-in `useId()` and does not modify existing editor behavior.