### PR TITLE
Promote One Location public sharing to UAT main

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -513,7 +513,11 @@ class OneLocationAgentService:
                 {"user_id": user_id},
             )
         except Exception as exc:
-            logger.debug("one.location.identity_lookup_failed user=%s error=%s", redact_log_value(user_id), exc)
+            logger.debug(
+                "one.location.identity_lookup_failed user=%s error=%s",
+                redact_log_value(user_id),
+                exc,
+            )
             return None
 
     def _identity_row_by_phone_digits(self, phone_digits: str) -> dict[str, Any] | None:
@@ -2527,7 +2531,12 @@ class OneLocationAgentService:
     def resolve_public_invite(self, *, public_token: str) -> dict[str, Any]:
         row = self._public_invite_row_for_token(public_token=public_token)
         invite = self._public_invite_payload(row, public=True)
-        return {"invite": invite}
+        result = {"invite": invite}
+        metadata = _loads_json(row.get("metadata")) or {}
+        public_location = metadata.get("publicLocation") if isinstance(metadata, dict) else None
+        if isinstance(public_location, dict):
+            result["publicLocation"] = self._public_location_snapshot_payload(public_location)
+        return result
 
     def _check_public_submission_limits(
         self,

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -1454,7 +1454,7 @@ def test_public_invite_is_request_only_and_token_hash_only() -> None:
     }
 
 
