### PR TITLE
fix(frontend): disable autocapitalize and autocorrect on api keys

### DIFF
--- a/hushh-webapp/components/profile/runtime-secret-settings-card.tsx
+++ b/hushh-webapp/components/profile/runtime-secret-settings-card.tsx
@@ -426,6 +426,8 @@ export function RuntimeSecretSettingsCard({
                     type={showKey ? "text" : "password"}
                     autoComplete="off"
                     spellCheck={false}
+                    autoCapitalize="none"
+                    autoCorrect="off"
                     placeholder={
                       configured
                         ? MASKED_RUNTIME_SECRET_PLACEHOLDER


### PR DESCRIPTION
# Description
Added `autoCapitalize="none"` and `autoCorrect="off"` to the API key inputs in `runtime-secret-settings-card.tsx`. This prevents mobile keyboards from automatically capitalizing the first letter or autocorrecting segments of API keys when the user toggles them to visible (`type="text"`), which would otherwise silently invalidate the key.

## 📌 Core Impact
- [x] **Routes Touched:** None
- [x] **API / Schema / Trust Boundary:** None
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS**: (N/A - Frontend Web UI Only)
- [ ] **Android**: (N/A - Frontend Web UI Only)

## 🧪 Testing & Privacy
- [x] Tested on Web (Chrome/Safari)
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible