### PR TITLE
test(hooks): preserve debounced value when rerendered with same reference

### DIFF
--- a/hushh-webapp/__tests__/hooks/use-debounced-value.test.tsx
+++ b/hushh-webapp/__tests__/hooks/use-debounced-value.test.tsx
@@ -194,4 +194,21 @@ describe("useDebouncedValue", () => {
 
     expect(onDebounced).toHaveBeenLastCalledWith(next);
   });
+
+  it("preserves debounced value when rerendered with the same reference", () => {
+    const onDebounced = vi.fn();
+    const value = { count: 0 };
+    const { getByTestId, rerender } = render(
+      <Harness value={value} delayMs={200} onDebounced={onDebounced} />
+    );
+    onDebounced.mockClear();
+
+    rerender(<Harness value={value} delayMs={200} onDebounced={onDebounced} />);
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(onDebounced).not.toHaveBeenCalled();
+    expect(getByTestId("value").textContent).toBe(JSON.stringify(value));
+  });
 });


### PR DESCRIPTION
## Summary
- Add a useDebouncedValue test for rerendering with the same object reference.
- Verify no extra debounced commit fires when the value reference does not change.

## Why
The hook already covers new object references. This adds same-reference coverage so rerenders do not accidentally schedule extra updates.

## Impact
Test-only change. No runtime behavior changes.

## Validation
- `npx.cmd vitest run __tests__/hooks/use-debounced-value.test.tsx`
- Verified the commit includes a DCO `Signed-off-by` trailer.
