### PR TITLE
test(utils): cover custom timeout override key

### DIFF
--- a/hushh-webapp/__tests__/utils/request-timeouts.test.ts
+++ b/hushh-webapp/__tests__/utils/request-timeouts.test.ts
@@ -46,6 +46,19 @@ describe("resolveSlowRequestTimeoutMs", () => {
 
     expect(resolveSlowRequestTimeoutMs(20_000)).toBe(33_000);
   });
+    it("honors custom timeout override env keys", () => {
+    process.env.NEXT_PUBLIC_APP_ENV = "uat";
+    process.env.CUSTOM_SLOW_TIMEOUT_MS = "45000";
+    delete process.env.HUSHH_SLOW_REQUEST_TIMEOUT_MS;
+
+    expect(
+      resolveSlowRequestTimeoutMs(20_000, {
+        overrideEnvKey: "CUSTOM_SLOW_TIMEOUT_MS",
+      })
+    ).toBe(45_000);
+
+    delete process.env.CUSTOM_SLOW_TIMEOUT_MS;
+  });
 });
 
 // ── Fringe-input boundary fallbacks ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds test coverage for custom timeout override environment keys in `resolveSlowRequestTimeoutMs`.

## Changes

* Added a test verifying that `overrideEnvKey` reads timeout values from a custom environment variable.
* Confirms custom override values take precedence over the default timeout.
* Keeps existing timeout resolution behavior unchanged.

## Testing

```bash
npm test -- request-timeouts
```

Passed: 19/19 tests.
