### PR TITLE
fix(field): add automatic accessible name for role=group

### DIFF
--- a/hushh-webapp/components/ui/field.tsx
+++ b/hushh-webapp/components/ui/field.tsx
@@ -1,11 +1,14 @@
 "use client"
 
-import { useMemo } from "react"
+import { createContext, useContext, useId, useMemo } from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 import { Label } from "@/components/ui/label"
 import { Separator } from "@/components/ui/separator"
+
+
+const FieldLabelIdContext = createContext<string | undefined>(undefined)
 
 function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
   return (
@@ -81,16 +84,23 @@ const fieldVariants = cva(
 function Field({
   className,
   orientation = "vertical",
+  "aria-labelledby": ariaLabelledBy,
   ...props
 }: React.ComponentProps<"div"> & VariantProps<typeof fieldVariants>) {
+  const autoId = useId()
+  const labelId = ariaLabelledBy ?? autoId
+
   return (
-    <div
-      role="group"
-      data-slot="field"
-      data-orientation={orientation}
-      className={cn(fieldVariants({ orientation }), className)}
-      {...props}
-    />
+    <FieldLabelIdContext.Provider value={labelId}>
+      <div
+        role="group"
+        data-slot="field"
+        data-orientation={orientation}
+        aria-labelledby={labelId}
+        className={cn(fieldVariants({ orientation }), className)}
+        {...props}
+      />
+    </FieldLabelIdContext.Provider>
   )
 }
 
@@ -109,11 +119,16 @@ function FieldContent({ className, ...props }: React.ComponentProps<"div">) {
 
 function FieldLabel({
   className,
+  id: idProp,
   ...props
 }: React.ComponentProps<typeof Label>) {
+  const contextLabelId = useContext(FieldLabelIdContext)
+  const resolvedId = idProp ?? contextLabelId
+
   return (
     <Label
       data-slot="field-label"
+      id={resolvedId}
       className={cn(
         "group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50",
         "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border [&>*]:data-[slot=field]:p-4",


### PR DESCRIPTION
## Summary

Automatically associate `Field` and `FieldLabel` so `role="group"` elements receive an accessible name.

## Problem

`Field` renders a group container but does not expose a programmatically determinable label. Screen readers encounter group boundaries without a name, making it difficult to understand what controls belong to the group.

## Changes

File changed:

* `hushh-webapp/components/ui/field.tsx`

Updates:

* Added `FieldLabelIdContext`.
* Added `useId()` to generate a stable label identifier.
* Added automatic `aria-labelledby` wiring from `Field` to `FieldLabel`.
* Preserved explicit consumer overrides for both `aria-labelledby` and `id`.

## Compatibility

* Explicit `aria-labelledby` on `Field` continues to work.
* Explicit `id` on `FieldLabel` continues to work.
* Existing consumers require no changes.
* No visual changes.

## Accessibility

Addresses:

* WCAG 1.3.1 — Info and Relationships

## Risk

LOW–MEDIUM

* Single-file change.
* No visual changes.
* Context and hook wiring only.
