### PR TITLE
fix(frontend): add explicit htmlFor and id pairs to inputs in plaid brokerage sections for accessibility

### DIFF
--- a/hushh-webapp/components/kai/plaid/plaid-brokerage-sections.tsx
+++ b/hushh-webapp/components/kai/plaid/plaid-brokerage-sections.tsx
@@ -725,9 +725,10 @@ export function PlaidFundingTransfersSection({
           {isFundingPanelOpen ? (
             <div className="rounded-[20px] border border-border/60 bg-background/60 p-4">
               <div className="grid gap-3 sm:grid-cols-2">
-                <label className="space-y-1 text-xs text-muted-foreground">
+                <label htmlFor="funding-account" className="space-y-1 text-xs text-muted-foreground">
                   Funding account
                   <select
+                    id="funding-account"
                     className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground"
                     value={selectedFundingAccountId}
                     onChange={(event) => {
@@ -750,9 +751,10 @@ export function PlaidFundingTransfersSection({
                 </label>
 
                 {brokerageAccountOptions.length > 0 ? (
-                  <label className="space-y-1 text-xs text-muted-foreground">
+                  <label htmlFor="brokerage-account" className="space-y-1 text-xs text-muted-foreground">
                     Alpaca brokerage destination
                     <select
+                      id="brokerage-account"
                       className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground"
                       value={selectedBrokerageAccountId}
                       onChange={(event) => setSelectedBrokerageAccountId(event.target.value)}
@@ -784,9 +786,10 @@ export function PlaidFundingTransfersSection({
                   </div>
                 )}
 
-                <label className="space-y-1 text-xs text-muted-foreground">
+                <label htmlFor="transfer-direction" className="space-y-1 text-xs text-muted-foreground">
                   Transfer direction
                   <select
+                    id="transfer-direction"
                     className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground"
                     value={transferDirection}
                     onChange={(event) =>
@@ -798,9 +801,10 @@ export function PlaidFundingTransfersSection({
                   </select>
                 </label>
 
-                <label className="space-y-1 text-xs text-muted-foreground">
+                <label htmlFor="transfer-amount" className="space-y-1 text-xs text-muted-foreground">
                   Amount (USD)
                   <input
+                    id="transfer-amount"
                     className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground"
                     value={amountInput}
                     onChange={(event) => setAmountInput(event.target.value)}
@@ -822,9 +826,10 @@ export function PlaidFundingTransfersSection({
                   </div>
                 </label>
 
-                <label className="space-y-1 text-xs text-muted-foreground">
+                <label htmlFor="legal-name" className="space-y-1 text-xs text-muted-foreground">
                   Legal name
                   <input
+                    id="legal-name"
                     className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground"
                     value={legalNameInput}
                     onChange={(event) => setLegalNameInput(event.target.value)}
@@ -983,27 +988,30 @@ export function PlaidFundingTransfersSection({
             Search transfer records and create a manual escalation with notes for operations.
           </p>
           <div className="mt-3 grid gap-3 sm:grid-cols-2">
-            <label className="space-y-1 text-xs text-muted-foreground">
+            <label htmlFor="support-transfer-id" className="space-y-1 text-xs text-muted-foreground">
               Transfer ID
               <input
+                id="support-transfer-id"
                 className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground"
                 value={supportTransferId}
                 onChange={(event) => setSupportTransferId(event.target.value)}
                 placeholder="Optional transfer ID"
               />
             </label>
-            <label className="space-y-1 text-xs text-muted-foreground">
+            <label htmlFor="support-relationship-id" className="space-y-1 text-xs text-muted-foreground">
               Relationship ID
               <input
+                id="support-relationship-id"
                 className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground"
                 value={supportRelationshipId}
                 onChange={(event) => setSupportRelationshipId(event.target.value)}
                 placeholder="Optional relationship ID"
               />
             </label>
-            <label className="space-y-1 text-xs text-muted-foreground">
+            <label htmlFor="support-severity" className="space-y-1 text-xs text-muted-foreground">
               Escalation severity
               <select
+                id="support-severity"
                 className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground"
                 value={supportSeverity}
                 onChange={(event) =>
@@ -1018,9 +1026,10 @@ export function PlaidFundingTransfersSection({
                 <option value="urgent">Urgent</option>
               </select>
             </label>
-            <label className="space-y-1 text-xs text-muted-foreground">
+            <label htmlFor="support-notes" className="space-y-1 text-xs text-muted-foreground">
               Escalation notes
               <input
+                id="support-notes"
                 className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground"
                 value={supportNotes}
                 onChange={(event) => setSupportNotes(event.target.value)}


### PR DESCRIPTION
# Description

Added explicit `id` and `htmlFor` pairings to the 9 inputs and selects inside `components/kai/plaid/plaid-brokerage-sections.tsx`. While the inputs were implicitly associated by being nested inside `<label>` tags, providing explicit ID associations adheres to stricter a11y guidelines, ensures robust compatibility with all screen readers, and resolves widespread linting warnings.

Before requesting review, read
[`docs/reference/quality/pr-contributor-readiness.md`](docs/reference/quality/pr-contributor-readiness.md).
Green CI is intake only; merge readiness also requires a reachable attach point,
production-code proof, and a title/body that match the diff.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None (Component-level accessibility fix)

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] Reachable production attach point: `components/kai/plaid/plaid-brokerage-sections.tsx`
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

Every cross-platform feature must cover all affected layers or explicitly mark
the layer as not applicable with the reason.

- [x] **Web**: Next.js implementation (`app/api/...`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

N/A (Under-the-hood accessibility fix)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none