### PR TITLE
fix(system): use global timer APIs in stale-cache-timestamp.tsx

### DIFF
--- a/hushh-webapp/components/system/stale-cache-timestamp.tsx
+++ b/hushh-webapp/components/system/stale-cache-timestamp.tsx
@@ -45,11 +45,11 @@ export function StaleCacheTimestamp({
   const [, setTick] = useState(0);
 
   useEffect(() => {
-    const intervalId = window.setInterval(() => {
+    const intervalId = setInterval(() => {
       setTick((value) => value + 1);
     }, 60 * 1000);
 
-    return () => window.clearInterval(intervalId);
+    return () => clearInterval(intervalId);
   }, []);
 
   const text = useMemo(() => {


### PR DESCRIPTION
## Summary

Replaces `window.setInterval` and `window.clearInterval` with their global equivalents in `stale-cache-timestamp.tsx`.

## Changes

* Replaced `window.setInterval(...)` with `setInterval(...)`
* Replaced `window.clearInterval(...)` with `clearInterval(...)`

## Scope

* `hushh-webapp/components/system/stale-cache-timestamp.tsx`

## Why

Using the global timer APIs avoids unnecessary dependence on the `window` object and aligns with SSR-safe frontend patterns used elsewhere in the codebase.

## Impact

* No functional changes
* No UI changes
* No behavior changes
* Single-file, low-risk cleanup

## Validation

* Scope limited to one file
* Two call sites updated
* No application logic modified
