### PR TITLE
fix(profile-settings): hide decorative profile icon

### DIFF
--- a/hushh-webapp/app/profile/page.tsx
+++ b/hushh-webapp/app/profile/page.tsx
@@ -4110,7 +4110,7 @@ function ProfilePageContent() {
                   .slice(0, 2)
                   .toUpperCase()
               ) : (
-                <Icon icon={User} size={48} />
+                <Icon icon={User} size={48} aria-hidden="true" />
               )}
             </AvatarFallback>
           </Avatar>


### PR DESCRIPTION
## Description

Hides a decorative profile icon in the Profile Settings view from assistive technologies when it does not convey meaningful information or provide an interactive function.

## Why

Decorative icons are intended to support visual presentation and should not add noise to the accessibility experience. When exposed to screen readers, non-informative icons can create redundant announcements and make navigation less efficient for assistive technology users.

This change improves accessibility by ensuring only meaningful content is included in the accessibility tree.

## What changed

- Marked the decorative profile icon as hidden from assistive technologies
- Prevented non-informative icon announcements in Profile Settings
- Preserved existing visual appearance and layout
- Maintained existing profile settings interactions and workflows

## Impact

- No API changes
- No schema changes
- No backend behavior changes
- Improves accessibility and screen reader experience

## Testing

- Ran `npm run lint`
- Ran `npm run build`
- Verified the decorative profile icon is excluded from the accessibility tree
- Verified profile settings functionality remains unchanged
- Verified visual presentation and layout remain unchanged

## Notes

This PR intentionally focuses on the existing Profile Settings component only and does not modify profile management logic, authentication flows, consent contracts, PKM behavior, backend services, or application architecture.

### Changed Surface

- Single existing Profile Settings component
- No shared components modified
- No hooks, utilities, providers, or abstractions changed
- No new files created
- Accessibility-only improvement with low regression risk