### PR TITLE
fix(morphy-button): keep consent approval button width stable during loading

### DIFF
--- a/hushh-webapp/lib/morphy-ux/button.tsx
+++ b/hushh-webapp/lib/morphy-ux/button.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { type IconWeight } from "@phosphor-icons/react";
+import { Loader2 } from "lucide-react";
 
 import {
   Button as StockButton,
@@ -112,22 +113,29 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 
     const renderContent = (contentChildren: React.ReactNode) => (
       <>
-        <span className="relative z-0 inline-flex items-center justify-center text-inherit">
-          {IconComponent ? (
-            <span
-              className={cn(
-                "mr-2.5 flex items-center justify-center rounded-lg border",
-                getIconBoxSize(),
-                iconBoxClass
-              )}
-            >
-              <IconComponent
-                className={cn(getIconSize(), iconColorClass)}
-                weight={icon?.weight || iconWeight}
-              />
+        <span className="relative z-0 inline-grid min-w-0 items-center justify-center text-inherit">
+          <span className={cn("inline-flex min-w-0 items-center justify-center", loading && "opacity-0")}>
+            {IconComponent ? (
+              <span
+                className={cn(
+                  "mr-2.5 flex items-center justify-center rounded-lg border",
+                  getIconBoxSize(),
+                  iconBoxClass
+                )}
+              >
+                <IconComponent
+                  className={cn(getIconSize(), iconColorClass)}
+                  weight={icon?.weight || iconWeight}
+                />
+              </span>
+            ) : null}
+            {contentChildren}
+          </span>
+          {loading ? (
+            <span className="absolute inset-0 flex items-center justify-center">
+              <Loader2 className={cn(getIconSize(), "animate-spin")} aria-hidden="true" />
             </span>
           ) : null}
-          {contentChildren}
         </span>
         {shouldShowRipple ? (
           <MaterialRipple


### PR DESCRIPTION
## Description

Keeps the consent approval button width stable while loading indicators are displayed, preventing visual shifts during approval actions.

## Why

When a consent approval request enters a loading state, button content can change from text to a spinner or loading label. This may cause the button width to expand or contract, resulting in layout movement, visual jitter, and a less polished user experience.

This change ensures the approval action maintains a consistent footprint throughout the interaction lifecycle.

## What changed

- Stabilized consent approval button width during loading states
- Prevented layout shifts caused by loading indicators or text changes
- Preserved existing approval workflow, loading feedback, and interaction behavior
- Maintained existing responsive layout behavior

## Impact

- No API changes
- No schema changes
- No backend behavior changes
- Improves visual stability and interaction consistency

## Testing

- Ran `npm run lint`
- Ran `npm run build`
- Verified button width remains stable during consent approval loading states
- Verified loading indicators continue displaying correctly
- Verified approval, success, and error flows remain unchanged

## Notes

This PR intentionally focuses on frontend visual consistency within the existing consent approval flow and does not modify consent logic, authorization behavior, PKM contracts, backend services, or application architecture.