### PR TITLE
fix(marketplace): use Pydantic v2 model_dump in contacts match handler

### DIFF
--- a/consent-protocol/api/routes/marketplace.py
+++ b/consent-protocol/api/routes/marketplace.py
@@ -164,7 +164,7 @@ async def match_marketplace_contacts(
     try:
         items = await service.match_marketplace_contacts(
             firebase_uid,
-            phone_lookups=[item.dict() for item in payload.phone_lookups],
+            phone_lookups=[item.model_dump() for item in payload.phone_lookups],
             limit=payload.limit,
         )
         return {"items": items}

--- a/consent-protocol/tests/test_marketplace_contacts_match.py
+++ b/consent-protocol/tests/test_marketplace_contacts_match.py
@@ -1,0 +1,105 @@
+"""Route-level tests for POST /api/marketplace/contacts/match.
+
+The handler serializes each MarketplaceContactLookup before handing it to
+RIAIAMService.match_marketplace_contacts, which reads item["hash"] and
+item["last4"] from plain dicts. These tests drive the live marketplace
+router through TestClient and assert:
+
+1. The handler forwards the lookups to the service as a list of dicts with
+   the expected keys, so the service contract keeps working.
+2. The serialized items are produced via the Pydantic v2 model_dump API
+   (no deprecated v1 dict call is emitted on this path).
+3. The authenticated firebase uid and limit are forwarded unchanged.
+
+Canonical attach:
+  api/routes/marketplace.py  -- match_marketplace_contacts handler
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routes import marketplace
+
+USER_ID = "user_abc"
+VALID_HASH = "a" * 64
+VALID_LAST4 = "1234"
+
+
+class _CapturingRIAIAMService:
+    """Stand-in service that records what the route forwards."""
+
+    last_call: dict = {}
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def match_marketplace_contacts(self, user_id, *, phone_lookups, limit):
+        _CapturingRIAIAMService.last_call = {
+            "user_id": user_id,
+            "phone_lookups": phone_lookups,
+            "limit": limit,
+        }
+        return [{"user_id": "match_1", "phone_number": "+15551234567"}]
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setattr(marketplace, "RIAIAMService", _CapturingRIAIAMService)
+
+    app = FastAPI()
+    app.include_router(marketplace.router)
+    app.dependency_overrides[marketplace.require_firebase_auth] = lambda: USER_ID
+    return TestClient(app)
+
+
+def test_contacts_match_forwards_lookups_as_dicts(client):
+    response = client.post(
+        "/api/marketplace/contacts/match",
+        json={
+            "phone_lookups": [{"hash": VALID_HASH, "last4": VALID_LAST4}],
+            "limit": 25,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"items": [{"user_id": "match_1", "phone_number": "+15551234567"}]}
+
+    call = _CapturingRIAIAMService.last_call
+    assert call["user_id"] == USER_ID
+    assert call["limit"] == 25
+    assert call["phone_lookups"] == [{"hash": VALID_HASH, "last4": VALID_LAST4}]
+    # Each forwarded lookup must be a plain dict the service can index into.
+    assert all(isinstance(item, dict) for item in call["phone_lookups"])
+    assert call["phone_lookups"][0]["hash"] == VALID_HASH
+    assert call["phone_lookups"][0]["last4"] == VALID_LAST4
+
+
+def test_contacts_match_emits_no_pydantic_deprecation(client):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        response = client.post(
+            "/api/marketplace/contacts/match",
+            json={
+                "phone_lookups": [{"hash": VALID_HASH, "last4": VALID_LAST4}],
+                "limit": 10,
+            },
+        )
+
+    assert response.status_code == 200
+
+
+def test_contacts_match_rejects_malformed_hash(client):
+    response = client.post(
+        "/api/marketplace/contacts/match",
+        json={
+            "phone_lookups": [{"hash": "tooshort", "last4": VALID_LAST4}],
+            "limit": 10,
+        },
+    )
+
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary

The marketplace contacts match handler serialized request models with the deprecated Pydantic v1 `.dict()` API. This switches to `.model_dump()` and adds the first route level test coverage for the endpoint.

## What the bug is

`POST /api/marketplace/contacts/match` builds the service payload with `[item.dict() for item in payload.phone_lookups]`. The project runs Pydantic v2, where `.dict()` is deprecated (`PydanticDeprecatedSince20`, a `DeprecationWarning` subclass) and scheduled for removal in v3. On this path it emits deprecation warnings and will break outright on a future Pydantic upgrade.

## Where it lives

consent-protocol/api/routes/marketplace.py, `match_marketplace_contacts` handler (the `phone_lookups` serialization line).

## What the fix does

- Replaces `item.dict()` with `item.model_dump()`. The output keeps the same `hash` and `last4` keys that `RIAIAMService.match_marketplace_contacts` reads via `item.get(...)`, so behavior is identical.
- Removes the deprecation warning and keeps the path forward compatible with Pydantic v3.

## Reachability

The endpoint is mounted on the live marketplace router (prefix `/api/marketplace`) and gated by `require_firebase_auth`. A client posts a list of phone lookups; the handler serializes them and forwards them to `RIAIAMService.match_marketplace_contacts`. The new tests reach the handler through FastAPI TestClient against the real router.

## How to verify

```
cd consent-protocol
.venv/bin/python -m pytest tests/test_marketplace_contacts_match.py -v
```

Three tests pass. One asserts the lookups are forwarded as plain dicts with the expected keys and that the authenticated uid and limit pass through unchanged. One runs the request under `warnings.simplefilter("error", DeprecationWarning)` and passes only because no Pydantic deprecation is emitted; the same test fails against the old `.dict()` code, which raises `PydanticDeprecatedSince20`. One asserts a malformed 64 char hash is rejected with 422. Ruff is clean on both files.

## Path to merge

- Base: integration/pr-train (direct PRs into main are blocked by repo policy)
- Branch: fix/marketplace-pydantic-model-dump
- Built on current main, no conflicts
- Blocker: requires `CI Status Gate` green and one maintainer approval
- Expected action: review of the model_dump swap and the new marketplace test coverage