### PR TITLE
fix(consent): resolve 404 routing issue when opening advisor workspace

### DIFF
--- a/hushh-webapp/components/consent/consent-center-view.tsx
+++ b/hushh-webapp/components/consent/consent-center-view.tsx
@@ -28,7 +28,7 @@ import {
   type ConsentCenterView,
 } from "@/lib/services/consent-center-service";
 import { CacheService, CACHE_KEYS } from "@/lib/services/cache-service";
-import { ROUTES } from "@/lib/navigation/routes";
+import { buildRiaClientWorkspaceRoute, ROUTES } from "@/lib/navigation/routes";
 import {
   buildConsentSheetProfileHref,
   CONSENT_BUNDLE_QUERY_KEY,
@@ -1041,9 +1041,7 @@ export function ConsentCenterView({
 
             {canOpenWorkspace ? (
               <Link
-                href={`${ROUTES.RIA_HOME}/workspace/${encodeURIComponent(
-                  String(entry.counterpart_id)
-                )}`}
+                href={buildRiaClientWorkspaceRoute(String(entry.counterpart_id))}
                 className="inline-flex min-h-10 items-center justify-center rounded-full border border-border bg-background px-4 text-sm font-medium text-foreground"
               >
                 Open workspace


### PR DESCRIPTION
## Description

This PR fixes advisor workspace navigation from the Consent Center.

### What Changed

* Replaced manual workspace URL construction with `buildRiaClientWorkspaceRoute()`.
* Removed the hardcoded route assembly logic.

### Files Changed

* `hushh-webapp/components/consent/consent-center-view.tsx`

### Why

The "Open workspace" action should navigate through the centralized route helper rather than manually constructing a URL. Using the shared route builder keeps navigation aligned with the application's route definitions and avoids routing inconsistencies.

### Impact Map

**Routes touched**

* Consent Center → Advisor Workspace navigation

**API / schema changes**

* None

**Database changes**

* None

**Runtime behavior**

* Navigation route generation only

### Testing

* Verified the route is generated through `buildRiaClientWorkspaceRoute()`
* Confirmed scope is limited to a single file
* No application logic changes outside route generation

### Risk

* Low
* Single-file change
* Uses existing route helper
