### PR TITLE
fix(a11y): add role="presentation" to propagation blocker in settings-ui

### DIFF
--- a/hushh-webapp/components/app-ui/settings-ui.tsx
+++ b/hushh-webapp/components/app-ui/settings-ui.tsx
@@ -303,7 +303,7 @@ export function SettingsRow({
             />
           </button>
           {trailingContent ? (
-            <div onClick={(e) => e.stopPropagation()}>
+            <div role="presentation" onClick={(e) => e.stopPropagation()}>
               {trailingContent}
             </div>
           ) : null}


### PR DESCRIPTION
## Summary

Adds `role="presentation"` to a click propagation blocker wrapper in `settings-ui.tsx`.

## Changes

- Added `role="presentation"` to the wrapper div used solely to stop click propagation.

## Scope

- `hushh-webapp/components/app-ui/settings-ui.tsx`

## Why

The wrapper is not intended to be an interactive element. Adding `role="presentation"` clarifies its purpose for assistive technologies and improves accessibility semantics.

## Impact

- No functional changes
- No UI changes
- Accessibility improvement
- Single-file, low-risk update

## Validation

- Scope limited to one file
- No application logic modified