### PR TITLE
fix(app-ui): suppress decorative spinner from assistive technology in Inline Loading State

### DIFF
--- a/hushh-webapp/components/app-ui/inline-loading-state.tsx
+++ b/hushh-webapp/components/app-ui/inline-loading-state.tsx
@@ -23,6 +23,7 @@ export function InlineLoadingState({
       )}
     >
       <Loader2
+        aria-hidden="true"
         className={cn("h-4 w-4 shrink-0 motion-safe:animate-spin", iconClassName)}
       />
       <span>{label}</span>


### PR DESCRIPTION
The Loader2 spinner SVG inside InlineLoadingState was exposed to screen readers even though the parent div already carries role="status" and aria-label, and the sibling span repeats the visible label text. Adding aria-hidden="true" to the icon prevents duplicate or noisy announcements for users of assistive technology.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable
- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — InlineLoadingState is a shared component used across multiple pages.
- [x] Reachable production attach point: components/app-ui/inline-loading-state.tsx
- [x] Production surface proved: 1-line attribute insertion, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/app-ui/inline-loading-state.tsx)
- [x] **iOS**: Not applicable — JSX accessibility annotation only
- [x] **Android**: Not applicable — JSX accessibility annotation only

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari with VoiceOver)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

No visual change. Screen reader no longer reads the raw spinner SVG redundantly alongside the aria-label and visible label span.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed