### PR TITLE
test(sonner): cover toast visible count default

### DIFF
--- a/hushh-webapp/__tests__/ui/sonner.test.tsx
+++ b/hushh-webapp/__tests__/ui/sonner.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Toaster } from "@/components/ui/sonner";
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ theme: "system" }),
+}));
+
+vi.mock("sonner", () => ({
+  Toaster: ({ visibleToasts }: { visibleToasts?: number }) => (
+    <div data-testid="sonner-toaster" data-visible-toasts={visibleToasts} />
+  ),
+}));
+
+describe("Toaster", () => {
+  it("uses the default visible toast count", () => {
+    render(<Toaster />);
+
+    expect(screen.getByTestId("sonner-toaster").getAttribute("data-visible-toasts")).toBe(
+      "2",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused Sonner UI test coverage for the default visible toast count.
- Verify the local Toaster wrapper passes `visibleToasts={2}` into Sonner.

## Scope Proof
- New test file only: `hushh-webapp/__tests__/ui/sonner.test.tsx`.
- No runtime component changes.
- No shared test files modified.

## Impact
Test-only change. This locks the existing toast visibility default without changing UI behavior.

## Validation
- `npx.cmd vitest run __tests__/ui/sonner.test.tsx`
- Verified the commit includes a DCO `Signed-off-by` trailer.
