### PR TITLE
fix: unbox Kai preference onboarding screens

### DIFF
--- a/hushh-webapp/components/kai/onboarding/KaiPersonaScreen.tsx
+++ b/hushh-webapp/components/kai/onboarding/KaiPersonaScreen.tsx
@@ -64,14 +64,14 @@ export function KaiPersonaScreen(props: {
       data-top-content-anchor="true"
       className="flex min-h-[100dvh] w-full flex-col bg-transparent px-5 pt-[var(--top-content-pad)] pb-[var(--app-screen-footer-pad)] sm:px-6 lg:px-[var(--page-inline-gutter-standard)]"
     >
-      <div className="mx-auto flex min-h-[calc(100dvh-var(--top-content-pad)-var(--app-screen-footer-pad))] w-full max-w-[42rem] flex-1 items-center">
-        <section className="w-full rounded-[32px] border border-black/[0.06] bg-white/[0.74] p-5 text-center shadow-[0_24px_80px_-56px_rgba(0,0,0,0.55)] backdrop-blur-2xl sm:p-7 lg:p-8 dark:border-white/10 dark:bg-white/[0.07]">
-          <div className="mx-auto flex w-full max-w-[33rem] flex-col items-center">
+      <div className="mx-auto flex min-h-[calc(100dvh-var(--top-content-pad)-var(--app-screen-footer-pad))] w-full max-w-[28rem] flex-1 items-center py-6">
+        <section className="w-full text-center">
+          <div className="mx-auto flex w-full flex-col items-center">
             <div
-              className={`grid h-14 w-14 place-items-center rounded-[18px] ${cfg.accent}`}
+              className={`grid h-[52px] w-[52px] place-items-center rounded-[17px] ${cfg.accent}`}
               aria-hidden="true"
             >
-              <Icon icon={icon} size={28} />
+              <Icon icon={icon} size={26} />
             </div>
 
             <div className="mt-5 space-y-3">
@@ -86,7 +86,7 @@ export function KaiPersonaScreen(props: {
               </p>
             </div>
 
-            <div className="mt-7 w-full rounded-[24px] border border-black/[0.06] bg-background/72 px-5 py-5 text-left shadow-[0_18px_48px_-42px_rgba(0,0,0,0.65)] dark:border-white/10 dark:bg-white/[0.05]">
+            <div className="mt-8 w-full border-y border-black/[0.08] py-5 text-left dark:border-white/10">
               <p className="text-[13px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
                 Kai profile
               </p>

--- a/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
+++ b/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
@@ -197,7 +197,7 @@ export function KaiPreferencesWizard(props: {
       <div
         className={cn(
           isPageLayout
-            ? "mx-auto flex min-h-[calc(100dvh-var(--top-content-pad)-var(--app-screen-footer-pad))] w-full max-w-[31rem] flex-col justify-center"
+            ? "mx-auto flex min-h-[calc(100dvh-var(--top-content-pad)-var(--app-screen-footer-pad))] w-full max-w-[25rem] flex-col justify-center py-6"
             : "w-full max-w-sm mx-auto flex min-h-[calc(100dvh-var(--app-screen-footer-pad))] flex-col",
           !isPageLayout && "min-h-0"
         )}
@@ -205,7 +205,7 @@ export function KaiPreferencesWizard(props: {
         <div
           className={cn(
             isPageLayout
-              ? "rounded-[26px] border border-black/[0.06] bg-white/[0.82] p-5 shadow-[0_22px_64px_-52px_rgba(0,0,0,0.48)] backdrop-blur-2xl sm:p-5 dark:border-white/10 dark:bg-white/[0.07]"
+              ? "w-full"
               : "contents"
           )}
         >
@@ -233,7 +233,7 @@ export function KaiPreferencesWizard(props: {
               ) : (
                 <span />
               )}
-              <span className="rounded-full bg-black/[0.035] px-3 py-1 text-[12px] font-medium tabular-nums text-muted-foreground dark:bg-white/10">
+              <span className="text-[12px] font-medium tabular-nums text-muted-foreground">
                 {progressValue}%
               </span>
             </div>
@@ -252,7 +252,7 @@ export function KaiPreferencesWizard(props: {
           <div
             className={cn(
               isPageLayout
-                ? "mx-auto flex w-full max-w-[25rem] flex-col pt-5 sm:pt-6"
+                ? "mx-auto flex w-full flex-col pt-8 sm:pt-9"
                 : "flex flex-1 flex-col pt-5"
             )}
           >
@@ -272,7 +272,7 @@ export function KaiPreferencesWizard(props: {
                 className={cn(
                   "tracking-normal text-balance text-foreground",
                   isPageLayout
-                    ? "text-[25px] font-medium leading-[1.12] sm:text-[27px]"
+                    ? "text-[30px] font-medium leading-[1.06] sm:text-[34px]"
                     : kaiAppSectionTitleClassName
                 )}
               >
@@ -283,14 +283,14 @@ export function KaiPreferencesWizard(props: {
             <RadioGroup
               value={activeValue ?? ""}
               onValueChange={handleSelect}
-              className={cn(isPageLayout ? "mt-6 gap-2.5 sm:mt-7" : "gap-3")}
+              className={cn(isPageLayout ? "mt-8 gap-3 sm:mt-9" : "gap-3")}
             >
               {activeQuestion.options.map((opt) => (
                 <RadioCardItem key={opt.value} value={opt.value} label={opt.label} />
               ))}
             </RadioGroup>
 
-            <div className={cn("space-y-3", isPageLayout ? "pt-6" : "mt-auto pt-6")}>
+            <div className={cn("space-y-3", isPageLayout ? "pt-8" : "mt-auto pt-6")}>
               <Button
                 type="button"
                 variant="none"


### PR DESCRIPTION
## Summary
- Removes the boxed/card-shell treatment from the three-question Kai preference onboarding page.
- Removes the heavy outer card from the dynamic persona/result screen and makes the profile summary calmer.
- UI-only; no save, skip, edit, routing, backend, auth, agent, search, or portfolio behavior changed.

## Verification
- npm run lint -- --max-warnings=0
- npm run typecheck
- Browser tests skipped per request.