### PR TITLE
fix(ui): correct Tooltip sideOffset to prevent arrow from overlapping trigger elements

### DIFF
--- a/hushh-webapp/components/ui/tooltip.tsx
+++ b/hushh-webapp/components/ui/tooltip.tsx
@@ -32,7 +32,7 @@ function TooltipTrigger({
 
 function TooltipContent({
   className,
-  sideOffset = 0,
+  sideOffset = 4,
   children,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content>) {


### PR DESCRIPTION
The `Tooltip` component featured a layout overlapping bug where its arrow would physically overlap the trigger element. 

The `TooltipContent` was explicitly hardcoded to `sideOffset = 0`, forcing the tooltip's bounding box to sit completely flush against the trigger. Because the Tooltip arrow (`size-2.5`) protrudes outward from the bounding box by several pixels, setting the offset to 0 caused the arrow geometry to stab into and overlap the trigger button/icon beneath it. 

Changing the default offset to `4` properly accommodates the arrow geometry, restoring a clean separation between the tooltip and the trigger.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None specifically (generic UI component)
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None (Pure UI Primitive)
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable
- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — generic UI Tooltip component.
- [x] Reachable production attach point: components/ui/tooltip.tsx
- [x] Production surface proved: explicit CSS offset/geometry fix, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/ui/tooltip.tsx)
- [x] **iOS**: Not applicable — Web DOM Layout Offsets
- [x] **Android**: Not applicable — Web DOM Layout Offsets

## 🧪 Testing

- [x] Tested on Web (Verified Tooltip arrow no longer overlaps the trigger element by properly offsetting the content box)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Fixes Tooltip arrow overlapping trigger element.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed