### PR TITLE
fix(top-app-bar): add live region to announce persona switch to screen readers

### DIFF
--- a/hushh-webapp/components/app-ui/top-app-bar.tsx
+++ b/hushh-webapp/components/app-ui/top-app-bar.tsx
@@ -576,6 +576,16 @@ export function TopAppBar({ className }: TopAppBarProps) {
           </div>
         </div>
       </div>
+      <span
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {switchingPersona
+          ? `Switching to ${switchingPersona === "ria" ? "RIA" : "Investor"}`
+          : ""}
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Add an ARIA live region to `TopAppBar` so screen reader users receive an announcement when persona switching begins.

## Problem

The persona switcher visually displays `"Switching to RIA"` or `"Switching to Investor"` while an async persona change is in progress. This feedback is visible to sighted users but is not announced to assistive technologies.

Because `aria-label` changes on a button do not automatically trigger announcements, screen reader users receive no indication that the switch is underway.

## Change

### `hushh-webapp/components/app-ui/top-app-bar.tsx`

Add an always-present, visually hidden live region:

* `role="status"`
* `aria-live="polite"`
* `aria-atomic="true"`
* `className="sr-only"`

The region announces:

* `Switching to RIA`
* `Switching to Investor`

when `switchingPersona` becomes non-null, and returns to an empty string when idle.

## Impact

* Announces persona switch progress to screen reader users
* Mirrors existing visual feedback exactly
* No visual changes
* No behavioral changes
* No API changes

## Accessibility

* WCAG 4.1.3 — Status Messages
* Uses the standard ARIA live region pattern for asynchronous status updates

## Risk

LOW — additive accessibility enhancement only. Uses existing state and introduces no new logic or dependencies.
