### PR TITLE
test(push-tokens): verify delete filters by platform

### DIFF
--- a/consent-protocol/tests/services/test_push_tokens_service.py
+++ b/consent-protocol/tests/services/test_push_tokens_service.py
@@ -1,0 +1,31 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from hushh_mcp.services.push_tokens_service import PushTokensService
+
+
+def test_delete_user_push_tokens_with_platform():
+    fake_db = Mock()
+
+    fake_db.execute_raw.return_value = SimpleNamespace(
+        data=[{}, {}],
+        error=None,
+    )
+
+    with patch(
+        "hushh_mcp.services.push_tokens_service.get_db",
+        return_value=fake_db,
+    ):
+        service = PushTokensService()
+
+        deleted = service.delete_user_push_tokens(
+            user_id="user1",
+            platform="ios",
+        )
+
+    assert deleted == 2
+
+    sql, params = fake_db.execute_raw.call_args.args
+
+    assert "platform" in sql
+    assert params["platform"] == "ios"


### PR DESCRIPTION
Summary

Adds coverage for PushTokensService.delete_user_push_tokens when a platform filter is supplied.

Changes

* Adds a test for deleting push tokens scoped to a platform
* Verifies the generated query includes platform filtering
* Verifies the platform parameter is forwarded correctly

Why

This validates that platform-specific token cleanup uses the expected filter and affects only the intended records.

Testing

* uv run pytest tests/services/test_push_tokens_service.py -v
