### PR TITLE
fix(hooks): align useIsMobile state evaluation with media query matches

### DIFF
--- a/hushh-webapp/hooks/use-mobile.ts
+++ b/hushh-webapp/hooks/use-mobile.ts
@@ -8,10 +8,10 @@ export function useIsMobile() {
   React.useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+      setIsMobile(mql.matches)
     }
     mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    setIsMobile(mql.matches)
     return () => mql.removeEventListener("change", onChange)
   }, [])
 


### PR DESCRIPTION
## Summary

Aligns `useIsMobile` state updates with the media query used by the hook.

## Changes

* Replaced `window.innerWidth` comparisons with `mql.matches`.
* Kept the existing breakpoint and media query unchanged.

## Scope

* `hushh-webapp/hooks/use-mobile.ts`

## Why

The hook already subscribes to a media query change event. Using `mql.matches` ensures the state is derived from the same source that triggers updates, avoiding inconsistencies between viewport measurements and media query evaluation.

## Impact

* Improves responsive state consistency
* No UI changes
* No API changes
* Single-file, low-risk update

## Validation

* Scope limited to one file
* Existing breakpoint preserved
* No application logic modified beyond state evaluation
