### PR TITLE
test(vault): cover missing userId validation

### DIFF
--- a/hushh-webapp/__tests__/api/vault-check-db-unavailable.test.ts
+++ b/hushh-webapp/__tests__/api/vault-check-db-unavailable.test.ts
@@ -37,15 +37,16 @@ describe("GET /api/vault/check database unavailable", () => {
     expect(payload.code).toBe("DATABASE_UNAVAILABLE");
     expect(payload.hint).toContain("proxy-aware launcher");
   });
-    it("renders title when description is omitted", () => {
-    render(
-      <Dialog open>
-        <DialogContent>
-          <DialogTitle>Title only dialog</DialogTitle>
-        </DialogContent>
-      </Dialog>,
-    );
+    it("rejects missing userId before backend work", async () => {
+  global.fetch = vi.fn();
 
-    expect(screen.getByText("Title only dialog")).toBeTruthy();
-  });
+  const route = await import("../../app/api/vault/check/route");
+  const request = new NextRequest("http://localhost:3000/api/vault/check");
+  const response = await route.GET(request);
+  const payload = await response.json();
+
+  expect(response.status).toBe(400);
+  expect(payload.error).toBe("userId required");
+  expect(global.fetch).not.toHaveBeenCalled();
+});
 });

--- a/hushh-webapp/__tests__/api/vault-check-db-unavailable.test.ts
+++ b/hushh-webapp/__tests__/api/vault-check-db-unavailable.test.ts
@@ -37,4 +37,15 @@ describe("GET /api/vault/check database unavailable", () => {
     expect(payload.code).toBe("DATABASE_UNAVAILABLE");
     expect(payload.hint).toContain("proxy-aware launcher");
   });
+    it("renders title when description is omitted", () => {
+    render(
+      <Dialog open>
+        <DialogContent>
+          <DialogTitle>Title only dialog</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    expect(screen.getByText("Title only dialog")).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary

Adds test coverage for vault check validation when the required `userId` query parameter is missing.

### Changes Made

* Added a test case for `GET /api/vault/check` requests without a `userId`.
* Verified the route returns a `400 Bad Request` response.
* Verified the expected validation error is returned.
* Confirmed backend requests are not executed when required input is missing.
* Expanded validation coverage for vault API routes.

## Test

```bash
npx vitest run __tests__/api/vault-check-db-unavailable.test.ts
```
