### PR TITLE
test(consent): verify normalizeInternalAppHref processes route values when input contains consecutive sequential slash characters

### DIFF
--- a/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
+++ b/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
@@ -11,6 +11,13 @@ describe("consent sheet route helpers", () => {
     expect(normalizeInternalAppHref("/consents?tab=pending")).toBe("/consents?tab=pending");
   });
 
+  it("processes internal route values when the input string contains consecutive sequential slash characters", () => {
+    const doubleSlashInput = "/consents//callback";
+    const result = normalizeInternalAppHref(doubleSlashInput);
+
+    expect(result).toBe(doubleSlashInput);
+  });
+
   it("normalizes absolute localhost consent links to relative app routes", () => {
     expect(
       normalizeInternalAppHref("http://localhost:3000/consents?tab=pending&requestId=req_123")


### PR DESCRIPTION
## Summary
Adds a narrow unit test asserting that `normalizeInternalAppHref(/consents//callback)` returns the same `/consents//callback` string when the internal app route value contains consecutive sequential slash characters.

## Production function exercised
- `normalizeInternalAppHref` from `hushh-webapp/lib/consent/consent-sheet-route.ts`

## Test file
- `hushh-webapp/__tests__/utils/consent-sheet-route.test.ts`

## CI gate checklist
- [x] PR Base Policy - targets `integration/pr-train`
- [x] DCO - Signed-off-by included
- [x] Narrow surface - one additive assertion for `normalizeInternalAppHref`
- [x] Clean diff - 1 tracked file, 7 additive lines, fresh upstream base
- [x] Proof - `npm test -- __tests__/utils/consent-sheet-route.test.ts` passed locally