### PR TITLE
fix(vault): remove backend detail from status response

### DIFF
--- a/hushh-webapp/app/api/vault/status/route.ts
+++ b/hushh-webapp/app/api/vault/status/route.ts
@@ -63,9 +63,10 @@ async function proxyVaultStatus(params: {
     console.error("[API] Backend error:", response.status, errorText);
     return {
       status: response.status,
-      payload: { error: "Backend error", details: errorText },
+      payload: { error: "Backend error" },
     };
   }
+  
 
   return {
     status: response.status,


### PR DESCRIPTION
## Summary

Remove backend error details from the vault status API response.

## What Changed

* Removed `details: errorText` from the vault status error payload.
* Preserved server-side logging of the backend error text.
* Kept the existing HTTP status code behavior unchanged.

## Why

Returning backend error details to clients can expose internal implementation details or diagnostic information. This change hardens the API response by returning a generic error payload while still keeping detailed logs available on the server.

## Testing

* `npm run lint`
* `npm run typecheck`

## Risk

Low. This only changes the error response payload when the upstream vault status request fails.
