### PR TITLE
test(utils): verify normalizeInternalAppHref returns long repeated internal route strings unchanged

### DIFF
--- a/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
+++ b/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
@@ -11,8 +11,8 @@ describe("consent sheet route helpers", () => {
     expect(normalizeInternalAppHref("/consents?tab=pending")).toBe("/consents?tab=pending");
   });
 
-  it("stabilizes processing evaluations when processing internal application route strings that reach extreme length character thresholds", () => {
-    const longPathStr = `/consents/${"subpath/".repeat(50)}`;
+  it("preserves long repeated consent review route strings unchanged", () => {
+    const longPathStr = `/consents/${"review/".repeat(50)}request_req_123`;
 
     expect(normalizeInternalAppHref(longPathStr)).toBe(longPathStr);
   });

--- a/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
+++ b/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
@@ -11,6 +11,12 @@ describe("consent sheet route helpers", () => {
     expect(normalizeInternalAppHref("/consents?tab=pending")).toBe("/consents?tab=pending");
   });
 
+  it("stabilizes processing evaluations when processing internal application route strings that reach extreme length character thresholds", () => {
+    const longPathStr = `/consents/${"subpath/".repeat(50)}`;
+
+    expect(normalizeInternalAppHref(longPathStr)).toBe(longPathStr);
+  });
+
   it("normalizes absolute localhost consent links to relative app routes", () => {
     expect(
       normalizeInternalAppHref("http://localhost:3000/consents?tab=pending&requestId=req_123")


### PR DESCRIPTION
## Summary
Narrows the long internal route normalization coverage for `normalizeInternalAppHref` by attaching it to consent review route preservation. The test now models a deep repeated `/consents/review/...` route and proves the existing helper keeps that internal review path unchanged instead of treating it as an external or malformed route.

## Concrete Attachment Plan
- Canonical app surface: `hushh-webapp`
- Production helper under test: `hushh-webapp/lib/consent/consent-sheet-route.ts`
- Production route contract: internal consent review routes under `/consents/*`
- Production callers: `hushh-webapp/components/consent/notification-provider.tsx` and `hushh-webapp/lib/notifications/fcm-service.ts`
- Test contract: `hushh-webapp/__tests__/utils/consent-sheet-route.test.ts`

## Why This Is Safe
- Test-only follow-up; no runtime code changes.
- Exercises the existing production helper directly.
- Keeps coverage inside the existing consent route helper contract test instead of adding a parallel test surface.
- Proves long repeated `/consents/review/*` paths remain stable for internal consent review navigation.

## Validation
- `npm run test:ci -- __tests__/utils/consent-sheet-route.test.ts` passed: 27 tests.
- `npm run typecheck` passed.
- `npm run verify:docs` passed.
- `npm run verify:service-boundary` passed.
- `npm run verify:routes` was attempted locally but is blocked by missing maintainer-only `REVIEWER_UID` and `REVIEWER_VAULT_PASSPHRASE`; the required GitHub CI Status Gate is the authoritative rerun for this branch.