### PR TITLE
fix(vault-unlock-dialog): add stable test identifier

### DIFF
--- a/hushh-webapp/components/vault/vault-unlock-dialog.tsx
+++ b/hushh-webapp/components/vault/vault-unlock-dialog.tsx
@@ -42,6 +42,7 @@ export function VaultUnlockDialog({
       <DialogContent
         showCloseButton={false}
         className="left-1/2 top-[calc(var(--top-shell-reserved-height,0px)+0.75rem)] z-[520] w-[calc(100%-1rem)] max-h-[calc(100svh-1rem)] -translate-x-1/2 translate-y-0 border-none bg-transparent p-0 shadow-none sm:top-[50%] sm:max-w-sm sm:-translate-y-1/2"
+        data-testid="vault-unlock-dialog"
         onEscapeKeyDown={(event) => {
           if (!dismissible) event.preventDefault();
         }}


### PR DESCRIPTION
## Summary

Adds a stable `data-testid` to `VaultUnlockDialog` for reliable test targeting.

## Changes

- Added `data-testid="vault-unlock-dialog"` to `DialogContent`

## Why

Tests currently rely on structural selectors that are more brittle than explicit test hooks. Adding a stable identifier improves reliability without changing behavior or component structure.

## Risk

- Additive only
- No visual changes
- No behavior changes
- No accessibility changes
- No architecture changes
