### PR TITLE
test(observability): reject email values in action field

### DIFF
--- a/hushh-webapp/__tests__/services/observability-schema.test.ts
+++ b/hushh-webapp/__tests__/services/observability-schema.test.ts
@@ -185,4 +185,18 @@ describe("observability schema", () => {
     expect(result.sanitized.resource_class).toBe("pkm_projection");
     expect(result.sanitized.freshness).toBe("fresh");
   });
+    it("drops allowed keys when values contain email addresses", () => {
+    const result = validateAndSanitizeEvent("auth_failed", {
+      env: "uat",
+      platform: "web",
+      event_category: "system",
+      app_version: "2.1.0",
+      action: "kai@example.com",
+      result: "error",
+    } as any);
+
+    expect(result.ok).toBe(false);
+    expect(result.droppedKeys).toContain("action");
+    expect(result.sanitized).not.toHaveProperty("action");
+  });
 });


### PR DESCRIPTION
## Summary

Adds a focused observability schema test verifying that email-like values are rejected from allowed metadata fields.

## Changes

- Add coverage for email-address values in the `action` field.
- Verify the schema drops the field during sanitization.
- Verify the event is marked invalid when sensitive data is detected.

## Validation

- pnpm exec vitest run __tests__/services/observability-schema.test.ts