### PR TITLE
fix(drawer): add type="button" to close button

### DIFF
--- a/hushh-webapp/components/ui/drawer.tsx
+++ b/hushh-webapp/components/ui/drawer.tsx
@@ -79,6 +79,7 @@ function DrawerContent({
 
       {showCloseButton && (
         <DrawerPrimitive.Close
+          type="button"
           data-slot="drawer-close"
           className="ring-offset-background focus:ring-ring absolute top-4 right-4 z-30 rounded-full border border-transparent bg-[color:var(--app-card-surface-compact)] p-2 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none"
         >


### PR DESCRIPTION
## Summary

Adds `type="button"` to the `DrawerPrimitive.Close` element used by `DrawerContent`.

## Problem

Native HTML `<button>` elements default to `type="submit"` when no explicit type is provided.

When a drawer is rendered inside a form, the close button can unintentionally trigger form submission instead of performing its intended close action.

## Change

**File**

* `hushh-webapp/components/ui/drawer.tsx`

**Update**

* Added `type="button"` to `DrawerPrimitive.Close`

## Why This Is Safe

* Single attribute addition
* No visual changes
* No layout changes
* No interaction changes outside form contexts
* No API changes
* No behavior changes except preventing accidental form submission

## Risk

Very low.

The change aligns the drawer close button with standard button semantics for non-submit actions and prevents unintended form submission when drawers are used within forms.
