### PR TITLE
fix(ui): hide vault flow loading icons from assistive technology

### DIFF
--- a/hushh-webapp/components/vault/vault-flow.tsx
+++ b/hushh-webapp/components/vault/vault-flow.tsx
@@ -760,7 +760,7 @@ export function VaultFlow({
               >
                 {isUnlocking ? (
                   <>
-                    <Icon icon={Loader2} size="md" className="mr-2 animate-spin" /> Creating Vault...
+                    <Icon aria-hidden="true" icon={Loader2} size="md" className="mr-2 animate-spin" /> Creating Vault...
                   </>
                 ) : (
                   "Create Vault"
@@ -822,7 +822,7 @@ export function VaultFlow({
                   >
                     {isUnlocking ? (
                       <>
-                        <Icon icon={Loader2} size="sm" className="mr-2 animate-spin" /> Unlocking...
+                        <Icon aria-hidden="true" icon={Loader2} size="sm" className="mr-2 animate-spin" /> Unlocking...
                       </>
                     ) : (
                       "Unlock"
@@ -834,7 +834,7 @@ export function VaultFlow({
                   <div className="flex min-h-10 items-center justify-center rounded-xl border border-border/60 bg-muted/20 px-3 py-2 text-xs text-muted-foreground sm:text-sm">
                     {isUnlocking ? (
                       <span className="inline-flex items-center">
-                        <Icon icon={Loader2} size="sm" className="mr-2 animate-spin" />
+                        <Icon aria-hidden="true" icon={Loader2} size="sm" className="mr-2 animate-spin" />
                         Prompting {generatedUnlockLabel.toLowerCase()}...
                       </span>
                     ) : (
@@ -960,7 +960,7 @@ export function VaultFlow({
                 >
                   {isUnlocking ? (
                     <>
-                      <Icon icon={Loader2} size="sm" className="mr-2 animate-spin" /> Unlocking...
+                      <Icon aria-hidden="true" icon={Loader2} size="sm" className="mr-2 animate-spin" /> Unlocking...
                     </>
                   ) : (
                     "Unlock"
@@ -1074,7 +1074,7 @@ export function VaultFlow({
                 >
                   {isUnlocking ? (
                     <>
-                      <Icon icon={Loader2} size="md" className="mr-2 animate-spin" />
+                      <Icon aria-hidden="true" icon={Loader2} size="md" className="mr-2 animate-spin" />
                       Enabling...
                     </>
                   ) : (


### PR DESCRIPTION
## Summary
- Hide Vault Flow loading icons from assistive technology.
- Add `aria-hidden="true"` to decorative `Loader2` icons used during create, unlock, prompt, recovery, and quick-unlock states.

## Root Cause
The Vault Flow already exposes loading state through visible text such as "Creating Vault...", "Unlocking...", "Prompting...", and "Enabling...". The spinner icons are visual-only indicators and should not be announced separately.

## Impact
Accessibility-only UI change. No vault creation, unlock, recovery, or quick-unlock behavior changes.

## Scope Proof
- Touched only `hushh-webapp/components/vault/vault-flow.tsx`.
- Updated only the five decorative loading icon render sites.

## Validation
- `npx.cmd eslint components/vault/vault-flow.tsx --max-warnings=0`
- Verified the commit includes a DCO `Signed-off-by` trailer.
