### PR TITLE
fix(world-model): suppress exception detail in store-domain response

### DIFF
--- a/hushh-webapp/app/api/world-model/store-domain/route.ts
+++ b/hushh-webapp/app/api/world-model/store-domain/route.ts
@@ -82,7 +82,7 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     console.error("[StoreDomain] Error:", error);
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Internal server error" },
+      { error: "Internal server error" },
       { status: 500 }
     );
   }


### PR DESCRIPTION
## What

Removes exception details from the error response returned by the world model store-domain API route.

## Why

Returning raw exception messages can expose internal implementation details to API consumers.

A generic error response reduces information disclosure while preserving existing error handling behavior and HTTP status codes.

## Changes

* Replaced exception-derived response text with a generic `"Internal server error"` message.

## Validation

* npm run lint
* npm run typecheck
