### PR TITLE
fix(ui): remove hardcoded sr-only DialogDescription hack from DialogContent to restore genuine accessibility labeling

### DIFF
--- a/hushh-webapp/components/ui/dialog.tsx
+++ b/hushh-webapp/components/ui/dialog.tsx
@@ -68,10 +68,6 @@ function DialogContent({
         )}
         {...props}
       >
-        <DialogDescription className="sr-only">
-          Dialog content
-        </DialogDescription>
-
         {children}
 
         {showCloseButton && (


### PR DESCRIPTION
The `Dialog` component featured a severe accessibility (A11y) hack. 

The `DialogContent` component aggressively hardcoded a visually hidden `DialogDescription` reading "Dialog content" into every single dialog rendered by the application. While this suppresses Radix UI's development-mode warnings for missing descriptions, it completely destroys the screen reader experience. It forces every dialog (whether it's "Edit Profile" or "Confirm Deletion") to announce itself identically as "Dialog content", rendering the accessibility label completely useless. 

Furthermore, if a developer provided their own actual `DialogDescription` as a child, the dialog would possess conflicting duplicate descriptions. Removing this hack restores Radix's intended behavior: developers must explicitly provide context-specific descriptions where necessary.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None specifically (generic UI component)
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None (Pure UI Primitive)
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable
- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — generic UI Dialog component.
- [x] Reachable production attach point: components/ui/dialog.tsx
- [x] Production surface proved: explicit A11y DOM hack removal, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/ui/dialog.tsx)
- [x] **iOS**: Not applicable — Web DOM Accessibility nodes
- [x] **Android**: Not applicable — Web DOM Accessibility nodes

## 🧪 Testing

- [x] Tested on Web (Verified DialogContent no longer forces a useless hidden description on every dialog, correctly relying on developers to pass their own descriptions for valid screen reader experiences)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Removes `sr-only` A11y hack from Dialog Content.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed