### PR TITLE
test(identity): verify confirm route returns 410

### DIFF
--- a/consent-protocol/tests/test_identity_routes.py
+++ b/consent-protocol/tests/test_identity_routes.py
@@ -1,0 +1,19 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routes.identity import router
+
+
+def _build_app():
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+def test_confirm_route_is_deprecated():
+    client = TestClient(_build_app())
+
+    response = client.post("/api/identity/confirm")
+
+    assert response.status_code == 410
+    assert response.json()["detail"]["error_code"] == "IDENTITY_ROUTES_DEPRECATED"


### PR DESCRIPTION
## Summary

Adds route coverage for the deprecated identity confirm endpoint.

## Changes

- verifies `/api/identity/confirm` returns HTTP 410
- verifies deprecated route response uses `IDENTITY_ROUTES_DEPRECATED`

## Testing

```bash
uv run pytest tests/test_identity_routes.py -v
```