### PR TITLE
test(navigation): verify app route layout matching on redundant slashes

### DIFF
--- a/hushh-webapp/__tests__/navigation/app-route-layout.test.ts
+++ b/hushh-webapp/__tests__/navigation/app-route-layout.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveAppRouteLayoutMode } from "@/lib/navigation/app-route-layout";
+
+describe("app route layout", () => {
+  it("matches the RIA clients layout contract across redundant slash separators", () => {
+    expect(resolveAppRouteLayoutMode("/ria////clients")).toBe("standard");
+  });
+});


### PR DESCRIPTION
## Summary
Adds a narrow app route layout test proving that `resolveAppRouteLayoutMode` matches the documented RIA clients route layout when the incoming pathname contains redundant slash separators.

## Canonical attachment plan
- **Target Package/Module:** `hushh-webapp/lib/navigation/app-route-layout.ts`
- **Production function exercised:** `resolveAppRouteLayoutMode`
- **Generated/static contract exercised:** `hushh-webapp/lib/navigation/app-route-layout.contract.json`
- **Existing route contract:** `/ria/clients`
- **Companion test file:** `hushh-webapp/__tests__/navigation/app-route-layout.test.ts`
- **Execution validation track:** Web unit test via Vitest

## Impact Map (Required)
- **Routes touched:** None
- **Runtime code touched:** None
- **Tests touched:** `hushh-webapp/__tests__/navigation/app-route-layout.test.ts`

## Privacy & Consent
- **Does this change access user data?** No
- **Sensitive surface touched:** None; test-only coverage of an existing route layout resolver

## Review-Ready Contract
- **Title, body, changed files, and tests describe the same contract:** Yes
- **Concrete attachment plan proved:** Yes; imports and exercises `resolveAppRouteLayoutMode` from the production navigation module
- **Surface alignment:** Yes; one additive companion test for the app route layout resolver

## Testing
- `npm test -- __tests__/navigation/app-route-layout.test.ts`
- DCO signed commit included