### PR TITLE
fix(a11y): add keyboard navigation and screen reader labels to data table

### DIFF
--- a/hushh-webapp/components/app-ui/data-table.tsx
+++ b/hushh-webapp/components/app-ui/data-table.tsx
@@ -365,6 +365,18 @@ export function DataTable<TData, TValue>({
                   key={row.id}
                   data-state={row.getIsSelected() && "selected"}
                   aria-selected={row.getIsSelected() || undefined}
+                  tabIndex={onRowClick ? 0 : undefined}
+                  role={onRowClick ? "button" : undefined}
+                  onKeyDown={
+                    onRowClick
+                      ? (e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            onRowClick(row.original);
+                          }
+                        }
+                      : undefined
+                  }
                   className={cn(
                     onRowClick
                       ? "cursor-pointer transition-[background-color,transform] duration-200 ease-out hover:-translate-y-px hover:bg-foreground/[0.045] active:translate-y-0 active:bg-foreground/[0.065]"
@@ -423,6 +435,7 @@ export function DataTable<TData, TValue>({
                     size="sm"
                     className="h-8 min-w-[64px] justify-between px-2 text-xs sm:min-w-[80px] sm:px-3 sm:text-sm"
                     data-no-route-swipe
+                    aria-label="Rows per page"
                   >
                     {table.getState().pagination.pageSize}
                   </Button>


### PR DESCRIPTION
# Description
Adds keyboard navigation and screen reader attributes to interactive `DataTable` rows.

Previously, rows with `onRowClick` handlers were only accessible via mouse/touch. This adds `tabIndex`, `role="button"`, and an `onKeyDown` handler to allow keyboard users to trigger row clicks using the `Enter` or `Space` keys. Additionally, adds a missing `aria-label` to the rows-per-page pagination dropdown.

## 📌 Core Impact
- [x] **Routes Touched:** Global (`DataTable` Component)
- [x] **API / Schema / Trust Boundary:** None (Purely UI/A11y)
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS**: (N/A)
- [ ] **Android**: (N/A)

## 🧪 Testing & Privacy
- [x] Tested on Web
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible