### PR TITLE
fix(a11y): hide decorative agent voice indicator icons

### DIFF
--- a/hushh-webapp/components/agent/agent-voice-floating-indicator.tsx
+++ b/hushh-webapp/components/agent/agent-voice-floating-indicator.tsx
@@ -29,13 +29,13 @@ export function AgentVoiceFloatingIndicator({
     status === "transcribing" || status === "thinking" ? (
       <Loader2 className="h-4 w-4 animate-spin" />
     ) : status === "muted" ? (
-      <MicOff className="h-4 w-4" />
+      <MicOff aria-hidden="true" className="h-4 w-4" />
     ) : status === "speaking" ? (
-      <Volume2 className="h-4 w-4" />
+      <Volume2 aria-hidden="true" className="h-4 w-4" />
     ) : status === "error" ? (
-      <AlertCircle className="h-4 w-4" />
+      <AlertCircle aria-hidden="true" className="h-4 w-4" />
     ) : (
-      <Mic className="h-4 w-4" />
+      <Mic aria-hidden="true" className="h-4 w-4" />
     );
 
   return (


### PR DESCRIPTION
## What

Hide decorative status icons in `AgentVoiceFloatingIndicator` from assistive technologies.

## Why

The floating voice indicator button already exposes its state through an accessible label. The visual status icons are decorative and do not provide additional information for screen reader users.

Marking these icons as `aria-hidden="true"` prevents redundant announcements and improves accessibility.

## Changes

* Added `aria-hidden="true"` to:

  * `Loader2`
  * `Mic`
  * `MicOff`
  * `Volume2`
  * `AlertCircle`

## Validation

* npm run lint
* npm run typecheck
