### PR TITLE
fix(cwe209): redact CrdScrapeProxyError detail in crd_scraper responses

### DIFF
--- a/consent-protocol/api/routes/crd_scraper.py
+++ b/consent-protocol/api/routes/crd_scraper.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Request
@@ -17,6 +18,8 @@ from hushh_mcp.services.crd_scrape_proxy_service import (
 )
 
 router = APIRouter(prefix="/api/ria", tags=["RIA", "CRD Scraper"])
+
+logger = logging.getLogger(__name__)
 
 _JobId = Annotated[str, Path(min_length=1, max_length=128)]
 
@@ -113,7 +116,13 @@ async def _call_provider(coro: Any) -> CrdScrapeProviderResponse:
             detail={"code": "CRD_INVALID_REQUEST", "message": "Invalid request parameters."},
         )
     except CrdScrapeProxyError as exc:
-        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+        # CWE-209: do not forward the internal proxy error verbatim to the client.
+        # Log the detail server-side; return a generic message with the status.
+        logger.warning("crd_scraper.proxy_error status=%s: %s", exc.status_code, exc)
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail={"code": "CRD_UPSTREAM_ERROR", "message": "Upstream request failed."},
+        ) from exc
 
 
 def _request_id(request: Request) -> str | None:


### PR DESCRIPTION
## What

Closes the last residual CWE-209 information leak in `crd_scraper.py`: the `CrdScrapeProxyError` branch still forwarded the internal proxy error verbatim via `detail=str(exc)`. Now logged server-side, with a generic `{code, message}` returned to the client.

## Why

The `ValueError` branch was already redacted by a prior PR. This patch salvages the still-needed portion of #1863 after its other hunks were superseded by sibling PRs and its branch fell into a moving-base conflict loop. Applied as a surgical maintainer patch so the security fix lands cleanly without the conflict churn.

## Verification
- `python3 -m py_compile` passes
- no `detail=str(exc)` leak remains in the file
- formatting clean

🤖 Autonomous governance: strengthens the codebase (closes a real info-leak), CI-green path.