### PR TITLE
test(consent): verify resolveConsentRequestHref processes reference calculations when options contain a multi-token string

### DIFF
--- a/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
+++ b/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
@@ -47,6 +47,18 @@ describe("consent sheet route helpers", () => {
     ).toBe("/consents?tab=pending&requestId=req_123&from=%2Fkai%2Fanalysis%3Ftab%3Dhistory");
   });
 
+  it("processes reference calculations when the configuration options parameter contains a multi-token string", () => {
+    const multiTokenOptions = {
+      requestId: "req_123",
+      from: "/kai/identity credentials tracking",
+    };
+    const result = resolveConsentRequestHref(null, "pending", multiTokenOptions);
+
+    expect(result).toBe(
+      "/consents?tab=pending&requestId=req_123&from=%2Fkai%2Fidentity+credentials+tracking"
+    );
+  });
+
   it("classifies internal consent links as SPA routes", () => {
     expect(
       resolveConsentNavigationTarget("http://localhost:3000/consents?tab=pending&requestId=req_123")


### PR DESCRIPTION
﻿## Summary
Adds a narrow unit test asserting that `resolveConsentRequestHref(null, "pending", { requestId: "req_123", from: "/kai/identity credentials tracking" })` returns `/consents?tab=pending&requestId=req_123&from=%2Fkai%2Fidentity+credentials+tracking`.

## Production function exercised
- `resolveConsentRequestHref` from `hushh-webapp/lib/consent/consent-sheet-route.ts`

## Test file
- `hushh-webapp/__tests__/utils/consent-sheet-route.test.ts`

## CI gate checklist
- [x] PR Base Policy - targets `integration/pr-train`
- [x] DCO - Signed-off-by included
- [x] Narrow surface - one additive assertion for `resolveConsentRequestHref`
- [x] Clean diff - 1 tracked file, 12 additive lines, fresh upstream base
- [x] Proof - `npm test -- __tests__/utils/consent-sheet-route.test.ts` passed locally
