### PR TITLE
fix(crd-scraper): add max_length=20 to crdNumber request field (CWE-400)

### DIFF
--- a/consent-protocol/api/routes/crd_scraper.py
+++ b/consent-protocol/api/routes/crd_scraper.py
@@ -27,6 +27,7 @@ class CrdScrapeJobRequest(BaseModel):
     crdNumber: str = Field(
         ...,
         min_length=1,
+        max_length=20,
         validation_alias=AliasChoices("crdNumber", "crd_number", "crd"),
     )
 

--- a/consent-protocol/tests/test_crd_scraper_cwe400_max_length.py
+++ b/consent-protocol/tests/test_crd_scraper_cwe400_max_length.py
@@ -1,0 +1,42 @@
+"""Tests that CrdScrapeJobRequest.crdNumber has a max_length bound (CWE-400).
+
+A missing max_length allows arbitrarily long strings to reach normalize_crd_number()
+and any downstream services, enabling resource exhaustion.
+
+Uses source-level assertions to avoid import-time side effects from rate-limit
+middleware that requires environment variables.
+"""
+
+import pathlib
+import re
+
+_SRC = pathlib.Path(__file__).parent.parent / "api" / "routes" / "crd_scraper.py"
+
+
+def test_crd_number_field_has_max_length():
+    src = _SRC.read_text()
+    assert re.search(r"max_length\s*=\s*\d+", src), (
+        "CrdScrapeJobRequest.crdNumber must declare max_length to prevent CWE-400"
+    )
+
+
+def test_crd_number_max_length_is_reasonable():
+    src = _SRC.read_text()
+    # Extract the crdNumber Field(...) block and check its max_length
+    field_block = re.search(
+        r"crdNumber:\s*str\s*=\s*Field\s*\(.*?\)", src, re.DOTALL
+    )
+    assert field_block, "crdNumber Field definition not found"
+    match = re.search(r"max_length\s*=\s*(\d+)", field_block.group(0))
+    assert match, "max_length not found in crdNumber Field"
+    value = int(match.group(1))
+    assert value <= 64, (
+        "CrdScrapeJobRequest.crdNumber max_length=%d is unreasonably large (> 64)" % value
+    )
+
+
+def test_crd_number_field_has_min_length():
+    src = _SRC.read_text()
+    assert re.search(r"min_length\s*=\s*1", src), (
+        "CrdScrapeJobRequest.crdNumber must retain min_length=1"
+    )


### PR DESCRIPTION
## Summary

- `api/routes/crd_scraper.py`: `CrdScrapeJobRequest.crdNumber` had `min_length=1` but no `max_length`, allowing arbitrarily long strings to pass Pydantic validation and reach `normalize_crd_number()` plus any downstream HTTP call to the RIA intelligence provider (CWE-400: Uncontrolled Resource Consumption)
- CRD numbers are at most 10 digits after normalization; `max_length=20` accommodates pre-normalization formatting characters (hyphens, spaces) while blocking oversized inputs
- The service-level guard in `normalize_crd_number()` (raises if `len(normalized) > 10`) is a second line of defense, not a substitute for input bounds at the schema layer

## Test plan

- [ ] `tests/test_crd_scraper_cwe400_max_length.py` -- 3 source-level assertions:
  - `max_length` is declared on the `crdNumber` Field
  - The `crdNumber` Field's `max_length` is at most 64 (reasonable upper bound)
  - `min_length=1` is retained
- All 3 pass against the fix; `test_crd_number_field_has_max_length` fails against `main`