### PR TITLE
fix(investors): remove proxy error detail leakage

### DIFF
--- a/hushh-webapp/app/api/investors/[id]/route.ts
+++ b/hushh-webapp/app/api/investors/[id]/route.ts
@@ -31,7 +31,7 @@ export async function GET(
         return NextResponse.json(errorJson, { status: response.status });
       } catch (_e) {
         return NextResponse.json(
-          { error: "Backend error", details: errorText },
+          { error: "Backend error" },
           { status: response.status }
         );
       }
@@ -42,7 +42,7 @@ export async function GET(
   } catch (error) {
     console.error("[Investors Proxy] Get error:", error);
     return NextResponse.json(
-      { error: "Failed to get investor", details: String(error) },
+      { error: "Failed to get investor" },
       { status: 500 }
     );
   }


### PR DESCRIPTION
## Summary

Remove detailed error payloads from the investor proxy API response.

## What Changed

* Removed raw backend error text from the fallback investor proxy error response.
* Removed exception-derived detail text from the catch block response.
* Preserved server-side logging for debugging.

## Why

Returning raw backend error text or exception details to clients can expose internal implementation details and diagnostic information. This change hardens the investor proxy API by returning generic error responses while keeping useful diagnostics on the server side.

## Testing

* `npm run lint`
* `npm run typecheck`

## Risk

Low. The change only affects error response payloads returned when the investor proxy request fails.
