### PR TITLE
fix(ui): hide ria clients chevron icon from assistive technology

### DIFF
--- a/hushh-webapp/app/ria/clients/page.tsx
+++ b/hushh-webapp/app/ria/clients/page.tsx
@@ -268,7 +268,7 @@ export default function RiaClientsPage() {
                       <Badge className={cn("text-[10px]", statusBadgeClass(client.status))}>
                         {formatStatus(client.status)}
                       </Badge>
-                      <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                      <ChevronRight className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
                     </div>
                   </div>
                   <MaterialRipple variant="none" effect="fade" className="z-0" />


### PR DESCRIPTION
## Summary
- Mark the RIA clients row chevron icon as decorative with `aria-hidden="true"`.
- Preserve the client row button text, status badge, and navigation behavior.

## Why
The row button already exposes the client name and status through visible text. Hiding the trailing chevron prevents decorative icon noise for assistive technology.

## Impact
Accessibility-only markup change. No visual or behavioral changes.

## Caller Proof
- `hushh-webapp/app/ria/clients/page.tsx` exports `RiaClientsPage`.
- The changed `ChevronRight` icon is rendered inside each connected investor row button.
- Only the decorative chevron receives `aria-hidden="true"`; the button, client label, status badge, click handler, and route target remain unchanged.

## Validation
- `npx.cmd eslint app/ria/clients/page.tsx --max-warnings=0`
- Verified the commit includes a DCO `Signed-off-by` trailer.
