### PR TITLE
test(observability): drop nested array endpoint templates from api events

### DIFF
--- a/hushh-webapp/__tests__/services/observability-schema.test.ts
+++ b/hushh-webapp/__tests__/services/observability-schema.test.ts
@@ -23,6 +23,26 @@ describe("observability schema", () => {
     expect(result.sanitized.endpoint_template).toBe("/api/kai/analyze/run/start");
   });
 
+  it("drops a nested array endpoint template from api request events", () => {
+    const result = validateAndSanitizeEvent("api_request_completed", {
+      env: "uat",
+      platform: "web",
+      event_category: "system",
+      app_version: "2.1.0",
+      route_id: "kai_dashboard",
+      endpoint_template: [[[["deep_nested_structural_token"]]]],
+      http_method: "POST",
+      result: "success",
+      status_bucket: "2xx",
+      duration_ms_bucket: "100ms_300ms",
+    } as any);
+
+    expect(result.ok).toBe(false);
+    expect(result.droppedKeys).toContain("endpoint_template");
+    expect(result.sanitized.endpoint_template).toBeUndefined();
+    expect(result.sanitized.route_id).toBe("kai_dashboard");
+  });
+
   it("preserves endpoint template sanitization", () => {
   const result = validateAndSanitizeEvent("api_request_completed", {
     env: "uat",


### PR DESCRIPTION
## Summary
Adds a narrow observability schema test proving that `validateAndSanitizeEvent` drops a nested array value supplied to the documented `api_request_completed.endpoint_template` field while preserving valid sibling metadata.

## Canonical attachment plan
- **Target Package/Module:** `hushh-webapp/lib/observability/schema.ts`
- **Production function exercised:** `validateAndSanitizeEvent`
- **Documented event contract:** `api_request_completed.endpoint_template` from `docs/reference/operations/observability-event-matrix.md`
- **Existing companion test file:** `hushh-webapp/__tests__/services/observability-schema.test.ts`
- **Execution validation track:** Web unit test via Vitest

## Impact Map (Required)
- **Routes touched:** None
- **Runtime code touched:** None
- **Tests touched:** `hushh-webapp/__tests__/services/observability-schema.test.ts`

## Privacy & Consent
- **Does this change access user data?** No
- **Sensitive surface touched:** None; test-only coverage of an existing observability schema validator

## Review-Ready Contract
- **Title, body, changed files, and tests describe the same contract:** Yes
- **Concrete attachment plan proved:** Yes; imports and exercises `validateAndSanitizeEvent` from the production observability schema module
- **Surface alignment:** Yes; one additive test in the existing observability schema companion test file

## Testing
- `npm test -- __tests__/services/observability-schema.test.ts`
- DCO signed commit included