### PR TITLE
feat(consent): wire isPurposeValid into approve route — validator + boundary proof

### DIFF
--- a/hushh-webapp/__tests__/lib/consent/purposeValidator.test.ts
+++ b/hushh-webapp/__tests__/lib/consent/purposeValidator.test.ts
@@ -1,0 +1,190 @@
+/**
+ * purposeValidator.ts — unit tests and route-boundary wiring proof.
+ *
+ * Section 1: Direct unit tests of isPurposeValid / APPROVED_PURPOSES.
+ *   Verifies every invalid purpose class is rejected and every approved
+ *   purpose is accepted, with no crash on malformed inputs.
+ *
+ * Section 2: Route-boundary integration proof.
+ *   Imports the shipped POST handler from app/api/consent/pending/approve
+ *   and asserts that the handler rejects invalid purposes with 400 before
+ *   the backend is ever reached — proving the validator is wired into the
+ *   live request path, not floating as a standalone helper.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import {
+  APPROVED_PURPOSES,
+  isPurposeValid,
+} from "@/lib/consent/purposeValidator";
+
+// ── Route-level mocks (hoisted, in place before the route module loads) ───────
+vi.mock("@/app/api/_utils/backend", () => ({
+  getPythonApiUrl: () => "http://mock-backend",
+}));
+
+vi.mock("@/app/api/_utils/hot-get-json-cache", () => ({
+  createHotGetJsonCache: () => ({
+    read: vi.fn(() => null),
+    getInflight: vi.fn(() => null),
+    setInflight: vi.fn(),
+    write: vi.fn(),
+    clearInflight: vi.fn(),
+  }),
+}));
+
+vi.mock("@/app/api/_utils/request-id", () => ({
+  resolveRequestId: () => "test-rid",
+  createUpstreamHeaders: (_id: string, h: Record<string, string>) => h,
+  withRequestIdJson: (_id: string, body: unknown, init?: ResponseInit) =>
+    new Response(JSON.stringify(body), {
+      status: (init?.status as number) ?? 200,
+      headers: { "content-type": "application/json" },
+    }),
+}));
+
+import { POST } from "@/app/api/consent/pending/approve/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function buildRequest(body: Record<string, unknown>): NextRequest {
+  return new Request("http://localhost/api/consent/pending/approve", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer vault-owner-token",
+    },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+const VALID_BASE = {
+  userId: "user-123",
+  requestId: "req-456",
+};
+
+// ── Section 1: isPurposeValid — unit tests ────────────────────────────────────
+
+describe("isPurposeValid — direct unit tests", () => {
+
+  describe("approved purposes → true", () => {
+    it.each([...APPROVED_PURPOSES])("accepts '%s'", (p) => {
+      expect(isPurposeValid(p)).toBe(true);
+    });
+  });
+
+  describe("invalid purpose strings → false (default-deny)", () => {
+    it.each([
+      ["null",             null],
+      ["undefined",        undefined],
+      ["empty string",     ""],
+      ["whitespace",       "   "],
+      ["unknown string",   "tracking"],
+      ["wrong case",       "ANALYTICS"],
+      ["trailing space",   "analytics "],
+      ["leading space",    " essential"],
+      ["numeric string",   "1"],
+      ["partial match",    "analytic"],
+    ])("%s → false", (_label, value) => {
+      expect(isPurposeValid(value)).toBe(false);
+    });
+  });
+
+  describe("non-string types → false", () => {
+    it.each([
+      ["number 1",         1],
+      ["boolean true",     true],
+      ["array",            ["analytics"]],
+      ["object",           { purpose: "analytics" }],
+    ])("%s → false", (_label, value) => {
+      expect(isPurposeValid(value)).toBe(false);
+    });
+  });
+
+  it("custom allowlist is respected", () => {
+    const custom = ["read", "write"] as const;
+    expect(isPurposeValid("read",      custom)).toBe(true);
+    expect(isPurposeValid("analytics", custom)).toBe(false);
+  });
+
+  it("empty allowlist always returns false", () => {
+    expect(isPurposeValid("analytics", [])).toBe(false);
+  });
+
+  it("return type is always a strict boolean", () => {
+    expect(typeof isPurposeValid("analytics")).toBe("boolean");
+    expect(typeof isPurposeValid(null)).toBe("boolean");
+  });
+});
+
+// ── Section 2: Route-boundary proof ──────────────────────────────────────────
+// The POST handler must call isPurposeValid before reaching fetch().
+// These tests call the shipped handler directly and assert the 400 fires
+// *without* any backend call — proving the validator is on the live path.
+
+describe("POST /api/consent/pending/approve — purpose guard (shipped handler)", () => {
+
+  describe("invalid purposes are rejected with 400 — backend never reached", () => {
+    it.each([
+      ["purpose absent",       { ...VALID_BASE }],
+      ["purpose: null",        { ...VALID_BASE, purpose: null }],
+      ["purpose: empty",       { ...VALID_BASE, purpose: "" }],
+      ["purpose: whitespace",  { ...VALID_BASE, purpose: "   " }],
+      ["purpose: unlisted",    { ...VALID_BASE, purpose: "tracking" }],
+      ["purpose: wrong case",  { ...VALID_BASE, purpose: "ANALYTICS" }],
+      ["purpose: number",      { ...VALID_BASE, purpose: 1 }],
+      ["purpose: partial",     { ...VALID_BASE, purpose: "analytic" }],
+    ])(
+      "%s → 400",
+      async (_label, body) => {
+        const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+        const res = await POST(buildRequest(body));
+
+        expect(res.status).toBe(400);
+        const json = await res.json() as { error?: string; allowedPurposes?: string[] };
+        expect(json.error).toMatch(/purpose/i);
+        // Backend must never be reached for an invalid purpose.
+        expect(fetchSpy).not.toHaveBeenCalled();
+
+        fetchSpy.mockRestore();
+      }
+    );
+  });
+
+  describe("approved purposes clear the guard and reach the backend", () => {
+    it.each([...APPROVED_PURPOSES])(
+      "purpose '%s' clears the guard",
+      async (purpose) => {
+        const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+          new Response(JSON.stringify({ consentToken: "ct_ok" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          })
+        );
+
+        const res = await POST(
+          buildRequest({ ...VALID_BASE, purpose })
+        );
+
+        // Guard cleared — fetch was called exactly once.
+        expect(fetchSpy).toHaveBeenCalledOnce();
+        expect(res.status).toBe(200);
+
+        fetchSpy.mockRestore();
+      }
+    );
+  });
+
+  it("response body lists all allowed purposes when rejecting an invalid one", async () => {
+    const res = await POST(
+      buildRequest({ ...VALID_BASE, purpose: "unknown" })
+    );
+
+    expect(res.status).toBe(400);
+    const json = await res.json() as { allowedPurposes?: string[] };
+    expect(Array.isArray(json.allowedPurposes)).toBe(true);
+    expect(json.allowedPurposes).toEqual(expect.arrayContaining([...APPROVED_PURPOSES]));
+  });
+});

--- a/hushh-webapp/app/api/consent/pending/approve/route.ts
+++ b/hushh-webapp/app/api/consent/pending/approve/route.ts
@@ -10,6 +10,10 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { getPythonApiUrl } from "@/app/api/_utils/backend";
+import {
+  APPROVED_PURPOSES,
+  isPurposeValid,
+} from "@/lib/consent/purposeValidator";
 
 const BACKEND_URL = getPythonApiUrl();
 
@@ -36,6 +40,20 @@ export async function POST(request: NextRequest) {
     if (!userId || !requestId) {
       return NextResponse.json(
         { error: "userId and requestId are required" },
+        { status: 400 }
+      );
+    }
+
+    // Purpose guard — rejects before any backend call when the declared
+    // purpose is absent, blank, or not in the approved operational tier list.
+    const rawPurpose = (body as Record<string, unknown>).purpose;
+    if (!isPurposeValid(rawPurpose, APPROVED_PURPOSES)) {
+      return NextResponse.json(
+        {
+          error:
+            "purpose is required and must be one of the approved operational tiers",
+          allowedPurposes: [...APPROVED_PURPOSES],
+        },
         { status: 400 }
       );
     }

--- a/hushh-webapp/lib/consent/purposeValidator.ts
+++ b/hushh-webapp/lib/consent/purposeValidator.ts
@@ -1,0 +1,45 @@
+/**
+ * Consent purpose validator — request-boundary allowlist enforcement.
+ *
+ * Imported directly by the consent approval route handler so that every
+ * inbound approval is checked against this allowlist before any backend call
+ * fires. Lives in lib/consent/ so unit tests can exercise it in isolation
+ * without spinning up the full HTTP stack.
+ */
+
+/** Exhaustive list of consent purposes accepted at the approval boundary. */
+export const APPROVED_PURPOSES = [
+  "essential",
+  "analytics",
+  "marketing",
+  "personalization",
+  "research",
+] as const;
+
+export type ApprovedPurpose = (typeof APPROVED_PURPOSES)[number];
+
+/**
+ * isPurposeValid(purpose, allowedPurposes?)
+ *
+ * Returns true only when `purpose` is a non-empty string that is an exact
+ * member of `allowedPurposes` (defaults to APPROVED_PURPOSES).
+ *
+ * Every other value — null, undefined, empty string, whitespace-only,
+ * unrecognised string, or non-string type — returns false (default-deny).
+ * Lookup uses Array.prototype.includes(), which applies SameValueZero
+ * equality: "ANALYTICS" does NOT match "analytics".
+ */
+export function isPurposeValid(
+  purpose: unknown,
+  allowedPurposes: readonly string[] = APPROVED_PURPOSES,
+): boolean {
+  if (
+    purpose === null ||
+    purpose === undefined ||
+    typeof purpose !== "string" ||
+    purpose.trim() === ""
+  ) {
+    return false;
+  }
+  return (allowedPurposes as string[]).includes(purpose);
+}


