### PR TITLE
fix(command-palette): add trigger accessibility semantics

### DIFF
--- a/hushh-webapp/components/kai/kai-search-bar.tsx
+++ b/hushh-webapp/components/kai/kai-search-bar.tsx
@@ -1692,6 +1692,8 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
                 className="h-10 w-full min-w-0 px-2 text-[12px] sm:text-[13px]"
                 contentClassName="gap-1.5"
                 aria-label="Search RIA workspace"
+                aria-expanded={open}
+                aria-haspopup="dialog"
                 onClick={() => setOpen(true)}
               >
                 <Search className="h-4 w-4 shrink-0" />


### PR DESCRIPTION
## Summary

Improves accessibility semantics for the command palette trigger by exposing its relationship to the dialog it opens.

## Changes

### components/kai/kai-search-bar.tsx

* Added `aria-expanded={open}` to reflect the open/closed state of the command palette
* Added `aria-haspopup="dialog"` to indicate that the control opens a dialog surface

## Accessibility Impact

* Exposes dialog state to assistive technologies
* Communicates that the search control opens a dialog
* Aligns with standard WAI-ARIA disclosure and dialog-trigger patterns

## Risk

Low risk.

This change only adds declarative accessibility attributes and does not modify command palette behavior, keyboard handling, routing, state management, or search functionality.
