### PR TITLE
fix(server): retain strong reference to consent-listener startup task

### DIFF
--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -19,3 +19,4 @@ tests/test_stream_path_query_bounds_cwe400.py
 tests/performance/test_market_cache_instrumentation.py
 tests/test_llm_operon_stream_error_leak.py
 tests/test_stream_agent_thinking_gemini_error_cwe209.py
+tests/test_server_consent_listener_task_ref.py

--- a/consent-protocol/server.py
+++ b/consent-protocol/server.py
@@ -6,6 +6,7 @@ Modular architecture with routes organized in api/routes/ directory.
 Run with: uvicorn server:app --reload --port 8000
 """
 
+import asyncio
 import logging
 import os
 import time
@@ -22,6 +23,11 @@ logging.basicConfig(level=logging.INFO)
 install_sensitive_log_filter()
 logger = logging.getLogger(__name__)
 _APP_RUNTIME_SETTINGS = get_app_runtime_settings()
+
+# Strong reference for background startup tasks. asyncio only holds a weak
+# reference to tasks created via create_task; without this, the consent
+# listener task can be garbage collected mid-run before it ever raises.
+_background_startup_tasks: set[asyncio.Task] = set()
 
 
 def _env_truthy(name: str, fallback: str = "false") -> bool:
@@ -426,11 +432,11 @@ async def startup_pool_and_iam_cache() -> None:
 @app.on_event("startup")
 async def startup_consent_listener():
     """Start background task that LISTENs to consent_audit_new (NOTIFY)."""
-    import asyncio
-
     from api.consent_listener import run_consent_listener
 
-    asyncio.create_task(run_consent_listener())
+    task = asyncio.create_task(run_consent_listener(), name="consent-listener")
+    _background_startup_tasks.add(task)
+    task.add_done_callback(_background_startup_tasks.discard)
 
 
 @app.on_event("startup")

--- a/consent-protocol/tests/test_server_consent_listener_task_ref.py
+++ b/consent-protocol/tests/test_server_consent_listener_task_ref.py
@@ -1,0 +1,41 @@
+"""Proof that the consent-listener startup task retains a strong reference.
+
+asyncio.create_task() only stores a weak reference to the returned task on
+the event loop; without an external strong reference, the task object can
+be garbage collected before it completes, silently killing the background
+consent listener.
+
+This test reads the source directly rather than importing server.py,
+because importing server.py runs module-level logging.basicConfig() and
+install_sensitive_log_filter() calls that mutate global logging state and
+collide with other tests' caplog assertions when run in the same session.
+
+Canonical attach point: server.py::startup_consent_listener
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_SERVER_PY = Path(__file__).resolve().parents[1] / "server.py"
+
+
+def test_consent_listener_task_has_strong_reference():
+    """startup_consent_listener must retain the task in a module-level set."""
+    source = _SERVER_PY.read_text(encoding="utf-8")
+
+    assert "_background_startup_tasks: set[asyncio.Task] = set()" in source, (
+        "Module-level strong-reference set for background startup tasks is missing"
+    )
+
+    idx = source.find("async def startup_consent_listener")
+    assert idx != -1, "startup_consent_listener not found in server.py"
+    snippet = source[idx : idx + 600]
+
+    assert "asyncio.create_task(run_consent_listener()" in snippet
+    assert "_background_startup_tasks.add(task)" in snippet, (
+        "consent listener task is not retained in the strong-reference set"
+    )
+    assert "_background_startup_tasks.discard" in snippet, (
+        "consent listener task has no done-callback to clean up the strong reference"
+    )


### PR DESCRIPTION
Summary

Fix for consent-listener task reference retention.
Adds _background_startup_tasks set and done_callback in server.py.

Changes:
- Add asyncio import
- Declare _background_startup_tasks set at module level
- Store task in set, register cleanup callback

Canonical attach point: server.startup_consent_listener (on_startup)
Status: CI green (11/11 checks)