### PR TITLE
Polish Meet One onboarding intro

### DIFF
--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -83,46 +83,38 @@ export function IntroStep({
 }) {
   return (
     <main className="min-h-[100dvh] w-full bg-[#ffffff] text-[#1d1d1f] dark:bg-[#ffffff] dark:text-[#1d1d1f]">
-      <div className="mx-auto flex min-h-[100dvh] w-full max-w-[440px] flex-col px-6 pt-[calc(46px+var(--app-safe-area-top-effective,0px))]">
+      <div className="mx-auto flex min-h-[100dvh] w-full max-w-[440px] flex-col px-6 pt-[calc(28px+var(--app-safe-area-top-effective,0px))]">
         <section className="relative flex flex-none flex-col items-center text-center">
-          <div
-            aria-hidden
-            className="absolute left-1/2 top-6 h-[220px] w-[320px] -translate-x-1/2 rounded-full bg-[#eaf5ff] blur-2xl"
-          />
-          <span className="relative text-[66px] leading-none">🤫</span>
+          <span className="relative text-[54px] leading-none">🤫</span>
 
           <div
             role="heading"
             aria-level={1}
             aria-label="Meet One, Your Personal Financial Advisor"
-            className="relative mt-5 text-[38px] font-semibold leading-[1.08] tracking-normal text-[#1d1d1f]"
+            className="relative mt-6 text-[38px] font-bold leading-[1.08] tracking-normal text-[#1d1d1f]"
           >
             Meet One.
           </div>
-          <p className="relative mt-2 text-[18px] leading-7 tracking-normal text-[#6e6e73]">
+          <p className="relative mt-2.5 text-[21px] font-medium leading-[1.32] tracking-normal text-[#1d1d1f]">
             Your personal financial advisor.
           </p>
         </section>
 
-        <div className="flex min-h-0 flex-1 items-center py-9">
+        <div className="flex min-h-0 flex-1 items-stretch py-6">
           <div className="relative w-full">
-            <div
-              aria-hidden
-              className="absolute bottom-[3.5rem] left-7 top-[3.5rem] w-0.5 rounded-full bg-gradient-to-b from-transparent via-[#b8d4ff] to-transparent"
-            />
-            <div className="relative z-10 space-y-6">
+            <div className="relative z-10 mx-auto flex h-full w-full max-w-[332px] flex-col justify-evenly gap-3">
               {INTRO_FEATURES.map((feature) => (
-                <div key={feature.title} className="grid grid-cols-[56px_minmax(0,1fr)] items-center gap-5">
+                <div key={feature.title} className="grid grid-cols-[46px_minmax(0,1fr)] items-center gap-4">
                   <span
-                    className={`grid h-14 w-14 place-items-center rounded-[16px] border ${feature.tileClassName}`}
+                    className={`grid h-[46px] w-[46px] place-items-center rounded-[14px] border ${feature.tileClassName}`}
                   >
-                    <feature.icon className="h-6 w-6" />
+                    <feature.icon className="h-[23px] w-[23px]" />
                   </span>
                   <div className="min-w-0">
-                    <p className="text-[20px] font-semibold leading-6 tracking-normal text-[#1d1d1f]">
+                    <p className="text-[16.5px] font-semibold leading-[1.25] tracking-normal text-[#1d1d1f]">
                       {feature.title}
                     </p>
-                    <p className="mt-1 text-[17px] leading-6 tracking-normal text-[#6e6e73]">
+                    <p className="mt-0.5 text-[14.5px] leading-[1.35] tracking-normal text-[rgba(0,0,0,0.56)]">
                       {feature.subtitle}
                     </p>
                   </div>
@@ -143,14 +135,14 @@ export function IntroStep({
               fullWidth
               onClick={onNext}
               showRipple
-              className="h-[60px] rounded-full bg-[#0071e3] text-[22px] font-semibold tracking-normal text-white shadow-none hover:bg-[#0077ed]"
+              className="h-[50px] rounded-full bg-[#0071e3] text-[17px] font-semibold tracking-normal text-white shadow-none hover:bg-[#0077ed]"
             >
               Get started
             </Button>
             {onLogin ? (
               <button
                 type="button"
-                className="mx-auto block min-h-10 px-4 text-[17px] font-semibold tracking-normal text-[#0066cc] transition-colors hover:text-[#0071e3]"
+                className="mx-auto block min-h-10 px-4 text-[15px] font-semibold tracking-normal text-[#0066cc] transition-colors hover:text-[#0071e3]"
                 onClick={onLogin}
               >
                 Log in

--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -1,8 +1,78 @@
 "use client";
 
-import { ArrowRight, CandlestickChart, LogIn, TrendingUp, Zap } from "lucide-react";
+import type { ComponentType, SVGProps } from "react";
 import { Button } from "@/lib/morphy-ux/button";
-import { BrandMark, Icon, OnboardingFeatureList } from "@/lib/morphy-ux/ui";
+
+function ShieldBadgeIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" {...props}>
+      <path d="M12 2.5 4.5 5.3v5.8c0 4.7 3.2 7.3 7.5 8.5 4.3-1.2 7.5-3.8 7.5-8.5V5.3L12 2.5Z" />
+      <path
+        d="m8.4 12 2.3 2.3 4.9-4.9"
+        fill="none"
+        stroke="#ffffff"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2.2"
+      />
+    </svg>
+  );
+}
+
+function HoldingsBarsIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" {...props}>
+      <rect x="3.8" y="13.3" width="4.2" height="7.1" rx="1.3" />
+      <rect x="9.9" y="8.8" width="4.2" height="11.6" rx="1.3" />
+      <rect x="16" y="3.6" width="4.2" height="16.8" rx="1.3" />
+    </svg>
+  );
+}
+
+function SignalPulseIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" {...props}>
+      <circle cx="12" cy="12" r="9.8" />
+      <path
+        d="M6.3 12h2.2l1.7-3.5 2.5 6.5 1.9-3h3.1"
+        fill="none"
+        stroke="#ffffff"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.9"
+      />
+    </svg>
+  );
+}
+
+const INTRO_FEATURES: Array<{
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+  title: string;
+  subtitle: string;
+  tileClassName: string;
+}> = [
+  {
+    icon: ShieldBadgeIcon,
+    title: "Verified in minutes",
+    subtitle: "Seamless KYC, no paperwork",
+    tileClassName:
+      "border-[#d7f8e0] bg-[linear-gradient(135deg,rgba(255,255,255,0.94),rgba(240,253,244,0.72))] text-[#34c759] shadow-[0_12px_28px_rgba(52,199,89,0.10)]",
+  },
+  {
+    icon: HoldingsBarsIcon,
+    title: "Top holdings, at a glance",
+    subtitle: "Your portfolio, always live",
+    tileClassName:
+      "border-[#e1e2ff] bg-[linear-gradient(135deg,rgba(255,255,255,0.94),rgba(247,247,255,0.76))] text-[#5856d6] shadow-[0_12px_28px_rgba(88,86,214,0.10)]",
+  },
+  {
+    icon: SignalPulseIcon,
+    title: "Buy, sell, hold",
+    subtitle: "Clear signals when they matter",
+    tileClassName:
+      "border-[#ffe1bd] bg-[linear-gradient(135deg,rgba(255,255,255,0.94),rgba(255,247,237,0.72))] text-[#ff9500] shadow-[0_12px_28px_rgba(255,149,0,0.10)]",
+  },
+];
 
 export function IntroStep({
   onNext,
@@ -12,72 +82,79 @@ export function IntroStep({
   onLogin?: () => void;
 }) {
   return (
-    <main className="min-h-[100dvh] w-full bg-transparent">
-      <div className="mx-auto flex min-h-[100dvh] w-full max-w-md flex-col px-6 pt-8">
-        <div className="flex-1 min-h-0">
-          <div className="flex min-h-full flex-col items-center text-center">
-            <BrandMark size="md" unframed />
+    <main className="min-h-[100dvh] w-full bg-[#ffffff] text-[#1d1d1f] dark:bg-[#ffffff] dark:text-[#1d1d1f]">
+      <div className="mx-auto flex min-h-[100dvh] w-full max-w-[440px] flex-col px-6 pt-[calc(46px+var(--app-safe-area-top-effective,0px))]">
+        <section className="relative flex flex-none flex-col items-center text-center">
+          <div
+            aria-hidden
+            className="absolute left-1/2 top-6 h-[220px] w-[320px] -translate-x-1/2 rounded-full bg-[#eaf5ff] blur-2xl"
+          />
+          <span className="relative text-[66px] leading-none">🤫</span>
 
-            <div className="mt-8 space-y-4">
-              <h1 className="text-[clamp(2.25rem,7.5vw,3.2rem)] font-black tracking-tight leading-[1.08]">
-                Meet One,
-                <br />
-                Your Personal
-                <br />
-                Financial Advisor
-              </h1>
-              <p className="mx-auto max-w-[18rem] text-[clamp(1rem,3.8vw,1.125rem)] leading-relaxed text-muted-foreground">
-                The fastest path to actionable wealth insights.
-              </p>
-            </div>
+          <div
+            role="heading"
+            aria-level={1}
+            aria-label="Meet One, Your Personal Financial Advisor"
+            className="relative mt-5 text-[38px] font-semibold leading-[1.08] tracking-normal text-[#1d1d1f]"
+          >
+            Meet One.
+          </div>
+          <p className="relative mt-2 text-[18px] leading-7 tracking-normal text-[#6e6e73]">
+            Your personal financial advisor.
+          </p>
+        </section>
 
-            <div className="mt-8 w-full max-w-sm text-left">
-              <OnboardingFeatureList
-                features={[
-                  {
-                    tone: "blue",
-                    icon: Zap,
-                    title: "Seamless KYC",
-                    subtitle: "Accelerating KYC with frictionless verification",
-                  },
-                  {
-                    tone: "green",
-                    icon: TrendingUp,
-                    title: "Portfolio Monitoring",
-                    subtitle: "Identify top performing holdings at a glance.",
-                  },
-                  {
-                    tone: "orange",
-                    icon: CandlestickChart,
-                    title: "Actionable Advice",
-                    subtitle:
-                      "Giving quick buy, sell, and hold investment signals",
-                  },
-                ]}
-              />
+        <div className="flex min-h-0 flex-1 items-center py-9">
+          <div className="relative w-full">
+            <div
+              aria-hidden
+              className="absolute bottom-[3.5rem] left-7 top-[3.5rem] w-0.5 rounded-full bg-gradient-to-b from-transparent via-[#b8d4ff] to-transparent"
+            />
+            <div className="relative z-10 space-y-6">
+              {INTRO_FEATURES.map((feature) => (
+                <div key={feature.title} className="grid grid-cols-[56px_minmax(0,1fr)] items-center gap-5">
+                  <span
+                    className={`grid h-14 w-14 place-items-center rounded-[16px] border ${feature.tileClassName}`}
+                  >
+                    <feature.icon className="h-6 w-6" />
+                  </span>
+                  <div className="min-w-0">
+                    <p className="text-[20px] font-semibold leading-6 tracking-normal text-[#1d1d1f]">
+                      {feature.title}
+                    </p>
+                    <p className="mt-1 text-[17px] leading-6 tracking-normal text-[#6e6e73]">
+                      {feature.subtitle}
+                    </p>
+                  </div>
+                </div>
+              ))}
             </div>
           </div>
         </div>
 
-        <footer className="flex-none pt-4 pb-[var(--app-screen-footer-pad)]">
-          <div className="space-y-3">
-            <Button size="lg" fullWidth onClick={onNext} showRipple>
-              Get Started
-              <Icon icon={ArrowRight} size="md" className="ml-2" />
+        <footer className="flex-none pb-[calc(16px+var(--app-safe-area-bottom-effective,0px))]">
+          <div className="space-y-4">
+            <p className="mx-auto max-w-[35ch] text-center text-sm leading-5 tracking-normal text-[#9a9a9f]">
+              One is consent-first. Your data stays in your vault — nothing is
+              shared without your approval.
+            </p>
+            <Button
+              size="lg"
+              fullWidth
+              onClick={onNext}
+              showRipple
+              className="h-[60px] rounded-full bg-[#0071e3] text-[22px] font-semibold tracking-normal text-white shadow-none hover:bg-[#0077ed]"
+            >
+              Get started
             </Button>
             {onLogin ? (
-              <Button
-                size="lg"
-                fullWidth
-                variant="none"
-                effect="fade"
-                className="border border-border/70 bg-background/80"
+              <button
+                type="button"
+                className="mx-auto block min-h-10 px-4 text-[17px] font-semibold tracking-normal text-[#0066cc] transition-colors hover:text-[#0071e3]"
                 onClick={onLogin}
-                showRipple
               >
-                Login
-                <Icon icon={LogIn} size="md" className="ml-2" />
-              </Button>
+                Log in
+              </button>
             ) : null}
           </div>
         </footer>


### PR DESCRIPTION
## Summary
- Restyles the Meet One onboarding intro toward the Apple-like UAT reference
- Updates typography, compact content, light tinted feature tiles, filled feature glyphs, and CTA styling
- Preserves existing `onNext` and `onLogin` handlers so linked routes/actions remain untouched

## Verification
- `cd hushh-webapp && npm run typecheck`
- `cd hushh-webapp && npm run lint`
- `cd hushh-webapp && npm run verify:design-system`
- `cd hushh-webapp && npm run verify:cache`
- `cd hushh-webapp && npm run verify:docs`

Browser testing intentionally skipped per request.

## Deploy Scope
- UAT deploy scope after merge: `frontend`