### PR TITLE
fix(frontend): add aria-labels to icon buttons on marketplace mobile view

### DIFF
--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -1319,6 +1319,7 @@ export default function MarketplacePage() {
                       size="sm"
                       className="justify-center"
                       onClick={passCurrentCard}
+                      aria-label="Pass card"
                     >
                       <X className="h-4 w-4 sm:mr-2" />
                       <span className="hidden sm:inline">Pass</span>
@@ -1329,6 +1330,7 @@ export default function MarketplacePage() {
                       size="sm"
                       className="justify-center"
                       onClick={() => openDiscoveryProfile(swipeCard)}
+                      aria-label="View profile"
                     >
                       <span className="hidden sm:inline">View</span>
                       <ArrowUpRight className="h-4 w-4 sm:ml-2" />


### PR DESCRIPTION
# Description
Added critical `aria-label` attributes to the primary swipe action buttons in the Marketplace. Because the text labels for these buttons ("Pass" and "View") use `hidden sm:inline` to render as icon-only buttons on mobile devices, they were completely invisible to assistive technologies. This fix ensures mobile screen readers can correctly identify the button actions.

## 📌 Core Impact
- [x] **Routes Touched:** `/marketplace`
- [x] **API / Schema / Trust Boundary:** None (Accessibility semantics only)
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS**: (N/A - Frontend Web UI Only)
- [ ] **Android**: (N/A - Frontend Web UI Only)

## 🧪 Testing & Privacy
- [x] Tested on Web (Chrome/Safari)
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible