### PR TITLE
test(auth-legal-dialog): cover terms document link target

### DIFF
--- a/hushh-webapp/__tests__/onboarding/auth-legal-dialog.test.tsx
+++ b/hushh-webapp/__tests__/onboarding/auth-legal-dialog.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AuthLegalDialog } from "@/components/onboarding/AuthLegalDialog";
+
+describe("AuthLegalDialog", () => {
+  it("renders terms document link target", () => {
+    render(
+      <AuthLegalDialog
+        docType="terms"
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    const link = screen.getByRole("link", {
+      name: /open in browser/i,
+    });
+
+    expect(link.getAttribute("href")).toBe("https://www.hushh.ai/terms");
+    expect(screen.getByTitle("Terms")).toBeTruthy();
+  });
+});

--- a/hushh-webapp/__tests__/ui/dialog.test.tsx
+++ b/hushh-webapp/__tests__/ui/dialog.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+describe("DialogContent", () => {
+  it("renders the close button by default", () => {
+    render(
+      <Dialog open>
+        <DialogContent>
+          <DialogTitle>Test dialog</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    expect(screen.getByRole("button", { name: /close/i })).toBeTruthy();
+  });
+
+  it("hides the close button when showCloseButton is false", () => {
+    render(
+      <Dialog open>
+        <DialogContent showCloseButton={false}>
+          <DialogTitle>Test dialog</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    expect(screen.queryByRole("button", { name: /close/i })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds test coverage for the Terms document link in `AuthLegalDialog`.

### Changes Made

* Added a test to verify the Terms document link renders correctly.
* Verified the link points to the expected Terms URL.
* Verified the Terms document iframe title is rendered.
* Extended onboarding legal dialog coverage for document-specific behavior.

## Test

```bash
npx vitest run __tests__/onboarding/auth-legal-dialog.test.tsx
```
