### PR TITLE
fix(routes): correct KAI_DASHBOARD route to /kai/dashboard in routes.ts

### DIFF
--- a/hushh-webapp/lib/navigation/routes.ts
+++ b/hushh-webapp/lib/navigation/routes.ts
@@ -37,7 +37,7 @@ export const ROUTES = {
   KAI_PORTFOLIO: "/kai/portfolio",
   KAI_INVESTMENTS: "/kai/investments",
   KAI_FUNDING_TRADE: "/kai/funding-trade",
-  KAI_DASHBOARD: "/kai/portfolio",
+  KAI_DASHBOARD: "/kai/dashboard",
   KAI_ANALYSIS: "/kai/analysis",
   KAI_OPTIMIZE: "/kai/optimize",
 } as const;


### PR DESCRIPTION
## Summary

- what changed: Changed KAI_DASHBOARD from /kai/portfolio to /kai/dashboard in hushh-webapp/lib/navigation/routes.ts
- why it changed: KAI_DASHBOARD and KAI_PORTFOLIO both pointed to /kai/portfolio making them identical. The Portfolio and Dashboard tabs could never be independently active and any navigation to a real /kai/dashboard page would silently resolve to /kai/portfolio.

## Attach point

hushh-webapp/lib/navigation/routes.ts — central route contract exported and consumed across all web and Capacitor navigation surfaces including navbar tab routing.

## Contract changed

Runtime behavior: KAI_DASHBOARD now resolves to /kai/dashboard as a distinct route separate from KAI_PORTFOLIO at /kai/portfolio.

## Tests run

```bash
cd hushh-webapp && npx tsc --noEmit
```
Passed locally. No type errors.

## Base/head status

Branch is current with main, mergeable, and DCO-signed. Targets integration/pr-train as required by repo base policy.

## Sensitive proof

Not applicable. No auth, consent, vault, PKM, finance, or KYC surfaces touched. No secrets involved. Rollback: revert by changing /kai/dashboard back to /kai/portfolio.

## Stack proof

Not applicable. Standalone fix, no predecessor PR.