### PR TITLE
fix(onboarding): add screen reader slide position announcements to carousel dots

### DIFF
--- a/hushh-webapp/components/onboarding/PreviewCarouselStep.tsx
+++ b/hushh-webapp/components/onboarding/PreviewCarouselStep.tsx
@@ -262,6 +262,14 @@ export function PreviewCarouselStep({ onContinue }: { onContinue: () => void }) 
 function Dots(props: { count: number; activeIndex: number }) {
   return (
     <div className="flex items-center justify-center gap-2">
+      <span
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {`Slide ${props.activeIndex + 1} of ${props.count}`}
+      </span>
       {Array.from({ length: props.count }).map((_, i) => (
         <span
           key={i}


### PR DESCRIPTION
The Dots pagination indicator in the onboarding carousel rendered all dot spans with aria-hidden, giving screen reader users no feedback when the active slide changes. Added a visually-hidden aria-live="polite" status region that announces the current slide position (e.g. "Slide 2 of 3") on each index change.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable
- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — PreviewCarouselStep is the second onboarding screen shown to every new user.
- [x] Reachable production attach point: components/onboarding/PreviewCarouselStep.tsx
- [x] Production surface proved: 8-line insertion only, zero deletions, no logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/onboarding/PreviewCarouselStep.tsx)
- [x] **iOS**: Not applicable — JSX accessibility annotation only
- [x] **Android**: Not applicable — JSX accessibility annotation only

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari with VoiceOver/NVDA)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Screen reader announces "Slide 2 of 3" on slide change via the sr-only live region. No visual change to any user.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed