### PR TITLE
fix: correct stale WORLD_MODEL_READ reference in HushhConsentToken comment

### DIFF
--- a/consent-protocol/hushh_mcp/types.py
+++ b/consent-protocol/hushh_mcp/types.py
@@ -18,7 +18,7 @@ class HushhConsentToken(BaseModel):
     token: str
     user_id: UserID
     agent_id: AgentID
-    scope: ConsentScope  # Resolved enum (fallback to WORLD_MODEL_READ for dynamic scopes)
+    scope: ConsentScope  # Resolved enum (fallback to VAULT_OWNER for dynamic scopes)
     scope_str: str = ""  # Actual scope string from token (e.g., "attr.financial.*")
     issued_at: int  # epoch ms
     expires_at: int  # epoch ms


### PR DESCRIPTION
## Description
The `scope` field in `HushhConsentToken` had a comment referencing `WORLD_MODEL_READ`
which does not exist anywhere in the `ConsentScope` enum, misleading developers
about the actual fallback behavior.

## Fix
Updated the comment to reference `VAULT_OWNER`, the actual master scope
defined in `ConsentScope`.

## Verification
Search `WORLD_MODEL_READ` across the codebase — no results found, confirming
it was a stale reference.

Fixes #2281