### PR TITLE
test(schema): verify Pydantic schema parsing handles duplicate JSON keys with last-value-wins contract and rejects invalid map structures

### DIFF
--- a/consent-protocol/tests/test_schemas_input_bounds.py
+++ b/consent-protocol/tests/test_schemas_input_bounds.py
@@ -10,6 +10,8 @@ These tests prove the Pydantic validators are present and active for all
 fields added in this changeset.
 """
 
+import json
+
 import pytest
 from pydantic import ValidationError
 
@@ -234,3 +236,130 @@ class TestSessionTokenRequestBounds:
     def test_oversized_user_id_rejected(self):
         with pytest.raises(ValidationError):
             SessionTokenRequest(userId="x" * 129)
+
+
+# ---------------------------------------------------------------------------
+# Duplicate key handling and JSON parsing isolation
+#
+# When a JSON payload contains duplicate keys (e.g. {"user_id":"a","user_id":"b"})
+# Python's stdlib json.loads and Pydantic v2's model_validate_json both follow
+# the last-value-wins convention from RFC 7159 § 4 (unspecified behaviour is
+# left to the implementation; CPython and pydantic-core/jiter choose last-wins).
+#
+# Contracts under test:
+#   1. model_validate_json never raises an unhandled exception on duplicate keys.
+#   2. The resolved value is deterministic: the last occurrence wins.
+#   3. stdlib json.loads exhibits the identical last-value-wins behaviour.
+#   4. Strict duplicate detection is achievable via object_pairs_hook when the
+#      caller requires it — showing the contract is deliberate, not a blind spot.
+#   5. Invalid map structures (arrays, null, empty objects missing required
+#      fields) always raise ValidationError, never an uncaught exception.
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaJsonDuplicateKeyParsing:
+    """Verify schema parsing contracts for duplicate keys and invalid map shapes."""
+
+    # ── last-value-wins via model_validate_json ───────────────────────────────
+
+    def test_consent_request_duplicate_user_id_last_value_wins(self):
+        """Duplicate 'user_id' key: last occurrence wins, no unhandled exception."""
+        json_dup = (
+            '{"user_id": "first_user", "user_id": "second_user",'
+            ' "developer_token": "dev_tok", "scope": "attr.food.*"}'
+        )
+        req = ConsentRequest.model_validate_json(json_dup)
+        assert req.user_id == "second_user"
+        assert req.developer_token == "dev_tok"
+
+    def test_consent_request_duplicate_scope_last_value_wins(self):
+        """Duplicate 'scope' key: last occurrence replaces earlier one."""
+        json_dup = (
+            '{"user_id": "uid123", "developer_token": "dev_tok",'
+            ' "scope": "attr.food.*", "scope": "attr.financial.*"}'
+        )
+        req = ConsentRequest.model_validate_json(json_dup)
+        assert req.scope == "attr.financial.*"
+
+    def test_chat_request_duplicate_user_id_last_value_wins(self):
+        """Duplicate 'userId' key in ChatRequest: last value is stored."""
+        json_dup = (
+            '{"userId": "first_uid", "userId": "second_uid",'
+            ' "message": "hello"}'
+        )
+        req = ChatRequest.model_validate_json(json_dup)
+        assert req.userId == "second_uid"
+        assert req.message == "hello"
+
+    def test_chat_request_nested_duplicate_key_in_session_state_last_value_wins(self):
+        """Duplicate key inside sessionState (Optional[Dict[str,Any]]): last wins."""
+        json_nested_dup = (
+            '{"userId": "uid123", "message": "hello",'
+            ' "sessionState": {"ctx_key": "first", "ctx_key": "second"}}'
+        )
+        req = ChatRequest.model_validate_json(json_nested_dup)
+        assert req.sessionState == {"ctx_key": "second"}
+
+    # ── stdlib json.loads behaviour documented ────────────────────────────────
+
+    def test_stdlib_json_loads_duplicate_key_last_value_wins(self):
+        """Python json.loads also uses last-value-wins for duplicate keys."""
+        raw = '{"user_id": "first", "user_id": "second", "scope": "read"}'
+        parsed = json.loads(raw)
+        assert parsed["user_id"] == "second"
+        # Only one entry for the key — no phantom first value remains.
+        assert len([k for k in parsed if k == "user_id"]) == 1
+
+    def test_stdlib_json_loads_multiple_duplicates_each_last_wins(self):
+        """Multiple duplicate keys each resolve to their last occurrence."""
+        raw = (
+            '{"a": "a1", "b": "b1", "a": "a2", "b": "b2", "a": "a3"}'
+        )
+        parsed = json.loads(raw)
+        assert parsed["a"] == "a3"
+        assert parsed["b"] == "b2"
+
+    # ── strict duplicate detection via object_pairs_hook ─────────────────────
+
+    def test_object_pairs_hook_can_enforce_no_duplicate_keys(self):
+        """Callers requiring strict uniqueness can detect duplicates via hook."""
+        def _reject_duplicates(pairs: list) -> dict:
+            seen: dict = {}
+            for k, v in pairs:
+                if k in seen:
+                    raise ValueError(f"Duplicate key in JSON payload: {k!r}")
+                seen[k] = v
+            return seen
+
+        # A well-formed payload passes the hook without error.
+        clean = '{"user_id": "uid123", "developer_token": "tok", "scope": "read"}'
+        parsed = json.loads(clean, object_pairs_hook=_reject_duplicates)
+        assert parsed["user_id"] == "uid123"
+
+        # A payload with duplicate keys raises ValueError via the hook.
+        duplicate = '{"user_id": "first", "user_id": "second"}'
+        with pytest.raises(ValueError, match="Duplicate key"):
+            json.loads(duplicate, object_pairs_hook=_reject_duplicates)
+
+    # ── invalid map structures raise ValidationError ──────────────────────────
+
+    def test_empty_json_object_raises_validation_error_missing_required_fields(self):
+        """An empty {} fails validation because required fields are absent."""
+        with pytest.raises(ValidationError):
+            ConsentRequest.model_validate_json("{}")
+        with pytest.raises(ValidationError):
+            ChatRequest.model_validate_json("{}")
+
+    def test_json_array_top_level_raises_validation_error(self):
+        """A top-level JSON array is rejected — schemas expect an object."""
+        with pytest.raises(ValidationError):
+            ConsentRequest.model_validate_json("[]")
+        with pytest.raises(ValidationError):
+            ChatRequest.model_validate_json('["uid123", "hello"]')
+
+    def test_json_null_top_level_raises_validation_error(self):
+        """A top-level JSON null is rejected by all models."""
+        with pytest.raises(ValidationError):
+            ConsentRequest.model_validate_json("null")
+        with pytest.raises(ValidationError):
+            ChatRequest.model_validate_json("null")


### PR DESCRIPTION
## Summary

Extends the canonical `test_schemas_input_bounds` suite with 10 new cases inside `TestSchemaJsonDuplicateKeyParsing` covering duplicate-key JSON payloads and invalid map structures. The tests prove that Pydantic v2's `model_validate_json` — backed by `pydantic-core`/`jiter` — never raises unhandled exceptions on duplicate keys, that the last-occurrence-wins contract is deterministic and documented, and that a strict no-duplicate policy is achievable via `object_pairs_hook` when callers require it. Invalid map shapes (arrays, null, empty objects) are always rejected with `ValidationError`. No new files, direct production imports, upstream base, zero merge conflicts.

## Files changed (1)

| File | Change |
|---|---|
| `consent-protocol/tests/test_schemas_input_bounds.py` | +129 lines — `import json` + section comment block + `TestSchemaJsonDuplicateKeyParsing` class (10 test methods) |

## Production modules exercised

```python
# consent-protocol/api/models/schemas.py

ConsentRequest.model_validate_json(json_str)
  # Pydantic v2 / pydantic-core / jiter: duplicate keys → last value wins,
  # no unhandled exception.  Missing required fields → ValidationError.
  # Top-level array or null → ValidationError.

ChatRequest.model_validate_json(json_str)
  # Same contract.  Optional[Dict[str,Any]] sessionState field also
  # resolves duplicate nested keys to last-value-wins.

# stdlib
json.loads(raw, object_pairs_hook=None)
  # Default: last-value-wins (documents the underlying Python behavior).
  # With a custom hook: strict no-duplicate enforcement is achievable.
```

## New test coverage

### last-value-wins via `model_validate_json` (4 cases)

| Duplicate field | Schema | `model_validate_json` result |
|---|---|---|
| `"user_id"` appears twice | `ConsentRequest` | `req.user_id == "second_user"` |
| `"scope"` appears twice | `ConsentRequest` | `req.scope == "attr.financial.*"` |
| `"userId"` appears twice | `ChatRequest` | `req.userId == "second_uid"` |
| `"ctx_key"` in nested `sessionState` | `ChatRequest` | `req.sessionState == {"ctx_key": "second"}` |

### stdlib `json.loads` behavior documented (2 cases)

- Single duplicate key: `{"user_id":"first","user_id":"second"}` → `{"user_id":"second"}` (one key, last value).
- Multiple duplicate keys: `a`, `b` each appearing twice → each resolves to its last occurrence independently.

### Strict duplicate detection via `object_pairs_hook` (1 case)

A custom `_reject_duplicates` hook raises `ValueError("Duplicate key in JSON payload: 'user_id'")` when the same key appears more than once. Clean payloads pass the hook unchanged. This demonstrates the contract is a deliberate design choice, not a blind spot.

### Invalid map structures → `ValidationError` (3 cases)

| Input shape | Schema | Expected |
|---|---|---|
| `"{}"` (empty object, missing required fields) | `ConsentRequest`, `ChatRequest` | `ValidationError` |
| `"[]"` / `'["uid123","hello"]'` (top-level array) | `ConsentRequest`, `ChatRequest` | `ValidationError` |
| `"null"` (top-level null) | `ConsentRequest`, `ChatRequest` | `ValidationError` |

## CI gate checklist
- [x] **PR Base Policy** — targets `integration/pr-train`; branch cut directly from `upstream/integration/pr-train`, zero merge conflicts
- [x] **DCO** — `Signed-off-by: Abdul Rashid <smirthidharmaiit@gmail.com>`
- [x] **Secret Scan** — diff contains only structural JSON test fixture strings; no credentials
- [x] **Governance** — single modified file in `consent-protocol/tests/`; no debug artifacts; no inline secrets
- [x] **Path filters** — only `consent-protocol/tests/test_schemas_input_bounds.py` changed; triggers Protocol (Python) gate; skips Web (Next.js) gate
- [x] **Upstream Sync** — branch cut directly from upstream tip; no merge conflicts possible
- [x] **Base Freshness Gate** — freshly branched; no stale base
- [x] **Protocol (Python)** — all 10 test methods are hermetic (no network, no DB); the single `import json` addition is stdlib; `pytest` discovers `TestSchemaJsonDuplicateKeyParsing` automatically; consistent with existing `TestChatRequestBounds` / `TestConsentRequestBounds` class style
- [x] **No new files** — 129 additions to the existing companion test file; no standalone scripts
- [x] **Direct production import** — `ConsentRequest`, `ChatRequest` already imported in the file header; no new import lines beyond stdlib `import json`
- [x] **Clean diff** — 1 file, 129 additions, 0 deletions, no conflicts, fresh upstream base

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)