### PR TITLE
fix(manage-portfolio): replace any with LucideProps on SpinningLoader

### DIFF
--- a/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
+++ b/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
@@ -15,7 +15,7 @@
 
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
-import { Plus, Pencil, Trash2, Save, Loader2, Undo2 } from "lucide-react";
+import { Plus, Pencil, Trash2, Save, Loader2, Undo2, type LucideProps } from "lucide-react";
 import { Kbd } from "@/components/ui/kbd";
 
 import { toast } from "sonner";
@@ -134,7 +134,7 @@ function deriveRiskBucket(holdings: Holding[]): string {
   return "conservative";
 }
 
-const SpinningLoader = (props: any) => (
+const SpinningLoader = (props: LucideProps) => (
   <Loader2 {...props} className={cn(props.className, "animate-spin")} />
 );
 


### PR DESCRIPTION
## Summary

Replaces the `any` type on `SpinningLoader` with the explicit `LucideProps` type from `lucide-react`.

## Problem

`SpinningLoader` currently accepts `props: any`, bypassing TypeScript validation and suppressing type safety for a Lucide icon wrapper.

## Changes

* Add `type LucideProps` to the existing `lucide-react` import
* Replace `props: any` with `props: LucideProps`

## Why This Is Safe

`LucideProps` is the official prop type used by Lucide icons and includes all props currently forwarded to `Loader2`, including `className`.

The implementation remains identical:

* Same rendered component
* Same forwarded props
* Same animation behavior
* Same styling

## Impact

* No runtime changes
* No visual changes
* No UX changes
* Improved TypeScript coverage
* Removes unnecessary use of `any`

## Files Changed

* `hushh-webapp/components/kai/views/manage-portfolio-view.tsx`
