### PR TITLE
fix(kai-chat): use UTC-aware datetime for analyzed_at PKM writes

### DIFF
--- a/consent-protocol/hushh_mcp/services/kai_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/kai_chat_service.py
@@ -23,7 +23,7 @@ import logging
 import os
 import re
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import Enum
 from typing import Optional
 
@@ -1227,7 +1227,7 @@ REASONING: [2-3 sentences]
             # Store decision as a non-sensitive summary in the PKM index
             saved = False
             try:
-                analyzed_at = datetime.now().isoformat()
+                analyzed_at = datetime.now(UTC).isoformat()
                 ticker_upper = str(ticker or "").upper()
                 await self.pkm_service.update_domain_summary(
                     user_id=user_id,

--- a/consent-protocol/tests/test_kai_chat_analyzed_at_utc.py
+++ b/consent-protocol/tests/test_kai_chat_analyzed_at_utc.py
@@ -1,0 +1,38 @@
+"""Tests that kai_chat_service stores analyzed_at as a UTC-aware datetime.
+
+These tests assert source-level properties to avoid the env-var requirements
+that prevent importing the module directly.
+"""
+
+import pathlib
+import re
+
+_SRC = (
+    pathlib.Path(__file__).parent.parent
+    / "hushh_mcp"
+    / "services"
+    / "kai_chat_service.py"
+)
+
+
+def test_datetime_import_includes_utc():
+    src = _SRC.read_text()
+    assert re.search(r"from datetime import.*\bUTC\b", src), (
+        "kai_chat_service must import UTC from datetime"
+    )
+
+
+def test_analyzed_at_uses_utc():
+    src = _SRC.read_text()
+    assert re.search(r"datetime\.now\(UTC\)", src), (
+        "analyzed_at must use datetime.now(UTC) not naive datetime.now()"
+    )
+
+
+def test_naive_datetime_now_not_present_in_analyzed_at():
+    src = _SRC.read_text()
+    # Look for datetime.now() with no argument (naive call)
+    naive_calls = re.findall(r"datetime\.now\(\s*\)", src)
+    assert not naive_calls, (
+        "kai_chat_service must not call naive datetime.now() -- found: %s" % naive_calls
+    )


### PR DESCRIPTION
## Summary

- `hushh_mcp/services/kai_chat_service.py` line 1230: `datetime.now()` produces a naive (timezone-unaware) ISO string stored in PKM under `analyzed_at` and `analysis_last_updated`
- Naive datetimes are ambiguous across DST boundaries and break any downstream timezone-aware comparison
- Replaces `datetime.now()` with `datetime.now(UTC)` and adds `UTC` to the import

## Test plan

- [ ] `tests/test_kai_chat_analyzed_at_utc.py` -- 3 source-level assertions:
  - `UTC` is imported from `datetime`
  - `datetime.now(UTC)` is present in the file
  - No bare `datetime.now()` calls remain
- All 3 pass against the fix; all 3 would fail against `main`