### PR TITLE
Remove Jhumma from hushh-research update routing

### DIFF
--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -17,8 +17,7 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx",
-      "Jhumma-hushh"
+      "azfx"
     ],
     "review_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_required": true,
@@ -29,15 +28,13 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx",
-      "Jhumma-hushh"
+      "azfx"
     ],
     "protected_pipeline_edit_users": [
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx",
-      "Jhumma-hushh"
+      "azfx"
     ],
     "protected_pipeline_paths": [
       ".github/workflows/",
@@ -57,8 +54,7 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx",
-      "Jhumma-hushh"
+      "azfx"
     ],
     "review_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_required": true,
@@ -69,8 +65,7 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx",
-      "Jhumma-hushh"
+      "azfx"
     ]
   },
   "uat": {
@@ -81,8 +76,7 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx",
-      "Jhumma-hushh"
+      "azfx"
     ]
   },
   "production": {


### PR DESCRIPTION
## Summary
- remove Jhumma-hushh from hushh-research review/deploy governance allowlists
- keep repository access untouched
- pair with live settings change that removed the user from branch bypass allowances and the maintainer notification team

## Verification
- branch protection bypass lists for main and integration/pr-train now omit Jhumma-hushh
- allowed-maintainers-to-approve membership for Jhumma-hushh was removed live
