### PR TITLE
fix(vault): replace non-null assertion on match() with null-safe fallback in vault-web plugin

### DIFF
--- a/hushh-webapp/lib/capacitor/plugins/vault-web.ts
+++ b/hushh-webapp/lib/capacitor/plugins/vault-web.ts
@@ -47,7 +47,8 @@ export class HushhVaultWeb extends WebPlugin {
     let saltBytes: Uint8Array;
     if (options.salt) {
       saltBytes = new Uint8Array(
-        options.salt.match(/.{1,2}/g)!.map((byte) => parseInt(byte, 16)),
+        (options.salt.match(/.{1,2}/g) ?? []).map((byte) => parseInt(byte, 16))
+        ,
       );
     } else {
       saltBytes = crypto.getRandomValues(new Uint8Array(16));
@@ -97,7 +98,7 @@ export class HushhVaultWeb extends WebPlugin {
    */
   async encryptData(options: EncryptDataOptions): Promise<EncryptedPayload> {
     const keyBytes = new Uint8Array(
-      options.keyHex.match(/.{1,2}/g)!.map((byte) => parseInt(byte, 16)),
+      (options.keyHex.match(/.{1,2}/g) ?? []).map((byte) => parseInt(byte, 16)),
     );
 
     const key = await crypto.subtle.importKey(
@@ -139,7 +140,7 @@ export class HushhVaultWeb extends WebPlugin {
    */
   async decryptData(options: DecryptDataOptions): Promise<DecryptDataResult> {
     const keyBytes = new Uint8Array(
-      options.keyHex.match(/.{1,2}/g)!.map((byte) => parseInt(byte, 16)),
+      (options.keyHex.match(/.{1,2}/g) ?? []).map((byte) => parseInt(byte, 16)),
     );
 
     const key = await crypto.subtle.importKey(


### PR DESCRIPTION
## Summary
- what changed: Replaced three non-null assertions `!` on `.match()` results with null-safe `?? []` fallbacks in `hushh-webapp/lib/capacitor/plugins/vault-web.ts` — covering `deriveKey` (line 50), `encryptData` (line 100), and `decryptData` (line 142)
- why it changed: `String.prototype.match()` returns `null` when there are no matches. If `options.salt` or `options.keyHex` is an empty string, `.match()` returns `null` and the non-null assertion `!` forces a runtime crash: `TypeError: Cannot read properties of null (reading 'map')`. This crash occurs inside vault encryption and decryption — core security surfaces of the app.

## Attach point
`hushh-webapp/lib/capacitor/plugins/vault-web.ts` — Capacitor web plugin implementing vault crypto operations (deriveKey, encryptData, decryptData) used across the vault surface on web/iOS/Android.

## Contract changed
Runtime behavior: empty or unmatched salt/keyHex strings no longer crash with TypeError — they produce an empty Uint8Array instead, allowing the caller to handle the invalid input gracefully. No change to normal non-empty hex string behavior. No change to AES-256-GCM encryption logic, IV generation, or key derivation parameters.

## Tests run
```bash
cd hushh-webapp && npx tsc --noEmit
```
Passed locally. No type errors.

## Base/head status
Branch is current with main, mergeable, and DCO-signed. Targets integration/pr-train as required by repo base policy.

## Sensitive proof
Vault surface touched — deriveKey, encryptData, decryptData. Only null-safety of match() result changed. No cryptographic algorithm, key length, IV generation, or AES-GCM parameters modified. Rollback: revert by replacing `?? []` fallbacks with `!` non-null assertions on all three lines.

## Stack proof
Not applicable. Standalone fix across three methods in one file, no predecessor PR.

Fixes #2330