### PR TITLE
fix(frontend): add autocomplete one-time-code to kyc alias

### DIFF
--- a/hushh-webapp/app/one/kyc/page.tsx
+++ b/hushh-webapp/app/one/kyc/page.tsx
@@ -2234,6 +2234,7 @@ function OneKycWorkspace() {
                     onChange={(event) => setAliasCode(event.target.value)}
                     placeholder="Verification code"
                     inputMode="numeric"
+                    autoComplete="one-time-code"
                   />
                 ) : null}
                 {aliasChallenge?.reviewCode ? (


### PR DESCRIPTION
# Description
Added `autoComplete="one-time-code"` to the email alias verification code input in `app/one/kyc/page.tsx`. This significantly improves the mobile UX by allowing iOS and Android keyboards to auto-suggest the OTP code received via email/SMS for one-tap autofill.

## 📌 Core Impact
- [x] **Routes Touched:** `/one/kyc`
- [x] **API / Schema / Trust Boundary:** None
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation

## 🧪 Testing & Privacy
- [x] Tested on Web (Chrome/Safari)
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible