### PR TITLE
fix(debate-task-center): add ARIA list semantics to notification items

### DIFF
--- a/hushh-webapp/components/app-ui/debate-task-center.tsx
+++ b/hushh-webapp/components/app-ui/debate-task-center.tsx
@@ -320,8 +320,8 @@ export function DebateTaskCenter({ triggerClassName, renderTrigger }: DebateTask
     AppBackgroundTaskService.cancelTask(task.taskId, "Plaid refresh canceled.");
   };
 
-  const renderAppTask = (task: AppBackgroundTask) => (
-    <div key={task.taskId} className="px-3 py-3">
+  const renderAppTask = (task: AppBackgroundTask, listRole?: string) => (
+    <div key={task.taskId} role={listRole} className="px-3 py-3">
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">
           <div className="flex items-center gap-2">
@@ -447,14 +447,14 @@ export function DebateTaskCenter({ triggerClassName, renderTrigger }: DebateTask
 
         <div className={TOP_SHELL_DROPDOWN_BODY_CLASSNAME}>
           {notifications.length === 0 && passiveAppTasks.length === 0 ? (
-            <div className="px-2 py-6 text-sm text-muted-foreground">
+            <div role="status" className="px-2 py-6 text-sm text-muted-foreground">
               No notifications yet.
             </div>
           ) : (
-            <div className="divide-y divide-border/45">
+            <div role="list" aria-label="Notifications" className="divide-y divide-border/45">
               {notifications.map((item) =>
                 item.kind === "debate" ? (
-                  <div key={item.id} className="px-3 py-3">
+                  <div key={item.id} role="listitem" className="px-3 py-3">
                     <div className="flex items-start justify-between gap-2">
                       <div className="min-w-0">
                         <div className="flex items-center gap-2">
@@ -541,7 +541,7 @@ export function DebateTaskCenter({ triggerClassName, renderTrigger }: DebateTask
                     </div>
                   </div>
                 ) : (
-                  renderAppTask(item.task)
+                  renderAppTask(item.task, "listitem")
                 )
               )}
               {passiveAppTasks.length > 0 ? (


### PR DESCRIPTION
## Summary

Add ARIA list semantics to notification items in `DebateTaskCenter`.

## Problem

Notifications are rendered using generic `div` elements without list semantics.

As a result:

* Screen readers cannot announce the number of notifications.
* Users cannot navigate notifications using list navigation shortcuts.
* Empty-state content is not announced as a status message.

## Changes

File changed:

* `hushh-webapp/components/app-ui/debate-task-center.tsx`

Updates:

* Added `role="status"` to the empty state.
* Added `role="list"` and `aria-label="Notifications"` to the notifications container.
* Added `role="listitem"` to debate notification entries.
* Added an optional `listRole` parameter to `renderAppTask`.
* Passed `"listitem"` when rendering app tasks in the main notifications list.

## Impact

* Improves notification list discoverability.
* Improves navigation for assistive technology users.
* Preserves existing layout and styling.

## Accessibility

Addresses:

* List semantics for assistive technologies.
* Status announcement for empty notification states.

## Risk

LOW

* Single-file change.
* No visual changes.
* No dependency changes.
* No structural HTML changes.
