### PR TITLE
fix(ui): add explicit type to streaming accordion scroll control

### DIFF
--- a/hushh-webapp/lib/morphy-ux/streaming-accordion.tsx
+++ b/hushh-webapp/lib/morphy-ux/streaming-accordion.tsx
@@ -479,7 +479,7 @@ export function StreamingAccordion({
 
             {/* Scroll to bottom button */}
             {userScrolledUp && isStreaming && isOpen && (
-              <button
+              <button`r`n                type="button"
                 onClick={handleScrollToBottom}
                 className={cn(
                   "absolute bottom-2 left-1/2 -translate-x-1/2 z-10",

--- a/hushh-webapp/lib/morphy-ux/streaming-accordion.tsx
+++ b/hushh-webapp/lib/morphy-ux/streaming-accordion.tsx
@@ -478,18 +478,19 @@ export function StreamingAccordion({
             </div>
 
             {/* Scroll to bottom button */}
-            {userScrolledUp && isStreaming && isOpen && (
-              <button`r`n                type="button"
-                onClick={handleScrollToBottom}
-                className={cn(
-                  "absolute bottom-2 left-1/2 -translate-x-1/2 z-10",
-                  "px-3 py-1.5 rounded-full",
-                  "bg-primary text-primary-foreground text-xs font-medium",
-                  "shadow-lg hover:shadow-xl transition-all",
-                  "animate-in fade-in slide-in-from-bottom-2",
-                  "flex items-center gap-1.5"
-                )}
-              >
+{userScrolledUp && isStreaming && isOpen && (
+  <button
+    type="button"
+    onClick={handleScrollToBottom}
+    className={cn(
+      "absolute bottom-2 left-1/2 -translate-x-1/2 z-10",
+      "px-3 py-1.5 rounded-full",
+      "bg-primary text-primary-foreground text-xs font-medium",
+      "shadow-lg hover:shadow-xl transition-all",
+      "animate-in fade-in slide-in-from-bottom-2",
+      "flex items-center gap-1.5"
+    )}
+  >
                 <svg
                   className="w-3 h-3"
                   fill="none"


### PR DESCRIPTION
## What

Adds an explicit `type="button"` to the scroll-to-bottom control in `StreamingAccordion`.

## Why

Buttons default to `type="submit"` when rendered inside forms.

Although this control is only intended to scroll the content area, rendering the component within a form could trigger an unintended form submission when clicked.

Adding an explicit button type makes the component behavior predictable and aligns it with other shared UI controls.

## Changes

* Added `type="button"` to the scroll-to-bottom control button in `StreamingAccordion`.

## Validation

* npm run lint
* npm run typecheck
