### PR TITLE
test(utils): verify resolveConsentRequestHref omits explicit undefined option keys from fallback hrefs

### DIFF
--- a/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
+++ b/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
@@ -47,14 +47,16 @@ describe("consent sheet route helpers", () => {
     ).toBe("/consents?tab=pending&requestId=req_123&from=%2Fkai%2Fanalysis%3Ftab%3Dhistory");
   });
 
-  it("handles structural reference calculations safely when options contain explicit unassigned key properties", () => {
-    const result = resolveConsentRequestHref(null, "pending", {
+  it("omits undefined notification identifiers from consent fallback hrefs", () => {
+    const fallbackHref = resolveConsentRequestHref(null, "pending", {
       requestId: undefined,
       bundleId: undefined,
       from: "/kai/analysis",
     });
 
-    expect(result).toBe("/consents?tab=pending&from=%2Fkai%2Fanalysis");
+    expect(fallbackHref).toBe("/consents?tab=pending&from=%2Fkai%2Fanalysis");
+    expect(fallbackHref).not.toContain("requestId");
+    expect(fallbackHref).not.toContain("bundleId");
   });
 
   it("classifies internal consent links as SPA routes", () => {

--- a/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
+++ b/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
@@ -47,6 +47,16 @@ describe("consent sheet route helpers", () => {
     ).toBe("/consents?tab=pending&requestId=req_123&from=%2Fkai%2Fanalysis%3Ftab%3Dhistory");
   });
 
+  it("handles structural reference calculations safely when options contain explicit unassigned key properties", () => {
+    const result = resolveConsentRequestHref(null, "pending", {
+      requestId: undefined,
+      bundleId: undefined,
+      from: "/kai/analysis",
+    });
+
+    expect(result).toBe("/consents?tab=pending&from=%2Fkai%2Fanalysis");
+  });
+
   it("classifies internal consent links as SPA routes", () => {
     expect(
       resolveConsentNavigationTarget("http://localhost:3000/consents?tab=pending&requestId=req_123")


### PR DESCRIPTION
## Summary
Narrows the undefined option-key coverage for `resolveConsentRequestHref` by attaching it to consent notification fallback route construction. The test now models the production shape where notification data may omit `request_id` and `bundle_id`, proving those absent identifiers are not serialized as literal query keys while the safe internal `from` route is preserved.

## Concrete Attachment Plan
- Canonical app surface: `hushh-webapp`
- Production helper under test: `hushh-webapp/lib/consent/consent-sheet-route.ts`
- Production callers: `hushh-webapp/components/consent/notification-provider.tsx` and `hushh-webapp/lib/notifications/fcm-service.ts`
- Runtime behavior protected: consent notification fallback hrefs when optional request/bundle identifiers are absent
- Test contract: `hushh-webapp/__tests__/utils/consent-sheet-route.test.ts`

## Why This Is Safe
- Test-only follow-up; no runtime code changes.
- Exercises the existing production helper directly.
- Keeps coverage inside the existing consent route helper contract test instead of adding a parallel test surface.
- Proves fallback hrefs omit `requestId` and `bundleId` when notification-derived identifiers are undefined.

## Validation
- `npm run test:ci -- __tests__/utils/consent-sheet-route.test.ts` passed: 27 tests.
- `npm run typecheck` passed.
- `npm run verify:docs` passed.
- `npm run verify:service-boundary` passed.
- `npm run verify:routes` was attempted locally but is blocked by missing maintainer-only `REVIEWER_UID` and `REVIEWER_VAULT_PASSPHRASE`; the required GitHub CI Status Gate is the authoritative rerun for this branch.