### PR TITLE
test(utils): preserve empty timeout override fallback

### DIFF
--- a/hushh-webapp/__tests__/utils/request-timeouts.test.ts
+++ b/hushh-webapp/__tests__/utils/request-timeouts.test.ts
@@ -244,4 +244,10 @@ describe("resolveSlowRequestTimeoutMs — fringe-input boundary fallbacks", () =
     expect(Number.isFinite(result)).toBe(true);
     expect(Number.isInteger(result)).toBe(true);
   });
+    it("falls back to the default timeout when the override is an empty string", () => {
+  process.env.NEXT_PUBLIC_APP_ENV = "uat";
+  process.env.HUSHH_SLOW_REQUEST_TIMEOUT_MS = "";
+
+  expect(resolveSlowRequestTimeoutMs(20_000)).toBe(20_000);
+});
 });


### PR DESCRIPTION
## Motivation

The slow request timeout resolver accepts environment-based timeout overrides. Empty-string override values should not bypass the existing timeout resolution contract or replace valid defaults.

This regression coverage protects empty override handling and preserves timeout fallback behavior.

## What Changed

Added regression coverage in:

`__tests__/utils/request-timeouts.test.ts`

## Covered Scenario

* preserves empty timeout override fallback
* verifies empty override values are ignored
* confirms valid default timeout values remain unchanged
* protects timeout configuration stability
* prevents regressions in environment override parsing

## Validation

```bash
npm run test -- request-timeouts
npm run lint
npm run typecheck
```

## Notes

* test-only change
* no production code modifications
* no runtime behavior changes
* DCO sign-off included
