### PR TITLE
test(mcp): verify package prepack stages runtime manifest

### DIFF
--- a/packages/hushh-mcp/stage-runtime.test.ts
+++ b/packages/hushh-mcp/stage-runtime.test.ts
@@ -1,0 +1,37 @@
+import { exec } from "node:child_process";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const execAsync = promisify(exec);
+const require = createRequire(import.meta.url);
+const packageJson = require("./package.json") as {
+  scripts: Record<string, string>;
+};
+const packageRoot = path.dirname(fileURLToPath(import.meta.url));
+const manifestPath = path.join(packageRoot, "vendor", "runtime-manifest.json");
+
+describe("hushh-mcp stage-runtime script asset", () => {
+  it("runs the package prepack staging script and writes the runtime manifest", async () => {
+    expect(packageJson.scripts.prepack).toBe("node ./scripts/stage-runtime.mjs");
+
+    const { stderr } = await execAsync("npm run prepack", {
+      cwd: packageRoot,
+    });
+
+    expect(stderr).toBe("");
+    expect(fs.existsSync(manifestPath)).toBe(true);
+
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as {
+      copyList: string[];
+      sourceRoot: string;
+    };
+    expect(manifest.sourceRoot).toContain("consent-protocol");
+    expect(manifest.copyList).toEqual(
+      expect.arrayContaining(["mcp_server.py", "hushh_mcp"]),
+    );
+  });
+});


### PR DESCRIPTION
## Description
Adds a focused, test-only package lifecycle check for the canonical `@hushh/mcp` runtime staging path. The test imports the real package manifest, verifies the declared `prepack` command, executes that package script, and asserts that the production staging script writes the expected runtime manifest for the vendored consent-protocol assets.

This is package-script coverage for an existing MCP developer surface. It does not add runtime helpers, app code, or duplicate staging logic.

## Canonical Attachment Plan
* **Target Package/Module:** `packages/hushh-mcp/package.json` and `packages/hushh-mcp/scripts/stage-runtime.mjs`
* **Exported Capabilities Exercised:** Package `prepack` lifecycle command and runtime manifest staging output
* **Execution Validation Track:** MCP package script integration via Vitest

## Impact Map (Required)
* **Routes touched:** None (Test-only addition)

## Privacy & Consent
* **Does this change access user data?** No
* **If yes, have you implemented checkConsentToken()?** Not applicable
* **Sensitive surface touched:** None; package lifecycle staging only
* **Error path, rollback, or safe-failure behavior proved:** The test executes the canonical staging command and verifies the manifest output exists with expected consent runtime entries.

## Review-Ready Contract
* **Title, body, and tests describe the same contract:** Yes
* **Concrete Attachment Plan Proved:** Yes; the test imports `./package.json`, asserts `scripts.prepack`, runs `npm run prepack`, and validates `vendor/runtime-manifest.json` generated by the real staging script.
* **New tests import and exercise production/package code:** Yes; this exercises the package manifest and the manifest-declared production script path rather than local mocks or text-only assertions.
* **Surface Alignment:** Validated. Footprint is isolated to `packages/hushh-mcp/stage-runtime.test.ts`.
* **Runtime behavior changed:** No.

## Tri-Flow Architecture Check
* **Web:** Not applicable.
* **iOS:** Not applicable.
* **Android:** Not applicable.
* **MCP Package:** Test-only lifecycle coverage for `@hushh/mcp`.

## Testing / Proofs
* **Focused package test:** `..\\..\\hushh-webapp\\node_modules\\.bin\\vitest.cmd run stage-runtime.test.ts` passed from `packages/hushh-mcp`.
* **MCP print config:** `npm run print-config` passed from `packages/hushh-mcp`.
* **Webapp typecheck:** `npm run typecheck` passed from `hushh-webapp`.
* **Known unrelated check:** `npm run docs:check` currently reports `README.md is out of date`; this PR intentionally does not widen into docs regeneration.
* **Commits are signed off:** Yes (`git commit -s`).