### PR TITLE
test(utils): cover trailing alphabetic characters during portfolio currency string parsing

### DIFF
--- a/hushh-webapp/__tests__/utils/portfolio-normalize.test.ts
+++ b/hushh-webapp/__tests__/utils/portfolio-normalize.test.ts
@@ -221,3 +221,34 @@ describe("portfolio normalizer — circular reference safety", () => {
     expect(consolidated.map((h) => h.symbol).sort()).toEqual(["AMZN", "META", "NVDA"]);
   });
 });
+
+describe("portfolio normalizer - mixed currency string boundaries", () => {
+  it("defaults dirty alpha-numeric currency strings to safe numeric floors without throwing", () => {
+    expect(() =>
+      consolidateHoldingsBySymbol([
+        {
+          symbol: "MIX",
+          name: "Mixed Currency Holding",
+          quantity: "1",
+          market_value: "1250.50INR",
+          cost_basis: "450.00USD",
+        },
+      ])
+    ).not.toThrow();
+
+    const consolidated = consolidateHoldingsBySymbol([
+      {
+        symbol: "MIX",
+        name: "Mixed Currency Holding",
+        quantity: "1",
+        market_value: "1250.50INR",
+        cost_basis: "450.00USD",
+      },
+    ]);
+
+    expect(consolidated).toHaveLength(1);
+    expect(consolidated[0].quantity).toBe(1);
+    expect(consolidated[0].market_value).toBe(0);
+    expect(consolidated[0].cost_basis).toBeUndefined();
+  });
+});


### PR DESCRIPTION
# Description

Adds isolated portfolio normalizer coverage for dirty currency strings with trailing alphabetic currency codes. The test verifies current production behavior: invalid numeric strings are handled without crashing, quantity parsing remains intact, `market_value` falls back to `0`, and optional invalid `cost_basis` remains unset.

## Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Not applicable; test-only change.

- UI browser or Playwright proof:
  - [x] Not applicable; non-UI unit test coverage only.

- Verification commands executed:
  - [x] `cd hushh-webapp && npm run test -- __tests__/utils/portfolio-normalize.test.ts`
  - [x] `cd hushh-webapp && npm run typecheck`

## Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate production behavior.
- [x] This PR is explicitly scoped as test/devex hygiene.
- [x] Reachable production attach point: `consolidateHoldingsBySymbol` from `hushh-webapp/src/lib/portfolio-normalize`.
- [x] New tests import and exercise production code, not only mock components/helpers defined inside the test file.
- [x] New helpers/components/services are not introduced.
- [x] Production surface proved by targeted unit coverage.
- [x] Commits are signed off.
- [x] Maintainer edits are enabled by fork PR defaults unless GitHub repository settings override them.

## Tri-Flow Architecture Check

- [x] **Web**: Not applicable; test-only utility coverage.
- [x] **iOS**: Not applicable.
- [x] **Android**: Not applicable.

## Testing

- [x] `cd hushh-webapp && npm run test -- __tests__/utils/portfolio-normalize.test.ts`
- [x] `cd hushh-webapp && npm run typecheck`
- [x] Commits are signed off (`git commit -s`)

## Screenshots / Video

Not applicable; no UI-visible changes.

## Privacy & Consent

- [x] Does this change access user data? No.
- [x] Sensitive surface touched: none.
- [x] Error path, rollback, or safe-failure behavior proved: test validates safe parser fallback behavior for dirty currency strings.

## Licensing

- [x] First-party changes remain Apache-2.0 compatible.
- [x] Third-party notice impact reviewed; no dependency changes.
