### PR TITLE
fix(kai): restore inline voice search chrome

### DIFF
--- a/hushh-webapp/__tests__/voice/kai-search-bar.test.ts
+++ b/hushh-webapp/__tests__/voice/kai-search-bar.test.ts
@@ -440,6 +440,25 @@ describe("kai-search-bar helpers", () => {
     expect(mockOpenAgent).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps Kai voice inside the integrated search surface", () => {
+    vi.useRealTimers();
+
+    render(
+      createElement(KaiSearchBar, {
+        onSelectAction: vi.fn(),
+        onVoiceResponse: vi.fn(),
+        userId: "user_1",
+        vaultOwnerToken: "vault_token",
+      }),
+    );
+
+    expect(screen.getByTestId("voice-ambient-search-surface")).toBeTruthy();
+    expect(screen.getByLabelText("Toggle voice microphone")).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "Start Kai voice" }),
+    ).toBeNull();
+  });
+
   it("acquires on explicit mic tap and releases on cancel", async () => {
     vi.useRealTimers();
     render(

--- a/hushh-webapp/app/kai/onboarding/page.tsx
+++ b/hushh-webapp/app/kai/onboarding/page.tsx
@@ -307,7 +307,7 @@ function KaiOnboardingPageContent() {
     return (
       <div
         data-top-content-anchor="true"
-        className="mx-auto flex min-h-[calc(100dvh_-_var(--top-content-pad))] w-full max-w-5xl items-start px-5 pb-8 pt-[calc(var(--top-content-pad)_+_1rem)] sm:px-6 lg:px-[var(--page-inline-gutter-standard)]"
+        className="mx-auto flex min-h-[calc(100dvh_-_var(--top-content-pad))] w-full max-w-5xl items-start px-5 pb-8 pt-[calc(var(--top-content-pad)_+_0.25rem)] sm:px-6 lg:px-[var(--page-inline-gutter-standard)]"
       >
         <NativeTestBeacon
           routeId="/kai/onboarding"
@@ -315,15 +315,19 @@ function KaiOnboardingPageContent() {
           authState={user ? "authenticated" : "pending"}
           dataState="loaded"
         />
-        <div className="w-full space-y-9">
-          <div className="space-y-3 text-center">
-            <p className="text-[12px] font-semibold uppercase tracking-[0.22em] text-primary/75">
+        <div className="w-full space-y-8">
+          <div className="mx-auto max-w-[48rem] space-y-3 text-center">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-primary/75">
               Choose your starting path
             </p>
-            <h1 className="text-[38px] font-medium leading-[1.05] tracking-normal text-foreground sm:text-[40px]">
+            <div
+              role="heading"
+              aria-level={1}
+              className="text-[38px] font-normal leading-[1.04] tracking-normal text-foreground sm:text-[46px] lg:text-[52px]"
+            >
               Start as an investor or set up RIA first
-            </h1>
-            <p className="mx-auto max-w-[36rem] text-[17px] leading-[1.45] text-muted-foreground sm:text-[18px]">
+            </div>
+            <p className="mx-auto max-w-[35rem] text-[17px] leading-[1.45] text-muted-foreground sm:text-[18px]">
               You can add the other profile later from Profile. This choice only sets the first
               workflow we open right now.
             </p>
@@ -336,7 +340,7 @@ function KaiOnboardingPageContent() {
               effect="glass"
               showRipple
               interactive={!saving}
-              className="transition-[border-color,background-color,box-shadow] enabled:hover:!border-primary/40"
+              className="transition-[border-color,background-color,box-shadow,transform] enabled:hover:!-translate-y-0.5 enabled:hover:!border-primary/30"
             >
               <button
                 type="button"
@@ -364,19 +368,25 @@ function KaiOnboardingPageContent() {
                     setSaving(false);
                   }
                 }}
-                className="flex min-h-[210px] w-full flex-col p-6 text-left sm:p-7"
+                className="flex h-full min-h-[228px] w-full flex-col justify-between gap-6 p-6 text-left sm:p-7"
               >
-                <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-primary/75">
-                  Investor
-                </p>
-                <h2 className="mt-3 text-[24px] font-medium leading-[1.12] tracking-normal text-foreground">
-                  Continue as Investor
-                </h2>
-                <p className="mt-3 text-[15px] leading-[1.55] text-muted-foreground">
-                  Answer your risk and preference questions, then connect accounts and start using
-                  Kai.
-                </p>
-                <span className="mt-auto pt-6 text-[14px] font-medium text-primary">
+                <div className="space-y-3.5">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-primary/75">
+                    Investor
+                  </p>
+                  <div
+                    role="heading"
+                    aria-level={2}
+                    className="text-[28px] font-normal leading-[1.08] tracking-normal text-foreground sm:text-[32px]"
+                  >
+                    Continue as Investor
+                  </div>
+                  <p className="max-w-[28rem] text-[16px] leading-[1.5] text-muted-foreground">
+                    Answer your risk and preference questions, then connect accounts and start using
+                    Kai.
+                  </p>
+                </div>
+                <span className="inline-flex w-fit items-center rounded-full bg-primary px-4 py-2 text-[14px] font-semibold text-primary-foreground shadow-[0_12px_26px_-18px_rgba(0,113,227,0.75)]">
                   Open investor setup
                 </span>
               </button>
@@ -388,7 +398,7 @@ function KaiOnboardingPageContent() {
               effect="glass"
               showRipple
               interactive={!saving && riaCapability !== "disabled"}
-              className="transition-[border-color,background-color,box-shadow] enabled:hover:!border-primary/40 disabled:opacity-60"
+              className="transition-[border-color,background-color,box-shadow,transform] enabled:hover:!-translate-y-0.5 enabled:hover:!border-primary/30 disabled:opacity-60"
             >
               <button
                 type="button"
@@ -414,24 +424,30 @@ function KaiOnboardingPageContent() {
                     setSaving(false);
                   }
                 }}
-                className="flex min-h-[210px] w-full flex-col p-6 text-left disabled:cursor-not-allowed sm:p-7"
+                className="flex h-full min-h-[228px] w-full flex-col justify-between gap-6 p-6 text-left disabled:cursor-not-allowed sm:p-7"
               >
-                <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-primary/75">
-                  RIA
-                </p>
-                <h2 className="mt-3 text-[24px] font-medium leading-[1.12] tracking-normal text-foreground">
-                  Continue as RIA
-                </h2>
-                <p className="mt-3 text-[15px] leading-[1.55] text-muted-foreground">
-                  Set up your advisor identity, verification, firm details, and marketplace trust
-                  profile before sending consent requests.
-                </p>
-                {riaCapability === "disabled" ? (
-                  <p className="mt-4 text-xs font-medium text-muted-foreground">
-                    RIA mode is unavailable in this environment until IAM is active.
+                <div className="space-y-3.5">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-primary/75">
+                    RIA
                   </p>
-                ) : null}
-                <span className="mt-auto pt-6 text-[14px] font-medium text-primary">
+                  <div
+                    role="heading"
+                    aria-level={2}
+                    className="text-[28px] font-normal leading-[1.08] tracking-normal text-foreground sm:text-[32px]"
+                  >
+                    Continue as RIA
+                  </div>
+                  <p className="max-w-[28rem] text-[16px] leading-[1.5] text-muted-foreground">
+                    Set up your advisor identity, verification, firm details, and marketplace trust
+                    profile before sending consent requests.
+                  </p>
+                  {riaCapability === "disabled" ? (
+                    <p className="text-xs font-medium text-muted-foreground">
+                      RIA mode is unavailable in this environment until IAM is active.
+                    </p>
+                  ) : null}
+                </div>
+                <span className="inline-flex w-fit items-center rounded-full bg-primary px-4 py-2 text-[14px] font-semibold text-primary-foreground shadow-[0_12px_26px_-18px_rgba(0,113,227,0.75)]">
                   Open advisor setup
                 </span>
               </button>

--- a/hushh-webapp/components/kai/kai-search-bar.tsx
+++ b/hushh-webapp/components/kai/kai-search-bar.tsx
@@ -1742,11 +1742,11 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
               </ShellActionSurface>
             </div>
           ) : (
-            <div className="relative flex h-[172px] w-full items-end justify-end">
-              <div className="ml-auto flex h-[172px] w-[58px] flex-col items-center justify-end gap-1.5">
+            <div className="relative flex h-[124px] w-full items-end justify-end">
+              <div className="ml-auto flex w-[min(17rem,calc(100vw-2rem))] flex-col items-end justify-end gap-2">
                 <button
                   type="button"
-                  className="pointer-events-auto grid h-[58px] w-[58px] place-items-center rounded-full transition-transform duration-200 ease-out hover:scale-[1.03] active:scale-[0.94] disabled:cursor-not-allowed disabled:opacity-50"
+                  className="pointer-events-auto grid h-12 w-12 place-items-center rounded-full transition-transform duration-200 ease-out hover:scale-[1.03] active:scale-[0.94] disabled:cursor-not-allowed disabled:opacity-50"
                   aria-label="Open Kai agent"
                   disabled={!agentPopover}
                   onClick={() => agentPopover?.openAgent()}
@@ -1755,100 +1755,67 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
                     <Bot className="h-[18px] w-[18px]" strokeWidth={1.95} />
                   </span>
                 </button>
-                <ShellActionSurface
-                  variant="icon"
-                  wrapperClassName="pointer-events-auto"
-                  className="kai-bottom-search-action grid h-[58px] w-[58px] place-items-center text-muted-foreground"
-                  aria-label={
-                    ambientMode === "idle"
-                      ? "Start Kai voice"
-                      : "End Kai voice session"
-                  }
-                  aria-disabled={micDisabled}
-                  onClick={(event) => {
-                    if (ambientMode !== "idle") {
-                      cancelListening();
-                      return;
+                <div className="pointer-events-auto w-full rounded-full kai-bottom-search-action p-[5px]">
+                  <VoiceAmbientSearchSurface
+                    mode={ambientMode}
+                    placeholder="Analyze, dashboard, consent with Kai"
+                    transcriptPreview={transcriptPreview}
+                    stageText={processingStageText}
+                    replyText={
+                      showSpeakingCompact || showRetryCompact
+                        ? lastReplyText || debouncedSearch
+                        : debouncedSearch
                     }
-                    if (micDisabled) {
-                      toast.info(stableMicDisabledReason || "Voice is unavailable right now.");
-                      return;
+                    smoothedLevel={smoothedLevel}
+                    disabled={disabled}
+                    showMic={!micHidden}
+                    micDisabled={micDisabled}
+                    micDisabledReason={stableMicDisabledReason}
+                    showDebug={DEV_VOICE_DEBUG_ENABLED}
+                    debugActive={voiceDebugOpen}
+                    showSubmit={
+                      VOICE_V2_FLAGS.submitDebugVisible &&
+                      (showVoiceSheet || realtimeConnecting)
                     }
-                    handleMicTap(event);
-                  }}
-                >
-                  {ambientMode === "idle" ? (
-                    <Mic className="h-5 w-5" strokeWidth={2.05} />
-                  ) : (
-                    <X className="h-5 w-5" strokeWidth={2.05} />
-                  )}
-                </ShellActionSurface>
-                <ShellActionSurface
-                  variant="icon"
-                  wrapperClassName="pointer-events-auto"
-                  className="kai-bottom-search-action grid h-[58px] w-[58px] place-items-center"
-                  aria-label="Search"
-                  onClick={() => setOpen(true)}
-                >
-                  <Search className="h-5 w-5" strokeWidth={2.2} />
-                </ShellActionSurface>
-              </div>
-              <div className="hidden">
-                <VoiceAmbientSearchSurface
-                  mode={ambientMode}
-                  placeholder="Analyze, dashboard, consent with Kai"
-                  transcriptPreview={transcriptPreview}
-                  stageText={processingStageText}
-                  replyText={
-                    showSpeakingCompact || showRetryCompact
-                      ? lastReplyText || debouncedSearch
-                      : debouncedSearch
-                  }
-                  smoothedLevel={smoothedLevel}
-                  disabled={disabled}
-                  showMic={!micHidden}
-                  micDisabled={micDisabled}
-                  micDisabledReason={stableMicDisabledReason}
-                  showDebug={DEV_VOICE_DEBUG_ENABLED}
-                  debugActive={voiceDebugOpen}
-                  showSubmit={
-                    VOICE_V2_FLAGS.submitDebugVisible &&
-                    (showVoiceSheet || realtimeConnecting)
-                  }
-                  submitEnabled={
-                    VOICE_V2_FLAGS.submitDebugVisible && realtimeSessionReady
-                  }
-                  ttsPlaying={ttsPlaybackState === "playing"}
-                  pendingConfirmation={Boolean(
-                    showRetryCompact && pendingConfirmation,
-                  )}
-                  onOpenSearch={() => setOpen(true)}
-                  onMicToggle={handleMicTap}
-                  onDebugToggle={(event) => {
-                    event.stopPropagation();
-                    setVoiceDebugOpen((current) => !current);
-                  }}
-                  onMuteToggle={toggleMuteListening}
-                  onSubmit={submitDebugTurn}
-                  onEnd={cancelListening}
-                  onStopSpeaking={handleStopSpeaking}
-                  onReplay={
-                    showSpeakingCompact || showRetryCompact ? handleReplay : undefined
-                  }
-                  onRetry={
-                    showRetryCompact && !pendingConfirmation ? handleRetry : undefined
-                  }
-                  onConfirm={
-                    showRetryCompact && pendingConfirmation
-                      ? handleConfirmPending
-                      : undefined
-                  }
-                  onCancel={
-                    showRetryCompact && pendingConfirmation
-                      ? handleCancelPending
-                      : undefined
-                  }
-                />
+                    submitEnabled={
+                      VOICE_V2_FLAGS.submitDebugVisible && realtimeSessionReady
+                    }
+                    ttsPlaying={ttsPlaybackState === "playing"}
+                    pendingConfirmation={Boolean(
+                      showRetryCompact && pendingConfirmation,
+                    )}
+                    onOpenSearch={() => setOpen(true)}
+                    onMicToggle={handleMicTap}
+                    onDebugToggle={(event) => {
+                      event.stopPropagation();
+                      setVoiceDebugOpen((current) => !current);
+                    }}
+                    onMuteToggle={toggleMuteListening}
+                    onSubmit={submitDebugTurn}
+                    onEnd={cancelListening}
+                    onStopSpeaking={handleStopSpeaking}
+                    onReplay={
+                      showSpeakingCompact || showRetryCompact
+                        ? handleReplay
+                        : undefined
+                    }
+                    onRetry={
+                      showRetryCompact && !pendingConfirmation
+                        ? handleRetry
+                        : undefined
+                    }
+                    onConfirm={
+                      showRetryCompact && pendingConfirmation
+                        ? handleConfirmPending
+                        : undefined
+                    }
+                    onCancel={
+                      showRetryCompact && pendingConfirmation
+                        ? handleCancelPending
+                        : undefined
+                    }
+                  />
+                </div>
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary
- restore Kai bottom search as the integrated VoiceAmbientSearchSurface instead of separate voice/search buttons
- keep Agent as the only separate Kai bottom action above search
- polish the Kai onboarding role-choice page with lighter Apple-like heading hierarchy, tighter spacing, matched card rhythm, and clearer premium CTA pills
- add regression coverage that Kai voice stays inside the search surface

## Verification
- cd hushh-webapp && npm run typecheck
- cd hushh-webapp && npm run lint
- cd hushh-webapp && npm run verify:design-system
- cd hushh-webapp && npm run verify:docs
- cd hushh-webapp && npm run verify:cache
- cd hushh-webapp && npx vitest run __tests__/voice/kai-search-bar.test.ts __tests__/voice/voice-ambient-search-surface.test.tsx __tests__/navigation/routes.test.ts

Browser tests intentionally skipped per request.