### PR TITLE
test(table): cover keyboard scrolling tabIndex on overflow container

### DIFF
--- a/hushh-webapp/__tests__/ui/table.test.tsx
+++ b/hushh-webapp/__tests__/ui/table.test.tsx
@@ -1,0 +1,24 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Table } from "@/components/ui/table";
+
+describe("Table", () => {
+  it("sets tabIndex on the overflow container for keyboard scrolling", () => {
+    const { container } = render(
+      <Table>
+        <tbody>
+          <tr>
+            <td>Holding</td>
+          </tr>
+        </tbody>
+      </Table>,
+    );
+
+    const tableContainer = container.querySelector(
+      '[data-slot="table-container"]',
+    );
+
+    expect(tableContainer?.getAttribute("tabindex")).toBe("0");
+  });
+});


### PR DESCRIPTION
## Summary
- Add UI test coverage for the table overflow container keyboard scrolling contract.
- Verify the shared `Table` wrapper exposes `tabIndex="0"` on its overflow container.

## Scope Proof
- New test file only: `hushh-webapp/__tests__/ui/table.test.tsx`.
- No runtime component changes.
- Covers the existing `components/ui/table` overflow wrapper behavior directly.

## Impact
Test-only change. This locks the existing keyboard scrolling accessibility behavior without changing UI output.

## Validation
- `npx.cmd vitest run __tests__/ui/table.test.tsx`
- Verified the commit includes a DCO `Signed-off-by` trailer.
