### PR TITLE
fix(frontend): add autocomplete and capitalization to name input

### DIFF
--- a/hushh-webapp/components/kai/onboarding/kai-invite-handshake.tsx
+++ b/hushh-webapp/components/kai/onboarding/kai-invite-handshake.tsx
@@ -171,6 +171,9 @@ export function KaiInviteHandshake({ inviteToken }: { inviteToken: string }) {
             <div className="space-y-4">
               <h2 className="text-2xl font-semibold text-foreground">A little about you</h2>
               <input
+                type="text"
+                autoComplete="name"
+                autoCapitalize="words"
                 value={name}
                 onChange={(event) => setName(event.target.value)}
                 className="min-h-12 w-full rounded-2xl border border-border bg-background px-4 text-sm"


### PR DESCRIPTION
# Description
Added `type="text"`, `autoComplete="name"`, and `autoCapitalize="words"` to the "How should Kai address you?" input in the onboarding handshake step. This allows mobile users to 1-tap autofill their name from their contact card, or automatically capitalizes their input if typing manually.

## 📌 Core Impact
- [x] **Routes Touched:** `/kai/onboarding`
- [x] **API / Schema / Trust Boundary:** None
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS**: (N/A - Frontend Web UI Only)
- [ ] **Android**: (N/A - Frontend Web UI Only)

## 🧪 Testing & Privacy
- [x] Tested on Web (Chrome/Safari)
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible