### PR TITLE
fix(a11y): add explicit htmlFor associations to implicitly wrapped labels

### DIFF
--- a/hushh-webapp/components/kai/plaid/plaid-brokerage-sections.tsx
+++ b/hushh-webapp/components/kai/plaid/plaid-brokerage-sections.tsx
@@ -725,9 +725,9 @@ export function PlaidFundingTransfersSection({
           {isFundingPanelOpen ? (
             <div className="rounded-[20px] border border-border/60 bg-background/60 p-4">
               <div className="grid gap-3 sm:grid-cols-2">
-                <label className="space-y-1 text-xs text-muted-foreground">
+                <label htmlFor="plaid-brokerage-input-1" className="space-y-1 text-xs text-muted-foreground">
                   Funding account
-                  <select
+                  <select id="plaid-brokerage-input-1"
                     className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground"
                     value={selectedFundingAccountId}
                     onChange={(event) => {
@@ -750,9 +750,9 @@ export function PlaidFundingTransfersSection({
                 </label>
 
                 {brokerageAccountOptions.length > 0 ? (
-                  <label className="space-y-1 text-xs text-muted-foreground">
+                  <label htmlFor="plaid-brokerage-input-2" className="space-y-1 text-xs text-muted-foreground">
                     Alpaca brokerage destination
-                    <select
+                    <select id="plaid-brokerage-input-2"
                       className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground"
                       value={selectedBrokerageAccountId}
                       onChange={(event) => setSelectedBrokerageAccountId(event.target.value)}
@@ -784,9 +784,9 @@ export function PlaidFundingTransfersSection({
                   </div>
                 )}
 
-                <label className="space-y-1 text-xs text-muted-foreground">
+                <label htmlFor="plaid-brokerage-input-3" className="space-y-1 text-xs text-muted-foreground">
                   Transfer direction
-                  <select
+                  <select id="plaid-brokerage-input-3"
                     className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground"
                     value={transferDirection}
                     onChange={(event) =>
@@ -798,9 +798,9 @@ export function PlaidFundingTransfersSection({
                   </select>
                 </label>
 
-                <label className="space-y-1 text-xs text-muted-foreground">
+                <label htmlFor="plaid-brokerage-input-4" className="space-y-1 text-xs text-muted-foreground">
                   Amount (USD)
-                  <input
+                  <input id="plaid-brokerage-input-4"
                     className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground"
                     value={amountInput}
                     onChange={(event) => setAmountInput(event.target.value)}
@@ -822,9 +822,9 @@ export function PlaidFundingTransfersSection({
                   </div>
                 </label>
 
-                <label className="space-y-1 text-xs text-muted-foreground">
+                <label htmlFor="plaid-brokerage-input-5" className="space-y-1 text-xs text-muted-foreground">
                   Legal name
-                  <input
+                  <input id="plaid-brokerage-input-5"
                     className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground"
                     value={legalNameInput}
                     onChange={(event) => setLegalNameInput(event.target.value)}
@@ -983,27 +983,27 @@ export function PlaidFundingTransfersSection({
             Search transfer records and create a manual escalation with notes for operations.
           </p>
           <div className="mt-3 grid gap-3 sm:grid-cols-2">
-            <label className="space-y-1 text-xs text-muted-foreground">
+            <label htmlFor="plaid-brokerage-input-6" className="space-y-1 text-xs text-muted-foreground">
               Transfer ID
-              <input
+              <input id="plaid-brokerage-input-6"
                 className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground"
                 value={supportTransferId}
                 onChange={(event) => setSupportTransferId(event.target.value)}
                 placeholder="Optional transfer ID"
               />
             </label>
-            <label className="space-y-1 text-xs text-muted-foreground">
+            <label htmlFor="plaid-brokerage-input-7" className="space-y-1 text-xs text-muted-foreground">
               Relationship ID
-              <input
+              <input id="plaid-brokerage-input-7"
                 className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground"
                 value={supportRelationshipId}
                 onChange={(event) => setSupportRelationshipId(event.target.value)}
                 placeholder="Optional relationship ID"
               />
             </label>
-            <label className="space-y-1 text-xs text-muted-foreground">
+            <label htmlFor="plaid-brokerage-input-8" className="space-y-1 text-xs text-muted-foreground">
               Escalation severity
-              <select
+              <select id="plaid-brokerage-input-8"
                 className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground"
                 value={supportSeverity}
                 onChange={(event) =>
@@ -1018,9 +1018,9 @@ export function PlaidFundingTransfersSection({
                 <option value="urgent">Urgent</option>
               </select>
             </label>
-            <label className="space-y-1 text-xs text-muted-foreground">
+            <label htmlFor="plaid-brokerage-input-9" className="space-y-1 text-xs text-muted-foreground">
               Escalation notes
-              <input
+              <input id="plaid-brokerage-input-9"
                 className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground"
                 value={supportNotes}
                 onChange={(event) => setSupportNotes(event.target.value)}


### PR DESCRIPTION
# Description
Resolves an accessibility and interaction bug in the Plaid Brokerage forms where 9 `<label>` wrappers lacked explicit `htmlFor` identity mappings to their nested `<input>` and `<select>` fields. This prevents screen reader ambiguity and ensures the click-to-focus area operates consistently across all browser environments.

## 📌 Core Impact
- [x] **Routes Touched:** 
  - `components/kai/plaid/plaid-brokerage-sections.tsx` (Single-file change to bypass broad integration patches)
- [x] **Architecture:** UI / Accessibility Form Semantics
- [x] **Verification:** Verified commit message length (<72 chars).

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (Plaid Integrations).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation

## 🧪 Testing & Privacy
- [x] Tested on Web
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible