### PR TITLE
test(services): cover undefined input in getErrorMessage stringification

### DIFF
--- a/hushh-webapp/__tests__/lib/services/error-sanitizer.test.ts
+++ b/hushh-webapp/__tests__/lib/services/error-sanitizer.test.ts
@@ -420,6 +420,10 @@ describe("getErrorMessage", () => {
     expect(getErrorMessage(null)).toBe("null");
   });
 
+  it("stringifies undefined", () => {
+    expect(getErrorMessage(undefined)).toBe("undefined");
+  });
+
   it("stringifies objects via String()", () => {
     const result = getErrorMessage({ detail: "x" });
     expect(typeof result).toBe("string");


### PR DESCRIPTION
## Summary

- Adds one test case to `__tests__/lib/services/error-sanitizer.test.ts` covering a real, previously-untested input variant of `getErrorMessage`
- `getErrorMessage` (`lib/services/error-sanitizer.ts`) has explicit test coverage for `Error`, string, number, `null`, and plain-object inputs — but `undefined`, the other nullish variant that sits right next to the existing `null` case, was not covered.

```ts
it("stringifies undefined", () => {
  expect(getErrorMessage(undefined)).toBe("undefined");
});
```

## Verification note

Same sandbox limitation as my last PR in this train (#2257): `npm install` repeatedly hits a persistent npm CLI bug (`Exit handler never called!`) that leaves the `vitest` package only partially unpacked, so I could not execute the suite directly here. In lieu of a live run, I traced the exact code path against the current source:

```ts
export function getErrorMessage(error: unknown): string {
  if (isError(error)) { ... }        // isError(undefined) → undefined instanceof Error → false
  if (typeof error === "string") {}  // typeof undefined === "string" → false
  return String(error);              // String(undefined) → "undefined"
}
```

`getErrorMessage(undefined)` falls through both guards to `String(undefined)`, which returns `"undefined"` — exactly matching the assertion. CI should be able to confirm this directly where registry access is unobstructed.

## Test plan

- [ ] `npm test -- error-sanitizer` passes, including the new "stringifies undefined" case
- [ ] No regressions in the existing `getErrorMessage` suite (Error / string / number / null / object cases)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)