### PR TITLE
fix(kai): add autocomplete hints to analysis preview inputs

### DIFF
--- a/hushh-webapp/components/kai/views/kai-analysis-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-analysis-preview-view.tsx
@@ -407,6 +407,7 @@ function KaiSheet({
           <input
             value={draft}
             onChange={(event) => setDraft(event.target.value)}
+            autoComplete="off"
             placeholder="Message Kai..."
             className="w-full bg-transparent text-[14px] text-[color:var(--one-fg)] outline-none placeholder:text-[color:var(--one-fg3)]"
           />
@@ -567,6 +568,7 @@ export function KaiAnalysisPreviewView() {
             <Search className="h-[17px] w-[17px] shrink-0 text-[color:var(--one-fg3)]" />
             <input
               type="text"
+              autoComplete="off"
               placeholder="Analyze any stock"
               value={stockQuery}
               onChange={(event) => setStockQuery(event.target.value)}


### PR DESCRIPTION
## Summary
- Add `autoComplete="off"` to the analysis preview Kai message input.
- Add `autoComplete="off"` to the analysis preview stock search input.

## Why
These preview inputs are transient query surfaces. Supplying an explicit autocomplete hint prevents browser-saved suggestions from appearing over the compact Kai preview UI while keeping the current input behavior unchanged.

## Impact
The analysis preview search/chat inputs keep the same layout and submit behavior. Browsers now receive an explicit hint not to show autocomplete suggestions.

## Caller Proof
- `KaiAnalysisPreviewView` is exported from `hushh-webapp/components/kai/views/kai-analysis-preview-view.tsx`.
- It is reached from `hushh-webapp/app/kai/analysis/page.tsx` and `hushh-webapp/components/kai/views/kai-preview-router.tsx`.
- The stock search input lives directly inside `KaiAnalysisPreviewView`.
- The Kai message input lives inside the local `KaiSheet` helper in the same file, and `KaiAnalysisPreviewView` renders `<KaiSheet open={kaiOpen} onClose={() => setKaiOpen(false)} />`.
- This PR intentionally touches both functions because both inputs belong to the same analysis preview surface and receive the same attribute-only autocomplete hint.

## Validation
- Inspected staged diff: two attribute-only updates in `hushh-webapp/components/kai/views/kai-analysis-preview-view.tsx`.
- Verified the commit includes a DCO `Signed-off-by` trailer.
- Attempted focused ESLint with `npx.cmd eslint hushh-webapp/components/kai/views/kai-analysis-preview-view.tsx --max-warnings=0`; blocked because the clean worktree has no installed `node_modules` and ESLint could not resolve `eslint-config-next`.
