### PR TITLE
test(config): cover production backend fallback

### DIFF
--- a/hushh-webapp/__tests__/lib/config.test.ts
+++ b/hushh-webapp/__tests__/lib/config.test.ts
@@ -63,4 +63,18 @@ describe("config", () => {
 
     expect(config.APP_FRONTEND_ORIGIN).toBe("http://localhost:3000");
   });
+
+  it("keeps production backend empty when runtime backend url is empty", async () => {
+    const { resolveAppEnvironment } = await import("@/lib/app-env");
+    const { resolveRuntimeBackendUrl } = await import(
+      "@/lib/runtime/settings"
+    );
+
+    vi.mocked(resolveAppEnvironment).mockReturnValue("production");
+    vi.mocked(resolveRuntimeBackendUrl).mockReturnValue("");
+
+    const config = await import("@/lib/config");
+
+    expect(config.BACKEND_URL).toBe("");
+  });
 });


### PR DESCRIPTION
## Summary

Add test coverage for configuration behavior when the runtime backend URL is empty in a production environment.

## Changes Made

* Added a production-mode configuration test
* Verified backend URL remains empty when no runtime backend URL is provided
* Extended coverage for environment-specific configuration behavior

## Test

```bash
npm test -- config
```
