### PR TITLE
fix(ui): remove one location removable chip icons from svg focus order

### DIFF
--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -3657,7 +3657,11 @@ function OneLocationAgentPageContent() {
                               <span className="min-w-0 truncate">
                                 {recipientLabel(recipient)}
                               </span>
-                              <X className="h-3.5 w-3.5" aria-hidden="true" />
+                              <X
+                                aria-hidden="true"
+                                focusable="false"
+                                className="h-3.5 w-3.5"
+                              />
                               <span className="sr-only">
                                 Remove {recipientLabel(recipient)}
                               </span>
@@ -3769,7 +3773,11 @@ function OneLocationAgentPageContent() {
                               <span className="min-w-0 truncate">
                                 {recipientLabel(recipient)}
                               </span>
-                              <X className="h-3.5 w-3.5" aria-hidden="true" />
+                              <X
+                                aria-hidden="true"
+                                focusable="false"
+                                className="h-3.5 w-3.5"
+                              />
                               <span className="sr-only">
                                 Remove {recipientLabel(recipient)}
                               </span>


### PR DESCRIPTION
## Summary

- Remove the two decorative one-location removable chip `X` SVGs from the SVG focus order.
- Keep the existing `aria-hidden="true"` treatment and add `focusable="false"` to the selected share/request owner chip icons.

## Claim Clarification

- This PR does not newly add `aria-hidden`; both affected icons were already hidden from assistive technology before this change.
- The actual narrowed change is `focusable="false"` on the already-decorative SVG icons, so older SVG focus behavior cannot expose the icon separately from the chip button label.

## Scope Proof

- Runtime file touched: `hushh-webapp/app/one/location/page.tsx`.
- Only the two removable chip `X` icons changed.
- No recipient selection, removal handlers, grant revoke controls, request submission, or location sharing logic changed.

## Caller Proof

- Each chip button already exposes visible recipient text plus sr-only `Remove {recipientLabel(recipient)}` text.
- The `X` SVGs are decorative duplicates of the remove affordance, so `aria-hidden="true"` with `focusable="false"` keeps assistive technology on the button text instead of the icon.

## Validation

- `npx.cmd eslint app/one/location/page.tsx --max-warnings=0`
- Verified the amended commit includes a DCO `Signed-off-by` trailer.
