### PR TITLE
Fix/apply log redaction to location agent service

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -18,6 +18,8 @@ from hushh_mcp.operons.location.policy import (
     normalize_source_platform,
 )
 
+from mcp_modules.log_redaction import redact_log_value
+
 logger = logging.getLogger(__name__)
 _NOTIFICATION_EXECUTOR = ThreadPoolExecutor(
     max_workers=max(1, int(os.getenv("ONE_LOCATION_NOTIFICATION_WORKERS", "2"))),
@@ -202,14 +204,14 @@ def _submit_notification_send(
                 logger.warning(
                     "one.location.notification_token_cleanup_failed type=%s user=%s error=%s",
                     notification_type,
-                    user_id,
+                    redact_log_value(user_id),
                     exc,
                 )
         except Exception as exc:
             logger.warning(
                 "one.location.notification_send_failed type=%s user=%s error=%s",
                 notification_type,
-                user_id,
+                redact_log_value(user_id),
                 exc,
             )
 
@@ -219,7 +221,7 @@ def _submit_notification_send(
         logger.warning(
             "one.location.notification_submit_failed type=%s user=%s error=%s",
             notification_type,
-            user_id,
+            redact_log_value(user_id),
             exc,
         )
 
@@ -486,7 +488,7 @@ class OneLocationAgentService:
                 {"user_id": user_id},
             )
         except Exception as exc:
-            logger.debug("one.location.identity_lookup_failed user=%s error=%s", user_id, exc)
+            logger.debug("one.location.identity_lookup_failed user=%s error=%s", redact_log_value(user_id), exc)
             return None
 
     def _identity_row_by_phone_digits(self, phone_digits: str) -> dict[str, Any] | None:

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -17,7 +17,6 @@ from hushh_mcp.operons.location.policy import (
     normalize_duration_hours,
     normalize_source_platform,
 )
-
 from mcp_modules.log_redaction import redact_log_value
 
 logger = logging.getLogger(__name__)

--- a/consent-protocol/tests/services/test_one_location_log_redaction.py
+++ b/consent-protocol/tests/services/test_one_location_log_redaction.py
@@ -5,7 +5,7 @@ appear in plaintext in production log output.
 """
 
 import logging
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from mcp_modules.log_redaction import REDACTED, redact_log_value
 

--- a/consent-protocol/tests/services/test_one_location_log_redaction.py
+++ b/consent-protocol/tests/services/test_one_location_log_redaction.py
@@ -1,0 +1,59 @@
+"""
+Tests for log redaction in OneLocationAgentService.
+Verifies user_id is redacted via redact_log_value in all
+notification and identity lookup log paths.
+"""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestOneLocationLogRedaction:
+    """user_id must never appear in plaintext in location service logs."""
+
+    def test_notification_send_failed_redacts_user_id(self, caplog):
+        """notification_send_failed must not log raw user_id."""
+        from mcp_modules.log_redaction import redact_log_value
+        user_id = "firebase-uid-abc123"
+        redacted = redact_log_value(user_id)
+        with caplog.at_level(logging.WARNING):
+            logging.getLogger("hushh_mcp.services.one_location_agent_service").warning(
+                "one.location.notification_send_failed type=%s user=%s error=%s",
+                "push",
+                redacted,
+                "timeout",
+            )
+        messages = [r.message for r in caplog.records]
+        assert any("notification_send_failed" in m for m in messages)
+        assert not any("firebase-uid-abc123" in m for m in messages)
+
+    def test_identity_lookup_failed_redacts_user_id(self, caplog):
+        """identity_lookup_failed must not log raw user_id."""
+        from mcp_modules.log_redaction import redact_log_value
+        user_id = "uid-secret-xyz"
+        redacted = redact_log_value(user_id)
+        with caplog.at_level(logging.DEBUG):
+            logging.getLogger("hushh_mcp.services.one_location_agent_service").debug(
+                "one.location.identity_lookup_failed user=%s error=%s",
+                redacted,
+                "db timeout",
+            )
+        messages = [r.message for r in caplog.records]
+        assert any("identity_lookup_failed" in m for m in messages)
+        assert not any("uid-secret-xyz" in m for m in messages)
+
+    def test_redact_log_value_masks_user_id_string(self):
+        """redact_log_value must redact a plain user_id string."""
+        from mcp_modules.log_redaction import redact_log_value, REDACTED
+        result = redact_log_value("some-firebase-uid")
+        assert result == REDACTED
+
+    def test_redact_log_value_masks_user_id_in_dict(self):
+        """redact_log_value must redact user_id key in a dict."""
+        from mcp_modules.log_redaction import redact_log_value, REDACTED
+        payload = {"user_id": "uid-abc", "type": "push"}
+        result = redact_log_value(payload)
+        assert result["user_id"] == REDACTED
+        assert result["type"] == "push"

--- a/consent-protocol/tests/services/test_one_location_log_redaction.py
+++ b/consent-protocol/tests/services/test_one_location_log_redaction.py
@@ -5,9 +5,8 @@ notification and identity lookup log paths.
 """
 
 import logging
-from unittest.mock import MagicMock, patch
 
-import pytest
+from mcp_modules.log_redaction import REDACTED, redact_log_value
 
 
 class TestOneLocationLogRedaction:
@@ -15,7 +14,6 @@ class TestOneLocationLogRedaction:
 
     def test_notification_send_failed_redacts_user_id(self, caplog):
         """notification_send_failed must not log raw user_id."""
-        from mcp_modules.log_redaction import redact_log_value
         user_id = "firebase-uid-abc123"
         redacted = redact_log_value(user_id)
         with caplog.at_level(logging.WARNING):
@@ -31,7 +29,6 @@ class TestOneLocationLogRedaction:
 
     def test_identity_lookup_failed_redacts_user_id(self, caplog):
         """identity_lookup_failed must not log raw user_id."""
-        from mcp_modules.log_redaction import redact_log_value
         user_id = "uid-secret-xyz"
         redacted = redact_log_value(user_id)
         with caplog.at_level(logging.DEBUG):
@@ -46,13 +43,11 @@ class TestOneLocationLogRedaction:
 
     def test_redact_log_value_masks_user_id_string(self):
         """redact_log_value must redact a plain user_id string."""
-        from mcp_modules.log_redaction import redact_log_value, REDACTED
         result = redact_log_value("some-firebase-uid")
         assert result == REDACTED
 
     def test_redact_log_value_masks_user_id_in_dict(self):
         """redact_log_value must redact user_id key in a dict."""
-        from mcp_modules.log_redaction import redact_log_value, REDACTED
         payload = {"user_id": "uid-abc", "type": "push"}
         result = redact_log_value(payload)
         assert result["user_id"] == REDACTED

--- a/consent-protocol/tests/services/test_one_location_log_redaction.py
+++ b/consent-protocol/tests/services/test_one_location_log_redaction.py
@@ -1,10 +1,11 @@
 """
 Tests for log redaction in OneLocationAgentService.
-Verifies user_id is redacted via redact_log_value in all
-notification and identity lookup log paths.
+Exercises real service call sites to prove user_id does not
+appear in plaintext in production log output.
 """
 
 import logging
+from unittest.mock import MagicMock, patch
 
 from mcp_modules.log_redaction import REDACTED, redact_log_value
 
@@ -13,33 +14,33 @@ class TestOneLocationLogRedaction:
     """user_id must never appear in plaintext in location service logs."""
 
     def test_notification_send_failed_redacts_user_id(self, caplog):
-        """notification_send_failed must not log raw user_id."""
-        user_id = "firebase-uid-abc123"
-        redacted = redact_log_value(user_id)
-        with caplog.at_level(logging.WARNING):
-            logging.getLogger("hushh_mcp.services.one_location_agent_service").warning(
-                "one.location.notification_send_failed type=%s user=%s error=%s",
-                "push",
-                redacted,
-                "timeout",
+        """Real _deliver path must not log raw user_id on send failure."""
+        from hushh_mcp.services.one_location_agent_service import OneLocationAgentService
+        svc = OneLocationAgentService.__new__(OneLocationAgentService)
+        raw_user_id = "firebase-uid-abc123"
+        with patch("hushh_mcp.services.one_location_agent_service.ensure_firebase_admin"),\
+             patch("hushh_mcp.services.one_location_agent_service.get_db", side_effect=RuntimeError("db down")),\
+             caplog.at_level(logging.WARNING, logger="hushh_mcp.services.one_location_agent_service"):
+            svc._send_push_notification(
+                user_id=raw_user_id,
+                notification_type="push",
+                title="Test",
+                body="Test body",
             )
-        messages = [r.message for r in caplog.records]
-        assert any("notification_send_failed" in m for m in messages)
-        assert not any("firebase-uid-abc123" in m for m in messages)
+        assert raw_user_id not in caplog.text
+        assert any("notification" in r.message for r in caplog.records)
 
     def test_identity_lookup_failed_redacts_user_id(self, caplog):
-        """identity_lookup_failed must not log raw user_id."""
-        user_id = "uid-secret-xyz"
-        redacted = redact_log_value(user_id)
-        with caplog.at_level(logging.DEBUG):
-            logging.getLogger("hushh_mcp.services.one_location_agent_service").debug(
-                "one.location.identity_lookup_failed user=%s error=%s",
-                redacted,
-                "db timeout",
-            )
-        messages = [r.message for r in caplog.records]
-        assert any("identity_lookup_failed" in m for m in messages)
-        assert not any("uid-secret-xyz" in m for m in messages)
+        """Real _identity_row path must not log raw user_id on db failure."""
+        from hushh_mcp.services.one_location_agent_service import OneLocationAgentService
+        svc = OneLocationAgentService.__new__(OneLocationAgentService)
+        raw_user_id = "uid-secret-xyz"
+        with patch("hushh_mcp.services.one_location_agent_service.get_db", side_effect=RuntimeError("db down")),\
+             caplog.at_level(logging.DEBUG, logger="hushh_mcp.services.one_location_agent_service"):
+            result = svc._identity_row(raw_user_id)
+        assert result is None
+        assert raw_user_id not in caplog.text
+        assert any("identity_lookup_failed" in r.message for r in caplog.records)
 
     def test_redact_log_value_masks_user_id_string(self):
         """redact_log_value must redact a plain user_id string."""


### PR DESCRIPTION

Four log paths in OneLocationAgentService logged raw user_id 
in plaintext. Applied redact_log_value from the canonical 
mcp_modules/log_redaction.py to all four sites.

## 📌 Impact Map
- Routes touched: [x] None
- API/schema/type changes: [x] None
- Cache keys touched: [x] None
- Runtime DB changes: [x] None
- World-model effects: [x] None
- Mobile parity: [x] None
- Docs updated: [x] None
- Config/generated files: [x] None
- Trust boundary: [x] None
- Caller/proxy pairing: [x] Not applicable
- Rollback behavior: [x] Not applicable — logging only
- UI proof: [x] Not applicable — backend only

## ✅ Review-Ready Contract
- [x] Title, body, and tests describe the same contract
- [x] No duplicate PR exists for this surface
- [x] Reachable attach point: one_location_agent_service.py
  called by api/routes/one/location.py (live route)
- [x] Tests exercise production redact_log_value — not mocks
- [x] Commits signed off, CI green

## 🛑 Tri-Flow
- [x] Web: Python backend only
- [x] iOS: Not applicable
- [x] Android: Not applicable

## 🧪 Testing
- [x] Commits signed off
- 4 new tests in tests/services/test_one_location_log_redaction.py

## 🛡️ Privacy & Consent
- [x] Reduces user_id exposure in logs
- [x] redact_log_value returns REDACTED — no exception path added

## 📜 Licensing
- [x] Apache-2.0 compatible
- [x] No new dependencies