### PR TITLE
test(config): cover UAT backend url resolution

### DIFF
--- a/hushh-webapp/__tests__/lib/config.test.ts
+++ b/hushh-webapp/__tests__/lib/config.test.ts
@@ -77,4 +77,20 @@ describe("config", () => {
 
     expect(config.BACKEND_URL).toBe("");
   });
+
+  it("resolves UAT backend url from runtime settings", async () => {
+    const { resolveAppEnvironment } = await import("@/lib/app-env");
+    const { resolveRuntimeBackendUrl } = await import(
+      "@/lib/runtime/settings"
+    );
+
+    vi.mocked(resolveAppEnvironment).mockReturnValue("uat");
+    vi.mocked(resolveRuntimeBackendUrl).mockReturnValue(
+      "https://uat-api.hushh.ai/",
+    );
+
+    const config = await import("@/lib/config");
+
+    expect(config.BACKEND_URL).toBe("https://uat-api.hushh.ai");
+  });
 });


### PR DESCRIPTION
## Summary
- Add focused config test coverage for UAT backend URL resolution.
- Verify `BACKEND_URL` uses the runtime backend URL in UAT and normalizes trailing slashes.

## Scope Proof
- Test file touched: `hushh-webapp/__tests__/lib/config.test.ts`.
- No runtime config code changed.
- Appends one new `it()` block inside the existing `describe("config")` suite.

## Impact
Test-only change. This locks the existing UAT backend URL resolution behavior without changing application output.

## Validation
- `npx.cmd vitest run __tests__/lib/config.test.ts`
- Verified the commit includes a DCO `Signed-off-by` trailer.
