### PR TITLE
fix(ui): suppress decorative icons from assistive technology in sidebar component

### DIFF
--- a/hushh-webapp/components/ui/sidebar.tsx
+++ b/hushh-webapp/components/ui/sidebar.tsx
@@ -273,7 +273,7 @@ function SidebarTrigger({
       }}
       {...props}
     >
-      <PanelLeftIcon />
+      <PanelLeftIcon aria-hidden="true" />
       <span className="sr-only">Toggle Sidebar</span>
     </Button>
   )


### PR DESCRIPTION
The `Sidebar` component featured an accessibility bug where the purely decorative inner SVG icon (`PanelLeftIcon`) within the `SidebarTrigger` was not explicitly hidden from screen readers. 

By adding `aria-hidden="true"` to this SVG icon, we ensure assistive technologies do not announce redundant "panel left" graphics alongside the `.sr-only` descriptive text "Toggle Sidebar". This continues our initiative of explicit decorative icon suppression across generic UI primitives.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None specifically (generic UI component)
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None (Pure UI Primitive)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface — generic UI Sidebar component.
- [x] Reachable production attach point: components/ui/sidebar.tsx
- [x] Production surface proved: explicit A11y SVG suppression fix, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (components/ui/sidebar.tsx)
- [x] **iOS**: Not applicable — Web Accessibility Tree
- [x] **Android**: Not applicable — Web Accessibility Tree

## 🧪 Testing

- [x] Tested on Web (Verified the Sidebar correctly suppresses its internal decorative graphics from assistive technologies)ice
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Suppresses decorative inner icons from assistive technology to prevent redundant screen reader announcements.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed