### PR TITLE
fix(iam): add aria-hidden to decorative loaders in persona bootstrap redirect

### DIFF
--- a/hushh-webapp/components/iam/persona-bootstrap-redirect.tsx
+++ b/hushh-webapp/components/iam/persona-bootstrap-redirect.tsx
@@ -182,7 +182,7 @@ export function PersonaBootstrapRedirect() {
             disabled={resolving !== null}
             className="w-full"
           >
-            {resolving === "route" ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+            {resolving === "route" ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" /> : null}
             {primaryLabel}
           </Button>
           <Button
@@ -192,7 +192,7 @@ export function PersonaBootstrapRedirect() {
             disabled={resolving !== null}
             className="w-full"
           >
-            {resolving === "persona" ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+            {resolving === "persona" ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" /> : null}
             {secondaryLabel}
           </Button>
         </AlertDialogFooter>


### PR DESCRIPTION
The Loader2 spinners inside the action buttons in the PersonaBootstrapRedirect dialog are purely visual indicators of busy state. The semantic "busy" state is already conveyed to screen readers via the button's disabled props or surrounding context. Adding aria-hidden="true" prevents screen readers from reading raw SVG elements alongside the button text, reducing redundant noise.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable
- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — PersonaBootstrapRedirect is rendered during the IAM login loop.
- [x] Reachable production attach point: components/iam/persona-bootstrap-redirect.tsx
- [x] Production surface proved: 2-line attribute insertion, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/iam/persona-bootstrap-redirect.tsx)
- [x] **iOS**: Not applicable — HTML attribute fix
- [x] **Android**: Not applicable — HTML attribute fix

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari — screen reader ignores spinning loader icon)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

No visual change. Accessibility semantics are improved.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed