### PR TITLE
fix(page-sections): add aria-hidden to decorative dividers

### DIFF
--- a/hushh-webapp/components/app-ui/page-sections.tsx
+++ b/hushh-webapp/components/app-ui/page-sections.tsx
@@ -232,7 +232,7 @@ export function PageHeader({
           {description}
         </div>
       ) : null}
-      <div className={cn("h-px w-full", styles.divider)} />
+      <div className={cn("h-px w-full", styles.divider)} aria-hidden="true" />
     </header>
   );
 }
@@ -311,7 +311,7 @@ export function SectionHeader({
           </div>
         </div>
       </div>
-      <div className={cn("h-px w-full", styles.divider)} />
+      <div className={cn("h-px w-full", styles.divider)} aria-hidden="true" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Remove two purely decorative divider elements from the accessibility tree in `PageHeader` and `SectionHeader`.

## Problem

`PageHeader` and `SectionHeader` both render a 1px visual divider using an empty `<div>`.

These elements:

* Have no semantic meaning
* Are not interactive
* Exist solely for visual presentation

Without `aria-hidden`, assistive technologies may traverse these elements as empty unnamed content, creating unnecessary noise during navigation.

## Change

### `hushh-webapp/components/app-ui/page-sections.tsx`

* Add `aria-hidden="true"` to the decorative divider rendered by `PageHeader`
* Add `aria-hidden="true"` to the decorative divider rendered by `SectionHeader`

`aria-hidden` is preferred over `role="separator"` because these elements are purely decorative and should not introduce additional semantics.

## Impact

* Removes decorative elements from the accessibility tree
* Reduces screen reader traversal noise
* No visual changes
* No behavioral changes
* No API changes

## Accessibility

* WCAG 1.1.1 — Non-text Content
* Decorative content is hidden from assistive technologies

## Risk

LOW — additive accessibility enhancement only. No structural or behavioral changes.
