### PR TITLE
test(observability): verify metrics exporter gracefully handles backend timeouts and dropped connections

### DIFF
--- a/hushh-webapp/__tests__/services/observability-web-transport.test.ts
+++ b/hushh-webapp/__tests__/services/observability-web-transport.test.ts
@@ -1,11 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+// Capacitor mock is required because client.ts (imported below for pure
+// utility functions) calls Capacitor.isNativePlatform() at module level.
+vi.mock("@capacitor/core", () => ({
+  Capacitor: { isNativePlatform: () => false, getPlatform: () => "web" },
+}));
+
 import {
   resolveAnalyticsMeasurementId,
   resolveGtmContainerId,
   shouldLoadWebAnalyticsScripts,
 } from "@/lib/observability/env";
 import { webGtmAdapter } from "@/lib/observability/adapters/web-gtm";
+import {
+  toDurationBucket,
+  toEventResult,
+  toStatusBucket,
+} from "@/lib/observability/client";
 
 declare global {
   interface Window {
@@ -124,5 +135,209 @@ describe("web observability transport", () => {
         app_version: "2.1.0",
       }
     );
+  });
+});
+
+// ── Metrics exporter — backend timeout fallback ───────────────────────────────
+//
+// The observability export pipeline is a two-layer stack:
+//   1. Pure utility layer — toDurationBucket / toStatusBucket / toEventResult:
+//      classify timeout-range metrics without I/O or side-effects.
+//   2. Transport layer — webGtmAdapter.track():
+//      always writes a local dataLayer frame before attempting remote gtag
+//      delivery; a throwing or absent gtag must never block the thread.
+//
+// Timeout contracts under test:
+//   A. null status code (dropped connection) → "network_error" bucket, never
+//      silently promoted to a 4xx_expected category.
+//   B. >= 10 s duration → "gte_10s" bucket; hard gateway timeouts are
+//      classified, not silently swallowed.
+//   C. "network_error" → EventResult "error", never "success" or "expected_error".
+//   D. webGtmAdapter.track() resolves when the remote delivery channel is
+//      unavailable; the local dataLayer frame is preserved.
+//   E. webGtmAdapter.track() yields a catchable rejection (never unhandled) when
+//      the gtag sink throws a gateway-timeout error synchronously.
+//   F. Burst of concurrent timeout events all queue to dataLayer; the thread
+//      never hangs regardless of delivery channel state.
+
+describe("metrics exporter — backend timeout fallback", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    window.dataLayer = [];
+    window.gtag = vi.fn();
+  });
+
+  // ── A: null status → network_error (connection drop / hard timeout) ───────
+
+  it("maps a null status code to the network_error bucket for any HTTP method", () => {
+    expect(toStatusBucket(null, "GET", "/api/pkm/metadata/{user_id}")).toBe("network_error");
+    expect(toStatusBucket(null, "POST", "/api/kai/analyze/run/start")).toBe("network_error");
+    expect(toStatusBucket(null, "DELETE", "/api/account/delete")).toBe("network_error");
+  });
+
+  it("never promotes a null status to 4xx_expected even for endpoints with known error codes", () => {
+    // These endpoints have expected 4xx codes, but a dropped connection is
+    // always network_error — the expected-error gate only applies to real status codes.
+    const expectedErrorEndpoints: Array<[string, string]> = [
+      ["GET",  "/api/kai/analyze/run/active"],
+      ["POST", "/api/kai/analyze/run/start"],
+      ["GET",  "/api/pkm/metadata/{user_id}"],
+      ["POST", "/db/vault/get"],
+      ["POST", "/db/vault/bootstrap-state"],
+    ];
+
+    for (const [method, template] of expectedErrorEndpoints) {
+      const bucket = toStatusBucket(null, method, template);
+      expect(bucket).toBe("network_error");
+      expect(bucket).not.toBe("4xx_expected");
+    }
+  });
+
+  // ── B: timeout durations → gte_10s bucket ────────────────────────────────
+
+  it("classifies hard gateway-timeout durations into the gte_10s duration bucket", () => {
+    expect(toDurationBucket(10_000)).toBe("gte_10s"); // exactly 10 s
+    expect(toDurationBucket(30_000)).toBe("gte_10s"); // 30 s hard gateway timeout
+    expect(toDurationBucket(60_000)).toBe("gte_10s"); // 60 s extreme timeout
+    expect(toDurationBucket(9_999)).toBe("3s_10s");   // just below threshold
+  });
+
+  // ── C: network_error → EventResult "error" ────────────────────────────────
+
+  it("escalates network_error to the error EventResult — never success or expected_error", () => {
+    const result = toEventResult("network_error");
+    expect(result).toBe("error");
+    expect(result).not.toBe("success");
+    expect(result).not.toBe("expected_error");
+  });
+
+  // ── D: adapter resolves cleanly when the remote delivery channel is down ──
+
+  it("resolves without throwing when the gtag delivery channel is unavailable", async () => {
+    // Simulate: gtag not injected (delivery endpoint unreachable / timed out)
+    window.gtag = undefined as unknown as typeof window.gtag;
+    vi.stubEnv("NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID", "G-TIMEOUTTEST1");
+
+    await expect(
+      webGtmAdapter.track("api_request_completed", {
+        env: "uat",
+        platform: "web",
+        event_category: "system",
+        app_version: "1.0.0",
+        result: "error",
+        status_bucket: "network_error",
+        duration_ms_bucket: "gte_10s",
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("still writes the frame to dataLayer before the gtag call even when gtag is absent", async () => {
+    window.dataLayer = [];
+    window.gtag = undefined as unknown as typeof window.gtag;
+    vi.stubEnv("NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID", "G-TIMEOUTTEST2");
+
+    await webGtmAdapter.track("api_request_completed", {
+      env: "uat",
+      platform: "web",
+      event_category: "system",
+      app_version: "1.0.0",
+      result: "error",
+      status_bucket: "network_error",
+      duration_ms_bucket: "gte_10s",
+    });
+
+    expect(window.dataLayer).toHaveLength(1);
+    expect(window.dataLayer?.[0]).toMatchObject({
+      event: "api_request_completed",
+      event_source: "observability_v2",
+      status_bucket: "network_error",
+      duration_ms_bucket: "gte_10s",
+    });
+  });
+
+  // ── E: adapter rejects catchably when gtag throws a gateway-timeout error ─
+
+  it("yields a catchable rejection — not an unhandled throw — when gtag fires a synchronous timeout error", async () => {
+    window.gtag = vi.fn().mockImplementation(() => {
+      throw new TypeError("Failed to fetch: 504 gateway timeout");
+    });
+    vi.stubEnv("NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID", "G-TIMEOUTTEST3");
+
+    const promise = webGtmAdapter.track("api_request_completed", {
+      env: "uat",
+      platform: "web",
+      event_category: "system",
+      app_version: "1.0.0",
+      result: "error",
+      status_bucket: "network_error",
+      duration_ms_bucket: "gte_10s",
+    });
+
+    // Rejection must be a Promise rejection (catchable), never an unhandled throw
+    await expect(promise).rejects.toThrow("504 gateway timeout");
+  });
+
+  it("preserves the dataLayer frame before the gtag call even when gtag throws a timeout error", async () => {
+    window.dataLayer = [];
+    window.gtag = vi.fn().mockImplementation(() => {
+      throw new TypeError("Failed to fetch: 504 gateway timeout");
+    });
+    vi.stubEnv("NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID", "G-TIMEOUTTEST4");
+
+    // Swallow the expected rejection from gtag
+    try {
+      await webGtmAdapter.track("api_request_completed", {
+        env: "uat",
+        platform: "web",
+        event_category: "system",
+        app_version: "1.0.0",
+        result: "error",
+        status_bucket: "network_error",
+        duration_ms_bucket: "gte_10s",
+      });
+    } catch { /* expected — gtag threw */ }
+
+    // The local dataLayer write happens before gtag — the frame is never lost
+    expect(window.dataLayer).toHaveLength(1);
+    expect(window.dataLayer?.[0]).toMatchObject({
+      event: "api_request_completed",
+      event_source: "observability_v2",
+      result: "error",
+      status_bucket: "network_error",
+      duration_ms_bucket: "gte_10s",
+    });
+  });
+
+  // ── F: burst of timeout events — thread never hangs ──────────────────────
+
+  it("queues all frames to dataLayer for a burst of 10 concurrent timeout events without blocking", async () => {
+    window.dataLayer = [];
+    // No gtag delivery — simulates backend timeout / unreachable endpoint
+    window.gtag = undefined as unknown as typeof window.gtag;
+
+    const BURST = 10;
+    const promises = Array.from({ length: BURST }, () =>
+      webGtmAdapter.track("api_request_completed", {
+        env: "uat",
+        platform: "web",
+        event_category: "system",
+        app_version: "1.0.0",
+        result: "error",
+        status_bucket: "network_error",
+        duration_ms_bucket: "gte_10s",
+      })
+    );
+
+    // Promise.allSettled must resolve — none may hang
+    const results = await Promise.allSettled(promises);
+    const statuses = results.map((r) => r.status);
+    expect(statuses.every((s) => s === "fulfilled")).toBe(true);
+
+    // All frames locally buffered despite no active delivery channel
+    expect(window.dataLayer).toHaveLength(BURST);
+    for (const frame of window.dataLayer ?? []) {
+      expect(frame.status_bucket).toBe("network_error");
+      expect(frame.duration_ms_bucket).toBe("gte_10s");
+    }
   });
 });


### PR DESCRIPTION
## Summary

Extends the canonical `observability-web-transport` test suite with 9 new cases that directly exercise the metrics export pipeline under simulated backend timeout conditions. The cases prove that the two-layer export stack — pure utility classifiers and the `webGtmAdapter` transport — both fail closed on gateway timeouts: null status codes are always classified as `network_error`, high-latency durations land in the `gte_10s` bucket, local `dataLayer` frames are buffered before the remote `gtag` call, and a burst of 10 concurrent timeout events all settle without hanging the thread. No new files, direct production imports, upstream base — zero conflict surface.

## Files changed (1)

| File | Change |
|---|---|
| `hushh-webapp/__tests__/services/observability-web-transport.test.ts` | +215 lines — capacitor mock + 3 new imports + header comment block + `describe("metrics exporter — backend timeout fallback")` with 9 `it` cases |

## Production modules exercised

```typescript
// hushh-webapp/lib/observability/client.ts
toStatusBucket(statusCode, httpMethod, endpointTemplate)
  // Maps null (dropped connection / hard timeout) → "network_error".
  // Must never promote a null status to "4xx_expected" for any endpoint.

toDurationBucket(durationMs)
  // Maps >= 10 000 ms → "gte_10s" — the gateway-timeout range.
  // Pure classification, no I/O.

toEventResult(statusBucket)
  // Maps "network_error" → "error". Never "success" or "expected_error".

// hushh-webapp/lib/observability/adapters/web-gtm.ts
webGtmAdapter.track(eventName, payload)
  // Writes to window.dataLayer BEFORE attempting window.gtag delivery.
  // Must resolve when gtag is absent; must yield a catchable Promise
  // rejection (not an unhandled throw) when gtag fires a timeout error.
```

## New test coverage

### A — null status → `network_error` (2 cases)

| Scenario | Assert |
|---|---|
| `null` status for GET, POST, DELETE | All return `"network_error"` |
| `null` for endpoints in the expected-error allowlist (5 endpoints) | Still `"network_error"` — never `"4xx_expected"` |

### B — timeout duration classification (1 case)

| Scenario | Assert |
|---|---|
| `10 000 ms`, `30 000 ms`, `60 000 ms` | `"gte_10s"` bucket |
| `9 999 ms` | `"3s_10s"` (just below threshold) |

### C — EventResult escalation (1 case)

| Scenario | Assert |
|---|---|
| `toEventResult("network_error")` | `"error"` — not `"success"` or `"expected_error"` |

### D — adapter resolves cleanly when delivery channel is down (2 cases)

| Scenario | Assert |
|---|---|
| `window.gtag = undefined`, real measurement ID | `track()` resolves to `undefined` |
| `window.gtag = undefined`, real measurement ID | `window.dataLayer` receives 1 frame with correct `status_bucket` and `duration_ms_bucket` |

### E — adapter yields catchable rejection on synchronous gateway-timeout throw (2 cases)

| Scenario | Assert |
|---|---|
| `window.gtag` throws `TypeError("504 gateway timeout")` | `track()` returns a rejected Promise; `await expect(promise).rejects.toThrow(...)` passes |
| Same gtag throw | `window.dataLayer` still receives the frame (dataLayer write precedes the gtag call) |

### F — burst of 10 timeout events, thread never hangs (1 case)

| Scenario | Assert |
|---|---|
| 10 concurrent `track()` calls, `window.gtag = undefined` | `Promise.allSettled` resolves; all 10 settle as `fulfilled`; `window.dataLayer` has 10 frames, each with `status_bucket: "network_error"` |

## Why the Capacitor mock is needed

`client.ts` (imported for `toDurationBucket`, `toStatusBucket`, `toEventResult`) references `Capacitor.isNativePlatform()` at module load time in `resolvePlatform()`. A `vi.mock("@capacitor/core", ...)` is hoisted to the top of the file by Vitest's module-mock transform — it does not interfere with the existing four transport tests, which do not call any Capacitor API.

## CI gate checklist
- [x] **PR Base Policy** — targets `integration/pr-train`; branch cut directly from `upstream/integration/pr-train`, zero merge conflicts
- [x] **DCO** — `Signed-off-by: Abdul Rashid <smirthidharmaiit@gmail.com>`
- [x] **Secret Scan** — diff contains only fixture strings (`"G-TIMEOUTTEST1"–4`, `"uat"`, `"1.0.0"`); no real tokens or credentials
- [x] **Governance** — single modified file in `__tests__/services/`; no debug artifacts; no `eslint-disable`
- [x] **Path filters** — only `hushh-webapp/__tests__/services/observability-web-transport.test.ts` changed; triggers Web (Next.js) path gate; skips Protocol (Python) gate
- [x] **Upstream Sync** — branch cut directly from upstream tip; cannot have upstream conflicts
- [x] **Base Freshness Gate** — freshly branched from upstream tip; no stale base
- [x] **Web (Next.js)** — 9 new cases use only `vi.fn()`, `vi.stubEnv()`, `window.dataLayer`, and `window.gtag` mocks — the same patterns already used in the existing 4 transport tests; picked up automatically by Vitest `include: ["__tests__/**/*.test.{ts,tsx}"]`
- [x] **No new files** — 215 additions to the existing companion test file; no standalone scripts
- [x] **Direct production import** — `toDurationBucket`, `toStatusBucket`, `toEventResult` from `@/lib/observability/client`; `webGtmAdapter` from `@/lib/observability/adapters/web-gtm`; no re-exports or path shims
- [x] **No `eslint-disable`** — zero lint suppressions in the diff
- [x] **Clean diff** — 1 file, 215 additions, 0 deletions, no conflicts, fresh upstream base

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)