### PR TITLE
fix(accessibility): restore focus after modal close

### DIFF
--- a/hushh-webapp/__tests__/components/modal-focus-restore.test.tsx
+++ b/hushh-webapp/__tests__/components/modal-focus-restore.test.tsx
@@ -1,0 +1,116 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet"
+
+function installAnimationFrameMock() {
+  return vi
+    .spyOn(window, "requestAnimationFrame")
+    .mockImplementation((callback) => {
+      callback(0)
+      return 1
+    })
+}
+
+describe("modal focus restoration", () => {
+  it("restores focus to the dialog trigger after close", async () => {
+    const requestAnimationFrameMock = installAnimationFrameMock()
+
+    render(
+      <Dialog>
+        <DialogTrigger>Open dialog</DialogTrigger>
+        <DialogContent>
+          <DialogTitle>Dialog title</DialogTitle>
+          <DialogDescription>Dialog description</DialogDescription>
+          <DialogClose>Close dialog</DialogClose>
+        </DialogContent>
+      </Dialog>,
+    )
+
+    const trigger = screen.getByRole("button", { name: "Open dialog" })
+    trigger.focus()
+    fireEvent.click(trigger)
+    fireEvent.click(await screen.findByRole("button", { name: "Close dialog" }))
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(trigger)
+    })
+
+    requestAnimationFrameMock.mockRestore()
+  })
+
+  it("restores focus to the sheet trigger after close", async () => {
+    const requestAnimationFrameMock = installAnimationFrameMock()
+
+    render(
+      <Sheet>
+        <SheetTrigger>Open sheet</SheetTrigger>
+        <SheetContent>
+          <SheetTitle>Sheet title</SheetTitle>
+          <SheetDescription>Sheet description</SheetDescription>
+          <SheetClose>Close sheet</SheetClose>
+        </SheetContent>
+      </Sheet>,
+    )
+
+    const trigger = screen.getByRole("button", { name: "Open sheet" })
+    trigger.focus()
+    fireEvent.click(trigger)
+    fireEvent.click(await screen.findByRole("button", { name: "Close sheet" }))
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(trigger)
+    })
+
+    requestAnimationFrameMock.mockRestore()
+  })
+
+  it("restores focus to the alert dialog trigger after cancel", async () => {
+    const requestAnimationFrameMock = installAnimationFrameMock()
+
+    render(
+      <AlertDialog>
+        <AlertDialogTrigger>Open alert</AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogTitle>Alert title</AlertDialogTitle>
+          <AlertDialogDescription>Alert description</AlertDialogDescription>
+          <AlertDialogCancel>Cancel alert</AlertDialogCancel>
+        </AlertDialogContent>
+      </AlertDialog>,
+    )
+
+    const trigger = screen.getByRole("button", { name: "Open alert" })
+    trigger.focus()
+    fireEvent.click(trigger)
+    fireEvent.click(await screen.findByRole("button", { name: "Cancel alert" }))
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(trigger)
+    })
+
+    requestAnimationFrameMock.mockRestore()
+  })
+})

--- a/hushh-webapp/__tests__/components/top-app-bar.contract.test.ts
+++ b/hushh-webapp/__tests__/components/top-app-bar.contract.test.ts
@@ -6,7 +6,9 @@ import { describe, expect, it } from "vitest";
 const WEBAPP_ROOT = path.resolve(__dirname, "../..");
 
 function read(relativePath: string) {
-  return fs.readFileSync(path.join(WEBAPP_ROOT, relativePath), "utf8");
+  return fs
+    .readFileSync(path.join(WEBAPP_ROOT, relativePath), "utf8")
+    .replace(/\r\n/g, "\n");
 }
 
 describe("Top app bar responsive contract", () => {

--- a/hushh-webapp/__tests__/components/top-app-bar.contract.test.ts
+++ b/hushh-webapp/__tests__/components/top-app-bar.contract.test.ts
@@ -6,9 +6,7 @@ import { describe, expect, it } from "vitest";
 const WEBAPP_ROOT = path.resolve(__dirname, "../..");
 
 function read(relativePath: string) {
-  return fs
-    .readFileSync(path.join(WEBAPP_ROOT, relativePath), "utf8")
-    .replace(/\r\n/g, "\n");
+  return fs.readFileSync(path.join(WEBAPP_ROOT, relativePath), "utf8");
 }
 
 describe("Top app bar responsive contract", () => {

--- a/hushh-webapp/components/ui/alert-dialog.tsx
+++ b/hushh-webapp/components/ui/alert-dialog.tsx
@@ -5,11 +5,21 @@ import { AlertDialog as AlertDialogPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
+import { useRestoreFocusOnClose } from "@/lib/a11y/restore-focus-on-close"
 
 function AlertDialog({
+  onOpenChange,
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
-  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+  const handleOpenChange = useRestoreFocusOnClose(onOpenChange)
+
+  return (
+    <AlertDialogPrimitive.Root
+      data-slot="alert-dialog"
+      onOpenChange={handleOpenChange}
+      {...props}
+    />
+  )
 }
 
 function AlertDialogTrigger({

--- a/hushh-webapp/components/ui/dialog.tsx
+++ b/hushh-webapp/components/ui/dialog.tsx
@@ -7,12 +7,23 @@ import { Dialog as DialogPrimitive } from "radix-ui"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { MaterialRipple } from "@/lib/morphy-ux/material-ripple"
+import { useRestoreFocusOnClose } from "@/lib/a11y/restore-focus-on-close"
 
 function Dialog({
   modal = false,
+  onOpenChange,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Root>) {
-  return <DialogPrimitive.Root data-slot="dialog" modal={modal} {...props} />
+  const handleOpenChange = useRestoreFocusOnClose(onOpenChange)
+
+  return (
+    <DialogPrimitive.Root
+      data-slot="dialog"
+      modal={modal}
+      onOpenChange={handleOpenChange}
+      {...props}
+    />
+  )
 }
 
 function DialogTrigger({

--- a/hushh-webapp/components/ui/sheet.tsx
+++ b/hushh-webapp/components/ui/sheet.tsx
@@ -5,12 +5,23 @@ import { XIcon } from "lucide-react"
 import { Dialog as SheetPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
+import { useRestoreFocusOnClose } from "@/lib/a11y/restore-focus-on-close"
 
 function Sheet({
   modal = false,
+  onOpenChange,
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Root>) {
-  return <SheetPrimitive.Root data-slot="sheet" modal={modal} {...props} />
+  const handleOpenChange = useRestoreFocusOnClose(onOpenChange)
+
+  return (
+    <SheetPrimitive.Root
+      data-slot="sheet"
+      modal={modal}
+      onOpenChange={handleOpenChange}
+      {...props}
+    />
+  )
 }
 
 function SheetTrigger({

--- a/hushh-webapp/lib/a11y/restore-focus-on-close.ts
+++ b/hushh-webapp/lib/a11y/restore-focus-on-close.ts
@@ -1,0 +1,32 @@
+"use client"
+
+import * as React from "react"
+
+function focusElement(element: Element | null) {
+  if (!(element instanceof HTMLElement)) return
+  if (!document.contains(element)) return
+  element.focus({ preventScroll: true })
+}
+
+export function useRestoreFocusOnClose(
+  onOpenChange?: (open: boolean) => void,
+) {
+  const lastFocusedElementRef = React.useRef<Element | null>(null)
+
+  return React.useCallback(
+    (nextOpen: boolean) => {
+      if (nextOpen) {
+        lastFocusedElementRef.current = document.activeElement
+      }
+
+      onOpenChange?.(nextOpen)
+
+      if (!nextOpen) {
+        window.requestAnimationFrame(() => {
+          focusElement(lastFocusedElementRef.current)
+        })
+      }
+    },
+    [onOpenChange],
+  )
+}


### PR DESCRIPTION
## Description

Restores keyboard focus to the previously active element after a modal is closed, improving accessibility and ensuring a predictable navigation experience for keyboard and assistive technology users.

## Why

When a modal closes, keyboard focus can be lost or reset to an unexpected location on the page. This forces users to navigate from the beginning of the interface again and can create confusion for screen reader and keyboard-only users.

Restoring focus to the element that originally opened the modal aligns with established accessibility best practices and improves overall usability.

## What changed

- Stored the previously focused element before modal open
- Restored focus to the triggering element after modal close
- Preserved existing modal open/close behavior
- Maintained existing keyboard navigation and focus management flows

## Impact

- No API changes
- No schema changes
- No business logic changes
- Improves accessibility and keyboard navigation experience

## Testing

- Ran `npm run lint`
- Ran `npm run build`
- Verified focus returns to the triggering element after modal close
- Verified keyboard navigation continues correctly after modal dismissal
- Verified existing modal interactions remain unchanged

## Notes

This PR intentionally focuses on accessibility and focus management only and does not modify authentication flows, consent contracts, PKM behavior, backend logic, or application architecture.