### PR TITLE
test(nav): ignore unsafe consent breadcrumb origins

### DIFF
--- a/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
+++ b/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
@@ -154,4 +154,20 @@ describe("top shell breadcrumbs", () => {
       ],
     });
   });
-});
+      it("ignores unsafe external from params for consent back navigation", () => {
+    const params = new URLSearchParams();
+    params.set("from", "https://evil.example.com/phish");
+
+    expect(resolveTopShellBreadcrumb("/consents", params)).toEqual({
+      backHref: "/profile?panel=access",
+      width: "profile",
+      align: "center",
+      items: [
+        { label: "Profile", href: "/profile?panel=access" },
+        { label: "Privacy", href: "/profile?panel=access" },
+        { label: "Consent center" },
+      ],
+    });
+  });
+    });
+ 


### PR DESCRIPTION
## Summary

Add test coverage for consent breadcrumb navigation when an unsafe external `from` parameter is provided.

## Changes Made

- Added a test for external `from` URL values
- Verified unsafe origins are ignored during breadcrumb resolution
- Confirmed consent routes fall back to the default profile privacy workspace
- Extended navigation safety coverage for consent back navigation

## Test

```bash
npm test -- top-shell-breadcrumbs