### PR TITLE
test(observability): check log redactor resilience against literal backslash escapes

### DIFF
--- a/hushh-webapp/__tests__/services/observability-log-redactor.test.ts
+++ b/hushh-webapp/__tests__/services/observability-log-redactor.test.ts
@@ -248,3 +248,17 @@ describe("observability log redactor — tab-separated value handling", () => {
     expect(output).toContain("data");
   });
 });
+
+describe("observability log redactor - literal escape sequence handling", () => {
+  it("redacts sensitive tokens surrounded by literal escaped quotes without regex failures", () => {
+    const escapedLogLine = String.raw`auth_header=\"Bearer literalEscapeToken12345\" status=\"ok\"`;
+
+    expect(() => redactObservabilityLog(escapedLogLine)).not.toThrow();
+
+    const output = redactObservabilityLog(escapedLogLine);
+
+    expect(output).not.toContain("literalEscapeToken12345");
+    expect(output).toContain(String.raw`auth_header=\"Bearer [REDACTED_TOKEN]\"`);
+    expect(output).toContain(String.raw`status=\"ok\"`);
+  });
+});


### PR DESCRIPTION
Test-only observability redactor coverage. Narrows the PR to one additive unit test in hushh-webapp/__tests__/services/observability-log-redactor.test.ts for literal backslash escape sequences and escaped quotes around a Bearer auth header. This intentionally avoids the sibling JSON/vault-token coverage surface and exercises the existing redactObservabilityLog production util. Local validation passed: cd hushh-webapp && npm run test -- __tests__/services/observability-log-redactor.test.ts; cd hushh-webapp && npm run typecheck. No routes, API/schema, cache, DB, mobile, docs, trust-boundary, dependency, or runtime behavior changes.