### PR TITLE
fix(skeleton): prevent overflow inside responsive cards

### DIFF
--- a/hushh-webapp/components/ui/skeleton.tsx
+++ b/hushh-webapp/components/ui/skeleton.tsx
@@ -6,7 +6,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
       aria-hidden="true"
       data-slot="skeleton"
       className={cn(
-        "pointer-events-none overflow-hidden rounded-md bg-accent motion-safe:animate-pulse [contain:layout_paint]",
+        "pointer-events-none min-w-0 max-w-full overflow-hidden rounded-md bg-accent motion-safe:animate-pulse [contain:layout_paint]",
         className
       )}
       {...props}


### PR DESCRIPTION
## Exact Surface
- File: hushh-webapp/components/ui/skeleton.tsx
- Component: Skeleton
- Lines changed: 9

## Caller Proof
- Caller: hushh-webapp/app/one/location/page.tsx imports Skeleton from hushh-webapp/components/ui/skeleton.tsx
- Route: /one/location

## No Overlap Proof
- This change does not exist anywhere else: confirmed

## Narrowness Proof
- 1 file changed
- Zero props or API changed
- Change limited to constraining Skeleton width inside responsive card containers.