### PR TITLE
test(consent): verify exact expiration boundary corner cases in kai-token-guard

### DIFF
--- a/hushh-webapp/__tests__/services/kai-token-guard.test.ts
+++ b/hushh-webapp/__tests__/services/kai-token-guard.test.ts
@@ -122,3 +122,157 @@ describe("kai-token-guard", () => {
     });
   });
 });
+
+// ── Expiration boundary — exact threshold corner cases ────────────────────────
+//
+// Production invariant (from kai-token-guard.ts):
+//   TOKEN_REFRESH_BUFFER_MS = 60_000
+//   hasUsableToken: Date.now() + 60_000 < expiresAt   (strict less-than)
+//
+// With Date.now() mocked to 1_000_000 the effective threshold is 1_060_000.
+// Any expiresAt <= 1_060_000 triggers a refresh; > 1_060_000 does not.
+
+describe("kai-token-guard — expiration boundary precision", () => {
+  // Mocked clock is shared with the outer suite's beforeEach.
+  // Each test restores mocks explicitly to stay isolated.
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+  });
+
+  // ── 1 ms above the threshold — token is usable ───────────────────────────
+
+  it("accepts a token expiring exactly 1 ms above the buffer threshold", async () => {
+    // 1_060_000 < 1_060_001 → true (usable)
+    const token = await ensureKaiVaultOwnerToken({
+      userId: "user-1",
+      currentToken: "one-ms-above",
+      currentExpiresAt: 1_060_001,
+    });
+
+    expect(token).toBe("one-ms-above");
+    expect(mockGetOrIssueVaultOwnerToken).not.toHaveBeenCalled();
+  });
+
+  // ── Exactly at the threshold — refresh required (strict < not <=) ─────────
+
+  it("triggers refresh when token expiry is exactly at the buffer threshold", async () => {
+    // 1_060_000 < 1_060_000 → false (strict less-than fails — boundary is open)
+    mockGetOrIssueVaultOwnerToken.mockResolvedValue({
+      token: "refreshed-at-threshold",
+      expiresAt: 2_000_000,
+    });
+
+    const token = await ensureKaiVaultOwnerToken({
+      userId: "user-1",
+      currentToken: "at-threshold",
+      currentExpiresAt: 1_060_000,
+    });
+
+    expect(token).toBe("refreshed-at-threshold");
+    expect(mockGetOrIssueVaultOwnerToken).toHaveBeenCalledOnce();
+  });
+
+  // ── 1 ms below the threshold — refresh required ───────────────────────────
+
+  it("triggers refresh when token expiry is exactly 1 ms below the buffer threshold", async () => {
+    // 1_060_000 < 1_059_999 → false
+    mockGetOrIssueVaultOwnerToken.mockResolvedValue({
+      token: "refreshed-one-ms-below",
+      expiresAt: 2_000_000,
+    });
+
+    const token = await ensureKaiVaultOwnerToken({
+      userId: "user-1",
+      currentToken: "one-ms-below",
+      currentExpiresAt: 1_059_999,
+    });
+
+    expect(token).toBe("refreshed-one-ms-below");
+    expect(mockGetOrIssueVaultOwnerToken).toHaveBeenCalledOnce();
+  });
+
+  // ── 1 second above the threshold — token is usable ───────────────────────
+
+  it("accepts a token expiring 1 second above the buffer threshold", async () => {
+    // 1_060_000 < 1_061_000 → true
+    const token = await ensureKaiVaultOwnerToken({
+      userId: "user-1",
+      currentToken: "one-sec-above",
+      currentExpiresAt: 1_061_000,
+    });
+
+    expect(token).toBe("one-sec-above");
+    expect(mockGetOrIssueVaultOwnerToken).not.toHaveBeenCalled();
+  });
+
+  // ── 1 second below the threshold — refresh required ──────────────────────
+
+  it("triggers refresh when token expiry is 1 second below the buffer threshold", async () => {
+    // 1_060_000 < 1_059_000 → false
+    mockGetOrIssueVaultOwnerToken.mockResolvedValue({
+      token: "refreshed-one-sec-below",
+      expiresAt: 2_000_000,
+    });
+
+    const token = await ensureKaiVaultOwnerToken({
+      userId: "user-1",
+      currentToken: "one-sec-below",
+      currentExpiresAt: 1_059_000,
+    });
+
+    expect(token).toBe("refreshed-one-sec-below");
+    expect(mockGetOrIssueVaultOwnerToken).toHaveBeenCalledOnce();
+  });
+
+  // ── Past expiry — token has already expired ───────────────────────────────
+
+  it("triggers refresh when expiresAt equals Date.now() — already in the past", async () => {
+    // 1_060_000 < 1_000_000 → false (token expired before the buffer window even starts)
+    mockGetOrIssueVaultOwnerToken.mockResolvedValue({
+      token: "post-expiry-token",
+      expiresAt: 2_000_000,
+    });
+
+    const token = await ensureKaiVaultOwnerToken({
+      userId: "user-1",
+      currentToken: "already-expired",
+      currentExpiresAt: 1_000_000,
+    });
+
+    expect(token).toBe("post-expiry-token");
+    expect(mockGetOrIssueVaultOwnerToken).toHaveBeenCalledOnce();
+  });
+
+  // ── No drift — the boundary transition is sharp ───────────────────────────
+
+  it("confirms no boundary drift: at-threshold refreshes, 1 ms above does not", async () => {
+    mockGetOrIssueVaultOwnerToken.mockResolvedValue({
+      token: "refreshed",
+      expiresAt: 2_000_000,
+    });
+
+    // At threshold → must refresh.
+    const atResult = await ensureKaiVaultOwnerToken({
+      userId: "user-1",
+      currentToken: "boundary-token",
+      currentExpiresAt: 1_060_000,
+    });
+    expect(atResult).toBe("refreshed");
+    expect(mockGetOrIssueVaultOwnerToken).toHaveBeenCalledOnce();
+
+    // Reset state and re-pin the clock.
+    vi.clearAllMocks();
+    vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+
+    // 1 ms above → must NOT refresh — state transition is sharp, no drift.
+    const aboveResult = await ensureKaiVaultOwnerToken({
+      userId: "user-1",
+      currentToken: "one-ms-above",
+      currentExpiresAt: 1_060_001,
+    });
+    expect(aboveResult).toBe("one-ms-above");
+    expect(mockGetOrIssueVaultOwnerToken).not.toHaveBeenCalled();
+  });
+});
+// ── End expiration boundary coverage ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds 7 precise boundary-condition tests for the consent token expiry evaluation in `kai-token-guard.ts`. All cases use the pinned `Date.now() = 1_000_000` clock already established by the outer `beforeEach`, directly import from the production module, live inside the package test tree, and are picked up by `npm run test` automatically.

## Files changed (1)

| File | Change |
|---|---|
| `hushh-webapp/__tests__/services/kai-token-guard.test.ts` | +154 lines — new `describe` block, 7 new `it` cases |

## Production boundary under test

```typescript
// kai-token-guard.ts
const TOKEN_REFRESH_BUFFER_MS = 60_000;

function hasUsableToken(token, expiresAt): boolean {
  if (!token || !expiresAt) return false;
  return Date.now() + TOKEN_REFRESH_BUFFER_MS < expiresAt;  // strict <
}
```

With clock pinned to `1_000_000`, the effective threshold is `1_060_000`.

## Boundary table

| `expiresAt` | Comparison | `hasUsableToken` | Expected outcome |
|---|---|---|---|
| `1_060_001` | `1_060_000 < 1_060_001` | `true` | token returned, no refresh |
| `1_060_000` | `1_060_000 < 1_060_000` | `false` | **refresh triggered** (strict `<`) |
| `1_059_999` | `1_060_000 < 1_059_999` | `false` | refresh triggered |
| `1_061_000` | `1_060_000 < 1_061_000` | `true` | token returned, no refresh (+1 s) |
| `1_059_000` | `1_060_000 < 1_059_000` | `false` | refresh triggered (−1 s) |
| `1_000_000` | `1_060_000 < 1_000_000` | `false` | refresh triggered (already expired) |
| Dual assertion | at=`1_060_000` then above=`1_060_001` | false / true | no drift — sharp transition |

## CI gate checklist
- [x] **PR Base Policy** — targets `integration/pr-train` (upstream tip `7cb9ae14`)
- [x] **DCO** — `Signed-off-by: Abdul Rashid <smirthidharmaiit@gmail.com>`
- [x] **No new files** — cases added to existing companion test file
- [x] **No `eslint-disable`** — zero lint suppressions
- [x] **Direct production import** — `@/lib/services/kai-token-guard`, existing mocks reused
- [x] **Vitest framework** — picked up by `npm run test` automatically
- [x] **Clean diff** — 1 file, 154 additions, fresh upstream base

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)