### PR TITLE
fix(frontend): replace useLayoutEffect with useEffect to prevent SSR hydration warnings

### DIFF
--- a/hushh-webapp/components/app-ui/top-shell-dropdown.tsx
+++ b/hushh-webapp/components/app-ui/top-shell-dropdown.tsx
@@ -69,7 +69,7 @@ export function TopShellDropdownContent({
     number | undefined
   >(undefined);
 
-  React.useLayoutEffect(() => {
+  React.useEffect(() => {
     if (!isMobile) {
       setMobileAlignOffset(undefined);
       return;

--- a/hushh-webapp/components/kai/kai-search-bar.tsx
+++ b/hushh-webapp/components/kai/kai-search-bar.tsx
@@ -4,7 +4,6 @@ import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import {
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -1147,7 +1146,7 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
     stopMeterRef.current = stop;
   }, [stop]);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     const root = document.documentElement;
     const update = () => {
       const barHeight = barRef.current?.getBoundingClientRect().height ?? 40;

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -53,7 +53,7 @@ export const Navbar = () => {
 
   const busyOperations = useKaiSession((s) => s.busyOperations);
 
-  React.useLayoutEffect(() => {
+  React.useEffect(() => {
     const el = pillRef.current;
     if (!el) return;
 

--- a/hushh-webapp/components/vault/vault-flow.tsx
+++ b/hushh-webapp/components/vault/vault-flow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef, useLayoutEffect } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { Capacitor } from "@capacitor/core";
 import { Button, Card, CardContent } from "@/lib/morphy-ux/morphy";
 import {
@@ -256,7 +256,7 @@ export function VaultFlow({
     checkStatus();
   }, [nativeTestConfig.vaultPassphrase, shouldPreferPassphraseUnlock, user.uid]);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (step !== "unlock") {
       return;
     }


### PR DESCRIPTION
# Description

Replaced `useLayoutEffect` with `useEffect` across multiple frontend components to eliminate React hydration warnings during Server-Side Rendering (SSR). `useLayoutEffect` does nothing on the server and generates console warnings in Next.js. Since these effects only measure the DOM or sync state on the client side after the initial paint, using `useEffect` is the standard and safe approach for SSR compatibility.

Before requesting review, read
[`docs/reference/quality/pr-contributor-readiness.md`](docs/reference/quality/pr-contributor-readiness.md).
Green CI is intake only; merge readiness also requires a reachable attach point,
production-code proof, and a title/body that match the diff.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None (Component-level fixes affecting multiple routes)

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] Reachable production attach point: `components/navbar.tsx`, `components/app-ui/top-shell-dropdown.tsx`, `components/kai/kai-search-bar.tsx`, `components/vault/vault-flow.tsx`
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

Every cross-platform feature must cover all affected layers or explicitly mark
the layer as not applicable with the reason.

- [x] **Web**: Next.js implementation (`app/api/...`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

N/A (Under-the-hood SSR console warning fix)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none