### PR TITLE
test(api): normalize whitespace-padded request timestamps before fetch

### DIFF
--- a/hushh-webapp/__tests__/services/api-service-fetch.test.ts
+++ b/hushh-webapp/__tests__/services/api-service-fetch.test.ts
@@ -128,6 +128,25 @@ describe("ApiService.apiFetch", () => {
     nowSpy.mockRestore();
   });
 
+  it("normalizes whitespace-padded request timestamp headers before fetch", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
+    const validTimestamp = 1_716_499_999_750;
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_716_500_000_000);
+
+    await ApiService.apiFetch("/api/ping", {
+      method: "GET",
+      headers: {
+        [REQUEST_TIMESTAMP_HEADER]: ` \t ${validTimestamp} \n `,
+      },
+    });
+
+    const [, fetchOptions] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const headers = fetchOptions.headers as Record<string, string>;
+    expect(headers[REQUEST_TIMESTAMP_HEADER]).toBe(String(validTimestamp));
+
+    nowSpy.mockRestore();
+  });
+
   it("retries with a fresh Firebase token on 401 and adds X-Hushh-Auth-Refresh-Retry header", async () => {
     const freshToken = "fresh-firebase-token-xyz";
     (AuthService.getIdToken as ReturnType<typeof vi.fn>).mockResolvedValueOnce(freshToken);


### PR DESCRIPTION
## Summary
Adds a narrow API service test proving that `ApiService.apiFetch` normalizes whitespace-padded `x-request-timestamp-ms` header values before sending the fetch request.

## Canonical attachment plan
- **Target Package/Module:** `hushh-webapp/lib/services/api-service.ts`
- **Production function exercised:** `ApiService.apiFetch`
- **Observed helper contract:** `getOrCreateRequestTimestampMs` from `hushh-webapp/lib/observability/request-id.ts` supplies the normalized outbound timestamp
- **Existing companion test file:** `hushh-webapp/__tests__/services/api-service-fetch.test.ts`
- **Execution validation track:** Web service unit test via Vitest

## Impact Map (Required)
- **Routes touched:** None
- **Runtime code touched:** None
- **Tests touched:** `hushh-webapp/__tests__/services/api-service-fetch.test.ts`

## Privacy & Consent
- **Does this change access user data?** No
- **Sensitive surface touched:** None; test-only coverage of existing request metadata normalization

## Review-Ready Contract
- **Title, body, changed files, and tests describe the same contract:** Yes
- **Concrete attachment plan proved:** Yes; exercises `ApiService.apiFetch` and verifies the outbound request timestamp header
- **Surface alignment:** Yes; one additive test in the existing API service fetch companion test file
- **Capability overlap avoided:** Yes; this covers runtime outbound header normalization instead of another isolated parser assertion

## Testing
- `npm test -- __tests__/services/api-service-fetch.test.ts`
- DCO signed commit included