### PR TITLE
fix(drawer-overlay): add touch-none parity with DialogOverlay

### DIFF
--- a/hushh-webapp/components/ui/drawer.tsx
+++ b/hushh-webapp/components/ui/drawer.tsx
@@ -37,7 +37,7 @@ function DrawerOverlay({
     <DrawerPrimitive.Overlay
       data-slot="drawer-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-[711] bg-transparent",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-[711] bg-transparent touch-none",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

Adds `touch-none` to `DrawerOverlay`, matching the existing overlay behavior used by `DialogOverlay`.

## Changes

* Add `touch-none` to the `DrawerOverlay` className.

## Why

`DialogOverlay` already includes `touch-none` to prevent touch interactions from propagating through the overlay while a modal surface is active.

`DrawerOverlay` uses the same overlay pattern but was missing this utility, creating a small parity gap between the two primitives.

## Impact

* No visual changes
* No layout changes
* No API changes
* Single-file, additive-only update

## Validation

* [x] TypeScript passes
* [x] ESLint passes
* [x] Single-file change
* [x] Existing Drawer behavior unchanged apart from overlay touch containment
