### PR TITLE
test(sheet): add showCloseButton visibility parity test

### DIFF
--- a/hushh-webapp/__tests__/ui/sheet.test.tsx
+++ b/hushh-webapp/__tests__/ui/sheet.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+} from "@/components/ui/sheet";
+
+describe("SheetContent", () => {
+  it("renders the close button by default", () => {
+    render(
+      <Sheet open>
+        <SheetContent>
+          <SheetTitle>Test sheet</SheetTitle>
+        </SheetContent>
+      </Sheet>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /close/i }),
+    ).toBeTruthy();
+  });
+
+  it("hides the close button when showCloseButton is false", () => {
+    render(
+      <Sheet open>
+        <SheetContent showCloseButton={false}>
+          <SheetTitle>Test sheet</SheetTitle>
+        </SheetContent>
+      </Sheet>,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /close/i }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds test coverage for the `showCloseButton` visibility contract on `SheetContent`.

## Problem

`SheetContent` exposes a `showCloseButton` prop with a default value of `true`, but currently has no direct test coverage verifying that the close button is rendered by default and hidden when explicitly disabled.

Equivalent overlay primitives already have coverage for this behavior.

## Change

Added a new test file:

* `hushh-webapp/__tests__/ui/sheet.test.tsx`

Covered scenarios:

1. Close button is rendered by default.
2. Close button is not rendered when `showCloseButton={false}`.

## Why This Is Safe

* Test-only change
* No production code modified
* No visual impact
* No runtime impact
* No API changes

## Pattern

Mirrors the structure and assertions used by the existing Dialog close-button visibility tests.

## Testing

* `npx vitest run __tests__/ui/sheet.test.tsx`
* `npm run typecheck`
* `npm run lint`

## Risk

Low.

The change adds coverage only and does not modify application behavior.
