### PR TITLE
fix(import-progress-view): constrain header status text

### DIFF
--- a/hushh-webapp/components/kai/views/import-progress-view.tsx
+++ b/hushh-webapp/components/kai/views/import-progress-view.tsx
@@ -243,9 +243,9 @@ export function ImportProgressView({
           )}
         </div>
 
-        <p className="text-sm text-muted-foreground">{displayStatusMessage}</p>
+        <p className="min-w-0 break-words text-sm text-muted-foreground">{displayStatusMessage}</p>
         {latestStreamUpdate && stage !== "complete" ? (
-          <p className="text-xs text-muted-foreground/80">
+          <p className="min-w-0 break-words text-xs text-muted-foreground/80">
             {(() => {
               const { tag, message } = splitTaggedLine(latestStreamUpdate);
               return tag ? `${tag}: ${message}` : message;


### PR DESCRIPTION
## Exact Surface
- File: hushh-webapp/components/kai/views/import-progress-view.tsx
- Component: ImportProgressView
- Lines changed: 246, 248

## Caller Proof
- Caller: hushh-webapp/components/kai/kai-flow.tsx imports ImportProgressView from hushh-webapp/components/kai/views/import-progress-view.tsx
- Route: /kai/import via hushh-webapp/app/kai/import/page.tsx

## No Overlap Proof
- This change does not exist anywhere else: confirmed

## Narrowness Proof
- 1 file changed
- Zero props or API changed
- Change limited to constraining the ImportProgressView display status and latest stream update text.