### PR TITLE
test(timeout-utils): cover zero timeout value handling

### DIFF
--- a/hushh-webapp/__tests__/lib/timeout-utils.test.ts
+++ b/hushh-webapp/__tests__/lib/timeout-utils.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+describe("timeout-utils", () => {
+  it("handles zero timeout values with a safe fallback", async () => {
+    process.env.NEXT_PUBLIC_APP_ENV = "uat";
+    delete process.env.HUSHH_SLOW_REQUEST_TIMEOUT_MS;
+
+    const { resolveSlowRequestTimeoutMs } = await import("@/lib/utils/request-timeouts");
+
+    expect(resolveSlowRequestTimeoutMs(0)).toBe(75_000);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a timeout-utils test for zero timeout input handling.
- Verify the existing slow request timeout resolver maps `0` to the safe fallback timeout.

## Scope Proof
- New test file: `hushh-webapp/__tests__/lib/timeout-utils.test.ts`.
- The existing timeout helper lives in `hushh-webapp/lib/utils/request-timeouts.ts`; there is no separate `timeout-utils` module on `integration/pr-train`.
- The test uses a dynamic import inside the test body and does not change runtime code.

## Impact
Test-only change. No runtime behavior changes.

## Validation
- `npx.cmd vitest run __tests__/lib/timeout-utils.test.ts`
- Verified the commit includes a DCO `Signed-off-by` trailer.
