### PR TITLE
fix(consent-inbox-dropdown): align request timestamps across rows

### DIFF
--- a/hushh-webapp/components/consent/consent-inbox-dropdown.tsx
+++ b/hushh-webapp/components/consent/consent-inbox-dropdown.tsx
@@ -286,7 +286,7 @@ export function ConsentInboxDropdown({
                         {entrySummary(entry)}
                       </p>
                     </div>
-                    <span className="shrink-0 text-[11px] text-muted-foreground">
+                    <span className="min-w-[4.75rem] shrink-0 text-right text-[11px] tabular-nums text-muted-foreground">
                       {formatRelative(entry.expires_at) ||
                         entry.counterpart_email ||
                         entry.counterpart_secondary_label ||


### PR DESCRIPTION
## Summary
- Add a fixed minimum width, right alignment, and tabular numerals to the existing Consent Inbox dropdown row timestamp/fallback text span.
- Preserve the displayed timestamp/fallback text and row behavior.

## Exact Surface
- Changed file: `hushh-webapp/components/consent/consent-inbox-dropdown.tsx`
- Changed component: `ConsentInboxDropdown`
- Changed node: the row trailing `<span>` that renders `formatRelative(entry.expires_at) || entry.counterpart_email || entry.counterpart_secondary_label || "Request"`
- Rendered surface: Consent Inbox dropdown request list rows
- Canonical caller proof: `ConsentInboxDropdown` is the exported dropdown component for this request-list surface

## Narrowness Proof
- One frontend file changed.
- One class-only change on one existing trailing row text span.
- No timestamp value, fallback order, date formatter, row click behavior, loading state, hook, helper, utility, provider, route handler, backend, cache, governance, PKM, vault, or generated file changed.
- No shared list, typography, dropdown, or consent workflow component changed.

## Existing Capability Overlap Check
- This PR is separate from PR 2549: it touches the request-row trailing timestamp/fallback span around line 286, not the header loading spinner around line 247.
- The change affects alignment only; it does not hide icons, alter loading UI, or modify consent request state.

## Validation
- `npm.cmd run lint`
- `npm.cmd run build`
- GitHub checks passing: DCO, PR Base Policy, Web (Next.js), Integration, CI Status Gate
