### PR TITLE
fix(vault): remove backend detail from wrapper upsert response

### DIFF
--- a/hushh-webapp/app/api/vault/wrapper/upsert/route.ts
+++ b/hushh-webapp/app/api/vault/wrapper/upsert/route.ts
@@ -89,13 +89,12 @@ export async function POST(request: NextRequest) {
       }),
     });
 
-    if (!response.ok) {
-      const errorText = await response.text();
-      return NextResponse.json(
-        { error: errorText || "Backend error" },
-        { status: response.status }
-      );
-    }
+if (!response.ok) {
+  return NextResponse.json(
+    { error: "Backend error" },
+    { status: response.status }
+  );
+}
 
     const result = await response.json();
     return NextResponse.json({ success: !!result.success });


### PR DESCRIPTION
## Summary

Remove backend error details from the vault wrapper upsert API response.

## What Changed

* Removed raw backend error text from the wrapper upsert error response.
* Preserved existing HTTP status code behavior.
* Kept server-side logging unchanged.

## Why

Returning backend error details to clients can expose internal implementation details and diagnostic information. This change ensures clients receive a generic error response while maintaining observability through server-side logs.

## Testing

* npm run lint
* npm run typecheck

## Risk

Low. Only affects error payloads returned when the upstream wrapper upsert request fails.
