### PR TITLE
fix: tighten Kai onboarding card spacing

### DIFF
--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -115,13 +115,13 @@ export function IntroStep({
           </p>
         </section>
 
-        <div className="flex min-h-0 flex-1 items-center py-7">
+        <div className="flex-none pt-9 pb-5">
           <div className="relative w-full">
-            <div className="relative z-10 mx-auto flex w-full max-w-[340px] flex-col gap-4">
+            <div className="relative z-10 mx-auto flex w-full max-w-[340px] flex-col gap-3">
               {INTRO_FEATURES.map((feature) => (
                 <div
                   key={feature.title}
-                  className="grid min-h-[68px] grid-cols-[48px_minmax(0,1fr)] items-center gap-4 rounded-[22px]"
+                  className="grid h-[70px] grid-cols-[48px_minmax(0,1fr)] items-center gap-4 rounded-[22px]"
                 >
                   <span
                     className={`grid h-12 w-12 place-items-center rounded-full border border-black/[0.04] dark:border-white/10 ${feature.tileClassName}`}

--- a/hushh-webapp/components/onboarding/PreviewCarouselStep.tsx
+++ b/hushh-webapp/components/onboarding/PreviewCarouselStep.tsx
@@ -224,7 +224,7 @@ export function PreviewCarouselStep({ onContinue }: { onContinue: () => void }) 
             </p>
           </div>
 
-          <div className="min-h-0 flex-1 flex items-center">
+          <div className="flex min-h-0 flex-1 items-start pt-5">
             <Carousel
               opts={{ align: "center", containScroll: "trimSnaps" }}
               setApi={setApi}
@@ -239,10 +239,10 @@ export function PreviewCarouselStep({ onContinue }: { onContinue: () => void }) 
                     aria-current={idx === selectedIndex ? "step" : undefined}
                     className="basis-full pl-0 flex items-center justify-center"
                   >
-                    <div className="flex w-full min-h-[clamp(23rem,48vh,29rem)] items-center justify-center px-4 sm:px-6 md:px-8 py-3">
+                    <div className="flex w-full items-start justify-center px-4 py-2 sm:px-6 md:px-8">
                       <div
                         aria-hidden="true"
-                        className="h-[clamp(29rem,55vh,33rem)] w-full max-w-[22rem] sm:max-w-[23rem] md:max-w-[24rem] lg:max-w-[25rem]"
+                        className="h-[clamp(24rem,50vh,29rem)] w-full max-w-[22rem] sm:max-w-[23rem] md:max-w-[24rem] lg:max-w-[25rem]"
                       >
                         {slide.preview}
                       </div>


### PR DESCRIPTION
## Summary
- Makes the Meet One feature rows equal height and removes the extra blank spacing below them.
- Aligns the three post-intro preview cards to one shared card height so the carousel feels consistent.
- UI-only change; no route, backend, auth, agent, search, or data behavior changed.

## Verification
- npm run lint -- --max-warnings=0
- npm run typecheck
- Browser tests skipped per request.