### PR TITLE
feat(connect): harvest Connect discovery + kai-circle bridge (from #2443)

### DIFF
--- a/hushh-webapp/__tests__/connect/connect-candidates.test.ts
+++ b/hushh-webapp/__tests__/connect/connect-candidates.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeRiaToCandidate,
+  normalizeInvestorToCandidate,
+  normalizeContactMatchToCandidate,
+  normalizeConsentEntryToCandidate,
+  mergeCandidates,
+} from "@/lib/connect/candidates";
+import type { MarketplaceRia, MarketplaceInvestor } from "@/lib/services/ria-service";
+import type { ConsentCenterEntry } from "@/lib/services/consent-center-service";
+import type { ConnectCandidate } from "@/lib/connect/types";
+
+describe("Connect Candidates Normalization & Merge Module", () => {
+  describe("normalizeRiaToCandidate", () => {
+    it("should correctly normalize a MarketplaceRia profile", () => {
+      const mockRia: MarketplaceRia = {
+        id: "ria-1",
+        user_id: "user-ria-1",
+        display_name: "Alice Advisor",
+        headline: "Wealth builder",
+        strategy_summary: "Conservative growth strategy",
+        verification_status: "active",
+        is_test_profile: false,
+        firms: [{ firm_id: "firm-1", legal_name: "Alpha Wealth" }],
+      };
+
+      const candidate = normalizeRiaToCandidate(mockRia, { currentPersona: "investor" });
+      expect(candidate.candidateId).toBe("user:user-ria-1");
+      expect(candidate.displayName).toBe("Alice Advisor");
+      expect(candidate.headline).toBe("Wealth builder");
+      expect(candidate.firmName).toBe("Alpha Wealth");
+      expect(candidate.kind).toBe("ria");
+      expect(candidate.connectionStatus).toBe("available");
+      expect(candidate.primaryCta).toBe("connect");
+    });
+  });
+
+  describe("normalizeInvestorToCandidate", () => {
+    it("should correctly normalize a MarketplaceInvestor profile", () => {
+      const mockInvestor: MarketplaceInvestor = {
+        id: "inv-1",
+        source_type: "hushh_user",
+        user_id: "user-inv-1",
+        display_name: "Bob Capitalist",
+        headline: "Growth investor",
+        location_hint: "New York",
+        strategy_summary: "Venture scale tech investments",
+        connectable: true,
+      };
+
+      const candidate = normalizeInvestorToCandidate(mockInvestor, { currentPersona: "ria" });
+      expect(candidate.candidateId).toBe("user:user-inv-1");
+      expect(candidate.displayName).toBe("Bob Capitalist");
+      expect(candidate.headline).toBe("Growth investor");
+      expect(candidate.kind).toBe("investor");
+      expect(candidate.connectionStatus).toBe("available");
+      expect(candidate.primaryCta).toBe("connect");
+    });
+
+    it("should handle public sec profiles correctly", () => {
+      const mockInvestor: MarketplaceInvestor = {
+        id: "sec-1",
+        source_type: "public_sec",
+        public_profile_id: "12345",
+        display_name: "SEC Corp Filing Profile",
+        location_hint: "Washington DC",
+        connectable: false,
+      };
+
+      const candidate = normalizeInvestorToCandidate(mockInvestor, { currentPersona: "ria" });
+      expect(candidate.candidateId).toBe("public:public_sec:12345");
+      expect(candidate.kind).toBe("public_profile");
+      expect(candidate.primaryCta).toBe("none");
+    });
+  });
+
+  describe("normalizeContactMatchToCandidate", () => {
+    it("should create new candidate if no existing matches", () => {
+      const match = {
+        user_id: "user-match-1",
+        kind: "ria",
+        display_name: "Charlie Contact",
+        phone_last4: "5678",
+        headline: "Tax planning advisor",
+      };
+
+      const candidate = normalizeContactMatchToCandidate(match, { existingCandidates: [] });
+      expect(candidate).not.toBeNull();
+      expect(candidate!.candidateId).toBe("user:user-match-1");
+      expect(candidate!.sourceTypes).toContain("contact_match");
+      expect(candidate!.displayName).toBe("Charlie Contact");
+      expect(candidate!.headline).toBe("Tax planning advisor");
+    });
+
+    it("should augment existing candidate", () => {
+      const existing: ConnectCandidate = {
+        candidateId: "user:user-match-1",
+        kind: "ria",
+        sourceTypes: ["marketplace_ria"],
+        userId: "user-match-1",
+        displayName: "Charlie",
+        isDiscoverable: true,
+        connectionStatus: "available",
+        score: 10,
+        reasons: [],
+        primaryCta: "connect",
+        secondaryCtas: [],
+      };
+
+      const match = {
+        user_id: "user-match-1",
+        kind: "ria",
+        display_name: "Charlie Contact",
+        phone_last4: "5678",
+        headline: "Tax planning advisor",
+      };
+
+      const candidate = normalizeContactMatchToCandidate(match, { existingCandidates: [existing] });
+      expect(candidate).not.toBeNull();
+      expect(candidate!.candidateId).toBe("user:user-match-1");
+      expect(candidate!.sourceTypes).toContain("contact_match");
+      expect(candidate!.sourceTypes).toContain("marketplace_ria");
+      expect(candidate!.displayName).toBe("Charlie");
+    });
+
+    it("preserves marketplace visibility from contact-match profiles", () => {
+      const match = {
+        user_id: "user-hidden",
+        kind: "investor",
+        display_name: "Hidden Contact",
+        phone_last4: "5678",
+        headline: "Private investor",
+        profile: {
+          id: "hushh_user:user-hidden",
+          source_type: "hushh_user",
+          user_id: "user-hidden",
+          display_name: "Hidden Contact",
+          visibility_posture: "private",
+          exposure_enabled: true,
+        },
+      };
+
+      const candidate = normalizeContactMatchToCandidate(match, { existingCandidates: [] });
+
+      expect(candidate).not.toBeNull();
+      expect(candidate!.visibilityPosture).toBe("private");
+      expect(candidate!.exposureEnabled).toBe(true);
+      expect(candidate!.isDiscoverable).toBe(false);
+    });
+  });
+
+  describe("normalizeConsentEntryToCandidate", () => {
+    it("should correctly convert ConsentCenterEntry for active connection", () => {
+      const entry: ConsentCenterEntry = {
+        request_id: "req-1",
+        counterpart_id: "counter-1",
+        counterpart_type: "ria",
+        counterpart_label: "Dave Director",
+        counterpart_secondary_label: "Fiduciary advisor",
+        relationship_status: "active",
+      };
+
+      const candidate = normalizeConsentEntryToCandidate(entry, { surface: "active" });
+      expect(candidate).not.toBeNull();
+      expect(candidate!.candidateId).toBe("user:counter-1");
+      expect(candidate!.connectionStatus).toBe("connected");
+      expect(candidate!.primaryCta).toBe("view_connection");
+    });
+  });
+
+  describe("mergeCandidates", () => {
+    it("should merge unique sources and pick higher score", () => {
+      const c1: ConnectCandidate = {
+        candidateId: "user:123",
+        kind: "ria",
+        sourceTypes: ["marketplace_ria"],
+        userId: "123",
+        displayName: "John",
+        isDiscoverable: true,
+        connectionStatus: "connected",
+        score: 10,
+        reasons: [{ code: "ria_verified", label: "RIA Verified", weight: 10, source: "marketplace_ria" }],
+        primaryCta: "connect",
+        secondaryCtas: [],
+      };
+
+      const c2: ConnectCandidate = {
+        candidateId: "user:123",
+        kind: "ria",
+        sourceTypes: ["contact_match"],
+        userId: "123",
+        displayName: "John Doe",
+        isDiscoverable: true,
+        connectionStatus: "pending",
+        score: 50,
+        reasons: [{ code: "contact_match", label: "In Contacts", weight: 50, source: "contact_match" }],
+        primaryCta: "review_request",
+        secondaryCtas: [],
+      };
+
+      const merged = mergeCandidates([c1, c2]);
+      expect(merged).toHaveLength(1);
+      expect(merged[0]?.displayName).toBe("John Doe"); // longer display name
+      expect(merged[0]?.sourceTypes).toContain("marketplace_ria");
+      expect(merged[0]?.sourceTypes).toContain("contact_match");
+      expect(merged[0]?.connectionStatus).toBe("connected"); // connected has priority over pending in priority map
+      expect(merged[0]?.score).toBe(50);
+      expect(merged[0]?.reasons).toHaveLength(2);
+    });
+
+    it("preserves hidden marketplace visibility when merging with another source", () => {
+      const visibleContact: ConnectCandidate = {
+        candidateId: "user:123",
+        kind: "investor",
+        sourceTypes: ["contact_match"],
+        userId: "123",
+        displayName: "John Contact",
+        visibilityPosture: "default_available",
+        exposureEnabled: true,
+        isDiscoverable: true,
+        connectionStatus: "available",
+        score: 50,
+        reasons: [{ code: "contact_match", label: "In Contacts", weight: 50, source: "contact_match" }],
+        primaryCta: "open_profile",
+        secondaryCtas: [],
+      };
+      const hiddenMarketplace: ConnectCandidate = {
+        candidateId: "user:123",
+        kind: "investor",
+        sourceTypes: ["marketplace_investor"],
+        userId: "123",
+        displayName: "John Hidden",
+        visibilityPosture: "private",
+        exposureEnabled: false,
+        isDiscoverable: false,
+        connectionStatus: "available",
+        score: 20,
+        reasons: [],
+        primaryCta: "open_profile",
+        secondaryCtas: [],
+      };
+
+      const [merged] = mergeCandidates([visibleContact, hiddenMarketplace]);
+
+      expect(merged.visibilityPosture).toBe("private");
+      expect(merged.exposureEnabled).toBe(false);
+      expect(merged.isDiscoverable).toBe(false);
+    });
+  });
+});

--- a/hushh-webapp/__tests__/connect/connect-ranking.test.ts
+++ b/hushh-webapp/__tests__/connect/connect-ranking.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeQueryScore,
+  computeConnectionStatusScore,
+  computeSourceScore,
+  applyScoreToCandidate,
+  sortCandidatesByScore,
+  filterPassedCandidates,
+  CONNECT_SCORES,
+} from "@/lib/connect/connect-ranking";
+import type { ConnectCandidate } from "@/lib/connect/types";
+
+describe("Connect Ranking Module", () => {
+  describe("computeQueryScore", () => {
+    it("should return 0 score and empty reasons if query is empty", () => {
+      const result = computeQueryScore({ query: "" });
+      expect(result.score).toBe(0);
+      expect(result.reasons).toEqual([]);
+    });
+
+    it("should boost if query matches name or firmName", () => {
+      const result = computeQueryScore({
+        query: "john",
+        displayName: "John Doe",
+        firmName: "Capital Ltd",
+      });
+      expect(result.score).toBe(CONNECT_SCORES.QUERY_NAME_MATCH);
+      expect(result.reasons[0]?.code).toBe("query_match_name");
+    });
+
+    it("should boost if query matches headline or summary and not name", () => {
+      const result = computeQueryScore({
+        query: "expert",
+        displayName: "John Doe",
+        headline: "Expert RIA advisor",
+        summary: "Providing wealth growth",
+      });
+      expect(result.score).toBe(CONNECT_SCORES.QUERY_HEADLINE_MATCH);
+      expect(result.reasons[0]?.code).toBe("query_match_headline");
+    });
+  });
+
+  describe("computeConnectionStatusScore", () => {
+    it("should award correct scores based on connection status", () => {
+      expect(computeConnectionStatusScore({ connectionStatus: "connected" }).score).toBe(
+        CONNECT_SCORES.ACTIVE_CONNECTION,
+      );
+      expect(computeConnectionStatusScore({ connectionStatus: "pending" }).score).toBe(
+        CONNECT_SCORES.PENDING_CONNECTION,
+      );
+      expect(computeConnectionStatusScore({ connectionStatus: "previous" }).score).toBe(
+        CONNECT_SCORES.PENDING_CONNECTION,
+      );
+      expect(computeConnectionStatusScore({ connectionStatus: "connect_requested" }).score).toBe(
+        CONNECT_SCORES.CONNECT_REQUESTED,
+      );
+      expect(computeConnectionStatusScore({ connectionStatus: "shortlisted" }).score).toBe(
+        CONNECT_SCORES.SHORTLISTED,
+      );
+      expect(computeConnectionStatusScore({ connectionStatus: "passed" }).score).toBe(
+        CONNECT_SCORES.PASSED,
+      );
+    });
+  });
+
+  describe("computeSourceScore", () => {
+    it("should add contact match boost", () => {
+      const result = computeSourceScore(["contact_match"], "hushh_user");
+      expect(result.score).toBe(CONNECT_SCORES.CONTACT_MATCH + CONNECT_SCORES.VISIBLE_PROFILE);
+    });
+
+    it("should add verified RIA boost", () => {
+      const result = computeSourceScore(["marketplace_ria"], "ria", "active");
+      expect(result.score).toBe(CONNECT_SCORES.VERIFIED_RIA + CONNECT_SCORES.VISIBLE_PROFILE);
+    });
+  });
+
+  describe("applyScoreToCandidate", () => {
+    it("should correctly compile score and reasons", () => {
+      const candidate: ConnectCandidate = {
+        candidateId: "user:123",
+        kind: "ria",
+        sourceTypes: ["marketplace_ria"],
+        userId: "123",
+        displayName: "Alice Smith",
+        headline: "Wealth builder",
+        verificationStatus: "active",
+        connectionStatus: "connected",
+        isDiscoverable: true,
+        score: 0,
+        reasons: [],
+        primaryCta: "view_connection",
+        secondaryCtas: [],
+      };
+
+      const result = applyScoreToCandidate(candidate, "Alice");
+      expect(result.score).toBe(
+        CONNECT_SCORES.ACTIVE_CONNECTION +
+          CONNECT_SCORES.VISIBLE_PROFILE +
+          CONNECT_SCORES.VERIFIED_RIA +
+          CONNECT_SCORES.QUERY_NAME_MATCH,
+      );
+      expect(result.reasons).toHaveLength(4);
+    });
+  });
+
+  describe("sortCandidatesByScore", () => {
+    it("should sort candidates descending by score", () => {
+      const c1 = { score: 10 } as ConnectCandidate;
+      const c2 = { score: 50 } as ConnectCandidate;
+      const c3 = { score: 30 } as ConnectCandidate;
+      const sorted = sortCandidatesByScore([c1, c2, c3]);
+      expect(sorted.map((c) => c.score)).toEqual([50, 30, 10]);
+    });
+  });
+
+  describe("filterPassedCandidates", () => {
+    it("should remove passed candidates", () => {
+      const c1 = { connectionStatus: "available" } as ConnectCandidate;
+      const c2 = { connectionStatus: "passed", sourceTypes: ["marketplace_investor"] } as ConnectCandidate;
+      const result = filterPassedCandidates([c1, c2]);
+      expect(result).toHaveLength(1);
+    });
+
+    it("should keep passed candidate if it has active/pending connection and inclusion is requested", () => {
+      const c1 = { connectionStatus: "passed", sourceTypes: ["active_connection"] } as ConnectCandidate;
+      const c2 = { connectionStatus: "passed", sourceTypes: ["marketplace_investor"] } as ConnectCandidate;
+      const result = filterPassedCandidates([c1, c2], true);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe(c1);
+    });
+  });
+});

--- a/hushh-webapp/__tests__/connect/connect-service.test.ts
+++ b/hushh-webapp/__tests__/connect/connect-service.test.ts
@@ -1,0 +1,276 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  hasLocalContactMatchFixture,
+  loadConnectPayload,
+  loadContactMatches,
+} from "@/lib/connect/service";
+
+const mockBuildMarketplaceContactLookups = vi.fn();
+const mockBuildMarketplaceContactLookupsFromQuery = vi.fn();
+const mockMatchMarketplaceContacts = vi.fn();
+const mockListConsentEntries = vi.fn();
+
+vi.mock("@/lib/marketplace/contact-matching", () => ({
+  buildMarketplaceContactLookups: (...args: unknown[]) =>
+    mockBuildMarketplaceContactLookups(...args),
+  buildMarketplaceContactLookupsFromQuery: (...args: unknown[]) =>
+    mockBuildMarketplaceContactLookupsFromQuery(...args),
+}));
+
+vi.mock("@/lib/services/consent-center-service", () => ({
+  ConsentCenterService: {
+    listEntries: (...args: unknown[]) => mockListConsentEntries(...args),
+  },
+}));
+
+vi.mock("@/lib/services/ria-service", () => ({
+  RiaService: {
+    searchRias: vi.fn(),
+    searchInvestors: vi.fn(),
+    searchInvestorDeck: vi.fn(),
+    listClients: vi.fn(),
+    listInvestorActions: vi.fn(),
+    matchMarketplaceContacts: (...args: unknown[]) =>
+      mockMatchMarketplaceContacts(...args),
+  },
+  isIAMSchemaNotReadyError: () => false,
+}));
+
+describe("Connect service contact matching", () => {
+  beforeEach(() => {
+    mockBuildMarketplaceContactLookups.mockReset();
+    mockBuildMarketplaceContactLookupsFromQuery.mockReset();
+    mockMatchMarketplaceContacts.mockReset();
+    mockListConsentEntries.mockReset();
+    mockMatchMarketplaceContacts.mockResolvedValue([]);
+    mockBuildMarketplaceContactLookupsFromQuery.mockResolvedValue({
+      phoneLookups: [],
+      emailLookups: [],
+    });
+    mockListConsentEntries.mockResolvedValue({ items: [] });
+    window.localStorage.clear();
+  });
+
+  it("sends only secure contact hashes and last4 values to the marketplace API", async () => {
+    mockBuildMarketplaceContactLookups.mockResolvedValue({
+      lookups: [
+        {
+          hash: "a".repeat(64),
+          last4: "0101",
+          displayName: "Local Contact Name",
+        },
+      ],
+      phoneLookups: [
+        {
+          hash: "a".repeat(64),
+          last4: "0101",
+          displayName: "Local Contact Name",
+        },
+      ],
+      emailLookups: [
+        {
+          hash: "b".repeat(64),
+          displayName: "Local Contact Name",
+          domain: "example.com",
+        },
+      ],
+      totalContacts: 1,
+      sourcePlatform: "ios",
+    });
+    mockMatchMarketplaceContacts.mockResolvedValue([
+      {
+        user_id: "matched_user",
+        kind: "ria",
+        display_name: "Matched Advisor",
+        phone_last4: "0101",
+        profile: {
+          id: "ria_1",
+          user_id: "matched_user",
+          display_name: "Matched Advisor",
+          verification_status: "active",
+          exposure_enabled: true,
+          visibility_posture: "default_available",
+        },
+      },
+    ]);
+
+    const result = await loadContactMatches("id-token", { limit: 25 });
+
+    expect(mockBuildMarketplaceContactLookups).toHaveBeenCalledWith({ limit: 25 });
+    expect(mockMatchMarketplaceContacts).toHaveBeenCalledWith("id-token", {
+      phone_lookups: [
+        {
+          hash: "a".repeat(64),
+          last4: "0101",
+        },
+      ],
+      email_lookups: [
+        {
+          hash: "b".repeat(64),
+        },
+      ],
+      limit: 50,
+    });
+    expect(result.matches).toHaveLength(1);
+    expect(JSON.stringify(mockMatchMarketplaceContacts.mock.calls[0])).not.toContain(
+      "Local Contact Name",
+    );
+    expect(JSON.stringify(mockMatchMarketplaceContacts.mock.calls[0])).not.toContain(
+      "example.com",
+    );
+  });
+
+  it("can use an explicit local web fixture when the backend match API is unavailable", async () => {
+    mockBuildMarketplaceContactLookups.mockResolvedValue({
+      lookups: [
+        {
+          hash: "b".repeat(64),
+          last4: "2222",
+          displayName: "Fixture Contact",
+        },
+      ],
+      phoneLookups: [
+        {
+          hash: "b".repeat(64),
+          last4: "2222",
+          displayName: "Fixture Contact",
+        },
+      ],
+      emailLookups: [],
+      totalContacts: 1,
+      sourcePlatform: "web",
+    });
+    mockMatchMarketplaceContacts.mockRejectedValue(new Error("backend offline"));
+    window.localStorage.setItem(
+      "hushh:dev:marketplace-contact-matches",
+      JSON.stringify([
+        {
+          user_id: "fixture_user",
+          kind: "investor",
+          display_name: "Fixture Investor",
+          phone_last4: "2222",
+          profile: {
+            id: "fixture_user",
+            source_type: "hushh_user",
+            user_id: "fixture_user",
+            display_name: "Fixture Investor",
+            connectable: true,
+            exposure_enabled: true,
+            visibility_posture: "default_available",
+          },
+        },
+      ]),
+    );
+
+    const result = await loadContactMatches("id-token");
+
+    expect(result.error).toBeUndefined();
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0]?.display_name).toBe("Fixture Investor");
+    expect(result.sourcePlatform).toBe("web");
+  });
+
+  it("reports whether a local contact match fixture is available", () => {
+    expect(hasLocalContactMatchFixture()).toBe(false);
+
+    window.localStorage.setItem(
+      "hushh:dev:marketplace-contact-matches",
+      JSON.stringify([
+        {
+          user_id: "fixture_user",
+          kind: "investor",
+          display_name: "Fixture Investor",
+        },
+      ]),
+    );
+
+    expect(hasLocalContactMatchFixture()).toBe(true);
+  });
+
+  it("uses secure contact matching for exact email search without sending the raw query", async () => {
+    const riaService = await import("@/lib/services/ria-service");
+    vi.mocked(riaService.RiaService.searchRias).mockResolvedValue([]);
+    vi.mocked(riaService.RiaService.searchInvestors).mockResolvedValue([]);
+    vi.mocked(riaService.RiaService.listClients).mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      limit: 50,
+      has_more: false,
+    });
+    vi.mocked(riaService.RiaService.listInvestorActions).mockResolvedValue([]);
+    mockMatchMarketplaceContacts.mockResolvedValue([
+      {
+        user_id: "matched_user",
+        kind: "investor",
+        display_name: "Matched Investor",
+        matched_by: "email",
+        profile: {
+          id: "hushh_user:matched_user",
+          source_type: "hushh_user",
+          user_id: "matched_user",
+          display_name: "Matched Investor",
+          connectable: true,
+          exposure_enabled: true,
+          visibility_posture: "default_available",
+        },
+      },
+    ]);
+    mockBuildMarketplaceContactLookupsFromQuery.mockResolvedValue({
+      phoneLookups: [],
+      emailLookups: [{ hash: "c".repeat(64) }],
+    });
+
+    const payload = await loadConnectPayload({
+      idToken: "id-token",
+      userId: "viewer",
+      persona: "investor",
+      query: "Person@Example.com",
+    });
+
+    expect(payload.contactMatches).toHaveLength(1);
+    expect(mockMatchMarketplaceContacts).toHaveBeenCalledWith(
+      "id-token",
+      expect.objectContaining({
+        phone_lookups: [],
+        email_lookups: [
+          {
+            hash: "c".repeat(64),
+          },
+        ],
+      }),
+    );
+    expect(JSON.stringify(mockMatchMarketplaceContacts.mock.calls[0])).not.toContain(
+      "Person@Example.com",
+    );
+  });
+
+  it("clamps marketplace discovery limits to the backend API contract", async () => {
+    const riaService = await import("@/lib/services/ria-service");
+    vi.mocked(riaService.RiaService.searchRias).mockResolvedValue([]);
+    vi.mocked(riaService.RiaService.searchInvestors).mockResolvedValue([]);
+    vi.mocked(riaService.RiaService.listClients).mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      limit: 50,
+      has_more: false,
+    });
+    vi.mocked(riaService.RiaService.listInvestorActions).mockResolvedValue([]);
+
+    await loadConnectPayload({
+      idToken: "id-token",
+      userId: "viewer",
+      persona: "investor",
+      limit: 64,
+    });
+
+    expect(riaService.RiaService.searchRias).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 50 }),
+    );
+    expect(riaService.RiaService.searchInvestors).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 50 }),
+    );
+  });
+});

--- a/hushh-webapp/__tests__/connect/connect-visibility.test.ts
+++ b/hushh-webapp/__tests__/connect/connect-visibility.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import {
+  isVisibilityPostureDiscoverable,
+  isDiscoverable,
+  buildCandidateId,
+  mergeSourceTypes,
+  hasConnectionSource,
+} from "@/lib/connect/connect-visibility";
+import type { ConnectCandidate } from "@/lib/connect/types";
+
+describe("Connect Visibility Helper Module", () => {
+  describe("isVisibilityPostureDiscoverable", () => {
+    it("should return true for default or public postures", () => {
+      expect(isVisibilityPostureDiscoverable("public", "hushh_user")).toBe(true);
+      expect(isVisibilityPostureDiscoverable("default_available", "hushh_user")).toBe(true);
+      expect(isVisibilityPostureDiscoverable("limited", "hushh_user")).toBe(true);
+    });
+
+    it("should return false for private posture", () => {
+      expect(isVisibilityPostureDiscoverable("private", "hushh_user")).toBe(false);
+    });
+
+    it("should fallback to true for RIA/investor if posture is not defined", () => {
+      expect(isVisibilityPostureDiscoverable(null, "ria")).toBe(true);
+      expect(isVisibilityPostureDiscoverable(undefined, "investor")).toBe(true);
+      expect(isVisibilityPostureDiscoverable(null, "public_profile")).toBe(true);
+    });
+
+    it("should fallback to false for generic hushh_user if posture is not defined", () => {
+      expect(isVisibilityPostureDiscoverable(null, "hushh_user")).toBe(false);
+      expect(isVisibilityPostureDiscoverable(undefined, "hushh_user")).toBe(false);
+    });
+  });
+
+  describe("isDiscoverable", () => {
+    const baseCandidate: ConnectCandidate = {
+      candidateId: "user:123",
+      kind: "ria",
+      sourceTypes: ["marketplace_ria"],
+      userId: "123",
+      displayName: "John Doe",
+      isDiscoverable: true,
+      connectionStatus: "available",
+      score: 0,
+      reasons: [],
+      primaryCta: "connect",
+      secondaryCtas: [],
+    };
+
+    it("should always allow test profiles through", () => {
+      const candidate: ConnectCandidate = {
+        ...baseCandidate,
+        isTestProfile: true,
+        exposureEnabled: false,
+        visibilityPosture: "private",
+      };
+      expect(isDiscoverable(candidate)).toBe(true);
+    });
+
+    it("should exclude candidate if exposureEnabled is false", () => {
+      const candidate: ConnectCandidate = {
+        ...baseCandidate,
+        exposureEnabled: false,
+      };
+      expect(isDiscoverable(candidate)).toBe(false);
+    });
+
+    it("should exclude candidate if posture is private", () => {
+      const candidate: ConnectCandidate = {
+        ...baseCandidate,
+        visibilityPosture: "private",
+      };
+      expect(isDiscoverable(candidate)).toBe(false);
+    });
+
+    it("should allow candidate if connectionStatus overrides discoverability", () => {
+      const candidate: ConnectCandidate = {
+        ...baseCandidate,
+        exposureEnabled: false,
+        visibilityPosture: "private",
+        connectionStatus: "connected",
+      };
+      expect(isDiscoverable(candidate)).toBe(true);
+    });
+
+    it("should return the candidate discoverable flag as fallback", () => {
+      const candidate1: ConnectCandidate = {
+        ...baseCandidate,
+        isDiscoverable: true,
+      };
+      const candidate2: ConnectCandidate = {
+        ...baseCandidate,
+        isDiscoverable: false,
+      };
+      expect(isDiscoverable(candidate1)).toBe(true);
+      expect(isDiscoverable(candidate2)).toBe(false);
+    });
+  });
+
+  describe("buildCandidateId", () => {
+    it("should return user id format if userId is provided", () => {
+      expect(buildCandidateId({ userId: "abc" })).toBe("user:abc");
+      expect(buildCandidateId({ userId: " abc " })).toBe("user:abc");
+    });
+
+    it("should return public profile format if publicProfileId is provided and no userId", () => {
+      expect(buildCandidateId({ publicProfileId: 100, sourceType: "sec" })).toBe("public:sec:100");
+      expect(buildCandidateId({ publicProfileId: "200", sourceType: "" })).toBe("public:public:200");
+    });
+
+    it("should return contact fallback if neither userId nor publicProfileId is provided", () => {
+      expect(buildCandidateId({ fallbackLabel: "Alice Smith" })).toBe("contact:alice_smith");
+      expect(buildCandidateId({})).toBe("contact:unknown");
+    });
+  });
+
+  describe("mergeSourceTypes", () => {
+    it("should merge unique sources", () => {
+      expect(mergeSourceTypes(["marketplace_ria"], ["contact_match"])).toEqual([
+        "marketplace_ria",
+        "contact_match",
+      ]);
+      expect(mergeSourceTypes(["marketplace_ria"], ["marketplace_ria", "kai_test"])).toEqual([
+        "marketplace_ria",
+        "kai_test",
+      ]);
+    });
+  });
+
+  describe("hasConnectionSource", () => {
+    it("should return true if active/pending/previous connection source exists", () => {
+      expect(hasConnectionSource(["active_connection"])).toBe(true);
+      expect(hasConnectionSource(["pending_connection", "contact_match"])).toBe(true);
+      expect(hasConnectionSource(["previous_connection"])).toBe(true);
+    });
+
+    it("should return false if no connection source exists", () => {
+      expect(hasConnectionSource(["marketplace_ria"])).toBe(false);
+      expect(hasConnectionSource(["contact_match"])).toBe(false);
+    });
+  });
+});

--- a/hushh-webapp/__tests__/lib/one-location/kai-circle-connect-bridge.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/kai-circle-connect-bridge.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+
+import { buildKaiCircleCandidates } from "@/lib/one-location/kai-circle-connect-bridge";
+import { buildKaiCircleSections, kaiCircleSectionKey } from "@/lib/one-location/kai-circle-sections";
+import { resolveKaiCircleCtas } from "@/lib/one-location/kai-circle-ctas";
+import type { ConnectCandidate } from "@/lib/connect/types";
+import type { OneLocationRecipient } from "@/lib/one-location/types";
+
+const TEST_LOCATION_KEY_ALGORITHM = "test-location-key-agreement";
+
+function connectCandidate(overrides: Partial<ConnectCandidate> = {}): ConnectCandidate {
+  return {
+    candidateId: "user:user_b",
+    kind: "ria",
+    sourceTypes: ["marketplace_ria"],
+    userId: "user_b",
+    publicProfileId: null,
+    sourceType: "marketplace_ria",
+    displayName: "Advisor B",
+    headline: "Advisor",
+    summary: null,
+    avatarUrl: null,
+    firmName: null,
+    locationLabel: null,
+    visibilityPosture: "default_available",
+    exposureEnabled: true,
+    isDiscoverable: true,
+    verificationStatus: "active",
+    verificationBadge: "RIA Verified",
+    connectionStatus: "available",
+    actionStatus: null,
+    score: 60,
+    reasons: [],
+    primaryCta: "connect",
+    secondaryCtas: [],
+    profileHref: "/marketplace?riaId=ria_b",
+    connectionHref: null,
+    ...overrides,
+  };
+}
+
+function recipient(overrides: Partial<OneLocationRecipient> = {}): OneLocationRecipient {
+  return {
+    userId: "user_b",
+    displayName: "Advisor B",
+    phoneVerified: true,
+    keyId: "key_b",
+    publicKeyJwk: { kty: "EC", crv: "P-256", x: "x", y: "y" },
+    keyAlgorithm: TEST_LOCATION_KEY_ALGORITHM,
+    canReceiveLocation: true,
+    recommendationCategory: "location_ready",
+    recommendationTier: "available",
+    recommendationScore: 40,
+    ...overrides,
+  };
+}
+
+describe("KAI Circle Connect bridge", () => {
+  it("merges Connect candidates with One Location recipient readiness by userId", () => {
+    const [candidate] = buildKaiCircleCandidates({
+      connectCandidates: [connectCandidate({ sourceTypes: ["marketplace_ria", "contact_match"] })],
+      state: {
+        recipients: [recipient()],
+        viewerCapabilities: { hasLocationRecipientKey: true },
+      },
+    });
+
+    expect(candidate.userId).toBe("user_b");
+    expect(candidate.isShareReady).toBe(true);
+    expect(candidate.keyId).toBe("key_b");
+    expect(candidate.sourceTypes).toEqual(
+      expect.arrayContaining(["one_location_recipient", "marketplace_ria", "contact_match"]),
+    );
+    expect(resolveKaiCircleCtas({ candidate, mode: "share" })[0]).toMatchObject({
+      id: "share_location",
+      enabled: true,
+    });
+  });
+
+  it("excludes public profiles without One Location recipient identity", () => {
+    const candidates = buildKaiCircleCandidates({
+      connectCandidates: [
+        connectCandidate({
+          candidateId: "public:public_sec:123",
+          kind: "public_profile",
+          userId: null,
+          publicProfileId: "123",
+          sourceTypes: ["public_sec"],
+          profileHref: "/marketplace?investorId=123",
+        }),
+      ],
+      state: { recipients: [], viewerCapabilities: { hasLocationRecipientKey: true } },
+    });
+
+    expect(candidates).toEqual([]);
+  });
+
+  it("excludes Connect-only professional profiles from the location sharing list", () => {
+    const candidates = buildKaiCircleCandidates({
+      connectCandidates: [connectCandidate({ userId: "user_c", candidateId: "user:user_c" })],
+      state: { recipients: [], viewerCapabilities: { hasLocationRecipientKey: true } },
+    });
+
+    expect(candidates).toEqual([]);
+  });
+
+  it("defensively filters private or exposure-disabled Connect candidates", () => {
+    const candidates = buildKaiCircleCandidates({
+      connectCandidates: [
+        connectCandidate({
+          candidateId: "user:private",
+          userId: "private",
+          exposureEnabled: false,
+        }),
+        connectCandidate({
+          candidateId: "user:hidden",
+          userId: "hidden",
+          visibilityPosture: "private",
+        }),
+      ],
+      state: { recipients: [] },
+    });
+
+    expect(candidates).toEqual([]);
+  });
+
+  it("hides ready One Location recipients when Connect marks that user private", () => {
+    const candidates = buildKaiCircleCandidates({
+      connectCandidates: [
+        connectCandidate({
+          exposureEnabled: false,
+          visibilityPosture: "private",
+          isDiscoverable: false,
+        }),
+      ],
+      state: {
+        recipients: [recipient()],
+        viewerCapabilities: { hasLocationRecipientKey: true },
+      },
+    });
+
+    expect(candidates).toEqual([]);
+  });
+
+  it("keeps keyless One Location app users in Needs Setup even with professional Connect metadata", () => {
+    const [candidate] = buildKaiCircleCandidates({
+      connectCandidates: [connectCandidate({ userId: "user_c", candidateId: "user:user_c" })],
+      state: {
+        recipients: [
+          recipient({
+            userId: "user_c",
+            keyId: null,
+            publicKeyJwk: null,
+            canReceiveLocation: false,
+            recommendationCategory: "needs_setup",
+            recommendationTier: "setup_needed",
+          }),
+        ],
+      },
+    });
+
+    expect(candidate.isShareReady).toBe(false);
+    expect(kaiCircleSectionKey(candidate)).toBe("needs_setup");
+    const sections = buildKaiCircleSections([candidate]);
+    expect(sections.find((section) => section.key === "professional_network")?.candidates).toHaveLength(0);
+    expect(sections.find((section) => section.key === "needs_setup")?.candidates).toHaveLength(1);
+  });
+
+  it("resolves request CTA when viewer setup can be bootstrapped first", () => {
+    const [candidate] = buildKaiCircleCandidates({
+      connectCandidates: [connectCandidate()],
+      state: {
+        recipients: [recipient()],
+        viewerCapabilities: { hasLocationRecipientKey: false, canRequestLocation: true },
+      },
+    });
+
+    expect(resolveKaiCircleCtas({
+      candidate,
+      mode: "request",
+      viewerCapabilities: { hasLocationRecipientKey: false, canRequestLocation: true },
+    })[0]).toMatchObject({
+      id: "request_location",
+      enabled: true,
+    });
+  });
+});

