### PR TITLE
Polish One Location app-user sharing copy

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -1213,7 +1213,7 @@ class OneLocationAgentService:
                 self._add_recommendation_reason(
                     signal,
                     code="location_key_ready",
-                    label="Ready for encrypted location sharing",
+                    label="Ready for location sharing",
                     weight=28,
                 )
             else:
@@ -1275,7 +1275,7 @@ class OneLocationAgentService:
                 tier = "setup_needed"
                 trust_level = "setup_needed"
                 category_label = "Needs setup"
-                summary = "They need to open One Location once before encrypted sharing."
+                summary = "They need to open One Location once before sharing."
             elif signal.get("needs_action"):
                 category = "needs_action"
                 tier = "needs_action"
@@ -1299,7 +1299,7 @@ class OneLocationAgentService:
                 tier = "available"
                 trust_level = "new"
                 category_label = "Location ready"
-                summary = "Verified KAI member with recipient encryption ready."
+                summary = "Verified One member ready for location sharing."
 
             enriched.append(
                 {
@@ -2144,7 +2144,7 @@ class OneLocationAgentService:
             raise OneLocationAgentError(
                 "LOCATION_RECIPIENT_UNAVAILABLE",
                 unavailable_message
-                or "Choose a verified recipient who has location key material ready.",
+                or "Choose someone marked One Network, or ask them to open One Location once.",
                 status_code=409,
             )
         return row

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -1006,7 +1006,9 @@ describe("OneLocationAgentPage", () => {
     );
 
     expect(
-      await screen.findByText(/need One Location setup before private sharing/i),
+      await screen.findByText(
+        /need to open One Location once before private sharing/i,
+      ),
     ).toBeTruthy();
     const shareButton = screen.getByRole("button", {
       name: /Review Share/i,

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -291,8 +291,8 @@ function recipientRecommendationLine(recipient: OneLocationRecipient): string {
     recipient.recommendationSummary ||
     visibleRecommendationReasons(recipient)[0]?.label ||
     (recipient.canReceiveLocation
-      ? "Ready for encrypted location access"
-      : "Needs a recipient key")
+      ? "Ready for private location sharing"
+      : "Needs to open One Location once")
   );
 }
 
@@ -1096,7 +1096,7 @@ function readinessCopy(permission: HushhLocationPermissionState | null): {
     description:
       permission.precise === false
         ? "Sharing can continue, but accuracy may be approximate on this device."
-        : "Foreground location is ready for encrypted sharing.",
+        : "Foreground location is ready for private sharing.",
     tone: permission.precise === false ? "warning" : "ready",
   };
 }
@@ -2214,7 +2214,7 @@ function OneLocationAgentPageContent() {
     ) => {
       if (!vaultOwnerToken) throw new Error("Vault owner token required.");
       if (!recipient.publicKeyJwk || !recipient.keyId) {
-        throw new Error("Recipient key unavailable.");
+        throw new Error("They need to open One Location once before private sharing can start.");
       }
       const point =
         pointOverride ?? (await OneLocationService.captureCurrentPosition());
@@ -2326,7 +2326,7 @@ function OneLocationAgentPageContent() {
     async (grant: OneLocationGrant) => {
       const recipient = recipientForGrant(grant);
       if (!recipient) {
-        toast.error("Recipient key unavailable for this active share.");
+        toast.error("This share needs the recipient to open One Location once.");
         return;
       }
       setBusy("publish");
@@ -2383,7 +2383,7 @@ function OneLocationAgentPageContent() {
           toast.error(
             error instanceof Error
               ? error.message
-              : "Could not view encrypted location.",
+              : "Could not view this private location update.",
           );
         } else {
           console.warn(
@@ -2837,7 +2837,7 @@ function OneLocationAgentPageContent() {
         (recipient) => recipient.userId === request.requesterUserId,
       );
       if (!requester?.keyId || !requester.publicKeyJwk) {
-        toast.error("Requester key unavailable.");
+        toast.error("They need to open One Location once before approval can finish.");
         return;
       }
       setBusy("approve");
@@ -3702,15 +3702,15 @@ function OneLocationAgentPageContent() {
                           {peopleCountLabel(
                             setupNeededSelectedRecipients.length,
                           )}{" "}
-                          need One Location setup before private sharing can
-                          start.
+                          need to open One Location once before private sharing
+                          can start.
                         </div>
                       ) : null}
                       <p className="text-[12px] font-medium text-[#8e8e93] dark:text-white/55">
                         {selectedShareRecipients.length
                           ? `${peopleCountLabel(
                               selectedShareRecipients.length,
-                            )} selected for private encrypted sharing.`
+                            )} selected for private sharing.`
                           : "Select one or more One users for private sharing."}
                       </p>
                       {shareReviewOpen ? (
@@ -3727,7 +3727,7 @@ function OneLocationAgentPageContent() {
                               {peopleCountLabel(
                                 shareReadySelectedRecipients.length,
                               )}{" "}
-                              will receive separate encrypted location access
+                              will receive separate private location access
                               for{" "}
                               {
                                 DURATION_OPTIONS.find(


### PR DESCRIPTION
Promotes the final One Location app-user friction cleanup to main.\n\nChanges:\n- Remove key/encryption jargon from normal share/request recipient messaging.\n- Keep request flow frictionless for signed-in app users.\n- Preserve public location link behavior.\n\nLocal verification:\n- consent-protocol pytest tests/test_one_location_routes.py tests/services/test_one_location_agent_service.py -q\n- hushh-webapp npm test -- __tests__/components/one-location-agent-page.test.tsx __tests__/services/location-agent-service.test.ts --runInBand\n- hushh-webapp npm run typecheck\n- hushh-webapp npm run lint\n- hushh-webapp npm run verify:docs\n- hushh-webapp npm run build