### PR TITLE
fix(frontend): add aria-hidden to decorative icons in columns view

### DIFF
--- a/hushh-webapp/components/kai/views/columns.tsx
+++ b/hushh-webapp/components/kai/views/columns.tsx
@@ -89,14 +89,14 @@ export const getColumns = ({
                   onClick={(event) => event.stopPropagation()}
                 >
                   <span className="sr-only">Open menu</span>
-                  <Icon icon={MoreHorizontal} size="sm" />
+                  <Icon icon={MoreHorizontal} size="sm" aria-hidden="true" />
             </Button>
           </DropdownMenuTrigger>
             <DropdownMenuContent align="start">
             <DropdownMenuLabel>Actions</DropdownMenuLabel>
             {onViewVersions && (
               <DropdownMenuItem onSelect={() => onViewVersions(entry.ticker)}>
-                <Icon icon={ArrowRight} size="sm" className="mr-2" />
+                <Icon icon={ArrowRight} size="sm" className="mr-2" aria-hidden="true" />
                 View Previous Versions
               </DropdownMenuItem>
             )}
@@ -105,14 +105,14 @@ export const getColumns = ({
               onSelect={() => onDelete(entry)}
               className="text-red-600 dark:text-red-400 focus:text-red-600 focus:bg-red-500/10"
             >
-              <Icon icon={Trash2} size="sm" className="mr-2" />
+              <Icon icon={Trash2} size="sm" className="mr-2" aria-hidden="true" />
               Delete Entry
             </DropdownMenuItem>
             <DropdownMenuItem
               onSelect={() => onDeleteTicker(entry.ticker)}
               className="text-red-600 dark:text-red-400 focus:text-red-600 focus:bg-red-500/10"
             >
-              <Icon icon={Trash2} size="sm" className="mr-2" />
+              <Icon icon={Trash2} size="sm" className="mr-2" aria-hidden="true" />
               Delete All {entry.ticker}
             </DropdownMenuItem>
           </DropdownMenuContent>


### PR DESCRIPTION
# Description

Added the missing `aria-hidden="true"` attribute to several decorative `<Icon>` components in the table columns of `columns.tsx`. This is a frontend UI accessibility fix that prevents screen readers from announcing raw SVG paths to visually impaired users.

Before requesting review, read
[`docs/reference/quality/pr-contributor-readiness.md`](docs/reference/quality/pr-contributor-readiness.md).
Green CI is intake only; merge readiness also requires a reachable attach point,
production-code proof, and a title/body that match the diff.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] Reachable production attach point: `components/kai/views/columns.tsx`
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

Every cross-platform feature must cover all affected layers or explicitly mark
the layer as not applicable with the reason.

- [x] **Web**: Next.js implementation (`app/api/...`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

N/A (Under-the-hood accessibility fix, no visual change)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none