### PR TITLE
fix(auth): scope Firebase retry to vault token

### DIFF
--- a/consent-protocol/api/routes/consent.py
+++ b/consent-protocol/api/routes/consent.py
@@ -320,6 +320,20 @@ class RefreshExportFailureRequest(BaseModel):
     lastError: str | None = Field(default=None, max_length=2000)
 
 
+class VaultOwnerTokenRequest(BaseModel):
+    """Validated body for issuing the vault-owner session token."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    userId: str = Field(min_length=1, max_length=128, pattern=r"^\S+$")
+
+
+def _verify_vault_owner_firebase_bearer(authorization: str | None) -> str:
+    """Route-owned Firebase tolerance for vault-owner token issuance only."""
+
+    return verify_firebase_bearer(authorization, retry_token_used_too_early=True)
+
+
 @router.get("/pending")
 async def get_pending_consents(
     userId: str = Query(..., max_length=128),
@@ -1138,7 +1152,10 @@ async def disconnect_relationship(
 
 
 @router.post("/vault-owner-token")
-async def issue_vault_owner_token(request: Request):
+async def issue_vault_owner_token(
+    payload: VaultOwnerTokenRequest,
+    authorization: str | None = Header(None, description="Bearer Firebase ID token"),
+):
     """
     Issue VAULT_OWNER consent token for authenticated user.
 
