### PR TITLE
Test/financial sources empty snapshots

### DIFF
--- a/docs/webapp-test-troubleshooting.md
+++ b/docs/webapp-test-troubleshooting.md
@@ -1,74 +1,91 @@
-\# Webapp Test Troubleshooting
+# Webapp Test Troubleshooting
 
+## Visual Map
 
+```text
+Repository root
+└── hushh-webapp
+    ├── package.json
+    ├── src
+    └── __tests__
+```
 
-\## `npm test` fails with `ENOENT package.json`
+Run webapp test commands from `hushh-webapp`, not from the repository root.
 
-
+## `npm test` fails with `ENOENT package.json`
 
 If `npm test` shows an error like:
 
-
-
 ```text
-
 Could not read package.json
-
 ENOENT: no such file or directory
-
 ```
-
-
 
 you are likely running the command from the repository root instead of the webapp package directory.
 
-
+## Correct Usage
 
 Run webapp tests from:
 
-
-
 ```powershell
-
 cd hushh-webapp
-
 npm test -- <test-name>
-
 ```
-
-
 
 Example:
 
-
-
 ```powershell
-
 cd hushh-webapp
-
 npm test -- financial-sources
-
 ```
 
+## Quick Check
 
-
-\## Quick check
-
-
-
-Before running webapp tests, confirm `package.json` exists:
-
-
+Before running webapp tests, confirm that `package.json` exists:
 
 ```powershell
-
 dir package.json
-
 ```
 
+Expected output should include:
 
+```text
+package.json
+```
 
-If the file is missing, move into the webapp folder first.
+If the file is missing, move into the webapp folder first:
 
+```powershell
+cd hushh-webapp
+```
 
+## Common Mistake
 
+Running tests from:
+
+```text
+hushh-research
+```
+
+instead of:
+
+```text
+hushh-research/hushh-webapp
+```
+
+will cause npm to fail because it cannot locate the webapp package configuration.
+
+## Resolution Steps
+
+1. Navigate to the webapp directory.
+2. Verify `package.json` is present.
+3. Run the desired test suite.
+4. Confirm the test runner starts successfully.
+
+Example:
+
+```powershell
+cd hushh-webapp
+dir package.json
+npm test -- financial-sources
+```

--- a/docs/webapp-test-troubleshooting.md
+++ b/docs/webapp-test-troubleshooting.md
@@ -1,19 +1,10 @@
 # Webapp Test Troubleshooting
 
-#Repository root
-+-- hushh-webapp
-    +-- package.json
-    +-- src
-    +-- __tests__
-```
+## Visual Context
 
-Run webapp test commands from `hushh-webapp`, not from the repository root.
+This guide helps troubleshoot common issues when running webapp tests locally, especially when `npm test` is run from the wrong directory.
 
-## `npm test` fails with `ENOENT package.json`
-
-If `npm test` shows an error like:
-
-```text
+## `npm test` fails with `ENOENT package.json````text
 Could not read package.json
 ENOENT: no such file or directory
 ```

--- a/docs/webapp-test-troubleshooting.md
+++ b/docs/webapp-test-troubleshooting.md
@@ -1,13 +1,10 @@
 # Webapp Test Troubleshooting
 
-## Visual Map
-
-```text
-Repository root
-└── hushh-webapp
-    ├── package.json
-    ├── src
-    └── __tests__
+#Repository root
++-- hushh-webapp
+    +-- package.json
+    +-- src
+    +-- __tests__
 ```
 
 Run webapp test commands from `hushh-webapp`, not from the repository root.

--- a/docs/webapp-test-troubleshooting.md
+++ b/docs/webapp-test-troubleshooting.md
@@ -1,0 +1,74 @@
+\# Webapp Test Troubleshooting
+
+
+
+\## `npm test` fails with `ENOENT package.json`
+
+
+
+If `npm test` shows an error like:
+
+
+
+```text
+
+Could not read package.json
+
+ENOENT: no such file or directory
+
+```
+
+
+
+you are likely running the command from the repository root instead of the webapp package directory.
+
+
+
+Run webapp tests from:
+
+
+
+```powershell
+
+cd hushh-webapp
+
+npm test -- <test-name>
+
+```
+
+
+
+Example:
+
+
+
+```powershell
+
+cd hushh-webapp
+
+npm test -- financial-sources
+
+```
+
+
+
+\## Quick check
+
+
+
+Before running webapp tests, confirm `package.json` exists:
+
+
+
+```powershell
+
+dir package.json
+
+```
+
+
+
+If the file is missing, move into the webapp folder first.
+
+
+

--- a/hushh-webapp/__tests__/utils/financial-sources.test.ts
+++ b/hushh-webapp/__tests__/utils/financial-sources.test.ts
@@ -188,4 +188,15 @@ describe("financial statement snapshots", () => {
       })
     ).toBe("plaid");
   });
+  it("returns no statement options when snapshot list is empty", () => {
+  expect(
+    getStatementSnapshotOptions({
+      sources: {
+        statement: {
+          snapshots: [],
+        },
+      },
+    })
+  ).toEqual([]);
+});
 });


### PR DESCRIPTION
## Summary

Add test coverage for financial sources when the statement snapshot list is empty.

## Changes Made

- Added a test for empty statement snapshot collections
- Verified snapshot option generation returns an empty array
- Extended defensive coverage for financial source utilities

## Test

npm test -- financial-sources