### PR TITLE
fix(security): add missing noopener attribute to agent markdown links

### DIFF
--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -315,7 +315,7 @@ function AgentMarkdown({ text }: { text: string }) {
             <a
               href={href || "#"}
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
               className="font-medium text-primary underline-offset-4 hover:underline"
             >
               {children}


### PR DESCRIPTION
# Description
Fixes a reverse tabnabbing vulnerability in the Agent Chat Workspace. When the AI agent generates external markdown links (`target="_blank"`), they were missing the `noopener` rel attribute. Because the agent's output is dynamic and potentially untrusted depending on the context window, enforcing `rel="noopener noreferrer"` is required to prevent the newly opened tab from hijacking the application's `window.opener` object.

## 📌 Core Impact
- [x] **Routes Touched:** `components/agent/agent-chat-workspace.tsx`
- [x] **API / Schema / Trust Boundary:** Agent Markdown Link Renderer (Client-side)
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS**: N/A
- [ ] **Android**: N/A

## 🧪 Testing & Privacy
- [x] Tested on Web
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible