### PR TITLE
test(skeleton): add data-slot contract test

### DIFF
--- a/hushh-webapp/__tests__/ui/skeleton.test.tsx
+++ b/hushh-webapp/__tests__/ui/skeleton.test.tsx
@@ -1,0 +1,20 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Skeleton } from "@/components/ui/skeleton";
+
+describe("Skeleton", () => {
+  it("renders with data-slot='skeleton'", () => {
+    const { container } = render(<Skeleton />);
+
+    expect(container.querySelector('[data-slot="skeleton"]')).toBeTruthy();
+  });
+
+  it("renders with aria-hidden='true'", () => {
+    const { container } = render(<Skeleton />);
+
+    const skeleton = container.querySelector('[data-slot="skeleton"]');
+
+    expect(skeleton?.getAttribute("aria-hidden")).toBe("true");
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract tests for the Skeleton primitive covering its exposed data-slot and accessibility contracts.

## What

New file:

`hushh-webapp/__tests__/ui/skeleton.test.tsx`

Coverage:

* `data-slot="skeleton"`
* `aria-hidden="true"`

## Why

Skeleton exposes a stable rendering contract through its data-slot attribute and accessibility behavior. These attributes currently have no direct test coverage.

## Notes

* Test-only change
* New file only
* No production code modified
* No animation behavior tested
* Uses `container.querySelector` because `aria-hidden="true"` intentionally removes the element from the accessibility tree

## Checklist

* [x] New file only
* [x] No implementation changes
* [x] No custom helpers introduced
* [x] Follows existing Vitest patterns
