### PR TITLE
fix(page-sections): add SectionHeader id passthrough

### DIFF
--- a/hushh-webapp/components/app-ui/page-sections.tsx
+++ b/hushh-webapp/components/app-ui/page-sections.tsx
@@ -247,6 +247,7 @@ export function SectionHeader({
   accent = "default",
   className,
   testId = "section-header",
+  id,
 }: {
   eyebrow?: string;
   title: ReactNode;
@@ -257,10 +258,15 @@ export function SectionHeader({
   accent?: SectionAccent;
   className?: string;
   testId?: string;
+  id?: string;
 }) {
   const styles = ACCENT_STYLES[accent];
   return (
-    <div className={cn("space-y-[var(--section-header-stack-gap)]", className)} data-testid={testId}>
+    <div
+      id={id}
+      className={cn("space-y-[var(--section-header-stack-gap)]", className)}
+      data-testid={testId}
+    >
       <div className="flex items-stretch gap-3">
         {icon || leading ? (
           <HeaderLeading


### PR DESCRIPTION
## Summary

Adds an optional `id` prop to `SectionHeader` and forwards it to the component's root element.

## Why

`SectionHeader` already forwards `testId` to its root container but does not expose a way to set a standard DOM `id`.

Adding an optional `id` prop enables:

* In-page anchor navigation (`#section-id`)
* `aria-labelledby` and related accessibility relationships
* Scroll-to-section behavior without requiring wrapper elements

## Changes

* Add `id?: string` to `SectionHeader` props
* Forward `id` to the root `<div>`

## Risk

* Additive only
* No visual changes
* No behavioral changes
* No impact on existing callers
* Undefined `id` remains a no-op
