### PR TITLE
fix(settings-row): restore visible keyboard focus in splitPrimaryAction mode

### DIFF
--- a/hushh-webapp/components/app-ui/settings-ui.tsx
+++ b/hushh-webapp/components/app-ui/settings-ui.tsx
@@ -263,7 +263,7 @@ export function SettingsRow({
       "transition-[border-color,box-shadow] focus:outline-none focus-visible:outline-none focus:ring-0 focus-visible:ring-0"
   );
   const primaryActionClassName = cn(
-    "relative isolate min-w-0 overflow-hidden rounded-[inherit] border-0 bg-transparent px-[var(--settings-row-px)] py-[var(--settings-row-py)] text-left outline-hidden ring-0 transition-[border-color,box-shadow] [-webkit-tap-highlight-color:transparent] focus:outline-none focus-visible:outline-none focus:ring-0 focus-visible:ring-0"
+    "relative isolate min-w-0 overflow-hidden rounded-[inherit] border-0 bg-transparent px-[var(--settings-row-px)] py-[var(--settings-row-py)] text-left outline-hidden ring-0 transition-[border-color,box-shadow] [-webkit-tap-highlight-color:transparent] focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
   );
   const voiceProps = {
     "data-voice-control-id": voiceControlId || undefined,


### PR DESCRIPTION
## Summary

Restore a visible keyboard focus indicator for the `splitPrimaryAction` render path in `SettingsRow`.

## Problem

`SettingsRow` supports multiple render paths, including `splitPrimaryAction`, where the primary action area is rendered as a button.

The shared `primaryActionClassName` explicitly suppresses visible keyboard focus using:

* `focus-visible:outline-none`
* `focus:ring-0`
* `focus-visible:ring-0`

As a result, keyboard users can tab to the control without receiving a visible focus indicator, creating a WCAG 2.4.7 Focus Visible accessibility issue.

## Changes

File changed:

* `hushh-webapp/components/app-ui/settings-ui.tsx`

Updates:

Removed:

* `focus-visible:outline-none`
* `focus:ring-0`
* `focus-visible:ring-0`

Added:

* `focus-visible:ring-2`
* `focus-visible:ring-ring`
* `focus-visible:ring-offset-2`

`focus:outline-none` is intentionally retained because the custom ring replaces the native browser outline.

## Impact

* Restores visible keyboard focus for the split action button path.
* Improves accessibility for keyboard and assistive technology users.
* Preserves existing mouse and touch behavior.

## Accessibility

Addresses:

* WCAG 2.4.7 — Focus Visible

## Risk

LOW

* Single-file change.
* One class string updated.
* No dependencies added.
* No behavioral changes outside focus styling.
