### PR TITLE
fix(vault): remove backend detail from status error response

### DIFF
--- a/hushh-webapp/app/api/vault/status/route.ts
+++ b/hushh-webapp/app/api/vault/status/route.ts
@@ -63,7 +63,7 @@ async function proxyVaultStatus(params: {
     console.error("[API] Backend error:", response.status, errorText);
     return {
       status: response.status,
-      payload: { error: "Backend error", details: errorText },
+      payload: { error: "Backend error" },
     };
   }
 


### PR DESCRIPTION
## Summary

Remove backend error details from the vault status API response.

## What Changed

* Removed `details: errorText` from the error payload returned by `proxyVaultStatus()`.
* Preserved the existing generic error response (`{ error: "Backend error" }`).
* Kept backend logging unchanged for debugging and observability.

## Why

Returning raw upstream error text can expose internal implementation details, backend responses, or sensitive diagnostic information to clients. This change hardens the API surface by ensuring consumers receive a stable generic error response while detailed information remains available in server logs.

## Testing

* `npm run lint`
* `npm run typecheck`

## Risk

Low. The change only affects the error response payload returned when the upstream vault status request fails.
