### PR TITLE
Fix native Kai debate run loop

### DIFF
--- a/consent-protocol/api/routes/kai/chat.py
+++ b/consent-protocol/api/routes/kai/chat.py
@@ -51,12 +51,16 @@ class KaiChatResponseModel(BaseModel):
 
     conversation_id: str = Field(..., description="Conversation ID for continuity", max_length=256)
     response: str = Field(..., description="Kai's response text", max_length=8192)
-    component_type: Optional[str] = Field(default=None, description="UI component type to render", max_length=128)
+    component_type: Optional[str] = Field(
+        default=None, description="UI component type to render", max_length=128
+    )
     component_data: Optional[dict] = Field(default=None, description="Data for the UI component")
     learned_attributes: list[dict] = Field(
         default_factory=list, description="Attributes learned from this exchange"
     )
-    tokens_used: Optional[int] = Field(default=None, description="Tokens used for this response", ge=0, le=1000000)
+    tokens_used: Optional[int] = Field(
+        default=None, description="Tokens used for this response", ge=0, le=1000000
+    )
 
 
 class ConversationHistoryResponse(BaseModel):
@@ -288,11 +292,15 @@ class AnalyzeLoserResponse(BaseModel):
 
     conversation_id: str = Field(..., description="Conversation ID for continuity", max_length=256)
     ticker: str = Field(..., description="Analyzed ticker symbol", max_length=10)
-    decision: str = Field(..., description="Investment decision: BUY, HOLD, or REDUCE", max_length=32)
+    decision: str = Field(
+        ..., description="Investment decision: BUY, HOLD, or REDUCE", max_length=32
+    )
     confidence: float = Field(..., description="Confidence score 0-1", ge=0.0, le=1.0)
     summary: str = Field(..., description="One-line summary of the analysis", max_length=256)
     reasoning: str = Field(..., description="Detailed reasoning for the decision", max_length=4096)
-    component_type: str = Field(default="analysis_summary", description="UI component type", max_length=64)
+    component_type: str = Field(
+        default="analysis_summary", description="UI component type", max_length=64
+    )
     component_data: dict = Field(default_factory=dict, description="Data for the UI component")
     saved_to_pkm: bool = Field(default=False, description="Whether decision was saved")
 

--- a/consent-protocol/api/routes/kai/losers.py
+++ b/consent-protocol/api/routes/kai/losers.py
@@ -62,7 +62,9 @@ class PortfolioHolding(BaseModel):
     name: Optional[str] = Field(default=None, max_length=256)
     gain_loss_pct: Optional[float] = Field(default=None, description="Unrealized P/L percent")
     gain_loss: Optional[float] = Field(default=None, description="Unrealized P/L amount")
-    market_value: Optional[float] = Field(default=None, description="Current market value of the position")
+    market_value: Optional[float] = Field(
+        default=None, description="Current market value of the position"
+    )
     sector: Optional[str] = Field(
         None, description="Sector or industry label if available", max_length=128
     )
@@ -104,7 +106,9 @@ class AnalyzeLosersResponse(BaseModel):
     summary: dict
     losers: list[dict]
     portfolio_level_takeaways: list[str] = Field(default_factory=list)
-    analytics: Optional[dict] = Field(default=None, description="Radar and sector distribution metrics")
+    analytics: Optional[dict] = Field(
+        default=None, description="Radar and sector distribution metrics"
+    )
 
 
 def _convert_decimals(obj: Any) -> Any:

