### PR TITLE
fix(consent): suppress request ID and response body logs in production for deny route

### DIFF
--- a/hushh-webapp/app/api/consent/pending/deny/route.ts
+++ b/hushh-webapp/app/api/consent/pending/deny/route.ts
@@ -33,8 +33,9 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    console.log(`[API] Denying consent request: ${requestId}`);
-
+   if (process.env.NODE_ENV !== "production") {
+  console.log(`[API] Denying consent request: ${requestId}`);
+}
     const response = await fetch(
       `${BACKEND_URL}/api/consent/pending/deny?userId=${userId}&requestId=${requestId}`,
       {
@@ -56,7 +57,9 @@ export async function POST(request: NextRequest) {
     }
 
     const data = await response.json();
-    console.log(`[API] Consent denied: ${JSON.stringify(data)}`);
+    if (process.env.NODE_ENV !== "production") {
+  console.log(`[API] Consent denied: ${JSON.stringify(data)}`);
+}
 
     return NextResponse.json(data);
   } catch (error) {


### PR DESCRIPTION
## Summary
- what changed: Wrapped two `console.log` calls in `hushh-webapp/app/api/consent/pending/deny/route.ts` with `process.env.NODE_ENV !== "production"` guards
- why it changed: Line 36 logs the consent `requestId` on every denial. Line 59 serializes and logs the full backend response body via `JSON.stringify(data)` — potentially exposing user IDs, token fragments, or internal backend fields to production server logs on every consent denial.

## Attach point
`hushh-webapp/app/api/consent/pending/deny/route.ts` — POST handler for denying pending consent requests across the consent-first architecture.

## Contract changed
Runtime behavior: consent `requestId` and full backend response body no longer appear in production server logs on consent denial. Development and staging behavior unchanged — both logs still appear in non-production environments. No change to response shape, status codes, or auth header forwarding logic.

## Tests run
```bash
cd hushh-webapp && npx tsc --noEmit
```
Passed locally. No type errors.

## Base/head status
Branch is current with main, mergeable, and DCO-signed. Targets integration/pr-train as required by repo base policy.

## Sensitive proof
Consent surface touched — but only logging behavior changed. No auth flow, token validation, vault, PKM, finance, or KYC logic structurally modified. Rollback: revert by removing the `NODE_ENV` guards and restoring both unconditional `console.log` calls.

## Stack proof
Not applicable. Standalone fix, no predecessor PR.

Fixes #2198