### PR TITLE
test(utils): verify portfolio normalizer safely handles circular object references without stack overflow

### DIFF
--- a/hushh-webapp/__tests__/utils/portfolio-normalize.test.ts
+++ b/hushh-webapp/__tests__/utils/portfolio-normalize.test.ts
@@ -73,4 +73,134 @@ describe("portfolio normalize helpers", () => {
 
     expect(consolidated).toHaveLength(0);
   });
- });
+});
+
+// ── Circular reference safety — deep object traversal guard ──────────────────
+//
+// normalizeStoredPortfolio and consolidateHoldingsBySymbol both traverse
+// holding objects using shallow spreads ({...row}) rather than recursive
+// deep cloning. A circular reference in any extra holding property is copied
+// by reference into the output without further traversal, so there is no risk
+// of a call-stack overflow — the function must exit cleanly.
+//
+// Each test below:
+//   1. Constructs a holding (or portfolio) object that contains a circular link.
+//   2. Asserts the production function does NOT throw.
+//   3. Asserts the normalized output carries the expected structural shape so
+//      the caller can still use the result safely.
+
+describe("portfolio normalizer — circular reference safety", () => {
+  it("does not throw and correctly normalizes a holding that directly references itself", () => {
+    const circularHolding: Record<string, unknown> = {
+      symbol: "AAPL",
+      name: "Apple Inc.",
+      quantity: 10,
+      market_value: 1_500,
+      cost_basis: 1_200,
+    };
+    // circularHolding.self === circularHolding
+    circularHolding.self = circularHolding;
+
+    expect(() =>
+      normalizeStoredPortfolio({ portfolio: { holdings: [circularHolding] } })
+    ).not.toThrow();
+
+    const normalized = normalizeStoredPortfolio({
+      portfolio: { holdings: [circularHolding] },
+    });
+
+    expect(Array.isArray(normalized.holdings)).toBe(true);
+    expect(normalized.holdings).toHaveLength(1);
+    expect(normalized.holdings[0].symbol).toBe("AAPL");
+    expect(normalized.holdings[0].quantity).toBe(10);
+    expect(normalized.holdings[0].market_value).toBe(1_500);
+  });
+
+  it("does not throw when a holding carries a nested circular reference in a metadata property", () => {
+    const holding: Record<string, unknown> = {
+      symbol: "MSFT",
+      name: "Microsoft",
+      quantity: 5,
+      market_value: 2_000,
+    };
+    // holding.meta.parent === holding — one-hop indirection
+    const meta: Record<string, unknown> = { source: "statement" };
+    meta.parent = holding;
+    holding.meta = meta;
+
+    expect(() => consolidateHoldingsBySymbol([holding])).not.toThrow();
+
+    const consolidated = consolidateHoldingsBySymbol([holding]);
+    expect(consolidated).toHaveLength(1);
+    expect(consolidated[0].symbol).toBe("MSFT");
+    expect(consolidated[0].quantity).toBe(5);
+  });
+
+  it("does not throw when the portfolio object itself has a parent circular reference", () => {
+    const portfolio: Record<string, unknown> = {
+      holdings: [
+        { symbol: "GOOG", name: "Alphabet", quantity: 2, market_value: 300 },
+      ],
+    };
+    // portfolio.parent === portfolio
+    portfolio.parent = portfolio;
+
+    expect(() => normalizeStoredPortfolio({ portfolio })).not.toThrow();
+
+    const normalized = normalizeStoredPortfolio({ portfolio });
+    expect(Array.isArray(normalized.holdings)).toBe(true);
+    expect(normalized.holdings).toHaveLength(1);
+    expect(normalized.holdings[0].symbol).toBe("GOOG");
+  });
+
+  it("does not throw when analytics_v2 contains a self-referential circular node", () => {
+    const circular: Record<string, unknown> = { label: "circular-analytics-node" };
+    // circular.next === circular
+    circular.next = circular;
+
+    const raw = {
+      portfolio: {
+        holdings: [
+          { symbol: "TSLA", name: "Tesla", quantity: 1, market_value: 250 },
+        ],
+        analytics_v2: circular,
+      },
+    };
+
+    expect(() => normalizeStoredPortfolio(raw)).not.toThrow();
+
+    const normalized = normalizeStoredPortfolio(raw);
+    expect(Array.isArray(normalized.holdings)).toBe(true);
+    expect(normalized.holdings[0].symbol).toBe("TSLA");
+  });
+
+  it("handles a batch of holdings where every entry carries its own circular reference without crashing or dropping rows", () => {
+    function makeCircularHolding(
+      symbol: string,
+      quantity: number,
+      marketValue: number
+    ): Record<string, unknown> {
+      const holding: Record<string, unknown> = {
+        symbol,
+        name: `Name for ${symbol}`,
+        quantity,
+        market_value: marketValue,
+      };
+      // Each holding references itself via a sentinel property
+      holding.circular = holding;
+      return holding;
+    }
+
+    const holdings = [
+      makeCircularHolding("AMZN", 3, 1_200),
+      makeCircularHolding("META", 7,   900),
+      makeCircularHolding("NVDA", 2,   600),
+    ];
+
+    expect(() => consolidateHoldingsBySymbol(holdings)).not.toThrow();
+
+    const consolidated = consolidateHoldingsBySymbol(holdings);
+    expect(consolidated).toHaveLength(3);
+    expect(consolidated.map((h) => h.symbol).sort()).toEqual(["AMZN", "META", "NVDA"]);
+  });
+});


### PR DESCRIPTION
## Summary

Extends the canonical `portfolio-normalize` test suite with 5 new cases that prove `normalizeStoredPortfolio` and `consolidateHoldingsBySymbol` resolve circular-reference graphs without throwing a call-stack overflow. Both functions use shallow spreads (`{...row}`, `{...canonical}`) internally — circular links in extra holding properties are copied by reference into the output without further traversal, so the process exits cleanly in all cases. No new files, direct production imports, zero merge conflicts, upstream base.

## Files changed (1)

| File | Change |
|---|---|
| `hushh-webapp/__tests__/utils/portfolio-normalize.test.ts` | +131 lines — header comment block + `describe("portfolio normalizer — circular reference safety")` with 5 `it` cases |

## Production modules exercised

```typescript
// hushh-webapp/lib/utils/portfolio-normalize.ts

normalizeStoredPortfolio(raw: AnyObj): AnyObj
  // Internal traversal: accesses domainRoot.portfolio, canonical.holdings,
  // canonical.account_info, canonical.account_summary, canonical.analytics_v2.
  // Uses shallow spreads — circular refs in extra properties are never
  // recursively traversed and cannot cause a stack overflow.

consolidateHoldingsBySymbol(holdings: AnyObj[] | undefined): AnyObj[]
  // Calls normalizeHoldings (map + shallow {...row} spread) then
  // mergeHoldingsBySymbol (Map + shallow {...row} spread). Circular refs
  // on individual holding objects survive the pipeline unchanged.
```

## New test coverage

### Circular reference scenarios (5 cases)

| Scenario | Circular link | Assert |
|---|---|---|
| Holding directly references itself | `holding.self = holding` | Does not throw; `holdings[0].symbol === "AAPL"`, `quantity === 10` |
| Holding carries a nested one-hop circular via metadata | `holding.meta.parent = holding` | Does not throw; `consolidated[0].symbol === "MSFT"`, `quantity === 5` |
| Portfolio object has a parent circular reference | `portfolio.parent = portfolio` | Does not throw; `holdings[0].symbol === "GOOG"` |
| `analytics_v2` field is a self-referential node | `circular.next = circular` | Does not throw; `holdings[0].symbol === "TSLA"` |
| Batch of 3 holdings, every entry references itself | `holding.circular = holding` (×3) | Does not throw; `consolidated.length === 3`; symbols `["AMZN", "META", "NVDA"]` |

## Why these are safe (no defensive code needed)

`normalizeHoldings` maps each holding to `{ ...row, symbol, quantity, ... }`. The spread copies the top-level own properties of `row` — if `row.self === row`, the output contains `self: <original row>` (a reference), not a clone. No further traversal occurs on that value. The same shallow-copy invariant holds for:

- `mergeHoldingsBySymbol` → `grouped.set(symbol, { ...row, ... })`  
- `normalizeStoredPortfolio` → `{ ...canonical, ... }`

None of these paths recurse into the copied value, so circular references cannot create an infinite call stack.

## CI gate checklist
- [x] **PR Base Policy** — targets `integration/pr-train`; branch cut directly from `upstream/integration/pr-train`, zero merge conflicts
- [x] **DCO** — `Signed-off-by: Abdul Rashid <smirthidharmaiit@gmail.com>`
- [x] **Secret Scan** — diff contains only structural test fixture strings; no tokens, credentials, or real user data
- [x] **Governance** — single modified file in `__tests__/utils/`; no debug artifacts; no `eslint-disable`
- [x] **Path filters** — only `hushh-webapp/__tests__/utils/portfolio-normalize.test.ts` changed; triggers Web (Next.js) path gate; skips Protocol (Python) gate
- [x] **Upstream Sync** — branch cut directly from upstream tip; cannot have upstream conflicts
- [x] **Base Freshness Gate** — freshly branched from upstream tip; no stale base
- [x] **Web (Next.js)** — 5 new cases are pure synchronous assertions on deterministic functions; no async, no mocks, no env stubs, no config changes; picked up automatically by Vitest `include: ["__tests__/**/*.test.{ts,tsx}"]`
- [x] **No new files** — 131 additions to the existing companion test file; no standalone scripts
- [x] **Direct production import** — `consolidateHoldingsBySymbol` and `normalizeStoredPortfolio` imported from `@/lib/utils/portfolio-normalize`; already present in the file header; no new imports needed
- [x] **No `eslint-disable`** — zero lint suppressions in the diff
- [x] **Clean diff** — 1 file, 131 additions, 1 deletion (trailing whitespace fix on closing brace), no conflicts, fresh upstream base

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)