### PR TITLE
fix(hooks): initialize useIsMobile with correct value to prevent layout flash

### DIFF
--- a/hushh-webapp/hooks/use-mobile.ts
+++ b/hushh-webapp/hooks/use-mobile.ts
@@ -3,8 +3,7 @@ import * as React from "react"
 const MOBILE_BREAKPOINT = 768
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
-
+  const [isMobile, setIsMobile] = React.useState<boolean>(() => typeof window !== "undefined" ? window.innerWidth < MOBILE_BREAKPOINT : false)
   React.useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
     const onChange = () => {


### PR DESCRIPTION
## Summary

- what changed: Changed useState initializer in useIsMobile from undefined to a lazy initializer that reads window.innerWidth on the client and falls back to false on the server
- why it changed: The undefined initial state caused !!isMobile to return false on the first render regardless of actual viewport width causing a layout flash from desktop to mobile on every page load for mobile users

## Attach point

hushh-webapp/hooks/use-mobile.ts — exported hook consumed by sidebar, settings-ui, kai-control-surface, and other layout components across the app.

## Contract changed

Runtime behavior: useIsMobile now returns the correct value on the first render with no layout flash on mobile devices. No change to the change listener or cleanup behavior.

## Tests run

```bash
cd hushh-webapp && npx tsc --noEmit
```
Passed locally. No type errors.

## Base/head status

Branch is current with main, mergeable, and DCO-signed. Targets integration/pr-train as required by repo base policy.

## Sensitive proof

Not applicable. No auth, consent, vault, PKM, finance, or KYC surfaces touched. No secrets involved. Rollback: revert by changing lazy initializer back to undefined.

## Stack proof

Not applicable. Standalone fix, no predecessor PR.