### PR TITLE
fix(consent-dialog): focus management parity

### DIFF
--- a/hushh-webapp/components/consent/consent-dialog.tsx
+++ b/hushh-webapp/components/consent/consent-dialog.tsx
@@ -12,7 +12,7 @@
 
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -112,9 +112,21 @@ export function ConsentDialog({
     }
   };
 
+  const scopeInfoRef = useRef<HTMLDivElement>(null);
+
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onDeny()}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent
+        className="sm:max-w-md"
+        aria-busy={isGranting || loading}
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          scopeInfoRef.current?.focus();
+        }}
+        onEscapeKeyDown={(event) => {
+          if (isGranting) event.preventDefault();
+        }}
+      >
         <DialogHeader>
           <div className="flex items-center gap-3 mb-2">
             <div className="h-12 w-12 rounded-full bg-linear-to-br from-blue-500 to-purple-600 flex items-center justify-center text-2xl shadow-lg">
@@ -132,7 +144,9 @@ export function ConsentDialog({
         {/* Scope Info */}
         <div className="space-y-4 py-4">
           <div
-            className="flex items-start gap-3 p-3 rounded-xl bg-blue-50 dark:bg-blue-950/40 border border-blue-200/60 dark:border-blue-800/40"
+            ref={scopeInfoRef}
+            tabIndex={-1}
+            className="flex items-start gap-3 p-3 rounded-xl bg-blue-50 dark:bg-blue-950/40 border border-blue-200/60 dark:border-blue-800/40 focus:outline-none"
             style={scopeInfo.colorHex ? {
               backgroundColor: `${scopeInfo.colorHex}08`,
               borderColor: `${scopeInfo.colorHex}20`,


### PR DESCRIPTION
## Summary

Adds focus management parity to `ConsentDialog`, aligning it with established Dialog accessibility patterns already used elsewhere in the application.

## Problem

`ConsentDialog` had three accessibility gaps:

1. Initial focus defaulted to the dialog close button instead of the consent scope information.
2. The dialog could be dismissed with the Escape key while a grant operation was in progress.
3. No busy state was exposed to assistive technology during async grant operations.

## Changes

### components/consent/consent-dialog.tsx

* Added `useRef<HTMLDivElement>` for the consent scope information block.
* Added `onOpenAutoFocus` to `DialogContent` to move initial focus to the scope information when the dialog opens.
* Added `aria-busy={isGranting || loading}` to expose processing state to assistive technology.
* Added `onEscapeKeyDown` guard to prevent dismissal while a grant operation is active.
* Added `tabIndex={-1}` and `focus:outline-none` to the scope information container to support programmatic focus.

## Accessibility Impact

* Screen reader users receive the consent scope information immediately when the dialog opens.
* Assistive technology receives a busy-state signal during async operations.
* Accidental Escape-key dismissal during an active grant operation is prevented.

## Scope

* 1 file changed
* No visual changes
* No routing changes
* No state-management changes
* No API changes
* Additive-only accessibility improvements
