### PR TITLE
fix(iam): suppress proxy exception detail in error response

### DIFF
--- a/hushh-webapp/app/api/iam/[...path]/route.ts
+++ b/hushh-webapp/app/api/iam/[...path]/route.ts
@@ -140,7 +140,7 @@ async function proxyRequest(
       requestId,
       {
         error: "Failed to proxy IAM request",
-        detail: error instanceof Error ? error.message : "unknown_error",
+        detail: "unknown_error",
       },
       { status: 504 }
     );


### PR DESCRIPTION
## What

Removes exception-derived detail text from IAM proxy error responses.

## Why

Returning raw exception messages can expose internal implementation details to API consumers.

Using a generic error detail preserves the response contract while reducing information disclosure.

## Changes

* Replaced exception-derived `detail` value with a generic `"unknown_error"` response.

## Validation

* npm run lint
* npm run typecheck
