### PR TITLE
fix(pkm-agent-lab-page-client): hide pkm agent lab capture action spinners from assistive technology

### DIFF
--- a/hushh-webapp/app/profile/pkm-agent-lab/page-client.tsx
+++ b/hushh-webapp/app/profile/pkm-agent-lab/page-client.tsx
@@ -1282,7 +1282,7 @@ export default function PkmAgentLabPageClient() {
                         data-voice-purpose="builds a preview of the current PKM capture without saving it."
                       >
                         {submitting ? (
-                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          <Loader2 aria-hidden="true" className="mr-2 h-4 w-4 animate-spin" />
                         ) : (
                           <Sparkles className="mr-2 h-4 w-4" />
                         )}
@@ -1298,7 +1298,7 @@ export default function PkmAgentLabPageClient() {
                         data-voice-label="Save PKM capture"
                         data-voice-purpose="persists the current capture into encrypted PKM storage."
                       >
-                        {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                        {saving ? <Loader2 aria-hidden="true" className="mr-2 h-4 w-4 animate-spin" /> : null}
                         {reviewRequiredCount > 0 ? "Save reviewed capture" : "Save encrypted capture"}
                       </Button>
                     </div>


### PR DESCRIPTION
## Exact Surface
- File: hushh-webapp/app/profile/pkm-agent-lab/page-client.tsx
- Component: PkmAgentLabPageClient
- Lines changed: 1285, 1301

## Caller Proof
- Caller: hushh-webapp/app/profile/pkm-agent-lab/page.tsx imports PkmAgentLabPageClient from hushh-webapp/app/profile/pkm-agent-lab/page-client.tsx
- Route: /profile/pkm-agent-lab

## No Overlap Proof
- This change does not exist anywhere else: confirmed
- Existing loading row spinners at lines 1119 and 1142 are separate SettingsRow loading surfaces and are unchanged.
- Changed lines are limited to the Generate preview and Save capture button Loader2 icons around handlePreview() and persistPreview().

## Narrowness Proof
- 1 file changed
- Zero props or API changed
- Change limited to hiding only the two capture action button Loader2 spinners from assistive technology.