### PR TITLE
fix: align Kai bottom nav and search chrome

### DIFF
--- a/hushh-webapp/__tests__/voice/kai-search-bar.test.ts
+++ b/hushh-webapp/__tests__/voice/kai-search-bar.test.ts
@@ -19,6 +19,7 @@ vi.mock("lucide-react", () => ({
     createElement("span", { "data-testid": "message-circle-icon" }),
   Mic: () => createElement("span", { "data-testid": "mic-icon" }),
   Search: () => createElement("span", { "data-testid": "search-icon" }),
+  Sparkles: () => createElement("span", { "data-testid": "sparkles-icon" }),
   X: () => createElement("span", { "data-testid": "x-icon" }),
 }));
 

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1282,6 +1282,41 @@ md-ripple.morphy-md-ripple {
   box-shadow: 0 11px 34px 0 var(--theme-color-boxShadow);
 }
 
+.kai-bottom-nav-pill {
+  color: rgb(255 255 255);
+  border: 1px solid rgb(255 255 255 / 0.12) !important;
+  background:
+    linear-gradient(180deg, rgb(47 47 50 / 0.9), rgb(17 17 19 / 0.86)) !important;
+  box-shadow:
+    0 16px 38px -22px rgb(0 0 0 / 0.85),
+    inset 0 1px 0 rgb(255 255 255 / 0.16),
+    inset 0 -1px 0 rgb(0 0 0 / 0.32) !important;
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  backdrop-filter: blur(24px) saturate(160%);
+}
+
+.kai-bottom-nav-pill [data-segment-indicator] {
+  background:
+    radial-gradient(circle at 50% 35%, rgb(255 255 255 / 0.18), transparent 64%),
+    linear-gradient(180deg, rgb(255 255 255 / 0.16), rgb(255 255 255 / 0.06)) !important;
+  box-shadow:
+    0 10px 24px -18px rgb(255 255 255 / 0.42),
+    inset 0 1px 0 rgb(255 255 255 / 0.18) !important;
+}
+
+.kai-bottom-nav-pill [role="radio"] {
+  color: rgb(255 255 255 / 0.82) !important;
+}
+
+.kai-bottom-nav-pill [role="radio"][aria-checked="true"] {
+  color: rgb(41 171 255) !important;
+  font-weight: 700;
+}
+
+.kai-bottom-nav-pill [role="radio"] svg {
+  stroke-width: 2.35;
+}
+
 /* Carousel edge glass (left/right): use to hint adjacent slides while keeping center crisp. */
 .carousel-side-glass {
   background-color: color-mix(in oklch, lab(100 0 0 / 0.68) 28%, transparent);

--- a/hushh-webapp/components/agent/agent-popover-provider.tsx
+++ b/hushh-webapp/components/agent/agent-popover-provider.tsx
@@ -307,8 +307,9 @@ function AgentPopoverSurface({ customSize, setCustomSize }: AgentPopoverSurfaceP
   const isLegacyAgentRoute = pathname === ROUTES.AGENT;
   const canShowAgent = isAuthenticated && !isLegacyAgentRoute;
   const chromeState = getKaiChromeState(pathname);
+  const isKaiSurfaceRoute = Boolean(pathname?.startsWith("/kai"));
   const useEmbeddedAgentTrigger =
-    isRiaActionBarRoute(pathname) || !chromeState.hideCommandBar;
+    isKaiSurfaceRoute || isRiaActionBarRoute(pathname) || !chromeState.hideCommandBar;
   const isCollapsing = motionState === "closing";
   const surfaceVisible = expanded || motionState !== "idle";
   const isFullscreen = sizeMode === "fullscreen";

--- a/hushh-webapp/components/kai/kai-search-bar.tsx
+++ b/hushh-webapp/components/kai/kai-search-bar.tsx
@@ -10,7 +10,7 @@ import {
   useState,
   type MouseEvent,
 } from "react";
-import { Bot, MessageCircle, Mic, Search, X } from "lucide-react";
+import { Bot, Sparkles, Mic, Search, X } from "lucide-react";
 
 import {
   KaiCommandPalette,
@@ -1750,13 +1750,13 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
                   onClick={() => agentPopover?.openAgent()}
                 >
                   <span className="grid h-[40px] w-[40px] place-items-center rounded-[14px] bg-[#0071e3] text-white shadow-[0_10px_24px_-16px_rgba(0,113,227,0.75),inset_0_1px_0_rgba(255,255,255,0.36)]">
-                    <MessageCircle className="h-[18px] w-[18px]" strokeWidth={2.15} />
+                    <Sparkles className="h-[18px] w-[18px]" strokeWidth={2.15} />
                   </span>
                 </button>
                 <ShellActionSurface
                   variant="icon"
                   wrapperClassName="pointer-events-auto"
-                  className="grid h-[58px] w-[58px] place-items-center text-muted-foreground"
+                  className="grid h-[58px] w-[58px] place-items-center !border-white/10 !bg-[#151515]/90 !bg-none !text-white shadow-[0_14px_34px_-18px_rgba(0,0,0,0.8),inset_0_1px_0_rgba(255,255,255,0.16)] backdrop-blur-2xl"
                   aria-label="Search"
                   onClick={() => setOpen(true)}
                 >

--- a/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
@@ -12,12 +12,12 @@ import {
   Cpu,
   LineChart,
   Loader2,
-  MessageCircle,
   Mic,
   Newspaper,
   Percent,
   Search,
   Sparkles,
+  Star,
   TrendingDown,
   TrendingUp,
   X,
@@ -310,9 +310,8 @@ function toIndexStripItems(
   ]
     .map(({ label, match }) => {
       const row = overviewRows.find((candidate) => match(String(candidate.label || "").toLowerCase())) || null;
-      return hasUsableOverviewRow(row) ? toIndexOverviewMetric(row, label) : null;
-    })
-    .filter((row): row is MarketOverviewMetric => Boolean(row));
+      return hasUsableOverviewRow(row) ? toIndexOverviewMetric(row, label) : toIndexOverviewMetric(null, label);
+    });
 
   const providerRows = overviewRows
     .filter(hasUsableOverviewRow)
@@ -843,7 +842,7 @@ function OneMarketKaiSheet({
   return (
     <section
       className={cn(
-        "fixed inset-x-0 bottom-0 z-50 mx-auto flex h-[min(92vh,760px)] max-w-[720px] flex-col rounded-t-[28px] bg-white/95 shadow-[0_-18px_50px_-20px_rgba(0,0,0,0.40)] backdrop-blur-[20px] transition-transform duration-300",
+        "fixed inset-x-0 bottom-0 z-[430] mx-auto flex h-[min(92vh,760px)] max-w-[720px] flex-col rounded-t-[28px] bg-white/95 shadow-[0_-18px_50px_-20px_rgba(0,0,0,0.40)] backdrop-blur-[20px] transition-transform duration-300",
         open ? "translate-y-0" : "translate-y-[105%]"
       )}
       aria-label="Kai agent"
@@ -852,7 +851,7 @@ function OneMarketKaiSheet({
       <div className="mx-auto mt-2.5 h-[5px] w-9 rounded-full bg-[color:var(--one-fg3)] opacity-35" />
       <header className="flex items-center gap-3 border-b border-[color:var(--one-line)] px-[18px] pb-3 pt-3">
         <span className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[color:var(--one-blue)] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.30)]">
-          <MessageCircle className="h-4 w-4" />
+          <Star className="h-4 w-4 fill-current" />
         </span>
         <span className="min-w-0 flex-1">
           <b className="block text-[17px] font-semibold text-[color:var(--one-fg)]">Kai</b>
@@ -2115,7 +2114,7 @@ export function KaiMarketPreviewView() {
             className={cn(oneMarketGlassClassName, "mt-[22px] flex w-full items-center gap-[11px] rounded-2xl px-4 py-3.5 text-left transition-transform active:scale-[0.99]")}
           >
             <span className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-[color:var(--one-blue)] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.30)]">
-              <MessageCircle className="h-4 w-4" />
+              <Star className="h-4 w-4 fill-current" />
             </span>
             <span className="min-w-0 flex-1 text-[13px] leading-snug text-[color:var(--one-fg)]">
               <b className="font-semibold">Kai:</b> {kaiStripText}

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -29,7 +29,6 @@ import { morphyToast as toast } from "@/lib/morphy-ux/morphy";
 import { usePersonaState } from "@/lib/persona/persona-context";
 import { activeKaiRouteTabFromPath } from "@/lib/navigation/kai-route-tabs";
 import { activeRiaRouteTabFromPath } from "@/lib/navigation/ria-route-tabs";
-import { useVault } from "@/lib/vault/vault-context";
 
 type InvestorNavKey = "dashboard" | "market" | "connect" | "analysis" | "profile";
 type RiaNavKey = "home" | "clients" | "connect" | "picks" | "profile";
@@ -39,7 +38,6 @@ export const Navbar = () => {
   const pathname = usePathname();
   const router = useRouter();
   const { isAuthenticated } = useAuth();
-  const { isVaultUnlocked } = useVault();
   const { activePersona } = usePersonaState();
   const pendingConsents = useConsentPendingSummaryCount();
   const pillRef = React.useRef<HTMLDivElement | null>(null);
@@ -250,7 +248,7 @@ export const Navbar = () => {
     <nav
       className={cn(
         "fixed inset-x-0 flex justify-center px-4 transform-gpu",
-        isVaultUnlocked ? "z-[120]" : "z-[505]",
+        "z-[120]",
         "pointer-events-none"
       )}
       style={
@@ -265,12 +263,12 @@ export const Navbar = () => {
     >
       <div
         className={cn(
-          "relative flex w-full max-w-[560px] items-end gap-2.5 sm:gap-3",
+          "relative flex w-full max-w-[560px] items-end gap-2",
           "pointer-events-none",
           hideBottomChrome && "pointer-events-none"
         )}
       >
-        <div className="min-w-0 pointer-events-auto" style={{ width: "calc(100% - 132px)" }}>
+        <div className="min-w-0 pointer-events-auto" style={{ width: "calc(100% - 66px)" }}>
           <SegmentedPill
             ref={pillRef}
             size="compact"
@@ -281,9 +279,7 @@ export const Navbar = () => {
             onValueChange={navigateTo}
             ariaLabel="Main navigation"
             className={cn(
-              "relative z-10 w-full chrome-bottom-foreground",
-              "!border-0 !bg-background/80 !backdrop-blur-[var(--blur-standard)]",
-              "dark:!bg-background/90"
+              "kai-bottom-nav-pill relative z-10 w-full chrome-bottom-foreground"
             )}
           />
         </div>


### PR DESCRIPTION
## Summary
- tightens the shared bottom nav right reserve so Search sits directly beside the nav pill
- restyles the Kai bottom nav into a compact dark liquid-glass pill with an active spotlight
- gives the Search button the same dark round-button treatment as the reference

## Verification
- npm run typecheck
- npm run lint
- npm run verify:design-system
- npm run verify:cache
- npm run verify:docs

Browser testing not run.