### PR TITLE
fix(frontend): remove stray console.log statements from manage portfolio view

### DIFF
--- a/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
+++ b/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
@@ -228,7 +228,6 @@ export function ManagePortfolioView() {
           
           // Priority 2: Decrypt the financial PKM domain (fallback)
           if (!parsed) {
-            console.log("[ManagePortfolio] No cache, attempting to decrypt the financial PKM domain...");
             try {
               const snapshot = await PkmDomainResourceService.getStaleFirst({
                 userId: user.uid,
@@ -247,7 +246,6 @@ export function ManagePortfolioView() {
 
                 // Update cache for future use
                 setCachePortfolioData(user.uid, parsed);
-                console.log("[ManagePortfolio] Decrypted and cached portfolio data");
               }
             } catch (decryptError) {
               console.error("[ManagePortfolio] Failed to decrypt the financial PKM domain:", decryptError);


### PR DESCRIPTION
# Description

Removed stray `console.log` statements from `manage-portfolio-view.tsx` related to the financial PKM domain decryption to clean up the browser console in production. (Kept `console.error` intact for actual failure reporting).

Before requesting review, read
[`docs/reference/quality/pr-contributor-readiness.md`](docs/reference/quality/pr-contributor-readiness.md).
Green CI is intake only; merge readiness also requires a reachable attach point,
production-code proof, and a title/body that match the diff.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] Reachable production attach point: `components/kai/views/manage-portfolio-view.tsx`
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

Every cross-platform feature must cover all affected layers or explicitly mark
the layer as not applicable with the reason.

- [x] **Web**: Next.js implementation (`app/api/...`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

N/A (Console cleanup, no visible UI change)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none