### PR TITLE
fix(consent-dialog): add focus management parity

### DIFF
--- a/hushh-webapp/components/consent/consent-dialog.tsx
+++ b/hushh-webapp/components/consent/consent-dialog.tsx
@@ -12,7 +12,7 @@
 
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -100,6 +100,8 @@ export function ConsentDialog({
   loading = false,
 }: ConsentDialogProps) {
   const [isGranting, setIsGranting] = useState(false);
+  
+  const scopeInfoRef = useRef<HTMLDivElement>(null);
 
   const scopeInfo = resolveScopeDisplay(request);
 
@@ -114,7 +116,17 @@ export function ConsentDialog({
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onDeny()}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent
+        className="sm:max-w-md"
+        aria-busy={isGranting || loading}
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          scopeInfoRef.current?.focus();
+        }}
+        onEscapeKeyDown={(event) => {
+          if (isGranting) event.preventDefault();
+        }}
+      >
         <DialogHeader>
           <div className="flex items-center gap-3 mb-2">
             <div className="h-12 w-12 rounded-full bg-linear-to-br from-blue-500 to-purple-600 flex items-center justify-center text-2xl shadow-lg">
@@ -132,7 +144,9 @@ export function ConsentDialog({
         {/* Scope Info */}
         <div className="space-y-4 py-4">
           <div
-            className="flex items-start gap-3 p-3 rounded-xl bg-blue-50 dark:bg-blue-950/40 border border-blue-200/60 dark:border-blue-800/40"
+            ref={scopeInfoRef}
+            tabIndex={-1}
+            className="flex items-start gap-3 p-3 rounded-xl bg-blue-50 dark:bg-blue-950/40 border border-blue-200/60 dark:border-blue-800/40 focus:outline-none"
             style={scopeInfo.colorHex ? {
               backgroundColor: `${scopeInfo.colorHex}08`,
               borderColor: `${scopeInfo.colorHex}20`,


### PR DESCRIPTION
## Summary

Improves accessibility behavior in ConsentDialog by aligning focus management and busy-state handling with established dialog patterns.

## Problem

ConsentDialog had a few accessibility gaps:

- Initial focus did not move to the consent scope information when the dialog opened.
- The dialog could be dismissed with the Escape key during an active grant operation.
- No busy state was exposed to assistive technologies while a grant request was processing.

## Changes

File:
- components/consent/consent-dialog.tsx

Updates:
- Added `useRef` for the consent scope information container.
- Added `onOpenAutoFocus` to move initial focus to the scope information section.
- Added `aria-busy={isGranting || loading}` to expose processing state.
- Added `onEscapeKeyDown` guard to prevent dismissal while a grant operation is active.
- Added `tabIndex={-1}` and `focus:outline-none` to support programmatic focus.

## Accessibility Impact

- Screen readers receive consent scope information immediately on open.
- Busy state is announced during async grant operations.
- Prevents accidental dialog dismissal while processing a grant request.

## Scope

- 1 file changed
- Accessibility-only improvement
- No visual changes
- No API changes
- No routing changes
- No business-logic changes
- No state-management changes

## Risk

Low.

The change is limited to focus management and accessibility attributes without modifying consent flow behavior or data handling.