### PR TITLE
test(pkm): verify readable metadata normalizes primary path casing

### DIFF
--- a/hushh-webapp/__tests__/services/pkm-natural-language.test.ts
+++ b/hushh-webapp/__tests__/services/pkm-natural-language.test.ts
@@ -90,4 +90,24 @@ describe("pkm natural-language helpers", () => {
       }),
     ]);
   });
+
+  it("normalizes primaryJsonPath casing when building readable metadata sections", () => {
+    const upperCasePath = buildReadablePkmMetadata({
+      domainKey: "profile",
+      domainDisplayName: "Profile",
+      primaryJsonPath: "USER_ID",
+      createdAt: "2026-06-11T00:00:00Z",
+    });
+
+    const lowerCasePath = buildReadablePkmMetadata({
+      domainKey: "profile",
+      domainDisplayName: "Profile",
+      primaryJsonPath: "user_id",
+      createdAt: "2026-06-11T00:00:00Z",
+    });
+
+    expect(upperCasePath).toEqual(lowerCasePath);
+    expect(upperCasePath.readable_highlights).toContain("User Id");
+    expect(upperCasePath.readable_event_summary).toBe("Updated Profile across User Id.");
+  });
 });


### PR DESCRIPTION
## Description
Adds focused test coverage for the existing PKM natural-language helper `buildReadablePkmMetadata`. The test passes mixed-case and lowercase `primaryJsonPath` values (`USER_ID` and `user_id`) into the production helper and verifies they produce the same readable metadata section output.

This is test-only coverage for the existing PKM readable metadata projection path; it does not add a new metadata formatter, parser, helper, or runtime behavior.

## Impact Map (Required)
* **Routes touched:** None (Test-only addition)

## Privacy & Consent
* **Does this change access user data?** No
* **If yes, have you implemented checkConsentToken()?** Not applicable
* **Sensitive surface touched:** None; test-only coverage of PKM readable metadata projection
* **Error path, rollback, or safe-failure behavior proved:** Not applicable; test-only addition

## Review-Ready Contract
* **Title, body, changed files, and tests describe the same contract:** Yes
* **Existing implementation was checked:** This extends `hushh-webapp/__tests__/services/pkm-natural-language.test.ts` for `buildReadablePkmMetadata`; it does not introduce a duplicate formatter.
* **Reachable production attach point:** `buildReadablePkmMetadata` builds readable PKM metadata from persisted save/update previews before PKM presentation surfaces consume it.
* **New tests import and exercise production code:** Yes, exercises `buildReadablePkmMetadata` directly.
* **New helpers/components/services are wired cleanly:** Yes; no new runtime helper is added.

## Tri-Flow Architecture Check
* **Web:** Test-only PKM utility coverage; no route/runtime change.
* **iOS:** Not applicable.
* **Android:** Not applicable.

## Testing
* **Tested on Web:** `npm test -- __tests__/services/pkm-natural-language.test.ts`
* **Typecheck:** `npm run typecheck`
* **Commits are signed off:** Yes (`git commit -s`)