### PR TITLE
feat(pwa): add appleWebApp metadata for native iOS installability

### DIFF
--- a/hushh-webapp/app/layout.tsx
+++ b/hushh-webapp/app/layout.tsx
@@ -48,6 +48,11 @@ export const metadata: Metadata = {
     shortcut: "/quiet-emoji-icon.svg",
     apple: "/quiet-emoji-icon.png",
   },
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: "black-translucent",
+    title: "Hushh One",
+  },
   manifest: "/manifest.webmanifest",
   openGraph: {
     title: "One | Your Personal Agent",


### PR DESCRIPTION
# Description
Adds `appleWebApp` metadata to enable a native-like PWA experience on iOS.

Configuring `capable: true` allows iOS users to "Add to Home Screen" and launch the web application in standalone mode, which hides the Safari URL bar and bottom navigation toolbar, providing a truly immersive, native app feel.

## 📌 Core Impact
- [x] **Routes Touched:** Global (`layout.tsx`)
- [x] **API / Schema / Trust Boundary:** None (Metadata only)
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation


## 🧪 Testing & Privacy
- [x] Tested on Web
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible