### PR TITLE
fix(consent): cancel consent route logs full error object in production

### DIFF
--- a/hushh-webapp/app/api/consent/cancel/route.ts
+++ b/hushh-webapp/app/api/consent/cancel/route.ts
@@ -43,7 +43,9 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    console.log(`[API] Cancelling consent request: ${requestId}`);
+    if (process.env.NODE_ENV !== "production") {
+  console.log(`[API] Cancelling consent request: ${requestId}`);
+}
 
     const response = await fetch(`${BACKEND_URL}/api/consent/cancel`, {
       method: "POST",
@@ -56,7 +58,9 @@ export async function POST(request: NextRequest) {
 
     if (!response.ok) {
       const error = await response.text();
-      console.error("[API] Backend error:", error);
+      if (process.env.NODE_ENV !== "production") {
+        console.error("[API] Cancel consent error:", error);
+      }
       return NextResponse.json(
         { error: "Failed to cancel consent" },
         { status: response.status },


### PR DESCRIPTION
## Description
In `hushh-webapp/app/api/consent/cancel/route.ts`, the catch block unconditionally logs the full error object including stack trace in production:

console.error("[API] Cancel consent error:", error);

This leaks internal error details on every consent cancellation failure in production. The cancel consent API handles VAULT_OWNER tokens and Authorization headers — error details here are particularly sensitive.

## Steps To Reproduce
1. Deploy to production with Python backend unreachable
2. Call POST /api/consent/cancel with valid userId, requestId and Authorization header
3. Observe full error stack trace logged to production server output

## Expected Behavior
Raw error details should only be logged in non-production environments, consistent with the NODE_ENV guard pattern already used across this codebase.

## Environment
- OS: Windows 11
- Node Version: 20.x

## Additional Context
Fix wraps the console.error call with process.env.NODE_ENV !== "production" guard — consistent with the pattern established in consent/active/route.ts (#2301), auth/session/route.ts (#2298), and review-mode/route.ts (#2062).