### PR TITLE
test(runtime): normalize carriage return layout sequences in config parser

### DIFF
--- a/hushh-webapp/__tests__/lib/runtime-settings.test.ts
+++ b/hushh-webapp/__tests__/lib/runtime-settings.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { resolveRuntimeBackendUrl } from "@/lib/runtime/settings";
+
+describe("runtime settings", () => {
+  const originalBackendUrl = process.env.BACKEND_URL;
+  const originalPublicBackendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+
+  afterEach(() => {
+    process.env.BACKEND_URL = originalBackendUrl;
+    process.env.NEXT_PUBLIC_BACKEND_URL = originalPublicBackendUrl;
+  });
+
+  it("normalizes carriage return line endings around runtime backend urls", () => {
+    process.env.BACKEND_URL = "\r\nhttps://runtime.example.com///\r\n";
+    process.env.NEXT_PUBLIC_BACKEND_URL = "";
+
+    expect(resolveRuntimeBackendUrl()).toBe("https://runtime.example.com");
+  });
+});


### PR DESCRIPTION
## Summary
Adds a distinct, narrow unit test to verify that the runtime settings utility normalizes configuration strings containing explicit carriage return line-break formatting segments around backend URL values.

## Production function exercised
- `hushh-webapp/lib/runtime/settings.ts` targeting `resolveRuntimeBackendUrl`

## CI gate checklist
- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO — Signed-off-by: Abdul Rashid <abdulbeast4@gmail.com>
- [x] Narrow surface — limits execution to one exported runtime settings resolver
- [x] Clean diff — 1 test file, minimal additive coverage, fresh upstream base
- [x] Proof — `npm test -- __tests__/lib/runtime-settings.test.ts` passed locally