### PR TITLE
fix(frontend): disable spellcheck on regulatory profile inputs

### DIFF
--- a/hushh-webapp/app/profile/page.tsx
+++ b/hushh-webapp/app/profile/page.tsx
@@ -4163,6 +4163,8 @@ function ProfilePageContent() {
                 inputMode="numeric"
                 placeholder="Enter license or CRD number"
                 disabled={refreshingRegulatoryProfile}
+                spellCheck={false}
+                autoComplete="off"
               />
             </label>
 
@@ -4175,6 +4177,8 @@ function ProfilePageContent() {
                 onChange={(event) => setRegulatoryRegulator(event.target.value)}
                 placeholder="SEC"
                 disabled={refreshingRegulatoryProfile}
+                spellCheck={false}
+                autoComplete="off"
               />
             </label>
 


### PR DESCRIPTION
# Description
Added `spellCheck={false}` and `autoComplete="off"` to the License/CRD and Regulator inputs in the Profile page (`app/profile/page.tsx`) to prevent the browser from falsely spellchecking numeric IDs and acronyms.

## 📌 Core Impact
- [x] **Routes Touched:** None
- [x] **API / Schema / Trust Boundary:** None
- [x] **Verification:** Executed `npm run typecheck` and `npm run build`

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS**: (N/A - Frontend Web UI Only)
- [ ] **Android**: (N/A - Frontend Web UI Only)

## 🧪 Testing & Privacy
- [x] Tested on Web (Chrome/Safari)
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible