### PR TITLE
fix(manage-portfolio): add test ids for save workflow

### DIFF
--- a/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
+++ b/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
@@ -580,7 +580,7 @@ export function ManagePortfolioView() {
             </Button>
           </div>
 
-          <div className="space-y-3">
+          <div className="space-y-3" data-testid="holdings-list">
             {holdings.length > 0 ? (
               <>
                 {holdings
@@ -744,6 +744,7 @@ export function ManagePortfolioView() {
               variant="morphy"
               effect="fill"
               className="w-full h-12 text-sm font-black rounded-xl border-none shadow-xl"
+              data-testid="portfolio-save-btn"
               icon={{ 
                 icon: isSaving ? SpinningLoader : Save,
                 gradient: false 


### PR DESCRIPTION
## Summary

Adds stable `data-testid` attributes to the portfolio save workflow for reliable automation and E2E targeting.

## Changes

* Add `data-testid="holdings-list"` to the holdings container
* Add `data-testid="portfolio-save-btn"` to the save button

## Why

The portfolio save flow currently lacks stable selectors for automated testing. Tests must rely on text content or styling selectors, which are more fragile.

These identifiers provide stable hooks for:

* Verifying holdings have loaded
* Triggering the save action
* Validating save workflow behavior

## Risk

* Additive only
* No logic changes
* No visual changes
* No UX changes
* No behavioral changes

## Files Changed

* `hushh-webapp/components/kai/views/manage-portfolio-view.tsx`
