### PR TITLE
fix(ui): restore missing CSS animations for Drawer backdrop

### DIFF
--- a/hushh-webapp/components/ui/drawer.tsx
+++ b/hushh-webapp/components/ui/drawer.tsx
@@ -38,7 +38,7 @@ function DrawerOverlay({
     <DrawerPrimitive.Overlay
       data-slot="drawer-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-[711] bg-transparent touch-none",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-[711] bg-black/22 backdrop-blur-[8px] [-webkit-backdrop-filter:blur(8px)] touch-none",
         className
       )}
       {...props}
@@ -56,10 +56,6 @@ function DrawerContent({
 }) {
   return (
     <DrawerPortal data-slot="drawer-portal">
-      <div
-        aria-hidden
-        className="pointer-events-none fixed inset-0 z-[710] bg-black/22 backdrop-blur-[8px] [-webkit-backdrop-filter:blur(8px)]"
-      />
       <DrawerOverlay />
       <DrawerPrimitive.Content
         data-slot="drawer-content"


### PR DESCRIPTION
A previous refactor incorrectly split the visual backdrop styles (`bg-black/22` and `backdrop-blur`) into a static, manually-rendered `<div />` completely separate from the `DrawerOverlay` primitive. 

Because this static div was entirely disconnected from the component's state machine, it lacked the `data-[state=open]` and `data-[state=closed]` attributes required by Tailwind. As a result, the `animate-in` and `fade-in-0` classes never triggered, causing the dark blurred backdrop to abruptly pop into existence with zero animation when a Drawer was opened. 

Moving the visual styles natively back into `DrawerOverlay` properly links it to the state machine and restores smooth, high-quality crossfading animations.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None specifically (generic UI component)
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None (Pure UI Primitive)
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable
- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — generic UI Drawer component.
- [x] Reachable production attach point: components/ui/drawer.tsx
- [x] Production surface proved: explicit animation state restore, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/ui/drawer.tsx)
- [x] **iOS**: Not applicable — CSS layout attribute tracking
- [x] **Android**: Not applicable — CSS layout attribute tracking

## 🧪 Testing

- [x] Tested on Web (Verified Drawer overlay backdrop smoothly fades in and out along with the drawer content)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Restores missing crossfade animations on Drawer backdrops. No structural visual changes, only UX improvements during transitions.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed