### PR TITLE
test(consent): verify sparse array payloads default closed

### DIFF
--- a/hushh-webapp/__tests__/utils/normalize-consent.test.ts
+++ b/hushh-webapp/__tests__/utils/normalize-consent.test.ts
@@ -228,6 +228,7 @@ describe("normalizeConsentResponse — malformed payload defaults to strict deny
       42 as never,
       false as never,
       [] as never,
+      [true, , false] as never,
     ];
 
     for (const input of corruptedInputs) {


### PR DESCRIPTION
## Description
Adds a focused utility test for the production privacy consent normalization utility. The test includes a sparse primitive array containing an explicit index gap (`[true, , false]`) in the existing malformed-payload coverage and verifies that `normalizeConsentResponse` treats the array-shaped payload as invalid and defaults to the closed deny state.

This is test-only coverage for an existing production utility; it does not add a parallel formatter, parser, or runtime behavior.

## Impact Map (Required)
* **Routes touched:** None (Test-only addition)

## Privacy & Consent
* **Does this change access user data?** No
* **If yes, have you implemented checkConsentToken()?** Not applicable
* **Sensitive surface touched:** None; test-only coverage of existing consent normalization parser
* **Error path, rollback, or safe-failure behavior proved:** Not applicable; test-only addition

## Review-Ready Contract
* **Title, body, changed files, and tests describe the same contract:** Yes
* **Existing implementation was checked:** This extends the existing malformed-payload test vector for `normalizeConsentResponse`; it does not introduce a duplicate utility.
* **Reachable production attach point:** `normalizeConsentResponse` normalizes consent response payloads into the closed/open consent state used by privacy-gated flows.
* **New tests import and exercise production code:** Yes, exercises production normalization utilities directly.
* **New helpers/components/services are wired cleanly:** Yes; no new runtime helper is added.

## Tri-Flow Architecture Check
* **Web:** Test-only utility coverage; no route/runtime change.
* **iOS:** Not applicable.
* **Android:** Not applicable.

## Testing
* **Tested on Web:** `npm test -- __tests__/utils/normalize-consent.test.ts`
* **Typecheck:** `npm run typecheck`
* **Commits are signed off:** Yes (`git commit -s`)