### PR TITLE
fix(streaming-progress-view): constrain bull-bear case text

### DIFF
--- a/hushh-webapp/components/kai/views/streaming-progress-view.tsx
+++ b/hushh-webapp/components/kai/views/streaming-progress-view.tsx
@@ -228,7 +228,7 @@ function BullBearCase({ bullCase, bearCase }: { bullCase?: string; bearCase?: st
             <Icon icon={TrendingUp} size={12} className="text-emerald-500" />
             <span className="text-[10px] font-semibold text-emerald-600 dark:text-emerald-400">Bull Case</span>
           </div>
-          <p className="text-[10px] text-muted-foreground leading-relaxed">{bullCase}</p>
+          <p className="break-words text-[10px] text-muted-foreground leading-relaxed">{bullCase}</p>
         </div>
       )}
       {hasBear && (
@@ -237,7 +237,7 @@ function BullBearCase({ bullCase, bearCase }: { bullCase?: string; bearCase?: st
             <Icon icon={TrendingDown} size={12} className="text-red-500" />
             <span className="text-[10px] font-semibold text-red-600 dark:text-red-400">Bear Case</span>
           </div>
-          <p className="text-[10px] text-muted-foreground leading-relaxed">{bearCase}</p>
+          <p className="break-words text-[10px] text-muted-foreground leading-relaxed">{bearCase}</p>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Exact Surface
- File: hushh-webapp/components/kai/views/streaming-progress-view.tsx
- Component: StreamingProgressView
- Lines changed: 231, 240

## Caller Proof
- Caller: hushh-webapp/components/kai/agent-analysis-card.tsx imports StreamingProgressView from hushh-webapp/components/kai/views/streaming-progress-view.tsx
- Route: /kai/analysis via hushh-webapp/app/kai/analysis/page.tsx

## No Overlap Proof
- This change does not exist anywhere else: confirmed

## Narrowness Proof
- 1 file changed
- Zero props or API changed
- Change limited to adding break-words to the Bull Case and Bear Case text paragraphs.