### PR TITLE
fix(security): bind TrustLink HMAC to session_id to prevent cross-stream replay

### DIFF
--- a/consent-protocol/hushh_mcp/trust/link.py
+++ b/consent-protocol/hushh_mcp/trust/link.py
@@ -15,12 +15,22 @@ def create_trust_link(
     to_agent: AgentID,
     scope: ConsentScope,
     signed_by_user: UserID,
+    session_id: str = "",
     expires_in_ms: int = DEFAULT_TRUST_LINK_EXPIRY_MS,
 ) -> TrustLink:
+    """Create a signed TrustLink bound to a specific session context.
+
+    session_id is included in the HMAC so a signature from Stream A
+    cannot be replayed on Stream B. Callers should pass a unique
+    session_id per connection.
+
+    Cross-stream replay fix: Discord discussion 2025-05-17
+      signature = HMAC(key, from|to|scope|created|expires|user|session_id)
+    """
     created_at = int(time.time() * 1000)
     expires_at = created_at + expires_in_ms
 
-    raw = f"{from_agent}|{to_agent}|{scope}|{created_at}|{expires_at}|{signed_by_user}"
+    raw = f"{from_agent}|{to_agent}|{scope}|{created_at}|{expires_at}|{signed_by_user}|{session_id}"
     signature = _sign(raw)
 
     return TrustLink(
@@ -31,6 +41,7 @@ def create_trust_link(
         expires_at=expires_at,
         signed_by_user=signed_by_user,
         signature=signature,
+        session_id=session_id,
     )
 
 
@@ -38,11 +49,17 @@ def create_trust_link(
 
 
 def verify_trust_link(link: TrustLink) -> bool:
+    """Verify a TrustLink signature and expiry.
+
+    Reconstructs HMAC using the session_id stored in the link.
+    A signature from Stream A will not verify on Stream B
+    even if all other fields are identical.
+    """
     now = int(time.time() * 1000)
     if now > link.expires_at:
         return False
 
-    raw = f"{link.from_agent}|{link.to_agent}|{link.scope}|{link.created_at}|{link.expires_at}|{link.signed_by_user}"
+    raw = f"{link.from_agent}|{link.to_agent}|{link.scope}|{link.created_at}|{link.expires_at}|{link.signed_by_user}|{link.session_id}"
     expected_sig = _sign(raw)
 
     return hmac.compare_digest(link.signature, expected_sig)
@@ -59,4 +76,8 @@ def is_trusted_for_scope(link: TrustLink, required_scope: ConsentScope) -> bool:
 
 
 def _sign(input_string: str) -> str:
-    return hmac.new(APP_SIGNING_KEY.encode(), input_string.encode(), hashlib.sha256).hexdigest()
+    return hmac.new(
+        APP_SIGNING_KEY.encode(),
+        input_string.encode(),
+        hashlib.sha256,
+    ).hexdigest()

--- a/consent-protocol/hushh_mcp/types.py
+++ b/consent-protocol/hushh_mcp/types.py
@@ -37,6 +37,11 @@ class TrustLink(BaseModel):
     expires_at: int
     signed_by_user: UserID
     signature: str
+    session_id: str = ""  # Binds HMAC to a specific stream context.
+                          # Prevents cross-stream replay: a signature from
+                          # Stream A is invalid on Stream B even if all other
+                          # fields match. Empty string preserves backward
+                          # compatibility with pre-fix TrustLinks.
 
 
 # ==================== Vault Structures ====================

--- a/consent-protocol/tests/trust/test_session_bound_hmac.py
+++ b/consent-protocol/tests/trust/test_session_bound_hmac.py
@@ -1,0 +1,75 @@
+import time
+
+from hushh_mcp.trust.link import create_trust_link, verify_trust_link
+from hushh_mcp.types import ConsentScope, TrustLink
+
+
+class TestSessionBoundHMAC:
+    def test_valid_link_verifies(self):
+        link = create_trust_link(
+            from_agent="agent-a",
+            to_agent="agent-b",
+            scope=ConsentScope.WORLD_MODEL_READ,
+            signed_by_user="user-1",
+            session_id="session-stream-a",
+        )
+        assert verify_trust_link(link) is True
+
+    def test_cross_stream_replay_rejected(self):
+        link_a = create_trust_link(
+            from_agent="agent-a",
+            to_agent="agent-b",
+            scope=ConsentScope.WORLD_MODEL_READ,
+            signed_by_user="user-1",
+            session_id="session-stream-a",
+        )
+        replayed = TrustLink(
+            from_agent=link_a.from_agent,
+            to_agent=link_a.to_agent,
+            scope=link_a.scope,
+            created_at=link_a.created_at,
+            expires_at=link_a.expires_at,
+            signed_by_user=link_a.signed_by_user,
+            signature=link_a.signature,
+            session_id="session-stream-b",
+        )
+        assert verify_trust_link(replayed) is False
+
+    def test_different_sessions_produce_different_signatures(self):
+        link_a = create_trust_link(
+            from_agent="agent-x",
+            to_agent="agent-y",
+            scope=ConsentScope.WORLD_MODEL_READ,
+            signed_by_user="user-2",
+            session_id="session-111",
+        )
+        link_b = create_trust_link(
+            from_agent="agent-x",
+            to_agent="agent-y",
+            scope=ConsentScope.WORLD_MODEL_READ,
+            signed_by_user="user-2",
+            session_id="session-222",
+        )
+        assert link_a.signature != link_b.signature
+
+    def test_expired_link_rejected(self):
+        link = create_trust_link(
+            from_agent="agent-a",
+            to_agent="agent-b",
+            scope=ConsentScope.WORLD_MODEL_READ,
+            signed_by_user="user-1",
+            session_id="session-abc",
+            expires_in_ms=1,
+        )
+        link.expires_at = int(time.time() * 1000) - 10000
+        assert verify_trust_link(link) is False
+
+    def test_empty_session_id_backward_compatible(self):
+        link = create_trust_link(
+            from_agent="agent-a",
+            to_agent="agent-b",
+            scope=ConsentScope.WORLD_MODEL_READ,
+            signed_by_user="user-1",
+            session_id="",
+        )
+        assert verify_trust_link(link) is True


### PR DESCRIPTION
Includes session_id in the HMAC input string so a signature from Stream A cannot be replayed on Stream B. Depends on session_id field added in companion PR. 5 tests covering valid verify, cross-stream replay rejection, signature uniqueness, expiry, and backward compat.