### PR TITLE
fix(frontend): disable spellcheck in renaissance market list search

### DIFF
--- a/hushh-webapp/components/kai/cards/renaissance-market-list.tsx
+++ b/hushh-webapp/components/kai/cards/renaissance-market-list.tsx
@@ -400,6 +400,7 @@ export function RiaPicksList({
                         value={query}
                         onChange={(event) => setQuery(event.target.value)}
                         placeholder="Search symbol, company, sector, or thesis"
+                        spellCheck={false}
                         className="h-10 rounded-2xl border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-compact)] pl-9 shadow-[var(--shadow-xs)]"
                       />
                     </div>
@@ -543,6 +544,7 @@ export function RiaPicksList({
                       value={query}
                       onChange={(event) => setQuery(event.target.value)}
                       placeholder="Search symbol, company, sector, or thesis"
+                      spellCheck={false}
                       className="h-10 rounded-2xl border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-compact)] pl-9 shadow-[var(--shadow-xs)]"
                     />
                   </div>


### PR DESCRIPTION
# Description
Disabled `spellCheck` on the search inputs in `renaissance-market-list.tsx`. Since users frequently search for proper nouns and stock symbols (e.g., AAPL, MSFT), this prevents the browser from cluttering the input with red squiggly error lines.

## 📌 Core Impact
- [x] **Routes Touched:** None
- [x] **API / Schema / Trust Boundary:** None
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS**: (N/A - Frontend Web UI Only)
- [ ] **Android**: (N/A - Frontend Web UI Only)

## 🧪 Testing & Privacy
- [x] Tested on Web (Chrome/Safari)
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible