### PR TITLE
fix(ria): add missing type=button and htmlFor associations in client workspace

### DIFF
--- a/hushh-webapp/components/ria/ria-client-workspace.tsx
+++ b/hushh-webapp/components/ria/ria-client-workspace.tsx
@@ -506,7 +506,7 @@ export function RiaClientWorkspace({
       }}
       actions={
         detail && !detail.is_self_relationship && !isTestProfile ? (
-          <Button
+          <Button type="button"
             variant="none"
             effect="fade"
             size="sm"
@@ -707,7 +707,7 @@ export function RiaClientWorkspace({
                   <>
                     <div className="flex flex-wrap gap-2">
                       {detail.requestable_scope_templates.map((template) => (
-                        <Button
+                        <Button type="button"
                           key={template.template_id}
                           variant={selectedTemplateId === template.template_id ? "blue-gradient" : "none"}
                           effect={selectedTemplateId === template.template_id ? "fill" : "fade"}
@@ -728,11 +728,11 @@ export function RiaClientWorkspace({
                         {availableScopeOptions.map((scope) => {
                           const checked = selectedScopes.includes(scope.scope);
                           return (
-                            <label
+                            <label htmlFor="ria-client-input-1"
                               key={scope.scope}
                               className="flex items-start gap-3 rounded-[20px] border border-border/60 bg-background/70 px-4 py-3"
                             >
-                              <Checkbox
+                              <Checkbox id="ria-client-input-1"
                                 checked={checked}
                                 onCheckedChange={(next) => {
                                   const shouldCheck = Boolean(next);
@@ -764,11 +764,11 @@ export function RiaClientWorkspace({
                           activeAccountBranches.map((branch) => {
                             const checked = selectedAccountIds.includes(branch.branch_id);
                             return (
-                              <label
+                              <label htmlFor="ria-client-input-2"
                                 key={branch.branch_id}
                                 className="flex items-start gap-3 px-4 py-3"
                               >
-                                <Checkbox
+                                <Checkbox id="ria-client-input-2"
                                   checked={checked}
                                   onCheckedChange={(next) => {
                                     const shouldCheck = Boolean(next);
@@ -814,7 +814,7 @@ export function RiaClientWorkspace({
                     />
 
                     <div className="flex flex-wrap gap-2">
-                      <Button
+                      <Button type="button"
                         variant="blue-gradient"
                         effect="fill"
                         data-voice-control-id="ria_client_workspace_send_request"
@@ -824,7 +824,7 @@ export function RiaClientWorkspace({
                         {requestingAccess ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
                         Send request
                       </Button>
-                      <Button asChild variant="none" effect="fade">
+                      <Button type="button" asChild variant="none" effect="fade">
                         <Link
                           href={consentManagerHref}
                           data-voice-control-id="ria_client_workspace_open_access_manager"


### PR DESCRIPTION
# Description
Resolves two categories of UI surface bugs in the RIA Client Workspace component.

1. **Form semantics**: 3 action `<Button>` elements were missing explicit `type="button"` declarations, risking implicit form submission in future form-wrapped refactors.
2. **Accessibility**: 2 `<label>` wrappers around `<Checkbox>` components were missing explicit `htmlFor` + `id` associations, causing ambiguous screen reader targeting and broken click-to-focus on the scope/account selectors.

## 📌 Core Impact
- [x] **Routes Touched:**
  - `components/ria/ria-client-workspace.tsx` (Single-file change)
- [x] **Architecture:** UI / Accessibility Form Semantics

## ✅ Review-Ready Contract
- [x] Title, body, changed files describe the same contract.
- [x] Commits are signed off and GitHub shows mergeable status.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS**: N/A
- [x] **Android**: N/A

## 🧪 Testing & Privacy
- [x] Does this change access user data? No
- [x] Licensing: Apache-2.0 compatible