### PR TITLE
feat(consent): inline purpose guard on consent approval request boundary

### DIFF
--- a/hushh-webapp/__tests__/api/consent/approve-purpose-guard.test.ts
+++ b/hushh-webapp/__tests__/api/consent/approve-purpose-guard.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Purpose guard proof for POST /api/consent/pending/approve
+ *
+ * Calls the shipped route handler (POST) directly — not through ApiService —
+ * so every assertion targets the actual request boundary, not a client stub.
+ *
+ * Rejection cases confirm that:
+ *   1. The handler returns 400 immediately.
+ *   2. fetch() is NEVER called — the backend is never reached.
+ *
+ * Pass-through cases confirm that each approved purpose clears the guard and
+ * proceeds to the backend fetch.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Module-level mock (hoisted before all imports) ────────────────────────────
+vi.mock("@/app/api/_utils/backend", () => ({
+  getPythonApiUrl: () => "http://mock-backend",
+}));
+
+// Import the live handler AFTER mock is registered.
+import { POST } from "@/app/api/consent/pending/approve/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function buildRequest(body: Record<string, unknown>): NextRequest {
+  return new Request("http://localhost/api/consent/pending/approve", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer vault-owner-token",
+    },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+const BASE_BODY = { userId: "user-123", requestId: "req-456" };
+
+const MOCK_BACKEND_OK = new Response(
+  JSON.stringify({ consentToken: "ct_ok" }),
+  { status: 200, headers: { "Content-Type": "application/json" } }
+);
+
+// ── Test suites ───────────────────────────────────────────────────────────────
+
+describe("POST /api/consent/pending/approve — purpose guard (inline default-deny)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ── Rejection cases ───────────────────────────────────────────────────────
+
+  describe("rejects invalid purpose with 400 — backend fetch() never called", () => {
+    it.each([
+      ["purpose key absent",          { ...BASE_BODY }],
+      ["purpose: null",               { ...BASE_BODY, purpose: null }],
+      ["purpose: empty string",       { ...BASE_BODY, purpose: "" }],
+      ["purpose: whitespace only",    { ...BASE_BODY, purpose: "   " }],
+      ["purpose: unlisted string",    { ...BASE_BODY, purpose: "tracking" }],
+      ["purpose: wrong case",         { ...BASE_BODY, purpose: "ANALYTICS" }],
+      ["purpose: numeric type",       { ...BASE_BODY, purpose: 1 }],
+      ["purpose: boolean type",       { ...BASE_BODY, purpose: true }],
+      ["purpose: array type",         { ...BASE_BODY, purpose: ["analytics"] }],
+      ["purpose: partial match",      { ...BASE_BODY, purpose: "analytic" }],
+    ])(
+      "%s → 400 and fetch not called",
+      async (_label, body) => {
+        const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+        const response = await POST(buildRequest(body));
+
+        expect(response.status).toBe(400);
+        const json = await response.json() as { error?: string };
+        expect(json.error).toMatch(/purpose/i);
+        expect(fetchSpy).not.toHaveBeenCalled();
+      }
+    );
+  });
+
+  // ── Pass-through cases ────────────────────────────────────────────────────
+
+  describe("allows every approved purpose through to backend", () => {
+    it.each([
+      "essential",
+      "analytics",
+      "marketing",
+      "personalization",
+      "research",
+    ])(
+      "purpose '%s' clears guard and reaches backend",
+      async (purpose) => {
+        const fetchSpy = vi
+          .spyOn(globalThis, "fetch")
+          .mockResolvedValue(MOCK_BACKEND_OK.clone());
+
+        const response = await POST(
+          buildRequest({ ...BASE_BODY, purpose })
+        );
+
+        // Guard cleared — backend was called exactly once.
+        expect(fetchSpy).toHaveBeenCalledOnce();
+        expect(response.status).toBe(200);
+      }
+    );
+  });
+
+  // ── Error message shape ───────────────────────────────────────────────────
+
+  it("error body names the approved-tiers requirement", async () => {
+    const response = await POST(
+      buildRequest({ ...BASE_BODY, purpose: "profiling" })
+    );
+    const json = await response.json() as { error?: string };
+    expect(json.error).toContain("approved operational tiers");
+  });
+});

--- a/hushh-webapp/app/api/consent/pending/approve/route.ts
+++ b/hushh-webapp/app/api/consent/pending/approve/route.ts
@@ -13,6 +13,15 @@ import { getPythonApiUrl } from "@/app/api/_utils/backend";
 
 const BACKEND_URL = getPythonApiUrl();
 
+/** Exhaustive list of consent purposes this endpoint accepts. */
+const APPROVED_PURPOSES = [
+  "essential",
+  "analytics",
+  "marketing",
+  "personalization",
+  "research",
+] as const;
+
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
@@ -39,6 +48,28 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
+
+    // ── Purpose guard (inline, default-deny) ─────────────────────────────────
+    // Reject before any backend call when purpose is absent, blank, or not in
+    // the approved operational tier list.  No helper import — validation lives
+    // entirely in this module so the check is always on the live request path.
+    const rawPurpose = (body as Record<string, unknown>).purpose;
+    if (
+      rawPurpose === undefined ||
+      rawPurpose === null ||
+      typeof rawPurpose !== "string" ||
+      rawPurpose.trim() === "" ||
+      !(APPROVED_PURPOSES as readonly string[]).includes(rawPurpose)
+    ) {
+      return NextResponse.json(
+        {
+          error:
+            "purpose is required and must be one of the approved operational tiers",
+        },
+        { status: 400 }
+      );
+    }
+    // ─────────────────────────────────────────────────────────────────────────
 
     if ("exportKey" in body) {
       return NextResponse.json(


### PR DESCRIPTION
## Summary

Injects a default-deny consent-purpose allowlist check directly into the shipped `POST /api/consent/pending/approve` route handler. No new helper file, no additional import — the validation is entirely self-contained within the module and fires on every inbound approval request.

## Files changed (2)

| File | Change |
|---|---|
| `hushh-webapp/app/api/consent/pending/approve/route.ts` | +31 lines — `APPROVED_PURPOSES` const + inline guard |
| `hushh-webapp/__tests__/api/consent/approve-purpose-guard.test.ts` | +118 lines — direct handler invocation proof |

## Route change

```typescript
/** Exhaustive list of consent purposes this endpoint accepts. */
const APPROVED_PURPOSES = [
  "essential", "analytics", "marketing", "personalization", "research",
] as const;

// Inside POST handler, after userId/requestId check, before backend fetch():
const rawPurpose = (body as Record<string, unknown>).purpose;
if (
  rawPurpose === undefined ||
  rawPurpose === null ||
  typeof rawPurpose !== "string" ||
  rawPurpose.trim() === "" ||
  !(APPROVED_PURPOSES as readonly string[]).includes(rawPurpose)
) {
  return NextResponse.json(
    { error: "purpose is required and must be one of the approved operational tiers" },
    { status: 400 }
  );
}
```

All original handler logic — `exportKey` check, `Authorization` header guard, backend `fetch()`, error parsing — is **completely untouched**.

## Rejection behaviour

| Input | Status |
|---|---|
| `purpose` key absent | 400 |
| `purpose: null` | 400 |
| `purpose: ""` | 400 |
| `purpose: "   "` (whitespace) | 400 |
| `purpose: "tracking"` (unlisted) | 400 |
| `purpose: "ANALYTICS"` (wrong case) | 400 |
| `purpose: 1` (numeric) | 400 |
| `purpose: "analytics"` ✓ | guard clears, backend reached |

## Test proof

`approve-purpose-guard.test.ts` calls the exported `POST` handler directly (not through ApiService) and uses a `fetch` spy to assert:

- **10 rejection cases** → `status === 400` AND `fetch` spy **not called** (backend never reached)
- **5 pass-through cases** (one per approved tier) → `fetch` called exactly once, `status === 200`
- **Error shape** → `error` message references `"approved operational tiers"`

## CI gate checklist

- [x] **PR Base Policy** — targets `integration/pr-train`
- [x] **DCO** — `Signed-off-by: Abdul Rashid <smirthidharmaiit@gmail.com>`
- [x] **No new helper files** — validation is inline in the route module
- [x] **No new imports** — zero change to the import block
- [x] **Original logic intact** — all downstream proxy code untouched
- [x] **Stacked diff** — branch from fresh `origin/integration/pr-train`; 2 files, 0 modified from base

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)