### PR TITLE
test(label): add data-slot contract test

### DIFF
--- a/hushh-webapp/__tests__/ui/label.test.tsx
+++ b/hushh-webapp/__tests__/ui/label.test.tsx
@@ -1,0 +1,20 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Label } from "@/components/ui/label";
+
+describe("Label", () => {
+  it("renders with data-slot='label'", () => {
+    const { container } = render(<Label>Email</Label>);
+
+    expect(container.querySelector('[data-slot="label"]')).toBeTruthy();
+  });
+
+  it("applies disabled peer styling class", () => {
+    const { container } = render(<Label>Email</Label>);
+
+    const label = container.querySelector('[data-slot="label"]');
+
+    expect(label?.className).toContain("peer-disabled:opacity-50");
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract coverage for the Label primitive.

## What

New file:

`hushh-webapp/__tests__/ui/label.test.tsx`

Tests:

* Verifies `data-slot="label"` is rendered
* Verifies the `peer-disabled:opacity-50` styling contract is present

## Why

Label is a small shared UI primitive that currently has no dedicated contract coverage.

The component exposes a `data-slot` contract used by styling and testing surfaces, and includes a disabled-peer styling contract through `peer-disabled:opacity-50`.

This test protects those contracts from accidental regressions.

## Scope

* New test file only
* No production code changes
* No API changes
* No behavior changes

## Validation

```bash
npx vitest run __tests__/ui/label.test.tsx
```

All tests pass successfully.

## Checklist

* [x] New file only
* [x] No production code modified
* [x] No custom test utilities introduced
* [x] Covers slot and styling contracts
* [x] Low conflict surface
