### PR TITLE
fix(vault): remove backend detail from wrapper upsert error response

### DIFF
--- a/hushh-webapp/app/api/vault/wrapper/upsert/route.ts
+++ b/hushh-webapp/app/api/vault/wrapper/upsert/route.ts
@@ -90,9 +90,8 @@ export async function POST(request: NextRequest) {
     });
 
     if (!response.ok) {
-      const errorText = await response.text();
       return NextResponse.json(
-        { error: errorText || "Backend error" },
+        { error: "Backend error" },
         { status: response.status }
       );
     }


### PR DESCRIPTION
## Summary

Remove backend error details from the vault wrapper upsert API response.

## What Changed

* Removed upstream error text from the error response returned by the vault wrapper upsert endpoint.
* Replaced the response with a generic `Backend error` message.
* Preserved the existing HTTP status code behavior.

## Why

Returning raw backend error text can expose internal implementation details and diagnostic information to clients. This change hardens the API surface by ensuring only a generic error response is returned while detailed information remains available in backend logs.

## Testing

* `npm run lint`
* `npm run typecheck`

## Risk

Low. The change only affects the error payload returned when the upstream vault wrapper upsert request fails.
