### PR TITLE
test(nav): ignore protocol-relative breadcrumb origins

### DIFF
--- a/docs/webapp-test-troubleshooting.md
+++ b/docs/webapp-test-troubleshooting.md
@@ -1,0 +1,74 @@
+\# Webapp Test Troubleshooting
+
+
+
+\## `npm test` fails with `ENOENT package.json`
+
+
+
+If `npm test` shows an error like:
+
+
+
+```text
+
+Could not read package.json
+
+ENOENT: no such file or directory
+
+```
+
+
+
+you are likely running the command from the repository root instead of the webapp package directory.
+
+
+
+Run webapp tests from:
+
+
+
+```powershell
+
+cd hushh-webapp
+
+npm test -- <test-name>
+
+```
+
+
+
+Example:
+
+
+
+```powershell
+
+cd hushh-webapp
+
+npm test -- financial-sources
+
+```
+
+
+
+\## Quick check
+
+
+
+Before running webapp tests, confirm `package.json` exists:
+
+
+
+```powershell
+
+dir package.json
+
+```
+
+
+
+If the file is missing, move into the webapp folder first.
+
+
+

--- a/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
+++ b/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
@@ -154,4 +154,12 @@ describe("top shell breadcrumbs", () => {
       ],
     });
   });
+    it("ignores protocol-relative from params for consent back navigation", () => {
+    const params = new URLSearchParams();
+    params.set("from", "//evil.example.com/phish");
+
+    expect(resolveTopShellBreadcrumb("/consents", params)?.backHref).toBe(
+      "/profile?panel=access"
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Add test coverage for consent breadcrumb navigation when a protocol-relative `from` parameter is provided.

## Changes Made

- Added a test for protocol-relative origin values such as `//example.com`
- Verified protocol-relative URLs are treated as unsafe navigation targets
- Confirmed breadcrumb resolution falls back to the default profile privacy workspace
- Extended navigation safety coverage for consent back navigation

## Test

```bash
npm test -- top-shell-breadcrumbs