### PR TITLE
test(checkbox): add data-slot contract test

### DIFF
--- a/hushh-webapp/__tests__/ui/checkbox.test.tsx
+++ b/hushh-webapp/__tests__/ui/checkbox.test.tsx
@@ -1,0 +1,20 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Checkbox } from "@/components/ui/checkbox";
+
+describe("Checkbox", () => {
+  it("renders root with data-slot='checkbox'", () => {
+    const { container } = render(<Checkbox />);
+
+    expect(container.querySelector('[data-slot="checkbox"]')).toBeTruthy();
+  });
+
+  it("renders indicator with data-slot='checkbox-indicator'", () => {
+    const { container } = render(<Checkbox checked />);
+
+    expect(
+      container.querySelector('[data-slot="checkbox-indicator"]'),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract coverage for the `Checkbox` primitive.

## What

New file:

`hushh-webapp/__tests__/ui/checkbox.test.tsx`

Tests:

* `data-slot="checkbox"` on the root element
* `data-slot="checkbox-indicator"` on the indicator element when checked

## Why

`Checkbox` exposes both root and indicator slot contracts that are relied upon by styling and test selectors. These contracts currently have no dedicated regression coverage.

The indicator assertion renders the component with `checked` to ensure the Radix indicator is mounted in the DOM before asserting on its slot contract.

## Scope

* New test file only
* No production code changes
* No API changes
* No behavior changes

## Validation

```bash
npx vitest run __tests__/ui/checkbox.test.tsx
```

All tests pass successfully.

## Checklist

* [x] New file only
* [x] No production code modified
* [x] No custom test utilities introduced
* [x] Covers root and indicator slot contracts
* [x] Low conflict surface
