### PR TITLE
test(switch): add data-slot contract test

### DIFF
--- a/hushh-webapp/__tests__/ui/switch.test.tsx
+++ b/hushh-webapp/__tests__/ui/switch.test.tsx
@@ -1,0 +1,34 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Switch } from "@/components/ui/switch";
+
+describe("Switch", () => {
+  it("renders root with data-slot='switch'", () => {
+    const { container } = render(<Switch />);
+
+    expect(container.querySelector('[data-slot="switch"]')).toBeTruthy();
+  });
+
+  it("renders thumb with data-slot='switch-thumb'", () => {
+    const { container } = render(<Switch />);
+
+    expect(container.querySelector('[data-slot="switch-thumb"]')).toBeTruthy();
+  });
+
+  it("defaults to data-size='default'", () => {
+    const { container } = render(<Switch />);
+
+    const root = container.querySelector('[data-slot="switch"]');
+
+    expect(root?.getAttribute("data-size")).toBe("default");
+  });
+
+  it("propagates size='sm' as data-size='sm'", () => {
+    const { container } = render(<Switch size="sm" />);
+
+    const root = container.querySelector('[data-slot="switch"]');
+
+    expect(root?.getAttribute("data-size")).toBe("sm");
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract coverage for the `Switch` primitive.

## What

New file:

`hushh-webapp/__tests__/ui/switch.test.tsx`

Tests:

* `data-slot="switch"` on the root element
* `data-slot="switch-thumb"` on the thumb element
* Default `data-size="default"` contract
* `size="sm"` propagates to `data-size="sm"`

## Why

`Switch` exposes both `data-slot` and `data-size` contracts that are relied upon by styling and test selectors. These contracts currently have no dedicated regression coverage.

This test ensures future refactors cannot accidentally remove or change these attributes without a visible CI failure.

## Scope

* New test file only
* No production code changes
* No API changes
* No behavior changes

## Validation

```bash
npx vitest run __tests__/ui/switch.test.tsx
```

All tests pass successfully.

## Checklist

* [x] New file only
* [x] No production code modified
* [x] No custom test utilities introduced
* [x] Covers slot and size contracts
* [x] Low conflict surface
