### PR TITLE
fix(holdings-mobile-list): add aria-label and group semantics to search and filter controls

### DIFF
--- a/hushh-webapp/components/kai/holdings/holdings-mobile-list.tsx
+++ b/hushh-webapp/components/kai/holdings/holdings-mobile-list.tsx
@@ -217,7 +217,11 @@ export function HoldingsMobileList({
   return (
     <>
       <div className="space-y-3">
-        <div className="grid h-10 w-full grid-cols-4 gap-1 rounded-xl bg-background/80 p-0.5">
+        <div
+          role="group"
+          aria-label="Filter holdings"
+          className="grid h-10 w-full grid-cols-4 gap-1 rounded-xl bg-background/80 p-0.5"
+        >
           {FILTERS.map((filter) => {
             const selected = activeFilter === filter.key;
             return (
@@ -240,7 +244,10 @@ export function HoldingsMobileList({
         </div>
 
         <div className="relative">
-          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Search
+            aria-hidden="true"
+            className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+          />
           <Input
             value={searchTerm}
             onChange={(event) => setSearchTerm(event.target.value)}
@@ -249,6 +256,7 @@ export function HoldingsMobileList({
             autoCapitalize="off"
             autoCorrect="off"
             spellCheck={false}
+            aria-label="Search holdings"
           />
         </div>
 


### PR DESCRIPTION
## Summary

Improves accessibility of the mobile holdings search and filter controls by adding explicit labeling and grouping semantics.

## Problem

The mobile holdings list search surface lacked several accessibility attributes already present in the repository's DataTable search implementation:

* Search input had no explicit accessible name
* Decorative search icon remained exposed to assistive technologies
* Filter buttons were not grouped under a named control group

This reduced discoverability and context for screen-reader users.

## Changes

### `components/kai/holdings/holdings-mobile-list.tsx`

* Added `role="group"` and `aria-label="Filter holdings"` to the filter button container
* Added `aria-hidden="true"` to the decorative search icon
* Added `aria-label="Search holdings"` to the search input

## Accessibility Impact

* Provides a stable accessible name for the search field
* Removes decorative icon noise from the accessibility tree
* Allows assistive technologies to announce the filter controls as a named group

## Pattern Reference

Matches the accessibility pattern already used by the repository's DataTable search controls.

## Risk

* Single file change
* Attribute additions only
* No logic changes
* No behavioral changes
* No visual changes

## Checklist

* [x] No visual changes
* [x] No behavioral changes
* [x] Accessibility-only improvement
* [x] Single-file change
* [x] Additive-only
