### PR TITLE
fix(consent-inbox-dropdown): hide decorative loading spinner

### DIFF
--- a/hushh-webapp/components/consent/consent-inbox-dropdown.tsx
+++ b/hushh-webapp/components/consent/consent-inbox-dropdown.tsx
@@ -247,7 +247,10 @@ export function ConsentInboxDropdown({
               </p>
             </div>
             {summaryResource.loading || summaryResource.refreshing ? (
-              <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" />
+              <Loader2
+                aria-hidden="true"
+                className="h-4 w-4 shrink-0 animate-spin text-muted-foreground"
+              />
             ) : null}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Add `aria-hidden="true"` to the existing Consent Inbox dropdown header loading spinner.
- Preserve the visible spinner, loading/refreshing condition, dropdown layout, and consent request behavior.

## Exact Surface
- Changed file: `hushh-webapp/components/consent/consent-inbox-dropdown.tsx`
- Changed component: `ConsentInboxDropdown`
- Changed node: the `Loader2` rendered only when `summaryResource.loading || summaryResource.refreshing` is true
- Rendered surface: Consent Inbox dropdown header loading/refreshing indicator
- Canonical caller proof: `ConsentInboxDropdown` is the exported dropdown component for this inbox surface

## Narrowness Proof
- One frontend file changed.
- One JSX attribute added to one existing spinner.
- Formatting changed only because the same `Loader2` element was split across lines.
- No loading condition, request list, timestamp row, hook, helper, utility, provider, route handler, backend, cache, governance, PKM, vault, or generated file changed.
- No shared spinner, icon, button, dropdown, or consent workflow component changed.

## Existing Capability Overlap Check
- This PR is separate from PR 2561: it touches the header loading spinner around line 247, not the request-row timestamp/fallback span around line 286.
- The change affects accessibility tree exposure only; it does not alter visible loading behavior or request data.

## Validation
- `npm.cmd run lint`
- `npm.cmd run build`
- GitHub checks passing: DCO, PR Base Policy, Web (Next.js), Integration, CI Status Gate
