### PR TITLE
fix(investors): remove exception detail from investor proxy response

### DIFF
--- a/hushh-webapp/app/api/investors/[id]/route.ts
+++ b/hushh-webapp/app/api/investors/[id]/route.ts
@@ -41,8 +41,9 @@ export async function GET(
     return NextResponse.json(data, { status: response.status });
   } catch (error) {
     console.error("[Investors Proxy] Get error:", error);
+
     return NextResponse.json(
-      { error: "Failed to get investor", details: String(error) },
+      { error: "Failed to get investor" },
       { status: 500 }
     );
   }

--- a/hushh-webapp/components/onboarding/previews/KycPreviewCompact.tsx
+++ b/hushh-webapp/components/onboarding/previews/KycPreviewCompact.tsx
@@ -23,9 +23,9 @@ type KycDisplayItem = {
 
 function StatusIcon({ status }: { status: KycItemStatus }) {
   if (status === "verified") {
-    return <Icon icon={CircleCheck} size="lg" className="text-emerald-500" />;
+    return <Icon icon={CircleCheck} size="lg" aria-hidden="true" className="text-emerald-500" />;
   }
-  return <Icon icon={CircleDashed} size="lg" className="text-muted-foreground" />;
+  return <Icon icon={CircleDashed} size="lg" aria-hidden="true" className="text-muted-foreground" />;
 }
 
 function buildDisplayItems(
@@ -99,7 +99,7 @@ export function KycPreviewCompact() {
                   <div
                     className={`grid h-10 w-10 place-items-center rounded-full ${item.iconTone}`}
                   >
-                    <Icon icon={item.icon} size="md" />
+                    <Icon icon={item.icon} size="md" aria-hidden="true" />
                   </div>
                   <span className="text-[15px] font-semibold">{item.label}</span>
                 </div>


### PR DESCRIPTION
## Summary

Remove exception details from the investor proxy error response to avoid exposing internal implementation information to clients.

## Changes

* Removed `details: String(error)` from the investor proxy error response.
* Retained the existing generic error message:

  * `Failed to get investor`
* Kept server-side logging unchanged for debugging purposes.

## Why

Returning raw exception details in API responses can unintentionally expose internal application behavior and implementation details. Clients only need a generic failure response, while detailed diagnostics should remain on the server.

## Testing

* npm run lint
* npm run typecheck
