### PR TITLE
fix(ui): disable automatic format detection in mobile browsers

### DIFF
--- a/hushh-webapp/app/layout.tsx
+++ b/hushh-webapp/app/layout.tsx
@@ -48,6 +48,12 @@ export const metadata: Metadata = {
     shortcut: "/quiet-emoji-icon.svg",
     apple: "/quiet-emoji-icon.png",
   },
+  formatDetection: {
+    telephone: false,
+    date: false,
+    email: false,
+    address: false,
+  },
   manifest: "/manifest.webmanifest",
   openGraph: {
     title: "One | Your Personal Agent",


### PR DESCRIPTION
# Description
Disables automatic format detection in mobile browsers.

Mobile browsers (like iOS Safari) automatically scan the DOM and wrap anything that looks like a phone number, date, or address in a native blue anchor link. This often breaks custom UI styling (especially in dark mode or with numeric IDs). This PR explicitly disables this behavior via Next.js metadata, ensuring consistent visuals across all platforms.

## 📌 Core Impact
- [x] **Routes Touched:** Global (`layout.tsx`)
- [x] **API / Schema / Trust Boundary:** None (Metadata only)
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation

## 🧪 Testing & Privacy
- [x] Tested on Web
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible