### PR TITLE
test(utils): verify URL building utility cleanly trims and sanitizes structural whitespace

### DIFF
--- a/hushh-webapp/__tests__/utils/backend-runtime.test.ts
+++ b/hushh-webapp/__tests__/utils/backend-runtime.test.ts
@@ -70,7 +70,39 @@ describe("backend runtime resolution", () => {
     const helper = await loadHelper();
     expect(helper.getDeveloperApiUrl()).toBe("https://consent-protocol-uat.example.com");
   });
-    it("preserves localhost canonicalization stability for uppercase loopback hosts", async () => {
+
+  describe("URL whitespace sanitization", () => {
+    it("strips leading and trailing spaces from a backend URL env var without throwing", async () => {
+      process.env.K_SERVICE = "hushh-webapp";
+      process.env.PYTHON_API_URL = "  https://api.example.com  ";
+      const helper = await loadHelper();
+      expect(helper.getPythonApiUrl()).toBe("https://api.example.com");
+    });
+
+    it("strips surrounding tab characters from a backend URL env var without throwing", async () => {
+      process.env.K_SERVICE = "hushh-webapp";
+      process.env.PYTHON_API_URL = "\thttps://api.example.com\t";
+      const helper = await loadHelper();
+      expect(helper.getPythonApiUrl()).toBe("https://api.example.com");
+    });
+
+    it("strips a trailing newline from a backend URL env var without throwing", async () => {
+      process.env.K_SERVICE = "hushh-webapp";
+      process.env.PYTHON_API_URL = "https://api.example.com\n";
+      const helper = await loadHelper();
+      expect(helper.getPythonApiUrl()).toBe("https://api.example.com");
+    });
+
+    it("skips a whitespace-only env var and falls through to the next key", async () => {
+      process.env.K_SERVICE = "hushh-webapp";
+      process.env.PYTHON_API_URL = "   ";
+      process.env.BACKEND_URL = "https://api.example.com";
+      const helper = await loadHelper();
+      expect(helper.getPythonApiUrl()).toBe("https://api.example.com");
+    });
+  });
+
+  it("preserves localhost canonicalization stability for uppercase loopback hosts", async () => {
     process.env.BACKEND_URL = "http://LOCALHOST:8000";
     process.env.NEXT_PUBLIC_BACKEND_URL = "http://LOCALHOST:8000";
 


### PR DESCRIPTION
## What

Adds four whitespace-sanitization test cases to the existing `backend-runtime.test.ts` suite covering the `normalizeUrl` helper inside `app/api/_utils/backend.ts`.

## Why

`normalizeUrl` calls `.trim()` before passing any env-supplied URL string to the `new URL()` constructor. Without that guard, a space-padded env var (e.g. `" https://api.example.com "`) would cause `new URL()` to throw a runtime `TypeError`, silently breaking every route handler that calls `getPythonApiUrl()` or `getDeveloperApiUrl()`. These tests lock in the contract so the guard can never be accidentally removed.

## Changes

**File modified:** `hushh-webapp/__tests__/utils/backend-runtime.test.ts`  
No production code changed — test-only patch.

Four cases added inside a new nested `describe("URL whitespace sanitization")` block:

| # | Input to `PYTHON_API_URL` | Asserted result |
|---|---|---|
| 1 | `"  https://api.example.com  "` (spaces) | resolves to `"https://api.example.com"` without throwing |
| 2 | `"\thttps://api.example.com\t"` (tabs) | resolves to `"https://api.example.com"` without throwing |
| 3 | `"https://api.example.com\n"` (trailing newline) | resolves to `"https://api.example.com"` without throwing |
| 4 | `"   "` (whitespace-only) + valid `BACKEND_URL` | skips the blank value and falls through to the next key |

## Reviewer risk

- **Zero production risk** — no source files modified, only a test file
- **Zero secret-scan risk** — all URL strings use RFC 2606 `example.com` (documentation-reserved domain), no tokens or credentials
- **DCO compliant** — single commit carries `Signed-off-by: Abdul Rashid <abdulbeast4@gmail.com>`
- **PR Base Policy compliant** — targets `integration/pr-train`, not `main`
- **One commit, one file** — trivial to review and revert if needed

## Test plan

- [ ] `vitest run __tests__/utils/backend-runtime.test.ts` — all existing + 4 new cases pass
- [ ] No changes to route handlers or production utilities
- [ ] CI Secret Scan, DCO, and PR Base Policy checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)