### PR TITLE
fix(holdings-search): add autoComplete="off" parity with DataTable search input

### DIFF
--- a/hushh-webapp/components/kai/holdings/holdings-mobile-list.tsx
+++ b/hushh-webapp/components/kai/holdings/holdings-mobile-list.tsx
@@ -247,6 +247,7 @@ export function HoldingsMobileList({
             placeholder="Search holdings by ticker or company"
             className="app-body-text h-10 rounded-full border-border/60 bg-background/70 pl-9 pr-4 text-sm"
             autoCapitalize="off"
+            autoComplete="off"
             autoCorrect="off"
             spellCheck={false}
           />


### PR DESCRIPTION
## Summary

Adds `autoComplete="off"` to the holdings mobile search input, aligning it with the existing DataTable search implementation.

## Problem

The holdings mobile search input already disables:

* `autoCapitalize`
* `autoCorrect`
* `spellCheck`

but does not disable browser autocomplete.

The repository's DataTable search input already includes `autoComplete="off"`, creating a small parity gap between the two search experiences.

## Solution

Add:

```tsx
autoComplete="off"
```

to the holdings mobile search input.

## Changes

### `components/kai/holdings/holdings-mobile-list.tsx`

* Added `autoComplete="off"` to the search input

## Pattern Reference

Matches the existing DataTable search input configuration:

```tsx
autoComplete="off"
autoCorrect="off"
autoCapitalize="off"
spellCheck={false}
```

## Risk

* Single file
* Single-line change
* No logic changes
* No behavioral changes
* No visual changes
* No dependency changes

## Checklist

* [x] No visual changes
* [x] No behavioral changes
* [x] Additive only
* [x] Single-file change
* [x] Existing repository pattern
* [x] Very low conflict surface
