### PR TITLE
fix(frontend): use global timers instead of window in kai-search-bar

### DIFF
--- a/hushh-webapp/components/kai/kai-search-bar.tsx
+++ b/hushh-webapp/components/kai/kai-search-bar.tsx
@@ -207,7 +207,7 @@ export function shouldTriggerVoiceBargeIn(partialTranscript: string): boolean {
 }
 
 type TimerRefLike = {
-  current: number | null;
+  current: ReturnType<typeof setTimeout> | null;
 };
 
 type VoiceUiStateRefLike = {
@@ -218,7 +218,7 @@ const CLIENT_VAD_SPEECH_STOP_COMMIT_DELAY_MS = 180;
 
 export function clearClientVadFallbackTimer(timerRef: TimerRefLike): void {
   if (timerRef.current === null) return;
-  window.clearTimeout(timerRef.current);
+  clearTimeout(timerRef.current);
   timerRef.current = null;
 }
 
@@ -236,7 +236,7 @@ export function scheduleClientVadFallbackCommit(input: {
   getCurrentTurnId: () => string | null;
 }): void {
   clearClientVadFallbackTimer(input.timerRef);
-  input.timerRef.current = window.setTimeout(() => {
+  input.timerRef.current = setTimeout(() => {
     input.timerRef.current = null;
     if (
       input.sessionMutedRef.current ||
@@ -268,7 +268,7 @@ export function scheduleClientVadSpeechStopCommit(input: {
   getCurrentTurnId: () => string | null;
 }): void {
   clearClientVadFallbackTimer(input.timerRef);
-  input.timerRef.current = window.setTimeout(() => {
+  input.timerRef.current = setTimeout(() => {
     input.timerRef.current = null;
     if (
       input.sessionMutedRef.current ||
@@ -367,7 +367,7 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
   const orchestratorRef = useRef<VoiceTurnOrchestrator | null>(null);
   const currentVoiceTurnIdRef = useRef<string | null>(null);
   const voiceUiStateRef = useRef<VoiceUiState>("idle");
-  const partialFallbackTimerRef = useRef<number | null>(null);
+  const partialFallbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastFinalTranscriptRef = useRef<{ text: string; atMs: number } | null>(
     null,
   );
@@ -1585,17 +1585,17 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
 
   useEffect(() => {
     if (voiceUiState !== "error_terminal") return;
-    const timer = window.setTimeout(() => {
+    const timer = setTimeout(() => {
       setVoiceErrorMessage(null);
       transitionVoiceState("idle", "error_recovered");
     }, 1600);
-    return () => window.clearTimeout(timer);
+    return () => clearTimeout(timer);
   }, [transitionVoiceState, voiceUiState]);
 
   useEffect(() => {
     if (voiceUiState !== "sheet_listening") return;
     if (!realtimeSessionReady) return;
-    const timer = window.setInterval(() => {
+    const timer = setInterval(() => {
       if (!shouldShowAmbientListeningStatus(transcriptPreviewRef.current)) {
         return;
       }
@@ -1604,7 +1604,7 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
       setTranscriptPreview(activity);
     }, 280);
     return () => {
-      window.clearInterval(timer);
+      clearInterval(timer);
     };
   }, [realtimeSessionReady, smoothedLevel, voiceUiState]);
 


### PR DESCRIPTION
# Description

Replaced all instances of `window.setTimeout`, `window.clearTimeout`, `window.setInterval`, and `window.clearInterval` with their global equivalents (`setTimeout`, `clearTimeout`, `setInterval`, `clearInterval`) in `kai-search-bar.tsx`. This ensures the component remains fully SSR-safe in Next.js, preventing potential hydration mismatches or undefined `window` reference errors during server rendering.

Before requesting review, read
[`docs/reference/quality/pr-contributor-readiness.md`](docs/reference/quality/pr-contributor-readiness.md).
Green CI is intake only; merge readiness also requires a reachable attach point,
production-code proof, and a title/body that match the diff.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] Reachable production attach point: `components/kai/kai-search-bar.tsx`
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

Every cross-platform feature must cover all affected layers or explicitly mark
the layer as not applicable with the reason.

- [x] **Web**: Next.js implementation (`app/api/...`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

N/A (Under-the-hood SSR safety fix)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none