### PR TITLE
promote: restore Kai vault-aware nav layering

### DIFF
--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -29,6 +29,7 @@ import { morphyToast as toast } from "@/lib/morphy-ux/morphy";
 import { usePersonaState } from "@/lib/persona/persona-context";
 import { activeKaiRouteTabFromPath } from "@/lib/navigation/kai-route-tabs";
 import { activeRiaRouteTabFromPath } from "@/lib/navigation/ria-route-tabs";
+import { useVault } from "@/lib/vault/vault-context";
 
 type InvestorNavKey = "dashboard" | "market" | "connect" | "analysis" | "profile";
 type RiaNavKey = "home" | "clients" | "connect" | "picks" | "profile";
@@ -38,6 +39,7 @@ export const Navbar = () => {
   const pathname = usePathname();
   const router = useRouter();
   const { isAuthenticated } = useAuth();
+  const { isVaultUnlocked } = useVault();
   const { activePersona } = usePersonaState();
   const pendingConsents = useConsentPendingSummaryCount();
   const pillRef = React.useRef<HTMLDivElement | null>(null);
@@ -248,7 +250,7 @@ export const Navbar = () => {
     <nav
       className={cn(
         "fixed inset-x-0 flex justify-center px-4 transform-gpu",
-        "z-[120]",
+        isVaultUnlocked ? "z-[120]" : "z-[505]",
         "pointer-events-none"
       )}
       style={


### PR DESCRIPTION
## Summary
- promote the Kai regression fix that restores vault-aware bottom nav layering on top of the existing UAT UI pass
- keeps Market RIA/default-list restoration and theme-safe bottom chrome in place

## Verification
- PR #2763 checks passed: Secret Scan, DCO, PR Base Policy, Governance, Base Freshness Gate, Web (Next.js), Integration, CI Status Gate
- Local verification on the source branch: typecheck, lint, verify:design-system, verify:cache, verify:docs
- Local verify:routes remains maintainer-secret gated and is covered by UAT semantic verification after deploy