### PR TITLE
fix(account): guard console.log with NODE_ENV check in account delete route

### DIFF
--- a/hushh-webapp/app/api/account/delete/route.ts
+++ b/hushh-webapp/app/api/account/delete/route.ts
@@ -17,7 +17,9 @@ export async function DELETE(request: NextRequest) {
     }
 
     const backendUrl = `${BACKEND_URL}/api/account/delete`;
-    console.log(`[API] Proxying account deletion to: ${backendUrl}`);
+    if (process.env.NODE_ENV !== "production") {
+      console.log(`[API] Proxying account deletion to: ${backendUrl}`);
+    }
 
     const response = await fetch(backendUrl, {
       method: "DELETE",
@@ -29,7 +31,9 @@ export async function DELETE(request: NextRequest) {
     });
 
     const responseText = await response.text();
-    console.log(`[API] Backend response status: ${response.status}`);
+    if (process.env.NODE_ENV !== "production") {
+      console.log(`[API] Backend response status: ${response.status}`);
+    }
 
     if (!response.ok) {
       console.error("[API] Backend error:", responseText);


### PR DESCRIPTION
## Summary

- what changed: Wrapped two console.log calls with if (process.env.NODE_ENV !== "production") guard in hushh-webapp/app/api/account/delete/route.ts
- why it changed: The unguarded logs exposed internal backend URL and response status to server logs in production leaking internal account deletion flow details

## Attach point

hushh-webapp/app/api/account/delete/route.ts — account deletion API route called when a user deletes their account.

## Contract changed

Runtime behavior: backend URL and response status are no longer logged in production. Development and UAT logging is unchanged.

## Tests run

```bash
cd hushh-webapp && npx tsc --noEmit
```
Passed locally. No type errors.

## Base/head status

Branch is current with main, mergeable, and DCO-signed. Targets integration/pr-train as required by repo base policy.

## Sensitive proof

This PR improves the security boundary by suppressing internal backend URL and response details from server logs in production. No auth consent vault PKM finance or KYC behavior is changed. Rollback: revert by removing the NODE_ENV guards.

## Stack proof

Not applicable. Standalone fix, no predecessor PR.