### PR TITLE
Always show One Location entry flow

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -308,12 +308,27 @@ function locationActivity() {
   };
 }
 
+async function skipLocationEntryFlow() {
+  expect(
+    await screen.findByRole("heading", {
+      name: "Experience location sharing with One.",
+    }),
+  ).toBeTruthy();
+  fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+  expect(
+    await screen.findByRole("heading", { name: "Keep your map live" }),
+  ).toBeTruthy();
+  fireEvent.click(screen.getByRole("button", { name: "Not now" }));
+  expect(
+    await screen.findByRole("heading", { name: "One Location Agent" }),
+  ).toBeTruthy();
+}
+
 describe("OneLocationAgentPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     Element.prototype.scrollIntoView = vi.fn();
     window.localStorage.clear();
-    window.localStorage.setItem("one_location_onboarding_v1:user_a", "done");
     mockSearchParamsGet.mockReturnValue(null);
     mockUseRequireAuth.mockReturnValue({
       loading: false,
@@ -416,6 +431,7 @@ describe("OneLocationAgentPage", () => {
 
   it("renders the One-owned encrypted location control surface", async () => {
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     expect(
       await screen.findByRole("heading", { name: "One Location Agent" }),
@@ -460,6 +476,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(
@@ -484,6 +501,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockEnsureKey).toHaveBeenCalledWith("user_a"));
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
@@ -491,7 +509,6 @@ describe("OneLocationAgentPage", () => {
   });
 
   it("shows the location onboarding before requesting foreground permission", async () => {
-    window.localStorage.removeItem("one_location_onboarding_v1:user_a");
     mockGetState.mockResolvedValueOnce({
       ...locationState(),
       ownerGrants: [],
@@ -537,13 +554,40 @@ describe("OneLocationAgentPage", () => {
     expect(
       await screen.findByRole("heading", { name: "One Location Agent" }),
     ).toBeTruthy();
-    expect(window.localStorage.getItem("one_location_onboarding_v1:user_a")).toBe(
-      "done",
-    );
+    expect(window.localStorage.getItem("one_location_onboarding_v1:user_a")).toBeNull();
+  });
+
+  it("shows the location entry flow even when foreground permission is already granted", async () => {
+    mockGetState.mockResolvedValueOnce({
+      ...locationState(),
+      ownerGrants: [],
+    });
+
+    render(<OneLocationAgentPage />);
+
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    expect(
+      await screen.findByRole("heading", {
+        name: "Experience location sharing with One.",
+      }),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    expect(
+      await screen.findByRole("heading", { name: "Keep your map live" }),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    expect(
+      await screen.findByRole("heading", { name: "One Location Agent" }),
+    ).toBeTruthy();
+    expect(mockCaptureCurrentPosition).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem("one_location_onboarding_v1:user_a")).toBeNull();
   });
 
   it("renders One Network recommendation metadata without phone-derived labels", async () => {
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
 
@@ -581,6 +625,7 @@ describe("OneLocationAgentPage", () => {
     ).toBeGreaterThan(0);
 
     resolveState(locationState());
+    await skipLocationEntryFlow();
     await waitFor(() =>
       expect(screen.getByText("Share Encrypted Update")).toBeTruthy(),
     );
@@ -588,6 +633,7 @@ describe("OneLocationAgentPage", () => {
 
   it("renders a public location link control", async () => {
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
 
@@ -599,6 +645,7 @@ describe("OneLocationAgentPage", () => {
 
   it("keeps location activity hidden in the compact mobile flow", async () => {
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     expect(screen.queryByRole("heading", { name: "Location activity" })).toBeNull();
@@ -660,6 +707,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     await waitFor(() => expect(mockViewEnvelope).toHaveBeenCalled());
@@ -700,6 +748,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(
@@ -738,6 +787,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(
@@ -804,6 +854,7 @@ describe("OneLocationAgentPage", () => {
       .mockResolvedValueOnce({});
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(screen.getByRole("button", { name: /Review Share/i }));
@@ -881,6 +932,7 @@ describe("OneLocationAgentPage", () => {
     );
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     expect(await screen.findByText(/1 person selected/i)).toBeTruthy();
@@ -944,6 +996,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(
@@ -969,6 +1022,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(screen.getByRole("button", { name: "request" }));
@@ -1011,6 +1065,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     expect(screen.getByText("My requests")).toBeTruthy();
@@ -1026,6 +1081,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(screen.getByRole("button", { name: "request" }));
@@ -1079,6 +1135,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(screen.getByRole("button", { name: /Sync Contacts/i }));
@@ -1105,6 +1162,7 @@ describe("OneLocationAgentPage", () => {
 
   it("creates an approval-first invite path for contacts who are not One users", async () => {
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(screen.getByRole("button", { name: /Share to Contacts/i }));
@@ -1125,6 +1183,7 @@ describe("OneLocationAgentPage", () => {
 
   it("does not show owner-grant revoke actions in the compact mobile flow", async () => {
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     expect(
@@ -1146,6 +1205,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     const shareButton = screen.getByRole("button", {
@@ -1169,6 +1229,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     expect(await screen.findByText("Turn on phone Location")).toBeTruthy();
@@ -1190,6 +1251,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     expect(screen.getByText("One Network is empty")).toBeTruthy();

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -128,7 +128,6 @@ const SHOW_LOCATION_ACTIVITY_SECTION = false;
 const SHOW_OWNER_GRANTS_SECTION = false;
 const SHOW_PUBLIC_RESPONSES_SECTION = false;
 const SHOW_REFERRAL_SECTION = false;
-const ONE_LOCATION_ONBOARDING_STORAGE_PREFIX = "one_location_onboarding_v1";
 
 type BusyState =
   | "load"
@@ -1134,34 +1133,6 @@ function OneLocationInitialSkeleton() {
   );
 }
 
-function oneLocationOnboardingStorageKey(userId: string): string {
-  return `${ONE_LOCATION_ONBOARDING_STORAGE_PREFIX}:${userId}`;
-}
-
-function readOneLocationOnboardingDismissed(userId: string): boolean {
-  if (typeof window === "undefined") return false;
-  try {
-    const value = window.localStorage.getItem(
-      oneLocationOnboardingStorageKey(userId),
-    );
-    return value === "done" || value === "skipped";
-  } catch {
-    return false;
-  }
-}
-
-function writeOneLocationOnboardingDismissed(
-  userId: string,
-  status: "done" | "skipped",
-) {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(oneLocationOnboardingStorageKey(userId), status);
-  } catch {
-    // Non-blocking: private browsing or storage restrictions should not trap users.
-  }
-}
-
 function OneLocationIntroMapIllustration() {
   return (
     <div
@@ -1990,13 +1961,8 @@ function OneLocationAgentPageContent() {
       setLocationOnboardingGate("checking");
       return;
     }
-    if (permission?.state === "granted") {
-      writeOneLocationOnboardingDismissed(auth.userId, "done");
-      setLocationOnboardingGate("hidden");
-      return;
-    }
-    if (readOneLocationOnboardingDismissed(auth.userId)) {
-      setLocationOnboardingGate("hidden");
+
+    if (locationOnboardingGate === "hidden") {
       return;
     }
 
@@ -2009,7 +1975,6 @@ function OneLocationAgentPageContent() {
     auth.userId,
     loadError,
     locationOnboardingGate,
-    permission?.state,
     state,
   ]);
 
@@ -3149,38 +3114,41 @@ function OneLocationAgentPageContent() {
     }
   }, [ensureForegroundLocationReady]);
 
-  const dismissLocationOnboarding = useCallback(
-    (status: "done" | "skipped") => {
-      if (auth.userId) {
-        writeOneLocationOnboardingDismissed(auth.userId, status);
-      }
-      setLocationOnboardingGate("hidden");
-      setLocationOnboardingBusy(false);
-    },
-    [auth.userId],
-  );
+  const dismissLocationOnboarding = useCallback(() => {
+    setLocationOnboardingGate("hidden");
+    setLocationOnboardingBusy(false);
+  }, []);
 
   const handleContinueLocationOnboardingIntro = useCallback(() => {
     setLocationOnboardingStep("permission");
   }, []);
 
   const handleSkipLocationOnboarding = useCallback(() => {
-    dismissLocationOnboarding("skipped");
+    dismissLocationOnboarding();
   }, [dismissLocationOnboarding]);
 
   const handleLocationOnboardingPermission = useCallback(async () => {
     if (locationOnboardingBusy) return;
     setLocationOnboardingBusy(true);
     try {
+      if (permission?.state === "granted" && !isLocationServicesDisabled(permission)) {
+        const nextPermission = await refreshLocationPermission();
+        if (
+          nextPermission.state === "granted" &&
+          !isLocationServicesDisabled(nextPermission)
+        ) {
+          dismissLocationOnboarding();
+          return;
+        }
+      }
       const result = await ensureForegroundLocationReady({
         capturePoint: false,
         autoOpenSettings: false,
         requestNativePrompt: true,
       });
       const nextPermission = await refreshLocationPermission();
-      if (result.ready || nextPermission.state === "granted") {
-        dismissLocationOnboarding("done");
-      }
+      if (!result.ready && nextPermission.state !== "granted") return;
+      dismissLocationOnboarding();
     } finally {
       setLocationOnboardingBusy(false);
     }
@@ -3188,6 +3156,7 @@ function OneLocationAgentPageContent() {
     dismissLocationOnboarding,
     ensureForegroundLocationReady,
     locationOnboardingBusy,
+    permission,
     refreshLocationPermission,
   ]);
 


### PR DESCRIPTION
# Description

Always show the two-screen One Location entry flow before the main location page on web, Android webview, and iOS webview. This removes the old persisted dismissal behavior and stops granted foreground permission from skipping the entry flow.

When permission is already granted, the second screen still appears and Continue refreshes permission then enters the main page without requesting/capturing location from the onboarding flow.

## Impact Map

- Routes touched: `/one/location`
- API / schema / type changes: none
- Cache keys touched: removed use of `one_location_onboarding_v1:*` dismissal storage for this flow
- Runtime DB data-plane changes: none
- Mobile parity impacts: shared Next.js route rendered by Capacitor Android/iOS webviews; verified with `cap:build`
- Docs updated: none
- Trust boundary touched: location permission UX only; no auth/consent/vault/KYC/backend changes
- Caller / proxy / backend pairing: not applicable
- Rollback / safe-failure behavior: if permission is denied/unavailable, the existing main-page readiness/fallback controls still handle settings/retry after the entry flow
- UI proof: component coverage for prompt and already-granted permission entry behavior

## Verification

- `cd hushh-webapp && npm test -- __tests__/components/one-location-agent-page.test.tsx` - passed, 26/26
- `cd hushh-webapp && npm run typecheck` - passed
- `cd hushh-webapp && npm run lint` - passed
- `cd hushh-webapp && npm run verify:docs` - passed
- `cd hushh-webapp && npm run cap:build` - passed; `/one/location` included in generated route output
- `C:\Program Files\Git\bin\bash.exe scripts/ci/check-dco-signoff.sh origin/main HEAD` - passed
- `cd hushh-webapp && npm run verify:routes` - attempted; blocked by unrelated UAT `/one/kyc` profile manager 500 before this route sweep completed

## Review-Ready Contract

- Title, body, changed files, and tests describe the same `/one/location` contract.
- Existing implementation was checked: the two screens already existed; the bug was the gate hiding them for granted permission or old localStorage dismissal.
- Production attach point: `hushh-webapp/app/one/location/page.tsx`.
- Tests exercise the production route component, including permission prompt and already-granted behavior.
- Commits are signed off.