### PR TITLE
fix(sheet): hide decorative close icon from assistive technology

### DIFF
--- a/hushh-webapp/components/ui/sheet.tsx
+++ b/hushh-webapp/components/ui/sheet.tsx
@@ -83,7 +83,7 @@ function SheetContent({
         {children}
         {showCloseButton && (
           <SheetPrimitive.Close className="ring-offset-background focus:ring-ring absolute top-4 right-4 rounded-full border border-transparent bg-[color:var(--app-card-surface-compact)] p-2 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
-            <XIcon className="size-4" />
+            <XIcon aria-hidden="true" className="size-4" />
             <span className="sr-only">Close</span>
           </SheetPrimitive.Close>
         )}


### PR DESCRIPTION
## Summary

Adds `aria-hidden="true"` to the decorative close icon rendered inside `SheetContent`.

## Problem

The close button already exposes its accessible name through the existing:

```tsx
<span className="sr-only">Close</span>
```

The accompanying `XIcon` is purely decorative and does not provide additional information. Without `aria-hidden="true"`, the SVG remains part of the accessibility tree.

## Change

Added:

```tsx
aria-hidden="true"
```

to the `XIcon` rendered inside the Sheet close button.

## Why This Is Safe

* No visual changes
* No behavioral changes
* No API changes
* No layout changes
* Accessible name remains "Close"

## Accessibility Impact

The button's accessible name continues to come entirely from the existing screen-reader-only text.

Marking the icon as decorative ensures assistive technologies ignore presentation-only content and focuses announcements on the intended label.

## Files Changed

* `hushh-webapp/components/ui/sheet.tsx`

## Risk

Low.

Single-file, additive accessibility improvement with no runtime impact.
