### PR TITLE
feat(deploy): GCP-native on-demand Cloud Build deploy orchestrator

### DIFF
--- a/deploy/cloud-build-deploy.sh
+++ b/deploy/cloud-build-deploy.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+#
+# GCP-native ON-DEMAND deploy orchestrator for hushh-research.
+# Mirrors the mechanics of .github/workflows/deploy-uat.yml and
+# deploy-production.yml, but runs entirely on GCP Cloud Build with NO GitHub
+# Actions runner and NO long-lived service-account key.
+#
+# Auth: impersonates the SAME service account the GitHub workflow uses
+#   (UAT: github-actions-uat-deployer@hushh-pda-uat).
+#   The caller must hold roles/iam.serviceAccountTokenCreator on that SA.
+#   The org enforces constraints/cloudbuild.useBuildServiceAccount, so a plain
+#   user `gcloud builds submit` is denied — impersonation is the canonical path.
+#
+# ON-DEMAND ONLY: this is invoked deliberately by a human/operator. It is NOT
+#   wired to push triggers. UAT/prod never auto-deploy on commit.
+#
+# Usage:
+#   deploy/cloud-build-deploy.sh --env uat   [--sha <git-sha>] [--scope all|backend|frontend] [--skip-migrations]
+#   deploy/cloud-build-deploy.sh --env prod  --sha <git-sha> --confirm-production "deploy production"
+#
+set -euo pipefail
+
+# ----- defaults -----
+ENV=""
+SHA=""
+SCOPE="all"
+SKIP_MIGRATIONS="false"
+CONFIRM_PRODUCTION=""
+NO_IMPERSONATE="false"
+REGION="us-central1"
+BACKEND_SERVICE="consent-protocol"
+FRONTEND_SERVICE="hushh-webapp"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env) ENV="$2"; shift 2;;
+    --sha) SHA="$2"; shift 2;;
+    --scope) SCOPE="$2"; shift 2;;
+    --skip-migrations) SKIP_MIGRATIONS="true"; shift;;
+    --no-impersonate) NO_IMPERSONATE="true"; shift;;
+    --confirm-production) CONFIRM_PRODUCTION="$2"; shift 2;;
+    *) echo "Unknown arg: $1" >&2; exit 2;;
+  esac
+done
+
+# ----- env-specific config -----
+case "$ENV" in
+  uat)
+    PROJECT="hushh-pda-uat"
+    DEPLOY_SA="github-actions-uat-deployer@hushh-pda-uat.iam.gserviceaccount.com"
+    APP_FRONTEND_ORIGIN="https://uat.kai.hushh.ai"
+    CLOUDSQL_INSTANCE="hushh-pda-uat:us-central1:hushh-uat-pg"
+    APP_ENV="uat"
+    DEPLOY_SOURCE="deploy-uat"
+    ;;
+  prod|production)
+    ENV="prod"
+    PROJECT="hushh-pda"
+    DEPLOY_SA="${PROD_DEPLOY_SA:-github-actions-deployer@hushh-pda.iam.gserviceaccount.com}"
+    APP_FRONTEND_ORIGIN="https://kai.hushh.ai"
+    CLOUDSQL_INSTANCE="${PROD_CLOUDSQL_INSTANCE:-hushh-pda:us-central1:hushh-pg}"
+    APP_ENV="production"
+    DEPLOY_SOURCE="deploy-production"
+    if [[ "$CONFIRM_PRODUCTION" != "deploy production" ]]; then
+      echo "REFUSING prod deploy: pass --confirm-production \"deploy production\"." >&2
+      exit 1
+    fi
+    ;;
+  *)
+    echo "Must pass --env uat|prod" >&2; exit 2;;
+esac
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# ----- resolve + gate SHA -----
+if [[ -z "$SHA" ]]; then
+  git fetch --no-tags origin main
+  SHA="$(git rev-parse origin/main)"
+fi
+echo "==> Deploying $ENV from SHA $SHA (scope=$SCOPE)"
+bash scripts/ci/require-deploy-sha-on-main.sh "$SHA" || {
+  echo "SHA gate failed — refusing deploy." >&2; exit 1; }
+
+if [[ "$NO_IMPERSONATE" == "true" ]]; then
+  IMPERSONATE=()
+else
+  IMPERSONATE=(--impersonate-service-account="$DEPLOY_SA")
+fi
+IMAGE_TAG="${ENV}-${SHA}"
+RUN_ID="manual-ondemand-$(date +%Y%m%d%H%M%S)"
+
+# ----- python runtime for ops scripts -----
+PY="$REPO_ROOT/consent-protocol/.venv/bin/python"
+if [[ ! -x "$PY" ]]; then
+  echo "==> Creating consent-protocol venv"
+  (cd consent-protocol && uv venv --python 3.13 .venv && \
+     uv pip install -p .venv/bin/python -r requirements.txt >/dev/null)
+fi
+
+# ----- 1. secret sync -----
+echo "==> Syncing runtime secrets"
+"$PY" scripts/ops/sync_backend_runtime_secrets.py \
+  --project "$PROJECT" --environment "$ENV" \
+  --app-frontend-origin "$APP_FRONTEND_ORIGIN" \
+  --db-host cloudsql-socket --db-port 5432 --db-name postgres \
+  --db-unix-socket "/cloudsql/$CLOUDSQL_INSTANCE" \
+  --cloudsql-instance-connection-name "$CLOUDSQL_INSTANCE" \
+  --consent-sse-enabled true --sync-remote-enabled false \
+  --developer-api-enabled true --remote-mcp-enabled true \
+  --cors-allowed-origins "$APP_FRONTEND_ORIGIN" \
+  --obs-data-stale-ratio-threshold 0.25 \
+  --plaid-env production --plaid-client-name "Hushh Kai" \
+  --plaid-country-codes US \
+  --plaid-webhook-url "$APP_FRONTEND_ORIGIN/api/kai/plaid/webhook" \
+  --plaid-redirect-path "/kai/plaid/oauth/return" --plaid-tx-history-days 730 \
+  > "/tmp/${ENV}-backend-secret-sync.json"
+"$PY" scripts/ops/sync_frontend_runtime_secrets.py \
+  --project "$PROJECT" --environment "$ENV" \
+  > "/tmp/${ENV}-frontend-secret-sync.json"
+
+# ----- 2. db migrations + predeploy schema gate (backend only) -----
+if [[ "$SCOPE" != "frontend" && "$SKIP_MIGRATIONS" != "true" ]]; then
+  echo "==> Running DB migrations + predeploy schema gate"
+  cloud-sql-proxy --address 127.0.0.1 --port 6543 "$CLOUDSQL_INSTANCE" \
+    >"/tmp/${ENV}-cloud-sql-proxy.log" 2>&1 &
+  PROXY_PID=$!
+  trap 'kill "$PROXY_PID" >/dev/null 2>&1 || true' EXIT
+  for _ in $(seq 1 40); do nc -z 127.0.0.1 6543 && break; sleep 0.25; done
+
+  DBU="$(gcloud secrets versions access latest --secret=DB_USER --project="$PROJECT")"
+  DBP="$(gcloud secrets versions access latest --secret=DB_PASSWORD --project="$PROJECT")"
+  export DB_HOST=127.0.0.1 DB_PORT=6543 DB_NAME=postgres DB_USER="$DBU" DB_PASSWORD="$DBP"
+  (cd "$REPO_ROOT/consent-protocol" && "$PY" db/migrate.py --release)
+  "$PY" scripts/ops/db_migration_release_guard.py \
+    --contract-file "consent-protocol/db/contracts/${ENV}_integrated_schema.json" \
+    --report-path "/tmp/${ENV}-db-guard-predeploy.json"
+  kill "$PROXY_PID" >/dev/null 2>&1 || true
+  trap - EXIT
+fi
+
+# ----- 3. build + deploy backend (no-traffic) -----
+if [[ "$SCOPE" == "all" || "$SCOPE" == "backend" ]]; then
+  echo "==> Building + deploying backend (no-traffic revision)"
+  BSUBS="_BACKEND_SERVICE=${BACKEND_SERVICE}##_REGION=${REGION}##_CLOUDSQL_INSTANCES=${CLOUDSQL_INSTANCE}"
+  BSUBS="${BSUBS}##_PLAID_CLIENT_ID_SECRET=PLAID_CLIENT_ID##_PLAID_SECRET_SECRET=PLAID_SECRET##_PLAID_ACCESS_TOKEN_KEY_SECRET=PLAID_ACCESS_TOKEN_KEY"
+  BSUBS="${BSUBS}##_FINNHUB_API_KEY_SECRET=FINNHUB_API_KEY##_PMP_API_KEY_SECRET=PMP_API_KEY##_NEWSAPI_KEY_SECRET=NEWSAPI_KEY"
+  BSUBS="${BSUBS}##_GMAIL_OAUTH_CLIENT_ID_SECRET=GMAIL_OAUTH_CLIENT_ID##_GMAIL_OAUTH_CLIENT_SECRET_SECRET=GMAIL_OAUTH_CLIENT_SECRET##_GMAIL_OAUTH_REDIRECT_URI_SECRET=GMAIL_OAUTH_REDIRECT_URI##_GMAIL_OAUTH_TOKEN_KEY_SECRET=GMAIL_OAUTH_TOKEN_KEY"
+  BSUBS="${BSUBS}##_OPENAI_API_KEY_SECRET=OPENAI_API_KEY##_VOICE_RUNTIME_CONFIG_JSON_SECRET=VOICE_RUNTIME_CONFIG_JSON##_HUSHH_DEVELOPER_TOKEN_SECRET=HUSHH_DEVELOPER_TOKEN"
+  BSUBS="${BSUBS}##_HUSHH_UAT_PHONE_TEST_NUMBERS_SECRET=HUSHH_UAT_PHONE_TEST_NUMBERS##_HUSHH_UAT_PHONE_TEST_CODE_SECRET=HUSHH_UAT_PHONE_TEST_CODE##_REVIEWER_UID_SECRET=REVIEWER_UID##_REVIEWER_VAULT_PASSPHRASE_SECRET=REVIEWER_VAULT_PASSPHRASE"
+  BSUBS="${BSUBS}##_RIA_INTELLIGENCE_VERIFY_BASE_URL_SECRET=RIA_INTELLIGENCE_VERIFY_BASE_URL##_ONE_EMAIL_WATCH_RENEW_TOKEN_SECRET=ONE_EMAIL_WATCH_RENEW_TOKEN##_ONE_EMAIL_ADDRESS=one@hushh.ai##_ONE_EMAIL_DELEGATED_USER=one@hushh.ai"
+  BSUBS="${BSUBS}##_ONE_EMAIL_KYC_DEFAULT_SCOPE=attr.identity.*##_ONE_EMAIL_KYC_STRICT_CLIENT_ZK_ENABLED=true##_APP_REVIEW_MODE=true"
+  BSUBS="${BSUBS}##_CLOUD_RUN_NO_TRAFFIC=true##_IMAGE_TAG=${IMAGE_TAG}##_DEPLOY_ENV=${ENV}##_DEPLOY_SOURCE=${DEPLOY_SOURCE}##_DEPLOY_SHA=${SHA}##_GITHUB_RUN_ID=${RUN_ID}"
+  gcloud builds submit --project="$PROJECT" "${IMPERSONATE[@]}" \
+    --config=deploy/backend.cloudbuild.yaml "--substitutions=^##^${BSUBS}"
+fi
+
+# ----- 4. build + deploy frontend (no-traffic) -----
+if [[ "$SCOPE" == "all" || "$SCOPE" == "frontend" ]]; then
+  echo "==> Building + deploying frontend (no-traffic revision)"
+  FSUBS="_FRONTEND_SERVICE=${FRONTEND_SERVICE}##_REGION=${REGION}##_APP_ENV=${APP_ENV}##_CLOUD_RUN_NO_TRAFFIC=true##_IMAGE_TAG=${IMAGE_TAG}##_DEPLOY_ENV=${ENV}##_DEPLOY_SOURCE=${DEPLOY_SOURCE}##_DEPLOY_SHA=${SHA}##_GITHUB_RUN_ID=${RUN_ID}"
+  gcloud builds submit --project="$PROJECT" "${IMPERSONATE[@]}" \
+    --config=deploy/frontend.cloudbuild.yaml "--substitutions=^##^${FSUBS}"
+fi
+
+# ----- 5. promote traffic to 100% -----
+echo "==> Promoting candidate revisions to 100% traffic"
+if [[ "$SCOPE" == "all" || "$SCOPE" == "backend" ]]; then
+  BE_REV="$(gcloud run services describe "$BACKEND_SERVICE" --project="$PROJECT" --region="$REGION" "${IMPERSONATE[@]}" --format='value(status.latestCreatedRevisionName)')"
+  gcloud run services update-traffic "$BACKEND_SERVICE" --project="$PROJECT" --region="$REGION" "${IMPERSONATE[@]}" --to-revisions="${BE_REV}=100"
+fi
+if [[ "$SCOPE" == "all" || "$SCOPE" == "frontend" ]]; then
+  FE_REV="$(gcloud run services describe "$FRONTEND_SERVICE" --project="$PROJECT" --region="$REGION" "${IMPERSONATE[@]}" --format='value(status.latestCreatedRevisionName)')"
+  gcloud run services update-traffic "$FRONTEND_SERVICE" --project="$PROJECT" --region="$REGION" "${IMPERSONATE[@]}" --to-revisions="${FE_REV}=100"
+fi
+
+# ----- 6. verify -----
+echo "==> Verifying live deployment"
+BE_URL="$(gcloud run services describe "$BACKEND_SERVICE" --project="$PROJECT" --region="$REGION" "${IMPERSONATE[@]}" --format='value(status.url)')"
+echo "backend health: $(curl -s -o /dev/null -w '%{http_code}' "$BE_URL/health")"
+echo "frontend ($APP_FRONTEND_ORIGIN): $(curl -s -o /dev/null -w '%{http_code}' "$APP_FRONTEND_ORIGIN")"
+echo "==> Deploy complete: $ENV @ $SHA"

--- a/deploy/prod-tag-trigger.cloudbuild.yaml
+++ b/deploy/prod-tag-trigger.cloudbuild.yaml
@@ -1,0 +1,56 @@
+# Cloud Build TAG-TRIGGER config for on-demand PRODUCTION deploys (Option C).
+#
+# Wired to a Cloud Build *tag trigger* matching `prod-*` on project hushh-pda.
+# Pushing a git tag like:
+#   git tag prod-<full-sha> && git push origin prod-<full-sha>
+# fires this build inside GCP — NO GitHub Actions runner, NO Actions minutes.
+#
+# The trigger runs AS the prod deployer SA, so the orchestrator uses
+# --no-impersonate. The prod orchestrator path requires the confirm token, which
+# we pass explicitly here because cutting a `prod-*` tag IS the deliberate
+# confirmation (immutable, auditable, human-initiated).
+
+steps:
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    entrypoint: "bash"
+    args:
+      - "-c"
+      - |
+        set -euo pipefail
+
+        TAG="${TAG_NAME:-}"
+        if [[ -z "$TAG" ]]; then
+          echo "No TAG_NAME provided; this config is for tag triggers only." >&2
+          exit 1
+        fi
+        DEPLOY_SHA="${TAG#prod-}"
+        if [[ "$DEPLOY_SHA" == "$TAG" || -z "$DEPLOY_SHA" ]]; then
+          echo "Tag '$TAG' is not in the expected 'prod-<sha>' form." >&2
+          exit 1
+        fi
+        echo "==> PROD tag deploy: tag=$TAG sha=$DEPLOY_SHA"
+
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        export PATH="$HOME/.local/bin:$PATH"
+        curl -fsSL \
+          https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.18.3/cloud-sql-proxy.linux.amd64 \
+          -o /usr/local/bin/cloud-sql-proxy
+        chmod +x /usr/local/bin/cloud-sql-proxy
+        chmod +x deploy/cloud-build-deploy.sh
+
+        deploy/cloud-build-deploy.sh \
+          --env prod \
+          --sha "$DEPLOY_SHA" \
+          --scope "${_SCOPE}" \
+          --no-impersonate \
+          --confirm-production "deploy production"
+    id: "prod-tag-deploy"
+
+timeout: "2400s"
+
+substitutions:
+  _SCOPE: "all"
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+  machineType: "E2_HIGHCPU_8"

--- a/deploy/prod-tag-trigger.cloudbuild.yaml
+++ b/deploy/prod-tag-trigger.cloudbuild.yaml
@@ -6,32 +6,36 @@
 # fires this build inside GCP — NO GitHub Actions runner, NO Actions minutes.
 #
 # The trigger runs AS the prod deployer SA, so the orchestrator uses
-# --no-impersonate. The prod orchestrator path requires the confirm token, which
-# we pass explicitly here because cutting a `prod-*` tag IS the deliberate
-# confirmation (immutable, auditable, human-initiated).
+# --no-impersonate. Cutting a `prod-*` tag IS the deliberate confirmation, so we
+# pass the confirm token explicitly.
+#
+# NOTE: bash variables use $$ so Cloud Build does not resolve them as build
+# substitutions. $TAG_NAME (built-in trigger value) is passed via env.
 
 steps:
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
     entrypoint: "bash"
+    env:
+      - "TAG_NAME=$TAG_NAME"
     args:
       - "-c"
       - |
         set -euo pipefail
 
-        TAG="${TAG_NAME:-}"
-        if [[ -z "$TAG" ]]; then
+        TAG="$${TAG_NAME:-}"
+        if [[ -z "$$TAG" ]]; then
           echo "No TAG_NAME provided; this config is for tag triggers only." >&2
           exit 1
         fi
-        DEPLOY_SHA="${TAG#prod-}"
-        if [[ "$DEPLOY_SHA" == "$TAG" || -z "$DEPLOY_SHA" ]]; then
-          echo "Tag '$TAG' is not in the expected 'prod-<sha>' form." >&2
+        DEPLOY_SHA="$${TAG#prod-}"
+        if [[ "$$DEPLOY_SHA" == "$$TAG" || -z "$$DEPLOY_SHA" ]]; then
+          echo "Tag '$$TAG' is not in the expected 'prod-<sha>' form." >&2
           exit 1
         fi
-        echo "==> PROD tag deploy: tag=$TAG sha=$DEPLOY_SHA"
+        echo "==> PROD tag deploy: tag=$$TAG sha=$$DEPLOY_SHA"
 
         curl -LsSf https://astral.sh/uv/install.sh | sh
-        export PATH="$HOME/.local/bin:$PATH"
+        export PATH="$$HOME/.local/bin:$$PATH"
         curl -fsSL \
           https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.18.3/cloud-sql-proxy.linux.amd64 \
           -o /usr/local/bin/cloud-sql-proxy
@@ -40,7 +44,7 @@ steps:
 
         deploy/cloud-build-deploy.sh \
           --env prod \
-          --sha "$DEPLOY_SHA" \
+          --sha "$$DEPLOY_SHA" \
           --scope "${_SCOPE}" \
           --no-impersonate \
           --confirm-production "deploy production"

--- a/deploy/uat-tag-trigger.cloudbuild.yaml
+++ b/deploy/uat-tag-trigger.cloudbuild.yaml
@@ -1,0 +1,57 @@
+# Cloud Build TAG-TRIGGER config for on-demand UAT deploys (Option C).
+#
+# Wired to a Cloud Build *tag trigger* matching `uat-*`. Pushing a git tag like
+#   git tag uat-<full-sha> && git push origin uat-<full-sha>
+# fires this build entirely inside GCP — NO GitHub Actions runner, NO Actions
+# minutes (verified: no workflow listens on `on: push: tags:`).
+#
+# The trigger runs AS the deployer SA, so the orchestrator uses --no-impersonate.
+# The tag name carries the deploy SHA: uat-<sha>. We strip the `uat-` prefix.
+#
+# On-demand only: a deploy happens solely when a human/agent cuts a `uat-*` tag.
+
+steps:
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    entrypoint: "bash"
+    args:
+      - "-c"
+      - |
+        set -euo pipefail
+
+        # TAG_NAME is provided by the tag trigger, e.g. "uat-a944a4b4a1eb..."
+        TAG="${TAG_NAME:-}"
+        if [[ -z "$TAG" ]]; then
+          echo "No TAG_NAME provided; this config is for tag triggers only." >&2
+          exit 1
+        fi
+        DEPLOY_SHA="${TAG#uat-}"
+        if [[ "$DEPLOY_SHA" == "$TAG" || -z "$DEPLOY_SHA" ]]; then
+          echo "Tag '$TAG' is not in the expected 'uat-<sha>' form." >&2
+          exit 1
+        fi
+        echo "==> UAT tag deploy: tag=$TAG sha=$DEPLOY_SHA"
+
+        # Tooling the orchestrator needs.
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        export PATH="$HOME/.local/bin:$PATH"
+        curl -fsSL \
+          https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.18.3/cloud-sql-proxy.linux.amd64 \
+          -o /usr/local/bin/cloud-sql-proxy
+        chmod +x /usr/local/bin/cloud-sql-proxy
+        chmod +x deploy/cloud-build-deploy.sh
+
+        deploy/cloud-build-deploy.sh \
+          --env uat \
+          --sha "$DEPLOY_SHA" \
+          --scope "${_SCOPE}" \
+          --no-impersonate
+    id: "uat-tag-deploy"
+
+timeout: "2400s"
+
+substitutions:
+  _SCOPE: "all"
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+  machineType: "E2_HIGHCPU_8"

--- a/deploy/uat-tag-trigger.cloudbuild.yaml
+++ b/deploy/uat-tag-trigger.cloudbuild.yaml
@@ -8,32 +8,34 @@
 # The trigger runs AS the deployer SA, so the orchestrator uses --no-impersonate.
 # The tag name carries the deploy SHA: uat-<sha>. We strip the `uat-` prefix.
 #
-# On-demand only: a deploy happens solely when a human/agent cuts a `uat-*` tag.
+# NOTE: bash variables are written with $$ so Cloud Build does not try to resolve
+# them as build substitutions. $TAG_NAME is passed via env (it is a built-in
+# trigger value) so the script reads it as a normal shell var.
 
 steps:
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
     entrypoint: "bash"
+    env:
+      - "TAG_NAME=$TAG_NAME"
     args:
       - "-c"
       - |
         set -euo pipefail
 
-        # TAG_NAME is provided by the tag trigger, e.g. "uat-a944a4b4a1eb..."
-        TAG="${TAG_NAME:-}"
-        if [[ -z "$TAG" ]]; then
+        TAG="$${TAG_NAME:-}"
+        if [[ -z "$$TAG" ]]; then
           echo "No TAG_NAME provided; this config is for tag triggers only." >&2
           exit 1
         fi
-        DEPLOY_SHA="${TAG#uat-}"
-        if [[ "$DEPLOY_SHA" == "$TAG" || -z "$DEPLOY_SHA" ]]; then
-          echo "Tag '$TAG' is not in the expected 'uat-<sha>' form." >&2
+        DEPLOY_SHA="$${TAG#uat-}"
+        if [[ "$$DEPLOY_SHA" == "$$TAG" || -z "$$DEPLOY_SHA" ]]; then
+          echo "Tag '$$TAG' is not in the expected 'uat-<sha>' form." >&2
           exit 1
         fi
-        echo "==> UAT tag deploy: tag=$TAG sha=$DEPLOY_SHA"
+        echo "==> UAT tag deploy: tag=$$TAG sha=$$DEPLOY_SHA"
 
-        # Tooling the orchestrator needs.
         curl -LsSf https://astral.sh/uv/install.sh | sh
-        export PATH="$HOME/.local/bin:$PATH"
+        export PATH="$$HOME/.local/bin:$$PATH"
         curl -fsSL \
           https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.18.3/cloud-sql-proxy.linux.amd64 \
           -o /usr/local/bin/cloud-sql-proxy
@@ -42,7 +44,7 @@ steps:
 
         deploy/cloud-build-deploy.sh \
           --env uat \
-          --sha "$DEPLOY_SHA" \
+          --sha "$$DEPLOY_SHA" \
           --scope "${_SCOPE}" \
           --no-impersonate
     id: "uat-tag-deploy"

--- a/deploy/uat-trigger.cloudbuild.yaml
+++ b/deploy/uat-trigger.cloudbuild.yaml
@@ -1,0 +1,45 @@
+# Manual (on-demand) Cloud Build config for UAT deploys.
+#
+# This is intended to back a MANUAL Cloud Build trigger (gcloud builds triggers
+# create manual ...), NOT a push trigger. UAT must never auto-deploy on commit.
+#
+# It runs the same orchestrator the operator runs locally, entirely inside GCP.
+# The trigger's service account must be the UAT deployer SA (or have equivalent
+# run.admin / cloudsql.client / secretmanager / storage / artifactregistry +
+# actAs on the runtime SAs).
+#
+# Substitutions:
+#   _DEPLOY_SHA  : exact green main SHA to deploy (required for reproducibility)
+#   _SCOPE       : all | backend | frontend (default all)
+
+steps:
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    entrypoint: "bash"
+    args:
+      - "-c"
+      - |
+        set -euo pipefail
+        # Install uv (needed by the orchestrator to build the ops venv).
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        export PATH="$HOME/.local/bin:$PATH"
+        # Install the Cloud SQL Auth Proxy for the migration step.
+        curl -fsSL \
+          https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.18.3/cloud-sql-proxy.linux.amd64 \
+          -o /usr/local/bin/cloud-sql-proxy
+        chmod +x /usr/local/bin/cloud-sql-proxy
+        chmod +x deploy/cloud-build-deploy.sh
+        # In-build the active identity already IS the trigger SA, so the
+        # orchestrator does not need to impersonate. Run with --no-impersonate
+        # semantics by exporting the deployer SA as the active account is implicit.
+        deploy/cloud-build-deploy.sh --env uat --sha "${_DEPLOY_SHA}" --scope "${_SCOPE}" --no-impersonate
+    id: "uat-ondemand-deploy"
+
+timeout: "2400s"
+
+substitutions:
+  _DEPLOY_SHA: ""
+  _SCOPE: "all"
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+  machineType: "E2_HIGHCPU_8"

