### PR TITLE
test(observability): verify boolean env-string coercion handles whitespace, case variants, and ambiguous values

### DIFF
--- a/hushh-webapp/__tests__/services/observability-web-transport.test.ts
+++ b/hushh-webapp/__tests__/services/observability-web-transport.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  isObservabilityDebugEnabled,
+  isObservabilityEnabled,
   resolveAnalyticsMeasurementId,
   resolveGtmContainerId,
   shouldLoadWebAnalyticsScripts,
@@ -124,5 +126,164 @@ describe("web observability transport", () => {
         app_version: "2.1.0",
       }
     );
+  });
+});
+
+// ── String-to-boolean coercion — fringe env string values ─────────────────────
+//
+// isObservabilityEnabled and isObservabilityDebugEnabled both pipe their env
+// var through normalizeValue() which trims whitespace and lowercases before
+// the final list comparison.  The tests below pin the exact coercion contract
+// for strings that callers (env files, CI configs, platform secrets) are known
+// to supply in non-canonical forms.
+//
+// Production module: lib/observability/env.ts
+// Coercion logic:    normalizeValue(raw) = String(raw||"").trim().toLowerCase()
+//
+//   isObservabilityEnabled  → false only for {"0","false","no","off"}; everything
+//                             else including empty/unset defaults to true.
+//   isObservabilityDebugEnabled → true only for {"1","true","yes","on"}.
+
+describe("string-to-boolean coercion — fringe env string values", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  // ── isObservabilityEnabled ─────────────────────────────────────────────────
+
+  describe("isObservabilityEnabled", () => {
+    // Falsy signals — the explicit opt-out list
+    it.each([
+      ["0"],
+      ["false"],
+      ["no"],
+      ["off"],
+      ["FALSE"],   // uppercase — lowercased by normalizeValue
+      ["NO"],
+      ["OFF"],
+      [" false "], // leading/trailing whitespace — trimmed by normalizeValue
+      [" 0 "],
+    ])('returns false for "%s"', (value: string) => {
+      vi.stubEnv("NEXT_PUBLIC_OBSERVABILITY_ENABLED", value);
+      expect(isObservabilityEnabled()).toBe(false);
+    });
+
+    // Truthy signals — anything outside the opt-out list is treated as enabled
+    it.each([
+      ["true"],
+      ["1"],
+      ["yes"],
+      ["on"],
+      ["TRUE"],    // uppercase → lowercased to "true", not in opt-out list
+      ["True"],
+      ["YES"],
+      ["ON"],
+      ["true "],   // trailing space → trimmed to "true"
+      [" true"],   // leading space
+    ])('returns true for "%s"', (value: string) => {
+      vi.stubEnv("NEXT_PUBLIC_OBSERVABILITY_ENABLED", value);
+      expect(isObservabilityEnabled()).toBe(true);
+    });
+
+    // Ambiguous / unexpected strings — not in the opt-out list → enabled
+    it('treats "disabled" as enabled (not in the opt-out list)', () => {
+      vi.stubEnv("NEXT_PUBLIC_OBSERVABILITY_ENABLED", "disabled");
+      // "disabled" is not one of {"0","false","no","off"} → returns true
+      expect(isObservabilityEnabled()).toBe(true);
+    });
+
+    it('treats "enabled" as enabled', () => {
+      vi.stubEnv("NEXT_PUBLIC_OBSERVABILITY_ENABLED", "enabled");
+      expect(isObservabilityEnabled()).toBe(true);
+    });
+
+    it("returns true when env var is absent (default-on posture)", () => {
+      // No stubEnv call → process.env value is undefined → normalizeValue → ""
+      // → !raw branch fires → returns true
+      expect(isObservabilityEnabled()).toBe(true);
+    });
+
+    it('returns true for empty string (default-on posture)', () => {
+      vi.stubEnv("NEXT_PUBLIC_OBSERVABILITY_ENABLED", "");
+      expect(isObservabilityEnabled()).toBe(true);
+    });
+  });
+
+  // ── isObservabilityDebugEnabled ────────────────────────────────────────────
+
+  describe("isObservabilityDebugEnabled", () => {
+    // Enabled signals — the explicit opt-in list
+    it.each([
+      ["1"],
+      ["true"],
+      ["yes"],
+      ["on"],
+      ["TRUE"],    // uppercase → lowercased to "true"
+      ["YES"],
+      ["ON"],
+      ["True"],
+      ["true "],   // trailing space → trimmed to "true"
+      [" 1"],      // leading space → trimmed to "1"
+    ])('returns true for "%s"', (value: string) => {
+      vi.stubEnv("NEXT_PUBLIC_OBSERVABILITY_DEBUG", value);
+      expect(isObservabilityDebugEnabled()).toBe(true);
+    });
+
+    // Disabled signals — anything outside the opt-in list
+    it.each([
+      ["0"],
+      ["false"],
+      ["no"],
+      ["off"],
+      ["FALSE"],
+      ["disabled"],
+      ["enabled"],  // truthy-sounding word, but not in the opt-in list
+      [""],
+    ])('returns false for "%s"', (value: string) => {
+      vi.stubEnv("NEXT_PUBLIC_OBSERVABILITY_DEBUG", value);
+      expect(isObservabilityDebugEnabled()).toBe(false);
+    });
+
+    it("returns false when env var is absent", () => {
+      // No stub → undefined → normalizeValue → "" → not in opt-in list
+      expect(isObservabilityDebugEnabled()).toBe(false);
+    });
+  });
+
+  // ── shouldLoadWebAnalyticsScripts ──────────────────────────────────────────
+
+  describe("shouldLoadWebAnalyticsScripts — coercion interop with isObservabilityEnabled", () => {
+    it('respects "YES" as a valid load-in-dev signal', () => {
+      vi.stubEnv("NODE_ENV", "development");
+      vi.stubEnv("NEXT_PUBLIC_OBSERVABILITY_LOAD_IN_DEV", "YES");
+      expect(shouldLoadWebAnalyticsScripts()).toBe(true);
+    });
+
+    it('respects "ON" as a valid load-in-dev signal', () => {
+      vi.stubEnv("NODE_ENV", "development");
+      vi.stubEnv("NEXT_PUBLIC_OBSERVABILITY_LOAD_IN_DEV", "ON");
+      expect(shouldLoadWebAnalyticsScripts()).toBe(true);
+    });
+
+    it('respects "true " (trailing space) as a valid load-in-dev signal', () => {
+      vi.stubEnv("NODE_ENV", "development");
+      vi.stubEnv("NEXT_PUBLIC_OBSERVABILITY_LOAD_IN_DEV", "true ");
+      expect(shouldLoadWebAnalyticsScripts()).toBe(true);
+    });
+
+    it('returns false when observability is disabled via "0" even if load-in-dev is "1"', () => {
+      vi.stubEnv("NODE_ENV", "development");
+      vi.stubEnv("NEXT_PUBLIC_OBSERVABILITY_ENABLED", "0");
+      vi.stubEnv("NEXT_PUBLIC_OBSERVABILITY_LOAD_IN_DEV", "1");
+      // isObservabilityEnabled() returns false → short-circuits to false
+      expect(shouldLoadWebAnalyticsScripts()).toBe(false);
+    });
+
+    it('returns false when observability is disabled via "FALSE" (uppercase)', () => {
+      vi.stubEnv("NODE_ENV", "development");
+      vi.stubEnv("NEXT_PUBLIC_OBSERVABILITY_ENABLED", "FALSE");
+      vi.stubEnv("NEXT_PUBLIC_OBSERVABILITY_LOAD_IN_DEV", "true");
+      expect(shouldLoadWebAnalyticsScripts()).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Extends the canonical `observability-web-transport` test suite with 47 new cases across a new `describe("string-to-boolean coercion — fringe env string values")` block. The cases pin the exact coercion contract of the shared `normalizeValue()` helper inside `lib/observability/env.ts` for `isObservabilityEnabled`, `isObservabilityDebugEnabled`, and `shouldLoadWebAnalyticsScripts` — exercising whitespace variants, uppercase forms, numeric strings, and semantically ambiguous words that real env files and CI secret stores commonly produce. No new files, direct production imports, upstream base.

## Files changed (1)

| File | Change |
|---|---|
| `hushh-webapp/__tests__/services/observability-web-transport.test.ts` | +161 lines — 2 new imports + section comment block + `describe("string-to-boolean coercion — fringe env string values")` with 3 nested describes and 47 `it` / `it.each` cases |

## Production module exercised

```typescript
// hushh-webapp/lib/observability/env.ts

function normalizeValue(raw): string          // trim + lowercase before comparison
isObservabilityEnabled(): boolean             // false only for {"0","false","no","off"}
isObservabilityDebugEnabled(): boolean        // true only for {"1","true","yes","on"}
shouldLoadWebAnalyticsScripts(): boolean      // combines both + NODE_ENV check
```

## New test coverage

### `isObservabilityEnabled` — opt-out falsy signals (9 cases)

| Input | After normalizeValue | Result |
|---|---|---|
| `"0"` | `"0"` | `false` |
| `"false"` | `"false"` | `false` |
| `"no"` | `"no"` | `false` |
| `"off"` | `"off"` | `false` |
| `"FALSE"` | `"false"` | `false` — uppercase lowercased |
| `"NO"` | `"no"` | `false` |
| `"OFF"` | `"off"` | `false` |
| `" false "` | `"false"` | `false` — whitespace trimmed |
| `" 0 "` | `"0"` | `false` |

### `isObservabilityEnabled` — opt-in truthy signals (12 cases)

`"true"`, `"1"`, `"yes"`, `"on"`, `"TRUE"`, `"True"`, `"YES"`, `"ON"`, `"true "` (trailing space), `" true"` (leading space) → all `true`; plus `""` and absent-var → `true` (default-on posture).

### `isObservabilityEnabled` — ambiguous strings (2 cases)

| Input | Result | Why |
|---|---|---|
| `"disabled"` | `true` | Not in the opt-out set `{"0","false","no","off"}` — documents that freeform words do NOT disable observability |
| `"enabled"` | `true` | Same reason |

### `isObservabilityDebugEnabled` — opt-in truthy signals (10 cases)

`"1"`, `"true"`, `"yes"`, `"on"`, `"TRUE"`, `"YES"`, `"ON"`, `"True"`, `"true "`, `" 1"` → all `true`.

### `isObservabilityDebugEnabled` — disabled signals (9 cases)

`"0"`, `"false"`, `"no"`, `"off"`, `"FALSE"`, `"disabled"`, `"enabled"`, `""`, absent-var → all `false`.

### `shouldLoadWebAnalyticsScripts` coercion interop (5 cases)

| Scenario | Expected |
|---|---|
| `LOAD_IN_DEV="YES"` in dev | `true` — uppercase accepted |
| `LOAD_IN_DEV="ON"` in dev | `true` |
| `LOAD_IN_DEV="true "` in dev | `true` — trailing space trimmed |
| `ENABLED="0"` + `LOAD_IN_DEV="1"` in dev | `false` — disabled gate short-circuits |
| `ENABLED="FALSE"` + `LOAD_IN_DEV="true"` in dev | `false` — uppercase disabled gate |

## CI gate checklist
- [x] **PR Base Policy** — targets `integration/pr-train`; branch cut directly from `upstream/integration/pr-train`, zero merge conflicts
- [x] **DCO** — `Signed-off-by: Abdul Rashid <smirthidharmaiit@gmail.com>`
- [x] **Secret Scan** — diff contains only env fixture strings (`"true "`, `"FALSE"`, `"disabled"`); no real tokens or credentials
- [x] **Governance** — single modified file in `__tests__/services/`; no debug artifacts; no `eslint-disable`
- [x] **Path filters** — only `hushh-webapp/__tests__/services/observability-web-transport.test.ts` changed; triggers Web (Next.js) gate
- [x] **Upstream Sync** — branch cut directly from upstream tip; no conflicts possible
- [x] **Base Freshness Gate** — freshly branched; no stale base
- [x] **Web (Next.js)** — all cases use `vi.stubEnv` + `vi.unstubAllEnvs` (existing pattern in the file); `it.each` callbacks typed as `(value: string)` to satisfy `strict` mode; picked up by Vitest `include: ["__tests__/**/*.test.{ts,tsx}"]`
- [x] **No new files** — 161 additions to existing companion test file; no standalone scripts
- [x] **Direct production import** — `isObservabilityEnabled`, `isObservabilityDebugEnabled` added to existing import from `@/lib/observability/env`; no re-exports or path shims
- [x] **No `eslint-disable`** — zero lint suppressions in the diff
- [x] **Clean diff** — 1 file, 161 additions, 0 deletions, no conflicts, fresh upstream base

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)