### PR TITLE
fix(frontend): add aria-label to consent center search input for accessibility

### DIFF
--- a/hushh-webapp/components/consent/consent-center-page.tsx
+++ b/hushh-webapp/components/consent/consent-center-page.tsx
@@ -1160,6 +1160,7 @@ export function ConsentCenterPage() {
                     placeholder={searchPlaceholder}
                     className="pl-9"
                     data-voice-control-id="consent_search"
+                    aria-label="Search consents"
                   />
                 </div>
                 {visibleSnapshot ? (


### PR DESCRIPTION
### Description
This PR addresses an accessibility bug in the Consent Center page where the search `<Input>` lacked an accessible name. An `aria-label="Search consents"` has been added to ensure screen readers correctly announce the input's purpose rather than reading it as a generic text edit field. 

### Changes
- **`hushh-webapp/components/consent/consent-center-page.tsx`**: Added an `aria-label` attribute to the search input field.