### PR TITLE
fix(frontend): add default type='button' to notifications button in d…

### DIFF
--- a/hushh-webapp/components/app-ui/debate-task-center.tsx
+++ b/hushh-webapp/components/app-ui/debate-task-center.tsx
@@ -423,6 +423,7 @@ export function DebateTaskCenter({ triggerClassName, renderTrigger }: DebateTask
           renderTrigger({ activeCount, badgeCount })
         ) : (
           <button
+            type="button"
             className={cn(DEFAULT_TRIGGER_CLASSNAME, triggerClassName)}
             aria-label="Notifications"
           >


### PR DESCRIPTION
# Description

Added the missing `type="button"` attribute to the main notifications trigger `<button>` in `debate-task-center.tsx`. This ensures the button does not default to `type="submit"`, preventing potential accidental form submissions and bugs if the component is used within a form context.

Before requesting review, read
[`docs/reference/quality/pr-contributor-readiness.md`](docs/reference/quality/pr-contributor-readiness.md).
Green CI is intake only; merge readiness also requires a reachable attach point,
production-code proof, and a title/body that match the diff.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] Reachable production attach point: `components/app-ui/debate-task-center.tsx`
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

Every cross-platform feature must cover all affected layers or explicitly mark
the layer as not applicable with the reason.

- [x] **Web**: Next.js implementation (`app/api/...`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

N/A (HTML attribute fix, no visible UI change)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none