### PR TITLE
Complete Kai BYOK runtime execution

### DIFF
--- a/consent-protocol/api/routes/kai/agent_chat.py
+++ b/consent-protocol/api/routes/kai/agent_chat.py
@@ -17,6 +17,7 @@ from hushh_mcp.services.agent_chat_service import (
     AgentChatConversation,
     AgentChatMessage,
     AgentRuntimeContractError,
+    AgentRuntimeProviderError,
     PreparedAgentChatTurn,
     get_agent_chat_service,
 )
@@ -152,7 +153,7 @@ async def stream_agent_chat(
     _assert_user(token_data, body.user_id)
     service = get_agent_chat_service()
     try:
-        service.prepare_runtime_contract(
+        runtime = await service.prepare_agent_runtime(
             runtime_credential=body.runtime_credential,
             runtime_credential_mode=body.runtime_credential_mode,
         )
@@ -164,6 +165,8 @@ async def stream_agent_chat(
         action_plan: AgentChatActionPlan | None = await service.plan_action_with_gemini(
             user_message=body.message,
             history=turn.history,
+            runtime_client=runtime.client,
+            runtime_model=runtime.model,
             pkm_context=body.pkm_context,
         )
     except AgentRuntimeContractError as error:
@@ -173,6 +176,20 @@ async def stream_agent_chat(
             error.error_code,
             body.runtime_credential_mode,
             bool((body.runtime_credential or "").strip()),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": error.error_code,
+                "message": error.message,
+            },
+        ) from error
+    except AgentRuntimeProviderError as error:
+        logger.warning(
+            "agent_chat.runtime_provider_failed user_id=%s error_code=%s detail=%s",
+            body.user_id,
+            error.error_code,
+            error.detail,
         )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -259,6 +276,8 @@ async def stream_agent_chat(
             async for token in service.stream_response(
                 user_message=body.message,
                 history=turn.history,
+                runtime_client=runtime.client,
+                runtime_model=runtime.model,
                 action_plan=action_plan,
                 pkm_context=body.pkm_context,
             ):
@@ -303,6 +322,31 @@ async def stream_agent_chat(
                     status_value="interrupted",
                 )
             raise
+        except AgentRuntimeProviderError as error:
+            logger.warning(
+                "agent_chat.stream_provider_failed user_id=%s error_code=%s detail=%s",
+                body.user_id,
+                error.error_code,
+                error.detail,
+            )
+            if not saved:
+                await _save_assistant_message(
+                    service=service,
+                    turn=turn,
+                    user_id=body.user_id,
+                    text=error.message,
+                    status_value="error",
+                    error_code=error.error_code,
+                )
+                saved = True
+            yield _event(
+                "error",
+                {
+                    "code": error.error_code,
+                    "message": error.message,
+                    "conversation_id": turn.conversation_id,
+                },
+            )
         except Exception as error:
             logger.exception("agent_chat.stream_failed user_id=%s: %s", body.user_id, error)
             if not saved:

--- a/consent-protocol/hushh_mcp/agents/kai/agent.yaml
+++ b/consent-protocol/hushh_mcp/agents/kai/agent.yaml
@@ -2,7 +2,16 @@ id: agent_kai
 name: Kai Financial Agent
 version: 2.0.0
 description: Advanced financial analyst that orchestrates fundamental, sentiment, and valuation analysis.
-model: gemini-3-flash-preview
+model:
+  provider: gemini
+  name: gemini-2.5-flash
+  mode: byok
+  credential_ref: pkm:runtime_secrets.llm.gemini_api_key
+credential_policy:
+  default: hushh_managed_vertex
+  allowed:
+    - hushh_managed_vertex
+    - byok
 system_instruction: |
   You are Kai, the personal financial voice agent for Hushh.
 

--- a/consent-protocol/hushh_mcp/hushh_adk/manifest.py
+++ b/consent-protocol/hushh_mcp/hushh_adk/manifest.py
@@ -9,7 +9,7 @@ This serves as the robust Source of Truth for:
 """
 
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import yaml
 from pydantic import BaseModel, Field, ValidationError
@@ -34,12 +34,19 @@ class AgentOutputConfig(BaseModel):
     type: str
 
 
+class AgentModelConfig(BaseModel):
+    provider: str = "gemini"
+    name: str = GEMINI_MODEL
+    mode: str = "hushh_managed_vertex"
+    credential_ref: Optional[str] = None
+
+
 class AgentManifest(BaseModel):
     id: str
     name: str
     version: str = "1.0.0"
     description: str
-    model: str = GEMINI_MODEL  # Standardized default model
+    model: Union[str, AgentModelConfig] = GEMINI_MODEL  # Standardized default model
     system_instruction: str
 
     required_scopes: List[str] = Field(default_factory=list)
@@ -68,6 +75,12 @@ class AgentManifest(BaseModel):
                 seen.add(tool.required_scope)
                 out.append(tool.required_scope)
         return out
+
+    def model_config_for_runtime(self) -> AgentModelConfig:
+        """Return a structured runtime model config for string or object manifests."""
+        if isinstance(self.model, AgentModelConfig):
+            return self.model
+        return AgentModelConfig(name=self.model)
 
 
 class ManifestLoader:

--- a/consent-protocol/hushh_mcp/services/agent_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/agent_chat_service.py
@@ -8,21 +8,32 @@ import os
 import re
 from dataclasses import dataclass
 from datetime import datetime
+from pathlib import Path
 from typing import Any, AsyncGenerator, Literal
 from uuid import uuid4
 
+import yaml
 from google import genai
+from google.genai import errors as genai_errors
 from google.genai import types as genai_types
 
 from db.db_client import get_db
+from hushh_mcp.hushh_adk.manifest import AgentModelConfig, ManifestLoader
 from hushh_mcp.runtime_settings import get_core_security_settings
 from hushh_mcp.types import EncryptedPayload
 from hushh_mcp.vault.encrypt import decrypt_data, encrypt_data
+from hussh_sdk import (
+    ModelConfig,
+    PKMCredentialResolver,
+    prepare_runtime_credentials,
+    runtime_config,
+)
 
 logger = logging.getLogger(__name__)
 
 AGENT_CHAT_MODEL_ENV = "AGENT_GEMINI_MODEL"
 DEFAULT_AGENT_CHAT_MODEL = "gemini-2.5-pro"
+KAI_AGENT_MANIFEST_PATH = Path(__file__).resolve().parents[1] / "agents" / "kai" / "agent.yaml"
 AGENT_SYSTEM_PROMPT = """You are Agent, the Kai-focused financial assistant inside Hussh.
 
 Current capability boundary:
@@ -257,11 +268,262 @@ class AgentRuntimeContract:
     credential_supplied: bool
 
 
+@dataclass(frozen=True)
+class PreparedAgentRuntime:
+    mode: AgentRuntimeCredentialMode
+    provider: str
+    model: str
+    credential_ref: str | None
+    client: Any
+    evidence: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class KaiAgentCredentialPolicy:
+    default: AgentRuntimeCredentialMode = DEFAULT_AGENT_RUNTIME_CREDENTIAL_MODE
+    allowed: tuple[AgentRuntimeCredentialMode, ...] = ("hushh_managed_vertex", "byok")
+
+
+@dataclass(frozen=True)
+class KaiAgentRuntimeManifest:
+    model: AgentModelConfig
+    credential_policy: KaiAgentCredentialPolicy
+
+
 class AgentRuntimeContractError(ValueError):
     def __init__(self, *, error_code: str, message: str):
         super().__init__(message)
         self.error_code = error_code
         self.message = message
+
+
+class AgentRuntimeProviderError(RuntimeError):
+    def __init__(
+        self,
+        *,
+        error_code: str,
+        message: str,
+        detail: dict[str, Any] | None = None,
+    ):
+        super().__init__(message)
+        self.error_code = error_code
+        self.message = message
+        self.detail = detail or {}
+
+
+class RuntimeSecretSession:
+    def __init__(self, credential_ref: str, secret: str | None):
+        self.credential_ref = credential_ref
+        self.secret = secret
+
+    async def read_secret(self, credential_ref: str) -> str | None:
+        if credential_ref != self.credential_ref:
+            return None
+        return self.secret
+
+
+def _parse_credential_mode(value: str | None) -> AgentRuntimeCredentialMode:
+    mode = (value or DEFAULT_AGENT_RUNTIME_CREDENTIAL_MODE).strip()
+    if mode == "byok":
+        return "byok"
+    if mode == "hushh_managed_vertex":
+        return "hushh_managed_vertex"
+    raise AgentRuntimeContractError(
+        error_code="AGENT_RUNTIME_MODE_INVALID",
+        message="Agent runtime credential mode is invalid.",
+    )
+
+
+def _load_kai_agent_manifest_data() -> dict[str, Any]:
+    with KAI_AGENT_MANIFEST_PATH.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+    return data if isinstance(data, dict) else {}
+
+
+def _credential_policy_from_manifest(data: dict[str, Any]) -> KaiAgentCredentialPolicy:
+    raw_policy = data.get("credential_policy")
+    policy = raw_policy if isinstance(raw_policy, dict) else {}
+    default = _parse_credential_mode(
+        str(policy.get("default") or DEFAULT_AGENT_RUNTIME_CREDENTIAL_MODE)
+    )
+    raw_allowed = policy.get("allowed")
+    allowed_values = (
+        raw_allowed if isinstance(raw_allowed, list) else ["hushh_managed_vertex", "byok"]
+    )
+    allowed: list[AgentRuntimeCredentialMode] = []
+    for value in allowed_values:
+        mode = _parse_credential_mode(str(value))
+        if mode not in allowed:
+            allowed.append(mode)
+    if default not in allowed:
+        allowed.insert(0, default)
+    return KaiAgentCredentialPolicy(default=default, allowed=tuple(allowed))
+
+
+def load_kai_agent_runtime_manifest() -> KaiAgentRuntimeManifest:
+    data = _load_kai_agent_manifest_data()
+    manifest = ManifestLoader.load_from_dict(data, source=str(KAI_AGENT_MANIFEST_PATH))
+    return KaiAgentRuntimeManifest(
+        model=manifest.model_config_for_runtime(),
+        credential_policy=_credential_policy_from_manifest(data),
+    )
+
+
+def create_runtime_client(runtime_provider: str, user_key: str):
+    provider = runtime_provider.strip().lower()
+    key = user_key.strip()
+
+    if not key:
+        raise ValueError("User BYOK runtime key is required")
+
+    if provider == "gemini":
+        return genai.Client(vertexai=False, api_key=key)
+
+    raise ValueError(f"Unsupported runtime provider: {provider}")
+
+
+def create_managed_runtime_client(runtime_provider: str, user_key: str):
+    provider = runtime_provider.strip().lower()
+    key = user_key.strip()
+
+    if not key:
+        raise RuntimeError("Managed Gemini API key is not configured")
+
+    if provider == "gemini":
+        return genai.Client(vertexai=True, api_key=key)
+
+    raise ValueError(f"Unsupported runtime provider: {provider}")
+
+
+def _redacted_runtime_evidence(evidence: dict[str, Any]) -> dict[str, Any]:
+    def redact(value: Any) -> Any:
+        if isinstance(value, dict):
+            return {
+                key: (
+                    "[REDACTED]"
+                    if key
+                    in {
+                        "credential_ref",
+                        "credential_resolved",
+                        "credential_packaged",
+                    }
+                    else redact(nested)
+                )
+                for key, nested in value.items()
+            }
+        if isinstance(value, list):
+            return [redact(item) for item in value]
+        return value
+
+    return redact(evidence)
+
+
+def _google_error_payload(error: Exception) -> dict[str, Any]:
+    response_json = getattr(error, "response_json", None)
+    if isinstance(response_json, dict):
+        return response_json
+    details = getattr(error, "details", None)
+    if isinstance(details, dict):
+        return details
+    try:
+        return dict(error.args[0]) if error.args and isinstance(error.args[0], dict) else {}
+    except Exception:
+        return {}
+
+
+def _google_error_info(payload: dict[str, Any]) -> dict[str, Any]:
+    error_payload = payload.get("error") if isinstance(payload.get("error"), dict) else payload
+    details = error_payload.get("details")
+    if not isinstance(details, list):
+        return {}
+    for detail in details:
+        if isinstance(detail, dict) and str(detail.get("@type") or "").endswith(
+            "google.rpc.ErrorInfo"
+        ):
+            return detail
+    return {}
+
+
+def _classify_gemini_error(error: Exception) -> dict[str, Any]:
+    detail: dict[str, Any] = {
+        "error_type": error.__class__.__name__,
+    }
+    if error.__class__.__name__ == "DefaultCredentialsError":
+        detail["likely_issue"] = "managed_google_credentials_unavailable"
+        detail["operator_hint"] = "Check Hushh managed Gemini credentials for this runtime."
+        return detail
+    status_code = getattr(error, "code", None) or getattr(error, "status_code", None)
+    if status_code is not None:
+        detail["status_code"] = status_code
+    status_value = getattr(error, "status", None)
+    if status_value:
+        detail["status"] = str(status_value)
+
+    payload = _google_error_payload(error)
+    info = _google_error_info(payload)
+    reason = str(info.get("reason") or "").strip()
+    metadata = info.get("metadata") if isinstance(info.get("metadata"), dict) else {}
+    if reason:
+        detail["provider_reason"] = reason
+    service = metadata.get("service")
+    if service:
+        detail["provider_service"] = str(service)
+
+    normalized_reason = reason.upper()
+    if normalized_reason in {"API_KEY_INVALID", "API_KEY_EXPIRED", "API_KEY_SERVICE_BLOCKED"}:
+        detail["likely_issue"] = "invalid_or_unauthorized_api_key"
+        detail["operator_hint"] = "Check the Gemini API key saved in encrypted PKM."
+    elif normalized_reason in {"CREDENTIALS_MISSING", "ACCESS_TOKEN_SCOPE_INSUFFICIENT"}:
+        detail["likely_issue"] = "managed_google_credentials_unavailable"
+        detail["operator_hint"] = "Check Hushh managed Gemini credentials for this runtime."
+    elif status_code in {401, 403}:
+        detail["likely_issue"] = "credential_not_authorized"
+        detail["operator_hint"] = "Check the runtime credential and model access."
+    elif status_code == 404:
+        detail["likely_issue"] = "model_not_available"
+        detail["operator_hint"] = "Check the model in agent.yaml."
+    return detail
+
+
+def _is_google_provider_runtime_error(error: Exception) -> bool:
+    module_name = getattr(error.__class__, "__module__", "")
+    return module_name.startswith(("google.", "google_")) or error.__class__.__name__ in {
+        "DefaultCredentialsError",
+    }
+
+
+def _runtime_provider_error_code(detail: dict[str, Any]) -> str:
+    likely_issue = str(detail.get("likely_issue") or "")
+    if likely_issue == "invalid_or_unauthorized_api_key":
+        return "AGENT_RUNTIME_CREDENTIAL_INVALID"
+    if likely_issue == "managed_google_credentials_unavailable":
+        return "AGENT_RUNTIME_MANAGED_CREDENTIALS_UNAVAILABLE"
+    if likely_issue == "model_not_available":
+        return "AGENT_RUNTIME_MODEL_UNAVAILABLE"
+    return "AGENT_RUNTIME_PROVIDER_ERROR"
+
+
+def _runtime_provider_user_message(error_code: str) -> str:
+    if error_code == "AGENT_RUNTIME_CREDENTIAL_INVALID":
+        return (
+            "Your saved Gemini key could not be used. Update it in Profile > Runtime keys "
+            "or switch Kai to Hushh managed Gemini."
+        )
+    if error_code == "AGENT_RUNTIME_MANAGED_CREDENTIALS_UNAVAILABLE":
+        return "Hushh managed Gemini is not available in this environment."
+    if error_code == "AGENT_RUNTIME_MODEL_UNAVAILABLE":
+        return "Kai's configured Gemini model is not available for this runtime."
+    return "Kai could not reach the configured Gemini runtime."
+
+
+def _runtime_provider_error_from_exception(error: Exception) -> AgentRuntimeProviderError:
+    detail = _classify_gemini_error(error)
+    error_code = _runtime_provider_error_code(detail)
+    return AgentRuntimeProviderError(
+        error_code=error_code,
+        message=_runtime_provider_user_message(error_code),
+        detail=detail,
+    )
 
 
 def _iso(value: Any) -> str | None:
@@ -425,7 +687,8 @@ class AgentChatService:
         self._db = db
         self._client = None
         self._settings = None
-        self.model = (model or os.getenv(AGENT_CHAT_MODEL_ENV) or DEFAULT_AGENT_CHAT_MODEL).strip()
+        self.runtime_manifest = load_kai_agent_runtime_manifest()
+        self.model = (model or self.runtime_manifest.model.name or DEFAULT_AGENT_CHAT_MODEL).strip()
         self._vault_key_hex = vault_key_hex
 
     @property
@@ -450,7 +713,10 @@ class AgentChatService:
             api_key = self.settings.google_api_key or os.getenv("GOOGLE_API_KEY", "").strip()
             if not api_key:
                 raise RuntimeError("Gemini API key is not configured")
-            self._client = genai.Client(api_key=api_key)
+            self._client = create_managed_runtime_client(
+                runtime_provider=self.runtime_manifest.model.provider,
+                user_key=api_key,
+            )
         return self._client
 
     def prepare_runtime_contract(
@@ -459,14 +725,15 @@ class AgentChatService:
         runtime_credential: str | None = None,
         runtime_credential_mode: str | None = None,
     ) -> AgentRuntimeContract:
-        mode_value = (runtime_credential_mode or DEFAULT_AGENT_RUNTIME_CREDENTIAL_MODE).strip()
-        if mode_value not in {"byok", "hushh_managed_vertex"}:
+        mode = _parse_credential_mode(
+            runtime_credential_mode or self.runtime_manifest.credential_policy.default
+        )
+        if mode not in self.runtime_manifest.credential_policy.allowed:
             raise AgentRuntimeContractError(
                 error_code="AGENT_RUNTIME_MODE_INVALID",
                 message="Agent runtime credential mode is invalid.",
             )
 
-        mode = mode_value
         secret = (runtime_credential or "").strip()
         if mode == "byok" and not secret:
             raise AgentRuntimeContractError(
@@ -480,6 +747,89 @@ class AgentChatService:
         return AgentRuntimeContract(
             mode=mode,
             credential_supplied=bool(secret),
+        )
+
+    async def prepare_agent_runtime(
+        self,
+        *,
+        runtime_credential: str | None = None,
+        runtime_credential_mode: str | None = None,
+    ) -> PreparedAgentRuntime:
+        contract = self.prepare_runtime_contract(
+            runtime_credential=runtime_credential,
+            runtime_credential_mode=runtime_credential_mode,
+        )
+        model_config = self.runtime_manifest.model
+        provider = model_config.provider.strip().lower()
+        model_name = (model_config.name or self.model or DEFAULT_AGENT_CHAT_MODEL).strip()
+        credential_ref = model_config.credential_ref
+
+        if contract.mode == "hushh_managed_vertex":
+            evidence = {
+                "framework": "google_adk",
+                "deployment_target": "personal_sandbox",
+                "model": {
+                    "mode": "hushh_managed_vertex",
+                    "provider": provider,
+                    "model": model_name,
+                    "credential_ref": credential_ref,
+                    "resolution_source": "hushh_managed_vertex",
+                },
+            }
+            logger.info("agent_chat_runtime_evidence=%s", _redacted_runtime_evidence(evidence))
+            return PreparedAgentRuntime(
+                mode=contract.mode,
+                provider=provider,
+                model=model_name,
+                credential_ref=credential_ref,
+                client=self.client,
+                evidence=evidence,
+            )
+
+        if not credential_ref:
+            raise AgentRuntimeContractError(
+                error_code="AGENT_RUNTIME_CREDENTIAL_REF_MISSING",
+                message="Kai BYOK runtime is missing a PKM credential reference.",
+            )
+
+        runtime = runtime_config(
+            "google_adk",
+            model=ModelConfig(
+                provider=provider,
+                model=model_name,
+                mode="byok",
+                credential_ref=credential_ref,
+            ),
+        )
+        bundle = await prepare_runtime_credentials(
+            runtime,
+            resolver=PKMCredentialResolver(
+                RuntimeSecretSession(
+                    credential_ref=runtime.model.credential_ref or credential_ref,
+                    secret=runtime_credential,
+                )
+            ),
+        )
+        if bundle.credential is None or not bundle.credential.secret.strip():
+            raise AgentRuntimeContractError(
+                error_code="AGENT_RUNTIME_CREDENTIAL_MISSING",
+                message=(
+                    "Kai needs your Gemini key to continue. Add or update it in "
+                    "Profile > Runtime keys, or switch Kai to Hushh managed Gemini."
+                ),
+            )
+
+        logger.info("agent_chat_runtime_evidence=%s", _redacted_runtime_evidence(bundle.evidence))
+        return PreparedAgentRuntime(
+            mode=contract.mode,
+            provider=provider,
+            model=model_name,
+            credential_ref=credential_ref,
+            client=create_runtime_client(
+                runtime_provider=runtime.model.provider,
+                user_key=bundle.credential.secret,
+            ),
+            evidence=bundle.evidence,
         )
 
     async def _execute_raw(self, sql: str, params: dict[str, Any] | None = None):
@@ -792,6 +1142,8 @@ class AgentChatService:
         *,
         user_message: str,
         history: list[AgentChatMessage],
+        runtime_client: Any,
+        runtime_model: str,
         action_plan: AgentChatActionPlan | None = None,
         pkm_context: str | None = None,
     ) -> AsyncGenerator[str, None]:
@@ -806,21 +1158,46 @@ class AgentChatService:
             temperature=0.7,
             max_output_tokens=4096,
         )
-        stream = await self.client.aio.models.generate_content_stream(
-            model=self.model,
-            contents=contents,
-            config=config,
-        )
-        async for chunk in stream:
-            text = self._chunk_text(chunk)
-            if text:
-                yield text
+        try:
+            stream = await runtime_client.aio.models.generate_content_stream(
+                model=runtime_model,
+                contents=contents,
+                config=config,
+            )
+            async for chunk in stream:
+                text = self._chunk_text(chunk)
+                if text:
+                    yield text
+        except genai_errors.APIError as error:
+            provider_error = _runtime_provider_error_from_exception(error)
+            logger.warning(
+                "agent_chat_runtime_provider_error phase=stream provider=%s model=%s credential_ref=%s detail=%s",
+                self.runtime_manifest.model.provider,
+                runtime_model,
+                self.runtime_manifest.model.credential_ref,
+                provider_error.detail,
+            )
+            raise provider_error from error
+        except Exception as error:
+            if _is_google_provider_runtime_error(error):
+                provider_error = _runtime_provider_error_from_exception(error)
+                logger.warning(
+                    "agent_chat_runtime_provider_error phase=stream provider=%s model=%s credential_ref=%s detail=%s",
+                    self.runtime_manifest.model.provider,
+                    runtime_model,
+                    self.runtime_manifest.model.credential_ref,
+                    provider_error.detail,
+                )
+                raise provider_error from error
+            raise
 
     async def plan_action_with_gemini(
         self,
         *,
         user_message: str,
         history: list[AgentChatMessage],
+        runtime_client: Any,
+        runtime_model: str,
         pkm_context: str | None = None,
     ) -> AgentChatActionPlan | None:
         deterministic_block = self._plan_blocked_action(user_message)
@@ -828,8 +1205,8 @@ class AgentChatService:
             return deterministic_block
 
         try:
-            response = await self.client.aio.models.generate_content(
-                model=self.model,
+            response = await runtime_client.aio.models.generate_content(
+                model=runtime_model,
                 contents=self._build_action_planning_contents(
                     user_message=user_message,
                     history=history,
@@ -852,7 +1229,27 @@ class AgentChatService:
                 action_plan = self._action_plan_from_function_call(function_call)
                 if action_plan is not None:
                     return action_plan
-        except Exception:
+        except genai_errors.APIError as error:
+            provider_error = _runtime_provider_error_from_exception(error)
+            logger.warning(
+                "agent_chat_runtime_provider_error phase=planner provider=%s model=%s credential_ref=%s detail=%s",
+                self.runtime_manifest.model.provider,
+                runtime_model,
+                self.runtime_manifest.model.credential_ref,
+                provider_error.detail,
+            )
+            raise provider_error from error
+        except Exception as error:
+            if _is_google_provider_runtime_error(error):
+                provider_error = _runtime_provider_error_from_exception(error)
+                logger.warning(
+                    "agent_chat_runtime_provider_error phase=planner provider=%s model=%s credential_ref=%s detail=%s",
+                    self.runtime_manifest.model.provider,
+                    runtime_model,
+                    self.runtime_manifest.model.credential_ref,
+                    provider_error.detail,
+                )
+                raise provider_error from error
             logger.exception("agent_chat.function_planning_failed")
 
         return self.plan_action(user_message)

--- a/consent-protocol/hussh_sdk/__init__.py
+++ b/consent-protocol/hussh_sdk/__init__.py
@@ -1,0 +1,54 @@
+from hussh_sdk.adk import HusshAdkImportError, create_personal_agent
+from hussh_sdk.agent import HusshAgent
+from hussh_sdk.client import HusshClient
+from hussh_sdk.credentials import (
+    CredentialResolver,
+    PKMCredentialResolver,
+    PKMSession,
+    ResolvedCredential,
+    RuntimeCredentialBundle,
+    VaultCredentialResolver,
+    VaultSession,
+    build_runtime_evidence,
+    prepare_runtime_credentials,
+    resolve_runtime_credential,
+    validate_runtime_config,
+)
+from hussh_sdk.errors import (
+    ConsentRevokedError,
+    HusshError,
+    RuntimeConfigError,
+    RuntimeCredentialMissingError,
+)
+from hussh_sdk.factory import create_agent
+from hussh_sdk.models import ModelConfig, RuntimeConfig, runtime_config
+from hussh_sdk.runtime import RuntimeAdapter, RuntimeRequest, RuntimeResult
+
+__all__ = [
+    "ConsentRevokedError",
+    "CredentialResolver",
+    "HusshAdkImportError",
+    "HusshAgent",
+    "HusshClient",
+    "HusshError",
+    "ModelConfig",
+    "PKMCredentialResolver",
+    "PKMSession",
+    "ResolvedCredential",
+    "RuntimeAdapter",
+    "RuntimeCredentialBundle",
+    "RuntimeConfigError",
+    "RuntimeConfig",
+    "RuntimeCredentialMissingError",
+    "RuntimeRequest",
+    "RuntimeResult",
+    "VaultCredentialResolver",
+    "VaultSession",
+    "build_runtime_evidence",
+    "create_agent",
+    "create_personal_agent",
+    "prepare_runtime_credentials",
+    "resolve_runtime_credential",
+    "runtime_config",
+    "validate_runtime_config",
+]

--- a/consent-protocol/hussh_sdk/adk.py
+++ b/consent-protocol/hussh_sdk/adk.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import Any
+
+from hussh_sdk.agent import HusshAgent
+
+
+class HusshAdkImportError(ImportError):
+    """Raised when ADK integration is requested without Google ADK installed."""
+
+
+def create_personal_agent(
+    *,
+    name: str,
+    model: Any,
+    instruction: str,
+    hussh_agent: HusshAgent | None = None,
+    extra_tools: Sequence[Callable[..., Any]] | None = None,
+    **kwargs: Any,
+) -> Any:
+    """Create a Google ADK personal agent with Hussh consent tools installed."""
+    if hussh_agent is None:
+        from hussh_sdk.factory import create_agent
+
+        agent = create_agent(
+            name=name,
+            runtime="google_adk",
+            model=model if isinstance(model, str) else None,
+        )
+    else:
+        agent = hussh_agent
+    return _build_adk_agent(
+        agent,
+        name=name,
+        model=model,
+        instruction=instruction,
+        extra_tools=extra_tools,
+        **kwargs,
+    )
+
+
+def _hussh_adk_tools(agent: HusshAgent) -> list[Callable[..., Any]]:
+    """Return Google ADK-compatible tools backed by Hussh consent methods."""
+
+    async def hussh_know(
+        domain: str, reason: str, fields: list[str] | None = None
+    ) -> dict[str, Any]:
+        """
+        Request consented personal context from Hussh before using it.
+
+        Args:
+            domain: The Hussh vault domain to request.
+            reason: The consent justification shown to the user.
+            fields: The minimum fields needed from the domain.
+        """
+        context = await agent.know(domain=domain, reason=reason, fields=fields or [])
+        if context is None:
+            return {"status": "declined", "context": None}
+        return {"status": "approved", "context": context}
+
+    async def hussh_do(action: str, preview: str, confirm: bool = True) -> dict[str, Any]:
+        """
+        Request user confirmation before taking an action.
+
+        Args:
+            action: The action the personal agent wants to take.
+            preview: The human-readable action preview.
+            confirm: Whether explicit confirmation is required.
+        """
+        approved = await agent.do(action=action, preview=preview, confirm=confirm)
+        return {"status": "approved" if approved else "declined"}
+
+    async def hussh_remember(content: str, domain: str) -> dict[str, Any]:
+        """
+        Request consent before writing an insight back to the user's vault.
+
+        Args:
+            content: The insight or memory to store.
+            domain: The Hussh vault domain where the insight belongs.
+        """
+        stored = await agent.remember(content=content, domain=domain)
+        return {"status": "stored" if stored else "declined"}
+
+    return [hussh_know, hussh_do, hussh_remember]
+
+
+def _build_adk_agent(
+    hussh_agent: HusshAgent,
+    *,
+    name: str,
+    model: Any,
+    instruction: str,
+    extra_tools: Sequence[Callable[..., Any]] | None = None,
+    **kwargs: Any,
+) -> Any:
+    """Build a Google ADK agent with Hussh consent tools installed.
+
+    The model argument is passed through unchanged so BYOK callers can provide
+    a Gemini model string, a LiteLLM-backed model, or any ADK-supported model.
+    """
+    agent_class = _load_adk_agent_class()
+    tools = [*_hussh_adk_tools(hussh_agent), *(extra_tools or [])]
+    return agent_class(
+        name=name,
+        model=model,
+        instruction=instruction,
+        tools=tools,
+        **kwargs,
+    )
+
+
+def _load_adk_agent_class() -> type[Any]:
+    try:
+        from google.adk.agents import Agent
+
+        return Agent
+    except ImportError:
+        try:
+            from google.adk import Agent
+
+            return Agent
+        except ImportError as exc:
+            raise HusshAdkImportError(
+                "Google ADK is not installed. Install the Hussh SDK with the 'adk' extra "
+                "before calling create_personal_agent()."
+            ) from exc

--- a/consent-protocol/hussh_sdk/agent.py
+++ b/consent-protocol/hussh_sdk/agent.py
@@ -1,0 +1,421 @@
+import httpx
+
+from hussh_sdk.client import HusshClient
+from hussh_sdk.credentials import (
+    CredentialResolver,
+    RuntimeCredentialBundle,
+)
+from hussh_sdk.credentials import (
+    prepare_runtime_credentials as prepare_runtime_credentials_for,
+)
+from hussh_sdk.errors import ConsentRevokedError, RuntimeConfigError
+from hussh_sdk.models import RuntimeConfig, runtime_config
+from hussh_sdk.runtime import RuntimeAdapter, RuntimeRequest
+
+
+class HusshAgent:
+    def __init__(
+        self,
+        api_key: str = "sandbox",
+        endpoint: str = "https://api.hussh.ai/v1",
+        mock_mode: bool = False,
+        mock_persona: str = "Manish",
+        sandbox_persona: str | None = None,
+        subject_ua: str = "ua_sandbox",
+        relying_service: str | None = None,
+        transport: httpx.AsyncBaseTransport | None = None,
+        runtime_config: RuntimeConfig | None = None,
+        runtime_adapter: RuntimeAdapter | None = None,
+        credential_resolver: CredentialResolver | None = None,
+    ):
+        self.client = HusshClient(api_key=api_key, endpoint=endpoint, transport=transport)
+        self.mock_mode = mock_mode
+        self.mock_persona = mock_persona
+        self.sandbox_persona = sandbox_persona
+        self.subject_ua = subject_ua
+        self.relying_service = relying_service or self.__class__.__name__
+        self.runtime_config = runtime_config or runtime_config_for_mock(mock_mode)
+        self.runtime_adapter = runtime_adapter
+        self.credential_resolver = credential_resolver
+        self.execution_events: list[dict] = []
+        self.mock_events = self.execution_events
+
+    async def know(self, domain: str, reason: str, fields: list[str] | None = None) -> dict | None:
+        """
+        Read from the Vault. Nav-gated — user must approve before data is returned.
+        Returns data if approved, None if declined.
+        Always handle the None case.
+        """
+        if self.mock_mode:
+            return self._mock_know(domain=domain, reason=reason, fields=fields or [])
+
+        return await self._real_know(domain=domain, reason=reason, fields=fields or [])
+
+    async def do(self, action: str, preview: str, confirm: bool = True) -> bool:
+        """
+        Take an action with one-tap user confirmation.
+        Returns True if confirmed, False if cancelled.
+        """
+        if self.mock_mode:
+            self.mock_events.append(
+                {
+                    "label": "agent.do()",
+                    "actor": "Hussh SDK",
+                    "status": "approved",
+                    "detail": "Mock mode auto-confirms non-context actions.",
+                    "data": {"action": action, "preview": preview, "confirm": confirm},
+                }
+            )
+            return True
+
+        raise NotImplementedError("Real HusshAgent.do() API mode is not implemented yet.")
+
+    async def remember(self, content: str, domain: str) -> bool:
+        """
+        Write to the Vault with consent.
+        Returns True if written, False if declined.
+        """
+        if self.mock_mode:
+            approved = self.mock_persona != "Priya"
+            self.mock_events.append(
+                {
+                    "label": "agent.remember()",
+                    "actor": "Hussh SDK",
+                    "status": "approved" if approved else "declined",
+                    "detail": "Mock mode simulates write consent.",
+                    "data": {"domain": domain, "content": content},
+                }
+            )
+            return approved
+
+        raise NotImplementedError("Real HusshAgent.remember() API mode is not implemented yet.")
+
+    async def run(
+        self,
+        prompt: str,
+        *,
+        context: dict | None = None,
+        metadata: dict | None = None,
+    ):
+        """
+        Execute the selected runtime with already-approved context.
+        Use know() first when personal context is needed.
+        """
+        if self.runtime_adapter is None:
+            raise NotImplementedError(
+                f"Runtime '{self.runtime_config.kind}' is not configured yet."
+            )
+
+        result = await self.runtime_adapter.run(
+            RuntimeRequest(
+                prompt=prompt,
+                context=context or {},
+                metadata=metadata or {},
+            )
+        )
+        self.execution_events.append(
+            {
+                "label": "Runtime executed",
+                "actor": "Hussh SDK",
+                "status": "completed",
+                "detail": "The selected runtime adapter executed using caller-provided approved context.",
+                "data": result.metadata,
+            }
+        )
+        return result.output
+
+    def describe_runtime(self) -> dict:
+        if self.runtime_adapter is not None:
+            return self.runtime_adapter.describe()
+        return self.runtime_config.describe()
+
+    async def prepare_runtime_credentials(
+        self,
+        *,
+        resolver: CredentialResolver | None = None,
+        required: bool = True,
+    ) -> RuntimeCredentialBundle:
+        credential_resolver = resolver or self.credential_resolver
+        if credential_resolver is None:
+            raise RuntimeConfigError(
+                "A credential resolver is required for BYOK runtime credentials."
+            )
+        return await prepare_runtime_credentials_for(
+            self.runtime_config,
+            resolver=credential_resolver,
+            required=required,
+        )
+
+    async def close(self) -> None:
+        await self.client.close()
+
+    async def _real_know(self, domain: str, reason: str, fields: list[str]) -> dict | None:
+        self.execution_events.append(
+            {
+                "label": f"agent.know({domain})",
+                "actor": self.__class__.__name__,
+                "status": "requested",
+                "detail": "The generated agent asks the Hussh SDK for one declared scope.",
+                "pchp_phase": "Offer",
+                "data": {
+                    "domain": domain,
+                    "fields": fields,
+                    "reason": reason,
+                    "access": "read",
+                    "ttl_seconds": 3600,
+                    "retention": "no-store",
+                },
+            }
+        )
+        payload = {
+            "subject_ua": self.subject_ua,
+            "relying_service": self.relying_service,
+            "scopes": [{"domain": domain, "fields": fields, "access": "read"}],
+            "purpose": reason,
+            "ttl_seconds": 3600,
+            "retention": "no-store",
+            "sandbox": True,
+        }
+        if self.sandbox_persona:
+            payload["sandbox_persona"] = self.sandbox_persona
+
+        try:
+            consent = await self.client.request_consent(payload)
+        except httpx.HTTPStatusError as error:
+            if error.response.status_code == 403 and "consent_declined" in error.response.text:
+                self.execution_events.append(
+                    {
+                        "label": "Consent declined",
+                        "actor": "Hussh Platform",
+                        "status": "declined",
+                        "detail": "The Hussh Platform declined the requested scope.",
+                        "pchp_phase": "Consent",
+                        "data": {"domain": domain, "fields": fields},
+                    }
+                )
+                return None
+            raise
+        crt = consent["crt"]
+        grant_id = consent["grant_id"]
+        self.execution_events.append(
+            {
+                "label": "CRT issued",
+                "actor": "Hussh Platform",
+                "status": "approved",
+                "detail": "The Hussh Platform minted a consent receipt token for the requested scope.",
+                "pchp_phase": "Consent",
+                "data": {"grant_id": grant_id, "domain": domain, "fields": fields},
+            }
+        )
+        try:
+            context_response = await self.client.get_context(crt)
+        except httpx.HTTPStatusError as error:
+            if error.response.status_code == 403 and "consent_revoked" in error.response.text:
+                self.execution_events.append(
+                    {
+                        "label": "Consent revoked",
+                        "actor": "Hussh Platform",
+                        "status": "revoked",
+                        "detail": "The Hussh Platform rejected context delivery because consent was revoked.",
+                        "pchp_phase": "Revocation",
+                        "data": {"domain": domain, "grant_id": grant_id},
+                    }
+                )
+                raise ConsentRevokedError(domain)
+            raise
+        context = context_response.get("context", {}).get(domain)
+        if context is None:
+            return None
+        self.execution_events.append(
+            {
+                "label": "SDK returns context",
+                "actor": "Hussh SDK",
+                "status": "returned",
+                "detail": "agent.know() returns only the approved fields from the Hussh Platform.",
+                "pchp_phase": "Context Delivery",
+                "data": {"domain": domain, "context": context, "grant_id": grant_id},
+            }
+        )
+
+        await self.client.acknowledge(
+            grant_id=grant_id,
+            effects=f"{self.relying_service} used {domain} context for: {reason}",
+        )
+        self.execution_events.append(
+            {
+                "label": "Usage acknowledged",
+                "actor": "Hussh SDK",
+                "status": "completed",
+                "detail": "The SDK acknowledged successful context use with the Hussh Platform.",
+                "pchp_phase": "Acknowledgment",
+                "data": {"grant_id": grant_id, "retention": "no-store"},
+            }
+        )
+        return context
+
+    def _mock_know(self, domain: str, reason: str, fields: list[str]) -> dict | None:
+        self.execution_events.append(
+            {
+                "label": f"agent.know({domain})",
+                "actor": self.__class__.__name__,
+                "status": "requested",
+                "detail": "The generated agent asks the Hussh SDK for one declared scope.",
+                "pchp_phase": "Offer",
+                "data": {
+                    "domain": domain,
+                    "fields": fields,
+                    "reason": reason,
+                    "access": "read",
+                    "ttl_seconds": 3600,
+                    "retention": "no-store",
+                },
+            }
+        )
+
+        if self.mock_persona == "Priya":
+            self.execution_events.extend(
+                [
+                    {
+                        "label": "Priya declines",
+                        "actor": "Nav",
+                        "status": "declined",
+                        "detail": "Priya declines the requested scope.",
+                        "pchp_phase": "Nav Gate",
+                        "data": {"decision": "declined", "domain": domain, "fields": fields},
+                    },
+                    {
+                        "label": "SDK returns None",
+                        "actor": "Hussh SDK",
+                        "status": "returned",
+                        "detail": "agent.know() returns None, so the generated fallback path runs.",
+                        "pchp_phase": "Context Delivery",
+                        "data": {"domain": domain, "value": None},
+                    },
+                ]
+            )
+            return None
+
+        context = self._mock_context(domain=domain, fields=fields)
+        self.execution_events.extend(
+            [
+                {
+                    "label": f"{self.mock_persona} approves",
+                    "actor": "Nav",
+                    "status": "approved",
+                    "detail": f"{self.mock_persona} approves the requested {domain} scope.",
+                    "pchp_phase": "Nav Gate",
+                    "data": {"decision": "approved", "domain": domain, "fields": fields},
+                },
+                {
+                    "label": "SDK returns context",
+                    "actor": "Hussh SDK",
+                    "status": "returned",
+                    "detail": "agent.know() returns only the approved fields for this scope.",
+                    "pchp_phase": "Context Delivery",
+                    "data": {
+                        "domain": domain,
+                        "context": context,
+                        "crt": {
+                            "grant_id": f"sandbox_{domain}_{self.mock_persona.lower()}",
+                            "ttl_seconds": 3600,
+                            "retention": "no-store",
+                        },
+                    },
+                },
+            ]
+        )
+
+        if self.mock_persona == "Reva":
+            self.execution_events.append(
+                {
+                    "label": "Reva revokes",
+                    "actor": "Nav",
+                    "status": "revoked",
+                    "detail": "Reva revokes consent during the run.",
+                    "pchp_phase": "Revocation",
+                    "data": {"domain": domain, "stop_access_within_seconds": 60},
+                }
+            )
+            raise ConsentRevokedError(domain)
+
+        return context
+
+    def _mock_context(self, domain: str, fields: list[str]) -> dict:
+        fixtures = {
+            "calendar": {
+                "upcoming_meetings": [
+                    {
+                        "title": "BYOK architecture review",
+                        "time": "3:00 PM",
+                        "attendees": ["Nirvana", "Priya"],
+                        "agenda": [
+                            "Show the Hussh One simulator",
+                            "Explain Nav's consent boundary",
+                            "Prove live BYOK runs without packaging keys",
+                        ],
+                    }
+                ],
+                "upcoming_events": [
+                    {
+                        "title": "BYOK architecture review",
+                        "time": "3:00 PM",
+                        "attendees": ["Nirvana", "Priya"],
+                    }
+                ],
+                "meeting_times": ["3:00 PM"],
+                "meeting_titles": ["BYOK architecture review"],
+                "attendees": ["Nirvana", "Priya"],
+            },
+            "contacts": {
+                "notes": {
+                    "Priya": "Cares about privacy UX, consent language, and clear front-stage/backstage separation.",
+                    "Nirvana": "Wants the demo to show real infrastructure value, not a narrow business app.",
+                },
+                "names": ["Priya", "Nirvana"],
+                "roles": {"Priya": "Privacy reviewer", "Nirvana": "Builder"},
+                "relationship_notes": {
+                    "Priya": "Privacy UX and consent language",
+                    "Nirvana": "Infrastructure value and demo clarity",
+                },
+                "recent_interactions": ["Architecture review prep"],
+            },
+            "preferences": {
+                "communication_style": "direct, architectural, demo-oriented",
+                "meeting_brief_format": "concise bullets with a suggested opener",
+                "travel_style": "low-friction, privacy-conscious",
+                "budget": "moderate",
+                "accessibility": "step-free preferred",
+            },
+            "subscriptions": {
+                "recurring": [
+                    {
+                        "name": "Figma",
+                        "monthly_cost": 15,
+                        "last_used_days_ago": 4,
+                        "status": "keep",
+                    },
+                    {
+                        "name": "Old analytics tool",
+                        "monthly_cost": 79,
+                        "last_used_days_ago": 96,
+                        "status": "review",
+                    },
+                    {
+                        "name": "Duplicate notes app",
+                        "monthly_cost": 12,
+                        "last_used_days_ago": 61,
+                        "status": "cancel_candidate",
+                    },
+                ]
+            },
+        }
+        domain_fixture = fixtures.get(domain, {})
+        if not fields:
+            return domain_fixture or {"summary": f"sandbox:{domain}.summary"}
+        return {field: domain_fixture.get(field, f"sandbox:{domain}.{field}") for field in fields}
+
+
+def runtime_config_for_mock(mock_mode: bool) -> RuntimeConfig:
+    if mock_mode:
+        return runtime_config("mock")
+    return runtime_config("local_platform")

--- a/consent-protocol/hussh_sdk/client.py
+++ b/consent-protocol/hussh_sdk/client.py
@@ -1,0 +1,45 @@
+from typing import Any, Dict
+
+import httpx
+
+
+class HusshClient:
+    def __init__(
+        self, api_key: str, endpoint: str, transport: httpx.AsyncBaseTransport | None = None
+    ):
+        self.api_key = api_key
+        self.endpoint = endpoint.rstrip("/")
+        self.client = httpx.AsyncClient(
+            headers={"X-API-Key": self.api_key},
+            transport=transport,
+        )
+
+    async def get_discovery(self) -> Dict[str, Any]:
+        """Phase 0: Discovery"""
+        response = await self.client.get(f"{self.endpoint}/.well-known/hussh")
+        response.raise_for_status()
+        return response.json()
+
+    async def request_consent(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Phase 3: Consent (Handshake)"""
+        response = await self.client.post(f"{self.endpoint}/consent/handshake", json=payload)
+        response.raise_for_status()
+        return response.json()
+
+    async def get_context(self, crt: str) -> Dict[str, Any]:
+        """Phase 4: Context Delivery"""
+        response = await self.client.get(
+            f"{self.endpoint}/consent/context", headers={"X-Hussh-Consent-Token": crt}
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def acknowledge(self, grant_id: str, effects: str) -> Dict[str, Any]:
+        """Phase 5: Acknowledgment"""
+        params = {"grant_id": grant_id, "effects": effects}
+        response = await self.client.post(f"{self.endpoint}/consent/ack", params=params)
+        response.raise_for_status()
+        return response.json()
+
+    async def close(self):
+        await self.client.aclose()

--- a/consent-protocol/hussh_sdk/credentials.py
+++ b/consent-protocol/hussh_sdk/credentials.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+from hussh_sdk.errors import RuntimeConfigError, RuntimeCredentialMissingError
+from hussh_sdk.models import RuntimeConfig
+
+SecretReader = Callable[[str], str | None | Awaitable[str | None]]
+
+
+@dataclass(frozen=True)
+class ResolvedCredential:
+    credential_ref: str
+    secret: str
+    source: str
+
+    def evidence(self) -> dict:
+        return {
+            "credential_ref": self.credential_ref,
+            "credential_resolved": True,
+            "resolution_source": self.source,
+            "credential_packaged": False,
+        }
+
+
+@runtime_checkable
+class CredentialResolver(Protocol):
+    async def resolve(self, credential_ref: str) -> ResolvedCredential | None:
+        """Resolve a credential_ref to a runtime-only secret."""
+        ...
+
+
+@runtime_checkable
+class VaultSession(Protocol):
+    async def read_secret(self, credential_ref: str) -> str | None:
+        """Read a secret from an already-unlocked user vault."""
+        ...
+
+
+@runtime_checkable
+class PKMSession(Protocol):
+    async def read_secret(self, credential_ref: str) -> str | None:
+        """Read a secret from an already-unlocked Personal Knowledge Model."""
+        ...
+
+
+@dataclass(frozen=True)
+class RuntimeCredentialBundle:
+    credential: ResolvedCredential | None
+    evidence: dict
+
+
+class VaultCredentialResolver:
+    """
+    Resolve BYOK secrets from an already-unlocked user vault.
+
+    The SDK does not unlock the vault. The host app passes either a vault session
+    with read_secret(), a read_secret callback, or a decrypted vault mapping.
+    """
+
+    def __init__(
+        self,
+        vault: VaultSession | Mapping[str, Any] | None = None,
+        *,
+        read_secret: SecretReader | None = None,
+        source: str = "user_vault",
+    ):
+        if vault is None and read_secret is None:
+            raise RuntimeConfigError("VaultCredentialResolver requires vault or read_secret.")
+        self.vault = vault
+        self.read_secret = read_secret
+        self.source = source
+
+    async def resolve(self, credential_ref: str) -> ResolvedCredential | None:
+        secret = await self._read_secret(credential_ref)
+        if not secret:
+            return None
+        return ResolvedCredential(
+            credential_ref=credential_ref,
+            secret=secret,
+            source=self.source,
+        )
+
+    async def _read_secret(self, credential_ref: str) -> str | None:
+        if self.read_secret is not None:
+            return await _maybe_await(self.read_secret(credential_ref))
+
+        if isinstance(self.vault, Mapping):
+            return _read_mapping_secret(self.vault, credential_ref, prefixes=("vault:", "pkm:"))
+
+        if self.vault is not None and hasattr(self.vault, "read_secret"):
+            return await _maybe_await(self.vault.read_secret(credential_ref))
+
+        return None
+
+
+class PKMCredentialResolver(VaultCredentialResolver):
+    """
+    Resolve BYOK secrets from an already-unlocked Personal Knowledge Model.
+
+    Expected refs look like:
+    pkm:runtime_secrets.llm.gemini_api_key
+    """
+
+    def __init__(
+        self,
+        pkm: PKMSession | Mapping[str, Any] | None = None,
+        *,
+        read_secret: SecretReader | None = None,
+        source: str = "user_pkm",
+    ):
+        super().__init__(pkm, read_secret=read_secret, source=source)
+
+
+def validate_runtime_config(runtime: RuntimeConfig | None) -> None:
+    if runtime is None:
+        raise RuntimeConfigError("RuntimeConfig is required.")
+
+    model = runtime.model
+    if model.mode == "byok" and not model.credential_ref:
+        raise RuntimeConfigError("BYOK runtime requires model.credential_ref.")
+
+    if model.mode == "none" and model.credential_ref:
+        raise RuntimeConfigError("mode='none' runtimes must not include model.credential_ref.")
+
+    if model.provider == "local" and model.mode != "none":
+        raise RuntimeConfigError("provider='local' runtimes must use mode='none'.")
+
+
+async def resolve_runtime_credential(
+    runtime: RuntimeConfig,
+    *,
+    resolver: CredentialResolver,
+    required: bool = False,
+) -> ResolvedCredential | None:
+    validate_runtime_config(runtime)
+
+    credential_ref = runtime.model.credential_ref
+    if runtime.model.mode != "byok":
+        return None
+
+    if not credential_ref:
+        if required:
+            raise RuntimeCredentialMissingError(credential_ref)
+        return None
+
+    credential = await resolver.resolve(credential_ref)
+    if credential is None and required:
+        raise RuntimeCredentialMissingError(credential_ref)
+    return credential
+
+
+async def prepare_runtime_credentials(
+    runtime: RuntimeConfig,
+    *,
+    resolver: CredentialResolver,
+    required: bool = True,
+) -> RuntimeCredentialBundle:
+    credential = await resolve_runtime_credential(
+        runtime,
+        resolver=resolver,
+        required=required,
+    )
+    return RuntimeCredentialBundle(
+        credential=credential,
+        evidence=build_runtime_evidence(runtime, credential=credential),
+    )
+
+
+def build_runtime_evidence(
+    runtime: RuntimeConfig,
+    *,
+    credential: ResolvedCredential | None = None,
+) -> dict:
+    validate_runtime_config(runtime)
+
+    model = runtime.model
+    if credential is not None and credential.credential_ref != model.credential_ref:
+        raise RuntimeConfigError("Resolved credential does not match runtime model.credential_ref.")
+
+    credential_evidence = (
+        credential.evidence()
+        if credential is not None
+        else {
+            "credential_ref": model.credential_ref,
+            "credential_resolved": False,
+            "resolution_source": None,
+            "credential_packaged": False,
+        }
+    )
+    return {
+        "framework": runtime.framework,
+        "deployment_target": runtime.deployment_target,
+        "model": {
+            "mode": model.mode,
+            "provider": model.provider,
+            "model": model.model,
+            **credential_evidence,
+        },
+    }
+
+
+async def _maybe_await(value: str | None | Awaitable[str | None]) -> str | None:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+def _read_mapping_secret(
+    vault: Mapping[str, Any],
+    credential_ref: str,
+    *,
+    prefixes: tuple[str, ...],
+) -> str | None:
+    path = credential_ref
+    for prefix in prefixes:
+        if path.startswith(prefix):
+            path = path.removeprefix(prefix)
+            break
+
+    current: Any = vault
+    for key in path.split("."):
+        if not key:
+            return None
+        if not isinstance(current, Mapping) or key not in current:
+            return None
+        current = current[key]
+    return current if isinstance(current, str) else None

--- a/consent-protocol/hussh_sdk/errors.py
+++ b/consent-protocol/hussh_sdk/errors.py
@@ -1,0 +1,22 @@
+class HusshError(Exception):
+    """Base SDK error."""
+
+
+class ConsentRevokedError(HusshError):
+    """Raised when consent is revoked during an agent run."""
+
+    def __init__(self, domain: str):
+        self.domain = domain
+        super().__init__(f"Consent was revoked for '{domain}'.")
+
+
+class RuntimeCredentialMissingError(HusshError):
+    """Raised when a BYOK runtime has no resolvable credential."""
+
+    def __init__(self, credential_ref: str | None):
+        self.credential_ref = credential_ref
+        super().__init__(f"No runtime credential resolved for '{credential_ref}'.")
+
+
+class RuntimeConfigError(HusshError):
+    """Raised when runtime/model metadata violates the Hussh SDK contract."""

--- a/consent-protocol/hussh_sdk/factory.py
+++ b/consent-protocol/hussh_sdk/factory.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import httpx
+
+from hussh_sdk.agent import HusshAgent
+from hussh_sdk.credentials import CredentialResolver
+from hussh_sdk.models import ModelConfig, RuntimeConfig, RuntimeKind, runtime_config
+from hussh_sdk.runtime import RuntimeAdapter, runtime_adapter_for
+
+
+def create_agent(
+    *,
+    name: str,
+    runtime: RuntimeKind | RuntimeConfig = "local_platform",
+    model: str | ModelConfig | None = None,
+    provider: str | None = None,
+    credential_ref: str | None = None,
+    api_key: str = "sandbox",
+    endpoint: str = "https://api.hussh.ai/v1",
+    mock_persona: str = "Manish",
+    sandbox_persona: str | None = None,
+    subject_ua: str = "ua_sandbox",
+    transport: httpx.AsyncBaseTransport | None = None,
+    runtime_adapter: RuntimeAdapter | None = None,
+    credential_resolver: CredentialResolver | None = None,
+) -> HusshAgent:
+    config = runtime_config(
+        runtime,
+        model=model,
+        provider=provider,
+        credential_ref=credential_ref,
+    )
+    agent = HusshAgent(
+        api_key=api_key,
+        endpoint=endpoint,
+        mock_mode=config.kind == "mock",
+        mock_persona=mock_persona,
+        sandbox_persona=sandbox_persona,
+        subject_ua=subject_ua,
+        relying_service=name,
+        transport=transport,
+        runtime_config=config,
+        runtime_adapter=runtime_adapter,
+        credential_resolver=credential_resolver,
+    )
+    if agent.runtime_adapter is None:
+        agent.runtime_adapter = runtime_adapter_for(config)
+    return agent

--- a/consent-protocol/hussh_sdk/models.py
+++ b/consent-protocol/hussh_sdk/models.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+RuntimeKind = Literal[
+    "mock",
+    "local_platform",
+    "google_adk",
+    "mlx_local",
+    "cloud_model",
+    "byoc_http",
+]
+
+ModelMode = Literal["byok", "runtime_managed", "none"]
+
+
+@dataclass(frozen=True)
+class ModelConfig:
+    provider: str = "gemini"
+    model: str = "gemini-3.5-flash"
+    mode: ModelMode = "byok"
+    credential_ref: str | None = "user_secret:gemini_api_key"
+
+    def describe(self) -> dict:
+        return {
+            "provider": self.provider,
+            "model": self.model,
+            "mode": self.mode,
+            "credential_ref": self.credential_ref,
+        }
+
+
+@dataclass(frozen=True)
+class RuntimeConfig:
+    kind: RuntimeKind = "local_platform"
+    framework: str = "hussh_sdk"
+    deployment_target: str = "personal_sandbox"
+    model: ModelConfig = field(default_factory=ModelConfig)
+
+    def describe(self) -> dict:
+        return {
+            "kind": self.kind,
+            "framework": self.framework,
+            "deployment_target": self.deployment_target,
+            "model": self.model.describe(),
+        }
+
+
+def runtime_config(
+    runtime: RuntimeKind | RuntimeConfig = "local_platform",
+    *,
+    model: str | ModelConfig | None = None,
+    provider: str | None = None,
+    mode: ModelMode | None = None,
+    credential_ref: str | None = None,
+    framework: str | None = None,
+    deployment_target: str | None = None,
+) -> RuntimeConfig:
+    if isinstance(runtime, RuntimeConfig):
+        return runtime
+
+    if isinstance(model, ModelConfig):
+        model_config = model
+    else:
+        model_config = ModelConfig(
+            provider=provider or _default_provider(runtime),
+            model=model or _default_model(runtime),
+            mode=mode or _default_model_mode(runtime),
+            credential_ref=credential_ref
+            if credential_ref is not None
+            else _default_credential_ref(runtime),
+        )
+
+    return RuntimeConfig(
+        kind=runtime,
+        framework=framework or _default_framework(runtime),
+        deployment_target=deployment_target or _default_deployment_target(runtime),
+        model=model_config,
+    )
+
+
+def _default_provider(runtime: RuntimeKind) -> str:
+    if runtime == "mlx_local":
+        return "local"
+    if runtime == "cloud_model":
+        return "openai"
+    if runtime == "mock":
+        return "mock"
+    return "gemini"
+
+
+def _default_model(runtime: RuntimeKind) -> str:
+    if runtime == "mlx_local":
+        return "mlx-community/Qwen2.5-7B-Instruct-4bit"
+    if runtime == "cloud_model":
+        return "gpt-4.1-mini"
+    if runtime == "mock":
+        return "mock-model"
+    return "gemini-3.5-flash"
+
+
+def _default_model_mode(runtime: RuntimeKind) -> ModelMode:
+    if runtime in {"mlx_local", "mock"}:
+        return "none"
+    return "byok"
+
+
+def _default_credential_ref(runtime: RuntimeKind) -> str | None:
+    if runtime in {"mlx_local", "mock"}:
+        return None
+    return f"user_secret:{_default_provider(runtime)}_api_key"
+
+
+def _default_framework(runtime: RuntimeKind) -> str:
+    return {
+        "google_adk": "google_adk",
+        "mlx_local": "mlx_local",
+        "cloud_model": "cloud_model",
+        "byoc_http": "http_service",
+        "mock": "hussh_mock",
+        "local_platform": "hussh_sdk",
+    }[runtime]
+
+
+def _default_deployment_target(runtime: RuntimeKind) -> str:
+    return {
+        "google_adk": "personal_sandbox",
+        "mlx_local": "apple_local",
+        "cloud_model": "platform_sandbox",
+        "byoc_http": "developer_byoc",
+        "mock": "local_mock",
+        "local_platform": "personal_sandbox",
+    }[runtime]

--- a/consent-protocol/hussh_sdk/runtime.py
+++ b/consent-protocol/hussh_sdk/runtime.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from hussh_sdk.models import RuntimeConfig
+
+
+@dataclass(frozen=True)
+class RuntimeRequest:
+    prompt: str
+    context: dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RuntimeResult:
+    output: Any
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class RuntimeAdapter(Protocol):
+    config: RuntimeConfig
+
+    async def run(self, request: RuntimeRequest) -> RuntimeResult:
+        """Execute using approved context only."""
+
+    def describe(self) -> dict[str, Any]:
+        """Return runtime metadata suitable for evidence."""
+
+
+class BaseRuntimeAdapter:
+    def __init__(self, config: RuntimeConfig):
+        self.config = config
+
+    def describe(self) -> dict[str, Any]:
+        return self.config.describe()
+
+
+class MockRuntimeAdapter(BaseRuntimeAdapter):
+    async def run(self, request: RuntimeRequest) -> RuntimeResult:
+        context_keys = sorted(request.context.keys())
+        output = {
+            "status": "succeeded",
+            "runtime": "mock",
+            "prompt": request.prompt,
+            "context_keys": context_keys,
+        }
+        return RuntimeResult(output=output, metadata={"runtime": self.describe()})
+
+
+class LocalPlatformRuntimeAdapter(BaseRuntimeAdapter):
+    async def run(self, request: RuntimeRequest) -> RuntimeResult:
+        return RuntimeResult(
+            output={
+                "status": "runtime_not_configured",
+                "message": "Consent succeeded, but no live specialist runtime produced output.",
+                "prompt": request.prompt,
+            },
+            metadata={"runtime": self.describe()},
+        )
+
+
+def runtime_adapter_for(config: RuntimeConfig) -> RuntimeAdapter:
+    if config.kind == "mock":
+        return MockRuntimeAdapter(config)
+    return LocalPlatformRuntimeAdapter(config)

--- a/consent-protocol/tests/services/test_agent_chat_service.py
+++ b/consent-protocol/tests/services/test_agent_chat_service.py
@@ -2,25 +2,33 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 from hushh_mcp.services.agent_chat_service import (
     AGENT_SYSTEM_PROMPT,
-    DEFAULT_AGENT_CHAT_MODEL,
     AgentChatMessage,
     AgentChatService,
     AgentRuntimeContractError,
+    RuntimeSecretSession,
+    create_managed_runtime_client,
+    create_runtime_client,
+)
+from hussh_sdk import (
+    ModelConfig,
+    PKMCredentialResolver,
+    prepare_runtime_credentials,
+    runtime_config,
 )
 
 
-def test_agent_chat_service_defaults_to_stable_gemini_model(monkeypatch, test_vault_key):
-    monkeypatch.delenv("AGENT_GEMINI_MODEL", raising=False)
-
+def test_agent_chat_service_uses_agent_yaml_model(test_vault_key):
     service = AgentChatService(vault_key_hex=test_vault_key)
 
-    assert service.model == DEFAULT_AGENT_CHAT_MODEL == "gemini-2.5-pro"
+    assert service.model == "gemini-2.5-flash"
 
 
-def test_agent_chat_service_allows_env_model_override(monkeypatch, test_vault_key):
-    monkeypatch.setenv("AGENT_GEMINI_MODEL", "gemini-2.5-flash")
+def test_agent_chat_service_ignores_env_model_override(monkeypatch, test_vault_key):
+    monkeypatch.setenv("AGENT_GEMINI_MODEL", "gemini-env-override")
 
     service = AgentChatService(vault_key_hex=test_vault_key)
 
@@ -76,6 +84,123 @@ def test_agent_chat_runtime_contract_rejects_invalid_mode(test_vault_key):
         assert error.message == "Agent runtime credential mode is invalid."
     else:  # pragma: no cover - defensive assertion clarity
         raise AssertionError("Expected AgentRuntimeContractError")
+
+
+@pytest.mark.anyio
+async def test_agent_chat_service_prepares_byok_runtime_from_pkm_secret(
+    monkeypatch,
+    test_vault_key,
+    caplog,
+):
+    calls: list[dict] = []
+    sample_runtime_value = "_".join(["USER", "BYOK", "VALUE", "SHOULD", "NOT", "LEAK"])
+
+    def fake_client(**kwargs):
+        calls.append(kwargs)
+        return SimpleNamespace(kind="client")
+
+    monkeypatch.setenv("GOOGLE_API_KEY", "BACKEND_KEY_SHOULD_NOT_BE_USED")
+    monkeypatch.setattr("hushh_mcp.services.agent_chat_service.genai.Client", fake_client)
+    service = AgentChatService(vault_key_hex=test_vault_key)
+
+    prepared = await service.prepare_agent_runtime(
+        runtime_credential=sample_runtime_value,
+        runtime_credential_mode="byok",
+    )
+
+    assert prepared.mode == "byok"
+    assert prepared.model == "gemini-2.5-flash"
+    assert prepared.client.kind == "client"
+    assert calls == [{"vertexai": False, "api_key": sample_runtime_value}]
+    assert sample_runtime_value not in str(prepared.evidence)
+    assert sample_runtime_value not in caplog.text
+
+
+def test_create_runtime_client_uses_byok_key_without_env_fallback(monkeypatch):
+    calls: list[dict] = []
+    monkeypatch.setenv("GOOGLE_API_KEY", "BACKEND_KEY_SHOULD_NOT_BE_USED")
+    monkeypatch.setenv("GEMINI_API_KEY", "BACKEND_GEMINI_SHOULD_NOT_BE_USED")
+
+    def fake_client(**kwargs):
+        calls.append(kwargs)
+        return SimpleNamespace(kind="client")
+
+    monkeypatch.setattr("hushh_mcp.services.agent_chat_service.genai.Client", fake_client)
+
+    client = create_runtime_client("gemini", " USER_BYOK_KEY ")
+
+    assert client.kind == "client"
+    assert calls == [{"vertexai": False, "api_key": "USER_BYOK_KEY"}]
+
+
+def test_create_managed_runtime_client_uses_vertex_api_key(monkeypatch):
+    calls: list[dict] = []
+
+    def fake_client(**kwargs):
+        calls.append(kwargs)
+        return SimpleNamespace(kind="client")
+
+    monkeypatch.setattr("hushh_mcp.services.agent_chat_service.genai.Client", fake_client)
+
+    client = create_managed_runtime_client("gemini", " MANAGED_KEY ")
+
+    assert client.kind == "client"
+    assert calls == [{"vertexai": True, "api_key": "MANAGED_KEY"}]
+
+
+@pytest.mark.anyio
+async def test_prepare_runtime_credentials_resolves_pkm_credential_without_raw_value_in_evidence():
+    sample_runtime_key = "USER_KEY_SHOULD_NOT_LEAK"
+    runtime = runtime_config(
+        "google_adk",
+        model=ModelConfig(
+            provider="gemini",
+            model="gemini-2.5-flash",
+            mode="byok",
+            credential_ref="pkm:runtime_secrets.llm.gemini_api_key",
+        ),
+    )
+
+    bundle = await prepare_runtime_credentials(
+        runtime,
+        resolver=PKMCredentialResolver(
+            RuntimeSecretSession(
+                "pkm:runtime_secrets.llm.gemini_api_key",
+                sample_runtime_key,
+            )
+        ),
+    )
+
+    assert bundle.credential is not None
+    assert bundle.credential.secret == sample_runtime_key
+    assert sample_runtime_key not in str(bundle.evidence)
+
+
+@pytest.mark.anyio
+async def test_prepare_runtime_credentials_fails_on_credential_ref_mismatch():
+    runtime = runtime_config(
+        "google_adk",
+        model=ModelConfig(
+            provider="gemini",
+            model="gemini-2.5-flash",
+            mode="byok",
+            credential_ref="pkm:runtime_secrets.llm.gemini_api_key",
+        ),
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        await prepare_runtime_credentials(
+            runtime,
+            resolver=PKMCredentialResolver(
+                RuntimeSecretSession(
+                    "pkm:runtime_secrets.llm.other_api_key",
+                    "USER_KEY_SHOULD_NOT_LEAK",
+                )
+            ),
+        )
+
+    assert "No runtime credential resolved" in str(exc_info.value)
+    assert "USER_KEY_SHOULD_NOT_LEAK" not in str(exc_info.value)
 
 
 def test_agent_chat_service_decrypts_encrypted_conversation_and_message(test_vault_key):

--- a/consent-protocol/tests/test_agent_chat_routes.py
+++ b/consent-protocol/tests/test_agent_chat_routes.py
@@ -9,7 +9,9 @@ from hushh_mcp.services.agent_chat_service import (
     AgentChatConversation,
     AgentChatMessage,
     AgentRuntimeContractError,
+    AgentRuntimeProviderError,
     PreparedAgentChatTurn,
+    PreparedAgentRuntime,
 )
 
 
@@ -19,9 +21,12 @@ class _FakeAgentChatService:
         self.next_action_plan: AgentChatActionPlan | None = None
         self.prepared_turns = 0
         self.runtime_contract_calls: list[dict] = []
+        self.prepared_runtimes: list[dict] = []
         self.stream_action_plans: list[AgentChatActionPlan | None] = []
         self.stream_tokens = ["Hello", " from Gemini"]
         self.stream_error: Exception | None = None
+        self.plan_error: Exception | None = None
+        self.runtime_client = object()
         self.deleted = False
         self.conversation = AgentChatConversation(
             id="conversation-1",
@@ -86,6 +91,31 @@ class _FakeAgentChatService:
             )
         return None
 
+    async def prepare_agent_runtime(
+        self,
+        *,
+        runtime_credential: str | None = None,
+        runtime_credential_mode: str | None = None,
+    ):
+        self.prepare_runtime_contract(
+            runtime_credential=runtime_credential,
+            runtime_credential_mode=runtime_credential_mode,
+        )
+        self.prepared_runtimes.append(
+            {
+                "runtime_credential": runtime_credential,
+                "runtime_credential_mode": runtime_credential_mode,
+            }
+        )
+        return PreparedAgentRuntime(
+            mode=runtime_credential_mode or "hushh_managed_vertex",
+            provider="gemini",
+            model="gemini-2.5-flash",
+            credential_ref="pkm:runtime_secrets.llm.gemini_api_key",
+            client=self.runtime_client,
+            evidence={},
+        )
+
     async def prepare_turn(self, *, user_id: str, message: str, conversation_id: str | None = None):
         assert user_id == "user-1"
         assert message == "Hello Agent"
@@ -103,11 +133,15 @@ class _FakeAgentChatService:
         *,
         user_message: str,
         history: list[AgentChatMessage],
+        runtime_client,
+        runtime_model: str,
         action_plan: AgentChatActionPlan | None = None,
         pkm_context: str | None = None,
     ):
         assert user_message == "Hello Agent"
         assert history == []
+        assert runtime_client is self.runtime_client
+        assert runtime_model == "gemini-2.5-flash"
         assert pkm_context in {None, "Saved domains: Financial"}
         self.stream_action_plans.append(action_plan)
         if self.stream_error is not None:
@@ -120,11 +154,17 @@ class _FakeAgentChatService:
         *,
         user_message: str,
         history: list[AgentChatMessage],
+        runtime_client,
+        runtime_model: str,
         pkm_context: str | None = None,
     ):
         assert user_message == "Hello Agent"
         assert history == []
+        assert runtime_client is self.runtime_client
+        assert runtime_model == "gemini-2.5-flash"
         assert pkm_context in {None, "Saved domains: Financial"}
+        if self.plan_error is not None:
+            raise self.plan_error
         return self.next_action_plan
 
     def plan_action(self, message: str):
@@ -396,6 +436,49 @@ def test_agent_chat_stream_saves_error_message_when_stream_fails_before_tokens(m
             "status": "error",
             "model": "gemini-2.5-pro",
             "error_code": "AGENT_CHAT_STREAM_FAILED",
+        }
+    ]
+
+
+def test_agent_chat_stream_saves_safe_runtime_provider_error(monkeypatch):
+    service = _FakeAgentChatService()
+    service.stream_error = AgentRuntimeProviderError(
+        error_code="AGENT_RUNTIME_CREDENTIAL_INVALID",
+        message=(
+            "Your saved Gemini key could not be used. Update it in Profile > Runtime keys "
+            "or switch Kai to Hushh managed Gemini."
+        ),
+        detail={"likely_issue": "invalid_or_unauthorized_api_key"},
+    )
+    monkeypatch.setattr(agent_chat, "get_agent_chat_service", lambda: service)
+    client = _client(service)
+
+    response = client.post(
+        "/agent/chat/stream",
+        json={
+            "user_id": "user-1",
+            "message": "Hello Agent",
+            "runtime_credential_mode": "byok",
+            "runtime_credential": "BAD_KEY_SHOULD_NOT_LEAK",
+        },
+    )
+
+    assert response.status_code == 200
+    assert '"code": "AGENT_RUNTIME_CREDENTIAL_INVALID"' in response.text
+    assert "Your saved Gemini key could not be used." in response.text
+    assert "BAD_KEY_SHOULD_NOT_LEAK" not in response.text
+    assert service.saved_messages == [
+        {
+            "conversation_id": "conversation-1",
+            "user_id": "user-1",
+            "role": "assistant",
+            "content": (
+                "Your saved Gemini key could not be used. Update it in Profile > Runtime keys "
+                "or switch Kai to Hushh managed Gemini."
+            ),
+            "status": "error",
+            "model": "gemini-2.5-pro",
+            "error_code": "AGENT_RUNTIME_CREDENTIAL_INVALID",
         }
     ]
 

--- a/hushh-webapp/__tests__/services/agent-chat-client.test.ts
+++ b/hushh-webapp/__tests__/services/agent-chat-client.test.ts
@@ -87,6 +87,37 @@ describe("agent chat client", () => {
       conversationId: undefined,
       vaultOwnerToken: "vault-token",
       pkmContext: undefined,
+      runtimeCredential: undefined,
+      runtimeCredentialMode: undefined,
+      signal: undefined,
+    });
+  });
+
+  it("passes runtime credential fields through to the backend stream request", async () => {
+    vi.spyOn(ApiService, "streamAgentChat").mockResolvedValue(
+      sseResponse([
+        'event: start\ndata: {"conversation_id":"conversation-1","model":"gemini-2.5-flash"}\n\n',
+        'event: complete\ndata: {"conversation_id":"conversation-1","model":"gemini-2.5-flash"}\n\n',
+      ])
+    );
+
+    await streamAgentChat({
+      userId: "user-1",
+      message: "Hello",
+      vaultOwnerToken: "vault-token",
+      pkmContext: "Saved domains: Financial",
+      runtimeCredential: "USER_BYOK_KEY",
+      runtimeCredentialMode: "byok",
+    });
+
+    expect(ApiService.streamAgentChat).toHaveBeenCalledWith({
+      userId: "user-1",
+      message: "Hello",
+      conversationId: undefined,
+      vaultOwnerToken: "vault-token",
+      pkmContext: "Saved domains: Financial",
+      runtimeCredential: "USER_BYOK_KEY",
+      runtimeCredentialMode: "byok",
       signal: undefined,
     });
   });
@@ -140,6 +171,34 @@ describe("agent chat client", () => {
     ).rejects.toThrow("Vault locked");
   });
 
+  it("formats runtime credential errors from backend JSON detail", async () => {
+    vi.spyOn(ApiService, "streamAgentChat").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          detail: {
+            code: "AGENT_RUNTIME_CREDENTIAL_MISSING",
+            message: "No runtime credential resolved for 'pkm:runtime_secrets.llm.gemini_api_key'.",
+          },
+        }),
+        {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        }
+      )
+    );
+
+    await expect(
+      streamAgentChat({
+        userId: "user-1",
+        message: "Hello",
+        vaultOwnerToken: "vault-token",
+        runtimeCredentialMode: "byok",
+      })
+    ).rejects.toThrow(
+      "Kai needs your Gemini key. Add it in Profile > Runtime keys, or switch Kai to Hushh managed Gemini."
+    );
+  });
+
   it("throws streamed backend error events after notifying the handler", async () => {
     vi.spyOn(ApiService, "streamAgentChat").mockResolvedValue(
       sseResponse([
@@ -161,6 +220,32 @@ describe("agent chat client", () => {
       })
     ).rejects.toThrow("Agent chat failed. Please try again.");
     expect(errors).toEqual(["Agent chat failed. Please try again."]);
+  });
+
+  it("formats streamed runtime provider errors", async () => {
+    vi.spyOn(ApiService, "streamAgentChat").mockResolvedValue(
+      sseResponse([
+        'event: start\ndata: {"conversation_id":"conversation-1","model":"gemini-2.5-flash"}\n\n',
+        'event: error\ndata: {"code":"AGENT_RUNTIME_CREDENTIAL_INVALID","message":"Provider detail should not leak."}\n\n',
+      ])
+    );
+    const errors: string[] = [];
+
+    await expect(
+      streamAgentChat({
+        userId: "user-1",
+        message: "Hello",
+        vaultOwnerToken: "vault-token",
+        handlers: {
+          onError: (message) => errors.push(message),
+        },
+      })
+    ).rejects.toThrow(
+      "Your saved Gemini key could not be used. Update it in Profile > Runtime keys, or switch Kai to Hushh managed Gemini."
+    );
+    expect(errors).toEqual([
+      "Your saved Gemini key could not be used. Update it in Profile > Runtime keys, or switch Kai to Hushh managed Gemini.",
+    ]);
   });
 
   it("reads recent conversations and history", async () => {

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -75,6 +75,12 @@ import {
   type AgentChatMessage as StoredAgentChatMessage,
   type AgentChatToolEvent,
 } from "@/lib/services/agent-chat-client";
+import {
+  GEMINI_RUNTIME_CREDENTIAL_REF,
+  PersonalKnowledgeModelService,
+  RUNTIME_CREDENTIAL_MODE_REF,
+  type RuntimeCredentialMode,
+} from "@/lib/services/personal-knowledge-model-service";
 import { useKaiSession } from "@/lib/stores/kai-session-store";
 import { cn } from "@/lib/utils";
 import { useVault } from "@/lib/vault/vault-context";
@@ -1777,6 +1783,61 @@ export function AgentChatWorkspace({
         });
       }
 
+      let runtimeCredentialMode: RuntimeCredentialMode = "hushh_managed_vertex";
+      let runtimeCredential: string | null = null;
+      if (vaultKey && token) {
+        try {
+          const savedMode = await PersonalKnowledgeModelService.loadRuntimeSecret({
+            userId,
+            vaultKey,
+            vaultOwnerToken: token,
+            credentialRef: RUNTIME_CREDENTIAL_MODE_REF,
+          });
+          runtimeCredentialMode = savedMode === "byok" ? "byok" : "hushh_managed_vertex";
+          if (runtimeCredentialMode === "byok") {
+            try {
+              runtimeCredential = await PersonalKnowledgeModelService.loadRuntimeSecret({
+                userId,
+                vaultKey,
+                vaultOwnerToken: token,
+                credentialRef: GEMINI_RUNTIME_CREDENTIAL_REF,
+              });
+            } catch (error) {
+              runtimeCredential = null;
+              appendDebugEvent(debugTurnId, "runtime_credential_load_failed", {
+                mode: runtimeCredentialMode,
+                provider: "gemini",
+                credential_ref: GEMINI_RUNTIME_CREDENTIAL_REF,
+                message:
+                  error instanceof Error && error.message
+                    ? error.message
+                    : "Failed to load the Gemini runtime key.",
+              });
+            }
+          }
+          appendDebugEvent(debugTurnId, "runtime_credentials_prepared", {
+            mode: runtimeCredentialMode,
+            provider: "gemini",
+            credential_ref: GEMINI_RUNTIME_CREDENTIAL_REF,
+            credential_resolved: Boolean(runtimeCredential),
+          });
+        } catch (error) {
+          runtimeCredentialMode = "hushh_managed_vertex";
+          runtimeCredential = null;
+          appendDebugEvent(debugTurnId, "runtime_credential_mode_load_failed", {
+            message:
+              error instanceof Error && error.message
+                ? error.message
+                : "Failed to load runtime credential settings.",
+          });
+        }
+      } else {
+        appendDebugEvent(debugTurnId, "runtime_credentials_skipped", {
+          reason: "vault_locked_or_unavailable",
+          mode: runtimeCredentialMode,
+        });
+      }
+
       armVoiceStreamWatchdog(
         VOICE_AGENT_FIRST_EVENT_TIMEOUT_MS,
         "Agent voice response timed out before it started. Please try again."
@@ -1787,6 +1848,8 @@ export function AgentChatWorkspace({
         conversationId,
         vaultOwnerToken: token,
         pkmContext: agentPkmContext.text || undefined,
+        runtimeCredential,
+        runtimeCredentialMode,
         signal: streamAbortController.signal,
         handlers: {
           onStart: ({ conversationId: nextConversationId }) => {

--- a/hushh-webapp/lib/services/agent-chat-client.ts
+++ b/hushh-webapp/lib/services/agent-chat-client.ts
@@ -63,6 +63,22 @@ function readRecord(record: Record<string, unknown>, key: string): Record<string
   return asRecord(record[key]) || {};
 }
 
+function formatAgentChatErrorMessage(message: string, code?: string): string {
+  if (code === "AGENT_RUNTIME_CREDENTIAL_MISSING") {
+    return "Kai needs your Gemini key. Add it in Profile > Runtime keys, or switch Kai to Hushh managed Gemini.";
+  }
+  if (code === "AGENT_RUNTIME_CREDENTIAL_INVALID") {
+    return "Your saved Gemini key could not be used. Update it in Profile > Runtime keys, or switch Kai to Hushh managed Gemini.";
+  }
+  if (code === "AGENT_RUNTIME_MANAGED_CREDENTIALS_UNAVAILABLE") {
+    return "Hushh managed Gemini is not available in this environment.";
+  }
+  if (code === "AGENT_RUNTIME_MODEL_UNAVAILABLE") {
+    return "Kai's configured Gemini model is not available for this runtime.";
+  }
+  return message || "Agent chat failed. Please try again.";
+}
+
 function normalizeToolEvent(payload: Record<string, unknown>): AgentChatToolEvent {
   return {
     callId: readString(payload, "call_id"),
@@ -80,8 +96,16 @@ function normalizeToolEvent(payload: Record<string, unknown>): AgentChatToolEven
 async function readError(response: Response): Promise<string> {
   const payload = (await response.json().catch(() => null)) as unknown;
   const record = asRecord(payload);
-  const detail = record ? readString(record, "detail") || readString(record, "message") : "";
-  return detail || `Agent chat request failed (${response.status})`;
+  const detailRecord = record ? asRecord(record.detail) : null;
+  const code = detailRecord ? readString(detailRecord, "code") : record ? readString(record, "code") : "";
+  const detail = detailRecord
+    ? readString(detailRecord, "message")
+    : record
+      ? readString(record, "detail") || readString(record, "message")
+      : "";
+  return detail
+    ? formatAgentChatErrorMessage(detail, code || undefined)
+    : `Agent chat request failed (${response.status})`;
 }
 
 export async function streamAgentChat(input: {
@@ -90,6 +114,8 @@ export async function streamAgentChat(input: {
   conversationId?: string | null;
   vaultOwnerToken: string;
   pkmContext?: string;
+  runtimeCredential?: string | null;
+  runtimeCredentialMode?: string | null;
   signal?: AbortSignal;
   handlers?: AgentChatStreamHandlers;
 }): Promise<{ conversationId: string | null; model: string | null; text: string }> {
@@ -99,6 +125,8 @@ export async function streamAgentChat(input: {
     conversationId: input.conversationId || undefined,
     vaultOwnerToken: input.vaultOwnerToken,
     pkmContext: input.pkmContext,
+    runtimeCredential: input.runtimeCredential,
+    runtimeCredentialMode: input.runtimeCredentialMode,
     signal: input.signal,
   });
 
@@ -158,7 +186,10 @@ export async function streamAgentChat(input: {
       return;
     }
     if (event === "error") {
-      streamError = readString(payload, "message") || "Agent chat failed.";
+      streamError = formatAgentChatErrorMessage(
+        readString(payload, "message"),
+        readString(payload, "code") || undefined
+      );
       input.handlers?.onError?.(streamError);
     }
   };

--- a/hushh-webapp/lib/services/api-service.ts
+++ b/hushh-webapp/lib/services/api-service.ts
@@ -2531,6 +2531,8 @@ export class ApiService {
     conversationId?: string;
     vaultOwnerToken: string;
     pkmContext?: string;
+    runtimeCredential?: string | null;
+    runtimeCredentialMode?: string | null;
     signal?: AbortSignal;
   }): Promise<Response> {
     return ApiService.apiFetchStream("/api/kai/agent/chat/stream", {
@@ -2543,6 +2545,8 @@ export class ApiService {
         message: data.message,
         conversation_id: data.conversationId,
         pkm_context: data.pkmContext,
+        runtime_credential: data.runtimeCredential || undefined,
+        runtime_credential_mode: data.runtimeCredentialMode || undefined,
       }),
       signal: data.signal,
     });


### PR DESCRIPTION
## Description

Completes the final Kai BYOK runtime execution slice. Agent chat now uses the model and credential policy from consent-protocol/hushh_mcp/agents/kai/agent.yaml, resolves the user Gemini key from encrypted PKM through the vendored Hussh SDK only for BYOK runs, and keeps Hushh-managed Gemini as the default mode.

BYOK runs create a Gemini Developer API client with the user key for that request only. Managed runs use the Hushh-managed Gemini path. Runtime evidence is logged with credentials redacted, and provider failures return user-friendly errors without leaking raw keys or PKM refs.

This also vendors the Hussh SDK source under consent-protocol/hussh_sdk so the open-source repo does not depend on a private package registry or private Git URL at deploy time.

## Verification

- cd consent-protocol && uv run ruff check hushh_mcp/services/agent_chat_service.py api/routes/kai/agent_chat.py tests/services/test_agent_chat_service.py tests/test_agent_chat_routes.py hussh_sdk
- cd consent-protocol && uv run python -m pytest tests/services/test_agent_chat_service.py tests/test_agent_chat_routes.py -q
- cd hushh-webapp && npm test -- __tests__/services/agent-chat-client.test.ts
- cd hushh-webapp && npm run typecheck
- Manual local verification: fake Gemini key fails in BYOK after web rebuild; managed mode remains default and works separately.

## Notes

The old broad BYOK branch feature/hussh-dev-byok-implementation had no open PR and was deleted from the fork after this final branch was pushed.