### PR TITLE
Test/negative timeout override fallback

### DIFF
--- a/hushh-webapp/__tests__/utils/request-timeouts.test.ts
+++ b/hushh-webapp/__tests__/utils/request-timeouts.test.ts
@@ -46,6 +46,12 @@ describe("resolveSlowRequestTimeoutMs", () => {
 
     expect(resolveSlowRequestTimeoutMs(20_000)).toBe(33_000);
   });
+    it("ignores invalid explicit timeout overrides", () => {
+    process.env.NEXT_PUBLIC_APP_ENV = "uat";
+    process.env.HUSHH_SLOW_REQUEST_TIMEOUT_MS = "not-a-number";
+
+    expect(resolveSlowRequestTimeoutMs(20_000)).toBe(20_000);
+  });
 });
 
 // ── Fringe-input boundary fallbacks ──────────────────────────────────────────

--- a/hushh-webapp/__tests__/utils/request-timeouts.test.ts
+++ b/hushh-webapp/__tests__/utils/request-timeouts.test.ts
@@ -250,4 +250,10 @@ describe("resolveSlowRequestTimeoutMs — fringe-input boundary fallbacks", () =
     expect(Number.isFinite(result)).toBe(true);
     expect(Number.isInteger(result)).toBe(true);
   });
+  it("ignores negative explicit timeout overrides", () => {
+    process.env.NEXT_PUBLIC_APP_ENV = "uat";
+    process.env.HUSHH_SLOW_REQUEST_TIMEOUT_MS = "-1000";
+
+    expect(resolveSlowRequestTimeoutMs(20_000)).toBe(20_000);
+  });
 });


### PR DESCRIPTION
## Motivation

The slow request timeout resolver supports environment-based timeout overrides. Invalid negative override values should not replace valid timeout defaults or alter the existing fallback contract.

This regression coverage protects negative override handling and ensures timeout resolution remains stable.

## What Changed

Added regression coverage in:

`__tests__/utils/request-timeouts.test.ts`

## Covered Scenario

* preserves negative timeout override fallback
* verifies negative timeout override values are ignored
* confirms valid default timeout values remain unchanged
* protects timeout configuration stability
* prevents regressions in environment override handling

## Validation

```bash
npm run test -- request-timeouts
npm run lint
npm run typecheck
```

## Notes

* test-only change
* no production code modifications
* no runtime behavior changes
* DCO sign-off included
