### PR TITLE
fix(frontend): add aria-hidden to decorative icons in portfolio review view

### DIFF
--- a/hushh-webapp/components/kai/views/portfolio-review-view.tsx
+++ b/hushh-webapp/components/kai/views/portfolio-review-view.tsx
@@ -1996,9 +1996,9 @@ export function PortfolioReviewView({
                       )}
                     >
                       {totalUnrealizedGainLoss >= 0 ? (
-                        <Icon icon={TrendingUp} size={12} className="mr-1.5" />
+                        <Icon icon={TrendingUp} size={12} className="mr-1.5" aria-hidden="true" />
                       ) : (
-                        <Icon icon={TrendingDown} size={12} className="mr-1.5" />
+                        <Icon icon={TrendingDown} size={12} className="mr-1.5" aria-hidden="true" />
                       )}
                       <span title={formatCurrency(totalUnrealizedGainLoss)}>
                         {formatCurrencyCompact(totalUnrealizedGainLoss)} unrealized
@@ -2061,7 +2061,7 @@ export function PortfolioReviewView({
 
 
             <div className="flex items-center gap-2">
-              <Icon icon={Building2} size="sm" />
+              <Icon icon={Building2} size="sm" aria-hidden="true" />
               Account Information
             </div>
           </AccordionTrigger>
@@ -2145,7 +2145,7 @@ export function PortfolioReviewView({
 
 
               <div className="flex items-center gap-2">
-                <Icon icon={PieChart} size="sm" />
+                <Icon icon={PieChart} size="sm" aria-hidden="true" />
                 Asset Allocation
               </div>
             </AccordionTrigger>
@@ -2234,7 +2234,7 @@ export function PortfolioReviewView({
 
 
               <div className="flex items-center gap-2">
-                <Icon icon={Wallet} size="sm" />
+                <Icon icon={Wallet} size="sm" aria-hidden="true" />
                 Income Summary
               </div>
             </AccordionTrigger>
@@ -2290,7 +2290,7 @@ export function PortfolioReviewView({
                   size="sm"
                   onClick={handleAddHolding}
                 >
-                  <Icon icon={Plus} size="sm" className="mr-1" />
+                  <Icon icon={Plus} size="sm" className="mr-1" aria-hidden="true" />
                   Add Holding
                 </MorphyButton>
               </div>
@@ -2414,7 +2414,7 @@ export function PortfolioReviewView({
                   {isBusySaving ? (
                     <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                   ) : (
-                    <Icon icon={Save} size="sm" className="mr-2" />
+                    <Icon icon={Save} size="sm" className="mr-2" aria-hidden="true" />
                   )}
                   {isBusySaving
                     ? hasVault === false


### PR DESCRIPTION
# Description

Added `aria-hidden="true"` to purely decorative icons used next to text labels in the Portfolio Review view to improve accessibility and prevent redundant announcements by screen readers.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Not applicable

- UI browser or Playwright proof:
  - [x] Not applicable

- Verification commands executed:
  - [x] `./bin/hushh codex pre-pr`
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm run lint`

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — `hushh-webapp/components/kai/views/portfolio-review-view.tsx`.
- [x] Reachable production attach point: Portfolio Review View.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: HTML attribute-only change, no iOS/Android impact.
- [x] **iOS**: Not applicable.
- [x] **Android**: Not applicable.

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

No UI-visible change — purely an accessibility fix for screen readers.

## 🛡️ Privacy & Consent

- [x] Does not access user data.
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependency changes