### PR TITLE
fix(frontend): add aria-hidden to decorative icons in analysis summary view

### DIFF
--- a/hushh-webapp/components/kai/views/analysis-summary-view.tsx
+++ b/hushh-webapp/components/kai/views/analysis-summary-view.tsx
@@ -362,7 +362,7 @@ export function AnalysisSummaryView({
       {!embedded ? (
         <div className="flex items-center justify-between gap-3">
           <Button variant="none" effect="fade" size="sm" onClick={onBack} disabled={!onBack}>
-            <Icon icon={ArrowLeft} size="sm" className="mr-1" />
+            <Icon icon={ArrowLeft} size="sm" className="mr-1" aria-hidden="true" />
             History
           </Button>
           <Button
@@ -372,7 +372,7 @@ export function AnalysisSummaryView({
             onClick={() => onReanalyze?.(entry.ticker)}
             disabled={!onReanalyze}
           >
-            <Icon icon={RefreshCw} size="sm" className="mr-1" />
+            <Icon icon={RefreshCw} size="sm" className="mr-1" aria-hidden="true" />
             Re-analyze
           </Button>
         </div>
@@ -466,7 +466,7 @@ export function AnalysisSummaryView({
           </div>
           {!embedded && onOpenDebate ? (
             <Button variant="blue-gradient" effect="fill" size="sm" onClick={onOpenDebate}>
-              <Icon icon={Scale} size="sm" className="mr-1" />
+              <Icon icon={Scale} size="sm" className="mr-1" aria-hidden="true" />
               Open Detailed Debate
             </Button>
           ) : null}


### PR DESCRIPTION
# Description

Added `aria-hidden="true"` to purely decorative `ArrowLeft`, `RefreshCw`, and `Scale` icons within buttons in the Analysis Summary View. Since the buttons have clear descriptive text, hiding these icons improves the screen reader experience.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Not applicable

- UI browser or Playwright proof:
  - [x] Not applicable

- Verification commands executed:
  - [x] `./bin/hushh codex pre-pr`
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm run lint`

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — `hushh-webapp/components/kai/views/analysis-summary-view.tsx`.
- [x] Reachable production attach point: Analysis Summary View.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: HTML attribute-only change, no iOS/Android impact.
- [x] **iOS**: Not applicable.
- [x] **Android**: Not applicable.

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

No UI-visible change — purely an accessibility fix for screen readers.

## 🛡️ Privacy & Consent

- [x] Does not access user data.
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependency changes