### PR TITLE
test(utils): preserve invalid timeout override fallback

### DIFF
--- a/hushh-webapp/__tests__/utils/request-timeouts.test.ts
+++ b/hushh-webapp/__tests__/utils/request-timeouts.test.ts
@@ -46,6 +46,12 @@ describe("resolveSlowRequestTimeoutMs", () => {
 
     expect(resolveSlowRequestTimeoutMs(20_000)).toBe(33_000);
   });
+    it("ignores invalid explicit timeout overrides", () => {
+    process.env.NEXT_PUBLIC_APP_ENV = "uat";
+    process.env.HUSHH_SLOW_REQUEST_TIMEOUT_MS = "not-a-number";
+
+    expect(resolveSlowRequestTimeoutMs(20_000)).toBe(20_000);
+  });
 });
 
 // ── Fringe-input boundary fallbacks ──────────────────────────────────────────


### PR DESCRIPTION
## Motivation

The slow-request timeout resolver supports explicit timeout overrides through environment configuration. Invalid override values should not bypass the existing fallback contract or introduce unstable timeout behavior.

This regression coverage protects invalid override handling and preserves the fallback timeout contract.

## What Changed

Added regression coverage in:

`__tests__/utils/request-timeouts.test.ts`

## Covered Scenario

* preserves invalid timeout override fallback
* verifies non-numeric timeout override values are ignored
* confirms fallback behavior continues to use the provided default timeout
* protects timeout configuration stability
* prevents regressions in environment-based timeout resolution

## Validation

```bash
npm run test -- request-timeouts
npm run lint
npm run typecheck
```

## Notes

* test-only change
* no production code modifications
* no runtime behavior changes
* DCO sign-off included
