### PR TITLE
fix(frontend): add type=url to url inputs in developer docs

### DIFF
--- a/hushh-webapp/components/developers/developer-docs-hub.tsx
+++ b/hushh-webapp/components/developers/developer-docs-hub.tsx
@@ -740,6 +740,7 @@ function AccessWorkspace({
                     <InputGroup>
                       <InputGroupInput
                         id="developer-website-url"
+                        type="url"
                         value={profileDraft.website_url}
                         onChange={(event) => onProfileDraftChange("website_url", event.target.value)}
                         placeholder="https://example.com"
@@ -754,6 +755,7 @@ function AccessWorkspace({
                     <InputGroup>
                       <InputGroupInput
                         id="developer-brand-image-url"
+                        type="url"
                         value={profileDraft.brand_image_url}
                         onChange={(event) =>
                           onProfileDraftChange("brand_image_url", event.target.value)
@@ -768,6 +770,7 @@ function AccessWorkspace({
                     <InputGroup>
                       <InputGroupInput
                         id="developer-support-url"
+                        type="url"
                         value={profileDraft.support_url}
                         onChange={(event) => onProfileDraftChange("support_url", event.target.value)}
                         placeholder="https://example.com/support"
@@ -782,6 +785,7 @@ function AccessWorkspace({
                     <InputGroup>
                       <InputGroupInput
                         id="developer-policy-url"
+                        type="url"
                         value={profileDraft.policy_url}
                         onChange={(event) => onProfileDraftChange("policy_url", event.target.value)}
                         placeholder="https://example.com/privacy"


### PR DESCRIPTION
# Description
Added `type="url"` to the website, brand image, support, and policy URL inputs in `developer-docs-hub.tsx`. This improves the mobile user experience by triggering the URL-optimized keyboard layout and enables native browser validation for these fields.

## 📌 Core Impact
- [x] **Routes Touched:** None
- [x] **API / Schema / Trust Boundary:** None
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS**: (N/A - Frontend Web UI Only)
- [ ] **Android**: (N/A - Frontend Web UI Only)

## 🧪 Testing & Privacy
- [x] Tested on Web (Chrome/Safari)
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible