### PR TITLE
fix(onboarding-previews): add aria-hidden to decorative preview card wrapper in carousel

### DIFF
--- a/hushh-webapp/components/onboarding/PreviewCarouselStep.tsx
+++ b/hushh-webapp/components/onboarding/PreviewCarouselStep.tsx
@@ -227,7 +227,10 @@ export function PreviewCarouselStep({ onContinue }: { onContinue: () => void }) 
                     className="basis-full pl-0 flex items-center justify-center"
                   >
                     <div className="flex w-full min-h-[clamp(24rem,50vh,31rem)] items-center justify-center px-4 sm:px-6 md:px-8 py-3">
-                      <div className="h-[clamp(31rem,58vh,35rem)] w-full max-w-[22rem] sm:max-w-[24rem] md:max-w-[25rem] lg:max-w-[26rem] xl:max-w-[27rem]">
+                      <div
+                        aria-hidden="true"
+                        className="h-[clamp(31rem,58vh,35rem)] w-full max-w-[22rem] sm:max-w-[24rem] md:max-w-[25rem] lg:max-w-[26rem] xl:max-w-[27rem]"
+                      >
                         {slide.preview}
                       </div>
                     </div>


### PR DESCRIPTION
## Problem

`PreviewCarouselStep` renders three preview cards (`KycPreviewCompact`, `PortfolioPreviewCompact`, and `DecisionPreviewCompact`) as visual onboarding illustrations.

These cards contain mock content such as sample ticker symbols, portfolio values, and KYC status rows. The onboarding step already provides accessible context through the slide heading and description, while the preview cards serve only as decorative visual examples.

Because the preview wrapper is not hidden from the accessibility tree, screen readers may announce the mock content as if it were meaningful application data.

## Fix

Add `aria-hidden="true"` to the wrapper that renders `{slide.preview}` inside each carousel slide.

This suppresses the decorative preview content while preserving the existing accessible title and description for each onboarding step.

## Scope

* 1 file changed
* Additive-only change
* No visual changes
* No behavioral changes
* No impact to carousel navigation

## Files Changed

* `hushh-webapp/components/onboarding/PreviewCarouselStep.tsx`