@@ -1157,19 +1174,8 @@ async def issue_vault_owner_token(request: Request):
     - All access logged for compliance
     """
     try:
-        auth_header = request.headers.get("Authorization")
-        if not auth_header or not auth_header.startswith("Bearer "):
-            raise HTTPException(
-                status_code=401, detail="Missing Authorization header with Firebase ID token"
-            )
-        # Verify request body
-        body = await request.json()
-        user_id = body.get("userId")
-
-        if not user_id:
-            raise HTTPException(status_code=400, detail="userId is required")
-
-        firebase_uid = verify_firebase_bearer(auth_header)
+        user_id = payload.userId
+        firebase_uid = _verify_vault_owner_firebase_bearer(authorization)
 
         # Ensure user is requesting token for their own vault
         if firebase_uid != user_id:

--- a/consent-protocol/api/utils/firebase_auth.py
+++ b/consent-protocol/api/utils/firebase_auth.py
@@ -7,6 +7,7 @@ Used by endpoints that require identity verification (Firebase Auth boundary).
 from __future__ import annotations
 
 import logging
+import time
 from typing import Optional
 
 from fastapi import HTTPException
@@ -15,8 +16,18 @@ from api.utils.firebase_admin import ensure_firebase_auth_admin, get_firebase_au
 
 logger = logging.getLogger(__name__)
 
+_TOKEN_USED_TOO_EARLY_RETRY_SECONDS = 12
 
-def verify_firebase_bearer(authorization: Optional[str]) -> str:
+
+def _is_token_used_too_early_error(exc: Exception) -> bool:
+    return "used too early" in str(exc).lower()
+
+
+def verify_firebase_bearer(
+    authorization: Optional[str],
+    *,
+    retry_token_used_too_early: bool = False,
+) -> str:
     """
     Verify `Authorization: Bearer <firebaseIdToken>` and return UID.
     """
@@ -36,7 +47,19 @@ def verify_firebase_bearer(authorization: Optional[str]) -> str:
 
     try:
         firebase_app = get_firebase_auth_app()
-        decoded = firebase_auth.verify_id_token(id_token, app=firebase_app)
+        deadline = time.monotonic() + _TOKEN_USED_TOO_EARLY_RETRY_SECONDS
+        while True:
+            try:
+                decoded = firebase_auth.verify_id_token(id_token, app=firebase_app)
+                break
+            except firebase_auth.InvalidIdTokenError as exc:
+                if (
+                    not retry_token_used_too_early
+                    or not _is_token_used_too_early_error(exc)
+                    or time.monotonic() >= deadline
+                ):
+                    raise
+                time.sleep(1)
         uid = decoded.get("uid")
         if not isinstance(uid, str) or not uid:
             raise HTTPException(status_code=401, detail="Invalid Firebase ID token")

--- a/consent-protocol/tests/test_consent_handshake.py
+++ b/consent-protocol/tests/test_consent_handshake.py
@@ -398,6 +398,87 @@ def test_pending_lookup_resolves_cross_linked_request_ids(monkeypatch):
     assert item["metadata"]["connector_public_key"] == "public-key"
 
 
+def test_vault_owner_token_uses_consent_route_firebase_retry_opt_in(monkeypatch):
+    """Vault-owner issuance owns the Firebase clock-skew tolerance at consent.py."""
+
+    fake_db = _FakeConsentDBService()
+    issued: dict[str, object] = {}
+    verifier_calls: list[dict[str, object]] = []
+
+    monkeypatch.setattr(consent, "ConsentDBService", lambda: fake_db)
+
+    def _issue_token(**kwargs):
+        issued.update(kwargs)
+        return SimpleNamespace(token="vault-owner-token", expires_at=123456789)  # noqa: S106
+
+    def _verify_firebase(authorization, *, retry_token_used_too_early=False):
+        verifier_calls.append(
+            {
+                "authorization": authorization,
+                "retry_token_used_too_early": retry_token_used_too_early,
+            }
+        )
+        return "investor_1"
+
+    monkeypatch.setattr(consent, "issue_token", _issue_token)
+    monkeypatch.setattr(consent, "verify_firebase_bearer", _verify_firebase)
+
+    client = TestClient(_build_app())
+
+    response = client.post(
+        "/api/consent/vault-owner-token",
+        json={"userId": "investor_1"},
+        headers={"Authorization": "Bearer firebase-token"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["token"] == "vault-owner-token"  # noqa: S105
+    assert issued["user_id"] == "investor_1"
+    assert issued["scope"] == consent.ConsentScope.VAULT_OWNER
+    assert verifier_calls == [
+        {
+            "authorization": "Bearer firebase-token",
+            "retry_token_used_too_early": True,
+        }
+    ]
+
+
+def test_vault_owner_token_rejects_bad_user_id_before_firebase(monkeypatch):
+    def _unexpected_verify(*_args, **_kwargs):
+        raise AssertionError("invalid route payload should not verify Firebase")
+
+    monkeypatch.setattr(consent, "verify_firebase_bearer", _unexpected_verify)
+
+    client = TestClient(_build_app())
+
+    response = client.post(
+        "/api/consent/vault-owner-token",
+        json={"userId": "u" * 129},
+        headers={"Authorization": "Bearer firebase-token"},
+    )
+
+    assert response.status_code == 422
+
+
+def test_vault_owner_token_user_mismatch_remains_forbidden(monkeypatch):
+    monkeypatch.setattr(
+        consent,
+        "verify_firebase_bearer",
+        lambda _authorization, **_kwargs: "other_user",
+    )
+
+    client = TestClient(_build_app())
+
+    response = client.post(
+        "/api/consent/vault-owner-token",
+        json={"userId": "investor_1"},
+        headers={"Authorization": "Bearer firebase-token"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Cannot issue VAULT_OWNER token for another user"
+
+
 def test_deny_consent_records_event(monkeypatch):
     """Investor denies a pending consent request."""
     fake_db = _FakeConsentDBService()

--- a/consent-protocol/tests/test_firebase_auth_split.py
+++ b/consent-protocol/tests/test_firebase_auth_split.py
@@ -90,6 +90,65 @@ def test_verify_firebase_bearer_invalid_id_token_returns_401(monkeypatch):
     assert exc.value.detail == "Invalid Firebase ID token"
 
 
+def test_verify_firebase_bearer_does_not_retry_token_used_too_early_by_default(monkeypatch):
+    import firebase_admin.auth as firebase_auth
+
+    monkeypatch.setattr(
+        "api.utils.firebase_auth.ensure_firebase_auth_admin",
+        lambda: (True, "test-project"),
+    )
+    monkeypatch.setattr("api.utils.firebase_auth.get_firebase_auth_app", lambda: object())
+
+    attempts = {"count": 0}
+
+    def _raise_clock_skew(*_args, **_kwargs):
+        attempts["count"] += 1
+        raise firebase_auth.InvalidIdTokenError(
+            "Token used too early, 100 < 108. Check that your computer's clock is set correctly."
+        )
+
+    monkeypatch.setattr(firebase_auth, "verify_id_token", _raise_clock_skew)
+
+    with pytest.raises(HTTPException) as exc:
+        verify_firebase_bearer("Bearer some-token")
+
+    assert exc.value.status_code == 401
+    assert attempts["count"] == 1
+
+
+def test_verify_firebase_bearer_retries_token_used_too_early(monkeypatch):
+    import firebase_admin.auth as firebase_auth
+
+    monkeypatch.setattr(
+        "api.utils.firebase_auth.ensure_firebase_auth_admin",
+        lambda: (True, "test-project"),
+    )
+    monkeypatch.setattr("api.utils.firebase_auth.get_firebase_auth_app", lambda: object())
+    monkeypatch.setattr("api.utils.firebase_auth.time.sleep", lambda _seconds: None)
+    monkeypatch.setattr("api.utils.firebase_auth.time.monotonic", lambda: 1.0)
+
+    attempts = {"count": 0}
+
+    def _verify_after_clock_skew(*_args, **_kwargs):
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise firebase_auth.InvalidIdTokenError(
+                "Token used too early, 100 < 108. Check that your computer's clock is set correctly."
+            )
+        return {"uid": "reviewer-user"}
+
+    monkeypatch.setattr(firebase_auth, "verify_id_token", _verify_after_clock_skew)
+
+    assert (
+        verify_firebase_bearer(
+            "Bearer some-token",
+            retry_token_used_too_early=True,
+        )
+        == "reviewer-user"
+    )
+    assert attempts["count"] == 2
+
+
 def test_verify_firebase_bearer_unexpected_error_returns_500(monkeypatch):
     import firebase_admin.auth as firebase_auth
 


### PR DESCRIPTION
## Summary

This PR is separate backend maintenance for Firebase/vault-owner token behavior. It is not part of the Location Agent / Connect marketplace feature train.

- Adds validated vault-owner token request parsing at `consent-protocol/api/routes/consent.py`.
- Keeps `verify_firebase_bearer(...)` retry behavior disabled by default.
- Lets the vault-owner token route opt into the bounded `TOKEN_USED_TOO_EARLY` retry for Firebase clock skew.
- Proves request validation, user mismatch rejection, default no-retry behavior, and explicit opt-in retry behavior.

## Reviewer readiness

Current head: `0ea12676`.

Boundary: backend consent/token trust boundary only.

Canonical attach points:

- `consent-protocol/api/routes/consent.py`
- `consent-protocol/api/utils/firebase_auth.py`
- `consent-protocol/tests/test_consent_handshake.py`
- `consent-protocol/tests/test_firebase_auth_split.py`

This PR does not touch One Location UI, route shell, navigation, mobile plugins, marketplace discovery, public snapshot behavior, notification/log-redaction behavior, or DB migrations.

## Feature-train status

This PR is intentionally excluded from the Location Agent / Connect marketplace feature train.

Feature train order:

1. #2363: marketplace visibility-posture DB foundation.
2. #2730: One Location notification/log-redaction split.
3. #2327: One Location route shell, onboarding, self-location, and UI/runtime hardening.
4. #2724: One Location public snapshot flow.
5. #2443: Connect discovery signals and One Location candidate UI behavior.

## Impact map

- Backend/API touched: consent vault-owner token route and Firebase bearer verification helper.
- Web touched: none.
- Mobile touched: none.
- DB touched: none.
- Public-link behavior touched: none.
- Rollback: removes bounded Firebase clock-skew retry for vault-owner token issuance and restores prior request parsing.

## Validation

Local validation on current head after merging the latest `integration/pr-train`:

- `git diff --check origin/integration/pr-train...HEAD`: passed.
- `scripts/ci/check-dco-signoff.sh origin/integration/pr-train HEAD`: passed, 1 commit.
- `uv run ruff check api/routes/consent.py api/utils/firebase_auth.py tests/test_consent_handshake.py tests/test_firebase_auth_split.py`: passed.
- `TESTING=true uv run pytest -q tests/test_consent_handshake.py::test_vault_owner_token_uses_consent_route_firebase_retry_opt_in tests/test_consent_handshake.py::test_vault_owner_token_rejects_bad_user_id_before_firebase tests/test_consent_handshake.py::test_vault_owner_token_user_mismatch_remains_forbidden tests/test_firebase_auth_split.py::test_verify_firebase_bearer_does_not_retry_token_used_too_early_by_default tests/test_firebase_auth_split.py::test_verify_firebase_bearer_retries_token_used_too_early`: 5 passed.

GitHub PR Validation is green on current head, including Protocol, Governance, Integration, DCO, and CI Status Gate.
