### PR TITLE
test(observability): verify one kyc route mapping

### DIFF
--- a/hushh-webapp/__tests__/services/observability-route-map.test.ts
+++ b/hushh-webapp/__tests__/services/observability-route-map.test.ts
@@ -55,6 +55,7 @@ describe("observability route map", () => {
     expect(resolveRouteId("/profile/receipts")).toBe("profile_receipts");
     expect(resolveRouteId("/profile/gmail/oauth/return")).toBe("profile_gmail_oauth_return");
     expect(resolveRouteId("/one/location")).toBe("one_location");
+    expect(resolveRouteId("/one/kyc")).toBe("one_kyc");
     expect(resolveRouteId("/one/location/request/sample")).toBe("one_location_public_request");
     expect(resolveRouteId("/agent")).toBe("agent");
     expect(resolveRouteId("/portfolio/shared")).toBe("portfolio_shared");


### PR DESCRIPTION
## Summary

Adds observability route-map coverage for the One KYC route.

## Changes

* adds a route mapping assertion for `/one/kyc`
* verifies the route resolves to the stable route identifier `one_kyc`

## Why

Observability route identifiers are used for analytics and monitoring. This test ensures the One KYC route continues to resolve to the expected canonical route ID and cannot silently regress.

## Testing

```bash
pnpm exec vitest run __tests__/services/observability-route-map.test.ts
```

Result:

* Test Files: 1 passed
* Tests: 5 passed
