### PR TITLE
fix(consent): logout route logs session token events and full error object in production

### DIFF
--- a/hushh-webapp/app/api/consent/logout/route.ts
+++ b/hushh-webapp/app/api/consent/logout/route.ts
@@ -31,7 +31,9 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    console.log("[API] Destroying session tokens");
+    if (process.env.NODE_ENV !== "production") {
+  console.log("[API] Destroying session tokens");
+}
 
     const response = await fetch(`${BACKEND_URL}/api/consent/logout`, {
       method: "POST",
@@ -49,11 +51,15 @@ export async function POST(request: NextRequest) {
     }
 
     const data = await response.json();
-    console.log("[API] Session tokens destroyed");
+    if (process.env.NODE_ENV !== "production") {
+  console.log("[API] Session tokens destroyed");
+}
 
     return NextResponse.json(data);
   } catch (error) {
-    console.error("[API] Logout error:", error);
+    if (process.env.NODE_ENV !== "production") {
+      console.error("[API] Logout error:", error);
+    } 
     return NextResponse.json(
       { error: "Internal server error" },
       { status: 500 },


### PR DESCRIPTION
## Description
In `hushh-webapp/app/api/consent/logout/route.ts`, three console calls unconditionally leak data in production:

- Line 29: console.log("[API] Destroying session tokens") — logs on every logout attempt
- Line 52: console.log("[API] Session tokens destroyed") — logs on every successful logout
- Line 55: console.error("[API] Logout error:", error) — logs full error stack trace on failure

The logout API destroys all session tokens — logging session lifecycle events in production leaks internal auth flow details to server logs.

## Steps To Reproduce
1. Deploy to production
2. Call POST /api/consent/logout with a valid userId
3. Observe session token lifecycle events and error details logged to production server output

## Expected Behavior
Session token events and error details should only be logged in non-production environments, consistent with the NODE_ENV guard pattern already used across this codebase.

## Environment
- OS: Windows 11
- Node Version: 20.x

## Additional Context
Fix wraps all three console calls with process.env.NODE_ENV !== "production" guard — consistent with the pattern established in consent/cancel/route.ts, consent/active/route.ts (#2301), and auth/session/route.ts (#2298).