### PR TITLE
fix(routes): correct buildMarketplaceConnectionsRoute to use MARKETPLACE_CONNECTIONS instead of CONSENTS

### DIFF
--- a/hushh-webapp/lib/navigation/routes.ts
+++ b/hushh-webapp/lib/navigation/routes.ts
@@ -68,7 +68,7 @@ export function buildMarketplaceConnectionsRoute(entries?: {
   tab?: "pending" | "active" | "previous" | null;
   selected?: string | null;
 }) {
-  return withQuery(ROUTES.CONSENTS, {
+  return withQuery(ROUTES.MARKETPLACE_CONNECTIONS, {
     tab: entries?.tab,
     selected: entries?.selected,
   });


### PR DESCRIPTION
## Summary

- what changed: Changed ROUTES.CONSENTS to ROUTES.MARKETPLACE_CONNECTIONS in buildMarketplaceConnectionsRoute in hushh-webapp/lib/navigation/routes.ts
- why it changed: The function was silently routing to /consents instead of /marketplace/connections making any caller that expects marketplace connections UI land on the wrong page

## Attach point

hushh-webapp/lib/navigation/routes.ts — central route contract exported and consumed across all web and Capacitor navigation surfaces.

## Contract changed

Runtime behavior: buildMarketplaceConnectionsRoute now returns /marketplace/connections as the function name implies instead of /consents.

## Tests run

```bash
cd hushh-webapp && npx tsc --noEmit
```
Passed locally. No type errors.

## Base/head status

Branch is current with main, mergeable, and DCO-signed. Targets integration/pr-train as required by repo base policy.

## Sensitive proof

Not applicable. No auth, consent, vault, PKM, finance, or KYC surfaces touched. No secrets involved. Rollback: revert by changing ROUTES.MARKETPLACE_CONNECTIONS back to ROUTES.CONSENTS.

## Stack proof

Not applicable. Standalone fix, no predecessor PR.