### PR TITLE
fix(page-header): complete data-slot contract

### DIFF
--- a/hushh-webapp/components/app-ui/page-sections.tsx
+++ b/hushh-webapp/components/app-ui/page-sections.tsx
@@ -194,6 +194,7 @@ export function PageHeader({
                     "text-xs font-semibold uppercase tracking-[0.24em]",
                     styles.eyebrow
                   )}
+                  data-slot="page-header-eyebrow"
                 >
                   {eyebrow}
                 </p>


### PR DESCRIPTION
## Summary

Adds the missing `data-slot="page-header-eyebrow"` attribute to `PageHeader`, completing the component's slot contract.

## Changes

* Add `data-slot="page-header-eyebrow"` to the eyebrow element within `PageHeader`

## Why

`PageHeader` already exposes slot identifiers for its primary regions:

* `page-header`
* `page-header-row`
* `page-header-description`
* `page-header-actions`

The eyebrow region was the only remaining area without a corresponding slot identifier. This change completes the existing contract without altering behavior or layout.

## Risk

* Additive only
* No logic changes
* No visual changes
* No UX changes
* No behavioral changes

## Files Changed

* `hushh-webapp/components/app-ui/page-sections.tsx`
