### PR TITLE
fix(frontend): add aria-hidden to decorative icons in portfolio metrics

### DIFF
--- a/hushh-webapp/components/kai/cards/portfolio-metrics-card.tsx
+++ b/hushh-webapp/components/kai/cards/portfolio-metrics-card.tsx
@@ -134,7 +134,7 @@ export function PortfolioMetricsCard({
     <Card variant="none" effect="glass" showRipple={false} className={className}>
       <CardHeader className="pb-1 pt-3 px-4">
         <CardTitle className="text-sm font-semibold flex items-center gap-2">
-          <Icon icon={BarChart3} size="md" className="text-primary" />
+          <Icon icon={BarChart3} size="md" className="text-primary" aria-hidden="true" />
           Metrics
         </CardTitle>
       </CardHeader>
@@ -143,7 +143,7 @@ export function PortfolioMetricsCard({
           {/* Diversification Score */}
           <div className="space-y-1">
             <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-              <Icon icon={Layers} size="md" />
+              <Icon icon={Layers} size="md" aria-hidden="true" />
               <span>Diversity</span>
             </div>
             <div className="flex items-baseline gap-1.5">
@@ -159,7 +159,7 @@ export function PortfolioMetricsCard({
           {/* Sector Count */}
           <div className="space-y-1">
             <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-              <Icon icon={Layers} size="md" />
+              <Icon icon={Layers} size="md" aria-hidden="true" />
               <span>Sectors</span>
             </div>
             <div className="flex items-baseline gap-1.5">
@@ -173,7 +173,7 @@ export function PortfolioMetricsCard({
           {avgYield !== null && (
             <div className="space-y-1">
               <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                <Icon icon={Percent} size="md" />
+                <Icon icon={Percent} size="md" aria-hidden="true" />
                 <span>Avg Yield</span>
               </div>
               <span className="text-lg font-bold text-emerald-500">
@@ -186,7 +186,7 @@ export function PortfolioMetricsCard({
           {weightedCostBasis !== null && (
             <div className="space-y-1">
               <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                <Icon icon={DollarSign} size="md" />
+                <Icon icon={DollarSign} size="md" aria-hidden="true" />
                 <span>Cost Basis</span>
               </div>
               <span className="text-lg font-bold">


### PR DESCRIPTION
# Description

Added `aria-hidden="true"` to purely decorative Lucide icons used alongside text labels in the Portfolio Metrics card to improve screen reader accessibility and prevent redundant announcements.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Not applicable

- UI browser or Playwright proof:
  - [x] Not applicable

- Verification commands executed:
  - [x] `./bin/hushh codex pre-pr`
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm run lint`

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — `hushh-webapp/components/kai/cards/portfolio-metrics-card.tsx`.
- [x] Reachable production attach point: Portfolio Metrics card rendered in Kai views.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: HTML attribute-only change, no iOS/Android impact.
- [x] **iOS**: Not applicable.
- [x] **Android**: Not applicable.

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

No UI-visible change — accessibility attribute-only fix on existing decorative icons.

## 🛡️ Privacy & Consent

- [x] Does not access user data.
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependency changes