### PR TITLE
fix(frontend): disable spellcheck for stock ticker input

### DIFF
--- a/hushh-webapp/components/kai/views/funding-trade-view.tsx
+++ b/hushh-webapp/components/kai/views/funding-trade-view.tsx
@@ -468,6 +468,8 @@ export function FundingTradeView({ userId, vaultOwnerToken }: FundingTradeViewPr
                     value={symbolInput}
                     onChange={(event) => setSymbolInput(event.target.value.toUpperCase())}
                     placeholder="AAPL"
+                    spellCheck={false}
+                    autoComplete="off"
                   />
                 </label>
 


### PR DESCRIPTION
# Description
Added `spellCheck={false}` and `autoComplete="off"` to the stock ticker input in `funding-trade-view.tsx` to prevent the browser from showing red squiggly lines on valid ticker symbols or suggesting unrelated words.

## 📌 Core Impact
- [x] **Routes Touched:** None
- [x] **API / Schema / Trust Boundary:** None
- [x] **Verification:** Executed `npm run typecheck` and `npm run build`

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS**: (N/A - Frontend Web UI Only)
- [ ] **Android**: (N/A - Frontend Web UI Only)

## 🧪 Testing & Privacy
- [x] Tested on Web (Chrome/Safari)
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible