### PR TITLE
test(auth-legal-dialog): cover external document link accessibility

### DIFF
--- a/hushh-webapp/__tests__/onboarding/auth-legal-dialog.test.tsx
+++ b/hushh-webapp/__tests__/onboarding/auth-legal-dialog.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AuthLegalDialog } from "@/components/onboarding/AuthLegalDialog";
+
+describe("AuthLegalDialog", () => {
+  it("renders accessible close button", () => {
+    render(
+      <AuthLegalDialog
+        docType="privacy"
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: /close legal document/i,
+      }),
+    ).toBeTruthy();
+  });
+
+  it("renders external document link", () => {
+    render(
+      <AuthLegalDialog
+        docType="privacy"
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    const link = screen.getByRole("link", {
+      name: /open in browser/i,
+    });
+
+    expect(link).toBeTruthy();
+    expect(link.getAttribute("target")).toBe("_blank");
+  });
+});

--- a/hushh-webapp/__tests__/ui/dialog.test.tsx
+++ b/hushh-webapp/__tests__/ui/dialog.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+describe("DialogContent", () => {
+  it("renders the close button by default", () => {
+    render(
+      <Dialog open>
+        <DialogContent>
+          <DialogTitle>Test dialog</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    expect(screen.getByRole("button", { name: /close/i })).toBeTruthy();
+  });
+
+  it("hides the close button when showCloseButton is false", () => {
+    render(
+      <Dialog open>
+        <DialogContent showCloseButton={false}>
+          <DialogTitle>Test dialog</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    expect(screen.queryByRole("button", { name: /close/i })).toBeNull();
+  });
+});


### PR DESCRIPTION
Summary
- Added coverage for AuthLegalDialog accessibility behavior.
- Verified the close button exposes an accessible label.
- Verified external document links remain accessible and open in a new tab.

Test
- npx vitest run __tests__/onboarding/auth-legal-dialog.test.tsx