### PR TITLE
test(utils): verify mixed-case symbol key normalization in portfolio-normalize

### DIFF
--- a/hushh-webapp/__tests__/utils/portfolio-normalize.test.ts
+++ b/hushh-webapp/__tests__/utils/portfolio-normalize.test.ts
@@ -73,4 +73,54 @@ describe("portfolio normalize helpers", () => {
 
     expect(consolidated).toHaveLength(0);
   });
+
+  it("treats mixed-case symbol variants as the same key and merges without data loss", () => {
+    // Three holdings with identical symbols written in different cases.
+    // normalizeHoldingSymbol uppercases each before mergeHoldingsBySymbol groups by Map key,
+    // so all three must collapse to exactly one canonical entry ("TSYM").
+    const consolidated = consolidateHoldingsBySymbol([
+      {
+        symbol: "tsym",
+        name: "Test Asset Lower",
+        quantity: 4,
+        market_value: 400,
+        cost_basis: 320,
+        unrealized_gain_loss: 80,
+      },
+      {
+        symbol: "TSYM",
+        name: "Test Asset Upper",
+        quantity: 6,
+        market_value: 600,
+        cost_basis: 480,
+        unrealized_gain_loss: 120,
+      },
+      {
+        symbol: "Tsym",
+        name: "Test Asset Mixed",
+        quantity: 2,
+        market_value: 200,
+        cost_basis: 160,
+        unrealized_gain_loss: 40,
+      },
+    ]);
+
+    // No duplicates and no dropped entries — all three folded into one.
+    expect(consolidated).toHaveLength(1);
+
+    const row = consolidated[0];
+    expect(row.symbol).toBe("TSYM");
+
+    // Numeric fields must be summed across all three inputs.
+    expect(row.quantity).toBe(12);
+    expect(row.market_value).toBe(1200);
+    expect(row.cost_basis).toBe(960);
+    expect(row.unrealized_gain_loss).toBe(240);
+
+    // lots_count is the internal merge counter — must equal 3 to confirm no silent drops.
+    expect(row.lots_count).toBe(3);
+
+    // Derived ratio must still be computed correctly on the consolidated values.
+    expect(row.unrealized_gain_loss_pct).toBeCloseTo((240 / 960) * 100, 8);
+  });
  });


### PR DESCRIPTION
## Hushh Research

This PR adds a targeted unit test to the `portfolio-normalize` utility suite verifying the case-insensitivity invariant of the symbol key normalization pipeline.

## What changed

**File:** `hushh-webapp/__tests__/utils/portfolio-normalize.test.ts`

Added one new test case inside the existing `describe("portfolio normalize helpers")` block:

- Passes three holdings with the same symbol written in three different cases: `"tsym"` (lower), `"TSYM"` (upper), `"Tsym"` (mixed)
- Asserts all three fold into **exactly one** consolidated entry with canonical key `"TSYM"`
- Verifies numeric fields are summed correctly across all three inputs (quantity, market\_value, cost\_basis, unrealized\_gain\_loss)
- Asserts `lots_count === 3` — the internal merge counter that proves no entry was silently dropped
- Asserts the derived `unrealized_gain_loss_pct` is recomputed correctly on the consolidated totals

## Why this matters

`normalizeHoldingSymbol` and `mergeHoldingsBySymbol` both call `.toUpperCase()` when building the dedup Map key. This test locks in that guarantee so any future refactor that accidentally breaks case-folding will be caught immediately, before it can cause double-counted or phantom-dropped holdings in the dashboard.

## Test design constraints

- All fixture strings are low-entropy and synthetic (`"tsym"`, `"Test Asset Lower"`, etc.) — zero secret-scan surface
- No new imports, no new files — rides the existing `consolidateHoldingsBySymbol` import
- Fully isolated: no network, no DB, no filesystem — pure function input/output
- Compliant with the existing Vitest suite structure

## Test plan

- [ ] `npm test -- __tests__/utils/portfolio-normalize.test.ts` passes (4 tests green)
- [ ] No new lint warnings (`npm run lint`)
- [ ] Typecheck clean (`npm run typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)