### PR TITLE
test(dialog): cover showCloseButton visibility behavior

### DIFF
--- a/hushh-webapp/__tests__/ui/dialog.test.tsx
+++ b/hushh-webapp/__tests__/ui/dialog.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+describe("DialogContent", () => {
+  it("renders the close button by default", () => {
+    render(
+      <Dialog open>
+        <DialogContent>
+          <DialogTitle>Test dialog</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    expect(screen.getByRole("button", { name: /close/i })).toBeTruthy();
+  });
+
+  it("hides the close button when showCloseButton is false", () => {
+    render(
+      <Dialog open>
+        <DialogContent showCloseButton={false}>
+          <DialogTitle>Test dialog</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    expect(screen.queryByRole("button", { name: /close/i })).toBeNull();
+  });
+});


### PR DESCRIPTION
Summary
- Added coverage for DialogContent close button visibility.
- Verified the close button renders by default.
- Verified showCloseButton={false} hides the close button.

Test
- npx vitest run __tests__/ui/dialog.test.tsx