### PR TITLE
test(spinner): add contract test

### DIFF
--- a/hushh-webapp/__tests__/ui/spinner.test.tsx
+++ b/hushh-webapp/__tests__/ui/spinner.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Spinner } from "@/components/ui/spinner";
+
+describe("Spinner", () => {
+  it("renders with role='status'", () => {
+    render(<Spinner />);
+
+    expect(screen.getByRole("status")).toBeTruthy();
+  });
+
+  it("renders with aria-label='Loading'", () => {
+    render(<Spinner />);
+
+    expect(screen.getByRole("status").getAttribute("aria-label")).toBe(
+      "Loading",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract tests for the Spinner component covering its accessibility contract.

## What

New file:

`hushh-webapp/__tests__/ui/spinner.test.tsx`

Coverage:

* `role="status"`
* `aria-label="Loading"`

## Why

Spinner exposes a stable accessibility contract through its status role and loading label. These attributes currently have no direct test coverage.

## Notes

* Test-only change
* New file only
* No production code modified
* No timers, animations, transitions, or interaction testing

## Checklist

* [x] New file only
* [x] No implementation changes
* [x] No custom helpers introduced
* [x] Follows existing Vitest patterns
