### PR TITLE
test(voice): trim oversized visible module labels in screen context

### DIFF
--- a/hushh-webapp/__tests__/voice/screen-context-builder.test.ts
+++ b/hushh-webapp/__tests__/voice/screen-context-builder.test.ts
@@ -210,6 +210,23 @@ describe("buildStructuredScreenContext", () => {
     );
   });
 
+  it("trims oversized DOM visible module labels before adding them to screen context", () => {
+    const longModuleLabel = `Portfolio ${"A".repeat(120)}`;
+    window.history.pushState({}, "", "/profile?tab=account");
+    document.body.innerHTML = `
+      <h1>Profile Settings</h1>
+      <section data-voice-module="${longModuleLabel}"></section>
+    `;
+
+    const context = buildStructuredScreenContext({
+      appRuntimeState: makeRuntimeState("/profile", "profile"),
+      voiceContext: {},
+    });
+
+    expect(context.ui.visible_modules).toContain(longModuleLabel.slice(0, 64));
+    expect(context.ui.visible_modules).not.toContain(longModuleLabel);
+  });
+
   it("caps multi-source context arrays before they enter the voice planner payload", () => {
     const oversizedActions = Array.from({ length: 12 }, (_, index) => ({
       id: `action_${index}`,


### PR DESCRIPTION
## Summary
Adds a narrow Kai voice screen-context test proving that `buildStructuredScreenContext` trims an oversized DOM `data-voice-module` label before adding it to `ui.visible_modules`.

## Canonical attachment plan
- **Target Package/Module:** `hushh-webapp/lib/voice/screen-context-builder.ts`
- **Production function exercised:** `buildStructuredScreenContext`
- **Observed contract:** DOM visible module collection trims long module labels before they enter the structured screen context payload
- **Existing companion test file:** `hushh-webapp/__tests__/voice/screen-context-builder.test.ts`
- **Execution validation track:** Kai voice / Web unit test via Vitest

## Impact Map (Required)
- **Routes touched:** None
- **Runtime code touched:** None
- **Tests touched:** `hushh-webapp/__tests__/voice/screen-context-builder.test.ts`

## Privacy & Consent
- **Does this change access user data?** No
- **Sensitive surface touched:** None; test-only coverage of existing voice screen-context DOM metadata normalization

## Review-Ready Contract
- **Title, body, changed files, and tests describe the same contract:** Yes
- **Concrete attachment plan proved:** Yes; builds screen context from DOM metadata and verifies the normalized `ui.visible_modules` payload
- **Surface alignment:** Yes; one additive test in the existing screen-context builder companion test file
- **Capability overlap avoided:** Yes; this covers DOM visible module label trimming instead of another direct single-item array assertion

## Testing
- `npm test -- __tests__/voice/screen-context-builder.test.ts`
- DCO signed commit included