### PR TITLE
fix(frontend): add autoCapitalize to message textareas across app

### DIFF
--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -1318,6 +1318,7 @@ export function OneLocationAgentPageContent() {
                     onChange={(event) => setRequestMessage(event.target.value)}
                     placeholder="Optional reason"
                     rows={3}
+                    autoCapitalize="sentences"
                   />
                   <ActionButton
                     busy={busy}

--- a/hushh-webapp/app/one/location/request/[token]/page-client.tsx
+++ b/hushh-webapp/app/one/location/request/[token]/page-client.tsx
@@ -186,6 +186,7 @@ export default function PublicLocationRequestPageClient() {
                 placeholder="Optional message"
                 rows={4}
                 maxLength={500}
+                autoCapitalize="sentences"
               />
               <Button onClick={() => void handleSubmit()} disabled={submitting}>
                 {submitting ? (

--- a/hushh-webapp/app/profile/page.tsx
+++ b/hushh-webapp/app/profile/page.tsx
@@ -3505,12 +3505,14 @@ function ProfilePageContent() {
           value={supportSubject}
           onChange={(event) => setSupportSubject(event.target.value)}
           placeholder="Subject"
+          autoCapitalize="sentences"
         />
         <Textarea
           value={supportMessage}
           onChange={(event) => setSupportMessage(event.target.value)}
           placeholder="Tell us what happened and what you expected."
           className="min-h-[180px]"
+          autoCapitalize="sentences"
         />
         <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
           <Button

--- a/hushh-webapp/app/profile/pkm-agent-lab/page-client.tsx
+++ b/hushh-webapp/app/profile/pkm-agent-lab/page-client.tsx
@@ -1269,6 +1269,7 @@ export default function PkmAgentLabPageClient() {
                       onChange={(event) => setMessage(event.target.value)}
                       rows={5}
                       placeholder="Tell Kai one new memory, preference, or intent."
+                      autoCapitalize="sentences"
                     />
                     <div className="flex flex-wrap gap-2">
                       <Button


### PR DESCRIPTION
# Description
Added `autoCapitalize="sentences"` to multi-line `<Textarea>` elements and subject `<Input>` elements across the application (Support, Location Requests, and PKM Agent memory capture). This explicitly instructs mobile keyboards to automatically capitalize the first letter of each new sentence, significantly improving the UX for long-form data entry.

## 📌 Core Impact
- [x] **Routes Touched:** `/profile`, `/profile/pkm-agent-lab`, `/one/location`, `/one/location/request/[token]`
- [x] **API / Schema / Trust Boundary:** None
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS**: (N/A - Frontend Web UI Only)
- [ ] **Android**: (N/A - Frontend Web UI Only)

## 🧪 Testing & Privacy
- [x] Tested on Web (Chrome/Safari)
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible