### PR TITLE
fix(holdings-search): add autoComplete="off" parity with DataTable search input

### DIFF
--- a/hushh-webapp/components/kai/holdings/holdings-mobile-list.tsx
+++ b/hushh-webapp/components/kai/holdings/holdings-mobile-list.tsx
@@ -247,6 +247,7 @@ export function HoldingsMobileList({
             placeholder="Search holdings by ticker or company"
             className="app-body-text h-10 rounded-full border-border/60 bg-background/70 pl-9 pr-4 text-sm"
             autoCapitalize="off"
+            autoComplete="off"
             autoCorrect="off"
             spellCheck={false}
           />


### PR DESCRIPTION
## Summary

Adds `autoComplete="off"` to the holdings mobile search input, aligning it with the existing DataTable search implementation.

## Problem

The holdings mobile search input already disables:

* autoCapitalize
* autoCorrect
* spellCheck

but does not disable browser autocomplete.

The repository's DataTable search input already includes `autoComplete="off"`, creating a parity gap between the two search experiences.

## Change

File:

`hushh-webapp/components/kai/holdings/holdings-mobile-list.tsx`

Added:

`autoComplete="off"`

to the holdings search input.

## Accessibility Impact

Keeps search-field behavior consistent with existing repository search patterns.

Reduces unexpected browser autocomplete suggestions that may interfere with focused search workflows.

## Scope

* Single file changed
* Single-line change
* No visual changes
* No behavioral changes
* No API changes
* No state-management changes

## Risk

LOW — additive attribute only. Existing search behavior remains unchanged.