--- a/consent-protocol/api/routes/kai/market_insights.py
+++ b/consent-protocol/api/routes/kai/market_insights.py
@@ -2572,7 +2572,9 @@ async def get_market_insights_baseline(
 @router.get("/market/insights/{user_id}")
 async def get_market_insights(
     user_id: str,
-    symbols: str | None = Query(default=None, max_length=512, description="CSV list of symbols, max 8"),
+    symbols: str | None = Query(
+        default=None, max_length=512, description="CSV list of symbols, max 8"
+    ),
     days_back: int = Query(default=7, ge=1, le=14),
     pick_source: str | None = Query(
         default=None,

--- a/consent-protocol/api/routes/pkm_routes_shared.py
+++ b/consent-protocol/api/routes/pkm_routes_shared.py
@@ -327,7 +327,9 @@ class EncryptedBlob(BaseModel):
     """Encrypted data blob."""
 
     # AES-256-GCM base64url ciphertext: 1 B minimum, 10 MB practical ceiling.
-    ciphertext: str = Field(..., min_length=1, max_length=10_000_000, description="AES-256-GCM encrypted data")
+    ciphertext: str = Field(
+        ..., min_length=1, max_length=10_000_000, description="AES-256-GCM encrypted data"
+    )
     # IV is typically 12 bytes -> 16 base64 chars; allow up to 512 for future algs.
     iv: str = Field(..., min_length=1, max_length=512, description="Initialization vector")
     # GCM tag is 16 bytes -> 24 base64 chars; allow up to 512.

--- a/consent-protocol/api/routes/ria.py
+++ b/consent-protocol/api/routes/ria.py
@@ -61,6 +61,7 @@ class RIAOnboardingSubmitRequest(BaseModel):
         if not v.startswith(("http://", "https://")):
             raise ValueError("disclosures_url must use http or https scheme")
         return v
+
     primary_firm_role: str | None = Field(None, max_length=128)
     force_live_verification: bool = False
     # Onboarding v2: license-first fields

--- a/consent-protocol/hushh_mcp/adk_bridge/kai_agent.py
+++ b/consent-protocol/hushh_mcp/adk_bridge/kai_agent.py
@@ -95,7 +95,9 @@ class KaiA2AServer(A2AServer):
 
         except Exception as e:
             logger.exception("Error in handle_message exc_type=%s", type(e).__name__)
-            return self._create_error_response(message, "Internal analysis error. Please try again.")
+            return self._create_error_response(
+                message, "Internal analysis error. Please try again."
+            )
 
     def _run_async(self, coro):
         """Helper to run async code in this sync method."""

--- a/consent-protocol/hushh_mcp/operons/kai/storage.py
+++ b/consent-protocol/hushh_mcp/operons/kai/storage.py
@@ -70,7 +70,9 @@ def store_decision_card(
     if token.user_id != user_id:
         raise PermissionError(f"Token user mismatch: expected {user_id}, got {token.user_id}")
 
-    logger.info("[Storage Operon] Storing decision for %s (user=[redacted])", decision_card.get("ticker"))
+    logger.info(
+        "[Storage Operon] Storing decision for %s (user=[redacted])", decision_card.get("ticker")
+    )
 
     # Serialize decision card
     decision_json = json.dumps(decision_card)

--- a/consent-protocol/hushh_mcp/services/vault_db.py
+++ b/consent-protocol/hushh_mcp/services/vault_db.py
@@ -573,5 +573,7 @@ class VaultDBService:
                 "encoding": "base64",
             }
 
-        logger.warning("vault.DEPRECATED: unauthenticated access domain=%s (user=[redacted])", domain)
+        logger.warning(
+            "vault.DEPRECATED: unauthenticated access domain=%s (user=[redacted])", domain
+        )
         return preferences

--- a/consent-protocol/tests/services/test_consent_request_links.py
+++ b/consent-protocol/tests/services/test_consent_request_links.py
@@ -247,22 +247,30 @@ class TestBuildConnectionRequestUrl:
 # ad-tracking and telemetry params (fbclid, gclid, utm_*) must NEVER appear
 # in any generated URL, regardless of inputs.
 
-_TRACKING_PARAMS: frozenset[str] = frozenset({
-    "fbclid",       # Facebook Click ID
-    "gclid",        # Google Ads Click ID
-    "utm_source",
-    "utm_medium",
-    "utm_campaign",
-    "utm_term",
-    "utm_content",
-    "msclkid",      # Microsoft Advertising Click ID
-    "twclid",       # Twitter Click ID
-    "ttclid",       # TikTok Click ID
-})
+_TRACKING_PARAMS: frozenset[str] = frozenset(
+    {
+        "fbclid",  # Facebook Click ID
+        "gclid",  # Google Ads Click ID
+        "utm_source",
+        "utm_medium",
+        "utm_campaign",
+        "utm_term",
+        "utm_content",
+        "msclkid",  # Microsoft Advertising Click ID
+        "twclid",  # Twitter Click ID
+        "ttclid",  # TikTok Click ID
+    }
+)
 
-_ALLOWED_CONSENT_PARAMS: frozenset[str] = frozenset({
-    "tab", "requestId", "bundleId", "actor", "view",
-})
+_ALLOWED_CONSENT_PARAMS: frozenset[str] = frozenset(
+    {
+        "tab",
+        "requestId",
+        "bundleId",
+        "actor",
+        "view",
+    }
+)
 
 
 def _query_keys(url_or_path: str) -> set[str]:
@@ -314,8 +322,9 @@ class TestTrackingParameterAbsence:
         params = parse_qs(urlparse(path).query)
 
         # Tracking key must NOT be injected as a top-level parameter.
-        assert "fbclid" not in params, \
+        assert "fbclid" not in params, (
             "fbclid was injected as a query parameter — urlencode is not escaping correctly"
+        )
 
         # The requestId value itself must be present (encoding should not drop it).
         assert "requestId" in params
@@ -348,8 +357,7 @@ class TestTrackingParameterAbsence:
             manager_view="outgoing",
         )
         unexpected = _query_keys(path) - _ALLOWED_CONSENT_PARAMS
-        assert not unexpected, \
-            f"Unexpected query params in consent path: {unexpected}"
+        assert not unexpected, f"Unexpected query params in consent path: {unexpected}"
 
     def test_utm_params_absent_across_all_valid_view_and_actor_combinations(self):
         """UTM parameters must never appear for any view+actor combination.
@@ -367,13 +375,9 @@ class TestTrackingParameterAbsence:
                     actor=actor,
                     request_id="req-sweep",
                 )
-                utm_leaked = {
-                    k for k in _query_keys(path)
-                    if k.startswith("utm_")
-                }
+                utm_leaked = {k for k in _query_keys(path) if k.startswith("utm_")}
                 assert not utm_leaked, (
-                    f"UTM params {utm_leaked} appeared for view={view!r}, "
-                    f"actor={actor!r}"
+                    f"UTM params {utm_leaked} appeared for view={view!r}, actor={actor!r}"
                 )
 
     def test_all_known_tracking_params_absent_in_connection_url(self):

--- a/consent-protocol/tests/test_agents_g004_loggers.py
+++ b/consent-protocol/tests/test_agents_g004_loggers.py
@@ -54,12 +54,12 @@ def test_no_f_string_loggers_in_module() -> None:
         if not isinstance(node, ast.Call):
             continue
         func = node.func
-        if not (isinstance(func, ast.Attribute) and func.attr in {"warning", "error", "info", "debug"}):
+        if not (
+            isinstance(func, ast.Attribute) and func.attr in {"warning", "error", "info", "debug"}
+        ):
             continue
         for arg in node.args:
             if isinstance(arg, ast.JoinedStr):
                 f_string_loggers.append(node.lineno)
 
-    assert f_string_loggers == [], (
-        f"G004: f-string logger calls found at lines {f_string_loggers}"
-    )
+    assert f_string_loggers == [], f"G004: f-string logger calls found at lines {f_string_loggers}"

--- a/consent-protocol/tests/test_constraints.py
+++ b/consent-protocol/tests/test_constraints.py
@@ -92,9 +92,7 @@ class TestRequestIdConstraints:
 
     def test_request_id_too_long_rejected(self):
         with pytest.raises(ValidationError) as exc_info:
-            ConsentApprovalPayload.model_validate(
-                {"userId": _VALID_USER, "requestId": "r" * 129}
-            )
+            ConsentApprovalPayload.model_validate({"userId": _VALID_USER, "requestId": "r" * 129})
         errors = exc_info.value.errors()
         assert any(e["loc"] == ("requestId",) for e in errors)
 
@@ -399,9 +397,7 @@ class TestTrustBoundaryProof:
     def test_field_constraints_are_enforced_not_handler_logic(self):
         """Pydantic ValidationError proves constraint rejection happens at parse time."""
         with pytest.raises(ValidationError) as exc_info:
-            ConsentApprovalPayload.model_validate(
-                {"userId": "", "requestId": _VALID_REQUEST}
-            )
+            ConsentApprovalPayload.model_validate({"userId": "", "requestId": _VALID_REQUEST})
         errors = exc_info.value.errors()
         assert any(e["loc"][-1] == "userId" for e in errors)
 

--- a/consent-protocol/tests/test_encrypted_blob_bounds.py
+++ b/consent-protocol/tests/test_encrypted_blob_bounds.py
@@ -29,7 +29,7 @@ _TOKEN = {"user_id": _UID, "token": "fake", "scope": "vault.owner"}
 
 _VALID_BLOB = {
     "ciphertext": "YWJjZGVmZ2g=",  # base64 "abcdefgh"
-    "iv": "dGVzdGl2MTI=",           # 12-byte IV in base64
+    "iv": "dGVzdGl2MTI=",  # 12-byte IV in base64
     "tag": "dGVzdHRhZzE2Ynl0ZXM=",  # 16-byte tag in base64
 }
 

--- a/consent-protocol/tests/test_kai_response_model_bounds_cwe400.py
+++ b/consent-protocol/tests/test_kai_response_model_bounds_cwe400.py
@@ -486,15 +486,21 @@ class TestDashboardProfilePicksResponseBounds:
 
     def test_user_id_max_length_256(self):
         with pytest.raises(ValidationError):
-            DashboardProfilePicksResponse(user_id="u" * 257, picks=[], generated_at="2026-01-01", risk_profile="balanced")
+            DashboardProfilePicksResponse(
+                user_id="u" * 257, picks=[], generated_at="2026-01-01", risk_profile="balanced"
+            )
 
     def test_generated_at_max_length_64(self):
         with pytest.raises(ValidationError):
-            DashboardProfilePicksResponse(user_id="user-1", picks=[], generated_at="d" * 65, risk_profile="balanced")
+            DashboardProfilePicksResponse(
+                user_id="user-1", picks=[], generated_at="d" * 65, risk_profile="balanced"
+            )
 
     def test_risk_profile_max_length_64(self):
         with pytest.raises(ValidationError):
-            DashboardProfilePicksResponse(user_id="user-1", picks=[], generated_at="2026-01-01", risk_profile="r" * 65)
+            DashboardProfilePicksResponse(
+                user_id="user-1", picks=[], generated_at="2026-01-01", risk_profile="r" * 65
+            )
 
 
 class TestPortfolioImportResponseBounds:

--- a/consent-protocol/tests/test_market_refresh_loop_resilience.py
+++ b/consent-protocol/tests/test_market_refresh_loop_resilience.py
@@ -75,10 +75,13 @@ async def test_loop_keeps_running_after_multiple_failures() -> None:
         raise asyncio.CancelledError
 
     with (
-        patch.object(mi_mod, "_run_refresh_with_advisory_lock", side_effect=_multi_fail_then_cancel),
+        patch.object(
+            mi_mod, "_run_refresh_with_advisory_lock", side_effect=_multi_fail_then_cancel
+        ),
         patch.object(mi_mod, "_market_refresh_interval_seconds", return_value=0.001),
         patch("api.routes.kai.market_insights.asyncio") as mock_asyncio,
     ):
+
         async def _noop(*_a, **_kw):
             return None
 

--- a/consent-protocol/tests/test_pkm_unbounded_list_inputs.py
+++ b/consent-protocol/tests/test_pkm_unbounded_list_inputs.py
@@ -12,6 +12,7 @@ the service layer, preventing authenticated DoS via resource exhaustion.
 Canonical wrapper route (api/routes/pkm.py) is tested directly to prove
 the live mounted path is guarded, not only the shared-router helper.
 """
+
 from __future__ import annotations
 
 import unittest.mock as mock
@@ -121,8 +122,7 @@ def test_store_domain_at_write_projections_cap_accepted(client: TestClient) -> N
 def test_scope_exposure_too_many_changes_rejected(client: TestClient) -> None:
     """201 scope-exposure changes must be rejected 422."""
     changes = [
-        {"scope_key": f"scope_{i}", "exposure_enabled": True}
-        for i in range(_SCOPE_CHANGES_MAX + 1)
+        {"scope_key": f"scope_{i}", "exposure_enabled": True} for i in range(_SCOPE_CHANGES_MAX + 1)
     ]
     resp = client.post(
         "/api/pkm/domains/financial/scope-exposure",

--- a/consent-protocol/tests/test_pkm_upgrade_run_id_path_bounds.py
+++ b/consent-protocol/tests/test_pkm_upgrade_run_id_path_bounds.py
@@ -81,9 +81,7 @@ def test_update_upgrade_run_status_valid_run_id_passes_path_guard(client: TestCl
         f"/api/pkm/upgrade/runs/{VALID_RUN_ID}/status",
         json=_status_body(),
     )
-    assert resp.status_code != 422, (
-        "A valid run_id must pass the path guard and reach the handler"
-    )
+    assert resp.status_code != 422, "A valid run_id must pass the path guard and reach the handler"
 
 
 # ---------------------------------------------------------------------------
@@ -135,9 +133,7 @@ def test_complete_upgrade_run_valid_run_id_passes_path_guard(client: TestClient)
         f"/api/pkm/upgrade/runs/{VALID_RUN_ID}/complete",
         json=_start_body(),
     )
-    assert resp.status_code != 422, (
-        "Valid run_id must pass the path guard and reach the handler"
-    )
+    assert resp.status_code != 422, "Valid run_id must pass the path guard and reach the handler"
 
 
 # ---------------------------------------------------------------------------
@@ -158,6 +154,4 @@ def test_fail_upgrade_run_valid_run_id_passes_path_guard(client: TestClient) -> 
         f"/api/pkm/upgrade/runs/{VALID_RUN_ID}/fail",
         json=_status_body(),
     )
-    assert resp.status_code != 422, (
-        "Valid run_id must pass the path guard and reach the handler"
-    )
+    assert resp.status_code != 422, "Valid run_id must pass the path guard and reach the handler"

--- a/consent-protocol/tests/test_ria_onboarding_bounds_cwe400.py
+++ b/consent-protocol/tests/test_ria_onboarding_bounds_cwe400.py
@@ -37,9 +37,7 @@ class TestRIAOnboardingSubmitRequestBounds:
     def test_individual_crd_max_length_50(self):
         """Test that individual_crd enforces max_length=50."""
         with pytest.raises(ValidationError):
-            RIAOnboardingSubmitRequest(
-                display_name="Test", individual_crd="a" * 51
-            )
+            RIAOnboardingSubmitRequest(display_name="Test", individual_crd="a" * 51)
 
     def test_bio_max_length_5000(self):
         """Test that bio enforces max_length=5000."""
@@ -49,23 +47,17 @@ class TestRIAOnboardingSubmitRequestBounds:
     def test_strategy_max_length_5000(self):
         """Test that strategy enforces max_length=5000."""
         with pytest.raises(ValidationError):
-            RIAOnboardingSubmitRequest(
-                display_name="Test", strategy="a" * 5001
-            )
+            RIAOnboardingSubmitRequest(display_name="Test", strategy="a" * 5001)
 
     def test_disclosures_url_max_length_2048(self):
         """Test that disclosures_url enforces max_length=2048."""
         with pytest.raises(ValidationError):
-            RIAOnboardingSubmitRequest(
-                display_name="Test", disclosures_url="https://" + "a" * 2048
-            )
+            RIAOnboardingSubmitRequest(display_name="Test", disclosures_url="https://" + "a" * 2048)
 
     def test_disclosures_url_scheme_validation(self):
         """Test that disclosures_url must use http or https."""
         with pytest.raises(ValidationError) as exc_info:
-            RIAOnboardingSubmitRequest(
-                display_name="Test", disclosures_url="ftp://example.com"
-            )
+            RIAOnboardingSubmitRequest(display_name="Test", disclosures_url="ftp://example.com")
         assert "http or https scheme" in str(exc_info.value)
 
     def test_contact_email_max_length_320(self):
@@ -78,16 +70,12 @@ class TestRIAOnboardingSubmitRequestBounds:
     def test_contact_phone_max_length_30(self):
         """Test that contact_phone enforces max_length=30."""
         with pytest.raises(ValidationError):
-            RIAOnboardingSubmitRequest(
-                display_name="Test", contact_phone="1" * 31
-            )
+            RIAOnboardingSubmitRequest(display_name="Test", contact_phone="1" * 31)
 
     def test_business_address_max_length_512(self):
         """Test that business_address enforces max_length=512."""
         with pytest.raises(ValidationError):
-            RIAOnboardingSubmitRequest(
-                display_name="Test", business_address="a" * 513
-            )
+            RIAOnboardingSubmitRequest(display_name="Test", business_address="a" * 513)
 
     def test_requested_capabilities_list_bounded(self):
         """Test that requested_capabilities list enforces max_length=20."""
@@ -137,9 +125,7 @@ class TestRIAOnboardingVerifyLicenseRequestBounds:
     def test_regulator_max_length_128(self):
         """Test that regulator enforces max_length=128."""
         with pytest.raises(ValidationError):
-            RIAOnboardingVerifyLicenseRequest(
-                license_number="123456", regulator="a" * 129
-            )
+            RIAOnboardingVerifyLicenseRequest(license_number="123456", regulator="a" * 129)
 
     def test_valid_license_verification(self):
         """Test that valid license verification passes."""
@@ -158,9 +144,7 @@ class TestRIAProfileRefreshLicenseRequestBounds:
     def test_regulator_max_length_128(self):
         """Test that regulator enforces max_length=128."""
         with pytest.raises(ValidationError):
-            RIAProfileRefreshLicenseRequest(
-                license_number="123456", regulator="a" * 129
-            )
+            RIAProfileRefreshLicenseRequest(license_number="123456", regulator="a" * 129)
 
 
 class TestRIAConsentRequestCreateBounds:
@@ -169,16 +153,12 @@ class TestRIAConsentRequestCreateBounds:
     def test_subject_user_id_max_length_128(self):
         """Test that subject_user_id enforces max_length=128."""
         with pytest.raises(ValidationError):
-            RIAConsentRequestCreate(
-                subject_user_id="a" * 129, scope_template_id="valid"
-            )
+            RIAConsentRequestCreate(subject_user_id="a" * 129, scope_template_id="valid")
 
     def test_scope_template_id_max_length_128(self):
         """Test that scope_template_id enforces max_length=128."""
         with pytest.raises(ValidationError):
-            RIAConsentRequestCreate(
-                subject_user_id="user", scope_template_id="a" * 129
-            )
+            RIAConsentRequestCreate(subject_user_id="user", scope_template_id="a" * 129)
 
     def test_selected_scope_max_length_128(self):
         """Test that selected_scope enforces max_length=128."""
@@ -214,9 +194,7 @@ class TestRIAConsentBundleCreateBounds:
     def test_subject_user_id_max_length_128(self):
         """Test that subject_user_id enforces max_length=128."""
         with pytest.raises(ValidationError):
-            RIAConsentBundleCreate(
-                subject_user_id="a" * 129, scope_template_id="valid"
-            )
+            RIAConsentBundleCreate(subject_user_id="a" * 129, scope_template_id="valid")
 
     def test_selected_scopes_list_bounded_50(self):
         """Test that selected_scopes list enforces max_length=50."""
@@ -257,16 +235,12 @@ class TestRIAPicksParseRequestBounds:
     def test_source_filename_max_length_256(self):
         """Test that source_filename enforces max_length=256."""
         with pytest.raises(ValidationError):
-            RIAPicksParseRequest(
-                csv_content="valid", source_filename="a" * 257
-            )
+            RIAPicksParseRequest(csv_content="valid", source_filename="a" * 257)
 
     def test_package_note_max_length_1000(self):
         """Test that package_note enforces max_length=1000."""
         with pytest.raises(ValidationError):
-            RIAPicksParseRequest(
-                csv_content="valid", package_note="a" * 1001
-            )
+            RIAPicksParseRequest(csv_content="valid", package_note="a" * 1001)
 
     def test_avoid_rows_list_bounded_5000(self):
         """Test that avoid_rows list enforces max_length=5000."""
@@ -365,16 +339,12 @@ class TestRIAInviteCreateRequestBounds:
     def test_duration_mode_max_length_50(self):
         """Test that duration_mode enforces max_length=50."""
         with pytest.raises(ValidationError):
-            RIAInviteCreateRequest(
-                scope_template_id="valid", duration_mode="a" * 51
-            )
+            RIAInviteCreateRequest(scope_template_id="valid", duration_mode="a" * 51)
 
     def test_reason_max_length_1000(self):
         """Test that reason enforces max_length=1000."""
         with pytest.raises(ValidationError):
-            RIAInviteCreateRequest(
-                scope_template_id="valid", reason="a" * 1001
-            )
+            RIAInviteCreateRequest(scope_template_id="valid", reason="a" * 1001)
 
     def test_targets_list_bounded_500(self):
         """Test that targets list enforces max_length=500."""
@@ -391,16 +361,12 @@ class TestRIAMarketplaceDiscoverabilityRequestBounds:
     def test_headline_max_length_512(self):
         """Test that headline enforces max_length=512."""
         with pytest.raises(ValidationError):
-            RIAMarketplaceDiscoverabilityRequest(
-                enabled=True, headline="a" * 513
-            )
+            RIAMarketplaceDiscoverabilityRequest(enabled=True, headline="a" * 513)
 
     def test_strategy_summary_max_length_5000(self):
         """Test that strategy_summary enforces max_length=5000."""
         with pytest.raises(ValidationError):
-            RIAMarketplaceDiscoverabilityRequest(
-                enabled=True, strategy_summary="a" * 5001
-            )
+            RIAMarketplaceDiscoverabilityRequest(enabled=True, strategy_summary="a" * 5001)
 
     def test_valid_marketplace_request(self):
         """Test that valid marketplace request passes."""
@@ -410,8 +376,6 @@ class TestRIAMarketplaceDiscoverabilityRequestBounds:
             strategy_summary="Long term growth focused",
         )
         assert req.enabled is True
-
-
 
 
 if __name__ == "__main__":

--- a/consent-protocol/tests/test_ria_request_model_bounds.py
+++ b/consent-protocol/tests/test_ria_request_model_bounds.py
@@ -334,7 +334,6 @@ class TestRIAMarketplaceDiscoverabilityRequest:
 # ===========================================================================
 
 
-
 def _firebase_stub():
     return "test-firebase-uid"
 
@@ -427,9 +426,7 @@ class TestVerifyOnboardingNameRouteInputBounds:
 
     def test_crd_number_over_max_returns_422(self):
         """crd_number > 50 chars must be rejected with 422."""
-        resp = _client_with_auth().post(
-            self._URL, json={"query": "Alice", "crd_number": "c" * 51}
-        )
+        resp = _client_with_auth().post(self._URL, json={"query": "Alice", "crd_number": "c" * 51})
         assert resp.status_code == 422
 
 
@@ -475,23 +472,18 @@ class TestCreateRiaRequestRouteInputBounds:
 
     def test_subject_user_id_over_max_returns_422(self):
         """subject_user_id > 128 chars must be rejected with 422."""
-        resp = _client_with_auth().post(
-            self._URL, json=self._valid_body(subject_user_id="u" * 129)
-        )
+        resp = _client_with_auth().post(self._URL, json=self._valid_body(subject_user_id="u" * 129))
         assert resp.status_code == 422
 
     def test_reason_over_max_returns_422(self):
         """reason > 1000 chars must be rejected with 422."""
-        resp = _client_with_auth().post(
-            self._URL, json=self._valid_body(reason="r" * 1001)
-        )
+        resp = _client_with_auth().post(self._URL, json=self._valid_body(reason="r" * 1001))
         assert resp.status_code == 422
 
 
 # ---------------------------------------------------------------------------
 # v2 onboarding fields: license, contact, address, URL scheme
 # ---------------------------------------------------------------------------
-
 
 
 class TestV2LicenseContactAddressBounds:

--- a/consent-protocol/tests/test_stream_agent_thinking_gemini_error_cwe209.py
+++ b/consent-protocol/tests/test_stream_agent_thinking_gemini_error_cwe209.py
@@ -67,9 +67,7 @@ async def test_sentinel_not_in_fallback_token() -> None:
         )
 
     full_output = str(events)
-    assert SENTINEL not in full_output, (
-        f"Gemini error sentinel leaked into SSE output: {SENTINEL}"
-    )
+    assert SENTINEL not in full_output, f"Gemini error sentinel leaked into SSE output: {SENTINEL}"
 
 
 @pytest.mark.asyncio
@@ -97,6 +95,7 @@ async def test_fallback_token_is_opaque_static_string() -> None:
 
     # At least one fallback token must be yielded
     assert events, "Expected at least one fallback token event when Gemini errors"
+
     # create_event serialises the payload into a JSON string under the "data" key.
     # Decode each frame and gather the text tokens from the envelope payload.
     def _frame_text(event: Any) -> str:

--- a/consent-protocol/tests/test_vault_db_kai_pii_logs.py
+++ b/consent-protocol/tests/test_vault_db_kai_pii_logs.py
@@ -7,6 +7,7 @@ emit plaintext user_id values in application logs (CWE-532).
 Tests exercise real call sites with mocked external dependencies so that
 captured log messages reflect actual logger invocations in production code.
 """
+
 from __future__ import annotations
 
 import logging
@@ -65,7 +66,7 @@ def test_storage_store_trust_link_failure_no_user_id(captured):
                 session_id="sess_1",
                 decision_card={"ticker": _TICKER},
                 vault_key_hex="dead" * 16,
-                consent_token="HCT:fake"  # noqa: S106,
+                consent_token="HCT:fake",  # noqa: S106,
             )
 
     _assert_no_user_id(captured.messages)
@@ -84,7 +85,7 @@ def test_storage_retrieve_trust_link_failure_no_user_id(captured):
                 encrypted_payload=MagicMock(),
                 user_id=_USER_ID,
                 vault_key_hex="dead" * 16,
-                consent_token="HCT:fake"  # noqa: S106,
+                consent_token="HCT:fake",  # noqa: S106,
             )
 
     _assert_no_user_id(captured.messages)
@@ -103,7 +104,7 @@ def test_storage_retrieve_success_no_user_id(captured):
             encrypted_payload=MagicMock(),
             user_id=_USER_ID,
             vault_key_hex="dead" * 16,
-            consent_token="HCT:fake"  # noqa: S106,
+            consent_token="HCT:fake",  # noqa: S106,
         )
 
     assert result == {"ticker": "AAPL"}
@@ -129,7 +130,7 @@ def test_analysis_fundamentals_no_user_id(captured):
             user_id=_USER_ID,
             ticker=_TICKER,
             sec_filings={"facts": {}},
-            consent_token="HCT:fake"  # noqa: S106,
+            consent_token="HCT:fake",  # noqa: S106,
         )
 
     _assert_no_user_id(captured.messages)

--- a/consent-protocol/tests/test_world_model_path_param_bounds.py
+++ b/consent-protocol/tests/test_world_model_path_param_bounds.py
@@ -30,6 +30,7 @@ def _make_app() -> FastAPI:
 # user_id path param bounds
 # ---------------------------------------------------------------------------
 
+
 def test_domains_user_id_too_long_returns_422():
     app = _make_app()
     client = TestClient(app, raise_server_exceptions=False)
@@ -63,6 +64,7 @@ def test_data_user_id_too_long_returns_422():
 # domain path param bounds
 # ---------------------------------------------------------------------------
 
+
 def test_domain_data_domain_too_long_returns_422():
     app = _make_app()
     client = TestClient(app, raise_server_exceptions=False)
@@ -81,6 +83,7 @@ def test_domain_data_user_id_too_long_returns_422():
 # ---------------------------------------------------------------------------
 # Valid lengths pass validation and reach the handler
 # ---------------------------------------------------------------------------
+
 
 def test_domains_valid_uid_reaches_handler():
     """A valid user_id passes Path validation and delegates to _get_metadata."""

--- a/hushh-webapp/__tests__/lib/kai-native-run-stream-contract.test.ts
+++ b/hushh-webapp/__tests__/lib/kai-native-run-stream-contract.test.ts
@@ -1,0 +1,36 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const WEBAPP_ROOT = path.resolve(__dirname, "../..");
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(WEBAPP_ROOT, relativePath), "utf8");
+}
+
+describe("Kai native debate run stream contract", () => {
+  it("keeps native run resume streams on the resumable run endpoint", () => {
+    const apiService = read("lib/services/api-service.ts");
+    const iosPlugin = read("ios/App/App/Plugins/KaiPlugin.swift");
+    const androidPlugin = read(
+      "android/app/src/main/java/com/hushh/app/plugins/Kai/KaiPlugin.kt"
+    );
+
+    expect(apiService).toContain("run_id: data.runId");
+    expect(apiService).toContain("resume_cursor: data.resumeCursor ?? 0");
+    expect(apiService).toContain("await Kai.streamKaiAnalysis({");
+
+    expect(iosPlugin).toContain("body[\"run_id\"]");
+    expect(iosPlugin).toContain("/api/kai/analyze/run/");
+    expect(iosPlugin).toContain("runRequest.httpMethod = \"GET\"");
+    expect(iosPlugin).toContain("text/event-stream");
+    expect(iosPlugin).toContain("/api/kai/analyze/stream");
+
+    expect(androidPlugin).toContain("bodyObj.optString(\"run_id\"");
+    expect(androidPlugin).toContain("/api/kai/analyze/run/");
+    expect(androidPlugin).toContain(".get()");
+    expect(androidPlugin).toContain("text/event-stream");
+    expect(androidPlugin).toContain("/api/kai/analyze/stream");
+  });
+});

--- a/hushh-webapp/__tests__/services/debate-run-manager.test.ts
+++ b/hushh-webapp/__tests__/services/debate-run-manager.test.ts
@@ -144,4 +144,36 @@ describe("DebateRunManagerService start gate", () => {
     expect(result.task.pickSource).toBe("search");
     expect(apiMocks.startKaiDebateRun).not.toHaveBeenCalled();
   });
+
+  it("coalesces identical in-flight starts for the same debate session", async () => {
+    const manager = await loadManager([]);
+    let resolveStart!: (value: ReturnType<typeof response>) => void;
+    apiMocks.startKaiDebateRun.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveStart = resolve;
+      }),
+    );
+
+    const first = manager.ensureRun({
+      ...ensureParams,
+      pickSource: "default",
+      pickSourceLabel: "Default list",
+    });
+    const second = manager.ensureRun({
+      ...ensureParams,
+      pickSource: "default",
+      pickSourceLabel: "Default list",
+    });
+
+    await Promise.resolve();
+    expect(apiMocks.startKaiDebateRun).toHaveBeenCalledTimes(1);
+
+    resolveStart(response(200, { run: runPayload("fresh-run") }));
+    const results = await Promise.all([first, second]);
+
+    expect(results.map((result) => result.kind)).toEqual(["started", "started"]);
+    expect(results[0]?.task.runId).toBe("fresh-run");
+    expect(results[1]?.task.runId).toBe("fresh-run");
+    expect(apiMocks.streamKaiDebateRun).toHaveBeenCalledTimes(1);
+  });
 });

--- a/hushh-webapp/android/app/src/main/java/com/hushh/app/plugins/Kai/KaiPlugin.kt
+++ b/hushh-webapp/android/app/src/main/java/com/hushh/app/plugins/Kai/KaiPlugin.kt
@@ -481,14 +481,35 @@ class KaiPlugin : Plugin() {
         }
 
         val backendUrl = getBackendUrl(call)
-        val url = "$backendUrl/api/kai/analyze/stream"
-        val bodyStr = bodyObj.toString()
-        val requestBody = bodyStr.toRequestBody("application/json".toMediaType())
-        val request = Request.Builder()
-            .url(url)
-            .post(requestBody)
-            .addHeader("Authorization", "Bearer $vaultOwnerToken")
-            .build()
+        val runId = bodyObj.optString("run_id", "").trim()
+        val request =
+            if (runId.isNotEmpty()) {
+                val userId = bodyObj.optString("user_id", "").trim()
+                if (userId.isEmpty()) {
+                    call.reject("Missing user_id for run stream")
+                    return
+                }
+                val cursor = maxOf(0, bodyObj.optInt("resume_cursor", 0))
+                val encodedRunId = URLEncoder.encode(runId, "UTF-8")
+                val encodedUserId = URLEncoder.encode(userId, "UTF-8")
+                val url =
+                    "$backendUrl/api/kai/analyze/run/$encodedRunId/stream?user_id=$encodedUserId&cursor=$cursor"
+                Request.Builder()
+                    .url(url)
+                    .get()
+                    .addHeader("Authorization", "Bearer $vaultOwnerToken")
+                    .addHeader("Accept", "text/event-stream")
+                    .build()
+            } else {
+                val url = "$backendUrl/api/kai/analyze/stream"
+                val bodyStr = bodyObj.toString()
+                val requestBody = bodyStr.toRequestBody("application/json".toMediaType())
+                Request.Builder()
+                    .url(url)
+                    .post(requestBody)
+                    .addHeader("Authorization", "Bearer $vaultOwnerToken")
+                    .build()
+            }
 
         val pluginCall = call
         Thread {

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -652,6 +652,8 @@ html body[data-scroll-locked] {
 
 /* Capacitor iOS uses `ios.contentInset = "never"` with CSS-owned insets; don't double-count shell spacing. */
 html.native-ios {
+  /* Enforce a minimum status bar safe area top of 44px to prevent overlapping on iOS Capacitor */
+  --app-safe-area-top: max(44px, env(safe-area-inset-top, 0px));
   /* Lift persistent bottom chrome above the iOS home indicator zone. */
   --app-bottom-chrome-lift: 10px;
   /* Keep a small effective inset because WKWebView already applies content inset on iOS. */
@@ -1805,4 +1807,13 @@ html.dark body,
 html.dark .morphy-app-bg {
   background-color: #1c1c1e !important;
   background-image: none !important;
+}
+
+@media (hover: hover) {
+  .segmented-pill-button-accent:hover {
+    color: var(--primary);
+  }
+  .segmented-pill-button-default:hover {
+    color: color-mix(in srgb, var(--foreground) 80%, transparent);
+  }
 }

--- a/hushh-webapp/components/app-ui/top-app-bar.tsx
+++ b/hushh-webapp/components/app-ui/top-app-bar.tsx
@@ -17,14 +17,16 @@
  * evaluates correctly in both environments.
  */
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   ArrowLeft,
   Bell,
   BriefcaseBusiness,
+  ChartColumnIncreasing,
   Check,
   ChevronDown,
   Code2,
+  Compass,
   type LucideIcon,
   Loader2,
   LogOut,
@@ -116,6 +118,7 @@ export function TopAppBarSpacer() {
 /* ── Helpers ───────────────────────────────────────────────────────── */
 function getTopBarTitle(
   pathname: string,
+  isScrolled: boolean = false,
 ): {
   label: string;
   icon?: LucideIcon;
@@ -151,6 +154,23 @@ function getTopBarTitle(
       icon: UserRound,
       interactive: true as const,
     };
+  }
+
+  if (isScrolled) {
+    if (pathname === ROUTES.KAI_HOME) {
+      return {
+        label: "Market",
+        icon: ChartColumnIncreasing,
+        interactive: false as const,
+      };
+    }
+    if (pathname === ROUTES.MARKETPLACE) {
+      return {
+        label: "Search people",
+        icon: Compass,
+        interactive: false as const,
+      };
+    }
   }
 
   const isPersonaShellRoute =
@@ -220,9 +240,52 @@ export function TopAppBar({ className }: TopAppBarProps) {
   const chromeState = useMemo(() => getKaiChromeState(pathname), [pathname]);
   const showOnboardingActions = chromeState.useOnboardingChrome;
   const hideChrome = !topShellMetrics.shellVisible;
+
+  // Track scroll state of the root page container to show dynamic titles
+  const [isScrolled, setIsScrolled] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const resolveTarget = () => {
+      return document.querySelector('[data-app-scroll-root="true"]');
+    };
+
+    const handleScroll = (e: Event) => {
+      const target = e.target as HTMLElement;
+      if (target) {
+        setIsScrolled(target.scrollTop > 60);
+      }
+    };
+
+    let target = resolveTarget();
+    let retryTimer: number;
+
+    const attach = () => {
+      if (target) {
+        target.addEventListener("scroll", handleScroll, { passive: true });
+        setIsScrolled(target.scrollTop > 60);
+      } else {
+        retryTimer = window.setTimeout(() => {
+          target = resolveTarget();
+          attach();
+        }, 150);
+      }
+    };
+
+    attach();
+
+    return () => {
+      if (target) {
+        target.removeEventListener("scroll", handleScroll);
+      }
+      window.clearTimeout(retryTimer);
+    };
+  }, [pathname]);
+
   const centerTitle = useMemo(
-    () => getTopBarTitle(pathname),
-    [pathname],
+    () => getTopBarTitle(pathname, isScrolled),
+    [pathname, isScrolled],
   );
   const canShowPersonaSwitcher = useMemo(
     () => isProfileTopBarRoute(pathname),
@@ -404,7 +467,7 @@ export function TopAppBar({ className }: TopAppBarProps) {
                 </div>
               </div>
 
-              <div className="pointer-events-none flex min-w-0 flex-1 items-center justify-center">
+              <div className="pointer-events-none flex min-w-0 flex-1 items-center justify-center px-3 sm:px-4">
                 {centerTitle ? (
                   centerTitle.interactive && canShowPersonaSwitcher ? (
                     <div className="pointer-events-auto inline-flex min-w-0 max-w-full items-center justify-center">

--- a/hushh-webapp/ios/App/App/NativeUiTestRunnerScript.swift
+++ b/hushh-webapp/ios/App/App/NativeUiTestRunnerScript.swift
@@ -401,6 +401,18 @@ enum NativeUiTestRunnerScript {
     throw new Error('text not visible: "' + value + '" on ' + window.location.href);
   }
 
+  async function assertNoText(value, regex, timeoutMs) {
+    var pattern = regex ? new RegExp(value, "i") : new RegExp(escapeRegExp(value), "i");
+    var deadline = Date.now() + (timeoutMs || 3000);
+    while (Date.now() < deadline) {
+      var text = (document.body && document.body.innerText) || "";
+      if (pattern.test(text)) {
+        throw new Error('unexpected text visible: "' + value + '" on ' + window.location.href);
+      }
+      await sleep(250);
+    }
+  }
+
   async function waitForUrlIncludes(value, timeoutMs) {
     var deadline = Date.now() + (timeoutMs || 5000);
     while (Date.now() < deadline) {
@@ -511,6 +523,22 @@ enum NativeUiTestRunnerScript {
       if (root) {
         root.setAttribute("data-hushh-native-test-initial-route", "");
         root.setAttribute("data-hushh-native-test-expected-route", "");
+        root.setAttribute("data-hushh-native-test-expected-marker", "");
+      }
+      window.dispatchEvent(new Event("hushh:native-test-config-updated"));
+    } catch (_) {}
+  }
+
+  function applyNativeTestRouteLock(route) {
+    var bridge = nativeTestBridge();
+    bridge.initialRoute = route;
+    bridge.expectedRoute = route;
+    bridge.expectedMarker = null;
+    try {
+      var root = document.documentElement;
+      if (root) {
+        root.setAttribute("data-hushh-native-test-initial-route", route);
+        root.setAttribute("data-hushh-native-test-expected-route", route);
         root.setAttribute("data-hushh-native-test-expected-marker", "");
       }
       window.dispatchEvent(new Event("hushh:native-test-config-updated"));
@@ -650,10 +678,13 @@ enum NativeUiTestRunnerScript {
 
   async function waitForRoute(route, timeoutMs) {
     var expected = normalizeRoute(route);
+    var expectedBase = expected.length > 1 && expected.endsWith("/") ? expected.slice(0, -1) : expected;
     var deadline = Date.now() + (timeoutMs || 5000);
     while (Date.now() < deadline) {
       var current = normalizeRoute(window.location.pathname + window.location.search);
+      var currentBase = current.length > 1 && current.endsWith("/") ? current.slice(0, -1) : current;
       if (
+        currentBase === expectedBase ||
         current === expected ||
         current.indexOf(expected + "/") === 0 ||
         current.indexOf(expected + "?") === 0 ||
@@ -668,10 +699,21 @@ enum NativeUiTestRunnerScript {
 
   async function navigateWithNativeRouter(route) {
     var bridge = nativeTestBridge();
-    clearNativeTestRouteLock();
+    if (currentRouteMatches(route)) {
+      clearNativeTestRouteLock();
+      return;
+    }
+    applyNativeTestRouteLock(route);
     if (typeof bridge.navigateToRoute === "function") {
       bridge.navigateToRoute(route);
-      if (await waitForRoute(route, 5000)) return;
+      if (await waitForRoute(route, 30000)) {
+        clearNativeTestRouteLock();
+        return;
+      }
+      if (currentRouteMatches(route)) {
+        clearNativeTestRouteLock();
+        return;
+      }
       throw new Error(
         "Next.js native router did not reach " +
           route +
@@ -697,10 +739,10 @@ enum NativeUiTestRunnerScript {
     }
 
     if (bridge.enabled === true && typeof bridge.switchPersona === "function") {
-      var switched = await attemptNativePersonaSwitch(persona);
       if (!routeMatchesPersona(persona)) {
         await navigateWithNativeRouter(route);
       }
+      var switched = await attemptNativePersonaSwitch(persona);
       if (switched) {
         await resolvePersonaMismatchPrompt(persona);
       }
@@ -837,6 +879,9 @@ enum NativeUiTestRunnerScript {
       case "assert_text":
         await waitForText(step.value, step.regex === true, step.timeoutMs);
         return;
+      case "assert_no_text":
+        await assertNoText(step.value, step.regex === true, step.timeoutMs);
+        return;
       case "assert_no_persona_mismatch_prompt":
         await waitForNoPersonaMismatchPrompt(step.timeoutMs);
         return;
@@ -855,6 +900,9 @@ enum NativeUiTestRunnerScript {
         }
         clickElement(testTarget);
         await sleep(400);
+        return;
+      case "navigate_route":
+        await navigateWithNativeRouter(step.route);
         return;
       case "wait_beacon":
         await waitForBeacon(step.routeIds, step.dataStates, step.timeoutMs);
@@ -878,7 +926,9 @@ enum NativeUiTestRunnerScript {
     var defaultStepTimeoutMs = flow.stepTimeoutMs || 30000;
     for (var i = 0; i < flow.steps.length; i += 1) {
       var step = flow.steps[i];
-      var stepTimeoutMs = step.timeoutMs || defaultStepTimeoutMs;
+      var stepTimeoutMs = step.timeoutMs
+        ? step.timeoutMs + 1000
+        : defaultStepTimeoutMs;
       var bridge = nativeTestBridge();
       bridge.uiFlowStepIndex = i;
       bridge.uiFlowStepType = step.type || "";

--- a/hushh-webapp/ios/App/App/Plugins/KaiPlugin.swift
+++ b/hushh-webapp/ios/App/App/Plugins/KaiPlugin.swift
@@ -675,17 +675,51 @@ public class KaiPlugin: CAPPlugin, CAPBridgedPlugin, URLSessionDataDelegate {
 
         activeStreamKind = "kai"
         let backendUrl = getBackendUrl(call)
-        let urlStr = "\(backendUrl)/api/kai/analyze/stream"
-        guard let url = URL(string: urlStr) else {
-            call.reject("Invalid URL: \(urlStr)")
-            return
-        }
+        let runId = (body["run_id"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let request: URLRequest
 
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("Bearer \(vaultOwnerToken)", forHTTPHeaderField: "Authorization")
-        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        if !runId.isEmpty {
+            guard let userId = (body["user_id"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !userId.isEmpty else {
+                call.reject("Missing user_id for run stream")
+                return
+            }
+            let cursor =
+                (body["resume_cursor"] as? Int) ??
+                (body["resume_cursor"] as? NSNumber)?.intValue ??
+                0
+            let encodedRunId = runId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? runId
+            guard var components = URLComponents(string: "\(backendUrl)/api/kai/analyze/run/\(encodedRunId)/stream") else {
+                call.reject("Invalid URL components for streamKaiAnalysis run")
+                return
+            }
+            components.queryItems = [
+                URLQueryItem(name: "user_id", value: userId),
+                URLQueryItem(name: "cursor", value: String(max(0, cursor))),
+            ]
+            guard let url = components.url else {
+                call.reject("Invalid URL for streamKaiAnalysis run")
+                return
+            }
+            var runRequest = URLRequest(url: url)
+            runRequest.httpMethod = "GET"
+            runRequest.setValue("Bearer \(vaultOwnerToken)", forHTTPHeaderField: "Authorization")
+            runRequest.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+            request = runRequest
+        } else {
+            let urlStr = "\(backendUrl)/api/kai/analyze/stream"
+            guard let url = URL(string: urlStr) else {
+                call.reject("Invalid URL: \(urlStr)")
+                return
+            }
+
+            var analysisRequest = URLRequest(url: url)
+            analysisRequest.httpMethod = "POST"
+            analysisRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            analysisRequest.setValue("Bearer \(vaultOwnerToken)", forHTTPHeaderField: "Authorization")
+            analysisRequest.httpBody = try? JSONSerialization.data(withJSONObject: body)
+            request = analysisRequest
+        }
 
         streamCall = call
         streamBuffer = ""

--- a/hushh-webapp/lib/capacitor/kai.ts
+++ b/hushh-webapp/lib/capacitor/kai.ts
@@ -201,6 +201,8 @@ export interface KaiPlugin {
 
   /**
    * Stream Kai stock analysis (SSE) from native.
+   * When body.run_id is present, native bridges must stream
+   * GET /api/kai/analyze/run/{run_id}/stream to preserve resumable run locks.
    * Subscribe to events via Kai.addListener('kaiStreamEvent', handler).
    * Resolves when stream ends.
    */

--- a/hushh-webapp/lib/morphy-ux/ui/segmented-pill.tsx
+++ b/hushh-webapp/lib/morphy-ux/ui/segmented-pill.tsx
@@ -142,8 +142,8 @@ export const SegmentedPill = React.forwardRef<HTMLDivElement, SegmentedPillProps
                 isActive
                   ? "text-foreground font-semibold"
                   : isAccent
-                    ? "text-primary/85 hover:text-primary"
-                    : "text-foreground/60 hover:text-foreground/80",
+                    ? "text-primary/85 segmented-pill-button-accent"
+                    : "text-foreground/60 segmented-pill-button-default",
                 isDisabled && "opacity-45"
               )}
             >

--- a/hushh-webapp/lib/services/debate-run-manager.ts
+++ b/hushh-webapp/lib/services/debate-run-manager.ts
@@ -69,6 +69,23 @@ export type EnsureRunResult =
   | { kind: "attached"; task: DebateRunTask }
   | { kind: "blocked"; task: DebateRunTask };
 
+export interface EnsureDebateRunParams {
+  userId: string;
+  ticker: string;
+  riskProfile: string;
+  userContext?: Record<string, unknown> | null;
+  pickSource?: string;
+  pickSourceLabel?: string;
+  pickSourceKind?: string;
+  vaultOwnerToken: string;
+  vaultKey?: string;
+}
+
+type InFlightEnsureRun = {
+  signature: string;
+  promise: Promise<EnsureRunResult>;
+};
+
 const AGENTS = ["fundamental", "sentiment", "valuation"] as const;
 
 type TranscriptAgentState = {
@@ -254,6 +271,7 @@ class DebateRunManager {
   private runSecrets = new Map<string, RunSecrets>();
   private runHistoryEntries = new Map<string, AnalysisHistoryEntry>();
   private streamControllers = new Map<string, AbortController>();
+  private ensureRunInFlight = new Map<string, InFlightEnsureRun>();
   private debateSessionId: string;
 
   constructor() {
@@ -621,17 +639,47 @@ class DebateRunManager {
     return this.verifyActiveRunWithBackend(params);
   }
 
-  async ensureRun(params: {
-    userId: string;
-    ticker: string;
-    riskProfile: string;
-    userContext?: Record<string, unknown> | null;
-    pickSource?: string;
-    pickSourceLabel?: string;
-    pickSourceKind?: string;
-    vaultOwnerToken: string;
-    vaultKey?: string;
-  }): Promise<EnsureRunResult> {
+  private ensureRunStartKey(userId: string): string {
+    return `${userId}:${this.debateSessionId}`;
+  }
+
+  private ensureRunSignature(params: EnsureDebateRunParams): string {
+    return [
+      toUpperTicker(params.ticker),
+      params.riskProfile,
+      params.pickSource || "",
+      params.pickSourceLabel || "",
+      params.pickSourceKind || "",
+    ].join("|");
+  }
+
+  async ensureRun(params: EnsureDebateRunParams): Promise<EnsureRunResult> {
+    const startKey = this.ensureRunStartKey(params.userId);
+    const signature = this.ensureRunSignature(params);
+    const inFlight = this.ensureRunInFlight.get(startKey);
+    if (inFlight) {
+      if (inFlight.signature === signature) {
+        return inFlight.promise;
+      }
+      const result = await inFlight.promise;
+      if (result.task.status === "running" && !result.task.dismissedAt) {
+        return { kind: "blocked", task: result.task };
+      }
+    }
+
+    const promise = this.ensureRunUntracked(params);
+    this.ensureRunInFlight.set(startKey, { signature, promise });
+    try {
+      return await promise;
+    } finally {
+      const current = this.ensureRunInFlight.get(startKey);
+      if (current?.promise === promise) {
+        this.ensureRunInFlight.delete(startKey);
+      }
+    }
+  }
+
+  private async ensureRunUntracked(params: EnsureDebateRunParams): Promise<EnsureRunResult> {
     const {
       userId,
       ticker,
@@ -651,7 +699,7 @@ class DebateRunManager {
         vaultKey,
       });
       if (!verifiedActiveTask) {
-        return this.ensureRun(params);
+        return this.ensureRunUntracked(params);
       }
       const refreshedActiveTask = this.upsertTask({
         ...verifiedActiveTask,

--- a/hushh-webapp/native-ios-parity-report.json
+++ b/hushh-webapp/native-ios-parity-report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-29T02:44:42.613Z",
+  "generated_at": "2026-06-07T03:11:27.689Z",
   "destination": "platform=iOS Simulator,id=9C5B1D61-028C-474A-BDFC-523BACC3B02C",
   "screenshot_dir": "native-ios-screenshots",
   "audited_routes": 36,
@@ -35,14 +35,14 @@
         "routeok": "1",
         "test": "1",
         "auto": "0",
-        "bridge": "1",
+        "bridge": "0",
         "uirunner": "1",
         "runui": "0",
         "uistarted": "0",
         "uifailed": "0",
         "uiboot": "0",
-        "persona": "investor",
-        "primary_persona": "investor",
+        "persona": "",
+        "primary_persona": "",
         "persona_switch": "",
         "persona_error": "",
         "portfolio_start_state": "",
@@ -62,8 +62,7 @@
         "bootstrap": "",
         "bootstrap_uid": "",
         "bootstrap_error": "",
-        "jserr": "<redacted>",
-        " visit https://react.dev/errors/418?args[]": "HTML&args[]= for the full message or use the non-minified dev environment for full errors and additional helpful warnings.",
+        "jserr": "",
         "jsrej": "",
         "body": "<redacted>",
         "visible404": "0",
@@ -75,7 +74,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/;ready=1;marker=native-route-home;auth=anonymous;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=0;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>; visit https://react.dev/errors/418?args[]=HTML&args[]= for the full message or use the non-minified dev environment for full errors and additional helpful warnings.;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/;ready=1;marker=native-route-home;auth=anonymous;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=0;bridge=0;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=;primary_persona=;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=;bootstrap_uid=;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/register-phone",
@@ -105,7 +104,7 @@
         "routeok": "1",
         "test": "1",
         "auto": "1",
-        "bridge": "0",
+        "bridge": "1",
         "uirunner": "1",
         "runui": "0",
         "uistarted": "0",
@@ -113,7 +112,7 @@
         "uiboot": "0",
         "persona": "investor",
         "primary_persona": "investor",
-        "persona_switch": "ok:investor",
+        "persona_switch": "",
         "persona_error": "",
         "portfolio_start_state": "",
         "portfolio_start_status": "",
@@ -145,7 +144,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/kai/;ready=1;marker=native-route-kai-home;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=0;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=ok:investor;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=1;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>; visit https://react.dev/errors/418?args[]=HTML&args[]= for the full message or use the non-minified dev environment for full errors and additional helpful warnings.;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/kai/;ready=1;marker=native-route-kai-home;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=1;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>; visit https://react.dev/errors/418?args[]=HTML&args[]= for the full message or use the non-minified dev environment for full errors and additional helpful warnings.;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/kai",
@@ -183,7 +182,7 @@
         "uiboot": "0",
         "persona": "investor",
         "primary_persona": "investor",
-        "persona_switch": "ok:investor",
+        "persona_switch": "",
         "persona_error": "",
         "portfolio_start_state": "",
         "portfolio_start_status": "",
@@ -215,7 +214,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/kai/;ready=1;marker=native-route-kai-home;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=ok:investor;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>; visit https://react.dev/errors/418?args[]=HTML&args[]= for the full message or use the non-minified dev environment for full errors and additional helpful warnings.;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/kai/;ready=1;marker=native-route-kai-home;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>; visit https://react.dev/errors/418?args[]=HTML&args[]= for the full message or use the non-minified dev environment for full errors and additional helpful warnings.;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/kai/analysis",
@@ -284,7 +283,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/kai/analysis/?ticker=AAPL;ready=1;marker=native-route-kai-analysis;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/kai/analysis/?ticker=AAPL;ready=1;marker=native-route-kai-analysis;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/kai/dashboard",
@@ -315,7 +314,7 @@
         "routeok": "1",
         "test": "1",
         "auto": "1",
-        "bridge": "1",
+        "bridge": "0",
         "uirunner": "1",
         "runui": "0",
         "uistarted": "0",
@@ -354,7 +353,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/kai/portfolio/;ready=1;marker=native-route-kai-portfolio;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/kai/portfolio/;ready=1;marker=native-route-kai-portfolio;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=0;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/kai/dashboard/analysis",
@@ -424,7 +423,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/kai/analysis/;ready=1;marker=native-route-kai-analysis;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/kai/analysis/;ready=1;marker=native-route-kai-analysis;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/kai/import",
@@ -493,7 +492,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/kai/import/;ready=1;marker=native-route-kai-import;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/kai/import/;ready=1;marker=native-route-kai-import;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/kai/investments",
@@ -562,7 +561,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/kai/investments/;ready=1;marker=native-route-kai-investments;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/kai/investments/;ready=1;marker=native-route-kai-investments;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/kai/funding-trade",
@@ -632,7 +631,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/kai/funding-trade/;ready=1;marker=native-route-kai-funding-trade;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/kai/funding-trade/;ready=1;marker=native-route-kai-funding-trade;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/kai/onboarding",
@@ -701,7 +700,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/kai/onboarding/;ready=1;marker=native-route-kai-onboarding;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/kai/onboarding/;ready=1;marker=native-route-kai-onboarding;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/kai/optimize",
@@ -772,7 +771,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/kai/optimize/;ready=1;marker=native-route-kai-optimize;auth=authenticated;data=unavailable-valid;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/kai/optimize/;ready=1;marker=native-route-kai-optimize;auth=authenticated;data=unavailable-valid;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/kai/plaid/oauth/return",
@@ -842,7 +841,7 @@
         "ui_error": "",
         "error": "plaid_resume"
       },
-      "raw": "route=/kai/plaid/oauth/return/;ready=1;marker=native-route-kai-plaid-return;auth=authenticated;data=unavailable-valid;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error=plaid_resume"
+      "raw": "route=/kai/plaid/oauth/return/;ready=1;marker=native-route-kai-plaid-return;auth=authenticated;data=unavailable-valid;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error=plaid_resume"
     },
     {
       "route": "/kai/alpaca/oauth/return",
@@ -912,7 +911,7 @@
         "ui_error": "",
         "error": "alpaca_connect_resume"
       },
-      "raw": "route=/kai/alpaca/oauth/return/;ready=1;marker=native-route-kai-alpaca-return;auth=authenticated;data=unavailable-valid;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error=alpaca_connect_resume"
+      "raw": "route=/kai/alpaca/oauth/return/;ready=1;marker=native-route-kai-alpaca-return;auth=authenticated;data=unavailable-valid;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error=alpaca_connect_resume"
     },
     {
       "route": "/kai/portfolio",
@@ -981,7 +980,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/kai/portfolio/;ready=1;marker=native-route-kai-portfolio;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/kai/portfolio/;ready=1;marker=native-route-kai-portfolio;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/portfolio/shared",
@@ -1052,7 +1051,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/portfolio/shared/;ready=1;marker=native-route-portfolio-shared;auth=public;data=empty-valid;doc=complete;found=1;routeok=1;test=1;auto=0;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/portfolio/shared/;ready=1;marker=native-route-portfolio-shared;auth=public;data=empty-valid;doc=complete;found=1;routeok=1;test=1;auto=0;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=;bootstrap_uid=;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/consents",
@@ -1121,7 +1120,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/consents/;ready=1;marker=native-route-consents;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/consents/;ready=1;marker=native-route-consents;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/agent",
@@ -1192,7 +1191,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/agent/;ready=1;marker=native-route-agent;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/agent/;ready=1;marker=native-route-agent;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/one/kyc",
@@ -1261,7 +1260,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/one/kyc/;ready=1;marker=native-route-one-kyc;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/one/kyc/;ready=1;marker=native-route-one-kyc;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/one/location",
@@ -1332,7 +1331,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/one/location/;ready=1;marker=native-route-one-location;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/one/location/;ready=1;marker=native-route-one-location;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/profile",
@@ -1401,7 +1400,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/profile/;ready=1;marker=native-route-profile;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/profile/;ready=1;marker=native-route-profile;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/profile/pkm",
@@ -1471,7 +1470,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/profile/pkm-agent-lab/;ready=1;marker=native-route-profile-pkm;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=0;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/profile/pkm-agent-lab/;ready=1;marker=native-route-profile-pkm;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=0;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/profile/receipts",
@@ -1542,7 +1541,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/profile/receipts/;ready=1;marker=native-route-profile-receipts;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/profile/receipts/;ready=1;marker=native-route-profile-receipts;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/profile/gmail/oauth/return",
@@ -1612,7 +1611,7 @@
         "ui_error": "",
         "error": "gmail_oauth"
       },
-      "raw": "route=/profile/gmail/oauth/return/;ready=1;marker=native-route-profile-gmail-return;auth=authenticated;data=unavailable-valid;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error=gmail_oauth"
+      "raw": "route=/profile/gmail/oauth/return/;ready=1;marker=native-route-profile-gmail-return;auth=authenticated;data=unavailable-valid;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error=gmail_oauth"
     },
     {
       "route": "/ria",
@@ -1682,7 +1681,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/ria/;ready=1;marker=native-route-ria-home;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=ria;primary_persona=ria;persona_switch=ok:ria;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/ria/;ready=1;marker=native-route-ria-home;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=ria;primary_persona=ria;persona_switch=ok:ria;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/ria/clients",
@@ -1753,7 +1752,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/ria/clients/;ready=1;marker=native-route-ria-clients;auth=authenticated;data=empty-valid;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=ria;primary_persona=ria;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/ria/clients/;ready=1;marker=native-route-ria-clients;auth=authenticated;data=empty-valid;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=ria;primary_persona=ria;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/ria/onboarding",
@@ -1823,7 +1822,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/ria/onboarding/;ready=1;marker=native-route-ria-onboarding;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=ria;primary_persona=ria;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/ria/onboarding/;ready=1;marker=native-route-ria-onboarding;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=ria;primary_persona=ria;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/ria/picks",
@@ -1893,7 +1892,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/ria/picks/;ready=1;marker=native-route-ria-picks;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=ria;primary_persona=ria;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/ria/picks/;ready=1;marker=native-route-ria-picks;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=ria;primary_persona=ria;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/ria/requests",
@@ -1962,7 +1961,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/consents/;ready=1;marker=native-route-consents;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=ria;primary_persona=ria;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/consents/;ready=1;marker=native-route-consents;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=ria;primary_persona=ria;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/ria/settings",
@@ -2031,7 +2030,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/profile/;ready=1;marker=native-route-profile;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=ria;primary_persona=ria;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/profile/;ready=1;marker=native-route-profile;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=ria;primary_persona=ria;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/ria/workspace",
@@ -2102,7 +2101,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/ria/clients/;ready=1;marker=native-route-ria-clients;auth=authenticated;data=empty-valid;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=ria;primary_persona=ria;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/ria/clients/;ready=1;marker=native-route-ria-clients;auth=authenticated;data=empty-valid;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=ria;primary_persona=ria;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/marketplace",
@@ -2173,7 +2172,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/marketplace/;ready=1;marker=native-route-marketplace;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=ria;primary_persona=ria;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/marketplace/;ready=1;marker=native-route-marketplace;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=ria;primary_persona=ria;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/marketplace/connections",
@@ -2243,7 +2242,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/consents/?tab=pending;ready=1;marker=native-route-consents;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=ria;primary_persona=ria;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/consents/?tab=pending;ready=1;marker=native-route-consents;auth=authenticated;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=ria;primary_persona=ria;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/marketplace/connections/portfolio",
@@ -2315,7 +2314,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/ria/clients/;ready=1;marker=native-route-ria-clients;auth=authenticated;data=empty-valid;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=ria;primary_persona=ria;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/ria/clients/;ready=1;marker=native-route-ria-clients;auth=authenticated;data=empty-valid;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=ria;primary_persona=ria;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/marketplace/ria",
@@ -2385,7 +2384,7 @@
         "ui_error": "",
         "error": "marketplace_ria"
       },
-      "raw": "route=/marketplace/ria/?riaId=missing-demo-ria;ready=1;marker=native-route-marketplace-ria;auth=authenticated;data=empty-valid;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=ria;primary_persona=ria;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error=marketplace_ria"
+      "raw": "route=/marketplace/ria/?riaId=missing-demo-ria;ready=1;marker=native-route-marketplace-ria;auth=authenticated;data=empty-valid;doc=complete;found=1;routeok=1;test=1;auto=1;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=ria;primary_persona=ria;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=vault_unlocked;bootstrap_uid=<redacted>;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error=marketplace_ria"
     },
     {
       "route": "/logout",
@@ -2455,7 +2454,7 @@
         "ui_error": "",
         "error": ""
       },
-      "raw": "route=/;ready=1;marker=native-route-home;auth=anonymous;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=0;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>; visit https://react.dev/errors/418?args[]=HTML&args[]= for the full message or use the non-minified dev environment for full errors and additional helpful warnings.;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
+      "raw": "route=/;ready=1;marker=native-route-home;auth=anonymous;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=0;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=0;domtest=;domauto=;reviewer=0;bootstrap=;bootstrap_uid=;bootstrap_error=;jserr=<redacted>; visit https://react.dev/errors/418?args[]=HTML&args[]= for the full message or use the non-minified dev environment for full errors and additional helpful warnings.;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error="
     },
     {
       "route": "/login",
@@ -2524,7 +2523,7 @@
         "ui_error": "",
         "error": "cfg_1_0"
       },
-      "raw": "route=/login/;ready=1;marker=native-route-login;auth=anonymous;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=0;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=1;domtest=;domauto=;reviewer=1;bootstrap=;bootstrap_uid=<redacted>;bootstrap_error=;jserr=<redacted>;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error=cfg_1_0"
+      "raw": "route=/login/;ready=1;marker=native-route-login;auth=anonymous;data=loaded;doc=complete;found=1;routeok=1;test=1;auto=0;bridge=1;uirunner=1;runui=0;uistarted=0;uifailed=0;uiboot=0;persona=investor;primary_persona=investor;persona_switch=;persona_error=;portfolio_start_state=;portfolio_start_status=;portfolio_start_run=;portfolio_start_error=;portfolio_stream_state=;portfolio_stream_run=;portfolio_events=0;portfolio_last_event=;portfolio_last_seq=;portfolio_stream_error=;trigger=1;domtest=;domauto=;reviewer=1;bootstrap=;bootstrap_uid=;bootstrap_error=;jserr=;jsrej=;body=<redacted>;visible404=0;ui_complete=0;ui_ok=0;ui_flow=;ui_step=;ui_step_type=;ui_error=;error=cfg_1_0"
     }
   ]
 }

--- a/hushh-webapp/native-ios-ui-interaction-report.json
+++ b/hushh-webapp/native-ios-ui-interaction-report.json
@@ -1,157 +1,20 @@
 {
-  "generated_at": "2026-05-29T02:46:54.701Z",
+  "generated_at": "2026-06-08T02:38:06.553Z",
   "destination": "platform=iOS Simulator,id=9C5B1D61-028C-474A-BDFC-523BACC3B02C",
-  "flow_count": 13,
-  "passed_flows": 13,
+  "flow_count": 1,
+  "passed_flows": 1,
   "failed_flows": 0,
   "ok": true,
   "flows": [
-    "shell-investor-kai-analysis",
-    "shell-investor-kai-portfolio",
-    "shell-investor-kai-import",
-    "shell-ria-home",
-    "shell-ria-clients",
-    "shell-ria-picks",
-    "shell-marketplace",
-    "shell-profile",
-    "shell-consents",
-    "ria-picks-source-category-tabs",
-    "ria-workspace-account-detail",
-    "ria-workspace-access-panel",
-    "marketplace-workspace-card"
+    "native-investor-kai-debate-preview-start"
   ],
   "report": {
     "flows": [
       {
         "optional": false,
         "ok": true,
+        "id": "native-investor-kai-debate-preview-start",
         "failedStep": null,
-        "id": "shell-investor-kai-analysis",
-        "results": [
-          {
-            "step": 0,
-            "type": "ensure_persona",
-            "ok": true
-          },
-          {
-            "type": "click_bottom_nav",
-            "step": 1,
-            "ok": true
-          },
-          {
-            "step": 2,
-            "type": "click_bottom_nav",
-            "ok": true
-          },
-          {
-            "step": 3,
-            "type": "wait_beacon",
-            "ok": true
-          },
-          {
-            "step": 4,
-            "type": "assert_visible_testid",
-            "ok": true
-          }
-        ],
-        "description": "Investor shell: Market -> Analysis",
-        "route": "/kai/analysis"
-      },
-      {
-        "ok": true,
-        "optional": false,
-        "failedStep": null,
-        "id": "shell-investor-kai-portfolio",
-        "results": [
-          {
-            "type": "ensure_persona",
-            "step": 0,
-            "ok": true
-          },
-          {
-            "step": 1,
-            "type": "click_bottom_nav",
-            "ok": true
-          },
-          {
-            "type": "wait_beacon",
-            "step": 2,
-            "ok": true
-          }
-        ],
-        "description": "Investor shell: Portfolio tab",
-        "route": "/kai/portfolio"
-      },
-      {
-        "optional": false,
-        "ok": true,
-        "id": "shell-investor-kai-import",
-        "failedStep": null,
-        "results": [
-          {
-            "type": "ensure_persona",
-            "step": 0,
-            "ok": true
-          },
-          {
-            "step": 1,
-            "type": "click_bottom_nav",
-            "ok": true
-          },
-          {
-            "type": "wait_beacon",
-            "step": 2,
-            "ok": true
-          },
-          {
-            "step": 3,
-            "type": "click_button",
-            "ok": true
-          },
-          {
-            "type": "wait_beacon",
-            "step": 4,
-            "ok": true
-          }
-        ],
-        "description": "Investor shell: Portfolio -> import CTA",
-        "route": "/kai/import"
-      },
-      {
-        "optional": false,
-        "ok": true,
-        "id": "shell-ria-home",
-        "failedStep": null,
-        "results": [
-          {
-            "type": "ensure_persona",
-            "step": 0,
-            "ok": true
-          },
-          {
-            "type": "click_bottom_nav",
-            "step": 1,
-            "ok": true
-          },
-          {
-            "type": "wait_beacon",
-            "step": 2,
-            "ok": true
-          },
-          {
-            "type": "assert_visible_testid",
-            "step": 3,
-            "ok": true
-          }
-        ],
-        "description": "RIA shell: Home tab",
-        "route": "/ria"
-      },
-      {
-        "ok": true,
-        "optional": false,
-        "failedStep": null,
-        "id": "shell-ria-clients",
         "results": [
           {
             "step": 0,
@@ -160,7 +23,7 @@
           },
           {
             "step": 1,
-            "type": "click_bottom_nav",
+            "type": "navigate_route",
             "ok": true
           },
           {
@@ -170,322 +33,55 @@
           },
           {
             "step": 3,
-            "type": "assert_visible_testid",
-            "ok": true
-          }
-        ],
-        "description": "RIA shell: Clients tab",
-        "route": "/ria/clients"
-      },
-      {
-        "ok": true,
-        "optional": false,
-        "failedStep": null,
-        "id": "shell-ria-picks",
-        "results": [
-          {
-            "step": 0,
-            "type": "ensure_persona",
-            "ok": true
-          },
-          {
-            "step": 1,
-            "type": "click_bottom_nav",
-            "ok": true
-          },
-          {
-            "step": 2,
-            "type": "wait_beacon",
-            "ok": true
-          },
-          {
-            "type": "assert_visible_testid",
-            "step": 3,
-            "ok": true
-          },
-          {
-            "step": 4,
-            "type": "assert_visible_testid",
-            "ok": true
-          }
-        ],
-        "description": "RIA shell: Picks tab",
-        "route": "/ria/picks"
-      },
-      {
-        "optional": false,
-        "ok": true,
-        "id": "shell-marketplace",
-        "failedStep": null,
-        "results": [
-          {
-            "step": 0,
-            "type": "ensure_persona",
-            "ok": true
-          },
-          {
-            "step": 1,
-            "type": "click_bottom_nav",
-            "ok": true
-          },
-          {
-            "step": 2,
-            "type": "wait_beacon",
-            "ok": true
-          }
-        ],
-        "description": "RIA shell: Connect / marketplace",
-        "route": "/marketplace"
-      },
-      {
-        "ok": true,
-        "optional": false,
-        "id": "shell-profile",
-        "failedStep": null,
-        "results": [
-          {
-            "step": 0,
-            "type": "click_bottom_nav",
-            "ok": true
-          },
-          {
-            "step": 1,
-            "type": "wait_beacon",
-            "ok": true
-          },
-          {
-            "type": "assert_visible_testid",
-            "step": 2,
-            "ok": true
-          }
-        ],
-        "description": "Profile tab from shell",
-        "route": "/profile"
-      },
-      {
-        "ok": true,
-        "optional": false,
-        "id": "shell-consents",
-        "failedStep": null,
-        "results": [
-          {
-            "step": 0,
-            "type": "click_bottom_nav",
-            "ok": true
-          },
-          {
-            "type": "wait_beacon",
-            "step": 1,
+            "type": "wait_button",
             "ok": true
           },
           {
             "type": "click_button",
-            "step": 2,
-            "ok": true
-          },
-          {
-            "step": 3,
-            "type": "click_button",
-            "ok": true
-          },
-          {
-            "type": "wait_beacon",
             "step": 4,
-            "ok": true
-          }
-        ],
-        "description": "Profile -> Access & sharing -> Consent center",
-        "route": "/consents"
-      },
-      {
-        "optional": false,
-        "ok": true,
-        "failedStep": null,
-        "id": "ria-picks-source-category-tabs",
-        "results": [
-          {
-            "type": "ensure_persona",
-            "step": 0,
-            "ok": true
-          },
-          {
-            "step": 1,
-            "type": "click_bottom_nav",
-            "ok": true
-          },
-          {
-            "step": 2,
-            "type": "wait_beacon",
-            "ok": true
-          },
-          {
-            "step": 3,
-            "type": "click_button",
-            "ok": true
-          },
-          {
-            "step": 4,
-            "type": "assert_url_includes",
             "ok": true
           },
           {
             "step": 5,
-            "type": "click_button",
+            "type": "assert_no_text",
             "ok": true
           },
           {
-            "type": "assert_url_includes",
             "step": 6,
-            "ok": true
-          },
-          {
-            "step": 7,
-            "type": "click_button",
-            "ok": true
-          },
-          {
-            "type": "assert_url_includes",
-            "step": 8,
-            "ok": true
-          },
-          {
-            "type": "click_button",
-            "step": 9,
-            "ok": true
-          },
-          {
-            "step": 10,
-            "type": "assert_url_includes",
-            "ok": true
-          },
-          {
-            "step": 11,
-            "type": "click_button",
-            "ok": true
-          },
-          {
-            "step": 12,
-            "type": "assert_url_includes",
+            "type": "assert_text",
             "ok": true
           }
         ],
-        "description": "RIA picks source + category segmented controls",
-        "route": "/ria/picks"
-      },
-      {
-        "ok": true,
-        "optional": false,
-        "failedStep": null,
-        "id": "ria-workspace-account-detail",
-        "results": [
-          {
-            "type": "open_ria_workspace",
-            "step": 0,
-            "ok": true
-          },
-          {
-            "type": "wait_button",
-            "step": 1,
-            "ok": true
-          },
-          {
-            "step": 2,
-            "type": "click_button",
-            "ok": true
-          },
-          {
-            "type": "wait_beacon",
-            "step": 3,
-            "ok": true
-          }
-        ],
-        "description": "RIA workspace -> taxable brokerage account",
-        "route": "/ria/clients/[userId]/accounts/[accountId]"
-      },
-      {
-        "ok": true,
-        "optional": false,
-        "failedStep": null,
-        "id": "ria-workspace-access-panel",
-        "results": [
-          {
-            "type": "open_ria_workspace",
-            "step": 0,
-            "ok": true
-          },
-          {
-            "step": 1,
-            "type": "click_button",
-            "ok": true
-          },
-          {
-            "type": "assert_visible_testid",
-            "step": 2,
-            "ok": true
-          }
-        ],
-        "description": "RIA workspace sharing/access panel",
-        "route": "/ria/clients/[userId]"
-      },
-      {
-        "optional": true,
-        "ok": true,
-        "failedStep": null,
-        "id": "marketplace-workspace-card",
-        "results": [
-          {
-            "type": "ensure_persona",
-            "step": 0,
-            "ok": true
-          },
-          {
-            "step": 1,
-            "type": "click_bottom_nav",
-            "ok": true
-          },
-          {
-            "type": "wait_beacon",
-            "step": 2,
-            "ok": true
-          },
-          {
-            "skipped": true,
-            "reason": "step timeout (click_button) visible=Home|Clients|Picks|Connect|Profile|Connections|Contacts|View profile bridge=enabled=1,navigate=1,switch=1,active=ria,primary=ria,persona_switch=ok:ria,bootstrap=vault_unlocked",
-            "ok": true,
-            "type": "click_button",
-            "step": 3
-          }
-        ],
-        "description": "Marketplace open workspace card when present",
-        "route": "/marketplace"
+        "description": "Investor analysis preview: select list source and start debate without active-run loop",
+        "route": "/kai/analysis?ticker=AAPL&pick_source=default"
       }
     ],
+    "completedAt": "2026-06-08T02:38:06.194Z",
     "ok": true,
-    "completedAt": "2026-05-29T02:46:54.372Z",
-    "startedAt": "2026-05-29T02:46:10.855Z"
+    "startedAt": "2026-06-08T02:37:53.248Z"
   },
   "error": null,
   "failure_screenshot": null,
   "last_status": {
-    "route": "",
-    "ready": "0",
+    "route": "/kai/analysis/?focus=active&ticker=AAPL",
+    "ready": "1",
     "marker": "",
-    "auth": "pending",
-    "data": "booting",
-    "doc": "",
-    "found": "0",
+    "auth": "authenticated",
+    "data": "loaded",
+    "doc": "complete",
+    "found": "1",
     "routeok": "1",
-    "test": "0",
-    "auto": "0",
-    "bridge": "0",
-    "uirunner": "0",
-    "runui": "0",
-    "uistarted": "0",
+    "test": "1",
+    "auto": "1",
+    "bridge": "1",
+    "uirunner": "1",
+    "runui": "1",
+    "uistarted": "1",
     "uifailed": "0",
     "uiboot": "0",
-    "persona": "",
-    "primary_persona": "",
-    "persona_switch": "",
+    "persona": "investor",
+    "primary_persona": "investor",
+    "persona_switch": "ok:investor",
     "persona_error": "",
     "portfolio_start_state": "",
     "portfolio_start_status": "",
@@ -493,26 +89,26 @@
     "portfolio_start_error": "",
     "portfolio_stream_state": "",
     "portfolio_stream_run": "",
-    "portfolio_events": "",
+    "portfolio_events": "0",
     "portfolio_last_event": "",
     "portfolio_last_seq": "",
     "portfolio_stream_error": "",
-    "trigger": "0",
+    "trigger": "1",
     "domtest": "",
     "domauto": "",
     "reviewer": "0",
-    "bootstrap": "",
-    "bootstrap_uid": "",
+    "bootstrap": "vault_unlocked",
+    "bootstrap_uid": "<redacted>",
     "bootstrap_error": "",
     "jserr": "",
     "jsrej": "",
-    "body": "",
+    "body": "<redacted>",
     "visible404": "0",
     "ui_complete": "1",
     "ui_ok": "1",
-    "ui_flow": "",
-    "ui_step": "",
-    "ui_step_type": "",
+    "ui_flow": "native-investor-kai-debate-preview-start",
+    "ui_step": "6",
+    "ui_step_type": "assert_text",
     "ui_error": "",
     "error": ""
   }

--- a/hushh-webapp/scripts/native/native-ui-test-runner-source.js
+++ b/hushh-webapp/scripts/native/native-ui-test-runner-source.js
@@ -397,6 +397,18 @@
     throw new Error('text not visible: "' + value + '" on ' + window.location.href);
   }
 
+  async function assertNoText(value, regex, timeoutMs) {
+    var pattern = regex ? new RegExp(value, "i") : new RegExp(escapeRegExp(value), "i");
+    var deadline = Date.now() + (timeoutMs || 3000);
+    while (Date.now() < deadline) {
+      var text = (document.body && document.body.innerText) || "";
+      if (pattern.test(text)) {
+        throw new Error('unexpected text visible: "' + value + '" on ' + window.location.href);
+      }
+      await sleep(250);
+    }
+  }
+
   async function waitForUrlIncludes(value, timeoutMs) {
     var deadline = Date.now() + (timeoutMs || 5000);
     while (Date.now() < deadline) {
@@ -507,6 +519,22 @@
       if (root) {
         root.setAttribute("data-hushh-native-test-initial-route", "");
         root.setAttribute("data-hushh-native-test-expected-route", "");
+        root.setAttribute("data-hushh-native-test-expected-marker", "");
+      }
+      window.dispatchEvent(new Event("hushh:native-test-config-updated"));
+    } catch (_) {}
+  }
+
+  function applyNativeTestRouteLock(route) {
+    var bridge = nativeTestBridge();
+    bridge.initialRoute = route;
+    bridge.expectedRoute = route;
+    bridge.expectedMarker = null;
+    try {
+      var root = document.documentElement;
+      if (root) {
+        root.setAttribute("data-hushh-native-test-initial-route", route);
+        root.setAttribute("data-hushh-native-test-expected-route", route);
         root.setAttribute("data-hushh-native-test-expected-marker", "");
       }
       window.dispatchEvent(new Event("hushh:native-test-config-updated"));
@@ -646,10 +674,13 @@
 
   async function waitForRoute(route, timeoutMs) {
     var expected = normalizeRoute(route);
+    var expectedBase = expected.length > 1 && expected.endsWith("/") ? expected.slice(0, -1) : expected;
     var deadline = Date.now() + (timeoutMs || 5000);
     while (Date.now() < deadline) {
       var current = normalizeRoute(window.location.pathname + window.location.search);
+      var currentBase = current.length > 1 && current.endsWith("/") ? current.slice(0, -1) : current;
       if (
+        currentBase === expectedBase ||
         current === expected ||
         current.indexOf(expected + "/") === 0 ||
         current.indexOf(expected + "?") === 0 ||
@@ -664,10 +695,21 @@
 
   async function navigateWithNativeRouter(route) {
     var bridge = nativeTestBridge();
-    clearNativeTestRouteLock();
+    if (currentRouteMatches(route)) {
+      clearNativeTestRouteLock();
+      return;
+    }
+    applyNativeTestRouteLock(route);
     if (typeof bridge.navigateToRoute === "function") {
       bridge.navigateToRoute(route);
-      if (await waitForRoute(route, 5000)) return;
+      if (await waitForRoute(route, 30000)) {
+        clearNativeTestRouteLock();
+        return;
+      }
+      if (currentRouteMatches(route)) {
+        clearNativeTestRouteLock();
+        return;
+      }
       throw new Error(
         "Next.js native router did not reach " +
           route +
@@ -693,10 +735,10 @@
     }
 
     if (bridge.enabled === true && typeof bridge.switchPersona === "function") {
-      var switched = await attemptNativePersonaSwitch(persona);
       if (!routeMatchesPersona(persona)) {
         await navigateWithNativeRouter(route);
       }
+      var switched = await attemptNativePersonaSwitch(persona);
       if (switched) {
         await resolvePersonaMismatchPrompt(persona);
       }
@@ -833,6 +875,9 @@
       case "assert_text":
         await waitForText(step.value, step.regex === true, step.timeoutMs);
         return;
+      case "assert_no_text":
+        await assertNoText(step.value, step.regex === true, step.timeoutMs);
+        return;
       case "assert_no_persona_mismatch_prompt":
         await waitForNoPersonaMismatchPrompt(step.timeoutMs);
         return;
@@ -851,6 +896,9 @@
         }
         clickElement(testTarget);
         await sleep(400);
+        return;
+      case "navigate_route":
+        await navigateWithNativeRouter(step.route);
         return;
       case "wait_beacon":
         await waitForBeacon(step.routeIds, step.dataStates, step.timeoutMs);
@@ -874,7 +922,9 @@
     var defaultStepTimeoutMs = flow.stepTimeoutMs || 30000;
     for (var i = 0; i < flow.steps.length; i += 1) {
       var step = flow.steps[i];
-      var stepTimeoutMs = step.timeoutMs || defaultStepTimeoutMs;
+      var stepTimeoutMs = step.timeoutMs
+        ? step.timeoutMs + 1000
+        : defaultStepTimeoutMs;
       var bridge = nativeTestBridge();
       bridge.uiFlowStepIndex = i;
       bridge.uiFlowStepType = step.type || "";

--- a/hushh-webapp/scripts/testing/signed-in-ui-flows.mjs
+++ b/hushh-webapp/scripts/testing/signed-in-ui-flows.mjs
@@ -8,10 +8,12 @@
  * - click_button: { name: string, regex?: boolean }  // case-insensitive exact match unless regex=true
  * - click_voice_control: { controlId: string }
  * - click_testid: { testId: string }
+ * - navigate_route: { route: string }
  * - clear_import_background: {}
  * - upload_test_asset: { assetPath: string, fileName: string, mimeType: string }
  * - wait_button: { name: string, regex?: boolean, timeoutMs?: number }
  * - assert_text: { value: string, regex?: boolean }
+ * - assert_no_text: { value: string, regex?: boolean, timeoutMs?: number }
  * - assert_no_persona_mismatch_prompt: { timeoutMs?: number }
  * - wait_beacon: { routeIds: string[], dataStates?: string[] }
  * - assert_url_includes: { value: string }
@@ -38,6 +40,37 @@ export const UI_FLOWS = [
       { type: "click_bottom_nav", label: "Analysis" },
       { type: "wait_beacon", routeIds: ["/kai/analysis"] },
       { type: "assert_visible_testid", testId: "kai-analysis-primary" },
+    ],
+  },
+  {
+    id: "native-investor-kai-debate-preview-start",
+    route: "/kai/analysis?ticker=AAPL&pick_source=default",
+    description: "Investor analysis preview: select list source and start debate without active-run loop",
+    stepTimeoutMs: 60000,
+    steps: [
+      { type: "ensure_persona", persona: "investor" },
+      {
+        type: "navigate_route",
+        route: "/kai/analysis?ticker=AAPL&pick_source=default",
+      },
+      {
+        type: "wait_beacon",
+        routeIds: ["/kai/analysis"],
+        dataStates: ["loaded"],
+        timeoutMs: 60000,
+      },
+      { type: "wait_button", name: "Start debate", timeoutMs: 60000 },
+      { type: "click_button", name: "Start debate" },
+      {
+        type: "assert_no_text",
+        value: "A debate is already running.",
+        timeoutMs: 5000,
+      },
+      {
+        type: "assert_text",
+        value: "Initial Deep Analysis",
+        timeoutMs: 60000,
+      },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- stabilizes native Kai debate run starts and in-flight run coalescing
- aligns iOS and Android native run resume streams with /api/kai/analyze/run/{run_id}/stream
- adds focused iOS simulator coverage for starting an AAPL debate from preview without the duplicate active-run toast

## Verification
- scripts/ci/integration-check.sh
- ./bin/hushh codex pre-pr
- focused iOS simulator flow: native-investor-kai-debate-preview-start

## Branching
- local branch includes latest origin/main and origin/integration/pr-train
- target base: integration/pr-train