### PR TITLE
feat(consent): inline structural integrity guard in normalizeConsentResponse

### DIFF
--- a/hushh-webapp/__tests__/utils/normalize-consent.test.ts
+++ b/hushh-webapp/__tests__/utils/normalize-consent.test.ts
@@ -1,5 +1,8 @@
 import { normalizeConsentResponse } from "@/src/lib/consent/normalizeConsent";
 
+// Shorthand for the closed fallback state asserted in integrity-guard tests.
+const DENY = { isGranted: false, permissions: [] as string[] };
+
 describe("normalizeConsentResponse", () => {
   it("treats active and granted flags as granted", () => {
     expect(normalizeConsentResponse({ active: true }).isGranted).toBe(true);
@@ -25,4 +28,73 @@ describe("normalizeConsentResponse", () => {
       }).permissions
     ).toEqual(["profile:read", "vault:read"]);
   });
+
+  // ── Integrity guard proof ──────────────────────────────────────────────────
+  // Each case below represents a class of tampered or corrupted payload.
+  // The guard must intercept ALL of them before the mapping logic runs and
+  // return the closed DENY_STATE — fetch/backend never entered.
+
+  describe("integrity guard — default-deny on tampered or corrupted payloads", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const call = (v: unknown) => normalizeConsentResponse(v as any);
+
+    it("rejects string-coerced active flag (truthy injection)", () => {
+      expect(call({ active: "true" })).toStrictEqual(DENY);
+    });
+
+    it("rejects numeric-coerced granted flag (1 is not a boolean)", () => {
+      expect(call({ granted: 1 })).toStrictEqual(DENY);
+    });
+
+    it("rejects object status (non-string type in status field)", () => {
+      expect(call({ status: {} })).toStrictEqual(DENY);
+    });
+
+    it("rejects array-as-status (truncation / wrong type)", () => {
+      expect(call({ status: ["approved"] })).toStrictEqual(DENY);
+    });
+
+    it("rejects stringified permissions blob (not an array)", () => {
+      expect(call({ permissions: "profile:read,vault:read" })).toStrictEqual(DENY);
+    });
+
+    it("rejects object-wrapped scopes (not an array)", () => {
+      expect(call({ scopes: { 0: "vault:read" } })).toStrictEqual(DENY);
+    });
+
+    it("rejects array top-level payload (not a plain object)", () => {
+      expect(call([{ active: true }])).toStrictEqual(DENY);
+    });
+
+    it("rejects prototype-pollution payload (__proto__ own key)", () => {
+      // JSON.parse is the safe way to construct an object with __proto__ as an
+      // own enumerable key without actually mutating the prototype chain.
+      const poisoned = JSON.parse('{"__proto__":{"isGranted":true},"active":true}');
+      expect(call(poisoned)).toStrictEqual(DENY);
+    });
+
+    it("rejects constructor-poisoning payload (constructor as own key)", () => {
+      const poisoned = JSON.parse('{"constructor":{"prototype":{}},"granted":true}');
+      expect(call(poisoned)).toStrictEqual(DENY);
+    });
+
+    it("passes a well-formed payload through the guard unchanged", () => {
+      const result = call({
+        active: true,
+        granted: true,
+        status: "approved",
+        permissions: ["profile:read"],
+        scopes: ["vault:read"],
+      });
+      expect(result.isGranted).toBe(true);
+      expect(result.permissions).toContain("profile:read");
+      expect(result.permissions).toContain("vault:read");
+    });
+
+    it("null and undefined still return safe default — existing contract preserved", () => {
+      expect(call(null)).toStrictEqual(DENY);
+      expect(call(undefined)).toStrictEqual(DENY);
+    });
+  });
+  // ── End integrity guard proof ──────────────────────────────────────────────
 });

