### PR TITLE
fix(holdings-drawer): add accessible title and description

### DIFF
--- a/hushh-webapp/components/kai/holdings/holding-details-drawer.tsx
+++ b/hushh-webapp/components/kai/holdings/holding-details-drawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Drawer, DrawerContent, DrawerFooter, DrawerHeader, DrawerTitle } from "@/components/ui/drawer";
+import { Drawer, DrawerContent, DrawerDescription, DrawerFooter, DrawerHeader, DrawerTitle } from "@/components/ui/drawer";
 import { Button as MorphyButton } from "@/lib/morphy-ux/button";
 import { cn } from "@/lib/utils";
 import type { HoldingMobileCardViewModel } from "@/components/kai/holdings/holding-mobile-card";
@@ -71,9 +71,9 @@ export function HoldingDetailsDrawer({
           <DrawerTitle className="app-card-title text-left text-foreground">
             {holding?.symbol || "Holding Details"}
           </DrawerTitle>
-          <p className="app-body-text app-title-subtitle-gap text-left text-muted-foreground">
+          <DrawerDescription className="app-body-text app-title-subtitle-gap text-left text-muted-foreground">
             {holding?.name || "Select a holding"}
-          </p>
+          </DrawerDescription>
         </DrawerHeader>
 
         <div className="grid max-h-[60svh] gap-2 overflow-y-auto px-5 pb-3 sm:grid-cols-2">


### PR DESCRIPTION
Summary

Completes the accessibility relationship between DrawerTitle and DrawerDescription in HoldingDetailsDrawer by replacing the existing subtitle paragraph with DrawerDescription.

Problem

HoldingDetailsDrawer already provides a DrawerTitle, but the accompanying company-name subtitle is rendered using a plain paragraph element.

Because the subtitle is not rendered through DrawerDescription, the drawer content does not receive the aria-describedby relationship provided by the drawer primitive.

As a result, assistive technologies may announce the drawer title without the associated holding-name description when the drawer opens.

Changes

File:
components/kai/holdings/holding-details-drawer.tsx

* Added DrawerDescription to the existing drawer import
* Replaced the subtitle paragraph with DrawerDescription
* Preserved existing styling classes
* Preserved existing content and fallback text

Accessibility Impact

* Completes the DrawerTitle + DrawerDescription accessibility pairing
* Enables automatic aria-describedby wiring on drawer content
* Improves screen-reader announcements when opening holding details
* Preserves existing fallback content when no holding is selected

Scope

* Single-file change
* Accessibility-only improvement
* No visual changes
* No behavioral changes
* No state-management changes
* No business-logic changes

Risk

LOW — additive accessibility improvement only. The change uses the existing drawer primitive accessibility relationship without modifying rendering behavior or business logic.
