### PR TITLE
feat(consent): inline structural type validation guard inside normalizeConsentResponse

### DIFF
--- a/hushh-webapp/__tests__/utils/normalize-consent.test.ts
+++ b/hushh-webapp/__tests__/utils/normalize-consent.test.ts
@@ -64,6 +64,14 @@ describe("normalizeConsentResponse", () => {
       expect(call({ scopes: { 0: "vault:read" } })).toStrictEqual(DENY);
     });
 
+    it("rejects permissions arrays containing non-string values", () => {
+      expect(call({ permissions: ["profile:read", 42, null] })).toStrictEqual(DENY);
+    });
+
+    it("rejects scopes arrays containing non-string values", () => {
+      expect(call({ scopes: ["vault:read", false, {}] })).toStrictEqual(DENY);
+    });
+
     it("rejects array top-level payload (not a plain object)", () => {
       expect(call([{ active: true }])).toStrictEqual(DENY);
     });

--- a/hushh-webapp/src/lib/consent/normalizeConsent.ts
+++ b/hushh-webapp/src/lib/consent/normalizeConsent.ts
@@ -14,6 +14,10 @@ export interface NormalizedConsentState {
 /** Closed fallback returned whenever structural integrity cannot be confirmed. */
 const DENY_STATE: NormalizedConsentState = { isGranted: false, permissions: [] };
 
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
 export function normalizeConsentResponse(
   response: RawConsentResponse | null | undefined
 ): NormalizedConsentState {
@@ -43,8 +47,8 @@ export function normalizeConsentResponse(
       (own("active")      && typeof r["active"]      !== "boolean") ||
       (own("granted")     && typeof r["granted"]     !== "boolean") ||
       (own("status")      && r["status"] !== null    && typeof r["status"] !== "string") ||
-      (own("permissions") && !Array.isArray(r["permissions"])) ||
-      (own("scopes")      && !Array.isArray(r["scopes"]))
+      (own("permissions") && !isStringArray(r["permissions"])) ||
+      (own("scopes")      && !isStringArray(r["scopes"]))
     ) {
       return DENY_STATE;
     }


### PR DESCRIPTION
## Overview

This PR tightens the existing structural guard inside `normalizeConsentResponse` so upstream consent responses must preserve expected primitive schema patterns before grant mapping runs. It extends the current default-deny behavior to reject malformed permission and scope arrays that contain non-string values.

## Impact

This is a low-risk consent hardening change because it is isolated to the existing normalization entrypoint and its focused unit tests. The behavior remains fail-closed: structurally mismatched upstream values are substituted with the safe fallback state of `isGranted: false` and an empty permissions list.

## Changes Cleared

- Hardened `permissions` validation to require an array of strings.
- Hardened `scopes` validation to require an array of strings.
- Added regression tests for mixed-type permission and scope arrays.
- Preserved existing valid consent response behavior.

## Validation

- `npm run test:ci -- __tests__/utils/normalize-consent.test.ts`
- `npm run typecheck`
- `npm run verify:service-boundary`
- `npm run verify:docs`
- `python -m pytest tests/test_granular_scopes.py -q`
- `python -m pytest tests/test_ria_iam_routes.py -q`