### PR TITLE
fix(frontend): add aria-hidden to decorative icons in theme toggle

### DIFF
--- a/hushh-webapp/components/theme-toggle.tsx
+++ b/hushh-webapp/components/theme-toggle.tsx
@@ -88,7 +88,7 @@ export function ThemeToggle({ className }: { className?: string }) {
             )}
           >
             <span className="relative z-10 inline-flex items-center gap-1.5">
-              <Icon icon={option.icon} size="sm" />
+              <Icon icon={option.icon} size="sm" aria-hidden="true" />
               <span className="text-[11px] font-medium leading-none sm:text-xs">
                 {option.label}
               </span>
@@ -132,7 +132,7 @@ export function ThemeToggleCompact({ className }: { className?: string }) {
             className
           )}
         >
-          <Icon icon={activeOption.icon} size="sm" />
+          <Icon icon={activeOption.icon} size="sm" aria-hidden="true" />
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" sideOffset={8} className="min-w-[140px]">
@@ -144,7 +144,7 @@ export function ThemeToggleCompact({ className }: { className?: string }) {
               onSelect={() => !isActive && setTheme(option.value)}
               className={cn("flex items-center gap-2", isActive && "font-medium")}
             >
-              <Icon icon={option.icon} size="sm" />
+              <Icon icon={option.icon} size="sm" aria-hidden="true" />
               <span className="flex-1">{option.label}</span>
               {isActive && <span className="text-xs">✓</span>}
             </DropdownMenuItem>


### PR DESCRIPTION
# Description

Added `aria-hidden="true"` to purely decorative `Icon` components in `theme-toggle.tsx` to prevent screen readers from announcing raw SVG metadata, improving overall accessibility for the theme switcher.

Before requesting review, read
[`docs/reference/quality/pr-contributor-readiness.md`](docs/reference/quality/pr-contributor-readiness.md).
Green CI is intake only; merge readiness also requires a reachable attach point,
production-code proof, and a title/body that match the diff.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] Reachable production attach point: `components/theme-toggle.tsx`
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

Every cross-platform feature must cover all affected layers or explicitly mark
the layer as not applicable with the reason.

- [x] **Web**: Next.js implementation (`app/api/...`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

N/A (Accessibility fix, no visible UI change)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none