### PR TITLE
Fix/analysis summary hydration date

### DIFF
--- a/hushh-webapp/components/kai/views/analysis-summary-view.tsx
+++ b/hushh-webapp/components/kai/views/analysis-summary-view.tsx
@@ -273,6 +273,11 @@ export function AnalysisSummaryView({
   const [marketSnapshot, setMarketSnapshot] = useState<TickerMarketSnapshot | null>(
     rawCardSnapshot
   );
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   useEffect(() => {
     setMarketSnapshot(rawCardSnapshot);
@@ -417,7 +422,7 @@ export function AnalysisSummaryView({
         <CardContent className="space-y-5 p-6">
           <div className="flex items-center justify-between gap-3">
             <span className="text-xs font-bold uppercase tracking-widest text-primary">Analysis</span>
-            <span className="text-xs font-medium text-muted-foreground">{updatedAt}</span>
+            <span className="text-xs font-medium text-muted-foreground">{mounted ? updatedAt : "Updated recently"}</span>
           </div>
 
           <div className="rounded-2xl border border-border/60 bg-background/60 p-4">


### PR DESCRIPTION
## Summary

Prevents hydration mismatches when rendering analysis timestamps.

## Changes

* Added a mounted-state guard for timestamp rendering.
* Displays a stable fallback value during initial render.
* Renders the localized timestamp after client mount.

## Scope

* `hushh-webapp/components/kai/views/analysis-summary-view.tsx`

## Why

The analysis timestamp is generated using `toLocaleString()`, which depends on the runtime locale and timezone. Server-rendered output and browser-rendered output can differ, producing hydration warnings in React.

The repository already uses mounted-state guards for similar client-specific rendering scenarios.

## Impact

* Prevents hydration mismatch warnings
* No API changes
* No business logic changes
* Single-file, low-risk update

## Validation

* Scope limited to one file
* Existing repository hydration pattern followed
* Timestamp formatting behavior preserved after mount
