### PR TITLE
style: align Kai real-route heading font

### DIFF
--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1016,7 +1016,7 @@ html.native-ios {
 
   .app-page-shell h1,
   .app-page-shell [role="heading"][aria-level="1"] {
-    font-family: var(--font-sans), system-ui, sans-serif;
+    font-family: var(--font-heading), var(--font-sans), system-ui, sans-serif;
     font-size: clamp(1.9rem, 4.8vw, 2rem) !important;
     line-height: 1.08 !important;
     font-weight: 600 !important;


### PR DESCRIPTION
## Summary
- aligns signed-in real-route page heading typography to the shared Inter heading token
- keeps the existing 600 weight, normal tracking, sizing, nav/search/agent geometry, and backend behavior unchanged

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run verify:design-system`
- `git diff --check` (CRLF warning only)

## UAT follow-up
After merge to main, deploy `scope=frontend` and rerun the same Kai route integrity probe.
