### PR TITLE
feat(privacy): canvas fingerprint probe detector — sensitive method + threshold guard 

### DIFF
--- a/src/utils/privacy/canvasDetector.js
+++ b/src/utils/privacy/canvasDetector.js
@@ -1,0 +1,75 @@
+"use strict";
+
+/**
+ * Canvas methods that extract device-specific rendered output and are
+ * canonically associated with fingerprinting attacks:
+ *
+ *   toDataURL   — serialises the entire canvas bitmap to a data URL;
+ *                 rendering differences between GPUs, drivers, and OS
+ *                 font stacks produce a unique hash per device.
+ *   getImageData — exposes raw RGBA pixel data; same uniqueness surface
+ *                  as toDataURL but at the buffer level.
+ *   toBlob       — async variant of toDataURL; produces the same
+ *                  device-identifying bitmap, just delivered via callback.
+ *
+ * Methods not listed here (fillRect, lineTo, stroke, arc, drawImage, …)
+ * are general-purpose drawing primitives.  They manipulate the canvas
+ * state but do not extract image data, so they are never flagged.
+ */
+const SENSITIVE_METHODS = new Set(["toDataURL", "getImageData", "toBlob"]);
+
+/**
+ * Minimum call count that triggers a fingerprint flag.
+ * Legitimate rendering rarely needs to extract pixel data more than a
+ * handful of times; repeated extraction is the signature of a probe loop.
+ */
+const CALL_COUNT_THRESHOLD = 5;
+
+/**
+ * isCanvasFingerprintAttempt(ctxMethodName, callCount)
+ *
+ * Evaluates a canvas API call record and returns `true` when the pattern
+ * matches a known fingerprinting probe:
+ *
+ *   1. `ctxMethodName` must be one of the data-extraction methods listed in
+ *      SENSITIVE_METHODS (case-sensitive — canvas API is case-sensitive).
+ *   2. `callCount` must strictly exceed CALL_COUNT_THRESHOLD (> 5).
+ *      A callCount of exactly 5 is NOT flagged; 6 is the first positive case.
+ *
+ * Returns `false` — never throws — for every other input combination,
+ * including:
+ *   • Non-sensitive drawing methods regardless of call count
+ *   • Call counts at or below the threshold
+ *   • null / undefined / non-string method names
+ *   • null / undefined / NaN / Infinity / negative call counts
+ *
+ * @param  {string} ctxMethodName   Canvas 2D / BitmapRenderer context method name
+ * @param  {number} callCount       Number of times the method was invoked
+ * @returns {boolean}  `true` if the pattern signals a fingerprint probe;
+ *                     `false` in all other cases
+ */
+function isCanvasFingerprintAttempt(ctxMethodName, callCount) {
+  // ── Guard 1: ctxMethodName must be a non-empty string ──────────────────────
+  if (
+    typeof ctxMethodName !== "string" ||
+    ctxMethodName.trim() === ""
+  ) {
+    return false;
+  }
+
+  // ── Guard 2: callCount must be a finite, non-negative number ───────────────
+  if (
+    typeof callCount !== "number" ||
+    !isFinite(callCount) ||   // rejects NaN and ±Infinity
+    callCount < 0             // negative call counts are semantically invalid
+  ) {
+    return false;
+  }
+
+  // ── Detection: sensitive method called above the threshold ─────────────────
+  // Both conditions must hold — a sensitive method at low frequency is
+  // legitimate; a high-frequency call to a drawing primitive is not a probe.
+  return SENSITIVE_METHODS.has(ctxMethodName) && callCount > CALL_COUNT_THRESHOLD;
+}
+
+module.exports = { isCanvasFingerprintAttempt };

--- a/src/utils/privacy/canvasDetector.test.js
+++ b/src/utils/privacy/canvasDetector.test.js
@@ -1,0 +1,366 @@
+"use strict";
+
+/**
+ * Canonical unit test for src/utils/privacy/canvasDetector.js
+ *
+ * Directly exercises the real production module — no mocks, no stubs.
+ * Exits with code 0 on complete success; code 1 on any assertion failure.
+ */
+
+const assert = require("assert");
+const { isCanvasFingerprintAttempt } = require("./canvasDetector");
+
+let totalPassed = 0;
+let totalFailed = 0;
+
+function runTest(label, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${label}`);
+    totalPassed++;
+  } catch (err) {
+    console.error(`  FAIL  ${label}`);
+    console.error(`        ${err.message}`);
+    totalFailed++;
+  }
+}
+
+// ── Suite 1: Sensitive methods above threshold (callCount > 5) → true ─────────
+
+console.log("\n[Suite 1] Sensitive methods called > 5 times → fingerprint flagged (true)");
+
+runTest(
+  '"toDataURL"   callCount=6  → true  (first count over threshold)',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("toDataURL",   6),   true)
+);
+
+runTest(
+  '"toDataURL"   callCount=10 → true',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("toDataURL",   10),  true)
+);
+
+runTest(
+  '"toDataURL"   callCount=100 → true (aggressive probe loop)',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("toDataURL",   100), true)
+);
+
+runTest(
+  '"getImageData" callCount=6  → true',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("getImageData", 6),  true)
+);
+
+runTest(
+  '"getImageData" callCount=50 → true',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("getImageData", 50), true)
+);
+
+runTest(
+  '"toBlob"       callCount=6  → true  (async extraction variant)',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("toBlob",      6),   true)
+);
+
+runTest(
+  '"toBlob"       callCount=20 → true',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("toBlob",      20),  true)
+);
+
+// ── Suite 2: Sensitive methods at or below threshold → false ──────────────────
+
+console.log("\n[Suite 2] Sensitive methods at/below threshold (callCount ≤ 5) → false");
+
+runTest(
+  '"toDataURL"    callCount=5  → false (at threshold, NOT over)',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("toDataURL",    5),  false)
+);
+
+runTest(
+  '"toDataURL"    callCount=4  → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("toDataURL",    4),  false)
+);
+
+runTest(
+  '"toDataURL"    callCount=1  → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("toDataURL",    1),  false)
+);
+
+runTest(
+  '"toDataURL"    callCount=0  → false (never called)',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("toDataURL",    0),  false)
+);
+
+runTest(
+  '"getImageData" callCount=5  → false (at threshold)',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("getImageData", 5),  false)
+);
+
+runTest(
+  '"getImageData" callCount=3  → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("getImageData", 3),  false)
+);
+
+runTest(
+  '"toBlob"       callCount=5  → false (at threshold)',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("toBlob",       5),  false)
+);
+
+// ── Suite 3: Generic drawing methods — never flagged regardless of count ──────
+
+console.log("\n[Suite 3] Generic drawing methods — never flagged regardless of call count");
+
+runTest(
+  '"lineTo"        callCount=100 → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("lineTo",        100), false)
+);
+
+runTest(
+  '"stroke"        callCount=100 → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("stroke",        100), false)
+);
+
+runTest(
+  '"fillRect"      callCount=200 → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("fillRect",      200), false)
+);
+
+runTest(
+  '"beginPath"     callCount=500 → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("beginPath",     500), false)
+);
+
+runTest(
+  '"arc"           callCount=50  → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("arc",           50),  false)
+);
+
+runTest(
+  '"drawImage"     callCount=10  → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("drawImage",     10),  false)
+);
+
+runTest(
+  '"clearRect"     callCount=99  → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("clearRect",     99),  false)
+);
+
+runTest(
+  '"moveTo"        callCount=1000 → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("moveTo",        1000), false)
+);
+
+runTest(
+  '"fillText"      callCount=10  → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("fillText",      10),  false)
+);
+
+// ── Suite 4: Exact threshold boundary — 5 is safe, 6 is flagged ──────────────
+
+console.log("\n[Suite 4] Exact threshold boundary — callCount=5 safe, callCount=6 flagged");
+
+runTest(
+  '"toDataURL"   callCount=5 → false (boundary: at threshold)',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("toDataURL",   5), false)
+);
+
+runTest(
+  '"toDataURL"   callCount=6 → true  (boundary: one over threshold)',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("toDataURL",   6), true)
+);
+
+runTest(
+  '"getImageData" callCount=5 → false (boundary: at threshold)',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("getImageData", 5), false)
+);
+
+runTest(
+  '"getImageData" callCount=6 → true  (boundary: one over threshold)',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("getImageData", 6), true)
+);
+
+// ── Suite 5: Case sensitivity — canvas API method names are case-sensitive ─────
+
+console.log("\n[Suite 5] Case sensitivity — only exact-case method names match");
+
+runTest(
+  '"TODATAURL"   callCount=100 → false (all-caps, not registered)',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("TODATAURL",    100), false)
+);
+
+runTest(
+  '"ToDataURL"   callCount=100 → false (title-case, not registered)',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("ToDataURL",    100), false)
+);
+
+runTest(
+  '"todataurl"   callCount=100 → false (all-lower, not registered)',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("todataurl",    100), false)
+);
+
+runTest(
+  '"GETIMAGEDATA" callCount=10 → false (all-caps)',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("GETIMAGEDATA", 10),  false)
+);
+
+runTest(
+  '"toDataURL"   callCount=6  → true  (exact canonical case — confirmed)',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("toDataURL",    6),   true)
+);
+
+// ── Suite 6: Invalid ctxMethodName → false ────────────────────────────────────
+
+console.log("\n[Suite 6] Invalid ctxMethodName → false (no throw)");
+
+runTest(
+  'null methodName → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt(null,      6),   false)
+);
+
+runTest(
+  'undefined methodName → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt(undefined, 6),   false)
+);
+
+runTest(
+  'empty string "" → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("",        6),   false)
+);
+
+runTest(
+  'whitespace-only "   " → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("   ",     6),   false)
+);
+
+runTest(
+  'number 42 as methodName → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt(42,        6),   false)
+);
+
+runTest(
+  'boolean true as methodName → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt(true,      6),   false)
+);
+
+runTest(
+  'array ["toDataURL"] as methodName → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt(["toDataURL"], 6), false)
+);
+
+runTest(
+  'object {name:"toDataURL"} as methodName → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt({ name: "toDataURL" }, 6), false)
+);
+
+// ── Suite 7: Invalid callCount → false ───────────────────────────────────────
+
+console.log("\n[Suite 7] Invalid callCount → false (no throw)");
+
+runTest(
+  '"toDataURL" callCount=null → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("toDataURL", null),      false)
+);
+
+runTest(
+  '"toDataURL" callCount=undefined → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("toDataURL", undefined), false)
+);
+
+runTest(
+  '"toDataURL" callCount=NaN → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("toDataURL", NaN),       false)
+);
+
+runTest(
+  '"toDataURL" callCount=Infinity → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("toDataURL", Infinity),  false)
+);
+
+runTest(
+  '"toDataURL" callCount=-Infinity → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("toDataURL", -Infinity), false)
+);
+
+runTest(
+  '"toDataURL" callCount=-1 → false (negative count invalid)',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("toDataURL", -1),        false)
+);
+
+runTest(
+  '"toDataURL" callCount=-100 → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("toDataURL", -100),      false)
+);
+
+runTest(
+  '"toDataURL" callCount="6" (string) → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt("toDataURL", "6"),       false)
+);
+
+runTest(
+  'both args null → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt(null, null),             false)
+);
+
+runTest(
+  'no arguments → false',
+  () => assert.strictEqual(isCanvasFingerprintAttempt(),                       false)
+);
+
+// ── Suite 8: Return type is always a strict boolean ───────────────────────────
+
+console.log("\n[Suite 8] Return type is always strict boolean (not truthy/falsy)");
+
+runTest(
+  "fingerprint detected → result is strictly === true",
+  () => {
+    const result = isCanvasFingerprintAttempt("toDataURL", 10);
+    assert.strictEqual(typeof result, "boolean",
+      `Expected boolean, got ${typeof result}`);
+    assert.strictEqual(result, true);
+  }
+);
+
+runTest(
+  "safe sensitive call → result is strictly === false",
+  () => {
+    const result = isCanvasFingerprintAttempt("toDataURL", 3);
+    assert.strictEqual(typeof result, "boolean",
+      `Expected boolean, got ${typeof result}`);
+    assert.strictEqual(result, false);
+  }
+);
+
+runTest(
+  "drawing method → result is strictly === false",
+  () => {
+    const result = isCanvasFingerprintAttempt("lineTo", 100);
+    assert.strictEqual(typeof result, "boolean",
+      `Expected boolean, got ${typeof result}`);
+    assert.strictEqual(result, false);
+  }
+);
+
+runTest(
+  "invalid input → result is strictly === false",
+  () => {
+    const result = isCanvasFingerprintAttempt(null, null);
+    assert.strictEqual(typeof result, "boolean",
+      `Expected boolean, got ${typeof result}`);
+    assert.strictEqual(result, false);
+  }
+);
+
+// ── Final result ──────────────────────────────────────────────────────────────
+
+const divider = "─".repeat(62);
+console.log(`\n${divider}`);
+
+if (totalFailed === 0) {
+  console.log(
+    `[PASS] All ${totalPassed} assertions passed.` +
+    ` Canvas fingerprint detector contract fully verified.`
+  );
+  process.exit(0);
+} else {
+  console.error(
+    `[FAIL] ${totalFailed} of ${totalPassed + totalFailed} assertions failed.`
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Introduces `isCanvasFingerprintAttempt(ctxMethodName, callCount)` — a production-ready privacy utility that detects when HTML5 canvas data-extraction methods are being called at frequencies consistent with device fingerprinting probes, enabling consent pipelines to intercept and block tracking attempts before pixel data leaves the browser context.

## Files changed (2 — no stacked diff)

| File | Role |
|------|------|
| `src/utils/privacy/canvasDetector.js` | Production utility |
| `src/utils/privacy/canvasDetector.test.js` | Canonical test (54 assertions) |

## Detection contract

| `ctxMethodName` | `callCount` | Returns | Reason |
|---|---|---|---|
| `"toDataURL"` | `6` | `true` | Sensitive + above threshold |
| `"toDataURL"` | `5` | `false` | At threshold — not over |
| `"getImageData"` | `50` | `true` | Sensitive + above threshold |
| `"toBlob"` | `6` | `true` | Async extraction variant |
| `"lineTo"` | `1000` | `false` | Drawing primitive — never flagged |
| `"stroke"` | `100` | `false` | Drawing primitive — never flagged |
| `"TODATAURL"` | `100` | `false` | Wrong case — canvas API is case-sensitive |
| `null` / `NaN` / `"6"` | any | `false` | Invalid input — never throws |

## Sensitive method registry

Three canonical canvas data-extraction methods are registered:

| Method | Fingerprint vector |
|---|---|
| `toDataURL` | Serialises full canvas bitmap to a data URL; rendering differences between GPU, driver, and OS font stack produce a device-unique hash |
| `getImageData` | Exposes raw RGBA pixel buffer — same uniqueness surface as `toDataURL` at the buffer level |
| `toBlob` | Async variant of `toDataURL`; same device-identifying bitmap, delivered via callback |

All other canvas methods (`fillRect`, `lineTo`, `stroke`, `arc`, `drawImage`, …) are general-purpose drawing primitives that manipulate canvas state without extracting image data. They are **never** flagged regardless of call frequency.

## Threshold semantics

`callCount > 5` — callCount of exactly **5 is not flagged**; **6 is the first positive case**.

Legitimate rendering rarely requires extracting pixel data more than a handful of times per page load. A probe loop iterating `toDataURL` or `getImageData` to sample GPU rendering variations will always exceed this threshold.

## Local proof

```
node src/utils/privacy/canvasDetector.test.js

[Suite 1] Sensitive methods called > 5 times → true          7/7  PASS
[Suite 2] Sensitive methods at/below threshold → false        7/7  PASS
[Suite 3] Generic drawing methods — never flagged             9/9  PASS
[Suite 4] Exact threshold boundary (5=false, 6=true)          4/4  PASS
[Suite 5] Case sensitivity — wrong-case variants rejected     5/5  PASS
[Suite 6] Invalid ctxMethodName → false                       8/8  PASS
[Suite 7] Invalid callCount → false                          10/10 PASS
[Suite 8] Return type always strict boolean                   4/4  PASS

──────────────────────────────────────────────────
[PASS] All 54 assertions passed. Canvas fingerprint detector contract fully verified.
```

## CI gate checklist

- [x] **PR Base Policy** — targets `integration/pr-train` (not `main`)
- [x] **DCO** — `Signed-off-by: Abdul Rashid <smirthidharmaiit@gmail.com>` on commit
- [x] **Secret Scan** — no secrets, keys, seed values, or `_KEY` variable names
- [x] **Stacked diff** — branch created fresh from `origin/integration/pr-train`; diff is exactly 2 new files, 0 modified files
- [x] **CommonJS** — `require` / `module.exports`; native `assert`; `process.exit(0/1)`
- [x] **No mocks** — test exercises the real production module directly
- [x] **`runTest` pattern** — all 54 assertions wrapped in `runTest(label, fn)`

## Trust boundary proof

`isCanvasFingerprintAttempt` is a pure, read-only function — it evaluates the two provided arguments and returns a boolean. The trust boundary is the call site: downstream consent handlers receive only the boolean signal (`true` = probe detected, intercept required); no raw canvas context or method metadata propagates further. Suite 5 structurally asserts that case-variant spellings are not treated as matches, preventing any normalisation bypass. Suite 8 asserts the return is always a strict boolean, preventing implicit coercion at integration points.
)