### PR TITLE
test(popover): add data-slot contract test

### DIFF
--- a/hushh-webapp/__tests__/ui/popover.test.tsx
+++ b/hushh-webapp/__tests__/ui/popover.test.tsx
@@ -1,0 +1,62 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+describe("Popover", () => {
+  it("renders PopoverTrigger with data-slot='popover-trigger'", () => {
+    const { container } = render(
+      <Popover>
+        <PopoverTrigger>Open</PopoverTrigger>
+      </Popover>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="popover-trigger"]'),
+    ).toBeTruthy();
+  });
+
+  it("renders PopoverContent with data-slot='popover-content' when open", () => {
+    render(
+      <Popover defaultOpen>
+        <PopoverTrigger>Open</PopoverTrigger>
+        <PopoverContent>Content</PopoverContent>
+      </Popover>,
+    );
+
+    expect(
+      document.querySelector('[data-slot="popover-content"]'),
+    ).toBeTruthy();
+  });
+
+  it("renders PopoverHeader with data-slot='popover-header'", () => {
+    const { container } = render(<PopoverHeader />);
+
+    expect(
+      container.querySelector('[data-slot="popover-header"]'),
+    ).toBeTruthy();
+  });
+
+  it("renders PopoverTitle with data-slot='popover-title'", () => {
+    const { container } = render(<PopoverTitle />);
+
+    expect(
+      container.querySelector('[data-slot="popover-title"]'),
+    ).toBeTruthy();
+  });
+
+  it("renders PopoverDescription with data-slot='popover-description'", () => {
+    const { container } = render(<PopoverDescription />);
+
+    expect(
+      container.querySelector('[data-slot="popover-description"]'),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract test coverage for the `Popover` UI primitive.

## What

New file:

`__tests__/ui/popover.test.tsx`

Tests:

* Verifies `data-slot="popover-trigger"` renders on `PopoverTrigger`
* Verifies `data-slot="popover-content"` renders when the popover is opened
* Verifies `data-slot="popover-header"` renders on `PopoverHeader`
* Verifies `data-slot="popover-title"` renders on `PopoverTitle`
* Verifies `data-slot="popover-description"` renders on `PopoverDescription`

## Why

`Popover` exposes multiple `data-slot` styling contracts but currently has no dedicated contract test coverage.

These tests help prevent accidental removal or renaming of slot attributes that are used by styling selectors and component consumers.

## Notes

* New test file only
* No production code changes
* No behavior changes
* No visual changes
* No accessibility changes
* Portal-rendered content is queried using `document.querySelector`, consistent with existing overlay component test patterns

## Validation

```bash
npx vitest run __tests__/ui/popover.test.tsx
```

All tests pass locally.

## Checklist

* [x] New file only
* [x] No implementation changes
* [x] Follows existing UI contract-test patterns
* [x] Zero runtime impact
