### PR TITLE
test(utils): verify vault base64 decoding preserves padded payload

### DIFF
--- a/hushh-webapp/__tests__/utils/vault-base64.test.ts
+++ b/hushh-webapp/__tests__/utils/vault-base64.test.ts
@@ -1,0 +1,12 @@
+import { base64ToBytes, bytesToBase64 } from "@/lib/vault/base64";
+
+describe("vault base64 helpers", () => {
+  it("decodes padded base64 without corrupting payload bytes", () => {
+    const input = "Yg==";
+
+    const decoded = base64ToBytes(input);
+
+    expect(Array.from(decoded)).toEqual([98]);
+    expect(bytesToBase64(decoded)).toBe(input);
+  });
+});


### PR DESCRIPTION
## Description
Adds focused test coverage for the production vault base64 helpers. The test decodes padded base64 input with `base64ToBytes` and re-encodes it with `bytesToBase64`, verifying that padded payload bytes round-trip without corruption.

This is test-only coverage for an existing production utility; it does not add a parallel formatter, mock helper, or new runtime behavior.

## Impact Map (Required)
* **Routes touched:** None (Test-only addition)

## Privacy & Consent
* **Does this change access user data?** No
* **If yes, have you implemented checkConsentToken()?** Not applicable
* **Sensitive surface touched:** None; test-only coverage of existing vault encoding helper
* **Error path, rollback, or safe-failure behavior proved:** Not applicable; test-only addition

## Review-Ready Contract
* **Title, body, changed files, and tests describe the same contract:** Yes
* **Existing implementation was checked:** This extends coverage for `hushh-webapp/lib/vault/base64.ts`; it does not introduce a duplicate utility.
* **Reachable production attach point:** `base64ToBytes` and `bytesToBase64` are production vault base64 helpers used by vault encoding flows.
* **New tests import and exercise production code:** Yes, exercises `base64ToBytes` and `bytesToBase64` directly.
* **New helpers/components/services are wired cleanly:** Yes; no new runtime helper is added.

## Tri-Flow Architecture Check
* **Web:** Test-only utility coverage; no route/runtime change.
* **iOS:** Not applicable.
* **Android:** Not applicable.

## Testing
* **Tested on Web:** `npm test -- __tests__/utils/vault-base64.test.ts`
* **Typecheck:** `npm run typecheck`
* **Commits are signed off:** Yes (`git commit -s`)