### PR TITLE
fix(portfolio): replace deprecated utcnow() with UTC-aware datetime.now(UTC)

### DIFF
--- a/consent-protocol/hushh_mcp/services/portfolio_import_service.py
+++ b/consent-protocol/hushh_mcp/services/portfolio_import_service.py
@@ -14,7 +14,7 @@ import json
 import logging
 import re
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
@@ -3643,7 +3643,7 @@ Content sample:
             "kpis": kpis,
             "losers": losers,
             "winners": winners,
-            "imported_at": datetime.utcnow().isoformat(),
+            "imported_at": datetime.now(UTC).isoformat(),
             "source": enhanced_portfolio.source,
         }
 

--- a/consent-protocol/hushh_mcp/services/portfolio_parser.py
+++ b/consent-protocol/hushh_mcp/services/portfolio_parser.py
@@ -12,7 +12,7 @@ import io
 import logging
 import re
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import Enum
 from typing import Optional
 
@@ -60,7 +60,7 @@ class Portfolio:
 
     def __post_init__(self):
         if self.parsed_at is None:
-            self.parsed_at = datetime.utcnow()
+            self.parsed_at = datetime.now(UTC)
 
 
 class PortfolioParser:

--- a/consent-protocol/tests/test_portfolio_utcnow_deprecated.py
+++ b/consent-protocol/tests/test_portfolio_utcnow_deprecated.py
@@ -1,0 +1,53 @@
+"""Tests that portfolio services use UTC-aware datetimes instead of deprecated utcnow().
+
+These tests use source-level assertions to avoid import-time side effects.
+"""
+
+import pathlib
+import re
+
+_SERVICES_DIR = pathlib.Path(__file__).parent.parent / "hushh_mcp" / "services"
+_IMPORT_SERVICE = _SERVICES_DIR / "portfolio_import_service.py"
+_PARSER = _SERVICES_DIR / "portfolio_parser.py"
+
+
+def test_import_service_utc_import():
+    src = _IMPORT_SERVICE.read_text()
+    assert re.search(r"from datetime import.*\bUTC\b", src), (
+        "portfolio_import_service must import UTC from datetime"
+    )
+
+
+def test_import_service_no_utcnow():
+    src = _IMPORT_SERVICE.read_text()
+    assert "datetime.utcnow()" not in src, (
+        "portfolio_import_service must not call deprecated datetime.utcnow()"
+    )
+
+
+def test_import_service_imported_at_uses_utc():
+    src = _IMPORT_SERVICE.read_text()
+    assert re.search(r"datetime\.now\(UTC\)\.isoformat\(\)", src), (
+        "imported_at must use datetime.now(UTC).isoformat()"
+    )
+
+
+def test_parser_utc_import():
+    src = _PARSER.read_text()
+    assert re.search(r"from datetime import.*\bUTC\b", src), (
+        "portfolio_parser must import UTC from datetime"
+    )
+
+
+def test_parser_no_utcnow():
+    src = _PARSER.read_text()
+    assert "datetime.utcnow()" not in src, (
+        "portfolio_parser must not call deprecated datetime.utcnow()"
+    )
+
+
+def test_parser_parsed_at_uses_utc():
+    src = _PARSER.read_text()
+    assert re.search(r"datetime\.now\(UTC\)", src), (
+        "parsed_at must use datetime.now(UTC)"
+    )


### PR DESCRIPTION
## Summary

- `hushh_mcp/services/portfolio_import_service.py` line 3646: `datetime.utcnow().isoformat()` is deprecated (Python 3.12) and returns a naive datetime with no timezone info embedded
- `hushh_mcp/services/portfolio_parser.py` line 63: `datetime.utcnow()` stores a naive datetime in `parsed_at`, which breaks any downstream timezone-aware comparison
- Both replaced with `datetime.now(UTC)` and `UTC` added to the respective import lines

## Test plan

- [ ] `tests/test_portfolio_utcnow_deprecated.py` -- 6 source-level assertions across both files:
  - `UTC` imported in each file
  - No `datetime.utcnow()` calls remain
  - `datetime.now(UTC)` call-sites present
- All 6 pass against the fix; all 6 would fail against `main`