### PR TITLE
a11y(sidebar): hide decorative PanelLeftIcon from assistive technology

### DIFF
--- a/hushh-webapp/components/ui/sidebar.tsx
+++ b/hushh-webapp/components/ui/sidebar.tsx
@@ -273,7 +273,7 @@ function SidebarTrigger({
       }}
       {...props}
     >
-      <PanelLeftIcon />
+      <PanelLeftIcon aria-hidden="true" />
       <span className="sr-only">Toggle Sidebar</span>
     </Button>
   )


### PR DESCRIPTION
## Summary

Adds `aria-hidden="true"` to the decorative `PanelLeftIcon` rendered inside `SidebarTrigger`.

## Motivation

`SidebarTrigger` already exposes its accessible name through the existing screen-reader-only text:

```tsx
<span className="sr-only">Toggle Sidebar</span>
```

The `PanelLeftIcon` serves only as a visual affordance and does not provide information beyond the button's existing accessible label.

Marking the icon as decorative prevents assistive technologies from announcing redundant icon content while preserving the existing button semantics.

## Changes

File modified:

`hushh-webapp/components/ui/sidebar.tsx`

Change:

* Add `aria-hidden="true"` to `PanelLeftIcon` inside `SidebarTrigger`

## Why This Is Safe

* No visual changes
* No behavior changes
* No API changes
* No keyboard interaction changes
* No focus changes
* No layout changes

The button's accessible name continues to come entirely from the existing screen-reader-only text.

## Pattern

Matches existing accessibility improvements that suppress decorative SVG icons when equivalent accessible text is already provided elsewhere.

## Validation

* TypeScript passes
* ESLint passes
* Single file modified
* One additive attribute only

## Checklist

* [x] Accessibility improvement
* [x] Additive-only change
* [x] No behavior changes
* [x] No visual changes
* [x] No API changes
* [x] Single file modified
* [x] Existing accessible label preserved
* [x] Decorative icon hidden from assistive technology
