### PR TITLE
test(radio-group): add data-slot contract test

### DIFF
--- a/hushh-webapp/__tests__/ui/radio-group.test.tsx
+++ b/hushh-webapp/__tests__/ui/radio-group.test.tsx
@@ -1,0 +1,40 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+
+describe("RadioGroup", () => {
+  it("renders root with data-slot='radio-group'", () => {
+    const { container } = render(
+      <RadioGroup defaultValue="a">
+        <RadioGroupItem value="a" />
+      </RadioGroup>,
+    );
+
+    expect(container.querySelector('[data-slot="radio-group"]')).toBeTruthy();
+  });
+
+  it("renders item with data-slot='radio-group-item'", () => {
+    const { container } = render(
+      <RadioGroup defaultValue="a">
+        <RadioGroupItem value="a" />
+      </RadioGroup>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="radio-group-item"]'),
+    ).toBeTruthy();
+  });
+
+  it("renders indicator with data-slot='radio-group-indicator' when item is checked", () => {
+    const { container } = render(
+      <RadioGroup defaultValue="a">
+        <RadioGroupItem value="a" />
+      </RadioGroup>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="radio-group-indicator"]'),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract coverage for the `RadioGroup` primitive.

## What

New file:

`hushh-webapp/__tests__/ui/radio-group.test.tsx`

Tests:

* `data-slot="radio-group"` on the root element
* `data-slot="radio-group-item"` on the item element
* `data-slot="radio-group-indicator"` on the indicator element when selected

## Why

`RadioGroup` exposes root, item, and indicator slot contracts that are relied upon by styling and test selectors. These contracts currently have no dedicated regression coverage.

The indicator assertion uses `defaultValue="a"` together with a matching item value to ensure the selected indicator is mounted before asserting on its slot contract.

## Scope

* New test file only
* No production code changes
* No API changes
* No behavior changes

## Validation

```bash
npx vitest run __tests__/ui/radio-group.test.tsx
```

All tests pass successfully.

## Checklist

* [x] New file only
* [x] No production code modified
* [x] No custom test utilities introduced
* [x] Covers root, item, and indicator slot contracts
* [x] Low conflict surface