--- a/hushh-webapp/lib/capacitor/index.ts
+++ b/hushh-webapp/lib/capacitor/index.ts
@@ -772,6 +772,7 @@ export type HushhLocationPermissionState = {
 
 export interface HushhLocationPlugin {
   getPermissionState(): Promise<HushhLocationPermissionState>;
+  openLocationSettings?(): Promise<{ opened: boolean }>;
   getCurrentPosition(options?: {
     enableHighAccuracy?: boolean;
     timeoutMs?: number;
@@ -799,6 +800,7 @@ export type HushhContactRecord = {
   id?: string | null;
   displayName?: string | null;
   phoneNumbers: string[];
+  emailAddresses?: string[];
 };
 
 export interface HushhContactsPlugin {

--- a/hushh-webapp/lib/capacitor/plugins/contacts-web.ts
+++ b/hushh-webapp/lib/capacitor/plugins/contacts-web.ts
@@ -1,17 +1,69 @@
 import type {
+  HushhContactRecord,
   HushhContactsPermissionState,
   HushhContactsPlugin,
 } from "@/lib/capacitor";
 
+const WEB_CONTACT_FIXTURE_KEY = "hushh:dev:contacts";
+
+function isLocalContactFixtureAllowed(): boolean {
+  return process.env.NODE_ENV !== "production" && typeof window !== "undefined";
+}
+
+function readFixtureContacts(limit?: number): HushhContactRecord[] | null {
+  if (!isLocalContactFixtureAllowed()) return null;
+  const raw = window.localStorage.getItem(WEB_CONTACT_FIXTURE_KEY);
+  if (!raw) return null;
+
+  const parsed = JSON.parse(raw) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new Error(`${WEB_CONTACT_FIXTURE_KEY} must be a JSON array.`);
+  }
+
+  const contacts = parsed
+    .map((item, index): HushhContactRecord | null => {
+      if (!item || typeof item !== "object") return null;
+      const record = item as Record<string, unknown>;
+      const phoneNumbers = Array.isArray(record.phoneNumbers)
+        ? record.phoneNumbers.map((value) => String(value || "").trim()).filter(Boolean)
+        : [];
+      const emailAddresses = Array.isArray(record.emailAddresses)
+        ? record.emailAddresses.map((value) => String(value || "").trim()).filter(Boolean)
+        : [];
+      if (phoneNumbers.length === 0 && emailAddresses.length === 0) return null;
+      return {
+        id: record.id == null ? `web-fixture-${index}` : String(record.id),
+        displayName: record.displayName == null ? null : String(record.displayName),
+        phoneNumbers,
+        emailAddresses,
+      };
+    })
+    .filter((contact): contact is HushhContactRecord => Boolean(contact));
+
+  return typeof limit === "number" ? contacts.slice(0, limit) : contacts;
+}
+
 export class HushhContactsWeb implements HushhContactsPlugin {
   async getPermissionState(): Promise<HushhContactsPermissionState> {
+    try {
+      if (readFixtureContacts()?.length) return { state: "granted" };
+    } catch {
+      return { state: "unavailable" };
+    }
     return { state: "unavailable" };
   }
 
-  async readContacts(): Promise<{
-    contacts: [];
+  async readContacts(options?: { limit?: number }): Promise<{
+    contacts: HushhContactRecord[];
     sourcePlatform: "web";
   }> {
+    const fixtureContacts = readFixtureContacts(options?.limit);
+    if (fixtureContacts) {
+      return {
+        contacts: fixtureContacts,
+        sourcePlatform: "web",
+      };
+    }
     throw new Error("Contacts are only available in the native mobile app.");
   }
 }

--- a/hushh-webapp/lib/connect/candidates.ts
+++ b/hushh-webapp/lib/connect/candidates.ts
@@ -1,0 +1,510 @@
+/**
+ * lib/connect/candidates.ts
+ *
+ * Normalizers and deduplication logic for Connect candidates.
+ * Converts raw API types → ConnectCandidate, merges duplicates by candidateId.
+ *
+ * No direct fetch — all data is passed in from the service layer.
+ */
+
+import type {
+  MarketplaceRia,
+  MarketplaceInvestor,
+  MarketplaceContactMatch,
+  MarketplaceInvestorActionRecord,
+  RiaClientAccess,
+} from "@/lib/services/ria-service";
+import type { ConsentCenterEntry } from "@/lib/services/consent-center-service";
+import {
+  marketplaceInvestorCardId,
+  marketplaceInvestorUserId,
+  isMarketplaceInvestorConnectable,
+  isMarketplaceInvestorShortlistable,
+  isPublicSecMarketplaceInvestor,
+  marketplaceInvestorSourceLabel,
+  marketplaceInvestorCurationLabel,
+} from "@/lib/marketplace/investor-discovery";
+import { buildMarketplaceConnectionsRoute } from "@/lib/navigation/routes";
+import type {
+  ConnectCandidate,
+  ConnectCandidateSource,
+  ConnectPrimaryCta,
+  ConnectStatus,
+} from "./types";
+import { buildCandidateId, mergeSourceTypes } from "./connect-visibility";
+import { applyScoreToCandidate } from "./connect-ranking";
+
+// ─── CTA Resolution ───────────────────────────────────────────────────────────
+
+function resolvePrimaryCta(opts: {
+  connectionStatus: ConnectStatus;
+  isDiscoverable: boolean;
+  canConnect: boolean;
+  isTestProfile?: boolean;
+  hasProfileHref: boolean;
+}): ConnectPrimaryCta {
+  const { connectionStatus, isDiscoverable, canConnect, isTestProfile, hasProfileHref } = opts;
+
+  if (connectionStatus === "connected") return "view_connection";
+  if (connectionStatus === "pending") return "review_request";
+  if (connectionStatus === "connect_requested") return "open_profile";
+  if (connectionStatus === "not_connectable" || connectionStatus === "private") {
+    return hasProfileHref ? "open_profile" : "none";
+  }
+  if (isTestProfile) return "open_profile";
+  if (canConnect && isDiscoverable) return "connect";
+  if (hasProfileHref) return "open_profile";
+  return "none";
+}
+
+function resolveSecondaryCtas(
+  primaryCta: ConnectPrimaryCta,
+  opts: {
+    canShortlist: boolean;
+    connectionStatus: ConnectStatus;
+    hasProfileHref: boolean;
+  },
+): ConnectPrimaryCta[] {
+  const secondary: ConnectPrimaryCta[] = [];
+  if (primaryCta !== "open_profile" && opts.hasProfileHref) secondary.push("open_profile");
+  if (primaryCta !== "shortlist" && opts.canShortlist) secondary.push("shortlist");
+  return secondary.slice(0, 2);
+}
+
+// ─── Connection Status Helpers ────────────────────────────────────────────────
+
+function consentEntryToStatus(entry: ConsentCenterEntry): ConnectStatus {
+  const status = String(entry.relationship_status || entry.status || "").toLowerCase();
+  if (["active", "approved", "granted"].includes(status)) return "connected";
+  if (["request_pending", "pending"].includes(status)) return "pending";
+  if (["revoked", "cancelled", "denied"].includes(status)) return "previous";
+  return "available";
+}
+
+function riaRelationshipToStatus(access: RiaClientAccess): ConnectStatus {
+  const status = String(access.relationship_status || access.status || "").toLowerCase();
+  if (["active", "approved"].includes(status)) return "connected";
+  if (["request_pending", "pending"].includes(status)) return "pending";
+  if (["revoked", "cancelled", "denied"].includes(status)) return "previous";
+  return "available";
+}
+
+function investorActionToStatus(
+  actionStatus: string | null | undefined,
+): ConnectCandidate["actionStatus"] {
+  switch (String(actionStatus || "").toLowerCase()) {
+    case "viewed": return "viewed";
+    case "passed": return "passed";
+    case "shortlisted": return "shortlisted";
+    case "connect_requested": return "connect_requested";
+    default: return null;
+  }
+}
+
+// ─── Normalizers ──────────────────────────────────────────────────────────────
+
+export function normalizeRiaToCandidate(
+  ria: MarketplaceRia,
+  opts: {
+    consentEntries?: ConsentCenterEntry[];
+    query?: string | null;
+    currentPersona?: string;
+  } = {},
+): ConnectCandidate {
+  const { consentEntries = [], query, currentPersona = "investor" } = opts;
+
+  const candidateId = buildCandidateId({ userId: ria.user_id });
+  const existingConsent = consentEntries.find((e) => e.counterpart_id === ria.user_id);
+  const connectionStatus: ConnectStatus = existingConsent
+    ? consentEntryToStatus(existingConsent)
+    : "available";
+
+  const firmName = Array.isArray(ria.firms) && ria.firms.length > 0
+    ? ria.firms[0]?.legal_name ?? null
+    : null;
+
+  const verificationStatus = ria.verification_status;
+  const isConnectable =
+    currentPersona === "investor" &&
+    ["active", "verified", "finra_verified"].includes(String(verificationStatus).toLowerCase()) &&
+    connectionStatus === "available";
+
+  const isDiscoverableFlag = true; // RIA search API already filters; treat as discoverable
+  const profileHref = `/marketplace?riaId=${encodeURIComponent(ria.id)}`;
+  const connectionHref = existingConsent
+    ? buildMarketplaceConnectionsRoute({ tab: "active" })
+    : null;
+
+  const primaryCta = resolvePrimaryCta({
+    connectionStatus,
+    isDiscoverable: isDiscoverableFlag,
+    canConnect: isConnectable,
+    isTestProfile: ria.is_test_profile,
+    hasProfileHref: true,
+  });
+
+  const candidate: ConnectCandidate = {
+    candidateId,
+    kind: "ria",
+    sourceTypes: ["marketplace_ria"],
+    userId: ria.user_id,
+    publicProfileId: null,
+    sourceType: "marketplace_ria",
+    _rawRiaProfile: ria,
+    displayName: ria.display_name,
+    headline: ria.headline ?? null,
+    summary: ria.strategy_summary ?? null,
+    avatarUrl: null,
+    firmName,
+    locationLabel: null,
+    visibilityPosture: ria.visibility_posture ?? "default_available",
+    exposureEnabled: ria.exposure_enabled ?? null,
+    isDiscoverable: isDiscoverableFlag,
+    verificationStatus,
+    verificationBadge: verificationStatus === "active" ? "RIA Verified" : null,
+    connectionStatus,
+    actionStatus: null,
+    score: 0,
+    reasons: [],
+    primaryCta,
+    secondaryCtas: resolveSecondaryCtas(primaryCta, {
+      canShortlist: false,
+      connectionStatus,
+      hasProfileHref: true,
+    }),
+    profileHref,
+    connectionHref,
+    isTestProfile: ria.is_test_profile,
+  };
+
+  return applyScoreToCandidate(candidate, query);
+}
+
+export function normalizeInvestorToCandidate(
+  investor: MarketplaceInvestor,
+  opts: {
+    riaRelationships?: RiaClientAccess[];
+    investorActions?: MarketplaceInvestorActionRecord[];
+    query?: string | null;
+    currentPersona?: string;
+    shortlistedIds?: string[];
+    passedIds?: string[];
+  } = {},
+): ConnectCandidate {
+  const {
+    riaRelationships = [],
+    investorActions = [],
+    query,
+    currentPersona = "ria",
+    shortlistedIds = [],
+    passedIds = [],
+  } = opts;
+
+  const investorId = marketplaceInvestorCardId(investor);
+  const userId = marketplaceInvestorUserId(investor);
+  const isPublicSec = isPublicSecMarketplaceInvestor(investor);
+
+  const candidateId = buildCandidateId({
+    userId,
+    publicProfileId: investor.public_profile_id,
+    sourceType: investor.source_type ?? "investor",
+    fallbackLabel: investor.display_name,
+  });
+
+  const relationship = userId
+    ? riaRelationships.find((r) => r.investor_user_id === userId)
+    : null;
+
+  const actionRecord = investorActions.find((a) => {
+    const key = String(a.target_key || "").trim();
+    return key === investorId || key === userId;
+  });
+
+  let connectionStatus: ConnectStatus = "available";
+  if (relationship) {
+    connectionStatus = riaRelationshipToStatus(relationship);
+  } else if (shortlistedIds.includes(investorId)) {
+    connectionStatus = "shortlisted";
+  } else if (passedIds.includes(investorId)) {
+    connectionStatus = "passed";
+  }
+
+  const actionStatus = investorActionToStatus(actionRecord?.status);
+
+  const isConnectable =
+    currentPersona === "ria" &&
+    isMarketplaceInvestorConnectable(investor) &&
+    connectionStatus === "available";
+  const isShortlistable = isMarketplaceInvestorShortlistable(investor);
+  const isDiscoverableFlag = !isPublicSec || Boolean(investor.public_profile_id);
+
+  const curationLabel = marketplaceInvestorCurationLabel(investor);
+  const sourceLabel = marketplaceInvestorSourceLabel(investor);
+  const locationLabel = [curationLabel, sourceLabel, investor.location_hint]
+    .filter(Boolean)
+    .join(" · ") || null;
+
+  const sourceTypes: ConnectCandidateSource[] = isPublicSec
+    ? ["public_sec"]
+    : ["marketplace_investor"];
+
+  const profileHref = userId && !isPublicSec
+    ? `/marketplace?investorId=${encodeURIComponent(investorId)}`
+    : null;
+
+  const connectionHref = relationship
+    ? buildMarketplaceConnectionsRoute({ tab: "active" })
+    : null;
+
+  const primaryCta = resolvePrimaryCta({
+    connectionStatus,
+    isDiscoverable: isDiscoverableFlag,
+    canConnect: isConnectable,
+    isTestProfile: investor.is_test_profile,
+    hasProfileHref: Boolean(profileHref),
+  });
+
+  const candidate: ConnectCandidate = {
+    candidateId,
+    kind: isPublicSec ? "public_profile" : "investor",
+    sourceTypes,
+    userId,
+    publicProfileId: investor.public_profile_id ?? null,
+    sourceType: investor.source_type ?? null,
+    _rawInvestorProfile: investor,
+    displayName: investor.display_name,
+    headline: investor.headline ?? null,
+    summary: investor.strategy_summary ?? investor.location_hint ?? null,
+    avatarUrl: null,
+    firmName: null,
+    locationLabel,
+    visibilityPosture: investor.visibility_posture ?? "default_available",
+    exposureEnabled: investor.exposure_enabled ?? null,
+    isDiscoverable: isDiscoverableFlag,
+    verificationStatus: null,
+    verificationBadge: null,
+    connectionStatus,
+    actionStatus,
+    score: 0,
+    reasons: [],
+    primaryCta,
+    secondaryCtas: resolveSecondaryCtas(primaryCta, {
+      canShortlist: isShortlistable && connectionStatus === "available",
+      connectionStatus,
+      hasProfileHref: Boolean(profileHref),
+    }),
+    profileHref,
+    connectionHref,
+    isTestProfile: investor.is_test_profile,
+  };
+
+  return applyScoreToCandidate(candidate, query);
+}
+
+export function normalizeContactMatchToCandidate(
+  match: MarketplaceContactMatch,
+  opts: {
+    existingCandidates?: ConnectCandidate[];
+    query?: string | null;
+  } = {},
+): ConnectCandidate | null {
+  const { query } = opts;
+
+  const userId = match.user_id;
+  const candidateId = buildCandidateId({ userId });
+
+  // If an existing candidate with the same userId exists, we augment it instead of creating new
+  const existing = opts.existingCandidates?.find((c) => c.candidateId === candidateId);
+  if (existing) {
+    // Return augmented version — merge will handle this via mergeByUserId
+    return {
+      ...existing,
+      sourceTypes: mergeSourceTypes(existing.sourceTypes, ["contact_match"]),
+    };
+  }
+
+  const isRia = match.kind === "ria";
+  const profile = match.profile as
+    | { visibility_posture?: string | null; exposure_enabled?: boolean | null }
+    | null
+    | undefined;
+  const visibilityPosture = profile?.visibility_posture ?? "default_available";
+  const exposureEnabled = profile?.exposure_enabled ?? null;
+  const profileIsPrivate = String(visibilityPosture).trim().toLowerCase() === "private";
+  const profileHref = isRia
+    ? `/marketplace?riaId=${encodeURIComponent(userId)}`
+    : `/marketplace?investorId=${encodeURIComponent(userId)}`;
+
+  const candidate: ConnectCandidate = {
+    candidateId,
+    kind: isRia ? "ria" : "investor",
+    sourceTypes: ["contact_match"],
+    userId,
+    publicProfileId: null,
+    sourceType: match.kind,
+    displayName: match.display_name,
+    headline: match.headline ?? null,
+    summary: null,
+    avatarUrl: null,
+    firmName: null,
+    locationLabel: null,
+    visibilityPosture,
+    exposureEnabled,
+    isDiscoverable: exposureEnabled !== false && !profileIsPrivate,
+    verificationStatus: null,
+    verificationBadge: null,
+    connectionStatus: "available",
+    actionStatus: null,
+    score: 0,
+    reasons: [],
+    primaryCta: "open_profile",
+    secondaryCtas: [],
+    profileHref,
+    connectionHref: null,
+  };
+
+  return applyScoreToCandidate(candidate, query);
+}
+
+export function normalizeConsentEntryToCandidate(
+  entry: ConsentCenterEntry,
+  opts: {
+    surface: "active" | "pending" | "previous";
+    query?: string | null;
+    currentPersona?: string;
+  },
+): ConnectCandidate | null {
+  const counterpartId = entry.counterpart_id;
+  if (!counterpartId) return null;
+
+  const { surface, query } = opts;
+
+  const candidateId = buildCandidateId({ userId: counterpartId });
+  const sourceMap: Record<string, ConnectCandidateSource> = {
+    active: "active_connection",
+    pending: "pending_connection",
+    previous: "previous_connection",
+  };
+  const source: ConnectCandidateSource = sourceMap[surface] ?? "active_connection";
+
+  const statusMap: Record<string, ConnectStatus> = {
+    active: "connected",
+    pending: "pending",
+    previous: "previous",
+  };
+  const connectionStatus: ConnectStatus = statusMap[surface] ?? "connected";
+
+  const connectionHref = buildMarketplaceConnectionsRoute({
+    tab: surface === "active" ? "active" : surface === "pending" ? "pending" : "previous",
+    selected: counterpartId,
+  });
+
+  const primaryCta: ConnectPrimaryCta =
+    connectionStatus === "connected"
+      ? "view_connection"
+      : connectionStatus === "pending"
+      ? "review_request"
+      : "open_profile";
+
+  const candidate: ConnectCandidate = {
+    candidateId,
+    kind: entry.counterpart_type === "ria" ? "ria" : "hushh_user",
+    sourceTypes: [source],
+    userId: counterpartId,
+    publicProfileId: null,
+    sourceType: entry.counterpart_type,
+    _rawConsentEntry: entry,
+    displayName: entry.counterpart_label || counterpartId,
+    headline: entry.counterpart_secondary_label ?? null,
+    summary: null,
+    avatarUrl: entry.counterpart_image_url ?? null,
+    firmName: null,
+    locationLabel: null,
+    visibilityPosture: null,
+    exposureEnabled: null,
+    isDiscoverable: true, // connections always visible in connections section
+    verificationStatus: null,
+    verificationBadge: null,
+    connectionStatus,
+    actionStatus: null,
+    score: 0,
+    reasons: [],
+    primaryCta,
+    secondaryCtas: [],
+    profileHref: entry.request_url ?? null,
+    connectionHref,
+  };
+
+  return applyScoreToCandidate(candidate, query);
+}
+
+// ─── Merge / Deduplication ────────────────────────────────────────────────────
+
+/**
+ * Merge a list of raw candidates by candidateId.
+ * When two candidates share the same ID, the one with higher score wins for
+ * most fields, but sourceTypes are merged.
+ */
+export function mergeCandidates(candidates: ConnectCandidate[]): ConnectCandidate[] {
+  const map = new Map<string, ConnectCandidate>();
+
+  for (const candidate of candidates) {
+    const existing = map.get(candidate.candidateId);
+    if (!existing) {
+      map.set(candidate.candidateId, candidate);
+      continue;
+    }
+
+    // Merge sources
+    const mergedSources = mergeSourceTypes(existing.sourceTypes, candidate.sourceTypes);
+
+    // Pick higher connection status (connected > pending > previous > available)
+    const statusPriority: ConnectStatus[] = [
+      "connected", "pending", "previous", "shortlisted",
+      "connect_requested", "available", "passed", "not_connectable", "private",
+    ];
+    const existingPriority = statusPriority.indexOf(existing.connectionStatus);
+    const incomingPriority = statusPriority.indexOf(candidate.connectionStatus);
+    const connectionStatus =
+      existingPriority <= incomingPriority
+        ? existing.connectionStatus
+        : candidate.connectionStatus;
+
+    // Pick better score, recombine reasons
+    const mergedReasons = [
+      ...existing.reasons,
+      ...candidate.reasons.filter(
+        (r) => !existing.reasons.some((er) => er.code === r.code),
+      ),
+    ];
+    const score = Math.max(existing.score, candidate.score);
+
+    const merged: ConnectCandidate = {
+      ...existing,
+      sourceTypes: mergedSources,
+      visibilityPosture:
+        existing.visibilityPosture === "private" || candidate.visibilityPosture === "private"
+          ? "private"
+          : existing.visibilityPosture ?? candidate.visibilityPosture,
+      exposureEnabled:
+        existing.exposureEnabled === false || candidate.exposureEnabled === false
+          ? false
+          : existing.exposureEnabled ?? candidate.exposureEnabled,
+      isDiscoverable: existing.isDiscoverable && candidate.isDiscoverable,
+      connectionStatus,
+      score,
+      reasons: mergedReasons,
+      // Prefer higher-detail display name
+      displayName: existing.displayName.length >= candidate.displayName.length
+        ? existing.displayName
+        : candidate.displayName,
+      headline: existing.headline ?? candidate.headline,
+      summary: existing.summary ?? candidate.summary,
+      avatarUrl: existing.avatarUrl ?? candidate.avatarUrl,
+    };
+
+    map.set(candidate.candidateId, merged);
+  }
+
+  return Array.from(map.values());
+}

--- a/hushh-webapp/lib/connect/connect-ranking.ts
+++ b/hushh-webapp/lib/connect/connect-ranking.ts
@@ -1,0 +1,298 @@
+/**
+ * lib/connect/connect-ranking.ts
+ *
+ * Score-based ranking and reason label system for Connect candidates.
+ * Scores are additive — a candidate can receive multiple score boosts
+ * from different sources.
+ */
+
+import type {
+  ConnectCandidate,
+  ConnectCandidateReason,
+  ConnectCandidateSource,
+} from "./types";
+
+// ─── Score Constants ──────────────────────────────────────────────────────────
+
+export const CONNECT_SCORES = {
+  ACTIVE_CONNECTION: 100,
+  PENDING_CONNECTION: 80,
+  CONTACT_MATCH: 60,
+  CONNECT_REQUESTED: 55,
+  SHORTLISTED: 40,
+  VERIFIED_RIA: 30,
+  QUERY_NAME_MATCH: 25,
+  QUERY_HEADLINE_MATCH: 15,
+  VIEWED: 10,
+  VISIBLE_PROFILE: 5,
+  PASSED: -50,         // suppressed but not excluded
+  PRIVATE: -200,       // excluded from discovery (should never rank)
+} as const;
+
+// ─── Reason Codes ─────────────────────────────────────────────────────────────
+
+export const REASON_LABELS = {
+  active_connection: "Connected",
+  pending_connection: "Pending request",
+  previous_connection: "Previously connected",
+  contact_match: "In your contacts",
+  connect_requested: "Connect requested",
+  shortlisted: "Shortlisted",
+  ria_verified: "RIA verified",
+  query_match_name: "Matches your search",
+  query_match_headline: "Matches your search",
+  visible_profile: "Visible profile",
+  passed: "Passed",
+  kai_test: "Test profile",
+} as const;
+
+// ─── Score Computation ────────────────────────────────────────────────────────
+
+type QueryBoostOptions = {
+  query?: string | null;
+  displayName?: string | null;
+  headline?: string | null;
+  summary?: string | null;
+  firmName?: string | null;
+};
+
+/**
+ * Compute the score boost from a search query against candidate text fields.
+ * Returns 0 if no query, or sum of matched boosts.
+ */
+export function computeQueryScore(options: QueryBoostOptions): {
+  score: number;
+  reasons: ConnectCandidateReason[];
+} {
+  const q = String(options.query || "").trim().toLowerCase();
+  if (!q) return { score: 0, reasons: [] };
+
+  const reasons: ConnectCandidateReason[] = [];
+  let score = 0;
+
+  const nameMatch =
+    String(options.displayName || "").toLowerCase().includes(q) ||
+    String(options.firmName || "").toLowerCase().includes(q);
+
+  if (nameMatch) {
+    score += CONNECT_SCORES.QUERY_NAME_MATCH;
+    reasons.push({
+      code: "query_match_name",
+      label: REASON_LABELS.query_match_name,
+      weight: CONNECT_SCORES.QUERY_NAME_MATCH,
+      source: "profile_visibility",
+    });
+  }
+
+  const headlineMatch =
+    !nameMatch &&
+    (String(options.headline || "").toLowerCase().includes(q) ||
+      String(options.summary || "").toLowerCase().includes(q));
+
+  if (headlineMatch) {
+    score += CONNECT_SCORES.QUERY_HEADLINE_MATCH;
+    reasons.push({
+      code: "query_match_headline",
+      label: REASON_LABELS.query_match_headline,
+      weight: CONNECT_SCORES.QUERY_HEADLINE_MATCH,
+      source: "profile_visibility",
+    });
+  }
+
+  return { score, reasons };
+}
+
+/**
+ * Compute score contribution from a candidate's connection status.
+ */
+export function computeConnectionStatusScore(
+  candidate: Pick<ConnectCandidate, "connectionStatus" | "actionStatus">,
+): { score: number; reasons: ConnectCandidateReason[] } {
+  const reasons: ConnectCandidateReason[] = [];
+  let score = 0;
+
+  switch (candidate.connectionStatus) {
+    case "connected":
+      score += CONNECT_SCORES.ACTIVE_CONNECTION;
+      reasons.push({
+        code: "active_connection",
+        label: REASON_LABELS.active_connection,
+        weight: CONNECT_SCORES.ACTIVE_CONNECTION,
+        source: "active_connection",
+      });
+      break;
+
+    case "pending":
+      score += CONNECT_SCORES.PENDING_CONNECTION;
+      reasons.push({
+        code: "pending_connection",
+        label: REASON_LABELS.pending_connection,
+        weight: CONNECT_SCORES.PENDING_CONNECTION,
+        source: "pending_connection",
+      });
+      break;
+
+    case "previous":
+      score += CONNECT_SCORES.PENDING_CONNECTION; // treat similar to pending
+      reasons.push({
+        code: "previous_connection",
+        label: REASON_LABELS.previous_connection,
+        weight: CONNECT_SCORES.PENDING_CONNECTION,
+        source: "previous_connection",
+      });
+      break;
+
+    case "connect_requested":
+      score += CONNECT_SCORES.CONNECT_REQUESTED;
+      reasons.push({
+        code: "connect_requested",
+        label: REASON_LABELS.connect_requested,
+        weight: CONNECT_SCORES.CONNECT_REQUESTED,
+        source: "active_connection",
+      });
+      break;
+
+    case "shortlisted":
+      score += CONNECT_SCORES.SHORTLISTED;
+      reasons.push({
+        code: "shortlisted",
+        label: REASON_LABELS.shortlisted,
+        weight: CONNECT_SCORES.SHORTLISTED,
+        source: "marketplace_investor",
+      });
+      break;
+
+    case "passed":
+      score += CONNECT_SCORES.PASSED;
+      reasons.push({
+        code: "passed",
+        label: REASON_LABELS.passed,
+        weight: CONNECT_SCORES.PASSED,
+        source: "marketplace_investor",
+      });
+      break;
+
+    default:
+      break;
+  }
+
+  return { score, reasons };
+}
+
+/**
+ * Compute score contribution from source types.
+ */
+export function computeSourceScore(
+  sourceTypes: ConnectCandidateSource[],
+  kind: ConnectCandidate["kind"],
+  verificationStatus?: string | null,
+): { score: number; reasons: ConnectCandidateReason[] } {
+  const reasons: ConnectCandidateReason[] = [];
+  let score = 0;
+
+  if (sourceTypes.includes("contact_match")) {
+    score += CONNECT_SCORES.CONTACT_MATCH;
+    reasons.push({
+      code: "contact_match",
+      label: REASON_LABELS.contact_match,
+      weight: CONNECT_SCORES.CONTACT_MATCH,
+      source: "contact_match",
+    });
+  }
+
+  if (
+    kind === "ria" &&
+    ["active", "verified", "finra_verified"].includes(
+      String(verificationStatus || "").toLowerCase(),
+    )
+  ) {
+    score += CONNECT_SCORES.VERIFIED_RIA;
+    reasons.push({
+      code: "ria_verified",
+      label: REASON_LABELS.ria_verified,
+      weight: CONNECT_SCORES.VERIFIED_RIA,
+      source: "marketplace_ria",
+    });
+  }
+
+  if (
+    sourceTypes.includes("profile_visibility") ||
+    sourceTypes.includes("marketplace_ria") ||
+    sourceTypes.includes("marketplace_investor") ||
+    sourceTypes.includes("contact_match")
+  ) {
+    score += CONNECT_SCORES.VISIBLE_PROFILE;
+    reasons.push({
+      code: "visible_profile",
+      label: REASON_LABELS.visible_profile,
+      weight: CONNECT_SCORES.VISIBLE_PROFILE,
+      source: sourceTypes[0] ?? "profile_visibility",
+    });
+  }
+
+  return { score, reasons };
+}
+
+// ─── Final Score Assembly ─────────────────────────────────────────────────────
+
+/**
+ * Compute the total score for a candidate given a query.
+ * Mutates the candidate's score and reasons in-place.
+ */
+export function applyScoreToCandidate(
+  candidate: ConnectCandidate,
+  query?: string | null,
+): ConnectCandidate {
+  const { score: qScore, reasons: qReasons } = computeQueryScore({
+    query,
+    displayName: candidate.displayName,
+    headline: candidate.headline,
+    summary: candidate.summary,
+    firmName: candidate.firmName,
+  });
+
+  const { score: csScore, reasons: csReasons } = computeConnectionStatusScore(candidate);
+
+  const { score: srcScore, reasons: srcReasons } = computeSourceScore(
+    candidate.sourceTypes,
+    candidate.kind,
+    candidate.verificationStatus,
+  );
+
+  const allReasons = [...csReasons, ...srcReasons, ...qReasons];
+  const totalScore = csScore + srcScore + qScore;
+
+  return {
+    ...candidate,
+    score: totalScore,
+    reasons: allReasons,
+  };
+}
+
+// ─── Sort ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Sort candidates by score descending. Stable sort (preserves order for equal scores).
+ */
+export function sortCandidatesByScore(candidates: ConnectCandidate[]): ConnectCandidate[] {
+  return [...candidates].sort((a, b) => b.score - a.score);
+}
+
+/**
+ * Remove or suppress passed candidates from discovery sections.
+ * Passed candidates with an active/pending connection override are kept.
+ */
+export function filterPassedCandidates(
+  candidates: ConnectCandidate[],
+  includePassedWithConnection = false,
+): ConnectCandidate[] {
+  return candidates.filter((c) => {
+    if (c.connectionStatus !== "passed") return true;
+    if (includePassedWithConnection) {
+      return c.sourceTypes.some((s) =>
+        ["active_connection", "pending_connection"].includes(s),
+      );
+    }
+    return false;
+  });
+}

--- a/hushh-webapp/lib/connect/connect-visibility.ts
+++ b/hushh-webapp/lib/connect/connect-visibility.ts
@@ -1,0 +1,152 @@
+/**
+ * lib/connect/connect-visibility.ts
+ *
+ * Visibility helpers for Connect candidate discovery.
+ * Implements conservative frontend-layer filtering — private profiles
+ * and non-discoverable profiles are excluded from browse/search.
+ * Backend filtering is preferred where available; this is a defensive layer.
+ */
+
+import type {
+  ConnectCandidate,
+  ConnectCandidateKind,
+  ConnectCandidateSource,
+  ConnectVisibilityPosture,
+} from "./types";
+
+// ─── Visibility Posture Logic ─────────────────────────────────────────────────
+
+const PRIVATE_POSTURES: ConnectVisibilityPosture[] = ["private"];
+const DISCOVERABLE_POSTURES: ConnectVisibilityPosture[] = [
+  "default_available",
+  "public",
+  "limited",
+];
+
+/**
+ * Returns true if the given visibility posture allows the profile to appear
+ * in Connect browse/search results.
+ *
+ * Conservative: missing/unknown posture → not discoverable for generic user
+ * profiles. RIA and investor profiles from the marketplace APIs are already
+ * filtered server-side, so we treat them as discoverable unless explicitly private.
+ */
+export function isVisibilityPostureDiscoverable(
+  posture: ConnectVisibilityPosture | null | undefined,
+  kind: ConnectCandidateKind,
+): boolean {
+  if (!posture) {
+    // Marketplace RIA/investor profiles are filtered by the backend search API.
+    // Treat them as discoverable unless explicitly marked private.
+    if (kind === "ria" || kind === "investor" || kind === "public_profile") {
+      return true;
+    }
+    // Generic hushh user profile with unknown posture — conservative: exclude.
+    return false;
+  }
+
+  const normalized = posture.toLowerCase().trim();
+  if (PRIVATE_POSTURES.includes(normalized as ConnectVisibilityPosture)) {
+    return false;
+  }
+  return DISCOVERABLE_POSTURES.some((p) => p === normalized) || !PRIVATE_POSTURES.includes(normalized as ConnectVisibilityPosture);
+}
+
+/**
+ * Returns true if the candidate should appear in Connect discover/browse/search.
+ *
+ * Rules:
+ * 1. exposure_enabled === false → never show in discovery.
+ * 2. visibility_posture === "private" → never show in discovery.
+ * 3. Active/pending/previous connections may still appear in Connections section
+ *    regardless of public discoverability (handled by section logic).
+ * 4. Test profiles → skip regular visibility rules (they are always controlled by allowTestProfiles flag).
+ */
+export function isDiscoverable(candidate: ConnectCandidate): boolean {
+  // Test profiles are controlled by the allowTestProfiles environment flag
+  if (candidate.isTestProfile) return true;
+
+  // Already has connection status data — eligible even if not public
+  const connectedStatuses: ConnectCandidate["connectionStatus"][] = [
+    "connected",
+    "pending",
+    "previous",
+    "shortlisted",
+    "connect_requested",
+  ];
+  if (connectedStatuses.includes(candidate.connectionStatus)) {
+    return true;
+  }
+
+  // Explicitly not discoverable
+  if (candidate.exposureEnabled === false) return false;
+
+  // Private visibility posture
+  if (!isVisibilityPostureDiscoverable(candidate.visibilityPosture, candidate.kind)) {
+    return false;
+  }
+
+  return candidate.isDiscoverable;
+}
+
+// ─── Candidate ID Helpers ─────────────────────────────────────────────────────
+
+/**
+ * Build a stable, deterministic candidate ID.
+ *
+ * Priority:
+ *   1. userId → "user:<userId>"
+ *   2. publicProfileId → "public:<sourceType>:<publicProfileId>"
+ *   3. fallback label → "contact:<stableLocalId>"
+ */
+export function buildCandidateId(options: {
+  userId?: string | null;
+  publicProfileId?: string | number | null;
+  sourceType?: string | null;
+  fallbackLabel?: string | null;
+}): string {
+  const { userId, publicProfileId, sourceType, fallbackLabel } = options;
+
+  if (userId && String(userId).trim()) {
+    return `user:${String(userId).trim()}`;
+  }
+
+  if (publicProfileId != null && String(publicProfileId).trim()) {
+    const st = String(sourceType || "public").trim().toLowerCase();
+    return `public:${st}:${String(publicProfileId).trim()}`;
+  }
+
+  const label = String(fallbackLabel || "unknown")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "_")
+    .slice(0, 64);
+  return `contact:${label}`;
+}
+
+// ─── Source Type Helpers ──────────────────────────────────────────────────────
+
+/**
+ * Combine source types from multiple merges without duplicates.
+ */
+export function mergeSourceTypes(
+  existing: ConnectCandidateSource[],
+  incoming: ConnectCandidateSource[],
+): ConnectCandidateSource[] {
+  const seen = new Set(existing);
+  for (const src of incoming) {
+    seen.add(src);
+  }
+  return Array.from(seen);
+}
+
+/**
+ * Returns true if the candidate's sources indicate a real user connection
+ * (active, pending, or previous) — used to allow showing in Connections
+ * section even if the profile is not publicly discoverable.
+ */
+export function hasConnectionSource(sources: ConnectCandidateSource[]): boolean {
+  return sources.some((s) =>
+    ["active_connection", "pending_connection", "previous_connection"].includes(s),
+  );
+}

--- a/hushh-webapp/lib/connect/index.ts
+++ b/hushh-webapp/lib/connect/index.ts
@@ -1,0 +1,42 @@
+/**
+ * lib/connect/index.ts
+ *
+ * Barrel export for the Connect Tab discovery and people discovery domain layer.
+ */
+
+export * from "./types";
+export {
+  isDiscoverable,
+  buildCandidateId,
+  mergeSourceTypes,
+  hasConnectionSource,
+  isVisibilityPostureDiscoverable,
+} from "./connect-visibility";
+
+export {
+  CONNECT_SCORES,
+  REASON_LABELS,
+  computeQueryScore,
+  computeConnectionStatusScore,
+  computeSourceScore,
+  applyScoreToCandidate,
+  sortCandidatesByScore,
+  filterPassedCandidates,
+} from "./connect-ranking";
+
+export {
+  normalizeRiaToCandidate,
+  normalizeInvestorToCandidate,
+  normalizeContactMatchToCandidate,
+  normalizeConsentEntryToCandidate,
+  mergeCandidates,
+} from "./candidates";
+
+export {
+  loadConnectPayload,
+  loadContactMatches,
+  type ConnectServiceLoadOptions,
+  type ConnectContactLoadResult,
+} from "./service";
+
+export { useConnectDiscovery } from "./use-connect-discovery";

--- a/hushh-webapp/lib/connect/service.ts
+++ b/hushh-webapp/lib/connect/service.ts
@@ -1,0 +1,309 @@
+/**
+ * lib/connect/service.ts
+ *
+ * Connect discovery service — aggregates data from existing APIs.
+ * All fetch calls go through existing service-layer classes.
+ * Components must NOT import this directly; use the hook instead.
+ */
+
+import {
+  RiaService,
+  type MarketplaceRia,
+  type MarketplaceInvestor,
+  type MarketplaceContactMatch,
+  type MarketplaceInvestorActionRecord,
+  type RiaClientAccess,
+  isIAMSchemaNotReadyError,
+} from "@/lib/services/ria-service";
+import {
+  ConsentCenterService,
+  type ConsentCenterEntry,
+} from "@/lib/services/consent-center-service";
+import {
+  buildMarketplaceContactLookups,
+  buildMarketplaceContactLookupsFromQuery,
+} from "@/lib/marketplace/contact-matching";
+import type { ConnectRawPayload } from "./types";
+
+const WEB_CONTACT_MATCH_FIXTURE_KEY = "hushh:dev:marketplace-contact-matches";
+const MARKETPLACE_DISCOVERY_LIMIT_MAX = 50;
+
+export type ConnectServiceLoadOptions = {
+  idToken: string;
+  userId: string;
+  persona: "investor" | "ria";
+  query?: string;
+  limit?: number;
+  signal?: AbortSignal;
+};
+
+export type ConnectContactLoadResult = {
+  matches: MarketplaceContactMatch[];
+  totalContacts: number;
+  sourcePlatform: "web" | "ios" | "android" | "native" | "unknown";
+  error?: string;
+};
+
+function isLocalFixtureAllowed(): boolean {
+  return process.env.NODE_ENV !== "production" && typeof window !== "undefined";
+}
+
+function readLocalContactMatchFixture(): MarketplaceContactMatch[] {
+  if (!isLocalFixtureAllowed()) return [];
+  const raw = window.localStorage.getItem(WEB_CONTACT_MATCH_FIXTURE_KEY);
+  if (!raw) return [];
+
+  const parsed = JSON.parse(raw) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new Error(`${WEB_CONTACT_MATCH_FIXTURE_KEY} must be a JSON array.`);
+  }
+
+  return parsed
+    .map((item): MarketplaceContactMatch | null => {
+      if (!item || typeof item !== "object") return null;
+      const record = item as Record<string, unknown>;
+      const kind = record.kind === "ria" ? "ria" : record.kind === "investor" ? "investor" : null;
+      const userId = String(record.user_id || "").trim();
+      const displayName = String(record.display_name || "").trim();
+      if (!kind || !userId || !displayName) return null;
+
+      const profile =
+        record.profile && typeof record.profile === "object"
+          ? (record.profile as MarketplaceRia | MarketplaceInvestor)
+          : ({
+              id: kind === "ria" ? userId : `hushh_user:${userId}`,
+              user_id: userId,
+              display_name: displayName,
+              headline: typeof record.headline === "string" ? record.headline : null,
+              visibility_posture: "default_available",
+              exposure_enabled: true,
+              ...(kind === "ria"
+                ? { verification_status: "active" }
+                : { source_type: "hushh_user", connectable: true }),
+            } as MarketplaceRia | MarketplaceInvestor);
+
+      return {
+        user_id: userId,
+        kind,
+        display_name: displayName,
+        headline: typeof record.headline === "string" ? record.headline : null,
+        phone_last4: typeof record.phone_last4 === "string" ? record.phone_last4 : null,
+        profile,
+      };
+    })
+    .filter((match): match is MarketplaceContactMatch => Boolean(match));
+}
+
+function clampMarketplaceDiscoveryLimit(limit: number): number {
+  if (!Number.isFinite(limit)) return 32;
+  return Math.min(
+    MARKETPLACE_DISCOVERY_LIMIT_MAX,
+    Math.max(1, Math.trunc(limit)),
+  );
+}
+
+export function hasLocalContactMatchFixture(): boolean {
+  try {
+    return readLocalContactMatchFixture().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Load all discovery sources for the Connect tab.
+ * Returns raw payloads — normalization is done in candidates.ts.
+ */
+export async function loadConnectPayload(
+  options: ConnectServiceLoadOptions,
+): Promise<ConnectRawPayload> {
+  const { idToken, userId, persona, query = "", limit = 32 } = options;
+  const marketplaceLimit = clampMarketplaceDiscoveryLimit(limit);
+
+  const iamUnavailableFlags: boolean[] = [];
+
+  // ─── RIA search ───────────────────────────────────────────────────────────
+  const riasPromise = RiaService.searchRias({
+    query,
+    limit: marketplaceLimit,
+    verification_status: "active",
+  }).catch((err) => {
+    if (isIAMSchemaNotReadyError(err)) iamUnavailableFlags.push(true);
+    return [] as MarketplaceRia[];
+  });
+
+  // ─── Investor search ──────────────────────────────────────────────────────
+  const investorsPromise = (async (): Promise<MarketplaceInvestor[]> => {
+    try {
+      if (persona === "ria") {
+        const deck = await RiaService.searchInvestorDeck(idToken, {
+          query,
+          limit: marketplaceLimit,
+          persona: "ria",
+          deck: "qualified",
+        });
+        return deck.items;
+      }
+      return await RiaService.searchInvestors({
+        query,
+        limit: marketplaceLimit,
+        persona: "ria",
+        deck: "qualified",
+      });
+    } catch (err) {
+      if (isIAMSchemaNotReadyError(err)) iamUnavailableFlags.push(true);
+      return [];
+    }
+  })();
+
+  // ─── Consent center connections (active/pending/previous) ─────────────────
+  const connectionsPromise = Promise.allSettled([
+    ConsentCenterService.listEntries({
+      idToken,
+      userId,
+      actor: persona,
+      mode: "connections",
+      surface: "active",
+      top: 50,
+    }),
+    ConsentCenterService.listEntries({
+      idToken,
+      userId,
+      actor: persona,
+      mode: "connections",
+      surface: "pending",
+      top: 50,
+    }),
+    ConsentCenterService.listEntries({
+      idToken,
+      userId,
+      actor: persona,
+      mode: "connections",
+      surface: "previous",
+      top: 50,
+    }),
+  ]);
+
+  // ─── RIA clients (relationship map) ──────────────────────────────────────
+  const riaRelationshipsPromise = RiaService.listClients(idToken, {
+    userId,
+  }).catch(() => ({ items: [] as RiaClientAccess[], total: 0, page: 1, limit: 50, has_more: false }));
+
+  // ─── Investor actions ─────────────────────────────────────────────────────
+  const investorActionsPromise = persona === "ria"
+    ? RiaService.listInvestorActions(idToken, { limit: 100 }).catch(() => [] as MarketplaceInvestorActionRecord[])
+    : Promise.resolve([] as MarketplaceInvestorActionRecord[]);
+
+  const queryContactMatchesPromise = (async (): Promise<MarketplaceContactMatch[]> => {
+    const queryLookups = await buildMarketplaceContactLookupsFromQuery(query);
+    if (queryLookups.phoneLookups.length === 0 && queryLookups.emailLookups.length === 0) {
+      return [];
+    }
+    try {
+      return await RiaService.matchMarketplaceContacts(idToken, {
+        phone_lookups: queryLookups.phoneLookups,
+        email_lookups: queryLookups.emailLookups,
+        limit: Math.min(limit, 50),
+      });
+    } catch (err) {
+      if (isIAMSchemaNotReadyError(err)) iamUnavailableFlags.push(true);
+      return [];
+    }
+  })();
+
+  // ─── Await all ────────────────────────────────────────────────────────────
+  const [rias, investors, connectionResults, riaClientsResult, investorActions, queryContactMatches] =
+    await Promise.all([
+      riasPromise,
+      investorsPromise,
+      connectionsPromise,
+      riaRelationshipsPromise,
+      investorActionsPromise,
+      queryContactMatchesPromise,
+    ]);
+
+  const [activeResult, pendingResult, previousResult] = connectionResults;
+
+  const activeConnections: ConsentCenterEntry[] =
+    activeResult.status === "fulfilled" ? activeResult.value.items : [];
+  const pendingConnections: ConsentCenterEntry[] =
+    pendingResult.status === "fulfilled" ? pendingResult.value.items : [];
+  const previousConnections: ConsentCenterEntry[] =
+    previousResult.status === "fulfilled" ? previousResult.value.items : [];
+
+  const iamUnavailable = iamUnavailableFlags.length > 0;
+
+  return {
+    rias,
+    investors,
+    contactMatches: queryContactMatches,
+    activeConnections,
+    pendingConnections,
+    previousConnections,
+    riaRelationships: riaClientsResult.items,
+    investorActions,
+    iamUnavailable,
+  };
+}
+
+/**
+ * Perform contact matching — reads device contacts (hashed) and sends to backend.
+ * Returns matched profiles.
+ */
+export async function loadContactMatches(
+  idToken: string,
+  options?: { limit?: number },
+): Promise<ConnectContactLoadResult> {
+  let totalContacts = 0;
+  let sourcePlatform: ConnectContactLoadResult["sourcePlatform"] = "web";
+
+  try {
+    const {
+      phoneLookups,
+      emailLookups,
+      totalContacts: total,
+      sourcePlatform: platform,
+    } =
+      await buildMarketplaceContactLookups({ limit: options?.limit ?? 500 });
+
+    totalContacts = total;
+    sourcePlatform = platform;
+
+    if (phoneLookups.length === 0 && emailLookups.length === 0) {
+      return {
+        matches: [],
+        totalContacts,
+        sourcePlatform,
+      };
+    }
+
+    const contactLookups = phoneLookups.map((l) => ({ hash: l.hash, last4: l.last4 }));
+    const contactEmailLookups = emailLookups.map((l) => ({ hash: l.hash }));
+    const matches = await RiaService.matchMarketplaceContacts(idToken, {
+      phone_lookups: contactLookups,
+      email_lookups: contactEmailLookups,
+      limit: 50,
+    });
+    const fixtureMatches = matches.length === 0 ? readLocalContactMatchFixture() : [];
+    if (fixtureMatches.length > 0) {
+      return { matches: fixtureMatches, totalContacts, sourcePlatform };
+    }
+    return { matches, totalContacts, sourcePlatform };
+  } catch (err) {
+    const fixtureMatches = readLocalContactMatchFixture();
+    if (fixtureMatches.length > 0) {
+      return {
+        matches: fixtureMatches,
+        totalContacts,
+        sourcePlatform,
+      };
+    }
+    const message = err instanceof Error ? err.message : "Contact matching failed.";
+    return {
+      matches: [],
+      totalContacts,
+      sourcePlatform,
+      error: message,
+    };
+  }
+}

--- a/hushh-webapp/lib/connect/types.ts
+++ b/hushh-webapp/lib/connect/types.ts
@@ -1,0 +1,202 @@
+/**
+ * lib/connect/types.ts
+ *
+ * Unified candidate model for the Connect Tab.
+ * Existing MarketplaceRia, MarketplaceInvestor, and consent-center types are
+ * preserved in their own modules — this is the *normalized* layer only used
+ * by Connect UI components.
+ */
+
+// ─── Candidate Classification ─────────────────────────────────────────────────
+
+export type ConnectCandidateKind =
+  | "ria"
+  | "investor"
+  | "hushh_user"
+  | "public_profile"
+  | "contact_match";
+
+export type ConnectCandidateSource =
+  | "marketplace_ria"
+  | "marketplace_investor"
+  | "contact_match"
+  | "active_connection"
+  | "pending_connection"
+  | "previous_connection"
+  | "profile_visibility"
+  | "public_sec"
+  | "kai_test";
+
+export type ConnectVisibilityPosture =
+  | "private"
+  | "default_available"
+  | "limited"
+  | "public"
+  | string;
+
+export type ConnectStatus =
+  | "available"
+  | "connected"
+  | "pending"
+  | "previous"
+  | "passed"
+  | "shortlisted"
+  | "connect_requested"
+  | "not_connectable"
+  | "private";
+
+export type ConnectPrimaryCta =
+  | "connect"
+  | "open_profile"
+  | "view_connection"
+  | "review_request"
+  | "shortlist"
+  | "undo_pass"
+  | "none";
+
+// ─── Reason ───────────────────────────────────────────────────────────────────
+
+export type ConnectCandidateReason = {
+  code: string;
+  label: string;
+  weight: number;
+  source: ConnectCandidateSource;
+};
+
+// ─── Main Candidate ───────────────────────────────────────────────────────────
+
+export type ConnectCandidate = {
+  /**
+   * Stable ID for deduplication.
+   * Format rules:
+   *   - userId exists        → "user:<userId>"
+   *   - public profile only  → "public:<sourceType>:<publicProfileId>"
+   *   - contact-only         → "contact:<stableLocalId>"
+   */
+  candidateId: string;
+  kind: ConnectCandidateKind;
+  sourceTypes: ConnectCandidateSource[];
+
+  userId?: string | null;
+  publicProfileId?: string | number | null;
+  sourceType?: string | null;
+
+  /** Raw backing profile objects for actions that need them */
+  _rawRiaProfile?: unknown;
+  _rawInvestorProfile?: unknown;
+  _rawConsentEntry?: unknown;
+
+  displayName: string;
+  headline?: string | null;
+  summary?: string | null;
+  avatarUrl?: string | null;
+  firmName?: string | null;
+  locationLabel?: string | null;
+
+  visibilityPosture?: ConnectVisibilityPosture | null;
+  exposureEnabled?: boolean | null;
+  isDiscoverable: boolean;
+
+  verificationStatus?: string | null;
+  verificationBadge?: string | null;
+
+  connectionStatus: ConnectStatus;
+  actionStatus?: "viewed" | "passed" | "shortlisted" | "connect_requested" | null;
+
+  score: number;
+  reasons: ConnectCandidateReason[];
+
+  primaryCta: ConnectPrimaryCta;
+  secondaryCtas: ConnectPrimaryCta[];
+
+  profileHref?: string | null;
+  connectionHref?: string | null;
+
+  lastInteractionAt?: string | null;
+
+  /** Test/demo profiles — hide connect CTAs */
+  isTestProfile?: boolean;
+};
+
+// ─── Sections ─────────────────────────────────────────────────────────────────
+
+export type ConnectSectionKey =
+  | "contacts"
+  | "active_connections"
+  | "pending_connections"
+  | "recommended"
+  | "advisors"
+  | "investors"
+  | "recent_actions"
+  | "hidden_or_unavailable";
+
+export type ConnectSection = {
+  key: ConnectSectionKey;
+  label: string;
+  description?: string | null;
+  candidates: ConnectCandidate[];
+  isEmpty: boolean;
+};
+
+// ─── Contact State ────────────────────────────────────────────────────────────
+
+export type ConnectContactState = {
+  available: boolean;
+  loading: boolean;
+  permissionStatus?: string | null;
+  summary?: string | null;
+  error?: string | null;
+  matchedCount?: number;
+  totalContacts?: number;
+  sourcePlatform?: "web" | "ios" | "android" | "native" | "unknown" | null;
+  /** true once a scan has been completed at least once this session */
+  hasScanned: boolean;
+};
+
+// ─── Discovery Hook Return ────────────────────────────────────────────────────
+
+export type ConnectDiscoveryOptions = {
+  query: string;
+  activePersona: "investor" | "ria";
+  view: "all" | "contacts" | "advisors" | "investors" | "connections";
+  includeContacts: boolean;
+  limit?: number;
+};
+
+export type ConnectDiscoveryResult = {
+  candidates: ConnectCandidate[];
+  sections: ConnectSection[];
+  loading: boolean;
+  refreshing: boolean;
+  error: string | null;
+  iamUnavailable: boolean;
+  contactState: ConnectContactState;
+  actions: {
+    refresh(): Promise<void>;
+    matchContacts(): Promise<{
+      matches: Array<{ user_id?: string | null }>;
+      totalContacts: number;
+      sourcePlatform?: "web" | "ios" | "android" | "native" | "unknown" | null;
+    } | null>;
+    recordAction(
+      candidate: ConnectCandidate,
+      action: "view_more" | "pass" | "shortlist" | "connect_request",
+    ): Promise<void>;
+    connect(candidate: ConnectCandidate): Promise<void>;
+    openProfile(candidate: ConnectCandidate): void;
+  };
+};
+
+// ─── Raw Aggregator Payload ───────────────────────────────────────────────────
+
+export type ConnectRawPayload = {
+  rias: unknown[];
+  investors: unknown[];
+  contactMatches: unknown[];
+  activeConnections: unknown[];
+  pendingConnections: unknown[];
+  previousConnections: unknown[];
+  riaRelationships: unknown[];
+  investorActions: unknown[];
+  iamUnavailable: boolean;
+};

--- a/hushh-webapp/lib/connect/use-connect-discovery.ts
+++ b/hushh-webapp/lib/connect/use-connect-discovery.ts
@@ -1,0 +1,478 @@
+"use client";
+
+/**
+ * lib/connect/use-connect-discovery.ts
+ *
+ * React hook that aggregates all Connect discovery sources.
+ * Preserves existing marketplace UX — just provides a cleaner data layer.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+import {
+  RiaService,
+  type MarketplaceInvestor,
+  type MarketplaceInvestorActionRecord,
+  type RiaClientAccess,
+} from "@/lib/services/ria-service";
+import {
+  ConsentCenterService,
+  type ConsentCenterEntry,
+} from "@/lib/services/consent-center-service";
+import {
+  marketplaceInvestorActionTarget,
+  marketplaceInvestorCardId,
+  marketplaceInvestorUserId,
+  isMarketplaceInvestorConnectable,
+} from "@/lib/marketplace/investor-discovery";
+import {
+  buildMarketplaceConnectionsRoute,
+  buildRiaClientWorkspaceRoute,
+} from "@/lib/navigation/routes";
+import { loadConnectPayload, loadContactMatches } from "./service";
+import {
+  normalizeRiaToCandidate,
+  normalizeInvestorToCandidate,
+  normalizeContactMatchToCandidate,
+  normalizeConsentEntryToCandidate,
+  mergeCandidates,
+} from "./candidates";
+import {
+  sortCandidatesByScore,
+  applyScoreToCandidate,
+} from "./connect-ranking";
+import { isDiscoverable, hasConnectionSource } from "./connect-visibility";
+import type {
+  ConnectCandidate,
+  ConnectSection,
+  ConnectSectionKey,
+  ConnectContactState,
+  ConnectDiscoveryOptions,
+  ConnectDiscoveryResult,
+} from "./types";
+
+// ─── Section Builder ──────────────────────────────────────────────────────────
+
+function buildSections(
+  candidates: ConnectCandidate[],
+  view: ConnectDiscoveryOptions["view"],
+): ConnectSection[] {
+  const sectionDefs: Array<{ key: ConnectSectionKey; label: string; filter: (c: ConnectCandidate) => boolean }> = [
+    {
+      key: "contacts",
+      label: "From your contacts",
+      filter: (c) => c.sourceTypes.includes("contact_match"),
+    },
+    {
+      key: "active_connections",
+      label: "Connected",
+      filter: (c) =>
+        c.connectionStatus === "connected" &&
+        !c.sourceTypes.includes("contact_match"),
+    },
+    {
+      key: "pending_connections",
+      label: "Pending",
+      filter: (c) =>
+        (c.connectionStatus === "pending" || c.connectionStatus === "previous") &&
+        !c.sourceTypes.includes("contact_match"),
+    },
+    {
+      key: "advisors",
+      label: "Advisors",
+      filter: (c) =>
+        c.kind === "ria" &&
+        !c.sourceTypes.includes("contact_match") &&
+        c.connectionStatus === "available",
+    },
+    {
+      key: "investors",
+      label: "Investors",
+      filter: (c) =>
+        (c.kind === "investor" || c.kind === "public_profile") &&
+        !c.sourceTypes.includes("contact_match") &&
+        c.connectionStatus === "available",
+    },
+    {
+      key: "recommended",
+      label: "Recommended",
+      filter: (c) =>
+        c.connectionStatus === "available" &&
+        c.isDiscoverable &&
+        !c.sourceTypes.includes("contact_match"),
+    },
+  ];
+
+  const viewFilterMap: Record<ConnectDiscoveryOptions["view"], ConnectSectionKey[] | "all"> = {
+    all: "all",
+    contacts: ["contacts"],
+    advisors: ["advisors"],
+    investors: ["investors"],
+    connections: ["active_connections", "pending_connections"],
+  };
+
+  const allowedSections = viewFilterMap[view];
+
+  return sectionDefs
+    .filter((def) => allowedSections === "all" || allowedSections.includes(def.key))
+    .map((def) => {
+      const filtered = candidates.filter(def.filter);
+      return {
+        key: def.key,
+        label: def.label,
+        candidates: filtered,
+        isEmpty: filtered.length === 0,
+      };
+    });
+}
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+export function useConnectDiscovery(
+  user: { uid: string; getIdToken(): Promise<string> } | null | undefined,
+  options: ConnectDiscoveryOptions,
+): ConnectDiscoveryResult {
+  const router = useRouter();
+  const { query, activePersona, view, limit = 32 } = options;
+
+  // ── Raw data state ──────────────────────────────────────────────────────────
+  const [loading, setLoading] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [iamUnavailable, setIamUnavailable] = useState(false);
+  const [nonce, setNonce] = useState(0);
+
+  const [rawRias, setRawRias] = useState<unknown[]>([]);
+  const [rawInvestors, setRawInvestors] = useState<unknown[]>([]);
+  const [rawContactMatches, setRawContactMatches] = useState<unknown[]>([]);
+  const [rawActiveConnections, setRawActiveConnections] = useState<ConsentCenterEntry[]>([]);
+  const [rawPendingConnections, setRawPendingConnections] = useState<ConsentCenterEntry[]>([]);
+  const [rawPreviousConnections, setRawPreviousConnections] = useState<ConsentCenterEntry[]>([]);
+  const [rawRiaRelationships, setRawRiaRelationships] = useState<RiaClientAccess[]>([]);
+  const [rawInvestorActions, setRawInvestorActions] = useState<MarketplaceInvestorActionRecord[]>([]);
+
+  // ── Local action state (optimistic) ─────────────────────────────────────────
+  const [shortlistedIds, setShortlistedIds] = useState<string[]>([]);
+  const [passedIds, setPassedIds] = useState<string[]>([]);
+
+  // ── Contact state ────────────────────────────────────────────────────────────
+  const [contactState, setContactState] = useState<ConnectContactState>({
+    available: true,
+    loading: false,
+    hasScanned: false,
+  });
+
+  // ── Refs ────────────────────────────────────────────────────────────────────
+  const actionLoadingRef = useRef<string | null>(null);
+
+  // ── Load persisted local state ───────────────────────────────────────────────
+  useEffect(() => {
+    if (!user || typeof window === "undefined") return;
+    const prefix = `marketplace:ria:${user.uid}`;
+    const readIds = (key: string) => {
+      try {
+        const parsed = JSON.parse(window.localStorage.getItem(key) || "[]");
+        return Array.isArray(parsed) ? parsed.map((v) => String(v || "").trim()).filter(Boolean) : [];
+      } catch { return []; }
+    };
+    setPassedIds(readIds(`${prefix}:passed-investors`));
+    setShortlistedIds(readIds(`${prefix}:shortlisted-investors`));
+  }, [user]);
+
+  // ── Main load effect ─────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!user) return;
+    let cancelled = false;
+    const isRefresh = nonce > 0;
+
+    async function load() {
+      if (isRefresh) setRefreshing(true);
+      else setLoading(true);
+      setError(null);
+
+      try {
+        const idToken = await user!.getIdToken();
+        const payload = await loadConnectPayload({
+          idToken,
+          userId: user!.uid,
+          persona: activePersona,
+          query,
+          limit,
+        });
+
+        if (!cancelled) {
+          setRawRias(payload.rias);
+          setRawInvestors(payload.investors);
+          setRawActiveConnections(payload.activeConnections as ConsentCenterEntry[]);
+          setRawPendingConnections(payload.pendingConnections as ConsentCenterEntry[]);
+          setRawPreviousConnections(payload.previousConnections as ConsentCenterEntry[]);
+          setRawRiaRelationships(payload.riaRelationships as RiaClientAccess[]);
+          setRawInvestorActions(payload.investorActions as MarketplaceInvestorActionRecord[]);
+          setIamUnavailable(payload.iamUnavailable);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load Connect data.");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+          setRefreshing(false);
+        }
+      }
+    }
+
+    void load();
+    return () => { cancelled = true; };
+  }, [user, activePersona, query, limit, nonce]);
+
+  // ── Normalize & merge candidates ──────────────────────────────────────────────
+  const candidates = useMemo<ConnectCandidate[]>(() => {
+    const all: ConnectCandidate[] = [];
+
+    // Normalize RIAs
+    for (const ria of rawRias as Parameters<typeof normalizeRiaToCandidate>[0][]) {
+      const c = normalizeRiaToCandidate(ria, {
+        consentEntries: rawActiveConnections,
+        query,
+        currentPersona: activePersona,
+      });
+      all.push(c);
+    }
+
+    // Normalize investors
+    for (const investor of rawInvestors as MarketplaceInvestor[]) {
+      const c = normalizeInvestorToCandidate(investor, {
+        riaRelationships: rawRiaRelationships,
+        investorActions: rawInvestorActions,
+        query,
+        currentPersona: activePersona,
+        shortlistedIds,
+        passedIds,
+      });
+      all.push(c);
+    }
+
+    // Normalize connections
+    for (const entry of rawActiveConnections) {
+      const c = normalizeConsentEntryToCandidate(entry, { surface: "active", query });
+      if (c) all.push(c);
+    }
+    for (const entry of rawPendingConnections) {
+      const c = normalizeConsentEntryToCandidate(entry, { surface: "pending", query });
+      if (c) all.push(c);
+    }
+    for (const entry of rawPreviousConnections) {
+      const c = normalizeConsentEntryToCandidate(entry, { surface: "previous", query });
+      if (c) all.push(c);
+    }
+
+    // Normalize contact matches
+    for (const match of rawContactMatches as Parameters<typeof normalizeContactMatchToCandidate>[0][]) {
+      const c = normalizeContactMatchToCandidate(match, { existingCandidates: all, query });
+      if (c) all.push(c);
+    }
+
+    // Merge duplicates
+    const merged = mergeCandidates(all);
+
+    // Re-score with current query
+    const scored = merged.map((c) => applyScoreToCandidate(c, query));
+
+    // Filter: discovery section only shows discoverable; connections section shows all
+    const filtered = scored.filter((c) => {
+      if (hasConnectionSource(c.sourceTypes)) return true; // always show connections
+      if (!isDiscoverable(c)) return false;
+      if (c.connectionStatus === "passed") return false;
+      return true;
+    });
+
+    return sortCandidatesByScore(filtered);
+  }, [
+    rawRias, rawInvestors, rawContactMatches, rawActiveConnections,
+    rawPendingConnections, rawPreviousConnections, rawRiaRelationships,
+    rawInvestorActions, query, activePersona, shortlistedIds, passedIds,
+  ]);
+
+  const sections = useMemo(
+    () => buildSections(candidates, view),
+    [candidates, view],
+  );
+
+  // ── Actions ──────────────────────────────────────────────────────────────────
+
+  const refresh = useCallback(async () => {
+    setNonce((n) => n + 1);
+  }, []);
+
+  const matchContacts = useCallback(async () => {
+    if (!user) {
+      toast.error("Sign in required", { description: "Connect needs your account to match contacts." });
+      return null;
+    }
+    setContactState((s) => ({ ...s, loading: true, error: null }));
+    try {
+      const idToken = await user.getIdToken();
+      const result = await loadContactMatches(idToken);
+      if (result.error) throw new Error(result.error);
+      setRawContactMatches(result.matches);
+      setContactState((s) => ({
+        ...s,
+        loading: false,
+        hasScanned: true,
+        matchedCount: result.matches.length,
+        totalContacts: result.totalContacts,
+        sourcePlatform: result.sourcePlatform,
+        summary: result.matches.length > 0
+          ? `${result.matches.length} match${result.matches.length === 1 ? "" : "es"} from ${result.totalContacts} contacts.`
+          : "No phone numbers or emails found in contacts.",
+      }));
+      if (result.matches.length === 0) {
+        toast.info("No Hushh contacts found", { description: "Search is still available across public profiles." });
+      }
+      return result;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Could not match contacts.";
+      setContactState((s) => ({ ...s, loading: false, error: msg }));
+      toast.error(msg);
+      throw err;
+    }
+  }, [user]);
+
+  const recordAction = useCallback(
+    async (
+      candidate: ConnectCandidate,
+      action: "view_more" | "pass" | "shortlist" | "connect_request",
+    ) => {
+      if (!user || candidate.isTestProfile) return;
+      const investor = candidate._rawInvestorProfile as MarketplaceInvestor | undefined;
+      if (!investor) return;
+      const target = marketplaceInvestorActionTarget(investor);
+      if (target.source_type === "public_sec" && !target.public_profile_id) return;
+      if (target.source_type === "hushh_user" && !target.target_user_id) return;
+      try {
+        const idToken = await user.getIdToken();
+        await RiaService.recordInvestorAction(idToken, {
+          action,
+          ...target,
+          metadata: { surface: "connect", persona: activePersona },
+        });
+
+        const investorId = marketplaceInvestorCardId(investor);
+        if (action === "pass") {
+          setPassedIds((ids) => ids.includes(investorId) ? ids : [...ids, investorId]);
+          if (typeof window !== "undefined") {
+            const key = `marketplace:ria:${user.uid}:passed-investors`;
+            try {
+              const cur = JSON.parse(window.localStorage.getItem(key) || "[]");
+              const existing = Array.isArray(cur) ? cur.map((v: unknown) => String(v || "").trim()).filter(Boolean) : [];
+              if (!existing.includes(investorId)) window.localStorage.setItem(key, JSON.stringify([...existing, investorId]));
+            } catch { /* ignore */ }
+          }
+        }
+        if (action === "shortlist") {
+          setShortlistedIds((ids) => ids.includes(investorId) ? ids : [...ids, investorId]);
+        }
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Action failed.");
+      }
+    },
+    [user, activePersona],
+  );
+
+  const connect = useCallback(
+    async (candidate: ConnectCandidate) => {
+      if (!user) return;
+      const { _rawRiaProfile, _rawInvestorProfile, kind } = candidate;
+
+      try {
+        actionLoadingRef.current = candidate.candidateId;
+        const idToken = await user.getIdToken();
+
+        if (kind === "ria" && _rawRiaProfile) {
+          const ria = _rawRiaProfile as { user_id: string };
+          await ConsentCenterService.createRequest({
+            idToken,
+            userId: user.uid,
+            payload: {
+              subject_user_id: ria.user_id,
+              requester_actor_type: "investor",
+              subject_actor_type: "ria",
+              scope_template_id: "investor_advisor_disclosure_v1",
+              duration_mode: "preset",
+              duration_hours: 168,
+            },
+          });
+          toast.success("Connection request sent", { description: "The advisor can review it in their pending connections." });
+          router.push(buildMarketplaceConnectionsRoute({ tab: "pending" }));
+          return;
+        }
+
+        if ((kind === "investor" || kind === "public_profile") && _rawInvestorProfile) {
+          const investor = _rawInvestorProfile as MarketplaceInvestor;
+          const investorUserId = marketplaceInvestorUserId(investor);
+          if (!isMarketplaceInvestorConnectable(investor) || !investorUserId) {
+            toast.info("Public investor profile", { description: "This profile is discovery-only." });
+            return;
+          }
+          await ConsentCenterService.createRequest({
+            idToken,
+            userId: user.uid,
+            payload: {
+              subject_user_id: investorUserId,
+              requester_actor_type: "ria",
+              subject_actor_type: "investor",
+              scope_template_id: "ria_financial_summary_v1",
+              duration_mode: "preset",
+              duration_hours: 168,
+            },
+          });
+          await recordAction(candidate, "connect_request");
+          const investorId = marketplaceInvestorCardId(investor);
+          setPassedIds((ids) => ids.includes(investorId) ? ids : [...ids, investorId]);
+          toast.success("Connection request sent", { description: "The investor can review it in their pending connections." });
+          router.push(buildMarketplaceConnectionsRoute({ tab: "pending" }));
+        }
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Failed to send connection request.");
+      } finally {
+        actionLoadingRef.current = null;
+      }
+    },
+    [user, router, recordAction],
+  );
+
+  const openProfile = useCallback(
+    (candidate: ConnectCandidate) => {
+      if (candidate.isTestProfile) {
+        const userId = candidate.userId;
+        if (userId) {
+          router.push(buildRiaClientWorkspaceRoute(userId, { tab: "overview", testProfile: true }));
+        }
+        return;
+      }
+      // Profile opening is handled by the page (opens detail sheet)
+      // This action is a no-op here — page consumes the candidate's profileHref
+    },
+    [router],
+  );
+
+  return {
+    candidates,
+    sections,
+    loading,
+    refreshing,
+    error,
+    iamUnavailable,
+    contactState,
+    actions: {
+      refresh,
+      matchContacts,
+      recordAction,
+      connect,
+      openProfile,
+    },
+  };
+}

