### PR TITLE
fix(ui): hide pagination chevrons from assistive technology

### DIFF
--- a/hushh-webapp/components/ui/pagination.tsx
+++ b/hushh-webapp/components/ui/pagination.tsx
@@ -84,7 +84,7 @@ function PaginationPrevious({
           : undefined
       }
     >
-      <ChevronLeftIcon />
+      <ChevronLeftIcon aria-hidden="true" />
       <span className="hidden sm:block">Previous</span>
     </PaginationLink>
   )
@@ -109,7 +109,7 @@ function PaginationNext({
       }
     >
       <span className="hidden sm:block">Next</span>
-      <ChevronRightIcon />
+      <ChevronRightIcon aria-hidden="true" />
     </PaginationLink>
   )
 }


### PR DESCRIPTION
## Summary
- Mark the previous and next pagination chevrons as decorative with `aria-hidden`.
- Keep the existing previous/next link labels as the accessible names.

## Why
The pagination controls already expose clear labels for assistive technology through `aria-label`. Hiding the chevron icons prevents decorative icon noise while preserving the intended previous and next page actions.

## Impact
Screen reader output stays focused on the pagination actions. There is no visual or behavioral change.

## Validation
- Inspected staged diff: two icon-only updates in `hushh-webapp/components/ui/pagination.tsx`.
- Verified the commit includes a DCO `Signed-off-by` trailer.
- Attempted focused ESLint with `npx.cmd eslint hushh-webapp/components/ui/pagination.tsx --max-warnings=0`; blocked because the clean worktree has no installed `node_modules` and ESLint could not resolve `eslint-config-next`.
