### PR TITLE
test(kai-analyze): assert opaque token message on invalid-token 401

### DIFF
--- a/consent-protocol/tests/test_kai_analyze.py
+++ b/consent-protocol/tests/test_kai_analyze.py
@@ -47,7 +47,8 @@ class TestAnalyzeRequiresVaultOwnerToken:
         )
 
         assert response.status_code == 401
-        assert "Invalid token" in response.json()["detail"]
+        assert "Bearer" in response.headers.get("WWW-Authenticate", "")
+        assert response.json()["detail"] == "Token validation failed."
 
     @pytest.mark.asyncio
     async def test_analyze_mismatched_user_id_returns_403(self, client, vault_owner_token_for_user):


### PR DESCRIPTION
## Summary

A test in test_kai_analyze.py fails on current main because it asserts an old token error message. This updates the assertion to the current opaque contract.

## What the bug is

TestAnalyzeRequiresVaultOwnerToken::test_analyze_invalid_token_returns_401 asserts `"Invalid token" in response.json()["detail"]`. The auth middleware now returns the opaque message "Token validation failed." for invalid tokens so it does not disclose why validation failed (CWE-209 hardening). The assertion is stale, so the test fails on main.

## Where it lives

- Test: consent-protocol/tests/test_kai_analyze.py (test_analyze_invalid_token_returns_401)
- Current behavior: consent-protocol/api/middleware.py raises _auth_error("Token validation failed.") for invalid or malformed tokens

## What the fix does

- Updates the assertion to match the current opaque message "Token validation failed.".
- Adds an assertion on the WWW-Authenticate: Bearer header so the test still guards the real 401 contract of POST /analyze.
- No production code changes.

## How to verify

cd consent-protocol
.venv/bin/python -m pytest tests/test_kai_analyze.py -q

All tests pass (6 passed). Before this change, test_analyze_invalid_token_returns_401 fails on current main with the stale assertion.

## Path to merge

- Base: integration/pr-train (direct PRs into main are blocked by repo policy)
- Branch: fix/kai-analyze-test-opaque-token-message
- Built on current main, no conflicts
- Blocker: requires CI Status Gate green and one maintainer approval
- Expected action: review of the updated assertion against the current middleware contract