### PR TITLE
test(voice): drop empty raw action frames from screen context

### DIFF
--- a/hushh-webapp/__tests__/voice/screen-context-builder.test.ts
+++ b/hushh-webapp/__tests__/voice/screen-context-builder.test.ts
@@ -256,6 +256,19 @@ describe("buildStructuredScreenContext", () => {
     );
   });
 
+  it("drops empty raw available action frames before building screen context", () => {
+    const context = buildStructuredScreenContext({
+      appRuntimeState: makeRuntimeState("/kai", "kai_home"),
+      voiceContext: {
+        available_actions: ["", "   ", "Open Kai"],
+      },
+    });
+
+    expect(context.ui.available_actions).toContain("Open Kai");
+    expect(context.ui.available_actions).not.toContain("");
+    expect(context.ui.available_actions).not.toContain("   ");
+  });
+
   it("prefers explicit published surface metadata and exposes available actions", () => {
     window.history.pushState({}, "", "/profile/receipts");
     publishVoiceSurfaceMetadata("test_surface", {


### PR DESCRIPTION
## Summary
Adds a narrow Kai voice screen-context test proving that `buildStructuredScreenContext` drops empty raw `voiceContext.available_actions` frames before they enter `ui.available_actions`.

## Canonical attachment plan
- **Target Package/Module:** `hushh-webapp/lib/voice/screen-context-builder.ts`
- **Production function exercised:** `buildStructuredScreenContext`
- **Observed contract:** raw `voiceContext.available_actions` values are filtered through the structured context string-normalization path before planner payload construction
- **Existing companion test file:** `hushh-webapp/__tests__/voice/screen-context-builder.test.ts`
- **Execution validation track:** Kai voice / Web unit test via Vitest

## Impact Map (Required)
- **Routes touched:** None
- **Runtime code touched:** None
- **Tests touched:** `hushh-webapp/__tests__/voice/screen-context-builder.test.ts`

## Privacy & Consent
- **Does this change access user data?** No
- **Sensitive surface touched:** None; test-only coverage of existing voice screen-context normalization

## Review-Ready Contract
- **Title, body, changed files, and tests describe the same contract:** Yes
- **Concrete attachment plan proved:** Yes; builds screen context from raw voice context and verifies normalized `ui.available_actions`
- **Surface alignment:** Yes; one additive test in the existing screen-context builder companion test file
- **Capability overlap avoided:** Yes; this covers raw available-action frame pruning instead of another direct invalid-array helper assertion

## Testing
- `npm test -- __tests__/voice/screen-context-builder.test.ts`
- DCO signed commit included