### PR TITLE
fix(frontend): add type search to pkm data manager search input

### DIFF
--- a/hushh-webapp/components/profile/pkm-data-manager.tsx
+++ b/hushh-webapp/components/profile/pkm-data-manager.tsx
@@ -284,6 +284,7 @@ export function PkmDataManagerPanel({
 
       {shouldShowSearch ? (
         <Input
+          type="search"
           value={searchQuery}
           onChange={(event) => setSearchQuery(event.target.value)}
           placeholder="Search saved details"


### PR DESCRIPTION
# Description
Added `type="search"` to the search `<Input>` within the PKM Data Manager (`pkm-data-manager.tsx`). This native HTML5 attribute ensures mobile keyboards display the correct "Search" action key instead of a standard "Return" key, and enables native clear buttons on supported browsers.

## 📌 Core Impact
- [x] **Routes Touched:** `/profile` (PKM Data Manager View)
- [x] **API / Schema / Trust Boundary:** None
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation

## 🧪 Testing & Privacy
- [x] Tested on Web (Chrome/Safari)
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible