### PR TITLE
Promote PR governance subagent train docs

### DIFF
--- a/.codex/skills/pr-governance-review/SKILL.md
+++ b/.codex/skills/pr-governance-review/SKILL.md
@@ -55,14 +55,18 @@ Non-owned surfaces:
 
 ## Workflow
 
-### Default PR-Train Mode
+### Default PR-Train Mode / PR Governance Subagent Train Mode
 
-Use the async PR-train method as the default for multi-PR work.
+Use the async PR-train method as the default for multi-PR work, now formalized
+as the PR governance subagent train method. Contributors may open PRs against
+`main`; before review, approval, maintainer patching, harvest, queue, or merge,
+normal intake must be retargeted to `integration/pr-train`. `main` receives
+only `integration/pr-train` promotion PRs except explicit emergency hotfixes.
 
 1. Lock the current PR head SHA, current `CI Status Gate`, mergeability, draft state, and review state before judging.
-2. Run the delegation router at intake; use read-only evidence lanes for non-trivial, high-risk, or multi-PR work.
+2. Run the delegation router at intake; use real read-only subagent evidence lanes for non-trivial, high-risk, or multi-PR work.
 3. Run the PR checklist or hybrid live report and treat `contract_set`, `duplicate_group`, `public_comment_policy`, `lane`, and `live_report_action` as decision records.
-4. Use the async PR-train method as the default for more than one PR: first lock the operator-approved surface scope, identify only trains inside that scope or its hard dependencies, run scoped non-touching trains in parallel through evidence lanes, sequence touching PRs oldest-first inside each train, queue independent green PRs together, run disjoint patch trains, and run decision waves asynchronously. Unrelated green-clean PRs stay in `out_of_scope_candidates` until a separate operator checkpoint approves a broader sweep.
+4. Use the async PR governance subagent train method as the default for more than one PR: first lock the operator-approved surface scope, identify only trains inside that scope or its hard dependencies, run scoped non-touching trains in parallel through subagent evidence lanes, sequence touching PRs oldest-first inside each train, queue independent green PRs together, run disjoint patch trains, and run decision waves asynchronously. Unrelated green-clean PRs stay in `out_of_scope_candidates` until a separate operator checkpoint approves a broader sweep.
 5. Exclude PRs with failing/missing/stale required checks or failing auxiliary checks from executable trains unless the task is CI repair.
 6. Apply blocker gates before merge: north-star drift, duplicate architecture, trust-boundary regression, caller/proxy/backend mismatch, unreachable helpers, stacked diff, proof gaps, and local dirty-file overlap.
 7. Prefer direct contributor PR merge, then `maintainer_patch_then_merge`, then maintainer harvest. Harvest is allowed only when the source PR should not be the merge vehicle and the plan names accepted value, canonical attach point, write set, dropped/deferred pieces, proof, source PR close-or-hold state, and co-author attribution when code/tests are materially reused.

--- a/.codex/skills/pr-governance-review/references/operator-batch-output-contract.md
+++ b/.codex/skills/pr-governance-review/references/operator-batch-output-contract.md
@@ -1,4 +1,4 @@
-# Operator Batch Output Contract
+# PR Governance Subagent Train Output Contract
 
 Use this when answering "next batch", "plan this batch", or any high-volume PR
 wave question. `pr-train-review-sop.md` defines behavior; this contract defines
@@ -9,7 +9,7 @@ the operator-facing dossier.
 Train recommendations must be deterministic and reviewable without opening the
 live report. Use these sections:
 
-1. `Batch`: one sentence naming the product/runtime purpose.
+1. `Batch`: one sentence naming the product/runtime purpose and confirming this is a PR governance subagent train.
 2. `Research Basis`: concise current truth, recommended path, and risk if accepted blindly.
 3. `Delegation Evidence`: router decision, taskforce lanes, async train-to-subagent map, each lane status (`spawned`, `emulated`, or `unavailable`), skipped/unavailable rationale, parent-local critical-path task, and parent-only authority.
 4. `Scan Scope`: mode, active limit, candidate limit, open inventory count, reviewed PRs, failed PRs, and completeness.
@@ -18,7 +18,7 @@ live report. Use these sections:
 7. `Actionable Intake Filter`: unattended PRs, repass PRs, material-state-change PRs, check-failure holds, and dormant-current holds.
 8. `Check Failure Holds`: PRs excluded because current required/auxiliary checks are not clean.
 9. `Input`: every actionable PR with a direct Markdown link and current lane; dormant-current holds are listed separately and do not consume lane capacity.
-10. `Train Simulation`: branch evidence, delta summary, behavior claim, canonical fit, simulated patch, action outcome, comment simulation, and verification timeline.
+10. `Train Simulation`: branch evidence, retarget plan for PRs opened to `main`, delta summary, behavior claim, canonical fit, simulated patch, action outcome, comment simulation, and verification timeline.
 11. `Output`: concise landing decision, async train placement, next refill train, and next operator-visible artifact.
 12. `Expected Actions`: each actionable PR mapped to `review_only`, `hold`, `request_changes`, `close`, `maintainer_harvest`, `maintainer_patch_then_merge`, `merge_now`, or `post_merge_monitor`; dormant-current PRs are reported as `dormant_current_hold`.
 13. `Comment Plan`: each actionable PR mapped to `none_before_merge_then_post_merge_closeout`, `edit_existing_maintainer_comment`, `new_changes_requested_comment`, `new_closed_superseded_comment`, or `no_comment_review_only`.
@@ -27,9 +27,10 @@ live report. Use these sections:
     internal impact credit, or no credit for each source PR.
 15. `Per-PR Assessment`: direct link, lane, risk, head SHA prefix, changed surface, batch reason, Blind-merge risk, planned action, comment action, and Smallest proof.
 16. `Execution`: queue cohort, collision sequence, patch train, decision wave, dormant-current split, and hold split.
-17. `All Async Trains`: every actionable train in the reviewed scope with exact PR links,
-    assigned evidence lane/subagent, non-touching parallel trains, hard-edge
-    sequence, oldest-first execution order, and worker refill order.
+17. `All Async Trains` / `All PR Governance Subagent Trains`: every actionable
+    train in the reviewed scope with exact PR links, assigned evidence
+    lane/subagent, non-touching parallel trains, hard-edge sequence,
+    oldest-first execution order, and worker refill order.
 18. `Worker Refill Queue`: active workers `1-5`, queued trains `6..n`, next refill candidate, and which lanes are allowed to continue while a decision wave waits.
 19. `Question Before Wave`: required before any comment, close, patch, queue,
     or merge checkpoint; include current truth, the complete train set already
@@ -123,6 +124,10 @@ code blocks.
     as `emulated`, and still maintain the five-lane refill queue. Silent
     sequential parent-only evidence collection is invalid for approved async
     trains.
+24. Normal PRs opened to `main` must be listed with `retarget_to_integration_pr_train`
+    before any approval, queue, merge, maintainer patch, or harvest action.
+    Promotion PRs from `integration/pr-train` to `main` are the only normal
+    main-lane merge vehicle.
 
 ## Research And Review Standard
 

--- a/.codex/skills/pr-governance-review/references/pr-train-review-sop.md
+++ b/.codex/skills/pr-governance-review/references/pr-train-review-sop.md
@@ -1,9 +1,32 @@
-# PR Train Review SOP
+# PR Governance Subagent Train SOP
 
 Use this SOP when a reviewer handles more than one PR, chooses the next batch,
 revisits `changes_requested`, or scales throughput without weakening quality.
 
-## Async Train Default
+## Branch Intake Model
+
+This SOP uses the PR governance subagent train as the default maintainer
+workflow. Contributor experience can stay simple: contributors may open PRs
+against `main` if that is the familiar GitHub default. Before any maintainer
+review, approval, patch, harvest, queue, or merge action, normal PR intake must
+be retargeted to `integration/pr-train`.
+
+The canonical path is:
+
+```text
+contributor branch -> PR opened to main or integration/pr-train
+maintainer/automation retargets normal intake to integration/pr-train
+integration/pr-train is reviewed, tested, merged, and manually validated
+integration/pr-train -> main promotion PR
+exact green main SHA -> UAT/production deploy
+```
+
+`main` is the stable promotion lane, not the normal feature landing lane.
+Direct feature, contributor, or agent PRs into `main` stay blocked unless they
+are explicitly approved emergency hotfixes. Retarget first, then trust checks
+from the `integration/pr-train` base.
+
+## Async Train Default / Async Subagent Train Default
 
 This SOP is the canonical behavior source for multi-PR governance.
 Canonical order for every backlog, batch, repass, decision-wave, or scale pass:
