### PR TITLE
fix(frontend): use unique disclosure string as React key instead of array index

### DIFF
--- a/hushh-webapp/components/kai/cards/legal-disclosures-card.tsx
+++ b/hushh-webapp/components/kai/cards/legal-disclosures-card.tsx
@@ -225,7 +225,7 @@ export function LegalDisclosuresCard({
 
       <CardContent className="space-y-3">
         {visibleDisclosures.map((disclosure, index) => (
-          <DisclosureItem key={index} text={disclosure} index={index} />
+          <DisclosureItem key={disclosure} text={disclosure} index={index} />
         ))}
 
         {hiddenCount > 0 && !showAll && (


### PR DESCRIPTION
# Description

Replaced the anti-pattern of using the array `index` as a React `key` with the unique `disclosure` string value in the `LegalDisclosuresCard` component. This ensures safer React component reconciliation and prevents potential re-rendering bugs if the disclosures list changes.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Not applicable

- UI browser or Playwright proof:
  - [x] Not applicable

- Verification commands executed:
  - [x] `./bin/hushh codex pre-pr`
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm run lint`

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — `hushh-webapp/components/kai/cards/legal-disclosures-card.tsx`.
- [x] Reachable production attach point: Legal Disclosures Card.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: React rendering fix only, no structural iOS/Android impact.
- [x] **iOS**: Not applicable.
- [x] **Android**: Not applicable.

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

No UI-visible change — purely a React reconciliation stability fix.

## 🛡️ Privacy & Consent

- [x] Does not access user data.
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependency changes