### PR TITLE
test(alert): add data-slot contract test

### DIFF
--- a/hushh-webapp/__tests__/ui/alert.test.tsx
+++ b/hushh-webapp/__tests__/ui/alert.test.tsx
@@ -1,0 +1,42 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+
+describe("Alert", () => {
+  it("renders root with data-slot='alert'", () => {
+    const { container } = render(<Alert />);
+
+    expect(container.querySelector('[data-slot="alert"]')).toBeTruthy();
+  });
+
+  it("renders root with role='alert'", () => {
+    const { container } = render(<Alert />);
+
+    const alert = container.querySelector('[data-slot="alert"]');
+
+    expect(alert?.getAttribute("role")).toBe("alert");
+  });
+
+  it("renders AlertTitle with data-slot='alert-title'", () => {
+    const { container } = render(
+      <Alert>
+        <AlertTitle>Title</AlertTitle>
+      </Alert>,
+    );
+
+    expect(container.querySelector('[data-slot="alert-title"]')).toBeTruthy();
+  });
+
+  it("renders AlertDescription with data-slot='alert-description'", () => {
+    const { container } = render(
+      <Alert>
+        <AlertDescription>Description</AlertDescription>
+      </Alert>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="alert-description"]'),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract tests for the Alert primitive covering its exposed data-slot attributes and alert role contract.

## What

New file:

`hushh-webapp/__tests__/ui/alert.test.tsx`

Coverage:

* `data-slot="alert"`
* `role="alert"`
* `data-slot="alert-title"`
* `data-slot="alert-description"`

## Why

Alert exposes styling and accessibility contracts through its data-slot attributes and alert role. These contracts currently have no direct test coverage.

## Notes

* Test-only change
* New file only
* No production code modified
* No Radix primitives, portals, or ResizeObserver dependencies

## Checklist

* [x] New file only
* [x] No implementation changes
* [x] No custom helpers introduced
* [x] Follows existing Vitest patterns
