### PR TITLE
fix(drawer): add showCloseButton parity with Dialog and Sheet

### DIFF
--- a/hushh-webapp/components/ui/drawer.tsx
+++ b/hushh-webapp/components/ui/drawer.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import * as React from "react"
+import { XIcon } from "lucide-react"
 import { Drawer as DrawerPrimitive } from "vaul"
 
 import { cn } from "@/lib/utils"
@@ -48,8 +49,11 @@ function DrawerOverlay({
 function DrawerContent({
   className,
   children,
+  showCloseButton = false,
   ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+}: React.ComponentProps<typeof DrawerPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
   return (
     <DrawerPortal data-slot="drawer-portal">
       <div
@@ -70,7 +74,18 @@ function DrawerContent({
         {...props}
       >
         <div className="bg-muted mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
-        {children}
+
+      {children}
+
+      {showCloseButton && (
+        <DrawerPrimitive.Close
+          data-slot="drawer-close"
+          className="ring-offset-background focus:ring-ring absolute top-4 right-4 z-30 rounded-full border border-transparent bg-[color:var(--app-card-surface-compact)] p-2 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none"
+        >
+          <XIcon className="size-4" />
+          <span className="sr-only">Close</span>
+        </DrawerPrimitive.Close>
+      )}
       </DrawerPrimitive.Content>
     </DrawerPortal>
   )


### PR DESCRIPTION
## Summary

Adds an optional `showCloseButton` prop to `DrawerContent`, matching the API already supported by `DialogContent` and `SheetContent`.

## Problem

`DialogContent` and `SheetContent` both expose a `showCloseButton` prop, while `DrawerContent` does not. This creates an API parity gap between the application's overlay primitives and prevents consumers from using a consistent prop contract when swapping between Dialog, Sheet, and Drawer surfaces.

## Change

* Added `showCloseButton?: boolean` to `DrawerContent`
* Added a conditional `DrawerPrimitive.Close` button when the prop is enabled
* Imported `XIcon` from `lucide-react`

The prop defaults to `false` to preserve all existing visual output and behavior.

## Why This Is Safe

* No visual changes for existing call sites
* No behavior changes unless the prop is explicitly enabled
* No architecture changes
* Follows the existing close-button implementation pattern already used in `SheetContent`

## Risk

* Single shared primitive file
* Additive-only API extension
* Backward compatible
* Existing drawers render exactly as before unless `showCloseButton` is provided
