### PR TITLE
fix(consent-sheet): improve test targeting hooks

### DIFF
--- a/hushh-webapp/components/consent/consent-sheet-controller.tsx
+++ b/hushh-webapp/components/consent/consent-sheet-controller.tsx
@@ -103,7 +103,9 @@ export function ConsentSheetProvider({ children }: { children: ReactNode }) {
 
   return (
     <ConsentSheetContext.Provider value={value}>
-      {children}
+      <div data-testid="consent-sheet-provider" style={{ display: "contents" }}>
+        {children}
+      </div>
     </ConsentSheetContext.Provider>
   );
 }


### PR DESCRIPTION
## Summary

Adds a stable `data-testid` hook to the consent sheet provider boundary for automation and E2E testing.

## Changes

* Add `data-testid="consent-sheet-provider"` around provider children
* Use `display: contents` to preserve the existing layout contract

## Why

The consent sheet provider currently renders its children directly, providing no stable DOM anchor for test automation.

Adding a dedicated test hook allows E2E tests to reliably target the provider boundary without coupling to URL parameters, routing state, or implementation details.

## Layout Safety

The wrapper uses `display: contents`, which preserves the existing rendering structure while exposing a DOM node for test targeting.

* No layout changes
* No styling changes
* No interaction changes
* No behavioral changes

## Risk

* Additive only
* No logic changes
* No state changes
* No routing changes
* No visual changes

## Files Changed

* `hushh-webapp/components/consent/consent-sheet-controller.tsx`
