### PR TITLE
fix(kai): restore bottom agent trigger

### DIFF
--- a/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
+++ b/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
@@ -1,0 +1,24 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const WEBAPP_ROOT = path.resolve(__dirname, "../..");
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(WEBAPP_ROOT, relativePath), "utf8");
+}
+
+describe("Navbar Agent trigger contract", () => {
+  it("keeps the embedded bottom-right Agent entrypoint wired to the popover provider", () => {
+    const navbar = read("components/navbar.tsx");
+    const provider = read("components/agent/agent-popover-provider.tsx");
+
+    expect(provider).toContain("useOptionalAgentPopover");
+    expect(navbar).toContain("useOptionalAgentPopover");
+    expect(navbar).toContain('data-testid="bottom-agent-trigger"');
+    expect(navbar).toContain('aria-label="Open Agent"');
+    expect(navbar).toContain("agentPopover.openAgent()");
+    expect(navbar).toContain('style={{ width: "calc(100% - 66px)" }}');
+  });
+});

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -6,6 +6,7 @@
 import React, { useEffect, useMemo, type CSSProperties } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import {
+  Bot,
   BriefcaseBusiness,
   ChartNoAxesColumnIncreasing,
   Compass,
@@ -288,6 +289,21 @@ export const Navbar = () => {
             )}
           />
         </div>
+        {agentPopover ? (
+          <button
+            type="button"
+            aria-label="Open Agent"
+            title="Open Agent"
+            data-testid="bottom-agent-trigger"
+            onClick={() => agentPopover.openAgent()}
+            className={cn(
+              "pointer-events-auto chrome-bottom-foreground flex h-[58px] w-[58px] shrink-0 items-center justify-center rounded-[22px] border border-black/[0.08] bg-white/92 text-[#1c1c1e] shadow-[0_10px_30px_rgba(15,23,42,0.16)] backdrop-blur-xl transition-colors hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 dark:border-white/[0.12] dark:bg-[#1c1c1e]/90 dark:text-white dark:shadow-black/30 dark:hover:bg-[#2c2c2e]",
+              hideBottomChrome && "pointer-events-none"
+            )}
+          >
+            <Bot className="h-5 w-5" aria-hidden="true" />
+          </button>
+        ) : null}
       </div>
     </nav>
   );


### PR DESCRIPTION
## Summary
- Restores the bottom-right Agent icon in the authenticated app navbar.
- Wires the icon to the existing AgentPopoverProvider openAgent flow.
- Adds a regression contract so the embedded Agent trigger cannot disappear silently again.

## Verification
- npx vitest run __tests__/components/navbar-agent-trigger.contract.test.ts --maxWorkers=1 --no-fileParallelism --reporter=verbose
- npx tsc --noEmit --pretty false
- npm run lint -- --max-warnings=0

## Hotfix note
This is an isolated UAT main hotfix for the missing Agent popover entrypoint regression.