### PR TITLE
fix(ui): add explicit type to streaming text scroll control

### DIFF
--- a/hushh-webapp/lib/morphy-ux/streaming-text.tsx
+++ b/hushh-webapp/lib/morphy-ux/streaming-text.tsx
@@ -298,6 +298,7 @@ export function StreamingTextDisplay({
       {/* Scroll to bottom button (shows when user scrolled up during streaming) */}
       {userScrolledUp && isStreaming && (
         <button
+          type="button"
           onClick={handleScrollToBottom}
           className={cn(
             "sticky bottom-2 left-1/2 -translate-x-1/2 z-10",


### PR DESCRIPTION
## What

Adds an explicit `type="button"` to the scroll-to-bottom control in `StreamingTextDisplay`.

## Why

Buttons default to `type="submit"` when rendered inside forms.

Although this control is intended only for scrolling, rendering the component within a form could trigger an unintended form submission when clicked.

Adding an explicit button type makes the component behavior predictable and aligns it with other shared UI controls.

## Changes

- Added `type="button"` to the scroll-to-bottom control button in `StreamingTextDisplay`.

## Validation

- npm run lint
- npm run typecheck