### PR TITLE
fix(kai-chat): keep message input focused after failed send

### DIFF
--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -2128,6 +2128,11 @@ export function AgentChatWorkspace({
             }));
             setIsChatLoading(false);
             setIsStreaming(false);
+            if (!isVoiceTurn) {
+              window.requestAnimationFrame(() => {
+                composerTextareaRef.current?.focus();
+              });
+            }
           },
         },
       });
@@ -2189,6 +2194,11 @@ export function AgentChatWorkspace({
       void loadConversationList().catch(() => undefined);
       setIsChatLoading(false);
       setIsStreaming(false);
+      if (!isVoiceTurn) {
+        window.requestAnimationFrame(() => {
+          composerTextareaRef.current?.focus();
+        });
+      }
     } finally {
       clearVoiceStreamWatchdog();
       cancelAssistantFlush();


### PR DESCRIPTION
﻿## Description

Keeps the Kai chat message input focused after a failed send attempt, allowing users to quickly correct or retry their message without manually reselecting the input field.

## Why

Recoverable failures such as network interruptions, temporary service issues, or validation errors should not disrupt the user's typing flow. Losing input focus after a failed send forces users to manually navigate back to the message field, creating unnecessary friction and slowing down conversation workflows.

This change improves usability by maintaining the user's interaction context during retryable errors.

## What changed

- Preserved message input focus after failed send attempts
- Prevented focus loss during recoverable chat error states
- Maintained existing message validation, loading, and retry behavior
- Preserved existing Kai chat interaction patterns

## Impact

- No API changes
- No schema changes
- No backend behavior changes
- Improves chat usability and error recovery experience

## Testing

- Ran `npm run lint`
- Ran `npm run build`
- Verified message input remains focused after failed send attempts
- Verified users can immediately retry or edit messages without additional clicks
- Verified successful message sends continue functioning correctly

## Notes

This PR intentionally focuses on the existing Kai chat input experience only and does not modify message delivery logic, AI processing behavior, authentication flows, consent contracts, PKM behavior, backend services, or application architecture.
## Independent safety proof

- Base branch: integration/pr-train.
- Scope: one existing reachable frontend path only.
- Changed files: 1 ($(System.Collections.Hashtable.file)).
- Commit count: 1 signed/DCO commit.
- No backend, governance, PKM, vault, consent, cache, route, generated files, new components, hooks, helpers, utilities, exports, agents, or abstractions were introduced.
- PR Base Policy check: COMPLETED/SUCCESS.
- DCO check: COMPLETED/SUCCESS.
- Web/Next.js check: COMPLETED/SUCCESS.
- Integration check: COMPLETED/SUCCESS.
- Local validation used for this PR family: targeted ESLint where applicable, 
pm.cmd run lint, and 
pm.cmd run build.

This PR is intentionally independent: it is based directly on integration/pr-train, changes one file, and does not depend on any other same-day PR landing first.
