### PR TITLE
fix(kai-control-surface): add explicit modal prop to Drawer for parity with Dialog

### DIFF
--- a/hushh-webapp/components/app-ui/kai-control-surface.tsx
+++ b/hushh-webapp/components/app-ui/kai-control-surface.tsx
@@ -57,7 +57,7 @@ export function KaiControlSurface({
 
   if (isMobile) {
     return (
-      <Drawer open={open} onOpenChange={onOpenChange}>
+      <Drawer open={open} onOpenChange={onOpenChange} modal>
         <DrawerContent className="max-h-[85dvh] rounded-t-[var(--app-card-radius-feature)] border-t border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-default-solid)] shadow-[var(--app-card-shadow-feature)]">
           <DrawerHeader className="relative z-10 border-b border-[color:var(--app-card-border-standard)] px-4 py-4 text-left">
             {eyebrow ? (


### PR DESCRIPTION
## Summary

Adds an explicit `modal` prop to the mobile `<Drawer>` implementation in `KaiControlSurface` to match the `modal` prop already declared on the desktop `<Dialog>` implementation.

## Motivation

`KaiControlSurface` is a responsive modal surface:

* Desktop → `Dialog`
* Mobile → `Drawer`

The desktop branch explicitly declares `modal`, while the mobile branch relies on the library default.

This creates an asymmetric declaration of the same modal contract.

## Change

Before:

```tsx
<Drawer open={open} onOpenChange={onOpenChange}>
```

After:

```tsx
<Drawer open={open} onOpenChange={onOpenChange} modal>
```

## Impact

* No runtime behavior change.
* Vaul already defaults `modal` to `true`.
* Makes the accessibility contract explicit.
* Prevents future divergence if library defaults change.

## Prop Chain Verification

`<Drawer modal>`

→ `Drawer` wrapper forwards props

→ `DrawerPrimitive.Root`

→ `modal?: boolean` supported by Vaul

## Files Changed

* `hushh-webapp/components/app-ui/kai-control-surface.tsx`

## Risk

LOW

* One token added.
* One file changed.
* No behavior changes.
* No styling changes.
* No dependency changes.
