### PR TITLE
fix(frontend): add aria-hidden to decorative icons in dashboard master view

### DIFF
--- a/hushh-webapp/components/kai/views/dashboard-master-view.tsx
+++ b/hushh-webapp/components/kai/views/dashboard-master-view.tsx
@@ -2767,7 +2767,7 @@ export function DashboardMasterView({
                     : "text-rose-600 dark:text-rose-400"
                 )}
               >
-                <Icon icon={model.hero.netChange >= 0 ? TrendingUp : TrendingDown} size="sm" className="mr-1" />
+                <Icon icon={model.hero.netChange >= 0 ? TrendingUp : TrendingDown} size="sm" className="mr-1" aria-hidden="true" />
                 {model.hero.netChange >= 0 ? "+" : ""}
                 {formatCurrency(model.hero.netChange)} ({model.hero.changePct.toFixed(2)}%)
               </span>
@@ -3039,7 +3039,7 @@ export function DashboardMasterView({
                     onClick={openAddHoldingModal}
                     data-voice-control-id="add_holding"
                   >
-                    <Icon icon={Plus} size="sm" className="mr-1" />
+                    <Icon icon={Plus} size="sm" className="mr-1" aria-hidden="true" />
                     Add Holding
                   </MorphyButton>
                 ) : (
@@ -3117,7 +3117,7 @@ export function DashboardMasterView({
                     className="bg-black text-white hover:bg-black/90 dark:bg-white dark:text-black dark:hover:bg-white/90"
                     data-voice-control-id="save_holdings_changes"
                   >
-                    <Icon icon={Save} size="sm" className="mr-2" />
+                    <Icon icon={Save} size="sm" className="mr-2" aria-hidden="true" />
                     {isSavingHoldings ? "Saving Holdings..." : "Save Holdings Changes"}
                   </MorphyButton>
                 </div>


### PR DESCRIPTION
# Description

Added the missing `aria-hidden="true"` attribute to several decorative `<Icon>` components in `dashboard-master-view.tsx` (e.g., inside the net change indicator, the Add Holding button, and the Save Holdings button). This UI accessibility fix ensures that screen readers ignore purely visual icons rather than reading out their SVG metadata.

Before requesting review, read
[`docs/reference/quality/pr-contributor-readiness.md`](docs/reference/quality/pr-contributor-readiness.md).
Green CI is intake only; merge readiness also requires a reachable attach point,
production-code proof, and a title/body that match the diff.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] Reachable production attach point: `components/kai/views/dashboard-master-view.tsx`
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

Every cross-platform feature must cover all affected layers or explicitly mark
the layer as not applicable with the reason.

- [x] **Web**: Next.js implementation (`app/api/...`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

N/A (Under-the-hood accessibility fix, no visual change)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none