### PR TITLE
fix(ui): change PopoverTitle element from div to h2 to match its ComponentProps typing

### DIFF
--- a/hushh-webapp/components/ui/popover.tsx
+++ b/hushh-webapp/components/ui/popover.tsx
@@ -58,7 +58,7 @@ function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
 
 function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
   return (
-    <div
+    <h2
       data-slot="popover-title"
       className={cn("font-medium", className)}
       {...props}


### PR DESCRIPTION
The `PopoverTitle` component featured a semantic and TypeScript typing mismatch bug. 

It was explicitly typing its props as `React.ComponentProps<"h2">` (signaling to consumers that it accepts standard heading attributes), but it was incorrectly rendering a generic `<div>` element to the DOM instead of an `<h2>`. 

By changing the returned element to an `<h2>`, we resolve the TypeScript/DOM mismatch and correctly restore standard HTML heading semantics for accessibility tools parsing Popover titles.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None specifically (generic UI component)
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None (Pure UI Primitive)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — generic UI Popover component.
- [x] Reachable production attach point: components/ui/popover.tsx
- [x] Production surface proved: explicit TS/DOM semantic mapping fix, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/ui/popover.tsx)
- [x] **iOS**: Not applicable — Web DOM states
- [x] **Android**: Not applicable — Web DOM states

## 🧪 Testing

- [x] Tested on Web (Verified PopoverTitle now correctly renders an h2 tag to the DOM, satisfying its TypeScript contract and A11y standards)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Restores correct HTML h2 semantics to PopoverTitle to match TS typings.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none