### PR TITLE
fix(vault): use null-check instead of falsy-check for encrypted preference fields

### DIFF
--- a/hushh-webapp/app/api/vault/store-preferences/route.ts
+++ b/hushh-webapp/app/api/vault/store-preferences/route.ts
@@ -111,7 +111,7 @@ export async function POST(request: NextRequest) {
 
     for (const [key, value] of Object.entries(preferences)) {
       // Skip if value is null/undefined
-      if (!value) continue;
+      if (value == null) continue;
 
       const encrypted = value as {
         ciphertext: string;


### PR DESCRIPTION
## Summary
- what changed: Replaced `if (!value)` with `if (value == null)` in the encrypted preference field loop in `hushh-webapp/app/api/vault/store-preferences/route.ts`
- why it changed: `!value` evaluates to `true` for `0`, `false`, and `""` — all potentially valid encrypted payloads — silently dropping them from the vault write with no error surfaced to the caller. `value == null` correctly skips only `null` and `undefined`.

## Attach point
`hushh-webapp/app/api/vault/store-preferences/route.ts` — Vault write handler used across the consent-gated preference storage flow.

## Contract changed
Runtime behavior: encrypted preference fields with falsy-but-valid values (`0`, `false`, `""`) are no longer silently skipped during vault write. No change to consent token validation, encryption structure checks, or `storeUserData` call signature.

## Tests run
```bash
cd hushh-webapp && npx tsc --noEmit
```
Passed locally. No type errors.

## Base/head status
Branch is current with main, mergeable, and DCO-signed. Targets integration/pr-train as required by repo base policy.

## Sensitive proof
Not applicable. No auth flow, consent protocol, PKM, finance, or KYC surfaces structurally changed. Rollback: revert by replacing `if (value == null)` with `if (!value)` on line 113.

## Stack proof
Not applicable. Standalone single-expression fix, no predecessor PR.

Fixes #2057