### PR TITLE
fix(ria-onboarding): add accessible step counter labels

### DIFF
--- a/hushh-webapp/components/ria/onboarding/onboarding-shell.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-shell.tsx
@@ -49,7 +49,10 @@ export function OnboardingShell({
             <ArrowLeft className="h-5 w-5" />
           </button>
 
-          <span className="inline-flex items-center rounded-full border border-border/60 bg-card/70 px-3 py-1 text-xs font-medium tabular-nums text-muted-foreground shadow-[0_8px_24px_rgba(15,23,42,0.06)] backdrop-blur dark:bg-card/45 dark:shadow-none">
+          <span
+            aria-label={`Step ${currentStepIndex + 1} of ${totalSteps}`}
+            className="inline-flex items-center rounded-full border border-border/60 bg-card/70 px-3 py-1 text-xs font-medium tabular-nums text-muted-foreground shadow-[0_8px_24px_rgba(15,23,42,0.06)] backdrop-blur dark:bg-card/45 dark:shadow-none"
+          >
             {currentStepIndex + 1} / {totalSteps}
           </span>
         </div>


### PR DESCRIPTION
## Summary

Adds an accessible label to the onboarding step counter pill so screen readers announce a meaningful step position rather than a condensed numeric fraction.

## Problem

The onboarding shell currently renders the step indicator as:

```tsx
{currentStepIndex + 1} / {totalSteps}
```

While visually compact, screen readers announce this as:

* "1 slash 4" (NVDA)
* "1 / 4" (VoiceOver)

This does not communicate that the element represents onboarding progress.

## Solution

Add:

```tsx
aria-label={`Step ${currentStepIndex + 1} of ${totalSteps}`}
```

to the existing step counter element.

This preserves the visual presentation while providing a meaningful accessible name.

## Changes

### components/ria/onboarding/onboarding-shell.tsx

* Added `aria-label` to the existing step counter span.
* No visual changes.
* No behavior changes.
* No state changes.

## Accessibility Impact

Screen readers now announce:

```text
Step 1 of 4
```

instead of:

```text
1 slash 4
```

This improves onboarding orientation and progress awareness.

## Pattern Reference

Matches the onboarding progress wording already used elsewhere in the repository:

```tsx
Step {currentStep} of {total}
```

## Risk

* Single file
* Single attribute
* No runtime logic
* No layout changes
* No interaction changes

## Checklist

* [x] No visual changes
* [x] No behavioral changes
* [x] Accessibility-only improvement
* [x] Single-file change
* [x] Additive-only
* [x] Low conflict surface
