### PR TITLE
test(separator): add data-slot contract test

### DIFF
--- a/hushh-webapp/__tests__/ui/separator.test.tsx
+++ b/hushh-webapp/__tests__/ui/separator.test.tsx
@@ -1,0 +1,28 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Separator } from "@/components/ui/separator";
+
+describe("Separator", () => {
+  it("renders with data-slot='separator'", () => {
+    const { container } = render(<Separator />);
+
+    expect(
+      container.querySelector('[data-slot="separator"]'),
+    ).toBeTruthy();
+  });
+
+  it("defaults to horizontal orientation", () => {
+    const { container } = render(<Separator />);
+    const el = container.querySelector('[data-slot="separator"]');
+
+    expect(el?.getAttribute("data-orientation")).toBe("horizontal");
+  });
+
+  it("renders with vertical orientation when specified", () => {
+    const { container } = render(<Separator orientation="vertical" />);
+    const el = container.querySelector('[data-slot="separator"]');
+
+    expect(el?.getAttribute("data-orientation")).toBe("vertical");
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract test coverage for the `Separator` UI primitive.

## What this PR does

* Creates `__tests__/ui/separator.test.tsx` (new file, no existing file modified)
* Verifies `data-slot="separator"` renders
* Verifies `data-orientation="horizontal"` is the default
* Verifies `data-orientation="vertical"` when `orientation="vertical"` is passed

## Why

`Separator` exposes a public `data-slot` contract and orientation-dependent styling through `data-orientation`. These attributes are relied upon by downstream styling and should be protected against accidental regressions.

## What this PR does NOT do

* Does not modify any production code
* Does not assert `role="separator"` because the component defaults to `decorative={true}`, which intentionally changes accessibility semantics
* Does not introduce interaction testing or styling assertions

## Pattern

Matches the contract-test pattern already established by other primitive tests such as `badge.test.tsx`, `progress.test.tsx`, and `tabs.test.tsx`.

## Risk

* Test-only PR
* New file only
* Zero production behavior changes
* Zero visual changes
* Zero API changes

## Checklist

* [x] New file only
* [x] No production code modified
* [x] Follows existing Vitest patterns
* [x] 3 passing tests
