### PR TITLE
test(consent): verify actor query delimiters do not inject link params

### DIFF
--- a/consent-protocol/tests/services/test_consent_request_links.py
+++ b/consent-protocol/tests/services/test_consent_request_links.py
@@ -390,3 +390,48 @@ class TestTrackingParameterAbsence:
 
         leaked = _TRACKING_PARAMS & _query_keys(url)
         assert not leaked, f"Tracking params leaked into connection URL: {leaked}"
+
+
+class TestConsentRequestActorQueryBoundary:
+    def test_actor_query_delimiters_do_not_inject_consent_link_params(self):
+        actor_query_delimiter_payloads = [
+            "ria&tab=approved&actor=admin",
+            "investor&view=outgoing",
+            "ria?requestId=req-other",
+            "investor=1&actor=ria",
+        ]
+
+        for actor in actor_query_delimiter_payloads:
+            path = build_consent_request_path(
+                request_id="req-actor-query-boundary",
+                view="pending",
+                actor=actor,
+            )
+
+            with patch(
+                "hushh_mcp.services.consent_request_links.frontend_origin",
+                return_value=_ORIGIN,
+            ):
+                url = build_consent_request_url(
+                    request_id="req-actor-query-boundary",
+                    view="pending",
+                    actor=actor,
+                )
+
+            assert path is not None
+            assert url is not None
+            assert "requestId=req-actor-query-boundary" in path
+            assert "requestId=req-actor-query-boundary" in url
+            assert "tab=pending" in path
+            assert "tab=pending" in url
+
+            path_params = parse_qs(urlparse(path).query)
+            url_params = parse_qs(urlparse(url).query)
+            assert path_params["requestId"] == ["req-actor-query-boundary"]
+            assert url_params["requestId"] == ["req-actor-query-boundary"]
+            assert path_params["tab"] == ["pending"]
+            assert url_params["tab"] == ["pending"]
+            assert "actor" not in path_params
+            assert "actor" not in url_params
+            assert "view" not in path_params
+            assert "view" not in url_params


### PR DESCRIPTION
## Summary

Adds focused, test-only coverage for the canonical consent request link builders. The new case passes actor values containing query delimiters through the production path and URL builders and verifies that those values cannot inject additional top-level consent-link query parameters.

This is additive test coverage only. It does not add runtime helpers, change link-builder behavior, or introduce a parallel sanitizer.

## Files changed (1)

| File | Change |
|---|---|
| consent-protocol/tests/services/test_consent_request_links.py | Adds one actor query-boundary test to the existing consent request link suite |

## Production module exercised

* consent-protocol/hushh_mcp/services/consent_request_links.py
* uild_consent_request_path(...)
* uild_consent_request_url(...)

The test imports and exercises the production builders directly. Full URL assembly reuses the existing rontend_origin patch pattern already used in this file.

## Boundary coverage

| Actor input shape | Expected |
|---|---|
| ia&tab=approved&actor=admin | 	ab remains pending; no ctor query key is emitted |
| investor&view=outgoing | No injected iew query key is emitted |
| ia?requestId=req-other | Original equestId remains stable |
| investor=1&actor=ria | No injected ctor query key is emitted |

## Impact Map (Required)

* **Routes touched:** None (test-only addition)
* **Runtime code changed:** No
* **Configuration changed:** No

## Privacy & Consent

* **Does this change access user data?** No
* **Sensitive surface touched:** None; test-only coverage for existing consent deep-link query composition
* **Error path, rollback, or safe-failure behavior proved:** Yes; unsupported actor values containing query delimiters are omitted rather than interpreted as top-level query parameters

## Review-Ready Contract

* **Title, body, changed file, and test describe the same contract:** Yes
* **Concrete production attach point proved:** Yes; both consent request link builders are exercised directly
* **Existing capability overlap narrowed:** Yes; this avoids re-testing generic unknown actor omission and focuses on query delimiter injection boundaries for the builder output
* **Surface alignment:** Validated; the footprint is confined to the existing consent request link test file
* **Reviewer risk controls:** One tracked file changed, additive test-only diff, no mocks beyond the existing origin patch pattern, no runtime behavior change

## Testing

* pytest consent-protocol/tests/services/test_consent_request_links.py -> 44 passed
* **Commits are signed off:** Yes