### PR TITLE
fix(streaming-progress-view): hide streaming progress fallback loader from assistive technology

### DIFF
--- a/hushh-webapp/components/kai/views/streaming-progress-view.tsx
+++ b/hushh-webapp/components/kai/views/streaming-progress-view.tsx
@@ -376,7 +376,7 @@ export function StreamingProgressView({
           ) : isError ? (
             <Icon icon={AlertCircle} size="sm" />
           ) : (
-            icon || <Icon icon={Loader2} size="sm" className={cn(isActive && "animate-spin")} />
+            icon || <Icon aria-hidden="true" icon={Loader2} size="sm" className={cn(isActive && "animate-spin")} />
           )}
         </div>
         <span className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Exact Surface
- File: hushh-webapp/components/kai/views/streaming-progress-view.tsx
- Component: StreamingProgressView
- Lines changed: 375

## Caller Proof
- Caller: hushh-webapp/components/kai/agent-analysis-card.tsx imports StreamingProgressView from hushh-webapp/components/kai/views/streaming-progress-view.tsx
- Route: /kai/analysis via hushh-webapp/app/kai/analysis/page.tsx

## No Overlap Proof
- This change does not exist anywhere else: confirmed

## Narrowness Proof
- 1 file changed
- Zero props or API changed
- Change limited to hiding only the fallback Loader2 icon from assistive technology.