### PR TITLE
fix(kai): promote UI polish to main

### DIFF
--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1330,8 +1330,8 @@ md-ripple.morphy-md-ripple {
 .kai-bottom-nav-pill [role="radio"] {
   color: rgb(60 60 67 / 0.7) !important;
   min-height: 48px;
-  gap: 0.22rem !important;
-  padding: 0.38rem 0.2rem 0.42rem !important;
+  gap: 0.2rem !important;
+  padding: 0.4rem 0.2rem 0.44rem !important;
   letter-spacing: 0;
 }
 
@@ -1341,7 +1341,7 @@ md-ripple.morphy-md-ripple {
 
 .kai-bottom-nav-pill [role="radio"][aria-checked="true"] {
   color: rgb(0 113 227) !important;
-  font-weight: 600;
+  font-weight: 590;
 }
 
 .dark .kai-bottom-nav-pill [role="radio"][aria-checked="true"] {
@@ -1349,25 +1349,39 @@ md-ripple.morphy-md-ripple {
 }
 
 .kai-bottom-nav-pill [role="radio"] svg {
-  width: 20px;
-  height: 20px;
-  opacity: 0.84;
-  stroke-width: 1.72;
-  filter: drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.6));
+  width: 19px;
+  height: 19px;
+  opacity: 0.88;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.48;
+  filter: drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.68));
   transform: translateY(0);
 }
 
 .kai-bottom-nav-pill [role="radio"][aria-checked="true"] svg {
   opacity: 1;
-  stroke-width: 2.08;
-  filter: drop-shadow(0 3px 8px rgb(0 113 227 / 0.2));
+  stroke-width: 1.82;
+  filter:
+    drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.72))
+    drop-shadow(0 4px 10px rgb(0 113 227 / 0.18));
   transform: translateY(-0.5px);
+}
+
+.dark .kai-bottom-nav-pill [role="radio"] svg {
+  filter: drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.12));
+}
+
+.dark .kai-bottom-nav-pill [role="radio"][aria-checked="true"] svg {
+  filter:
+    drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.16))
+    drop-shadow(0 4px 12px rgb(41 171 255 / 0.2));
 }
 
 .kai-bottom-nav-pill [role="radio"] > span:last-of-type {
   max-width: 100%;
   font-size: 9.5px;
-  font-weight: 500;
+  font-weight: 510;
   line-height: 1;
   letter-spacing: 0;
   text-wrap: nowrap;
@@ -1375,7 +1389,7 @@ md-ripple.morphy-md-ripple {
 }
 
 .kai-bottom-nav-pill [role="radio"][aria-checked="true"] > span:last-of-type {
-  font-weight: 600;
+  font-weight: 590;
   opacity: 1;
 }
 

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1353,8 +1353,8 @@ md-ripple.morphy-md-ripple {
 .kai-bottom-nav-pill [role="radio"] {
   color: rgb(60 60 67 / 0.7) !important;
   min-height: 48px;
-  gap: 0.2rem !important;
-  padding: 0.4rem 0.2rem 0.44rem !important;
+  gap: 0.22rem !important;
+  padding: 0.38rem 0.2rem 0.42rem !important;
   letter-spacing: 0;
 }
 
@@ -1364,7 +1364,7 @@ md-ripple.morphy-md-ripple {
 
 .kai-bottom-nav-pill [role="radio"][aria-checked="true"] {
   color: rgb(0 113 227) !important;
-  font-weight: 590;
+  font-weight: 600;
 }
 
 .dark .kai-bottom-nav-pill [role="radio"][aria-checked="true"] {
@@ -1372,39 +1372,25 @@ md-ripple.morphy-md-ripple {
 }
 
 .kai-bottom-nav-pill [role="radio"] svg {
-  width: 19px;
-  height: 19px;
-  opacity: 0.88;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  stroke-width: 1.48;
-  filter: drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.68));
+  width: 20px;
+  height: 20px;
+  opacity: 0.84;
+  stroke-width: 1.72;
+  filter: drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.6));
   transform: translateY(0);
 }
 
 .kai-bottom-nav-pill [role="radio"][aria-checked="true"] svg {
   opacity: 1;
-  stroke-width: 1.82;
-  filter:
-    drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.72))
-    drop-shadow(0 4px 10px rgb(0 113 227 / 0.18));
+  stroke-width: 2.08;
+  filter: drop-shadow(0 3px 8px rgb(0 113 227 / 0.2));
   transform: translateY(-0.5px);
