### PR TITLE
test(consent): preserve permission gate locked-state copy

### DIFF
--- a/hushh-webapp/__tests__/components/permission-gate.test.tsx
+++ b/hushh-webapp/__tests__/components/permission-gate.test.tsx
@@ -62,4 +62,26 @@ describe("PermissionGate", () => {
       "/consents"
     );
   });
+ it("keeps locked permission guidance visible for missing vault access", () => {
+  mockUseVault.mockReturnValue({
+    isVaultUnlocked: false,
+    vaultOwnerToken: null,
+  });
+
+  render(
+    <PermissionGate permission="portfolio_valuation">
+      <button type="button">Connect Portfolio</button>
+    </PermissionGate>
+  );
+
+  expect(screen.getByTestId("permission-locked-state")).toBeTruthy();
+
+  expect(
+    screen.getByText("Vault permission required")
+  ).toBeTruthy();
+
+  expect(
+    screen.getByRole("link", { name: "Review permissions" })
+  ).toBeTruthy();
+});
 });


### PR DESCRIPTION
Summary

- add regression coverage for the locked PermissionGate experience
- verify locked-state guidance remains visible when vault access is unavailable
- ensure the canonical "Review permissions" action remains available to users

Changes

- added a regression test for locked vault states
- verified the locked-state container renders correctly
- verified the "Vault permission required" guidance remains visible
- verified the "Review permissions" action is present

Testing

npm test -- permission-gate

Why

PermissionGate is a critical privacy and consent boundary. This regression test helps prevent future UI changes from accidentally removing the guidance or consent review path that users rely on when vault access is unavailable.