### PR TITLE
fix(sheet-content): add overscroll containment parity

### DIFF
--- a/hushh-webapp/components/ui/sheet.tsx
+++ b/hushh-webapp/components/ui/sheet.tsx
@@ -75,7 +75,7 @@ function SheetContent({
           side === "top" &&
             "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b rounded-b-[var(--app-card-radius-feature)]",
           side === "bottom" &&
-            "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto max-h-[85dvh] overflow-y-auto border-t rounded-t-[var(--app-card-radius-feature)]",
+            "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto max-h-[85dvh] overflow-y-auto overscroll-contain [-webkit-overflow-scrolling:touch] border-t rounded-t-[var(--app-card-radius-feature)]",
           className
         )}
         {...props}


### PR DESCRIPTION
## Summary

Adds `overscroll-contain` and `-webkit-overflow-scrolling: touch` to the bottom-side `SheetContent` variant to match the scroll containment behavior already used by `DialogContent`.

## Changes

* Add `overscroll-contain`
* Add `[-webkit-overflow-scrolling:touch]`

to the `side === "bottom"` SheetContent variant.

## Why

The bottom sheet variant uses `overflow-y-auto` but does not currently include the scroll-containment utilities used by `DialogContent`.

This change aligns scrolling behavior between the two modal surfaces and helps prevent scroll chaining into the underlying page when the sheet reaches its scroll bounds on mobile devices.

## Impact

* No visual changes
* No layout changes
* No API changes
* Single-file, additive-only update

## Validation

* [x] TypeScript passes
* [x] ESLint passes
* [x] Single-file change
* [x] Existing Sheet behavior unchanged apart from scroll containment
