### PR TITLE
fix(ria-onboarding): autofocus first invalid onboarding field after failed validation

### DIFF
--- a/hushh-webapp/app/ria/onboarding/page.tsx
+++ b/hushh-webapp/app/ria/onboarding/page.tsx
@@ -345,8 +345,28 @@ export default function RiaOnboardingPage() {
     moveToStep(steps[currentStepIndex - 1]?.id ?? steps[0]?.id ?? "welcome");
   }
 
+  function focusFirstInvalidField() {
+    let target: HTMLElement | null = null;
+
+    if (currentStep.id === "license_number") {
+      target = document.getElementById("ria-license-number");
+    } else if (currentStep.id === "license_details") {
+      target = document.getElementById("ria-advisor-name");
+    } else if (currentStep.id === "services") {
+      target = draft.servicesOffered.length === 0
+        ? document.querySelector<HTMLElement>('[data-ria-service-option="first"]')
+        : document.querySelector<HTMLElement>('[data-ria-fee-option="first"]');
+    }
+
+    target?.focus({ preventScroll: true });
+  }
+
   function handleContinue() {
-    if (!canContinue || saving) return;
+    if (saving) return;
+    if (!canContinue) {
+      focusFirstInvalidField();
+      return;
+    }
     if (currentStep.id === "review") {
       void handleSubmit();
       return;

--- a/hushh-webapp/components/ria/onboarding/onboarding-shell.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-shell.tsx
@@ -83,7 +83,7 @@ export function OnboardingShell({
         <div className="pb-[calc(var(--bottom-chrome-stack-height,var(--app-screen-footer-pad))+0.75rem)] pt-7 sm:pt-8">
           <button
             type="button"
-            disabled={!canContinue || saving}
+            aria-disabled={!canContinue || saving}
             onClick={onContinue}
             className={cn(
               "inline-flex min-h-[52px] w-full items-center justify-center gap-2 rounded-full bg-primary px-6 text-[17px] font-semibold text-primary-foreground shadow-[0_12px_32px_rgba(0,113,227,0.22)] transition-opacity dark:shadow-none",

--- a/hushh-webapp/components/ria/onboarding/onboarding-step-license-details.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-step-license-details.tsx
@@ -59,11 +59,13 @@ function InfoRow({
 
 function EditableRow({
   label,
+  inputId,
   value,
   onChange,
   loading,
 }: {
   label: string;
+  inputId?: string;
   value: string;
   onChange: (value: string) => void;
   loading?: boolean;
@@ -78,6 +80,7 @@ function EditableRow({
       ) : (
         <span className="ml-auto flex min-w-0 flex-1 items-center justify-end gap-2">
           <input
+            id={inputId}
             type="text"
             value={value}
             onChange={(event) => onChange(event.target.value)}
@@ -137,6 +140,7 @@ export function OnboardingStepLicenseDetails({
       <GroupShell>
         <EditableRow
           label="Advisor"
+          inputId="ria-advisor-name"
           value={advisorName}
           onChange={onAdvisorNameChange}
         />

--- a/hushh-webapp/components/ria/onboarding/onboarding-step-services.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-step-services.tsx
@@ -158,6 +158,7 @@ export function OnboardingStepServices({
               <button
                 key={label}
                 type="button"
+                data-ria-service-option={label === AVAILABLE_SERVICES[0]?.label ? "first" : undefined}
                 aria-pressed={selected}
                 onClick={() => toggleService(label)}
                 className={cn(
@@ -193,6 +194,7 @@ export function OnboardingStepServices({
               <button
                 key={fee}
                 type="button"
+                data-ria-fee-option={fee === FEE_OPTIONS[0] ? "first" : undefined}
                 aria-pressed={selected}
                 onClick={() => toggleFee(fee)}
                 className={cn(


### PR DESCRIPTION
﻿## Summary

- Lets invalid RIA onboarding Continue attempts reach the existing page handler while preserving the disabled visual state.
- Focuses the first invalid field/group for the current onboarding step: licence number, advisor name, services, or fee structure.

## Independent safety proof

- Base branch: `integration/pr-train`.
- Scope: one existing reachable frontend path only: `/ria/onboarding` validation recovery.
- Changed files: 4 existing RIA onboarding UI files (`hushh-webapp/app/ria/onboarding/page.tsx`, `hushh-webapp/components/ria/onboarding/onboarding-shell.tsx`, `hushh-webapp/components/ria/onboarding/onboarding-step-license-details.tsx`, `hushh-webapp/components/ria/onboarding/onboarding-step-services.tsx`).
- Canonical caller: `/ria/onboarding` renders `RiaOnboardingPage`, which renders the existing shell and step components.
- Commit count: 1 signed/DCO commit.
- No backend, governance, PKM, vault, consent, cache, route, generated files, new components, hooks, helpers, utilities, exports, agents, or abstractions were introduced.
- This PR is independent: it is based directly on `integration/pr-train` and does not depend on any other same-day PR landing first.

## Validation

- `npx.cmd eslint app/ria/onboarding/page.tsx components/ria/onboarding/onboarding-shell.tsx components/ria/onboarding/onboarding-step-license-details.tsx components/ria/onboarding/onboarding-step-services.tsx --max-warnings=0`
- `npm.cmd run lint`
- `npm.cmd run build`
