### PR TITLE
test(progress): add data-slot and value clamping contract coverage

### DIFF
--- a/hushh-webapp/__tests__/ui/progress.test.tsx
+++ b/hushh-webapp/__tests__/ui/progress.test.tsx
@@ -1,0 +1,48 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Progress } from "@/components/ui/progress";
+
+describe("Progress", () => {
+  it("renders root and indicator data-slot contracts", () => {
+    const { container } = render(<Progress value={50} />);
+
+    expect(
+      container.querySelector('[data-slot="progress"]'),
+    ).toBeTruthy();
+
+    expect(
+      container.querySelector('[data-slot="progress-indicator"]'),
+    ).toBeTruthy();
+  });
+
+  it("uses provided value when within range", () => {
+    const { container } = render(<Progress value={50} />);
+
+    const indicator = container.querySelector(
+      '[data-slot="progress-indicator"]',
+    ) as HTMLElement;
+
+    expect(indicator.style.width).toBe("50%");
+  });
+
+  it("clamps values above 100", () => {
+    const { container } = render(<Progress value={150} />);
+
+    const indicator = container.querySelector(
+      '[data-slot="progress-indicator"]',
+    ) as HTMLElement;
+
+    expect(indicator.style.width).toBe("100%");
+  });
+
+  it("clamps values below 0", () => {
+    const { container } = render(<Progress value={-50} />);
+
+    const indicator = container.querySelector(
+      '[data-slot="progress-indicator"]',
+    ) as HTMLElement;
+
+    expect(indicator.style.width).toBe("0%");
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract coverage for the Progress primitive.

## What

New file:

`hushh-webapp/__tests__/ui/progress.test.tsx`

Coverage includes:

* Root renders with `data-slot="progress"`
* Indicator renders with `data-slot="progress-indicator"`
* In-range values are reflected in indicator width
* Values above 100 are clamped to 100%
* Values below 0 are clamped to 0%

## Why

The Progress component exposes styling and behavior contracts through its data-slot attributes and value-clamping logic. These contracts are relied upon by consuming surfaces and can regress silently during refactors.

This test provides regression protection for those contracts without modifying implementation code.

## Notes

* New test file only
* No production code changes
* No behavior changes
* No dependency changes
* No custom test helpers introduced

## Checklist

* [x] Additive-only change
* [x] Single new test file
* [x] No implementation changes
* [x] Local test passes
