### PR TITLE
fix(ssr): resolve next.js hydration mismatch in agent popover

### DIFF
--- a/hushh-webapp/components/agent/agent-popover-provider.tsx
+++ b/hushh-webapp/components/agent/agent-popover-provider.tsx
@@ -100,8 +100,13 @@ export function AgentPopoverProvider({ children }: { children: ReactNode }) {
   const [hasOpened, setHasOpened] = useState(false);
   const [motionState, setMotionState] =
     useState<AgentPopoverMotionState>("idle");
-  const [sizeMode, setSizeModeState] = useState<AgentPopoverSizeMode>(readStoredSizeMode);
-  const [customSize, setCustomSize] = useState<AgentPopoverSize>(readStoredCustomSize);
+  const [sizeMode, setSizeModeState] = useState<AgentPopoverSizeMode>(AGENT_POPOVER_DEFAULT_SIZE_MODE);
+  const [customSize, setCustomSize] = useState<AgentPopoverSize>(DEFAULT_CUSTOM_SIZE);
+
+  useEffect(() => {
+    setSizeModeState(readStoredSizeMode());
+    setCustomSize(readStoredCustomSize());
+  }, []);
   const animationFrameRef = useRef<number | null>(null);
   const motionTimerRef = useRef<number | null>(null);
 


### PR DESCRIPTION
# Description
Resolves a Next.js SSR hydration mismatch in the Agent Popover Provider. By deferring `localStorage` state initialization to a `useEffect` post-mount, we prevent React from discarding and rebuilding the provider tree on the client due to server/client HTML divergence.

## 📌 Core Impact
- [x] **Routes Touched:** `components/agent/agent-popover-provider.tsx`
- [x] **API / Schema / Trust Boundary:** React Component State / LocalStorage
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation

## 🧪 Testing & Privacy
- [x] Tested on Web
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible