### PR TITLE
fix(onboarding): add missing type=button to IntroStep CTA buttons

### DIFF
--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -61,12 +61,13 @@ export function IntroStep({
 
         <footer className="flex-none pt-4 pb-[var(--app-screen-footer-pad)]">
           <div className="space-y-3">
-            <Button size="lg" fullWidth onClick={onNext} showRipple>
+            <Button type="button" size="lg" fullWidth onClick={onNext} showRipple>
               Get Started
               <Icon icon={ArrowRight} size="md" className="ml-2" />
             </Button>
             {onLogin ? (
               <Button
+                type="button"
                 size="lg"
                 fullWidth
                 variant="none"


### PR DESCRIPTION
The Get Started and Login buttons in IntroStep were missing explicit type declarations. HTML buttons default to type=submit when omitted, which can cause unintended form submissions if this onboarding step is ever composed inside a form element.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable
- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — onboarding/IntroStep.tsx is the first screen new users see.
- [x] Reachable production attach point: components/onboarding/IntroStep.tsx
- [x] Production surface proved: 2-line attribute addition, no logic change.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/onboarding/IntroStep.tsx)
- [x] **iOS**: Not applicable — UI-only JSX attribute fix
- [x] **Android**: Not applicable — UI-only JSX attribute fix

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

UI behaviour is unchanged. Defensive attribute-only patch — no visible output altered.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none
- [x] Error path, rollback, or safe-failure behavior proved: attribute-only, no logic or data flow altered.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed — no dependencies changed