### PR TITLE
fix(page-header): add id passthrough

### DIFF
--- a/hushh-webapp/components/app-ui/page-sections.tsx
+++ b/hushh-webapp/components/app-ui/page-sections.tsx
@@ -145,6 +145,7 @@ export function PageHeader({
   leading,
   accent = "default",
   className,
+  id,
   testId = "page-header",
 }: {
   eyebrow?: string;
@@ -157,11 +158,13 @@ export function PageHeader({
   leading?: ReactNode;
   accent?: SectionAccent;
   className?: string;
+  id?: string;
   testId?: string;
 }) {
   const styles = ACCENT_STYLES[accent];
   return (
     <header
+      id={id}
       className={cn("space-y-[var(--page-header-stack-gap)]", className)}
       data-slot="page-header"
       data-page-primary="true"


### PR DESCRIPTION
## Summary

Adds optional `id` prop passthrough support to `PageHeader`, allowing callers to assign an HTML id to the root header element.

## Problem

`SectionHeader` already supports an optional `id` prop and forwards it to its root element.

`PageHeader`, which is defined in the same file and serves a parallel role, does not currently expose the same capability.

This prevents consumers from using `PageHeader` as:

* an anchor target (`#section-id`)
* an `aria-labelledby` reference target
* an integration-test selector via `document.getElementById`

## Change

Adds:

* `id?: string` to the PageHeader props
* `id` to the component destructuring
* `id={id}` on the root `<header>` element

## Impact

* No visual changes
* No runtime changes
* No behavior changes
* Fully backward compatible
* Existing callers remain unaffected

## Parity

Matches the existing `SectionHeader` id passthrough pattern already present in the same file.

## Risk

Low.

Optional prop addition only. Existing consumers are unchanged.
