### PR TITLE
test(datatable): cover empty search results state

### DIFF
--- a/hushh-webapp/__tests__/components/data-table.test.tsx
+++ b/hushh-webapp/__tests__/components/data-table.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import type { ColumnDef } from "@tanstack/react-table";
 
@@ -78,6 +78,32 @@ describe("DataTable", () => {
     expect(screen.getByText("Row 3")).toBeTruthy();
     expect(screen.queryByText("No results.")).toBeNull();
   });
+
+  it("shows the empty results state when search matches no rows", async () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={makeRows(3)}
+        enableSearch
+        searchKey="name"
+        searchPlaceholder="Search rows"
+        initialPageSize={8}
+        pageSizeOptions={[8, 16, 24]}
+      />
+    );
+
+    const search = screen.getByPlaceholderText("Search rows");
+
+    fireEvent.change(search, { target: { value: "missing row" } });
+
+    await waitFor(() => {
+      expect(screen.getByText("No results found.")).toBeTruthy();
+    });
+    expect(screen.queryByText("Row 1")).toBeNull();
+    expect(screen.queryByText("Row 2")).toBeNull();
+    expect(screen.queryByText("Row 3")).toBeNull();
+  });
+
   it("preserves accessible search input behavior", () => {
     render(
       <DataTable


### PR DESCRIPTION
## Summary
- Add a DataTable test for the empty state when a search query matches no rows.
- Cover the debounced search path by waiting for the filtered results to settle.

## Why
The DataTable already has coverage for whitespace-only search and accessible search input behavior. This adds the missing no-match search state so the `No results found.` row stays protected.

## Impact
Test-only change. No runtime behavior changes.

## No Overlap Proof
- Shared file risk checked for `hushh-webapp/__tests__/components/data-table.test.tsx`.
- This PR adds a positive assertion for the no-match search state: after typing `missing row`, the test waits for and asserts `No results found.` is rendered.
- The nearby existing search test uses a negative assertion for a different behavior: whitespace-only search should not show the generic `No results.` fallback and should continue rendering rows.
- These assertions protect opposite outcomes in separate scenarios:
  - positive empty-state assertion: non-empty query with zero matching rows should render `No results found.`
  - negative fallback assertion: whitespace-only query should not enter the empty-results path
- The import change is limited to adding `waitFor` from Testing Library for the debounced positive assertion.

## Validation
- `npx.cmd vitest run __tests__/components/data-table.test.tsx`
- Verified the commit includes a DCO `Signed-off-by` trailer.
