### PR TITLE
pr-governance: agent-authored patches default, no-unattended invariant, mentor comms, evolution log + harvest reconciliation

### DIFF
--- a/.codex/skills/pr-governance-review/references/comment-and-report-contract.md
+++ b/.codex/skills/pr-governance-review/references/comment-and-report-contract.md
@@ -2,6 +2,18 @@
 
 Use this reference for GitHub write actions, post-merge closeouts, live report updates, and contributor-impact updates.
 
+## Communication Personality
+
+Every contributor-facing write uses the Hussh mentor voice defined in
+`comment-templates-and-reporting.md` ("Communication Personality"): lead with
+specific genuine appreciation, state the decision unambiguously, explain the why
+from linked repo truth, give a concrete achievable next step, encourage
+continued contribution, be firm-but-kind on non-negotiable boundaries, never
+leak internal governance, and credit fairly. The headings below are fixed; this
+voice governs how the prose inside them reads. Contributors should always finish
+a comment knowing what happened, why, and exactly what a great next PR looks
+like.
+
 ## GitHub Comment Rules
 
 1. First line must be a markdown headline: `## <Decision>: <contract or outcome>`.

--- a/.codex/skills/pr-governance-review/references/comment-templates-and-reporting.md
+++ b/.codex/skills/pr-governance-review/references/comment-templates-and-reporting.md
@@ -3,6 +3,43 @@
 Use this reference after `comment-and-report-contract.md` selects the public
 write lane.
 
+## Communication Personality (applies to every contributor-facing write)
+
+Hussh PR governance speaks to contributors as a mentor, not a gatekeeper. Every
+public comment — merge, changes-requested, or close — must leave the contributor
+knowing exactly what happened, why, and what a great next step looks like. Hold
+this voice on every record:
+
+1. `Lead with genuine, specific appreciation.` Name the real value in their work
+   ("the temporal-expiry guard is exactly the right instinct"), not a generic
+   "thanks for the PR". If nothing is salvageable, still respect the effort.
+2. `Be unambiguous about the decision.` The contributor must never wonder whether
+   they are merged, need to act, or are closed. State it plainly in the heading
+   and the first line.
+3. `Explain the why from repo truth, not preference.` Tie the blocker to a
+   concrete contract, file, trust boundary, or test — link it — so the feedback
+   teaches the codebase, not just this PR.
+4. `Make the next step concrete and achievable.` Give the smallest real path to
+   merge: the exact file/contract to attach to, the guard to add, the test to
+   evolve. Prefer "do X on file Y and assert Z" over "narrow the scope".
+5. `Encourage continuation.` End change-requests and closures with a sincere
+   invitation to keep contributing and, where true, point to which of their
+   other PRs are landing well. Contributors should leave motivated, not deflated.
+6. `Be honest and firm without being harsh.` When a boundary (regulated advice,
+   consent, vault, security) is non-negotiable, say so clearly and kindly, and
+   explain the principle so they internalize it for next time. Repeated
+   submissions of the same boundary violation get firmer clarity, never sarcasm.
+7. `Never leak internal governance.` No lane names, queue mechanics, scanner
+   findings, CI dumps, or maintainer sequencing in public comments — translate
+   them into plain contributor-facing language.
+8. `Credit fairly.` When work is harvested or co-authored, say so and link the
+   landing commit/PR; never let a contributor wonder if their work was used.
+
+The headings and required sections below are fixed; this personality governs HOW
+the prose inside them reads. Direction/Why-it-matters sections carry the warmth
+and the teaching; Blocker/Path-To-Merge/Proof sections carry the precise,
+actionable engineering guidance.
+
 ## Post-Merge Without Maintainer Patch
 
 ```markdown

--- a/.codex/skills/pr-governance-review/references/governance-evolution.md
+++ b/.codex/skills/pr-governance-review/references/governance-evolution.md
@@ -1,0 +1,51 @@
+# PR Governance Evolution
+
+This skill matured through operator-directed iterations. The current operating
+model is the sum of these; honor all of them:
+
+1. `Two-stage merge topology.` Contributor PRs merge ONLY to
+   `integration/pr-train` (never `main`). `main` is updated solely by a
+   maintainer-only `integration/pr-train -> main` promotion PR, which agents
+   never create or merge autonomously (`config/ci-governance.json` →
+   `branch_flow` / `main_allowed_head_branches` is the source of truth). Every
+   "merge"/"queue" action this skill performs is a train-level action.
+2. `No invented gates.` There is NO "Autonomy Confidence Gate / HIGH-band /
+   cap-of-8" model — that was a launcher invention and is retired. Behavior is
+   governed only by the files in this skill folder.
+3. `Drive to terminal, every cycle.` A pass is not done after a green cohort.
+   Every actionable PR must reach a terminal decision (see No-Unattended
+   Invariant in `pr-train-write-contract.md`). Compute "unattended" from the
+   presence of a current maintainer record, NOT `reviewDecision` alone — a later
+   APPROVED/DISMISSED supersedes an earlier CHANGES_REQUESTED.
+4. `Whole-backlog, oldest-first, with caching.` Scan the full open inventory
+   (hundreds of PRs), deep-review oldest-first, reuse the live report for 12h,
+   and advance via `--exclude-prs-file` tranche refill. Never cache merge-safety
+   verdicts; Exact-Head Queue Safety re-reads live state before every write.
+5. `Repass detection is mandatory and batched.` GitHub's UI cannot show whether
+   a CHANGES_REQUESTED PR was addressed; compute it (latest contributor activity
+   vs latest maintainer changes-requested review), batched via aliased GraphQL.
+6. `Agent-authored maintainer patches are the DEFAULT`, not a human handoff, per
+   the Agent-Authored Maintainer Patch Authority gate. Actively strengthen the
+   change; test evolution counts as valid proof. Only fall back to
+   `request_changes` when a safe patch cannot be derived from repo evidence.
+7. `Diff over path.` Sensitivity is judged from the actual diff, not the file
+   path. A benign/security-positive change on a sensitive path may merge; a
+   self-mock test or a hidden `config/ci-governance.json` merge-authority edit
+   must not.
+8. `Mentor communication personality` governs every contributor-facing write
+   (see `comment-templates-and-reporting.md`): specific appreciation,
+   unambiguous decision, repo-truth why, concrete next step, encouragement,
+   firm-but-kind on non-negotiable boundaries, no governance leakage, fair
+   credit.
+9. `Attribution integrity.` A harvest is not complete on a temporary-branch
+   commit; verify content AND co-author credit on a durable ref before closing
+   source PRs. If credit was lost, acknowledge it and offer a transparent
+   co-authored replay before closing (see the harvest ledger's Lesson Recorded).
+10. `Automation lives in scripts/automation/.` `pr_train_autodrive.py` (daily
+    drive-to-terminal) and `maintainer_patch_campaign.py` (trust-boundary patch
+    drain) are the executable arms; the daily train cron and the patch campaign
+    cron invoke them. Keep them idempotent + resumable for the 600s cron idle
+    limit.
+
+When operator direction changes the model again, update this list AND the
+specific reference file so the evolution stays self-describing.

--- a/.codex/skills/pr-governance-review/references/maintainer-harvest-attribution-ledger.md
+++ b/.codex/skills/pr-governance-review/references/maintainer-harvest-attribution-ledger.md
@@ -48,33 +48,52 @@ Attribution status:
 
 ## 2026-05-30: Author-Scoped PR Governance Harvest
 
-Maintainer landing commit:
+Maintainer landing commit (ORIGINAL, now superseded):
 `72c464be84a14f73c2872d1028edf2b8433b85a3`
 
 Landing status:
 
-- The commit is on `kushaltrivedi/feat/agent-kai-revamp`.
-- Native GitHub contributor credit remains pending until this co-authored
-  landing commit reaches `main`.
-- Source PRs remain open with `CHANGES_REQUESTED`; do not close them as
-  superseded until the landing commit is merged to `main` and linked from the
-  source PR records.
+- RECONCILED 2026-06-08: the original co-authored landing commit
+  `72c464be` and its branch `kushaltrivedi/feat/agent-kai-revamp` no longer
+  exist (branch deleted during cleanup; commit is on neither `main` nor
+  `integration/pr-train`). The accepted value nevertheless SHIPPED on
+  `integration/pr-train` under different, non-co-authored commits (verified by
+  content match — see per-PR landing files below).
+- Source PRs #1029, #1031, #1066 were CLOSED 2026-06-08 as "your work shipped"
+  with a contributor-facing note acknowledging the lost GitHub-visible credit
+  and offering a transparent co-authored replay commit on request.
 
 Attribution status:
 
-- The landing commit contains valid co-author trailers for `Ayush04-C` and
-  `DamriaNeelesh`.
+- The original `72c464be` (which DID carry valid `Co-authored-by:` trailers for
+  `Ayush04-C` and `DamriaNeelesh`) is gone, so GitHub-visible co-author credit
+  for the Ayush04-C frontend items was LOST on the surviving train commits.
 - Internal impact credit remains attached to the source PRs.
-- If a source PR receives a fresh contributor update before the landing commit
-  reaches `main`, re-enter that PR through a repass train and prefer direct
-  contributor PR merge when safe.
+- Remediation path if/when requested by the contributor: land a transparent,
+  non-rewrite co-authored replay/supplemental commit per this ledger's
+  follow-up-PR rule; do NOT rewrite existing `main`/train history for retroactive
+  credit.
 
-| Source PR | Contributor | Accepted Value |
-| --- | --- | --- |
-| [PR #1029](https://github.com/hushh-labs/hushh-research/pull/1029) | `Ayush04-C` | Visual not-found recovery on the canonical app route. |
-| [PR #1031](https://github.com/hushh-labs/hushh-research/pull/1031) | `Ayush04-C` | Motion-safe loader feedback and ARIA status polish. |
-| [PR #1066](https://github.com/hushh-labs/hushh-research/pull/1066) | `Ayush04-C` | Narrowed root metadata/SEO hardening. |
-| [PR #1667](https://github.com/hushh-labs/hushh-research/pull/1667) | `DamriaNeelesh` | One Location profile entry point. |
+| Source PR | Contributor | Accepted Value | Verified landing on train |
+| --- | --- | --- | --- |
+| [PR #1029](https://github.com/hushh-labs/hushh-research/pull/1029) | `Ayush04-C` | Visual not-found recovery on the canonical app route. | `hushh-webapp/app/not-found.tsx` (Morphy glass-card recovery page) — CLOSED |
+| [PR #1031](https://github.com/hushh-labs/hushh-research/pull/1031) | `Ayush04-C` | Motion-safe loader feedback and ARIA status polish. | `hushh-webapp/components/app-ui/hushh-loader.tsx` (`role=status`/`aria-live`) — CLOSED |
+| [PR #1066](https://github.com/hushh-labs/hushh-research/pull/1066) | `Ayush04-C` | Narrowed root metadata/SEO hardening. | `hushh-webapp/app/layout.tsx` (full Next `Metadata` export) — CLOSED |
+| [PR #1667](https://github.com/hushh-labs/hushh-research/pull/1667) | `DamriaNeelesh` | One Location profile entry point. | pending verification |
+
+### Lesson Recorded (process evolution)
+
+A harvest is not "done" when staged on a temporary branch. When that branch is
+deleted before promotion, the named landing commit and its co-author credit
+vanish even though the content ships. Going forward: (1) never record a harvest
+as complete against a temporary-branch commit alone; verify the co-authored
+commit on a durable ref; (2) when closing harvested source PRs, re-verify the
+content AND credit on the current `integration/pr-train` head, not the ledger's
+recorded commit; (3) if credit was lost, acknowledge it to the contributor and
+offer the replay path before closing. This rule is now part of the
+Attribution Gate behavior.
+
+
 
 ## 2026-05-14: PR #1013 Async PR Train Patch Wave One
 

--- a/.codex/skills/pr-governance-review/references/pr-train-write-contract.md
+++ b/.codex/skills/pr-governance-review/references/pr-train-write-contract.md
@@ -130,6 +130,76 @@ If generated reports still emit `patch_then_merge`, treat it as
 Choosing `maintainer_harvest` over `maintainer_patch_then_merge` requires an
 explicit reason in the dossier.
 
+## Agent-Authored Maintainer Patch Authority
+
+Agent-authored maintainer patches are the DEFAULT execution path for
+`maintainer_patch_then_merge`, not an exception. Under operator standing
+approval the coding agent writes the patch itself and does NOT ask the operator
+per-PR. Hand-write the patch whenever the gate below is satisfied; only fall
+back to `request_changes` when the gate genuinely cannot be met from repo
+evidence (see trust-boundary rule). The maintainer patch is authored by the
+agent when ALL of the following hold:
+
+1. `aligned_direction`: the contributor's intent matches the north-star and a
+   real reachable app/backend/package/runtime use case.
+2. `net_improvement`: the patched head is measurably better than both the
+   contributor head AND current `integration/pr-train` on at least one of
+   security, correctness, trust-boundary integrity, or contributor clarity, and
+   worse on none. Increasing security/correctness by repo standards is the
+   whole point of the patch — a patch that only reformats or only silences a
+   gate is not allowed. The agent SHOULD actively strengthen the change beyond
+   the contributor's version when repo standards call for it (tighter
+   validation, DB-backed enforcement, correct error surface, missing guard).
+3. `bounded_to_attach_point`: edits stay on the canonical attach point and its
+   direct caller/contract/test; no new parallel root, no scope sprawl, no
+   unrelated files.
+4. `intent_preserved`: the change does not alter product or policy intent; it
+   makes the contributor's stated intent safe and landable.
+5. `proof`: a test that exercises the patched behavior passes locally, and the
+   required `CI Status Gate` is green at the patched head before queueing. Proof
+   may be (a) an existing test that already covers the surface, (b) the
+   contributor's test, or (c) a test the agent ADDS or EVOLVES as part of the
+   patch. Evolving an existing test to assert the strengthened behavior counts
+   as valid proof and is encouraged — a patch that changes behavior without a
+   test that would fail on regression is not done. When the agent tightens a
+   contract, it must also update/extend the test so the test logically tracks
+   the new behavior (the test evolving WITH the code is correct, not a red flag).
+6. `attribution`: the landing commit preserves `Co-authored-by:` for the
+   original contributor when their code or tests are materially reused.
+7. `mechanics`: prefer pushing to the contributor branch when
+   `maintainerCanModify` is true; otherwise use a short-lived
+   `temp/pr-<n>-patch` branch and delete it after.
+
+Trust-boundary surfaces (auth, consent, vault, PKM, voice, finance, KYC,
+session, migration, generated contracts, CI/merge authority) get the SAME
+authority but a HIGHER bar: the patch must independently strengthen — never
+weaken or merely preserve-while-touching — the DB-backed enforcement, scope,
+caller-credential shape, or data-boundary, and the security reasoning must be
+written into the landing record. When the safe patch is not obvious from repo
+evidence, downgrade to `request_changes` with the researched blocker rather than
+guessing on a trust boundary.
+
+The ABSOLUTE FORBIDDEN list still binds: never merge directly to `main`, never
+deploy, never handle secrets, never change product/policy intent, never create
+the `integration/pr-train -> main` promotion PR. Agent-authored patches are a
+contributor-branch / pr-train operation only; the merge queue (CI + auto-eject)
+is the backstop against a bad patch reaching `main`.
+
+## No-Unattended Invariant
+
+Every governance cycle must end with ZERO unattended actionable PRs. "Unattended"
+means an open non-draft contributor PR on the train with no current maintainer
+decision of any kind. Every such PR must terminate the cycle in exactly one
+decision state: `merge_now` (queued), `maintainer_patch_then_merge` (patched +
+queued), `maintainer_harvest`, `request_changes` (standardized record),
+`close` (duplicate/superseded), or `dormant_current_hold` (a current maintainer
+record already applies and no new contributor activity). Self-authored
+maintainer PRs (GitHub blocks self-review) are the only allowed exception and
+must be listed explicitly. Compute "unattended" from the presence of a current
+maintainer review record, NOT from `reviewDecision` alone — a later
+APPROVED/DISMISSED state can supersede an earlier `CHANGES_REQUESTED` while the
+PR remains decided/handled.
+
 Before requesting changes, evaluate whether the useful contribution can be
 harvested or patched into a current canonical surface.
 


### PR DESCRIPTION
## What Landed

Codifies the PR-governance operating model that evolved through this maintainer cycle, scoped entirely to `.codex/skills/pr-governance-review/` (no product code):

- **Agent-Authored Maintainer Patch Authority** (`pr-train-write-contract.md`) — agent-written maintainer patches are now the DEFAULT path for `maintainer_patch_then_merge` (not a human handoff). 7-condition gate; the agent actively strengthens the change; **test evolution counts as valid proof**. Trust-boundary surfaces keep a higher bar; fall back to `request_changes` only when a safe patch can't be derived from repo evidence.
- **No-Unattended Invariant** — every cycle ends with zero undecided contributor PRs, computed from the presence of a current maintainer record (not `reviewDecision` alone, since a later APPROVED/DISMISSED supersedes an earlier CHANGES_REQUESTED).
- **Communication Personality** (`comment-templates-and-reporting.md` + `comment-and-report-contract.md`) — mentor voice on every contributor-facing write: specific appreciation, unambiguous decision, repo-truth why, concrete next step, encouragement, firm-but-kind on non-negotiable boundaries, no governance leakage, fair credit.
- **Evolution Of This Governance** (`SKILL.md`) — a 10-point self-describing record of the current operating model (two-stage merge topology, drive-to-terminal, whole-backlog oldest-first + caching, batched repass detection, diff-over-path, automation arms, etc.).
- **Harvest reconciliation** (`maintainer-harvest-attribution-ledger.md`) — corrected the 2026-05-30 Ayush04-C harvest: the recorded landing commit/branch were deleted, but the content shipped on the train uncredited; added the per-PR landing verification and a Lesson Recorded on attribution integrity.

## Why It Matters

Makes the governance model durable, branch-safe, and self-describing so every daily train / patch campaign run reads one consistent source of truth. Targets `integration/pr-train`; promotion to `main` follows the normal train→main promotion path.