### PR TITLE
fix(route-error-boundary): move keyboard focus to error container on render error

### DIFF
--- a/hushh-webapp/components/app-ui/route-error-boundary.tsx
+++ b/hushh-webapp/components/app-ui/route-error-boundary.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Component, type ErrorInfo, type ReactNode } from "react";
+import { Component, createRef, type ErrorInfo, type ReactNode } from "react";
 import { Button } from "@/lib/morphy-ux/button";
 import { Card } from "@/lib/morphy-ux/card";
 import { AlertTriangle } from "lucide-react";
@@ -21,6 +21,8 @@ interface State {
  * Catches render errors and shows a morphy-styled recovery UI.
  */
 export class RouteErrorBoundary extends Component<Props, State> {
+  private errorRef = createRef<HTMLDivElement>();
+
   constructor(props: Props) {
     super(props);
     this.state = { hasError: false, error: null };
@@ -28,6 +30,12 @@ export class RouteErrorBoundary extends Component<Props, State> {
 
   static getDerivedStateFromError(error: Error): State {
     return { hasError: true, error };
+  }
+
+  componentDidUpdate(_prevProps: Props, prevState: State) {
+    if (this.state.hasError && !prevState.hasError) {
+      this.errorRef.current?.focus();
+    }
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
@@ -54,8 +62,10 @@ export class RouteErrorBoundary extends Component<Props, State> {
     if (this.state.hasError) {
       return (
         <div
+          ref={this.errorRef}
           role="alert"
-          className="flex min-h-[60vh] flex-col items-center justify-center px-6"
+          tabIndex={-1}
+          className="flex min-h-[60vh] flex-col items-center justify-center px-6 outline-none"
         >
           <Card
             preset="default"


### PR DESCRIPTION
## Summary

Add keyboard focus management to `RouteErrorBoundary` when a render error occurs.

## Problem

`RouteErrorBoundary` correctly announces errors using `role="alert"`, but keyboard focus remains on the element that triggered the error. Since that element is removed from the DOM, keyboard users lose their focus context.

This makes it difficult to discover and reach recovery actions such as retry or navigation buttons.

## Changes

File changed:

* `hushh-webapp/components/app-ui/route-error-boundary.tsx`

Updates:

* Added `createRef<HTMLDivElement>` to track the error container.
* Added `componentDidUpdate` to move focus when entering the error state.
* Added `tabIndex={-1}` to support programmatic focus.
* Added `outline-none` to avoid showing a browser outline on the container.

## Impact

* Restores focus context after route-level failures.
* Improves keyboard accessibility.
* Complements the existing `role="alert"` announcement behavior.

## Accessibility

Addresses:

* WCAG 2.4.3 — Focus Order
* WCAG 2.4.7 — Focus Visible
* Error recovery and focus management best practices

## Risk

LOW

* Single-file change.
* No dependencies added.
* No behavioral changes outside focus management.
