### PR TITLE
test(api): verify createUpstreamHeaders preserves a custom header string containing nested colon punctuation characters

### DIFF
--- a/hushh-webapp/__tests__/api/request-id-headers.test.ts
+++ b/hushh-webapp/__tests__/api/request-id-headers.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { createUpstreamHeaders } from "@/app/api/_utils/request-id";
+import { REQUEST_ID_HEADER } from "@/lib/observability/request-id";
+
+describe("createUpstreamHeaders", () => {
+  it("preserves a custom header string containing nested colon punctuation characters", () => {
+    const rawInput = "custom:header:string";
+    const headers = createUpstreamHeaders("req_colon_123", {
+      "X-Hushh-Custom-Metadata": rawInput,
+    });
+
+    expect(headers.get(REQUEST_ID_HEADER)).toBe("req_colon_123");
+    expect(headers.get("X-Hushh-Custom-Metadata")).toBe(rawInput);
+  });
+});


### PR DESCRIPTION
## Summary
Asserts that `createUpstreamHeaders` returns a `Headers` object that preserves the request id header and preserves a custom header value equal to `custom:header:string`.

## Production function exercised
- `createUpstreamHeaders` from `hushh-webapp/app/api/_utils/request-id.ts`

## Test file
- `hushh-webapp/__tests__/api/request-id-headers.test.ts`

## CI gate checklist
- [x] PR Base Policy - targets `integration/pr-train`
- [x] DCO - Signed-off-by included
- [x] Narrow surface - one additive assertion block for `createUpstreamHeaders`
- [x] Clean diff - 1 tracked file, 16 additive lines, fresh upstream base
- [x] Proof - `npm test -- __tests__/api/request-id-headers.test.ts` passed locally