### PR TITLE
fix: stack Kai agent above search

### DIFF
--- a/hushh-webapp/components/kai/kai-search-bar.tsx
+++ b/hushh-webapp/components/kai/kai-search-bar.tsx
@@ -1740,17 +1740,17 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
               </ShellActionSurface>
             </div>
           ) : (
-            <div className="relative flex h-[58px] w-full items-center justify-end">
-              <div className="ml-auto flex h-[58px] w-[124px] items-center justify-end gap-2">
+            <div className="relative flex h-[124px] w-full items-end justify-end">
+              <div className="ml-auto flex h-[124px] w-[58px] flex-col items-center justify-end gap-2">
                 <button
                   type="button"
                   className="pointer-events-auto grid h-[58px] w-[58px] place-items-center rounded-full transition-transform duration-200 ease-out hover:scale-[1.03] active:scale-[0.94] disabled:cursor-not-allowed disabled:opacity-50"
-                  aria-label="Talk to Kai"
+                  aria-label="Open Kai agent"
                   disabled={!agentPopover}
                   onClick={() => agentPopover?.openAgent()}
                 >
                   <span className="grid h-[38px] w-[38px] place-items-center rounded-[13px] bg-[#0071e3] text-white shadow-[0_10px_24px_-16px_rgba(0,113,227,0.75),inset_0_1px_0_rgba(255,255,255,0.35)]">
-                    <X className="h-[17px] w-[17px] rotate-45" strokeWidth={2} />
+                    <Bot className="h-[17px] w-[17px]" strokeWidth={2} />
                   </span>
                 </button>
                 <ShellActionSurface


### PR DESCRIPTION
## Summary
- stack the shared Kai Agent control above Search across Kai pages
- replace the plus-looking rotated X with an agent icon
- keep existing Agent/Search behavior and backend routes unchanged

## Validation
- npm run typecheck
- npm run lint
- npm run verify:design-system
- npm run verify:cache
- npm run verify:docs

Browser tests skipped per request.