### PR TITLE
fix(consent): add aria-hidden to decorative icons in consent center view buttons

### DIFF
--- a/hushh-webapp/components/consent/consent-center-view.tsx
+++ b/hushh-webapp/components/consent/consent-center-view.tsx
@@ -1033,7 +1033,7 @@ export function ConsentCenterView({
                 disabled={disconnectKey === disconnectingCounterpartKey}
               >
                 {disconnectKey === disconnectingCounterpartKey ? (
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
                 ) : null}
                 Disconnect
               </Button>
@@ -1137,9 +1137,9 @@ export function ConsentCenterView({
                   onClick={() => notificationState.retryPushRegistration()}
                 >
                   {notificationState.isRetryingPushRegistration ? (
-                    <Loader2 className="size-4 animate-spin" />
+                    <Loader2 className="size-4 animate-spin" aria-hidden="true" />
                   ) : (
-                    <RefreshCw className="size-4" />
+                    <RefreshCw className="size-4" aria-hidden="true" />
                   )}
                   Retry push registration
                 </Button>


### PR DESCRIPTION
The Loader2 and RefreshCw icons inside action buttons ("Disconnect" and "Retry push registration") in the ConsentCenterView are purely visual indicators. The button text already conveys the action to screen readers, and the disabled state conveys when an action is loading. Adding aria-hidden="true" to these icons prevents screen readers from reading raw SVG elements alongside the button text, reducing redundant noise.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable
- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — ConsentCenterView is rendered when viewing the consent ledger.
- [x] Reachable production attach point: components/consent/consent-center-view.tsx
- [x] Production surface proved: 3-line attribute insertion, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/consent/consent-center-view.tsx)
- [x] **iOS**: Not applicable — HTML attribute fix
- [x] **Android**: Not applicable — HTML attribute fix

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari — screen reader ignores spinning loader icon)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

No visual change. Accessibility semantics are improved.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed