### PR TITLE
a11y(carousel): hide decorative navigation arrow icons from assistive technology

### DIFF
--- a/hushh-webapp/components/ui/carousel.tsx
+++ b/hushh-webapp/components/ui/carousel.tsx
@@ -200,7 +200,7 @@ function CarouselPrevious({
       onClick={scrollPrev}
       {...props}
     >
-      <ArrowLeft />
+      <ArrowLeft aria-hidden="true" />
       <span className="sr-only">Previous slide</span>
     </Button>
   )
@@ -230,7 +230,7 @@ function CarouselNext({
       onClick={scrollNext}
       {...props}
     >
-      <ArrowRight />
+      <ArrowRight aria-hidden="true" />
       <span className="sr-only">Next slide</span>
     </Button>
   )


### PR DESCRIPTION
## Summary

Adds `aria-hidden="true"` to the decorative navigation arrow icons rendered by `CarouselPrevious` and `CarouselNext`.

## Motivation

Both carousel navigation buttons already expose their accessible names through existing screen-reader-only text:

* `CarouselPrevious` → "Previous slide"
* `CarouselNext` → "Next slide"

The `ArrowLeft` and `ArrowRight` icons are visual affordances only and do not contribute additional semantic information.

Marking them as decorative prevents assistive technologies from announcing redundant icon content and keeps focus on the intended button labels.

## Changes

File modified:

`hushh-webapp/components/ui/carousel.tsx`

Changes:

* Add `aria-hidden="true"` to `ArrowLeft` in `CarouselPrevious`
* Add `aria-hidden="true"` to `ArrowRight` in `CarouselNext`

## Why This Is Safe

* No visual changes
* No behavior changes
* No API changes
* No keyboard interaction changes
* No focus management changes
* No layout changes

The accessible names remain unchanged because they are already provided by the existing `sr-only` text.

## Pattern

Matches established accessibility improvements that suppress decorative icons from the accessibility tree.

Also aligns with existing navigation patterns where directional icons are hidden and accessible names are provided separately.

## Validation

* TypeScript passes
* ESLint passes
* Single-file change
* Two additive attribute additions only

## Checklist

* [x] Accessibility improvement
* [x] Additive-only change
* [x] No behavior changes
* [x] No visual changes
* [x] No API changes
* [x] Single file modified
* [x] Accessible names already provided via existing sr-only text
