### PR TITLE
test(utils): verify normalizeInternalAppHref returns internal anchor hash route strings unchanged

### DIFF
--- a/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
+++ b/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
@@ -11,7 +11,7 @@ describe("consent sheet route helpers", () => {
     expect(normalizeInternalAppHref("/consents?tab=pending")).toBe("/consents?tab=pending");
   });
 
-  it("processes internal target string records properly when the input string ends with a standard trailing numerical anchor hash segment", () => {
+  it("preserves consent callback anchor hashes used as internal review return routes", () => {
     const anchorInputString = "/consents/callback#id=44";
 
     expect(normalizeInternalAppHref(anchorInputString)).toBe(anchorInputString);

--- a/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
+++ b/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
@@ -11,6 +11,12 @@ describe("consent sheet route helpers", () => {
     expect(normalizeInternalAppHref("/consents?tab=pending")).toBe("/consents?tab=pending");
   });
 
+  it("processes internal target string records properly when the input string ends with a standard trailing numerical anchor hash segment", () => {
+    const anchorInputString = "/consents/callback#id=44";
+
+    expect(normalizeInternalAppHref(anchorInputString)).toBe(anchorInputString);
+  });
+
   it("normalizes absolute localhost consent links to relative app routes", () => {
     expect(
       normalizeInternalAppHref("http://localhost:3000/consents?tab=pending&requestId=req_123")


### PR DESCRIPTION
## Summary
Narrows the anchor-hash normalization coverage for `normalizeInternalAppHref` by attaching it to consent review return-route handling. The test keeps the existing production helper assertion but names the real route contract: internal consent callback hashes must remain unchanged when they are used as safe in-app return targets.

## Concrete Attachment Plan
- Canonical app surface: `hushh-webapp`
- Production helper under test: `hushh-webapp/lib/consent/consent-sheet-route.ts`
- Production route contract: internal consent callback/return routes under `/consents/*`
- Production caller path: `resolveConsentRequestHref` / `resolveConsentNavigationTarget`, used by `hushh-webapp/components/consent/notification-provider.tsx` and `hushh-webapp/lib/notifications/fcm-service.ts`
- Test contract: `hushh-webapp/__tests__/utils/consent-sheet-route.test.ts`

## Why This Is Safe
- Test-only follow-up; no runtime code changes.
- Exercises the existing production helper directly.
- Keeps coverage inside the existing consent route helper contract test instead of adding a parallel test surface.
- Proves internal `/consents/*` callback hash routes remain stable for review/return navigation.

## Validation
- `npm run test:ci -- __tests__/utils/consent-sheet-route.test.ts` passed: 27 tests.
- `npm run typecheck` passed.
- `npm run verify:docs` passed.
- `npm run verify:service-boundary` passed.
- `npm run verify:routes` was attempted locally but is blocked by missing maintainer-only `REVIEWER_UID` and `REVIEWER_VAULT_PASSPHRASE`; the required GitHub CI Status Gate is the authoritative rerun for this branch.