### PR TITLE
test(utils): verify resolveSlowRequestTimeoutMs falls back to safe floor for negative, zero, NaN, and undefined duration inputs

### DIFF
--- a/hushh-webapp/__tests__/utils/request-timeouts.test.ts
+++ b/hushh-webapp/__tests__/utils/request-timeouts.test.ts
@@ -47,3 +47,179 @@ describe("resolveSlowRequestTimeoutMs", () => {
     expect(resolveSlowRequestTimeoutMs(20_000)).toBe(33_000);
   });
 });
+
+// ── Fringe-input boundary fallbacks ──────────────────────────────────────────
+//
+// resolveSlowRequestTimeoutMs guards the defaultMs parameter with:
+//   Number.isFinite(defaultMs) && defaultMs > 0
+//
+// When either condition fails, the function falls back to the internal
+// DEVELOPMENT_SLOW_REQUEST_TIMEOUT_MS floor (75 000 ms) rather than
+// propagating 0, a negative value, or NaN to callers.  This ensures every
+// code path that relies on a timeout receives a non-zero, non-NaN value
+// even when the caller passes fringe or undefined input.
+//
+// Tests run against a non-development runtime (uat) so the result depends
+// only on safeDefaultMs — no development-floor amplification obscures the
+// fallback contract.
+
+describe("resolveSlowRequestTimeoutMs — fringe-input boundary fallbacks", () => {
+  const SAFE_FLOOR = 75_000; // DEVELOPMENT_SLOW_REQUEST_TIMEOUT_MS
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_APP_ENV = ORIGINAL_APP_ENV;
+    process.env.APP_RUNTIME_PROFILE = ORIGINAL_RUNTIME_PROFILE;
+    process.env.ENVIRONMENT = ORIGINAL_ENVIRONMENT;
+    process.env.HUSHH_SLOW_REQUEST_TIMEOUT_MS = ORIGINAL_OVERRIDE;
+  });
+
+  // ── Negative defaultMs ────────────────────────────────────────────────────
+
+  it("falls back to the safe floor when defaultMs is a negative integer", () => {
+    process.env.NEXT_PUBLIC_APP_ENV = "uat";
+    delete process.env.HUSHH_SLOW_REQUEST_TIMEOUT_MS;
+
+    // -1 fails the `defaultMs > 0` guard → safeDefaultMs = SAFE_FLOOR.
+    expect(resolveSlowRequestTimeoutMs(-1)).toBe(SAFE_FLOOR);
+    expect(resolveSlowRequestTimeoutMs(-5_000)).toBe(SAFE_FLOOR);
+    expect(resolveSlowRequestTimeoutMs(-Infinity)).toBe(SAFE_FLOOR);
+  });
+
+  // ── Zero defaultMs ────────────────────────────────────────────────────────
+
+  it("falls back to the safe floor when defaultMs is exactly zero (closed-posture boundary)", () => {
+    process.env.NEXT_PUBLIC_APP_ENV = "uat";
+    delete process.env.HUSHH_SLOW_REQUEST_TIMEOUT_MS;
+
+    // 0 is finite but not > 0 → safeDefaultMs = SAFE_FLOOR.
+    // A zero-millisecond timeout would cause immediate connection drops;
+    // the guard replaces it with a meaningful minimum.
+    expect(resolveSlowRequestTimeoutMs(0)).toBe(SAFE_FLOOR);
+  });
+
+  // ── NaN defaultMs ─────────────────────────────────────────────────────────
+
+  it("falls back to the safe floor when defaultMs is NaN — no NaN escapes the function", () => {
+    process.env.NEXT_PUBLIC_APP_ENV = "uat";
+    delete process.env.HUSHH_SLOW_REQUEST_TIMEOUT_MS;
+
+    // Number.isFinite(NaN) = false → safeDefaultMs = SAFE_FLOOR.
+    const result = resolveSlowRequestTimeoutMs(Number.NaN);
+    expect(result).toBe(SAFE_FLOOR);
+    // Critical: the returned value must never be NaN.
+    expect(Number.isNaN(result)).toBe(false);
+    expect(Number.isFinite(result)).toBe(true);
+  });
+
+  // ── Infinity defaultMs ────────────────────────────────────────────────────
+
+  it("falls back to the safe floor when defaultMs is positive Infinity", () => {
+    process.env.NEXT_PUBLIC_APP_ENV = "uat";
+    delete process.env.HUSHH_SLOW_REQUEST_TIMEOUT_MS;
+
+    // Number.isFinite(Infinity) = false → safeDefaultMs = SAFE_FLOOR.
+    const result = resolveSlowRequestTimeoutMs(Infinity);
+    expect(result).toBe(SAFE_FLOOR);
+    expect(Number.isFinite(result)).toBe(true);
+  });
+
+  // ── Undefined / non-numeric defaultMs ────────────────────────────────────
+
+  it("falls back to the safe floor when defaultMs is undefined", () => {
+    process.env.NEXT_PUBLIC_APP_ENV = "uat";
+    delete process.env.HUSHH_SLOW_REQUEST_TIMEOUT_MS;
+
+    // Number.isFinite(undefined) = false → safeDefaultMs = SAFE_FLOOR.
+    expect(resolveSlowRequestTimeoutMs(undefined as never)).toBe(SAFE_FLOOR);
+  });
+
+  it("falls back to the safe floor when defaultMs is a non-numeric object", () => {
+    process.env.NEXT_PUBLIC_APP_ENV = "uat";
+    delete process.env.HUSHH_SLOW_REQUEST_TIMEOUT_MS;
+
+    // Number.isFinite({}) = false → safeDefaultMs = SAFE_FLOOR.
+    expect(resolveSlowRequestTimeoutMs({} as never)).toBe(SAFE_FLOOR);
+    expect(resolveSlowRequestTimeoutMs(null as never)).toBe(SAFE_FLOOR);
+  });
+
+  // ── Fractional defaultMs rounds safely ────────────────────────────────────
+
+  it("rounds fractional defaultMs to the nearest integer without NaN or truncation error", () => {
+    process.env.NEXT_PUBLIC_APP_ENV = "uat";
+    delete process.env.HUSHH_SLOW_REQUEST_TIMEOUT_MS;
+
+    // Math.round is applied to valid finite positive fractions.
+    expect(resolveSlowRequestTimeoutMs(1.4)).toBe(1);
+    expect(resolveSlowRequestTimeoutMs(1.5)).toBe(2);
+    expect(resolveSlowRequestTimeoutMs(20_000.9)).toBe(20_001);
+    // Result is always an integer (no fractional millisecond leaks to callers).
+    expect(Number.isInteger(resolveSlowRequestTimeoutMs(9_999.1))).toBe(true);
+  });
+
+  // ── Empty options object ───────────────────────────────────────────────────
+
+  it("behaves identically whether options is omitted or passed as an empty object", () => {
+    process.env.NEXT_PUBLIC_APP_ENV = "uat";
+    delete process.env.HUSHH_SLOW_REQUEST_TIMEOUT_MS;
+
+    // {} has no overrideEnvKey or developmentFloorMs — both code paths converge.
+    expect(resolveSlowRequestTimeoutMs(20_000)).toBe(
+      resolveSlowRequestTimeoutMs(20_000, {})
+    );
+  });
+
+  // ── Zero developmentFloorMs treated as missing ────────────────────────────
+
+  it("treats zero developmentFloorMs as absent and applies the built-in floor in development", () => {
+    process.env.NEXT_PUBLIC_APP_ENV = "development";
+    delete process.env.HUSHH_SLOW_REQUEST_TIMEOUT_MS;
+
+    // `0 || SAFE_FLOOR` evaluates to SAFE_FLOOR because 0 is falsy.
+    // Math.max(20_000, SAFE_FLOOR) = SAFE_FLOOR.
+    expect(resolveSlowRequestTimeoutMs(20_000, { developmentFloorMs: 0 })).toBe(
+      SAFE_FLOOR
+    );
+  });
+
+  // ── Negative developmentFloorMs does not undercut safeDefaultMs ───────────
+
+  it("ignores a negative developmentFloorMs — Math.max preserves safeDefaultMs in development", () => {
+    process.env.NEXT_PUBLIC_APP_ENV = "development";
+    delete process.env.HUSHH_SLOW_REQUEST_TIMEOUT_MS;
+
+    // -5_000 is truthy so it is used as the floor argument.
+    // Math.max(20_000, -5_000) = 20_000 → safeDefaultMs wins.
+    expect(
+      resolveSlowRequestTimeoutMs(20_000, { developmentFloorMs: -5_000 })
+    ).toBe(20_000);
+  });
+
+  // ── Custom override key pointing to an unset env var ─────────────────────
+
+  it("falls through gracefully when the custom override env var is not defined", () => {
+    process.env.NEXT_PUBLIC_APP_ENV = "uat";
+    delete process.env.MY_CUSTOM_TIMEOUT_KEY;
+    delete process.env.HUSHH_SLOW_REQUEST_TIMEOUT_MS;
+
+    // parsePositiveInteger(undefined) → null → no override applied.
+    expect(
+      resolveSlowRequestTimeoutMs(20_000, { overrideEnvKey: "MY_CUSTOM_TIMEOUT_KEY" })
+    ).toBe(20_000);
+  });
+
+  // ── Override env var with fringe string values ────────────────────────────
+
+  it("ignores override env vars that contain non-positive or non-numeric strings", () => {
+    process.env.NEXT_PUBLIC_APP_ENV = "uat";
+
+    const fringe = ["0", "-1", "abc", "NaN", "Infinity", "", "  "];
+    for (const value of fringe) {
+      process.env.HUSHH_SLOW_REQUEST_TIMEOUT_MS = value;
+      // parsePositiveInteger rejects all of these → falls through to safeDefaultMs.
+      expect(
+        resolveSlowRequestTimeoutMs(20_000),
+        `override "${value}" should be ignored`
+      ).toBe(20_000);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Extends the canonical `request-timeouts` test suite with 11 new cases covering fringe-input boundary fallbacks in `resolveSlowRequestTimeoutMs`. The tests pin the guard contract — `Number.isFinite(defaultMs) && defaultMs > 0` — which ensures every code path that depends on a request timeout receives a non-zero, non-NaN value even when callers supply negative integers, zero, NaN, Infinity, undefined, or empty/invalid override env-var strings. No new files, direct production imports, upstream base, zero merge conflicts.

## Files changed (1)

| File | Change |
|---|---|
| `hushh-webapp/__tests__/utils/request-timeouts.test.ts` | +176 lines — section comment block + `describe("resolveSlowRequestTimeoutMs — fringe-input boundary fallbacks")` with 11 `it` cases |

## Production module exercised

```typescript
// hushh-webapp/lib/utils/request-timeouts.ts

const DEVELOPMENT_SLOW_REQUEST_TIMEOUT_MS = 75_000;   // safe floor

function parsePositiveInteger(value: string | undefined): number | null
  // Returns null for "0", "-1", "abc", "NaN", "Infinity", "", whitespace.

export function resolveSlowRequestTimeoutMs(defaultMs, options?): number
  // Guard: Number.isFinite(defaultMs) && defaultMs > 0
  //   → true:  safeDefaultMs = Math.round(defaultMs)
  //   → false: safeDefaultMs = DEVELOPMENT_SLOW_REQUEST_TIMEOUT_MS (75 000)
  // Override: parsePositiveInteger(env[overrideEnvKey]) — returns null for fringe strings.
  // Development floor: options.developmentFloorMs || DEVELOPMENT_SLOW_REQUEST_TIMEOUT_MS
  //   (zero is falsy → treated as absent → 75 000 floor applied).
```

## New test coverage

### Negative `defaultMs` (1 case)

`-1`, `-5_000`, `-Infinity` → all return `75_000`. The `defaultMs > 0` guard catches every negative value; no negative timeout escapes to callers.

### Zero `defaultMs` — closed-posture boundary (1 case)

`0` → returns `75_000`. Zero is finite but not positive; a zero-millisecond timeout would cause immediate connection drops and is treated as a configuration error.

### NaN `defaultMs` — no-NaN contract (1 case)

`Number.NaN` → returns `75_000`. Asserts both that the result equals `75_000` AND that `Number.isNaN(result) === false` — NaN can never escape the function boundary.

### Infinity `defaultMs` (1 case)

`Infinity` → returns `75_000`. `Number.isFinite(Infinity) = false` triggers the fallback; result is always finite.

### Undefined / non-numeric `defaultMs` (1 case)

`undefined`, `{}`, `null` → all return `75_000`. `Number.isFinite` returns false for all of these; no runtime exception.

### Fractional `defaultMs` rounds safely (1 case)

`1.4` → `1`, `1.5` → `2`, `20_000.9` → `20_001`. `Math.round` is applied to all valid fractions; `Number.isInteger(result)` is verified — no fractional millisecond leaks.

### Empty `options` object (1 case)

`resolveSlowRequestTimeoutMs(20_000)` ≡ `resolveSlowRequestTimeoutMs(20_000, {})` — the two paths converge when no override key or floor is provided.

### Zero `developmentFloorMs` treated as absent (1 case)

In development: `{ developmentFloorMs: 0 }` → `0 || 75_000 = 75_000` (0 is falsy) → `Math.max(20_000, 75_000) = 75_000`. Documents the falsy-zero semantic.

### Negative `developmentFloorMs` does not undercut `safeDefaultMs` (1 case)

In development: `{ developmentFloorMs: -5_000 }` → `-5_000` is truthy → `Math.max(20_000, -5_000) = 20_000`. `safeDefaultMs` always wins against a negative floor.

### Custom override key pointing to an unset env var (1 case)

`{ overrideEnvKey: "MY_CUSTOM_TIMEOUT_KEY" }` with the var deleted → `parsePositiveInteger(undefined) = null` → no override → returns `safeDefaultMs`.

### Fringe override env-var strings (1 case — 7 parametrized values)

`HUSHH_SLOW_REQUEST_TIMEOUT_MS` set to `"0"`, `"-1"`, `"abc"`, `"NaN"`, `"Infinity"`, `""`, `"  "` → `parsePositiveInteger` returns `null` for all → falls through to `safeDefaultMs = 20_000`.

## CI gate checklist
- [x] **PR Base Policy** — targets `integration/pr-train`; branch cut directly from `upstream/integration/pr-train`, zero merge conflicts
- [x] **DCO** — `Signed-off-by: Abdul Rashid <smirthidharmaiit@gmail.com>`
- [x] **Secret Scan** — diff contains only numeric timeout fixture values and env-var key strings; no credentials
- [x] **Governance** — single modified file in `__tests__/utils/`; no debug artifacts; no `eslint-disable`
- [x] **Path filters** — only `hushh-webapp/__tests__/utils/request-timeouts.test.ts` changed; triggers Web (Next.js) gate
- [x] **Upstream Sync** — branch cut directly from upstream tip; no conflicts possible
- [x] **Base Freshness Gate** — freshly branched; no stale base
- [x] **Web (Next.js)** — all 11 cases are synchronous assertions on a pure function; the new `describe` block has its own `afterEach` restoring the same `ORIGINAL_*` constants used by the outer describe, following the exact env-management pattern of the existing 4 tests; picked up by Vitest `include: ["__tests__/**/*.test.{ts,tsx}"]`
- [x] **No new files** — 176 additions to the existing companion test file; no standalone scripts
- [x] **Direct production import** — `resolveSlowRequestTimeoutMs` already imported in the file header; no new import lines needed
- [x] **No `eslint-disable`** — zero lint suppressions; `as never` used for non-typed fringe inputs
- [x] **Clean diff** — 1 file, 176 additions, 0 deletions, no conflicts, fresh upstream base

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)