### PR TITLE
feat(consent-active): inline timeline-expiry guard in active consent GET route

### DIFF
--- a/hushh-webapp/__tests__/api/consent/api-service-consent.test.ts
+++ b/hushh-webapp/__tests__/api/consent/api-service-consent.test.ts
@@ -1,4 +1,30 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Route-level mocks (hoisted, apply before route module is imported) ────────
+vi.mock("@/app/api/_utils/backend", () => ({
+  getPythonApiUrl: () => "http://mock-backend",
+}));
+
+vi.mock("@/app/api/_utils/hot-get-json-cache", () => ({
+  createHotGetJsonCache: () => ({
+    read:          vi.fn(() => null),
+    getInflight:   vi.fn(() => null),
+    setInflight:   vi.fn(),
+    write:         vi.fn(),
+    clearInflight: vi.fn(),
+  }),
+}));
+
+vi.mock("@/app/api/_utils/request-id", () => ({
+  resolveRequestId:      () => "test-rid",
+  createUpstreamHeaders: (_id: string, h: Record<string, string>) => h,
+  withRequestIdJson: (_id: string, body: unknown, init?: ResponseInit) =>
+    new Response(JSON.stringify(body), {
+      status: (init?.status as number) ?? 200,
+      headers: { "content-type": "application/json" },
+    }),
+}));
 
 // Move mocks to the top-level scope to ensure they apply before imports
 vi.mock("@capacitor/core", () => ({
@@ -90,3 +116,103 @@ describe("ApiService consent token plumbing", () => {
     }
   });
 });
+
+// ── Timeline-expiry enforcement proof ─────────────────────────────────────────
+// Tests the GET /api/consent/active route handler directly.
+
+function makeActiveRequest(userId = "user-123"): NextRequest {
+  return new Request(
+    `http://localhost/api/consent/active?userId=${userId}`,
+    { headers: { Authorization: "Bearer test-token" } }
+  ) as unknown as NextRequest;
+}
+
+function backendResponse(items: unknown[], status = 200): Response {
+  return new Response(JSON.stringify({ items }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("GET /api/consent/active — inline timeline-expiry enforcement", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    // AbortSignal.timeout may be absent in older jsdom — provide a safe stub.
+    if (typeof AbortSignal.timeout !== "function") {
+      vi.stubGlobal("AbortSignal", {
+        ...AbortSignal,
+        timeout: () => new AbortController().signal,
+      });
+    }
+  });
+
+  it("returns 401 when an item carries an expired expires_at (Unix seconds)", async () => {
+    const expiredSecs = Math.floor((Date.now() - 3_600_000) / 1_000); // 1 h ago
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      backendResponse([{ id: "c1", expires_at: expiredSecs }])
+    ));
+
+    const { GET } = await import("@/app/api/consent/active/route");
+    const res = await GET(makeActiveRequest());
+
+    expect(res.status).toBe(401);
+    const body = await res.json() as { error?: string };
+    expect(body.error).toMatch(/expired/i);
+  });
+
+  it("returns 401 when an item carries an ISO-string expires_at in the past", async () => {
+    const expiredIso = new Date(Date.now() - 7_200_000).toISOString(); // 2 h ago
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      backendResponse([{ id: "c2", expires_at: expiredIso }])
+    ));
+
+    const { GET } = await import("@/app/api/consent/active/route");
+    const res = await GET(makeActiveRequest());
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when an item's issued_at exceeds the 24-hour policy window", async () => {
+    const staleSecs = Math.floor((Date.now() - 25 * 3_600_000) / 1_000); // 25 h ago
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      backendResponse([{ id: "c3", issued_at: staleSecs }])
+    ));
+
+    const { GET } = await import("@/app/api/consent/active/route");
+    const res = await GET(makeActiveRequest());
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 200 when all items have a future expires_at", async () => {
+    const futureSecs = Math.floor((Date.now() + 3_600_000) / 1_000); // 1 h from now
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      backendResponse([{ id: "c4", expires_at: futureSecs }])
+    ));
+
+    const { GET } = await import("@/app/api/consent/active/route");
+    const res = await GET(makeActiveRequest());
+
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 200 when items have no timestamp fields (no expiry data to evaluate)", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      backendResponse([{ id: "c5", scope: "read" }])
+    ));
+
+    const { GET } = await import("@/app/api/consent/active/route");
+    const res = await GET(makeActiveRequest());
+
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 400 when userId query param is absent", async () => {
+    const { GET } = await import("@/app/api/consent/active/route");
+    const req = new Request("http://localhost/api/consent/active") as unknown as NextRequest;
+    const res = await GET(req);
+
+    expect(res.status).toBe(400);
+  });
+});
+// ── End timeline-expiry enforcement proof ─────────────────────────────────────

--- a/hushh-webapp/app/api/consent/active/route.ts
+++ b/hushh-webapp/app/api/consent/active/route.ts
@@ -21,6 +21,9 @@ const hotGet = createHotGetJsonCache({
   staleTtlMs: 5 * 60 * 1000,
 });
 
