### PR TITLE
fix(kai-command-palette): preserve market search input during refresh

### DIFF
--- a/hushh-webapp/components/kai/kai-command-palette.tsx
+++ b/hushh-webapp/components/kai/kai-command-palette.tsx
@@ -149,7 +149,14 @@ export function KaiCommandPalette({
   appRuntimeState,
   portfolioTickers = [],
 }: KaiCommandPaletteProps) {
-  const [query, setQuery] = useState("");
+  const [query, setQuery] = useState(() => {
+    if (typeof window === "undefined") return "";
+    try {
+      return window.sessionStorage.getItem("kai-command-palette-query") ?? "";
+    } catch {
+      return "";
+    }
+  });
   const [universe, setUniverse] = useState<TickerUniverseRow[] | null>(
     getTickerUniverseSnapshot()
   );
@@ -157,6 +164,18 @@ export function KaiCommandPalette({
   const [remoteMatches, setRemoteMatches] = useState<TickerUniverseRow[]>([]);
   const [universeError, setUniverseError] = useState<string | null>(null);
   const [remoteSearchError, setRemoteSearchError] = useState<string | null>(null);
+
+  useEffect(() => {
+    try {
+      if (query) {
+        window.sessionStorage.setItem("kai-command-palette-query", query);
+      } else {
+        window.sessionStorage.removeItem("kai-command-palette-query");
+      }
+    } catch {
+      // Session storage can be unavailable in private or restricted contexts.
+    }
+  }, [query]);
 
   useEffect(() => {
     if (!open) {


### PR DESCRIPTION
## Description

Preserves the user's active Kai market search input during data refreshes so searches remain uninterrupted while market information is updated.

## Why

Refreshing market data can unintentionally reset or clear the current search input, forcing users to re-enter their query and disrupting exploration workflows. This creates unnecessary friction, particularly when users are actively filtering or comparing market information.

This change ensures refresh operations update data without affecting the user's current search context.

## What changed

- Preserved active search input during Kai market data refreshes
- Prevented search state from resetting when refreshed data is loaded
- Maintained existing refresh, filtering, and search behavior
- Preserved existing loading and error handling flows

## Impact

- No API changes
- No schema changes
- No backend behavior changes
- Improves user experience and search workflow continuity

## Testing

- Ran `npm run lint`
- Ran `npm run build`
- Verified search input remains unchanged during market refresh operations
- Verified refreshed market data continues loading correctly
- Verified existing filtering and search behavior remain unchanged

## Notes

This PR intentionally focuses on the existing Kai market search experience only and does not modify market data processing, recommendation logic, authentication flows, consent contracts, PKM behavior, backend services, or application architecture.