### PR TITLE
fix(frontend): add aria-hidden to decorative icons in holding cta

### DIFF
--- a/hushh-webapp/components/kai/cards/new-holding-cta-card.tsx
+++ b/hushh-webapp/components/kai/cards/new-holding-cta-card.tsx
@@ -24,11 +24,11 @@ export function NewHoldingCtaCard({ onAddHolding, onImportStatement }: NewHoldin
 
         <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
           <Button variant="blue-gradient" effect="fill" size="default" onClick={onAddHolding}>
-            <Icon icon={Plus} size="sm" className="mr-2" />
+            <Icon icon={Plus} size="sm" className="mr-2" aria-hidden="true" />
             Add Holding
           </Button>
           <Button variant="none" effect="fade" size="default" onClick={onImportStatement}>
-            <Icon icon={Upload} size="sm" className="mr-2" />
+            <Icon icon={Upload} size="sm" className="mr-2" aria-hidden="true" />
             Import Statement
           </Button>
         </div>


### PR DESCRIPTION
# Description

Added `aria-hidden="true"` to decorative Lucide icons inside the New Holding CTA buttons to improve accessibility and prevent redundant screen reader announcements.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Not applicable

- UI browser or Playwright proof:
  - [x] Not applicable

- Verification commands executed:
  - [x] `./bin/hushh codex pre-pr`
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm run lint`

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — `hushh-webapp/components/kai/cards/new-holding-cta-card.tsx`.
- [x] Reachable production attach point: New Holding CTA card rendered in Kai views.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: HTML attribute-only change, no iOS/Android impact.
- [x] **iOS**: Not applicable.
- [x] **Android**: Not applicable.

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

No UI-visible change — accessibility attribute-only fix on existing decorative icons.

## 🛡️ Privacy & Consent

- [x] Does not access user data.
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependency changes