+/** Maximum window an active consent may span before this layer force-expires it. */
+const _CONSENT_POLICY_WINDOW_MS = 24 * 60 * 60 * 1_000; // 24 hours
+
 export const dynamic = "force-dynamic";
 
 export async function GET(request: NextRequest) {
@@ -79,6 +82,40 @@ export async function GET(request: NextRequest) {
       hotGet.setInflight(hotCacheKey, load);
     }
     const result = await load;
+
+    // ── Inline timeline verification (default-deny) ───────────────────────────
+    // Secondary enforcement: inspect every item in a 200 payload for stale
+    // timestamps before the response reaches the client.  Two signals trigger
+    // a force-expire:
+    //   1. expires_at is already in the past (consent expired server-side but
+    //      slipped through the backend filter).
+    //   2. issued_at predates the policy window ceiling (_CONSENT_POLICY_WINDOW_MS).
+    // Numbers are treated as Unix epoch seconds (standard Python/FastAPI output).
+    // All original cache and error-handling logic below is untouched.
+    if (result.status === 200) {
+      const items = (result.payload as Record<string, unknown>)?.items;
+      if (Array.isArray(items)) {
+        const now = Date.now();
+        const stale = (items as Array<Record<string, unknown>>).some(item => {
+          const toMs = (v: unknown): number | null => {
+            if (v == null) return null;
+            const n = typeof v === "number" ? v * 1_000 : Date.parse(String(v));
+            return Number.isFinite(n) ? n : null;
+          };
+          const expiresMs = toMs(item["expires_at"]);
+          if (expiresMs !== null && expiresMs <= now) return true;
+          const issuedMs  = toMs(item["issued_at"]);
+          return issuedMs !== null && now - issuedMs > _CONSENT_POLICY_WINDOW_MS;
+        });
+        if (stale) {
+          const body = { error: "Active consent session has expired. Re-authentication required." };
+          if (hotCacheKey) hotGet.write(hotCacheKey, { status: 401, payload: body });
+          return withRequestIdJson(requestId, body, { status: 401 });
+        }
+      }
+    }
+    // ── End timeline verification ─────────────────────────────────────────────
+
     if (hotCacheKey && result.status < 500) {
       hotGet.write(hotCacheKey, result);
     } else if (hotCacheKey && result.status >= 500) {


### PR DESCRIPTION
## Summary

Injects a secondary timeline-expiry enforcement layer directly into the shipped `GET /api/consent/active` route handler. After the backend response is received and before it reaches the client, every item in the payload is inspected for stale timestamps. Stale sessions are force-expired with a 401 before the payload can be cached or forwarded. No new files, no new imports.

## Files changed (2)

| File | Change |
|---|---|
| `hushh-webapp/app/api/consent/active/route.ts` | +37 lines — `_CONSENT_POLICY_WINDOW_MS` const + inline timeline check |
| `hushh-webapp/__tests__/api/consent/api-service-consent.test.ts` | +126 lines — 3 route mocks + 6-case expiry suite |

## Injection point

```
const result = await load;          ← backend response received
[ timeline check fires here ]       ← new guard
if (hotCacheKey && ...)             ← original cache-write (untouched)
```

## Two stale signals that trigger 401

```typescript
const toMs = (v: unknown): number | null => {
  if (v == null) return null;
  const n = typeof v === "number" ? v * 1_000 : Date.parse(String(v));
  return Number.isFinite(n) ? n : null;
};
// Signal 1: expires_at is in the past
const expiresMs = toMs(item["expires_at"]);
if (expiresMs !== null && expiresMs <= now) return true;
// Signal 2: issued_at exceeds 24-hour policy ceiling
const issuedMs = toMs(item["issued_at"]);
return issuedMs !== null && now - issuedMs > _CONSENT_POLICY_WINDOW_MS;
```

Numbers are treated as Unix epoch **seconds** (standard FastAPI/Python output) and converted to milliseconds.

## Test proof — direct `GET` handler invocation

| Case | Payload | Status |
|---|---|---|
| Unix-second `expires_at` 1 hour in the past | `{ id, expires_at: <past-secs> }` | **401** |
| ISO-string `expires_at` 2 hours in the past | `{ id, expires_at: "<iso-past>" }` | **401** |
| `issued_at` 25 hours ago (exceeds 24-h window) | `{ id, issued_at: <stale-secs> }` | **401** |
| `expires_at` 1 hour in the future | `{ id, expires_at: <future-secs> }` | 200 |
| Items with no timestamp fields | `{ id, scope: "read" }` | 200 |
| Missing `userId` query param | — | 400 (existing guard) |

## CI gate checklist
- [x] **PR Base Policy** — targets `integration/pr-train`
- [x] **DCO** — `Signed-off-by: Abdul Rashid <smirthidharmaiit@gmail.com>`
- [x] **No new files** — guard inline; tests in existing file
- [x] **No new imports** in `route.ts` — zero import block changes
- [x] **Original logic intact** — cache, inflight, error, stale-fallback untouched
- [x] **Clean diff** — 2 files, fresh base from `origin/integration/pr-train`

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)