### PR TITLE
promote Kai wizard title scale polish

### DIFF
--- a/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
+++ b/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
@@ -272,7 +272,7 @@ export function KaiPreferencesWizard(props: {
               className={cn(
                 "tracking-normal text-balance text-foreground",
                 isPageLayout
-                  ? "max-w-[34rem] text-[clamp(2.25rem,3.2vw,3.45rem)] font-medium leading-[1.08]"
+                  ? "max-w-[32rem] text-[clamp(1.9rem,2.35vw,2.65rem)] font-normal leading-[1.12]"
                   : "text-[clamp(0.95rem,2.8vw,1.2rem)] leading-[1.3] font-semibold"
               )}
             >


### PR DESCRIPTION
## Summary
- promote the Kai preference wizard title scale polish to main
- reduce the desktop onboarding question heading from an oversized hero scale to a calmer Apple-style product heading

## Scope
- Frontend-only typography/layout polish in KaiPreferencesWizard
- No backend, route, auth, data, or link behavior changes

## Validation
- npm run typecheck
- npm run lint
- npm run verify:design-system
- PR validation on #2823 is green

Browser tests intentionally skipped per request.