### PR TITLE
Remove Jhumma from hushh-research main update routing

### DIFF
--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -17,8 +17,7 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx",
-      "Jhumma-hushh"
+      "azfx"
     ],
     "review_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_required": true,
@@ -29,15 +28,13 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx",
-      "Jhumma-hushh"
+      "azfx"
     ],
     "protected_pipeline_edit_users": [
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx",
-      "Jhumma-hushh"
+      "azfx"
     ],
     "protected_pipeline_paths": [
       ".github/workflows/",
@@ -57,8 +54,7 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx",
-      "Jhumma-hushh"
+      "azfx"
     ],
     "review_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_required": true,
@@ -69,8 +65,7 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx",
-      "Jhumma-hushh"
+      "azfx"
     ]
   },
   "uat": {
@@ -81,8 +76,7 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx",
-      "Jhumma-hushh"
+      "azfx"
     ]
   },
   "production": {


### PR DESCRIPTION
## Summary
- remove Jhumma-hushh from hushh-research governance allowlists on main
- keep repository access untouched
- follows the allowed maintainer promotion branch policy for main

## Verification
- live branch protection bypass users now omit Jhumma-hushh for main and integration/pr-train
- integration/pr-train config cleanup landed in #2943
- this PR carries the same one-file config cleanup to main

Signed-off-by: Ankit Kumar Singh <94732725+ankitkumarsingh1702@users.noreply.github.com>
