### PR TITLE
test(drawer): cover showCloseButton=false hides close button

### DIFF
--- a/hushh-webapp/__tests__/ui/drawer.test.tsx
+++ b/hushh-webapp/__tests__/ui/drawer.test.tsx
@@ -31,6 +31,7 @@ describe("DrawerContent", () => {
       </Drawer>,
     );
 
+    expect(screen.getByText("Test drawer")).toBeTruthy();
     expect(
       screen.queryByRole("button", { name: /close/i }),
     ).toBeNull();


### PR DESCRIPTION
## Summary
- Strengthen DrawerContent test coverage for `showCloseButton={false}`.
- Verify the drawer title still renders while the accessible close button is hidden.

## Scope Proof
- Touched only `hushh-webapp/__tests__/ui/drawer.test.tsx`.
- Test-only change with no runtime component changes.
- The existing hide-close-button assertion remains in place.

## Impact
No UI behavior changes. This only locks the existing DrawerContent close-button hiding behavior.

## Validation
- `npx.cmd vitest run __tests__/ui/drawer.test.tsx`
- Verified the commit includes a DCO `Signed-off-by` trailer.
