### PR TITLE
test(api): preserve caller request id header

### DIFF
--- a/hushh-webapp/__tests__/services/api-service-fetch.test.ts
+++ b/hushh-webapp/__tests__/services/api-service-fetch.test.ts
@@ -296,4 +296,19 @@ describe("ApiService.apiFetch", () => {
     expect(payload.phone_verified).toBe(true);
     expect(payload.identity?.source).toBe("uat_test_phone_claim");
   });
+  it("preserves a caller supplied x-request-id header", async () => {
+  mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+  await ApiService.apiFetch("/api/ping", {
+    method: "GET",
+    headers: {
+      "x-request-id": "req_test_123",
+    },
+  });
+
+  const [, fetchOptions] = mockFetch.mock.calls[0] as [string, RequestInit];
+  const headers = fetchOptions.headers as Record<string, string>;
+
+  expect(headers["x-request-id"]).toBe("req_test_123");
+});
 });


### PR DESCRIPTION
## Motivation

API request tracing relies on request identifiers to correlate client and server activity across observability pipelines. When a caller explicitly provides an `x-request-id`, that identifier should remain intact rather than being replaced during request preparation.

This regression coverage protects caller-supplied request ID preservation behavior.

## What's covered

`__tests__/services/api-service-fetch.test.ts`

Added regression coverage for request ID header handling.

### Key scenarios

* preserves caller supplied request ID headers
* verifies existing request identifiers are not overwritten
* protects request tracing and observability correlation contracts
* strengthens API request metadata stability
* prevents regressions in request header normalization behavior

## Validation

* npm run test -- api-service-fetch
* npm run lint
* npm run typecheck

## Notes

* regression coverage only
* no production behavior changes
* no runtime behavior changes
* DCO sign-off included
