### PR TITLE
[codex] fix agent voice and UX regressions

### DIFF
--- a/consent-protocol/api/routes/kai/agent_voice.py
+++ b/consent-protocol/api/routes/kai/agent_voice.py
@@ -13,13 +13,17 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, Response, Upl
 from pydantic import BaseModel, Field
 
 from api.middleware import require_vault_owner_token
-from hushh_mcp.services.agent_voice_service import get_agent_voice_service
+from hushh_mcp.services.agent_voice_service import (
+    AGENT_TTS_ALLOWED_VOICES,
+    get_agent_voice_service,
+)
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["Agent Voice"])
 
 MAX_AGENT_VOICE_AUDIO_BYTES = 8 * 1024 * 1024
+AGENT_VOICE_AUDIO_READ_CHUNK_BYTES = 1024 * 1024
 _DISABLED_FLAG_VALUES = {"0", "false", "off", "disabled", "no"}
 
 
@@ -57,6 +61,36 @@ def _ensure_agent_gemini_voice_enabled() -> None:
     )
 
 
+def _normalize_agent_tts_voice(voice: str | None) -> str | None:
+    raw = str(voice or "").strip()
+    if not raw:
+        return None
+    for allowed_voice in AGENT_TTS_ALLOWED_VOICES:
+        if raw.lower() == allowed_voice.lower():
+            return allowed_voice
+    raise HTTPException(
+        status_code=422,
+        detail="Unsupported Agent voice.",
+    )
+
+
+async def _read_agent_voice_audio(audio: UploadFile) -> bytes:
+    chunks: list[bytes] = []
+    total_bytes = 0
+    while True:
+        chunk = await audio.read(AGENT_VOICE_AUDIO_READ_CHUNK_BYTES)
+        if not chunk:
+            break
+        total_bytes += len(chunk)
+        if total_bytes > MAX_AGENT_VOICE_AUDIO_BYTES:
+            raise HTTPException(
+                status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+                detail="Agent voice audio is too large.",
+            )
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
 @router.post("/agent/voice/stt", response_model=AgentVoiceTranscriptionResponse)
 async def transcribe_agent_voice(
     user_id: str = Form(..., max_length=128),
@@ -73,12 +107,7 @@ async def transcribe_agent_voice(
             detail="Agent voice STT requires an audio upload.",
         )
 
-    audio_bytes = await audio.read()
-    if len(audio_bytes) > MAX_AGENT_VOICE_AUDIO_BYTES:
-        raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-            detail="Agent voice audio is too large.",
-        )
+    audio_bytes = await _read_agent_voice_audio(audio)
 
     try:
         transcription = await get_agent_voice_service().transcribe_audio(
@@ -120,10 +149,12 @@ async def synthesize_agent_voice(
             detail="Text is required for Agent voice TTS.",
         )
 
+    selected_voice = _normalize_agent_tts_voice(body.voice)
+
     try:
         synthesis = await get_agent_voice_service().synthesize_speech(
             text=clean_text,
-            voice=body.voice,
+            voice=selected_voice,
         )
     except ValueError as error:
         logger.warning("agent_voice.tts_invalid user_id=%s: %s", body.user_id, error)

--- a/consent-protocol/docs/reference/env-vars.md
+++ b/consent-protocol/docs/reference/env-vars.md
@@ -74,6 +74,13 @@ What is in `.env` / GCP Secret Manager must match exactly what the code reads --
 | `HUSHH_UAT_PHONE_TEST_CHALLENGE_SECRET` | `api/routes/account.py` | Optional | Optional HMAC key for stateless UAT phone challenge IDs; falls back to `APP_SIGNING_KEY`. |
 | `ROOT_PATH` | `server.py` | No | FastAPI root path for reverse proxy. |
 | `AGENT_GEMINI_MODEL` | `hushh_mcp/services/agent_chat_service.py` | No | Optional Agent text chat model override. Defaults to stable `gemini-2.5-pro`. |
+| `AGENT_GEMINI_VOICE_ENABLED` | `api/routes/kai/agent_voice.py` | No | Agent chained voice kill switch. Defaults enabled; set a disabled flag value to turn off Gemini STT/TTS adapters. |
+| `AGENT_GEMINI_STT_MODEL` | `hushh_mcp/services/agent_voice_service.py` | No | Optional Agent voice STT model override. Defaults to `gemini-2.5-flash`. |
+| `AGENT_GEMINI_STT_TIMEOUT_SECONDS` | `hushh_mcp/services/agent_voice_service.py` | No | Optional Agent voice STT Gemini timeout. Defaults to `30`. |
+| `AGENT_GEMINI_TTS_MODEL` | `hushh_mcp/services/agent_voice_service.py` | No | Optional Agent voice TTS model override. Defaults to `gemini-2.5-flash-preview-tts`. |
+| `AGENT_GEMINI_TTS_VOICE` | `hushh_mcp/services/agent_voice_service.py` | No | Optional backend default Agent TTS voice. Defaults to `Sulafat`. |
+| `AGENT_GEMINI_TTS_TIMEOUT_SECONDS` | `hushh_mcp/services/agent_voice_service.py` | No | Optional Agent voice TTS Gemini timeout per attempt. Defaults to `45`. |
+| `AGENT_GEMINI_TTS_MAX_ATTEMPTS` | `hushh_mcp/services/agent_voice_service.py` | No | Optional Agent voice TTS retry cap. Defaults to `2`; bounded from `1` to `4`. |
 | `GOOGLE_GENAI_USE_VERTEXAI` | Cloud Run env | No | Set `True` for Vertex AI in production. |
 | `PLAID_ENV` / `PLAID_ENVIRONMENT` | `hushh_mcp/services/plaid_portfolio_service.py` | No | Plaid environment. Defaults to `sandbox`. |
 | `PLAID_CLIENT_ID` | `hushh_mcp/services/plaid_portfolio_service.py` | If Plaid enabled | Plaid client ID. |
@@ -304,6 +311,13 @@ Local runtime bootstrap:
 | `DB_NAME` | No | Cloud Run env var |
 | `ENVIRONMENT` | No | Cloud Run env var |
 | `AGENT_GEMINI_MODEL` | No | Cloud Run env var |
+| `AGENT_GEMINI_VOICE_ENABLED` | No | Cloud Run env var |
+| `AGENT_GEMINI_STT_MODEL` | No | Cloud Run env var |
+| `AGENT_GEMINI_STT_TIMEOUT_SECONDS` | No | Cloud Run env var |
+| `AGENT_GEMINI_TTS_MODEL` | No | Cloud Run env var |
+| `AGENT_GEMINI_TTS_VOICE` | No | Cloud Run env var |
+| `AGENT_GEMINI_TTS_TIMEOUT_SECONDS` | No | Cloud Run env var |
+| `AGENT_GEMINI_TTS_MAX_ATTEMPTS` | No | Cloud Run env var |
 | `GOOGLE_GENAI_USE_VERTEXAI` | No | Cloud Run env var |
 
 ---

--- a/consent-protocol/hushh_mcp/services/agent_voice_service.py
+++ b/consent-protocol/hushh_mcp/services/agent_voice_service.py
@@ -26,10 +26,15 @@ AGENT_STT_MODEL_ENV = "AGENT_GEMINI_STT_MODEL"
 AGENT_TTS_MODEL_ENV = "AGENT_GEMINI_TTS_MODEL"
 AGENT_TTS_VOICE_ENV = "AGENT_GEMINI_TTS_VOICE"
 AGENT_TTS_MAX_ATTEMPTS_ENV = "AGENT_GEMINI_TTS_MAX_ATTEMPTS"
+AGENT_STT_TIMEOUT_SECONDS_ENV = "AGENT_GEMINI_STT_TIMEOUT_SECONDS"
+AGENT_TTS_TIMEOUT_SECONDS_ENV = "AGENT_GEMINI_TTS_TIMEOUT_SECONDS"
 DEFAULT_AGENT_STT_MODEL = "gemini-2.5-flash"
 DEFAULT_AGENT_TTS_MODEL = "gemini-2.5-flash-preview-tts"
 DEFAULT_AGENT_TTS_VOICE = "Sulafat"
 DEFAULT_AGENT_TTS_MAX_ATTEMPTS = 2
+DEFAULT_AGENT_STT_TIMEOUT_SECONDS = 30.0
+DEFAULT_AGENT_TTS_TIMEOUT_SECONDS = 45.0
+AGENT_TTS_ALLOWED_VOICES = frozenset({"Charon", "Sulafat", "Kore", "Puck"})
 MALFORMED_TRANSCRIPTION_REASON = "The transcription response was not structured."
 
 _TRANSCRIPTION_SCHEMA = {
@@ -81,14 +86,27 @@ class AgentVoiceService:
         self.model = configured_model or DEFAULT_AGENT_STT_MODEL
         configured_tts_model = tts_model or os.getenv(AGENT_TTS_MODEL_ENV, "").strip()
         self.tts_model = configured_tts_model or DEFAULT_AGENT_TTS_MODEL
-        self.tts_default_voice = (
-            os.getenv(AGENT_TTS_VOICE_ENV, "").strip() or DEFAULT_AGENT_TTS_VOICE
+        self.tts_default_voice = _normalize_tts_voice(
+            os.getenv(AGENT_TTS_VOICE_ENV, "").strip() or DEFAULT_AGENT_TTS_VOICE,
+            fallback=DEFAULT_AGENT_TTS_VOICE,
         )
         self.tts_max_attempts = _read_int_env(
             AGENT_TTS_MAX_ATTEMPTS_ENV,
             default=DEFAULT_AGENT_TTS_MAX_ATTEMPTS,
             minimum=1,
             maximum=4,
+        )
+        self.stt_timeout_seconds = _read_float_env(
+            AGENT_STT_TIMEOUT_SECONDS_ENV,
+            default=DEFAULT_AGENT_STT_TIMEOUT_SECONDS,
+            minimum=1.0,
+            maximum=120.0,
+        )
+        self.tts_timeout_seconds = _read_float_env(
+            AGENT_TTS_TIMEOUT_SECONDS_ENV,
+            default=DEFAULT_AGENT_TTS_TIMEOUT_SECONDS,
+            minimum=1.0,
+            maximum=120.0,
         )
         self.client: genai.Client | None = None
         self._client_error: str | None = None
@@ -143,6 +161,9 @@ class AgentVoiceService:
         mime_type: str,
         prompt: str,
     ) -> str:
+        client = self.client
+        if client is None:
+            raise RuntimeError(self._client_error or "Gemini Agent voice client is unavailable.")
         config = genai_types.GenerateContentConfig(
             temperature=0.0,
             max_output_tokens=128,
@@ -150,17 +171,23 @@ class AgentVoiceService:
             response_schema=_TRANSCRIPTION_SCHEMA,
             automatic_function_calling=genai_types.AutomaticFunctionCallingConfig(disable=True),
         )
-        response = await self.client.aio.models.generate_content(
-            model=self.model,
-            contents=genai_types.Content(
-                role="user",
-                parts=[
-                    genai_types.Part.from_text(text=prompt),
-                    genai_types.Part.from_bytes(data=audio_bytes, mime_type=mime_type),
-                ],
-            ),
-            config=config,
-        )
+        try:
+            response = await asyncio.wait_for(
+                client.aio.models.generate_content(
+                    model=self.model,
+                    contents=genai_types.Content(
+                        role="user",
+                        parts=[
+                            genai_types.Part.from_text(text=prompt),
+                            genai_types.Part.from_bytes(data=audio_bytes, mime_type=mime_type),
+                        ],
+                    ),
+                    config=config,
+                ),
+                timeout=self.stt_timeout_seconds,
+            )
+        except TimeoutError as error:
+            raise RuntimeError("Gemini Agent voice transcription timed out.") from error
         return response.text or ""
 
     async def synthesize_speech(
@@ -169,14 +196,15 @@ class AgentVoiceService:
         text: str,
         voice: str | None = None,
     ) -> AgentVoiceSynthesis:
-        if not self.client:
+        client = self.client
+        if not client:
             raise RuntimeError(self._client_error or "Gemini Agent voice client is unavailable.")
 
         clean_text = " ".join(str(text or "").strip().split())
         if not clean_text:
             raise ValueError("Text is required for Agent voice TTS.")
 
-        selected_voice = str(voice or "").strip() or self.tts_default_voice
+        selected_voice = _normalize_tts_voice(voice or self.tts_default_voice)
         config = genai_types.GenerateContentConfig(
             temperature=0.7,
             response_modalities=["AUDIO"],
@@ -194,22 +222,25 @@ class AgentVoiceService:
         last_error: Exception | None = None
         for attempt in range(1, self.tts_max_attempts + 1):
             try:
-                response = await self.client.aio.models.generate_content(
-                    model=self.tts_model,
-                    contents=genai_types.Content(
-                        role="user",
-                        parts=[
-                            genai_types.Part.from_text(
-                                text=(
-                                    "Synthesize speech for the Kai Agent.\n"
-                                    "Read only the text under TRANSCRIPT.\n\n"
-                                    "VOICE DIRECTION: warm, clear, concise, helpful.\n"
-                                    f"TRANSCRIPT:\n{clean_text}"
+                response = await asyncio.wait_for(
+                    client.aio.models.generate_content(
+                        model=self.tts_model,
+                        contents=genai_types.Content(
+                            role="user",
+                            parts=[
+                                genai_types.Part.from_text(
+                                    text=(
+                                        "Synthesize speech for the Kai Agent.\n"
+                                        "Read only the text under TRANSCRIPT.\n\n"
+                                        "VOICE DIRECTION: warm, clear, concise, helpful.\n"
+                                        f"TRANSCRIPT:\n{clean_text}"
+                                    )
                                 )
-                            )
-                        ],
+                            ],
+                        ),
+                        config=config,
                     ),
-                    config=config,
+                    timeout=self.tts_timeout_seconds,
                 )
                 audio, mime_type = _extract_audio_part(response)
                 if audio:
@@ -274,6 +305,16 @@ def _is_clearly_uncertain_transcript(transcript: str) -> bool:
     return alphanumeric_count < 2
 
 
+def _normalize_tts_voice(value: str | None, *, fallback: str | None = None) -> str:
+    raw = str(value or "").strip()
+    for allowed_voice in AGENT_TTS_ALLOWED_VOICES:
+        if raw.lower() == allowed_voice.lower():
+            return allowed_voice
+    if fallback is not None:
+        return fallback
+    raise ValueError("Unsupported Agent voice.")
+
+
 def _extract_audio_part(response: genai_types.GenerateContentResponse) -> tuple[bytes, str]:
     for candidate in response.candidates or []:
         content = candidate.content
@@ -309,6 +350,17 @@ def _read_int_env(name: str, *, default: int, minimum: int, maximum: int) -> int
         return default
     try:
         value = int(raw)
+    except ValueError:
+        return default
+    return max(minimum, min(maximum, value))
+
+
+def _read_float_env(name: str, *, default: float, minimum: float, maximum: float) -> float:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
     except ValueError:
         return default
     return max(minimum, min(maximum, value))

--- a/consent-protocol/tests/services/test_agent_voice_service.py
+++ b/consent-protocol/tests/services/test_agent_voice_service.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
+import asyncio
+from types import SimpleNamespace
+
 import pytest
 
-from hushh_mcp.services.agent_voice_service import AgentVoiceService, _wav_from_pcm
+from hushh_mcp.services.agent_voice_service import (
+    AgentVoiceService,
+    _normalize_tts_voice,
+    _wav_from_pcm,
+)
 
 
 def test_agent_voice_service_parses_structured_transcription(monkeypatch):
@@ -78,3 +85,49 @@ def test_agent_voice_service_wraps_pcm_as_wav():
     assert wav.startswith(b"RIFF")
     assert b"WAVEfmt " in wav[:24]
     assert wav.endswith(b"\x00\x00\x01\x00")
+
+
+def test_agent_voice_service_normalizes_allowed_tts_voices():
+    assert _normalize_tts_voice("kore") == "Kore"
+    assert _normalize_tts_voice("Sulafat") == "Sulafat"
+    with pytest.raises(ValueError):
+        _normalize_tts_voice("not-a-voice")
+
+
+@pytest.mark.asyncio
+async def test_agent_voice_service_times_out_transcription(monkeypatch):
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    service = AgentVoiceService(model="gemini-2.5-flash")
+    service.stt_timeout_seconds = 0.01
+
+    class SlowModels:
+        async def generate_content(self, **kwargs):
+            await asyncio.sleep(0.05)
+            return SimpleNamespace(text='{"transcript":"late","uncertain":false}')
+
+    service.client = SimpleNamespace(aio=SimpleNamespace(models=SlowModels()))
+
+    with pytest.raises(RuntimeError):
+        await service._generate_transcription_text(
+            audio_bytes=b"audio",
+            mime_type="audio/wav",
+            prompt="transcribe",
+        )
+
+
+@pytest.mark.asyncio
+async def test_agent_voice_service_times_out_tts(monkeypatch):
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    service = AgentVoiceService(model="gemini-2.5-flash")
+    service.tts_timeout_seconds = 0.01
+    service.tts_max_attempts = 1
+
+    class SlowModels:
+        async def generate_content(self, **kwargs):
+            await asyncio.sleep(0.05)
+            return SimpleNamespace(candidates=[])
+
+    service.client = SimpleNamespace(aio=SimpleNamespace(models=SlowModels()))
+
+    with pytest.raises(RuntimeError):
+        await service.synthesize_speech(text="hello", voice="Kore")

--- a/consent-protocol/tests/test_agent_voice_routes.py
+++ b/consent-protocol/tests/test_agent_voice_routes.py
@@ -125,6 +125,27 @@ def test_agent_voice_stt_rejects_non_audio_upload(monkeypatch) -> None:
     assert response.status_code == 415
 
 
+def test_agent_voice_stt_rejects_oversized_audio(monkeypatch) -> None:
+    service = _FakeAgentVoiceService()
+    monkeypatch.setattr(agent_voice, "get_agent_voice_service", lambda: service)
+    client = _client()
+
+    response = client.post(
+        "/agent/voice/stt",
+        data={"user_id": "user-1"},
+        files={
+            "audio": (
+                "utterance.webm",
+                b"x" * (agent_voice.MAX_AGENT_VOICE_AUDIO_BYTES + 1),
+                "audio/webm",
+            )
+        },
+    )
+
+    assert response.status_code == 413
+    assert service.last_audio_bytes is None
+
+
 def test_agent_voice_tts_returns_transient_audio(monkeypatch) -> None:
     service = _FakeAgentVoiceService()
     monkeypatch.setattr(agent_voice, "get_agent_voice_service", lambda: service)
@@ -142,6 +163,34 @@ def test_agent_voice_tts_returns_transient_audio(monkeypatch) -> None:
     assert response.headers["x-agent-tts-source"] == "backend_gemini_audio"
     assert service.last_tts_text == "Starting Nvidia analysis."
     assert service.last_tts_voice == "Kore"
+
+
+def test_agent_voice_tts_normalizes_voice_case(monkeypatch) -> None:
+    service = _FakeAgentVoiceService()
+    monkeypatch.setattr(agent_voice, "get_agent_voice_service", lambda: service)
+    client = _client()
+
+    response = client.post(
+        "/agent/voice/tts",
+        json={"user_id": "user-1", "text": "Starting Nvidia analysis.", "voice": "kore"},
+    )
+
+    assert response.status_code == 200
+    assert service.last_tts_voice == "Kore"
+
+
+def test_agent_voice_tts_rejects_unsupported_voice(monkeypatch) -> None:
+    service = _FakeAgentVoiceService()
+    monkeypatch.setattr(agent_voice, "get_agent_voice_service", lambda: service)
+    client = _client()
+
+    response = client.post(
+        "/agent/voice/tts",
+        json={"user_id": "user-1", "text": "Hello.", "voice": "not-a-voice"},
+    )
+
+    assert response.status_code == 422
+    assert service.last_tts_text is None
 
 
 def test_agent_voice_tts_rejects_empty_text(monkeypatch) -> None:

--- a/docs/reference/kai/agent-chained-voice-architecture.md
+++ b/docs/reference/kai/agent-chained-voice-architecture.md
@@ -99,6 +99,18 @@ Kill switch:
 
 Both flags default to enabled when unset.
 
+Timeouts and retries:
+
+- Browser Agent STT uses a short abortable client timeout for responsiveness.
+- The Next.js Kai proxy also bounds Agent voice requests with
+  `HUSHH_KAI_AGENT_VOICE_STT_TIMEOUT_MS` and
+  `HUSHH_KAI_AGENT_VOICE_TTS_TIMEOUT_MS`, and forwards client aborts upstream so
+  cancelled turns do not keep backend Gemini work running.
+- Backend Gemini STT/TTS calls are bounded by
+  `AGENT_GEMINI_STT_TIMEOUT_SECONDS` and
+  `AGENT_GEMINI_TTS_TIMEOUT_SECONDS`.
+- TTS retries are capped by `AGENT_GEMINI_TTS_MAX_ATTEMPTS`.
+
 ## OpenAI Realtime Runtime
 
 The existing OpenAI realtime voice path remains untouched. Its routes, session

--- a/docs/reference/operations/env-and-secrets.md
+++ b/docs/reference/operations/env-and-secrets.md
@@ -192,8 +192,14 @@ Used by:
 | `AGENT_GEMINI_MODEL` | `hushh_mcp/services/agent_chat_service.py` | No | Optional Agent text chat model override. Defaults to stable `gemini-2.5-pro`. |
 | `AGENT_GEMINI_VOICE_ENABLED` | `api/routes/kai/agent_voice.py` | No | Agent chained voice kill switch. Defaults enabled; set `false`, `0`, `off`, `disabled`, or `no` to disable Gemini STT/TTS adapters. |
 | `AGENT_GEMINI_STT_MODEL` | `hushh_mcp/services/agent_voice_service.py` | No | Optional Agent voice STT model override. Defaults to `gemini-2.5-flash`. |
+| `AGENT_GEMINI_STT_TIMEOUT_SECONDS` | `hushh_mcp/services/agent_voice_service.py` | No | Optional server-side Agent voice STT Gemini timeout. Defaults to `30`. |
 | `AGENT_GEMINI_TTS_MODEL` | `hushh_mcp/services/agent_voice_service.py` | No | Optional Agent voice TTS model override. Defaults to `gemini-2.5-flash-preview-tts`. |
 | `AGENT_GEMINI_TTS_VOICE` | `hushh_mcp/services/agent_voice_service.py` | No | Optional backend default Agent TTS voice. Defaults to `Sulafat`; frontend profile setting can pass a per-device voice. |
+| `AGENT_GEMINI_TTS_TIMEOUT_SECONDS` | `hushh_mcp/services/agent_voice_service.py` | No | Optional server-side Agent voice TTS Gemini timeout per attempt. Defaults to `45`. |
+| `AGENT_GEMINI_TTS_MAX_ATTEMPTS` | `hushh_mcp/services/agent_voice_service.py` | No | Optional Agent voice TTS retry cap. Defaults to `2`; bounded from `1` to `4`. |
+| `HUSHH_KAI_AGENT_VOICE_STT_TIMEOUT_MS` | `hushh-webapp/app/api/kai/[...path]/route.ts` | No | Optional Next.js Kai proxy timeout for Agent voice STT uploads. Defaults to `35000`. |
+| `HUSHH_KAI_AGENT_VOICE_TTS_TIMEOUT_MS` | `hushh-webapp/app/api/kai/[...path]/route.ts` | No | Optional Next.js Kai proxy timeout for Agent voice TTS. Defaults to `45000`. |
+| `HUSHH_KAI_AGENT_CHAT_STREAM_TIMEOUT_MS` | `hushh-webapp/app/api/kai/[...path]/route.ts` | No | Optional Next.js Kai proxy timeout for Agent chat SSE streams. Defaults to `120000`. |
 | `GOOGLE_GENAI_USE_VERTEXAI` | Cloud Run env (Gemini SDK) | No | Set in deploy, not in .env |
 | `CONSENT_SSE_ENABLED` | `api/routes/sse.py` | No | Default off in production unless explicitly enabled |
 | `SYNC_REMOTE_ENABLED` | deploy env (`deploy/backend.cloudbuild.yaml`) | No | Legacy deploy flag; currently not read by backend code |
@@ -243,8 +249,14 @@ Used by:
 | `AGENT_GEMINI_MODEL` | No | No | Local: `.env`; Prod: Cloud Run env | Optional; defaults to `gemini-2.5-pro`. |
 | `AGENT_GEMINI_VOICE_ENABLED` | No | No | Local: `.env`; Prod: Cloud Run env | Agent chained voice backend kill switch. Defaults enabled. |
 | `AGENT_GEMINI_STT_MODEL` | No | No | Local: `.env`; Prod: Cloud Run env | Optional Agent voice STT model override. Defaults to `gemini-2.5-flash`. |
+| `AGENT_GEMINI_STT_TIMEOUT_SECONDS` | No | No | Local: `.env`; Prod: Cloud Run env | Optional server-side Agent voice STT timeout. Defaults to `30`. |
 | `AGENT_GEMINI_TTS_MODEL` | No | No | Local: `.env`; Prod: Cloud Run env | Optional Agent voice TTS model override. Defaults to `gemini-2.5-flash-preview-tts`. |
 | `AGENT_GEMINI_TTS_VOICE` | No | No | Local: `.env`; Prod: Cloud Run env | Optional backend default Agent TTS voice. Defaults to `Sulafat`. |
+| `AGENT_GEMINI_TTS_TIMEOUT_SECONDS` | No | No | Local: `.env`; Prod: Cloud Run env | Optional server-side Agent voice TTS timeout. Defaults to `45`. |
+| `AGENT_GEMINI_TTS_MAX_ATTEMPTS` | No | No | Local: `.env`; Prod: Cloud Run env | Optional Agent voice TTS retry cap. Defaults to `2`. |
+| `HUSHH_KAI_AGENT_VOICE_STT_TIMEOUT_MS` | No | No | Local: `hushh-webapp/.env.local`; Frontend runtime env | Optional Next.js proxy timeout for Agent voice STT uploads. Defaults to `35000`. |
+| `HUSHH_KAI_AGENT_VOICE_TTS_TIMEOUT_MS` | No | No | Local: `hushh-webapp/.env.local`; Frontend runtime env | Optional Next.js proxy timeout for Agent voice TTS. Defaults to `45000`. |
+| `HUSHH_KAI_AGENT_CHAT_STREAM_TIMEOUT_MS` | No | No | Local: `hushh-webapp/.env.local`; Frontend runtime env | Optional Next.js proxy timeout for Agent chat SSE streams. Defaults to `120000`. |
 | `GMAIL_OAUTH_CLIENT_ID` | Yes (Gmail sync) | Yes | Local: `.env`; Hosted: Secret Manager | Same key name across local, UAT, and production. |
 | `GMAIL_OAUTH_CLIENT_SECRET` | Yes (Gmail sync) | Yes | Local: `.env`; Hosted: Secret Manager | Same key name across local, UAT, and production. |
 | `GMAIL_OAUTH_REDIRECT_URI` | Yes (Gmail sync) | Yes | Local: `.env`; Hosted: Secret Manager | Same key name across local, UAT, and production. |

--- a/docs/reference/operations/env-secrets-key-matrix.md
+++ b/docs/reference/operations/env-secrets-key-matrix.md
@@ -41,8 +41,14 @@ Profile bootstrap rule:
 | `AGENT_GEMINI_MODEL` | `consent-protocol/hushh_mcp/services/agent_chat_service.py` | Y | N | N | env | N | env | N | optional |
 | `AGENT_GEMINI_VOICE_ENABLED` | `consent-protocol/api/routes/kai/agent_voice.py` | Y | N | N | env | N | env | N | optional kill switch |
 | `AGENT_GEMINI_STT_MODEL` | `consent-protocol/hushh_mcp/services/agent_voice_service.py` | Y | N | N | env | N | env | N | optional |
+| `AGENT_GEMINI_STT_TIMEOUT_SECONDS` | `consent-protocol/hushh_mcp/services/agent_voice_service.py` | Y | N | N | env | N | env | N | optional |
 | `AGENT_GEMINI_TTS_MODEL` | `consent-protocol/hushh_mcp/services/agent_voice_service.py` | Y | N | N | env | N | env | N | optional |
 | `AGENT_GEMINI_TTS_VOICE` | `consent-protocol/hushh_mcp/services/agent_voice_service.py` | Y | N | N | env | N | env | N | optional |
+| `AGENT_GEMINI_TTS_TIMEOUT_SECONDS` | `consent-protocol/hushh_mcp/services/agent_voice_service.py` | Y | N | N | env | N | env | N | optional |
+| `AGENT_GEMINI_TTS_MAX_ATTEMPTS` | `consent-protocol/hushh_mcp/services/agent_voice_service.py` | Y | N | N | env | N | env | N | optional |
+| `HUSHH_KAI_AGENT_VOICE_STT_TIMEOUT_MS` | `hushh-webapp/app/api/kai/[...path]/route.ts` | N | Y | N | N | env | N | env | optional |
+| `HUSHH_KAI_AGENT_VOICE_TTS_TIMEOUT_MS` | `hushh-webapp/app/api/kai/[...path]/route.ts` | N | Y | N | N | env | N | env | optional |
+| `HUSHH_KAI_AGENT_CHAT_STREAM_TIMEOUT_MS` | `hushh-webapp/app/api/kai/[...path]/route.ts` | N | Y | N | N | env | N | env | optional |
 | `NEXT_PUBLIC_AGENT_GEMINI_VOICE_ENABLED` | `hushh-webapp/lib/agent/agent-voice-settings.ts` | N | Y | N | N | env | N | env | optional frontend mirror |
 | `FIREBASE_ADMIN_CREDENTIALS_JSON` | `consent-protocol/api/utils/firebase_admin.py`, `consent-protocol/hushh_mcp/runtime_settings.py`, `hushh-webapp/lib/firebase/admin.ts` | Y | Y | Y | secret | secret | secret | secret | required |
 | `FIREBASE_SERVICE_ACCOUNT_JSON` | `consent-protocol/hushh_mcp/runtime_settings.py` | Y | N | Y | N | N | alias | N | optional alias |

--- a/hushh-webapp/__tests__/api/kai/proxy-route.test.ts
+++ b/hushh-webapp/__tests__/api/kai/proxy-route.test.ts
@@ -22,6 +22,14 @@ function createRequest(url: string, init: RequestInit): NextRequest {
   return new NextRequest(url, init);
 }
 
+async function waitForFetchCall(fetchSpy: ReturnType<typeof vi.spyOn>) {
+  for (let index = 0; index < 10; index += 1) {
+    if (fetchSpy.mock.calls.length > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  expect(fetchSpy).toHaveBeenCalled();
+}
+
 describe("/api/kai/[...path] proxy", () => {
   it("forwards Authorization header for JSON POST routes", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
@@ -143,6 +151,67 @@ describe("/api/kai/[...path] proxy", () => {
     expect(headers.get("Accept")).toBe("text/event-stream");
     expect(headers.get("Content-Type")).toBeNull();
     expect(options?.body).toBeInstanceOf(FormData);
+  });
+
+  it("applies an upstream timeout to Agent voice STT uploads", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ transcript: "hello", uncertain: false }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    const formData = new FormData();
+    formData.set("user_id", "user_123");
+    formData.set("audio", new Blob(["audio"], { type: "audio/webm" }), "utterance.webm");
+    const req = createRequest("http://localhost:3000/api/kai/agent/voice/stt", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer vault_owner_token",
+        "Content-Type": "multipart/form-data; boundary=testboundary",
+      },
+      body: "--testboundary--",
+    });
+    vi.spyOn(req, "formData").mockResolvedValue(formData);
+
+    const res = await kaiRoute.POST(req, {
+      params: Promise.resolve({ path: ["agent", "voice", "stt"] }),
+    });
+
+    expect(res.status).toBe(200);
+    const [, options] = fetchSpy.mock.calls[0] ?? [];
+    expect(options?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("applies an upstream timeout to Agent chat streams", async () => {
+    const streamBody = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("event: start\\ndata: {}\\n\\n"));
+        controller.close();
+      },
+    });
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(streamBody, {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      })
+    );
+    const req = createRequest("http://localhost:3000/api/kai/agent/chat/stream", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer vault_owner_token",
+        Accept: "text/event-stream",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ user_id: "user_123", message: "hello" }),
+    });
+
+    const res = await kaiRoute.POST(req, {
+      params: Promise.resolve({ path: ["agent", "chat", "stream"] }),
+    });
+
+    expect(res.status).toBe(200);
+    const [, options] = fetchSpy.mock.calls[0] ?? [];
+    expect(options?.signal).toBeInstanceOf(AbortSignal);
   });
 
   it("passes through SSE stream headers and forwards Authorization on stream path", async () => {
@@ -342,5 +411,49 @@ describe("/api/kai/[...path] proxy", () => {
     const headers = options?.headers as Headers;
     expect(headers.get("Authorization")).toBe("Bearer vault_owner_token");
     expect(headers.get("Accept")).toBe("audio/wav");
+    expect(options?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("aborts Agent voice TTS upstream work when the incoming request is cancelled", async () => {
+    const controller = new AbortController();
+    let upstreamSignal: AbortSignal | undefined;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((_url, init) => {
+      upstreamSignal = init?.signal as AbortSignal;
+      return new Promise<Response>((_resolve, reject) => {
+        upstreamSignal?.addEventListener(
+          "abort",
+          () => reject(new DOMException("Aborted", "AbortError")),
+          { once: true }
+        );
+      });
+    });
+
+    const req = createRequest("http://localhost:3000/api/kai/agent/voice/tts", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer vault_owner_token",
+        Accept: "audio/wav",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ user_id: "user_123", text: "hello" }),
+      signal: controller.signal,
+    });
+
+    const pending = kaiRoute.POST(req, {
+      params: Promise.resolve({ path: ["agent", "voice", "tts"] }),
+    });
+    await waitForFetchCall(fetchSpy);
+
+    expect(upstreamSignal).toBeInstanceOf(AbortSignal);
+    expect(upstreamSignal?.aborted).toBe(false);
+    controller.abort();
+
+    const res = await pending;
+    expect(upstreamSignal?.aborted).toBe(true);
+    expect(res.status).toBe(499);
+    await expect(res.json()).resolves.toEqual({
+      error: "Request cancelled",
+      message: "The request was cancelled.",
+    });
   });
 });

--- a/hushh-webapp/__tests__/services/agent-chat-client.test.ts
+++ b/hushh-webapp/__tests__/services/agent-chat-client.test.ts
@@ -222,6 +222,28 @@ describe("agent chat client", () => {
     expect(errors).toEqual(["Agent chat failed. Please try again."]);
   });
 
+  it("sanitizes malformed Agent SSE JSON frames", async () => {
+    vi.spyOn(ApiService, "streamAgentChat").mockResolvedValue(
+      sseResponse([
+        'event: start\ndata: {"conversation_id":"conversation-1","model":"gemini-2.5-pro"}\n\n',
+        "event: token\ndata: {not-json}\n\n",
+      ])
+    );
+    const errors: string[] = [];
+
+    await expect(
+      streamAgentChat({
+        userId: "user-1",
+        message: "Hello",
+        vaultOwnerToken: "vault-token",
+        handlers: {
+          onError: (message) => errors.push(message),
+        },
+      })
+    ).rejects.toThrow("Agent chat stream returned malformed data. Please retry.");
+    expect(errors).toEqual(["Agent chat stream returned malformed data. Please retry."]);
+  });
+
   it("formats streamed runtime provider errors", async () => {
     vi.spyOn(ApiService, "streamAgentChat").mockResolvedValue(
       sseResponse([

--- a/hushh-webapp/__tests__/services/agent-voice-client.test.ts
+++ b/hushh-webapp/__tests__/services/agent-voice-client.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/services/api-service", () => ({
   ApiService: {
@@ -7,6 +7,7 @@ vi.mock("@/lib/services/api-service", () => ({
 }));
 
 import {
+  AgentVoiceClient,
   getAgentVoiceEndSilenceThresholdMs,
   getAgentVoiceStartErrorMessage,
   shouldConfirmAgentVoiceTranscript,
@@ -17,6 +18,10 @@ import { ApiService } from "@/lib/services/api-service";
 describe("agent voice client", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("posts audio to the Agent voice STT route through ApiService", async () => {
@@ -105,5 +110,38 @@ describe("agent voice client", () => {
   it("uses a shorter end-of-speech window after established speech", () => {
     expect(getAgentVoiceEndSilenceThresholdMs(250)).toBe(1200);
     expect(getAgentVoiceEndSilenceThresholdMs(900)).toBe(850);
+  });
+
+  it("tears down capture when MediaRecorder cannot start", async () => {
+    const stop = vi.fn();
+    const stream = {
+      getTracks: () => [{ stop }],
+      getAudioTracks: () => [{ enabled: true }],
+    } as unknown as MediaStream;
+    const MediaRecorderMock = vi.fn(function MockMediaRecorder() {
+      throw new DOMException("busy", "NotReadableError");
+    });
+    Object.assign(MediaRecorderMock, {
+      isTypeSupported: vi.fn(() => false),
+    });
+    vi.stubGlobal("MediaRecorder", MediaRecorderMock);
+    vi.stubGlobal("navigator", {
+      mediaDevices: {
+        getUserMedia: vi.fn().mockResolvedValue(stream),
+      },
+    });
+    const client = new AgentVoiceClient();
+    const errors: string[] = [];
+    const statuses: string[] = [];
+
+    await client.start({
+      onError: (message) => errors.push(message),
+      onStatus: (status) => statuses.push(status),
+    });
+
+    expect(client.isActive).toBe(false);
+    expect(stop).toHaveBeenCalled();
+    expect(errors).toEqual(["The microphone is already in use or could not be started."]);
+    expect(statuses.at(-1)).toBe("idle");
   });
 });

--- a/hushh-webapp/app/api/kai/[...path]/route.ts
+++ b/hushh-webapp/app/api/kai/[...path]/route.ts
@@ -27,6 +27,18 @@ const GMAIL_CONNECT_COMPLETE_TIMEOUT_MS = resolveSlowRequestTimeoutMs(30_000, {
   developmentFloorMs: 30_000,
   overrideEnvKey: "HUSHH_KAI_GMAIL_CONNECT_COMPLETE_TIMEOUT_MS",
 });
+const AGENT_VOICE_STT_PROXY_TIMEOUT_MS = resolveSlowRequestTimeoutMs(35_000, {
+  developmentFloorMs: 35_000,
+  overrideEnvKey: "HUSHH_KAI_AGENT_VOICE_STT_TIMEOUT_MS",
+});
+const AGENT_VOICE_TTS_PROXY_TIMEOUT_MS = resolveSlowRequestTimeoutMs(45_000, {
+  developmentFloorMs: 45_000,
+  overrideEnvKey: "HUSHH_KAI_AGENT_VOICE_TTS_TIMEOUT_MS",
+});
+const AGENT_CHAT_STREAM_PROXY_TIMEOUT_MS = resolveSlowRequestTimeoutMs(120_000, {
+  developmentFloorMs: 120_000,
+  overrideEnvKey: "HUSHH_KAI_AGENT_CHAT_STREAM_TIMEOUT_MS",
+});
 
 function isGmailPath(path: string): boolean {
   return path === "gmail" || path.startsWith("gmail/");
@@ -49,6 +61,48 @@ function isUpstreamTimeoutError(error: unknown): boolean {
     normalizedMessage.includes("timeout") ||
     causeCode === "UND_ERR_HEADERS_TIMEOUT"
   );
+}
+
+function isClientAbortError(error: unknown): boolean {
+  const name =
+    typeof (error as { name?: unknown })?.name === "string"
+      ? (error as { name: string }).name
+      : "";
+  const message = error instanceof Error ? error.message : String(error);
+  const normalizedMessage = message.toLowerCase();
+  return name === "AbortError" || normalizedMessage.includes("abort");
+}
+
+function resolveUpstreamSignal(
+  requestSignal: AbortSignal,
+  timeoutMs: number | null
+): AbortSignal {
+  if (!timeoutMs) {
+    return requestSignal;
+  }
+
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const anySignal = (AbortSignal as typeof AbortSignal & {
+    any?: (signals: AbortSignal[]) => AbortSignal;
+  }).any;
+  if (typeof anySignal === "function") {
+    return anySignal([requestSignal, timeoutSignal]);
+  }
+
+  const controller = new AbortController();
+  const abortFrom = (signal: AbortSignal) => {
+    if (controller.signal.aborted) return;
+    controller.abort(signal.reason);
+  };
+  if (requestSignal.aborted) {
+    abortFrom(requestSignal);
+  } else if (timeoutSignal.aborted) {
+    abortFrom(timeoutSignal);
+  } else {
+    requestSignal.addEventListener("abort", () => abortFrom(requestSignal), { once: true });
+    timeoutSignal.addEventListener("abort", () => abortFrom(timeoutSignal), { once: true });
+  }
+  return controller.signal;
 }
 
 function buildUpstreamFailurePayload(path: string, error: unknown) {
@@ -105,6 +159,15 @@ function buildUpstreamFailurePayload(path: string, error: unknown) {
 }
 
 function resolveKaiUpstreamTimeoutMs(path: string): number | null {
+  if (path === "agent/voice/stt") {
+    return AGENT_VOICE_STT_PROXY_TIMEOUT_MS;
+  }
+  if (path === "agent/voice/tts") {
+    return AGENT_VOICE_TTS_PROXY_TIMEOUT_MS;
+  }
+  if (path === "agent/chat/stream") {
+    return AGENT_CHAT_STREAM_PROXY_TIMEOUT_MS;
+  }
   if (path === "gmail/receipts-memory/preview") {
     return GMAIL_RECEIPTS_MEMORY_PREVIEW_TIMEOUT_MS;
   }
@@ -234,7 +297,7 @@ async function proxyRequest(request: NextRequest, params: { path: string[] }) {
       method: request.method,
       headers: headers,
       body: body,
-      ...(upstreamTimeoutMs ? { signal: AbortSignal.timeout(upstreamTimeoutMs) } : {}),
+      signal: resolveUpstreamSignal(request.signal, upstreamTimeoutMs),
     });
 
     // Check for SSE stream response
@@ -294,6 +357,18 @@ async function proxyRequest(request: NextRequest, params: { path: string[] }) {
 
     return withRequestIdJson(requestId, data);
   } catch (error) {
+    if (isClientAbortError(error)) {
+      console.info(`[Kai API] request_id=${requestId} client_aborted path=${path}`);
+      return withRequestIdJson(
+        requestId,
+        {
+          error: "Request cancelled",
+          message: "The request was cancelled.",
+        },
+        { status: 499 }
+      );
+    }
+
     console.error(
       `[Kai API] request_id=${requestId} proxy_error path=${path}`,
       summarizeProxyError(error)

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -8,6 +8,7 @@ import {
   useRef,
   useState,
   type ReactNode,
+  type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
 } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -15,6 +16,8 @@ import {
   Bot,
   Check,
   Copy,
+  KeyRound,
+  LogIn,
   Menu,
   Mic,
   Minus,
@@ -83,6 +86,7 @@ import {
   type AgentChatToolEvent,
 } from "@/lib/services/agent-chat-client";
 import { useKaiSession } from "@/lib/stores/kai-session-store";
+import { ROUTES } from "@/lib/navigation/routes";
 import { cn } from "@/lib/utils";
 import { useVault } from "@/lib/vault/vault-context";
 import { deriveVoiceRouteScreen } from "@/lib/voice/route-screen-derivation";
@@ -161,6 +165,8 @@ const AGENT_STREAM_RENDER_FRAME_MS = 32;
 const VOICE_PKM_CONTEXT_DEADLINE_MS = 650;
 const VOICE_AGENT_FIRST_EVENT_TIMEOUT_MS = 25_000;
 const VOICE_AGENT_IDLE_TIMEOUT_MS = 45_000;
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 const EXPLICIT_PKM_SAVE_PATTERN =
   /\b(?:add|save|store|remember)\b[\s\S]{0,140}\b(?:pkm|personal knowledge|memory|memories)\b|\b(?:add|save|store|remember)\s+(?:this|that)\b/i;
@@ -203,6 +209,37 @@ function createGreetingMessage(): AgentMessage {
     timestamp: AGENT_GREETING_TIMESTAMP,
     status: "done",
   };
+}
+
+function getFocusableElements(container: HTMLElement | null): HTMLElement[] {
+  if (!container) return [];
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+    (element) =>
+      !element.hasAttribute("disabled") &&
+      element.getAttribute("aria-hidden") !== "true" &&
+      element.offsetParent !== null
+  );
+}
+
+function trapFocusWithin(event: ReactKeyboardEvent, container: HTMLElement | null): void {
+  if (event.key !== "Tab") return;
+  const focusable = getFocusableElements(container);
+  if (focusable.length === 0) {
+    event.preventDefault();
+    return;
+  }
+  const first = focusable[0]!;
+  const last = focusable[focusable.length - 1]!;
+  const active = document.activeElement;
+  if (event.shiftKey && active === first) {
+    event.preventDefault();
+    last.focus();
+    return;
+  }
+  if (!event.shiftKey && active === last) {
+    event.preventDefault();
+    first.focus();
+  }
 }
 
 function formatAgentDisplayName(displayName?: string | null, email?: string | null): string {
@@ -715,6 +752,10 @@ export function AgentChatWorkspace({
   const voiceTtsQueueRef = useRef<AgentTtsQueue | null>(null);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
   const composerTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const historyDrawerRef = useRef<HTMLDivElement | null>(null);
+  const historyDrawerReturnFocusRef = useRef<HTMLElement | null>(null);
+  const voiceTranscriptDialogRef = useRef<HTMLDivElement | null>(null);
+  const voiceTranscriptReturnFocusRef = useRef<HTMLElement | null>(null);
   const historyLoadKeyRef = useRef<string | null>(null);
   const streamAbortControllerRef = useRef<AbortController | null>(null);
   const voiceSttAbortControllerRef = useRef<AbortController | null>(null);
@@ -937,14 +978,40 @@ export function AgentChatWorkspace({
 
   useEffect(() => {
     if (!isHistoryDrawerOpen) return;
+    historyDrawerReturnFocusRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         setIsHistoryDrawerOpen(false);
       }
     };
+    window.requestAnimationFrame(() => {
+      getFocusableElements(historyDrawerRef.current)[0]?.focus();
+    });
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [isHistoryDrawerOpen]);
+
+  useEffect(() => {
+    if (isHistoryDrawerOpen) return;
+    historyDrawerReturnFocusRef.current?.focus();
+    historyDrawerReturnFocusRef.current = null;
+  }, [isHistoryDrawerOpen]);
+
+  useEffect(() => {
+    if (!voiceTranscriptReview) return;
+    voiceTranscriptReturnFocusRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    window.requestAnimationFrame(() => {
+      const focusable = getFocusableElements(voiceTranscriptDialogRef.current);
+      const preferred = voiceTranscriptReview.transcript.trim() ? focusable.at(-1) : focusable[0];
+      preferred?.focus();
+    });
+    return () => {
+      voiceTranscriptReturnFocusRef.current?.focus();
+      voiceTranscriptReturnFocusRef.current = null;
+    };
+  }, [voiceTranscriptReview]);
 
   useEffect(() => {
     return () => {
@@ -2206,10 +2273,10 @@ export function AgentChatWorkspace({
     await runAgentTurn(input, { source: "typed" });
   };
 
-  function setAgentVoiceStatus(status: AgentVoiceStatus, message?: string | null) {
+  const setAgentVoiceStatus = useCallback((status: AgentVoiceStatus, message?: string | null) => {
     setVoiceState(status);
     setGlobalVoiceStatus(status, message ?? null);
-  }
+  }, [setGlobalVoiceStatus]);
 
   function resumeAgentVoiceCapture(expectedEpoch?: number | null) {
     if (expectedEpoch !== undefined && expectedEpoch !== null) {
@@ -2251,14 +2318,14 @@ export function AgentChatWorkspace({
     });
   };
 
-  const handleVoiceTranscriptRetry = () => {
+  const handleVoiceTranscriptRetry = useCallback(() => {
     setVoiceTranscriptReview(null);
     const client = voiceClientRef.current;
     if (!client?.isActive) return;
     client.setMuted(false);
     client.setCapturePaused(false);
     setAgentVoiceStatus("listening");
-  };
+  }, [setAgentVoiceStatus]);
 
   const handleToggleVoice = async () => {
     if (!agentVoiceEnabled) {
@@ -2468,6 +2535,21 @@ export function AgentChatWorkspace({
       : !isVaultUnlocked || !vaultOwnerToken || !tokenIsFresh
         ? "Unlock your vault to use Agent."
         : null;
+  const accessAction = authLoading
+    ? null
+    : !user?.uid
+      ? {
+          label: "Sign in",
+          icon: LogIn,
+          onClick: () => router.push(ROUTES.LOGIN),
+        }
+      : !isVaultUnlocked || !vaultOwnerToken || !tokenIsFresh
+        ? {
+            label: "Unlock vault",
+            icon: KeyRound,
+            onClick: () => router.push(ROUTES.PROFILE),
+          }
+        : null;
   const displayName = useMemo(
     () => formatAgentDisplayName(user?.displayName, user?.email),
     [user?.displayName, user?.email]
@@ -2521,17 +2603,46 @@ export function AgentChatWorkspace({
       onMinimize();
     }
   };
+  const openHistoryDrawer = useCallback(() => {
+    historyDrawerReturnFocusRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    setIsHistoryDrawerOpen(true);
+  }, []);
   const handlePageMinimize = useCallback(() => {
     if (onMinimize) {
       onMinimize();
       return;
     }
-    if (typeof window !== "undefined" && window.history.length > 1) {
-      router.back();
+    if (typeof window !== "undefined") {
+      const referrer = document.referrer ? new URL(document.referrer) : null;
+      const isSameOriginReferrer =
+        referrer?.origin === window.location.origin && referrer.pathname !== ROUTES.AGENT;
+      if (isSameOriginReferrer && window.history.length > 1) {
+        router.back();
+        return;
+      }
+    }
+    router.push(ROUTES.PROFILE);
+  }, [onMinimize, router]);
+  const handleHistoryDrawerKeyDown = useCallback((event: ReactKeyboardEvent) => {
+    if (event.key === "Escape") {
+      event.stopPropagation();
+      setIsHistoryDrawerOpen(false);
       return;
     }
-    router.push("/profile");
-  }, [onMinimize, router]);
+    trapFocusWithin(event, historyDrawerRef.current);
+  }, []);
+  const handleVoiceTranscriptDialogKeyDown = useCallback(
+    (event: ReactKeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.stopPropagation();
+        handleVoiceTranscriptRetry();
+        return;
+      }
+      trapFocusWithin(event, voiceTranscriptDialogRef.current);
+    },
+    [handleVoiceTranscriptRetry]
+  );
   const renderHistorySidebar = (
     sidebarClassName?: string,
     onClose?: () => void,
@@ -2583,14 +2694,17 @@ export function AgentChatWorkspace({
           onClick={() => setIsHistoryDrawerOpen(false)}
         />
         <div
+          ref={historyDrawerRef}
           className={cn(
-            "fixed bottom-0 left-0 top-[var(--app-safe-area-top-effective,0px)] z-[530] w-[min(88vw,320px)] transform transition-transform duration-200 ease-out lg:hidden",
+            "fixed bottom-0 left-0 top-[var(--top-shell-reserved-height,var(--app-safe-area-top-effective,0px))] z-[530] w-[min(88vw,320px)] transform transition-transform duration-200 ease-out lg:hidden",
             isHistoryDrawerOpen ? "translate-x-0" : "-translate-x-full"
           )}
           role="dialog"
           aria-modal="true"
           aria-hidden={!isHistoryDrawerOpen}
           aria-label="Agent chat history"
+          inert={!isHistoryDrawerOpen}
+          onKeyDown={handleHistoryDrawerKeyDown}
         >
           {renderHistorySidebar("h-full w-full shadow-2xl shadow-black/40", () =>
             setIsHistoryDrawerOpen(false)
@@ -2602,6 +2716,7 @@ export function AgentChatWorkspace({
             "relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-[#15171c]",
             isPopover && "rounded-lg border border-white/10 shadow-sm"
           )}
+          inert={isHistoryDrawerOpen}
         >
           <div
             className={cn(
@@ -2618,19 +2733,17 @@ export function AgentChatWorkspace({
             }}
           >
             <div className="flex min-w-0 items-center gap-3">
-              {!isPopover ? (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="h-9 w-9 rounded-lg text-zinc-300 hover:bg-white/[0.07] hover:text-zinc-50 focus-visible:ring-2 focus-visible:ring-primary/60 lg:hidden"
-                  onClick={() => setIsHistoryDrawerOpen(true)}
-                  aria-label="Open chat history"
-                  title="Open chat history"
-                >
-                  <Menu className="h-4 w-4" />
-                </Button>
-              ) : null}
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-9 w-9 rounded-lg text-zinc-300 hover:bg-white/[0.07] hover:text-zinc-50 focus-visible:ring-2 focus-visible:ring-primary/60 lg:hidden"
+                onClick={openHistoryDrawer}
+                aria-label="Open chat history"
+                title="Open chat history"
+              >
+                <Menu className="h-4 w-4" />
+              </Button>
               <div className="grid h-8 w-8 shrink-0 place-items-center rounded-md border border-white/10 bg-white/[0.04] text-primary">
                 <Bot className="h-4 w-4" />
               </div>
@@ -2673,8 +2786,19 @@ export function AgentChatWorkspace({
           >
             <div className="mx-auto flex min-h-full w-full max-w-3xl flex-col gap-6">
               {accessMessage ? (
-                <div className="rounded-xl border border-white/10 bg-white/[0.03] px-4 py-4 text-sm text-zinc-400">
-                  {accessMessage}
+                <div className="flex flex-col gap-3 rounded-xl border border-white/10 bg-white/[0.03] px-4 py-4 text-sm text-zinc-400 sm:flex-row sm:items-center sm:justify-between">
+                  <span>{accessMessage}</span>
+                  {accessAction ? (
+                    <Button
+                      type="button"
+                      size="sm"
+                      className="w-full shrink-0 gap-2 rounded-lg sm:w-auto"
+                      onClick={accessAction.onClick}
+                    >
+                      <accessAction.icon className="h-4 w-4" aria-hidden="true" />
+                      {accessAction.label}
+                    </Button>
+                  ) : null}
                 </div>
               ) : null}
 
@@ -2719,10 +2843,12 @@ export function AgentChatWorkspace({
           {voiceTranscriptReview ? (
             <div className="absolute inset-0 z-20 grid place-items-end bg-black/40 p-4 backdrop-blur-[2px] sm:place-items-center">
               <div
+                ref={voiceTranscriptDialogRef}
                 className="w-full max-w-sm rounded-xl border border-white/10 bg-[#15171c] p-4 shadow-xl"
                 role="dialog"
                 aria-modal="true"
                 aria-label="Confirm voice transcript"
+                onKeyDown={handleVoiceTranscriptDialogKeyDown}
               >
                 <p className="text-xs font-medium uppercase tracking-[0.16em] text-primary">
                   Confirm voice transcript
@@ -2784,6 +2910,7 @@ export function AgentChatWorkspace({
                 <div className="flex min-h-14 items-end gap-2 rounded-[1.5rem] border border-white/12 bg-[#0f1116] px-3 py-2 shadow-lg shadow-black/15 transition-colors focus-within:border-primary/55 focus-within:ring-2 focus-within:ring-primary/20">
                   <textarea
                     ref={composerTextareaRef}
+                    aria-label="Message Agent"
                     value={input}
                     onChange={(event) => setInput(event.target.value)}
                     onKeyDown={(event) => {

--- a/hushh-webapp/components/agent/agent-popover-provider.tsx
+++ b/hushh-webapp/components/agent/agent-popover-provider.tsx
@@ -519,7 +519,7 @@ function AgentPopoverSurface({ customSize, setCustomSize }: AgentPopoverSurfaceP
   }
 
   if (!canShowAgent) {
-    return <AgentVoiceFloatingIndicator onClick={openAgent} />;
+    return null;
   }
 
   return (

--- a/hushh-webapp/components/agent/agent-screen.tsx
+++ b/hushh-webapp/components/agent/agent-screen.tsx
@@ -1,10 +1,21 @@
 "use client";
 
-import { AppPageShell } from "@/components/app-ui/app-page-shell";
+import { AppPageContentRegion, AppPageShell } from "@/components/app-ui/app-page-shell";
 import { NativeRouteMarker } from "@/components/app-ui/native-route-marker";
 import { AgentChatWorkspace } from "@/components/agent/agent-chat-workspace";
+import { useAuth } from "@/hooks/use-auth";
+import { useVault } from "@/lib/vault/vault-context";
 
 export function AgentScreen() {
+  const { user, loading } = useAuth();
+  const { isVaultUnlocked, vaultOwnerToken } = useVault();
+  const nativeAuthState = loading ? "pending" : user?.uid ? "authenticated" : "anonymous";
+  const nativeDataState = loading
+    ? "loading"
+    : user?.uid && isVaultUnlocked && vaultOwnerToken
+      ? "loaded"
+      : "unavailable-valid";
+
   return (
     <AppPageShell
       width="wide"
@@ -12,17 +23,19 @@ export function AgentScreen() {
       nativeTest={{
         routeId: "/agent",
         marker: "native-route-agent",
-        authState: "authenticated",
-        dataState: "loaded",
+        authState: nativeAuthState,
+        dataState: nativeDataState,
       }}
     >
       <NativeRouteMarker
         routeId="/agent"
         marker="native-route-agent"
-        authState="authenticated"
-        dataState="loaded"
+        authState={nativeAuthState}
+        dataState={nativeDataState}
       />
-      <AgentChatWorkspace variant="page" />
+      <AppPageContentRegion className="min-h-0">
+        <AgentChatWorkspace variant="page" />
+      </AppPageContentRegion>
     </AppPageShell>
   );
 }

--- a/hushh-webapp/components/app-ui/top-app-bar.tsx
+++ b/hushh-webapp/components/app-ui/top-app-bar.tsx
@@ -210,6 +210,7 @@ interface TopAppBarProps {
 export function TopAppBar({ className }: TopAppBarProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { isAuthenticated } = useAuth();
   const { isVaultUnlocked } = useVault();
   const { activePersona, riaCapability, riaEntryRoute, switchPersona } =
     usePersonaState();
@@ -565,7 +566,7 @@ export function TopAppBar({ className }: TopAppBarProps) {
                   data-testid="top-app-bar-actions"
                   className="pointer-events-auto flex flex-nowrap items-center justify-end gap-1.5 sm:gap-2 pr-[env(safe-area-inset-right)]"
                 >
-                  {showOnboardingActions ? (
+                  {!isAuthenticated ? null : showOnboardingActions ? (
                     <OnboardingRouteActions />
                   ) : (
                     <>

--- a/hushh-webapp/components/features/focus/focus-timer-widget.tsx
+++ b/hushh-webapp/components/features/focus/focus-timer-widget.tsx
@@ -45,6 +45,8 @@ export function FocusTimerWidget() {
         className={`pointer-events-auto origin-bottom-left transition-all duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] flex flex-col bg-background/80 backdrop-blur-2xl border shadow-2xl rounded-2xl w-[300px] overflow-hidden ${
           isOpen ? "opacity-100 scale-100 translate-y-0" : "opacity-0 scale-95 translate-y-4 pointer-events-none"
         }`}
+        aria-hidden={!isOpen}
+        inert={!isOpen}
       >
         <div className="flex items-center justify-between px-4 py-3 border-b bg-muted/30">
           <div className="flex items-center gap-2">
@@ -56,6 +58,7 @@ export function FocusTimerWidget() {
             size="icon" 
             className="h-7 w-7 rounded-full text-muted-foreground hover:text-foreground" 
             onClick={() => setIsOpen(false)}
+            aria-label="Close Focus Timer"
           >
             <X className="w-4 h-4" />
           </Button>
@@ -143,6 +146,9 @@ export function FocusTimerWidget() {
         size="icon"
         onClick={() => setIsOpen(!isOpen)}
         className={`pointer-events-auto h-12 w-12 rounded-full shadow-lg border transition-all duration-300 ${isOpen ? "rotate-90 scale-90 opacity-0" : "hover:scale-105"}`}
+        aria-label="Open Focus Timer"
+        aria-hidden={isOpen}
+        tabIndex={isOpen ? -1 : 0}
         title="Open Focus Timer"
       >
         <Timer className="w-5 h-5" />

--- a/hushh-webapp/frontend-native-surface-map.generated.json
+++ b/hushh-webapp/frontend-native-surface-map.generated.json
@@ -311,9 +311,8 @@
         "shell_verification_file": "components/agent/agent-screen.tsx",
         "shell_verification_includes": [
           "AppPageShell",
-          "AppPageHeaderRegion",
           "AppPageContentRegion",
-          "PageHeader"
+          "AgentChatWorkspace"
         ]
       },
       "native": {

--- a/hushh-webapp/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/hushh-webapp/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "eea15ec51d7f8483241df1a68a200b62597462f85d24e12fd25a91de3503f994",
+  "originHash" : "7f64484facf79b8c1a3b4c31150dff407dab08a35cdbe0b3b96a61f500ef10aa",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ionic-team/capacitor-swift-pm.git",
       "state" : {
-        "revision" : "44ae2505f54a80c5e559533950886d0644fc2fca",
-        "version" : "8.4.0"
+        "revision" : "f1a8fadf1437c23b825c818fb6509c9dbbae2f61",
+        "version" : "8.3.1"
       }
     },
     {

--- a/hushh-webapp/ios/App/CapApp-SPM/Package.swift
+++ b/hushh-webapp/ios/App/CapApp-SPM/Package.swift
@@ -11,14 +11,14 @@ let package = Package(
             targets: ["CapApp-SPM"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.4.0"),
-        .package(name: "CapacitorFirebaseAnalytics", path: "../../../node_modules/.pnpm/@capacitor-firebase+analytics@8.3.0_@capacitor+core@8.4.0_firebase@12.14.0/node_modules/@capacitor-firebase/analytics"),
-        .package(name: "CapacitorFirebaseAuthentication", path: "../../../node_modules/.pnpm/@capacitor-firebase+authentication@8.3.0_@capacitor+core@8.4.0_firebase@12.14.0/node_modules/@capacitor-firebase/authentication"),
-        .package(name: "CapacitorFirebaseMessaging", path: "../../../node_modules/.pnpm/@capacitor-firebase+messaging@8.3.0_@capacitor+core@8.4.0_firebase@12.14.0/node_modules/@capacitor-firebase/messaging"),
-        .package(name: "CapacitorApp", path: "../../../node_modules/.pnpm/@capacitor+app@8.1.0_@capacitor+core@8.4.0/node_modules/@capacitor/app"),
-        .package(name: "CapacitorFilesystem", path: "../../../node_modules/.pnpm/@capacitor+filesystem@8.1.2_@capacitor+core@8.4.0/node_modules/@capacitor/filesystem"),
-        .package(name: "CapacitorPreferences", path: "../../../node_modules/.pnpm/@capacitor+preferences@8.0.1_@capacitor+core@8.4.0/node_modules/@capacitor/preferences"),
-        .package(name: "CapacitorShare", path: "../../../node_modules/.pnpm/@capacitor+share@8.0.1_@capacitor+core@8.4.0/node_modules/@capacitor/share")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.3.1"),
+        .package(name: "CapacitorFirebaseAnalytics", path: "../../../node_modules/@capacitor-firebase/analytics"),
+        .package(name: "CapacitorFirebaseAuthentication", path: "../../../node_modules/@capacitor-firebase/authentication"),
+        .package(name: "CapacitorFirebaseMessaging", path: "../../../node_modules/@capacitor-firebase/messaging"),
+        .package(name: "CapacitorApp", path: "../../../node_modules/@capacitor/app"),
+        .package(name: "CapacitorFilesystem", path: "../../../node_modules/@capacitor/filesystem"),
+        .package(name: "CapacitorPreferences", path: "../../../node_modules/@capacitor/preferences"),
+        .package(name: "CapacitorShare", path: "../../../node_modules/@capacitor/share")
     ],
     targets: [
         .target(

--- a/hushh-webapp/lib/navigation/app-route-layout.contract.json
+++ b/hushh-webapp/lib/navigation/app-route-layout.contract.json
@@ -17,7 +17,7 @@
     "mode": "standard",
     "shellVerification": {
       "file": "components/agent/agent-screen.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader"]
+      "includes": ["AppPageShell", "AppPageContentRegion", "AgentChatWorkspace"]
     }
   },
   {

--- a/hushh-webapp/lib/services/agent-chat-client.ts
+++ b/hushh-webapp/lib/services/agent-chat-client.ts
@@ -147,7 +147,14 @@ export async function streamAgentChat(input: {
   let streamError: string | null = null;
 
   const handleFrame = (event: string, data: string) => {
-    const payload = parseJsonPayload(data);
+    let payload: Record<string, unknown>;
+    try {
+      payload = parseJsonPayload(data);
+    } catch {
+      streamError = "Agent chat stream returned malformed data. Please retry.";
+      input.handlers?.onError?.(streamError);
+      return;
+    }
     if (event === "start") {
       conversationId = readString(payload, "conversation_id") || conversationId;
       model = readString(payload, "model") || model;

--- a/hushh-webapp/lib/services/agent-voice-client.ts
+++ b/hushh-webapp/lib/services/agent-voice-client.ts
@@ -443,9 +443,8 @@ export class AgentVoiceClient {
     try {
       this.recorder = new MediaRecorder(this.stream, options);
     } catch (error) {
-      this.processingUtterance = false;
-      this.stopNativeRecognition(true);
-      this.handlers.onError?.(getAgentVoiceStartErrorMessage(error));
+      this.recorder = null;
+      this.failRecorderStart(error);
       return;
     }
     this.recorder.addEventListener("dataavailable", (event) => {
@@ -459,6 +458,13 @@ export class AgentVoiceClient {
     });
     this.recorder.start(RECORDER_TIMESLICE_MS);
     this.handlers.onStatus?.("listening");
+  }
+
+  private failRecorderStart(error: unknown): void {
+    this.processingUtterance = false;
+    this.stopNativeRecognition(true);
+    this.handlers.onError?.(getAgentVoiceStartErrorMessage(error));
+    void this.stop();
   }
 
   private stopRecorder(submit: boolean): void {

--- a/hushh-webapp/scripts/testing/verify-signed-in-routes.mjs
+++ b/hushh-webapp/scripts/testing/verify-signed-in-routes.mjs
@@ -57,8 +57,10 @@ const VIEWPORTS = [
 ];
 const NAVIGATION_TIMEOUT_MS = 120000;
 const CLIENT_NAVIGATION_CONTEXT_KEY = "__hushhSignedInRouteContextProbe";
+const INTERNAL_APP_NAVIGATION_REQUEST_EVENT = "app-internal-navigation-requested";
 const REVIEWER_BOOTSTRAP_ROUTE = "/ria";
 const SAME_SESSION_SHELL_ROUTES = new Set([
+  "/agent",
   "/profile",
   "/profile/pkm-agent-lab",
   "/one/kyc",
@@ -746,6 +748,18 @@ async function openRiaWorkspace(page) {
 
 async function navigateViaShell(page, spec) {
   switch (spec.route) {
+    case "/agent":
+      await page.evaluate((eventName) => {
+        window.dispatchEvent(
+          new CustomEvent(eventName, {
+            detail: {
+              href: "/agent",
+              scroll: false,
+            },
+          })
+        );
+      }, INTERNAL_APP_NAVIGATION_REQUEST_EVENT);
+      return true;
     case "/ria":
       await ensurePersona(page, "ria");
       await clickBottomNav(page, "Home");


### PR DESCRIPTION
## Summary
- Fix Agent section mobile/tablet UX regressions around minimize behavior, history drawer modality/focus, Focus Timer focus leakage, signed-out actions, and route surface mapping.
- Harden Agent voice/text client behavior for malformed SSE, MediaRecorder startup failure, proxy timeout handling, upstream abort propagation, and backend Gemini STT/TTS timeouts.
- Add focused regression coverage and env/docs updates for Agent voice timeout and route verification contracts.

## Validation
- GitHub PR Validation passed on corrected head `e041bf55`.
- Passing GitHub jobs: Secret Scan, DCO, PR Base Policy, Governance, Path filters, Upstream Sync, Base Freshness Gate, Web (Next.js), Protocol (Python), Integration, and CI Status Gate.
- Local publish-time secret hygiene passed: `gitleaks protect --staged --redact --no-banner`.

## Branch policy note
- Normal feature/fix work must target `integration/pr-train`; direct feature PRs into `main` are blocked by repo policy.
- This PR is now based on `integration/pr-train`, with one signed-off feature commit on top of the train branch.
- Promotion to `main` should happen through the repo train promotion flow.

## Notes
- Corrected PR head: `e041bf55`.
- Backup of the previous main-based local head was preserved locally as `backup/kai-voice-level3-main-based-c32e36ef`.
- The local 260 MB backup archive `2026-05-11T14-17-37.738Z-openclaw-backup.tar.gz` was intentionally not committed.
