### PR TITLE
fix(frontend): add autocomplete attributes to vault passwords

### DIFF
--- a/hushh-webapp/app/profile/page.tsx
+++ b/hushh-webapp/app/profile/page.tsx
@@ -4234,12 +4234,14 @@ function ProfilePageContent() {
           <div className="space-y-3 pt-2">
             <Input
               type="password"
+              autoComplete="new-password"
               placeholder="New passphrase (min 8 characters)"
               value={newPassphrase}
               onChange={(event) => setNewPassphrase(event.target.value)}
             />
             <Input
               type="password"
+              autoComplete="new-password"
               placeholder="Confirm passphrase"
               value={confirmPassphrase}
               onChange={(event) => setConfirmPassphrase(event.target.value)}

--- a/hushh-webapp/components/vault/vault-flow.tsx
+++ b/hushh-webapp/components/vault/vault-flow.tsx
@@ -711,6 +711,7 @@ export function VaultFlow({
                 <Input
                   id="passphrase"
                   type="password"
+                  autoComplete="new-password"
                   placeholder="Enter your passphrase"
                   value={passphrase}
                   onChange={(e) => setPassphrase(e.target.value)}
@@ -723,6 +724,7 @@ export function VaultFlow({
                 <Input
                   id="confirm"
                   type="password"
+                  autoComplete="new-password"
                   placeholder="Confirm your passphrase"
                   value={confirmPassphrase}
                   onChange={(e) => setConfirmPassphrase(e.target.value)}
@@ -794,6 +796,7 @@ export function VaultFlow({
                   <Input
                     id="unlock-passphrase"
                     type="password"
+                    autoComplete="current-password"
                     placeholder="Enter vault key"
                     value={passphrase}
                     onChange={(e) => setPassphrase(e.target.value)}


### PR DESCRIPTION
# Description
Added critical `autoComplete` attributes (`new-password` and `current-password`) to Vault passphrase inputs in both the Vault Setup Flow and the Profile Settings page. This fixes a major UX friction point by explicitly signaling to OS-level password managers (1Password, Keychain, etc.) when to suggest generating a strong password vs when to offer autofilling an existing one.

## 📌 Core Impact
- [x] **Routes Touched:** `/profile`, Global Vault Unlock Dialogs
- [x] **API / Schema / Trust Boundary:** None (Frontend HTML semantics only)
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS**: (N/A - Frontend Web UI Only)
- [ ] **Android**: (N/A - Frontend Web UI Only)

## 🧪 Testing & Privacy
- [x] Tested on Web (Chrome/Safari)
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible