### PR TITLE
fix(settings-detail-panel): add onOpenAutoFocus to DialogContent to match Drawer focus parity

### DIFF
--- a/hushh-webapp/components/app-ui/settings-ui.tsx
+++ b/hushh-webapp/components/app-ui/settings-ui.tsx
@@ -428,6 +428,10 @@ export function SettingsDetailPanel({
           "w-[calc(100%-1.5rem)] overflow-hidden p-0",
           desktopMaxWidthClassName || "sm:!max-w-[720px]"
         )}
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+          (e.currentTarget as HTMLElement).focus();
+        }}
       >
         <DialogHeader className="sticky top-0 z-10 border-b border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-default-solid)] px-6 py-4 text-left">
           <DialogTitle className="text-base font-semibold tracking-tight">


### PR DESCRIPTION
## Problem

`SettingsDetailPanel` has different focus behavior depending on viewport:

* Mobile (`DrawerContent`) explicitly prevents default autofocus and focuses the content container.
* Desktop (`DialogContent`) relies on Radix's default autofocus behavior, which places focus on the close button.

As a result, keyboard and screen-reader users opening the same settings surface receive different focus targets depending on device size.

## Fix

Apply the same `onOpenAutoFocus` handler already used by the mobile drawer path to the desktop dialog path:

```tsx
onOpenAutoFocus={(e) => {
  e.preventDefault();
  (e.currentTarget as HTMLElement).focus();
}}
```

This aligns desktop and mobile behavior and keeps focus on the panel container when the surface opens.

## Scope

* 1 file changed
* Additive-only change
* No visual changes
* No impact to pointer interactions
* No changes to close behavior or Escape handling

## Files Changed

* `hushh-webapp/components/app-ui/settings-ui.tsx`
