### PR TITLE
fix(vault): remove backend detail from setup error response

### DIFF
--- a/hushh-webapp/app/api/vault/setup/route.ts
+++ b/hushh-webapp/app/api/vault/setup/route.ts
@@ -111,13 +111,12 @@ export async function POST(request: NextRequest) {
       }),
     });
 
-    if (!response.ok) {
-      const errorText = await response.text();
-      return NextResponse.json(
-        { error: errorText || "Backend error" },
-        { status: response.status },
-      );
-    }
+if (!response.ok) {
+  return NextResponse.json(
+    { error: "Backend error" },
+    { status: response.status },
+  );
+}
 
     const result = await response.json();
     logSecurityEvent("VAULT_SETUP_SUCCESS", { userId, primaryMethod });


### PR DESCRIPTION
## Summary

Remove backend error details from the vault setup API response.

## What Changed

* Removed the upstream error text from the error response returned by the vault setup endpoint.
* Replaced the response with a generic `Backend error` message.
* Preserved the existing HTTP status code behavior.

## Why

Returning raw backend error text to clients can expose internal implementation details and diagnostic information. This change hardens the API surface by ensuring clients receive a generic error response while preventing unnecessary information disclosure.

## Testing

* `npm run lint`
* `npm run typecheck`

## Risk

Low. The change only affects the error payload returned when the upstream vault setup request fails.
