### PR TITLE
test(one-kyc): verify scoped export wrapping algorithm fallback

### DIFF
--- a/hushh-webapp/__tests__/services/one-kyc-client-zk-service.test.ts
+++ b/hushh-webapp/__tests__/services/one-kyc-client-zk-service.test.ts
@@ -841,6 +841,33 @@ describe("ZK preflight — non-compliant and structurally empty payload rejectio
     // NOT "different client connector" — algorithm gate fires first.
   });
 
+  it("uses the canonical wrapping algorithm fallback when the export omits wrapping_alg", async () => {
+    let error: unknown;
+
+    try {
+      await OneKycClientZkService.decryptScopedExport({
+        connector,
+        exportPackage: {
+          encrypted_data: "",
+          iv: "",
+          tag: "",
+          wrapped_key_bundle: {
+            wrapped_export_key: "",
+            wrapped_key_iv: "",
+            wrapped_key_tag: "",
+            sender_public_key: "",
+            connector_key_id: connector.connector_key_id,
+          },
+        },
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).not.toContain("Unsupported KYC export wrapping algorithm");
+  });
+
   // ── Structurally empty crypto payload ─────────────────────────────────────
 
   it("rejects a package with empty crypto fields — preflight passes but crypto fails", async () => {


### PR DESCRIPTION
## Summary
Adds a narrow One KYC client-side ZK service test proving that `OneKycClientZkService.decryptScopedExport` uses the canonical wrapping algorithm fallback when a scoped export omits `wrapped_key_bundle.wrapping_alg`, instead of treating the missing field as an unsupported algorithm.

## Canonical attachment plan
- **Target Package/Module:** `hushh-webapp/lib/services/one-kyc-client-zk-service.ts`
- **Production function exercised:** `OneKycClientZkService.decryptScopedExport`
- **Observed contract:** missing `wrapped_key_bundle.wrapping_alg` falls back to `KYC_CONNECTOR_WRAPPING_ALG` before downstream crypto handling
- **Existing companion test file:** `hushh-webapp/__tests__/services/one-kyc-client-zk-service.test.ts`
- **Execution validation track:** Web unit test via Vitest

## Impact Map (Required)
- **Routes touched:** None
- **Runtime code touched:** None
- **Tests touched:** `hushh-webapp/__tests__/services/one-kyc-client-zk-service.test.ts`

## Privacy & Consent
- **Does this change access user data?** No
- **Sensitive surface touched:** None; test-only coverage of an existing client-side export decryption guard

## Review-Ready Contract
- **Title, body, changed files, and tests describe the same contract:** Yes
- **Concrete attachment plan proved:** Yes; imports and exercises `OneKycClientZkService.decryptScopedExport` from the production service module
- **Surface alignment:** Yes; one additive test in the existing One KYC client ZK service companion test file
- **Capability overlap avoided:** Yes; this covers the missing-field fallback path rather than adding another unsupported-algorithm value to existing rejection tests

## Testing
- `npm test -- __tests__/services/one-kyc-client-zk-service.test.ts`
- DCO signed commit included