### PR TITLE
Promote Kai heading font alignment to main

### DIFF
--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1016,7 +1016,7 @@ html.native-ios {
 
   .app-page-shell h1,
   .app-page-shell [role="heading"][aria-level="1"] {
-    font-family: var(--font-sans), system-ui, sans-serif;
+    font-family: var(--font-heading), var(--font-sans), system-ui, sans-serif;
     font-size: clamp(1.9rem, 4.8vw, 2rem) !important;
     line-height: 1.08 !important;
     font-weight: 600 !important;


### PR DESCRIPTION
## Summary
- promotes the Kai real-route heading font-family alignment from integration to main
- keeps nav/search/agent geometry unchanged
- frontend-only CSS token change; no backend/API changes

## Validation
- PR #2664 checks passed after DCO signoff amend
- local checks passed: lint, typecheck, design-system verification, diff check with CRLF warning only

## UAT plan
- deploy `scope=frontend` from the resulting green main SHA
- rerun signed-in Kai route integrity probe for typography and dock geometry
