### PR TITLE
Polish mobile auth and One Location layouts

### DIFF
--- a/hushh-webapp/__tests__/app/register-phone-safe-area.contract.test.ts
+++ b/hushh-webapp/__tests__/app/register-phone-safe-area.contract.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 describe("/register-phone safe-area shell contract", () => {
-  it("uses dynamic viewport height and native safe-area padding variables", () => {
+  it("uses centered dynamic viewport height and native safe-area padding variables", () => {
     const source = readFileSync(
       join(process.cwd(), "app/register-phone/page.tsx"),
       "utf8",
@@ -14,9 +14,13 @@ describe("/register-phone safe-area shell contract", () => {
     expect(source).toContain("--phone-mandate-safe-pb");
     expect(source).toContain("var(--app-safe-area-top-effective");
     expect(source).toContain("var(--app-safe-area-bottom-effective");
-    expect(source).toContain("min-h-[100dvh]");
+    expect(source).toContain("h-[100dvh]");
+    expect(source).toContain("min-h-[100svh]");
+    expect(source).toContain("justify-center");
+    expect(source).toContain("overflow-hidden");
     expect(source).toContain("pt-[var(--phone-mandate-safe-pt)]");
     expect(source).toContain("pb-[var(--phone-mandate-safe-pb)]");
+    expect(source).not.toContain("min-h-[24rem]");
     expect(source).not.toContain("4vh");
   });
 });

--- a/hushh-webapp/__tests__/components/auth-step-layout.contract.test.ts
+++ b/hushh-webapp/__tests__/components/auth-step-layout.contract.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+describe("AuthStep layout contract", () => {
+  it("keeps the login controls centered without page scroll on mobile viewports", () => {
+    const source = readFileSync(
+      join(process.cwd(), "components/onboarding/AuthStep.tsx"),
+      "utf8",
+    );
+
+    expect(source).toContain("h-[100dvh]");
+    expect(source).toContain("min-h-[100svh]");
+    expect(source).toContain("overflow-hidden");
+    expect(source).toContain("justify-center");
+    expect(source).toContain("bottom-[calc(20px+var(--app-screen-footer-pad))]");
+    expect(source).not.toContain("mt-auto flex-none pt-8");
+    expect(source).not.toContain("min-h-[100dvh]");
+  });
+});

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -990,7 +990,7 @@ describe("OneLocationAgentPage", () => {
       expect.objectContaining({
         route_id: "one_location",
         action: "share",
-        selection_surface: "quick_circle",
+        selection_surface: "section_list",
         selected_count: 2,
       }),
       expect.any(Object),

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -1113,22 +1113,6 @@ function OneLocationInitialSkeleton() {
           <Skeleton className="h-full flex-1 rounded-[7px] opacity-60" />
         </div>
 
-        <div className="space-y-2">
-          {sectionLabel("One Network")}
-          <div className="flex gap-4 overflow-hidden px-1 pb-2 pt-1">
-            {Array.from({ length: 5 }).map((_, index) => (
-              <div
-                key={index}
-                className="flex w-[68px] shrink-0 flex-col items-center gap-2"
-              >
-                <Skeleton className="h-[52px] w-[52px] rounded-full" />
-                <Skeleton className="h-3 w-12 rounded-full" />
-                <Skeleton className="h-3 w-16 rounded-md" />
-              </div>
-            ))}
-          </div>
-        </div>
-
         <Skeleton className="h-10 w-full rounded-[14px]" />
 
         <div className={onePanelClassName}>
@@ -3446,78 +3430,8 @@ function OneLocationAgentPageContent() {
                   onChange={setActiveMode}
                 />
 
-                <div className="min-w-0 max-w-full space-y-2">
-                  {sectionLabel("One Network")}
-                  <div className="flex max-w-full gap-4 overflow-x-auto overscroll-x-contain px-1 pb-2 pt-1 [scrollbar-width:thin] [&::-webkit-scrollbar]:h-2 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-black/20 dark:[&::-webkit-scrollbar-thumb]:bg-white/20">
-                    {rankedRecipients.length ? (
-                      rankedRecipients.map((recipient, index) => {
-                        const label = displayNameFromRecipient(recipient);
-                        const selected =
-                          activeMode === "share"
-                            ? selectedRecipientIds.includes(recipient.userId)
-                            : selectedRequestOwnerIds.includes(
-                                recipient.userId,
-                              );
-                        return (
-                          <button
-                            key={recipient.userId}
-                            type="button"
-                            aria-label={`Select ${recipientLabel(
-                              recipient,
-                            )} from One Network`}
-                            onClick={() => {
-                              if (activeMode === "share") {
-                                toggleShareRecipient(recipient.userId);
-                              } else {
-                                toggleRequestOwner(recipient.userId);
-                              }
-                            }}
-                            className="flex shrink-0 flex-col items-center gap-1.5"
-                          >
-                            <span className="relative">
-                              <AvatarBubble label={label} index={index} />
-                              <span
-                                className={cn(
-                                  "absolute bottom-0 right-0 flex h-[18px] w-[18px] items-center justify-center rounded-full border border-black/5 bg-white shadow-sm dark:border-white/10 dark:bg-[#2c2c2e]",
-                                  selected && "ring-2 ring-[#007aff]/30",
-                                )}
-                              >
-                                {selected ? (
-                                  <CheckCircle2 className="h-3 w-3 text-[#2e7d32] dark:text-emerald-300" />
-                                ) : recipient.canReceiveLocation ? (
-                                  <ShieldCheck className="h-3 w-3 text-[#8e8e93] dark:text-white/55" />
-                                ) : (
-                                  <AlertTriangle className="h-3 w-3 text-[#ff9500]" />
-                                )}
-                              </span>
-                            </span>
-                            <span className="max-w-[68px] truncate text-[12px] font-medium text-[#1c1c1e] dark:text-white">
-                              {label}
-                            </span>
-                            <span
-                              className={cn(
-                                "max-w-[88px] truncate rounded-md px-1.5 py-0.5 text-[9px] font-bold uppercase",
-                                recommendationToneClassName(
-                                  recipient.recommendationTier,
-                                ),
-                              )}
-                            >
-                              {recommendationTierLabel(
-                                recipient.recommendationTier,
-                              )}
-                            </span>
-                          </button>
-                        );
-                      })
-                    ) : (
-                      <p className="text-[13px] text-[#8e8e93] dark:text-white/55">
-                        One Network recommendations will appear here.
-                      </p>
-                    )}
-                  </div>
-                </div>
-
                 <div className="flex min-w-0 max-w-full flex-col gap-3">
+                  {sectionLabel("One Network")}
                   <div className="relative">
                     <Search className="absolute left-3.5 top-1/2 h-5 w-5 -translate-y-1/2 text-[#8e8e93]" />
                     <input
@@ -3634,6 +3548,9 @@ function OneLocationAgentPageContent() {
                               ) : (
                                 <button
                                   type="button"
+                                  aria-label={`Select ${recipientLabel(
+                                    recipient,
+                                  )} from One Network`}
                                   onClick={() => {
                                     if (activeMode === "share") {
                                       toggleShareRecipient(

--- a/hushh-webapp/app/register-phone/page.tsx
+++ b/hushh-webapp/app/register-phone/page.tsx
@@ -22,9 +22,9 @@ import { shouldBypassPhoneMandateForLocalhost } from "@/lib/services/phone-manda
 const FLOW_SHELL_STYLE = {
   "--page-top-local-offset": "0px",
   "--phone-mandate-safe-pt":
-    "calc(var(--app-safe-area-top-effective, env(safe-area-inset-top, 0px)) + 3rem)",
+    "calc(var(--app-safe-area-top-effective, env(safe-area-inset-top, 0px)) + 1.25rem)",
   "--phone-mandate-safe-pb":
-    "calc(var(--app-safe-area-bottom-effective, env(safe-area-inset-bottom, 0px)) + 2.5rem)",
+    "calc(var(--app-safe-area-bottom-effective, env(safe-area-inset-bottom, 0px)) + 1.25rem)",
 } as CSSProperties;
 
 function requiresVaultUnlockForRedirect(path?: string | null): boolean {
@@ -121,7 +121,7 @@ function PhoneMandatePageContent() {
     <FullscreenFlowShell
       as="main"
       width="narrow"
-      className="min-h-[100dvh] px-6 pb-[var(--phone-mandate-safe-pb)] pt-[var(--phone-mandate-safe-pt)]"
+      className="h-[100dvh] min-h-[100svh] justify-center overflow-hidden px-6 pb-[var(--phone-mandate-safe-pb)] pt-[var(--phone-mandate-safe-pt)]"
       style={FLOW_SHELL_STYLE}
     >
       <NativeRouteMarker
@@ -162,7 +162,7 @@ function PhoneMandatePageContent() {
           onCompleted={continueToNextRoute}
           onContinueExisting={continueToNextRoute}
           confirmLabel="Verify and continue"
-          className="mt-8 min-h-[24rem] gap-5"
+          className="mt-8 gap-5"
         />
 
         <div id="recaptcha-container" className="mt-6 min-h-0" />

--- a/hushh-webapp/components/onboarding/AuthStep.tsx
+++ b/hushh-webapp/components/onboarding/AuthStep.tsx
@@ -524,7 +524,7 @@ export function AuthStep({
 
   return (
     <main
-      className="min-h-[100dvh] w-full bg-white text-[#1d1d1f] dark:bg-[#000000] dark:text-[#f5f5f7]"
+      className="h-[100dvh] min-h-[100svh] w-full overflow-hidden bg-white text-[#1d1d1f] dark:bg-[#000000] dark:text-[#f5f5f7]"
       data-testid="auth-step-primary"
     >
       <NativeTestBeacon
@@ -553,67 +553,69 @@ export function AuthStep({
       <div
         className={
           compact
-            ? "mx-auto flex min-h-[100dvh] w-full max-w-[27rem] flex-col px-6 pt-[calc(24px+var(--app-safe-area-top-effective,0px))] pb-[calc(24px+var(--app-screen-footer-pad))]"
-            : "mx-auto flex min-h-[100dvh] w-full max-w-[27rem] flex-col px-6 pt-[calc(48px+var(--app-safe-area-top-effective,0px))] pb-[calc(28px+var(--app-screen-footer-pad))]"
+            ? "relative mx-auto flex h-full min-h-0 w-full max-w-[27rem] flex-col justify-center px-6 pb-[calc(54px+var(--app-screen-footer-pad))] pt-[calc(24px+var(--app-safe-area-top-effective,0px))]"
+            : "relative mx-auto flex h-full min-h-0 w-full max-w-[27rem] flex-col justify-center px-6 pb-[calc(58px+var(--app-screen-footer-pad))] pt-[calc(32px+var(--app-safe-area-top-effective,0px))]"
         }
       >
-        <header className="flex-none text-center">
-          <Image
-            src="/one-quiet-emoji.png"
-            alt="One"
-            width={48}
-            height={48}
-            priority
-            className="mx-auto h-12 w-12 object-contain drop-shadow-[0_14px_28px_rgba(0,0,0,0.08)]"
-          />
-          <div
-            role="heading"
-            aria-level={1}
-            aria-label="Sign in to One"
-            className={`mt-2.5 ${kaiAppHeroTitleClassName} text-[#1d1d1f] dark:text-[#f5f5f7]`}
-          >
-            Sign in to One.
-          </div>
-          <p className={`mx-auto mt-3 max-w-[20rem] ${kaiAppHeroBodyClassName} text-[rgba(0,0,0,0.56)] dark:text-[rgba(245,245,247,0.60)]`}>
-            Continue to your personal financial advisor.
-          </p>
-        </header>
-
-        <section
-          className={
-            compact
-              ? "flex-none pt-11"
-              : "flex-none pt-12"
-          }
-        >
-          <div className="mx-auto w-full max-w-[21.5rem] space-y-3">
-            {authOptions.map((option) => (
-              <AuthProviderButton
-                key={option.id}
-                label={option.label}
-                icon={option.icon}
-                onClick={option.onClick}
-              />
-            ))}
-
-            <p className="mx-auto max-w-[18.75rem] pt-2 text-center text-[13px] leading-[1.45] text-[#86868b] dark:text-[#8e8e93]">
-              A verified phone number is required before you continue.
+        <div className="w-full shrink-0">
+          <header className="flex-none text-center">
+            <Image
+              src="/one-quiet-emoji.png"
+              alt="One"
+              width={48}
+              height={48}
+              priority
+              className="mx-auto h-12 w-12 object-contain drop-shadow-[0_14px_28px_rgba(0,0,0,0.08)]"
+            />
+            <div
+              role="heading"
+              aria-level={1}
+              aria-label="Sign in to One"
+              className={`mt-2.5 ${kaiAppHeroTitleClassName} text-[#1d1d1f] dark:text-[#f5f5f7]`}
+            >
+              Sign in to One.
+            </div>
+            <p className={`mx-auto mt-3 max-w-[20rem] ${kaiAppHeroBodyClassName} text-[rgba(0,0,0,0.56)] dark:text-[rgba(245,245,247,0.60)]`}>
+              Continue to your personal financial advisor.
             </p>
+          </header>
 
-            {(reviewModeConfig.enabled ||
-              nativeReviewerVisible ||
-              localReviewerCredentialsAvailable ||
-              isLocalReviewerSurface) && (
-              <AuthProviderButton
-                label="Continue as Reviewer"
-                icon={<Icon icon={Shield} size="md" />}
-                onClick={handleReviewerLogin}
-              />
-            )}
-          </div>
-        </section>
+          <section
+            className={
+              compact
+                ? "flex-none pt-10"
+                : "flex-none pt-11"
+            }
+          >
+            <div className="mx-auto w-full max-w-[21.5rem] space-y-3">
+              {authOptions.map((option) => (
+                <AuthProviderButton
+                  key={option.id}
+                  label={option.label}
+                  icon={option.icon}
+                  onClick={option.onClick}
+                />
+              ))}
 
-        <footer className={compact ? "mt-auto flex-none pt-8" : "mt-auto flex-none pt-10"}>
+              <p className="mx-auto max-w-[18.75rem] pt-2 text-center text-[13px] leading-[1.45] text-[#86868b] dark:text-[#8e8e93]">
+                A verified phone number is required before you continue.
+              </p>
+
+              {(reviewModeConfig.enabled ||
+                nativeReviewerVisible ||
+                localReviewerCredentialsAvailable ||
+                isLocalReviewerSurface) && (
+                <AuthProviderButton
+                  label="Continue as Reviewer"
+                  icon={<Icon icon={Shield} size="md" />}
+                  onClick={handleReviewerLogin}
+                />
+              )}
+            </div>
+          </section>
+        </div>
+
+        <footer className="absolute inset-x-6 bottom-[calc(20px+var(--app-screen-footer-pad))] flex-none">
           <p className="mx-auto max-w-[19.5rem] text-center text-[11px] leading-[1.45] text-[#86868b] dark:text-[#8e8e93]">
             By continuing, you agree to Kai&apos;s{" "}
             <button


### PR DESCRIPTION
## Summary\n- center the login and phone verification flows for mobile/native WebView viewports\n- remove the duplicate top One Network slider while keeping the searchable One Network list\n- add layout contract coverage for login and register-phone screens\n\n## Safety\n- previous unrelated Kai UI branch heads were preserved at backup/pr-3091-kai-ui-hierarchy-before-mobile-auth-layouts and backup/pr-3091-current-before-mobile-auth-layouts\n- source scope is frontend UI/tests only\n\n## Local validation\n- npm test -- __tests__/components/auth-step-layout.contract.test.ts __tests__/app/register-phone-safe-area.contract.test.ts __tests__/components/one-location-agent-page.test.tsx --runInBand\n- npm run typecheck\n- npm run lint -- --max-warnings=0\n- npm run verify:design-system\n- npm run verify:docs\n- npm run verify:cache\n- npm run build\n- npm run cap:build\n- Playwright mobile viewport smoke for /login: iPhone SE, Android compact, iOS large, no vertical scroll