### PR TITLE
fix(ui): hide ria picks loading spinners from assistive technology

### DIFF
--- a/hushh-webapp/app/ria/picks/page.tsx
+++ b/hushh-webapp/app/ria/picks/page.tsx
@@ -2447,14 +2447,14 @@ export default function RiaPicksPage() {
 
               {source === "kai" && kaiLoading ? (
                 <div className="flex items-center gap-2 py-8 text-sm text-muted-foreground">
-                  <Loader2 className="h-4 w-4 animate-spin" />
+                  <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />
                   Loading Kai list...
                 </div>
               ) : null}
 
               {source === "my" && picksResource.loading ? (
                 <div className="flex items-center gap-2 py-8 text-sm text-muted-foreground">
-                  <Loader2 className="h-4 w-4 animate-spin" />
+                  <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />
                   Loading My list...
                 </div>
               ) : null}
@@ -2525,7 +2525,7 @@ export default function RiaPicksPage() {
             <div className="space-y-4">
               {source === "kai" && avoidLoading ? (
                 <div className="flex items-center gap-2 py-8 text-sm text-muted-foreground">
-                  <Loader2 className="h-4 w-4 animate-spin" />
+                  <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />
                   Loading avoid list...
                 </div>
               ) : null}
@@ -2594,7 +2594,7 @@ export default function RiaPicksPage() {
             <div className="space-y-4">
               {source === "kai" && screeningLoading ? (
                 <div className="flex items-center gap-2 py-8 text-sm text-muted-foreground">
-                  <Loader2 className="h-4 w-4 animate-spin" />
+                  <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />
                   Loading screening criteria...
                 </div>
               ) : null}


### PR DESCRIPTION
## Summary
- Hide the RIA picks loading spinner icons from assistive technology.
- Add `aria-hidden="true"` to the decorative `Loader2` icons used in top picks, avoid, and screening loading states.

## Root Cause
The visible loading labels already announce the state, while the spinner icons are decorative and do not need separate exposure to assistive technology.

## Impact
Accessibility-only UI change. No data loading, table, or RIA picks behavior changes.

## Scope Proof
- Touched only `hushh-webapp/app/ria/picks/page.tsx`.
- Updated only the four `Loader2` loading spinner render sites.

## Validation
- `npx.cmd eslint app/ria/picks/page.tsx --max-warnings=0`
- Verified the commit includes a DCO `Signed-off-by` trailer.
