### PR TITLE
fix(kai-agents): use timezone-aware UTC in decision card timestamps

### DIFF
--- a/consent-protocol/hushh_mcp/agents/kai/decision_generator.py
+++ b/consent-protocol/hushh_mcp/agents/kai/decision_generator.py
@@ -14,7 +14,7 @@ Key Responsibilities:
 import json
 import logging
 from dataclasses import asdict, dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List
 
 from .config import DecisionType, RiskProfile
@@ -155,7 +155,7 @@ By using Kai, you acknowledge that you understand these limitations.
         """
         logger.info(f"[DecisionGen] Generating decision card for {ticker}")
 
-        decision_id = f"decision_{datetime.utcnow().timestamp()}"
+        decision_id = f"decision_{datetime.now(timezone.utc).timestamp()}"
 
         # Generate headline
         headline = self._generate_headline(ticker, debate.decision, debate.confidence)
@@ -183,7 +183,7 @@ By using Kai, you acknowledge that you understand these limitations.
             decision_id=decision_id,
             ticker=ticker,
             user_id=user_id,
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
             decision=debate.decision,
             confidence=debate.confidence,
             headline=headline,

--- a/consent-protocol/hushh_mcp/agents/kai/orchestrator.py
+++ b/consent-protocol/hushh_mcp/agents/kai/orchestrator.py
@@ -14,7 +14,7 @@ This is the "conductor" that brings everything together:
 
 import asyncio
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 from hushh_mcp.agents.base_agent import HushhAgent
@@ -106,7 +106,7 @@ class KaiOrchestrator(HushhAgent):
             ValueError: If consent token is invalid
             TimeoutError: If analysis exceeds timeout
         """
-        start_time = datetime.utcnow()
+        start_time = datetime.now(timezone.utc)
         logger.info(f"[Kai] Starting analysis for {ticker}")
 
         # Step 1: Validate consent
@@ -137,7 +137,7 @@ class KaiOrchestrator(HushhAgent):
             )
 
             # Step 5: Log completion
-            duration = (datetime.utcnow() - start_time).total_seconds()
+            duration = (datetime.now(timezone.utc) - start_time).total_seconds()
             logger.info(f"[Kai] Analysis complete for {ticker} in {duration:.1f}s")
 
             return decision_card

--- a/consent-protocol/tests/test_kai_decision_card_utc_timestamp.py
+++ b/consent-protocol/tests/test_kai_decision_card_utc_timestamp.py
@@ -1,0 +1,128 @@
+"""Tests that Kai decision cards use timezone-aware UTC timestamps.
+
+DecisionGenerator.generate produced its timestamp and decision_id with
+datetime.utcnow(). That call returns a naive datetime, and calling
+.timestamp() on a naive value interprets it as local time, so the epoch
+embedded in decision_id was wrong on any host not set to UTC. The naive
+timestamp also serialized without a UTC marker when the analyze route renders
+created_at via timestamp.isoformat().
+
+The fix uses datetime.now(timezone.utc). These tests drive the real
+DecisionGenerator.generate method with real insight and debate objects and
+assert the produced timestamp is timezone-aware UTC and the decision_id epoch
+matches the true UTC epoch.
+
+Reachable from api/routes/kai/analyze.py POST /analyze, which runs
+KaiOrchestrator.analyze, which calls decision_generator.generate_decision,
+which delegates to generate.
+"""
+
+from __future__ import annotations
+
+import warnings
+from datetime import datetime, timezone
+
+import pytest
+
+from hushh_mcp.agents.kai.debate_engine import DebateResult, DebateRound
+from hushh_mcp.agents.kai.decision_generator import DecisionGenerator
+from hushh_mcp.agents.kai.fundamental_agent import FundamentalInsight
+from hushh_mcp.agents.kai.sentiment_agent import SentimentInsight
+from hushh_mcp.agents.kai.valuation_agent import ValuationInsight
+
+
+def _fundamental() -> FundamentalInsight:
+    return FundamentalInsight(
+        summary="Cash generation supports the upside case.",
+        key_metrics={},
+        quant_metrics={},
+        business_moat="durable",
+        financial_resilience="healthy",
+        growth_efficiency="improving",
+        bull_case="cash generation",
+        bear_case="valuation risk",
+        sources=["fundamental"],
+        confidence=0.7,
+        recommendation="buy",
+    )
+
+
+def _sentiment() -> SentimentInsight:
+    return SentimentInsight(
+        summary="News flow is constructive.",
+        sentiment_score=0.4,
+        key_catalysts=["product launch"],
+        news_highlights=[],
+        sources=["sentiment"],
+        confidence=0.6,
+        recommendation="bullish",
+    )
+
+
+def _valuation() -> ValuationInsight:
+    return ValuationInsight(
+        summary="Multiples are reasonable against peers.",
+        valuation_metrics={},
+        peer_comparison={},
+        price_targets={},
+        sources=["valuation"],
+        confidence=0.6,
+        recommendation="fair",
+    )
+
+
+def _debate() -> DebateResult:
+    return DebateResult(
+        decision="buy",
+        confidence=0.65,
+        consensus_reached=True,
+        rounds=[DebateRound(1, {"fundamental": "supports buy"}, datetime.now(timezone.utc))],
+        agent_votes={"fundamental": "buy"},
+        dissenting_opinions=[],
+        final_statement="Consensus leans buy.",
+    )
+
+
+async def _generate_card():
+    generator = DecisionGenerator()
+    return await generator.generate(
+        ticker="AAPL",
+        user_id="user_1",
+        processing_mode="hybrid",
+        fundamental=_fundamental(),
+        sentiment=_sentiment(),
+        valuation=_valuation(),
+        debate=_debate(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_decision_card_timestamp_is_timezone_aware_utc():
+    card = await _generate_card()
+
+    assert card.timestamp.tzinfo is not None
+    assert card.timestamp.utcoffset() == timezone.utc.utcoffset(None)
+    # The rendered created_at must carry an explicit UTC marker.
+    assert card.timestamp.isoformat().endswith("+00:00")
+
+
+@pytest.mark.asyncio
+async def test_decision_id_encodes_true_utc_epoch():
+    before = datetime.now(timezone.utc).timestamp()
+    card = await _generate_card()
+    after = datetime.now(timezone.utc).timestamp()
+
+    assert card.decision_id.startswith("decision_")
+    embedded = float(card.decision_id.removeprefix("decision_"))
+    # The embedded epoch must fall within the real UTC window of this call,
+    # which only holds when the value is computed from an aware UTC datetime.
+    assert before <= embedded <= after
+
+
+@pytest.mark.asyncio
+async def test_decision_card_generation_emits_no_utcnow_deprecation():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        card = await _generate_card()
+
+    assert card.ticker == "AAPL"


### PR DESCRIPTION
## Summary

Kai decision cards built their timestamp and decision_id with datetime.utcnow(), producing a wrong epoch in decision_id on non UTC hosts and a created_at value that serialized without a UTC marker. This switches to datetime.now(timezone.utc) and adds tests.

## What the bug is

In decision_generator.py, generate built decision_id from datetime.utcnow().timestamp() and set the card timestamp to datetime.utcnow(). datetime.utcnow() returns a naive datetime. Calling timestamp() on a naive value interprets it as local time, so the epoch embedded in decision_id is shifted by the host offset and is only correct when the host clock is UTC. The naive card timestamp also serializes without a UTC marker when the analyze route renders created_at via timestamp.isoformat(). orchestrator.py measured analysis duration with the same deprecated call.

## Where it lives

- hushh_mcp/agents/kai/decision_generator.py (decision_id and DecisionCard.timestamp in generate)
- hushh_mcp/agents/kai/orchestrator.py (analysis start_time and duration)

## What the fix does

- Replaces datetime.utcnow() with datetime.now(timezone.utc) at these call sites.
- decision_id now embeds the true UTC epoch regardless of host timezone.
- created_at now renders as an explicit UTC ISO 8601 string, consistent with other timestamps in the codebase.
- The orchestrator duration math is unchanged because both endpoints are now timezone aware.

## Canonical attach point and reachability

api/routes/kai/analyze.py POST /analyze runs KaiOrchestrator.analyze, which calls decision_generator.generate_decision, which delegates to generate (the changed code). analyze.py then serializes decision_card.timestamp.isoformat() into the created_at response field. This is a backend behavior change under the existing analyze route contract; no signature or response shape change.

## Path to merge

- Base: integration/pr-train
- Branch: fix/kai-agents-utc-aware-datetime
- Built on current base, no conflicts, all required checks green
- Blocker: maintainer re-review after the requested changes are addressed

## Testing

```
cd consent-protocol
.venv/bin/python -m pytest tests/test_kai_decision_card_utc_timestamp.py -v
```

Three tests call the real DecisionGenerator.generate with real insight and debate objects and assert the card timestamp is timezone-aware UTC, its isoformat ends with the plus zero offset, the decision_id epoch falls within the true UTC window measured around the call, and no deprecation warning is emitted.