### PR TITLE
chore(governance): add DamriaNeelesh and Jhumma-hushh to allowed maintainers

### DIFF
--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -17,7 +17,9 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx"
+      "azfx",
+      "Jhumma-hushh",
+      "DamriaNeelesh"
     ],
     "review_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_required": true,
@@ -28,13 +30,17 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx"
+      "azfx",
+      "Jhumma-hushh",
+      "DamriaNeelesh"
     ],
     "protected_pipeline_edit_users": [
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx"
+      "azfx",
+      "Jhumma-hushh",
+      "DamriaNeelesh"
     ],
     "protected_pipeline_paths": [
       ".github/workflows/",
@@ -54,7 +60,9 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx"
+      "azfx",
+      "Jhumma-hushh",
+      "DamriaNeelesh"
     ],
     "review_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_required": true,
@@ -65,7 +73,9 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx"
+      "azfx",
+      "Jhumma-hushh",
+      "DamriaNeelesh"
     ]
   },
   "uat": {
@@ -76,7 +86,9 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx"
+      "azfx",
+      "Jhumma-hushh",
+      "DamriaNeelesh"
     ]
   },
   "production": {


### PR DESCRIPTION
## Summary
Keep config/ci-governance.json in sync with GitHub team membership (allowed-maintainers-to-approve) where DamriaNeelesh has been added with maintainer role, and ensure Jhumma-hushh is completely synced on the train config.

Gives DamriaNeelesh and Jhumma-hushh merge queue bypass, review bypass, and manual UAT dispatch capabilities.

### Proof
- Pushed branch to head.
- Validates cleanly.