### PR TITLE
test(utils): verify numeric normalizer parses exponential string notation cleanly

### DIFF
--- a/hushh-webapp/__tests__/utils/portfolio-normalize.test.ts
+++ b/hushh-webapp/__tests__/utils/portfolio-normalize.test.ts
@@ -272,3 +272,20 @@ describe("portfolio normalizer - negative currency boundaries", () => {
     expect(consolidated[0].cost_basis).toBeCloseTo(-0.0001, 8);
   });
 });
+
+describe("portfolio normalizer - exponential numeric string boundaries", () => {
+  it("normalizes exponential currency strings to standard numeric values", () => {
+    const consolidated = consolidateHoldingsBySymbol([
+      {
+        symbol: "EXP",
+        name: "Exponential Numeric Holding",
+        quantity: "1",
+        market_value: "1.5e3",
+      },
+    ]);
+
+    expect(consolidated).toHaveLength(1);
+    expect(consolidated[0].market_value).toBe(1500);
+    expect(consolidated[0].price).toBe(1500);
+  });
+});


### PR DESCRIPTION
## Description
Adds a focused utility test for the production portfolio calculation and normalization helpers. The test passes a numeric input containing exponential/scientific notation ("1.5e3") through the existing portfolio normalizer path and verifies it parses cleanly into standard numeric primitives without mathematical scale drift.

This is test-only coverage for an existing production utility; it does not add a parallel formatter or new runtime behavior.

## Impact Map (Required)
* **Routes touched:** None (test-only addition)
* **API / schema / type changes:** None
* **Cache keys touched:** None
* **Runtime DB data-plane changes:** None
* **World-model domain summary effects:** None
* **Mobile parity impacts:** None
* **Docs updated:** None
* **Trust boundary touched:** None; test-only coverage of existing numeric normalizer helper
* **Caller / proxy / backend pairing:** Not applicable
* **Rollback or safe-failure behavior:** Not applicable; test-only addition
* **UI browser or Playwright proof:** Not applicable

## Privacy & Consent
* **Does this change access user data?** No
* **If yes, have you implemented checkConsentToken()?** Not applicable
* **Sensitive surface touched:** None; test-only coverage of existing numeric normalizer helper
* **Error path, rollback, or safe-failure behavior proved:** Not applicable; test-only addition

## Review-Ready Contract
* **Title, body, changed files, and tests describe the same contract:** Yes
* **Existing implementation was checked:** This extends coverage for `hushh-webapp/lib/utils/portfolio-normalize.ts` rather than adding a duplicate utility.
* **Reachable production attach point:** `consolidateHoldingsBySymbol` processes and normalizes raw portfolio holding payloads used by financial portfolio surfaces.
* **New tests import and exercise production code:** Yes, exercises the production portfolio normalizer directly.
* **New helpers/components/services are wired cleanly:** Yes; no new runtime helper is added.
* **Production surface proved:** Exponential notation string `1.5e3` normalizes to `1500` for `market_value` and derived `price`.

## Tri-Flow Architecture Check
* **Web:** Test-only utility coverage; no route/runtime change.
* **iOS:** Not applicable.
* **Android:** Not applicable.

## Testing
* **Tested on Web:** Unit test via Vitest verified locally: `cd hushh-webapp && npm test -- __tests__/utils/portfolio-normalize.test.ts`
* **Typecheck:** `cd hushh-webapp && npm run typecheck`
* **Commits are signed off:** Yes (`git commit -s`)
