### PR TITLE
fix(ria-client-workspace): keep request actions focusable after failures

### DIFF
--- a/hushh-webapp/components/ria/ria-client-workspace.tsx
+++ b/hushh-webapp/components/ria/ria-client-workspace.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   Loader2,
@@ -269,6 +269,7 @@ export function RiaClientWorkspace({
   const [selectedScopes, setSelectedScopes] = useState<string[]>([]);
   const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([]);
   const [requestReason, setRequestReason] = useState("");
+  const requestAccessButtonRef = useRef<HTMLButtonElement | null>(null);
 
   useEffect(() => {
     setActiveTab(initialTab);
@@ -348,6 +349,9 @@ export function RiaClientWorkspace({
       await refreshWorkspace();
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to send access request");
+      window.requestAnimationFrame(() => {
+        requestAccessButtonRef.current?.focus({ preventScroll: true });
+      });
     } finally {
       setRequestingAccess(false);
     }
@@ -815,6 +819,7 @@ export function RiaClientWorkspace({
 
                     <div className="flex flex-wrap gap-2">
                       <Button type="button"
+                        ref={requestAccessButtonRef}
                         variant="blue-gradient"
                         effect="fill"
                         data-voice-control-id="ria_client_workspace_send_request"


### PR DESCRIPTION
## Exact Surface
- File: hushh-webapp/components/ria/ria-client-workspace.tsx
- Component: RiaClientWorkspace
- Lines changed: 4, 272, 352-354, 822

## Caller Proof
- Caller: hushh-webapp/app/ria/clients/[userId]/page-client.tsx imports and renders RiaClientWorkspace
- Route: /ria/clients/[userId]

## No Overlap Proof
- This change does not exist anywhere else: confirmed

## Narrowness Proof
- 1 file changed
- Zero props or API changed
- Change limited to restoring focus to the request access action after a recoverable request failure.