### PR TITLE
test(scroll-area): cover keyboard focus on scroll container

### DIFF
--- a/hushh-webapp/__tests__/ui/scroll-area.test.tsx
+++ b/hushh-webapp/__tests__/ui/scroll-area.test.tsx
@@ -1,0 +1,22 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+describe("ScrollArea", () => {
+  it("allows keyboard focus on the scroll container", () => {
+    const { container } = render(
+      <ScrollArea className="h-20 w-40">
+        <div className="h-40">Scrollable content</div>
+      </ScrollArea>,
+    );
+
+    const viewport = container.querySelector<HTMLElement>(
+      '[data-slot="scroll-area-viewport"]',
+    );
+
+    expect(viewport).toBeTruthy();
+    viewport?.focus();
+    expect(document.activeElement).toBe(viewport);
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused UI test coverage for ScrollArea viewport focus behavior.
- Verify the rendered scroll container can receive keyboard focus.

## Scope Proof
- New test file only: `hushh-webapp/__tests__/ui/scroll-area.test.tsx`.
- No runtime component changes.
- Covers the existing `components/ui/scroll-area` viewport directly.

## Impact
Test-only change. This locks the existing keyboard-focus contract for the scroll container without changing UI output.

## Validation
- `npx.cmd vitest run __tests__/ui/scroll-area.test.tsx`
- Verified the commit includes a DCO `Signed-off-by` trailer.
