### PR TITLE
fix(auth): resolve hydration mismatch in register phone flow

### DIFF
--- a/hushh-webapp/app/register-phone/page.tsx
+++ b/hushh-webapp/app/register-phone/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type CSSProperties, Suspense, useCallback, useEffect } from "react";
+import { type CSSProperties, Suspense, useCallback, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
 import { FullscreenFlowShell } from "@/components/app-ui/fullscreen-flow-shell";
@@ -87,12 +87,15 @@ function PhoneMandatePageContent() {
     [redirectPath, refreshUser, router, user]
   );
 
-  const shouldBypassLocalPhoneMandate =
-    !loading &&
-    Boolean(user) &&
-    !phoneNumber &&
-    typeof window !== "undefined" &&
-    shouldBypassPhoneMandateForLocalhost(window.location.hostname);
+  const [shouldBypassLocalPhoneMandate, setShouldBypassLocalPhoneMandate] = useState(false);
+
+  useEffect(() => {
+    if (!loading && Boolean(user) && !phoneNumber) {
+      if (typeof window !== "undefined" && shouldBypassPhoneMandateForLocalhost(window.location.hostname)) {
+        setShouldBypassLocalPhoneMandate(true);
+      }
+    }
+  }, [loading, user, phoneNumber]);
 
   useEffect(() => {
     if (!shouldBypassLocalPhoneMandate || !user) {


### PR DESCRIPTION
# Description
Fixes a React hydration error in the Phone Registration flow. The component previously evaluated `typeof window !== 'undefined'` as false during SSR, but the client immediately evaluated it as true during hydration, causing mismatched loader UI elements. By moving the window checks and local phone mandate bypass evaluation into a `useEffect`, the initial client render now perfectly matches the SSR output before resolving.

## 📌 Core Impact
- [x] **Routes Touched:** `app/register-phone/page.tsx`
- [x] **Architecture:** Client-side React hooks (Hydration safety)
- [x] **Verification:** Verified commit message length (<72 chars).

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation

## 🧪 Testing & Privacy
- [x] Tested on Web
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible