### PR TITLE
test(financial): cover missing statement source

### DIFF
--- a/hushh-webapp/__tests__/utils/financial-sources.test.ts
+++ b/hushh-webapp/__tests__/utils/financial-sources.test.ts
@@ -188,4 +188,11 @@ describe("financial statement snapshots", () => {
       })
     ).toBe("plaid");
   });
+it("returns no statement options when statement source is missing", () => {
+  expect(
+    getStatementSnapshotOptions({
+      sources: {},
+    }),
+  ).toEqual([]);
+});
 });


### PR DESCRIPTION
## Summary

Add test coverage for financial sources when the statement source object is missing.

## Changes Made

* Added a test for missing statement source data
* Verified snapshot option generation safely returns an empty array
* Extended defensive coverage for financial source utilities

## Test

npm test -- financial-sources
