### PR TITLE
fix(voice-surfaces): add control relationships and hide decorative voice visuals

### DIFF
--- a/hushh-webapp/components/agent/agent-voice-floating-indicator.tsx
+++ b/hushh-webapp/components/agent/agent-voice-floating-indicator.tsx
@@ -55,6 +55,7 @@ export function AgentVoiceFloatingIndicator({
       title={label}
     >
       <span
+        aria-hidden="true"
         className={cn(
           "flex h-7 w-7 items-center justify-center rounded-full bg-primary/15 text-primary",
           status === "error" && "bg-destructive/10 text-destructive"

--- a/hushh-webapp/components/agent/agent-voice-wave-input.tsx
+++ b/hushh-webapp/components/agent/agent-voice-wave-input.tsx
@@ -56,7 +56,10 @@ export function AgentVoiceWaveInput({
           )}
           <span>{label}</span>
         </div>
-        <div className="mt-2 flex h-8 items-center gap-1 overflow-hidden">
+        <div
+          className="mt-2 flex h-8 items-center gap-1 overflow-hidden"
+          aria-hidden="true"
+        >
           {WAVE_BARS.map((index) => {
             const phase = Math.sin(index * 0.85);
             const scale = muted ? 0.12 : activeLevel * (0.7 + Math.abs(phase) * 0.8);

--- a/hushh-webapp/components/kai/voice/voice-debug-drawer.tsx
+++ b/hushh-webapp/components/kai/voice/voice-debug-drawer.tsx
@@ -269,6 +269,7 @@ export function VoiceDebugDrawer({
       }
     >
       <div
+        id="voice-debug-panel"
         className={cn(
           "pointer-events-auto overflow-hidden rounded-2xl border border-border/70 bg-background/95 shadow-2xl backdrop-blur transition-all duration-200",
           drawerOpen
@@ -393,6 +394,8 @@ export function VoiceDebugDrawer({
         <div className="pointer-events-auto mt-2 flex justify-center sm:justify-end">
           <button
             type="button"
+            aria-expanded={drawerOpen}
+            aria-controls="voice-debug-panel"
             className="inline-flex h-9 items-center gap-2 rounded-full border border-border/70 bg-background/95 px-3 text-xs font-semibold text-foreground shadow-md backdrop-blur hover:bg-muted"
             onClick={() => setDrawerOpen((v) => !v)}
           >


### PR DESCRIPTION
## Summary

Adds small accessibility improvements across voice surfaces by exposing the relationship between the voice debug toggle and its panel, and hiding decorative voice visualizations from assistive technology.

## Problem

Several voice UI elements relied solely on visual presentation:

* The voice debug toggle button did not expose the panel relationship through ARIA.
* Decorative waveform visuals in `AgentVoiceWaveInput` were exposed to the accessibility tree despite conveying no semantic information.
* Decorative status icons in `AgentVoiceFloatingIndicator` were exposed to assistive technology even though the button already provides an accessible label.

## Changes

### components/kai/voice/voice-debug-drawer.tsx

* Added `id="voice-debug-panel"` to the collapsible panel.
* Added `aria-expanded={drawerOpen}` to the toggle button.
* Added `aria-controls="voice-debug-panel"` to the toggle button.

### components/agent/agent-voice-wave-input.tsx

* Added `aria-hidden="true"` to the decorative waveform container.

### components/agent/agent-voice-floating-indicator.tsx

* Added `aria-hidden="true"` to the decorative icon wrapper.

## Accessibility Impact

* Exposes the control relationship between the debug toggle and its associated panel.
* Removes decorative waveform elements from the accessibility tree.
* Removes decorative status icons from the accessibility tree.
* Preserves all existing voice interaction behavior.

## Scope

* 3 files changed
* Attribute-only additions
* No visual changes
* No logic changes
* No voice session behavior changes
* No API changes

## Validation

* Verified ARIA control relationship attributes on the debug toggle.
* Verified decorative visual elements are hidden from assistive technology.
* No functional changes introduced.
