### PR TITLE
fix(step-progress-bar): add accessible progress announcements

### DIFF
--- a/hushh-webapp/components/app-ui/step-progress-bar.tsx
+++ b/hushh-webapp/components/app-ui/step-progress-bar.tsx
@@ -73,9 +73,18 @@ export function StepProgressBar() {
         top: "var(--top-inset, 0px)",
       }}
     >
+      <span
+        role="status"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {displayProgress >= 100 ? "Page loaded." : ""}
+      </span>
       <Progress
         value={displayProgress}
         className="h-1 w-full rounded-none bg-transparent"
+        aria-label="Page loading"
+        aria-valuetext={`${Math.round(displayProgress)}%`}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

Improves accessibility for `StepProgressBar` by providing a named progress indicator, human-readable progress values, and a completion announcement for assistive technology users.

## Problem

`StepProgressBar` renders a progress indicator but does not provide:

* An accessible label describing what is loading
* A human-readable progress value
* A completion announcement for assistive technologies that do not treat `role="progressbar"` as a live region

As a result, screen reader users may hear an unnamed progress control or receive no indication when loading completes.

## Changes

### `components/app-ui/step-progress-bar.tsx`

* Add `aria-label="Page loading"` to the progress bar
* Add `aria-valuetext` using a rounded percentage value
* Add an `sr-only` status region that announces `"Page loaded."` once when progress reaches 100%

## What was not changed

`components/ui/progress.tsx` was intentionally left unchanged.

`ProgressPrimitive.Root` already provides:

* `role="progressbar"`
* `aria-valuenow`
* `aria-valuemin`
* `aria-valuemax`

and forwards additional ARIA props through `{...props}`.

## Accessibility Impact

* Fixes unnamed progressbar semantics
* Provides human-readable progress values
* Announces completion for assistive technologies that do not automatically announce progressbar completion
* Avoids noisy incremental announcements by only announcing completion

## Scope

* 1 file changed
* Additive accessibility attributes only
* No visual changes
* No animation changes
* No timing changes
* No behavioral changes
