### PR TITLE
fix(investors): cap search result limit

### DIFF
--- a/hushh-webapp/app/api/investors/search/route.ts
+++ b/hushh-webapp/app/api/investors/search/route.ts
@@ -11,7 +11,10 @@ export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const name = searchParams.get("name");
-    const limit = searchParams.get("limit") || "10";
+    const rawLimit = Number.parseInt(searchParams.get("limit") || "10", 10);
+    const limit = Number.isFinite(rawLimit)
+       ? Math.min(Math.max(rawLimit, 1), 50)
+       : 10;
 
     if (!name) {
       return NextResponse.json(


### PR DESCRIPTION
## Summary

Add bounds checking to the investor search limit query parameter.

## What Changed

* Parse the `limit` query parameter as a number.
* Enforce a minimum value of 1.
* Enforce a maximum value of 50.
* Fall back to the default value when the input is invalid.

## Why

Unbounded user-controlled limits can cause excessive backend work and unnecessary resource consumption. Applying bounds improves resilience and aligns with existing pagination and query hardening patterns.

## Testing

* npm run lint
* npm run typecheck

## Risk

Low. Only affects requests providing invalid or excessively large limit values.
