### PR TITLE
fix(frontend): add aria-hidden to decorative badges in decision card

### DIFF
--- a/hushh-webapp/components/kai/views/decision-card.tsx
+++ b/hushh-webapp/components/kai/views/decision-card.tsx
@@ -788,22 +788,22 @@ function RenaissanceBadge({ tier, score }: { tier: "ACE" | "KING" | "QUEEN" | "J
   const badgeConfig = {
     ACE: {
       color: "bg-fuchsia-100 text-fuchsia-700 border-fuchsia-200 dark:bg-fuchsia-950/30 dark:text-fuchsia-400 dark:border-fuchsia-800",
-      icon: <Icon icon={Crown} size="xs" className="fill-current" />,
+      icon: <Icon icon={Crown} size="xs" className="fill-current" aria-hidden="true" />,
       label: "Renaissance Ace",
     },
     KING: {
       color: "bg-amber-100 text-amber-700 border-amber-200 dark:bg-amber-950/30 dark:text-amber-400 dark:border-amber-800",
-      icon: <Icon icon={Trophy} size="xs" className="fill-current" />,
+      icon: <Icon icon={Trophy} size="xs" className="fill-current" aria-hidden="true" />,
       label: "Renaissance King",
     },
     QUEEN: {
       color: "bg-violet-100 text-violet-700 border-violet-200 dark:bg-violet-950/30 dark:text-violet-400 dark:border-violet-800",
-      icon: <Icon icon={Star} size="xs" className="fill-current" />,
+      icon: <Icon icon={Star} size="xs" className="fill-current" aria-hidden="true" />,
       label: "Renaissance Queen",
     },
     JACK: {
       color: "bg-blue-100 text-blue-700 border-blue-200 dark:bg-blue-950/30 dark:text-blue-400 dark:border-blue-800",
-      icon: <Icon icon={Medal} size="xs" className="fill-current" />,
+      icon: <Icon icon={Medal} size="xs" className="fill-current" aria-hidden="true" />,
       label: "Renaissance Jack",
     },
   };


### PR DESCRIPTION
# Description

Added `aria-hidden="true"` to purely decorative tier icons (Crown, Trophy, Star, Medal) used inside Renaissance Badges in the Decision Card view to improve accessibility and prevent redundant announcements by screen readers.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Not applicable

- UI browser or Playwright proof:
  - [x] Not applicable

- Verification commands executed:
  - [x] `./bin/hushh codex pre-pr`
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm run lint`

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — `hushh-webapp/components/kai/views/decision-card.tsx`.
- [x] Reachable production attach point: Decision Card View.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: HTML attribute-only change, no iOS/Android impact.
- [x] **iOS**: Not applicable.
- [x] **Android**: Not applicable.

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

No UI-visible change — purely an accessibility fix for screen readers.

## 🛡️ Privacy & Consent

- [x] Does not access user data.
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependency changes