### PR TITLE
feat(consent): inline scope guard on consent revocation request boundary

### DIFF
--- a/hushh-webapp/__tests__/api/consent/revoke-scope-guard.test.ts
+++ b/hushh-webapp/__tests__/api/consent/revoke-scope-guard.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Scope guard proof for POST /api/consent/revoke
+ *
+ * Calls the shipped route handler (POST) directly — not through ApiService —
+ * so every assertion targets the actual request boundary.
+ *
+ * Rejection cases confirm:
+ *   1. Handler returns 400 immediately.
+ *   2. fetch() is NEVER called — backend never reached.
+ *
+ * Pass-through cases confirm each revocable scope clears the guard.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/app/api/_utils/backend", () => ({
+  getPythonApiUrl: () => "http://mock-backend",
+}));
+
+vi.mock("@/app/api/_utils/json-body", () => ({
+  invalidJsonPayloadResponse: () =>
+    new Response(JSON.stringify({ error: "invalid payload" }), { status: 400 }),
+  readJsonObject: async (req: Request) => {
+    try {
+      return await req.json();
+    } catch {
+      return null;
+    }
+  },
+}));
+
+import { POST } from "@/app/api/consent/revoke/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function buildRequest(body: Record<string, unknown>): NextRequest {
+  return new Request("http://localhost/api/consent/revoke", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer vault-owner-token",
+    },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+const BASE_BODY = { userId: "user-123" };
+
+const MOCK_BACKEND_OK = new Response(
+  JSON.stringify({ status: "revoked" }),
+  { status: 200, headers: { "Content-Type": "application/json" } }
+);
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("POST /api/consent/revoke — scope guard (inline default-deny)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ── Rejection cases ───────────────────────────────────────────────────────
+
+  describe("rejects invalid scope with 400 — backend fetch() never called", () => {
+    it.each([
+      ["scope: unlisted string",   { ...BASE_BODY, scope: "notifications" }],
+      ["scope: wildcard",          { ...BASE_BODY, scope: "*" }],
+      ["scope: SQL fragment",      { ...BASE_BODY, scope: "read; DROP TABLE" }],
+      ["scope: wrong case",        { ...BASE_BODY, scope: "READ" }],
+      ["scope: partial match",     { ...BASE_BODY, scope: "reads" }],
+      ["scope: empty string",      { ...BASE_BODY, scope: "" }],
+      ["scope: numeric type",      { ...BASE_BODY, scope: 1 }],
+      ["scope: boolean type",      { ...BASE_BODY, scope: true }],
+      ["scope: array type",        { ...BASE_BODY, scope: ["read"] }],
+    ])(
+      "%s → 400 and fetch not called",
+      async (_label, body) => {
+        const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+        const response = await POST(buildRequest(body));
+
+        expect(response.status).toBe(400);
+        const json = await response.json() as { error?: string };
+        expect(json.error).toMatch(/scope/i);
+        expect(fetchSpy).not.toHaveBeenCalled();
+      }
+    );
+  });
+
+  // ── Pass-through cases ────────────────────────────────────────────────────
+
+  describe("allows every revocable scope through to backend", () => {
+    it.each([
+      "read",
+      "write",
+      "export",
+      "full",
+      "analytics",
+      "marketing",
+      "personalization",
+    ])(
+      "scope '%s' clears guard and reaches backend",
+      async (scope) => {
+        const fetchSpy = vi
+          .spyOn(globalThis, "fetch")
+          .mockResolvedValue(MOCK_BACKEND_OK.clone());
+
+        const response = await POST(
+          buildRequest({ ...BASE_BODY, scope })
+        );
+
+        expect(fetchSpy).toHaveBeenCalledOnce();
+        expect(response.status).toBe(200);
+      }
+    );
+  });
+
+  // ── Error message shape ───────────────────────────────────────────────────
+
+  it("error body names the revocable-scopes requirement", async () => {
+    const response = await POST(
+      buildRequest({ ...BASE_BODY, scope: "admin" })
+    );
+    const json = await response.json() as { error?: string };
+    expect(json.error).toContain("revocable consent scopes");
+  });
+});

--- a/hushh-webapp/app/api/consent/revoke/route.ts
+++ b/hushh-webapp/app/api/consent/revoke/route.ts
@@ -15,6 +15,20 @@ import {
 
 const BACKEND_URL = getPythonApiUrl();
 
+/**
+ * Scope values this revocation endpoint will act on.
+ * Prevents arbitrary or injected strings from reaching the consent service.
+ */
+const REVOCABLE_SCOPES = [
+  "read",
+  "write",
+  "export",
+  "full",
+  "analytics",
+  "marketing",
+  "personalization",
+] as const;
+
 export async function POST(request: NextRequest) {
   try {
     const body = (await readJsonObject(request)) as {
@@ -35,6 +49,19 @@ export async function POST(request: NextRequest) {
         { status: 400 },
       );
     }
+
+    // ── Scope guard (inline, default-deny) ────────────────────────────────────
+    // Validate scope against the known revocable surface before any backend
+    // call.  Unrecognised scope values are rejected here so the Python service
+    // never receives an arbitrary string it cannot act on.  No helper import.
+    if (!(REVOCABLE_SCOPES as readonly string[]).includes(scope)) {
+      return NextResponse.json(
+        { error: "scope must be one of the recognised revocable consent scopes" },
+        { status: 400 },
+      );
+    }
+    // ─────────────────────────────────────────────────────────────────────────
+
     if (!authHeader) {
       return NextResponse.json(
         { error: "Missing Authorization header" },


### PR DESCRIPTION
## Summary

Injects a default-deny scope allowlist check directly into the shipped `POST /api/consent/revoke` handler. No new helper file, no extra import — the validation is self-contained in the module and fires on every inbound revocation request before the backend is reached.

## Files changed (2)

| File | Change |
|---|---|
| `hushh-webapp/app/api/consent/revoke/route.ts` | +27 lines — `REVOCABLE_SCOPES` const + inline guard |
| `hushh-webapp/__tests__/api/consent/revoke-scope-guard.test.ts` | +127 lines — direct handler invocation proof |

## Route change

```typescript
const REVOCABLE_SCOPES = [
  "read", "write", "export", "full",
  "analytics", "marketing", "personalization",
] as const;

// Inside POST handler, after userId/scope presence check, before backend fetch():
if (!(REVOCABLE_SCOPES as readonly string[]).includes(scope)) {
  return NextResponse.json(
    { error: "scope must be one of the recognised revocable consent scopes" },
    { status: 400 }
  );
}
```

## Rejection behaviour

| Input | Status |
|---|---|
| `scope: "notifications"` (unlisted) | 400 |
| `scope: "*"` (wildcard) | 400 |
| `scope: "read; DROP TABLE"` (injection) | 400 |
| `scope: "READ"` (wrong case) | 400 |
| `scope: "read"` ✓ | guard clears, backend reached |

## Test proof — direct handler invocation

- **9 rejection cases** → `status === 400` AND `fetch` spy **not called**
- **7 pass-through cases** (one per revocable scope) → `fetch` called exactly once, `status === 200`
- **Error shape** → message references `"revocable consent scopes"`

## CI gate checklist
- [x] **PR Base Policy** — targets `integration/pr-train`
- [x] **DCO** — `Signed-off-by: Abdul Rashid <smirthidharmaiit@gmail.com>`
- [x] **No new helper files** — validation inline, zero new imports
- [x] **Original logic intact** — all downstream proxy code untouched
- [x] **Clean diff** — 2 files, fresh base

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)