### PR TITLE
fix(security): add missing noopener to liquid glass demo external link

### DIFF
--- a/hushh-webapp/components/labs/liquid-glass-search-demo.tsx
+++ b/hushh-webapp/components/labs/liquid-glass-search-demo.tsx
@@ -139,7 +139,7 @@ export function LiquidGlassSearchDemo() {
             <a
               href="https://unsplash.com/@visaxslr"
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
               className="absolute left-3 top-3 inline-block text-[9px] uppercase tracking-wider text-white/40"
             >
               Photo by @visaxslr


### PR DESCRIPTION
# Description
Adds the missing `noopener` attribute to the external Unsplash link in the Liquid Glass Search Demo.

This is a targeted security fix. Whenever `target="_blank"` is used to open an external link, `rel="noopener noreferrer"` should be explicitly defined to prevent reverse tab-nabbing vulnerabilities where the newly opened tab could gain access to the `window.opener` object of our application.

## 📌 Core Impact
- [x] **Routes Touched:** `/labs/liquid-glass`
- [x] **API / Schema / Trust Boundary:** Front-end Security (Tab isolation)
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation

## 🧪 Testing & Privacy
- [x] Tested on Web
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible