### PR TITLE
fix(ui): hide decorative breadcrumb separator icon

### DIFF
--- a/hushh-webapp/components/ui/breadcrumb.tsx
+++ b/hushh-webapp/components/ui/breadcrumb.tsx
@@ -75,7 +75,7 @@ function BreadcrumbSeparator({
       className={cn("[&>svg]:size-3.5", className)}
       {...props}
     >
-      {children ?? <ChevronRight />}
+      {children ?? <ChevronRight aria-hidden="true" />}
     </li>
   )
 }


### PR DESCRIPTION
## Summary
- Mark the default breadcrumb separator chevron as decorative with `aria-hidden`.
- Keep the existing `BreadcrumbSeparator` structure and presentation role unchanged.

## Why
The breadcrumb separator is visual chrome between navigation items. The wrapper is already presentational, and explicitly hiding the default chevron keeps assistive technology focused on the breadcrumb links and current page instead of decorative separators.

## Impact
Screen reader output remains cleaner for breadcrumb navigation. There is no visual or behavioral change.

## Validation
- Inspected staged diff: one-line change in `hushh-webapp/components/ui/breadcrumb.tsx`.
- Attempted focused ESLint with `npx.cmd eslint hushh-webapp/components/ui/breadcrumb.tsx --max-warnings=0`; blocked because the clean worktree has no installed `node_modules` and ESLint could not resolve `eslint-config-next`.
