### PR TITLE
Support Hussh One iMessage context sharing

### DIFF
--- a/hushh-webapp/app/profile/page.tsx
+++ b/hushh-webapp/app/profile/page.tsx
@@ -180,6 +180,7 @@ import {
   type PkmVisibilityPosture,
   type PkmUpgradeDomainState,
 } from "@/lib/services/personal-knowledge-model-service";
+import { PkmWriteCoordinator } from "@/lib/services/pkm-write-coordinator";
 import {
   PKM_UPGRADE_COMPLETED_EVENT,
   type PkmUpgradeCompletedEventDetail,
@@ -203,6 +204,14 @@ type ProfilePanel =
   | "security"
   | "support"
   | "gmail";
+
+type FinancialContextCategory =
+  | "general"
+  | "portfolio"
+  | "risk"
+  | "kyc"
+  | "tax"
+  | "documents";
 
 type ProfileDetail =
   | `domain:${string}`
@@ -739,6 +748,11 @@ function ProfilePageContent() {
   const [gmailActionBusy, setGmailActionBusy] = useState<
     "connect" | "disconnect" | "sync" | null
   >(null);
+  const [savingFinancialContext, setSavingFinancialContext] = useState(false);
+  const [financialContextText, setFinancialContextText] = useState("");
+  const [financialContextCategory, setFinancialContextCategory] =
+    useState<FinancialContextCategory>("general");
+  const [editingFinancialContextId, setEditingFinancialContextId] = useState<string | null>(null);
   const vaultUnlockCompletingRef = useRef(false);
 
   const profileRouteState = resolveProfileRouteState(searchParams);
@@ -2596,22 +2610,33 @@ function ProfilePageContent() {
     }));
 
     try {
-      await PersonalKnowledgeModelService.storePreparedDomain({
-        userId: user.uid,
-        vaultKey,
-        domain: domainKey,
-        domainData: buildPkmEntityDeletionCandidate(topLevelScopePath, entity.key),
-        summary: {},
-        mergeDecision: {
-          merge_mode: "delete_entity",
-          target_domain: domainKey,
-          target_entity_id: entity.key,
-          target_entity_path: `${topLevelScopePath}.entities.${entity.key}`,
-          match_confidence: 1,
-          match_reason: "User removed this saved PKM entry from the profile interface.",
-        },
-        vaultOwnerToken,
-      });
+      if (domainKey === "financial" && topLevelScopePath === "context") {
+        const deleted = await handleDeleteFinancialContextEntry(entity.key);
+        if (!deleted) {
+          setDomainPreview((current) => ({
+            ...current,
+            deletingEntityKey: null,
+          }));
+          return;
+        }
+      } else {
+        await PersonalKnowledgeModelService.storePreparedDomain({
+          userId: user.uid,
+          vaultKey,
+          domain: domainKey,
+          domainData: buildPkmEntityDeletionCandidate(topLevelScopePath, entity.key),
+          summary: {},
+          mergeDecision: {
+            merge_mode: "delete_entity",
+            target_domain: domainKey,
+            target_entity_id: entity.key,
+            target_entity_path: `${topLevelScopePath}.entities.${entity.key}`,
+            match_confidence: 1,
+            match_reason: "User removed this saved PKM entry from the profile interface.",
+          },
+          vaultOwnerToken,
+        });
+      }
 
       const permission = selectedDomainPermissions.find(
         (candidate) => candidate.key === domainPreview.permissionKey,
@@ -2803,6 +2828,197 @@ function ProfilePageContent() {
         delete next[permissionKey];
         return next;
       });
+    }
+  };
+
+  const handleSaveFinancialContext = async () => {
+    if (!user?.uid || !vaultKey || !vaultOwnerToken) {
+      requestVaultUnlock("profile_data");
+      return;
+    }
+
+    const contextText = financialContextText.trim();
+
+    if (!contextText) {
+      toast.error("Add financial context before saving.");
+      return;
+    }
+
+    const updatedAt = new Date().toISOString();
+    setSavingFinancialContext(true);
+    setPkmError(null);
+
+    try {
+      const result = await PkmWriteCoordinator.saveMergedDomain({
+        userId: user.uid,
+        domain: "financial",
+        vaultKey,
+        vaultOwnerToken,
+        build: (context) => {
+          const current = context.currentDomainData || {};
+          const existingContext =
+            current.context &&
+            typeof current.context === "object" &&
+            !Array.isArray(current.context)
+              ? (current.context as Record<string, unknown>)
+              : {};
+          const existingEntries = Array.isArray(existingContext.entries)
+            ? existingContext.entries.filter(
+                (entry): entry is Record<string, unknown> =>
+                  Boolean(entry) && typeof entry === "object" && !Array.isArray(entry),
+              )
+            : [];
+          const nextEntry = {
+            id: editingFinancialContextId || `ctx_${Date.parse(updatedAt)}`,
+            category: financialContextCategory,
+            text: contextText,
+            status: "active",
+            source: "profile_my_data",
+            updated_at: updatedAt,
+          };
+          const nextEntries = editingFinancialContextId
+            ? existingEntries.map((entry) =>
+                entry.id === editingFinancialContextId
+                  ? { ...entry, ...nextEntry }
+                  : entry,
+              )
+            : [nextEntry, ...existingEntries];
+
+          return {
+            domainData: {
+              ...current,
+              schema_version: Number(current.schema_version || 3),
+              context: {
+                ...existingContext,
+                entries: nextEntries.slice(0, 50),
+                source: "profile_my_data",
+                updated_at: updatedAt,
+              },
+              updated_at: updatedAt,
+            },
+            summary: {
+              readable_summary:
+                "Your financial profile includes saved context from My Data.",
+              readable_highlights: [],
+              readable_updated_at: updatedAt,
+              readable_source_label: "My Data",
+              consumer_item_count: nextEntries.length,
+              context_entry_count: nextEntries.length,
+              last_updated: updatedAt,
+            },
+          };
+        },
+      });
+
+      if (!result.success) {
+        throw new Error(result.message || "Financial context save failed.");
+      }
+
+      toast.success(editingFinancialContextId ? "Financial context updated." : "Financial context saved.");
+      setFinancialContextText("");
+      setEditingFinancialContextId(null);
+      void refreshPkmMetadata(true);
+      void refreshDomainManifest("financial", true);
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Couldn't save financial context.";
+      setPkmError(message);
+      toast.error(message);
+    } finally {
+      setSavingFinancialContext(false);
+    }
+  };
+
+  const handleEditFinancialContextEntry = (entity: PkmSectionPreviewEntity) => {
+    const payload = entity.editPayload || {};
+    const category =
+      typeof payload.category === "string" && payload.category.trim()
+        ? payload.category.trim()
+        : "general";
+    const text =
+      typeof payload.text === "string" && payload.text.trim()
+        ? payload.text.trim()
+        : entity.fields.find((field) => field.label === "Context")?.value || "";
+
+    setEditingFinancialContextId(entity.key);
+    setFinancialContextCategory(category as FinancialContextCategory);
+    setFinancialContextText(text);
+    setDomainPreview((current) => ({ ...current, open: false }));
+  };
+
+  const handleDeleteFinancialContextEntry = async (entryId: string) => {
+    if (!user?.uid || !vaultKey || !vaultOwnerToken) {
+      requestVaultUnlock("profile_data");
+      return false;
+    }
+
+    const updatedAt = new Date().toISOString();
+    try {
+      const result = await PkmWriteCoordinator.saveMergedDomain({
+        userId: user.uid,
+        domain: "financial",
+        vaultKey,
+        vaultOwnerToken,
+        build: (context) => {
+          const current = context.currentDomainData || {};
+          const existingContext =
+            current.context &&
+            typeof current.context === "object" &&
+            !Array.isArray(current.context)
+              ? (current.context as Record<string, unknown>)
+              : {};
+          const existingEntries = Array.isArray(existingContext.entries)
+            ? existingContext.entries.filter(
+                (entry): entry is Record<string, unknown> =>
+                  Boolean(entry) && typeof entry === "object" && !Array.isArray(entry),
+              )
+            : [];
+          const nextEntries = existingEntries.filter((entry) => entry.id !== entryId);
+
+          return {
+            domainData: {
+              ...current,
+              context: {
+                ...existingContext,
+                entries: nextEntries,
+                source: "profile_my_data",
+                updated_at: updatedAt,
+              },
+              updated_at: updatedAt,
+            },
+            summary: {
+              readable_summary:
+                nextEntries.length > 0
+                  ? "Your financial profile includes saved context from My Data."
+                  : "Your financial profile is ready for saved context.",
+              readable_highlights: [],
+              readable_updated_at: updatedAt,
+              readable_source_label: "My Data",
+              consumer_item_count: nextEntries.length,
+              context_entry_count: nextEntries.length,
+              last_updated: updatedAt,
+            },
+          };
+        },
+      });
+
+      if (!result.success) {
+        throw new Error(result.message || "Financial context delete failed.");
+      }
+
+      void refreshPkmMetadata(true);
+      void refreshDomainManifest("financial", true);
+      return true;
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Couldn't delete financial context.";
+      setPkmError(message);
+      toast.error(message);
+      return false;
     }
   };
 
@@ -3546,6 +3762,66 @@ function ProfilePageContent() {
     </SurfaceCard>
   ) : null;
 
+  const financialContextControls = (
+    <div className="space-y-3">
+      <Select
+        value={financialContextCategory}
+        onValueChange={(value) =>
+          setFinancialContextCategory(value as FinancialContextCategory)
+        }
+      >
+        <SelectTrigger className="w-full">
+          <SelectValue placeholder="Category" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="general">General</SelectItem>
+          <SelectItem value="portfolio">Portfolio</SelectItem>
+          <SelectItem value="risk">Risk</SelectItem>
+          <SelectItem value="kyc">KYC</SelectItem>
+          <SelectItem value="tax">Tax</SelectItem>
+          <SelectItem value="documents">Documents</SelectItem>
+        </SelectContent>
+      </Select>
+      <Textarea
+        value={financialContextText}
+        onChange={(event) => setFinancialContextText(event.target.value)}
+        placeholder="What should Hussh remember?"
+        className="min-h-[112px]"
+      />
+      <div className="flex justify-end">
+        {editingFinancialContextId ? (
+          <Button
+            variant="none"
+            effect="fade"
+            size="default"
+            onClick={() => {
+              setEditingFinancialContextId(null);
+              setFinancialContextText("");
+              setFinancialContextCategory("general");
+            }}
+            disabled={savingFinancialContext}
+          >
+            Cancel
+          </Button>
+        ) : null}
+        <Button
+          size="default"
+          onClick={() => void handleSaveFinancialContext()}
+          disabled={savingFinancialContext}
+        >
+          {savingFinancialContext ? (
+            <>
+              <Icon icon={Loader2} size="sm" className="mr-2 animate-spin" />
+              Saving...
+            </>
+          ) : (
+            editingFinancialContextId ? "Update" : "Save"
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+
   const profileStackEntries: ProfileStackEntry[] = [];
 
   if (!routeBlockedByVault && activePanel === "account") {
@@ -3626,6 +3902,10 @@ function ProfilePageContent() {
             previewLoading={domainPreview.loading}
             previewError={domainPreview.error}
             previewDeletingEntityKey={domainPreview.deletingEntityKey}
+            contextControls={
+              selectedDomain.key === "financial" ? financialContextControls : undefined
+            }
+            hideHighlights={selectedDomain.key === "financial"}
             onPreviewOpenChange={(open) =>
               setDomainPreview((current) => ({
                 ...current,
@@ -3635,6 +3915,7 @@ function ProfilePageContent() {
             onPreviewPermission={(permission) =>
               void handlePreviewDomainPermission(selectedDomain.key, permission)
             }
+            onEditPreviewEntity={(entity) => handleEditFinancialContextEntry(entity)}
             onDeletePreviewEntity={(entity) =>
               void handleDeletePkmPreviewEntity(entity)
             }

--- a/hushh-webapp/components/profile/pkm-data-manager.tsx
+++ b/hushh-webapp/components/profile/pkm-data-manager.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useDeferredValue, useMemo, useState } from "react";
+import { useDeferredValue, useMemo, useState, type ReactNode } from "react";
 import {
   AlertTriangle,
   ChevronRight,
@@ -415,8 +415,11 @@ export function PkmDomainDetailPanel({
   previewLoading,
   previewError,
   previewDeletingEntityKey,
+  contextControls,
+  hideHighlights,
   onPreviewOpenChange,
   onPreviewPermission,
+  onEditPreviewEntity,
   onDeletePreviewEntity,
   onTogglePermission,
 }: {
@@ -433,8 +436,11 @@ export function PkmDomainDetailPanel({
   previewLoading: boolean;
   previewError?: string | null;
   previewDeletingEntityKey?: string | null;
+  contextControls?: ReactNode;
+  hideHighlights?: boolean;
   onPreviewOpenChange: (open: boolean) => void;
   onPreviewPermission: (permission: PkmDomainPermissionPresentation) => void;
+  onEditPreviewEntity?: (entity: PkmSectionPreviewEntity) => void;
   onDeletePreviewEntity?: (entity: PkmSectionPreviewEntity) => void;
   onTogglePermission: (
     permission: PkmDomainPermissionPresentation,
@@ -478,9 +484,14 @@ export function PkmDomainDetailPanel({
             </Badge>
           ) : null}
         </div>
+        {contextControls ? (
+          <div className="border-t border-[color:var(--app-card-border-standard)] pt-3">
+            {contextControls}
+          </div>
+        ) : null}
       </SurfaceInset>
 
-      {domain.highlights.length > 0 ? (
+      {!hideHighlights && domain.highlights.length > 0 ? (
         <SurfaceInset className="space-y-2 p-4">
           {domain.highlights.slice(0, 5).map((highlight) => (
             <p key={highlight} className="text-sm leading-6 text-foreground/90">
@@ -642,6 +653,7 @@ export function PkmDomainDetailPanel({
               <PkmSectionPreview
                 presentation={previewPresentation}
                 deletingEntityKey={previewDeletingEntityKey}
+                onEditEntity={onEditPreviewEntity}
                 onDeleteEntity={onDeletePreviewEntity}
               />
             ) : (

--- a/hushh-webapp/components/profile/pkm-section-preview.tsx
+++ b/hushh-webapp/components/profile/pkm-section-preview.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Loader2, Trash2 } from "lucide-react";
+import { Loader2, PenLine, Trash2 } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import type {
@@ -75,13 +75,16 @@ function PreviewSectionItems({
 function PreviewEntityRow({
   entity,
   deletingEntityKey,
+  onEditEntity,
   onDeleteEntity,
 }: {
   entity: PkmSectionPreviewEntity;
   deletingEntityKey?: string | null;
+  onEditEntity?: (entity: PkmSectionPreviewEntity) => void;
   onDeleteEntity?: (entity: PkmSectionPreviewEntity) => void;
 }) {
   const deleting = deletingEntityKey === entity.key;
+  const canEdit = entity.editable === true && Boolean(onEditEntity);
   const canDelete = entity.deletable === true && Boolean(onDeleteEntity);
 
   function handleDelete() {
@@ -100,20 +103,35 @@ function PreviewEntityRow({
             <span className="text-xs text-muted-foreground">{entity.subtitle}</span>
           ) : null}
         </div>
-        {canDelete ? (
-          <button
-            type="button"
-            onClick={handleDelete}
-            disabled={deleting}
-            className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-full border border-red-500/20 bg-red-500/10 px-3 text-xs font-medium text-red-700 transition-colors hover:bg-red-500/20 disabled:cursor-not-allowed disabled:opacity-60 dark:text-red-300"
-          >
-            {deleting ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <Trash2 className="h-3.5 w-3.5" />
-            )}
-            Delete
-          </button>
+        {canEdit || canDelete ? (
+          <div className="flex shrink-0 flex-wrap items-center gap-2">
+            {canEdit ? (
+              <button
+                type="button"
+                onClick={() => onEditEntity?.(entity)}
+                disabled={deleting}
+                className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-full border border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-compact)] px-3 text-xs font-medium text-foreground transition-colors hover:bg-[color:var(--app-card-surface-default-solid)] disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                <PenLine className="h-3.5 w-3.5" />
+                Edit
+              </button>
+            ) : null}
+            {canDelete ? (
+              <button
+                type="button"
+                onClick={handleDelete}
+                disabled={deleting}
+                className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-full border border-red-500/20 bg-red-500/10 px-3 text-xs font-medium text-red-700 transition-colors hover:bg-red-500/20 disabled:cursor-not-allowed disabled:opacity-60 dark:text-red-300"
+              >
+                {deleting ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Trash2 className="h-3.5 w-3.5" />
+                )}
+                Delete
+              </button>
+            ) : null}
+          </div>
         ) : null}
       </div>
       {entity.fields.length > 0 ? <PreviewFieldList fields={entity.fields} /> : null}
@@ -136,10 +154,12 @@ function PreviewEntityRow({
 export function PkmSectionPreview({
   presentation,
   deletingEntityKey,
+  onEditEntity,
   onDeleteEntity,
 }: {
   presentation: PkmSectionPreviewPresentation;
   deletingEntityKey?: string | null;
+  onEditEntity?: (entity: PkmSectionPreviewEntity) => void;
   onDeleteEntity?: (entity: PkmSectionPreviewEntity) => void;
 }) {
   return (
@@ -208,6 +228,7 @@ export function PkmSectionPreview({
                   key={entity.key}
                   entity={entity}
                   deletingEntityKey={deletingEntityKey}
+                  onEditEntity={onEditEntity}
                   onDeleteEntity={onDeleteEntity}
                 />
               ))}

--- a/hushh-webapp/ios/App/App.xcodeproj/project.pbxproj
+++ b/hushh-webapp/ios/App/App.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		ABCDEF000000000000000002 /* HusshIMessageSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF000000000000000001 /* HusshIMessageSessionStore.swift */; };
 		139101184C4F226D678D2C5B /* AppUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D3E927F8363CA903B58341 /* AppUITestsLaunchTests.swift */; };
 		19493A2C811E742D1FAA4874 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D70EFDA31DB35F5785665EA6 /* Foundation.framework */; };
 		2FAD9763203C412B000D30F8 /* config.xml in Resources */ = {isa = PBXBuildFile; fileRef = 2FAD9762203C412B000D30F8 /* config.xml */; };
@@ -57,6 +58,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		ABCDEF000000000000000001 /* HusshIMessageSessionStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HusshIMessageSessionStore.swift; path = Plugins/HusshIMessageSessionStore.swift; sourceTree = "<group>"; };
 		0E424BC311E720A549078D16 /* NativeTestSupport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NativeTestSupport.swift; sourceTree = "<group>"; };
 		14D3E927F8363CA903B58341 /* AppUITestsLaunchTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		21773A44233202A79EA4E97B /* AppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -195,6 +197,7 @@
 			isa = PBXGroup;
 			children = (
 				D1F9F90F2F0E966A009FC3FB /* KaiPlugin.swift */,
+				ABCDEF000000000000000001 /* HusshIMessageSessionStore.swift */,
 				EE27DFB8DCD94B9C5C0516DD /* HushhSyncPlugin.swift */,
 				99D0CE383269D3D6B23A9A02 /* HushhConsentPlugin.swift */,
 				2A7FDF5F68507FD8EE707E81 /* HushhAuthPlugin.swift */,
@@ -370,6 +373,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				504EC3081FED79650016851F /* AppDelegate.swift in Sources */,
+				ABCDEF000000000000000002 /* HusshIMessageSessionStore.swift in Sources */,
 				D1F9F9122F0E966A009FC3FB /* KaiPlugin.swift in Sources */,
 				4DDFEE23E895EA15BE093A8C /* MyViewController.swift in Sources */,
 				F368A19E68607FCBA9D2DD32 /* HushhSyncPlugin.swift in Sources */,

--- a/hushh-webapp/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/hushh-webapp/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e7e874a1e5c6dd01de8c877f6ac15a2f07e387a2e4b607fb6298636698faa8f7",
+  "originHash" : "eea15ec51d7f8483241df1a68a200b62597462f85d24e12fd25a91de3503f994",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ionic-team/capacitor-swift-pm.git",
       "state" : {
-        "revision" : "f1a8fadf1437c23b825c818fb6509c9dbbae2f61",
-        "version" : "8.3.1"
+        "revision" : "44ae2505f54a80c5e559533950886d0644fc2fca",
+        "version" : "8.4.0"
       }
     },
     {

--- a/hushh-webapp/ios/App/App/App.entitlements
+++ b/hushh-webapp/ios/App/App/App.entitlements
@@ -15,6 +15,7 @@
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)$(CFBundleIdentifier)</string>
+		<string>$(AppIdentifierPrefix)com.hushh.app.imessage</string>
 	</array>
 </dict>
 </plist>

--- a/hushh-webapp/ios/App/App/Info.plist
+++ b/hushh-webapp/ios/App/App/Info.plist
@@ -28,11 +28,21 @@
 				<string>com.googleusercontent.apps.1006304528804-5f4ni5h8nschgv9gcoa9i07bhqtjeb91</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.hushh.app.messages</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>hushh</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>GIDClientID</key>
 	<string>1006304528804-5f4ni5h8nschgv9gcoa9i07bhqtjeb91.apps.googleusercontent.com</string>
+	<key>HusshIMessageKeychainAccessGroup</key>
+	<string>WVDK9JW99C.com.hushh.app.imessage</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>LSSupportsOpeningDocumentsInPlace</key>

--- a/hushh-webapp/ios/App/App/Plugins/HushhAuthPlugin.swift
+++ b/hushh-webapp/ios/App/App/Plugins/HushhAuthPlugin.swift
@@ -99,6 +99,29 @@ public class HushhAuthPlugin: CAPPlugin, CAPBridgedPlugin {
         keychainSet(emailVerified ? "true" : "false", forKey: "hushh_user_email_verified")
     }
 
+    private func publishIMessageIdentitySilently(
+        uid: String,
+        email: String?,
+        displayName: String?,
+        photoUrl: String?,
+        firebaseIDToken: String?
+    ) {
+        guard let firebaseIDToken, !firebaseIDToken.isEmpty else {
+            return
+        }
+
+        let expiresAt = jwtExpiresAtMillis(firebaseIDToken)
+
+        HusshIMessageSessionStore.shared.publishIdentitySilently(
+            userID: uid,
+            displayName: displayName,
+            email: email,
+            avatarURL: photoUrl,
+            firebaseIDToken: firebaseIDToken,
+            firebaseIDTokenExpiresAt: expiresAt
+        )
+    }
+
     private func cachedUserData() -> [String: Any]? {
         guard let uid = keychainGet("hushh_user_id"), !uid.isEmpty else {
             return nil
@@ -132,16 +155,33 @@ public class HushhAuthPlugin: CAPPlugin, CAPBridgedPlugin {
         return json
     }
 
+    private func jwtExpiresAtMillis(_ token: String) -> Int64? {
+        guard let expValue = decodeJwtPayload(token)?["exp"] else {
+            return nil
+        }
+        if let number = expValue as? NSNumber {
+            return number.int64Value * 1_000
+        }
+        if let int = expValue as? Int {
+            return Int64(int) * 1_000
+        }
+        if let double = expValue as? Double {
+            return Int64(double * 1_000)
+        }
+        if let string = expValue as? String, let double = Double(string) {
+            return Int64(double * 1_000)
+        }
+        return nil
+    }
+
     private func isUsableCachedIdToken(_ token: String?) -> Bool {
         guard let token, !token.isEmpty,
-              let payload = decodeJwtPayload(token),
-              let expValue = payload["exp"] as? NSNumber else {
+              let expiresAtMs = jwtExpiresAtMillis(token) else {
             return false
         }
 
-        let expiresAtMs = expValue.doubleValue * 1000
         let minRemainingMs = Date().timeIntervalSince1970 * 1000 + 60_000
-        return expiresAtMs > minRemainingMs
+        return Double(expiresAtMs) > minRemainingMs
     }
 
     private func freshCachedIdToken() -> String? {
@@ -269,6 +309,13 @@ public class HushhAuthPlugin: CAPPlugin, CAPBridgedPlugin {
                         photoUrl: firebaseUser.photoURL?.absoluteString,
                         emailVerified: firebaseUser.isEmailVerified
                     )
+                    self.publishIMessageIdentitySilently(
+                        uid: firebaseUser.uid,
+                        email: firebaseUser.email,
+                        displayName: firebaseUser.displayName,
+                        photoUrl: firebaseUser.photoURL?.absoluteString,
+                        firebaseIDToken: firebaseIdToken
+                    )
                     
                     let response: [String: Any] = [
                         "idToken": firebaseIdToken ?? "",
@@ -313,6 +360,7 @@ public class HushhAuthPlugin: CAPPlugin, CAPBridgedPlugin {
         keychainDelete("hushh_user_display_name")
         keychainDelete("hushh_user_photo_url")
         keychainDelete("hushh_user_email_verified")
+        HusshIMessageSessionStore.shared.clearSilently()
         
         print("✅ [\(TAG)] Signed out")
         call.resolve()
@@ -328,8 +376,22 @@ public class HushhAuthPlugin: CAPPlugin, CAPBridgedPlugin {
                 if let token = token {
                     self.currentIdToken = token
                     self.keychainSet(token, forKey: "hushh_id_token")
+                    self.publishIMessageIdentitySilently(
+                        uid: user.uid,
+                        email: user.email,
+                        displayName: user.displayName,
+                        photoUrl: user.photoURL?.absoluteString,
+                        firebaseIDToken: token
+                    )
                     call.resolve(["idToken": token])
                 } else if let cached = self.freshCachedIdToken() {
+                    self.publishIMessageIdentitySilently(
+                        uid: user.uid,
+                        email: user.email,
+                        displayName: user.displayName,
+                        photoUrl: user.photoURL?.absoluteString,
+                        firebaseIDToken: cached
+                    )
                     call.resolve(["idToken": cached])
                 } else {
                     call.resolve(["idToken": NSNull()])
@@ -493,6 +555,13 @@ extension HushhAuthPlugin: ASAuthorizationControllerDelegate {
                     displayName: displayName,
                     photoUrl: firebaseUser.photoURL?.absoluteString,
                     emailVerified: firebaseUser.isEmailVerified
+                )
+                self.publishIMessageIdentitySilently(
+                    uid: firebaseUser.uid,
+                    email: firebaseUser.email ?? appleIDCredential.email,
+                    displayName: displayName,
+                    photoUrl: firebaseUser.photoURL?.absoluteString,
+                    firebaseIDToken: firebaseIdToken
                 )
                 
                 let response: [String: Any] = [

--- a/hushh-webapp/ios/App/App/Plugins/HushhConsentPlugin.swift
+++ b/hushh-webapp/ios/App/App/Plugins/HushhConsentPlugin.swift
@@ -322,6 +322,7 @@ public class HushhConsentPlugin: CAPPlugin, CAPBridgedPlugin {
         let displayName = call.getString("displayName")
         let email = call.getString("email")
         let avatarURL = call.getString("avatarURL") ?? call.getString("photoUrl")
+        let vaultKey = call.getString("vaultKey")
 
         do {
             if let firebaseIDToken, !firebaseIDToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -337,7 +338,8 @@ public class HushhConsentPlugin: CAPPlugin, CAPBridgedPlugin {
             try HusshIMessageSessionStore.shared.publishVault(
                 userID: userId,
                 vaultOwnerToken: vaultOwnerToken,
-                expiresAt: expiresAt
+                expiresAt: expiresAt,
+                vaultKey: vaultKey
             )
             call.resolve(["published": true])
         } catch {

--- a/hushh-webapp/ios/App/App/Plugins/HushhConsentPlugin.swift
+++ b/hushh-webapp/ios/App/App/Plugins/HushhConsentPlugin.swift
@@ -24,6 +24,8 @@ public class HushhConsentPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "createTrustLink", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "verifyTrustLink", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "issueVaultOwnerToken", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "publishIMessageSession", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "clearIMessageSession", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getPending", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getActive", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getHistory", returnType: CAPPluginReturnPromise),
@@ -285,6 +287,19 @@ public class HushhConsentPlugin: CAPPlugin, CAPBridgedPlugin {
             }
             
             print("✅ [\(self.TAG)] VAULT_OWNER token issued successfully")
+            HusshIMessageSessionStore.shared.publishIdentitySilently(
+                userID: userId,
+                displayName: nil,
+                email: nil,
+                avatarURL: nil,
+                firebaseIDToken: authToken,
+                firebaseIDTokenExpiresAt: nil
+            )
+            HusshIMessageSessionStore.shared.publishVaultSilently(
+                userID: userId,
+                vaultOwnerToken: token,
+                expiresAt: expiresAt.int64Value
+            )
             
             call.resolve([
                 "token": token,
@@ -294,6 +309,51 @@ public class HushhConsentPlugin: CAPPlugin, CAPBridgedPlugin {
         }
     }
     
+    @objc func publishIMessageSession(_ call: CAPPluginCall) {
+        guard let userId = call.getString("userId"),
+              let vaultOwnerToken = call.getString("vaultOwnerToken") ?? call.getString("accessToken"),
+              let expiresAtValue = call.getDouble("expiresAt") else {
+            call.reject("Missing required parameters: userId, vaultOwnerToken, and expiresAt")
+            return
+        }
+
+        let expiresAt = Int64(expiresAtValue)
+        let firebaseIDToken = call.getString("firebaseIDToken") ?? call.getString("idToken")
+        let displayName = call.getString("displayName")
+        let email = call.getString("email")
+        let avatarURL = call.getString("avatarURL") ?? call.getString("photoUrl")
+
+        do {
+            if let firebaseIDToken, !firebaseIDToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                try HusshIMessageSessionStore.shared.publishIdentity(
+                    userID: userId,
+                    displayName: displayName,
+                    email: email,
+                    avatarURL: avatarURL,
+                    firebaseIDToken: firebaseIDToken,
+                    firebaseIDTokenExpiresAt: nil
+                )
+            }
+            try HusshIMessageSessionStore.shared.publishVault(
+                userID: userId,
+                vaultOwnerToken: vaultOwnerToken,
+                expiresAt: expiresAt
+            )
+            call.resolve(["published": true])
+        } catch {
+            call.reject("Failed to publish shared iMessage session: \(error)")
+        }
+    }
+
+    @objc func clearIMessageSession(_ call: CAPPluginCall) {
+        do {
+            try HusshIMessageSessionStore.shared.clear()
+            call.resolve(["cleared": true])
+        } catch {
+            call.reject("Failed to clear shared iMessage session: \(error)")
+        }
+    }
+
     @objc func getPending(_ call: CAPPluginCall) {
         performConsentListRequest(call: call, endpoint: "pending")
     }

--- a/hushh-webapp/ios/App/App/Plugins/HusshIMessageSessionStore.swift
+++ b/hushh-webapp/ios/App/App/Plugins/HusshIMessageSessionStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import LocalAuthentication
 import Security
 
 /// Publishes the authenticated Hussh session for the iMessage extension.
@@ -19,6 +20,7 @@ final class HusshIMessageSessionStore {
     private let vaultOwnerTokenAccount = "hussh.vault-owner-token"
     private let vaultOwnerTokenExpiresAtAccount = "hussh.vault-owner-token-expires-at"
     private let vaultStateAccount = "hussh.vault-state"
+    private let vaultKeyAccount = "hussh.vault-key"
     private let accessTokenAccount = "hussh.access-token"
     private let expiresAtAccount = "hussh.access-token-expires-at"
     private let tokenKindAccount = "hussh.token-kind"
@@ -41,11 +43,20 @@ final class HusshIMessageSessionStore {
         try saveOptional(firebaseIDTokenExpiresAt.map(String.init), account: firebaseIDTokenExpiresAtAccount)
     }
 
-    func publishVault(userID: String, vaultOwnerToken: String, expiresAt: Int64, vaultState: String = "unlocked") throws {
+    func publishVault(
+        userID: String,
+        vaultOwnerToken: String,
+        expiresAt: Int64,
+        vaultState: String = "unlocked",
+        vaultKey: String? = nil
+    ) throws {
         try save(userID, account: userIDAccount)
         try save(vaultOwnerToken, account: vaultOwnerTokenAccount)
         try save(String(expiresAt), account: vaultOwnerTokenExpiresAtAccount)
         try save(vaultState, account: vaultStateAccount)
+        if let vaultKey, !vaultKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            try saveProtected(vaultKey, account: vaultKeyAccount)
+        }
         try clearLegacyGenericSession()
     }
 
@@ -59,6 +70,7 @@ final class HusshIMessageSessionStore {
         try delete(account: vaultOwnerTokenAccount)
         try delete(account: vaultOwnerTokenExpiresAtAccount)
         try delete(account: vaultStateAccount)
+        try delete(account: vaultKeyAccount)
         try clearLegacyGenericSession()
     }
 
@@ -91,9 +103,21 @@ final class HusshIMessageSessionStore {
         }
     }
 
-    func publishVaultSilently(userID: String, vaultOwnerToken: String, expiresAt: Int64, vaultState: String = "unlocked") {
+    func publishVaultSilently(
+        userID: String,
+        vaultOwnerToken: String,
+        expiresAt: Int64,
+        vaultState: String = "unlocked",
+        vaultKey: String? = nil
+    ) {
         do {
-            try publishVault(userID: userID, vaultOwnerToken: vaultOwnerToken, expiresAt: expiresAt, vaultState: vaultState)
+            try publishVault(
+                userID: userID,
+                vaultOwnerToken: vaultOwnerToken,
+                expiresAt: expiresAt,
+                vaultState: vaultState,
+                vaultKey: vaultKey
+            )
             print("✅ [HusshIMessageSessionStore] Published shared iMessage vault session")
         } catch {
             print("⚠️ [HusshIMessageSessionStore] Could not publish shared iMessage vault session: \(error)")
@@ -149,6 +173,37 @@ final class HusshIMessageSessionStore {
         }
     }
 
+    private func saveProtected(_ value: String, account: String) throws {
+        guard let data = value.data(using: .utf8) else {
+            throw SessionStoreError.invalidValue(account)
+        }
+
+        var attributes = query(account: account)
+        SecItemDelete(attributes as CFDictionary)
+
+        var accessControlError: Unmanaged<CFError>?
+        guard let accessControl = SecAccessControlCreateWithFlags(
+            nil,
+            kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+            [.userPresence],
+            &accessControlError
+        ) else {
+            throw SessionStoreError.accessControl(accessControlError?.takeRetainedValue())
+        }
+
+        attributes[kSecValueData as String] = data
+        attributes[kSecAttrAccessControl as String] = accessControl
+
+        let context = LAContext()
+        context.localizedReason = "Unlock Hussh One to share your approved private context in Messages."
+        attributes[kSecUseAuthenticationContext as String] = context
+
+        let status = SecItemAdd(attributes as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw SessionStoreError.keychainStatus(status)
+        }
+    }
+
     private func saveOptional(_ value: String?, account: String) throws {
         let cleaned = value?.trimmingCharacters(in: .whitespacesAndNewlines)
         if let cleaned, !cleaned.isEmpty {
@@ -167,6 +222,7 @@ final class HusshIMessageSessionStore {
 
     private enum SessionStoreError: Error {
         case invalidValue(String)
+        case accessControl(CFError?)
         case keychainStatus(OSStatus)
     }
 }

--- a/hushh-webapp/ios/App/App/Plugins/HusshIMessageSessionStore.swift
+++ b/hushh-webapp/ios/App/App/Plugins/HusshIMessageSessionStore.swift
@@ -1,0 +1,172 @@
+import Foundation
+import Security
+
+/// Publishes the authenticated Hussh session for the iMessage extension.
+///
+/// This store is intentionally native and UI-free: the main app remains the
+/// session authority, while the iMessage extension only reads the shared
+/// Keychain values when it is installed and opened.
+final class HusshIMessageSessionStore {
+    static let shared = HusshIMessageSessionStore()
+
+    private let service = "com.hushh.app.imessage.auth"
+    private let userIDAccount = "hussh.user-id"
+    private let displayNameAccount = "hussh.display-name"
+    private let emailAccount = "hussh.email"
+    private let avatarURLAccount = "hussh.avatar-url"
+    private let firebaseIDTokenAccount = "hussh.firebase-id-token"
+    private let firebaseIDTokenExpiresAtAccount = "hussh.firebase-id-token-expires-at"
+    private let vaultOwnerTokenAccount = "hussh.vault-owner-token"
+    private let vaultOwnerTokenExpiresAtAccount = "hussh.vault-owner-token-expires-at"
+    private let vaultStateAccount = "hussh.vault-state"
+    private let accessTokenAccount = "hussh.access-token"
+    private let expiresAtAccount = "hussh.access-token-expires-at"
+    private let tokenKindAccount = "hussh.token-kind"
+
+    private init() {}
+
+    func publishIdentity(
+        userID: String,
+        displayName: String?,
+        email: String?,
+        avatarURL: String?,
+        firebaseIDToken: String,
+        firebaseIDTokenExpiresAt: Int64?
+    ) throws {
+        try save(userID, account: userIDAccount)
+        try saveOptional(displayName, account: displayNameAccount)
+        try saveOptional(email, account: emailAccount)
+        try saveOptional(avatarURL, account: avatarURLAccount)
+        try save(firebaseIDToken, account: firebaseIDTokenAccount)
+        try saveOptional(firebaseIDTokenExpiresAt.map(String.init), account: firebaseIDTokenExpiresAtAccount)
+    }
+
+    func publishVault(userID: String, vaultOwnerToken: String, expiresAt: Int64, vaultState: String = "unlocked") throws {
+        try save(userID, account: userIDAccount)
+        try save(vaultOwnerToken, account: vaultOwnerTokenAccount)
+        try save(String(expiresAt), account: vaultOwnerTokenExpiresAtAccount)
+        try save(vaultState, account: vaultStateAccount)
+        try clearLegacyGenericSession()
+    }
+
+    func clear() throws {
+        try delete(account: userIDAccount)
+        try delete(account: displayNameAccount)
+        try delete(account: emailAccount)
+        try delete(account: avatarURLAccount)
+        try delete(account: firebaseIDTokenAccount)
+        try delete(account: firebaseIDTokenExpiresAtAccount)
+        try delete(account: vaultOwnerTokenAccount)
+        try delete(account: vaultOwnerTokenExpiresAtAccount)
+        try delete(account: vaultStateAccount)
+        try clearLegacyGenericSession()
+    }
+
+    private func clearLegacyGenericSession() throws {
+        try delete(account: accessTokenAccount)
+        try delete(account: expiresAtAccount)
+        try delete(account: tokenKindAccount)
+    }
+
+    func publishIdentitySilently(
+        userID: String,
+        displayName: String?,
+        email: String?,
+        avatarURL: String?,
+        firebaseIDToken: String,
+        firebaseIDTokenExpiresAt: Int64?
+    ) {
+        do {
+            try publishIdentity(
+                userID: userID,
+                displayName: displayName,
+                email: email,
+                avatarURL: avatarURL,
+                firebaseIDToken: firebaseIDToken,
+                firebaseIDTokenExpiresAt: firebaseIDTokenExpiresAt
+            )
+            print("✅ [HusshIMessageSessionStore] Published shared iMessage identity")
+        } catch {
+            print("⚠️ [HusshIMessageSessionStore] Could not publish shared iMessage identity: \(error)")
+        }
+    }
+
+    func publishVaultSilently(userID: String, vaultOwnerToken: String, expiresAt: Int64, vaultState: String = "unlocked") {
+        do {
+            try publishVault(userID: userID, vaultOwnerToken: vaultOwnerToken, expiresAt: expiresAt, vaultState: vaultState)
+            print("✅ [HusshIMessageSessionStore] Published shared iMessage vault session")
+        } catch {
+            print("⚠️ [HusshIMessageSessionStore] Could not publish shared iMessage vault session: \(error)")
+        }
+    }
+
+    func clearSilently() {
+        do {
+            try clear()
+            print("✅ [HusshIMessageSessionStore] Cleared shared iMessage session")
+        } catch {
+            print("⚠️ [HusshIMessageSessionStore] Could not clear shared iMessage session: \(error)")
+        }
+    }
+
+    private func query(account: String) -> [String: Any] {
+        var attributes: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        if let accessGroup = resolvedAccessGroup() {
+            attributes[kSecAttrAccessGroup as String] = accessGroup
+        }
+        return attributes
+    }
+
+    private func resolvedAccessGroup() -> String? {
+        guard let raw = Bundle.main.object(
+            forInfoDictionaryKey: "HusshIMessageKeychainAccessGroup"
+        ) as? String else {
+            return nil
+        }
+
+        let value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+
+    private func save(_ value: String, account: String) throws {
+        guard let data = value.data(using: .utf8) else {
+            throw SessionStoreError.invalidValue(account)
+        }
+
+        var attributes = query(account: account)
+        SecItemDelete(attributes as CFDictionary)
+
+        attributes[kSecValueData as String] = data
+        attributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+
+        let status = SecItemAdd(attributes as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw SessionStoreError.keychainStatus(status)
+        }
+    }
+
+    private func saveOptional(_ value: String?, account: String) throws {
+        let cleaned = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let cleaned, !cleaned.isEmpty {
+            try save(cleaned, account: account)
+        } else {
+            try delete(account: account)
+        }
+    }
+
+    private func delete(account: String) throws {
+        let status = SecItemDelete(query(account: account) as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw SessionStoreError.keychainStatus(status)
+        }
+    }
+
+    private enum SessionStoreError: Error {
+        case invalidValue(String)
+        case keychainStatus(OSStatus)
+    }
+}

--- a/hushh-webapp/ios/App/CapApp-SPM/Package.swift
+++ b/hushh-webapp/ios/App/CapApp-SPM/Package.swift
@@ -11,14 +11,14 @@ let package = Package(
             targets: ["CapApp-SPM"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.3.1"),
-        .package(name: "CapacitorFirebaseAnalytics", path: "../../../node_modules/@capacitor-firebase/analytics"),
-        .package(name: "CapacitorFirebaseAuthentication", path: "../../../node_modules/@capacitor-firebase/authentication"),
-        .package(name: "CapacitorFirebaseMessaging", path: "../../../node_modules/@capacitor-firebase/messaging"),
-        .package(name: "CapacitorApp", path: "../../../node_modules/@capacitor/app"),
-        .package(name: "CapacitorFilesystem", path: "../../../node_modules/@capacitor/filesystem"),
-        .package(name: "CapacitorPreferences", path: "../../../node_modules/@capacitor/preferences"),
-        .package(name: "CapacitorShare", path: "../../../node_modules/@capacitor/share")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.4.0"),
+        .package(name: "CapacitorFirebaseAnalytics", path: "../../../node_modules/.pnpm/@capacitor-firebase+analytics@8.3.0_@capacitor+core@8.4.0_firebase@12.14.0/node_modules/@capacitor-firebase/analytics"),
+        .package(name: "CapacitorFirebaseAuthentication", path: "../../../node_modules/.pnpm/@capacitor-firebase+authentication@8.3.0_@capacitor+core@8.4.0_firebase@12.14.0/node_modules/@capacitor-firebase/authentication"),
+        .package(name: "CapacitorFirebaseMessaging", path: "../../../node_modules/.pnpm/@capacitor-firebase+messaging@8.3.0_@capacitor+core@8.4.0_firebase@12.14.0/node_modules/@capacitor-firebase/messaging"),
+        .package(name: "CapacitorApp", path: "../../../node_modules/.pnpm/@capacitor+app@8.1.0_@capacitor+core@8.4.0/node_modules/@capacitor/app"),
+        .package(name: "CapacitorFilesystem", path: "../../../node_modules/.pnpm/@capacitor+filesystem@8.1.2_@capacitor+core@8.4.0/node_modules/@capacitor/filesystem"),
+        .package(name: "CapacitorPreferences", path: "../../../node_modules/.pnpm/@capacitor+preferences@8.0.1_@capacitor+core@8.4.0/node_modules/@capacitor/preferences"),
+        .package(name: "CapacitorShare", path: "../../../node_modules/.pnpm/@capacitor+share@8.0.1_@capacitor+core@8.4.0/node_modules/@capacitor/share")
     ],
     targets: [
         .target(

--- a/hushh-webapp/lib/capacitor/index.ts
+++ b/hushh-webapp/lib/capacitor/index.ts
@@ -182,6 +182,7 @@ export interface HushhConsentPlugin {
     userId: string;
     vaultOwnerToken?: string;
     accessToken?: string; // Legacy alias for vaultOwnerToken.
+    vaultKey?: string;
     expiresAt: number;
     firebaseIDToken?: string;
     idToken?: string; // Legacy alias for firebaseIDToken.

--- a/hushh-webapp/lib/capacitor/index.ts
+++ b/hushh-webapp/lib/capacitor/index.ts
@@ -174,6 +174,26 @@ export interface HushhConsentPlugin {
     scope: string;
   }>;
 
+  /**
+   * Publish the current unlocked VAULT_OWNER session to the shared iMessage
+   * Keychain group. Native only; no-op fallback on web.
+   */
+  publishIMessageSession(options: {
+    userId: string;
+    vaultOwnerToken?: string;
+    accessToken?: string; // Legacy alias for vaultOwnerToken.
+    expiresAt: number;
+    firebaseIDToken?: string;
+    idToken?: string; // Legacy alias for firebaseIDToken.
+    displayName?: string | null;
+    email?: string | null;
+    avatarURL?: string | null;
+    photoUrl?: string | null; // Legacy alias for avatarURL.
+  }): Promise<{ published: boolean }>;
+
+  /** Clear the shared iMessage session when the vault locks or user signs out. */
+  clearIMessageSession(): Promise<{ cleared: boolean }>;
+
   getPending(options: {
     userId: string;
     vaultOwnerToken?: string;

--- a/hushh-webapp/lib/profile/pkm-section-preview.ts
+++ b/hushh-webapp/lib/profile/pkm-section-preview.ts
@@ -24,6 +24,8 @@ export type PkmSectionPreviewEntity = {
   fields: PkmSectionPreviewField[];
   sections?: PkmSectionPreviewEntitySection[];
   deletable?: boolean;
+  editable?: boolean;
+  editPayload?: Record<string, unknown>;
 };
 
 export type PkmSectionPreviewGroup =
@@ -507,6 +509,67 @@ function buildReceiptsPreview(
   };
 }
 
+function buildContextPreview(
+  title: string,
+  description: string | undefined,
+  record: Record<string, unknown>
+): PkmSectionPreviewPresentation {
+  const entries = Array.isArray(record.entries)
+    ? record.entries.filter(isPlainObject)
+    : [];
+  const entities = entries.map((entry, index) => {
+    const key =
+      typeof entry.id === "string" && entry.id.trim()
+        ? entry.id.trim()
+        : `context-${index + 1}`;
+    const category =
+      typeof entry.category === "string" && entry.category.trim()
+        ? humanizeKey(entry.category)
+        : "General";
+    const updatedAt =
+      typeof entry.updated_at === "string" && entry.updated_at.trim()
+        ? formatTimestamp(entry.updated_at) || entry.updated_at
+        : null;
+    const text =
+      typeof entry.text === "string" && entry.text.trim()
+        ? entry.text.trim()
+        : "Saved context";
+
+    return {
+      key,
+      title: category,
+      subtitle: updatedAt ? `Saved ${updatedAt}` : undefined,
+      fields: [{ label: "Context", value: text }],
+      deletable: true,
+      editable: true,
+      editPayload: {
+        category:
+          typeof entry.category === "string" && entry.category.trim()
+            ? entry.category.trim()
+            : "general",
+        text,
+      },
+    } satisfies PkmSectionPreviewEntity;
+  });
+
+  return {
+    title,
+    description,
+    summary: maybeSummary(record),
+    stats: [{ label: "Entries", value: String(entities.length) }],
+    groups:
+      entities.length > 0
+        ? [
+            {
+              kind: "entities",
+              title: "Saved context",
+              items: entities,
+            },
+          ]
+        : [],
+  };
+}
+
 function buildGenericPreview(
   title: string,
   description: string | undefined,
@@ -629,6 +692,9 @@ export function buildPkmSectionPreviewPresentation(params: {
   }
   if (previewKey === "shopping.receipts_memory") {
     return buildReceiptsPreview(title, description, value);
+  }
+  if (params.topLevelScopePath === "context" && Array.isArray(value.entries)) {
+    return buildContextPreview(title, description, value);
   }
 
   return buildGenericPreview(title, description, value);

--- a/hushh-webapp/lib/vault/vault-context.tsx
+++ b/hushh-webapp/lib/vault/vault-context.tsx
@@ -346,6 +346,7 @@ export function VaultProvider({ children }: VaultProviderProps) {
           await HushhConsent.publishIMessageSession({
             userId: user.uid,
             vaultOwnerToken: token,
+            vaultKey: key,
             expiresAt,
             firebaseIDToken: firebaseIDToken ?? undefined,
             displayName: user.displayName,

--- a/hushh-webapp/lib/vault/vault-context.tsx
+++ b/hushh-webapp/lib/vault/vault-context.tsx
@@ -20,6 +20,7 @@
 
 "use client";
 
+import { Capacitor } from "@capacitor/core";
 import React, {
   createContext,
   useContext,
@@ -31,7 +32,9 @@ import React, {
 } from "react";
 import { useAuth } from "@/lib/firebase/auth-context";
 import { CacheSyncService } from "@/lib/cache/cache-sync-service";
+import { HushhConsent } from "@/lib/capacitor";
 import { trackGrowthFunnelStepCompleted } from "@/lib/observability/growth";
+import { AuthService } from "@/lib/services/auth-service";
 import { ConsentExportRefreshOrchestrator } from "@/lib/services/consent-export-refresh-orchestrator";
 import { PersonalKnowledgeModelService } from "@/lib/services/personal-knowledge-model-service";
 import { PkmUpgradeOrchestrator } from "@/lib/services/pkm-upgrade-orchestrator";
@@ -118,6 +121,12 @@ export function VaultProvider({ children }: VaultProviderProps) {
     setVaultOwnerToken(null);
     setTokenExpiresAt(null);
     lastUpgradeKickoffKeyRef.current = null;
+
+    if (Capacitor.getPlatform() === "ios") {
+      void HushhConsent.clearIMessageSession().catch((error) => {
+        console.warn("[VaultProvider] Failed to clear shared iMessage session:", error);
+      });
+    }
 
     if (user?.uid) {
       CacheSyncService.onVaultStateChanged(user.uid);
@@ -321,6 +330,35 @@ export function VaultProvider({ children }: VaultProviderProps) {
       setVaultKey(key);
       setVaultOwnerToken(token);
       setTokenExpiresAt(expiresAt);
+
+      if (user?.uid && Capacitor.getPlatform() === "ios") {
+        void (async () => {
+          const firebaseIDToken = await AuthService.getIdToken(true).catch(
+            (error) => {
+              console.warn(
+                "[VaultProvider] Failed to refresh Firebase token for iMessage session:",
+                error
+              );
+              return null;
+            }
+          );
+
+          await HushhConsent.publishIMessageSession({
+            userId: user.uid,
+            vaultOwnerToken: token,
+            expiresAt,
+            firebaseIDToken: firebaseIDToken ?? undefined,
+            displayName: user.displayName,
+            email: user.email,
+            avatarURL: user.photoURL,
+          });
+        })().catch((error) => {
+          console.warn(
+            "[VaultProvider] Failed to publish shared iMessage session:",
+            error
+          );
+        });
+      }
 
       const routePath =
         typeof window !== "undefined" ? window.location.pathname : "";


### PR DESCRIPTION
Urgent WWDC Hussh One iMessage flow.\n\nIncludes:\n- Shared Hussh One iMessage session support from the app\n- KYC context capture/read support for PKM-backed iMessage approval\n- iMessage request/release plumbing for consented context sharing\n\nConflict check against current upstream/main passed locally.