### PR TITLE
fix(kai): polish onboarding import and search chrome

### DIFF
--- a/hushh-webapp/__tests__/voice/kai-search-bar.test.ts
+++ b/hushh-webapp/__tests__/voice/kai-search-bar.test.ts
@@ -265,6 +265,13 @@ const {
   shouldTriggerVoiceBargeIn,
 } = await import("@/components/kai/kai-search-bar");
 
+function openSearchAndStartVoice() {
+  fireEvent.click(
+    screen.getByRole("button", { name: "Open Kai command search" }),
+  );
+  fireEvent.click(screen.getByRole("button", { name: "Start Kai voice" }));
+}
+
 describe("kai-search-bar helpers", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -440,7 +447,7 @@ describe("kai-search-bar helpers", () => {
     expect(mockOpenAgent).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps Kai voice inside the integrated search surface", () => {
+  it("keeps Kai voice inside the compact search surface", () => {
     vi.useRealTimers();
 
     render(
@@ -452,11 +459,17 @@ describe("kai-search-bar helpers", () => {
       }),
     );
 
-    expect(screen.getByTestId("voice-ambient-search-surface")).toBeTruthy();
-    expect(screen.getByLabelText("Toggle voice microphone")).toBeTruthy();
+    expect(screen.getByTestId("kai-compact-search-surface")).toBeTruthy();
     expect(
-      screen.queryByRole("button", { name: "Start Kai voice" }),
-    ).toBeNull();
+      screen.getByRole("button", { name: "Open Kai command search" }),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Start Kai voice" })).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open Kai command search" }),
+    );
+
+    expect(screen.getByRole("button", { name: "Start Kai voice" })).toBeTruthy();
   });
 
   it("acquires on explicit mic tap and releases on cancel", async () => {
@@ -470,7 +483,7 @@ describe("kai-search-bar helpers", () => {
       }),
     );
 
-    fireEvent.click(screen.getByLabelText("Toggle voice microphone"));
+    openSearchAndStartVoice();
 
     await waitFor(() => {
       expect(acquireMock).toHaveBeenCalledWith(
@@ -483,10 +496,10 @@ describe("kai-search-bar helpers", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByTestId("voice-ambient-search-surface")).toBeTruthy();
+      expect(screen.getByTestId("kai-compact-search-surface")).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByText("cancel voice"));
+    fireEvent.click(screen.getByRole("button", { name: "End Kai voice" }));
 
     await waitFor(() => {
       expect(releaseMock).toHaveBeenCalled();
@@ -508,7 +521,7 @@ describe("kai-search-bar helpers", () => {
       }),
     );
 
-    fireEvent.click(screen.getByLabelText("Toggle voice microphone"));
+    openSearchAndStartVoice();
 
     await waitFor(() => {
       expect(acquireMock).toHaveBeenCalled();
@@ -517,7 +530,7 @@ describe("kai-search-bar helpers", () => {
     await waitFor(() => {
       expect(
         screen
-          .getByTestId("voice-ambient-search-surface")
+          .getByTestId("kai-compact-search-surface")
           .getAttribute("data-mode"),
       ).toBe("idle");
       expect(
@@ -550,10 +563,10 @@ describe("kai-search-bar helpers", () => {
       }),
     );
 
-    fireEvent.click(screen.getByLabelText("Toggle voice microphone"));
+    openSearchAndStartVoice();
 
     await waitFor(() => {
-      const surface = screen.getByTestId("voice-ambient-search-surface");
+      const surface = screen.getByTestId("kai-compact-search-surface");
       expect(surface).toBeTruthy();
       expect(surface.getAttribute("data-mode")).toBe("connecting");
       expect(screen.getByTestId("voice-ambient-preview").textContent).toContain(
@@ -590,10 +603,10 @@ describe("kai-search-bar helpers", () => {
       }),
     );
 
-    fireEvent.click(screen.getByLabelText("Toggle voice microphone"));
+    openSearchAndStartVoice();
 
     await waitFor(() => {
-      expect(screen.getByTestId("voice-ambient-search-surface")).toBeTruthy();
+      expect(screen.getByTestId("kai-compact-search-surface")).toBeTruthy();
     });
 
     await act(async () => {
@@ -649,7 +662,7 @@ describe("kai-search-bar helpers", () => {
       });
     });
 
-    fireEvent.click(screen.getByLabelText("Toggle voice microphone"));
+    openSearchAndStartVoice();
 
     await waitFor(() => {
       expect(setMutedMock).toHaveBeenCalledWith(false);
@@ -682,7 +695,7 @@ describe("kai-search-bar helpers", () => {
       }),
     );
 
-    fireEvent.click(screen.getByLabelText("Toggle voice microphone"));
+    openSearchAndStartVoice();
 
     await waitFor(() => {
       expect(acquireMock).toHaveBeenCalled();
@@ -691,7 +704,7 @@ describe("kai-search-bar helpers", () => {
     await waitFor(() => {
       expect(
         screen
-          .getByTestId("voice-ambient-search-surface")
+          .getByTestId("kai-compact-search-surface")
           .getAttribute("data-mode"),
       ).toBe("idle");
       expect(

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1284,16 +1284,17 @@ md-ripple.morphy-md-ripple {
 
 .kai-bottom-nav-pill {
   color: rgb(29 29 31);
-  border: 1px solid rgb(255 255 255 / 0.72) !important;
+  border: 1px solid rgb(255 255 255 / 0.78) !important;
   background:
-    linear-gradient(180deg, rgb(255 255 255 / 0.88), rgb(245 245 247 / 0.76)) !important;
+    radial-gradient(circle at 50% 0%, rgb(255 255 255 / 0.96), transparent 54%),
+    linear-gradient(180deg, rgb(255 255 255 / 0.9), rgb(246 246 248 / 0.76)) !important;
   box-shadow:
-    0 18px 44px -26px rgb(0 0 0 / 0.34),
-    0 2px 8px -6px rgb(0 0 0 / 0.18),
+    0 18px 42px -28px rgb(0 0 0 / 0.34),
+    0 2px 10px -8px rgb(0 0 0 / 0.22),
     inset 0 1px 0 rgb(255 255 255 / 0.9),
     inset 0 -1px 0 rgb(0 0 0 / 0.06) !important;
-  -webkit-backdrop-filter: blur(24px) saturate(180%);
-  backdrop-filter: blur(24px) saturate(180%);
+  -webkit-backdrop-filter: blur(26px) saturate(190%);
+  backdrop-filter: blur(26px) saturate(190%);
 }
 
 .dark .kai-bottom-nav-pill {
@@ -1309,11 +1310,12 @@ md-ripple.morphy-md-ripple {
 
 .kai-bottom-nav-pill [data-segment-indicator] {
   background:
-    radial-gradient(circle at 50% 35%, rgb(255 255 255 / 0.95), transparent 64%),
-    linear-gradient(180deg, rgb(255 255 255 / 0.94), rgb(255 255 255 / 0.74)) !important;
+    radial-gradient(circle at 50% 16%, rgb(255 255 255 / 0.98), transparent 58%),
+    linear-gradient(180deg, rgb(255 255 255 / 0.96), rgb(255 255 255 / 0.7)) !important;
   box-shadow:
-    0 11px 24px -18px rgb(0 0 0 / 0.42),
-    inset 0 1px 0 rgb(255 255 255 / 0.92) !important;
+    0 12px 25px -19px rgb(0 0 0 / 0.48),
+    0 1px 4px -3px rgb(0 0 0 / 0.18),
+    inset 0 1px 0 rgb(255 255 255 / 0.94) !important;
 }
 
 .dark .kai-bottom-nav-pill [data-segment-indicator] {
@@ -1326,10 +1328,10 @@ md-ripple.morphy-md-ripple {
 }
 
 .kai-bottom-nav-pill [role="radio"] {
-  color: rgb(60 60 67 / 0.78) !important;
+  color: rgb(60 60 67 / 0.7) !important;
   min-height: 48px;
-  gap: 0.24rem !important;
-  padding: 0.4rem 0.25rem 0.44rem !important;
+  gap: 0.22rem !important;
+  padding: 0.38rem 0.2rem 0.42rem !important;
   letter-spacing: 0;
 }
 
@@ -1347,28 +1349,34 @@ md-ripple.morphy-md-ripple {
 }
 
 .kai-bottom-nav-pill [role="radio"] svg {
-  width: 18px;
-  height: 18px;
-  opacity: 0.9;
-  stroke-width: 1.9;
+  width: 20px;
+  height: 20px;
+  opacity: 0.84;
+  stroke-width: 1.72;
+  filter: drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.6));
+  transform: translateY(0);
 }
 
 .kai-bottom-nav-pill [role="radio"][aria-checked="true"] svg {
   opacity: 1;
-  stroke-width: 2;
+  stroke-width: 2.08;
+  filter: drop-shadow(0 3px 8px rgb(0 113 227 / 0.2));
+  transform: translateY(-0.5px);
 }
 
 .kai-bottom-nav-pill [role="radio"] > span:last-of-type {
   max-width: 100%;
-  font-size: 10px;
+  font-size: 9.5px;
   font-weight: 500;
   line-height: 1;
   letter-spacing: 0;
   text-wrap: nowrap;
+  opacity: 0.92;
 }
 
 .kai-bottom-nav-pill [role="radio"][aria-checked="true"] > span:last-of-type {
   font-weight: 600;
+  opacity: 1;
 }
 
 .kai-bottom-search-action {

--- a/hushh-webapp/components/kai/kai-search-bar.tsx
+++ b/hushh-webapp/components/kai/kai-search-bar.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import {
   useCallback,
   useEffect,
@@ -17,7 +16,6 @@ import {
   type KaiCommandPaletteSelection,
 } from "@/components/kai/kai-command-palette";
 import {
-  VoiceAmbientSearchSurface,
   type VoiceAmbientMode,
 } from "@/components/kai/voice/voice-ambient-search-surface";
 import { VoiceDebugDrawer } from "@/components/kai/voice/voice-debug-drawer";
@@ -329,15 +327,10 @@ export function KaiSearchBar({
     null,
   );
   const [transcriptPreview, setTranscriptPreview] = useState<string>("");
-  const [finalTranscript, setFinalTranscript] = useState<string>("");
+  const [_finalTranscript, setFinalTranscript] = useState<string>("");
   const [lastReplyText, setLastReplyText] = useState<string>("");
   const [micPermissionStatus, setMicPermissionStatus] =
     useState<string>("unknown");
-    // If the text is stored in finalTranscript:
-const debouncedSearch = useDebouncedValue(finalTranscript, 500);
-
-// OR, if there is a standard text input state further down like 'query':
-// const debouncedSearch = useDebouncedValue(query, 500);
   const [stableMicDisabledReason, setStableMicDisabledReason] = useState<
     string | null
   >(null);
@@ -694,7 +687,7 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
     ],
   );
 
-  const submitDebugTurn = useCallback(() => {
+  const _submitDebugTurn = useCallback(() => {
     if (!VOICE_V2_FLAGS.submitDebugVisible) return;
     if (!realtimeSessionReady) {
       toast.info("Realtime session still connecting.");
@@ -709,7 +702,7 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
     );
   }, [emitDebug, realtimeSessionReady]);
 
-  const toggleMuteListening = useCallback(() => {
+  const _toggleMuteListening = useCallback(() => {
     const nextMuted = voiceSessionManager.toggleMuted();
     setSessionMuted(nextMuted);
     if (nextMuted) {
@@ -744,7 +737,7 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
     setFinalTranscript("");
   }, [sessionScopeId, setPendingConfirmation, transitionVoiceState]);
 
-  const handleReplay = useCallback(async () => {
+  const _handleReplay = useCallback(async () => {
     const replayText = String(lastReplyText || "").trim();
     if (!replayText) return;
     const turnId = createVoiceTurnId();
@@ -774,7 +767,7 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
     transitionVoiceState,
   ]);
 
-  const handleStopSpeaking = useCallback(
+  const _handleStopSpeaking = useCallback(
     (event?: MouseEvent<HTMLButtonElement>) => {
       event?.preventDefault();
       event?.stopPropagation();
@@ -901,13 +894,13 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
     transitionVoiceState,
   ]);
 
-  const handleRetry = useCallback(async () => {
+  const _handleRetry = useCallback(async () => {
     setPendingConfirmation(null);
     transitionVoiceState("idle", "retry_button_clicked");
     await startListening();
   }, [setPendingConfirmation, startListening, transitionVoiceState]);
 
-  const handleConfirmPending = useCallback(async () => {
+  const _handleConfirmPending = useCallback(async () => {
     if (!pendingConfirmation || !onVoiceResponseRef.current) {
       return;
     }
@@ -1022,7 +1015,7 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
     transitionVoiceState,
   ]);
 
-  const handleCancelPending = useCallback(() => {
+  const _handleCancelPending = useCallback(() => {
     if (!pendingConfirmation) return;
     setPendingConfirmation(null);
     setProcessingStageText("Voice action canceled.");
@@ -1647,6 +1640,7 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
   const riaVoiceActive = ambientMode !== "idle";
   const riaVoiceDisabled =
     !riaVoiceActive && (disabled || micDisabled || voiceVisibilityMode === "hidden");
+  const compactDockExpanded = open || riaVoiceActive;
   const handleRiaVoiceClick = useCallback(
     (event: MouseEvent<HTMLButtonElement>) => {
       if (riaVoiceDisabled) {
@@ -1742,8 +1736,15 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
               </ShellActionSurface>
             </div>
           ) : (
-            <div className="relative flex h-[124px] w-full items-end justify-end">
-              <div className="ml-auto flex w-[min(17rem,calc(100vw-2rem))] flex-col items-end justify-end gap-2">
+            <div className="relative flex h-[114px] w-full items-end justify-end">
+              <div
+                className={cn(
+                  "ml-auto flex flex-col items-end justify-end gap-2 transition-[width] duration-200 ease-out",
+                  compactDockExpanded
+                    ? "w-[min(15.5rem,calc(100vw-2rem))]"
+                    : "w-[58px]"
+                )}
+              >
                 <button
                   type="button"
                   className="pointer-events-auto grid h-12 w-12 place-items-center rounded-full transition-transform duration-200 ease-out hover:scale-[1.03] active:scale-[0.94] disabled:cursor-not-allowed disabled:opacity-50"
@@ -1755,66 +1756,56 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
                     <Bot className="h-[18px] w-[18px]" strokeWidth={1.95} />
                   </span>
                 </button>
-                <div className="pointer-events-auto w-full rounded-full kai-bottom-search-action p-[5px]">
-                  <VoiceAmbientSearchSurface
-                    mode={ambientMode}
-                    placeholder="Analyze, dashboard, consent with Kai"
-                    transcriptPreview={transcriptPreview}
-                    stageText={processingStageText}
-                    replyText={
-                      showSpeakingCompact || showRetryCompact
-                        ? lastReplyText || debouncedSearch
-                        : debouncedSearch
-                    }
-                    smoothedLevel={smoothedLevel}
+                <div
+                  className={cn(
+                    "pointer-events-auto grid rounded-full kai-bottom-search-action p-[5px]",
+                    compactDockExpanded ? "w-full grid-cols-2 gap-1" : "w-[58px] grid-cols-1"
+                  )}
+                  data-testid="kai-compact-search-surface"
+                  data-mode={ambientMode}
+                >
+                  <span data-testid="voice-ambient-preview" className="sr-only">
+                    {transcriptPreview || processingStageText || ""}
+                  </span>
+                  <button
+                    type="button"
+                    data-tour-id="kai-command-bar"
+                    aria-label="Open Kai command search"
+                    aria-expanded={open}
+                    aria-haspopup="dialog"
                     disabled={disabled}
-                    showMic={!micHidden}
-                    micDisabled={micDisabled}
-                    micDisabledReason={stableMicDisabledReason}
-                    showDebug={DEV_VOICE_DEBUG_ENABLED}
-                    debugActive={voiceDebugOpen}
-                    showSubmit={
-                      VOICE_V2_FLAGS.submitDebugVisible &&
-                      (showVoiceSheet || realtimeConnecting)
-                    }
-                    submitEnabled={
-                      VOICE_V2_FLAGS.submitDebugVisible && realtimeSessionReady
-                    }
-                    ttsPlaying={ttsPlaybackState === "playing"}
-                    pendingConfirmation={Boolean(
-                      showRetryCompact && pendingConfirmation,
+                    onClick={() => setOpen(true)}
+                    className={cn(
+                      "inline-flex h-11 min-w-0 items-center justify-center rounded-full px-3 text-[13px] font-semibold text-muted-foreground transition-colors hover:bg-black/[0.045] hover:text-foreground disabled:pointer-events-none disabled:opacity-50 dark:hover:bg-white/10",
+                      open && "bg-primary/10 text-primary"
                     )}
-                    onOpenSearch={() => setOpen(true)}
-                    onMicToggle={handleMicTap}
-                    onDebugToggle={(event) => {
-                      event.stopPropagation();
-                      setVoiceDebugOpen((current) => !current);
-                    }}
-                    onMuteToggle={toggleMuteListening}
-                    onSubmit={submitDebugTurn}
-                    onEnd={cancelListening}
-                    onStopSpeaking={handleStopSpeaking}
-                    onReplay={
-                      showSpeakingCompact || showRetryCompact
-                        ? handleReplay
-                        : undefined
-                    }
-                    onRetry={
-                      showRetryCompact && !pendingConfirmation
-                        ? handleRetry
-                        : undefined
-                    }
-                    onConfirm={
-                      showRetryCompact && pendingConfirmation
-                        ? handleConfirmPending
-                        : undefined
-                    }
-                    onCancel={
-                      showRetryCompact && pendingConfirmation
-                        ? handleCancelPending
-                        : undefined
-                    }
-                  />
+                  >
+                    <Search className="h-5 w-5 shrink-0" strokeWidth={1.9} />
+                    {compactDockExpanded ? <span className="ml-1.5 truncate">Search</span> : null}
+                  </button>
+                  {compactDockExpanded ? (
+                    <button
+                      type="button"
+                      aria-label={riaVoiceActive ? "End Kai voice" : "Start Kai voice"}
+                      aria-disabled={riaVoiceDisabled}
+                      disabled={voiceVisibilityMode === "hidden"}
+                      onClick={handleRiaVoiceClick}
+                      className={cn(
+                        "inline-flex h-11 min-w-0 items-center justify-center rounded-full px-3 text-[13px] font-semibold transition-colors hover:bg-black/[0.045] disabled:cursor-not-allowed dark:hover:bg-white/10",
+                        riaVoiceActive
+                          ? "bg-primary text-primary-foreground hover:bg-primary/90"
+                          : "text-muted-foreground hover:text-foreground",
+                        riaVoiceDisabled && "opacity-60"
+                      )}
+                    >
+                      {riaVoiceActive ? (
+                        <X className="h-5 w-5 shrink-0" strokeWidth={1.9} />
+                      ) : (
+                        <Mic className="h-5 w-5 shrink-0" strokeWidth={1.9} />
+                      )}
+                      <span className="ml-1.5 truncate">Voice</span>
+                    </button>
+                  ) : null}
                 </div>
               </div>
             </div>

--- a/hushh-webapp/components/kai/onboarding/KaiPersonaScreen.tsx
+++ b/hushh-webapp/components/kai/onboarding/KaiPersonaScreen.tsx
@@ -14,31 +14,35 @@ const PERSONA_CONFIG: Record<
     headline: string;
     support: string;
     footerTagline: string;
+    accent: string;
     icon: LucideIcon;
   }
 > = {
   conservative: {
-    pill: "YOU VALUE STABILITY",
-    title: "Ready for steady growth?",
-    headline: "You prefer steady progress without unnecessary swings",
-    support: "Kai helps you grow steadily - without exposing you to unnecessary risk",
+    pill: "Stability first",
+    title: "Your plan should feel steady.",
+    headline: "You prefer dependable progress with fewer surprises.",
+    support: "Kai will keep risk visible, pacing calm, and every move easy to understand.",
     footerTagline: "Smart growth. Less stress.",
+    accent: "text-emerald-600 bg-emerald-500/10 dark:text-emerald-300 dark:bg-emerald-400/12",
     icon: Shield,
   },
   balanced: {
-    pill: "YOU PLAY IT SMART",
-    title: "Ready to move ahead?",
-    headline: "You're comfortable with some ups and downs for consistent long-term growth",
-    support: "Kai balances opportunity and discipline to keep your growth on track",
-    footerTagline: "Progress - without overexposure",
+    pill: "Balanced growth",
+    title: "You like progress with discipline.",
+    headline: "You can accept some movement when the long-term path is clear.",
+    support: "Kai will balance opportunity, concentration, and timing before suggesting action.",
+    footerTagline: "Progress without overexposure.",
+    accent: "text-primary bg-primary/10 dark:text-blue-300 dark:bg-blue-400/12",
     icon: Target,
   },
   aggressive: {
-    pill: "YOU'RE BUILT FOR GROWTH",
-    title: "Ready to level up?",
-    headline: "You're comfortable with market swings when the potential reward justifies it.",
-    support: "Kai helps you pursue stronger growth while managing risk intelligently",
-    footerTagline: "Let's build momentum",
+    pill: "Growth focused",
+    title: "You are comfortable leaning in.",
+    headline: "You can handle larger swings when the upside is worth the risk.",
+    support: "Kai will help you pursue momentum while keeping downside and concentration in view.",
+    footerTagline: "Build momentum with guardrails.",
+    accent: "text-orange-600 bg-orange-500/10 dark:text-orange-300 dark:bg-orange-400/12",
     icon: TrendingUp,
   },
 };
@@ -54,56 +58,70 @@ export function KaiPersonaScreen(props: {
   return (
     <main
       data-top-content-anchor="true"
-      className="min-h-[100dvh] w-full bg-transparent flex flex-col px-8 pt-[var(--top-content-pad)] pb-[var(--app-screen-footer-pad)]"
+      className="flex min-h-[100dvh] w-full flex-col bg-transparent px-5 pt-[var(--top-content-pad)] pb-[var(--app-screen-footer-pad)] sm:px-6 lg:px-[var(--page-inline-gutter-standard)]"
     >
-      <div className="w-full max-w-md mx-auto flex-1 min-h-0 flex items-start sm:items-center">
-        <section className="relative w-full py-4">
-          <div className="relative z-10 space-y-6 text-left">
-            <div className="h-20 w-20 rounded-[24px] border border-border/60 bg-background/70 backdrop-blur-sm grid place-items-center shadow-sm">
-              <Icon icon={icon} size={40} className="text-[var(--brand-600)]" />
+      <div className="mx-auto flex min-h-[calc(100dvh-var(--top-content-pad)-var(--app-screen-footer-pad))] w-full max-w-[42rem] flex-1 items-center">
+        <section className="w-full rounded-[32px] border border-black/[0.06] bg-white/[0.74] p-5 text-center shadow-[0_24px_80px_-56px_rgba(0,0,0,0.55)] backdrop-blur-2xl sm:p-7 lg:p-8 dark:border-white/10 dark:bg-white/[0.07]">
+          <div className="mx-auto flex w-full max-w-[33rem] flex-col items-center">
+            <div
+              className={`grid h-14 w-14 place-items-center rounded-[18px] ${cfg.accent}`}
+              aria-hidden="true"
+            >
+              <Icon icon={icon} size={28} />
             </div>
 
-            <div className="space-y-3">
-              <p className="text-[13px] font-extrabold tracking-[0.2em] text-[var(--brand-600)] uppercase leading-tight">
+            <div className="mt-5 space-y-3">
+              <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
                 {cfg.pill}
               </p>
-              <h1 className="text-[clamp(2rem,9.5vw,2.75rem)] font-bold tracking-tight leading-[1.05] text-foreground">
+              <h1 className="text-balance text-[clamp(2rem,4.2vw,2.75rem)] font-normal leading-[1.06] tracking-normal text-foreground">
                 {cfg.title}
               </h1>
+              <p className="mx-auto max-w-[30rem] text-[16px] leading-[1.5] text-muted-foreground">
+                {cfg.support}
+              </p>
             </div>
 
-            <p className="text-[16px] font-medium leading-relaxed text-muted-foreground">
-              {cfg.support}
-            </p>
+            <div className="mt-7 w-full rounded-[24px] border border-black/[0.06] bg-background/72 px-5 py-5 text-left shadow-[0_18px_48px_-42px_rgba(0,0,0,0.65)] dark:border-white/10 dark:bg-white/[0.05]">
+              <p className="text-[13px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+                Kai profile
+              </p>
+              <p className="mt-2 text-[18px] font-medium leading-[1.45] text-foreground sm:text-[19px]">
+                {cfg.headline}
+              </p>
+              <p className="mt-3 text-[15px] leading-[1.45] text-muted-foreground">
+                {cfg.footerTagline}
+              </p>
+            </div>
 
-            <p className="text-[21px] font-semibold leading-relaxed text-foreground">
-              {cfg.headline}
-            </p>
+            <div className="mt-7 w-full space-y-3">
+              <Button
+                type="button"
+                size="lg"
+                fullWidth
+                onClick={props.onLaunchDashboard}
+                showRipple
+                className="h-11 rounded-full text-[15px] font-semibold shadow-[0_16px_34px_-24px_rgba(0,113,227,0.85)]"
+              >
+                Connect portfolio
+                <ArrowRight className="ml-2 h-5 w-5" aria-hidden="true" />
+              </Button>
 
-            <p className="text-[16px] font-medium leading-relaxed text-muted-foreground">
-              {cfg.footerTagline}
-            </p>
-
-            <Button type="button" size="lg" fullWidth onClick={props.onLaunchDashboard} showRipple>
-              Connect Portfolio
-              <ArrowRight className="ml-2 h-5 w-5" aria-hidden="true" />
-            </Button>
-
-            {props.onEditAnswers && (
-              <div className="pt-1">
+              {props.onEditAnswers && (
                 <Button
                   type="button"
-                  variant="blue-gradient"
+                  variant="none"
                   effect="fade"
                   size="lg"
                   fullWidth
                   onClick={props.onEditAnswers}
                   showRipple={false}
+                  className="h-11 rounded-full !bg-primary/10 text-[15px] font-semibold !text-primary shadow-none hover:!bg-primary/15 dark:!bg-primary/15"
                 >
                   Edit answers
                 </Button>
-              </div>
-            )}
+              )}
+            </div>
           </div>
         </section>
       </div>

--- a/hushh-webapp/components/kai/views/portfolio-import-view.tsx
+++ b/hushh-webapp/components/kai/views/portfolio-import-view.tsx
@@ -32,11 +32,15 @@ import { scrollAppToTop } from "@/lib/navigation/use-scroll-reset";
 import {
   kaiAppBodyClassName,
   kaiAppCardBodyClassName,
-  kaiAppCardTitleClassName,
   kaiAppCompactTitleClassName,
   kaiAppEyebrowClassName,
   kaiAppHelperClassName,
 } from "@/components/kai/shared/kai-typography";
+
+const importCardTitleClassName =
+  "text-[22px] font-medium leading-[1.12] tracking-normal text-foreground sm:text-[24px]";
+const importDropzoneTitleClassName =
+  "text-[16px] font-medium leading-[1.24] tracking-normal sm:text-[17px]";
 
 // =============================================================================
 // TYPES
@@ -163,7 +167,7 @@ export function PortfolioImportView({
     <div className="mx-auto w-full space-y-3.5 pt-3 pb-6" style={APP_MEASURE_STYLES.reading}>
       {/* Header */}
       <div className="space-y-2.5 text-center">
-        <h1 className={kaiAppCompactTitleClassName}>
+        <h1 className={cn(kaiAppCompactTitleClassName, "text-foreground")}>
           Your money
           <br />
           <span>Your options</span>
@@ -188,7 +192,7 @@ export function PortfolioImportView({
                 <Icon icon={Link2} size="md" className="text-primary" />
               </div>
               <div className="min-w-0">
-                <h3 className={kaiAppCardTitleClassName}>Connect with Plaid</h3>
+                <h3 className={importCardTitleClassName}>Connect with Plaid</h3>
                 <p className={cn(kaiAppCardBodyClassName, "mt-0.5 text-muted-foreground")}>
                   Automatically sync your brokerage accounts
                 </p>
@@ -254,7 +258,7 @@ export function PortfolioImportView({
               <Icon icon={Upload} size="md" className="text-primary" />
             </div>
             <div>
-              <h3 className={cn(kaiAppCardTitleClassName, "text-foreground")}>Upload statement</h3>
+              <h3 className={importCardTitleClassName}>Upload statement</h3>
               <p className={cn(kaiAppCardBodyClassName, "mt-0.5 text-muted-foreground")}>
                 Import official brokerage PDF or CSV manually
               </p>
@@ -282,7 +286,7 @@ export function PortfolioImportView({
 
             {/* Text */}
             <div className="space-y-1">
-              <h3 className={cn(kaiAppCardTitleClassName, "text-primary")}>
+              <h3 className={cn(importDropzoneTitleClassName, "text-primary")}>
                 {isDragging
                   ? "Drop your file here"
                   : "Tap to upload official statement"}

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -7,11 +7,11 @@ import React, { useEffect, useMemo, type CSSProperties } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import {
   ChartSpline,
+  ChartCandlestick,
+  CircleUserRound,
   Compass,
   FileSpreadsheet,
   House,
-  Landmark,
-  UserRound,
   Users,
   WalletCards,
 } from "lucide-react";
@@ -126,7 +126,7 @@ export const Navbar = () => {
             {
               value: "profile",
               label: "Profile",
-              icon: UserRound,
+              icon: CircleUserRound,
               badge: pendingConsents > 0 ? pendingConsents : undefined,
               dataTourId: "nav-profile",
             },
@@ -135,7 +135,7 @@ export const Navbar = () => {
             {
               value: "market",
               label: "Market",
-              icon: Landmark,
+              icon: ChartCandlestick,
               dataTourId: "nav-market",
             },
             {
@@ -159,7 +159,7 @@ export const Navbar = () => {
             {
               value: "profile",
               label: "Profile",
-              icon: UserRound,
+              icon: CircleUserRound,
               badge: pendingConsents > 0 ? pendingConsents : undefined,
               dataTourId: "nav-profile",
             },


### PR DESCRIPTION
## Summary
- tighten Kai portfolio import typography so card headings no longer overpower the page title
- replace the oversized bottom search/voice surface with a compact search-first dock that reveals Voice on expand
- polish persona outcome screens with a centered Apple-like hierarchy and softer copy
- update the voice search test to preserve voice session behavior through the compact dock

## Validation
- npm run typecheck
- npm run lint
- npm run verify:design-system
- npm test -- --run __tests__/voice/kai-search-bar.test.ts --reporter=dot