### PR TITLE
fix(hooks): replace window.setTimeout with global setTimeout in useDebouncedValue

### DIFF
--- a/hushh-webapp/hooks/use-debounced-value.ts
+++ b/hushh-webapp/hooks/use-debounced-value.ts
@@ -45,12 +45,12 @@ export function useDebouncedValue<T>(value: T, delayMs: number): T {
         ? delayMs
         : 0;
 
-    const timer = window.setTimeout(() => {
+    const timer = setTimeout(() => {
       setDebounced(value);
     }, clampedDelay);
 
     return () => {
-      window.clearTimeout(timer);
+      clearTimeout(timer);
     };
   }, [value, delayMs]);
 


### PR DESCRIPTION
## Summary

- what changed: Replaced window.setTimeout and window.clearTimeout with global setTimeout and clearTimeout in hushh-webapp/hooks/use-debounced-value.ts
- why it changed: window.setTimeout throws ReferenceError in SSR and Node.js environments where window is not defined. The global setTimeout and clearTimeout work in all JavaScript environments including browser, Node.js, and edge runtimes.

## Attach point

hushh-webapp/hooks/use-debounced-value.ts — exported hook consumed by search, filter, and form surfaces across the app.

## Contract changed

Runtime behavior: hook no longer throws ReferenceError in SSR or Node.js environments. No change to debounce semantics or timing.

## Tests run

```bash
cd hushh-webapp && npx tsc --noEmit
```
Passed locally. No type errors.

## Base/head status

Branch is current with main, mergeable, and DCO-signed. Targets integration/pr-train as required by repo base policy.

## Sensitive proof

Not applicable. No auth, consent, vault, PKM, finance, or KYC surfaces touched. No secrets involved. Rollback: revert by adding window. prefix back to both calls.

## Stack proof

Not applicable. Standalone fix, no predecessor PR.