### PR TITLE
test(ui): preserve command input accessible search behavior

### DIFF
--- a/hushh-webapp/__tests__/ui/command.test.tsx
+++ b/hushh-webapp/__tests__/ui/command.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { CommandDialog } from "@/components/ui/command";
+import { Command, CommandDialog, CommandInput } from "@/components/ui/command";
 
 describe("CommandDialog", () => {
   it("renders the close button by default", () => {
@@ -26,5 +26,24 @@ describe("CommandDialog", () => {
     expect(
       screen.queryByRole("button", { name: /close/i }),
     ).toBeNull();
+  });
+});
+
+describe("CommandInput", () => {
+  it("preserves accessible search behavior", () => {
+    render(
+      <Command>
+        <CommandInput aria-label="Search commands" placeholder="Search commands" />
+      </Command>,
+    );
+
+    const search = screen.getByRole("combobox");
+
+    expect(search.getAttribute("aria-autocomplete")).toBe("list");
+    expect(search.getAttribute("aria-expanded")).toBe("true");
+    expect(search.getAttribute("placeholder")).toBe("Search commands");
+    expect(search.getAttribute("spellcheck")).toBe("false");
+    expect(search.getAttribute("autocorrect")).toBe("off");
+    expect(search.getAttribute("autocapitalize")).toBe("off");
   });
 });


### PR DESCRIPTION
## Summary
- Add CommandInput coverage for the command search combobox behavior.
- Assert the input keeps cmdk list-autocomplete semantics, placeholder text, and browser text-helper attributes.

## Why
CommandInput is shared by command surfaces. This test protects the accessibility-facing search contract while keeping the component implementation unchanged.

## Impact
Test-only change. No runtime behavior changes.

## Caller Proof
- `hushh-webapp/components/ui/command.tsx` exports `CommandInput` and the `Command` wrapper used by this test.
- `hushh-webapp/components/app-ui/command-fields.tsx` renders `CommandInput` inside `CommandDialog` for picker search.
- `hushh-webapp/components/kai/kai-command-palette.tsx` renders `CommandInput` inside `CommandDialog` for Kai command and ticker search.
- The test targets the shared `CommandInput` wrapper, so both callers keep the same cmdk combobox semantics and search-friendly input attributes.

## Validation
- `npx.cmd vitest run __tests__/ui/command.test.tsx`
- Verified the commit includes a DCO `Signed-off-by` trailer.
