### PR TITLE
feat(consent-center): inline strict zero-value fallback inside normalizeConsentEntry

### DIFF
--- a/hushh-webapp/__tests__/services/consent-center-service.test.ts
+++ b/hushh-webapp/__tests__/services/consent-center-service.test.ts
@@ -203,9 +203,9 @@ describe("normalizeConsentEntry — local-override precedence matrix", () => {
 describe("normalizeConsentEntry - zero-value fallback", () => {
   beforeEach(() => { vi.clearAllMocks(); });
 
-  const expectZeroValueConsentEntry = (item: unknown) => {
+  const expectZeroValueConsentEntry = (item: unknown, index: number) => {
     expect(item).toMatchObject({
-      id: "zero-value-consent-entry",
+      id: `zero-value-consent-entry-${index}`,
       kind: "history",
       status: "revoked",
       active: false,
@@ -230,9 +230,13 @@ describe("normalizeConsentEntry - zero-value fallback", () => {
     });
 
     expect(items).toHaveLength(3);
-    for (const item of items) {
-      expectZeroValueConsentEntry(item);
-    }
+    expect(items.map((item) => item.id)).toEqual([
+      "zero-value-consent-entry-0",
+      "zero-value-consent-entry-1",
+      "zero-value-consent-entry-2",
+    ]);
+    expect(new Set(items).size).toBe(items.length);
+    items.forEach((item, index) => expectZeroValueConsentEntry(item, index));
   });
 
   it("returns an immutable revoked entry for an undefined runtime payload", async () => {
@@ -259,6 +263,6 @@ describe("normalizeConsentEntry - zero-value fallback", () => {
     });
 
     expect(items).toHaveLength(1);
-    expectZeroValueConsentEntry(items[0]);
+    expectZeroValueConsentEntry(items[0], 0);
   });
 });

--- a/hushh-webapp/__tests__/services/consent-center-service.test.ts
+++ b/hushh-webapp/__tests__/services/consent-center-service.test.ts
@@ -200,3 +200,65 @@ describe("normalizeConsentEntry — local-override precedence matrix", () => {
   });
 });
 // ── End override-precedence proof ─────────────────────────────────────────────
+describe("normalizeConsentEntry - zero-value fallback", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  const expectZeroValueConsentEntry = (item: unknown) => {
+    expect(item).toMatchObject({
+      id: "zero-value-consent-entry",
+      kind: "history",
+      status: "revoked",
+      active: false,
+      granted: false,
+      action: "deny",
+      counterpart_type: "self",
+      metadata: {
+        fallback_reason: "empty_consent_entry",
+      },
+    });
+    expect(Object.isFrozen(item)).toBe(true);
+    expect(Object.isFrozen((item as { metadata?: unknown }).metadata)).toBe(true);
+  };
+
+  it("returns immutable revoked entries for empty or null consent payloads", async () => {
+    mockApiFetch.mockResolvedValueOnce(listResponse([{}, null, undefined]));
+
+    const { items } = await ConsentCenterService.listEntries({
+      idToken: "tok",
+      userId: "u-1",
+      surface: "active",
+    });
+
+    expect(items).toHaveLength(3);
+    for (const item of items) {
+      expectZeroValueConsentEntry(item);
+    }
+  });
+
+  it("returns an immutable revoked entry for an undefined runtime payload", async () => {
+    mockApiFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        user_id: "u-1",
+        actor: "investor",
+        mode: "consents",
+        surface: "active",
+        query: "",
+        page: 1,
+        limit: 20,
+        total: 1,
+        has_more: false,
+        items: [undefined],
+      }),
+    } as unknown as Response);
+
+    const { items } = await ConsentCenterService.listEntries({
+      idToken: "tok",
+      userId: "u-1",
+      surface: "active",
+    });
+
+    expect(items).toHaveLength(1);
+    expectZeroValueConsentEntry(items[0]);
+  });
+});

--- a/hushh-webapp/lib/services/consent-center-service.ts
+++ b/hushh-webapp/lib/services/consent-center-service.ts
@@ -261,7 +261,30 @@ interface ErrorPayload {
   error?: string;
 }
 
