### PR TITLE
fix(sheet): add safe-area-inset-bottom to SheetFooter matching DrawerFooter parity

### DIFF
--- a/hushh-webapp/components/ui/sheet.tsx
+++ b/hushh-webapp/components/ui/sheet.tsx
@@ -106,7 +106,7 @@ function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="sheet-footer"
-      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      className={cn("mt-auto flex flex-col gap-2 p-4 pb-[max(1rem,env(safe-area-inset-bottom))]", className)}
       {...props}
     />
   )


### PR DESCRIPTION
## Problem

`DrawerFooter` and `SheetFooter` are both used as the bottom action area of overlay primitives.

`DrawerFooter` already applies:

```tsx
pb-[max(1rem,env(safe-area-inset-bottom))]
```

while `SheetFooter` only applies:

```tsx
p-4
```

with no safe-area handling.

On devices with a home indicator (iPhone X and newer, as well as modern Android devices), bottom-aligned sheet actions can render too close to the system gesture area. This creates an inconsistency between the Sheet and Drawer primitives and may reduce usability for bottom-sheet experiences.

## Fix

Add:

```tsx
pb-[max(1rem,env(safe-area-inset-bottom))]
```

to `SheetFooter`, matching the existing implementation already used by `DrawerFooter`.

The `max()` expression preserves the current 1rem bottom padding on devices without a safe area while expanding appropriately on devices that require additional inset spacing.

## Why This Approach

This change follows an established pattern already present in the codebase rather than introducing a new spacing strategy.

Benefits:

* Consistent behavior between Sheet and Drawer primitives
* Better footer spacing on devices with home indicators
* No visual change on desktop or flat-bottom devices
* No behavioral changes
* Future-safe parity between related overlay components

## Scope

* 1 file changed
* 1 className updated
* No API changes
* No behavioral changes
* No visual regression expected on devices without safe-area insets

