### PR TITLE
test(vault): cover empty wrapper validation

### DIFF
--- a/hushh-webapp/__tests__/api/consent-vault-json-validation.test.ts
+++ b/hushh-webapp/__tests__/api/consent-vault-json-validation.test.ts
@@ -14,6 +14,14 @@ function malformedPost(path: string): NextRequest {
   });
 }
 
+function vaultSetupPost(body: unknown): NextRequest {
+  return new NextRequest("http://localhost:3000/api/vault/setup", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
 async function expectInvalidJson(response: Response) {
   expect(response.status).toBe(400);
   await expect(response.json()).resolves.toEqual({
@@ -26,6 +34,25 @@ describe("malformed JSON route handling", () => {
     await expectInvalidJson(
       await setupVault(malformedPost("/api/vault/setup")),
     );
+  });
+
+  it("rejects vault setup payloads with empty wrappers", async () => {
+    const response = await setupVault(
+      vaultSetupPost({
+        userId: "user_1",
+        vaultKeyHash: "hash",
+        primaryMethod: "passphrase",
+        recoveryEncryptedVaultKey: "encrypted",
+        recoverySalt: "salt",
+        recoveryIv: "iv",
+        wrappers: [],
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Missing required vault state fields",
+    });
   });
 
   it.each([

--- a/hushh-webapp/__tests__/api/vault-check-db-unavailable.test.ts
+++ b/hushh-webapp/__tests__/api/vault-check-db-unavailable.test.ts
@@ -37,4 +37,16 @@ describe("GET /api/vault/check database unavailable", () => {
     expect(payload.code).toBe("DATABASE_UNAVAILABLE");
     expect(payload.hint).toContain("proxy-aware launcher");
   });
+  it("rejects missing userId before backend work", async () => {
+  global.fetch = vi.fn();
+
+  const route = await import("../../app/api/vault/check/route");
+  const request = new NextRequest("http://localhost:3000/api/vault/check");
+  const response = await route.GET(request);
+  const payload = await response.json();
+
+  expect(response.status).toBe(400);
+ expect(payload.error).toBe("userId required");
+  expect(global.fetch).not.toHaveBeenCalled();
+});
 });


### PR DESCRIPTION
## Summary

Adds test coverage for vault setup validation when the wrappers array is empty.

### Changes Made

* Added a test case for vault setup requests with an empty `wrappers` array.
* Verified the route returns a `400 Bad Request` response.
* Verified the expected validation error message is returned.
* Expanded vault setup validation coverage for required wrapper configuration.

## Test

```bash
npx vitest run __tests__/api/consent-vault-json-validation.test.ts
```
