### PR TITLE
test(env): cover uppercase UAT alias

### DIFF
--- a/hushh-webapp/__tests__/lib/app-env.test.ts
+++ b/hushh-webapp/__tests__/lib/app-env.test.ts
@@ -62,4 +62,9 @@ describe("resolveAppEnvironment", () => {
 
     expect(resolveAppEnvironment()).toBe("development");
   });
+  it("maps UAT to uat", () => {
+    process.env.NEXT_PUBLIC_APP_ENV = "UAT";
+
+    expect(resolveAppEnvironment()).toBe("uat");
+  });
 });


### PR DESCRIPTION
## Summary

Add test coverage for uppercase UAT environment aliases.

## Changes Made

* Added a test for `NEXT_PUBLIC_APP_ENV="UAT"`
* Verified environment normalization resolves to `uat`
* Improved coverage for environment alias handling

## Test

```bash
npm test -- app-env
```
