### PR TITLE
fix(button): prevent loading spinner overlap on narrow screens

### DIFF
--- a/hushh-webapp/components/ui/button.tsx
+++ b/hushh-webapp/components/ui/button.tsx
@@ -62,14 +62,16 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const Comp = asChild ? Slot : "button"
 
     // When using asChild, we must ensure only one child is passed to Slot.
-    // If loading, we handle the content inside a single span.
-    const content = (
-      <>
-        {isLoading && (
-          <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
-        )}
-        {isLoading ? <span className="opacity-0">{children}</span> : children}
-      </>
+    // If loading, keep the label's footprint while centering the spinner.
+    const content = isLoading ? (
+      <span className="relative inline-grid min-w-0 max-w-full items-center">
+        <span className="min-w-0 truncate opacity-0">{children}</span>
+        <span className="absolute inset-0 flex items-center justify-center">
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+        </span>
+      </span>
+    ) : (
+      children
     )
 
     return (


### PR DESCRIPTION
## Description

Prevents loading indicators from overlapping adjacent content and interactive elements on narrow screens by improving responsive spacing and layout behavior during loading states.

## Why

On smaller viewports, loading spinners can overlap button labels, icons, or nearby content when space becomes constrained. This can reduce readability, create visual clutter, and make interactive elements appear broken or unstable.

This change ensures loading states remain clear and visually consistent across supported screen sizes.

## What changed

- Improved responsive layout handling for loading indicators
- Prevented spinner overlap with button text and nearby UI elements
- Preserved existing loading behavior and visual feedback
- Maintained existing responsive design patterns and interactions

## Impact

- No API changes
- No schema changes
- No backend behavior changes
- Improves mobile usability and visual consistency

## Testing

- Ran `npm run lint`
- Ran `npm run build`
- Verified loading indicators do not overlap content on narrow screens
- Verified responsive layouts remain stable across supported breakpoints
- Verified existing loading and interaction behavior remains unchanged

## Notes

This PR intentionally focuses on frontend responsive layout correctness only and does not modify business logic, authentication flows, consent contracts, PKM behavior, backend services, or application architecture.