### PR TITLE
docs: add PowerShell path note

### DIFF
--- a/docs/powershell-path-notes.md
+++ b/docs/powershell-path-notes.md
@@ -12,5 +12,7 @@ Repository root
 
 └── hushh-webapp
 
-&#x20;   └── package.json
+&#x20;   ├── package.json
+
+&#x20;   └── \_\_tests\_\_
 

--- a/docs/powershell-path-notes.md
+++ b/docs/powershell-path-notes.md
@@ -1,0 +1,16 @@
+\# PowerShell Path Notes
+
+
+
+\## Visual Map
+
+
+
+```text
+
+Repository root
+
+└── hushh-webapp
+
+&#x20;   └── package.json
+


### PR DESCRIPTION
## Summary

Add a short troubleshooting guide for PowerShell path navigation when working with the repository.

## Changes Made

- Added `docs/powershell-path-notes.md`
- Documented correct PowerShell directory navigation syntax
- Included examples of common path mistakes
- Added a visual map showing the expected project structure
- Added verification steps for confirming the active working directory

## Problem

Developers may accidentally run commands such as:

```powershell
cd.\hushh-webapp