### PR TITLE
Remove One Location request key preflight friction

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -2669,6 +2669,7 @@ class OneLocationAgentService:
                     owner_user_id=owner_user_id,
                     message=message_value or f"Public request from {display_name}",
                     notify_owner=False,
+                    require_requester_key_material=True,
                 )
                 status_value = "matched_request_pending"
             except OneLocationAgentError as exc:
@@ -2944,19 +2945,17 @@ class OneLocationAgentService:
         message: str | None = None,
         referred_by_user_id: str | None = None,
         notify_owner: bool = True,
+        require_requester_key_material: bool = False,
     ) -> dict[str, Any]:
         if requester_user_id == owner_user_id:
             raise OneLocationAgentError(
                 "LOCATION_REQUEST_SELF", "Request a different person's location.", status_code=422
             )
-        self._recipient_key_row(
-            recipient_user_id=requester_user_id,
-            require_phone_verified=False,
-            unavailable_message=(
-                "Your One Location key is still setting up. Refresh this page once, "
-                "then send the request again."
-            ),
-        )
+        if require_requester_key_material:
+            self._recipient_key_row(
+                recipient_user_id=requester_user_id,
+                require_phone_verified=False,
+            )
         message_value = (message or "").strip()[:500] or None
         row = self._execute_one(
             """

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -1372,6 +1372,35 @@ def test_four_user_location_workflow_contract() -> None:
     assert "longitude" not in serialized_state
 
 
+def test_location_request_creation_does_not_require_requester_key_material() -> None:
+    service = FourUserMemoryService()
+    service.register_recipient_key(
+        user_id="user_a",
+        key_id="key-user_a",
+        public_key_jwk={"kty": "EC", "crv": "P-256", "x": "user_a", "y": "user_a"},
+    )
+
+    request = service.request_access(
+        requester_user_id="user_c",
+        owner_user_id="user_a",
+        message="Can I see your location?",
+    )
+
+    assert request["ownerUserId"] == "user_a"
+    assert request["requesterUserId"] == "user_c"
+    assert request["status"] == "pending"
+
+    with pytest.raises(OneLocationAgentError) as missing_key:
+        service.create_grant(
+            owner_user_id="user_a",
+            recipient_user_id="user_c",
+            recipient_key_id=None,
+            duration_hours=1,
+            require_recipient_phone_verified=False,
+        )
+    assert missing_key.value.code == "LOCATION_RECIPIENT_UNAVAILABLE"
+
+
 def test_one_location_activity_summary_uses_existing_metadata_events() -> None:
     service = FourUserMemoryService()
 

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -612,18 +612,6 @@ function oneLocationErrorMessage(error: unknown, fallback: string): string {
   return error instanceof Error ? error.message : fallback;
 }
 
-function oneLocationRequestErrorMessage(error: unknown, fallback: string): string {
-  const message = oneLocationErrorMessage(error, fallback);
-  const normalized = message.toLowerCase();
-  if (
-    normalized.includes("verified recipient") &&
-    normalized.includes("location key material")
-  ) {
-    return "Your One Location key is still setting up. Refresh this page once, then send the request again.";
-  }
-  return message;
-}
-
 function isLocationPointStale(point: PlainLocationPoint): boolean {
   const capturedAt = new Date(point.capturedAt).getTime();
   if (!Number.isFinite(capturedAt)) return false;
@@ -2633,13 +2621,22 @@ function OneLocationAgentPageContent() {
       await AccountIdentityService.syncCurrentUser(activeUser).catch((error) => {
         console.warn("[OneLocation] Failed to sync account identity before request:", error);
       });
-      const key = await ensureLocationRecipientKey(activeUserId);
-      await OneLocationService.registerRecipientKey({
-        vaultOwnerToken: activeVaultOwnerToken,
-        keyId: key.keyId,
-        publicKeyJwk: key.publicKeyJwk,
-        algorithm: key.algorithm,
-      });
+      await (async () => {
+        try {
+          const key = await ensureLocationRecipientKey(activeUserId);
+          await OneLocationService.registerRecipientKey({
+            vaultOwnerToken: activeVaultOwnerToken,
+            keyId: key.keyId,
+            publicKeyJwk: key.publicKeyJwk,
+            algorithm: key.algorithm,
+          });
+        } catch (error) {
+          console.warn(
+            "[OneLocation] Continuing request after key sync failed:",
+            error,
+          );
+        }
+      })();
       for (const owner of selectedRequestOwners) {
         await OneLocationService.requestAccess({
           vaultOwnerToken: activeVaultOwnerToken,
@@ -2676,7 +2673,7 @@ function OneLocationAgentPageContent() {
         failure_count: failureCount,
         has_note: Boolean(requestMessage.trim()),
       });
-      toast.error(oneLocationRequestErrorMessage(error, "Could not send request."));
+      toast.error(oneLocationErrorMessage(error, "Could not send request."));
       if (isTransientOneApiError(error)) {
         await refresh().catch(() => null);
       }


### PR DESCRIPTION
## Summary
- let signed-in One Location requests be created without blocking on requester recipient-key preflight
- keep public invite intake key-gated so identity_pending_key still works
- make request-page key registration best-effort instead of a blocking toast

## Verification
- cd consent-protocol && .\\.venv\\Scripts\\python.exe -m pytest tests/test_one_location_routes.py tests/services/test_one_location_agent_service.py -q
- cd hushh-webapp && npm test -- __tests__/components/one-location-agent-page.test.tsx __tests__/services/location-agent-service.test.ts --runInBand
- cd hushh-webapp && npm run typecheck
- cd hushh-webapp && npm run lint
- cd hushh-webapp && npm run verify:docs
- cd hushh-webapp && npm run build