### PR TITLE
fix(holdings-drawer): accessible title and description

### DIFF
--- a/hushh-webapp/components/kai/holdings/holding-details-drawer.tsx
+++ b/hushh-webapp/components/kai/holdings/holding-details-drawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Drawer, DrawerContent, DrawerFooter, DrawerHeader, DrawerTitle } from "@/components/ui/drawer";
+import { Drawer, DrawerContent, DrawerDescription, DrawerFooter, DrawerHeader, DrawerTitle } from "@/components/ui/drawer";
 import { Button as MorphyButton } from "@/lib/morphy-ux/button";
 import { cn } from "@/lib/utils";
 import type { HoldingMobileCardViewModel } from "@/components/kai/holdings/holding-mobile-card";
@@ -71,9 +71,9 @@ export function HoldingDetailsDrawer({
           <DrawerTitle className="app-card-title text-left text-foreground">
             {holding?.symbol || "Holding Details"}
           </DrawerTitle>
-          <p className="app-body-text app-title-subtitle-gap text-left text-muted-foreground">
+          <DrawerDescription className="app-body-text app-title-subtitle-gap text-left text-muted-foreground">
             {holding?.name || "Select a holding"}
-          </p>
+          </DrawerDescription>
         </DrawerHeader>
 
         <div className="grid max-h-[60svh] gap-2 overflow-y-auto px-5 pb-3 sm:grid-cols-2">


### PR DESCRIPTION
## Summary

Completes the accessibility relationship between `DrawerTitle` and `DrawerDescription` in `HoldingDetailsDrawer` by replacing the existing subtitle paragraph with `DrawerDescription`.

## Problem

`HoldingDetailsDrawer` already provides a `DrawerTitle`, but the accompanying company-name subtitle was rendered using a plain `<p>` element.

Because the subtitle was not rendered through `DrawerDescription`, the drawer content did not receive the expected `aria-describedby` relationship provided by the drawer primitive.

As a result, assistive technologies announce the drawer title but may omit the contextual company-name description when the drawer opens.

## Changes

### `components/kai/holdings/holding-details-drawer.tsx`

* Add `DrawerDescription` to the existing drawer import
* Replace the subtitle `<p>` element with `DrawerDescription`
* Preserve all existing visual styling classes
* Preserve existing content and fallback text

## Accessibility Impact

* Completes the `DrawerTitle` + `DrawerDescription` accessibility pairing
* Enables automatic `aria-describedby` wiring on drawer content
* Improves screen-reader announcements when opening holding details
* Provides meaningful context when no holding is selected through the existing fallback text

## Scope

* 1 file changed
* Accessibility-only improvement
* No visual changes
* No behavior changes
* No state-management changes
* No business-logic changes
