### PR TITLE
fix(kai-onboarding): suppress error log in production for onboarding load failure

### DIFF
--- a/hushh-webapp/app/kai/onboarding/page.tsx
+++ b/hushh-webapp/app/kai/onboarding/page.tsx
@@ -184,7 +184,9 @@ function KaiOnboardingPageContent() {
         // Always return to the questionnaire until the onboarding completion flag is set.
         setStage("wizard");
       } catch (error) {
-        console.warn("[KaiOnboardingPage] Failed to load onboarding:", error);
+        if (process.env.NODE_ENV !== "production") {
+         console.warn("[KaiOnboardingPage] Failed to load onboarding:", error);
+        }
         if (!cancelled) {
           setLoadError("Couldn't load onboarding state. Please retry.");
           setStage("loading");


### PR DESCRIPTION
## Summary
- what changed: Wrapped `console.warn` in the main `load()` catch block in `hushh-webapp/app/kai/onboarding/page.tsx` with a `process.env.NODE_ENV !== "production"` guard
- why it changed: The catch block unconditionally logs the full error object including stack trace to production browser console on every onboarding load failure. This is the same pattern fixed in `review-mode/route.ts` (#2062) and `notifications/register/route.ts` (#2064) — this fix brings the onboarding page in line with the same standard.

## Attach point
`hushh-webapp/app/kai/onboarding/page.tsx` — main `load()` effect catch block, triggered on every failed onboarding state load across the `/kai/onboarding` route.

## Contract changed
Runtime behavior: raw error details and stack traces no longer appear in production browser console when onboarding state fails to load. Development and staging behavior unchanged — error is still logged in non-production environments. No change to error UI, retry logic, or `loadError` state handling.

## Tests run
```bash
cd hushh-webapp && npx tsc --noEmit
```
Passed locally. No type errors.

## Base/head status
Branch is current with main, mergeable, and DCO-signed. Targets integration/pr-train as required by repo base policy.

## Sensitive proof
Not applicable. No auth, consent, vault, PKM, finance, or KYC surfaces structurally changed. No secrets involved. Rollback: revert by removing the `NODE_ENV` guard and restoring the unconditional `console.warn`.

## Stack proof
Not applicable. Standalone fix, no predecessor PR.

Fixes #2067