### PR TITLE
fix(ui): remove conflicting outline class from ScrollArea to fix double-focus ring

### DIFF
--- a/hushh-webapp/components/ui/scroll-area.tsx
+++ b/hushh-webapp/components/ui/scroll-area.tsx
@@ -19,7 +19,7 @@ function ScrollArea({
       <ScrollAreaPrimitive.Viewport
         tabIndex={0}
         data-slot="scroll-area-viewport"
-        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px]"
       >
         {children}
       </ScrollAreaPrimitive.Viewport>


### PR DESCRIPTION
The `ScrollArea` viewport featured a visual bug where conflicting focus indicators caused an ugly double-ring effect. 

The viewport was simultaneously defining a smooth Shadcn UI ring (`focus-visible:ring-[3px]`) AND a harsh system outline (`focus-visible:outline-1`). When focused via keyboard, this drew a sharp 1px outline straight through the beautiful 3px shadow ring, creating a messy, unpolished focus state that ignored the `rounded-[inherit]` corner radiuses. 

By removing the redundant `outline-1` class, we restore the pure, unblemished aesthetic of the standard design system focus ring.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None specifically (generic UI component)
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None (Pure UI Primitive)
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable
- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — generic UI ScrollArea component.
- [x] Reachable production attach point: components/ui/scroll-area.tsx
- [x] Production surface proved: explicit CSS focus state fix, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/ui/scroll-area.tsx)
- [x] **iOS**: Not applicable — Web keyboard focus states
- [x] **Android**: Not applicable — Web keyboard focus states

## 🧪 Testing

- [x] Tested on Web (Verified ScrollArea viewport now uses the pure shadow-based ring when focused, without the conflicting harsh 1px outline)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Fixes conflicting double-focus ring on ScrollArea.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed