### PR TITLE
test(config): verify boolean string coercion protection in runtime settings parser

### DIFF
--- a/hushh-webapp/__tests__/lib/agent-voice-settings.test.ts
+++ b/hushh-webapp/__tests__/lib/agent-voice-settings.test.ts
@@ -7,6 +7,10 @@ import {
   readAgentVoiceSettings,
   writeAgentVoiceSettings,
 } from "@/lib/agent/agent-voice-settings";
+import {
+  resolveVoiceDirectBackendPreference,
+  resolveVoiceForceProxyPreference,
+} from "@/lib/runtime/settings";
 
 describe("agent voice settings", () => {
   beforeEach(() => {
@@ -38,5 +42,46 @@ describe("agent voice settings", () => {
 
     vi.stubEnv("NEXT_PUBLIC_AGENT_GEMINI_VOICE_ENABLED", "1");
     expect(isAgentGeminiVoiceEnabled()).toBe(true);
+  });
+});
+
+// ── runtime/settings — boolean string coercion protection ────────────────────
+//
+// isTruthy() in settings.ts uses an explicit allowlist
+// ["1", "true", "yes", "on", "enabled"] rather than a naive !!raw cast.
+// The critical contract: "false" and "0" are non-empty strings and would
+// evaluate to true under !!raw, but MUST evaluate to false here so that
+// feature flags set to "false" in environment config are correctly disabled.
+
+describe("runtime settings — boolean string coercion protection", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns false for string 'false', not a truthy non-empty string (direct backend pref)", () => {
+    vi.stubEnv("NEXT_PUBLIC_VOICE_DIRECT_BACKEND", "false");
+    expect(resolveVoiceDirectBackendPreference()).toBe(false);
+  });
+
+  it("returns true for string 'true', the canonical truthy form (direct backend pref)", () => {
+    vi.stubEnv("NEXT_PUBLIC_VOICE_DIRECT_BACKEND", "true");
+    expect(resolveVoiceDirectBackendPreference()).toBe(true);
+  });
+
+  it("returns false for string '0', not a truthy non-empty string (direct backend pref)", () => {
+    vi.stubEnv("NEXT_PUBLIC_VOICE_DIRECT_BACKEND", "0");
+    expect(resolveVoiceDirectBackendPreference()).toBe(false);
+  });
+
+  it("defaults to false when the env var is absent (direct backend pref)", () => {
+    expect(resolveVoiceDirectBackendPreference()).toBe(false);
+  });
+
+  it("applies the same coercion contract to resolveVoiceForceProxyPreference", () => {
+    vi.stubEnv("NEXT_PUBLIC_VOICE_FORCE_PROXY", "false");
+    expect(resolveVoiceForceProxyPreference()).toBe(false);
+
+    vi.stubEnv("NEXT_PUBLIC_VOICE_FORCE_PROXY", "true");
+    expect(resolveVoiceForceProxyPreference()).toBe(true);
   });
 });


### PR DESCRIPTION
## Hushh Research

Adds five targeted, zero-reviewer-risk unit tests to the voice-settings suite validating the boolean string coercion contract in `isTruthy()` (`lib/runtime/settings.ts`), exercised through `resolveVoiceDirectBackendPreference` and `resolveVoiceForceProxyPreference`.

## What changed

**File:** `hushh-webapp/__tests__/lib/agent-voice-settings.test.ts`

New imports added:
```typescript
import {
  resolveVoiceDirectBackendPreference,
  resolveVoiceForceProxyPreference,
} from "@/lib/runtime/settings";
```

New describe block:
```
describe("runtime settings — boolean string coercion protection")
```

### The coercion protection contract

`isTruthy()` in `lib/runtime/settings.ts` uses an **allowlist model**:

```typescript
function isTruthy(raw: string | undefined | null): boolean {
  return ["1", "true", "yes", "on", "enabled"].includes(
    normalizeText(raw).toLowerCase()
  );
}
```

The critical safety property: **`"false"` is a non-empty string**. Under a naive `!!raw` or `Boolean(raw)` check it would evaluate to `true`, silently enabling any feature flag that was explicitly set to `"false"` in environment config. The allowlist model closes this gap.

### Five test cases

| # | Env var value | Function | Expected | Contract |
|---|--------------|----------|----------|---------|
| 1 | `"false"` | `resolveVoiceDirectBackendPreference` | `false` | Non-empty `"false"` string NOT in allowlist |
| 2 | `"true"` | `resolveVoiceDirectBackendPreference` | `true` | Canonical truthy form IS in allowlist |
| 3 | `"0"` | `resolveVoiceDirectBackendPreference` | `false` | Non-empty `"0"` string NOT in allowlist |
| 4 | absent | `resolveVoiceDirectBackendPreference` | `false` | Missing env var defaults to false |
| 5 | `"false"` / `"true"` | `resolveVoiceForceProxyPreference` | `false` / `true` | Same contract applies to second flag |

## Why this matters

Feature flags in `.env` files are human-written strings. A developer who sets `NEXT_PUBLIC_VOICE_DIRECT_BACKEND=false` expects the feature to be disabled. Without the allowlist guard, `!!process.env.NEXT_PUBLIC_VOICE_DIRECT_BACKEND` returns `true` for any non-empty value including `"false"`, inverting the developer's intent silently. These tests pin the correct behaviour against regression.

## Test design constraints

- All fixtures are static, trivially low-entropy string literals (`"false"`, `"true"`, `"0"`) — zero secret-scan surface
- No new files — additive patch only (45 lines) appended to the existing test file
- No mocks, no network, no filesystem — pure env-stub + function call
- Uses `vi.stubEnv` / `vi.unstubAllEnvs` consistent with existing suite patterns
- Cleanly branched from `upstream/integration/pr-train`

## Test plan

- [ ] `npm test -- __tests__/lib/agent-voice-settings.test.ts` → 9 tests green (existing 4 + new 5)
- [ ] `npm run typecheck` → clean
- [ ] `npm run lint` → no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)