### PR TITLE
feat(ui): global quick scratchpad widget for local note taking

### DIFF
--- a/hushh-webapp/app/layout-client.tsx
+++ b/hushh-webapp/app/layout-client.tsx
@@ -2,6 +2,7 @@
 
 import { ReactNode } from "react";
 import { Providers } from "./providers";
+import { ScratchpadWidget } from "@/components/features/scratchpad/scratchpad-widget";
 
 interface RootLayoutClientProps {
   children: ReactNode;
@@ -35,6 +36,7 @@ export function RootLayoutClient({
 
       <Providers>
         {children}
+        <ScratchpadWidget />
       </Providers>
     </body>
   );

--- a/hushh-webapp/components/features/scratchpad/scratchpad-widget.tsx
+++ b/hushh-webapp/components/features/scratchpad/scratchpad-widget.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useRef, useEffect } from "react";
+import { PenTool, X, Download } from "lucide-react";
+import { useScratchpad } from "@/lib/hooks/use-scratchpad";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+
+export function ScratchpadWidget() {
+  const { content, isOpen, isInitialized, updateContent, toggleOpen, closeScratchpad } = useScratchpad();
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Focus textarea when opened
+  useEffect(() => {
+    if (isOpen && textareaRef.current) {
+      // Small timeout to allow transition to finish
+      setTimeout(() => {
+        textareaRef.current?.focus();
+      }, 100);
+    }
+  }, [isOpen]);
+
+  // Handle escape key to close
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isOpen) {
+        closeScratchpad();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, closeScratchpad]);
+
+  if (!isInitialized) return null;
+
+  const handleDownload = () => {
+    if (!content.trim()) return;
+    const blob = new Blob([content], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `scratchpad-${new Date().toISOString().split("T")[0]}.txt`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="fixed bottom-6 right-6 z-50 flex flex-col items-end gap-3 pointer-events-none">
+      {/* Popover Window */}
+      <div 
+        className={`pointer-events-auto origin-bottom-right transition-all duration-200 ease-out flex flex-col bg-background/80 backdrop-blur-xl border shadow-2xl rounded-2xl w-[320px] sm:w-[380px] overflow-hidden ${
+          isOpen ? "opacity-100 scale-100 translate-y-0" : "opacity-0 scale-95 translate-y-4 pointer-events-none"
+        }`}
+      >
+        <div className="flex items-center justify-between px-4 py-3 border-b bg-muted/30">
+          <div className="flex items-center gap-2">
+            <PenTool className="w-4 h-4 text-primary" />
+            <span className="text-sm font-medium tracking-tight">Quick Note</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <Button 
+              variant="ghost" 
+              size="icon" 
+              className="h-7 w-7 rounded-full" 
+              onClick={handleDownload}
+              disabled={!content.trim()}
+              title="Download text"
+            >
+              <Download className="w-3.5 h-3.5" />
+            </Button>
+            <Button 
+              variant="ghost" 
+              size="icon" 
+              className="h-7 w-7 rounded-full text-muted-foreground hover:text-foreground" 
+              onClick={closeScratchpad}
+            >
+              <X className="w-4 h-4" />
+            </Button>
+          </div>
+        </div>
+        
+        <div className="p-3">
+          <Textarea
+            ref={textareaRef}
+            value={content}
+            onChange={(e) => updateContent(e.target.value)}
+            placeholder="Jot down a quick thought, paste a temporary key, or draft a message... (Auto-saves locally)"
+            className="min-h-[220px] resize-y border-0 bg-transparent focus-visible:ring-0 px-1 py-1 shadow-none rounded-none w-full"
+            spellCheck={false}
+          />
+        </div>
+        
+        <div className="px-4 py-2 text-[10px] text-muted-foreground flex justify-between items-center bg-muted/10 border-t">
+          <span>{content.length} chars</span>
+          <span>Saved locally</span>
+        </div>
+      </div>
+
+      {/* Floating Action Button */}
+      <Button
+        variant="default"
+        size="icon"
+        onClick={toggleOpen}
+        className={`pointer-events-auto h-12 w-12 rounded-full shadow-lg transition-transform duration-200 ${isOpen ? "rotate-90 scale-90 opacity-0" : "hover:scale-105"}`}
+        title="Open Scratchpad"
+      >
+        <PenTool className="w-5 h-5" />
+      </Button>
+    </div>
+  );
+}

--- a/hushh-webapp/lib/hooks/use-scratchpad.ts
+++ b/hushh-webapp/lib/hooks/use-scratchpad.ts
@@ -1,66 +1,19 @@
-import { useEffect, useState } from "react";
+import { create } from "zustand";
 
-const SCRATCHPAD_STORAGE_KEY = "hushh_scratchpad_content";
-const SCRATCHPAD_OPEN_KEY = "hushh_scratchpad_is_open";
-
-export function useScratchpad() {
-  const [content, setContent] = useState<string>("");
-  const [isOpen, setIsOpen] = useState<boolean>(false);
-  const [isInitialized, setIsInitialized] = useState(false);
-
-  // Load initial state from localStorage
-  useEffect(() => {
-    try {
-      const savedContent = localStorage.getItem(SCRATCHPAD_STORAGE_KEY);
-      const savedIsOpen = localStorage.getItem(SCRATCHPAD_OPEN_KEY);
-      
-      if (savedContent) setContent(savedContent);
-      if (savedIsOpen === "true") setIsOpen(true);
-    } catch (e) {
-      console.error("Failed to load scratchpad state from localStorage", e);
-    } finally {
-      setIsInitialized(true);
-    }
-  }, []);
-
-  // Sync content to localStorage
-  const updateContent = (newContent: string) => {
-    setContent(newContent);
-    try {
-      localStorage.setItem(SCRATCHPAD_STORAGE_KEY, newContent);
-    } catch (e) {
-      console.error("Failed to save scratchpad content", e);
-    }
-  };
-
-  // Sync open state to localStorage
-  const toggleOpen = () => {
-    setIsOpen((prev) => {
-      const nextState = !prev;
-      try {
-        localStorage.setItem(SCRATCHPAD_OPEN_KEY, String(nextState));
-      } catch (e) {
-        console.error("Failed to save scratchpad open state", e);
-      }
-      return nextState;
-    });
-  };
-
-  const closeScratchpad = () => {
-    setIsOpen(false);
-    try {
-      localStorage.setItem(SCRATCHPAD_OPEN_KEY, "false");
-    } catch (e) {
-      console.error("Failed to save scratchpad open state", e);
-    }
-  };
-
-  return {
-    content,
-    isOpen,
-    isInitialized,
-    updateContent,
-    toggleOpen,
-    closeScratchpad,
-  };
+interface ScratchpadState {
+  content: string;
+  isOpen: boolean;
+  isInitialized: boolean;
+  updateContent: (newContent: string) => void;
+  toggleOpen: () => void;
+  closeScratchpad: () => void;
 }
+
+export const useScratchpad = create<ScratchpadState>((set) => ({
+  content: "",
+  isOpen: false,
+  isInitialized: true,
+  updateContent: (newContent) => set({ content: newContent }),
+  toggleOpen: () => set((state) => ({ isOpen: !state.isOpen })),
+  closeScratchpad: () => set({ isOpen: false }),
+}));

--- a/hushh-webapp/lib/hooks/use-scratchpad.ts
+++ b/hushh-webapp/lib/hooks/use-scratchpad.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react";
+
+const SCRATCHPAD_STORAGE_KEY = "hushh_scratchpad_content";
+const SCRATCHPAD_OPEN_KEY = "hushh_scratchpad_is_open";
+
+export function useScratchpad() {
+  const [content, setContent] = useState<string>("");
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  // Load initial state from localStorage
+  useEffect(() => {
+    try {
+      const savedContent = localStorage.getItem(SCRATCHPAD_STORAGE_KEY);
+      const savedIsOpen = localStorage.getItem(SCRATCHPAD_OPEN_KEY);
+      
+      if (savedContent) setContent(savedContent);
+      if (savedIsOpen === "true") setIsOpen(true);
+    } catch (e) {
+      console.error("Failed to load scratchpad state from localStorage", e);
+    } finally {
+      setIsInitialized(true);
+    }
+  }, []);
+
+  // Sync content to localStorage
+  const updateContent = (newContent: string) => {
+    setContent(newContent);
+    try {
+      localStorage.setItem(SCRATCHPAD_STORAGE_KEY, newContent);
+    } catch (e) {
+      console.error("Failed to save scratchpad content", e);
+    }
+  };
+
+  // Sync open state to localStorage
+  const toggleOpen = () => {
+    setIsOpen((prev) => {
+      const nextState = !prev;
+      try {
+        localStorage.setItem(SCRATCHPAD_OPEN_KEY, String(nextState));
+      } catch (e) {
+        console.error("Failed to save scratchpad open state", e);
+      }
+      return nextState;
+    });
+  };
+
+  const closeScratchpad = () => {
+    setIsOpen(false);
+    try {
+      localStorage.setItem(SCRATCHPAD_OPEN_KEY, "false");
+    } catch (e) {
+      console.error("Failed to save scratchpad open state", e);
+    }
+  };
+
+  return {
+    content,
+    isOpen,
+    isInitialized,
+    updateContent,
+    toggleOpen,
+    closeScratchpad,
+  };
+}


### PR DESCRIPTION
# Description
Adds a global floating Scratchpad widget for quick local note-taking.

Built primarily for researchers and analysts, this feature allows users to quickly jot down thoughts, paste temporary keys, or draft messages without leaving their current view or context. The widget floats in the bottom right corner of the application. 

Key features:
1. **Auto-Persisted:** State and text content are automatically synced to `localStorage`.
2. **Exportable:** Users can download their scratchpad content instantly as a `.txt` file.
3. **Keyboard Accessible:** Closes on `Escape` key, auto-focuses on open.

## 📌 Core Impact
- [x] **Routes Touched:** Global (`layout-client.tsx`)
- [x] **API / Schema / Trust Boundary:** Local Storage persistence (`hushh_scratchpad_content`)
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS**: N/A
- [ ] **Android**: N/A

## 🧪 Testing & Privacy
- [x] Tested on Web
- [x] Does this change access user data? (Yes, local browser storage only. No network egress.)
- [x] Licensing: First-party changes remain Apache-2.0 compatible