### PR TITLE
fix(vault): disable autocorrect and spellcheck on recovery key input

### DIFF
--- a/hushh-webapp/components/vault/vault-flow.tsx
+++ b/hushh-webapp/components/vault/vault-flow.tsx
@@ -937,6 +937,10 @@ export function VaultFlow({
                   onChange={(e) =>
                     setRecoveryKeyInput(e.target.value.toUpperCase())
                   }
+                  spellCheck={false}
+                  autoComplete="off"
+                  autoCorrect="off"
+                  autoCapitalize="characters"
                   className="h-10 px-3 font-mono text-base sm:h-11"
                 />
               </div>


### PR DESCRIPTION
# Description
Disables autocorrect, autocomplete, and spellcheck on the Vault Recovery Key input.

Because recovery keys are pseudo-random alphanumeric strings (e.g., `HRK-XXXX-XXXX`), mobile browsers (like iOS Safari) often aggressively attempt to autocorrect them or flag them with red spellcheck squiggles. This adds the appropriate HTML attributes to disable all browser intervention, ensuring a smooth UX when users are recovering their vault.

## 📌 Core Impact
- [x] **Routes Touched:** `/one/location` (Vault Flow Component)
- [x] **API / Schema / Trust Boundary:** None (Purely UX)
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation

## 🧪 Testing & Privacy
- [x] Tested on Web
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible