### PR TITLE
fix(ui): hide marketplace filter search icon from assistive technology

### DIFF
--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -1172,7 +1172,10 @@ export default function MarketplacePage() {
           {searchOpen ? (
             <div className="mt-2">
               <div className="relative">
-                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <Search
+                  aria-hidden="true"
+                  className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                />
                 <Input
                   value={query}
                   onChange={(event) => setQuery(event.target.value)}


### PR DESCRIPTION
## Summary
- Hide the marketplace filter search icon from assistive technology.
- Keep the existing search input placeholder as the accessible user-facing cue.

## Scope Proof
- Runtime file touched: `hushh-webapp/app/marketplace/page.tsx`.
- Only the decorative `Search` icon inside the filter input wrapper changed.
- No marketplace search logic, query state, list rendering, or toggle button behavior changed.

## Caller Proof
- The adjacent `Input` keeps the existing `placeholder={searchPlaceholder}` text for the search affordance.
- The search icon is positioned visually with `pointer-events-none`, so marking it `aria-hidden="true"` removes decorative SVG noise without affecting input access.

## Validation
- `npx.cmd eslint app/marketplace/page.tsx --max-warnings=0`
- Verified the commit includes a DCO `Signed-off-by` trailer.
