### PR TITLE
a11y(command): hide decorative SearchIcon from assistive technology

### DIFF
--- a/hushh-webapp/components/ui/command.tsx
+++ b/hushh-webapp/components/ui/command.tsx
@@ -69,7 +69,7 @@ function CommandInput({
       data-slot="command-input-wrapper"
       className="flex h-9 items-center gap-2 border-b px-3"
     >
-      <SearchIcon className="size-4 shrink-0 opacity-50" />
+      <SearchIcon aria-hidden="true" className="size-4 shrink-0 opacity-50" />
       <CommandPrimitive.Input
         spellCheck={false}
         autoCorrect="off"


### PR DESCRIPTION
## Summary

Adds `aria-hidden="true"` to the decorative `SearchIcon` rendered inside `CommandInput`.

## Motivation

The search icon displayed before the command input is a visual affordance only. The input's accessible name is provided independently through its placeholder text or an associated label.

Because the icon does not contribute meaningful information, exposing it to assistive technologies creates unnecessary screen-reader noise.

Marking the icon as decorative ensures assistive technologies focus on the actual interactive control.

## Changes

File modified:

`hushh-webapp/components/ui/command.tsx`

Change:

* Add `aria-hidden="true"` to `SearchIcon` in `CommandInput`

## Why This Is Safe

* No visual changes
* No behavior changes
* No API changes
* No keyboard interaction changes
* No focus management changes
* No layout changes

The accessible information for the input remains unchanged.

## Pattern

Matches existing accessibility improvements that suppress decorative icons from the accessibility tree.

## Validation

* TypeScript passes
* ESLint passes
* Single-file change
* One additive attribute only

## Checklist

* [x] Accessibility improvement
* [x] Additive-only change
* [x] No behavior changes
* [x] No visual changes
* [x] No API changes
* [x] Single file modified
