### PR TITLE
[codex] Improve Agent voice latency and sidebar

### DIFF
--- a/consent-protocol/hushh_mcp/services/agent_voice_service.py
+++ b/consent-protocol/hushh_mcp/services/agent_voice_service.py
@@ -117,7 +117,7 @@ class AgentVoiceService:
 
         config = genai_types.GenerateContentConfig(
             temperature=0.0,
-            max_output_tokens=256,
+            max_output_tokens=128,
             response_mime_type="application/json",
             response_schema=_TRANSCRIPTION_SCHEMA,
             automatic_function_calling=genai_types.AutomaticFunctionCallingConfig(disable=True),

--- a/hushh-webapp/__tests__/lib/agent-voice-tts.test.ts
+++ b/hushh-webapp/__tests__/lib/agent-voice-tts.test.ts
@@ -89,6 +89,35 @@ describe("agent voice TTS", () => {
     await vi.waitFor(() => expect(playAudio).toHaveBeenCalledTimes(1));
   });
 
+  it("uses browser speech fallback when backend TTS does not return audio", async () => {
+    const synthesize = vi.fn().mockResolvedValue(new Response("unavailable", { status: 503 }));
+    const playAudio = vi.fn().mockResolvedValue(undefined);
+    const fallbackSpeak = vi.fn().mockResolvedValue(undefined);
+    const onError = vi.fn();
+    const queue = new AgentTtsQueue({
+      userId: "user-1",
+      vaultOwnerToken: "vault-token",
+      synthesize,
+      playAudio,
+      fallbackSpeak,
+      onError,
+      maxAttempts: 1,
+    });
+
+    queue.speakNow("Fallback sentence.");
+
+    await vi.waitFor(() => expect(fallbackSpeak).toHaveBeenCalledTimes(1));
+
+    expect(playAudio).not.toHaveBeenCalled();
+    expect(fallbackSpeak).toHaveBeenCalledWith("Fallback sentence.", expect.any(AbortSignal));
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: "synthesize",
+        status: 503,
+      })
+    );
+  });
+
   it("aborts current TTS work on cancel", async () => {
     let aborted = false;
     const synthesize = vi.fn(

--- a/hushh-webapp/__tests__/services/agent-voice-client.test.ts
+++ b/hushh-webapp/__tests__/services/agent-voice-client.test.ts
@@ -7,6 +7,7 @@ vi.mock("@/lib/services/api-service", () => ({
 }));
 
 import {
+  getAgentVoiceEndSilenceThresholdMs,
   getAgentVoiceStartErrorMessage,
   shouldConfirmAgentVoiceTranscript,
   transcribeAgentVoice,
@@ -99,5 +100,10 @@ describe("agent voice client", () => {
     expect(
       getAgentVoiceStartErrorMessage(new DOMException("busy", "NotReadableError"))
     ).toContain("already in use");
+  });
+
+  it("uses a shorter end-of-speech window after established speech", () => {
+    expect(getAgentVoiceEndSilenceThresholdMs(250)).toBe(1200);
+    expect(getAgentVoiceEndSilenceThresholdMs(900)).toBe(850);
   });
 });

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -141,7 +141,7 @@ const EMPTY_PKM_CONTEXT: AgentPkmContext = {
   updatedAt: null,
 };
 const AGENT_STREAM_RENDER_FRAME_MS = 32;
-const VOICE_PKM_CONTEXT_DEADLINE_MS = 1_800;
+const VOICE_PKM_CONTEXT_DEADLINE_MS = 650;
 const VOICE_AGENT_FIRST_EVENT_TIMEOUT_MS = 25_000;
 const VOICE_AGENT_IDLE_TIMEOUT_MS = 45_000;
 
@@ -513,6 +513,7 @@ export function AgentChatWorkspace({
   const [isChatLoading, setIsChatLoading] = useState(false);
   const [isLoadingHistory, setIsLoadingHistory] = useState(false);
   const [isHistoryDrawerOpen, setIsHistoryDrawerOpen] = useState(false);
+  const [isHistoryCollapsed, setIsHistoryCollapsed] = useState(false);
   const [historyActionPendingId, setHistoryActionPendingId] = useState<string | null>(null);
   const [isVoiceConnecting, setIsVoiceConnecting] = useState(false);
   const [isStreaming, setIsStreaming] = useState(false);
@@ -1203,6 +1204,7 @@ export function AgentChatWorkspace({
     const executedToolCalls = new Set<string>();
     let toolStatusMessageId: string | null = null;
     let pkmStatusItemId: string | null = null;
+    let voiceTtsFailureReported = false;
     let assistantHasToken = false;
     let turnPkmContext = EMPTY_PKM_CONTEXT;
     let pkmAddToolHandled = false;
@@ -1225,6 +1227,20 @@ export function AgentChatWorkspace({
           voiceClientRef.current?.setCapturePaused(false);
           if (voiceClientRef.current?.isActive) {
             setAgentVoiceStatus(voiceClientRef.current.isMuted ? "muted" : "listening");
+          }
+        },
+        onError: (failure) => {
+          console.warn("[Agent voice] TTS failure", failure);
+          if (failure.stage === "fallback") {
+            if (!voiceTtsFailureReported) {
+              voiceTtsFailureReported = true;
+              addErrorMessage("Agent voice playback failed. The text response is still available.");
+            }
+            return;
+          }
+          if (!voiceTtsFailureReported) {
+            voiceTtsFailureReported = true;
+            toast.error("Agent voice audio failed. Falling back to browser speech.");
           }
         },
       });
@@ -2064,19 +2080,53 @@ export function AgentChatWorkspace({
         onLevel: (level) => {
           setGlobalVoiceLevel(level);
         },
-        onUtterance: async ({ audio }) => {
+        onUtterance: async ({ audio, durationMs, nativeTranscript }) => {
           const voiceSessionEpoch = voiceSessionEpochRef.current;
           const sttAbortController = new AbortController();
           voiceSttAbortControllerRef.current?.abort();
           voiceSttAbortControllerRef.current = sttAbortController;
+          const sttStartedAt = performance.now();
           setAgentVoiceStatus("transcribing");
           try {
-            const result = await transcribeAgentVoice({
-              userId: user.uid,
-              vaultOwnerToken: token,
-              audio,
-              signal: sttAbortController.signal,
-              timeoutMs: AGENT_VOICE_STT_TIMEOUT_MS,
+            const nativeCandidate = nativeTranscript?.transcript.trim()
+              ? nativeTranscript
+              : null;
+            let transcriptionSource:
+              | "browser_native"
+              | "backend_gemini"
+              | "browser_native_uncertain"
+              | "empty" = "empty";
+            let result = nativeCandidate && !nativeCandidate.uncertain ? nativeCandidate : null;
+
+            if (result) {
+              transcriptionSource = "browser_native";
+            } else if (audio.size > 0) {
+              result = await transcribeAgentVoice({
+                userId: user.uid,
+                vaultOwnerToken: token,
+                audio,
+                signal: sttAbortController.signal,
+                timeoutMs: AGENT_VOICE_STT_TIMEOUT_MS,
+              });
+              transcriptionSource = "backend_gemini";
+            } else if (nativeCandidate) {
+              result = nativeCandidate;
+              transcriptionSource = "browser_native_uncertain";
+            } else {
+              result = {
+                transcript: "",
+                uncertain: true,
+                reason: "No speech was captured.",
+              };
+            }
+            console.info("[Agent voice] STT timing", {
+              source: transcriptionSource,
+              audio_bytes: audio.size,
+              captured_ms: Math.round(durationMs),
+              stt_ms: Math.round(performance.now() - sttStartedAt),
+              native_transcript_chars: nativeCandidate?.transcript.length ?? 0,
+              transcript_chars: result.transcript.length,
+              uncertain: result.uncertain,
             });
             if (
               sttAbortController.signal.aborted ||
@@ -2096,7 +2146,30 @@ export function AgentChatWorkspace({
                 ) {
                   return;
                 }
-                await runAgentTurn(transcript, { source: "voice" });
+                voiceClientRef.current.setCapturePaused(true);
+                setAgentVoiceStatus("thinking");
+                void runAgentTurn(transcript, { source: "voice" })
+                  .catch((error) => {
+                    const message =
+                      error instanceof Error && error.message
+                        ? error.message
+                        : "Agent voice turn failed.";
+                    addErrorMessage(message);
+                    setAgentVoiceStatus("error", message);
+                  })
+                  .finally(() => {
+                    if (
+                      voiceSessionEpoch !== voiceSessionEpochRef.current ||
+                      !voiceClientRef.current?.isActive ||
+                      voiceTtsSpeakingRef.current
+                    ) {
+                      return;
+                    }
+                    voiceClientRef.current.setCapturePaused(false);
+                    setAgentVoiceStatus(
+                      voiceClientRef.current.isMuted ? "muted" : "listening"
+                    );
+                  });
               },
               requestReview: (transcript, reason) => {
                 if (
@@ -2187,7 +2260,11 @@ export function AgentChatWorkspace({
       onMinimize();
     }
   };
-  const renderHistorySidebar = (sidebarClassName?: string, onClose?: () => void) => (
+  const renderHistorySidebar = (
+    sidebarClassName?: string,
+    onClose?: () => void,
+    collapsed = false
+  ) => (
     <AgentHistorySidebar
       conversations={conversations}
       activeConversationId={conversationId}
@@ -2195,7 +2272,9 @@ export function AgentChatWorkspace({
       disabled={!hasChatAccess || historyInteractionDisabled}
       actionPendingId={historyActionPendingId}
       className={sidebarClassName}
+      collapsed={collapsed}
       onClose={onClose}
+      onToggleCollapsed={() => setIsHistoryCollapsed((current) => !current)}
       onCreateNew={handleSidebarCreateNewChat}
       onSelectConversation={handleSidebarSelectConversation}
       onRenameConversation={handleRenameConversation}
@@ -2217,40 +2296,34 @@ export function AgentChatWorkspace({
       <div
         className={cn(
           "relative flex min-h-0 flex-1",
-          isPopover ? "flex-col gap-3 overflow-hidden p-3 sm:p-4 lg:flex-row" : "overflow-hidden"
+          isPopover ? "overflow-hidden p-2 sm:p-3" : "overflow-hidden"
         )}
       >
-        {isPopover ? (
-          renderHistorySidebar("max-lg:h-44 max-lg:w-full max-lg:border-b max-lg:border-r-0 lg:h-full lg:w-64")
-        ) : (
-          <>
-            <div className="hidden h-full lg:flex">
-              {renderHistorySidebar("h-full w-[18rem]")}
-            </div>
-            <div
-              className={cn(
-                "fixed inset-0 z-[520] bg-black/55 backdrop-blur-sm transition-opacity duration-200 lg:hidden",
-                isHistoryDrawerOpen ? "opacity-100" : "pointer-events-none opacity-0"
-              )}
-              aria-hidden="true"
-              onClick={() => setIsHistoryDrawerOpen(false)}
-            />
-            <div
-              className={cn(
-                "fixed inset-y-0 left-0 z-[530] w-[min(88vw,320px)] transform transition-transform duration-200 ease-out lg:hidden",
-                isHistoryDrawerOpen ? "translate-x-0" : "-translate-x-full"
-              )}
-              role="dialog"
-              aria-modal="true"
-              aria-hidden={!isHistoryDrawerOpen}
-              aria-label="Agent chat history"
-            >
-              {renderHistorySidebar("h-full w-full shadow-2xl shadow-black/40", () =>
-                setIsHistoryDrawerOpen(false)
-              )}
-            </div>
-          </>
-        )}
+        <div className="hidden h-full lg:flex">
+          {renderHistorySidebar("h-full", undefined, isHistoryCollapsed)}
+        </div>
+        <div
+          className={cn(
+            "fixed inset-0 z-[520] bg-black/55 backdrop-blur-sm transition-opacity duration-200 lg:hidden",
+            isHistoryDrawerOpen ? "opacity-100" : "pointer-events-none opacity-0"
+          )}
+          aria-hidden="true"
+          onClick={() => setIsHistoryDrawerOpen(false)}
+        />
+        <div
+          className={cn(
+            "fixed inset-y-0 left-0 z-[530] w-[min(88vw,320px)] transform transition-transform duration-200 ease-out lg:hidden",
+            isHistoryDrawerOpen ? "translate-x-0" : "-translate-x-full"
+          )}
+          role="dialog"
+          aria-modal="true"
+          aria-hidden={!isHistoryDrawerOpen}
+          aria-label="Agent chat history"
+        >
+          {renderHistorySidebar("h-full w-full shadow-2xl shadow-black/40", () =>
+            setIsHistoryDrawerOpen(false)
+          )}
+        </div>
 
         <section
           className={cn(

--- a/hushh-webapp/components/agent/agent-history-sidebar.tsx
+++ b/hushh-webapp/components/agent/agent-history-sidebar.tsx
@@ -5,6 +5,8 @@ import {
   Check,
   MessageSquare,
   MoreHorizontal,
+  PanelLeftClose,
+  PanelLeftOpen,
   Pencil,
   Plus,
   Trash2,
@@ -39,7 +41,9 @@ type AgentHistorySidebarProps = {
   disabled?: boolean;
   actionPendingId?: string | null;
   className?: string;
+  collapsed?: boolean;
   onClose?: () => void;
+  onToggleCollapsed?: () => void;
   onCreateNew: () => void;
   onSelectConversation: (conversationId: string) => void;
   onRenameConversation: (conversationId: string, title: string) => Promise<void> | void;
@@ -62,7 +66,9 @@ export function AgentHistorySidebar({
   disabled = false,
   actionPendingId,
   className,
+  collapsed = false,
   onClose,
+  onToggleCollapsed,
   onCreateNew,
   onSelectConversation,
   onRenameConversation,
@@ -111,24 +117,69 @@ export function AgentHistorySidebar({
     <>
       <aside
         className={cn(
-          "flex min-h-0 w-72 shrink-0 flex-col overflow-hidden border-r border-white/10 bg-[#101216] text-zinc-200",
+          "flex min-h-0 shrink-0 flex-col overflow-hidden border-r border-white/10 bg-[#101216] text-zinc-200 transition-[width] duration-200 ease-out",
+          collapsed ? "w-16" : "w-72",
           className
         )}
         aria-label="Agent chat history"
+        data-collapsed={collapsed ? "true" : "false"}
       >
         <div className="flex items-center gap-2 border-b border-white/10 p-3">
-          <Button
-            type="button"
-            variant="ghost"
-            className="h-11 min-w-0 flex-1 justify-start gap-2 rounded-lg border border-white/10 bg-white/[0.04] px-3 text-sm font-medium text-zinc-100 shadow-sm transition-colors hover:bg-white/[0.08] focus-visible:ring-2 focus-visible:ring-primary/60"
-            onClick={onCreateNew}
-            disabled={disabled}
-            aria-label="Create new Agent chat"
-            title="Create new chat"
-          >
-            <Plus className="h-4 w-4" />
-            <span className="truncate">New chat</span>
-          </Button>
+          {collapsed ? (
+            <div className="flex w-full flex-col items-center gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-10 w-10 rounded-lg border border-white/10 bg-white/[0.04] text-zinc-100 hover:bg-white/[0.08] focus-visible:ring-2 focus-visible:ring-primary/60"
+                onClick={onToggleCollapsed}
+                aria-label="Expand chat history"
+                title="Expand chat history"
+              >
+                <PanelLeftOpen className="h-4 w-4" />
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-10 w-10 rounded-lg text-zinc-300 hover:bg-white/[0.07] hover:text-zinc-100 focus-visible:ring-2 focus-visible:ring-primary/60"
+                onClick={onCreateNew}
+                disabled={disabled}
+                aria-label="Create new Agent chat"
+                title="New chat"
+              >
+                <Plus className="h-4 w-4" />
+              </Button>
+            </div>
+          ) : (
+            <>
+              <Button
+                type="button"
+                variant="ghost"
+                className="h-11 min-w-0 flex-1 justify-start gap-2 rounded-lg border border-white/10 bg-white/[0.04] px-3 text-sm font-medium text-zinc-100 shadow-sm transition-colors hover:bg-white/[0.08] focus-visible:ring-2 focus-visible:ring-primary/60"
+                onClick={onCreateNew}
+                disabled={disabled}
+                aria-label="Create new Agent chat"
+                title="Create new chat"
+              >
+                <Plus className="h-4 w-4" />
+                <span className="truncate">New chat</span>
+              </Button>
+              {onToggleCollapsed ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="hidden h-10 w-10 rounded-lg text-zinc-400 hover:bg-white/[0.07] hover:text-zinc-100 focus-visible:ring-2 focus-visible:ring-primary/60 lg:inline-flex"
+                  onClick={onToggleCollapsed}
+                  aria-label="Collapse chat history"
+                  title="Collapse chat history"
+                >
+                  <PanelLeftClose className="h-4 w-4" />
+                </Button>
+              ) : null}
+            </>
+          )}
           {onClose ? (
             <Button
               type="button"
@@ -145,14 +196,18 @@ export function AgentHistorySidebar({
         </div>
 
         <div className="min-h-0 flex-1 overflow-y-auto p-2 scrollbar-thin scrollbar-thumb-muted scrollbar-track-transparent">
-          <div className="px-2 pb-2 pt-1 text-[11px] font-medium uppercase tracking-[0.16em] text-zinc-500">
-            Chats
-          </div>
+          {collapsed ? (
+            <div className="h-4" aria-hidden="true" />
+          ) : (
+            <div className="px-2 pb-2 pt-1 text-[11px] font-medium uppercase tracking-[0.16em] text-zinc-500">
+              Chats
+            </div>
+          )}
           {loading ? (
             <div className="h-10 w-full rounded-lg bg-white/[0.05]" />
           ) : null}
 
-          {!loading && conversations.length === 0 ? (
+          {!collapsed && !loading && conversations.length === 0 ? (
             <div className="grid min-h-24 place-items-center rounded-lg border border-dashed border-white/10 px-3 text-center text-xs text-zinc-500">
               No chats yet
             </div>
@@ -213,7 +268,8 @@ export function AgentHistorySidebar({
                       <button
                         type="button"
                         className={cn(
-                          "flex h-10 min-w-0 flex-1 items-center gap-2 rounded-lg px-2 text-left text-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary/60"
+                          "flex h-10 min-w-0 flex-1 items-center gap-2 rounded-lg text-left text-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary/60",
+                          collapsed ? "justify-center px-0" : "px-2"
                         )}
                         onClick={() => onSelectConversation(conversation.id)}
                         disabled={disabled || pending}
@@ -221,37 +277,39 @@ export function AgentHistorySidebar({
                         title={title}
                       >
                         <MessageSquare className="h-4 w-4 shrink-0 opacity-75" />
-                        <span className="truncate">{title}</span>
+                        {collapsed ? null : <span className="truncate">{title}</span>}
                       </button>
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="icon-xs"
-                            className="mr-1 text-zinc-500 opacity-0 transition-opacity hover:bg-white/[0.07] hover:text-zinc-100 group-hover:opacity-100 focus-visible:opacity-100"
-                            disabled={disabled || pending}
-                            onPointerDown={(event) => event.stopPropagation()}
-                            onClick={(event) => event.stopPropagation()}
-                            aria-label={`Open actions for ${title}`}
-                          >
-                            <MoreHorizontal className="h-3.5 w-3.5" />
-                          </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end" sideOffset={6} className="z-[520]">
-                          <DropdownMenuItem onSelect={() => startRename(conversation)}>
-                            <Pencil className="h-4 w-4" />
-                            Rename chat
-                          </DropdownMenuItem>
-                          <DropdownMenuItem
-                            variant="destructive"
-                            onSelect={() => setDeleteTarget(conversation)}
-                          >
-                            <Trash2 className="h-4 w-4" />
-                            Delete chat
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
+                      {collapsed ? null : (
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon-xs"
+                              className="mr-1 text-zinc-500 opacity-0 transition-opacity hover:bg-white/[0.07] hover:text-zinc-100 group-hover:opacity-100 focus-visible:opacity-100"
+                              disabled={disabled || pending}
+                              onPointerDown={(event) => event.stopPropagation()}
+                              onClick={(event) => event.stopPropagation()}
+                              aria-label={`Open actions for ${title}`}
+                            >
+                              <MoreHorizontal className="h-3.5 w-3.5" />
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end" sideOffset={6} className="z-[520]">
+                            <DropdownMenuItem onSelect={() => startRename(conversation)}>
+                              <Pencil className="h-4 w-4" />
+                              Rename chat
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              variant="destructive"
+                              onSelect={() => setDeleteTarget(conversation)}
+                            >
+                              <Trash2 className="h-4 w-4" />
+                              Delete chat
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      )}
                     </div>
                   )}
                 </div>

--- a/hushh-webapp/lib/agent/agent-voice-tts.ts
+++ b/hushh-webapp/lib/agent/agent-voice-tts.ts
@@ -16,9 +16,17 @@ export type AgentTtsQueueOptions = {
   voice?: string;
   synthesize?: (input: AgentTtsRequest) => Promise<Response>;
   playAudio?: (audio: Blob, signal: AbortSignal) => Promise<void>;
+  fallbackSpeak?: (text: string, signal: AbortSignal) => Promise<void>;
   onStateChange?: (state: "idle" | "speaking") => void;
+  onError?: (failure: AgentTtsFailure) => void;
   requestTimeoutMs?: number;
   maxAttempts?: number;
+};
+
+export type AgentTtsFailure = {
+  stage: "synthesize" | "playback" | "fallback";
+  message: string;
+  status?: number;
 };
 
 export type SpeechChunks = {
@@ -26,9 +34,9 @@ export type SpeechChunks = {
   remainder: string;
 };
 
-const MAX_TTS_CHUNK_CHARS = 280;
-const MIN_TTS_CHUNK_CHARS = 18;
-const EARLY_TTS_CHUNK_CHARS = 140;
+const MAX_TTS_CHUNK_CHARS = 220;
+const MIN_TTS_CHUNK_CHARS = 12;
+const EARLY_TTS_CHUNK_CHARS = 90;
 const DEFAULT_TTS_REQUEST_TIMEOUT_MS = 30_000;
 const DEFAULT_TTS_MAX_ATTEMPTS = 2;
 
@@ -105,10 +113,16 @@ async function defaultSynthesize(input: AgentTtsRequest): Promise<Response> {
   return ApiService.synthesizeAgentVoice(input);
 }
 
+function errorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message ? error.message : fallback;
+}
+
 async function defaultPlayAudio(audio: Blob, signal: AbortSignal): Promise<void> {
   if (signal.aborted) throw new DOMException("Aborted", "AbortError");
   const url = URL.createObjectURL(audio);
   const element = new Audio(url);
+  element.preload = "auto";
+  element.setAttribute("playsinline", "true");
 
   try {
     await new Promise<void>((resolve, reject) => {
@@ -141,13 +155,61 @@ async function defaultPlayAudio(audio: Blob, signal: AbortSignal): Promise<void>
   }
 }
 
+async function defaultFallbackSpeak(text: string, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) throw new DOMException("Aborted", "AbortError");
+  if (
+    typeof window === "undefined" ||
+    !window.speechSynthesis ||
+    typeof SpeechSynthesisUtterance === "undefined"
+  ) {
+    throw new Error("Browser speech synthesis is not available.");
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const utterance = new SpeechSynthesisUtterance(text);
+    let settled = false;
+
+    const cleanup = () => {
+      utterance.onend = null;
+      utterance.onerror = null;
+      signal.removeEventListener("abort", handleAbort);
+    };
+    const settle = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      callback();
+    };
+    const handleAbort = () => {
+      window.speechSynthesis.cancel();
+      settle(() => reject(new DOMException("Aborted", "AbortError")));
+    };
+
+    utterance.onend = () => settle(resolve);
+    utterance.onerror = (event) =>
+      settle(() =>
+        reject(
+          new Error(
+            event.error
+              ? `Browser speech synthesis failed: ${event.error}.`
+              : "Browser speech synthesis failed."
+          )
+        )
+      );
+    signal.addEventListener("abort", handleAbort, { once: true });
+    window.speechSynthesis.speak(utterance);
+  });
+}
+
 export class AgentTtsQueue {
   private readonly userId: string;
   private readonly vaultOwnerToken: string;
   private readonly voice?: string;
   private readonly synthesize: (input: AgentTtsRequest) => Promise<Response>;
   private readonly playAudio: (audio: Blob, signal: AbortSignal) => Promise<void>;
+  private readonly fallbackSpeak: (text: string, signal: AbortSignal) => Promise<void>;
   private readonly onStateChange?: (state: "idle" | "speaking") => void;
+  private readonly onError?: (failure: AgentTtsFailure) => void;
   private readonly requestTimeoutMs: number;
   private readonly maxAttempts: number;
   private queue: string[] = [];
@@ -163,7 +225,9 @@ export class AgentTtsQueue {
     this.voice = options.voice;
     this.synthesize = options.synthesize || defaultSynthesize;
     this.playAudio = options.playAudio || defaultPlayAudio;
+    this.fallbackSpeak = options.fallbackSpeak || defaultFallbackSpeak;
     this.onStateChange = options.onStateChange;
+    this.onError = options.onError;
     this.requestTimeoutMs = Math.max(
       1_000,
       options.requestTimeoutMs || DEFAULT_TTS_REQUEST_TIMEOUT_MS
@@ -238,18 +302,14 @@ export class AgentTtsQueue {
         const controller = new AbortController();
         this.abortController = controller;
         this.onStateChange?.("speaking");
-        const response = await this.synthesizeWithRetry(text, controller.signal);
-        if (!response.ok) {
-          continue;
-        }
-        const audio = await response.blob();
-        if (audio.size > 0) {
-          await this.playAudio(audio, controller.signal);
-        }
+        await this.speakChunk(text, controller.signal);
       }
     } catch (error) {
       if (!(error instanceof DOMException && error.name === "AbortError")) {
-        // Speech is best-effort; chat state is the source of truth.
+        this.onError?.({
+          stage: "playback",
+          message: errorMessage(error, "Agent voice playback failed."),
+        });
       }
     } finally {
       this.abortController = null;
@@ -259,6 +319,67 @@ export class AgentTtsQueue {
       } else {
         this.onStateChange?.("idle");
       }
+    }
+  }
+
+  private async speakChunk(text: string, signal: AbortSignal): Promise<void> {
+    try {
+      const response = await this.synthesizeWithRetry(text, signal);
+      if (!response.ok) {
+        this.onError?.({
+          stage: "synthesize",
+          message: `Agent voice TTS returned HTTP ${response.status}.`,
+          status: response.status,
+        });
+        await this.speakWithFallback(text, signal);
+        return;
+      }
+
+      const audio = await response.blob();
+      if (audio.size <= 0) {
+        this.onError?.({
+          stage: "synthesize",
+          message: "Agent voice TTS returned empty audio.",
+        });
+        await this.speakWithFallback(text, signal);
+        return;
+      }
+
+      try {
+        await this.playAudio(audio, signal);
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          throw error;
+        }
+        this.onError?.({
+          stage: "playback",
+          message: errorMessage(error, "Agent voice audio playback failed."),
+        });
+        await this.speakWithFallback(text, signal);
+      }
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        throw error;
+      }
+      this.onError?.({
+        stage: "synthesize",
+        message: errorMessage(error, "Agent voice TTS failed."),
+      });
+      await this.speakWithFallback(text, signal);
+    }
+  }
+
+  private async speakWithFallback(text: string, signal: AbortSignal): Promise<void> {
+    try {
+      await this.fallbackSpeak(text, signal);
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        throw error;
+      }
+      this.onError?.({
+        stage: "fallback",
+        message: errorMessage(error, "Agent voice fallback speech failed."),
+      });
     }
   }
 

--- a/hushh-webapp/lib/services/agent-voice-client.ts
+++ b/hushh-webapp/lib/services/agent-voice-client.ts
@@ -12,6 +12,7 @@ export type AgentVoiceUtterance = {
   audio: Blob;
   mimeType: string;
   durationMs: number;
+  nativeTranscript?: AgentVoiceTranscriptionResult | null;
 };
 
 export type AgentVoiceTranscriptionResult = {
@@ -27,10 +28,13 @@ type AgentVoiceClientHandlers = {
   onError?: (message: string) => void;
 };
 
-const SILENCE_THRESHOLD_MS = 1500;
+const END_OF_SPEECH_SILENCE_MS = 850;
+const SHORT_UTTERANCE_SILENCE_MS = 1200;
+const SHORT_UTTERANCE_MS = 700;
 const RMS_SPEECH_THRESHOLD = 0.035;
 const METER_INTERVAL_MS = 80;
 const RECORDER_TIMESLICE_MS = 250;
+const NATIVE_STT_FINAL_GRACE_MS = 280;
 export const AGENT_VOICE_STT_TIMEOUT_MS = 25_000;
 
 const PREFERRED_AUDIO_MIME_TYPES = [
@@ -42,6 +46,44 @@ const PREFERRED_AUDIO_MIME_TYPES = [
 
 type WindowWithWebkitAudio = Window & {
   webkitAudioContext?: typeof AudioContext;
+};
+
+type BrowserSpeechRecognitionAlternative = {
+  transcript?: string;
+};
+
+type BrowserSpeechRecognitionResult = {
+  isFinal?: boolean;
+  length: number;
+  [index: number]: BrowserSpeechRecognitionAlternative | undefined;
+};
+
+type BrowserSpeechRecognitionEvent = {
+  resultIndex?: number;
+  results: {
+    length: number;
+    [index: number]: BrowserSpeechRecognitionResult | undefined;
+  };
+};
+
+type BrowserSpeechRecognition = {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  maxAlternatives: number;
+  onresult: ((event: BrowserSpeechRecognitionEvent) => void) | null;
+  onerror: (() => void) | null;
+  onend: (() => void) | null;
+  start: () => void;
+  stop: () => void;
+  abort: () => void;
+};
+
+type BrowserSpeechRecognitionConstructor = new () => BrowserSpeechRecognition;
+
+type WindowWithSpeechRecognition = Window & {
+  SpeechRecognition?: BrowserSpeechRecognitionConstructor;
+  webkitSpeechRecognition?: BrowserSpeechRecognitionConstructor;
 };
 
 function createTimeoutSignal(
@@ -91,6 +133,21 @@ function getSupportedAudioMimeType(): string {
 function getAudioContextCtor(): typeof AudioContext | null {
   if (typeof window === "undefined") return null;
   return window.AudioContext || (window as WindowWithWebkitAudio).webkitAudioContext || null;
+}
+
+function getSpeechRecognitionCtor(): BrowserSpeechRecognitionConstructor | null {
+  if (typeof window === "undefined") return null;
+  return (
+    (window as WindowWithSpeechRecognition).SpeechRecognition ||
+    (window as WindowWithSpeechRecognition).webkitSpeechRecognition ||
+    null
+  );
+}
+
+export function getAgentVoiceEndSilenceThresholdMs(speechDurationMs: number): number {
+  return speechDurationMs < SHORT_UTTERANCE_MS
+    ? SHORT_UTTERANCE_SILENCE_MS
+    : END_OF_SPEECH_SILENCE_MS;
 }
 
 export function getAgentVoiceStartErrorMessage(error: unknown): string {
@@ -181,10 +238,15 @@ export class AgentVoiceClient {
   private muted = false;
   private hasSpeech = false;
   private recordingStartedAt = 0;
+  private firstSpeechAt = 0;
   private lastSpeechAt = 0;
   private processingUtterance = false;
   private capturePaused = false;
   private mimeType = "";
+  private nativeRecognition: BrowserSpeechRecognition | null = null;
+  private nativeFinalTranscript = "";
+  private nativeInterimTranscript = "";
+  private nativeStopWaiters: Array<() => void> = [];
 
   get isActive(): boolean {
     return this.active;
@@ -233,6 +295,7 @@ export class AgentVoiceClient {
     this.capturePaused = false;
     this.stopMeter();
     this.stopRecorder(false);
+    this.stopNativeRecognition(true);
     this.stream?.getTracks().forEach((track) => track.stop());
     this.stream = null;
     this.disconnectAudioGraph();
@@ -247,6 +310,7 @@ export class AgentVoiceClient {
 
     if (muted) {
       this.stopRecorder(false);
+      this.stopNativeRecognition(true);
       this.handlers.onLevel?.(0);
       this.handlers.onStatus?.("muted");
       return;
@@ -271,6 +335,7 @@ export class AgentVoiceClient {
 
     if (paused) {
       this.stopRecorder(false);
+      this.stopNativeRecognition(true);
       this.hasSpeech = false;
       this.handlers.onLevel?.(0);
       return;
@@ -347,12 +412,19 @@ export class AgentVoiceClient {
 
     const now = performance.now();
     if (rms >= RMS_SPEECH_THRESHOLD) {
+      if (!this.hasSpeech) {
+        this.firstSpeechAt = now;
+      }
       this.hasSpeech = true;
       this.lastSpeechAt = now;
       return;
     }
 
-    if (this.hasSpeech && now - this.lastSpeechAt >= SILENCE_THRESHOLD_MS) {
+    if (
+      this.hasSpeech &&
+      now - this.lastSpeechAt >=
+        getAgentVoiceEndSilenceThresholdMs(this.lastSpeechAt - this.firstSpeechAt)
+    ) {
       this.finishUtterance();
     }
   }
@@ -362,13 +434,17 @@ export class AgentVoiceClient {
     this.chunks = [];
     this.hasSpeech = false;
     this.recordingStartedAt = performance.now();
+    this.firstSpeechAt = 0;
     this.lastSpeechAt = this.recordingStartedAt;
+    this.resetNativeTranscript();
+    this.startNativeRecognition();
 
     const options = this.mimeType ? { mimeType: this.mimeType } : undefined;
     try {
       this.recorder = new MediaRecorder(this.stream, options);
     } catch (error) {
       this.processingUtterance = false;
+      this.stopNativeRecognition(true);
       this.handlers.onError?.(getAgentVoiceStartErrorMessage(error));
       return;
     }
@@ -388,7 +464,10 @@ export class AgentVoiceClient {
   private stopRecorder(submit: boolean): void {
     const recorder = this.recorder;
     if (!recorder) return;
-    if (!submit) this.chunks = [];
+    if (!submit) {
+      this.chunks = [];
+      this.stopNativeRecognition(true);
+    }
     if (recorder.state !== "inactive") {
       recorder.stop();
     }
@@ -407,16 +486,18 @@ export class AgentVoiceClient {
     const chunks = this.chunks;
     this.chunks = [];
     const durationMs = Math.max(0, performance.now() - this.recordingStartedAt);
+    const nativeTranscript = await this.waitForNativeTranscript(NATIVE_STT_FINAL_GRACE_MS);
     const audio = new Blob(chunks, {
       type: this.mimeType || chunks[0]?.type || "audio/webm",
     });
 
     try {
-      if (audio.size > 0) {
+      if (audio.size > 0 || nativeTranscript?.transcript) {
         await this.handlers.onUtterance?.({
           audio,
           mimeType: audio.type || "audio/webm",
           durationMs,
+          nativeTranscript,
         });
       }
     } catch (error) {
@@ -430,5 +511,133 @@ export class AgentVoiceClient {
         this.startRecorder();
       }
     }
+  }
+
+  private resetNativeTranscript(): void {
+    this.nativeFinalTranscript = "";
+    this.nativeInterimTranscript = "";
+  }
+
+  private startNativeRecognition(): void {
+    if (this.nativeRecognition || this.muted || this.capturePaused || this.processingUtterance) {
+      return;
+    }
+    const Recognition = getSpeechRecognitionCtor();
+    if (!Recognition) return;
+
+    try {
+      const recognition = new Recognition();
+      recognition.continuous = true;
+      recognition.interimResults = true;
+      recognition.lang = "en-US";
+      recognition.maxAlternatives = 1;
+      recognition.onresult = (event) => {
+        let finalTranscript = this.nativeFinalTranscript;
+        let interimTranscript = "";
+        const startIndex = Math.max(0, event.resultIndex ?? 0);
+        for (let index = startIndex; index < event.results.length; index += 1) {
+          const result = event.results[index];
+          const transcript = result?.[0]?.transcript?.trim();
+          if (!transcript) continue;
+          if (result?.isFinal) {
+            finalTranscript = `${finalTranscript} ${transcript}`.trim();
+          } else {
+            interimTranscript = `${interimTranscript} ${transcript}`.trim();
+          }
+        }
+        this.nativeFinalTranscript = finalTranscript;
+        this.nativeInterimTranscript = interimTranscript || this.nativeInterimTranscript;
+      };
+      recognition.onerror = () => {
+        if (this.nativeRecognition === recognition) {
+          this.nativeRecognition = null;
+        }
+        this.resetNativeTranscript();
+        this.resolveNativeStopWaiters();
+      };
+      recognition.onend = () => {
+        if (this.nativeRecognition === recognition) {
+          this.nativeRecognition = null;
+        }
+        this.resolveNativeStopWaiters();
+        if (this.active && !this.muted && !this.capturePaused && !this.processingUtterance) {
+          window.setTimeout(() => this.startNativeRecognition(), 120);
+        }
+      };
+      this.nativeRecognition = recognition;
+      recognition.start();
+    } catch {
+      this.nativeRecognition = null;
+    }
+  }
+
+  private stopNativeRecognition(abort: boolean): void {
+    const recognition = this.nativeRecognition;
+    if (!recognition) return;
+    try {
+      if (abort) {
+        recognition.abort();
+        this.resetNativeTranscript();
+      } else {
+        recognition.stop();
+      }
+    } catch {
+      this.nativeRecognition = null;
+      this.resolveNativeStopWaiters();
+    }
+  }
+
+  private async waitForNativeTranscript(
+    timeoutMs: number
+  ): Promise<AgentVoiceTranscriptionResult | null> {
+    const recognition = this.nativeRecognition;
+    if (!recognition) return this.getNativeTranscriptResult();
+
+    let timeoutId: number | null = null;
+    let settled = false;
+    const stopped = new Promise<void>((resolve) => {
+      const resolveOnce = () => {
+        if (settled) return;
+        settled = true;
+        if (timeoutId !== null) {
+          window.clearTimeout(timeoutId);
+        }
+        this.nativeStopWaiters = this.nativeStopWaiters.filter(
+          (waiter) => waiter !== resolveOnce
+        );
+        resolve();
+      };
+      this.nativeStopWaiters.push(resolveOnce);
+      timeoutId = window.setTimeout(resolveOnce, timeoutMs);
+    });
+    this.stopNativeRecognition(false);
+    await stopped;
+    return this.getNativeTranscriptResult();
+  }
+
+  private resolveNativeStopWaiters(): void {
+    const waiters = this.nativeStopWaiters.splice(0);
+    for (const resolve of waiters) {
+      resolve();
+    }
+  }
+
+  private getNativeTranscriptResult(): AgentVoiceTranscriptionResult | null {
+    const finalTranscript = this.nativeFinalTranscript.trim();
+    if (finalTranscript) {
+      return {
+        transcript: finalTranscript,
+        uncertain: false,
+        reason: null,
+      };
+    }
+
+    const interimTranscript = this.nativeInterimTranscript.trim();
+    if (!interimTranscript) return null;
+    return {
+      transcript: interimTranscript,
+      uncertain: true,
+      reason: "Browser speech recognition did not finalize the transcript.",
+    };
   }
 }


### PR DESCRIPTION
## Summary
- Add a collapsible desktop Agent history sidebar on top of the merged Agent chat redesign.
- Improve Agent voice latency with faster end-of-speech detection, browser-native transcript fast path, shorter voice PKM blocking, earlier TTS chunking, and browser speech fallback when backend TTS fails.
- Add focused Agent voice tests and reduce backend STT JSON output cap.

## Root Cause
The voice turn had avoidable latency from a fixed silence delay, always using backend STT, waiting too long on PKM context before streaming, and waiting for larger TTS chunks before speaking.

## Validation
- `npm run typecheck`
- `npx eslint components/agent/agent-chat-workspace.tsx components/agent/agent-history-sidebar.tsx lib/agent/agent-voice-tts.ts lib/services/agent-voice-client.ts __tests__/lib/agent-voice-tts.test.ts __tests__/services/agent-voice-client.test.ts`
- `npm run test -- __tests__/services/agent-chat-client.test.ts __tests__/services/agent-voice-client.test.ts __tests__/lib/agent-popover-layout.test.ts __tests__/lib/agent-voice-turn.test.ts __tests__/lib/agent-voice-tts.test.ts __tests__/lib/agent-voice-state.test.ts __tests__/lib/agent-voice-settings.test.ts`
- `.venv/bin/python -m pytest tests/services/test_agent_voice_service.py tests/test_agent_voice_routes.py`

Note: direct PRs into `main` are blocked by repository policy unless the head branch is `integration/pr-train`.
