### PR TITLE
test(phone-mandate): verify phone masking behavior

### DIFF
--- a/hushh-webapp/__tests__/services/phone-mandate-service.test.ts
+++ b/hushh-webapp/__tests__/services/phone-mandate-service.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { maskPhoneNumber } from "@/lib/services/phone-mandate-service";
+
+describe("maskPhoneNumber", () => {
+  it("preserves the last four digits", () => {
+    const masked = maskPhoneNumber("+1 (650) 555-0101");
+
+    expect(masked).toContain("0101");
+    expect(masked).not.toContain("6505550101");
+  });
+
+  it("returns short values unchanged", () => {
+    expect(maskPhoneNumber("1234")).toBe("1234");
+  });
+
+  it("returns empty string for empty values", () => {
+    expect(maskPhoneNumber("")).toBe("");
+    expect(maskPhoneNumber(null)).toBe("");
+    expect(maskPhoneNumber(undefined)).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

Adds focused coverage for phone number masking behavior.

## Changes

* Verify masked phone numbers preserve only the last four digits.
* Verify short phone values are returned unchanged.
* Verify empty, null, and undefined values return an empty string.

## Validation

* `pnpm exec vitest run __tests__/services/phone-mandate-service.test.ts`
