### PR TITLE
Promote Kai heading font fallback to main

### DIFF
--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -107,7 +107,7 @@ a, button, input, select, textarea {
    * Next/font sets these variables at runtime from app/layout.tsx.
    * Keep names semantic so future font swaps only need layout.tsx changes. */
   --font-app-body: system-ui, sans-serif;
-  --font-app-heading: system-ui, sans-serif;
+  --font-app-heading: Inter, "Inter Fallback", system-ui, sans-serif;
   --font-app-mono: ui-monospace, monospace;
 
   /* Runtime CSS variable fallbacks for dynamic primitives/charts. */


### PR DESCRIPTION
## What changed
- Promotes the focused Kai heading font fallback fix from integration to main.

## Why
- UAT visual integrity found signed-in real-route titles using system-ui while preview pages used Inter.
- This keeps real Kai/Profile route typography aligned with the approved Apple-like direction before the next UAT deploy.

## Validation
- PR #2667 checks passed: Web, Integration, DCO, Secret Scan, Governance, Base Freshness, Upstream Sync, CI Status Gate.
- Local validation on the source PR: `npm run lint`, `npm run typecheck`, `npm run verify:design-system`, `git diff --check`.

## Deploy
- After merge, deploy UAT with `scope=frontend` from the resulting green main SHA.
