### PR TITLE
fix(ui): align PopoverTitle element with declared h2 type contract

### DIFF
--- a/hushh-webapp/components/ui/popover.tsx
+++ b/hushh-webapp/components/ui/popover.tsx
@@ -58,7 +58,7 @@ function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
 
 function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
   return (
-    <div
+    <h2
       data-slot="popover-title"
       className={cn("font-medium", className)}
       {...props}


### PR DESCRIPTION
## Summary

`PopoverTitle` declares `React.ComponentProps<"h2">` but renders a `<div>` element.

This change aligns the rendered element with its declared type contract.

## Why

* The component type declares heading semantics through `React.ComponentProps<"h2">`
* The implementation currently renders a non-heading element
* Screen readers rely on heading elements for heading navigation
* Overlay title components should be semantically consistent

## How

Replaces the rendered element in `PopoverTitle`:

```diff
- <div
+ <h2
```

No other behavior is changed.

## Impact

* No styling changes
* No API changes
* No visual changes
* No state changes
* No runtime behavior changes

## Checklist

* [x] Single file change
* [x] Semantic alignment only
* [x] No API changes
* [x] No visual regression
* [x] Type contract matches implementation
