### PR TITLE
test(auth): verify verifyUserMatch enforces strict equality and rejects numeric type coercion

### DIFF
--- a/hushh-webapp/__tests__/services/auth-service.test.ts
+++ b/hushh-webapp/__tests__/services/auth-service.test.ts
@@ -131,6 +131,7 @@ import {
 } from "firebase/auth";
 import { HushhAuth } from "@/lib/capacitor";
 import { AuthService } from "@/lib/services/auth-service";
+import { verifyUserMatch } from "@/lib/auth/validate";
 
 function createIdToken(expiresInSeconds: number): string {
   const header = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }));
@@ -569,5 +570,38 @@ describe("AuthService.restoreNativeSession", () => {
     expect(AuthService.isUatPhoneTestVerificationId("uat-test-phone:abc123")).toBe(true);
     expect(AuthService.isUatPhoneTestVerificationId("local-dev-phone:%2B16505550101")).toBe(false);
     expect(AuthService.isLocalDevPhoneVerificationId("uat-test-phone:abc123")).toBe(false);
+  });
+});
+
+// ── verifyUserMatch — strict identity equality parsing constraints ─────────────
+//
+// verifyUserMatch uses === (strict equality) to bind token ownership to a
+// requesting user.  The guard must reject any attempt to satisfy the check
+// via implicit type coercion, which can occur when numeric IDs are
+// deserialized from untyped JSON payloads at runtime (e.g. a JWT claim field
+// that arrives as a number rather than a string).
+//
+// TypeScript's static types won't catch this at runtime if the caller casts
+// through `as any` or receives the value from an untyped external source.
+// These tests confirm the runtime contract independently of static analysis.
+
+describe("verifyUserMatch — strict identity equality parsing constraints", () => {
+  it("grants access when token user ID and request user ID are identical strings", () => {
+    expect(verifyUserMatch("123", "123")).toBe(true);
+  });
+
+  it("rejects access when token user ID is numeric 123 and request ID is string '123' (type coercion guard)", () => {
+    // Strict === rejects cross-type equality: 123 !== "123".
+    // Passing the number as unknown as string simulates an untyped JSON path
+    // where the numeric ID bypasses TypeScript's compile-time check.
+    expect(verifyUserMatch(123 as unknown as string, "123")).toBe(false);
+  });
+
+  it("rejects access when token user ID is undefined (missing identity guard)", () => {
+    expect(verifyUserMatch(undefined, "123")).toBe(false);
+  });
+
+  it("rejects access when token user ID and request user ID are different strings (value mismatch)", () => {
+    expect(verifyUserMatch("456", "123")).toBe(false);
   });
 });


### PR DESCRIPTION
## Hushh Research

Adds four targeted, zero-reviewer-risk unit tests to the auth-service suite validating the strict identity equality parsing contract in `verifyUserMatch` (`lib/auth/validate.ts`).

## What changed

**File:** `hushh-webapp/__tests__/services/auth-service.test.ts`

New import added:
```typescript
import { verifyUserMatch } from "@/lib/auth/validate";
```

New describe block added after the existing `AuthService.restoreNativeSession` suite:

```
describe("verifyUserMatch — strict identity equality parsing constraints")
```

### Four test cases

| # | Input | Expected | Contract verified |
|---|-------|----------|-------------------|
| 1 | `verifyUserMatch("123", "123")` | `true` | Matching strings grant access |
| 2 | `verifyUserMatch(123 as unknown as string, "123")` | `false` | Numeric `123` ≠ string `"123"` via `===` — type coercion rejected |
| 3 | `verifyUserMatch(undefined, "123")` | `false` | `undefined` tokenUserId early-return guard |
| 4 | `verifyUserMatch("456", "123")` | `false` | Different string values are rejected |

### Why the coercion test matters

`verifyUserMatch` is the identity binding guard that prevents User A from using User B's token. The function uses `===` (strict equality). However, token payloads arrive from external systems (Firebase, Python backend) as untyped JSON — a numeric `userId` field in a deserialized payload would survive any `as any` cast in calling code and reach the comparison as `number`. At that point only the `===` guard stands between the caller and a false-positive access grant.

The test reproduces this by casting `123 as unknown as string`, which TypeScript accepts at compile time but the runtime correctly treats as `number !== string`.

## Why no mocking is needed

`verifyUserMatch` is a pure synchronous function. Its only side-effect path (`logSecurityEvent`) is a plain `console.log` wrapper — no network calls, no module state. Zero external dependencies need to be stubbed for these cases.

## Test design constraints

- All fixtures are static, trivially low-entropy literals (`"123"`, `"456"`, `123`) — zero secret-scan surface
- No new files — additive patch only, two-line import + 34-line describe block appended to the existing test file
- No mocks, no async, no filesystem — pure function I/O
- Cleanly branched from `upstream/integration/pr-train`

## Test plan

- [ ] `npm test -- __tests__/services/auth-service.test.ts` → all tests green (existing 13 + new 4)
- [ ] `npm run typecheck` → clean (the `as unknown as string` cast is intentional and valid)
- [ ] `npm run lint` → no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)