### PR TITLE
fix(ui): add explicit type to streaming progress toggle

### DIFF
--- a/hushh-webapp/components/kai/views/streaming-progress-view.tsx
+++ b/hushh-webapp/components/kai/views/streaming-progress-view.tsx
@@ -278,9 +278,10 @@ function SourcesList({ sources }: { sources: string[] }) {
   return (
     <div className="space-y-1.5">
       <button
-        onClick={() => setExpanded(!expanded)}
-        className="flex items-center gap-1.5 text-xs font-semibold text-muted-foreground uppercase tracking-wider hover:text-foreground transition-colors"
-      >
+  type="button"
+  onClick={() => setExpanded(!expanded)}
+  className="flex items-center gap-1.5 text-xs font-semibold text-muted-foreground uppercase tracking-wider hover:text-foreground transition-colors"
+>
         <Icon icon={ExternalLink} size={12} />
         Sources ({valid.length})
         {valid.length > 3 &&


### PR DESCRIPTION
## Summary

* adds an explicit `type="button"` to the streaming progress sources toggle
* prevents unintended form submission behavior when rendered inside forms
* aligns the component with HTML button best practices

## Validation

* npm run lint
* npm run typecheck
