### PR TITLE
test(consent): verify metadata map schema bounds enforce width, depth, and character-class constraints

### DIFF
--- a/hushh-webapp/__tests__/services/consent-export-builder.test.ts
+++ b/hushh-webapp/__tests__/services/consent-export-builder.test.ts
@@ -228,3 +228,174 @@ describe("buildConsentExportForScope", () => {
     ).rejects.toBeInstanceOf(ConsentExportNoDataError);
   });
 });
+
+// ── Metadata map schema bounds ────────────────────────────────────────────────
+//
+// The export engine must enforce a rigid schema on the __export_metadata map
+// regardless of how large, deeply nested, or character-corrupted the inbound
+// domain data or manifest payloads are.
+//
+// Boundary contracts under test:
+//   1. __export_metadata always emits exactly the canonical 6-field schema.
+//   2. A maximally wide flat map with all-empty values is rejected.
+//   3. A deeply nested all-null map is rejected.
+//   4. Segment IDs with special characters and uppercase are clamped to [a-z0-9_].
+//   5. A deeply nested map with one non-empty leaf is treated as shareable.
+//   6. A wide map dominated by null values is shareable if one valid string exists.
+//   7. export_timestamp is always a valid ISO 8601 string regardless of payload size.
+
+describe("buildConsentExportForScope — metadata map schema bounds", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pkmMocks.getDomainManifest.mockResolvedValue(manifest);
+    pkmMocks.getDomainData.mockResolvedValue({ dataVersion: 12 });
+    pkmMocks.loadDomainData.mockResolvedValue({
+      seat_preferences: { summary: "Prefers aisle seats near the front." },
+    });
+    pkmMocks.resolveSegmentIdsForPaths.mockReturnValue(["seat_preferences"]);
+  });
+
+  it("emits exactly the canonical 6-field __export_metadata schema when domain payload has 200 keys", async () => {
+    const widePayload = Object.fromEntries(
+      Array.from({ length: 200 }, (_, i) => [`field_${i}`, `value_${i}`])
+    );
+    pkmMocks.loadDomainData.mockResolvedValueOnce({ seat_preferences: widePayload });
+
+    const built = await buildConsentExportForScope({
+      userId: "user_1",
+      scope: "attr.travel.seat_preferences.*",
+      vaultKey: "vault-key",
+      vaultOwnerToken: "vault-owner",
+    });
+
+    expect(
+      Object.keys(built.payload.__export_metadata as object).sort()
+    ).toEqual([
+      "approved_paths",
+      "approved_segment_ids",
+      "export_timestamp",
+      "manifest_version",
+      "scope",
+      "source_domain",
+    ]);
+  });
+
+  it("throws ConsentExportNoDataError when a 200-key flat metadata map contains exclusively empty-string values", async () => {
+    const allEmpty = Object.fromEntries(
+      Array.from({ length: 200 }, (_, i) => [`field_${i}`, ""])
+    );
+    // Two mocks: first for the targeted-segment load, second for the full-domain
+    // fallback load the engine attempts before giving up.
+    pkmMocks.loadDomainData
+      .mockResolvedValueOnce({ seat_preferences: allEmpty })
+      .mockResolvedValueOnce({ seat_preferences: allEmpty });
+
+    await expect(
+      buildConsentExportForScope({
+        userId: "user_1",
+        scope: "attr.travel.seat_preferences.*",
+        vaultKey: "vault-key",
+        vaultOwnerToken: "vault-owner",
+      })
+    ).rejects.toBeInstanceOf(ConsentExportNoDataError);
+  });
+
+  it("throws ConsentExportNoDataError when a 10-level deeply nested map has exclusively null leaf values", async () => {
+    function buildDeepNull(depth: number): unknown {
+      return depth === 0 ? null : { nested: buildDeepNull(depth - 1) };
+    }
+    pkmMocks.loadDomainData
+      .mockResolvedValueOnce({ seat_preferences: buildDeepNull(10) })
+      .mockResolvedValueOnce({ seat_preferences: buildDeepNull(10) });
+
+    await expect(
+      buildConsentExportForScope({
+        userId: "user_1",
+        scope: "attr.travel.seat_preferences.*",
+        vaultKey: "vault-key",
+        vaultOwnerToken: "vault-owner",
+      })
+    ).rejects.toBeInstanceOf(ConsentExportNoDataError);
+  });
+
+  it("clamps segment IDs with special characters and uppercase to [a-z0-9_] in __export_metadata.approved_segment_ids", async () => {
+    // The engine normalises via normalizeSegmentCandidate before placing IDs in the
+    // metadata map — raw symbols and capital letters must never appear verbatim.
+    pkmMocks.resolveSegmentIdsForPaths.mockReturnValueOnce([
+      "Seat-Preferences!!!",
+      "PROFILE_DATA",
+    ]);
+
+    const built = await buildConsentExportForScope({
+      userId: "user_1",
+      scope: "attr.travel.seat_preferences.*",
+      vaultKey: "vault-key",
+      vaultOwnerToken: "vault-owner",
+    });
+
+    const meta = built.payload.__export_metadata as Record<string, unknown>;
+    const segmentIds = meta.approved_segment_ids as string[];
+
+    for (const id of segmentIds) {
+      expect(id).toMatch(/^[a-z0-9_]+$/);
+    }
+    expect(segmentIds).not.toContain("Seat-Preferences!!!");
+    expect(segmentIds).not.toContain("PROFILE_DATA");
+  });
+
+  it("does not throw when a 10-level deeply nested domain map has at least one non-empty string leaf", async () => {
+    const deepValue = {
+      l1: { l2: { l3: { l4: { l5: { l6: { l7: { l8: { l9: { l10: "deep-content" } } } } } } } } },
+    };
+    pkmMocks.loadDomainData.mockResolvedValueOnce({ seat_preferences: deepValue });
+
+    const built = await buildConsentExportForScope({
+      userId: "user_1",
+      scope: "attr.travel.seat_preferences.*",
+      vaultKey: "vault-key",
+      vaultOwnerToken: "vault-owner",
+    });
+
+    const meta = built.payload.__export_metadata as Record<string, unknown>;
+    expect(meta.scope).toBe("attr.travel.seat_preferences.*");
+    expect(meta.source_domain).toBe("travel");
+  });
+
+  it("does not throw when a 200-key map has 199 null/empty values but one valid non-empty string", async () => {
+    const mixedPayload = Object.fromEntries([
+      ...Array.from({ length: 100 }, (_, i) => [`empty_${i}`, ""]),
+      ...Array.from({ length: 99 }, (_, i) => [`null_${i}`, null]),
+      ["valid_field", "this is a real value"],
+    ]);
+    pkmMocks.loadDomainData.mockResolvedValueOnce({ seat_preferences: mixedPayload });
+
+    await expect(
+      buildConsentExportForScope({
+        userId: "user_1",
+        scope: "attr.travel.seat_preferences.*",
+        vaultKey: "vault-key",
+        vaultOwnerToken: "vault-owner",
+      })
+    ).resolves.toBeDefined();
+  });
+
+  it("always writes export_timestamp as a valid ISO 8601 string regardless of domain payload size", async () => {
+    const widePayload = Object.fromEntries(
+      Array.from({ length: 200 }, (_, i) => [`f${i}`, `v${i}`])
+    );
+    pkmMocks.loadDomainData.mockResolvedValueOnce({ seat_preferences: widePayload });
+
+    const built = await buildConsentExportForScope({
+      userId: "user_1",
+      scope: "attr.travel.seat_preferences.*",
+      vaultKey: "vault-key",
+      vaultOwnerToken: "vault-owner",
+    });
+
+    const meta = built.payload.__export_metadata as Record<string, unknown>;
+    const ts = meta.export_timestamp as string;
+    expect(typeof ts).toBe("string");
+    // toISOString() is idempotent on its own output — round-trip proves format validity.
+    expect(new Date(ts).toISOString()).toBe(ts);
+  });
+});


### PR DESCRIPTION
## Summary

Extends the canonical `consent-export-builder` test suite with 7 new cases that directly exercise the three boundary-enforcement mechanisms built into `buildConsentExportForScope` — metadata schema rigidity, shareable-value rejection, and segment-ID character clamping. Every case passes an extreme or malformed domain payload and asserts a hard structural outcome: exact field set on the metadata map, `ConsentExportNoDataError` for all-empty/all-null inputs, sanitised `[a-z0-9_]` segment IDs, and an idempotent ISO 8601 timestamp. No new files, direct production imports, upstream base.

## Files changed (1)

| File | Change |
|---|---|
| `hushh-webapp/__tests__/services/consent-export-builder.test.ts` | +171 lines — header comment block + `describe("buildConsentExportForScope — metadata map schema bounds")` with 7 `it` cases |

## Production module exercised

```typescript
// hushh-webapp/lib/consent/export-builder.ts
buildConsentExportForScope({ userId, scope, vaultKey, vaultOwnerToken })
  // internal boundary functions exercised through this entry point:
  hasShareableValue(value)           // recursive leaf-value check — rejects empty width + empty depth
  assertShareablePayload(scope, payload)  // throws ConsentExportNoDataError when nothing is shareable
  normalizeSegmentCandidate(path)    // clamps to [a-z0-9_], strips leading/trailing underscores
  mergeSegmentIds(...groups)         // deduplicates normalised segment IDs
  buildPayload(domainData, segIds)   // always emits the canonical 6-field __export_metadata map
```

## New test coverage

### `__export_metadata` schema rigidity (2 cases)

| Scenario | Assert |
|---|---|
| `loadDomainData` returns a 200-key flat map with non-empty values | `Object.keys(__export_metadata).sort()` equals exactly `["approved_paths", "approved_segment_ids", "export_timestamp", "manifest_version", "scope", "source_domain"]` — no extra keys bleed in |
| Same 200-key wide payload | `export_timestamp` round-trips through `new Date(ts).toISOString() === ts` — proves valid ISO 8601 regardless of payload size |

### Shareable-value rejection — width (1 case)

| Scenario | Assert |
|---|---|
| 200-key flat map, every value `""` (empty string) | `rejects.toBeInstanceOf(ConsentExportNoDataError)` — requires **2** `loadDomainData` mocks: one for the targeted-segment load, one for the full-domain fallback the engine attempts before giving up |

### Shareable-value rejection — depth (1 case)

| Scenario | Assert |
|---|---|
| `{ nested: { nested: … null } }` 10 levels deep | `rejects.toBeInstanceOf(ConsentExportNoDataError)` — `hasShareableValue` recurses all 10 levels, finds no truthy leaf; 2 `loadDomainData` mocks required for the same fallback reason |

### Shareable-value pass-through — depth and mixed width (2 cases)

| Scenario | Assert |
|---|---|
| 10-level nesting with `"deep-content"` at `l10` | Does not throw; `__export_metadata.scope` and `source_domain` are correct |
| 200-key map: 100 empty strings + 99 nulls + 1 `"this is a real value"` | `resolves.toBeDefined()` — single non-empty leaf is sufficient; width of dead keys cannot suppress a valid value |

### Segment ID character-class clamping (1 case)

| Raw ID from `resolveSegmentIdsForPaths` | After `normalizeSegmentCandidate` |
|---|---|
| `"Seat-Preferences!!!"` | `"seat_preferences"` — uppercase lowered, `-` and `!` → `_`, trailing underscores stripped |
| `"PROFILE_DATA"` | `"profile_data"` — uppercase lowered, underscore preserved |

Assert: every entry in `approved_segment_ids` matches `/^[a-z0-9_]+$/`; raw strings are absent.

## Mock interaction map

All 7 tests reuse the existing `vi.hoisted` `pkmMocks` at the top of the file. The new `describe` block registers its own `beforeEach` that clears and resets all mocks identically to the original block — Vitest scopes `beforeEach` to the enclosing `describe`, so there is zero cross-contamination with the existing 5 cases.

Tests that exercise the full-domain fallback path (cases 2 and 3) chain `.mockResolvedValueOnce` twice on `loadDomainData` — once for the initial targeted-segment read and once for the fallback read triggered when `hasShareableValue` returns `false` on the first result.

## CI gate checklist
- [x] **PR Base Policy** — targets `integration/pr-train` (upstream tip `c817c103`)
- [x] **DCO** — `Signed-off-by: Abdul Rashid <smirthidharmaiit@gmail.com>`
- [x] **Secret Scan** — diff contains only test fixture strings (`"vault-key"`, `"vault-owner"`, `"user_1"`); no tokens, keys, or credentials
- [x] **Governance** — single modified file in `__tests__/services/`, no debug artifacts, no commented-out code, no `eslint-disable`
- [x] **Path filters** — only `hushh-webapp/__tests__/services/consent-export-builder.test.ts` changed; triggers Web (Next.js) path gate, skips Protocol (Python) gate
- [x] **Upstream Sync** — branch cut from `c817c103` (current `integration/pr-train` tip); no merge conflicts
- [x] **Base Freshness Gate** — freshly branched from upstream tip; no stale base
- [x] **Web (Next.js)** — cases added to an existing file already covered by the Vitest `include: ["__tests__/**/*.test.{ts,tsx}"]` glob; no config changes; all new mocks follow the established `vi.hoisted` + `vi.mock` pattern already in the file
- [x] **No new files** — 171 additions to existing companion test file; no standalone scripts
- [x] **Direct production import** — `buildConsentExportForScope` and `ConsentExportNoDataError` imported directly from `@/lib/consent/export-builder`; no re-exports or path shims
- [x] **Clean diff** — 1 file, 171 additions, 0 deletions, fresh upstream base

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)