### PR TITLE
test(token): verify malformed expiry claims fail closed

### DIFF
--- a/consent-protocol/tests/test_validate_token_expiry_ordering.py
+++ b/consent-protocol/tests/test_validate_token_expiry_ordering.py
@@ -134,3 +134,38 @@ class TestExpiredTokenResponseOrdering:
                 f"Probing scope {probe!r} against expired vault.owner token returned "
                 f"'{reason}' instead of 'Token expired'. Scope information leaked."
             )
+
+
+class TestMalformedExpiryClaimGuard:
+    def test_expired_and_malformed_expiry_claims_fail_closed(self):
+        import base64
+        import time
+
+        from hushh_mcp.consent.token import _sign
+        from hushh_mcp.constants import CONSENT_TOKEN_PREFIX
+
+        issued_at = int(time.time() * 1000)
+        expiry_claim_values = [
+            str(2**31 - 1),
+            "-" + ("9" * 64),
+            "-1",
+            "not-an-epoch",
+            "1e309",
+            "Infinity",
+        ]
+
+        for expires_at in expiry_claim_values:
+            raw = f"{_UID}|{_AGENT}|{ConsentScope.PKM_READ.value}|{issued_at}|{expires_at}"
+            signature = _sign(raw)
+            encoded = base64.urlsafe_b64encode(raw.encode()).decode()
+            token = f"{CONSENT_TOKEN_PREFIX}:{encoded}.{signature}"
+
+            valid, reason, parsed = validate_token(
+                token,
+                expected_scope=ConsentScope.PKM_READ,
+            )
+
+            assert valid is False
+            assert parsed is None
+            assert reason is not None
+            assert reason == "Token expired" or reason.startswith("Malformed token")


### PR DESCRIPTION
## Description
Adds focused, test-only coverage for signed HCT token expiry-claim validation. The new case builds real signed consent tokens in the canonical wire format and sends them through the production validator to confirm expired or malformed expiry values are rejected cleanly.

This is additive test coverage only. It does not add runtime helpers, change token validation logic, or introduce a parallel token parser.

## Canonical Attachment Plan
* **Target Package/Module:** consent-protocol/hushh_mcp/consent/token.py
* **Production Capability Exercised:** alidate_token(...) against signed HCT payloads
* **Execution Validation Track:** Consent protocol pytest coverage

## Impact Map (Required)
* **Routes touched:** None (test-only addition)
* **Files changed:** consent-protocol/tests/test_validate_token_expiry_ordering.py
* **Runtime code changed:** No

## Privacy & Consent
* **Does this change access user data?** No
* **Sensitive surface touched:** None; test-only coverage for existing consent token expiry validation
* **Error path, rollback, or safe-failure behavior proved:** Yes; invalid expiry claims return invalid token responses with no parsed token object

## Review-Ready Contract
* **Title, body, changed files, and tests describe the same contract:** Yes
* **Concrete production attach point proved:** Yes; the test imports and exercises production alidate_token(...)
* **No local mock-only contract:** Yes; tokens are generated in the canonical HCT wire format and validated by production code
* **Surface alignment:** Validated; the footprint is confined to the existing token expiry ordering test companion file
* **Reviewer risk controls:** One tracked file changed, additive test-only diff, no runtime behavior change, no new configuration files, no mocks/services/helpers

## Boundary Proof
* Covers an expired Year-2038-shaped seconds value interpreted as a millisecond expiry claim
* Covers negative expiry claims, a large negative expiry claim, and non-numeric expiry strings
* Does not claim that far-future positive millisecond expiry values are invalid under the current implementation

## Testing
* pytest consent-protocol/tests/test_validate_token_expiry_ordering.py -> 9 passed
* cd consent-protocol && python -m pytest tests/test_granular_scopes.py -q -> 21 passed
* cd consent-protocol && python -m pytest tests/test_ria_iam_routes.py -q -> 29 passed
* **Commits are signed off:** Yes