### PR TITLE
fix(frontend): make kai-nav-tour hydration safe

### DIFF
--- a/hushh-webapp/components/kai/onboarding/kai-nav-tour.tsx
+++ b/hushh-webapp/components/kai/onboarding/kai-nav-tour.tsx
@@ -358,7 +358,7 @@ export function KaiNavTour() {
 
   const cardStyle = (() => {
     const isBottomNavStep = activeStep.id.startsWith("nav-");
-    const viewportWidth = anchor?.viewportWidth ?? (typeof window !== "undefined" ? window.innerWidth : 430);
+    const viewportWidth = anchor?.viewportWidth ?? 430;
     const margin = 12;
     const cardWidth = Math.min(480, viewportWidth - margin * 2);
 


### PR DESCRIPTION
# Description
Fixed a React hydration mismatch warning in the `kai-nav-tour` component. 

The initial viewport width fallback was dynamically checking `window.innerWidth`, which causes a mismatch between the server render and the initial client render. Hardcoded the fallback to `430` since the `useEffect` handles resolving the true viewport width immediately on mount.

## 🧪 Testing
- [x] Verified zero layout shift on mount
- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)