### PR TITLE
test(breadcrumb): cover separator renders between items

### DIFF
--- a/hushh-webapp/__tests__/ui/breadcrumb.test.tsx
+++ b/hushh-webapp/__tests__/ui/breadcrumb.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+
+describe("Breadcrumb", () => {
+  it("renders a separator between breadcrumb items", () => {
+    const { container } = render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>Home</BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Settings</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+
+    const list = screen.getByRole("list");
+    const separator = container.querySelector('[data-slot="breadcrumb-separator"]');
+
+    expect(separator).toBeTruthy();
+    expect(list.children[0]?.textContent).toBe("Home");
+    expect(list.children[1]).toBe(separator);
+    expect(list.children[2]?.textContent).toBe("Settings");
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused UI test coverage for breadcrumb separator placement.
- Verify a separator renders between two breadcrumb items in list order.

## Scope Proof
- New test file only: `hushh-webapp/__tests__/ui/breadcrumb.test.tsx`.
- No runtime component changes.
- Covers the existing `components/ui/breadcrumb` composition directly.

## Impact
Test-only change. This locks the existing breadcrumb separator placement behavior without changing UI output.

## Validation
- `npx.cmd vitest run __tests__/ui/breadcrumb.test.tsx`
- Verified the commit includes a DCO `Signed-off-by` trailer.
