### PR TITLE
fix(investors): remove backend detail from investor proxy response

### DIFF
--- a/hushh-webapp/app/api/investors/[id]/route.ts
+++ b/hushh-webapp/app/api/investors/[id]/route.ts
@@ -31,7 +31,7 @@ export async function GET(
         return NextResponse.json(errorJson, { status: response.status });
       } catch (_e) {
         return NextResponse.json(
-          { error: "Backend error", details: errorText },
+          { error: "Backend error" },
           { status: response.status }
         );
       }


### PR DESCRIPTION
## Summary

Remove backend error details from the investor proxy error response.

## What Changed

* Removed `details: errorText` from the fallback error response returned when the upstream investors service returns a non-JSON error payload.
* Preserved the existing generic error response (`{ error: "Backend error" }`).
* Kept backend logging unchanged for troubleshooting and observability.

## Why

Returning raw upstream error text to clients can expose internal implementation details, backend responses, or diagnostic information that is not intended for end users. This change hardens the proxy layer by ensuring only a generic error response is returned while detailed information remains available in server logs.

## Testing

* `npm run lint`
* `npm run typecheck`

## Risk

Low. The change only affects the error payload returned when the upstream investors service responds with a non-JSON error body.
