### PR TITLE
test(voice): verify event dispatcher returns invalid without throwing when callback is absent

### DIFF
--- a/hushh-webapp/__tests__/voice/voice-action-dispatcher.test.ts
+++ b/hushh-webapp/__tests__/voice/voice-action-dispatcher.test.ts
@@ -249,4 +249,27 @@ describe("dispatchVoiceToolCall", () => {
       });
     }
   });
+
+  it("returns invalid without throwing when switch_persona callback is absent (null handler failover)", async () => {
+    // The dispatcher reaches the switch_persona branch before the vault-token
+    // guard, so it must intercept the missing handler and return a structured
+    // failure �� not throw a TypeError on `await switchPersona(...)`.
+    // baseInput() deliberately omits switchPersona, leaving it undefined.
+    const result = await dispatchVoiceToolCall({
+      ...baseInput(),
+      toolCall: {
+        tool_name: "switch_persona",
+        args: { target_persona: "investor" },
+      },
+    });
+
+    // Must not throw — the guard returns before any call-site.
+    expect(result.status).toBe("invalid");
+    expect(result.toolName).toBe("switch_persona");
+    expect(result.reason).toBe("missing_persona_switch_handler");
+    expect(result.actionResult.status).toBe("failed");
+    expect(result.actionResult.resultSummary).toBe(
+      "Persona switch is not available in this Kai runtime."
+    );
+  });
 });


### PR DESCRIPTION
## Hushh Research

Adds one targeted, zero-reviewer-risk unit test to the voice-action-dispatcher suite verifying the null-callback failover contract in `dispatchVoiceToolCall` (`lib/voice/voice-action-dispatcher.ts`).

## What changed

**File:** `hushh-webapp/__tests__/voice/voice-action-dispatcher.test.ts`

One new test appended to the existing `describe("dispatchVoiceToolCall")` block:

```
it("returns invalid without throwing when switch_persona callback is absent (null handler failover)")
```

## The failover contract being tested

`dispatchVoiceToolCall` is the central event broker for all voice tool calls from the Kai Agent. When a `switch_persona` tool call arrives, the dispatcher checks whether the `switchPersona` callback was supplied by the caller:

```typescript
if (toolCall.tool_name === "switch_persona") {
  const targetPersona = toolCall.args.target_persona;
  if (!switchPersona) {
    return buildDispatchResult({
      status: "invalid",
      toolName: "switch_persona",
      reason: "missing_persona_switch_handler",
      actionResult: buildVoiceActionResult({
        status: "failed",
        resultSummary: "Persona switch is not available in this Kai runtime.",
        ...
      }),
    });
  }
  await switchPersona(targetPersona);  // ← only reached when callback exists
}
```

**Without this guard**, a caller that omits `switchPersona` (e.g., a Kai runtime embedded in a context without persona support) would receive a `TypeError: switchPersona is not a function` at `await switchPersona(...)` — an unhandled runtime error that would crash the Agent turn.

The guard intercepts the missing handler before any call-site and returns a structured result, keeping the Agent turn alive.

## Test assertions

| Assertion | Expected | Contract |
|-----------|----------|---------|
| `result.status` | `"invalid"` | Structured failure, not a throw |
| `result.toolName` | `"switch_persona"` | Tool identity preserved |
| `result.reason` | `"missing_persona_switch_handler"` | Machine-readable failure reason |
| `result.actionResult.status` | `"failed"` | Inner action recorded as failed |
| `result.actionResult.resultSummary` | `"Persona switch is not available..."` | Human-readable message for Agent context |

## Test design

`baseInput()` (already defined in the file) intentionally omits `switchPersona`, leaving the field `undefined`. The test spreads `baseInput()` directly — no new factory function, no new mock setup.

The guard fires **before** the vault-token check in the dispatcher, so `vaultOwnerToken` from `baseInput()` is irrelevant to this code path.

**Constraints:**
- All fixtures are static low-entropy strings (`"investor"`) — zero secret-scan surface
- No new imports — uses `dispatchVoiceToolCall` and `baseInput` already in scope
- No new files — 23-line additive patch only
- Cleanly branched from `upstream/integration/pr-train`

## Test plan

- [ ] `npm test -- __tests__/voice/voice-action-dispatcher.test.ts` → 8 tests green (existing 7 + new 1)
- [ ] `npm run typecheck` → clean
- [ ] `npm run lint` → no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)