### PR TITLE
fix(ui): hide round tab collapse chevrons from assistive technology

### DIFF
--- a/hushh-webapp/components/kai/views/round-tabs-card.tsx
+++ b/hushh-webapp/components/kai/views/round-tabs-card.tsx
@@ -161,7 +161,11 @@ export function RoundTabsCard({
               onClick={onToggleCollapse}
               aria-label={isCollapsed ? "Expand round details" : "Collapse round details"}
             >
-              {isCollapsed ? <Icon icon={ChevronDown} size="sm" /> : <Icon icon={ChevronUp} size="sm" />}
+              {isCollapsed ? (
+                <Icon aria-hidden="true" icon={ChevronDown} size="sm" />
+              ) : (
+                <Icon aria-hidden="true" icon={ChevronUp} size="sm" />
+              )}
             </MorphyButton>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Hide the round tabs collapse and expand chevron icons from assistive technology.
- Keep the existing labelled collapse button as the accessible control.

## Scope Proof
- Runtime file touched: `hushh-webapp/components/kai/views/round-tabs-card.tsx`.
- Only the `ChevronDown` and `ChevronUp` icons inside the collapse toggle button changed.
- No tab logic, card rendering, agent state handling, or button label behavior changed.

## Caller Proof
- The parent `MorphyButton` already exposes `aria-label={isCollapsed ? "Expand round details" : "Collapse round details"}`.
- Marking the nested chevron SVGs `aria-hidden="true"` prevents duplicate decorative icon exposure while preserving the button's accessible name.

## Validation
- `npx.cmd eslint components/kai/views/round-tabs-card.tsx --max-warnings=0`
- Verified the commit includes a DCO `Signed-off-by` trailer.
