### PR TITLE
fix: align Kai typography hierarchy

### DIFF
--- a/hushh-webapp/components/auth/phone-verification-flow.tsx
+++ b/hushh-webapp/components/auth/phone-verification-flow.tsx
@@ -30,6 +30,11 @@ import {
 import { morphyToast } from "@/lib/morphy-ux/morphy";
 import { maskPhoneNumber } from "@/lib/services/phone-mandate-service";
 import { trackEvent } from "@/lib/observability/client";
+import {
+  kaiAppCardTitleClassName,
+  kaiAppHelperClassName,
+} from "@/components/kai/shared/kai-typography";
+import { cn } from "@/lib/utils";
 
 const E164_PHONE_PATTERN = /^\+[1-9]\d{7,14}$/;
 const DEFAULT_COUNTRY_VALUE = "US";
@@ -336,8 +341,8 @@ export function PhoneVerificationFlow({
           className={`${FLOW_SURFACE_RADIUS_CLASS_NAME} border border-emerald-500/20 bg-emerald-50/80 p-5 dark:bg-emerald-950/20`}
         >
           <ShieldCheck className="h-10 w-10 text-emerald-600" />
-          <h2 className="mt-4 text-lg font-semibold text-foreground">Phone already linked</h2>
-          <p className="mt-2 text-sm text-muted-foreground">
+          <h2 className={cn(kaiAppCardTitleClassName, "mt-4 text-foreground")}>Phone already linked</h2>
+          <p className={cn(kaiAppHelperClassName, "mt-2 text-muted-foreground")}>
             This account already has a verified phone number:{" "}
             {maskedPhone || "already on this account"}.
           </p>
@@ -438,7 +443,7 @@ export function PhoneVerificationFlow({
             </Field>
           </FieldGroup>
 
-          <FieldDescription className="text-[15px] leading-7 text-muted-foreground">
+          <FieldDescription className="text-[15px] font-normal leading-[1.45] text-muted-foreground">
             {helperText ||
               "Choose your country code and enter your phone number. We’ll send you a verification code."}
           </FieldDescription>
@@ -471,8 +476,8 @@ export function PhoneVerificationFlow({
           <div
             className={`${FLOW_SURFACE_RADIUS_CLASS_NAME} border border-black/5 bg-neutral-50 p-5 dark:bg-neutral-900/60`}
           >
-            <p className="text-sm font-medium text-foreground">Verification code sent</p>
-            <p className="mt-2 text-sm text-muted-foreground">
+            <p className={cn(kaiAppCardTitleClassName, "text-foreground")}>Verification code sent</p>
+            <p className={cn(kaiAppHelperClassName, "mt-2 text-muted-foreground")}>
               We sent a verification code to {submittedPhoneNumber}. Enter it to continue.
             </p>
           </div>

--- a/hushh-webapp/components/kai/shared/kai-typography.ts
+++ b/hushh-webapp/components/kai/shared/kai-typography.ts
@@ -1,0 +1,25 @@
+"use client";
+
+export const kaiAppEyebrowClassName =
+  "text-[10.5px] font-medium uppercase tracking-[0.14em]";
+
+export const kaiAppDisplayTitleClassName =
+  "text-[36px] font-medium leading-[1.06] tracking-normal sm:text-[48px]";
+
+export const kaiAppCompactTitleClassName =
+  "text-[34px] font-medium leading-[1.06] tracking-normal sm:text-[42px]";
+
+export const kaiAppBodyClassName =
+  "text-[16px] font-normal leading-[1.45] tracking-normal sm:text-[17px]";
+
+export const kaiAppSectionTitleClassName =
+  "text-[21px] font-medium leading-[1.12] tracking-normal sm:text-[24px]";
+
+export const kaiAppCardTitleClassName =
+  "text-[16.5px] font-medium leading-[1.22] tracking-normal";
+
+export const kaiAppCardBodyClassName =
+  "text-[14px] font-normal leading-[1.42] tracking-normal";
+
+export const kaiAppHelperClassName =
+  "text-[12.5px] font-normal leading-[1.45] tracking-normal";

--- a/hushh-webapp/components/kai/shared/market-surface-theme.ts
+++ b/hushh-webapp/components/kai/shared/market-surface-theme.ts
@@ -1,6 +1,11 @@
 "use client";
 
 import { cn } from "@/lib/utils";
+import {
+  kaiAppDisplayTitleClassName,
+  kaiAppEyebrowClassName,
+  kaiAppSectionTitleClassName,
+} from "@/components/kai/shared/kai-typography";
 
 export const marketSurfaceVariablesClassName = cn(
   "[--app-card-surface-default-solid:rgba(255,255,255,0.68)]",
@@ -18,13 +23,13 @@ export const marketSurfaceVariablesClassName = cn(
 );
 
 export const kaiPreviewEyebrowClassName =
-  "text-[11px] font-medium uppercase tracking-[0.16em]";
+  kaiAppEyebrowClassName;
 
 export const kaiPreviewPageTitleClassName =
-  "font-sans !text-[34px] !font-medium !leading-[1.06] !tracking-normal text-[color:var(--one-fg)] sm:!text-[40px]";
+  cn("font-sans text-[color:var(--one-fg)]", kaiAppDisplayTitleClassName);
 
 export const kaiPreviewSectionTitleClassName =
-  "flex min-w-0 items-center gap-2.5 !text-[22px] !font-medium !leading-[1.08] !tracking-normal text-[color:var(--one-fg)] sm:!text-[24px]";
+  cn("flex min-w-0 items-center gap-2.5 text-[color:var(--one-fg)]", kaiAppSectionTitleClassName);
 
 export const kaiPreviewDockFrameClassName =
   "pointer-events-none fixed inset-x-0 bottom-0 z-30 mx-auto w-full max-w-[560px] px-4 pb-[calc(10px+env(safe-area-inset-bottom))] sm:px-6";

--- a/hushh-webapp/components/kai/views/portfolio-import-view.tsx
+++ b/hushh-webapp/components/kai/views/portfolio-import-view.tsx
@@ -29,6 +29,14 @@ import { Badge } from "@/components/ui/badge";
 import { SurfaceCard, SurfaceCardContent } from "@/components/app-ui/surfaces";
 import { Icon } from "@/lib/morphy-ux/ui";
 import { scrollAppToTop } from "@/lib/navigation/use-scroll-reset";
+import {
+  kaiAppBodyClassName,
+  kaiAppCardBodyClassName,
+  kaiAppCardTitleClassName,
+  kaiAppCompactTitleClassName,
+  kaiAppEyebrowClassName,
+  kaiAppHelperClassName,
+} from "@/components/kai/shared/kai-typography";
 
 // =============================================================================
 // TYPES
@@ -154,19 +162,19 @@ export function PortfolioImportView({
   return (
     <div className="mx-auto w-full space-y-3.5 pt-3 pb-6" style={APP_MEASURE_STYLES.reading}>
       {/* Header */}
-      <div className="space-y-2 text-center">
-        <h1 className="text-[34px] font-medium tracking-normal leading-[1.06] sm:text-[40px]">
+      <div className="space-y-2.5 text-center">
+        <h1 className={kaiAppCompactTitleClassName}>
           Your money
           <br />
           <span>Your options</span>
         </h1>
-        <p className="text-[17px] font-normal text-muted-foreground leading-[1.42]">
+        <p className={cn(kaiAppBodyClassName, "text-muted-foreground")}>
           Let Kai analyze your holdings for precise advice
         </p>
       </div>
 
       <div className="text-center">
-        <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+        <p className={cn(kaiAppEyebrowClassName, "text-muted-foreground")}>
           Choose import method
         </p>
       </div>
@@ -180,8 +188,8 @@ export function PortfolioImportView({
                 <Icon icon={Link2} size="md" className="text-primary" />
               </div>
               <div className="min-w-0">
-                <h3 className="text-[17px] font-semibold leading-tight">Connect with Plaid</h3>
-                <p className="text-[13px] font-medium text-muted-foreground leading-snug">
+                <h3 className={kaiAppCardTitleClassName}>Connect with Plaid</h3>
+                <p className={cn(kaiAppCardBodyClassName, "mt-0.5 text-muted-foreground")}>
                   Automatically sync your brokerage accounts
                 </p>
               </div>
@@ -201,7 +209,7 @@ export function PortfolioImportView({
               )}
             </div>
           </div>
-          <p className="text-[12px] text-muted-foreground">
+          <p className={cn(kaiAppHelperClassName, "text-muted-foreground")}>
             Best for brokerage-sourced holdings, refreshable sync status, and non-editable portfolio context.
           </p>
           <MorphyButton
@@ -224,7 +232,7 @@ export function PortfolioImportView({
                   ? "Connect Another Brokerage"
                   : "Connect Brokerage With Plaid"}
           </MorphyButton>
-          <p className="text-[11px] text-muted-foreground">
+          <p className={cn(kaiAppHelperClassName, "text-muted-foreground")}>
             Plaid data stays read-only in Kai. Statements remain your editable source.
           </p>
         </SurfaceCardContent>
@@ -232,7 +240,7 @@ export function PortfolioImportView({
 
       <div className="flex items-center gap-3">
         <div className="h-px flex-1 bg-border/60" />
-        <span className="text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+        <span className={cn(kaiAppEyebrowClassName, "text-muted-foreground")}>
           or
         </span>
         <div className="h-px flex-1 bg-border/60" />
@@ -246,8 +254,8 @@ export function PortfolioImportView({
               <Icon icon={Upload} size="md" className="text-primary" />
             </div>
             <div>
-              <h3 className="text-[17px] font-semibold text-foreground">Upload statement</h3>
-              <p className="text-[13px] font-medium text-muted-foreground">
+              <h3 className={cn(kaiAppCardTitleClassName, "text-foreground")}>Upload statement</h3>
+              <p className={cn(kaiAppCardBodyClassName, "mt-0.5 text-muted-foreground")}>
                 Import official brokerage PDF or CSV manually
               </p>
             </div>
@@ -274,12 +282,12 @@ export function PortfolioImportView({
 
             {/* Text */}
             <div className="space-y-1">
-              <h3 className="text-[17px] font-semibold text-primary">
+              <h3 className={cn(kaiAppCardTitleClassName, "text-primary")}>
                 {isDragging
                   ? "Drop your file here"
                   : "Tap to upload official statement"}
               </h3>
-              <p className="text-[14px] font-medium text-muted-foreground">
+              <p className={cn(kaiAppCardBodyClassName, "text-muted-foreground")}>
                 PDF or CSV
               </p>
             </div>
@@ -322,12 +330,12 @@ export function PortfolioImportView({
       </SurfaceCard>
 
       {selectionError && (
-        <p className="text-xs text-destructive px-2">{selectionError}</p>
+        <p className={cn(kaiAppHelperClassName, "px-2 text-destructive")}>{selectionError}</p>
       )}
 
       <div className="flex items-start gap-2 rounded-xl border border-border/60 bg-muted/30 px-3 py-2.5">
         <Icon icon={AlertCircle} size="sm" className="mt-0.5 text-muted-foreground shrink-0" />
-        <p className="text-[12px] leading-relaxed text-muted-foreground">
+        <p className={cn(kaiAppHelperClassName, "text-muted-foreground")}>
           We support official brokerage statements from all major systems.
         </p>
       </div>
@@ -348,7 +356,7 @@ export function PortfolioImportView({
           >
             {isPreloadingSchema ? "Loading Sample Brokerage..." : "Load Sample Brokerage"}
           </MorphyButton>
-          <p className="px-1 text-[11px] text-muted-foreground">
+          <p className={cn(kaiAppHelperClassName, "px-1 text-muted-foreground")}>
             Load demo portfolio data any time, review it, then save to vault.
           </p>
         </div>

--- a/hushh-webapp/components/kai/views/portfolio-overview-view.tsx
+++ b/hushh-webapp/components/kai/views/portfolio-overview-view.tsx
@@ -33,6 +33,14 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Icon } from "@/lib/morphy-ux/ui";
+import {
+  kaiAppBodyClassName,
+  kaiAppCardBodyClassName,
+  kaiAppCardTitleClassName,
+  kaiAppCompactTitleClassName,
+  kaiAppEyebrowClassName,
+  kaiAppHelperClassName,
+} from "@/components/kai/shared/kai-typography";
 
 // =============================================================================
 // TYPES
@@ -86,20 +94,20 @@ export function PortfolioOverviewView({
   const kpiIconClassName =
     "rounded-2xl border border-transparent bg-[color:var(--app-card-surface-compact)] p-2 text-muted-foreground shadow-[var(--shadow-xs)]";
   const kpiLabelClassName =
-    "text-[11px] font-medium uppercase tracking-normal text-muted-foreground";
+    cn(kaiAppEyebrowClassName, "text-muted-foreground");
   const kpiValueClassName =
-    "text-2xl font-semibold tracking-normal text-foreground sm:text-[1.7rem]";
+    "text-[26px] font-medium leading-none tracking-normal text-foreground sm:text-[30px]";
   const actionCardClassName =
     "flex h-full min-h-[132px] flex-col items-start gap-3 rounded-[var(--app-card-radius-compact)] border border-transparent bg-[color:var(--app-card-surface-compact)] p-5 text-left shadow-[var(--shadow-xs)] transition-[background-color,box-shadow,transform] duration-200 hover:bg-[color:var(--app-card-surface-default-solid)] hover:shadow-[var(--app-card-shadow-standard)] hover:-translate-y-0.5";
 
   return (
     <div className="w-full space-y-5">
       {/* Header */}
-      <div className="space-y-1.5">
-        <h1 className="text-[1.7rem] font-semibold leading-tight tracking-normal text-foreground sm:text-3xl">
+      <div className="space-y-2">
+        <h1 className={cn(kaiAppCompactTitleClassName, "text-foreground")}>
           Portfolio Overview
         </h1>
-        <p className="text-sm leading-6 text-muted-foreground">
+        <p className={cn(kaiAppBodyClassName, "text-muted-foreground")}>
           Your investment portfolio at a glance
         </p>
       </div>
@@ -116,7 +124,7 @@ export function PortfolioOverviewView({
               <span className={kpiLabelClassName}>Holdings</span>
             </div>
             <p className={kpiValueClassName}>{holdingsCount}</p>
-            <p className="mt-1 text-xs text-muted-foreground">
+            <p className={cn(kaiAppHelperClassName, "mt-1 text-muted-foreground")}>
               Tracked positions
             </p>
           </SurfaceCardContent>
@@ -136,7 +144,7 @@ export function PortfolioOverviewView({
                 ? valueBucketLabels[portfolioValue] || portfolioValue
                 : "N/A"}
             </p>
-            <p className="mt-1 text-xs text-muted-foreground">
+            <p className={cn(kaiAppHelperClassName, "mt-1 text-muted-foreground")}>
               Estimated range
             </p>
           </SurfaceCardContent>
@@ -165,7 +173,7 @@ export function PortfolioOverviewView({
                 ? `${totalGainLossPct >= 0 ? "+" : ""}${totalGainLossPct.toFixed(1)}%`
                 : "N/A"}
             </p>
-            <p className="mt-1 text-xs text-muted-foreground">
+            <p className={cn(kaiAppHelperClassName, "mt-1 text-muted-foreground")}>
               Total gain/loss
             </p>
           </SurfaceCardContent>
@@ -183,7 +191,7 @@ export function PortfolioOverviewView({
             <p className={cn(kpiValueClassName, "capitalize", riskColors[riskProfile])}>
               {riskProfile}
             </p>
-            <p className="mt-1 text-xs text-muted-foreground">
+            <p className={cn(kaiAppHelperClassName, "mt-1 text-muted-foreground")}>
               Investment style
             </p>
           </SurfaceCardContent>
@@ -198,16 +206,16 @@ export function PortfolioOverviewView({
               <div className="flex items-center gap-3">
                 <Icon icon={TrendingUp} size="md" className="text-green-600 dark:text-green-300" />
                 <div>
-                  <p className="text-2xl font-semibold tracking-normal">{winnersCount}</p>
-                  <p className="text-xs text-muted-foreground">Winners</p>
+                  <p className="text-[26px] font-medium leading-none tracking-normal">{winnersCount}</p>
+                  <p className={cn(kaiAppHelperClassName, "mt-1 text-muted-foreground")}>Winners</p>
                 </div>
               </div>
               <div className="h-12 w-px bg-border" />
               <div className="flex items-center gap-3">
                 <Icon icon={TrendingDown} size="md" className="text-red-600 dark:text-red-300" />
                 <div>
-                  <p className="text-2xl font-semibold tracking-normal">{losersCount}</p>
-                  <p className="text-xs text-muted-foreground">Losers</p>
+                  <p className="text-[26px] font-medium leading-none tracking-normal">{losersCount}</p>
+                  <p className={cn(kaiAppHelperClassName, "mt-1 text-muted-foreground")}>Losers</p>
                 </div>
               </div>
             </div>
@@ -238,8 +246,8 @@ export function PortfolioOverviewView({
                 }}
               >
                 <div className="w-full text-left">
-                  <h4 className="font-semibold mb-1">Review Losers</h4>
-                  <p className="text-xs text-muted-foreground">
+                  <h4 className={cn(kaiAppCardTitleClassName, "mb-1")}>Review Losers</h4>
+                  <p className={cn(kaiAppHelperClassName, "text-muted-foreground")}>
                     {losersCount} position{losersCount > 1 ? "s" : ""} need attention
                   </p>
                 </div>
@@ -258,8 +266,8 @@ export function PortfolioOverviewView({
                 }}
               >
                 <div className="w-full text-left">
-                  <h4 className="font-semibold mb-1">Analyze Stock</h4>
-                  <p className="text-xs text-muted-foreground">
+                  <h4 className={cn(kaiAppCardTitleClassName, "mb-1")}>Analyze Stock</h4>
+                  <p className={cn(kaiAppHelperClassName, "text-muted-foreground")}>
                     Get Kai's investment analysis
                   </p>
                 </div>
@@ -278,8 +286,8 @@ export function PortfolioOverviewView({
                 }}
               >
                 <div className="w-full text-left">
-                  <h4 className="font-semibold mb-1">Import New</h4>
-                  <p className="text-xs text-muted-foreground">
+                  <h4 className={cn(kaiAppCardTitleClassName, "mb-1")}>Import New</h4>
+                  <p className={cn(kaiAppHelperClassName, "text-muted-foreground")}>
                     Update with latest statement
                   </p>
                 </div>
@@ -298,8 +306,8 @@ export function PortfolioOverviewView({
                 }}
               >
                 <div className="w-full text-left">
-                  <h4 className="font-semibold mb-1">Settings</h4>
-                  <p className="text-xs text-muted-foreground">
+                  <h4 className={cn(kaiAppCardTitleClassName, "mb-1")}>Settings</h4>
+                  <p className={cn(kaiAppHelperClassName, "text-muted-foreground")}>
                     Risk profile & preferences
                   </p>
                 </div>
@@ -316,8 +324,8 @@ export function PortfolioOverviewView({
           <div className="flex items-start gap-3">
             <Icon icon={Activity} size="md" className="text-primary mt-0.5 shrink-0" />
             <div>
-              <h4 className="mb-1 text-sm font-semibold tracking-normal">About Your Portfolio</h4>
-              <p className="text-sm leading-6 text-muted-foreground">
+              <h4 className={cn(kaiAppCardTitleClassName, "mb-1 text-foreground")}>About Your Portfolio</h4>
+              <p className={cn(kaiAppCardBodyClassName, "text-muted-foreground")}>
                 Kai tracks your portfolio using encrypted data in your personal vault.
                 All analysis happens with your privacy intact. Holdings data is organized
                 into the financial domain of your Personal Knowledge Model.

--- a/hushh-webapp/components/onboarding/AuthStep.tsx
+++ b/hushh-webapp/components/onboarding/AuthStep.tsx
@@ -565,11 +565,11 @@ export function AuthStep({
           <div
             role="heading"
             aria-level={1}
-            className="mt-3 text-[34px] font-medium leading-[1.06] tracking-normal text-[#1d1d1f] sm:text-[40px] dark:text-[#f5f5f7]"
+            className="mt-2.5 text-[36px] font-medium leading-[1.06] tracking-normal text-[#1d1d1f] sm:text-[42px] dark:text-[#f5f5f7]"
           >
             Sign in to One.
           </div>
-          <p className="mx-auto mt-3 max-w-[20rem] text-[17px] font-normal leading-[1.42] tracking-normal text-[#6e6e73] dark:text-[#a1a1a6]">
+          <p className="mx-auto mt-3 max-w-[20rem] text-[16px] font-normal leading-[1.45] tracking-normal text-[#6e6e73] sm:text-[17px] dark:text-[#a1a1a6]">
             Continue to your personal financial advisor.
           </p>
         </header>
@@ -608,7 +608,7 @@ export function AuthStep({
           </div>
         </section>
 
-        <footer className={compact ? "mt-auto flex-none pt-9" : "mt-auto flex-none pt-10"}>
+        <footer className={compact ? "mt-auto flex-none pt-8" : "mt-auto flex-none pt-10"}>
           <p className="mx-auto max-w-[19.5rem] text-center text-[11px] leading-[1.45] text-[#86868b] dark:text-[#8e8e93]">
             By continuing, you agree to Kai&apos;s{" "}
             <button

--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -102,16 +102,16 @@ export function IntroStep({
             role="heading"
             aria-level={1}
             aria-label="Meet One, Your Personal Financial Advisor"
-            className="relative mt-3 text-[40px] font-medium leading-[1.04] tracking-normal text-[#1d1d1f] dark:text-[#f5f5f7]"
+            className="relative mt-2.5 text-[38px] font-medium leading-[1.05] tracking-normal text-[#1d1d1f] sm:text-[40px] dark:text-[#f5f5f7]"
           >
             Meet One.
           </div>
-          <p className="relative mt-3 text-[19px] font-normal leading-[1.34] tracking-normal text-[rgba(0,0,0,0.56)] dark:text-[rgba(245,245,247,0.60)]">
+          <p className="relative mt-3 text-[17px] font-normal leading-[1.42] tracking-normal text-[rgba(0,0,0,0.56)] sm:text-[18px] dark:text-[rgba(245,245,247,0.60)]">
             Your personal financial advisor.
           </p>
         </section>
 
-        <div className="flex min-h-0 flex-1 items-center py-7">
+        <div className="flex min-h-0 flex-1 items-center py-6">
           <div className="relative w-full">
             <div className="relative z-10 mx-auto flex w-full max-w-[340px] flex-col gap-5">
               {INTRO_FEATURES.map((feature) => (


### PR DESCRIPTION
## Summary
- add a shared Kai typography ladder based on the rendered HushhTech hierarchy
- apply the ladder to Kai preview page titles/section headings, portfolio import, portfolio overview, login, Meet One, and phone verification copy
- keep the change frontend-only for Kai UAT; no backend behavior or production deploy changes

## Verification
- npm run typecheck
- npm run lint
- npm run verify:design-system
- npm run verify:cache
- npm run verify:docs

Browser tests skipped per request.
