### PR TITLE
fix(ux): disable autocorrect and spellcheck on vault recovery key input

### DIFF
--- a/hushh-webapp/components/vault/vault-flow.tsx
+++ b/hushh-webapp/components/vault/vault-flow.tsx
@@ -933,6 +933,10 @@ export function VaultFlow({
                 <Input
                   id="recovery-key"
                   placeholder="HRK-XXXX-XXXX-XXXX-XXXX"
+                  autoComplete="off"
+                  autoCorrect="off"
+                  autoCapitalize="characters"
+                  spellCheck={false}
                   value={recoveryKeyInput}
                   onChange={(e) =>
                     setRecoveryKeyInput(e.target.value.toUpperCase())


### PR DESCRIPTION
# Description
Disables native autocorrect and spellcheck behaviors on the Vault Recovery Key input.

Adds `autoComplete="off"`, `autoCorrect="off"`, `autoCapitalize="characters"`, and `spellCheck={false}` to the recovery key `<Input>`. Because recovery keys are random high-entropy strings (e.g. `HRK-XXXX-XXXX`), mobile keyboards (iOS/Android) frequently try to aggressively autocorrect them or display red spellcheck squiggles. Disabling these native text-input behaviors provides a vastly superior UX when external users are pasting or typing their secure recovery keys.

## 📌 Core Impact
- [x] **Routes Touched:** `/vault` (Vault Recovery Flow)
- [x] **API / Schema / Trust Boundary:** Mobile Browser Text Processing API
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [x] **iOS**: Disables QuickType autocorrection on Safari
- [x] **Android**: Disables Gboard autocorrection on Chrome

## 🧪 Testing & Privacy
- [x] Tested on Web
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible