### PR TITLE
fix: align Kai agent search chrome

### DIFF
--- a/hushh-webapp/__tests__/components/agent-popover-provider.test.tsx
+++ b/hushh-webapp/__tests__/components/agent-popover-provider.test.tsx
@@ -69,7 +69,7 @@ describe("AgentPopoverProvider floating trigger", () => {
   let getBoundingClientRectSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    navigationMock.pathname = "/profile";
+    navigationMock.pathname = "/login";
     window.localStorage.clear();
     Object.defineProperty(window, "innerWidth", {
       configurable: true,
@@ -251,6 +251,22 @@ describe("AgentPopoverProvider floating trigger", () => {
 
   it("does not render a duplicate floating trigger on Kai command-bar routes", () => {
     navigationMock.pathname = "/kai";
+
+    render(
+      <div>
+        <div data-tour-id="kai-command-bar" />
+        <div aria-label="Main navigation" />
+        <AgentPopoverProvider>
+          <main />
+        </AgentPopoverProvider>
+      </div>
+    );
+
+    expect(screen.queryByRole("button", { name: "Open Agent" })).toBeNull();
+  });
+
+  it("does not render a duplicate floating trigger on Profile command-bar routes", () => {
+    navigationMock.pathname = "/profile";
 
     render(
       <div>

--- a/hushh-webapp/components/agent/agent-popover-provider.tsx
+++ b/hushh-webapp/components/agent/agent-popover-provider.tsx
@@ -306,10 +306,9 @@ function AgentPopoverSurface({ customSize, setCustomSize }: AgentPopoverSurfaceP
     useAgentPopover();
   const isLegacyAgentRoute = pathname === ROUTES.AGENT;
   const canShowAgent = isAuthenticated && !isLegacyAgentRoute;
-  const useRiaActionBarTrigger = isRiaActionBarRoute(pathname);
-  const useKaiCommandBarTrigger =
-    pathname.startsWith(ROUTES.KAI_HOME) && !getKaiChromeState(pathname).hideCommandBar;
-  const useEmbeddedAgentTrigger = useRiaActionBarTrigger || useKaiCommandBarTrigger;
+  const chromeState = getKaiChromeState(pathname);
+  const useEmbeddedAgentTrigger =
+    isRiaActionBarRoute(pathname) || !chromeState.hideCommandBar;
   const isCollapsing = motionState === "closing";
   const surfaceVisible = expanded || motionState !== "idle";
   const isFullscreen = sizeMode === "fullscreen";

--- a/hushh-webapp/components/kai/kai-search-bar.tsx
+++ b/hushh-webapp/components/kai/kai-search-bar.tsx
@@ -1672,7 +1672,7 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
     <>
       <div
         className={cn(
-          "fixed inset-x-0 z-[136] flex justify-center px-4 pointer-events-none",
+          "fixed inset-x-0 z-[121] flex justify-center px-4 pointer-events-none",
         )}
         style={{
           bottom: isRiaSurface
@@ -1740,29 +1740,29 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
               </ShellActionSurface>
             </div>
           ) : (
-            <div className="relative flex h-[58px] w-full justify-end gap-2">
-              <ShellActionSurface
-                variant="icon"
-                wrapperClassName="pointer-events-auto"
-                className="grid h-[58px] w-[58px] place-items-center"
-                contentClassName="h-full w-full"
-                aria-label="Talk to Kai"
-                disabled={!agentPopover}
-                onClick={() => agentPopover?.openAgent()}
-              >
-                <span className="grid h-[38px] w-[38px] place-items-center rounded-[13px] bg-[#0071e3] text-white shadow-[0_10px_24px_-16px_rgba(0,113,227,0.75),inset_0_1px_0_rgba(255,255,255,0.35)]">
-                  <X className="h-[17px] w-[17px] rotate-45" strokeWidth={2} />
-                </span>
-              </ShellActionSurface>
-              <ShellActionSurface
-                variant="icon"
-                wrapperClassName="pointer-events-auto"
-                className="grid h-[58px] w-[58px] place-items-center text-muted-foreground"
-                aria-label="Search"
-                onClick={() => setOpen(true)}
-              >
-                <Search className="h-5 w-5" strokeWidth={2.2} />
-              </ShellActionSurface>
+            <div className="relative flex h-[58px] w-full items-center justify-end">
+              <div className="ml-auto flex h-[58px] w-[124px] items-center justify-end gap-2">
+                <button
+                  type="button"
+                  className="pointer-events-auto grid h-[58px] w-[58px] place-items-center rounded-full transition-transform duration-200 ease-out hover:scale-[1.03] active:scale-[0.94] disabled:cursor-not-allowed disabled:opacity-50"
+                  aria-label="Talk to Kai"
+                  disabled={!agentPopover}
+                  onClick={() => agentPopover?.openAgent()}
+                >
+                  <span className="grid h-[38px] w-[38px] place-items-center rounded-[13px] bg-[#0071e3] text-white shadow-[0_10px_24px_-16px_rgba(0,113,227,0.75),inset_0_1px_0_rgba(255,255,255,0.35)]">
+                    <X className="h-[17px] w-[17px] rotate-45" strokeWidth={2} />
+                  </span>
+                </button>
+                <ShellActionSurface
+                  variant="icon"
+                  wrapperClassName="pointer-events-auto"
+                  className="grid h-[58px] w-[58px] place-items-center text-muted-foreground"
+                  aria-label="Search"
+                  onClick={() => setOpen(true)}
+                >
+                  <Search className="h-5 w-5" strokeWidth={2.2} />
+                </ShellActionSurface>
+              </div>
               <div className="hidden">
                 <VoiceAmbientSearchSurface
                   mode={ambientMode}


### PR DESCRIPTION
## Summary
- suppress the legacy draggable Agent trigger anywhere the global Kai command bar already provides Agent
- align the Agent and Search controls on the same bottom baseline as the nav pill
- remove the extra glass shell behind the blue Agent icon so it does not look like a second floating layer

## Verification
- npx eslint components/agent/agent-popover-provider.tsx components/kai/kai-search-bar.tsx --max-warnings=0
- npm run typecheck
- npm run verify:design-system
- npm run verify:cache
- npm run verify:docs

Browser tests skipped per request.