### PR TITLE
fix(frontend): add name autocomplete to funding account input

### DIFF
--- a/hushh-webapp/components/kai/plaid/plaid-brokerage-sections.tsx
+++ b/hushh-webapp/components/kai/plaid/plaid-brokerage-sections.tsx
@@ -825,6 +825,11 @@ export function PlaidFundingTransfersSection({
                 <label className="space-y-1 text-xs text-muted-foreground">
                   Legal name
                   <input
+                    type="text"
+                    autoComplete="name"
+                    autoCapitalize="words"
+                    spellCheck={false}
+                    autoCorrect="off"
                     className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground"
                     value={legalNameInput}
                     onChange={(event) => setLegalNameInput(event.target.value)}


### PR DESCRIPTION
# Description
Added mobile UX optimization attributes (`autoComplete="name"`, `autoCapitalize="words"`, `spellCheck={false}`, `autoCorrect="off"`) to the legal name `<input>` within the Plaid funding account section (`plaid-brokerage-sections.tsx`). This reduces friction during the critical onboarding flow by allowing one-tap name autofill and preventing aggressive autocorrect on unique names.

## 📌 Core Impact
- [x] **Routes Touched:** Plaid Brokerage Sections (Onboarding / Funding Flow)
- [x] **API / Schema / Trust Boundary:** None
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS**: (N/A - Frontend Web UI Only)
- [ ] **Android**: (N/A - Frontend Web UI Only)

## 🧪 Testing & Privacy
- [x] Tested on Web (Chrome/Safari)
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible