### PR TITLE
test(one-kyc): preserve maximum safe workflow list limit serialization

### DIFF
--- a/hushh-webapp/__tests__/services/one-kyc-service.test.ts
+++ b/hushh-webapp/__tests__/services/one-kyc-service.test.ts
@@ -101,6 +101,24 @@ describe("OneKycService", () => {
     );
   });
 
+  it("serializes a maximum safe integer workflow list limit without coercion", async () => {
+    await OneKycService.listWorkflows({
+      userId: "user_1",
+      vaultOwnerToken: "vault-token",
+      limit: Number.MAX_SAFE_INTEGER,
+    });
+
+    expect(mockApiJson).toHaveBeenCalledWith(
+      `/api/one/kyc/workflows?user_id=user_1&limit=${Number.MAX_SAFE_INTEGER}`,
+      {
+        headers: {
+          Authorization: "Bearer vault-token",
+          "Content-Type": "application/json",
+        },
+      },
+    );
+  });
+
   it("syncs recent One mailbox messages before refreshing the request list", async () => {
     await OneKycService.syncRecentEmails({
       userId: "user_1",


### PR DESCRIPTION
## Summary
Adds a narrow One KYC service test proving that `OneKycService.listWorkflows` serializes a `Number.MAX_SAFE_INTEGER` workflow list limit into the generated request URL without coercing or dropping the value.

## Canonical attachment plan
- **Target Package/Module:** `hushh-webapp/lib/services/one-kyc-service.ts`
- **Production function exercised:** `OneKycService.listWorkflows`
- **Observed contract:** workflow list query construction preserves the provided `limit` value in the API request path
- **Execution validation track:** Web unit test via Vitest

## Impact Map (Required)
- **Routes touched:** None
- **Runtime code touched:** None
- **Tests touched:** `hushh-webapp/__tests__/services/one-kyc-service.test.ts`

## Privacy & Consent
- **Does this change access user data?** No
- **Sensitive surface touched:** None; test-only coverage of an existing service query builder

## Review-Ready Contract
- **Title, body, changed files, and tests describe the same contract:** Yes
- **Concrete attachment plan proved:** Yes; imports and exercises `OneKycService.listWorkflows` from the production service module
- **Surface alignment:** Yes; one additive test in the existing companion service test file

## Testing
- `npm test -- __tests__/services/one-kyc-service.test.ts`
- DCO signed commit included