### PR TITLE
fix(kai): keep bottom chrome theme-safe

### DIFF
--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1298,13 +1298,13 @@ md-ripple.morphy-md-ripple {
 
 .dark .kai-bottom-nav-pill {
   color: rgb(255 255 255);
-  border-color: rgb(255 255 255 / 0.12) !important;
+  border-color: rgb(255 255 255 / 0.18) !important;
   background:
-    linear-gradient(180deg, rgb(47 47 50 / 0.9), rgb(17 17 19 / 0.86)) !important;
+    linear-gradient(180deg, rgb(72 72 74 / 0.72), rgb(44 44 46 / 0.68)) !important;
   box-shadow:
-    0 16px 38px -22px rgb(0 0 0 / 0.85),
-    inset 0 1px 0 rgb(255 255 255 / 0.16),
-    inset 0 -1px 0 rgb(0 0 0 / 0.32) !important;
+    0 16px 38px -22px rgb(0 0 0 / 0.62),
+    inset 0 1px 0 rgb(255 255 255 / 0.2),
+    inset 0 -1px 0 rgb(0 0 0 / 0.18) !important;
 }
 
 .kai-bottom-nav-pill [data-segment-indicator] {
@@ -1361,11 +1361,12 @@ md-ripple.morphy-md-ripple {
 
 .dark .kai-bottom-search-action {
   color: rgb(255 255 255) !important;
-  border-color: rgb(255 255 255 / 0.1) !important;
-  background: rgb(21 21 21 / 0.9) !important;
+  border-color: rgb(255 255 255 / 0.18) !important;
+  background:
+    linear-gradient(180deg, rgb(72 72 74 / 0.72), rgb(44 44 46 / 0.68)) !important;
   box-shadow:
-    0 14px 34px -18px rgb(0 0 0 / 0.8),
-    inset 0 1px 0 rgb(255 255 255 / 0.16) !important;
+    0 14px 34px -18px rgb(0 0 0 / 0.62),
+    inset 0 1px 0 rgb(255 255 255 / 0.2) !important;
 }
 
 .kai-bottom-agent-action {

--- a/hushh-webapp/components/kai/kai-search-bar.tsx
+++ b/hushh-webapp/components/kai/kai-search-bar.tsx
@@ -10,7 +10,7 @@ import {
   useState,
   type MouseEvent,
 } from "react";
-import { Bot, Sparkles, Mic, Search, X } from "lucide-react";
+import { Bot, MessageCircle, Mic, Search, X } from "lucide-react";
 
 import {
   KaiCommandPalette,
@@ -1752,7 +1752,7 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
                   onClick={() => agentPopover?.openAgent()}
                 >
                   <span className="kai-bottom-agent-action grid h-[40px] w-[40px] place-items-center rounded-[14px]">
-                    <Sparkles className="h-[18px] w-[18px]" strokeWidth={2.15} />
+                    <MessageCircle className="h-[18px] w-[18px]" strokeWidth={2.15} />
                   </span>
                 </button>
                 <ShellActionSurface

--- a/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
@@ -12,12 +12,12 @@ import {
   Cpu,
   LineChart,
   Loader2,
+  MessageCircle,
   Mic,
   Newspaper,
   Percent,
   Search,
   Sparkles,
-  Star,
   TrendingDown,
   TrendingUp,
   X,
@@ -852,7 +852,7 @@ function OneMarketKaiSheet({
       <div className="mx-auto mt-2.5 h-[5px] w-9 rounded-full bg-[color:var(--one-fg3)] opacity-35" />
       <header className="flex items-center gap-3 border-b border-[color:var(--one-line)] px-[18px] pb-3 pt-3">
         <span className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[color:var(--one-blue)] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.30)]">
-          <Star className="h-4 w-4 fill-current" />
+          <MessageCircle className="h-4 w-4" />
         </span>
         <span className="min-w-0 flex-1">
           <b className="block text-[17px] font-semibold text-[color:var(--one-fg)]">Kai</b>
@@ -2126,7 +2126,7 @@ export function KaiMarketPreviewView() {
             className={cn(oneMarketGlassClassName, "mt-[22px] flex w-full items-center gap-[11px] rounded-2xl px-4 py-3.5 text-left transition-transform active:scale-[0.99]")}
           >
             <span className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-[color:var(--one-blue)] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.30)]">
-              <Star className="h-4 w-4 fill-current" />
+              <MessageCircle className="h-4 w-4" />
             </span>
             <span className="min-w-0 flex-1 text-[13px] leading-snug text-[color:var(--one-fg)]">
               <b className="font-semibold">Kai:</b> {kaiStripText}


### PR DESCRIPTION
## Summary
- Revert unnecessary Kai agent/Kai-strip icon drift back to the prior MessageCircle symbol.
- Keep bottom nav/search light by default and make dark mode dark-gray glass instead of black material.
- No route, API, backend, link, search, agent, or source-selection behavior changes.

## Regression audit notes
- Confirmed Market now mounts existing `RiaPicksList` with existing `pickSources`, `activePickSource`, and `handlePickSourceChange`.
- Confirmed default-list fallback remains in `RiaPicksList`.
- Confirmed bottom nav route pushes remain unchanged for Market, Portfolio, Analysis, Connect, and Profile.
- Confirmed search still opens the existing command palette and agent still calls `agentPopover.openAgent()`.

## Verification
- `cd hushh-webapp && npm run typecheck`
- `cd hushh-webapp && npm run lint`
- `cd hushh-webapp && npm run verify:design-system`
- `cd hushh-webapp && npm run verify:cache`
- `cd hushh-webapp && npm run verify:docs`
- `cd hushh-webapp && npm run verify:routes` attempted locally, blocked by missing maintainer-only `REVIEWER_UID` / `REVIEWER_VAULT_PASSPHRASE`; UAT workflow carries that secret overlay.