### PR TITLE
fix(system): suppress decorative status icon from assistive technology in AsyncActionSt

### DIFF
--- a/hushh-webapp/components/system/async-action-status.tsx
+++ b/hushh-webapp/components/system/async-action-status.tsx
@@ -46,6 +46,7 @@ export function AsyncActionStatus({
       }
     >
       <Icon
+        aria-hidden="true"
         className={
           state === "loading" || state === "retrying"
             ? "h-4 w-4 animate-spin"


### PR DESCRIPTION
The WifiOff icon in NetworkStatusBanner is purely decorative. The parent element already carries role="status" and aria-live="polite", and the sibling span provides a complete text description of the offline state. Suppressing the SVG with aria-hidden="true" prevents screen readers from reading raw icon noise on top of the accessible message.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable
- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — NetworkStatusBanner is globally mounted and shown to all users when offline.
- [x] Reachable production attach point: components/system/network-status-banner.tsx
- [x] Production surface proved: 1-character attribute change, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/system/network-status-banner.tsx)
- [x] **iOS**: Not applicable — JSX accessibility attribute only
- [x] **Android**: Not applicable — JSX accessibility attribute only

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari with VoiceOver — banner no longer reads SVG noise)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

No visual change. Screen reader now reads only the text message, not the decorative icon SVG.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed