### PR TITLE
fix(route-tabs): add tab semantics and selected state to route tab navigation

### DIFF
--- a/hushh-webapp/components/kai/layout/dashboard-route-tabs.tsx
+++ b/hushh-webapp/components/kai/layout/dashboard-route-tabs.tsx
@@ -361,12 +361,14 @@ export function DashboardRouteTabs({ embedded = false }: DashboardRouteTabsProps
 
   const tabsBody = (
     <>
-      <div className="relative grid grid-cols-3 items-center border-b border-border/70 px-1">
+      <div role="tablist" className="relative grid grid-cols-3 items-center border-b border-border/70 px-1">
         {KAI_ROUTE_TABS.map((tab) => (
           <button
             key={tab.id}
             type="button"
+            role="tab"
             onClick={() => handleTabChange(tab.id)}
+            aria-selected={tab.id === activeTab}
             className={cn(
               "relative z-[1] h-8 text-sm font-semibold transition-colors duration-200",
               tab.id === activeTab

--- a/hushh-webapp/components/ria/layout/ria-route-tabs.tsx
+++ b/hushh-webapp/components/ria/layout/ria-route-tabs.tsx
@@ -20,6 +20,7 @@ export function RiaRouteTabs({ embedded = false }: { embedded?: boolean }) {
 
   return (
     <div
+      role="tablist"
       className={cn(
         "w-full pb-2",
         embedded ? "pt-1" : "pt-2"
@@ -38,8 +39,11 @@ export function RiaRouteTabs({ embedded = false }: { embedded?: boolean }) {
             <button
               key={tab.id}
               type="button"
+              role="tab"
               data-voice-control-id={`ria_route_tab_${tab.id}`}
               onClick={() => router.push(tab.href)}
+              aria-selected={isActive}
+              aria-current={isActive ? "page" : undefined}
               className={cn(
                 "min-h-11 rounded-[18px] px-2 text-[12px] font-semibold tracking-tight transition-all",
                 isActive


### PR DESCRIPTION
## Summary

Adds ARIA tab semantics to the route tab navigation components used by Kai and RIA surfaces.

## Problem

Both route tab components visually function as tab navigation but do not expose complete tab semantics to assistive technologies.

### DashboardRouteTabs

* Uses buttons for navigation
* Exposes `aria-current="page"` on the active tab
* Missing `role="tablist"`
* Missing `role="tab"`
* Missing `aria-selected`

### RiaRouteTabs

* Uses buttons for navigation
* Missing `role="tablist"`
* Missing `role="tab"`
* Missing `aria-selected`
* Missing active-state semantics

Without these attributes, screen readers announce the controls as generic buttons rather than as a grouped tab interface with a selected state.

## Change

### DashboardRouteTabs

* Added `role="tablist"` to the tab container
* Added `role="tab"` to each tab button
* Added `aria-selected` based on active state
* Preserved existing `aria-current="page"`

### RiaRouteTabs

* Added `role="tablist"` to the wrapper containing the tab controls
* Added `role="tab"` to each tab button
* Added `aria-selected` based on active state
* Added `aria-current="page"` for the active tab

## Impact

* No visual changes
* No routing changes
* No behavioral changes
* Semantic accessibility improvement only
* Provides consistent tab semantics across Kai and RIA navigation surfaces

## Files Changed

* `hushh-webapp/components/kai/layout/dashboard-route-tabs.tsx`
* `hushh-webapp/components/ria/layout/ria-route-tabs.tsx`
