### PR TITLE
fix(frontend): add missing noopener to external links

### DIFF
--- a/hushh-webapp/app/marketplace/ria/page-client.tsx
+++ b/hushh-webapp/app/marketplace/ria/page-client.tsx
@@ -308,7 +308,7 @@ export default function MarketplaceRiaProfilePageClient() {
                 <a
                   href={profile.disclosures_url}
                   target="_blank"
-                  rel="noreferrer"
+                  rel="noopener noreferrer"
                   data-voice-control-id="marketplace_ria_public_disclosure"
                   className="inline-flex min-h-11 items-center justify-center rounded-full border border-border bg-background px-4 text-sm font-medium text-foreground"
                 >

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -228,7 +228,7 @@ function AgentMarkdown({ text }: { text: string }) {
             <a
               href={href || "#"}
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
               className="font-medium text-primary underline-offset-4 hover:underline"
             >
               {children}

--- a/hushh-webapp/components/labs/liquid-glass-search-demo.tsx
+++ b/hushh-webapp/components/labs/liquid-glass-search-demo.tsx
@@ -139,7 +139,7 @@ export function LiquidGlassSearchDemo() {
             <a
               href="https://unsplash.com/@visaxslr"
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
               className="absolute left-3 top-3 inline-block text-[9px] uppercase tracking-wider text-white/40"
             >
               Photo by @visaxslr


### PR DESCRIPTION
# Description
Added the missing `noopener` attribute to three external `target="_blank"` links across the application that previously only had `rel="noreferrer"`. This is a standard security and performance best practice that prevents the opened page from maliciously accessing the `window.opener` object, and allows the browser to run the new tab in a separate process immediately.

## 📌 Core Impact
- [x] **Routes Touched:** `/marketplace/ria`, `/kai`, `/labs`
- [x] **API / Schema / Trust Boundary:** Strengthened client-side external link isolation.
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS**: (N/A - Frontend Web UI Only)
- [ ] **Android**: (N/A - Frontend Web UI Only)

## 🧪 Testing & Privacy
- [x] Tested on Web (Chrome/Safari)
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible