### PR TITLE
fix(domain-registry): use timezone-aware UTC for cache freshness timer

### DIFF
--- a/consent-protocol/hushh_mcp/services/domain_registry_service.py
+++ b/consent-protocol/hushh_mcp/services/domain_registry_service.py
@@ -16,7 +16,7 @@ Attach points:
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 from db.db_client import get_db
@@ -75,7 +75,7 @@ class DomainRegistryService:
         """Check if cache is still valid."""
         if self._cache_time is None:
             return False
-        elapsed = (datetime.utcnow() - self._cache_time).total_seconds()
+        elapsed = (datetime.now(timezone.utc) - self._cache_time).total_seconds()
         return elapsed < self._cache_ttl
 
     def _invalidate_cache(self):
@@ -347,7 +347,7 @@ class DomainRegistryService:
                     user_count=rpc_payload.get("user_count", 0),
                 )
                 self._cache[domain_key] = domain_info
-                self._cache_time = datetime.utcnow()
+                self._cache_time = datetime.now(timezone.utc)
                 return domain_info
         except Exception as e:
             logger.warning(
@@ -381,7 +381,7 @@ class DomainRegistryService:
                 row = result.data[0]
                 domain_info = self._row_to_domain_info(row)
                 self._cache[domain_key] = domain_info
-                self._cache_time = datetime.utcnow()
+                self._cache_time = datetime.now(timezone.utc)
                 return domain_info
         except Exception as e:
             logger.error("domain_registry.auto_register.error domain=%s: %s", domain_key, e)
@@ -440,7 +440,7 @@ class DomainRegistryService:
             # Update cache
             for domain in domains:
                 self._cache[domain.domain_key] = domain
-            self._cache_time = datetime.utcnow()
+            self._cache_time = datetime.now(timezone.utc)
 
             return domains
         except Exception as e:

--- a/consent-protocol/tests/test_domain_registry_cache_utc.py
+++ b/consent-protocol/tests/test_domain_registry_cache_utc.py
@@ -1,0 +1,58 @@
+"""Tests that the domain registry cache timer uses timezone-aware UTC.
+
+DomainRegistryService tracked cache freshness with datetime.utcnow(): it set
+self._cache_time on load and computed elapsed time in _is_cache_valid by
+subtracting _cache_time from another utcnow() value. datetime.utcnow() is
+deprecated and returns a naive datetime.
+
+The fix uses datetime.now(timezone.utc) at every site. Because the setter and
+the elapsed computation must stay on the same awareness, mixing a tz-aware
+"now" with a naive _cache_time would raise TypeError inside _is_cache_valid.
+These tests drive the real _is_cache_valid method on a real service instance
+with a tz-aware _cache_time and assert fresh and expired cache windows behave
+correctly without raising, and that the module no longer calls utcnow.
+
+Reachable from api/routes/pkm.py and api/routes/pkm_routes_shared.py, which
+use DomainRegistryService.get_domain, list_domains, and register_domain; each
+calls _is_cache_valid before serving cached domains.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from hushh_mcp.services.domain_registry_service import DomainRegistryService
+
+
+def test_is_cache_valid_true_for_fresh_aware_cache_time():
+    service = DomainRegistryService()
+    service._cache["financial"] = object()  # type: ignore[assignment]
+    service._cache_time = datetime.now(timezone.utc)
+
+    # Must not raise: a tz-aware now minus a tz-aware _cache_time is valid.
+    assert service._is_cache_valid() is True
+
+
+def test_is_cache_valid_false_for_expired_aware_cache_time():
+    service = DomainRegistryService()
+    service._cache["financial"] = object()  # type: ignore[assignment]
+    service._cache_time = datetime.now(timezone.utc) - timedelta(
+        seconds=service._cache_ttl + 10
+    )
+
+    assert service._is_cache_valid() is False
+
+
+def test_is_cache_valid_false_when_never_loaded():
+    service = DomainRegistryService()
+    assert service._cache_time is None
+    assert service._is_cache_valid() is False
+
+
+def test_domain_registry_module_has_no_deprecated_utcnow():
+    import inspect
+
+    from hushh_mcp.services import domain_registry_service
+
+    source = inspect.getsource(domain_registry_service)
+    assert "datetime.utcnow(" not in source


### PR DESCRIPTION
## Summary

DomainRegistryService tracked its in-memory cache freshness with the deprecated naive datetime.utcnow(). This switches all four call sites to datetime.now(timezone.utc) and adds tests.

## What the bug is

The service set self._cache_time on each load and computed elapsed time in _is_cache_valid by subtracting _cache_time from another datetime.utcnow() value. datetime.utcnow() is deprecated and returns a naive datetime. The setter and the elapsed computation must stay on the same awareness, otherwise the subtraction raises TypeError.

## Where it lives

consent-protocol/hushh_mcp/services/domain_registry_service.py:
- line 78: elapsed computation in _is_cache_valid
- lines 350, 384, 443: _cache_time assignments on load

## What the fix does

- Replaces all four datetime.utcnow() calls with datetime.now(timezone.utc) and imports timezone.
- The setter and the elapsed math move together, so the subtraction stays valid and the 300 second TTL behavior is unchanged.
- _cache_time stays None until the first load, and _is_cache_valid still returns False in that state.

## Reachability

api/routes/pkm.py and api/routes/pkm_routes_shared.py use DomainRegistryService. Its public methods get_domain, list_domains, and register_domain each call _is_cache_valid before serving cached domains, so the changed timing code runs on real PKM domain reads.

## How to verify

cd consent-protocol
.venv/bin/python -m pytest tests/test_domain_registry_cache_utc.py -v

Four tests pass. They drive the real _is_cache_valid method on a real service instance and assert a fresh tz-aware cache time is valid without raising, an expired one is invalid, the never-loaded state is invalid, and the module no longer references utcnow. The wider domain suite stays green (333 passed).

## Path to merge

- Base: integration/pr-train (direct PRs into main are blocked by repo policy)
- Branch: fix/domain-registry-utc-aware-cache-time
- Built on current main, no conflicts
- Blocker: requires CI Status Gate green and one maintainer approval
- Expected action: review of the timezone-aware swap and the PKM reachability trace