### PR TITLE
fix(hooks): use global timer APIs in use-debounced-value.ts

### DIFF
--- a/hushh-webapp/hooks/use-debounced-value.ts
+++ b/hushh-webapp/hooks/use-debounced-value.ts
@@ -45,12 +45,12 @@ export function useDebouncedValue<T>(value: T, delayMs: number): T {
         ? delayMs
         : 0;
 
-    const timer = window.setTimeout(() => {
+    const timer = setTimeout(() => {
       setDebounced(value);
     }, clampedDelay);
 
     return () => {
-      window.clearTimeout(timer);
+      clearTimeout(timer);
     };
   }, [value, delayMs]);
 


### PR DESCRIPTION
## Summary

Addresses issue #2065 by replacing `window.setTimeout` and `window.clearTimeout` with their global equivalents in `use-debounced-value.ts`.

## Changes

* Replaced `window.setTimeout(...)` with `setTimeout(...)`
* Replaced `window.clearTimeout(...)` with `clearTimeout(...)`

## Scope

* `hushh-webapp/hooks/use-debounced-value.ts`

## Why

Using the global timer APIs avoids unnecessary dependence on the `window` object and aligns with SSR-safe frontend patterns used elsewhere in the codebase.

## Impact

* No functional changes
* No UI changes
* No behavior changes
* Single-file, low-risk cleanup

## Validation

* Scope limited to one file
* Two call sites updated
* No application logic modified

Closes #2065
