### PR TITLE
fix(frontend): add missing type=button to consent center actions

### DIFF
--- a/hushh-webapp/components/consent/consent-center-view.tsx
+++ b/hushh-webapp/components/consent/consent-center-view.tsx
@@ -669,7 +669,7 @@ export function ConsentCenterView({
           </div>
 
           <div className="flex flex-wrap gap-2">
-            <Button
+            <Button type="button"
               variant="none"
               effect="fade"
               size="sm"
@@ -783,7 +783,7 @@ export function ConsentCenterView({
                             </SelectContent>
                           </Select>
                         ) : null}
-                        <Button
+                        <Button type="button"
                           variant="none"
                           effect="fade"
                           size="sm"
@@ -800,7 +800,7 @@ export function ConsentCenterView({
           ) : null}
 
           <div className="flex flex-wrap gap-2">
-            <Button
+            <Button type="button"
               size="sm"
               onClick={() =>
                 void handleApproveBundle(
@@ -822,7 +822,7 @@ export function ConsentCenterView({
             >
               Approve bundle
             </Button>
-            <Button
+            <Button type="button"
               variant="none"
               effect="fade"
               size="sm"
@@ -992,7 +992,7 @@ export function ConsentCenterView({
                     ))}
                   </SelectContent>
                 </Select>
-                <Button
+                <Button type="button"
                   size="sm"
                   onClick={() =>
                     void handleApprove(
@@ -1002,7 +1002,7 @@ export function ConsentCenterView({
                 >
                   Approve
                 </Button>
-                <Button
+                <Button type="button"
                   variant="none"
                   effect="fade"
                   size="sm"
@@ -1014,7 +1014,7 @@ export function ConsentCenterView({
             ) : null}
 
             {entry.kind === "active_grant" && entry.scope ? (
-              <Button
+              <Button type="button"
                 variant="none"
                 effect="fade"
                 size="sm"
@@ -1025,7 +1025,7 @@ export function ConsentCenterView({
             ) : null}
 
             {canDisconnectRelationship ? (
-              <Button
+              <Button type="button"
                 variant="none"
                 effect="fade"
                 size="sm"
@@ -1129,7 +1129,7 @@ export function ConsentCenterView({
             icon={BellRing}
             actions={
               notificationState.deliveryMode !== "push_active" ? (
-                <Button
+                <Button type="button"
                   variant="none"
                   effect="fade"
                   size="sm"
@@ -1342,7 +1342,7 @@ export function ConsentCenterView({
     return (
       <div className={cn("space-y-5", className)}>
         <div className="flex justify-end">
-            <Button
+            <Button type="button"
               variant="none"
               effect="fade"
               size="sm"
@@ -1380,7 +1380,7 @@ export function ConsentCenterView({
           icon={ClipboardList}
           accent="consent"
           actions={
-            <Button
+            <Button type="button"
               variant="none"
               effect="fade"
               size="default"


### PR DESCRIPTION
# Description
Resolves a pervasive UI bug in the Consent Center module where 11 action buttons were missing explicit `type="button"` declarations. This ensures these buttons never trigger unintended default `<form>` submissions when rendered dynamically or refactored within complex parent contexts.

## 📌 Core Impact
- [x] **Routes Touched:** 
  - `components/consent/consent-center-view.tsx` (Single-file change to bypass broad integration patches)
- [x] **Architecture:** UI / React DOM Form Constraints
- [x] **Verification:** Verified commit message length (<72 chars).

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app surface (Consent Views).
- [x] Commits are signed off (`git commit -s`) and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation

## 🧪 Testing & Privacy
- [x] Tested on Web
- [x] Does this change access user data? (No)
- [x] Licensing: First-party changes remain Apache-2.0 compatible