### PR TITLE
fix(routes): correct marketplace connections destination

### DIFF
--- a/hushh-webapp/lib/navigation/routes.ts
+++ b/hushh-webapp/lib/navigation/routes.ts
@@ -68,7 +68,7 @@ export function buildMarketplaceConnectionsRoute(entries?: {
   tab?: "pending" | "active" | "previous" | null;
   selected?: string | null;
 }) {
-  return withQuery(ROUTES.CONSENTS, {
+  return withQuery(ROUTES.MARKETPLACE_CONNECTIONS, {
     tab: entries?.tab,
     selected: entries?.selected,
   });


### PR DESCRIPTION
## Summary

Corrects the destination route used by `buildMarketplaceConnectionsRoute`.

## Changes

* Replaced `ROUTES.CONSENTS` with `ROUTES.MARKETPLACE_CONNECTIONS` when building marketplace connection navigation URLs.

## Scope

* `hushh-webapp/lib/navigation/routes.ts`

## Why

`buildMarketplaceConnectionsRoute` is intended to generate URLs for the Marketplace Connections experience. The current implementation routes users to the Consents page instead of the Marketplace Connections page, resulting in incorrect navigation behavior.

## Impact

* Fixes marketplace connection navigation flow
* No UI changes
* No API changes
* Single-file, low-risk update

## Validation

* Scope limited to one file
* Route helper now points to the marketplace connections destination
* No application logic modified beyond route selection
