### PR TITLE
fix(ux): disable browser autocomplete on liquid glass search input

### DIFF
--- a/hushh-webapp/components/labs/liquid-glass-search-demo.tsx
+++ b/hushh-webapp/components/labs/liquid-glass-search-demo.tsx
@@ -409,6 +409,7 @@ function LiquidGlassSearchBar({
             <input
               ref={inputRef}
               type="search"
+              autoComplete="off"
               spellCheck={false}
               autoCorrect="off"
               autoCapitalize="off"


### PR DESCRIPTION
# Description
Disables native browser autocomplete on the Liquid Glass custom search input.

This is a targeted UX fix. When `type="search"` is used, browsers natively display a history dropdown. By explicitly setting `autoComplete="off"`, we prevent the browser's ugly native UI from overlapping and ruining the custom Liquid Glass search experience.

## 📌 Core Impact
- [x] **Routes Touched:** `/labs/liquid-glass`
- [x] **API / Schema / Trust Boundary:** None (Purely UX)
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS**: (N/A)
- [ ] **Android**: (N/A)

## 🧪 Testing & Privacy
- [x] Tested on Web
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible