### PR TITLE
fix(kai-run-managers): use opaque message in run worker crash events (CWE-209)

### DIFF
--- a/consent-protocol/api/routes/kai/import_run_manager.py
+++ b/consent-protocol/api/routes/kai/import_run_manager.py
@@ -169,7 +169,7 @@ class KaiPortfolioImportRunManager:
                 event_name="error",
                 payload={
                     "code": "IMPORT_RUN_WORKER_FAILED",
-                    "message": str(exc),
+                    "message": "Import run worker failed.",
                     "run_id": run.run_id,
                 },
             )

--- a/consent-protocol/api/routes/kai/run_manager.py
+++ b/consent-protocol/api/routes/kai/run_manager.py
@@ -184,7 +184,7 @@ class KaiAnalyzeRunManager:
                 event_name="error",
                 payload={
                     "code": "ANALYZE_RUN_WORKER_FAILED",
-                    "message": str(exc),
+                    "message": "Analysis run worker failed.",
                     "ticker": run.ticker,
                     "run_id": run.run_id,
                 },

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -19,3 +19,4 @@ tests/test_stream_path_query_bounds_cwe400.py
 tests/performance/test_market_cache_instrumentation.py
 tests/test_llm_operon_stream_error_leak.py
 tests/test_stream_agent_thinking_gemini_error_cwe209.py
+tests/test_kai_run_worker_crash_cwe209.py

--- a/consent-protocol/tests/test_kai_run_worker_crash_cwe209.py
+++ b/consent-protocol/tests/test_kai_run_worker_crash_cwe209.py
@@ -1,0 +1,42 @@
+"""Minimal proof: run worker crash SSE events use opaque messages (CWE-209).
+
+Canonical attach points:
+  api/routes/kai/run_manager.py::KaiAnalyzeRunManager
+    -- ANALYZE_RUN_WORKER_FAILED event
+  api/routes/kai/import_run_manager.py::KaiPortfolioImportRunManager
+    -- IMPORT_RUN_WORKER_FAILED event
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_ROUTES_DIR = Path(__file__).resolve().parents[1] / "api" / "routes" / "kai"
+
+
+def test_analyze_run_worker_failed_message_is_static():
+    """ANALYZE_RUN_WORKER_FAILED event must carry a static message, not str(exc)."""
+    source = (_ROUTES_DIR / "run_manager.py").read_text(encoding="utf-8")
+
+    assert '"Analysis run worker failed."' in source
+
+    idx = source.find('"ANALYZE_RUN_WORKER_FAILED"')
+    assert idx != -1, "ANALYZE_RUN_WORKER_FAILED event not found in run_manager.py"
+    snippet = source[idx : idx + 200]
+    assert '"message": str(exc)' not in snippet, (
+        "ANALYZE_RUN_WORKER_FAILED event still forwards str(exc) as message"
+    )
+
+
+def test_import_run_worker_failed_message_is_static():
+    """IMPORT_RUN_WORKER_FAILED event must carry a static message, not str(exc)."""
+    source = (_ROUTES_DIR / "import_run_manager.py").read_text(encoding="utf-8")
+
+    assert '"Import run worker failed."' in source
+
+    idx = source.find('"IMPORT_RUN_WORKER_FAILED"')
+    assert idx != -1, "IMPORT_RUN_WORKER_FAILED event not found in import_run_manager.py"
+    snippet = source[idx : idx + 200]
+    assert '"message": str(exc)' not in snippet, (
+        "IMPORT_RUN_WORKER_FAILED event still forwards str(exc) as message"
+    )


### PR DESCRIPTION
Summary

Fix for run worker crash events (CWE-209).
Replaces str(exc) with opaque messages in both run managers.

Changes:
- run_manager.py: Analysis run worker failed
- import_run_manager.py: Import run worker failed

Canonical attach points:
- GET /api/kai/stream/analyze-run/{run_id} (KaiAnalyzeRunManager)
- GET /api/kai/portfolio/import-run/{run_id} (KaiPortfolioImportRunManager)

Status: CI green (11/11 checks)