### PR TITLE
fix(funding-trade-view): hide decorative submit loading spinner

### DIFF
--- a/hushh-webapp/components/kai/views/funding-trade-view.tsx
+++ b/hushh-webapp/components/kai/views/funding-trade-view.tsx
@@ -527,7 +527,7 @@ export function FundingTradeView({ userId, vaultOwnerToken }: FundingTradeViewPr
                   onClick={() => void createFundAndTrade()}
                 >
                   {isSubmitting ? (
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    <Loader2 aria-hidden="true" className="mr-2 h-4 w-4 animate-spin" />
                   ) : (
                     <BadgeDollarSign className="mr-2 h-4 w-4" />
                   )}


### PR DESCRIPTION
## Exact Surface
- File: hushh-webapp/components/kai/views/funding-trade-view.tsx
- Component: FundingTradeView
- Lines changed: 530

## Caller Proof
- Caller: hushh-webapp/app/kai/funding-trade/page.tsx imports FundingTradeView from hushh-webapp/components/kai/views/funding-trade-view.tsx
- Route: /kai/funding-trade

## No Overlap Proof
- This change does not exist anywhere else: confirmed

## Narrowness Proof
- 1 file changed
- Zero props or API changed
- Change limited to hiding only the Fund and trade submit Loader2 spinner from assistive technology.