### PR TITLE
fix(app-sidebar): hide decorative navigation icons

### DIFF
--- a/hushh-webapp/components/dashboard/app-sidebar.tsx
+++ b/hushh-webapp/components/dashboard/app-sidebar.tsx
@@ -58,7 +58,7 @@ export function AppSidebar() {
                   className="md:h-12 md:text-base font-semibold"
                 >
                   <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary text-primary-foreground">
-                    <Icon icon={Home} size="sm" />
+                    <Icon icon={Home} size="sm" aria-hidden="true" />
                   </div>
                   <span className="ml-2">Kai</span>
                 </SidebarMenuButton>
@@ -81,7 +81,7 @@ export function AppSidebar() {
                 return (
                   <SidebarMenuItem key={domain.href}>
                     <SidebarMenuButton href={domain.href} isActive={isActive}>
-                      <Icon icon={DomainIcon} size="sm" />
+                      <Icon icon={DomainIcon} size="sm" aria-hidden="true" />
                       <span>{domain.name}</span>
                     </SidebarMenuButton>
                     {domain.status === "soon" && (
@@ -104,7 +104,7 @@ export function AppSidebar() {
                   href="/consents"
                   isActive={pathname === "/consents"}
                 >
-                  <Icon icon={Shield} size="sm" />
+                  <Icon icon={Shield} size="sm" aria-hidden="true" />
                   <span>Consents</span>
                 </SidebarMenuButton>
                 {pendingCount > 0 && (


### PR DESCRIPTION
## Exact Surface
- File: hushh-webapp/components/dashboard/app-sidebar.tsx
- Component: AppSidebar
- Lines changed: 61, 82, 105

## Caller Proof
- Caller: none found in the current tree; AppSidebar is exported but not imported or rendered by any route/layout/component.
- Route: none reachable until AppSidebar is mounted.

## No Overlap Proof
- This change does not exist anywhere else: confirmed

## Narrowness Proof
- 1 file changed
- Zero props or API changed
- Change limited to adding aria-hidden to the three decorative AppSidebar navigation icons.

## Reachability Finding
- Direct search for AppSidebar/app-sidebar only finds hushh-webapp/components/dashboard/app-sidebar.tsx.
- Because there is no reachable caller, frontend_component_without_reachable_caller cannot be honestly cleared by description alone.