### PR TITLE
fix(frontend): implement global mobile UX css resets

### DIFF
--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1,6 +1,34 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
+/* ============================================================================
+ * MOBILE UX & ACCESSIBILITY FIXES
+ * ============================================================================ */
+
+/* Remove 300ms tap delay on interactive elements */
+a,
+button,
+input[type="button"],
+input[type="submit"],
+input[type="reset"],
+[role="button"] {
+  touch-action: manipulation;
+}
+
+/* Remove default iOS tap highlight flash */
+* {
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* Prevent auto-zoom on iOS Safari when focusing inputs */
+@media screen and (max-width: 767px) {
+  input,
+  select,
+  textarea {
+    font-size: 16px !important;
+  }
+}
+
 html,
 body {
   height: 100%;


### PR DESCRIPTION
# Description
Implemented a suite of global mobile CSS resets in `globals.css` to fix the three most common Mobile Safari/Chrome UX friction points:
1. Removed the 300ms tap delay on all interactive elements via `touch-action: manipulation`.
2. Disabled the default iOS tap highlight flash via `-webkit-tap-highlight-color: transparent`.
3. Prevented aggressive auto-zooming on iOS when focusing inputs by enforcing a minimum 16px font size on mobile screens.

## 📌 Core Impact
- [x] **Routes Touched:** Global (`globals.css`)
- [x] **API / Schema / Trust Boundary:** None (Frontend styling only)
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation

## 🧪 Testing & Privacy
- [x] Tested on Web (Chrome/Safari)
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible