### PR TITLE
test(consent): cover hash fragment route handling

### DIFF
--- a/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
+++ b/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
@@ -187,5 +187,11 @@ describe("path resolver safety — dangerous edge case handling", () => {
     const result = resolveConsentNavigationTarget("data:text/html,<h1>test</h1>");
     expect(result.kind).toBe("external");
   });
+  it("keeps hash-fragment consent routes as external navigation", () => {
+  expect(resolveConsentNavigationTarget("/consents#review-section")).toEqual({
+    kind: "external",
+    href: "/consents#review-section",
+  });
+});
 });
 // ── End path safety coverage ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Add test coverage for consent route handling when a route contains a hash fragment.

## Changes Made

* Added a test for consent navigation targets containing URL fragments
* Verifies fragment-based consent routes are classified consistently
* Documents the current navigation behavior for hash-fragment routes

## Test

```bash
npm test -- consent-sheet-route
```

## Expected Behavior

When resolving:

```text
/consents#review-section
```

the navigation target should remain:

```json
{
  "kind": "external",
  "href": "/consents#review-section"
}
```

This ensures fragment-based routes continue to follow the current navigation contract.
