### PR TITLE
promote Kai bottom chrome integrity to main

### DIFF
--- a/hushh-webapp/components/app-ui/top-app-bar.tsx
+++ b/hushh-webapp/components/app-ui/top-app-bar.tsx
@@ -22,11 +22,9 @@ import {
   ArrowLeft,
   Bell,
   BriefcaseBusiness,
-  ChartColumnIncreasing,
   Check,
   ChevronDown,
   Code2,
-  Compass,
   type LucideIcon,
   Loader2,
   LogOut,
@@ -157,19 +155,8 @@ function getTopBarTitle(
   }
 
   if (isScrolled) {
-    if (pathname === ROUTES.KAI_HOME) {
-      return {
-        label: "Market",
-        icon: ChartColumnIncreasing,
-        interactive: false as const,
-      };
-    }
-    if (pathname === ROUTES.MARKETPLACE) {
-      return {
-        label: "Search people",
-        icon: Compass,
-        interactive: false as const,
-      };
+    if (pathname === ROUTES.KAI_HOME || pathname === ROUTES.MARKETPLACE) {
+      return null;
     }
   }
 

--- a/hushh-webapp/components/kai/kai-command-bar-global.tsx
+++ b/hushh-webapp/components/kai/kai-command-bar-global.tsx
@@ -127,10 +127,6 @@ function computeAnalyzeEligibilityFromHolding(holding: Record<string, unknown>):
   return false;
 }
 
-function isKaiPreviewChromeOwner(preview: string | null): boolean {
-  return preview === "market" || preview === "analysis" || preview === "connect";
-}
-
 export function KaiCommandBarGlobal() {
   const [mounted, setMounted] = useState(false);
   const router = useRouter();
@@ -163,7 +159,6 @@ export function KaiCommandBarGlobal() {
     AppBackgroundTaskService.getState()
   );
   const chromeState = useMemo(() => getKaiChromeState(pathname), [pathname]);
-  const previewChromeOwner = isKaiPreviewChromeOwner(searchParams.get("preview"));
   const userId = user?.uid ?? "";
   const [voiceCapabilityState, setVoiceCapabilityState] = useState<{
     status: "idle" | "loading" | "ready" | "error";
@@ -732,7 +727,7 @@ export function KaiCommandBarGlobal() {
     return null;
   }
 
-  if (chromeState.hideCommandBar || previewChromeOwner) {
+  if (chromeState.hideCommandBar) {
     return null;
   }
 

--- a/hushh-webapp/components/kai/kai-search-bar.tsx
+++ b/hushh-webapp/components/kai/kai-search-bar.tsx
@@ -1740,18 +1740,18 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
               </ShellActionSurface>
             </div>
           ) : (
-            <div className="relative flex h-[58px] w-full justify-end">
+            <div className="relative flex h-[58px] w-full justify-end gap-2">
               <ShellActionSurface
                 variant="icon"
-                wrapperClassName="pointer-events-auto absolute bottom-[72px] right-1"
-                className="grid h-[50px] w-[50px] place-items-center"
+                wrapperClassName="pointer-events-auto"
+                className="grid h-[58px] w-[58px] place-items-center"
                 contentClassName="h-full w-full"
                 aria-label="Talk to Kai"
                 disabled={!agentPopover}
                 onClick={() => agentPopover?.openAgent()}
               >
-                <span className="grid h-[30px] w-[30px] place-items-center rounded-[9px] bg-[#0071e3] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.35)]">
-                  <X className="h-[15px] w-[15px] rotate-45" strokeWidth={2} />
+                <span className="grid h-[38px] w-[38px] place-items-center rounded-[13px] bg-[#0071e3] text-white shadow-[0_10px_24px_-16px_rgba(0,113,227,0.75),inset_0_1px_0_rgba(255,255,255,0.35)]">
+                  <X className="h-[17px] w-[17px] rotate-45" strokeWidth={2} />
                 </span>
               </ShellActionSurface>
               <ShellActionSurface

--- a/hushh-webapp/components/kai/views/kai-analysis-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-analysis-preview-view.tsx
@@ -5,19 +5,13 @@ import {
   BarChart3,
   Bell,
   ChevronRight,
-  CirclePlus,
-  Compass,
-  LineChart,
   MessageCircle,
   Mic,
   PieChart,
   Search,
   Shield,
   Star,
-  Store,
   TrendingUp,
-  UserRound,
-  WalletCards,
   X,
   Zap,
   type LucideIcon,
@@ -25,10 +19,6 @@ import {
 
 import { AppPageShell } from "@/components/app-ui/app-page-shell";
 import {
-  kaiPreviewDockActiveItemClassName,
-  kaiPreviewDockFrameClassName,
-  kaiPreviewDockItemClassName,
-  kaiPreviewDockSurfaceClassName,
   kaiPreviewEyebrowClassName,
   kaiPreviewPageTitleClassName,
   kaiPreviewSectionTitleClassName,
@@ -330,116 +320,6 @@ function AllocationSection() {
         </div>
       </div>
     </section>
-  );
-}
-
-function AnalysisDock({ onKaiOpen }: { onKaiOpen: () => void }) {
-  const [searchOpen, setSearchOpen] = useState(false);
-  const [query, setQuery] = useState("");
-  const items: Array<{ label: string; href: string; icon: LucideIcon; active?: boolean }> = [
-    { label: "Market", href: "/kai?preview=market", icon: Store },
-    { label: "Portfolio", href: "/kai/portfolio", icon: WalletCards },
-    { label: "Analysis", href: "/kai/analysis?preview=analysis", icon: LineChart, active: true },
-    { label: "Connect", href: "/kai?preview=connect", icon: Compass },
-    { label: "Profile", href: "/profile", icon: UserRound },
-  ];
-
-  const submitSearch = () => {
-    const normalized = query.trim();
-    if (!normalized) return;
-    setSearchOpen(false);
-    openAnalysisHref(`/kai/analysis?preview=analysis&q=${encodeURIComponent(normalized)}`);
-  };
-
-  return (
-    <div className={kaiPreviewDockFrameClassName}>
-      <div className="relative flex items-end gap-2.5 sm:gap-3">
-        {searchOpen ? (
-          <>
-            <form
-              onSubmit={(event) => {
-                event.preventDefault();
-                submitSearch();
-              }}
-              className={cn(
-                kaiPreviewDockSurfaceClassName,
-                "pointer-events-auto flex h-[50px] min-w-0 flex-1 items-center gap-[9px] rounded-full px-[15px] pr-2"
-              )}
-            >
-              <Search className="h-5 w-5 shrink-0 text-[color:var(--one-fg3)]" />
-              <input
-                placeholder="Search"
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
-                className="min-w-0 flex-1 bg-transparent text-[14px] text-[color:var(--one-fg)] outline-none placeholder:text-[color:var(--one-fg3)]"
-              />
-              <button
-                type="button"
-                onClick={submitSearch}
-                className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[color:var(--one-blue)] text-white transition-transform active:scale-[0.92]"
-                aria-label="Voice search"
-              >
-                <Mic className="h-4 w-4" />
-              </button>
-            </form>
-            <button
-              type="button"
-              onClick={() => setSearchOpen(false)}
-              className="pointer-events-auto flex h-[50px] shrink-0 items-center justify-center rounded-full px-1.5 text-[14px] font-semibold text-[color:var(--one-link)]"
-            >
-              Cancel
-            </button>
-          </>
-        ) : (
-          <>
-            <nav
-              className={cn(
-                kaiPreviewDockSurfaceClassName,
-                "pointer-events-auto grid h-[58px] min-w-0 flex-1 grid-cols-5 content-center rounded-full px-1.5"
-              )}
-            >
-              {items.map((item) => {
-                const Icon = item.icon;
-                return (
-                  <button
-                    key={item.label}
-                    type="button"
-                    onClick={() => openAnalysisHref(item.href)}
-                    className={cn(
-                      kaiPreviewDockItemClassName,
-                      item.active && kaiPreviewDockActiveItemClassName
-                    )}
-                  >
-                    <Icon className="h-[21px] w-[21px]" strokeWidth={1.8} />
-                    <span className="truncate">{item.label}</span>
-                  </button>
-                );
-              })}
-            </nav>
-            <button
-              type="button"
-              onClick={onKaiOpen}
-              className={cn(kaiPreviewDockSurfaceClassName, "pointer-events-auto absolute bottom-[72px] right-1 grid h-[50px] w-[50px] place-items-center rounded-full")}
-              aria-label="Talk to Kai"
-            >
-              <span className="grid h-[30px] w-[30px] place-items-center rounded-[9px] bg-[color:var(--one-blue)] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.35)]">
-                <CirclePlus className="h-[15px] w-[15px]" strokeWidth={2} />
-              </span>
-            </button>
-            <div className="pointer-events-auto flex shrink-0">
-              <button
-                type="button"
-                onClick={() => setSearchOpen(true)}
-                className={cn(kaiPreviewDockSurfaceClassName, "grid h-[58px] w-[58px] place-items-center rounded-full text-[color:var(--one-fg2)] transition-transform active:scale-[0.9]")}
-                aria-label="Search"
-              >
-                <Search className="h-5 w-5" strokeWidth={2.2} />
-              </button>
-            </div>
-          </>
-        )}
-      </div>
-    </div>
   );
 }
 
@@ -844,7 +724,6 @@ export function KaiAnalysisPreviewView() {
           </section>
         </main>
 
-        <AnalysisDock onKaiOpen={() => setKaiOpen(true)} />
       </div>
 
       {sheetOpen ? (

--- a/hushh-webapp/components/kai/views/kai-connect-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-connect-preview-view.tsx
@@ -7,36 +7,25 @@ import {
   Check,
   CheckCircle2,
   ChevronRight,
-  CirclePlus,
-  Compass,
-  LineChart,
   MessageCircle,
   Mic,
   Minus,
   Search,
   ShieldCheck,
   Star,
-  Store,
-  UserRound,
   UsersRound,
-  WalletCards,
   X,
   type LucideIcon,
 } from "lucide-react";
 
 import { AppPageShell } from "@/components/app-ui/app-page-shell";
 import {
-  kaiPreviewDockActiveItemClassName,
-  kaiPreviewDockFrameClassName,
-  kaiPreviewDockItemClassName,
-  kaiPreviewDockSurfaceClassName,
   kaiPreviewEyebrowClassName,
   kaiPreviewPageTitleClassName,
   kaiPreviewSectionTitleClassName,
   marketSurfaceVariablesClassName,
 } from "@/components/kai/shared/market-surface-theme";
 import { cn } from "@/lib/utils";
-import { requestInternalAppNavigation } from "@/lib/utils/browser-navigation";
 
 type ConnectTone = "indigo" | "teal" | "orange" | "purple" | "blue";
 type DirectoryMode = "advisors" | "firms";
@@ -224,10 +213,6 @@ const connectGlassClassName = cn(
   "ring-1 ring-white/55"
 );
 
-function openConnectHref(href: string) {
-  requestInternalAppNavigation({ href, scroll: false });
-}
-
 function toneClassName(tone: ConnectTone): string {
   if (tone === "teal") return "bg-[color:var(--one-teal-t)] text-[color:var(--one-teal)]";
   if (tone === "orange") return "bg-[color:var(--one-orange-t)] text-[color:var(--one-orange)]";
@@ -321,128 +306,6 @@ function AdvisorRow({
       </span>
       <ChevronRight className="h-4 w-4 shrink-0 text-[color:var(--one-fg3)]" />
     </button>
-  );
-}
-
-function ConnectDock({
-  searchQuery,
-  onSearchQueryChange,
-  onKaiOpen,
-}: {
-  searchQuery: string;
-  onSearchQueryChange: (value: string) => void;
-  onKaiOpen: () => void;
-}) {
-  const [searchOpen, setSearchOpen] = useState(false);
-  const [draft, setDraft] = useState(searchQuery);
-  const items: Array<{ label: string; href: string; icon: LucideIcon; active?: boolean }> = [
-    { label: "Market", href: "/kai?preview=market", icon: Store },
-    { label: "Portfolio", href: "/kai/portfolio", icon: WalletCards },
-    { label: "Analysis", href: "/kai/analysis?preview=analysis", icon: LineChart },
-    { label: "Connect", href: "/kai?preview=connect", icon: Compass, active: true },
-    { label: "Profile", href: "/profile", icon: UserRound },
-  ];
-
-  const submitSearch = () => {
-    onSearchQueryChange(draft.trim());
-    setSearchOpen(false);
-  };
-
-  return (
-    <div className={kaiPreviewDockFrameClassName}>
-      <div className="relative flex items-end gap-2.5 sm:gap-3">
-        {searchOpen ? (
-          <>
-            <form
-              onSubmit={(event) => {
-                event.preventDefault();
-                submitSearch();
-              }}
-              className={cn(
-                kaiPreviewDockSurfaceClassName,
-                "pointer-events-auto flex h-[50px] min-w-0 flex-1 items-center gap-[9px] rounded-full px-[15px] pr-2"
-              )}
-            >
-              <Search className="h-5 w-5 shrink-0 text-[color:var(--one-fg3)]" />
-              <input
-                placeholder="Search"
-                value={draft}
-                onChange={(event) => setDraft(event.target.value)}
-                className="min-w-0 flex-1 bg-transparent text-[14px] text-[color:var(--one-fg)] outline-none placeholder:text-[color:var(--one-fg3)]"
-              />
-              <button
-                type="button"
-                onClick={submitSearch}
-                className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[color:var(--one-blue)] text-white transition-transform active:scale-[0.92]"
-                aria-label="Voice search"
-              >
-                <Mic className="h-4 w-4" />
-              </button>
-            </form>
-            <button
-              type="button"
-              onClick={() => {
-                setSearchOpen(false);
-                setDraft(searchQuery);
-              }}
-              className="pointer-events-auto flex h-[50px] shrink-0 items-center justify-center rounded-full px-1.5 text-[14px] font-semibold text-[color:var(--one-link)]"
-            >
-              Cancel
-            </button>
-          </>
-        ) : (
-          <>
-            <nav
-              className={cn(
-                kaiPreviewDockSurfaceClassName,
-                "pointer-events-auto grid h-[58px] min-w-0 flex-1 grid-cols-5 content-center rounded-full px-1.5"
-              )}
-            >
-              {items.map((item) => {
-                const Icon = item.icon;
-                return (
-                  <button
-                    key={item.label}
-                    type="button"
-                    onClick={() => openConnectHref(item.href)}
-                    className={cn(
-                      kaiPreviewDockItemClassName,
-                      item.active && kaiPreviewDockActiveItemClassName
-                    )}
-                  >
-                    <Icon className="h-[21px] w-[21px]" strokeWidth={1.8} />
-                    <span className="truncate">{item.label}</span>
-                  </button>
-                );
-              })}
-            </nav>
-            <button
-              type="button"
-              onClick={onKaiOpen}
-              className={cn(kaiPreviewDockSurfaceClassName, "pointer-events-auto absolute bottom-[72px] right-1 grid h-[50px] w-[50px] place-items-center rounded-full")}
-              aria-label="Talk to Kai"
-            >
-              <span className="grid h-[30px] w-[30px] place-items-center rounded-[9px] bg-[color:var(--one-blue)] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.35)]">
-                <CirclePlus className="h-[15px] w-[15px]" strokeWidth={2} />
-              </span>
-            </button>
-            <div className="pointer-events-auto flex shrink-0">
-              <button
-                type="button"
-                onClick={() => {
-                  setDraft(searchQuery);
-                  setSearchOpen(true);
-                }}
-                className={cn(kaiPreviewDockSurfaceClassName, "grid h-[58px] w-[58px] place-items-center rounded-full text-[color:var(--one-fg2)] transition-transform active:scale-[0.9]")}
-                aria-label="Search"
-              >
-                <Search className="h-5 w-5" strokeWidth={2.2} />
-              </button>
-            </div>
-          </>
-        )}
-      </div>
-    </div>
   );
 }
 
@@ -945,11 +808,6 @@ export function KaiConnectPreviewView() {
           </section>
         </main>
 
-        <ConnectDock
-          searchQuery={searchQuery}
-          onSearchQueryChange={setSearchQuery}
-          onKaiOpen={() => setKaiOpen(true)}
-        />
       </div>
 
       {overlayOpen ? (

--- a/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
@@ -9,8 +9,6 @@ import {
   Blocks,
   ChartColumnIncreasing,
   ChevronRight,
-  CirclePlus,
-  Compass,
   Cpu,
   LineChart,
   Loader2,
@@ -20,11 +18,8 @@ import {
   Percent,
   Search,
   Sparkles,
-  Store,
   TrendingDown,
   TrendingUp,
-  UserRound,
-  WalletCards,
   X,
   type LucideIcon,
   Zap,
@@ -40,10 +35,6 @@ import {
   type MarketOverviewMetric,
 } from "@/components/kai/cards/market-overview-grid";
 import {
-  kaiPreviewDockActiveItemClassName,
-  kaiPreviewDockFrameClassName,
-  kaiPreviewDockItemClassName,
-  kaiPreviewDockSurfaceClassName,
   kaiPreviewEyebrowClassName,
   kaiPreviewPageTitleClassName,
   kaiPreviewSectionTitleClassName,
@@ -302,16 +293,44 @@ function toIndexStripItems(
         (row) => Boolean(row?.label) && !String(row.label).toLowerCase().includes("market status")
       )
     : [];
+
+  const hasUsableOverviewRow = (
+    row: NonNullable<KaiHomeInsightsV2["market_overview"]>[number] | null | undefined
+  ) => {
+    if (!row || row.degraded) return false;
+    if (typeof row.value === "number" && Number.isFinite(row.value)) return true;
+    return typeof row.value === "string" && row.value.trim() !== "" && !isUnavailableText(row.value);
+  };
+
   const benchmarkRows = [
     { label: "S&P 500", match: (label: string) => label.includes("s&p") || label.includes("sp 500") },
     { label: "NASDAQ 100", match: (label: string) => label.includes("nasdaq") },
     { label: "DOW 30", match: (label: string) => label.includes("dow") },
     { label: "Russell 2000", match: (label: string) => label.includes("russell") },
-  ].map(({ label, match }) => {
-    const row = overviewRows.find((candidate) => match(String(candidate.label || "").toLowerCase())) || null;
-    return toIndexOverviewMetric(row, label);
-  });
-  return benchmarkRows.length ? benchmarkRows : fallbackMetrics.slice(0, 4);
+  ]
+    .map(({ label, match }) => {
+      const row = overviewRows.find((candidate) => match(String(candidate.label || "").toLowerCase())) || null;
+      return hasUsableOverviewRow(row) ? toIndexOverviewMetric(row, label) : null;
+    })
+    .filter((row): row is MarketOverviewMetric => Boolean(row));
+
+  const providerRows = overviewRows
+    .filter(hasUsableOverviewRow)
+    .map((row) => toIndexOverviewMetric(row, String(row.label || "Market")));
+  const nonDelayedFallbackRows = fallbackMetrics.filter(
+    (metric) =>
+      !/delayed/i.test(`${metric.value} ${metric.delta}`) &&
+      !/delayed/i.test(metric.detailPanel?.statusLabel || "")
+  );
+  const seen = new Set<string>();
+  return [...benchmarkRows, ...providerRows, ...nonDelayedFallbackRows]
+    .filter((metric) => {
+      const key = metric.id || metric.label.toLowerCase();
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .slice(0, 4);
 }
 
 function toKaiStripText(
@@ -880,129 +899,6 @@ function OneMarketKaiSheet({
         </button>
       </div>
     </section>
-  );
-}
-
-function OneMarketDock({
-  searchOpen,
-  searchQuery,
-  onSearchOpen,
-  onSearchClose,
-  onSearchQueryChange,
-  onSearchSubmit,
-  onKaiOpen,
-}: {
-  searchOpen: boolean;
-  searchQuery: string;
-  onSearchOpen: () => void;
-  onSearchClose: () => void;
-  onSearchQueryChange: (value: string) => void;
-  onSearchSubmit: () => void;
-  onKaiOpen: () => void;
-}) {
-  const items: Array<{ label: string; href: string; icon: LucideIcon; active?: boolean }> = [
-    { label: "Market", href: "/kai", icon: Store, active: true },
-    { label: "Portfolio", href: "/kai/portfolio", icon: WalletCards },
-    { label: "Analysis", href: "/kai/analysis", icon: LineChart },
-    { label: "Connect", href: "/kai?preview=connect", icon: Compass },
-    { label: "Profile", href: "/profile", icon: UserRound },
-  ];
-  const submitDockSearch = () => {
-    const hasQuery = searchQuery.trim().length > 0;
-    onSearchSubmit();
-    if (hasQuery) {
-      onSearchClose();
-    }
-  };
-  return (
-    <div className={kaiPreviewDockFrameClassName}>
-      <div className="relative flex items-end gap-2.5 sm:gap-3">
-        {searchOpen ? (
-          <>
-            <form
-              onSubmit={(event) => {
-                event.preventDefault();
-                submitDockSearch();
-              }}
-              className={cn(
-                kaiPreviewDockSurfaceClassName,
-                "pointer-events-auto flex h-[50px] min-w-0 flex-1 items-center gap-[9px] rounded-full px-[15px] pr-2"
-              )}
-            >
-              <Search className="h-5 w-5 shrink-0 text-[color:var(--one-fg3)]" />
-              <input
-                placeholder="Search"
-                value={searchQuery}
-                onChange={(event) => onSearchQueryChange(event.target.value)}
-                className="min-w-0 flex-1 bg-transparent text-[14px] text-[color:var(--one-fg)] outline-none placeholder:text-[color:var(--one-fg3)]"
-              />
-              <button
-                type="button"
-                onClick={submitDockSearch}
-                className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[color:var(--one-blue)] text-white transition-transform active:scale-[0.92]"
-                aria-label="Voice search"
-              >
-                <Mic className="h-4 w-4" />
-              </button>
-            </form>
-            <button
-              type="button"
-              onClick={onSearchClose}
-              className="pointer-events-auto flex h-[50px] shrink-0 items-center justify-center rounded-full px-1.5 text-[14px] font-semibold text-[color:var(--one-link)]"
-            >
-              Cancel
-            </button>
-          </>
-        ) : (
-          <>
-            <nav
-              className={cn(
-                kaiPreviewDockSurfaceClassName,
-                "pointer-events-auto grid h-[58px] min-w-0 flex-1 grid-cols-5 content-center rounded-full px-1.5"
-              )}
-            >
-              {items.map((item) => {
-                const Icon = item.icon;
-                return (
-                  <button
-                    key={item.label}
-                    type="button"
-                    onClick={() => openOneMarketHref(item.href)}
-                    className={cn(
-                      kaiPreviewDockItemClassName,
-                      item.active && kaiPreviewDockActiveItemClassName
-                    )}
-                  >
-                    <Icon className="h-[21px] w-[21px]" strokeWidth={1.8} />
-                    <span className="truncate">{item.label}</span>
-                  </button>
-                );
-              })}
-            </nav>
-            <button
-              type="button"
-              onClick={onKaiOpen}
-              className={cn(kaiPreviewDockSurfaceClassName, "pointer-events-auto absolute bottom-[72px] right-1 grid h-[50px] w-[50px] place-items-center rounded-full")}
-              aria-label="Talk to Kai"
-            >
-              <span className="grid h-[30px] w-[30px] place-items-center rounded-[9px] bg-[color:var(--one-blue)] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.35)]">
-                <CirclePlus className="h-[15px] w-[15px]" strokeWidth={2} />
-              </span>
-            </button>
-            <div className="pointer-events-auto flex shrink-0">
-              <button
-                type="button"
-                onClick={onSearchOpen}
-                className={cn(kaiPreviewDockSurfaceClassName, "grid h-[58px] w-[58px] place-items-center rounded-full text-[color:var(--one-fg2)] transition-transform active:scale-[0.9]")}
-                aria-label="Search"
-              >
-                <Search className="h-5 w-5" strokeWidth={2.2} />
-              </button>
-            </div>
-          </>
-        )}
-      </div>
-    </div>
   );
 }
 
@@ -1855,10 +1751,8 @@ export function KaiMarketPreviewView() {
   const displayError = usingLocalPreviewFallback ? null : error;
   const [selectedOverviewMetricId, setSelectedOverviewMetricId] = useState<string | null>(null);
   const [moverTab, setMoverTab] = useState<OneMarketMoverTab>("gain");
-  const [topbarVisible, setTopbarVisible] = useState(false);
   const [notificationsOpen, setNotificationsOpen] = useState(false);
   const [kaiSheetOpen, setKaiSheetOpen] = useState(false);
-  const [dockSearchOpen, setDockSearchOpen] = useState(false);
   const [marketSearchQuery, setMarketSearchQuery] = useState("");
   const {
     activeControlId: activeVoiceControlId,
@@ -2115,21 +2009,9 @@ export function KaiMarketPreviewView() {
     setKaiSheetOpen(false);
   }, []);
 
-  useEffect(() => {
-    const updateTopbar = () => {
-      setTopbarVisible(window.scrollY > 64);
-    };
-    updateTopbar();
-    window.addEventListener("scroll", updateTopbar, { passive: true });
-    return () => {
-      window.removeEventListener("scroll", updateTopbar);
-    };
-  }, []);
-
   const handleMarketSearchSubmit = useCallback(() => {
     const query = marketSearchQuery.trim();
     if (!query) {
-      setDockSearchOpen(true);
       return;
     }
     const normalizedQuery = query.length <= 6 ? query.toUpperCase() : query;
@@ -2176,16 +2058,6 @@ export function KaiMarketPreviewView() {
         aria-hidden
         className="pointer-events-none absolute inset-0 -z-20 bg-[color:var(--one-bg)]"
       />
-      <div
-        className={cn(
-          oneMarketGlassClassName,
-          "pointer-events-none fixed inset-x-0 top-0 z-30 mx-auto flex h-[50px] max-w-[1080px] items-center justify-center bg-[color:var(--one-bg)] text-[17px] font-medium text-[color:var(--one-fg)] transition duration-300",
-          topbarVisible ? "translate-y-0 opacity-100" : "-translate-y-2 opacity-0"
-        )}
-      >
-        Market
-      </div>
-
       <div className="flex-1 pb-[calc(148px+env(safe-area-inset-bottom))] pt-0">
         <header className="mx-auto w-full max-w-[1080px] px-[var(--one-gutter)] pt-4">
           <div className="flex items-start justify-between">
@@ -2338,16 +2210,6 @@ export function KaiMarketPreviewView() {
           </>
         ) : null}
       </div>
-
-      <OneMarketDock
-        searchOpen={dockSearchOpen}
-        searchQuery={marketSearchQuery}
-        onSearchOpen={() => setDockSearchOpen(true)}
-        onSearchClose={() => setDockSearchOpen(false)}
-        onSearchQueryChange={setMarketSearchQuery}
-        onSearchSubmit={handleMarketSearchSubmit}
-        onKaiOpen={() => setKaiSheetOpen(true)}
-      />
 
       {shellOverlayOpen ? (
         <button

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -270,7 +270,7 @@ export const Navbar = () => {
           hideBottomChrome && "pointer-events-none"
         )}
       >
-        <div className="min-w-0 pointer-events-auto" style={{ width: "calc(100% - 68px)" }}>
+        <div className="min-w-0 pointer-events-auto" style={{ width: "calc(100% - 132px)" }}>
           <SegmentedPill
             ref={pillRef}
             size="compact"


### PR DESCRIPTION
## Summary
- promote Kai bottom chrome consolidation from integration train
- keeps one global nav/search/agent combo across Kai market, analysis, connect, portfolio, and profile surfaces
- removes route-local preview docks and duplicate scrolled top title chips

## Verification
- PR #2695 checks passed
- Browser tests skipped per request.