### PR TITLE
fix(observability): freeze web transport payloads

### DIFF
--- a/hushh-webapp/__tests__/services/observability-web-transport.test.ts
+++ b/hushh-webapp/__tests__/services/observability-web-transport.test.ts
@@ -66,6 +66,7 @@ describe("web observability transport", () => {
         app_version: "2.1.0",
       },
     ]);
+    expect(Object.isFrozen(window.dataLayer?.[0])).toBe(true);
     expect(window.gtag).toHaveBeenCalledTimes(1);
     expect(window.gtag).toHaveBeenCalledWith(
       "event",
@@ -81,6 +82,7 @@ describe("web observability transport", () => {
         app_version: "2.1.0",
       }
     );
+    expect(Object.isFrozen(window.gtag.mock.calls[0]?.[2])).toBe(true);
   });
 
   it("pushes to GTM and still sends direct GA4 when a real container is configured", async () => {
@@ -109,6 +111,7 @@ describe("web observability transport", () => {
         app_version: "2.1.0",
       },
     ]);
+    expect(Object.isFrozen(window.dataLayer?.[0])).toBe(true);
     expect(window.gtag).toHaveBeenCalledTimes(1);
     expect(window.gtag).toHaveBeenCalledWith(
       "event",
@@ -124,5 +127,6 @@ describe("web observability transport", () => {
         app_version: "2.1.0",
       }
     );
+    expect(Object.isFrozen(window.gtag.mock.calls[0]?.[2])).toBe(true);
   });
 });

--- a/hushh-webapp/lib/observability/adapters/web-gtm.ts
+++ b/hushh-webapp/lib/observability/adapters/web-gtm.ts
@@ -16,10 +16,6 @@ declare global {
   }
 }
 
-function freezeTransportPayload<T extends Record<string, unknown>>(payload: T): T {
-  return Object.freeze(payload);
-}
-
 export const webGtmAdapter: ObservabilityAdapter = {
   name: "web-gtm",
 
@@ -34,7 +30,9 @@ export const webGtmAdapter: ObservabilityAdapter = {
     if (typeof window === "undefined") return;
 
     window.dataLayer = window.dataLayer || [];
-    const transportPayload = freezeTransportPayload({
+    // Freeze the outbound payload so downstream GTM/dataLayer consumers cannot
+    // mutate it after we hand it off (telemetry immutability at the transport edge).
+    const transportPayload = Object.freeze({
       event: eventName,
       event_source: "observability_v2",
       ...payload,
@@ -47,7 +45,7 @@ export const webGtmAdapter: ObservabilityAdapter = {
     }
 
     if (typeof window.gtag === "function") {
-      const gtagPayload = freezeTransportPayload({
+      const gtagPayload = Object.freeze({
         send_to: measurementId,
         event_source: "observability_v2",
         ...payload,

--- a/hushh-webapp/lib/observability/adapters/web-gtm.ts
+++ b/hushh-webapp/lib/observability/adapters/web-gtm.ts
@@ -16,6 +16,10 @@ declare global {
   }
 }
 
+function freezeTransportPayload<T extends Record<string, unknown>>(payload: T): T {
+  return Object.freeze(payload);
+}
+
 export const webGtmAdapter: ObservabilityAdapter = {
   name: "web-gtm",
 
@@ -30,11 +34,11 @@ export const webGtmAdapter: ObservabilityAdapter = {
     if (typeof window === "undefined") return;
 
     window.dataLayer = window.dataLayer || [];
-    const transportPayload = {
+    const transportPayload = freezeTransportPayload({
       event: eventName,
       event_source: "observability_v2",
       ...payload,
-    };
+    });
     window.dataLayer.push(transportPayload);
 
     const measurementId = resolveAnalyticsMeasurementId();
@@ -43,11 +47,12 @@ export const webGtmAdapter: ObservabilityAdapter = {
     }
 
     if (typeof window.gtag === "function") {
-      window.gtag("event", eventName, {
+      const gtagPayload = freezeTransportPayload({
         send_to: measurementId,
         event_source: "observability_v2",
         ...payload,
       });
+      window.gtag("event", eventName, gtagPayload);
     }
   },
 };


### PR DESCRIPTION
## Overview
Narrows the original telemetry immutability proposal to the existing web observability transport path. Instead of adding a reusable exported deep-freeze utility, this patch freezes the outbound GTM/dataLayer and GA4 gtag payload objects inside the real webGtmAdapter before transport.

## Risk Narrowing
- Removed the standalone freeze utility export.
- Removed the standalone utility-only test file.
- Kept the behavior attached to the canonical adapter: hushh-webapp/lib/observability/adapters/web-gtm.ts.
- Moved proof into the existing web transport contract: hushh-webapp/__tests__/services/observability-web-transport.test.ts.

## Impact
This is a bounded observability transport hardening. It does not add a new public helper, route, package export, backend caller, dependency, UI surface, or parallel telemetry runtime.

## Verification
- cd hushh-webapp && npm run test:ci -- __tests__/services/observability-web-transport.test.ts
- cd hushh-webapp && npm run typecheck
- cd hushh-webapp && npm run verify:docs
- cd hushh-webapp && npm run verify:service-boundary
- cd hushh-webapp && npm run lint -- --max-warnings=0