### PR TITLE
fix(vault): remove backend detail from wrapper delete response

### DIFF
--- a/hushh-webapp/app/api/vault/wrapper/delete/route.ts
+++ b/hushh-webapp/app/api/vault/wrapper/delete/route.ts
@@ -83,12 +83,12 @@ export async function POST(request: NextRequest) {
       }),
     });
 
-    if (!response.ok) {
-      const errorPayload = await response
-        .json()
-        .catch(async () => ({ error: await response.text().catch(() => "") }));
-      return NextResponse.json(errorPayload, { status: response.status });
-    }
+if (!response.ok) {
+  return NextResponse.json(
+    { error: "Backend error" },
+    { status: response.status }
+  );
+}
 
     const result = await response.json();
     return NextResponse.json({ success: !!result.success });


### PR DESCRIPTION
## Summary

Remove backend error details from the vault wrapper delete API response.

## What Changed

* Replaced forwarding of backend error payloads with a generic error response.
* Preserved existing HTTP status code behavior.
* Prevented upstream error details from being exposed to clients.

## Why

Returning raw backend error payloads can expose internal implementation details and diagnostic information. This change hardens the API surface by returning a generic error response while preserving failure status codes.

## Testing

* npm run lint
* npm run typecheck

## Risk

Low. Only affects error payloads returned when the upstream wrapper delete request fails.
