### PR TITLE
test(financial): cover empty snapshot list

### DIFF
--- a/hushh-webapp/__tests__/utils/financial-sources.test.ts
+++ b/hushh-webapp/__tests__/utils/financial-sources.test.ts
@@ -188,4 +188,15 @@ describe("financial statement snapshots", () => {
       })
     ).toBe("plaid");
   });
+  it("returns no statement options when snapshot list is empty", () => {
+  expect(
+    getStatementSnapshotOptions({
+      sources: {
+        statement: {
+          snapshots: [],
+        },
+      },
+    })
+  ).toEqual([]);
+});
 });


### PR DESCRIPTION
## Summary

Add test coverage for financial sources when the statement snapshot list is empty.

## Changes Made

* Added a test for empty statement snapshot collections
* Verified snapshot option generation returns an empty array
* Improved defensive coverage for financial source utilities

## Test

```bash
npm test -- financial-sources
```
