### PR TITLE
fix(shell-action-surface): improve badge accessibility contract

### DIFF
--- a/hushh-webapp/components/app-ui/shell-action-surface.tsx
+++ b/hushh-webapp/components/app-ui/shell-action-surface.tsx
@@ -81,6 +81,7 @@ export const ShellActionSurface = React.forwardRef<
       </button>
       {badge ? (
         <span
+          aria-hidden="true"
           className={cn(
             "pointer-events-none absolute right-0 top-0 z-20 translate-x-[24%] -translate-y-[22%]",
             badgeClassName

--- a/hushh-webapp/components/app-ui/top-app-bar.tsx
+++ b/hushh-webapp/components/app-ui/top-app-bar.tsx
@@ -523,7 +523,7 @@ export function TopAppBar({ className }: TopAppBarProps) {
                         renderTrigger={({ pendingCount }) => (
                           <ShellActionSurface
                             variant="icon"
-                            aria-label="Open consent inbox"
+                            aria-label={pendingCount > 0 ? `Open consent inbox, ${pendingCount} pending` : "Open consent inbox"}
                             badge={
                               pendingCount > 0 ? (
                                 <span className="inline-flex min-h-5 min-w-5 items-center justify-center rounded-full bg-sky-500 px-1 text-[10px] font-semibold leading-none text-white shadow-[0_8px_18px_rgba(14,165,233,0.32)] ring-2 ring-white/90 dark:ring-[#111113]">
@@ -542,7 +542,7 @@ export function TopAppBar({ className }: TopAppBarProps) {
                           renderTrigger={({ activeCount, badgeCount }) => (
                             <ShellActionSurface
                               variant="icon"
-                              aria-label="Notifications"
+                              aria-label={badgeCount > 0 ? `Notifications, ${badgeCount} unread` : "Notifications"}
                               badge={
                                 badgeCount > 0 ? (
                                   <span className="inline-flex min-h-5 min-w-5 items-center justify-center rounded-full bg-sky-500 px-1 text-[10px] font-semibold leading-none text-white shadow-[0_8px_18px_rgba(14,165,233,0.32)] ring-2 ring-white/90 dark:ring-[#111113]">


### PR DESCRIPTION
## Summary

Improve accessibility for badge-backed action buttons by hiding decorative badge overlays from assistive technologies and exposing badge counts through accessible names.

## Change

### `hushh-webapp/components/app-ui/shell-action-surface.tsx`

* Add `aria-hidden="true"` to the decorative badge wrapper

### `hushh-webapp/components/app-ui/top-app-bar.tsx`

* Announce pending consent counts through the consent inbox trigger label
* Announce unread notification counts through the notifications trigger label

Examples:

* `Open consent inbox, 3 pending`
* `Notifications, 2 unread`

When counts are zero, labels remain unchanged.

## Impact

* Improves screen reader announcements
* Prevents decorative badge content from being announced separately
* No visual changes
* No behavioral changes
* No API changes

## Accessibility

* WCAG 4.1.2 — Name, Role, Value
* Badge counts are conveyed through the control's accessible name
* Decorative badge overlays are hidden from assistive technologies

## Risk

LOW — additive accessibility enhancement only. No structural or behavioral changes.
