### PR TITLE
test(alert-dialog): add button rendering coverage

### DIFF
--- a/hushh-webapp/__tests__/ui/alert-dialog.test.tsx
+++ b/hushh-webapp/__tests__/ui/alert-dialog.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+describe("AlertDialogContent", () => {
+  it("renders the cancel button", () => {
+    render(
+      <AlertDialog open>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+            <AlertDialogDescription>This action cannot be undone.</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction>Continue</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>,
+    );
+
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeTruthy();
+  });
+
+  it("renders the action button", () => {
+    render(
+      <AlertDialog open>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+            <AlertDialogDescription>This action cannot be undone.</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction>Continue</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>,
+    );
+
+    expect(screen.getByRole("button", { name: /continue/i })).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new AlertDialog test file covering the presence of both action and cancel buttons when AlertDialog content is rendered.

## What Changed

Added:

* `hushh-webapp/__tests__/ui/alert-dialog.test.tsx`

The test verifies:

* `AlertDialogCancel` renders an accessible button named "Cancel"
* `AlertDialogAction` renders an accessible button named "Continue"

## Why

AlertDialog is a shared overlay primitive used throughout the application.

This test provides a lightweight regression guard around the expected action and dismissal controls exposed by AlertDialog content.

## Testing Approach

The test:

* renders AlertDialog in an open state
* queries buttons by accessible role and name
* verifies both action paths are present

The assertions use:

```tsx
screen.getByRole("button", { name: /cancel/i })
screen.getByRole("button", { name: /continue/i })
```

which also validates accessible naming behavior.

## Risk

None.

* New file only
* No source code changes
* No runtime behavior changes
* No visual changes

## Validation

* `npx vitest run __tests__/ui/alert-dialog.test.tsx`
* `npm run typecheck`
* `npm run lint`