-function normalizeConsentEntry(entry: ConsentCenterEntry): ConsentCenterEntry {
+const ZERO_VALUE_CONSENT_ENTRY = Object.freeze({
+  id: "zero-value-consent-entry",
+  kind: "history",
+  status: "revoked",
+  active: false,
+  granted: false,
+  action: "deny",
+  counterpart_type: "self",
+  metadata: Object.freeze({
+    fallback_reason: "empty_consent_entry",
+  }),
+} satisfies ConsentCenterEntry);
+
+function isConsentEntryRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeConsentEntry(entry: unknown): ConsentCenterEntry {
+  if (!isConsentEntryRecord(entry) || Object.keys(entry).length === 0) {
+    return ZERO_VALUE_CONSENT_ENTRY;
+  }
+
+  const consentEntry = entry as unknown as ConsentCenterEntry;
+
   // ── Local-override precedence matrix (inline) ─────────────────────────────
   // When entry.active is an explicit boolean it carries a local user decision
   // that must bypass every system-derived inference, including the
@@ -274,31 +297,37 @@ function normalizeConsentEntry(entry: ConsentCenterEntry): ConsentCenterEntry {
   //
   // Only when active is absent (undefined) does execution fall through to the
   // original normalization logic — preserving backward compatibility.
-  if (typeof entry.active === "boolean") {
-    if (entry.active) {
-      const status = ["approved", "active", "granted"].includes(entry.status)
-        ? entry.status
-        : entry.kind === "active_grant"
+  if (typeof consentEntry.active === "boolean") {
+    if (consentEntry.active) {
+      const status = ["approved", "active", "granted"].includes(consentEntry.status)
+        ? consentEntry.status
+        : consentEntry.kind === "active_grant"
         ? "active"
         : "approved";
-      return { ...entry, status };
+      return { ...consentEntry, status };
     }
     // Explicit local revocation — return entry as-is, no promotion.
-    return entry;
+    return consentEntry;
   }
   // ── End override matrix ───────────────────────────────────────────────────
 
   const normalized = normalizeConsentResponse({
-    active: entry.active,
-    granted: entry.granted,
-    status: entry.status,
-    permissions: entry.existing_granted_scopes || undefined,
-    scopes: entry.scope ? [entry.scope] : undefined,
+    active: consentEntry.active,
+    granted: consentEntry.granted,
+    status: consentEntry.status,
+    permissions: consentEntry.existing_granted_scopes || undefined,
+    scopes: consentEntry.scope ? [consentEntry.scope] : undefined,
   });
-  if (normalized.isGranted && !["approved", "active", "granted"].includes(entry.status)) {
-    return { ...entry, status: entry.kind === "active_grant" ? "active" : "approved" };
+  if (
+    normalized.isGranted &&
+    !["approved", "active", "granted"].includes(consentEntry.status)
+  ) {
+    return {
+      ...consentEntry,
+      status: consentEntry.kind === "active_grant" ? "active" : "approved",
+    };
   }
-  return entry;
+  return consentEntry;
 }
 
 function normalizeConsentEntries(entries: ConsentCenterEntry[] | undefined): ConsentCenterEntry[] {

--- a/hushh-webapp/lib/services/consent-center-service.ts
+++ b/hushh-webapp/lib/services/consent-center-service.ts
@@ -261,26 +261,31 @@ interface ErrorPayload {
   error?: string;
 }
 
-const ZERO_VALUE_CONSENT_ENTRY = Object.freeze({
-  id: "zero-value-consent-entry",
-  kind: "history",
-  status: "revoked",
-  active: false,
-  granted: false,
-  action: "deny",
-  counterpart_type: "self",
-  metadata: Object.freeze({
-    fallback_reason: "empty_consent_entry",
-  }),
-} satisfies ConsentCenterEntry);
+const ZERO_VALUE_CONSENT_ENTRY_ID = "zero-value-consent-entry";
+const EMPTY_CONSENT_ENTRY_REASON = "empty_consent_entry";
+
+function buildZeroValueConsentEntry(index = 0): ConsentCenterEntry {
+  return Object.freeze({
+    id: `${ZERO_VALUE_CONSENT_ENTRY_ID}-${index}`,
+    kind: "history",
+    status: "revoked",
+    active: false,
+    granted: false,
+    action: "deny",
+    counterpart_type: "self",
+    metadata: Object.freeze({
+      fallback_reason: EMPTY_CONSENT_ENTRY_REASON,
+    }),
+  } satisfies ConsentCenterEntry);
+}
 
 function isConsentEntryRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function normalizeConsentEntry(entry: unknown): ConsentCenterEntry {
+function normalizeConsentEntry(entry: unknown, index = 0): ConsentCenterEntry {
   if (!isConsentEntryRecord(entry) || Object.keys(entry).length === 0) {
-    return ZERO_VALUE_CONSENT_ENTRY;
+    return buildZeroValueConsentEntry(index);
   }
 
   const consentEntry = entry as unknown as ConsentCenterEntry;
@@ -331,7 +336,9 @@ function normalizeConsentEntry(entry: unknown): ConsentCenterEntry {
 }
 
 function normalizeConsentEntries(entries: ConsentCenterEntry[] | undefined): ConsentCenterEntry[] {
-  return Array.isArray(entries) ? entries.map(normalizeConsentEntry) : [];
+  return Array.isArray(entries)
+    ? entries.map((entry, index) => normalizeConsentEntry(entry, index))
+    : [];
 }
 
 export class ConsentCenterService {


### PR DESCRIPTION
﻿## Overview
Adds an inline fail-closed guard at the entry point of `normalizeConsentEntry`. Empty, null, or undefined consent payloads now normalize to an immutable zero-value consent entry before any grant inference can run.

## Impact
Low risk: the change is localized to consent-center entry normalization and preserves existing active/granted behavior for valid entries. High impact: malformed structural payloads now fail closed into a revoked, non-granted state instead of risking runtime errors or accidental status promotion.

## Changes Cleared
- Added explicit object/null/array validation before consent normalization.
- Added empty-object fallback handling.
- Added immutable zero-value consent entry with `active: false`, `granted: false`, and `status: "revoked"`.
- Preserved existing local active override behavior for valid entries.
- Added `listEntries` regression coverage for `{}`, `null`, and runtime `undefined` consent entry payloads.

## Verification
- `npm run test:ci -- __tests__/services/consent-center-service.test.ts`
- `npm run typecheck`
- `npm run verify:docs`
- `npm run verify:service-boundary`

## Notes
- `npm run verify:routes` was attempted locally but requires maintainer-only `REVIEWER_UID` and `REVIEWER_VAULT_PASSPHRASE` values in this environment.
