### PR TITLE
test(voice): preserve unicode action aliases in screen context metadata

### DIFF
--- a/hushh-webapp/__tests__/voice/screen-context-builder.test.ts
+++ b/hushh-webapp/__tests__/voice/screen-context-builder.test.ts
@@ -666,6 +666,29 @@ describe("buildStructuredScreenContext", () => {
     expect(control?.voice_aliases).toHaveLength(STRUCTURED_CONTEXT_ARRAY_CAP);
   });
 
+  it("preserves multi-byte unicode action aliases from published voice surface metadata", () => {
+    const unicodeAlias = "🎙️✨🚀_voice_frame_𝓤𝓝𝓘𝓒𝓞𝓓𝓔";
+
+    publishVoiceSurfaceMetadata("test_surface", {
+      actions: [
+        {
+          id: "unicode-action",
+          label: "Unicode Action",
+          voiceAliases: [unicodeAlias],
+        },
+      ],
+    });
+
+    const context = buildStructuredScreenContext({
+      appRuntimeState: makeRuntimeState("/kai", "kai_home"),
+      voiceContext: {},
+    });
+
+    const action = context.surface.actions.find((item) => item.id === "unicode-action");
+    expect(action).toBeDefined();
+    expect(action?.voice_aliases).toContain(unicodeAlias);
+  });
+
   it("clamps oversized concept aliases in nested concept definitions", () => {
     publishVoiceSurfaceMetadata("test_surface", {
       concepts: [


### PR DESCRIPTION
## Summary
Adds a narrow Kai voice screen-context test proving that `buildStructuredScreenContext` preserves a multi-byte unicode `voiceAliases` value published through voice surface action metadata.

## Canonical attachment plan
- **Target Package/Module:** `hushh-webapp/lib/voice/screen-context-builder.ts`
- **Production functions exercised:** `buildStructuredScreenContext` and its action metadata alias normalization path
- **Published metadata source:** `hushh-webapp/lib/voice/voice-surface-metadata.ts`
- **Existing companion test file:** `hushh-webapp/__tests__/voice/screen-context-builder.test.ts`
- **Execution validation track:** Kai voice / Web unit test via Vitest

## Impact Map (Required)
- **Routes touched:** None
- **Runtime code touched:** None
- **Tests touched:** `hushh-webapp/__tests__/voice/screen-context-builder.test.ts`

## Privacy & Consent
- **Does this change access user data?** No
- **Sensitive surface touched:** None; test-only coverage of existing voice surface metadata normalization

## Review-Ready Contract
- **Title, body, changed files, and tests describe the same contract:** Yes
- **Concrete attachment plan proved:** Yes; publishes action metadata and exercises the production screen-context builder
- **Surface alignment:** Yes; one additive test in the existing screen-context builder companion test file
- **Capability overlap avoided:** Yes; this covers published action alias ingestion instead of another direct one-item array cap assertion

## Testing
- `npm test -- __tests__/voice/screen-context-builder.test.ts`
- DCO signed commit included