### PR TITLE
fix(kai): polish UAT shell and onboarding styling

### DIFF
--- a/hushh-webapp/__tests__/components/agent-popover-provider.test.tsx
+++ b/hushh-webapp/__tests__/components/agent-popover-provider.test.tsx
@@ -130,7 +130,8 @@ describe("AgentPopoverProvider floating trigger", () => {
       expect(trigger.style.left).toBe("366px");
       expect(trigger.style.top).toBe("660px");
     });
-    expect(trigger.className).toContain("bg-primary");
+    expect(trigger.className).toContain("bg-white/92");
+    expect(trigger.className).toContain("dark:bg-[#1c1c1e]/90");
   });
 
   it("does not allow dragging the trigger into the command bar", async () => {

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1327,6 +1327,10 @@ md-ripple.morphy-md-ripple {
 
 .kai-bottom-nav-pill [role="radio"] {
   color: rgb(60 60 67 / 0.78) !important;
+  min-height: 48px;
+  gap: 0.24rem !important;
+  padding: 0.4rem 0.25rem 0.44rem !important;
+  letter-spacing: 0;
 }
 
 .dark .kai-bottom-nav-pill [role="radio"] {
@@ -1335,7 +1339,7 @@ md-ripple.morphy-md-ripple {
 
 .kai-bottom-nav-pill [role="radio"][aria-checked="true"] {
   color: rgb(0 113 227) !important;
-  font-weight: 700;
+  font-weight: 600;
 }
 
 .dark .kai-bottom-nav-pill [role="radio"][aria-checked="true"] {
@@ -1343,7 +1347,28 @@ md-ripple.morphy-md-ripple {
 }
 
 .kai-bottom-nav-pill [role="radio"] svg {
-  stroke-width: 2.35;
+  width: 18px;
+  height: 18px;
+  opacity: 0.9;
+  stroke-width: 1.9;
+}
+
+.kai-bottom-nav-pill [role="radio"][aria-checked="true"] svg {
+  opacity: 1;
+  stroke-width: 2;
+}
+
+.kai-bottom-nav-pill [role="radio"] > span:last-of-type {
+  max-width: 100%;
+  font-size: 10px;
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: 0;
+  text-wrap: nowrap;
+}
+
+.kai-bottom-nav-pill [role="radio"][aria-checked="true"] > span:last-of-type {
+  font-weight: 600;
 }
 
 .kai-bottom-search-action {

--- a/hushh-webapp/app/kai/onboarding/page.tsx
+++ b/hushh-webapp/app/kai/onboarding/page.tsx
@@ -307,7 +307,7 @@ function KaiOnboardingPageContent() {
     return (
       <div
         data-top-content-anchor="true"
-        className="mx-auto flex min-h-[calc(100dvh_-_var(--top-content-pad))] w-full max-w-6xl items-start px-5 pb-8 pt-[calc(var(--top-content-pad)_+_1rem)] sm:px-6 lg:px-[var(--page-inline-gutter-standard)]"
+        className="mx-auto flex min-h-[calc(100dvh_-_var(--top-content-pad))] w-full max-w-5xl items-start px-5 pb-8 pt-[calc(var(--top-content-pad)_+_1rem)] sm:px-6 lg:px-[var(--page-inline-gutter-standard)]"
       >
         <NativeTestBeacon
           routeId="/kai/onboarding"
@@ -315,21 +315,21 @@ function KaiOnboardingPageContent() {
           authState={user ? "authenticated" : "pending"}
           dataState="loaded"
         />
-        <div className="w-full space-y-6">
-          <div className="text-center space-y-3">
-            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-primary/80">
+        <div className="w-full space-y-9">
+          <div className="space-y-3 text-center">
+            <p className="text-[12px] font-semibold uppercase tracking-[0.22em] text-primary/75">
               Choose your starting path
             </p>
-            <h1 className="text-3xl font-semibold tracking-tight text-foreground">
+            <h1 className="text-[38px] font-medium leading-[1.05] tracking-normal text-foreground sm:text-[40px]">
               Start as an investor or set up RIA first
             </h1>
-            <p className="mx-auto max-w-2xl text-sm leading-7 text-muted-foreground">
+            <p className="mx-auto max-w-[36rem] text-[17px] leading-[1.45] text-muted-foreground sm:text-[18px]">
               You can add the other profile later from Profile. This choice only sets the first
               workflow we open right now.
             </p>
           </div>
 
-          <div className="grid gap-4 md:grid-cols-2">
+          <div className="grid items-stretch gap-4 md:grid-cols-2">
             <Card
               preset="hero"
               variant="none"
@@ -364,18 +364,21 @@ function KaiOnboardingPageContent() {
                     setSaving(false);
                   }
                 }}
-                className="w-full p-6 text-left"
+                className="flex min-h-[210px] w-full flex-col p-6 text-left sm:p-7"
               >
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary/80">
+                <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-primary/75">
                   Investor
                 </p>
-                <h2 className="mt-3 text-2xl font-semibold text-foreground">
-                  Build your Kai profile first
+                <h2 className="mt-3 text-[24px] font-medium leading-[1.12] tracking-normal text-foreground">
+                  Continue as Investor
                 </h2>
-                <p className="mt-3 text-sm leading-7 text-muted-foreground">
+                <p className="mt-3 text-[15px] leading-[1.55] text-muted-foreground">
                   Answer your risk and preference questions, then connect accounts and start using
                   Kai.
                 </p>
+                <span className="mt-auto pt-6 text-[14px] font-medium text-primary">
+                  Open investor setup
+                </span>
               </button>
             </Card>
 
@@ -411,15 +414,15 @@ function KaiOnboardingPageContent() {
                     setSaving(false);
                   }
                 }}
-                className="w-full p-6 text-left disabled:cursor-not-allowed"
+                className="flex min-h-[210px] w-full flex-col p-6 text-left disabled:cursor-not-allowed sm:p-7"
               >
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary/80">
+                <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-primary/75">
                   RIA
                 </p>
-                <h2 className="mt-3 text-2xl font-semibold text-foreground">
-                  Verify the advisor workspace
+                <h2 className="mt-3 text-[24px] font-medium leading-[1.12] tracking-normal text-foreground">
+                  Continue as RIA
                 </h2>
-                <p className="mt-3 text-sm leading-7 text-muted-foreground">
+                <p className="mt-3 text-[15px] leading-[1.55] text-muted-foreground">
                   Set up your advisor identity, verification, firm details, and marketplace trust
                   profile before sending consent requests.
                 </p>
@@ -428,6 +431,9 @@ function KaiOnboardingPageContent() {
                     RIA mode is unavailable in this environment until IAM is active.
                   </p>
                 ) : null}
+                <span className="mt-auto pt-6 text-[14px] font-medium text-primary">
+                  Open advisor setup
+                </span>
               </button>
             </Card>
           </div>

--- a/hushh-webapp/app/register-phone/page.tsx
+++ b/hushh-webapp/app/register-phone/page.tsx
@@ -126,11 +126,11 @@ function PhoneMandatePageContent() {
         dataState="loaded"
       />
       <div className="mx-auto w-full max-w-[28rem]">
-        <div className="space-y-2.5 text-center">
-          <h1 className="mx-auto max-w-[23rem] text-[34px] font-medium leading-[1.06] tracking-normal text-foreground sm:text-[40px]">
+        <div className="space-y-3 text-center">
+          <h1 className="mx-auto max-w-[23rem] text-[38px] font-medium leading-[1.05] tracking-normal text-[#1d1d1f] sm:text-[40px] dark:text-[#f5f5f7]">
             Verify your phone number
           </h1>
-          <p className="mx-auto max-w-sm text-[17px] leading-[1.42] text-muted-foreground">
+          <p className="mx-auto max-w-sm text-[17px] font-normal leading-[1.42] tracking-normal text-[rgba(0,0,0,0.56)] sm:text-[18px] dark:text-[rgba(245,245,247,0.60)]">
             Add your phone number to continue.
           </p>
         </div>
@@ -142,7 +142,7 @@ function PhoneMandatePageContent() {
           onCompleted={continueToNextRoute}
           onContinueExisting={continueToNextRoute}
           confirmLabel="Verify and continue"
-          className="mt-10 min-h-[25rem] gap-5"
+          className="mt-9 min-h-[25rem] gap-5"
         />
 
         <div id="recaptcha-container" className="mt-6 min-h-0" />

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -284,14 +284,14 @@ function AgentWelcomePanel({
   return (
     <section className="flex min-h-[clamp(18rem,45vh,32rem)] flex-col justify-center py-6 sm:py-10">
       <div className="mx-auto w-full max-w-2xl">
-        <div className="mb-7 inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.04] px-3 py-1.5 text-xs font-medium text-zinc-400">
+        <div className="mb-7 inline-flex items-center gap-2 rounded-full border border-black/10 bg-black/[0.035] px-3 py-1.5 text-xs font-medium text-[rgba(0,0,0,0.56)] dark:border-white/10 dark:bg-white/[0.04] dark:text-zinc-400">
           <Sparkles className="h-3.5 w-3.5 text-primary" />
           Kai workspace
         </div>
-        <h2 className="text-4xl font-semibold tracking-normal text-zinc-50 sm:text-5xl">
+        <h2 className="text-4xl font-medium tracking-normal text-[#1d1d1f] sm:text-5xl dark:text-zinc-50">
           Hi {name}
         </h2>
-        <p className="mt-3 max-w-xl text-base leading-7 text-zinc-400 sm:text-lg">
+        <p className="mt-3 max-w-xl text-base leading-7 text-[rgba(0,0,0,0.56)] sm:text-lg dark:text-zinc-400">
           Ask Agent about your markets, portfolio, memories, or Hushh workflows.
         </p>
         <div className="mt-8 grid gap-3 sm:grid-cols-3">
@@ -301,7 +301,7 @@ function AgentWelcomePanel({
               type="button"
               disabled={disabled}
               onClick={() => onPromptSelect(prompt)}
-              className="group min-h-24 rounded-xl border border-white/10 bg-white/[0.035] p-4 text-left text-sm font-medium text-zinc-200 transition hover:border-primary/40 hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-50"
+              className="group min-h-24 rounded-xl border border-black/10 bg-white/80 p-4 text-left text-sm font-medium text-[#1d1d1f] shadow-sm shadow-black/[0.03] transition hover:border-primary/40 hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-50 dark:border-white/10 dark:bg-white/[0.035] dark:text-zinc-200 dark:hover:bg-white/[0.06]"
             >
               <span className="block leading-5">{prompt}</span>
               <span className="mt-4 block h-px w-10 bg-primary/50 transition group-hover:w-14" />
@@ -529,7 +529,7 @@ function AgentBubble({
       )}
     >
       {!isUser ? (
-        <div className="mt-1 hidden h-7 w-7 shrink-0 place-items-center rounded-md border border-white/10 bg-white/[0.04] text-zinc-300 sm:grid">
+        <div className="mt-1 hidden h-7 w-7 shrink-0 place-items-center rounded-md border border-black/10 bg-black/[0.035] text-[rgba(0,0,0,0.58)] sm:grid dark:border-white/10 dark:bg-white/[0.04] dark:text-zinc-300">
           <Bot className="h-3.5 w-3.5" />
         </div>
       ) : null}
@@ -545,7 +545,7 @@ function AgentBubble({
             "text-sm leading-6",
             isUser
               ? "rounded-2xl bg-primary px-4 py-2.5 text-primary-foreground shadow-sm shadow-primary/10"
-              : "px-0 py-1 text-zinc-200",
+              : "px-0 py-1 text-[#1d1d1f] dark:text-zinc-200",
             isError &&
               "rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-2.5 text-destructive"
           )}
@@ -568,7 +568,7 @@ function AgentBubble({
         </div>
         <div
           className={cn(
-            "mt-1 flex items-center gap-2 text-[11px] text-zinc-500",
+            "mt-1 flex items-center gap-2 text-[11px] text-[rgba(0,0,0,0.46)] dark:text-zinc-500",
             isUser && "justify-end text-right"
           )}
         >
@@ -578,7 +578,7 @@ function AgentBubble({
               <button
                 type="button"
                 onClick={handleCopy}
-                className="grid h-7 w-7 place-items-center rounded-md border border-transparent text-zinc-500 transition hover:border-white/10 hover:bg-white/[0.06] hover:text-zinc-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+                className="grid h-7 w-7 place-items-center rounded-md border border-transparent text-[rgba(0,0,0,0.46)] transition hover:border-black/10 hover:bg-black/[0.04] hover:text-[#1d1d1f] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 dark:text-zinc-500 dark:hover:border-white/10 dark:hover:bg-white/[0.06] dark:hover:text-zinc-200"
                 aria-label={copied ? "Response copied" : "Copy response"}
                 title={copied ? "Copied" : "Copy response"}
               >
@@ -594,8 +594,8 @@ function AgentBubble({
                 className={cn(
                   "grid h-7 w-7 place-items-center rounded-md border transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60",
                   liked
-                    ? "border-white/15 bg-zinc-800 text-zinc-100"
-                    : "border-transparent text-zinc-500 hover:border-white/10 hover:bg-white/[0.06] hover:text-zinc-200"
+                    ? "border-black/10 bg-black/[0.06] text-[#1d1d1f] dark:border-white/15 dark:bg-zinc-800 dark:text-zinc-100"
+                    : "border-transparent text-[rgba(0,0,0,0.46)] hover:border-black/10 hover:bg-black/[0.04] hover:text-[#1d1d1f] dark:text-zinc-500 dark:hover:border-white/10 dark:hover:bg-white/[0.06] dark:hover:text-zinc-200"
                 )}
                 aria-label="Like response"
                 aria-pressed={liked}
@@ -613,8 +613,8 @@ function AgentBubble({
                 className={cn(
                   "grid h-7 w-7 place-items-center rounded-md border transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60",
                   disliked
-                    ? "border-white/15 bg-zinc-800 text-zinc-100"
-                    : "border-transparent text-zinc-500 hover:border-white/10 hover:bg-white/[0.06] hover:text-zinc-200"
+                    ? "border-black/10 bg-black/[0.06] text-[#1d1d1f] dark:border-white/15 dark:bg-zinc-800 dark:text-zinc-100"
+                    : "border-transparent text-[rgba(0,0,0,0.46)] hover:border-black/10 hover:bg-black/[0.04] hover:text-[#1d1d1f] dark:text-zinc-500 dark:hover:border-white/10 dark:hover:bg-white/[0.06] dark:hover:text-zinc-200"
                 )}
                 aria-label="Dislike response"
                 aria-pressed={disliked}
@@ -627,7 +627,7 @@ function AgentBubble({
                   type="button"
                   onClick={onRetry}
                   disabled={retryDisabled}
-                  className="ml-1 inline-flex h-7 items-center gap-1.5 rounded-md border border-transparent px-2 text-xs font-medium text-zinc-500 transition hover:border-white/10 hover:bg-white/[0.06] hover:text-zinc-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-45"
+                  className="ml-1 inline-flex h-7 items-center gap-1.5 rounded-md border border-transparent px-2 text-xs font-medium text-[rgba(0,0,0,0.46)] transition hover:border-black/10 hover:bg-black/[0.04] hover:text-[#1d1d1f] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-45 dark:text-zinc-500 dark:hover:border-white/10 dark:hover:bg-white/[0.06] dark:hover:text-zinc-200"
                   aria-label="Try again"
                   title="Try again"
                 >
@@ -640,7 +640,7 @@ function AgentBubble({
         </div>
       </div>
       {isUser ? (
-        <div className="mt-1 hidden h-7 w-7 shrink-0 place-items-center rounded-md border border-white/10 bg-white/[0.04] text-zinc-400 sm:grid">
+        <div className="mt-1 hidden h-7 w-7 shrink-0 place-items-center rounded-md border border-black/10 bg-black/[0.035] text-[rgba(0,0,0,0.56)] sm:grid dark:border-white/10 dark:bg-white/[0.04] dark:text-zinc-400">
           <UserRound className="h-3.5 w-3.5" />
         </div>
       ) : null}
@@ -2668,10 +2668,10 @@ export function AgentChatWorkspace({
   return (
     <div
       className={cn(
-        "agent-chat-workspace flex min-h-0 w-full flex-col text-zinc-100",
+        "agent-chat-workspace flex min-h-0 w-full flex-col text-[#1d1d1f] dark:text-zinc-100",
         isPopover
-          ? "h-full overflow-hidden bg-[#0d0f13]"
-          : "h-[calc(100dvh-var(--app-top-content-offset,0px)-var(--app-bottom-fixed-ui,0px)-var(--app-safe-area-bottom-effective,0px))] min-h-[420px] overflow-hidden bg-[#0b0d10]",
+          ? "h-full overflow-hidden bg-white dark:bg-[#0d0f13]"
+          : "h-[calc(100dvh-var(--app-top-content-offset,0px)-var(--app-bottom-fixed-ui,0px)-var(--app-safe-area-bottom-effective,0px))] min-h-[420px] overflow-hidden bg-white dark:bg-[#0b0d10]",
         className
       )}
       data-agent-chat-workspace={variant}
@@ -2687,7 +2687,7 @@ export function AgentChatWorkspace({
         </div>
         <div
           className={cn(
-            "fixed inset-0 z-[520] bg-black/55 backdrop-blur-sm transition-opacity duration-200 lg:hidden",
+            "fixed inset-0 z-[520] bg-black/35 backdrop-blur-sm transition-opacity duration-200 dark:bg-black/55 lg:hidden",
             isHistoryDrawerOpen ? "opacity-100" : "pointer-events-none opacity-0"
           )}
           aria-hidden="true"
@@ -2713,14 +2713,14 @@ export function AgentChatWorkspace({
 
         <section
           className={cn(
-            "relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-[#15171c]",
-            isPopover && "rounded-lg border border-white/10 shadow-sm"
+            "relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-white dark:bg-[#15171c]",
+            isPopover && "rounded-lg border border-black/10 shadow-sm dark:border-white/10"
           )}
           inert={isHistoryDrawerOpen}
         >
           <div
             className={cn(
-              "flex shrink-0 touch-pan-y items-center justify-between gap-3 border-b border-white/10 bg-[#15171c]/95 px-3 pt-[var(--app-safe-area-top-effective,0px)] backdrop-blur sm:px-5",
+              "flex shrink-0 touch-pan-y items-center justify-between gap-3 border-b border-black/10 bg-white/95 px-3 pt-[var(--app-safe-area-top-effective,0px)] backdrop-blur dark:border-white/10 dark:bg-[#15171c]/95 sm:px-5",
               isPopover
                 ? "h-14 sm:h-16"
                 : "h-[calc(3.5rem+var(--app-safe-area-top-effective,0px))] sm:h-[calc(4rem+var(--app-safe-area-top-effective,0px))]",
@@ -2733,32 +2733,34 @@ export function AgentChatWorkspace({
             }}
           >
             <div className="flex min-w-0 items-center gap-3">
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="h-9 w-9 rounded-lg text-zinc-300 hover:bg-white/[0.07] hover:text-zinc-50 focus-visible:ring-2 focus-visible:ring-primary/60 lg:hidden"
-                onClick={openHistoryDrawer}
-                aria-label="Open chat history"
-                title="Open chat history"
-              >
-                <Menu className="h-4 w-4" />
-              </Button>
-              <div className="grid h-8 w-8 shrink-0 place-items-center rounded-md border border-white/10 bg-white/[0.04] text-primary">
+              {!isPopover ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-9 w-9 rounded-lg text-[rgba(0,0,0,0.56)] hover:bg-black/[0.04] hover:text-[#1d1d1f] focus-visible:ring-2 focus-visible:ring-primary/60 dark:text-zinc-300 dark:hover:bg-white/[0.07] dark:hover:text-zinc-50 lg:hidden"
+                  onClick={openHistoryDrawer}
+                  aria-label="Open chat history"
+                  title="Open chat history"
+                >
+                  <Menu className="h-4 w-4" />
+                </Button>
+              ) : null}
+              <div className="grid h-8 w-8 shrink-0 place-items-center rounded-md border border-black/10 bg-black/[0.035] text-primary dark:border-white/10 dark:bg-white/[0.04]">
                 <Bot className="h-4 w-4" />
               </div>
               <div className="min-w-0">
-                <div className="truncate text-sm font-semibold leading-5 text-zinc-100 sm:text-base">
+                <div className="truncate text-sm font-semibold leading-5 text-[#1d1d1f] sm:text-base dark:text-zinc-100">
                   Agent
                 </div>
-                <p className="hidden truncate text-xs text-zinc-500 sm:block">
+                <p className="hidden truncate text-xs text-[rgba(0,0,0,0.46)] dark:text-zinc-500 sm:block">
                   Kai workspace
                 </p>
               </div>
             </div>
 
             <div className="flex shrink-0 items-center gap-2">
-              <span className="hidden rounded-md border border-white/10 bg-white/[0.03] px-2.5 py-1 text-xs font-medium text-zinc-400 sm:inline-flex">
+              <span className="hidden rounded-md border border-black/10 bg-black/[0.035] px-2.5 py-1 text-xs font-medium text-[rgba(0,0,0,0.56)] dark:border-white/10 dark:bg-white/[0.03] dark:text-zinc-400 sm:inline-flex">
                 {statusText}
               </span>
               {!isPopover ? (
@@ -2766,7 +2768,7 @@ export function AgentChatWorkspace({
                   type="button"
                   variant="ghost"
                   size="icon"
-                  className="h-9 w-9 rounded-lg text-zinc-300 hover:bg-white/[0.07] hover:text-zinc-50 focus-visible:ring-2 focus-visible:ring-primary/60 lg:hidden"
+                  className="h-9 w-9 rounded-lg text-[rgba(0,0,0,0.56)] hover:bg-black/[0.04] hover:text-[#1d1d1f] focus-visible:ring-2 focus-visible:ring-primary/60 dark:text-zinc-300 dark:hover:bg-white/[0.07] dark:hover:text-zinc-50 lg:hidden"
                   onClick={handlePageMinimize}
                   aria-label="Minimize Agent"
                   title="Minimize Agent"
@@ -2786,7 +2788,7 @@ export function AgentChatWorkspace({
           >
             <div className="mx-auto flex min-h-full w-full max-w-3xl flex-col gap-6">
               {accessMessage ? (
-                <div className="flex flex-col gap-3 rounded-xl border border-white/10 bg-white/[0.03] px-4 py-4 text-sm text-zinc-400 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex flex-col gap-3 rounded-xl border border-black/10 bg-black/[0.035] px-4 py-4 text-sm text-[rgba(0,0,0,0.56)] dark:border-white/10 dark:bg-white/[0.03] dark:text-zinc-400 sm:flex-row sm:items-center sm:justify-between">
                   <span>{accessMessage}</span>
                   {accessAction ? (
                     <Button
@@ -2841,10 +2843,10 @@ export function AgentChatWorkspace({
           </div>
 
           {voiceTranscriptReview ? (
-            <div className="absolute inset-0 z-20 grid place-items-end bg-black/40 p-4 backdrop-blur-[2px] sm:place-items-center">
+            <div className="absolute inset-0 z-20 grid place-items-end bg-black/25 p-4 backdrop-blur-[2px] dark:bg-black/40 sm:place-items-center">
               <div
                 ref={voiceTranscriptDialogRef}
-                className="w-full max-w-sm rounded-xl border border-white/10 bg-[#15171c] p-4 shadow-xl"
+                className="w-full max-w-sm rounded-xl border border-black/10 bg-white p-4 shadow-xl dark:border-white/10 dark:bg-[#15171c]"
                 role="dialog"
                 aria-modal="true"
                 aria-label="Confirm voice transcript"
@@ -2888,13 +2890,13 @@ export function AgentChatWorkspace({
           <form
             onSubmit={handleSubmit}
             className={cn(
-              "shrink-0 border-t border-white/10 bg-[#15171c]/95 px-3 py-3 backdrop-blur sm:px-5",
+              "shrink-0 border-t border-black/10 bg-white/95 px-3 py-3 backdrop-blur dark:border-white/10 dark:bg-[#15171c]/95 sm:px-5",
               !isPopover && "pb-[calc(0.75rem+var(--app-safe-area-bottom-effective,0px))]"
             )}
           >
             <div className="mx-auto w-full max-w-3xl">
               {voiceActive ? (
-                <div className="rounded-2xl border border-white/10 bg-[#0f1116] p-2 shadow-lg shadow-black/15">
+                <div className="rounded-2xl border border-black/10 bg-[#f5f5f7] p-2 shadow-lg shadow-black/[0.06] dark:border-white/10 dark:bg-[#0f1116] dark:shadow-black/15">
                   <AgentVoiceWaveInput
                     status={voiceState}
                     level={voiceLevel}
@@ -2907,7 +2909,7 @@ export function AgentChatWorkspace({
                   />
                 </div>
               ) : (
-                <div className="flex min-h-14 items-end gap-2 rounded-[1.5rem] border border-white/12 bg-[#0f1116] px-3 py-2 shadow-lg shadow-black/15 transition-colors focus-within:border-primary/55 focus-within:ring-2 focus-within:ring-primary/20">
+                <div className="flex min-h-14 items-end gap-2 rounded-[1.5rem] border border-black/10 bg-[#f5f5f7] px-3 py-2 shadow-lg shadow-black/[0.06] transition-colors focus-within:border-primary/55 focus-within:ring-2 focus-within:ring-primary/20 dark:border-white/12 dark:bg-[#0f1116] dark:shadow-black/15">
                   <textarea
                     ref={composerTextareaRef}
                     aria-label="Message Agent"
@@ -2925,14 +2927,14 @@ export function AgentChatWorkspace({
                     disabled={!hasChatAccess || isLoadingHistory || isVoiceConnecting}
                     placeholder="Message Agent..."
                     rows={1}
-                    className="max-h-40 min-h-8 min-w-0 flex-1 resize-none bg-transparent px-1 py-2 text-sm leading-6 text-zinc-100 outline-none placeholder:text-zinc-500 disabled:cursor-not-allowed disabled:opacity-60"
+                    className="max-h-40 min-h-8 min-w-0 flex-1 resize-none bg-transparent px-1 py-2 text-sm leading-6 text-[#1d1d1f] outline-none placeholder:text-[rgba(0,0,0,0.42)] disabled:cursor-not-allowed disabled:opacity-60 dark:text-zinc-100 dark:placeholder:text-zinc-500"
                   />
                   {agentVoiceEnabled ? (
                     <Button
                       type="button"
                       variant="ghost"
                       size="icon"
-                      className="h-9 w-9 shrink-0 rounded-xl text-zinc-400 hover:bg-white/[0.07] hover:text-zinc-100 focus-visible:ring-2 focus-visible:ring-primary/60"
+                      className="h-9 w-9 shrink-0 rounded-xl text-[rgba(0,0,0,0.50)] hover:bg-black/[0.04] hover:text-[#1d1d1f] focus-visible:ring-2 focus-visible:ring-primary/60 dark:text-zinc-400 dark:hover:bg-white/[0.07] dark:hover:text-zinc-100"
                       disabled={!canToggleVoice}
                       onClick={handleToggleVoice}
                       aria-label="Start voice mode"
@@ -2944,7 +2946,7 @@ export function AgentChatWorkspace({
                   <Button
                     type="submit"
                     size="icon"
-                    className="h-9 w-9 shrink-0 rounded-xl bg-primary text-primary-foreground shadow-sm shadow-primary/20 hover:bg-primary/90 focus-visible:ring-2 focus-visible:ring-primary/60 disabled:bg-white/[0.08] disabled:text-zinc-500 disabled:shadow-none"
+                    className="h-9 w-9 shrink-0 rounded-xl bg-primary text-primary-foreground shadow-sm shadow-primary/20 hover:bg-primary/90 focus-visible:ring-2 focus-visible:ring-primary/60 disabled:bg-black/[0.06] disabled:text-[rgba(0,0,0,0.36)] disabled:shadow-none dark:disabled:bg-white/[0.08] dark:disabled:text-zinc-500"
                     disabled={!canSend}
                     aria-label="Send message"
                   >

--- a/hushh-webapp/components/agent/agent-popover-provider.tsx
+++ b/hushh-webapp/components/agent/agent-popover-provider.tsx
@@ -534,7 +534,7 @@ function AgentPopoverSurface({ customSize, setCustomSize }: AgentPopoverSurfaceP
         >
           <section
             className={cn(
-              "pointer-events-auto fixed flex min-h-0 origin-bottom-right flex-col overflow-hidden border border-border/70 bg-background/95 shadow-2xl backdrop-blur-xl transition-[border-radius,filter,height,opacity,transform,width] duration-[360ms] ease-[cubic-bezier(0.22,1,0.36,1)] will-change-transform motion-reduce:transform-none motion-reduce:transition-none",
+              "pointer-events-auto fixed flex min-h-0 origin-bottom-right flex-col overflow-hidden border border-black/10 bg-white/95 text-[#1d1d1f] shadow-2xl backdrop-blur-xl transition-[border-radius,filter,height,opacity,transform,width] duration-[360ms] ease-[cubic-bezier(0.22,1,0.36,1)] will-change-transform motion-reduce:transform-none motion-reduce:transition-none dark:border-white/10 dark:bg-[#1c1c1e]/95 dark:text-[#f5f5f7]",
               isFullscreen
                 ? "inset-0 rounded-none"
                 : "bottom-[calc(max(var(--app-safe-area-bottom-effective),0.5rem)+0.5rem)] right-2 h-[min(var(--agent-popover-height),calc(100dvh-1rem))] w-[min(var(--agent-popover-width),calc(100vw-1rem))] rounded-lg max-sm:inset-0 max-sm:h-auto max-sm:w-auto max-sm:rounded-none sm:right-4 sm:h-[min(var(--agent-popover-height),calc(100dvh-2rem))] sm:w-[min(var(--agent-popover-width),calc(100vw-2rem))]",
@@ -594,7 +594,7 @@ function AgentPopoverSurface({ customSize, setCustomSize }: AgentPopoverSurfaceP
           type="button"
           variant="secondary"
           className={cn(
-            "fixed z-[130] h-11 touch-none select-none gap-2 rounded-full border border-primary/55 bg-primary px-4 text-primary-foreground shadow-lg shadow-primary/20 backdrop-blur-md transition-[box-shadow,opacity,transform,background-color,border-color] duration-300 ease-out hover:border-primary/70 hover:bg-primary/90 hover:text-primary-foreground focus-visible:ring-2 focus-visible:ring-primary/60 motion-reduce:transform-none motion-reduce:transition-none",
+            "fixed z-[130] h-11 touch-none select-none gap-2 rounded-full border border-black/10 bg-white/92 px-4 text-[#1d1d1f] shadow-lg shadow-black/10 backdrop-blur-md transition-[box-shadow,opacity,transform,background-color,border-color] duration-300 ease-out hover:border-black/15 hover:bg-white hover:text-[#1d1d1f] focus-visible:ring-2 focus-visible:ring-primary/60 motion-reduce:transform-none motion-reduce:transition-none dark:border-white/15 dark:bg-[#1c1c1e]/90 dark:text-[#f5f5f7] dark:shadow-black/35 dark:hover:bg-[#2c2c2e]",
             "cursor-grab active:cursor-grabbing",
             expanded && !isCollapsing
               ? "pointer-events-none translate-y-3 scale-95 opacity-0"
@@ -646,7 +646,7 @@ function AgentPopoverWindowControls({
 
   return (
     <div
-      className="hidden h-8 overflow-hidden rounded-md border border-white/10 bg-white/[0.03] sm:flex"
+      className="hidden h-8 overflow-hidden rounded-md border border-black/10 bg-black/[0.035] dark:border-white/10 dark:bg-white/[0.03] sm:flex"
       aria-label="Agent window controls"
       role="group"
     >
@@ -654,7 +654,7 @@ function AgentPopoverWindowControls({
         type="button"
         variant="ghost"
         size="icon-xs"
-        className="h-8 w-10 rounded-none text-zinc-400 hover:bg-white/[0.08] hover:text-zinc-100 focus-visible:ring-2 focus-visible:ring-primary/60"
+        className="h-8 w-10 rounded-none text-[rgba(0,0,0,0.50)] hover:bg-black/[0.05] hover:text-[#1d1d1f] focus-visible:ring-2 focus-visible:ring-primary/60 dark:text-zinc-400 dark:hover:bg-white/[0.08] dark:hover:text-zinc-100"
         onClick={onMinimize}
         aria-label="Minimize Agent"
         title="Minimize Agent"
@@ -665,7 +665,7 @@ function AgentPopoverWindowControls({
         type="button"
         variant="ghost"
         size="icon-xs"
-        className="h-8 w-10 rounded-none text-zinc-400 hover:bg-white/[0.08] hover:text-zinc-100 focus-visible:ring-2 focus-visible:ring-primary/60"
+        className="h-8 w-10 rounded-none text-[rgba(0,0,0,0.50)] hover:bg-black/[0.05] hover:text-[#1d1d1f] focus-visible:ring-2 focus-visible:ring-primary/60 dark:text-zinc-400 dark:hover:bg-white/[0.08] dark:hover:text-zinc-100"
         onClick={() => setSizeMode(isFullscreen ? "large" : "fullscreen")}
       aria-label={isFullscreen ? "Restore Agent" : "Maximize Agent"}
       title={isFullscreen ? "Restore Agent" : "Maximize Agent"}
@@ -680,7 +680,7 @@ function AgentPopoverWindowControls({
         type="button"
         variant="ghost"
         size="icon-xs"
-        className="h-8 w-10 rounded-none text-zinc-400 hover:bg-red-500/85 hover:text-white focus-visible:ring-2 focus-visible:ring-red-400/70"
+        className="h-8 w-10 rounded-none text-[rgba(0,0,0,0.50)] hover:bg-red-500/85 hover:text-white focus-visible:ring-2 focus-visible:ring-red-400/70 dark:text-zinc-400"
         onClick={onClose}
         aria-label="Close Agent"
         title="Close Agent"

--- a/hushh-webapp/components/auth/phone-verification-flow.tsx
+++ b/hushh-webapp/components/auth/phone-verification-flow.tsx
@@ -39,9 +39,9 @@ import { cn } from "@/lib/utils";
 const E164_PHONE_PATTERN = /^\+[1-9]\d{7,14}$/;
 const DEFAULT_COUNTRY_VALUE = "US";
 const FLOW_CONTROL_SHELL_CLASS_NAME =
-  "h-12 overflow-hidden rounded-[18px] border-black/10 bg-background/80 shadow-xs dark:border-white/10 dark:bg-input/30";
+  "h-12 overflow-hidden rounded-[18px] border-black/10 bg-[#f5f5f7]/92 shadow-xs dark:border-white/10 dark:bg-white/[0.08]";
 const FLOW_CONTROL_CLASS_NAME =
-  "h-full rounded-[inherit] border-0 bg-transparent px-4 text-base shadow-none focus-visible:border-transparent focus-visible:ring-0 dark:bg-transparent md:text-sm";
+  "h-full rounded-[inherit] border-0 bg-transparent px-4 text-[16px] font-normal shadow-none focus-visible:border-transparent focus-visible:ring-0 dark:bg-transparent md:text-[15px]";
 const FLOW_SURFACE_RADIUS_CLASS_NAME = "rounded-[18px]";
 
 export type PhoneVerificationFlowMode = "link" | "replace";
@@ -370,10 +370,6 @@ export function PhoneVerificationFlow({
                 open={countryComboboxOpen}
                 onOpenChange={(open) => {
                   setCountryComboboxOpen(open);
-                  if (open) {
-                    setCountryQuery("");
-                    return;
-                  }
                   setCountryQuery(
                     getCountryOptionLabel(selectedCountryOption ?? COUNTRY_PHONE_OPTIONS[0]!)
                   );
@@ -392,7 +388,10 @@ export function PhoneVerificationFlow({
                       setCountryComboboxOpen(true);
                     }
                   }}
-                  onFocus={() => setCountryComboboxOpen(true)}
+                  onFocus={(event: React.FocusEvent<HTMLInputElement>) => {
+                    setCountryComboboxOpen(true);
+                    event.currentTarget.select();
+                  }}
                   className={`${FLOW_CONTROL_SHELL_CLASS_NAME} w-full`}
                   autoComplete="off"
                   autoCorrect="off"
@@ -443,7 +442,7 @@ export function PhoneVerificationFlow({
             </Field>
           </FieldGroup>
 
-          <FieldDescription className="text-[15px] font-normal leading-[1.45] text-muted-foreground">
+          <FieldDescription className="text-[15px] font-normal leading-[1.45] text-[rgba(0,0,0,0.56)] dark:text-[rgba(245,245,247,0.60)]">
             {helperText ||
               "Choose your country code and enter your phone number. We’ll send you a verification code."}
           </FieldDescription>
@@ -474,7 +473,7 @@ export function PhoneVerificationFlow({
       ) : (
         <>
           <div
-            className={`${FLOW_SURFACE_RADIUS_CLASS_NAME} border border-black/5 bg-neutral-50 p-5 dark:bg-neutral-900/60`}
+            className={`${FLOW_SURFACE_RADIUS_CLASS_NAME} border border-black/5 bg-[#f5f5f7]/85 p-5 dark:border-white/10 dark:bg-white/[0.08]`}
           >
             <p className={cn(kaiAppCardTitleClassName, "text-foreground")}>Verification code sent</p>
             <p className={cn(kaiAppHelperClassName, "mt-2 text-muted-foreground")}>

--- a/hushh-webapp/components/kai/kai-search-bar.tsx
+++ b/hushh-webapp/components/kai/kai-search-bar.tsx
@@ -10,7 +10,7 @@ import {
   useState,
   type MouseEvent,
 } from "react";
-import { Bot, MessageCircle, Mic, Search, X } from "lucide-react";
+import { Bot, Mic, Search, X } from "lucide-react";
 
 import {
   KaiCommandPalette,
@@ -1742,8 +1742,8 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
               </ShellActionSurface>
             </div>
           ) : (
-            <div className="relative flex h-[112px] w-full items-end justify-end">
-              <div className="ml-auto flex h-[112px] w-[58px] flex-col items-center justify-end gap-1.5">
+            <div className="relative flex h-[172px] w-full items-end justify-end">
+              <div className="ml-auto flex h-[172px] w-[58px] flex-col items-center justify-end gap-1.5">
                 <button
                   type="button"
                   className="pointer-events-auto grid h-[58px] w-[58px] place-items-center rounded-full transition-transform duration-200 ease-out hover:scale-[1.03] active:scale-[0.94] disabled:cursor-not-allowed disabled:opacity-50"
@@ -1752,9 +1752,37 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
                   onClick={() => agentPopover?.openAgent()}
                 >
                   <span className="kai-bottom-agent-action grid h-[40px] w-[40px] place-items-center rounded-[14px]">
-                    <MessageCircle className="h-[18px] w-[18px]" strokeWidth={2.15} />
+                    <Bot className="h-[18px] w-[18px]" strokeWidth={1.95} />
                   </span>
                 </button>
+                <ShellActionSurface
+                  variant="icon"
+                  wrapperClassName="pointer-events-auto"
+                  className="kai-bottom-search-action grid h-[58px] w-[58px] place-items-center text-muted-foreground"
+                  aria-label={
+                    ambientMode === "idle"
+                      ? "Start Kai voice"
+                      : "End Kai voice session"
+                  }
+                  aria-disabled={micDisabled}
+                  onClick={(event) => {
+                    if (ambientMode !== "idle") {
+                      cancelListening();
+                      return;
+                    }
+                    if (micDisabled) {
+                      toast.info(stableMicDisabledReason || "Voice is unavailable right now.");
+                      return;
+                    }
+                    handleMicTap(event);
+                  }}
+                >
+                  {ambientMode === "idle" ? (
+                    <Mic className="h-5 w-5" strokeWidth={2.05} />
+                  ) : (
+                    <X className="h-5 w-5" strokeWidth={2.05} />
+                  )}
+                </ShellActionSurface>
                 <ShellActionSurface
                   variant="icon"
                   wrapperClassName="pointer-events-auto"

--- a/hushh-webapp/components/kai/views/kai-analysis-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-analysis-preview-view.tsx
@@ -4,8 +4,8 @@ import { useMemo, useState, type ReactNode } from "react";
 import {
   BarChart3,
   Bell,
+  Bot,
   ChevronRight,
-  MessageCircle,
   Mic,
   PieChart,
   Search,
@@ -354,7 +354,7 @@ function KaiSheet({
       <div className="mx-auto mt-[9px] h-[5px] w-9 rounded-full bg-[color:var(--one-fg3)]/35" />
       <header className="flex items-center gap-[11px] border-b border-[color:var(--one-line)] px-[18px] pb-3 pt-3">
         <span className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[color:var(--one-blue)] text-white">
-          <MessageCircle className="h-4 w-4" />
+          <Bot className="h-4 w-4" />
         </span>
         <span className="min-w-0 flex-1">
           <b className="block text-[17px] font-semibold text-[color:var(--one-fg)]">Kai</b>
@@ -629,7 +629,7 @@ export function KaiAnalysisPreviewView() {
             className={cn(analysisGlassClassName, "mt-3 flex w-full items-center gap-[11px] rounded-2xl px-3.5 py-2.5 text-left transition-transform active:scale-[0.99]")}
           >
             <span className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-[color:var(--one-blue)] text-white">
-              <MessageCircle className="h-4 w-4" />
+              <Bot className="h-4 w-4" />
             </span>
             <span className="min-w-0 flex-1 text-[13px] leading-snug text-[color:var(--one-fg)]">
               <b className="font-semibold">Kai:</b> Tesla drove most of this week's gain. Concentration is your main risk - ask me for a rebalance plan.

--- a/hushh-webapp/components/kai/views/kai-connect-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-connect-preview-view.tsx
@@ -3,11 +3,11 @@
 import { useMemo, useState, type ReactNode } from "react";
 import {
   Bell,
+  Bot,
   Building2,
   Check,
   CheckCircle2,
   ChevronRight,
-  MessageCircle,
   Mic,
   Minus,
   Search,
@@ -341,7 +341,7 @@ function KaiSheet({
       <div className="mx-auto mt-[9px] h-[5px] w-9 rounded-full bg-[color:var(--one-fg3)]/35" />
       <header className="flex items-center gap-[11px] border-b border-[color:var(--one-line)] px-[18px] pb-3 pt-3">
         <span className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[color:var(--one-blue)] text-white">
-          <MessageCircle className="h-4 w-4" />
+          <Bot className="h-4 w-4" />
         </span>
         <span className="min-w-0 flex-1">
           <b className="block text-[17px] font-semibold text-[color:var(--one-fg)]">Kai</b>
@@ -710,7 +710,7 @@ export function KaiConnectPreviewView() {
             className={cn(connectGlassClassName, "mt-4 flex w-full items-center gap-[11px] rounded-2xl px-3.5 py-3 text-left transition-transform active:scale-[0.99]")}
           >
             <span className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-[color:var(--one-blue)] text-white">
-              <MessageCircle className="h-4 w-4" />
+              <Bot className="h-4 w-4" />
             </span>
             <span className="min-w-0 flex-1 text-[13px] leading-snug text-[color:var(--one-fg)]">
               <b className="font-semibold">Kai:</b> I compared all five against your portfolio - ask me why Emily fits best.

--- a/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
@@ -7,12 +7,12 @@ import {
   AlertTriangle,
   Bell,
   Blocks,
+  Bot,
   ChartColumnIncreasing,
   ChevronRight,
   Cpu,
   LineChart,
   Loader2,
-  MessageCircle,
   Mic,
   Newspaper,
   Percent,
@@ -852,7 +852,7 @@ function OneMarketKaiSheet({
       <div className="mx-auto mt-2.5 h-[5px] w-9 rounded-full bg-[color:var(--one-fg3)] opacity-35" />
       <header className="flex items-center gap-3 border-b border-[color:var(--one-line)] px-[18px] pb-3 pt-3">
         <span className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[color:var(--one-blue)] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.30)]">
-          <MessageCircle className="h-4 w-4" />
+          <Bot className="h-4 w-4" />
         </span>
         <span className="min-w-0 flex-1">
           <b className="block text-[17px] font-semibold text-[color:var(--one-fg)]">Kai</b>
@@ -2126,7 +2126,7 @@ export function KaiMarketPreviewView() {
             className={cn(oneMarketGlassClassName, "mt-[22px] flex w-full items-center gap-[11px] rounded-2xl px-4 py-3.5 text-left transition-transform active:scale-[0.99]")}
           >
             <span className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-[color:var(--one-blue)] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.30)]">
-              <MessageCircle className="h-4 w-4" />
+              <Bot className="h-4 w-4" />
             </span>
             <span className="min-w-0 flex-1 text-[13px] leading-snug text-[color:var(--one-fg)]">
               <b className="font-semibold">Kai:</b> {kaiStripText}

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -6,14 +6,14 @@
 import React, { useEffect, useMemo, type CSSProperties } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import {
-  BriefcaseBusiness,
+  ChartSpline,
   Compass,
   FileSpreadsheet,
-  LayoutDashboard,
-  LineChart,
-  Store,
-  User,
+  House,
+  Landmark,
+  UserRound,
   Users,
+  WalletCards,
 } from "lucide-react";
 
 import { useAuth } from "@/hooks/use-auth";
@@ -91,6 +91,7 @@ export const Navbar = () => {
     }
   }, [pathname]);
   const hideNavbar =
+    pathname?.startsWith(ROUTES.PHONE_MANDATE) ||
     pathname?.startsWith(ROUTES.LABS_PROFILE_APPEARANCE) ||
     pathname === ROUTES.DEVELOPERS;
 
@@ -101,7 +102,7 @@ export const Navbar = () => {
             {
               value: "home",
               label: "Home",
-              icon: BriefcaseBusiness,
+              icon: House,
               dataTourId: "nav-ria-home",
             },
             {
@@ -125,7 +126,7 @@ export const Navbar = () => {
             {
               value: "profile",
               label: "Profile",
-              icon: User,
+              icon: UserRound,
               badge: pendingConsents > 0 ? pendingConsents : undefined,
               dataTourId: "nav-profile",
             },
@@ -134,19 +135,19 @@ export const Navbar = () => {
             {
               value: "market",
               label: "Market",
-              icon: Store,
+              icon: Landmark,
               dataTourId: "nav-market",
             },
             {
               value: "dashboard",
               label: "Portfolio",
-              icon: LayoutDashboard,
+              icon: WalletCards,
               dataTourId: "nav-portfolio",
             },
             {
               value: "analysis",
               label: "Analysis",
-              icon: LineChart,
+              icon: ChartSpline,
               dataTourId: "nav-analysis",
             },
             {
@@ -158,7 +159,7 @@ export const Navbar = () => {
             {
               value: "profile",
               label: "Profile",
-              icon: User,
+              icon: UserRound,
               badge: pendingConsents > 0 ? pendingConsents : undefined,
               dataTourId: "nav-profile",
             },

--- a/hushh-webapp/components/onboarding/AuthStep.tsx
+++ b/hushh-webapp/components/onboarding/AuthStep.tsx
@@ -557,19 +557,20 @@ export function AuthStep({
           <Image
             src="/one-quiet-emoji.png"
             alt="One"
-            width={compact ? 52 : 58}
-            height={compact ? 52 : 58}
+            width={52}
+            height={52}
             priority
-            className="mx-auto h-[52px] w-[52px] object-contain drop-shadow-[0_14px_28px_rgba(0,0,0,0.08)] sm:h-[58px] sm:w-[58px]"
+            className="mx-auto h-[52px] w-[52px] object-contain drop-shadow-[0_14px_28px_rgba(0,0,0,0.08)]"
           />
           <div
             role="heading"
             aria-level={1}
-            className="mt-2.5 text-[36px] font-medium leading-[1.06] tracking-normal text-[#1d1d1f] sm:text-[42px] dark:text-[#f5f5f7]"
+            aria-label="Sign in to One"
+            className="mt-2.5 text-[38px] font-medium leading-[1.05] tracking-normal text-[#1d1d1f] sm:text-[40px] dark:text-[#f5f5f7]"
           >
             Sign in to One.
           </div>
-          <p className="mx-auto mt-3 max-w-[20rem] text-[16px] font-normal leading-[1.45] tracking-normal text-[#6e6e73] sm:text-[17px] dark:text-[#a1a1a6]">
+          <p className="mx-auto mt-3 max-w-[20rem] text-[17px] font-normal leading-[1.42] tracking-normal text-[rgba(0,0,0,0.56)] sm:text-[18px] dark:text-[rgba(245,245,247,0.60)]">
             Continue to your personal financial advisor.
           </p>
         </header>

--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -95,7 +95,7 @@ export function IntroStep({
             unoptimized
             aria-hidden="true"
             draggable={false}
-            className="relative h-[58px] w-[58px] select-none object-contain"
+            className="relative h-[52px] w-[52px] select-none object-contain"
           />
 
           <div
@@ -113,9 +113,12 @@ export function IntroStep({
 
         <div className="flex min-h-0 flex-1 items-center py-6">
           <div className="relative w-full">
-            <div className="relative z-10 mx-auto flex w-full max-w-[340px] flex-col gap-5">
+            <div className="relative z-10 mx-auto flex w-full max-w-[340px] flex-col gap-4">
               {INTRO_FEATURES.map((feature) => (
-                <div key={feature.title} className="grid grid-cols-[48px_minmax(0,1fr)] items-center gap-4">
+                <div
+                  key={feature.title}
+                  className="grid min-h-[64px] grid-cols-[48px_minmax(0,1fr)] items-center gap-4 rounded-[22px]"
+                >
                   <span
                     className={`grid h-12 w-12 place-items-center rounded-full border border-black/[0.04] dark:border-white/10 ${feature.tileClassName}`}
                   >

--- a/hushh-webapp/lib/navigation/kai-chrome-state.ts
+++ b/hushh-webapp/lib/navigation/kai-chrome-state.ts
@@ -37,6 +37,7 @@ export function getKaiChromeState(
     useOnboardingChrome ||
     path === ROUTES.HOME ||
     path.startsWith(ROUTES.LOGIN) ||
+    path.startsWith(ROUTES.PHONE_MANDATE) ||
     path.startsWith(ROUTES.LOGOUT) ||
     path.startsWith(ROUTES.LABS_PROFILE_APPEARANCE) ||
     isRiaOnboardingRoute(path);


### PR DESCRIPTION
## Summary
- Align Meet One, sign-in, phone verification, and persona onboarding typography with the premium One/Kai hierarchy
- Restore visible Agent / Voice / Search bottom actions without changing existing handlers or routes
- Make Agent surfaces and bottom chrome light/dark mode aware, and hide bottom chrome on phone verification

## Verification
- cd hushh-webapp && npm run typecheck
- cd hushh-webapp && npm run lint
- cd hushh-webapp && npm run verify:design-system
- cd hushh-webapp && npm run verify:cache
- cd hushh-webapp && npm run verify:docs
- cd hushh-webapp && npm run build

Direct push to main was attempted and blocked by repo rules requiring merge queue and CI Status Gate, so this PR is the governed landing path.