### PR TITLE
test(pkm): verify array index boundary guards in PKM memory-card pagination

### DIFF
--- a/hushh-webapp/__tests__/lib/pkm-memory-cards.test.ts
+++ b/hushh-webapp/__tests__/lib/pkm-memory-cards.test.ts
@@ -108,4 +108,59 @@ describe("PKM memory cards", () => {
     expect((domainData.profile as Record<string, unknown>).name).toBe("Akshat Kumar");
     expect((deleted.profile as Record<string, unknown>).roll_no).toBeUndefined();
   });
+
+  it("returns empty array without crash when limit is zero (minimum boundary guard)", () => {
+    // selectRelevantPkmMemoryCards calls cards.slice(0, limit) directly.
+    // Passing limit=0 must yield [] and never throw — slice(0, 0) is the
+    // zero-page-size boundary and the function must handle it gracefully.
+    const snapshot = buildPkmMemorySnapshot({
+      metadata,
+      fullBlob: {
+        professional: {
+          profile: {
+            name: "test_user_alpha",
+            university: "test_org_beta",
+          },
+        },
+      },
+    });
+
+    // Snapshot must have at least one card so we know cards were available.
+    expect(snapshot.cards.length).toBeGreaterThanOrEqual(1);
+
+    // Empty query bypasses scoring and goes straight to cards.slice(0, limit).
+    const result = selectRelevantPkmMemoryCards(snapshot.cards, "", 0);
+
+    expect(result).toHaveLength(0);
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  it("returns only available cards without crash when limit far exceeds dataset size (upper boundary guard)", () => {
+    // Passing limit=9999 to a 2-card snapshot must return at most the 2 real
+    // cards — slice(0, 9999) on a 2-element array yields the 2 elements, not
+    // 9999 phantom entries. No index error, no undefined slots.
+    const snapshot = buildPkmMemorySnapshot({
+      metadata,
+      fullBlob: {
+        professional: {
+          profile: {
+            name: "test_user_alpha",
+            university: "test_org_beta",
+          },
+        },
+      },
+    });
+
+    const datasetSize = snapshot.cards.length;
+    expect(datasetSize).toBeGreaterThanOrEqual(1);
+
+    const result = selectRelevantPkmMemoryCards(snapshot.cards, "", 9999);
+
+    // Must be bounded by the actual dataset — no phantom items beyond what exists.
+    expect(result.length).toBeLessThanOrEqual(datasetSize);
+    // Must return the full dataset when the limit exceeds it.
+    expect(result.length).toBe(datasetSize);
+    // Every returned entry must be a real card with a non-empty id.
+    result.forEach((card) => expect(card.id).toBeTruthy());
+  });
 });


### PR DESCRIPTION
## Hushh Research

Adds two targeted, zero-reviewer-risk unit tests to the PKM memory-cards suite verifying that the pagination boundary guards in `selectRelevantPkmMemoryCards` handle fringe limit values without crashing or producing phantom data.

## What changed

**File:** `hushh-webapp/__tests__/lib/pkm-memory-cards.test.ts`

Two new test cases added inside the existing `describe("PKM memory cards")` block:

### Test 1 — Zero limit: minimum boundary guard

Passes `limit = 0` to `selectRelevantPkmMemoryCards` with an empty query string.

**Production path exercised:**
```typescript
if (queryTokens.size === 0) return cards.slice(0, limit);
//                                           ↑ slice(0, 0) → []
```

Asserts:
- Result is `[]` — zero page size returns empty without throwing
- `Array.isArray(result)` is `true` — return type is always an array, never `undefined`
- Snapshot pre-check: `cards.length ≥ 1` confirms cards existed (the limit, not data absence, caused the empty result)

### Test 2 — Limit far exceeding dataset: upper boundary guard

Passes `limit = 9999` to `selectRelevantPkmMemoryCards` with a 2-card snapshot.

**Production path exercised:**
```typescript
return cards.slice(0, limit);
//           ↑ slice(0, 9999) on a 2-element array → 2 real elements, not 9999
```

Asserts:
- `result.length ≤ datasetSize` — result is bounded by the actual dataset, no phantom entries
- `result.length === datasetSize` — full dataset is returned when limit exceeds it
- `card.id` is truthy for every returned card — no `undefined` slots

## Why this matters

`selectRelevantPkmMemoryCards` feeds Agent context with org-tracked PKM data. If a caller miscalculates the limit (off-by-one, uninitialized variable), these guards ensure the function degrades gracefully rather than producing phantom `undefined` slots that could corrupt the Agent's context window or cause a downstream null-dereference.

## Test design constraints

- Fixture strings are low-entropy synthetics (`test_user_alpha`, `test_org_beta`) — zero secret-scan surface
- No new imports — reuses `buildPkmMemorySnapshot`, `selectRelevantPkmMemoryCards`, and `metadata` already present in the file
- No new files — additive patch only, cleanly branched from `upstream/integration/pr-train`
- No mocks, no network, no filesystem — pure function I/O

## Test plan

- [ ] `npm test -- __tests__/lib/pkm-memory-cards.test.ts` → 5 tests green
- [ ] `npm run lint` → no new warnings
- [ ] `npm run typecheck` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)