### PR TITLE
fix(ui): suppress decorative icons from assistive technology in carousel component

### DIFF
--- a/hushh-webapp/components/ui/carousel.tsx
+++ b/hushh-webapp/components/ui/carousel.tsx
@@ -200,7 +200,7 @@ function CarouselPrevious({
       onClick={scrollPrev}
       {...props}
     >
-      <ArrowLeft />
+      <ArrowLeft aria-hidden="true" />
       <span className="sr-only">Previous slide</span>
     </Button>
   )
@@ -230,7 +230,7 @@ function CarouselNext({
       onClick={scrollNext}
       {...props}
     >
-      <ArrowRight />
+      <ArrowRight aria-hidden="true" />
       <span className="sr-only">Next slide</span>
     </Button>
   )


### PR DESCRIPTION
The `Carousel` component featured accessibility bugs where purely decorative inner SVG icons (`ArrowLeft`, `ArrowRight`) were not explicitly hidden from screen readers. 

By adding `aria-hidden="true"` to these SVG icons, we ensure assistive technologies do not announce redundant "arrow" graphics alongside the `.sr-only` descriptive text spans. This continues our initiative of explicit decorative icon suppression across generic UI primitives.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None specifically (generic UI component)
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None (Pure UI Primitive)
  

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — generic UI Carousel component.
- [x] Reachable production attach point: components/ui/carousel.tsx
- [x] Production surface proved: explicit A11y SVG suppression fix, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/ui/carousel.tsx)
- [x] **iOS**: Not applicable — Web Accessibility Tree
- [x] **Android**: Not applicable — Web Accessibility Tree

## 🧪 Testing

- [x] Tested on Web (Verified the Carousel correctly suppresses its internal decorative graphics from assistive technologies)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Suppresses decorative inner icons from assistive technology to prevent redundant screen reader announcements.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none