### PR TITLE
test(phone-mandate): verify verified phone detection

### DIFF
--- a/hushh-webapp/__tests__/services/phone-mandate-service.test.ts
+++ b/hushh-webapp/__tests__/services/phone-mandate-service.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { hasVerifiedPhoneNumber } from "@/lib/services/phone-mandate-service";
+
+describe("hasVerifiedPhoneNumber", () => {
+  it("accepts populated phone numbers", () => {
+    expect(hasVerifiedPhoneNumber("+16505550101")).toBe(true);
+    expect(hasVerifiedPhoneNumber(" 123 ")).toBe(true);
+  });
+
+  it("rejects empty values", () => {
+    expect(hasVerifiedPhoneNumber("")).toBe(false);
+    expect(hasVerifiedPhoneNumber(null)).toBe(false);
+    expect(hasVerifiedPhoneNumber(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds focused coverage for verified phone number detection.

## Changes

* Verify populated phone numbers are treated as verified.
* Verify empty, null, and undefined values are not treated as verified.

## Validation

* `pnpm exec vitest run __tests__/services/phone-mandate-service.test.ts`
