### PR TITLE
test(observability): verify logout route mapping

### DIFF
--- a/hushh-webapp/__tests__/services/observability-route-map.test.ts
+++ b/hushh-webapp/__tests__/services/observability-route-map.test.ts
@@ -40,6 +40,7 @@ function collectAppPageRoutes(dir: string, root: string = dir): string[] {
 
 describe("observability route map", () => {
   it("maps canonical app routes to stable route IDs", () => {
+    expect(resolveRouteId("/logout")).toBe("logout");
     expect(resolveRouteId("/kai")).toBe("kai_home");
     expect(resolveRouteId("/kai/dashboard")).toBe("kai_dashboard_legacy_redirect");
     expect(resolveRouteId("/kai/dashboard/analysis")).toBe("kai_dashboard_legacy_redirect");


### PR DESCRIPTION
## Summary

Adds observability route-map coverage for the logout route.

## Changes

* adds a route mapping assertion for `/logout`
* verifies the route resolves to the stable route identifier `logout`

## Why

Observability route identifiers are used for analytics and monitoring. This test ensures the logout route continues to resolve to the expected canonical route ID and cannot silently regress.

## Testing

```bash
pnpm exec vitest run __tests__/services/observability-route-map.test.ts
```

Result:

* Test Files: 1 passed
* Tests: 5 passed
