### PR TITLE
test(observability): add coverage for request ID and timestamp utilities

### DIFF
--- a/hushh-webapp/__tests__/services/observability-request-id.test.ts
+++ b/hushh-webapp/__tests__/services/observability-request-id.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  FUTURE_TIMESTAMP_ERROR,
+  INVALID_TIMESTAMP_ERROR,
+  REQUEST_ID_HEADER,
+  REQUEST_TIMESTAMP_HEADER,
+  getOrCreateRequestId,
+  getOrCreateRequestTimestampMs,
+  sanitizeRequestId,
+  validateHeaderTimestampConstraints,
+} from "@/lib/observability/request-id";
+
+describe("sanitizeRequestId", () => {
+  it("accepts valid request ids", () => {
+    expect(sanitizeRequestId("abc12345")).toBe("abc12345");
+  });
+
+  it("trims valid request ids", () => {
+    expect(sanitizeRequestId("  abc12345  ")).toBe("abc12345");
+  });
+
+  it("rejects invalid request ids", () => {
+    expect(sanitizeRequestId("")).toBeNull();
+    expect(sanitizeRequestId("bad id")).toBeNull();
+    expect(sanitizeRequestId("%%%%")).toBeNull();
+  });
+});
+
+describe("getOrCreateRequestId", () => {
+  it("uses a valid header value", () => {
+    const result = getOrCreateRequestId(
+      new Headers({
+        [REQUEST_ID_HEADER]: "abc12345",
+      })
+    );
+
+    expect(result).toBe("abc12345");
+  });
+
+  it("creates a replacement for invalid header values", () => {
+    const result = getOrCreateRequestId(
+      new Headers({
+        [REQUEST_ID_HEADER]: "bad id",
+      })
+    );
+
+    expect(result).toBeTruthy();
+    expect(result).not.toBe("bad id");
+  });
+});
+
+describe("validateHeaderTimestampConstraints", () => {
+  it("accepts valid timestamps", () => {
+    expect(
+      validateHeaderTimestampConstraints(900, {
+        nowMs: 1000,
+      })
+    ).toEqual({
+      isSyncBlockAccepted: true,
+      errorLabel: null,
+    });
+  });
+
+  it("rejects invalid timestamps", () => {
+    expect(
+      validateHeaderTimestampConstraints(Number.NaN)
+    ).toEqual({
+      isSyncBlockAccepted: false,
+      errorLabel: INVALID_TIMESTAMP_ERROR,
+    });
+  });
+
+  it("rejects timestamps too far in the future", () => {
+    expect(
+      validateHeaderTimestampConstraints(62000, {
+        nowMs: 0,
+      })
+    ).toEqual({
+      isSyncBlockAccepted: false,
+      errorLabel: FUTURE_TIMESTAMP_ERROR,
+    });
+  });
+});
+
+describe("getOrCreateRequestTimestampMs", () => {
+  it("uses a valid timestamp header", () => {
+    const result = getOrCreateRequestTimestampMs(
+      new Headers({
+        [REQUEST_TIMESTAMP_HEADER]: "500",
+      }),
+      1000
+    );
+
+    expect(result).toBe(500);
+  });
+
+  it("falls back to nowMs for invalid timestamps", () => {
+    const result = getOrCreateRequestTimestampMs(
+      new Headers({
+        [REQUEST_TIMESTAMP_HEADER]: "abc",
+      }),
+      1000
+    );
+
+    expect(result).toBe(1000);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a dedicated test suite for the observability request ID utilities.

### What was added

* Tests for `sanitizeRequestId`

  * accepts valid request IDs
  * trims whitespace from valid IDs
  * rejects invalid values

* Tests for `getOrCreateRequestId`

  * reuses valid request IDs from headers
  * generates a replacement when header values are invalid

* Tests for `validateHeaderTimestampConstraints`

  * accepts valid timestamps
  * rejects invalid numeric values
  * rejects timestamps that exceed the allowed future clock drift

* Tests for `getOrCreateRequestTimestampMs`

  * returns valid header timestamps
  * falls back to `nowMs` when timestamps are invalid

### Validation

```bash
npx vitest run __tests__/services/observability-request-id.test.ts
```

Result: 10 tests passed.
