### PR TITLE
fix(frontend): add address autocomplete to ria onboarding

### DIFF
--- a/hushh-webapp/components/ria/onboarding/onboarding-step-services.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-step-services.tsx
@@ -57,6 +57,7 @@ function TextRow({
   placeholder,
   inputMode,
   prefix,
+  autoComplete,
 }: {
   label: string;
   value: string;
@@ -64,6 +65,7 @@ function TextRow({
   placeholder?: string;
   inputMode?: "numeric" | "text";
   prefix?: string;
+  autoComplete?: string;
 }) {
   return (
     <label className="flex min-h-[54px] items-center gap-4 px-4 py-2 sm:px-5">
@@ -75,6 +77,7 @@ function TextRow({
         <input
           type="text"
           inputMode={inputMode}
+          autoComplete={autoComplete}
           value={value}
           onChange={(event) => onChange(event.target.value)}
           placeholder={placeholder}
@@ -244,6 +247,7 @@ export function OnboardingStepServices({
             value={fullStreetAddress}
             onChange={onFullStreetAddressChange}
             placeholder="Building, floor, street"
+            autoComplete="street-address"
           />
           <Divider />
           <TextRow
@@ -251,6 +255,7 @@ export function OnboardingStepServices({
             value={areaLocality}
             onChange={onAreaLocalityChange}
             placeholder="Area or state"
+            autoComplete="address-level1"
           />
           <Divider />
           <TextRow
@@ -258,6 +263,7 @@ export function OnboardingStepServices({
             value={city}
             onChange={onCityChange}
             placeholder="City"
+            autoComplete="address-level2"
           />
           <Divider />
           <TextRow
@@ -266,6 +272,7 @@ export function OnboardingStepServices({
             onChange={onPinZipChange}
             placeholder="PIN / ZIP"
             inputMode="numeric"
+            autoComplete="postal-code"
           />
         </GroupShell>
 


### PR DESCRIPTION
# Description
Added standard `autoComplete` attributes to the Business Location fields in the RIA onboarding flow. This adds support for single-tap keyboard autofill of addresses (`street-address`, `address-level1`, `address-level2`, and `postal-code`), vastly reducing friction for mobile users entering their business address.

## 📌 Core Impact
- [x] **Routes Touched:** `/ria/onboarding`
- [x] **API / Schema / Trust Boundary:** None
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS**: (N/A - Frontend Web UI Only)
- [ ] **Android**: (N/A - Frontend Web UI Only)

## 🧪 Testing & Privacy
- [x] Tested on Web (Chrome/Safari)
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible