### PR TITLE
promote(train->main): deploy-authority alignment + protected-surface hardening (#2599)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,29 +1,61 @@
-# CODEOWNERS - Automatic PR Review Assignment
+# CODEOWNERS - Automatic PR Review Assignment & Protected-Surface Gate
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Ownership is mapped to the @hushh-labs/allowed-maintainers-to-approve team
+# (the sanctioned maintainer cohort defined in config/ci-governance.json) rather
+# than to a single hardcoded user. This:
+#   1. removes the single-owner bus factor and review bottleneck, and
+#   2. keeps code-owner review in lockstep with the bypass cohort automatically
+#      as team membership changes (no file edit required when a maintainer is
+#      added or removed).
+#
+# For this file to BLOCK merges (not just request review), the branch protection
+# for `main` and `integration/pr-train` must have "Require review from Code
+# Owners" enabled. The team must retain at least write/maintain access to the
+# repo or GitHub silently ignores these team entries.
+#
+# Most-specific match wins: the protected-surface entries at the bottom override
+# the broader directory entries above them.
 
-# Global owner of record (fallback)
-* @kushaltrivedi5
+# ---------------------------------------------------------------------------
+# Global owner of record (fallback) -- any maintainer may satisfy review.
+# ---------------------------------------------------------------------------
+* @hushh-labs/allowed-maintainers-to-approve
 
 # Backend (Python/FastAPI) -- GIT SUBTREE: upstream at hushh-labs/consent-protocol
-/consent-protocol/ @kushaltrivedi5
+/consent-protocol/ @hushh-labs/allowed-maintainers-to-approve
 
 # Frontend (Next.js/Capacitor)
-/hushh-webapp/ @kushaltrivedi5
+/hushh-webapp/ @hushh-labs/allowed-maintainers-to-approve
 
 # Documentation
-/docs/ @kushaltrivedi5
+/docs/ @hushh-labs/allowed-maintainers-to-approve
 
 # CI/CD and workflows
-/.github/ @kushaltrivedi5
+/.github/ @hushh-labs/allowed-maintainers-to-approve
 
 # Deployment configs
-/deploy/ @kushaltrivedi5
+/deploy/ @hushh-labs/allowed-maintainers-to-approve
 
 # Scripts and utilities
-/scripts/ @kushaltrivedi5
+/scripts/ @hushh-labs/allowed-maintainers-to-approve
 
 # Native macOS app (One for macOS)
-/apps/one-mac/ @kushaltrivedi5
-/.codex/skills/desktop-mac/ @kushaltrivedi5
-/.codex/skills/desktop-mac-connectors/ @kushaltrivedi5
-/.codex/skills/desktop-mac-mcp-host/ @kushaltrivedi5
+/apps/one-mac/ @hushh-labs/allowed-maintainers-to-approve
+/.codex/skills/desktop-mac/ @hushh-labs/allowed-maintainers-to-approve
+/.codex/skills/desktop-mac-connectors/ @hushh-labs/allowed-maintainers-to-approve
+/.codex/skills/desktop-mac-mcp-host/ @hushh-labs/allowed-maintainers-to-approve
+
+# ---------------------------------------------------------------------------
+# PROTECTED GOVERNANCE & DEPLOY-AUTHORITY SURFACES
+# These define who may merge, deploy, and edit the pipeline itself. They are
+# owned by the maintainer team and additionally enforced at CI time by
+# scripts/ci/verify-protected-pipeline-edits.py. A community PR touching any of
+# these must pass: CODEOWNERS team review + the CI maintainer-actor guard +
+# branch-protection approval. No single mistaken approval can land them.
+# ---------------------------------------------------------------------------
+/.github/workflows/ @hushh-labs/allowed-maintainers-to-approve
+/.github/actions/ @hushh-labs/allowed-maintainers-to-approve
+/scripts/ci/ @hushh-labs/allowed-maintainers-to-approve
+/config/ci-governance.json @hushh-labs/allowed-maintainers-to-approve
+/.github/CODEOWNERS @hushh-labs/allowed-maintainers-to-approve

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,12 @@ jobs:
 
       - name: Run repo governance checks
         run: bash scripts/ci/orchestrate.sh governance
+        env:
+          # Required so verify-protected-pipeline-edits.py can resolve the PR's
+          # changed-file list from the GitHub API. Without a token the guard
+          # silently resolves zero files and passes (fails open). The job
+          # already declares `pull-requests: read`, which is sufficient.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # ============================================================================
   # Path filters: run frontend/backend jobs only when their paths change (or manual scope)

--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -17,7 +17,8 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx"
+      "azfx",
+      "Jhumma-hushh"
     ],
     "review_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_required": true,
