### PR TITLE
test(consent): verify resolveConsentNavigationTarget preserves bracket array query hrefs

### DIFF
--- a/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
+++ b/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
@@ -57,13 +57,16 @@ describe("consent sheet route helpers", () => {
     });
   });
 
-  it("interprets structural query keys properly when the input target incorporates bracket-notation array layouts", () => {
-    const bracketArrayInput = "/consents/verify?permissions[]=read&permissions[]=share";
-    const result = resolveConsentNavigationTarget(bracketArrayInput);
+  it("preserves bracket-array query hrefs from consent notification review targets", () => {
+    const notificationReviewHref = "/consents/verify?permissions[]=read&permissions[]=share";
+    const result = resolveConsentNavigationTarget(notificationReviewHref, "pending", {
+      requestId: "req_123",
+      from: "/kai/analysis?tab=history",
+    });
 
     expect(result).toEqual({
       kind: "internal",
-      href: bracketArrayInput,
+      href: notificationReviewHref,
       pathname: "/consents/verify",
     });
   });

--- a/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
+++ b/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
@@ -57,6 +57,17 @@ describe("consent sheet route helpers", () => {
     });
   });
 
+  it("interprets structural query keys properly when the input target incorporates bracket-notation array layouts", () => {
+    const bracketArrayInput = "/consents/verify?permissions[]=read&permissions[]=share";
+    const result = resolveConsentNavigationTarget(bracketArrayInput);
+
+    expect(result).toEqual({
+      kind: "internal",
+      href: bracketArrayInput,
+      pathname: "/consents/verify",
+    });
+  });
+
   it("classifies Email Helper workflow links as SPA routes", () => {
     expect(
       resolveConsentNavigationTarget("http://localhost:3000/one/kyc?workflowId=wf_123")


### PR DESCRIPTION
## Summary

Narrows the bracket-array query coverage for `resolveConsentNavigationTarget` by attaching it to the production consent notification review path. The test now mirrors the `notification-provider.tsx` caller shape by passing a raw consent review href plus `requestId` and `from` options, then asserting the bracket-array href is preserved as the internal SPA target.

## Concrete Attachment Plan

- Canonical app surface: `hushh-webapp`
- Production helper under test: `hushh-webapp/lib/consent/consent-sheet-route.ts`
- Production callers: `hushh-webapp/components/consent/notification-provider.tsx` and `hushh-webapp/lib/notifications/fcm-service.ts`
- Test contract: `hushh-webapp/__tests__/utils/consent-sheet-route.test.ts`

## Why This Is Safe

- Test-only follow-up; no runtime code changes.
- Exercises the existing production route helper directly.
- Keeps coverage inside the existing consent route helper contract test instead of adding a parallel test surface.
- Proves bracket-notation array query keys survive the same navigation target resolution used by consent review notifications.

## Validation

- `npm run test:ci -- __tests__/utils/consent-sheet-route.test.ts` passed: 27 tests.
- `npm run typecheck` passed.
- `npm run verify:docs` passed.
- `npm run verify:service-boundary` passed.
- `npm run verify:routes` was attempted locally but is blocked by missing maintainer-only `REVIEWER_UID` and `REVIEWER_VAULT_PASSPHRASE`; the required GitHub CI Status Gate is the authoritative rerun for this branch.