### PR TITLE
fix(popup-text-editor-field): associate accessible label with textarea

### DIFF
--- a/hushh-webapp/components/app-ui/command-fields.tsx
+++ b/hushh-webapp/components/app-ui/command-fields.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useDeferredValue, useEffect, useMemo, useState, type ReactNode } from "react";
+import { useDeferredValue, useEffect, useId, useMemo, useState, type ReactNode } from "react";
 import { Check, ChevronsUpDown, FilePenLine, X } from "lucide-react";
 
 import {
@@ -265,6 +265,7 @@ export function PopupTextEditorField({
 }) {
   const [open, setOpen] = useState(false);
   const [draft, setDraft] = useState(value);
+  const textareaId = useId();
 
   useEffect(() => {
     if (open) {
@@ -320,7 +321,12 @@ export function PopupTextEditorField({
           </DialogHeader>
 
           <div className="overflow-y-auto px-4 py-4 sm:px-5">
+            <label htmlFor={textareaId} className="sr-only">
+              {typeof title === "string" ? title : placeholder}
+            </label>
+
             <Textarea
+              id={textareaId}
               value={draft}
               onChange={(event) => setDraft(event.target.value)}
               placeholder={placeholder}


### PR DESCRIPTION
## Summary

Associate a programmatically accessible label with the textarea used by `PopupTextEditorField`.

## Problem

`PopupTextEditorField` renders a textarea inside a dialog but the textarea does not have a programmatically associated accessible name.

The component currently relies on placeholder text, which is not a sufficient replacement for a label and may not be consistently announced by assistive technologies.

As a result, screen reader users can encounter an unlabeled form control when editing text through the popup editor.

## Solution

Add a stable textarea identifier using React `useId()` and associate a visually hidden label with the textarea.

Changes:

* Import `useId` from React
* Generate `textareaId` using `useId()`
* Add an `sr-only` label linked via `htmlFor`
* Add `id={textareaId}` to the textarea

The label text uses:

```tsx
typeof title === "string" ? title : placeholder
```

to provide a meaningful accessible name while preserving existing behavior.

## Changes

File:

* `hushh-webapp/components/app-ui/command-fields.tsx`

## Impact

* No visual changes
* No behavior changes
* No API changes
* Improves screen reader accessibility

## Accessibility

Provides a programmatically associated label for the popup textarea.

WCAG 1.3.1 — Info and Relationships

## Risk

Low. Additive accessibility enhancement only.
