### PR TITLE
fix(decision-card): prevent agent vote legend text from overflowing

### DIFF
--- a/hushh-webapp/components/kai/views/decision-card.tsx
+++ b/hushh-webapp/components/kai/views/decision-card.tsx
@@ -452,7 +452,7 @@ function AgentVoteBar({ result }: { result: DecisionResult }) {
             tick={{ fontSize: 11, fill: "hsl(var(--foreground))" }}
           />
           <ChartTooltip cursor={false} content={renderVoteTooltip} />
-          <ChartLegend content={<ChartLegendContent className="text-[11px] font-medium text-foreground/80 dark:text-foreground/80" />} />
+          <ChartLegend content={<ChartLegendContent className="max-w-full overflow-hidden text-[11px] font-medium text-foreground/80 [&>*]:min-w-0 [&>*]:truncate dark:text-foreground/80" />} />
           <Bar dataKey="bullish" stackId="vote" fill="var(--color-bullish)" radius={[4, 0, 0, 4]} barSize={14} />
           <Bar dataKey="neutral" stackId="vote" fill="var(--color-neutral)" barSize={14} />
           <Bar dataKey="bearish" stackId="vote" fill="var(--color-bearish)" radius={[0, 4, 4, 0]} barSize={14} />


### PR DESCRIPTION
## Exact Surface
- File: hushh-webapp/components/kai/views/decision-card.tsx
- Component: DecisionCard
- Lines changed: 455

## Caller Proof
- Caller: hushh-webapp/components/kai/views/history-detail-view.tsx imports DecisionCard from hushh-webapp/components/kai/views/decision-card.tsx
- Route: /kai/analysis via hushh-webapp/app/kai/analysis/page.tsx

## No Overlap Proof
- This change does not exist anywhere else: confirmed

## Narrowness Proof
- 1 file changed
- Zero props or API changed
- Change limited to constraining the AgentVoteBar chart legend text inside DecisionCard.