### PR TITLE
fix(kai-dashboard): debug and audit logs leak session data in production

### DIFF
--- a/hushh-webapp/app/kai/dashboard/actions.ts
+++ b/hushh-webapp/app/kai/dashboard/actions.ts
@@ -120,9 +120,11 @@ export async function storeKaiPreferences(
   // For now, preferences are stored in kai_sessions table
   // In production, might want to encrypt and store in vault
 
+  if (process.env.NODE_ENV !== "production") {
   console.log(
     "[Kai] Preferences stored in session (vault integration pending)"
   );
+}
   return { success: true };
 }
 
@@ -136,5 +138,7 @@ export async function logKaiAudit(
   metadata: Record<string, unknown> = {}
 ): Promise<void> {
   // Optional: Add audit logging endpoint
+ if (process.env.NODE_ENV !== "production") {
   console.log(`[Kai Audit] ${action}`, { sessionId, ...metadata });
+}
 }


### PR DESCRIPTION
## Description
In `hushh-webapp/app/kai/dashboard/actions.ts`, two exported functions unconditionally log internal data to the console in production:

- `storeKaiPreferences` (line 110) leaks internal vault integration status
- `logKaiAudit` (line 120) exposes session IDs, action names, and arbitrary metadata on every call

Both are exported functions called across the app, making this a broad production log leak.

## Steps To Reproduce
1. Deploy to production
2. Trigger any Kai preference save or audit log call
3. Observe session ID and action metadata logged to production console

## Expected Behavior
Debug and audit logs should only appear in non-production environments, consistent with the NODE_ENV guard pattern already used across this codebase.

## Environment
- OS: Windows 11
- Node Version: 20.x

## Additional Context
Fix wraps both console.log calls with process.env.NODE_ENV !== "production" guard — consistent with the pattern established in review-mode/route.ts (#2062), notifications/register/route.ts (#2064), and kai/onboarding/page.tsx (#2067).