### PR TITLE
fix(constants): guard navigator.userAgent access with typeof check in constants.ts

### DIFF
--- a/hushh-webapp/lib/constants.ts
+++ b/hushh-webapp/lib/constants.ts
@@ -61,13 +61,14 @@ export const API_CONFIG = {
   /** Backend base URL */
   BASE_URL:
     typeof window !== "undefined" &&
-    /Android/i.test(navigator.userAgent) &&
-    (process.env.NEXT_PUBLIC_BACKEND_URL || "").includes("localhost")
+    typeof navigator !== "undefined" &&
+     /Android/i.test(navigator.userAgent) &&
+      (process.env.NEXT_PUBLIC_BACKEND_URL || "").includes("localhost")
       ? (process.env.NEXT_PUBLIC_BACKEND_URL || "").replace("localhost", "10.0.2.2")
       : process.env.NEXT_PUBLIC_BACKEND_URL ||
-        (process.env.NEXT_PUBLIC_APP_ENV === "development"
-          ? "http://127.0.0.1:8000"
-          : ""),
+      (process.env.NEXT_PUBLIC_APP_ENV === "development"
+        ? "http://127.0.0.1:8000"
+        : ""),
   /** SSE endpoint for consent notifications */
   SSE_CONSENT_EVENTS: "/api/consent/events",
 } as const;


### PR DESCRIPTION
## Summary

- what changed: Added typeof navigator !== "undefined" guard before navigator.userAgent access in API_CONFIG.BASE_URL in hushh-webapp/lib/constants.ts
- why it changed: navigator.userAgent was accessed without a guard after typeof window !== "undefined" check. In SSR and Node.js environments navigator is not defined causing ReferenceError: navigator is not defined.

## Attach point

hushh-webapp/lib/constants.ts — shared constants file exporting API_CONFIG consumed across all web and Capacitor app surfaces.

## Contract changed

Runtime behavior: navigator.userAgent is now only accessed when navigator is defined preventing ReferenceError in SSR and Node.js environments. No change to Android localhost rewrite behavior.

## Tests run

```bash
cd hushh-webapp && npx tsc --noEmit
```
Passed locally. No type errors.

## Base/head status

Branch is current with main, mergeable, and DCO-signed. Targets integration/pr-train as required by repo base policy.

## Sensitive proof

Not applicable. No auth, consent, vault, PKM, finance, or KYC surfaces touched. No secrets involved. Rollback: revert by removing the typeof navigator guard.

## Stack proof

Not applicable. Standalone fix, no predecessor PR.