### PR TITLE
test(token-utils): cover token signature truncation at exact boundary

### DIFF
--- a/hushh-webapp/__tests__/lib/token-utils.test.ts
+++ b/hushh-webapp/__tests__/lib/token-utils.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+describe("token-utils", () => {
+  it("truncates token signature at exact 8-char boundary", async () => {
+    const { truncateSignature } = await import("@/lib/token-utils");
+    expect(truncateSignature("abcdefgh")).toBe("abcdefgh");
+    expect(truncateSignature("abcdefghi")).toBe("abcdefgh...");
+  });
+});

--- a/hushh-webapp/lib/token-utils.ts
+++ b/hushh-webapp/lib/token-utils.ts
@@ -1,0 +1,3 @@
+export function truncateSignature(signature: string): string {
+  return signature.length > 8 ? `${signature.slice(0, 8)}...` : signature;
+}


### PR DESCRIPTION
## Summary
- Add a small `truncateSignature` token utility.
- Add a new `token-utils` test covering the exact 8-character boundary and the first truncating 9-character case.

## Scope Proof
- New test file: `hushh-webapp/__tests__/lib/token-utils.test.ts`.
- New module file: `hushh-webapp/lib/token-utils.ts`.
- The requested `@/lib/token-utils` module did not exist on `integration/pr-train`, so the minimal export was added for the test target.
- The requested CommonJS `require("@/lib/token-utils")` does not resolve the `@` alias in this Vitest setup, so the test uses `await import("@/lib/token-utils")` for the same module and scenario.
- Git stat is additions-only: 12 insertions, 0 deletions.

## Impact
Adds a reusable token signature truncation helper. No existing runtime call sites are changed.

## Validation
- `npx.cmd vitest run __tests__/lib/token-utils.test.ts`
- Verified the commit includes a DCO `Signed-off-by` trailer.
