### PR TITLE
test(observability): preserve bounded metadata values

### DIFF
--- a/hushh-webapp/__tests__/services/observability-schema.test.ts
+++ b/hushh-webapp/__tests__/services/observability-schema.test.ts
@@ -185,4 +185,18 @@ describe("observability schema", () => {
     expect(result.sanitized.resource_class).toBe("pkm_projection");
     expect(result.sanitized.freshness).toBe("fresh");
   });
+    it("preserves short bounded metadata values", () => {
+    const result = validateAndSanitizeEvent("auth_failed", {
+      env: "uat",
+      platform: "web",
+      event_category: "system",
+      app_version: "2.1.0",
+      action: "google",
+      result: "error",
+      error_class: "auth_failed",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.sanitized.action).toBe("google");
+  });
 });


### PR DESCRIPTION
## Summary

Adds focused observability schema coverage for bounded metadata values.

## Changes

- verifies short bounded metadata values are preserved during sanitization
- confirms valid action metadata remains available after schema validation
- validates successful sanitization for a governed observability event

## Validation

- pnpm exec vitest run __tests__/services/observability-schema.test.ts