### PR TITLE
fix(ui): use stable React key for field error list

### DIFF
--- a/hushh-webapp/components/ui/field.tsx
+++ b/hushh-webapp/components/ui/field.tsx
@@ -211,8 +211,8 @@ function FieldError({
     return (
       <ul className="ml-4 flex list-disc flex-col gap-1">
         {uniqueErrors.map(
-          (error, index) =>
-            error?.message && <li key={index}>{error.message}</li>
+          (error) =>
+            error?.message && <li key={error.message}>{error.message}</li>
         )}
       </ul>
     )


### PR DESCRIPTION
## Summary

Replaces the array index key used when rendering field validation errors with a stable key derived from the error message.

## Changes

* Replaced `key={index}` with `key={error.message}` in the field error list.

## Scope

* `hushh-webapp/components/ui/field.tsx`

## Why

The error list is already deduplicated by `error.message` before rendering. Using the error message as the React key provides a stable identity for each rendered item and avoids relying on array indexes for dynamic lists.

## Impact

* No functional changes
* No UI changes
* Improves React reconciliation correctness
* Single-file, low-risk update

## Validation

* Scope limited to one file
* Error messages are deduplicated before rendering
* No application logic modified
