### PR TITLE
fix(frontend): use global setTimeout instead of window in kai-command-palette

### DIFF
--- a/hushh-webapp/components/kai/kai-command-palette.tsx
+++ b/hushh-webapp/components/kai/kai-command-palette.tsx
@@ -209,7 +209,7 @@ export function KaiCommandPalette({
         cancelled = true;
       };
     }
-    const timer = window.setTimeout(() => {
+    const timer = setTimeout(() => {
       void (async () => {
         try {
           const rows = await searchTickerUniverseRemote(q, 20);
@@ -230,7 +230,7 @@ export function KaiCommandPalette({
 
     return () => {
       cancelled = true;
-      window.clearTimeout(timer);
+      clearTimeout(timer);
     };
   }, [open, query]);
 


### PR DESCRIPTION
# Description

Replaced `window.setTimeout` and `window.clearTimeout` with global `setTimeout` and `clearTimeout` in `kai-command-palette.tsx`. This ensures the component remains fully SSR-safe in Next.js, preventing potential hydration mismatches or undefined `window` reference errors during server rendering.

Before requesting review, read
[`docs/reference/quality/pr-contributor-readiness.md`](docs/reference/quality/pr-contributor-readiness.md).
Green CI is intake only; merge readiness also requires a reachable attach point,
production-code proof, and a title/body that match the diff.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] Reachable production attach point: `components/kai/kai-command-palette.tsx`
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

Every cross-platform feature must cover all affected layers or explicitly mark
the layer as not applicable with the reason.

- [x] **Web**: Next.js implementation (`app/api/...`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

N/A (Under-the-hood SSR safety fix)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none