### PR TITLE
fix(security): add missing noopener to external disclosure link

### DIFF
--- a/hushh-webapp/app/marketplace/ria/page-client.tsx
+++ b/hushh-webapp/app/marketplace/ria/page-client.tsx
@@ -308,7 +308,7 @@ export default function MarketplaceRiaProfilePageClient() {
                 <a
                   href={profile.disclosures_url}
                   target="_blank"
-                  rel="noreferrer"
+                  rel="noopener noreferrer"
                   data-voice-control-id="marketplace_ria_public_disclosure"
                   className="inline-flex min-h-11 items-center justify-center rounded-full border border-border bg-background px-4 text-sm font-medium text-foreground"
                 >


### PR DESCRIPTION
# Description
Adds the missing `noopener` attribute to an external disclosure link.

This is a standard security fix. Whenever `target="_blank"` is used to open an external link, `rel="noopener noreferrer"` should be explicitly defined to prevent reverse tab-nabbing vulnerabilities, where the external page could maliciously manipulate the `window.opener` object of the origin application.

## 📌 Core Impact
- [x] **Routes Touched:** `/marketplace/ria`
- [x] **API / Schema / Trust Boundary:** Front-end Security (Tab isolation)
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation


## 🧪 Testing & Privacy
- [x] Tested on Web
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible