### PR TITLE
fix(consent): cap history pagination parameters

### DIFF
--- a/hushh-webapp/app/api/consent/history/route.ts
+++ b/hushh-webapp/app/api/consent/history/route.ts
@@ -41,8 +41,15 @@ export async function GET(request: NextRequest) {
 
     const { searchParams } = new URL(request.url);
     const userId = searchParams.get("userId");
-    const page = searchParams.get("page") || "1";
-    const limit = searchParams.get("limit") || "20";
+    const rawPage = Number.parseInt(searchParams.get("page") || "1", 10);
+    const rawLimit = Number.parseInt(searchParams.get("limit") || "20", 10);
+
+    const page = Number.isFinite(rawPage)
+      ? Math.min(Math.max(rawPage, 1), 1000)
+      : 1;
+    const limit = Number.isFinite(rawLimit)
+      ? Math.min(Math.max(rawLimit, 1), 100)
+      : 20;
 
     if (!userId) {
       return withRequestIdJson(


### PR DESCRIPTION
## Summary

Add bounds checking for consent history pagination parameters.

## What Changed

* Parse `page` and `limit` query parameters as numbers.
* Enforce a minimum value of `1` for both parameters.
* Cap `page` at `1000`.
* Cap `limit` at `100`.
* Preserve existing default values when invalid input is provided.

## Why

The consent history endpoint previously forwarded user-controlled pagination values without validation. Excessively large values can increase backend workload, impact performance, and create unnecessary resource consumption. Applying reasonable bounds improves resilience and aligns with existing pagination hardening efforts across the codebase.

## Testing

* `npm run lint`
* `npm run typecheck`

## Risk

Low. This change only affects requests with invalid, negative, or excessively large pagination values. Existing valid requests continue to behave as expected.
