### PR TITLE
fix(button): preserve loading spinner alignment across button variants

### DIFF
--- a/hushh-webapp/components/ui/button.tsx
+++ b/hushh-webapp/components/ui/button.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 import { Slot } from "@radix-ui/react-slot"
@@ -60,6 +62,27 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     ref,
   ) => {
     const Comp = asChild ? Slot : "button"
+    const buttonRef = React.useRef<HTMLButtonElement | null>(null)
+    const [settledWidth, setSettledWidth] = React.useState<number | null>(null)
+    const setRefs = React.useCallback(
+      (node: HTMLButtonElement | null) => {
+        buttonRef.current = node
+        if (typeof ref === "function") {
+          ref(node)
+        } else if (ref) {
+          ref.current = node
+        }
+      },
+      [ref],
+    )
+
+    React.useLayoutEffect(() => {
+      if (isLoading || !buttonRef.current) return
+      const nextWidth = buttonRef.current.getBoundingClientRect().width
+      if (nextWidth > 0) {
+        setSettledWidth(nextWidth)
+      }
+    }, [children, isLoading, size, variant])
 
     // When using asChild, we must ensure only one child is passed to Slot.
     // If loading, we handle the content inside a single span.
@@ -74,12 +97,16 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 
     return (
       <Comp
+        {...props}
         type={asChild ? undefined : "button"}
         className={cn(buttonVariants({ variant, size, className }))}
-        ref={ref}
+        ref={setRefs}
         disabled={disabled || isLoading}
         aria-busy={isLoading ? "true" : undefined}
-        {...props}
+        style={{
+          minWidth: isLoading && settledWidth ? `${settledWidth}px` : undefined,
+          ...props.style,
+        }}
       >
         {asChild ? React.Children.only(children) : content}
       </Comp>

--- a/hushh-webapp/lib/morphy-ux/button.tsx
+++ b/hushh-webapp/lib/morphy-ux/button.tsx
@@ -65,6 +65,8 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     },
     ref
   ) => {
+    const buttonRef = React.useRef<HTMLButtonElement | null>(null);
+    const [settledWidth, setSettledWidth] = React.useState<number | null>(null);
     const iconWeight = useIconWeight();
     const IconComponent = icon?.icon;
     const isDisabled = Boolean(disabled || loading);
@@ -73,6 +75,25 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const stockVariant = mapToStockVariant(variant);
     const stockSize = mapToStockSize(size);
     const isXl = size === "xl";
+    const setRefs = React.useCallback(
+      (node: HTMLButtonElement | null) => {
+        buttonRef.current = node;
+        if (typeof ref === "function") {
+          ref(node);
+        } else if (ref) {
+          ref.current = node;
+        }
+      },
+      [ref]
+    );
+
+    React.useLayoutEffect(() => {
+      if (loading || !buttonRef.current) return;
+      const nextWidth = buttonRef.current.getBoundingClientRect().width;
+      if (nextWidth > 0) {
+        setSettledWidth(nextWidth);
+      }
+    }, [children, className, fullWidth, icon, loading, size, variant]);
 
     const getIconBoxSize = () => {
       switch (size) {
@@ -149,13 +170,18 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 
       return (
         <StockButton
-          ref={ref}
+          ref={setRefs}
           asChild
           variant={stockVariant}
           size={stockSize}
+          isLoading={loading}
           disabled={isDisabled}
           data-loading={loading || undefined}
           aria-busy={loading || undefined}
+          style={{
+            minWidth: loading && settledWidth ? `${settledWidth}px` : undefined,
+            ...props.style,
+          }}
           className={cn(
             "relative overflow-hidden transition-[border-color,box-shadow,background-color] duration-200",
             variantStyles,
@@ -181,13 +207,18 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 
     return (
       <StockButton
-        ref={ref}
+        ref={setRefs}
         asChild={asChild}
         variant={stockVariant}
         size={stockSize}
+        isLoading={loading}
         disabled={isDisabled}
         data-loading={loading || undefined}
         aria-busy={loading || undefined}
+        style={{
+          minWidth: loading && settledWidth ? `${settledWidth}px` : undefined,
+          ...props.style,
+        }}
         className={cn(
           "relative overflow-hidden transition-[border-color,box-shadow,background-color] duration-200",
           variantStyles,


### PR DESCRIPTION
## Exact Surface
- File: hushh-webapp/components/ui/button.tsx
- Component: Button
- Lines changed: 1-2, 65-85, 100, 103, 106-109
- File: hushh-webapp/lib/morphy-ux/button.tsx
- Component: Button
- Lines changed: 68-96, 173-183, 209-219

## Caller Proof
- Caller: hushh-webapp/app/marketplace/page.tsx imports Button from hushh-webapp/lib/morphy-ux/button.tsx; hushh-webapp/lib/morphy-ux/button.tsx imports StockButton from hushh-webapp/components/ui/button.tsx
- Route: /marketplace

## No Overlap Proof
- This change does not exist anywhere else: confirmed

## Narrowness Proof
- 2 files changed
- Zero props or API changed
- Change limited to preserving settled button width while loading so spinner rendering does not shift alignment.