### PR TITLE
fix(ui): suppress decorative icon from assistive technology in radio-group component

### DIFF
--- a/hushh-webapp/components/ui/radio-group.tsx
+++ b/hushh-webapp/components/ui/radio-group.tsx
@@ -36,7 +36,7 @@ function RadioGroupItem({
         data-slot="radio-group-indicator"
         className="flex items-center justify-center"
       >
-        <CircleIcon className="fill-primary size-2" />
+        <CircleIcon className="fill-primary size-2" aria-hidden="true" />
       </RadioGroupPrimitive.Indicator>
     </RadioGroupPrimitive.Item>
   )


### PR DESCRIPTION
The `RadioGroup` component featured an accessibility bug where the purely decorative inner `CircleIcon` was not explicitly hidden from screen readers. 

By adding `aria-hidden="true"` to the SVG icon, we ensure assistive technologies do not attempt to read out meaningless "circle" or "graphic" elements when focusing on the radio group item. This perfectly mirrors the explicit decorative icon suppression we previously merged for the `Checkbox` component.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None specifically (generic UI component)
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None (Pure UI Primitive)
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable
- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — generic UI RadioGroup component.
- [x] Reachable production attach point: components/ui/radio-group.tsx
- [x] Production surface proved: explicit A11y SVG suppression fix, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/ui/radio-group.tsx)
- [x] **iOS**: Not applicable — Web Accessibility Tree
- [x] **Android**: Not applicable — Web Accessibility Tree

## 🧪 Testing

- [x] Tested on Web (Verified the RadioGroup correctly suppresses its internal `CircleIcon` graphic from assistive technologies)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Suppresses decorative inner circle icon from assistive technology to prevent redundant screen reader announcements.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed