### PR TITLE
fix(vault): remove backend detail from wrapper delete error response

### DIFF
--- a/hushh-webapp/app/api/vault/wrapper/delete/route.ts
+++ b/hushh-webapp/app/api/vault/wrapper/delete/route.ts
@@ -84,10 +84,10 @@ export async function POST(request: NextRequest) {
     });
 
     if (!response.ok) {
-      const errorPayload = await response
-        .json()
-        .catch(async () => ({ error: await response.text().catch(() => "") }));
-      return NextResponse.json(errorPayload, { status: response.status });
+      return NextResponse.json(
+        { error: "Backend error" },
+        { status: response.status }
+      );
     }
 
     const result = await response.json();


### PR DESCRIPTION
## Summary

Remove backend error details from the vault wrapper delete API response.

## What Changed

* Removed propagation of upstream error payloads from the vault wrapper delete endpoint.
* Replaced the response with a generic `Backend error` message.
* Preserved existing HTTP status code behavior.

## Why

Returning upstream error payloads can expose internal implementation details and diagnostic information to clients. This change hardens the API surface by ensuring only a generic error response is returned while keeping detailed diagnostics on the server side.

## Testing

* `npm run lint`
* `npm run typecheck`

## Risk

Low. The change only affects the error payload returned when the upstream vault wrapper delete request fails.
