### PR TITLE
fix(sheet-overlay): add touch-none parity with DialogOverlay

### DIFF
--- a/hushh-webapp/components/ui/sheet.tsx
+++ b/hushh-webapp/components/ui/sheet.tsx
@@ -39,7 +39,7 @@ function SheetOverlay({
     <SheetPrimitive.Overlay
       data-slot="sheet-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-[711] bg-transparent",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-[711] bg-transparent touch-none",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

Adds `touch-none` to `SheetOverlay`, matching the existing overlay behavior used by `DialogOverlay`.

## Changes

* Add `touch-none` to the `SheetOverlay` className.

## Why

`DialogOverlay` already includes `touch-none` to prevent touch interactions from propagating through the overlay while a modal surface is active.

`SheetOverlay` uses the same overlay pattern but was missing this utility, creating a parity gap between the two primitives.

## Impact

* No visual changes
* No layout changes
* No API changes
* Single-file, additive-only update

## Validation

* [x] TypeScript passes
* [x] ESLint passes
* [x] Single-file change
* [x] Existing Sheet behavior unchanged apart from overlay touch containment
