### PR TITLE
test(voice): verify enforceArrayDimensionCap evaluates array allocation constraints cleanly when payload includes multi-byte emoji entries

### DIFF
--- a/hushh-webapp/__tests__/voice/screen-context-builder.test.ts
+++ b/hushh-webapp/__tests__/voice/screen-context-builder.test.ts
@@ -92,6 +92,15 @@ describe("enforceArrayDimensionCap — structured input array bounds", () => {
     expect(result.errorLabel).toBeNull();
   });
 
+  it("evaluates array allocation constraints cleanly when the payload sequence includes multi-byte emoji string entries", () => {
+    const emojiVectorInput = ["🚀", "🔥", "🛡️"];
+    const result = enforceArrayDimensionCap(emojiVectorInput);
+
+    expect(result.isValidAllocation).toBe(true);
+    expect(result.items).toEqual(emojiVectorInput);
+    expect(result.errorLabel).toBeNull();
+  });
+
   it("accepts an array whose length equals the default cap exactly", () => {
     const atCap = Array.from({ length: STRUCTURED_CONTEXT_ARRAY_CAP }, (_, i) => i);
     const result = enforceArrayDimensionCap(atCap);


### PR DESCRIPTION
﻿## Summary
Adds a narrow unit test asserting that `enforceArrayDimensionCap(["🚀", "🔥", "🛡️"])` returns `isValidAllocation: true`, returns the same emoji string array in `items`, and returns `errorLabel: null`.

## Production function exercised
- `enforceArrayDimensionCap` from `hushh-webapp/lib/voice/screen-context-builder.ts`

## Test file
- `hushh-webapp/__tests__/voice/screen-context-builder.test.ts`

## CI gate checklist
- [x] PR Base Policy - targets `integration/pr-train`
- [x] DCO - Signed-off-by included
- [x] Narrow surface - one additive assertion for `enforceArrayDimensionCap`
- [x] Clean diff - 1 tracked file, 9 additive lines, fresh upstream base
- [x] Proof - `npm test -- __tests__/voice/screen-context-builder.test.ts` passed locally
