### PR TITLE
fix(security): resolve OWASP reverse tabnabbing in AI markdown renderer

### DIFF
--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -315,7 +315,7 @@ function AgentMarkdown({ text }: { text: string }) {
             <a
               href={href || "#"}
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
               className="font-medium text-primary underline-offset-4 hover:underline"
             >
               {children}


### PR DESCRIPTION
# Description
Resolves an OWASP Reverse Tabnabbing vulnerability within the AI Agent's markdown renderer. Dynamically generated links were missing the `noopener` attribute. Without `noopener`, an external malicious site opened via an AI-provided link could potentially hijack the application's `window.opener` context. 

## 📌 Core Impact
- [x] **Routes Touched:** `components/agent/agent-chat-workspace.tsx`
- [x] **Architecture:** Markdown Rendering (Security)
- [x] **Verification:** Verified commit message length (<72 chars).

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation

## 🧪 Testing & Privacy
- [x] Tested on Web
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible