### PR TITLE
fix(frontend): add tel autocomplete to location phone input

### DIFF
--- a/hushh-webapp/app/one/location/request/[token]/page-client.tsx
+++ b/hushh-webapp/app/one/location/request/[token]/page-client.tsx
@@ -174,6 +174,8 @@ export default function PublicLocationRequestPageClient() {
                 maxLength={120}
               />
               <Input
+                type="tel"
+                autoComplete="tel"
                 value={phoneNumber}
                 onChange={(event) => setPhoneNumber(event.target.value)}
                 placeholder="Phone number"


### PR DESCRIPTION
# Description
Added `type="tel"` and `autoComplete="tel"` to the phone number `<Input>` in the location request flow (`page-client.tsx`). This allows iOS, Android, and password managers to securely prompt the user to one-tap auto-fill their phone number from their contact card, significantly reducing input friction.

## 📌 Core Impact
- [x] **Routes Touched:** `/one/location/request/[token]`
- [x] **API / Schema / Trust Boundary:** None
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation

## 🧪 Testing & Privacy
- [x] Tested on Web (Chrome/Safari)
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible