### PR TITLE
fix(ux): eliminate 300ms mobile tap delay globally

### DIFF
--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -16,6 +16,11 @@ html body[data-scroll-locked] {
   margin-right: 0 !important;
 }
 
+/* Eliminate 300ms tap delay globally on mobile */
+a, button, input, select, textarea {
+  touch-action: manipulation;
+}
+
 [data-app-scroll-root="true"][data-app-scroll-mode="hidden-shell"] {
   overflow-y: auto;
   overflow-x: hidden;


### PR DESCRIPTION
# Description
Eliminates the 300ms tap delay globally on mobile devices.

Adds `touch-action: manipulation` to all interactive elements (`a`, `button`, `input`, `select`, `textarea`) in the global stylesheet. This tells mobile browsers to immediately dispatch click events without waiting 300ms to check for a double-tap zoom gesture, making the PWA feel perfectly instantaneous and snappy like a native iOS/Android app.

## 📌 Core Impact
- [x] **Routes Touched:** Global (`globals.css`)
- [x] **API / Schema / Trust Boundary:** Mobile Browser Interaction Layer
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [x] **iOS**: Eliminates tap delay in Safari / iOS PWA
- [x] **Android**: Eliminates tap delay in Chrome / Android PWA

## 🧪 Testing & Privacy
- [x] Tested on Web (Mobile Simulation)
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible