### PR TITLE
fix(kai-chat): prevent duplicate send clicks while response is pending

### DIFF
--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -711,6 +711,7 @@ export function AgentChatWorkspace({
   const [backgroundTaskState, setBackgroundTaskState] = useState(() =>
     AppBackgroundTaskService.getState()
   );
+  const typedSubmitPendingRef = useRef(false);
   const voiceClientRef = useRef<AgentVoiceClient | null>(null);
   const voiceTtsQueueRef = useRef<AgentTtsQueue | null>(null);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
@@ -2203,7 +2204,13 @@ export function AgentChatWorkspace({
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    await runAgentTurn(input, { source: "typed" });
+    if (!canSend || typedSubmitPendingRef.current) return;
+    typedSubmitPendingRef.current = true;
+    try {
+      await runAgentTurn(input, { source: "typed" });
+    } finally {
+      typedSubmitPendingRef.current = false;
+    }
   };
 
   function setAgentVoiceStatus(status: AgentVoiceStatus, message?: string | null) {


### PR DESCRIPTION
﻿## Description

Prevents duplicate message submissions in Kai Chat by disabling repeated send actions while a response is already pending.

## Why

AI responses may take time to complete due to network latency, model processing, or streaming behavior. During this period, users can unintentionally click the send action multiple times, resulting in duplicate messages, repeated requests, inconsistent chat state, or unnecessary backend load.

This change ensures only one active send operation is processed at a time while preserving the existing chat experience.

## What changed

- Disabled repeated send actions while a message response is pending
- Prevented duplicate message submissions from rapid user interaction
- Preserved existing message composition, loading, and response behavior
- Maintained existing Kai Chat workflows and interactions

## Impact

- No API changes
- No schema changes
- No backend behavior changes
- Improves chat interaction safety and message consistency

## Testing

- Ran `npm run lint`
- Ran `npm run build`
- Verified repeated send clicks do not create duplicate messages
- Verified send actions re-enable correctly after response completion
- Verified existing chat, streaming, and error handling behavior remain unchanged

## Notes

This PR intentionally focuses on the existing Kai Chat send action only and does not modify message delivery logic, AI processing behavior, authentication flows, consent contracts, PKM behavior, backend services, or application architecture.
## Independent safety proof

- Base branch: integration/pr-train.
- Scope: one existing reachable frontend path only.
- Changed files: 1 ($(System.Collections.Hashtable.file)).
- Commit count: 1 signed/DCO commit.
- No backend, governance, PKM, vault, consent, cache, route, generated files, new components, hooks, helpers, utilities, exports, agents, or abstractions were introduced.
- PR Base Policy check: COMPLETED/SUCCESS.
- DCO check: COMPLETED/SUCCESS.
- Web/Next.js check: COMPLETED/SUCCESS.
- Integration check: COMPLETED/SUCCESS.
- Local validation used for this PR family: targeted ESLint where applicable, 
pm.cmd run lint, and 
pm.cmd run build.

This PR is intentionally independent: it is based directly on integration/pr-train, changes one file, and does not depend on any other same-day PR landing first.
