### PR TITLE
fix(holdings-drawer): add accessible title and description

### DIFF
--- a/hushh-webapp/components/kai/holdings/holding-details-drawer.tsx
+++ b/hushh-webapp/components/kai/holdings/holding-details-drawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Drawer, DrawerContent, DrawerFooter, DrawerHeader, DrawerTitle } from "@/components/ui/drawer";
+import { Drawer, DrawerContent, DrawerDescription, DrawerFooter, DrawerHeader, DrawerTitle } from "@/components/ui/drawer";
 import { Button as MorphyButton } from "@/lib/morphy-ux/button";
 import { cn } from "@/lib/utils";
 import type { HoldingMobileCardViewModel } from "@/components/kai/holdings/holding-mobile-card";
@@ -71,9 +71,9 @@ export function HoldingDetailsDrawer({
           <DrawerTitle className="app-card-title text-left text-foreground">
             {holding?.symbol || "Holding Details"}
           </DrawerTitle>
-          <p className="app-body-text app-title-subtitle-gap text-left text-muted-foreground">
+          <DrawerDescription className="app-body-text app-title-subtitle-gap text-left text-muted-foreground">
             {holding?.name || "Select a holding"}
-          </p>
+          </DrawerDescription>
         </DrawerHeader>
 
         <div className="grid max-h-[60svh] gap-2 overflow-y-auto px-5 pb-3 sm:grid-cols-2">


### PR DESCRIPTION
## Summary

Completes the accessibility contract for `HoldingDetailsDrawer` by replacing the subtitle `<p>` with `DrawerDescription`.

## Problem

The drawer already exposes a `DrawerTitle`, but its subtitle was rendered as a plain paragraph element. Because it was not rendered through `DrawerDescription`, the drawer content was not connected to the dialog description relationship used by the underlying accessibility primitives.

As a result, assistive technologies could announce the drawer title without the associated holding name description.

## Changes

### `components/kai/holdings/holding-details-drawer.tsx`

* Added `DrawerDescription` import from `@/components/ui/drawer`
* Replaced the subtitle `<p>` element with `DrawerDescription`
* Preserved all existing styling classes
* Preserved all existing displayed text

## Accessibility Impact

* Enables dialog description wiring through the drawer primitive
* Improves screen-reader announcement of drawer content
* Maintains title + description parity with other drawer surfaces

## Risk

* Single-file change
* No logic changes
* No behavioral changes
* No visual changes
* Additive accessibility improvement only
