### PR TITLE
feat(consent): inline denial-reason guard on consent deny request boundary

### DIFF
--- a/hushh-webapp/__tests__/api/consent/deny-reason-guard.test.ts
+++ b/hushh-webapp/__tests__/api/consent/deny-reason-guard.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Denial-reason guard proof for POST /api/consent/pending/deny
+ *
+ * Calls the shipped route handler (POST) directly — not through ApiService —
+ * so every assertion targets the actual request boundary.
+ *
+ * Rejection cases confirm:
+ *   1. The handler returns 400 immediately.
+ *   2. fetch() is NEVER called — the backend is never reached.
+ *
+ * Pass-through cases confirm each approved reason clears the guard and
+ * proceeds to the backend fetch.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/app/api/_utils/backend", () => ({
+  getPythonApiUrl: () => "http://mock-backend",
+}));
+
+import { POST } from "@/app/api/consent/pending/deny/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function buildRequest(body: Record<string, unknown>): NextRequest {
+  return new Request("http://localhost/api/consent/pending/deny", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer vault-owner-token",
+    },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+const BASE_BODY = { userId: "user-123", requestId: "req-456" };
+
+const MOCK_BACKEND_OK = new Response(
+  JSON.stringify({ status: "denied" }),
+  { status: 200, headers: { "Content-Type": "application/json" } }
+);
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("POST /api/consent/pending/deny — denial-reason guard (inline default-deny)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ── Rejection cases ───────────────────────────────────────────────────────
+
+  describe("rejects invalid reason with 400 — backend fetch() never called", () => {
+    it.each([
+      ["reason key absent",           { ...BASE_BODY }],
+      ["reason: null",                { ...BASE_BODY, reason: null }],
+      ["reason: empty string",        { ...BASE_BODY, reason: "" }],
+      ["reason: whitespace only",     { ...BASE_BODY, reason: "   " }],
+      ["reason: free-form text",      { ...BASE_BODY, reason: "I just don't want to" }],
+      ["reason: unlisted category",   { ...BASE_BODY, reason: "unknown-reason" }],
+      ["reason: wrong case",          { ...BASE_BODY, reason: "User-Declined" }],
+      ["reason: numeric type",        { ...BASE_BODY, reason: 0 }],
+      ["reason: boolean type",        { ...BASE_BODY, reason: false }],
+      ["reason: array type",          { ...BASE_BODY, reason: ["user-declined"] }],
+    ])(
+      "%s → 400 and fetch not called",
+      async (_label, body) => {
+        const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+        const response = await POST(buildRequest(body));
+
+        expect(response.status).toBe(400);
+        const json = await response.json() as { error?: string };
+        expect(json.error).toMatch(/reason/i);
+        expect(fetchSpy).not.toHaveBeenCalled();
+      }
+    );
+  });
+
+  // ── Pass-through cases ────────────────────────────────────────────────────
+
+  describe("allows every approved denial reason through to backend", () => {
+    it.each([
+      "user-declined",
+      "scope-too-broad",
+      "policy-violation",
+      "expired-request",
+      "duplicate-request",
+    ])(
+      "reason '%s' clears guard and reaches backend",
+      async (reason) => {
+        const fetchSpy = vi
+          .spyOn(globalThis, "fetch")
+          .mockResolvedValue(MOCK_BACKEND_OK.clone());
+
+        const response = await POST(
+          buildRequest({ ...BASE_BODY, reason })
+        );
+
+        expect(fetchSpy).toHaveBeenCalledOnce();
+        expect(response.status).toBe(200);
+      }
+    );
+  });
+
+  // ── Error message shape ───────────────────────────────────────────────────
+
+  it("error body names the approved-categories requirement", async () => {
+    const response = await POST(
+      buildRequest({ ...BASE_BODY, reason: "nope" })
+    );
+    const json = await response.json() as { error?: string };
+    expect(json.error).toContain("approved denial categories");
+  });
+});

