### PR TITLE
fix(settings-ui): add explicit modal prop to SettingsDetailPanel Drawer for parity with Dialog

### DIFF
--- a/hushh-webapp/components/app-ui/settings-ui.tsx
+++ b/hushh-webapp/components/app-ui/settings-ui.tsx
@@ -390,7 +390,7 @@ export function SettingsDetailPanel({
   const isMobile = useIsMobile();
   if (isMobile) {
     return (
-      <Drawer open={open} onOpenChange={onOpenChange}>
+      <Drawer open={open} onOpenChange={onOpenChange} modal>
         <DrawerContent
           className="h-[100dvh] max-h-[100dvh] rounded-none border-none bg-[color:var(--app-card-surface-default-solid)] shadow-[var(--app-card-shadow-feature)]"
           onOpenAutoFocus={(e) => {


### PR DESCRIPTION
## Summary

Adds an explicit `modal` prop to the mobile `<Drawer>` implementation in `SettingsDetailPanel` to match the `modal` prop already declared on the desktop `<Dialog>` implementation.

## Motivation

`SettingsDetailPanel` is a responsive modal surface:

* Desktop → `Dialog`
* Mobile → `Drawer`

The desktop branch explicitly declares `modal`, while the mobile branch relies on the library default.

This creates an asymmetric declaration of the same modal contract.

## Change

Before:

```tsx
<Drawer open={open} onOpenChange={onOpenChange}>
```

After:

```tsx
<Drawer open={open} onOpenChange={onOpenChange} modal>
```

## Impact

* No runtime behavior change.
* Vaul already defaults `modal` to `true`.
* Makes the modal contract explicit.
* Prevents future divergence if library defaults change.

## Prop Chain Verification

`<Drawer modal>`

→ `Drawer` wrapper forwards props

→ `DrawerPrimitive.Root`

→ `modal?: boolean` supported by Vaul

## Files Changed

* `hushh-webapp/components/app-ui/settings-ui.tsx`

## Risk

LOW

* One token added.
* One file changed.
* No behavior changes.
* No styling changes.
* No dependency changes.

## Related

Follows the same pattern established in:

`fix(kai-control-surface): add explicit modal prop to Drawer for parity with Dialog`
