### PR TITLE
fix(ui): hide settings row decorative icons and chevrons from assistive technology

### DIFF
--- a/hushh-webapp/components/app-ui/settings-ui.tsx
+++ b/hushh-webapp/components/app-ui/settings-ui.tsx
@@ -214,7 +214,7 @@ export function SettingsRow({
             tone === "destructive" && "bg-destructive/10 text-destructive"
           )}
         >
-          <Icon icon={icon} size="md" />
+          <Icon icon={icon} size="md" aria-hidden="true" />
         </span>
       ) : null}
       <div className="min-w-0 flex-1 space-y-0.5">
@@ -245,6 +245,7 @@ export function SettingsRow({
       {trailing}
       {chevron ? (
         <ChevronRight
+          aria-hidden="true"
           className={cn(
             "h-4 w-4 shrink-0 text-muted-foreground/90 transition-transform",
             isInteractive && "group-hover:translate-x-0.5"


### PR DESCRIPTION
## Summary
- Add `aria-hidden=true` to the existing decorative `SettingsRow` leading icon.
- Add `aria-hidden=true` to the existing decorative `SettingsRow` chevron.
- Preserve row labels, descriptions, click handling, trailing controls, and visual styling.

## Exact Surface
- Changed file: `hushh-webapp/components/app-ui/settings-ui.tsx`
- Changed component: `SettingsRow`
- Changed nodes: the `Icon icon={icon}` rendered for row leading icons and the optional `ChevronRight` rendered when `chevron` is true.
- Rendered surface: settings rows that use the shared `SettingsRow` primitive.

## Caller Proof
- `SettingsRow` is exported from `components/app-ui/settings-ui.tsx`.
- It is re-exported through `components/profile/settings-ui.tsx` for profile-style settings surfaces.
- Route/page callers import the shared settings primitives, including `app/profile/page.tsx`, `app/one/kyc/page.tsx`, `app/one/location/page.tsx`, `app/ria/clients/page.tsx`, and `app/ria/picks/page.tsx`.
- Component callers also import the wrapper, including `components/consent/consent-center-page.tsx`, `components/ria/ria-client-workspace.tsx`, `components/ria/ria-client-request-detail.tsx`, `components/ria/ria-client-account-detail.tsx`, and `components/kai/views/investments-master-view.tsx`.

## Narrowness Proof
- One frontend file changed.
- Two JSX attributes added to two existing decorative icons.
- No settings row structure, labels, descriptions, trailing content, click behavior, voice metadata, ripple behavior, hook, helper, utility, provider, route handler, backend, cache, governance, PKM, vault, consent, or generated file changed.
- No shared icon implementation or Lucide icon source changed.

## Overlap Check
- Existing `aria-hidden` in this component applied only to interaction overlay spans.
- The `SettingsRow` leading icon and chevron did not already have `aria-hidden`.
- The change is limited to lines inside `SettingsRow`; it does not touch any route/page caller.

## Validation
- `npx.cmd vitest run __tests__/components/settings-ui.test.tsx`