### PR TITLE
fix(sheet): add data-slot="sheet-close" to internal close button

### DIFF
--- a/hushh-webapp/components/ui/sheet.tsx
+++ b/hushh-webapp/components/ui/sheet.tsx
@@ -78,7 +78,7 @@ function SheetContent({
       >
         {children}
         {showCloseButton && (
-          <SheetPrimitive.Close type="button" className="ring-offset-background focus:ring-ring absolute top-4 right-4 rounded-full border border-transparent bg-[color:var(--app-card-surface-compact)] p-2 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+          <SheetPrimitive.Close data-slot="sheet-close" type="button" className="ring-offset-background focus:ring-ring absolute top-4 right-4 rounded-full border border-transparent bg-[color:var(--app-card-surface-compact)] p-2 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
             <XIcon className="size-4" aria-hidden="true" />
             <span className="sr-only">Close</span>
           </SheetPrimitive.Close>


### PR DESCRIPTION
## Summary

Adds `data-slot="sheet-close"` to the internal close button rendered by `SheetContent`.

## Problem

The exported `SheetClose` component already exposes `data-slot="sheet-close"`, but the internal close button rendered when `showCloseButton` is enabled does not.

This creates an inconsistency within the Sheet primitive and breaks parity with similar overlay primitives.

Parity comparison:

* Dialog internal close button → `data-slot="dialog-close"`
* Drawer internal close button → `data-slot="drawer-close"`
* Sheet internal close button → missing

## Change

Adds a single attribute:

```diff
+ data-slot="sheet-close"
```

to the internal `SheetPrimitive.Close` element rendered by `SheetContent`.

## Impact

* No behavior changes
* No styling changes
* No accessibility changes
* No API changes
* Single-file modification

## Validation

Existing `sheet.test.tsx` passes unchanged.

## Checklist

* [x] Single-file change
* [x] Additive only
* [x] No runtime behavior changes
* [x] No visual changes
* [x] Primitive parity improvement
