### PR TITLE
test(observability): confirm log redactor handles Windows style multi-line splits cleanly

### DIFF
--- a/hushh-webapp/__tests__/services/observability-log-redactor.test.ts
+++ b/hushh-webapp/__tests__/services/observability-log-redactor.test.ts
@@ -247,4 +247,16 @@ describe("observability log redactor — tab-separated value handling", () => {
     expect(output).toContain("profile");
     expect(output).toContain("data");
   });
+
+  it("redacts a vault token before Windows carriage return boundaries without corrupting the next line", () => {
+    const logLine = "vault_crlf_test_key_004\r\nstatus=complete";
+
+    const output = redactObservabilityLog(logLine);
+
+    expect(output).toBe("[REDACTED_VAULT_KEY]\r\nstatus=complete");
+    expect(output).not.toContain("vault_crlf_test_key_004");
+    expect(output).toContain("[REDACTED_VAULT_KEY]");
+    expect(output).toContain("\r\nstatus=complete");
+    expect(output.split("\r\n")[1]).toBe("status=complete");
+  });
 });


### PR DESCRIPTION
# Description

Adds isolated Windows CRLF boundary coverage for the observability log redactor. The new test verifies that a vault-style sensitive token before `\r\n` is redacted without corrupting the non-sensitive line that follows.

## Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Not applicable; test-only change.

- UI browser or Playwright proof:
  - [x] Not applicable; non-UI unit test coverage only.

- Verification commands executed:
  - [x] `git fetch upstream`
  - [x] `git rebase --autostash upstream/integration/pr-train`
  - [x] `cd hushh-webapp && npm run test -- __tests__/services/observability-log-redactor.test.ts`
  - [x] `cd hushh-webapp && npm run typecheck`

## Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate production behavior.
- [x] This PR is explicitly scoped as test/devex hygiene.
- [x] Reachable production attach point: `redactObservabilityLog` from `hushh-webapp/lib/observability/log-redactor`.
- [x] New tests import and exercise production code, not only mock components/helpers defined inside the test file.
- [x] New helpers/components/services are not introduced.
- [x] Production surface proved by targeted unit coverage.
- [x] Commits are signed off.
- [x] Maintainer edits are enabled by fork PR defaults unless GitHub repository settings override them.

## Tri-Flow Architecture Check

- [x] **Web**: Not applicable; test-only utility coverage.
- [x] **iOS**: Not applicable.
- [x] **Android**: Not applicable.

## Testing

- [x] `cd hushh-webapp && npm run test -- __tests__/services/observability-log-redactor.test.ts`
- [x] `cd hushh-webapp && npm run typecheck`
- [x] Commits are signed off (`git commit -s`)

## Screenshots / Video

Not applicable; no UI-visible changes.

## Privacy & Consent

- [x] Does this change access user data? No.
- [x] Sensitive surface touched: none.
- [x] Error path, rollback, or safe-failure behavior proved: test validates CRLF boundary handling while preserving the following non-sensitive line.

## Licensing

- [x] First-party changes remain Apache-2.0 compatible.
- [x] Third-party notice impact reviewed; no dependency changes.
