### PR TITLE
fix(portfolio-import): prevent duplicate submit clicks while pending

### DIFF
--- a/hushh-webapp/components/kai/views/portfolio-import-view.tsx
+++ b/hushh-webapp/components/kai/views/portfolio-import-view.tsx
@@ -64,7 +64,9 @@ export function PortfolioImportView({
   const [isDragging, setIsDragging] = useState(false);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [selectionError, setSelectionError] = useState<string | null>(null);
+  const [submitPending, setSubmitPending] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const isSubmittingImport = isUploading || submitPending;
 
   useEffect(() => {
     scrollAppToTop("auto");
@@ -129,9 +131,17 @@ export function PortfolioImportView({
   };
 
   const handleContinue = useCallback(() => {
-    if (!selectedFile || isUploading) return;
-    onFileSelect(selectedFile);
-  }, [selectedFile, isUploading, onFileSelect]);
+    if (!selectedFile || isSubmittingImport) return;
+    setSubmitPending(true);
+    try {
+      void Promise.resolve(onFileSelect(selectedFile)).finally(() => {
+        setSubmitPending(false);
+      });
+    } catch (error) {
+      setSubmitPending(false);
+      throw error;
+    }
+  }, [selectedFile, isSubmittingImport, onFileSelect]);
 
   const handlePreloadSchema = useCallback(() => {
     if (!onPreloadSchema || isUploading || isPreloadingSchema) return;
@@ -263,7 +273,7 @@ export function PortfolioImportView({
               isDragging
                 ? "border-primary bg-primary/8 scale-[1.01]"
                 : "border-border/70 hover:border-primary/50 hover:bg-muted/25",
-              isUploading && "pointer-events-none opacity-50"
+              isSubmittingImport && "pointer-events-none opacity-50"
             )}
             onClick={triggerFileInput}
           >
@@ -285,7 +295,7 @@ export function PortfolioImportView({
             </div>
 
             {/* Selected File Display */}
-            {selectedFile && !isUploading && (
+            {selectedFile && !isSubmittingImport && (
               <div className="mt-4 inline-flex items-center gap-2 px-4 py-2 bg-primary/10 rounded-full text-sm">
                 <Icon icon={FileText} size="sm" />
                 <span>{selectedFile.name}</span>
@@ -300,7 +310,7 @@ export function PortfolioImportView({
               accept=".csv,.pdf"
               onChange={handleFileChange}
               className="hidden"
-              disabled={isUploading}
+              disabled={isSubmittingImport}
             />
           </div>
 
@@ -310,13 +320,13 @@ export function PortfolioImportView({
             size="default"
             className="w-full font-black shadow-xl border-none"
             onClick={handleContinue}
-            disabled={isUploading || isPreloadingSchema || !selectedFile}
+            disabled={isSubmittingImport || isPreloadingSchema || !selectedFile}
             icon={{
-              icon: Upload,
+              icon: isSubmittingImport ? Loader2 : Upload,
               gradient: false,
             }}
           >
-            {isUploading ? "Parsing..." : "Continue"}
+            {isSubmittingImport ? "Parsing..." : "Continue"}
           </MorphyButton>
         </SurfaceCardContent>
       </SurfaceCard>


### PR DESCRIPTION
## Description

Prevents duplicate submissions from the portfolio import action by disabling repeated clicks while the import request is already in progress.

## Why

Portfolio imports can involve network requests, validation, and downstream processing that may take several seconds to complete. During this period, users can unintentionally click the submit action multiple times, resulting in duplicate requests, repeated import attempts, inconsistent loading states, or confusing feedback.

This change ensures only a single import action is processed at a time.

## What changed

- Disabled the portfolio import submit action while an import request is pending
- Prevented duplicate requests triggered by repeated clicks
- Preserved existing validation, loading, success, and error handling behavior
- Maintained existing portfolio import workflow and user experience

## Impact

- No API changes
- No schema changes
- No backend behavior changes
- Improves frontend interaction safety and import consistency

## Testing

- Ran `npm run lint`
- Ran `npm run build`
- Verified repeated clicks do not trigger duplicate portfolio import requests
- Verified the submit action re-enables after request completion
- Verified existing validation and error handling behavior remain unchanged

## Notes

This PR intentionally focuses on the existing portfolio import UI flow only and does not modify portfolio processing logic, authentication flows, consent contracts, PKM behavior, backend services, or application architecture.