### PR TITLE
fix(kai): restore market picks and theme bottom chrome

### DIFF
--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1283,19 +1283,40 @@ md-ripple.morphy-md-ripple {
 }
 
 .kai-bottom-nav-pill {
+  color: rgb(29 29 31);
+  border: 1px solid rgb(255 255 255 / 0.72) !important;
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 0.88), rgb(245 245 247 / 0.76)) !important;
+  box-shadow:
+    0 18px 44px -26px rgb(0 0 0 / 0.34),
+    0 2px 8px -6px rgb(0 0 0 / 0.18),
+    inset 0 1px 0 rgb(255 255 255 / 0.9),
+    inset 0 -1px 0 rgb(0 0 0 / 0.06) !important;
+  -webkit-backdrop-filter: blur(24px) saturate(180%);
+  backdrop-filter: blur(24px) saturate(180%);
+}
+
+.dark .kai-bottom-nav-pill {
   color: rgb(255 255 255);
-  border: 1px solid rgb(255 255 255 / 0.12) !important;
+  border-color: rgb(255 255 255 / 0.12) !important;
   background:
     linear-gradient(180deg, rgb(47 47 50 / 0.9), rgb(17 17 19 / 0.86)) !important;
   box-shadow:
     0 16px 38px -22px rgb(0 0 0 / 0.85),
     inset 0 1px 0 rgb(255 255 255 / 0.16),
     inset 0 -1px 0 rgb(0 0 0 / 0.32) !important;
-  -webkit-backdrop-filter: blur(24px) saturate(160%);
-  backdrop-filter: blur(24px) saturate(160%);
 }
 
 .kai-bottom-nav-pill [data-segment-indicator] {
+  background:
+    radial-gradient(circle at 50% 35%, rgb(255 255 255 / 0.95), transparent 64%),
+    linear-gradient(180deg, rgb(255 255 255 / 0.94), rgb(255 255 255 / 0.74)) !important;
+  box-shadow:
+    0 11px 24px -18px rgb(0 0 0 / 0.42),
+    inset 0 1px 0 rgb(255 255 255 / 0.92) !important;
+}
+
+.dark .kai-bottom-nav-pill [data-segment-indicator] {
   background:
     radial-gradient(circle at 50% 35%, rgb(255 255 255 / 0.18), transparent 64%),
     linear-gradient(180deg, rgb(255 255 255 / 0.16), rgb(255 255 255 / 0.06)) !important;
@@ -1305,16 +1326,61 @@ md-ripple.morphy-md-ripple {
 }
 
 .kai-bottom-nav-pill [role="radio"] {
+  color: rgb(60 60 67 / 0.78) !important;
+}
+
+.dark .kai-bottom-nav-pill [role="radio"] {
   color: rgb(255 255 255 / 0.82) !important;
 }
 
 .kai-bottom-nav-pill [role="radio"][aria-checked="true"] {
-  color: rgb(41 171 255) !important;
+  color: rgb(0 113 227) !important;
   font-weight: 700;
+}
+
+.dark .kai-bottom-nav-pill [role="radio"][aria-checked="true"] {
+  color: rgb(41 171 255) !important;
 }
 
 .kai-bottom-nav-pill [role="radio"] svg {
   stroke-width: 2.35;
+}
+
+.kai-bottom-search-action {
+  color: rgb(29 29 31) !important;
+  border-color: rgb(255 255 255 / 0.74) !important;
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 0.92), rgb(245 245 247 / 0.8)) !important;
+  box-shadow:
+    0 18px 42px -24px rgb(0 0 0 / 0.32),
+    inset 0 1px 0 rgb(255 255 255 / 0.9),
+    inset 0 -1px 0 rgb(0 0 0 / 0.06) !important;
+  -webkit-backdrop-filter: blur(24px) saturate(180%);
+  backdrop-filter: blur(24px) saturate(180%);
+}
+
+.dark .kai-bottom-search-action {
+  color: rgb(255 255 255) !important;
+  border-color: rgb(255 255 255 / 0.1) !important;
+  background: rgb(21 21 21 / 0.9) !important;
+  box-shadow:
+    0 14px 34px -18px rgb(0 0 0 / 0.8),
+    inset 0 1px 0 rgb(255 255 255 / 0.16) !important;
+}
+
+.kai-bottom-agent-action {
+  background: rgb(0 113 227) !important;
+  color: rgb(255 255 255);
+  box-shadow:
+    0 12px 26px -18px rgb(0 113 227 / 0.75),
+    inset 0 1px 0 rgb(255 255 255 / 0.36);
+}
+
+.dark .kai-bottom-agent-action {
+  background: rgb(10 132 255) !important;
+  box-shadow:
+    0 12px 28px -18px rgb(10 132 255 / 0.86),
+    inset 0 1px 0 rgb(255 255 255 / 0.34);
 }
 
 /* Carousel edge glass (left/right): use to hint adjacent slides while keeping center crisp. */

--- a/hushh-webapp/components/kai/kai-search-bar.tsx
+++ b/hushh-webapp/components/kai/kai-search-bar.tsx
@@ -1751,14 +1751,14 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
                   disabled={!agentPopover}
                   onClick={() => agentPopover?.openAgent()}
                 >
-                  <span className="grid h-[40px] w-[40px] place-items-center rounded-[14px] bg-[#0071e3] text-white shadow-[0_10px_24px_-16px_rgba(0,113,227,0.75),inset_0_1px_0_rgba(255,255,255,0.36)]">
+                  <span className="kai-bottom-agent-action grid h-[40px] w-[40px] place-items-center rounded-[14px]">
                     <Sparkles className="h-[18px] w-[18px]" strokeWidth={2.15} />
                   </span>
                 </button>
                 <ShellActionSurface
                   variant="icon"
                   wrapperClassName="pointer-events-auto"
-                  className="grid h-[58px] w-[58px] place-items-center !border-white/10 !bg-[#151515]/90 !bg-none !text-white shadow-[0_14px_34px_-18px_rgba(0,0,0,0.8),inset_0_1px_0_rgba(255,255,255,0.16)] backdrop-blur-2xl"
+                  className="kai-bottom-search-action grid h-[58px] w-[58px] place-items-center"
                   aria-label="Search"
                   onClick={() => setOpen(true)}
                 >

--- a/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
@@ -29,6 +29,7 @@ import { AppPageShell } from "@/components/app-ui/app-page-shell";
 import { KaiControlSurface } from "@/components/app-ui/kai-control-surface";
 import { SurfaceInset } from "@/components/app-ui/surfaces";
 import { ConnectPortfolioCta } from "@/components/kai/cards/connect-portfolio-cta";
+import { RiaPicksList } from "@/components/kai/cards/renaissance-market-list";
 import { PermissionGate } from "@/components/privacy/permission-gate/permission-gate";
 import {
   type MarketOverviewDetailPanel,
@@ -1741,6 +1742,7 @@ export function KaiMarketPreviewView() {
     error,
     activePickSource,
     loadInsights,
+    handlePickSourceChange,
   } = useKaiMarketHomeController();
   const [retainedPayload, setRetainedPayload] = useState<KaiHomeInsightsV2 | null>(payload);
   const usingLocalPreviewFallback = Boolean(localPreviewPayload && !payload);
@@ -1773,6 +1775,16 @@ export function KaiMarketPreviewView() {
         : Array.isArray(effectivePayload?.renaissance_list)
           ? effectivePayload.renaissance_list.filter((row) => Boolean(row?.symbol))
           : [],
+    [effectivePayload]
+  );
+  const riaPickRows = useMemo<KaiHomeRenaissanceItem[]>(
+    () =>
+      (Array.isArray(effectivePayload?.renaissance_list)
+        ? effectivePayload.renaissance_list
+        : Array.isArray(effectivePayload?.pick_rows)
+          ? effectivePayload.pick_rows
+          : []
+      ).filter((row) => Boolean(row?.symbol)),
     [effectivePayload]
   );
   const overviewMetrics = useMemo(
@@ -2156,6 +2168,16 @@ export function KaiMarketPreviewView() {
 
         {hasPayload ? (
           <>
+            <section className="mx-auto mt-9 w-full max-w-[1080px] px-[var(--one-gutter)]">
+              <RiaPicksList
+                rows={riaPickRows}
+                sources={pickSources}
+                activeSourceId={activePickSource}
+                onSourceChange={handlePickSourceChange}
+                controlMode="adaptive-surface"
+              />
+            </section>
+
             <section className="mx-auto mt-9 w-full max-w-[1080px] px-[var(--one-gutter)]">
               <OneMarketSectionHeader title="Most bought on One" icon={Blocks} tone="indigo" />
               <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">


### PR DESCRIPTION
## Summary
- Restore the Market RIA/Kai default-list surface by mounting the existing `RiaPicksList` with the existing `pickSources`, `activePickSource`, and `handlePickSourceChange` controller path.
- Make the shared Kai bottom nav/search/agent chrome light by default and dark only under `.dark`, so light mode no longer shows hardcoded dark chrome.
- Keep API calls, routes, links, and backend behavior unchanged.

## Verification
- `cd hushh-webapp && npm run typecheck`
- `cd hushh-webapp && npm run lint`
- `cd hushh-webapp && npm run verify:design-system`
- `cd hushh-webapp && npm run verify:cache`
- `cd hushh-webapp && npm run verify:docs`

## Deploy scope
- UAT scope after promotion to main: `frontend`