### PR TITLE
fix(consent): guard console.log with NODE_ENV check in session-token route

### DIFF
--- a/hushh-webapp/app/api/consent/session-token/route.ts
+++ b/hushh-webapp/app/api/consent/session-token/route.ts
@@ -43,7 +43,9 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    console.log("[API] Issuing session token");
+    if (process.env.NODE_ENV !== "production") {
+      console.log("[API] Issuing session token");
+    }
 
     const response = await fetch(`${BACKEND_URL}/api/consent/issue-token`, {
       method: "POST",
@@ -64,7 +66,9 @@ export async function POST(request: NextRequest) {
     }
 
     const data = await response.json();
-    console.log(`[API] Session token issued, expires at: ${data.expiresAt}`);
+    if (process.env.NODE_ENV !== "production") {
+      console.log(`[API] Session token issued, expires at: ${data.expiresAt}`);
+    }
 
     return NextResponse.json(data);
   } catch (error) {


### PR DESCRIPTION
## Summary

- what changed: Wrapped two console.log calls with if (process.env.NODE_ENV !== "production") guard in hushh-webapp/app/api/consent/session-token/route.ts
- why it changed: The unguarded logs exposed session token issuance details and expiry time to server logs in production leaking internal consent flow details

## Attach point

hushh-webapp/app/api/consent/session-token/route.ts — session token issuance API route called after passphrase verification in the consent flow.

## Contract changed

Runtime behavior: session token issuance details and expiry time are no longer logged in production. Development and UAT logging is unchanged.

## Tests run

```bash
cd hushh-webapp && npx tsc --noEmit
```
Passed locally. No type errors.

## Base/head status

Branch is current with main, mergeable, and DCO-signed. Targets integration/pr-train as required by repo base policy.

## Sensitive proof

This PR improves the security boundary by suppressing session token details from server logs in production. No auth consent vault PKM finance or KYC behavior is changed. Rollback: revert by removing the NODE_ENV guards.

## Stack proof

Not applicable. Standalone fix, no predecessor PR.