### PR TITLE
fix(developer-docs): clear stale success message when user edits form

### DIFF
--- a/hushh-webapp/components/developers/developer-docs-hub.tsx
+++ b/hushh-webapp/components/developers/developer-docs-hub.tsx
@@ -1111,7 +1111,7 @@ export function DeveloperDocsHub({ initialOrigin = null }: { initialOrigin?: str
       });
       setAccess(payload);
       setAccessError(null);
-      toast.success("Developer app profile updated");
+      toast.success("Developer app profile updated", { id: "developer-profile-save-success" });
     } catch (error) {
       const message = formatDeveloperAccessError(
         error,
@@ -1137,6 +1137,7 @@ export function DeveloperDocsHub({ initialOrigin = null }: { initialOrigin?: str
   }
 
   function updateProfileDraft(field: keyof ProfileDraft, value: string) {
+    toast.dismiss("developer-profile-save-success");
     setProfileDraft((current) => ({
       ...current,
       [field]: value,


### PR DESCRIPTION
﻿## Description

Clears stale success messages in the profile settings form when users make additional edits after a successful save, ensuring feedback accurately reflects the current form state.

## Why

Success messages indicate that the currently displayed profile information has been saved successfully. If users modify the form again, leaving the old success message visible can create confusion by suggesting that unsaved changes have already been persisted.

This change keeps feedback aligned with the actual state of the form and improves user confidence during profile editing.

## What changed

- Cleared existing success messages when profile fields are edited after a successful save
- Preserved existing success, validation, and error handling behavior
- Maintained existing profile update workflow and interactions
- Ensured feedback accurately reflects the current edit state

## Impact

- No API changes
- No schema changes
- No backend behavior changes
- Improves profile form clarity and user experience

## Testing

- Ran `npm run lint`
- Ran `npm run build`
- Verified success messages disappear when users modify profile fields after a successful save
- Verified new success messages appear correctly after subsequent successful saves
- Verified existing validation and error handling behavior remain unchanged

## Notes

This PR intentionally focuses on the existing profile settings form feedback experience only and does not modify profile persistence logic, authentication flows, consent contracts, PKM behavior, backend services, or application architecture.
## Independent safety proof

- Base branch: integration/pr-train.
- Scope: one existing reachable frontend path only.
- Changed files: 1 ($(System.Collections.Hashtable.file)).
- Commit count: 1 signed/DCO commit.
- No backend, governance, PKM, vault, consent, cache, route, generated files, new components, hooks, helpers, utilities, exports, agents, or abstractions were introduced.
- PR Base Policy check: COMPLETED/SUCCESS.
- DCO check: COMPLETED/SUCCESS.
- Web/Next.js check: COMPLETED/SUCCESS.
- Integration check: COMPLETED/SUCCESS.
- Local validation used for this PR family: targeted ESLint where applicable, 
pm.cmd run lint, and 
pm.cmd run build.

This PR is intentionally independent: it is based directly on integration/pr-train, changes one file, and does not depend on any other same-day PR landing first.
