### PR TITLE
fix(ui): mark sonner toast icons as decorative

### DIFF
--- a/hushh-webapp/components/ui/sonner.tsx
+++ b/hushh-webapp/components/ui/sonner.tsx
@@ -24,11 +24,11 @@ const Toaster = ({ ...props }: ToasterProps) => {
       visibleToasts={2}
       gap={10}
       icons={{
-        success: <CircleCheckIcon className="size-4" />,
-        info: <InfoIcon className="size-4" />,
-        warning: <TriangleAlertIcon className="size-4" />,
-        error: <OctagonXIcon className="size-4" />,
-        loading: <Loader2Icon className="size-4 animate-spin" />,
+        success: <CircleCheckIcon className="size-4" aria-hidden="true" />,
+        info: <InfoIcon className="size-4" aria-hidden="true" />,
+        warning: <TriangleAlertIcon className="size-4" aria-hidden="true" />,
+        error: <OctagonXIcon className="size-4" aria-hidden="true" />,
+        loading: <Loader2Icon className="size-4 animate-spin" aria-hidden="true" />,
       }}
       toastOptions={{
         classNames: {


### PR DESCRIPTION
## Summary
- Mark custom Sonner toast status icons as decorative with `aria-hidden`.
- Preserve the existing toast text content and visual status icons.

## Why
The toast title and description already communicate the status message to assistive technology. Hiding the custom icons prevents decorative icon noise while keeping the visible status affordance unchanged.

## Impact
Screen reader output stays focused on the toast message. There is no visual or behavioral change.

## Caller Proof
- `hushh-webapp/components/ui/sonner.tsx` exports the local `Toaster` wrapper.
- `hushh-webapp/app/providers.tsx` imports that wrapper and renders `<Toaster />` once at the app provider layer.
- The changed `icons` prop is therefore applied to the shared Sonner instance used by app toasts, without changing individual toast call sites.
- Only the custom icon elements receive `aria-hidden="true"`; toast titles, descriptions, actions, timing, and placement remain owned by Sonner and are unchanged.

## Validation
- Inspected staged diff: icon-only updates in `hushh-webapp/components/ui/sonner.tsx`.
- Verified the commit includes a DCO `Signed-off-by` trailer.
- Attempted focused ESLint with `npx.cmd eslint hushh-webapp/components/ui/sonner.tsx --max-warnings=0`; blocked because the clean worktree has no installed `node_modules` and ESLint could not resolve `eslint-config-next`.
