### PR TITLE
fix(iam): bound proxy path parameters

### DIFF
--- a/hushh-webapp/app/api/iam/[...path]/route.ts
+++ b/hushh-webapp/app/api/iam/[...path]/route.ts
@@ -48,6 +48,17 @@ async function proxyRequest(
 ) {
   const requestId = resolveRequestId(request);
   const query = request.nextUrl.search;
+  if (
+    params.path.length === 0 ||
+    params.path.length > 8 ||
+    params.path.some((segment) => segment.length > 128)
+  ) {
+    return withRequestIdJson(
+      requestId,
+      { error: "Invalid IAM API path" },
+      { status: 400 }
+    );
+  }
   const path = params.path.join("/");
   const targetUrl = `${getPythonApiUrl()}/api/iam/${path}${query}`;
   const authHeader = request.headers.get("authorization") || "";


### PR DESCRIPTION
## Summary

Add bounds validation for IAM proxy path parameters.

## What Changed

* Reject empty IAM proxy paths.
* Reject paths with more than 8 segments.
* Reject individual path segments longer than 128 characters.
* Return a `400` response for invalid IAM API paths before constructing the upstream request URL.

## Why

The IAM proxy previously accepted arbitrary path depth and segment lengths. Adding validation helps prevent excessively large path inputs from reaching the upstream proxy layer and aligns with existing route hardening efforts.

## Testing

* `npm run lint`
* `npm run typecheck`

## Risk

Low. Valid IAM API paths continue to function normally. Only malformed or excessively large path inputs are rejected.
