### PR TITLE
test(token): verify token signature truncation boundaries

### DIFF
--- a/consent-protocol/tests/test_token.py
+++ b/consent-protocol/tests/test_token.py
@@ -133,6 +133,19 @@ def test_signature_tampering():
     assert "Malformed token" in reason or "Invalid token prefix" in reason
 
 
+def test_truncated_token_signature_is_rejected():
+    token_obj = issue_token(USER_ID, AGENT_ID, VALID_SCOPE)
+    prefix, signed_part = token_obj.token.split(":", 1)
+    encoded, signature = signed_part.split(".", 1)
+
+    for truncated_signature in ("", signature[:1], signature[:-1]):
+        valid, reason, parsed = validate_token(f"{prefix}:{encoded}.{truncated_signature}")
+
+        assert valid is False
+        assert reason == "Invalid signature"
+        assert parsed is None
+
+
 def test_invalid_base64_token_is_rejected():
     malformed = "HCT:%%%%.signature"
 


### PR DESCRIPTION
## Description
Adds focused, test-only coverage for the canonical consent token validator. The test issues a real production HCT token, truncates only the signature segment, and verifies that `validate_token(...)` rejects each truncated signature with the existing invalid-signature response.

This is additive test coverage only. It does not add runtime helpers, change token validation logic, or introduce a parallel signature verifier.

## Canonical Attachment Plan
* **Target Package/Module:** `consent-protocol/hushh_mcp/consent/token.py`
* **Production Capabilities Exercised:** `issue_token(...)` and `validate_token(...)`
* **Execution Validation Track:** Consent protocol pytest coverage

## Impact Map (Required)
* **Routes touched:** None
* **Files changed:** `consent-protocol/tests/test_token.py`
* **Runtime code changed:** No

## Privacy & Consent
* **Does this change access user data?** No
* **Sensitive surface touched:** Yes; consent token validation test coverage only, with no runtime enforcement changes
* **Security review posture:** Human sensitive-surface review required before merge because this exercises consent/IAM token validation behavior
* **Error path, rollback, or safe-failure behavior proved:** Truncated token signatures return invalid token responses with no parsed token object

## Review-Ready Contract
* **Title, body, changed file, and test describe the same contract:** Yes
* **Concrete production attach point proved:** Yes; the test imports and exercises production `issue_token(...)` and `validate_token(...)`
* **No local mock-only contract:** Yes; the token is issued by production code and only the signature segment is mutated
* **Surface alignment:** The footprint is confined to the existing canonical token validation test file
* **Runtime impact:** None; one additive test file change only

## Testing
* `pytest consent-protocol/tests/test_token.py` -> 15 passed
* `cd consent-protocol && python -m pytest tests/test_granular_scopes.py -q` -> 21 passed
* `cd consent-protocol && python -m pytest tests/test_ria_iam_routes.py -q` -> 29 passed
* DCO signed commit included