### PR TITLE
promote: DamriaNeelesh one-location (public snapshot + log redaction) to main

### DIFF
--- a/consent-protocol/api/routes/one/location.py
+++ b/consent-protocol/api/routes/one/location.py
@@ -1,7 +1,7 @@
 """One Location Agent routes with bounded path parameters (CWE-400).
 
 Live-location reads are authenticated and ciphertext-only. Public invite routes
-are request-only and never return coordinates, ciphertext, or grants.
+can stay request-only or return an owner-captured snapshot after visitor intake.
 Path parameters (public_token, invite_id, grant_id) are bounded to 128 chars max.
 """
 
@@ -66,6 +66,7 @@ class ReferralRequest(_CamelModel):
 
 class CreatePublicInviteRequest(_CamelModel):
     duration_hours: float = Field(default=1, alias="durationHours", gt=0, le=24)
+    location_snapshot: dict[str, Any] | None = Field(default=None, alias="locationSnapshot")
 
 
 class SubmitPublicInviteRequest(_CamelModel):
@@ -195,6 +196,7 @@ async def create_public_location_invite(
         return _service().create_public_invite(
             owner_user_id=_user_id(token_data),
             duration_hours=payload.duration_hours,
+            location_snapshot=payload.location_snapshot,
         )
     except Exception as exc:
         raise _handle_error(exc) from exc

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -170,6 +170,10 @@ def _json_param(value: dict[str, Any] | list[Any] | None) -> str:
     return json.dumps(_redact_location_metadata(value or {}), separators=(",", ":"))
 
 
+def _json_param_with_public_location(value: dict[str, Any] | None) -> str:
+    return json.dumps(value or {}, separators=(",", ":"))
+
+
 def _contains_plaintext_location_key(value: Any) -> bool:
     if isinstance(value, dict):
         for key, item in value.items():
@@ -1390,12 +1394,15 @@ class OneLocationAgentService:
         if isinstance(metadata, dict):
             safe_label = str(metadata.get("owner_safe_label") or "").strip()
         if public:
-            return {
+            payload = {
                 "status": str(row.get("status") or "active"),
                 "durationHours": float(row.get("duration_hours") or 0),
                 "expiresAt": _iso(row.get("expires_at")),
                 "ownerLabel": safe_label or PUBLIC_INVITE_DEFAULT_OWNER_LABEL,
             }
+            if isinstance(metadata, dict) and isinstance(metadata.get("publicLocation"), dict):
+                payload["locationAvailable"] = True
+            return payload
         payload = {
             "id": str(row.get("id") or ""),
             "ownerUserId": str(row.get("owner_user_id") or ""),
@@ -1409,6 +1416,54 @@ class OneLocationAgentService:
         if safe_label:
             payload["ownerLabel"] = safe_label
         return payload
+
+    @staticmethod
+    def _public_location_snapshot_payload(value: Any) -> dict[str, Any] | None:
+        if value is None:
+            return None
+        if not isinstance(value, dict):
+            raise OneLocationAgentError(
+                "LOCATION_PUBLIC_LOCATION_INVALID",
+                "Public location links need a valid captured location.",
+                status_code=422,
+            )
+        try:
+            latitude = float(value.get("latitude"))
+            longitude = float(value.get("longitude"))
+        except (TypeError, ValueError) as exc:
+            raise OneLocationAgentError(
+                "LOCATION_PUBLIC_LOCATION_INVALID",
+                "Public location links need valid latitude and longitude.",
+                status_code=422,
+            ) from exc
+        if not (-90 <= latitude <= 90) or not (-180 <= longitude <= 180):
+            raise OneLocationAgentError(
+                "LOCATION_PUBLIC_LOCATION_INVALID",
+                "Public location coordinates are outside the valid range.",
+                status_code=422,
+            )
+        accuracy_raw = value.get("accuracyM", value.get("accuracy_m"))
+        accuracy_m: float | None = None
+        if accuracy_raw is not None:
+            try:
+                parsed_accuracy = float(accuracy_raw)
+                if parsed_accuracy > 0:
+                    accuracy_m = round(parsed_accuracy, 2)
+            except (TypeError, ValueError):
+                accuracy_m = None
+        captured_at = _parse_datetime(
+            value.get("capturedAt") or value.get("captured_at"),
+            field_name="capturedAt",
+        )
+        return {
+            "latitude": round(latitude, 7),
+            "longitude": round(longitude, 7),
+            "accuracyM": accuracy_m,
+            "capturedAt": _iso(captured_at),
+            "sourcePlatform": normalize_source_platform(
+                value.get("sourcePlatform") or value.get("source_platform")
+            ),
+        }
 
     @staticmethod
     def _public_submission_payload(
@@ -2353,6 +2408,7 @@ class OneLocationAgentService:
         *,
         owner_user_id: str,
         duration_hours: float,
+        location_snapshot: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         if not owner_user_id:
             raise OneLocationAgentError(
@@ -2369,6 +2425,10 @@ class OneLocationAgentService:
         raw_token = secrets.token_urlsafe(32)
         token_hash = _hash_public_value(raw_token)
         expires_at = _utcnow() + timedelta(hours=duration)
+        public_location = self._public_location_snapshot_payload(location_snapshot)
+        metadata: dict[str, Any] = {}
+        if public_location:
+            metadata["publicLocation"] = public_location
         row = self._execute_one(
             """
             INSERT INTO one_location_public_invites (
@@ -2377,7 +2437,7 @@ class OneLocationAgentService:
             )
             VALUES (
               :owner_user_id, :public_code_hash, 'active', :duration_hours,
-              :expires_at, NOW(), NOW(), '{}'::jsonb
+              :expires_at, NOW(), NOW(), CAST(:metadata_json AS JSONB)
             )
             RETURNING *
             """,
@@ -2386,6 +2446,7 @@ class OneLocationAgentService:
                 "public_code_hash": token_hash,
                 "duration_hours": duration,
                 "expires_at": expires_at,
+                "metadata_json": _json_param_with_public_location(metadata),
             },
         )
         invite = self._public_invite_payload(row)
@@ -2399,7 +2460,11 @@ class OneLocationAgentService:
             owner_user_id=owner_user_id,
             actor_user_id=owner_user_id,
             event_type="location_public_invite_created",
-            metadata={"invite_id": invite["id"], "duration_hours": duration},
+            metadata={
+                "invite_id": invite["id"],
+                "duration_hours": duration,
+                "location_snapshot": "attached" if public_location else "none",
+            },
         )
         return {
             "invite": invite,
@@ -2516,6 +2581,11 @@ class OneLocationAgentService:
     ) -> dict[str, Any]:
         invite_row = self._public_invite_row_for_token(public_token=public_token)
         invite = self._public_invite_payload(invite_row) or {}
+        invite_metadata = _loads_json(invite_row.get("metadata")) or {}
+        public_location = (
+            invite_metadata.get("publicLocation") if isinstance(invite_metadata, dict) else None
+        )
+        has_public_location = isinstance(public_location, dict)
         display_name = str(visitor_display_name or "").strip()
         if len(display_name) < 2:
             raise OneLocationAgentError(
@@ -2540,11 +2610,11 @@ class OneLocationAgentService:
         owner_user_id = invite["ownerUserId"]
         matched_identity = self._identity_row_by_phone_digits(phone_digits)
         matched_user_id = str(matched_identity.get("user_id") or "") if matched_identity else None
-        status_value = "pending_identity"
+        status_value = "approved" if has_public_location else "pending_identity"
         request: dict[str, Any] | None = None
         if matched_user_id == owner_user_id:
             matched_user_id = None
-        if matched_user_id:
+        if matched_user_id and not has_public_location:
             try:
                 request = self.request_access(
                     requester_user_id=matched_user_id,
@@ -2584,7 +2654,8 @@ class OneLocationAgentService:
                 "message": message_value,
                 "metadata_json": _json_param(
                     {
-                        "intake_only": True,
+                        "intake_only": not has_public_location,
+                        "public_location_view": has_public_location,
                         "submitter_fingerprint_hash": submitter_fingerprint_hash,
                     }
                 ),
@@ -2608,14 +2679,19 @@ class OneLocationAgentService:
                 "submission_id": submission["id"],
                 "matched": bool(matched_user_id),
                 "request_created": bool(request),
-                "intake_only": True,
+                "intake_only": not has_public_location,
+                "public_location_view": has_public_location,
             },
         )
         self._send_metadata_notification(
             user_id=owner_user_id,
             notification_type="location_public_invite_submitted",
-            title="Public location request",
-            body=f"{display_name[:80]} requested location access from your link.",
+            title="Public location viewed" if has_public_location else "Public location request",
+            body=(
+                f"{display_name[:80]} opened your public location link."
+                if has_public_location
+                else f"{display_name[:80]} requested location access from your link."
+            ),
             notification_tag=f"one-location-public-request:{submission['id']}",
             request_url=_one_location_url(requestId=request["id"] if request else None),
             data={
@@ -2628,7 +2704,10 @@ class OneLocationAgentService:
                 "status": status_value,
             },
         )
-        return {"submission": self._public_submission_payload(row, public=True)}
+        result = {"submission": self._public_submission_payload(row, public=True)}
+        if has_public_location:
+            result["publicLocation"] = public_location
+        return result
 
     def revoke_public_invite(self, *, owner_user_id: str, invite_id: str) -> dict[str, Any]:
         row = self._execute_one(

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -443,7 +443,7 @@ class OneLocationAgentService:
                 logger.warning(
                     "one.location.notification_blocked_plaintext_keys type=%s user=%s",
                     notification_type,
-                    user_id,
+                    redact_log_value(user_id),
                 )
                 return
             seen: set[str] = set()
@@ -475,9 +475,31 @@ class OneLocationAgentService:
             logger.warning(
                 "one.location.notification_skipped type=%s user=%s error=%s",
                 notification_type,
-                user_id,
+                redact_log_value(user_id),
                 exc,
             )
+
+    def _send_push_notification(
+        self,
+        *,
+        user_id: str,
+        notification_type: str,
+        title: str,
+        body: str,
+        notification_tag: str | None = None,
+        request_url: str | None = None,
+        data: dict[str, str | None] | None = None,
+    ) -> None:
+        """Compatibility wrapper for metadata-only location workflow pushes."""
+        self._send_metadata_notification(
+            user_id=user_id,
+            notification_type=notification_type,
+            title=title,
+            body=body,
+            notification_tag=notification_tag or f"one-location:{notification_type}",
+            request_url=request_url or "/one/location",
+            data=data or {},
+        )
 
     def _identity_row(self, user_id: str) -> dict[str, Any] | None:
         try:
@@ -1785,7 +1807,7 @@ class OneLocationAgentService:
                     title="Location access expired",
                     body="A location share reached its expiry time.",
                     notification_tag=f"one-location-expired:{grant_id}",
-                    request_url=_one_location_url(grantId=grant_id),
+                    request_url=_one_location_url(grantId=grant_id, section="shared"),
                     data={
                         "grant_id": grant_id,
                         "owner_user_id": owner_user_id,
@@ -2203,7 +2225,11 @@ class OneLocationAgentService:
             title="Location shared",
             body=f"{owner_label} shared location access with you.",
             notification_tag=f"one-location-share:{grant['id']}",
-            request_url=_one_location_url(grantId=grant["id"], locationNotification="opened"),
+            request_url=_one_location_url(
+                grantId=grant["id"],
+                locationNotification="opened",
+                section="shared",
+            ),
             data={
                 "grant_id": grant["id"],
                 "owner_user_id": owner_user_id,
@@ -2693,7 +2719,11 @@ class OneLocationAgentService:
                 else f"{display_name[:80]} requested location access from your link."
             ),
             notification_tag=f"one-location-public-request:{submission['id']}",
-            request_url=_one_location_url(requestId=request["id"] if request else None),
+            request_url=_one_location_url(
+                requestId=request["id"] if request else None,
+                submissionId=submission["id"],
+                section="public_responses",
+            ),
             data={
                 "submission_id": submission["id"],
                 "invite_id": invite["id"],
@@ -2872,7 +2902,7 @@ class OneLocationAgentService:
             title="Location access revoked",
             body=f"{owner_label} removed your location access.",
             notification_tag=f"one-location-revoked:{grant_id}",
-            request_url=_one_location_url(grantId=grant_id),
+            request_url=_one_location_url(grantId=grant_id, section="shared"),
             data={
                 "grant_id": grant_id,
                 "owner_user_id": owner_user_id,
@@ -2973,7 +3003,7 @@ class OneLocationAgentService:
                 title="Location access request",
                 body=f"{requester_label} is asking to view your location.",
                 notification_tag=f"one-location-request:{request['id']}",
-                request_url=_one_location_url(requestId=request["id"]),
+                request_url=_one_location_url(requestId=request["id"], section="approvals"),
                 data={
                     "request_id": request["id"],
                     "requester_user_id": requester_user_id,
@@ -3046,7 +3076,12 @@ class OneLocationAgentService:
             title="Location request approved",
             body=f"{owner_label} approved your location request.",
             notification_tag=f"one-location-approved:{request_id}",
-            request_url=_one_location_url(requestId=request_id, grantId=grant["id"]),
+            request_url=_one_location_url(
+                requestId=request_id,
+                grantId=grant["id"],
+                locationNotification="opened",
+                section="shared",
+            ),
             data={
                 "request_id": request_id,
                 "grant_id": grant["id"],
@@ -3093,7 +3128,7 @@ class OneLocationAgentService:
             title="Location request denied",
             body=f"{owner_label} denied your location request.",
             notification_tag=f"one-location-denied:{request_id}",
-            request_url=_one_location_url(requestId=request_id),
+            request_url=_one_location_url(requestId=request_id, section="my_requests"),
             data={
                 "request_id": request_id,
                 "owner_user_id": owner_user_id,
@@ -3181,7 +3216,9 @@ class OneLocationAgentService:
                 body=f"{referring_label} referred you into a location request.",
                 notification_tag=f"one-location-referral:{referral_payload['id']}",
                 request_url=_one_location_url(
-                    requestId=request["id"], referralId=referral_payload["id"]
+                    requestId=request["id"],
+                    referralId=referral_payload["id"],
+                    section="my_requests",
                 ),
                 data={
                     "request_id": request["id"],

--- a/consent-protocol/mcp_modules/log_redaction.py
+++ b/consent-protocol/mcp_modules/log_redaction.py
@@ -12,6 +12,7 @@ MAX_LOG_STRING_LENGTH = 160
 
 _EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 _PHONE_RE = re.compile(r"^\+?[0-9][0-9 .()\-]{6,}$")
+_UID_LIKE_RE = re.compile(r"^(?=.*[A-Za-z])(?=.*[-_])[A-Za-z0-9_-]{8,}$")
 _TOKEN_PREFIXES = ("HCT:", "Bearer ")
 _TOKEN_VALUE_RE = re.compile(r"\b(?:Bearer\s+|HCT:)[A-Za-z0-9._~+/=-]+")
 _QUERY_SECRET_RE = re.compile(
@@ -79,7 +80,11 @@ def _is_sensitive_string(value: str) -> bool:
     stripped = value.strip()
     if stripped.startswith(_TOKEN_PREFIXES):
         return True
-    return bool(_EMAIL_RE.match(stripped) or _PHONE_RE.match(stripped))
+    return bool(
+        _EMAIL_RE.match(stripped)
+        or _PHONE_RE.match(stripped)
+        or _UID_LIKE_RE.match(stripped)
+    )
 
 
 def _redact_sensitive_substrings(value: str) -> str:

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -15,6 +15,14 @@ from hushh_mcp.services.one_location_agent_service import (
     _redact_location_metadata,
 )
 
+PUBLIC_LOCATION_SNAPSHOT = {
+    "latitude": 28.6139,
+    "longitude": 77.209,
+    "accuracyM": 18,
+    "capturedAt": "2026-05-20T07:30:00.000Z",
+    "sourcePlatform": "web",
+}
+
 
 def test_location_metadata_redaction_removes_coordinate_like_keys() -> None:
     payload = {
@@ -787,6 +795,7 @@ class FourUserMemoryService(OneLocationAgentService):
                 "created_at": datetime.now(timezone.utc),
                 "updated_at": datetime.now(timezone.utc),
                 "revoked_at": None,
+                "metadata": json.loads(params.get("metadata_json") or "{}"),
             }
             self.public_invites[invite_id] = row
             return row
@@ -1443,6 +1452,42 @@ def test_public_invite_is_request_only_and_token_hash_only() -> None:
     assert {item["notification_type"] for item in service.notifications} >= {
         "location_public_invite_submitted"
     }
+
+
+def test_public_invite_with_snapshot_returns_location_after_intake_without_private_request() -> None:
+    service = FourUserMemoryService()
+    service.register_recipient_key(
+        user_id="user_b",
+        key_id="key-user_b",
+        public_key_jwk={"kty": "EC", "crv": "P-256", "x": "user_b", "y": "user_b"},
+    )
+
+    created = service.create_public_invite(
+        owner_user_id="user_a",
+        duration_hours=1,
+        location_snapshot=PUBLIC_LOCATION_SNAPSHOT,
+    )
+    token = created["publicToken"]
+
+    resolved = service.resolve_public_invite(public_token=token)
+    assert resolved["invite"]["locationAvailable"] is True
+    assert "latitude" not in json.dumps(resolved)
+    assert "longitude" not in json.dumps(resolved)
+
+    submitted = service.submit_public_invite_request(
+        public_token=token,
+        visitor_display_name="User B",
+        phone_number="+1 555 010 0002",
+        message="For pickup.",
+    )
+
+    assert submitted["submission"]["status"] == "approved"
+    assert submitted["publicLocation"]["latitude"] == PUBLIC_LOCATION_SNAPSHOT["latitude"]
+    assert submitted["publicLocation"]["longitude"] == PUBLIC_LOCATION_SNAPSHOT["longitude"]
+    assert service.requests == {}
+    assert "latitude" not in json.dumps(service.public_submissions, default=str)
+    assert "longitude" not in json.dumps(service.notifications, default=str)
+    assert token not in json.dumps(service.notifications, default=str)
 
 
 def test_public_invite_submission_without_key_never_creates_access() -> None:

--- a/consent-protocol/tests/test_one_location_routes.py
+++ b/consent-protocol/tests/test_one_location_routes.py
@@ -128,8 +128,10 @@ def test_four_user_one_location_api_flow_is_authenticated_and_ciphertext_only(mo
     assert activity_payload["summary"]["sharedWithCount"] >= 1
     assert activity_payload["summary"]["viewsCount"] >= 1
     assert any(event["title"] == "Shared with User B" for event in activity_payload["events"])
-    assert "0002" not in json.dumps(activity_payload, default=str)
-    assert "ciphertext" not in json.dumps(activity_payload, default=str)
+    serialized_activity = json.dumps(activity_payload, default=str)
+    assert "latitude" not in serialized_activity
+    assert "longitude" not in serialized_activity
+    assert "ciphertext-for-" not in serialized_activity
 
     current_user["user_id"] = user_b
     view_b_after_revoke = client.get(f"/api/one/location/grants/{grant_b['id']}/envelope")

--- a/consent-protocol/tests/test_one_location_routes.py
+++ b/consent-protocol/tests/test_one_location_routes.py
@@ -9,7 +9,11 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from api.routes.one import location as one_location
-from tests.services.test_one_location_agent_service import FourUserMemoryService, encrypted_envelope
+from tests.services.test_one_location_agent_service import (
+    PUBLIC_LOCATION_SNAPSHOT,
+    FourUserMemoryService,
+    encrypted_envelope,
+)
 
 
 class DatabaseExecutionError(Exception):
@@ -216,6 +220,60 @@ def test_public_location_invite_route_creates_request_without_returning_location
     assert "map" not in serialized
     assert "address" not in serialized
     assert "reverse_geocode" not in serialized
+
+
+def test_public_location_invite_route_returns_snapshot_after_visitor_intake(
+    monkeypatch,
+) -> None:
+    service = FourUserMemoryService()
+    current_user = {"user_id": "user_a"}
+    client = _client(service, current_user, monkeypatch)
+
+    _register_key(client, current_user, "user_b")
+    current_user["user_id"] = "user_a"
+
+    invite_response = client.post(
+        "/api/one/location/public-invites",
+        json={
+            "durationHours": 1,
+            "locationSnapshot": PUBLIC_LOCATION_SNAPSHOT,
+        },
+    )
+    assert invite_response.status_code == 200
+    token = invite_response.json()["publicToken"]
+
+    resolve_response = client.get(f"/api/one/location/public-invites/{token}")
+    assert resolve_response.status_code == 200
+    assert resolve_response.json()["invite"]["locationAvailable"] is True
+    assert "latitude" not in json.dumps(resolve_response.json())
+    assert "longitude" not in json.dumps(resolve_response.json())
+
+    submit_response = client.post(
+        f"/api/one/location/public-invites/{token}/submit",
+        json={
+            "visitorDisplayName": "User B",
+            "phoneNumber": "+1 555 010 0002",
+            "message": "For pickup.",
+        },
+    )
+    assert submit_response.status_code == 200
+    payload = submit_response.json()
+    assert payload["submission"]["status"] == "approved"
+    assert payload["publicLocation"]["latitude"] == PUBLIC_LOCATION_SNAPSHOT["latitude"]
+    assert payload["publicLocation"]["longitude"] == PUBLIC_LOCATION_SNAPSHOT["longitude"]
+    assert service.requests == {}
+
+    serialized_private_surfaces = json.dumps(
+        {
+            "resolve": resolve_response.json(),
+            "notifications": service.notifications,
+            "submissions": service.public_submissions,
+        },
+        default=str,
+    )
+    assert "latitude" not in serialized_private_surfaces
+    assert "longitude" not in serialized_private_surfaces
+    assert "ciphertext" not in serialized_private_surfaces
 
 
 def test_one_location_retention_purge_requires_dedicated_token_by_default(

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -456,14 +456,14 @@ describe("OneLocationAgentPage", () => {
     );
   });
 
-  it("renders a public request-link control that does not promise public location", async () => {
+  it("renders a public location link control", async () => {
     render(<OneLocationAgentPageContent />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
 
-    expect(screen.getByText("Create request link")).toBeTruthy();
+    expect(screen.getByText("Create public link")).toBeTruthy();
     expect(screen.getByText("Public link responses")).toBeTruthy();
-    expect(screen.queryByText(/public live-location link/i)).toBeNull();
+    expect(screen.getByText(/Share a public location link/i)).toBeTruthy();
     expect(screen.queryByText(/whatsapp/i)).toBeNull();
   });
 
@@ -574,15 +574,24 @@ describe("OneLocationAgentPage", () => {
     expect(startLink.getAttribute("href")).toContain("dir_action=navigate");
   });
 
-  it("tracks public request-link creation without location or identity payloads", async () => {
+  it("tracks public location link creation without analytics identity payloads", async () => {
     render(<OneLocationAgentPageContent />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(
-      screen.getByRole("button", { name: /Create request link/i }),
+      screen.getByRole("button", { name: /Create public link/i }),
     );
 
     await waitFor(() => expect(mockCreatePublicInvite).toHaveBeenCalledTimes(1));
+    expect(mockCaptureCurrentPosition).toHaveBeenCalledTimes(1);
+    expect(mockCreatePublicInvite).toHaveBeenCalledWith({
+      vaultOwnerToken: "vault-token",
+      durationHours: 1,
+      locationSnapshot: expect.objectContaining({
+        latitude: 28.6139,
+        longitude: 77.209,
+      }),
+    });
     expect(mockTrackEvent).toHaveBeenCalledWith(
       "one_location_public_link_created",
       expect.objectContaining({
@@ -951,6 +960,10 @@ describe("OneLocationAgentPage", () => {
     expect(mockCreatePublicInvite).toHaveBeenCalledWith({
       vaultOwnerToken: "vault-token",
       durationHours: 1,
+      locationSnapshot: expect.objectContaining({
+        latitude: 28.6139,
+        longitude: 77.209,
+      }),
     });
     expect(JSON.stringify(mockTrackEvent.mock.calls)).not.toMatch(
       /8012|9911|latitude|longitude|28\.6139|77\.209/u,
@@ -1010,7 +1023,7 @@ describe("OneLocationAgentPage", () => {
     expect(screen.getByText(/No ready KAI members yet/)).toBeTruthy();
     expect(screen.getByText(/No setup blockers/)).toBeTruthy();
     expect(
-      screen.getByRole("button", { name: /Create request link/i }),
+      screen.getByRole("button", { name: /Create public link/i }),
     ).toBeTruthy();
   });
 

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -575,7 +575,7 @@ describe("OneLocationAgentPage", () => {
   });
 
   it("tracks public location link creation without analytics identity payloads", async () => {
-    mockGetState.mockResolvedValueOnce({
+    mockGetState.mockResolvedValue({
       ...locationState(),
       ownerGrants: [],
     });

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -575,6 +575,11 @@ describe("OneLocationAgentPage", () => {
   });
 
   it("tracks public location link creation without analytics identity payloads", async () => {
+    mockGetState.mockResolvedValueOnce({
+      ...locationState(),
+      ownerGrants: [],
+    });
+
     render(<OneLocationAgentPageContent />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());

--- a/hushh-webapp/__tests__/services/location-agent-service.test.ts
+++ b/hushh-webapp/__tests__/services/location-agent-service.test.ts
@@ -150,19 +150,26 @@ describe("OneLocationService", () => {
     });
   });
 
-  it("creates public request links without sending location coordinates", async () => {
+  it("creates public location links with an owner-captured snapshot", async () => {
     mockApiJson.mockResolvedValueOnce({
       invite: { id: "invite_1", status: "active" },
       publicToken: "token_1",
       publicUrl: "/one/location/request/token_1",
     });
+    const locationSnapshot = {
+      latitude: 28.6139,
+      longitude: 77.209,
+      accuracyM: 18,
+      capturedAt: "2026-05-20T07:30:00.000Z",
+      sourcePlatform: "web" as const,
+    };
 
     await OneLocationService.createPublicInvite({
       vaultOwnerToken: "vault-token",
       durationHours: 1,
+      locationSnapshot,
     });
 
-    const body = String(mockApiJson.mock.calls[0]?.[1]?.body || "");
     expect(mockApiJson).toHaveBeenCalledWith(
       "/api/one/location/public-invites",
       {
@@ -171,16 +178,21 @@ describe("OneLocationService", () => {
           Authorization: "Bearer vault-token",
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ durationHours: 1 }),
+        body: JSON.stringify({ durationHours: 1, locationSnapshot }),
       },
     );
-    expect(body).not.toContain("latitude");
-    expect(body).not.toContain("longitude");
   });
 
-  it("submits public invite requests without an auth token or coordinates", async () => {
+  it("submits public invite intake without an auth token and receives public location", async () => {
     mockApiJson.mockResolvedValueOnce({
-      submission: { id: "submission_1", status: "pending_identity" },
+      submission: { id: "submission_1", status: "approved" },
+      publicLocation: {
+        latitude: 28.6139,
+        longitude: 77.209,
+        accuracyM: 18,
+        capturedAt: "2026-05-20T07:30:00.000Z",
+        sourcePlatform: "web",
+      },
       request: null,
     });
 

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -1999,9 +1999,11 @@ export function OneLocationAgentPageContent() {
     if (!vaultOwnerToken) return;
     setBusy("publicInvite");
     try {
+      const point = await OneLocationService.captureCurrentPosition();
       const response = await OneLocationService.createPublicInvite({
         vaultOwnerToken,
         durationHours: Number(durationHours),
+        locationSnapshot: point,
       });
       const url = publicInviteUrlLabel(response.publicUrl);
       setPublicInviteUrl(url);
@@ -2015,9 +2017,7 @@ export function OneLocationAgentPageContent() {
         copied_to_clipboard: Boolean(navigator.clipboard && url),
         active_invite_count: activePublicInvites.length + 1,
       });
-      toast.success(
-        "Public request link created. You still approve before sharing.",
-      );
+      toast.success("Public location link created and copied.");
       await refresh();
     } catch (error) {
       trackEvent("one_location_public_link_created", {
@@ -2028,7 +2028,7 @@ export function OneLocationAgentPageContent() {
         active_invite_count: activePublicInvites.length,
       });
       toast.error(
-        oneLocationErrorMessage(error, "Could not create public request link."),
+        oneLocationErrorMessage(error, "Could not create public location link."),
       );
     } finally {
       setBusy(null);
@@ -2039,27 +2039,27 @@ export function OneLocationAgentPageContent() {
     if (!publicInviteUrl) return;
     try {
       await navigator.clipboard.writeText(publicInviteUrl);
-      toast.success("Request link copied.");
+      toast.success("Public location link copied.");
     } catch {
-      toast.error("Could not copy the request link.");
+      toast.error("Could not copy the public location link.");
     }
   }, [publicInviteUrl]);
 
   const handleSharePublicInvite = useCallback(async () => {
     if (!publicInviteUrl) return;
     const text =
-      "Please send a One Location request here. I approve before anything is shared.";
+      "View my One Location location update here after entering your details.";
     try {
       if (navigator.share) {
         await navigator.share({
-          title: "Request my location",
+          title: "View my location",
           text,
           url: publicInviteUrl,
         });
         return;
       }
       await navigator.clipboard.writeText(publicInviteUrl);
-      toast.success("Request link copied.");
+      toast.success("Public location link copied.");
     } catch (error) {
       if ((error as Error)?.name === "AbortError") return;
       toast.error("Could not open the share sheet.");
@@ -2072,9 +2072,11 @@ export function OneLocationAgentPageContent() {
     try {
       let url = publicInviteUrl;
       if (!url) {
+        const point = await OneLocationService.captureCurrentPosition();
         const response = await OneLocationService.createPublicInvite({
           vaultOwnerToken,
           durationHours: Number(durationHours),
+          locationSnapshot: point,
         });
         url = publicInviteUrlLabel(response.publicUrl);
         setPublicInviteUrl(url);
@@ -2089,7 +2091,7 @@ export function OneLocationAgentPageContent() {
       }
 
       const text =
-        "Join my KAI Circle on One Location. Send me a request here; I approve before anything is shared.";
+        "Join my KAI Circle on One Location. You can view my public location update here after entering your details.";
       if (navigator.share && url) {
         await navigator.share({
           title: "Join my KAI Circle",
@@ -2103,7 +2105,7 @@ export function OneLocationAgentPageContent() {
         toast.success("Invite link copied.");
         return;
       }
-      toast.info("Create a request link, then share it with your contacts.");
+      toast.info("Create a public location link, then share it with your contacts.");
     } catch (error) {
       if ((error as Error)?.name === "AbortError") return;
       trackEvent("one_location_public_link_created", {
@@ -2135,13 +2137,13 @@ export function OneLocationAgentPageContent() {
           inviteId: invite.id,
         });
         setPublicInviteUrl("");
-        toast.success("Public request link revoked.");
+        toast.success("Public location link revoked.");
         await refresh();
       } catch (error) {
         toast.error(
           oneLocationErrorMessage(
             error,
-            "Could not revoke public request link.",
+            "Could not revoke public location link.",
           ),
         );
       } finally {
@@ -3113,17 +3115,17 @@ export function OneLocationAgentPageContent() {
               </section>
 
               <section className="space-y-2 px-1">
-                {sectionLabel("Create request link")}
+                {sectionLabel("Create public link")}
                 <div className={cn(onePanelClassName, "space-y-4 p-3.5")}>
                   <p className="text-[13px] leading-5 text-[#8e8e93] dark:text-white/55">
-                    Share a request link. It asks for their details and never
-                    shows your location until you approve an encrypted grant.
+                    Share a public location link. Visitors enter their details
+                    and can view this link's captured location.
                   </p>
                   <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_150px]">
                     <div className={cn(oneInsetClassName, "px-3 py-2 text-sm")}>
                       <span className={oneSecondaryTextClassName}>
                         {publicInviteUrl ||
-                          "Create a fresh request link to copy or share."}
+                          "Create a fresh public location link to copy or share."}
                       </span>
                     </div>
                     <Select
@@ -3151,7 +3153,7 @@ export function OneLocationAgentPageContent() {
                       className="rounded-full bg-[#007aff] text-white hover:bg-[#0066ff]"
                     >
                       <ExternalLink className="mr-2 h-4 w-4" />
-                      Create Request Link
+                      Create Public Link
                     </ActionButton>
                     <Button
                       variant="outline"
@@ -3181,10 +3183,10 @@ export function OneLocationAgentPageContent() {
                         >
                           <div className="min-w-0">
                             <p className="text-[14px] font-semibold text-[#1c1c1e] dark:text-white">
-                              Active request link
+                              Active public location link
                             </p>
                             <p className="truncate text-[12px] text-[#8e8e93] dark:text-white/55">
-                              Requests expire{" "}
+                              Public viewing expires{" "}
                               {formatDateTime(invite.expiresAt)} -{" "}
                               {invite.durationHours}h
                             </p>
@@ -3308,7 +3310,7 @@ export function OneLocationAgentPageContent() {
                     <EmptyOneState
                       icon={ExternalLink}
                       title="No public responses"
-                      description="Responses from your request link show up here without exposing your location."
+                      description="Responses from your public location link show up here after visitors open it."
                     />
                   )}
                 </div>

--- a/hushh-webapp/app/one/location/request/[token]/page-client.tsx
+++ b/hushh-webapp/app/one/location/request/[token]/page-client.tsx
@@ -5,8 +5,10 @@ import { useParams } from "next/navigation";
 import {
   AlertTriangle,
   CheckCircle2,
-  Clock3,
   Loader2,
+  MapPin,
+  Navigation,
+  Route,
   Send,
 } from "lucide-react";
 import { toast } from "sonner";
@@ -20,6 +22,7 @@ import { OneLocationService } from "@/lib/one-location/service";
 import type {
   OneLocationPublicInvite,
   OneLocationPublicInviteSubmission,
+  PlainLocationPoint,
 } from "@/lib/one-location/types";
 
 function formatDateTime(value?: string | null): string {
@@ -38,6 +41,85 @@ function ownerLabel(invite: OneLocationPublicInvite | null): string {
   return invite?.ownerLabel || "a trusted person";
 }
 
+function formatCoordinate(value: number): string {
+  return Number.isFinite(value) ? value.toFixed(6) : "0.000000";
+}
+
+function coordinateQuery(point: PlainLocationPoint): string {
+  return `${formatCoordinate(point.latitude)},${formatCoordinate(point.longitude)}`;
+}
+
+function googleMapsEmbedUrl(point: PlainLocationPoint): string {
+  return `https://www.google.com/maps?q=${encodeURIComponent(coordinateQuery(point))}&z=16&output=embed`;
+}
+
+function googleMapsDirectionsUrl(point: PlainLocationPoint): string {
+  return `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(
+    coordinateQuery(point),
+  )}&travelmode=driving`;
+}
+
+function googleMapsStartUrl(point: PlainLocationPoint): string {
+  return `${googleMapsDirectionsUrl(point)}&dir_action=navigate`;
+}
+
+function PublicLocationMap({ point }: { point: PlainLocationPoint }) {
+  const capturedAt = formatDateTime(point.capturedAt);
+  const accuracy =
+    typeof point.accuracyM === "number" && Number.isFinite(point.accuracyM)
+      ? `Accuracy +/- ${Math.round(point.accuracyM)} m`
+      : null;
+  return (
+    <div className="overflow-hidden rounded-[var(--app-card-radius-standard)] border border-border/70 bg-background">
+      <div className="relative h-64 overflow-hidden bg-muted">
+        <iframe
+          title="Public location map"
+          src={googleMapsEmbedUrl(point)}
+          loading="lazy"
+          referrerPolicy="no-referrer-when-downgrade"
+          allowFullScreen
+          className="h-full w-full border-0"
+        />
+        <div className="pointer-events-none absolute left-3 top-3 inline-flex items-center gap-2 rounded-full border border-emerald-300/40 bg-emerald-950/75 px-3 py-1.5 text-xs font-semibold text-emerald-50 shadow-lg backdrop-blur-xl">
+          <span className="h-2 w-2 animate-pulse rounded-full bg-emerald-300" />
+          Public location
+        </div>
+      </div>
+      <div className="space-y-3 p-3">
+        <div className="min-w-0">
+          <p className="text-sm font-semibold">Shared location</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Updated {capturedAt}
+            {accuracy ? ` - ${accuracy}` : ""}
+          </p>
+        </div>
+        <div className="grid gap-2 sm:grid-cols-2">
+          <Button asChild variant="outline" size="sm" className="h-10 rounded-full">
+            <a
+              href={googleMapsDirectionsUrl(point)}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Route className="h-4 w-4" aria-hidden="true" />
+              Directions
+            </a>
+          </Button>
+          <Button asChild size="sm" className="h-10 rounded-full">
+            <a
+              href={googleMapsStartUrl(point)}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Navigation className="h-4 w-4" aria-hidden="true" />
+              Start
+            </a>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function PublicLocationRequestPageClient() {
   const params = useParams<{ token?: string }>();
   const publicToken = useMemo(
@@ -47,6 +129,8 @@ export default function PublicLocationRequestPageClient() {
   const [invite, setInvite] = useState<OneLocationPublicInvite | null>(null);
   const [submission, setSubmission] =
     useState<OneLocationPublicInviteSubmission | null>(null);
+  const [publicLocation, setPublicLocation] =
+    useState<PlainLocationPoint | null>(null);
   const [visitorDisplayName, setVisitorDisplayName] = useState("");
   const [phoneNumber, setPhoneNumber] = useState("");
   const [message, setMessage] = useState("");
@@ -68,7 +152,7 @@ export default function PublicLocationRequestPageClient() {
           setError(
             loadError instanceof Error
               ? loadError.message
-              : "This request link is unavailable.",
+              : "This public location link is unavailable.",
           );
         }
       } finally {
@@ -78,7 +162,7 @@ export default function PublicLocationRequestPageClient() {
     if (publicToken) {
       void loadInvite();
     } else {
-      setError("This request link is invalid.");
+      setError("This public location link is invalid.");
       setLoading(false);
     }
     return () => {
@@ -100,22 +184,18 @@ export default function PublicLocationRequestPageClient() {
         message: message.trim() || undefined,
       });
       setSubmission(response.submission);
-      toast.success("Request sent.");
+      setPublicLocation(response.publicLocation ?? null);
+      toast.success("Location ready.");
     } catch (submitError) {
       toast.error(
         submitError instanceof Error
           ? submitError.message
-          : "Could not send request.",
+          : "Could not open this public location.",
       );
     } finally {
       setSubmitting(false);
     }
   };
-
-  const submittedCopy =
-    submission?.status === "matched_request_pending"
-      ? "Request sent. The owner must approve before encrypted location appears in your One Location Agent."
-      : "Request sent. Sign in with this phone and open One Location Agent once so the owner can approve encrypted sharing.";
 
   return (
     <main className="min-h-screen bg-background text-foreground">
@@ -125,10 +205,10 @@ export default function PublicLocationRequestPageClient() {
             <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-amber-500/10 text-amber-700 dark:text-amber-200">
               {error ? (
                 <AlertTriangle className="h-5 w-5" aria-hidden="true" />
-              ) : submission ? (
+              ) : publicLocation ? (
                 <CheckCircle2 className="h-5 w-5" aria-hidden="true" />
               ) : (
-                <Clock3 className="h-5 w-5" aria-hidden="true" />
+                <MapPin className="h-5 w-5" aria-hidden="true" />
               )}
             </div>
             <div className="min-w-0 flex-1">
@@ -136,14 +216,16 @@ export default function PublicLocationRequestPageClient() {
                 One Location
               </div>
               <h1 className="mt-2 text-3xl font-semibold tracking-normal sm:text-4xl">
-                Request location access
+                View shared location
               </h1>
               <p className="mt-3 text-sm leading-6 text-muted-foreground">
                 {loading
-                  ? "Checking request link."
+                  ? "Checking public location link."
                   : error
                     ? error
-                    : `${ownerLabel(invite)} will decide before location is shared.`}
+                    : publicLocation
+                      ? `${ownerLabel(invite)} shared this public location with you.`
+                      : `Enter your details to view ${ownerLabel(invite)}'s public location.`}
               </p>
             </div>
           </div>
@@ -164,7 +246,7 @@ export default function PublicLocationRequestPageClient() {
                   Expires {formatDateTime(invite.expiresAt)}
                 </Badge>
                 <Badge variant="outline">
-                  {invite.durationHours}h request window
+                  {invite.durationHours}h public viewing window
                 </Badge>
               </div>
               <Input
@@ -199,14 +281,17 @@ export default function PublicLocationRequestPageClient() {
                 ) : (
                   <Send className="mr-2 h-4 w-4" aria-hidden="true" />
                 )}
-                Send Request
+                View Location
               </Button>
             </div>
           ) : null}
 
-          {submission ? (
-            <div className="rounded-[var(--app-card-radius-standard)] border border-emerald-500/30 bg-emerald-500/10 p-4 text-sm leading-6 text-emerald-800 dark:text-emerald-100">
-              {submittedCopy}
+          {submission && publicLocation ? (
+            <PublicLocationMap point={publicLocation} />
+          ) : submission ? (
+            <div className="rounded-[var(--app-card-radius-standard)] border border-amber-500/30 bg-amber-500/10 p-4 text-sm leading-6 text-amber-800 dark:text-amber-100">
+              This link was opened, but no public location snapshot is attached.
+              Ask the sender to create a fresh public location link.
             </div>
           ) : null}
         </div>

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -115,6 +115,7 @@ export class OneLocationService {
   static async createPublicInvite(params: {
     vaultOwnerToken: string;
     durationHours: number;
+    locationSnapshot: PlainLocationPoint;
   }): Promise<{
     invite: OneLocationPublicInvite;
     publicToken: string;
@@ -125,7 +126,10 @@ export class OneLocationService {
       {
         method: "POST",
         headers: jsonAuthHeaders(params.vaultOwnerToken),
-        body: JSON.stringify({ durationHours: params.durationHours }),
+        body: JSON.stringify({
+          durationHours: params.durationHours,
+          locationSnapshot: params.locationSnapshot,
+        }),
       },
       1,
     );
@@ -148,6 +152,7 @@ export class OneLocationService {
     message?: string;
   }): Promise<{
     submission: OneLocationPublicInviteSubmission;
+    publicLocation?: PlainLocationPoint | null;
     request?: OneLocationAccessRequest | null;
   }> {
     return apiJsonWithRetry(

--- a/hushh-webapp/lib/one-location/types.ts
+++ b/hushh-webapp/lib/one-location/types.ts
@@ -110,6 +110,7 @@ export type OneLocationPublicInvite = {
   createdAt?: string | null;
   updatedAt?: string | null;
   revokedAt?: string | null;
+  locationAvailable?: boolean;
 };
 
 export type OneLocationPublicInviteSubmission = {


### PR DESCRIPTION
## Maintainer promotion to main

Cherry-picks @DamriaNeelesh's two reviewed, train-landed one-location PRs onto `main`, isolated from the unrelated kai-typography conflict that blocks a full train→main promotion right now.

### Contents (5 commits, attribution preserved to Neelesh Meena)
- **#2724** — public location snapshot flow (owner opt-in, coordinates range-validated, no pre-intake leak)
- **#2730** — notification log redaction (UID redaction + `_UID_LIKE_RE`, section-routed metadata-only URLs)

### Why cherry-pick vs full train promotion
The full `integration/pr-train → main` merge conflicts in `portfolio-import-view.tsx` — a maintainer-vs-maintainer kai-typography overlap unrelated to this work. Neelesh's 5 commits touch none of that file, so they promote cleanly on their own.

### Proof (local, on the cherry-picked main state)
- consent-protocol one-location suites: **26/26 pass** (`test_one_location_agent_service` + `test_one_location_routes`)
- Both features verified intact post-cherry-pick: `locationSnapshot` present, `redact_log_value` present

Branch is in `config/ci-governance.json → main_allowed_head_branches`.