@@ -13,11 +36,11 @@ Canonical order for every backlog, batch, repass, decision-wave, or scale pass:
 3. Apply the Actionable Intake Filter before deep review: include unattended PRs, PRs with contributor activity after the latest maintainer `changes_requested` record, and PRs whose head SHA/check/mergeability changed; move unchanged PRs with current standardized maintainer records into `Dormant Current Holds`.
 4. Move failing, missing, stale, or auxiliary-failing checks into `Check Failure Holds` unless this is CI repair.
 5. Build the train graph from hard edges: exact files, lockfiles, generated contracts, schema/migrations, concrete shared route/runtime surfaces, dirty-file overlap, stacked/conflicting state, and train/promotion dependencies. Treat broad sensitive-runtime labels as risk signals unless they share a concrete file, route, schema, generated contract, or explicit dependency edge.
-6. Identify all async trains from that graph, oldest PRs first, not only the next visible batch.
-7. Start one read-only evidence lane per independent train family; the writer-lane exception does not make evidence lanes writable.
+6. Identify all async subagent trains from that graph, oldest PRs first, not only the next visible batch.
+7. Start one read-only evidence lane per independent train family; when the subagent tool is available, that lane must be a real read-only subagent evidence lane. The writer-lane exception does not make evidence lanes writable.
 8. Ask one Pre-Wave Operator Question before any comment, close, patch, queue, merge, or deploy checkpoint unless the operator has already given explicit standing approval for this scoped async-train run.
 9. After a wave completes, treat PRs with current standardized maintainer records as handled until their head SHA, CI state, mergeability, or contributor response changes.
-10. Run independent trains in parallel through a five-worker train pool; sequence hard-edge PRs oldest-first inside a train and refill a freed worker with the next oldest non-touching train.
+10. Run independent trains in parallel through a five-worker subagent train pool; sequence hard-edge PRs oldest-first inside a train and refill a freed worker with the next oldest non-touching train.
 11. Treat PR Validation, Queue Validation, and Main Post-Merge Smoke as monitor lanes; while they run, prepare the next independent train or decision wave.
 12. Ingest every returned lane into queue, patch, comment/close, hold, dormant hold, or next-refill writes; do not call the set complete until every scoped PR is linked as acted, terminal, blocked, dormant-current, or remaining.
 
@@ -25,7 +48,7 @@ If this order conflicts with another PR-governance reference, this section wins.
 
 ## Surface-Scoped Async Train Guard
 
-Async trains are parallelism inside the operator-approved surface scope, not permission to act on unrelated green PRs. Build trains only from PRs touching the named scope or hard dependencies; put unrelated green-clean PRs in `out_of_scope_candidates` until a separate checkpoint approves writes. For Location, PKM, vault, consent, KYC, voice, finance, deploy, or branch governance, default to one surface train plus direct hard-edge dependencies.
+Async subagent trains are parallelism inside the operator-approved surface scope, not permission to act on unrelated green PRs. Build trains only from PRs touching the named scope or hard dependencies; put unrelated green-clean PRs in `out_of_scope_candidates` until a separate checkpoint approves writes. For Location, PKM, vault, consent, KYC, voice, finance, deploy, or branch governance, default to one surface train plus direct hard-edge dependencies.
 
 ## Live Report Reuse
 
@@ -72,7 +95,7 @@ Move a PR to `Dormant Current Holds` without deep re-review when all are true:
 
 ## Preflight
 
-Fetch `origin/integration/pr-train`, inspect worktree, confirm no dirty local file overlaps a PR under review, and use only a fresh scoped live report. High-volume (`>20` PRs scanned, `>5` acted on, mixed trains, repasses, or throughput maximization) requires the delegation router and read-only lanes.
+Fetch `origin/integration/pr-train`, inspect worktree, confirm no dirty local file overlaps a PR under review, and use only a fresh scoped live report. For any normal PR that currently targets `main`, retarget to `integration/pr-train` before approval, queue, merge, maintainer patch, or harvest. High-volume (`>20` PRs scanned, `>5` acted on, mixed trains, repasses, or throughput maximization) requires the delegation router and read-only subagent lanes.
 
 Record the starting developer branch before any worktree, PR checkout, detached HEAD, or temporary review branch operation. If the parent session switches away, the train is not complete until it returns to that branch or reports the exact blocker. Fetch `origin/integration/pr-train` before any PR-train state-changing wave or branch switch so decisions are based on the current train ref. Fetch `origin/main` only for train-to-main promotion, hotfix, or deploy-authority checks.
 

