### PR TITLE
fix(system): suppress decorative WifiOff icon from assistive technology in NetworkStatusBanner

### DIFF
--- a/hushh-webapp/components/system/network-status-banner.tsx
+++ b/hushh-webapp/components/system/network-status-banner.tsx
@@ -18,7 +18,7 @@ export function NetworkStatusBanner() {
       className="fixed inset-x-0 top-0 z-[9999] border-b border-amber-500/20 bg-amber-500/10 px-4 py-2 text-center text-sm text-amber-700 backdrop-blur dark:text-amber-300"
     >
       <div className="flex items-center justify-center gap-2">
-        <WifiOff className="h-4 w-4" />
+        <WifiOff className="h-4 w-4" aria-hidden="true" />
         <span>You are offline. Some data may be outdated until your connection returns.</span>
       </div>
     </div>


### PR DESCRIPTION
The WifiOff icon in NetworkStatusBanner is purely decorative. The parent element already carries role="status" and aria-live="polite", and the sibling span provides a complete text description of the offline state. Suppressing the SVG with aria-hidden="true" prevents screen readers from reading raw icon noise on top of the accessible message.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable
- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — NetworkStatusBanner is globally mounted and shown to all users when offline.
- [x] Reachable production attach point: components/system/network-status-banner.tsx
- [x] Production surface proved: 1-character attribute change, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/system/network-status-banner.tsx)
- [x] **iOS**: Not applicable — JSX accessibility attribute only
- [x] **Android**: Not applicable — JSX accessibility attribute only

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari with VoiceOver — banner no longer reads SVG noise)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

No visual change. Screen reader now reads only the text message, not the decorative icon SVG.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed