### PR TITLE
fix(consent-timeline): add selection state and semantic time elements

### DIFF
--- a/hushh-webapp/components/consent/consent-audit-timeline.tsx
+++ b/hushh-webapp/components/consent/consent-audit-timeline.tsx
@@ -73,6 +73,14 @@ function formatEventDate(entry: ConsentCenterEntry) {
   return date.toLocaleString();
 }
 
+function getEventIsoDate(entry: ConsentCenterEntry): string | null {
+  const value = entry.issued_at || entry.expires_at;
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
 function entryKey(entry: ConsentCenterEntry, index: number) {
   return [
     entry.kind,
@@ -163,11 +171,14 @@ export function ConsentAuditTimeline({
             const type = resolveEventType(entry);
             const selected =
               selectedId === entry.id || selectedId === entry.request_id;
+            const isoDate = getEventIsoDate(entry);
             return (
               <button
                 key={entryKey(entry, index)}
                 type="button"
                 onClick={() => onSelect(entry)}
+                aria-pressed={selected}
+                aria-label={`${resolveCounterpartLabel(entry)}, ${type} consent, ${formatEventDate(entry)}`}
                 className={cn(
                   "group relative w-full rounded-[var(--app-card-radius-compact)] border px-4 py-3 text-left transition-colors",
                   selected
@@ -186,7 +197,11 @@ export function ConsentAuditTimeline({
                           {resolveCounterpartLabel(entry)}
                         </p>
                         <p className="text-xs text-muted-foreground">
-                          {formatEventDate(entry)}
+                          {isoDate ? (
+                            <time dateTime={isoDate}>{formatEventDate(entry)}</time>
+                          ) : (
+                            formatEventDate(entry)
+                          )}
                         </p>
                       </div>
                       <Badge className={cn("capitalize", TYPE_STYLES[type])}>


### PR DESCRIPTION
## Summary

Consent timeline entries communicated selection visually but did not expose selection state to assistive technology. Dates were rendered as plain text without semantic time markup.

## Changes

### `components/consent/consent-audit-timeline.tsx`

* Add `getEventIsoDate(entry)` helper that mirrors existing `formatEventDate()` logic and returns an ISO timestamp when available
* Add `isoDate` extraction within the timeline entry mapping logic to avoid repeated date calculations
* Add `aria-pressed={selected}` to timeline entry buttons so assistive technologies can identify the currently selected entry
* Add an explicit `aria-label` combining counterpart, consent type, and formatted date for a predictable reading order
* Wrap rendered timestamps in `<time dateTime={isoDate}>` when a valid ISO timestamp is available

## What Was Not Changed

* Existing filter button accessibility (`aria-pressed`) remains unchanged
* Existing filter wrapper labeling remains unchanged
* Existing heading structure remains unchanged
* Visual styling and interaction behavior remain unchanged

## Accessibility Impact

* Exposes selection state to assistive technologies through `aria-pressed`
* Improves announcement consistency through explicit button labels
* Adds semantic machine-readable timestamps through the HTML `<time>` element
* Preserves existing interaction patterns and visual appearance

## Scope

* 1 file changed
* Accessibility-only enhancements
* No routing changes
* No state-management changes
* No visual changes
* No behavior changes
