### PR TITLE
test(observability): verify invalid request id header replacement

### DIFF
--- a/hushh-webapp/__tests__/services/observability-request-id.test.ts
+++ b/hushh-webapp/__tests__/services/observability-request-id.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  REQUEST_ID_HEADER,
+  getOrCreateRequestId,
+} from "@/lib/observability/request-id";
+
+describe("getOrCreateRequestId", () => {
+  it("creates a replacement for invalid header values", () => {
+    const result = getOrCreateRequestId(
+      new Headers({
+        [REQUEST_ID_HEADER]: "bad id",
+      })
+    );
+
+    expect(result).toBeTruthy();
+    expect(result).not.toBe("bad id");
+  });
+});


### PR DESCRIPTION
## Summary

Adds focused coverage for invalid request ID header handling.

## Changes

* verifies invalid request ID header values are not reused
* verifies a replacement request ID is generated when the header value fails validation

## Why

Request identifiers are used for observability and tracing. This test ensures malformed request ID headers cannot propagate through the system and are replaced with valid identifiers.

## Testing

pnpm exec vitest run **tests**/services/observability-request-id.test.ts