### PR TITLE
fix(ui): prevent duplicate form submission while request is pending

### DIFF
--- a/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
@@ -816,6 +816,53 @@ describe("RiaOnboardingPage", () => {
     });
   });
 
+  it("does not submit onboarding twice while the first request is pending", async () => {
+    mocks.draftService.load.mockResolvedValue({
+      currentStepId: "review",
+      onboardingType: "individual",
+      licenseNumber: "7265726",
+      licenseVerificationStatus: "found",
+      advisorName: "Ria Ashley Sen",
+      firmName: "Not Currently Registered",
+      regulator: "SEC",
+      regulatorStatus: "ACTIVE",
+      crdNumber: "7265726",
+      individualCrd: "7265726",
+      verifiedLicensePrefillKey: "sec:7265726",
+      servicesOffered: ["Portfolio Management"],
+      feeStructure: ["Fee-only"],
+      contactEmail: "ria-e2e@example.invalid",
+    });
+
+    let resolveSubmit: (value: unknown) => void = () => undefined;
+    const pendingSubmit = new Promise((resolve) => {
+      resolveSubmit = resolve;
+    });
+    mocks.riaService.submitOnboarding.mockReturnValue(pendingSubmit);
+
+    render(<RiaOnboardingPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("step-review")).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("continue-btn"));
+      fireEvent.click(screen.getByTestId("continue-btn"));
+    });
+
+    expect(mocks.riaService.submitOnboarding).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveSubmit({
+        requested_capabilities: ["advisory"],
+        verification_status: "submitted",
+        advisory_status: "submitted",
+      });
+      await pendingSubmit;
+    });
+  });
+
   it("redirects to RIA home if already verified when submit clicked", async () => {
     mocks.riaService.getOnboardingStatus.mockResolvedValue({
       exists: true,

--- a/hushh-webapp/app/ria/onboarding/page.tsx
+++ b/hushh-webapp/app/ria/onboarding/page.tsx
@@ -141,6 +141,7 @@ export default function RiaOnboardingPage() {
     inFlight: boolean;
     lastKey: string | null;
   }>({ inFlight: false, lastKey: null });
+  const submitInFlightRef = useRef(false);
 
   const advisoryVerificationStatus =
     status?.advisory_status || status?.verification_status || "draft";
@@ -576,11 +577,13 @@ export default function RiaOnboardingPage() {
 
   async function handleSubmit() {
     if (!user) return;
+    if (submitInFlightRef.current) return;
     if (advisoryAccessReady) {
       router.push(ROUTES.RIA_HOME);
       return;
     }
 
+    submitInFlightRef.current = true;
     setSaving(true);
     setError(null);
 
@@ -697,6 +700,7 @@ export default function RiaOnboardingPage() {
             : "Failed to submit onboarding.",
       });
     } finally {
+      submitInFlightRef.current = false;
       setSaving(false);
     }
   }


### PR DESCRIPTION
## Summary
- add a synchronous in-flight guard for RIA onboarding submit requests
- keep the existing saving state for UI feedback while preventing same-tick duplicate submissions
- add a regression test that double-clicks submit while the first request is pending

## Validation
- npm run test -- __tests__/app/ria/onboarding-page.test.tsx
- npx eslint app/ria/onboarding/page.tsx __tests__/app/ria/onboarding-page.test.tsx --max-warnings=0