### PR TITLE
fix(ui): use bg-muted instead of bg-accent for Skeletons to fix semantic visual hierarchy

### DIFF
--- a/hushh-webapp/components/ui/skeleton.tsx
+++ b/hushh-webapp/components/ui/skeleton.tsx
@@ -6,7 +6,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
       aria-hidden="true"
       data-slot="skeleton"
       className={cn(
-        "pointer-events-none overflow-hidden rounded-md bg-accent motion-safe:animate-pulse [contain:layout_paint]",
+        "pointer-events-none overflow-hidden rounded-md bg-muted motion-safe:animate-pulse [contain:layout_paint]",
         className
       )}
       {...props}


### PR DESCRIPTION
The `Skeleton` component was incorrectly styled with the `bg-accent` color token, violating visual hierarchy guidelines. 

Because `bg-accent` is strictly reserved by the design system for active/interactive hover states (e.g., hovering over dropdown items or buttons), using it for skeletons made loading placeholders visually look like selected or interactive elements. 

Changing it to `bg-muted` correctly styles them as static background placeholders, restoring standard UI color semantics and matching other fallback components like `AvatarFallback`.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None specifically (generic UI component)
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None (Pure UI Primitive)
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable
- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — generic UI Skeleton component.
- [x] Reachable production attach point: components/ui/skeleton.tsx
- [x] Production surface proved: explicit CSS token override fix, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/ui/skeleton.tsx)
- [x] **iOS**: Not applicable — Web color tokens
- [x] **Android**: Not applicable — Web color tokens

## 🧪 Testing

- [x] Tested on Web (Verified Skeleton now correctly uses the muted background color for its pulse animation instead of the contrasting accent color)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Restores correct `bg-muted` color token to Skeletons.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed