### PR TITLE
test(observability): verify TSV tab-delimiter handling in log redactor sanitization layer

### DIFF
--- a/hushh-webapp/__tests__/services/observability-log-redactor.test.ts
+++ b/hushh-webapp/__tests__/services/observability-log-redactor.test.ts
@@ -41,3 +41,67 @@ describe("observability log redactor", () => {
     expect(result.sanitized).not.toHaveProperty("user_email");
   });
 });
+
+// ── Tab-separated value handling ──────────────────────────────────────────────
+//
+// Log pipelines frequently emit TSV-structured entries where field values may
+// carry PII (email addresses, vault keys).  The redactor must sanitize every
+// sensitive token in-place regardless of surrounding tab delimiters, and must
+// leave the tab characters themselves untouched so that downstream TSV parsers
+// can still reconstruct the record structure correctly.
+//
+// Two contracts are verified:
+//   1. Pattern matching fires correctly even when tabs surround a sensitive token.
+//   2. Tab characters are never consumed, escaped, or shifted by a redaction pass.
+
+describe("observability log redactor — tab-separated value handling", () => {
+  it("redacts sensitive tokens inside a tab-delimited log entry while preserving all tab delimiters", () => {
+    // Four-column TSV: timestamp \t email \t action \t vault_key
+    // EMAIL_PATTERN domain clause [A-Z0-9.-]+ does not allow underscores,
+    // so the domain is written without underscores to guarantee a match.
+    const tsvLogLine = [
+      "test_timestamp_001",
+      "test_user@testorg.com",
+      "test_action_read",
+      "vault_test_org_key_001",
+    ].join("\t");
+
+    const redacted = redactObservabilityLog(tsvLogLine);
+
+    // Sensitive tokens must be scrubbed regardless of surrounding tab delimiters.
+    expect(redacted).not.toContain("test_user@testorg.com");
+    expect(redacted).toContain("[REDACTED_EMAIL]");
+    expect(redacted).not.toContain("vault_test_org_key_001");
+    expect(redacted).toContain("[REDACTED_VAULT_KEY]");
+
+    // Tab delimiters must survive intact — three delimiters for four fields.
+    // If redaction consumed or shifted a tab, the downstream TSV parser would
+    // produce a malformed record with the wrong column count.
+    const tabCount = (redacted.match(/\t/g) ?? []).length;
+    expect(tabCount).toBe(3);
+
+    // Non-sensitive fields pass through unchanged.
+    expect(redacted).toContain("test_timestamp_001");
+    expect(redacted).toContain("test_action_read");
+  });
+
+  it("matches and redacts a sensitive token that immediately follows a tab without crashing", () => {
+    // Validates that a word boundary after \t is correctly recognized so the
+    // vault key is redacted even when no other text precedes it in the field.
+    const tabEmbeddedValue = "user\tprofile\tdata\tvault_tab_test_key_002";
+
+    const output = redactObservabilityLog(tabEmbeddedValue);
+
+    // The vault key at the end of the tab-delimited string must be redacted.
+    expect(output).not.toContain("vault_tab_test_key_002");
+    expect(output).toContain("[REDACTED_VAULT_KEY]");
+
+    // All three structural tab characters must be preserved.
+    expect((output.match(/\t/g) ?? []).length).toBe(3);
+
+    // Non-sensitive field content passes through unchanged.
+    expect(output).toContain("user");
+    expect(output).toContain("profile");
+    expect(output).toContain("data");
+  });
+});


### PR DESCRIPTION
## Hushh Research

Adds two targeted, zero-reviewer-risk tests to the observability log-redactor suite verifying that the data sanitization layer handles tab-separated value inputs without corrupting downstream TSV field structure.

## What changed

**File:** `hushh-webapp/__tests__/services/observability-log-redactor.test.ts`

New `describe` block: **`observability log redactor — tab-separated value handling`**

### Test 1 — TSV log line with sensitive fields across tab-delimited columns

Constructs `"test_timestamp_001\ttest_user@testorg.com\ttest_action_read\tvault_test_org_key_001"` and asserts:
- `test_user@testorg.com` → `[REDACTED_EMAIL]`
- `vault_test_org_key_001` → `[REDACTED_VAULT_KEY]`
- Tab count stays exactly 3 — redaction must never consume or shift a structural delimiter
- Non-sensitive fields pass through unchanged

### Test 2 — Sensitive token immediately following a `\t`

Passes `"user\tprofile\tdata\tvault_tab_test_key_002"` and asserts:
- Vault key is redacted — `\b` word boundary after `\t` is correctly recognized
- All 3 tabs are preserved
- Plain tokens pass through unchanged

## Test design constraints

- All fixture strings are low-entropy synthetics — zero secret-scan surface
- No new imports — rides existing `redactObservabilityLog` import
- Cleanly branched directly from `integration/pr-train` — no extra commits

## Test plan

- [ ] `npm test -- __tests__/services/observability-log-redactor.test.ts` → 5 tests green
- [ ] `npm run lint` → no new warnings
- [ ] `npm run typecheck` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)