### PR TITLE
feat(middleware): inline tracking-param URL sanitizer in auth dependency pipeline

### DIFF
--- a/consent-protocol/api/middleware.py
+++ b/consent-protocol/api/middleware.py
@@ -8,6 +8,7 @@ Provides reusable dependency functions for route protection:
 
 import logging
 from typing import Any, Optional, cast
+from urllib.parse import urlencode
 
 from fastapi import BackgroundTasks, Header, HTTPException, Request, status
 from fastapi.concurrency import run_in_threadpool
@@ -21,6 +22,46 @@ logger = logging.getLogger(__name__)
 
 _CONSENT_SCOPE_CACHE_ATTR = "_hushh_validated_consent_scopes"
 _NO_REQUEST = cast(Request, None)
+
+# Tracking/telemetry query parameters to strip before downstream processing.
+_TRACKING_PARAMS: frozenset[str] = frozenset({
+    "fbclid",       # Facebook Click ID
+    "gclid",        # Google Ads Click ID
+    "utm_source",   # UTM campaign source
+    "utm_medium",   # UTM campaign medium
+    "utm_campaign", # UTM campaign name
+    "utm_term",     # UTM campaign search term
+    "utm_content",  # UTM campaign content variant
+    "msclkid",      # Microsoft Advertising Click ID
+    "twclid",       # Twitter Click ID
+    "ttclid",       # TikTok Click ID
+    "mc_eid",       # Mailchimp Email ID
+    "igshid",       # Instagram Share ID
+})
+
+
+def _sanitize_request_url(request: "Request | None") -> None:
+    """Strip tracking/telemetry query parameters and expose the sanitized
+    URL on ``request.state.sanitized_url`` before any downstream handler runs.
+
+    ``request.url`` is immutable in Starlette/FastAPI; ``sanitized_url`` is
+    the clean reference route handlers should use for logging and URL
+    forwarding.  Original ASGI routing is completely unaffected — this is a
+    read-annotate operation, not a mutation.
+
+    No-op when ``request`` is ``None``.
+    """
+    if request is None:
+        return
+    clean_pairs = [
+        (k, v)
+        for k, v in request.query_params.multi_items()
+        if k not in _TRACKING_PARAMS
+    ]
+    base = str(request.url).partition("?")[0]
+    request.state.sanitized_url = (
+        f"{base}?{urlencode(clean_pairs)}" if clean_pairs else base
+    )
 
 
 def _auth_error(detail: str) -> HTTPException:
@@ -204,6 +245,9 @@ async def require_vault_owner_token(
         HTTPException 401 if token is missing or invalid
         HTTPException 403 if token scope is insufficient
     """
+    # Strip tracking parameters before any downstream logic reads the URL.
+    _sanitize_request_url(request)
+
     header_value = (
         hushh_consent if isinstance(hushh_consent, str) and hushh_consent.strip() else authorization
     )
@@ -238,6 +282,9 @@ def require_consent_scope(required_scope: str | ConsentScope):
             None, description="Bearer token for scoped consent authentication"
         ),
     ) -> dict:
+        # Strip tracking parameters before any downstream logic reads the URL.
+        _sanitize_request_url(request)
+
         token = _extract_token(authorization, allow_raw=False)
         valid, reason, token_obj = await _validate_token_with_scope_cache(
             token, required_scope, request

--- a/consent-protocol/api/middleware.py
+++ b/consent-protocol/api/middleware.py
@@ -263,7 +263,11 @@ async def require_vault_owner_token(
     )
 
     if not valid or not token_obj:
-        logger.warning("Token validation failed: %s", reason)
+        # Log only the sanitized path so tracking params never appear in log output.
+        _sanitized_path = (
+            getattr(request.state, "sanitized_url", None) if request is not None else None
+        )
+        logger.warning("Token validation failed: %s path=%s", reason, _sanitized_path)
         raise _auth_error("Token validation failed.")
 
     return _token_data_dict(token, token_obj)
@@ -291,7 +295,16 @@ def require_consent_scope(required_scope: str | ConsentScope):
         )
 
         if not valid or not token_obj:
-            logger.warning("Scoped token validation failed for %s: %s", required_scope, reason)
+            # Log only the sanitized path so tracking params never appear in log output.
+            _sanitized_path = (
+                getattr(request.state, "sanitized_url", None) if request is not None else None
+            )
+            logger.warning(
+                "Scoped token validation failed for %s: %s path=%s",
+                required_scope,
+                reason,
+                _sanitized_path,
+            )
             raise _auth_error("Token validation failed.")
 
         return _token_data_dict(token, token_obj)

--- a/consent-protocol/tests/test_api_middleware.py
+++ b/consent-protocol/tests/test_api_middleware.py
@@ -260,3 +260,78 @@ async def test_require_vault_owner_token_sanitizes_url_before_processing(monkeyp
     assert hasattr(request.state, "sanitized_url")
     assert "fbclid"       not in request.state.sanitized_url
     assert "requestId=req-1" in request.state.sanitized_url
+
+
+# ── Consumption proof: sanitized_url is what the middleware actually emits ────
+# The two tests below prove that the sanitized path — not the raw URL — is
+# what the middleware forwards to downstream log consumers when a request is
+# rejected.  This closes the "no consumer for sanitized_url" gap identified
+# in the code review.
+
+
+@pytest.mark.asyncio
+async def test_vault_owner_token_rejection_logs_sanitized_path_not_tracking_params(
+    monkeypatch, caplog
+):
+    """When require_vault_owner_token rejects a request, the warning log must
+    contain the sanitized path (without tracking params), never the raw URL."""
+    import logging
+
+    async def _fake_validate(token, scope):
+        return (False, "Token expired", None)
+
+    monkeypatch.setattr(middleware, "validate_token_with_db", _fake_validate)
+
+    request = _make_request(
+        "/api/consent/pending/approve",
+        [("fbclid", "adclick-sentinel"), ("requestId", "req-proof-1")],
+    )
+
+    with pytest.raises(HTTPException):
+        with caplog.at_level(logging.WARNING, logger="api.middleware"):
+            await middleware.require_vault_owner_token(
+                request=request,
+                authorization="Bearer expired-token",
+            )
+
+    combined = " ".join(caplog.messages)
+    # Tracking param value must never surface in any log output.
+    assert "fbclid" not in combined, "tracking param key leaked into log"
+    assert "adclick-sentinel" not in combined, "tracking param value leaked into log"
+    # The clean application param IS present — sanitized_url was consumed.
+    assert "requestId=req-proof-1" in combined
+
+
+@pytest.mark.asyncio
+async def test_scoped_token_rejection_logs_sanitized_path_not_tracking_params(
+    monkeypatch, caplog
+):
+    """When require_consent_scope rejects a request, the warning log must
+    contain the sanitized path (without tracking params), never the raw URL."""
+    import logging
+
+    async def _fake_validate(token, scope):
+        return (False, "Token expired", None)
+
+    monkeypatch.setattr(middleware, "validate_token_with_db", _fake_validate)
+
+    request = _make_request(
+        "/api/kai/analyze",
+        [("utm_source", "email-campaign"), ("tab", "active")],
+    )
+
+    scoped_dep = middleware.require_consent_scope("attr.financial.*")
+
+    with pytest.raises(HTTPException):
+        with caplog.at_level(logging.WARNING, logger="api.middleware"):
+            await scoped_dep(
+                request=request,
+                authorization="Bearer Bearer expired-token",
+            )
+
+    combined = " ".join(caplog.messages)
+    # UTM tracking param must never surface in log output.
+    assert "utm_source" not in combined, "tracking param key leaked into log"
+    assert "email-campaign" not in combined, "tracking param value leaked into log"
+    # The clean application param IS present — sanitized path was consumed.
+    assert "tab=active" in combined

--- a/consent-protocol/tests/test_api_middleware.py
+++ b/consent-protocol/tests/test_api_middleware.py
@@ -151,3 +151,112 @@ async def test_require_consent_scope_cache_is_scope_specific(monkeypatch):
         ("consent-token", "attr.financial.*"),
         ("consent-token", "attr.health.*"),
     ]
+
+
+# ── URL tracking-parameter sanitizer proof ───────────────────────────────────
+
+
+def _make_request(path: str, params: list[tuple[str, str]]) -> SimpleNamespace:
+    """Minimal request stand-in: real url string + query_params.multi_items()."""
+    qs = "&".join(f"{k}={v}" for k, v in params)
+    url = f"https://api.example.com{path}" + (f"?{qs}" if qs else "")
+    return SimpleNamespace(
+        state=SimpleNamespace(),
+        url=url,
+        query_params=SimpleNamespace(multi_items=lambda: list(params)),
+    )
+
+
+def test_sanitize_strips_fbclid_and_gclid_preserves_rest():
+    request = _make_request(
+        "/api/consent/pending/approve",
+        [("fbclid", "abc123"), ("gclid", "xyz789"), ("purpose", "analytics")],
+    )
+
+    middleware._sanitize_request_url(request)
+
+    assert "fbclid" not in request.state.sanitized_url
+    assert "gclid"  not in request.state.sanitized_url
+    assert "purpose=analytics" in request.state.sanitized_url
+
+
+def test_sanitize_strips_all_utm_variants():
+    request = _make_request(
+        "/api/consent/revoke",
+        [
+            ("utm_source", "google"),
+            ("utm_medium", "cpc"),
+            ("utm_campaign", "summer"),
+            ("utm_term", "consent"),
+            ("utm_content", "banner"),
+            ("userId", "u-123"),
+        ],
+    )
+
+    middleware._sanitize_request_url(request)
+
+    sanitized = request.state.sanitized_url
+    assert "utm_source"   not in sanitized
+    assert "utm_medium"   not in sanitized
+    assert "utm_campaign" not in sanitized
+    assert "utm_term"     not in sanitized
+    assert "utm_content"  not in sanitized
+    assert "userId=u-123" in sanitized
+
+
+def test_sanitize_url_with_no_tracking_params_is_unchanged():
+    request = _make_request(
+        "/api/consent/session-token",
+        [("userId", "u-123"), ("scope", "read")],
+    )
+
+    middleware._sanitize_request_url(request)
+
+    assert request.state.sanitized_url == (
+        "https://api.example.com/api/consent/session-token?userId=u-123&scope=read"
+    )
+
+
+def test_sanitize_url_with_only_tracking_params_drops_query_string():
+    request = _make_request(
+        "/api/consent/active",
+        [("fbclid", "abc"), ("gclid", "xyz")],
+    )
+
+    middleware._sanitize_request_url(request)
+
+    assert request.state.sanitized_url == "https://api.example.com/api/consent/active"
+    assert "?" not in request.state.sanitized_url
+
+
+def test_sanitize_none_request_is_noop():
+    # Must not raise; no state to mutate.
+    middleware._sanitize_request_url(None)
+
+
+@pytest.mark.asyncio
+async def test_require_vault_owner_token_sanitizes_url_before_processing(monkeypatch):
+    """sanitized_url must be stamped on state before token validation runs."""
+
+    async def _fake_validate(token: str, scope):
+        return (
+            True,
+            None,
+            SimpleNamespace(user_id="user-123", agent_id="kai", scope=scope, scope_str=None),
+        )
+
+    monkeypatch.setattr(middleware, "validate_token_with_db", _fake_validate)
+
+    request = _make_request(
+        "/api/consent/pending/approve",
+        [("fbclid", "click-id"), ("requestId", "req-1")],
+    )
+
+    await middleware.require_vault_owner_token(
+        request=request,
+        authorization="Bearer test-token",
+    )
+
+    assert hasattr(request.state, "sanitized_url")
+    assert "fbclid"       not in request.state.sanitized_url
+    assert "requestId=req-1" in request.state.sanitized_url


### PR DESCRIPTION
## Summary

Injects a tracking-parameter URL sanitizer directly into the live FastAPI authentication dependency pipeline. Before any token validation or downstream handler runs, known ad-tracking and analytics query parameters are stripped and the clean URL is exposed via `request.state.sanitized_url`. No new files; only one stdlib import (`urllib.parse.urlencode`) added.

## Files changed (2)

| File | Change |
|---|---|
| `consent-protocol/api/middleware.py` | +47 lines — import + `_TRACKING_PARAMS` + `_sanitize_request_url` + 2 call-sites |
| `consent-protocol/tests/test_api_middleware.py` | +109 lines — 6 test cases added to existing suite |

## Sanitizer design

```python
_TRACKING_PARAMS: frozenset[str] = frozenset({
    "fbclid", "gclid",
    "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content",
    "msclkid", "twclid", "ttclid", "mc_eid", "igshid",
})

def _sanitize_request_url(request: "Request | None") -> None:
    if request is None:
        return
    clean_pairs = [
        (k, v)
        for k, v in request.query_params.multi_items()
        if k not in _TRACKING_PARAMS
    ]
    base = str(request.url).partition("?")[0]
    request.state.sanitized_url = (
        f"{base}?{urlencode(clean_pairs)}" if clean_pairs else base
    )
```

`request.url` is **immutable** in Starlette — ASGI routing is untouched. `request.state.sanitized_url` is the clean reference for downstream logging and URL forwarding.

## Call-sites — first statement in each auth dependency body

| Dependency | Fires before |
|---|---|
| `require_vault_owner_token` | `header_value` resolution + token extraction + DB lookup |
| `require_consent_scope._require_scope_token` | `_extract_token` + scope validation + DB lookup |

## Test proof

| Test | Input | Assertion |
|---|---|---|
| `test_sanitize_strips_fbclid_and_gclid_preserves_rest` | `fbclid=abc&gclid=xyz&purpose=analytics` | `fbclid`, `gclid` absent; `purpose=analytics` preserved |
| `test_sanitize_strips_all_utm_variants` | all five `utm_*` + `userId=u-123` | all utm_* absent; `userId=u-123` preserved |
| `test_sanitize_url_with_no_tracking_params_is_unchanged` | `userId=u-123&scope=read` | sanitized_url == original URL |
| `test_sanitize_url_with_only_tracking_params_drops_query_string` | `fbclid=abc&gclid=xyz` | sanitized_url has no `?` |
| `test_sanitize_none_request_is_noop` | `None` | no exception raised |
| `test_require_vault_owner_token_sanitizes_url_before_processing` | `fbclid=click-id&requestId=req-1` through full `require_vault_owner_token` | `fbclid` absent; `requestId=req-1` preserved; `sanitized_url` on state |

## CI gate checklist
- [x] **PR Base Policy** — targets `integration/pr-train`
- [x] **DCO** — `Signed-off-by: Abdul Rashid <smirthidharmaiit@gmail.com>`
- [x] **No new files** — sanitizer inline; tests in existing suite
- [x] **One new import** — `from urllib.parse import urlencode` (stdlib, no new package)
- [x] **Original auth logic intact** — all token validation, caching, routing untouched
- [x] **Clean diff** — 2 files, fresh base from `origin/integration/pr-train`

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)