### PR TITLE
fix(ui): restore missing accessibility focus ring in TabsContent

### DIFF
--- a/hushh-webapp/components/ui/tabs.tsx
+++ b/hushh-webapp/components/ui/tabs.tsx
@@ -95,7 +95,7 @@ function TabsContent({
   return (
     <TabsPrimitive.Content
       data-slot="tabs-content"
-      className={cn("flex-1 outline-none", className)}
+      className={cn("flex-1 outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50", className)}
       {...props}
     />
   )


### PR DESCRIPTION
The `TabsContent` pane natively receives programmatic focus from Radix UI when a keyboard user navigates into the tab's panel. However, the component forcibly stripped the native focus ring using `outline-none` without providing a `focus-visible` replacement. 

This caused a critical WCAG A11y failure where keyboard users were left completely blind as to where their focus was on the page. Adding standard `focus-visible:ring-[3px] focus-visible:ring-ring/50` restores the necessary visual focus indicators for keyboard navigation.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None specifically (generic UI component)
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None (Pure UI Primitive)
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable
- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — generic UI Tabs component.
- [x] Reachable production attach point: components/ui/tabs.tsx
- [x] Production surface proved: explicit a11y focus ring fix, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/ui/tabs.tsx)
- [x] **iOS**: Not applicable — CSS keyboard focus styles
- [x] **Android**: Not applicable — CSS keyboard focus styles

## 🧪 Testing

- [x] Tested on Web (Verified TabContent shows an explicit focus ring when navigated to via Tab key)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Restores missing WCAG-compliant keyboard focus rings on Tab panels. Invisible to mouse users.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none