### PR TITLE
fix(kai-preferences-wizard): improve accessibility semantics

### DIFF
--- a/hushh-webapp/components/kai/onboarding/KaiPreferencesSheet.tsx
+++ b/hushh-webapp/components/kai/onboarding/KaiPreferencesSheet.tsx
@@ -83,7 +83,10 @@ export function KaiPreferencesSheet(props: {
                 <HushhLoader label="Loading preferences..." />
               </div>
             ) : !profile ? (
-              <div className="p-6 text-sm text-muted-foreground">
+              <div
+                className="p-6 text-sm text-muted-foreground"
+                role="alert"
+              >
                 Couldn&#39;t load preferences. Close and reopen to retry.
               </div>
             ) : (

--- a/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
+++ b/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
@@ -231,7 +231,9 @@ export function KaiPreferencesWizard(props: {
             <span className="font-medium">
               Step {currentStep} of {total}
             </span>
-            <span className="tabular-nums">{progressValue}%</span>
+            <span className="tabular-nums" aria-hidden="true">
+              {progressValue}%
+            </span>
           </div>
           <Progress value={progressValue} className="h-1 rounded-full bg-muted" />
         </div>
@@ -428,6 +430,7 @@ function RadioCardItem(props: { value: string; label: string }) {
           {props.label}
         </p>
         <div
+          aria-hidden="true"
           className={cn(
             "h-5 w-5 rounded-full border grid place-items-center",
             "border-muted-foreground/30"


### PR DESCRIPTION
## Summary

Improves accessibility semantics in the Kai Preferences onboarding flow by hiding decorative UI from assistive technologies and ensuring error states are announced immediately.

## Changes

### components/kai/onboarding/KaiPreferencesWizard.tsx

* Added `aria-hidden="true"` to the decorative custom radio indicator wrapper
* Added `aria-hidden="true"` to the visual progress percentage, preventing duplicate progress announcements when step information is already conveyed elsewhere

### components/kai/onboarding/KaiPreferencesSheet.tsx

* Added `role="alert"` to the preferences loading error state so screen readers announce the failure immediately

## Accessibility Impact

* Decorative visual indicators are removed from the accessibility tree
* Error states are announced automatically to assistive technology users
* No keyboard interaction changes
* No focus management changes
* No onboarding flow changes

## Risk

Low risk.

The change consists entirely of additive accessibility attributes and does not modify state management, navigation, rendering flow, or business logic.
