### PR TITLE
test(command): cover showCloseButton dialog forwarding

### DIFF
--- a/hushh-webapp/__tests__/ui/command.test.tsx
+++ b/hushh-webapp/__tests__/ui/command.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { CommandDialog } from "@/components/ui/command";
+
+describe("CommandDialog", () => {
+  it("renders the close button by default", () => {
+    render(
+      <CommandDialog open>
+        <div>Command content</div>
+      </CommandDialog>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /close/i }),
+    ).toBeTruthy();
+  });
+
+  it("hides the close button when showCloseButton is false", () => {
+    render(
+      <CommandDialog open showCloseButton={false}>
+        <div>Command content</div>
+      </CommandDialog>,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /close/i }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
Summary
- Added coverage for CommandDialog showCloseButton behavior.
- Verified the close button renders by default.
- Verified the close button is hidden when showCloseButton is false.

Test
- npx vitest run __tests__/ui/command.test.tsx