### PR TITLE
test(vault): require passphrase wrapper in setup payload

### DIFF
--- a/hushh-webapp/__tests__/api/consent-vault-json-validation.test.ts
+++ b/hushh-webapp/__tests__/api/consent-vault-json-validation.test.ts
@@ -14,6 +14,14 @@ function malformedPost(path: string): NextRequest {
   });
 }
 
+function vaultSetupPost(body: unknown): NextRequest {
+  return new NextRequest("http://localhost:3000/api/vault/setup", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
 async function expectInvalidJson(response: Response) {
   expect(response.status).toBe(400);
   await expect(response.json()).resolves.toEqual({
@@ -26,6 +34,32 @@ describe("malformed JSON route handling", () => {
     await expectInvalidJson(
       await setupVault(malformedPost("/api/vault/setup")),
     );
+  });
+
+  it("rejects vault setup payloads without a passphrase wrapper", async () => {
+    const response = await setupVault(
+      vaultSetupPost({
+        userId: "user_1",
+        vaultKeyHash: "hash",
+        primaryMethod: "passkey",
+        recoveryEncryptedVaultKey: "encrypted",
+        recoverySalt: "salt",
+        recoveryIv: "iv",
+        wrappers: [
+          {
+            method: "passkey",
+            encryptedVaultKey: "encrypted",
+            salt: "salt",
+            iv: "iv",
+          },
+        ],
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Passphrase wrapper is required",
+    });
   });
 
   it.each([


### PR DESCRIPTION
## Summary

Adds test coverage for vault setup validation when no passphrase wrapper is provided.

### Changes Made

* Added a test case for vault setup requests that contain wrappers but omit the required passphrase wrapper.
* Verified the route returns a `400 Bad Request` response.
* Verified the expected validation error message is returned.
* Expanded vault setup validation coverage to include passphrase wrapper requirements.

## Test

```bash
npx vitest run __tests__/api/consent-vault-json-validation.test.ts
```
