### PR TITLE
test(utils): cover IPv6 loopback backend hints

### DIFF
--- a/hushh-webapp/__tests__/utils/backend-runtime.test.ts
+++ b/hushh-webapp/__tests__/utils/backend-runtime.test.ts
@@ -110,4 +110,13 @@ describe("backend runtime resolution", () => {
 
     expect(helper.getPythonApiUrl()).toContain("127.0.0.1");
   });
+        it("keeps IPv6 loopback backend hints as valid local development URLs", async () => {
+    process.env.NEXT_PUBLIC_APP_ENV = "development";
+    process.env.NEXT_PUBLIC_BACKEND_URL = "http://[::1]:8000";
+
+    const helper = await loadHelper();
+
+    expect(helper.getPythonApiUrl()).toBe("http://[::1]:8000");
+  });
 });
+


### PR DESCRIPTION
## Summary
Add test coverage for IPv6 loopback backend URLs used during local development.

## Changes
- Added a backend runtime test covering IPv6 loopback (`http://[::1]:8000`) backend hints.
- Verified local development backend resolution remains stable when IPv6 loopback addresses are provided.
- Preserved existing localhost canonicalization coverage.

## Test
npm test -- backend-runtime

Result:
✓ 12 tests passed
✓ backend runtime resolution coverage remains green