--- a/hushh-webapp/app/api/consent/pending/deny/route.ts
+++ b/hushh-webapp/app/api/consent/pending/deny/route.ts
@@ -12,6 +12,18 @@ import { getPythonApiUrl } from "@/app/api/_utils/backend";
 
 const BACKEND_URL = getPythonApiUrl();
 
+/**
+ * Exhaustive list of structured denial categories accepted by this endpoint.
+ * Any denial reason not in this list is rejected before reaching the backend.
+ */
+const APPROVED_DENIAL_REASONS = [
+  "user-declined",
+  "scope-too-broad",
+  "policy-violation",
+  "expired-request",
+  "duplicate-request",
+] as const;
+
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
@@ -23,6 +35,28 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
+
+    // ── Denial-reason guard (inline, default-deny) ────────────────────────────
+    // `reason` is required — a denial without a structured reason is
+    // indistinguishable from a silent drop and cannot be audited downstream.
+    // Must be an exact match in APPROVED_DENIAL_REASONS; no helper import.
+    const rawReason = (body as Record<string, unknown>).reason;
+    if (
+      rawReason === undefined ||
+      rawReason === null ||
+      typeof rawReason !== "string" ||
+      rawReason.trim() === "" ||
+      !(APPROVED_DENIAL_REASONS as readonly string[]).includes(rawReason)
+    ) {
+      return NextResponse.json(
+        {
+          error:
+            "reason is required and must be one of the approved denial categories",
+        },
+        { status: 400 }
+      );
+    }
+    // ─────────────────────────────────────────────────────────────────────────
 
     // Forward Authorization header (VAULT_OWNER token)
     const authHeader = request.headers.get("Authorization");


### PR DESCRIPTION
## Summary

Injects a default-deny structured denial-reason check directly into the shipped `POST /api/consent/pending/deny` handler. No new helper file, no additional import — the validation is self-contained within the module and fires on every inbound denial request.

## Files changed (2)

| File | Change |
|---|---|
| `hushh-webapp/app/api/consent/pending/deny/route.ts` | +34 lines — `APPROVED_DENIAL_REASONS` const + inline guard |
| `hushh-webapp/__tests__/api/consent/deny-reason-guard.test.ts` | +115 lines — direct handler invocation proof |

## Route change

```typescript
const APPROVED_DENIAL_REASONS = [
  "user-declined", "scope-too-broad", "policy-violation",
  "expired-request", "duplicate-request",
] as const;

// Inside POST handler, after userId/requestId check, before backend fetch():
const rawReason = (body as Record<string, unknown>).reason;
if (
  rawReason === undefined || rawReason === null ||
  typeof rawReason !== "string" || rawReason.trim() === "" ||
  !(APPROVED_DENIAL_REASONS as readonly string[]).includes(rawReason)
) {
  return NextResponse.json(
    { error: "reason is required and must be one of the approved denial categories" },
    { status: 400 }
  );
}
```

All original handler logic untouched.

## Rejection behaviour

| Input | Status |
|---|---|
| `reason` key absent | 400 |
| `reason: null` | 400 |
| `reason: ""` / whitespace | 400 |
| `reason: "nope"` (unlisted) | 400 |
| `reason: "User-Declined"` (wrong case) | 400 |
| `reason: "user-declined"` ✓ | guard clears, backend reached |

## Test proof — direct handler invocation

- **10 rejection cases** → `status === 400` AND `fetch` spy **not called**
- **5 pass-through cases** → `fetch` called exactly once, `status === 200`
- **Error shape** → message references `"approved denial categories"`

## CI gate checklist
- [x] **PR Base Policy** — targets `integration/pr-train`
- [x] **DCO** — `Signed-off-by: Abdul Rashid <smirthidharmaiit@gmail.com>`
- [x] **No new helper files** — validation inline, zero new imports
- [x] **Original logic intact** — all downstream proxy code untouched
- [x] **Clean diff** — 2 files, fresh base

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)