@@ -28,13 +29,15 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx"
+      "azfx",
+      "Jhumma-hushh"
     ],
     "protected_pipeline_edit_users": [
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx"
+      "azfx",
+      "Jhumma-hushh"
     ],
     "protected_pipeline_paths": [
       ".github/workflows/",
@@ -54,7 +57,8 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx"
+      "azfx",
+      "Jhumma-hushh"
     ],
     "review_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_required": true,
@@ -65,7 +69,8 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx"
+      "azfx",
+      "Jhumma-hushh"
     ]
   },
   "uat": {
@@ -75,7 +80,9 @@
     "manual_dispatch_users": [
       "kushaltrivedi5",
       "RGlodAkshat",
-      "ankitkumarsingh1702"
+      "ankitkumarsingh1702",
+      "azfx",
+      "Jhumma-hushh"
     ]
   },
   "production": {

--- a/docs/reference/operations/branch-governance.md
+++ b/docs/reference/operations/branch-governance.md
@@ -75,7 +75,7 @@ Before deleting a local backup branch, classify its unique commits as:
 
 1. UAT deploys only through a manual workflow dispatch with an explicit green `main` SHA.
 2. The workflow checks out that exact chosen green `main` SHA.
-3. Manual dispatch is limited to `kushaltrivedi5`, `RGlodAkshat`, and `ankitkumarsingh1702`.
+3. Manual dispatch is limited to the maintainer cohort in `config/ci-governance.json` (`uat.manual_dispatch_users`): `kushaltrivedi5`, `RGlodAkshat`, `ankitkumarsingh1702`, `azfx`, and `Jhumma-hushh`. This list is held equal to the merge cohort (`main.review_bypass_users`) by design — anyone trusted to land code on `main` may validate it in the UAT sandbox — and `scripts/ci/verify-deployment-environment-governance.py` fails if the two drift apart.
 4. Workflow preflight fails if the requested SHA is not reachable from `origin/main`.
 5. Workflow preflight also fails if the SHA does not already have a successful `Main Post-Merge Smoke Gate`.
 6. The canonical GitHub deployment environment for this lane is `uat`.
@@ -91,6 +91,68 @@ Before deleting a local backup branch, classify its unique commits as:
 4. The workflow also validates that `Main Post-Merge Smoke Gate` succeeded for that SHA before deployment starts.
 5. Only `kushaltrivedi5` may dispatch the production workflow after the SHA preflight passes.
 6. The canonical GitHub deployment environment for this lane is `production`.
+
+## Protected Surfaces & Trust Model
+
+The repository protects a set of high-blast-radius surfaces — the files that
+decide who can merge, who can deploy, and what the pipeline does — behind
+**three independent, defense-in-depth layers**. No single mistaken approval can
+land a change to these surfaces.
+
+### Protected surfaces
+
+These paths are owned by the maintainer team in `.github/CODEOWNERS` and are
+listed in `config/ci-governance.json` under `main.protected_pipeline_paths`:
+
+- `.github/workflows/`
+- `.github/actions/`
+- `scripts/ci/`
+- `deploy/`
+- `config/ci-governance.json`
+- `.github/CODEOWNERS`
+
+### The three enforcement layers
+
+1. **CODEOWNERS (GitHub-native, blocks merge).** Ownership is mapped to the
+   `@hushh-labs/allowed-maintainers-to-approve` team, not a single user, so it
+   auto-tracks membership and removes the single-owner bottleneck. For this to
+   *block* (not merely request review), `main` and `integration/pr-train` must
+   have **"Require review from Code Owners"** enabled, and the team must keep at
+   least write/maintain repo access or GitHub silently ignores team entries.
+2. **CI maintainer-actor guard (fails closed).**
+   `scripts/ci/verify-protected-pipeline-edits.py` runs in the required
+   `CI Status Gate` and fails the PR if a non-maintainer touches a protected
+   surface. It requires `GH_TOKEN` in the governance job to resolve the PR's
+   changed files; if it cannot resolve them it **fails closed** (blocks), never
+   open. A `--self-test` runs in CI so the guard can never silently regress.
+3. **Branch-protection approval.** The standard 1 independent approval plus
+   approval-of-most-recent-push still applies underneath the two layers above.
+
+### Concentric privilege rings
+
+Privilege is deliberately nested. Each inner ring is a strict subset of the one
+outside it, and the boundaries are enforced, not informal:
+
+| Ring | Who | Authority | Source of truth |
+|---|---|---|---|
+| Merge cohort | `allowed-maintainers-to-approve` team (5) | bypass review + queue, edit pipeline | `main.review_bypass_users` / `merge_queue_bypass_users` / `protected_pipeline_edit_users` |
+| UAT deploy cohort | same 5 | dispatch UAT deploy of a green `main` SHA | `uat.manual_dispatch_users` (held == merge cohort) |
+| Production deploy cohort | `kushaltrivedi5` only | dispatch production deploy | `production.manual_dispatch_users` |
+
+Invariants enforced in CI by `verify-deployment-environment-governance.py`:
+
+- **UAT == merge cohort.** Anyone trusted to land code on `main` may validate it
+  in the UAT sandbox — no more, no less. The two lists are held equal and any
+  independent drift fails the check.
+- **Production == owner only.** `production.manual_dispatch_users` must be exactly
+  `["kushaltrivedi5"]`; any widening fails the check.
+
+### Rule: deploy-actor lists are governance, not routine config
+
+Changes to `manual_dispatch_users` (UAT or production) and to the maintainer
+cohort lists are protected-surface edits: they require maintainer-team code-owner
+review, pass the CI guard, and should be authored/merged by the owner. Widening
+who can deploy is never a routine, self-mergeable change.
 
 ## Hotfix Playbook
 
@@ -140,8 +202,8 @@ Current operating note:
 - admin ownership does not count as an independent PR approval
 - require approval of the most recent push is enabled, so stale approvals cannot carry newly pushed code
 - a PR author cannot self-approve through GitHub; sanctioned maintainer "self approval" means explicit branch-protection bypass, not a counted GitHub review
-- the current live branch protection review-bypass allowlist is `kushaltrivedi5`, `RGlodAkshat`, `ankitkumarsingh1702`, and `azfx`
-- the current live merge-queue bypass team is `Allowed Maintainers to Approve`, containing those same 4 users only
+- the current live branch protection review-bypass allowlist is `kushaltrivedi5`, `RGlodAkshat`, `ankitkumarsingh1702`, `azfx`, and `Jhumma-hushh`
+- the current live merge-queue bypass team is `Allowed Maintainers to Approve`, containing those same 5 users only
 - the sanctioned review-bypass cohort is intentional policy and should not be reported as governance drift when it matches `config/ci-governance.json`
 - if an admin needs to proceed on a green PR, verify whether the live ruleset allows queue entry; do not assume approval is implicitly satisfied
 - bypass actors may waive review through branch protection and bypass queue through the dedicated owner team path

--- a/scripts/ci/repo-governance-check.sh
+++ b/scripts/ci/repo-governance-check.sh
@@ -9,6 +9,7 @@ cd "$REPO_ROOT"
 
 python3 scripts/ci/verify-pr-governance-sections.py
 python3 scripts/ci/verify-protected-pipeline-edits.py
+python3 scripts/ci/verify-protected-pipeline-edits.py --self-test
 python3 scripts/ci/verify-pr-base-policy.py --self-test
 python3 scripts/ci/test_resolve_deploy_scope.py
 ./bin/hushh docs verify

--- a/scripts/ci/verify-deployment-environment-governance.py
+++ b/scripts/ci/verify-deployment-environment-governance.py
@@ -63,6 +63,20 @@ def _assert_surface(surface: str, repo: str, policy: dict) -> list[str]:
             f"production manual dispatch policy drifted: expected ['kushaltrivedi5'], got {allowed_users}"
         )
 
