### PR TITLE
fix(ui): hide marketplace search icons from assistive technology

### DIFF
--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -1121,7 +1121,7 @@ export default function MarketplacePage() {
                 aria-label="Toggle search"
                 onClick={() => setSearchOpen((current) => !current)}
               >
-                <Search className="h-4 w-4" />
+                <Search className="h-4 w-4" aria-hidden="true" />
               </button>
               <Button
                 variant="none"
@@ -1172,7 +1172,10 @@ export default function MarketplacePage() {
           {searchOpen ? (
             <div className="mt-2">
               <div className="relative">
-                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <Search
+                  className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                  aria-hidden="true"
+                />
                 <Input
                   value={query}
                   onChange={(event) => setQuery(event.target.value)}


### PR DESCRIPTION
## Summary
- Mark the Marketplace search toggle icon as decorative with `aria-hidden="true"`.
- Mark the expanded Marketplace search input icon as decorative with `aria-hidden="true"`.

## Why
The toggle button already has an `aria-label`, and the expanded search input exposes the searchable control through input semantics and placeholder text. Hiding the standalone icons prevents decorative icon noise for assistive technology.

## Impact
Accessibility-only markup change. No visual or behavioral changes.

## Caller Proof
- `hushh-webapp/app/marketplace/page.tsx` exports `MarketplacePage`.
- The changed icons are the `Search` icon inside the labeled search toggle button and the absolute-positioned `Search` icon beside the expanded search input.
- Only the decorative icon elements receive `aria-hidden="true"`; the toggle label, search state, input value, change handler, placeholder, and styling remain unchanged.

## Validation
- `npx.cmd eslint app/marketplace/page.tsx --max-warnings=0`
- Verified the commit includes a DCO `Signed-off-by` trailer.
