### PR TITLE
perf(frontend): add lazy loading to images in consent center

### DIFF
--- a/hushh-webapp/components/consent/consent-center-view.tsx
+++ b/hushh-webapp/components/consent/consent-center-view.tsx
@@ -631,6 +631,8 @@ export function ConsentCenterView({
                     src={requesterImage}
                     alt={bundle.counterpartLabel}
                     className="size-full object-cover"
+                    loading="lazy"
+                    decoding="async"
                   />
                 ) : (
                   requesterInitials(bundle.counterpartLabel)
@@ -905,6 +907,8 @@ export function ConsentCenterView({
                     src={requesterImage}
                     alt={entryHeadline(entry)}
                     className="size-full object-cover"
+                    loading="lazy"
+                    decoding="async"
                   />
                 ) : (
                   requesterInitials(entry.counterpart_label)


### PR DESCRIPTION
# Description
Added `loading="lazy"` and `decoding="async"` to native `<img>` tags in `consent-center-view.tsx`. This is a frontend performance optimization that defers off-screen image loading and prevents UI blocking during image decoding in long consent lists.

## 📌 Core Impact
- [x] **Routes Touched:** None
- [x] **API / Schema / Trust Boundary:** None
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS**: (N/A - Frontend Web UI Only)
- [ ] **Android**: (N/A - Frontend Web UI Only)

## 🧪 Testing & Privacy
- [x] Tested on Web (Chrome/Safari)
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible