### PR TITLE
fix(ux): disable autocapitalize and autocorrect on email inputs

### DIFF
--- a/hushh-webapp/components/ui/input.tsx
+++ b/hushh-webapp/components/ui/input.tsx
@@ -7,6 +7,9 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
     <input
       type={type}
       data-slot="input"
+      autoCapitalize={type === "email" ? "none" : props.autoCapitalize}
+      autoCorrect={type === "email" ? "off" : props.autoCorrect}
+      spellCheck={type === "email" ? false : props.spellCheck}
       className={cn(
         "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",


### PR DESCRIPTION
# Description
Disables native OS auto-capitalization and auto-correct on email inputs globally.

When rendering the global `Input` component, if the type is `email`, we automatically set `autoCapitalize="none"`, `autoCorrect="off"`, and `spellCheck={false}`. This prevents iOS/Android virtual keyboards from fighting the user by attempting to capitalize the first letter or spell-check the email address domain, creating a significantly smoother mobile UX.

## 📌 Core Impact
- [x] **Routes Touched:** Global (All Email Inputs)
- [x] **API / Schema / Trust Boundary:** Mobile OS Keyboard Interface
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [  ] **iOS**: Fixes virtual keyboard behavior on Safari
- [x] **Android**: Fixes virtual keyboard behavior on Chrome

## 🧪 Testing & Privacy
- [x] Tested on Web (Mobile Simulation)
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible