### PR TITLE
test(runtime-settings): cover empty runtime backend url return

### DIFF
--- a/hushh-webapp/__tests__/lib/runtime-settings.test.ts
+++ b/hushh-webapp/__tests__/lib/runtime-settings.test.ts
@@ -17,4 +17,15 @@ describe("runtime settings", () => {
 
     expect(resolveRuntimeBackendUrl()).toBe("https://runtime.example.com");
   });
+
+  it("returns an empty string when runtime backend urls are empty", async () => {
+    process.env.BACKEND_URL = "";
+    process.env.NEXT_PUBLIC_BACKEND_URL = "   ";
+
+    const { resolveRuntimeBackendUrl: resolveFreshRuntimeBackendUrl } = await import(
+      "@/lib/runtime/settings"
+    );
+
+    expect(resolveFreshRuntimeBackendUrl()).toBe("");
+  });
 });


### PR DESCRIPTION
## Summary
- Append one `runtime-settings` test for empty runtime backend URL values.
- Verify `resolveRuntimeBackendUrl()` returns an empty string when both backend URL env inputs normalize empty.

## Scope Proof
- Existing file changed: `hushh-webapp/__tests__/lib/runtime-settings.test.ts`.
- One new `it()` block appended to the existing `runtime settings` describe.
- No existing describe blocks were restructured.
- No existing closing braces were moved or repositioned.
- The lib import is dynamic inside the new test.
- Git stat is additions-only: 11 insertions, 0 deletions.

## Note
The requested path was `__tests__/lib/runtime/runtime-settings.test.ts`, but the existing integration-train test file is `hushh-webapp/__tests__/lib/runtime-settings.test.ts`. I used the existing file so the change remains an appended test instead of creating a new file.

## Impact
Test-only change. No runtime behavior changes.

## Validation
- `npx.cmd vitest run __tests__/lib/runtime-settings.test.ts`
- Verified the commit includes a DCO `Signed-off-by` trailer.
