### PR TITLE
test(privacy): cover metadata redaction boundary

### DIFF
--- a/hushh-webapp/__tests__/services/observability-log-redactor.test.ts
+++ b/hushh-webapp/__tests__/services/observability-log-redactor.test.ts
@@ -25,6 +25,29 @@ describe("observability log redactor", () => {
     expect(redactObservabilityLogValue(value)).toBe(value);
   });
 
+  it("redacts sensitive metadata values while preserving safe diagnostic fields", () => {
+    const metadataLog = JSON.stringify({
+      event: "consent_export_attempt",
+      route: "/consents",
+      actor: "investor",
+      user_email: "privacy@example.com",
+      vault_key: "vault_sensitive_metadata_key_001",
+      session_token: "Bearer abcdefghijklmnopqrstuvwxyz123456",
+    });
+
+    const redacted = redactObservabilityLog(metadataLog);
+
+    expect(redacted).toContain('"event":"consent_export_attempt"');
+    expect(redacted).toContain('"route":"/consents"');
+    expect(redacted).toContain('"actor":"investor"');
+    expect(redacted).toContain("[REDACTED_EMAIL]");
+    expect(redacted).toContain("[REDACTED_VAULT_KEY]");
+    expect(redacted).toContain("Bearer [REDACTED_TOKEN]");
+    expect(redacted).not.toContain("privacy@example.com");
+    expect(redacted).not.toContain("vault_sensitive_metadata_key_001");
+    expect(redacted).not.toContain("abcdefghijklmnopqrstuvwxyz123456");
+  });
+
   it("keeps analytics payload sanitization owned by the schema", () => {
     const result = validateAndSanitizeEvent("auth_failed", {
       env: "uat",


### PR DESCRIPTION
## Overview

Adds one focused assertion to the existing observability log redactor test contract. The test verifies that metadata-shaped diagnostic payloads redact sensitive values while preserving safe fields needed for debugging.

## Impact

Low risk: this is a test-only change in an existing test file attached to the existing production redaction helper. It changes no runtime code, schemas, APIs, or UI behavior, while strengthening coverage that prevents sensitive metadata from leaking through observability logs.

## Changes Cleared

- Updated `hushh-webapp/__tests__/services/observability-log-redactor.test.ts`
- Added coverage for sensitive metadata value redaction
- Confirmed safe diagnostic fields remain available after redaction

## Verification

- `cd hushh-webapp && npm run test:ci -- __tests__/services/observability-log-redactor.test.ts`