### PR TITLE
fix(ria-onboarding): add progress announcement parity

### DIFF
--- a/hushh-webapp/components/ria/onboarding/onboarding-shell.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-shell.tsx
@@ -54,7 +54,7 @@ export function OnboardingShell({
           </span>
         </div>
 
-        <div className="mt-4 flex gap-1.5">
+        <div className="mt-4 flex gap-1.5" aria-hidden="true">
           {Array.from({ length: totalSteps }, (_, i) => (
             <div
               key={i}
@@ -65,6 +65,9 @@ export function OnboardingShell({
             />
           ))}
         </div>
+        <span role="status" aria-atomic="true" className="sr-only">
+          {`Step ${currentStepIndex + 1} of ${totalSteps}`}
+        </span>
 
         <div className="mt-6 space-y-2 sm:mt-7">
           <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">


### PR DESCRIPTION
## Summary

Adds accessibility parity to the RIA onboarding progress indicator by hiding decorative progress dots from assistive technologies and announcing the current step through a screen-reader-only status region.

## Changes

* Add `aria-hidden="true"` to the decorative progress dots container
* Add an `sr-only` `role="status"` region that announces:

  * `Step 1 of N`
  * `Step 2 of N`
  * etc.

## Why

The progress dots are visual-only and do not convey meaningful information to screen readers. Step changes were previously silent, making onboarding progress difficult to track for assistive technology users.

## Impact

* No visual changes
* No behavioral changes
* No logic changes
* Accessibility-only enhancement

## Validation

* [x] TypeScript passes
* [x] Single-file change
* [x] Additive-only
* [x] Existing onboarding flow unchanged
