### PR TITLE
feat(ux): add global network status indicator

### DIFF
--- a/hushh-webapp/app/layout-client.tsx
+++ b/hushh-webapp/app/layout-client.tsx
@@ -2,6 +2,7 @@
 
 import { ReactNode } from "react";
 import { Providers } from "./providers";
+import { NetworkStatusIndicator } from "@/components/app-ui/network-status-indicator";
 
 interface RootLayoutClientProps {
   children: ReactNode;
@@ -36,6 +37,8 @@ export function RootLayoutClient({
       <Providers>
         {children}
       </Providers>
+      
+      <NetworkStatusIndicator />
     </body>
   );
 }

--- a/hushh-webapp/components/app-ui/network-status-indicator.tsx
+++ b/hushh-webapp/components/app-ui/network-status-indicator.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { Wifi, WifiOff } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useNetworkStatus } from "@/lib/hooks/use-network-status";
+
+/**
+ * A global floating indicator that notifies the user when they lose internet connection,
+ * and briefly shows a success message when the connection is restored.
+ */
+export function NetworkStatusIndicator() {
+  const { isOnline, isOffline, wasOffline } = useNetworkStatus();
+  const [showRestored, setShowRestored] = useState(false);
+
+  // When connection is restored after being offline, show the "Back online" pill briefly.
+  useEffect(() => {
+    if (isOnline && wasOffline) {
+      setShowRestored(true);
+      const timer = setTimeout(() => {
+        setShowRestored(false);
+      }, 3500); // Hide after 3.5 seconds
+      return () => clearTimeout(timer);
+    }
+  }, [isOnline, wasOffline]);
+
+  const isVisible = isOffline || showRestored;
+
+  return (
+    <div
+      className={cn(
+        "fixed bottom-6 left-1/2 z-[9999] flex -translate-x-1/2 transform items-center justify-center transition-all duration-500 ease-in-out",
+        isVisible
+          ? "translate-y-0 opacity-100 scale-100"
+          : "translate-y-8 opacity-0 scale-95 pointer-events-none"
+      )}
+      aria-hidden={!isVisible}
+    >
+      <div
+        className={cn(
+          "flex items-center gap-2.5 rounded-full px-4 py-2.5 text-sm font-medium shadow-lg backdrop-blur-md border transition-colors duration-300",
+          isOffline
+            ? "border-destructive/40 bg-destructive/90 text-destructive-foreground dark:bg-destructive/80"
+            : "border-green-500/40 bg-green-500/90 text-white dark:bg-green-600/80"
+        )}
+        role="alert"
+        aria-live="polite"
+      >
+        {isOffline ? (
+          <>
+            <WifiOff className="h-4 w-4 shrink-0" aria-hidden="true" />
+            <span>You are offline. Retrying connection...</span>
+          </>
+        ) : (
+          <>
+            <Wifi className="h-4 w-4 shrink-0" aria-hidden="true" />
+            <span>Connection restored!</span>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/hushh-webapp/components/app-ui/network-status-indicator.tsx
+++ b/hushh-webapp/components/app-ui/network-status-indicator.tsx
@@ -22,6 +22,7 @@ export function NetworkStatusIndicator() {
       }, 3500); // Hide after 3.5 seconds
       return () => clearTimeout(timer);
     }
+    return undefined;
   }, [isOnline, wasOffline]);
 
   const isVisible = isOffline || showRestored;

--- a/hushh-webapp/lib/hooks/use-network-status.ts
+++ b/hushh-webapp/lib/hooks/use-network-status.ts
@@ -1,0 +1,50 @@
+import { useState, useEffect, useCallback } from "react";
+
+interface NetworkStatus {
+  isOnline: boolean;
+  isOffline: boolean;
+  wasOffline: boolean;
+}
+
+/**
+ * Hook to track the browser's network connection status.
+ * Safely handles SSR and tracks if the user was previously offline.
+ */
+export function useNetworkStatus(): NetworkStatus {
+  const [isOnline, setIsOnline] = useState<boolean>(true);
+  const [wasOffline, setWasOffline] = useState<boolean>(false);
+
+  // Initialize state once mounted to prevent SSR hydration mismatch
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      setIsOnline(navigator.onLine);
+    }
+  }, []);
+
+  const handleOnline = useCallback(() => {
+    setIsOnline(true);
+  }, []);
+
+  const handleOffline = useCallback(() => {
+    setIsOnline(false);
+    setWasOffline(true);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, [handleOnline, handleOffline]);
+
+  return {
+    isOnline,
+    isOffline: !isOnline,
+    wasOffline,
+  };
+}


### PR DESCRIPTION
# Description
Adds a robust, SSR-safe Network Status Indicator that slides in at the bottom of the screen whenever the user's browser loses internet connectivity. When the connection is restored, it briefly flashes a success message and disappears. This is highly useful for progressive web app paradigms and provides vital feedback during API-heavy workflows.

## 📌 Core Impact
- [x] **Routes Touched:** `app/layout-client.tsx` (Global)
- [x] **New Files:** `lib/hooks/use-network-status.ts`, `components/app-ui/network-status-indicator.tsx`
- [x] **Verification:** Verified commit message length (<72 chars) and code validity.

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS**: N/A
- [ ] **Android**: N/A

## 🧪 Testing & Privacy
- [x] Tested on Web
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible