### PR TITLE
test(observability): verify getOrCreateRequestTimestampMs parses timestamp header values with trailing tab characters

### DIFF
--- a/hushh-webapp/__tests__/services/request-timestamp.test.ts
+++ b/hushh-webapp/__tests__/services/request-timestamp.test.ts
@@ -183,6 +183,13 @@ describe("getOrCreateRequestTimestampMs — drift-safe header parsing", () => {
     expect(getOrCreateRequestTimestampMs(headers, NOW)).toBe(validTs);
   });
 
+  it("returns the parsed timestamp when the header value contains trailing tab characters", () => {
+    const validTs = NOW - 10_000;
+    const headers = { [REQUEST_TIMESTAMP_HEADER]: `${validTs}\t\t` };
+
+    expect(getOrCreateRequestTimestampMs(headers, NOW)).toBe(validTs);
+  });
+
   it("falls back to runtime clock when no timestamp header is present", () => {
     expect(getOrCreateRequestTimestampMs({}, NOW)).toBe(NOW);
     expect(getOrCreateRequestTimestampMs(null, NOW)).toBe(NOW);


### PR DESCRIPTION
﻿## Summary
Adds a narrow unit test asserting that `getOrCreateRequestTimestampMs` returns the parsed timestamp number when the `x-request-timestamp-ms` header value is a numeric millisecond timestamp string followed by two trailing tab characters.

## Production function exercised
- `getOrCreateRequestTimestampMs` from `hushh-webapp/lib/observability/request-id.ts`

## Test file
- `hushh-webapp/__tests__/services/request-timestamp.test.ts`

## CI gate checklist
- [x] PR Base Policy - targets `integration/pr-train`
- [x] DCO - Signed-off-by included
- [x] Narrow surface - one additive assertion for `getOrCreateRequestTimestampMs`
- [x] Clean diff - 1 tracked file, 7 additive lines, fresh upstream base
- [x] Proof - `npm test -- __tests__/services/request-timestamp.test.ts` passed locally
