### PR TITLE
test(devex): verify package typecheck config contract

### DIFF
--- a/hushh-webapp/__tests__/devex-config.test.ts
+++ b/hushh-webapp/__tests__/devex-config.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import packageJson from "../package.json";
+import tsconfig from "../tsconfig.json";
+
+describe("DevEx configuration integrity", () => {
+  it("keeps the package typecheck script aligned with the TypeScript project config", () => {
+    expect(packageJson.scripts.typecheck).toBe("tsc --noEmit");
+
+    expect(tsconfig.compilerOptions.noEmit).toBe(true);
+    expect(tsconfig.compilerOptions.strict).toBe(true);
+    expect(tsconfig.compilerOptions.moduleResolution).toBe("bundler");
+    expect(tsconfig.include).toEqual(
+      expect.arrayContaining(["app/**/*.ts", "lib/**/*.ts"]),
+    );
+  });
+});


### PR DESCRIPTION
## Description
Adds a focused, test-only DevEx contract check for the canonical hushh-webapp TypeScript validation path. The test imports the real webapp package manifest and TypeScript project config, then verifies the declared `typecheck` script remains aligned with the `tsconfig.json` compiler contract used by CI.

This is DevEx/package-manifest coverage for existing project configuration. It does not add runtime helpers, app code, or duplicate parsing behavior.

## Canonical Attachment Plan
* **Target Package/Module:** `hushh-webapp/package.json` and `hushh-webapp/tsconfig.json`
* **Exported Capabilities Exercised:** Package `typecheck` command contract and TypeScript compiler configuration boundary
* **Execution Validation Track:** Web / Unit Test via Vitest plus TypeScript typecheck

## Impact Map (Required)
* **Routes touched:** None (Test-only addition)

## Privacy & Consent
* **Does this change access user data?** No
* **If yes, have you implemented checkConsentToken()?** Not applicable
* **Sensitive surface touched:** None; DevEx/package configuration only
* **Error path, rollback, or safe-failure behavior proved:** Not applicable; test-only configuration contract

## Review-Ready Contract
* **Title, body, and tests describe the same contract:** Yes
* **Concrete Attachment Plan Proved:** Yes; the test imports the real webapp package manifest and TypeScript config JSON modules instead of using local mocks or in-file helpers.
* **New tests import and exercise production/package code:** Yes; assertions are tied to `packageJson.scripts.typecheck` and `tsconfig.compilerOptions`.
* **Surface Alignment:** Validated. Footprint is isolated to `hushh-webapp/__tests__/devex-config.test.ts`.
* **Runtime behavior changed:** No.

## Tri-Flow Architecture Check
* **Web:** Test-only DevEx coverage for webapp typecheck configuration.
* **iOS:** Not applicable.
* **Android:** Not applicable.

## Testing / Proofs
* **Focused unit test:** `npm test -- __tests__/devex-config.test.ts` passed.
* **Typecheck:** `npm run typecheck` passed.
* **Commits are signed off:** Yes (`git commit -s`).