### PR TITLE
fix(frontend): enforce strict noopener noreferrer security on external marketplace link

### DIFF
--- a/hushh-webapp/app/marketplace/ria/page-client.tsx
+++ b/hushh-webapp/app/marketplace/ria/page-client.tsx
@@ -308,7 +308,7 @@ export default function MarketplaceRiaProfilePageClient() {
                 <a
                   href={profile.disclosures_url}
                   target="_blank"
-                  rel="noreferrer"
+                  rel="noopener noreferrer"
                   data-voice-control-id="marketplace_ria_public_disclosure"
                   className="inline-flex min-h-11 items-center justify-center rounded-full border border-border bg-background px-4 text-sm font-medium text-foreground"
                 >


### PR DESCRIPTION
# Description

Updated an external link in `app/marketplace/ria/page-client.tsx` to use `rel="noopener noreferrer"` instead of just `rel="noreferrer"`. While modern browsers often treat `noreferrer` safely, explicitly including `noopener` is the industry standard practice for all `target="_blank"` links to ensure complete protection against cross-origin `window.opener` exploits across all browser versions.

Before requesting review, read
[`docs/reference/quality/pr-contributor-readiness.md`](docs/reference/quality/pr-contributor-readiness.md).
Green CI is intake only; merge readiness also requires a reachable attach point,
production-code proof, and a title/body that match the diff.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `/marketplace/ria`

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] Reachable production attach point: `app/marketplace/ria/page-client.tsx`
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

Every cross-platform feature must cover all affected layers or explicitly mark
the layer as not applicable with the reason.

- [x] **Web**: Next.js implementation (`app/api/...`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

N/A (Under-the-hood security attribute fix)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none