### PR TITLE
fix(account): bound proxy path parameters

### DIFF
--- a/hushh-webapp/app/api/account/[...path]/route.ts
+++ b/hushh-webapp/app/api/account/[...path]/route.ts
@@ -32,6 +32,18 @@ function isUpstreamTimeoutError(error: unknown): boolean {
 
 async function proxyRequest(request: NextRequest, params: { path: string[] }) {
   const requestId = resolveRequestId(request);
+
+  if (
+    params.path.length === 0 ||
+    params.path.length > 8 ||
+    params.path.some((segment) => segment.length > 128)
+  ) {
+    return withRequestIdJson(
+      requestId,
+      { error: "Invalid account API path" },
+      { status: 400 }
+    );
+  }
   const path = params.path.join("/");
   const url = `${getPythonApiUrl()}/api/account/${path}${request.nextUrl.search}`;
   const authHeader = request.headers.get("authorization");


### PR DESCRIPTION
## Summary

Add bounds validation for account proxy path parameters.

## What Changed

* Reject empty account proxy paths.
* Reject paths with more than 8 segments.
* Reject individual path segments longer than 128 characters.
* Return a `400` response for invalid account API paths before constructing the upstream request URL.

## Why

The account proxy previously accepted arbitrary path depth and segment lengths. Adding validation helps prevent excessively large path inputs from reaching the upstream proxy layer and aligns with existing route hardening efforts.

## Testing

* `npm run lint`
* `npm run typecheck`

## Risk

Low. Valid account API paths continue to function normally. Only malformed or excessively large path inputs are rejected.
