### PR TITLE
test(consent): verify resolveConsentNavigationTarget parses parameter assignments containing multiple adjacent question mark tokens

### DIFF
--- a/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
+++ b/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
@@ -57,6 +57,17 @@ describe("consent sheet route helpers", () => {
     });
   });
 
+  it("parses parameter assignments containing multiple adjacent question mark tokens", () => {
+    const multiQuestionMarkInput = "/consents/auth??token=abc??hash=xyz";
+    const result = resolveConsentNavigationTarget(multiQuestionMarkInput);
+
+    expect(result).toEqual({
+      kind: "internal",
+      href: multiQuestionMarkInput,
+      pathname: "/consents/auth",
+    });
+  });
+
   it("classifies Email Helper workflow links as SPA routes", () => {
     expect(
       resolveConsentNavigationTarget("http://localhost:3000/one/kyc?workflowId=wf_123")


### PR DESCRIPTION
﻿## Summary
Adds a narrow unit test asserting that `resolveConsentNavigationTarget("/consents/auth??token=abc??hash=xyz")` returns an internal navigation target with `href` equal to `/consents/auth??token=abc??hash=xyz` and `pathname` equal to `/consents/auth`.

## Production function exercised
- `resolveConsentNavigationTarget` from `hushh-webapp/lib/consent/consent-sheet-route.ts`

## Test file
- `hushh-webapp/__tests__/utils/consent-sheet-route.test.ts`

## CI gate checklist
- [x] PR Base Policy - targets `integration/pr-train`
- [x] DCO - Signed-off-by included
- [x] Narrow surface - one additive assertion for `resolveConsentNavigationTarget`
- [x] Clean diff - 1 tracked file, 11 additive lines, fresh upstream base
- [x] Proof - `npm test -- __tests__/utils/consent-sheet-route.test.ts` passed locally
