### PR TITLE
fix(consent): active consents route logs full error object in production

### DIFF
--- a/hushh-webapp/app/api/consent/active/route.ts
+++ b/hushh-webapp/app/api/consent/active/route.ts
@@ -89,7 +89,9 @@ export async function GET(request: NextRequest) {
     }
     return withRequestIdJson(requestId, result.payload, { status: result.status });
   } catch (error) {
-    console.error("[API] Active consents error:", error);
+    if (process.env.NODE_ENV !== "production") {
+      console.error("[API] Active consents error:", error);
+    }
     const { searchParams } = new URL(request.url);
     const userId = searchParams.get("userId");
     const authHeader = request.headers.get("Authorization");


### PR DESCRIPTION
## Description
In `hushh-webapp/app/api/consent/active/route.ts`, the catch block unconditionally logs the full error object including stack trace in production:

console.error("[API] Active consents error:", error);

This leaks internal error details on every active consent fetch failure in production. The active consents API handles Authorization headers and user consent tokens — error details here are particularly sensitive.

## Steps To Reproduce
1. Deploy to production with Python backend unreachable
2. Call GET /api/consent/active?userId=<id> with a valid Authorization header
3. Observe full error stack trace logged to production server output

## Expected Behavior
Raw error details should only be logged in non-production environments, consistent with the NODE_ENV guard pattern already used across this codebase.

## Environment
- OS: Windows 11
- Node Version: 20.x

## Additional Context
Fix wraps the console.error call with process.env.NODE_ENV !== "production" guard — consistent with the pattern established in auth/session/route.ts (#2298), review-mode/route.ts (#2062), and notifications/register/route.ts (#2064).