### PR TITLE
fix(app-ui): add aria-hidden to decorative loaders in top app bar

### DIFF
--- a/hushh-webapp/components/app-ui/top-app-bar.tsx
+++ b/hushh-webapp/components/app-ui/top-app-bar.tsx
@@ -541,7 +541,7 @@ export function TopAppBar({ className }: TopAppBarProps) {
                               </span>
                             </div>
                             {switchingPersona === "ria" ? (
-                              <Loader2 className="ml-auto h-4 w-4 animate-spin text-current" />
+                              <Loader2 className="ml-auto h-4 w-4 animate-spin text-current" aria-hidden="true" />
                             ) : activePersona === "ria" ? (
                               <Check className="ml-auto h-4 w-4 text-current" />
                             ) : null}
@@ -615,7 +615,7 @@ export function TopAppBar({ className }: TopAppBarProps) {
                               }
                             >
                               {activeCount > 0 ? (
-                                <Loader2 className="h-5 w-5 animate-spin text-sky-500" />
+                                <Loader2 className="h-5 w-5 animate-spin text-sky-500" aria-hidden="true" />
                               ) : (
                                 <Bell className="h-5 w-5" />
                               )}


### PR DESCRIPTION
The Loader2 spinners in the top app bar (during persona switching and active notifications) are purely visual indicators. Adding aria-hidden="true" to these icons prevents screen readers from reading raw SVG elements, reducing redundant noise for users who navigate via screen readers.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable
- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — TopAppBar is rendered across all authenticated layouts.
- [x] Reachable production attach point: components/app-ui/top-app-bar.tsx
- [x] Production surface proved: 2-line attribute insertion, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/app-ui/top-app-bar.tsx)
- [x] **iOS**: Not applicable — HTML attribute fix
- [x] **Android**: Not applicable — HTML attribute fix

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari — screen reader ignores spinning loader icon)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

No visual change. Accessibility semantics are improved.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed