### PR TITLE
fix(ui): hide drawer close icon from assistive technology

### DIFF
--- a/hushh-webapp/components/ui/drawer.tsx
+++ b/hushh-webapp/components/ui/drawer.tsx
@@ -82,7 +82,7 @@ function DrawerContent({
           data-slot="drawer-close"
           className="ring-offset-background focus:ring-ring absolute top-4 right-4 z-30 rounded-full border border-transparent bg-[color:var(--app-card-surface-compact)] p-2 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none"
         >
-          <XIcon className="size-4" />
+          <XIcon className="size-4" aria-hidden="true" />
           <span className="sr-only">Close</span>
         </DrawerPrimitive.Close>
       )}


### PR DESCRIPTION
## Summary
- Mark the drawer close button's visual `XIcon` as decorative with `aria-hidden`.
- Keep the existing screen-reader-only `Close` label as the accessible name.

## Why
The drawer close icon is visual chrome inside a button that already exposes a text label for assistive technology. Hiding the icon prevents duplicate or noisy announcement while preserving the close control's accessible name.

## Impact
Screen reader output stays focused on the close action. There is no visual or behavioral change.

## Validation
- Inspected staged diff: one-line change in `hushh-webapp/components/ui/drawer.tsx`.
- Verified the commit includes a DCO `Signed-off-by` trailer.
- Attempted focused ESLint with `npx.cmd eslint hushh-webapp/components/ui/drawer.tsx --max-warnings=0`; blocked because the clean worktree has no installed `node_modules` and ESLint could not resolve `eslint-config-next`.
