### PR TITLE
fix(ui): disable browser autocomplete on CommandInput

### DIFF
--- a/hushh-webapp/components/ui/command.tsx
+++ b/hushh-webapp/components/ui/command.tsx
@@ -74,6 +74,7 @@ function CommandInput({
         spellCheck={false}
         autoCorrect="off"
         autoCapitalize="off"
+        autoComplete="off"
         data-slot="command-input"
         className={cn(
           "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",


### PR DESCRIPTION
CommandInput already sets spellCheck={false}, autoCorrect="off", and autoCapitalize="off" to prevent browser interference with custom in-app filtering, but was missing autoComplete="off". Without it, browsers inject saved-search or address-book suggestions into every command palette, overlaying the custom dropdown results. Adding autoComplete="off" completes the set of browser-suppression attributes already present on this primitive.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable
- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — CommandInput is a shared primitive used by every command palette and command-field throughout the app.
- [x] Reachable production attach point: components/ui/command.tsx
- [x] Production surface proved: 1-line attribute insertion, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/ui/command.tsx)
- [x] **iOS**: Not applicable — HTML input attribute fix
- [x] **Android**: Not applicable — HTML input attribute fix

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari — browser autocomplete no longer appears over command palette results)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

No visual change. Browser no longer injects autocomplete suggestions into the command palette search field.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed