### PR TITLE
test(consent): omit whitespace bundle metadata in request URLs

### DIFF
--- a/consent-protocol/tests/services/test_consent_request_links.py
+++ b/consent-protocol/tests/services/test_consent_request_links.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
+from hushh_mcp.services.consent_db import ConsentDBService
 from hushh_mcp.services.consent_request_links import (
     build_connection_request_path,
     build_connection_request_url,
@@ -158,6 +159,22 @@ class TestBuildConsentRequestUrl:
     def test_url_carries_bundle_id(self):
         url = self._build(bundle_id="b1")
         assert "bundleId=b1" in url
+
+    def test_consent_db_request_url_omits_whitespace_bundle_metadata(self):
+        with patch(
+            "hushh_mcp.services.consent_request_links.frontend_origin",
+            return_value=_ORIGIN,
+        ):
+            url = ConsentDBService._request_url(
+                request_id="req-bundle-fallback",
+                metadata={"bundle_id": "   "},
+            )
+
+        assert url is not None
+        params = parse_qs(urlparse(url).query)
+
+        assert params["requestId"] == ["req-bundle-fallback"]
+        assert "bundleId" not in params
 
     def test_canonical_caller_path_consent_db(self):
         """Exercises the same call pattern used by consent_db.py.


### PR DESCRIPTION
## Description
Adds focused, test-only coverage for the canonical consent request URL caller path. The test exercises `ConsentDBService._request_url(...)` with whitespace-only `metadata[bundle_id]` and verifies the generated consent request URL preserves `requestId` while omitting `bundleId`.

This is additive test coverage only. It does not add runtime helpers, change URL-builder behavior, or introduce a parallel normalization function.

## Canonical Attachment Plan
* **Target Package/Module:** `consent-protocol/hushh_mcp/services/consent_db.py`
* **Production Caller Exercised:** `ConsentDBService._request_url(...)`
* **Downstream Helper Observed:** `build_consent_request_url(...)` from `consent-protocol/hushh_mcp/services/consent_request_links.py`
* **Execution Validation Track:** Consent protocol pytest coverage

## Impact Map (Required)
* **Routes touched:** None
* **Files changed:** `consent-protocol/tests/services/test_consent_request_links.py`
* **Runtime code changed:** No

## Privacy & Consent
* **Does this change access user data?** No
* **Sensitive surface touched:** Consent request URL metadata normalization test coverage only; no runtime enforcement change
* **Error path, rollback, or safe-failure behavior proved:** Whitespace-only bundle metadata is treated as absent before request URL generation

## Review-Ready Contract
* **Title, body, changed file, and test describe the same contract:** Yes
* **Concrete production attach point proved:** Yes; the test imports and exercises `ConsentDBService._request_url(...)`
* **Existing capability overlap narrowed:** Yes; this covers consent DB metadata normalization, not another direct `bundle_id=None` or empty URL-builder call
* **No local mock-only contract:** Yes; only `frontend_origin()` is patched to keep URL assertions hermetic
* **Surface alignment:** The footprint stays in the existing consent request link suite that already documents the `consent_db.py` caller path

## Testing
* `pytest consent-protocol/tests/services/test_consent_request_links.py` -> 44 passed
* DCO signed commit included