### PR TITLE
fix(auth): disable browser autocomplete on phone verification country search input

### DIFF
--- a/hushh-webapp/components/auth/phone-verification-flow.tsx
+++ b/hushh-webapp/components/auth/phone-verification-flow.tsx
@@ -389,6 +389,9 @@ export function PhoneVerificationFlow({
                   }}
                   onFocus={() => setCountryComboboxOpen(true)}
                   className={`${FLOW_CONTROL_SHELL_CLASS_NAME} w-full`}
+                  autoComplete="off"
+                  autoCorrect="off"
+                  spellCheck={false}
                   showTrigger
                 />
                 <ComboboxContent


### PR DESCRIPTION
The country code ComboboxInput in PhoneVerificationFlow drives a custom-filtered dropdown. Browser autocomplete overlays conflicting address book suggestions on a field expecting country dial codes, autocorrect mutates typed dial codes or country names, and spellcheck underlines valid country names as errors. Adding autoComplete="off", autoCorrect="off", and spellCheck={false} prevents all three sources of browser interference — matching the same fix already applied to the data-table search input.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable
- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — PhoneVerificationFlow is rendered during phone linking and KYC onboarding.
- [x] Reachable production attach point: components/auth/phone-verification-flow.tsx
- [x] Production surface proved: 3-line attribute insertion on a search input, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/auth/phone-verification-flow.tsx)
- [x] **iOS**: Not applicable — HTML input attribute fix
- [x] **Android**: Not applicable — HTML input attribute fix

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari — browser autocomplete no longer appears over the country dropdown)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

No visual change. Browser no longer injects autocomplete suggestions or autocorrect behaviour into the country code search field.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none — input attribute change only, no data read or written

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed