### PR TITLE
test(financial): cover missing statement sources

### DIFF
--- a/hushh-webapp/__tests__/utils/financial-sources.test.ts
+++ b/hushh-webapp/__tests__/utils/financial-sources.test.ts
@@ -188,4 +188,7 @@ describe("financial statement snapshots", () => {
       })
     ).toBe("plaid");
   });
+    it("returns no statement options when sources are missing", () => {
+    expect(getStatementSnapshotOptions({})).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

Add test coverage for financial source helpers when statement sources are missing from the financial object.

## Changes Made

- Added a test for missing statement source data
- Verified `getStatementSnapshotOptions()` safely handles an empty object
- Confirmed the helper returns an empty array instead of throwing
- Improved edge-case coverage for financial source utilities

## Test

```bash
npm test -- financial-sources