### PR TITLE
fix(ui): disable browser autocomplete on data table search input

### DIFF
--- a/hushh-webapp/components/app-ui/data-table.tsx
+++ b/hushh-webapp/components/app-ui/data-table.tsx
@@ -253,6 +253,7 @@ export function DataTable<TData, TValue>({
               <Input
                 type="search"
                 spellCheck={false}
+                autoComplete="off"
                 autoCorrect="off"
                 autoCapitalize="off"
                 placeholder={searchPlaceholder}


### PR DESCRIPTION
# Description
Disables native browser autocomplete on the global `DataTable` search input.

Adding `autoComplete="off"` prevents browsers from displaying their native history dropdown over the search input. Previously, this native dropdown would obscure the data table results below it while the user was typing, leading to a confusing user experience.

## 📌 Core Impact
- [x] **Routes Touched:** Global (`DataTable` Component)
- [x] **API / Schema / Trust Boundary:** None (Purely UX)
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS**: (N/A)
- [ ] **Android**: (N/A)

## 🧪 Testing & Privacy
- [x] Tested on Web
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible