### PR TITLE
fix(consent-inbox-dropdown): add explicit return types to navigation helpers

### DIFF
--- a/hushh-webapp/components/consent/consent-inbox-dropdown.tsx
+++ b/hushh-webapp/components/consent/consent-inbox-dropdown.tsx
@@ -73,14 +73,14 @@ function formatRelative(value?: string | number | null) {
   return `${Math.ceil(totalHours / 24)} days left`;
 }
 
-function entryHref(actor: ConsentCenterActor, entry: ConsentCenterEntry) {
+function entryHref(actor: ConsentCenterActor, entry: ConsentCenterEntry): string {
   const requestId = entry.request_id || entry.id;
   return actor === "ria"
     ? buildRiaConsentManagerHref("pending", { requestId })
     : buildConsentCenterHref("pending", { actor: "investor", requestId });
 }
 
-function managerHref(actor: ConsentCenterActor) {
+function managerHref(actor: ConsentCenterActor): string {
   return actor === "ria"
     ? buildRiaConsentManagerHref("pending")
     : buildConsentCenterHref("pending", { actor: "investor" });


### PR DESCRIPTION
## Summary

Adds explicit `string` return type annotations to the consent inbox navigation helper functions.

## Problem

`entryHref` and `managerHref` rely on TypeScript inference for their return types. While the inferred type is already correct, the functions construct navigation URLs used throughout the consent inbox flow and benefit from explicit return type contracts.

## Changes

* Add `: string` to `entryHref`
* Add `: string` to `managerHref`

Both functions already return values from helpers that explicitly declare a `string` return type.

## Why This Is Safe

* No logic changes
* No runtime changes
* No visual changes
* No UX changes
* No behavior changes

The update only makes an existing inferred type explicit.

## Impact

* Improves type safety and static analysis
* Prevents accidental future return type drift
* Aligns with existing typed navigation helper patterns in the consent flow

## Files Changed

* `hushh-webapp/components/consent/consent-inbox-dropdown.tsx`
