### PR TITLE
fix Kai preference onboarding flow alignment

### DIFF
--- a/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
+++ b/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
@@ -91,15 +91,9 @@ export function KaiPreferencesWizard(props: {
   const [horizonDialogOpen, setHorizonDialogOpen] = useState(false);
   const [horizonAnchorChoice, setHorizonAnchorChoice] = useState<HorizonAnchorChoice>("from_now");
 
-  const answeredCount = useMemo(() => {
-    return QUESTIONS.reduce((count, question) => {
-      return answers[question.id] ? count + 1 : count;
-    }, 0);
-  }, [answers]);
-
   const progressValue = useMemo(() => {
-    return Math.round((answeredCount / total) * 100);
-  }, [answeredCount, total]);
+    return Math.round((step / total) * 100);
+  }, [step, total]);
   const currentStep = step + 1;
 
   const isLast = step === total - 1;
@@ -198,105 +192,100 @@ export function KaiPreferencesWizard(props: {
       <div
         className={cn(
           isPageLayout
-            ? "mx-auto flex min-h-[calc(100dvh-var(--top-content-pad)-var(--app-screen-footer-pad))] w-full max-w-md flex-col justify-center sm:max-w-2xl lg:max-w-[76rem]"
+            ? "mx-auto flex min-h-[calc(100dvh-var(--top-content-pad)-var(--app-screen-footer-pad))] w-full max-w-[44rem] flex-col justify-center"
             : "w-full max-w-sm mx-auto flex min-h-[calc(100dvh-var(--app-screen-footer-pad))] flex-col",
           !isPageLayout && "min-h-0"
         )}
       >
-        <div className={cn("space-y-2.5", isPageLayout ? "pt-2 lg:pt-0" : "pt-1")}>
-          {reserveBackSlot && (
-            <div className="flex justify-start">
-              <Button
-                type="button"
-                variant="link"
-                effect="fade"
-                size="sm"
-                onClick={handleBack}
-                disabled={isSubmitting}
-                className={cn(
-                  "h-8 rounded-full px-2.5 text-[15px] font-medium text-primary hover:bg-primary/10",
-                  !showBack && "invisible pointer-events-none"
-                )}
-                showRipple={false}
-                aria-hidden={!showBack}
-                tabIndex={showBack ? 0 : -1}
-              >
-                <ArrowLeft className="mr-1 h-4 w-4" />
-                Back
-              </Button>
-            </div>
-          )}
-
-          <div className="flex items-center justify-between text-[13px] text-muted-foreground">
-            <span className="font-medium tracking-normal">
-              Step {currentStep} of {total}
-            </span>
-            <span className="font-medium tabular-nums" aria-hidden="true">
-              {progressValue}%
-            </span>
-          </div>
-          <Progress
-            value={progressValue}
-            className="h-1 rounded-full bg-black/[0.035] dark:bg-white/10"
-          />
-        </div>
-
         <div
           className={cn(
             isPageLayout
-              ? "grid flex-1 gap-7 pt-8 sm:gap-9 sm:pt-10 lg:grid-cols-[minmax(0,0.92fr)_minmax(23rem,0.82fr)] lg:items-center lg:gap-12 lg:pt-10 xl:gap-14"
+              ? "rounded-[32px] border border-black/[0.06] bg-white/[0.72] p-5 shadow-[0_24px_80px_-56px_rgba(0,0,0,0.55)] backdrop-blur-2xl sm:p-7 lg:p-8 dark:border-white/10 dark:bg-white/[0.07]"
               : "contents"
           )}
         >
-          <div
-            className={cn(
-              isPageLayout
-                ? "space-y-5"
-                : "pt-6 space-y-3"
-            )}
-          >
-            <p
-              className={cn(
-                "text-muted-foreground leading-relaxed",
-                isPageLayout ? "text-[16px] sm:text-[18px]" : "text-xs"
+          <div className={cn("space-y-2.5", isPageLayout ? "" : "pt-1")}>
+            <div className="flex min-h-8 items-center justify-between gap-3">
+              {reserveBackSlot ? (
+                <Button
+                  type="button"
+                  variant="link"
+                  effect="fade"
+                  size="sm"
+                  onClick={handleBack}
+                  disabled={isSubmitting}
+                  className={cn(
+                    "h-8 rounded-full px-2.5 text-[14px] font-medium text-primary hover:bg-primary/10",
+                    !showBack && "invisible pointer-events-none"
+                  )}
+                  showRipple={false}
+                  aria-hidden={!showBack}
+                  tabIndex={showBack ? 0 : -1}
+                >
+                  <ArrowLeft className="mr-1 h-4 w-4" />
+                  Back
+                </Button>
+              ) : (
+                <span />
               )}
-            >
-              There are no right or wrong answers.
-              <br />
-              Help us tailor your investment plan.
-            </p>
-
-            <div
-              role="heading"
-              aria-level={1}
-              className={cn(
-                "tracking-normal text-balance text-foreground",
-                isPageLayout
-                  ? "max-w-[32rem] text-[clamp(1.9rem,2.35vw,2.65rem)] font-normal leading-[1.12]"
-                  : "text-[clamp(0.95rem,2.8vw,1.2rem)] leading-[1.3] font-semibold"
-              )}
-            >
-              {activeQuestion.prompt}
+              <span className="rounded-full bg-black/[0.035] px-3 py-1 text-[12px] font-medium tabular-nums text-muted-foreground dark:bg-white/10">
+                {progressValue}%
+              </span>
             </div>
+
+            <div className="flex items-center justify-between text-[13px] text-muted-foreground">
+              <span className="font-medium tracking-normal">
+                Step {currentStep} of {total}
+              </span>
+            </div>
+            <Progress
+              value={progressValue}
+              className="h-1 rounded-full bg-black/[0.045] dark:bg-white/10"
+            />
           </div>
 
           <div
             className={cn(
-              "min-w-0",
-              isPageLayout ? "flex flex-col gap-5 lg:gap-6" : "flex flex-1 flex-col pt-5"
+              isPageLayout
+                ? "mx-auto flex w-full max-w-[35rem] flex-col pt-8 sm:pt-10"
+                : "flex flex-1 flex-col pt-5"
             )}
           >
+            <div className={cn(isPageLayout ? "space-y-4 text-center" : "space-y-3")}>
+              <p
+                className={cn(
+                  "text-muted-foreground leading-relaxed",
+                  isPageLayout ? "text-[15px] sm:text-[16px]" : "text-xs"
+                )}
+              >
+                No right or wrong answers. We’ll tune Kai to your investing style.
+              </p>
+
+              <div
+                role="heading"
+                aria-level={1}
+                className={cn(
+                  "tracking-normal text-balance text-foreground",
+                  isPageLayout
+                    ? "text-[clamp(1.85rem,2.6vw,2.35rem)] font-normal leading-[1.1]"
+                    : "text-[clamp(0.95rem,2.8vw,1.2rem)] leading-[1.3] font-semibold"
+                )}
+              >
+                {activeQuestion.prompt}
+              </div>
+            </div>
+
             <RadioGroup
               value={activeValue ?? ""}
               onValueChange={handleSelect}
-              className={cn(isPageLayout ? "gap-3" : "gap-3")}
+              className={cn(isPageLayout ? "mt-8 gap-2.5 sm:mt-9" : "gap-3")}
             >
               {activeQuestion.options.map((opt) => (
                 <RadioCardItem key={opt.value} value={opt.value} label={opt.label} />
               ))}
             </RadioGroup>
 
-            <div className={cn("space-y-4", isPageLayout ? "pt-1" : "mt-auto pt-6")}>
+            <div className={cn("space-y-3.5", isPageLayout ? "pt-6" : "mt-auto pt-6")}>
               <Button
                 type="button"
                 variant="none"
@@ -308,7 +297,7 @@ export function KaiPreferencesWizard(props: {
                 loading={isSubmitting}
                 showRipple
                 className={cn(
-                  "h-12 rounded-full text-[15px] font-semibold shadow-[0_16px_34px_-24px_rgba(0,113,227,0.85)]",
+                  "h-11 rounded-full text-[15px] font-semibold shadow-[0_16px_34px_-24px_rgba(0,113,227,0.85)]",
                   canContinue
                     ? "!bg-primary !text-primary-foreground hover:!bg-primary/90"
                     : "!bg-muted !text-muted-foreground shadow-none"
@@ -329,7 +318,7 @@ export function KaiPreferencesWizard(props: {
                   disabled={isSubmitting}
                   loading={isSubmitting}
                   showRipple
-                  className="h-12 rounded-full !bg-primary/10 text-[15px] font-semibold !text-primary shadow-none hover:!bg-primary/15 dark:!bg-primary/15"
+                  className="h-11 rounded-full !bg-primary/10 text-[15px] font-semibold !text-primary shadow-none hover:!bg-primary/15 dark:!bg-primary/15"
                 >
                   {isSubmitting ? "Saving..." : "Skip"}
                   {!isSubmitting && <ArrowRight className="ml-2 h-5 w-5" />}
@@ -431,16 +420,16 @@ function RadioCardItem(props: { value: string; label: string }) {
     <RadioGroupPrimitive.Item
       value={props.value}
       className={cn(
-        "group w-full rounded-[22px] border px-5 py-4 text-left transition-[background-color,border-color,box-shadow,transform] sm:px-6 sm:py-5",
-        "min-h-[72px] focus:outline-hidden focus-visible:ring-2 focus-visible:ring-[var(--brand-primary)]/35",
-        "border-black/[0.08] bg-white/62 shadow-[0_12px_34px_-30px_rgba(0,0,0,0.45)] backdrop-blur-xl",
-        "hover:-translate-y-0.5 hover:bg-white/82 hover:shadow-[0_18px_42px_-32px_rgba(0,0,0,0.5)]",
-        "data-[state=checked]:border-primary/55 data-[state=checked]:bg-primary/[0.07] data-[state=checked]:shadow-[0_18px_42px_-32px_rgba(0,113,227,0.7)]",
+        "group w-full rounded-[18px] border px-4 py-3.5 text-left transition-[background-color,border-color,box-shadow,transform] sm:px-5",
+        "min-h-[58px] focus:outline-hidden focus-visible:ring-2 focus-visible:ring-[var(--brand-primary)]/35",
+        "border-black/[0.08] bg-white/68 shadow-[0_10px_30px_-28px_rgba(0,0,0,0.5)] backdrop-blur-xl",
+        "hover:-translate-y-0.5 hover:bg-white/86 hover:shadow-[0_16px_38px_-32px_rgba(0,0,0,0.55)]",
+        "data-[state=checked]:border-primary/55 data-[state=checked]:bg-primary/[0.08] data-[state=checked]:shadow-[0_16px_38px_-32px_rgba(0,113,227,0.7)]",
         "dark:border-white/10 dark:bg-white/[0.06] dark:hover:bg-white/[0.09] dark:data-[state=checked]:bg-primary/15"
       )}
     >
       <div className="flex items-center justify-between gap-3">
-        <p className="text-[16px] font-medium leading-snug text-foreground sm:text-[17px]">
+        <p className="text-[15px] font-medium leading-snug text-foreground sm:text-[16px]">
           {props.label}
         </p>
         <div


### PR DESCRIPTION
## Summary
- replace the wide left/right onboarding questionnaire layout with one centered premium setup panel
- keep the question and options in one vertical composition
- reduce option row height and button height so the flow feels calmer and less heavy
- restore staged onboarding progress so Step 1 no longer appears as 100% just because an answer is selected

## Scope
- Frontend-only styling/composition in KaiPreferencesWizard
- No backend, auth, data, link, route, answer, or submit behavior changes

## Validation
- npm run typecheck
- npm run lint
- npm run verify:design-system

Browser tests intentionally skipped per request.