### PR TITLE
test(switch): add data-slot and size variant contract tests

### DIFF
--- a/hushh-webapp/__tests__/ui/switch.test.tsx
+++ b/hushh-webapp/__tests__/ui/switch.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Switch } from "@/components/ui/switch";
+
+describe("Switch", () => {
+  it("renders with data-slot switch on root", () => {
+    render(<Switch />);
+    const el = screen.getByRole("switch");
+    expect(el.getAttribute("data-slot")).toBe("switch");
+  });
+
+  it("renders switch-thumb with data-slot switch-thumb", () => {
+    const { container } = render(<Switch />);
+    const thumb = container.querySelector('[data-slot="switch-thumb"]');
+    expect(thumb).not.toBeNull();
+  });
+
+  it("applies data-size default when no size prop is given", () => {
+    render(<Switch />);
+    const el = screen.getByRole("switch");
+    expect(el.getAttribute("data-size")).toBe("default");
+  });
+
+  it("applies data-size sm when size is sm", () => {
+    render(<Switch size="sm" />);
+    const el = screen.getByRole("switch");
+    expect(el.getAttribute("data-size")).toBe("sm");
+  });
+
+  it("applies data-size default when size is default", () => {
+    render(<Switch size="default" />);
+    const el = screen.getByRole("switch");
+    expect(el.getAttribute("data-size")).toBe("default");
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract coverage for the `Switch` primitive.

## What

New file:

`hushh-webapp/__tests__/ui/switch.test.tsx`

Coverage includes:

* Root renders with `data-slot="switch"`
* Thumb renders with `data-slot="switch-thumb"`
* Default `data-size="default"` contract
* `size="sm"` propagates to `data-size="sm"`
* Explicit `size="default"` propagates to `data-size="default"`

## Why

`Switch` exposes both `data-slot` and `data-size` contracts that are relied upon by styling and testing consumers. These contracts currently have no regression coverage.

Adding a dedicated test file ensures future refactors cannot accidentally remove or change these attributes without a visible CI failure.

## Scope

* New test file only
* No production code changes
* No new test helpers
* No API changes

## Validation

```bash
npx vitest run __tests__/ui/switch.test.tsx
```

All tests pass successfully.

## Checklist

* [x] New file only
* [x] No production code modified
* [x] No custom test utilities introduced
* [x] Covers root, thumb, and size contracts
* [x] Low conflict surface
