### PR TITLE
fix(ui): hide ria picks upload loader icons from assistive technology

### DIFF
--- a/hushh-webapp/app/ria/picks/page.tsx
+++ b/hushh-webapp/app/ria/picks/page.tsx
@@ -421,7 +421,7 @@ function UploadPanel({
               onClick={onUpload}
               disabled={submitting || !fileContent.trim()}
             >
-              <Upload className="mr-2 h-4 w-4" />
+              <Upload aria-hidden="true" className="mr-2 h-4 w-4" />
               {submitting ? "Uploading..." : "Upload and replace top picks"}
             </Button>
             <Button asChild variant="none" effect="fade" size="sm">
@@ -2327,7 +2327,7 @@ export default function RiaPicksPage() {
                     }}
                     className="w-full justify-center"
                   >
-                    <Upload className="mr-2 h-4 w-4" />
+                    <Upload aria-hidden="true" className="mr-2 h-4 w-4" />
                     {uploadOpen ? "Close upload" : "Upload"}
                   </Button>
                   <Button


### PR DESCRIPTION
## Summary
- Hide decorative RIA picks upload icons from assistive technology.
- Preserve the visible upload labels as the accessible control text.

## Scope Proof
- Runtime file touched: `hushh-webapp/app/ria/picks/page.tsx`.
- Only the two `Upload` icons in the RIA picks upload controls changed.
- No upload state, CSV parsing, save behavior, source tabs, or pick-list rendering changed.

## Caller Proof
- The upload panel button already exposes text: `Upload and replace top picks` or `Uploading...`.
- The toolbar upload toggle already exposes text: `Upload` or `Close upload`.
- Marking the nested upload SVGs `aria-hidden="true"` removes decorative icon noise while preserving the button names.

## Validation
- `npx.cmd eslint app/ria/picks/page.tsx --max-warnings=0`
- Verified the commit includes a DCO `Signed-off-by` trailer.
