### PR TITLE
fix(ui): add explicit type to segmented control buttons

### DIFF
--- a/hushh-webapp/lib/morphy-ux/ui/segmented-control.tsx
+++ b/hushh-webapp/lib/morphy-ux/ui/segmented-control.tsx
@@ -98,6 +98,7 @@ export function SegmentedControl({
         
         return (
           <button
+            type="button"
             key={option.value}
             role="radio"
             aria-checked={isActive}


### PR DESCRIPTION
## Summary
- adds explicit `type="button"` to segmented control option buttons
- prevents unintended form submission behavior when used inside forms
- aligns segmented control with other segmented UI components

## Validation
- npm run lint
- npm run typecheck