### PR TITLE
style: preserve Kai heading font fallback

### DIFF
--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -107,7 +107,7 @@ a, button, input, select, textarea {
    * Next/font sets these variables at runtime from app/layout.tsx.
    * Keep names semantic so future font swaps only need layout.tsx changes. */
   --font-app-body: system-ui, sans-serif;
-  --font-app-heading: system-ui, sans-serif;
+  --font-app-heading: Inter, "Inter Fallback", system-ui, sans-serif;
   --font-app-mono: ui-monospace, monospace;
 
   /* Runtime CSS variable fallbacks for dynamic primitives/charts. */


### PR DESCRIPTION
## What changed
- Keeps the shared Kai/app heading fallback on Inter instead of raw system-ui.
- Preserves the existing Next/font runtime variables and only improves the fallback path used by signed-in real routes.

## Why
- UAT visual integrity passed nav/search/agent geometry, but real signed-in routes still computed page-title family as system-ui while preview routes computed Inter.
- This keeps the Apple-like typography philosophy consistent across preview and real Kai/Profile pages without touching backend behavior, data fetching, route links, CTAs, or search/agent wiring.

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run verify:design-system`
- `git diff --check`
