### PR TITLE
fix(sheet): add type="button" to close button

### DIFF
--- a/hushh-webapp/components/ui/sheet.tsx
+++ b/hushh-webapp/components/ui/sheet.tsx
@@ -82,7 +82,7 @@ function SheetContent({
       >
         {children}
         {showCloseButton && (
-          <SheetPrimitive.Close className="ring-offset-background focus:ring-ring absolute top-4 right-4 rounded-full border border-transparent bg-[color:var(--app-card-surface-compact)] p-2 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+          <SheetPrimitive.Close type="button" className="ring-offset-background focus:ring-ring absolute top-4 right-4 rounded-full border border-transparent bg-[color:var(--app-card-surface-compact)] p-2 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
             <XIcon className="size-4" aria-hidden="true" />
             <span className="sr-only">Close</span>
           </SheetPrimitive.Close>


### PR DESCRIPTION
## Summary

Adds `type="button"` to the `SheetPrimitive.Close` element inside `SheetContent`.

## Problem

Native HTML `<button>` elements default to `type="submit"` when no explicit type is provided.

When `SheetContent` is rendered inside a form, the close button can unintentionally trigger form submission instead of performing its intended close action.

## Change

**File**

* `hushh-webapp/components/ui/sheet.tsx`

**Update**

* Added `type="button"` to `SheetPrimitive.Close`

## Why This Is Safe

* Single attribute addition
* No visual changes
* No layout changes
* No API changes
* No interaction changes outside form contexts
* Prevents unintended form submission when sheets are used within forms

## Parity

Matches the close-button contract applied to other non-submit actions and keeps Sheet behavior aligned with Drawer and the shared Button primitive.

## Risk

Very low.

The change only makes the close button explicit about its intended behavior and prevents accidental form submission.
