### PR TITLE
fix(ui): add accessible privacy toggle

### DIFF
--- a/hushh-webapp/__tests__/components/privacy-toggle.test.tsx
+++ b/hushh-webapp/__tests__/components/privacy-toggle.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PrivacyToggle } from "@/components/profile/privacy-toggle";
+
+describe("PrivacyToggle", () => {
+  it("exposes switch semantics for privacy preferences", () => {
+    render(
+      <PrivacyToggle
+        checked
+        ariaLabel="Toggle marketplace visibility for privacy preferences"
+        onCheckedChange={() => {}}
+      />
+    );
+
+    const toggle = screen.getByRole("switch", {
+      name: "Toggle marketplace visibility for privacy preferences",
+    });
+
+    expect(toggle.getAttribute("aria-checked")).toBe("true");
+    expect(toggle.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("toggles from keyboard Enter and Space activation", () => {
+    const handleCheckedChange = vi.fn();
+    render(
+      <PrivacyToggle
+        checked={false}
+        ariaLabel="Toggle location data for privacy preferences"
+        onCheckedChange={handleCheckedChange}
+      />
+    );
+
+    const toggle = screen.getByRole("switch", {
+      name: "Toggle location data for privacy preferences",
+    });
+
+    fireEvent.keyDown(toggle, { key: "Enter" });
+    fireEvent.keyDown(toggle, { key: " " });
+
+    expect(handleCheckedChange).toHaveBeenNthCalledWith(1, true);
+    expect(handleCheckedChange).toHaveBeenNthCalledWith(2, true);
+  });
+
+  it("does not toggle when disabled", () => {
+    const handleCheckedChange = vi.fn();
+    render(
+      <PrivacyToggle
+        checked={false}
+        disabled
+        ariaLabel="Toggle marketplace visibility for privacy preferences"
+        onCheckedChange={handleCheckedChange}
+      />
+    );
+
+    const toggle = screen.getByRole("switch", {
+      name: "Toggle marketplace visibility for privacy preferences",
+    });
+
+    fireEvent.click(toggle);
+    fireEvent.keyDown(toggle, { key: "Enter" });
+
+    expect(toggle.hasAttribute("disabled")).toBe(true);
+    expect(toggle.getAttribute("tabindex")).toBe("-1");
+    expect(handleCheckedChange).not.toHaveBeenCalled();
+  });
+});

--- a/hushh-webapp/app/profile/page.tsx
+++ b/hushh-webapp/app/profile/page.tsx
@@ -69,6 +69,7 @@ import {
   type ProfileStackEntry,
 } from "@/components/profile/profile-stack-navigator";
 import { ProfileKaiPreferencesPanel } from "@/components/profile/profile-kai-preferences-panel";
+import { PrivacyToggle } from "@/components/profile/privacy-toggle";
 import { RuntimeSecretSettingsCard } from "@/components/profile/runtime-secret-settings-card";
 import { ThemeToggle } from "@/components/theme-toggle";
 import {
@@ -91,7 +92,6 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { Switch } from "@/components/ui/switch";
 import {
   Select,
   SelectContent,
@@ -3172,14 +3172,10 @@ function ProfilePageContent() {
           title="Marketplace visibility"
           description={marketplaceStatusText}
           trailing={
-            <Switch
+            <PrivacyToggle
               checked={marketplaceOptIn}
               disabled={loadingMarketplaceOptIn || savingMarketplaceOptIn}
-              aria-label="Toggle marketplace visibility"
-              onPointerDown={(event) => {
-                event.stopPropagation();
-              }}
-              onClick={(event) => event.stopPropagation()}
+              ariaLabel="Toggle marketplace visibility for privacy preferences"
               onCheckedChange={() => void handleMarketplaceOptInToggle()}
             />
           }
@@ -4276,13 +4272,9 @@ function ProfilePageContent() {
                     : "Nearby advisors and local market hours. Off by default."
                 }
                 trailing={
-                  <Switch
+                  <PrivacyToggle
                     checked={locationContextEnabled}
-                    aria-label="Toggle location"
-                    onPointerDown={(event) => {
-                      event.stopPropagation();
-                    }}
-                    onClick={(event) => event.stopPropagation()}
+                    ariaLabel="Toggle location data for privacy preferences"
                     onCheckedChange={setLocationContextEnabled}
                   />
                 }

--- a/hushh-webapp/components/profile/privacy-toggle.tsx
+++ b/hushh-webapp/components/profile/privacy-toggle.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import type { KeyboardEvent, MouseEvent, PointerEvent } from "react";
+
+import { cn } from "@/lib/utils";
+
+type PrivacyToggleProps = {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  ariaLabel: string;
+  disabled?: boolean;
+  className?: string;
+};
+
+export function PrivacyToggle({
+  checked,
+  onCheckedChange,
+  ariaLabel,
+  disabled = false,
+  className,
+}: PrivacyToggleProps) {
+  function toggle() {
+    if (disabled) return;
+    onCheckedChange(!checked);
+  }
+
+  function handleClick(event: MouseEvent<HTMLButtonElement>) {
+    event.stopPropagation();
+    toggle();
+  }
+
+  function handleKeyDown(event: KeyboardEvent<HTMLButtonElement>) {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    event.preventDefault();
+    event.stopPropagation();
+    toggle();
+  }
+
+  function handlePointerDown(event: PointerEvent<HTMLButtonElement>) {
+    event.stopPropagation();
+  }
+
+  return (
+    <button
+      type="button"
+      role="switch"
+      tabIndex={disabled ? -1 : 0}
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      disabled={disabled}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      onPointerDown={handlePointerDown}
+      className={cn(
+        "inline-flex h-5 w-9 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-colors outline-none",
+        "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        checked ? "bg-primary" : "bg-input dark:bg-input/80",
+        className
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "block size-4 rounded-full bg-background ring-0 transition-transform dark:bg-foreground",
+          checked && "translate-x-4 dark:bg-primary-foreground"
+        )}
+      />
+    </button>
+  );
+}


### PR DESCRIPTION
## Overview
Upgrades the profile privacy toggle presentation layer with explicit keyboard and screen-reader semantics. The marketplace visibility and location privacy controls now use a focused PrivacyToggle component with switch semantics, descriptive labels, and Enter/Space activation.

## Impact
Low risk: this touches local toggle presentation behavior only and does not modify data fetching, persistence, backend contracts, or state machines. High impact: core transparency and privacy controls become easier to operate for keyboard users, assistive technologies, and screen readers.

## Changes Cleared
- Adds a focused PrivacyToggle presentation component.
- Implements tabIndex focus handling for enabled toggles.
- Supports Enter and Space keyboard activation.
- Adds explicit role=switch and aria-checked state.
- Adds descriptive privacy preference aria-label support.
- Wires the component into profile marketplace visibility and location privacy toggles.
- Adds unit coverage for semantics, keyboard activation, and disabled behavior.

## Impact Map
- Routes touched: /profile presentation only.
- API/schema/type changes: none.
- Runtime DB data-plane changes: none.
- Cache keys touched: none.
- PKM effects: none.
- Mobile parity impacts: none; web presentation only.
- Trust boundary touched: privacy control accessibility only; no authorization or consent logic changes.
- Caller/proxy/backend pairing: no caller, proxy, or backend changes.
- Rollback or safe-failure behavior: revert the component and profile presentation attachment if needed.
- UI browser or Playwright proof: not applicable; component unit tests cover keyboard and ARIA behavior.
- Docs updated: none.
- Verification run: cd hushh-webapp && npm run test:ci -- __tests__/components/privacy-toggle.test.tsx; cd hushh-webapp && npm run typecheck