### PR TITLE
Fix One Location request key readiness

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -2113,7 +2113,12 @@ class OneLocationAgentService:
         )
 
     def _recipient_key_row(
-        self, *, recipient_user_id: str, recipient_key_id: str | None = None
+        self,
+        *,
+        recipient_user_id: str,
+        recipient_key_id: str | None = None,
+        require_phone_verified: bool = True,
+        unavailable_message: str | None = None,
     ) -> dict[str, Any]:
         row = self._execute_one(
             """
@@ -2123,18 +2128,23 @@ class OneLocationAgentService:
             FROM actor_identity_cache a
             JOIN one_location_recipient_keys k ON k.user_id = a.user_id
             WHERE a.user_id = :recipient_user_id
-              AND a.phone_verified = TRUE
+              AND (:require_phone_verified IS FALSE OR a.phone_verified = TRUE)
               AND k.status = 'active'
               AND (:recipient_key_id IS NULL OR k.key_id = :recipient_key_id)
             ORDER BY k.created_at DESC
             LIMIT 1
             """,
-            {"recipient_user_id": recipient_user_id, "recipient_key_id": recipient_key_id},
+            {
+                "recipient_user_id": recipient_user_id,
+                "recipient_key_id": recipient_key_id,
+                "require_phone_verified": require_phone_verified,
+            },
         )
         if not row:
             raise OneLocationAgentError(
                 "LOCATION_RECIPIENT_UNAVAILABLE",
-                "Choose a verified recipient who has location key material ready.",
+                unavailable_message
+                or "Choose a verified recipient who has location key material ready.",
                 status_code=409,
             )
         return row
@@ -2147,6 +2157,7 @@ class OneLocationAgentService:
         recipient_key_id: str | None,
         duration_hours: float,
         reason: str | None = None,
+        require_recipient_phone_verified: bool = True,
     ) -> dict[str, Any]:
         if owner_user_id == recipient_user_id:
             raise OneLocationAgentError(
@@ -2163,7 +2174,9 @@ class OneLocationAgentService:
                 status_code=422,
             ) from exc
         recipient = self._recipient_key_row(
-            recipient_user_id=recipient_user_id, recipient_key_id=recipient_key_id
+            recipient_user_id=recipient_user_id,
+            recipient_key_id=recipient_key_id,
+            require_phone_verified=require_recipient_phone_verified,
         )
         owner_identity = self._identity_row(owner_user_id)
         owner_label = _identity_display_label(owner_identity)
@@ -2936,7 +2949,14 @@ class OneLocationAgentService:
             raise OneLocationAgentError(
                 "LOCATION_REQUEST_SELF", "Request a different person's location.", status_code=422
             )
-        self._recipient_key_row(recipient_user_id=requester_user_id)
+        self._recipient_key_row(
+            recipient_user_id=requester_user_id,
+            require_phone_verified=False,
+            unavailable_message=(
+                "Your One Location key is still setting up. Refresh this page once, "
+                "then send the request again."
+            ),
+        )
         message_value = (message or "").strip()[:500] or None
         row = self._execute_one(
             """
@@ -3056,6 +3076,7 @@ class OneLocationAgentService:
             recipient_key_id=None,
             duration_hours=duration_hours,
             reason="request_approved",
+            require_recipient_phone_verified=False,
         )
         resolved = self._execute_one(
             """

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -223,10 +223,16 @@ class FourUserMemoryService(OneLocationAgentService):
             matches = [key for key in matches if key["key_id"] == key_id]
         return matches[-1] if matches else None
 
-    def _identity_key_row(self, user_id: str, key_id: str | None = None) -> dict | None:
+    def _identity_key_row(
+        self,
+        user_id: str,
+        key_id: str | None = None,
+        *,
+        require_phone_verified: bool = True,
+    ) -> dict | None:
         identity = self.identities.get(user_id)
         key = self._active_key(user_id, key_id)
-        if not identity or not identity["phone_verified"] or not key:
+        if not identity or (require_phone_verified and not identity["phone_verified"]) or not key:
             return None
         return {
             **identity,
@@ -638,7 +644,9 @@ class FourUserMemoryService(OneLocationAgentService):
             return row
         if "JOIN one_location_recipient_keys k" in sql:
             return self._identity_key_row(
-                params["recipient_user_id"], params.get("recipient_key_id")
+                params["recipient_user_id"],
+                params.get("recipient_key_id"),
+                require_phone_verified=bool(params.get("require_phone_verified", True)),
             )
         if "INSERT INTO one_location_share_grants" in sql:
             grant_id = str(uuid.uuid4())
@@ -1254,6 +1262,7 @@ def test_four_user_location_workflow_contract() -> None:
             key_id=f"key-{user_id}",
             public_key_jwk={"kty": "EC", "crv": "P-256", "x": user_id, "y": user_id},
         )
+    service.identities[user_c]["phone_verified"] = False
 
     grant_b = service.create_grant(
         owner_user_id=user_a,
@@ -1274,6 +1283,15 @@ def test_four_user_location_workflow_contract() -> None:
         service.view_latest_envelope(recipient_user_id=user_c, grant_id=grant_b["id"])
     assert denied_c.value.code == "LOCATION_GRANT_NOT_FOUND"
 
+    with pytest.raises(OneLocationAgentError) as unverified_share:
+        service.create_grant(
+            owner_user_id=user_a,
+            recipient_user_id=user_c,
+            recipient_key_id=f"key-{user_c}",
+            duration_hours=1,
+        )
+    assert unverified_share.value.code == "LOCATION_RECIPIENT_UNAVAILABLE"
+
     direct_request_c = service.request_access(
         requester_user_id=user_c,
         owner_user_id=user_a,
@@ -1286,6 +1304,21 @@ def test_four_user_location_workflow_contract() -> None:
     )
     assert duplicate_request_c["id"] == direct_request_c["id"]
     assert duplicate_request_c["message"] == "Can you share where you are now?"
+
+    approved_c = service.approve_request(
+        owner_user_id=user_a,
+        request_id=direct_request_c["id"],
+        duration_hours=1,
+    )
+    grant_c = approved_c["grant"]
+    assert grant_c["recipientUserId"] == user_c
+    service.store_encrypted_envelope(
+        owner_user_id=user_a,
+        grant_id=grant_c["id"],
+        envelope=encrypted_envelope(f"key-{user_c}", "ciphertext-for-c"),
+    )
+    viewed_c = service.view_latest_envelope(recipient_user_id=user_c, grant_id=grant_c["id"])
+    assert viewed_c["envelope"]["ciphertext"] == "ciphertext-for-c"
 
     referral_response = service.refer_recipient(
         referring_user_id=user_b,

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -1025,7 +1025,7 @@ describe("OneLocationAgentPage", () => {
     await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-    fireEvent.click(screen.getByRole("button", { name: "request" }));
+    fireEvent.click(screen.getByRole("tab", { name: "request" }));
     fireEvent.click(screen.getByRole("button", { name: /Send Request/i }));
 
     await waitFor(() => expect(mockRequestAccess).toHaveBeenCalledTimes(1));
@@ -1084,7 +1084,7 @@ describe("OneLocationAgentPage", () => {
     await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-    fireEvent.click(screen.getByRole("button", { name: "request" }));
+    fireEvent.click(screen.getByRole("tab", { name: "request" }));
     fireEvent.click(
       screen.getByRole("button", {
         name: /Select Investor D from One Network/i,

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -612,6 +612,18 @@ function oneLocationErrorMessage(error: unknown, fallback: string): string {
   return error instanceof Error ? error.message : fallback;
 }
 
+function oneLocationRequestErrorMessage(error: unknown, fallback: string): string {
+  const message = oneLocationErrorMessage(error, fallback);
+  const normalized = message.toLowerCase();
+  if (
+    normalized.includes("verified recipient") &&
+    normalized.includes("location key material")
+  ) {
+    return "Your One Location key is still setting up. Refresh this page once, then send the request again.";
+  }
+  return message;
+}
+
 function isLocationPointStale(point: PlainLocationPoint): boolean {
   const capturedAt = new Date(point.capturedAt).getTime();
   if (!Number.isFinite(capturedAt)) return false;
@@ -896,10 +908,16 @@ function SegmentedModeControl({
   onChange: (value: ShareMode) => void;
 }) {
   return (
-    <div className="flex h-9 w-full min-w-0 max-w-full items-center overflow-hidden rounded-[9px] bg-[#efeff0] p-[3px] dark:bg-white/10">
+    <div
+      aria-label="Choose location sharing mode"
+      className="flex h-9 w-full min-w-0 max-w-full items-center overflow-hidden rounded-[9px] bg-[#efeff0] p-[3px] dark:bg-white/10"
+      role="tablist"
+    >
       {(["share", "request"] as const).map((mode) => (
         <button
           key={mode}
+          aria-selected={value === mode}
+          role="tab"
           type="button"
           onClick={() => onChange(mode)}
           className={cn(
@@ -1097,7 +1115,7 @@ function readinessCopy(permission: HushhLocationPermissionState | null): {
 
 function OneLocationInitialSkeleton() {
   return (
-    <div className="grid gap-6 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
+    <div className="space-y-6">
       <div className="space-y-6">
         <SettingsGroup eyebrow="Device" title="Readiness">
           <SkeletonRow />
@@ -2602,12 +2620,29 @@ function OneLocationAgentPageContent() {
 
   const handleRequestAccess = useCallback(async () => {
     if (!vaultOwnerToken || !selectedRequestOwners.length) return;
+    if (!auth.user || !auth.userId) {
+      toast.error("Refresh your session before sending a location request.");
+      return;
+    }
+    const activeUser = auth.user;
+    const activeUserId = auth.userId;
+    const activeVaultOwnerToken = vaultOwnerToken;
     setBusy("request");
     let successCount = 0;
     try {
+      await AccountIdentityService.syncCurrentUser(activeUser).catch((error) => {
+        console.warn("[OneLocation] Failed to sync account identity before request:", error);
+      });
+      const key = await ensureLocationRecipientKey(activeUserId);
+      await OneLocationService.registerRecipientKey({
+        vaultOwnerToken: activeVaultOwnerToken,
+        keyId: key.keyId,
+        publicKeyJwk: key.publicKeyJwk,
+        algorithm: key.algorithm,
+      });
       for (const owner of selectedRequestOwners) {
         await OneLocationService.requestAccess({
-          vaultOwnerToken,
+          vaultOwnerToken: activeVaultOwnerToken,
           ownerUserId: owner.userId,
           message: requestMessage.trim() || undefined,
         });
@@ -2641,14 +2676,14 @@ function OneLocationAgentPageContent() {
         failure_count: failureCount,
         has_note: Boolean(requestMessage.trim()),
       });
-      toast.error(oneLocationErrorMessage(error, "Could not send request."));
+      toast.error(oneLocationRequestErrorMessage(error, "Could not send request."));
       if (isTransientOneApiError(error)) {
         await refresh().catch(() => null);
       }
     } finally {
       setBusy(null);
     }
-  }, [refresh, requestMessage, selectedRequestOwners, vaultOwnerToken]);
+  }, [auth.user, auth.userId, refresh, requestMessage, selectedRequestOwners, vaultOwnerToken]);
 
   const handleCreatePublicInvite = useCallback(async () => {
     if (!vaultOwnerToken) return;
@@ -3197,7 +3232,7 @@ function OneLocationAgentPageContent() {
       width="standard"
       nativeTest={nativeTestConfig}
     >
-      <AppPageHeaderRegion className="mx-auto w-full max-w-[1120px] min-w-0 overflow-hidden">
+      <AppPageHeaderRegion className="mx-auto w-full max-w-[860px] min-w-0 overflow-hidden">
         <div className="flex flex-col gap-4 px-1 pt-3 sm:flex-row sm:items-end sm:justify-between">
           <header className="max-w-[560px] min-w-0 space-y-2">
             <span className="text-[11px] font-bold uppercase tracking-[0.22em] text-[#007aff] dark:text-[#76b7ff]">
@@ -3231,7 +3266,7 @@ function OneLocationAgentPageContent() {
         </div>
       </AppPageHeaderRegion>
 
-      <AppPageContentRegion className="mx-auto w-full max-w-[1120px] min-w-0 space-y-6 overflow-x-hidden pb-10 sm:pb-8">
+      <AppPageContentRegion className="mx-auto w-full max-w-[860px] min-w-0 space-y-6 overflow-x-hidden pb-10 sm:pb-8">
         {loadError ? (
           <div className="rounded-[20px] border border-[#ff3b30]/30 bg-[#ff3b30]/10 p-4 text-sm text-[#ff3b30] dark:text-[#ff9f9a]">
             {loadError}
@@ -3241,7 +3276,7 @@ function OneLocationAgentPageContent() {
         {showInitialSkeleton ? (
           <OneLocationInitialSkeleton />
         ) : (
-          <div className="grid min-w-0 max-w-full gap-6 xl:grid-cols-[minmax(0,520px)_minmax(0,1fr)] xl:items-start">
+          <div className="flex min-w-0 max-w-full flex-col gap-6">
             <div className="min-w-0 max-w-full space-y-7">
               <section className="min-w-0 max-w-full space-y-2 px-1">
                 {sectionLabel("Device readiness")}
@@ -3416,7 +3451,7 @@ function OneLocationAgentPageContent() {
                   </div>
                 </div>
 
-                <div className="min-w-0 max-w-full space-y-3">
+                <div className="flex min-w-0 max-w-full flex-col gap-3">
                   <div className="relative">
                     <Search className="absolute left-3.5 top-1/2 h-5 w-5 -translate-y-1/2 text-[#8e8e93]" />
                     <input
@@ -3599,7 +3634,7 @@ function OneLocationAgentPageContent() {
                     </Button>
                   ) : null}
 
-                  <div>
+                  <div className="order-first min-w-0 max-w-full overflow-hidden rounded-[18px] border border-black/[0.04] bg-white/80 p-3.5 shadow-sm dark:border-white/[0.08] dark:bg-white/[0.06]">
                     {activeMode === "share" ? (
                       <div className="space-y-3">
                       <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_160px]">


### PR DESCRIPTION
## Summary
- allow One Location request/approval flow to validate requester key readiness without requiring phone verification
- keep direct owner share recipient verification strict
- re-register the requester location key before sending access requests

## Verification
- cd consent-protocol && .\\.venv\\Scripts\\python.exe -m pytest tests/test_one_location_routes.py tests/services/test_one_location_agent_service.py -q
- cd hushh-webapp && npm test -- __tests__/components/one-location-agent-page.test.tsx __tests__/services/location-agent-service.test.ts --runInBand
- cd hushh-webapp && npm run typecheck
- cd hushh-webapp && npm run lint
- cd hushh-webapp && npm run verify:docs
- cd hushh-webapp && npm run build