### PR TITLE
test(sheet): cover showCloseButton=false hides close button

### DIFF
--- a/hushh-webapp/__tests__/ui/sheet.test.tsx
+++ b/hushh-webapp/__tests__/ui/sheet.test.tsx
@@ -31,6 +31,7 @@ describe("SheetContent", () => {
       </Sheet>,
     );
 
+    expect(screen.getByText("Test sheet")).toBeTruthy();
     expect(
       screen.queryByRole("button", { name: /close/i }),
     ).toBeNull();


### PR DESCRIPTION
## Summary
- Strengthen SheetContent test coverage for `showCloseButton={false}`.
- Verify the sheet title still renders while the accessible close button is hidden.

## Scope Proof
- Touched only `hushh-webapp/__tests__/ui/sheet.test.tsx`.
- Test-only change with no runtime component changes.
- The existing hide-close-button assertion remains in place.

## Impact
No UI behavior changes. This only locks the existing SheetContent close-button hiding behavior.

## Validation
- `npx.cmd vitest run __tests__/ui/sheet.test.tsx`
- Verified the commit includes a DCO `Signed-off-by` trailer.
