### PR TITLE
chore: promote accessibility fixes from PR train

### DIFF
--- a/hushh-webapp/components/kai/modals/edit-holding-modal.tsx
+++ b/hushh-webapp/components/kai/modals/edit-holding-modal.tsx
@@ -473,11 +473,12 @@ export function EditHoldingModal({
 
           {/* Name */}
           <div>
-            <label className="block text-sm font-medium mb-1">
+            <label htmlFor="holding-name" className="block text-sm font-medium mb-1">
               Company Name <span className="text-red-500">*</span>
             </label>
             <div ref={nameInputWrapRef} className="relative">
               <input
+                id="holding-name"
                 type="text"
                 value={formData.name}
                 onChange={(e) => handleChange("name", e.target.value)}
@@ -533,10 +534,11 @@ export function EditHoldingModal({
           {/* Quantity & Price Row */}
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="block text-sm font-medium mb-1">
+              <label htmlFor="holding-quantity" className="block text-sm font-medium mb-1">
                 Quantity <span className="text-red-500">*</span>
               </label>
 	              <input
+                id="holding-quantity"
                 type="number"
                 value={formData.quantity || ""}
                 onChange={(e) => handleChange("quantity", parseFloat(e.target.value) || 0)}
@@ -556,10 +558,11 @@ export function EditHoldingModal({
             </div>
 
             <div>
-              <label className="block text-sm font-medium mb-1">
+              <label htmlFor="holding-price" className="block text-sm font-medium mb-1">
                 Price <span className="text-red-500">*</span>
               </label>
 	              <input
+                id="holding-price"
                 type="number"
                 value={formData.price || ""}
                 onChange={(e) => handleChange("price", parseFloat(e.target.value) || 0)}
@@ -581,10 +584,11 @@ export function EditHoldingModal({
 
           {/* Market Value (calculated, read-only) */}
           <div>
-            <label className="block text-sm text-muted-foreground font-medium mb-1">
+            <label htmlFor="holding-market-value" className="block text-sm text-muted-foreground font-medium mb-1">
               Market Value (Auto-calculated)
             </label>
             <input
+              id="holding-market-value"
               type="text"
               value={`$${formData.market_value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}
               readOnly
@@ -600,10 +604,11 @@ export function EditHoldingModal({
 
           {/* Cost Basis */}
           <div>
-            <label className="block text-sm font-medium mb-1">
+            <label htmlFor="holding-cost-basis" className="block text-sm font-medium mb-1">
               Cost Basis (Total)
             </label>
             <input
+              id="holding-cost-basis"
               type="number"
               value={formData.cost_basis || ""}
               onChange={(e) => handleChange("cost_basis", parseFloat(e.target.value) || 0)}
@@ -619,11 +624,12 @@ export function EditHoldingModal({
 
           {/* Acquisition Date */}
           <div>
-            <label className="block text-sm font-medium mb-1">
+            <label htmlFor="holding-acquisition-date" className="block text-sm font-medium mb-1">
               Acquisition Date
             </label>
             <div className="relative">
               <input
+                id="holding-acquisition-date"
                 type="text"
                 value={formatAcquisitionDate(formData.acquisition_date)}
                 placeholder="MM/DD/YYYY"

--- a/hushh-webapp/components/kai/views/analysis-history-dashboard.tsx
+++ b/hushh-webapp/components/kai/views/analysis-history-dashboard.tsx
@@ -1140,6 +1140,7 @@ export function AnalysisHistoryDashboard({
                       className="h-9 w-9 shrink-0 border border-transparent text-red-600 hover:border-red-500/30 hover:bg-red-500/10 dark:text-red-400"
                       onClick={() => setPendingDelete({ kind: "entry", entry })}
                       title="Delete this version"
+                      aria-label="Delete this version"
                     >
                       <Icon icon={Trash2} size="sm" />
                     </Button>

--- a/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
+++ b/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
@@ -642,33 +642,35 @@ export function ManagePortfolioView() {
                             </div>
                             <div className="flex items-center gap-3 ml-4 border-l border-primary/10 pl-4">
                               <div className="flex flex-col items-center gap-1">
-                                <Button
-                                  variant="none"
-                                  effect="glass"
-                                  size="icon-sm"
-                                  className={cn(
-                                    "h-10 w-10 text-muted-foreground hover:text-primary transition-all duration-300 rounded-xl",
-                                    holding.pending_delete && "pointer-events-none opacity-50"
-                                  )}
-                                  onClick={() => handleEditHolding(actualIndex)}
-                                  icon={{ icon: Pencil }}
-                                />
+                                  <Button
+                                    variant="none"
+                                    effect="glass"
+                                    size="icon-sm"
+                                    className={cn(
+                                      "h-10 w-10 text-muted-foreground hover:text-primary transition-all duration-300 rounded-xl",
+                                      holding.pending_delete && "pointer-events-none opacity-50"
+                                    )}
+                                    onClick={() => handleEditHolding(actualIndex)}
+                                    icon={{ icon: Pencil }}
+                                    aria-label={`Edit ${holding.symbol} holding`}
+                                  />
                                 <Kbd className="text-[8px] px-1 h-3.5">EDIT</Kbd>
                               </div>
                               <div className="flex flex-col items-center gap-1">
-                                <Button
-                                  variant="none"
-                                  effect="glass"
-                                  size="icon-sm"
-                                  className={cn(
-                                    "h-10 w-10 transition-all duration-300 rounded-xl",
-                                    holding.pending_delete
-                                      ? "text-emerald-500 hover:text-emerald-600 hover:bg-emerald-50"
-                                      : "text-red-400 hover:text-red-500 hover:bg-red-50"
-                                  )}
-                                  onClick={() => handleDeleteHolding(actualIndex)}
-                                  icon={{ icon: holding.pending_delete ? Undo2 : Trash2 }}
-                                />
+                                  <Button
+                                    variant="none"
+                                    effect="glass"
+                                    size="icon-sm"
+                                    className={cn(
+                                      "h-10 w-10 transition-all duration-300 rounded-xl",
+                                      holding.pending_delete
+                                        ? "text-emerald-500 hover:text-emerald-600 hover:bg-emerald-50"
+                                        : "text-red-400 hover:text-red-500 hover:bg-red-50"
+                                    )}
+                                    onClick={() => handleDeleteHolding(actualIndex)}
+                                    icon={{ icon: holding.pending_delete ? Undo2 : Trash2 }}
+                                    aria-label={holding.pending_delete ? `Undo delete ${holding.symbol}` : `Delete ${holding.symbol} holding`}
+                                  />
                                 <Kbd className="text-[8px] px-1 h-3.5">
                                   {holding.pending_delete ? "UNDO" : "DEL"}
                                 </Kbd>

--- a/hushh-webapp/components/kai/views/round-tabs-card.tsx
+++ b/hushh-webapp/components/kai/views/round-tabs-card.tsx
@@ -159,6 +159,7 @@ export function RoundTabsCard({
               size="icon-sm"
               showRipple={false}
               onClick={onToggleCollapse}
+              aria-label={isCollapsed ? "Expand round details" : "Collapse round details"}
             >
               {isCollapsed ? <Icon icon={ChevronDown} size="sm" /> : <Icon icon={ChevronUp} size="sm" />}
             </MorphyButton>

--- a/hushh-webapp/components/ria/onboarding/onboarding-step-services.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-step-services.tsx
@@ -32,7 +32,17 @@ function Divider() {
   return <div className="ml-4 h-px bg-border/50 sm:ml-5" />;
 }
 
-function SectionLabel({ children }: { children: React.ReactNode }) {
+function SectionLabel({ children, htmlFor }: { children: React.ReactNode; htmlFor?: string }) {
+  if (htmlFor) {
+    return (
+      <label
+        htmlFor={htmlFor}
+        className="block text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground"
+      >
+        {children}
+      </label>
+    );
+  }
   return (
     <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
       {children}
@@ -208,8 +218,9 @@ export function OnboardingStepServices({
       </GroupShell>
 
       <div className="space-y-3">
-        <SectionLabel>Short Bio</SectionLabel>
+        <SectionLabel htmlFor="ria-bio">Short Bio</SectionLabel>
         <textarea
+          id="ria-bio"
           rows={4}
           value={bio}
           onChange={(event) => onBioChange(event.target.value)}


### PR DESCRIPTION
Promotes the first approved PR-train wave from integration/pr-train to main.\n\nIncluded PRs:\n- #1925 add aria-label for Kai round details toggle\n- #1933 associate RIA onboarding bio label with textarea\n- #1928 add form labels/aria label in Kai portfolio views\n- #1924 add aria-labels to portfolio icon buttons\n\nVerification before promotion:\n- Each source PR was approved on current head.\n- Each source PR passed CI Status Gate.\n- Each source PR entered the integration/pr-train merge queue through enqueuePullRequest with expectedHeadOid.\n- Queue Validation passed before integration/pr-train advanced to 12c1cfcaa31e74a94e59b151327d86f10603c77b.\n\nHeld out of this promotion:\n- #1934 requires reapproval after the merge-base changed.\n- #1942 has a requested change to remove .rerun-ci.\n- Backend bounds PRs are held for trust-boundary review.