### PR TITLE
fix(ux): add missing autocomplete attributes to location request form

### DIFF
--- a/hushh-webapp/app/one/location/request/[token]/page-client.tsx
+++ b/hushh-webapp/app/one/location/request/[token]/page-client.tsx
@@ -171,12 +171,14 @@ export default function PublicLocationRequestPageClient() {
                 value={visitorDisplayName}
                 onChange={(event) => setVisitorDisplayName(event.target.value)}
                 placeholder="Your name"
+                autoComplete="name"
                 maxLength={120}
               />
               <Input
                 value={phoneNumber}
                 onChange={(event) => setPhoneNumber(event.target.value)}
                 placeholder="Phone number"
+                autoComplete="tel"
                 inputMode="tel"
                 maxLength={32}
               />


### PR DESCRIPTION
# Description
Adds missing `autoComplete` attributes to the location request form to enable mobile OS autofill.

Adds `autoComplete="name"` and `autoComplete="tel"` to the visitor name and phone number inputs on the public location request page. This allows mobile operating systems (iOS/Android) and password managers to correctly surface quick-fill contact suggestions above the keyboard, significantly reducing friction for external users.

## 📌 Core Impact
- [x] **Routes Touched:** `/one/location/request/[token]`
- [x] **API / Schema / Trust Boundary:** Mobile Browser Autofill API
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [x] **iOS**: Enables QuickType autofill on Safari
- [x] **Android**: Enables Gboard autofill on Chrome

## 🧪 Testing & Privacy
- [x] Tested on Web
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible