### PR TITLE
fix(kpi-card): improve screen reader metric presentation

### DIFF
--- a/hushh-webapp/components/kai/cards/kpi-card.tsx
+++ b/hushh-webapp/components/kai/cards/kpi-card.tsx
@@ -109,7 +109,7 @@ export function KPICard({
         {/* Header with icon and title - Icon followed by Title */}
         <div className="flex items-center gap-2.5 mb-2">
           {icon && (
-            <div className={cn("text-primary shrink-0", styles.icon)}>
+            <div className={cn("text-primary shrink-0", styles.icon)} aria-hidden="true">
               {icon}
             </div>
           )}
@@ -119,7 +119,12 @@ export function KPICard({
         </div>
 
         {/* Value */}
-        <p className={cn("font-black tracking-tighter leading-tight", styles.value)}>{value}</p>
+        <p
+          className={cn("font-black tracking-tighter leading-tight", styles.value)}
+          aria-label={`${title}: ${value}`}
+        >
+          {value}
+        </p>
 
         {/* Optional one-line description */}
         {description && (
@@ -131,7 +136,7 @@ export function KPICard({
         {/* Change indicator */}
         {change !== undefined && (
           <div className={cn("flex items-center gap-1 mt-1.5", styles.change, trendColor)}>
-            <TrendIcon className="w-3.5 h-3.5" />
+            <TrendIcon className="w-3.5 h-3.5" aria-hidden="true" />
             <span className="font-bold">
               {isPositive && !isNeutral ? "+" : ""}
               {change.toFixed(2)}%


### PR DESCRIPTION
## Summary

Improves screen reader announcements in `KpiCard` by providing metric context for values and removing decorative icons from the accessibility tree.

## Changes

### `components/kai/cards/kpi-card.tsx`

* Adds an `aria-label` to the KPI value element so assistive technologies announce both the metric title and value together.
* Marks the decorative KPI icon wrapper as `aria-hidden="true"`.
* Marks the decorative trend icon as `aria-hidden="true"`.

## Accessibility Impact

Previously, KPI values could be announced as standalone numbers without sufficient context. This change associates each value with its metric title and suppresses decorative visual indicators that do not convey additional information.

## Scope

* Single file changed
* Accessibility-only attribute updates
* No visual changes
* No behavior changes
* No business logic changes
