### PR TITLE
fix(pkm): add bounds to PKMAgentLabStructureRequest fields (CWE-400)

### DIFF
--- a/consent-protocol/api/routes/pkm.py
+++ b/consent-protocol/api/routes/pkm.py
@@ -111,10 +111,10 @@ async def require_pkm_metadata_access(
 
 
 class PKMAgentLabStructureRequest(BaseModel):
-    user_id: str
+    user_id: str = Field(min_length=1, max_length=128)
     message: str = Field(min_length=1, max_length=12000)
-    current_domains: list[str] = Field(default_factory=list)
-    current_manifests: list[dict] = Field(default_factory=list)
+    current_domains: list[str] = Field(default_factory=list, max_length=256)
+    current_manifests: list[dict] = Field(default_factory=list, max_length=256)
     simulated_state: dict | None = None
 
 

--- a/consent-protocol/tests/test_pkm_agent_lab_cwe400_bounds.py
+++ b/consent-protocol/tests/test_pkm_agent_lab_cwe400_bounds.py
@@ -1,0 +1,51 @@
+"""Tests that PKMAgentLabStructureRequest has bounds on unbounded fields (CWE-400).
+
+Without max_length on user_id and max_length on list fields, a caller can send
+arbitrarily large payloads that propagate deep into the PKM agent pipeline.
+
+Uses source-level assertions to avoid import-time side effects from middleware
+that requires environment variables.
+"""
+
+import pathlib
+import re
+
+_SRC = pathlib.Path(__file__).parent.parent / "api" / "routes" / "pkm.py"
+
+
+def _agent_lab_block(src: str) -> str:
+    match = re.search(
+        r"class PKMAgentLabStructureRequest\(BaseModel\):.*?(?=\nclass |\Z)",
+        src,
+        re.DOTALL,
+    )
+    assert match, "PKMAgentLabStructureRequest class not found in pkm.py"
+    return match.group(0)
+
+
+def test_user_id_has_max_length():
+    block = _agent_lab_block(_SRC.read_text())
+    assert re.search(r"user_id.*max_length\s*=\s*\d+", block), (
+        "PKMAgentLabStructureRequest.user_id must declare max_length to prevent CWE-400"
+    )
+
+
+def test_user_id_has_min_length():
+    block = _agent_lab_block(_SRC.read_text())
+    assert re.search(r"user_id.*min_length\s*=\s*1", block), (
+        "PKMAgentLabStructureRequest.user_id must have min_length=1"
+    )
+
+
+def test_current_domains_has_max_length():
+    block = _agent_lab_block(_SRC.read_text())
+    assert re.search(r"current_domains.*max_length\s*=\s*\d+", block), (
+        "PKMAgentLabStructureRequest.current_domains list must declare max_length"
+    )
+
+
+def test_current_manifests_has_max_length():
+    block = _agent_lab_block(_SRC.read_text())
+    assert re.search(r"current_manifests.*max_length\s*=\s*\d+", block), (
+        "PKMAgentLabStructureRequest.current_manifests list must declare max_length"
+    )


### PR DESCRIPTION
## Summary

`PKMAgentLabStructureRequest` in `api/routes/pkm.py` had three unbounded fields that a caller could exploit for resource exhaustion (CWE-400):

- `user_id: str` -- no length bounds; now `Field(min_length=1, max_length=128)`
- `current_domains: list[str]` -- no item count limit; now `Field(..., max_length=256)`
- `current_manifests: list[dict]` -- no item count limit; now `Field(..., max_length=256)`

`message` already had `max_length=12000`; the other bounded path params in the file use `max_length=128`.

## Test plan

- [ ] `tests/test_pkm_agent_lab_cwe400_bounds.py` -- 4 source-level assertions:
  - `user_id` has `max_length`
  - `user_id` has `min_length=1`
  - `current_domains` has `max_length`
  - `current_manifests` has `max_length`
- All 4 pass against the fix; the 3 `max_length` tests fail against `main`