### PR TITLE
fix(consent-inbox-dropdown): add notification list semantics

### DIFF
--- a/hushh-webapp/components/consent/consent-inbox-dropdown.tsx
+++ b/hushh-webapp/components/consent/consent-inbox-dropdown.tsx
@@ -268,10 +268,10 @@ export function ConsentInboxDropdown({
           ) : null}
 
           {items.length > 0 ? (
-            <div className="divide-y divide-border/45">
+            <div role="list" aria-label="Pending consents" className="divide-y divide-border/45">
               {items.map((entry) => (
-                <Link
-                  key={entry.id}
+                <div key={entry.id} role="listitem">
+                  <Link
                   href={entryHref(actor, entry)}
                   prefetch={false}
                   onClick={() => setOpen(false)}
@@ -294,6 +294,7 @@ export function ConsentInboxDropdown({
                     </span>
                   </div>
                 </Link>
+              </div>
               ))}
             </div>
           ) : null}


### PR DESCRIPTION
## Summary

Adds list semantics to the pending consents dropdown, matching the accessibility pattern already used in DebateTaskCenter.

## Problem

ConsentInboxDropdown currently renders pending consent entries as a sequence of links without list semantics.

As a result:

* Screen readers do not announce the number of entries.
* Users do not receive list context when entering the dropdown.
* List navigation shortcuts available in assistive technologies are unavailable.

DebateTaskCenter already applies list semantics to its notification surface. This change aligns ConsentInboxDropdown with that established pattern.

## Changes

### components/consent/consent-inbox-dropdown.tsx

* Added `role="list"` to the pending consents container.
* Added `aria-label="Pending consents"` to the list container.
* Wrapped each entry in a `role="listitem"` container.
* Moved the React `key` from the Link to the list item wrapper.

## Accessibility Impact

Screen readers can now:

* Announce the surface as a list.
* Announce the number of entries.
* Navigate using list-item navigation commands.
* Understand the grouping relationship between consent entries.

## Pattern Reference

Matches the existing DebateTaskCenter notification list implementation.

## Risk

* No visual changes.
* No behavioral changes.
* No routing changes.
* No state-management changes.
* Accessibility-only enhancement.

## Checklist

* [x] No visual changes
* [x] No behavioral changes
* [x] Additive accessibility enhancement
* [x] Single-file change
* [x] Existing repository pattern
