### PR TITLE
fix(notifications): suppress error log in production for register route

### DIFF
--- a/hushh-webapp/app/api/notifications/register/route.ts
+++ b/hushh-webapp/app/api/notifications/register/route.ts
@@ -46,7 +46,9 @@ export async function POST(request: NextRequest) {
     }
     return NextResponse.json(data);
   } catch (error) {
-    console.warn("[API] Notifications register unavailable:", error);
+    if (process.env.NODE_ENV !== "production") {
+  console.warn("[API] Notifications register unavailable:", error);
+}
     return NextResponse.json(
       {
         registered: false,


### PR DESCRIPTION
## Summary
- what changed: Wrapped `console.warn` in `hushh-webapp/app/api/notifications/register/route.ts` catch block with a `process.env.NODE_ENV !== "production"` guard
- why it changed: The catch block unconditionally logs the full error object including stack trace to production server logs on every upstream timeout or backend failure. This is the same pattern fixed in `review-mode/route.ts` (#2062) — this fix brings the notifications register route in line with the same standard.

## Attach point
`hushh-webapp/app/api/notifications/register/route.ts` — POST handler for FCM/APNs push notification token registration.

## Contract changed
Runtime behavior: raw error details and stack traces no longer appear in production server logs when the upstream notifications backend is unreachable. Development and staging behavior unchanged — error is still logged in non-production environments. No change to response shape, status codes, or fallback logic.

## Tests run
```bash
cd hushh-webapp && npx tsc --noEmit
```
Passed locally. No type errors.

## Base/head status
Branch is current with main, mergeable, and DCO-signed. Targets integration/pr-train as required by repo base policy.

## Sensitive proof
Not applicable. No auth, consent, vault, PKM, finance, or KYC surfaces touched. No secrets involved. Rollback: revert by removing the `NODE_ENV` guard and restoring the unconditional `console.warn`.

## Stack proof
Not applicable. Standalone fix, no predecessor PR.

Fixes #2063