### PR TITLE
test(financial): cover empty financial object

### DIFF
--- a/hushh-webapp/__tests__/utils/financial-sources.test.ts
+++ b/hushh-webapp/__tests__/utils/financial-sources.test.ts
@@ -188,4 +188,7 @@ describe("financial statement snapshots", () => {
       })
     ).toBe("plaid");
   });
+    it("returns no statement options when sources are missing", () => {
+    expect(getStatementSnapshotOptions({})).toEqual([]);
+  });
 });

--- a/hushh-webapp/__tests__/utils/vault-access-policy.test.ts
+++ b/hushh-webapp/__tests__/utils/vault-access-policy.test.ts
@@ -54,5 +54,11 @@ describe("vault access policy", () => {
       needsVaultCreation: true,
       needsUnlock: false,
     });
+      it("returns no statement options when sources are missing", () => {
+    expect(getStatementSnapshotOptions({})).toEqual([]);
+  });
+  it("returns null portfolio when financial object is empty", () => {
+  expect(getStatementPortfolio({})).toBeNull();
+});
   });
 });

--- a/hushh-webapp/__tests__/utils/vault-access-policy.test.ts
+++ b/hushh-webapp/__tests__/utils/vault-access-policy.test.ts
@@ -54,11 +54,5 @@ describe("vault access policy", () => {
       needsVaultCreation: true,
       needsUnlock: false,
     });
-      it("returns no statement options when sources are missing", () => {
-    expect(getStatementSnapshotOptions({})).toEqual([]);
-  });
-  it("returns null portfolio when financial object is empty", () => {
-  expect(getStatementPortfolio({})).toBeNull();
-});
   });
 });


### PR DESCRIPTION
## Summary

Add test coverage for financial source helpers when the financial object is empty.

## Changes Made

- Added a test for empty financial input
- Verifies helper functions handle missing financial data safely
- Confirms no exceptions are thrown when an empty object is provided
- Extends edge-case coverage for financial source utilities

## Test

```bash
npm test -- financial-sources