-}
-
-.dark .kai-bottom-nav-pill [role="radio"] svg {
-  filter: drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.12));
-}
-
-.dark .kai-bottom-nav-pill [role="radio"][aria-checked="true"] svg {
-  filter:
-    drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.16))
-    drop-shadow(0 4px 12px rgb(41 171 255 / 0.2));
 }
 
 .kai-bottom-nav-pill [role="radio"] > span:last-of-type {
   max-width: 100%;
   font-size: 9.5px;
-  font-weight: 510;
+  font-weight: 500;
   line-height: 1;
   letter-spacing: 0;
   text-wrap: nowrap;
@@ -1412,7 +1398,7 @@ md-ripple.morphy-md-ripple {
 }
 
 .kai-bottom-nav-pill [role="radio"][aria-checked="true"] > span:last-of-type {
-  font-weight: 590;
+  font-weight: 600;
   opacity: 1;
 }
 

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -959,42 +959,42 @@ html.native-ios {
   }
 
   h1 {
-    font-size: clamp(1.875rem, 3.4vw, 2.75rem) !important;
+    font-size: clamp(1.75rem, 3vw, 2.5rem) !important;
     line-height: 1.1 !important;
-    font-weight: 800 !important;
-    letter-spacing: -0.022em;
+    font-weight: 600 !important;
+    letter-spacing: 0;
   }
 
   h2 {
-    font-size: clamp(1.55rem, 2.8vw, 2.25rem) !important;
-    line-height: 1.14 !important;
-    font-weight: 750 !important;
-    letter-spacing: -0.018em;
+    font-size: clamp(1.3rem, 2vw, 1.75rem) !important;
+    line-height: 1.16 !important;
+    font-weight: 550 !important;
+    letter-spacing: 0;
   }
 
   h3 {
-    font-size: clamp(1.35rem, 2.3vw, 1.85rem) !important;
+    font-size: clamp(1.1rem, 1.55vw, 1.35rem) !important;
     line-height: 1.2 !important;
-    font-weight: 700 !important;
-    letter-spacing: -0.014em;
+    font-weight: 550 !important;
+    letter-spacing: 0;
   }
 
   h4 {
-    font-size: clamp(1.2rem, 1.85vw, 1.45rem) !important;
+    font-size: clamp(1rem, 1.25vw, 1.125rem) !important;
     line-height: 1.24 !important;
-    font-weight: 650 !important;
+    font-weight: 525 !important;
   }
 
   h5 {
-    font-size: clamp(1.12rem, 1.55vw, 1.25rem) !important;
+    font-size: clamp(0.95rem, 1.12vw, 1rem) !important;
     line-height: 1.3 !important;
-    font-weight: 625 !important;
+    font-weight: 525 !important;
   }
 
   h6 {
-    font-size: clamp(1.05rem, 1.35vw, 1.125rem) !important;
+    font-size: clamp(0.875rem, 1vw, 0.95rem) !important;
     line-height: 1.32 !important;
-    font-weight: 600 !important;
+    font-weight: 525 !important;
   }
 
   [data-slot$="title"] {
@@ -1017,10 +1017,33 @@ html.native-ios {
   .app-page-shell h1,
   .app-page-shell [role="heading"][aria-level="1"] {
     font-family: var(--font-heading), var(--font-sans), system-ui, sans-serif;
-    font-size: clamp(1.9rem, 4.8vw, 2rem) !important;
+    font-size: clamp(1.75rem, 3.4vw, 2.125rem) !important;
     line-height: 1.08 !important;
-    font-weight: 600 !important;
+    font-weight: 500 !important;
     letter-spacing: 0 !important;
+  }
+
+  .app-page-shell h2,
+  .app-page-shell [role="heading"][aria-level="2"] {
+    font-family: var(--font-heading), var(--font-sans), system-ui, sans-serif;
+    font-size: clamp(1rem, 1.45vw, 1.25rem) !important;
+    line-height: 1.2 !important;
+    font-weight: 500 !important;
+    letter-spacing: 0 !important;
+  }
+
+  .app-page-shell h3,
+  .app-page-shell [role="heading"][aria-level="3"] {
+    font-family: var(--font-heading), var(--font-sans), system-ui, sans-serif;
+    font-size: clamp(0.95rem, 1.18vw, 1.0625rem) !important;
+    line-height: 1.25 !important;
+    font-weight: 500 !important;
+    letter-spacing: 0 !important;
+  }
+
+  .app-page-shell .font-black,
+  .app-page-shell .font-extrabold {
+    font-weight: 600 !important;
   }
 
   /* Global Lucide icon stroke thickness (lucide-react adds `.lucide` on the SVG). */

--- a/hushh-webapp/app/kai/analysis/page.tsx
+++ b/hushh-webapp/app/kai/analysis/page.tsx
@@ -1079,9 +1079,13 @@ function KaiAnalysisPageContent() {
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <div className="flex items-center gap-3">
                   <SymbolAvatar symbol={activeTicker} name={activeTicker} size="lg" />
-                  <h1 className="text-[28px] font-medium tracking-normal text-foreground sm:text-[34px]">
+                  <div
+                    role="heading"
+                    aria-level={2}
+                    className="text-[20px] font-medium leading-tight tracking-normal text-foreground sm:text-[22px]"
+                  >
                     {activeTicker}
-                  </h1>
+                  </div>
                 </div>
                 <div className="flex items-center gap-2">
                   <span className="text-sm font-medium tabular-nums text-muted-foreground sm:text-base">

--- a/hushh-webapp/app/kai/onboarding/page.tsx
+++ b/hushh-webapp/app/kai/onboarding/page.tsx
@@ -41,6 +41,12 @@ import { Card } from "@/lib/morphy-ux/card";
 import { Button } from "@/lib/morphy-ux/button";
 import { AlertTriangle } from "lucide-react";
 import { useNativeTestConfig } from "@/lib/testing/native-test";
+import {
+  kaiAppBodyClassName,
+  kaiAppCardTitleClassName,
+  kaiAppDisplayTitleClassName,
+  kaiAppEyebrowClassName,
+} from "@/components/kai/shared/kai-typography";
 
 type Stage = "loading" | "entry" | "wizard" | "persona";
 type OnboardingSource = "pre_vault" | "vault";
@@ -315,19 +321,19 @@ function KaiOnboardingPageContent() {
           authState={user ? "authenticated" : "pending"}
           dataState="loaded"
         />
-        <div className="w-full space-y-6">
-          <div className="mx-auto max-w-[36rem] space-y-3 text-center">
-            <p className="text-[10.5px] font-medium uppercase tracking-[0.16em] text-primary/75">
+        <div className="w-full space-y-8">
+          <div className="mx-auto max-w-[48rem] space-y-3 text-center">
+            <p className={`${kaiAppEyebrowClassName} text-primary/75`}>
               Choose your starting path
             </p>
             <div
               role="heading"
               aria-level={1}
-              className="text-[34px] font-medium leading-[1.06] tracking-normal text-foreground sm:text-[40px]"
+              className={`${kaiAppDisplayTitleClassName} text-foreground`}
             >
               Start as an investor or set up RIA first
             </div>
-            <p className="mx-auto max-w-[31rem] text-[16px] leading-[1.45] text-muted-foreground sm:text-[17px]">
+            <p className={`mx-auto max-w-[35rem] ${kaiAppBodyClassName} text-muted-foreground`}>
               You can add the other profile later from Profile. This choice only sets the first
               workflow we open right now.
             </p>
@@ -377,11 +383,11 @@ function KaiOnboardingPageContent() {
                   <div
                     role="heading"
                     aria-level={2}
-                    className="text-[24px] font-medium leading-[1.12] tracking-normal text-foreground sm:text-[26px]"
+                    className={`${kaiAppCardTitleClassName} text-foreground`}
                   >
                     Continue as Investor
                   </div>
-                  <p className="max-w-[31rem] text-[15px] leading-[1.45] text-muted-foreground sm:text-[16px]">
+                  <p className="max-w-[28rem] text-[14px] font-normal leading-[1.45] tracking-normal text-muted-foreground">
                     Answer your risk and preference questions, then connect accounts and start using
                     Kai.
                   </p>
@@ -433,11 +439,11 @@ function KaiOnboardingPageContent() {
                   <div
                     role="heading"
                     aria-level={2}
-                    className="text-[24px] font-medium leading-[1.12] tracking-normal text-foreground sm:text-[26px]"
+                    className={`${kaiAppCardTitleClassName} text-foreground`}
                   >
                     Continue as RIA
                   </div>
-                  <p className="max-w-[31rem] text-[15px] leading-[1.45] text-muted-foreground sm:text-[16px]">
+                  <p className="max-w-[28rem] text-[14px] font-normal leading-[1.45] tracking-normal text-muted-foreground">
                     Set up your advisor identity, verification, firm details, and marketplace trust
                     profile before sending consent requests.
                   </p>

--- a/hushh-webapp/app/kai/optimize/page.tsx
+++ b/hushh-webapp/app/kai/optimize/page.tsx
@@ -769,7 +769,7 @@ export default function PortfolioHealthPage() {
                 
                 {/* LEFT COLUMN: Visual Analytics (The Graph) */}
                 <div className="relative p-6 md:p-8 bg-gradient-to-b from-muted/10 to-transparent">
-                  <div className="absolute top-4 left-4 md:top-6 md:left-6 text-[9px] font-black uppercase tracking-[0.2em] text-muted-foreground/50">
+                  <div className="absolute top-4 left-4 md:top-6 md:left-6 text-[9px] font-semibold uppercase tracking-[0.2em] text-muted-foreground/50">
                     Health Radar
                   </div>
                   
@@ -825,11 +825,11 @@ export default function PortfolioHealthPage() {
                   <div className="flex justify-center gap-6 mt-[-10px]">
                     <div className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-background/50 border border-border/5 backdrop-blur-sm">
                       <div className="w-2 h-2 rounded-full bg-[var(--color-current)]" />
-                      <span className="text-[9px] font-black uppercase tracking-widest text-muted-foreground">Current</span>
+                      <span className="text-[9px] font-semibold uppercase tracking-widest text-muted-foreground">Current</span>
                     </div>
                     <div className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-background/50 border border-border/5 backdrop-blur-sm">
                       <div className="w-2 h-2 rounded-full bg-[var(--color-optimized)]" />
-                      <span className="text-[9px] font-black uppercase tracking-widest text-muted-foreground">Optimized</span>
+                      <span className="text-[9px] font-semibold uppercase tracking-widest text-muted-foreground">Optimized</span>
                     </div>
                   </div>
                 </div>
@@ -843,21 +843,21 @@ export default function PortfolioHealthPage() {
                       <div className="space-y-4">
                          {/* Header Row */}
                         <div className="flex flex-wrap items-center justify-between gap-3">
-                          <span className="text-[10px] font-black text-muted-foreground uppercase tracking-[0.2em]">
+                          <span className="text-[10px] font-semibold text-muted-foreground uppercase tracking-[0.2em]">
                             Alpha Alignment
                           </span>
                           
                           {result.summary.projected_health_score && (
                             <div className="flex items-center gap-2 px-2 py-1 rounded-md bg-emerald-500/10 border border-emerald-500/20">
-                               <span className="text-[9px] font-black uppercase tracking-wider text-emerald-500">Projected Goal</span>
-                               <span className="text-xs font-black text-emerald-500">{result.summary.projected_health_score.toFixed(0)}%</span>
+                               <span className="text-[9px] font-semibold uppercase tracking-wider text-emerald-500">Projected Goal</span>
+                               <span className="text-xs font-semibold text-emerald-500">{result.summary.projected_health_score.toFixed(0)}%</span>
                             </div>
                           )}
                         </div>
 
                         {/* Big Score Row */}
                         <div className="flex items-baseline gap-1">
-                          <span className="text-7xl font-black tracking-tighter text-foreground leading-none">
+                          <span className="text-[32px] font-medium tracking-normal text-foreground leading-none sm:text-[36px]">
                             {result.summary.health_score.toFixed(0)}
                           </span>
                           <span className="text-2xl font-bold text-muted-foreground/40">%</span>
@@ -888,7 +888,7 @@ export default function PortfolioHealthPage() {
 
                   {/* Strategic Insights Module */}
                   <div className="flex-1 flex flex-col justify-end pt-6 border-t border-border/10">
-                    <h4 className="flex items-center gap-2 text-[10px] font-black text-muted-foreground uppercase tracking-[0.2em] mb-4">
+                    <h4 className="flex items-center gap-2 text-[10px] font-semibold text-muted-foreground uppercase tracking-[0.2em] mb-4">
                       <Icon icon={ListChecks} size="sm" className="text-primary" />
                       Key Insights
                     </h4>
@@ -925,8 +925,8 @@ export default function PortfolioHealthPage() {
                         <Icon icon={stat.icon} size="md" className="text-primary" />
                       </div>
                       <div className="flex flex-col gap-1">
-                        <span className="text-[10px] text-muted-foreground font-black uppercase tracking-widest">{stat.label}</span>
-                        <span className="text-sm font-black text-foreground">{stat.value}</span>
+                        <span className="text-[10px] text-muted-foreground font-semibold uppercase tracking-widest">{stat.label}</span>
+                        <span className="text-sm font-semibold text-foreground">{stat.value}</span>
                       </div>
                     </div>
                   ))}
@@ -938,7 +938,7 @@ export default function PortfolioHealthPage() {
           {sectorData.length > 0 && (
             <SurfaceCard>
               <SurfaceCardHeader className="pb-0">
-                <SurfaceCardTitle className="flex items-center gap-2 text-[10px] font-black uppercase tracking-widest text-muted-foreground">
+                <SurfaceCardTitle className="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
                   <Icon icon={TrendingUp} size={12} className="text-primary" />
                   Sector Concentration Shift
                 </SurfaceCardTitle>
@@ -1012,7 +1012,7 @@ export default function PortfolioHealthPage() {
                  <Icon icon={ShieldCheck} size={128} className="text-foreground" />
                </div>
                <div className="relative z-10">
-                <h3 className="text-xs font-black uppercase tracking-[0.2em] text-primary mb-6 flex items-center gap-2">
+                <h3 className="text-xs font-semibold uppercase tracking-[0.2em] text-primary mb-6 flex items-center gap-2">
                   <Icon icon={Zap} size="sm" />
                   Executive Strategic Summary
                 </h3>
@@ -1034,24 +1034,24 @@ export default function PortfolioHealthPage() {
             <SurfaceCardHeader>
               <div className="flex items-center gap-2">
                 <Icon icon={Zap} size="md" className="text-primary animate-pulse" />
-                <SurfaceCardTitle className="text-sm font-black uppercase tracking-widest">Simulated Alignment Outcome</SurfaceCardTitle>
+                <SurfaceCardTitle className="text-sm font-semibold uppercase tracking-widest">Simulated Alignment Outcome</SurfaceCardTitle>
               </div>
             </SurfaceCardHeader>
             <SurfaceCardContent className="space-y-4">
               <p className="text-sm text-foreground/80 font-medium">
-                By executing these {result.losers.length} adjustments, your portfolio's alpha alignment score is projected to move from <span className="text-red-400 font-black">{typeof result.summary.health_score === 'number' ? result.summary.health_score.toFixed(0) : "0"}</span> to <span className="text-emerald-400 font-black text-lg">{typeof result.summary.projected_health_score === 'number' ? `${result.summary.projected_health_score.toFixed(0)}+` : "92+"}</span>.
+                By executing these {result.losers.length} adjustments, your portfolio's alpha alignment score is projected to move from <span className="text-red-400 font-semibold">{typeof result.summary.health_score === 'number' ? result.summary.health_score.toFixed(0) : "0"}</span> to <span className="text-emerald-400 font-semibold text-lg">{typeof result.summary.projected_health_score === 'number' ? `${result.summary.projected_health_score.toFixed(0)}+` : "92+"}</span>.
               </p>
               <div className="p-5 rounded-3xl bg-background/80 border border-border/10 space-y-4">
-                <div className="flex items-center justify-between text-[10px] font-black uppercase tracking-widest text-muted-foreground">
+                <div className="flex items-center justify-between text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
                   <span>Current Fragility</span>
                   <Icon icon={ArrowRight} size={12} />
                   <span>Optimized Resilience</span>
                 </div>
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 md:gap-4">
-                   <div className="h-14 rounded-2xl bg-red-500/10 border border-red-500/20 flex items-center justify-center text-[10px] font-black text-red-500">
+                   <div className="h-14 rounded-2xl bg-red-500/10 border border-red-500/20 flex items-center justify-center text-[10px] font-semibold text-red-500">
                      HIGH SPECULATIVE RISK
                    </div>
-                   <div className="h-14 rounded-2xl bg-emerald-500/10 border border-emerald-500/20 flex items-center justify-center text-[10px] font-black text-emerald-500">
+                   <div className="h-14 rounded-2xl bg-emerald-500/10 border border-emerald-500/20 flex items-center justify-center text-[10px] font-semibold text-emerald-500">
                      CONVICTION ALPHA DIVERSITY
                    </div>
                 </div>
@@ -1091,7 +1091,7 @@ export default function PortfolioHealthPage() {
                   
                   return (
                     <div key={groupIdx} className="space-y-4">
-                      <div className={cn("flex items-center gap-2 px-3 py-2 rounded-xl border font-black text-[10px] uppercase tracking-widest", group.banner)}>
+                      <div className={cn("flex items-center gap-2 px-3 py-2 rounded-xl border font-semibold text-[10px] uppercase tracking-widest", group.banner)}>
                         <group.icon className={cn("w-3.5 h-3.5", group.iconColor)} />
                         {group.title}
                       </div>
@@ -1099,10 +1099,10 @@ export default function PortfolioHealthPage() {
                       <Table>
                         <TableHeader>
                           <TableRow className="hover:bg-transparent border-white/5">
-                            <TableHead className="w-[100px] text-[10px] uppercase font-black text-muted-foreground">Asset</TableHead>
-                            <TableHead className="text-[10px] uppercase font-black text-muted-foreground">Tier</TableHead>
-                            <TableHead className="text-[10px] uppercase font-black text-muted-foreground text-right">Target Δ</TableHead>
-                            <TableHead className="text-[10px] uppercase font-black text-muted-foreground text-right">Rationale</TableHead>
+                            <TableHead className="w-[100px] text-[10px] uppercase font-semibold text-muted-foreground">Asset</TableHead>
+                            <TableHead className="text-[10px] uppercase font-semibold text-muted-foreground">Tier</TableHead>
+                            <TableHead className="text-[10px] uppercase font-semibold text-muted-foreground text-right">Target Δ</TableHead>
+                            <TableHead className="text-[10px] uppercase font-semibold text-muted-foreground text-right">Rationale</TableHead>
                           </TableRow>
                         </TableHeader>
                         <TableBody>
@@ -1113,7 +1113,7 @@ export default function PortfolioHealthPage() {
                               <TableRow key={lIdx} className="group border-white/5 hover:bg-white/5 transition-colors">
                                 <TableCell className="py-4">
                                   <div className="flex flex-col">
-                                    <span className="font-black text-xs text-foreground uppercase">{l.symbol}</span>
+                                    <span className="font-semibold text-xs text-foreground uppercase">{l.symbol}</span>
                                     <span className="text-[9px] text-muted-foreground truncate max-w-[100px] font-medium">{l.name}</span>
                                   </div>
                                 </TableCell>
@@ -1122,7 +1122,7 @@ export default function PortfolioHealthPage() {
                                     <Badge 
                                       variant="outline" 
                                       className={cn(
-                                        "text-[9px] font-black tracking-widest px-1.5 py-0 rounded",
+                                        "text-[9px] font-semibold tracking-widest px-1.5 py-0 rounded",
                                         l.renaissance_tier === "ACE" ? "bg-emerald-500/10 text-emerald-500 border-emerald-500/20" :
                                         l.renaissance_tier === "KING" ? "bg-blue-500/10 text-blue-500 border-blue-500/20" :
                                         "bg-amber-500/10 text-amber-500 border-amber-500/20"
@@ -1134,7 +1134,7 @@ export default function PortfolioHealthPage() {
                                 </TableCell>
                                 <TableCell className="text-right">
                                   <span className={cn(
-                                    "text-xs font-black",
+                                    "text-xs font-semibold",
                                     group.actionType === "REDUCE" ? "text-red-500" : "text-emerald-500"
                                   )}>
                                     {group.actionType === "REDUCE" ? "–" : "+"}{delta > 0 ? `${delta.toFixed(1)}%` : "N/A"}
@@ -1161,7 +1161,7 @@ export default function PortfolioHealthPage() {
           {result.summary.plans && (
             <SurfaceCard>
               <SurfaceCardHeader className="pb-4">
-                <SurfaceCardTitle className="flex items-center gap-2 text-xs font-black uppercase tracking-widest text-muted-foreground">
+                <SurfaceCardTitle className="flex items-center gap-2 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
                   <Icon icon={LayoutDashboard} size="sm" className="text-primary" />
                   Proposed Rebalance Path Scenarios
                 </SurfaceCardTitle>
@@ -1173,7 +1173,7 @@ export default function PortfolioHealthPage() {
                       <TabsTrigger 
                         key={key}
                         value={key} 
-                        className="rounded-xl text-[10px] font-black uppercase tracking-widest data-[state=active]:bg-background data-[state=active]:text-primary transition-all"
+                        className="rounded-xl text-[10px] font-semibold uppercase tracking-widest data-[state=active]:bg-background data-[state=active]:text-primary transition-all"
                       >
                         {key}
                       </TabsTrigger>
@@ -1191,7 +1191,7 @@ export default function PortfolioHealthPage() {
                             <div key={idx} className="flex flex-col md:flex-row md:items-center justify-between p-5 rounded-3xl bg-muted/20 border border-border/20 hover:border-primary/40 transition-all group gap-4 ring-1 ring-transparent hover:ring-primary/10">
                               <div className="flex items-center gap-4">
                                 <div className={cn(
-                                  "w-10 h-10 rounded-2xl flex items-center justify-center font-black text-xs",
+                                  "w-10 h-10 rounded-2xl flex items-center justify-center font-semibold text-xs",
                                   a.action?.toLowerCase() === "exit" ? "bg-red-500/20 text-red-500" :
                                   a.action?.toLowerCase() === "trim" ? "bg-amber-500/20 text-amber-500" :
                                   "bg-emerald-500/20 text-emerald-500"
@@ -1200,8 +1200,8 @@ export default function PortfolioHealthPage() {
                                 </div>
                                 <div className="flex flex-col">
                                   <div className="flex items-center gap-2">
-                                    <span className="text-sm font-black text-foreground uppercase tracking-tight">{a.symbol}</span>
-                                    <Badge variant="outline" className="text-[8px] h-4 font-black px-1.5 opacity-60">{a.action}</Badge>
+                                    <span className="text-sm font-semibold text-foreground uppercase tracking-tight">{a.symbol}</span>
+                                    <Badge variant="outline" className="text-[8px] h-4 font-semibold px-1.5 opacity-60">{a.action}</Badge>
                                   </div>
                                   <span className="text-[10px] font-medium text-muted-foreground line-clamp-1">{a.name || "Portfolio Holding"}</span>
                                 </div>
@@ -1216,7 +1216,7 @@ export default function PortfolioHealthPage() {
                               <div className="flex items-center justify-between md:justify-end gap-6 bg-white/5 md:bg-transparent p-3 md:p-0 rounded-2xl">
                                 {typeof a.current_weight_pct === "number" && (
                                   <div className="flex flex-col items-end">
-                                    <span className="text-[8px] font-black text-muted-foreground uppercase tracking-widest mb-0.5">Transition</span>
+                                    <span className="text-[8px] font-semibold text-muted-foreground uppercase tracking-widest mb-0.5">Transition</span>
                                     <div className="flex items-center gap-2">
                                       <span className="text-xs font-bold text-muted-foreground/60">{a.current_weight_pct.toFixed(1)}%</span>
                                       <Icon
@@ -1224,7 +1224,7 @@ export default function PortfolioHealthPage() {
                                         size={12}
                                         className="text-primary group-hover:translate-x-1 transition-transform"
                                       />
-                                      <span className="text-sm font-black text-foreground">{(a.target_weight_pct ?? a.current_weight_pct).toFixed(1)}%</span>
+                                      <span className="text-sm font-semibold text-foreground">{(a.target_weight_pct ?? a.current_weight_pct).toFixed(1)}%</span>
                                     </div>
                                   </div>
                                 )}
@@ -1247,7 +1247,7 @@ export default function PortfolioHealthPage() {
           <div className="grid gap-6 md:grid-cols-2">
             <SurfaceCard className="opacity-80 transition-opacity hover:opacity-100">
               <SurfaceCardHeader className="py-4">
-                <SurfaceCardTitle className="text-[10px] font-black uppercase tracking-widest">Renaissance Alignment Context</SurfaceCardTitle>
+                <SurfaceCardTitle className="text-[10px] font-semibold uppercase tracking-widest">Renaissance Alignment Context</SurfaceCardTitle>
               </SurfaceCardHeader>
               <SurfaceCardContent className="pb-4">
                 <pre className="whitespace-pre-wrap text-[11px] text-muted-foreground/80 leading-relaxed font-medium">
@@ -1259,7 +1259,7 @@ export default function PortfolioHealthPage() {
             {streamedText && (
               <SurfaceCard accent="sky">
                 <SurfaceCardHeader className="py-4">
-                  <SurfaceCardTitle className="text-[10px] font-black uppercase tracking-widest">
+                  <SurfaceCardTitle className="text-[10px] font-semibold uppercase tracking-widest">
                     Alpha Analysis Runtime Transcript
                   </SurfaceCardTitle>
                 </SurfaceCardHeader>

--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -1417,7 +1417,7 @@ export default function MarketplacePage() {
                   <ProfileAvatar kind={item.kind} label={item.title} />
                   <div className="min-w-0 flex-1 space-y-2">
                     <div className="flex flex-wrap items-center gap-2">
-                      <h3 className="text-[17px] font-semibold leading-snug tracking-normal text-foreground">
+                      <h3 className="text-[15.5px] font-medium leading-[1.24] tracking-normal text-foreground sm:text-[16px]">
                         {item.title}
                       </h3>
                       {item.isTestProfile ? (
@@ -1437,12 +1437,12 @@ export default function MarketplacePage() {
                         </span>
                       ) : null}
                     </div>
-                    <p className="text-[14px] leading-[1.45] text-foreground/78">{item.headline}</p>
+                    <p className="text-[14px] font-normal leading-[1.45] tracking-normal text-foreground/72">{item.headline}</p>
                   </div>
                 </div>
 
                 <div className="flex-1 rounded-[var(--radius-md)] bg-background/50 p-4 dark:bg-white/5">
-                  <p className="text-[14px] leading-[1.5] text-foreground/86">{item.summary}</p>
+                  <p className="text-[14px] font-normal leading-[1.45] tracking-normal text-foreground/82">{item.summary}</p>
                   <p className="mt-3 text-[13px] text-muted-foreground">{item.metaLine}</p>
                 </div>
 

--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -1109,7 +1109,7 @@ export default function MarketplacePage() {
       </AppPageHeaderRegion>
 
       <AppPageContentRegion className="space-y-4 pb-24 pt-0">
-        <div className="sticky top-[calc(var(--top-shell-reserved-height)+6px)] z-[115] rounded-[28px] bg-background/90 p-1.5 shadow-[var(--app-card-shadow-standard)] backdrop-blur-[var(--blur-standard)]">
+        <div className="rounded-[28px] bg-background/90 p-1.5 shadow-[var(--app-card-shadow-standard)] backdrop-blur-[var(--blur-standard)]">
           <div className="flex items-center justify-between gap-2">
             <div className="flex items-center gap-2">
               <button
@@ -1411,7 +1411,7 @@ export default function MarketplacePage() {
             return (
               <RiaSurface
                 key={`${item.kind}-${item.id}`}
-                className="grid h-full grid-rows-[auto_1fr_auto] gap-4 rounded-[28px] p-4 sm:p-5"
+                className="flex h-full min-h-[286px] flex-col gap-4 rounded-[28px] p-4 sm:p-5"
               >
                 <div className="flex items-start gap-4">
                   <ProfileAvatar kind={item.kind} label={item.title} />
@@ -1441,17 +1441,17 @@ export default function MarketplacePage() {
                   </div>
                 </div>
 
-                <div className="rounded-[var(--radius-md)] bg-background/50 p-4 dark:bg-white/5">
+                <div className="flex-1 rounded-[var(--radius-md)] bg-background/50 p-4 dark:bg-white/5">
                   <p className="text-[14px] leading-[1.5] text-foreground/86">{item.summary}</p>
                   <p className="mt-3 text-[13px] text-muted-foreground">{item.metaLine}</p>
                 </div>
 
-                <div className="mt-auto grid grid-cols-1 gap-2 sm:grid-cols-2">
+                <div className="mt-auto grid grid-cols-1 gap-2 pt-1 sm:grid-cols-2">
                   <Button
                     variant="blue-gradient"
                     effect="fill"
                     size="sm"
-                    className="justify-center"
+                    className="min-w-0 justify-center"
                     onClick={() => performPrimaryCardAction(item)}
                     disabled={
                       (Boolean(userId) && actionLoadingUserId === userId) ||
@@ -1479,7 +1479,7 @@ export default function MarketplacePage() {
                     variant="none"
                     effect="fade"
                     size="sm"
-                    className="justify-center"
+                    className="min-w-0 justify-center"
                     onClick={() => openDiscoveryProfile(item)}
                   >
                     View details

--- a/hushh-webapp/app/profile/page.tsx
+++ b/hushh-webapp/app/profile/page.tsx
@@ -725,7 +725,6 @@ function ProfilePageContent() {
   const [marketplaceOptIn, setMarketplaceOptIn] = useState(false);
   const [loadingMarketplaceOptIn, setLoadingMarketplaceOptIn] = useState(true);
   const [savingMarketplaceOptIn, setSavingMarketplaceOptIn] = useState(false);
-  const [locationContextEnabled, setLocationContextEnabled] = useState(false);
   const [riaOnboardingStatus, setRiaOnboardingStatus] =
     useState<RiaOnboardingStatus | null>(null);
   const [loadingRiaOnboardingStatus, setLoadingRiaOnboardingStatus] =
@@ -2032,15 +2031,6 @@ function ProfilePageContent() {
         voiceAliases: ["access", "sharing", "consent access"],
       },
       {
-        id: "profile_location_context",
-        label: "Location",
-        purpose:
-          "toggles nearby advisors and local market hours on this device.",
-        actionId: "profile.location_context",
-        role: "switch",
-        voiceAliases: ["location", "nearby advisors", "local market hours"],
-      },
-      {
         id: "profile_vault",
         label: vaultSettingsRow.title,
         purpose: vaultSettingsRow.voicePurpose,
@@ -2155,7 +2145,6 @@ function ProfilePageContent() {
           "Access & sharing",
           "Gmail receipts",
           "Email",
-          "Location",
           "Preferences",
           "Security",
           "Support & feedback",
@@ -2194,7 +2183,6 @@ function ProfilePageContent() {
                   "Open Access & sharing",
                   "Open Gmail receipts",
                   "Open Email",
-                  locationContextEnabled ? "Turn off Location" : "Turn on Location",
                   "Open Support",
                 ];
 
@@ -2253,11 +2241,6 @@ function ProfilePageContent() {
             id: "email",
             title: "Email",
             purpose: "Requests and approval drafts.",
-          },
-          {
-            id: "location",
-            title: "Location",
-            purpose: "Nearby advisors and local market hours.",
           },
           {
             id: "support",
@@ -2332,7 +2315,6 @@ function ProfilePageContent() {
         google_email: gmail.status?.google_email || null,
         pkm_agent_lab_available: canShowPkmAgentLab,
         marketplace_opt_in: marketplaceOptIn,
-        location_context_enabled: locationContextEnabled,
         ria_regulatory_profile_visible: shouldShowRiaRegulatoryRow,
         ria_license_number: currentRiaLicenseNumber || null,
         ria_regulator: currentRiaRegulator,
@@ -2356,7 +2338,6 @@ function ProfilePageContent() {
     gmailStatusSummary.title,
     gmail.status?.google_email,
     lastVoiceControlId,
-    locationContextEnabled,
     marketplaceOptIn,
     passphraseDialogOpen,
     pendingConsents,
@@ -4266,30 +4247,6 @@ function ProfilePageContent() {
                   }
                   router.push(ROUTES.ONE_KYC);
                 }}
-              />
-              <SettingsRow
-                icon={MapPin}
-                title="Location"
-                description={
-                  locationContextEnabled
-                    ? "While using the app - every read is receipted."
-                    : "Nearby advisors and local market hours. Off by default."
-                }
-                trailing={
-                  <Switch
-                    checked={locationContextEnabled}
-                    aria-label="Toggle location"
-                    onPointerDown={(event) => {
-                      event.stopPropagation();
-                    }}
-                    onClick={(event) => event.stopPropagation()}
-                    onCheckedChange={setLocationContextEnabled}
-                  />
-                }
-                voiceControlId="profile_location_context"
-                voiceActionId="profile.location_context"
-                voiceLabel="Location"
-                voicePurpose="Nearby advisors and local market hours."
               />
             </SettingsGroup>
 

--- a/hushh-webapp/app/register-phone/page.tsx
+++ b/hushh-webapp/app/register-phone/page.tsx
@@ -9,6 +9,10 @@ import { HushhLoader } from "@/components/app-ui/hushh-loader";
 import { NativeRouteMarker } from "@/components/app-ui/native-route-marker";
 import { PhoneVerificationFlow } from "@/components/auth/phone-verification-flow";
 import { VaultLockGuard } from "@/components/vault/vault-lock-guard";
+import {
+  kaiAppHeroBodyClassName,
+  kaiAppHeroTitleClassName,
+} from "@/components/kai/shared/kai-typography";
 import { useAuth } from "@/lib/firebase/auth-context";
 import { ROUTES } from "@/lib/navigation/routes";
 import { AccountIdentityService } from "@/lib/services/account-identity-service";
@@ -142,11 +146,11 @@ function PhoneMandatePageContent() {
             role="heading"
             aria-level={1}
             aria-label="Verify your phone number"
-            className="mt-2.5 text-[38px] font-medium leading-[1.05] tracking-normal text-[#1d1d1f] sm:text-[40px] dark:text-[#f5f5f7]"
+            className={`mt-2.5 ${kaiAppHeroTitleClassName} text-[#1d1d1f] dark:text-[#f5f5f7]`}
           >
             Verify your phone number
           </div>
-          <p className="mx-auto mt-3 max-w-[20rem] text-[17px] font-normal leading-[1.42] tracking-normal text-[rgba(0,0,0,0.56)] sm:text-[18px] dark:text-[rgba(245,245,247,0.60)]">
+          <p className={`mx-auto mt-3 max-w-[20rem] ${kaiAppHeroBodyClassName} text-[rgba(0,0,0,0.56)] dark:text-[rgba(245,245,247,0.60)]`}>
             Add your phone number to continue.
           </p>
         </header>

--- a/hushh-webapp/components/kai/cards/allocation-strip.tsx
+++ b/hushh-webapp/components/kai/cards/allocation-strip.tsx
@@ -60,7 +60,7 @@ export function AllocationStrip({ cashPct, equitiesPct, bondsPct }: AllocationSt
 
   return (
     <div className="space-y-2 rounded-xl border border-border/60 bg-card/70 p-4">
-      <h3 className="text-[11px] font-black uppercase tracking-[0.16em] text-muted-foreground">Allocation</h3>
+      <h3 className="text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">Allocation</h3>
       <div className="h-3 w-full overflow-hidden rounded-full bg-muted">
         <div className="flex h-full w-full">
           {segments.map((segment) => (

--- a/hushh-webapp/components/kai/cards/connect-portfolio-cta.tsx
+++ b/hushh-webapp/components/kai/cards/connect-portfolio-cta.tsx
@@ -12,7 +12,7 @@ export function ConnectPortfolioCta() {
     <SurfaceCard accent="emerald">
       <SurfaceCardContent className="space-y-4 p-6 text-center">
         <div className="space-y-2">
-          <h3 className="text-lg font-black tracking-tight">
+          <h3 className="text-lg font-semibold tracking-tight">
             See insights tailored to your portfolio
           </h3>
           <p className="text-sm text-muted-foreground">

--- a/hushh-webapp/components/kai/cards/dashboard-summary-hero.tsx
+++ b/hushh-webapp/components/kai/cards/dashboard-summary-hero.tsx
@@ -59,7 +59,7 @@ export function DashboardSummaryHero({
       <CardContent className="space-y-4 p-5 sm:p-6">
         <div className="space-y-2 text-center">
           <p className="text-sm font-medium text-muted-foreground">Total portfolio value</p>
-          <div className="flex items-center justify-center gap-2">
+          <div className="flex flex-wrap items-center justify-center gap-2">
             <Badge className="rounded-full bg-muted px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
               Risk: {normalizeRiskLabel(riskLabel)}
             </Badge>
@@ -72,14 +72,12 @@ export function DashboardSummaryHero({
               </Badge>
             )}
           </div>
-          <h2 className="text-[34px] font-medium leading-tight tracking-normal">{formatCurrency(totalValue)}</h2>
+          <h2 className="text-[28px] font-medium leading-tight tracking-normal sm:text-[32px]">{formatCurrency(totalValue)}</h2>
           <div className="flex items-center justify-center gap-2 text-sm">
-            <span className={positive ? "text-emerald-600" : "text-red-500"}>
-              <span className="inline-flex items-center font-medium">
-                <Icon icon={positive ? ArrowUpRight : ArrowDownRight} size="sm" className="mr-1" />
-                {formatChange(netChange)} ({changePct >= 0 ? "+" : ""}
-                {changePct.toFixed(2)}%)
-              </span>
+            <span className={positive ? "inline-flex items-center font-medium text-emerald-600 dark:text-emerald-400" : "inline-flex items-center font-medium text-rose-500 dark:text-rose-400"}>
+              <Icon icon={positive ? ArrowUpRight : ArrowDownRight} size="sm" className="mr-1" />
+              {formatChange(netChange)} ({changePct >= 0 ? "+" : ""}
+              {changePct.toFixed(2)}%)
             </span>
             <span className="text-muted-foreground">•</span>
             <span className="font-medium text-muted-foreground">{periodLabel}</span>

--- a/hushh-webapp/components/kai/cards/holding-position-card.tsx
+++ b/hushh-webapp/components/kai/cards/holding-position-card.tsx
@@ -43,11 +43,11 @@ export function HoldingPositionCard({ holding, onAnalyze, onManage }: HoldingPos
       <CardContent className="space-y-3 p-4">
         <div className="flex items-start justify-between">
           <div className="flex items-center gap-3">
-            <div className="grid h-10 w-10 place-items-center rounded-xl bg-muted text-xs font-black text-foreground">
+            <div className="grid h-10 w-10 place-items-center rounded-xl bg-muted text-xs font-semibold text-foreground">
               {tickerFallback(holding.symbol)}
             </div>
             <div>
-              <h4 className="text-sm font-black leading-tight">{holding.name}</h4>
+              <h4 className="text-sm font-semibold leading-tight">{holding.name}</h4>
               <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
                 {holding.symbol}
               </span>
@@ -78,17 +78,17 @@ export function HoldingPositionCard({ holding, onAnalyze, onManage }: HoldingPos
 
         <div className="grid grid-cols-2 gap-3 text-sm">
           <div>
-            <p className="text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground">Shares @ Price</p>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">Shares @ Price</p>
             <p className="font-medium">
               {holding.quantity.toLocaleString()} @ {formatCurrency(holding.price)}
             </p>
           </div>
           <div className="text-right">
-            <p className="text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground">Market Value</p>
-            <p className="font-black">{formatCurrency(holding.marketValue)}</p>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">Market Value</p>
+            <p className="font-semibold">{formatCurrency(holding.marketValue)}</p>
           </div>
           <div>
-            <p className="text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground">Gain/Loss</p>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">Gain/Loss</p>
             <p className={positive ? "font-semibold text-emerald-600" : "font-semibold text-red-500"}>
               {positive ? "+" : "-"}
               {formatCurrency(Math.abs(holding.gainLossValue))} ({holding.gainLossPct >= 0 ? "+" : ""}

--- a/hushh-webapp/components/kai/cards/kpi-card.tsx
+++ b/hushh-webapp/components/kai/cards/kpi-card.tsx
@@ -113,14 +113,14 @@ export function KPICard({
               {icon}
             </div>
           )}
-          <span className={cn("text-muted-foreground uppercase font-black tracking-widest leading-none", styles.title)}>
+          <span className={cn("text-muted-foreground uppercase font-semibold tracking-widest leading-none", styles.title)}>
             {title}
           </span>
         </div>
 
         {/* Value */}
         <p
-          className={cn("font-black tracking-tighter leading-tight", styles.value)}
+          className={cn("font-semibold tracking-tighter leading-tight", styles.value)}
           aria-label={`${title}: ${value}`}
         >
           {value}

--- a/hushh-webapp/components/kai/cards/new-holding-cta-card.tsx
+++ b/hushh-webapp/components/kai/cards/new-holding-cta-card.tsx
@@ -16,7 +16,7 @@ export function NewHoldingCtaCard({ onAddHolding, onImportStatement }: NewHoldin
     <Card variant="none" effect="glass" preset="default">
       <CardContent className="space-y-4 p-5">
         <div className="space-y-1">
-          <h4 className="text-sm font-black">New Holding Entry</h4>
+          <h4 className="text-sm font-semibold">New Holding Entry</h4>
           <p className="text-xs text-muted-foreground">
             Use Manage Portfolio for full edits, or import another statement for bulk updates.
           </p>

--- a/hushh-webapp/components/kai/cards/profile-based-picks-list.tsx
+++ b/hushh-webapp/components/kai/cards/profile-based-picks-list.tsx
@@ -151,7 +151,7 @@ export function ProfileBasedPicksList({
   return (
     <div className="space-y-2">
       <div className="space-y-0.5">
-        <h3 className="text-sm font-black">Personalized picks</h3>
+        <h3 className="text-sm font-semibold">Personalized picks</h3>
         <p className="text-[11px] text-muted-foreground">
           Source: Kai risk profile ({riskProfile}) + current holdings context.
         </p>
@@ -177,11 +177,11 @@ export function ProfileBasedPicksList({
                 className="flex items-center justify-between gap-3 p-3"
               >
                 <div className="flex min-w-0 items-center gap-3">
-                  <div className="grid h-9 w-9 place-items-center rounded-full border border-border/70 bg-muted text-[11px] font-black">
+                  <div className="grid h-9 w-9 place-items-center rounded-full border border-border/70 bg-muted text-[11px] font-semibold">
                     {pick.symbol}
                   </div>
                   <div className="min-w-0">
-                    <p className="truncate text-sm font-bold leading-tight">{pick.company_name}</p>
+                    <p className="truncate text-sm font-medium leading-tight">{pick.company_name}</p>
                     <p className="truncate text-xs font-medium text-muted-foreground">
                       {(pick.tier || "Tier N/A").toUpperCase()}
                       {pick.sector ? ` • ${pick.sector}` : ""}

--- a/hushh-webapp/components/kai/cards/renaissance-verdict-card.tsx
+++ b/hushh-webapp/components/kai/cards/renaissance-verdict-card.tsx
@@ -150,14 +150,14 @@ export function RenaissanceVerdictCard({
           </p>
           <div className="flex items-center gap-2">
             <VerdictIcon signal={signal} className={tone.icon} />
-            <p className={cn("text-xl font-bold tracking-tight", tone.label)}>
+            <p className={cn("text-base font-medium leading-tight tracking-normal", tone.label)}>
               {label}
             </p>
           </div>
         </div>
         <Badge
           variant="outline"
-          className={cn("shrink-0 text-[10px] font-bold uppercase tracking-wide", tone.badge)}
+          className={cn("shrink-0 text-[10px] font-semibold uppercase tracking-wide", tone.badge)}
         >
           {signal}
         </Badge>

--- a/hushh-webapp/components/kai/cards/spotlight-card.tsx
+++ b/hushh-webapp/components/kai/cards/spotlight-card.tsx
@@ -85,19 +85,19 @@ export function SpotlightCard(props: {
             <div className="flex min-w-0 items-start gap-3">
               <SymbolAvatar symbol={props.symbol} name={props.companyName} size="md" />
               <div className="min-w-0 space-y-1">
-                <h3 className="text-base font-black tracking-tight leading-tight">{props.title}</h3>
+                <h3 className="text-[15.5px] font-medium leading-tight tracking-normal sm:text-base">{props.title}</h3>
                 <p className="text-sm text-muted-foreground">{props.price}</p>
               </div>
             </div>
             <div className="flex items-center gap-1.5">
               {props.confidenceLabel ? (
-                <span className="inline-flex items-center rounded-full bg-background/75 px-2 py-1 text-[10px] font-bold tracking-wide text-muted-foreground transition-colors duration-200 group-hover:bg-background/85">
+                <span className="inline-flex items-center rounded-full bg-background/75 px-2 py-1 text-[10px] font-medium tracking-wide text-muted-foreground transition-colors duration-200 group-hover:bg-background/85">
                   {props.confidenceLabel}
                 </span>
               ) : null}
               <span
                 className={cn(
-                  "inline-flex items-center rounded-full px-3 py-1 text-[11px] font-extrabold tracking-wide",
+                  "inline-flex items-center rounded-full px-3 py-1 text-[11px] font-semibold tracking-wide",
                   decisionTone
                 )}
               >
@@ -106,7 +106,7 @@ export function SpotlightCard(props: {
             </div>
           </div>
 
-          <p className="text-sm font-medium leading-relaxed">{props.summary}</p>
+          <p className="text-sm font-normal leading-relaxed text-foreground/80">{props.summary}</p>
 
           <div className="flex items-center gap-2 border-t border-border/40 pt-3 text-xs text-muted-foreground transition-colors duration-200 group-hover:border-border/60">
             <Icon icon={LineChart} size="sm" />

--- a/hushh-webapp/components/kai/home/movers-tabs.tsx
+++ b/hushh-webapp/components/kai/home/movers-tabs.tsx
@@ -60,7 +60,7 @@ export function MoversTabs({ movers }: MoversTabsProps) {
   return (
     <Card variant="none" effect="glass" preset="compact">
       <CardContent className="space-y-3 p-4">
-        <p className="text-sm font-black tracking-tight">Market Movers</p>
+        <p className="text-sm font-semibold tracking-tight">Market Movers</p>
 
         <div className="flex gap-2 overflow-x-auto pb-1">
           {TABS.map((item) => (

--- a/hushh-webapp/components/kai/home/sector-rotation-card.tsx
+++ b/hushh-webapp/components/kai/home/sector-rotation-card.tsx
@@ -27,7 +27,7 @@ export function SectorRotationCard({ rows }: SectorRotationCardProps) {
   return (
     <Card variant="none" effect="glass" preset="compact">
       <CardContent className="space-y-3 p-4">
-        <p className="text-sm font-black tracking-tight">Sector Rotation</p>
+        <p className="text-sm font-semibold tracking-tight">Sector Rotation</p>
         <div className="space-y-2">
           {rows.slice(0, 6).map((row) => {
             const pct = typeof row.change_pct === "number" ? row.change_pct : 0;

--- a/hushh-webapp/components/kai/home/signal-chips.tsx
+++ b/hushh-webapp/components/kai/home/signal-chips.tsx
@@ -24,7 +24,7 @@ export function SignalChips({ signals }: SignalChipsProps) {
         <Card key={signal.id} variant="none" effect="glass" preset="compact">
           <CardContent className="space-y-2 p-3">
             <div className="flex items-start justify-between gap-2">
-              <p className="text-sm font-black tracking-tight">{signal.title}</p>
+              <p className="text-sm font-semibold tracking-tight">{signal.title}</p>
               <span className="rounded-full bg-background/70 px-2 py-0.5 text-[10px] font-semibold text-muted-foreground">
                 {(signal.confidence * 100).toFixed(0)}%
               </span>

--- a/hushh-webapp/components/kai/home/watchlist-strip.tsx
+++ b/hushh-webapp/components/kai/home/watchlist-strip.tsx
@@ -40,7 +40,7 @@ export function WatchlistStrip({ items }: WatchlistStripProps) {
               <CardContent className="space-y-2 p-3">
                 <div className="flex items-start justify-between gap-2">
                   <div className="min-w-0">
-                    <p className="truncate text-sm font-black">{item.symbol}</p>
+                    <p className="truncate text-sm font-semibold">{item.symbol}</p>
                     <p className="truncate text-[11px] text-muted-foreground">{item.company_name}</p>
                   </div>
                   <span
@@ -51,7 +51,7 @@ export function WatchlistStrip({ items }: WatchlistStripProps) {
                 </div>
 
                 <div>
-                  <p className="text-base font-extrabold tracking-tight">{formatCurrency(item.price)}</p>
+                  <p className="text-base font-semibold tracking-tight">{formatCurrency(item.price)}</p>
                   <p
                     className={cn(
                       "text-xs font-semibold",

--- a/hushh-webapp/components/kai/kai-command-bar-global.tsx
+++ b/hushh-webapp/components/kai/kai-command-bar-global.tsx
@@ -5,6 +5,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 import { useAuth } from "@/hooks/use-auth";
 import { KaiSearchBar } from "@/components/kai/kai-search-bar";
+import { useOptionalAgentPopover } from "@/components/agent/agent-popover-provider";
 import { usePersonaState } from "@/lib/persona/persona-context";
 import { useKaiSession } from "@/lib/stores/kai-session-store";
 import { CacheService, CACHE_KEYS } from "@/lib/services/cache-service";
@@ -132,6 +133,7 @@ export function KaiCommandBarGlobal() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const agentPopover = useOptionalAgentPopover();
   const { user, loading } = useAuth();
   const {
     activePersona,
@@ -310,6 +312,8 @@ export function KaiCommandBarGlobal() {
     [pathname]
   );
   const voiceEligibleRoute = isVoiceEligibleRouteScreen(routeInfo.screen, chromeState.hideCommandBar);
+  const agentWindowOpen =
+    agentPopover?.expanded || agentPopover?.motionState === "opening";
 
   useEffect(() => {
     if (!voiceEligibleRoute) {
@@ -727,7 +731,7 @@ export function KaiCommandBarGlobal() {
     return null;
   }
 
-  if (chromeState.hideCommandBar) {
+  if (chromeState.hideCommandBar || agentWindowOpen) {
     return null;
   }
 

--- a/hushh-webapp/components/kai/onboarding/KaiPersonaScreen.tsx
+++ b/hushh-webapp/components/kai/onboarding/KaiPersonaScreen.tsx
@@ -5,6 +5,10 @@ import { ArrowRight, Shield, Target, TrendingUp, type LucideIcon } from "lucide-
 import type { RiskProfile } from "@/lib/services/kai-profile-service";
 import { Button } from "@/lib/morphy-ux/button";
 import { Icon } from "@/lib/morphy-ux/ui";
+import {
+  kaiAppBodyClassName,
+  kaiAppDisplayTitleClassName,
+} from "@/components/kai/shared/kai-typography";
 
 const PERSONA_CONFIG: Record<
   RiskProfile,
@@ -74,10 +78,10 @@ export function KaiPersonaScreen(props: {
               <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
                 {cfg.pill}
               </p>
-              <h1 className="text-balance text-[clamp(2rem,4.2vw,2.75rem)] font-normal leading-[1.06] tracking-normal text-foreground">
+              <h1 className={`text-balance ${kaiAppDisplayTitleClassName} text-foreground`}>
                 {cfg.title}
               </h1>
-              <p className="mx-auto max-w-[30rem] text-[16px] leading-[1.5] text-muted-foreground">
+              <p className={`mx-auto max-w-[30rem] ${kaiAppBodyClassName} text-muted-foreground`}>
                 {cfg.support}
               </p>
             </div>

--- a/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
+++ b/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
@@ -23,6 +23,10 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import {
+  kaiAppDisplayTitleClassName,
+  kaiAppSectionTitleClassName,
+} from "@/components/kai/shared/kai-typography";
 
 type WizardAnswers = {
   investment_horizon: InvestmentHorizon | null;
@@ -267,8 +271,8 @@ export function KaiPreferencesWizard(props: {
                 className={cn(
                   "tracking-normal text-balance text-foreground",
                   isPageLayout
-                    ? "text-[clamp(1.65rem,2.25vw,2.05rem)] font-medium leading-[1.12]"
-                    : "text-[clamp(0.95rem,2.8vw,1.2rem)] leading-[1.3] font-semibold"
+                    ? kaiAppDisplayTitleClassName
+                    : kaiAppSectionTitleClassName
                 )}
               >
                 {activeQuestion.prompt}

--- a/hushh-webapp/components/kai/onboarding/kai-nav-tour.tsx
+++ b/hushh-webapp/components/kai/onboarding/kai-nav-tour.tsx
@@ -428,7 +428,7 @@ export function KaiNavTour() {
             </div>
 
             <div className="space-y-1">
-              <h3 className="text-base font-black">{activeStep.title}</h3>
+              <h3 className="text-base font-semibold">{activeStep.title}</h3>
               <p className="text-sm text-muted-foreground">{activeStep.description}</p>
             </div>
 

--- a/hushh-webapp/components/kai/shared/kai-typography.ts
+++ b/hushh-webapp/components/kai/shared/kai-typography.ts
@@ -3,20 +3,26 @@
 export const kaiAppEyebrowClassName =
   "!text-[10.5px] !font-medium !leading-[1.2] uppercase !tracking-[0.14em]";
 
+export const kaiAppHeroTitleClassName =
+  "text-[38px] font-medium leading-[1.05] tracking-normal sm:text-[40px]";
+
+export const kaiAppHeroBodyClassName =
+  "text-[17px] font-normal leading-[1.42] tracking-normal sm:text-[18px]";
+
 export const kaiAppDisplayTitleClassName =
-  "!text-[36px] !font-medium !leading-[1.06] !tracking-normal sm:!text-[48px]";
+  "!text-[30px] !font-medium !leading-[1.08] !tracking-normal sm:!text-[34px]";
 
 export const kaiAppCompactTitleClassName =
-  "!text-[34px] !font-medium !leading-[1.06] !tracking-normal sm:!text-[42px]";
+  "!text-[30px] !font-medium !leading-[1.08] !tracking-normal sm:!text-[34px]";
 
 export const kaiAppBodyClassName =
   "!text-[16px] !font-normal !leading-[1.45] !tracking-normal sm:!text-[17px]";
 
 export const kaiAppSectionTitleClassName =
-  "!text-[21px] !font-medium !leading-[1.12] !tracking-normal sm:!text-[24px]";
+  "!text-[18px] !font-medium !leading-[1.18] !tracking-normal sm:!text-[20px]";
 
 export const kaiAppCardTitleClassName =
-  "!text-[16.5px] !font-medium !leading-[1.22] !tracking-normal";
+  "!text-[15.5px] !font-medium !leading-[1.24] !tracking-normal sm:!text-[16px]";
 
 export const kaiAppCardBodyClassName =
   "!text-[14px] !font-normal !leading-[1.42] !tracking-normal";

--- a/hushh-webapp/components/kai/views/analysis-summary-view.tsx
+++ b/hushh-webapp/components/kai/views/analysis-summary-view.tsx
@@ -381,11 +381,11 @@ export function AnalysisSummaryView({
 
       {showHeader ? (
         <div className="flex items-center gap-4 px-1">
-          <div className="grid h-14 w-14 place-items-center rounded-full bg-black text-lg font-black text-white dark:bg-white dark:text-black">
+          <div className="grid h-14 w-14 place-items-center rounded-full bg-black text-lg font-semibold text-white dark:bg-white dark:text-black">
             {entry.ticker.slice(0, 1)}
           </div>
           <div>
-            <h2 className="text-2xl font-black tracking-tight leading-tight">{entry.ticker} Insight</h2>
+            <h2 className="text-[20px] font-medium leading-tight tracking-normal sm:text-[22px]">{entry.ticker} Insight</h2>
             <div className="mt-1 flex flex-wrap items-center gap-2">
               <span className="font-mono text-sm text-muted-foreground">{priceLabel}</span>
               {todayChangePct !== null ? (

--- a/hushh-webapp/components/kai/views/dashboard-master-view.tsx
+++ b/hushh-webapp/components/kai/views/dashboard-master-view.tsx
@@ -158,7 +158,7 @@ const portfolioChipTones = {
 const portfolioMetricLabelClassName =
   "text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground";
 const portfolioMetricValueClassName =
-  "mt-1 text-2xl font-medium tracking-normal sm:text-[1.65rem]";
+  "mt-1 text-[1.35rem] font-medium tracking-normal sm:text-[1.5rem]";
 const portfolioSummaryPillClassName =
   "rounded-2xl px-3 py-2 text-[12px] leading-5 text-muted-foreground";
 
@@ -2777,7 +2777,7 @@ export function DashboardMasterView({
                 </span>
               ) : null}
             </div>
-            <p className="text-[2.35rem] font-medium leading-none tracking-normal text-foreground sm:text-5xl">
+            <p className="text-[2rem] font-medium leading-none tracking-normal text-foreground sm:text-[2.5rem]">
               {formatCurrency(model.hero.totalValue)}
             </p>
             <div className="flex flex-wrap items-center justify-center gap-2 text-sm">

--- a/hushh-webapp/components/kai/views/decision-card.tsx
+++ b/hushh-webapp/components/kai/views/decision-card.tsx
@@ -493,7 +493,7 @@ function ConsensusDonut({ result }: { result: DecisionResult }) {
       <div className="space-y-3">
         <div className="flex items-end justify-between gap-3">
           <div>
-            <p className="text-2xl font-black tracking-tight text-foreground">{agreePct}%</p>
+            <p className="text-2xl font-semibold tracking-tight text-foreground">{agreePct}%</p>
             <p className="text-xs text-muted-foreground">Agents align with the final call</p>
           </div>
           <div className="rounded-xl border border-amber-500/15 bg-amber-500/[0.08] px-3 py-2 text-right">
@@ -759,7 +759,7 @@ function ConfidenceGauge({ confidence }: { confidence: number }) {
                       <tspan
                         x={viewBox.cx}
                         y={viewBox.cy}
-                        className="fill-foreground text-3xl font-black tracking-tighter"
+                        className="fill-foreground text-3xl font-semibold tracking-tighter"
                       >
                         {score}%
                       </tspan>
@@ -923,7 +923,7 @@ export function DecisionCard({ result }: { result: DecisionResult }) {
             {/* Main Decision Pill */}
             <div
                 className={cn(
-                "px-10 py-5 rounded-2xl border-2 text-4xl font-black uppercase tracking-tighter shadow-xl backdrop-blur-md transform transition-all duration-300 hover:scale-[1.02]",
+                "px-10 py-5 rounded-2xl border-2 text-2xl font-semibold uppercase tracking-normal shadow-xl backdrop-blur-md transform transition-all duration-300 hover:scale-[1.02]",
                 isBuy
                     ? "bg-emerald-500/10 border-emerald-500/20 text-emerald-500 shadow-emerald-500/10"
                     : isReduce

--- a/hushh-webapp/components/kai/views/history-detail-view.tsx
+++ b/hushh-webapp/components/kai/views/history-detail-view.tsx
@@ -170,7 +170,7 @@ export function HistoryDetailView({
             <CardContent className="p-4">
               <div className="flex items-center gap-3">
                 <SymbolAvatar symbol={entry.ticker} name={entry.ticker} size="md" />
-                <h2 className="text-2xl font-black tracking-tight">{entry.ticker}</h2>
+                <h2 className="text-2xl font-semibold tracking-tight">{entry.ticker}</h2>
                 <span className="text-sm font-semibold tabular-nums text-muted-foreground">{priceLabel}</span>
                 {todayChangePct !== null ? (
                   <span
@@ -234,7 +234,7 @@ export function HistoryDetailView({
               <div className="flex items-start gap-3">
                 <SymbolAvatar symbol={entry.ticker} name={entry.ticker} size="lg" className="mt-0.5" />
                 <div>
-                  <h1 className="text-2xl font-black tracking-tighter text-foreground leading-none">
+                  <h1 className="text-2xl font-semibold tracking-tighter text-foreground leading-none">
                     {entry.ticker}
                   </h1>
                   <div className="mt-1 flex items-center gap-2">

--- a/hushh-webapp/components/kai/views/kai-analysis-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-analysis-preview-view.tsx
@@ -584,7 +584,7 @@ export function KaiAnalysisPreviewView() {
           <div className="mt-5 flex items-start justify-between gap-3">
             <div>
               <p className="text-[13px] font-medium text-[color:var(--one-fg2)]">Portfolio value</p>
-              <p className="mt-1 text-[38px] font-semibold leading-none tracking-normal text-[color:var(--one-fg)] tabular-nums">
+              <p className="mt-1 text-[30px] font-medium leading-none tracking-normal text-[color:var(--one-fg)] tabular-nums sm:text-[34px]">
                 {rangeMeta.value}
               </p>
             </div>

--- a/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
@@ -148,8 +148,8 @@ const oneMarketRootClassName = cn(
   marketSurfaceVariablesClassName,
   "relative isolate mx-auto flex min-h-screen w-full !max-w-none flex-col overflow-x-hidden !px-0 pb-0",
   "bg-[color:var(--one-bg)] font-sans text-[color:var(--one-fg)] antialiased",
-  "[--one-bg:#ffffff] [--one-card:#ffffff] [--one-surface:#f2f2f7]",
-  "dark:[--one-bg:#000000] dark:[--one-card:#1c1c1e] dark:[--one-surface:#1c1c1e]",
+  "[--one-bg:var(--background)] [--one-card:#ffffff] [--one-surface:#f2f2f7]",
+  "dark:[--one-bg:rgb(28,28,30)] dark:[--one-card:#1c1c1e] dark:[--one-surface:#1c1c1e]",
   "[--one-hairline:rgba(0,0,0,0.08)] [--one-line:rgba(0,0,0,0.06)]",
   "dark:[--one-hairline:rgba(255,255,255,0.14)] dark:[--one-line:rgba(255,255,255,0.10)]",
   "[--one-fg:#1d1d1f] [--one-fg2:rgba(0,0,0,0.55)] [--one-fg3:rgba(0,0,0,0.42)]",
@@ -2041,13 +2041,13 @@ export function KaiMarketPreviewView() {
           {`
             html:has([data-one-market-preview="true"]),
             body {
-              background: #ffffff !important;
+              background: var(--background) !important;
             }
 
             body:has([data-one-market-preview="true"]) main,
             body:has([data-one-market-preview="true"]) [data-top-content-anchor="true"],
             body:has([data-one-market-preview="true"]) [class*="overflow-y-auto"][class*="touch-pan-y"] {
-              background: #ffffff !important;
+              background: var(--background) !important;
             }
 
             html.dark:has([data-one-market-preview="true"]),
@@ -2055,7 +2055,7 @@ export function KaiMarketPreviewView() {
             html.dark:has([data-one-market-preview="true"]) body main,
             html.dark:has([data-one-market-preview="true"]) body [data-top-content-anchor="true"],
             html.dark:has([data-one-market-preview="true"]) body [class*="overflow-y-auto"][class*="touch-pan-y"] {
-              background: #000000 !important;
+              background: rgb(28, 28, 30) !important;
             }
 
             nextjs-portal,

--- a/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
+++ b/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
@@ -743,7 +743,7 @@ export function ManagePortfolioView() {
               disabled={isSaving}
               variant="morphy"
               effect="fill"
-              className="w-full h-12 text-sm font-black rounded-xl border-none shadow-xl"
+              className="w-full h-12 text-sm font-semibold rounded-xl border-none shadow-xl"
               icon={{ 
                 icon: isSaving ? SpinningLoader : Save,
                 gradient: false 

--- a/hushh-webapp/components/kai/views/portfolio-import-view.tsx
+++ b/hushh-webapp/components/kai/views/portfolio-import-view.tsx
@@ -32,15 +32,17 @@ import { scrollAppToTop } from "@/lib/navigation/use-scroll-reset";
 import {
   kaiAppBodyClassName,
   kaiAppCardBodyClassName,
+  kaiAppCardTitleClassName,
   kaiAppCompactTitleClassName,
   kaiAppEyebrowClassName,
   kaiAppHelperClassName,
+  kaiAppSectionTitleClassName,
 } from "@/components/kai/shared/kai-typography";
 
 const importCardTitleClassName =
-  "!text-[22px] !font-medium !leading-[1.12] !tracking-normal text-foreground sm:!text-[24px]";
+  cn(kaiAppSectionTitleClassName, "text-foreground");
 const importDropzoneTitleClassName =
-  "!text-[16px] !font-medium !leading-[1.24] !tracking-normal sm:!text-[17px]";
+  cn(kaiAppCardTitleClassName, "text-foreground");
 
 // =============================================================================
 // TYPES

--- a/hushh-webapp/components/kai/views/portfolio-import-view.tsx
+++ b/hushh-webapp/components/kai/views/portfolio-import-view.tsx
@@ -166,22 +166,17 @@ export function PortfolioImportView({
   ]);
 
   return (
-    <div className="mx-auto w-full space-y-3.5 pt-3 pb-6" style={APP_MEASURE_STYLES.reading}>
+    <div className="mx-auto w-full space-y-4 pt-3 pb-6" style={APP_MEASURE_STYLES.reading}>
       {/* Header */}
-      <div className="space-y-2.5 text-center">
+      <div className="space-y-2 text-left">
+        <p className={cn(kaiAppEyebrowClassName, "text-muted-foreground")}>
+          Getting started
+        </p>
         <h1 className={cn(kaiAppCompactTitleClassName, "text-foreground")}>
-          Your money
-          <br />
-          <span>Your options</span>
+          Portfolio
         </h1>
         <p className={cn(kaiAppBodyClassName, "text-muted-foreground")}>
           Let Kai analyze your holdings for precise advice
-        </p>
-      </div>
-
-      <div className="text-center">
-        <p className={cn(kaiAppEyebrowClassName, "text-muted-foreground")}>
-          Choose import method
         </p>
       </div>
 

--- a/hushh-webapp/components/kai/views/portfolio-review-view.tsx
+++ b/hushh-webapp/components/kai/views/portfolio-review-view.tsx
@@ -1943,7 +1943,7 @@ export function PortfolioReviewView({
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex items-start gap-3">
           <div className="px-1">
-	            <h1 className="text-xl font-bold tracking-tight">Review Portfolio</h1>
+	            <h1 className="text-[20px] font-medium tracking-normal">Review Portfolio</h1>
 	            <p className="max-w-[28rem] text-sm leading-snug text-muted-foreground">
 	              {hasVault === false
 	                ? "Review your portfolio, then create your Vault to save it."
@@ -1981,7 +1981,7 @@ export function PortfolioReviewView({
                 <p className="text-xs font-bold uppercase tracking-widest text-muted-foreground mb-1">
                   Total Portfolio Value
                 </p>
-                <p className="max-w-full px-2 text-[clamp(1.7rem,8.5vw,2.55rem)] font-black leading-none tracking-tight tabular-nums whitespace-nowrap bg-linear-to-br from-foreground to-foreground/70 bg-clip-text text-transparent sm:text-4xl">
+                <p className="max-w-full px-2 text-[28px] font-medium leading-none tracking-normal tabular-nums whitespace-nowrap bg-linear-to-br from-foreground to-foreground/70 bg-clip-text text-transparent sm:text-[32px]">
                   <span title={formatCurrency(totalValue)}>{formatCurrencyCompact(totalValue)}</span>
                 </p>
 
@@ -2010,14 +2010,14 @@ export function PortfolioReviewView({
 
               <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 sm:gap-4 pt-6 border-t border-primary/10">
                 <div className="min-w-0 text-center sm:text-left sm:pl-4">
-                  <p className="text-2xl font-black">{activeHoldings.length}</p>
+                  <p className="text-[1.35rem] font-medium sm:text-[1.5rem]">{activeHoldings.length}</p>
                   <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">Assets</p>
                 </div>
                 <div className="min-w-0 flex flex-col items-center justify-center">
                   <Badge
                     variant="outline"
                     className={cn(
-                      "font-black text-[10px] uppercase tracking-widest px-2",
+                      "font-semibold text-[10px] uppercase tracking-widest px-2",
                       riskBucket === "aggressive"
                         ? "app-critical-badge"
                         : riskBucket === "moderate"
@@ -2032,7 +2032,7 @@ export function PortfolioReviewView({
                 <div className="min-w-0 text-center sm:text-right sm:pr-4">
                   <p
                     className={cn(
-                      "max-w-full text-[clamp(1.05rem,5.8vw,1.55rem)] font-black leading-none tabular-nums whitespace-nowrap sm:text-2xl",
+                      "max-w-full text-[20px] font-medium leading-none tracking-normal tabular-nums whitespace-nowrap sm:text-[22px]",
                       liveCashBalance < 0
                         ? "text-red-500 dark:text-red-400"
                         : "text-foreground"
@@ -2275,7 +2275,7 @@ export function PortfolioReviewView({
             <CardHeader className="border-b border-[color:var(--app-card-border-standard)] bg-[var(--app-card-surface-sticky-header)] px-6 pb-4 pt-6">
               <div className="flex items-center justify-between gap-2">
                 <div>
-                  <CardTitle className="text-lg font-black uppercase tracking-widest text-foreground">
+                  <CardTitle className="text-[15px] font-medium uppercase tracking-[0.14em] text-foreground">
                     Holdings ({holdings.length})
                     {pendingDeleteCount > 0 ? (
                       <span className="ml-2 text-[11px] font-semibold text-muted-foreground">

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -6,14 +6,16 @@
 import React, { useEffect, useMemo, type CSSProperties } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import {
-  ChartSpline,
-  ChartCandlestick,
+  BriefcaseBusiness,
+  ChartNoAxesColumnIncreasing,
+  ChartNoAxesCombined,
   CircleUserRound,
   Compass,
   FileSpreadsheet,
   House,
+  Network,
+  UserRound,
   Users,
-  WalletCards,
 } from "lucide-react";
 
 import { useAuth } from "@/hooks/use-auth";
@@ -135,31 +137,31 @@ export const Navbar = () => {
             {
               value: "market",
               label: "Market",
-              icon: ChartCandlestick,
+              icon: ChartNoAxesColumnIncreasing,
               dataTourId: "nav-market",
             },
             {
               value: "dashboard",
               label: "Portfolio",
-              icon: WalletCards,
+              icon: BriefcaseBusiness,
               dataTourId: "nav-portfolio",
             },
             {
               value: "analysis",
               label: "Analysis",
-              icon: ChartSpline,
+              icon: ChartNoAxesCombined,
               dataTourId: "nav-analysis",
             },
             {
               value: "connect",
               label: "Connect",
-              icon: Compass,
+              icon: Network,
               dataTourId: "nav-connect",
             },
             {
               value: "profile",
               label: "Profile",
-              icon: CircleUserRound,
+              icon: UserRound,
               badge: pendingConsents > 0 ? pendingConsents : undefined,
               dataTourId: "nav-profile",
             },

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -6,16 +6,14 @@
 import React, { useEffect, useMemo, type CSSProperties } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import {
-  BriefcaseBusiness,
-  ChartNoAxesColumnIncreasing,
-  ChartNoAxesCombined,
+  ChartSpline,
+  ChartCandlestick,
   CircleUserRound,
   Compass,
   FileSpreadsheet,
   House,
-  Network,
-  UserRound,
   Users,
+  WalletCards,
 } from "lucide-react";
 
 import { useAuth } from "@/hooks/use-auth";
@@ -142,31 +140,31 @@ export const Navbar = () => {
             {
               value: "market",
               label: "Market",
-              icon: ChartNoAxesColumnIncreasing,
+              icon: ChartCandlestick,
               dataTourId: "nav-market",
             },
             {
               value: "dashboard",
               label: "Portfolio",
-              icon: BriefcaseBusiness,
+              icon: WalletCards,
               dataTourId: "nav-portfolio",
             },
             {
               value: "analysis",
               label: "Analysis",
-              icon: ChartNoAxesCombined,
+              icon: ChartSpline,
               dataTourId: "nav-analysis",
             },
             {
               value: "connect",
               label: "Connect",
-              icon: Network,
+              icon: Compass,
               dataTourId: "nav-connect",
             },
             {
               value: "profile",
               label: "Profile",
-              icon: UserRound,
+              icon: CircleUserRound,
               badge: pendingConsents > 0 ? pendingConsents : undefined,
               dataTourId: "nav-profile",
             },

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -32,6 +32,7 @@ import { usePersonaState } from "@/lib/persona/persona-context";
 import { activeKaiRouteTabFromPath } from "@/lib/navigation/kai-route-tabs";
 import { activeRiaRouteTabFromPath } from "@/lib/navigation/ria-route-tabs";
 import { useVault } from "@/lib/vault/vault-context";
+import { useOptionalAgentPopover } from "@/components/agent/agent-popover-provider";
 
 type InvestorNavKey = "dashboard" | "market" | "connect" | "analysis" | "profile";
 type RiaNavKey = "home" | "clients" | "connect" | "picks" | "profile";
@@ -42,6 +43,7 @@ export const Navbar = () => {
   const router = useRouter();
   const { isAuthenticated } = useAuth();
   const { isVaultUnlocked } = useVault();
+  const agentPopover = useOptionalAgentPopover();
   const { activePersona } = usePersonaState();
   const pendingConsents = useConsentPendingSummaryCount();
   const pillRef = React.useRef<HTMLDivElement | null>(null);
@@ -93,9 +95,12 @@ export const Navbar = () => {
     }
   }, [pathname]);
   const hideNavbar =
+    pathname === ROUTES.AGENT ||
     pathname?.startsWith(ROUTES.PHONE_MANDATE) ||
     pathname?.startsWith(ROUTES.LABS_PROFILE_APPEARANCE) ||
     pathname === ROUTES.DEVELOPERS;
+  const agentWindowOpen =
+    agentPopover?.expanded || agentPopover?.motionState === "opening";
 
   const navOptions = useMemo<SegmentedPillOption[]>(
     () =>
@@ -169,7 +174,7 @@ export const Navbar = () => {
     [activePersona, pendingConsents]
   );
 
-  if (hideNavbar) {
+  if (hideNavbar || agentWindowOpen) {
     return null;
   }
 

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -6,14 +6,14 @@
 import React, { useEffect, useMemo, type CSSProperties } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import {
-  ChartSpline,
-  ChartCandlestick,
-  CircleUserRound,
+  BriefcaseBusiness,
   Compass,
   FileSpreadsheet,
-  House,
+  LayoutDashboard,
+  LineChart,
+  Store,
+  User,
   Users,
-  WalletCards,
 } from "lucide-react";
 
 import { useAuth } from "@/hooks/use-auth";
@@ -47,10 +47,7 @@ export const Navbar = () => {
   const pillRef = React.useRef<HTMLDivElement | null>(null);
   const chromeState = useMemo(() => getKaiChromeState(pathname), [pathname]);
   const useOnboardingChrome = chromeState.useOnboardingChrome;
-  const preserveBottomChrome = Boolean(
-    pathname?.startsWith("/ria") || pathname?.startsWith("/marketplace")
-  );
-  const allowScrollHide = isAuthenticated && !useOnboardingChrome && !preserveBottomChrome;
+  const allowScrollHide = false;
   const { hidden: hideBottomChrome, progress: hideBottomChromeProgress } = useKaiBottomChromeVisibility(allowScrollHide);
 
   const busyOperations = useKaiSession((s) => s.busyOperations);
@@ -107,7 +104,7 @@ export const Navbar = () => {
             {
               value: "home",
               label: "Home",
-              icon: House,
+              icon: BriefcaseBusiness,
               dataTourId: "nav-ria-home",
             },
             {
@@ -131,7 +128,7 @@ export const Navbar = () => {
             {
               value: "profile",
               label: "Profile",
-              icon: CircleUserRound,
+              icon: User,
               badge: pendingConsents > 0 ? pendingConsents : undefined,
               dataTourId: "nav-profile",
             },
@@ -140,19 +137,19 @@ export const Navbar = () => {
             {
               value: "market",
               label: "Market",
-              icon: ChartCandlestick,
+              icon: Store,
               dataTourId: "nav-market",
             },
             {
               value: "dashboard",
               label: "Portfolio",
-              icon: WalletCards,
+              icon: LayoutDashboard,
               dataTourId: "nav-portfolio",
             },
             {
               value: "analysis",
               label: "Analysis",
-              icon: ChartSpline,
+              icon: LineChart,
               dataTourId: "nav-analysis",
             },
             {
@@ -164,7 +161,7 @@ export const Navbar = () => {
             {
               value: "profile",
               label: "Profile",
-              icon: CircleUserRound,
+              icon: User,
               badge: pendingConsents > 0 ? pendingConsents : undefined,
               dataTourId: "nav-profile",
             },

--- a/hushh-webapp/components/onboarding/AuthStep.tsx
+++ b/hushh-webapp/components/onboarding/AuthStep.tsx
@@ -19,6 +19,10 @@ import { AuthProviderButton } from "@/components/onboarding/AuthProviderButton";
 import { PostAuthRouteService } from "@/lib/services/post-auth-route-service";
 import { AuthLegalDialog } from "@/components/onboarding/AuthLegalDialog";
 import {
+  kaiAppHeroBodyClassName,
+  kaiAppHeroTitleClassName,
+} from "@/components/kai/shared/kai-typography";
+import {
   isOnboardingFlowActiveCookieEnabled,
   setOnboardingFlowActiveCookie,
   setOnboardingRequiredCookie,
@@ -566,11 +570,11 @@ export function AuthStep({
             role="heading"
             aria-level={1}
             aria-label="Sign in to One"
-            className="mt-2.5 text-[38px] font-medium leading-[1.05] tracking-normal text-[#1d1d1f] sm:text-[40px] dark:text-[#f5f5f7]"
+            className={`mt-2.5 ${kaiAppHeroTitleClassName} text-[#1d1d1f] dark:text-[#f5f5f7]`}
           >
             Sign in to One.
           </div>
-          <p className="mx-auto mt-3 max-w-[20rem] text-[17px] font-normal leading-[1.42] tracking-normal text-[rgba(0,0,0,0.56)] sm:text-[18px] dark:text-[rgba(245,245,247,0.60)]">
+          <p className={`mx-auto mt-3 max-w-[20rem] ${kaiAppHeroBodyClassName} text-[rgba(0,0,0,0.56)] dark:text-[rgba(245,245,247,0.60)]`}>
             Continue to your personal financial advisor.
           </p>
         </header>

--- a/hushh-webapp/components/onboarding/CarouselDemo.tsx
+++ b/hushh-webapp/components/onboarding/CarouselDemo.tsx
@@ -17,7 +17,7 @@ export function CarouselDemo() {
             <div className="p-1">
               <Card>
                 <CardContent className="flex aspect-square items-center justify-center p-6">
-                  <span className="text-4xl font-semibold">{index + 1}</span>
+                  <span className="text-2xl font-medium">{index + 1}</span>
                 </CardContent>
               </Card>
             </div>

--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -3,6 +3,10 @@
 import Image from "next/image";
 import type { ComponentType, SVGProps } from "react";
 import { Button } from "@/lib/morphy-ux/button";
+import {
+  kaiAppHeroBodyClassName,
+  kaiAppHeroTitleClassName,
+} from "@/components/kai/shared/kai-typography";
 
 function ShieldBadgeIcon(props: SVGProps<SVGSVGElement>) {
   return (
@@ -102,11 +106,11 @@ export function IntroStep({
             role="heading"
             aria-level={1}
             aria-label="Meet One, Your Personal Financial Advisor"
-            className="relative mt-2.5 text-[38px] font-medium leading-[1.05] tracking-normal text-[#1d1d1f] sm:text-[40px] dark:text-[#f5f5f7]"
+            className={`relative mt-2.5 ${kaiAppHeroTitleClassName} text-[#1d1d1f] dark:text-[#f5f5f7]`}
           >
             Meet One.
           </div>
-          <p className="relative mt-3 text-[17px] font-normal leading-[1.42] tracking-normal text-[rgba(0,0,0,0.56)] sm:text-[18px] dark:text-[rgba(245,245,247,0.60)]">
+          <p className={`relative mt-3 ${kaiAppHeroBodyClassName} text-[rgba(0,0,0,0.56)] dark:text-[rgba(245,245,247,0.60)]`}>
             Your personal financial advisor.
           </p>
         </section>

--- a/hushh-webapp/components/onboarding/previews/PortfolioPreviewCompact.tsx
+++ b/hushh-webapp/components/onboarding/previews/PortfolioPreviewCompact.tsx
@@ -55,7 +55,7 @@ export function PortfolioPreviewCompact() {
               </span>
             </div>
 
-            <div className="mt-3 text-[38px] font-medium leading-none tracking-normal text-foreground sm:text-[48px]">
+            <div className="mt-3 text-[30px] font-medium leading-none tracking-normal text-foreground sm:text-[34px]">
               $142,893
             </div>
           </div>

--- a/hushh-webapp/lib/navigation/kai-chrome-state.ts
+++ b/hushh-webapp/lib/navigation/kai-chrome-state.ts
@@ -36,6 +36,7 @@ export function getKaiChromeState(
   const hideCommandBar =
     useOnboardingChrome ||
     path === ROUTES.HOME ||
+    path === ROUTES.AGENT ||
     path.startsWith(ROUTES.LOGIN) ||
     path.startsWith(ROUTES.PHONE_MANDATE) ||
     path.startsWith(ROUTES.LOGOUT) ||


### PR DESCRIPTION
## Summary
- promote Kai UAT UI/chrome polish onto main using the authorized promotion branch
- includes bottom nav icon refinement, agent chrome hiding, Connect toolbar/card action stabilization, and global typography hierarchy cleanup
- UI-only; no route/link/backend changes

## Verification
- git diff --check origin/main...HEAD
- browser tests intentionally skipped per request

## Notes
- Direct push to main was blocked by GitHub rules requiring PR + merge queue + CI Status Gate.