### PR TITLE
test(app-env): cover unknown environment string fallback

### DIFF
--- a/hushh-webapp/__tests__/lib/app-env.test.ts
+++ b/hushh-webapp/__tests__/lib/app-env.test.ts
@@ -62,4 +62,13 @@ describe("resolveAppEnvironment", () => {
 
     expect(resolveAppEnvironment()).toBe("development");
   });
+
+  it("falls back when NEXT_PUBLIC_APP_ENV is an unknown environment string", async () => {
+    process.env.NEXT_PUBLIC_APP_ENV = "sandbox-preview";
+    process.env.NEXT_PUBLIC_OBSERVABILITY_ENV = "uat";
+
+    const { resolveAppEnvironment: resolveFreshAppEnvironment } = await import("@/lib/app-env");
+
+    expect(resolveFreshAppEnvironment()).toBe("uat");
+  });
 });


### PR DESCRIPTION
## Summary
- Append one `app-env` test for an unknown `NEXT_PUBLIC_APP_ENV` string.
- Verify the resolver falls back to a valid observability environment value.

## Scope Proof
- One file changed: `hushh-webapp/__tests__/lib/app-env.test.ts`.
- One new `it()` block appended to the existing `resolveAppEnvironment` describe.
- No existing describe blocks were restructured.
- No existing closing braces were moved or repositioned.
- The config/lib import is dynamic inside the new test.
- Git stat is additions-only: 9 insertions, 0 deletions.

## Impact
Test-only change. No runtime behavior changes.

## Validation
- `npx.cmd vitest run __tests__/lib/app-env.test.ts`
- Verified the commit includes a DCO `Signed-off-by` trailer.
