### PR TITLE
fix(ui): remove invalid aria-invalid CSS variants from Badge component

### DIFF
--- a/hushh-webapp/components/ui/badge.tsx
+++ b/hushh-webapp/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import { Slot } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "inline-flex items-center justify-center rounded-full border border-transparent px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  "inline-flex items-center justify-center rounded-full border border-transparent px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] transition-[color,box-shadow] overflow-hidden",
   {
     variants: {
       variant: {


### PR DESCRIPTION
Badges are inherently non-interactive display elements (`span` or `div`) and therefore cannot semantically possess an `aria-invalid` form validation state. 

The `aria-invalid:ring-destructive/20`, `dark:aria-invalid:ring-destructive/40`, and `aria-invalid:border-destructive` utility classes were mistakenly copy-pasted into `badgeVariants` from interactive form primitives like `button` or `input`. 

Removing them cleans up semantic HTML confusion, removes dead CSS utilities from the bundle, and strictly aligns the component with its intended display-only purpose.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None specifically (generic UI component)
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None (Pure UI Primitive)
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable
- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — generic UI Badge component.
- [x] Reachable production attach point: components/ui/badge.tsx
- [x] Production surface proved: explicit semantic CSS cleanup, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/ui/badge.tsx)
- [x] **iOS**: Not applicable — CSS attribute cleanup
- [x] **Android**: Not applicable — CSS attribute cleanup

## 🧪 Testing

- [x] Tested on Web (Verified Badge continues to render flawlessly and scales down dead CSS classes)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

No visual change. Pure CSS semantics cleanup.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed