### PR TITLE
[codex] Redesign Agent chat UI

### DIFF
--- a/hushh-webapp/__tests__/lib/agent-popover-layout.test.ts
+++ b/hushh-webapp/__tests__/lib/agent-popover-layout.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AGENT_POPOVER_PRESET_SIZES,
+  clampAgentPopoverSize,
+  getAgentPopoverViewportBounds,
+  isAgentPopoverSizeMode,
+  resolveAgentPopoverSize,
+} from "@/lib/agent/agent-popover-layout";
+
+describe("agent popover layout", () => {
+  it("accepts only supported size modes", () => {
+    expect(isAgentPopoverSizeMode("fullscreen")).toBe(true);
+    expect(isAgentPopoverSizeMode("large")).toBe(true);
+    expect(isAgentPopoverSizeMode("compact")).toBe(true);
+    expect(isAgentPopoverSizeMode("custom")).toBe(true);
+    expect(isAgentPopoverSizeMode("dock-left")).toBe(false);
+  });
+
+  it("clamps custom size to viewport-safe bounds", () => {
+    expect(clampAgentPopoverSize({ width: 50, height: 50 }, 390, 700)).toEqual({
+      width: 358,
+      height: 520,
+    });
+    expect(clampAgentPopoverSize({ width: 9999, height: 9999 }, 1440, 900)).toEqual({
+      width: 1408,
+      height: 868,
+    });
+  });
+
+  it("resolves presets while preserving custom size", () => {
+    expect(resolveAgentPopoverSize("compact", { width: 777, height: 666 })).toEqual(
+      AGENT_POPOVER_PRESET_SIZES.compact
+    );
+    expect(resolveAgentPopoverSize("large", { width: 777, height: 666 })).toEqual(
+      AGENT_POPOVER_PRESET_SIZES.large
+    );
+    expect(resolveAgentPopoverSize("custom", { width: 777, height: 666 })).toEqual({
+      width: 777,
+      height: 666,
+    });
+  });
+
+  it("keeps minimums below maximums on small screens", () => {
+    const bounds = getAgentPopoverViewportBounds(320, 480);
+    expect(bounds.minWidth).toBeLessThanOrEqual(bounds.maxWidth);
+    expect(bounds.minHeight).toBeLessThanOrEqual(bounds.maxHeight);
+  });
+});

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -7,13 +7,13 @@ import {
   useMemo,
   useRef,
   useState,
+  type ReactNode,
   type PointerEvent as ReactPointerEvent,
 } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
   Bot,
-  BriefcaseBusiness,
-  ChevronDown,
+  Menu,
   Mic,
   Send,
   UserRound,
@@ -75,12 +75,6 @@ import {
   type AgentChatMessage as StoredAgentChatMessage,
   type AgentChatToolEvent,
 } from "@/lib/services/agent-chat-client";
-import {
-  GEMINI_RUNTIME_CREDENTIAL_REF,
-  PersonalKnowledgeModelService,
-  RUNTIME_CREDENTIAL_MODE_REF,
-  type RuntimeCredentialMode,
-} from "@/lib/services/personal-knowledge-model-service";
 import { useKaiSession } from "@/lib/stores/kai-session-store";
 import { cn } from "@/lib/utils";
 import { useVault } from "@/lib/vault/vault-context";
@@ -131,6 +125,7 @@ export type AgentChatWorkspaceVariant = "page" | "popover";
 type AgentChatWorkspaceProps = {
   variant?: AgentChatWorkspaceVariant;
   className?: string;
+  windowControls?: ReactNode;
   onMinimize?: () => void;
   onNavigationActionComplete?: (result: AgentActionRuntimeResult) => void;
 };
@@ -233,7 +228,7 @@ function AgentMarkdown({ text }: { text: string }) {
             <a
               href={href || "#"}
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noreferrer"
               className="font-medium text-primary underline-offset-4 hover:underline"
             >
               {children}
@@ -381,24 +376,30 @@ function AgentBubble({ message }: { message: AgentMessage }) {
   return (
     <div
       className={cn(
-        "flex gap-3 animate-in fade-in slide-in-from-bottom-1 duration-200 motion-reduce:animate-none",
+        "flex w-full gap-3 animate-in fade-in slide-in-from-bottom-1 duration-200 motion-reduce:animate-none",
         isUser ? "justify-end" : "justify-start"
       )}
     >
       {!isUser ? (
-        <div className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-primary/10 text-primary">
-          <Bot className="h-4 w-4" />
+        <div className="mt-1 hidden h-7 w-7 shrink-0 place-items-center rounded-md border border-white/10 bg-white/[0.04] text-zinc-300 sm:grid">
+          <Bot className="h-3.5 w-3.5" />
         </div>
       ) : null}
-      <div className={cn("max-w-[78%]", isUser && "order-first")}>
+      <div
+        className={cn(
+          "min-w-0 max-w-[90%] sm:max-w-[min(82%,48rem)]",
+          isUser && "order-first sm:max-w-[min(76%,42rem)]"
+        )}
+      >
         <div
           aria-live={!isUser && isStreaming ? "polite" : undefined}
           className={cn(
-            "rounded-lg px-4 py-3 text-sm leading-6 shadow-sm",
+            "text-sm leading-6",
             isUser
-              ? "bg-primary text-primary-foreground"
-              : "border border-border/70 bg-background text-foreground",
-            isError && "border-destructive/40 bg-destructive/10 text-destructive"
+              ? "rounded-2xl bg-primary px-4 py-2.5 text-primary-foreground shadow-sm shadow-primary/10"
+              : "px-0 py-1 text-zinc-200",
+            isError &&
+              "rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-2.5 text-destructive"
           )}
         >
           {isUser ? (
@@ -417,13 +418,13 @@ function AgentBubble({ message }: { message: AgentMessage }) {
             />
           ) : null}
         </div>
-        <p className={cn("mt-1 text-xs text-muted-foreground", isUser && "text-right")}>
+        <p className={cn("mt-1 text-[11px] text-zinc-500", isUser && "text-right")}>
           {message.timestamp}
         </p>
       </div>
       {isUser ? (
-        <div className="grid h-8 w-8 shrink-0 place-items-center rounded-full border border-border/70 bg-background text-muted-foreground">
-          <UserRound className="h-4 w-4" />
+        <div className="mt-1 hidden h-7 w-7 shrink-0 place-items-center rounded-md border border-white/10 bg-white/[0.04] text-zinc-400 sm:grid">
+          <UserRound className="h-3.5 w-3.5" />
         </div>
       ) : null}
     </div>
@@ -479,6 +480,7 @@ function shouldMinimizeForNavigationResult(result: AgentActionRuntimeResult): bo
 export function AgentChatWorkspace({
   variant = "page",
   className,
+  windowControls,
   onMinimize,
   onNavigationActionComplete,
 }: AgentChatWorkspaceProps) {
@@ -510,7 +512,7 @@ export function AgentChatWorkspace({
   const [messages, setMessages] = useState<AgentMessage[]>(() => [createGreetingMessage()]);
   const [isChatLoading, setIsChatLoading] = useState(false);
   const [isLoadingHistory, setIsLoadingHistory] = useState(false);
-  const [isHistorySidebarCollapsed, setIsHistorySidebarCollapsed] = useState(false);
+  const [isHistoryDrawerOpen, setIsHistoryDrawerOpen] = useState(false);
   const [historyActionPendingId, setHistoryActionPendingId] = useState<string | null>(null);
   const [isVoiceConnecting, setIsVoiceConnecting] = useState(false);
   const [isStreaming, setIsStreaming] = useState(false);
@@ -531,6 +533,7 @@ export function AgentChatWorkspace({
   const voiceClientRef = useRef<AgentVoiceClient | null>(null);
   const voiceTtsQueueRef = useRef<AgentTtsQueue | null>(null);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
+  const composerTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const historyLoadKeyRef = useRef<string | null>(null);
   const streamAbortControllerRef = useRef<AbortController | null>(null);
   const voiceSttAbortControllerRef = useRef<AbortController | null>(null);
@@ -743,6 +746,24 @@ export function AgentChatWorkspace({
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
   }, [messages, pkmReviews]);
+
+  useEffect(() => {
+    const textarea = composerTextareaRef.current;
+    if (!textarea || voiceActive) return;
+    textarea.style.height = "0px";
+    textarea.style.height = `${Math.min(textarea.scrollHeight, 160)}px`;
+  }, [input, voiceActive]);
+
+  useEffect(() => {
+    if (!isHistoryDrawerOpen) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsHistoryDrawerOpen(false);
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isHistoryDrawerOpen]);
 
   useEffect(() => {
     return () => {
@@ -986,6 +1007,19 @@ export function AgentChatWorkspace({
       historyInteractionDisabled,
       restoreConversationMessages,
     ]
+  );
+
+  const handleSidebarCreateNewChat = useCallback(() => {
+    setIsHistoryDrawerOpen(false);
+    handleCreateNewChat();
+  }, [handleCreateNewChat]);
+
+  const handleSidebarSelectConversation = useCallback(
+    (nextConversationId: string) => {
+      setIsHistoryDrawerOpen(false);
+      void handleSelectConversation(nextConversationId);
+    },
+    [handleSelectConversation]
   );
 
   const handleRenameConversation = useCallback(
@@ -1783,61 +1817,6 @@ export function AgentChatWorkspace({
         });
       }
 
-      let runtimeCredentialMode: RuntimeCredentialMode = "hushh_managed_vertex";
-      let runtimeCredential: string | null = null;
-      if (vaultKey && token) {
-        try {
-          const savedMode = await PersonalKnowledgeModelService.loadRuntimeSecret({
-            userId,
-            vaultKey,
-            vaultOwnerToken: token,
-            credentialRef: RUNTIME_CREDENTIAL_MODE_REF,
-          });
-          runtimeCredentialMode = savedMode === "byok" ? "byok" : "hushh_managed_vertex";
-          if (runtimeCredentialMode === "byok") {
-            try {
-              runtimeCredential = await PersonalKnowledgeModelService.loadRuntimeSecret({
-                userId,
-                vaultKey,
-                vaultOwnerToken: token,
-                credentialRef: GEMINI_RUNTIME_CREDENTIAL_REF,
-              });
-            } catch (error) {
-              runtimeCredential = null;
-              appendDebugEvent(debugTurnId, "runtime_credential_load_failed", {
-                mode: runtimeCredentialMode,
-                provider: "gemini",
-                credential_ref: GEMINI_RUNTIME_CREDENTIAL_REF,
-                message:
-                  error instanceof Error && error.message
-                    ? error.message
-                    : "Failed to load the Gemini runtime key.",
-              });
-            }
-          }
-          appendDebugEvent(debugTurnId, "runtime_credentials_prepared", {
-            mode: runtimeCredentialMode,
-            provider: "gemini",
-            credential_ref: GEMINI_RUNTIME_CREDENTIAL_REF,
-            credential_resolved: Boolean(runtimeCredential),
-          });
-        } catch (error) {
-          runtimeCredentialMode = "hushh_managed_vertex";
-          runtimeCredential = null;
-          appendDebugEvent(debugTurnId, "runtime_credential_mode_load_failed", {
-            message:
-              error instanceof Error && error.message
-                ? error.message
-                : "Failed to load runtime credential settings.",
-          });
-        }
-      } else {
-        appendDebugEvent(debugTurnId, "runtime_credentials_skipped", {
-          reason: "vault_locked_or_unavailable",
-          mode: runtimeCredentialMode,
-        });
-      }
-
       armVoiceStreamWatchdog(
         VOICE_AGENT_FIRST_EVENT_TIMEOUT_MS,
         "Agent voice response timed out before it started. Please try again."
@@ -1848,8 +1827,6 @@ export function AgentChatWorkspace({
         conversationId,
         vaultOwnerToken: token,
         pkmContext: agentPkmContext.text || undefined,
-        runtimeCredential,
-        runtimeCredentialMode,
         signal: streamAbortController.signal,
         handlers: {
           onStart: ({ conversationId: nextConversationId }) => {
@@ -2210,138 +2187,161 @@ export function AgentChatWorkspace({
       onMinimize();
     }
   };
+  const renderHistorySidebar = (sidebarClassName?: string, onClose?: () => void) => (
+    <AgentHistorySidebar
+      conversations={conversations}
+      activeConversationId={conversationId}
+      loading={isLoadingHistory && conversations.length === 0}
+      disabled={!hasChatAccess || historyInteractionDisabled}
+      actionPendingId={historyActionPendingId}
+      className={sidebarClassName}
+      onClose={onClose}
+      onCreateNew={handleSidebarCreateNewChat}
+      onSelectConversation={handleSidebarSelectConversation}
+      onRenameConversation={handleRenameConversation}
+      onDeleteConversation={handleDeleteConversation}
+    />
+  );
 
   return (
     <div
       className={cn(
-        "agent-chat-workspace flex min-h-0 w-full flex-col",
-        isPopover ? "h-full overflow-hidden" : "gap-5",
+        "agent-chat-workspace flex min-h-0 w-full flex-col text-zinc-100",
+        isPopover
+          ? "h-full overflow-hidden bg-[#0d0f13]"
+          : "h-[calc(100dvh-var(--app-top-content-offset,0px)-var(--app-bottom-fixed-ui,0px)-var(--app-safe-area-bottom-effective,0px))] min-h-[420px] overflow-hidden bg-[#0b0d10]",
         className
       )}
       data-agent-chat-workspace={variant}
     >
       <div
         className={cn(
-          "flex shrink-0 touch-pan-y items-center justify-between gap-4 border-b border-primary/35",
-          isPopover ? "px-4 py-3 sm:px-5" : "pb-5"
-        )}
-        onPointerDown={handleHeaderPointerDown}
-        onPointerUp={handleHeaderPointerEnd}
-        onPointerCancel={() => {
-          swipeStartYRef.current = null;
-        }}
-      >
-        <div className="flex min-w-0 items-center gap-4">
-          <div
-            className={cn(
-              "grid shrink-0 place-items-center rounded-full border border-primary/30 bg-primary/10 text-primary",
-              isPopover ? "h-12 w-12" : "h-24 w-16"
-            )}
-            aria-hidden
-          >
-            <BriefcaseBusiness className={isPopover ? "h-5 w-5" : "h-6 w-6"} />
-          </div>
-          <div className="min-w-0">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-primary">
-              Kai
-            </p>
-            <h1
-              className={cn(
-                "font-semibold leading-none text-foreground",
-                isPopover ? "mt-1 text-2xl sm:text-3xl" : "mt-3 text-4xl sm:text-5xl"
-              )}
-            >
-              Agent
-            </h1>
-            <p
-              className={cn(
-                "mt-2 max-w-2xl text-muted-foreground",
-                isPopover ? "text-sm" : "text-base"
-              )}
-            >
-              A Kai-focused chat surface for markets, portfolio, analysis, and consent workflows.
-            </p>
-          </div>
-        </div>
-
-        <div className="flex shrink-0 items-center gap-2">
-          <span className="hidden rounded-md border border-border/70 bg-background px-3 py-1.5 text-xs font-medium text-muted-foreground sm:inline-flex">
-            {statusText}
-          </span>
-          {onMinimize ? (
-            <Button
-              type="button"
-              variant="outline"
-              size="icon"
-              className="h-9 w-9"
-              onClick={onMinimize}
-              aria-label="Minimize Agent"
-              title="Minimize Agent"
-            >
-              <ChevronDown className="h-4 w-4" />
-            </Button>
-          ) : null}
-        </div>
-      </div>
-
-      <div
-        className={cn(
-          "flex min-h-0 flex-1 flex-col gap-3 lg:flex-row",
-          isPopover ? "overflow-hidden p-3 sm:p-4" : ""
+          "relative flex min-h-0 flex-1",
+          isPopover ? "flex-col gap-3 overflow-hidden p-3 sm:p-4 lg:flex-row" : "overflow-hidden"
         )}
       >
-        <AgentHistorySidebar
-          conversations={conversations}
-          activeConversationId={conversationId}
-          collapsed={isHistorySidebarCollapsed}
-          loading={isLoadingHistory && conversations.length === 0}
-          disabled={!hasChatAccess || historyInteractionDisabled}
-          actionPendingId={historyActionPendingId}
-          className={isPopover ? "max-lg:max-h-48 lg:h-full" : undefined}
-          onToggleCollapsed={() => setIsHistorySidebarCollapsed((current) => !current)}
-          onCreateNew={handleCreateNewChat}
-          onSelectConversation={handleSelectConversation}
-          onRenameConversation={handleRenameConversation}
-          onDeleteConversation={handleDeleteConversation}
-        />
+        {isPopover ? (
+          renderHistorySidebar("max-lg:h-44 max-lg:w-full max-lg:border-b max-lg:border-r-0 lg:h-full lg:w-64")
+        ) : (
+          <>
+            <div className="hidden h-full lg:flex">
+              {renderHistorySidebar("h-full w-[18rem]")}
+            </div>
+            <div
+              className={cn(
+                "fixed inset-0 z-[520] bg-black/55 backdrop-blur-sm transition-opacity duration-200 lg:hidden",
+                isHistoryDrawerOpen ? "opacity-100" : "pointer-events-none opacity-0"
+              )}
+              aria-hidden="true"
+              onClick={() => setIsHistoryDrawerOpen(false)}
+            />
+            <div
+              className={cn(
+                "fixed inset-y-0 left-0 z-[530] w-[min(88vw,320px)] transform transition-transform duration-200 ease-out lg:hidden",
+                isHistoryDrawerOpen ? "translate-x-0" : "-translate-x-full"
+              )}
+              role="dialog"
+              aria-modal="true"
+              aria-hidden={!isHistoryDrawerOpen}
+              aria-label="Agent chat history"
+            >
+              {renderHistorySidebar("h-full w-full shadow-2xl shadow-black/40", () =>
+                setIsHistoryDrawerOpen(false)
+              )}
+            </div>
+          </>
+        )}
 
-        <section className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-lg border border-border/70 bg-card shadow-sm">
+        <section
+          className={cn(
+            "relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-[#15171c]",
+            isPopover && "rounded-lg border border-white/10 shadow-sm"
+          )}
+        >
           <div
             className={cn(
-              "min-h-0 flex-1 space-y-5 overflow-y-auto p-4 sm:p-5",
-              !isPopover && "max-h-[min(68vh,680px)]"
+              "flex h-14 shrink-0 touch-pan-y items-center justify-between gap-3 border-b border-white/10 bg-[#15171c]/95 px-3 backdrop-blur sm:h-16 sm:px-5",
+              !isPopover && "lg:px-6"
             )}
+            onPointerDown={handleHeaderPointerDown}
+            onPointerUp={handleHeaderPointerEnd}
+            onPointerCancel={() => {
+              swipeStartYRef.current = null;
+            }}
           >
-            {accessMessage ? (
-              <div className="rounded-lg border border-border/70 bg-background px-4 py-5 text-sm text-muted-foreground">
-                {accessMessage}
+            <div className="flex min-w-0 items-center gap-3">
+              {!isPopover ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-9 w-9 rounded-lg text-zinc-300 hover:bg-white/[0.07] hover:text-zinc-50 focus-visible:ring-2 focus-visible:ring-primary/60 lg:hidden"
+                  onClick={() => setIsHistoryDrawerOpen(true)}
+                  aria-label="Open chat history"
+                  title="Open chat history"
+                >
+                  <Menu className="h-4 w-4" />
+                </Button>
+              ) : null}
+              <div className="grid h-8 w-8 shrink-0 place-items-center rounded-md border border-white/10 bg-white/[0.04] text-primary">
+                <Bot className="h-4 w-4" />
               </div>
-            ) : null}
+              <div className="min-w-0">
+                <div className="truncate text-sm font-semibold leading-5 text-zinc-100 sm:text-base">
+                  Agent
+                </div>
+                <p className="hidden truncate text-xs text-zinc-500 sm:block">
+                  Kai workspace
+                </p>
+              </div>
+            </div>
 
-            {messages.map((message) => (
-              <AgentBubble key={message.id} message={message} />
-            ))}
+            <div className="flex shrink-0 items-center gap-2">
+              <span className="hidden rounded-md border border-white/10 bg-white/[0.03] px-2.5 py-1 text-xs font-medium text-zinc-400 sm:inline-flex">
+                {statusText}
+              </span>
+              {windowControls ? <div className="ml-1">{windowControls}</div> : null}
+            </div>
+          </div>
 
-            {pkmActivity.map((item) => (
-              <AgentPkmActivityLine key={item.id} item={item} />
-            ))}
+          <div
+            className={cn(
+              "min-h-0 flex-1 overflow-y-auto scroll-smooth px-4 pt-5 scrollbar-thin scrollbar-thumb-muted scrollbar-track-transparent sm:px-6",
+              isPopover ? "pb-4" : "pb-6 lg:px-8"
+            )}
+          >
+            <div className="mx-auto flex min-h-full w-full max-w-3xl flex-col gap-6">
+              {accessMessage ? (
+                <div className="rounded-xl border border-white/10 bg-white/[0.03] px-4 py-4 text-sm text-zinc-400">
+                  {accessMessage}
+                </div>
+              ) : null}
 
-            {pkmReviews.map((review) => (
-              <AgentPkmReviewPanel
-                key={review.id}
-                cards={review.cards}
-                saving={review.saving}
-                onSave={() => void handleSavePkmReview(review.id)}
-                onDismiss={() => handleDismissPkmReview(review.id)}
-              />
-            ))}
-            <div ref={messagesEndRef} />
+              {messages.map((message) => (
+                <AgentBubble key={message.id} message={message} />
+              ))}
+
+              {pkmActivity.map((item) => (
+                <AgentPkmActivityLine key={item.id} item={item} />
+              ))}
+
+              {pkmReviews.map((review) => (
+                <AgentPkmReviewPanel
+                  key={review.id}
+                  cards={review.cards}
+                  saving={review.saving}
+                  onSave={() => void handleSavePkmReview(review.id)}
+                  onDismiss={() => handleDismissPkmReview(review.id)}
+                />
+              ))}
+              <div ref={messagesEndRef} />
+            </div>
           </div>
 
           {voiceTranscriptReview ? (
-            <div className="absolute inset-0 z-20 grid place-items-end bg-background/30 p-4 backdrop-blur-[1px] sm:place-items-center">
+            <div className="absolute inset-0 z-20 grid place-items-end bg-black/40 p-4 backdrop-blur-[2px] sm:place-items-center">
               <div
-                className="w-full max-w-sm rounded-md border border-primary/30 bg-background p-4 shadow-xl"
+                className="w-full max-w-sm rounded-xl border border-white/10 bg-[#15171c] p-4 shadow-xl"
                 role="dialog"
                 aria-modal="true"
                 aria-label="Confirm voice transcript"
@@ -2383,46 +2383,71 @@ export function AgentChatWorkspace({
 
           <form
             onSubmit={handleSubmit}
-            className="flex shrink-0 items-center gap-2 border-t border-border/70 bg-background/80 p-3"
-          >
-            {voiceActive ? (
-              <AgentVoiceWaveInput
-                status={voiceState}
-                level={voiceLevel}
-                muted={voiceMuted}
-                disabled={!hasChatAccess || isVoiceConnecting}
-                onToggleMute={handleToggleVoice}
-                onCancel={() => {
-                  void handleCancelVoice();
-                }}
-              />
-            ) : (
-              <>
-                <input
-                  value={input}
-                  onChange={(event) => setInput(event.target.value)}
-                  disabled={!hasChatAccess || isLoadingHistory || isVoiceConnecting}
-                  placeholder="Ask Agent about markets, portfolio, analysis..."
-                  className="h-11 min-w-0 flex-1 rounded-md border border-border/70 bg-background px-4 text-sm outline-none transition-colors placeholder:text-muted-foreground focus:border-primary/60"
-                />
-                {agentVoiceEnabled ? (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    disabled={!canToggleVoice}
-                    onClick={handleToggleVoice}
-                    aria-label="Start voice mode"
-                    title="Start voice mode"
-                  >
-                    <Mic className="h-4 w-4" />
-                  </Button>
-                ) : null}
-                <Button type="submit" size="icon" disabled={!canSend} aria-label="Send message">
-                  <Send className="h-4 w-4" />
-                </Button>
-              </>
+            className={cn(
+              "shrink-0 border-t border-white/10 bg-[#15171c]/95 px-3 py-3 backdrop-blur sm:px-5",
+              !isPopover && "pb-[calc(0.75rem+var(--app-safe-area-bottom-effective,0px))]"
             )}
+          >
+            <div className="mx-auto w-full max-w-3xl">
+              {voiceActive ? (
+                <div className="rounded-2xl border border-white/10 bg-[#0f1116] p-2 shadow-lg shadow-black/15">
+                  <AgentVoiceWaveInput
+                    status={voiceState}
+                    level={voiceLevel}
+                    muted={voiceMuted}
+                    disabled={!hasChatAccess || isVoiceConnecting}
+                    onToggleMute={handleToggleVoice}
+                    onCancel={() => {
+                      void handleCancelVoice();
+                    }}
+                  />
+                </div>
+              ) : (
+                <div className="flex min-h-14 items-end gap-2 rounded-[1.5rem] border border-white/12 bg-[#0f1116] px-3 py-2 shadow-lg shadow-black/15 transition-colors focus-within:border-primary/55 focus-within:ring-2 focus-within:ring-primary/20">
+                  <textarea
+                    ref={composerTextareaRef}
+                    value={input}
+                    onChange={(event) => setInput(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key !== "Enter" || event.shiftKey || event.nativeEvent.isComposing) {
+                        return;
+                      }
+                      event.preventDefault();
+                      if (canSend) {
+                        event.currentTarget.form?.requestSubmit();
+                      }
+                    }}
+                    disabled={!hasChatAccess || isLoadingHistory || isVoiceConnecting}
+                    placeholder="Message Agent..."
+                    rows={1}
+                    className="max-h-40 min-h-8 min-w-0 flex-1 resize-none bg-transparent px-1 py-2 text-sm leading-6 text-zinc-100 outline-none placeholder:text-zinc-500 disabled:cursor-not-allowed disabled:opacity-60"
+                  />
+                  {agentVoiceEnabled ? (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="h-9 w-9 shrink-0 rounded-xl text-zinc-400 hover:bg-white/[0.07] hover:text-zinc-100 focus-visible:ring-2 focus-visible:ring-primary/60"
+                      disabled={!canToggleVoice}
+                      onClick={handleToggleVoice}
+                      aria-label="Start voice mode"
+                      title="Start voice mode"
+                    >
+                      <Mic className="h-4 w-4" />
+                    </Button>
+                  ) : null}
+                  <Button
+                    type="submit"
+                    size="icon"
+                    className="h-9 w-9 shrink-0 rounded-xl bg-primary text-primary-foreground shadow-sm shadow-primary/20 hover:bg-primary/90 focus-visible:ring-2 focus-visible:ring-primary/60 disabled:bg-white/[0.08] disabled:text-zinc-500 disabled:shadow-none"
+                    disabled={!canSend}
+                    aria-label="Send message"
+                  >
+                    <Send className="h-4 w-4" />
+                  </Button>
+                </div>
+              )}
+            </div>
           </form>
         </section>
       </div>

--- a/hushh-webapp/components/agent/agent-history-sidebar.tsx
+++ b/hushh-webapp/components/agent/agent-history-sidebar.tsx
@@ -5,8 +5,6 @@ import {
   Check,
   MessageSquare,
   MoreHorizontal,
-  PanelLeftClose,
-  PanelLeftOpen,
   Pencil,
   Plus,
   Trash2,
@@ -37,12 +35,11 @@ import { cn } from "@/lib/utils";
 type AgentHistorySidebarProps = {
   conversations: AgentChatConversation[];
   activeConversationId: string | null;
-  collapsed: boolean;
   loading?: boolean;
   disabled?: boolean;
   actionPendingId?: string | null;
   className?: string;
-  onToggleCollapsed: () => void;
+  onClose?: () => void;
   onCreateNew: () => void;
   onSelectConversation: (conversationId: string) => void;
   onRenameConversation: (conversationId: string, title: string) => Promise<void> | void;
@@ -61,12 +58,11 @@ function conversationLabel(conversation: AgentChatConversation): string {
 export function AgentHistorySidebar({
   conversations,
   activeConversationId,
-  collapsed,
   loading = false,
   disabled = false,
   actionPendingId,
   className,
-  onToggleCollapsed,
+  onClose,
   onCreateNew,
   onSelectConversation,
   onRenameConversation,
@@ -115,77 +111,54 @@ export function AgentHistorySidebar({
     <>
       <aside
         className={cn(
-          "flex shrink-0 flex-col overflow-hidden rounded-lg border border-border/70 bg-card shadow-sm transition-[width] duration-200 ease-out",
-          collapsed ? "w-full lg:w-14" : "w-full lg:w-72",
+          "flex min-h-0 w-72 shrink-0 flex-col overflow-hidden border-r border-white/10 bg-[#101216] text-zinc-200",
           className
         )}
         aria-label="Agent chat history"
       >
-        <div
-          className={cn(
-            "flex items-center gap-2 border-b border-border/70 p-2",
-            collapsed && "lg:flex-col"
-          )}
-        >
+        <div className="flex items-center gap-2 border-b border-white/10 p-3">
           <Button
             type="button"
-            variant="secondary"
-            className={cn(
-              "min-w-0",
-              collapsed ? "h-9 w-9 px-0" : "flex-1 justify-start px-3"
-            )}
+            variant="ghost"
+            className="h-11 min-w-0 flex-1 justify-start gap-2 rounded-lg border border-white/10 bg-white/[0.04] px-3 text-sm font-medium text-zinc-100 shadow-sm transition-colors hover:bg-white/[0.08] focus-visible:ring-2 focus-visible:ring-primary/60"
             onClick={onCreateNew}
             disabled={disabled}
             aria-label="Create new Agent chat"
             title="Create new chat"
           >
             <Plus className="h-4 w-4" />
-            {!collapsed ? <span className="truncate">Create New Chat</span> : null}
+            <span className="truncate">New chat</span>
           </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className="h-9 w-9"
-            onClick={onToggleCollapsed}
-            aria-label={collapsed ? "Expand chat history" : "Collapse chat history"}
-            title={collapsed ? "Expand chat history" : "Collapse chat history"}
-          >
-            {collapsed ? (
-              <PanelLeftOpen className="h-4 w-4" />
-            ) : (
-              <PanelLeftClose className="h-4 w-4" />
-            )}
-          </Button>
+          {onClose ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-10 w-10 rounded-lg text-zinc-400 hover:bg-white/[0.07] hover:text-zinc-100 lg:hidden"
+              onClick={onClose}
+              aria-label="Close chat history"
+              title="Close chat history"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          ) : null}
         </div>
 
-        <div
-          className={cn(
-            "min-h-0 flex-1 overflow-y-auto p-2",
-            collapsed && "max-lg:flex max-lg:gap-1 max-lg:overflow-x-auto"
-          )}
-        >
+        <div className="min-h-0 flex-1 overflow-y-auto p-2 scrollbar-thin scrollbar-thumb-muted scrollbar-track-transparent">
+          <div className="px-2 pb-2 pt-1 text-[11px] font-medium uppercase tracking-[0.16em] text-zinc-500">
+            Chats
+          </div>
           {loading ? (
-            <div
-              className={cn(
-                "rounded-md bg-muted/40",
-                collapsed ? "h-9 w-9 shrink-0" : "h-10 w-full"
-              )}
-            />
+            <div className="h-10 w-full rounded-lg bg-white/[0.05]" />
           ) : null}
 
           {!loading && conversations.length === 0 ? (
-            <div
-              className={cn(
-                "grid place-items-center rounded-md border border-dashed border-border/70 text-center text-xs text-muted-foreground",
-                collapsed ? "h-9 w-9 shrink-0" : "min-h-24 px-3"
-              )}
-            >
-              {collapsed ? <MessageSquare className="h-4 w-4" /> : "No chats yet"}
+            <div className="grid min-h-24 place-items-center rounded-lg border border-dashed border-white/10 px-3 text-center text-xs text-zinc-500">
+              No chats yet
             </div>
           ) : null}
 
-          <div className={cn("space-y-1", collapsed && "max-lg:flex max-lg:space-y-0")}>
+          <div className="space-y-1">
             {conversations.map((conversation) => {
               const title = conversationLabel(conversation);
               const active = conversation.id === activeConversationId;
@@ -196,20 +169,20 @@ export function AgentHistorySidebar({
                 <div
                   key={conversation.id}
                   className={cn(
-                    "group rounded-md transition-colors",
-                    active && "bg-primary/10 text-primary",
-                    !active && "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+                    "group rounded-lg transition-colors",
+                    active && "bg-primary/15 text-zinc-50 ring-1 ring-primary/20",
+                    !active && "text-zinc-400 hover:bg-white/[0.06] hover:text-zinc-100"
                   )}
                 >
-                  {isRenaming && !collapsed ? (
+                  {isRenaming ? (
                     <form
                       onSubmit={submitRename}
-                      className="flex items-center gap-1 rounded-md bg-background p-1"
+                      className="flex items-center gap-1 rounded-lg bg-[#151820] p-1"
                     >
                       <Input
                         value={renameValue}
                         onChange={(event) => setRenameValue(event.target.value)}
-                        className="h-8 min-w-0 flex-1 text-sm"
+                        className="h-8 min-w-0 flex-1 border-white/10 bg-black/20 text-sm text-zinc-100"
                         maxLength={160}
                         autoFocus
                         disabled={pending}
@@ -240,48 +213,45 @@ export function AgentHistorySidebar({
                       <button
                         type="button"
                         className={cn(
-                          "flex h-9 min-w-0 flex-1 items-center gap-2 rounded-md px-2 text-left text-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring/50",
-                          collapsed && "w-9 flex-none justify-center px-0"
+                          "flex h-10 min-w-0 flex-1 items-center gap-2 rounded-lg px-2 text-left text-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary/60"
                         )}
                         onClick={() => onSelectConversation(conversation.id)}
                         disabled={disabled || pending}
                         aria-current={active ? "page" : undefined}
                         title={title}
                       >
-                        <MessageSquare className="h-4 w-4 shrink-0" />
-                        {!collapsed ? <span className="truncate">{title}</span> : null}
+                        <MessageSquare className="h-4 w-4 shrink-0 opacity-75" />
+                        <span className="truncate">{title}</span>
                       </button>
-                      {!collapsed ? (
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="icon-xs"
-                              className="mr-1 opacity-70 transition-opacity group-hover:opacity-100"
-                              disabled={disabled || pending}
-                              onPointerDown={(event) => event.stopPropagation()}
-                              onClick={(event) => event.stopPropagation()}
-                              aria-label={`Open actions for ${title}`}
-                            >
-                              <MoreHorizontal className="h-3.5 w-3.5" />
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="end" sideOffset={6} className="z-[520]">
-                            <DropdownMenuItem onSelect={() => startRename(conversation)}>
-                              <Pencil className="h-4 w-4" />
-                              Rename chat
-                            </DropdownMenuItem>
-                            <DropdownMenuItem
-                              variant="destructive"
-                              onSelect={() => setDeleteTarget(conversation)}
-                            >
-                              <Trash2 className="h-4 w-4" />
-                              Delete chat
-                            </DropdownMenuItem>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      ) : null}
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon-xs"
+                            className="mr-1 text-zinc-500 opacity-0 transition-opacity hover:bg-white/[0.07] hover:text-zinc-100 group-hover:opacity-100 focus-visible:opacity-100"
+                            disabled={disabled || pending}
+                            onPointerDown={(event) => event.stopPropagation()}
+                            onClick={(event) => event.stopPropagation()}
+                            aria-label={`Open actions for ${title}`}
+                          >
+                            <MoreHorizontal className="h-3.5 w-3.5" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end" sideOffset={6} className="z-[520]">
+                          <DropdownMenuItem onSelect={() => startRename(conversation)}>
+                            <Pencil className="h-4 w-4" />
+                            Rename chat
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            variant="destructive"
+                            onSelect={() => setDeleteTarget(conversation)}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                            Delete chat
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
                     </div>
                   )}
                 </div>

--- a/hushh-webapp/components/agent/agent-popover-provider.tsx
+++ b/hushh-webapp/components/agent/agent-popover-provider.tsx
@@ -8,15 +8,29 @@ import {
   useMemo,
   useRef,
   useState,
+  type CSSProperties,
+  type Dispatch,
+  type PointerEvent as ReactPointerEvent,
   type ReactNode,
+  type SetStateAction,
 } from "react";
 import { usePathname } from "next/navigation";
-import { Bot } from "lucide-react";
+import { Bot, Grip, Maximize2, Minimize2, Minus, X } from "lucide-react";
 
 import { AgentChatWorkspace } from "@/components/agent/agent-chat-workspace";
 import { AgentVoiceFloatingIndicator } from "@/components/agent/agent-voice-floating-indicator";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/use-auth";
+import {
+  AGENT_POPOVER_DEFAULT_SIZE_MODE,
+  AGENT_POPOVER_PRESET_SIZES,
+  AGENT_POPOVER_STORAGE_KEYS,
+  clampAgentPopoverSize,
+  isAgentPopoverSizeMode,
+  resolveAgentPopoverSize,
+  type AgentPopoverSize,
+  type AgentPopoverSizeMode,
+} from "@/lib/agent/agent-popover-layout";
 import { ROUTES, isRiaActionBarRoute } from "@/lib/navigation/routes";
 import { cn } from "@/lib/utils";
 
@@ -24,15 +38,50 @@ type AgentPopoverContextValue = {
   expanded: boolean;
   hasOpened: boolean;
   motionState: AgentPopoverMotionState;
+  sizeMode: AgentPopoverSizeMode;
   openAgent: () => void;
   minimizeAgent: () => void;
+  setSizeMode: (mode: AgentPopoverSizeMode) => void;
 };
 
 type AgentPopoverMotionState = "idle" | "opening" | "closing";
 
 const AGENT_POPOVER_TRANSITION_MS = 360;
+const DEFAULT_CUSTOM_SIZE: AgentPopoverSize = AGENT_POPOVER_PRESET_SIZES.large;
 
 const AgentPopoverContext = createContext<AgentPopoverContextValue | null>(null);
+
+function getViewportSize() {
+  if (typeof window === "undefined") {
+    return { width: 1280, height: 800 };
+  }
+  return {
+    width: window.innerWidth,
+    height: window.innerHeight,
+  };
+}
+
+function readStoredSizeMode(): AgentPopoverSizeMode {
+  if (typeof window === "undefined") return AGENT_POPOVER_DEFAULT_SIZE_MODE;
+  const stored = window.localStorage.getItem(AGENT_POPOVER_STORAGE_KEYS.mode);
+  return isAgentPopoverSizeMode(stored) ? stored : AGENT_POPOVER_DEFAULT_SIZE_MODE;
+}
+
+function readStoredCustomSize(): AgentPopoverSize {
+  if (typeof window === "undefined") return DEFAULT_CUSTOM_SIZE;
+  const stored = window.localStorage.getItem(AGENT_POPOVER_STORAGE_KEYS.customSize);
+  if (!stored) return DEFAULT_CUSTOM_SIZE;
+  try {
+    const parsed = JSON.parse(stored) as Partial<AgentPopoverSize>;
+    if (typeof parsed.width !== "number" || typeof parsed.height !== "number") {
+      return DEFAULT_CUSTOM_SIZE;
+    }
+    const viewport = getViewportSize();
+    return clampAgentPopoverSize(parsed as AgentPopoverSize, viewport.width, viewport.height);
+  } catch {
+    return DEFAULT_CUSTOM_SIZE;
+  }
+}
 
 export function useAgentPopover() {
   const value = useContext(AgentPopoverContext);
@@ -51,8 +100,14 @@ export function AgentPopoverProvider({ children }: { children: ReactNode }) {
   const [hasOpened, setHasOpened] = useState(false);
   const [motionState, setMotionState] =
     useState<AgentPopoverMotionState>("idle");
+  const [sizeMode, setSizeModeState] = useState<AgentPopoverSizeMode>(readStoredSizeMode);
+  const [customSize, setCustomSize] = useState<AgentPopoverSize>(readStoredCustomSize);
   const animationFrameRef = useRef<number | null>(null);
   const motionTimerRef = useRef<number | null>(null);
+
+  const setSizeMode = useCallback((mode: AgentPopoverSizeMode) => {
+    setSizeModeState(mode);
+  }, []);
 
   const clearMotionHandles = useCallback(() => {
     if (animationFrameRef.current !== null) {
@@ -102,36 +157,141 @@ export function AgentPopoverProvider({ children }: { children: ReactNode }) {
       expanded,
       hasOpened,
       motionState,
+      sizeMode,
       openAgent,
       minimizeAgent,
+      setSizeMode,
     }),
-    [expanded, hasOpened, minimizeAgent, motionState, openAgent]
+    [expanded, hasOpened, minimizeAgent, motionState, openAgent, setSizeMode, sizeMode]
   );
+
+  useEffect(() => {
+    window.localStorage.setItem(AGENT_POPOVER_STORAGE_KEYS.mode, sizeMode);
+  }, [sizeMode]);
+
+  useEffect(() => {
+    window.localStorage.setItem(
+      AGENT_POPOVER_STORAGE_KEYS.customSize,
+      JSON.stringify(customSize)
+    );
+  }, [customSize]);
+
+  useEffect(() => {
+    const handleResize = () => {
+      const viewport = getViewportSize();
+      setCustomSize((current) =>
+        clampAgentPopoverSize(current, viewport.width, viewport.height)
+      );
+    };
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
 
   return (
     <AgentPopoverContext.Provider value={value}>
       {children}
-      <AgentPopoverSurface />
+      <AgentPopoverSurface customSize={customSize} setCustomSize={setCustomSize} />
     </AgentPopoverContext.Provider>
   );
 }
 
-function AgentPopoverSurface() {
+type AgentPopoverSurfaceProps = {
+  customSize: AgentPopoverSize;
+  setCustomSize: Dispatch<SetStateAction<AgentPopoverSize>>;
+};
+
+function AgentPopoverSurface({ customSize, setCustomSize }: AgentPopoverSurfaceProps) {
   const { isAuthenticated } = useAuth();
   const pathname = usePathname();
-  const { expanded, hasOpened, motionState, openAgent, minimizeAgent } =
+  const { expanded, hasOpened, motionState, sizeMode, setSizeMode, openAgent, minimizeAgent } =
     useAgentPopover();
   const isLegacyAgentRoute = pathname === ROUTES.AGENT;
   const canShowAgent = isAuthenticated && !isLegacyAgentRoute;
   const useRiaActionBarTrigger = isRiaActionBarRoute(pathname);
   const isCollapsing = motionState === "closing";
   const surfaceVisible = expanded || motionState !== "idle";
+  const isFullscreen = sizeMode === "fullscreen";
+  const resizeStartRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    startWidth: number;
+    startHeight: number;
+  } | null>(null);
+
+  const resolvedPanelSize = useMemo(() => {
+    const viewport = getViewportSize();
+    return clampAgentPopoverSize(
+      resolveAgentPopoverSize(sizeMode, customSize),
+      viewport.width,
+      viewport.height
+    );
+  }, [customSize, sizeMode]);
+
+  const panelStyle = useMemo<CSSProperties>(
+    () =>
+      ({
+        "--agent-popover-width": `${resolvedPanelSize.width}px`,
+        "--agent-popover-height": `${resolvedPanelSize.height}px`,
+      }) as CSSProperties,
+    [resolvedPanelSize.height, resolvedPanelSize.width]
+  );
 
   const handleNavigationActionComplete = useCallback(() => {
     window.setTimeout(() => {
       minimizeAgent();
     }, 120);
   }, [minimizeAgent]);
+
+  const handleResizePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>) => {
+      if (isFullscreen) return;
+      event.preventDefault();
+      event.stopPropagation();
+      event.currentTarget.setPointerCapture(event.pointerId);
+      resizeStartRef.current = {
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        startWidth: resolvedPanelSize.width,
+        startHeight: resolvedPanelSize.height,
+      };
+      setSizeMode("custom");
+    },
+    [isFullscreen, resolvedPanelSize.height, resolvedPanelSize.width, setSizeMode]
+  );
+
+  const handleResizePointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>) => {
+      const start = resizeStartRef.current;
+      if (!start || start.pointerId !== event.pointerId) return;
+      event.preventDefault();
+      const viewport = getViewportSize();
+      setCustomSize(
+        clampAgentPopoverSize(
+          {
+            width: start.startWidth + start.startX - event.clientX,
+            height: start.startHeight + start.startY - event.clientY,
+          },
+          viewport.width,
+          viewport.height
+        )
+      );
+    },
+    [setCustomSize]
+  );
+
+  const handleResizePointerEnd = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>) => {
+      const start = resizeStartRef.current;
+      if (!start || start.pointerId !== event.pointerId) return;
+      resizeStartRef.current = null;
+      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }
+    },
+    []
+  );
 
   if (!isAuthenticated) {
     return null;
@@ -153,12 +313,16 @@ function AgentPopoverSurface() {
         >
           <section
             className={cn(
-              "pointer-events-auto fixed bottom-[calc(max(var(--app-safe-area-bottom-effective),0.5rem)+0.5rem)] left-2 right-2 top-[calc(max(var(--app-safe-area-top-effective),0.5rem)+0.5rem)] flex min-h-0 origin-bottom-right flex-col overflow-hidden rounded-lg border border-border/70 bg-background/95 shadow-2xl backdrop-blur-xl transition-[border-radius,filter,opacity,transform] duration-[360ms] ease-[cubic-bezier(0.22,1,0.36,1)] will-change-transform motion-reduce:transform-none motion-reduce:transition-none sm:left-4 sm:right-4 lg:left-auto lg:right-4 lg:w-[min(72rem,calc(100vw-2rem))]",
+              "pointer-events-auto fixed flex min-h-0 origin-bottom-right flex-col overflow-hidden border border-border/70 bg-background/95 shadow-2xl backdrop-blur-xl transition-[border-radius,filter,height,opacity,transform,width] duration-[360ms] ease-[cubic-bezier(0.22,1,0.36,1)] will-change-transform motion-reduce:transform-none motion-reduce:transition-none",
+              isFullscreen
+                ? "inset-0 rounded-none"
+                : "bottom-[calc(max(var(--app-safe-area-bottom-effective),0.5rem)+0.5rem)] right-2 h-[min(var(--agent-popover-height),calc(100dvh-1rem))] w-[min(var(--agent-popover-width),calc(100vw-1rem))] rounded-lg max-sm:inset-0 max-sm:h-auto max-sm:w-auto max-sm:rounded-none sm:right-4 sm:h-[min(var(--agent-popover-height),calc(100dvh-2rem))] sm:w-[min(var(--agent-popover-width),calc(100vw-2rem))]",
               expanded
                 ? "translate-x-0 translate-y-0 scale-100 opacity-100 blur-0"
                 : "pointer-events-none translate-x-3 translate-y-[calc(100%-5.75rem)] scale-[0.2] opacity-0 blur-sm",
               isCollapsing && "rounded-2xl ring-1 ring-primary/25"
             )}
+            style={panelStyle}
             role="dialog"
             aria-label="Agent"
             aria-modal={false}
@@ -170,8 +334,32 @@ function AgentPopoverSurface() {
               minimizeAgent();
             }}
           >
+            {!isFullscreen ? (
+              <Button
+                type="button"
+                variant="secondary"
+                size="icon-xs"
+                className="absolute left-2 top-2 z-20 hidden cursor-nwse-resize touch-none rounded-md border border-border/70 bg-background/90 text-muted-foreground shadow-sm backdrop-blur sm:inline-flex"
+                onPointerDown={handleResizePointerDown}
+                onPointerMove={handleResizePointerMove}
+                onPointerUp={handleResizePointerEnd}
+                onPointerCancel={handleResizePointerEnd}
+                aria-label="Resize Agent"
+                title="Drag to resize Agent"
+              >
+                <Grip className="h-3.5 w-3.5" />
+              </Button>
+            ) : null}
             <AgentChatWorkspace
               variant="popover"
+              windowControls={
+                <AgentPopoverWindowControls
+                  sizeMode={sizeMode}
+                  setSizeMode={setSizeMode}
+                  onMinimize={minimizeAgent}
+                  onClose={minimizeAgent}
+                />
+              }
               onMinimize={minimizeAgent}
               onNavigationActionComplete={handleNavigationActionComplete}
             />
@@ -205,5 +393,65 @@ function AgentPopoverSurface() {
 
       <AgentVoiceFloatingIndicator onClick={openAgent} />
     </>
+  );
+}
+
+function AgentPopoverWindowControls({
+  sizeMode,
+  setSizeMode,
+  onMinimize,
+  onClose,
+}: {
+  sizeMode: AgentPopoverSizeMode;
+  setSizeMode: (mode: AgentPopoverSizeMode) => void;
+  onMinimize: () => void;
+  onClose: () => void;
+}) {
+  const isFullscreen = sizeMode === "fullscreen";
+
+  return (
+    <div
+      className="hidden h-8 overflow-hidden rounded-md border border-white/10 bg-white/[0.03] sm:flex"
+      aria-label="Agent window controls"
+      role="group"
+    >
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        className="h-8 w-10 rounded-none text-zinc-400 hover:bg-white/[0.08] hover:text-zinc-100 focus-visible:ring-2 focus-visible:ring-primary/60"
+        onClick={onMinimize}
+        aria-label="Minimize Agent"
+        title="Minimize Agent"
+      >
+        <Minus className="h-3.5 w-3.5" />
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        className="h-8 w-10 rounded-none text-zinc-400 hover:bg-white/[0.08] hover:text-zinc-100 focus-visible:ring-2 focus-visible:ring-primary/60"
+        onClick={() => setSizeMode(isFullscreen ? "large" : "fullscreen")}
+      aria-label={isFullscreen ? "Restore Agent" : "Maximize Agent"}
+      title={isFullscreen ? "Restore Agent" : "Maximize Agent"}
+    >
+        {isFullscreen ? (
+          <Minimize2 className="h-3.5 w-3.5" />
+        ) : (
+          <Maximize2 className="h-3.5 w-3.5" />
+        )}
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        className="h-8 w-10 rounded-none text-zinc-400 hover:bg-red-500/85 hover:text-white focus-visible:ring-2 focus-visible:ring-red-400/70"
+        onClick={onClose}
+        aria-label="Close Agent"
+        title="Close Agent"
+      >
+        <X className="h-3.5 w-3.5" />
+      </Button>
+    </div>
   );
 }

--- a/hushh-webapp/components/agent/agent-screen.tsx
+++ b/hushh-webapp/components/agent/agent-screen.tsx
@@ -7,8 +7,8 @@ import { AgentChatWorkspace } from "@/components/agent/agent-chat-workspace";
 export function AgentScreen() {
   return (
     <AppPageShell
-      width="expanded"
-      className="px-[var(--page-inline-gutter-standard)] py-[var(--page-block-padding)]"
+      width="wide"
+      className="!max-w-none !px-0 !py-0"
       nativeTest={{
         routeId: "/agent",
         marker: "native-route-agent",

--- a/hushh-webapp/lib/agent/agent-popover-layout.ts
+++ b/hushh-webapp/lib/agent/agent-popover-layout.ts
@@ -1,0 +1,62 @@
+export type AgentPopoverSizeMode = "fullscreen" | "large" | "compact" | "custom";
+
+export type AgentPopoverSize = {
+  width: number;
+  height: number;
+};
+
+export const AGENT_POPOVER_DEFAULT_SIZE_MODE: AgentPopoverSizeMode = "fullscreen";
+
+export const AGENT_POPOVER_PRESET_SIZES: Record<Exclude<AgentPopoverSizeMode, "fullscreen" | "custom">, AgentPopoverSize> = {
+  compact: {
+    width: 520,
+    height: 620,
+  },
+  large: {
+    width: 1120,
+    height: 760,
+  },
+};
+
+export const AGENT_POPOVER_STORAGE_KEYS = {
+  mode: "hushh.agent.popover.sizeMode",
+  customSize: "hushh.agent.popover.customSize",
+} as const;
+
+export function isAgentPopoverSizeMode(value: unknown): value is AgentPopoverSizeMode {
+  return value === "fullscreen" || value === "large" || value === "compact" || value === "custom";
+}
+
+export function getAgentPopoverViewportBounds(viewportWidth: number, viewportHeight: number) {
+  const maxWidth = Math.max(320, viewportWidth - 32);
+  const maxHeight = Math.max(360, viewportHeight - 32);
+
+  return {
+    minWidth: Math.min(420, maxWidth),
+    maxWidth,
+    minHeight: Math.min(520, maxHeight),
+    maxHeight,
+  };
+}
+
+export function clampAgentPopoverSize(
+  size: AgentPopoverSize,
+  viewportWidth: number,
+  viewportHeight: number
+): AgentPopoverSize {
+  const bounds = getAgentPopoverViewportBounds(viewportWidth, viewportHeight);
+  return {
+    width: Math.round(Math.min(bounds.maxWidth, Math.max(bounds.minWidth, size.width))),
+    height: Math.round(Math.min(bounds.maxHeight, Math.max(bounds.minHeight, size.height))),
+  };
+}
+
+export function resolveAgentPopoverSize(
+  mode: AgentPopoverSizeMode,
+  customSize: AgentPopoverSize
+): AgentPopoverSize {
+  if (mode === "compact" || mode === "large") {
+    return AGENT_POPOVER_PRESET_SIZES[mode];
+  }
+  return customSize;
+}


### PR DESCRIPTION
## Summary
- Redesign the `/agent` chat surface into a cleaner ChatGPT-style dark interface.
- Add a desktop history rail, mobile off-canvas drawer, compact Agent header, readable message layout, and pill composer.
- Replace the Agent popover sizing cluster with subtle Windows-style minimize / maximize-restore / close controls.

## Validation
- `npm run typecheck`
- `npx eslint components/agent/agent-chat-workspace.tsx components/agent/agent-history-sidebar.tsx components/agent/agent-popover-provider.tsx components/agent/agent-screen.tsx`
- `npm run test -- __tests__/services/agent-chat-client.test.ts __tests__/services/agent-voice-client.test.ts __tests__/lib/agent-popover-layout.test.ts __tests__/lib/agent-voice-turn.test.ts __tests__/lib/agent-voice-tts.test.ts`
- Playwright viewport checks via system Chrome for desktop 1440x900, iPhone 14 Pro Max 430x932, and narrow mobile 375x812

## Notes
- Left the unrelated local backup tarball untracked.
- Pushed to a fresh branch because `origin/kai-voice-level3` had diverged; this avoids overwriting remote work.