### PR TITLE
test(utils): confirm request timing utility enforces hard ceilings on extreme sub-millisecond durations

### DIFF
--- a/hushh-webapp/__tests__/utils/request-timeouts.test.ts
+++ b/hushh-webapp/__tests__/utils/request-timeouts.test.ts
@@ -244,4 +244,17 @@ describe("resolveSlowRequestTimeoutMs — fringe-input boundary fallbacks", () =
     expect(Number.isFinite(result)).toBe(true);
     expect(Number.isInteger(result)).toBe(true);
   });
+
+  it("applies the development floor for extreme sub-millisecond defaults", () => {
+    process.env.NEXT_PUBLIC_APP_ENV = "development";
+    delete process.env.APP_RUNTIME_PROFILE;
+    delete process.env.ENVIRONMENT;
+    delete process.env.HUSHH_SLOW_REQUEST_TIMEOUT_MS;
+
+    const result = resolveSlowRequestTimeoutMs(Number("0.000025"));
+
+    expect(result).toBe(SAFE_FLOOR);
+    expect(Number.isFinite(result)).toBe(true);
+    expect(Number.isInteger(result)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Description
Adds a focused utility test for the production request configuration and timing helper utilities. The test feeds an extreme sub-millisecond precision decimal string (`0.000025`) into the existing slow-request timeout resolver and verifies that the current development runtime floor is applied cleanly.

This is test-only coverage for an existing production utility; it does not add a parallel formatter or new runtime behavior.

## Impact Map (Required)
* **Routes touched:** None (Test-only addition)

## Privacy & Consent
* **Does this change access user data?** No
* **If yes, have you implemented checkConsentToken()?** Not applicable
* **Sensitive surface touched:** None; test-only coverage of existing configuration utility
* **Error path, rollback, or safe-failure behavior proved:** Not applicable; test-only addition

## Review-Ready Contract
* **Title, body, changed files, and tests describe the same contract:** Yes
* **Existing implementation was checked:** This extends coverage for the core request timing/configuration utility file rather than adding a duplicate utility.
* **Reachable production attach point:** The existing helper resolves slow request timeout boundaries before client-side request timing behavior uses them.
* **New tests import and exercise production code:** Yes, exercises `resolveSlowRequestTimeoutMs` directly.
* **New helpers/components/services are wired cleanly:** Yes; no new runtime helper is added.

## Tri-Flow Architecture Check
* **Web:** Test-only utility coverage; no route/runtime change.
* **iOS:** Not applicable.
* **Android:** Not applicable.

## Testing
* **Tested on Web:** `npm test -- __tests__/utils/request-timeouts.test.ts`
* **Typecheck:** `npm run typecheck`
* **Commits are signed off:** Yes (`git commit -s`)