### PR TITLE
fix: restore Kai portfolio import chrome isolation

### DIFF
--- a/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
+++ b/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
@@ -9,16 +9,16 @@ function read(relativePath: string) {
   return fs.readFileSync(path.join(WEBAPP_ROOT, relativePath), "utf8");
 }
 
-describe("Navbar Agent trigger contract", () => {
-  it("keeps the embedded bottom-right Agent entrypoint wired to the popover provider", () => {
+describe("Navbar bottom chrome contract", () => {
+  it("keeps Agent owned by search chrome instead of duplicating it beside the nav", () => {
     const navbar = read("components/navbar.tsx");
-    const provider = read("components/agent/agent-popover-provider.tsx");
+    const searchBar = read("components/kai/kai-search-bar.tsx");
 
-    expect(provider).toContain("useOptionalAgentPopover");
     expect(navbar).toContain("useOptionalAgentPopover");
-    expect(navbar).toContain('data-testid="bottom-agent-trigger"');
-    expect(navbar).toContain('aria-label="Open Agent"');
-    expect(navbar).toContain("agentPopover.openAgent()");
     expect(navbar).toContain('style={{ width: "calc(100% - 66px)" }}');
+    expect(navbar).not.toContain('data-testid="bottom-agent-trigger"');
+    expect(searchBar).toContain("kai-bottom-agent-action");
+    expect(searchBar).toContain('aria-label="Open Agent"');
+    expect(searchBar).toContain("agentPopover.openAgent()");
   });
 });

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -27,6 +27,7 @@ import {
   ThumbsDown,
   ThumbsUp,
   UserRound,
+  X,
 } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -2774,6 +2775,19 @@ export function AgentChatWorkspace({
                   title="Minimize Agent"
                 >
                   <Minus className="h-4 w-4" />
+                </Button>
+              ) : null}
+              {isPopover && onMinimize ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-9 w-9 rounded-lg text-[rgba(0,0,0,0.56)] hover:bg-black/[0.04] hover:text-[#1d1d1f] focus-visible:ring-2 focus-visible:ring-primary/60 dark:text-zinc-300 dark:hover:bg-white/[0.07] dark:hover:text-zinc-50 sm:hidden"
+                  onClick={onMinimize}
+                  aria-label="Close Agent"
+                  title="Close Agent"
+                >
+                  <X className="h-4 w-4" />
                 </Button>
               ) : null}
               {windowControls ? <div className="ml-1">{windowControls}</div> : null}

--- a/hushh-webapp/components/kai/kai-command-bar-global.tsx
+++ b/hushh-webapp/components/kai/kai-command-bar-global.tsx
@@ -241,6 +241,9 @@ export function KaiCommandBarGlobal() {
   const reviewScreenActive = Boolean(
     busyOperations["portfolio_review_active"] || busyOperations["portfolio_save"]
   );
+  const portfolioImportSurfaceActive = Boolean(
+    busyOperations["portfolio_import_surface"]
+  );
   const reviewDirty = Boolean(
     busyOperations["portfolio_review_active"] && busyOperations["portfolio_review_dirty"]
   );
@@ -727,7 +730,7 @@ export function KaiCommandBarGlobal() {
     ]
   );
 
-  if (!mounted || loading || !user || reviewScreenActive) {
+  if (!mounted || loading || !user || reviewScreenActive || portfolioImportSurfaceActive) {
     return null;
   }
 

--- a/hushh-webapp/components/kai/kai-flow.tsx
+++ b/hushh-webapp/components/kai/kai-flow.tsx
@@ -660,6 +660,19 @@ export function KaiFlow({
     stateRef.current = state;
   }, [state]);
 
+  const portfolioImportSurfaceActive =
+    state === "import_required" ||
+    state === "importing" ||
+    state === "import_complete" ||
+    state === "reviewing";
+
+  useEffect(() => {
+    setBusyOperation("portfolio_import_surface", portfolioImportSurfaceActive);
+    return () => {
+      setBusyOperation("portfolio_import_surface", false);
+    };
+  }, [portfolioImportSurfaceActive, setBusyOperation]);
+
   useScrollReset(`${mode}:${state}`, { enabled: true, behavior: "auto" });
 
   const plaidPortfolioData =

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -97,6 +97,9 @@ export const Navbar = () => {
     pathname === ROUTES.DEVELOPERS;
   const agentWindowOpen =
     agentPopover?.expanded || agentPopover?.motionState === "opening";
+  const portfolioImportSurfaceActive = Boolean(
+    busyOperations["portfolio_import_surface"]
+  );
 
   const navOptions = useMemo<SegmentedPillOption[]>(
     () =>
@@ -170,7 +173,7 @@ export const Navbar = () => {
     [activePersona, pendingConsents]
   );
 
-  if (hideNavbar || agentWindowOpen) {
+  if (hideNavbar || agentWindowOpen || portfolioImportSurfaceActive) {
     return null;
   }
 

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -6,7 +6,6 @@
 import React, { useEffect, useMemo, type CSSProperties } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import {
-  Bot,
   BriefcaseBusiness,
   ChartNoAxesColumnIncreasing,
   Compass,
@@ -292,21 +291,6 @@ export const Navbar = () => {
             )}
           />
         </div>
-        {agentPopover ? (
-          <button
-            type="button"
-            aria-label="Open Agent"
-            title="Open Agent"
-            data-testid="bottom-agent-trigger"
-            onClick={() => agentPopover.openAgent()}
-            className={cn(
-              "pointer-events-auto chrome-bottom-foreground flex h-[58px] w-[58px] shrink-0 items-center justify-center rounded-[22px] border border-black/[0.08] bg-white/92 text-[#1c1c1e] shadow-[0_10px_30px_rgba(15,23,42,0.16)] backdrop-blur-xl transition-colors hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 dark:border-white/[0.12] dark:bg-[#1c1c1e]/90 dark:text-white dark:shadow-black/30 dark:hover:bg-[#2c2c2e]",
-              hideBottomChrome && "pointer-events-none"
-            )}
-          >
-            <Bot className="h-5 w-5" aria-hidden="true" />
-          </button>
-        ) : null}
       </div>
     </nav>
   );


### PR DESCRIPTION
## Summary\n- hide global bottom nav/search/agent while Kai portfolio import, import progress, and review surfaces are active\n- keep PortfolioImportView, Plaid, upload, sample brokerage, skip, and save handlers unchanged\n- restore click/visibility room for import CTAs on /kai/portfolio when no portfolio data exists\n\n## Validation\n- npm run lint -- --max-warnings=0\n- npm run typecheck\n\nBrowser tests intentionally skipped per maintainer request.