### PR TITLE
fix(frontend): add inputMode decimal to numeric inputs in holding modal

### DIFF
--- a/hushh-webapp/components/kai/modals/edit-holding-modal.tsx
+++ b/hushh-webapp/components/kai/modals/edit-holding-modal.tsx
@@ -545,6 +545,7 @@ export function EditHoldingModal({
                 placeholder="0"
                 min="0.0001"
                 step="0.0001"
+                inputMode="decimal"
                 className={cn(
                   "w-full px-4 py-3 h-12 rounded-xl border bg-background outline-none transition-colors",
                   errors.quantity
@@ -569,6 +570,7 @@ export function EditHoldingModal({
                 placeholder="0.00"
                 min="0.01"
                 step="0.01"
+                inputMode="decimal"
                 className={cn(
                   "w-full px-4 py-3 h-12 rounded-xl border bg-background outline-none transition-colors",
                   errors.price
@@ -615,6 +617,7 @@ export function EditHoldingModal({
               placeholder="0.00"
               min="0"
               step="0.01"
+              inputMode="decimal"
               className="w-full px-4 py-3 h-12 rounded-xl border border-border bg-background outline-none focus:border-primary transition-colors"
             />
             {errors.cost_basis && (


### PR DESCRIPTION
# Description
Added `inputMode="decimal"` to the numeric inputs (Quantity, Price, Cost Basis) in `edit-holding-modal.tsx` to ensure mobile devices display the correct numeric keypad with a decimal point.

## 📌 Core Impact
- [x] **Routes Touched:** None
- [x] **API / Schema / Trust Boundary:** None
- [x] **Verification:** Executed `npm run typecheck` and `npm run build`

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS**: (N/A - Frontend Web UI Only)
- [x] **Android**: (N/A - Frontend Web UI Only)

## 🧪 Testing & Privacy
- [x] Tested on Web (Chrome/Safari)
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible