### PR TITLE
fix(frontend): add autoComplete to location request form inputs

### DIFF
--- a/hushh-webapp/app/one/location/request/[token]/page-client.tsx
+++ b/hushh-webapp/app/one/location/request/[token]/page-client.tsx
@@ -171,13 +171,16 @@ export default function PublicLocationRequestPageClient() {
                 value={visitorDisplayName}
                 onChange={(event) => setVisitorDisplayName(event.target.value)}
                 placeholder="Your name"
+                autoComplete="name"
                 maxLength={120}
               />
               <Input
                 value={phoneNumber}
                 onChange={(event) => setPhoneNumber(event.target.value)}
                 placeholder="Phone number"
+                type="tel"
                 inputMode="tel"
+                autoComplete="tel"
                 maxLength={32}
               />
               <Textarea


### PR DESCRIPTION
# Description
Added `autoComplete="name"`, `autoComplete="tel"`, and `type="tel"` to the location request form inputs in `app/one/location/request/[token]/page-client.tsx`. This improves UX by enabling browser-native autofill for contact information and ensuring mobile devices bring up the correct numeric keypad.

## 📌 Core Impact
- [x] **Routes Touched:** None
- [x] **API / Schema / Trust Boundary:** None
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS**: (N/A - Frontend Web UI Only)
- [ ] **Android**: (N/A - Frontend Web UI Only)

## 🧪 Testing & Privacy
- [x] Tested on Web (Chrome/Safari)
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible