### PR TITLE
fix(agent-chat-workspace): guard typed submit path against in-flight resubmission

### DIFF
--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -721,6 +721,7 @@ export function AgentChatWorkspace({
   const voiceTtsSpeakingRef = useRef(false);
   const pkmAbortControllersRef = useRef<Set<AbortController>>(new Set());
   const latestVisibleTurnIdRef = useRef<string | null>(null);
+  const typedSubmitInFlightRef = useRef(false);
 
   const voiceActive = voiceState !== "idle";
   const voiceMuted = voiceState === "muted";
@@ -2195,7 +2196,14 @@ export function AgentChatWorkspace({
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    await runAgentTurn(input, { source: "typed" });
+    if (!canSend || typedSubmitInFlightRef.current) return;
+
+    typedSubmitInFlightRef.current = true;
+    try {
+      await runAgentTurn(input, { source: "typed" });
+    } finally {
+      typedSubmitInFlightRef.current = false;
+    }
   };
 
   function setAgentVoiceStatus(status: AgentVoiceStatus, message?: string | null) {


### PR DESCRIPTION
## Description

Prevents duplicate typed chat submissions triggered by repeated Enter key presses while a request is already pending.

## Root cause

`AgentChatWorkspace` let the typed submit path call `runAgentTurn` again before the previous typed request finished. Rapid Enter presses could therefore schedule duplicate async turns during latency.

## What changed

- Added `typedSubmitInFlightRef` to guard the typed submit handler while an async `runAgentTurn` call is active.
- Preserved the existing `canSend` validation and disabled-button behavior.
- Limited the change to `hushh-webapp/components/agent/agent-chat-workspace.tsx`.

## No Overlap Proof

`canSend` is a UI-layer flag reflecting input validity.
`typedSubmitInFlightRef` is an async ref guard preventing a second `runAgentTurn` during an active in-flight call.
Different layers, not redundant.

## Caller Proof

Caller: `hushh-webapp/app/agent/page.tsx` -> `<AgentScreen />` -> `hushh-webapp/components/agent/agent-screen.tsx` -> `<AgentChatWorkspace />`
Route: `/agent` - authenticated users

Note: in this branch, `hushh-webapp/app/kai/page.tsx` renders `<KaiMarketPreviewView />`, not `<AgentChatWorkspace />`.

## Testing

- Ran `npm run lint`
- Ran `npm run build`
- Verified repeated Enter presses do not trigger duplicate submissions
- Verified forms continue submitting normally after request completion
- Verified existing accessibility and keyboard navigation behavior remain unchanged