### PR DESCRIPTION
## Summary

Resolves maintainer feedback: **"Resubmit against the actual request/consent boundary with tests proving invalid purposes are rejected by the shipped handler."**

The validator lives in `lib/consent/` (importable by any consumer), is imported by the shipped `approve/route.ts` handler, and the companion test proves the wiring by calling the **actual POST handler directly** — not a stub.

## Files changed (3)

| File | Role |
|---|---|
| `hushh-webapp/lib/consent/purposeValidator.ts` | Production validator — `isPurposeValid`, `APPROVED_PURPOSES` |
| `hushh-webapp/app/api/consent/pending/approve/route.ts` | Shipped handler — imports + calls validator at the request boundary |
| `hushh-webapp/__tests__/lib/consent/purposeValidator.test.ts` | Companion test — direct unit tests + route-boundary proof |

## Validator (`lib/consent/purposeValidator.ts`)

```typescript
export const APPROVED_PURPOSES = [
  "essential", "analytics", "marketing", "personalization", "research",
] as const;

export function isPurposeValid(
  purpose: unknown,
  allowedPurposes: readonly string[] = APPROVED_PURPOSES,
): boolean {
  if (purpose === null || purpose === undefined ||
      typeof purpose !== "string" || purpose.trim() === "") return false;
  return (allowedPurposes as string[]).includes(purpose);
}
```

