### PR TITLE
test(phone-mandate): verify phone mandate route detection

### DIFF
--- a/hushh-webapp/__tests__/services/phone-mandate-service.test.ts
+++ b/hushh-webapp/__tests__/services/phone-mandate-service.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { ROUTES } from "@/lib/navigation/routes";
+import { isPhoneMandatePath } from "@/lib/services/phone-mandate-service";
+
+describe("isPhoneMandatePath", () => {
+  it("detects the phone mandate route", () => {
+    expect(
+      isPhoneMandatePath(
+        ROUTES.PHONE_MANDATE
+      )
+    ).toBe(true);
+  });
+
+  it("rejects non-phone-mandate routes", () => {
+    expect(
+      isPhoneMandatePath("/kai")
+    ).toBe(false);
+
+    expect(
+      isPhoneMandatePath(null)
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds focused coverage for phone mandate route detection.

## Changes

- Verify the phone mandate route is correctly identified.
- Verify unrelated routes are not treated as phone mandate routes.
- Verify null values are handled safely.

## Validation

- pnpm exec vitest run __tests__/services/phone-mandate-service.test.ts