### PR TITLE
fix(frontend): add aria-hidden to decorative icons in trinity cards

### DIFF
--- a/hushh-webapp/components/kai/views/trinity-cards.tsx
+++ b/hushh-webapp/components/kai/views/trinity-cards.tsx
@@ -22,7 +22,7 @@ export function TrinityCards({ bullCase, bearCase, renaissanceVerdict }: Trinity
       <Card className={cn("border-emerald-500/20 bg-emerald-500/5", !bullCase && "opacity-50")}>
         <CardHeader className="pb-2">
           <CardTitle className="text-sm font-medium text-emerald-600 dark:text-emerald-400 flex items-center gap-2">
-            <Icon icon={TrendingUp} size="sm" />
+            <Icon icon={TrendingUp} size="sm" aria-hidden="true" />
             Personalized Bull Case
           </CardTitle>
         </CardHeader>
@@ -43,7 +43,7 @@ export function TrinityCards({ bullCase, bearCase, renaissanceVerdict }: Trinity
       <Card className={cn("border-rose-500/20 bg-rose-500/5", !bearCase && "opacity-50")}>
         <CardHeader className="pb-2">
           <CardTitle className="text-sm font-medium text-rose-600 dark:text-rose-400 flex items-center gap-2">
-            <Icon icon={ShieldAlert} size="sm" />
+            <Icon icon={ShieldAlert} size="sm" aria-hidden="true" />
             Personalized Bear Case
           </CardTitle>
         </CardHeader>
@@ -64,7 +64,7 @@ export function TrinityCards({ bullCase, bearCase, renaissanceVerdict }: Trinity
       <Card className={cn("border-violet-500/20 bg-violet-500/5", !renaissanceVerdict && "opacity-50")}>
         <CardHeader className="pb-2">
           <CardTitle className="text-sm font-medium text-violet-600 dark:text-violet-400 flex items-center gap-2">
-            <Icon icon={Crown} size="sm" className="text-amber-500" />
+            <Icon icon={Crown} size="sm" className="text-amber-500" aria-hidden="true" />
             Renaissance Verdict
           </CardTitle>
         </CardHeader>


### PR DESCRIPTION
# Description

Added `aria-hidden="true"` to purely decorative icons used next to text labels in the Trinity Cards component to improve accessibility and prevent redundant announcements by screen readers.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Not applicable

- UI browser or Playwright proof:
  - [x] Not applicable

- Verification commands executed:
  - [x] `./bin/hushh codex pre-pr`
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm run lint`

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — `hushh-webapp/components/kai/views/trinity-cards.tsx`.
- [x] Reachable production attach point: Trinity Cards rendered in Kai views.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: HTML attribute-only change, no iOS/Android impact.
- [x] **iOS**: Not applicable.
- [x] **Android**: Not applicable.

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

No UI-visible change — purely an accessibility fix for screen readers.

## 🛡️ Privacy & Consent

- [x] Does not access user data.
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependency changes