### PR TITLE
fix(frontend): make sector allocation chart hydration-safe

### DIFF
--- a/hushh-webapp/components/kai/charts/sector-allocation-chart.tsx
+++ b/hushh-webapp/components/kai/charts/sector-allocation-chart.tsx
@@ -221,15 +221,15 @@ export function SectorAllocationChart({
   title = "Sector Allocation",
   subtitle,
 }: SectorAllocationChartProps) {
-  const [windowWidth, setWindowWidth] = useState<number>(
-    typeof window !== "undefined" ? window.innerWidth : 1024
-  );
+  const [windowWidth, setWindowWidth] = useState<number>(1024);
   const [sectorHoldingPages, setSectorHoldingPages] = useState<Record<string, number>>({});
   const [openSectors, setOpenSectors] = useState<Record<string, boolean>>({});
   const holdingsPageSize = windowWidth < 640 ? 4 : 8;
 
   useEffect(() => {
     if (!responsive) return;
+
+    setWindowWidth(window.innerWidth);
 
     const handleResize = () => {
       setWindowWidth(window.innerWidth);


### PR DESCRIPTION
# Description

Fixed a React hydration mismatch in the Sector Allocation Chart by using a static initial state for window width and updating it dynamically in the `useEffect` on mount. This ensures the first client render exactly matches the server render.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Not applicable

- UI browser or Playwright proof:
  - [x] Not applicable

- Verification commands executed:
  - [x] `./bin/hushh codex pre-pr`
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm run lint`

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — `hushh-webapp/components/kai/charts/sector-allocation-chart.tsx`.
- [x] Reachable production attach point: Sector Allocation Chart.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Hydration bug fix, no iOS/Android impact.
- [x] **iOS**: Not applicable.
- [x] **Android**: Not applicable.

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

No UI-visible change — purely a Next.js hydration safety fix.

## 🛡️ Privacy & Consent

- [x] Does not access user data.
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependency changes