### PR TITLE
fix(frontend): add noopener to target blank link in liquid glass search demo

### DIFF
--- a/hushh-webapp/components/labs/liquid-glass-search-demo.tsx
+++ b/hushh-webapp/components/labs/liquid-glass-search-demo.tsx
@@ -139,7 +139,7 @@ export function LiquidGlassSearchDemo() {
             <a
               href="https://unsplash.com/@visaxslr"
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
               className="absolute left-3 top-3 inline-block text-[9px] uppercase tracking-wider text-white/40"
             >
               Photo by @visaxslr


### PR DESCRIPTION
# Description

Added `noopener` to an external `target="_blank"` link in `liquid-glass-search-demo.tsx` (changed `rel="noreferrer"` to `rel="noopener noreferrer"`). This fixes a frontend security issue by preventing the newly opened tab from having a reference back to the original page's `window.opener` object.

Before requesting review, read
[`docs/reference/quality/pr-contributor-readiness.md`](docs/reference/quality/pr-contributor-readiness.md).
Green CI is intake only; merge readiness also requires a reachable attach point,
production-code proof, and a title/body that match the diff.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] Reachable production attach point: `components/labs/liquid-glass-search-demo.tsx`
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

Every cross-platform feature must cover all affected layers or explicitly mark
the layer as not applicable with the reason.

- [x] **Web**: Next.js implementation (`app/api/...`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

N/A (Under-the-hood security fix, no visual change)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none