### PR TITLE
test(env-utils): cover uppercase UAT env alias normalisation

### DIFF
--- a/hushh-webapp/__tests__/lib/env-utils.test.ts
+++ b/hushh-webapp/__tests__/lib/env-utils.test.ts
@@ -1,0 +1,18 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("env-utils", () => {
+  const ORIGINAL_ENV = process.env;
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.resetModules();
+  });
+
+  it("normalises uppercase UAT env alias", async () => {
+    process.env.NEXT_PUBLIC_APP_ENV = "UAT";
+
+    const { resolveAppEnvironment } = await import("@/lib/app-env");
+
+    expect(resolveAppEnvironment()).toBe("uat");
+  });
+});


### PR DESCRIPTION
## Summary
- Add an env-utils test for uppercase `UAT` environment input.
- Verify the app environment resolver normalises the alias to canonical `uat`.

## Scope Proof
- New test file: `hushh-webapp/__tests__/lib/env-utils.test.ts`.
- The existing environment resolver lives in `hushh-webapp/lib/app-env.ts`; there is no separate `env-utils` module on `integration/pr-train`.
- The test uses a dynamic import inside the test body and does not change runtime code.

## Impact
Test-only change. No runtime behavior changes.

## Validation
- `npx.cmd vitest run __tests__/lib/env-utils.test.ts`
- Verified the commit includes a DCO `Signed-off-by` trailer.