+    # UAT dispatch authority must equal the merge cohort (main.review_bypass_users).
+    # Invariant: anyone trusted to land code on `main` is trusted to validate that
+    # code in the hosted UAT sandbox -- no more, no less. This keeps the two lists
+    # in lockstep and fails CI if either is widened or narrowed independently
+    # (e.g. a maintainer quietly adding only themselves to UAT dispatch).
+    if surface == "uat":
+        merge_cohort = sorted(set(policy.get("main", {}).get("review_bypass_users") or []))
+        uat_cohort = sorted(set(allowed_users))
+        if uat_cohort != merge_cohort:
+            errors.append(
+                "uat manual dispatch policy drifted from the merge cohort: "
+                f"expected {merge_cohort} (main.review_bypass_users), got {uat_cohort}"
+            )
+
     summary = (
         f"{surface} environment summary: env={env_name}, "
         f"reviewers={reviewers}, can_admins_bypass={payload.get('can_admins_bypass')}, "

--- a/scripts/ci/verify-protected-pipeline-edits.py
+++ b/scripts/ci/verify-protected-pipeline-edits.py
@@ -70,6 +70,18 @@ def _fetch_pr_files(repo: str, pr_number: int, token: str) -> list[str]:
     return files
 
 
+class GuardResolutionError(RuntimeError):
+    """Raised when a PR's changed-file list cannot be resolved.
+
+    The guard must FAIL CLOSED on resolution failure: if we cannot determine
+    which files a pull request touches, we cannot prove the change is safe, so
+    we refuse rather than wave it through. Historically this path returned an
+    empty list, which the caller treated as "nothing to enforce" and passed —
+    a silent fail-open that disabled the guard entirely whenever GH_TOKEN was
+    not wired into the job environment.
+    """
+
+
 def _files_from_event(args: argparse.Namespace) -> list[str]:
     if args.files:
         return _normalize_csv(args.files)
@@ -78,15 +90,100 @@ def _files_from_event(args: argparse.Namespace) -> list[str]:
         return []
     event_path = os.environ.get("GITHUB_EVENT_PATH", "")
     if not event_path:
-        return []
-    payload = json.loads(Path(event_path).read_text(encoding="utf-8"))
+        raise GuardResolutionError(
+            "GITHUB_EVENT_PATH is unset on a pull_request event; cannot resolve "
+            "changed files to enforce protected-surface policy."
+        )
+    try:
+        payload = json.loads(Path(event_path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise GuardResolutionError(
+            f"Could not read GitHub event payload at '{event_path}': {exc}"
+        ) from exc
     pull_request = payload.get("pull_request") or {}
     pr_number = args.pr_number or pull_request.get("number")
     repo = args.repo or os.environ.get("GITHUB_REPOSITORY", "").strip()
     token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or ""
-    if not pr_number or not repo or not token:
-        return []
-    return _fetch_pr_files(repo=repo, pr_number=int(pr_number), token=token)
+    missing = [
+        name
+        for name, value in (
+            ("pr_number", pr_number),
+            ("repo", repo),
+            ("GH_TOKEN/GITHUB_TOKEN", token),
+        )
+        if not value
+    ]
+    if missing:
+        raise GuardResolutionError(
+            "Cannot resolve PR changed files for protected-surface enforcement; "
+            f"missing required input(s): {', '.join(missing)}. Wire GH_TOKEN into "
+            "the governance job and ensure the repo/PR context is present."
+        )
+    assert pr_number is not None  # narrowed by the `missing` guard above
+    return _fetch_pr_files(repo=str(repo), pr_number=int(pr_number), token=str(token))
+
+
+def evaluate(
+    *,
+    changed_files: list[str],
+    actor: str,
+    allowed_users: list[str],
+    protected_paths: list[str],
+) -> tuple[int, str]:
+    """Pure decision core for protected-surface enforcement.
+
+    Returns (exit_code, message). 0 = allowed/not-applicable, 1 = blocked.
+    Kept side-effect-free so it can be unit-tested via --self-test.
+    """
+    protected_changes = sorted(
+        path
+        for path in changed_files
+        if any(_matches(path, protected_path) for protected_path in protected_paths)
+    )
+    if not protected_changes:
+        return 0, "Protected pipeline edit guard: no protected pipeline surfaces changed."
+
+    actor = actor.strip()
+    if actor in allowed_users:
+        return 0, (
+            "Protected pipeline edit guard: allowed "
+            f"(actor={actor}, files={protected_changes}, allowed_users={allowed_users})."
+        )
+
+    return 1, (
+        "ERROR: protected pipeline surfaces changed by non-sanctioned actor "
+        f"'{actor or '<unknown>'}'.\n"
+        f"ERROR: protected files={protected_changes}\n"
+        f"ERROR: allowed users={allowed_users}"
+    )
+
+
+def _self_test() -> int:
+    allowed = ["kushaltrivedi5", "Jhumma-hushh"]
+    paths = list(DEFAULT_PROTECTED_PATHS)
+    cases: list[tuple[str, list[str], str, int]] = [
+        # name, changed_files, actor, expected_exit
+        ("community edits governance config", ["config/ci-governance.json"], "random-contributor", 1),
+        ("community edits a workflow", [".github/workflows/ci.yml"], "random-contributor", 1),
+        ("maintainer edits governance config", ["config/ci-governance.json"], "kushaltrivedi5", 0),
+        ("community edits only app code", ["hushh-webapp/app/page.tsx"], "random-contributor", 0),
+        ("community edits scripts/ci", ["scripts/ci/orchestrate.sh"], "random-contributor", 1),
+    ]
+    failures: list[str] = []
+    for name, files, actor, expected in cases:
+        code, message = evaluate(
+            changed_files=files, actor=actor, allowed_users=allowed, protected_paths=paths
+        )
+        status = "ok" if code == expected else "FAIL"
+        print(f"[{status}] {name}: exit={code} (expected {expected})")
+        if code != expected:
+            failures.append(f"{name}: got {code}, expected {expected}")
+    if failures:
+        for failure in failures:
+            print(f"ERROR: self-test case failed: {failure}", file=sys.stderr)
+        return 1
+    print("Protected pipeline edit guard self-test passed.")
+    return 0
 
 
 def main() -> int:
@@ -101,7 +198,15 @@ def main() -> int:
         "--files",
         help="Comma-separated changed files for local verification.",
     )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="Run the built-in decision-core self-test and exit.",
+    )
     args = parser.parse_args()
+
+    if args.self_test:
+        return _self_test()
 
     policy = _load_policy()
     main_policy = policy["main"]
@@ -127,35 +232,23 @@ def main() -> int:
         print("Protected pipeline edit guard: no changed files resolved; nothing to enforce.")
         return 0
 
-    protected_changes = sorted(
-        path
-        for path in changed_files
-        if any(_matches(path, protected_path) for protected_path in protected_paths)
+    code, message = evaluate(
+        changed_files=changed_files,
+        actor=args.actor or os.environ.get("GITHUB_ACTOR", ""),
+        allowed_users=allowed_users,
+        protected_paths=protected_paths,
     )
-    if not protected_changes:
-        print("Protected pipeline edit guard: no protected pipeline surfaces changed.")
-        return 0
-
-    actor = (args.actor or os.environ.get("GITHUB_ACTOR", "")).strip()
-    if actor in allowed_users:
-        print(
-            "Protected pipeline edit guard: allowed "
-            f"(actor={actor}, files={protected_changes}, allowed_users={allowed_users})."
-        )
-        return 0
-
-    print(
-        "ERROR: protected pipeline surfaces changed by non-sanctioned actor "
-        f"'{actor or '<unknown>'}'."
-    )
-    print(f"ERROR: protected files={protected_changes}")
-    print(f"ERROR: allowed users={allowed_users}")
-    return 1
+    print(message)
+    return code
 
 
 if __name__ == "__main__":
     try:
         raise SystemExit(main())
+    except GuardResolutionError as exc:
+        # Fail CLOSED: an unresolvable PR file list must block, never wave through.
+        print(f"ERROR: protected pipeline edit guard could not enforce policy: {exc}", file=sys.stderr)
+        raise SystemExit(1)
     except urllib.error.HTTPError as exc:
         print(f"ERROR: failed to resolve PR files from GitHub API: {exc}", file=sys.stderr)
         raise SystemExit(1)


### PR DESCRIPTION
Promotes the single governance commit on `integration/pr-train` to `main` so the UAT deploy workflow (which reads `config/ci-governance.json` from `main`) picks up the corrected `uat.manual_dispatch_users` list.

Contents: exactly #2599 (deploy-authority alignment to the maintainer cohort + fail-closed protected-surface guard + team CODEOWNERS + UAT drift assertion + docs). Train is 1 commit ahead of main; no unrelated changes ride along.

After merge, Jhumma-hushh (and azfx) can dispatch UAT for green main SHAs.