### PR TITLE
fix(ui): disable repeated action clicks during loading states

### DIFF
--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -213,6 +213,17 @@ export default function MarketplacePage() {
   const [deckRefreshNonce, setDeckRefreshNonce] = useState(0);
   const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
   const dragStartRef = useRef<{ x: number; y: number } | null>(null);
+  const actionInFlightRef = useRef<Set<string>>(new Set());
+
+  const beginAction = useCallback((key: string) => {
+    if (actionInFlightRef.current.has(key)) return false;
+    actionInFlightRef.current.add(key);
+    return true;
+  }, []);
+
+  const endAction = useCallback((key: string) => {
+    actionInFlightRef.current.delete(key);
+  }, []);
 
   const injectedTestCards = useMemo<DiscoveryCard[]>(() => {
     if (!allowTestProfiles || directoryKind !== "rias") return [];
@@ -865,6 +876,8 @@ export default function MarketplacePage() {
       });
       return;
     }
+    const actionKey = `connect-investor:${investorUserId}`;
+    if (!beginAction(actionKey)) return;
     try {
       setActionLoadingUserId(investorUserId);
       const idToken = await user.getIdToken();
@@ -899,12 +912,15 @@ export default function MarketplacePage() {
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to send connection request");
     } finally {
+      endAction(actionKey);
       setActionLoadingUserId(null);
     }
-  }, [persistInvestorAction, rememberInvestorDeckDecision, router, user]);
+  }, [beginAction, endAction, persistInvestorAction, rememberInvestorDeckDecision, router, user]);
 
   const createConnectionToAdvisor = useCallback(async (ria: MarketplaceRia) => {
     if (!user) return;
+    const actionKey = `connect-advisor:${ria.user_id}`;
+    if (!beginAction(actionKey)) return;
     try {
       setActionLoadingUserId(ria.user_id);
       const idToken = await user.getIdToken();
@@ -927,12 +943,15 @@ export default function MarketplacePage() {
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to send connection request");
     } finally {
+      endAction(actionKey);
       setActionLoadingUserId(null);
     }
-  }, [router, user]);
+  }, [beginAction, endAction, router, user]);
 
   const shortlistInvestor = useCallback(async (investor: MarketplaceInvestor) => {
     const investorId = marketplaceInvestorCardId(investor);
+    const actionKey = `shortlist-investor:${investorId}`;
+    if (!beginAction(actionKey)) return;
     try {
       await persistInvestorAction(investor, "shortlist", { gesture: "right_swipe_or_save" });
       setShortlistedInvestorIds((current) =>
@@ -948,8 +967,10 @@ export default function MarketplacePage() {
       });
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Could not save investor lead");
+    } finally {
+      endAction(actionKey);
     }
-  }, [persistInvestorAction, rememberInvestorDeckDecision]);
+  }, [beginAction, endAction, persistInvestorAction, rememberInvestorDeckDecision]);
 
   const openDiscoveryProfile = useCallback((card: DiscoveryCard) => {
     if (card.kind === "investor") {

--- a/hushh-webapp/app/marketplace/ria/page-client.tsx
+++ b/hushh-webapp/app/marketplace/ria/page-client.tsx
@@ -57,6 +57,7 @@ export default function MarketplaceRiaProfilePageClient() {
   const [error, setError] = useState<string | null>(null);
   const [actionLoading, setActionLoading] = useState(false);
   const trackedProfileViewRef = useRef(false);
+  const actionInFlightRef = useRef(false);
   const firmNames = Array.isArray(profile?.firms)
     ? profile.firms
         .map((firm) => String(firm?.legal_name || "").trim())
@@ -107,6 +108,8 @@ export default function MarketplaceRiaProfilePageClient() {
 
   async function requestAdvisory() {
     if (!user || !profile) return;
+    if (actionInFlightRef.current) return;
+    actionInFlightRef.current = true;
     try {
       setActionLoading(true);
       const idToken = await user.getIdToken();
@@ -131,6 +134,7 @@ export default function MarketplaceRiaProfilePageClient() {
         requestError instanceof Error ? requestError.message : "Failed to send advisory request"
       );
     } finally {
+      actionInFlightRef.current = false;
       setActionLoading(false);
     }
   }

--- a/hushh-webapp/components/ria/ria-client-workspace.tsx
+++ b/hushh-webapp/components/ria/ria-client-workspace.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   Loader2,
@@ -269,6 +269,8 @@ export function RiaClientWorkspace({
   const [selectedScopes, setSelectedScopes] = useState<string[]>([]);
   const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([]);
   const [requestReason, setRequestReason] = useState("");
+  const disconnectInFlightRef = useRef(false);
+  const requestAccessInFlightRef = useRef(false);
 
   useEffect(() => {
     setActiveTab(initialTab);
@@ -302,6 +304,8 @@ export function RiaClientWorkspace({
 
   async function handleDisconnect() {
     if (!user || !detail || isTestProfile) return;
+    if (disconnectInFlightRef.current) return;
+    disconnectInFlightRef.current = true;
     try {
       setDisconnecting(true);
       const idToken = await user.getIdToken();
@@ -316,12 +320,14 @@ export function RiaClientWorkspace({
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to disconnect relationship");
     } finally {
+      disconnectInFlightRef.current = false;
       setDisconnecting(false);
     }
   }
 
   async function handleRequestAccess() {
     if (!user || !detail || !activeTemplate || isTestProfile) return;
+    if (requestAccessInFlightRef.current) return;
     if (selectedScopes.length === 0) {
       toast.error("Select at least one access area to request.");
       return;
@@ -331,6 +337,7 @@ export function RiaClientWorkspace({
       return;
     }
 
+    requestAccessInFlightRef.current = true;
     try {
       setRequestingAccess(true);
       const idToken = await user.getIdToken();
@@ -349,6 +356,7 @@ export function RiaClientWorkspace({
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to send access request");
     } finally {
+      requestAccessInFlightRef.current = false;
       setRequestingAccess(false);
     }
   }


### PR DESCRIPTION
## Description

Disables repeated action clicks while an operation is in a loading state to prevent duplicate user actions and inconsistent UI behavior.

## Why

Interactive actions such as save, submit, approve, sync, import, or refresh can be triggered multiple times while a request is still in progress. Repeated clicks may generate duplicate requests, inconsistent state transitions, repeated notifications, or unnecessary backend work.

This change ensures actions remain single-execution until the current operation completes.

## What changed

- Disabled interactive actions during active loading states
- Prevented repeated clicks from triggering duplicate operations
- Preserved existing loading indicators and user feedback
- Maintained existing success, error, and retry behavior

## Impact

- No API changes
- No schema changes
- No backend behavior changes
- Improves frontend reliability and interaction consistency

## Testing

- Ran `npm run lint`
- Ran `npm run build`
- Verified repeated clicks during loading do not trigger duplicate actions
- Verified actions re-enable correctly after completion
- Verified existing success and error flows continue functioning correctly

## Notes

This PR intentionally focuses on frontend interaction safety only and does not modify business logic, authentication flows, consent contracts, PKM behavior, or backend architecture.