### PR TITLE
fix: correct GEMINI_MODEL to valid model name gemini-2.5-pro-preview

### DIFF
--- a/consent-protocol/hushh_mcp/constants.py
+++ b/consent-protocol/hushh_mcp/constants.py
@@ -267,13 +267,13 @@ DEFAULT_TRUST_LINK_EXPIRY_MS = 1000 * 60 * 60 * 24 * 30  # 30 days
 # ==================== Gemini Model Configuration ====================
 
 # Standard model for general LLM operations across the codebase.
-GEMINI_MODEL = "gemini-3.1-pro-preview"
+GEMINI_MODEL = "gemini-2.5-pro-preview"
 
 # Full path format (for ADK and direct API calls)
-GEMINI_MODEL_FULL = "models/gemini-3.1-pro-preview"
+GEMINI_MODEL_FULL = "models/gemini-2.5-pro-preview"
 
 # Vertex AI model (for Google Cloud deployments)
-GEMINI_MODEL_VERTEX = "gemini-3.1-pro-preview"
+GEMINI_MODEL_VERTEX = "gemini-2.5-pro-preview"
 
 # ==================== Kai Portfolio Import Defaults ====================
 


### PR DESCRIPTION
## Description
`GEMINI_MODEL` was set to `"gemini-3.1-pro-preview"` which does not exist,
causing all LLM calls using this constant to fail with a model not found
error from the Google API.

## Fix
Updated `GEMINI_MODEL` to `"gemini-2.5-pro-preview"` in
`consent-protocol/hushh_mcp/constants.py`.

## Verification
Check Google's official model list — `gemini-2.5-pro-preview` is valid,
`gemini-3.1-pro-preview` does not exist.

Fixes #2283