### PR TITLE
Polish Kai UI integrity pass

### DIFF
--- a/hushh-webapp/__tests__/app/register-phone-safe-area.contract.test.ts
+++ b/hushh-webapp/__tests__/app/register-phone-safe-area.contract.test.ts
@@ -21,6 +21,5 @@ describe("/register-phone safe-area shell contract", () => {
     expect(source).toContain("pt-[var(--phone-mandate-safe-pt)]");
     expect(source).toContain("pb-[var(--phone-mandate-safe-pb)]");
     expect(source).not.toContain("4vh");
-    expect(source).toContain("min-h-[25rem]");
   });
 });

--- a/hushh-webapp/__tests__/components/agent-popover-provider.test.tsx
+++ b/hushh-webapp/__tests__/components/agent-popover-provider.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AgentPopoverProvider } from "@/components/agent/agent-popover-provider";
@@ -43,26 +43,6 @@ function makeRect(input: {
     toJSON: () => rect,
   };
   return rect as DOMRect;
-}
-
-function dispatchPointer(
-  element: HTMLElement,
-  type: "pointerdown" | "pointermove" | "pointerup",
-  init: {
-    button?: number;
-    clientX: number;
-    clientY: number;
-    pointerId: number;
-  }
-) {
-  const event = new Event(type, { bubbles: true, cancelable: true });
-  Object.defineProperties(event, {
-    button: { value: init.button ?? 0 },
-    clientX: { value: init.clientX },
-    clientY: { value: init.clientY },
-    pointerId: { value: init.pointerId },
-  });
-  fireEvent(element, event);
 }
 
 describe("AgentPopoverProvider floating trigger", () => {
@@ -113,7 +93,7 @@ describe("AgentPopoverProvider floating trigger", () => {
     getBoundingClientRectSpy.mockRestore();
   });
 
-  it("positions the trigger above the command bar on iPhone-sized viewports", async () => {
+  it("does not render a stray floating trigger when app chrome owns Agent entrypoints", () => {
     render(
       <div>
         <div data-tour-id="kai-command-bar" />
@@ -124,130 +104,7 @@ describe("AgentPopoverProvider floating trigger", () => {
       </div>
     );
 
-    const trigger = screen.getByRole("button", { name: "Open Agent" });
-
-    await waitFor(() => {
-      expect(trigger.style.left).toBe("366px");
-      expect(trigger.style.top).toBe("660px");
-    });
-    expect(trigger.className).toContain("bg-white/92");
-    expect(trigger.className).toContain("dark:bg-[#1c1c1e]/90");
-  });
-
-  it("does not allow dragging the trigger into the command bar", async () => {
-    render(
-      <div>
-        <div data-tour-id="kai-command-bar" />
-        <div aria-label="Main navigation" />
-        <AgentPopoverProvider>
-          <main />
-        </AgentPopoverProvider>
-      </div>
-    );
-
-    const trigger = screen.getByRole("button", { name: "Open Agent" });
-
-    await waitFor(() => {
-      expect(trigger.style.top).toBe("660px");
-    });
-
-    dispatchPointer(trigger, "pointerdown", {
-      button: 0,
-      clientX: 390,
-      clientY: 682,
-      pointerId: 1,
-    });
-    dispatchPointer(trigger, "pointermove", {
-      clientX: 390,
-      clientY: 910,
-      pointerId: 1,
-    });
-    dispatchPointer(trigger, "pointerup", {
-      clientX: 390,
-      clientY: 910,
-      pointerId: 1,
-    });
-
-    expect(trigger.style.top).toBe("660px");
-  });
-
-  it("keeps horizontal drags on the right-side rail", async () => {
-    render(
-      <div>
-        <div data-tour-id="kai-command-bar" />
-        <div aria-label="Main navigation" />
-        <AgentPopoverProvider>
-          <main />
-        </AgentPopoverProvider>
-      </div>
-    );
-
-    const trigger = screen.getByRole("button", { name: "Open Agent" });
-
-    await waitFor(() => {
-      expect(trigger.style.left).toBe("366px");
-    });
-
-    dispatchPointer(trigger, "pointerdown", {
-      button: 0,
-      clientX: 390,
-      clientY: 682,
-      pointerId: 1,
-    });
-    dispatchPointer(trigger, "pointermove", {
-      clientX: 40,
-      clientY: 600,
-      pointerId: 1,
-    });
-    dispatchPointer(trigger, "pointerup", {
-      clientX: 40,
-      clientY: 600,
-      pointerId: 1,
-    });
-
-    await waitFor(() => {
-      expect(trigger.style.left).toBe("366px");
-      expect(trigger.style.top).toBe("578px");
-    });
-  });
-
-  it("does not allow dragging the trigger into the top chrome", async () => {
-    render(
-      <div>
-        <div data-tour-id="kai-command-bar" />
-        <div aria-label="Main navigation" />
-        <AgentPopoverProvider>
-          <main />
-        </AgentPopoverProvider>
-      </div>
-    );
-
-    const trigger = screen.getByRole("button", { name: "Open Agent" });
-
-    await waitFor(() => {
-      expect(trigger.style.top).toBe("660px");
-    });
-
-    dispatchPointer(trigger, "pointerdown", {
-      button: 0,
-      clientX: 390,
-      clientY: 682,
-      pointerId: 1,
-    });
-    dispatchPointer(trigger, "pointermove", {
-      clientX: 390,
-      clientY: 0,
-      pointerId: 1,
-    });
-    dispatchPointer(trigger, "pointerup", {
-      clientX: 390,
-      clientY: 0,
-      pointerId: 1,
-    });
-
-    await waitFor(() => {
-      expect(trigger.style.top).toBe("104px");
-    });
+    expect(screen.queryByRole("button", { name: "Open Agent" })).toBeNull();
   });
 
   it("does not render a duplicate floating trigger on Kai command-bar routes", () => {

--- a/hushh-webapp/__tests__/voice/kai-search-bar.test.ts
+++ b/hushh-webapp/__tests__/voice/kai-search-bar.test.ts
@@ -441,10 +441,8 @@ describe("kai-search-bar helpers", () => {
     expect(screen.getByRole("button", { name: "Start RIA voice" }).getAttribute("aria-disabled")).toBe(
       "true",
     );
-
-    fireEvent.click(screen.getByRole("button", { name: "Open Agent" }));
-
-    expect(mockOpenAgent).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("button", { name: "Open Agent" })).toBeNull();
+    expect(mockOpenAgent).not.toHaveBeenCalled();
   });
 
   it("keeps Kai voice inside the compact search surface", () => {

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1354,7 +1354,7 @@ md-ripple.morphy-md-ripple {
   color: rgb(60 60 67 / 0.7) !important;
   min-height: 48px;
   gap: 0.2rem !important;
-  padding: 0.4rem 0.2rem 0.44rem !important;
+  padding: 0.4rem 0.2rem 0.42rem !important;
   letter-spacing: 0;
 }
 
@@ -1364,7 +1364,7 @@ md-ripple.morphy-md-ripple {
 
 .kai-bottom-nav-pill [role="radio"][aria-checked="true"] {
   color: rgb(0 113 227) !important;
-  font-weight: 590;
+  font-weight: 600;
 }
 
 .dark .kai-bottom-nav-pill [role="radio"][aria-checked="true"] {
@@ -1372,39 +1372,27 @@ md-ripple.morphy-md-ripple {
 }
 
 .kai-bottom-nav-pill [role="radio"] svg {
-  width: 19px;
-  height: 19px;
+  width: 19.5px;
+  height: 19.5px;
   opacity: 0.88;
+  stroke-width: 1.85;
+  filter: drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.6));
+  transform: translateY(0);
   stroke-linecap: round;
   stroke-linejoin: round;
-  stroke-width: 1.48;
-  filter: drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.68));
-  transform: translateY(0);
 }
 
 .kai-bottom-nav-pill [role="radio"][aria-checked="true"] svg {
   opacity: 1;
-  stroke-width: 1.82;
-  filter:
-    drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.72))
-    drop-shadow(0 4px 10px rgb(0 113 227 / 0.18));
+  stroke-width: 2.15;
+  filter: drop-shadow(0 3px 8px rgb(0 113 227 / 0.24));
   transform: translateY(-0.5px);
-}
-
-.dark .kai-bottom-nav-pill [role="radio"] svg {
-  filter: drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.12));
-}
-
-.dark .kai-bottom-nav-pill [role="radio"][aria-checked="true"] svg {
-  filter:
-    drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.16))
-    drop-shadow(0 4px 12px rgb(41 171 255 / 0.2));
 }
 
 .kai-bottom-nav-pill [role="radio"] > span:last-of-type {
   max-width: 100%;
-  font-size: 9.5px;
-  font-weight: 510;
+  font-size: 9.25px;
+  font-weight: 500;
   line-height: 1;
   letter-spacing: 0;
   text-wrap: nowrap;
@@ -1412,7 +1400,7 @@ md-ripple.morphy-md-ripple {
 }
 
 .kai-bottom-nav-pill [role="radio"][aria-checked="true"] > span:last-of-type {
-  font-weight: 590;
+  font-weight: 600;
   opacity: 1;
 }
 
@@ -1452,6 +1440,16 @@ md-ripple.morphy-md-ripple {
   box-shadow:
     0 12px 28px -18px rgb(10 132 255 / 0.86),
     inset 0 1px 0 rgb(255 255 255 / 0.34);
+}
+
+body:has([data-one-market-surface="true"]) .bar-glass-top {
+  --app-bar-glass-bg-light: var(--background) !important;
+  --app-bar-glass-bg-dark: rgb(28, 28, 30) !important;
+  --app-bar-shadow: none !important;
+  --app-bar-fade-top-strong: transparent !important;
+  --app-bar-fade-top-medium: transparent !important;
+  --app-bar-fade-top-soft: transparent !important;
+  --app-bar-fade-top-trace: transparent !important;
 }
 
 /* Carousel edge glass (left/right): use to hint adjacent slides while keeping center crisp. */

--- a/hushh-webapp/app/kai/onboarding/page.tsx
+++ b/hushh-webapp/app/kai/onboarding/page.tsx
@@ -313,7 +313,7 @@ function KaiOnboardingPageContent() {
     return (
       <div
         data-top-content-anchor="true"
-        className="mx-auto flex min-h-[calc(100dvh_-_var(--top-content-pad))] w-full max-w-5xl items-start px-5 pb-8 pt-[calc(var(--top-content-pad)_+_0.25rem)] sm:px-6 lg:px-[var(--page-inline-gutter-standard)]"
+        className="mx-auto flex min-h-[calc(100dvh_-_var(--top-content-pad))] w-full max-w-[42rem] items-start px-5 pb-8 pt-[calc(var(--top-content-pad)_+_0.25rem)] sm:px-6 lg:px-[var(--page-inline-gutter-standard)]"
       >
         <NativeTestBeacon
           routeId="/kai/onboarding"
@@ -321,8 +321,8 @@ function KaiOnboardingPageContent() {
           authState={user ? "authenticated" : "pending"}
           dataState="loaded"
         />
-        <div className="w-full space-y-8">
-          <div className="mx-auto max-w-[48rem] space-y-3 text-center">
+        <div className="w-full space-y-6">
+          <div className="mx-auto max-w-[36rem] space-y-2.5 text-left">
             <p className={`${kaiAppEyebrowClassName} text-primary/75`}>
               Choose your starting path
             </p>
@@ -333,13 +333,13 @@ function KaiOnboardingPageContent() {
             >
               Start as an investor or set up RIA first
             </div>
-            <p className={`mx-auto max-w-[35rem] ${kaiAppBodyClassName} text-muted-foreground`}>
+            <p className={`max-w-[32rem] ${kaiAppBodyClassName} text-muted-foreground`}>
               You can add the other profile later from Profile. This choice only sets the first
               workflow we open right now.
             </p>
           </div>
 
-          <div className="grid items-stretch gap-4 md:grid-cols-2">
+          <div className="mx-auto grid w-full max-w-[36rem] items-stretch gap-3.5">
             <Card
               preset="hero"
               variant="none"
@@ -374,10 +374,10 @@ function KaiOnboardingPageContent() {
                     setSaving(false);
                   }
                 }}
-                className="flex h-full min-h-[228px] w-full flex-col justify-between gap-6 p-6 text-left sm:p-7"
+                className="flex h-full min-h-[160px] w-full flex-col justify-between gap-5 p-5 text-left"
               >
-                <div className="space-y-3.5">
-                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-primary/75">
+                <div className="space-y-2.5">
+                  <p className="text-[10.5px] font-medium uppercase tracking-[0.16em] text-primary/75">
                     Investor
                   </p>
                   <div
@@ -392,7 +392,7 @@ function KaiOnboardingPageContent() {
                     Kai.
                   </p>
                 </div>
-                <span className="inline-flex w-fit items-center rounded-full bg-primary px-4 py-2 text-[14px] font-semibold text-primary-foreground shadow-[0_12px_26px_-18px_rgba(0,113,227,0.75)]">
+                <span className="inline-flex h-9 w-fit items-center rounded-full bg-primary px-4 text-[13.5px] font-medium text-primary-foreground shadow-[0_12px_26px_-18px_rgba(0,113,227,0.75)]">
                   Open investor setup
                 </span>
               </button>
@@ -430,10 +430,10 @@ function KaiOnboardingPageContent() {
                     setSaving(false);
                   }
                 }}
-                className="flex h-full min-h-[228px] w-full flex-col justify-between gap-6 p-6 text-left disabled:cursor-not-allowed sm:p-7"
+                className="flex h-full min-h-[160px] w-full flex-col justify-between gap-5 p-5 text-left disabled:cursor-not-allowed"
               >
-                <div className="space-y-3.5">
-                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-primary/75">
+                <div className="space-y-2.5">
+                  <p className="text-[10.5px] font-medium uppercase tracking-[0.16em] text-primary/75">
                     RIA
                   </p>
                   <div
@@ -453,7 +453,7 @@ function KaiOnboardingPageContent() {
                     </p>
                   ) : null}
                 </div>
-                <span className="inline-flex w-fit items-center rounded-full bg-primary px-4 py-2 text-[14px] font-semibold text-primary-foreground shadow-[0_12px_26px_-18px_rgba(0,113,227,0.75)]">
+                <span className="inline-flex h-9 w-fit items-center rounded-full bg-primary px-4 text-[13.5px] font-medium text-primary-foreground shadow-[0_12px_26px_-18px_rgba(0,113,227,0.75)]">
                   Open advisor setup
                 </span>
               </button>

--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -1089,9 +1089,9 @@ export default function MarketplacePage() {
     >
       <AppPageHeaderRegion>
         <PageHeader
-          eyebrow="Connect"
-          title="Search people"
-          description="Find investors, RIAs, and contacts already on Hushh."
+          eyebrow="SEBI-registered network"
+          title="Connect"
+          description="Find a registered advisor. Connect with consent."
           icon={Compass}
           accent="marketplace"
           actions={
@@ -1109,7 +1109,7 @@ export default function MarketplacePage() {
       </AppPageHeaderRegion>
 
       <AppPageContentRegion className="space-y-4 pb-24 pt-0">
-        <div className="rounded-[28px] bg-background/90 p-1.5 shadow-[var(--app-card-shadow-standard)] backdrop-blur-[var(--blur-standard)]">
+        <div className="rounded-[24px] border border-border/45 bg-card/88 p-1.5 shadow-[var(--app-card-shadow-standard)] backdrop-blur-[var(--blur-standard)]">
           <div className="flex items-center justify-between gap-2">
             <div className="flex items-center gap-2">
               <button
@@ -1252,7 +1252,7 @@ export default function MarketplacePage() {
       ) : null}
 
       {!iamUnavailable && view === "swipe" ? (
-        <div className={cn("pb-16", searchOpen && "pt-12")}>
+        <div className="pb-16">
           {!hasLoadedDirectory || loading ? (
             <div className="flex min-h-[420px] items-center justify-center px-6 py-14 text-center">
               <p className="text-sm text-muted-foreground">Loading discovery…</p>

--- a/hushh-webapp/app/register-phone/page.tsx
+++ b/hushh-webapp/app/register-phone/page.tsx
@@ -10,8 +10,8 @@ import { NativeRouteMarker } from "@/components/app-ui/native-route-marker";
 import { PhoneVerificationFlow } from "@/components/auth/phone-verification-flow";
 import { VaultLockGuard } from "@/components/vault/vault-lock-guard";
 import {
-  kaiAppHeroBodyClassName,
-  kaiAppHeroTitleClassName,
+  kaiAppBodyClassName,
+  kaiAppCompactTitleClassName,
 } from "@/components/kai/shared/kai-typography";
 import { useAuth } from "@/lib/firebase/auth-context";
 import { ROUTES } from "@/lib/navigation/routes";
@@ -140,22 +140,22 @@ function PhoneMandatePageContent() {
           <Image
             src="/one-quiet-emoji.png"
             alt=""
-            width={52}
-            height={52}
+            width={48}
+            height={48}
             priority
             aria-hidden="true"
             draggable={false}
-            className="mx-auto h-[52px] w-[52px] select-none object-contain drop-shadow-[0_14px_28px_rgba(0,0,0,0.08)]"
+            className="mx-auto h-12 w-12 select-none object-contain drop-shadow-[0_14px_28px_rgba(0,0,0,0.08)]"
           />
           <div
             role="heading"
             aria-level={1}
             aria-label="Verify your phone number"
-            className={`mt-2.5 ${kaiAppHeroTitleClassName} text-[#1d1d1f] dark:text-[#f5f5f7]`}
+            className={`mt-2.5 ${kaiAppCompactTitleClassName} text-[#1d1d1f] dark:text-[#f5f5f7]`}
           >
             Verify your phone number
           </div>
-          <p className={`mx-auto mt-3 max-w-[20rem] ${kaiAppHeroBodyClassName} text-[rgba(0,0,0,0.56)] dark:text-[rgba(245,245,247,0.60)]`}>
+          <p className={`mx-auto mt-2.5 max-w-[20rem] ${kaiAppBodyClassName} text-[rgba(0,0,0,0.56)] dark:text-[rgba(245,245,247,0.60)]`}>
             Add your phone number to continue.
           </p>
         </header>
@@ -167,7 +167,7 @@ function PhoneMandatePageContent() {
           onCompleted={continueToNextRoute}
           onContinueExisting={continueToNextRoute}
           confirmLabel="Verify and continue"
-          className="mt-10 min-h-[25rem] gap-5"
+          className="mt-8 min-h-[24rem] gap-5"
         />
 
         <div id="recaptcha-container" className="mt-6 min-h-0" />

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -288,10 +288,10 @@ function AgentWelcomePanel({
           <Sparkles className="h-3.5 w-3.5 text-primary" />
           Kai workspace
         </div>
-        <h2 className="text-4xl font-medium tracking-normal text-[#1d1d1f] sm:text-5xl dark:text-zinc-50">
+        <h2 className="text-[34px] font-medium leading-[1.08] tracking-normal text-foreground sm:text-[38px]">
           Hi {name}
         </h2>
-        <p className="mt-3 max-w-xl text-base leading-7 text-[rgba(0,0,0,0.56)] sm:text-lg dark:text-zinc-400">
+        <p className="mt-3 max-w-xl text-[16px] leading-7 text-muted-foreground sm:text-[17px]">
           Ask Agent about your markets, portfolio, memories, or Hushh workflows.
         </p>
         <div className="mt-8 grid gap-3 sm:grid-cols-3">
@@ -2668,10 +2668,10 @@ export function AgentChatWorkspace({
   return (
     <div
       className={cn(
-        "agent-chat-workspace flex min-h-0 w-full flex-col text-[#1d1d1f] dark:text-zinc-100",
+        "agent-chat-workspace flex min-h-0 w-full flex-col text-foreground",
         isPopover
-          ? "h-full overflow-hidden bg-white dark:bg-[#0d0f13]"
-          : "h-[calc(100dvh-var(--app-top-content-offset,0px)-var(--app-bottom-fixed-ui,0px)-var(--app-safe-area-bottom-effective,0px))] min-h-[420px] overflow-hidden bg-white dark:bg-[#0b0d10]",
+          ? "h-full overflow-hidden bg-background"
+          : "h-[calc(100dvh-var(--app-top-content-offset,0px)-var(--app-bottom-fixed-ui,0px)-var(--app-safe-area-bottom-effective,0px))] min-h-[420px] overflow-hidden bg-background",
         className
       )}
       data-agent-chat-workspace={variant}
@@ -2713,14 +2713,14 @@ export function AgentChatWorkspace({
 
         <section
           className={cn(
-            "relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-white dark:bg-[#15171c]",
+            "relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background",
             isPopover && "rounded-lg border border-black/10 shadow-sm dark:border-white/10"
           )}
           inert={isHistoryDrawerOpen}
         >
           <div
             className={cn(
-              "flex shrink-0 touch-pan-y items-center justify-between gap-3 border-b border-black/10 bg-white/95 px-3 pt-[var(--app-safe-area-top-effective,0px)] backdrop-blur dark:border-white/10 dark:bg-[#15171c]/95 sm:px-5",
+              "flex shrink-0 touch-pan-y items-center justify-between gap-3 border-b border-border/70 bg-background/92 px-3 pt-[var(--app-safe-area-top-effective,0px)] backdrop-blur sm:px-5",
               isPopover
                 ? "h-14 sm:h-16"
                 : "h-[calc(3.5rem+var(--app-safe-area-top-effective,0px))] sm:h-[calc(4rem+var(--app-safe-area-top-effective,0px))]",
@@ -2750,10 +2750,10 @@ export function AgentChatWorkspace({
                 <Bot className="h-4 w-4" />
               </div>
               <div className="min-w-0">
-                <div className="truncate text-sm font-semibold leading-5 text-[#1d1d1f] sm:text-base dark:text-zinc-100">
+                <div className="truncate text-sm font-medium leading-5 text-foreground sm:text-base">
                   Agent
                 </div>
-                <p className="hidden truncate text-xs text-[rgba(0,0,0,0.46)] dark:text-zinc-500 sm:block">
+                <p className="hidden truncate text-xs text-muted-foreground sm:block">
                   Kai workspace
                 </p>
               </div>
@@ -2788,7 +2788,7 @@ export function AgentChatWorkspace({
           >
             <div className="mx-auto flex min-h-full w-full max-w-3xl flex-col gap-6">
               {accessMessage ? (
-                <div className="flex flex-col gap-3 rounded-xl border border-black/10 bg-black/[0.035] px-4 py-4 text-sm text-[rgba(0,0,0,0.56)] dark:border-white/10 dark:bg-white/[0.03] dark:text-zinc-400 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex flex-col gap-3 rounded-xl border border-border/70 bg-muted/35 px-4 py-4 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
                   <span>{accessMessage}</span>
                   {accessAction ? (
                     <Button
@@ -2890,7 +2890,7 @@ export function AgentChatWorkspace({
           <form
             onSubmit={handleSubmit}
             className={cn(
-              "shrink-0 border-t border-black/10 bg-white/95 px-3 py-3 backdrop-blur dark:border-white/10 dark:bg-[#15171c]/95 sm:px-5",
+              "shrink-0 border-t border-border/70 bg-background/92 px-3 py-3 backdrop-blur sm:px-5",
               !isPopover && "pb-[calc(0.75rem+var(--app-safe-area-bottom-effective,0px))]"
             )}
           >

--- a/hushh-webapp/components/agent/agent-popover-provider.tsx
+++ b/hushh-webapp/components/agent/agent-popover-provider.tsx
@@ -304,10 +304,14 @@ function AgentPopoverSurface({ customSize, setCustomSize }: AgentPopoverSurfaceP
   const pathname = usePathname();
   const { expanded, hasOpened, motionState, sizeMode, setSizeMode, openAgent, minimizeAgent } =
     useAgentPopover();
+  const chromeState = getKaiChromeState(pathname);
   const isLegacyAgentRoute = pathname === ROUTES.AGENT;
   const isPhoneMandateRoute = pathname?.startsWith(ROUTES.PHONE_MANDATE);
-  const canShowAgent = isAuthenticated && !isLegacyAgentRoute && !isPhoneMandateRoute;
-  const chromeState = getKaiChromeState(pathname);
+  const canShowAgent =
+    isAuthenticated &&
+    !isLegacyAgentRoute &&
+    !isPhoneMandateRoute &&
+    !chromeState.hideCommandBar;
   const isKaiSurfaceRoute = Boolean(pathname?.startsWith("/kai"));
   const useEmbeddedAgentTrigger =
     isKaiSurfaceRoute || isRiaActionBarRoute(pathname) || !chromeState.hideCommandBar;

--- a/hushh-webapp/components/kai/kai-search-bar.tsx
+++ b/hushh-webapp/components/kai/kai-search-bar.tsx
@@ -9,7 +9,7 @@ import {
   useState,
   type MouseEvent,
 } from "react";
-import { Bot, Mic, Search, X } from "lucide-react";
+import { Mic, Search, X } from "lucide-react";
 
 import {
   KaiCommandPalette,
@@ -20,7 +20,6 @@ import {
 } from "@/components/kai/voice/voice-ambient-search-surface";
 import { VoiceDebugDrawer } from "@/components/kai/voice/voice-debug-drawer";
 import { ShellActionSurface } from "@/components/app-ui/shell-action-surface";
-import { useOptionalAgentPopover } from "@/components/agent/agent-popover-provider";
 import { morphyToast as toast } from "@/lib/morphy-ux/morphy";
 import { useKaiBottomChromeVisibility } from "@/lib/navigation/kai-bottom-chrome-visibility";
 import { KAI_COMMAND_BAR_OPEN_EVENT } from "@/lib/navigation/kai-command-bar-events";
@@ -313,7 +312,6 @@ export function KaiSearchBar({
   portfolioTickers = [],
 }: KaiSearchBarProps) {
   const { getVaultOwnerToken, vaultKey } = useVault();
-  const agentPopover = useOptionalAgentPopover();
   const [open, setOpen] = useState(false);
   const [voiceDebugOpen, setVoiceDebugOpen] = useState(false);
   const [voiceUiState, setVoiceUiState] = useState<VoiceUiState>("idle");
@@ -1687,7 +1685,7 @@ export function KaiSearchBar({
         >
           {isRiaSurface ? (
             <div
-              className="grid grid-cols-3 gap-1.5 rounded-full border border-[color:var(--app-shell-surface-border)] bg-[color:var(--app-shell-surface-bg)] bg-[image:var(--app-shell-surface-fill)] p-1 shadow-[var(--app-shell-surface-shadow)] backdrop-blur-[var(--app-shell-surface-blur)]"
+              className="grid grid-cols-2 gap-1.5 rounded-full border border-[color:var(--app-shell-surface-border)] bg-[color:var(--app-shell-surface-bg)] bg-[image:var(--app-shell-surface-fill)] p-1 shadow-[var(--app-shell-surface-shadow)] backdrop-blur-[var(--app-shell-surface-blur)]"
               data-testid="ria-action-bar"
             >
               <ShellActionSurface
@@ -1722,40 +1720,17 @@ export function KaiSearchBar({
                 )}
                 <span className="truncate">Voice</span>
               </ShellActionSurface>
-              <ShellActionSurface
-                variant="pill"
-                wrapperClassName="w-full"
-                className="h-10 w-full min-w-0 px-2 text-[12px] sm:text-[13px]"
-                contentClassName="gap-1.5"
-                aria-label="Open Agent"
-                disabled={!agentPopover}
-                onClick={() => agentPopover?.openAgent()}
-              >
-                <Bot className="h-4 w-4 shrink-0" />
-                <span className="truncate">Agent</span>
-              </ShellActionSurface>
             </div>
           ) : (
-            <div className="relative flex h-[114px] w-full items-end justify-end">
+            <div className="relative flex h-[58px] w-full items-end justify-end">
               <div
                 className={cn(
-                  "ml-auto flex flex-col items-end justify-end gap-2 transition-[width] duration-200 ease-out",
+                  "ml-auto flex items-end justify-end transition-[width] duration-200 ease-out",
                   compactDockExpanded
                     ? "w-[min(15.5rem,calc(100vw-2rem))]"
                     : "w-[58px]"
                 )}
               >
-                <button
-                  type="button"
-                  className="pointer-events-auto grid h-12 w-12 place-items-center rounded-full transition-transform duration-200 ease-out hover:scale-[1.03] active:scale-[0.94] disabled:cursor-not-allowed disabled:opacity-50"
-                  aria-label="Open Kai agent"
-                  disabled={!agentPopover}
-                  onClick={() => agentPopover?.openAgent()}
-                >
-                  <span className="kai-bottom-agent-action grid h-[40px] w-[40px] place-items-center rounded-[14px]">
-                    <Bot className="h-[18px] w-[18px]" strokeWidth={1.95} />
-                  </span>
-                </button>
                 <div
                   className={cn(
                     "pointer-events-auto grid rounded-full kai-bottom-search-action p-[5px]",

--- a/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
+++ b/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
@@ -24,7 +24,8 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import {
-  kaiAppDisplayTitleClassName,
+  kaiAppBodyClassName,
+  kaiAppCardTitleClassName,
   kaiAppSectionTitleClassName,
 } from "@/components/kai/shared/kai-typography";
 
@@ -196,7 +197,7 @@ export function KaiPreferencesWizard(props: {
       <div
         className={cn(
           isPageLayout
-            ? "mx-auto flex min-h-[calc(100dvh-var(--top-content-pad)-var(--app-screen-footer-pad))] w-full max-w-[44rem] flex-col justify-center"
+            ? "mx-auto flex min-h-[calc(100dvh-var(--top-content-pad)-var(--app-screen-footer-pad))] w-full max-w-[33rem] flex-col justify-center"
             : "w-full max-w-sm mx-auto flex min-h-[calc(100dvh-var(--app-screen-footer-pad))] flex-col",
           !isPageLayout && "min-h-0"
         )}
@@ -204,7 +205,7 @@ export function KaiPreferencesWizard(props: {
         <div
           className={cn(
             isPageLayout
-              ? "rounded-[32px] border border-black/[0.06] bg-white/[0.72] p-5 shadow-[0_24px_80px_-56px_rgba(0,0,0,0.55)] backdrop-blur-2xl sm:p-7 lg:p-8 dark:border-white/10 dark:bg-white/[0.07]"
+              ? "rounded-[26px] border border-black/[0.06] bg-white/[0.82] p-5 shadow-[0_22px_64px_-52px_rgba(0,0,0,0.48)] backdrop-blur-2xl sm:p-6 dark:border-white/10 dark:bg-white/[0.07]"
               : "contents"
           )}
         >
@@ -251,15 +252,15 @@ export function KaiPreferencesWizard(props: {
           <div
             className={cn(
               isPageLayout
-                ? "mx-auto flex w-full max-w-[35rem] flex-col pt-8 sm:pt-10"
+                ? "mx-auto flex w-full max-w-[26rem] flex-col pt-6 sm:pt-7"
                 : "flex flex-1 flex-col pt-5"
             )}
           >
-            <div className={cn(isPageLayout ? "space-y-4 text-center" : "space-y-3")}>
+            <div className={cn(isPageLayout ? "space-y-3 text-left" : "space-y-3")}>
               <p
                 className={cn(
                   "text-muted-foreground leading-relaxed",
-                  isPageLayout ? "text-[15px] sm:text-[16px]" : "text-xs"
+                  isPageLayout ? kaiAppBodyClassName : "text-xs"
                 )}
               >
                 No right or wrong answers. We’ll tune Kai to your investing style.
@@ -271,7 +272,7 @@ export function KaiPreferencesWizard(props: {
                 className={cn(
                   "tracking-normal text-balance text-foreground",
                   isPageLayout
-                    ? kaiAppDisplayTitleClassName
+                    ? "text-[28px] font-medium leading-[1.08] sm:text-[30px]"
                     : kaiAppSectionTitleClassName
                 )}
               >
@@ -282,14 +283,14 @@ export function KaiPreferencesWizard(props: {
             <RadioGroup
               value={activeValue ?? ""}
               onValueChange={handleSelect}
-              className={cn(isPageLayout ? "mt-8 gap-2.5 sm:mt-9" : "gap-3")}
+              className={cn(isPageLayout ? "mt-7 gap-2.5 sm:mt-8" : "gap-3")}
             >
               {activeQuestion.options.map((opt) => (
                 <RadioCardItem key={opt.value} value={opt.value} label={opt.label} />
               ))}
             </RadioGroup>
 
-            <div className={cn("space-y-3.5", isPageLayout ? "pt-6" : "mt-auto pt-6")}>
+            <div className={cn("space-y-3", isPageLayout ? "pt-6" : "mt-auto pt-6")}>
               <Button
                 type="button"
                 variant="none"
@@ -301,7 +302,7 @@ export function KaiPreferencesWizard(props: {
                 loading={isSubmitting}
                 showRipple
                 className={cn(
-                  "h-11 rounded-full text-[15px] font-semibold shadow-[0_16px_34px_-24px_rgba(0,113,227,0.85)]",
+                  "h-12 rounded-full text-[15.5px] font-medium shadow-[0_16px_34px_-24px_rgba(0,113,227,0.85)]",
                   canContinue
                     ? "!bg-primary !text-primary-foreground hover:!bg-primary/90"
                     : "!bg-muted !text-muted-foreground shadow-none"
@@ -322,7 +323,7 @@ export function KaiPreferencesWizard(props: {
                   disabled={isSubmitting}
                   loading={isSubmitting}
                   showRipple
-                  className="h-11 rounded-full !bg-primary/10 text-[15px] font-semibold !text-primary shadow-none hover:!bg-primary/15 dark:!bg-primary/15"
+                  className="h-11 rounded-full !bg-primary/10 text-[15px] font-medium !text-primary shadow-none hover:!bg-primary/15 dark:!bg-primary/15"
                 >
                   {isSubmitting ? "Saving..." : "Skip"}
                   {!isSubmitting && <ArrowRight className="ml-2 h-5 w-5" />}
@@ -425,7 +426,7 @@ function RadioCardItem(props: { value: string; label: string }) {
       value={props.value}
       className={cn(
         "group w-full rounded-[18px] border px-4 py-3.5 text-left transition-[background-color,border-color,box-shadow,transform] sm:px-5",
-        "min-h-[58px] focus:outline-hidden focus-visible:ring-2 focus-visible:ring-[var(--brand-primary)]/35",
+        "min-h-[54px] focus:outline-hidden focus-visible:ring-2 focus-visible:ring-[var(--brand-primary)]/35",
         "border-black/[0.08] bg-white/68 shadow-[0_10px_30px_-28px_rgba(0,0,0,0.5)] backdrop-blur-xl",
         "hover:-translate-y-0.5 hover:bg-white/86 hover:shadow-[0_16px_38px_-32px_rgba(0,0,0,0.55)]",
         "data-[state=checked]:border-primary/55 data-[state=checked]:bg-primary/[0.08] data-[state=checked]:shadow-[0_16px_38px_-32px_rgba(0,113,227,0.7)]",
@@ -433,7 +434,7 @@ function RadioCardItem(props: { value: string; label: string }) {
       )}
     >
       <div className="flex items-center justify-between gap-3">
-        <p className="text-[15px] font-medium leading-snug text-foreground sm:text-[16px]">
+        <p className={cn(kaiAppCardTitleClassName, "text-foreground")}>
           {props.label}
         </p>
         <div

--- a/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
@@ -2034,6 +2034,7 @@ export function KaiMarketPreviewView() {
       as="div"
       width="reading"
       className={oneMarketRootClassName}
+      data-one-market-surface="true"
       data-one-market-preview={localPreviewPayload ? "true" : undefined}
     >
       {localPreviewPayload ? (

--- a/hushh-webapp/components/kai/views/portfolio-import-view.tsx
+++ b/hushh-webapp/components/kai/views/portfolio-import-view.tsx
@@ -30,7 +30,6 @@ import { SurfaceCard, SurfaceCardContent } from "@/components/app-ui/surfaces";
 import { Icon } from "@/lib/morphy-ux/ui";
 import { scrollAppToTop } from "@/lib/navigation/use-scroll-reset";
 import {
-  kaiAppBodyClassName,
   kaiAppCardBodyClassName,
   kaiAppCardTitleClassName,
   kaiAppCompactTitleClassName,

--- a/hushh-webapp/components/kai/views/portfolio-import-view.tsx
+++ b/hushh-webapp/components/kai/views/portfolio-import-view.tsx
@@ -166,31 +166,26 @@ export function PortfolioImportView({
   ]);
 
   return (
-    <div className="mx-auto w-full space-y-3.5 pt-3 pb-6" style={APP_MEASURE_STYLES.reading}>
+    <div className="mx-auto w-full space-y-4 pb-6 pt-3" style={APP_MEASURE_STYLES.reading}>
       {/* Header */}
-      <div className="space-y-2.5 text-center">
-        <h1 className={cn(kaiAppCompactTitleClassName, "text-foreground")}>
-          Your money
-          <br />
-          <span>Your options</span>
-        </h1>
-        <p className={cn(kaiAppBodyClassName, "text-muted-foreground")}>
-          Let Kai analyze your holdings for precise advice
-        </p>
-      </div>
-
-      <div className="text-center">
+      <div className="space-y-1.5 text-left">
         <p className={cn(kaiAppEyebrowClassName, "text-muted-foreground")}>
-          Choose import method
+          Getting started
+        </p>
+        <h1 className={cn(kaiAppCompactTitleClassName, "text-foreground")}>
+          Portfolio
+        </h1>
+        <p className={cn(kaiAppCardBodyClassName, "max-w-[32rem] text-muted-foreground sm:!text-[15px]")}>
+          Let Kai analyze your holdings for precise advice
         </p>
       </div>
 
       {/* Plaid integration */}
       <SurfaceCard accent="sky">
         <SurfaceCardContent className="space-y-3 p-4 md:p-5">
-          <div className="flex items-center justify-between gap-3">
-            <div className="flex items-center gap-3 min-w-0">
-              <div className="w-12 h-12 rounded-full bg-primary/10 border border-primary/15 flex items-center justify-center shrink-0">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex min-w-0 items-center gap-3">
+              <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-primary/15 bg-primary/10">
                 <Icon icon={Link2} size="md" className="text-primary" />
               </div>
               <div className="min-w-0">
@@ -200,7 +195,7 @@ export function PortfolioImportView({
                 </p>
               </div>
             </div>
-            <div className="shrink-0 flex flex-col items-end gap-2">
+            <div className="flex shrink-0 flex-wrap gap-2 sm:justify-end">
               <Badge className="border border-[var(--brand-200)] bg-[var(--brand-50)] text-[var(--brand-700)]">
                 Read-only sync
               </Badge>
@@ -221,8 +216,8 @@ export function PortfolioImportView({
           <MorphyButton
             variant="blue-gradient"
             effect="fill"
-            size="lg"
-            className="w-full rounded-full border-none font-medium shadow-[0_10px_30px_-20px_rgba(0,102,204,0.55)]"
+            size="default"
+            className="h-11 w-full rounded-full border-none text-[15px] font-medium shadow-[0_10px_30px_-20px_rgba(0,102,204,0.55)]"
             disabled={!onConnectPlaid || isUploading || isPreloadingSchema || isConnectingPlaid || plaidConfigured === false}
             onClick={handleConnectPlaid}
             icon={{
@@ -256,7 +251,7 @@ export function PortfolioImportView({
       <SurfaceCard>
         <SurfaceCardContent className="space-y-4 p-4 md:p-5">
           <div className="flex items-center gap-3">
-            <div className="w-11 h-11 rounded-full bg-primary/10 border border-primary/15 flex items-center justify-center shrink-0">
+            <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-primary/15 bg-primary/10">
               <Icon icon={Upload} size="md" className="text-primary" />
             </div>
             <div>
@@ -273,7 +268,7 @@ export function PortfolioImportView({
             onDragOver={handleDragOver}
             onDragLeave={handleDragLeave}
             className={cn(
-              "relative border border-dashed rounded-3xl p-7 transition-all duration-200 text-center cursor-pointer min-h-44 flex flex-col items-center justify-center",
+              "relative flex min-h-40 cursor-pointer flex-col items-center justify-center rounded-[24px] border border-dashed p-6 text-center transition-all duration-200",
               isDragging
                 ? "border-primary bg-primary/8 scale-[1.01]"
                 : "border-border/70 hover:border-primary/50 hover:bg-muted/25",
@@ -282,8 +277,8 @@ export function PortfolioImportView({
             onClick={triggerFileInput}
           >
             {/* Upload Icon */}
-            <div className="mx-auto w-14 h-14 rounded-full bg-primary/10 border border-primary/15 flex items-center justify-center mb-3">
-              <Icon icon={Upload} size={30} className="text-primary" />
+            <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full border border-primary/15 bg-primary/10">
+              <Icon icon={Upload} size={26} className="text-primary" />
             </div>
 
             {/* Text */}
@@ -322,7 +317,7 @@ export function PortfolioImportView({
             variant="morphy"
             effect="fill"
             size="default"
-            className="w-full rounded-full border-none font-medium shadow-[0_10px_30px_-20px_rgba(0,102,204,0.55)]"
+            className="h-11 w-full rounded-full border-none text-[15px] font-medium shadow-[0_10px_30px_-20px_rgba(0,102,204,0.55)]"
             onClick={handleContinue}
             disabled={isUploading || isPreloadingSchema || !selectedFile}
             icon={{
@@ -351,8 +346,8 @@ export function PortfolioImportView({
           <MorphyButton
             variant="blue-gradient"
             effect="fill"
-            size="lg"
-            className="w-full rounded-full border-none font-medium shadow-[0_10px_30px_-20px_rgba(0,102,204,0.55)]"
+            size="default"
+            className="h-11 w-full rounded-full border-none text-[15px] font-medium shadow-[0_10px_30px_-20px_rgba(0,102,204,0.55)]"
             onClick={handlePreloadSchema}
             disabled={isUploading || isPreloadingSchema}
             icon={{
@@ -375,7 +370,7 @@ export function PortfolioImportView({
           effect="fade"
           onClick={onSkip}
           disabled={isUploading || isPreloadingSchema}
-          className="text-muted-foreground hover:text-foreground text-base"
+          className="h-10 rounded-full px-5 text-[14px] font-medium text-muted-foreground hover:text-foreground"
         >
           Skip for now
         </MorphyButton>

--- a/hushh-webapp/components/onboarding/AuthStep.tsx
+++ b/hushh-webapp/components/onboarding/AuthStep.tsx
@@ -598,10 +598,10 @@ export function AuthStep({
           <Image
             src="/one-quiet-emoji.png"
             alt="One"
-            width={52}
-            height={52}
+            width={48}
+            height={48}
             priority
-            className="mx-auto h-[52px] w-[52px] object-contain drop-shadow-[0_14px_28px_rgba(0,0,0,0.08)]"
+            className="mx-auto h-12 w-12 object-contain drop-shadow-[0_14px_28px_rgba(0,0,0,0.08)]"
           />
           <div
             role="heading"

--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -99,7 +99,7 @@ export function IntroStep({
             unoptimized
             aria-hidden="true"
             draggable={false}
-            className="relative h-[52px] w-[52px] select-none object-contain"
+            className="relative h-12 w-12 select-none object-contain"
           />
 
           <div

--- a/hushh-webapp/components/vault/vault-flow.tsx
+++ b/hushh-webapp/components/vault/vault-flow.tsx
@@ -34,6 +34,7 @@ import { User } from "firebase/auth";
 import { useVault } from "@/lib/vault/vault-context";
 import { HushhLoader } from "@/components/app-ui/hushh-loader";
 import { Icon } from "@/lib/morphy-ux/ui";
+import { useHostname } from "@/lib/hooks/use-hostname";
 import type { GeneratedVaultKeyMode } from "@/lib/services/vault-bootstrap-service";
 import { VaultMethodService, type VaultMethod } from "@/lib/services/vault-method-service";
 import { VaultMethodPromptLocalService } from "@/lib/services/vault-method-prompt-local-service";
@@ -101,9 +102,10 @@ export function VaultFlow({
     preferPassphraseUnlockForAutomation(nativeTestConfig);
   const skipGeneratedUnlockForAutomation =
     shouldSkipGeneratedVaultUnlockForAutomation();
+  const hostname = useHostname();
   const currentRpId = resolvePasskeyRpId({
     isNative: Capacitor.isNativePlatform(),
-    hostname: typeof window !== "undefined" ? window.location.hostname : null,
+    hostname: hostname,
   });
 
   const { unlockVault } = useVault();
@@ -316,13 +318,9 @@ export function VaultFlow({
       VaultService.setVaultCheckCache(user.uid, true);
       setRecoveryKey(vaultData.recoveryKey);
       setStep("recovery"); // Show recovery key dialog
-    } catch (err: unknown) {
+    } catch (err: any) {
       console.error("Create vault error:", err);
-      toast.error(
-        err instanceof Error
-          ? err.message
-          : "We could not create your Vault. Please try again."
-      );
+      toast.error(err.message || "We could not create your Vault. Please try again.");
     } finally {
       setIsUnlocking(false);
     }
@@ -364,7 +362,7 @@ export function VaultFlow({
         setError(message);
         toast.error(message);
       }
-    } catch (err: unknown) {
+    } catch (err: any) {
       console.error("Unlock error:", err);
       const message = toInvestorVaultUnlockError(err);
       setError(message);
@@ -483,7 +481,7 @@ export function VaultFlow({
 
       await VaultService.assertVaultKeyMatchesState(vaultData, decryptedKey);
       await finalizeUnlock(decryptedKey);
-    } catch (err: unknown) {
+    } catch (err: any) {
       console.error("Generated vault unlock failed:", err);
       const message = toInvestorVaultUnlockError(err);
       setError(message);
@@ -642,47 +640,58 @@ export function VaultFlow({
       <Card
         variant="none"
         effect="fill"
-        className="overflow-hidden"
+        className="overflow-hidden rounded-[28px] border border-border/35 bg-background/95 shadow-[0_24px_70px_rgba(15,23,42,0.16)] backdrop-blur-xl dark:bg-background/92"
       >
-        <CardContent className="max-h-[calc(100svh-8rem)] space-y-3 overflow-y-auto p-4 pb-[calc(1rem+env(safe-area-inset-bottom,0px))] sm:max-h-[calc(100svh-10rem)] sm:space-y-4 sm:p-6">
+        <CardContent className="max-h-[min(680px,calc(100svh-2rem))] space-y-4 overflow-y-auto px-5 py-6 pb-[calc(1.5rem+env(safe-area-inset-bottom,0px))] [scrollbar-width:none] sm:max-h-[min(680px,calc(100svh-3rem))] sm:px-7 sm:py-7 [&::-webkit-scrollbar]:hidden">
           {/* Intro / Education Step */}
           {step === "intro" && (
-            <div className="space-y-6 text-center animate-in fade-in slide-in-from-bottom-4 duration-500">
-              <div className="flex justify-center mb-4">
-                <div className="h-20 w-20 rounded-2xl bg-primary/10 flex items-center justify-center">
-                  <Icon icon={Shield} size={40} className="text-primary" />
+            <div className="mx-auto max-w-[21rem] animate-in space-y-4 text-center fade-in slide-in-from-bottom-4 duration-500">
+              <div className="flex justify-center">
+                <div className="flex h-14 w-14 items-center justify-center rounded-[20px] bg-primary/10 ring-1 ring-primary/10">
+                  <Icon icon={Shield} size={26} className="text-primary" />
                 </div>
               </div>
-              
+               
               <div className="space-y-2">
-                <h3 className="text-2xl font-bold tracking-tight">Secure Your Digital Vault</h3>
-                <p className="text-muted-foreground text-balance max-w-sm mx-auto">
+                <div
+                  role="heading"
+                  aria-level={2}
+                  className="text-[25px] font-medium leading-[1.08] tracking-normal text-foreground sm:text-[27px]"
+                >
+                  Secure Your Digital Vault
+                </div>
+                <p className="mx-auto max-w-[18rem] text-balance text-[14.5px] leading-[1.45] text-muted-foreground sm:text-[15px]">
                   Hussh uses end-to-end encryption to protect your personal data.
                   Create your passphrase first, then optionally enable faster sign-in.
                 </p>
               </div>
 
-              <div className="text-left bg-muted/50 rounded-xl p-4 space-y-3 text-sm border border-border/50">
+              <div className="space-y-3 rounded-[20px] border border-border/45 bg-muted/35 p-4 text-left text-[14px] leading-[1.42] shadow-[inset_0_1px_0_rgba(255,255,255,0.35)]">
                 <div className="flex gap-3">
                   <div className="mt-0.5 min-w-[1.25rem] text-primary">
-                     <Icon icon={Check} size="md" />
+                    <Icon icon={Check} size="sm" />
                   </div>
-                  <p><span className="font-semibold block text-foreground">You hold the only key</span> We cannot see your data or reset your password.</p>
+                  <p>
+                    <span className="block font-medium text-foreground">You hold the only key</span>
+                    <span className="text-muted-foreground">We cannot see your data or reset your password.</span>
+                  </p>
                 </div>
                 <div className="flex gap-3">
-                   <div className="mt-0.5 min-w-[1.25rem] text-primary">
-                     <Icon icon={Check} size="md" />
+                  <div className="mt-0.5 min-w-[1.25rem] text-primary">
+                    <Icon icon={Check} size="sm" />
                   </div>
-                  <p><span className="font-semibold block text-foreground">Protected by default</span> Your data stays private and secure.</p>
+                  <p>
+                    <span className="block font-medium text-foreground">Protected by default</span>
+                    <span className="text-muted-foreground">Your data stays private and secure.</span>
+                  </p>
                 </div>
               </div>
 
-              <div className="space-y-2">
               <Button 
                   variant="gradient" 
                   size={ACTION_BUTTON_SIZE}
                   fullWidth
-                  className="group whitespace-normal text-center leading-snug px-4"
+                  className="group h-12 whitespace-normal rounded-full px-4 text-center text-[16px] font-medium leading-snug"
                   onClick={() => {
                     setError(null);
                     setStep("create");
@@ -695,23 +704,29 @@ export function VaultFlow({
                     className="ml-2 transition-transform group-hover:translate-x-1"
                   />
                 </Button>
-
-              </div>
             </div>
           )}
 
           {/* Create Passphrase */}
           {step === "create" && (
-            <div className="space-y-3">
+            <div className="mx-auto max-w-[21rem] space-y-4">
               <div className="text-center">
-                <Icon icon={Lock} size={36} className="mx-auto text-primary mb-3" />
-                <h3 className="text-lg font-semibold sm:text-xl">Create Your Vault Passphrase</h3>
-                <p className="mt-1.5 text-sm text-muted-foreground sm:text-base">
+                <div className="mx-auto mb-3 flex h-11 w-11 items-center justify-center rounded-[17px] bg-primary/10 ring-1 ring-primary/10">
+                  <Icon icon={Lock} size={22} className="text-primary" />
+                </div>
+                <div
+                  role="heading"
+                  aria-level={2}
+                  className="text-[25px] font-medium leading-[1.08] tracking-normal text-foreground sm:text-[27px]"
+                >
+                  Create Your Vault Passphrase
+                </div>
+                <p className="mx-auto mt-2 max-w-[18rem] text-[14.5px] leading-[1.45] text-muted-foreground">
                   This passphrase protects your Vault. Keep it private.
                 </p>
               </div>
               <div className="space-y-2">
-                <Label htmlFor="passphrase" className="text-sm sm:text-base">Passphrase</Label>
+                <Label htmlFor="passphrase" className="text-[14px] font-medium">Passphrase</Label>
                 <Input
                   id="passphrase"
                   type="password"
@@ -719,18 +734,18 @@ export function VaultFlow({
                   value={passphrase}
                   onChange={(e) => setPassphrase(e.target.value)}
                   autoFocus
-                  className="h-11 px-3 text-base sm:h-12 sm:px-4 sm:text-lg"
+                  className="h-11 rounded-[17px] px-4 text-[15px] shadow-sm"
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="confirm" className="text-sm sm:text-base">Confirm Passphrase</Label>
+                <Label htmlFor="confirm" className="text-[14px] font-medium">Confirm Passphrase</Label>
                 <Input
                   id="confirm"
                   type="password"
                   placeholder="Confirm your passphrase"
                   value={confirmPassphrase}
                   onChange={(e) => setConfirmPassphrase(e.target.value)}
-                  className="h-11 px-3 text-base sm:h-12 sm:px-4 sm:text-lg"
+                  className="h-11 rounded-[17px] px-4 text-[15px] shadow-sm"
                 />
                 {createPassphraseHelperText && (
                   <p className="text-xs font-medium text-destructive" role="status">
@@ -738,14 +753,14 @@ export function VaultFlow({
                   </p>
                 )}
               </div>
-              <div className="rounded-xl border border-border/60 bg-muted/20 p-2.5 text-[11px] text-muted-foreground sm:p-3 sm:text-sm">
-                <p className="font-semibold text-foreground">Passphrase requirements</p>
-                <ul className="mt-1 list-disc space-y-0.5 pl-4">
+              <div className="rounded-[18px] border border-border/45 bg-muted/30 p-4 text-[13.5px] leading-[1.45] text-muted-foreground">
+                <p className="font-medium text-foreground">Passphrase requirements</p>
+                <ul className="mt-2 list-disc space-y-1 pl-4">
                   <li>Minimum 8 characters</li>
                   <li>Use a memorable phrase unique to you</li>
                   <li>Avoid reused passwords from other apps</li>
                 </ul>
-                <p className="mt-1.5 text-[10px] text-muted-foreground sm:mt-2 sm:text-xs">
+                <p className="mt-3 text-[13px] leading-[1.4] text-muted-foreground">
                   You can enable passkey or device unlock later from Profile.
                 </p>
               </div>
@@ -754,7 +769,7 @@ export function VaultFlow({
                 effect="glass"
                 size="default"
                 fullWidth
-                className="mt-2 h-11 text-sm sm:mt-4 sm:h-12 sm:text-base"
+                className="mt-1 h-12 rounded-full text-[16px] font-medium"
                 onClick={handleCreatePassphrase}
                 disabled={isUnlocking || passphrase.length < 8 || passphrase !== confirmPassphrase}
               >
@@ -778,7 +793,13 @@ export function VaultFlow({
                   size={24}
                   className="mx-auto mb-2 text-primary"
                 />
-                <h3 className="text-base font-semibold sm:text-lg">Unlock Your Vault</h3>
+                <div
+                  role="heading"
+                  aria-level={2}
+                  className="text-[20px] font-medium leading-[1.14] tracking-normal text-foreground"
+                >
+                  Unlock Your Vault
+                </div>
                 <p className="mt-1 line-clamp-1 text-xs text-muted-foreground sm:text-sm">
                   {isGeneratedVaultMode
                     ? "Confirm with your device to open Vault"
@@ -816,7 +837,7 @@ export function VaultFlow({
                     effect="glass"
                     size="default"
                     fullWidth
-                    className="h-10 text-sm font-semibold sm:h-11"
+                    className="h-11 rounded-full text-[15px] font-medium"
                     onClick={() => void handleUnlockPassphrase()}
                     disabled={isUnlocking || !passphrase}
                   >
@@ -867,7 +888,7 @@ export function VaultFlow({
                           effect="fade"
                           size="default"
                           fullWidth
-                          className="h-10 px-2 text-xs sm:h-11 sm:text-sm"
+                          className="h-10 rounded-full px-2 text-[13px] font-medium sm:h-11 sm:text-[14px]"
                           data-testid="vault-use-passphrase-instead"
                           onClick={() => {
                             setError(null);
@@ -885,7 +906,7 @@ export function VaultFlow({
                           effect="fade"
                           size="default"
                           fullWidth
-                          className="h-10 px-2 text-xs sm:h-11 sm:text-sm"
+                          className="h-10 rounded-full px-2 text-[13px] font-medium sm:h-11 sm:text-[14px]"
                           onClick={() => {
                             setError(null);
                             setPassphrase("");
@@ -905,7 +926,7 @@ export function VaultFlow({
                           effect="glass"
                           size="default"
                           fullWidth
-                          className="h-10 px-2 text-xs sm:h-11 sm:text-sm"
+                          className="h-10 rounded-full px-2 text-[13px] font-medium sm:h-11 sm:text-[14px]"
                           onClick={() => {
                             setError(null);
                             setStep("recovery");
@@ -927,7 +948,13 @@ export function VaultFlow({
             <div className="space-y-2.5">
               <div className="text-center">
                 <Icon icon={Key} size={24} className="mx-auto mb-2 text-primary" />
-                <h3 className="text-base font-semibold sm:text-lg">Enter Recovery Key</h3>
+                <div
+                  role="heading"
+                  aria-level={2}
+                  className="text-[20px] font-medium leading-[1.14] tracking-normal text-foreground"
+                >
+                  Enter Recovery Key
+                </div>
                 <p className="mt-1 line-clamp-1 text-xs text-muted-foreground sm:text-sm">
                   Enter your recovery key to open Vault
                 </p>
@@ -954,7 +981,7 @@ export function VaultFlow({
                   effect="glass"
                   size="default"
                   fullWidth
-                  className="h-10 text-sm font-semibold sm:h-11"
+                  className="h-11 rounded-full text-[15px] font-medium"
                   onClick={handleRecoveryKeySubmit}
                   disabled={isUnlocking || !recoveryKeyInput}
                 >
@@ -974,7 +1001,7 @@ export function VaultFlow({
                       effect="glass"
                       size="default"
                       fullWidth
-                      className="h-10 px-2 text-xs sm:h-11 sm:text-sm"
+                      className="h-10 rounded-full px-2 text-[13px] font-medium sm:h-11 sm:text-[14px]"
                       onClick={() => {
                         setError(null);
                         setUnlockWithPassphraseFallback(true);
@@ -990,7 +1017,7 @@ export function VaultFlow({
                         effect="glass"
                         size="default"
                         fullWidth
-                        className="h-10 px-2 text-xs sm:h-11 sm:text-sm"
+                        className="h-10 rounded-full px-2 text-[13px] font-medium sm:h-11 sm:text-[14px]"
                         onClick={() => {
                           setError(null);
                           setPassphrase("");
@@ -1022,8 +1049,14 @@ export function VaultFlow({
                   size={36}
                   className="mx-auto mb-3 text-primary"
                 />
-                <h3 className="text-lg font-semibold sm:text-xl">Enable quicker unlock?</h3>
-                <p className="mt-1.5 text-sm text-muted-foreground sm:text-base">
+                <div
+                  role="heading"
+                  aria-level={2}
+                  className="text-[24px] font-medium leading-[1.1] tracking-normal text-foreground"
+                >
+                  Enable quicker unlock?
+                </div>
+                <p className="mt-2 text-[15px] leading-[1.45] text-muted-foreground">
                   You can keep passphrase unlock, or enable{" "}
                   {recommendedQuickMethod === "generated_default_web_prf" ||
                   recommendedQuickMethod === "generated_default_native_passkey_prf"
@@ -1039,7 +1072,7 @@ export function VaultFlow({
                   effect="glass"
                   size="default"
                   fullWidth
-                  className="h-11 text-sm sm:h-12 sm:text-base"
+                  className="h-12 rounded-full text-[16px] font-medium"
                   disabled={isUnlocking || !pendingUnlockKey || !recommendedQuickMethod}
                   onClick={async () => {
                     if (!pendingUnlockKey || !recommendedQuickMethod) return;
@@ -1060,12 +1093,10 @@ export function VaultFlow({
                           ? "Passkey unlock enabled."
                           : "Biometric unlock enabled."
                       );
-                    } catch (err: unknown) {
+                    } catch (err: any) {
                       console.error("Quick unlock enable failed:", err);
                       toast.error(
-                        err instanceof Error
-                          ? err.message
-                          : "Couldn't enable quick unlock right now."
+                        err?.message || "Couldn't enable quick unlock right now."
                       );
                     } finally {
                       setIsUnlocking(false);
@@ -1092,7 +1123,7 @@ export function VaultFlow({
                   effect="fade"
                   size="default"
                   fullWidth
-                  className="h-11 whitespace-normal px-4 text-center text-sm leading-snug sm:h-12 sm:text-base"
+                  className="h-11 whitespace-normal rounded-full px-4 text-center text-[15px] font-medium leading-snug sm:h-12"
                   disabled={isUnlocking || !pendingUnlockKey}
                   onClick={async () => {
                     if (!pendingUnlockKey) return;
@@ -1127,31 +1158,35 @@ export function VaultFlow({
         onOpenChange={() => {}}
       >
         <DialogContent
-          className="z-[520] w-[calc(100%-1rem)] max-h-[calc(100svh-1rem)] overflow-y-auto sm:max-w-md"
+          className="z-[520] max-h-[calc(100svh-1rem)] w-[calc(100%-1rem)] overflow-y-auto rounded-[28px] border border-border/35 bg-background/95 p-6 shadow-[0_24px_70px_rgba(15,23,42,0.18)] backdrop-blur-xl sm:max-w-md sm:p-7"
           onPointerDownOutside={(e) => e.preventDefault()}
         >
           <DialogHeader>
-            <div className="flex items-center gap-2">
-              <Icon icon={Key} size="lg" className="text-orange-500" />
-              <DialogTitle>Save Your Recovery Key</DialogTitle>
+            <div className="flex items-center gap-3">
+              <div className="grid h-11 w-11 shrink-0 place-items-center rounded-[16px] bg-orange-500/10 ring-1 ring-orange-500/15">
+                <Icon icon={Key} size="sm" className="text-orange-500" />
+              </div>
+              <DialogTitle className="!text-[22px] !font-medium !leading-[1.12] !tracking-normal">
+                Save Your Recovery Key
+              </DialogTitle>
             </div>
-            <DialogDescription>
+            <DialogDescription className="pt-1 text-[14.5px] leading-[1.45]">
               This is the ONLY way to recover your vault if you forget your
               vault credentials. Store it somewhere safe!
             </DialogDescription>
           </DialogHeader>
 
           <div className="space-y-4">
-            <Alert className="bg-orange-500/10 border-orange-500/50">
+            <Alert className="rounded-[18px] border-orange-500/30 bg-orange-500/10">
               <Icon icon={AlertCircle} size="sm" className="text-orange-500" />
-              <AlertDescription className="text-orange-700 dark:text-orange-300">
+              <AlertDescription className="text-[13.5px] leading-[1.4] text-orange-700 dark:text-orange-300">
                 Write this down or save it securely. You cannot recover it
                 later!
               </AlertDescription>
             </Alert>
 
-            <div className="p-4 bg-muted rounded-lg border-2 border-dashed">
-              <code className="text-lg font-mono font-bold tracking-wide">
+            <div className="rounded-[18px] border border-dashed border-border bg-muted/45 p-4">
+              <code className="break-all font-mono text-[15px] font-medium leading-[1.5] tracking-normal">
                 {recoveryKey}
               </code>
             </div>
@@ -1159,7 +1194,7 @@ export function VaultFlow({
             <div className="flex flex-col gap-2 sm:flex-row">
               <Button
                 variant="none"
-                className="flex-1 border border-gray-200 dark:border-gray-700 whitespace-normal"
+                className="h-11 flex-1 whitespace-normal rounded-full border border-gray-200 text-[15px] font-medium dark:border-gray-700"
                 onClick={handleCopyRecoveryKey}
               >
                 {copied ? (
@@ -1176,7 +1211,7 @@ export function VaultFlow({
               </Button>
               <Button
                 variant="none"
-                className="flex-1 border border-gray-200 dark:border-gray-700 whitespace-normal"
+                className="h-11 flex-1 whitespace-normal rounded-full border border-gray-200 text-[15px] font-medium dark:border-gray-700"
                 onClick={async () => {
                   const content = `Hussh Recovery Key\n\n${recoveryKey}\n\nStore this file securely. This is the ONLY way to recover your vault if you lose your vault credentials.`;
                   await downloadTextFile(content, "hushh-recovery-key.txt");
@@ -1193,7 +1228,7 @@ export function VaultFlow({
               variant="gradient"
               effect="glass"
               size={ACTION_BUTTON_SIZE}
-              className="w-full whitespace-normal text-center leading-snug h-auto min-h-12 px-4"
+              className="h-12 w-full whitespace-normal rounded-full px-4 text-center text-[16px] font-medium leading-snug"
               onClick={handleRecoveryKeyContinue}
             >
               I've Saved My Recovery Key


### PR DESCRIPTION
## Summary
- Normalizes Kai UI hierarchy across onboarding, phone verification, portfolio import, vault setup, Agent, Market, Connect, and shared bottom chrome.
- Removes duplicate Agent/search chrome paths while preserving existing route, auth, voice, and backend behavior.
- Keeps Market data functionality intact, including the four-card overview path and existing UAT data loaders.

## Scope
Frontend UI-only. No route constants, backend APIs, auth providers, data contracts, or feature links changed.

## Validation
- `npm run typecheck`
- `npm run verify:design-system`
- `npm run verify:cache`
- `npm run verify:docs`
- `git diff --check`

Browser route sweep intentionally skipped per request.

## Merge note
Main requires merge queue, one approving review, and `CI Status Gate`. Please approve so this can enter the queue for UAT.
