### PR TITLE
fix(one-kyc-page): hide one kyc alias action spinners from assistive technology

### DIFF
--- a/hushh-webapp/app/one/kyc/page.tsx
+++ b/hushh-webapp/app/one/kyc/page.tsx
@@ -2251,7 +2251,7 @@ function OneKycWorkspace() {
                     className="w-full sm:w-auto"
                   >
                     {busy === "alias" ? (
-                      <Loader2 className="size-4 animate-spin" />
+                      <Loader2 aria-hidden="true" className="size-4 animate-spin" />
                     ) : (
                       <MailPlus className="size-4" />
                     )}
@@ -2267,7 +2267,7 @@ function OneKycWorkspace() {
                     className="w-full sm:w-auto"
                   >
                     {busy === "alias" ? (
-                      <Loader2 className="size-4 animate-spin" />
+                      <Loader2 aria-hidden="true" className="size-4 animate-spin" />
                     ) : (
                       <BadgeCheck className="size-4" />
                     )}


### PR DESCRIPTION
## Exact Surface
- File: hushh-webapp/app/one/kyc/page.tsx
- Component: OneKycPage
- Lines changed: 2254, 2270

## Caller Proof
- Caller: hushh-webapp/app/one/kyc/page.tsx exports OneKycPage as the Next.js App Router page component
- Route: /one/kyc

## No Overlap Proof
- This change does not exist anywhere else: confirmed

## Narrowness Proof
- 1 file changed
- Zero props or API changed
- Change limited to hiding only the two OneKycPage verified-email alias action Loader2 spinners from assistive technology.