### PR TITLE
fix(ui): remove contradictory pointer-events-none from Input to restore disabled cursor

### DIFF
--- a/hushh-webapp/components/ui/input.tsx
+++ b/hushh-webapp/components/ui/input.tsx
@@ -18,7 +18,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
         type === "email" || type === "search" ? false : props.spellCheck
       }
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className


### PR DESCRIPTION
The `Input` component featured a contradictory CSS bug where the disabled "not allowed" cursor was physically impossible to trigger. 

The `disabled:pointer-events-none` class tells the browser to completely ignore mouse events. Because hover events were ignored, the adjacent `disabled:cursor-not-allowed` class could never fire, leaving the user with a confusing standard pointer when hovering over disabled form inputs. 

Because native `disabled` inputs already strictly prevent clicks and focus, `pointer-events-none` is entirely redundant. By removing it, the correct OS-level visual "not-allowed" feedback is finally restored when hovering.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None specifically (generic UI component)
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None (Pure UI Primitive)
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable
- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — generic UI Input component.
- [x] Reachable production attach point: components/ui/input.tsx
- [x] Production surface proved: explicit UX interaction feedback fix, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/ui/input.tsx)
- [x] **iOS**: Not applicable — Web cursor states
- [x] **Android**: Not applicable — Web cursor states

## 🧪 Testing

- [x] Tested on Web (Verified disabled Input elements now correctly display the `not-allowed` cursor on hover instead of masking the event)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Restores missing `not-allowed` cursor on disabled input states.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed