### PR TITLE
test(phone-mandate): verify mandate requirement fallback

### DIFF
--- a/hushh-webapp/__tests__/services/phone-mandate-service.test.ts
+++ b/hushh-webapp/__tests__/services/phone-mandate-service.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldRequirePhoneMandate } from "@/lib/services/phone-mandate-service";
+
+describe("shouldRequirePhoneMandate", () => {
+  it("requires a mandate when no bypass conditions apply", () => {
+    expect(
+      shouldRequirePhoneMandate({
+        hasVault: false,
+      })
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds focused coverage for the default phone mandate requirement behavior.

## Changes

- Verify a phone mandate is required when no bypass conditions apply.
- Validate the fallback decision path for users without exemptions.

## Validation

- pnpm exec vitest run __tests__/services/phone-mandate-service.test.ts