### PR TITLE
test(toaster): cover decorative status icons hidden from assistive technology

### DIFF
--- a/hushh-webapp/__tests__/ui/toaster.test.tsx
+++ b/hushh-webapp/__tests__/ui/toaster.test.tsx
@@ -1,0 +1,38 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  sonnerProps: [] as Array<{ icons?: Record<string, React.ReactNode> }>,
+}));
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ theme: "light" }),
+}));
+
+vi.mock("sonner", () => ({
+  Toaster: (props: { icons?: Record<string, React.ReactNode> }) => {
+    mocks.sonnerProps.push(props);
+    return null;
+  },
+}));
+
+import { Toaster } from "@/components/ui/sonner";
+
+describe("Toaster", () => {
+  it("hides decorative status icons from assistive technology", () => {
+    render(<Toaster />);
+
+    const icons = mocks.sonnerProps.at(-1)?.icons;
+
+    expect(icons).toBeTruthy();
+    for (const status of ["success", "info", "warning", "error", "loading"]) {
+      const icon = icons?.[status];
+
+      expect(React.isValidElement(icon)).toBe(true);
+      expect(
+        React.isValidElement(icon) ? icon.props["aria-hidden"] : undefined,
+      ).toBe("true");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add UI test coverage for decorative Toaster status icons.
- Verify the shared Toaster passes `aria-hidden="true"` on success, info, warning, error, and loading status icons.

## Scope Proof
- New test file only: `hushh-webapp/__tests__/ui/toaster.test.tsx`.
- No runtime component changes.
- The test mocks Sonner and inspects the status icons passed by `components/ui/sonner`.

## Impact
Test-only change. This locks the existing Toaster accessibility behavior without changing UI output.

## Validation
- `npx.cmd vitest run __tests__/ui/toaster.test.tsx`
- Verified the commit includes a DCO `Signed-off-by` trailer.
