### PR TITLE
Test/account export proxy validation

### DIFF
--- a/hushh-webapp/__tests__/api/account-export-proxy.test.ts
+++ b/hushh-webapp/__tests__/api/account-export-proxy.test.ts
@@ -58,12 +58,12 @@ describe("GET /api/account/export proxy", () => {
 
     expect(response.status).toBe(200);
     expect(fetchMock).toHaveBeenCalledWith(
-     "http://backend.test/api/account/export"
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          Authorization: "Bearer HCT:test",
-        }),
-      }),
-    );
+  "http://backend.test/api/account/export",
+  expect.objectContaining({
+    headers: expect.objectContaining({
+      Authorization: "Bearer HCT:test",
+    }),
+  }),
+);
   });
 });

--- a/hushh-webapp/__tests__/api/account-export-proxy.test.ts
+++ b/hushh-webapp/__tests__/api/account-export-proxy.test.ts
@@ -45,4 +45,25 @@ describe("GET /api/account/export proxy", () => {
     expect(response.status).toBe(502);
     expect(payload).toEqual({ error: "Invalid response from backend" });
   });
+    it("forwards the authorization header to the backend", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        Response.json({ downloadUrl: "https://example.com/export.json" }),
+      );
+
+    const response = await route.GET(
+      request({ Authorization: "Bearer HCT:test" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://backend.test/db/account/export",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer HCT:test",
+        }),
+      }),
+    );
+  });
 });

--- a/hushh-webapp/__tests__/api/account-export-proxy.test.ts
+++ b/hushh-webapp/__tests__/api/account-export-proxy.test.ts
@@ -58,7 +58,7 @@ describe("GET /api/account/export proxy", () => {
 
     expect(response.status).toBe(200);
     expect(fetchMock).toHaveBeenCalledWith(
-      "http://backend.test/db/account/export",
+     "http://backend.test/api/account/export"
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: "Bearer HCT:test",


### PR DESCRIPTION
## Summary

Adds coverage for account export proxy authorization forwarding.

### Changes Made

* Added a test to verify the account export proxy forwards the `Authorization` header to the backend request.
* Validated that authenticated export requests preserve the caller's auth context.
* Expanded proxy route coverage for backend request construction.

## Test

```bash
npx vitest run __tests__/api/account-export-proxy.test.ts
```
