### PR TITLE
test(api): preserve colon-delimited custom request header values

### DIFF
--- a/hushh-webapp/__tests__/api/request-id-headers.test.ts
+++ b/hushh-webapp/__tests__/api/request-id-headers.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { createUpstreamHeaders } from "@/app/api/_utils/request-id";
+import { REQUEST_ID_HEADER } from "@/lib/observability/request-id";
+
+describe("createUpstreamHeaders", () => {
+  it("preserves colon-delimited custom header values when creating upstream request headers", () => {
+    const compoundHeaderValue = "tier1:component:auth-proxy-relay";
+    const headers = createUpstreamHeaders("req_network_123", {
+      "X-Hushh-Custom-Metadata": compoundHeaderValue,
+    });
+
+    expect(headers.get(REQUEST_ID_HEADER)).toBe("req_network_123");
+    expect(headers.get("X-Hushh-Custom-Metadata")).toBe(compoundHeaderValue);
+  });
+});


### PR DESCRIPTION
## Summary
Adds a narrow API utility test proving that `createUpstreamHeaders` preserves colon-delimited custom header values while attaching the canonical request id header.

## Production function exercised
- `hushh-webapp/app/api/_utils/request-id.ts` targeting `createUpstreamHeaders`

## CI gate checklist
- [x] PR Base Policy - targets `integration/pr-train`
- [x] DCO - Signed-off-by: Abdul Rashid <abdulbeast4@gmail.com>
- [x] Narrow surface - exercises one exported API header serialization helper
- [x] Clean diff - 1 test file, minimal additive coverage, fresh upstream base
- [x] Proof - `npm test -- __tests__/api/request-id-headers.test.ts` passed locally