### PR TITLE
fix(accordion): add missing accordion-header data-slot

### DIFF
--- a/hushh-webapp/components/ui/accordion.tsx
+++ b/hushh-webapp/components/ui/accordion.tsx
@@ -31,7 +31,7 @@ function AccordionTrigger({
   ...props
 }: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
   return (
-    <AccordionPrimitive.Header className="flex">
+    <AccordionPrimitive.Header data-slot="accordion-header" className="flex">
       <AccordionPrimitive.Trigger
         data-slot="accordion-trigger"
         className={cn(


### PR DESCRIPTION
## Summary

Adds the missing `data-slot="accordion-header"` attribute to `AccordionPrimitive.Header`, completing the Accordion primitive's data-slot contract.

## Problem

The Accordion primitive already exposes data-slot attributes for:

* `accordion`
* `accordion-item`
* `accordion-trigger`
* `accordion-content`

`AccordionPrimitive.Header` was the only structural sub-element without a corresponding data-slot.

## Change

Added:

```tsx
data-slot="accordion-header"
```

to the existing `AccordionPrimitive.Header` element.

## Why

This brings the Accordion primitive in line with the established data-slot pattern used throughout shared UI primitives and allows consumers to target the header region consistently for styling, testing, and inspection purposes.

## Impact

* No visual changes
* No behavioral changes
* No accessibility changes
* No API changes
* Additive only

## Files Changed

* `hushh-webapp/components/ui/accordion.tsx`

## Risk

Low.

Single-file, single-attribute change with no runtime impact.
