### PR TITLE
fix(ui): add missing A11y focus rings to Sonner close button for keyboard accessibility

### DIFF
--- a/hushh-webapp/components/ui/sonner.tsx
+++ b/hushh-webapp/components/ui/sonner.tsx
@@ -39,7 +39,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
             "line-clamp-2 text-[12px] leading-5 text-muted-foreground text-center sm:text-left",
           content: "flex-1 gap-1.5 text-center sm:text-left",
           closeButton:
-            "left-auto right-3 top-3 border-border/70 bg-background/90 text-muted-foreground hover:bg-muted hover:text-foreground",
+            "left-auto right-3 top-3 border-border/70 bg-background/90 text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
         },
       }}
       style={


### PR DESCRIPTION
The `Sonner` Toast notification component featured a WCAG accessibility violation. 

The custom `closeButton` styles lacked explicit keyboard focus states (`focus-visible:ring`). When a keyboard user tabs into the toast notification to dismiss it, they would receive no visible indication that the close button was currently focused, making it extremely difficult to navigate the UI via keyboard. 

By injecting standard `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring` utilities, we restore the necessary focus halo, ensuring the close button is fully keyboard accessible.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None specifically (generic UI component)
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None (Pure UI Primitive)
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable
- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — generic UI Sonner component.
- [x] Reachable production attach point: components/ui/sonner.tsx
- [x] Production surface proved: explicit A11y CSS utility fix, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/ui/sonner.tsx)
- [x] **iOS**: Not applicable — Web CSS Focus States
- [x] **Android**: Not applicable — Web CSS Focus States

## 🧪 Testing

- [x] Tested on Web (Verified Sonner close button correctly renders a focus ring when navigated to via keyboard tab, restoring WCAG keyboard accessibility)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Restores missing `focus-visible` styling to the Sonner close button.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed