### PR TITLE
test(kai-analyze): match opaque token validation message

### DIFF
--- a/consent-protocol/tests/test_kai_analyze.py
+++ b/consent-protocol/tests/test_kai_analyze.py
@@ -47,7 +47,8 @@ class TestAnalyzeRequiresVaultOwnerToken:
         )
 
         assert response.status_code == 401
-        assert "Invalid token" in response.json()["detail"]
+        assert "Bearer" in response.headers.get("WWW-Authenticate", "")
+        assert "Token validation failed." in response.json()["detail"]
 
     @pytest.mark.asyncio
     async def test_analyze_mismatched_user_id_returns_403(self, client, vault_owner_token_for_user):


### PR DESCRIPTION
## What

`TestAnalyzeRequiresVaultOwnerToken::test_analyze_invalid_token_returns_401` in `consent-protocol/tests/test_kai_analyze.py` fails on the current base. It asserts `"Invalid token" in response.json()["detail"]`, but `api/middleware.py` now returns the opaque message `"Token validation failed."` for invalid tokens (a CWE-209 opaque-error hardening that landed without updating this test).

## Change

Single surface, one test file. Update the assertion to the current opaque middleware message and additionally confirm the 401 still carries a `Bearer` `WWW-Authenticate` header.

```python
assert response.status_code == 401
assert "Bearer" in response.headers.get("WWW-Authenticate", "")
assert "Token validation failed." in response.json()["detail"]
```

## Verification

```
cd consent-protocol && .venv/bin/python -m pytest tests/test_kai_analyze.py -q
6 passed
```