### PR TITLE
test(consent): preserve internal route query params

### DIFF
--- a/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
+++ b/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
@@ -187,5 +187,16 @@ describe("path resolver safety — dangerous edge case handling", () => {
     const result = resolveConsentNavigationTarget("data:text/html,<h1>test</h1>");
     expect(result.kind).toBe("external");
   });
+  it("preserves query parameters on internal consent routes", () => {
+  const result = resolveConsentNavigationTarget(
+    "/consents?id=123&tab=review"
+  );
+
+  expect(result).toEqual({
+  kind: "internal",
+  href: "/consents?id=123&tab=review",
+  pathname: "/consents",
+});
+});
 });
 // ── End path safety coverage ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Add test coverage for internal consent routes that contain query parameters.

## Changes Made

- Added a test for consent navigation targets with query strings
- Verifies internal consent routes remain classified as internal
- Ensures query parameters do not affect route handling

## Test

```bash
npm test -- consent-sheet-route