### PR TITLE
test(hooks): add coverage for network status hook

### DIFF
--- a/hushh-webapp/__tests__/hooks/use-network-status.test.tsx
+++ b/hushh-webapp/__tests__/hooks/use-network-status.test.tsx
@@ -1,0 +1,91 @@
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { act, render } from "@testing-library/react";
+
+import { useNetworkStatus } from "@/hooks/use-network-status";
+
+function Harness({
+  onStatus,
+}: {
+  onStatus: (status: { online: boolean; offline: boolean }) => void;
+}) {
+  const status = useNetworkStatus();
+
+  React.useEffect(() => {
+    onStatus(status);
+  }, [status, onStatus]);
+
+  return null;
+}
+
+describe("useNetworkStatus", () => {
+  it("reports online status", () => {
+    const callback = vi.fn();
+
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      value: true,
+    });
+
+    render(<Harness onStatus={callback} />);
+
+    expect(callback).toHaveBeenCalledWith({
+      online: true,
+      offline: false,
+    });
+  });
+
+  it("responds to offline events", () => {
+    const callback = vi.fn();
+
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      value: true,
+    });
+
+    render(<Harness onStatus={callback} />);
+
+    callback.mockClear();
+
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      value: false,
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event("offline"));
+    });
+
+    expect(callback).toHaveBeenLastCalledWith({
+      online: false,
+      offline: true,
+    });
+  });
+
+  it("responds to online events", () => {
+    const callback = vi.fn();
+
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      value: false,
+    });
+
+    render(<Harness onStatus={callback} />);
+
+    callback.mockClear();
+
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      value: true,
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event("online"));
+    });
+
+    expect(callback).toHaveBeenLastCalledWith({
+      online: true,
+      offline: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add test coverage for the network status hook.

## Changes

* Add tests for online state handling.
* Add tests for offline state handling.
* Verify network status updates are reflected correctly by the hook.

## Why

The hook relies on browser network events and navigator state. These tests help prevent regressions in connectivity handling and ensure expected behavior across online/offline transitions.

## Validation

```bash
pnpm test use-network-status.test.tsx
```
