### PR TITLE
fix(frontend): add type search to holdings mobile search input

### DIFF
--- a/hushh-webapp/components/kai/holdings/holdings-mobile-list.tsx
+++ b/hushh-webapp/components/kai/holdings/holdings-mobile-list.tsx
@@ -242,6 +242,7 @@ export function HoldingsMobileList({
         <div className="relative">
           <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
+            type="search"
             value={searchTerm}
             onChange={(event) => setSearchTerm(event.target.value)}
             placeholder="Search holdings by ticker or company"


### PR DESCRIPTION
# Description
Added `type="search"` to the search `<Input>` in `holdings-mobile-list.tsx`. This tells mobile keyboards (iOS/Android) to display a dedicated "Search" action key instead of a standard "Return" key, improving the native feel of the mobile holdings list.

## 📌 Core Impact
- [x] **Routes Touched:** `/kai/holdings` (Mobile View)
- [x] **API / Schema / Trust Boundary:** None
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS**: (N/A - Frontend Web UI Only)
- [ ] **Android**: (N/A - Frontend Web UI Only)

## 🧪 Testing & Privacy
- [x] Tested on Web (Chrome/Safari)
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible