### PR TITLE
fix(portfolio-share-sheet): add aria-busy and aria-label to action buttons

### DIFF
--- a/hushh-webapp/components/kai/share/portfolio-share-sheet.tsx
+++ b/hushh-webapp/components/kai/share/portfolio-share-sheet.tsx
@@ -72,13 +72,15 @@ function ActionRow(props: {
       type="button"
       onClick={props.onClick}
       disabled={props.disabled}
+      aria-busy={props.busy}
+      aria-label={`${props.title}: ${props.description}`}
       className={cn(
         "w-full rounded-2xl border border-border/70 bg-background/65 p-4 text-left transition",
         "hover:bg-background/85 disabled:cursor-not-allowed disabled:opacity-60"
       )}
     >
       <div className="flex items-start gap-3">
-        <div className="mt-0.5 rounded-xl border border-border/60 bg-background/80 p-2 text-foreground">
+        <div aria-hidden="true" className="mt-0.5 rounded-xl border border-border/60 bg-background/80 p-2 text-foreground">
           {props.busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Icon className="h-4 w-4" />}
         </div>
         <div className="min-w-0">


### PR DESCRIPTION
## Summary

Improves accessibility for portfolio share sheet actions by exposing async loading state to assistive technologies and suppressing decorative icon content from the accessibility tree.

## Problem

`ActionRow` buttons in `PortfolioShareSheet` provide visual feedback when an async share action is running, but that state is not communicated to assistive technologies.

Additionally:

* Decorative icons and loading spinners are exposed to the accessibility tree.
* The button accessible name is derived implicitly from nested content rather than a controlled label.

## Changes

### `components/kai/share/portfolio-share-sheet.tsx`

* Add `aria-busy={props.busy}` to action buttons
* Add `aria-label={`${props.title}: ${props.description}`}` for a controlled accessible name
* Add `aria-hidden="true"` to the decorative icon container

## What was not changed

`SheetTitle` and `SheetDescription` are already present and correctly provide the sheet's accessible name and description through Radix composition. No changes were required.

## Accessibility Impact

* Async actions now expose busy state to assistive technologies
* Decorative Lucide icons and loading spinners are removed from the accessibility tree
* Button names are announced consistently and in a predictable order

## Scope

* 1 file changed
* Additive-only accessibility attributes
* No visual changes
* No behavioral changes
* No business logic changes

