### PR TITLE
fix(ria-onboarding): add aria-current to active progress step

### DIFF
--- a/hushh-webapp/components/ria/onboarding/onboarding-shell.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-shell.tsx
@@ -51,6 +51,7 @@ export function OnboardingShell({
 
           <span
             aria-label={`Step ${currentStepIndex + 1} of ${totalSteps}`}
+            aria-current="step"
             className="inline-flex items-center rounded-full border border-border/60 bg-card/70 px-3 py-1 text-xs font-medium tabular-nums text-muted-foreground shadow-[0_8px_24px_rgba(15,23,42,0.06)] backdrop-blur dark:bg-card/45 dark:shadow-none"
           >
             {currentStepIndex + 1} / {totalSteps}


### PR DESCRIPTION
## Description

Adds the `aria-current` attribute to the active step in the RIA onboarding progress indicator, improving accessibility for screen reader users navigating the onboarding flow.

## Why

The onboarding progress tracker visually indicates the user's current step, but assistive technologies may not receive the same contextual information. Adding `aria-current` allows screen readers to announce which onboarding step is currently active, making progress easier to understand and navigate.

This change aligns the progress indicator with established accessibility best practices while preserving the existing onboarding experience.

## What changed

- Added `aria-current` to the active onboarding progress step
- Improved screen reader awareness of the current onboarding position
- Preserved existing progress indicator styling and behavior
- Maintained existing onboarding navigation and workflow logic

## Impact

- No API changes
- No schema changes
- No backend behavior changes
- Improves accessibility and assistive technology support

## Testing

- Ran `npm run lint`
- Ran `npm run build`
- Verified the active onboarding step exposes `aria-current`
- Verified screen readers correctly identify the current step
- Verified onboarding navigation and progress display remain unchanged

## Notes

This PR intentionally focuses on the existing RIA onboarding progress indicator only and does not modify onboarding business logic, license verification behavior, authentication flows, consent contracts, PKM behavior, backend services, or application architecture.