### PR TITLE
test(crypto): verify decryptScopedExport rejects wrapping_alg values with trailing punctuation marks

### DIFF
--- a/hushh-webapp/__tests__/services/one-kyc-client-zk-service.test.ts
+++ b/hushh-webapp/__tests__/services/one-kyc-client-zk-service.test.ts
@@ -810,6 +810,27 @@ describe("OneKycClientZkService", () => {
       })
     ).rejects.toThrow("Unsupported KYC export wrapping algorithm");
   });
+
+  it("rejects export wrapping algorithm values with trailing punctuation marks before decrypting", async () => {
+    await expect(
+      OneKycClientZkService.decryptScopedExport({
+        connector,
+        exportPackage: {
+          encrypted_data: "",
+          iv: "",
+          tag: "",
+          wrapped_key_bundle: {
+            wrapped_export_key: "",
+            wrapped_key_iv: "",
+            wrapped_key_tag: "",
+            sender_public_key: "",
+            wrapping_alg: "aes-256-gcm!!",
+            connector_key_id: connector.connector_key_id,
+          },
+        },
+      })
+    ).rejects.toThrow("Unsupported KYC export wrapping algorithm");
+  });
 });
 
 // ── ZK preflight — structurally invalid payload rejection ──────────────────────


### PR DESCRIPTION
﻿## Summary
Adds a narrow unit test asserting that `OneKycClientZkService.decryptScopedExport` rejects an export package whose `wrapped_key_bundle.wrapping_alg` value is exactly `aes-256-gcm!!` by throwing `Unsupported KYC export wrapping algorithm` before decrypting.

## Production function exercised
- `OneKycClientZkService.decryptScopedExport` from `hushh-webapp/lib/services/one-kyc-client-zk-service.ts`

## Test file
- `hushh-webapp/__tests__/services/one-kyc-client-zk-service.test.ts`

## CI gate checklist
- [x] PR Base Policy - targets `integration/pr-train`
- [x] DCO - Signed-off-by included
- [x] Narrow surface - one additive assertion for `decryptScopedExport`
- [x] Clean diff - 1 tracked file, 21 additive lines, fresh upstream base
- [x] Proof - `npm test -- __tests__/services/one-kyc-client-zk-service.test.ts` passed locally
