### PR TITLE
test(tabs): add data-slot and orientation contract coverage

### DIFF
--- a/hushh-webapp/__tests__/ui/tabs.test.tsx
+++ b/hushh-webapp/__tests__/ui/tabs.test.tsx
@@ -1,0 +1,91 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs";
+
+describe("Tabs", () => {
+  it("renders root with data-slot='tabs'", () => {
+    const { container } = render(
+      <Tabs defaultValue="tab-1">
+        <TabsList>
+          <TabsTrigger value="tab-1">Tab 1</TabsTrigger>
+        </TabsList>
+        <TabsContent value="tab-1">Content 1</TabsContent>
+      </Tabs>,
+    );
+
+    expect(container.querySelector('[data-slot="tabs"]')).toBeTruthy();
+  });
+
+  it("renders TabsList with data-slot='tabs-list'", () => {
+    const { container } = render(
+      <Tabs defaultValue="tab-1">
+        <TabsList>
+          <TabsTrigger value="tab-1">Tab 1</TabsTrigger>
+        </TabsList>
+        <TabsContent value="tab-1">Content 1</TabsContent>
+      </Tabs>,
+    );
+
+    expect(container.querySelector('[data-slot="tabs-list"]')).toBeTruthy();
+  });
+
+  it("renders TabsTrigger with data-slot='tabs-trigger'", () => {
+    const { container } = render(
+      <Tabs defaultValue="tab-1">
+        <TabsList>
+          <TabsTrigger value="tab-1">Tab 1</TabsTrigger>
+        </TabsList>
+        <TabsContent value="tab-1">Content 1</TabsContent>
+      </Tabs>,
+    );
+
+    expect(container.querySelector('[data-slot="tabs-trigger"]')).toBeTruthy();
+  });
+
+  it("renders TabsContent with data-slot='tabs-content'", () => {
+    const { container } = render(
+      <Tabs defaultValue="tab-1">
+        <TabsList>
+          <TabsTrigger value="tab-1">Tab 1</TabsTrigger>
+        </TabsList>
+        <TabsContent value="tab-1">Content 1</TabsContent>
+      </Tabs>,
+    );
+
+    expect(container.querySelector('[data-slot="tabs-content"]')).toBeTruthy();
+  });
+
+  it("passes orientation through as data-orientation on the root", () => {
+    const { container } = render(
+      <Tabs defaultValue="tab-1" orientation="vertical">
+        <TabsList>
+          <TabsTrigger value="tab-1">Tab 1</TabsTrigger>
+        </TabsList>
+        <TabsContent value="tab-1">Content 1</TabsContent>
+      </Tabs>,
+    );
+
+    const root = container.querySelector('[data-slot="tabs"]');
+    expect(root?.getAttribute("data-orientation")).toBe("vertical");
+  });
+
+  it("propagates variant as data-variant on TabsList", () => {
+    const { container } = render(
+      <Tabs defaultValue="tab-1">
+        <TabsList variant="line">
+          <TabsTrigger value="tab-1">Tab 1</TabsTrigger>
+        </TabsList>
+        <TabsContent value="tab-1">Content 1</TabsContent>
+      </Tabs>,
+    );
+
+    const list = container.querySelector('[data-slot="tabs-list"]');
+    expect(list?.getAttribute("data-variant")).toBe("line");
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract coverage for the Tabs primitive.

## What

New test file:

`__tests__/ui/tabs.test.tsx`

Coverage:

* Root renders with `data-slot="tabs"`
* `TabsList` renders with `data-slot="tabs-list"`
* `TabsTrigger` renders with `data-slot="tabs-trigger"`
* `TabsContent` renders with `data-slot="tabs-content"`
* `orientation="vertical"` is reflected through the component contract

## Why

Tabs relies on data attributes as styling and behavior contracts. These attributes are not protected by TypeScript and can be removed accidentally during refactors.

This test ensures those contracts remain visible in CI.

## Scope

* New test file only
* No implementation changes
* No runtime behavior changes
* No API changes

## Validation

* `npx vitest run __tests__/ui/tabs.test.tsx`
* `npm run typecheck`
* `npm run lint`

## Checklist

* [x] New file only
* [x] No production code changes
* [x] Contract-focused coverage
* [x] Additive-only
