### PR TITLE
test(push-tokens): verify upsert raises on database error

### DIFF
--- a/consent-protocol/tests/services/test_push_tokens_service.py
+++ b/consent-protocol/tests/services/test_push_tokens_service.py
@@ -1,0 +1,30 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from hushh_mcp.services.push_tokens_service import PushTokensService
+
+TEST_PUSH_VALUE = "sample_value"  # nosec B105
+
+
+def test_upsert_user_push_token_raises_on_db_error():
+    fake_db = Mock()
+
+    fake_db.execute_raw.return_value = SimpleNamespace(
+        data=[],
+        error="boom",
+    )
+
+    with patch(
+        "hushh_mcp.services.push_tokens_service.get_db",
+        return_value=fake_db,
+    ):
+        service = PushTokensService()
+
+        with pytest.raises(RuntimeError):
+            service.upsert_user_push_token(
+                user_id="user1",
+                token=TEST_PUSH_VALUE,
+                platform="web",
+            )


### PR DESCRIPTION
Summary

Adds coverage for PushTokensService.upsert_user_push_token error handling.

Changes

* Adds a test for database error propagation during token upsert
* Mocks a database error response
* Verifies the service raises RuntimeError

Why

This validates the service contract when persistence fails and ensures callers receive a consistent exception.

Testing

* uv run pytest tests/services/test_push_tokens_service.py -v
