### PR TITLE
test(drawer): add showCloseButton visibility parity test

### DIFF
--- a/hushh-webapp/__tests__/ui/drawer.test.tsx
+++ b/hushh-webapp/__tests__/ui/drawer.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Drawer,
+  DrawerContent,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+
+describe("DrawerContent", () => {
+  it("renders the close button when showCloseButton is true", () => {
+    render(
+      <Drawer open>
+        <DrawerContent showCloseButton>
+          <DrawerTitle>Test drawer</DrawerTitle>
+        </DrawerContent>
+      </Drawer>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /close/i }),
+    ).toBeTruthy();
+  });
+
+  it("hides the close button when showCloseButton is false", () => {
+    render(
+      <Drawer open>
+        <DrawerContent showCloseButton={false}>
+          <DrawerTitle>Test drawer</DrawerTitle>
+        </DrawerContent>
+      </Drawer>,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /close/i }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds test coverage for the `showCloseButton` contract on `DrawerContent`.

## Problem

`DrawerContent` exposes a `showCloseButton` prop but currently has no direct test coverage verifying that the close button appears when enabled and is absent when disabled.

Equivalent overlay components already have coverage for this visibility contract.

## Change

Added a new test file:

* `hushh-webapp/__tests__/ui/drawer.test.tsx`

Covered scenarios:

1. Close button is rendered when `showCloseButton` is true.
2. Close button is not rendered when `showCloseButton` is false.

## Why This Is Safe

* Test-only change
* No production code modified
* No visual impact
* No runtime impact
* No API changes

## Pattern

Follows the existing overlay-component testing approach used elsewhere in the UI test suite and verifies the close button through its accessible name.

## Testing

* `npx vitest run __tests__/ui/drawer.test.tsx`
* `npm run typecheck`
* `npm run lint`

## Risk

Low.

The change adds coverage only and does not modify application behavior.
