### PR TITLE
test(consent): verify consent path omits empty bundleId

### DIFF
--- a/consent-protocol/tests/services/test_consent_request_links.py
+++ b/consent-protocol/tests/services/test_consent_request_links.py
@@ -62,6 +62,16 @@ class TestBuildConsentRequestPath:
         _, params = _parse_path(build_consent_request_path(bundle_id=None))
         assert "bundleId" not in params
 
+    def test_bundle_id_omitted_when_empty(self):
+        _, params = _parse_path(
+            build_consent_request_path(
+                request_id="req-bundle-boundary",
+                bundle_id="",
+            )
+        )
+        assert params["requestId"] == ["req-bundle-boundary"]
+        assert "bundleId" not in params
+
     def test_view_overrides_tab(self):
         _, params = _parse_path(build_consent_request_path(view="approved"))
         assert params["tab"] == ["approved"]


### PR DESCRIPTION
## Description
Adds focused, test-only coverage for the canonical consent request path builder. The new case passes an empty undle_id value into uild_consent_request_path(...) and verifies that the generated consent path preserves equestId while omitting undleId.

This is additive test coverage only. It does not add runtime helpers, change link-builder behavior, or introduce a parallel normalization function.

## Canonical Attachment Plan
* **Target Package/Module:** consent-protocol/hushh_mcp/services/consent_request_links.py
* **Production Capability Exercised:** uild_consent_request_path(...) empty undle_id query composition
* **Execution Validation Track:** Consent protocol pytest coverage

## Impact Map (Required)
* **Routes touched:** None (test-only addition)
* **Files changed:** consent-protocol/tests/services/test_consent_request_links.py
* **Runtime code changed:** No

## Privacy & Consent
* **Does this change access user data?** No
* **Sensitive surface touched:** None; test-only coverage for consent deep-link query composition
* **Error path, rollback, or safe-failure behavior proved:** Yes; empty bundleId input is omitted from the generated consent request path

## Review-Ready Contract
* **Title, body, changed file, and test describe the same contract:** Yes
* **Concrete production attach point proved:** Yes; the test imports and exercises production uild_consent_request_path(...)
* **Existing capability overlap narrowed:** Yes; this covers the empty-string path-builder boundary only and avoids the full URL boundary owned by PR #2593
* **No local mock-only contract:** Yes; no mock normalizer or helper is introduced
* **Surface alignment:** Validated; the footprint is confined to the existing canonical consent request link test suite where bundleId path behavior already lives
* **Reviewer risk controls:** One tracked file changed, 10 additive lines, no runtime behavior change, no new configuration files, no mocks/services/helpers

## Testing
* pytest consent-protocol/tests/services/test_consent_request_links.py -> 44 passed
* **Commits are signed off:** Yes