### PR TITLE
fix(ria-onboarding): prevent duplicate continue clicks while step is saving

### DIFF
--- a/hushh-webapp/app/ria/onboarding/page.tsx
+++ b/hushh-webapp/app/ria/onboarding/page.tsx
@@ -142,6 +142,7 @@ export default function RiaOnboardingPage() {
     lastKey: string | null;
   }>({ inFlight: false, lastKey: null });
   const submitInFlightRef = useRef(false);
+  const continueInFlightRef = useRef(false);
 
   const advisoryVerificationStatus =
     status?.advisory_status || status?.verification_status || "draft";
@@ -346,12 +347,18 @@ export default function RiaOnboardingPage() {
   }
 
   function handleContinue() {
-    if (!canContinue || saving) return;
+    if (!canContinue || saving || continueInFlightRef.current) return;
+    continueInFlightRef.current = true;
     if (currentStep.id === "review") {
-      void handleSubmit();
+      void handleSubmit().finally(() => {
+        continueInFlightRef.current = false;
+      });
       return;
     }
     moveToStep(steps[currentStepIndex + 1]?.id ?? currentStep.id);
+    window.setTimeout(() => {
+      continueInFlightRef.current = false;
+    }, 0);
   }
 
   const startScrapePolling = useCallback(


### PR DESCRIPTION
﻿## Summary

- Adds a synchronous guard around the existing RIA onboarding Continue handler.
- Prevents rapid duplicate Continue clicks from advancing or submitting more than once before the step/save state settles.

## Independent safety proof

- Base branch: `integration/pr-train`.
- Scope: one existing reachable frontend path only: `/ria/onboarding` Continue action.
- Changed files: 1 (`hushh-webapp/app/ria/onboarding/page.tsx`).
- Canonical caller: `/ria/onboarding` renders `RiaOnboardingPage`, which passes `handleContinue` to the existing `OnboardingShell` continue button.
- Commit count: 1 signed/DCO commit.
- No backend, governance, PKM, vault, consent, cache, route, generated files, new components, hooks, helpers, utilities, exports, agents, or abstractions were introduced.
- This PR is independent: it is based directly on `integration/pr-train` and does not depend on any other same-day PR landing first.

## Validation

- `npx.cmd eslint app/ria/onboarding/page.tsx --max-warnings=0`
- `npm.cmd run lint`
- `npm.cmd run build`
