### PR TITLE
fix(onboarding-carousel): add accessible labels for carousel and slides

### DIFF
--- a/hushh-webapp/components/onboarding/PreviewCarouselStep.tsx
+++ b/hushh-webapp/components/onboarding/PreviewCarouselStep.tsx
@@ -218,11 +218,13 @@ export function PreviewCarouselStep({ onContinue }: { onContinue: () => void }) 
               opts={{ align: "center", containScroll: "trimSnaps" }}
               setApi={setApi}
               className="w-full"
+              aria-label="Onboarding feature preview"
             >
               <CarouselContent className="items-center -ml-0">
                 {slides.map((slide, idx) => (
                   <CarouselItem
                     key={idx}
+                    aria-label={`Slide ${idx + 1} of ${slides.length}`}
                     aria-current={idx === selectedIndex ? "step" : undefined}
                     className="basis-full pl-0 flex items-center justify-center"
                   >


### PR DESCRIPTION
## Summary

Adds accessible labels to the onboarding feature carousel and its slides to improve screen reader navigation and slide identification.

## Changes

### `components/onboarding/PreviewCarouselStep.tsx`

* Add `aria-label="Onboarding feature preview"` to the carousel container
* Add `aria-label="Slide N of M"` to each carousel slide
* Preserve existing `aria-current` behavior for the active slide

## Accessibility Impact

The carousel already exposes carousel and slide semantics through the shared carousel components. This change adds explicit labels so assistive technologies can identify:

* The purpose of the carousel region
* The position of each slide within the sequence

This improves navigation and orientation for screen reader users without changing visual presentation or interaction behavior.

## Scope

* 1 file changed
* Accessibility-only attributes
* No logic changes
* No state changes
* No visual changes
* No behavior changes
