### PR TITLE
test(breadcrumb-separator): cover decorative chevron hidden from assistive technology

### DIFF
--- a/hushh-webapp/__tests__/ui/breadcrumb-separator.test.tsx
+++ b/hushh-webapp/__tests__/ui/breadcrumb-separator.test.tsx
@@ -1,0 +1,19 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { BreadcrumbSeparator } from "@/components/ui/breadcrumb";
+
+describe("BreadcrumbSeparator", () => {
+  it("hides the decorative chevron from assistive technology", () => {
+    const { container } = render(<BreadcrumbSeparator />);
+
+    const separator = container.querySelector(
+      '[data-slot="breadcrumb-separator"]',
+    );
+    const chevron = separator?.querySelector("svg");
+
+    expect(separator?.getAttribute("aria-hidden")).toBe("true");
+    expect(separator?.getAttribute("role")).toBe("presentation");
+    expect(chevron?.getAttribute("aria-hidden")).toBe("true");
+  });
+});


### PR DESCRIPTION
## Summary
- Add UI test coverage for the breadcrumb separator accessibility contract.
- Verify the separator wrapper and default chevron are hidden from assistive technology.

## Scope Proof
- New test file only: `hushh-webapp/__tests__/ui/breadcrumb-separator.test.tsx`.
- No component or runtime code changes.
- Covers the existing `BreadcrumbSeparator` primitive behavior directly.

## Impact
Test-only change. This locks the existing decorative breadcrumb separator behavior without changing UI output.

## Validation
- `npx.cmd vitest run __tests__/ui/breadcrumb-separator.test.tsx`
- Verified the commit includes a DCO `Signed-off-by` trailer.
