### PR TITLE
fix(ria-onboarding): preserve firm-name input after validation failure

### DIFF
--- a/hushh-webapp/app/ria/onboarding/page.tsx
+++ b/hushh-webapp/app/ria/onboarding/page.tsx
@@ -793,6 +793,9 @@ export default function RiaOnboardingPage() {
             onAdvisorNameChange={(value: string) =>
               updateDraft({ advisorName: value, displayName: value })
             }
+            onFirmNameChange={(value: string) =>
+              updateDraft({ firmName: value, advisoryFirmName: value })
+            }
             onCityChange={(value: string) => updateDraft({ city: value })}
             onPinZipChange={(value: string) => updateDraft({ pinZip: value })}
             isEnriching={isEnriching}

--- a/hushh-webapp/components/ria/onboarding/onboarding-step-license-details.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-step-license-details.tsx
@@ -101,6 +101,7 @@ export function OnboardingStepLicenseDetails({
   pinZip,
   crdNumber,
   onAdvisorNameChange,
+  onFirmNameChange,
   onCityChange,
   onPinZipChange,
   isEnriching,
@@ -115,6 +116,7 @@ export function OnboardingStepLicenseDetails({
   pinZip: string;
   crdNumber: string;
   onAdvisorNameChange: (value: string) => void;
+  onFirmNameChange: (value: string) => void;
   onCityChange: (value: string) => void;
   onPinZipChange: (value: string) => void;
   isEnriching: boolean;
@@ -141,7 +143,12 @@ export function OnboardingStepLicenseDetails({
           onChange={onAdvisorNameChange}
         />
         <Divider />
-        <InfoRow label="Firm" value={firmName} loading={isEnriching && !firmName} />
+        <EditableRow
+          label="Firm"
+          value={firmName}
+          onChange={onFirmNameChange}
+          loading={isEnriching && !firmName}
+        />
         <Divider />
         <InfoRow label="CRD" value={crdNumber} />
       </GroupShell>


### PR DESCRIPTION
﻿## Summary

- Makes the existing RIA onboarding Firm row editable in the license details step.
- Persists firm-name edits into the existing onboarding draft fields used by submit, so a validation/submission failure keeps the corrected value.

## Independent safety proof

- Base branch: `integration/pr-train`.
- Scope: one existing reachable frontend path only: `/ria/onboarding` license details.
- Changed files: 2 (`hushh-webapp/app/ria/onboarding/page.tsx`, `hushh-webapp/components/ria/onboarding/onboarding-step-license-details.tsx`).
- Canonical caller: `RiaOnboardingPage` renders `OnboardingStepLicenseDetails` for the current RIA onboarding flow.
- Commit count: 1 signed/DCO commit.
- No backend, governance, PKM, vault, consent, cache, route, generated files, new components, hooks, helpers, utilities, exports, agents, or abstractions were introduced.
- This PR is independent: it is based directly on `integration/pr-train` and does not depend on any other same-day PR landing first.

## Validation

- `npx.cmd eslint app/ria/onboarding/page.tsx components/ria/onboarding/onboarding-step-license-details.tsx --max-warnings=0`
- `npm.cmd run lint`
- `npm.cmd run build`
