### PR TITLE
test(consent): verify resolveConsentNavigationTarget preserves hyphenated token query hrefs

### DIFF
--- a/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
+++ b/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
@@ -57,6 +57,17 @@ describe("consent sheet route helpers", () => {
     });
   });
 
+  it("evaluates internal routing properties properly when query parameter strings incorporate nested hyphenated token sequences", () => {
+    const hyphenatedQueryInput = "/consents/target?token=auth-session-guid-verification-101";
+    const result = resolveConsentNavigationTarget(hyphenatedQueryInput);
+
+    expect(result).toEqual({
+      kind: "internal",
+      href: hyphenatedQueryInput,
+      pathname: "/consents/target",
+    });
+  });
+
   it("classifies Email Helper workflow links as SPA routes", () => {
     expect(
       resolveConsentNavigationTarget("http://localhost:3000/one/kyc?workflowId=wf_123")

--- a/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
+++ b/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
@@ -57,13 +57,17 @@ describe("consent sheet route helpers", () => {
     });
   });
 
-  it("evaluates internal routing properties properly when query parameter strings incorporate nested hyphenated token sequences", () => {
-    const hyphenatedQueryInput = "/consents/target?token=auth-session-guid-verification-101";
-    const result = resolveConsentNavigationTarget(hyphenatedQueryInput);
+  it("preserves hyphenated token query hrefs from consent notification review targets", () => {
+    const notificationReviewHref = "/consents/target?token=auth-session-guid-verification-101";
+    const result = resolveConsentNavigationTarget(notificationReviewHref, "pending", {
+      requestId: "req_123",
+      bundleId: "bundle_456",
+      from: "/kai/analysis?tab=history",
+    });
 
     expect(result).toEqual({
       kind: "internal",
-      href: hyphenatedQueryInput,
+      href: notificationReviewHref,
       pathname: "/consents/target",
     });
   });


### PR DESCRIPTION
## Summary
Narrows the hyphenated token query coverage for `resolveConsentNavigationTarget` by attaching it to consent notification review URL resolution. The test now models the raw review href shape accepted by `notification-provider.tsx` and `fcm-service.ts`, passing the same fallback options (`requestId`, `bundleId`, `from`) while asserting the hyphenated token query is preserved in the internal SPA target.

## Concrete Attachment Plan
- Canonical app surface: `hushh-webapp`
- Production helper under test: `hushh-webapp/lib/consent/consent-sheet-route.ts`
- Production callers: `hushh-webapp/components/consent/notification-provider.tsx` and `hushh-webapp/lib/notifications/fcm-service.ts`
- Test contract: `hushh-webapp/__tests__/utils/consent-sheet-route.test.ts`

## Why This Is Safe
- Test-only follow-up; no runtime code changes.
- Exercises the existing production helper directly.
- Keeps coverage inside the existing consent route helper contract test instead of adding a parallel test surface.
- Proves hyphenated token query values survive the same navigation target resolution used by consent review notifications.

## Validation
- `npm run test:ci -- __tests__/utils/consent-sheet-route.test.ts` passed: 27 tests.
- `npm run typecheck` passed.
- `npm run verify:docs` passed.
- `npm run verify:service-boundary` passed.
- `npm run verify:routes` was attempted locally but is blocked by missing maintainer-only `REVIEWER_UID` and `REVIEWER_VAULT_PASSPHRASE`; the required GitHub CI Status Gate is the authoritative rerun for this branch.