### PR TITLE
fix(kai-optimize): prevent sector chart legend text from overflowing

### DIFF
--- a/hushh-webapp/app/kai/optimize/page.tsx
+++ b/hushh-webapp/app/kai/optimize/page.tsx
@@ -986,11 +986,18 @@ export default function PortfolioHealthPage() {
                       <Legend 
                         verticalAlign="top" 
                         align="right" 
+                        formatter={(value) => (
+                          <span className="inline-block max-w-[7rem] truncate align-middle">
+                            {value}
+                          </span>
+                        )}
                         wrapperStyle={{
                           fontSize: "10px",
                           fontWeight: "bold",
                           textTransform: "uppercase",
                           letterSpacing: "0.1em",
+                          maxWidth: "100%",
+                          overflow: "hidden",
                           paddingBottom: "20px",
                           color: "var(--muted-foreground)",
                         }} 


### PR DESCRIPTION
## Summary
- Constrain the existing Recharts `Legend` labels for the Kai Optimize current-vs-optimized allocation chart.
- Preserve chart data, bars, tooltip behavior, legend entries, and optimizer logic.

## Exact Surface
- Changed file: `hushh-webapp/app/kai/optimize/page.tsx`
- Changed route/page: `/kai/optimize`
- Changed component scope: `PortfolioHealthPage`
- Changed node: the existing Recharts `<Legend>` immediately above the `Current` and `Optimized` `<Bar>` elements
- Rendered surface: Kai Optimize current-vs-optimized allocation chart legend

## Narrowness Proof
- One frontend page file changed.
- The diff only adds a `Legend` formatter for legend label text and two wrapper containment styles.
- No chart data, optimizer result processing, bars, axes, tooltip formatter, API calls, hook, helper, utility, provider, route handler, backend, cache, governance, PKM, vault, consent, or generated file changed.
- No shared chart or legend component changed.

## Existing Capability Overlap Check
- This PR touches only the Kai Optimize allocation chart legend in `app/kai/optimize/page.tsx`.
- It does not touch Kai Market, Kai Streaming Progress, Kai Decision Card, or any shared `ChartLegendContent`.
- The formatter only wraps the displayed legend value; it does not alter the underlying legend payload.

## Validation
- `npm.cmd run lint`
- `npm.cmd run build`
- GitHub checks passing: DCO, PR Base Policy, Web (Next.js), Integration, CI Status Gate
