### PR TITLE
test(financial): cover null portfolio state

### DIFF
--- a/hushh-webapp/__tests__/utils/financial-sources.test.ts
+++ b/hushh-webapp/__tests__/utils/financial-sources.test.ts
@@ -188,4 +188,11 @@ describe("financial statement snapshots", () => {
       })
     ).toBe("plaid");
   });
+  it("returns null portfolio when portfolio data is missing", () => {
+  expect(
+    getStatementPortfolio({
+      portfolio: null,
+    })
+  ).toBeNull();
+});
 });


### PR DESCRIPTION
## Summary

Add test coverage for financial sources when portfolio data is missing.

## Changes Made

- Added a test for a null portfolio state
- Verified portfolio resolution safely returns null
- Extended defensive coverage for financial source utilities

## Test

npm test -- financial-sources