### PR TITLE
fix(kai-fetchers): use timezone-aware UTC timestamps in data fetchers

### DIFF
--- a/consent-protocol/hushh_mcp/operons/kai/fetchers.py
+++ b/consent-protocol/hushh_mcp/operons/kai/fetchers.py
@@ -19,7 +19,7 @@ import threading
 import time
 import urllib.parse
 from collections import Counter
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List
 
 import httpx
@@ -266,7 +266,7 @@ async def _fetch_yahoo_quote_fast(ticker: str) -> Dict[str, Any]:
             "sector": q.get("sector") or "Unknown",
             "industry": q.get("industry") or "Unknown",
             "source": "Yahoo Quote (Fast)",
-            "fetched_at": datetime.utcnow().isoformat(),
+            "fetched_at": datetime.now(timezone.utc).isoformat(),
             "ttl_seconds": 60,
             "is_stale": False,
         }
@@ -300,7 +300,7 @@ def _parse_google_news_rss(xml_text: str, ticker: str) -> List[Dict[str, Any]]:
                 "title": title,
                 "description": f"Realtime market coverage for {ticker}",
                 "url": link,
-                "publishedAt": published_at or datetime.utcnow().isoformat(),
+                "publishedAt": published_at or datetime.now(timezone.utc).isoformat(),
                 "source": {"name": source_name},
                 "provider": "google_news_rss",
             }
@@ -326,7 +326,7 @@ async def _fetch_newsapi_articles(ticker: str, days_back: int) -> List[Dict[str,
     if not api_key:
         return []
 
-    since = (datetime.utcnow() - timedelta(days=max(1, days_back))).date().isoformat()
+    since = (datetime.now(timezone.utc) - timedelta(days=max(1, days_back))).date().isoformat()
     params = {
         "q": f"{ticker} stock",
         "sortBy": "publishedAt",
@@ -352,7 +352,7 @@ async def _fetch_newsapi_articles(ticker: str, days_back: int) -> List[Dict[str,
                     "title": title,
                     "description": str(row.get("description") or "").strip(),
                     "url": url,
-                    "publishedAt": str(row.get("publishedAt") or datetime.utcnow().isoformat()),
+                    "publishedAt": str(row.get("publishedAt") or datetime.now(timezone.utc).isoformat()),
                     "source": {"name": str((row.get("source") or {}).get("name") or "NewsAPI")},
                     "provider": "newsapi",
                 }
@@ -441,7 +441,7 @@ async def _fetch_finnhub_quote(ticker: str) -> Dict[str, Any]:
             "sector": str(profile.get("finnhubIndustry") or "Unknown"),
             "industry": str(profile.get("finnhubIndustry") or "Unknown"),
             "source": "Finnhub",
-            "fetched_at": datetime.utcnow().isoformat(),
+            "fetched_at": datetime.now(timezone.utc).isoformat(),
             "ttl_seconds": 60,
             "is_stale": False,
         }
@@ -496,7 +496,7 @@ async def _fetch_pmp_quote(ticker: str) -> Dict[str, Any]:
             "sector": str(details.get("sector") or "Unknown"),
             "industry": str(details.get("industry") or "Unknown"),
             "source": "PMP/FMP",
-            "fetched_at": datetime.utcnow().isoformat(),
+            "fetched_at": datetime.now(timezone.utc).isoformat(),
             "ttl_seconds": 60,
             "is_stale": False,
         }
@@ -507,8 +507,8 @@ async def _fetch_finnhub_company_news(ticker: str, days_back: int) -> List[Dict[
     if not api_key:
         return []
 
-    end_date = datetime.utcnow().date().isoformat()
-    start_date = (datetime.utcnow() - timedelta(days=max(1, days_back))).date().isoformat()
+    end_date = datetime.now(timezone.utc).date().isoformat()
+    start_date = (datetime.now(timezone.utc) - timedelta(days=max(1, days_back))).date().isoformat()
     timeout = httpx.Timeout(connect=4.0, read=8.0, write=8.0, pool=4.0)
     headers = {"User-Agent": "Hushh-Research/1.0 (eng@hush1one.com)"}
     async with httpx.AsyncClient(timeout=timeout, headers=headers) as client:
@@ -533,7 +533,7 @@ async def _fetch_finnhub_company_news(ticker: str, days_back: int) -> List[Dict[
             published_at = (
                 datetime.utcfromtimestamp(ts).isoformat() + "Z"
                 if ts > 0
-                else datetime.utcnow().isoformat()
+                else datetime.now(timezone.utc).isoformat()
             )
             articles.append(
                 {
@@ -582,7 +582,7 @@ async def _fetch_pmp_news(ticker: str) -> List[Dict[str, Any]]:
                     "description": str((row or {}).get("description") or "").strip(),
                     "url": url,
                     "publishedAt": str(
-                        (row or {}).get("publishedDate") or datetime.utcnow().isoformat()
+                        (row or {}).get("publishedDate") or datetime.now(timezone.utc).isoformat()
                     ),
                     "source": {"name": "PMP/FMP"},
                     "provider": "pmp_fmp",
@@ -647,7 +647,7 @@ async def _fetch_yfinance_quote(ticker: str) -> Dict[str, Any]:
         "sector": info.get("sector", "Unknown"),
         "industry": info.get("industry", "Unknown"),
         "source": "yfinance (Real-time)",
-        "fetched_at": datetime.utcnow().isoformat(),
+        "fetched_at": datetime.now(timezone.utc).isoformat(),
         "ttl_seconds": 60,
         "is_stale": False,
     }
@@ -726,7 +726,7 @@ async def _fetch_yahoo_quotes(symbols: List[str]) -> List[Dict[str, Any]]:
                     "sector": row.get("sector") or "Unknown",
                     "industry": row.get("industry") or "Unknown",
                     "source": "Yahoo Quote (Peers)",
-                    "fetched_at": datetime.utcnow().isoformat(),
+                    "fetched_at": datetime.now(timezone.utc).isoformat(),
                     "ttl_seconds": 60,
                     "is_stale": False,
                 }
@@ -1126,7 +1126,7 @@ async def fetch_sec_filings(
             },
             "filing_date": filing_dates[latest_10k_idx],
             "source": "SEC EDGAR (Institutional Trend Extract)",
-            "fetched_at": datetime.utcnow().isoformat(),
+            "fetched_at": datetime.now(timezone.utc).isoformat(),
         }
 
 

--- a/consent-protocol/tests/test_kai_fetchers_utc_timestamp.py
+++ b/consent-protocol/tests/test_kai_fetchers_utc_timestamp.py
@@ -1,0 +1,75 @@
+"""Tests that Kai data fetchers stamp timezone-aware UTC times.
+
+operons/kai/fetchers.py generated freshness and fallback timestamps with
+datetime.utcnow(). That returns a naive datetime, so the fetched_at and
+publishedAt strings it produced carried no UTC marker, and date range bounds
+computed from it depended on the host timezone. The fix uses
+datetime.now(timezone.utc) at every site.
+
+These tests drive the real pure parser _parse_google_news_rss, which is the
+function behind the Google News fetch path consumed by the Kai sentiment and
+market insight flows, and assert that the publishedAt fallback it emits is a
+timezone-aware UTC ISO 8601 string. They also confirm a supplied pubDate is
+preserved and that the module no longer calls the deprecated utcnow.
+
+Reachable from _fetch_google_news_rss, which calls _parse_google_news_rss on
+the fetched RSS body.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from hushh_mcp.operons.kai import fetchers
+from hushh_mcp.operons.kai.fetchers import _parse_google_news_rss
+
+_RSS_WITHOUT_PUBDATE = """<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <item>
+      <title>Example headline for AAPL</title>
+      <link>https://example.com/aapl-news</link>
+      <source>Example Wire</source>
+    </item>
+  </channel>
+</rss>
+"""
+
+_RSS_WITH_PUBDATE = """<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <item>
+      <title>Dated headline for AAPL</title>
+      <link>https://example.com/aapl-dated</link>
+      <pubDate>Mon, 01 Jun 2026 10:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>
+"""
+
+
+def test_published_at_fallback_is_timezone_aware_utc():
+    items = _parse_google_news_rss(_RSS_WITHOUT_PUBDATE, "AAPL")
+
+    assert len(items) == 1
+    published_at = items[0]["publishedAt"]
+
+    # The fallback value must be a timezone-aware UTC ISO 8601 string.
+    assert published_at.endswith("+00:00")
+    parsed = datetime.fromisoformat(published_at)
+    assert parsed.tzinfo is not None
+    assert parsed.utcoffset().total_seconds() == 0
+
+
+def test_supplied_pubdate_is_preserved():
+    items = _parse_google_news_rss(_RSS_WITH_PUBDATE, "AAPL")
+
+    assert len(items) == 1
+    assert items[0]["publishedAt"] == "Mon, 01 Jun 2026 10:00:00 GMT"
+
+
+def test_fetchers_module_has_no_deprecated_utcnow():
+    import inspect
+
+    source = inspect.getsource(fetchers)
+    assert "datetime.utcnow(" not in source


### PR DESCRIPTION
## Summary

hushh_mcp/operons/kai/fetchers.py stamped freshness, article fallback, and date range values with the deprecated naive datetime.utcnow(). This switches all thirteen call sites to datetime.now(timezone.utc) and adds tests.

## What the bug is

datetime.utcnow() is deprecated and returns a naive datetime. In fetchers.py it was used for fetched_at freshness markers, publishedAt and publishedDate fallbacks when a source article has no date, and date range query bounds for news lookups. Because the value was naive, the emitted ISO strings carried no UTC marker, and the date range bounds were computed from a naive value rather than an explicit UTC instant.

## Where it lives

hushh_mcp/operons/kai/fetchers.py, thirteen datetime.utcnow() call sites across the quote, news, and filing fetchers.

## What the fix does

- Replaces every datetime.utcnow() with datetime.now(timezone.utc) and imports timezone.
- fetched_at and publishedAt now render as explicit UTC ISO 8601 strings with the plus zero offset.
- Date range bounds use date().isoformat(), which yields the same string while being computed against UTC.
- Safety: these values are only stored, emitted as telemetry, or passed as provider query parameters. A repo wide check confirms publishedAt and publishedDate are never read back into datetimes for comparison or sorting, so no mixed awareness comparison can occur.

## Canonical attach point and reachability

_parse_google_news_rss is called by _fetch_google_news_rss on the fetched RSS body, which feeds the Kai news aggregation used by the sentiment and market insight flows under api/routes/kai. The quote and filing fetchers are imported by api/routes/kai/losers.py, market_insights.py, portfolio.py, and analyze.py. This is a backend behavior change under existing route contracts; no route signature or response shape changes.

## Path to merge

- Base: integration/pr-train
- Branch: fix/kai-fetchers-utc-aware-datetime
- Built on current base, no conflicts, all required checks green
- Blocker: maintainer re-review after the requested changes are addressed

## Testing

```
cd consent-protocol
.venv/bin/python -m pytest tests/test_kai_fetchers_utc_timestamp.py -v
```

Three tests drive the real Google News reader function and assert the publishedAt fallback is a timezone-aware UTC ISO 8601 string, a supplied pubDate is preserved verbatim, and the module no longer references the deprecated call. The wider fetcher and operon suites stay green (278 passed).