### PR TITLE
fix(kai): hide decorative loading spinner in portfolio source switcher

### DIFF
--- a/hushh-webapp/components/kai/portfolio-source-switcher.tsx
+++ b/hushh-webapp/components/kai/portfolio-source-switcher.tsx
@@ -180,7 +180,7 @@ export function PortfolioSourceSwitcher({
                 data-voice-control-id="delete_imported_data"
               >
                 {isDeletingPortfolio ? (
-                  <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                  <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" aria-hidden="true" />
                 ) : (
                   <Trash2 className="mr-2 h-3.5 w-3.5" />
                 )}
@@ -233,7 +233,7 @@ export function PortfolioSourceSwitcher({
                   data-voice-control-id="delete_statement_snapshot"
                 >
                   {isDeletingStatementSnapshot ? (
-                    <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                    <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" aria-hidden="true" />
                   ) : (
                     <Trash2 className="mr-2 h-3.5 w-3.5" />
                   )}


### PR DESCRIPTION
## Summary
- Mark portfolio and statement deletion loading spinners as decorative with `aria-hidden`.
- Keep the existing button text as the accessible action label.

## Why
The loading spinners are visual status affordances shown inside labeled buttons. Hiding them from assistive technology avoids decorative icon noise while preserving the delete action labels.

## Impact
Screen reader output stays focused on the button text. There is no visual or behavioral change.

## Validation
- Inspected staged diff: two spinner-only updates in `hushh-webapp/components/kai/portfolio-source-switcher.tsx`.
- Verified the commit includes a DCO `Signed-off-by` trailer.
- Attempted focused ESLint with `npx.cmd eslint hushh-webapp/components/kai/portfolio-source-switcher.tsx --max-warnings=0`; blocked because the clean worktree has no installed `node_modules` and ESLint could not resolve `eslint-config-next`.
