### PR TITLE
test(accordion): add data-slot contract coverage

### DIFF
--- a/hushh-webapp/__tests__/ui/accordion.test.tsx
+++ b/hushh-webapp/__tests__/ui/accordion.test.tsx
@@ -1,0 +1,101 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+
+// Radix Accordion uses @radix-ui/react-use-size → ResizeObserver to compute
+// content height for CSS variable --radix-accordion-content-height.
+// jsdom v25 does not implement ResizeObserver; this stub prevents ReferenceError
+// when AccordionContent is rendered in the open state.
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    globalThis.ResizeObserver = class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+});
+
+describe("Accordion", () => {
+  it("renders root with data-slot='accordion'", () => {
+    const { container } = render(
+      <Accordion type="single">
+        <AccordionItem value="item-1">
+          <AccordionTrigger>Trigger</AccordionTrigger>
+          <AccordionContent>Content</AccordionContent>
+        </AccordionItem>
+      </Accordion>,
+    );
+
+    expect(container.querySelector('[data-slot="accordion"]')).toBeTruthy();
+  });
+
+  it("renders AccordionItem with data-slot='accordion-item'", () => {
+    const { container } = render(
+      <Accordion type="single">
+        <AccordionItem value="item-1">
+          <AccordionTrigger>Trigger</AccordionTrigger>
+          <AccordionContent>Content</AccordionContent>
+        </AccordionItem>
+      </Accordion>,
+    );
+
+    expect(container.querySelector('[data-slot="accordion-item"]')).toBeTruthy();
+  });
+
+  it("renders AccordionTrigger with data-slot='accordion-trigger'", () => {
+    const { container } = render(
+      <Accordion type="single">
+        <AccordionItem value="item-1">
+          <AccordionTrigger>Trigger</AccordionTrigger>
+          <AccordionContent>Content</AccordionContent>
+        </AccordionItem>
+      </Accordion>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="accordion-trigger"]'),
+    ).toBeTruthy();
+  });
+
+  it("renders AccordionContent with data-slot='accordion-content' when item is open", () => {
+    const { container } = render(
+      <Accordion type="single" defaultValue="item-1">
+        <AccordionItem value="item-1">
+          <AccordionTrigger>Trigger</AccordionTrigger>
+          <AccordionContent>Content</AccordionContent>
+        </AccordionItem>
+      </Accordion>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="accordion-content"]'),
+    ).toBeTruthy();
+  });
+
+  it("renders multiple AccordionItems each with data-slot='accordion-item'", () => {
+    const { container } = render(
+      <Accordion type="multiple">
+        <AccordionItem value="item-1">
+          <AccordionTrigger>First</AccordionTrigger>
+          <AccordionContent>First content</AccordionContent>
+        </AccordionItem>
+        <AccordionItem value="item-2">
+          <AccordionTrigger>Second</AccordionTrigger>
+          <AccordionContent>Second content</AccordionContent>
+        </AccordionItem>
+      </Accordion>,
+    );
+
+    const items = container.querySelectorAll('[data-slot="accordion-item"]');
+    const triggers = container.querySelectorAll('[data-slot="accordion-trigger"]');
+    expect(items).toHaveLength(2);
+    expect(triggers).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract coverage for the Accordion primitive's data-slot attributes.

## What

New test file:

- `__tests__/ui/accordion.test.tsx`

Coverage:

- Root renders with `data-slot="accordion"`
- `AccordionItem` renders with `data-slot="accordion-item"`
- `AccordionTrigger` renders with `data-slot="accordion-trigger"`
- `AccordionContent` renders with `data-slot="accordion-content"`

## Why

`data-slot` attributes are a styling and testing contract used throughout the component library. A refactor that removes or renames one of these attributes would not produce a TypeScript error but could silently break downstream styling.

This test provides CI coverage for that contract.

## Scope

- New test file only
- No implementation changes
- No runtime behavior changes
- No API changes

## Checklist

- [x] New file only
- [x] No production code changes
- [x] Contract-focused coverage
- [x] Additive-only