### PR TITLE
fix(ui): remove hardcoded button size in Carousel navigation to fix broken size prop

### DIFF
--- a/hushh-webapp/components/ui/carousel.tsx
+++ b/hushh-webapp/components/ui/carousel.tsx
@@ -179,7 +179,7 @@ function CarouselItem({ className, ...props }: React.ComponentProps<"div">) {
 function CarouselPrevious({
   className,
   variant = "outline",
-  size = "icon",
+  size = "icon-sm",
   ...props
 }: React.ComponentProps<typeof Button>) {
   const { orientation, scrollPrev, canScrollPrev } = useCarousel()
@@ -190,7 +190,7 @@ function CarouselPrevious({
       variant={variant}
       size={size}
       className={cn(
-        "absolute size-8 rounded-full",
+        "absolute rounded-full",
         orientation === "horizontal"
           ? "top-1/2 -left-12 -translate-y-1/2"
           : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
@@ -209,7 +209,7 @@ function CarouselPrevious({
 function CarouselNext({
   className,
   variant = "outline",
-  size = "icon",
+  size = "icon-sm",
   ...props
 }: React.ComponentProps<typeof Button>) {
   const { orientation, scrollNext, canScrollNext } = useCarousel()
@@ -220,7 +220,7 @@ function CarouselNext({
       variant={variant}
       size={size}
       className={cn(
-        "absolute size-8 rounded-full",
+        "absolute rounded-full",
         orientation === "horizontal"
           ? "top-1/2 -right-12 -translate-y-1/2"
           : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",


### PR DESCRIPTION
The `CarouselPrevious` and `CarouselNext` components featured a CSS prop override bug where the size of the navigation buttons was violently hardcoded. 

The components explicitly exposed a `size` prop (defaulting to `"icon"`), but they improperly hardcoded the `size-8` utility class directly into their internal `cn()` merge list. This forcefully overrode whatever size the developer passed in via props (e.g. `size="icon-lg"`), permanently locking the buttons at 32px regardless of design intent. 

We resolved this by removing the hardcoded `size-8` override and changing the default prop value to `"icon-sm"`, which natively evaluates to `size-8` in the `buttonVariants` design system. This preserves the original 32px design intent while finally allowing the `size` prop to function as expected.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None specifically (generic UI component)
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None (Pure UI Primitive)
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable
- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — generic UI Carousel component.
- [x] Reachable production attach point: components/ui/carousel.tsx
- [x] Production surface proved: explicit CSS class override fix, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/ui/carousel.tsx)
- [x] **iOS**: Not applicable — Web DOM element sizing
- [x] **Android**: Not applicable — Web DOM element sizing

## 🧪 Testing

- [x] Tested on Web (Verified Carousel buttons correctly render at 32px by default via the `icon-sm` variant, and now correctly respect arbitrary sizes passed via the `size` prop)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Fixes `CarouselNext` and `CarouselPrevious` size prop CSS override bug.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed