### PR TITLE
fix(world-model): bound proxy path parameters

### DIFF
--- a/hushh-webapp/app/api/world-model/[...path]/route.ts
+++ b/hushh-webapp/app/api/world-model/[...path]/route.ts
@@ -18,6 +18,17 @@ async function proxyWorldModelRequest(
 
   try {
     const { path } = await paramsPromise;
+    if (
+      path.length === 0 ||
+      path.length > 8 ||
+      path.some((segment) => segment.length > 128)
+    ) {
+      return withRequestIdJson(
+        requestId,
+        { error: "Invalid world model API path" },
+        { status: 400 }
+      );
+    }
     const pathStr = path.join("/");
     const query = request.nextUrl.search;
     const backendUrl = `${getPythonApiUrl()}/api/world-model/${pathStr}${query}`;


### PR DESCRIPTION
## Summary

Add bounds validation for world model proxy path parameters.

## What Changed

* Reject empty world model proxy paths.
* Reject paths with more than 8 segments.
* Reject individual path segments longer than 128 characters.
* Return a `400` response for invalid world model API paths before constructing the upstream request URL.

## Why

The world model proxy previously accepted arbitrary path depth and segment lengths. Adding validation helps prevent excessively large path inputs from reaching the upstream proxy layer and aligns with existing route hardening efforts.

## Testing

* `npm run lint`
* `npm run typecheck`

## Risk

Low. Valid world model API paths continue to function normally. Only malformed or excessively large path inputs are rejected.
