### PR TITLE
fix(vault): remove backend detail from status response

### DIFF
--- a/hushh-webapp/app/api/vault/status/route.ts
+++ b/hushh-webapp/app/api/vault/status/route.ts
@@ -63,7 +63,7 @@ async function proxyVaultStatus(params: {
     console.error("[API] Backend error:", response.status, errorText);
     return {
       status: response.status,
-      payload: { error: "Backend error", details: errorText },
+      payload: { error: "Backend error" },
     };
   }
 


### PR DESCRIPTION
## Summary

Remove backend error details from the vault status API response.

## What Changed

* Removed backend error details from the response payload returned by the vault status endpoint.
* Preserved server-side logging of the backend error text for debugging.
* Kept the existing HTTP status code behavior unchanged.

## Why

Returning backend error details to clients can expose internal implementation details and diagnostic information. This change hardens the API surface by returning a generic error response while retaining detailed logs on the server.

## Testing

* `npm run lint`
* `npm run typecheck`

## Risk

Low. The change only affects the error payload returned when the upstream vault status request fails.
