### PR TITLE
test(api): preserve invalid request timestamp normalization

### DIFF
--- a/hushh-webapp/__tests__/services/api-service-fetch.test.ts
+++ b/hushh-webapp/__tests__/services/api-service-fetch.test.ts
@@ -296,4 +296,19 @@ describe("ApiService.apiFetch", () => {
     expect(payload.phone_verified).toBe(true);
     expect(payload.identity?.source).toBe("uat_test_phone_claim");
   });
+  it("normalizes invalid request timestamp headers before fetch", async () => {
+  mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+  await ApiService.apiFetch("/api/ping", {
+    method: "GET",
+    headers: {
+      [REQUEST_TIMESTAMP_HEADER]: "not-a-number",
+    },
+  });
+
+  const [, fetchOptions] = mockFetch.mock.calls[0] as [string, RequestInit];
+  const headers = fetchOptions.headers as Record<string, string>;
+
+  expect(headers[REQUEST_TIMESTAMP_HEADER]).not.toBe("not-a-number");
+});
 });


### PR DESCRIPTION
## Motivation

API request metadata uses timestamp headers for observability and request tracking. Invalid timestamp values should be normalized before fetch execution so downstream telemetry and request processing do not receive malformed timing metadata.

This regression coverage protects request timestamp header normalization behavior.

## What's covered

`__tests__/services/api-service-fetch.test.ts`

Added regression coverage for invalid request timestamp header handling.

### Key scenarios

* preserves invalid request timestamp normalization
* verifies malformed timestamp values are not forwarded unchanged
* protects request metadata hygiene before fetch execution
* strengthens API observability header safety
* prevents regressions in timestamp normalization behavior

## Validation

* npm run test -- api-service-fetch
* npm run lint
* npm run typecheck

## Notes

* regression coverage only
* no production behavior changes
* DCO sign-off included
