### PR TITLE
fix(ria-picks-page): autofocus first invalid field after validation failure

### DIFF
--- a/hushh-webapp/app/ria/picks/page.tsx
+++ b/hushh-webapp/app/ria/picks/page.tsx
@@ -781,6 +781,7 @@ function TopPicksEditor({
             return (
             <SurfaceInset
               key={row.id}
+              data-ria-picks-row-id={row.id}
               className={cn(
                 "space-y-3 p-3",
                 focusedRowId === row.id && "ring-2 ring-amber-300/70 dark:ring-amber-500/40"
@@ -858,7 +859,7 @@ function TopPicksEditor({
             </TableHeader>
             <TableBody>
               {visibleRows.map((row) => (
-                <TableRow key={row.id} className="align-top">
+                <TableRow key={row.id} data-ria-picks-row-id={row.id} className="align-top">
                   <TableCell className="space-y-2 px-3 py-2.5 align-top">
                     <TickerLookupField
                       rowId={row.id}
@@ -1014,6 +1015,7 @@ function AvoidEditor({
             return (
             <SurfaceInset
               key={row.id}
+              data-ria-picks-row-id={row.id}
               className={cn(
                 "space-y-3 p-3",
                 focusedRowId === row.id && "ring-2 ring-amber-300/70 dark:ring-amber-500/40"
@@ -1103,7 +1105,7 @@ function AvoidEditor({
             </TableHeader>
             <TableBody>
               {visibleRows.map((row) => (
-                <TableRow key={row.id} className="align-top">
+                <TableRow key={row.id} data-ria-picks-row-id={row.id} className="align-top">
                   <TableCell className="space-y-2 px-3 py-2.5 align-top">
                     <TickerLookupField
                       rowId={row.id}
@@ -1268,6 +1270,7 @@ function ScreeningEditor({
                 {filteredRows.map((row) => (
                   <SurfaceInset
                     key={row.id}
+                    data-ria-picks-row-id={row.id}
                     className={cn(
                       "space-y-3 p-3",
                       focusedRowId === row.id && "ring-2 ring-amber-300/70 dark:ring-amber-500/40"
@@ -1518,6 +1521,23 @@ export default function RiaPicksPage() {
       setValidationState({ packageErrors: [], rowErrors: {} });
     }
   }, [editing, picksResource.data?.package]);
+
+  useEffect(() => {
+    if (!focusedIssueRowId) return;
+    const timeoutId = window.setTimeout(() => {
+      const row = Array.from(
+        document.querySelectorAll<HTMLElement>("[data-ria-picks-row-id]")
+      ).find((element) => element.dataset.riaPicksRowId === focusedIssueRowId);
+      if (!row) return;
+      row.scrollIntoView({ block: "center", behavior: "smooth" });
+      row
+        .querySelector<HTMLElement>(
+          'input:not([disabled]):not([readonly]), textarea:not([disabled]), button[aria-haspopup="dialog"]:not([disabled])'
+        )
+        ?.focus();
+    }, 0);
+    return () => window.clearTimeout(timeoutId);
+  }, [category, focusedIssueRowId, showIssuesOnly]);
 
   useEffect(() => {
     if (!user || kaiRows.length > 0) return;
@@ -2083,6 +2103,20 @@ export default function RiaPicksPage() {
       const { payload, validation } = await validateDraft(draftPackage);
       setValidationState(validation);
       if (validation.packageErrors.length > 0 || Object.keys(validation.rowErrors).length > 0) {
+        const firstTopIssue = draftPackage.top_picks.find((row) => validation.rowErrors[row.id]?.length);
+        const firstAvoidIssue = draftPackage.avoid_rows.find((row) => validation.rowErrors[row.id]?.length);
+        const firstScreeningIssue = draftPackage.screening_sections
+          .flatMap((section) => section.rows)
+          .find((row) => validation.rowErrors[row.id]?.length);
+        const firstIssue =
+          firstTopIssue || firstAvoidIssue || firstScreeningIssue || null;
+
+        if (firstIssue) {
+          setCategory(
+            firstTopIssue ? "top-picks" : firstAvoidIssue ? "avoid" : "screening"
+          );
+          setFocusedIssueRowId(firstIssue.id);
+        }
         setShowIssuesOnly(true);
         toast.error("Fix the highlighted validation issues before saving.");
         return;


### PR DESCRIPTION
## Exact Surface
- File: hushh-webapp/app/ria/picks/page.tsx
- Component: RiaPicksPage
- Lines changed: 784, 862, 1018, 1108, 1273, 1525-1540, 2106-2119

## Caller Proof
- Caller: hushh-webapp/app/ria/picks/page.tsx is the Next.js App Router page export for this route
- Route: /ria/picks

## No Overlap Proof
- This change does not exist anywhere else: confirmed

## Narrowness Proof
- 1 file changed
- Zero props or API changed
- Change limited to focusing and scrolling the first invalid RIA picks row after validation failure.