### PR TITLE
fix(frontend): add aria-hidden to decorative icons in analysis history dashboard

### DIFF
--- a/hushh-webapp/components/kai/views/analysis-history-dashboard.tsx
+++ b/hushh-webapp/components/kai/views/analysis-history-dashboard.tsx
@@ -125,7 +125,7 @@ function decisionStyles(decision: string, ownsPosition?: boolean | null): {
       bg: "bg-emerald-500/10",
       text: "text-emerald-600 dark:text-emerald-400",
       border: "border-emerald-500/30",
-      icon: <Icon icon={TrendingUp} size={12} />,
+      icon: <Icon icon={TrendingUp} size={12} aria-hidden="true" />,
       label: presentation.label,
     };
   }
@@ -134,7 +134,7 @@ function decisionStyles(decision: string, ownsPosition?: boolean | null): {
       bg: "bg-red-500/10",
       text: "text-red-600 dark:text-red-400",
       border: "border-red-500/30",
-      icon: <Icon icon={TrendingDown} size={12} />,
+      icon: <Icon icon={TrendingDown} size={12} aria-hidden="true" />,
       label: presentation.label,
     };
   }
@@ -151,7 +151,7 @@ function decisionStyles(decision: string, ownsPosition?: boolean | null): {
       presentation.label === "WATCH"
         ? "border-[color:var(--app-card-border-standard)]"
         : "border-amber-500/30",
-    icon: <Icon icon={Minus} size={12} />,
+    icon: <Icon icon={Minus} size={12} aria-hidden="true" />,
     label: presentation.label,
   };
 }
@@ -1142,7 +1142,7 @@ export function AnalysisHistoryDashboard({
                       title="Delete this version"
                       aria-label="Delete this version"
                     >
-                      <Icon icon={Trash2} size="sm" />
+                      <Icon icon={Trash2} size="sm" aria-hidden="true" />
                     </Button>
                   </div>
                 );


### PR DESCRIPTION
# Description

Added the missing `aria-hidden="true"` attribute to several decorative `<Icon>` components in `analysis-history-dashboard.tsx`. This UI accessibility fix ensures that screen readers ignore purely visual status and action icons rather than reading out their SVG metadata.

Before requesting review, read
[`docs/reference/quality/pr-contributor-readiness.md`](docs/reference/quality/pr-contributor-readiness.md).
Green CI is intake only; merge readiness also requires a reachable attach point,
production-code proof, and a title/body that match the diff.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] Reachable production attach point: `components/kai/views/analysis-history-dashboard.tsx`
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

Every cross-platform feature must cover all affected layers or explicitly mark
the layer as not applicable with the reason.

- [x] **Web**: Next.js implementation (`app/api/...`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

N/A (Under-the-hood accessibility fix, no visual change)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none