## Route wiring (`approve/route.ts`)

```typescript
import { APPROVED_PURPOSES, isPurposeValid } from "@/lib/consent/purposeValidator";

// After userId/requestId check, before fetch():
const rawPurpose = (body as Record<string, unknown>).purpose;
if (!isPurposeValid(rawPurpose, APPROVED_PURPOSES)) {
  return NextResponse.json(
    { error: "purpose is required and must be one of the approved operational tiers",
      allowedPurposes: [...APPROVED_PURPOSES] },
    { status: 400 }
  );
}
```

## Test proof (`__tests__/lib/consent/purposeValidator.test.ts`)

**Section 1 — `isPurposeValid` unit tests:**
- All 5 approved purposes → `true`
- 10 invalid inputs (null, undefined, empty, whitespace, wrong-case, partial match…) → `false`
- Non-string types (number, boolean, array, object) → `false`
- Custom allowlist respected; empty allowlist always `false`

**Section 2 — Shipped handler boundary proof (direct `POST` invocation):**

| Input | `fetch` called? | Status |
|---|---|---|
| `purpose` absent | No | **400** |
| `purpose: null` | No | **400** |
| `purpose: "tracking"` (unlisted) | No | **400** |
| `purpose: "ANALYTICS"` (wrong case) | No | **400** |
| `purpose: "analytics"` ✓ | **Yes (once)** | 200 |
| All 5 approved purposes | Yes each | 200 each |

The `fetch` spy confirms the backend is never reached on invalid input — the validation fires at the request boundary.

## CI gate checklist
- [x] **PR Base Policy** — targets `integration/pr-train` (upstream tip `7cb9ae14`)
- [x] **DCO** — `Signed-off-by: Abdul Rashid <smirthidharmaiit@gmail.com>`
- [x] **No unattached helpers** — validator imported by the shipped route; test calls the route handler directly
- [x] **Stacked diff** — 3 files, fresh upstream base, zero unrelated changes
- [x] **No `eslint-disable`** — zero lint suppressions

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)