### PR TITLE
fix(system): add missing type=button to ApiRetryState retry buttons

### DIFF
--- a/hushh-webapp/components/system/api-retry-state.tsx
+++ b/hushh-webapp/components/system/api-retry-state.tsx
@@ -27,7 +27,7 @@ export function ApiRetryState({
             <p className="text-xs text-muted-foreground">{description}</p>
           </div>
         </div>
-        <Button variant="none" effect="fade" size="sm" onClick={onRetry}>
+        <Button type="button" variant="none" effect="fade" size="sm" onClick={onRetry}>
           <RefreshCcw className="mr-2 h-4 w-4" />
           Retry
         </Button>
@@ -50,7 +50,7 @@ export function ApiRetryState({
             </p>
           </div>
 
-          <Button variant="none" effect="fade" size="sm" onClick={onRetry}>
+          <Button type="button" variant="none" effect="fade" size="sm" onClick={onRetry}>
             <RefreshCcw className="mr-2 h-4 w-4" />
             Retry
           </Button>


### PR DESCRIPTION
Both Retry buttons in the compact and full variants of ApiRetryState were missing explicit type declarations. HTML buttons default to type=submit when omitted, which can trigger unintended form submissions if this error state is ever rendered inside a form context.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Not applicable

- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app/backend/package/docs surface, or it is explicitly scoped as test/devex hygiene.
- [x] Reachable production attach point: components/system/api-retry-state.tsx — rendered across multiple pages as a reusable error boundary widget.
- [x] New helpers/components/services are wired to an existing route, caller, package export, generated contract, or documented devex entrypoint.
- [x] Production surface proved: 2-line attribute addition, no logic change.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled, or the reason they cannot be enabled is listed here.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/system/api-retry-state.tsx)
- [x] **iOS**: Not applicable — UI-only JSX attribute fix
- [x] **Android**: Not applicable — UI-only JSX attribute fix

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)
- [x] If generated files changed, they were regenerated by the canonical repo command listed above

## 📸 Screenshots / Video

UI behaviour is unchanged. This fix prevents a latent bug (implicit type=submit) without altering any visible output. Browser proof not applicable for a defensive attribute-only patch.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none
- [x] Error path, rollback, or safe-failure behavior proved: attribute-only change, no logic or data flow altered.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed — no dependencies changed