### PR TITLE
test(utils): cover formatted-string numeric parsing in portfolio normalize

### DIFF
--- a/hushh-webapp/__tests__/utils/portfolio-normalize.test.ts
+++ b/hushh-webapp/__tests__/utils/portfolio-normalize.test.ts
@@ -61,7 +61,24 @@ describe("portfolio normalize helpers", () => {
     expect(normalized.holdings[0].market_value).toBe(800);
     expect(normalized.holdings[0].quantity).toBe(3);
   });
-       it("drops empty symbol holdings during consolidation", () => {
+       it("parses formatted currency strings and parenthesized negatives in numeric fields", () => {
+    const consolidated = consolidateHoldingsBySymbol([
+      {
+        symbol: "msft",
+        name: "Microsoft",
+        quantity: "10",
+        market_value: "$1,200.50",
+        cost_basis: "(200)",
+      },
+    ]);
+
+    expect(consolidated).toHaveLength(1);
+    expect(consolidated[0].quantity).toBe(10);
+    expect(consolidated[0].market_value).toBe(1200.5);
+    expect(consolidated[0].cost_basis).toBe(-200);
+  });
+
+  it("drops empty symbol holdings during consolidation", () => {
     const consolidated = consolidateHoldingsBySymbol([
       {
         symbol: "",


### PR DESCRIPTION
## Summary

- Adds one test case to `__tests__/utils/portfolio-normalize.test.ts` covering a real, previously-untested edge case in `consolidateHoldingsBySymbol`
- The internal `parseMaybeNumber` helper (`lib/utils/portfolio-normalize.ts`) coerces brokerage-export-style numeric strings — currency symbols, thousands separators, and parenthesized negatives like `"(200)"` — into numbers, but every existing case in the suite passed plain numeric values. This test exercises that string-parsing path through the public `consolidateHoldingsBySymbol` API with `quantity: "10"`, `market_value: "$1,200.50"`, `cost_basis: "(200)"` and asserts the parsed numeric output (`10`, `1200.5`, `-200`).
- Also fixes a stray indentation inconsistency on the adjacent `"drops empty symbol holdings during consolidation"` test (whitespace only, no logic change).

## Verification note

I was unable to execute the suite directly in my sandbox — `node_modules` wasn't present, and three separate `npm install` attempts hit either a persistent npm CLI bug (`Exit handler never called!`, leaving `vitest` only partially unpacked) or a TLS certificate verification failure reaching the npm registry. None of that reflects on the test itself.

In lieu of a live run, I hand-traced the exact execution path against the current source:
- `consolidateHoldingsBySymbol` → `mergeHoldingsBySymbol(normalizeHoldings(holdings))`
- `normalizeHoldings` calls `parseMaybeNumber` on each numeric field before any merge logic runs:
  - `"10"` → `10`
  - `"$1,200.50"` → strips `$`/`,` → `"1200.50"` → `1200.5`
  - `"(200)"` → matches the parenthesized-negative branch → `"200"` → `Number("-200")` = `-200`
- A single holding with a unique symbol passes through `mergeHoldingsBySymbol` without merge-collision logic touching these fields further

So the assertions (`quantity: 10`, `market_value: 1200.5`, `cost_basis: -200`) match the implementation's actual output. CI should be able to confirm this where `npm install`/registry access works normally.

## Test plan

- [ ] `npm test -- portfolio-normalize` passes, including the new case
- [ ] No regressions in the existing three test cases in this file

🤖 Generated with [Claude Code](https://claude.ai/claude-code)