### PR TITLE
fix(kai-analysis-summary): prevent recommendation text overflow

### DIFF
--- a/hushh-webapp/components/kai/views/analysis-summary-view.tsx
+++ b/hushh-webapp/components/kai/views/analysis-summary-view.tsx
@@ -460,7 +460,7 @@ export function AnalysisSummaryView({
       <Card variant="muted" effect="fill" preset="default">
         <CardContent className="space-y-3 p-4">
           <div className="border-l-2 border-primary pl-3">
-            <p className="text-sm font-medium leading-relaxed">{shortRecommendation}</p>
+            <p className="break-words text-sm font-medium leading-relaxed">{shortRecommendation}</p>
             <p className="mt-2 text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
               Kai Insight
             </p>


### PR DESCRIPTION
## Summary
- Add `break-words` to the existing Kai Analysis Summary short recommendation paragraph.
- Preserve the recommendation text, `Kai Insight` label, card layout, and analysis behavior.

## Exact Surface
- Changed file: `hushh-webapp/components/kai/views/analysis-summary-view.tsx`
- Changed component: `AnalysisSummaryView`
- Changed node: the `<p>` that renders `shortRecommendation` inside the muted insight card
- Rendered surface: Kai Analysis Summary recommendation text card
- Canonical caller proof: `AnalysisSummaryView` is the exported view component for this analysis summary surface

## Narrowness Proof
- One frontend file changed.
- One class-only change: `break-words` added to the `shortRecommendation` paragraph.
- No insight header metadata, price labels, ticker heading, fair value labels, hook, helper, utility, provider, route handler, backend, cache, governance, PKM, vault, consent, or generated file changed.
- No shared typography or card component changed.

## Existing Capability Overlap Check
- This PR is separate from PR 2617: it touches only the `shortRecommendation` paragraph around line 460, not the header metadata block around line 384.
- It does not touch Kai Streaming Progress, Kai Import Progress, or any chart legend.
- Existing recommendation content and label rendering remain unchanged.

## Validation
- `npm.cmd run lint`
- `npm.cmd run build`
- GitHub checks passing: DCO, PR Base Policy, Web (Next.js), Integration, CI Status Gate
