### PR TITLE
fix(sse): normalize _authorize_sse_user error response to structured shape

### DIFF
--- a/consent-protocol/api/routes/sse.py
+++ b/consent-protocol/api/routes/sse.py
@@ -62,7 +62,13 @@ def _ensure_consent_sse_enabled() -> None:
 def _authorize_sse_user(user_id: str, authorization: Optional[str]) -> None:
     firebase_uid = verify_firebase_bearer(authorization)
     if firebase_uid != user_id:
-        raise HTTPException(status_code=403, detail="User ID mismatch")
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "error_code": "USER_ID_MISMATCH",
+                "message": "Authenticated user does not match the requested user_id.",
+            },
+        )
 
 
 def _payload_map(value: object | None) -> dict[str, object]:


### PR DESCRIPTION
## Summary

Normalize the `_authorize_sse_user` error response shape to match the structured error format already used elsewhere in `sse.py`.

## Motivation

The module currently contains a mix of structured and unstructured error responses.

Existing handlers already return:

```python
{
    "error_code": "...",
    "message": "..."
}
```

However, `_authorize_sse_user` returns a bare string:

```python
raise HTTPException(status_code=403, detail="User ID mismatch")
```

This creates inconsistency for clients consuming SSE endpoint errors.

## Change

Replaced the string detail with a structured error payload:

```python
raise HTTPException(
    status_code=403,
    detail={
        "error_code": "USER_ID_MISMATCH",
        "message": "Authenticated user does not match the requested user_id.",
    },
)
```

## Impact

* HTTP status code remains 403.
* No changes to successful request handling.
* No new imports.
* No schema changes.
* No route changes.
* Clients can now rely on a machine-readable `error_code`.

## Consistency

Matches the existing patterns:

* `CONSENT_SSE_DISABLED`
* `CONSENT_POLL_DEPRECATED`

and follows the same `error_code` + `message` structure.

## Files Changed

* `consent-protocol/api/routes/sse.py`

## Risk

LOW

* Single-file change.
* Single function updated.
* No behavioral changes outside the error payload format.
