### PR TITLE
test(observability): verify invalid request ids are rejected

### DIFF
--- a/hushh-webapp/__tests__/services/observability-request-id.test.ts
+++ b/hushh-webapp/__tests__/services/observability-request-id.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+import { sanitizeRequestId } from "@/lib/observability/request-id";
+
+describe("sanitizeRequestId", () => {
+  it("rejects invalid request ids", () => {
+    expect(sanitizeRequestId("")).toBeNull();
+    expect(sanitizeRequestId("bad id")).toBeNull();
+    expect(sanitizeRequestId("%%%%")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds focused coverage for invalid request ID handling.

## Changes

* verifies empty request IDs are rejected
* verifies request IDs containing whitespace are rejected
* verifies request IDs containing invalid characters are rejected

## Why

Observability request IDs must conform to the expected format to ensure reliable tracing and correlation across services. This test protects the rejection behavior from accidental regressions.

## Testing

pnpm exec vitest run **tests**/services/observability-request-id.test.ts

Result:

* Test Files: 1 passed
* Tests: 1 passed
