### PR TITLE
fix(kai-dashboard): preserve portfolio active tab after refresh

### DIFF
--- a/hushh-webapp/components/kai/views/dashboard-master-view.tsx
+++ b/hushh-webapp/components/kai/views/dashboard-master-view.tsx
@@ -478,7 +478,15 @@ export function DashboardMasterView({
   const [isReconcilingFunding, setIsReconcilingFunding] = useState(false);
   const [isSharingPortfolioPdf, setIsSharingPortfolioPdf] = useState(false);
   const [preferencesSheetOpen, setPreferencesSheetOpen] = useState(false);
-  const [dashboardMainTab, setDashboardMainTab] = useState<DashboardMainTab>("overview");
+  const [dashboardMainTab, setDashboardMainTab] = useState<DashboardMainTab>(() => {
+    if (typeof window === "undefined") return "overview";
+    try {
+      const storedTab = window.sessionStorage.getItem("kai-portfolio-dashboard-tab");
+      return storedTab && isDashboardMainTab(storedTab) ? storedTab : "overview";
+    } catch {
+      return "overview";
+    }
+  });
   const {
     activeControlId: activeVoiceControlId,
     lastInteractedControlId: lastVoiceControlId,
@@ -503,6 +511,14 @@ export function DashboardMasterView({
   );
   const canDeletePlaid = isPlaidView && activePlaidItemIds.length > 0;
   const canDeletePortfolio = canEditStatement || canDeletePlaid;
+
+  useEffect(() => {
+    try {
+      window.sessionStorage.setItem("kai-portfolio-dashboard-tab", dashboardMainTab);
+    } catch {
+      // Session storage can be unavailable in private or restricted contexts.
+    }
+  }, [dashboardMainTab]);
 
   useEffect(() => {
     const holdingsCount = displayedPortfolio?.holdings?.length || 0;


### PR DESCRIPTION
## Description

Preserves the currently selected portfolio tab during portfolio refresh operations so users remain in their active workflow context while data updates are loaded.

## Why

Refreshing portfolio data can unintentionally reset tab state and return users to a default view. This disrupts navigation flow, forces users to manually reselect their tab, and creates unnecessary friction when monitoring or comparing portfolio information.

This change ensures refresh actions update portfolio data without affecting the user's active tab selection.

## What changed

- Preserved active tab state during portfolio refresh operations
- Prevented tab selection from resetting when refreshed data is loaded
- Maintained existing refresh, navigation, and portfolio workflows
- Preserved existing loading and error handling behavior

## Impact

- No API changes
- No schema changes
- No backend behavior changes
- Improves workflow continuity and user experience

## Testing

- Ran `npm run lint`
- Ran `npm run build`
- Verified active portfolio tab remains selected after refresh
- Verified refreshed portfolio data loads correctly
- Verified existing navigation and tab interactions remain unchanged

## Notes

This PR intentionally focuses on frontend state preservation within the existing portfolio experience and does not modify portfolio processing logic, authentication flows, consent contracts, PKM behavior, backend services, or application architecture.