### PR TITLE
test(input): add data-slot contract test

### DIFF
--- a/hushh-webapp/__tests__/ui/input.test.tsx
+++ b/hushh-webapp/__tests__/ui/input.test.tsx
@@ -1,0 +1,21 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Input } from "@/components/ui/input";
+
+describe("Input", () => {
+  it("renders with data-slot='input'", () => {
+    const { container } = render(<Input />);
+
+    expect(
+      container.querySelector('[data-slot="input"]'),
+    ).toBeTruthy();
+  });
+
+  it("forwards className to the input element", () => {
+    const { container } = render(<Input className="test-class" />);
+    const el = container.querySelector('[data-slot="input"]');
+
+    expect(el?.classList.contains("test-class")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract test coverage for the `Input` UI primitive.

## What this PR does

* Creates `__tests__/ui/input.test.tsx` (new file, no existing file modified)
* Verifies `data-slot="input"` renders on the native input element
* Verifies `className` is forwarded correctly to the rendered input

## Why

`Input` is a shared UI primitive with a public `data-slot` contract and className passthrough behavior. These contracts are relied upon by downstream consumers and should be protected against accidental regressions.

## What this PR does NOT do

* Does not modify any production code
* Does not simulate typing or user interactions
* Does not test browser-specific input behavior
* Does not introduce custom test helpers

## Pattern

Matches the contract-test style already established by other primitive tests such as `badge.test.tsx`, `progress.test.tsx`, `separator.test.tsx`, and `tabs.test.tsx`.

## Risk

* Test-only PR
* New file only
* Zero production behavior changes
* Zero visual changes
* Zero API changes

## Checklist

* [x] New file only
* [x] No production code modified
* [x] Follows existing Vitest patterns
* [x] 2 passing tests
