### PR TITLE
fix(core): resolve hydration mismatch from synchronous window.location.hostname usage

### DIFF
--- a/hushh-webapp/components/auth/phone-mandate-guard.tsx
+++ b/hushh-webapp/components/auth/phone-mandate-guard.tsx
@@ -13,6 +13,7 @@ import {
   shouldRequirePhoneMandate,
 } from "@/lib/services/phone-mandate-service";
 import { VaultService } from "@/lib/services/vault-service";
+import { useHostname } from "@/lib/hooks/use-hostname";
 
 const vaultPresenceCache = new Map<string, boolean>();
 
@@ -29,7 +30,7 @@ export function PhoneMandateGuard({
   const { user, loading, phoneNumber } = useAuth();
   const [hasVault, setHasVault] = useState<boolean | null>(null);
   const [backendPhoneVerified, setBackendPhoneVerified] = useState<boolean | null>(null);
-  const hostname = typeof window === "undefined" ? null : window.location.hostname;
+  const hostname = useHostname();
   const localPhoneMandateBypassed = shouldBypassPhoneMandateForLocalhost(hostname);
   const firebasePhoneVerified = hasVerifiedPhoneNumber(phoneNumber);
 

--- a/hushh-webapp/components/vault/vault-flow.tsx
+++ b/hushh-webapp/components/vault/vault-flow.tsx
@@ -34,6 +34,7 @@ import { User } from "firebase/auth";
 import { useVault } from "@/lib/vault/vault-context";
 import { HushhLoader } from "@/components/app-ui/hushh-loader";
 import { Icon } from "@/lib/morphy-ux/ui";
+import { useHostname } from "@/lib/hooks/use-hostname";
 import type { GeneratedVaultKeyMode } from "@/lib/services/vault-bootstrap-service";
 import { VaultMethodService, type VaultMethod } from "@/lib/services/vault-method-service";
 import { VaultMethodPromptLocalService } from "@/lib/services/vault-method-prompt-local-service";
@@ -101,9 +102,10 @@ export function VaultFlow({
     preferPassphraseUnlockForAutomation(nativeTestConfig);
   const skipGeneratedUnlockForAutomation =
     shouldSkipGeneratedVaultUnlockForAutomation();
+  const hostname = useHostname();
   const currentRpId = resolvePasskeyRpId({
     isNative: Capacitor.isNativePlatform(),
-    hostname: typeof window !== "undefined" ? window.location.hostname : null,
+    hostname: hostname,
   });
 
   const { unlockVault } = useVault();

--- a/hushh-webapp/components/vault/vault-method-prompt.tsx
+++ b/hushh-webapp/components/vault/vault-method-prompt.tsx
@@ -17,6 +17,7 @@ import { KaiNavTourLocalService } from "@/lib/services/kai-nav-tour-local-servic
 import { resolvePasskeyRpId } from "@/lib/vault/passkey-rp";
 import { Button } from "@/lib/morphy-ux/button";
 import { Icon } from "@/lib/morphy-ux/ui";
+import { useHostname } from "@/lib/hooks/use-hostname";
 import {
   Dialog,
   DialogContent,
@@ -28,7 +29,7 @@ import {
 import { toast } from "sonner";
 
 interface VaultMethodPromptProps {
-  enabled: boolean;
+  enabled?: boolean;
 }
 
 function readableMethod(method: VaultMethod): string {
@@ -46,13 +47,14 @@ export function VaultMethodPrompt({ enabled }: VaultMethodPromptProps) {
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
   const [targetMethod, setTargetMethod] = useState<VaultMethod | null>(null);
+  const hostname = useHostname();
   const currentRpId = useMemo(
     () =>
       resolvePasskeyRpId({
         isNative: Capacitor.isNativePlatform(),
-        hostname: typeof window !== "undefined" ? window.location.hostname : null,
+        hostname: hostname,
       }),
-    []
+    [hostname]
   );
 
   const canEvaluate = enabled && !loading && !!user?.uid && isVaultUnlocked && !!vaultKey;

--- a/hushh-webapp/lib/hooks/use-hostname.ts
+++ b/hushh-webapp/lib/hooks/use-hostname.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Safely retrieves the window.location.hostname without causing React hydration mismatches.
+ * Returns null during SSR and on the first client render, then updates to the real hostname.
+ */
+export function useHostname() {
+  const [hostname, setHostname] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      setHostname(window.location.hostname);
+    }
+  }, []);
+
+  return hostname;
+}


### PR DESCRIPTION
# Description
Resolves a pervasive React Hydration Mismatch and state divergence bug caused by synchronous `window.location.hostname` access during SSR. Introduced a `useHostname` React hook to safely defer browser-only `window` access until after the initial client hydration phase. Refactored critical `Vault` and `PhoneMandate` guards to consume the new hook.

## 📌 Core Impact
- [x] **Routes Touched:** 
  - `lib/hooks/use-hostname.ts` (New)
  - `components/auth/phone-mandate-guard.tsx`
  - `components/vault/vault-flow.tsx`
  - `components/vault/vault-method-prompt.tsx`
- [x] **Architecture:** Next.js SSR / React Hydration Lifecycles
- [x] **Verification:** Verified commit message length (<72 chars).

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS**: N/A
- [ ] **Android**: N/A

## 🧪 Testing & Privacy
- [x] Tested on Web
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible