### PR TITLE
test(mcp): verify package bin entrypoint print-config output

### DIFF
--- a/packages/hushh-mcp/bin-config.test.ts
+++ b/packages/hushh-mcp/bin-config.test.ts
@@ -1,0 +1,25 @@
+import { exec } from "node:child_process";
+import { createRequire } from "node:module";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const execAsync = promisify(exec);
+const require = createRequire(import.meta.url);
+const packageJson = require("./package.json") as {
+  bin: Record<string, string>;
+};
+
+describe("hushh-mcp CLI config output", () => {
+  it("prints the MCP config through the package entrypoint executable", async () => {
+    expect(packageJson.bin["hushh-mcp"]).toBe("bin/hushh-mcp.js");
+
+    const { stdout, stderr } = await execAsync(`node ${packageJson.bin["hushh-mcp"]} --print-config`, {
+      cwd: process.cwd(),
+    });
+
+    expect(stderr).toBe("");
+    expect(stdout).toContain('"mcpServers"');
+    expect(stdout).toContain('"hushh-consent"');
+    expect(stdout).toContain('"@hushh/mcp"');
+  });
+});


### PR DESCRIPTION
## Description
Adds focused, test-only integration coverage for the canonical `@hushh/mcp` package binary entrypoint. The test imports the package manifest with `createRequire`, verifies the published `bin[hushh-mcp]` entry points to `bin/hushh-mcp.js`, and executes that declared entrypoint with `--print-config` to verify the expected MCP configuration output.

This does not assume internal helpers, a `src/` directory, or new MCP parser behavior. It exercises the existing package entrypoint contract directly.

## Canonical Attachment Plan
* **Target Package/Module:** `packages/hushh-mcp/package.json` and `packages/hushh-mcp/bin/hushh-mcp.js`
* **Test Contract:** `packages/hushh-mcp/bin-config.test.ts`
* **Capability Exercised:** Package `bin` entrypoint resolution and `--print-config` CLI output
* **Execution Validation Track:** Package entrypoint integration verification via `child_process.exec`

## Impact Map (Required)
* **Routes touched:** None (Test-only addition)
* **Runtime code touched:** None
* **Generated files touched:** None
* **Docs touched:** None

## Privacy & Consent
* **Does this change access user data?** No
* **If yes, have you implemented checkConsentToken()?** Not applicable
* **Sensitive surface touched:** None; test-only execution coverage of shell configuration parameters
* **Error path, rollback, or safe-failure behavior proved:** Not applicable; test-only addition

## Review-Ready Contract
* **Title, body, changed files, and tests describe the same contract:** Yes
* **Concrete Attachment Plan Proved:** Yes; the test imports the package manifest and executes the declared package binary entrypoint.
* **Existing implementation was checked:** Yes; `packages/hushh-mcp` contains `bin/hushh-mcp.js` and no `src/` helper surface is assumed.
* **New tests import and exercise production/package code:** Yes; uses `createRequire` to load `./package.json` and executes the manifest-declared `bin` target.
* **New helpers/components/services are wired cleanly:** Yes; no new runtime helper is added.

## Tri-Flow Architecture Check
* **Web:** Not applicable; package test-only addition.
* **iOS:** Not applicable.
* **Android:** Not applicable.

## Proofs / Testing
* **MCP package test:** `..\\..\\hushh-webapp\\node_modules\\.bin\\vitest.cmd run bin-config.test.ts` from `packages/hushh-mcp` - passed
* **MCP config smoke:** `npm run print-config` from `packages/hushh-mcp` - passed
* **Typecheck:** `npm run typecheck` from `hushh-webapp` - passed
* **Known unrelated check state:** `npm run docs:check` from `packages/hushh-mcp` reports existing README render drift; README was intentionally not changed to keep this PR test-only and focused on the production/package entrypoint blocker.
* **Commits are signed off:** Yes (`git commit -s`)