### PR TITLE
fix(ui): prevent aria-hidden from swallowing sr-only text in ellipsis components

### DIFF
--- a/hushh-webapp/components/ui/breadcrumb.tsx
+++ b/hushh-webapp/components/ui/breadcrumb.tsx
@@ -85,12 +85,10 @@ function BreadcrumbEllipsis({
   return (
     <span
       data-slot="breadcrumb-ellipsis"
-      role="presentation"
-      aria-hidden="true"
       className={cn("flex size-9 items-center justify-center", className)}
       {...props}
     >
-      <MoreHorizontal className="size-4" />
+      <MoreHorizontal className="size-4" aria-hidden="true" />
       <span className="sr-only">More</span>
     </span>
   )

--- a/hushh-webapp/components/ui/pagination.tsx
+++ b/hushh-webapp/components/ui/pagination.tsx
@@ -121,12 +121,11 @@ function PaginationEllipsis({
 }: React.ComponentProps<"span">) {
   return (
     <span
-      aria-hidden
       data-slot="pagination-ellipsis"
       className={cn("flex size-9 items-center justify-center", className)}
       {...props}
     >
-      <MoreHorizontalIcon className="size-4" />
+      <MoreHorizontalIcon className="size-4" aria-hidden="true" />
       <span className="sr-only">More pages</span>
     </span>
   )


### PR DESCRIPTION
The `BreadcrumbEllipsis` and `PaginationEllipsis` components featured a critical accessibility bug where `aria-hidden="true"` was placed on the wrapper `span` element. 

Because this wrapper also contained the `.sr-only` descriptive text ("More" and "More pages"), screen readers were forced to completely skip reading the descriptive text, rendering the ellipsis entirely silent to assistive technologies. By removing `aria-hidden="true"` and `role="presentation"` from the wrappers and applying `aria-hidden="true"` directly to the decorative SVG icons instead, we ensure screen readers properly announce the sr-only text.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None specifically (generic UI components)
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None (Pure UI Primitives)
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable
- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes current reachable app surfaces — generic UI components.
- [x] Reachable production attach point: `components/ui/{breadcrumb,pagination}.tsx`
- [x] Production surface proved: explicit A11y sr-only restoration, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation
- [x] **iOS**: Not applicable — Web Accessibility Tree
- [x] **Android**: Not applicable — Web Accessibility Tree

## 🧪 Testing

- [x] Tested on Web (Verified the affected UI components correctly announce their `.sr-only` content to screen readers)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Prevents `aria-hidden` from swallowing nested `.sr-only` descriptive text on ellipsis components.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed