### PR TITLE
fix: assign unique port 10001 to agent_one in AGENT_PORTS

### DIFF
--- a/consent-protocol/hushh_mcp/constants.py
+++ b/consent-protocol/hushh_mcp/constants.py
@@ -245,7 +245,7 @@ class ConsentScope(str, Enum):
 # Port assignments for agent-to-agent communication
 AGENT_PORTS = {
     "agent_orchestrator": 10000,
-    "agent_one": 10000,  # One top personal agent / orchestration layer
+    "agent_one": 10001,  # One top personal agent / orchestration layer
     "agent_kai": 10005,  # Kai investment analysis agent
     "agent_nav": 10006,  # Nav privacy and consent guardian
     "agent_kyc": 10007,  # KYC identity workflow specialist


### PR DESCRIPTION
## Description
Both `agent_orchestrator` and `agent_one` shared port `10000` in `AGENT_PORTS`.
The second agent to start would crash with `OSError: [Errno 98] Address already in use`.

## Fix
Changed `agent_one` port from `10000` to `10001` in `consent-protocol/hushh_mcp/constants.py`.

## Verification
Both agents can now start independently without port conflict.

Fixes #2279