### PR TITLE
fix(profile-page): hide profile labeled loading icons from assistive technology

### DIFF
--- a/hushh-webapp/app/profile/page.tsx
+++ b/hushh-webapp/app/profile/page.tsx
@@ -3447,7 +3447,7 @@ function ProfilePageContent() {
 
         {vaultAccess.hasVault && loadingVaultMethod ? (
           <SurfaceInset className="flex items-center gap-2 px-4 py-4 text-sm text-muted-foreground">
-            <Icon icon={Loader2} size="sm" className="animate-spin" />
+            <Icon aria-hidden="true" icon={Loader2} size="sm" className="animate-spin" />
             Loading vault methods...
           </SurfaceInset>
         ) : null}
@@ -3773,7 +3773,7 @@ function ProfilePageContent() {
           >
             {sendingSupportMessage ? (
               <>
-                <Icon icon={Loader2} size="sm" className="mr-2 animate-spin" />
+                <Icon aria-hidden="true" icon={Loader2} size="sm" className="mr-2 animate-spin" />
                 Sending...
               </>
             ) : (
@@ -3837,7 +3837,7 @@ function ProfilePageContent() {
         >
           {savingFinancialContext ? (
             <>
-              <Icon icon={Loader2} size="sm" className="mr-2 animate-spin" />
+              <Icon aria-hidden="true" icon={Loader2} size="sm" className="mr-2 animate-spin" />
               Saving...
             </>
           ) : (
@@ -4541,6 +4541,7 @@ function ProfilePageContent() {
                 {refreshingRegulatoryProfile ? (
                   <>
                     <Icon
+                      aria-hidden="true"
                       icon={Loader2}
                       size="sm"
                       className="mr-2 animate-spin"


### PR DESCRIPTION
## Exact Surface
- File: hushh-webapp/app/profile/page.tsx
- Component: ProfilePage
- Lines changed: 3450, 3776, 3840, 4544

## Caller Proof
- Caller: hushh-webapp/app/profile/page.tsx exports ProfilePage as the Next.js App Router page component
- Route: /profile

## No Overlap Proof
- This change does not exist anywhere else: confirmed

## Narrowness Proof
- 1 file changed
- Zero props or API changed
- Change limited to hiding only the four labeled ProfilePage Loader2 icons from assistive technology.