### PR TITLE
test(push-tokens): verify upsert returns inserted id

### DIFF
--- a/consent-protocol/tests/services/test_push_tokens_service.py
+++ b/consent-protocol/tests/services/test_push_tokens_service.py
@@ -1,0 +1,29 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from hushh_mcp.services.push_tokens_service import PushTokensService
+
+TEST_PUSH_VALUE = "sample_value"  # nosec B105
+
+
+def test_upsert_user_push_token_returns_inserted_id():
+    fake_db = Mock()
+
+    fake_db.execute_raw.return_value = SimpleNamespace(
+        data=[{"id": 123}],
+        error=None,
+    )
+
+    with patch(
+        "hushh_mcp.services.push_tokens_service.get_db",
+        return_value=fake_db,
+    ):
+        service = PushTokensService()
+
+        result = service.upsert_user_push_token(
+            user_id="user1",
+            token=TEST_PUSH_VALUE,
+            platform="web",
+        )
+
+    assert result == 123


### PR DESCRIPTION
Summary

Adds coverage for PushTokensService.upsert_user_push_token.

Changes

- Adds a test covering successful token upsert
- Verifies the inserted row id is returned
- Uses a mocked database response

Why

This validates the service contract for successful push token registration and ensures callers receive the inserted identifier.

Testing

- uv run pytest tests/services/test_push_tokens_service.py -v