### PR TITLE
chore(ui): remove production console logs from KaiFlow

### DIFF
--- a/hushh-webapp/components/kai/kai-flow.tsx
+++ b/hushh-webapp/components/kai/kai-flow.tsx
@@ -515,13 +515,7 @@ function normalizePortfolioData(backendData: Record<string, unknown>): ReviewPor
     parse_fallback: normalized.parse_fallback === true,
   };
 
-  console.log("[KaiFlow] Final normalized data:", {
-    holdingsCount: result.holdings?.length || 0,
-    hasAccountInfo: !!result.account_info,
-    hasAccountSummary: !!result.account_summary,
-    totalValue: result.total_value,
-    cashBalance: result.cash_balance,
-  });
+
 
   return result;
 }
@@ -2537,9 +2531,7 @@ export function KaiFlow({
         const parsedPortfolioData: ReviewPortfolioData = parsedPortfolio;
         trackImportTerminalTelemetry("success");
 
-        console.log("[KaiFlow] Portfolio parsed via streaming:", {
-          holdings: parsedPortfolioData.holdings?.length || 0,
-        });
+
 
         // Store parsed portfolio and transition to review state
         setFlowData((prev) => ({
@@ -2618,7 +2610,7 @@ export function KaiFlow({
             setState("importing");
             return;
           }
-          console.log("[KaiFlow] Import cancelled by user");
+
           persistBackgroundSnapshot("canceled");
           clearImportBackgroundSnapshot(userId);
           importResumeAppliedRef.current = false;
@@ -2875,7 +2867,7 @@ export function KaiFlow({
     // Update cache context so other pages (Manage, etc.) can access the data
     setPortfolioData(userId, portfolioData);
     CacheSyncService.onPortfolioUpserted(userId, portfolioData);
-    console.log("[KaiFlow] Portfolio data saved to cache");
+
 
     setFlowData({
       hasFinancialData: true,


### PR DESCRIPTION
# Description

Removed leftover development `console.log` statements from the KaiFlow component to clean up the production browser console during portfolio imports, aligning with standard hygiene practices.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Not applicable

- UI browser or Playwright proof:
  - [x] Not applicable

- Verification commands executed:
  - [x] `./bin/hushh codex pre-pr`
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm run lint`

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — `hushh-webapp/components/kai/kai-flow.tsx`.
- [x] Reachable production attach point: Kai Portfolio Import Flow.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Console output cleanup only, no iOS/Android impact.
- [x] **iOS**: Not applicable.
- [x] **Android**: Not applicable.

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

No UI-visible change — purely a console hygiene cleanup.

## 🛡️ Privacy & Consent

- [x] Does not access user data.
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependency changes