### PR TITLE
refactor(ui): add safe haptic fallback wrapper

### DIFF
--- a/hushh-webapp/__tests__/utils/haptic-utils.test.ts
+++ b/hushh-webapp/__tests__/utils/haptic-utils.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  isBrowserVibrationSupported,
+  triggerToggleHaptic,
+} from "@/lib/utils/haptic-utils";
+
+const originalVibrateDescriptor = Object.getOwnPropertyDescriptor(
+  Navigator.prototype,
+  "vibrate"
+);
+
+function setNavigatorVibrate(value: unknown): void {
+  Object.defineProperty(Navigator.prototype, "vibrate", {
+    configurable: true,
+    value,
+  });
+}
+
+describe("haptic utils", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+
+    if (originalVibrateDescriptor) {
+      Object.defineProperty(
+        Navigator.prototype,
+        "vibrate",
+        originalVibrateDescriptor
+      );
+    } else {
+      delete (Navigator.prototype as Partial<Navigator>).vibrate;
+    }
+  });
+
+  it("returns false without logging when vibration is unsupported", () => {
+    delete (Navigator.prototype as Partial<Navigator>).vibrate;
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    expect(isBrowserVibrationSupported()).toBe(false);
+    expect(triggerToggleHaptic()).toBe(false);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("triggers the browser vibration API with the default toggle pattern", () => {
+    const vibrate = vi.fn().mockReturnValue(true);
+    setNavigatorVibrate(vibrate);
+
+    expect(isBrowserVibrationSupported()).toBe(true);
+    expect(triggerToggleHaptic()).toBe(true);
+    expect(vibrate).toHaveBeenCalledWith(10);
+  });
+
+  it("sanitizes malformed vibration patterns before calling the browser API", () => {
+    const vibrate = vi.fn().mockReturnValue(true);
+    setNavigatorVibrate(vibrate);
+
+    expect(triggerToggleHaptic([12, -1, Number.NaN, 4])).toBe(true);
+    expect(vibrate).toHaveBeenCalledWith([12, 4]);
+  });
+
+  it("fails silently when the browser blocks vibration", () => {
+    const vibrate = vi.fn(() => {
+      throw new Error("vibration blocked");
+    });
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    setNavigatorVibrate(vibrate);
+
+    expect(triggerToggleHaptic()).toBe(false);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/hushh-webapp/__tests__/utils/haptic-utils.test.ts
+++ b/hushh-webapp/__tests__/utils/haptic-utils.test.ts
@@ -1,9 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import {
-  isBrowserVibrationSupported,
-  triggerToggleHaptic,
-} from "@/lib/utils/haptic-utils";
+import { triggerToggleHaptic } from "@/lib/utils/haptic-utils";
 
 const originalVibrateDescriptor = Object.getOwnPropertyDescriptor(
   Navigator.prototype,
@@ -32,13 +29,14 @@ describe("haptic utils", () => {
     }
   });
 
+  // Vibration support is exercised through triggerToggleHaptic's observable
+  // behavior (the support check is a module-internal guard, not a public export).
   it("returns false without logging when vibration is unsupported", () => {
     delete (Navigator.prototype as Partial<Navigator>).vibrate;
     const consoleErrorSpy = vi
       .spyOn(console, "error")
       .mockImplementation(() => {});
 
-    expect(isBrowserVibrationSupported()).toBe(false);
     expect(triggerToggleHaptic()).toBe(false);
     expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
@@ -47,7 +45,6 @@ describe("haptic utils", () => {
     const vibrate = vi.fn().mockReturnValue(true);
     setNavigatorVibrate(vibrate);
 
-    expect(isBrowserVibrationSupported()).toBe(true);
     expect(triggerToggleHaptic()).toBe(true);
     expect(vibrate).toHaveBeenCalledWith(10);
   });

--- a/hushh-webapp/components/theme-toggle.tsx
+++ b/hushh-webapp/components/theme-toggle.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { MaterialRipple } from "@/lib/morphy-ux/material-ripple";
 import { Icon } from "@/lib/morphy-ux/ui";
+import { triggerToggleHaptic } from "@/lib/utils/haptic-utils";
 import { cn } from "@/lib/utils";
 
 type ThemeOption = "light" | "dark" | "system";
@@ -74,6 +75,7 @@ export function ThemeToggle({ className }: { className?: string }) {
             aria-checked={isActive}
             onClick={() => {
               if (option.value === activeTheme) return;
+              triggerToggleHaptic();
               setTheme(option.value);
             }}
             className={cn(
@@ -141,7 +143,11 @@ export function ThemeToggleCompact({ className }: { className?: string }) {
           return (
             <DropdownMenuItem
               key={option.value}
-              onSelect={() => !isActive && setTheme(option.value)}
+              onSelect={() => {
+                if (isActive) return;
+                triggerToggleHaptic();
+                setTheme(option.value);
+              }}
               className={cn("group flex items-center gap-2", isActive && "font-medium")}
             >
               <Icon icon={option.icon} size="sm" aria-hidden="true" className="text-current" />

--- a/hushh-webapp/lib/utils/haptic-utils.ts
+++ b/hushh-webapp/lib/utils/haptic-utils.ts
@@ -1,0 +1,48 @@
+"use client";
+
+export type HapticPattern = number | number[];
+
+const DEFAULT_TOGGLE_HAPTIC_PATTERN_MS = 10;
+
+function normalizeHapticPattern(pattern: HapticPattern): HapticPattern | null {
+  if (typeof pattern === "number") {
+    return Number.isFinite(pattern) && pattern >= 0 ? pattern : null;
+  }
+
+  if (!Array.isArray(pattern)) {
+    return null;
+  }
+
+  const normalized = pattern.filter(
+    (value) => Number.isFinite(value) && value >= 0
+  );
+
+  return normalized.length > 0 ? normalized : null;
+}
+
+export function isBrowserVibrationSupported(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof navigator !== "undefined" &&
+    typeof navigator.vibrate === "function"
+  );
+}
+
+export function triggerToggleHaptic(
+  pattern: HapticPattern = DEFAULT_TOGGLE_HAPTIC_PATTERN_MS
+): boolean {
+  if (!isBrowserVibrationSupported()) {
+    return false;
+  }
+
+  const normalizedPattern = normalizeHapticPattern(pattern);
+  if (normalizedPattern === null) {
+    return false;
+  }
+
+  try {
+    return navigator.vibrate(normalizedPattern);
+  } catch {
+    return false;
+  }
+}

--- a/hushh-webapp/lib/utils/haptic-utils.ts
+++ b/hushh-webapp/lib/utils/haptic-utils.ts
@@ -20,7 +20,7 @@ function normalizeHapticPattern(pattern: HapticPattern): HapticPattern | null {
   return normalized.length > 0 ? normalized : null;
 }
 
-export function isBrowserVibrationSupported(): boolean {
+function isBrowserVibrationSupported(): boolean {
   return (
     typeof window !== "undefined" &&
     typeof navigator !== "undefined" &&


### PR DESCRIPTION
## Overview

This PR adds a safe browser haptic fallback wrapper and now attaches it to the existing theme toggle controls. The wrapper checks for browser vibration support, sanitizes malformed vibration patterns, and silently returns `false` when the API is unavailable or blocked.

## Concrete Attachment Plan

- Canonical production caller: `hushh-webapp/components/theme-toggle.tsx`.
- User-facing controls attached: `ThemeToggle` and `ThemeToggleCompact` call `triggerToggleHaptic()` only when a real theme change is requested.
- Utility location: `hushh-webapp/lib/utils/haptic-utils.ts`.
- Test contract: `hushh-webapp/__tests__/utils/haptic-utils.test.ts` verifies unsupported browsers, default vibration, malformed pattern sanitization, and blocked API fallback behavior.
- No backend routes, generated contracts, new dependencies, or unrelated UI surfaces are introduced.

## Impact

- Low risk: the helper is defensive and returns early when `navigator.vibrate` is missing, undefined, unsupported, malformed, or blocked.
- The app remains desktop-safe because unsupported environments get a no-op `false` result with no console noise.
- The new export is reachable from a current app UI caller, resolving the prior unattached-helper risk.

## Verification

- `cd hushh-webapp && npm run test:ci -- __tests__/utils/haptic-utils.test.ts`
- `cd hushh-webapp && npm run typecheck`
- `cd hushh-webapp && npm run verify:docs`
- `cd hushh-webapp && npm run verify:design-system`
- `cd hushh-webapp && npm run verify:service-boundary`
- `cd hushh-webapp && npm run lint -- --max-warnings=0`