### PR TITLE
a11y(dropdown-menu): hide decorative icons from assistive technology

### DIFF
--- a/hushh-webapp/components/ui/dropdown-menu.tsx
+++ b/hushh-webapp/components/ui/dropdown-menu.tsx
@@ -106,7 +106,7 @@ function DropdownMenuCheckboxItem({
     >
       <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
         <DropdownMenuPrimitive.ItemIndicator>
-          <CheckIcon className="size-4" />
+          <CheckIcon aria-hidden="true" className="size-4" />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       {children}
@@ -141,7 +141,7 @@ function DropdownMenuRadioItem({
     >
       <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
         <DropdownMenuPrimitive.ItemIndicator>
-          <CircleIcon className="size-2 fill-current" />
+          <CircleIcon aria-hidden="true" className="size-2 fill-current" />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       {children}
@@ -223,7 +223,7 @@ function DropdownMenuSubTrigger({
       {...props}
     >
       {children}
-      <ChevronRightIcon className="ml-auto size-4" />
+      <ChevronRightIcon aria-hidden="true" className="ml-auto size-4" />
     </DropdownMenuPrimitive.SubTrigger>
   )
 }


### PR DESCRIPTION
## Summary

Adds `aria-hidden="true"` to decorative icons rendered inside dropdown menu primitives.

## Motivation

Three SVG icons currently exist only for visual presentation and do not provide information beyond what is already exposed through Radix accessibility semantics:

* `CheckIcon` in `DropdownMenuCheckboxItem`
* `CircleIcon` in `DropdownMenuRadioItem`
* `ChevronRightIcon` in `DropdownMenuSubTrigger`

The checked and selected states are already communicated through Radix-managed accessibility attributes, and the sub-trigger accessible name comes from its text content.

Marking these icons as decorative removes unnecessary screen-reader noise while preserving all existing behavior.

## Changes

File modified:

`hushh-webapp/components/ui/dropdown-menu.tsx`

Changes:

* Add `aria-hidden="true"` to `CheckIcon`
* Add `aria-hidden="true"` to `CircleIcon`
* Add `aria-hidden="true"` to `ChevronRightIcon`

## Why This Is Safe

* No visual changes
* No behavior changes
* No API changes
* No keyboard interaction changes
* No focus management changes
* No layout changes

The accessible information already exists through Radix semantics and visible text.

## Pattern

Matches previously accepted accessibility improvements that suppress decorative icons from the accessibility tree.

## Validation

* TypeScript passes
* ESLint passes
* Single-file change
* Three additive attributes only

## Checklist

* [x] Accessibility improvement
* [x] Additive-only change
* [x] No behavior changes
* [x] No visual changes
* [x] No API changes
* [x] Single file modified
