### PR TITLE
fix(kai-analysis-summary): constrain insight header metadata

### DIFF
--- a/hushh-webapp/components/kai/views/analysis-summary-view.tsx
+++ b/hushh-webapp/components/kai/views/analysis-summary-view.tsx
@@ -384,10 +384,10 @@ export function AnalysisSummaryView({
           <div className="grid h-14 w-14 place-items-center rounded-full bg-black text-lg font-black text-white dark:bg-white dark:text-black">
             {entry.ticker.slice(0, 1)}
           </div>
-          <div>
+          <div className="min-w-0">
             <h2 className="text-2xl font-black tracking-tight leading-tight">{entry.ticker} Insight</h2>
-            <div className="mt-1 flex flex-wrap items-center gap-2">
-              <span className="font-mono text-sm text-muted-foreground">{priceLabel}</span>
+            <div className="mt-1 flex min-w-0 flex-wrap items-center gap-2">
+              <span className="break-words font-mono text-sm text-muted-foreground">{priceLabel}</span>
               {todayChangePct !== null ? (
                 <span
                   className={cn(
@@ -401,10 +401,10 @@ export function AnalysisSummaryView({
                   {todayChangePct.toFixed(2)}%
                 </span>
               ) : (
-                <span className="text-xs text-muted-foreground">Today's status unavailable</span>
+                <span className="break-words text-xs text-muted-foreground">Today's status unavailable</span>
               )}
               {fairValueGapLabel ? (
-                <span className="rounded bg-emerald-500/10 px-1.5 py-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-400">
+                <span className="break-words rounded bg-emerald-500/10 px-1.5 py-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-400">
                   {fairValueGapLabel}
                 </span>
               ) : null}


### PR DESCRIPTION
## Description

Constrains insight header metadata within the Kai Analysis Summary to prevent metadata fields from overflowing, overlapping adjacent content, or disrupting header layout.

## Why

Insight header metadata can contain variable-length values such as identifiers, labels, timestamps, or analysis context. When these values exceed the available space, they may overflow their container and reduce readability of the analysis summary.

This change improves layout stability and presentation while preserving existing analysis functionality.

## What changed

- Added containment behavior for insight header metadata
- Prevented long metadata values from overflowing or affecting adjacent header content
- Preserved existing metadata content, formatting, and display logic
- Maintained existing responsive layout behavior

## Impact

- No API changes
- No schema changes
- No backend behavior changes
- Improves readability and visual consistency

## Testing

- Ran `npm run lint`
- Ran `npm run build`
- Verified long metadata values remain contained within the insight header
- Verified analysis summaries continue rendering correctly
- Verified responsive layouts remain stable across supported viewport sizes

## Notes

This PR intentionally focuses on the existing Kai Analysis Summary header component only and does not modify analysis logic, recommendation generation, portfolio calculations, authentication flows, consent contracts, PKM behavior, backend services, or application architecture.

### Changed Surface

- Single existing Kai Analysis Summary component
- No shared metadata, typography, or layout components modified
- No hooks, utilities, providers, or abstractions changed
- No new files created
- UI-only layout containment improvement with low regression risk