### PR TITLE
test(services): expand getErrorMessage to cover explicit null and circular references

### DIFF
--- a/hushh-webapp/__tests__/services/observability-log-redactor.test.ts
+++ b/hushh-webapp/__tests__/services/observability-log-redactor.test.ts
@@ -42,6 +42,26 @@ describe("observability log redactor", () => {
   });
 });
 
+describe("getErrorMessage stringification - boundary limits", () => {
+  it("handles explicit null without crashing", async () => {
+    const { getErrorMessage } = await import("@/lib/services/error-sanitizer");
+
+    expect(() => getErrorMessage(null)).not.toThrow();
+    expect(getErrorMessage(null)).toBe("null");
+  });
+
+  it("handles circular object inputs without JSON circular-structure panic", async () => {
+    const { getErrorMessage } = await import("@/lib/services/error-sanitizer");
+    const circularValue: { label: string; self?: unknown } = {
+      label: "circular-boundary",
+    };
+    circularValue.self = circularValue;
+
+    expect(() => getErrorMessage(circularValue)).not.toThrow();
+    expect(getErrorMessage(circularValue)).toBe("[object Object]");
+  });
+});
+
 // ── Parameter truncation mechanics ────────────────────────────────────────────
 //
 // redactObservabilityLog contains an implicit truncation mechanism:


### PR DESCRIPTION
# Description

Adds an isolated boundary test block for `getErrorMessage` stringification behavior in the observability log redactor test suite. The block covers explicit `null` input and a circular object reference without adding new top-level imports to the target file.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
  - [ ] Listed below:

- API / schema / type changes:
  - [x] None
  - [ ] Listed below:

- Cache keys touched:
  - [x] None
  - [ ] Listed below:

- Runtime DB data-plane changes:
  - [x] None
  - [ ] Listed below:

- World-model domain summary effects:
  - [x] None
  - [ ] Listed below:

- Mobile parity impacts:
  - [x] None
  - [ ] Listed below:

- Docs updated (exact files):
  - [x] None
  - [ ] Listed below:

- Top-level / devex / config / generated / ignore files touched:
  - [x] None
  - [ ] Listed below with the existing workflow they attach to:

- Trust boundary touched:
  - [ ] None
  - [x] Auth / consent / vault / PKM / finance / voice-action / KYC / schema / deploy / public ingress listed below:
    - Observability/error-message boundary tests only. No production behavior changed.

- Caller / proxy / backend pairing:
  - [x] Not applicable
  - [ ] Listed below with contract proof:

- Rollback or safe-failure behavior:
  - [ ] Not applicable
  - [x] Listed below:
    - Tests prove `getErrorMessage(null)` returns the standard string fallback and circular object inputs do not trigger JSON circular-structure panics.

- UI browser or Playwright proof:
  - [x] Not applicable
  - [ ] Route/spec/command listed below:

- Verification commands executed:
  - [ ] `./bin/hushh codex pre-pr`
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm run test -- __tests__/services/observability-log-redactor.test.ts`
  - [ ] `cd hushh-webapp && npm run test:ci`
  - [ ] `cd hushh-webapp && npm run lint`

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate:
  - Existing utility found at `hushh-webapp/lib/services/error-sanitizer.ts`; this PR only adds boundary tests.
- [x] This PR changes a current reachable app/backend/package/docs surface, or it is explicitly scoped as test/devex hygiene.
- [x] Reachable production attach point:
  - Test-only coverage for production `getErrorMessage`.
- [x] New tests import and exercise production code, not only mock components/helpers defined inside the test file.
- [x] New helpers/components/services are wired to an existing route, caller, package export, generated contract, or documented devex entrypoint.
- [x] Production surface proved:
  - `hushh-webapp/__tests__/services/observability-log-redactor.test.ts` dynamically imports `getErrorMessage` from production `@/lib/services/error-sanitizer` without adding top-level imports.
- [ ] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `integration/pr-train`.
  - Signed-off commit is present. GitHub-hosted checks/mergeability attach after PR creation.
- [ ] Maintainer edits are enabled, or the reason they cannot be enabled is listed here:
  - Fork PR state must be confirmed in GitHub after PR creation.
- [x] If this is one PR in a stack, the predecessor PR is linked here:
  - Integration train target: `integration/pr-train`.
- [x] If this responds to requested changes, the new commit or material explanation is described here:
  - Adds isolated null and circular-reference stringification coverage with no production code changes.

## 🛑 Tri-Flow Architecture Check

Every cross-platform feature must cover all affected layers or explicitly mark
the layer as not applicable with the reason.

- [x] **Web**: Vitest coverage for shared service utility.
- [x] **iOS**: Not applicable; test-only service utility coverage.
- [x] **Android**: Not applicable; test-only service utility coverage.

## 🧪 Testing

- [ ] Tested on Web (Chrome/Safari)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)
- [x] If generated files changed, they were regenerated by the canonical repo command listed above
  - No generated files changed.

## 📸 Screenshots / Video

Not applicable. No UI-visible route changed.

## 🛡️ Privacy & Consent

- [x] Does this change access user data?
  - No.
- [ ] If yes, have you implemented `checkConsentToken()`?
- [x] Sensitive surface touched: auth / consent / vault / PKM / finance / voice-action / KYC / schema / deploy / public ingress / none
  - observability/error-message boundary tests only.
- [x] Error path, rollback, or safe-failure behavior proved:
  - Tests prove explicit `null` and circular object inputs do not crash `getErrorMessage`.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed
  - No dependency changes.
