### PR TITLE
fix(ria-onboarding): keep step footer buttons aligned during loading

### DIFF
--- a/hushh-webapp/components/ria/onboarding/onboarding-shell.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-shell.tsx
@@ -91,7 +91,14 @@ export function OnboardingShell({
             )}
           >
             {saving ? (
-              <Loader2 className="h-5 w-5 animate-spin" />
+              <>
+                <Loader2 className="h-5 w-5 animate-spin" />
+                <span className="sr-only">Saving</span>
+                <span aria-hidden="true" className="invisible">
+                  Continue
+                </span>
+                <ArrowRight aria-hidden="true" className="invisible h-4 w-4" />
+              </>
             ) : isLastStep && advisoryAccessReady ? (
               <>
                 Continue to Dashboard


### PR DESCRIPTION
﻿## Summary

- Keeps the RIA onboarding footer Continue button footprint stable while the saving spinner is shown.
- Preserves accessible loading text with `sr-only` while invisible text/icon reserve the normal button content width.

## Independent safety proof

- Base branch: `integration/pr-train`.
- Scope: one existing reachable frontend path only: `/ria/onboarding` step footer loading state.
- Changed files: 1 (`hushh-webapp/components/ria/onboarding/onboarding-shell.tsx`).
- Canonical caller: `/ria/onboarding` renders `RiaOnboardingPage`, which renders the existing `OnboardingShell` footer.
- Commit count: 1 signed/DCO commit.
- No backend, governance, PKM, vault, consent, cache, route, generated files, new components, hooks, helpers, utilities, exports, agents, or abstractions were introduced.
- This PR is independent: it is based directly on `integration/pr-train` and does not depend on any other same-day PR landing first.

## Validation

- `npx.cmd eslint components/ria/onboarding/onboarding-shell.tsx --max-warnings=0`
- `npm.cmd run lint`
- `npm.cmd run build`
