### PR TITLE
test(timeouts): cover zero timeout value

### DIFF
--- a/hushh-webapp/__tests__/utils/request-timeouts.test.ts
+++ b/hushh-webapp/__tests__/utils/request-timeouts.test.ts
@@ -244,4 +244,7 @@ describe("resolveSlowRequestTimeoutMs — fringe-input boundary fallbacks", () =
     expect(Number.isFinite(result)).toBe(true);
     expect(Number.isInteger(result)).toBe(true);
   });
+it("handles a zero timeout value", () => {
+  expect(normalizeTimeout(0)).toBe(0);
+});
 });

--- a/hushh-webapp/__tests__/utils/request-timeouts.test.ts
+++ b/hushh-webapp/__tests__/utils/request-timeouts.test.ts
@@ -244,7 +244,11 @@ describe("resolveSlowRequestTimeoutMs — fringe-input boundary fallbacks", () =
     expect(Number.isFinite(result)).toBe(true);
     expect(Number.isInteger(result)).toBe(true);
   });
-it("handles a zero timeout value", () => {
-  expect(normalizeTimeout(0)).toBe(0);
+it("ignores a zero timeout override and uses the default timeout", () => {
+  process.env.NEXT_PUBLIC_APP_ENV = "uat";
+  delete process.env.APP_RUNTIME_PROFILE;
+  process.env.HUSHH_SLOW_REQUEST_TIMEOUT_MS = "0";
+
+  expect(resolveSlowRequestTimeoutMs(20_000)).toBe(20_000);
 });
 });


### PR DESCRIPTION
## Summary

Add test coverage for timeout normalization when a zero timeout value is provided.

## Changes Made

* Added a test for zero timeout input
* Verified timeout normalization handles boundary values correctly
* Improved defensive coverage for request timeout utilities

## Test

```bash
npm test -- request-timeouts
```
