### PR TITLE
fix(kai): use global timer APIs in stock-search

### DIFF
--- a/hushh-webapp/components/kai/views/stock-search.tsx
+++ b/hushh-webapp/components/kai/views/stock-search.tsx
@@ -150,7 +150,7 @@ export function StockSearch({
     }
 
     let cancelled = false;
-    const timer = window.setTimeout(async () => {
+    const timer = setTimeout(async () => {
       try {
         setRemoteLoading(true);
         const rows = await searchTickerUniverseRemote(q, 25);
@@ -178,7 +178,7 @@ export function StockSearch({
 
     return () => {
       cancelled = true;
-      window.clearTimeout(timer);
+      clearTimeout(timer);
     };
   }, [search]);
 


### PR DESCRIPTION
## Summary

Replaces `window.setTimeout` and `window.clearTimeout` with their global equivalents in `stock-search.tsx`.

## Changes

* Replaced `window.setTimeout(...)` with `setTimeout(...)`
* Replaced `window.clearTimeout(...)` with `clearTimeout(...)`

## Scope

* `hushh-webapp/components/kai/views/stock-search.tsx`

## Why

Using the global timer APIs avoids unnecessary dependence on the `window` object and aligns with SSR-safe frontend patterns used elsewhere in the codebase.

## Impact

* No functional changes
* No UI changes
* No behavior changes
* Single-file, low-risk cleanup

## Validation

* Scope limited to one file
* Two call sites updated
* No application logic modified