### PR TITLE
fix(consent): suppress export refresh backend error detail

### DIFF
--- a/hushh-webapp/app/api/consent/export-refresh/jobs/route.ts
+++ b/hushh-webapp/app/api/consent/export-refresh/jobs/route.ts
@@ -27,9 +27,7 @@ export async function GET(request: NextRequest) {
         },
       }
     );
-    const payload = await response
-      .json()
-      .catch(async () => ({ error: await response.text().catch(() => "") }));
+    const payload = await response.json().catch(() => ({ error: "Backend error" }));
     return NextResponse.json(payload, { status: response.status });
   } catch (error) {
     console.error("[API] export-refresh/jobs error:", error);


### PR DESCRIPTION
## Summary

Prevent backend error details from being exposed by the export refresh jobs endpoint.

## What Changed

* Replaced forwarding of backend response text when JSON parsing fails.
* Return a generic `"Backend error"` payload instead.
* Preserve existing response status behavior.

## Why

Returning raw backend error text can expose internal implementation details and diagnostic information. This change hardens the API response while preserving error handling behavior.

## Testing

* `npm run lint`
* `npm run typecheck`

## Risk

Low. Only affects error payloads returned when backend responses cannot be parsed as JSON.
