### PR TITLE
test(api): verify account export GET returns missing authorization response without backend fetch

### DIFF
--- a/hushh-webapp/__tests__/api/account-export-proxy.test.ts
+++ b/hushh-webapp/__tests__/api/account-export-proxy.test.ts
@@ -24,6 +24,17 @@ function request(headers: Record<string, string> = {}) {
 }
 
 describe("GET /api/account/export proxy", () => {
+  it("returns a stable missing authorization response without calling the backend", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+
+    const response = await route.GET(request());
+    const payload = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(payload).toEqual({ error: "Missing Authorization header" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("does not expose raw backend error text", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response("raw database failure with table names", { status: 500 })


### PR DESCRIPTION
﻿## Summary
Adds a narrow unit test asserting that `GET` from `hushh-webapp/app/api/account/export/route.ts` returns status `401`, returns `{ "error": "Missing Authorization header" }`, and does not call `fetch` when the request has no Authorization header.

## Production function exercised
- `GET` from `hushh-webapp/app/api/account/export/route.ts`

## Test file
- `hushh-webapp/__tests__/api/account-export-proxy.test.ts`

## CI gate checklist
- [x] PR Base Policy - targets `integration/pr-train`
- [x] DCO - Signed-off-by included
- [x] Narrow surface - one additive assertion for account export `GET`
- [x] Clean diff - 1 tracked file, 11 additive lines, fresh upstream base
- [x] Proof - `npm test -- __tests__/api/account-export-proxy.test.ts` passed locally
