### PR TITLE
promote: Kai agent search chrome to main

### DIFF
--- a/hushh-webapp/__tests__/voice/kai-search-bar.test.ts
+++ b/hushh-webapp/__tests__/voice/kai-search-bar.test.ts
@@ -15,6 +15,8 @@ const { mockOpenAgent } = vi.hoisted(() => ({
 vi.mock("lucide-react", () => ({
   Bot: () => createElement("span", { "data-testid": "bot-icon" }),
   Bug: () => null,
+  MessageCircle: () =>
+    createElement("span", { "data-testid": "message-circle-icon" }),
   Mic: () => createElement("span", { "data-testid": "mic-icon" }),
   Search: () => createElement("span", { "data-testid": "search-icon" }),
   X: () => createElement("span", { "data-testid": "x-icon" }),

--- a/hushh-webapp/components/kai/kai-search-bar.tsx
+++ b/hushh-webapp/components/kai/kai-search-bar.tsx
@@ -10,7 +10,7 @@ import {
   useState,
   type MouseEvent,
 } from "react";
-import { Bot, Mic, Search, X } from "lucide-react";
+import { Bot, MessageCircle, Mic, Search, X } from "lucide-react";
 
 import {
   KaiCommandPalette,
@@ -1740,8 +1740,8 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
               </ShellActionSurface>
             </div>
           ) : (
-            <div className="relative flex h-[124px] w-full items-end justify-end">
-              <div className="ml-auto flex h-[124px] w-[58px] flex-col items-center justify-end gap-2">
+            <div className="relative flex h-[112px] w-full items-end justify-end">
+              <div className="ml-auto flex h-[112px] w-[58px] flex-col items-center justify-end gap-1.5">
                 <button
                   type="button"
                   className="pointer-events-auto grid h-[58px] w-[58px] place-items-center rounded-full transition-transform duration-200 ease-out hover:scale-[1.03] active:scale-[0.94] disabled:cursor-not-allowed disabled:opacity-50"
@@ -1749,8 +1749,8 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
                   disabled={!agentPopover}
                   onClick={() => agentPopover?.openAgent()}
                 >
-                  <span className="grid h-[38px] w-[38px] place-items-center rounded-[13px] bg-[#0071e3] text-white shadow-[0_10px_24px_-16px_rgba(0,113,227,0.75),inset_0_1px_0_rgba(255,255,255,0.35)]">
-                    <Bot className="h-[17px] w-[17px]" strokeWidth={2} />
+                  <span className="grid h-[40px] w-[40px] place-items-center rounded-[14px] bg-[#0071e3] text-white shadow-[0_10px_24px_-16px_rgba(0,113,227,0.75),inset_0_1px_0_rgba(255,255,255,0.36)]">
+                    <MessageCircle className="h-[18px] w-[18px]" strokeWidth={2.15} />
                   </span>
                 </button>
                 <ShellActionSurface


### PR DESCRIPTION
## Summary
- promotes the Kai bottom chrome fix from integration to main
- tightens Agent/Search spacing and uses the premium chat-style agent icon
- no backend behavior changes

## Verification
- PR #2726 checks passed
- Browser testing skipped per request