### PR TITLE
fix(system): add aria-atomic consistency across live region components

### DIFF
--- a/hushh-webapp/components/system/async-action-status.tsx
+++ b/hushh-webapp/components/system/async-action-status.tsx
@@ -39,6 +39,7 @@ export function AsyncActionStatus({
     <div
       role="status"
       aria-live={state === "error" ? "assertive" : "polite"}
+      aria-atomic="true"
       className={
         compact
           ? "inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-2.5 py-1 text-xs font-medium text-muted-foreground"

--- a/hushh-webapp/components/system/network-status-banner.tsx
+++ b/hushh-webapp/components/system/network-status-banner.tsx
@@ -15,6 +15,7 @@ export function NetworkStatusBanner() {
     <div
       role="status"
       aria-live="polite"
+      aria-atomic="true"
       className="fixed inset-x-0 top-0 z-[9999] border-b border-amber-500/20 bg-amber-500/10 px-4 py-2 text-center text-sm text-amber-700 backdrop-blur dark:text-amber-300"
     >
       <div className="flex items-center justify-center gap-2">

--- a/hushh-webapp/components/system/route-suspense-fallback.tsx
+++ b/hushh-webapp/components/system/route-suspense-fallback.tsx
@@ -11,6 +11,7 @@ export function RouteSuspenseFallback({
     <div
       role="status"
       aria-live="polite"
+      aria-atomic="true"
       className="flex min-h-[320px] items-center justify-center px-6 py-12"
     >
       <HushhLoader variant="inline" label={label} />

--- a/hushh-webapp/components/system/session-expiry-recovery.tsx
+++ b/hushh-webapp/components/system/session-expiry-recovery.tsx
@@ -19,6 +19,7 @@ export function SessionExpiryRecovery({
     <div
       role="status"
       aria-live="polite"
+      aria-atomic="true"
       className="rounded-[var(--app-card-radius-compact)] border border-amber-500/20 bg-amber-500/10 p-4"
     >
       <div className="flex items-start gap-3">


### PR DESCRIPTION
## Problem

Several system-level status components already expose live region semantics using `role="status"` and `aria-live`, but do not explicitly declare `aria-atomic="true"`.

Without `aria-atomic="true"`, assistive technologies may announce only the portion of the live region that changed rather than the complete status message. This can result in truncated or incomplete announcements depending on the browser and screen reader combination.

`AccessibilityStatusAnnouncer` already uses `aria-atomic="true"`, establishing the preferred pattern within the system layer.

## Fix

Add `aria-atomic="true"` to existing live regions in:

* `AsyncActionStatus`
* `NetworkStatusBanner`
* `SessionExpiryRecovery`
* `RouteSuspenseFallback`

No existing roles or live region behavior were changed.

## Scope

* 4 files changed
* Additive-only accessibility attributes
* No visual changes
* No behavioral changes
* Aligns all existing system live regions with the same accessibility contract

## Files Changed

* `components/system/async-action-status.tsx`
* `components/system/network-status-banner.tsx`
* `components/system/session-expiry-recovery.tsx`
* `components/system/route-suspense-fallback.tsx`
