### PR TITLE
fix(ui): remove redundant CSS absolute positioning in RadioGroup

### DIFF
--- a/hushh-webapp/components/ui/radio-group.tsx
+++ b/hushh-webapp/components/ui/radio-group.tsx
@@ -34,9 +34,9 @@ function RadioGroupItem({
     >
       <RadioGroupPrimitive.Indicator
         data-slot="radio-group-indicator"
-        className="relative flex items-center justify-center"
+        className="flex items-center justify-center"
       >
-        <CircleIcon className="fill-primary absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2" />
+        <CircleIcon className="fill-primary size-2" />
       </RadioGroupPrimitive.Indicator>
     </RadioGroupPrimitive.Item>
   )


### PR DESCRIPTION
The `RadioGroupPrimitive.Indicator` icon was incorrectly styled using absolute positioning with `-translate-x-1/2 -translate-y-1/2`, despite its parent container already being a flexbox with `items-center justify-center` applied. 

Injecting absolute composite calculations inside a perfectly centered flexbox is entirely redundant, forces unnecessary browser layout repaints, and can cause sub-pixel rendering blur on non-retina screens if the 50% translation lands on a half-pixel boundary. Removing the absolute positioning delegates the layout entirely to the much faster flexbox engine, ensuring crisp rendering.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None specifically (generic UI component)
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None (Pure UI Primitive)
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable
- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — generic UI RadioGroup component.
- [x] Reachable production attach point: components/ui/radio-group.tsx
- [x] Production surface proved: explicit CSS rendering redundancy fix, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/ui/radio-group.tsx)
- [x] **iOS**: Not applicable — CSS layout mathematics
- [x] **Android**: Not applicable — CSS layout mathematics

## 🧪 Testing

- [x] Tested on Web (Verified RadioGroup indicator renders perfectly centered using native flexbox rules)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Removes CSS layout redundancy and sub-pixel blur potential.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed