### PR TITLE
fix(ux): add missing type=button to prevent unintended form submissions

### DIFF
--- a/hushh-webapp/components/app-ui/paginated-list-footer.tsx
+++ b/hushh-webapp/components/app-ui/paginated-list-footer.tsx
@@ -56,6 +56,7 @@ export function PaginatedListFooter({
       </span>
       <div className="flex gap-2">
         <Button
+          type="button"
           variant="ghost"
           size="sm"
           disabled={safePage <= 1}
@@ -65,6 +66,7 @@ export function PaginatedListFooter({
           Previous
         </Button>
         <Button
+          type="button"
           variant="ghost"
           size="sm"
           disabled={!hasMore}

--- a/hushh-webapp/components/app-ui/route-error-boundary.tsx
+++ b/hushh-webapp/components/app-ui/route-error-boundary.tsx
@@ -85,6 +85,7 @@ export class RouteErrorBoundary extends Component<Props, State> {
               </div>
               <div className="flex gap-3 pt-1">
                 <Button
+                  type="button"
                   variant="muted"
                   effect="glass"
                   size="sm"
@@ -94,6 +95,7 @@ export class RouteErrorBoundary extends Component<Props, State> {
                   Try again
                 </Button>
                 <Button
+                  type="button"
                   variant="blue-gradient"
                   effect="fill"
                   size="sm"

--- a/hushh-webapp/components/onboarding/AuthProviderButton.tsx
+++ b/hushh-webapp/components/onboarding/AuthProviderButton.tsx
@@ -22,6 +22,7 @@ export function AuthProviderButton({
 }: AuthProviderButtonProps) {
   return (
     <Button
+      type="button"
       variant="none"
       effect="glass"
       size="lg"


### PR DESCRIPTION
# Description
Fixes a widespread React/HTML bug where `<Button>` components lacking an explicit `type` attribute implicitly default to `type="submit"` when rendered inside a `<form>`. Added explicit `type="button"` to `RouteErrorBoundary` recovery actions, `AuthProviderButton`, and `PaginatedListFooter` controls to prevent accidental page reloads or broken form submissions during interaction.

## 📌 Core Impact
- [x] **Routes Touched:** `app-ui/route-error-boundary.tsx`, `app-ui/paginated-list-footer.tsx`, `onboarding/AuthProviderButton.tsx`
- [x] **Architecture:** HTML Semantics & Form Safety
- [x] **Verification:** Verified commit message length (<72 chars).

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS**: N/A
- [x] **Android**: N/A

## 🧪 Testing & Privacy
- [x] Tested on Web
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible