### PR TITLE
test(button): cover aria-busy attribute during loading state

### DIFF
--- a/hushh-webapp/__tests__/ui/button.test.tsx
+++ b/hushh-webapp/__tests__/ui/button.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Button } from "@/lib/morphy-ux/button";
+
+describe("Button", () => {
+  it("sets aria-busy during loading state", () => {
+    render(<Button loading>Save changes</Button>);
+
+    const button = screen.getByRole("button", { name: /save changes/i });
+
+    expect(button.getAttribute("aria-busy")).toBe("true");
+  });
+});


### PR DESCRIPTION
## Summary
- Add UI test coverage for the button loading accessibility contract.
- Verify the Morphy button sets `aria-busy="true"` while loading.

## Scope Proof
- New test file only: `hushh-webapp/__tests__/ui/button.test.tsx`.
- No runtime component changes.
- Covers the existing loading behavior exposed by `@/lib/morphy-ux/button`.

## Impact
Test-only change. This locks the existing loading-state accessibility behavior without changing UI output.

## Validation
- `npx.cmd vitest run __tests__/ui/button.test.tsx`
- Verified the commit includes a DCO `Signed-off-by` trailer.
