### PR TITLE
fix(auth-legal-dialog): add contextual aria-label to external document link

### DIFF
--- a/hushh-webapp/components/onboarding/AuthLegalDialog.tsx
+++ b/hushh-webapp/components/onboarding/AuthLegalDialog.tsx
@@ -52,6 +52,7 @@ export function AuthLegalDialog({ docType, onOpenChange }: AuthLegalDialogProps)
                   href={content.url}
                   target="_blank"
                   rel="noopener noreferrer"
+                  aria-label={`Open ${content.title} in browser`}
                   className="inline-flex items-center gap-1 rounded-full border border-border px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
                 >
                   Open in browser


### PR DESCRIPTION
## Summary

Adds a contextual `aria-label` to the external document link in `AuthLegalDialog` so assistive technologies can distinguish between legal document links.

## Problem

The external link currently uses the generic visible text **"Open in browser"** for all legal documents. While the dialog title provides visual context, screen readers navigating by links may encounter multiple links with the same accessible name and no indication of which document will open.

## Change

* Added `aria-label={\`Open ${content.title} in browser`}` to the external document link.
* Uses the existing `content.title` value already available in component scope.
* Preserves all existing behavior, styling, and navigation.

## Accessibility Impact

Provides unique and descriptive link names such as:

* "Open Privacy Policy in browser"
* "Open Terms in browser"

This improves link identification for screen-reader users and aligns with established accessible naming patterns used elsewhere in onboarding surfaces.

## Risk

* Single-file change
* No visual changes
* No behavior changes
* No business logic changes
* Additive only
