### PR TITLE
fix(kai): polish onboarding preference wizard

### DIFF
--- a/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
+++ b/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
@@ -37,7 +37,7 @@ type WizardCompletePayload = WizardAnswers & {
 const QUESTIONS = [
   {
     id: "investment_horizon" as const,
-    prompt: "How long do you expect to keep\nthis money invested?",
+    prompt: "How long do you expect to keep this money invested?",
     options: [
       { value: "short_term" as const, label: "Less than 3 years" },
       { value: "medium_term" as const, label: "3–7 years" },
@@ -46,7 +46,7 @@ const QUESTIONS = [
   },
   {
     id: "drawdown_response" as const,
-    prompt: "If your portfolio drops 20%, what\nwould you most likely do?",
+    prompt: "If your portfolio drops 20%, what would you most likely do?",
     options: [
       { value: "reduce" as const, label: "Reduce investments to limit further losses" },
       { value: "stay" as const, label: "Stay invested and review the situation" },
@@ -55,7 +55,7 @@ const QUESTIONS = [
   },
   {
     id: "volatility_preference" as const,
-    prompt: "Which feels more comfortable to\nyou?",
+    prompt: "Which feels more comfortable to you?",
     options: [
       { value: "small" as const, label: "Smaller, steadier returns" },
       { value: "moderate" as const, label: "Moderate ups and downs for better returns" },
@@ -198,12 +198,12 @@ export function KaiPreferencesWizard(props: {
       <div
         className={cn(
           isPageLayout
-            ? "mx-auto flex min-h-[calc(100dvh-var(--top-content-pad)-var(--app-screen-footer-pad))] w-full max-w-md flex-col sm:max-w-2xl lg:max-w-5xl xl:max-w-6xl"
+            ? "mx-auto flex min-h-[calc(100dvh-var(--top-content-pad)-var(--app-screen-footer-pad))] w-full max-w-md flex-col justify-center sm:max-w-2xl lg:max-w-[76rem]"
             : "w-full max-w-sm mx-auto flex min-h-[calc(100dvh-var(--app-screen-footer-pad))] flex-col",
           !isPageLayout && "min-h-0"
         )}
       >
-        <div className={cn("space-y-2", isPageLayout ? "pt-2 lg:pt-0" : "pt-1")}>
+        <div className={cn("space-y-2.5", isPageLayout ? "pt-2 lg:pt-0" : "pt-1")}>
           {reserveBackSlot && (
             <div className="flex justify-start">
               <Button
@@ -214,7 +214,7 @@ export function KaiPreferencesWizard(props: {
                 onClick={handleBack}
                 disabled={isSubmitting}
                 className={cn(
-                  "h-auto p-0",
+                  "h-8 rounded-full px-2.5 text-[15px] font-medium text-primary hover:bg-primary/10",
                   !showBack && "invisible pointer-events-none"
                 )}
                 showRipple={false}
@@ -227,35 +227,38 @@ export function KaiPreferencesWizard(props: {
             </div>
           )}
 
-          <div className="flex items-center justify-between text-xs text-muted-foreground">
-            <span className="font-medium">
+          <div className="flex items-center justify-between text-[13px] text-muted-foreground">
+            <span className="font-medium tracking-normal">
               Step {currentStep} of {total}
             </span>
-            <span className="tabular-nums" aria-hidden="true">
+            <span className="font-medium tabular-nums" aria-hidden="true">
               {progressValue}%
             </span>
           </div>
-          <Progress value={progressValue} className="h-1 rounded-full bg-muted" />
+          <Progress
+            value={progressValue}
+            className="h-1 rounded-full bg-black/[0.035] dark:bg-white/10"
+          />
         </div>
 
         <div
           className={cn(
             isPageLayout
-              ? "grid flex-1 gap-6 pt-7 sm:gap-8 sm:pt-9 lg:grid-cols-[minmax(0,0.95fr)_minmax(24rem,0.85fr)] lg:items-start lg:gap-12 lg:pt-12 xl:gap-16"
+              ? "grid flex-1 gap-7 pt-8 sm:gap-9 sm:pt-10 lg:grid-cols-[minmax(0,0.92fr)_minmax(23rem,0.82fr)] lg:items-center lg:gap-12 lg:pt-10 xl:gap-14"
               : "contents"
           )}
         >
           <div
             className={cn(
               isPageLayout
-                ? "space-y-4 lg:pt-6"
+                ? "space-y-5"
                 : "pt-6 space-y-3"
             )}
           >
             <p
               className={cn(
                 "text-muted-foreground leading-relaxed",
-                isPageLayout ? "text-sm sm:text-base lg:text-lg" : "text-xs"
+                isPageLayout ? "text-[16px] sm:text-[18px]" : "text-xs"
               )}
             >
               There are no right or wrong answers.
@@ -263,18 +266,18 @@ export function KaiPreferencesWizard(props: {
               Help us tailor your investment plan.
             </p>
 
-            <p
+            <div
               role="heading"
               aria-level={1}
               className={cn(
-                "whitespace-pre-line tracking-tight text-balance",
+                "tracking-normal text-balance text-foreground",
                 isPageLayout
-                  ? "text-[clamp(2rem,4.2vw,4rem)] font-bold leading-[1.06]"
+                  ? "max-w-[34rem] text-[clamp(2.25rem,3.2vw,3.45rem)] font-medium leading-[1.08]"
                   : "text-[clamp(0.95rem,2.8vw,1.2rem)] leading-[1.3] font-semibold"
               )}
             >
               {activeQuestion.prompt}
-            </p>
+            </div>
           </div>
 
           <div
@@ -286,7 +289,7 @@ export function KaiPreferencesWizard(props: {
             <RadioGroup
               value={activeValue ?? ""}
               onValueChange={handleSelect}
-              className={cn(isPageLayout ? "gap-3 sm:gap-4" : "gap-3")}
+              className={cn(isPageLayout ? "gap-3" : "gap-3")}
             >
               {activeQuestion.options.map((opt) => (
                 <RadioCardItem key={opt.value} value={opt.value} label={opt.label} />
@@ -296,12 +299,20 @@ export function KaiPreferencesWizard(props: {
             <div className={cn("space-y-4", isPageLayout ? "pt-1" : "mt-auto pt-6")}>
               <Button
                 type="button"
+                variant="none"
+                effect="fill"
                 size="lg"
                 fullWidth
                 onClick={handlePrimary}
                 disabled={!canContinue || isSubmitting}
                 loading={isSubmitting}
                 showRipple
+                className={cn(
+                  "h-12 rounded-full text-[15px] font-semibold shadow-[0_16px_34px_-24px_rgba(0,113,227,0.85)]",
+                  canContinue
+                    ? "!bg-primary !text-primary-foreground hover:!bg-primary/90"
+                    : "!bg-muted !text-muted-foreground shadow-none"
+                )}
               >
                 {isSubmitting ? "Saving..." : primaryLabel}
                 {!isSubmitting && <ArrowRight className="ml-2 h-5 w-5" />}
@@ -310,14 +321,15 @@ export function KaiPreferencesWizard(props: {
               {props.mode === "onboarding" && props.onSkip && (
                 <Button
                   type="button"
-                  variant="blue-gradient"
-                  effect="fade"
+                  variant="none"
+                  effect="fill"
                   size="lg"
                   fullWidth
                   onClick={props.onSkip}
                   disabled={isSubmitting}
                   loading={isSubmitting}
-                  showRipple={false}
+                  showRipple
+                  className="h-12 rounded-full !bg-primary/10 text-[15px] font-semibold !text-primary shadow-none hover:!bg-primary/15 dark:!bg-primary/15"
                 >
                   {isSubmitting ? "Saving..." : "Skip"}
                   {!isSubmitting && <ArrowRight className="ml-2 h-5 w-5" />}
@@ -419,24 +431,27 @@ function RadioCardItem(props: { value: string; label: string }) {
     <RadioGroupPrimitive.Item
       value={props.value}
       className={cn(
-        "w-full rounded-2xl border p-4 text-left transition-colors sm:p-5 lg:p-6",
-        "focus:outline-hidden focus-visible:ring-2 focus-visible:ring-[var(--brand-primary)]/40",
-        "data-[state=checked]:border-[var(--brand-primary)] data-[state=checked]:bg-[var(--brand-50)]/30",
-        "hover:bg-muted/40"
+        "group w-full rounded-[22px] border px-5 py-4 text-left transition-[background-color,border-color,box-shadow,transform] sm:px-6 sm:py-5",
+        "min-h-[72px] focus:outline-hidden focus-visible:ring-2 focus-visible:ring-[var(--brand-primary)]/35",
+        "border-black/[0.08] bg-white/62 shadow-[0_12px_34px_-30px_rgba(0,0,0,0.45)] backdrop-blur-xl",
+        "hover:-translate-y-0.5 hover:bg-white/82 hover:shadow-[0_18px_42px_-32px_rgba(0,0,0,0.5)]",
+        "data-[state=checked]:border-primary/55 data-[state=checked]:bg-primary/[0.07] data-[state=checked]:shadow-[0_18px_42px_-32px_rgba(0,113,227,0.7)]",
+        "dark:border-white/10 dark:bg-white/[0.06] dark:hover:bg-white/[0.09] dark:data-[state=checked]:bg-primary/15"
       )}
     >
       <div className="flex items-center justify-between gap-3">
-        <p className="text-sm font-semibold leading-snug sm:text-base lg:text-lg">
+        <p className="text-[16px] font-medium leading-snug text-foreground sm:text-[17px]">
           {props.label}
         </p>
         <div
           aria-hidden="true"
           className={cn(
-            "h-5 w-5 rounded-full border grid place-items-center",
-            "border-muted-foreground/30"
+            "grid h-5 w-5 shrink-0 place-items-center rounded-full border transition-colors",
+            "border-muted-foreground/28 bg-background/60",
+            "group-data-[state=checked]:border-primary"
           )}
         >
-          <RadioGroupPrimitive.Indicator className="h-2.5 w-2.5 rounded-full bg-[var(--brand-primary)]" />
+          <RadioGroupPrimitive.Indicator className="h-2.5 w-2.5 rounded-full bg-primary" />
         </div>
       </div>
     </RadioGroupPrimitive.Item>


### PR DESCRIPTION
## Summary
- soften Kai preference wizard headings to match the Meet One / Apple-like hierarchy
- tighten desktop composition across all three questionnaire steps
- restyle option rows, progress, back affordance, Next disabled state, and Skip CTA without changing answer/save/navigation behavior

## Verification
- cd hushh-webapp && npm run typecheck
- cd hushh-webapp && npm run lint
- cd hushh-webapp && npm run verify:design-system

Browser tests intentionally skipped per request.