### PR TITLE
fix(consent-inbox-dropdown): add aria-haspopup and aria-expanded to trigger button

### DIFF
--- a/hushh-webapp/components/consent/consent-inbox-dropdown.tsx
+++ b/hushh-webapp/components/consent/consent-inbox-dropdown.tsx
@@ -222,6 +222,8 @@ export function ConsentInboxDropdown({
             type="button"
             className={triggerClassName}
             aria-label="Open consent inbox"
+            aria-haspopup="menu"
+            aria-expanded={open}
           >
             <Shield className="h-5 w-5" />
             {pendingCount > 0 ? (


### PR DESCRIPTION
## Summary

Adds `aria-haspopup="menu"` and `aria-expanded={open}` to the ConsentInboxDropdown trigger button.

## Why

The trigger already has an accessible label but does not expose its popup relationship or expanded state to assistive technologies.

Adding these attributes completes the standard menu-button accessibility contract and reflects the existing dropdown state without introducing new logic.

## Changes

- Added `aria-haspopup="menu"`
- Added `aria-expanded={open}`

## Risk

- Single file change
- No visual changes
- No behavior changes
- Uses existing `open` state already controlling `DropdownMenu`
- Additive only