### PR TITLE
Test/auth legal dialog close button

### DIFF
--- a/hushh-webapp/__tests__/ui/dialog.test.tsx
+++ b/hushh-webapp/__tests__/ui/dialog.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+describe("DialogContent", () => {
+  it("renders the close button by default", () => {
+    render(
+      <Dialog open>
+        <DialogContent>
+          <DialogTitle>Test dialog</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    expect(screen.getByRole("button", { name: /close/i })).toBeTruthy();
+  });
+
+  it("hides the close button when showCloseButton is false", () => {
+    render(
+      <Dialog open>
+        <DialogContent showCloseButton={false}>
+          <DialogTitle>Test dialog</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    expect(screen.queryByRole("button", { name: /close/i })).toBeNull();
+  });
+});

--- a/hushh-webapp/__tests__/ui/dialog.test.tsx
+++ b/hushh-webapp/__tests__/ui/dialog.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogTitle,
 } from "@/components/ui/dialog";
 
@@ -30,5 +31,18 @@ describe("DialogContent", () => {
     );
 
     expect(screen.queryByRole("button", { name: /close/i })).toBeNull();
+  });
+
+  it("renders dialog description content", () => {
+    render(
+      <Dialog open>
+        <DialogContent>
+          <DialogTitle>Test dialog</DialogTitle>
+          <DialogDescription>Helpful dialog description</DialogDescription>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    expect(screen.getByText("Helpful dialog description")).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

Adds test coverage for dialog description rendering behavior.

### Changes Made

* Added a test to verify `DialogDescription` content is rendered correctly within `DialogContent`.
* Ensured dialog descriptive text remains accessible and visible to users.
* Extended existing dialog component test coverage.

## Test

```bash
npx vitest run __tests__/ui/dialog.test.tsx
```
