### PR TITLE
fix(consent): add aria-hidden to decorative loader in consent inbox dropdown

### DIFF
--- a/hushh-webapp/components/consent/consent-inbox-dropdown.tsx
+++ b/hushh-webapp/components/consent/consent-inbox-dropdown.tsx
@@ -247,7 +247,7 @@ export function ConsentInboxDropdown({
               </p>
             </div>
             {summaryResource.loading || summaryResource.refreshing ? (
-              <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" />
+              <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" aria-hidden="true" />
             ) : null}
           </div>
         </div>


### PR DESCRIPTION
The Loader2 spinner inside the ConsentInboxDropdown is a purely visual indicator of the loading state. The surrounding structure already conveys the loading state to screen readers. Adding aria-hidden="true" prevents screen readers from reading raw SVG elements, reducing redundant noise for users who navigate via screen readers.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable
- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — ConsentInboxDropdown is rendered in the global navigation bar.
- [x] Reachable production attach point: components/consent/consent-inbox-dropdown.tsx
- [x] Production surface proved: 1-line attribute insertion, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/consent/consent-inbox-dropdown.tsx)
- [x] **iOS**: Not applicable — HTML attribute fix
- [x] **Android**: Not applicable — HTML attribute fix

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari — screen reader ignores spinning loader icon)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

No visual change. Accessibility semantics are improved.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed