### PR TITLE
feat(middleware): inline GPC opt-out flag in FastAPI auth dependency pipeline

### DIFF
--- a/consent-protocol/api/middleware.py
+++ b/consent-protocol/api/middleware.py
@@ -22,6 +22,31 @@ logger = logging.getLogger(__name__)
 _CONSENT_SCOPE_CACHE_ATTR = "_hushh_validated_consent_scopes"
 _NO_REQUEST = cast(Request, None)
 
+# Canonical GPC header name (ASGI lowercases all header names on ingress).
+_SEC_GPC_HEADER = "sec-gpc"
+
+
+def _apply_gpc_flag(request: "Request | None") -> None:
+    """Inspect the Sec-GPC request header and, when the user has signalled a
+    Global Privacy Control opt-out (value ``'1'``), stamp the request state
+    with privacy-safe defaults **before** any downstream handler executes.
+
+    Attributes written on ``request.state`` when GPC opt-out is active:
+        gpc_opt_out       = True  — canonical opt-out signal for route handlers
+        tracking_allowed  = False — suppresses optional cross-site tracking
+        analytics_allowed = False — suppresses optional behavioural analytics
+
+    When the header is absent, set to ``'0'``, or the request is ``None``,
+    this function is a no-op — existing state is never modified.
+    No new imports required; all logic is inline.
+    """
+    if request is None:
+        return
+    if request.headers.get(_SEC_GPC_HEADER, "") == "1":
+        request.state.gpc_opt_out = True
+        request.state.tracking_allowed = False
+        request.state.analytics_allowed = False
+
 
 def _auth_error(detail: str) -> HTTPException:
     """Helper to ensure consistent 401 Unauthorized responses across all routes."""
@@ -204,6 +229,9 @@ async def require_vault_owner_token(
         HTTPException 401 if token is missing or invalid
         HTTPException 403 if token scope is insufficient
     """
+    # GPC opt-out — must run before token validation or any downstream logic.
+    _apply_gpc_flag(request)
+
     header_value = (
         hushh_consent if isinstance(hushh_consent, str) and hushh_consent.strip() else authorization
     )
@@ -238,6 +266,9 @@ def require_consent_scope(required_scope: str | ConsentScope):
             None, description="Bearer token for scoped consent authentication"
         ),
     ) -> dict:
+        # GPC opt-out — must run before token validation or any downstream logic.
+        _apply_gpc_flag(request)
+
         token = _extract_token(authorization, allow_raw=False)
         valid, reason, token_obj = await _validate_token_with_scope_cache(
             token, required_scope, request

--- a/consent-protocol/tests/test_api_middleware.py
+++ b/consent-protocol/tests/test_api_middleware.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 from fastapi import BackgroundTasks, HTTPException
+from starlette.datastructures import Headers
 
 import api.middleware as middleware
 
@@ -151,3 +152,74 @@ async def test_require_consent_scope_cache_is_scope_specific(monkeypatch):
         ("consent-token", "attr.financial.*"),
         ("consent-token", "attr.health.*"),
     ]
+
+
+# ── GPC opt-out guard proof ───────────────────────────────────────────────────
+
+
+def _make_request(headers: list[tuple[str, str]]) -> SimpleNamespace:
+    """Build a minimal request stand-in with a real Starlette Headers object."""
+    return SimpleNamespace(
+        state=SimpleNamespace(),
+        headers=Headers(headers=headers),
+    )
+
+
+def test_gpc_opt_out_header_sets_privacy_deny_flags():
+    """Sec-GPC: 1 must set gpc_opt_out=True, tracking_allowed=False,
+    analytics_allowed=False on request.state before any downstream logic."""
+    request = _make_request([("sec-gpc", "1")])
+
+    middleware._apply_gpc_flag(request)
+
+    assert request.state.gpc_opt_out is True
+    assert request.state.tracking_allowed is False
+    assert request.state.analytics_allowed is False
+
+
+def test_gpc_header_absent_leaves_request_state_untouched():
+    """No Sec-GPC header → _apply_gpc_flag is a no-op; state is never written."""
+    request = _make_request([])
+
+    middleware._apply_gpc_flag(request)
+
+    assert not hasattr(request.state, "gpc_opt_out")
+    assert not hasattr(request.state, "tracking_allowed")
+    assert not hasattr(request.state, "analytics_allowed")
+
+
+def test_gpc_header_value_zero_leaves_request_state_untouched():
+    """Sec-GPC: 0 is an explicit opt-in; state must not be modified."""
+    request = _make_request([("sec-gpc", "0")])
+
+    middleware._apply_gpc_flag(request)
+
+    assert not hasattr(request.state, "gpc_opt_out")
+    assert not hasattr(request.state, "tracking_allowed")
+
+
+@pytest.mark.asyncio
+async def test_require_vault_owner_token_applies_gpc_flag_before_token_validation(monkeypatch):
+    """When Sec-GPC: 1 is present, require_vault_owner_token must stamp privacy
+    deny flags on request.state before token validation completes."""
+
+    async def _fake_validate(token: str, scope):
+        return (
+            True,
+            None,
+            SimpleNamespace(user_id="user-123", agent_id="kai", scope=scope, scope_str=None),
+        )
+
+    monkeypatch.setattr(middleware, "validate_token_with_db", _fake_validate)
+
+    request = _make_request([("sec-gpc", "1")])
+
+    await middleware.require_vault_owner_token(
+        request=request,
+        authorization="Bearer test-token",
+    )
+
+    # GPC flag must be set even though token validation also succeeded.
+    assert request.state.gpc_opt_out is True
+    assert request.state.tracking_allowed is False
+    assert request.state.analytics_allowed is False


### PR DESCRIPTION
## Summary

Injects Global Privacy Control (GPC) header detection directly into the live FastAPI authentication dependency pipeline. When a request carries `Sec-GPC: 1`, the `request.state` is stamped with privacy-safe defaults **before** any token validation, routing, or downstream handler executes. No new files, no new imports.

## Files changed (2)

| File | Change |
|---|---|
| `consent-protocol/api/middleware.py` | +31 lines — `_SEC_GPC_HEADER` const + `_apply_gpc_flag` + 2 call-sites |
| `consent-protocol/tests/test_api_middleware.py` | +72 lines — 4 test cases added to existing suite |

## Implementation

```python
_SEC_GPC_HEADER = "sec-gpc"  # ASGI lowercases all header names on ingress

def _apply_gpc_flag(request: "Request | None") -> None:
    if request is None:
        return
    if request.headers.get(_SEC_GPC_HEADER, "") == "1":
        request.state.gpc_opt_out = True
        request.state.tracking_allowed = False
        request.state.analytics_allowed = False
```

Called as the **first statement** in both request-handling dependency bodies:

| Call-site | Function | Fires before |
|---|---|---|
| 1 | `require_vault_owner_token` | `header_value` resolution, token extraction, DB validation |
| 2 | `require_consent_scope._require_scope_token` | `_extract_token`, scope validation, DB lookup |

## State written on GPC opt-out

| Attribute | Value | Meaning |
|---|---|---|
| `request.state.gpc_opt_out` | `True` | Canonical opt-out signal for route handlers |
| `request.state.tracking_allowed` | `False` | Suppresses optional cross-site tracking |
| `request.state.analytics_allowed` | `False` | Suppresses optional behavioural analytics |

No-op when: header absent, value is `"0"`, or `request` is `None`.

## Test proof — added to existing `test_api_middleware.py`

| Test | Input | Assertion |
|---|---|---|
| `test_gpc_opt_out_header_sets_privacy_deny_flags` | `Sec-GPC: 1` | All three state flags set correctly |
| `test_gpc_header_absent_leaves_request_state_untouched` | No header | No state attributes written |
| `test_gpc_header_value_zero_leaves_request_state_untouched` | `Sec-GPC: 0` | No state attributes written |
| `test_require_vault_owner_token_applies_gpc_flag_before_token_validation` | `Sec-GPC: 1` through full `require_vault_owner_token` call | State flags set even when token validation passes |

## CI gate checklist
- [x] **PR Base Policy** — targets `integration/pr-train`
- [x] **DCO** — `Signed-off-by: Abdul Rashid <smirthidharmaiit@gmail.com>`
- [x] **No new files** — logic and tests in existing modules
- [x] **No new imports** in `middleware.py` — zero import block changes
- [x] **Original logic intact** — all auth, caching, rate-limiting code untouched
- [x] **Clean diff** — 2 files, fresh base

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)