### PR TITLE
fix(scripts): replace hardcoded generated_at date with dynamic timestamp in generate-surface-map.mjs

### DIFF
--- a/hushh-webapp/scripts/architecture/generate-surface-map.mjs
+++ b/hushh-webapp/scripts/architecture/generate-surface-map.mjs
@@ -78,9 +78,9 @@ function readVoiceActionIds(contractFile) {
   const payload = readJson(path.join(appRoot, contractFile));
   return Array.isArray(payload.actions)
     ? payload.actions
-        .map((action) => action?.action_id)
-        .filter((actionId) => typeof actionId === "string" && actionId.trim())
-        .sort()
+      .map((action) => action?.action_id)
+      .filter((actionId) => typeof actionId === "string" && actionId.trim())
+      .sort()
     : [];
 }
 
@@ -195,7 +195,7 @@ function buildSurfaceMap() {
 
   return {
     schema_version: "hushh.frontend_native_surface_map.v1",
-    generated_at: "2026-05-21",
+    generated_at: new Date().toISOString().slice(0, 10),
     purpose:
       "Scaffolded contract mapping app routes to Next.js API, backend, native parity, plugin, and voice/action surfaces.",
     sources: {
@@ -218,11 +218,11 @@ function buildSurfaceMap() {
         physical_page_exists: Boolean(pageFile),
         route_contract: routeContractEntry
           ? {
-              mode: routeContractEntry.mode,
-              exemption_reason: routeContractEntry.exemptionReason || null,
-              shell_verification_file: routeContractEntry.shellVerification?.file || null,
-              shell_verification_includes: routeContractEntry.shellVerification?.includes || [],
-            }
+            mode: routeContractEntry.mode,
+            exemption_reason: routeContractEntry.exemptionReason || null,
+            shell_verification_file: routeContractEntry.shellVerification?.file || null,
+            shell_verification_includes: routeContractEntry.shellVerification?.includes || [],
+          }
           : null,
         native: inventoryByRoute.get(route) || null,
         shell: shellForPage(pageFile),


### PR DESCRIPTION
## Summary

- what changed: Replaced hardcoded generated_at string "2026-05-21" with new Date().toISOString().slice(0, 10) in scripts/architecture/generate-surface-map.mjs
- why it changed: The hardcoded date never updates regardless of when the script runs making the metadata always wrong and the audit trail unreliable

## Attach point

scripts/architecture/generate-surface-map.mjs — architecture script that generates the surface map used by --check mode and audit tooling.

## Contract changed

Runtime behavior: generated_at now reflects the actual date the script was executed instead of a hardcoded stale value.

## Tests run

```bash
npx tsc --noEmit
```
Passed locally. No type errors.

## Base/head status

Branch is current with main, mergeable, and DCO-signed. Targets integration/pr-train as required by repo base policy.

## Sensitive proof

Not applicable. No auth, consent, vault, PKM, finance, or KYC surfaces touched. No secrets involved. Rollback: revert by replacing dynamic expression with a hardcoded date string.

## Stack proof

Not applicable. Standalone fix, no predecessor PR.