### PR TITLE
fix(data-table): stabilize height during loading transitions

### DIFF
--- a/hushh-webapp/__tests__/components/data-table.test.tsx
+++ b/hushh-webapp/__tests__/components/data-table.test.tsx
@@ -95,4 +95,21 @@ describe("DataTable", () => {
     expect(searchInput.getAttribute("placeholder")).toBe("Search records");
     expect(searchInput.getAttribute("aria-hidden")).toBeNull();
   });
+
+  it("reserves table height from the configured page size", () => {
+    const { container } = render(
+      <DataTable
+        columns={columns}
+        data={makeRows(3)}
+        enableSearch={false}
+        initialPageSize={5}
+      />
+    );
+
+    expect(
+      container
+        .querySelector('[data-slot="surface-data-table-shell"]')
+        ?.getAttribute("style")
+    ).toContain("min-height: 330px");
+  });
 });

--- a/hushh-webapp/components/app-ui/data-table.tsx
+++ b/hushh-webapp/components/app-ui/data-table.tsx
@@ -237,6 +237,7 @@ export function DataTable<TData, TValue>({
 
   const compact = density === "compact";
   const resolvedTableShellClassName = cn("w-full", tableContainerClassName);
+  const reservedTableHeight = (compact ? 37 : 45) + initialPageSize * (compact ? 41 : 57);
 
   return (
     <div
@@ -299,6 +300,7 @@ export function DataTable<TData, TValue>({
       <div
         className={cn(surfaceDataTableShellClassName, resolvedTableShellClassName)}
         data-slot="surface-data-table-shell"
+        style={{ minHeight: reservedTableHeight }}
       >
         <Table className={tableClassName}>
           <TableHeader


### PR DESCRIPTION
## Description

Stabilizes table height during loading transitions to prevent visual jumps and layout shifts while data is being fetched or refreshed.

## Why

Tables that dynamically change height between loading and loaded states can cause content below them to shift unexpectedly, creating a distracting user experience and making interfaces feel unstable. This is especially noticeable during refreshes, pagination changes, or slow network conditions.

Maintaining a consistent table footprint improves perceived performance and visual continuity.

## What changed

- Preserved table height during loading-to-loaded transitions
- Reduced layout shifts caused by asynchronous data updates
- Maintained existing loading indicators and table functionality
- Preserved existing responsive behavior across supported viewports

## Impact

- No API changes
- No schema changes
- No backend behavior changes
- Improves visual stability and user experience during data loading

## Testing

- Ran `npm run lint`
- Ran `npm run build`
- Verified table height remains stable during loading transitions
- Verified pagination, refresh, and data-loading flows continue functioning correctly
- Verified responsive layouts remain unaffected across supported screen sizes

## Notes

This PR intentionally focuses on frontend layout stability only and does not modify business logic, authentication flows, consent contracts, PKM behavior, backend services, or application architecture., PKM behavior, backend services, or application architecture.