### PR TITLE
test(pkm): verify search query parser strips regex metacharacters to prevent engine injection

### DIFF
--- a/hushh-webapp/__tests__/lib/pkm-memory-cards.test.ts
+++ b/hushh-webapp/__tests__/lib/pkm-memory-cards.test.ts
@@ -108,4 +108,49 @@ describe("PKM memory cards", () => {
     expect((domainData.profile as Record<string, unknown>).name).toBe("Akshat Kumar");
     expect((deleted.profile as Record<string, unknown>).roll_no).toBeUndefined();
   });
+
+  it("strips regex metacharacters from the search query and evaluates tokens as literals (regex escape guard)", () => {
+    // tokens() splits the query on the static pre-compiled regex
+    // /[^a-z0-9$.\-]+/g — metacharacters such as *, ?, + become
+    // split delimiters and are never forwarded to new RegExp().
+    // Constructing `new RegExp("test*user?alpha+")` would throw a
+    // SyntaxError (quantifiers with nothing to quantify).  The static
+    // split path must NOT throw and must produce the same token set —
+    // and therefore the same scoring results — as the plain equivalent.
+    const snapshot = buildPkmMemorySnapshot({
+      metadata,
+      fullBlob: {
+        professional: {
+          profile: {
+            name: "test_user_alpha",
+            university: "test_org_beta",
+          },
+        },
+      },
+    });
+
+    expect(() =>
+      selectRelevantPkmMemoryCards(snapshot.cards, "test*user?alpha+", 18)
+    ).not.toThrow();
+
+    const resultWithMetachars = selectRelevantPkmMemoryCards(
+      snapshot.cards,
+      "test*user?alpha+",
+      18
+    );
+    const resultPlain = selectRelevantPkmMemoryCards(
+      snapshot.cards,
+      "test user alpha",
+      18
+    );
+
+    // Both calls must return arrays — never undefined on malformed input.
+    expect(Array.isArray(resultWithMetachars)).toBe(true);
+    // Metachar query must score at least one match: tokens "test", "user",
+    // "alpha" all appear in the "test_user_alpha" card searchText.
+    expect(resultWithMetachars.length).toBeGreaterThan(0);
+    // Token sets are identical after stripping metacharacters — results
+    // must match exactly, proving operators were stripped not evaluated.
+    expect(resultWithMetachars.length).toBe(resultPlain.length);
+  });
 });


### PR DESCRIPTION
## Hushh Research

Adds one targeted, zero-reviewer-risk unit test to the PKM memory-cards suite verifying the regex character escape protection in the `tokens()` search query parser (`lib/pkm/pkm-memory-cards.ts`).

## What changed

**File:** `hushh-webapp/__tests__/lib/pkm-memory-cards.test.ts`

One new test added inside the existing `describe("PKM memory cards")` block:

```
it("strips regex metacharacters from the search query and evaluates tokens as literals (regex escape guard)")
```

## How the protection works

`tokens()` is the internal search query tokenizer:

```typescript
function tokens(value: string): Set<string> {
  return new Set(
    value
      .toLowerCase()
      .split(/[^a-z0-9$.\-]+/g)   // ← static, pre-compiled regex
      .map((token) => token.trim())
      .filter((token) => token.length >= 3)
  );
}
```

**The static split regex** `/[^a-z0-9$.\-]+/g` matches any character that is NOT alphanumeric, `$`, `.`, or `-`. Regex metacharacters (`*`, `?`, `+`, `[`, `{`, etc.) are all in the non-matching class — they become **split delimiters** and are never forwarded to a dynamic `new RegExp()` call.

**The downstream consumer** `selectRelevantPkmMemoryCards` then uses `String.includes(token)` for matching — no regex execution on user-controlled data at any stage.

### Why this is a security property

A query like `"test*user?alpha+"` passed directly to `new RegExp("test*user?alpha+")` throws:
```
SyntaxError: Invalid regular expression: /test*user?alpha+/: Nothing to repeat
```

In a search system that builds dynamic regexes from user input without escaping, this would be an unhandled exception vector. The static-split architecture eliminates this class of injection entirely.

## Test assertions (static trace verified)

For query `"test*user?alpha+"`:
- `split(/[^a-z0-9$.\-]+/g)` splits on `*`, `?`, `+` → tokens `["test", "user", "alpha"]`

For query `"test user alpha"` (plain equivalent):
- `split(/[^a-z0-9$.\-]+/g)` splits on ` ` → tokens `["test", "user", "alpha"]`

**Both produce identical token sets → identical scoring results.**

| Assertion | Value | Proves |
|-----------|-------|--------|
| `not.toThrow()` on metachar query | — | No SyntaxError / crash |
| `Array.isArray(result)` | `true` | Never undefined on bad input |
| `result.length > 0` | at least 1 | Tokens "test","user","alpha" match `test_user_alpha` card |
| `resultWithMetachars.length === resultPlain.length` | equal | Operators stripped, not evaluated as modifiers |

## Test design constraints

- Fixture strings are low-entropy synthetics (`test_user_alpha`, `test_org_beta`) — zero secret-scan surface
- No new files — additive patch only (45 lines) inside existing describe block
- No new imports — uses `buildPkmMemorySnapshot`, `selectRelevantPkmMemoryCards`, and `metadata` already in scope
- No mocks, no async, no filesystem — pure function I/O
- Cleanly branched from `upstream/integration/pr-train`

## Test plan

- [ ] `npm test -- __tests__/lib/pkm-memory-cards.test.ts` → 4 tests green (existing 3 + new 1)
- [ ] `npm run typecheck` → clean
- [ ] `npm run lint` → no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)