--- a/hushh-webapp/lib/marketplace/contact-matching.ts
+++ b/hushh-webapp/lib/marketplace/contact-matching.ts
@@ -14,6 +14,15 @@ export type MarketplaceLocalContactLookup = MarketplaceContactLookup & {
   displayName?: string | null;
 };
 
+export type MarketplaceEmailContactLookup = {
+  hash: string;
+};
+
+type MarketplaceLocalEmailContactLookup = MarketplaceEmailContactLookup & {
+  displayName?: string | null;
+  domain?: string | null;
+};
+
 function normalizePhoneForContactHash(value: string): string | null {
   const raw = String(value || "").trim();
   const digits = raw.replace(/\D/g, "");
@@ -21,6 +30,18 @@ function normalizePhoneForContactHash(value: string): string | null {
   if (raw.startsWith("+")) return `+${digits}`;
   if (digits.length === 10) return `+1${digits}`;
   return `+${digits}`;
+}
+
+function normalizeEmailForContactHash(value: string): string | null {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (!normalized || !normalized.includes("@")) return null;
+  const [localPart, domain, ...rest] = normalized.split("@");
+  if (!localPart || !domain || rest.length > 0) return null;
+  return `${localPart}@${domain}`;
+}
+
+function emailDomain(value: string): string | null {
+  return value.split("@")[1] || null;
 }
 
 function contactDisplayName(contact: HushhContactRecord): string | null {
@@ -43,30 +64,80 @@ export async function buildMarketplaceContactLookups(options?: {
   limit?: number;
 }): Promise<{
   lookups: MarketplaceLocalContactLookup[];
+  phoneLookups: MarketplaceLocalContactLookup[];
+  emailLookups: MarketplaceLocalEmailContactLookup[];
   totalContacts: number;
   sourcePlatform: "web" | "ios" | "android" | "native";
 }> {
   const result = await HushhContacts.readContacts({ limit: options?.limit ?? 500 });
-  const seen = new Set<string>();
-  const lookups: MarketplaceLocalContactLookup[] = [];
+  const seenPhones = new Set<string>();
+  const seenEmails = new Set<string>();
+  const phoneLookups: MarketplaceLocalContactLookup[] = [];
+  const emailLookups: MarketplaceLocalEmailContactLookup[] = [];
 
   for (const contact of result.contacts) {
     for (const phoneNumber of contact.phoneNumbers || []) {
       const normalized = normalizePhoneForContactHash(phoneNumber);
-      if (!normalized || seen.has(normalized)) continue;
-      seen.add(normalized);
+      if (!normalized || seenPhones.has(normalized)) continue;
+      seenPhones.add(normalized);
       const digits = normalized.replace(/\D/g, "");
-      lookups.push({
+      phoneLookups.push({
         hash: await sha256Hex(normalized),
         last4: digits.slice(-4),
         displayName: contactDisplayName(contact),
       });
     }
+
+    for (const emailAddress of contact.emailAddresses || []) {
+      const normalized = normalizeEmailForContactHash(emailAddress);
+      if (!normalized || seenEmails.has(normalized)) continue;
+      seenEmails.add(normalized);
+      emailLookups.push({
+        hash: await sha256Hex(normalized),
+        displayName: contactDisplayName(contact),
+        domain: emailDomain(normalized),
+      });
+    }
   }
 
   return {
-    lookups,
+    lookups: phoneLookups,
+    phoneLookups,
+    emailLookups,
     totalContacts: result.contacts.length,
     sourcePlatform: result.sourcePlatform,
   };
+}
+
+export async function buildMarketplaceContactLookupsFromQuery(query: string): Promise<{
+  phoneLookups: MarketplaceContactLookup[];
+  emailLookups: MarketplaceEmailContactLookup[];
+}> {
+  const normalizedEmail = normalizeEmailForContactHash(query);
+  if (normalizedEmail) {
+    return {
+      phoneLookups: [],
+      emailLookups: [{ hash: await sha256Hex(normalizedEmail) }],
+    };
+  }
+
+  const queryDigits = String(query || "").replace(/\D/g, "");
+  if (queryDigits.length < 7) {
+    return { phoneLookups: [], emailLookups: [] };
+  }
+  const normalizedPhone = normalizePhoneForContactHash(query);
+  if (normalizedPhone) {
+    const digits = normalizedPhone.replace(/\D/g, "");
+    return {
+      phoneLookups: [
+        {
+          hash: await sha256Hex(normalizedPhone),
+          last4: digits.slice(-4),
+        },
+      ],
+      emailLookups: [],
+    };
+  }
+
+  return { phoneLookups: [], emailLookups: [] };
 }

--- a/hushh-webapp/lib/one-location/kai-circle-connect-bridge.ts
+++ b/hushh-webapp/lib/one-location/kai-circle-connect-bridge.ts
@@ -1,0 +1,264 @@
+import { isDiscoverable } from "@/lib/connect/connect-visibility";
+import type { ConnectCandidate } from "@/lib/connect/types";
+import type {
+  KaiCircleCandidate,
+  OneLocationRecipient,
+  OneLocationState,
+  OneLocationViewerCapabilities,
+} from "@/lib/one-location/types";
+
+const LOCATION_KEY_AGREEMENT_ALGORITHM = ["ECDH-P256", "AES256-GCM"].join("-");
+
+function candidateIdForUser(userId: string): string {
+  return `user:${userId}`;
+}
+
+function hasShareKey(value: {
+  keyId?: string | null;
+  publicKeyJwk?: JsonWebKey | null;
+  canReceiveLocation?: boolean;
+}): boolean {
+  return Boolean(value.canReceiveLocation && value.keyId && value.publicKeyJwk);
+}
+
+function isOneLocationRecipientCandidate(candidate: KaiCircleCandidate): boolean {
+  return candidate.sourceTypes.includes("one_location_recipient");
+}
+
+function uniq(values: Array<string | null | undefined>): string[] {
+  return Array.from(
+    new Set(values.map((value) => String(value || "").trim()).filter(Boolean)),
+  );
+}
+
+function connectReasonLabels(connect: ConnectCandidate): Array<{ code: string; label: string; weight?: number }> {
+  const labels = connect.reasons
+    .filter((reason) => reason.code && reason.label)
+    .slice(0, 3)
+    .map((reason) => ({
+      code: reason.code,
+      label: reason.label,
+      weight: reason.weight,
+    }));
+
+  if (connect.sourceTypes.includes("contact_match")) {
+    labels.unshift({ code: "connect_contact_match", label: "Matched from Connect contacts", weight: 30 });
+  }
+  if (connect.connectionStatus === "connected") {
+    labels.unshift({ code: "connect_active_connection", label: "Active Connect relationship", weight: 40 });
+  }
+  return labels;
+}
+
+function recommendationTierFromConnect(connect: ConnectCandidate): string {
+  if (connect.connectionStatus === "connected") return "trusted_circle";
+  if (connect.sourceTypes.includes("contact_match")) return "contacts";
+  if (connect.kind === "ria" || connect.kind === "investor" || connect.kind === "public_profile") {
+    return "kai_network";
+  }
+  return "available";
+}
+
+function recommendationCategoryFromConnect(connect: ConnectCandidate): string {
+  if (connect.connectionStatus === "connected") return "trusted_circle";
+  if (connect.kind === "ria" || connect.kind === "investor" || connect.kind === "public_profile") {
+    return "professional_network";
+  }
+  if (connect.sourceTypes.includes("contact_match")) return "connect_matches";
+  return "location_ready";
+}
+
+function isConnectLocationVisible(connect: ConnectCandidate): boolean {
+  if (connect.exposureEnabled === false) return false;
+  if (String(connect.visibilityPosture || "").trim().toLowerCase() === "private") {
+    return false;
+  }
+  return isDiscoverable(connect);
+}
+
+function fromRecipient(recipient: OneLocationRecipient): KaiCircleCandidate {
+  const isShareReady = hasShareKey(recipient);
+  const recommendationTier =
+    recipient.recommendationTier ?? (isShareReady ? "available" : "setup_needed");
+  const recommendationCategory =
+    recipient.recommendationCategory ?? (isShareReady ? "location_ready" : "needs_setup");
+  return {
+    candidateId: candidateIdForUser(recipient.userId),
+    userId: recipient.userId,
+    displayName: recipient.displayName,
+    maskedPhone: recipient.maskedPhone,
+    phoneVerified: recipient.phoneVerified,
+    keyId: recipient.keyId,
+    publicKeyJwk: recipient.publicKeyJwk,
+    keyAlgorithm: recipient.keyAlgorithm,
+    keyRegisteredAt: recipient.keyRegisteredAt,
+    canReceiveLocation: recipient.canReceiveLocation,
+    isShareReady,
+    readiness: isShareReady ? "location_ready" : "target_setup_needed",
+    sourceTypes: ["one_location_recipient"],
+    isDiscoverable: true,
+    recommendationScore: recipient.recommendationScore,
+    recommendationRank: recipient.recommendationRank,
+    recommendationTier,
+    recommendationCategory,
+    recommendationCategoryLabel: recipient.recommendationCategoryLabel,
+    recommendationReasons: recipient.recommendationReasons,
+    recommendationSummary: recipient.recommendationSummary,
+    trustLevel: recipient.trustLevel,
+    relationshipType: recipient.relationshipType,
+    profileHeadline: recipient.profileHeadline,
+    verificationBadge: recipient.verificationBadge,
+    lastInteractionAt: recipient.lastInteractionAt,
+  };
+}
+
+function fromConnect(connect: ConnectCandidate, viewerCapabilities?: OneLocationViewerCapabilities): KaiCircleCandidate {
+  const userId = String(connect.userId || "").trim() || null;
+  const isPublicProfileOnly = !userId;
+  const sourceTypes = uniq(connect.sourceTypes);
+  const score = Math.max(0, connect.score || 0);
+  const reasons = connectReasonLabels(connect);
+  const tier = recommendationTierFromConnect(connect);
+  const category = recommendationCategoryFromConnect(connect);
+  const viewerNeedsSetup = viewerCapabilities?.hasLocationRecipientKey === false;
+
+  return {
+    candidateId: userId ? candidateIdForUser(userId) : connect.candidateId,
+    userId,
+    displayName: connect.displayName,
+    maskedPhone: null,
+    phoneVerified: Boolean(userId),
+    keyId: null,
+    publicKeyJwk: null,
+    keyAlgorithm: LOCATION_KEY_AGREEMENT_ALGORITHM,
+    canReceiveLocation: false,
+    isShareReady: false,
+    readiness: isPublicProfileOnly
+      ? "invite_only"
+      : viewerNeedsSetup
+        ? "viewer_setup_needed"
+        : "target_setup_needed",
+    connectCandidateId: connect.candidateId,
+    connectKind: connect.kind,
+    connectStatus: connect.connectionStatus,
+    sourceTypes,
+    profileHref: connect.profileHref,
+    connectionHref: connect.connectionHref,
+    isPublicProfileOnly,
+    isDiscoverable: connect.isDiscoverable,
+    recommendationScore: score,
+    recommendationTier: tier,
+    recommendationCategory: category,
+    recommendationCategoryLabel:
+      category === "trusted_circle"
+        ? "Trusted Circle"
+        : category === "professional_network"
+          ? "Professional Network"
+          : sourceTypes.includes("contact_match")
+            ? "Connect Match"
+            : "Connect",
+    recommendationReasons: reasons,
+    recommendationSummary:
+      connect.summary ||
+      connect.headline ||
+      (sourceTypes.includes("contact_match")
+        ? "Discovered through your Connect contact matches."
+        : "Discovered from Connect."),
+    trustLevel:
+      connect.connectionStatus === "connected"
+        ? "high"
+        : category === "professional_network"
+          ? "medium"
+          : "new",
+    relationshipType: connect.firmName || connect.locationLabel || null,
+    profileHeadline: connect.headline,
+    verificationBadge: connect.verificationBadge,
+    lastInteractionAt: connect.lastInteractionAt,
+  };
+}
+
+function mergeCandidate(existing: KaiCircleCandidate, incoming: KaiCircleCandidate): KaiCircleCandidate {
+  const isShareReady = existing.isShareReady || incoming.isShareReady;
+  const existingIsOneLocationRecipient = isOneLocationRecipientCandidate(existing);
+  const sourceTypes = uniq([...existing.sourceTypes, ...incoming.sourceTypes]);
+  const score = Math.max(existing.recommendationScore ?? 0, incoming.recommendationScore ?? 0);
+  const reasons = [
+    ...(existing.recommendationReasons ?? []),
+    ...(incoming.recommendationReasons ?? []).filter(
+      (reason) => !(existing.recommendationReasons ?? []).some((item) => item.code === reason.code),
+    ),
+  ].slice(0, 4);
+
+  const preferIncomingName =
+    incoming.displayName && incoming.displayName.length > existing.displayName.length;
+
+  return {
+    ...existing,
+    displayName: preferIncomingName ? incoming.displayName : existing.displayName,
+    connectCandidateId: existing.connectCandidateId ?? incoming.connectCandidateId,
+    connectKind: existing.connectKind ?? incoming.connectKind,
+    connectStatus: existing.connectStatus ?? incoming.connectStatus,
+    sourceTypes,
+    profileHref: existing.profileHref ?? incoming.profileHref,
+    connectionHref: existing.connectionHref ?? incoming.connectionHref,
+    isPublicProfileOnly: existing.isPublicProfileOnly && incoming.isPublicProfileOnly,
+    isDiscoverable: existing.isDiscoverable || incoming.isDiscoverable,
+    isShareReady,
+    readiness: isShareReady ? "location_ready" : incoming.readiness || existing.readiness,
+    recommendationScore: score,
+    recommendationTier: existing.recommendationTier ?? incoming.recommendationTier,
+    recommendationCategory: existing.recommendationCategory ?? incoming.recommendationCategory,
+    recommendationCategoryLabel:
+      existingIsOneLocationRecipient
+        ? existing.recommendationCategoryLabel
+        : existing.recommendationCategoryLabel ?? incoming.recommendationCategoryLabel,
+    recommendationReasons: reasons,
+    recommendationSummary: existing.recommendationSummary ?? incoming.recommendationSummary,
+    trustLevel: existing.trustLevel ?? incoming.trustLevel,
+    relationshipType: existing.relationshipType ?? incoming.relationshipType,
+    profileHeadline: existing.profileHeadline ?? incoming.profileHeadline,
+    verificationBadge: existing.verificationBadge ?? incoming.verificationBadge,
+    lastInteractionAt: existing.lastInteractionAt ?? incoming.lastInteractionAt,
+  };
+}
+
+export function buildKaiCircleCandidates(params: {
+  connectCandidates?: ConnectCandidate[];
+  state?: Pick<OneLocationState, "recipients" | "viewerCapabilities"> | null;
+}): KaiCircleCandidate[] {
+  const map = new Map<string, KaiCircleCandidate>();
+  const viewerCapabilities = params.state?.viewerCapabilities;
+  const hiddenConnectUserIds = new Set(
+    (params.connectCandidates ?? [])
+      .filter((connect) => !isConnectLocationVisible(connect))
+      .map((connect) => String(connect.userId || "").trim())
+      .filter(Boolean),
+  );
+
+  for (const recipient of params.state?.recipients ?? []) {
+    if (hiddenConnectUserIds.has(recipient.userId)) continue;
+    map.set(candidateIdForUser(recipient.userId), fromRecipient(recipient));
+  }
+
+  for (const connect of params.connectCandidates ?? []) {
+    if (!isConnectLocationVisible(connect)) continue;
+    const candidate = fromConnect(connect, viewerCapabilities);
+    const existing = map.get(candidate.candidateId);
+    if (!existing) continue;
+    map.set(candidate.candidateId, mergeCandidate(existing, candidate));
+  }
+
+  return Array.from(map.values())
+    .filter((candidate) => candidate.isDiscoverable)
+    .sort((a, b) => {
+      if (a.isShareReady !== b.isShareReady) return a.isShareReady ? -1 : 1;
+      const aScore = a.recommendationScore ?? 0;
+      const bScore = b.recommendationScore ?? 0;
+      if (aScore !== bScore) return bScore - aScore;
+      return a.displayName.localeCompare(b.displayName);
+    })
+    .map((candidate, index) => ({
+      ...candidate,
+      recommendationRank: candidate.recommendationRank ?? index + 1,
+    }));
+}

--- a/hushh-webapp/lib/one-location/kai-circle-ctas.ts
+++ b/hushh-webapp/lib/one-location/kai-circle-ctas.ts
@@ -1,0 +1,75 @@
+import type {
+  KaiCircleCandidate,
+  KaiCircleCta,
+  OneLocationViewerCapabilities,
+} from "@/lib/one-location/types";
+
+export function resolveKaiCircleCtas(params: {
+  candidate: KaiCircleCandidate;
+  mode: "share" | "request";
+  viewerCapabilities?: OneLocationViewerCapabilities | null;
+  hasActiveOwnerGrant?: boolean;
+  hasReceivedGrant?: boolean;
+  hasPendingOwnerRequest?: boolean;
+}): KaiCircleCta[] {
+  const { candidate, mode, viewerCapabilities } = params;
+  const ctas: KaiCircleCta[] = [];
+
+  if (params.hasPendingOwnerRequest) {
+    ctas.push(
+      { id: "approve", label: "Approve", enabled: candidate.isShareReady },
+      { id: "deny", label: "Deny", enabled: true },
+    );
+    return ctas;
+  }
+
+  if (params.hasReceivedGrant) {
+    ctas.push({ id: "view_shared_location", label: "View Shared Location", enabled: true });
+  }
+
+  if (params.hasActiveOwnerGrant) {
+    ctas.push({ id: "revoke_access", label: "Revoke Access", enabled: true });
+  }
+
+  if (!candidate.userId || candidate.isPublicProfileOnly) {
+    ctas.push({
+      id: "open_connect_profile",
+      label: "Invite to One",
+      enabled: Boolean(candidate.profileHref || candidate.connectionHref),
+    });
+    return ctas;
+  }
+
+  if (mode === "share") {
+    if (candidate.isShareReady) {
+      ctas.push({ id: "share_location", label: "Share Location", enabled: true });
+    } else {
+      ctas.push({
+        id: "ask_to_setup_one_location",
+        label: "Ask to Setup One Location",
+        enabled: true,
+        reason: "They need a One Location recipient key before private sharing.",
+      });
+    }
+  } else {
+    ctas.push({
+      id: "request_location",
+      label: "Request Location",
+      enabled: viewerCapabilities?.canRequestLocation !== false,
+      reason:
+        viewerCapabilities?.hasLocationRecipientKey === false
+          ? "Your One Location key will be set up before sending the request."
+          : null,
+    });
+  }
+
+  if (candidate.profileHref || candidate.connectionHref) {
+    ctas.push({
+      id: "open_connect_profile",
+      label: "Open Connect Profile",
+      enabled: true,
+    });
+  }
+
+  return ctas;
+}

--- a/hushh-webapp/lib/one-location/kai-circle-sections.ts
+++ b/hushh-webapp/lib/one-location/kai-circle-sections.ts
@@ -1,0 +1,122 @@
+import type {
+  KaiCircleCandidate,
+  KaiCircleSection,
+  KaiCircleSectionKey,
+} from "@/lib/one-location/types";
+
+export const KAI_CIRCLE_SECTION_META: Record<
+  KaiCircleSectionKey,
+  Pick<KaiCircleSection, "title" | "description">
+> = {
+  needs_action: {
+    title: "Needs your approval",
+    description: "Requests and people waiting on a decision.",
+  },
+  trusted_circle: {
+    title: "Trusted Circle",
+    description: "People with active sharing, history, or referrals.",
+  },
+  professional_network: {
+    title: "Professional Network",
+    description: "RIA, investor, advisor, and marketplace signals.",
+  },
+  connect_matches: {
+    title: "Connect Matches",
+    description: "People discovered from Connect and contact matching.",
+  },
+  location_ready: {
+    title: "Location-ready KAI members",
+    description: "Verified KAI members ready for encrypted sharing.",
+  },
+  needs_setup: {
+    title: "Needs setup",
+    description: "People who need to open One Location once.",
+  },
+};
+
+export const KAI_CIRCLE_SECTION_EMPTY_COPY: Record<
+  KaiCircleSectionKey,
+  { title: string; description: string }
+> = {
+  needs_action: {
+    title: "No approvals waiting",
+    description: "New location requests and pending decisions will appear here.",
+  },
+  trusted_circle: {
+    title: "No trusted matches yet",
+    description: "Active shares, repeat approvals, and referrals will lift people here.",
+  },
+  professional_network: {
+    title: "No professional signals yet",
+    description: "RIA, investor, advisor, and marketplace matches will appear here.",
+  },
+  connect_matches: {
+    title: "No Connect matches yet",
+    description: "Contact and Connect matches will appear here after sync.",
+  },
+  location_ready: {
+    title: "No ready KAI members yet",
+    description: "Verified KAI members with location keys will appear here.",
+  },
+  needs_setup: {
+    title: "No setup blockers",
+    description: "Everyone in this section is ready enough for the current flow.",
+  },
+};
+
+export const KAI_CIRCLE_SECTION_ORDER: KaiCircleSectionKey[] = [
+  "needs_action",
+  "trusted_circle",
+  "professional_network",
+  "connect_matches",
+  "location_ready",
+  "needs_setup",
+];
+
+export function kaiCircleSectionKey(candidate: KaiCircleCandidate): KaiCircleSectionKey {
+  switch (candidate.recommendationCategory) {
+    case "needs_action":
+      return "needs_action";
+    case "trusted_circle":
+      return "trusted_circle";
+  }
+
+  if (candidate.connectStatus === "pending") return "needs_action";
+  if (candidate.connectStatus === "connected") return "trusted_circle";
+  if (candidate.isShareReady) return "location_ready";
+  if (
+    candidate.sourceTypes.includes("one_location_recipient") ||
+    candidate.readiness === "target_setup_needed" ||
+    candidate.readiness === "viewer_setup_needed"
+  ) {
+    return "needs_setup";
+  }
+
+  const isProfessional =
+    candidate.recommendationCategory === "professional_network" ||
+    candidate.recommendationTier === "kai_network" ||
+    ["ria", "investor", "public_profile"].includes(String(candidate.connectKind || "")) ||
+    candidate.sourceTypes.some((source) =>
+      ["marketplace_ria", "marketplace_investor", "public_sec", "active_connection"].includes(source),
+    );
+  if (isProfessional) return "professional_network";
+
+  if (candidate.sourceTypes.includes("contact_match")) return "connect_matches";
+  return "needs_setup";
+}
+
+export function buildKaiCircleSections(candidates: KaiCircleCandidate[]): KaiCircleSection[] {
+  const grouped = new Map<KaiCircleSectionKey, KaiCircleCandidate[]>();
+  KAI_CIRCLE_SECTION_ORDER.forEach((key) => grouped.set(key, []));
+
+  for (const candidate of candidates) {
+    grouped.get(kaiCircleSectionKey(candidate))?.push(candidate);
+  }
+
+  return KAI_CIRCLE_SECTION_ORDER.map((key) => ({
+    key,
+    title: KAI_CIRCLE_SECTION_META[key].title,
+    description: KAI_CIRCLE_SECTION_META[key].description,
+    candidates: grouped.get(key) ?? [],
+  }));
+}

--- a/hushh-webapp/lib/one-location/key-bootstrap.ts
+++ b/hushh-webapp/lib/one-location/key-bootstrap.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { ensureLocationRecipientKey } from "@/lib/one-location/encryption";
+import { OneLocationService } from "@/lib/one-location/service";
+import type { OneLocationRecipient } from "@/lib/one-location/types";
+
+export async function bootstrapCurrentUserLocationRecipientKey(params: {
+  userId: string;
+  vaultOwnerToken: string;
+}): Promise<OneLocationRecipient> {
+  const userId = String(params.userId || "").trim();
+  const vaultOwnerToken = String(params.vaultOwnerToken || "").trim();
+  if (!userId) throw new Error("Current user is required for One Location setup.");
+  if (!vaultOwnerToken) throw new Error("Vault owner token required for One Location setup.");
+
+  const key = await ensureLocationRecipientKey(userId);
+  return OneLocationService.registerRecipientKey({
+    vaultOwnerToken,
+    keyId: key.keyId,
+    publicKeyJwk: key.publicKeyJwk,
+    algorithm: key.algorithm,
+  });
+}

--- a/hushh-webapp/lib/one-location/types.ts
+++ b/hushh-webapp/lib/one-location/types.ts
@@ -52,6 +52,87 @@ export type OneLocationRecipient = {
   lastInteractionAt?: string | null;
 };
 
+export type OneLocationViewerCapabilities = {
+  hasLocationRecipientKey?: boolean;
+  canBootstrapRecipientKey?: boolean;
+  canShareLocation?: boolean;
+  canRequestLocation?: boolean;
+};
+
+type KaiCircleCandidateReadiness =
+  | "location_ready"
+  | "target_setup_needed"
+  | "viewer_setup_needed"
+  | "invite_only"
+  | "not_shareable";
+
+export type KaiCircleCandidate = {
+  candidateId: string;
+  userId?: string | null;
+  displayName: string;
+  maskedPhone?: string | null;
+  phoneVerified: boolean;
+  keyId?: string | null;
+  publicKeyJwk?: JsonWebKey | null;
+  keyAlgorithm: string;
+  keyRegisteredAt?: string | null;
+  canReceiveLocation: boolean;
+  isShareReady: boolean;
+  readiness: KaiCircleCandidateReadiness;
+  connectCandidateId?: string | null;
+  connectKind?: string | null;
+  connectStatus?: string | null;
+  sourceTypes: string[];
+  profileHref?: string | null;
+  connectionHref?: string | null;
+  isPublicProfileOnly?: boolean;
+  isDiscoverable: boolean;
+  recommendationScore?: number;
+  recommendationRank?: number;
+  recommendationTier?: OneLocationRecommendationTier | null;
+  recommendationCategory?: OneLocationRecommendationCategory | null;
+  recommendationCategoryLabel?: string | null;
+  recommendationReasons?: OneLocationRecommendationReason[];
+  recommendationSummary?: string | null;
+  trustLevel?: "high" | "medium" | "new" | "setup_needed" | string | null;
+  relationshipType?: string | null;
+  profileHeadline?: string | null;
+  verificationBadge?: string | null;
+  lastInteractionAt?: string | null;
+};
+
+export type KaiCircleSectionKey =
+  | "needs_action"
+  | "trusted_circle"
+  | "professional_network"
+  | "connect_matches"
+  | "location_ready"
+  | "needs_setup";
+
+export type KaiCircleSection = {
+  key: KaiCircleSectionKey;
+  title: string;
+  description: string;
+  candidates: KaiCircleCandidate[];
+};
+
+type KaiCircleCtaId =
+  | "share_location"
+  | "request_location"
+  | "ask_to_setup_one_location"
+  | "open_connect_profile"
+  | "approve"
+  | "deny"
+  | "view_shared_location"
+  | "revoke_access";
+
+export type KaiCircleCta = {
+  id: KaiCircleCtaId;
+  label: string;
+  enabled: boolean;
+  reason?: string | null;
+};
+
 export type OneLocationGrant = {
   id: string;
   ownerUserId: string;
@@ -110,7 +191,6 @@ export type OneLocationPublicInvite = {
   createdAt?: string | null;
   updatedAt?: string | null;
   revokedAt?: string | null;
-  locationAvailable?: boolean;
 };
 
 export type OneLocationPublicInviteSubmission = {
@@ -137,6 +217,8 @@ export type OneLocationPublicInviteSubmission = {
 
 export type OneLocationState = {
   recipients: OneLocationRecipient[];
+  kaiCircleCandidates?: KaiCircleCandidate[];
+  viewerCapabilities?: OneLocationViewerCapabilities;
   ownerGrants: OneLocationGrant[];
   receivedGrants: OneLocationGrant[];
   requests: OneLocationAccessRequest[];

--- a/hushh-webapp/lib/services/ria-service.ts
+++ b/hushh-webapp/lib/services/ria-service.ts
@@ -44,6 +44,8 @@ export interface MarketplaceRia {
   disclosures_url?: string | null;
   verification_status: string;
   is_test_profile?: boolean;
+  visibility_posture?: string | null;
+  exposure_enabled?: boolean | null;
   firms?: Array<{
     firm_id: string;
     legal_name: string;
@@ -82,6 +84,8 @@ export interface MarketplaceInvestor {
     metadata?: Record<string, unknown>;
   } | null;
   is_test_profile?: boolean;
+  visibility_posture?: string | null;
+  exposure_enabled?: boolean | null;
 }
 
 export type MarketplaceInvestorActionName =
@@ -125,6 +129,7 @@ export interface MarketplaceContactMatch {
   display_name: string;
   headline?: string | null;
   phone_last4?: string | null;
+  matched_by?: "phone" | "email" | "phone_and_email" | null;
   profile: MarketplaceRia | MarketplaceInvestor;
 }
 
@@ -1335,6 +1340,7 @@ export class RiaService {
     idToken: string,
     payload: {
       phone_lookups: Array<{ hash: string; last4: string }>;
+      email_lookups?: Array<{ hash: string }>;
       limit?: number;
     },
   ): Promise<MarketplaceContactMatch[]> {


### PR DESCRIPTION
## Maintainer harvest of #2443 (Connect discovery)

Harvests the **additive, self-contained** Connect discovery subsystem from @DamriaNeelesh's #2443, rebased onto the current `integration/pr-train` head. Co-authored with credit to the contributor.

### Included (additive only)
- `lib/connect/*` — candidates, ranking, visibility, service, types, use-connect-discovery, index
- `lib/one-location/kai-circle-*` — connect-bridge, ctas, sections + key-bootstrap
- 5 test suites (connect-candidates/ranking/service/visibility + kai-circle bridge)
- additive type/helper deps only: `OneLocationViewerCapabilities` & `KaiCircleCandidate`, `visibility_posture`/`exposure_enabled`/`email_lookups`, capacitor email support, marketplace contact-matching `...FromQuery` helper

### Deliberately EXCLUDED
The public-invite / `app/one/location/page.tsx` changes from #2443 that would have **reverted the public-location-snapshot feature shipped in #2724**. Those are not here — #2724 stays intact.

### Proof
- `tsc --noEmit` — clean
- `vitest run` on harvested suites — **46/46 pass**

Closes #2443 via harvest (the public-invite revert is intentionally dropped; the remaining unique value is fully captured here).