### PR TITLE
test(utils): verify normalizeInternalAppHref preserves internal route strings containing dot-dot sub-path segments

### DIFF
--- a/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
+++ b/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
@@ -145,6 +145,11 @@ describe("path resolver safety — dangerous edge case handling", () => {
     expect(normalizeInternalAppHref(deep)).toBe(deep);
   });
 
+  it("normalizeInternalAppHref preserves internal route strings containing dot-dot sub-path segments", () => {
+    const traversalInput = "/consents/../callback";
+    expect(normalizeInternalAppHref(traversalInput)).toBe(traversalInput);
+  });
+
   it("resolveConsentNavigationTarget classifies /consents/* deep paths as internal", () => {
     const result = resolveConsentNavigationTarget(
       "/consents/a/b/c/d/e/f?requestId=req_1",


### PR DESCRIPTION
﻿## Summary
Adds a narrow unit test asserting that `normalizeInternalAppHref("/consents/../callback")` returns the same `/consents/../callback` string for an internal route value containing a dot-dot sub-path segment.

## Production function exercised
- `normalizeInternalAppHref` from `hushh-webapp/lib/consent/consent-sheet-route.ts`

## Test file
- `hushh-webapp/__tests__/utils/consent-sheet-route.test.ts`

## CI gate checklist
- [x] PR Base Policy - targets `integration/pr-train`
- [x] DCO - Signed-off-by included
- [x] Narrow surface - one additive assertion for `normalizeInternalAppHref`
- [x] Clean diff - 1 tracked file, 5 additive lines, fresh upstream base
- [x] Proof - `npm test -- __tests__/utils/consent-sheet-route.test.ts` passed locally
