### PR TITLE
test(observability): verify request id header reuse

### DIFF
--- a/hushh-webapp/__tests__/services/observability-request-id.test.ts
+++ b/hushh-webapp/__tests__/services/observability-request-id.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  REQUEST_ID_HEADER,
+  getOrCreateRequestId,
+} from "@/lib/observability/request-id";
+
+describe("getOrCreateRequestId", () => {
+  it("uses a valid header value", () => {
+    const result = getOrCreateRequestId(
+      new Headers({
+        [REQUEST_ID_HEADER]: "abc12345",
+      })
+    );
+
+    expect(result).toBe("abc12345");
+  });
+});


### PR DESCRIPTION
## Summary

Adds focused coverage for request ID header reuse behavior.

## Changes

* verifies a valid request ID supplied through the request header is reused unchanged
* confirms request ID generation does not replace already-valid values

## Why

Observability tooling relies on preserving upstream request IDs for trace continuity. This test protects that behavior from regressions and ensures valid request identifiers continue to propagate correctly.

## Testing

pnpm exec vitest run **tests**/services/observability-request-id.test.ts

Result:

* Test Files: 1 passed
* Tests: 1 passed
