### PR TITLE
test(tooltip): add data-slot contract test

### DIFF
--- a/hushh-webapp/__tests__/ui/tooltip.test.tsx
+++ b/hushh-webapp/__tests__/ui/tooltip.test.tsx
@@ -1,0 +1,50 @@
+import { render } from "@testing-library/react";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+beforeAll(() => {
+  class ResizeObserverMock {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  globalThis.ResizeObserver = ResizeObserverMock as typeof ResizeObserver;
+});
+
+describe("Tooltip", () => {
+  it("renders TooltipTrigger with data-slot='tooltip-trigger'", () => {
+    const { container } = render(
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger>Hover me</TooltipTrigger>
+        </Tooltip>
+      </TooltipProvider>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="tooltip-trigger"]'),
+    ).toBeTruthy();
+  });
+
+  it("renders TooltipContent with data-slot='tooltip-content' when open", () => {
+    render(
+      <TooltipProvider>
+        <Tooltip defaultOpen>
+          <TooltipTrigger>Hover me</TooltipTrigger>
+          <TooltipContent>Tooltip text</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+    );
+
+    expect(
+      document.querySelector('[data-slot="tooltip-content"]'),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract test coverage for the `Tooltip` UI primitive.

## What

New file:

`__tests__/ui/tooltip.test.tsx`

Tests:

* Verifies `data-slot="tooltip-trigger"` renders on `TooltipTrigger`
* Verifies `data-slot="tooltip-content"` renders when the tooltip is opened via `defaultOpen`

## Why

`Tooltip` exposes public `data-slot` styling contracts but currently has no dedicated contract test coverage.

These tests help prevent accidental removal or renaming of slot attributes used by styling selectors and component consumers.

## Notes

* New test file only
* No production code changes
* No behavior changes
* No visual changes
* No accessibility changes
* Portal-rendered content is queried using `document.querySelector`, consistent with existing overlay component test patterns

## Validation

```bash
npx vitest run __tests__/ui/tooltip.test.tsx
```

All tests pass locally.

## Checklist

* [x] New file only
* [x] No implementation changes
* [x] Follows existing UI contract-test patterns
* [x] Zero runtime impact
