### PR TITLE
fix(manage-portfolio): add pagination accessibility labels

### DIFF
--- a/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
+++ b/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
@@ -688,9 +688,10 @@ export function ManagePortfolioView() {
                     <Pagination>
                       <PaginationContent>
                         <PaginationItem>
-                          <PaginationPrevious 
+                          <PaginationPrevious
                             onClick={() => setCurrentPage(prev => Math.max(1, prev - 1))}
                             className={cn("cursor-pointer", currentPage === 1 && "pointer-events-none opacity-50")}
+                            aria-label="Previous page"
                           />
                         </PaginationItem>
                         
@@ -710,6 +711,7 @@ export function ManagePortfolioView() {
                           <PaginationNext 
                             onClick={() => setCurrentPage(prev => Math.min(Math.ceil(holdings.length / itemsPerPage), prev + 1))}
                             className={cn("cursor-pointer", currentPage === Math.ceil(holdings.length / itemsPerPage) && "pointer-events-none opacity-50")}
+                            aria-label="Next page"
                           />
                         </PaginationItem>
                       </PaginationContent>


### PR DESCRIPTION
## Summary

Adds accessible labels to the pagination controls in `ManagePortfolioView`.

## Why

The pagination controls currently rely on their visual presentation for context. Adding explicit labels improves accessibility and ensures assistive technologies can clearly identify the purpose of each control.

## Changes

* Add `aria-label="Previous page"` to `PaginationPrevious`
* Add `aria-label="Next page"` to `PaginationNext`

## Risk

* Single file change
* Two ARIA attributes only
* No visual changes
* No behavioral changes
* No pagination logic changes
