### PR TITLE
fix(ria-onboarding): add group semantics to service selectors

### DIFF
--- a/hushh-webapp/components/ria/onboarding/onboarding-step-services.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-step-services.tsx
@@ -151,7 +151,7 @@ export function OnboardingStepServices({
     <div className="space-y-6">
       <div className="space-y-3">
         <SectionLabel>Services</SectionLabel>
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <div role="group" aria-label="Services offered" className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           {AVAILABLE_SERVICES.map(({ label, icon: Icon }) => {
             const selected = servicesOffered.includes(label);
             return (
@@ -186,7 +186,7 @@ export function OnboardingStepServices({
 
       <div className="space-y-3">
         <SectionLabel>Fee Structure</SectionLabel>
-        <div className="flex flex-wrap gap-2">
+        <div role="group" aria-label="Fee structure" className="flex flex-wrap gap-2">
           {FEE_OPTIONS.map((fee) => {
             const selected = feeStructure.includes(fee);
             return (


### PR DESCRIPTION
## Summary

Adds group semantics to the Services and Fee Structure toggle-button collections in the RIA onboarding flow.

## Problem

The onboarding services step contains two collections of related toggle controls:

* Services offered
* Fee structure

Each button correctly exposes its pressed state through `aria-pressed`, but the containing groups do not expose any grouping semantics.

As a result, assistive technologies encounter the controls as independent buttons without group context.

## Solution

Add:

* `role="group"`
* `aria-label`

to each toggle-button container.

### Services

```tsx
role="group"
aria-label="Services offered"
```

### Fee Structure

```tsx
role="group"
aria-label="Fee structure"
```

## Why `role="group"`

These controls support multiple active selections simultaneously.

`radiogroup` would incorrectly imply single-selection behavior.

`group` is the appropriate ARIA pattern for a labeled collection of related controls without radio-button semantics.

## Changes

### components/ria/onboarding/onboarding-step-services.tsx

* Added `role="group"` and `aria-label="Services offered"` to the services container.
* Added `role="group"` and `aria-label="Fee structure"` to the fee structure container.

## Accessibility Impact

Screen readers can now announce:

* "Services offered, group"
* "Fee structure, group"

before reading the individual toggle buttons.

This improves context and navigation without changing interaction behavior.

## Risk

* No visual changes
* No behavioral changes
* No state changes
* No toggle logic changes
* Accessibility-only enhancement

## Checklist

* [x] No visual changes
* [x] No behavioral changes
* [x] Accessibility-only improvement
* [x] Single-file change
* [x] Additive-only
* [x] Low conflict surface