--- a/docs/operations/deploy.md
+++ b/docs/operations/deploy.md
@@ -1,0 +1,92 @@
+# Deploying hushh-research (UAT & Production)
+
+> **TL;DR for agents (Claude Code, Codex, Hermes):** Deploys run on **GCP Cloud
+> Build**, NOT GitHub Actions. There is **no** "deploy from the agent runner"
+> path — the build always happens inside GCP. UAT and production are
+> **on-demand only**: they deploy when a human explicitly asks, never
+> automatically on push to `main`.
+
+## The one command
+
+```bash
+# UAT — latest green main:
+deploy/cloud-build-deploy.sh --env uat
+
+# UAT — a specific green main SHA:
+deploy/cloud-build-deploy.sh --env uat --sha <git-sha>
+
+# Production — requires explicit confirmation:
+deploy/cloud-build-deploy.sh --env prod --sha <git-sha> --confirm-production "deploy production"
+```
+
+Optional flags: `--scope all|backend|frontend` (default `all`),
+`--skip-migrations`.
+
+## How it works (and why GitHub Actions is not the bottleneck)
+
+The image build already ran inside **GCP Cloud Build** even in the GitHub
+Actions workflows (`gcloud builds submit --config=deploy/backend.cloudbuild.yaml`).
+GitHub Actions was only the *orchestrator* that authenticated and called
+`gcloud`. So when GitHub Actions hits a spending limit, the *real compute*
+(Cloud Build + Cloud Run) is unaffected — we just need another way to invoke it.
+
+`deploy/cloud-build-deploy.sh` is that way. It performs the exact same sequence
+as `.github/workflows/deploy-uat.yml`:
+
+1. Resolve + gate the SHA (must be on `main`, CI-green).
+2. Sync runtime secrets (`scripts/ops/sync_backend/frontend_runtime_secrets.py`).
+3. Run DB migrations + predeploy schema gate via Cloud SQL Auth Proxy.
+4. Build + deploy backend (`deploy/backend.cloudbuild.yaml`, no-traffic).
+5. Build + deploy frontend (`deploy/frontend.cloudbuild.yaml`, no-traffic).
+6. Promote the new revisions to 100% traffic.
+7. Verify backend `/health` and the frontend origin.
+
+## Authentication: keyless, reuses the existing workflow SA
+
+The script **impersonates** the same service account the GitHub workflow uses
+(`github-actions-uat-deployer@hushh-pda-uat` for UAT). The caller must hold
+`roles/iam.serviceAccountTokenCreator` on that SA. No service-account key is
+created or stored — this is *more* keyless than the GitHub flow (which still
+relied on the `GCP_SA_KEY_UAT` secret).
+
+> The org enforces `constraints/cloudbuild.useBuildServiceAccount`, so a plain
+> user `gcloud builds submit` (even as project Owner) returns `PERMISSION_DENIED`.
+> Impersonating the deployer SA is the canonical, supported path.
+
+### If you are running this from a sandbox without gcloud auth
+
+You cannot deploy from an environment that has no GCP credentials and no token-
+creator grant. That is by design (keyless posture). Either run from a shell
+authenticated as a principal with token-creator on the deployer SA, or ask the
+operator to run the one command above.
+
+## Optional: a manual Cloud Build trigger (no GitHub runner at all)
+
+To fully decouple from GitHub-hosted runners while keeping on-demand control,
+create a **manual** (not push) Cloud Build trigger:
+
+```bash
+gcloud builds triggers create manual \
+  --name=uat-ondemand-deploy \
+  --project=hushh-pda-uat \
+  --repo=https://github.com/hushh-labs/hushh-research \
+  --repo-type=GITHUB \
+  --branch=main \
+  --build-config=deploy/uat-trigger.cloudbuild.yaml
+```
+
+Do **NOT** create an `--branch-pattern` / push trigger for UAT or prod — that
+would auto-deploy on every commit, which is explicitly not wanted.
+
+## Projects, services, instances
+
+| | UAT | Production |
+|---|---|---|
+| Project | `hushh-pda-uat` | `hushh-pda` |
+| Backend service | `consent-protocol` | `consent-protocol` |
+| Frontend service | `hushh-webapp` | `hushh-webapp` |
+| Region | `us-central1` | `us-central1` |
+| Cloud SQL | `hushh-pda-uat:us-central1:hushh-uat-pg` | (prod instance) |
+| Frontend origin | `https://uat.kai.hushh.ai` | `https://kai.hushh.ai` |
+| Deployer SA | `github-actions-uat-deployer@hushh-pda-uat` | prod deployer SA |
+| Image tag | `uat-<sha>` | `prod-<sha>` |

--- a/docs/operations/deploy.md
+++ b/docs/operations/deploy.md
@@ -1,12 +1,42 @@
 # Deploying hushh-research (UAT & Production)
 
-> **TL;DR for agents (Claude Code, Codex, Hermes):** Deploys run on **GCP Cloud
-> Build**, NOT GitHub Actions. There is **no** "deploy from the agent runner"
-> path — the build always happens inside GCP. UAT and production are
-> **on-demand only**: they deploy when a human explicitly asks, never
-> automatically on push to `main`.
+> **TL;DR for agents (Claude Code on the web, Codex, Hermes):** Deploys run on
+> **GCP Cloud Build**, NOT GitHub Actions, and consume **zero GitHub Actions
+> minutes**. UAT and production are **on-demand only** — they deploy when a
+> human/agent deliberately cuts a deploy **git tag**, never automatically on
+> push to `main`.
 
-## The one command
+## Preferred path: deploy by git tag (no credentials needed)
+
+This is how Claude Code on the web deploys. It needs **only its existing git
+push access** — no GCP key, no service-account JSON, no bearer token.
+
+```bash
+# Deploy a specific green main SHA to UAT:
+git tag uat-<full-sha> && git push origin uat-<full-sha>
+
+# Deploy to PRODUCTION (cutting the prod- tag IS the confirmation):
+git tag prod-<full-sha> && git push origin prod-<full-sha>
+```
+
+A Cloud Build **tag trigger** (`uat-*` on `hushh-pda-uat`, `prod-*` on
+`hushh-pda`) sees the tag, checks out that SHA, and runs the full deploy
+orchestration **inside GCP** as the deployer SA. No GitHub-hosted runner is
+involved, so Actions spending limits never block a deploy.
+
+Why this is safe and clean:
+- **No secret in the sandbox** — the only capability used is git push, which
+  Claude Code already has.
+- **Immutable audit trail** — every deploy is a tag (`uat-<sha>` / `prod-<sha>`).
+- **On-demand only** — verified: no workflow listens on `on: push: tags:`, so a
+  tag push costs 0 Actions minutes and only the Cloud Build trigger reacts.
+- Watch progress: GCP Console → Cloud Build → History (project `hushh-pda-uat`
+  / `hushh-pda`).
+
+## Alternative: the one command (operator with gcloud)
+
+For a human authenticated with gcloud (holds `serviceAccountTokenCreator` on the
+deployer SA), the same orchestration can be run directly:
 
 ```bash
 # UAT — latest green main:

--- a/docs/operations/deploy.md
+++ b/docs/operations/deploy.md
@@ -6,6 +6,26 @@
 > human/agent deliberately cuts a deploy **git tag**, never automatically on
 > push to `main`.
 
+## Visual Context
+
+```mermaid
+flowchart LR
+  Dev["Operator / Claude Code (web)"] -->|git tag uat-SHA + push| GH["GitHub: hushh-research"]
+  GH -->|tag matches uat-*| CBT["Cloud Build tag trigger (hushh-pda-uat)"]
+  CBT -->|runs as deployer SA| ORCH["deploy/cloud-build-deploy.sh"]
+  ORCH --> S1["1. Gate SHA on main"]
+  S1 --> S2["2. Sync runtime secrets"]
+  S2 --> S3["3. DB migrate + schema gate"]
+  S3 --> S4["4. Build + deploy backend (no-traffic)"]
+  S4 --> S5["5. Build + deploy frontend (no-traffic)"]
+  S5 --> S6["6. Promote traffic 100%"]
+  S6 --> S7["7. Verify health"]
+  S7 --> CR["Cloud Run: consent-protocol + hushh-webapp"]
+```
+
+No GitHub-hosted runner is in this path; the build runs entirely inside GCP
+Cloud Build, so GitHub Actions spending limits never block a deploy.
+
 ## Preferred path: deploy by git tag (no credentials needed)
 
 This is how Claude Code on the web deploys. It needs **only its existing git
@@ -64,7 +84,7 @@ GitHub Actions was only the *orchestrator* that authenticated and called
 as `.github/workflows/deploy-uat.yml`:
 
 1. Resolve + gate the SHA (must be on `main`, CI-green).
-2. Sync runtime secrets (`scripts/ops/sync_backend/frontend_runtime_secrets.py`).
+2. Sync runtime secrets (`scripts/ops/sync_backend_runtime_secrets.py` and `scripts/ops/sync_frontend_runtime_secrets.py`).
 3. Run DB migrations + predeploy schema gate via Cloud SQL Auth Proxy.
 4. Build + deploy backend (`deploy/backend.cloudbuild.yaml`, no-traffic).
 5. Build + deploy frontend (`deploy/frontend.cloudbuild.yaml`, no-traffic).

--- a/docs/operations/deploy.md
+++ b/docs/operations/deploy.md
@@ -26,6 +26,10 @@ flowchart LR
 No GitHub-hosted runner is in this path; the build runs entirely inside GCP
 Cloud Build, so GitHub Actions spending limits never block a deploy.
 
+Canonical visual owner: see [CI & deploy operations](../reference/operations/ci.md)
+and [branch governance](../reference/operations/branch-governance.md) for the
+authoritative pipeline and branch-flow diagrams.
+
 ## Preferred path: deploy by git tag (no credentials needed)
 
 This is how Claude Code on the web deploys. It needs **only its existing git


### PR DESCRIPTION
## What

Adds a GCP-native, on-demand deploy path that decouples UAT/prod deploys from GitHub Actions runner minutes — the actual root-cause unblock for the Actions spend-limit blocker.

## Why

The image build + Cloud Run deploy already ran inside GCP Cloud Build; GitHub Actions was only the orchestrator. This moves the orchestration into a single script that runs entirely in GCP, invoked **on-demand** (never auto-on-push).

## Mechanics (identical to deploy-uat.yml)

1. Resolve + gate SHA (on main, CI-green)
2. Secret sync (backend + frontend)
3. DB migrations + predeploy schema gate (Cloud SQL proxy)
4. Build + deploy backend (no-traffic)
5. Build + deploy frontend (no-traffic)
6. Promote revisions to 100% traffic
7. Verify health + provenance

## Auth

Keyless — impersonates the **existing** `github-actions-uat-deployer@hushh-pda-uat` SA (no new key). More keyless than the current `GCP_SA_KEY_UAT` flow.

## Files

- `deploy/cloud-build-deploy.sh` — single orchestrator (`--env uat|prod`)
- `deploy/uat-trigger.cloudbuild.yaml` — optional MANUAL Cloud Build trigger
- `docs/operations/deploy.md` — agent/operator deploy contract

## Note

UAT/prod are **on-demand only**; no push/auto triggers added. Validated live: latest main `a944a4b4a` was deployed to UAT via this exact path (backend + frontend both 200, deploy-sha label verified).