### PR TITLE
fix(holdings-mobile-list): announce filtered result counts

### DIFF
--- a/hushh-webapp/components/kai/holdings/holdings-mobile-list.tsx
+++ b/hushh-webapp/components/kai/holdings/holdings-mobile-list.tsx
@@ -254,7 +254,11 @@ export function HoldingsMobileList({
 
         {filteredHoldings.length > 0 ? (
           <>
-            <p className="app-label-text text-muted-foreground text-right">
+            <p
+              aria-live="polite"
+              aria-atomic="true"
+              className="app-label-text text-muted-foreground text-right"
+            >
               {filteredHoldings.length} holding{filteredHoldings.length !== 1 ? "s" : ""}
             </p>
             <div


### PR DESCRIPTION
## Summary

Adds `aria-live="polite"` and `aria-atomic="true"` to the holdings count element in `HoldingsMobileList` so screen readers announce updated result counts when filters or search terms change.

## Problem

`HoldingsMobileList` displays a dynamic count such as:

* 48 holdings
* 12 holdings
* 3 holdings

The count updates whenever a user changes filters or enters a search term.

Without a live region, these updates are silent for assistive technology users. Screen reader users must manually navigate back to the count element to determine how many results remain after filtering.

The desktop `DataTable` surface already announces result-count changes through a live-region pattern. This mobile surface does not currently provide equivalent feedback.

## Changes

### components/kai/holdings/holdings-mobile-list.tsx

Added:

```tsx
aria-live="polite"
aria-atomic="true"
```

to the holdings count paragraph.

## Accessibility Impact

* Announces updated result counts after filtering
* Announces updated result counts after searching
* Uses polite announcements that do not interrupt the current interaction
* Uses atomic announcements so the complete count is read

Examples:

* “48 holdings”
* “12 holdings”
* “3 holdings”

## Risk

* No visual changes
* No behavioral changes
* No filtering logic changes
* No virtualizer changes
* Accessibility-only enhancement
