### PR TITLE
fix(consent): add missing aria-hidden and sr-only label to handshake timeline loading state

### DIFF
--- a/hushh-webapp/components/consent/handshake-timeline.tsx
+++ b/hushh-webapp/components/consent/handshake-timeline.tsx
@@ -146,8 +146,9 @@ export function HandshakeTimeline({
 
   if (loading) {
     return (
-      <div className={cn("flex items-center justify-center py-8", className)}>
-        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      <div className={cn("flex items-center justify-center py-8", className)} role="status">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" aria-hidden="true" />
+        <span className="sr-only">Loading timeline...</span>
       </div>
     );
   }


### PR DESCRIPTION
The loading state in HandshakeTimeline only rendered a raw SVG Loader2 without any screen-reader accessible text or aria-hidden attributes. By adding role="status", a screen-reader-only text node, and aria-hidden="true" to the decorative icon, screen readers will now correctly announce "Loading timeline..." instead of reading raw SVG attributes or remaining silent.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable
- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — HandshakeTimeline is rendered when viewing connection history.
- [x] Reachable production attach point: components/consent/handshake-timeline.tsx
- [x] Production surface proved: 3-line attribute insertion, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/consent/handshake-timeline.tsx)
- [x] **iOS**: Not applicable — HTML attribute fix
- [x] **Android**: Not applicable — HTML attribute fix

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari — screen reader announces "Loading timeline..." instead of ignoring the spinner)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

No visual change. Accessibility semantics are improved.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed