### PR TITLE
fix(auth-session): suppress error logs in production for session API

### DIFF
--- a/hushh-webapp/app/api/auth/session/route.ts
+++ b/hushh-webapp/app/api/auth/session/route.ts
@@ -63,7 +63,9 @@ export async function POST(request: NextRequest) {
       message: "Session created successfully",
     });
   } catch (error) {
-    console.error("[Session API] Error creating session:", error);
+    if (process.env.NODE_ENV !== "production") {
+  console.error("[Session API] Error creating session:", error);
+}
     return NextResponse.json(
       { error: "Internal server error" },
       { status: 500 }
@@ -85,7 +87,9 @@ export async function DELETE() {
       message: "Session destroyed",
     });
   } catch (error) {
-    console.error("[Session API] Error destroying session:", error);
+    if (process.env.NODE_ENV !== "production") {
+  console.error("[Session API] Error destroying session:", error);
+}
     return NextResponse.json(
       { error: "Internal server error" },
       { status: 500 }
@@ -119,10 +123,12 @@ export async function GET() {
       uid,
     });
   } catch (error) {
-    console.error("[Session API] Error verifying session:", error);
+    if (process.env.NODE_ENV !== "production") {
+      console.error("[Session API] Error verifying session:", error);
+    }
     return NextResponse.json(
       { authenticated: false, error: "Verification failed" },
-      { status: 500 }
+      { status: 500 } 
     );
   }
 }


### PR DESCRIPTION
## Summary
- what changed: Wrapped three `console.error` calls in `hushh-webapp/app/api/auth/session/route.ts` with `process.env.NODE_ENV !== "production"` guards across POST, DELETE, and GET handlers
- why it changed: All three catch blocks unconditionally log the full error object including stack trace in production. The session API handles httpOnly cookies and Firebase Admin SDK — error details here are particularly sensitive and should not appear in production server logs on every session create, destroy, or verify failure.

## Attach point
`hushh-webapp/app/api/auth/session/route.ts` — POST, DELETE, and GET handlers for secure session management using Firebase Admin SDK and httpOnly cookies across the `/api/auth/session` route.

## Contract changed
Runtime behavior: full error details and stack traces no longer appear in production server logs on session API failures. Development and staging behavior unchanged — errors still logged in non-production environments. No change to response shape, status codes, cookie handling, or Firebase Admin SDK calls.

## Tests run
```bash
cd hushh-webapp && npx tsc --noEmit
```
Passed locally. No type errors.

## Base/head status
Branch is current with main, mergeable, and DCO-signed. Targets integration/pr-train as required by repo base policy.

## Sensitive proof
Auth surface touched — session cookie creation, destruction, and verification. Only logging behavior changed. No auth flow, token validation, vault, PKM, finance, or KYC logic structurally modified. Rollback: revert by removing the three `NODE_ENV` guards and restoring unconditional `console.error` calls.

## Stack proof
Not applicable. Standalone fix, no predecessor PR.

Fixes #2298