### PR TITLE
test(voice): verify enforceArrayDimensionCap preserves elements when processing an array with multi-byte emoji string entries

### DIFF
--- a/hushh-webapp/__tests__/voice/screen-context-builder.test.ts
+++ b/hushh-webapp/__tests__/voice/screen-context-builder.test.ts
@@ -92,6 +92,15 @@ describe("enforceArrayDimensionCap — structured input array bounds", () => {
     expect(result.errorLabel).toBeNull();
   });
 
+  it("preserves elements when processing an array with multi-byte emoji string entries", () => {
+    const emojiPayload = ["🚀", "🔥", "🛡️"];
+    const result = enforceArrayDimensionCap(emojiPayload);
+
+    expect(result.isValidAllocation).toBe(true);
+    expect(result.items).toEqual(emojiPayload);
+    expect(result.errorLabel).toBeNull();
+  });
+
   it("accepts an array whose length equals the default cap exactly", () => {
     const atCap = Array.from({ length: STRUCTURED_CONTEXT_ARRAY_CAP }, (_, i) => i);
     const result = enforceArrayDimensionCap(atCap);


### PR DESCRIPTION
## Summary
Asserts that `enforceArrayDimensionCap` returns a valid allocation, preserves the returned `items` array, and leaves `errorLabel` null when processing an array containing multi-byte emoji string entries.

## Production function exercised
- `enforceArrayDimensionCap` from `hushh-webapp/lib/voice/screen-context-builder.ts`

## Test file
- `hushh-webapp/__tests__/voice/screen-context-builder.test.ts`

## CI gate checklist
- [x] PR Base Policy - targets `integration/pr-train`
- [x] DCO - Signed-off-by included
- [x] Narrow surface - one additive assertion block for `enforceArrayDimensionCap`
- [x] Clean diff - 1 tracked file, 9 additive lines, fresh upstream base
- [x] Proof - `npm test -- __tests__/voice/screen-context-builder.test.ts` passed locally