### PR TITLE
fix(tickers): cap search result limit

### DIFF
--- a/hushh-webapp/app/api/tickers/search/route.ts
+++ b/hushh-webapp/app/api/tickers/search/route.ts
@@ -25,7 +25,10 @@ export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const q = searchParams.get("q") || "";
-    const limit = searchParams.get("limit") || "25";
+    const rawLimit = Number.parseInt(searchParams.get("limit") || "25", 10);
+    const limit = Number.isFinite(rawLimit)
+       ? Math.min(Math.max(rawLimit, 1), 100)
+       : 25;
 
     if (!q.trim()) {
       return NextResponse.json([], { status: 200 });


### PR DESCRIPTION
## Summary

Add bounds checking for the ticker search limit parameter.

## What Changed

* Parse the `limit` query parameter as a number.
* Enforce a minimum value of `1`.
* Enforce a maximum value of `100`.
* Preserve the default value when invalid input is provided.

## Why

The ticker search endpoint previously forwarded a user-controlled limit value without validation. Excessively large values can increase backend workload and resource consumption. Applying reasonable bounds improves resilience and aligns with existing query parameter hardening patterns.

## Testing

* `npm run lint`
* `npm run typecheck`

## Risk

Low. Only affects requests providing invalid, negative, or excessively large limit values. Existing valid requests continue to behave as expected.
