### PR TITLE
fix(app-ui): add missing accessibility annotations and button types to route error boundary

### DIFF
--- a/hushh-webapp/components/app-ui/route-error-boundary.tsx
+++ b/hushh-webapp/components/app-ui/route-error-boundary.tsx
@@ -75,7 +75,7 @@ export class RouteErrorBoundary extends Component<Props, State> {
           >
             <div className="flex flex-col items-center gap-4">
               <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-red-500/12 to-orange-500/12 dark:from-red-400/16 dark:to-orange-400/16">
-                <AlertTriangle className="h-7 w-7 text-red-500 dark:text-red-400" />
+                <AlertTriangle className="h-7 w-7 text-red-500 dark:text-red-400" aria-hidden="true" />
               </div>
               <div className="space-y-1.5">
                 <h2 className="text-lg font-semibold tracking-tight">Something went wrong</h2>
@@ -85,6 +85,7 @@ export class RouteErrorBoundary extends Component<Props, State> {
               </div>
               <div className="flex gap-3 pt-1">
                 <Button
+                  type="button"
                   variant="muted"
                   effect="glass"
                   size="sm"
@@ -94,6 +95,7 @@ export class RouteErrorBoundary extends Component<Props, State> {
                   Try again
                 </Button>
                 <Button
+                  type="button"
                   variant="blue-gradient"
                   effect="fill"
                   size="sm"


### PR DESCRIPTION
The RouteErrorBoundary component had two accessibility and semantic gaps: the AlertTriangle icon was not hidden from screen readers despite being purely decorative (the text already describes the error), and the action buttons were missing explicit type='button' declarations. Without type='button', these buttons could default to type='submit' and trigger unexpected form submissions if the error boundary catches an error inside a form context. This patch adds aria-hidden='true' to the icon and type='button' to both recovery actions.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable
- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — RouteErrorBoundary wraps the main application routes.
- [x] Reachable production attach point: components/app-ui/route-error-boundary.tsx
- [x] Production surface proved: 3-line attribute insertion, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/app-ui/route-error-boundary.tsx)
- [x] **iOS**: Not applicable — HTML attribute fix
- [x] **Android**: Not applicable — HTML attribute fix

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari — screen reader ignores icon, buttons do not submit forms)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

No visual change. Accessibility and HTML semantics are improved.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed