### PR TITLE
fix(ui): restore missing CSS animations for Sheet backdrop

### DIFF
--- a/hushh-webapp/components/ui/sheet.tsx
+++ b/hushh-webapp/components/ui/sheet.tsx
@@ -39,7 +39,7 @@ function SheetOverlay({
     <SheetPrimitive.Overlay
       data-slot="sheet-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-[711] bg-transparent touch-none",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-[711] bg-black/22 backdrop-blur-[8px] [-webkit-backdrop-filter:blur(8px)] touch-none",
         className
       )}
       {...props}
@@ -59,10 +59,6 @@ function SheetContent({
 }) {
   return (
     <SheetPortal>
-      <div
-        aria-hidden
-        className="pointer-events-none fixed inset-0 z-[710] bg-black/22 backdrop-blur-[8px] [-webkit-backdrop-filter:blur(8px)]"
-      />
       <SheetOverlay />
       <SheetPrimitive.Content
         data-slot="sheet-content"


### PR DESCRIPTION
A previous refactor incorrectly split the visual backdrop styles (`bg-black/22` and `backdrop-blur`) into a static, manually-rendered `<div />` completely separate from the managed Radix `SheetPrimitive.Overlay`. 

Because this static div was entirely disconnected from the Radix state machine, it lacked the `data-[state=open]` and `data-[state=closed]` attributes required by Tailwind. As a result, the `animate-in` and `fade-in-0` classes never triggered, causing the dark blurred backdrop to abruptly pop into existence with zero animation when a Sheet was opened. 

Moving the visual styles natively back into `SheetOverlay` properly links it to the Radix state machine and restores smooth, high-quality crossfading animations.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None specifically (generic UI component)
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None (Pure UI Primitive)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — generic UI Sheet component.
- [x] Reachable production attach point: components/ui/sheet.tsx
- [x] Production surface proved: explicit animation state restore, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/ui/sheet.tsx)
- [x] **iOS**: Not applicable — CSS layout attribute tracking
- [x] **Android**: Not applicable — CSS layout attribute tracking

## 🧪 Testing

- [x] Tested on Web (Verified Sheet overlay backdrop smoothly fades in and out along with the sheet content)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Restores missing crossfade animations on Sheet backdrops. No structural visual changes, only UX improvements during transitions.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none
