### PR TITLE
 test(vault): cover null vault availability state

### DIFF
--- a/hushh-webapp/__tests__/utils/vault-access-policy.test.ts
+++ b/hushh-webapp/__tests__/utils/vault-access-policy.test.ts
@@ -55,4 +55,20 @@ describe("vault access policy", () => {
       needsUnlock: false,
     });
   });
+
+  it("treats null vault availability as unknown without requiring creation or unlock", () => {
+    expect(
+      resolveVaultAvailabilityState({
+        hasVault: null,
+        isVaultUnlocked: false,
+        vaultKey: null,
+        vaultOwnerToken: null,
+      })
+    ).toMatchObject({
+      hasVault: false,
+      vaultUnknown: true,
+      needsVaultCreation: false,
+      needsUnlock: false,
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Add test coverage for vault availability state when `hasVault` is `null`.

## Changes Made

- Added a test for `resolveVaultAvailabilityState`
- Covers the edge case where vault availability is unknown (`hasVault: null`)
- Verifies the returned state remains consistent and does not require unlock actions

## Test

```bash
npm test -- vault-access-policy