-def test_public_invite_with_snapshot_returns_location_after_intake_without_private_request() -> None:
+def test_public_invite_with_snapshot_returns_location_on_resolve_without_private_request() -> None:
     service = FourUserMemoryService()
     service.register_recipient_key(
         user_id="user_b",
@@ -1471,8 +1471,8 @@ def test_public_invite_with_snapshot_returns_location_after_intake_without_priva
 
     resolved = service.resolve_public_invite(public_token=token)
     assert resolved["invite"]["locationAvailable"] is True
-    assert "latitude" not in json.dumps(resolved)
-    assert "longitude" not in json.dumps(resolved)
+    assert resolved["publicLocation"]["latitude"] == PUBLIC_LOCATION_SNAPSHOT["latitude"]
+    assert resolved["publicLocation"]["longitude"] == PUBLIC_LOCATION_SNAPSHOT["longitude"]
 
     submitted = service.submit_public_invite_request(
         public_token=token,

--- a/consent-protocol/tests/test_one_location_routes.py
+++ b/consent-protocol/tests/test_one_location_routes.py
@@ -224,7 +224,7 @@ def test_public_location_invite_route_creates_request_without_returning_location
     assert "reverse_geocode" not in serialized
 
 
-def test_public_location_invite_route_returns_snapshot_after_visitor_intake(
+def test_public_location_invite_route_returns_snapshot_on_resolve(
     monkeypatch,
 ) -> None:
     service = FourUserMemoryService()
@@ -246,9 +246,10 @@ def test_public_location_invite_route_returns_snapshot_after_visitor_intake(
 
     resolve_response = client.get(f"/api/one/location/public-invites/{token}")
     assert resolve_response.status_code == 200
-    assert resolve_response.json()["invite"]["locationAvailable"] is True
-    assert "latitude" not in json.dumps(resolve_response.json())
-    assert "longitude" not in json.dumps(resolve_response.json())
+    resolve_payload = resolve_response.json()
+    assert resolve_payload["invite"]["locationAvailable"] is True
+    assert resolve_payload["publicLocation"]["latitude"] == PUBLIC_LOCATION_SNAPSHOT["latitude"]
+    assert resolve_payload["publicLocation"]["longitude"] == PUBLIC_LOCATION_SNAPSHOT["longitude"]
 
     submit_response = client.post(
         f"/api/one/location/public-invites/{token}/submit",
@@ -267,7 +268,6 @@ def test_public_location_invite_route_returns_snapshot_after_visitor_intake(
 
     serialized_private_surfaces = json.dumps(
         {
-            "resolve": resolve_response.json(),
             "notifications": service.notifications,
             "submissions": service.public_submissions,
         },

--- a/docs/reference/architecture/api-contracts.md
+++ b/docs/reference/architecture/api-contracts.md
@@ -156,11 +156,12 @@ resolve intake.
 ### One Location Agent
 
 One Location Agent is One-owned live-location sharing for trusted people. The
-route family is authenticated and ciphertext-only for all live-location reads.
-Public bearer links that reveal location, server-readable latitude/longitude,
-reverse geocoding, map thumbnails, and movement trails do not belong in this
-contract. Scope-2 public links are request-only: they collect visitor metadata
-and route the workflow back to owner approval; they never reveal live location.
+authenticated route family is ciphertext-only for approved live-location reads.
+Snapshot-backed public links are explicit, duration-bounded bearer links created
+by the owner to show one captured public location directly. Request-only public
+links without an owner-attached snapshot remain metadata-only and route the
+workflow back to owner approval. Public links must not expose private grants,
+ciphertext, movement trails, raw owner identity, or reverse-geocoded enrichment.
 The maintained architecture reference is
 [One Location Agent](./one-location-agent.md).
 
@@ -173,8 +174,8 @@ not the product owner for live location.
 | GET | `/api/one/location/recipients` | VAULT_OWNER Bearer | List phone-verified users excluding self, with masked labels and active public key metadata only |
 | POST | `/api/one/location/recipient-keys` | VAULT_OWNER Bearer | Register the authenticated user's recipient public key; private key remains device-local |
 | POST | `/api/one/location/public-invites` | VAULT_OWNER Bearer | Create a duration-bounded public request link; the raw token is returned once and only its hash is stored |
-| GET | `/api/one/location/public-invites/{public_token}` | Public | Resolve request-link metadata only: safe owner label, status, duration, and expiry |
-| POST | `/api/one/location/public-invites/{public_token}/submit` | Public | Submit visitor name, phone, and optional message as metadata-only request intent; creates an owner approval request only for matched verified/keyed Hussh users; response stays submission-only |
+| GET | `/api/one/location/public-invites/{public_token}` | Public | Resolve safe owner label, status, duration, expiry, and the attached `publicLocation` snapshot when the owner created a public location link |
+| POST | `/api/one/location/public-invites/{public_token}/submit` | Public | Legacy/request-only visitor intake; submit visitor name, phone, and optional message as metadata-only request intent for links without public location snapshots |
 | DELETE | `/api/one/location/public-invites/{invite_id}` | VAULT_OWNER Bearer | Revoke an active public request link |
 | POST | `/api/one/location/grants` | VAULT_OWNER Bearer | Create a duration-bounded owner-approved grant for one verified recipient identity/key |
 | POST | `/api/one/location/grants/{grant_id}/envelopes` | VAULT_OWNER Bearer | Store the owner-device encrypted latest-location envelope; backend receives ciphertext and metadata only |

--- a/docs/reference/architecture/one-location-agent.md
+++ b/docs/reference/architecture/one-location-agent.md
@@ -2,7 +2,7 @@
 
 Status: v1 implementation contract
 Owner: One + IAM/consent governance
-Last updated: 2026-05-22
+Last updated: 2026-06-18
 
 ## Visual Map
 
@@ -23,8 +23,9 @@ public shared resolver and server-readable latest coordinate rows. They are not
 the One Location Agent architecture and should not receive more product entry
 points.
 
-The production direction is One-owned, authenticated, recipient-scoped, and
-ciphertext-only for live coordinates.
+The production direction is One-owned. Authenticated recipient-scoped live
+location remains ciphertext-only. Owner-created public location links are a
+separate, explicit, duration-bounded snapshot-sharing mode.
 
 ## Plaintext Boundary
 
@@ -32,16 +33,26 @@ Plain coordinates are allowed only on:
 
 - the owner's device while capturing foreground location
 - the approved recipient's device after local decryption
+- `one_location_public_invites.metadata.publicLocation` when the owner
+  explicitly creates a snapshot-backed public location link
+- public invite resolve responses when the owner explicitly attached a captured
+  `publicLocation` snapshot to a public link
 
 Plain coordinates are forbidden in:
 
-- backend database rows
-- backend API responses
+- backend database rows outside the explicit public invite snapshot field
+- backend API responses outside snapshot-backed public invite resolve
 - logs and analytics
 - notification payloads
 - consent/audit metadata
-- public URLs and share links
+- public URLs themselves
 - support tooling and server fallback buffers
+
+Public links may store one sanitized `publicLocation` snapshot in invite
+metadata only when created through the explicit public location flow. That
+snapshot is returned by token resolve while the invite is active. It is not a
+live grant, ciphertext envelope, movement trail, raw owner identity, address, or
+reverse-geocoded enrichment.
 
 ## Ciphertext Envelope
 
@@ -76,18 +87,21 @@ reverse geocode, map, notify, or inspect latitude/longitude.
 ## Authorization Contract
 
 All live-location grant, envelope, approval, revocation, and state routes
-require a VAULT_OWNER bearer token. Scope-2 public invite routes are the only
-public exceptions, and they are request-only. They may resolve safe owner/link
-metadata and accept visitor name/phone/message, but they never return
-coordinates, ciphertext, grants, map embeds, or share authority.
+require a VAULT_OWNER bearer token. Public invite routes are the only public
+exceptions. Request-only invites resolve safe owner/link metadata and accept
+visitor name/phone/message. Snapshot-backed public location invites resolve safe
+owner/link metadata plus the attached public location snapshot.
 
 - `actor_identity_cache.phone_verified = true` is eligibility only.
 - Each recipient needs a separate active grant.
 - Expiry and revocation block reads before ciphertext is returned.
 - Referrals create access requests only; they never forward access.
-- Public invite submissions create access requests only when the visitor maps
+- Request-only public invite submissions create access requests only when the visitor maps
   to a verified Hussh user with active recipient key material; otherwise they
   remain metadata-only intent for follow-up.
+- Snapshot-backed public invite resolves do not create grants, requests, or
+  recipient-scoped access. Anyone with the active token can view the attached
+  public snapshot until expiry or revocation.
 - Consent/audit records are metadata-only.
 
 Capability scopes:
@@ -106,24 +120,28 @@ envelope publishing, ciphertext viewing, revocation, access requests, request
 resolution, and referrals. Tools validate their capability scope per invocation
 and delegate persistence to `OneLocationAgentService`.
 
-The agent refuses public bearer links that reveal location, plaintext server
-coordinates, and referrals or public submissions that grant access without owner
-approval.
+The agent refuses referrals or public submissions that grant private access
+without owner approval. Public bearer links may reveal only the explicit
+owner-attached public snapshot, never private grants, ciphertext, movement
+trails, raw tokens, or raw owner identity.
 
-## Public Request Links
+## Public Links
 
-Scope-2 public sharing is a request-link workflow, not a public live-location
-viewer.
+Public sharing has two modes: snapshot-backed public location links and legacy
+request-only links.
 
-1. The authenticated owner creates a duration-bounded public request link from
+1. The authenticated owner creates a duration-bounded public link from
    `/one/location`.
 2. The backend returns the raw token once and stores only its hash.
-3. The public page `/one/location/request/{token}` asks the visitor for name, phone,
-   and optional message.
-4. The public resolve response exposes only a safe owner label, status,
-   duration, and expiry. By default the safe label is "a trusted person".
-5. The public page submits metadata only. It never displays a map or location.
-6. If the phone maps to a verified/keyed Hussh user, One creates a normal
+3. If the owner attached a `publicLocation` snapshot, the public resolve
+   response returns safe owner/link metadata plus that snapshot. The public page
+   displays the map immediately with no name, phone, or message form.
+4. If no snapshot is attached, the link is request-only and the public resolve
+   response exposes only a safe owner label, status, duration, and expiry. By
+   default the safe label is "a trusted person".
+5. Request-only public links may submit metadata only. They do not display a map
+   or location.
+6. If the phone maps to a verified/keyed Hussh user in a request-only flow, One creates a normal
    pending access request for owner approval.
 7. If the phone does not have usable Hussh identity/key material, the submission
    stays pending identity/key setup.
@@ -131,11 +149,12 @@ viewer.
    device still encrypts the coordinate envelope for that recipient.
 
 Public invite tables store token hashes, status, expiry, visitor display name,
-phone hash/last4, matched user id when available, and request linkage. They must
-not store raw phone numbers, raw invite tokens, coordinates, addresses, map
-previews, or movement/freshness trails. Public submissions are bounded per token,
-throttled per phone/fingerprint hash, and never return request internals, grants,
-ciphertext, or location payloads to the anonymous caller.
+phone hash/last4, matched user id when available, request linkage, and an
+optional sanitized public location snapshot for snapshot-backed links. They must
+not store raw phone numbers, raw invite tokens, addresses, map previews, or
+movement/freshness trails. Public submissions are bounded per token, throttled
+per phone/fingerprint hash, and never return request internals, grants, or
+ciphertext to the anonymous caller.
 
 ## KAI Circle Recommendation Contract
 
@@ -208,7 +227,8 @@ The implementation must prove:
 - expired/revoked grants block reads
 - referrals create requests but no access
 - notification and audit metadata contain no coordinates
-- public request links store token hashes only and never reveal location
+- public links store token hashes only; snapshot-backed links reveal only the
+  explicit public snapshot, while request-only links never reveal location
 - web, iOS, and Android have foreground permission parity
 - A/B/C/D flow is covered at service, authenticated API route, and browser
   crypto levels

--- a/hushh-webapp/__tests__/app/one/location/public-request-page.test.tsx
+++ b/hushh-webapp/__tests__/app/one/location/public-request-page.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  resolvePublicInvite: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ token: "public-token" }),
+}));
+
+vi.mock("@/lib/one-location/service", () => ({
+  OneLocationService: {
+    resolvePublicInvite: mocks.resolvePublicInvite,
+  },
+}));
+
+import PublicLocationRequestPageClient from "@/app/one/location/request/[token]/page-client";
+
+describe("PublicLocationRequestPageClient", () => {
+  beforeEach(() => {
+    mocks.resolvePublicInvite.mockResolvedValue({
+      invite: {
+        status: "active",
+        durationHours: 1,
+        expiresAt: "2026-05-20T08:30:00.000Z",
+        ownerLabel: "A trusted person",
+        locationAvailable: true,
+      },
+      publicLocation: {
+        latitude: 28.6139,
+        longitude: 77.209,
+        accuracyM: 18,
+        capturedAt: "2026-05-20T07:30:00.000Z",
+        sourcePlatform: "web",
+      },
+    });
+  });
+
+  it("opens a public location directly without visitor intake", async () => {
+    render(<PublicLocationRequestPageClient />);
+
+    await waitFor(() =>
+      expect(mocks.resolvePublicInvite).toHaveBeenCalledWith("public-token"),
+    );
+
+    expect(await screen.findByTitle("Public location map")).toBeTruthy();
+    expect(screen.queryByPlaceholderText("Your name")).toBeNull();
+    expect(screen.queryByPlaceholderText("Phone number")).toBeNull();
+    expect(screen.queryByPlaceholderText("Optional message")).toBeNull();
+  });
+});

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -10,6 +10,7 @@ const {
   mockDecryptLocationEnvelope,
   mockRegisterKey,
   mockGetPermissionState,
+  mockOpenLocationSettings,
   mockCaptureCurrentPosition,
   mockCreateGrant,
   mockStoreEnvelope,
@@ -32,6 +33,7 @@ const {
   mockDecryptLocationEnvelope: vi.fn(),
   mockRegisterKey: vi.fn(),
   mockGetPermissionState: vi.fn(),
+  mockOpenLocationSettings: vi.fn(),
   mockCaptureCurrentPosition: vi.fn(),
   mockCreateGrant: vi.fn(),
   mockStoreEnvelope: vi.fn(),
@@ -85,6 +87,7 @@ vi.mock("@/lib/one-location/service", () => ({
   OneLocationService: {
     registerRecipientKey: mockRegisterKey,
     getPermissionState: mockGetPermissionState,
+    openLocationSettings: mockOpenLocationSettings,
     getActivity: mockGetActivity,
     getState: mockGetState,
     createGrant: mockCreateGrant,
@@ -111,15 +114,33 @@ vi.mock("@/lib/services/account-identity-service", () => ({
   },
 }));
 
-vi.mock("sonner", () => ({
-  toast: {
-    success: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-  },
-}));
+vi.mock("sonner", () => {
+  const toast = vi.fn();
+  return {
+    toast: Object.assign(toast, {
+      success: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      dismiss: vi.fn(),
+    }),
+  };
+});
 
-import { OneLocationAgentPageContent } from "@/app/one/location/page";
+import OneLocationAgentPage from "@/app/one/location/page";
+
+if (!window.localStorage) {
+  const localStorageStore = new Map<string, string>();
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: {
+      clear: () => localStorageStore.clear(),
+      getItem: (key: string) => localStorageStore.get(key) ?? null,
+      removeItem: (key: string) => localStorageStore.delete(key),
+      setItem: (key: string, value: string) =>
+        localStorageStore.set(key, String(value)),
+    },
+  });
+}
 
 function locationState() {
   return {
@@ -290,6 +311,7 @@ function locationActivity() {
 describe("OneLocationAgentPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    Element.prototype.scrollIntoView = vi.fn();
     window.localStorage.clear();
     mockSearchParamsGet.mockReturnValue(null);
     mockUseRequireAuth.mockReturnValue({
@@ -312,6 +334,11 @@ describe("OneLocationAgentPage", () => {
       state: "granted",
       precise: true,
       background: "foreground-only",
+      locationServicesEnabled: true,
+    });
+    mockOpenLocationSettings.mockResolvedValue({
+      opened: true,
+      sourcePlatform: "android",
     });
     mockCaptureCurrentPosition.mockResolvedValue({
       latitude: 28.6139,
@@ -373,7 +400,10 @@ describe("OneLocationAgentPage", () => {
     });
     mockGetState.mockResolvedValue(locationState());
     mockGetActivity.mockResolvedValue(locationActivity());
-    mockSyncCurrentUser.mockResolvedValue({ user_id: "user_a" });
+    mockSyncCurrentUser.mockResolvedValue({
+      user_id: "user_a",
+      phone_verified: true,
+    });
     mockSyncOneLocationContactSignals.mockResolvedValue({
       matches: [],
       matchedUserIds: [],
@@ -384,23 +414,22 @@ describe("OneLocationAgentPage", () => {
   });
 
   it("renders the One-owned encrypted location control surface", async () => {
-    render(<OneLocationAgentPageContent />);
+    render(<OneLocationAgentPage />);
 
     expect(
       await screen.findByRole("heading", { name: "One Location Agent" }),
     ).toBeTruthy();
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     expect(
-      await screen.findByRole("heading", { name: "People who can see me" }),
+      await screen.findByRole("heading", { name: "One Network" }),
     ).toBeTruthy();
     expect(
       screen.queryByRole("heading", { name: "Proximity alerts" }),
     ).toBeNull();
     expect(screen.queryByText("Advisor meetup")).toBeNull();
     expect(screen.queryAllByText("Trusted B").length).toBeGreaterThan(0);
-    expect(screen.getByText("Professional Network")).toBeTruthy();
-    expect(screen.getByText("No approvals waiting. New location requests and pending decisions will appear here.")).toBeTruthy();
-    expect(screen.getByText("No ready KAI members yet. Verified KAI members with location keys will appear here.")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Create public link" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Shared with me" })).toBeTruthy();
     expect(screen.queryByText(/8012|9911/)).toBeNull();
     expect(screen.getByText("Share Encrypted Update")).toBeTruthy();
     expect(mockRegisterKey).toHaveBeenCalledWith({
@@ -412,12 +441,91 @@ describe("OneLocationAgentPage", () => {
     expect(mockSyncCurrentUser).toHaveBeenCalledWith({ uid: "user_a" });
   });
 
-  it("renders KAI Circle recommendation metadata without phone-derived labels", async () => {
-    render(<OneLocationAgentPageContent />);
+  it("does not render the removed onboarding tour", async () => {
+    render(<OneLocationAgentPage />);
+
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    expect(screen.queryByRole("button", { name: /Show onboarding tour/i })).toBeNull();
+    expect(
+      screen.queryByRole("dialog", { name: /One Location guided tour/i }),
+    ).toBeNull();
+  });
+
+  it("previews my live location without creating a share, request, or public link", async () => {
+    mockGetState.mockResolvedValueOnce({
+      ...locationState(),
+      ownerGrants: [],
+      receivedGrants: [],
+    });
+
+    render(<OneLocationAgentPage />);
+
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    fireEvent.click(
+      screen.getByRole("button", { name: /Show my location/i }),
+    );
+
+    await waitFor(() => expect(mockCaptureCurrentPosition).toHaveBeenCalledTimes(1));
+    const mapPreview = await screen.findByTitle("Live location map preview");
+    expect(mapPreview.getAttribute("src")).toContain(
+      "https://www.google.com/maps?q=28.613900%2C77.209000",
+    );
+    expect(mockCreateGrant).not.toHaveBeenCalled();
+    expect(mockRequestAccess).not.toHaveBeenCalled();
+    expect(mockCreatePublicInvite).not.toHaveBeenCalled();
+  });
+
+  it("loads One Location setup without requiring backend phone verification", async () => {
+    mockSyncCurrentUser.mockResolvedValueOnce({
+      user_id: "user_a",
+      display_name: "Test User",
+      phone_verified: false,
+    });
+
+    render(<OneLocationAgentPage />);
+
+    await waitFor(() => expect(mockEnsureKey).toHaveBeenCalledWith("user_a"));
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    expect(screen.queryByText("Verify your phone number first")).toBeNull();
+  });
+
+  it("prompts for foreground location permission on first verified page load", async () => {
+    mockGetState.mockResolvedValueOnce({
+      ...locationState(),
+      ownerGrants: [],
+    });
+    mockGetPermissionState
+      .mockResolvedValueOnce({
+        state: "prompt",
+        precise: null,
+        background: "foreground-only",
+        locationServicesEnabled: true,
+      })
+      .mockResolvedValueOnce({
+        state: "prompt",
+        precise: null,
+        background: "foreground-only",
+        locationServicesEnabled: true,
+      })
+      .mockResolvedValueOnce({
+        state: "granted",
+        precise: true,
+        background: "foreground-only",
+        locationServicesEnabled: true,
+      });
+
+    render(<OneLocationAgentPage />);
+
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    await waitFor(() => expect(mockCaptureCurrentPosition).toHaveBeenCalledTimes(1));
+  });
+
+  it("renders One Network recommendation metadata without phone-derived labels", async () => {
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
 
-    expect(screen.getByRole("heading", { name: "KAI Circle" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "One Network" })).toBeTruthy();
     expect(screen.getAllByText("Trusted Circle").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Recent share history").length).toBeGreaterThan(
       0,
@@ -425,7 +533,7 @@ describe("OneLocationAgentPage", () => {
     expect(screen.getByText("Recently shared location with you")).toBeTruthy();
     expect(screen.queryByText(/8012|4455|9911/)).toBeNull();
 
-    fireEvent.change(screen.getByPlaceholderText("Search KAI Circle..."), {
+    fireEvent.change(screen.getByPlaceholderText("Search One Network..."), {
       target: { value: "advisor" },
     });
 
@@ -443,7 +551,7 @@ describe("OneLocationAgentPage", () => {
       }),
     );
 
-    const { container } = render(<OneLocationAgentPageContent />);
+    const { container } = render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockRegisterKey).toHaveBeenCalled());
     expect(
@@ -457,33 +565,22 @@ describe("OneLocationAgentPage", () => {
   });
 
   it("renders a public location link control", async () => {
-    render(<OneLocationAgentPageContent />);
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
 
     expect(screen.getByText("Create public link")).toBeTruthy();
-    expect(screen.getByText("Public link responses")).toBeTruthy();
-    expect(screen.getByText(/Share a public location link/i)).toBeTruthy();
+    expect(screen.queryByText("Public link responses")).toBeNull();
+    expect(screen.queryByText(/Share a public location link/i)).toBeNull();
     expect(screen.queryByText(/whatsapp/i)).toBeNull();
   });
 
-  it("renders activity history from the One Location activity API without phone-derived labels", async () => {
-    render(<OneLocationAgentPageContent />);
+  it("keeps location activity hidden in the compact mobile flow", async () => {
+    render(<OneLocationAgentPage />);
 
-    await waitFor(() =>
-      expect(mockGetActivity).toHaveBeenCalledWith({
-        vaultOwnerToken: "vault-token",
-        range: "30d",
-      }),
-    );
-
-    expect(screen.getByRole("heading", { name: "Location activity" })).toBeTruthy();
-    expect(screen.getByText("Activity history")).toBeTruthy();
-    expect(await screen.findByText("Viewed by Trusted B")).toBeTruthy();
-    expect(screen.getByText("Shared with Trusted B")).toBeTruthy();
-    expect(screen.getByText("Request from Advisor C")).toBeTruthy();
-    expect(screen.getByText("Response from Visitor Alpha")).toBeTruthy();
-    expect(screen.getByLabelText(/One Location activity chart/i)).toBeTruthy();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    expect(screen.queryByRole("heading", { name: "Location activity" })).toBeNull();
+    expect(screen.queryByText("Activity history")).toBeNull();
     expect(screen.queryByText(/8012|4455|9911/)).toBeNull();
   });
 
@@ -540,7 +637,7 @@ describe("OneLocationAgentPage", () => {
       sourcePlatform: "web",
     });
 
-    render(<OneLocationAgentPageContent />);
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     await waitFor(() => expect(mockViewEnvelope).toHaveBeenCalled());
@@ -580,7 +677,7 @@ describe("OneLocationAgentPage", () => {
       ownerGrants: [],
     });
 
-    render(<OneLocationAgentPageContent />);
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(
@@ -618,14 +715,14 @@ describe("OneLocationAgentPage", () => {
       ownerGrants: [],
     });
 
-    render(<OneLocationAgentPageContent />);
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(
       screen.getByRole("button", { name: /Review Share/i }),
     );
     expect(
-      screen.getByRole("region", { name: "Share safety review" }),
+      await screen.findByRole("region", { name: "Share safety review" }),
     ).toBeTruthy();
     fireEvent.click(
       screen.getByRole("button", { name: /Confirm & Share Location/i }),
@@ -684,10 +781,13 @@ describe("OneLocationAgentPage", () => {
       )
       .mockResolvedValueOnce({});
 
-    render(<OneLocationAgentPageContent />);
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(screen.getByRole("button", { name: /Review Share/i }));
+    expect(
+      await screen.findByRole("region", { name: "Share safety review" }),
+    ).toBeTruthy();
     fireEvent.click(
       screen.getByRole("button", { name: /Confirm & Share Location/i }),
     );
@@ -758,13 +858,13 @@ describe("OneLocationAgentPage", () => {
       }),
     );
 
-    render(<OneLocationAgentPageContent />);
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     expect(await screen.findByText(/1 person selected/i)).toBeTruthy();
     fireEvent.click(
       screen.getByRole("button", {
-        name: /Select Investor D from KAI Circle/i,
+        name: /Select Investor D from One Network/i,
       }),
     );
     expect(await screen.findByText(/2 people selected/i)).toBeTruthy();
@@ -772,6 +872,9 @@ describe("OneLocationAgentPage", () => {
     fireEvent.click(
       screen.getByRole("button", { name: /Review Share/i }),
     );
+    expect(
+      await screen.findByRole("region", { name: "Share safety review" }),
+    ).toBeTruthy();
     fireEvent.click(
       screen.getByRole("button", { name: /Confirm & Share Location/i }),
     );
@@ -818,12 +921,12 @@ describe("OneLocationAgentPage", () => {
       ownerGrants: [],
     });
 
-    render(<OneLocationAgentPageContent />);
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(
       screen.getByRole("button", {
-        name: /Select Advisor C from KAI Circle/i,
+        name: /Select Advisor C from One Network/i,
       }),
     );
 
@@ -843,7 +946,7 @@ describe("OneLocationAgentPage", () => {
       ownerGrants: [],
     });
 
-    render(<OneLocationAgentPageContent />);
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(screen.getByRole("button", { name: "request" }));
@@ -870,19 +973,43 @@ describe("OneLocationAgentPage", () => {
     );
   });
 
+  it("renders my requests with safe labels instead of raw owner ids", async () => {
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      ownerGrants: [],
+      requests: [
+        {
+          id: "request_1",
+          ownerUserId: "user_b",
+          requesterUserId: "user_a",
+          status: "pending",
+          requestedAt: "2026-05-20T07:30:00.000Z",
+        },
+      ],
+    });
+
+    render(<OneLocationAgentPage />);
+
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    expect(screen.getByText("My requests")).toBeTruthy();
+    expect(screen.getAllByText("Trusted B").length).toBeGreaterThan(0);
+    expect(screen.queryByText("user_b")).toBeNull();
+    expect(screen.queryByText("request_1")).toBeNull();
+  });
+
   it("fans out approval-first requests to multiple selected owners without coordinates", async () => {
     mockGetState.mockResolvedValue({
       ...locationState(),
       ownerGrants: [],
     });
 
-    render(<OneLocationAgentPageContent />);
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(screen.getByRole("button", { name: "request" }));
     fireEvent.click(
       screen.getByRole("button", {
-        name: /Select Investor D from KAI Circle/i,
+        name: /Select Investor D from One Network/i,
       }),
     );
     expect(await screen.findByText(/2 people selected/i)).toBeTruthy();
@@ -929,7 +1056,7 @@ describe("OneLocationAgentPage", () => {
       sourcePlatform: "ios",
     });
 
-    render(<OneLocationAgentPageContent />);
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(screen.getByRole("button", { name: /Sync Contacts/i }));
@@ -940,7 +1067,6 @@ describe("OneLocationAgentPage", () => {
       }),
     );
     expect(await screen.findByText("In your contacts")).toBeTruthy();
-    expect(screen.getByText(/1 matched \/ 7 invite-ready/i)).toBeTruthy();
     expect(screen.queryByText(/9911|8012|4455/)).toBeNull();
     expect(mockTrackEvent).toHaveBeenCalledWith(
       "one_location_contact_signal_synced",
@@ -955,11 +1081,11 @@ describe("OneLocationAgentPage", () => {
     );
   });
 
-  it("creates an approval-first invite path for contacts who are not KAI users", async () => {
-    render(<OneLocationAgentPageContent />);
+  it("creates an approval-first invite path for contacts who are not One users", async () => {
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-    fireEvent.click(screen.getByRole("button", { name: /Invite Contacts/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Share to Contacts/i }));
 
     await waitFor(() => expect(mockCreatePublicInvite).toHaveBeenCalledTimes(1));
     expect(mockCreatePublicInvite).toHaveBeenCalledWith({
@@ -975,19 +1101,14 @@ describe("OneLocationAgentPage", () => {
     );
   });
 
-  it("revokes an active grant from the visible owner list", async () => {
-    render(<OneLocationAgentPageContent />);
+  it("does not show owner-grant revoke actions in the compact mobile flow", async () => {
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-    fireEvent.click(
-      screen.getByRole("button", { name: /Revoke access for Trusted B/i }),
-    );
-
-    await waitFor(() => expect(mockRevokeGrant).toHaveBeenCalledTimes(1));
-    expect(mockRevokeGrant).toHaveBeenCalledWith({
-      vaultOwnerToken: "vault-token",
-      grantId: "grant_1",
-    });
+    expect(
+      screen.queryByRole("button", { name: /Revoke access for Trusted B/i }),
+    ).toBeNull();
+    expect(mockRevokeGrant).not.toHaveBeenCalled();
   });
 
   it("blocks share actions when browser location permission is denied", async () => {
@@ -995,38 +1116,66 @@ describe("OneLocationAgentPage", () => {
       state: "denied",
       precise: false,
       background: "unavailable",
+      locationServicesEnabled: true,
     });
     mockGetState.mockResolvedValueOnce({
       ...locationState(),
       ownerGrants: [],
     });
 
-    render(<OneLocationAgentPageContent />);
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     const shareButton = screen.getByRole("button", {
       name: /Review Share/i,
     }) as HTMLButtonElement;
-    expect(shareButton.disabled).toBe(true);
+    fireEvent.click(shareButton);
+    await waitFor(() => expect(mockCaptureCurrentPosition).not.toHaveBeenCalled());
     expect(mockCreateGrant).not.toHaveBeenCalled();
   });
 
-  it("keeps KAI Circle section empty states visible when no candidates exist", async () => {
+  it("blocks sharing and opens settings when phone location services are off", async () => {
+    mockGetPermissionState.mockResolvedValue({
+      state: "unavailable",
+      precise: false,
+      background: "foreground-only",
+      locationServicesEnabled: false,
+    });
+    mockGetState.mockResolvedValueOnce({
+      ...locationState(),
+      ownerGrants: [],
+    });
+
+    render(<OneLocationAgentPage />);
+
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    expect(await screen.findByText("Turn on phone Location")).toBeTruthy();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Open Location Settings/i }),
+    );
+
+    await waitFor(() => expect(mockOpenLocationSettings).toHaveBeenCalled());
+    expect(mockCreateGrant).not.toHaveBeenCalled();
+    expect(mockStoreEnvelope).not.toHaveBeenCalled();
+  });
+
+  it("keeps One Network section empty states visible when no candidates exist", async () => {
     mockGetState.mockResolvedValueOnce({
       ...locationState(),
       recipients: [],
       ownerGrants: [],
     });
 
-    render(<OneLocationAgentPageContent />);
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-    expect(screen.getByText("KAI Circle is empty")).toBeTruthy();
-    expect(screen.getByText(/No approvals waiting/)).toBeTruthy();
-    expect(screen.getByText(/No trusted matches yet/)).toBeTruthy();
-    expect(screen.getByText(/No professional signals yet/)).toBeTruthy();
-    expect(screen.getByText(/No ready KAI members yet/)).toBeTruthy();
-    expect(screen.getByText(/No setup blockers/)).toBeTruthy();
+    expect(screen.getByText("One Network is empty")).toBeTruthy();
+    expect(screen.queryByText(/No approvals waiting/)).toBeNull();
+    expect(screen.queryByText(/No trusted matches yet/)).toBeNull();
+    expect(screen.queryByText(/No professional signals yet/)).toBeNull();
+    expect(screen.queryByText(/No ready One users yet/)).toBeNull();
+    expect(screen.queryByText(/No setup blockers/)).toBeNull();
     expect(
       screen.getByRole("button", { name: /Create public link/i }),
     ).toBeTruthy();
@@ -1038,7 +1187,7 @@ describe("OneLocationAgentPage", () => {
       vaultOwnerToken: null,
     });
 
-    render(<OneLocationAgentPageContent />);
+    render(<OneLocationAgentPage />);
 
     expect(
       await screen.findByText(

--- a/hushh-webapp/__tests__/services/location-agent-service.test.ts
+++ b/hushh-webapp/__tests__/services/location-agent-service.test.ts
@@ -183,6 +183,36 @@ describe("OneLocationService", () => {
     );
   });
 
+  it("resolves public location links with an attached public snapshot", async () => {
+    mockApiJson.mockResolvedValueOnce({
+      invite: {
+        status: "active",
+        durationHours: 1,
+        expiresAt: "2026-05-20T08:30:00.000Z",
+        ownerLabel: "A trusted person",
+        locationAvailable: true,
+      },
+      publicLocation: {
+        latitude: 28.6139,
+        longitude: 77.209,
+        accuracyM: 18,
+        capturedAt: "2026-05-20T07:30:00.000Z",
+        sourcePlatform: "web",
+      },
+    });
+
+    const response =
+      await OneLocationService.resolvePublicInvite("public-token");
+
+    expect(mockApiJson).toHaveBeenCalledWith(
+      "/api/one/location/public-invites/public-token",
+      {},
+    );
+    expect(response.invite.locationAvailable).toBe(true);
+    expect(response.publicLocation?.latitude).toBe(28.6139);
+    expect(response.publicLocation?.longitude).toBe(77.209);
+  });
+
   it("submits public invite intake without an auth token and receives public location", async () => {
     mockApiJson.mockResolvedValueOnce({
       submission: { id: "submission_1", status: "approved" },

--- a/hushh-webapp/android/app/src/main/java/com/hushh/app/plugins/HushhLocation/HushhLocationPlugin.kt
+++ b/hushh-webapp/android/app/src/main/java/com/hushh/app/plugins/HushhLocation/HushhLocationPlugin.kt
@@ -3,6 +3,7 @@ package com.hushh.app.plugins.HushhLocation
 import android.Manifest
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.location.Location
 import android.location.LocationListener
@@ -10,6 +11,7 @@ import android.location.LocationManager
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.provider.Settings
 import androidx.core.content.ContextCompat
 import com.getcapacitor.JSObject
 import com.getcapacitor.PermissionState
@@ -50,6 +52,22 @@ class HushhLocationPlugin : Plugin() {
     }
 
     @PluginMethod
+    fun openLocationSettings(call: PluginCall) {
+        try {
+            val intent = Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            context.startActivity(intent)
+            call.resolve(
+                JSObject()
+                    .put("opened", true)
+                    .put("sourcePlatform", "android")
+            )
+        } catch (error: Exception) {
+            call.reject("Could not open location settings: ${error.message}")
+        }
+    }
+
+    @PluginMethod
     fun getCurrentPosition(call: PluginCall) {
         if (getPermissionState("location") != PermissionState.GRANTED) {
             requestPermissionForAlias("location", call, "locationPermissionCallback")
@@ -70,15 +88,29 @@ class HushhLocationPlugin : Plugin() {
     private fun permissionPayload(): JSObject {
         val fineGranted = hasAndroidPermission(Manifest.permission.ACCESS_FINE_LOCATION)
         val coarseGranted = hasAndroidPermission(Manifest.permission.ACCESS_COARSE_LOCATION)
-        val state = if (fineGranted || coarseGranted) "granted" else "prompt"
+        val permissionState = getPermissionState("location")
+        val locationServicesEnabled = locationServicesEnabled()
+        val state = when {
+            (fineGranted || coarseGranted) && !locationServicesEnabled -> "unavailable"
+            fineGranted || coarseGranted -> "granted"
+            permissionState == PermissionState.DENIED -> "denied"
+            else -> "prompt"
+        }
         return JSObject()
             .put("state", state)
             .put("precise", fineGranted)
             .put("background", "foreground-only")
+            .put("locationServicesEnabled", locationServicesEnabled)
     }
 
     private fun hasAndroidPermission(permission: String): Boolean {
         return ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun locationServicesEnabled(): Boolean {
+        val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+        return listOf(LocationManager.GPS_PROVIDER, LocationManager.NETWORK_PROVIDER)
+            .any { provider -> locationManager.isProviderEnabled(provider) }
     }
 
     @SuppressLint("MissingPermission")

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -7,17 +7,19 @@ import {
   useRef,
   useState,
   type ComponentProps,
+  type MutableRefObject,
 } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import type { LucideIcon } from "lucide-react";
 import {
   AlertTriangle,
   CheckCircle2,
+  ChevronDown,
+  ChevronUp,
   Clock3,
   ContactRound,
   Copy,
   ExternalLink,
-  KeyRound,
   Loader2,
   LocateFixed,
   MapPin,
@@ -62,15 +64,25 @@ import {
 } from "@/lib/one-location/encryption";
 import {
   buildOneLocationNotificationHref,
+  buildOneLocationWorkflowHref,
   isOneLocationGrantOpened,
   locationShareNotificationDescription,
+  locationWorkflowNotificationCopy,
   markOneLocationGrantOpened,
   ONE_LOCATION_GRANT_ID_PARAM,
   ONE_LOCATION_GRANT_OPENED_EVENT,
   ONE_LOCATION_NOTIFICATION_OPEN_PARAM,
   ONE_LOCATION_NOTIFICATION_OPEN_VALUE,
+  ONE_LOCATION_REFERRAL_ID_PARAM,
+  ONE_LOCATION_REQUEST_ID_PARAM,
+  ONE_LOCATION_SECTION_PARAM,
+  ONE_LOCATION_SUBMISSION_ID_PARAM,
+  oneLocationSectionForWorkflowNotificationType,
   playOneLocationNotificationSound,
   recordOneLocationShareNotification,
+  recordOneLocationWorkflowNotification,
+  type OneLocationNotificationSection,
+  type OneLocationWorkflowNotificationType,
 } from "@/lib/one-location/notifications";
 import { OneLocationService } from "@/lib/one-location/service";
 import {
@@ -108,6 +120,13 @@ const DURATION_OPTIONS = [
 const LIVE_LOCATION_UPDATE_INTERVAL_MS = 20_000;
 const LIVE_LOCATION_STALE_THRESHOLD_MS = LIVE_LOCATION_UPDATE_INTERVAL_MS * 3;
 const FOREGROUND_RETRY_DELAYS_MS = [450, 900] as const;
+const ONE_NETWORK_PREVIEW_LIMIT = 3;
+const ONE_LOCATION_SHARE_TITLE = "Join my One Location circle";
+const ONE_LOCATION_PUBLIC_SHARE_COPY = "Join my One Location circle";
+const SHOW_LOCATION_ACTIVITY_SECTION = false;
+const SHOW_OWNER_GRANTS_SECTION = false;
+const SHOW_PUBLIC_RESPONSES_SECTION = false;
+const SHOW_REFERRAL_SECTION = false;
 
 type BusyState =
   | "load"
@@ -119,25 +138,13 @@ type BusyState =
   | "deny"
   | "refer"
   | "revoke"
+  | "locationSettings"
+  | "selfLocation"
   | "contactSync"
   | "contactInvite"
   | "publicInvite"
   | "publicRevoke"
   | null;
-
-type KaiCircleSectionKey =
-  | "needs_action"
-  | "trusted_circle"
-  | "professional_network"
-  | "location_ready"
-  | "needs_setup";
-
-type KaiCircleSection = {
-  key: KaiCircleSectionKey;
-  title: string;
-  description: string;
-  recipients: OneLocationRecipient[];
-};
 
 type OneLocationSelectionSurface =
   | "quick_circle"
@@ -147,6 +154,7 @@ type OneLocationSelectionSurface =
 type OneLocationDurationBucket = "15m" | "30m" | "1h" | "4h" | "24h" | "custom";
 type OneLocationForegroundOperation = "publish" | "view";
 type OneLocationForegroundTrigger = "manual" | "foreground_interval";
+type OneLocationFocusTarget = OneLocationNotificationSection;
 type OneLocationBackoffBucket =
   | "none"
   | "lt_500ms"
@@ -202,8 +210,31 @@ function expiresLabel(grant: OneLocationGrant): string {
   return `Expires ${formatDateTime(grant.expiresAt)}`;
 }
 
-function safePersonLabel(value?: string | null, fallback = "KAI member"): string {
-  return String(value || "").trim() || fallback;
+function looksLikeInternalIdentifier(value: string): boolean {
+  const label = value.trim();
+  if (!label) return false;
+  if (
+    /^(actor|grant|invite|key|location|one_location|recipient|referral|request|submission|user)[_-]/i.test(
+      label,
+    )
+  ) {
+    return true;
+  }
+  if (/^[0-9a-f]{24,}$/i.test(label) || /^[0-9a-f-]{32,}$/i.test(label)) {
+    return true;
+  }
+  return (
+    /^[A-Za-z0-9_-]{16,}$/.test(label) &&
+    /[A-Z]/.test(label) &&
+    /[a-z]/.test(label) &&
+    /\d/.test(label)
+  );
+}
+
+function safePersonLabel(value?: string | null, fallback = "One user"): string {
+  const label = String(value || "").trim();
+  if (!label || looksLikeInternalIdentifier(label)) return fallback;
+  return label;
 }
 
 function recipientLabel(recipient: OneLocationRecipient): string {
@@ -217,7 +248,7 @@ function recommendationTierLabel(tier?: string | null): string {
     case "trusted_circle":
       return "Trusted Circle";
     case "kai_network":
-      return "KAI Network";
+      return "One Network";
     case "contacts":
       return "Contact match";
     case "setup_needed":
@@ -225,7 +256,7 @@ function recommendationTierLabel(tier?: string | null): string {
     case "available":
       return "Ready";
     default:
-      return "KAI Circle";
+      return "One Network";
   }
 }
 
@@ -394,120 +425,6 @@ function peopleCountLabel(count: number): string {
   return count === 1 ? "1 person" : `${count} people`;
 }
 
-const KAI_CIRCLE_SECTION_META: Record<
-  KaiCircleSectionKey,
-  Pick<KaiCircleSection, "title" | "description">
-> = {
-  needs_action: {
-    title: "Needs your approval",
-    description: "Requests and people waiting on a decision.",
-  },
-  trusted_circle: {
-    title: "Trusted Circle",
-    description: "People with active sharing, history, or referrals.",
-  },
-  professional_network: {
-    title: "Professional Network",
-    description: "RIA, investor, advisor, and marketplace signals.",
-  },
-  location_ready: {
-    title: "Location-ready KAI members",
-    description: "Verified KAI members ready for encrypted sharing.",
-  },
-  needs_setup: {
-    title: "Needs setup",
-    description: "People who need to open One Location once.",
-  },
-};
-
-const KAI_CIRCLE_SECTION_EMPTY_COPY: Record<
-  KaiCircleSectionKey,
-  { title: string; description: string }
-> = {
-  needs_action: {
-    title: "No approvals waiting",
-    description: "New location requests and pending decisions will appear here.",
-  },
-  trusted_circle: {
-    title: "No trusted matches yet",
-    description:
-      "Active shares, repeat approvals, and referrals will lift people here.",
-  },
-  professional_network: {
-    title: "No professional signals yet",
-    description: "RIA, investor, advisor, and marketplace matches will appear here.",
-  },
-  location_ready: {
-    title: "No ready KAI members yet",
-    description: "Verified KAI members with location keys will appear here.",
-  },
-  needs_setup: {
-    title: "No setup blockers",
-    description: "Everyone in this section is ready enough for the current flow.",
-  },
-};
-
-const KAI_CIRCLE_SECTION_ORDER: KaiCircleSectionKey[] = [
-  "needs_action",
-  "trusted_circle",
-  "professional_network",
-  "location_ready",
-  "needs_setup",
-];
-
-function kaiCircleSectionKey(
-  recipient: OneLocationRecipient,
-): KaiCircleSectionKey {
-  switch (recipient.recommendationCategory) {
-    case "needs_action":
-    case "trusted_circle":
-    case "professional_network":
-    case "location_ready":
-    case "needs_setup":
-      return recipient.recommendationCategory;
-  }
-
-  if (!recipient.canReceiveLocation) return "needs_setup";
-  switch (recipient.recommendationTier) {
-    case "needs_action":
-      return "needs_action";
-    case "trusted_circle":
-      return "trusted_circle";
-    case "kai_network":
-      return "professional_network";
-    default:
-      if (
-        recipient.relationshipType ||
-        recipient.profileHeadline ||
-        recipient.verificationBadge
-      ) {
-        return "professional_network";
-      }
-      return "location_ready";
-  }
-}
-
-function buildKaiCircleSections(
-  recipients: OneLocationRecipient[],
-): KaiCircleSection[] {
-  const grouped = new Map<KaiCircleSectionKey, OneLocationRecipient[]>();
-  KAI_CIRCLE_SECTION_ORDER.forEach((key) => grouped.set(key, []));
-
-  recipients.forEach((recipient) => {
-    grouped.get(kaiCircleSectionKey(recipient))?.push(recipient);
-  });
-
-  return KAI_CIRCLE_SECTION_ORDER.map((key) => {
-    const meta = KAI_CIRCLE_SECTION_META[key];
-    return {
-      key,
-      title: meta.title,
-      description: meta.description,
-      recipients: grouped.get(key) ?? [],
-    };
-  });
-}
-
 function oneLocationDurationBucket(value: string): OneLocationDurationBucket {
   switch (value) {
     case "0.25":
@@ -542,48 +459,6 @@ function contactCountBucket(
   return "251_plus";
 }
 
-function contactSignalStatusLabel(status: OneLocationContactSignalStatus): string {
-  switch (status) {
-    case "scanning":
-      return "Scanning";
-    case "matched":
-      return "Signal active";
-    case "empty":
-      return "No matches yet";
-    case "unavailable":
-      return "Mobile only";
-    case "denied":
-      return "Permission needed";
-    case "error":
-      return "Needs retry";
-    default:
-      return "Optional signal";
-  }
-}
-
-function contactSignalSummary(state: OneLocationContactSignalState): string {
-  switch (state.status) {
-    case "matched":
-      return `${state.matchedCount} KAI match${
-        state.matchedCount === 1 ? "" : "es"
-      } added as a ranking signal.`;
-    case "empty":
-      return state.totalContacts > 0
-        ? "No KAI users matched from this scan."
-        : "No contact numbers were available to match.";
-    case "unavailable":
-      return "Open One on iOS or Android to scan contacts.";
-    case "denied":
-      return "Allow contacts to use this optional ranking signal.";
-    case "error":
-      return state.error || "Contact signal could not be refreshed.";
-    case "scanning":
-      return "Checking contacts privately on this device.";
-    default:
-      return "Contacts stay on-device; only hashed lookups are used for matching.";
-  }
-}
-
 function grantCounterpartyLabel(grant: OneLocationGrant): string {
   return safePersonLabel(grant.recipientDisplayName);
 }
@@ -599,6 +474,16 @@ function requestLabel(request: OneLocationAccessRequest): string {
   return safePersonLabel(request.requesterDisplayName, "Someone from KAI");
 }
 
+function requestOwnerLabel(
+  request: OneLocationAccessRequest,
+  recipients: OneLocationRecipient[],
+): string {
+  const owner = recipients.find(
+    (recipient) => recipient.userId === request.ownerUserId,
+  );
+  return safePersonLabel(owner?.displayName, "Location owner");
+}
+
 function publicSubmissionLabel(
   submission: OneLocationPublicInviteSubmission,
 ): string {
@@ -608,8 +493,16 @@ function publicSubmissionLabel(
 function publicInviteUrlLabel(value: string): string {
   if (!value) return "";
   if (/^https?:\/\//i.test(value)) return value;
-  if (typeof window === "undefined") return value;
-  return new URL(value, window.location.origin).toString();
+  const configuredOrigin = String(process.env.NEXT_PUBLIC_APP_URL || "")
+    .trim()
+    .replace(/\/+$/, "");
+  const origin =
+    /^https?:\/\//i.test(configuredOrigin) ||
+    typeof window === "undefined"
+      ? configuredOrigin
+      : String(window.location.origin || "").trim().replace(/\/+$/, "");
+  if (!/^https?:\/\//i.test(origin)) return value;
+  return new URL(value, origin).toString();
 }
 
 function statusVariant(
@@ -782,8 +675,8 @@ function LocalMapPreview({ point }: { point: PlainLocationPoint }) {
   const startUrl = googleMapsStartNavigationUrl(point);
   const statusLabel = isStale ? "Last known location" : "Live location";
   return (
-    <div className="overflow-hidden rounded-[var(--app-card-radius-standard)] border border-border/70 bg-[color:var(--app-card-surface-default-solid)]">
-      <div className="relative h-56 overflow-hidden bg-[#e5e5ea] dark:bg-[#111113]">
+    <div className="w-full min-w-0 max-w-full overflow-hidden rounded-[var(--app-card-radius-standard)] border border-border/70 bg-[color:var(--app-card-surface-default-solid)]">
+      <div className="relative h-48 max-w-full overflow-hidden bg-[#e5e5ea] sm:h-56 dark:bg-[#111113]">
         <iframe
           title="Live location map preview"
           src={embedUrl}
@@ -818,7 +711,7 @@ function LocalMapPreview({ point }: { point: PlainLocationPoint }) {
           <p className="text-[15px] font-semibold text-foreground">
             {statusLabel}
           </p>
-          <p className="mt-1 text-[12px] font-medium text-muted-foreground">
+          <p className="mt-1 break-words text-[12px] font-medium text-muted-foreground [overflow-wrap:anywhere]">
             Updated {captured}
             {accuracy ? ` - ${accuracy}` : ""} -{" "}
             {locationSourceLabel(point.sourcePlatform)}
@@ -830,7 +723,7 @@ function LocalMapPreview({ point }: { point: PlainLocationPoint }) {
             asChild
             variant="outline"
             size="sm"
-            className="h-10 rounded-full border-[#0a84ff]/30 bg-[#0a84ff]/10 text-[#0066cc] hover:bg-[#0a84ff]/15 dark:text-[#76b7ff]"
+            className="h-10 w-full min-w-0 rounded-full border-[#0a84ff]/30 bg-[#0a84ff]/10 text-[#0066cc] hover:bg-[#0a84ff]/15 dark:text-[#76b7ff]"
           >
             <a
               href={directionsUrl}
@@ -845,7 +738,7 @@ function LocalMapPreview({ point }: { point: PlainLocationPoint }) {
           <Button
             asChild
             size="sm"
-            className="h-10 rounded-full bg-[#1c1c1e] text-white hover:bg-black dark:bg-white dark:text-[#1c1c1e] dark:hover:bg-white/90"
+            className="h-10 w-full min-w-0 rounded-full bg-[#1c1c1e] text-white hover:bg-black dark:bg-white dark:text-[#1c1c1e] dark:hover:bg-white/90"
           >
             <a
               href={startUrl}
@@ -863,10 +756,10 @@ function LocalMapPreview({ point }: { point: PlainLocationPoint }) {
       {isStale ? (
         <div
           role="status"
-          className="mx-3 mb-3 flex items-start gap-2 rounded-[12px] border border-amber-500/35 bg-amber-500/10 px-3 py-2 text-[12px] font-medium text-amber-800 dark:text-amber-100"
+          className="mx-3 mb-3 flex min-w-0 items-start gap-2 rounded-[12px] border border-amber-500/35 bg-amber-500/10 px-3 py-2 text-[12px] font-medium text-amber-800 dark:text-amber-100"
         >
           <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
-          <span>
+          <span className="min-w-0 break-words [overflow-wrap:anywhere]">
             Location update may be stale. Ask them to refresh sharing.
           </span>
         </div>
@@ -907,9 +800,13 @@ function SkeletonRow({ wide = false }: { wide?: boolean }) {
 type ShareMode = "share" | "request";
 
 const onePanelClassName =
-  "overflow-hidden rounded-[20px] border border-black/[0.05] bg-white shadow-[0_1px_2px_rgba(0,0,0,0.04),0_10px_30px_rgba(15,23,42,0.05)] dark:border-white/[0.08] dark:bg-[#1c1c1e]/90 dark:shadow-[0_12px_38px_rgba(0,0,0,0.28)]";
+  "w-full min-w-0 max-w-full overflow-x-hidden rounded-[20px] border border-black/[0.05] bg-white shadow-[0_1px_2px_rgba(0,0,0,0.04),0_10px_30px_rgba(15,23,42,0.05)] dark:border-white/[0.08] dark:bg-[#1c1c1e]/90 dark:shadow-[0_12px_38px_rgba(0,0,0,0.28)]";
+const oneScrollablePanelClassName = cn(
+  onePanelClassName,
+  "max-h-[min(70dvh,560px)] overflow-y-auto overscroll-contain [scrollbar-width:thin] [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-black/20 dark:[&::-webkit-scrollbar-thumb]:bg-white/20",
+);
 const oneInsetClassName =
-  "rounded-[14px] border border-black/[0.04] bg-[#f7f7fa] text-[#1c1c1e] dark:border-white/[0.08] dark:bg-white/[0.07] dark:text-white";
+  "w-full min-w-0 max-w-full overflow-hidden rounded-[14px] border border-black/[0.04] bg-[#f7f7fa] text-[#1c1c1e] dark:border-white/[0.08] dark:bg-white/[0.07] dark:text-white";
 const oneSecondaryTextClassName = "text-[#8e8e93] dark:text-white/55";
 
 function sectionLabel(title: string, count?: number) {
@@ -917,7 +814,7 @@ function sectionLabel(title: string, count?: number) {
     <div
       role="heading"
       aria-level={2}
-      className="ml-1 flex items-center gap-1.5 text-[12px] font-semibold uppercase tracking-[0.08em] text-[#8e8e93] dark:text-white/45"
+      className="ml-1 flex min-w-0 max-w-full flex-wrap items-center gap-1.5 text-[12px] font-semibold uppercase tracking-[0.08em] text-[#8e8e93] dark:text-white/45"
     >
       {title}
       {typeof count === "number" && count > 0 ? (
@@ -987,47 +884,6 @@ function AvatarBubble({
   );
 }
 
-function PromiseCard({
-  icon: Icon,
-  title,
-  description,
-  tone,
-}: {
-  icon: LucideIcon;
-  title: string;
-  description: string;
-  tone: "blue" | "green" | "orange";
-}) {
-  const toneClassName = {
-    blue: "bg-[#eaf3ff] text-[#007aff] dark:bg-[#0a84ff]/15 dark:text-[#76b7ff]",
-    green:
-      "bg-[#eaf9ef] text-[#2dbd5a] dark:bg-emerald-400/15 dark:text-emerald-200",
-    orange:
-      "bg-[#fff3e6] text-[#ff9500] dark:bg-orange-400/15 dark:text-orange-200",
-  }[tone];
-
-  return (
-    <div className="flex items-center gap-4 rounded-[20px] border border-black/[0.06] bg-white p-4 shadow-[0_2px_12px_rgba(15,23,42,0.06)] dark:border-white/[0.08] dark:bg-[#1c1c1e]/90 dark:shadow-[0_12px_30px_rgba(0,0,0,0.22)]">
-      <span
-        className={cn(
-          "flex h-11 w-11 shrink-0 items-center justify-center rounded-full",
-          toneClassName,
-        )}
-      >
-        <Icon className="h-5 w-5" aria-hidden="true" />
-      </span>
-      <div className="min-w-0">
-        <h3 className="text-[16px] font-bold tracking-tight text-[#1c1c1e] dark:text-white">
-          {title}
-        </h3>
-        <p className="mt-1 text-[14px] font-medium leading-snug text-[#8e8e93] dark:text-white/55">
-          {description}
-        </p>
-      </div>
-    </div>
-  );
-}
-
 function SegmentedModeControl({
   value,
   onChange,
@@ -1036,7 +892,7 @@ function SegmentedModeControl({
   onChange: (value: ShareMode) => void;
 }) {
   return (
-    <div className="flex h-9 w-full items-center rounded-[9px] bg-[#efeff0] p-[3px] dark:bg-white/10">
+    <div className="flex h-9 w-full min-w-0 max-w-full items-center overflow-hidden rounded-[9px] bg-[#efeff0] p-[3px] dark:bg-white/10">
       {(["share", "request"] as const).map((mode) => (
         <button
           key={mode}
@@ -1066,20 +922,173 @@ function EmptyOneState({
   description: string;
 }) {
   return (
-    <div className="flex min-h-24 items-center gap-3 p-3.5 text-sm">
+    <div className="flex min-h-24 min-w-0 max-w-full flex-col items-start gap-3 p-3.5 text-sm sm:flex-row sm:items-center">
       <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#f2f2f7] text-[#8e8e93] dark:bg-white/10 dark:text-white/55">
         <Icon className="h-4 w-4" aria-hidden="true" />
       </span>
-      <div className="min-w-0">
+      <div className="min-w-0 flex-1">
         <div className="font-semibold text-[#1c1c1e] dark:text-white">
           {title}
         </div>
-        <div className="text-[13px] leading-5 text-[#8e8e93] dark:text-white/55">
+        <div className="break-words text-[13px] leading-5 text-[#8e8e93] [overflow-wrap:anywhere] dark:text-white/55">
           {description}
         </div>
       </div>
     </div>
   );
+}
+
+function isLocationServicesDisabled(
+  permission: HushhLocationPermissionState | null,
+): boolean {
+  return permission?.locationServicesEnabled === false;
+}
+
+function locationPermissionBlocksSharing(
+  permission: HushhLocationPermissionState | null,
+): boolean {
+  return (
+    isLocationServicesDisabled(permission) ||
+    permission?.state === "denied" ||
+    permission?.state === "restricted" ||
+    permission?.state === "unavailable"
+  );
+}
+
+function locationServicesErrorMessage(error: unknown): string {
+  const message =
+    error instanceof Error
+      ? error.message
+      : String((error as { message?: unknown })?.message || error || "");
+  const normalized = message.toLowerCase();
+  if (
+    normalized.includes("services are unavailable") ||
+    normalized.includes("location services") ||
+    normalized.includes("provider") ||
+    normalized.includes("unavailable on this device")
+  ) {
+    return "Turn on Location from your phone settings before sharing.";
+  }
+  if (normalized.includes("permission") || normalized.includes("not granted")) {
+    return "Allow location permission before sharing.";
+  }
+  return message || "Location is needed before sharing.";
+}
+
+function isShareAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+function oneLocationPublicShareMessage(url: string): string {
+  return `${ONE_LOCATION_PUBLIC_SHARE_COPY}\n${url}`;
+}
+
+async function shareOneLocationLink(params: {
+  title: string;
+  text: string;
+  url: string;
+  dialogTitle: string;
+}): Promise<"native-share" | "web-share" | "copied"> {
+  const url = publicInviteUrlLabel(params.url.trim());
+  if (!url) {
+    throw new Error("Create a public location link before sharing.");
+  }
+  const message = oneLocationPublicShareMessage(url);
+
+  const { Capacitor } = await import("@capacitor/core");
+  if (Capacitor.isNativePlatform()) {
+    const { Share } = (await import("@capacitor/share")) as typeof import("@capacitor/share");
+    if (Capacitor.getPlatform() === "android") {
+      await Share.share({
+        title: params.title,
+        text: message,
+        dialogTitle: params.dialogTitle,
+      });
+      return "native-share";
+    }
+    await Share.share({
+      title: params.title,
+      text: params.text,
+      url,
+      dialogTitle: params.dialogTitle,
+    });
+    return "native-share";
+  }
+
+  if (typeof navigator !== "undefined" && typeof navigator.share === "function") {
+    await navigator.share({
+      title: params.title,
+      text: params.text,
+      url,
+    });
+    return "web-share";
+  }
+
+  if (typeof navigator !== "undefined" && navigator.clipboard) {
+    await navigator.clipboard.writeText(message);
+    return "copied";
+  }
+
+  throw new Error("Sharing is not supported on this device.");
+}
+
+function readinessCopy(permission: HushhLocationPermissionState | null): {
+  title: string;
+  description: string;
+  tone: "ready" | "warning" | "blocked" | "checking";
+  actionLabel?: string;
+} {
+  if (!permission) {
+    return {
+      title: "Checking location readiness",
+      description: "One is checking whether this device can share your current location.",
+      tone: "checking",
+    };
+  }
+  if (isLocationServicesDisabled(permission)) {
+    return {
+      title: "Turn on phone Location",
+      description:
+        "Your phone Location switch is off. Turn it on before sharing with your trusted circle.",
+      tone: "blocked",
+      actionLabel: "Open Location Settings",
+    };
+  }
+  if (permission.state === "prompt") {
+    return {
+      title: "Allow location permission",
+      description:
+        "One will ask for foreground location access before your first encrypted share.",
+      tone: "warning",
+      actionLabel: "Allow Location",
+    };
+  }
+  if (permission.state === "denied" || permission.state === "restricted") {
+    return {
+      title: "Location permission blocked",
+      description:
+        "Allow location access from app settings before you share your location.",
+      tone: "blocked",
+      actionLabel: "Open Location Settings",
+    };
+  }
+  if (permission.state === "unavailable") {
+    return {
+      title: "Location unavailable",
+      description:
+        "This device cannot provide a fresh location right now. Check Location settings and try again.",
+      tone: "blocked",
+      actionLabel: "Open Location Settings",
+    };
+  }
+  return {
+    title: permission.precise === false ? "Approximate location ready" : "Location ready",
+    description:
+      permission.precise === false
+        ? "Sharing can continue, but accuracy may be approximate on this device."
+        : "Foreground location is ready for encrypted sharing.",
+    tone: permission.precise === false ? "warning" : "ready",
+  };
 }
 
 function OneLocationInitialSkeleton() {
@@ -1109,22 +1118,18 @@ function OneLocationInitialSkeleton() {
         </SettingsGroup>
       </div>
       <div className="space-y-6">
-        <SettingsGroup eyebrow="Owner" title="People who can see me">
-          <SkeletonRow wide />
-          <SkeletonRow />
-        </SettingsGroup>
-        <SettingsGroup eyebrow="Recipient" title="Shared with me">
-          <SkeletonRow wide />
-        </SettingsGroup>
         <SettingsGroup eyebrow="Approvals" title="Pending requests">
           <SkeletonRow />
+        </SettingsGroup>
+        <SettingsGroup eyebrow="Location" title="Shared with me">
+          <SkeletonRow wide />
         </SettingsGroup>
       </div>
     </div>
   );
 }
 
-export function OneLocationAgentPageContent() {
+function OneLocationAgentPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const auth = useRequireAuth();
@@ -1137,6 +1142,7 @@ export function OneLocationAgentPageContent() {
   const [activeMode, setActiveMode] = useState<ShareMode>("share");
   const [shareReviewOpen, setShareReviewOpen] = useState(false);
   const [recipientSearch, setRecipientSearch] = useState("");
+  const [oneNetworkListExpanded, setOneNetworkListExpanded] = useState(false);
   const [selectedRecipientId, setSelectedRecipientId] = useState("");
   const [selectedRequestOwnerId, setSelectedRequestOwnerId] = useState("");
   const [selectedRecipientIds, setSelectedRecipientIds] = useState<string[]>(
@@ -1159,11 +1165,25 @@ export function OneLocationAgentPageContent() {
     Record<string, string>
   >({});
   const [publicInviteUrl, setPublicInviteUrl] = useState("");
+  const [myLocationPoint, setMyLocationPoint] =
+    useState<PlainLocationPoint | null>(null);
+  const [myLocationError, setMyLocationError] = useState<string | null>(null);
   const [decryptedPoints, setDecryptedPoints] = useState<
     Record<string, PlainLocationPoint>
   >({});
   const [openedGrantTick, setOpenedGrantTick] = useState(0);
+  const [focusedSection, setFocusedSection] =
+    useState<OneLocationFocusTarget | null>(null);
   const refreshInFlightRef = useRef<Promise<void> | null>(null);
+  const permissionPromptInFlightRef = useRef(false);
+  const locationLandingPromptUserRef = useRef<string | null>(null);
+  const peopleSectionRef = useRef<HTMLElement | null>(null);
+  const approvalsSectionRef = useRef<HTMLElement | null>(null);
+  const sharedSectionRef = useRef<HTMLElement | null>(null);
+  const myRequestsSectionRef = useRef<HTMLElement | null>(null);
+  const publicResponsesSectionRef = useRef<HTMLElement | null>(null);
+  const activitySectionRef = useRef<HTMLElement | null>(null);
+  const focusClearRef = useRef<number | null>(null);
   const livePublishInFlightRef = useRef(false);
   const liveViewInFlightRef = useRef(false);
 
@@ -1194,10 +1214,21 @@ export function OneLocationAgentPageContent() {
       recommendationSearchText(recipient).includes(query),
     );
   }, [rankedRecipients, recipientSearch]);
-  const kaiCircleSections = useMemo(
-    () => buildKaiCircleSections(visibleRecipients),
-    [visibleRecipients],
+  const hasMoreVisibleRecipients =
+    visibleRecipients.length > ONE_NETWORK_PREVIEW_LIMIT;
+  const showExpandedOneNetworkList =
+    oneNetworkListExpanded && hasMoreVisibleRecipients;
+  const displayedVisibleRecipients = useMemo(
+    () =>
+      showExpandedOneNetworkList
+        ? visibleRecipients
+        : visibleRecipients.slice(0, ONE_NETWORK_PREVIEW_LIMIT),
+    [showExpandedOneNetworkList, visibleRecipients],
   );
+
+  useEffect(() => {
+    setOneNetworkListExpanded(false);
+  }, [recipientSearch]);
   const selectedShareRecipients = useMemo(
     () => recipientSelectionFromIds(contactSignalRecipients, selectedRecipientIds),
     [contactSignalRecipients, selectedRecipientIds],
@@ -1262,6 +1293,15 @@ export function OneLocationAgentPageContent() {
       ),
     [state?.publicInvites],
   );
+  const latestActivePublicInvite = useMemo(() => {
+    const inviteTime = (invite: OneLocationPublicInvite) =>
+      Date.parse(
+        invite.createdAt || invite.updatedAt || invite.expiresAt || "",
+      ) || 0;
+    return [...activePublicInvites].sort(
+      (left, right) => inviteTime(right) - inviteTime(left),
+    )[0] ?? null;
+  }, [activePublicInvites]);
   const publicSubmissions = useMemo(
     () => state?.publicInviteSubmissions ?? [],
     [state?.publicInviteSubmissions],
@@ -1271,7 +1311,44 @@ export function OneLocationAgentPageContent() {
     [activityRange, auth.userId, state],
   );
   const locationActivity = activitySnapshot ?? fallbackActivity;
+  const focusOneLocationSection = useCallback(
+    (target: OneLocationFocusTarget | null) => {
+      if (!target || typeof window === "undefined") return;
+      const sectionRefs: Record<
+        OneLocationFocusTarget,
+        MutableRefObject<HTMLElement | null>
+      > = {
+        people: peopleSectionRef,
+        approvals: approvalsSectionRef,
+        shared: sharedSectionRef,
+        my_requests: myRequestsSectionRef,
+        public_responses: publicResponsesSectionRef,
+        activity: activitySectionRef,
+      };
+      window.setTimeout(() => {
+        const element = sectionRefs[target]?.current;
+        if (!element) return;
+        element.scrollIntoView({ behavior: "smooth", block: "start" });
+        element.focus({ preventScroll: true });
+        setFocusedSection(target);
+        if (focusClearRef.current) {
+          window.clearTimeout(focusClearRef.current);
+        }
+        focusClearRef.current = window.setTimeout(() => {
+          setFocusedSection((current) => (current === target ? null : current));
+        }, 2200);
+      }, 80);
+    },
+    [],
+  );
 
+  const sectionFocusClassName = useCallback(
+    (target: OneLocationFocusTarget) =>
+      focusedSection === target
+        ? "rounded-[22px] ring-2 ring-[#007aff]/35 ring-offset-2 ring-offset-transparent"
+        : "",
+    [focusedSection],
+  );
   useEffect(() => {
     if (!auth.userId || !vaultOwnerToken || !state) {
       setActivitySnapshot(null);
@@ -1308,8 +1385,9 @@ export function OneLocationAgentPageContent() {
       markOneLocationGrantOpened(auth.userId, grantId);
       setOpenedGrantTick((value) => value + 1);
       router.push(buildOneLocationNotificationHref(grantId), { scroll: false });
+      focusOneLocationSection("shared");
     },
-    [auth.userId, router],
+    [auth.userId, focusOneLocationSection, router],
   );
 
   const showLocationShareToast = useCallback(
@@ -1349,6 +1427,92 @@ export function OneLocationAgentPageContent() {
     [auth.userId, openLocationShareFromNotification],
   );
 
+  const showWorkflowToast = useCallback(
+    (params: {
+      notificationType: OneLocationWorkflowNotificationType;
+      id: string;
+      ownerLabel?: string | null;
+      requesterLabel?: string | null;
+      referringLabel?: string | null;
+      visitorLabel?: string | null;
+      grantId?: string | null;
+      requestId?: string | null;
+      referralId?: string | null;
+      submissionId?: string | null;
+      section?: OneLocationFocusTarget | null;
+      openGrant?: boolean;
+    }) => {
+      if (!auth.userId) return;
+      const section =
+        params.section ||
+        oneLocationSectionForWorkflowNotificationType(params.notificationType);
+      const copy = locationWorkflowNotificationCopy({
+        type: params.notificationType,
+        ownerLabel: params.ownerLabel,
+        requesterLabel: params.requesterLabel,
+        referringLabel: params.referringLabel,
+        visitorLabel: params.visitorLabel,
+      });
+      const routeHref = buildOneLocationWorkflowHref({
+        grantId: params.grantId,
+        requestId: params.requestId,
+        referralId: params.referralId,
+        submissionId: params.submissionId,
+        section,
+        openGrant: params.openGrant,
+      });
+      const created = recordOneLocationWorkflowNotification({
+        userId: auth.userId,
+        notificationType: params.notificationType,
+        id: params.id,
+        title: copy.title,
+        description: copy.description,
+        routeHref,
+        metadata: {
+          grantId: params.grantId || null,
+          requestId: params.requestId || null,
+          referralId: params.referralId || null,
+          submissionId: params.submissionId || null,
+          section,
+        },
+      });
+      if (!created) return;
+
+      playOneLocationNotificationSound();
+      const toastKey = `one-location-workflow:${params.notificationType}:${params.id}`;
+      toast(
+        <div className="flex flex-col gap-2">
+          <div className="space-y-0.5">
+            <p className="line-clamp-1 text-sm font-semibold">{copy.title}</p>
+            <p className="line-clamp-2 text-xs text-muted-foreground">
+              {copy.description}
+            </p>
+          </div>
+          <button
+            onClick={() => {
+              if (params.openGrant && params.grantId) {
+                markOneLocationGrantOpened(auth.userId, params.grantId);
+                setOpenedGrantTick((value) => value + 1);
+              }
+              toast.dismiss(toastKey);
+              router.push(routeHref, { scroll: false });
+              focusOneLocationSection(section);
+            }}
+            className="rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background transition-colors"
+          >
+            Open
+          </button>
+        </div>,
+        {
+          id: toastKey,
+          duration: 10000,
+          position: "top-center",
+        },
+      );
+    },
+    [auth.userId, focusOneLocationSection, router],
+  );
+
   const refresh = useCallback(async () => {
     if (!auth.userId) {
       setBusy(null);
@@ -1374,17 +1538,12 @@ export function OneLocationAgentPageContent() {
     const task = (async () => {
       setLoadError(null);
       try {
-        if (activeUser) {
-          await AccountIdentityService.syncCurrentUser(activeUser).catch(
-            (error) => {
-              console.warn(
-                "[OneLocationAgent] Identity shadow sync skipped:",
-                error,
-              );
-              return null;
-            },
-          );
+        if (!activeUser) {
+          throw new Error("Refresh your session before loading location sharing.");
         }
+        await AccountIdentityService.syncCurrentUser(activeUser).catch((error) => {
+          console.warn("[OneLocation] Failed to sync account identity:", error);
+        });
         const key = await ensureLocationRecipientKey(activeUserId);
         await OneLocationService.registerRecipientKey({
           vaultOwnerToken: activeVaultOwnerToken,
@@ -1462,11 +1621,173 @@ export function OneLocationAgentPageContent() {
     vaultOwnerToken,
   ]);
 
+  const refreshLocationPermission = useCallback(async () => {
+    const nextPermission = await OneLocationService.getPermissionState().catch(
+      () => ({
+        state: "unavailable" as const,
+        precise: false,
+        background: "unavailable" as const,
+        locationServicesEnabled: null,
+      }),
+    );
+    setPermission(nextPermission);
+    return nextPermission;
+  }, []);
+
+  const handleOpenLocationSettings = useCallback(async () => {
+    setBusy("locationSettings");
+    try {
+      const result = await OneLocationService.openLocationSettings();
+      toast.info(
+        result.opened
+          ? "Turn on Location, then return to One Location and refresh."
+          : "Open your phone or browser location settings, then return and refresh.",
+      );
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Could not open location settings.",
+      );
+    } finally {
+      setBusy(null);
+      window.setTimeout(() => void refreshLocationPermission(), 1200);
+    }
+  }, [refreshLocationPermission]);
+
+  const ensureForegroundLocationReady = useCallback(
+    async (options?: {
+      capturePoint?: boolean;
+      autoOpenSettings?: boolean;
+      requestNativePrompt?: boolean;
+    }): Promise<{ ready: boolean; point?: PlainLocationPoint }> => {
+      const shouldCapturePoint = Boolean(options?.capturePoint);
+      const shouldOpenSettings = options?.autoOpenSettings !== false;
+      const shouldRequestNativePrompt = options?.requestNativePrompt === true;
+      const currentPermission = await refreshLocationPermission();
+
+      if (isLocationServicesDisabled(currentPermission)) {
+        toast.error("Turn on phone Location before sharing.");
+        if (shouldOpenSettings) {
+          await OneLocationService.openLocationSettings().catch(() => null);
+        }
+        return { ready: false };
+      }
+
+      if (
+        currentPermission.state === "restricted" ||
+        (currentPermission.state === "denied" && !shouldRequestNativePrompt)
+      ) {
+        toast.error("Allow location permission before sharing.");
+        if (shouldOpenSettings) {
+          await OneLocationService.openLocationSettings().catch(() => null);
+        }
+        return { ready: false };
+      }
+
+      if (currentPermission.state === "unavailable") {
+        toast.error("Location is unavailable. Check your phone Location settings.");
+        if (shouldOpenSettings) {
+          await OneLocationService.openLocationSettings().catch(() => null);
+        }
+        return { ready: false };
+      }
+
+      if (currentPermission.state === "granted" && !shouldCapturePoint) {
+        return { ready: true };
+      }
+
+      try {
+        const point = await OneLocationService.captureCurrentPosition();
+        const nextPermission = await OneLocationService.getPermissionState().catch(
+          () => null,
+        );
+        setPermission(
+          nextPermission ?? {
+            state: "granted",
+            precise: null,
+            background: "foreground-only",
+            locationServicesEnabled: true,
+          },
+        );
+        return shouldCapturePoint ? { ready: true, point } : { ready: true };
+      } catch (error) {
+        const nextPermission = await OneLocationService.getPermissionState().catch(
+          () => null,
+        );
+        if (nextPermission) {
+          setPermission(nextPermission);
+        }
+        const message = locationServicesErrorMessage(error);
+        toast.error(message);
+        if (
+          shouldOpenSettings &&
+          (isLocationServicesDisabled(nextPermission) ||
+            message.toLowerCase().includes("turn on location"))
+        ) {
+          await OneLocationService.openLocationSettings().catch(() => null);
+        }
+        return { ready: false };
+      }
+    },
+    [refreshLocationPermission],
+  );
+
   useEffect(() => {
     if (!auth.loading) {
       void refresh();
     }
   }, [auth.loading, refresh]);
+
+  useEffect(() => {
+    if (
+      !auth.userId ||
+      !state ||
+      locationLandingPromptUserRef.current === auth.userId ||
+      permissionPromptInFlightRef.current
+    ) {
+      return;
+    }
+    const canRequestNativePrompt =
+      !permission ||
+      permission.state === "prompt" ||
+      permission.state === "denied";
+    if (!canRequestNativePrompt || isLocationServicesDisabled(permission)) {
+      return;
+    }
+
+    let cancelled = false;
+    locationLandingPromptUserRef.current = auth.userId;
+    permissionPromptInFlightRef.current = true;
+    const promptForForegroundLocation = async () => {
+      try {
+        await ensureForegroundLocationReady({
+          capturePoint: false,
+          autoOpenSettings: false,
+          requestNativePrompt: true,
+        });
+      } finally {
+        if (!cancelled) {
+          permissionPromptInFlightRef.current = false;
+        }
+      }
+    };
+
+    void promptForForegroundLocation();
+
+    return () => {
+      cancelled = true;
+      permissionPromptInFlightRef.current = false;
+    };
+  }, [auth.userId, ensureForegroundLocationReady, permission, state]);
+
+  useEffect(() => {
+    return () => {
+      if (focusClearRef.current && typeof window !== "undefined") {
+        window.clearTimeout(focusClearRef.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     if (!auth.userId || typeof window === "undefined") return;
@@ -1496,18 +1817,62 @@ export function OneLocationAgentPageContent() {
   }, [auth.userId, refresh]);
 
   useEffect(() => {
-    if (!auth.userId) return;
+    if (!auth.userId || !state) return;
     const grantId = String(
       searchParams.get(ONE_LOCATION_GRANT_ID_PARAM) || "",
     ).trim();
+    const requestId = String(
+      searchParams.get(ONE_LOCATION_REQUEST_ID_PARAM) || "",
+    ).trim();
+    const referralId = String(
+      searchParams.get(ONE_LOCATION_REFERRAL_ID_PARAM) || "",
+    ).trim();
+    const submissionId = String(
+      searchParams.get(ONE_LOCATION_SUBMISSION_ID_PARAM) || "",
+    ).trim();
+    const section = String(
+      searchParams.get(ONE_LOCATION_SECTION_PARAM) || "",
+    ).trim() as OneLocationFocusTarget | "";
     const notificationState = String(
       searchParams.get(ONE_LOCATION_NOTIFICATION_OPEN_PARAM) || "",
     ).trim();
+    let focusTarget: OneLocationFocusTarget | null =
+      section && [
+        "people",
+        "approvals",
+        "shared",
+        "my_requests",
+        "public_responses",
+        "activity",
+      ].includes(section)
+        ? section
+        : null;
     if (grantId && notificationState === ONE_LOCATION_NOTIFICATION_OPEN_VALUE) {
       markOneLocationGrantOpened(auth.userId, grantId);
       setOpenedGrantTick((value) => value + 1);
+      focusTarget = focusTarget || "shared";
     }
-  }, [auth.userId, searchParams]);
+    if (requestId) {
+      focusTarget =
+        focusTarget ||
+        (pendingOwnerRequests.some((request) => request.id === requestId)
+          ? "approvals"
+          : "my_requests");
+    }
+    if (referralId) {
+      focusTarget = focusTarget || "my_requests";
+    }
+    if (submissionId) {
+      focusTarget = focusTarget || "public_responses";
+    }
+    focusOneLocationSection(focusTarget);
+  }, [
+    auth.userId,
+    focusOneLocationSection,
+    pendingOwnerRequests,
+    searchParams,
+    state,
+  ]);
 
   useEffect(() => {
     if (!auth.userId || typeof window === "undefined") return;
@@ -1548,6 +1913,84 @@ export function OneLocationAgentPageContent() {
     openedGrantTick,
     showLocationShareToast,
     state?.receivedGrants,
+  ]);
+
+  useEffect(() => {
+    if (!auth.userId || !state) return;
+
+    for (const request of pendingOwnerRequests) {
+      showWorkflowToast({
+        notificationType: "location_access_request",
+        id: request.id,
+        requestId: request.id,
+        requesterLabel: requestLabel(request),
+        section: "approvals",
+      });
+    }
+
+    for (const request of requestedByMe) {
+      const ownerLabel = requestOwnerLabel(request, recipients);
+      if (request.status === "approved") {
+        showWorkflowToast({
+          notificationType: "location_access_approved",
+          id: request.approvedGrantId || request.id,
+          requestId: request.id,
+          grantId: request.approvedGrantId,
+          ownerLabel,
+          section: "shared",
+          openGrant: Boolean(request.approvedGrantId),
+        });
+      }
+      if (request.status === "denied") {
+        showWorkflowToast({
+          notificationType: "location_access_denied",
+          id: request.id,
+          requestId: request.id,
+          ownerLabel,
+          section: "my_requests",
+        });
+      }
+    }
+
+    for (const grant of state.receivedGrants ?? []) {
+      if (grant.status === "revoked") {
+        showWorkflowToast({
+          notificationType: "location_share_revoked",
+          id: grant.id,
+          grantId: grant.id,
+          ownerLabel: receivedGrantOwnerLabel(grant),
+          section: "shared",
+        });
+      }
+      if (grant.status === "expired") {
+        showWorkflowToast({
+          notificationType: "location_share_expired",
+          id: grant.id,
+          grantId: grant.id,
+          ownerLabel: receivedGrantOwnerLabel(grant),
+          section: "shared",
+        });
+      }
+    }
+
+    for (const submission of publicSubmissions) {
+      if (submission.ownerUserId !== auth.userId) continue;
+      showWorkflowToast({
+        notificationType: "location_public_invite_submitted",
+        id: submission.id,
+        submissionId: submission.id,
+        visitorLabel: publicSubmissionLabel(submission),
+        section: "public_responses",
+      });
+    }
+  }, [
+    auth.userId,
+    pendingOwnerRequests,
+    publicSubmissions,
+    recipients,
+    requestedByMe,
+    showWorkflowToast,
+    state,
   ]);
 
   const recipientForGrant = useCallback(
@@ -1606,15 +2049,20 @@ export function OneLocationAgentPageContent() {
       !vaultOwnerToken ||
       !shareReadySelectedRecipients.length ||
       setupNeededSelectedRecipients.length ||
-      permission?.state === "denied" ||
-      permission?.state === "restricted" ||
-      permission?.state === "unavailable"
+      locationPermissionBlocksSharing(permission)
     )
       return;
     setBusy("share");
     let successCount = 0;
     try {
-      const point = await OneLocationService.captureCurrentPosition();
+      const readiness = await ensureForegroundLocationReady({
+        capturePoint: true,
+        autoOpenSettings: true,
+      });
+      if (!readiness.ready || !readiness.point) {
+        return;
+      }
+      const point = readiness.point;
       for (const recipient of shareReadySelectedRecipients) {
         const grant = await OneLocationService.createGrant({
           vaultOwnerToken,
@@ -1661,7 +2109,8 @@ export function OneLocationAgentPageContent() {
     }
   }, [
     durationHours,
-    permission?.state,
+    ensureForegroundLocationReady,
+    permission,
     publishEnvelopeWithRetry,
     refresh,
     setupNeededSelectedRecipients.length,
@@ -1679,7 +2128,14 @@ export function OneLocationAgentPageContent() {
       }
       setBusy("publish");
       try {
-        await publishEnvelopeWithRetry(grant, recipient, "manual");
+        const readiness = await ensureForegroundLocationReady({
+          capturePoint: true,
+          autoOpenSettings: true,
+        });
+        if (!readiness.ready || !readiness.point) {
+          return;
+        }
+        await publishEnvelopeWithRetry(grant, recipient, "manual", readiness.point);
         toast.success("Encrypted location update published.");
         await refresh();
       } catch (error) {
@@ -1690,7 +2146,7 @@ export function OneLocationAgentPageContent() {
         setBusy(null);
       }
     },
-    [publishEnvelopeWithRetry, recipientForGrant, refresh],
+    [ensureForegroundLocationReady, publishEnvelopeWithRetry, recipientForGrant, refresh],
   );
 
   const viewGrantEnvelope = useCallback(
@@ -1778,6 +2234,7 @@ export function OneLocationAgentPageContent() {
           );
         }
       } catch (error) {
+        void refreshLocationPermission();
         console.warn(
           "[OneLocationAgent] Foreground live update skipped:",
           error,
@@ -1799,6 +2256,7 @@ export function OneLocationAgentPageContent() {
     permission?.state,
     publishEnvelopeWithRetry,
     recipientForGrant,
+    refreshLocationPermission,
     vaultOwnerToken,
   ]);
 
@@ -1904,7 +2362,7 @@ export function OneLocationAgentPageContent() {
           )} added as a contact signal.`,
         );
       } else {
-        toast.info("No KAI users matched from this contact scan.");
+        toast.info("No One users matched from this contact scan.");
       }
     } catch (error) {
       const message = oneLocationErrorMessage(
@@ -2047,21 +2505,18 @@ export function OneLocationAgentPageContent() {
 
   const handleSharePublicInvite = useCallback(async () => {
     if (!publicInviteUrl) return;
-    const text =
-      "View my One Location location update here after entering your details.";
     try {
-      if (navigator.share) {
-        await navigator.share({
-          title: "View my location",
-          text,
-          url: publicInviteUrl,
-        });
-        return;
+      const delivery = await shareOneLocationLink({
+        title: ONE_LOCATION_SHARE_TITLE,
+        text: ONE_LOCATION_PUBLIC_SHARE_COPY,
+        url: publicInviteUrl,
+        dialogTitle: "Share to contacts",
+      });
+      if (delivery === "copied") {
+        toast.success("Public location link copied.");
       }
-      await navigator.clipboard.writeText(publicInviteUrl);
-      toast.success("Public location link copied.");
     } catch (error) {
-      if ((error as Error)?.name === "AbortError") return;
+      if (isShareAbortError(error)) return;
       toast.error("Could not open the share sheet.");
     }
   }, [publicInviteUrl]);
@@ -2090,24 +2545,17 @@ export function OneLocationAgentPageContent() {
         await refresh();
       }
 
-      const text =
-        "Join my KAI Circle on One Location. You can view my public location update here after entering your details.";
-      if (navigator.share && url) {
-        await navigator.share({
-          title: "Join my KAI Circle",
-          text,
-          url,
-        });
-        return;
-      }
-      if (navigator.clipboard && url) {
-        await navigator.clipboard.writeText(`${text} ${url}`);
+      const delivery = await shareOneLocationLink({
+        title: ONE_LOCATION_SHARE_TITLE,
+        text: ONE_LOCATION_PUBLIC_SHARE_COPY,
+        url,
+        dialogTitle: "Share to contacts",
+      });
+      if (delivery === "copied") {
         toast.success("Invite link copied.");
-        return;
       }
-      toast.info("Create a public location link, then share it with your contacts.");
     } catch (error) {
-      if ((error as Error)?.name === "AbortError") return;
+      if (isShareAbortError(error)) return;
       trackEvent("one_location_public_link_created", {
         route_id: "one_location",
         result: "error",
@@ -2374,12 +2822,17 @@ export function OneLocationAgentPageContent() {
     selectedShareRecipients.length &&
     shareReadySelectedRecipients.length &&
     !setupNeededSelectedRecipients.length &&
-    permission?.state !== "denied" &&
-    permission?.state !== "restricted" &&
-    permission?.state !== "unavailable",
+    !locationPermissionBlocksSharing(permission),
   );
-  const handleOpenShareReview = useCallback(() => {
+  const handleOpenShareReview = useCallback(async () => {
     if (!canShare) return;
+    setBusy("share");
+    const readiness = await ensureForegroundLocationReady({
+      capturePoint: false,
+      autoOpenSettings: true,
+    });
+    setBusy(null);
+    if (!readiness.ready) return;
     setShareReviewOpen(true);
     trackEvent(
       "one_location_share_review_opened",
@@ -2391,7 +2844,13 @@ export function OneLocationAgentPageContent() {
         has_permission_warning: permission?.state !== "granted",
         has_professional_signal: shareReadySelectedRecipients.some(
           (recipient) =>
-            kaiCircleSectionKey(recipient) === "professional_network",
+            recipient.recommendationCategory === "professional_network" ||
+            recipient.recommendationTier === "kai_network" ||
+            Boolean(
+              recipient.relationshipType ||
+                recipient.profileHeadline ||
+                recipient.verificationBadge,
+            ),
         ),
         has_setup_warning: Boolean(setupNeededSelectedRecipients.length),
       },
@@ -2402,6 +2861,7 @@ export function OneLocationAgentPageContent() {
   }, [
     canShare,
     durationHours,
+    ensureForegroundLocationReady,
     permission?.state,
     setupNeededSelectedRecipients.length,
     shareReadySelectedRecipients,
@@ -2417,6 +2877,45 @@ export function OneLocationAgentPageContent() {
     (auth.loading ||
       busy === "load" ||
       Boolean(auth.userId && vaultOwnerToken));
+  const locationReadiness = useMemo(
+    () => readinessCopy(permission),
+    [permission],
+  );
+  const handleRequestLocationPermission = useCallback(async () => {
+    setBusy("locationSettings");
+    try {
+      await ensureForegroundLocationReady({
+        capturePoint: false,
+        autoOpenSettings: true,
+      });
+    } finally {
+      setBusy(null);
+    }
+  }, [ensureForegroundLocationReady]);
+
+  const handleShowMyLiveLocation = useCallback(async () => {
+    setBusy("selfLocation");
+    setMyLocationError(null);
+    try {
+      const result = await ensureForegroundLocationReady({
+        capturePoint: true,
+        autoOpenSettings: true,
+      });
+      if (!result.ready || !result.point) {
+        const message = "Live location preview needs device Location permission.";
+        setMyLocationError(message);
+        return;
+      }
+      setMyLocationPoint(result.point);
+      toast.success("Your live location preview is ready.");
+    } catch (error) {
+      const message = locationServicesErrorMessage(error);
+      setMyLocationError(message);
+      toast.error(message);
+    } finally {
+      setBusy(null);
+    }
+  }, [ensureForegroundLocationReady]);
 
   return (
     <AppPageShell
@@ -2430,13 +2929,15 @@ export function OneLocationAgentPageContent() {
             ? "authenticated"
             : "anonymous",
         dataState,
-        errorCode: loadError ? "one_location_unavailable" : null,
+        errorCode: loadError
+          ? "one_location_unavailable"
+          : null,
         errorMessage: loadError,
       }}
     >
-      <AppPageHeaderRegion className="mx-auto w-full max-w-[1120px]">
+      <AppPageHeaderRegion className="mx-auto w-full max-w-[1120px] min-w-0 overflow-hidden">
         <div className="flex flex-col gap-4 px-1 pt-3 sm:flex-row sm:items-end sm:justify-between">
-          <header className="max-w-[560px] space-y-2">
+          <header className="max-w-[560px] min-w-0 space-y-2">
             <span className="text-[11px] font-bold uppercase tracking-[0.22em] text-[#007aff] dark:text-[#76b7ff]">
               When it matters most
             </span>
@@ -2449,24 +2950,26 @@ export function OneLocationAgentPageContent() {
               after they approve.
             </p>
           </header>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => void refresh()}
-            disabled={busy === "load"}
-            className="h-9 w-fit rounded-full border-black/[0.06] bg-white/80 px-3 text-[#1c1c1e] shadow-sm backdrop-blur-xl hover:bg-[#f2f2f7] dark:border-white/[0.08] dark:bg-white/10 dark:text-white dark:hover:bg-white/15"
-          >
-            {busy === "load" ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
-            ) : (
-              <RefreshCw className="mr-2 h-4 w-4" aria-hidden="true" />
-            )}
-            Refresh
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => void refresh()}
+              disabled={busy === "load"}
+              className="h-9 w-full rounded-full border-black/[0.06] bg-white/80 px-3 text-[#1c1c1e] shadow-sm backdrop-blur-xl hover:bg-[#f2f2f7] sm:w-fit dark:border-white/[0.08] dark:bg-white/10 dark:text-white dark:hover:bg-white/15"
+            >
+              {busy === "load" ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+              ) : (
+                <RefreshCw className="mr-2 h-4 w-4" aria-hidden="true" />
+              )}
+              Refresh
+            </Button>
+          </div>
         </div>
       </AppPageHeaderRegion>
 
-      <AppPageContentRegion className="mx-auto w-full max-w-[1120px] space-y-6">
+      <AppPageContentRegion className="mx-auto w-full max-w-[1120px] min-w-0 space-y-6 overflow-x-hidden pb-10 sm:pb-8">
         {loadError ? (
           <div className="rounded-[20px] border border-[#ff3b30]/30 bg-[#ff3b30]/10 p-4 text-sm text-[#ff3b30] dark:text-[#ff9f9a]">
             {loadError}
@@ -2476,38 +2979,113 @@ export function OneLocationAgentPageContent() {
         {showInitialSkeleton ? (
           <OneLocationInitialSkeleton />
         ) : (
-          <div className="grid gap-6 xl:grid-cols-[minmax(0,520px)_minmax(0,1fr)] xl:items-start">
-            <div className="space-y-7">
-              <section className="space-y-3 px-1">
-                <PromiseCard
-                  icon={LocateFixed}
-                  title="Chosen People"
-                  description="Only selected contacts can see your location."
-                  tone="blue"
-                />
-                <PromiseCard
-                  icon={ShieldCheck}
-                  title="Approval First"
-                  description="Every location request needs approval."
-                  tone="green"
-                />
-                <PromiseCard
-                  icon={KeyRound}
-                  title="Stop Anytime"
-                  description="Change access, set a time limit, or stop sharing anytime."
-                  tone="orange"
-                />
+          <div className="grid min-w-0 max-w-full gap-6 xl:grid-cols-[minmax(0,520px)_minmax(0,1fr)] xl:items-start">
+            <div className="min-w-0 max-w-full space-y-7">
+              <section className="min-w-0 max-w-full space-y-2 px-1">
+                {sectionLabel("Device readiness")}
+                <div
+                  className={cn(
+                    "flex min-w-0 max-w-full flex-col gap-3 overflow-hidden rounded-[20px] border p-3.5 shadow-sm sm:flex-row sm:items-center sm:justify-between",
+                    locationReadiness.tone === "ready" &&
+                      "border-[#34c759]/25 bg-[#34c759]/10 text-[#1c1c1e] dark:text-white",
+                    locationReadiness.tone === "warning" &&
+                      "border-[#ff9500]/30 bg-[#ff9500]/10 text-[#1c1c1e] dark:text-white",
+                    locationReadiness.tone === "blocked" &&
+                      "border-[#ff3b30]/30 bg-[#ff3b30]/10 text-[#1c1c1e] dark:text-white",
+                    locationReadiness.tone === "checking" &&
+                      "border-black/[0.04] bg-white/70 text-[#1c1c1e] dark:border-white/[0.08] dark:bg-white/[0.06] dark:text-white",
+                  )}
+                >
+                  <div className="flex min-w-0 items-start gap-3">
+                    <span
+                      className={cn(
+                        "flex h-10 w-10 shrink-0 items-center justify-center rounded-full",
+                        locationReadiness.tone === "ready" &&
+                          "bg-[#34c759]/15 text-[#2dbd5a]",
+                        locationReadiness.tone === "warning" &&
+                          "bg-[#ff9500]/15 text-[#ff9500]",
+                        locationReadiness.tone === "blocked" &&
+                          "bg-[#ff3b30]/15 text-[#ff3b30]",
+                        locationReadiness.tone === "checking" &&
+                          "bg-[#007aff]/15 text-[#007aff]",
+                      )}
+                    >
+                      {locationReadiness.tone === "ready" ? (
+                        <CheckCircle2 className="h-5 w-5" aria-hidden="true" />
+                      ) : locationReadiness.tone === "checking" ? (
+                        <Loader2 className="h-5 w-5 animate-spin" aria-hidden="true" />
+                      ) : (
+                        <AlertTriangle className="h-5 w-5" aria-hidden="true" />
+                      )}
+                    </span>
+                    <div className="min-w-0">
+                      <h3 className="break-words text-[16px] font-bold tracking-tight [overflow-wrap:anywhere]">
+                        {locationReadiness.title}
+                      </h3>
+                    </div>
+                  </div>
+                  {locationReadiness.actionLabel ? (
+                    <ActionButton
+                      busy={busy}
+                      busyKey="locationSettings"
+                      onClick={
+                        permission?.state === "prompt"
+                          ? () => void handleRequestLocationPermission()
+                          : () => void handleOpenLocationSettings()
+                      }
+                      variant="outline"
+                      className="h-10 w-full shrink-0 rounded-full border-black/[0.06] bg-white px-4 text-[13px] font-semibold text-[#1c1c1e] shadow-sm hover:bg-[#f2f2f7] sm:w-auto dark:border-white/[0.08] dark:bg-white/10 dark:text-white dark:hover:bg-white/15"
+                    >
+                      {busy !== "locationSettings" ? (
+                        <ExternalLink className="mr-2 h-4 w-4" aria-hidden="true" />
+                      ) : null}
+                      {locationReadiness.actionLabel}
+                    </ActionButton>
+                  ) : null}
+                </div>
+
+                <div className="overflow-hidden rounded-[20px] border border-black/[0.06] bg-white shadow-[0_2px_12px_rgba(15,23,42,0.06)] dark:border-white/[0.08] dark:bg-[#1c1c1e]/90 dark:shadow-[0_12px_30px_rgba(0,0,0,0.22)]">
+                  <div className="p-3.5">
+                    <Button
+                      type="button"
+                      variant="default"
+                      size="sm"
+                      onClick={() => void handleShowMyLiveLocation()}
+                      disabled={busy !== null && busy !== "selfLocation"}
+                      className="h-11 w-full shrink-0 rounded-full bg-[#007aff] px-4 text-[14px] font-semibold text-white hover:bg-[#006fe6]"
+                    >
+                      {busy === "selfLocation" ? (
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                      ) : (
+                        <LocateFixed className="mr-2 h-4 w-4" aria-hidden="true" />
+                      )}
+                      {myLocationPoint ? "Refresh location" : "Show my location"}
+                    </Button>
+                  </div>
+
+                  {myLocationError ? (
+                    <div className="mx-3.5 mb-3.5 rounded-[14px] border border-[#ff3b30]/25 bg-[#ff3b30]/10 px-3 py-2 text-[12px] font-medium text-[#b42318] dark:text-[#ff9f9a]">
+                      {myLocationError}
+                    </div>
+                  ) : null}
+
+                  {myLocationPoint ? (
+                    <div className="px-3.5 pb-3.5">
+                      <LocalMapPreview point={myLocationPoint} />
+                    </div>
+                  ) : null}
+                </div>
               </section>
 
-              <section className="space-y-4 px-1">
+              <section className="min-w-0 max-w-full space-y-4 px-1">
                 <SegmentedModeControl
                   value={activeMode}
                   onChange={setActiveMode}
                 />
 
-                <div className="space-y-2">
-                  {sectionLabel("KAI Circle")}
-                  <div className="flex gap-4 overflow-x-auto px-1 pb-2 pt-1 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                <div className="min-w-0 max-w-full space-y-2">
+                  {sectionLabel("One Network")}
+                  <div className="flex max-w-full gap-4 overflow-x-auto overscroll-x-contain px-1 pb-2 pt-1 [scrollbar-width:thin] [&::-webkit-scrollbar]:h-2 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-black/20 dark:[&::-webkit-scrollbar-thumb]:bg-white/20">
                     {rankedRecipients.length ? (
                       rankedRecipients.map((recipient, index) => {
                         const label = displayNameFromRecipient(recipient);
@@ -2523,7 +3101,7 @@ export function OneLocationAgentPageContent() {
                             type="button"
                             aria-label={`Select ${recipientLabel(
                               recipient,
-                            )} from KAI Circle`}
+                            )} from One Network`}
                             onClick={() => {
                               if (activeMode === "share") {
                                 toggleShareRecipient(recipient.userId);
@@ -2570,13 +3148,13 @@ export function OneLocationAgentPageContent() {
                       })
                     ) : (
                       <p className="text-[13px] text-[#8e8e93] dark:text-white/55">
-                        KAI Circle recommendations will appear here.
+                        One Network recommendations will appear here.
                       </p>
                     )}
                   </div>
                 </div>
 
-                <div className="space-y-3">
+                <div className="min-w-0 max-w-full space-y-3">
                   <div className="relative">
                     <Search className="absolute left-3.5 top-1/2 h-5 w-5 -translate-y-1/2 text-[#8e8e93]" />
                     <input
@@ -2585,68 +3163,20 @@ export function OneLocationAgentPageContent() {
                         setRecipientSearch(event.target.value)
                       }
                       className="h-10 w-full rounded-[14px] border border-black/[0.04] bg-white pl-10 pr-4 text-[15px] text-[#1c1c1e] shadow-sm outline-none transition-shadow placeholder:text-[#8e8e93] focus:ring-2 focus:ring-[#007aff]/20 dark:border-white/[0.08] dark:bg-white/[0.07] dark:text-white"
-                      placeholder="Search KAI Circle..."
+                      placeholder="Search One Network..."
                       type="text"
                     />
                   </div>
 
-                  <div
-                    aria-label="KAI Circle section states"
-                    className="grid gap-2 sm:grid-cols-2"
-                  >
-                    {kaiCircleSections.map((section) => {
-                      const emptyCopy =
-                        KAI_CIRCLE_SECTION_EMPTY_COPY[section.key];
-                      return (
-                        <div
-                          key={section.key}
-                          className="rounded-[14px] border border-black/[0.04] bg-white/70 p-3 shadow-sm dark:border-white/[0.08] dark:bg-white/[0.06]"
-                        >
-                          {sectionLabel(section.title, section.recipients.length)}
-                          <p className="mt-1 text-[12px] leading-5 text-[#8e8e93] dark:text-white/55">
-                            {section.recipients.length
-                              ? section.description
-                              : `${emptyCopy.title}. ${emptyCopy.description}`}
-                          </p>
-                        </div>
-                      );
-                    })}
-                  </div>
-
-                  <div className="rounded-[14px] border border-black/[0.04] bg-white/70 p-3 shadow-sm dark:border-white/[0.08] dark:bg-white/[0.06]">
-                    <div className="flex items-start gap-3">
-                      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#eaf9ef] text-[#2dbd5a] dark:bg-emerald-400/15 dark:text-emerald-200">
-                        <ContactRound className="h-4 w-4" aria-hidden="true" />
-                      </span>
-                      <div className="min-w-0 flex-1">
-                        <div className="flex flex-wrap items-center gap-2">
-                          <h3 className="text-[14px] font-bold tracking-tight text-[#1c1c1e] dark:text-white">
-                            Mobile contact signal
-                          </h3>
-                          <span className="rounded-full bg-[#f2f2f7] px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-[#636366] dark:bg-white/10 dark:text-white/65">
-                            {contactSignalStatusLabel(contactSignal.status)}
-                          </span>
-                        </div>
-                        <p className="mt-1 text-[12px] leading-5 text-[#8e8e93] dark:text-white/55">
-                          {contactSignalSummary(contactSignal)}
-                        </p>
-                        {contactSignal.status === "matched" ||
-                        contactSignal.status === "empty" ? (
-                          <p className="mt-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-[#8e8e93] dark:text-white/45">
-                            {contactSignal.matchedCount} matched /{" "}
-                            {contactSignal.inviteCandidateCount} invite-ready
-                          </p>
-                        ) : null}
-                      </div>
-                    </div>
-                    <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                  <div className="min-w-0 max-w-full overflow-hidden rounded-[14px] border border-black/[0.04] bg-white/70 p-3 shadow-sm dark:border-white/[0.08] dark:bg-white/[0.06]">
+                    <div className="grid gap-2 sm:grid-cols-2">
                       <ActionButton
                         busy={busy}
                         busyKey="contactSync"
                         onClick={() => void handleSyncContactSignal()}
                         disabled={!auth.user || busy === "contactInvite"}
                         variant="outline"
-                        className="h-10 rounded-[12px] border-black/[0.06] bg-white text-[13px] font-semibold text-[#1c1c1e] shadow-sm hover:bg-[#f2f2f7] dark:border-white/[0.08] dark:bg-white/10 dark:text-white dark:hover:bg-white/15"
+                        className="h-10 w-full min-w-0 rounded-[12px] border-black/[0.06] bg-white text-[13px] font-semibold text-[#1c1c1e] shadow-sm hover:bg-[#f2f2f7] dark:border-white/[0.08] dark:bg-white/10 dark:text-white dark:hover:bg-white/15"
                       >
                         {busy !== "contactSync" ? (
                           <ContactRound className="mr-2 h-4 w-4" aria-hidden="true" />
@@ -2659,19 +3189,26 @@ export function OneLocationAgentPageContent() {
                         onClick={() => void handleShareContactInvite()}
                         disabled={!vaultOwnerToken || busy === "contactSync"}
                         variant="outline"
-                        className="h-10 rounded-[12px] border-black/[0.06] bg-white text-[13px] font-semibold text-[#007aff] shadow-sm hover:bg-[#f2f2f7] dark:border-white/[0.08] dark:bg-white/10 dark:text-[#76b7ff] dark:hover:bg-white/15"
+                        className="h-10 w-full min-w-0 rounded-[12px] border-black/[0.06] bg-white text-[13px] font-semibold text-[#007aff] shadow-sm hover:bg-[#f2f2f7] dark:border-white/[0.08] dark:bg-white/10 dark:text-[#76b7ff] dark:hover:bg-white/15"
                       >
                         {busy !== "contactInvite" ? (
                           <Send className="mr-2 h-4 w-4" aria-hidden="true" />
                         ) : null}
-                        Invite Contacts
+                        Share to Contacts
                       </ActionButton>
                     </div>
                   </div>
 
-                  <div className={onePanelClassName}>
+                  <div
+                    id="one-network-contact-list"
+                    className={
+                      showExpandedOneNetworkList
+                        ? oneScrollablePanelClassName
+                        : onePanelClassName
+                    }
+                  >
                     {visibleRecipients.length ? (
-                      visibleRecipients.map((recipient, index) => {
+                      displayedVisibleRecipients.map((recipient, index) => {
                         const label = displayNameFromRecipient(recipient);
                         const selected =
                           activeMode === "share"
@@ -2683,9 +3220,9 @@ export function OneLocationAgentPageContent() {
                         return (
                           <div
                             key={recipient.userId}
-                            className="relative flex flex-col gap-2.5 p-3.5 after:absolute after:bottom-0 after:left-[62px] after:right-0 after:border-b after:border-black/[0.05] last:after:hidden dark:after:border-white/[0.08]"
+                            className="relative flex min-w-0 max-w-full flex-col gap-2.5 overflow-hidden p-3.5 after:absolute after:bottom-0 after:left-[62px] after:right-0 after:border-b after:border-black/[0.05] last:after:hidden dark:after:border-white/[0.08]"
                           >
-                            <div className="flex items-center gap-3">
+                            <div className="flex min-w-0 items-start gap-3">
                               <AvatarBubble
                                 label={label}
                                 index={index}
@@ -2693,8 +3230,8 @@ export function OneLocationAgentPageContent() {
                                 muted={!recipient.canReceiveLocation}
                               />
                               <div className="min-w-0 flex-1">
-                                <div className="flex min-w-0 items-center gap-1.5">
-                                  <span className="truncate text-[16px] font-semibold tracking-tight text-[#1c1c1e] dark:text-white">
+                                <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+                                  <span className="min-w-0 max-w-full truncate text-[16px] font-semibold tracking-tight text-[#1c1c1e] dark:text-white">
                                     {recipientLabel(recipient)}
                                   </span>
                                   <span className="rounded-md bg-[#f0f5ff] px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider text-[#007aff] dark:bg-[#0a84ff]/15 dark:text-[#76b7ff]">
@@ -2713,7 +3250,7 @@ export function OneLocationAgentPageContent() {
                                     {recommendationCategoryLabel(recipient)}
                                   </span>
                                 </div>
-                                <p className="mt-0.5 text-[12px] font-medium text-[#8e8e93] dark:text-white/55">
+                                <p className="mt-0.5 break-words text-[12px] font-medium text-[#8e8e93] [overflow-wrap:anywhere] dark:text-white/55">
                                   {recipientRecommendationLine(recipient)}
                                 </p>
                                 {reasons.length ? (
@@ -2730,7 +3267,7 @@ export function OneLocationAgentPageContent() {
                                 ) : null}
                               </div>
                               {selected ? (
-                                <CheckCircle2 className="h-[22px] w-[22px] text-[#007aff] dark:text-[#76b7ff]" />
+                                <CheckCircle2 className="mt-1 h-[22px] w-[22px] shrink-0 text-[#007aff] dark:text-[#76b7ff]" />
                               ) : (
                                 <button
                                   type="button"
@@ -2747,7 +3284,7 @@ export function OneLocationAgentPageContent() {
                                       );
                                     }
                                   }}
-                                  className="inline-flex h-8 items-center gap-1 rounded-full bg-[#f2f2f7] px-3 text-[12px] font-semibold text-[#007aff] transition-colors hover:bg-[#e5e5ea] dark:bg-white/10 dark:text-[#76b7ff] dark:hover:bg-white/15"
+                                  className="mt-0.5 inline-flex h-8 shrink-0 items-center gap-1 rounded-full bg-[#f2f2f7] px-3 text-[12px] font-semibold text-[#007aff] transition-colors hover:bg-[#e5e5ea] dark:bg-white/10 dark:text-[#76b7ff] dark:hover:bg-white/15"
                                 >
                                   <Plus className="h-3.5 w-3.5" />
                                   Select
@@ -2762,20 +3299,47 @@ export function OneLocationAgentPageContent() {
                         icon={UsersRound}
                         title={
                           recipients.length
-                            ? "No KAI Circle matches"
-                            : "KAI Circle is empty"
+                            ? "No One Network matches"
+                            : "One Network is empty"
                         }
                         description={
                           recipients.length
                             ? "Try another name, role, or recommendation signal."
-                            : "Approval, professional, ready, and setup signals will appear as your KAI network grows."
+                            : "Approval, professional, ready, and setup signals will appear as your One Network grows."
                         }
                       />
                     )}
                   </div>
 
-                  {activeMode === "share" ? (
-                    <div className="space-y-3">
+                  {hasMoreVisibleRecipients ? (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      aria-controls="one-network-contact-list"
+                      aria-expanded={showExpandedOneNetworkList}
+                      onClick={() =>
+                        setOneNetworkListExpanded((expanded) => !expanded)
+                      }
+                      className="h-9 w-full rounded-full border-black/[0.06] bg-white text-[13px] font-semibold text-[#007aff] shadow-sm hover:bg-[#f2f2f7] dark:border-white/[0.08] dark:bg-white/10 dark:text-[#76b7ff] dark:hover:bg-white/15"
+                    >
+                      {showExpandedOneNetworkList ? (
+                        <ChevronUp className="mr-2 h-4 w-4" aria-hidden="true" />
+                      ) : (
+                        <ChevronDown
+                          className="mr-2 h-4 w-4"
+                          aria-hidden="true"
+                        />
+                      )}
+                      {showExpandedOneNetworkList
+                        ? "Show less"
+                        : `View more (${visibleRecipients.length - ONE_NETWORK_PREVIEW_LIMIT})`}
+                    </Button>
+                  ) : null}
+
+                  <div>
+                    {activeMode === "share" ? (
+                      <div className="space-y-3">
                       <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_160px]">
                         <Select
                           value={selectedRecipientId}
@@ -2826,9 +3390,11 @@ export function OneLocationAgentPageContent() {
                               onClick={() =>
                                 removeShareRecipient(recipient.userId)
                               }
-                              className="inline-flex h-8 items-center gap-1.5 rounded-full bg-[#eef5ff] px-3 text-[12px] font-semibold text-[#005bb5] transition-colors hover:bg-[#dfefff] dark:bg-[#0a84ff]/15 dark:text-[#a7d4ff] dark:hover:bg-[#0a84ff]/25"
+                              className="inline-flex h-8 max-w-full items-center gap-1.5 rounded-full bg-[#eef5ff] px-3 text-[12px] font-semibold text-[#005bb5] transition-colors hover:bg-[#dfefff] dark:bg-[#0a84ff]/15 dark:text-[#a7d4ff] dark:hover:bg-[#0a84ff]/25"
                             >
-                              {recipientLabel(recipient)}
+                              <span className="min-w-0 truncate">
+                                {recipientLabel(recipient)}
+                              </span>
                               <X className="h-3.5 w-3.5" aria-hidden="true" />
                               <span className="sr-only">
                                 Remove {recipientLabel(recipient)}
@@ -2851,17 +3417,17 @@ export function OneLocationAgentPageContent() {
                           ? `${peopleCountLabel(
                               selectedShareRecipients.length,
                             )} selected for private encrypted sharing.`
-                          : "Select one or more KAI users for private sharing."}
+                          : "Select one or more One users for private sharing."}
                       </p>
                       {shareReviewOpen ? (
                         <div
                           role="region"
                           aria-label="Share safety review"
-                          className="space-y-3 rounded-[14px] border border-[#007aff]/20 bg-[#eef5ff] p-3 text-[13px] leading-5 text-[#17446f] dark:border-[#0a84ff]/30 dark:bg-[#0a84ff]/15 dark:text-[#cfe7ff]"
+                          className="min-w-0 max-w-full space-y-3 overflow-hidden rounded-[14px] border border-[#007aff]/20 bg-[#eef5ff] p-3 text-[13px] leading-5 text-[#17446f] dark:border-[#0a84ff]/30 dark:bg-[#0a84ff]/15 dark:text-[#cfe7ff]"
                         >
                           <div>
                             <p className="font-semibold text-[#0b3d70] dark:text-[#e6f2ff]">
-                              Confirm private KAI-to-KAI sharing
+                              Confirm private One user sharing
                             </p>
                             <p className="mt-1">
                               {peopleCountLabel(
@@ -2882,7 +3448,7 @@ export function OneLocationAgentPageContent() {
                             busyKey="share"
                             onClick={() => void handleShare()}
                             disabled={!canShare}
-                            className="h-10 rounded-full bg-[#007aff] px-4 text-[13px] font-semibold text-white hover:bg-[#006fe6]"
+                            className="h-10 w-full min-w-0 rounded-full bg-[#007aff] px-4 text-[13px] font-semibold text-white hover:bg-[#006fe6] sm:w-auto"
                           >
                             <Send
                               className="mr-2 h-4 w-4"
@@ -2895,7 +3461,7 @@ export function OneLocationAgentPageContent() {
                       <ActionButton
                         busy={busy}
                         busyKey="share"
-                        onClick={handleOpenShareReview}
+                        onClick={() => void handleOpenShareReview()}
                         disabled={!canShare}
                         className="h-12 w-full rounded-[16px] bg-gradient-to-b from-[#1a85ff] to-[#0066ff] text-[16px] font-semibold text-white shadow-[0_4px_14px_rgba(0,122,255,0.35)] hover:opacity-95"
                       >
@@ -2903,9 +3469,9 @@ export function OneLocationAgentPageContent() {
                         Review Share
                         <span className="sr-only">Share Encrypted Update</span>
                       </ActionButton>
-                    </div>
-                  ) : (
-                    <div className="space-y-3">
+                      </div>
+                    ) : (
+                      <div className="space-y-3">
                       <Select
                         value={selectedRequestOwnerId}
                         onValueChange={addRequestOwner}
@@ -2936,9 +3502,11 @@ export function OneLocationAgentPageContent() {
                               onClick={() =>
                                 removeRequestOwner(recipient.userId)
                               }
-                              className="inline-flex h-8 items-center gap-1.5 rounded-full bg-[#eef5ff] px-3 text-[12px] font-semibold text-[#005bb5] transition-colors hover:bg-[#dfefff] dark:bg-[#0a84ff]/15 dark:text-[#a7d4ff] dark:hover:bg-[#0a84ff]/25"
+                              className="inline-flex h-8 max-w-full items-center gap-1.5 rounded-full bg-[#eef5ff] px-3 text-[12px] font-semibold text-[#005bb5] transition-colors hover:bg-[#dfefff] dark:bg-[#0a84ff]/15 dark:text-[#a7d4ff] dark:hover:bg-[#0a84ff]/25"
                             >
-                              {recipientLabel(recipient)}
+                              <span className="min-w-0 truncate">
+                                {recipientLabel(recipient)}
+                              </span>
                               <X className="h-3.5 w-3.5" aria-hidden="true" />
                               <span className="sr-only">
                                 Remove {recipientLabel(recipient)}
@@ -2952,7 +3520,7 @@ export function OneLocationAgentPageContent() {
                           ? `${peopleCountLabel(
                               selectedRequestOwners.length,
                             )} selected for approval-first requests.`
-                          : "Select one or more KAI users before requesting location access."}
+                          : "Select one or more One users before requesting location access."}
                       </p>
                       <Textarea
                         value={requestMessage}
@@ -2975,115 +3543,137 @@ export function OneLocationAgentPageContent() {
                         <Send className="mr-2 h-4 w-4" aria-hidden="true" />
                         Send Request
                       </ActionButton>
-                    </div>
-                  )}
+                      </div>
+                    )}
+                  </div>
                 </div>
               </section>
             </div>
 
-            <div className="space-y-6">
-              <OneLocationActivityDashboard
-                activity={locationActivity}
-                range={activityRange}
-                loading={activityLoading}
-                error={activityError}
-                onRangeChange={(value) => {
-                  setActivityRange(value);
-                  setActivitySnapshot(null);
-                }}
-              />
-
-              <section className="space-y-2 px-1">
-                {sectionLabel("People who can see me")}
-                <div className={onePanelClassName}>
-                  {(state?.ownerGrants ?? []).length ? (
-                    state?.ownerGrants.map((grant, index) => (
-                      <div
-                        key={grant.id}
-                        className="relative flex items-center gap-3 p-3.5 after:absolute after:bottom-0 after:left-[62px] after:right-0 after:border-b after:border-black/[0.05] last:after:hidden dark:after:border-white/[0.08]"
-                      >
-                        <AvatarBubble
-                          label={grantCounterpartyLabel(grant)}
-                          index={index}
-                          size="sm"
-                        />
-                        <div className="min-w-0 flex-1">
-                          <h3 className="truncate text-[16px] font-medium tracking-tight text-[#1c1c1e] dark:text-white">
-                            {grantCounterpartyLabel(grant)}
-                          </h3>
-                          <div className="mt-0.5 flex flex-wrap items-center gap-1.5">
-                            <Badge variant={statusVariant(grant.status)}>
-                              {grant.status}
-                            </Badge>
-                            <span className="text-[12px] font-medium text-[#8e8e93] dark:text-white/55">
-                              {expiresLabel(grant)} - {grant.durationHours}h
-                            </span>
-                          </div>
-                        </div>
-                        {grant.status === "active" ? (
-                          <div className="flex shrink-0 gap-1.5">
-                            <Button
-                              aria-label="Update share"
-                              variant="outline"
-                              size="icon"
-                              onClick={() => void handlePublish(grant)}
-                              disabled={busy === "publish"}
-                              className="h-8 w-8 rounded-full border-0 bg-[#f2f2f7] text-[#8e8e93] hover:bg-[#e5e5ea] dark:bg-white/10 dark:text-white/55 dark:hover:bg-white/15"
-                            >
-                              {busy === "publish" ? (
-                                <Loader2 className="h-4 w-4 animate-spin" />
-                              ) : (
-                                <Pencil className="h-4 w-4" />
-                              )}
-                            </Button>
-                            <Button
-                              aria-label={`Revoke access for ${grantCounterpartyLabel(grant)}`}
-                              variant="outline"
-                              size="icon"
-                              onClick={() => void handleRevoke(grant.id)}
-                              disabled={busy === "revoke"}
-                              className="h-8 w-8 rounded-full border-0 bg-[#ff3b30]/10 text-[#ff3b30] hover:bg-[#ff3b30]/20 dark:bg-[#ff453a]/15 dark:text-[#ff9f9a]"
-                            >
-                              <X className="h-4 w-4" />
-                            </Button>
-                          </div>
-                        ) : null}
-                      </div>
-                    ))
-                  ) : (
-                    <EmptyOneState
-                      icon={UsersRound}
-                      title="No active shares"
-                      description="Create one encrypted grant when you need a trusted person to see you."
-                    />
+            <div className="min-w-0 max-w-full space-y-6">
+              {SHOW_LOCATION_ACTIVITY_SECTION ? (
+                <section
+                  ref={activitySectionRef}
+                  tabIndex={-1}
+                  className={cn(
+                    "min-w-0 max-w-full outline-none",
+                    sectionFocusClassName("activity"),
                   )}
-                </div>
-              </section>
+                >
+                  <OneLocationActivityDashboard
+                    activity={locationActivity}
+                    range={activityRange}
+                    loading={activityLoading}
+                    error={activityError}
+                    onRangeChange={(value) => {
+                      setActivityRange(value);
+                      setActivitySnapshot(null);
+                    }}
+                  />
+                </section>
+              ) : null}
 
-              <section className="space-y-2 px-1">
+              {SHOW_OWNER_GRANTS_SECTION ? (
+                <section
+                  ref={peopleSectionRef}
+                  tabIndex={-1}
+                  className={cn("min-w-0 max-w-full space-y-2 px-1 outline-none", sectionFocusClassName("people"))}
+                >
+                  {sectionLabel("People who can see me")}
+                  <div className={oneScrollablePanelClassName}>
+                    {(state?.ownerGrants ?? []).length ? (
+                      state?.ownerGrants.map((grant, index) => (
+                        <div
+                          key={grant.id}
+                          className="relative flex min-w-0 max-w-full flex-col gap-3 overflow-hidden p-3.5 after:absolute after:bottom-0 after:left-[62px] after:right-0 after:border-b after:border-black/[0.05] sm:flex-row sm:items-center last:after:hidden dark:after:border-white/[0.08]"
+                        >
+                          <AvatarBubble
+                            label={grantCounterpartyLabel(grant)}
+                            index={index}
+                            size="sm"
+                          />
+                          <div className="min-w-0 flex-1">
+                            <h3 className="break-words text-[16px] font-medium tracking-tight text-[#1c1c1e] [overflow-wrap:anywhere] dark:text-white">
+                              {grantCounterpartyLabel(grant)}
+                            </h3>
+                            <div className="mt-0.5 flex flex-wrap items-center gap-1.5">
+                              <Badge variant={statusVariant(grant.status)}>
+                                {grant.status}
+                              </Badge>
+                              <span className="min-w-0 break-words text-[12px] font-medium text-[#8e8e93] [overflow-wrap:anywhere] dark:text-white/55">
+                                {expiresLabel(grant)} - {grant.durationHours}h
+                              </span>
+                            </div>
+                          </div>
+                          {grant.status === "active" ? (
+                            <div className="flex w-full shrink-0 justify-end gap-1.5 sm:w-auto">
+                              <Button
+                                aria-label="Update share"
+                                variant="outline"
+                                size="icon"
+                                onClick={() => void handlePublish(grant)}
+                                disabled={busy === "publish"}
+                                className="h-8 w-8 rounded-full border-0 bg-[#f2f2f7] text-[#8e8e93] hover:bg-[#e5e5ea] dark:bg-white/10 dark:text-white/55 dark:hover:bg-white/15"
+                              >
+                                {busy === "publish" ? (
+                                  <Loader2 className="h-4 w-4 animate-spin" />
+                                ) : (
+                                  <Pencil className="h-4 w-4" />
+                                )}
+                              </Button>
+                              <Button
+                                aria-label={`Revoke access for ${grantCounterpartyLabel(grant)}`}
+                                variant="outline"
+                                size="icon"
+                                onClick={() => void handleRevoke(grant.id)}
+                                disabled={busy === "revoke"}
+                                className="h-8 w-8 rounded-full border-0 bg-[#ff3b30]/10 text-[#ff3b30] hover:bg-[#ff3b30]/20 dark:bg-[#ff453a]/15 dark:text-[#ff9f9a]"
+                              >
+                                <X className="h-4 w-4" />
+                              </Button>
+                            </div>
+                          ) : null}
+                        </div>
+                      ))
+                    ) : (
+                      <EmptyOneState
+                        icon={UsersRound}
+                        title="No active shares"
+                        description="Create one encrypted grant when you need a trusted person to see you."
+                      />
+                    )}
+                  </div>
+                </section>
+              ) : null}
+
+              <section
+                ref={approvalsSectionRef}
+                tabIndex={-1}
+                className={cn("min-w-0 max-w-full space-y-2 px-1 outline-none", sectionFocusClassName("approvals"))}
+              >
                 {sectionLabel("Approvals", pendingOwnerRequests.length)}
                 <div
                   className={cn(
-                    onePanelClassName,
+                    oneScrollablePanelClassName,
                     pendingOwnerRequests.length &&
                       "relative before:absolute before:bottom-0 before:left-0 before:top-0 before:w-1 before:bg-[#ff3b30]",
                   )}
                 >
                   {pendingOwnerRequests.length ? (
                     pendingOwnerRequests.map((request) => (
-                      <div key={request.id} className="flex items-start gap-3 p-3.5">
+                      <div key={request.id} className="flex min-w-0 max-w-full items-start gap-3 overflow-hidden p-3.5">
                         <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#f2f2f7] text-[#8e8e93] dark:bg-white/10 dark:text-white/55">
                           <UserRoundCheck className="h-[18px] w-[18px]" />
                         </span>
                         <div className="min-w-0 flex-1 space-y-1">
-                          <h3 className="text-[16px] font-semibold tracking-tight text-[#1c1c1e] dark:text-white">
+                          <h3 className="break-words text-[16px] font-semibold tracking-tight text-[#1c1c1e] [overflow-wrap:anywhere] dark:text-white">
                             {requestLabel(request)}
                           </h3>
                           <p className="text-[13px] font-medium leading-relaxed text-[#8e8e93] dark:text-white/55">
                             {request.message ||
                               `Requested ${formatDateTime(request.requestedAt)}`}
                           </p>
-                          <div className="flex gap-2 pt-2">
+                          <div className="flex flex-col gap-2 pt-2 sm:flex-row">
                             <Button
                               variant="outline"
                               onClick={() => void handleDeny(request.id)}
@@ -3114,16 +3704,12 @@ export function OneLocationAgentPageContent() {
                 </div>
               </section>
 
-              <section className="space-y-2 px-1">
+              <section className="min-w-0 max-w-full space-y-2 px-1">
                 {sectionLabel("Create public link")}
                 <div className={cn(onePanelClassName, "space-y-4 p-3.5")}>
-                  <p className="text-[13px] leading-5 text-[#8e8e93] dark:text-white/55">
-                    Share a public location link. Visitors enter their details
-                    and can view this link's captured location.
-                  </p>
                   <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_150px]">
-                    <div className={cn(oneInsetClassName, "px-3 py-2 text-sm")}>
-                      <span className={oneSecondaryTextClassName}>
+                    <div className={cn(oneInsetClassName, "min-w-0 px-3 py-2 text-sm")}>
+                      <span className={cn(oneSecondaryTextClassName, "break-all")}>
                         {publicInviteUrl ||
                           "Create a fresh public location link to copy or share."}
                       </span>
@@ -3144,13 +3730,13 @@ export function OneLocationAgentPageContent() {
                       </SelectContent>
                     </Select>
                   </div>
-                  <div className="flex flex-wrap gap-2">
+                  <div className="grid min-w-0 max-w-full grid-cols-1 gap-2 sm:flex sm:flex-wrap">
                     <ActionButton
                       busy={busy}
                       busyKey="publicInvite"
                       onClick={() => void handleCreatePublicInvite()}
                       disabled={!vaultOwnerToken}
-                      className="rounded-full bg-[#007aff] text-white hover:bg-[#0066ff]"
+                      className="w-full min-w-0 rounded-full bg-[#007aff] text-white hover:bg-[#0066ff] sm:w-auto"
                     >
                       <ExternalLink className="mr-2 h-4 w-4" />
                       Create Public Link
@@ -3159,7 +3745,7 @@ export function OneLocationAgentPageContent() {
                       variant="outline"
                       onClick={() => void handleSharePublicInvite()}
                       disabled={!publicInviteUrl}
-                      className="rounded-full border-black/[0.06] bg-[#f2f2f7] dark:border-white/[0.08] dark:bg-white/10"
+                      className="w-full min-w-0 rounded-full border-black/[0.06] bg-[#f2f2f7] sm:w-auto dark:border-white/[0.08] dark:bg-white/10"
                     >
                       <Send className="mr-2 h-4 w-4" />
                       Share
@@ -3168,71 +3754,70 @@ export function OneLocationAgentPageContent() {
                       variant="outline"
                       onClick={() => void handleCopyPublicInvite()}
                       disabled={!publicInviteUrl}
-                      className="rounded-full border-black/[0.06] bg-[#f2f2f7] dark:border-white/[0.08] dark:bg-white/10"
+                      className="w-full min-w-0 rounded-full border-black/[0.06] bg-[#f2f2f7] sm:w-auto dark:border-white/[0.08] dark:bg-white/10"
                     >
                       <Copy className="mr-2 h-4 w-4" />
                       Copy
                     </Button>
                   </div>
-                  {activePublicInvites.length ? (
+                  {latestActivePublicInvite ? (
                     <div className="space-y-2">
-                      {activePublicInvites.map((invite) => (
-                        <div
-                          key={invite.id}
-                          className="flex items-center justify-between gap-3 rounded-[14px] bg-[#f2f2f7] p-3 dark:bg-white/10"
-                        >
-                          <div className="min-w-0">
-                            <p className="text-[14px] font-semibold text-[#1c1c1e] dark:text-white">
-                              Active public location link
-                            </p>
-                            <p className="truncate text-[12px] text-[#8e8e93] dark:text-white/55">
-                              Public viewing expires{" "}
-                              {formatDateTime(invite.expiresAt)} -{" "}
-                              {invite.durationHours}h
-                            </p>
-                          </div>
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => void handleRevokePublicInvite(invite)}
-                            disabled={busy === "publicRevoke"}
-                            className="rounded-full"
-                          >
-                            Revoke
-                          </Button>
+                      <div className="flex flex-col gap-3 rounded-[14px] bg-[#f2f2f7] p-3 sm:flex-row sm:items-center sm:justify-between dark:bg-white/10">
+                        <div className="min-w-0">
+                          <p className="text-[14px] font-semibold text-[#1c1c1e] dark:text-white">
+                            Latest active public link
+                          </p>
+                          <p className="break-words text-[12px] text-[#8e8e93] [overflow-wrap:anywhere] dark:text-white/55">
+                            Expires {formatDateTime(latestActivePublicInvite.expiresAt)}
+                          </p>
                         </div>
-                      ))}
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() =>
+                            void handleRevokePublicInvite(latestActivePublicInvite)
+                          }
+                          disabled={busy === "publicRevoke"}
+                          className="w-full rounded-full sm:w-auto"
+                        >
+                          Revoke
+                        </Button>
+                      </div>
                     </div>
                   ) : null}
                 </div>
               </section>
 
-              <section className="space-y-2 px-1">
+              <section
+                ref={sharedSectionRef}
+                tabIndex={-1}
+                className={cn("min-w-0 max-w-full space-y-2 px-1 outline-none", sectionFocusClassName("shared"))}
+              >
                 {sectionLabel("Shared with me")}
-                <div className={onePanelClassName}>
+                <div className={oneScrollablePanelClassName}>
                   {visibleReceivedGrants.length ? (
                     visibleReceivedGrants.map((grant, index) => {
                       const point = decryptedPoints[grant.id];
                       return (
                         <div
                           key={grant.id}
-                          className="border-b border-black/[0.05] last:border-b-0 dark:border-white/[0.08]"
+                          className="min-w-0 max-w-full overflow-hidden border-b border-black/[0.05] last:border-b-0 dark:border-white/[0.08]"
                         >
-                          <div className="flex items-center gap-3 p-3.5">
+                          <div className="flex flex-col gap-3 p-3.5 sm:flex-row sm:items-center">
                             <AvatarBubble
                               label={receivedGrantOwnerLabel(grant)}
                               index={index + 2}
                               size="sm"
                             />
                             <div className="min-w-0 flex-1">
-                              <h3 className="truncate text-[16px] font-medium tracking-tight text-[#1c1c1e] dark:text-white">
+                              <h3 className="break-words text-[16px] font-medium tracking-tight text-[#1c1c1e] [overflow-wrap:anywhere] dark:text-white">
                                 {receivedGrantOwnerLabel(grant)}
                               </h3>
                               <div className="mt-0.5 flex flex-wrap items-center gap-1.5">
                                 <Badge variant={statusVariant(grant.status)}>
                                   {grant.status}
                                 </Badge>
-                                <span className="text-[12px] font-medium text-[#8e8e93] dark:text-white/55">
+                                <span className="min-w-0 break-words text-[12px] font-medium text-[#8e8e93] [overflow-wrap:anywhere] dark:text-white/55">
                                   {expiresLabel(grant)}
                                 </span>
                               </div>
@@ -3243,7 +3828,7 @@ export function OneLocationAgentPageContent() {
                                 size="sm"
                                 onClick={() => void handleView(grant)}
                                 disabled={busy === "view"}
-                                className="rounded-full border-black/[0.06] bg-[#f2f2f7] dark:border-white/[0.08] dark:bg-white/10"
+                                className="w-full rounded-full border-black/[0.06] bg-[#f2f2f7] sm:w-auto dark:border-white/[0.08] dark:bg-white/10"
                               >
                                 {busy === "view" ? (
                                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -3280,122 +3865,134 @@ export function OneLocationAgentPageContent() {
                 </div>
               </section>
 
-              <section className="space-y-2 px-1">
-                {sectionLabel("Public link responses")}
-                <div className={onePanelClassName}>
-                  {publicSubmissions.length ? (
-                    publicSubmissions.map((submission) => (
-                      <div
-                        key={submission.id}
-                        className="flex items-center gap-3 p-3.5"
-                      >
-                        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#f2f2f7] text-[#8e8e93] dark:bg-white/10 dark:text-white/55">
-                          <ExternalLink className="h-[18px] w-[18px]" />
-                        </span>
-                        <div className="min-w-0 flex-1">
-                          <h3 className="truncate text-[16px] font-medium text-[#1c1c1e] dark:text-white">
-                            {publicSubmissionLabel(submission)}
-                          </h3>
-                          <p className="truncate text-[12px] text-[#8e8e93] dark:text-white/55">
-                            {submission.message ||
-                              `Status ${submission.status} - ${formatDateTime(submission.submittedAt)}`}
-                          </p>
-                        </div>
-                        <Badge variant={statusVariant(submission.status)}>
-                          {submission.requestStatus || submission.status}
-                        </Badge>
-                      </div>
-                    ))
-                  ) : (
-                    <EmptyOneState
-                      icon={ExternalLink}
-                      title="No public responses"
-                      description="Responses from your public location link show up here after visitors open it."
-                    />
-                  )}
-                </div>
-              </section>
-
-              <section className="space-y-2 px-1">
-                {sectionLabel("Refer someone else")}
-                <div className={cn(onePanelClassName, "p-3.5")}>
-                  {(state?.receivedGrants ?? []).filter(
-                    (grant) => grant.status === "active",
-                  ).length ? (
-                    state?.receivedGrants
-                      .filter((grant) => grant.status === "active")
-                      .map((grant) => (
+              {SHOW_PUBLIC_RESPONSES_SECTION ? (
+                <section
+                  ref={publicResponsesSectionRef}
+                  tabIndex={-1}
+                  className={cn("min-w-0 max-w-full space-y-2 px-1 outline-none", sectionFocusClassName("public_responses"))}
+                >
+                  {sectionLabel("Public link responses")}
+                  <div className={oneScrollablePanelClassName}>
+                    {publicSubmissions.length ? (
+                      publicSubmissions.map((submission) => (
                         <div
-                          key={grant.id}
-                          className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto]"
+                          key={submission.id}
+                          className="flex min-w-0 max-w-full flex-col gap-3 overflow-hidden p-3.5 sm:flex-row sm:items-center"
                         >
-                          <Select
-                            value={referralTargets[grant.id] || ""}
-                            onValueChange={(value) =>
-                              setReferralTargets((current) => ({
-                                ...current,
-                                [grant.id]: value,
-                              }))
-                            }
-                          >
-                            <SelectTrigger className="h-10 w-full rounded-[12px] border-black/[0.04] bg-white shadow-sm dark:border-white/[0.08] dark:bg-white/[0.07]">
-                              <SelectValue placeholder="Select referred person" />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {recipients
-                                .filter(
-                                  (recipient) =>
-                                    recipient.userId !== grant.ownerUserId,
-                                )
-                                .map((recipient) => (
-                                  <SelectItem
-                                    key={recipient.userId}
-                                    value={recipient.userId}
-                                  >
-                                    {recipientLabel(recipient)}
-                                  </SelectItem>
-                                ))}
-                            </SelectContent>
-                          </Select>
-                          <ActionButton
-                            busy={busy}
-                            busyKey="refer"
-                            variant="outline"
-                            onClick={() => void handleRefer(grant)}
-                            disabled={!referralTargets[grant.id]}
-                            className="rounded-full"
-                          >
-                            Refer
-                          </ActionButton>
+                          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#f2f2f7] text-[#8e8e93] dark:bg-white/10 dark:text-white/55">
+                            <ExternalLink className="h-[18px] w-[18px]" />
+                          </span>
+                          <div className="min-w-0 flex-1">
+                            <h3 className="break-words text-[16px] font-medium text-[#1c1c1e] [overflow-wrap:anywhere] dark:text-white">
+                              {publicSubmissionLabel(submission)}
+                            </h3>
+                            <p className="break-words text-[12px] text-[#8e8e93] [overflow-wrap:anywhere] dark:text-white/55">
+                              {submission.message ||
+                                `Status ${submission.status} - ${formatDateTime(submission.submittedAt)}`}
+                            </p>
+                          </div>
+                          <Badge variant={statusVariant(submission.status)}>
+                            {submission.requestStatus || submission.status}
+                          </Badge>
                         </div>
                       ))
-                  ) : (
-                    <EmptyOneState
-                      icon={UsersRound}
-                      title="No active received grant"
-                      description="You can refer only from an active share, and the owner still decides."
-                    />
-                  )}
-                </div>
-              </section>
+                    ) : (
+                      <EmptyOneState
+                        icon={ExternalLink}
+                        title="No public responses"
+                        description="Responses from your public location link show up here after visitors open it."
+                      />
+                    )}
+                  </div>
+                </section>
+              ) : null}
+
+              {SHOW_REFERRAL_SECTION ? (
+                <section className="min-w-0 max-w-full space-y-2 px-1">
+                  {sectionLabel("Refer someone else")}
+                  <div className={cn(onePanelClassName, "p-3.5")}>
+                    {(state?.receivedGrants ?? []).filter(
+                      (grant) => grant.status === "active",
+                    ).length ? (
+                      state?.receivedGrants
+                        .filter((grant) => grant.status === "active")
+                        .map((grant) => (
+                          <div
+                            key={grant.id}
+                            className="grid min-w-0 max-w-full gap-3 sm:grid-cols-[minmax(0,1fr)_auto]"
+                          >
+                            <Select
+                              value={referralTargets[grant.id] || ""}
+                              onValueChange={(value) =>
+                                setReferralTargets((current) => ({
+                                  ...current,
+                                  [grant.id]: value,
+                                }))
+                              }
+                            >
+                              <SelectTrigger className="h-10 w-full rounded-[12px] border-black/[0.04] bg-white shadow-sm dark:border-white/[0.08] dark:bg-white/[0.07]">
+                                <SelectValue placeholder="Select referred person" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {recipients
+                                  .filter(
+                                    (recipient) =>
+                                      recipient.userId !== grant.ownerUserId,
+                                  )
+                                  .map((recipient) => (
+                                    <SelectItem
+                                      key={recipient.userId}
+                                      value={recipient.userId}
+                                    >
+                                      {recipientLabel(recipient)}
+                                    </SelectItem>
+                                  ))}
+                              </SelectContent>
+                            </Select>
+                            <ActionButton
+                              busy={busy}
+                              busyKey="refer"
+                              variant="outline"
+                              onClick={() => void handleRefer(grant)}
+                              disabled={!referralTargets[grant.id]}
+                              className="w-full min-w-0 rounded-full sm:w-auto"
+                            >
+                              Refer
+                            </ActionButton>
+                          </div>
+                        ))
+                    ) : (
+                      <EmptyOneState
+                        icon={UsersRound}
+                        title="No active received grant"
+                        description="You can refer only from an active share, and the owner still decides."
+                      />
+                    )}
+                  </div>
+                </section>
+              ) : null}
 
               {requestedByMe.length ? (
-                <section className="space-y-2 px-1">
+                <section
+                  ref={myRequestsSectionRef}
+                  tabIndex={-1}
+                  className={cn("min-w-0 max-w-full space-y-2 px-1 outline-none", sectionFocusClassName("my_requests"))}
+                >
                   {sectionLabel("My requests")}
-                  <div className={onePanelClassName}>
+                  <div className={oneScrollablePanelClassName}>
                     {requestedByMe.map((request) => (
                       <div
                         key={request.id}
-                        className="flex items-center gap-3 p-3.5"
+                        className="flex min-w-0 max-w-full flex-col gap-3 overflow-hidden p-3.5 sm:flex-row sm:items-center"
                       >
                         <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#f2f2f7] text-[#8e8e93] dark:bg-white/10 dark:text-white/55">
                           <Clock3 className="h-[18px] w-[18px]" />
                         </span>
                         <div className="min-w-0 flex-1">
-                          <h3 className="truncate text-[16px] font-medium text-[#1c1c1e] dark:text-white">
-                            {request.ownerUserId}
+                          <h3 className="break-words text-[16px] font-medium text-[#1c1c1e] [overflow-wrap:anywhere] dark:text-white">
+                            {requestOwnerLabel(request, recipients)}
                           </h3>
-                          <p className="truncate text-[12px] text-[#8e8e93] dark:text-white/55">
+                          <p className="break-words text-[12px] text-[#8e8e93] [overflow-wrap:anywhere] dark:text-white/55">
                             Status {request.status} -{" "}
                             {formatDateTime(request.requestedAt)}
                           </p>

--- a/hushh-webapp/app/one/location/request/[token]/page-client.tsx
+++ b/hushh-webapp/app/one/location/request/[token]/page-client.tsx
@@ -5,23 +5,17 @@ import { useParams } from "next/navigation";
 import {
   AlertTriangle,
   CheckCircle2,
-  Loader2,
   MapPin,
   Navigation,
   Route,
-  Send,
 } from "lucide-react";
-import { toast } from "sonner";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Textarea } from "@/components/ui/textarea";
 import { OneLocationService } from "@/lib/one-location/service";
 import type {
   OneLocationPublicInvite,
-  OneLocationPublicInviteSubmission,
   PlainLocationPoint,
 } from "@/lib/one-location/types";
 
@@ -127,15 +121,9 @@ export default function PublicLocationRequestPageClient() {
     [params?.token],
   );
   const [invite, setInvite] = useState<OneLocationPublicInvite | null>(null);
-  const [submission, setSubmission] =
-    useState<OneLocationPublicInviteSubmission | null>(null);
   const [publicLocation, setPublicLocation] =
     useState<PlainLocationPoint | null>(null);
-  const [visitorDisplayName, setVisitorDisplayName] = useState("");
-  const [phoneNumber, setPhoneNumber] = useState("");
-  const [message, setMessage] = useState("");
   const [loading, setLoading] = useState(true);
-  const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -146,7 +134,10 @@ export default function PublicLocationRequestPageClient() {
       try {
         const response =
           await OneLocationService.resolvePublicInvite(publicToken);
-        if (!cancelled) setInvite(response.invite);
+        if (!cancelled) {
+          setInvite(response.invite);
+          setPublicLocation(response.publicLocation ?? null);
+        }
       } catch (loadError) {
         if (!cancelled) {
           setError(
@@ -169,33 +160,6 @@ export default function PublicLocationRequestPageClient() {
       cancelled = true;
     };
   }, [publicToken]);
-
-  const handleSubmit = async () => {
-    if (!visitorDisplayName.trim() || !phoneNumber.trim()) {
-      toast.error("Enter your name and phone number.");
-      return;
-    }
-    setSubmitting(true);
-    try {
-      const response = await OneLocationService.submitPublicInviteRequest({
-        publicToken,
-        visitorDisplayName: visitorDisplayName.trim(),
-        phoneNumber: phoneNumber.trim(),
-        message: message.trim() || undefined,
-      });
-      setSubmission(response.submission);
-      setPublicLocation(response.publicLocation ?? null);
-      toast.success("Location ready.");
-    } catch (submitError) {
-      toast.error(
-        submitError instanceof Error
-          ? submitError.message
-          : "Could not open this public location.",
-      );
-    } finally {
-      setSubmitting(false);
-    }
-  };
 
   return (
     <main className="min-h-screen bg-background text-foreground">
@@ -225,7 +189,7 @@ export default function PublicLocationRequestPageClient() {
                     ? error
                     : publicLocation
                       ? `${ownerLabel(invite)} shared this public location with you.`
-                      : `Enter your details to view ${ownerLabel(invite)}'s public location.`}
+                      : "This public link is active, but no location snapshot is attached."}
               </p>
             </div>
           </div>
@@ -233,13 +197,12 @@ export default function PublicLocationRequestPageClient() {
           {loading ? (
             <div className="space-y-3">
               <Skeleton className="h-11 rounded-xl" />
-              <Skeleton className="h-11 rounded-xl" />
               <Skeleton className="h-24 rounded-xl" />
               <Skeleton className="h-10 w-36 rounded-xl" />
             </div>
           ) : null}
 
-          {!loading && invite && !submission ? (
+          {!loading && invite ? (
             <div className="space-y-4">
               <div className="flex flex-wrap items-center gap-2 text-sm">
                 <Badge variant="secondary">
@@ -249,49 +212,14 @@ export default function PublicLocationRequestPageClient() {
                   {invite.durationHours}h public viewing window
                 </Badge>
               </div>
-              <Input
-                value={visitorDisplayName}
-                onChange={(event) => setVisitorDisplayName(event.target.value)}
-                placeholder="Your name"
-                autoComplete="name"
-                maxLength={120}
-              />
-              <Input
-                value={phoneNumber}
-                onChange={(event) => setPhoneNumber(event.target.value)}
-                placeholder="Phone number"
-                type="tel"
-                inputMode="tel"
-                autoComplete="tel"
-                maxLength={32}
-              />
-              <Textarea
-                value={message}
-                onChange={(event) => setMessage(event.target.value)}
-                placeholder="Optional message"
-                rows={4}
-                maxLength={500}
-              />
-              <Button onClick={() => void handleSubmit()} disabled={submitting}>
-                {submitting ? (
-                  <Loader2
-                    className="mr-2 h-4 w-4 animate-spin"
-                    aria-hidden="true"
-                  />
-                ) : (
-                  <Send className="mr-2 h-4 w-4" aria-hidden="true" />
-                )}
-                View Location
-              </Button>
-            </div>
-          ) : null}
-
-          {submission && publicLocation ? (
-            <PublicLocationMap point={publicLocation} />
-          ) : submission ? (
-            <div className="rounded-[var(--app-card-radius-standard)] border border-amber-500/30 bg-amber-500/10 p-4 text-sm leading-6 text-amber-800 dark:text-amber-100">
-              This link was opened, but no public location snapshot is attached.
-              Ask the sender to create a fresh public location link.
+              {publicLocation ? (
+                <PublicLocationMap point={publicLocation} />
+              ) : (
+                <div className="rounded-[var(--app-card-radius-standard)] border border-amber-500/30 bg-amber-500/10 p-4 text-sm leading-6 text-amber-800 dark:text-amber-100">
+                  This link opened correctly, but no public location is attached.
+                  Ask the sender to create a fresh public location link.
+                </div>
+              )}
             </div>
           ) : null}
         </div>

--- a/hushh-webapp/capacitor.config.ts
+++ b/hushh-webapp/capacitor.config.ts
@@ -23,6 +23,9 @@ const NORMALIZED_BACKEND_URL = (() => {
   const backendHost = hostFromUrl(normalized);
 
   if (process.env.CAPACITOR_PLATFORM !== "android") return normalized;
+  if (process.env.NEXT_PUBLIC_ANDROID_LOCAL_BACKEND_MODE === "adb_reverse") {
+    return normalized;
+  }
   // Android emulator cannot reach host loopback; use 10.0.2.2
   if (backendHost === "localhost") {
     return normalized.replace("localhost", "10.0.2.2");

--- a/hushh-webapp/components/one-location/activity-dashboard.tsx
+++ b/hushh-webapp/components/one-location/activity-dashboard.tsx
@@ -26,7 +26,7 @@ const ACTIVITY_RANGE_OPTIONS: {
 ];
 
 const activityPanelClassName =
-  "overflow-hidden rounded-[20px] border border-black/[0.05] bg-white shadow-[0_1px_2px_rgba(0,0,0,0.04),0_10px_30px_rgba(15,23,42,0.05)] dark:border-white/[0.08] dark:bg-[#1c1c1e]/90 dark:shadow-[0_12px_38px_rgba(0,0,0,0.28)]";
+  "w-full min-w-0 max-w-full overflow-hidden rounded-[20px] border border-black/[0.05] bg-white shadow-[0_1px_2px_rgba(0,0,0,0.04),0_10px_30px_rgba(15,23,42,0.05)] dark:border-white/[0.08] dark:bg-[#1c1c1e]/90 dark:shadow-[0_12px_38px_rgba(0,0,0,0.28)]";
 
 function activityRangeLabel(range: OneLocationActivityRange): string {
   return (
@@ -50,7 +50,7 @@ function ActivitySectionLabel({ title }: { title: string }) {
     <div
       role="heading"
       aria-level={2}
-      className="ml-1 flex items-center gap-1.5 text-[12px] font-semibold uppercase tracking-[0.08em] text-[#8e8e93] dark:text-white/45"
+      className="ml-1 flex min-w-0 max-w-full flex-wrap items-center gap-1.5 text-[12px] font-semibold uppercase tracking-[0.08em] text-[#8e8e93] dark:text-white/45"
     >
       {title}
     </div>
@@ -67,14 +67,14 @@ function ActivityMetricTile({
   detail: string;
 }) {
   return (
-    <div className="rounded-[14px] border border-black/[0.04] bg-[#f7f7fa] p-3 dark:border-white/[0.08] dark:bg-white/[0.07]">
+    <div className="min-w-0 rounded-[14px] border border-black/[0.04] bg-[#f7f7fa] p-3 dark:border-white/[0.08] dark:bg-white/[0.07]">
       <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[#8e8e93] dark:text-white/45">
         {label}
       </p>
       <p className="mt-1 text-[24px] font-bold leading-none text-[#1c1c1e] dark:text-white">
         {value}
       </p>
-      <p className="mt-1 text-[11px] font-medium text-[#8e8e93] dark:text-white/55">
+      <p className="mt-1 break-words text-[11px] font-medium text-[#8e8e93] [overflow-wrap:anywhere] dark:text-white/55">
         {detail}
       </p>
     </div>
@@ -123,10 +123,10 @@ export function OneLocationActivityDashboard({
   const recentEvents = activity.events.slice(0, 5);
 
   return (
-    <section className="space-y-2 px-1">
+    <section className="min-w-0 max-w-full space-y-2 px-1">
       <ActivitySectionLabel title="Location activity" />
       <div className={cn(activityPanelClassName, "space-y-4 p-3.5")}>
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="flex min-w-0 items-start gap-3">
             <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#eaf3ff] text-[#007aff] dark:bg-[#0a84ff]/15 dark:text-[#76b7ff]">
               {loading ? (
@@ -139,7 +139,7 @@ export function OneLocationActivityDashboard({
               <h3 className="text-[15px] font-bold tracking-tight text-[#1c1c1e] dark:text-white">
                 Activity history
               </h3>
-              <p className="mt-1 text-[12px] leading-5 text-[#8e8e93] dark:text-white/55">
+              <p className="mt-1 break-words text-[12px] leading-5 text-[#8e8e93] [overflow-wrap:anywhere] dark:text-white/55">
                 {error ||
                   `${activityRangeLabel(range)} of shares, requests, views, and link responses.`}
               </p>
@@ -164,7 +164,7 @@ export function OneLocationActivityDashboard({
           </Select>
         </div>
 
-        <div className="grid gap-2 sm:grid-cols-3">
+        <div className="grid min-w-0 gap-2 sm:grid-cols-3">
           <ActivityMetricTile
             label="Shared with"
             value={activity.summary.sharedWithCount}
@@ -190,15 +190,15 @@ export function OneLocationActivityDashboard({
             aria-label={`One Location activity chart for ${activityRangeLabel(
               range,
             )}`}
-            className="rounded-[14px] border border-black/[0.04] bg-white/70 p-3 dark:border-white/[0.08] dark:bg-white/[0.04]"
+            className="min-w-0 max-w-full overflow-hidden rounded-[14px] border border-black/[0.04] bg-white/70 p-3 dark:border-white/[0.08] dark:bg-white/[0.04]"
           >
-            <div className="flex h-32 items-end gap-2">
+            <div className="flex h-32 min-w-0 items-end gap-1.5 sm:gap-2">
               {activity.buckets.map((bucket) => {
                 const height = Math.max(12, (bucket.total / maxBucketTotal) * 100);
                 return (
                   <div
                     key={bucket.key}
-                    className="flex min-w-0 flex-1 flex-col items-center gap-1"
+                    className="flex min-w-0 flex-1 basis-0 flex-col items-center gap-1"
                   >
                     <div className="flex h-24 w-full items-end">
                       <div
@@ -264,11 +264,11 @@ export function OneLocationActivityDashboard({
             <p className="ml-1 text-[11px] font-semibold uppercase tracking-[0.08em] text-[#8e8e93] dark:text-white/45">
               Recent history
             </p>
-            <div className="space-y-2">
+            <div className="min-w-0 space-y-2">
               {recentEvents.map((event) => (
                 <div
                   key={event.id}
-                  className="flex items-start gap-3 rounded-[14px] bg-[#f7f7fa] p-3 dark:bg-white/[0.07]"
+                  className="flex min-w-0 items-start gap-3 overflow-hidden rounded-[14px] bg-[#f7f7fa] p-3 dark:bg-white/[0.07]"
                 >
                   <span
                     className={cn(
@@ -279,10 +279,10 @@ export function OneLocationActivityDashboard({
                     <Clock3 className="h-4 w-4" aria-hidden="true" />
                   </span>
                   <div className="min-w-0 flex-1">
-                    <p className="truncate text-[14px] font-semibold text-[#1c1c1e] dark:text-white">
+                    <p className="break-words text-[14px] font-semibold text-[#1c1c1e] [overflow-wrap:anywhere] dark:text-white">
                       {event.title}
                     </p>
-                    <p className="mt-0.5 truncate text-[12px] font-medium text-[#8e8e93] dark:text-white/55">
+                    <p className="mt-0.5 break-words text-[12px] font-medium text-[#8e8e93] [overflow-wrap:anywhere] dark:text-white/55">
                       {event.detail}
                     </p>
                   </div>

--- a/hushh-webapp/ios/App/App/Plugins/HushhLocationPlugin.swift
+++ b/hushh-webapp/ios/App/App/Plugins/HushhLocationPlugin.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Capacitor
 import CoreLocation
+import UIKit
 
 /**
  * HushhLocationPlugin - foreground-only one-shot location capture.
@@ -15,6 +16,7 @@ public class HushhLocationPlugin: CAPPlugin, CAPBridgedPlugin, CLLocationManager
     public let jsName = "HushhLocation"
     public let pluginMethods: [CAPPluginMethod] = [
         CAPPluginMethod(name: "getPermissionState", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "openLocationSettings", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getCurrentPosition", returnType: CAPPluginReturnPromise)
     ]
 
@@ -28,6 +30,22 @@ public class HushhLocationPlugin: CAPPlugin, CAPBridgedPlugin, CLLocationManager
 
     @objc func getPermissionState(_ call: CAPPluginCall) {
         call.resolve(permissionPayload())
+    }
+
+    @objc func openLocationSettings(_ call: CAPPluginCall) {
+        guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else {
+            call.reject("Location settings are unavailable on this device.")
+            return
+        }
+
+        DispatchQueue.main.async {
+            UIApplication.shared.open(settingsUrl, options: [:]) { opened in
+                call.resolve([
+                    "opened": opened,
+                    "sourcePlatform": "ios"
+                ])
+            }
+        }
     }
 
     @objc func getCurrentPosition(_ call: CAPPluginCall) {
@@ -59,10 +77,11 @@ public class HushhLocationPlugin: CAPPlugin, CAPBridgedPlugin, CLLocationManager
     }
 
     private func permissionPayload() -> [String: Any] {
+        let locationServicesEnabled = CLLocationManager.locationServicesEnabled()
         let state: String
         switch manager.authorizationStatus {
         case .authorizedAlways, .authorizedWhenInUse:
-            state = "granted"
+            state = locationServicesEnabled ? "granted" : "unavailable"
         case .notDetermined:
             state = "prompt"
         case .denied:
@@ -83,7 +102,8 @@ public class HushhLocationPlugin: CAPPlugin, CAPBridgedPlugin, CLLocationManager
         return [
             "state": state,
             "precise": precise as Any,
-            "background": "foreground-only"
+            "background": "foreground-only",
+            "locationServicesEnabled": locationServicesEnabled
         ]
     }
 

--- a/hushh-webapp/lib/capacitor/index.ts
+++ b/hushh-webapp/lib/capacitor/index.ts
@@ -768,10 +768,15 @@ export type HushhLocationPermissionState = {
   state: "granted" | "denied" | "prompt" | "restricted" | "unavailable";
   precise: boolean | null;
   background: "foreground-only" | "available" | "restricted" | "unavailable";
+  locationServicesEnabled?: boolean | null;
 };
 
 export interface HushhLocationPlugin {
   getPermissionState(): Promise<HushhLocationPermissionState>;
+  openLocationSettings(): Promise<{
+    opened: boolean;
+    sourcePlatform: "web" | "ios" | "android" | "native";
+  }>;
   getCurrentPosition(options?: {
     enableHighAccuracy?: boolean;
     timeoutMs?: number;
@@ -799,6 +804,7 @@ export type HushhContactRecord = {
   id?: string | null;
   displayName?: string | null;
   phoneNumbers: string[];
+  emailAddresses?: string[];
 };
 
 export interface HushhContactsPlugin {

--- a/hushh-webapp/lib/capacitor/plugins/location-web.ts
+++ b/hushh-webapp/lib/capacitor/plugins/location-web.ts
@@ -10,10 +10,20 @@ function geolocationAvailable(): boolean {
 export class HushhLocationWeb implements HushhLocationPlugin {
   async getPermissionState(): Promise<HushhLocationPermissionState> {
     if (!geolocationAvailable()) {
-      return { state: "unavailable", precise: false, background: "unavailable" };
+      return {
+        state: "unavailable",
+        precise: false,
+        background: "unavailable",
+        locationServicesEnabled: false,
+      };
     }
     if (!navigator.permissions?.query) {
-      return { state: "prompt", precise: null, background: "foreground-only" };
+      return {
+        state: "prompt",
+        precise: null,
+        background: "foreground-only",
+        locationServicesEnabled: null,
+      };
     }
     const result = await navigator.permissions.query({
       name: "geolocation" as PermissionName,
@@ -22,7 +32,15 @@ export class HushhLocationWeb implements HushhLocationPlugin {
       state: result.state,
       precise: null,
       background: "foreground-only",
+      locationServicesEnabled: null,
     };
+  }
+
+  async openLocationSettings(): Promise<{
+    opened: boolean;
+    sourcePlatform: "web";
+  }> {
+    return { opened: false, sourcePlatform: "web" };
   }
 
   async getCurrentPosition(options?: {

--- a/hushh-webapp/lib/one-location/activity.ts
+++ b/hushh-webapp/lib/one-location/activity.ts
@@ -22,8 +22,31 @@ function formatDateTime(value?: string | null): string {
   }).format(date);
 }
 
-function safeLabel(value?: string | null, fallback = "KAI member"): string {
-  return String(value || "").trim() || fallback;
+function looksLikeInternalIdentifier(value: string): boolean {
+  const label = value.trim();
+  if (!label) return false;
+  if (
+    /^(actor|grant|invite|key|location|one_location|recipient|referral|request|submission|user)[_-]/i.test(
+      label,
+    )
+  ) {
+    return true;
+  }
+  if (/^[0-9a-f]{24,}$/i.test(label) || /^[0-9a-f-]{32,}$/i.test(label)) {
+    return true;
+  }
+  return (
+    /^[A-Za-z0-9_-]{16,}$/.test(label) &&
+    /[A-Z]/.test(label) &&
+    /[a-z]/.test(label) &&
+    /\d/.test(label)
+  );
+}
+
+function safeLabel(value?: string | null, fallback = "One user"): string {
+  const label = String(value || "").trim();
+  if (!label || looksLikeInternalIdentifier(label)) return fallback;
+  return label;
 }
 
 function grantCounterpartyLabel(grant: OneLocationGrant): string {
@@ -151,7 +174,7 @@ export function buildOneLocationActivityFallback(
       safeLabel(recipient.displayName),
     ]),
   );
-  const labelForUser = (userId?: string | null, fallback = "KAI member") =>
+  const labelForUser = (userId?: string | null, fallback = "One user") =>
     safeLabel(userId ? recipientLabels.get(userId) : null, fallback);
   const events: OneLocationActivityEvent[] = [];
   const addEvent = ({

--- a/hushh-webapp/lib/one-location/kai-circle-ctas.ts
+++ b/hushh-webapp/lib/one-location/kai-circle-ctas.ts
@@ -1,0 +1,75 @@
+import type {
+  KaiCircleCandidate,
+  KaiCircleCta,
+  OneLocationViewerCapabilities,
+} from "@/lib/one-location/types";
+
+export function resolveKaiCircleCtas(params: {
+  candidate: KaiCircleCandidate;
+  mode: "share" | "request";
+  viewerCapabilities?: OneLocationViewerCapabilities | null;
+  hasActiveOwnerGrant?: boolean;
+  hasReceivedGrant?: boolean;
+  hasPendingOwnerRequest?: boolean;
+}): KaiCircleCta[] {
+  const { candidate, mode, viewerCapabilities } = params;
+  const ctas: KaiCircleCta[] = [];
+
+  if (params.hasPendingOwnerRequest) {
+    ctas.push(
+      { id: "approve", label: "Approve", enabled: candidate.isShareReady },
+      { id: "deny", label: "Deny", enabled: true },
+    );
+    return ctas;
+  }
+
+  if (params.hasReceivedGrant) {
+    ctas.push({ id: "view_shared_location", label: "View Shared Location", enabled: true });
+  }
+
+  if (params.hasActiveOwnerGrant) {
+    ctas.push({ id: "revoke_access", label: "Revoke Access", enabled: true });
+  }
+
+  if (!candidate.userId || candidate.isPublicProfileOnly) {
+    ctas.push({
+      id: "open_connect_profile",
+      label: "Invite to One",
+      enabled: Boolean(candidate.profileHref || candidate.connectionHref),
+    });
+    return ctas;
+  }
+
+  if (mode === "share") {
+    if (candidate.isShareReady) {
+      ctas.push({ id: "share_location", label: "Share Location", enabled: true });
+    } else {
+      ctas.push({
+        id: "ask_to_setup_one_location",
+        label: "Ask to Setup One Location",
+        enabled: true,
+        reason: "They need a One Location recipient key before private sharing.",
+      });
+    }
+  } else {
+    ctas.push({
+      id: "request_location",
+      label: "Request Location",
+      enabled: viewerCapabilities?.canRequestLocation !== false,
+      reason:
+        viewerCapabilities?.hasLocationRecipientKey === false
+          ? "Your One Location key will be set up before sending the request."
+          : null,
+    });
+  }
+
+  if (candidate.profileHref || candidate.connectionHref) {
+    ctas.push({
+      id: "open_connect_profile",
+      label: "Open Connect Profile",
+      enabled: true,
+    });
+  }
+
+  return ctas;
+}

--- a/hushh-webapp/lib/one-location/kai-circle-sections.ts
+++ b/hushh-webapp/lib/one-location/kai-circle-sections.ts
@@ -1,0 +1,122 @@
+import type {
+  KaiCircleCandidate,
+  KaiCircleSection,
+  KaiCircleSectionKey,
+} from "@/lib/one-location/types";
+
+export const KAI_CIRCLE_SECTION_META: Record<
+  KaiCircleSectionKey,
+  Pick<KaiCircleSection, "title" | "description">
+> = {
+  needs_action: {
+    title: "Needs your approval",
+    description: "Requests and people waiting on a decision.",
+  },
+  trusted_circle: {
+    title: "Trusted Circle",
+    description: "People with active sharing, history, or referrals.",
+  },
+  professional_network: {
+    title: "Professional Network",
+    description: "RIA, investor, advisor, and marketplace signals.",
+  },
+  connect_matches: {
+    title: "Connect Matches",
+    description: "People discovered from Connect and contact matching.",
+  },
+  location_ready: {
+    title: "Location-ready KAI members",
+    description: "Verified KAI members ready for encrypted sharing.",
+  },
+  needs_setup: {
+    title: "Needs setup",
+    description: "People who need to open One Location once.",
+  },
+};
+
+export const KAI_CIRCLE_SECTION_EMPTY_COPY: Record<
+  KaiCircleSectionKey,
+  { title: string; description: string }
+> = {
+  needs_action: {
+    title: "No approvals waiting",
+    description: "New location requests and pending decisions will appear here.",
+  },
+  trusted_circle: {
+    title: "No trusted matches yet",
+    description: "Active shares, repeat approvals, and referrals will lift people here.",
+  },
+  professional_network: {
+    title: "No professional signals yet",
+    description: "RIA, investor, advisor, and marketplace matches will appear here.",
+  },
+  connect_matches: {
+    title: "No Connect matches yet",
+    description: "Contact and Connect matches will appear here after sync.",
+  },
+  location_ready: {
+    title: "No ready KAI members yet",
+    description: "Verified KAI members with location keys will appear here.",
+  },
+  needs_setup: {
+    title: "No setup blockers",
+    description: "Everyone in this section is ready enough for the current flow.",
+  },
+};
+
+export const KAI_CIRCLE_SECTION_ORDER: KaiCircleSectionKey[] = [
+  "needs_action",
+  "trusted_circle",
+  "professional_network",
+  "connect_matches",
+  "location_ready",
+  "needs_setup",
+];
+
+export function kaiCircleSectionKey(candidate: KaiCircleCandidate): KaiCircleSectionKey {
+  switch (candidate.recommendationCategory) {
+    case "needs_action":
+      return "needs_action";
+    case "trusted_circle":
+      return "trusted_circle";
+  }
+
+  if (candidate.connectStatus === "pending") return "needs_action";
+  if (candidate.connectStatus === "connected") return "trusted_circle";
+  if (candidate.isShareReady) return "location_ready";
+  if (
+    candidate.sourceTypes.includes("one_location_recipient") ||
+    candidate.readiness === "target_setup_needed" ||
+    candidate.readiness === "viewer_setup_needed"
+  ) {
+    return "needs_setup";
+  }
+
+  const isProfessional =
+    candidate.recommendationCategory === "professional_network" ||
+    candidate.recommendationTier === "kai_network" ||
+    ["ria", "investor", "public_profile"].includes(String(candidate.connectKind || "")) ||
+    candidate.sourceTypes.some((source) =>
+      ["marketplace_ria", "marketplace_investor", "public_sec", "active_connection"].includes(source),
+    );
+  if (isProfessional) return "professional_network";
+
+  if (candidate.sourceTypes.includes("contact_match")) return "connect_matches";
+  return "needs_setup";
+}
+
+export function buildKaiCircleSections(candidates: KaiCircleCandidate[]): KaiCircleSection[] {
+  const grouped = new Map<KaiCircleSectionKey, KaiCircleCandidate[]>();
+  KAI_CIRCLE_SECTION_ORDER.forEach((key) => grouped.set(key, []));
+
+  for (const candidate of candidates) {
+    grouped.get(kaiCircleSectionKey(candidate))?.push(candidate);
+  }
+
+  return KAI_CIRCLE_SECTION_ORDER.map((key) => ({
+    key,
+    title: KAI_CIRCLE_SECTION_META[key].title,
+    description: KAI_CIRCLE_SECTION_META[key].description,
+    candidates: grouped.get(key) ?? [],
+  }));
+}

--- a/hushh-webapp/lib/one-location/key-bootstrap.ts
+++ b/hushh-webapp/lib/one-location/key-bootstrap.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { ensureLocationRecipientKey } from "@/lib/one-location/encryption";
+import { OneLocationService } from "@/lib/one-location/service";
+import type { OneLocationRecipient } from "@/lib/one-location/types";
+
+export async function bootstrapCurrentUserLocationRecipientKey(params: {
+  userId: string;
+  vaultOwnerToken: string;
+}): Promise<OneLocationRecipient> {
+  const userId = String(params.userId || "").trim();
+  const vaultOwnerToken = String(params.vaultOwnerToken || "").trim();
+  if (!userId) throw new Error("Current user is required for One Location setup.");
+  if (!vaultOwnerToken) throw new Error("Vault owner token required for One Location setup.");
+
+  const key = await ensureLocationRecipientKey(userId);
+  return OneLocationService.registerRecipientKey({
+    vaultOwnerToken,
+    keyId: key.keyId,
+    publicKeyJwk: key.publicKeyJwk,
+    algorithm: key.algorithm,
+  });
+}

--- a/hushh-webapp/lib/one-location/notifications.ts
+++ b/hushh-webapp/lib/one-location/notifications.ts
@@ -8,6 +8,8 @@ export const ONE_LOCATION_NOTIFICATION_OPEN_VALUE = "opened";
 export const ONE_LOCATION_GRANT_ID_PARAM = "grantId";
 export const ONE_LOCATION_REQUEST_ID_PARAM = "requestId";
 export const ONE_LOCATION_REFERRAL_ID_PARAM = "referralId";
+export const ONE_LOCATION_SUBMISSION_ID_PARAM = "submissionId";
+export const ONE_LOCATION_SECTION_PARAM = "section";
 
 const OPENED_GRANTS_KEY_PREFIX = "one_location_opened_grants_v1";
 const LOCATION_SHARE_TASK_KIND = "one_location_share";
@@ -22,6 +24,14 @@ export type OneLocationWorkflowNotificationType =
   | "location_access_denied"
   | "location_referral_invite"
   | "location_public_invite_submitted";
+
+export type OneLocationNotificationSection =
+  | "people"
+  | "approvals"
+  | "shared"
+  | "my_requests"
+  | "public_responses"
+  | "activity";
 
 const WORKFLOW_COPY: Record<
   OneLocationWorkflowNotificationType,
@@ -150,6 +160,7 @@ export function buildOneLocationNotificationHref(grantId: string): string {
   const params = new URLSearchParams();
   params.set(ONE_LOCATION_GRANT_ID_PARAM, grantId);
   params.set(ONE_LOCATION_NOTIFICATION_OPEN_PARAM, ONE_LOCATION_NOTIFICATION_OPEN_VALUE);
+  params.set(ONE_LOCATION_SECTION_PARAM, "shared");
   return `/one/location?${params.toString()}`;
 }
 
@@ -157,20 +168,48 @@ export function buildOneLocationWorkflowHref(params: {
   grantId?: string | null;
   requestId?: string | null;
   referralId?: string | null;
+  submissionId?: string | null;
+  section?: OneLocationNotificationSection | null;
   openGrant?: boolean;
 }): string {
   const query = new URLSearchParams();
   const grantId = String(params.grantId || "").trim();
   const requestId = String(params.requestId || "").trim();
   const referralId = String(params.referralId || "").trim();
+  const submissionId = String(params.submissionId || "").trim();
+  const section = String(params.section || "").trim();
   if (grantId) query.set(ONE_LOCATION_GRANT_ID_PARAM, grantId);
   if (requestId) query.set(ONE_LOCATION_REQUEST_ID_PARAM, requestId);
   if (referralId) query.set(ONE_LOCATION_REFERRAL_ID_PARAM, referralId);
+  if (submissionId) query.set(ONE_LOCATION_SUBMISSION_ID_PARAM, submissionId);
+  if (section) query.set(ONE_LOCATION_SECTION_PARAM, section);
   if (grantId && params.openGrant) {
     query.set(ONE_LOCATION_NOTIFICATION_OPEN_PARAM, ONE_LOCATION_NOTIFICATION_OPEN_VALUE);
   }
   const suffix = query.toString();
   return suffix ? `/one/location?${suffix}` : "/one/location";
+}
+
+export function oneLocationSectionForWorkflowNotificationType(
+  type: OneLocationWorkflowNotificationType,
+): OneLocationNotificationSection {
+  switch (type) {
+    case "location_share_created":
+    case "location_access_approved":
+    case "location_share_revoked":
+    case "location_share_expired":
+      return "shared";
+    case "location_access_request":
+      return "approvals";
+    case "location_access_denied":
+      return "my_requests";
+    case "location_public_invite_submitted":
+      return "public_responses";
+    case "location_referral_invite":
+      return "my_requests";
+    default:
+      return "activity";
+  }
 }
 
 export function locationShareNotificationDescription(ownerLabel?: string | null): string {

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -65,6 +65,10 @@ export class OneLocationService {
     return HushhLocation.getPermissionState();
   }
 
+  static async openLocationSettings() {
+    return HushhLocation.openLocationSettings();
+  }
+
   static async captureCurrentPosition(): Promise<PlainLocationPoint> {
     return HushhLocation.getCurrentPosition({
       enableHighAccuracy: true,
@@ -137,6 +141,7 @@ export class OneLocationService {
 
   static async resolvePublicInvite(publicToken: string): Promise<{
     invite: OneLocationPublicInvite;
+    publicLocation?: PlainLocationPoint | null;
   }> {
     return apiJsonWithRetry(
       `/api/one/location/public-invites/${encodeURIComponent(publicToken)}`,

--- a/hushh-webapp/lib/one-location/types.ts
+++ b/hushh-webapp/lib/one-location/types.ts
@@ -52,6 +52,87 @@ export type OneLocationRecipient = {
   lastInteractionAt?: string | null;
 };
 
+export type OneLocationViewerCapabilities = {
+  hasLocationRecipientKey?: boolean;
+  canBootstrapRecipientKey?: boolean;
+  canShareLocation?: boolean;
+  canRequestLocation?: boolean;
+};
+
+type KaiCircleCandidateReadiness =
+  | "location_ready"
+  | "target_setup_needed"
+  | "viewer_setup_needed"
+  | "invite_only"
+  | "not_shareable";
+
+export type KaiCircleCandidate = {
+  candidateId: string;
+  userId?: string | null;
+  displayName: string;
+  maskedPhone?: string | null;
+  phoneVerified: boolean;
+  keyId?: string | null;
+  publicKeyJwk?: JsonWebKey | null;
+  keyAlgorithm: string;
+  keyRegisteredAt?: string | null;
+  canReceiveLocation: boolean;
+  isShareReady: boolean;
+  readiness: KaiCircleCandidateReadiness;
+  connectCandidateId?: string | null;
+  connectKind?: string | null;
+  connectStatus?: string | null;
+  sourceTypes: string[];
+  profileHref?: string | null;
+  connectionHref?: string | null;
+  isPublicProfileOnly?: boolean;
+  isDiscoverable: boolean;
+  recommendationScore?: number;
+  recommendationRank?: number;
+  recommendationTier?: OneLocationRecommendationTier | null;
+  recommendationCategory?: OneLocationRecommendationCategory | null;
+  recommendationCategoryLabel?: string | null;
+  recommendationReasons?: OneLocationRecommendationReason[];
+  recommendationSummary?: string | null;
+  trustLevel?: "high" | "medium" | "new" | "setup_needed" | string | null;
+  relationshipType?: string | null;
+  profileHeadline?: string | null;
+  verificationBadge?: string | null;
+  lastInteractionAt?: string | null;
+};
+
+export type KaiCircleSectionKey =
+  | "needs_action"
+  | "trusted_circle"
+  | "professional_network"
+  | "connect_matches"
+  | "location_ready"
+  | "needs_setup";
+
+export type KaiCircleSection = {
+  key: KaiCircleSectionKey;
+  title: string;
+  description: string;
+  candidates: KaiCircleCandidate[];
+};
+
+type KaiCircleCtaId =
+  | "share_location"
+  | "request_location"
+  | "ask_to_setup_one_location"
+  | "open_connect_profile"
+  | "approve"
+  | "deny"
+  | "view_shared_location"
+  | "revoke_access";
+
+export type KaiCircleCta = {
+  id: KaiCircleCtaId;
+  label: string;
+  enabled: boolean;
+  reason?: string | null;
+};
+
 export type OneLocationGrant = {
   id: string;
   ownerUserId: string;
@@ -104,13 +185,13 @@ export type OneLocationPublicInvite = {
   ownerLabel?: string | null;
   ownerDisplayName?: string | null;
   ownerMaskedPhone?: string | null;
+  locationAvailable?: boolean;
   status: "active" | "expired" | "revoked" | string;
   durationHours: number;
   expiresAt?: string | null;
   createdAt?: string | null;
   updatedAt?: string | null;
   revokedAt?: string | null;
-  locationAvailable?: boolean;
 };
 
 export type OneLocationPublicInviteSubmission = {
@@ -137,6 +218,8 @@ export type OneLocationPublicInviteSubmission = {
 
 export type OneLocationState = {
   recipients: OneLocationRecipient[];
+  kaiCircleCandidates?: KaiCircleCandidate[];
+  viewerCapabilities?: OneLocationViewerCapabilities;
   ownerGrants: OneLocationGrant[];
   receivedGrants: OneLocationGrant[];
   requests: OneLocationAccessRequest[];


### PR DESCRIPTION
## Summary
- promote only the One Location public-sharing feature set from the train work onto main
- remove public-link visitor form friction and render attached public location directly
- keep mobile/native location permission/share-sheet updates and compact One Location UI

## Scope guard
This PR is intentionally based on origin/main and includes only One Location/native-location docs/tests/runtime paths. It does not merge integration/pr-train or unrelated train PRs.

## Validation
- npm test -- --run __tests__/components/one-location-agent-page.test.tsx __tests__/services/location-agent-service.test.ts __tests__/app/one/location/public-request-page.test.tsx
- npm run typecheck
- npm run lint
- npm run verify:docs
- npm run verify:capacitor:static
- npm run cap:build
- .\\.venv\\Scripts\\python.exe -m pytest tests/test_one_location_routes.py tests/services/test_one_location_agent_service.py tests/test_developer_api_routes.py -q
- .\\.venv\\Scripts\\python.exe -m ruff check hushh_mcp/services/one_location_agent_service.py tests/services/test_one_location_agent_service.py tests/test_one_location_routes.py
- .\\.venv\\Scripts\\python.exe -m ruff format --check hushh_mcp/services/one_location_agent_service.py tests/services/test_one_location_agent_service.py tests/test_one_location_routes.py
- python .codex/skills/codex-skill-authoring/scripts/skill_lint.py