### PR TITLE
Polish Kai UI chrome and typography for UAT

### DIFF
--- a/hushh-webapp/__tests__/app/register-phone-safe-area.contract.test.ts
+++ b/hushh-webapp/__tests__/app/register-phone-safe-area.contract.test.ts
@@ -18,6 +18,6 @@ describe("/register-phone safe-area shell contract", () => {
     expect(source).toContain("pt-[var(--phone-mandate-safe-pt)]");
     expect(source).toContain("pb-[var(--phone-mandate-safe-pb)]");
     expect(source).not.toContain("4vh");
-    expect(source).toContain("min-h-[22rem]");
+    expect(source).toContain("min-h-[25rem]");
   });
 });

--- a/hushh-webapp/__tests__/components/agent-popover-provider.test.tsx
+++ b/hushh-webapp/__tests__/components/agent-popover-provider.test.tsx
@@ -3,8 +3,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AgentPopoverProvider } from "@/components/agent/agent-popover-provider";
 
+const navigationMock = vi.hoisted(() => ({
+  pathname: "/profile",
+}));
+
 vi.mock("next/navigation", () => ({
-  usePathname: () => "/kai",
+  usePathname: () => navigationMock.pathname,
 }));
 
 vi.mock("@/hooks/use-auth", () => ({
@@ -65,6 +69,7 @@ describe("AgentPopoverProvider floating trigger", () => {
   let getBoundingClientRectSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    navigationMock.pathname = "/profile";
     window.localStorage.clear();
     Object.defineProperty(window, "innerWidth", {
       configurable: true,
@@ -242,5 +247,21 @@ describe("AgentPopoverProvider floating trigger", () => {
     await waitFor(() => {
       expect(trigger.style.top).toBe("104px");
     });
+  });
+
+  it("does not render a duplicate floating trigger on Kai command-bar routes", () => {
+    navigationMock.pathname = "/kai";
+
+    render(
+      <div>
+        <div data-tour-id="kai-command-bar" />
+        <div aria-label="Main navigation" />
+        <AgentPopoverProvider>
+          <main />
+        </AgentPopoverProvider>
+      </div>
+    );
+
+    expect(screen.queryByRole("button", { name: "Open Agent" })).toBeNull();
   });
 });

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1246,10 +1246,10 @@ md-ripple.morphy-md-ripple {
   opacity: 1;
   background: linear-gradient(
     to top,
-    rgba(245, 245, 247, 0.17) 0%,
-    rgba(245, 245, 247, 0.13) 42%,
-    rgba(245, 245, 247, 0.07) 70%,
-    rgba(245, 245, 247, 0.024) 90%,
+    var(--app-bar-bottom-fade-strong, rgba(245, 245, 247, 0.17)) 0%,
+    var(--app-bar-bottom-fade-medium, rgba(245, 245, 247, 0.13)) 42%,
+    var(--app-bar-bottom-fade-soft, rgba(245, 245, 247, 0.07)) 70%,
+    var(--app-bar-bottom-fade-trace, rgba(245, 245, 247, 0.024)) 90%,
     transparent 100%
   );
 }
@@ -1257,10 +1257,10 @@ md-ripple.morphy-md-ripple {
 .dark .bar-glass-bottom::after {
   background: linear-gradient(
     to top,
-    rgba(28, 28, 30, 0.18) 0%,
-    rgba(28, 28, 30, 0.14) 42%,
-    rgba(28, 28, 30, 0.08) 70%,
-    rgba(28, 28, 30, 0.03) 90%,
+    var(--app-bar-bottom-fade-strong, rgba(28, 28, 30, 0.18)) 0%,
+    var(--app-bar-bottom-fade-medium, rgba(28, 28, 30, 0.14)) 42%,
+    var(--app-bar-bottom-fade-soft, rgba(28, 28, 30, 0.08)) 70%,
+    var(--app-bar-bottom-fade-trace, rgba(28, 28, 30, 0.03)) 90%,
     transparent 100%
   );
 }

--- a/hushh-webapp/app/kai/analysis/page.tsx
+++ b/hushh-webapp/app/kai/analysis/page.tsx
@@ -1079,18 +1079,18 @@ function KaiAnalysisPageContent() {
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <div className="flex items-center gap-3">
                   <SymbolAvatar symbol={activeTicker} name={activeTicker} size="lg" />
-                  <h1 className="text-2xl font-semibold tracking-normal text-foreground sm:text-3xl">
+                  <h1 className="text-[28px] font-medium tracking-normal text-foreground sm:text-[34px]">
                     {activeTicker}
                   </h1>
                 </div>
                 <div className="flex items-center gap-2">
-                  <span className="text-sm font-semibold tabular-nums text-muted-foreground sm:text-base">
+                  <span className="text-sm font-medium tabular-nums text-muted-foreground sm:text-base">
                     {headerPriceLabel}
                   </span>
                   {headerChangePct !== null ? (
                     <span
                       className={cn(
-                        "rounded px-1.5 py-0.5 text-xs font-semibold tabular-nums",
+                        "rounded px-1.5 py-0.5 text-xs font-medium tabular-nums",
                         headerChangePct >= 0
                           ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
                           : "bg-rose-500/10 text-rose-600 dark:text-rose-400"

--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -1198,10 +1198,10 @@ export default function MarketplacePage() {
           <RiaSurface className="space-y-3 p-4">
             <div className="flex items-center justify-between gap-3">
               <div className="min-w-0">
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                <p className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
                   Contacts
                 </p>
-                <h3 className="mt-1 line-clamp-1 text-base font-semibold tracking-tight text-foreground">
+                <h3 className="mt-1 line-clamp-1 text-base font-medium tracking-normal text-foreground">
                   Already on Hushh
                 </h3>
               </div>
@@ -1229,7 +1229,7 @@ export default function MarketplacePage() {
                     className="h-11 w-11 rounded-2xl"
                   />
                   <span className="min-w-0 flex-1">
-                    <span className="block line-clamp-1 text-sm font-semibold text-foreground">
+                    <span className="block line-clamp-1 text-sm font-medium text-foreground">
                       {match.display_name}
                     </span>
                     <span className="block line-clamp-1 text-xs text-muted-foreground">
@@ -1278,7 +1278,7 @@ export default function MarketplacePage() {
                       <ProfileAvatar kind={swipeCard.kind} label={swipeCard.title} className="h-20 w-20 shrink-0 rounded-[24px]" />
                       <div className="min-w-0 space-y-2">
                         <div className="flex flex-wrap items-center gap-2">
-                          <h3 className="text-2xl font-semibold tracking-tight text-foreground sm:text-[2.1rem]">
+                          <h3 className="text-[28px] font-medium tracking-normal text-foreground sm:text-[34px]">
                             {swipeCard.title}
                           </h3>
                           {swipeCard.isTestProfile ? (
@@ -1373,7 +1373,7 @@ export default function MarketplacePage() {
             </div>
           ) : (
             <div className="flex flex-col items-center justify-center gap-4 px-6 py-14 text-center">
-              <h3 className="text-xl font-semibold tracking-tight text-foreground">
+              <h3 className="text-xl font-medium tracking-normal text-foreground">
                 {investorDeckComplete ? "Deck complete" : "That&apos;s everyone for now"}
               </h3>
               <p className="max-w-xl text-sm leading-6 text-muted-foreground">
@@ -1417,7 +1417,7 @@ export default function MarketplacePage() {
                   <ProfileAvatar kind={item.kind} label={item.title} />
                   <div className="min-w-0 flex-1 space-y-2">
                     <div className="flex flex-wrap items-center gap-2">
-                      <h3 className="text-lg font-semibold tracking-tight text-foreground">
+                      <h3 className="text-lg font-medium tracking-normal text-foreground">
                         {item.title}
                       </h3>
                       {item.isTestProfile ? (
@@ -1492,7 +1492,7 @@ export default function MarketplacePage() {
 
           {!loading && activeCards.length === 0 ? (
             <RiaSurface className="col-span-full p-6 text-center">
-              <h3 className="text-lg font-semibold tracking-tight text-foreground">No profiles</h3>
+              <h3 className="text-lg font-medium tracking-normal text-foreground">No profiles</h3>
               <p className="mt-2 text-sm leading-6 text-muted-foreground">
                 Try a broader search.
               </p>

--- a/hushh-webapp/app/profile/page.tsx
+++ b/hushh-webapp/app/profile/page.tsx
@@ -4141,7 +4141,7 @@ function ProfilePageContent() {
             </AvatarFallback>
           </Avatar>
           <div className="min-w-0 max-w-full space-y-1.5">
-            <h1 className="text-2xl font-semibold leading-tight tracking-normal text-foreground [overflow-wrap:anywhere] sm:text-[2rem]">
+            <h1 className="text-[28px] font-medium leading-[1.08] tracking-normal text-foreground [overflow-wrap:anywhere] sm:text-[34px]">
               {user.displayName || "User"}
             </h1>
             <div

--- a/hushh-webapp/app/providers.tsx
+++ b/hushh-webapp/app/providers.tsx
@@ -240,7 +240,7 @@ export function Providers({ children }: ProvidersProps) {
   }, [routeLayoutMode, signedInShellContentOffset.mode, signedInShellContentOffset.style, topShellRouteProfile.id, topShellRouteStyle]);
 
   return (
-    <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
       <ObservabilityRouteObserver />
       <StepProgressProvider>
         <StatusBarManager />

--- a/hushh-webapp/app/providers.tsx
+++ b/hushh-webapp/app/providers.tsx
@@ -285,10 +285,18 @@ export function Providers({ children }: ProvidersProps) {
                                         transform:
                                           "translate3d(0, calc(var(--bottom-chrome-progress, 0) * var(--bottom-chrome-hide-distance)), 0)",
                                         "--bottom-chrome-progress": String(hideBottomChromeGlassProgress),
-                                        "--app-bar-glass-bg-light": "rgba(245, 245, 247, 0.72)",
-                                        "--app-bar-glass-bg-dark": "rgba(28, 28, 30, 0.72)",
+                                        "--app-bar-glass-bg-light": "rgba(255, 255, 255, 0.16)",
+                                        "--app-bar-glass-bg-dark": "rgba(28, 28, 30, 0.22)",
+                                        "--app-bar-glass-blur": "0px",
                                         "--app-bar-shadow": "none",
-                                        "--app-bar-mask-overscan": "14px",
+                                        "--app-bar-mask-overscan": "6px",
+                                        "--app-bar-bottom-fade-strong":
+                                          "color-mix(in oklab, var(--background) 6%, transparent)",
+                                        "--app-bar-bottom-fade-medium":
+                                          "color-mix(in oklab, var(--background) 4%, transparent)",
+                                        "--app-bar-bottom-fade-soft":
+                                          "color-mix(in oklab, var(--background) 1.8%, transparent)",
+                                        "--app-bar-bottom-fade-trace": "transparent",
                                       } as CSSProperties
                                     }
                                   />
@@ -361,10 +369,18 @@ export function Providers({ children }: ProvidersProps) {
                                         transform:
                                           "translate3d(0, calc(var(--bottom-chrome-progress, 0) * var(--bottom-chrome-hide-distance)), 0)",
                                         "--bottom-chrome-progress": String(hideBottomChromeGlassProgress),
-                                        "--app-bar-glass-bg-light": "rgba(245, 245, 247, 0.72)",
-                                        "--app-bar-glass-bg-dark": "rgba(28, 28, 30, 0.72)",
+                                        "--app-bar-glass-bg-light": "rgba(255, 255, 255, 0.16)",
+                                        "--app-bar-glass-bg-dark": "rgba(28, 28, 30, 0.22)",
+                                        "--app-bar-glass-blur": "0px",
                                         "--app-bar-shadow": "none",
-                                        "--app-bar-mask-overscan": "14px",
+                                        "--app-bar-mask-overscan": "6px",
+                                        "--app-bar-bottom-fade-strong":
+                                          "color-mix(in oklab, var(--background) 6%, transparent)",
+                                        "--app-bar-bottom-fade-medium":
+                                          "color-mix(in oklab, var(--background) 4%, transparent)",
+                                        "--app-bar-bottom-fade-soft":
+                                          "color-mix(in oklab, var(--background) 1.8%, transparent)",
+                                        "--app-bar-bottom-fade-trace": "transparent",
                                       } as CSSProperties
                                     }
                                   />

--- a/hushh-webapp/app/register-phone/page.tsx
+++ b/hushh-webapp/app/register-phone/page.tsx
@@ -126,11 +126,11 @@ function PhoneMandatePageContent() {
         dataState="loaded"
       />
       <div className="mx-auto w-full max-w-[28rem]">
-        <div className="space-y-3">
-          <h1 className="max-w-[18rem] text-[clamp(2.5rem,9vw,3.5rem)] font-black leading-[0.94] tracking-tight text-foreground">
+        <div className="space-y-2.5 text-center">
+          <h1 className="mx-auto max-w-[23rem] text-[34px] font-medium leading-[1.06] tracking-normal text-foreground sm:text-[40px]">
             Verify your phone number
           </h1>
-          <p className="max-w-sm text-[15px] leading-7 text-muted-foreground">
+          <p className="mx-auto max-w-sm text-[17px] leading-[1.42] text-muted-foreground">
             Add your phone number to continue.
           </p>
         </div>
@@ -142,7 +142,7 @@ function PhoneMandatePageContent() {
           onCompleted={continueToNextRoute}
           onContinueExisting={continueToNextRoute}
           confirmLabel="Verify and continue"
-          className="mt-8 min-h-[22rem] gap-5"
+          className="mt-10 min-h-[25rem] gap-5"
         />
 
         <div id="recaptcha-container" className="mt-6 min-h-0" />

--- a/hushh-webapp/components/agent/agent-popover-provider.tsx
+++ b/hushh-webapp/components/agent/agent-popover-provider.tsx
@@ -36,6 +36,7 @@ import {
   type AgentTriggerBounds,
   type AgentTriggerPosition,
 } from "@/lib/agent/agent-popover-layout";
+import { getKaiChromeState } from "@/lib/navigation/kai-chrome-state";
 import { ROUTES, isRiaActionBarRoute } from "@/lib/navigation/routes";
 import { cn } from "@/lib/utils";
 
@@ -306,6 +307,9 @@ function AgentPopoverSurface({ customSize, setCustomSize }: AgentPopoverSurfaceP
   const isLegacyAgentRoute = pathname === ROUTES.AGENT;
   const canShowAgent = isAuthenticated && !isLegacyAgentRoute;
   const useRiaActionBarTrigger = isRiaActionBarRoute(pathname);
+  const useKaiCommandBarTrigger =
+    pathname.startsWith(ROUTES.KAI_HOME) && !getKaiChromeState(pathname).hideCommandBar;
+  const useEmbeddedAgentTrigger = useRiaActionBarTrigger || useKaiCommandBarTrigger;
   const isCollapsing = motionState === "closing";
   const surfaceVisible = expanded || motionState !== "idle";
   const isFullscreen = sizeMode === "fullscreen";
@@ -418,7 +422,7 @@ function AgentPopoverSurface({ customSize, setCustomSize }: AgentPopoverSurfaceP
   }, []);
 
   useLayoutEffect(() => {
-    if (!canShowAgent || useRiaActionBarTrigger) return;
+    if (!canShowAgent || useEmbeddedAgentTrigger) return;
     clampStoredTriggerPosition();
 
     window.addEventListener("resize", clampStoredTriggerPosition);
@@ -427,7 +431,7 @@ function AgentPopoverSurface({ customSize, setCustomSize }: AgentPopoverSurfaceP
       window.removeEventListener("resize", clampStoredTriggerPosition);
       window.removeEventListener("orientationchange", clampStoredTriggerPosition);
     };
-  }, [canShowAgent, clampStoredTriggerPosition, useRiaActionBarTrigger]);
+  }, [canShowAgent, clampStoredTriggerPosition, useEmbeddedAgentTrigger]);
 
   useEffect(() => {
     if (!triggerPosition) return;
@@ -584,7 +588,7 @@ function AgentPopoverSurface({ customSize, setCustomSize }: AgentPopoverSurfaceP
         </div>
       ) : null}
 
-      {!useRiaActionBarTrigger ? (
+      {!useEmbeddedAgentTrigger ? (
         <Button
           ref={triggerRef}
           type="button"

--- a/hushh-webapp/components/app-ui/page-sections.tsx
+++ b/hushh-webapp/components/app-ui/page-sections.tsx
@@ -191,7 +191,7 @@ export function PageHeader({
               {eyebrow ? (
                 <p
                   className={cn(
-                    "text-xs font-semibold uppercase tracking-[0.24em]",
+                    "text-xs font-medium uppercase tracking-[0.16em]",
                     styles.eyebrow
                   )}
                   data-slot="page-header-eyebrow"
@@ -199,7 +199,7 @@ export function PageHeader({
                   {eyebrow}
                 </p>
               ) : null}
-              <h1 className="text-[clamp(1.28rem,3vw,1.75rem)] font-semibold tracking-tight leading-[1.1] text-foreground">
+              <h1 className="text-[28px] font-medium tracking-normal leading-[1.08] text-foreground sm:text-[34px]">
                 {title}
               </h1>
               {description && !descriptionFullWidth ? (
@@ -287,14 +287,14 @@ export function SectionHeader({
           >
             <div className="min-w-0 flex-1 space-y-[var(--section-header-copy-gap)]">
               {eyebrow ? (
-                <p className={cn("text-xs font-semibold uppercase tracking-[0.2em]", styles.eyebrow)}>
+                <p className={cn("text-xs font-medium uppercase tracking-[0.16em]", styles.eyebrow)}>
                   {eyebrow}
                 </p>
               ) : null}
               <div
                 role="heading"
                 aria-level={2}
-                className="text-[15px] font-semibold leading-tight tracking-tight text-foreground sm:text-[16px]"
+                className="text-[15px] font-medium leading-tight tracking-normal text-foreground sm:text-[16px]"
               >
                 {title}
               </div>

--- a/hushh-webapp/components/app-ui/settings-ui.tsx
+++ b/hushh-webapp/components/app-ui/settings-ui.tsx
@@ -123,10 +123,10 @@ export function SettingsGroup({
             <div
               role="heading"
               aria-level={embedded ? 3 : 2}
-              className="flex flex-wrap items-center gap-x-2 gap-y-1 text-pretty text-[15px] font-semibold leading-tight tracking-tight text-foreground [overflow-wrap:anywhere] sm:text-[16px]"
+              className="flex flex-wrap items-center gap-x-2 gap-y-1 text-pretty text-[12px] font-medium uppercase leading-tight tracking-[0.14em] text-muted-foreground [overflow-wrap:anywhere]"
             >
               {eyebrow ? (
-                <span className="text-[10px] font-semibold uppercase tracking-[0.22em] text-muted-foreground sm:text-[11px]">
+                <span className="text-[10px] font-medium uppercase tracking-[0.22em] text-muted-foreground sm:text-[11px]">
                   {eyebrow}
                 </span>
               ) : null}
@@ -220,14 +220,14 @@ export function SettingsRow({
       <div className="min-w-0 flex-1 space-y-0.5">
         <div
           className={cn(
-            "text-[13px] font-medium tracking-tight text-foreground [overflow-wrap:anywhere] sm:text-[14px]",
+            "text-[14px] font-medium tracking-normal text-foreground [overflow-wrap:anywhere] sm:text-[15px]",
             tone === "destructive" && "text-destructive"
           )}
         >
           {title}
         </div>
         {description ? (
-          <div className="text-[11px] leading-[1.45] text-muted-foreground [overflow-wrap:anywhere] sm:text-[12px]">
+          <div className="text-[12px] leading-[1.45] text-muted-foreground [overflow-wrap:anywhere] sm:text-[13px]">
             {description}
           </div>
         ) : null}
@@ -399,7 +399,7 @@ export function SettingsDetailPanel({
           }}
         >
           <DrawerHeader className="sticky top-0 z-10 border-b border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-default-solid)] px-4 py-3 text-left sm:px-5 sm:py-4">
-            <DrawerTitle className="text-base font-semibold tracking-tight">
+            <DrawerTitle className="text-base font-medium tracking-normal">
               {title}
             </DrawerTitle>
             <DrawerDescription
@@ -434,7 +434,7 @@ export function SettingsDetailPanel({
         }}
       >
         <DialogHeader className="sticky top-0 z-10 border-b border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-default-solid)] px-6 py-4 text-left">
-          <DialogTitle className="text-base font-semibold tracking-tight">
+          <DialogTitle className="text-base font-medium tracking-normal">
             {title}
           </DialogTitle>
           <DialogDescription

--- a/hushh-webapp/components/app-ui/shell-action-surface.tsx
+++ b/hushh-webapp/components/app-ui/shell-action-surface.tsx
@@ -12,7 +12,7 @@ const shellActionSurfaceVariants = cva(
     variants: {
       variant: {
         icon: "h-10 w-10 items-center justify-center hover:scale-[1.035] hover:bg-[color:var(--app-shell-surface-bg-hover)] active:scale-[0.965]",
-        pill: "min-h-10 min-w-0 max-w-full items-center justify-center gap-1.5 px-3 py-1.5 text-[14px] font-semibold tracking-tight hover:bg-[color:var(--app-shell-surface-bg-hover)] sm:gap-2 sm:px-4 sm:text-base",
+        pill: "min-h-10 min-w-0 max-w-full items-center justify-center gap-1.5 px-3 py-1.5 text-[14px] font-medium tracking-normal hover:bg-[color:var(--app-shell-surface-bg-hover)] sm:gap-2 sm:px-4 sm:text-base",
       },
     },
     defaultVariants: {

--- a/hushh-webapp/components/auth/phone-verification-flow.tsx
+++ b/hushh-webapp/components/auth/phone-verification-flow.tsx
@@ -34,10 +34,10 @@ import { trackEvent } from "@/lib/observability/client";
 const E164_PHONE_PATTERN = /^\+[1-9]\d{7,14}$/;
 const DEFAULT_COUNTRY_VALUE = "US";
 const FLOW_CONTROL_SHELL_CLASS_NAME =
-  "h-12 overflow-hidden rounded-[var(--radius-md)] border-black/10 bg-background/80 shadow-xs dark:border-white/10 dark:bg-input/30";
+  "h-12 overflow-hidden rounded-[18px] border-black/10 bg-background/80 shadow-xs dark:border-white/10 dark:bg-input/30";
 const FLOW_CONTROL_CLASS_NAME =
   "h-full rounded-[inherit] border-0 bg-transparent px-4 text-base shadow-none focus-visible:border-transparent focus-visible:ring-0 dark:bg-transparent md:text-sm";
-const FLOW_SURFACE_RADIUS_CLASS_NAME = "rounded-[var(--radius-md)]";
+const FLOW_SURFACE_RADIUS_CLASS_NAME = "rounded-[18px]";
 
 export type PhoneVerificationFlowMode = "link" | "replace";
 

--- a/hushh-webapp/components/kai/cards/dashboard-summary-hero.tsx
+++ b/hushh-webapp/components/kai/cards/dashboard-summary-hero.tsx
@@ -60,22 +60,22 @@ export function DashboardSummaryHero({
         <div className="space-y-2 text-center">
           <p className="text-sm font-medium text-muted-foreground">Total portfolio value</p>
           <div className="flex items-center justify-center gap-2">
-            <Badge className="rounded-full bg-muted px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.14em] text-muted-foreground">
+            <Badge className="rounded-full bg-muted px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
               Risk: {normalizeRiskLabel(riskLabel)}
             </Badge>
-            <Badge className="rounded-full bg-muted px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.14em] text-muted-foreground">
+            <Badge className="rounded-full bg-muted px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
               Holdings: {holdingsCount}
             </Badge>
             {brokerageName && (
-              <Badge className="rounded-full bg-muted px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.14em] text-muted-foreground">
+              <Badge className="rounded-full bg-muted px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
                 {brokerageName}
               </Badge>
             )}
           </div>
-          <h2 className="text-[34px] font-black leading-tight tracking-tight">{formatCurrency(totalValue)}</h2>
+          <h2 className="text-[34px] font-medium leading-tight tracking-normal">{formatCurrency(totalValue)}</h2>
           <div className="flex items-center justify-center gap-2 text-sm">
             <span className={positive ? "text-emerald-600" : "text-red-500"}>
-              <span className="inline-flex items-center font-semibold">
+              <span className="inline-flex items-center font-medium">
                 <Icon icon={positive ? ArrowUpRight : ArrowDownRight} size="sm" className="mr-1" />
                 {formatChange(netChange)} ({changePct >= 0 ? "+" : ""}
                 {changePct.toFixed(2)}%)
@@ -88,10 +88,10 @@ export function DashboardSummaryHero({
 
         <div className="rounded-xl border border-border/60 bg-muted/40 p-3 text-center">
           <div className="space-y-1">
-            <p className="text-sm font-semibold">{periodRange ?? "Current Statement Period"}</p>
+            <p className="text-sm font-medium">{periodRange ?? "Current Statement Period"}</p>
             {typeof beginningBalance === "number" && (
               <p className="text-xs text-muted-foreground">
-                Beginning Balance: <span className="font-semibold text-foreground">{formatCurrency(beginningBalance)}</span>
+                Beginning Balance: <span className="font-medium text-foreground">{formatCurrency(beginningBalance)}</span>
               </p>
             )}
           </div>

--- a/hushh-webapp/components/kai/debate-stream-view.tsx
+++ b/hushh-webapp/components/kai/debate-stream-view.tsx
@@ -1588,11 +1588,11 @@ export function DebateStreamView({
         <div className="relative z-10 mb-4 overflow-hidden rounded-2xl border border-border/50 bg-background/65 px-4 py-3 shadow-sm backdrop-blur-md">
           <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-3">
             <div />
-            <h1 className="justify-self-center text-3xl font-black tracking-tighter text-foreground">
+            <h1 className="justify-self-center text-[34px] font-medium tracking-normal text-foreground">
               {normalizedTicker}
             </h1>
             <div className="justify-self-end flex items-center gap-2">
-              <span className="text-sm font-semibold tabular-nums text-muted-foreground">
+              <span className="text-sm font-medium tabular-nums text-muted-foreground">
                 {headerQuoteLoading && headerPrice === null
                   ? "Loading price..."
                   : formatHeaderPrice(headerPrice)}
@@ -1600,7 +1600,7 @@ export function DebateStreamView({
               {headerChangePct !== null ? (
                 <span
                   className={cn(
-                    "rounded px-1.5 py-0.5 text-xs font-semibold tabular-nums",
+                    "rounded px-1.5 py-0.5 text-xs font-medium tabular-nums",
                     headerChangePct >= 0
                       ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
                       : "bg-rose-500/10 text-rose-600 dark:text-rose-400"

--- a/hushh-webapp/components/kai/shared/market-surface-theme.ts
+++ b/hushh-webapp/components/kai/shared/market-surface-theme.ts
@@ -18,27 +18,31 @@ export const marketSurfaceVariablesClassName = cn(
 );
 
 export const kaiPreviewEyebrowClassName =
-  "text-[11px] font-medium uppercase tracking-normal";
+  "text-[11px] font-medium uppercase tracking-[0.16em]";
 
 export const kaiPreviewPageTitleClassName =
-  "font-heading !text-[31px] !font-semibold !leading-[1.08] !tracking-normal text-[color:var(--one-fg)] sm:!text-[32px]";
+  "font-sans !text-[34px] !font-medium !leading-[1.06] !tracking-normal text-[color:var(--one-fg)] sm:!text-[40px]";
 
 export const kaiPreviewSectionTitleClassName =
-  "flex min-w-0 items-center gap-2.5 !text-[20px] !font-semibold !leading-[1.12] !tracking-normal text-[color:var(--one-fg)]";
+  "flex min-w-0 items-center gap-2.5 !text-[22px] !font-medium !leading-[1.08] !tracking-normal text-[color:var(--one-fg)] sm:!text-[24px]";
+
+export const kaiPreviewDockFrameClassName =
+  "pointer-events-none fixed inset-x-0 bottom-0 z-30 mx-auto w-full max-w-[560px] px-4 pb-[calc(10px+env(safe-area-inset-bottom))] sm:px-6";
 
 export const kaiPreviewDockSurfaceClassName = cn(
-  "relative overflow-hidden bg-[image:var(--one-glass-fill)] backdrop-blur-[20px] backdrop-saturate-[200%]",
-  "shadow-[var(--one-glass-float),inset_0_1px_0_rgba(255,255,255,0.35),inset_0_-1px_1px_rgba(0,0,0,0.06)]",
-  "before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:p-px before:[background:linear-gradient(135deg,rgba(255,255,255,0.95),transparent_45%,transparent_60%,rgba(255,255,255,0.30))]",
+  "relative overflow-hidden bg-white/[0.82] backdrop-blur-[18px] backdrop-saturate-[180%]",
+  "shadow-[0_14px_36px_-24px_rgba(0,0,0,0.30),0_1px_2px_rgba(0,0,0,0.05),inset_0_1px_0_rgba(255,255,255,0.72)]",
+  "before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:p-px before:[background:linear-gradient(135deg,rgba(255,255,255,0.88),rgba(255,255,255,0.22)_52%,rgba(0,0,0,0.08))]",
   "before:[-webkit-mask:linear-gradient(#000_0_0)_content-box,linear-gradient(#000_0_0)] before:[-webkit-mask-composite:xor] before:[mask-composite:exclude]",
+  "dark:bg-[#1c1c1e]/80 dark:shadow-[0_16px_40px_-22px_rgba(0,0,0,0.78),inset_0_1px_0_rgba(255,255,255,0.12)]",
   "[&>*]:relative [&>*]:z-[1]"
 );
 
 export const kaiPreviewDockItemClassName =
-  "flex min-w-0 flex-col items-center justify-center gap-0.5 rounded-full border-0 bg-transparent px-0 pb-[5px] pt-[6px] text-[10px] font-semibold tracking-normal text-[color:var(--one-fg2)] no-underline transition-[background,color,box-shadow,transform] duration-200 hover:text-[color:var(--one-fg)] active:scale-[0.93]";
+  "flex min-w-0 flex-col items-center justify-center gap-0.5 rounded-full border-0 bg-transparent px-0 pb-[5px] pt-[6px] text-[10px] font-medium tracking-normal text-[color:var(--one-fg2)] no-underline transition-[background,color,box-shadow,transform] duration-200 hover:text-[color:var(--one-fg)] active:scale-[0.93]";
 
 export const kaiPreviewDockActiveItemClassName =
-  "bg-[color:var(--one-card)] text-[color:var(--one-blue)] shadow-[0_2px_10px_rgba(0,0,0,0.14)]";
+  "bg-white text-[color:var(--one-blue)] shadow-[0_10px_26px_-18px_rgba(0,0,0,0.34),0_1px_2px_rgba(0,0,0,0.08)] dark:bg-white/[0.12]";
 
 export const marketCardClassName = cn(
   marketSurfaceVariablesClassName,

--- a/hushh-webapp/components/kai/views/analysis-view.tsx
+++ b/hushh-webapp/components/kai/views/analysis-view.tsx
@@ -133,7 +133,7 @@ export function AnalysisView({
             />
 
             <div>
-              <h1 className="text-2xl font-bold tracking-tighter">{result.symbol}</h1>
+              <h1 className="text-[28px] font-medium tracking-normal">{result.symbol}</h1>
               <p className="text-xs text-muted-foreground uppercase tracking-wider font-medium">Investment Analysis</p>
             </div>
           </div>
@@ -162,7 +162,7 @@ export function AnalysisView({
                 <p className="text-sm text-muted-foreground">Recommendation</p>
                 <p
                   className={cn(
-                    "text-2xl font-bold",
+                    "text-2xl font-medium",
                     getDecisionColor(result.decision)
                   )}
                 >

--- a/hushh-webapp/components/kai/views/dashboard-master-view.tsx
+++ b/hushh-webapp/components/kai/views/dashboard-master-view.tsx
@@ -143,7 +143,7 @@ const ALLOCATION_COLOR_PALETTE = [
 ];
 
 const portfolioChipClassName =
-  "inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-semibold leading-none shadow-[var(--shadow-xs)]";
+  "inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-medium leading-none shadow-[var(--shadow-xs)]";
 const portfolioChipTones = {
   blue:
     "border-blue-500/12 bg-blue-500/[0.08] text-blue-700 dark:border-blue-400/16 dark:bg-blue-400/[0.10] dark:text-blue-200",
@@ -156,9 +156,9 @@ const portfolioChipTones = {
 } as const;
 
 const portfolioMetricLabelClassName =
-  "text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground";
+  "text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground";
 const portfolioMetricValueClassName =
-  "mt-1 text-2xl font-semibold tracking-tight sm:text-[1.65rem]";
+  "mt-1 text-2xl font-medium tracking-normal sm:text-[1.65rem]";
 const portfolioSummaryPillClassName =
   "rounded-2xl px-3 py-2 text-[12px] leading-5 text-muted-foreground";
 
@@ -2777,13 +2777,13 @@ export function DashboardMasterView({
                 </span>
               ) : null}
             </div>
-            <p className="text-[2.35rem] font-semibold leading-none tracking-tight text-foreground sm:text-5xl">
+            <p className="text-[2.35rem] font-medium leading-none tracking-normal text-foreground sm:text-5xl">
               {formatCurrency(model.hero.totalValue)}
             </p>
             <div className="flex flex-wrap items-center justify-center gap-2 text-sm">
               <span
                 className={cn(
-                  "inline-flex items-center font-semibold tracking-tight",
+                  "inline-flex items-center font-medium tracking-normal",
                   model.hero.netChange >= 0
                     ? "text-emerald-600 dark:text-emerald-400"
                     : "text-rose-600 dark:text-rose-400"
@@ -2803,7 +2803,7 @@ export function DashboardMasterView({
           </div>
 
           <SurfaceInset className="px-4 py-3 text-center">
-            <p className="text-[13px] font-semibold tracking-tight text-foreground sm:text-sm">
+            <p className="text-[13px] font-medium tracking-normal text-foreground sm:text-sm">
               {isPlaidView
                 ? freshness?.lastSyncedAt
                   ? `Last synced ${new Date(freshness.lastSyncedAt).toLocaleString()}`
@@ -2819,7 +2819,7 @@ export function DashboardMasterView({
               ) : (
                 <>
                   Beginning Balance:{" "}
-                  <span className="font-semibold text-foreground">{formatCurrency(model.hero.beginningValue)}</span>
+                  <span className="font-medium text-foreground">{formatCurrency(model.hero.beginningValue)}</span>
                 </>
               )}
             </p>
@@ -2827,7 +2827,7 @@ export function DashboardMasterView({
 
           <SurfaceInset className="flex flex-col gap-3 px-4 py-3 text-left sm:flex-row sm:items-center sm:justify-between">
             <div className="min-w-0">
-              <p className="text-[13px] font-semibold tracking-tight text-foreground sm:text-sm">
+              <p className="text-[13px] font-medium tracking-normal text-foreground sm:text-sm">
                 Investment preferences
               </p>
               <p className="mt-1 text-[12px] leading-5 text-muted-foreground">
@@ -2987,7 +2987,7 @@ export function DashboardMasterView({
 
           <SurfaceCard>
             <SurfaceCardHeader className="px-5 pb-2 pt-5 sm:px-7 sm:pt-6">
-              <SurfaceCardTitle className="text-[15px] font-semibold tracking-tight text-foreground">
+              <SurfaceCardTitle className="text-[15px] font-medium tracking-normal text-foreground">
                 Investor Snapshot
               </SurfaceCardTitle>
             </SurfaceCardHeader>
@@ -3060,7 +3060,7 @@ export function DashboardMasterView({
           <SurfaceCard className="min-w-0">
             <SurfaceCardHeader className="px-5 pb-2 pt-5 sm:px-7 sm:pt-6">
               <div className="flex items-center justify-between gap-2">
-                <SurfaceCardTitle className="text-[15px] font-semibold tracking-tight text-foreground">
+                <SurfaceCardTitle className="text-[15px] font-medium tracking-normal text-foreground">
                   {isPlaidView ? "Brokerage Holdings" : "Current Holdings"}
                 </SurfaceCardTitle>
                 {canEditStatement ? (
@@ -3161,7 +3161,7 @@ export function DashboardMasterView({
 
         <TabsContent value="deep-dive" className="mt-0 space-y-5">
           <section className="space-y-3">
-            <h2 className="px-1 text-[15px] font-semibold tracking-tight text-foreground">
+            <h2 className="px-1 text-[15px] font-medium tracking-normal text-foreground">
               Portfolio Insights
             </h2>
             <div className="grid gap-4 lg:grid-cols-2">

--- a/hushh-webapp/components/kai/views/kai-analysis-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-analysis-preview-view.tsx
@@ -26,6 +26,7 @@ import {
 import { AppPageShell } from "@/components/app-ui/app-page-shell";
 import {
   kaiPreviewDockActiveItemClassName,
+  kaiPreviewDockFrameClassName,
   kaiPreviewDockItemClassName,
   kaiPreviewDockSurfaceClassName,
   kaiPreviewEyebrowClassName,
@@ -41,9 +42,13 @@ const analysisRootClassName = cn(
   "relative isolate mx-auto flex min-h-screen w-full !max-w-none flex-col overflow-x-hidden !px-0 pb-0",
   "bg-[color:var(--one-bg)] font-sans text-[color:var(--one-fg)] antialiased",
   "[--one-bg:#ffffff] [--one-card:#ffffff] [--one-surface:#f2f2f7]",
+  "dark:[--one-bg:#000000] dark:[--one-card:#1c1c1e] dark:[--one-surface:#1c1c1e]",
   "[--one-hairline:rgba(0,0,0,0.08)] [--one-line:rgba(0,0,0,0.06)]",
+  "dark:[--one-hairline:rgba(255,255,255,0.14)] dark:[--one-line:rgba(255,255,255,0.10)]",
   "[--one-fg:#1d1d1f] [--one-fg2:rgba(0,0,0,0.55)] [--one-fg3:rgba(0,0,0,0.42)]",
+  "dark:[--one-fg:#f5f5f7] dark:[--one-fg2:rgba(245,245,247,0.64)] dark:[--one-fg3:rgba(245,245,247,0.46)]",
   "[--one-blue:#0071e3] [--one-link:#0066cc] [--one-blue-t:rgba(0,113,227,0.10)]",
+  "dark:[--one-blue:#0a84ff] dark:[--one-link:#2997ff] dark:[--one-blue-t:rgba(10,132,255,0.18)]",
   "[--one-up:#34c759] [--one-up-t:rgba(52,199,89,0.12)]",
   "[--one-down:#ff3b30] [--one-down-t:rgba(255,59,48,0.10)]",
   "[--one-indigo:#5856d6] [--one-indigo-t:rgba(88,86,214,0.12)]",
@@ -51,8 +56,9 @@ const analysisRootClassName = cn(
   "[--one-teal:#30b0c7] [--one-teal-t:rgba(48,176,199,0.13)]",
   "[--one-purple:#af52de] [--one-purple-t:rgba(175,82,222,0.12)]",
   "[--one-glass-fill:linear-gradient(135deg,rgba(255,255,255,0.45),rgba(255,255,255,0.16))]",
+  "dark:[--one-glass-fill:linear-gradient(135deg,rgba(44,44,46,0.86),rgba(28,28,30,0.62))]",
   "[--one-glass-float:0_16px_38px_-20px_rgba(0,0,0,0.28),0_4px_12px_-8px_rgba(0,0,0,0.10)]",
-  "[--one-gutter:clamp(16px,4.6vw,22px)]"
+  "[--one-gutter:clamp(18px,5vw,32px)]"
 );
 
 const analysisGlassClassName = cn(
@@ -346,7 +352,7 @@ function AnalysisDock({ onKaiOpen }: { onKaiOpen: () => void }) {
   };
 
   return (
-    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-30 mx-auto w-full max-w-[560px] px-4 pb-[calc(10px+env(safe-area-inset-bottom))] sm:px-6 before:pointer-events-none before:absolute before:inset-x-[-18px] before:bottom-[-10px] before:h-[126px] before:bg-[linear-gradient(180deg,rgba(255,255,255,0),rgba(255,255,255,0.88)_34%,rgba(255,255,255,0.98))] before:backdrop-blur-[8px] [&>*]:relative [&>*]:z-[1]">
+    <div className={kaiPreviewDockFrameClassName}>
       <div className="relative flex items-end gap-2.5 sm:gap-3">
         {searchOpen ? (
           <>
@@ -627,16 +633,24 @@ export function KaiAnalysisPreviewView() {
             background: #ffffff !important;
           }
 
+          html.dark:has([data-one-analysis-preview="true"]),
+          html.dark:has([data-one-analysis-preview="true"]) body,
+          html.dark:has([data-one-analysis-preview="true"]) body main,
+          html.dark:has([data-one-analysis-preview="true"]) body [data-top-content-anchor="true"],
+          html.dark:has([data-one-analysis-preview="true"]) body [class*="overflow-y-auto"][class*="touch-pan-y"] {
+            background: #000000 !important;
+          }
+
           nextjs-portal,
           [aria-label="Open consent inbox"] {
             display: none !important;
           }
         `}
       </style>
-      <div aria-hidden className="pointer-events-none absolute inset-0 -z-20 bg-white" />
+      <div aria-hidden className="pointer-events-none absolute inset-0 -z-20 bg-[color:var(--one-bg)]" />
 
-      <div className="mx-auto flex min-h-screen w-full max-w-[440px] flex-col">
-        <main className="min-h-0 flex-1 overflow-y-auto px-5 pb-[calc(190px+env(safe-area-inset-bottom))] pt-3 sm:px-[22px]">
+      <div className="mx-auto flex min-h-screen w-full max-w-[1080px] flex-col">
+        <main className="min-h-0 flex-1 overflow-y-auto px-[var(--one-gutter)] pb-[calc(190px+env(safe-area-inset-bottom))] pt-5 sm:pt-7">
           <header className="flex items-start justify-between gap-4">
             <div className="min-w-0">
               <span className={cn(kaiPreviewEyebrowClassName, "text-[color:var(--one-fg3)]")}>
@@ -645,7 +659,7 @@ export function KaiAnalysisPreviewView() {
               <div className={cn("mt-1.5", kaiPreviewPageTitleClassName)} role="heading" aria-level={1}>
                 Analysis
               </div>
-              <p className="mt-2 max-w-[32ch] text-[14px] leading-snug text-[color:var(--one-fg2)]">
+              <p className="mt-2 max-w-[34ch] text-[17px] leading-[1.42] text-[color:var(--one-fg2)]">
                 How your portfolio is performing.
               </p>
             </div>
@@ -668,7 +682,7 @@ export function KaiAnalysisPreviewView() {
                 openAnalysisHref(`/kai/analysis?preview=analysis&q=${encodeURIComponent(query)}`);
               }
             }}
-            className="mt-3 flex h-11 items-center gap-2.5 rounded-xl bg-[color:var(--one-surface)] px-3.5"
+            className="mt-5 flex h-12 items-center gap-2.5 rounded-[16px] bg-[color:var(--one-surface)] px-4"
           >
             <Search className="h-[17px] w-[17px] shrink-0 text-[color:var(--one-fg3)]" />
             <input
@@ -687,7 +701,7 @@ export function KaiAnalysisPreviewView() {
             </button>
           </form>
 
-          <div className="mt-3.5 flex items-start justify-between gap-3">
+          <div className="mt-5 flex items-start justify-between gap-3">
             <div>
               <p className="text-[13px] font-medium text-[color:var(--one-fg2)]">Portfolio value</p>
               <p className="mt-1 text-[38px] font-semibold leading-none tracking-normal text-[color:var(--one-fg)] tabular-nums">
@@ -745,7 +759,7 @@ export function KaiAnalysisPreviewView() {
 
           <section className="mt-8">
             <SectionHeader title="Returns" icon={TrendingUp} tone="indigo" />
-            <div className="grid grid-cols-2 gap-2.5">
+            <div className="grid grid-cols-2 gap-2.5 lg:grid-cols-4">
               <StatCard label="Total return" value="+$18,420" sub="+14.8% - 1Y" tone="up" />
               <StatCard label="Today" value="+$579" sub="+0.41%" tone="up" />
               <StatCard label="CAGR" value="12.6%" sub="Since inception" />
@@ -765,7 +779,7 @@ export function KaiAnalysisPreviewView() {
               <div className="mt-2 h-[7px] overflow-hidden rounded-full bg-[color:var(--one-surface)]">
                 <span className="block h-full w-[62%] rounded-full bg-[color:var(--one-orange)]" />
               </div>
-              <div className="mt-3.5 grid grid-cols-2 gap-2.5">
+              <div className="mt-3.5 grid grid-cols-2 gap-2.5 lg:grid-cols-4">
                 <StatCard label="Risk profile" value="Moderate" sub="64 / 22 / 14 mix" />
                 <StatCard label="Beta" value="1.18" sub="vs S&P 500" />
                 <StatCard label="Volatility" value="14.2%" sub="1Y annualised" />

--- a/hushh-webapp/components/kai/views/kai-connect-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-connect-preview-view.tsx
@@ -27,6 +27,7 @@ import {
 import { AppPageShell } from "@/components/app-ui/app-page-shell";
 import {
   kaiPreviewDockActiveItemClassName,
+  kaiPreviewDockFrameClassName,
   kaiPreviewDockItemClassName,
   kaiPreviewDockSurfaceClassName,
   kaiPreviewEyebrowClassName,
@@ -198,9 +199,13 @@ const connectRootClassName = cn(
   "relative isolate mx-auto flex min-h-screen w-full !max-w-none flex-col overflow-x-hidden !px-0 pb-0",
   "bg-[color:var(--one-bg)] font-sans text-[color:var(--one-fg)] antialiased",
   "[--one-bg:#ffffff] [--one-card:#ffffff] [--one-surface:#f2f2f7]",
+  "dark:[--one-bg:#000000] dark:[--one-card:#1c1c1e] dark:[--one-surface:#1c1c1e]",
   "[--one-hairline:rgba(0,0,0,0.08)] [--one-line:rgba(0,0,0,0.06)]",
+  "dark:[--one-hairline:rgba(255,255,255,0.14)] dark:[--one-line:rgba(255,255,255,0.10)]",
   "[--one-fg:#1d1d1f] [--one-fg2:rgba(0,0,0,0.55)] [--one-fg3:rgba(0,0,0,0.42)]",
+  "dark:[--one-fg:#f5f5f7] dark:[--one-fg2:rgba(245,245,247,0.64)] dark:[--one-fg3:rgba(245,245,247,0.46)]",
   "[--one-blue:#0071e3] [--one-link:#0066cc] [--one-blue-t:rgba(0,113,227,0.10)]",
+  "dark:[--one-blue:#0a84ff] dark:[--one-link:#2997ff] dark:[--one-blue-t:rgba(10,132,255,0.18)]",
   "[--one-up:#34c759] [--one-up-t:rgba(52,199,89,0.12)]",
   "[--one-down:#ff3b30] [--one-down-t:rgba(255,59,48,0.10)]",
   "[--one-indigo:#5856d6] [--one-indigo-t:rgba(88,86,214,0.12)]",
@@ -208,8 +213,9 @@ const connectRootClassName = cn(
   "[--one-teal:#30b0c7] [--one-teal-t:rgba(48,176,199,0.13)]",
   "[--one-purple:#af52de] [--one-purple-t:rgba(175,82,222,0.12)]",
   "[--one-glass-fill:linear-gradient(135deg,rgba(255,255,255,0.45),rgba(255,255,255,0.16))]",
+  "dark:[--one-glass-fill:linear-gradient(135deg,rgba(44,44,46,0.86),rgba(28,28,30,0.62))]",
   "[--one-glass-float:0_16px_38px_-20px_rgba(0,0,0,0.28),0_4px_12px_-8px_rgba(0,0,0,0.10)]",
-  "[--one-gutter:clamp(16px,4.6vw,22px)]"
+  "[--one-gutter:clamp(18px,5vw,32px)]"
 );
 
 const connectGlassClassName = cn(
@@ -343,7 +349,7 @@ function ConnectDock({
   };
 
   return (
-    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-30 mx-auto w-full max-w-[560px] px-4 pb-[calc(10px+env(safe-area-inset-bottom))] sm:px-6 before:pointer-events-none before:absolute before:inset-x-[-18px] before:bottom-[-10px] before:h-[126px] before:bg-[linear-gradient(180deg,rgba(255,255,255,0),rgba(255,255,255,0.88)_34%,rgba(255,255,255,0.98))] before:backdrop-blur-[8px] [&>*]:relative [&>*]:z-[1]">
+    <div className={kaiPreviewDockFrameClassName}>
       <div className="relative flex items-end gap-2.5 sm:gap-3">
         {searchOpen ? (
           <>
@@ -780,16 +786,24 @@ export function KaiConnectPreviewView() {
             background: #ffffff !important;
           }
 
+          html.dark:has([data-one-connect-preview="true"]),
+          html.dark:has([data-one-connect-preview="true"]) body,
+          html.dark:has([data-one-connect-preview="true"]) body main,
+          html.dark:has([data-one-connect-preview="true"]) body [data-top-content-anchor="true"],
+          html.dark:has([data-one-connect-preview="true"]) body [class*="overflow-y-auto"][class*="touch-pan-y"] {
+            background: #000000 !important;
+          }
+
           nextjs-portal,
           [aria-label="Open consent inbox"] {
             display: none !important;
           }
         `}
       </style>
-      <div aria-hidden className="pointer-events-none absolute inset-0 -z-20 bg-white" />
+      <div aria-hidden className="pointer-events-none absolute inset-0 -z-20 bg-[color:var(--one-bg)]" />
 
-      <div className="mx-auto flex min-h-screen w-full max-w-[440px] flex-col">
-        <main className="min-h-0 flex-1 overflow-y-auto px-5 pb-[calc(190px+env(safe-area-inset-bottom))] pt-4 sm:px-[22px]">
+      <div className="mx-auto flex min-h-screen w-full max-w-[1080px] flex-col">
+        <main className="min-h-0 flex-1 overflow-y-auto px-[var(--one-gutter)] pb-[calc(190px+env(safe-area-inset-bottom))] pt-5 sm:pt-7">
           <header className="flex items-start justify-between gap-4">
             <div className="min-w-0">
               <span className={cn(kaiPreviewEyebrowClassName, "text-[color:var(--one-fg3)]")}>
@@ -798,7 +812,7 @@ export function KaiConnectPreviewView() {
               <div className={cn("mt-1.5", kaiPreviewPageTitleClassName)} role="heading" aria-level={1}>
                 Connect
               </div>
-              <p className="mt-2 max-w-[30ch] text-[14px] leading-snug text-[color:var(--one-fg2)]">
+              <p className="mt-2 max-w-[34ch] text-[17px] leading-[1.42] text-[color:var(--one-fg2)]">
                 Find a registered advisor. Connect with consent.
               </p>
             </div>
@@ -815,7 +829,7 @@ export function KaiConnectPreviewView() {
 
           <form
             onSubmit={(event) => event.preventDefault()}
-            className="mt-3.5 flex h-11 items-center gap-2.5 rounded-xl bg-[color:var(--one-surface)] px-3.5"
+            className="mt-5 flex h-12 items-center gap-2.5 rounded-[16px] bg-[color:var(--one-surface)] px-4"
           >
             <Search className="h-[17px] w-[17px] shrink-0 text-[color:var(--one-fg3)]" />
             <input

--- a/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
@@ -41,6 +41,7 @@ import {
 } from "@/components/kai/cards/market-overview-grid";
 import {
   kaiPreviewDockActiveItemClassName,
+  kaiPreviewDockFrameClassName,
   kaiPreviewDockItemClassName,
   kaiPreviewDockSurfaceClassName,
   kaiPreviewEyebrowClassName,
@@ -156,15 +157,20 @@ const oneMarketRootClassName = cn(
   "relative isolate mx-auto flex min-h-screen w-full !max-w-none flex-col overflow-x-hidden !px-0 pb-0",
   "bg-[color:var(--one-bg)] font-sans text-[color:var(--one-fg)] antialiased",
   "[--one-bg:#ffffff] [--one-card:#ffffff] [--one-surface:#f2f2f7]",
+  "dark:[--one-bg:#000000] dark:[--one-card:#1c1c1e] dark:[--one-surface:#1c1c1e]",
   "[--one-hairline:rgba(0,0,0,0.08)] [--one-line:rgba(0,0,0,0.06)]",
+  "dark:[--one-hairline:rgba(255,255,255,0.14)] dark:[--one-line:rgba(255,255,255,0.10)]",
   "[--one-fg:#1d1d1f] [--one-fg2:rgba(0,0,0,0.55)] [--one-fg3:rgba(0,0,0,0.42)]",
+  "dark:[--one-fg:#f5f5f7] dark:[--one-fg2:rgba(245,245,247,0.64)] dark:[--one-fg3:rgba(245,245,247,0.46)]",
   "[--one-blue:#0071e3] [--one-link:#0066cc]",
+  "dark:[--one-blue:#0a84ff] dark:[--one-link:#2997ff]",
   "[--one-up:#34c759] [--one-up-t:rgba(52,199,89,0.12)]",
   "[--one-down:#ff3b30] [--one-down-t:rgba(255,59,48,0.10)]",
   "[--one-indigo:#5856d6] [--one-indigo-t:rgba(88,86,214,0.12)]",
   "[--one-orange:#ff9500] [--one-orange-t:rgba(255,149,0,0.14)]",
   "[--one-teal:#30b0c7] [--one-teal-t:rgba(48,176,199,0.13)]",
   "[--one-glass-fill:linear-gradient(135deg,rgba(255,255,255,0.45),rgba(255,255,255,0.16))]",
+  "dark:[--one-glass-fill:linear-gradient(135deg,rgba(44,44,46,0.86),rgba(28,28,30,0.62))]",
   "[--one-glass-float:0_16px_38px_-20px_rgba(0,0,0,0.28),0_4px_12px_-8px_rgba(0,0,0,0.10)]",
   "[--one-gutter:clamp(18px,4vw,32px)]"
 );
@@ -901,7 +907,7 @@ function OneMarketDock({
     }
   };
   return (
-    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-30 mx-auto w-full max-w-[560px] px-4 pb-[calc(10px+env(safe-area-inset-bottom))] sm:px-6 before:pointer-events-none before:absolute before:inset-x-[-18px] before:bottom-[-10px] before:h-[126px] before:bg-[linear-gradient(180deg,rgba(255,255,255,0),rgba(255,255,255,0.88)_34%,rgba(255,255,255,0.98))] before:backdrop-blur-[8px] [&>*]:relative [&>*]:z-[1]">
+    <div className={kaiPreviewDockFrameClassName}>
       <div className="relative flex items-end gap-2.5 sm:gap-3">
         {searchOpen ? (
           <>
@@ -2143,6 +2149,14 @@ export function KaiMarketPreviewView() {
               background: #ffffff !important;
             }
 
+            html.dark:has([data-one-market-preview="true"]),
+            html.dark:has([data-one-market-preview="true"]) body,
+            html.dark:has([data-one-market-preview="true"]) body main,
+            html.dark:has([data-one-market-preview="true"]) body [data-top-content-anchor="true"],
+            html.dark:has([data-one-market-preview="true"]) body [class*="overflow-y-auto"][class*="touch-pan-y"] {
+              background: #000000 !important;
+            }
+
             nextjs-portal,
             [aria-label="Open consent inbox"] {
               display: none !important;
@@ -2152,12 +2166,12 @@ export function KaiMarketPreviewView() {
       ) : null}
       <div
         aria-hidden
-        className="pointer-events-none absolute inset-0 -z-20 bg-white"
+        className="pointer-events-none absolute inset-0 -z-20 bg-[color:var(--one-bg)]"
       />
       <div
         className={cn(
           oneMarketGlassClassName,
-          "pointer-events-none fixed inset-x-0 top-0 z-30 mx-auto flex h-[50px] max-w-[1080px] items-center justify-center border-b border-[color:var(--one-hairline)] bg-white/85 text-[17px] font-semibold text-[color:var(--one-fg)] transition duration-300",
+          "pointer-events-none fixed inset-x-0 top-0 z-30 mx-auto flex h-[50px] max-w-[1080px] items-center justify-center bg-[color:var(--one-bg)] text-[17px] font-medium text-[color:var(--one-fg)] transition duration-300",
           topbarVisible ? "translate-y-0 opacity-100" : "-translate-y-2 opacity-0"
         )}
       >
@@ -2175,7 +2189,7 @@ export function KaiMarketPreviewView() {
               <div className={kaiPreviewPageTitleClassName} role="heading" aria-level={1}>
                 Market
               </div>
-              <p className="max-w-[32ch] text-[14px] leading-snug text-[color:var(--one-fg2)]">
+              <p className="max-w-[34ch] text-[17px] leading-[1.42] text-[color:var(--one-fg2)]">
                 Track the market and your watchlist.
               </p>
             </div>
@@ -2196,7 +2210,7 @@ export function KaiMarketPreviewView() {
               event.preventDefault();
               handleMarketSearchSubmit();
             }}
-            className="mt-[18px] flex h-[46px] items-center gap-2.5 rounded-xl bg-[color:var(--one-surface)] px-3.5"
+            className="mt-5 flex h-12 items-center gap-2.5 rounded-[16px] bg-[color:var(--one-surface)] px-4"
           >
             <Search className="h-[17px] w-[17px] shrink-0 text-[color:var(--one-fg3)]" />
             <input

--- a/hushh-webapp/components/kai/views/portfolio-import-view.tsx
+++ b/hushh-webapp/components/kai/views/portfolio-import-view.tsx
@@ -155,12 +155,12 @@ export function PortfolioImportView({
     <div className="mx-auto w-full space-y-3.5 pt-3 pb-6" style={APP_MEASURE_STYLES.reading}>
       {/* Header */}
       <div className="space-y-2 text-center">
-        <h1 className="text-[34px] font-bold tracking-tight leading-[1.08]">
+        <h1 className="text-[34px] font-medium tracking-normal leading-[1.06] sm:text-[40px]">
           Your money
           <br />
-          <span className="hushh-gradient-text">Your options</span>
+          <span>Your options</span>
         </h1>
-        <p className="text-[17px] font-medium text-muted-foreground leading-snug">
+        <p className="text-[17px] font-normal text-muted-foreground leading-[1.42]">
           Let Kai analyze your holdings for precise advice
         </p>
       </div>
@@ -208,7 +208,7 @@ export function PortfolioImportView({
             variant="blue-gradient"
             effect="fill"
             size="lg"
-            className="w-full border-none font-black shadow-xl"
+            className="w-full rounded-full border-none font-medium shadow-[0_10px_30px_-20px_rgba(0,102,204,0.55)]"
             disabled={!onConnectPlaid || isUploading || isPreloadingSchema || isConnectingPlaid || plaidConfigured === false}
             onClick={handleConnectPlaid}
             icon={{
@@ -308,7 +308,7 @@ export function PortfolioImportView({
             variant="morphy"
             effect="fill"
             size="default"
-            className="w-full font-black shadow-xl border-none"
+            className="w-full rounded-full border-none font-medium shadow-[0_10px_30px_-20px_rgba(0,102,204,0.55)]"
             onClick={handleContinue}
             disabled={isUploading || isPreloadingSchema || !selectedFile}
             icon={{
@@ -338,7 +338,7 @@ export function PortfolioImportView({
             variant="blue-gradient"
             effect="fill"
             size="lg"
-            className="w-full border-none font-black shadow-xl"
+            className="w-full rounded-full border-none font-medium shadow-[0_10px_30px_-20px_rgba(0,102,204,0.55)]"
             onClick={handlePreloadSchema}
             disabled={isUploading || isPreloadingSchema}
             icon={{

--- a/hushh-webapp/components/onboarding/AuthProviderButton.tsx
+++ b/hushh-webapp/components/onboarding/AuthProviderButton.tsx
@@ -31,7 +31,7 @@ export function AuthProviderButton({
       disabled={disabled}
       onClick={onClick}
       className={cn(
-        "min-h-14 rounded-full border border-black/[0.08] bg-[#f5f5f7] text-[16px] font-semibold text-[#1d1d1f] shadow-[0_1px_2px_rgba(0,0,0,0.04)] transition-[background,border-color,box-shadow,transform] hover:border-black/[0.12] hover:bg-white hover:shadow-[0_8px_28px_rgba(0,0,0,0.08)] active:translate-y-px dark:border-white/[0.12] dark:bg-white/[0.10] dark:text-[#f5f5f7] dark:hover:border-white/[0.18] dark:hover:bg-white/[0.14]",
+        "min-h-[52px] rounded-full border border-black/[0.08] bg-white text-[16px] font-medium text-[#1d1d1f] shadow-[0_1px_2px_rgba(0,0,0,0.04)] transition-[background,border-color,box-shadow,transform] hover:border-black/[0.12] hover:bg-[#f5f5f7] hover:shadow-[0_10px_30px_-20px_rgba(0,0,0,0.28)] active:translate-y-px dark:border-white/[0.12] dark:bg-white/[0.10] dark:text-[#f5f5f7] dark:hover:border-white/[0.18] dark:hover:bg-white/[0.14]",
         className
       )}
     >

--- a/hushh-webapp/components/onboarding/AuthStep.tsx
+++ b/hushh-webapp/components/onboarding/AuthStep.tsx
@@ -520,7 +520,7 @@ export function AuthStep({
 
   return (
     <main
-      className="min-h-[100dvh] w-full bg-[#fbfbfd] text-[#1d1d1f] dark:bg-[#000000] dark:text-[#f5f5f7]"
+      className="min-h-[100dvh] w-full bg-white text-[#1d1d1f] dark:bg-[#000000] dark:text-[#f5f5f7]"
       data-testid="auth-step-primary"
     >
       <NativeTestBeacon
@@ -549,8 +549,8 @@ export function AuthStep({
       <div
         className={
           compact
-            ? "mx-auto flex min-h-[100dvh] w-full max-w-[27rem] flex-col px-6 pt-[calc(28px+var(--app-safe-area-top-effective,0px))] pb-[calc(24px+var(--app-screen-footer-pad))]"
-            : "mx-auto flex min-h-[100dvh] w-full max-w-[27rem] flex-col px-6 pt-[calc(54px+var(--app-safe-area-top-effective,0px))] pb-[calc(28px+var(--app-screen-footer-pad))]"
+            ? "mx-auto flex min-h-[100dvh] w-full max-w-[27rem] flex-col px-6 pt-[calc(24px+var(--app-safe-area-top-effective,0px))] pb-[calc(24px+var(--app-screen-footer-pad))]"
+            : "mx-auto flex min-h-[100dvh] w-full max-w-[27rem] flex-col px-6 pt-[calc(48px+var(--app-safe-area-top-effective,0px))] pb-[calc(28px+var(--app-screen-footer-pad))]"
         }
       >
         <header className="flex-none text-center">
@@ -565,11 +565,11 @@ export function AuthStep({
           <div
             role="heading"
             aria-level={1}
-            className="mt-4 text-[32px] font-semibold leading-[1.1] tracking-normal text-[#1d1d1f] sm:text-[38px] dark:text-[#f5f5f7]"
+            className="mt-3 text-[34px] font-medium leading-[1.06] tracking-normal text-[#1d1d1f] sm:text-[40px] dark:text-[#f5f5f7]"
           >
             Sign in to One.
           </div>
-          <p className="mx-auto mt-3 max-w-[19rem] text-[17px] font-normal leading-[1.42] tracking-normal text-[#6e6e73] dark:text-[#a1a1a6]">
+          <p className="mx-auto mt-3 max-w-[20rem] text-[17px] font-normal leading-[1.42] tracking-normal text-[#6e6e73] dark:text-[#a1a1a6]">
             Continue to your personal financial advisor.
           </p>
         </header>
@@ -577,8 +577,8 @@ export function AuthStep({
         <section
           className={
             compact
-              ? "flex-none pt-14"
-              : "flex-none pt-16"
+              ? "flex-none pt-11"
+              : "flex-none pt-12"
           }
         >
           <div className="mx-auto w-full max-w-[21.5rem] space-y-3">
@@ -608,7 +608,7 @@ export function AuthStep({
           </div>
         </section>
 
-        <footer className={compact ? "mt-auto flex-none pt-10" : "mt-auto flex-none pt-12"}>
+        <footer className={compact ? "mt-auto flex-none pt-9" : "mt-auto flex-none pt-10"}>
           <p className="mx-auto max-w-[19.5rem] text-center text-[11px] leading-[1.45] text-[#86868b] dark:text-[#8e8e93]">
             By continuing, you agree to Kai&apos;s{" "}
             <button

--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -102,7 +102,7 @@ export function IntroStep({
             role="heading"
             aria-level={1}
             aria-label="Meet One, Your Personal Financial Advisor"
-            className="relative mt-4 text-[42px] font-semibold leading-none tracking-normal text-[#1d1d1f] dark:text-[#f5f5f7]"
+            className="relative mt-3 text-[40px] font-medium leading-[1.04] tracking-normal text-[#1d1d1f] dark:text-[#f5f5f7]"
           >
             Meet One.
           </div>
@@ -117,12 +117,12 @@ export function IntroStep({
               {INTRO_FEATURES.map((feature) => (
                 <div key={feature.title} className="grid grid-cols-[48px_minmax(0,1fr)] items-center gap-4">
                   <span
-                    className={`grid h-12 w-12 place-items-center rounded-[16px] border border-black/[0.04] dark:border-white/10 ${feature.tileClassName}`}
+                    className={`grid h-12 w-12 place-items-center rounded-full border border-black/[0.04] dark:border-white/10 ${feature.tileClassName}`}
                   >
                     <feature.icon className="h-[22px] w-[22px]" />
                   </span>
                   <div className="min-w-0">
-                    <p className="text-[17px] font-semibold leading-[1.22] tracking-normal text-[#1d1d1f] dark:text-[#f5f5f7]">
+                    <p className="text-[17px] font-medium leading-[1.22] tracking-normal text-[#1d1d1f] dark:text-[#f5f5f7]">
                       {feature.title}
                     </p>
                     <p className="mt-1 text-[14.5px] leading-[1.35] tracking-normal text-[rgba(0,0,0,0.50)] dark:text-[rgba(245,245,247,0.56)]">
@@ -146,14 +146,14 @@ export function IntroStep({
               fullWidth
               onClick={onNext}
               showRipple
-              className="h-[50px] rounded-full bg-[#0071e3] text-[17px] font-semibold tracking-normal text-white shadow-none hover:bg-[#0077ed]"
+              className="h-[50px] rounded-full bg-[#0066cc] text-[17px] font-medium tracking-normal text-white shadow-none hover:bg-[#0071e3]"
             >
               Get started
             </Button>
             {onLogin ? (
               <button
                 type="button"
-                className="mx-auto block min-h-10 px-4 text-[15px] font-semibold tracking-normal text-[#0066cc] transition-colors hover:text-[#0071e3] dark:text-[#2997ff] dark:hover:text-[#5eb0ff]"
+                className="mx-auto block min-h-10 px-4 text-[15px] font-medium tracking-normal text-[#0066cc] transition-colors hover:text-[#0071e3] dark:text-[#2997ff] dark:hover:text-[#5eb0ff]"
                 onClick={onLogin}
               >
                 Log in

--- a/hushh-webapp/components/onboarding/PreviewCarouselStep.tsx
+++ b/hushh-webapp/components/onboarding/PreviewCarouselStep.tsx
@@ -198,7 +198,7 @@ export function PreviewCarouselStep({ onContinue }: { onContinue: () => void }) 
             </button>
             <button
               type="button"
-              className="min-h-10 rounded-full px-4 text-[15px] font-semibold tracking-normal text-muted-foreground transition-colors hover:text-foreground"
+              className="min-h-10 rounded-full px-4 text-[15px] font-medium tracking-normal text-muted-foreground transition-colors hover:text-foreground"
               onClick={completeAndContinue}
             >
               Skip
@@ -214,12 +214,12 @@ export function PreviewCarouselStep({ onContinue }: { onContinue: () => void }) 
               "sm:max-w-lg"
             )}
           >
-            <h2 className="text-[clamp(1.65rem,4.7vw,2.65rem)] font-bold tracking-normal leading-[1.04] text-[#1d1d1f] dark:text-[#f5f5f7]">
+            <h2 className="text-[32px] font-medium tracking-normal leading-[1.06] text-[#1d1d1f] sm:text-[40px] dark:text-[#f5f5f7]">
               {slides[displayIndex]?.title}{" "}
               <br />
               <span>{slides[displayIndex]?.accent}</span>
             </h2>
-            <p className="mx-auto max-w-[20rem] text-[clamp(0.92rem,2.1vw,1.02rem)] text-[rgba(0,0,0,0.56)] leading-relaxed dark:text-[rgba(245,245,247,0.60)]">
+            <p className="mx-auto max-w-[20rem] text-[16px] text-[rgba(0,0,0,0.56)] leading-[1.45] sm:text-[17px] dark:text-[rgba(245,245,247,0.60)]">
               {slides[displayIndex]?.subtitle}
             </p>
           </div>
@@ -259,7 +259,7 @@ export function PreviewCarouselStep({ onContinue }: { onContinue: () => void }) 
             <Button
               size="lg"
               fullWidth
-              className="mx-auto h-[52px] w-full max-w-md rounded-full bg-[#0071e3] text-[17px] font-semibold tracking-normal text-white shadow-none hover:bg-[#0077ed]"
+              className="mx-auto h-[52px] w-full max-w-md rounded-full bg-[#0066cc] text-[17px] font-medium tracking-normal text-white shadow-none hover:bg-[#0071e3]"
               onClick={handlePrimary}
               showRipple
             >

--- a/hushh-webapp/components/onboarding/previews/KycPreviewCompact.tsx
+++ b/hushh-webapp/components/onboarding/previews/KycPreviewCompact.tsx
@@ -42,10 +42,10 @@ export function KycPreviewCompact() {
         <div className="relative flex h-full flex-col">
           <div>
             <div className="flex items-center justify-between gap-4">
-            <span className="font-mono text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+            <span className="font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
               Identity check
             </span>
-            <span className="inline-flex items-center rounded-full bg-emerald-500/12 px-[11px] py-[5px] text-xs font-bold text-emerald-600 dark:text-emerald-300">
+            <span className="inline-flex items-center rounded-full bg-emerald-500/12 px-[11px] py-[5px] text-xs font-medium text-emerald-600 dark:text-emerald-300">
               Verified
             </span>
             </div>
@@ -68,7 +68,7 @@ export function KycPreviewCompact() {
                 >
                   <Icon icon={item.icon} size="md" />
                 </span>
-                <span className="flex-1 text-[15px] font-semibold tracking-normal">
+                <span className="flex-1 text-[15px] font-medium tracking-normal">
                   {item.label}
                 </span>
                 <span className="grid h-[22px] w-[22px] shrink-0 place-items-center rounded-full bg-emerald-500 text-white">
@@ -83,7 +83,7 @@ export function KycPreviewCompact() {
               <Icon icon={Zap} size="md" />
             </span>
             <div>
-              <p className="text-[14.5px] font-bold leading-tight tracking-normal">
+              <p className="text-[14.5px] font-medium leading-tight tracking-normal">
                 KYC completed in minutes
               </p>
               <p className="mt-0.5 text-xs text-muted-foreground">

--- a/hushh-webapp/components/onboarding/previews/PortfolioPreviewCompact.tsx
+++ b/hushh-webapp/components/onboarding/previews/PortfolioPreviewCompact.tsx
@@ -47,15 +47,15 @@ export function PortfolioPreviewCompact() {
         <div className="flex h-full flex-col">
           <div>
             <div className="flex items-center justify-between gap-4">
-              <span className="font-mono text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+              <span className="font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
                 Total value
               </span>
-              <span className="inline-flex items-center rounded-full bg-emerald-500/12 px-[9px] py-1 text-[12.5px] font-bold text-emerald-600 dark:text-emerald-300">
+              <span className="inline-flex items-center rounded-full bg-emerald-500/12 px-[9px] py-1 text-[12.5px] font-medium text-emerald-600 dark:text-emerald-300">
                 ▲ 2.4%
               </span>
             </div>
 
-            <div className="mt-3 text-[clamp(2.15rem,5.8vh,3.1rem)] font-bold leading-none tracking-normal text-foreground">
+            <div className="mt-3 text-[38px] font-medium leading-none tracking-normal text-foreground sm:text-[48px]">
               $142,893
             </div>
           </div>
@@ -93,7 +93,7 @@ export function PortfolioPreviewCompact() {
               <div key={holding.symbol} className="flex items-center gap-3 py-2 first:pt-0">
                 <LogoChip type={holding.logo} />
                 <div className="min-w-0">
-                  <p className="truncate text-[14.5px] font-semibold leading-tight tracking-normal">
+                  <p className="truncate text-[14.5px] font-medium leading-tight tracking-normal">
                     {holding.name}
                   </p>
                   <p className="mt-0.5 font-mono text-[11px] tracking-[0.04em] text-muted-foreground">
@@ -101,12 +101,12 @@ export function PortfolioPreviewCompact() {
                   </p>
                 </div>
                 <div className="ml-auto text-right">
-                  <p className="text-sm font-semibold tabular-nums">
+                  <p className="text-sm font-medium tabular-nums">
                     {holding.price}
                   </p>
                   <p
                     className={cn(
-                      "mt-0.5 text-[11.5px] font-bold tabular-nums",
+                      "mt-0.5 text-[11.5px] font-medium tabular-nums",
                       holding.direction === "up"
                         ? "text-emerald-600 dark:text-emerald-300"
                         : "text-red-500 dark:text-red-300"


### PR DESCRIPTION
## Summary
- Suppress duplicate global Agent trigger on Kai command-bar routes so the bottom Agent/search layout remains single-source.
- Align Kai preview, onboarding, auth, phone verification, portfolio, analysis, connect, and profile typography with the HushhTech/Apple-style medium-weight system scale.
- Improve responsive preview widths, bottom nav visibility, Light/Dark/System default behavior, and remove the bottom dock blur curtain while preserving existing routes/data wiring.

## Verification
- npm run lint
- npm run typecheck
- npm run verify:design-system
- git diff --check
- Local screenshots: market mobile/desktop, analysis mobile, connect desktop, market light mobile