### PR TITLE
fix(navigation): replace window-prefixed rAF calls in kai-bottom-chrome-visibility

### DIFF
--- a/hushh-webapp/lib/navigation/kai-bottom-chrome-visibility.ts
+++ b/hushh-webapp/lib/navigation/kai-bottom-chrome-visibility.ts
@@ -47,7 +47,7 @@ function emit() {
 
 function cancelAnimation() {
   if (typeof window === "undefined" || state.rafId === null) return;
-  window.cancelAnimationFrame(state.rafId);
+  cancelAnimationFrame(state.rafId);
   state.rafId = null;
   state.lastFrameTs = null;
 }
@@ -77,7 +77,7 @@ function animateProgress(ts: number) {
     emit();
   }
 
-  state.rafId = window.requestAnimationFrame(animateProgress);
+  state.rafId = requestAnimationFrame(animateProgress);
 }
 
 function setTargetProgress(nextTarget: number) {
@@ -99,7 +99,7 @@ function setTargetProgress(nextTarget: number) {
 
   if (typeof window !== "undefined" && state.rafId === null) {
     state.lastFrameTs = null;
-    state.rafId = window.requestAnimationFrame(animateProgress);
+    state.rafId = requestAnimationFrame(animateProgress);
   }
 }
 


### PR DESCRIPTION
## Summary

Addresses issue #1996 by replacing `window.requestAnimationFrame` and `window.cancelAnimationFrame` with their global equivalents in `kai-bottom-chrome-visibility.ts`.

## Changes

* Replaced `window.cancelAnimationFrame(...)` with `cancelAnimationFrame(...)`
* Replaced `window.requestAnimationFrame(...)` with `requestAnimationFrame(...)` in two locations

## Why

Using the global animation frame APIs avoids direct dependence on the `window` object and aligns with SSR-safe patterns used throughout Next.js applications.

This change is intentionally scoped to the locations identified in issue #1996.

## Impact

* Scope limited to `hushh-webapp/lib/navigation/kai-bottom-chrome-visibility.ts`
* No UI changes
* No routing changes
* No behavioral changes
* No consent, privacy, or telemetry changes

## Validation

* Change limited to a single file
* Three call sites updated
* Lint checks passed
* Type checks passed

Closes #1996
