### PR TITLE
fix(vault): remove backend detail from primary set error response

### DIFF
--- a/hushh-webapp/app/api/vault/primary/set/route.ts
+++ b/hushh-webapp/app/api/vault/primary/set/route.ts
@@ -52,9 +52,8 @@ export async function POST(request: NextRequest) {
     });
 
     if (!response.ok) {
-      const errorText = await response.text();
       return NextResponse.json(
-        { error: errorText || "Backend error" },
+        { error: "Backend error" },
         { status: response.status }
       );
     }


### PR DESCRIPTION
## Summary

Remove backend error details from the vault primary set API response.

## What Changed

* Removed the upstream error text from the error response returned by the vault primary set endpoint.
* Replaced the response with a generic `Backend error` message.
* Preserved the existing HTTP status code behavior.

## Why

Returning raw backend error text to clients can expose internal implementation details and diagnostic information. This change hardens the API surface by ensuring clients receive a consistent generic error response while avoiding unnecessary information disclosure.

## Testing

* `npm run lint`
* `npm run typecheck`

## Risk

Low. The change only affects the error payload returned when the upstream vault primary set request fails.
