### PR TITLE
fix(frontend): add aria-hidden to decorative icons in analysis history dashboard

### DIFF
--- a/hushh-webapp/components/kai/views/analysis-history-dashboard.tsx
+++ b/hushh-webapp/components/kai/views/analysis-history-dashboard.tsx
@@ -551,7 +551,7 @@ function EmptyState() {
   return (
     <div className="flex flex-col items-center justify-center py-12 px-4 space-y-6">
       <div className="p-4 rounded-full bg-primary/5 border border-primary/10">
-        <Icon icon={BarChart3} size={32} className="text-primary/60" />
+        <Icon icon={BarChart3} size={32} className="text-primary/60" aria-hidden="true" />
       </div>
       <div className="text-center space-y-2 max-w-sm">
         <h3 className="text-lg font-semibold">No analyses yet</h3>
@@ -593,7 +593,7 @@ function DebateInputsCard({
       <SurfaceCardHeader>
         <div className="flex items-center justify-between gap-2">
           <SurfaceCardTitle className="flex items-center gap-2 text-sm">
-            <Icon icon={MessageSquareText} size="sm" className="text-primary" />
+            <Icon icon={MessageSquareText} size="sm" className="text-primary" aria-hidden="true" />
             Debate Inputs
           </SurfaceCardTitle>
           <Badge variant="secondary" className="text-[11px] font-semibold">


### PR DESCRIPTION
# Description

Added `aria-hidden="true"` to purely decorative `BarChart3` and `MessageSquareText` icons in the Analysis History Dashboard to improve accessibility and prevent redundant announcements by screen readers.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Not applicable

- UI browser or Playwright proof:
  - [x] Not applicable

- Verification commands executed:
  - [x] `./bin/hushh codex pre-pr`
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm run lint`

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — `hushh-webapp/components/kai/views/analysis-history-dashboard.tsx`.
- [x] Reachable production attach point: Analysis History Dashboard View.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: HTML attribute-only change, no iOS/Android impact.
- [x] **iOS**: Not applicable.
- [x] **Android**: Not applicable.

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

No UI-visible change — purely an accessibility fix for screen readers.

## 🛡️ Privacy & Consent

- [x] Does not access user data.
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependency changes