### PR TITLE
fix(ui): resolve hydration mismatch in carousel preferences query

### DIFF
--- a/hushh-webapp/components/ui/carousel.tsx
+++ b/hushh-webapp/components/ui/carousel.tsx
@@ -21,6 +21,24 @@ type CarouselProps = {
   setApi?: (api: CarouselApi) => void
 }
 
+function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = React.useState(false);
+
+  React.useEffect(() => {
+    const mediaQuery = window.matchMedia(query);
+    setMatches(mediaQuery.matches);
+
+    const handler = (event: MediaQueryListEvent) => {
+      setMatches(event.matches);
+    };
+
+    mediaQuery.addEventListener("change", handler);
+    return () => mediaQuery.removeEventListener("change", handler);
+  }, [query]);
+
+  return matches;
+}
+
 type CarouselContextProps = {
   carouselRef: ReturnType<typeof useEmblaCarousel>[0]
   api: ReturnType<typeof useEmblaCarousel>[1]
@@ -51,9 +69,7 @@ function Carousel({
   children,
   ...props
 }: React.ComponentProps<"div"> & CarouselProps) {
-  const prefersReducedMotion =
-  typeof window !== "undefined" &&
-  window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  const prefersReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
 
   const [carouselRef, api] = useEmblaCarousel(
     {


### PR DESCRIPTION
# Description
Resolves a React hydration mismatch in the `Carousel` primitive caused by synchronous `window.matchMedia` evaluation during SSR/hydration. Implemented a robust `useMediaQuery` hook directly within the component to defer browser API access to the layout phase, ensuring the server HTML correctly matches the initial client render while adding dynamic reactivity to OS preference changes.

## 📌 Core Impact
- [x] **Routes Touched:** 
  - `components/ui/carousel.tsx` (Single-file change to avoid cross-boundary automation blocks)
- [x] **Architecture:** UI / React Hooks / Accessibility
- [x] **Verification:** Verified commit message length (<72 chars).

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (App UI).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS**: N/A
- [ ] **Android**: N/A

## 🧪 Testing & Privacy
- [x] Tested on Web
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible