### PR TITLE
promote: Kai UI hierarchy and chrome polish

### DIFF
--- a/hushh-webapp/__tests__/voice/kai-search-bar.test.ts
+++ b/hushh-webapp/__tests__/voice/kai-search-bar.test.ts
@@ -24,7 +24,31 @@ vi.mock("lucide-react", () => ({
 }));
 
 vi.mock("@/components/kai/kai-command-palette", () => ({
-  KaiCommandPalette: () => null,
+  KaiCommandPalette: ({
+    open,
+    onVoiceClick,
+    voiceActive,
+    voiceDisabled,
+    voiceHidden,
+  }: {
+    open: boolean;
+    onVoiceClick?: (event: unknown) => void;
+    voiceActive?: boolean;
+    voiceDisabled?: boolean;
+    voiceHidden?: boolean;
+  }) =>
+    open && !voiceHidden
+      ? createElement(
+          "button",
+          {
+            type: "button",
+            "aria-label": voiceActive ? "End Kai voice" : "Start Kai voice",
+            "aria-disabled": voiceDisabled,
+            onClick: onVoiceClick,
+          },
+          "voice",
+        )
+      : null,
 }));
 
 vi.mock("@/components/kai/voice/voice-ambient-search-surface", () => ({

--- a/hushh-webapp/__tests__/voice/kai-search-bar.test.ts
+++ b/hushh-webapp/__tests__/voice/kai-search-bar.test.ts
@@ -441,8 +441,10 @@ describe("kai-search-bar helpers", () => {
     expect(screen.getByRole("button", { name: "Start RIA voice" }).getAttribute("aria-disabled")).toBe(
       "true",
     );
-    expect(screen.queryByRole("button", { name: "Open Agent" })).toBeNull();
-    expect(mockOpenAgent).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Agent" }));
+
+    expect(mockOpenAgent).toHaveBeenCalledTimes(1);
   });
 
   it("keeps Kai voice inside the compact search surface", () => {

--- a/hushh-webapp/__tests__/voice/kai-search-bar.test.ts
+++ b/hushh-webapp/__tests__/voice/kai-search-bar.test.ts
@@ -70,6 +70,12 @@ vi.mock("@/components/kai/voice/voice-debug-drawer", () => ({
   VoiceDebugDrawer: () => null,
 }));
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
 vi.mock("@/components/app-ui/shell-action-surface", () => ({
   ShellActionSurface: ({
     children,

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1372,10 +1372,10 @@ md-ripple.morphy-md-ripple {
 }
 
 .kai-bottom-nav-pill [role="radio"] svg {
-  width: 19.5px;
-  height: 19.5px;
-  opacity: 0.88;
-  stroke-width: 1.85;
+  width: 18.5px;
+  height: 18.5px;
+  opacity: 0.9;
+  stroke-width: 1.62;
   filter: drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.6));
   transform: translateY(0);
   stroke-linecap: round;
@@ -1384,7 +1384,7 @@ md-ripple.morphy-md-ripple {
 
 .kai-bottom-nav-pill [role="radio"][aria-checked="true"] svg {
   opacity: 1;
-  stroke-width: 2.15;
+  stroke-width: 1.95;
   filter: drop-shadow(0 3px 8px rgb(0 113 227 / 0.24));
   transform: translateY(-0.5px);
 }
@@ -1428,7 +1428,9 @@ md-ripple.morphy-md-ripple {
 }
 
 .kai-bottom-agent-action {
-  background: rgb(0 113 227) !important;
+  background:
+    radial-gradient(circle at 50% 18%, rgb(92 200 255 / 0.9), transparent 54%),
+    linear-gradient(180deg, rgb(0 122 255), rgb(0 102 204)) !important;
   color: rgb(255 255 255);
   box-shadow:
     0 12px 26px -18px rgb(0 113 227 / 0.75),
@@ -1436,16 +1438,19 @@ md-ripple.morphy-md-ripple {
 }
 
 .dark .kai-bottom-agent-action {
-  background: rgb(10 132 255) !important;
+  background:
+    radial-gradient(circle at 50% 18%, rgb(92 200 255 / 0.72), transparent 54%),
+    linear-gradient(180deg, rgb(10 132 255), rgb(0 102 204)) !important;
   box-shadow:
     0 12px 28px -18px rgb(10 132 255 / 0.86),
     inset 0 1px 0 rgb(255 255 255 / 0.34);
 }
 
 body:has([data-one-market-surface="true"]) .bar-glass-top {
-  --app-bar-glass-bg-light: var(--background) !important;
-  --app-bar-glass-bg-dark: rgb(28, 28, 30) !important;
+  --app-bar-glass-bg-light: transparent !important;
+  --app-bar-glass-bg-dark: transparent !important;
   --app-bar-shadow: none !important;
+  opacity: 0;
   --app-bar-fade-top-strong: transparent !important;
   --app-bar-fade-top-medium: transparent !important;
   --app-bar-fade-top-soft: transparent !important;

--- a/hushh-webapp/app/kai/onboarding/page.tsx
+++ b/hushh-webapp/app/kai/onboarding/page.tsx
@@ -313,7 +313,7 @@ function KaiOnboardingPageContent() {
     return (
       <div
         data-top-content-anchor="true"
-        className="mx-auto flex min-h-[calc(100dvh_-_var(--top-content-pad))] w-full max-w-[42rem] items-start px-5 pb-8 pt-[calc(var(--top-content-pad)_+_0.25rem)] sm:px-6 lg:px-[var(--page-inline-gutter-standard)]"
+        className="mx-auto flex min-h-[calc(100dvh_-_var(--top-content-pad))] w-full max-w-[40rem] items-start px-5 pb-8 pt-[calc(var(--top-content-pad)_+_0.25rem)] sm:px-6 lg:px-[var(--page-inline-gutter-standard)]"
       >
         <NativeTestBeacon
           routeId="/kai/onboarding"
@@ -321,8 +321,8 @@ function KaiOnboardingPageContent() {
           authState={user ? "authenticated" : "pending"}
           dataState="loaded"
         />
-        <div className="w-full space-y-6">
-          <div className="mx-auto max-w-[36rem] space-y-2.5 text-left">
+        <div className="w-full space-y-5">
+          <div className="mx-auto max-w-[34rem] space-y-2.5 text-left">
             <p className={`${kaiAppEyebrowClassName} text-primary/75`}>
               Choose your starting path
             </p>
@@ -333,13 +333,13 @@ function KaiOnboardingPageContent() {
             >
               Start as an investor or set up RIA first
             </div>
-            <p className={`max-w-[32rem] ${kaiAppBodyClassName} text-muted-foreground`}>
+            <p className={`max-w-[30rem] ${kaiAppBodyClassName} text-muted-foreground`}>
               You can add the other profile later from Profile. This choice only sets the first
               workflow we open right now.
             </p>
           </div>
 
-          <div className="mx-auto grid w-full max-w-[36rem] items-stretch gap-3.5">
+          <div className="mx-auto grid w-full max-w-[34rem] items-stretch gap-3.5">
             <Card
               preset="hero"
               variant="none"
@@ -374,7 +374,7 @@ function KaiOnboardingPageContent() {
                     setSaving(false);
                   }
                 }}
-                className="flex h-full min-h-[160px] w-full flex-col justify-between gap-5 p-5 text-left"
+                className="flex h-full min-h-[148px] w-full flex-col justify-between gap-4 p-5 text-left"
               >
                 <div className="space-y-2.5">
                   <p className="text-[10.5px] font-medium uppercase tracking-[0.16em] text-primary/75">
@@ -430,7 +430,7 @@ function KaiOnboardingPageContent() {
                     setSaving(false);
                   }
                 }}
-                className="flex h-full min-h-[160px] w-full flex-col justify-between gap-5 p-5 text-left disabled:cursor-not-allowed"
+                className="flex h-full min-h-[148px] w-full flex-col justify-between gap-4 p-5 text-left disabled:cursor-not-allowed"
               >
                 <div className="space-y-2.5">
                   <p className="text-[10.5px] font-medium uppercase tracking-[0.16em] text-primary/75">

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -1330,8 +1330,8 @@ function OneLocationOnboardingFlow({
 
             <h1
               className={cn(
-                "mt-8 max-w-[350px] text-center text-[34px] font-bold leading-[1.08] text-[#1d1d1f] sm:text-[36px] dark:text-white",
-                isPermissionStep && "max-w-[340px] text-[32px] leading-[1.1] sm:text-[34px]",
+                "mt-8 max-w-[340px] text-center text-[28px] font-medium leading-[1.1] text-[#1d1d1f] sm:text-[31px] dark:text-white",
+                isPermissionStep && "max-w-[330px] text-[27px] leading-[1.12] sm:text-[30px]",
               )}
             >
               {isPermissionStep
@@ -1341,7 +1341,7 @@ function OneLocationOnboardingFlow({
 
             {isPermissionStep ? (
               <>
-                <p className="mt-3 max-w-[340px] text-[17px] font-normal leading-[1.5] text-[#6e6e73] dark:text-white/62">
+                <p className="mt-3 max-w-[330px] text-[15.5px] font-normal leading-[1.5] text-[#6e6e73] dark:text-white/62">
                   Choose{" "}
                   <strong className="font-semibold text-[#1d1d1f] dark:text-white">
                     Allow Always
@@ -1355,7 +1355,7 @@ function OneLocationOnboardingFlow({
                 </div>
               </>
             ) : (
-              <p className="mt-3 max-w-[310px] text-[18px] leading-[1.4] text-[#6e6e73] dark:text-white/62">
+              <p className="mt-3 max-w-[310px] text-[15.5px] leading-[1.45] text-[#6e6e73] dark:text-white/62">
                 Never text "where are you?" again.
               </p>
             )}
@@ -3285,10 +3285,10 @@ function OneLocationAgentPageContent() {
       <AppPageHeaderRegion className="mx-auto w-full max-w-[540px] min-w-0 overflow-hidden">
         <div className="flex flex-col gap-4 px-1 pt-3 sm:flex-row sm:items-end sm:justify-between">
           <header className="max-w-[560px] min-w-0 space-y-2">
-            <span className="text-[11px] font-bold uppercase tracking-[0.22em] text-[#007aff] dark:text-[#76b7ff]">
+            <span className="text-[10.5px] font-medium uppercase tracking-[0.16em] text-[#007aff] dark:text-[#76b7ff]">
               When it matters most
             </span>
-            <h1 className="text-[34px] font-bold leading-[1.2] tracking-tight text-[#1c1c1e] sm:text-[42px] dark:text-white">
+            <h1 className="text-[28px] font-medium leading-[1.12] tracking-normal text-[#1c1c1e] sm:text-[32px] dark:text-white">
               Your circle, safely connected.
             </h1>
             <h2 className="sr-only">One Location Agent</h2>

--- a/hushh-webapp/app/one/location/request/[token]/page-client.tsx
+++ b/hushh-webapp/app/one/location/request/[token]/page-client.tsx
@@ -179,7 +179,7 @@ export default function PublicLocationRequestPageClient() {
               <div className="text-xs font-semibold uppercase tracking-[0.22em] text-amber-600 dark:text-amber-300">
                 One Location
               </div>
-              <h1 className="mt-2 text-3xl font-semibold tracking-normal sm:text-4xl">
+              <h1 className="mt-2 text-[28px] font-medium leading-[1.12] tracking-normal sm:text-[32px]">
                 View shared location
               </h1>
               <p className="mt-3 text-sm leading-6 text-muted-foreground">

--- a/hushh-webapp/app/register-phone/page.tsx
+++ b/hushh-webapp/app/register-phone/page.tsx
@@ -135,12 +135,12 @@ function PhoneMandatePageContent() {
           <Image
             src="/one-quiet-emoji.png"
             alt=""
-            width={48}
-            height={48}
+            width={44}
+            height={44}
             priority
             aria-hidden="true"
             draggable={false}
-            className="mx-auto h-12 w-12 select-none object-contain drop-shadow-[0_14px_28px_rgba(0,0,0,0.08)]"
+            className="mx-auto h-11 w-11 select-none object-contain drop-shadow-[0_12px_24px_rgba(0,0,0,0.08)]"
           />
           <div
             role="heading"

--- a/hushh-webapp/components/auth/phone-verification-flow.tsx
+++ b/hushh-webapp/components/auth/phone-verification-flow.tsx
@@ -370,9 +370,11 @@ export function PhoneVerificationFlow({
                 open={countryComboboxOpen}
                 onOpenChange={(open) => {
                   setCountryComboboxOpen(open);
-                  setCountryQuery(
-                    getCountryOptionLabel(selectedCountryOption ?? COUNTRY_PHONE_OPTIONS[0]!)
-                  );
+                  if (!open) {
+                    setCountryQuery(
+                      getCountryOptionLabel(selectedCountryOption ?? COUNTRY_PHONE_OPTIONS[0]!)
+                    );
+                  }
                 }}
                 value={selectedCountry}
                 onValueChange={handleCountrySelection}
@@ -390,6 +392,7 @@ export function PhoneVerificationFlow({
                   }}
                   onFocus={(event: React.FocusEvent<HTMLInputElement>) => {
                     setCountryComboboxOpen(true);
+                    setCountryQuery("");
                     event.currentTarget.select();
                   }}
                   className={`${FLOW_CONTROL_SHELL_CLASS_NAME} w-full`}

--- a/hushh-webapp/components/kai/kai-command-palette.tsx
+++ b/hushh-webapp/components/kai/kai-command-palette.tsx
@@ -31,6 +31,7 @@ import {
 import { searchKaiActions } from "@/lib/voice/kai-action-gateway";
 import type { AppRuntimeState } from "@/lib/voice/voice-types";
 import { Icon } from "@/lib/morphy-ux/ui";
+import { cn } from "@/lib/utils";
 
 export type KaiCommandPaletteSelection = {
   actionId: string;
@@ -406,16 +407,19 @@ export function KaiCommandPalette({
           value={query}
           onValueChange={setQuery}
           placeholder="Run Kai command or search ticker..."
-          className="pr-24"
+          className="pr-28"
         />
-        <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1.5">
+        <div className="absolute right-2.5 top-1/2 flex -translate-y-1/2 items-center gap-1.5">
           {!voiceHidden ? (
             <button
               type="button"
               aria-label={voiceActive ? "End Kai voice" : "Start Kai voice"}
               aria-disabled={voiceDisabled}
               onClick={onVoiceClick}
-              className="inline-flex h-9 w-9 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-black/[0.045] hover:text-foreground dark:hover:bg-white/10"
+              className={cn(
+                "inline-flex h-9 w-9 items-center justify-center rounded-full transition-colors hover:bg-black/[0.045] hover:text-foreground dark:hover:bg-white/10",
+                voiceActive ? "bg-primary text-primary-foreground hover:bg-primary/90" : "text-muted-foreground"
+              )}
             >
               <Mic className="h-4 w-4" strokeWidth={1.9} aria-hidden="true" />
             </button>

--- a/hushh-webapp/components/kai/kai-command-palette.tsx
+++ b/hushh-webapp/components/kai/kai-command-palette.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type MouseEvent } from "react";
 import {
   Activity,
   Compass,
   History,
+  Mic,
   Search,
   ShieldCheck,
   UserRound,
+  X,
 } from "lucide-react";
 
 import {
@@ -40,6 +42,10 @@ interface KaiCommandPaletteProps {
   onOpenChange: (open: boolean) => void;
   onSelectAction: (selection: KaiCommandPaletteSelection) => void;
   appRuntimeState?: AppRuntimeState;
+  onVoiceClick?: (event: MouseEvent<HTMLButtonElement>) => void;
+  voiceActive?: boolean;
+  voiceDisabled?: boolean;
+  voiceHidden?: boolean;
   portfolioTickers?: Array<{
     symbol: string;
     name?: string;
@@ -147,6 +153,10 @@ export function KaiCommandPalette({
   onOpenChange,
   onSelectAction,
   appRuntimeState,
+  onVoiceClick,
+  voiceActive = false,
+  voiceDisabled = false,
+  voiceHidden = false,
   portfolioTickers = [],
 }: KaiCommandPaletteProps) {
   const [query, setQuery] = useState("");
@@ -388,13 +398,38 @@ export function KaiCommandPalette({
     <CommandDialog
       open={open}
       onOpenChange={onOpenChange}
+      showCloseButton={false}
       className="top-[calc(var(--top-shell-reserved-height,0px)+0.75rem)] max-h-[min(70dvh,32rem)] w-[calc(100%-1rem)] translate-y-0 sm:top-1/2 sm:w-full sm:max-h-none sm:-translate-y-1/2"
     >
-      <CommandInput
-        value={query}
-        onValueChange={setQuery}
-        placeholder="Run Kai command or search ticker..."
-      />
+      <div className="relative">
+        <CommandInput
+          value={query}
+          onValueChange={setQuery}
+          placeholder="Run Kai command or search ticker..."
+          className="pr-24"
+        />
+        <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1.5">
+          {!voiceHidden ? (
+            <button
+              type="button"
+              aria-label={voiceActive ? "End Kai voice" : "Start Kai voice"}
+              aria-disabled={voiceDisabled}
+              onClick={onVoiceClick}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-black/[0.045] hover:text-foreground dark:hover:bg-white/10"
+            >
+              <Mic className="h-4 w-4" strokeWidth={1.9} aria-hidden="true" />
+            </button>
+          ) : null}
+          <button
+            type="button"
+            aria-label="Close command search"
+            onClick={() => onOpenChange(false)}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-black/[0.045] hover:text-foreground dark:hover:bg-white/10"
+          >
+            <X className="h-4 w-4" strokeWidth={1.9} aria-hidden="true" />
+          </button>
+        </div>
+      </div>
       <CommandList className="max-h-[min(56dvh,24rem)] sm:max-h-[300px]">
         <CommandEmpty>{commandEmptyMessage}</CommandEmpty>
 

--- a/hushh-webapp/components/kai/kai-search-bar.tsx
+++ b/hushh-webapp/components/kai/kai-search-bar.tsx
@@ -1643,7 +1643,6 @@ export function KaiSearchBar({
   const riaVoiceActive = ambientMode !== "idle";
   const riaVoiceDisabled =
     !riaVoiceActive && (disabled || micDisabled || voiceVisibilityMode === "hidden");
-  const compactDockExpanded = open || riaVoiceActive;
   const handleRiaVoiceClick = useCallback(
     (event: MouseEvent<HTMLButtonElement>) => {
       if (riaVoiceDisabled) {
@@ -1692,7 +1691,7 @@ export function KaiSearchBar({
           ref={barRef}
           className={cn(
             "pointer-events-none w-full",
-            isRiaSurface ? "max-w-[360px] sm:max-w-[392px]" : "max-w-[560px]"
+            isRiaSurface ? "max-w-[360px] sm:max-w-[392px]" : "max-w-[630px]"
           )}
         >
           {isRiaSurface ? (
@@ -1744,7 +1743,7 @@ export function KaiSearchBar({
               </div>
             </div>
           ) : (
-            <div className="relative flex h-[112px] w-full items-end justify-end">
+            <div className="relative ml-auto flex h-[112px] w-[58px] items-end justify-end">
               <button
                 type="button"
                 aria-label="Open Agent"
@@ -1755,16 +1754,13 @@ export function KaiSearchBar({
               </button>
               <div
                 className={cn(
-                  "ml-auto flex items-end justify-end transition-[width] duration-200 ease-out",
-                  compactDockExpanded
-                    ? "w-[min(15.5rem,calc(100vw-2rem))]"
-                    : "w-[58px]"
+                  "ml-auto flex w-[58px] items-end justify-end"
                 )}
               >
                 <div
                   className={cn(
                     "pointer-events-auto grid rounded-full kai-bottom-search-action p-[5px]",
-                    compactDockExpanded ? "w-full grid-cols-2 gap-1" : "w-[58px] grid-cols-1"
+                    "w-[58px] grid-cols-1"
                   )}
                   data-testid="kai-compact-search-surface"
                   data-mode={ambientMode}
@@ -1786,31 +1782,8 @@ export function KaiSearchBar({
                     )}
                   >
                     <Search className="h-5 w-5 shrink-0" strokeWidth={1.9} />
-                    {compactDockExpanded ? <span className="ml-1.5 truncate">Search</span> : null}
+                    <span className="sr-only">Search</span>
                   </button>
-                  {compactDockExpanded ? (
-                    <button
-                      type="button"
-                      aria-label={riaVoiceActive ? "End Kai voice" : "Start Kai voice"}
-                      aria-disabled={riaVoiceDisabled}
-                      disabled={voiceVisibilityMode === "hidden"}
-                      onClick={handleRiaVoiceClick}
-                      className={cn(
-                        "inline-flex h-11 min-w-0 items-center justify-center rounded-full px-3 text-[13px] font-semibold transition-colors hover:bg-black/[0.045] disabled:cursor-not-allowed dark:hover:bg-white/10",
-                        riaVoiceActive
-                          ? "bg-primary text-primary-foreground hover:bg-primary/90"
-                          : "text-muted-foreground hover:text-foreground",
-                        riaVoiceDisabled && "opacity-60"
-                      )}
-                    >
-                      {riaVoiceActive ? (
-                        <X className="h-5 w-5 shrink-0" strokeWidth={1.9} />
-                      ) : (
-                        <Mic className="h-5 w-5 shrink-0" strokeWidth={1.9} />
-                      )}
-                      <span className="ml-1.5 truncate">Voice</span>
-                    </button>
-                  ) : null}
                 </div>
               </div>
             </div>

--- a/hushh-webapp/components/kai/kai-search-bar.tsx
+++ b/hushh-webapp/components/kai/kai-search-bar.tsx
@@ -9,7 +9,7 @@ import {
   useState,
   type MouseEvent,
 } from "react";
-import { Mic, Search, X } from "lucide-react";
+import { Bot, Mic, Search, X } from "lucide-react";
 
 import {
   KaiCommandPalette,
@@ -20,6 +20,7 @@ import {
 } from "@/components/kai/voice/voice-ambient-search-surface";
 import { VoiceDebugDrawer } from "@/components/kai/voice/voice-debug-drawer";
 import { ShellActionSurface } from "@/components/app-ui/shell-action-surface";
+import { useOptionalAgentPopover } from "@/components/agent/agent-popover-provider";
 import { morphyToast as toast } from "@/lib/morphy-ux/morphy";
 import { useKaiBottomChromeVisibility } from "@/lib/navigation/kai-bottom-chrome-visibility";
 import { KAI_COMMAND_BAR_OPEN_EVENT } from "@/lib/navigation/kai-command-bar-events";
@@ -312,6 +313,7 @@ export function KaiSearchBar({
   portfolioTickers = [],
 }: KaiSearchBarProps) {
   const { getVaultOwnerToken, vaultKey } = useVault();
+  const agentPopover = useOptionalAgentPopover();
   const [open, setOpen] = useState(false);
   const [voiceDebugOpen, setVoiceDebugOpen] = useState(false);
   const [voiceUiState, setVoiceUiState] = useState<VoiceUiState>("idle");
@@ -1659,6 +1661,9 @@ export function KaiSearchBar({
       stableMicDisabledReason,
     ],
   );
+  const handleAgentClick = useCallback(() => {
+    agentPopover?.openAgent();
+  }, [agentPopover]);
 
   return (
     <>
@@ -1684,45 +1689,65 @@ export function KaiSearchBar({
           )}
         >
           {isRiaSurface ? (
-            <div
-              className="grid grid-cols-2 gap-1.5 rounded-full border border-[color:var(--app-shell-surface-border)] bg-[color:var(--app-shell-surface-bg)] bg-[image:var(--app-shell-surface-fill)] p-1 shadow-[var(--app-shell-surface-shadow)] backdrop-blur-[var(--app-shell-surface-blur)]"
-              data-testid="ria-action-bar"
-            >
-              <ShellActionSurface
-                variant="pill"
-                wrapperClassName="w-full"
-                className="h-10 w-full min-w-0 px-2 text-[12px] sm:text-[13px]"
-                contentClassName="gap-1.5"
-                aria-label="Search RIA workspace"
-                aria-expanded={open}
-                aria-haspopup="dialog"
-                onClick={() => setOpen(true)}
+            <div className="relative flex w-full items-end justify-end">
+              <button
+                type="button"
+                aria-label="Open Agent"
+                onClick={handleAgentClick}
+                disabled={!agentPopover}
+                className="kai-bottom-agent-action pointer-events-auto absolute -top-[54px] right-1 inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/30 disabled:pointer-events-none disabled:opacity-50"
               >
-                <Search className="h-4 w-4 shrink-0" />
-                <span className="truncate">Search</span>
-              </ShellActionSurface>
-              <ShellActionSurface
-                variant="pill"
-                wrapperClassName="w-full"
-                contentClassName="gap-1.5"
-                aria-label={riaVoiceActive ? "End RIA voice session" : "Start RIA voice"}
-                aria-disabled={riaVoiceDisabled}
-                className={cn(
-                  "h-10 w-full min-w-0 px-2 text-[12px] sm:text-[13px]",
-                  riaVoiceDisabled && "opacity-60"
-                )}
-                onClick={handleRiaVoiceClick}
+                <Bot className="h-[18px] w-[18px]" strokeWidth={1.9} />
+              </button>
+              <div
+                className="grid w-full grid-cols-2 gap-1.5 rounded-full border border-[color:var(--app-shell-surface-border)] bg-[color:var(--app-shell-surface-bg)] bg-[image:var(--app-shell-surface-fill)] p-1 shadow-[var(--app-shell-surface-shadow)] backdrop-blur-[var(--app-shell-surface-blur)]"
+                data-testid="ria-action-bar"
               >
-                {riaVoiceActive ? (
-                  <X className="h-4 w-4 shrink-0" />
-                ) : (
-                  <Mic className="h-4 w-4 shrink-0" />
-                )}
-                <span className="truncate">Voice</span>
-              </ShellActionSurface>
+                <ShellActionSurface
+                  variant="pill"
+                  wrapperClassName="w-full"
+                  className="h-10 w-full min-w-0 px-2 text-[12px] sm:text-[13px]"
+                  contentClassName="gap-1.5"
+                  aria-label="Search RIA workspace"
+                  aria-expanded={open}
+                  aria-haspopup="dialog"
+                  onClick={() => setOpen(true)}
+                >
+                  <Search className="h-4 w-4 shrink-0" />
+                  <span className="truncate">Search</span>
+                </ShellActionSurface>
+                <ShellActionSurface
+                  variant="pill"
+                  wrapperClassName="w-full"
+                  contentClassName="gap-1.5"
+                  aria-label={riaVoiceActive ? "End RIA voice session" : "Start RIA voice"}
+                  aria-disabled={riaVoiceDisabled}
+                  className={cn(
+                    "h-10 w-full min-w-0 px-2 text-[12px] sm:text-[13px]",
+                    riaVoiceDisabled && "opacity-60"
+                  )}
+                  onClick={handleRiaVoiceClick}
+                >
+                  {riaVoiceActive ? (
+                    <X className="h-4 w-4 shrink-0" />
+                  ) : (
+                    <Mic className="h-4 w-4 shrink-0" />
+                  )}
+                  <span className="truncate">Voice</span>
+                </ShellActionSurface>
+              </div>
             </div>
           ) : (
-            <div className="relative flex h-[58px] w-full items-end justify-end">
+            <div className="relative flex h-[112px] w-full items-end justify-end">
+              <button
+                type="button"
+                aria-label="Open Agent"
+                onClick={handleAgentClick}
+                disabled={!agentPopover}
+                className="kai-bottom-agent-action pointer-events-auto absolute right-[7px] top-0 inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/30 disabled:pointer-events-none disabled:opacity-50"
+              >
+                <Bot className="h-[18px] w-[18px]" strokeWidth={1.9} />
+              </button>
               <div
                 className={cn(
                   "ml-auto flex items-end justify-end transition-[width] duration-200 ease-out",

--- a/hushh-webapp/components/kai/kai-search-bar.tsx
+++ b/hushh-webapp/components/kai/kai-search-bar.tsx
@@ -9,6 +9,7 @@ import {
   useState,
   type MouseEvent,
 } from "react";
+import { useRouter } from "next/navigation";
 import { Bot, Mic, Search, X } from "lucide-react";
 
 import {
@@ -24,6 +25,7 @@ import { useOptionalAgentPopover } from "@/components/agent/agent-popover-provid
 import { morphyToast as toast } from "@/lib/morphy-ux/morphy";
 import { useKaiBottomChromeVisibility } from "@/lib/navigation/kai-bottom-chrome-visibility";
 import { KAI_COMMAND_BAR_OPEN_EVENT } from "@/lib/navigation/kai-command-bar-events";
+import { ROUTES } from "@/lib/navigation/routes";
 import { cn } from "@/lib/utils";
 import { useVault } from "@/lib/vault/vault-context";
 import { useAmplitudeMeter } from "@/lib/voice/use-amplitude-meter";
@@ -312,6 +314,7 @@ export function KaiSearchBar({
   surfaceVariant = "kai",
   portfolioTickers = [],
 }: KaiSearchBarProps) {
+  const router = useRouter();
   const { getVaultOwnerToken, vaultKey } = useVault();
   const agentPopover = useOptionalAgentPopover();
   const [open, setOpen] = useState(false);
@@ -1662,8 +1665,12 @@ export function KaiSearchBar({
     ],
   );
   const handleAgentClick = useCallback(() => {
-    agentPopover?.openAgent();
-  }, [agentPopover]);
+    if (agentPopover) {
+      agentPopover.openAgent();
+      return;
+    }
+    router.push(ROUTES.AGENT);
+  }, [agentPopover, router]);
 
   return (
     <>
@@ -1694,8 +1701,7 @@ export function KaiSearchBar({
                 type="button"
                 aria-label="Open Agent"
                 onClick={handleAgentClick}
-                disabled={!agentPopover}
-                className="kai-bottom-agent-action pointer-events-auto absolute -top-[54px] right-1 inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/30 disabled:pointer-events-none disabled:opacity-50"
+                className="kai-bottom-agent-action pointer-events-auto absolute -top-[54px] right-1 inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/30"
               >
                 <Bot className="h-[18px] w-[18px]" strokeWidth={1.9} />
               </button>
@@ -1743,8 +1749,7 @@ export function KaiSearchBar({
                 type="button"
                 aria-label="Open Agent"
                 onClick={handleAgentClick}
-                disabled={!agentPopover}
-                className="kai-bottom-agent-action pointer-events-auto absolute right-[7px] top-0 inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/30 disabled:pointer-events-none disabled:opacity-50"
+                className="kai-bottom-agent-action pointer-events-auto absolute right-[7px] top-0 inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/30"
               >
                 <Bot className="h-[18px] w-[18px]" strokeWidth={1.9} />
               </button>
@@ -1823,6 +1828,10 @@ export function KaiSearchBar({
         onOpenChange={setOpen}
         onSelectAction={onSelectAction}
         appRuntimeState={appRuntimeState}
+        onVoiceClick={handleRiaVoiceClick}
+        voiceActive={riaVoiceActive}
+        voiceDisabled={riaVoiceDisabled}
+        voiceHidden={voiceVisibilityMode === "hidden"}
         portfolioTickers={portfolioTickers}
       />
 

--- a/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
+++ b/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
@@ -197,7 +197,7 @@ export function KaiPreferencesWizard(props: {
       <div
         className={cn(
           isPageLayout
-            ? "mx-auto flex min-h-[calc(100dvh-var(--top-content-pad)-var(--app-screen-footer-pad))] w-full max-w-[33rem] flex-col justify-center"
+            ? "mx-auto flex min-h-[calc(100dvh-var(--top-content-pad)-var(--app-screen-footer-pad))] w-full max-w-[31rem] flex-col justify-center"
             : "w-full max-w-sm mx-auto flex min-h-[calc(100dvh-var(--app-screen-footer-pad))] flex-col",
           !isPageLayout && "min-h-0"
         )}
@@ -205,7 +205,7 @@ export function KaiPreferencesWizard(props: {
         <div
           className={cn(
             isPageLayout
-              ? "rounded-[26px] border border-black/[0.06] bg-white/[0.82] p-5 shadow-[0_22px_64px_-52px_rgba(0,0,0,0.48)] backdrop-blur-2xl sm:p-6 dark:border-white/10 dark:bg-white/[0.07]"
+              ? "rounded-[26px] border border-black/[0.06] bg-white/[0.82] p-5 shadow-[0_22px_64px_-52px_rgba(0,0,0,0.48)] backdrop-blur-2xl sm:p-5 dark:border-white/10 dark:bg-white/[0.07]"
               : "contents"
           )}
         >
@@ -252,7 +252,7 @@ export function KaiPreferencesWizard(props: {
           <div
             className={cn(
               isPageLayout
-                ? "mx-auto flex w-full max-w-[26rem] flex-col pt-6 sm:pt-7"
+                ? "mx-auto flex w-full max-w-[25rem] flex-col pt-5 sm:pt-6"
                 : "flex flex-1 flex-col pt-5"
             )}
           >
@@ -272,7 +272,7 @@ export function KaiPreferencesWizard(props: {
                 className={cn(
                   "tracking-normal text-balance text-foreground",
                   isPageLayout
-                    ? "text-[28px] font-medium leading-[1.08] sm:text-[30px]"
+                    ? "text-[25px] font-medium leading-[1.12] sm:text-[27px]"
                     : kaiAppSectionTitleClassName
                 )}
               >
@@ -283,7 +283,7 @@ export function KaiPreferencesWizard(props: {
             <RadioGroup
               value={activeValue ?? ""}
               onValueChange={handleSelect}
-              className={cn(isPageLayout ? "mt-7 gap-2.5 sm:mt-8" : "gap-3")}
+              className={cn(isPageLayout ? "mt-6 gap-2.5 sm:mt-7" : "gap-3")}
             >
               {activeQuestion.options.map((opt) => (
                 <RadioCardItem key={opt.value} value={opt.value} label={opt.label} />

--- a/hushh-webapp/components/kai/shared/kai-typography.ts
+++ b/hushh-webapp/components/kai/shared/kai-typography.ts
@@ -4,22 +4,22 @@ export const kaiAppEyebrowClassName =
   "!text-[10.5px] !font-medium !leading-[1.2] uppercase !tracking-[0.14em]";
 
 export const kaiAppHeroTitleClassName =
-  "text-[38px] font-medium leading-[1.05] tracking-normal sm:text-[40px]";
+  "text-[36px] font-medium leading-[1.06] tracking-normal sm:text-[38px]";
 
 export const kaiAppHeroBodyClassName =
-  "text-[17px] font-normal leading-[1.42] tracking-normal sm:text-[18px]";
+  "text-[16.5px] font-normal leading-[1.42] tracking-normal sm:text-[17.5px]";
 
 export const kaiAppDisplayTitleClassName =
-  "!text-[30px] !font-medium !leading-[1.08] !tracking-normal sm:!text-[34px]";
+  "!text-[28px] !font-medium !leading-[1.1] !tracking-normal sm:!text-[32px]";
 
 export const kaiAppCompactTitleClassName =
-  "!text-[30px] !font-medium !leading-[1.08] !tracking-normal sm:!text-[34px]";
+  "!text-[28px] !font-medium !leading-[1.1] !tracking-normal sm:!text-[32px]";
 
 export const kaiAppBodyClassName =
-  "!text-[16px] !font-normal !leading-[1.45] !tracking-normal sm:!text-[17px]";
+  "!text-[15.5px] !font-normal !leading-[1.46] !tracking-normal sm:!text-[16.5px]";
 
 export const kaiAppSectionTitleClassName =
-  "!text-[18px] !font-medium !leading-[1.18] !tracking-normal sm:!text-[20px]";
+  "!text-[17px] !font-medium !leading-[1.2] !tracking-normal sm:!text-[18px]";
 
 export const kaiAppCardTitleClassName =
   "!text-[15.5px] !font-medium !leading-[1.24] !tracking-normal sm:!text-[16px]";

--- a/hushh-webapp/components/kai/views/analysis-history-dashboard.tsx
+++ b/hushh-webapp/components/kai/views/analysis-history-dashboard.tsx
@@ -549,14 +549,14 @@ function removeTickerFromHistoryMap(
 
 function EmptyState() {
   return (
-    <div className="flex max-w-xl flex-col items-start justify-center space-y-4 px-1 py-10">
+      <div className="flex max-w-xl flex-col items-start justify-center space-y-4 px-1 py-8">
       <div className="rounded-full border border-primary/10 bg-primary/5 p-3">
         <Icon icon={BarChart3} size={24} className="text-primary/70" aria-hidden="true" />
       </div>
       <div className="space-y-2 text-left">
-        <h3 className="text-[22px] font-semibold leading-tight tracking-normal text-foreground">
-          No analyses yet
-        </h3>
+          <h3 className="text-[20px] font-medium leading-tight tracking-normal text-foreground">
+            No analyses yet
+          </h3>
         <p className="max-w-md text-[15px] leading-6 text-muted-foreground">
           Search for a stock ticker below and let Agent Kai&apos;s multi-agent
           debate engine give you a data-driven recommendation.

--- a/hushh-webapp/components/kai/views/analysis-history-dashboard.tsx
+++ b/hushh-webapp/components/kai/views/analysis-history-dashboard.tsx
@@ -549,13 +549,15 @@ function removeTickerFromHistoryMap(
 
 function EmptyState() {
   return (
-    <div className="flex flex-col items-center justify-center py-12 px-4 space-y-6">
-      <div className="p-4 rounded-full bg-primary/5 border border-primary/10">
-        <Icon icon={BarChart3} size={32} className="text-primary/60" aria-hidden="true" />
+    <div className="flex max-w-xl flex-col items-start justify-center space-y-4 px-1 py-10">
+      <div className="rounded-full border border-primary/10 bg-primary/5 p-3">
+        <Icon icon={BarChart3} size={24} className="text-primary/70" aria-hidden="true" />
       </div>
-      <div className="text-center space-y-2 max-w-sm">
-        <h3 className="text-lg font-semibold">No analyses yet</h3>
-        <p className="text-sm text-muted-foreground leading-relaxed">
+      <div className="space-y-2 text-left">
+        <h3 className="text-[22px] font-semibold leading-tight tracking-normal text-foreground">
+          No analyses yet
+        </h3>
+        <p className="max-w-md text-[15px] leading-6 text-muted-foreground">
           Search for a stock ticker below and let Agent Kai&apos;s multi-agent
           debate engine give you a data-driven recommendation.
         </p>

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -7,13 +7,13 @@ import React, { useEffect, useMemo, type CSSProperties } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import {
   BriefcaseBusiness,
+  ChartNoAxesColumnIncreasing,
   Compass,
   FileSpreadsheet,
-  LayoutDashboard,
-  LineChart,
-  Store,
-  User,
+  Landmark,
+  UserRound,
   Users,
+  WalletCards,
 } from "lucide-react";
 
 import { useAuth } from "@/hooks/use-auth";
@@ -128,7 +128,7 @@ export const Navbar = () => {
             {
               value: "profile",
               label: "Profile",
-              icon: User,
+              icon: UserRound,
               badge: pendingConsents > 0 ? pendingConsents : undefined,
               dataTourId: "nav-profile",
             },
@@ -137,19 +137,19 @@ export const Navbar = () => {
             {
               value: "market",
               label: "Market",
-              icon: Store,
+              icon: Landmark,
               dataTourId: "nav-market",
             },
             {
               value: "dashboard",
               label: "Portfolio",
-              icon: LayoutDashboard,
+              icon: WalletCards,
               dataTourId: "nav-portfolio",
             },
             {
               value: "analysis",
               label: "Analysis",
-              icon: LineChart,
+              icon: ChartNoAxesColumnIncreasing,
               dataTourId: "nav-analysis",
             },
             {
@@ -161,7 +161,7 @@ export const Navbar = () => {
             {
               value: "profile",
               label: "Profile",
-              icon: User,
+              icon: UserRound,
               badge: pendingConsents > 0 ? pendingConsents : undefined,
               dataTourId: "nav-profile",
             },

--- a/hushh-webapp/components/onboarding/AuthStep.tsx
+++ b/hushh-webapp/components/onboarding/AuthStep.tsx
@@ -557,49 +557,48 @@ export function AuthStep({
             : "relative mx-auto flex h-full min-h-0 w-full max-w-[27rem] flex-col justify-center px-6 pb-[calc(58px+var(--app-screen-footer-pad))] pt-[calc(32px+var(--app-safe-area-top-effective,0px))]"
         }
       >
-        <div className="w-full shrink-0">
-          <header className="flex-none text-center">
-            <Image
-              src="/one-quiet-emoji.png"
-              alt="One"
-              width={48}
-              height={48}
-              priority
-              className="mx-auto h-12 w-12 object-contain drop-shadow-[0_14px_28px_rgba(0,0,0,0.08)]"
-            />
-            <div
-              role="heading"
-              aria-level={1}
-              aria-label="Sign in to One"
-              className={`mt-2.5 ${kaiAppHeroTitleClassName} text-[#1d1d1f] dark:text-[#f5f5f7]`}
-            >
-              Sign in to One.
-            </div>
-            <p className={`mx-auto mt-3 max-w-[20rem] ${kaiAppHeroBodyClassName} text-[rgba(0,0,0,0.56)] dark:text-[rgba(245,245,247,0.60)]`}>
-              Continue to your personal financial advisor.
-            </p>
-          </header>
-
-          <section
-            className={
-              compact
-                ? "flex-none pt-10"
-                : "flex-none pt-11"
-            }
+        <header className="flex-none text-center">
+          <Image
+            src="/one-quiet-emoji.png"
+            alt="One"
+            width={44}
+            height={44}
+            priority
+            className="mx-auto h-11 w-11 object-contain drop-shadow-[0_12px_24px_rgba(0,0,0,0.08)]"
+          />
+          <div
+            role="heading"
+            aria-level={1}
+            aria-label="Sign in to One"
+            className={`mt-2.5 ${kaiAppHeroTitleClassName} text-[#1d1d1f] dark:text-[#f5f5f7]`}
           >
-            <div className="mx-auto w-full max-w-[21.5rem] space-y-3">
-              {authOptions.map((option) => (
-                <AuthProviderButton
-                  key={option.id}
-                  label={option.label}
-                  icon={option.icon}
-                  onClick={option.onClick}
-                />
-              ))}
+            Sign in to One.
+          </div>
+          <p className={`mx-auto mt-3 max-w-[20rem] ${kaiAppHeroBodyClassName} text-[rgba(0,0,0,0.56)] dark:text-[rgba(245,245,247,0.60)]`}>
+            Continue to your personal financial advisor.
+          </p>
+        </header>
 
-              <p className="mx-auto max-w-[18.75rem] pt-2 text-center text-[13px] leading-[1.45] text-[#86868b] dark:text-[#8e8e93]">
-                A verified phone number is required before you continue.
-              </p>
+        <section
+          className={
+            compact
+              ? "flex-none pt-11"
+              : "flex-none pt-12"
+          }
+        >
+          <div className="mx-auto w-full max-w-[21.5rem] space-y-3">
+            {authOptions.map((option) => (
+              <AuthProviderButton
+                key={option.id}
+                label={option.label}
+                icon={option.icon}
+                onClick={option.onClick}
+              />
+            ))}
+
+            <p className="mx-auto max-w-[18.75rem] pt-2 text-center text-[13px] leading-[1.45] text-[#86868b] dark:text-[#8e8e93]">
+              A verified phone number is required before you continue.
+            </p>
 
               {(reviewModeConfig.enabled ||
                 nativeReviewerVisible ||
@@ -613,7 +612,6 @@ export function AuthStep({
               )}
             </div>
           </section>
-        </div>
 
         <footer className="absolute inset-x-6 bottom-[calc(20px+var(--app-screen-footer-pad))] flex-none">
           <p className="mx-auto max-w-[19.5rem] text-center text-[11px] leading-[1.45] text-[#86868b] dark:text-[#8e8e93]">

--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -99,7 +99,7 @@ export function IntroStep({
             unoptimized
             aria-hidden="true"
             draggable={false}
-            className="relative h-12 w-12 select-none object-contain"
+            className="relative h-11 w-11 select-none object-contain"
           />
 
           <div
@@ -115,13 +115,13 @@ export function IntroStep({
           </p>
         </section>
 
-        <div className="flex min-h-0 flex-1 items-center py-6">
+        <div className="flex min-h-0 flex-1 items-center py-7">
           <div className="relative w-full">
             <div className="relative z-10 mx-auto flex w-full max-w-[340px] flex-col gap-4">
               {INTRO_FEATURES.map((feature) => (
                 <div
                   key={feature.title}
-                  className="grid min-h-[64px] grid-cols-[48px_minmax(0,1fr)] items-center gap-4 rounded-[22px]"
+                  className="grid min-h-[68px] grid-cols-[48px_minmax(0,1fr)] items-center gap-4 rounded-[22px]"
                 >
                   <span
                     className={`grid h-12 w-12 place-items-center rounded-full border border-black/[0.04] dark:border-white/10 ${feature.tileClassName}`}
@@ -129,7 +129,7 @@ export function IntroStep({
                     <feature.icon className="h-[22px] w-[22px]" />
                   </span>
                   <div className="min-w-0">
-                    <p className="text-[17px] font-medium leading-[1.22] tracking-normal text-[#1d1d1f] dark:text-[#f5f5f7]">
+                    <p className="text-[16.5px] font-medium leading-[1.22] tracking-normal text-[#1d1d1f] dark:text-[#f5f5f7]">
                       {feature.title}
                     </p>
                     <p className="mt-1 text-[14.5px] leading-[1.35] tracking-normal text-[rgba(0,0,0,0.50)] dark:text-[rgba(245,245,247,0.56)]">

--- a/hushh-webapp/components/onboarding/PreviewCarouselStep.tsx
+++ b/hushh-webapp/components/onboarding/PreviewCarouselStep.tsx
@@ -210,16 +210,16 @@ export function PreviewCarouselStep({ onContinue }: { onContinue: () => void }) 
             className={cn(
               "w-full mx-auto text-center flex flex-col justify-end gap-2",
               // Keep copy + spacing responsive without clipping on larger screens.
-              "min-h-[clamp(132px,18vh,190px)] pt-5",
+              "min-h-[clamp(118px,16vh,164px)] pt-4",
               "sm:max-w-lg"
             )}
           >
-            <h2 className="text-[32px] font-medium tracking-normal leading-[1.06] text-[#1d1d1f] sm:text-[40px] dark:text-[#f5f5f7]">
+            <h2 className="text-[28px] font-medium tracking-normal leading-[1.08] text-[#1d1d1f] sm:text-[34px] dark:text-[#f5f5f7]">
               {slides[displayIndex]?.title}{" "}
               <br />
               <span>{slides[displayIndex]?.accent}</span>
             </h2>
-            <p className="mx-auto max-w-[20rem] text-[16px] text-[rgba(0,0,0,0.56)] leading-[1.45] sm:text-[17px] dark:text-[rgba(245,245,247,0.60)]">
+            <p className="mx-auto max-w-[20rem] text-[15px] text-[rgba(0,0,0,0.56)] leading-[1.45] sm:text-[16px] dark:text-[rgba(245,245,247,0.60)]">
               {slides[displayIndex]?.subtitle}
             </p>
           </div>
@@ -239,10 +239,10 @@ export function PreviewCarouselStep({ onContinue }: { onContinue: () => void }) 
                     aria-current={idx === selectedIndex ? "step" : undefined}
                     className="basis-full pl-0 flex items-center justify-center"
                   >
-                    <div className="flex w-full min-h-[clamp(24rem,50vh,31rem)] items-center justify-center px-4 sm:px-6 md:px-8 py-3">
+                    <div className="flex w-full min-h-[clamp(23rem,48vh,29rem)] items-center justify-center px-4 sm:px-6 md:px-8 py-3">
                       <div
                         aria-hidden="true"
-                        className="h-[clamp(31rem,58vh,35rem)] w-full max-w-[22rem] sm:max-w-[24rem] md:max-w-[25rem] lg:max-w-[26rem] xl:max-w-[27rem]"
+                        className="h-[clamp(29rem,55vh,33rem)] w-full max-w-[22rem] sm:max-w-[23rem] md:max-w-[24rem] lg:max-w-[25rem]"
                       >
                         {slide.preview}
                       </div>

--- a/hushh-webapp/components/one-location/activity-dashboard.tsx
+++ b/hushh-webapp/components/one-location/activity-dashboard.tsx
@@ -26,7 +26,7 @@ const ACTIVITY_RANGE_OPTIONS: {
 ];
 
 const activityPanelClassName =
-  "w-full min-w-0 max-w-full overflow-hidden rounded-[20px] border border-black/[0.05] bg-white shadow-[0_1px_2px_rgba(0,0,0,0.04),0_10px_30px_rgba(15,23,42,0.05)] dark:border-white/[0.08] dark:bg-[#1c1c1e]/90 dark:shadow-[0_12px_38px_rgba(0,0,0,0.28)]";
+  "w-full min-w-0 max-w-full overflow-hidden rounded-[24px] border border-black/[0.04] bg-white/95 shadow-[0_1px_2px_rgba(0,0,0,0.03),0_14px_34px_rgba(15,23,42,0.06)] backdrop-blur-xl dark:border-white/[0.08] dark:bg-[#1c1c1e]/90 dark:shadow-[0_12px_38px_rgba(0,0,0,0.24)]";
 
 function activityRangeLabel(range: OneLocationActivityRange): string {
   return (
@@ -50,7 +50,7 @@ function ActivitySectionLabel({ title }: { title: string }) {
     <div
       role="heading"
       aria-level={2}
-      className="ml-1 flex min-w-0 max-w-full flex-wrap items-center gap-1.5 text-[12px] font-semibold uppercase tracking-[0.08em] text-[#8e8e93] dark:text-white/45"
+      className="ml-1 flex min-w-0 max-w-full flex-wrap items-center gap-1.5 text-[12px] font-semibold uppercase tracking-[0.12em] text-[#8e8e93] dark:text-white/45"
     >
       {title}
     </div>
@@ -67,11 +67,11 @@ function ActivityMetricTile({
   detail: string;
 }) {
   return (
-    <div className="min-w-0 rounded-[14px] border border-black/[0.04] bg-[#f7f7fa] p-3 dark:border-white/[0.08] dark:bg-white/[0.07]">
+    <div className="min-w-0 rounded-[18px] border border-black/[0.04] bg-[#f7f7fa] p-3.5 dark:border-white/[0.08] dark:bg-white/[0.07]">
       <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[#8e8e93] dark:text-white/45">
         {label}
       </p>
-      <p className="mt-1 text-[24px] font-bold leading-none text-[#1c1c1e] dark:text-white">
+      <p className="mt-1 text-[24px] font-semibold leading-none text-[#1c1c1e] dark:text-white">
         {value}
       </p>
       <p className="mt-1 break-words text-[11px] font-medium text-[#8e8e93] [overflow-wrap:anywhere] dark:text-white/55">
@@ -91,7 +91,7 @@ function EmptyActivityState({
   description: string;
 }) {
   return (
-    <div className="flex flex-col items-center justify-center gap-2 rounded-[14px] border border-dashed border-black/[0.08] bg-[#f7f7fa] p-5 text-center dark:border-white/[0.12] dark:bg-white/[0.05]">
+    <div className="flex flex-col items-center justify-center gap-2 rounded-[18px] border border-dashed border-black/[0.08] bg-[#f7f7fa] p-5 text-center dark:border-white/[0.12] dark:bg-white/[0.05]">
       <Icon className="h-5 w-5 text-[#8e8e93]" aria-hidden="true" />
       <p className="text-[14px] font-semibold text-[#1c1c1e] dark:text-white">
         {title}
@@ -125,7 +125,7 @@ export function OneLocationActivityDashboard({
   return (
     <section className="min-w-0 max-w-full space-y-2 px-1">
       <ActivitySectionLabel title="Location activity" />
-      <div className={cn(activityPanelClassName, "space-y-4 p-3.5")}>
+      <div className={cn(activityPanelClassName, "space-y-4 p-4")}>
         <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="flex min-w-0 items-start gap-3">
             <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#eaf3ff] text-[#007aff] dark:bg-[#0a84ff]/15 dark:text-[#76b7ff]">
@@ -136,10 +136,10 @@ export function OneLocationActivityDashboard({
               )}
             </span>
             <div className="min-w-0">
-              <h3 className="text-[15px] font-bold tracking-tight text-[#1c1c1e] dark:text-white">
+              <h3 className="text-[16px] font-semibold tracking-normal text-[#1c1c1e] dark:text-white">
                 Activity history
               </h3>
-              <p className="mt-1 break-words text-[12px] leading-5 text-[#8e8e93] [overflow-wrap:anywhere] dark:text-white/55">
+              <p className="mt-1 break-words text-[13px] leading-5 text-[#6e6e73] [overflow-wrap:anywhere] dark:text-white/60">
                 {error ||
                   `${activityRangeLabel(range)} of shares, requests, views, and link responses.`}
               </p>


### PR DESCRIPTION
## Summary
- Applies the Kai UI hierarchy/chrome polish on top of the latest main-backed UAT train.
- Keeps existing routes, backend contracts, RIA/default market list behavior, search, voice, and agent paths intact.
- Restores the shared bottom nav/search/agent chrome and tightens Apple-like typography across auth, onboarding, location, and Kai pages.

## Verification
- npm run lint -- --max-warnings=0
- npm run typecheck
- npm run test -- --run __tests__/voice/kai-search-bar.test.ts
- Browser tests skipped per request.