### PR TITLE
fix(dashboard-nav): add aria-label and aria-current to navigation landmarks

### DIFF
--- a/hushh-webapp/components/dashboard/app-sidebar.tsx
+++ b/hushh-webapp/components/dashboard/app-sidebar.tsx
@@ -34,7 +34,7 @@ export function AppSidebar() {
   const pendingCount = useConsentPendingSummaryCount();
 
   return (
-    <Sidebar>
+    <Sidebar aria-label="Application navigation">
       <SidebarHeader className="h-16 flex items-center justify-start border-b px-4">
         <div className="flex items-center gap-2">
           <span className="text-2xl">🤫</span>

--- a/hushh-webapp/components/dashboard/domain-nav.tsx
+++ b/hushh-webapp/components/dashboard/domain-nav.tsx
@@ -22,7 +22,7 @@ export function DomainNav() {
   const pathname = usePathname();
 
   return (
-    <nav className="space-y-1">
+    <nav className="space-y-1" aria-label="Domain navigation">
       {domains.map((domain) => {
         const Lucide = domain.icon;
         const isActive = pathname?.startsWith(domain.href);
@@ -31,6 +31,7 @@ export function DomainNav() {
           <Link
             key={domain.name}
             href={domain.href}
+            aria-current={isActive ? "page" : undefined}
             className={cn(
               "flex items-center justify-between px-3 py-2 rounded-lg text-sm font-medium transition-colors",
               isActive


### PR DESCRIPTION
## Summary

Dashboard navigation exposed active state internally but did not communicate it to assistive technologies, and navigation landmarks lacked explicit labels.

## Changes

### components/dashboard/domain-nav.tsx

* Add `aria-label="Domain navigation"` to the navigation landmark
* Add `aria-current={isActive ? "page" : undefined}` to active links

The active state was already computed via `isActive`; this change simply forwards that information to assistive technologies.

### components/dashboard/app-sidebar.tsx

* Add `aria-label="Application navigation"` to the sidebar navigation region

`Sidebar` already forwards props to its underlying element, so this is an additive accessibility improvement with no behavior change.

## Accessibility Impact

* Provides distinguishable navigation landmarks for screen reader landmark navigation
* Announces the currently active page using the standard `aria-current="page"` pattern
* Improves navigation context without affecting visual presentation

## Scope

* 2 files changed
* Accessibility-only attributes
* No visual changes
* No routing changes
* No behavioral changes
* Additive-only modifications
