### PR TITLE
test(hooks): cover debounced boolean and same-reference rerenders

### DIFF
--- a/hushh-webapp/__tests__/hooks/use-debounced-value.test.tsx
+++ b/hushh-webapp/__tests__/hooks/use-debounced-value.test.tsx
@@ -234,4 +234,21 @@ describe("useDebouncedValue", () => {
 
     expect(onDebounced).toHaveBeenLastCalledWith(next);
   });
+
+  it("preserves debounced value when rerendered with the same reference", () => {
+    const onDebounced = vi.fn();
+    const value = { count: 0 };
+    const { getByTestId, rerender } = render(
+      <Harness value={value} delayMs={200} onDebounced={onDebounced} />
+    );
+    onDebounced.mockClear();
+
+    rerender(<Harness value={value} delayMs={200} onDebounced={onDebounced} />);
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(onDebounced).not.toHaveBeenCalled();
+    expect(getByTestId("value").textContent).toBe(JSON.stringify(value));
+  });
 });

--- a/hushh-webapp/__tests__/hooks/use-debounced-value.test.tsx
+++ b/hushh-webapp/__tests__/hooks/use-debounced-value.test.tsx
@@ -178,6 +178,46 @@ describe("useDebouncedValue", () => {
     expect(onDebounced).toHaveBeenLastCalledWith(10);
   });
 
+  it("debounces boolean value transitions", () => {
+    const onDebounced = vi.fn();
+    const { getByTestId, rerender } = render(
+      <Harness value={false} delayMs={100} onDebounced={onDebounced} />
+    );
+    onDebounced.mockClear();
+
+    rerender(<Harness value={true} delayMs={100} onDebounced={onDebounced} />);
+    act(() => {
+      vi.advanceTimersByTime(99);
+    });
+
+    expect(onDebounced).not.toHaveBeenCalled();
+    expect(getByTestId("value").textContent).toBe("false");
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(onDebounced).toHaveBeenCalledTimes(1);
+    expect(onDebounced).toHaveBeenLastCalledWith(true);
+    expect(getByTestId("value").textContent).toBe("true");
+    onDebounced.mockClear();
+
+    rerender(<Harness value={false} delayMs={100} onDebounced={onDebounced} />);
+    act(() => {
+      vi.advanceTimersByTime(99);
+    });
+
+    expect(onDebounced).not.toHaveBeenCalled();
+    expect(getByTestId("value").textContent).toBe("true");
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(onDebounced).toHaveBeenCalledTimes(1);
+    expect(onDebounced).toHaveBeenLastCalledWith(false);
+  });
+
   it("works for non-primitive values, comparing by reference", () => {
     const onDebounced = vi.fn();
     const initial = { count: 0 };


### PR DESCRIPTION
## Summary
- Add useDebouncedValue coverage for boolean transitions.
- Add same-reference rerender coverage so unchanged object references do not schedule extra debounced commits.

## Why
PR #2773 and PR #2774 both touched `hushh-webapp/__tests__/hooks/use-debounced-value.test.tsx`, including the same EOF hunk. To remove the shared-file blocker risk, this PR now consolidates both test cases into one branch and PR.

## Impact
Test-only change. No runtime behavior changes.

## Validation
- `npx.cmd vitest run __tests__/hooks/use-debounced-value.test.tsx`
- Verified both commits include DCO `Signed-off-by` trailers.

## PR Consolidation
- Supersedes #2773.
- Keeps one open PR for this hook test file: #2774.
