### PR TITLE
fix(ui): use transition-all on Switch thumb to fix abrupt dark mode color snapping

### DIFF
--- a/hushh-webapp/components/ui/switch.tsx
+++ b/hushh-webapp/components/ui/switch.tsx
@@ -25,7 +25,7 @@ function Switch({
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
         className={cn(
-          "pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-[state=checked]:translate-x-4 group-data-[size=sm]/switch:data-[state=checked]:translate-x-3 data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground"
+          "pointer-events-none block rounded-full bg-background ring-0 transition-all group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-[state=checked]:translate-x-4 group-data-[size=sm]/switch:data-[state=checked]:translate-x-3 data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground"
         )}
       />
     </SwitchPrimitive.Root>


### PR DESCRIPTION
The `Switch` component featured an animation omission bug where the thumb's background color abruptly snapped during state changes in dark mode. 

The thumb was using the `transition-transform` utility, which explicitly restricts CSS animations to movement only. Replacing it with `transition-all` allows both the layout movement and the dark mode background color to transition simultaneously over 150ms, perfectly mirroring the smooth crossfade behavior of the parent Switch track.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None specifically (generic UI component)
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None (Pure UI Primitive)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — generic UI Switch component.
- [x] Reachable production attach point: components/ui/switch.tsx
- [x] Production surface proved: explicit CSS animation property fix, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/ui/switch.tsx)
- [x] **iOS**: Not applicable — Web animation states
- [x] **Android**: Not applicable — Web animation states

## 🧪 Testing

- [x] Tested on Web (Verified Switch thumb now smoothly crossfades its background color during toggle instead of abruptly snapping)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none