### PR TITLE
test(observability): reject secret-like action values

### DIFF
--- a/hushh-webapp/__tests__/services/observability-schema.test.ts
+++ b/hushh-webapp/__tests__/services/observability-schema.test.ts
@@ -185,4 +185,18 @@ describe("observability schema", () => {
     expect(result.sanitized.resource_class).toBe("pkm_projection");
     expect(result.sanitized.freshness).toBe("fresh");
   });
+    it("drops allowed keys when values look like opaque secrets", () => {
+    const result = validateAndSanitizeEvent("auth_failed", {
+      env: "uat",
+      platform: "web",
+      event_category: "system",
+      app_version: "2.1.0",
+      action: "ABCDEFGHIJKLMNOPQRSTUVWXYZ123456",
+      result: "error",
+    } as any);
+
+    expect(result.ok).toBe(false);
+    expect(result.droppedKeys).toContain("action");
+    expect(result.sanitized).not.toHaveProperty("action");
+  });
 });


### PR DESCRIPTION
## Summary

Adds focused observability schema coverage for secret-like metadata values.

## Changes

- Add coverage for opaque secret-like values in the action field.
- Verify the schema rejects the value.
- Verify the field is removed during sanitization.

## Validation

- pnpm exec vitest run __tests__/services/observability-schema.test.ts