### PR TITLE
test(config): cover development backend url resolution

### DIFF
--- a/hushh-webapp/__tests__/lib/config.test.ts
+++ b/hushh-webapp/__tests__/lib/config.test.ts
@@ -50,6 +50,22 @@ describe("config", () => {
     expect(config.BACKEND_URL).toBe("http://127.0.0.1:8000");
   });
 
+  it("resolves configured development backend url", async () => {
+    const { resolveAppEnvironment } = await import("@/lib/app-env");
+    const { resolveRuntimeBackendUrl } = await import(
+      "@/lib/runtime/settings"
+    );
+
+    vi.mocked(resolveAppEnvironment).mockReturnValue("development");
+    vi.mocked(resolveRuntimeBackendUrl).mockReturnValue(
+      " http://localhost:8000/ "
+    );
+
+    const config = await import("@/lib/config");
+
+    expect(config.BACKEND_URL).toBe("http://localhost:8000");
+  });
+
   it("uses development frontend fallback when runtime frontend url is empty", async () => {
     const { resolveAppEnvironment } = await import("@/lib/app-env");
     const { resolveRuntimeFrontendUrl } = await import(


### PR DESCRIPTION
## Summary
- Add config test coverage for development backend URL resolution.
- Verify an explicit runtime backend URL wins over the development fallback and is normalized.

## Scope Proof
- Touched only `hushh-webapp/__tests__/lib/config.test.ts`.
- Appended one focused `it()` block inside the existing `config` describe block.
- Test-only change with no runtime code changes.

## Impact
No application behavior changes. This only locks existing config behavior around configured development backend URLs.

## Validation
- `npx.cmd vitest run __tests__/lib/config.test.ts`
- Verified the commit includes a DCO `Signed-off-by` trailer.
