### PR TITLE
Fix/ria workspace checkbox ids

### DIFF
--- a/hushh-webapp/components/ria/ria-client-workspace.tsx
+++ b/hushh-webapp/components/ria/ria-client-workspace.tsx
@@ -728,11 +728,11 @@ export function RiaClientWorkspace({
                         {availableScopeOptions.map((scope) => {
                           const checked = selectedScopes.includes(scope.scope);
                           return (
-                            <label htmlFor="ria-client-input-1"
+                            <label htmlFor={`ria-scope-${scope.scope}`}
                               key={scope.scope}
                               className="flex items-start gap-3 rounded-[20px] border border-border/60 bg-background/70 px-4 py-3"
                             >
-                              <Checkbox id="ria-client-input-1"
+                              <Checkbox id={`ria-scope-${scope.scope}`}
                                 checked={checked}
                                 onCheckedChange={(next) => {
                                   const shouldCheck = Boolean(next);
@@ -764,11 +764,11 @@ export function RiaClientWorkspace({
                           activeAccountBranches.map((branch) => {
                             const checked = selectedAccountIds.includes(branch.branch_id);
                             return (
-                              <label htmlFor="ria-client-input-2"
+                              <label htmlFor={`ria-branch-${branch.branch_id}`}
                                 key={branch.branch_id}
                                 className="flex items-start gap-3 px-4 py-3"
                               >
-                                <Checkbox id="ria-client-input-2"
+                                <Checkbox id={`ria-branch-${branch.branch_id}`}
                                   checked={checked}
                                   onCheckedChange={(next) => {
                                     const shouldCheck = Boolean(next);


### PR DESCRIPTION
## Summary

Assigns unique IDs to dynamically rendered workspace scope and branch checkboxes.

## Changes

* Replaced static checkbox IDs with dynamic IDs derived from scope and branch values.
* Updated matching `htmlFor` attributes to reference the generated IDs.

## Scope

* `hushh-webapp/components/ria/ria-client-workspace.tsx`

## Why

The workspace configuration UI renders checkbox lists dynamically. Using static IDs in repeated elements can cause labels to target the wrong checkbox and results in duplicate HTML IDs within the page.

## Impact

* Improves checkbox label targeting
* Improves accessibility and browser behavior
* No UI changes
* No API changes
* Single-file, low-risk update

## Validation

* Scope limited to one file
* Each checkbox now receives a unique ID
* Matching label associations preserved
* No application logic modified
