### PR TITLE
test(consent): verify resolveConsentNavigationTarget processes navigation target values when input features mixed case characters

### DIFF
--- a/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
+++ b/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
@@ -75,6 +75,16 @@ describe("consent sheet route helpers", () => {
       href: "https://example.com/disclosures/request-123",
     });
   });
+
+  it("processes navigation target values when the input string features mixed case characters and trailing numerical query elements", () => {
+    const mixedCaseInput = "/Consent/Auth?hash=992A";
+    const result = resolveConsentNavigationTarget(mixedCaseInput);
+
+    expect(result).toEqual({
+      kind: "external",
+      href: mixedCaseInput,
+    });
+  });
 });
 
 // ── Path safety — edge cases, empty inputs, and traversal resistance ──────────


### PR DESCRIPTION
## Summary
Adds a narrow unit test asserting that `resolveConsentNavigationTarget(/Consent/Auth?hash=992A)` returns an external navigation target with `href` equal to `/Consent/Auth?hash=992A`.

## Production function exercised
- `resolveConsentNavigationTarget` from `hushh-webapp/lib/consent/consent-sheet-route.ts`

## Test file
- `hushh-webapp/__tests__/utils/consent-sheet-route.test.ts`

## CI gate checklist
- [x] PR Base Policy - targets `integration/pr-train`
- [x] DCO - Signed-off-by included
- [x] Narrow surface - one additive assertion for `resolveConsentNavigationTarget`
- [x] Clean diff - 1 tracked file, 10 additive lines, fresh upstream base
- [x] Proof - `npm test -- __tests__/utils/consent-sheet-route.test.ts` passed locally