### PR TITLE
test(command-input): cover accessible search role and placeholder

### DIFF
--- a/hushh-webapp/__tests__/ui/command-input.test.tsx
+++ b/hushh-webapp/__tests__/ui/command-input.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Command, CommandInput } from "@/components/ui/command";
+
+describe("CommandInput", () => {
+  it("exposes an accessible search role and placeholder", () => {
+    render(
+      <Command>
+        <CommandInput aria-label="Search commands" placeholder="Search commands" />
+      </Command>,
+    );
+
+    const searchInput = screen.getByRole("combobox");
+
+    expect(searchInput.getAttribute("aria-label")).toBe("Search commands");
+    expect(searchInput.getAttribute("placeholder")).toBe("Search commands");
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused UI test coverage for CommandInput search accessibility.
- Verify the command input exposes the combobox search control and preserves the search label and placeholder.

## Scope Proof
- New test file only: `hushh-webapp/__tests__/ui/command-input.test.tsx`.
- No runtime component changes.
- Covers the existing `components/ui/command` input behavior directly.

## Impact
Test-only change. This locks the existing CommandInput search role and placeholder behavior without changing UI output.

## Validation
- `npx.cmd vitest run __tests__/ui/command-input.test.tsx`
- Verified the commit includes a DCO `Signed-off-by` trailer.
