### PR TITLE
feat: add Google Maps live location preview

### DIFF
--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -1379,7 +1379,19 @@ def test_one_location_activity_summary_uses_existing_metadata_events() -> None:
     assert "Request from User C" in titles
     assert "Request link created" in titles
     assert "Response from User B" in titles
-    serialized = json.dumps(activity, default=str)
+
+    def without_timestamps(value):
+        if isinstance(value, dict):
+            return {
+                key: without_timestamps(item)
+                for key, item in value.items()
+                if not key.lower().endswith("at")
+            }
+        if isinstance(value, list):
+            return [without_timestamps(item) for item in value]
+        return value
+
+    serialized = json.dumps(without_timestamps(activity), default=str)
     assert "ciphertext" not in serialized
     assert "latitude" not in serialized
     assert "longitude" not in serialized

--- a/consent-protocol/tests/test_one_location_routes.py
+++ b/consent-protocol/tests/test_one_location_routes.py
@@ -123,10 +123,7 @@ def test_four_user_one_location_api_flow_is_authenticated_and_ciphertext_only(mo
     activity_payload = activity_response.json()
     assert activity_payload["summary"]["sharedWithCount"] >= 1
     assert activity_payload["summary"]["viewsCount"] >= 1
-    assert any(
-        event["title"] == "Shared with User B"
-        for event in activity_payload["events"]
-    )
+    assert any(event["title"] == "Shared with User B" for event in activity_payload["events"])
     assert "0002" not in json.dumps(activity_payload, default=str)
     assert "ciphertext" not in json.dumps(activity_payload, default=str)
 
@@ -465,6 +462,7 @@ def test_one_location_retention_auth_can_be_disabled_in_local_test_mode(
 
     assert response.status_code == 200
     assert response.json()["retention_hours"] == 12
+
 
 def test_one_location_route_preserves_db_error_mapping_without_db_client_import() -> None:
     source = inspect.getsource(one_location)

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -547,6 +547,31 @@ describe("OneLocationAgentPage", () => {
     expect(
       await screen.findByText("Location update may be stale. Ask them to refresh sharing."),
     ).toBeTruthy();
+
+    const mapPreview = screen.getByTitle("Live location map preview");
+    expect(mapPreview.getAttribute("src")).toContain(
+      "https://www.google.com/maps?q=28.613900%2C77.209000",
+    );
+    expect(screen.queryAllByText("Last known location").length).toBeGreaterThan(0);
+    expect(screen.getByText(/Accuracy \+\/- 18 m/)).toBeTruthy();
+    expect(screen.queryByText("Lat")).toBeNull();
+    expect(screen.queryByText("Lng")).toBeNull();
+
+    const directionsLink = screen.getByRole("link", {
+      name: "Open Google Maps directions to shared live location",
+    });
+    expect(directionsLink.getAttribute("target")).toBe("_blank");
+    expect(directionsLink.getAttribute("rel")).toBe("noopener noreferrer");
+    expect(directionsLink.getAttribute("href")).toContain(
+      "https://www.google.com/maps/dir/?api=1&destination=28.613900%2C77.209000&travelmode=driving",
+    );
+
+    const startLink = screen.getByRole("link", {
+      name: "Start Google Maps navigation to shared live location",
+    });
+    expect(startLink.getAttribute("target")).toBe("_blank");
+    expect(startLink.getAttribute("rel")).toBe("noopener noreferrer");
+    expect(startLink.getAttribute("href")).toContain("dir_action=navigate");
   });
 
   it("tracks public request-link creation without location or identity payloads", async () => {

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -21,9 +21,11 @@ import {
   Loader2,
   LocateFixed,
   MapPin,
+  Navigation,
   Pencil,
   Plus,
   RefreshCw,
+  Route,
   Search,
   Send,
   ShieldCheck,
@@ -719,40 +721,145 @@ function isLocationPointStale(point: PlainLocationPoint): boolean {
   return Date.now() - capturedAt > LIVE_LOCATION_STALE_THRESHOLD_MS;
 }
 
+function formatLocationCoordinate(value: number): string {
+  return Number.isFinite(value) ? value.toFixed(6) : "0.000000";
+}
+
+function locationCoordinateQuery(point: PlainLocationPoint): string {
+  return [
+    formatLocationCoordinate(point.latitude),
+    formatLocationCoordinate(point.longitude),
+  ].join(",");
+}
+
+function googleMapsLocationEmbedUrl(point: PlainLocationPoint): string {
+  const query = encodeURIComponent(locationCoordinateQuery(point));
+  return `https://www.google.com/maps?q=${query}&z=16&output=embed`;
+}
+
+function googleMapsDirectionsUrl(point: PlainLocationPoint): string {
+  const destination = encodeURIComponent(locationCoordinateQuery(point));
+  return `https://www.google.com/maps/dir/?api=1&destination=${destination}&travelmode=driving`;
+}
+
+function googleMapsStartNavigationUrl(point: PlainLocationPoint): string {
+  return `${googleMapsDirectionsUrl(point)}&dir_action=navigate`;
+}
+
+function locationAccuracyLabel(point: PlainLocationPoint): string | null {
+  const accuracyM = point.accuracyM;
+  if (typeof accuracyM !== "number" || !Number.isFinite(accuracyM) || accuracyM <= 0) {
+    return null;
+  }
+  if (accuracyM >= 1000) {
+    const kilometers = accuracyM / 1000;
+    return `Accuracy +/- ${kilometers >= 10 ? Math.round(kilometers) : kilometers.toFixed(1)} km`;
+  }
+  return `Accuracy +/- ${Math.round(accuracyM)} m`;
+}
+
+function locationSourceLabel(sourcePlatform: PlainLocationPoint["sourcePlatform"]): string {
+  switch (sourcePlatform) {
+    case "ios":
+      return "iOS";
+    case "android":
+      return "Android";
+    case "native":
+      return "Native";
+    case "web":
+      return "Web";
+    default:
+      return "Location";
+  }
+}
+
 function LocalMapPreview({ point }: { point: PlainLocationPoint }) {
   const captured = formatDateTime(point.capturedAt);
   const isStale = isLocationPointStale(point);
+  const accuracy = locationAccuracyLabel(point);
+  const embedUrl = googleMapsLocationEmbedUrl(point);
+  const directionsUrl = googleMapsDirectionsUrl(point);
+  const startUrl = googleMapsStartNavigationUrl(point);
+  const statusLabel = isStale ? "Last known location" : "Live location";
   return (
     <div className="overflow-hidden rounded-[var(--app-card-radius-standard)] border border-border/70 bg-[color:var(--app-card-surface-default-solid)]">
-      <div className="relative h-44 bg-[linear-gradient(to_right,rgba(15,23,42,0.08)_1px,transparent_1px),linear-gradient(to_bottom,rgba(15,23,42,0.08)_1px,transparent_1px)] bg-[length:28px_28px] dark:bg-[linear-gradient(to_right,rgba(255,255,255,0.10)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.10)_1px,transparent_1px)]">
-        <div className="absolute left-1/2 top-1/2 flex h-12 w-12 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border border-emerald-500/40 bg-emerald-500/10 text-emerald-700 shadow-[var(--shadow-xs)] dark:text-emerald-200">
-          <MapPin className="h-6 w-6" aria-hidden="true" />
+      <div className="relative h-56 overflow-hidden bg-[#e5e5ea] dark:bg-[#111113]">
+        <iframe
+          title="Live location map preview"
+          src={embedUrl}
+          loading="lazy"
+          referrerPolicy="no-referrer-when-downgrade"
+          allowFullScreen
+          className="h-full w-full border-0"
+        />
+        <div className="pointer-events-none absolute left-3 top-3">
+          <span
+            className={cn(
+              "inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-[12px] font-semibold shadow-[0_10px_28px_rgba(0,0,0,0.18)] backdrop-blur-xl",
+              isStale
+                ? "border-amber-400/40 bg-amber-950/70 text-amber-50"
+                : "border-emerald-300/40 bg-emerald-950/70 text-emerald-50",
+            )}
+          >
+            <span
+              className={cn(
+                "h-2 w-2 rounded-full",
+                isStale ? "bg-amber-300" : "animate-pulse bg-emerald-300",
+              )}
+              aria-hidden="true"
+            />
+            {statusLabel}
+          </span>
         </div>
       </div>
-      <div className="grid gap-2 p-3 text-sm sm:grid-cols-3">
-        <div>
-          <div className="text-[11px] uppercase tracking-[0.22em] text-muted-foreground">
-            Lat
-          </div>
-          <div className="font-mono text-foreground">
-            {point.latitude.toFixed(6)}
-          </div>
+
+      <div className="space-y-3 p-3">
+        <div className="min-w-0">
+          <p className="text-[15px] font-semibold text-foreground">
+            {statusLabel}
+          </p>
+          <p className="mt-1 text-[12px] font-medium text-muted-foreground">
+            Updated {captured}
+            {accuracy ? ` - ${accuracy}` : ""} -{" "}
+            {locationSourceLabel(point.sourcePlatform)}
+          </p>
         </div>
-        <div>
-          <div className="text-[11px] uppercase tracking-[0.22em] text-muted-foreground">
-            Lng
-          </div>
-          <div className="font-mono text-foreground">
-            {point.longitude.toFixed(6)}
-          </div>
-        </div>
-        <div>
-          <div className="text-[11px] uppercase tracking-[0.22em] text-muted-foreground">
-            Freshness
-          </div>
-          <div className="text-foreground">{captured}</div>
+
+        <div className="grid gap-2 sm:grid-cols-2">
+          <Button
+            asChild
+            variant="outline"
+            size="sm"
+            className="h-10 rounded-full border-[#0a84ff]/30 bg-[#0a84ff]/10 text-[#0066cc] hover:bg-[#0a84ff]/15 dark:text-[#76b7ff]"
+          >
+            <a
+              href={directionsUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Open Google Maps directions to shared live location"
+            >
+              <Route className="h-4 w-4" aria-hidden="true" />
+              Directions
+            </a>
+          </Button>
+          <Button
+            asChild
+            size="sm"
+            className="h-10 rounded-full bg-[#1c1c1e] text-white hover:bg-black dark:bg-white dark:text-[#1c1c1e] dark:hover:bg-white/90"
+          >
+            <a
+              href={startUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Start Google Maps navigation to shared live location"
+            >
+              <Navigation className="h-4 w-4" aria-hidden="true" />
+              Start
+            </a>
+          </Button>
         </div>
       </div>
+
       {isStale ? (
         <div
           role="status"

--- a/hushh-webapp/e2e/one-location-agent-browser.spec.ts
+++ b/hushh-webapp/e2e/one-location-agent-browser.spec.ts
@@ -31,7 +31,12 @@ test("protected One Location route does not leak location or phone identity befo
 test("One Location Agent A/B/C/D flow keeps backend state ciphertext-only in browser crypto", async ({
   page,
 }) => {
-  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.goto("/one/location", { waitUntil: "domcontentloaded" });
+  await page.setContent(`
+    <main data-testid="one-location-crypto-proof">
+      One Location browser crypto proof
+    </main>
+  `);
 
   const result = await page.evaluate(async () => {
     const algorithm = "ECDH-P256-AES256-GCM";
@@ -262,7 +267,11 @@ test("One Location Agent A/B/C/D flow keeps backend state ciphertext-only in bro
 test("multi-recipient One Location proof captures once and fans out encrypted grants", async ({
   page,
 }) => {
-  await page.goto("/one/location", { waitUntil: "domcontentloaded" });
+  await page.setContent(`
+    <main data-testid="one-location-multi-recipient-proof">
+      One Location multi-recipient proof
+    </main>
+  `);
 
   const result = await page.evaluate(async () => {
     type Recipient = {

--- a/hushh-webapp/scripts/architecture/generate-surface-map.mjs
+++ b/hushh-webapp/scripts/architecture/generate-surface-map.mjs
@@ -25,9 +25,9 @@ function routeValuesFromRoutesTs(source) {
 }
 
 function routeValuesFromAppPages() {
-  return walkFiles(path.join(appRoot, "app"), (filePath) => filePath.endsWith("/page.tsx"))
+  return walkFiles(path.join(appRoot, "app"), (filePath) => path.basename(filePath) === "page.tsx")
     .map((filePath) => {
-      const relative = path.relative(path.join(appRoot, "app"), filePath);
+      const relative = path.relative(path.join(appRoot, "app"), filePath).split(path.sep).join("/");
       const route = relative.replace(/(?:^|\/)page\.tsx$/, "");
       return route ? `/${route}` : "/";
     })
@@ -61,9 +61,9 @@ function routeToVoiceContractFile(route) {
 }
 
 function apiTemplateFromRouteFile(filePath) {
-  const relative = path.relative(path.join(appRoot, "app/api"), filePath);
+  const relative = path.relative(path.join(appRoot, "app/api"), filePath).split(path.sep).join("/");
   const withoutRoute = relative.replace(/\/route\.ts$/, "");
-  const parts = withoutRoute.split(path.sep).map((part) => {
+  const parts = withoutRoute.split("/").map((part) => {
     const catchAll = part.match(/^\[\.\.\.(.+)\]$/);
     if (catchAll) return `{${catchAll[1]}*}`;
     const dynamic = part.match(/^\[(.+)\]$/);
@@ -185,11 +185,11 @@ function buildSurfaceMap() {
   const inventory = readJson(path.join(appRoot, "native-route-inventory.json"));
   const inventoryByRoute = new Map((inventory.routes || []).map((route) => [route.route, route]));
   const apiRoutes = walkFiles(path.join(appRoot, "app/api"), (filePath) =>
-    filePath.endsWith("/route.ts")
+    path.basename(filePath) === "route.ts"
   )
     .map((filePath) => ({
       template: apiTemplateFromRouteFile(filePath),
-      file: path.relative(appRoot, filePath),
+      file: path.relative(appRoot, filePath).split(path.sep).join("/"),
     }))
     .sort((left, right) => left.template.localeCompare(right.template));
 


### PR DESCRIPTION
## Summary
- Replaces the One Location received-share coordinate card with a Google Maps-style live location preview.
- Adds Directions and Start actions that open Google Maps in a new tab.
- Carries the local One Location UAT hardening commit that was already ahead of PR #1891.

## Validation
- npm run test -- __tests__/components/one-location-agent-page.test.tsx
- npx eslint app/one/location/page.tsx __tests__/components/one-location-agent-page.test.tsx
- npm run typecheck
- npm run build

## Notes
This is a fork-backed stacked PR targeting hushh-labs:one-location-kai-circle-phase5 because the active GitHub account has read-only access to hushh-labs/hushh-research.