### PR TITLE
test(observability): verify user-agent headers do not alter trace metadata

### DIFF
--- a/consent-protocol/tests/test_observability_middleware.py
+++ b/consent-protocol/tests/test_observability_middleware.py
@@ -156,3 +156,34 @@ def test_malformed_request_id_header_is_replaced_with_fresh_id():
 )
 def test_status_bucket_parametrized(method, route, status, expected_bucket):
     assert _status_bucket(method, route, status) == expected_bucket
+
+
+def test_untrusted_user_agent_headers_do_not_change_trace_metadata_contract():
+    client = TestClient(_build_app())
+    untrusted_user_agent_headers = [
+        {"User-Agent": '{"profile":{"browser":{"name":"nested","tags":["bad"]}}}'},
+        {"User-Agent": '["unterminated-json-array"'},
+        {"User-Agent": ""},
+        {"User-Agent": "   "},
+        {},
+    ]
+
+    for headers in untrusted_user_agent_headers:
+        response = client.get(
+            "/metadata",
+            headers={
+                **headers,
+                REQUEST_ID_HEADER: "req_safe_telemetry_123",
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["request_id"] == "req_safe_telemetry_123"
+        assert body["method"] == "GET"
+        assert body["route_template"] == "/metadata"
+
+        assert "user_agent" not in body
+        assert "profile" not in body
+        assert "browser" not in body
+        assert get_request_trace_metadata() is None


### PR DESCRIPTION
## Summary

Adds focused, test-only coverage for the backend observability middleware trace metadata contract. The new case sends untrusted User-Agent header values through the real FastAPI middleware and verifies that request trace metadata remains limited to the canonical request correlation fields.

This is not a user-agent parser change and does not claim telemetry normalization behavior. It only proves that malformed or JSON-looking User-Agent header content is ignored by the trace metadata response path.

## Files changed (1)

| File | Change |
|---|---|
| consent-protocol/tests/test_observability_middleware.py | Adds one backend observability middleware boundary test |

## Production module exercised

- consent-protocol/api/middlewares/observability.py
- observability_middleware(...)
- get_request_trace_metadata()
- REQUEST_ID_HEADER

The request flows through the real middleware via TestClient; no local parser, mock middleware, or parallel helper is introduced.

## Boundary coverage

| Header shape | Expected |
|---|---|
| JSON-looking User-Agent profile text | Request succeeds; trace metadata contract remains unchanged |
| Unterminated JSON-looking User-Agent text | Request succeeds; no traceback |
| Empty User-Agent | Request succeeds; safe metadata only |
| Whitespace-only User-Agent | Request succeeds; safe metadata only |
| Missing User-Agent override | Request succeeds; safe metadata only |

## Impact Map (Required)

* **Routes touched:** None (test-only addition)
* **Runtime code changed:** No
* **Configuration changed:** No

## Privacy & Consent

* **Does this change access user data?** No
* **Sensitive surface touched:** None; request correlation metadata test only
* **Error path, rollback, or safe-failure behavior proved:** Yes; untrusted header content does not appear in trace metadata and request context is cleared after the request

## Review-Ready Contract

* **Title, body, changed file, and test describe the same contract:** Yes
* **Concrete backend attach point proved:** Yes; the test exercises pi.middlewares.observability directly through the FastAPI middleware chain
* **Surface alignment:** Validated; the footprint is confined to the existing backend observability middleware test file
* **No new helpers/components/services:** Yes
* **Reviewer risk controls:** One tracked file changed, additive test-only diff, no mocks, no runtime behavior change

## Testing

* pytest consent-protocol/tests/test_observability_middleware.py -> 23 passed
* **Commits are signed off:** Yes