### PR TITLE
fix(agent-sidebar): add list semantics to conversation history

### DIFF
--- a/hushh-webapp/components/agent/agent-history-sidebar.tsx
+++ b/hushh-webapp/components/agent/agent-history-sidebar.tsx
@@ -213,7 +213,11 @@ export function AgentHistorySidebar({
             </div>
           ) : null}
 
-          <div className="space-y-1">
+          <div
+            className="space-y-1"
+            role="list"
+            aria-label="Conversation history"
+          >
             {conversations.map((conversation) => {
               const title = conversationLabel(conversation);
               const active = conversation.id === activeConversationId;
@@ -223,6 +227,7 @@ export function AgentHistorySidebar({
               return (
                 <div
                   key={conversation.id}
+                  role="listitem"
                   className={cn(
                     "group rounded-lg transition-colors",
                     active && "bg-primary/15 text-zinc-50 ring-1 ring-primary/20",


### PR DESCRIPTION
## Summary

Adds list semantics to the conversation history in `AgentHistorySidebar` so assistive technologies can identify and navigate the conversation collection as a structured list.

## Problem

Conversation entries are rendered inside a generic container without list semantics. Screen readers announce the individual controls, but the collection itself is not exposed as a list, reducing structural context for users navigating large conversation histories.

Already present and unchanged:

* Active conversation uses `aria-current="page"`
* Conversation actions use native `<button>` elements
* Sidebar landmark is labeled with `aria-label="Agent chat history"`

## Changes

### components/agent/agent-history-sidebar.tsx

* Add `role="list"` and `aria-label="Conversation history"` to the conversation container
* Add `role="listitem"` to each conversation wrapper

## Accessibility Impact

* Exposes conversation history as a structured list
* Allows assistive technologies to announce list boundaries and item counts
* Improves navigation context for screen-reader users

## Scope

* One file changed
* Attribute-only additions
* No visual changes
* No behavioral changes
* No keyboard interaction changes
