### PR TITLE
fix(app-config): suppress review-mode error log in production

### DIFF
--- a/hushh-webapp/app/api/app-config/review-mode/route.ts
+++ b/hushh-webapp/app/api/app-config/review-mode/route.ts
@@ -29,7 +29,8 @@ export async function GET(_request: NextRequest) {
     return NextResponse.json(data, { status: 200, headers: NO_STORE_HEADERS });
   } catch (error) {
     clearTimeout(timeout);
-    console.warn("[app-config/review-mode] fallback disabled:", error);
+    if (process.env.NODE_ENV !== "production") {
+      console.warn("[app-config/review-mode] fallback disabled:", error);}
     return NextResponse.json(
       { enabled: false },
       { status: 200, headers: NO_STORE_HEADERS },


### PR DESCRIPTION
## Summary
- what changed: Wrapped `console.warn` in `hushh-webapp/app/api/app-config/review-mode/route.ts` catch block with a `process.env.NODE_ENV !== "production"` guard
- why it changed: The catch block unconditionally logs the full error object including stack trace to production server logs on every upstream timeout or failure. The sibling file `review-mode/session/route.ts` already applies this guard correctly — this fix brings `review-mode/route.ts` in line with the same pattern.

## Attach point
`hushh-webapp/app/api/app-config/review-mode/route.ts` — GET handler for the review-mode config flag used across the app-config surface.

## Contract changed
Runtime behavior: raw error details and stack traces no longer appear in production server logs when the upstream review-mode endpoint is unreachable. Development and staging behavior unchanged — error is still logged in non-production environments. No change to response shape, status codes, or fallback logic.

## Tests run
```bash
cd hushh-webapp && npx tsc --noEmit
```
Passed locally. No type errors.

## Base/head status
Branch is current with main, mergeable, and DCO-signed. Targets integration/pr-train as required by repo base policy.

## Sensitive proof
Not applicable. No auth, consent, vault, PKM, finance, or KYC surfaces touched. No secrets involved. Rollback: revert by removing the `NODE_ENV` guard and restoring the unconditional `console.warn`.

## Stack proof
Not applicable. Standalone fix, no predecessor PR.

Fixes #2061