### PR TITLE
fix(ui): hide one location search icon from assistive technology

### DIFF
--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -3389,7 +3389,10 @@ function OneLocationAgentPageContent() {
 
                 <div className="min-w-0 max-w-full space-y-3">
                   <div className="relative">
-                    <Search className="absolute left-3.5 top-1/2 h-5 w-5 -translate-y-1/2 text-[#8e8e93]" />
+                    <Search
+                      className="absolute left-3.5 top-1/2 h-5 w-5 -translate-y-1/2 text-[#8e8e93]"
+                      aria-hidden="true"
+                    />
                     <input
                       value={recipientSearch}
                       onChange={(event) =>


### PR DESCRIPTION
## Summary
- Mark the One Location recipient search icon as decorative with `aria-hidden="true"`.
- Preserve the visible search affordance and input behavior.

## Why
The adjacent search input already exposes the searchable control through its placeholder and text input semantics. Hiding the standalone icon prevents decorative icon noise for assistive technology.

## Impact
Accessibility-only markup change. No visual or behavioral changes.

## Caller Proof
- `hushh-webapp/app/one/location/page.tsx` renders `OneLocationAgentPageContent` from the default One Location page export.
- The changed icon is the absolute-positioned `Search` icon next to the `recipientSearch` input.
- Only the decorative icon receives `aria-hidden="true"`; the input value, change handler, placeholder, type, and styling are unchanged.

## Validation
- `npx.cmd eslint app/one/location/page.tsx --max-warnings=0`
- Verified the commit includes a DCO `Signed-off-by` trailer.
