### PR TITLE
test(card): add data-slot contract coverage

### DIFF
--- a/hushh-webapp/__tests__/ui/card.test.tsx
+++ b/hushh-webapp/__tests__/ui/card.test.tsx
@@ -1,0 +1,56 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+describe("Card", () => {
+  it("renders all data-slot contracts", () => {
+    const { container } = render(
+      <Card>
+        <CardHeader>
+          <CardTitle>Title</CardTitle>
+          <CardDescription>Description</CardDescription>
+          <CardAction>Action</CardAction>
+        </CardHeader>
+
+        <CardContent>Content</CardContent>
+
+        <CardFooter>Footer</CardFooter>
+      </Card>,
+    );
+
+    expect(container.querySelector('[data-slot="card"]')).toBeTruthy();
+
+    expect(
+      container.querySelector('[data-slot="card-header"]'),
+    ).toBeTruthy();
+
+    expect(
+      container.querySelector('[data-slot="card-title"]'),
+    ).toBeTruthy();
+
+    expect(
+      container.querySelector('[data-slot="card-description"]'),
+    ).toBeTruthy();
+
+    expect(
+      container.querySelector('[data-slot="card-action"]'),
+    ).toBeTruthy();
+
+    expect(
+      container.querySelector('[data-slot="card-content"]'),
+    ).toBeTruthy();
+
+    expect(
+      container.querySelector('[data-slot="card-footer"]'),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract coverage for the Card primitive.

## What

New file:

`hushh-webapp/__tests__/ui/card.test.tsx`

Coverage includes:

* `card`
* `card-header`
* `card-title`
* `card-description`
* `card-action`
* `card-content`
* `card-footer`

All exported Card sub-components are verified through their public `data-slot` contracts.

## Why

Card is a compound UI primitive whose styling depends on `data-slot` attributes. These attributes are consumed by compound Tailwind selectors and can regress silently during refactors.

This test provides regression protection for those contracts without modifying implementation code.

## Notes

* New test file only
* No production code changes
* No dependency changes
* No behavior changes
* No custom test helpers introduced

## Checklist

* [x] Additive-only change
* [x] Single new test file
* [x] No implementation changes
* [x] Local test passes
