### PR TITLE
fix(a11y): hide decorative phone verification icons

### DIFF
--- a/hushh-webapp/components/auth/phone-verification-flow.tsx
+++ b/hushh-webapp/components/auth/phone-verification-flow.tsx
@@ -335,7 +335,7 @@ export function PhoneVerificationFlow({
         <div
           className={`${FLOW_SURFACE_RADIUS_CLASS_NAME} border border-emerald-500/20 bg-emerald-50/80 p-5 dark:bg-emerald-950/20`}
         >
-          <ShieldCheck className="h-10 w-10 text-emerald-600" />
+          <ShieldCheck aria-hidden="true" className="h-10 w-10 text-emerald-600" />
           <h2 className="mt-4 text-lg font-semibold text-foreground">Phone already linked</h2>
           <p className="mt-2 text-sm text-muted-foreground">
             This account already has a verified phone number:{" "}
@@ -447,7 +447,7 @@ export function PhoneVerificationFlow({
               fullWidth
               className={`h-12 ${FLOW_SURFACE_RADIUS_CLASS_NAME}`}
             >
-              {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : "Send verification code"}
+              {busy ? <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" /> : "Send verification code"}
             </Button>
             {onCancel ? (
               <Button
@@ -498,7 +498,7 @@ export function PhoneVerificationFlow({
               fullWidth
               className={`h-12 ${FLOW_SURFACE_RADIUS_CLASS_NAME}`}
             >
-              {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : confirmLabel || "Verify and continue"}
+              {busy ? <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" /> : confirmLabel || "Verify and continue"}
             </Button>
             <Button
               onClick={() => void handleStartVerification(true)}


### PR DESCRIPTION
## Summary

* Hide decorative phone verification icons from assistive technologies
* Prevent screen readers from announcing non-informational visual elements
* Improve accessibility of the phone verification flow

## Changes

* Added `aria-hidden="true"` to the linked-phone status icon
* Added `aria-hidden="true"` to loading spinner shown during verification code send
* Added `aria-hidden="true"` to loading spinner shown during verification confirmation

## Testing

* npm run lint
* npm run typecheck