--- a/hushh-webapp/__tests__/utils/normalize-consent.test.ts
+++ b/hushh-webapp/__tests__/utils/normalize-consent.test.ts
@@ -35,8 +35,7 @@ describe("normalizeConsentResponse", () => {
   // return the closed DENY_STATE — fetch/backend never entered.
 
   describe("integrity guard — default-deny on tampered or corrupted payloads", () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const call = (v: unknown) => normalizeConsentResponse(v as any);
+    const call = (v: unknown) => normalizeConsentResponse(v as never);
 
     it("rejects string-coerced active flag (truthy injection)", () => {
       expect(call({ active: "true" })).toStrictEqual(DENY);

--- a/hushh-webapp/src/lib/consent/normalizeConsent.ts
+++ b/hushh-webapp/src/lib/consent/normalizeConsent.ts
@@ -11,9 +11,46 @@ export interface NormalizedConsentState {
   permissions: string[];
 }
 
+/** Closed fallback returned whenever structural integrity cannot be confirmed. */
+const DENY_STATE: NormalizedConsentState = { isGranted: false, permissions: [] };
+
 export function normalizeConsentResponse(
   response: RawConsentResponse | null | undefined
 ): NormalizedConsentState {
+  // ── Structural integrity guard (inline, default-deny) ──────────────────────
+  // Intercepts payloads that show signs of tampering, type-coercion injection,
+  // or prototype-pollution before any mapping logic runs.  No external import.
+  //
+  // A well-formed RawConsentResponse satisfies all of:
+  //   • plain object (not array, not primitive)
+  //   • no own "constructor" / "__proto__" keys (prototype-pollution vectors)
+  //   • active / granted are boolean when present (not truthy-coerced strings)
+  //   • status is string or null when present (not an object / array)
+  //   • permissions / scopes are arrays when present (not stringified blobs)
+  //
+  // Any violation short-circuits to DENY_STATE; null/undefined is allowed
+  // through unchanged (the existing mapping already handles it safely).
+  if (response !== null && response !== undefined) {
+    const r = response as Record<string, unknown>;
+    const own = (k: string): boolean =>
+      Object.prototype.hasOwnProperty.call(r, k);
+
+    if (
+      typeof r !== "object" ||
+      Array.isArray(r) ||
+      own("__proto__") ||
+      own("constructor") ||
+      (own("active")      && typeof r["active"]      !== "boolean") ||
+      (own("granted")     && typeof r["granted"]     !== "boolean") ||
+      (own("status")      && r["status"] !== null    && typeof r["status"] !== "string") ||
+      (own("permissions") && !Array.isArray(r["permissions"])) ||
+      (own("scopes")      && !Array.isArray(r["scopes"]))
+    ) {
+      return DENY_STATE;
+    }
+  }
+  // ── End integrity guard ────────────────────────────────────────────────────
+
   const permissions = [
     ...(Array.isArray(response?.permissions) ? response.permissions : []),
     ...(Array.isArray(response?.scopes) ? response.scopes : []),


### PR DESCRIPTION
## Summary

Injects a compact, default-deny structural integrity check at the entry point of `normalizeConsentResponse` — the core consent normalization engine. The guard intercepts tampered, truncated, and prototype-polluted payloads **before any mapping logic runs**. No new files, no new imports.

## Files changed (2)

| File | Change |
|---|---|
| `hushh-webapp/src/lib/consent/normalizeConsent.ts` | +37 lines — `DENY_STATE` const + inline integrity block |
| `hushh-webapp/__tests__/utils/normalize-consent.test.ts` | +72 lines — 11 guard cases added to existing suite |

## Guard logic (inline, no imports)

```typescript
const DENY_STATE: NormalizedConsentState = { isGranted: false, permissions: [] };

// At the top of normalizeConsentResponse, before existing mapping:
if (response !== null && response !== undefined) {
  const r = response as Record<string, unknown>;
  const own = (k: string): boolean =>
    Object.prototype.hasOwnProperty.call(r, k);

  if (
    typeof r !== "object" || Array.isArray(r) ||
    own("__proto__")  || own("constructor") ||
    (own("active")      && typeof r["active"]      !== "boolean") ||
    (own("granted")     && typeof r["granted"]     !== "boolean") ||
    (own("status")      && r["status"] !== null    && typeof r["status"] !== "string") ||
    (own("permissions") && !Array.isArray(r["permissions"])) ||
    (own("scopes")      && !Array.isArray(r["scopes"]))
  ) {
    return DENY_STATE;
  }
}
```

## What each check stops

| Tamper class | Vector | Result |
|---|---|---|
| `active: "true"` | truthy-string coercion injection | `DENY_STATE` |
| `granted: 1` | numeric coercion | `DENY_STATE` |
| `status: {}` / `["approved"]` | field truncation / type substitution | `DENY_STATE` |
| `permissions: "read,write"` | stringified blob replacing array | `DENY_STATE` |
| `scopes: { 0: "vault:read" }` | object-wrapped scope | `DENY_STATE` |
| `[{ active: true }]` | array at top level | `DENY_STATE` |
| `{"__proto__": {...}}` | prototype-pollution (own key) | `DENY_STATE` |
| `{"constructor": {...}}` | constructor poisoning (own key) | `DENY_STATE` |
| Well-formed payload | — | passes through unchanged |
| `null` / `undefined` | — | existing safe mapping preserved |

## Test proof — added to existing `normalize-consent.test.ts`

11 new `it` cases inside a nested `describe("integrity guard")` block. Each tamper class is exercised with `.toStrictEqual(DENY)` to confirm the closed fallback is returned. The pass-through case confirms clean payloads are unaffected.

## CI gate checklist
- [x] **PR Base Policy** — targets `integration/pr-train`
- [x] **DCO** — `Signed-off-by: Abdul Rashid <smirthidharmaiit@gmail.com>`
- [x] **No new files** — guard is inline; test cases extend the existing suite
- [x] **No new imports** — zero additions to the import block
- [x] **Original logic intact** — all existing permissions mapping and status normalization untouched
- [x] **Clean diff** — 2 files, fresh base from `origin/integration/pr-train`

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)