### PR TITLE
test(vault): cover whitespace-only tokens

### DIFF
--- a/hushh-webapp/__tests__/utils/vault-access-policy.test.ts
+++ b/hushh-webapp/__tests__/utils/vault-access-policy.test.ts
@@ -40,7 +40,7 @@ describe("vault access policy", () => {
     });
   });
 
-  it("treats accounts without a vault as creation-required", () => {
+    it("treats accounts without a vault as creation-required", () => {
     expect(
       resolveVaultAvailabilityState({
         hasVault: false,
@@ -53,6 +53,19 @@ describe("vault access policy", () => {
       vaultUnknown: false,
       needsVaultCreation: true,
       needsUnlock: false,
+    });
+  });
+
+  it("treats whitespace-only owner token as unavailable", () => {
+    expect(
+      resolveVaultCapabilityState({
+        isVaultUnlocked: false,
+        vaultKey: "   ",
+        vaultOwnerToken: "   ",
+      })
+    ).toMatchObject({
+      hasVaultKey: false,
+      hasVaultOwnerToken: false,
     });
   });
 });


### PR DESCRIPTION
## Summary

Add test coverage for vault capability resolution when vault credentials contain only whitespace.

## Changes Made

- Added a test for whitespace-only vault keys and owner tokens
- Verifies whitespace values are treated as unavailable credentials
- Extends vault access policy edge-case coverage

## Test

```bash
npm test -- vault-access-policy