### PR TITLE
fix(developer): bound proxy path parameters

### DIFF
--- a/hushh-webapp/app/api/developer/[...path]/route.ts
+++ b/hushh-webapp/app/api/developer/[...path]/route.ts
@@ -16,6 +16,18 @@ async function proxyDeveloperRequest(
 ) {
   const requestId = resolveRequestId(request);
   const query = request.nextUrl.search;
+
+  if (
+    params.path.length === 0 ||
+    params.path.length > 8 ||
+    params.path.some((segment) => segment.length > 128)
+  ) {
+    return withRequestIdJson(
+      requestId,
+      { error: "Invalid developer API path" },
+      { status: 400 }
+    );
+  }
   const path = params.path.join("/");
   const isVersionedDeveloperApi = params.path[0] === "v1";
   const upstreamPath = isVersionedDeveloperApi


### PR DESCRIPTION
## Summary

Add bounds validation for developer proxy path parameters.

## What Changed

* Reject empty developer proxy paths.
* Reject paths with more than 8 segments.
* Reject individual path segments longer than 128 characters.
* Return a `400` response for invalid developer API paths before constructing the upstream request URL.

## Why

The developer proxy previously joined dynamic path segments without applying basic bounds. Adding path validation helps prevent excessively deep or oversized paths from reaching the upstream proxy layer and aligns with existing route hardening patterns.

## Testing

* `npm run lint`
* `npm run typecheck`

## Risk

Low. Valid developer API paths continue to work normally. Only empty, overly deep, or oversized paths are rejected.