--- a/docs/reference/operations/branch-governance.md
+++ b/docs/reference/operations/branch-governance.md
@@ -20,24 +20,25 @@ This repo now runs on a dedicated PR-train branch, a protected promotion branch,
 
 | Lane | Purpose | Default policy |
 |---|---|---|
-| `integration/pr-train` | Normal PR intake and async train landing | Every feature/fix/docs PR targets `integration/pr-train` |
+| `integration/pr-train` | Normal PR intake and async train landing | Effective landing base for every normal feature/fix/docs PR |
 | `main` | Promotion branch for deployable history | Only `integration/pr-train` may open normal promotion PRs into `main` |
 | UAT | Hosted validation environment | Manual deploy of an exact green `main` SHA |
 | Production | Live user traffic | Manual deploy of an approved green `main` SHA |
 
 ## Working Rules
 
-1. Start all development branches from the current `integration/pr-train` unless an isolated `main` hotfix is explicitly required.
-2. Merge all normal feature/fix/docs work into `integration/pr-train`.
-3. Promote `integration/pr-train` into `main` through a PR after the train is green and ancestry-clean.
-4. Do not open direct feature, contributor, or agent PRs into `main`; CI blocks them unless the head branch is `integration/pr-train`.
-5. Continue follow-up fixes on the active development branch by default; do not create extra temporary branches for routine polish, validation follow-up, or same-lane fixes.
-6. Create a new branch only when isolation is materially required, such as a post-merge hotfix from `main`, a deploy blocker that must land independently, or unrelated in-flight changes on the current branch.
-7. After an isolated hotfix lands, return local work to the normal development branch or `integration/pr-train` and delete the temporary branch after rollout validation.
-8. Do not use `deploy_uat` or `deploy` as release branches; they are retired from the deployment path.
-9. UAT deploys only from a successful `Main Post-Merge Smoke` run on `main` and uses an explicitly chosen exact green commit SHA.
-10. Production deploys only from a manually chosen SHA that is reachable from `origin/main` and already green in CI.
-11. Do not open release PRs into environment branches; the deployment source of truth is `main`.
+1. Start all maintainer/developer branches from the current `integration/pr-train` unless an isolated `main` hotfix is explicitly required.
+2. Contributor PRs may still be opened to `main` for a familiar GitHub intake experience; maintainers or automation retarget normal intake to `integration/pr-train` before review, approval, queue, merge, maintainer patch, or harvest.
+3. Merge all normal feature/fix/docs work into `integration/pr-train`.
+4. Promote `integration/pr-train` into `main` through a PR after the train is green and ancestry-clean.
+5. Do not merge direct feature, contributor, or agent PRs into `main`; CI blocks them unless the head branch is `integration/pr-train`.
+6. Continue follow-up fixes on the active development branch by default; do not create extra temporary branches for routine polish, validation follow-up, or same-lane fixes.
+7. Create a new branch only when isolation is materially required, such as a post-merge hotfix from `main`, a deploy blocker that must land independently, or unrelated in-flight changes on the current branch.
+8. After an isolated hotfix lands, return local work to the normal development branch or `integration/pr-train` and delete the temporary branch after rollout validation.
+9. Do not use `deploy_uat` or `deploy` as release branches; they are retired from the deployment path.
+10. UAT deploys only from a successful `Main Post-Merge Smoke` run on `main` and uses an explicitly chosen exact green commit SHA.
+11. Production deploys only from a manually chosen SHA that is reachable from `origin/main` and already green in CI.
+12. Do not open release PRs into environment branches; the deployment source of truth is `main`.
 
 ## Codex Branch Preservation Gate
 


### PR DESCRIPTION
Promotes the integration train containing #1946.\n\nScope:\n- Clarifies PR governance subagent train mode.\n- Documents contributor PRs may open to main while maintainers retarget normal intake to integration/pr-train before writes/merge.\n- Keeps main as the stable promotion lane.\n\nVerified on #1946:\n- CI Status Gate passed on head aef3ab37ba648606351a336d94025f6ee033be8c.\n- DCO, Governance, PR Base Policy, Secret Scan, Base Freshness Gate, and Upstream Sync passed.\n- Local governance checks passed before merge.