### PR TITLE
fix(ui): add explicit button type to one location contact card actions

### DIFF
--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -3459,6 +3459,7 @@ function OneLocationAgentPageContent() {
                     </div>
                     <div className="mt-3 grid gap-2 sm:grid-cols-2">
                       <ActionButton
+                        type="button"
                         busy={busy}
                         busyKey="contactSync"
                         onClick={() => void handleSyncContactSignal()}
@@ -3472,6 +3473,7 @@ function OneLocationAgentPageContent() {
                         Sync Contacts
                       </ActionButton>
                       <ActionButton
+                        type="button"
                         busy={busy}
                         busyKey="contactInvite"
                         onClick={() => void handleShareContactInvite()}


### PR DESCRIPTION
## Summary
- Add explicit `type="button"` to the One Location contact-card action controls.
- Keep contact sync and invite actions from behaving like implicit submit buttons if the card is ever rendered near form context.

## Scope Proof
- Runtime file touched: `hushh-webapp/app/one/location/page.tsx`.
- Only the two contact-card `ActionButton` controls changed: `Sync Contacts` and `Invite Contacts`.
- No contact sync logic, invite sharing logic, KAI Circle selection, or location sharing behavior changed.

## Caller Proof
- Both controls are action buttons wired through `onClick` handlers, not form submit controls.
- Adding `type="button"` makes that contract explicit while preserving existing labels, disabled states, and busy handling.

## Validation
- `npx.cmd eslint app/one/location/page.tsx --max-warnings=0`
- Verified the commit includes a DCO `Signed-off-by` trailer.
