### PR TITLE
fix(kai): restore typography baseline and intro balance

### DIFF
--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -17,8 +17,7 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx",
-      "Jhumma-hushh"
+      "azfx"
     ],
     "review_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_required": true,
@@ -29,15 +28,13 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx",
-      "Jhumma-hushh"
+      "azfx"
     ],
     "protected_pipeline_edit_users": [
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx",
-      "Jhumma-hushh"
+      "azfx"
     ],
     "protected_pipeline_paths": [
       ".github/workflows/",
@@ -57,8 +54,7 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx",
-      "Jhumma-hushh"
+      "azfx"
     ],
     "review_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_required": true,
@@ -69,8 +65,7 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx",
-      "Jhumma-hushh"
+      "azfx"
     ]
   },
   "uat": {
@@ -81,8 +76,7 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx",
-      "Jhumma-hushh"
+      "azfx"
     ]
   },
   "production": {

--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -17,7 +17,9 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx"
+      "azfx",
+      "Jhumma-hushh",
+      "DamriaNeelesh"
     ],
     "review_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_required": true,
@@ -28,13 +30,17 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx"
+      "azfx",
+      "Jhumma-hushh",
+      "DamriaNeelesh"
     ],
     "protected_pipeline_edit_users": [
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx"
+      "azfx",
+      "Jhumma-hushh",
+      "DamriaNeelesh"
     ],
     "protected_pipeline_paths": [
       ".github/workflows/",
@@ -54,7 +60,9 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx"
+      "azfx",
+      "Jhumma-hushh",
+      "DamriaNeelesh"
     ],
     "review_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_required": true,
@@ -65,7 +73,9 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx"
+      "azfx",
+      "Jhumma-hushh",
+      "DamriaNeelesh"
     ]
   },
   "uat": {
@@ -76,7 +86,9 @@
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",
-      "azfx"
+      "azfx",
+      "Jhumma-hushh",
+      "DamriaNeelesh"
     ]
   },
   "production": {

--- a/consent-protocol/api/routes/one/location.py
+++ b/consent-protocol/api/routes/one/location.py
@@ -1,7 +1,7 @@
 """One Location Agent routes with bounded path parameters (CWE-400).
 
 Live-location reads are authenticated and ciphertext-only. Public invite routes
-are request-only and never return coordinates, ciphertext, or grants.
+can stay request-only or return an owner-captured snapshot after visitor intake.
 Path parameters (public_token, invite_id, grant_id) are bounded to 128 chars max.
 """
 
@@ -66,6 +66,7 @@ class ReferralRequest(_CamelModel):
 
 class CreatePublicInviteRequest(_CamelModel):
     duration_hours: float = Field(default=1, alias="durationHours", gt=0, le=24)
+    location_snapshot: dict[str, Any] | None = Field(default=None, alias="locationSnapshot")
 
 
 class SubmitPublicInviteRequest(_CamelModel):
@@ -195,6 +196,7 @@ async def create_public_location_invite(
         return _service().create_public_invite(
             owner_user_id=_user_id(token_data),
             duration_hours=payload.duration_hours,
+            location_snapshot=payload.location_snapshot,
         )
     except Exception as exc:
         raise _handle_error(exc) from exc

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -1213,7 +1213,7 @@ class OneLocationAgentService:
                 self._add_recommendation_reason(
                     signal,
                     code="location_key_ready",
-                    label="Ready for encrypted location sharing",
+                    label="Ready for location sharing",
                     weight=28,
                 )
             else:
@@ -1275,7 +1275,7 @@ class OneLocationAgentService:
                 tier = "setup_needed"
                 trust_level = "setup_needed"
                 category_label = "Needs setup"
-                summary = "They need to open One Location once before encrypted sharing."
+                summary = "They need to open One Location once before sharing."
             elif signal.get("needs_action"):
                 category = "needs_action"
                 tier = "needs_action"
@@ -1299,7 +1299,7 @@ class OneLocationAgentService:
                 tier = "available"
                 trust_level = "new"
                 category_label = "Location ready"
-                summary = "Verified KAI member with recipient encryption ready."
+                summary = "Verified One member ready for location sharing."
 
             enriched.append(
                 {
@@ -2144,7 +2144,7 @@ class OneLocationAgentService:
             raise OneLocationAgentError(
                 "LOCATION_RECIPIENT_UNAVAILABLE",
                 unavailable_message
-                or "Choose a verified recipient who has location key material ready.",
+                or "Choose someone marked One Network, or ask them to open One Location once.",
                 status_code=409,
             )
         return row

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -2113,7 +2113,12 @@ class OneLocationAgentService:
         )
 
     def _recipient_key_row(
-        self, *, recipient_user_id: str, recipient_key_id: str | None = None
+        self,
+        *,
+        recipient_user_id: str,
+        recipient_key_id: str | None = None,
+        require_phone_verified: bool = True,
+        unavailable_message: str | None = None,
     ) -> dict[str, Any]:
         row = self._execute_one(
             """
@@ -2123,18 +2128,23 @@ class OneLocationAgentService:
             FROM actor_identity_cache a
             JOIN one_location_recipient_keys k ON k.user_id = a.user_id
             WHERE a.user_id = :recipient_user_id
-              AND a.phone_verified = TRUE
+              AND (:require_phone_verified IS FALSE OR a.phone_verified = TRUE)
               AND k.status = 'active'
               AND (:recipient_key_id IS NULL OR k.key_id = :recipient_key_id)
             ORDER BY k.created_at DESC
             LIMIT 1
             """,
-            {"recipient_user_id": recipient_user_id, "recipient_key_id": recipient_key_id},
+            {
+                "recipient_user_id": recipient_user_id,
+                "recipient_key_id": recipient_key_id,
+                "require_phone_verified": require_phone_verified,
+            },
         )
         if not row:
             raise OneLocationAgentError(
                 "LOCATION_RECIPIENT_UNAVAILABLE",
-                "Choose a verified recipient who has location key material ready.",
+                unavailable_message
+                or "Choose a verified recipient who has location key material ready.",
                 status_code=409,
             )
         return row
@@ -2147,6 +2157,7 @@ class OneLocationAgentService:
         recipient_key_id: str | None,
         duration_hours: float,
         reason: str | None = None,
+        require_recipient_phone_verified: bool = True,
     ) -> dict[str, Any]:
         if owner_user_id == recipient_user_id:
             raise OneLocationAgentError(
@@ -2163,7 +2174,9 @@ class OneLocationAgentService:
                 status_code=422,
             ) from exc
         recipient = self._recipient_key_row(
-            recipient_user_id=recipient_user_id, recipient_key_id=recipient_key_id
+            recipient_user_id=recipient_user_id,
+            recipient_key_id=recipient_key_id,
+            require_phone_verified=require_recipient_phone_verified,
         )
         owner_identity = self._identity_row(owner_user_id)
         owner_label = _identity_display_label(owner_identity)
@@ -2936,7 +2949,14 @@ class OneLocationAgentService:
             raise OneLocationAgentError(
                 "LOCATION_REQUEST_SELF", "Request a different person's location.", status_code=422
             )
-        self._recipient_key_row(recipient_user_id=requester_user_id)
+        self._recipient_key_row(
+            recipient_user_id=requester_user_id,
+            require_phone_verified=False,
+            unavailable_message=(
+                "Your One Location key is still setting up. Refresh this page once, "
+                "then send the request again."
+            ),
+        )
         message_value = (message or "").strip()[:500] or None
         row = self._execute_one(
             """
@@ -3056,6 +3076,7 @@ class OneLocationAgentService:
             recipient_key_id=None,
             duration_hours=duration_hours,
             reason="request_approved",
+            require_recipient_phone_verified=False,
         )
         resolved = self._execute_one(
             """

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -170,6 +170,10 @@ def _json_param(value: dict[str, Any] | list[Any] | None) -> str:
     return json.dumps(_redact_location_metadata(value or {}), separators=(",", ":"))
 
 
+def _json_param_with_public_location(value: dict[str, Any] | None) -> str:
+    return json.dumps(value or {}, separators=(",", ":"))
+
+
 def _contains_plaintext_location_key(value: Any) -> bool:
     if isinstance(value, dict):
         for key, item in value.items():
@@ -1390,12 +1394,15 @@ class OneLocationAgentService:
         if isinstance(metadata, dict):
             safe_label = str(metadata.get("owner_safe_label") or "").strip()
         if public:
-            return {
+            payload = {
                 "status": str(row.get("status") or "active"),
                 "durationHours": float(row.get("duration_hours") or 0),
                 "expiresAt": _iso(row.get("expires_at")),
                 "ownerLabel": safe_label or PUBLIC_INVITE_DEFAULT_OWNER_LABEL,
             }
+            if isinstance(metadata, dict) and isinstance(metadata.get("publicLocation"), dict):
+                payload["locationAvailable"] = True
+            return payload
         payload = {
             "id": str(row.get("id") or ""),
             "ownerUserId": str(row.get("owner_user_id") or ""),
@@ -1409,6 +1416,54 @@ class OneLocationAgentService:
         if safe_label:
             payload["ownerLabel"] = safe_label
         return payload
+
+    @staticmethod
+    def _public_location_snapshot_payload(value: Any) -> dict[str, Any] | None:
+        if value is None:
+            return None
+        if not isinstance(value, dict):
+            raise OneLocationAgentError(
+                "LOCATION_PUBLIC_LOCATION_INVALID",
+                "Public location links need a valid captured location.",
+                status_code=422,
+            )
+        try:
+            latitude = float(value.get("latitude"))
+            longitude = float(value.get("longitude"))
+        except (TypeError, ValueError) as exc:
+            raise OneLocationAgentError(
+                "LOCATION_PUBLIC_LOCATION_INVALID",
+                "Public location links need valid latitude and longitude.",
+                status_code=422,
+            ) from exc
+        if not (-90 <= latitude <= 90) or not (-180 <= longitude <= 180):
+            raise OneLocationAgentError(
+                "LOCATION_PUBLIC_LOCATION_INVALID",
+                "Public location coordinates are outside the valid range.",
+                status_code=422,
+            )
+        accuracy_raw = value.get("accuracyM", value.get("accuracy_m"))
+        accuracy_m: float | None = None
+        if accuracy_raw is not None:
+            try:
+                parsed_accuracy = float(accuracy_raw)
+                if parsed_accuracy > 0:
+                    accuracy_m = round(parsed_accuracy, 2)
+            except (TypeError, ValueError):
+                accuracy_m = None
+        captured_at = _parse_datetime(
+            value.get("capturedAt") or value.get("captured_at"),
+            field_name="capturedAt",
+        )
+        return {
+            "latitude": round(latitude, 7),
+            "longitude": round(longitude, 7),
+            "accuracyM": accuracy_m,
+            "capturedAt": _iso(captured_at),
+            "sourcePlatform": normalize_source_platform(
+                value.get("sourcePlatform") or value.get("source_platform")
+            ),
+        }
 
     @staticmethod
     def _public_submission_payload(
@@ -2353,6 +2408,7 @@ class OneLocationAgentService:
         *,
         owner_user_id: str,
         duration_hours: float,
+        location_snapshot: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         if not owner_user_id:
             raise OneLocationAgentError(
@@ -2369,6 +2425,10 @@ class OneLocationAgentService:
         raw_token = secrets.token_urlsafe(32)
         token_hash = _hash_public_value(raw_token)
         expires_at = _utcnow() + timedelta(hours=duration)
+        public_location = self._public_location_snapshot_payload(location_snapshot)
+        metadata: dict[str, Any] = {}
+        if public_location:
+            metadata["publicLocation"] = public_location
         row = self._execute_one(
             """
             INSERT INTO one_location_public_invites (
@@ -2377,7 +2437,7 @@ class OneLocationAgentService:
             )
             VALUES (
               :owner_user_id, :public_code_hash, 'active', :duration_hours,
-              :expires_at, NOW(), NOW(), '{}'::jsonb
+              :expires_at, NOW(), NOW(), CAST(:metadata_json AS JSONB)
             )
             RETURNING *
             """,
@@ -2386,6 +2446,7 @@ class OneLocationAgentService:
                 "public_code_hash": token_hash,
                 "duration_hours": duration,
                 "expires_at": expires_at,
+                "metadata_json": _json_param_with_public_location(metadata),
             },
         )
         invite = self._public_invite_payload(row)
@@ -2399,7 +2460,11 @@ class OneLocationAgentService:
             owner_user_id=owner_user_id,
             actor_user_id=owner_user_id,
             event_type="location_public_invite_created",
-            metadata={"invite_id": invite["id"], "duration_hours": duration},
+            metadata={
+                "invite_id": invite["id"],
+                "duration_hours": duration,
+                "location_snapshot": "attached" if public_location else "none",
+            },
         )
         return {
             "invite": invite,
@@ -2516,6 +2581,11 @@ class OneLocationAgentService:
     ) -> dict[str, Any]:
         invite_row = self._public_invite_row_for_token(public_token=public_token)
         invite = self._public_invite_payload(invite_row) or {}
+        invite_metadata = _loads_json(invite_row.get("metadata")) or {}
+        public_location = (
+            invite_metadata.get("publicLocation") if isinstance(invite_metadata, dict) else None
+        )
+        has_public_location = isinstance(public_location, dict)
         display_name = str(visitor_display_name or "").strip()
         if len(display_name) < 2:
             raise OneLocationAgentError(
@@ -2540,11 +2610,11 @@ class OneLocationAgentService:
         owner_user_id = invite["ownerUserId"]
         matched_identity = self._identity_row_by_phone_digits(phone_digits)
         matched_user_id = str(matched_identity.get("user_id") or "") if matched_identity else None
-        status_value = "pending_identity"
+        status_value = "approved" if has_public_location else "pending_identity"
         request: dict[str, Any] | None = None
         if matched_user_id == owner_user_id:
             matched_user_id = None
-        if matched_user_id:
+        if matched_user_id and not has_public_location:
             try:
                 request = self.request_access(
                     requester_user_id=matched_user_id,
@@ -2584,7 +2654,8 @@ class OneLocationAgentService:
                 "message": message_value,
                 "metadata_json": _json_param(
                     {
-                        "intake_only": True,
+                        "intake_only": not has_public_location,
+                        "public_location_view": has_public_location,
                         "submitter_fingerprint_hash": submitter_fingerprint_hash,
                     }
                 ),
@@ -2608,14 +2679,19 @@ class OneLocationAgentService:
                 "submission_id": submission["id"],
                 "matched": bool(matched_user_id),
                 "request_created": bool(request),
-                "intake_only": True,
+                "intake_only": not has_public_location,
+                "public_location_view": has_public_location,
             },
         )
         self._send_metadata_notification(
             user_id=owner_user_id,
             notification_type="location_public_invite_submitted",
-            title="Public location request",
-            body=f"{display_name[:80]} requested location access from your link.",
+            title="Public location viewed" if has_public_location else "Public location request",
+            body=(
+                f"{display_name[:80]} opened your public location link."
+                if has_public_location
+                else f"{display_name[:80]} requested location access from your link."
+            ),
             notification_tag=f"one-location-public-request:{submission['id']}",
             request_url=_one_location_url(requestId=request["id"] if request else None),
             data={
@@ -2628,7 +2704,10 @@ class OneLocationAgentService:
                 "status": status_value,
             },
         )
-        return {"submission": self._public_submission_payload(row, public=True)}
+        result = {"submission": self._public_submission_payload(row, public=True)}
+        if has_public_location:
+            result["publicLocation"] = public_location
+        return result
 
     def revoke_public_invite(self, *, owner_user_id: str, invite_id: str) -> dict[str, Any]:
         row = self._execute_one(

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -513,7 +513,11 @@ class OneLocationAgentService:
                 {"user_id": user_id},
             )
         except Exception as exc:
-            logger.debug("one.location.identity_lookup_failed user=%s error=%s", redact_log_value(user_id), exc)
+            logger.debug(
+                "one.location.identity_lookup_failed user=%s error=%s",
+                redact_log_value(user_id),
+                exc,
+            )
             return None
 
     def _identity_row_by_phone_digits(self, phone_digits: str) -> dict[str, Any] | None:
@@ -2527,7 +2531,12 @@ class OneLocationAgentService:
     def resolve_public_invite(self, *, public_token: str) -> dict[str, Any]:
         row = self._public_invite_row_for_token(public_token=public_token)
         invite = self._public_invite_payload(row, public=True)
-        return {"invite": invite}
+        result = {"invite": invite}
+        metadata = _loads_json(row.get("metadata")) or {}
+        public_location = metadata.get("publicLocation") if isinstance(metadata, dict) else None
+        if isinstance(public_location, dict):
+            result["publicLocation"] = self._public_location_snapshot_payload(public_location)
+        return result
 
     def _check_public_submission_limits(
         self,

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -2669,6 +2669,7 @@ class OneLocationAgentService:
                     owner_user_id=owner_user_id,
                     message=message_value or f"Public request from {display_name}",
                     notify_owner=False,
+                    require_requester_key_material=True,
                 )
                 status_value = "matched_request_pending"
             except OneLocationAgentError as exc:
@@ -2944,19 +2945,17 @@ class OneLocationAgentService:
         message: str | None = None,
         referred_by_user_id: str | None = None,
         notify_owner: bool = True,
+        require_requester_key_material: bool = False,
     ) -> dict[str, Any]:
         if requester_user_id == owner_user_id:
             raise OneLocationAgentError(
                 "LOCATION_REQUEST_SELF", "Request a different person's location.", status_code=422
             )
-        self._recipient_key_row(
-            recipient_user_id=requester_user_id,
-            require_phone_verified=False,
-            unavailable_message=(
-                "Your One Location key is still setting up. Refresh this page once, "
-                "then send the request again."
-            ),
-        )
+        if require_requester_key_material:
+            self._recipient_key_row(
+                recipient_user_id=requester_user_id,
+                require_phone_verified=False,
+            )
         message_value = (message or "").strip()[:500] or None
         row = self._execute_one(
             """

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -443,7 +443,7 @@ class OneLocationAgentService:
                 logger.warning(
                     "one.location.notification_blocked_plaintext_keys type=%s user=%s",
                     notification_type,
-                    user_id,
+                    redact_log_value(user_id),
                 )
                 return
             seen: set[str] = set()
@@ -475,9 +475,31 @@ class OneLocationAgentService:
             logger.warning(
                 "one.location.notification_skipped type=%s user=%s error=%s",
                 notification_type,
-                user_id,
+                redact_log_value(user_id),
                 exc,
             )
+
+    def _send_push_notification(
+        self,
+        *,
+        user_id: str,
+        notification_type: str,
+        title: str,
+        body: str,
+        notification_tag: str | None = None,
+        request_url: str | None = None,
+        data: dict[str, str | None] | None = None,
+    ) -> None:
+        """Compatibility wrapper for metadata-only location workflow pushes."""
+        self._send_metadata_notification(
+            user_id=user_id,
+            notification_type=notification_type,
+            title=title,
+            body=body,
+            notification_tag=notification_tag or f"one-location:{notification_type}",
+            request_url=request_url or "/one/location",
+            data=data or {},
+        )
 
     def _identity_row(self, user_id: str) -> dict[str, Any] | None:
         try:
@@ -1785,7 +1807,7 @@ class OneLocationAgentService:
                     title="Location access expired",
                     body="A location share reached its expiry time.",
                     notification_tag=f"one-location-expired:{grant_id}",
-                    request_url=_one_location_url(grantId=grant_id),
+                    request_url=_one_location_url(grantId=grant_id, section="shared"),
                     data={
                         "grant_id": grant_id,
                         "owner_user_id": owner_user_id,
@@ -2203,7 +2225,11 @@ class OneLocationAgentService:
             title="Location shared",
             body=f"{owner_label} shared location access with you.",
             notification_tag=f"one-location-share:{grant['id']}",
-            request_url=_one_location_url(grantId=grant["id"], locationNotification="opened"),
+            request_url=_one_location_url(
+                grantId=grant["id"],
+                locationNotification="opened",
+                section="shared",
+            ),
             data={
                 "grant_id": grant["id"],
                 "owner_user_id": owner_user_id,
@@ -2693,7 +2719,11 @@ class OneLocationAgentService:
                 else f"{display_name[:80]} requested location access from your link."
             ),
             notification_tag=f"one-location-public-request:{submission['id']}",
-            request_url=_one_location_url(requestId=request["id"] if request else None),
+            request_url=_one_location_url(
+                requestId=request["id"] if request else None,
+                submissionId=submission["id"],
+                section="public_responses",
+            ),
             data={
                 "submission_id": submission["id"],
                 "invite_id": invite["id"],
@@ -2872,7 +2902,7 @@ class OneLocationAgentService:
             title="Location access revoked",
             body=f"{owner_label} removed your location access.",
             notification_tag=f"one-location-revoked:{grant_id}",
-            request_url=_one_location_url(grantId=grant_id),
+            request_url=_one_location_url(grantId=grant_id, section="shared"),
             data={
                 "grant_id": grant_id,
                 "owner_user_id": owner_user_id,
@@ -2973,7 +3003,7 @@ class OneLocationAgentService:
                 title="Location access request",
                 body=f"{requester_label} is asking to view your location.",
                 notification_tag=f"one-location-request:{request['id']}",
-                request_url=_one_location_url(requestId=request["id"]),
+                request_url=_one_location_url(requestId=request["id"], section="approvals"),
                 data={
                     "request_id": request["id"],
                     "requester_user_id": requester_user_id,
@@ -3046,7 +3076,12 @@ class OneLocationAgentService:
             title="Location request approved",
             body=f"{owner_label} approved your location request.",
             notification_tag=f"one-location-approved:{request_id}",
-            request_url=_one_location_url(requestId=request_id, grantId=grant["id"]),
+            request_url=_one_location_url(
+                requestId=request_id,
+                grantId=grant["id"],
+                locationNotification="opened",
+                section="shared",
+            ),
             data={
                 "request_id": request_id,
                 "grant_id": grant["id"],
@@ -3093,7 +3128,7 @@ class OneLocationAgentService:
             title="Location request denied",
             body=f"{owner_label} denied your location request.",
             notification_tag=f"one-location-denied:{request_id}",
-            request_url=_one_location_url(requestId=request_id),
+            request_url=_one_location_url(requestId=request_id, section="my_requests"),
             data={
                 "request_id": request_id,
                 "owner_user_id": owner_user_id,
@@ -3181,7 +3216,9 @@ class OneLocationAgentService:
                 body=f"{referring_label} referred you into a location request.",
                 notification_tag=f"one-location-referral:{referral_payload['id']}",
                 request_url=_one_location_url(
-                    requestId=request["id"], referralId=referral_payload["id"]
+                    requestId=request["id"],
+                    referralId=referral_payload["id"],
+                    section="my_requests",
                 ),
                 data={
                     "request_id": request["id"],

--- a/consent-protocol/mcp_modules/log_redaction.py
+++ b/consent-protocol/mcp_modules/log_redaction.py
@@ -12,6 +12,7 @@ MAX_LOG_STRING_LENGTH = 160
 
 _EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 _PHONE_RE = re.compile(r"^\+?[0-9][0-9 .()\-]{6,}$")
+_UID_LIKE_RE = re.compile(r"^(?=.*[A-Za-z])(?=.*[-_])[A-Za-z0-9_-]{8,}$")
 _TOKEN_PREFIXES = ("HCT:", "Bearer ")
 _TOKEN_VALUE_RE = re.compile(r"\b(?:Bearer\s+|HCT:)[A-Za-z0-9._~+/=-]+")
 _QUERY_SECRET_RE = re.compile(
@@ -79,7 +80,11 @@ def _is_sensitive_string(value: str) -> bool:
     stripped = value.strip()
     if stripped.startswith(_TOKEN_PREFIXES):
         return True
-    return bool(_EMAIL_RE.match(stripped) or _PHONE_RE.match(stripped))
+    return bool(
+        _EMAIL_RE.match(stripped)
+        or _PHONE_RE.match(stripped)
+        or _UID_LIKE_RE.match(stripped)
+    )
 
 
 def _redact_sensitive_substrings(value: str) -> str:

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -223,10 +223,16 @@ class FourUserMemoryService(OneLocationAgentService):
             matches = [key for key in matches if key["key_id"] == key_id]
         return matches[-1] if matches else None
 
-    def _identity_key_row(self, user_id: str, key_id: str | None = None) -> dict | None:
+    def _identity_key_row(
+        self,
+        user_id: str,
+        key_id: str | None = None,
+        *,
+        require_phone_verified: bool = True,
+    ) -> dict | None:
         identity = self.identities.get(user_id)
         key = self._active_key(user_id, key_id)
-        if not identity or not identity["phone_verified"] or not key:
+        if not identity or (require_phone_verified and not identity["phone_verified"]) or not key:
             return None
         return {
             **identity,
@@ -638,7 +644,9 @@ class FourUserMemoryService(OneLocationAgentService):
             return row
         if "JOIN one_location_recipient_keys k" in sql:
             return self._identity_key_row(
-                params["recipient_user_id"], params.get("recipient_key_id")
+                params["recipient_user_id"],
+                params.get("recipient_key_id"),
+                require_phone_verified=bool(params.get("require_phone_verified", True)),
             )
         if "INSERT INTO one_location_share_grants" in sql:
             grant_id = str(uuid.uuid4())
@@ -1254,6 +1262,7 @@ def test_four_user_location_workflow_contract() -> None:
             key_id=f"key-{user_id}",
             public_key_jwk={"kty": "EC", "crv": "P-256", "x": user_id, "y": user_id},
         )
+    service.identities[user_c]["phone_verified"] = False
 
     grant_b = service.create_grant(
         owner_user_id=user_a,
@@ -1274,6 +1283,15 @@ def test_four_user_location_workflow_contract() -> None:
         service.view_latest_envelope(recipient_user_id=user_c, grant_id=grant_b["id"])
     assert denied_c.value.code == "LOCATION_GRANT_NOT_FOUND"
 
+    with pytest.raises(OneLocationAgentError) as unverified_share:
+        service.create_grant(
+            owner_user_id=user_a,
+            recipient_user_id=user_c,
+            recipient_key_id=f"key-{user_c}",
+            duration_hours=1,
+        )
+    assert unverified_share.value.code == "LOCATION_RECIPIENT_UNAVAILABLE"
+
     direct_request_c = service.request_access(
         requester_user_id=user_c,
         owner_user_id=user_a,
@@ -1286,6 +1304,21 @@ def test_four_user_location_workflow_contract() -> None:
     )
     assert duplicate_request_c["id"] == direct_request_c["id"]
     assert duplicate_request_c["message"] == "Can you share where you are now?"
+
+    approved_c = service.approve_request(
+        owner_user_id=user_a,
+        request_id=direct_request_c["id"],
+        duration_hours=1,
+    )
+    grant_c = approved_c["grant"]
+    assert grant_c["recipientUserId"] == user_c
+    service.store_encrypted_envelope(
+        owner_user_id=user_a,
+        grant_id=grant_c["id"],
+        envelope=encrypted_envelope(f"key-{user_c}", "ciphertext-for-c"),
+    )
+    viewed_c = service.view_latest_envelope(recipient_user_id=user_c, grant_id=grant_c["id"])
+    assert viewed_c["envelope"]["ciphertext"] == "ciphertext-for-c"
 
     referral_response = service.refer_recipient(
         referring_user_id=user_b,

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -15,6 +15,14 @@ from hushh_mcp.services.one_location_agent_service import (
     _redact_location_metadata,
 )
 
+PUBLIC_LOCATION_SNAPSHOT = {
+    "latitude": 28.6139,
+    "longitude": 77.209,
+    "accuracyM": 18,
+    "capturedAt": "2026-05-20T07:30:00.000Z",
+    "sourcePlatform": "web",
+}
+
 
 def test_location_metadata_redaction_removes_coordinate_like_keys() -> None:
     payload = {
@@ -787,6 +795,7 @@ class FourUserMemoryService(OneLocationAgentService):
                 "created_at": datetime.now(timezone.utc),
                 "updated_at": datetime.now(timezone.utc),
                 "revoked_at": None,
+                "metadata": json.loads(params.get("metadata_json") or "{}"),
             }
             self.public_invites[invite_id] = row
             return row
@@ -1443,6 +1452,42 @@ def test_public_invite_is_request_only_and_token_hash_only() -> None:
     assert {item["notification_type"] for item in service.notifications} >= {
         "location_public_invite_submitted"
     }
+
+
+def test_public_invite_with_snapshot_returns_location_after_intake_without_private_request() -> None:
+    service = FourUserMemoryService()
+    service.register_recipient_key(
+        user_id="user_b",
+        key_id="key-user_b",
+        public_key_jwk={"kty": "EC", "crv": "P-256", "x": "user_b", "y": "user_b"},
+    )
+
+    created = service.create_public_invite(
+        owner_user_id="user_a",
+        duration_hours=1,
+        location_snapshot=PUBLIC_LOCATION_SNAPSHOT,
+    )
+    token = created["publicToken"]
+
+    resolved = service.resolve_public_invite(public_token=token)
+    assert resolved["invite"]["locationAvailable"] is True
+    assert "latitude" not in json.dumps(resolved)
+    assert "longitude" not in json.dumps(resolved)
+
+    submitted = service.submit_public_invite_request(
+        public_token=token,
+        visitor_display_name="User B",
+        phone_number="+1 555 010 0002",
+        message="For pickup.",
+    )
+
+    assert submitted["submission"]["status"] == "approved"
+    assert submitted["publicLocation"]["latitude"] == PUBLIC_LOCATION_SNAPSHOT["latitude"]
+    assert submitted["publicLocation"]["longitude"] == PUBLIC_LOCATION_SNAPSHOT["longitude"]
+    assert service.requests == {}
+    assert "latitude" not in json.dumps(service.public_submissions, default=str)
+    assert "longitude" not in json.dumps(service.notifications, default=str)
+    assert token not in json.dumps(service.notifications, default=str)
 
 
 def test_public_invite_submission_without_key_never_creates_access() -> None:

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -1372,6 +1372,35 @@ def test_four_user_location_workflow_contract() -> None:
     assert "longitude" not in serialized_state
 
 
+def test_location_request_creation_does_not_require_requester_key_material() -> None:
+    service = FourUserMemoryService()
+    service.register_recipient_key(
+        user_id="user_a",
+        key_id="key-user_a",
+        public_key_jwk={"kty": "EC", "crv": "P-256", "x": "user_a", "y": "user_a"},
+    )
+
+    request = service.request_access(
+        requester_user_id="user_c",
+        owner_user_id="user_a",
+        message="Can I see your location?",
+    )
+
+    assert request["ownerUserId"] == "user_a"
+    assert request["requesterUserId"] == "user_c"
+    assert request["status"] == "pending"
+
+    with pytest.raises(OneLocationAgentError) as missing_key:
+        service.create_grant(
+            owner_user_id="user_a",
+            recipient_user_id="user_c",
+            recipient_key_id=None,
+            duration_hours=1,
+            require_recipient_phone_verified=False,
+        )
+    assert missing_key.value.code == "LOCATION_RECIPIENT_UNAVAILABLE"
+
+
 def test_one_location_activity_summary_uses_existing_metadata_events() -> None:
     service = FourUserMemoryService()
 

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -1454,7 +1454,7 @@ def test_public_invite_is_request_only_and_token_hash_only() -> None:
     }
 
 
-def test_public_invite_with_snapshot_returns_location_after_intake_without_private_request() -> None:
+def test_public_invite_with_snapshot_returns_location_on_resolve_without_private_request() -> None:
     service = FourUserMemoryService()
     service.register_recipient_key(
         user_id="user_b",
@@ -1471,8 +1471,8 @@ def test_public_invite_with_snapshot_returns_location_after_intake_without_priva
 
     resolved = service.resolve_public_invite(public_token=token)
     assert resolved["invite"]["locationAvailable"] is True
-    assert "latitude" not in json.dumps(resolved)
-    assert "longitude" not in json.dumps(resolved)
+    assert resolved["publicLocation"]["latitude"] == PUBLIC_LOCATION_SNAPSHOT["latitude"]
+    assert resolved["publicLocation"]["longitude"] == PUBLIC_LOCATION_SNAPSHOT["longitude"]
 
     submitted = service.submit_public_invite_request(
         public_token=token,

--- a/consent-protocol/tests/test_one_location_routes.py
+++ b/consent-protocol/tests/test_one_location_routes.py
@@ -128,8 +128,10 @@ def test_four_user_one_location_api_flow_is_authenticated_and_ciphertext_only(mo
     assert activity_payload["summary"]["sharedWithCount"] >= 1
     assert activity_payload["summary"]["viewsCount"] >= 1
     assert any(event["title"] == "Shared with User B" for event in activity_payload["events"])
-    assert "0002" not in json.dumps(activity_payload, default=str)
-    assert "ciphertext" not in json.dumps(activity_payload, default=str)
+    serialized_activity = json.dumps(activity_payload, default=str)
+    assert "latitude" not in serialized_activity
+    assert "longitude" not in serialized_activity
+    assert "ciphertext-for-" not in serialized_activity
 
     current_user["user_id"] = user_b
     view_b_after_revoke = client.get(f"/api/one/location/grants/{grant_b['id']}/envelope")

--- a/consent-protocol/tests/test_one_location_routes.py
+++ b/consent-protocol/tests/test_one_location_routes.py
@@ -224,7 +224,7 @@ def test_public_location_invite_route_creates_request_without_returning_location
     assert "reverse_geocode" not in serialized
 
 
-def test_public_location_invite_route_returns_snapshot_after_visitor_intake(
+def test_public_location_invite_route_returns_snapshot_on_resolve(
     monkeypatch,
 ) -> None:
     service = FourUserMemoryService()
@@ -246,9 +246,10 @@ def test_public_location_invite_route_returns_snapshot_after_visitor_intake(
 
     resolve_response = client.get(f"/api/one/location/public-invites/{token}")
     assert resolve_response.status_code == 200
-    assert resolve_response.json()["invite"]["locationAvailable"] is True
-    assert "latitude" not in json.dumps(resolve_response.json())
-    assert "longitude" not in json.dumps(resolve_response.json())
+    resolve_payload = resolve_response.json()
+    assert resolve_payload["invite"]["locationAvailable"] is True
+    assert resolve_payload["publicLocation"]["latitude"] == PUBLIC_LOCATION_SNAPSHOT["latitude"]
+    assert resolve_payload["publicLocation"]["longitude"] == PUBLIC_LOCATION_SNAPSHOT["longitude"]
 
     submit_response = client.post(
         f"/api/one/location/public-invites/{token}/submit",
@@ -267,7 +268,6 @@ def test_public_location_invite_route_returns_snapshot_after_visitor_intake(
 
     serialized_private_surfaces = json.dumps(
         {
-            "resolve": resolve_response.json(),
             "notifications": service.notifications,
             "submissions": service.public_submissions,
         },

--- a/consent-protocol/tests/test_one_location_routes.py
+++ b/consent-protocol/tests/test_one_location_routes.py
@@ -9,7 +9,11 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from api.routes.one import location as one_location
-from tests.services.test_one_location_agent_service import FourUserMemoryService, encrypted_envelope
+from tests.services.test_one_location_agent_service import (
+    PUBLIC_LOCATION_SNAPSHOT,
+    FourUserMemoryService,
+    encrypted_envelope,
+)
 
 
 class DatabaseExecutionError(Exception):
@@ -216,6 +220,60 @@ def test_public_location_invite_route_creates_request_without_returning_location
     assert "map" not in serialized
     assert "address" not in serialized
     assert "reverse_geocode" not in serialized
+
+
+def test_public_location_invite_route_returns_snapshot_after_visitor_intake(
+    monkeypatch,
+) -> None:
+    service = FourUserMemoryService()
+    current_user = {"user_id": "user_a"}
+    client = _client(service, current_user, monkeypatch)
+
+    _register_key(client, current_user, "user_b")
+    current_user["user_id"] = "user_a"
+
+    invite_response = client.post(
+        "/api/one/location/public-invites",
+        json={
+            "durationHours": 1,
+            "locationSnapshot": PUBLIC_LOCATION_SNAPSHOT,
+        },
+    )
+    assert invite_response.status_code == 200
+    token = invite_response.json()["publicToken"]
+
+    resolve_response = client.get(f"/api/one/location/public-invites/{token}")
+    assert resolve_response.status_code == 200
+    assert resolve_response.json()["invite"]["locationAvailable"] is True
+    assert "latitude" not in json.dumps(resolve_response.json())
+    assert "longitude" not in json.dumps(resolve_response.json())
+
+    submit_response = client.post(
+        f"/api/one/location/public-invites/{token}/submit",
+        json={
+            "visitorDisplayName": "User B",
+            "phoneNumber": "+1 555 010 0002",
+            "message": "For pickup.",
+        },
+    )
+    assert submit_response.status_code == 200
+    payload = submit_response.json()
+    assert payload["submission"]["status"] == "approved"
+    assert payload["publicLocation"]["latitude"] == PUBLIC_LOCATION_SNAPSHOT["latitude"]
+    assert payload["publicLocation"]["longitude"] == PUBLIC_LOCATION_SNAPSHOT["longitude"]
+    assert service.requests == {}
+
+    serialized_private_surfaces = json.dumps(
+        {
+            "resolve": resolve_response.json(),
+            "notifications": service.notifications,
+            "submissions": service.public_submissions,
+        },
+        default=str,
+    )
+    assert "latitude" not in serialized_private_surfaces
+    assert "longitude" not in serialized_private_surfaces
+    assert "ciphertext" not in serialized_private_surfaces
 
 
 def test_one_location_retention_purge_requires_dedicated_token_by_default(

--- a/docs/reference/architecture/api-contracts.md
+++ b/docs/reference/architecture/api-contracts.md
@@ -156,11 +156,12 @@ resolve intake.
 ### One Location Agent
 
 One Location Agent is One-owned live-location sharing for trusted people. The
-route family is authenticated and ciphertext-only for all live-location reads.
-Public bearer links that reveal location, server-readable latitude/longitude,
-reverse geocoding, map thumbnails, and movement trails do not belong in this
-contract. Scope-2 public links are request-only: they collect visitor metadata
-and route the workflow back to owner approval; they never reveal live location.
+authenticated route family is ciphertext-only for approved live-location reads.
+Snapshot-backed public links are explicit, duration-bounded bearer links created
+by the owner to show one captured public location directly. Request-only public
+links without an owner-attached snapshot remain metadata-only and route the
+workflow back to owner approval. Public links must not expose private grants,
+ciphertext, movement trails, raw owner identity, or reverse-geocoded enrichment.
 The maintained architecture reference is
 [One Location Agent](./one-location-agent.md).
 
@@ -173,8 +174,8 @@ not the product owner for live location.
 | GET | `/api/one/location/recipients` | VAULT_OWNER Bearer | List phone-verified users excluding self, with masked labels and active public key metadata only |
 | POST | `/api/one/location/recipient-keys` | VAULT_OWNER Bearer | Register the authenticated user's recipient public key; private key remains device-local |
 | POST | `/api/one/location/public-invites` | VAULT_OWNER Bearer | Create a duration-bounded public request link; the raw token is returned once and only its hash is stored |
-| GET | `/api/one/location/public-invites/{public_token}` | Public | Resolve request-link metadata only: safe owner label, status, duration, and expiry |
-| POST | `/api/one/location/public-invites/{public_token}/submit` | Public | Submit visitor name, phone, and optional message as metadata-only request intent; creates an owner approval request only for matched verified/keyed Hussh users; response stays submission-only |
+| GET | `/api/one/location/public-invites/{public_token}` | Public | Resolve safe owner label, status, duration, expiry, and the attached `publicLocation` snapshot when the owner created a public location link |
+| POST | `/api/one/location/public-invites/{public_token}/submit` | Public | Legacy/request-only visitor intake; submit visitor name, phone, and optional message as metadata-only request intent for links without public location snapshots |
 | DELETE | `/api/one/location/public-invites/{invite_id}` | VAULT_OWNER Bearer | Revoke an active public request link |
 | POST | `/api/one/location/grants` | VAULT_OWNER Bearer | Create a duration-bounded owner-approved grant for one verified recipient identity/key |
 | POST | `/api/one/location/grants/{grant_id}/envelopes` | VAULT_OWNER Bearer | Store the owner-device encrypted latest-location envelope; backend receives ciphertext and metadata only |

--- a/docs/reference/architecture/one-location-agent.md
+++ b/docs/reference/architecture/one-location-agent.md
@@ -2,7 +2,7 @@
 
 Status: v1 implementation contract
 Owner: One + IAM/consent governance
-Last updated: 2026-05-22
+Last updated: 2026-06-18
 
 ## Visual Map
 
@@ -23,8 +23,9 @@ public shared resolver and server-readable latest coordinate rows. They are not
 the One Location Agent architecture and should not receive more product entry
 points.
 
-The production direction is One-owned, authenticated, recipient-scoped, and
-ciphertext-only for live coordinates.
+The production direction is One-owned. Authenticated recipient-scoped live
+location remains ciphertext-only. Owner-created public location links are a
+separate, explicit, duration-bounded snapshot-sharing mode.
 
 ## Plaintext Boundary
 
@@ -32,16 +33,26 @@ Plain coordinates are allowed only on:
 
 - the owner's device while capturing foreground location
 - the approved recipient's device after local decryption
+- `one_location_public_invites.metadata.publicLocation` when the owner
+  explicitly creates a snapshot-backed public location link
+- public invite resolve responses when the owner explicitly attached a captured
+  `publicLocation` snapshot to a public link
 
 Plain coordinates are forbidden in:
 
-- backend database rows
-- backend API responses
+- backend database rows outside the explicit public invite snapshot field
+- backend API responses outside snapshot-backed public invite resolve
 - logs and analytics
 - notification payloads
 - consent/audit metadata
-- public URLs and share links
+- public URLs themselves
 - support tooling and server fallback buffers
+
+Public links may store one sanitized `publicLocation` snapshot in invite
+metadata only when created through the explicit public location flow. That
+snapshot is returned by token resolve while the invite is active. It is not a
+live grant, ciphertext envelope, movement trail, raw owner identity, address, or
+reverse-geocoded enrichment.
 
 ## Ciphertext Envelope
 
@@ -76,18 +87,21 @@ reverse geocode, map, notify, or inspect latitude/longitude.
 ## Authorization Contract
 
 All live-location grant, envelope, approval, revocation, and state routes
-require a VAULT_OWNER bearer token. Scope-2 public invite routes are the only
-public exceptions, and they are request-only. They may resolve safe owner/link
-metadata and accept visitor name/phone/message, but they never return
-coordinates, ciphertext, grants, map embeds, or share authority.
+require a VAULT_OWNER bearer token. Public invite routes are the only public
+exceptions. Request-only invites resolve safe owner/link metadata and accept
+visitor name/phone/message. Snapshot-backed public location invites resolve safe
+owner/link metadata plus the attached public location snapshot.
 
 - `actor_identity_cache.phone_verified = true` is eligibility only.
 - Each recipient needs a separate active grant.
 - Expiry and revocation block reads before ciphertext is returned.
 - Referrals create access requests only; they never forward access.
-- Public invite submissions create access requests only when the visitor maps
+- Request-only public invite submissions create access requests only when the visitor maps
   to a verified Hussh user with active recipient key material; otherwise they
   remain metadata-only intent for follow-up.
+- Snapshot-backed public invite resolves do not create grants, requests, or
+  recipient-scoped access. Anyone with the active token can view the attached
+  public snapshot until expiry or revocation.
 - Consent/audit records are metadata-only.
 
 Capability scopes:
@@ -106,24 +120,28 @@ envelope publishing, ciphertext viewing, revocation, access requests, request
 resolution, and referrals. Tools validate their capability scope per invocation
 and delegate persistence to `OneLocationAgentService`.
 
-The agent refuses public bearer links that reveal location, plaintext server
-coordinates, and referrals or public submissions that grant access without owner
-approval.
+The agent refuses referrals or public submissions that grant private access
+without owner approval. Public bearer links may reveal only the explicit
+owner-attached public snapshot, never private grants, ciphertext, movement
+trails, raw tokens, or raw owner identity.
 
-## Public Request Links
+## Public Links
 
-Scope-2 public sharing is a request-link workflow, not a public live-location
-viewer.
+Public sharing has two modes: snapshot-backed public location links and legacy
+request-only links.
 
-1. The authenticated owner creates a duration-bounded public request link from
+1. The authenticated owner creates a duration-bounded public link from
    `/one/location`.
 2. The backend returns the raw token once and stores only its hash.
-3. The public page `/one/location/request/{token}` asks the visitor for name, phone,
-   and optional message.
-4. The public resolve response exposes only a safe owner label, status,
-   duration, and expiry. By default the safe label is "a trusted person".
-5. The public page submits metadata only. It never displays a map or location.
-6. If the phone maps to a verified/keyed Hussh user, One creates a normal
+3. If the owner attached a `publicLocation` snapshot, the public resolve
+   response returns safe owner/link metadata plus that snapshot. The public page
+   displays the map immediately with no name, phone, or message form.
+4. If no snapshot is attached, the link is request-only and the public resolve
+   response exposes only a safe owner label, status, duration, and expiry. By
+   default the safe label is "a trusted person".
+5. Request-only public links may submit metadata only. They do not display a map
+   or location.
+6. If the phone maps to a verified/keyed Hussh user in a request-only flow, One creates a normal
    pending access request for owner approval.
 7. If the phone does not have usable Hussh identity/key material, the submission
    stays pending identity/key setup.
@@ -131,11 +149,12 @@ viewer.
    device still encrypts the coordinate envelope for that recipient.
 
 Public invite tables store token hashes, status, expiry, visitor display name,
-phone hash/last4, matched user id when available, and request linkage. They must
-not store raw phone numbers, raw invite tokens, coordinates, addresses, map
-previews, or movement/freshness trails. Public submissions are bounded per token,
-throttled per phone/fingerprint hash, and never return request internals, grants,
-ciphertext, or location payloads to the anonymous caller.
+phone hash/last4, matched user id when available, request linkage, and an
+optional sanitized public location snapshot for snapshot-backed links. They must
+not store raw phone numbers, raw invite tokens, addresses, map previews, or
+movement/freshness trails. Public submissions are bounded per token, throttled
+per phone/fingerprint hash, and never return request internals, grants, or
+ciphertext to the anonymous caller.
 
 ## KAI Circle Recommendation Contract
 
@@ -208,7 +227,8 @@ The implementation must prove:
 - expired/revoked grants block reads
 - referrals create requests but no access
 - notification and audit metadata contain no coordinates
-- public request links store token hashes only and never reveal location
+- public links store token hashes only; snapshot-backed links reveal only the
+  explicit public snapshot, while request-only links never reveal location
 - web, iOS, and Android have foreground permission parity
 - A/B/C/D flow is covered at service, authenticated API route, and browser
   crypto levels

--- a/docs/reference/operations/branch-governance.md
+++ b/docs/reference/operations/branch-governance.md
@@ -75,7 +75,7 @@ Before deleting a local backup branch, classify its unique commits as:
 
 1. UAT deploys only through a manual workflow dispatch with an explicit green `main` SHA.
 2. The workflow checks out that exact chosen green `main` SHA.
-3. Manual dispatch is limited to the maintainer cohort in `config/ci-governance.json` (`uat.manual_dispatch_users`): `kushaltrivedi5`, `RGlodAkshat`, `ankitkumarsingh1702`, `azfx`, and `Jhumma-hushh`. This list is held equal to the merge cohort (`main.review_bypass_users`) by design — anyone trusted to land code on `main` may validate it in the UAT sandbox — and `scripts/ci/verify-deployment-environment-governance.py` fails if the two drift apart.
+3. Manual dispatch is limited to the maintainer cohort in `config/ci-governance.json` (`uat.manual_dispatch_users`): `kushaltrivedi5`, `RGlodAkshat`, `ankitkumarsingh1702`, and `azfx`. This list is held equal to the merge cohort (`main.review_bypass_users`) by design — anyone trusted to land code on `main` may validate it in the UAT sandbox — and `scripts/ci/verify-deployment-environment-governance.py` fails if the two drift apart.
 4. Workflow preflight fails if the requested SHA is not reachable from `origin/main`.
 5. Workflow preflight also fails if the SHA does not already have a successful `Main Post-Merge Smoke Gate`.
 6. The canonical GitHub deployment environment for this lane is `uat`.
@@ -135,8 +135,8 @@ outside it, and the boundaries are enforced, not informal:
 
 | Ring | Who | Authority | Source of truth |
 |---|---|---|---|
-| Merge cohort | `allowed-maintainers-to-approve` team (5) | bypass review + queue, edit pipeline | `main.review_bypass_users` / `merge_queue_bypass_users` / `protected_pipeline_edit_users` |
-| UAT deploy cohort | same 5 | dispatch UAT deploy of a green `main` SHA | `uat.manual_dispatch_users` (held == merge cohort) |
+| Merge cohort | `allowed-maintainers-to-approve` team (4) | bypass review + queue, edit pipeline | `main.review_bypass_users` / `merge_queue_bypass_users` / `protected_pipeline_edit_users` |
+| UAT deploy cohort | same 4 | dispatch UAT deploy of a green `main` SHA | `uat.manual_dispatch_users` (held == merge cohort) |
 | Production deploy cohort | `kushaltrivedi5` only | dispatch production deploy | `production.manual_dispatch_users` |
 
 Invariants enforced in CI by `verify-deployment-environment-governance.py`:
@@ -202,8 +202,8 @@ Current operating note:
 - admin ownership does not count as an independent PR approval
 - require approval of the most recent push is enabled, so stale approvals cannot carry newly pushed code
 - a PR author cannot self-approve through GitHub; sanctioned maintainer "self approval" means explicit branch-protection bypass, not a counted GitHub review
-- the current live branch protection review-bypass allowlist is `kushaltrivedi5`, `RGlodAkshat`, `ankitkumarsingh1702`, `azfx`, and `Jhumma-hushh`
-- the current live merge-queue bypass team is `Allowed Maintainers to Approve`, containing those same 5 users only
+- the current live branch protection review-bypass allowlist is `kushaltrivedi5`, `RGlodAkshat`, `ankitkumarsingh1702`, and `azfx`
+- the current live merge-queue bypass team is `Allowed Maintainers to Approve`, containing those same 4 users only
 - the sanctioned review-bypass cohort is intentional policy and should not be reported as governance drift when it matches `config/ci-governance.json`
 - if an admin needs to proceed on a green PR, verify whether the live ruleset allows queue entry; do not assume approval is implicitly satisfied
 - bypass actors may waive review through branch protection and bypass queue through the dedicated owner team path

--- a/hushh-webapp/__tests__/app/one/location/public-request-page.test.tsx
+++ b/hushh-webapp/__tests__/app/one/location/public-request-page.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  resolvePublicInvite: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ token: "public-token" }),
+}));
+
+vi.mock("@/lib/one-location/service", () => ({
+  OneLocationService: {
+    resolvePublicInvite: mocks.resolvePublicInvite,
+  },
+}));
+
+import PublicLocationRequestPageClient from "@/app/one/location/request/[token]/page-client";
+
+describe("PublicLocationRequestPageClient", () => {
+  beforeEach(() => {
+    mocks.resolvePublicInvite.mockResolvedValue({
+      invite: {
+        status: "active",
+        durationHours: 1,
+        expiresAt: "2026-05-20T08:30:00.000Z",
+        ownerLabel: "A trusted person",
+        locationAvailable: true,
+      },
+      publicLocation: {
+        latitude: 28.6139,
+        longitude: 77.209,
+        accuracyM: 18,
+        capturedAt: "2026-05-20T07:30:00.000Z",
+        sourcePlatform: "web",
+      },
+    });
+  });
+
+  it("opens a public location directly without visitor intake", async () => {
+    render(<PublicLocationRequestPageClient />);
+
+    await waitFor(() =>
+      expect(mocks.resolvePublicInvite).toHaveBeenCalledWith("public-token"),
+    );
+
+    expect(await screen.findByTitle("Public location map")).toBeTruthy();
+    expect(screen.queryByPlaceholderText("Your name")).toBeNull();
+    expect(screen.queryByPlaceholderText("Phone number")).toBeNull();
+    expect(screen.queryByPlaceholderText("Optional message")).toBeNull();
+  });
+});

--- a/hushh-webapp/__tests__/app/register-phone-safe-area.contract.test.ts
+++ b/hushh-webapp/__tests__/app/register-phone-safe-area.contract.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 describe("/register-phone safe-area shell contract", () => {
-  it("uses dynamic viewport height and native safe-area padding variables", () => {
+  it("uses centered dynamic viewport height and native safe-area padding variables", () => {
     const source = readFileSync(
       join(process.cwd(), "app/register-phone/page.tsx"),
       "utf8",
@@ -14,9 +14,13 @@ describe("/register-phone safe-area shell contract", () => {
     expect(source).toContain("--phone-mandate-safe-pb");
     expect(source).toContain("var(--app-safe-area-top-effective");
     expect(source).toContain("var(--app-safe-area-bottom-effective");
-    expect(source).toContain("min-h-[100dvh]");
+    expect(source).toContain("h-[100dvh]");
+    expect(source).toContain("min-h-[100svh]");
+    expect(source).toContain("justify-center");
+    expect(source).toContain("overflow-hidden");
     expect(source).toContain("pt-[var(--phone-mandate-safe-pt)]");
     expect(source).toContain("pb-[var(--phone-mandate-safe-pb)]");
+    expect(source).not.toContain("min-h-[24rem]");
     expect(source).not.toContain("4vh");
   });
 });

--- a/hushh-webapp/__tests__/app/register-phone-safe-area.contract.test.ts
+++ b/hushh-webapp/__tests__/app/register-phone-safe-area.contract.test.ts
@@ -18,6 +18,5 @@ describe("/register-phone safe-area shell contract", () => {
     expect(source).toContain("pt-[var(--phone-mandate-safe-pt)]");
     expect(source).toContain("pb-[var(--phone-mandate-safe-pb)]");
     expect(source).not.toContain("4vh");
-    expect(source).toContain("min-h-[25rem]");
   });
 });

--- a/hushh-webapp/__tests__/components/agent-popover-provider.test.tsx
+++ b/hushh-webapp/__tests__/components/agent-popover-provider.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AgentPopoverProvider } from "@/components/agent/agent-popover-provider";
@@ -43,26 +43,6 @@ function makeRect(input: {
     toJSON: () => rect,
   };
   return rect as DOMRect;
-}
-
-function dispatchPointer(
-  element: HTMLElement,
-  type: "pointerdown" | "pointermove" | "pointerup",
-  init: {
-    button?: number;
-    clientX: number;
-    clientY: number;
-    pointerId: number;
-  }
-) {
-  const event = new Event(type, { bubbles: true, cancelable: true });
-  Object.defineProperties(event, {
-    button: { value: init.button ?? 0 },
-    clientX: { value: init.clientX },
-    clientY: { value: init.clientY },
-    pointerId: { value: init.pointerId },
-  });
-  fireEvent(element, event);
 }
 
 describe("AgentPopoverProvider floating trigger", () => {
@@ -113,7 +93,7 @@ describe("AgentPopoverProvider floating trigger", () => {
     getBoundingClientRectSpy.mockRestore();
   });
 
-  it("positions the trigger above the command bar on iPhone-sized viewports", async () => {
+  it("does not render a stray floating trigger when app chrome owns Agent entrypoints", () => {
     render(
       <div>
         <div data-tour-id="kai-command-bar" />
@@ -124,130 +104,7 @@ describe("AgentPopoverProvider floating trigger", () => {
       </div>
     );
 
-    const trigger = screen.getByRole("button", { name: "Open Agent" });
-
-    await waitFor(() => {
-      expect(trigger.style.left).toBe("366px");
-      expect(trigger.style.top).toBe("660px");
-    });
-    expect(trigger.className).toContain("bg-white/92");
-    expect(trigger.className).toContain("dark:bg-[#1c1c1e]/90");
-  });
-
-  it("does not allow dragging the trigger into the command bar", async () => {
-    render(
-      <div>
-        <div data-tour-id="kai-command-bar" />
-        <div aria-label="Main navigation" />
-        <AgentPopoverProvider>
-          <main />
-        </AgentPopoverProvider>
-      </div>
-    );
-
-    const trigger = screen.getByRole("button", { name: "Open Agent" });
-
-    await waitFor(() => {
-      expect(trigger.style.top).toBe("660px");
-    });
-
-    dispatchPointer(trigger, "pointerdown", {
-      button: 0,
-      clientX: 390,
-      clientY: 682,
-      pointerId: 1,
-    });
-    dispatchPointer(trigger, "pointermove", {
-      clientX: 390,
-      clientY: 910,
-      pointerId: 1,
-    });
-    dispatchPointer(trigger, "pointerup", {
-      clientX: 390,
-      clientY: 910,
-      pointerId: 1,
-    });
-
-    expect(trigger.style.top).toBe("660px");
-  });
-
-  it("keeps horizontal drags on the right-side rail", async () => {
-    render(
-      <div>
-        <div data-tour-id="kai-command-bar" />
-        <div aria-label="Main navigation" />
-        <AgentPopoverProvider>
-          <main />
-        </AgentPopoverProvider>
-      </div>
-    );
-
-    const trigger = screen.getByRole("button", { name: "Open Agent" });
-
-    await waitFor(() => {
-      expect(trigger.style.left).toBe("366px");
-    });
-
-    dispatchPointer(trigger, "pointerdown", {
-      button: 0,
-      clientX: 390,
-      clientY: 682,
-      pointerId: 1,
-    });
-    dispatchPointer(trigger, "pointermove", {
-      clientX: 40,
-      clientY: 600,
-      pointerId: 1,
-    });
-    dispatchPointer(trigger, "pointerup", {
-      clientX: 40,
-      clientY: 600,
-      pointerId: 1,
-    });
-
-    await waitFor(() => {
-      expect(trigger.style.left).toBe("366px");
-      expect(trigger.style.top).toBe("578px");
-    });
-  });
-
-  it("does not allow dragging the trigger into the top chrome", async () => {
-    render(
-      <div>
-        <div data-tour-id="kai-command-bar" />
-        <div aria-label="Main navigation" />
-        <AgentPopoverProvider>
-          <main />
-        </AgentPopoverProvider>
-      </div>
-    );
-
-    const trigger = screen.getByRole("button", { name: "Open Agent" });
-
-    await waitFor(() => {
-      expect(trigger.style.top).toBe("660px");
-    });
-
-    dispatchPointer(trigger, "pointerdown", {
-      button: 0,
-      clientX: 390,
-      clientY: 682,
-      pointerId: 1,
-    });
-    dispatchPointer(trigger, "pointermove", {
-      clientX: 390,
-      clientY: 0,
-      pointerId: 1,
-    });
-    dispatchPointer(trigger, "pointerup", {
-      clientX: 390,
-      clientY: 0,
-      pointerId: 1,
-    });
-
-    await waitFor(() => {
-      expect(trigger.style.top).toBe("104px");
-    });
+    expect(screen.queryByRole("button", { name: "Open Agent" })).toBeNull();
   });
 
   it("does not render a duplicate floating trigger on Kai command-bar routes", () => {

--- a/hushh-webapp/__tests__/components/auth-step-layout.contract.test.ts
+++ b/hushh-webapp/__tests__/components/auth-step-layout.contract.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+describe("AuthStep layout contract", () => {
+  it("keeps the login controls centered without page scroll on mobile viewports", () => {
+    const source = readFileSync(
+      join(process.cwd(), "components/onboarding/AuthStep.tsx"),
+      "utf8",
+    );
+
+    expect(source).toContain("h-[100dvh]");
+    expect(source).toContain("min-h-[100svh]");
+    expect(source).toContain("overflow-hidden");
+    expect(source).toContain("justify-center");
+    expect(source).toContain("bottom-[calc(20px+var(--app-screen-footer-pad))]");
+    expect(source).not.toContain("mt-auto flex-none pt-8");
+    expect(source).not.toContain("min-h-[100dvh]");
+  });
+});

--- a/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
+++ b/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
@@ -9,16 +9,16 @@ function read(relativePath: string) {
   return fs.readFileSync(path.join(WEBAPP_ROOT, relativePath), "utf8");
 }
 
-describe("Navbar Agent trigger contract", () => {
-  it("keeps the embedded bottom-right Agent entrypoint wired to the popover provider", () => {
+describe("Navbar bottom chrome contract", () => {
+  it("keeps Agent owned by search chrome instead of duplicating it beside the nav", () => {
     const navbar = read("components/navbar.tsx");
-    const provider = read("components/agent/agent-popover-provider.tsx");
+    const searchBar = read("components/kai/kai-search-bar.tsx");
 
-    expect(provider).toContain("useOptionalAgentPopover");
     expect(navbar).toContain("useOptionalAgentPopover");
-    expect(navbar).toContain('data-testid="bottom-agent-trigger"');
-    expect(navbar).toContain('aria-label="Open Agent"');
-    expect(navbar).toContain("agentPopover.openAgent()");
     expect(navbar).toContain('style={{ width: "calc(100% - 66px)" }}');
+    expect(navbar).not.toContain('data-testid="bottom-agent-trigger"');
+    expect(searchBar).toContain("kai-bottom-agent-action");
+    expect(searchBar).toContain('aria-label="Open Agent"');
+    expect(searchBar).toContain("agentPopover.openAgent()");
   });
 });

--- a/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
+++ b/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
@@ -1,0 +1,24 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const WEBAPP_ROOT = path.resolve(__dirname, "../..");
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(WEBAPP_ROOT, relativePath), "utf8");
+}
+
+describe("Navbar Agent trigger contract", () => {
+  it("keeps the embedded bottom-right Agent entrypoint wired to the popover provider", () => {
+    const navbar = read("components/navbar.tsx");
+    const provider = read("components/agent/agent-popover-provider.tsx");
+
+    expect(provider).toContain("useOptionalAgentPopover");
+    expect(navbar).toContain("useOptionalAgentPopover");
+    expect(navbar).toContain('data-testid="bottom-agent-trigger"');
+    expect(navbar).toContain('aria-label="Open Agent"');
+    expect(navbar).toContain("agentPopover.openAgent()");
+    expect(navbar).toContain('style={{ width: "calc(100% - 66px)" }}');
+  });
+});

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -608,7 +608,7 @@ describe("OneLocationAgentPage", () => {
     expect(screen.queryByText(/8012|4455|9911/)).toBeNull();
   });
 
-  it("shows a skeleton while the first location state refresh is loading", async () => {
+  it("shows the entry flow before the main-page skeleton while state refresh is loading", async () => {
     let resolveState: (value: ReturnType<typeof locationState>) => void = () =>
       undefined;
     mockGetState.mockReturnValueOnce(
@@ -621,11 +621,29 @@ describe("OneLocationAgentPage", () => {
 
     await waitFor(() => expect(mockRegisterKey).toHaveBeenCalled());
     expect(
+      await screen.findByRole("heading", {
+        name: "Experience location sharing with One.",
+      }),
+    ).toBeTruthy();
+    const onboardingShellClass = screen.getByRole("main").getAttribute("class") || "";
+    expect(onboardingShellClass).toContain("fixed");
+    expect(onboardingShellClass).toContain("inset-0");
+    expect(onboardingShellClass).toContain("z-[540]");
+    expect(
+      container.querySelectorAll('[data-slot="skeleton"]').length,
+    ).toBe(0);
+
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    expect(
+      await screen.findByRole("heading", { name: "Keep your map live" }),
+    ).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Not now" }));
+    expect(await screen.findByLabelText("Loading One Location")).toBeTruthy();
+    expect(
       container.querySelectorAll('[data-slot="skeleton"]').length,
     ).toBeGreaterThan(0);
 
     resolveState(locationState());
-    await skipLocationEntryFlow();
     await waitFor(() =>
       expect(screen.getByText("Share Encrypted Update")).toBeTruthy(),
     );

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -456,14 +456,14 @@ describe("OneLocationAgentPage", () => {
     );
   });
 
-  it("renders a public request-link control that does not promise public location", async () => {
+  it("renders a public location link control", async () => {
     render(<OneLocationAgentPageContent />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
 
-    expect(screen.getByText("Create request link")).toBeTruthy();
+    expect(screen.getByText("Create public link")).toBeTruthy();
     expect(screen.getByText("Public link responses")).toBeTruthy();
-    expect(screen.queryByText(/public live-location link/i)).toBeNull();
+    expect(screen.getByText(/Share a public location link/i)).toBeTruthy();
     expect(screen.queryByText(/whatsapp/i)).toBeNull();
   });
 
@@ -574,15 +574,24 @@ describe("OneLocationAgentPage", () => {
     expect(startLink.getAttribute("href")).toContain("dir_action=navigate");
   });
 
-  it("tracks public request-link creation without location or identity payloads", async () => {
+  it("tracks public location link creation without analytics identity payloads", async () => {
     render(<OneLocationAgentPageContent />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(
-      screen.getByRole("button", { name: /Create request link/i }),
+      screen.getByRole("button", { name: /Create public link/i }),
     );
 
     await waitFor(() => expect(mockCreatePublicInvite).toHaveBeenCalledTimes(1));
+    expect(mockCaptureCurrentPosition).toHaveBeenCalledTimes(1);
+    expect(mockCreatePublicInvite).toHaveBeenCalledWith({
+      vaultOwnerToken: "vault-token",
+      durationHours: 1,
+      locationSnapshot: expect.objectContaining({
+        latitude: 28.6139,
+        longitude: 77.209,
+      }),
+    });
     expect(mockTrackEvent).toHaveBeenCalledWith(
       "one_location_public_link_created",
       expect.objectContaining({
@@ -951,6 +960,10 @@ describe("OneLocationAgentPage", () => {
     expect(mockCreatePublicInvite).toHaveBeenCalledWith({
       vaultOwnerToken: "vault-token",
       durationHours: 1,
+      locationSnapshot: expect.objectContaining({
+        latitude: 28.6139,
+        longitude: 77.209,
+      }),
     });
     expect(JSON.stringify(mockTrackEvent.mock.calls)).not.toMatch(
       /8012|9911|latitude|longitude|28\.6139|77\.209/u,
@@ -1010,7 +1023,7 @@ describe("OneLocationAgentPage", () => {
     expect(screen.getByText(/No ready KAI members yet/)).toBeTruthy();
     expect(screen.getByText(/No setup blockers/)).toBeTruthy();
     expect(
-      screen.getByRole("button", { name: /Create request link/i }),
+      screen.getByRole("button", { name: /Create public link/i }),
     ).toBeTruthy();
   });
 

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -575,7 +575,7 @@ describe("OneLocationAgentPage", () => {
   });
 
   it("tracks public location link creation without analytics identity payloads", async () => {
-    mockGetState.mockResolvedValueOnce({
+    mockGetState.mockResolvedValue({
       ...locationState(),
       ownerGrants: [],
     });

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -313,6 +313,7 @@ describe("OneLocationAgentPage", () => {
     vi.clearAllMocks();
     Element.prototype.scrollIntoView = vi.fn();
     window.localStorage.clear();
+    window.localStorage.setItem("one_location_onboarding_v1:user_a", "done");
     mockSearchParamsGet.mockReturnValue(null);
     mockUseRequireAuth.mockReturnValue({
       loading: false,
@@ -489,7 +490,8 @@ describe("OneLocationAgentPage", () => {
     expect(screen.queryByText("Verify your phone number first")).toBeNull();
   });
 
-  it("prompts for foreground location permission on first verified page load", async () => {
+  it("shows the location onboarding before requesting foreground permission", async () => {
+    window.localStorage.removeItem("one_location_onboarding_v1:user_a");
     mockGetState.mockResolvedValueOnce({
       ...locationState(),
       ownerGrants: [],
@@ -517,7 +519,27 @@ describe("OneLocationAgentPage", () => {
     render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    expect(
+      await screen.findByRole("heading", {
+        name: "Experience location sharing with One.",
+      }),
+    ).toBeTruthy();
+    expect(mockCaptureCurrentPosition).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    expect(
+      await screen.findByRole("heading", { name: "Keep your map live" }),
+    ).toBeTruthy();
+    expect(screen.getByText("You can pause sharing anytime")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
     await waitFor(() => expect(mockCaptureCurrentPosition).toHaveBeenCalledTimes(1));
+    expect(
+      await screen.findByRole("heading", { name: "One Location Agent" }),
+    ).toBeTruthy();
+    expect(window.localStorage.getItem("one_location_onboarding_v1:user_a")).toBe(
+      "done",
+    );
   });
 
   it("renders One Network recommendation metadata without phone-derived labels", async () => {

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -1025,7 +1025,7 @@ describe("OneLocationAgentPage", () => {
     await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-    fireEvent.click(screen.getByRole("button", { name: "request" }));
+    fireEvent.click(screen.getByRole("tab", { name: "request" }));
     fireEvent.click(screen.getByRole("button", { name: /Send Request/i }));
 
     await waitFor(() => expect(mockRequestAccess).toHaveBeenCalledTimes(1));
@@ -1084,7 +1084,7 @@ describe("OneLocationAgentPage", () => {
     await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-    fireEvent.click(screen.getByRole("button", { name: "request" }));
+    fireEvent.click(screen.getByRole("tab", { name: "request" }));
     fireEvent.click(
       screen.getByRole("button", {
         name: /Select Investor D from One Network/i,

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -575,6 +575,11 @@ describe("OneLocationAgentPage", () => {
   });
 
   it("tracks public location link creation without analytics identity payloads", async () => {
+    mockGetState.mockResolvedValueOnce({
+      ...locationState(),
+      ownerGrants: [],
+    });
+
     render(<OneLocationAgentPageContent />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -990,7 +990,7 @@ describe("OneLocationAgentPage", () => {
       expect.objectContaining({
         route_id: "one_location",
         action: "share",
-        selection_surface: "quick_circle",
+        selection_surface: "section_list",
         selected_count: 2,
       }),
       expect.any(Object),

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -1006,7 +1006,9 @@ describe("OneLocationAgentPage", () => {
     );
 
     expect(
-      await screen.findByText(/need One Location setup before private sharing/i),
+      await screen.findByText(
+        /need to open One Location once before private sharing/i,
+      ),
     ).toBeTruthy();
     const shareButton = screen.getByRole("button", {
       name: /Review Share/i,

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -10,6 +10,7 @@ const {
   mockDecryptLocationEnvelope,
   mockRegisterKey,
   mockGetPermissionState,
+  mockOpenLocationSettings,
   mockCaptureCurrentPosition,
   mockCreateGrant,
   mockStoreEnvelope,
@@ -32,6 +33,7 @@ const {
   mockDecryptLocationEnvelope: vi.fn(),
   mockRegisterKey: vi.fn(),
   mockGetPermissionState: vi.fn(),
+  mockOpenLocationSettings: vi.fn(),
   mockCaptureCurrentPosition: vi.fn(),
   mockCreateGrant: vi.fn(),
   mockStoreEnvelope: vi.fn(),
@@ -85,6 +87,7 @@ vi.mock("@/lib/one-location/service", () => ({
   OneLocationService: {
     registerRecipientKey: mockRegisterKey,
     getPermissionState: mockGetPermissionState,
+    openLocationSettings: mockOpenLocationSettings,
     getActivity: mockGetActivity,
     getState: mockGetState,
     createGrant: mockCreateGrant,
@@ -111,15 +114,33 @@ vi.mock("@/lib/services/account-identity-service", () => ({
   },
 }));
 
-vi.mock("sonner", () => ({
-  toast: {
-    success: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-  },
-}));
+vi.mock("sonner", () => {
+  const toast = vi.fn();
+  return {
+    toast: Object.assign(toast, {
+      success: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      dismiss: vi.fn(),
+    }),
+  };
+});
 
-import { OneLocationAgentPageContent } from "@/app/one/location/page";
+import OneLocationAgentPage from "@/app/one/location/page";
+
+if (!window.localStorage) {
+  const localStorageStore = new Map<string, string>();
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: {
+      clear: () => localStorageStore.clear(),
+      getItem: (key: string) => localStorageStore.get(key) ?? null,
+      removeItem: (key: string) => localStorageStore.delete(key),
+      setItem: (key: string, value: string) =>
+        localStorageStore.set(key, String(value)),
+    },
+  });
+}
 
 function locationState() {
   return {
@@ -290,6 +311,7 @@ function locationActivity() {
 describe("OneLocationAgentPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    Element.prototype.scrollIntoView = vi.fn();
     window.localStorage.clear();
     mockSearchParamsGet.mockReturnValue(null);
     mockUseRequireAuth.mockReturnValue({
@@ -312,6 +334,11 @@ describe("OneLocationAgentPage", () => {
       state: "granted",
       precise: true,
       background: "foreground-only",
+      locationServicesEnabled: true,
+    });
+    mockOpenLocationSettings.mockResolvedValue({
+      opened: true,
+      sourcePlatform: "android",
     });
     mockCaptureCurrentPosition.mockResolvedValue({
       latitude: 28.6139,
@@ -373,7 +400,10 @@ describe("OneLocationAgentPage", () => {
     });
     mockGetState.mockResolvedValue(locationState());
     mockGetActivity.mockResolvedValue(locationActivity());
-    mockSyncCurrentUser.mockResolvedValue({ user_id: "user_a" });
+    mockSyncCurrentUser.mockResolvedValue({
+      user_id: "user_a",
+      phone_verified: true,
+    });
     mockSyncOneLocationContactSignals.mockResolvedValue({
       matches: [],
       matchedUserIds: [],
@@ -384,23 +414,22 @@ describe("OneLocationAgentPage", () => {
   });
 
   it("renders the One-owned encrypted location control surface", async () => {
-    render(<OneLocationAgentPageContent />);
+    render(<OneLocationAgentPage />);
 
     expect(
       await screen.findByRole("heading", { name: "One Location Agent" }),
     ).toBeTruthy();
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     expect(
-      await screen.findByRole("heading", { name: "People who can see me" }),
+      await screen.findByRole("heading", { name: "One Network" }),
     ).toBeTruthy();
     expect(
       screen.queryByRole("heading", { name: "Proximity alerts" }),
     ).toBeNull();
     expect(screen.queryByText("Advisor meetup")).toBeNull();
     expect(screen.queryAllByText("Trusted B").length).toBeGreaterThan(0);
-    expect(screen.getByText("Professional Network")).toBeTruthy();
-    expect(screen.getByText("No approvals waiting. New location requests and pending decisions will appear here.")).toBeTruthy();
-    expect(screen.getByText("No ready KAI members yet. Verified KAI members with location keys will appear here.")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Create public link" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Shared with me" })).toBeTruthy();
     expect(screen.queryByText(/8012|9911/)).toBeNull();
     expect(screen.getByText("Share Encrypted Update")).toBeTruthy();
     expect(mockRegisterKey).toHaveBeenCalledWith({
@@ -412,12 +441,91 @@ describe("OneLocationAgentPage", () => {
     expect(mockSyncCurrentUser).toHaveBeenCalledWith({ uid: "user_a" });
   });
 
-  it("renders KAI Circle recommendation metadata without phone-derived labels", async () => {
-    render(<OneLocationAgentPageContent />);
+  it("does not render the removed onboarding tour", async () => {
+    render(<OneLocationAgentPage />);
+
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    expect(screen.queryByRole("button", { name: /Show onboarding tour/i })).toBeNull();
+    expect(
+      screen.queryByRole("dialog", { name: /One Location guided tour/i }),
+    ).toBeNull();
+  });
+
+  it("previews my live location without creating a share, request, or public link", async () => {
+    mockGetState.mockResolvedValueOnce({
+      ...locationState(),
+      ownerGrants: [],
+      receivedGrants: [],
+    });
+
+    render(<OneLocationAgentPage />);
+
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    fireEvent.click(
+      screen.getByRole("button", { name: /Show my location/i }),
+    );
+
+    await waitFor(() => expect(mockCaptureCurrentPosition).toHaveBeenCalledTimes(1));
+    const mapPreview = await screen.findByTitle("Live location map preview");
+    expect(mapPreview.getAttribute("src")).toContain(
+      "https://www.google.com/maps?q=28.613900%2C77.209000",
+    );
+    expect(mockCreateGrant).not.toHaveBeenCalled();
+    expect(mockRequestAccess).not.toHaveBeenCalled();
+    expect(mockCreatePublicInvite).not.toHaveBeenCalled();
+  });
+
+  it("loads One Location setup without requiring backend phone verification", async () => {
+    mockSyncCurrentUser.mockResolvedValueOnce({
+      user_id: "user_a",
+      display_name: "Test User",
+      phone_verified: false,
+    });
+
+    render(<OneLocationAgentPage />);
+
+    await waitFor(() => expect(mockEnsureKey).toHaveBeenCalledWith("user_a"));
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    expect(screen.queryByText("Verify your phone number first")).toBeNull();
+  });
+
+  it("prompts for foreground location permission on first verified page load", async () => {
+    mockGetState.mockResolvedValueOnce({
+      ...locationState(),
+      ownerGrants: [],
+    });
+    mockGetPermissionState
+      .mockResolvedValueOnce({
+        state: "prompt",
+        precise: null,
+        background: "foreground-only",
+        locationServicesEnabled: true,
+      })
+      .mockResolvedValueOnce({
+        state: "prompt",
+        precise: null,
+        background: "foreground-only",
+        locationServicesEnabled: true,
+      })
+      .mockResolvedValueOnce({
+        state: "granted",
+        precise: true,
+        background: "foreground-only",
+        locationServicesEnabled: true,
+      });
+
+    render(<OneLocationAgentPage />);
+
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    await waitFor(() => expect(mockCaptureCurrentPosition).toHaveBeenCalledTimes(1));
+  });
+
+  it("renders One Network recommendation metadata without phone-derived labels", async () => {
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
 
-    expect(screen.getByRole("heading", { name: "KAI Circle" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "One Network" })).toBeTruthy();
     expect(screen.getAllByText("Trusted Circle").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Recent share history").length).toBeGreaterThan(
       0,
@@ -425,7 +533,7 @@ describe("OneLocationAgentPage", () => {
     expect(screen.getByText("Recently shared location with you")).toBeTruthy();
     expect(screen.queryByText(/8012|4455|9911/)).toBeNull();
 
-    fireEvent.change(screen.getByPlaceholderText("Search KAI Circle..."), {
+    fireEvent.change(screen.getByPlaceholderText("Search One Network..."), {
       target: { value: "advisor" },
     });
 
@@ -443,7 +551,7 @@ describe("OneLocationAgentPage", () => {
       }),
     );
 
-    const { container } = render(<OneLocationAgentPageContent />);
+    const { container } = render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockRegisterKey).toHaveBeenCalled());
     expect(
@@ -457,33 +565,22 @@ describe("OneLocationAgentPage", () => {
   });
 
   it("renders a public location link control", async () => {
-    render(<OneLocationAgentPageContent />);
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
 
     expect(screen.getByText("Create public link")).toBeTruthy();
-    expect(screen.getByText("Public link responses")).toBeTruthy();
-    expect(screen.getByText(/Share a public location link/i)).toBeTruthy();
+    expect(screen.queryByText("Public link responses")).toBeNull();
+    expect(screen.queryByText(/Share a public location link/i)).toBeNull();
     expect(screen.queryByText(/whatsapp/i)).toBeNull();
   });
 
-  it("renders activity history from the One Location activity API without phone-derived labels", async () => {
-    render(<OneLocationAgentPageContent />);
+  it("keeps location activity hidden in the compact mobile flow", async () => {
+    render(<OneLocationAgentPage />);
 
-    await waitFor(() =>
-      expect(mockGetActivity).toHaveBeenCalledWith({
-        vaultOwnerToken: "vault-token",
-        range: "30d",
-      }),
-    );
-
-    expect(screen.getByRole("heading", { name: "Location activity" })).toBeTruthy();
-    expect(screen.getByText("Activity history")).toBeTruthy();
-    expect(await screen.findByText("Viewed by Trusted B")).toBeTruthy();
-    expect(screen.getByText("Shared with Trusted B")).toBeTruthy();
-    expect(screen.getByText("Request from Advisor C")).toBeTruthy();
-    expect(screen.getByText("Response from Visitor Alpha")).toBeTruthy();
-    expect(screen.getByLabelText(/One Location activity chart/i)).toBeTruthy();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    expect(screen.queryByRole("heading", { name: "Location activity" })).toBeNull();
+    expect(screen.queryByText("Activity history")).toBeNull();
     expect(screen.queryByText(/8012|4455|9911/)).toBeNull();
   });
 
@@ -540,7 +637,7 @@ describe("OneLocationAgentPage", () => {
       sourcePlatform: "web",
     });
 
-    render(<OneLocationAgentPageContent />);
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     await waitFor(() => expect(mockViewEnvelope).toHaveBeenCalled());
@@ -580,7 +677,7 @@ describe("OneLocationAgentPage", () => {
       ownerGrants: [],
     });
 
-    render(<OneLocationAgentPageContent />);
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(
@@ -618,14 +715,14 @@ describe("OneLocationAgentPage", () => {
       ownerGrants: [],
     });
 
-    render(<OneLocationAgentPageContent />);
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(
       screen.getByRole("button", { name: /Review Share/i }),
     );
     expect(
-      screen.getByRole("region", { name: "Share safety review" }),
+      await screen.findByRole("region", { name: "Share safety review" }),
     ).toBeTruthy();
     fireEvent.click(
       screen.getByRole("button", { name: /Confirm & Share Location/i }),
@@ -684,10 +781,13 @@ describe("OneLocationAgentPage", () => {
       )
       .mockResolvedValueOnce({});
 
-    render(<OneLocationAgentPageContent />);
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(screen.getByRole("button", { name: /Review Share/i }));
+    expect(
+      await screen.findByRole("region", { name: "Share safety review" }),
+    ).toBeTruthy();
     fireEvent.click(
       screen.getByRole("button", { name: /Confirm & Share Location/i }),
     );
@@ -758,13 +858,13 @@ describe("OneLocationAgentPage", () => {
       }),
     );
 
-    render(<OneLocationAgentPageContent />);
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     expect(await screen.findByText(/1 person selected/i)).toBeTruthy();
     fireEvent.click(
       screen.getByRole("button", {
-        name: /Select Investor D from KAI Circle/i,
+        name: /Select Investor D from One Network/i,
       }),
     );
     expect(await screen.findByText(/2 people selected/i)).toBeTruthy();
@@ -772,6 +872,9 @@ describe("OneLocationAgentPage", () => {
     fireEvent.click(
       screen.getByRole("button", { name: /Review Share/i }),
     );
+    expect(
+      await screen.findByRole("region", { name: "Share safety review" }),
+    ).toBeTruthy();
     fireEvent.click(
       screen.getByRole("button", { name: /Confirm & Share Location/i }),
     );
@@ -818,12 +921,12 @@ describe("OneLocationAgentPage", () => {
       ownerGrants: [],
     });
 
-    render(<OneLocationAgentPageContent />);
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(
       screen.getByRole("button", {
-        name: /Select Advisor C from KAI Circle/i,
+        name: /Select Advisor C from One Network/i,
       }),
     );
 
@@ -843,7 +946,7 @@ describe("OneLocationAgentPage", () => {
       ownerGrants: [],
     });
 
-    render(<OneLocationAgentPageContent />);
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(screen.getByRole("button", { name: "request" }));
@@ -870,19 +973,43 @@ describe("OneLocationAgentPage", () => {
     );
   });
 
+  it("renders my requests with safe labels instead of raw owner ids", async () => {
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      ownerGrants: [],
+      requests: [
+        {
+          id: "request_1",
+          ownerUserId: "user_b",
+          requesterUserId: "user_a",
+          status: "pending",
+          requestedAt: "2026-05-20T07:30:00.000Z",
+        },
+      ],
+    });
+
+    render(<OneLocationAgentPage />);
+
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    expect(screen.getByText("My requests")).toBeTruthy();
+    expect(screen.getAllByText("Trusted B").length).toBeGreaterThan(0);
+    expect(screen.queryByText("user_b")).toBeNull();
+    expect(screen.queryByText("request_1")).toBeNull();
+  });
+
   it("fans out approval-first requests to multiple selected owners without coordinates", async () => {
     mockGetState.mockResolvedValue({
       ...locationState(),
       ownerGrants: [],
     });
 
-    render(<OneLocationAgentPageContent />);
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(screen.getByRole("button", { name: "request" }));
     fireEvent.click(
       screen.getByRole("button", {
-        name: /Select Investor D from KAI Circle/i,
+        name: /Select Investor D from One Network/i,
       }),
     );
     expect(await screen.findByText(/2 people selected/i)).toBeTruthy();
@@ -929,7 +1056,7 @@ describe("OneLocationAgentPage", () => {
       sourcePlatform: "ios",
     });
 
-    render(<OneLocationAgentPageContent />);
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(screen.getByRole("button", { name: /Sync Contacts/i }));
@@ -940,7 +1067,6 @@ describe("OneLocationAgentPage", () => {
       }),
     );
     expect(await screen.findByText("In your contacts")).toBeTruthy();
-    expect(screen.getByText(/1 matched \/ 7 invite-ready/i)).toBeTruthy();
     expect(screen.queryByText(/9911|8012|4455/)).toBeNull();
     expect(mockTrackEvent).toHaveBeenCalledWith(
       "one_location_contact_signal_synced",
@@ -955,11 +1081,11 @@ describe("OneLocationAgentPage", () => {
     );
   });
 
-  it("creates an approval-first invite path for contacts who are not KAI users", async () => {
-    render(<OneLocationAgentPageContent />);
+  it("creates an approval-first invite path for contacts who are not One users", async () => {
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-    fireEvent.click(screen.getByRole("button", { name: /Invite Contacts/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Share to Contacts/i }));
 
     await waitFor(() => expect(mockCreatePublicInvite).toHaveBeenCalledTimes(1));
     expect(mockCreatePublicInvite).toHaveBeenCalledWith({
@@ -975,19 +1101,14 @@ describe("OneLocationAgentPage", () => {
     );
   });
 
-  it("revokes an active grant from the visible owner list", async () => {
-    render(<OneLocationAgentPageContent />);
+  it("does not show owner-grant revoke actions in the compact mobile flow", async () => {
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-    fireEvent.click(
-      screen.getByRole("button", { name: /Revoke access for Trusted B/i }),
-    );
-
-    await waitFor(() => expect(mockRevokeGrant).toHaveBeenCalledTimes(1));
-    expect(mockRevokeGrant).toHaveBeenCalledWith({
-      vaultOwnerToken: "vault-token",
-      grantId: "grant_1",
-    });
+    expect(
+      screen.queryByRole("button", { name: /Revoke access for Trusted B/i }),
+    ).toBeNull();
+    expect(mockRevokeGrant).not.toHaveBeenCalled();
   });
 
   it("blocks share actions when browser location permission is denied", async () => {
@@ -995,38 +1116,66 @@ describe("OneLocationAgentPage", () => {
       state: "denied",
       precise: false,
       background: "unavailable",
+      locationServicesEnabled: true,
     });
     mockGetState.mockResolvedValueOnce({
       ...locationState(),
       ownerGrants: [],
     });
 
-    render(<OneLocationAgentPageContent />);
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     const shareButton = screen.getByRole("button", {
       name: /Review Share/i,
     }) as HTMLButtonElement;
-    expect(shareButton.disabled).toBe(true);
+    fireEvent.click(shareButton);
+    await waitFor(() => expect(mockCaptureCurrentPosition).not.toHaveBeenCalled());
     expect(mockCreateGrant).not.toHaveBeenCalled();
   });
 
-  it("keeps KAI Circle section empty states visible when no candidates exist", async () => {
+  it("blocks sharing and opens settings when phone location services are off", async () => {
+    mockGetPermissionState.mockResolvedValue({
+      state: "unavailable",
+      precise: false,
+      background: "foreground-only",
+      locationServicesEnabled: false,
+    });
+    mockGetState.mockResolvedValueOnce({
+      ...locationState(),
+      ownerGrants: [],
+    });
+
+    render(<OneLocationAgentPage />);
+
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    expect(await screen.findByText("Turn on phone Location")).toBeTruthy();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Open Location Settings/i }),
+    );
+
+    await waitFor(() => expect(mockOpenLocationSettings).toHaveBeenCalled());
+    expect(mockCreateGrant).not.toHaveBeenCalled();
+    expect(mockStoreEnvelope).not.toHaveBeenCalled();
+  });
+
+  it("keeps One Network section empty states visible when no candidates exist", async () => {
     mockGetState.mockResolvedValueOnce({
       ...locationState(),
       recipients: [],
       ownerGrants: [],
     });
 
-    render(<OneLocationAgentPageContent />);
+    render(<OneLocationAgentPage />);
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
-    expect(screen.getByText("KAI Circle is empty")).toBeTruthy();
-    expect(screen.getByText(/No approvals waiting/)).toBeTruthy();
-    expect(screen.getByText(/No trusted matches yet/)).toBeTruthy();
-    expect(screen.getByText(/No professional signals yet/)).toBeTruthy();
-    expect(screen.getByText(/No ready KAI members yet/)).toBeTruthy();
-    expect(screen.getByText(/No setup blockers/)).toBeTruthy();
+    expect(screen.getByText("One Network is empty")).toBeTruthy();
+    expect(screen.queryByText(/No approvals waiting/)).toBeNull();
+    expect(screen.queryByText(/No trusted matches yet/)).toBeNull();
+    expect(screen.queryByText(/No professional signals yet/)).toBeNull();
+    expect(screen.queryByText(/No ready One users yet/)).toBeNull();
+    expect(screen.queryByText(/No setup blockers/)).toBeNull();
     expect(
       screen.getByRole("button", { name: /Create public link/i }),
     ).toBeTruthy();
@@ -1038,7 +1187,7 @@ describe("OneLocationAgentPage", () => {
       vaultOwnerToken: null,
     });
 
-    render(<OneLocationAgentPageContent />);
+    render(<OneLocationAgentPage />);
 
     expect(
       await screen.findByText(

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -308,12 +308,27 @@ function locationActivity() {
   };
 }
 
+async function skipLocationEntryFlow() {
+  expect(
+    await screen.findByRole("heading", {
+      name: "Experience location sharing with One.",
+    }),
+  ).toBeTruthy();
+  fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+  expect(
+    await screen.findByRole("heading", { name: "Keep your map live" }),
+  ).toBeTruthy();
+  fireEvent.click(screen.getByRole("button", { name: "Not now" }));
+  expect(
+    await screen.findByRole("heading", { name: "One Location Agent" }),
+  ).toBeTruthy();
+}
+
 describe("OneLocationAgentPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     Element.prototype.scrollIntoView = vi.fn();
     window.localStorage.clear();
-    window.localStorage.setItem("one_location_onboarding_v1:user_a", "done");
     mockSearchParamsGet.mockReturnValue(null);
     mockUseRequireAuth.mockReturnValue({
       loading: false,
@@ -416,6 +431,7 @@ describe("OneLocationAgentPage", () => {
 
   it("renders the One-owned encrypted location control surface", async () => {
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     expect(
       await screen.findByRole("heading", { name: "One Location Agent" }),
@@ -460,6 +476,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(
@@ -484,6 +501,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockEnsureKey).toHaveBeenCalledWith("user_a"));
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
@@ -491,7 +509,6 @@ describe("OneLocationAgentPage", () => {
   });
 
   it("shows the location onboarding before requesting foreground permission", async () => {
-    window.localStorage.removeItem("one_location_onboarding_v1:user_a");
     mockGetState.mockResolvedValueOnce({
       ...locationState(),
       ownerGrants: [],
@@ -537,13 +554,40 @@ describe("OneLocationAgentPage", () => {
     expect(
       await screen.findByRole("heading", { name: "One Location Agent" }),
     ).toBeTruthy();
-    expect(window.localStorage.getItem("one_location_onboarding_v1:user_a")).toBe(
-      "done",
-    );
+    expect(window.localStorage.getItem("one_location_onboarding_v1:user_a")).toBeNull();
+  });
+
+  it("shows the location entry flow even when foreground permission is already granted", async () => {
+    mockGetState.mockResolvedValueOnce({
+      ...locationState(),
+      ownerGrants: [],
+    });
+
+    render(<OneLocationAgentPage />);
+
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    expect(
+      await screen.findByRole("heading", {
+        name: "Experience location sharing with One.",
+      }),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    expect(
+      await screen.findByRole("heading", { name: "Keep your map live" }),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    expect(
+      await screen.findByRole("heading", { name: "One Location Agent" }),
+    ).toBeTruthy();
+    expect(mockCaptureCurrentPosition).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem("one_location_onboarding_v1:user_a")).toBeNull();
   });
 
   it("renders One Network recommendation metadata without phone-derived labels", async () => {
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
 
@@ -581,6 +625,7 @@ describe("OneLocationAgentPage", () => {
     ).toBeGreaterThan(0);
 
     resolveState(locationState());
+    await skipLocationEntryFlow();
     await waitFor(() =>
       expect(screen.getByText("Share Encrypted Update")).toBeTruthy(),
     );
@@ -588,6 +633,7 @@ describe("OneLocationAgentPage", () => {
 
   it("renders a public location link control", async () => {
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
 
@@ -599,6 +645,7 @@ describe("OneLocationAgentPage", () => {
 
   it("keeps location activity hidden in the compact mobile flow", async () => {
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     expect(screen.queryByRole("heading", { name: "Location activity" })).toBeNull();
@@ -660,6 +707,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     await waitFor(() => expect(mockViewEnvelope).toHaveBeenCalled());
@@ -700,6 +748,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(
@@ -738,6 +787,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(
@@ -804,6 +854,7 @@ describe("OneLocationAgentPage", () => {
       .mockResolvedValueOnce({});
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(screen.getByRole("button", { name: /Review Share/i }));
@@ -881,6 +932,7 @@ describe("OneLocationAgentPage", () => {
     );
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     expect(await screen.findByText(/1 person selected/i)).toBeTruthy();
@@ -944,6 +996,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(
@@ -969,6 +1022,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(screen.getByRole("button", { name: "request" }));
@@ -1011,6 +1065,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     expect(screen.getByText("My requests")).toBeTruthy();
@@ -1026,6 +1081,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(screen.getByRole("button", { name: "request" }));
@@ -1079,6 +1135,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(screen.getByRole("button", { name: /Sync Contacts/i }));
@@ -1105,6 +1162,7 @@ describe("OneLocationAgentPage", () => {
 
   it("creates an approval-first invite path for contacts who are not One users", async () => {
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     fireEvent.click(screen.getByRole("button", { name: /Share to Contacts/i }));
@@ -1125,6 +1183,7 @@ describe("OneLocationAgentPage", () => {
 
   it("does not show owner-grant revoke actions in the compact mobile flow", async () => {
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     expect(
@@ -1146,6 +1205,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     const shareButton = screen.getByRole("button", {
@@ -1169,6 +1229,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     expect(await screen.findByText("Turn on phone Location")).toBeTruthy();
@@ -1190,6 +1251,7 @@ describe("OneLocationAgentPage", () => {
     });
 
     render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     expect(screen.getByText("One Network is empty")).toBeTruthy();

--- a/hushh-webapp/__tests__/services/location-agent-service.test.ts
+++ b/hushh-webapp/__tests__/services/location-agent-service.test.ts
@@ -183,6 +183,36 @@ describe("OneLocationService", () => {
     );
   });
 
+  it("resolves public location links with an attached public snapshot", async () => {
+    mockApiJson.mockResolvedValueOnce({
+      invite: {
+        status: "active",
+        durationHours: 1,
+        expiresAt: "2026-05-20T08:30:00.000Z",
+        ownerLabel: "A trusted person",
+        locationAvailable: true,
+      },
+      publicLocation: {
+        latitude: 28.6139,
+        longitude: 77.209,
+        accuracyM: 18,
+        capturedAt: "2026-05-20T07:30:00.000Z",
+        sourcePlatform: "web",
+      },
+    });
+
+    const response =
+      await OneLocationService.resolvePublicInvite("public-token");
+
+    expect(mockApiJson).toHaveBeenCalledWith(
+      "/api/one/location/public-invites/public-token",
+      {},
+    );
+    expect(response.invite.locationAvailable).toBe(true);
+    expect(response.publicLocation?.latitude).toBe(28.6139);
+    expect(response.publicLocation?.longitude).toBe(77.209);
+  });
+
   it("submits public invite intake without an auth token and receives public location", async () => {
     mockApiJson.mockResolvedValueOnce({
       submission: { id: "submission_1", status: "approved" },

--- a/hushh-webapp/__tests__/services/location-agent-service.test.ts
+++ b/hushh-webapp/__tests__/services/location-agent-service.test.ts
@@ -150,19 +150,26 @@ describe("OneLocationService", () => {
     });
   });
 
-  it("creates public request links without sending location coordinates", async () => {
+  it("creates public location links with an owner-captured snapshot", async () => {
     mockApiJson.mockResolvedValueOnce({
       invite: { id: "invite_1", status: "active" },
       publicToken: "token_1",
       publicUrl: "/one/location/request/token_1",
     });
+    const locationSnapshot = {
+      latitude: 28.6139,
+      longitude: 77.209,
+      accuracyM: 18,
+      capturedAt: "2026-05-20T07:30:00.000Z",
+      sourcePlatform: "web" as const,
+    };
 
     await OneLocationService.createPublicInvite({
       vaultOwnerToken: "vault-token",
       durationHours: 1,
+      locationSnapshot,
     });
 
-    const body = String(mockApiJson.mock.calls[0]?.[1]?.body || "");
     expect(mockApiJson).toHaveBeenCalledWith(
       "/api/one/location/public-invites",
       {
@@ -171,16 +178,21 @@ describe("OneLocationService", () => {
           Authorization: "Bearer vault-token",
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ durationHours: 1 }),
+        body: JSON.stringify({ durationHours: 1, locationSnapshot }),
       },
     );
-    expect(body).not.toContain("latitude");
-    expect(body).not.toContain("longitude");
   });
 
-  it("submits public invite requests without an auth token or coordinates", async () => {
+  it("submits public invite intake without an auth token and receives public location", async () => {
     mockApiJson.mockResolvedValueOnce({
-      submission: { id: "submission_1", status: "pending_identity" },
+      submission: { id: "submission_1", status: "approved" },
+      publicLocation: {
+        latitude: 28.6139,
+        longitude: 77.209,
+        accuracyM: 18,
+        capturedAt: "2026-05-20T07:30:00.000Z",
+        sourcePlatform: "web",
+      },
       request: null,
     });
 

--- a/hushh-webapp/__tests__/voice/kai-search-bar.test.ts
+++ b/hushh-webapp/__tests__/voice/kai-search-bar.test.ts
@@ -441,10 +441,8 @@ describe("kai-search-bar helpers", () => {
     expect(screen.getByRole("button", { name: "Start RIA voice" }).getAttribute("aria-disabled")).toBe(
       "true",
     );
-
-    fireEvent.click(screen.getByRole("button", { name: "Open Agent" }));
-
-    expect(mockOpenAgent).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("button", { name: "Open Agent" })).toBeNull();
+    expect(mockOpenAgent).not.toHaveBeenCalled();
   });
 
   it("keeps Kai voice inside the compact search surface", () => {

--- a/hushh-webapp/__tests__/voice/kai-search-bar.test.ts
+++ b/hushh-webapp/__tests__/voice/kai-search-bar.test.ts
@@ -24,7 +24,31 @@ vi.mock("lucide-react", () => ({
 }));
 
 vi.mock("@/components/kai/kai-command-palette", () => ({
-  KaiCommandPalette: () => null,
+  KaiCommandPalette: ({
+    open,
+    onVoiceClick,
+    voiceActive,
+    voiceDisabled,
+    voiceHidden,
+  }: {
+    open: boolean;
+    onVoiceClick?: (event: unknown) => void;
+    voiceActive?: boolean;
+    voiceDisabled?: boolean;
+    voiceHidden?: boolean;
+  }) =>
+    open && !voiceHidden
+      ? createElement(
+          "button",
+          {
+            type: "button",
+            "aria-label": voiceActive ? "End Kai voice" : "Start Kai voice",
+            "aria-disabled": voiceDisabled,
+            onClick: onVoiceClick,
+          },
+          "voice",
+        )
+      : null,
 }));
 
 vi.mock("@/components/kai/voice/voice-ambient-search-surface", () => ({

--- a/hushh-webapp/__tests__/voice/kai-search-bar.test.ts
+++ b/hushh-webapp/__tests__/voice/kai-search-bar.test.ts
@@ -441,8 +441,10 @@ describe("kai-search-bar helpers", () => {
     expect(screen.getByRole("button", { name: "Start RIA voice" }).getAttribute("aria-disabled")).toBe(
       "true",
     );
-    expect(screen.queryByRole("button", { name: "Open Agent" })).toBeNull();
-    expect(mockOpenAgent).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Agent" }));
+
+    expect(mockOpenAgent).toHaveBeenCalledTimes(1);
   });
 
   it("keeps Kai voice inside the compact search surface", () => {

--- a/hushh-webapp/__tests__/voice/kai-search-bar.test.ts
+++ b/hushh-webapp/__tests__/voice/kai-search-bar.test.ts
@@ -265,6 +265,13 @@ const {
   shouldTriggerVoiceBargeIn,
 } = await import("@/components/kai/kai-search-bar");
 
+function openSearchAndStartVoice() {
+  fireEvent.click(
+    screen.getByRole("button", { name: "Open Kai command search" }),
+  );
+  fireEvent.click(screen.getByRole("button", { name: "Start Kai voice" }));
+}
+
 describe("kai-search-bar helpers", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -440,7 +447,7 @@ describe("kai-search-bar helpers", () => {
     expect(mockOpenAgent).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps Kai voice inside the integrated search surface", () => {
+  it("keeps Kai voice inside the compact search surface", () => {
     vi.useRealTimers();
 
     render(
@@ -452,11 +459,17 @@ describe("kai-search-bar helpers", () => {
       }),
     );
 
-    expect(screen.getByTestId("voice-ambient-search-surface")).toBeTruthy();
-    expect(screen.getByLabelText("Toggle voice microphone")).toBeTruthy();
+    expect(screen.getByTestId("kai-compact-search-surface")).toBeTruthy();
     expect(
-      screen.queryByRole("button", { name: "Start Kai voice" }),
-    ).toBeNull();
+      screen.getByRole("button", { name: "Open Kai command search" }),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Start Kai voice" })).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open Kai command search" }),
+    );
+
+    expect(screen.getByRole("button", { name: "Start Kai voice" })).toBeTruthy();
   });
 
   it("acquires on explicit mic tap and releases on cancel", async () => {
@@ -470,7 +483,7 @@ describe("kai-search-bar helpers", () => {
       }),
     );
 
-    fireEvent.click(screen.getByLabelText("Toggle voice microphone"));
+    openSearchAndStartVoice();
 
     await waitFor(() => {
       expect(acquireMock).toHaveBeenCalledWith(
@@ -483,10 +496,10 @@ describe("kai-search-bar helpers", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByTestId("voice-ambient-search-surface")).toBeTruthy();
+      expect(screen.getByTestId("kai-compact-search-surface")).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByText("cancel voice"));
+    fireEvent.click(screen.getByRole("button", { name: "End Kai voice" }));
 
     await waitFor(() => {
       expect(releaseMock).toHaveBeenCalled();
@@ -508,7 +521,7 @@ describe("kai-search-bar helpers", () => {
       }),
     );
 
-    fireEvent.click(screen.getByLabelText("Toggle voice microphone"));
+    openSearchAndStartVoice();
 
     await waitFor(() => {
       expect(acquireMock).toHaveBeenCalled();
@@ -517,7 +530,7 @@ describe("kai-search-bar helpers", () => {
     await waitFor(() => {
       expect(
         screen
-          .getByTestId("voice-ambient-search-surface")
+          .getByTestId("kai-compact-search-surface")
           .getAttribute("data-mode"),
       ).toBe("idle");
       expect(
@@ -550,10 +563,10 @@ describe("kai-search-bar helpers", () => {
       }),
     );
 
-    fireEvent.click(screen.getByLabelText("Toggle voice microphone"));
+    openSearchAndStartVoice();
 
     await waitFor(() => {
-      const surface = screen.getByTestId("voice-ambient-search-surface");
+      const surface = screen.getByTestId("kai-compact-search-surface");
       expect(surface).toBeTruthy();
       expect(surface.getAttribute("data-mode")).toBe("connecting");
       expect(screen.getByTestId("voice-ambient-preview").textContent).toContain(
@@ -590,10 +603,10 @@ describe("kai-search-bar helpers", () => {
       }),
     );
 
-    fireEvent.click(screen.getByLabelText("Toggle voice microphone"));
+    openSearchAndStartVoice();
 
     await waitFor(() => {
-      expect(screen.getByTestId("voice-ambient-search-surface")).toBeTruthy();
+      expect(screen.getByTestId("kai-compact-search-surface")).toBeTruthy();
     });
 
     await act(async () => {
@@ -649,7 +662,7 @@ describe("kai-search-bar helpers", () => {
       });
     });
 
-    fireEvent.click(screen.getByLabelText("Toggle voice microphone"));
+    openSearchAndStartVoice();
 
     await waitFor(() => {
       expect(setMutedMock).toHaveBeenCalledWith(false);
@@ -682,7 +695,7 @@ describe("kai-search-bar helpers", () => {
       }),
     );
 
-    fireEvent.click(screen.getByLabelText("Toggle voice microphone"));
+    openSearchAndStartVoice();
 
     await waitFor(() => {
       expect(acquireMock).toHaveBeenCalled();
@@ -691,7 +704,7 @@ describe("kai-search-bar helpers", () => {
     await waitFor(() => {
       expect(
         screen
-          .getByTestId("voice-ambient-search-surface")
+          .getByTestId("kai-compact-search-surface")
           .getAttribute("data-mode"),
       ).toBe("idle");
       expect(

--- a/hushh-webapp/__tests__/voice/kai-search-bar.test.ts
+++ b/hushh-webapp/__tests__/voice/kai-search-bar.test.ts
@@ -70,6 +70,12 @@ vi.mock("@/components/kai/voice/voice-debug-drawer", () => ({
   VoiceDebugDrawer: () => null,
 }));
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
 vi.mock("@/components/app-ui/shell-action-surface", () => ({
   ShellActionSurface: ({
     children,

--- a/hushh-webapp/android/app/src/main/java/com/hushh/app/plugins/HushhLocation/HushhLocationPlugin.kt
+++ b/hushh-webapp/android/app/src/main/java/com/hushh/app/plugins/HushhLocation/HushhLocationPlugin.kt
@@ -3,6 +3,7 @@ package com.hushh.app.plugins.HushhLocation
 import android.Manifest
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.location.Location
 import android.location.LocationListener
@@ -10,6 +11,7 @@ import android.location.LocationManager
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.provider.Settings
 import androidx.core.content.ContextCompat
 import com.getcapacitor.JSObject
 import com.getcapacitor.PermissionState
@@ -50,6 +52,22 @@ class HushhLocationPlugin : Plugin() {
     }
 
     @PluginMethod
+    fun openLocationSettings(call: PluginCall) {
+        try {
+            val intent = Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            context.startActivity(intent)
+            call.resolve(
+                JSObject()
+                    .put("opened", true)
+                    .put("sourcePlatform", "android")
+            )
+        } catch (error: Exception) {
+            call.reject("Could not open location settings: ${error.message}")
+        }
+    }
+
+    @PluginMethod
     fun getCurrentPosition(call: PluginCall) {
         if (getPermissionState("location") != PermissionState.GRANTED) {
             requestPermissionForAlias("location", call, "locationPermissionCallback")
@@ -70,15 +88,29 @@ class HushhLocationPlugin : Plugin() {
     private fun permissionPayload(): JSObject {
         val fineGranted = hasAndroidPermission(Manifest.permission.ACCESS_FINE_LOCATION)
         val coarseGranted = hasAndroidPermission(Manifest.permission.ACCESS_COARSE_LOCATION)
-        val state = if (fineGranted || coarseGranted) "granted" else "prompt"
+        val permissionState = getPermissionState("location")
+        val locationServicesEnabled = locationServicesEnabled()
+        val state = when {
+            (fineGranted || coarseGranted) && !locationServicesEnabled -> "unavailable"
+            fineGranted || coarseGranted -> "granted"
+            permissionState == PermissionState.DENIED -> "denied"
+            else -> "prompt"
+        }
         return JSObject()
             .put("state", state)
             .put("precise", fineGranted)
             .put("background", "foreground-only")
+            .put("locationServicesEnabled", locationServicesEnabled)
     }
 
     private fun hasAndroidPermission(permission: String): Boolean {
         return ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun locationServicesEnabled(): Boolean {
+        val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+        return listOf(LocationManager.GPS_PROVIDER, LocationManager.NETWORK_PROVIDER)
+            .any { provider -> locationManager.isProviderEnabled(provider) }
     }
 
     @SuppressLint("MissingPermission")

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1330,8 +1330,8 @@ md-ripple.morphy-md-ripple {
 .kai-bottom-nav-pill [role="radio"] {
   color: rgb(60 60 67 / 0.7) !important;
   min-height: 48px;
-  gap: 0.22rem !important;
-  padding: 0.38rem 0.2rem 0.42rem !important;
+  gap: 0.2rem !important;
+  padding: 0.4rem 0.2rem 0.44rem !important;
   letter-spacing: 0;
 }
 
@@ -1341,7 +1341,7 @@ md-ripple.morphy-md-ripple {
 
 .kai-bottom-nav-pill [role="radio"][aria-checked="true"] {
   color: rgb(0 113 227) !important;
-  font-weight: 600;
+  font-weight: 590;
 }
 
 .dark .kai-bottom-nav-pill [role="radio"][aria-checked="true"] {
@@ -1349,25 +1349,39 @@ md-ripple.morphy-md-ripple {
 }
 
 .kai-bottom-nav-pill [role="radio"] svg {
-  width: 20px;
-  height: 20px;
-  opacity: 0.84;
-  stroke-width: 1.72;
-  filter: drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.6));
+  width: 19px;
+  height: 19px;
+  opacity: 0.88;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.48;
+  filter: drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.68));
   transform: translateY(0);
 }
 
 .kai-bottom-nav-pill [role="radio"][aria-checked="true"] svg {
   opacity: 1;
-  stroke-width: 2.08;
-  filter: drop-shadow(0 3px 8px rgb(0 113 227 / 0.2));
+  stroke-width: 1.82;
+  filter:
+    drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.72))
+    drop-shadow(0 4px 10px rgb(0 113 227 / 0.18));
   transform: translateY(-0.5px);
+}
+
+.dark .kai-bottom-nav-pill [role="radio"] svg {
+  filter: drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.12));
+}
+
+.dark .kai-bottom-nav-pill [role="radio"][aria-checked="true"] svg {
+  filter:
+    drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.16))
+    drop-shadow(0 4px 12px rgb(41 171 255 / 0.2));
 }
 
 .kai-bottom-nav-pill [role="radio"] > span:last-of-type {
   max-width: 100%;
   font-size: 9.5px;
-  font-weight: 500;
+  font-weight: 510;
   line-height: 1;
   letter-spacing: 0;
   text-wrap: nowrap;
@@ -1375,7 +1389,7 @@ md-ripple.morphy-md-ripple {
 }
 
 .kai-bottom-nav-pill [role="radio"][aria-checked="true"] > span:last-of-type {
-  font-weight: 600;
+  font-weight: 590;
   opacity: 1;
 }
 

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1353,8 +1353,8 @@ md-ripple.morphy-md-ripple {
 .kai-bottom-nav-pill [role="radio"] {
   color: rgb(60 60 67 / 0.7) !important;
   min-height: 48px;
-  gap: 0.2rem !important;
-  padding: 0.4rem 0.2rem 0.44rem !important;
+  gap: 0.22rem !important;
+  padding: 0.38rem 0.2rem 0.42rem !important;
   letter-spacing: 0;
 }
 
@@ -1364,7 +1364,7 @@ md-ripple.morphy-md-ripple {
 
 .kai-bottom-nav-pill [role="radio"][aria-checked="true"] {
   color: rgb(0 113 227) !important;
-  font-weight: 590;
+  font-weight: 600;
 }
 
 .dark .kai-bottom-nav-pill [role="radio"][aria-checked="true"] {
@@ -1372,39 +1372,25 @@ md-ripple.morphy-md-ripple {
 }
 
 .kai-bottom-nav-pill [role="radio"] svg {
-  width: 19px;
-  height: 19px;
-  opacity: 0.88;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  stroke-width: 1.48;
-  filter: drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.68));
+  width: 20px;
+  height: 20px;
+  opacity: 0.84;
+  stroke-width: 1.72;
+  filter: drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.6));
   transform: translateY(0);
 }
 
 .kai-bottom-nav-pill [role="radio"][aria-checked="true"] svg {
   opacity: 1;
-  stroke-width: 1.82;
-  filter:
-    drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.72))
-    drop-shadow(0 4px 10px rgb(0 113 227 / 0.18));
+  stroke-width: 2.08;
+  filter: drop-shadow(0 3px 8px rgb(0 113 227 / 0.2));
   transform: translateY(-0.5px);
-}
-
-.dark .kai-bottom-nav-pill [role="radio"] svg {
-  filter: drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.12));
-}
-
-.dark .kai-bottom-nav-pill [role="radio"][aria-checked="true"] svg {
-  filter:
-    drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.16))
-    drop-shadow(0 4px 12px rgb(41 171 255 / 0.2));
 }
 
 .kai-bottom-nav-pill [role="radio"] > span:last-of-type {
   max-width: 100%;
   font-size: 9.5px;
-  font-weight: 510;
+  font-weight: 500;
   line-height: 1;
   letter-spacing: 0;
   text-wrap: nowrap;
@@ -1412,7 +1398,7 @@ md-ripple.morphy-md-ripple {
 }
 
 .kai-bottom-nav-pill [role="radio"][aria-checked="true"] > span:last-of-type {
-  font-weight: 590;
+  font-weight: 600;
   opacity: 1;
 }
 

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1284,16 +1284,17 @@ md-ripple.morphy-md-ripple {
 
 .kai-bottom-nav-pill {
   color: rgb(29 29 31);
-  border: 1px solid rgb(255 255 255 / 0.72) !important;
+  border: 1px solid rgb(255 255 255 / 0.78) !important;
   background:
-    linear-gradient(180deg, rgb(255 255 255 / 0.88), rgb(245 245 247 / 0.76)) !important;
+    radial-gradient(circle at 50% 0%, rgb(255 255 255 / 0.96), transparent 54%),
+    linear-gradient(180deg, rgb(255 255 255 / 0.9), rgb(246 246 248 / 0.76)) !important;
   box-shadow:
-    0 18px 44px -26px rgb(0 0 0 / 0.34),
-    0 2px 8px -6px rgb(0 0 0 / 0.18),
+    0 18px 42px -28px rgb(0 0 0 / 0.34),
+    0 2px 10px -8px rgb(0 0 0 / 0.22),
     inset 0 1px 0 rgb(255 255 255 / 0.9),
     inset 0 -1px 0 rgb(0 0 0 / 0.06) !important;
-  -webkit-backdrop-filter: blur(24px) saturate(180%);
-  backdrop-filter: blur(24px) saturate(180%);
+  -webkit-backdrop-filter: blur(26px) saturate(190%);
+  backdrop-filter: blur(26px) saturate(190%);
 }
 
 .dark .kai-bottom-nav-pill {
@@ -1309,11 +1310,12 @@ md-ripple.morphy-md-ripple {
 
 .kai-bottom-nav-pill [data-segment-indicator] {
   background:
-    radial-gradient(circle at 50% 35%, rgb(255 255 255 / 0.95), transparent 64%),
-    linear-gradient(180deg, rgb(255 255 255 / 0.94), rgb(255 255 255 / 0.74)) !important;
+    radial-gradient(circle at 50% 16%, rgb(255 255 255 / 0.98), transparent 58%),
+    linear-gradient(180deg, rgb(255 255 255 / 0.96), rgb(255 255 255 / 0.7)) !important;
   box-shadow:
-    0 11px 24px -18px rgb(0 0 0 / 0.42),
-    inset 0 1px 0 rgb(255 255 255 / 0.92) !important;
+    0 12px 25px -19px rgb(0 0 0 / 0.48),
+    0 1px 4px -3px rgb(0 0 0 / 0.18),
+    inset 0 1px 0 rgb(255 255 255 / 0.94) !important;
 }
 
 .dark .kai-bottom-nav-pill [data-segment-indicator] {
@@ -1326,10 +1328,10 @@ md-ripple.morphy-md-ripple {
 }
 
 .kai-bottom-nav-pill [role="radio"] {
-  color: rgb(60 60 67 / 0.78) !important;
+  color: rgb(60 60 67 / 0.7) !important;
   min-height: 48px;
-  gap: 0.24rem !important;
-  padding: 0.4rem 0.25rem 0.44rem !important;
+  gap: 0.22rem !important;
+  padding: 0.38rem 0.2rem 0.42rem !important;
   letter-spacing: 0;
 }
 
@@ -1347,28 +1349,34 @@ md-ripple.morphy-md-ripple {
 }
 
 .kai-bottom-nav-pill [role="radio"] svg {
-  width: 18px;
-  height: 18px;
-  opacity: 0.9;
-  stroke-width: 1.9;
+  width: 20px;
+  height: 20px;
+  opacity: 0.84;
+  stroke-width: 1.72;
+  filter: drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.6));
+  transform: translateY(0);
 }
 
 .kai-bottom-nav-pill [role="radio"][aria-checked="true"] svg {
   opacity: 1;
-  stroke-width: 2;
+  stroke-width: 2.08;
+  filter: drop-shadow(0 3px 8px rgb(0 113 227 / 0.2));
+  transform: translateY(-0.5px);
 }
 
 .kai-bottom-nav-pill [role="radio"] > span:last-of-type {
   max-width: 100%;
-  font-size: 10px;
+  font-size: 9.5px;
   font-weight: 500;
   line-height: 1;
   letter-spacing: 0;
   text-wrap: nowrap;
+  opacity: 0.92;
 }
 
 .kai-bottom-nav-pill [role="radio"][aria-checked="true"] > span:last-of-type {
   font-weight: 600;
+  opacity: 1;
 }
 
 .kai-bottom-search-action {

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1372,10 +1372,10 @@ md-ripple.morphy-md-ripple {
 }
 
 .kai-bottom-nav-pill [role="radio"] svg {
-  width: 19.5px;
-  height: 19.5px;
-  opacity: 0.88;
-  stroke-width: 1.85;
+  width: 18.5px;
+  height: 18.5px;
+  opacity: 0.9;
+  stroke-width: 1.62;
   filter: drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.6));
   transform: translateY(0);
   stroke-linecap: round;
@@ -1384,7 +1384,7 @@ md-ripple.morphy-md-ripple {
 
 .kai-bottom-nav-pill [role="radio"][aria-checked="true"] svg {
   opacity: 1;
-  stroke-width: 2.15;
+  stroke-width: 1.95;
   filter: drop-shadow(0 3px 8px rgb(0 113 227 / 0.24));
   transform: translateY(-0.5px);
 }
@@ -1428,7 +1428,9 @@ md-ripple.morphy-md-ripple {
 }
 
 .kai-bottom-agent-action {
-  background: rgb(0 113 227) !important;
+  background:
+    radial-gradient(circle at 50% 18%, rgb(92 200 255 / 0.9), transparent 54%),
+    linear-gradient(180deg, rgb(0 122 255), rgb(0 102 204)) !important;
   color: rgb(255 255 255);
   box-shadow:
     0 12px 26px -18px rgb(0 113 227 / 0.75),
@@ -1436,16 +1438,19 @@ md-ripple.morphy-md-ripple {
 }
 
 .dark .kai-bottom-agent-action {
-  background: rgb(10 132 255) !important;
+  background:
+    radial-gradient(circle at 50% 18%, rgb(92 200 255 / 0.72), transparent 54%),
+    linear-gradient(180deg, rgb(10 132 255), rgb(0 102 204)) !important;
   box-shadow:
     0 12px 28px -18px rgb(10 132 255 / 0.86),
     inset 0 1px 0 rgb(255 255 255 / 0.34);
 }
 
 body:has([data-one-market-surface="true"]) .bar-glass-top {
-  --app-bar-glass-bg-light: var(--background) !important;
-  --app-bar-glass-bg-dark: rgb(28, 28, 30) !important;
+  --app-bar-glass-bg-light: transparent !important;
+  --app-bar-glass-bg-dark: transparent !important;
   --app-bar-shadow: none !important;
+  opacity: 0;
   --app-bar-fade-top-strong: transparent !important;
   --app-bar-fade-top-medium: transparent !important;
   --app-bar-fade-top-soft: transparent !important;

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1353,8 +1353,8 @@ md-ripple.morphy-md-ripple {
 .kai-bottom-nav-pill [role="radio"] {
   color: rgb(60 60 67 / 0.7) !important;
   min-height: 48px;
-  gap: 0.22rem !important;
-  padding: 0.38rem 0.2rem 0.42rem !important;
+  gap: 0.2rem !important;
+  padding: 0.4rem 0.2rem 0.42rem !important;
   letter-spacing: 0;
 }
 
@@ -1372,24 +1372,26 @@ md-ripple.morphy-md-ripple {
 }
 
 .kai-bottom-nav-pill [role="radio"] svg {
-  width: 20px;
-  height: 20px;
-  opacity: 0.84;
-  stroke-width: 1.72;
+  width: 19.5px;
+  height: 19.5px;
+  opacity: 0.88;
+  stroke-width: 1.85;
   filter: drop-shadow(0 0.5px 0 rgb(255 255 255 / 0.6));
   transform: translateY(0);
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .kai-bottom-nav-pill [role="radio"][aria-checked="true"] svg {
   opacity: 1;
-  stroke-width: 2.08;
-  filter: drop-shadow(0 3px 8px rgb(0 113 227 / 0.2));
+  stroke-width: 2.15;
+  filter: drop-shadow(0 3px 8px rgb(0 113 227 / 0.24));
   transform: translateY(-0.5px);
 }
 
 .kai-bottom-nav-pill [role="radio"] > span:last-of-type {
   max-width: 100%;
-  font-size: 9.5px;
+  font-size: 9.25px;
   font-weight: 500;
   line-height: 1;
   letter-spacing: 0;
@@ -1438,6 +1440,16 @@ md-ripple.morphy-md-ripple {
   box-shadow:
     0 12px 28px -18px rgb(10 132 255 / 0.86),
     inset 0 1px 0 rgb(255 255 255 / 0.34);
+}
+
+body:has([data-one-market-surface="true"]) .bar-glass-top {
+  --app-bar-glass-bg-light: var(--background) !important;
+  --app-bar-glass-bg-dark: rgb(28, 28, 30) !important;
+  --app-bar-shadow: none !important;
+  --app-bar-fade-top-strong: transparent !important;
+  --app-bar-fade-top-medium: transparent !important;
+  --app-bar-fade-top-soft: transparent !important;
+  --app-bar-fade-top-trace: transparent !important;
 }
 
 /* Carousel edge glass (left/right): use to hint adjacent slides while keeping center crisp. */

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -959,42 +959,42 @@ html.native-ios {
   }
 
   h1 {
-    font-size: clamp(1.875rem, 3.4vw, 2.75rem) !important;
+    font-size: clamp(1.75rem, 3vw, 2.5rem) !important;
     line-height: 1.1 !important;
-    font-weight: 800 !important;
-    letter-spacing: -0.022em;
+    font-weight: 600 !important;
+    letter-spacing: 0;
   }
 
   h2 {
-    font-size: clamp(1.55rem, 2.8vw, 2.25rem) !important;
-    line-height: 1.14 !important;
-    font-weight: 750 !important;
-    letter-spacing: -0.018em;
+    font-size: clamp(1.3rem, 2vw, 1.75rem) !important;
+    line-height: 1.16 !important;
+    font-weight: 550 !important;
+    letter-spacing: 0;
   }
 
   h3 {
-    font-size: clamp(1.35rem, 2.3vw, 1.85rem) !important;
+    font-size: clamp(1.1rem, 1.55vw, 1.35rem) !important;
     line-height: 1.2 !important;
-    font-weight: 700 !important;
-    letter-spacing: -0.014em;
+    font-weight: 550 !important;
+    letter-spacing: 0;
   }
 
   h4 {
-    font-size: clamp(1.2rem, 1.85vw, 1.45rem) !important;
+    font-size: clamp(1rem, 1.25vw, 1.125rem) !important;
     line-height: 1.24 !important;
-    font-weight: 650 !important;
+    font-weight: 525 !important;
   }
 
   h5 {
-    font-size: clamp(1.12rem, 1.55vw, 1.25rem) !important;
+    font-size: clamp(0.95rem, 1.12vw, 1rem) !important;
     line-height: 1.3 !important;
-    font-weight: 625 !important;
+    font-weight: 525 !important;
   }
 
   h6 {
-    font-size: clamp(1.05rem, 1.35vw, 1.125rem) !important;
+    font-size: clamp(0.875rem, 1vw, 0.95rem) !important;
     line-height: 1.32 !important;
-    font-weight: 600 !important;
+    font-weight: 525 !important;
   }
 
   [data-slot$="title"] {
@@ -1017,10 +1017,33 @@ html.native-ios {
   .app-page-shell h1,
   .app-page-shell [role="heading"][aria-level="1"] {
     font-family: var(--font-heading), var(--font-sans), system-ui, sans-serif;
-    font-size: clamp(1.9rem, 4.8vw, 2rem) !important;
+    font-size: clamp(1.75rem, 3.4vw, 2.125rem) !important;
     line-height: 1.08 !important;
-    font-weight: 600 !important;
+    font-weight: 500 !important;
     letter-spacing: 0 !important;
+  }
+
+  .app-page-shell h2,
+  .app-page-shell [role="heading"][aria-level="2"] {
+    font-family: var(--font-heading), var(--font-sans), system-ui, sans-serif;
+    font-size: clamp(1rem, 1.45vw, 1.25rem) !important;
+    line-height: 1.2 !important;
+    font-weight: 500 !important;
+    letter-spacing: 0 !important;
+  }
+
+  .app-page-shell h3,
+  .app-page-shell [role="heading"][aria-level="3"] {
+    font-family: var(--font-heading), var(--font-sans), system-ui, sans-serif;
+    font-size: clamp(0.95rem, 1.18vw, 1.0625rem) !important;
+    line-height: 1.25 !important;
+    font-weight: 500 !important;
+    letter-spacing: 0 !important;
+  }
+
+  .app-page-shell .font-black,
+  .app-page-shell .font-extrabold {
+    font-weight: 600 !important;
   }
 
   /* Global Lucide icon stroke thickness (lucide-react adds `.lucide` on the SVG). */

--- a/hushh-webapp/app/kai/analysis/page.tsx
+++ b/hushh-webapp/app/kai/analysis/page.tsx
@@ -1079,9 +1079,13 @@ function KaiAnalysisPageContent() {
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <div className="flex items-center gap-3">
                   <SymbolAvatar symbol={activeTicker} name={activeTicker} size="lg" />
-                  <h1 className="text-[28px] font-medium tracking-normal text-foreground sm:text-[34px]">
+                  <div
+                    role="heading"
+                    aria-level={2}
+                    className="text-[20px] font-medium leading-tight tracking-normal text-foreground sm:text-[22px]"
+                  >
                     {activeTicker}
-                  </h1>
+                  </div>
                 </div>
                 <div className="flex items-center gap-2">
                   <span className="text-sm font-medium tabular-nums text-muted-foreground sm:text-base">

--- a/hushh-webapp/app/kai/onboarding/page.tsx
+++ b/hushh-webapp/app/kai/onboarding/page.tsx
@@ -41,6 +41,12 @@ import { Card } from "@/lib/morphy-ux/card";
 import { Button } from "@/lib/morphy-ux/button";
 import { AlertTriangle } from "lucide-react";
 import { useNativeTestConfig } from "@/lib/testing/native-test";
+import {
+  kaiAppBodyClassName,
+  kaiAppCardTitleClassName,
+  kaiAppDisplayTitleClassName,
+  kaiAppEyebrowClassName,
+} from "@/components/kai/shared/kai-typography";
 
 type Stage = "loading" | "entry" | "wizard" | "persona";
 type OnboardingSource = "pre_vault" | "vault";
@@ -315,19 +321,19 @@ function KaiOnboardingPageContent() {
           authState={user ? "authenticated" : "pending"}
           dataState="loaded"
         />
-        <div className="w-full space-y-6">
-          <div className="mx-auto max-w-[36rem] space-y-3 text-center">
-            <p className="text-[10.5px] font-medium uppercase tracking-[0.16em] text-primary/75">
+        <div className="w-full space-y-8">
+          <div className="mx-auto max-w-[48rem] space-y-3 text-center">
+            <p className={`${kaiAppEyebrowClassName} text-primary/75`}>
               Choose your starting path
             </p>
             <div
               role="heading"
               aria-level={1}
-              className="text-[34px] font-medium leading-[1.06] tracking-normal text-foreground sm:text-[40px]"
+              className={`${kaiAppDisplayTitleClassName} text-foreground`}
             >
               Start as an investor or set up RIA first
             </div>
-            <p className="mx-auto max-w-[31rem] text-[16px] leading-[1.45] text-muted-foreground sm:text-[17px]">
+            <p className={`mx-auto max-w-[35rem] ${kaiAppBodyClassName} text-muted-foreground`}>
               You can add the other profile later from Profile. This choice only sets the first
               workflow we open right now.
             </p>
@@ -377,11 +383,11 @@ function KaiOnboardingPageContent() {
                   <div
                     role="heading"
                     aria-level={2}
-                    className="text-[24px] font-medium leading-[1.12] tracking-normal text-foreground sm:text-[26px]"
+                    className={`${kaiAppCardTitleClassName} text-foreground`}
                   >
                     Continue as Investor
                   </div>
-                  <p className="max-w-[31rem] text-[15px] leading-[1.45] text-muted-foreground sm:text-[16px]">
+                  <p className="max-w-[28rem] text-[14px] font-normal leading-[1.45] tracking-normal text-muted-foreground">
                     Answer your risk and preference questions, then connect accounts and start using
                     Kai.
                   </p>
@@ -433,11 +439,11 @@ function KaiOnboardingPageContent() {
                   <div
                     role="heading"
                     aria-level={2}
-                    className="text-[24px] font-medium leading-[1.12] tracking-normal text-foreground sm:text-[26px]"
+                    className={`${kaiAppCardTitleClassName} text-foreground`}
                   >
                     Continue as RIA
                   </div>
-                  <p className="max-w-[31rem] text-[15px] leading-[1.45] text-muted-foreground sm:text-[16px]">
+                  <p className="max-w-[28rem] text-[14px] font-normal leading-[1.45] tracking-normal text-muted-foreground">
                     Set up your advisor identity, verification, firm details, and marketplace trust
                     profile before sending consent requests.
                   </p>

--- a/hushh-webapp/app/kai/onboarding/page.tsx
+++ b/hushh-webapp/app/kai/onboarding/page.tsx
@@ -307,7 +307,7 @@ function KaiOnboardingPageContent() {
     return (
       <div
         data-top-content-anchor="true"
-        className="mx-auto flex min-h-[calc(100dvh_-_var(--top-content-pad))] w-full max-w-5xl items-start px-5 pb-8 pt-[calc(var(--top-content-pad)_+_0.25rem)] sm:px-6 lg:px-[var(--page-inline-gutter-standard)]"
+        className="mx-auto flex min-h-[calc(100dvh_-_var(--top-content-pad))] w-full max-w-[46rem] items-start px-5 pb-8 pt-[calc(var(--top-content-pad)_+_0.25rem)] sm:px-6 lg:px-[var(--page-inline-gutter-standard)]"
       >
         <NativeTestBeacon
           routeId="/kai/onboarding"
@@ -315,25 +315,25 @@ function KaiOnboardingPageContent() {
           authState={user ? "authenticated" : "pending"}
           dataState="loaded"
         />
-        <div className="w-full space-y-8">
-          <div className="mx-auto max-w-[48rem] space-y-3 text-center">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-primary/75">
+        <div className="w-full space-y-6">
+          <div className="mx-auto max-w-[36rem] space-y-3 text-center">
+            <p className="text-[10.5px] font-medium uppercase tracking-[0.16em] text-primary/75">
               Choose your starting path
             </p>
             <div
               role="heading"
               aria-level={1}
-              className="text-[38px] font-normal leading-[1.04] tracking-normal text-foreground sm:text-[46px] lg:text-[52px]"
+              className="text-[34px] font-medium leading-[1.06] tracking-normal text-foreground sm:text-[40px]"
             >
               Start as an investor or set up RIA first
             </div>
-            <p className="mx-auto max-w-[35rem] text-[17px] leading-[1.45] text-muted-foreground sm:text-[18px]">
+            <p className="mx-auto max-w-[31rem] text-[16px] leading-[1.45] text-muted-foreground sm:text-[17px]">
               You can add the other profile later from Profile. This choice only sets the first
               workflow we open right now.
             </p>
           </div>
 
-          <div className="grid items-stretch gap-4 md:grid-cols-2">
+          <div className="mx-auto grid w-full max-w-[40rem] items-stretch gap-3.5">
             <Card
               preset="hero"
               variant="none"
@@ -368,25 +368,25 @@ function KaiOnboardingPageContent() {
                     setSaving(false);
                   }
                 }}
-                className="flex h-full min-h-[228px] w-full flex-col justify-between gap-6 p-6 text-left sm:p-7"
+                className="flex h-full min-h-[168px] w-full flex-col justify-between gap-5 p-5 text-left sm:p-6"
               >
-                <div className="space-y-3.5">
-                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-primary/75">
+                <div className="space-y-2.5">
+                  <p className="text-[10.5px] font-medium uppercase tracking-[0.16em] text-primary/75">
                     Investor
                   </p>
                   <div
                     role="heading"
                     aria-level={2}
-                    className="text-[28px] font-normal leading-[1.08] tracking-normal text-foreground sm:text-[32px]"
+                    className="text-[24px] font-medium leading-[1.12] tracking-normal text-foreground sm:text-[26px]"
                   >
                     Continue as Investor
                   </div>
-                  <p className="max-w-[28rem] text-[16px] leading-[1.5] text-muted-foreground">
+                  <p className="max-w-[31rem] text-[15px] leading-[1.45] text-muted-foreground sm:text-[16px]">
                     Answer your risk and preference questions, then connect accounts and start using
                     Kai.
                   </p>
                 </div>
-                <span className="inline-flex w-fit items-center rounded-full bg-primary px-4 py-2 text-[14px] font-semibold text-primary-foreground shadow-[0_12px_26px_-18px_rgba(0,113,227,0.75)]">
+                <span className="inline-flex h-10 w-fit items-center rounded-full bg-primary px-4 text-[14px] font-medium text-primary-foreground shadow-[0_12px_26px_-18px_rgba(0,113,227,0.75)]">
                   Open investor setup
                 </span>
               </button>
@@ -424,20 +424,20 @@ function KaiOnboardingPageContent() {
                     setSaving(false);
                   }
                 }}
-                className="flex h-full min-h-[228px] w-full flex-col justify-between gap-6 p-6 text-left disabled:cursor-not-allowed sm:p-7"
+                className="flex h-full min-h-[168px] w-full flex-col justify-between gap-5 p-5 text-left disabled:cursor-not-allowed sm:p-6"
               >
-                <div className="space-y-3.5">
-                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-primary/75">
+                <div className="space-y-2.5">
+                  <p className="text-[10.5px] font-medium uppercase tracking-[0.16em] text-primary/75">
                     RIA
                   </p>
                   <div
                     role="heading"
                     aria-level={2}
-                    className="text-[28px] font-normal leading-[1.08] tracking-normal text-foreground sm:text-[32px]"
+                    className="text-[24px] font-medium leading-[1.12] tracking-normal text-foreground sm:text-[26px]"
                   >
                     Continue as RIA
                   </div>
-                  <p className="max-w-[28rem] text-[16px] leading-[1.5] text-muted-foreground">
+                  <p className="max-w-[31rem] text-[15px] leading-[1.45] text-muted-foreground sm:text-[16px]">
                     Set up your advisor identity, verification, firm details, and marketplace trust
                     profile before sending consent requests.
                   </p>
@@ -447,7 +447,7 @@ function KaiOnboardingPageContent() {
                     </p>
                   ) : null}
                 </div>
-                <span className="inline-flex w-fit items-center rounded-full bg-primary px-4 py-2 text-[14px] font-semibold text-primary-foreground shadow-[0_12px_26px_-18px_rgba(0,113,227,0.75)]">
+                <span className="inline-flex h-10 w-fit items-center rounded-full bg-primary px-4 text-[14px] font-medium text-primary-foreground shadow-[0_12px_26px_-18px_rgba(0,113,227,0.75)]">
                   Open advisor setup
                 </span>
               </button>

--- a/hushh-webapp/app/kai/onboarding/page.tsx
+++ b/hushh-webapp/app/kai/onboarding/page.tsx
@@ -313,7 +313,7 @@ function KaiOnboardingPageContent() {
     return (
       <div
         data-top-content-anchor="true"
-        className="mx-auto flex min-h-[calc(100dvh_-_var(--top-content-pad))] w-full max-w-[46rem] items-start px-5 pb-8 pt-[calc(var(--top-content-pad)_+_0.25rem)] sm:px-6 lg:px-[var(--page-inline-gutter-standard)]"
+        className="mx-auto flex min-h-[calc(100dvh_-_var(--top-content-pad))] w-full max-w-[42rem] items-start px-5 pb-8 pt-[calc(var(--top-content-pad)_+_0.25rem)] sm:px-6 lg:px-[var(--page-inline-gutter-standard)]"
       >
         <NativeTestBeacon
           routeId="/kai/onboarding"
@@ -321,8 +321,8 @@ function KaiOnboardingPageContent() {
           authState={user ? "authenticated" : "pending"}
           dataState="loaded"
         />
-        <div className="w-full space-y-8">
-          <div className="mx-auto max-w-[48rem] space-y-3 text-center">
+        <div className="w-full space-y-6">
+          <div className="mx-auto max-w-[36rem] space-y-2.5 text-left">
             <p className={`${kaiAppEyebrowClassName} text-primary/75`}>
               Choose your starting path
             </p>
@@ -333,13 +333,13 @@ function KaiOnboardingPageContent() {
             >
               Start as an investor or set up RIA first
             </div>
-            <p className={`mx-auto max-w-[35rem] ${kaiAppBodyClassName} text-muted-foreground`}>
+            <p className={`max-w-[32rem] ${kaiAppBodyClassName} text-muted-foreground`}>
               You can add the other profile later from Profile. This choice only sets the first
               workflow we open right now.
             </p>
           </div>
 
-          <div className="mx-auto grid w-full max-w-[40rem] items-stretch gap-3.5">
+          <div className="mx-auto grid w-full max-w-[36rem] items-stretch gap-3.5">
             <Card
               preset="hero"
               variant="none"
@@ -374,7 +374,7 @@ function KaiOnboardingPageContent() {
                     setSaving(false);
                   }
                 }}
-                className="flex h-full min-h-[168px] w-full flex-col justify-between gap-5 p-5 text-left sm:p-6"
+                className="flex h-full min-h-[160px] w-full flex-col justify-between gap-5 p-5 text-left"
               >
                 <div className="space-y-2.5">
                   <p className="text-[10.5px] font-medium uppercase tracking-[0.16em] text-primary/75">
@@ -392,7 +392,7 @@ function KaiOnboardingPageContent() {
                     Kai.
                   </p>
                 </div>
-                <span className="inline-flex h-10 w-fit items-center rounded-full bg-primary px-4 text-[14px] font-medium text-primary-foreground shadow-[0_12px_26px_-18px_rgba(0,113,227,0.75)]">
+                <span className="inline-flex h-9 w-fit items-center rounded-full bg-primary px-4 text-[13.5px] font-medium text-primary-foreground shadow-[0_12px_26px_-18px_rgba(0,113,227,0.75)]">
                   Open investor setup
                 </span>
               </button>
@@ -430,7 +430,7 @@ function KaiOnboardingPageContent() {
                     setSaving(false);
                   }
                 }}
-                className="flex h-full min-h-[168px] w-full flex-col justify-between gap-5 p-5 text-left disabled:cursor-not-allowed sm:p-6"
+                className="flex h-full min-h-[160px] w-full flex-col justify-between gap-5 p-5 text-left disabled:cursor-not-allowed"
               >
                 <div className="space-y-2.5">
                   <p className="text-[10.5px] font-medium uppercase tracking-[0.16em] text-primary/75">
@@ -453,7 +453,7 @@ function KaiOnboardingPageContent() {
                     </p>
                   ) : null}
                 </div>
-                <span className="inline-flex h-10 w-fit items-center rounded-full bg-primary px-4 text-[14px] font-medium text-primary-foreground shadow-[0_12px_26px_-18px_rgba(0,113,227,0.75)]">
+                <span className="inline-flex h-9 w-fit items-center rounded-full bg-primary px-4 text-[13.5px] font-medium text-primary-foreground shadow-[0_12px_26px_-18px_rgba(0,113,227,0.75)]">
                   Open advisor setup
                 </span>
               </button>

--- a/hushh-webapp/app/kai/onboarding/page.tsx
+++ b/hushh-webapp/app/kai/onboarding/page.tsx
@@ -313,7 +313,7 @@ function KaiOnboardingPageContent() {
     return (
       <div
         data-top-content-anchor="true"
-        className="mx-auto flex min-h-[calc(100dvh_-_var(--top-content-pad))] w-full max-w-[42rem] items-start px-5 pb-8 pt-[calc(var(--top-content-pad)_+_0.25rem)] sm:px-6 lg:px-[var(--page-inline-gutter-standard)]"
+        className="mx-auto flex min-h-[calc(100dvh_-_var(--top-content-pad))] w-full max-w-[40rem] items-start px-5 pb-8 pt-[calc(var(--top-content-pad)_+_0.25rem)] sm:px-6 lg:px-[var(--page-inline-gutter-standard)]"
       >
         <NativeTestBeacon
           routeId="/kai/onboarding"
@@ -321,8 +321,8 @@ function KaiOnboardingPageContent() {
           authState={user ? "authenticated" : "pending"}
           dataState="loaded"
         />
-        <div className="w-full space-y-6">
-          <div className="mx-auto max-w-[36rem] space-y-2.5 text-left">
+        <div className="w-full space-y-5">
+          <div className="mx-auto max-w-[34rem] space-y-2.5 text-left">
             <p className={`${kaiAppEyebrowClassName} text-primary/75`}>
               Choose your starting path
             </p>
@@ -333,13 +333,13 @@ function KaiOnboardingPageContent() {
             >
               Start as an investor or set up RIA first
             </div>
-            <p className={`max-w-[32rem] ${kaiAppBodyClassName} text-muted-foreground`}>
+            <p className={`max-w-[30rem] ${kaiAppBodyClassName} text-muted-foreground`}>
               You can add the other profile later from Profile. This choice only sets the first
               workflow we open right now.
             </p>
           </div>
 
-          <div className="mx-auto grid w-full max-w-[36rem] items-stretch gap-3.5">
+          <div className="mx-auto grid w-full max-w-[34rem] items-stretch gap-3.5">
             <Card
               preset="hero"
               variant="none"
@@ -374,7 +374,7 @@ function KaiOnboardingPageContent() {
                     setSaving(false);
                   }
                 }}
-                className="flex h-full min-h-[160px] w-full flex-col justify-between gap-5 p-5 text-left"
+                className="flex h-full min-h-[148px] w-full flex-col justify-between gap-4 p-5 text-left"
               >
                 <div className="space-y-2.5">
                   <p className="text-[10.5px] font-medium uppercase tracking-[0.16em] text-primary/75">
@@ -430,7 +430,7 @@ function KaiOnboardingPageContent() {
                     setSaving(false);
                   }
                 }}
-                className="flex h-full min-h-[160px] w-full flex-col justify-between gap-5 p-5 text-left disabled:cursor-not-allowed"
+                className="flex h-full min-h-[148px] w-full flex-col justify-between gap-4 p-5 text-left disabled:cursor-not-allowed"
               >
                 <div className="space-y-2.5">
                   <p className="text-[10.5px] font-medium uppercase tracking-[0.16em] text-primary/75">

--- a/hushh-webapp/app/kai/optimize/page.tsx
+++ b/hushh-webapp/app/kai/optimize/page.tsx
@@ -769,7 +769,7 @@ export default function PortfolioHealthPage() {
                 
                 {/* LEFT COLUMN: Visual Analytics (The Graph) */}
                 <div className="relative p-6 md:p-8 bg-gradient-to-b from-muted/10 to-transparent">
-                  <div className="absolute top-4 left-4 md:top-6 md:left-6 text-[9px] font-black uppercase tracking-[0.2em] text-muted-foreground/50">
+                  <div className="absolute top-4 left-4 md:top-6 md:left-6 text-[9px] font-semibold uppercase tracking-[0.2em] text-muted-foreground/50">
                     Health Radar
                   </div>
                   
@@ -825,11 +825,11 @@ export default function PortfolioHealthPage() {
                   <div className="flex justify-center gap-6 mt-[-10px]">
                     <div className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-background/50 border border-border/5 backdrop-blur-sm">
                       <div className="w-2 h-2 rounded-full bg-[var(--color-current)]" />
-                      <span className="text-[9px] font-black uppercase tracking-widest text-muted-foreground">Current</span>
+                      <span className="text-[9px] font-semibold uppercase tracking-widest text-muted-foreground">Current</span>
                     </div>
                     <div className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-background/50 border border-border/5 backdrop-blur-sm">
                       <div className="w-2 h-2 rounded-full bg-[var(--color-optimized)]" />
-                      <span className="text-[9px] font-black uppercase tracking-widest text-muted-foreground">Optimized</span>
+                      <span className="text-[9px] font-semibold uppercase tracking-widest text-muted-foreground">Optimized</span>
                     </div>
                   </div>
                 </div>
@@ -843,21 +843,21 @@ export default function PortfolioHealthPage() {
                       <div className="space-y-4">
                          {/* Header Row */}
                         <div className="flex flex-wrap items-center justify-between gap-3">
-                          <span className="text-[10px] font-black text-muted-foreground uppercase tracking-[0.2em]">
+                          <span className="text-[10px] font-semibold text-muted-foreground uppercase tracking-[0.2em]">
                             Alpha Alignment
                           </span>
                           
                           {result.summary.projected_health_score && (
                             <div className="flex items-center gap-2 px-2 py-1 rounded-md bg-emerald-500/10 border border-emerald-500/20">
-                               <span className="text-[9px] font-black uppercase tracking-wider text-emerald-500">Projected Goal</span>
-                               <span className="text-xs font-black text-emerald-500">{result.summary.projected_health_score.toFixed(0)}%</span>
+                               <span className="text-[9px] font-semibold uppercase tracking-wider text-emerald-500">Projected Goal</span>
+                               <span className="text-xs font-semibold text-emerald-500">{result.summary.projected_health_score.toFixed(0)}%</span>
                             </div>
                           )}
                         </div>
 
                         {/* Big Score Row */}
                         <div className="flex items-baseline gap-1">
-                          <span className="text-7xl font-black tracking-tighter text-foreground leading-none">
+                          <span className="text-[32px] font-medium tracking-normal text-foreground leading-none sm:text-[36px]">
                             {result.summary.health_score.toFixed(0)}
                           </span>
                           <span className="text-2xl font-bold text-muted-foreground/40">%</span>
@@ -888,7 +888,7 @@ export default function PortfolioHealthPage() {
 
                   {/* Strategic Insights Module */}
                   <div className="flex-1 flex flex-col justify-end pt-6 border-t border-border/10">
-                    <h4 className="flex items-center gap-2 text-[10px] font-black text-muted-foreground uppercase tracking-[0.2em] mb-4">
+                    <h4 className="flex items-center gap-2 text-[10px] font-semibold text-muted-foreground uppercase tracking-[0.2em] mb-4">
                       <Icon icon={ListChecks} size="sm" className="text-primary" />
                       Key Insights
                     </h4>
@@ -925,8 +925,8 @@ export default function PortfolioHealthPage() {
                         <Icon icon={stat.icon} size="md" className="text-primary" />
                       </div>
                       <div className="flex flex-col gap-1">
-                        <span className="text-[10px] text-muted-foreground font-black uppercase tracking-widest">{stat.label}</span>
-                        <span className="text-sm font-black text-foreground">{stat.value}</span>
+                        <span className="text-[10px] text-muted-foreground font-semibold uppercase tracking-widest">{stat.label}</span>
+                        <span className="text-sm font-semibold text-foreground">{stat.value}</span>
                       </div>
                     </div>
                   ))}
@@ -938,7 +938,7 @@ export default function PortfolioHealthPage() {
           {sectorData.length > 0 && (
             <SurfaceCard>
               <SurfaceCardHeader className="pb-0">
-                <SurfaceCardTitle className="flex items-center gap-2 text-[10px] font-black uppercase tracking-widest text-muted-foreground">
+                <SurfaceCardTitle className="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
                   <Icon icon={TrendingUp} size={12} className="text-primary" />
                   Sector Concentration Shift
                 </SurfaceCardTitle>
@@ -1012,7 +1012,7 @@ export default function PortfolioHealthPage() {
                  <Icon icon={ShieldCheck} size={128} className="text-foreground" />
                </div>
                <div className="relative z-10">
-                <h3 className="text-xs font-black uppercase tracking-[0.2em] text-primary mb-6 flex items-center gap-2">
+                <h3 className="text-xs font-semibold uppercase tracking-[0.2em] text-primary mb-6 flex items-center gap-2">
                   <Icon icon={Zap} size="sm" />
                   Executive Strategic Summary
                 </h3>
@@ -1034,24 +1034,24 @@ export default function PortfolioHealthPage() {
             <SurfaceCardHeader>
               <div className="flex items-center gap-2">
                 <Icon icon={Zap} size="md" className="text-primary animate-pulse" />
-                <SurfaceCardTitle className="text-sm font-black uppercase tracking-widest">Simulated Alignment Outcome</SurfaceCardTitle>
+                <SurfaceCardTitle className="text-sm font-semibold uppercase tracking-widest">Simulated Alignment Outcome</SurfaceCardTitle>
               </div>
             </SurfaceCardHeader>
             <SurfaceCardContent className="space-y-4">
               <p className="text-sm text-foreground/80 font-medium">
-                By executing these {result.losers.length} adjustments, your portfolio's alpha alignment score is projected to move from <span className="text-red-400 font-black">{typeof result.summary.health_score === 'number' ? result.summary.health_score.toFixed(0) : "0"}</span> to <span className="text-emerald-400 font-black text-lg">{typeof result.summary.projected_health_score === 'number' ? `${result.summary.projected_health_score.toFixed(0)}+` : "92+"}</span>.
+                By executing these {result.losers.length} adjustments, your portfolio's alpha alignment score is projected to move from <span className="text-red-400 font-semibold">{typeof result.summary.health_score === 'number' ? result.summary.health_score.toFixed(0) : "0"}</span> to <span className="text-emerald-400 font-semibold text-lg">{typeof result.summary.projected_health_score === 'number' ? `${result.summary.projected_health_score.toFixed(0)}+` : "92+"}</span>.
               </p>
               <div className="p-5 rounded-3xl bg-background/80 border border-border/10 space-y-4">
-                <div className="flex items-center justify-between text-[10px] font-black uppercase tracking-widest text-muted-foreground">
+                <div className="flex items-center justify-between text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
                   <span>Current Fragility</span>
                   <Icon icon={ArrowRight} size={12} />
                   <span>Optimized Resilience</span>
                 </div>
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 md:gap-4">
-                   <div className="h-14 rounded-2xl bg-red-500/10 border border-red-500/20 flex items-center justify-center text-[10px] font-black text-red-500">
+                   <div className="h-14 rounded-2xl bg-red-500/10 border border-red-500/20 flex items-center justify-center text-[10px] font-semibold text-red-500">
                      HIGH SPECULATIVE RISK
                    </div>
-                   <div className="h-14 rounded-2xl bg-emerald-500/10 border border-emerald-500/20 flex items-center justify-center text-[10px] font-black text-emerald-500">
+                   <div className="h-14 rounded-2xl bg-emerald-500/10 border border-emerald-500/20 flex items-center justify-center text-[10px] font-semibold text-emerald-500">
                      CONVICTION ALPHA DIVERSITY
                    </div>
                 </div>
@@ -1091,7 +1091,7 @@ export default function PortfolioHealthPage() {
                   
                   return (
                     <div key={groupIdx} className="space-y-4">
-                      <div className={cn("flex items-center gap-2 px-3 py-2 rounded-xl border font-black text-[10px] uppercase tracking-widest", group.banner)}>
+                      <div className={cn("flex items-center gap-2 px-3 py-2 rounded-xl border font-semibold text-[10px] uppercase tracking-widest", group.banner)}>
                         <group.icon className={cn("w-3.5 h-3.5", group.iconColor)} />
                         {group.title}
                       </div>
@@ -1099,10 +1099,10 @@ export default function PortfolioHealthPage() {
                       <Table>
                         <TableHeader>
                           <TableRow className="hover:bg-transparent border-white/5">
-                            <TableHead className="w-[100px] text-[10px] uppercase font-black text-muted-foreground">Asset</TableHead>
-                            <TableHead className="text-[10px] uppercase font-black text-muted-foreground">Tier</TableHead>
-                            <TableHead className="text-[10px] uppercase font-black text-muted-foreground text-right">Target Δ</TableHead>
-                            <TableHead className="text-[10px] uppercase font-black text-muted-foreground text-right">Rationale</TableHead>
+                            <TableHead className="w-[100px] text-[10px] uppercase font-semibold text-muted-foreground">Asset</TableHead>
+                            <TableHead className="text-[10px] uppercase font-semibold text-muted-foreground">Tier</TableHead>
+                            <TableHead className="text-[10px] uppercase font-semibold text-muted-foreground text-right">Target Δ</TableHead>
+                            <TableHead className="text-[10px] uppercase font-semibold text-muted-foreground text-right">Rationale</TableHead>
                           </TableRow>
                         </TableHeader>
                         <TableBody>
@@ -1113,7 +1113,7 @@ export default function PortfolioHealthPage() {
                               <TableRow key={lIdx} className="group border-white/5 hover:bg-white/5 transition-colors">
                                 <TableCell className="py-4">
                                   <div className="flex flex-col">
-                                    <span className="font-black text-xs text-foreground uppercase">{l.symbol}</span>
+                                    <span className="font-semibold text-xs text-foreground uppercase">{l.symbol}</span>
                                     <span className="text-[9px] text-muted-foreground truncate max-w-[100px] font-medium">{l.name}</span>
                                   </div>
                                 </TableCell>
@@ -1122,7 +1122,7 @@ export default function PortfolioHealthPage() {
                                     <Badge 
                                       variant="outline" 
                                       className={cn(
-                                        "text-[9px] font-black tracking-widest px-1.5 py-0 rounded",
+                                        "text-[9px] font-semibold tracking-widest px-1.5 py-0 rounded",
                                         l.renaissance_tier === "ACE" ? "bg-emerald-500/10 text-emerald-500 border-emerald-500/20" :
                                         l.renaissance_tier === "KING" ? "bg-blue-500/10 text-blue-500 border-blue-500/20" :
                                         "bg-amber-500/10 text-amber-500 border-amber-500/20"
@@ -1134,7 +1134,7 @@ export default function PortfolioHealthPage() {
                                 </TableCell>
                                 <TableCell className="text-right">
                                   <span className={cn(
-                                    "text-xs font-black",
+                                    "text-xs font-semibold",
                                     group.actionType === "REDUCE" ? "text-red-500" : "text-emerald-500"
                                   )}>
                                     {group.actionType === "REDUCE" ? "–" : "+"}{delta > 0 ? `${delta.toFixed(1)}%` : "N/A"}
@@ -1161,7 +1161,7 @@ export default function PortfolioHealthPage() {
           {result.summary.plans && (
             <SurfaceCard>
               <SurfaceCardHeader className="pb-4">
-                <SurfaceCardTitle className="flex items-center gap-2 text-xs font-black uppercase tracking-widest text-muted-foreground">
+                <SurfaceCardTitle className="flex items-center gap-2 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
                   <Icon icon={LayoutDashboard} size="sm" className="text-primary" />
                   Proposed Rebalance Path Scenarios
                 </SurfaceCardTitle>
@@ -1173,7 +1173,7 @@ export default function PortfolioHealthPage() {
                       <TabsTrigger 
                         key={key}
                         value={key} 
-                        className="rounded-xl text-[10px] font-black uppercase tracking-widest data-[state=active]:bg-background data-[state=active]:text-primary transition-all"
+                        className="rounded-xl text-[10px] font-semibold uppercase tracking-widest data-[state=active]:bg-background data-[state=active]:text-primary transition-all"
                       >
                         {key}
                       </TabsTrigger>
@@ -1191,7 +1191,7 @@ export default function PortfolioHealthPage() {
                             <div key={idx} className="flex flex-col md:flex-row md:items-center justify-between p-5 rounded-3xl bg-muted/20 border border-border/20 hover:border-primary/40 transition-all group gap-4 ring-1 ring-transparent hover:ring-primary/10">
                               <div className="flex items-center gap-4">
                                 <div className={cn(
-                                  "w-10 h-10 rounded-2xl flex items-center justify-center font-black text-xs",
+                                  "w-10 h-10 rounded-2xl flex items-center justify-center font-semibold text-xs",
                                   a.action?.toLowerCase() === "exit" ? "bg-red-500/20 text-red-500" :
                                   a.action?.toLowerCase() === "trim" ? "bg-amber-500/20 text-amber-500" :
                                   "bg-emerald-500/20 text-emerald-500"
@@ -1200,8 +1200,8 @@ export default function PortfolioHealthPage() {
                                 </div>
                                 <div className="flex flex-col">
                                   <div className="flex items-center gap-2">
-                                    <span className="text-sm font-black text-foreground uppercase tracking-tight">{a.symbol}</span>
-                                    <Badge variant="outline" className="text-[8px] h-4 font-black px-1.5 opacity-60">{a.action}</Badge>
+                                    <span className="text-sm font-semibold text-foreground uppercase tracking-tight">{a.symbol}</span>
+                                    <Badge variant="outline" className="text-[8px] h-4 font-semibold px-1.5 opacity-60">{a.action}</Badge>
                                   </div>
                                   <span className="text-[10px] font-medium text-muted-foreground line-clamp-1">{a.name || "Portfolio Holding"}</span>
                                 </div>
@@ -1216,7 +1216,7 @@ export default function PortfolioHealthPage() {
                               <div className="flex items-center justify-between md:justify-end gap-6 bg-white/5 md:bg-transparent p-3 md:p-0 rounded-2xl">
                                 {typeof a.current_weight_pct === "number" && (
                                   <div className="flex flex-col items-end">
-                                    <span className="text-[8px] font-black text-muted-foreground uppercase tracking-widest mb-0.5">Transition</span>
+                                    <span className="text-[8px] font-semibold text-muted-foreground uppercase tracking-widest mb-0.5">Transition</span>
                                     <div className="flex items-center gap-2">
                                       <span className="text-xs font-bold text-muted-foreground/60">{a.current_weight_pct.toFixed(1)}%</span>
                                       <Icon
@@ -1224,7 +1224,7 @@ export default function PortfolioHealthPage() {
                                         size={12}
                                         className="text-primary group-hover:translate-x-1 transition-transform"
                                       />
-                                      <span className="text-sm font-black text-foreground">{(a.target_weight_pct ?? a.current_weight_pct).toFixed(1)}%</span>
+                                      <span className="text-sm font-semibold text-foreground">{(a.target_weight_pct ?? a.current_weight_pct).toFixed(1)}%</span>
                                     </div>
                                   </div>
                                 )}
@@ -1247,7 +1247,7 @@ export default function PortfolioHealthPage() {
           <div className="grid gap-6 md:grid-cols-2">
             <SurfaceCard className="opacity-80 transition-opacity hover:opacity-100">
               <SurfaceCardHeader className="py-4">
-                <SurfaceCardTitle className="text-[10px] font-black uppercase tracking-widest">Renaissance Alignment Context</SurfaceCardTitle>
+                <SurfaceCardTitle className="text-[10px] font-semibold uppercase tracking-widest">Renaissance Alignment Context</SurfaceCardTitle>
               </SurfaceCardHeader>
               <SurfaceCardContent className="pb-4">
                 <pre className="whitespace-pre-wrap text-[11px] text-muted-foreground/80 leading-relaxed font-medium">
@@ -1259,7 +1259,7 @@ export default function PortfolioHealthPage() {
             {streamedText && (
               <SurfaceCard accent="sky">
                 <SurfaceCardHeader className="py-4">
-                  <SurfaceCardTitle className="text-[10px] font-black uppercase tracking-widest">
+                  <SurfaceCardTitle className="text-[10px] font-semibold uppercase tracking-widest">
                     Alpha Analysis Runtime Transcript
                   </SurfaceCardTitle>
                 </SurfaceCardHeader>

--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -1417,7 +1417,7 @@ export default function MarketplacePage() {
                   <ProfileAvatar kind={item.kind} label={item.title} />
                   <div className="min-w-0 flex-1 space-y-2">
                     <div className="flex flex-wrap items-center gap-2">
-                      <h3 className="text-[17px] font-semibold leading-snug tracking-normal text-foreground">
+                      <h3 className="text-[15.5px] font-medium leading-[1.24] tracking-normal text-foreground sm:text-[16px]">
                         {item.title}
                       </h3>
                       {item.isTestProfile ? (
@@ -1437,12 +1437,12 @@ export default function MarketplacePage() {
                         </span>
                       ) : null}
                     </div>
-                    <p className="text-[14px] leading-[1.45] text-foreground/78">{item.headline}</p>
+                    <p className="text-[14px] font-normal leading-[1.45] tracking-normal text-foreground/72">{item.headline}</p>
                   </div>
                 </div>
 
                 <div className="flex-1 rounded-[var(--radius-md)] bg-background/50 p-4 dark:bg-white/5">
-                  <p className="text-[14px] leading-[1.5] text-foreground/86">{item.summary}</p>
+                  <p className="text-[14px] font-normal leading-[1.45] tracking-normal text-foreground/82">{item.summary}</p>
                   <p className="mt-3 text-[13px] text-muted-foreground">{item.metaLine}</p>
                 </div>
 

--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -1089,9 +1089,9 @@ export default function MarketplacePage() {
     >
       <AppPageHeaderRegion>
         <PageHeader
-          eyebrow="Connect"
-          title="Search people"
-          description="Find investors, RIAs, and contacts already on Hushh."
+          eyebrow="SEBI-registered network"
+          title="Connect"
+          description="Find a registered advisor. Connect with consent."
           icon={Compass}
           accent="marketplace"
           actions={
@@ -1109,7 +1109,7 @@ export default function MarketplacePage() {
       </AppPageHeaderRegion>
 
       <AppPageContentRegion className="space-y-4 pb-24 pt-0">
-        <div className="rounded-[28px] bg-background/90 p-1.5 shadow-[var(--app-card-shadow-standard)] backdrop-blur-[var(--blur-standard)]">
+        <div className="rounded-[24px] border border-border/45 bg-card/88 p-1.5 shadow-[var(--app-card-shadow-standard)] backdrop-blur-[var(--blur-standard)]">
           <div className="flex items-center justify-between gap-2">
             <div className="flex items-center gap-2">
               <button
@@ -1252,7 +1252,7 @@ export default function MarketplacePage() {
       ) : null}
 
       {!iamUnavailable && view === "swipe" ? (
-        <div className={cn("pb-16", searchOpen && "pt-12")}>
+        <div className="pb-16">
           {!hasLoadedDirectory || loading ? (
             <div className="flex min-h-[420px] items-center justify-center px-6 py-14 text-center">
               <p className="text-sm text-muted-foreground">Loading discovery…</p>

--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -1109,7 +1109,7 @@ export default function MarketplacePage() {
       </AppPageHeaderRegion>
 
       <AppPageContentRegion className="space-y-4 pb-24 pt-0">
-        <div className="sticky top-[calc(var(--top-shell-reserved-height)+6px)] z-[115] rounded-[28px] bg-background/90 p-1.5 shadow-[var(--app-card-shadow-standard)] backdrop-blur-[var(--blur-standard)]">
+        <div className="rounded-[28px] bg-background/90 p-1.5 shadow-[var(--app-card-shadow-standard)] backdrop-blur-[var(--blur-standard)]">
           <div className="flex items-center justify-between gap-2">
             <div className="flex items-center gap-2">
               <button
@@ -1411,7 +1411,7 @@ export default function MarketplacePage() {
             return (
               <RiaSurface
                 key={`${item.kind}-${item.id}`}
-                className="grid h-full grid-rows-[auto_1fr_auto] gap-4 rounded-[28px] p-4 sm:p-5"
+                className="flex h-full min-h-[286px] flex-col gap-4 rounded-[28px] p-4 sm:p-5"
               >
                 <div className="flex items-start gap-4">
                   <ProfileAvatar kind={item.kind} label={item.title} />
@@ -1441,17 +1441,17 @@ export default function MarketplacePage() {
                   </div>
                 </div>
 
-                <div className="rounded-[var(--radius-md)] bg-background/50 p-4 dark:bg-white/5">
+                <div className="flex-1 rounded-[var(--radius-md)] bg-background/50 p-4 dark:bg-white/5">
                   <p className="text-[14px] leading-[1.5] text-foreground/86">{item.summary}</p>
                   <p className="mt-3 text-[13px] text-muted-foreground">{item.metaLine}</p>
                 </div>
 
-                <div className="mt-auto grid grid-cols-1 gap-2 sm:grid-cols-2">
+                <div className="mt-auto grid grid-cols-1 gap-2 pt-1 sm:grid-cols-2">
                   <Button
                     variant="blue-gradient"
                     effect="fill"
                     size="sm"
-                    className="justify-center"
+                    className="min-w-0 justify-center"
                     onClick={() => performPrimaryCardAction(item)}
                     disabled={
                       (Boolean(userId) && actionLoadingUserId === userId) ||
@@ -1479,7 +1479,7 @@ export default function MarketplacePage() {
                     variant="none"
                     effect="fade"
                     size="sm"
-                    className="justify-center"
+                    className="min-w-0 justify-center"
                     onClick={() => openDiscoveryProfile(item)}
                   >
                     View details

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -291,8 +291,8 @@ function recipientRecommendationLine(recipient: OneLocationRecipient): string {
     recipient.recommendationSummary ||
     visibleRecommendationReasons(recipient)[0]?.label ||
     (recipient.canReceiveLocation
-      ? "Ready for encrypted location access"
-      : "Needs a recipient key")
+      ? "Ready for private location sharing"
+      : "Needs to open One Location once")
   );
 }
 
@@ -1096,7 +1096,7 @@ function readinessCopy(permission: HushhLocationPermissionState | null): {
     description:
       permission.precise === false
         ? "Sharing can continue, but accuracy may be approximate on this device."
-        : "Foreground location is ready for encrypted sharing.",
+        : "Foreground location is ready for private sharing.",
     tone: permission.precise === false ? "warning" : "ready",
   };
 }
@@ -2214,7 +2214,7 @@ function OneLocationAgentPageContent() {
     ) => {
       if (!vaultOwnerToken) throw new Error("Vault owner token required.");
       if (!recipient.publicKeyJwk || !recipient.keyId) {
-        throw new Error("Recipient key unavailable.");
+        throw new Error("They need to open One Location once before private sharing can start.");
       }
       const point =
         pointOverride ?? (await OneLocationService.captureCurrentPosition());
@@ -2326,7 +2326,7 @@ function OneLocationAgentPageContent() {
     async (grant: OneLocationGrant) => {
       const recipient = recipientForGrant(grant);
       if (!recipient) {
-        toast.error("Recipient key unavailable for this active share.");
+        toast.error("This share needs the recipient to open One Location once.");
         return;
       }
       setBusy("publish");
@@ -2383,7 +2383,7 @@ function OneLocationAgentPageContent() {
           toast.error(
             error instanceof Error
               ? error.message
-              : "Could not view encrypted location.",
+              : "Could not view this private location update.",
           );
         } else {
           console.warn(
@@ -2837,7 +2837,7 @@ function OneLocationAgentPageContent() {
         (recipient) => recipient.userId === request.requesterUserId,
       );
       if (!requester?.keyId || !requester.publicKeyJwk) {
-        toast.error("Requester key unavailable.");
+        toast.error("They need to open One Location once before approval can finish.");
         return;
       }
       setBusy("approve");
@@ -3702,15 +3702,15 @@ function OneLocationAgentPageContent() {
                           {peopleCountLabel(
                             setupNeededSelectedRecipients.length,
                           )}{" "}
-                          need One Location setup before private sharing can
-                          start.
+                          need to open One Location once before private sharing
+                          can start.
                         </div>
                       ) : null}
                       <p className="text-[12px] font-medium text-[#8e8e93] dark:text-white/55">
                         {selectedShareRecipients.length
                           ? `${peopleCountLabel(
                               selectedShareRecipients.length,
-                            )} selected for private encrypted sharing.`
+                            )} selected for private sharing.`
                           : "Select one or more One users for private sharing."}
                       </p>
                       {shareReviewOpen ? (
@@ -3727,7 +3727,7 @@ function OneLocationAgentPageContent() {
                               {peopleCountLabel(
                                 shareReadySelectedRecipients.length,
                               )}{" "}
-                              will receive separate encrypted location access
+                              will receive separate private location access
                               for{" "}
                               {
                                 DURATION_OPTIONS.find(

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -42,6 +42,7 @@ import {
   AppPageHeaderRegion,
   AppPageShell,
 } from "@/components/app-ui/app-page-shell";
+import { NativeTestBeacon } from "@/components/app-ui/native-test-beacon";
 import { SettingsGroup } from "@/components/app-ui/settings-ui";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -127,6 +128,7 @@ const SHOW_LOCATION_ACTIVITY_SECTION = false;
 const SHOW_OWNER_GRANTS_SECTION = false;
 const SHOW_PUBLIC_RESPONSES_SECTION = false;
 const SHOW_REFERRAL_SECTION = false;
+const ONE_LOCATION_ONBOARDING_STORAGE_PREFIX = "one_location_onboarding_v1";
 
 type BusyState =
   | "load"
@@ -155,6 +157,9 @@ type OneLocationDurationBucket = "15m" | "30m" | "1h" | "4h" | "24h" | "custom";
 type OneLocationForegroundOperation = "publish" | "view";
 type OneLocationForegroundTrigger = "manual" | "foreground_interval";
 type OneLocationFocusTarget = OneLocationNotificationSection;
+type OneLocationOnboardingStep = "intro" | "permission";
+type OneLocationOnboardingGate = "checking" | "show" | "hidden";
+type OneLocationNativeTestConfig = ComponentProps<typeof NativeTestBeacon>;
 type OneLocationBackoffBucket =
   | "none"
   | "lt_500ms"
@@ -1129,6 +1134,240 @@ function OneLocationInitialSkeleton() {
   );
 }
 
+function oneLocationOnboardingStorageKey(userId: string): string {
+  return `${ONE_LOCATION_ONBOARDING_STORAGE_PREFIX}:${userId}`;
+}
+
+function readOneLocationOnboardingDismissed(userId: string): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const value = window.localStorage.getItem(
+      oneLocationOnboardingStorageKey(userId),
+    );
+    return value === "done" || value === "skipped";
+  } catch {
+    return false;
+  }
+}
+
+function writeOneLocationOnboardingDismissed(
+  userId: string,
+  status: "done" | "skipped",
+) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(oneLocationOnboardingStorageKey(userId), status);
+  } catch {
+    // Non-blocking: private browsing or storage restrictions should not trap users.
+  }
+}
+
+function OneLocationIntroMapIllustration() {
+  return (
+    <div
+      className="relative aspect-square w-[min(290px,78vw,42dvh)] overflow-hidden rounded-[32px] bg-[#efece5] shadow-[0_26px_54px_-14px_rgba(40,34,22,0.24),0_6px_16px_rgba(0,0,0,0.06)] dark:bg-[#1d2229] dark:shadow-[0_26px_54px_-14px_rgba(0,0,0,0.65),0_6px_16px_rgba(0,0,0,0.28)]"
+      aria-hidden="true"
+    >
+      <svg
+        width="100%"
+        height="100%"
+        viewBox="0 0 300 300"
+        preserveAspectRatio="xMidYMid slice"
+        focusable="false"
+      >
+        <rect width="300" height="300" className="fill-[#efece5] dark:fill-[#1d2229]" />
+        <path
+          d="M0 198 Q44 182 86 198 T172 204 L172 300 L0 300 Z"
+          className="fill-[#d3e7c4] dark:fill-[#243f2d]"
+        />
+        <path
+          d="M214 0 Q248 42 300 38 L300 0 Z"
+          className="fill-[#c2dcf4] dark:fill-[#20374f]"
+        />
+        <circle cx="58" cy="54" r="30" className="fill-[#d3e7c4] dark:fill-[#274633]" />
+        <path
+          d="M-20 116 L320 88"
+          className="stroke-[#e6e0d4] dark:stroke-[#2c333c]"
+          strokeWidth="17"
+          fill="none"
+        />
+        <path
+          d="M150 -20 L172 320"
+          className="stroke-[#e6e0d4] dark:stroke-[#2c333c]"
+          strokeWidth="17"
+          fill="none"
+        />
+        <path
+          d="M-20 224 L320 202"
+          className="stroke-[#e6e0d4] dark:stroke-[#2c333c]"
+          strokeWidth="12"
+          fill="none"
+        />
+        <path
+          d="M-20 116 L320 88"
+          className="stroke-[#fbfaf6] dark:stroke-[#11161c]"
+          strokeWidth="11.5"
+          fill="none"
+        />
+        <path
+          d="M150 -20 L172 320"
+          className="stroke-[#fbfaf6] dark:stroke-[#11161c]"
+          strokeWidth="11.5"
+          fill="none"
+        />
+        <path
+          d="M-20 224 L320 202"
+          className="stroke-[#fbfaf6] dark:stroke-[#11161c]"
+          strokeWidth="7.5"
+          fill="none"
+        />
+        <rect x="38" y="128" width="44" height="38" rx="6" className="fill-[#e8e2d6] dark:fill-[#29313a]" />
+        <rect x="90" y="132" width="40" height="34" rx="6" className="fill-[#e8e2d6] dark:fill-[#29313a]" />
+        <rect x="198" y="124" width="52" height="46" rx="6" className="fill-[#e8e2d6] dark:fill-[#29313a]" />
+        <rect x="40" y="250" width="48" height="40" rx="6" className="fill-[#e8e2d6] dark:fill-[#29313a]" />
+      </svg>
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(110%_80%_at_28%_4%,rgba(255,255,255,0.55),rgba(255,255,255,0)_58%)] dark:bg-[radial-gradient(110%_80%_at_28%_4%,rgba(255,255,255,0.09),rgba(255,255,255,0)_58%)]" />
+      <div className="absolute left-[18%] top-[27%] flex flex-col items-center">
+        <span className="flex h-[50px] w-[50px] items-center justify-center rounded-full border-[3px] border-white bg-[#34c759] text-[19px] font-semibold text-white shadow-[0_6px_15px_rgba(0,0,0,0.16),0_1px_3px_rgba(0,0,0,0.1)]">
+          M
+        </span>
+        <span className="-mt-0.5 h-0 w-0 border-l-[6px] border-r-[6px] border-t-[9px] border-l-transparent border-r-transparent border-t-white" />
+      </div>
+      <div className="absolute left-[45%] top-[47%] flex -translate-x-1/2 -translate-y-1/2 items-center justify-center">
+        <span className="absolute h-20 w-20 rounded-full bg-[#0071e3]/12 dark:bg-[#0a84ff]/18" />
+        <span className="absolute h-[30px] w-[30px] animate-ping rounded-full bg-[#0071e3]/35" />
+        <span className="relative h-[22px] w-[22px] rounded-full border-[3px] border-white bg-[#0071e3] shadow-[0_2px_8px_rgba(0,113,227,0.55),0_1px_3px_rgba(0,0,0,0.25)]" />
+      </div>
+      <div className="absolute bottom-[29%] right-[21%] flex flex-col items-center">
+        <span className="flex h-11 w-11 items-center justify-center rounded-full border-[3px] border-white bg-[#ff3b30] text-[16px] font-semibold text-white shadow-[0_6px_15px_rgba(0,0,0,0.16),0_1px_3px_rgba(0,0,0,0.1)]">
+          E
+        </span>
+        <span className="-mt-0.5 h-0 w-0 border-l-[6px] border-r-[6px] border-t-[9px] border-l-transparent border-r-transparent border-t-white" />
+      </div>
+      <div className="absolute bottom-[16%] left-[29%] flex flex-col items-center">
+        <span className="flex h-[42px] w-[42px] items-center justify-center rounded-full border-[3px] border-white bg-[#ff9f0a] text-[15px] font-semibold text-white shadow-[0_6px_15px_rgba(0,0,0,0.16),0_1px_3px_rgba(0,0,0,0.1)]">
+          J
+        </span>
+        <span className="-mt-0.5 h-0 w-0 border-l-[6px] border-r-[6px] border-t-[9px] border-l-transparent border-r-transparent border-t-white" />
+      </div>
+      <div className="pointer-events-none absolute inset-0 rounded-[32px] shadow-[inset_0_0_60px_rgba(70,60,40,0.09),inset_0_0_0_1px_rgba(255,255,255,0.35)] dark:shadow-[inset_0_0_60px_rgba(0,0,0,0.28),inset_0_0_0_1px_rgba(255,255,255,0.08)]" />
+    </div>
+  );
+}
+
+function OneLocationPermissionGlyph() {
+  return (
+    <div
+      className="flex h-24 w-24 items-center justify-center rounded-full bg-[#0071e3] text-[#0071e3] shadow-[0_0_64px_10px_rgba(0,113,227,0.34),0_16px_34px_rgba(0,113,227,0.34)] dark:bg-[#0a84ff] dark:text-[#0a84ff] dark:shadow-[0_0_70px_10px_rgba(10,132,255,0.42),0_18px_38px_rgba(10,132,255,0.32)]"
+      aria-hidden="true"
+    >
+      <svg width="42" height="42" viewBox="0 0 24 24" fill="none" focusable="false">
+        <path
+          d="M12 21s7-6.3 7-11.5A7 7 0 0 0 5 9.5C5 14.7 12 21 12 21Z"
+          fill="#fff"
+        />
+        <circle cx="12" cy="9.5" r="2.7" fill="currentColor" />
+      </svg>
+    </div>
+  );
+}
+
+function OneLocationOnboardingFlow({
+  step,
+  busy,
+  nativeTest,
+  onContinueIntro,
+  onRequestPermission,
+  onSkip,
+}: {
+  step: OneLocationOnboardingStep;
+  busy: boolean;
+  nativeTest: OneLocationNativeTestConfig;
+  onContinueIntro: () => void;
+  onRequestPermission: () => void;
+  onSkip: () => void;
+}) {
+  const isPermissionStep = step === "permission";
+
+  return (
+    <main className="min-h-dvh w-full bg-white text-[#1d1d1f] dark:bg-[#050506] dark:text-white">
+      <NativeTestBeacon {...nativeTest} />
+      <div className="mx-auto flex min-h-dvh w-full max-w-[430px] flex-col overflow-hidden bg-white dark:bg-[#050506]">
+        <div className="h-[calc(env(safe-area-inset-top,0px)+24px)] shrink-0" />
+        <section className="flex min-h-0 flex-1 flex-col items-center justify-center overflow-y-auto px-[clamp(24px,7vw,34px)] py-3 [-webkit-overflow-scrolling:touch]">
+          <div
+            key={step}
+            className="flex w-full flex-col items-center text-center animate-in fade-in slide-in-from-right-4 duration-300 motion-reduce:animate-none"
+          >
+            {isPermissionStep ? <OneLocationPermissionGlyph /> : <OneLocationIntroMapIllustration />}
+
+            <h1
+              className={cn(
+                "mt-8 max-w-[350px] text-center text-[34px] font-bold leading-[1.08] text-[#1d1d1f] sm:text-[36px] dark:text-white",
+                isPermissionStep && "max-w-[340px] text-[32px] leading-[1.1] sm:text-[34px]",
+              )}
+            >
+              {isPermissionStep
+                ? "Keep your map live"
+                : "Experience location sharing with One."}
+            </h1>
+
+            {isPermissionStep ? (
+              <>
+                <p className="mt-3 max-w-[340px] text-[17px] font-normal leading-[1.5] text-[#6e6e73] dark:text-white/62">
+                  Choose{" "}
+                  <strong className="font-semibold text-[#1d1d1f] dark:text-white">
+                    Allow Always
+                  </strong>{" "}
+                  so the map and alerts keep working. Only your Circle ever sees
+                  you.
+                </p>
+                <div className="mt-6 inline-flex max-w-full items-center gap-2.5 rounded-full bg-[#f5f5f7] px-4 py-2.5 text-[14px] text-[#6e6e73] dark:bg-white/[0.08] dark:text-white/62">
+                  <Clock3 className="h-[18px] w-[18px] shrink-0 text-[#34c759]" aria-hidden="true" />
+                  <span className="min-w-0 truncate">You can pause sharing anytime</span>
+                </div>
+              </>
+            ) : (
+              <p className="mt-3 max-w-[310px] text-[18px] leading-[1.4] text-[#6e6e73] dark:text-white/62">
+                Never text "where are you?" again.
+              </p>
+            )}
+          </div>
+        </section>
+        <footer className="flex shrink-0 flex-col items-center gap-3.5 px-[clamp(24px,7vw,34px)] pb-2 pt-2">
+          <Button
+            type="button"
+            onClick={isPermissionStep ? onRequestPermission : onContinueIntro}
+            disabled={busy}
+            className="h-[54px] w-full rounded-full bg-[#0071e3] text-[17px] font-semibold text-white shadow-[0_8px_22px_rgba(0,113,227,0.28)] hover:bg-[#006fe6] dark:bg-[#0a84ff] dark:hover:bg-[#0077ed]"
+          >
+            {busy ? (
+              <Loader2 className="mr-2 h-5 w-5 animate-spin" aria-hidden="true" />
+            ) : null}
+            Continue
+          </Button>
+
+          {isPermissionStep ? (
+            <button
+              type="button"
+              onClick={onSkip}
+              disabled={busy}
+              className="h-6 rounded-full px-3 text-[14.5px] font-medium text-[#86868b] transition-colors hover:text-[#1d1d1f] disabled:opacity-50 dark:text-white/45 dark:hover:text-white"
+            >
+              Not now
+            </button>
+          ) : (
+            <p className="min-h-6 text-center text-[13px] text-[#86868b] dark:text-white/45">
+              Private - shared only with your Circle.
+            </p>
+          )}
+        </footer>
+        <div className="h-[calc(env(safe-area-inset-bottom,0px)+22px)] shrink-0" />
+      </div>
+    </main>
+  );
+}
+
 function OneLocationAgentPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -1138,6 +1377,11 @@ function OneLocationAgentPageContent() {
   const [permission, setPermission] =
     useState<HushhLocationPermissionState | null>(null);
   const [busy, setBusy] = useState<BusyState>(null);
+  const [locationOnboardingGate, setLocationOnboardingGate] =
+    useState<OneLocationOnboardingGate>("checking");
+  const [locationOnboardingStep, setLocationOnboardingStep] =
+    useState<OneLocationOnboardingStep>("intro");
+  const [locationOnboardingBusy, setLocationOnboardingBusy] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [activeMode, setActiveMode] = useState<ShareMode>("share");
   const [shareReviewOpen, setShareReviewOpen] = useState(false);
@@ -1175,8 +1419,6 @@ function OneLocationAgentPageContent() {
   const [focusedSection, setFocusedSection] =
     useState<OneLocationFocusTarget | null>(null);
   const refreshInFlightRef = useRef<Promise<void> | null>(null);
-  const permissionPromptInFlightRef = useRef(false);
-  const locationLandingPromptUserRef = useRef<string | null>(null);
   const peopleSectionRef = useRef<HTMLElement | null>(null);
   const approvalsSectionRef = useRef<HTMLElement | null>(null);
   const sharedSectionRef = useRef<HTMLElement | null>(null);
@@ -1740,46 +1982,36 @@ function OneLocationAgentPageContent() {
   }, [auth.loading, refresh]);
 
   useEffect(() => {
-    if (
-      !auth.userId ||
-      !state ||
-      locationLandingPromptUserRef.current === auth.userId ||
-      permissionPromptInFlightRef.current
-    ) {
+    if (!auth.userId || auth.loading || loadError) {
+      setLocationOnboardingGate("hidden");
       return;
     }
-    const canRequestNativePrompt =
-      !permission ||
-      permission.state === "prompt" ||
-      permission.state === "denied";
-    if (!canRequestNativePrompt || isLocationServicesDisabled(permission)) {
+    if (!state) {
+      setLocationOnboardingGate("checking");
+      return;
+    }
+    if (permission?.state === "granted") {
+      writeOneLocationOnboardingDismissed(auth.userId, "done");
+      setLocationOnboardingGate("hidden");
+      return;
+    }
+    if (readOneLocationOnboardingDismissed(auth.userId)) {
+      setLocationOnboardingGate("hidden");
       return;
     }
 
-    let cancelled = false;
-    locationLandingPromptUserRef.current = auth.userId;
-    permissionPromptInFlightRef.current = true;
-    const promptForForegroundLocation = async () => {
-      try {
-        await ensureForegroundLocationReady({
-          capturePoint: false,
-          autoOpenSettings: false,
-          requestNativePrompt: true,
-        });
-      } finally {
-        if (!cancelled) {
-          permissionPromptInFlightRef.current = false;
-        }
-      }
-    };
-
-    void promptForForegroundLocation();
-
-    return () => {
-      cancelled = true;
-      permissionPromptInFlightRef.current = false;
-    };
-  }, [auth.userId, ensureForegroundLocationReady, permission, state]);
+    if (locationOnboardingGate !== "show") {
+      setLocationOnboardingStep("intro");
+    }
+    setLocationOnboardingGate("show");
+  }, [
+    auth.loading,
+    auth.userId,
+    loadError,
+    locationOnboardingGate,
+    permission?.state,
+    state,
+  ]);
 
   useEffect(() => {
     return () => {
@@ -2917,23 +3149,84 @@ function OneLocationAgentPageContent() {
     }
   }, [ensureForegroundLocationReady]);
 
+  const dismissLocationOnboarding = useCallback(
+    (status: "done" | "skipped") => {
+      if (auth.userId) {
+        writeOneLocationOnboardingDismissed(auth.userId, status);
+      }
+      setLocationOnboardingGate("hidden");
+      setLocationOnboardingBusy(false);
+    },
+    [auth.userId],
+  );
+
+  const handleContinueLocationOnboardingIntro = useCallback(() => {
+    setLocationOnboardingStep("permission");
+  }, []);
+
+  const handleSkipLocationOnboarding = useCallback(() => {
+    dismissLocationOnboarding("skipped");
+  }, [dismissLocationOnboarding]);
+
+  const handleLocationOnboardingPermission = useCallback(async () => {
+    if (locationOnboardingBusy) return;
+    setLocationOnboardingBusy(true);
+    try {
+      const result = await ensureForegroundLocationReady({
+        capturePoint: false,
+        autoOpenSettings: false,
+        requestNativePrompt: true,
+      });
+      const nextPermission = await refreshLocationPermission();
+      if (result.ready || nextPermission.state === "granted") {
+        dismissLocationOnboarding("done");
+      }
+    } finally {
+      setLocationOnboardingBusy(false);
+    }
+  }, [
+    dismissLocationOnboarding,
+    ensureForegroundLocationReady,
+    locationOnboardingBusy,
+    refreshLocationPermission,
+  ]);
+
+  const nativeTestConfig: OneLocationNativeTestConfig = {
+    routeId: "/one/location",
+    marker: "native-route-one-location",
+    authState: auth.loading
+      ? "pending"
+      : auth.isAuthenticated
+        ? "authenticated"
+        : "anonymous",
+    dataState,
+    errorCode: loadError ? "one_location_unavailable" : null,
+    errorMessage: loadError,
+  };
+
+  const showLocationOnboarding =
+    locationOnboardingGate === "show" &&
+    !showInitialSkeleton &&
+    !loadError &&
+    Boolean(auth.userId && state);
+
+  if (showLocationOnboarding) {
+    return (
+      <OneLocationOnboardingFlow
+        step={locationOnboardingStep}
+        busy={locationOnboardingBusy}
+        nativeTest={nativeTestConfig}
+        onContinueIntro={handleContinueLocationOnboardingIntro}
+        onRequestPermission={handleLocationOnboardingPermission}
+        onSkip={handleSkipLocationOnboarding}
+      />
+    );
+  }
+
   return (
     <AppPageShell
       width="standard"
-      nativeTest={{
-        routeId: "/one/location",
-        marker: "native-route-one-location",
-        authState: auth.loading
-          ? "pending"
-          : auth.isAuthenticated
-            ? "authenticated"
-            : "anonymous",
-        dataState,
-        errorCode: loadError
-          ? "one_location_unavailable"
-          : null,
-        errorMessage: loadError,
-      }}
+      nativeTest={nativeTestConfig}
     >
       <AppPageHeaderRegion className="mx-auto w-full max-w-[1120px] min-w-0 overflow-hidden">
         <div className="flex flex-col gap-4 px-1 pt-3 sm:flex-row sm:items-end sm:justify-between">

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -1999,9 +1999,11 @@ export function OneLocationAgentPageContent() {
     if (!vaultOwnerToken) return;
     setBusy("publicInvite");
     try {
+      const point = await OneLocationService.captureCurrentPosition();
       const response = await OneLocationService.createPublicInvite({
         vaultOwnerToken,
         durationHours: Number(durationHours),
+        locationSnapshot: point,
       });
       const url = publicInviteUrlLabel(response.publicUrl);
       setPublicInviteUrl(url);
@@ -2015,9 +2017,7 @@ export function OneLocationAgentPageContent() {
         copied_to_clipboard: Boolean(navigator.clipboard && url),
         active_invite_count: activePublicInvites.length + 1,
       });
-      toast.success(
-        "Public request link created. You still approve before sharing.",
-      );
+      toast.success("Public location link created and copied.");
       await refresh();
     } catch (error) {
       trackEvent("one_location_public_link_created", {
@@ -2028,7 +2028,7 @@ export function OneLocationAgentPageContent() {
         active_invite_count: activePublicInvites.length,
       });
       toast.error(
-        oneLocationErrorMessage(error, "Could not create public request link."),
+        oneLocationErrorMessage(error, "Could not create public location link."),
       );
     } finally {
       setBusy(null);
@@ -2039,27 +2039,27 @@ export function OneLocationAgentPageContent() {
     if (!publicInviteUrl) return;
     try {
       await navigator.clipboard.writeText(publicInviteUrl);
-      toast.success("Request link copied.");
+      toast.success("Public location link copied.");
     } catch {
-      toast.error("Could not copy the request link.");
+      toast.error("Could not copy the public location link.");
     }
   }, [publicInviteUrl]);
 
   const handleSharePublicInvite = useCallback(async () => {
     if (!publicInviteUrl) return;
     const text =
-      "Please send a One Location request here. I approve before anything is shared.";
+      "View my One Location location update here after entering your details.";
     try {
       if (navigator.share) {
         await navigator.share({
-          title: "Request my location",
+          title: "View my location",
           text,
           url: publicInviteUrl,
         });
         return;
       }
       await navigator.clipboard.writeText(publicInviteUrl);
-      toast.success("Request link copied.");
+      toast.success("Public location link copied.");
     } catch (error) {
       if ((error as Error)?.name === "AbortError") return;
       toast.error("Could not open the share sheet.");
@@ -2072,9 +2072,11 @@ export function OneLocationAgentPageContent() {
     try {
       let url = publicInviteUrl;
       if (!url) {
+        const point = await OneLocationService.captureCurrentPosition();
         const response = await OneLocationService.createPublicInvite({
           vaultOwnerToken,
           durationHours: Number(durationHours),
+          locationSnapshot: point,
         });
         url = publicInviteUrlLabel(response.publicUrl);
         setPublicInviteUrl(url);
@@ -2089,7 +2091,7 @@ export function OneLocationAgentPageContent() {
       }
 
       const text =
-        "Join my KAI Circle on One Location. Send me a request here; I approve before anything is shared.";
+        "Join my KAI Circle on One Location. You can view my public location update here after entering your details.";
       if (navigator.share && url) {
         await navigator.share({
           title: "Join my KAI Circle",
@@ -2103,7 +2105,7 @@ export function OneLocationAgentPageContent() {
         toast.success("Invite link copied.");
         return;
       }
-      toast.info("Create a request link, then share it with your contacts.");
+      toast.info("Create a public location link, then share it with your contacts.");
     } catch (error) {
       if ((error as Error)?.name === "AbortError") return;
       trackEvent("one_location_public_link_created", {
@@ -2135,13 +2137,13 @@ export function OneLocationAgentPageContent() {
           inviteId: invite.id,
         });
         setPublicInviteUrl("");
-        toast.success("Public request link revoked.");
+        toast.success("Public location link revoked.");
         await refresh();
       } catch (error) {
         toast.error(
           oneLocationErrorMessage(
             error,
-            "Could not revoke public request link.",
+            "Could not revoke public location link.",
           ),
         );
       } finally {
@@ -3113,17 +3115,17 @@ export function OneLocationAgentPageContent() {
               </section>
 
               <section className="space-y-2 px-1">
-                {sectionLabel("Create request link")}
+                {sectionLabel("Create public link")}
                 <div className={cn(onePanelClassName, "space-y-4 p-3.5")}>
                   <p className="text-[13px] leading-5 text-[#8e8e93] dark:text-white/55">
-                    Share a request link. It asks for their details and never
-                    shows your location until you approve an encrypted grant.
+                    Share a public location link. Visitors enter their details
+                    and can view this link's captured location.
                   </p>
                   <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_150px]">
                     <div className={cn(oneInsetClassName, "px-3 py-2 text-sm")}>
                       <span className={oneSecondaryTextClassName}>
                         {publicInviteUrl ||
-                          "Create a fresh request link to copy or share."}
+                          "Create a fresh public location link to copy or share."}
                       </span>
                     </div>
                     <Select
@@ -3151,7 +3153,7 @@ export function OneLocationAgentPageContent() {
                       className="rounded-full bg-[#007aff] text-white hover:bg-[#0066ff]"
                     >
                       <ExternalLink className="mr-2 h-4 w-4" />
-                      Create Request Link
+                      Create Public Link
                     </ActionButton>
                     <Button
                       variant="outline"
@@ -3181,10 +3183,10 @@ export function OneLocationAgentPageContent() {
                         >
                           <div className="min-w-0">
                             <p className="text-[14px] font-semibold text-[#1c1c1e] dark:text-white">
-                              Active request link
+                              Active public location link
                             </p>
                             <p className="truncate text-[12px] text-[#8e8e93] dark:text-white/55">
-                              Requests expire{" "}
+                              Public viewing expires{" "}
                               {formatDateTime(invite.expiresAt)} -{" "}
                               {invite.durationHours}h
                             </p>
@@ -3308,7 +3310,7 @@ export function OneLocationAgentPageContent() {
                     <EmptyOneState
                       icon={ExternalLink}
                       title="No public responses"
-                      description="Responses from your request link show up here without exposing your location."
+                      description="Responses from your public location link show up here after visitors open it."
                     />
                   )}
                 </div>

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -1113,22 +1113,6 @@ function OneLocationInitialSkeleton() {
           <Skeleton className="h-full flex-1 rounded-[7px] opacity-60" />
         </div>
 
-        <div className="space-y-2">
-          {sectionLabel("One Network")}
-          <div className="flex gap-4 overflow-hidden px-1 pb-2 pt-1">
-            {Array.from({ length: 5 }).map((_, index) => (
-              <div
-                key={index}
-                className="flex w-[68px] shrink-0 flex-col items-center gap-2"
-              >
-                <Skeleton className="h-[52px] w-[52px] rounded-full" />
-                <Skeleton className="h-3 w-12 rounded-full" />
-                <Skeleton className="h-3 w-16 rounded-md" />
-              </div>
-            ))}
-          </div>
-        </div>
-
         <Skeleton className="h-10 w-full rounded-[14px]" />
 
         <div className={onePanelClassName}>
@@ -3446,78 +3430,8 @@ function OneLocationAgentPageContent() {
                   onChange={setActiveMode}
                 />
 
-                <div className="min-w-0 max-w-full space-y-2">
-                  {sectionLabel("One Network")}
-                  <div className="flex max-w-full gap-4 overflow-x-auto overscroll-x-contain px-1 pb-2 pt-1 [scrollbar-width:thin] [&::-webkit-scrollbar]:h-2 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-black/20 dark:[&::-webkit-scrollbar-thumb]:bg-white/20">
-                    {rankedRecipients.length ? (
-                      rankedRecipients.map((recipient, index) => {
-                        const label = displayNameFromRecipient(recipient);
-                        const selected =
-                          activeMode === "share"
-                            ? selectedRecipientIds.includes(recipient.userId)
-                            : selectedRequestOwnerIds.includes(
-                                recipient.userId,
-                              );
-                        return (
-                          <button
-                            key={recipient.userId}
-                            type="button"
-                            aria-label={`Select ${recipientLabel(
-                              recipient,
-                            )} from One Network`}
-                            onClick={() => {
-                              if (activeMode === "share") {
-                                toggleShareRecipient(recipient.userId);
-                              } else {
-                                toggleRequestOwner(recipient.userId);
-                              }
-                            }}
-                            className="flex shrink-0 flex-col items-center gap-1.5"
-                          >
-                            <span className="relative">
-                              <AvatarBubble label={label} index={index} />
-                              <span
-                                className={cn(
-                                  "absolute bottom-0 right-0 flex h-[18px] w-[18px] items-center justify-center rounded-full border border-black/5 bg-white shadow-sm dark:border-white/10 dark:bg-[#2c2c2e]",
-                                  selected && "ring-2 ring-[#007aff]/30",
-                                )}
-                              >
-                                {selected ? (
-                                  <CheckCircle2 className="h-3 w-3 text-[#2e7d32] dark:text-emerald-300" />
-                                ) : recipient.canReceiveLocation ? (
-                                  <ShieldCheck className="h-3 w-3 text-[#8e8e93] dark:text-white/55" />
-                                ) : (
-                                  <AlertTriangle className="h-3 w-3 text-[#ff9500]" />
-                                )}
-                              </span>
-                            </span>
-                            <span className="max-w-[68px] truncate text-[12px] font-medium text-[#1c1c1e] dark:text-white">
-                              {label}
-                            </span>
-                            <span
-                              className={cn(
-                                "max-w-[88px] truncate rounded-md px-1.5 py-0.5 text-[9px] font-bold uppercase",
-                                recommendationToneClassName(
-                                  recipient.recommendationTier,
-                                ),
-                              )}
-                            >
-                              {recommendationTierLabel(
-                                recipient.recommendationTier,
-                              )}
-                            </span>
-                          </button>
-                        );
-                      })
-                    ) : (
-                      <p className="text-[13px] text-[#8e8e93] dark:text-white/55">
-                        One Network recommendations will appear here.
-                      </p>
-                    )}
-                  </div>
-                </div>
-
                 <div className="flex min-w-0 max-w-full flex-col gap-3">
+                  {sectionLabel("One Network")}
                   <div className="relative">
                     <Search className="absolute left-3.5 top-1/2 h-5 w-5 -translate-y-1/2 text-[#8e8e93]" />
                     <input
@@ -3634,6 +3548,9 @@ function OneLocationAgentPageContent() {
                               ) : (
                                 <button
                                   type="button"
+                                  aria-label={`Select ${recipientLabel(
+                                    recipient,
+                                  )} from One Network`}
                                   onClick={() => {
                                     if (activeMode === "share") {
                                       toggleShareRecipient(

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -612,18 +612,6 @@ function oneLocationErrorMessage(error: unknown, fallback: string): string {
   return error instanceof Error ? error.message : fallback;
 }
 
-function oneLocationRequestErrorMessage(error: unknown, fallback: string): string {
-  const message = oneLocationErrorMessage(error, fallback);
-  const normalized = message.toLowerCase();
-  if (
-    normalized.includes("verified recipient") &&
-    normalized.includes("location key material")
-  ) {
-    return "Your One Location key is still setting up. Refresh this page once, then send the request again.";
-  }
-  return message;
-}
-
 function isLocationPointStale(point: PlainLocationPoint): boolean {
   const capturedAt = new Date(point.capturedAt).getTime();
   if (!Number.isFinite(capturedAt)) return false;
@@ -2633,13 +2621,22 @@ function OneLocationAgentPageContent() {
       await AccountIdentityService.syncCurrentUser(activeUser).catch((error) => {
         console.warn("[OneLocation] Failed to sync account identity before request:", error);
       });
-      const key = await ensureLocationRecipientKey(activeUserId);
-      await OneLocationService.registerRecipientKey({
-        vaultOwnerToken: activeVaultOwnerToken,
-        keyId: key.keyId,
-        publicKeyJwk: key.publicKeyJwk,
-        algorithm: key.algorithm,
-      });
+      await (async () => {
+        try {
+          const key = await ensureLocationRecipientKey(activeUserId);
+          await OneLocationService.registerRecipientKey({
+            vaultOwnerToken: activeVaultOwnerToken,
+            keyId: key.keyId,
+            publicKeyJwk: key.publicKeyJwk,
+            algorithm: key.algorithm,
+          });
+        } catch (error) {
+          console.warn(
+            "[OneLocation] Continuing request after key sync failed:",
+            error,
+          );
+        }
+      })();
       for (const owner of selectedRequestOwners) {
         await OneLocationService.requestAccess({
           vaultOwnerToken: activeVaultOwnerToken,
@@ -2676,7 +2673,7 @@ function OneLocationAgentPageContent() {
         failure_count: failureCount,
         has_note: Boolean(requestMessage.trim()),
       });
-      toast.error(oneLocationRequestErrorMessage(error, "Could not send request."));
+      toast.error(oneLocationErrorMessage(error, "Could not send request."));
       if (isTransientOneApiError(error)) {
         await refresh().catch(() => null);
       }

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -612,6 +612,18 @@ function oneLocationErrorMessage(error: unknown, fallback: string): string {
   return error instanceof Error ? error.message : fallback;
 }
 
+function oneLocationRequestErrorMessage(error: unknown, fallback: string): string {
+  const message = oneLocationErrorMessage(error, fallback);
+  const normalized = message.toLowerCase();
+  if (
+    normalized.includes("verified recipient") &&
+    normalized.includes("location key material")
+  ) {
+    return "Your One Location key is still setting up. Refresh this page once, then send the request again.";
+  }
+  return message;
+}
+
 function isLocationPointStale(point: PlainLocationPoint): boolean {
   const capturedAt = new Date(point.capturedAt).getTime();
   if (!Number.isFinite(capturedAt)) return false;
@@ -896,10 +908,16 @@ function SegmentedModeControl({
   onChange: (value: ShareMode) => void;
 }) {
   return (
-    <div className="flex h-9 w-full min-w-0 max-w-full items-center overflow-hidden rounded-[9px] bg-[#efeff0] p-[3px] dark:bg-white/10">
+    <div
+      aria-label="Choose location sharing mode"
+      className="flex h-9 w-full min-w-0 max-w-full items-center overflow-hidden rounded-[9px] bg-[#efeff0] p-[3px] dark:bg-white/10"
+      role="tablist"
+    >
       {(["share", "request"] as const).map((mode) => (
         <button
           key={mode}
+          aria-selected={value === mode}
+          role="tab"
           type="button"
           onClick={() => onChange(mode)}
           className={cn(
@@ -1097,7 +1115,7 @@ function readinessCopy(permission: HushhLocationPermissionState | null): {
 
 function OneLocationInitialSkeleton() {
   return (
-    <div className="grid gap-6 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
+    <div className="space-y-6">
       <div className="space-y-6">
         <SettingsGroup eyebrow="Device" title="Readiness">
           <SkeletonRow />
@@ -2602,12 +2620,29 @@ function OneLocationAgentPageContent() {
 
   const handleRequestAccess = useCallback(async () => {
     if (!vaultOwnerToken || !selectedRequestOwners.length) return;
+    if (!auth.user || !auth.userId) {
+      toast.error("Refresh your session before sending a location request.");
+      return;
+    }
+    const activeUser = auth.user;
+    const activeUserId = auth.userId;
+    const activeVaultOwnerToken = vaultOwnerToken;
     setBusy("request");
     let successCount = 0;
     try {
+      await AccountIdentityService.syncCurrentUser(activeUser).catch((error) => {
+        console.warn("[OneLocation] Failed to sync account identity before request:", error);
+      });
+      const key = await ensureLocationRecipientKey(activeUserId);
+      await OneLocationService.registerRecipientKey({
+        vaultOwnerToken: activeVaultOwnerToken,
+        keyId: key.keyId,
+        publicKeyJwk: key.publicKeyJwk,
+        algorithm: key.algorithm,
+      });
       for (const owner of selectedRequestOwners) {
         await OneLocationService.requestAccess({
-          vaultOwnerToken,
+          vaultOwnerToken: activeVaultOwnerToken,
           ownerUserId: owner.userId,
           message: requestMessage.trim() || undefined,
         });
@@ -2641,14 +2676,14 @@ function OneLocationAgentPageContent() {
         failure_count: failureCount,
         has_note: Boolean(requestMessage.trim()),
       });
-      toast.error(oneLocationErrorMessage(error, "Could not send request."));
+      toast.error(oneLocationRequestErrorMessage(error, "Could not send request."));
       if (isTransientOneApiError(error)) {
         await refresh().catch(() => null);
       }
     } finally {
       setBusy(null);
     }
-  }, [refresh, requestMessage, selectedRequestOwners, vaultOwnerToken]);
+  }, [auth.user, auth.userId, refresh, requestMessage, selectedRequestOwners, vaultOwnerToken]);
 
   const handleCreatePublicInvite = useCallback(async () => {
     if (!vaultOwnerToken) return;
@@ -3197,7 +3232,7 @@ function OneLocationAgentPageContent() {
       width="standard"
       nativeTest={nativeTestConfig}
     >
-      <AppPageHeaderRegion className="mx-auto w-full max-w-[1120px] min-w-0 overflow-hidden">
+      <AppPageHeaderRegion className="mx-auto w-full max-w-[860px] min-w-0 overflow-hidden">
         <div className="flex flex-col gap-4 px-1 pt-3 sm:flex-row sm:items-end sm:justify-between">
           <header className="max-w-[560px] min-w-0 space-y-2">
             <span className="text-[11px] font-bold uppercase tracking-[0.22em] text-[#007aff] dark:text-[#76b7ff]">
@@ -3231,7 +3266,7 @@ function OneLocationAgentPageContent() {
         </div>
       </AppPageHeaderRegion>
 
-      <AppPageContentRegion className="mx-auto w-full max-w-[1120px] min-w-0 space-y-6 overflow-x-hidden pb-10 sm:pb-8">
+      <AppPageContentRegion className="mx-auto w-full max-w-[860px] min-w-0 space-y-6 overflow-x-hidden pb-10 sm:pb-8">
         {loadError ? (
           <div className="rounded-[20px] border border-[#ff3b30]/30 bg-[#ff3b30]/10 p-4 text-sm text-[#ff3b30] dark:text-[#ff9f9a]">
             {loadError}
@@ -3241,7 +3276,7 @@ function OneLocationAgentPageContent() {
         {showInitialSkeleton ? (
           <OneLocationInitialSkeleton />
         ) : (
-          <div className="grid min-w-0 max-w-full gap-6 xl:grid-cols-[minmax(0,520px)_minmax(0,1fr)] xl:items-start">
+          <div className="flex min-w-0 max-w-full flex-col gap-6">
             <div className="min-w-0 max-w-full space-y-7">
               <section className="min-w-0 max-w-full space-y-2 px-1">
                 {sectionLabel("Device readiness")}
@@ -3416,7 +3451,7 @@ function OneLocationAgentPageContent() {
                   </div>
                 </div>
 
-                <div className="min-w-0 max-w-full space-y-3">
+                <div className="flex min-w-0 max-w-full flex-col gap-3">
                   <div className="relative">
                     <Search className="absolute left-3.5 top-1/2 h-5 w-5 -translate-y-1/2 text-[#8e8e93]" />
                     <input
@@ -3599,7 +3634,7 @@ function OneLocationAgentPageContent() {
                     </Button>
                   ) : null}
 
-                  <div>
+                  <div className="order-first min-w-0 max-w-full overflow-hidden rounded-[18px] border border-black/[0.04] bg-white/80 p-3.5 shadow-sm dark:border-white/[0.08] dark:bg-white/[0.06]">
                     {activeMode === "share" ? (
                       <div className="space-y-3">
                       <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_160px]">

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -7,17 +7,19 @@ import {
   useRef,
   useState,
   type ComponentProps,
+  type MutableRefObject,
 } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import type { LucideIcon } from "lucide-react";
 import {
   AlertTriangle,
   CheckCircle2,
+  ChevronDown,
+  ChevronUp,
   Clock3,
   ContactRound,
   Copy,
   ExternalLink,
-  KeyRound,
   Loader2,
   LocateFixed,
   MapPin,
@@ -62,15 +64,25 @@ import {
 } from "@/lib/one-location/encryption";
 import {
   buildOneLocationNotificationHref,
+  buildOneLocationWorkflowHref,
   isOneLocationGrantOpened,
   locationShareNotificationDescription,
+  locationWorkflowNotificationCopy,
   markOneLocationGrantOpened,
   ONE_LOCATION_GRANT_ID_PARAM,
   ONE_LOCATION_GRANT_OPENED_EVENT,
   ONE_LOCATION_NOTIFICATION_OPEN_PARAM,
   ONE_LOCATION_NOTIFICATION_OPEN_VALUE,
+  ONE_LOCATION_REFERRAL_ID_PARAM,
+  ONE_LOCATION_REQUEST_ID_PARAM,
+  ONE_LOCATION_SECTION_PARAM,
+  ONE_LOCATION_SUBMISSION_ID_PARAM,
+  oneLocationSectionForWorkflowNotificationType,
   playOneLocationNotificationSound,
   recordOneLocationShareNotification,
+  recordOneLocationWorkflowNotification,
+  type OneLocationNotificationSection,
+  type OneLocationWorkflowNotificationType,
 } from "@/lib/one-location/notifications";
 import { OneLocationService } from "@/lib/one-location/service";
 import {
@@ -108,6 +120,13 @@ const DURATION_OPTIONS = [
 const LIVE_LOCATION_UPDATE_INTERVAL_MS = 20_000;
 const LIVE_LOCATION_STALE_THRESHOLD_MS = LIVE_LOCATION_UPDATE_INTERVAL_MS * 3;
 const FOREGROUND_RETRY_DELAYS_MS = [450, 900] as const;
+const ONE_NETWORK_PREVIEW_LIMIT = 3;
+const ONE_LOCATION_SHARE_TITLE = "Join my One Location circle";
+const ONE_LOCATION_PUBLIC_SHARE_COPY = "Join my One Location circle";
+const SHOW_LOCATION_ACTIVITY_SECTION = false;
+const SHOW_OWNER_GRANTS_SECTION = false;
+const SHOW_PUBLIC_RESPONSES_SECTION = false;
+const SHOW_REFERRAL_SECTION = false;
 
 type BusyState =
   | "load"
@@ -119,25 +138,13 @@ type BusyState =
   | "deny"
   | "refer"
   | "revoke"
+  | "locationSettings"
+  | "selfLocation"
   | "contactSync"
   | "contactInvite"
   | "publicInvite"
   | "publicRevoke"
   | null;
-
-type KaiCircleSectionKey =
-  | "needs_action"
-  | "trusted_circle"
-  | "professional_network"
-  | "location_ready"
-  | "needs_setup";
-
-type KaiCircleSection = {
-  key: KaiCircleSectionKey;
-  title: string;
-  description: string;
-  recipients: OneLocationRecipient[];
-};
 
 type OneLocationSelectionSurface =
   | "quick_circle"
@@ -147,6 +154,7 @@ type OneLocationSelectionSurface =
 type OneLocationDurationBucket = "15m" | "30m" | "1h" | "4h" | "24h" | "custom";
 type OneLocationForegroundOperation = "publish" | "view";
 type OneLocationForegroundTrigger = "manual" | "foreground_interval";
+type OneLocationFocusTarget = OneLocationNotificationSection;
 type OneLocationBackoffBucket =
   | "none"
   | "lt_500ms"
@@ -202,8 +210,31 @@ function expiresLabel(grant: OneLocationGrant): string {
   return `Expires ${formatDateTime(grant.expiresAt)}`;
 }
 
-function safePersonLabel(value?: string | null, fallback = "KAI member"): string {
-  return String(value || "").trim() || fallback;
+function looksLikeInternalIdentifier(value: string): boolean {
+  const label = value.trim();
+  if (!label) return false;
+  if (
+    /^(actor|grant|invite|key|location|one_location|recipient|referral|request|submission|user)[_-]/i.test(
+      label,
+    )
+  ) {
+    return true;
+  }
+  if (/^[0-9a-f]{24,}$/i.test(label) || /^[0-9a-f-]{32,}$/i.test(label)) {
+    return true;
+  }
+  return (
+    /^[A-Za-z0-9_-]{16,}$/.test(label) &&
+    /[A-Z]/.test(label) &&
+    /[a-z]/.test(label) &&
+    /\d/.test(label)
+  );
+}
+
+function safePersonLabel(value?: string | null, fallback = "One user"): string {
+  const label = String(value || "").trim();
+  if (!label || looksLikeInternalIdentifier(label)) return fallback;
+  return label;
 }
 
 function recipientLabel(recipient: OneLocationRecipient): string {
@@ -217,7 +248,7 @@ function recommendationTierLabel(tier?: string | null): string {
     case "trusted_circle":
       return "Trusted Circle";
     case "kai_network":
-      return "KAI Network";
+      return "One Network";
     case "contacts":
       return "Contact match";
     case "setup_needed":
@@ -225,7 +256,7 @@ function recommendationTierLabel(tier?: string | null): string {
     case "available":
       return "Ready";
     default:
-      return "KAI Circle";
+      return "One Network";
   }
 }
 
@@ -394,120 +425,6 @@ function peopleCountLabel(count: number): string {
   return count === 1 ? "1 person" : `${count} people`;
 }
 
-const KAI_CIRCLE_SECTION_META: Record<
-  KaiCircleSectionKey,
-  Pick<KaiCircleSection, "title" | "description">
-> = {
-  needs_action: {
-    title: "Needs your approval",
-    description: "Requests and people waiting on a decision.",
-  },
-  trusted_circle: {
-    title: "Trusted Circle",
-    description: "People with active sharing, history, or referrals.",
-  },
-  professional_network: {
-    title: "Professional Network",
-    description: "RIA, investor, advisor, and marketplace signals.",
-  },
-  location_ready: {
-    title: "Location-ready KAI members",
-    description: "Verified KAI members ready for encrypted sharing.",
-  },
-  needs_setup: {
-    title: "Needs setup",
-    description: "People who need to open One Location once.",
-  },
-};
-
-const KAI_CIRCLE_SECTION_EMPTY_COPY: Record<
-  KaiCircleSectionKey,
-  { title: string; description: string }
-> = {
-  needs_action: {
-    title: "No approvals waiting",
-    description: "New location requests and pending decisions will appear here.",
-  },
-  trusted_circle: {
-    title: "No trusted matches yet",
-    description:
-      "Active shares, repeat approvals, and referrals will lift people here.",
-  },
-  professional_network: {
-    title: "No professional signals yet",
-    description: "RIA, investor, advisor, and marketplace matches will appear here.",
-  },
-  location_ready: {
-    title: "No ready KAI members yet",
-    description: "Verified KAI members with location keys will appear here.",
-  },
-  needs_setup: {
-    title: "No setup blockers",
-    description: "Everyone in this section is ready enough for the current flow.",
-  },
-};
-
-const KAI_CIRCLE_SECTION_ORDER: KaiCircleSectionKey[] = [
-  "needs_action",
-  "trusted_circle",
-  "professional_network",
-  "location_ready",
-  "needs_setup",
-];
-
-function kaiCircleSectionKey(
-  recipient: OneLocationRecipient,
-): KaiCircleSectionKey {
-  switch (recipient.recommendationCategory) {
-    case "needs_action":
-    case "trusted_circle":
-    case "professional_network":
-    case "location_ready":
-    case "needs_setup":
-      return recipient.recommendationCategory;
-  }
-
-  if (!recipient.canReceiveLocation) return "needs_setup";
-  switch (recipient.recommendationTier) {
-    case "needs_action":
-      return "needs_action";
-    case "trusted_circle":
-      return "trusted_circle";
-    case "kai_network":
-      return "professional_network";
-    default:
-      if (
-        recipient.relationshipType ||
-        recipient.profileHeadline ||
-        recipient.verificationBadge
-      ) {
-        return "professional_network";
-      }
-      return "location_ready";
-  }
-}
-
-function buildKaiCircleSections(
-  recipients: OneLocationRecipient[],
-): KaiCircleSection[] {
-  const grouped = new Map<KaiCircleSectionKey, OneLocationRecipient[]>();
-  KAI_CIRCLE_SECTION_ORDER.forEach((key) => grouped.set(key, []));
-
-  recipients.forEach((recipient) => {
-    grouped.get(kaiCircleSectionKey(recipient))?.push(recipient);
-  });
-
-  return KAI_CIRCLE_SECTION_ORDER.map((key) => {
-    const meta = KAI_CIRCLE_SECTION_META[key];
-    return {
-      key,
-      title: meta.title,
-      description: meta.description,
-      recipients: grouped.get(key) ?? [],
-    };
-  });
-}
-
 function oneLocationDurationBucket(value: string): OneLocationDurationBucket {
   switch (value) {
     case "0.25":
@@ -542,48 +459,6 @@ function contactCountBucket(
   return "251_plus";
 }
 
-function contactSignalStatusLabel(status: OneLocationContactSignalStatus): string {
-  switch (status) {
-    case "scanning":
-      return "Scanning";
-    case "matched":
-      return "Signal active";
-    case "empty":
-      return "No matches yet";
-    case "unavailable":
-      return "Mobile only";
-    case "denied":
-      return "Permission needed";
-    case "error":
-      return "Needs retry";
-    default:
-      return "Optional signal";
-  }
-}
-
-function contactSignalSummary(state: OneLocationContactSignalState): string {
-  switch (state.status) {
-    case "matched":
-      return `${state.matchedCount} KAI match${
-        state.matchedCount === 1 ? "" : "es"
-      } added as a ranking signal.`;
-    case "empty":
-      return state.totalContacts > 0
-        ? "No KAI users matched from this scan."
-        : "No contact numbers were available to match.";
-    case "unavailable":
-      return "Open One on iOS or Android to scan contacts.";
-    case "denied":
-      return "Allow contacts to use this optional ranking signal.";
-    case "error":
-      return state.error || "Contact signal could not be refreshed.";
-    case "scanning":
-      return "Checking contacts privately on this device.";
-    default:
-      return "Contacts stay on-device; only hashed lookups are used for matching.";
-  }
-}
-
 function grantCounterpartyLabel(grant: OneLocationGrant): string {
   return safePersonLabel(grant.recipientDisplayName);
 }
@@ -599,6 +474,16 @@ function requestLabel(request: OneLocationAccessRequest): string {
   return safePersonLabel(request.requesterDisplayName, "Someone from KAI");
 }
 
+function requestOwnerLabel(
+  request: OneLocationAccessRequest,
+  recipients: OneLocationRecipient[],
+): string {
+  const owner = recipients.find(
+    (recipient) => recipient.userId === request.ownerUserId,
+  );
+  return safePersonLabel(owner?.displayName, "Location owner");
+}
+
 function publicSubmissionLabel(
   submission: OneLocationPublicInviteSubmission,
 ): string {
@@ -608,8 +493,16 @@ function publicSubmissionLabel(
 function publicInviteUrlLabel(value: string): string {
   if (!value) return "";
   if (/^https?:\/\//i.test(value)) return value;
-  if (typeof window === "undefined") return value;
-  return new URL(value, window.location.origin).toString();
+  const configuredOrigin = String(process.env.NEXT_PUBLIC_APP_URL || "")
+    .trim()
+    .replace(/\/+$/, "");
+  const origin =
+    /^https?:\/\//i.test(configuredOrigin) ||
+    typeof window === "undefined"
+      ? configuredOrigin
+      : String(window.location.origin || "").trim().replace(/\/+$/, "");
+  if (!/^https?:\/\//i.test(origin)) return value;
+  return new URL(value, origin).toString();
 }
 
 function statusVariant(
@@ -782,8 +675,8 @@ function LocalMapPreview({ point }: { point: PlainLocationPoint }) {
   const startUrl = googleMapsStartNavigationUrl(point);
   const statusLabel = isStale ? "Last known location" : "Live location";
   return (
-    <div className="overflow-hidden rounded-[var(--app-card-radius-standard)] border border-border/70 bg-[color:var(--app-card-surface-default-solid)]">
-      <div className="relative h-56 overflow-hidden bg-[#e5e5ea] dark:bg-[#111113]">
+    <div className="w-full min-w-0 max-w-full overflow-hidden rounded-[var(--app-card-radius-standard)] border border-border/70 bg-[color:var(--app-card-surface-default-solid)]">
+      <div className="relative h-48 max-w-full overflow-hidden bg-[#e5e5ea] sm:h-56 dark:bg-[#111113]">
         <iframe
           title="Live location map preview"
           src={embedUrl}
@@ -818,7 +711,7 @@ function LocalMapPreview({ point }: { point: PlainLocationPoint }) {
           <p className="text-[15px] font-semibold text-foreground">
             {statusLabel}
           </p>
-          <p className="mt-1 text-[12px] font-medium text-muted-foreground">
+          <p className="mt-1 break-words text-[12px] font-medium text-muted-foreground [overflow-wrap:anywhere]">
             Updated {captured}
             {accuracy ? ` - ${accuracy}` : ""} -{" "}
             {locationSourceLabel(point.sourcePlatform)}
@@ -830,7 +723,7 @@ function LocalMapPreview({ point }: { point: PlainLocationPoint }) {
             asChild
             variant="outline"
             size="sm"
-            className="h-10 rounded-full border-[#0a84ff]/30 bg-[#0a84ff]/10 text-[#0066cc] hover:bg-[#0a84ff]/15 dark:text-[#76b7ff]"
+            className="h-10 w-full min-w-0 rounded-full border-[#0a84ff]/30 bg-[#0a84ff]/10 text-[#0066cc] hover:bg-[#0a84ff]/15 dark:text-[#76b7ff]"
           >
             <a
               href={directionsUrl}
@@ -845,7 +738,7 @@ function LocalMapPreview({ point }: { point: PlainLocationPoint }) {
           <Button
             asChild
             size="sm"
-            className="h-10 rounded-full bg-[#1c1c1e] text-white hover:bg-black dark:bg-white dark:text-[#1c1c1e] dark:hover:bg-white/90"
+            className="h-10 w-full min-w-0 rounded-full bg-[#1c1c1e] text-white hover:bg-black dark:bg-white dark:text-[#1c1c1e] dark:hover:bg-white/90"
           >
             <a
               href={startUrl}
@@ -863,10 +756,10 @@ function LocalMapPreview({ point }: { point: PlainLocationPoint }) {
       {isStale ? (
         <div
           role="status"
-          className="mx-3 mb-3 flex items-start gap-2 rounded-[12px] border border-amber-500/35 bg-amber-500/10 px-3 py-2 text-[12px] font-medium text-amber-800 dark:text-amber-100"
+          className="mx-3 mb-3 flex min-w-0 items-start gap-2 rounded-[12px] border border-amber-500/35 bg-amber-500/10 px-3 py-2 text-[12px] font-medium text-amber-800 dark:text-amber-100"
         >
           <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
-          <span>
+          <span className="min-w-0 break-words [overflow-wrap:anywhere]">
             Location update may be stale. Ask them to refresh sharing.
           </span>
         </div>
@@ -907,9 +800,13 @@ function SkeletonRow({ wide = false }: { wide?: boolean }) {
 type ShareMode = "share" | "request";
 
 const onePanelClassName =
-  "overflow-hidden rounded-[20px] border border-black/[0.05] bg-white shadow-[0_1px_2px_rgba(0,0,0,0.04),0_10px_30px_rgba(15,23,42,0.05)] dark:border-white/[0.08] dark:bg-[#1c1c1e]/90 dark:shadow-[0_12px_38px_rgba(0,0,0,0.28)]";
+  "w-full min-w-0 max-w-full overflow-x-hidden rounded-[20px] border border-black/[0.05] bg-white shadow-[0_1px_2px_rgba(0,0,0,0.04),0_10px_30px_rgba(15,23,42,0.05)] dark:border-white/[0.08] dark:bg-[#1c1c1e]/90 dark:shadow-[0_12px_38px_rgba(0,0,0,0.28)]";
+const oneScrollablePanelClassName = cn(
+  onePanelClassName,
+  "max-h-[min(70dvh,560px)] overflow-y-auto overscroll-contain [scrollbar-width:thin] [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-black/20 dark:[&::-webkit-scrollbar-thumb]:bg-white/20",
+);
 const oneInsetClassName =
-  "rounded-[14px] border border-black/[0.04] bg-[#f7f7fa] text-[#1c1c1e] dark:border-white/[0.08] dark:bg-white/[0.07] dark:text-white";
+  "w-full min-w-0 max-w-full overflow-hidden rounded-[14px] border border-black/[0.04] bg-[#f7f7fa] text-[#1c1c1e] dark:border-white/[0.08] dark:bg-white/[0.07] dark:text-white";
 const oneSecondaryTextClassName = "text-[#8e8e93] dark:text-white/55";
 
 function sectionLabel(title: string, count?: number) {
@@ -917,7 +814,7 @@ function sectionLabel(title: string, count?: number) {
     <div
       role="heading"
       aria-level={2}
-      className="ml-1 flex items-center gap-1.5 text-[12px] font-semibold uppercase tracking-[0.08em] text-[#8e8e93] dark:text-white/45"
+      className="ml-1 flex min-w-0 max-w-full flex-wrap items-center gap-1.5 text-[12px] font-semibold uppercase tracking-[0.08em] text-[#8e8e93] dark:text-white/45"
     >
       {title}
       {typeof count === "number" && count > 0 ? (
@@ -987,47 +884,6 @@ function AvatarBubble({
   );
 }
 
-function PromiseCard({
-  icon: Icon,
-  title,
-  description,
-  tone,
-}: {
-  icon: LucideIcon;
-  title: string;
-  description: string;
-  tone: "blue" | "green" | "orange";
-}) {
-  const toneClassName = {
-    blue: "bg-[#eaf3ff] text-[#007aff] dark:bg-[#0a84ff]/15 dark:text-[#76b7ff]",
-    green:
-      "bg-[#eaf9ef] text-[#2dbd5a] dark:bg-emerald-400/15 dark:text-emerald-200",
-    orange:
-      "bg-[#fff3e6] text-[#ff9500] dark:bg-orange-400/15 dark:text-orange-200",
-  }[tone];
-
-  return (
-    <div className="flex items-center gap-4 rounded-[20px] border border-black/[0.06] bg-white p-4 shadow-[0_2px_12px_rgba(15,23,42,0.06)] dark:border-white/[0.08] dark:bg-[#1c1c1e]/90 dark:shadow-[0_12px_30px_rgba(0,0,0,0.22)]">
-      <span
-        className={cn(
-          "flex h-11 w-11 shrink-0 items-center justify-center rounded-full",
-          toneClassName,
-        )}
-      >
-        <Icon className="h-5 w-5" aria-hidden="true" />
-      </span>
-      <div className="min-w-0">
-        <h3 className="text-[16px] font-bold tracking-tight text-[#1c1c1e] dark:text-white">
-          {title}
-        </h3>
-        <p className="mt-1 text-[14px] font-medium leading-snug text-[#8e8e93] dark:text-white/55">
-          {description}
-        </p>
-      </div>
-    </div>
-  );
-}
-
 function SegmentedModeControl({
   value,
   onChange,
@@ -1036,7 +892,7 @@ function SegmentedModeControl({
   onChange: (value: ShareMode) => void;
 }) {
   return (
-    <div className="flex h-9 w-full items-center rounded-[9px] bg-[#efeff0] p-[3px] dark:bg-white/10">
+    <div className="flex h-9 w-full min-w-0 max-w-full items-center overflow-hidden rounded-[9px] bg-[#efeff0] p-[3px] dark:bg-white/10">
       {(["share", "request"] as const).map((mode) => (
         <button
           key={mode}
@@ -1066,20 +922,173 @@ function EmptyOneState({
   description: string;
 }) {
   return (
-    <div className="flex min-h-24 items-center gap-3 p-3.5 text-sm">
+    <div className="flex min-h-24 min-w-0 max-w-full flex-col items-start gap-3 p-3.5 text-sm sm:flex-row sm:items-center">
       <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#f2f2f7] text-[#8e8e93] dark:bg-white/10 dark:text-white/55">
         <Icon className="h-4 w-4" aria-hidden="true" />
       </span>
-      <div className="min-w-0">
+      <div className="min-w-0 flex-1">
         <div className="font-semibold text-[#1c1c1e] dark:text-white">
           {title}
         </div>
-        <div className="text-[13px] leading-5 text-[#8e8e93] dark:text-white/55">
+        <div className="break-words text-[13px] leading-5 text-[#8e8e93] [overflow-wrap:anywhere] dark:text-white/55">
           {description}
         </div>
       </div>
     </div>
   );
+}
+
+function isLocationServicesDisabled(
+  permission: HushhLocationPermissionState | null,
+): boolean {
+  return permission?.locationServicesEnabled === false;
+}
+
+function locationPermissionBlocksSharing(
+  permission: HushhLocationPermissionState | null,
+): boolean {
+  return (
+    isLocationServicesDisabled(permission) ||
+    permission?.state === "denied" ||
+    permission?.state === "restricted" ||
+    permission?.state === "unavailable"
+  );
+}
+
+function locationServicesErrorMessage(error: unknown): string {
+  const message =
+    error instanceof Error
+      ? error.message
+      : String((error as { message?: unknown })?.message || error || "");
+  const normalized = message.toLowerCase();
+  if (
+    normalized.includes("services are unavailable") ||
+    normalized.includes("location services") ||
+    normalized.includes("provider") ||
+    normalized.includes("unavailable on this device")
+  ) {
+    return "Turn on Location from your phone settings before sharing.";
+  }
+  if (normalized.includes("permission") || normalized.includes("not granted")) {
+    return "Allow location permission before sharing.";
+  }
+  return message || "Location is needed before sharing.";
+}
+
+function isShareAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+function oneLocationPublicShareMessage(url: string): string {
+  return `${ONE_LOCATION_PUBLIC_SHARE_COPY}\n${url}`;
+}
+
+async function shareOneLocationLink(params: {
+  title: string;
+  text: string;
+  url: string;
+  dialogTitle: string;
+}): Promise<"native-share" | "web-share" | "copied"> {
+  const url = publicInviteUrlLabel(params.url.trim());
+  if (!url) {
+    throw new Error("Create a public location link before sharing.");
+  }
+  const message = oneLocationPublicShareMessage(url);
+
+  const { Capacitor } = await import("@capacitor/core");
+  if (Capacitor.isNativePlatform()) {
+    const { Share } = (await import("@capacitor/share")) as typeof import("@capacitor/share");
+    if (Capacitor.getPlatform() === "android") {
+      await Share.share({
+        title: params.title,
+        text: message,
+        dialogTitle: params.dialogTitle,
+      });
+      return "native-share";
+    }
+    await Share.share({
+      title: params.title,
+      text: params.text,
+      url,
+      dialogTitle: params.dialogTitle,
+    });
+    return "native-share";
+  }
+
+  if (typeof navigator !== "undefined" && typeof navigator.share === "function") {
+    await navigator.share({
+      title: params.title,
+      text: params.text,
+      url,
+    });
+    return "web-share";
+  }
+
+  if (typeof navigator !== "undefined" && navigator.clipboard) {
+    await navigator.clipboard.writeText(message);
+    return "copied";
+  }
+
+  throw new Error("Sharing is not supported on this device.");
+}
+
+function readinessCopy(permission: HushhLocationPermissionState | null): {
+  title: string;
+  description: string;
+  tone: "ready" | "warning" | "blocked" | "checking";
+  actionLabel?: string;
+} {
+  if (!permission) {
+    return {
+      title: "Checking location readiness",
+      description: "One is checking whether this device can share your current location.",
+      tone: "checking",
+    };
+  }
+  if (isLocationServicesDisabled(permission)) {
+    return {
+      title: "Turn on phone Location",
+      description:
+        "Your phone Location switch is off. Turn it on before sharing with your trusted circle.",
+      tone: "blocked",
+      actionLabel: "Open Location Settings",
+    };
+  }
+  if (permission.state === "prompt") {
+    return {
+      title: "Allow location permission",
+      description:
+        "One will ask for foreground location access before your first encrypted share.",
+      tone: "warning",
+      actionLabel: "Allow Location",
+    };
+  }
+  if (permission.state === "denied" || permission.state === "restricted") {
+    return {
+      title: "Location permission blocked",
+      description:
+        "Allow location access from app settings before you share your location.",
+      tone: "blocked",
+      actionLabel: "Open Location Settings",
+    };
+  }
+  if (permission.state === "unavailable") {
+    return {
+      title: "Location unavailable",
+      description:
+        "This device cannot provide a fresh location right now. Check Location settings and try again.",
+      tone: "blocked",
+      actionLabel: "Open Location Settings",
+    };
+  }
+  return {
+    title: permission.precise === false ? "Approximate location ready" : "Location ready",
+    description:
+      permission.precise === false
+        ? "Sharing can continue, but accuracy may be approximate on this device."
+        : "Foreground location is ready for encrypted sharing.",
+    tone: permission.precise === false ? "warning" : "ready",
+  };
 }
 
 function OneLocationInitialSkeleton() {
@@ -1109,22 +1118,18 @@ function OneLocationInitialSkeleton() {
         </SettingsGroup>
       </div>
       <div className="space-y-6">
-        <SettingsGroup eyebrow="Owner" title="People who can see me">
-          <SkeletonRow wide />
-          <SkeletonRow />
-        </SettingsGroup>
-        <SettingsGroup eyebrow="Recipient" title="Shared with me">
-          <SkeletonRow wide />
-        </SettingsGroup>
         <SettingsGroup eyebrow="Approvals" title="Pending requests">
           <SkeletonRow />
+        </SettingsGroup>
+        <SettingsGroup eyebrow="Location" title="Shared with me">
+          <SkeletonRow wide />
         </SettingsGroup>
       </div>
     </div>
   );
 }
 
-export function OneLocationAgentPageContent() {
+function OneLocationAgentPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const auth = useRequireAuth();
@@ -1137,6 +1142,7 @@ export function OneLocationAgentPageContent() {
   const [activeMode, setActiveMode] = useState<ShareMode>("share");
   const [shareReviewOpen, setShareReviewOpen] = useState(false);
   const [recipientSearch, setRecipientSearch] = useState("");
+  const [oneNetworkListExpanded, setOneNetworkListExpanded] = useState(false);
   const [selectedRecipientId, setSelectedRecipientId] = useState("");
   const [selectedRequestOwnerId, setSelectedRequestOwnerId] = useState("");
   const [selectedRecipientIds, setSelectedRecipientIds] = useState<string[]>(
@@ -1159,11 +1165,25 @@ export function OneLocationAgentPageContent() {
     Record<string, string>
   >({});
   const [publicInviteUrl, setPublicInviteUrl] = useState("");
+  const [myLocationPoint, setMyLocationPoint] =
+    useState<PlainLocationPoint | null>(null);
+  const [myLocationError, setMyLocationError] = useState<string | null>(null);
   const [decryptedPoints, setDecryptedPoints] = useState<
     Record<string, PlainLocationPoint>
   >({});
   const [openedGrantTick, setOpenedGrantTick] = useState(0);
+  const [focusedSection, setFocusedSection] =
+    useState<OneLocationFocusTarget | null>(null);
   const refreshInFlightRef = useRef<Promise<void> | null>(null);
+  const permissionPromptInFlightRef = useRef(false);
+  const locationLandingPromptUserRef = useRef<string | null>(null);
+  const peopleSectionRef = useRef<HTMLElement | null>(null);
+  const approvalsSectionRef = useRef<HTMLElement | null>(null);
+  const sharedSectionRef = useRef<HTMLElement | null>(null);
+  const myRequestsSectionRef = useRef<HTMLElement | null>(null);
+  const publicResponsesSectionRef = useRef<HTMLElement | null>(null);
+  const activitySectionRef = useRef<HTMLElement | null>(null);
+  const focusClearRef = useRef<number | null>(null);
   const livePublishInFlightRef = useRef(false);
   const liveViewInFlightRef = useRef(false);
 
@@ -1194,10 +1214,21 @@ export function OneLocationAgentPageContent() {
       recommendationSearchText(recipient).includes(query),
     );
   }, [rankedRecipients, recipientSearch]);
-  const kaiCircleSections = useMemo(
-    () => buildKaiCircleSections(visibleRecipients),
-    [visibleRecipients],
+  const hasMoreVisibleRecipients =
+    visibleRecipients.length > ONE_NETWORK_PREVIEW_LIMIT;
+  const showExpandedOneNetworkList =
+    oneNetworkListExpanded && hasMoreVisibleRecipients;
+  const displayedVisibleRecipients = useMemo(
+    () =>
+      showExpandedOneNetworkList
+        ? visibleRecipients
+        : visibleRecipients.slice(0, ONE_NETWORK_PREVIEW_LIMIT),
+    [showExpandedOneNetworkList, visibleRecipients],
   );
+
+  useEffect(() => {
+    setOneNetworkListExpanded(false);
+  }, [recipientSearch]);
   const selectedShareRecipients = useMemo(
     () => recipientSelectionFromIds(contactSignalRecipients, selectedRecipientIds),
     [contactSignalRecipients, selectedRecipientIds],
@@ -1262,6 +1293,15 @@ export function OneLocationAgentPageContent() {
       ),
     [state?.publicInvites],
   );
+  const latestActivePublicInvite = useMemo(() => {
+    const inviteTime = (invite: OneLocationPublicInvite) =>
+      Date.parse(
+        invite.createdAt || invite.updatedAt || invite.expiresAt || "",
+      ) || 0;
+    return [...activePublicInvites].sort(
+      (left, right) => inviteTime(right) - inviteTime(left),
+    )[0] ?? null;
+  }, [activePublicInvites]);
   const publicSubmissions = useMemo(
     () => state?.publicInviteSubmissions ?? [],
     [state?.publicInviteSubmissions],
@@ -1271,7 +1311,44 @@ export function OneLocationAgentPageContent() {
     [activityRange, auth.userId, state],
   );
   const locationActivity = activitySnapshot ?? fallbackActivity;
+  const focusOneLocationSection = useCallback(
+    (target: OneLocationFocusTarget | null) => {
+      if (!target || typeof window === "undefined") return;
+      const sectionRefs: Record<
+        OneLocationFocusTarget,
+        MutableRefObject<HTMLElement | null>
+      > = {
+        people: peopleSectionRef,
+        approvals: approvalsSectionRef,
+        shared: sharedSectionRef,
+        my_requests: myRequestsSectionRef,
+        public_responses: publicResponsesSectionRef,
+        activity: activitySectionRef,
+      };
+      window.setTimeout(() => {
+        const element = sectionRefs[target]?.current;
+        if (!element) return;
+        element.scrollIntoView({ behavior: "smooth", block: "start" });
+        element.focus({ preventScroll: true });
+        setFocusedSection(target);
+        if (focusClearRef.current) {
+          window.clearTimeout(focusClearRef.current);
+        }
+        focusClearRef.current = window.setTimeout(() => {
+          setFocusedSection((current) => (current === target ? null : current));
+        }, 2200);
+      }, 80);
+    },
+    [],
+  );
 
+  const sectionFocusClassName = useCallback(
+    (target: OneLocationFocusTarget) =>
+      focusedSection === target
+        ? "rounded-[22px] ring-2 ring-[#007aff]/35 ring-offset-2 ring-offset-transparent"
+        : "",
+    [focusedSection],
+  );
   useEffect(() => {
     if (!auth.userId || !vaultOwnerToken || !state) {
       setActivitySnapshot(null);
@@ -1308,8 +1385,9 @@ export function OneLocationAgentPageContent() {
       markOneLocationGrantOpened(auth.userId, grantId);
       setOpenedGrantTick((value) => value + 1);
       router.push(buildOneLocationNotificationHref(grantId), { scroll: false });
+      focusOneLocationSection("shared");
     },
-    [auth.userId, router],
+    [auth.userId, focusOneLocationSection, router],
   );
 
   const showLocationShareToast = useCallback(
@@ -1349,6 +1427,92 @@ export function OneLocationAgentPageContent() {
     [auth.userId, openLocationShareFromNotification],
   );
 
+  const showWorkflowToast = useCallback(
+    (params: {
+      notificationType: OneLocationWorkflowNotificationType;
+      id: string;
+      ownerLabel?: string | null;
+      requesterLabel?: string | null;
+      referringLabel?: string | null;
+      visitorLabel?: string | null;
+      grantId?: string | null;
+      requestId?: string | null;
+      referralId?: string | null;
+      submissionId?: string | null;
+      section?: OneLocationFocusTarget | null;
+      openGrant?: boolean;
+    }) => {
+      if (!auth.userId) return;
+      const section =
+        params.section ||
+        oneLocationSectionForWorkflowNotificationType(params.notificationType);
+      const copy = locationWorkflowNotificationCopy({
+        type: params.notificationType,
+        ownerLabel: params.ownerLabel,
+        requesterLabel: params.requesterLabel,
+        referringLabel: params.referringLabel,
+        visitorLabel: params.visitorLabel,
+      });
+      const routeHref = buildOneLocationWorkflowHref({
+        grantId: params.grantId,
+        requestId: params.requestId,
+        referralId: params.referralId,
+        submissionId: params.submissionId,
+        section,
+        openGrant: params.openGrant,
+      });
+      const created = recordOneLocationWorkflowNotification({
+        userId: auth.userId,
+        notificationType: params.notificationType,
+        id: params.id,
+        title: copy.title,
+        description: copy.description,
+        routeHref,
+        metadata: {
+          grantId: params.grantId || null,
+          requestId: params.requestId || null,
+          referralId: params.referralId || null,
+          submissionId: params.submissionId || null,
+          section,
+        },
+      });
+      if (!created) return;
+
+      playOneLocationNotificationSound();
+      const toastKey = `one-location-workflow:${params.notificationType}:${params.id}`;
+      toast(
+        <div className="flex flex-col gap-2">
+          <div className="space-y-0.5">
+            <p className="line-clamp-1 text-sm font-semibold">{copy.title}</p>
+            <p className="line-clamp-2 text-xs text-muted-foreground">
+              {copy.description}
+            </p>
+          </div>
+          <button
+            onClick={() => {
+              if (params.openGrant && params.grantId) {
+                markOneLocationGrantOpened(auth.userId, params.grantId);
+                setOpenedGrantTick((value) => value + 1);
+              }
+              toast.dismiss(toastKey);
+              router.push(routeHref, { scroll: false });
+              focusOneLocationSection(section);
+            }}
+            className="rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background transition-colors"
+          >
+            Open
+          </button>
+        </div>,
+        {
+          id: toastKey,
+          duration: 10000,
+          position: "top-center",
+        },
+      );
+    },
+    [auth.userId, focusOneLocationSection, router],
+  );
+
   const refresh = useCallback(async () => {
     if (!auth.userId) {
       setBusy(null);
@@ -1374,17 +1538,12 @@ export function OneLocationAgentPageContent() {
     const task = (async () => {
       setLoadError(null);
       try {
-        if (activeUser) {
-          await AccountIdentityService.syncCurrentUser(activeUser).catch(
-            (error) => {
-              console.warn(
-                "[OneLocationAgent] Identity shadow sync skipped:",
-                error,
-              );
-              return null;
-            },
-          );
+        if (!activeUser) {
+          throw new Error("Refresh your session before loading location sharing.");
         }
+        await AccountIdentityService.syncCurrentUser(activeUser).catch((error) => {
+          console.warn("[OneLocation] Failed to sync account identity:", error);
+        });
         const key = await ensureLocationRecipientKey(activeUserId);
         await OneLocationService.registerRecipientKey({
           vaultOwnerToken: activeVaultOwnerToken,
@@ -1462,11 +1621,173 @@ export function OneLocationAgentPageContent() {
     vaultOwnerToken,
   ]);
 
+  const refreshLocationPermission = useCallback(async () => {
+    const nextPermission = await OneLocationService.getPermissionState().catch(
+      () => ({
+        state: "unavailable" as const,
+        precise: false,
+        background: "unavailable" as const,
+        locationServicesEnabled: null,
+      }),
+    );
+    setPermission(nextPermission);
+    return nextPermission;
+  }, []);
+
+  const handleOpenLocationSettings = useCallback(async () => {
+    setBusy("locationSettings");
+    try {
+      const result = await OneLocationService.openLocationSettings();
+      toast.info(
+        result.opened
+          ? "Turn on Location, then return to One Location and refresh."
+          : "Open your phone or browser location settings, then return and refresh.",
+      );
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Could not open location settings.",
+      );
+    } finally {
+      setBusy(null);
+      window.setTimeout(() => void refreshLocationPermission(), 1200);
+    }
+  }, [refreshLocationPermission]);
+
+  const ensureForegroundLocationReady = useCallback(
+    async (options?: {
+      capturePoint?: boolean;
+      autoOpenSettings?: boolean;
+      requestNativePrompt?: boolean;
+    }): Promise<{ ready: boolean; point?: PlainLocationPoint }> => {
+      const shouldCapturePoint = Boolean(options?.capturePoint);
+      const shouldOpenSettings = options?.autoOpenSettings !== false;
+      const shouldRequestNativePrompt = options?.requestNativePrompt === true;
+      const currentPermission = await refreshLocationPermission();
+
+      if (isLocationServicesDisabled(currentPermission)) {
+        toast.error("Turn on phone Location before sharing.");
+        if (shouldOpenSettings) {
+          await OneLocationService.openLocationSettings().catch(() => null);
+        }
+        return { ready: false };
+      }
+
+      if (
+        currentPermission.state === "restricted" ||
+        (currentPermission.state === "denied" && !shouldRequestNativePrompt)
+      ) {
+        toast.error("Allow location permission before sharing.");
+        if (shouldOpenSettings) {
+          await OneLocationService.openLocationSettings().catch(() => null);
+        }
+        return { ready: false };
+      }
+
+      if (currentPermission.state === "unavailable") {
+        toast.error("Location is unavailable. Check your phone Location settings.");
+        if (shouldOpenSettings) {
+          await OneLocationService.openLocationSettings().catch(() => null);
+        }
+        return { ready: false };
+      }
+
+      if (currentPermission.state === "granted" && !shouldCapturePoint) {
+        return { ready: true };
+      }
+
+      try {
+        const point = await OneLocationService.captureCurrentPosition();
+        const nextPermission = await OneLocationService.getPermissionState().catch(
+          () => null,
+        );
+        setPermission(
+          nextPermission ?? {
+            state: "granted",
+            precise: null,
+            background: "foreground-only",
+            locationServicesEnabled: true,
+          },
+        );
+        return shouldCapturePoint ? { ready: true, point } : { ready: true };
+      } catch (error) {
+        const nextPermission = await OneLocationService.getPermissionState().catch(
+          () => null,
+        );
+        if (nextPermission) {
+          setPermission(nextPermission);
+        }
+        const message = locationServicesErrorMessage(error);
+        toast.error(message);
+        if (
+          shouldOpenSettings &&
+          (isLocationServicesDisabled(nextPermission) ||
+            message.toLowerCase().includes("turn on location"))
+        ) {
+          await OneLocationService.openLocationSettings().catch(() => null);
+        }
+        return { ready: false };
+      }
+    },
+    [refreshLocationPermission],
+  );
+
   useEffect(() => {
     if (!auth.loading) {
       void refresh();
     }
   }, [auth.loading, refresh]);
+
+  useEffect(() => {
+    if (
+      !auth.userId ||
+      !state ||
+      locationLandingPromptUserRef.current === auth.userId ||
+      permissionPromptInFlightRef.current
+    ) {
+      return;
+    }
+    const canRequestNativePrompt =
+      !permission ||
+      permission.state === "prompt" ||
+      permission.state === "denied";
+    if (!canRequestNativePrompt || isLocationServicesDisabled(permission)) {
+      return;
+    }
+
+    let cancelled = false;
+    locationLandingPromptUserRef.current = auth.userId;
+    permissionPromptInFlightRef.current = true;
+    const promptForForegroundLocation = async () => {
+      try {
+        await ensureForegroundLocationReady({
+          capturePoint: false,
+          autoOpenSettings: false,
+          requestNativePrompt: true,
+        });
+      } finally {
+        if (!cancelled) {
+          permissionPromptInFlightRef.current = false;
+        }
+      }
+    };
+
+    void promptForForegroundLocation();
+
+    return () => {
+      cancelled = true;
+      permissionPromptInFlightRef.current = false;
+    };
+  }, [auth.userId, ensureForegroundLocationReady, permission, state]);
+
+  useEffect(() => {
+    return () => {
+      if (focusClearRef.current && typeof window !== "undefined") {
+        window.clearTimeout(focusClearRef.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     if (!auth.userId || typeof window === "undefined") return;
@@ -1496,18 +1817,62 @@ export function OneLocationAgentPageContent() {
   }, [auth.userId, refresh]);
 
   useEffect(() => {
-    if (!auth.userId) return;
+    if (!auth.userId || !state) return;
     const grantId = String(
       searchParams.get(ONE_LOCATION_GRANT_ID_PARAM) || "",
     ).trim();
+    const requestId = String(
+      searchParams.get(ONE_LOCATION_REQUEST_ID_PARAM) || "",
+    ).trim();
+    const referralId = String(
+      searchParams.get(ONE_LOCATION_REFERRAL_ID_PARAM) || "",
+    ).trim();
+    const submissionId = String(
+      searchParams.get(ONE_LOCATION_SUBMISSION_ID_PARAM) || "",
+    ).trim();
+    const section = String(
+      searchParams.get(ONE_LOCATION_SECTION_PARAM) || "",
+    ).trim() as OneLocationFocusTarget | "";
     const notificationState = String(
       searchParams.get(ONE_LOCATION_NOTIFICATION_OPEN_PARAM) || "",
     ).trim();
+    let focusTarget: OneLocationFocusTarget | null =
+      section && [
+        "people",
+        "approvals",
+        "shared",
+        "my_requests",
+        "public_responses",
+        "activity",
+      ].includes(section)
+        ? section
+        : null;
     if (grantId && notificationState === ONE_LOCATION_NOTIFICATION_OPEN_VALUE) {
       markOneLocationGrantOpened(auth.userId, grantId);
       setOpenedGrantTick((value) => value + 1);
+      focusTarget = focusTarget || "shared";
     }
-  }, [auth.userId, searchParams]);
+    if (requestId) {
+      focusTarget =
+        focusTarget ||
+        (pendingOwnerRequests.some((request) => request.id === requestId)
+          ? "approvals"
+          : "my_requests");
+    }
+    if (referralId) {
+      focusTarget = focusTarget || "my_requests";
+    }
+    if (submissionId) {
+      focusTarget = focusTarget || "public_responses";
+    }
+    focusOneLocationSection(focusTarget);
+  }, [
+    auth.userId,
+    focusOneLocationSection,
+    pendingOwnerRequests,
+    searchParams,
+    state,
+  ]);
 
   useEffect(() => {
     if (!auth.userId || typeof window === "undefined") return;
@@ -1548,6 +1913,84 @@ export function OneLocationAgentPageContent() {
     openedGrantTick,
     showLocationShareToast,
     state?.receivedGrants,
+  ]);
+
+  useEffect(() => {
+    if (!auth.userId || !state) return;
+
+    for (const request of pendingOwnerRequests) {
+      showWorkflowToast({
+        notificationType: "location_access_request",
+        id: request.id,
+        requestId: request.id,
+        requesterLabel: requestLabel(request),
+        section: "approvals",
+      });
+    }
+
+    for (const request of requestedByMe) {
+      const ownerLabel = requestOwnerLabel(request, recipients);
+      if (request.status === "approved") {
+        showWorkflowToast({
+          notificationType: "location_access_approved",
+          id: request.approvedGrantId || request.id,
+          requestId: request.id,
+          grantId: request.approvedGrantId,
+          ownerLabel,
+          section: "shared",
+          openGrant: Boolean(request.approvedGrantId),
+        });
+      }
+      if (request.status === "denied") {
+        showWorkflowToast({
+          notificationType: "location_access_denied",
+          id: request.id,
+          requestId: request.id,
+          ownerLabel,
+          section: "my_requests",
+        });
+      }
+    }
+
+    for (const grant of state.receivedGrants ?? []) {
+      if (grant.status === "revoked") {
+        showWorkflowToast({
+          notificationType: "location_share_revoked",
+          id: grant.id,
+          grantId: grant.id,
+          ownerLabel: receivedGrantOwnerLabel(grant),
+          section: "shared",
+        });
+      }
+      if (grant.status === "expired") {
+        showWorkflowToast({
+          notificationType: "location_share_expired",
+          id: grant.id,
+          grantId: grant.id,
+          ownerLabel: receivedGrantOwnerLabel(grant),
+          section: "shared",
+        });
+      }
+    }
+
+    for (const submission of publicSubmissions) {
+      if (submission.ownerUserId !== auth.userId) continue;
+      showWorkflowToast({
+        notificationType: "location_public_invite_submitted",
+        id: submission.id,
+        submissionId: submission.id,
+        visitorLabel: publicSubmissionLabel(submission),
+        section: "public_responses",
+      });
+    }
+  }, [
+    auth.userId,
+    pendingOwnerRequests,
+    publicSubmissions,
+    recipients,
+    requestedByMe,
+    showWorkflowToast,
+    state,
   ]);
 
   const recipientForGrant = useCallback(
@@ -1606,15 +2049,20 @@ export function OneLocationAgentPageContent() {
       !vaultOwnerToken ||
       !shareReadySelectedRecipients.length ||
       setupNeededSelectedRecipients.length ||
-      permission?.state === "denied" ||
-      permission?.state === "restricted" ||
-      permission?.state === "unavailable"
+      locationPermissionBlocksSharing(permission)
     )
       return;
     setBusy("share");
     let successCount = 0;
     try {
-      const point = await OneLocationService.captureCurrentPosition();
+      const readiness = await ensureForegroundLocationReady({
+        capturePoint: true,
+        autoOpenSettings: true,
+      });
+      if (!readiness.ready || !readiness.point) {
+        return;
+      }
+      const point = readiness.point;
       for (const recipient of shareReadySelectedRecipients) {
         const grant = await OneLocationService.createGrant({
           vaultOwnerToken,
@@ -1661,7 +2109,8 @@ export function OneLocationAgentPageContent() {
     }
   }, [
     durationHours,
-    permission?.state,
+    ensureForegroundLocationReady,
+    permission,
     publishEnvelopeWithRetry,
     refresh,
     setupNeededSelectedRecipients.length,
@@ -1679,7 +2128,14 @@ export function OneLocationAgentPageContent() {
       }
       setBusy("publish");
       try {
-        await publishEnvelopeWithRetry(grant, recipient, "manual");
+        const readiness = await ensureForegroundLocationReady({
+          capturePoint: true,
+          autoOpenSettings: true,
+        });
+        if (!readiness.ready || !readiness.point) {
+          return;
+        }
+        await publishEnvelopeWithRetry(grant, recipient, "manual", readiness.point);
         toast.success("Encrypted location update published.");
         await refresh();
       } catch (error) {
@@ -1690,7 +2146,7 @@ export function OneLocationAgentPageContent() {
         setBusy(null);
       }
     },
-    [publishEnvelopeWithRetry, recipientForGrant, refresh],
+    [ensureForegroundLocationReady, publishEnvelopeWithRetry, recipientForGrant, refresh],
   );
 
   const viewGrantEnvelope = useCallback(
@@ -1778,6 +2234,7 @@ export function OneLocationAgentPageContent() {
           );
         }
       } catch (error) {
+        void refreshLocationPermission();
         console.warn(
           "[OneLocationAgent] Foreground live update skipped:",
           error,
@@ -1799,6 +2256,7 @@ export function OneLocationAgentPageContent() {
     permission?.state,
     publishEnvelopeWithRetry,
     recipientForGrant,
+    refreshLocationPermission,
     vaultOwnerToken,
   ]);
 
@@ -1904,7 +2362,7 @@ export function OneLocationAgentPageContent() {
           )} added as a contact signal.`,
         );
       } else {
-        toast.info("No KAI users matched from this contact scan.");
+        toast.info("No One users matched from this contact scan.");
       }
     } catch (error) {
       const message = oneLocationErrorMessage(
@@ -2047,21 +2505,18 @@ export function OneLocationAgentPageContent() {
 
   const handleSharePublicInvite = useCallback(async () => {
     if (!publicInviteUrl) return;
-    const text =
-      "View my One Location location update here after entering your details.";
     try {
-      if (navigator.share) {
-        await navigator.share({
-          title: "View my location",
-          text,
-          url: publicInviteUrl,
-        });
-        return;
+      const delivery = await shareOneLocationLink({
+        title: ONE_LOCATION_SHARE_TITLE,
+        text: ONE_LOCATION_PUBLIC_SHARE_COPY,
+        url: publicInviteUrl,
+        dialogTitle: "Share to contacts",
+      });
+      if (delivery === "copied") {
+        toast.success("Public location link copied.");
       }
-      await navigator.clipboard.writeText(publicInviteUrl);
-      toast.success("Public location link copied.");
     } catch (error) {
-      if ((error as Error)?.name === "AbortError") return;
+      if (isShareAbortError(error)) return;
       toast.error("Could not open the share sheet.");
     }
   }, [publicInviteUrl]);
@@ -2090,24 +2545,17 @@ export function OneLocationAgentPageContent() {
         await refresh();
       }
 
-      const text =
-        "Join my KAI Circle on One Location. You can view my public location update here after entering your details.";
-      if (navigator.share && url) {
-        await navigator.share({
-          title: "Join my KAI Circle",
-          text,
-          url,
-        });
-        return;
-      }
-      if (navigator.clipboard && url) {
-        await navigator.clipboard.writeText(`${text} ${url}`);
+      const delivery = await shareOneLocationLink({
+        title: ONE_LOCATION_SHARE_TITLE,
+        text: ONE_LOCATION_PUBLIC_SHARE_COPY,
+        url,
+        dialogTitle: "Share to contacts",
+      });
+      if (delivery === "copied") {
         toast.success("Invite link copied.");
-        return;
       }
-      toast.info("Create a public location link, then share it with your contacts.");
     } catch (error) {
-      if ((error as Error)?.name === "AbortError") return;
+      if (isShareAbortError(error)) return;
       trackEvent("one_location_public_link_created", {
         route_id: "one_location",
         result: "error",
@@ -2374,12 +2822,17 @@ export function OneLocationAgentPageContent() {
     selectedShareRecipients.length &&
     shareReadySelectedRecipients.length &&
     !setupNeededSelectedRecipients.length &&
-    permission?.state !== "denied" &&
-    permission?.state !== "restricted" &&
-    permission?.state !== "unavailable",
+    !locationPermissionBlocksSharing(permission),
   );
-  const handleOpenShareReview = useCallback(() => {
+  const handleOpenShareReview = useCallback(async () => {
     if (!canShare) return;
+    setBusy("share");
+    const readiness = await ensureForegroundLocationReady({
+      capturePoint: false,
+      autoOpenSettings: true,
+    });
+    setBusy(null);
+    if (!readiness.ready) return;
     setShareReviewOpen(true);
     trackEvent(
       "one_location_share_review_opened",
@@ -2391,7 +2844,13 @@ export function OneLocationAgentPageContent() {
         has_permission_warning: permission?.state !== "granted",
         has_professional_signal: shareReadySelectedRecipients.some(
           (recipient) =>
-            kaiCircleSectionKey(recipient) === "professional_network",
+            recipient.recommendationCategory === "professional_network" ||
+            recipient.recommendationTier === "kai_network" ||
+            Boolean(
+              recipient.relationshipType ||
+                recipient.profileHeadline ||
+                recipient.verificationBadge,
+            ),
         ),
         has_setup_warning: Boolean(setupNeededSelectedRecipients.length),
       },
@@ -2402,6 +2861,7 @@ export function OneLocationAgentPageContent() {
   }, [
     canShare,
     durationHours,
+    ensureForegroundLocationReady,
     permission?.state,
     setupNeededSelectedRecipients.length,
     shareReadySelectedRecipients,
@@ -2417,6 +2877,45 @@ export function OneLocationAgentPageContent() {
     (auth.loading ||
       busy === "load" ||
       Boolean(auth.userId && vaultOwnerToken));
+  const locationReadiness = useMemo(
+    () => readinessCopy(permission),
+    [permission],
+  );
+  const handleRequestLocationPermission = useCallback(async () => {
+    setBusy("locationSettings");
+    try {
+      await ensureForegroundLocationReady({
+        capturePoint: false,
+        autoOpenSettings: true,
+      });
+    } finally {
+      setBusy(null);
+    }
+  }, [ensureForegroundLocationReady]);
+
+  const handleShowMyLiveLocation = useCallback(async () => {
+    setBusy("selfLocation");
+    setMyLocationError(null);
+    try {
+      const result = await ensureForegroundLocationReady({
+        capturePoint: true,
+        autoOpenSettings: true,
+      });
+      if (!result.ready || !result.point) {
+        const message = "Live location preview needs device Location permission.";
+        setMyLocationError(message);
+        return;
+      }
+      setMyLocationPoint(result.point);
+      toast.success("Your live location preview is ready.");
+    } catch (error) {
+      const message = locationServicesErrorMessage(error);
+      setMyLocationError(message);
+      toast.error(message);
+    } finally {
+      setBusy(null);
+    }
+  }, [ensureForegroundLocationReady]);
 
   return (
     <AppPageShell
@@ -2430,13 +2929,15 @@ export function OneLocationAgentPageContent() {
             ? "authenticated"
             : "anonymous",
         dataState,
-        errorCode: loadError ? "one_location_unavailable" : null,
+        errorCode: loadError
+          ? "one_location_unavailable"
+          : null,
         errorMessage: loadError,
       }}
     >
-      <AppPageHeaderRegion className="mx-auto w-full max-w-[1120px]">
+      <AppPageHeaderRegion className="mx-auto w-full max-w-[1120px] min-w-0 overflow-hidden">
         <div className="flex flex-col gap-4 px-1 pt-3 sm:flex-row sm:items-end sm:justify-between">
-          <header className="max-w-[560px] space-y-2">
+          <header className="max-w-[560px] min-w-0 space-y-2">
             <span className="text-[11px] font-bold uppercase tracking-[0.22em] text-[#007aff] dark:text-[#76b7ff]">
               When it matters most
             </span>
@@ -2449,24 +2950,26 @@ export function OneLocationAgentPageContent() {
               after they approve.
             </p>
           </header>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => void refresh()}
-            disabled={busy === "load"}
-            className="h-9 w-fit rounded-full border-black/[0.06] bg-white/80 px-3 text-[#1c1c1e] shadow-sm backdrop-blur-xl hover:bg-[#f2f2f7] dark:border-white/[0.08] dark:bg-white/10 dark:text-white dark:hover:bg-white/15"
-          >
-            {busy === "load" ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
-            ) : (
-              <RefreshCw className="mr-2 h-4 w-4" aria-hidden="true" />
-            )}
-            Refresh
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => void refresh()}
+              disabled={busy === "load"}
+              className="h-9 w-full rounded-full border-black/[0.06] bg-white/80 px-3 text-[#1c1c1e] shadow-sm backdrop-blur-xl hover:bg-[#f2f2f7] sm:w-fit dark:border-white/[0.08] dark:bg-white/10 dark:text-white dark:hover:bg-white/15"
+            >
+              {busy === "load" ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+              ) : (
+                <RefreshCw className="mr-2 h-4 w-4" aria-hidden="true" />
+              )}
+              Refresh
+            </Button>
+          </div>
         </div>
       </AppPageHeaderRegion>
 
-      <AppPageContentRegion className="mx-auto w-full max-w-[1120px] space-y-6">
+      <AppPageContentRegion className="mx-auto w-full max-w-[1120px] min-w-0 space-y-6 overflow-x-hidden pb-10 sm:pb-8">
         {loadError ? (
           <div className="rounded-[20px] border border-[#ff3b30]/30 bg-[#ff3b30]/10 p-4 text-sm text-[#ff3b30] dark:text-[#ff9f9a]">
             {loadError}
@@ -2476,38 +2979,113 @@ export function OneLocationAgentPageContent() {
         {showInitialSkeleton ? (
           <OneLocationInitialSkeleton />
         ) : (
-          <div className="grid gap-6 xl:grid-cols-[minmax(0,520px)_minmax(0,1fr)] xl:items-start">
-            <div className="space-y-7">
-              <section className="space-y-3 px-1">
-                <PromiseCard
-                  icon={LocateFixed}
-                  title="Chosen People"
-                  description="Only selected contacts can see your location."
-                  tone="blue"
-                />
-                <PromiseCard
-                  icon={ShieldCheck}
-                  title="Approval First"
-                  description="Every location request needs approval."
-                  tone="green"
-                />
-                <PromiseCard
-                  icon={KeyRound}
-                  title="Stop Anytime"
-                  description="Change access, set a time limit, or stop sharing anytime."
-                  tone="orange"
-                />
+          <div className="grid min-w-0 max-w-full gap-6 xl:grid-cols-[minmax(0,520px)_minmax(0,1fr)] xl:items-start">
+            <div className="min-w-0 max-w-full space-y-7">
+              <section className="min-w-0 max-w-full space-y-2 px-1">
+                {sectionLabel("Device readiness")}
+                <div
+                  className={cn(
+                    "flex min-w-0 max-w-full flex-col gap-3 overflow-hidden rounded-[20px] border p-3.5 shadow-sm sm:flex-row sm:items-center sm:justify-between",
+                    locationReadiness.tone === "ready" &&
+                      "border-[#34c759]/25 bg-[#34c759]/10 text-[#1c1c1e] dark:text-white",
+                    locationReadiness.tone === "warning" &&
+                      "border-[#ff9500]/30 bg-[#ff9500]/10 text-[#1c1c1e] dark:text-white",
+                    locationReadiness.tone === "blocked" &&
+                      "border-[#ff3b30]/30 bg-[#ff3b30]/10 text-[#1c1c1e] dark:text-white",
+                    locationReadiness.tone === "checking" &&
+                      "border-black/[0.04] bg-white/70 text-[#1c1c1e] dark:border-white/[0.08] dark:bg-white/[0.06] dark:text-white",
+                  )}
+                >
+                  <div className="flex min-w-0 items-start gap-3">
+                    <span
+                      className={cn(
+                        "flex h-10 w-10 shrink-0 items-center justify-center rounded-full",
+                        locationReadiness.tone === "ready" &&
+                          "bg-[#34c759]/15 text-[#2dbd5a]",
+                        locationReadiness.tone === "warning" &&
+                          "bg-[#ff9500]/15 text-[#ff9500]",
+                        locationReadiness.tone === "blocked" &&
+                          "bg-[#ff3b30]/15 text-[#ff3b30]",
+                        locationReadiness.tone === "checking" &&
+                          "bg-[#007aff]/15 text-[#007aff]",
+                      )}
+                    >
+                      {locationReadiness.tone === "ready" ? (
+                        <CheckCircle2 className="h-5 w-5" aria-hidden="true" />
+                      ) : locationReadiness.tone === "checking" ? (
+                        <Loader2 className="h-5 w-5 animate-spin" aria-hidden="true" />
+                      ) : (
+                        <AlertTriangle className="h-5 w-5" aria-hidden="true" />
+                      )}
+                    </span>
+                    <div className="min-w-0">
+                      <h3 className="break-words text-[16px] font-bold tracking-tight [overflow-wrap:anywhere]">
+                        {locationReadiness.title}
+                      </h3>
+                    </div>
+                  </div>
+                  {locationReadiness.actionLabel ? (
+                    <ActionButton
+                      busy={busy}
+                      busyKey="locationSettings"
+                      onClick={
+                        permission?.state === "prompt"
+                          ? () => void handleRequestLocationPermission()
+                          : () => void handleOpenLocationSettings()
+                      }
+                      variant="outline"
+                      className="h-10 w-full shrink-0 rounded-full border-black/[0.06] bg-white px-4 text-[13px] font-semibold text-[#1c1c1e] shadow-sm hover:bg-[#f2f2f7] sm:w-auto dark:border-white/[0.08] dark:bg-white/10 dark:text-white dark:hover:bg-white/15"
+                    >
+                      {busy !== "locationSettings" ? (
+                        <ExternalLink className="mr-2 h-4 w-4" aria-hidden="true" />
+                      ) : null}
+                      {locationReadiness.actionLabel}
+                    </ActionButton>
+                  ) : null}
+                </div>
+
+                <div className="overflow-hidden rounded-[20px] border border-black/[0.06] bg-white shadow-[0_2px_12px_rgba(15,23,42,0.06)] dark:border-white/[0.08] dark:bg-[#1c1c1e]/90 dark:shadow-[0_12px_30px_rgba(0,0,0,0.22)]">
+                  <div className="p-3.5">
+                    <Button
+                      type="button"
+                      variant="default"
+                      size="sm"
+                      onClick={() => void handleShowMyLiveLocation()}
+                      disabled={busy !== null && busy !== "selfLocation"}
+                      className="h-11 w-full shrink-0 rounded-full bg-[#007aff] px-4 text-[14px] font-semibold text-white hover:bg-[#006fe6]"
+                    >
+                      {busy === "selfLocation" ? (
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                      ) : (
+                        <LocateFixed className="mr-2 h-4 w-4" aria-hidden="true" />
+                      )}
+                      {myLocationPoint ? "Refresh location" : "Show my location"}
+                    </Button>
+                  </div>
+
+                  {myLocationError ? (
+                    <div className="mx-3.5 mb-3.5 rounded-[14px] border border-[#ff3b30]/25 bg-[#ff3b30]/10 px-3 py-2 text-[12px] font-medium text-[#b42318] dark:text-[#ff9f9a]">
+                      {myLocationError}
+                    </div>
+                  ) : null}
+
+                  {myLocationPoint ? (
+                    <div className="px-3.5 pb-3.5">
+                      <LocalMapPreview point={myLocationPoint} />
+                    </div>
+                  ) : null}
+                </div>
               </section>
 
-              <section className="space-y-4 px-1">
+              <section className="min-w-0 max-w-full space-y-4 px-1">
                 <SegmentedModeControl
                   value={activeMode}
                   onChange={setActiveMode}
                 />
 
-                <div className="space-y-2">
-                  {sectionLabel("KAI Circle")}
-                  <div className="flex gap-4 overflow-x-auto px-1 pb-2 pt-1 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                <div className="min-w-0 max-w-full space-y-2">
+                  {sectionLabel("One Network")}
+                  <div className="flex max-w-full gap-4 overflow-x-auto overscroll-x-contain px-1 pb-2 pt-1 [scrollbar-width:thin] [&::-webkit-scrollbar]:h-2 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-black/20 dark:[&::-webkit-scrollbar-thumb]:bg-white/20">
                     {rankedRecipients.length ? (
                       rankedRecipients.map((recipient, index) => {
                         const label = displayNameFromRecipient(recipient);
@@ -2523,7 +3101,7 @@ export function OneLocationAgentPageContent() {
                             type="button"
                             aria-label={`Select ${recipientLabel(
                               recipient,
-                            )} from KAI Circle`}
+                            )} from One Network`}
                             onClick={() => {
                               if (activeMode === "share") {
                                 toggleShareRecipient(recipient.userId);
@@ -2570,13 +3148,13 @@ export function OneLocationAgentPageContent() {
                       })
                     ) : (
                       <p className="text-[13px] text-[#8e8e93] dark:text-white/55">
-                        KAI Circle recommendations will appear here.
+                        One Network recommendations will appear here.
                       </p>
                     )}
                   </div>
                 </div>
 
-                <div className="space-y-3">
+                <div className="min-w-0 max-w-full space-y-3">
                   <div className="relative">
                     <Search className="absolute left-3.5 top-1/2 h-5 w-5 -translate-y-1/2 text-[#8e8e93]" />
                     <input
@@ -2585,68 +3163,20 @@ export function OneLocationAgentPageContent() {
                         setRecipientSearch(event.target.value)
                       }
                       className="h-10 w-full rounded-[14px] border border-black/[0.04] bg-white pl-10 pr-4 text-[15px] text-[#1c1c1e] shadow-sm outline-none transition-shadow placeholder:text-[#8e8e93] focus:ring-2 focus:ring-[#007aff]/20 dark:border-white/[0.08] dark:bg-white/[0.07] dark:text-white"
-                      placeholder="Search KAI Circle..."
+                      placeholder="Search One Network..."
                       type="text"
                     />
                   </div>
 
-                  <div
-                    aria-label="KAI Circle section states"
-                    className="grid gap-2 sm:grid-cols-2"
-                  >
-                    {kaiCircleSections.map((section) => {
-                      const emptyCopy =
-                        KAI_CIRCLE_SECTION_EMPTY_COPY[section.key];
-                      return (
-                        <div
-                          key={section.key}
-                          className="rounded-[14px] border border-black/[0.04] bg-white/70 p-3 shadow-sm dark:border-white/[0.08] dark:bg-white/[0.06]"
-                        >
-                          {sectionLabel(section.title, section.recipients.length)}
-                          <p className="mt-1 text-[12px] leading-5 text-[#8e8e93] dark:text-white/55">
-                            {section.recipients.length
-                              ? section.description
-                              : `${emptyCopy.title}. ${emptyCopy.description}`}
-                          </p>
-                        </div>
-                      );
-                    })}
-                  </div>
-
-                  <div className="rounded-[14px] border border-black/[0.04] bg-white/70 p-3 shadow-sm dark:border-white/[0.08] dark:bg-white/[0.06]">
-                    <div className="flex items-start gap-3">
-                      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#eaf9ef] text-[#2dbd5a] dark:bg-emerald-400/15 dark:text-emerald-200">
-                        <ContactRound className="h-4 w-4" aria-hidden="true" />
-                      </span>
-                      <div className="min-w-0 flex-1">
-                        <div className="flex flex-wrap items-center gap-2">
-                          <h3 className="text-[14px] font-bold tracking-tight text-[#1c1c1e] dark:text-white">
-                            Mobile contact signal
-                          </h3>
-                          <span className="rounded-full bg-[#f2f2f7] px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-[#636366] dark:bg-white/10 dark:text-white/65">
-                            {contactSignalStatusLabel(contactSignal.status)}
-                          </span>
-                        </div>
-                        <p className="mt-1 text-[12px] leading-5 text-[#8e8e93] dark:text-white/55">
-                          {contactSignalSummary(contactSignal)}
-                        </p>
-                        {contactSignal.status === "matched" ||
-                        contactSignal.status === "empty" ? (
-                          <p className="mt-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-[#8e8e93] dark:text-white/45">
-                            {contactSignal.matchedCount} matched /{" "}
-                            {contactSignal.inviteCandidateCount} invite-ready
-                          </p>
-                        ) : null}
-                      </div>
-                    </div>
-                    <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                  <div className="min-w-0 max-w-full overflow-hidden rounded-[14px] border border-black/[0.04] bg-white/70 p-3 shadow-sm dark:border-white/[0.08] dark:bg-white/[0.06]">
+                    <div className="grid gap-2 sm:grid-cols-2">
                       <ActionButton
                         busy={busy}
                         busyKey="contactSync"
                         onClick={() => void handleSyncContactSignal()}
                         disabled={!auth.user || busy === "contactInvite"}
                         variant="outline"
-                        className="h-10 rounded-[12px] border-black/[0.06] bg-white text-[13px] font-semibold text-[#1c1c1e] shadow-sm hover:bg-[#f2f2f7] dark:border-white/[0.08] dark:bg-white/10 dark:text-white dark:hover:bg-white/15"
+                        className="h-10 w-full min-w-0 rounded-[12px] border-black/[0.06] bg-white text-[13px] font-semibold text-[#1c1c1e] shadow-sm hover:bg-[#f2f2f7] dark:border-white/[0.08] dark:bg-white/10 dark:text-white dark:hover:bg-white/15"
                       >
                         {busy !== "contactSync" ? (
                           <ContactRound className="mr-2 h-4 w-4" aria-hidden="true" />
@@ -2659,19 +3189,26 @@ export function OneLocationAgentPageContent() {
                         onClick={() => void handleShareContactInvite()}
                         disabled={!vaultOwnerToken || busy === "contactSync"}
                         variant="outline"
-                        className="h-10 rounded-[12px] border-black/[0.06] bg-white text-[13px] font-semibold text-[#007aff] shadow-sm hover:bg-[#f2f2f7] dark:border-white/[0.08] dark:bg-white/10 dark:text-[#76b7ff] dark:hover:bg-white/15"
+                        className="h-10 w-full min-w-0 rounded-[12px] border-black/[0.06] bg-white text-[13px] font-semibold text-[#007aff] shadow-sm hover:bg-[#f2f2f7] dark:border-white/[0.08] dark:bg-white/10 dark:text-[#76b7ff] dark:hover:bg-white/15"
                       >
                         {busy !== "contactInvite" ? (
                           <Send className="mr-2 h-4 w-4" aria-hidden="true" />
                         ) : null}
-                        Invite Contacts
+                        Share to Contacts
                       </ActionButton>
                     </div>
                   </div>
 
-                  <div className={onePanelClassName}>
+                  <div
+                    id="one-network-contact-list"
+                    className={
+                      showExpandedOneNetworkList
+                        ? oneScrollablePanelClassName
+                        : onePanelClassName
+                    }
+                  >
                     {visibleRecipients.length ? (
-                      visibleRecipients.map((recipient, index) => {
+                      displayedVisibleRecipients.map((recipient, index) => {
                         const label = displayNameFromRecipient(recipient);
                         const selected =
                           activeMode === "share"
@@ -2683,9 +3220,9 @@ export function OneLocationAgentPageContent() {
                         return (
                           <div
                             key={recipient.userId}
-                            className="relative flex flex-col gap-2.5 p-3.5 after:absolute after:bottom-0 after:left-[62px] after:right-0 after:border-b after:border-black/[0.05] last:after:hidden dark:after:border-white/[0.08]"
+                            className="relative flex min-w-0 max-w-full flex-col gap-2.5 overflow-hidden p-3.5 after:absolute after:bottom-0 after:left-[62px] after:right-0 after:border-b after:border-black/[0.05] last:after:hidden dark:after:border-white/[0.08]"
                           >
-                            <div className="flex items-center gap-3">
+                            <div className="flex min-w-0 items-start gap-3">
                               <AvatarBubble
                                 label={label}
                                 index={index}
@@ -2693,8 +3230,8 @@ export function OneLocationAgentPageContent() {
                                 muted={!recipient.canReceiveLocation}
                               />
                               <div className="min-w-0 flex-1">
-                                <div className="flex min-w-0 items-center gap-1.5">
-                                  <span className="truncate text-[16px] font-semibold tracking-tight text-[#1c1c1e] dark:text-white">
+                                <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+                                  <span className="min-w-0 max-w-full truncate text-[16px] font-semibold tracking-tight text-[#1c1c1e] dark:text-white">
                                     {recipientLabel(recipient)}
                                   </span>
                                   <span className="rounded-md bg-[#f0f5ff] px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider text-[#007aff] dark:bg-[#0a84ff]/15 dark:text-[#76b7ff]">
@@ -2713,7 +3250,7 @@ export function OneLocationAgentPageContent() {
                                     {recommendationCategoryLabel(recipient)}
                                   </span>
                                 </div>
-                                <p className="mt-0.5 text-[12px] font-medium text-[#8e8e93] dark:text-white/55">
+                                <p className="mt-0.5 break-words text-[12px] font-medium text-[#8e8e93] [overflow-wrap:anywhere] dark:text-white/55">
                                   {recipientRecommendationLine(recipient)}
                                 </p>
                                 {reasons.length ? (
@@ -2730,7 +3267,7 @@ export function OneLocationAgentPageContent() {
                                 ) : null}
                               </div>
                               {selected ? (
-                                <CheckCircle2 className="h-[22px] w-[22px] text-[#007aff] dark:text-[#76b7ff]" />
+                                <CheckCircle2 className="mt-1 h-[22px] w-[22px] shrink-0 text-[#007aff] dark:text-[#76b7ff]" />
                               ) : (
                                 <button
                                   type="button"
@@ -2747,7 +3284,7 @@ export function OneLocationAgentPageContent() {
                                       );
                                     }
                                   }}
-                                  className="inline-flex h-8 items-center gap-1 rounded-full bg-[#f2f2f7] px-3 text-[12px] font-semibold text-[#007aff] transition-colors hover:bg-[#e5e5ea] dark:bg-white/10 dark:text-[#76b7ff] dark:hover:bg-white/15"
+                                  className="mt-0.5 inline-flex h-8 shrink-0 items-center gap-1 rounded-full bg-[#f2f2f7] px-3 text-[12px] font-semibold text-[#007aff] transition-colors hover:bg-[#e5e5ea] dark:bg-white/10 dark:text-[#76b7ff] dark:hover:bg-white/15"
                                 >
                                   <Plus className="h-3.5 w-3.5" />
                                   Select
@@ -2762,20 +3299,47 @@ export function OneLocationAgentPageContent() {
                         icon={UsersRound}
                         title={
                           recipients.length
-                            ? "No KAI Circle matches"
-                            : "KAI Circle is empty"
+                            ? "No One Network matches"
+                            : "One Network is empty"
                         }
                         description={
                           recipients.length
                             ? "Try another name, role, or recommendation signal."
-                            : "Approval, professional, ready, and setup signals will appear as your KAI network grows."
+                            : "Approval, professional, ready, and setup signals will appear as your One Network grows."
                         }
                       />
                     )}
                   </div>
 
-                  {activeMode === "share" ? (
-                    <div className="space-y-3">
+                  {hasMoreVisibleRecipients ? (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      aria-controls="one-network-contact-list"
+                      aria-expanded={showExpandedOneNetworkList}
+                      onClick={() =>
+                        setOneNetworkListExpanded((expanded) => !expanded)
+                      }
+                      className="h-9 w-full rounded-full border-black/[0.06] bg-white text-[13px] font-semibold text-[#007aff] shadow-sm hover:bg-[#f2f2f7] dark:border-white/[0.08] dark:bg-white/10 dark:text-[#76b7ff] dark:hover:bg-white/15"
+                    >
+                      {showExpandedOneNetworkList ? (
+                        <ChevronUp className="mr-2 h-4 w-4" aria-hidden="true" />
+                      ) : (
+                        <ChevronDown
+                          className="mr-2 h-4 w-4"
+                          aria-hidden="true"
+                        />
+                      )}
+                      {showExpandedOneNetworkList
+                        ? "Show less"
+                        : `View more (${visibleRecipients.length - ONE_NETWORK_PREVIEW_LIMIT})`}
+                    </Button>
+                  ) : null}
+
+                  <div>
+                    {activeMode === "share" ? (
+                      <div className="space-y-3">
                       <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_160px]">
                         <Select
                           value={selectedRecipientId}
@@ -2826,9 +3390,11 @@ export function OneLocationAgentPageContent() {
                               onClick={() =>
                                 removeShareRecipient(recipient.userId)
                               }
-                              className="inline-flex h-8 items-center gap-1.5 rounded-full bg-[#eef5ff] px-3 text-[12px] font-semibold text-[#005bb5] transition-colors hover:bg-[#dfefff] dark:bg-[#0a84ff]/15 dark:text-[#a7d4ff] dark:hover:bg-[#0a84ff]/25"
+                              className="inline-flex h-8 max-w-full items-center gap-1.5 rounded-full bg-[#eef5ff] px-3 text-[12px] font-semibold text-[#005bb5] transition-colors hover:bg-[#dfefff] dark:bg-[#0a84ff]/15 dark:text-[#a7d4ff] dark:hover:bg-[#0a84ff]/25"
                             >
-                              {recipientLabel(recipient)}
+                              <span className="min-w-0 truncate">
+                                {recipientLabel(recipient)}
+                              </span>
                               <X className="h-3.5 w-3.5" aria-hidden="true" />
                               <span className="sr-only">
                                 Remove {recipientLabel(recipient)}
@@ -2851,17 +3417,17 @@ export function OneLocationAgentPageContent() {
                           ? `${peopleCountLabel(
                               selectedShareRecipients.length,
                             )} selected for private encrypted sharing.`
-                          : "Select one or more KAI users for private sharing."}
+                          : "Select one or more One users for private sharing."}
                       </p>
                       {shareReviewOpen ? (
                         <div
                           role="region"
                           aria-label="Share safety review"
-                          className="space-y-3 rounded-[14px] border border-[#007aff]/20 bg-[#eef5ff] p-3 text-[13px] leading-5 text-[#17446f] dark:border-[#0a84ff]/30 dark:bg-[#0a84ff]/15 dark:text-[#cfe7ff]"
+                          className="min-w-0 max-w-full space-y-3 overflow-hidden rounded-[14px] border border-[#007aff]/20 bg-[#eef5ff] p-3 text-[13px] leading-5 text-[#17446f] dark:border-[#0a84ff]/30 dark:bg-[#0a84ff]/15 dark:text-[#cfe7ff]"
                         >
                           <div>
                             <p className="font-semibold text-[#0b3d70] dark:text-[#e6f2ff]">
-                              Confirm private KAI-to-KAI sharing
+                              Confirm private One user sharing
                             </p>
                             <p className="mt-1">
                               {peopleCountLabel(
@@ -2882,7 +3448,7 @@ export function OneLocationAgentPageContent() {
                             busyKey="share"
                             onClick={() => void handleShare()}
                             disabled={!canShare}
-                            className="h-10 rounded-full bg-[#007aff] px-4 text-[13px] font-semibold text-white hover:bg-[#006fe6]"
+                            className="h-10 w-full min-w-0 rounded-full bg-[#007aff] px-4 text-[13px] font-semibold text-white hover:bg-[#006fe6] sm:w-auto"
                           >
                             <Send
                               className="mr-2 h-4 w-4"
@@ -2895,7 +3461,7 @@ export function OneLocationAgentPageContent() {
                       <ActionButton
                         busy={busy}
                         busyKey="share"
-                        onClick={handleOpenShareReview}
+                        onClick={() => void handleOpenShareReview()}
                         disabled={!canShare}
                         className="h-12 w-full rounded-[16px] bg-gradient-to-b from-[#1a85ff] to-[#0066ff] text-[16px] font-semibold text-white shadow-[0_4px_14px_rgba(0,122,255,0.35)] hover:opacity-95"
                       >
@@ -2903,9 +3469,9 @@ export function OneLocationAgentPageContent() {
                         Review Share
                         <span className="sr-only">Share Encrypted Update</span>
                       </ActionButton>
-                    </div>
-                  ) : (
-                    <div className="space-y-3">
+                      </div>
+                    ) : (
+                      <div className="space-y-3">
                       <Select
                         value={selectedRequestOwnerId}
                         onValueChange={addRequestOwner}
@@ -2936,9 +3502,11 @@ export function OneLocationAgentPageContent() {
                               onClick={() =>
                                 removeRequestOwner(recipient.userId)
                               }
-                              className="inline-flex h-8 items-center gap-1.5 rounded-full bg-[#eef5ff] px-3 text-[12px] font-semibold text-[#005bb5] transition-colors hover:bg-[#dfefff] dark:bg-[#0a84ff]/15 dark:text-[#a7d4ff] dark:hover:bg-[#0a84ff]/25"
+                              className="inline-flex h-8 max-w-full items-center gap-1.5 rounded-full bg-[#eef5ff] px-3 text-[12px] font-semibold text-[#005bb5] transition-colors hover:bg-[#dfefff] dark:bg-[#0a84ff]/15 dark:text-[#a7d4ff] dark:hover:bg-[#0a84ff]/25"
                             >
-                              {recipientLabel(recipient)}
+                              <span className="min-w-0 truncate">
+                                {recipientLabel(recipient)}
+                              </span>
                               <X className="h-3.5 w-3.5" aria-hidden="true" />
                               <span className="sr-only">
                                 Remove {recipientLabel(recipient)}
@@ -2952,7 +3520,7 @@ export function OneLocationAgentPageContent() {
                           ? `${peopleCountLabel(
                               selectedRequestOwners.length,
                             )} selected for approval-first requests.`
-                          : "Select one or more KAI users before requesting location access."}
+                          : "Select one or more One users before requesting location access."}
                       </p>
                       <Textarea
                         value={requestMessage}
@@ -2975,115 +3543,137 @@ export function OneLocationAgentPageContent() {
                         <Send className="mr-2 h-4 w-4" aria-hidden="true" />
                         Send Request
                       </ActionButton>
-                    </div>
-                  )}
+                      </div>
+                    )}
+                  </div>
                 </div>
               </section>
             </div>
 
-            <div className="space-y-6">
-              <OneLocationActivityDashboard
-                activity={locationActivity}
-                range={activityRange}
-                loading={activityLoading}
-                error={activityError}
-                onRangeChange={(value) => {
-                  setActivityRange(value);
-                  setActivitySnapshot(null);
-                }}
-              />
-
-              <section className="space-y-2 px-1">
-                {sectionLabel("People who can see me")}
-                <div className={onePanelClassName}>
-                  {(state?.ownerGrants ?? []).length ? (
-                    state?.ownerGrants.map((grant, index) => (
-                      <div
-                        key={grant.id}
-                        className="relative flex items-center gap-3 p-3.5 after:absolute after:bottom-0 after:left-[62px] after:right-0 after:border-b after:border-black/[0.05] last:after:hidden dark:after:border-white/[0.08]"
-                      >
-                        <AvatarBubble
-                          label={grantCounterpartyLabel(grant)}
-                          index={index}
-                          size="sm"
-                        />
-                        <div className="min-w-0 flex-1">
-                          <h3 className="truncate text-[16px] font-medium tracking-tight text-[#1c1c1e] dark:text-white">
-                            {grantCounterpartyLabel(grant)}
-                          </h3>
-                          <div className="mt-0.5 flex flex-wrap items-center gap-1.5">
-                            <Badge variant={statusVariant(grant.status)}>
-                              {grant.status}
-                            </Badge>
-                            <span className="text-[12px] font-medium text-[#8e8e93] dark:text-white/55">
-                              {expiresLabel(grant)} - {grant.durationHours}h
-                            </span>
-                          </div>
-                        </div>
-                        {grant.status === "active" ? (
-                          <div className="flex shrink-0 gap-1.5">
-                            <Button
-                              aria-label="Update share"
-                              variant="outline"
-                              size="icon"
-                              onClick={() => void handlePublish(grant)}
-                              disabled={busy === "publish"}
-                              className="h-8 w-8 rounded-full border-0 bg-[#f2f2f7] text-[#8e8e93] hover:bg-[#e5e5ea] dark:bg-white/10 dark:text-white/55 dark:hover:bg-white/15"
-                            >
-                              {busy === "publish" ? (
-                                <Loader2 className="h-4 w-4 animate-spin" />
-                              ) : (
-                                <Pencil className="h-4 w-4" />
-                              )}
-                            </Button>
-                            <Button
-                              aria-label={`Revoke access for ${grantCounterpartyLabel(grant)}`}
-                              variant="outline"
-                              size="icon"
-                              onClick={() => void handleRevoke(grant.id)}
-                              disabled={busy === "revoke"}
-                              className="h-8 w-8 rounded-full border-0 bg-[#ff3b30]/10 text-[#ff3b30] hover:bg-[#ff3b30]/20 dark:bg-[#ff453a]/15 dark:text-[#ff9f9a]"
-                            >
-                              <X className="h-4 w-4" />
-                            </Button>
-                          </div>
-                        ) : null}
-                      </div>
-                    ))
-                  ) : (
-                    <EmptyOneState
-                      icon={UsersRound}
-                      title="No active shares"
-                      description="Create one encrypted grant when you need a trusted person to see you."
-                    />
+            <div className="min-w-0 max-w-full space-y-6">
+              {SHOW_LOCATION_ACTIVITY_SECTION ? (
+                <section
+                  ref={activitySectionRef}
+                  tabIndex={-1}
+                  className={cn(
+                    "min-w-0 max-w-full outline-none",
+                    sectionFocusClassName("activity"),
                   )}
-                </div>
-              </section>
+                >
+                  <OneLocationActivityDashboard
+                    activity={locationActivity}
+                    range={activityRange}
+                    loading={activityLoading}
+                    error={activityError}
+                    onRangeChange={(value) => {
+                      setActivityRange(value);
+                      setActivitySnapshot(null);
+                    }}
+                  />
+                </section>
+              ) : null}
 
-              <section className="space-y-2 px-1">
+              {SHOW_OWNER_GRANTS_SECTION ? (
+                <section
+                  ref={peopleSectionRef}
+                  tabIndex={-1}
+                  className={cn("min-w-0 max-w-full space-y-2 px-1 outline-none", sectionFocusClassName("people"))}
+                >
+                  {sectionLabel("People who can see me")}
+                  <div className={oneScrollablePanelClassName}>
+                    {(state?.ownerGrants ?? []).length ? (
+                      state?.ownerGrants.map((grant, index) => (
+                        <div
+                          key={grant.id}
+                          className="relative flex min-w-0 max-w-full flex-col gap-3 overflow-hidden p-3.5 after:absolute after:bottom-0 after:left-[62px] after:right-0 after:border-b after:border-black/[0.05] sm:flex-row sm:items-center last:after:hidden dark:after:border-white/[0.08]"
+                        >
+                          <AvatarBubble
+                            label={grantCounterpartyLabel(grant)}
+                            index={index}
+                            size="sm"
+                          />
+                          <div className="min-w-0 flex-1">
+                            <h3 className="break-words text-[16px] font-medium tracking-tight text-[#1c1c1e] [overflow-wrap:anywhere] dark:text-white">
+                              {grantCounterpartyLabel(grant)}
+                            </h3>
+                            <div className="mt-0.5 flex flex-wrap items-center gap-1.5">
+                              <Badge variant={statusVariant(grant.status)}>
+                                {grant.status}
+                              </Badge>
+                              <span className="min-w-0 break-words text-[12px] font-medium text-[#8e8e93] [overflow-wrap:anywhere] dark:text-white/55">
+                                {expiresLabel(grant)} - {grant.durationHours}h
+                              </span>
+                            </div>
+                          </div>
+                          {grant.status === "active" ? (
+                            <div className="flex w-full shrink-0 justify-end gap-1.5 sm:w-auto">
+                              <Button
+                                aria-label="Update share"
+                                variant="outline"
+                                size="icon"
+                                onClick={() => void handlePublish(grant)}
+                                disabled={busy === "publish"}
+                                className="h-8 w-8 rounded-full border-0 bg-[#f2f2f7] text-[#8e8e93] hover:bg-[#e5e5ea] dark:bg-white/10 dark:text-white/55 dark:hover:bg-white/15"
+                              >
+                                {busy === "publish" ? (
+                                  <Loader2 className="h-4 w-4 animate-spin" />
+                                ) : (
+                                  <Pencil className="h-4 w-4" />
+                                )}
+                              </Button>
+                              <Button
+                                aria-label={`Revoke access for ${grantCounterpartyLabel(grant)}`}
+                                variant="outline"
+                                size="icon"
+                                onClick={() => void handleRevoke(grant.id)}
+                                disabled={busy === "revoke"}
+                                className="h-8 w-8 rounded-full border-0 bg-[#ff3b30]/10 text-[#ff3b30] hover:bg-[#ff3b30]/20 dark:bg-[#ff453a]/15 dark:text-[#ff9f9a]"
+                              >
+                                <X className="h-4 w-4" />
+                              </Button>
+                            </div>
+                          ) : null}
+                        </div>
+                      ))
+                    ) : (
+                      <EmptyOneState
+                        icon={UsersRound}
+                        title="No active shares"
+                        description="Create one encrypted grant when you need a trusted person to see you."
+                      />
+                    )}
+                  </div>
+                </section>
+              ) : null}
+
+              <section
+                ref={approvalsSectionRef}
+                tabIndex={-1}
+                className={cn("min-w-0 max-w-full space-y-2 px-1 outline-none", sectionFocusClassName("approvals"))}
+              >
                 {sectionLabel("Approvals", pendingOwnerRequests.length)}
                 <div
                   className={cn(
-                    onePanelClassName,
+                    oneScrollablePanelClassName,
                     pendingOwnerRequests.length &&
                       "relative before:absolute before:bottom-0 before:left-0 before:top-0 before:w-1 before:bg-[#ff3b30]",
                   )}
                 >
                   {pendingOwnerRequests.length ? (
                     pendingOwnerRequests.map((request) => (
-                      <div key={request.id} className="flex items-start gap-3 p-3.5">
+                      <div key={request.id} className="flex min-w-0 max-w-full items-start gap-3 overflow-hidden p-3.5">
                         <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#f2f2f7] text-[#8e8e93] dark:bg-white/10 dark:text-white/55">
                           <UserRoundCheck className="h-[18px] w-[18px]" />
                         </span>
                         <div className="min-w-0 flex-1 space-y-1">
-                          <h3 className="text-[16px] font-semibold tracking-tight text-[#1c1c1e] dark:text-white">
+                          <h3 className="break-words text-[16px] font-semibold tracking-tight text-[#1c1c1e] [overflow-wrap:anywhere] dark:text-white">
                             {requestLabel(request)}
                           </h3>
                           <p className="text-[13px] font-medium leading-relaxed text-[#8e8e93] dark:text-white/55">
                             {request.message ||
                               `Requested ${formatDateTime(request.requestedAt)}`}
                           </p>
-                          <div className="flex gap-2 pt-2">
+                          <div className="flex flex-col gap-2 pt-2 sm:flex-row">
                             <Button
                               variant="outline"
                               onClick={() => void handleDeny(request.id)}
@@ -3114,16 +3704,12 @@ export function OneLocationAgentPageContent() {
                 </div>
               </section>
 
-              <section className="space-y-2 px-1">
+              <section className="min-w-0 max-w-full space-y-2 px-1">
                 {sectionLabel("Create public link")}
                 <div className={cn(onePanelClassName, "space-y-4 p-3.5")}>
-                  <p className="text-[13px] leading-5 text-[#8e8e93] dark:text-white/55">
-                    Share a public location link. Visitors enter their details
-                    and can view this link's captured location.
-                  </p>
                   <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_150px]">
-                    <div className={cn(oneInsetClassName, "px-3 py-2 text-sm")}>
-                      <span className={oneSecondaryTextClassName}>
+                    <div className={cn(oneInsetClassName, "min-w-0 px-3 py-2 text-sm")}>
+                      <span className={cn(oneSecondaryTextClassName, "break-all")}>
                         {publicInviteUrl ||
                           "Create a fresh public location link to copy or share."}
                       </span>
@@ -3144,13 +3730,13 @@ export function OneLocationAgentPageContent() {
                       </SelectContent>
                     </Select>
                   </div>
-                  <div className="flex flex-wrap gap-2">
+                  <div className="grid min-w-0 max-w-full grid-cols-1 gap-2 sm:flex sm:flex-wrap">
                     <ActionButton
                       busy={busy}
                       busyKey="publicInvite"
                       onClick={() => void handleCreatePublicInvite()}
                       disabled={!vaultOwnerToken}
-                      className="rounded-full bg-[#007aff] text-white hover:bg-[#0066ff]"
+                      className="w-full min-w-0 rounded-full bg-[#007aff] text-white hover:bg-[#0066ff] sm:w-auto"
                     >
                       <ExternalLink className="mr-2 h-4 w-4" />
                       Create Public Link
@@ -3159,7 +3745,7 @@ export function OneLocationAgentPageContent() {
                       variant="outline"
                       onClick={() => void handleSharePublicInvite()}
                       disabled={!publicInviteUrl}
-                      className="rounded-full border-black/[0.06] bg-[#f2f2f7] dark:border-white/[0.08] dark:bg-white/10"
+                      className="w-full min-w-0 rounded-full border-black/[0.06] bg-[#f2f2f7] sm:w-auto dark:border-white/[0.08] dark:bg-white/10"
                     >
                       <Send className="mr-2 h-4 w-4" />
                       Share
@@ -3168,71 +3754,70 @@ export function OneLocationAgentPageContent() {
                       variant="outline"
                       onClick={() => void handleCopyPublicInvite()}
                       disabled={!publicInviteUrl}
-                      className="rounded-full border-black/[0.06] bg-[#f2f2f7] dark:border-white/[0.08] dark:bg-white/10"
+                      className="w-full min-w-0 rounded-full border-black/[0.06] bg-[#f2f2f7] sm:w-auto dark:border-white/[0.08] dark:bg-white/10"
                     >
                       <Copy className="mr-2 h-4 w-4" />
                       Copy
                     </Button>
                   </div>
-                  {activePublicInvites.length ? (
+                  {latestActivePublicInvite ? (
                     <div className="space-y-2">
-                      {activePublicInvites.map((invite) => (
-                        <div
-                          key={invite.id}
-                          className="flex items-center justify-between gap-3 rounded-[14px] bg-[#f2f2f7] p-3 dark:bg-white/10"
-                        >
-                          <div className="min-w-0">
-                            <p className="text-[14px] font-semibold text-[#1c1c1e] dark:text-white">
-                              Active public location link
-                            </p>
-                            <p className="truncate text-[12px] text-[#8e8e93] dark:text-white/55">
-                              Public viewing expires{" "}
-                              {formatDateTime(invite.expiresAt)} -{" "}
-                              {invite.durationHours}h
-                            </p>
-                          </div>
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => void handleRevokePublicInvite(invite)}
-                            disabled={busy === "publicRevoke"}
-                            className="rounded-full"
-                          >
-                            Revoke
-                          </Button>
+                      <div className="flex flex-col gap-3 rounded-[14px] bg-[#f2f2f7] p-3 sm:flex-row sm:items-center sm:justify-between dark:bg-white/10">
+                        <div className="min-w-0">
+                          <p className="text-[14px] font-semibold text-[#1c1c1e] dark:text-white">
+                            Latest active public link
+                          </p>
+                          <p className="break-words text-[12px] text-[#8e8e93] [overflow-wrap:anywhere] dark:text-white/55">
+                            Expires {formatDateTime(latestActivePublicInvite.expiresAt)}
+                          </p>
                         </div>
-                      ))}
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() =>
+                            void handleRevokePublicInvite(latestActivePublicInvite)
+                          }
+                          disabled={busy === "publicRevoke"}
+                          className="w-full rounded-full sm:w-auto"
+                        >
+                          Revoke
+                        </Button>
+                      </div>
                     </div>
                   ) : null}
                 </div>
               </section>
 
-              <section className="space-y-2 px-1">
+              <section
+                ref={sharedSectionRef}
+                tabIndex={-1}
+                className={cn("min-w-0 max-w-full space-y-2 px-1 outline-none", sectionFocusClassName("shared"))}
+              >
                 {sectionLabel("Shared with me")}
-                <div className={onePanelClassName}>
+                <div className={oneScrollablePanelClassName}>
                   {visibleReceivedGrants.length ? (
                     visibleReceivedGrants.map((grant, index) => {
                       const point = decryptedPoints[grant.id];
                       return (
                         <div
                           key={grant.id}
-                          className="border-b border-black/[0.05] last:border-b-0 dark:border-white/[0.08]"
+                          className="min-w-0 max-w-full overflow-hidden border-b border-black/[0.05] last:border-b-0 dark:border-white/[0.08]"
                         >
-                          <div className="flex items-center gap-3 p-3.5">
+                          <div className="flex flex-col gap-3 p-3.5 sm:flex-row sm:items-center">
                             <AvatarBubble
                               label={receivedGrantOwnerLabel(grant)}
                               index={index + 2}
                               size="sm"
                             />
                             <div className="min-w-0 flex-1">
-                              <h3 className="truncate text-[16px] font-medium tracking-tight text-[#1c1c1e] dark:text-white">
+                              <h3 className="break-words text-[16px] font-medium tracking-tight text-[#1c1c1e] [overflow-wrap:anywhere] dark:text-white">
                                 {receivedGrantOwnerLabel(grant)}
                               </h3>
                               <div className="mt-0.5 flex flex-wrap items-center gap-1.5">
                                 <Badge variant={statusVariant(grant.status)}>
                                   {grant.status}
                                 </Badge>
-                                <span className="text-[12px] font-medium text-[#8e8e93] dark:text-white/55">
+                                <span className="min-w-0 break-words text-[12px] font-medium text-[#8e8e93] [overflow-wrap:anywhere] dark:text-white/55">
                                   {expiresLabel(grant)}
                                 </span>
                               </div>
@@ -3243,7 +3828,7 @@ export function OneLocationAgentPageContent() {
                                 size="sm"
                                 onClick={() => void handleView(grant)}
                                 disabled={busy === "view"}
-                                className="rounded-full border-black/[0.06] bg-[#f2f2f7] dark:border-white/[0.08] dark:bg-white/10"
+                                className="w-full rounded-full border-black/[0.06] bg-[#f2f2f7] sm:w-auto dark:border-white/[0.08] dark:bg-white/10"
                               >
                                 {busy === "view" ? (
                                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -3280,122 +3865,134 @@ export function OneLocationAgentPageContent() {
                 </div>
               </section>
 
-              <section className="space-y-2 px-1">
-                {sectionLabel("Public link responses")}
-                <div className={onePanelClassName}>
-                  {publicSubmissions.length ? (
-                    publicSubmissions.map((submission) => (
-                      <div
-                        key={submission.id}
-                        className="flex items-center gap-3 p-3.5"
-                      >
-                        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#f2f2f7] text-[#8e8e93] dark:bg-white/10 dark:text-white/55">
-                          <ExternalLink className="h-[18px] w-[18px]" />
-                        </span>
-                        <div className="min-w-0 flex-1">
-                          <h3 className="truncate text-[16px] font-medium text-[#1c1c1e] dark:text-white">
-                            {publicSubmissionLabel(submission)}
-                          </h3>
-                          <p className="truncate text-[12px] text-[#8e8e93] dark:text-white/55">
-                            {submission.message ||
-                              `Status ${submission.status} - ${formatDateTime(submission.submittedAt)}`}
-                          </p>
-                        </div>
-                        <Badge variant={statusVariant(submission.status)}>
-                          {submission.requestStatus || submission.status}
-                        </Badge>
-                      </div>
-                    ))
-                  ) : (
-                    <EmptyOneState
-                      icon={ExternalLink}
-                      title="No public responses"
-                      description="Responses from your public location link show up here after visitors open it."
-                    />
-                  )}
-                </div>
-              </section>
-
-              <section className="space-y-2 px-1">
-                {sectionLabel("Refer someone else")}
-                <div className={cn(onePanelClassName, "p-3.5")}>
-                  {(state?.receivedGrants ?? []).filter(
-                    (grant) => grant.status === "active",
-                  ).length ? (
-                    state?.receivedGrants
-                      .filter((grant) => grant.status === "active")
-                      .map((grant) => (
+              {SHOW_PUBLIC_RESPONSES_SECTION ? (
+                <section
+                  ref={publicResponsesSectionRef}
+                  tabIndex={-1}
+                  className={cn("min-w-0 max-w-full space-y-2 px-1 outline-none", sectionFocusClassName("public_responses"))}
+                >
+                  {sectionLabel("Public link responses")}
+                  <div className={oneScrollablePanelClassName}>
+                    {publicSubmissions.length ? (
+                      publicSubmissions.map((submission) => (
                         <div
-                          key={grant.id}
-                          className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto]"
+                          key={submission.id}
+                          className="flex min-w-0 max-w-full flex-col gap-3 overflow-hidden p-3.5 sm:flex-row sm:items-center"
                         >
-                          <Select
-                            value={referralTargets[grant.id] || ""}
-                            onValueChange={(value) =>
-                              setReferralTargets((current) => ({
-                                ...current,
-                                [grant.id]: value,
-                              }))
-                            }
-                          >
-                            <SelectTrigger className="h-10 w-full rounded-[12px] border-black/[0.04] bg-white shadow-sm dark:border-white/[0.08] dark:bg-white/[0.07]">
-                              <SelectValue placeholder="Select referred person" />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {recipients
-                                .filter(
-                                  (recipient) =>
-                                    recipient.userId !== grant.ownerUserId,
-                                )
-                                .map((recipient) => (
-                                  <SelectItem
-                                    key={recipient.userId}
-                                    value={recipient.userId}
-                                  >
-                                    {recipientLabel(recipient)}
-                                  </SelectItem>
-                                ))}
-                            </SelectContent>
-                          </Select>
-                          <ActionButton
-                            busy={busy}
-                            busyKey="refer"
-                            variant="outline"
-                            onClick={() => void handleRefer(grant)}
-                            disabled={!referralTargets[grant.id]}
-                            className="rounded-full"
-                          >
-                            Refer
-                          </ActionButton>
+                          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#f2f2f7] text-[#8e8e93] dark:bg-white/10 dark:text-white/55">
+                            <ExternalLink className="h-[18px] w-[18px]" />
+                          </span>
+                          <div className="min-w-0 flex-1">
+                            <h3 className="break-words text-[16px] font-medium text-[#1c1c1e] [overflow-wrap:anywhere] dark:text-white">
+                              {publicSubmissionLabel(submission)}
+                            </h3>
+                            <p className="break-words text-[12px] text-[#8e8e93] [overflow-wrap:anywhere] dark:text-white/55">
+                              {submission.message ||
+                                `Status ${submission.status} - ${formatDateTime(submission.submittedAt)}`}
+                            </p>
+                          </div>
+                          <Badge variant={statusVariant(submission.status)}>
+                            {submission.requestStatus || submission.status}
+                          </Badge>
                         </div>
                       ))
-                  ) : (
-                    <EmptyOneState
-                      icon={UsersRound}
-                      title="No active received grant"
-                      description="You can refer only from an active share, and the owner still decides."
-                    />
-                  )}
-                </div>
-              </section>
+                    ) : (
+                      <EmptyOneState
+                        icon={ExternalLink}
+                        title="No public responses"
+                        description="Responses from your public location link show up here after visitors open it."
+                      />
+                    )}
+                  </div>
+                </section>
+              ) : null}
+
+              {SHOW_REFERRAL_SECTION ? (
+                <section className="min-w-0 max-w-full space-y-2 px-1">
+                  {sectionLabel("Refer someone else")}
+                  <div className={cn(onePanelClassName, "p-3.5")}>
+                    {(state?.receivedGrants ?? []).filter(
+                      (grant) => grant.status === "active",
+                    ).length ? (
+                      state?.receivedGrants
+                        .filter((grant) => grant.status === "active")
+                        .map((grant) => (
+                          <div
+                            key={grant.id}
+                            className="grid min-w-0 max-w-full gap-3 sm:grid-cols-[minmax(0,1fr)_auto]"
+                          >
+                            <Select
+                              value={referralTargets[grant.id] || ""}
+                              onValueChange={(value) =>
+                                setReferralTargets((current) => ({
+                                  ...current,
+                                  [grant.id]: value,
+                                }))
+                              }
+                            >
+                              <SelectTrigger className="h-10 w-full rounded-[12px] border-black/[0.04] bg-white shadow-sm dark:border-white/[0.08] dark:bg-white/[0.07]">
+                                <SelectValue placeholder="Select referred person" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {recipients
+                                  .filter(
+                                    (recipient) =>
+                                      recipient.userId !== grant.ownerUserId,
+                                  )
+                                  .map((recipient) => (
+                                    <SelectItem
+                                      key={recipient.userId}
+                                      value={recipient.userId}
+                                    >
+                                      {recipientLabel(recipient)}
+                                    </SelectItem>
+                                  ))}
+                              </SelectContent>
+                            </Select>
+                            <ActionButton
+                              busy={busy}
+                              busyKey="refer"
+                              variant="outline"
+                              onClick={() => void handleRefer(grant)}
+                              disabled={!referralTargets[grant.id]}
+                              className="w-full min-w-0 rounded-full sm:w-auto"
+                            >
+                              Refer
+                            </ActionButton>
+                          </div>
+                        ))
+                    ) : (
+                      <EmptyOneState
+                        icon={UsersRound}
+                        title="No active received grant"
+                        description="You can refer only from an active share, and the owner still decides."
+                      />
+                    )}
+                  </div>
+                </section>
+              ) : null}
 
               {requestedByMe.length ? (
-                <section className="space-y-2 px-1">
+                <section
+                  ref={myRequestsSectionRef}
+                  tabIndex={-1}
+                  className={cn("min-w-0 max-w-full space-y-2 px-1 outline-none", sectionFocusClassName("my_requests"))}
+                >
                   {sectionLabel("My requests")}
-                  <div className={onePanelClassName}>
+                  <div className={oneScrollablePanelClassName}>
                     {requestedByMe.map((request) => (
                       <div
                         key={request.id}
-                        className="flex items-center gap-3 p-3.5"
+                        className="flex min-w-0 max-w-full flex-col gap-3 overflow-hidden p-3.5 sm:flex-row sm:items-center"
                       >
                         <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#f2f2f7] text-[#8e8e93] dark:bg-white/10 dark:text-white/55">
                           <Clock3 className="h-[18px] w-[18px]" />
                         </span>
                         <div className="min-w-0 flex-1">
-                          <h3 className="truncate text-[16px] font-medium text-[#1c1c1e] dark:text-white">
-                            {request.ownerUserId}
+                          <h3 className="break-words text-[16px] font-medium text-[#1c1c1e] [overflow-wrap:anywhere] dark:text-white">
+                            {requestOwnerLabel(request, recipients)}
                           </h3>
-                          <p className="truncate text-[12px] text-[#8e8e93] dark:text-white/55">
+                          <p className="break-words text-[12px] text-[#8e8e93] [overflow-wrap:anywhere] dark:text-white/55">
                             Status {request.status} -{" "}
                             {formatDateTime(request.requestedAt)}
                           </p>

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -1330,8 +1330,8 @@ function OneLocationOnboardingFlow({
 
             <h1
               className={cn(
-                "mt-8 max-w-[350px] text-center text-[34px] font-bold leading-[1.08] text-[#1d1d1f] sm:text-[36px] dark:text-white",
-                isPermissionStep && "max-w-[340px] text-[32px] leading-[1.1] sm:text-[34px]",
+                "mt-8 max-w-[340px] text-center text-[28px] font-medium leading-[1.1] text-[#1d1d1f] sm:text-[31px] dark:text-white",
+                isPermissionStep && "max-w-[330px] text-[27px] leading-[1.12] sm:text-[30px]",
               )}
             >
               {isPermissionStep
@@ -1341,7 +1341,7 @@ function OneLocationOnboardingFlow({
 
             {isPermissionStep ? (
               <>
-                <p className="mt-3 max-w-[340px] text-[17px] font-normal leading-[1.5] text-[#6e6e73] dark:text-white/62">
+                <p className="mt-3 max-w-[330px] text-[15.5px] font-normal leading-[1.5] text-[#6e6e73] dark:text-white/62">
                   Choose{" "}
                   <strong className="font-semibold text-[#1d1d1f] dark:text-white">
                     Allow Always
@@ -1355,7 +1355,7 @@ function OneLocationOnboardingFlow({
                 </div>
               </>
             ) : (
-              <p className="mt-3 max-w-[310px] text-[18px] leading-[1.4] text-[#6e6e73] dark:text-white/62">
+              <p className="mt-3 max-w-[310px] text-[15.5px] leading-[1.45] text-[#6e6e73] dark:text-white/62">
                 Never text "where are you?" again.
               </p>
             )}
@@ -3285,10 +3285,10 @@ function OneLocationAgentPageContent() {
       <AppPageHeaderRegion className="mx-auto w-full max-w-[540px] min-w-0 overflow-hidden">
         <div className="flex flex-col gap-4 px-1 pt-3 sm:flex-row sm:items-end sm:justify-between">
           <header className="max-w-[560px] min-w-0 space-y-2">
-            <span className="text-[11px] font-bold uppercase tracking-[0.22em] text-[#007aff] dark:text-[#76b7ff]">
+            <span className="text-[10.5px] font-medium uppercase tracking-[0.16em] text-[#007aff] dark:text-[#76b7ff]">
               When it matters most
             </span>
-            <h1 className="text-[34px] font-bold leading-[1.2] tracking-tight text-[#1c1c1e] sm:text-[42px] dark:text-white">
+            <h1 className="text-[28px] font-medium leading-[1.12] tracking-normal text-[#1c1c1e] sm:text-[32px] dark:text-white">
               Your circle, safely connected.
             </h1>
             <h2 className="sr-only">One Location Agent</h2>

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -43,7 +43,6 @@ import {
   AppPageShell,
 } from "@/components/app-ui/app-page-shell";
 import { NativeTestBeacon } from "@/components/app-ui/native-test-beacon";
-import { SettingsGroup } from "@/components/app-ui/settings-ui";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -788,19 +787,6 @@ function ActionButton({
   );
 }
 
-function SkeletonRow({ wide = false }: { wide?: boolean }) {
-  return (
-    <div className="flex min-h-20 items-center gap-3 px-[var(--settings-row-px)] py-[var(--settings-row-py)]">
-      <Skeleton className="h-9 w-9 shrink-0 rounded-2xl" />
-      <div className="min-w-0 flex-1 space-y-2">
-        <Skeleton className={wide ? "h-4 w-2/3" : "h-4 w-40"} />
-        <Skeleton className="h-3 w-full max-w-md" />
-      </div>
-      <Skeleton className="hidden h-8 w-20 rounded-full sm:block" />
-    </div>
-  );
-}
-
 type ShareMode = "share" | "request";
 
 const onePanelClassName =
@@ -1103,38 +1089,115 @@ function readinessCopy(permission: HushhLocationPermissionState | null): {
 
 function OneLocationInitialSkeleton() {
   return (
-    <div className="space-y-6">
-      <div className="space-y-6">
-        <SettingsGroup eyebrow="Device" title="Readiness">
-          <SkeletonRow />
-          <SkeletonRow />
-          <SkeletonRow />
-        </SettingsGroup>
-        <SettingsGroup eyebrow="Share" title="Share with trusted person">
-          <div className="space-y-4 px-[var(--settings-row-px)] py-[var(--settings-row-py)]">
-            <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_160px]">
-              <Skeleton className="h-11 rounded-xl" />
-              <Skeleton className="h-11 rounded-xl" />
+    <div
+      aria-label="Loading One Location"
+      className="mx-auto w-full max-w-[540px] space-y-5"
+      role="status"
+    >
+      <section className="space-y-2 px-1">
+        {sectionLabel("Device readiness")}
+        <div className="rounded-[20px] border border-[#34c759]/20 bg-[#34c759]/10 p-4 shadow-sm dark:border-[#34c759]/25 dark:bg-[#34c759]/12">
+          <div className="flex items-center gap-3">
+            <Skeleton className="h-10 w-10 shrink-0 rounded-full" />
+            <Skeleton className="h-6 w-44 max-w-[70%] rounded-lg" />
+          </div>
+        </div>
+        <div className={cn(onePanelClassName, "p-3.5")}>
+          <Skeleton className="h-11 w-full rounded-full" />
+        </div>
+      </section>
+
+      <section className="space-y-4 px-1">
+        <div className="flex h-9 w-full rounded-[9px] bg-[#efeff0] p-[3px] dark:bg-white/10">
+          <Skeleton className="h-full flex-1 rounded-[7px]" />
+          <Skeleton className="h-full flex-1 rounded-[7px] opacity-60" />
+        </div>
+
+        <div className="space-y-2">
+          {sectionLabel("One Network")}
+          <div className="flex gap-4 overflow-hidden px-1 pb-2 pt-1">
+            {Array.from({ length: 5 }).map((_, index) => (
+              <div
+                key={index}
+                className="flex w-[68px] shrink-0 flex-col items-center gap-2"
+              >
+                <Skeleton className="h-[52px] w-[52px] rounded-full" />
+                <Skeleton className="h-3 w-12 rounded-full" />
+                <Skeleton className="h-3 w-16 rounded-md" />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <Skeleton className="h-10 w-full rounded-[14px]" />
+
+        <div className={onePanelClassName}>
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div
+              key={index}
+              className="relative flex items-center gap-3 p-3.5 after:absolute after:bottom-0 after:left-[62px] after:right-0 after:border-b after:border-black/[0.05] last:after:hidden dark:after:border-white/[0.08]"
+            >
+              <Skeleton className="h-9 w-9 shrink-0 rounded-full" />
+              <div className="min-w-0 flex-1 space-y-2">
+                <Skeleton className="h-4 w-40 max-w-full rounded-lg" />
+                <Skeleton className="h-3 w-56 max-w-full rounded-lg" />
+              </div>
+              <Skeleton className="h-8 w-20 shrink-0 rounded-full" />
             </div>
-            <Skeleton className="h-10 w-56 rounded-xl" />
+          ))}
+        </div>
+
+        <Skeleton className="h-9 w-full rounded-full" />
+
+        <div className={cn(onePanelClassName, "space-y-3 p-3.5")}>
+          <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_150px]">
+            <Skeleton className="h-11 rounded-[14px]" />
+            <Skeleton className="h-11 rounded-[14px]" />
           </div>
-        </SettingsGroup>
-        <SettingsGroup eyebrow="Request" title="Ask someone to share">
-          <div className="space-y-4 px-[var(--settings-row-px)] py-[var(--settings-row-py)]">
-            <Skeleton className="h-11 rounded-xl" />
-            <Skeleton className="h-24 rounded-xl" />
-            <Skeleton className="h-10 w-40 rounded-xl" />
+          <div className="flex flex-wrap gap-2">
+            <Skeleton className="h-8 w-32 rounded-full" />
+            <Skeleton className="h-8 w-24 rounded-full" />
           </div>
-        </SettingsGroup>
-      </div>
-      <div className="space-y-6">
-        <SettingsGroup eyebrow="Approvals" title="Pending requests">
-          <SkeletonRow />
-        </SettingsGroup>
-        <SettingsGroup eyebrow="Location" title="Shared with me">
-          <SkeletonRow wide />
-        </SettingsGroup>
-      </div>
+          <Skeleton className="h-12 w-full rounded-[16px]" />
+        </div>
+      </section>
+
+      <section className="space-y-2 px-1">
+        {sectionLabel("Approvals")}
+        <div className={cn(onePanelClassName, "flex items-center gap-3 p-3.5")}>
+          <Skeleton className="h-9 w-9 shrink-0 rounded-full" />
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-4 w-40 rounded-lg" />
+            <Skeleton className="h-3 w-56 max-w-full rounded-lg" />
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-2 px-1">
+        {sectionLabel("Create public link")}
+        <div className={cn(onePanelClassName, "space-y-3 p-3.5")}>
+          <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_150px]">
+            <Skeleton className="h-10 rounded-[12px]" />
+            <Skeleton className="h-10 rounded-[12px]" />
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Skeleton className="h-10 w-full rounded-full sm:w-44" />
+            <Skeleton className="h-10 w-full rounded-full sm:w-24" />
+            <Skeleton className="h-10 w-full rounded-full sm:w-24" />
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-2 px-1">
+        {sectionLabel("Shared with me")}
+        <div className={cn(onePanelClassName, "flex items-center gap-3 p-3.5")}>
+          <Skeleton className="h-9 w-9 shrink-0 rounded-full" />
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-4 w-40 rounded-lg" />
+            <Skeleton className="h-3 w-64 max-w-full rounded-lg" />
+          </div>
+        </div>
+      </section>
     </div>
   );
 }
@@ -1267,9 +1330,12 @@ function OneLocationOnboardingFlow({
   const isPermissionStep = step === "permission";
 
   return (
-    <main className="min-h-dvh w-full bg-white text-[#1d1d1f] dark:bg-[#050506] dark:text-white">
+    <main
+      className="fixed inset-0 z-[540] h-dvh min-h-[100svh] w-full overflow-hidden bg-white text-[#1d1d1f] dark:bg-[#050506] dark:text-white"
+      data-no-route-swipe
+    >
       <NativeTestBeacon {...nativeTest} />
-      <div className="mx-auto flex min-h-dvh w-full max-w-[430px] flex-col overflow-hidden bg-white dark:bg-[#050506]">
+      <div className="mx-auto flex h-full min-h-0 w-full max-w-[430px] flex-col overflow-hidden bg-white dark:bg-[#050506]">
         <div className="h-[calc(env(safe-area-inset-top,0px)+24px)] shrink-0" />
         <section className="flex min-h-0 flex-1 flex-col items-center justify-center overflow-y-auto px-[clamp(24px,7vw,34px)] py-3 [-webkit-overflow-scrolling:touch]">
           <div
@@ -1959,11 +2025,15 @@ function OneLocationAgentPageContent() {
   }, [auth.loading, refresh]);
 
   useEffect(() => {
-    if (!auth.userId || auth.loading || loadError) {
+    if (auth.loading) {
+      setLocationOnboardingGate("checking");
+      return;
+    }
+    if (!auth.userId || loadError) {
       setLocationOnboardingGate("hidden");
       return;
     }
-    if (!state) {
+    if (!vaultOwnerToken) {
       setLocationOnboardingGate("checking");
       return;
     }
@@ -1981,7 +2051,7 @@ function OneLocationAgentPageContent() {
     auth.userId,
     loadError,
     locationOnboardingGate,
-    state,
+    vaultOwnerToken,
   ]);
 
   useEffect(() => {
@@ -3207,9 +3277,8 @@ function OneLocationAgentPageContent() {
 
   const showLocationOnboarding =
     locationOnboardingGate === "show" &&
-    !showInitialSkeleton &&
     !loadError &&
-    Boolean(auth.userId && state);
+    Boolean(auth.userId && vaultOwnerToken);
 
   if (showLocationOnboarding) {
     return (
@@ -3229,7 +3298,7 @@ function OneLocationAgentPageContent() {
       width="standard"
       nativeTest={nativeTestConfig}
     >
-      <AppPageHeaderRegion className="mx-auto w-full max-w-[860px] min-w-0 overflow-hidden">
+      <AppPageHeaderRegion className="mx-auto w-full max-w-[540px] min-w-0 overflow-hidden">
         <div className="flex flex-col gap-4 px-1 pt-3 sm:flex-row sm:items-end sm:justify-between">
           <header className="max-w-[560px] min-w-0 space-y-2">
             <span className="text-[11px] font-bold uppercase tracking-[0.22em] text-[#007aff] dark:text-[#76b7ff]">
@@ -3263,7 +3332,7 @@ function OneLocationAgentPageContent() {
         </div>
       </AppPageHeaderRegion>
 
-      <AppPageContentRegion className="mx-auto w-full max-w-[860px] min-w-0 space-y-6 overflow-x-hidden pb-10 sm:pb-8">
+      <AppPageContentRegion className="mx-auto w-full max-w-[540px] min-w-0 space-y-6 overflow-x-hidden pb-10 sm:pb-8">
         {loadError ? (
           <div className="rounded-[20px] border border-[#ff3b30]/30 bg-[#ff3b30]/10 p-4 text-sm text-[#ff3b30] dark:text-[#ff9f9a]">
             {loadError}

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -128,7 +128,6 @@ const SHOW_LOCATION_ACTIVITY_SECTION = false;
 const SHOW_OWNER_GRANTS_SECTION = false;
 const SHOW_PUBLIC_RESPONSES_SECTION = false;
 const SHOW_REFERRAL_SECTION = false;
-const ONE_LOCATION_ONBOARDING_STORAGE_PREFIX = "one_location_onboarding_v1";
 
 type BusyState =
   | "load"
@@ -1134,34 +1133,6 @@ function OneLocationInitialSkeleton() {
   );
 }
 
-function oneLocationOnboardingStorageKey(userId: string): string {
-  return `${ONE_LOCATION_ONBOARDING_STORAGE_PREFIX}:${userId}`;
-}
-
-function readOneLocationOnboardingDismissed(userId: string): boolean {
-  if (typeof window === "undefined") return false;
-  try {
-    const value = window.localStorage.getItem(
-      oneLocationOnboardingStorageKey(userId),
-    );
-    return value === "done" || value === "skipped";
-  } catch {
-    return false;
-  }
-}
-
-function writeOneLocationOnboardingDismissed(
-  userId: string,
-  status: "done" | "skipped",
-) {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(oneLocationOnboardingStorageKey(userId), status);
-  } catch {
-    // Non-blocking: private browsing or storage restrictions should not trap users.
-  }
-}
-
 function OneLocationIntroMapIllustration() {
   return (
     <div
@@ -1990,13 +1961,8 @@ function OneLocationAgentPageContent() {
       setLocationOnboardingGate("checking");
       return;
     }
-    if (permission?.state === "granted") {
-      writeOneLocationOnboardingDismissed(auth.userId, "done");
-      setLocationOnboardingGate("hidden");
-      return;
-    }
-    if (readOneLocationOnboardingDismissed(auth.userId)) {
-      setLocationOnboardingGate("hidden");
+
+    if (locationOnboardingGate === "hidden") {
       return;
     }
 
@@ -2009,7 +1975,6 @@ function OneLocationAgentPageContent() {
     auth.userId,
     loadError,
     locationOnboardingGate,
-    permission?.state,
     state,
   ]);
 
@@ -3149,38 +3114,41 @@ function OneLocationAgentPageContent() {
     }
   }, [ensureForegroundLocationReady]);
 
-  const dismissLocationOnboarding = useCallback(
-    (status: "done" | "skipped") => {
-      if (auth.userId) {
-        writeOneLocationOnboardingDismissed(auth.userId, status);
-      }
-      setLocationOnboardingGate("hidden");
-      setLocationOnboardingBusy(false);
-    },
-    [auth.userId],
-  );
+  const dismissLocationOnboarding = useCallback(() => {
+    setLocationOnboardingGate("hidden");
+    setLocationOnboardingBusy(false);
+  }, []);
 
   const handleContinueLocationOnboardingIntro = useCallback(() => {
     setLocationOnboardingStep("permission");
   }, []);
 
   const handleSkipLocationOnboarding = useCallback(() => {
-    dismissLocationOnboarding("skipped");
+    dismissLocationOnboarding();
   }, [dismissLocationOnboarding]);
 
   const handleLocationOnboardingPermission = useCallback(async () => {
     if (locationOnboardingBusy) return;
     setLocationOnboardingBusy(true);
     try {
+      if (permission?.state === "granted" && !isLocationServicesDisabled(permission)) {
+        const nextPermission = await refreshLocationPermission();
+        if (
+          nextPermission.state === "granted" &&
+          !isLocationServicesDisabled(nextPermission)
+        ) {
+          dismissLocationOnboarding();
+          return;
+        }
+      }
       const result = await ensureForegroundLocationReady({
         capturePoint: false,
         autoOpenSettings: false,
         requestNativePrompt: true,
       });
       const nextPermission = await refreshLocationPermission();
-      if (result.ready || nextPermission.state === "granted") {
-        dismissLocationOnboarding("done");
-      }
+      if (!result.ready && nextPermission.state !== "granted") return;
+      dismissLocationOnboarding();
     } finally {
       setLocationOnboardingBusy(false);
     }
@@ -3188,6 +3156,7 @@ function OneLocationAgentPageContent() {
     dismissLocationOnboarding,
     ensureForegroundLocationReady,
     locationOnboardingBusy,
+    permission,
     refreshLocationPermission,
   ]);
 

--- a/hushh-webapp/app/one/location/request/[token]/page-client.tsx
+++ b/hushh-webapp/app/one/location/request/[token]/page-client.tsx
@@ -5,23 +5,17 @@ import { useParams } from "next/navigation";
 import {
   AlertTriangle,
   CheckCircle2,
-  Loader2,
   MapPin,
   Navigation,
   Route,
-  Send,
 } from "lucide-react";
-import { toast } from "sonner";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Textarea } from "@/components/ui/textarea";
 import { OneLocationService } from "@/lib/one-location/service";
 import type {
   OneLocationPublicInvite,
-  OneLocationPublicInviteSubmission,
   PlainLocationPoint,
 } from "@/lib/one-location/types";
 
@@ -127,15 +121,9 @@ export default function PublicLocationRequestPageClient() {
     [params?.token],
   );
   const [invite, setInvite] = useState<OneLocationPublicInvite | null>(null);
-  const [submission, setSubmission] =
-    useState<OneLocationPublicInviteSubmission | null>(null);
   const [publicLocation, setPublicLocation] =
     useState<PlainLocationPoint | null>(null);
-  const [visitorDisplayName, setVisitorDisplayName] = useState("");
-  const [phoneNumber, setPhoneNumber] = useState("");
-  const [message, setMessage] = useState("");
   const [loading, setLoading] = useState(true);
-  const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -146,7 +134,10 @@ export default function PublicLocationRequestPageClient() {
       try {
         const response =
           await OneLocationService.resolvePublicInvite(publicToken);
-        if (!cancelled) setInvite(response.invite);
+        if (!cancelled) {
+          setInvite(response.invite);
+          setPublicLocation(response.publicLocation ?? null);
+        }
       } catch (loadError) {
         if (!cancelled) {
           setError(
@@ -169,33 +160,6 @@ export default function PublicLocationRequestPageClient() {
       cancelled = true;
     };
   }, [publicToken]);
-
-  const handleSubmit = async () => {
-    if (!visitorDisplayName.trim() || !phoneNumber.trim()) {
-      toast.error("Enter your name and phone number.");
-      return;
-    }
-    setSubmitting(true);
-    try {
-      const response = await OneLocationService.submitPublicInviteRequest({
-        publicToken,
-        visitorDisplayName: visitorDisplayName.trim(),
-        phoneNumber: phoneNumber.trim(),
-        message: message.trim() || undefined,
-      });
-      setSubmission(response.submission);
-      setPublicLocation(response.publicLocation ?? null);
-      toast.success("Location ready.");
-    } catch (submitError) {
-      toast.error(
-        submitError instanceof Error
-          ? submitError.message
-          : "Could not open this public location.",
-      );
-    } finally {
-      setSubmitting(false);
-    }
-  };
 
   return (
     <main className="min-h-screen bg-background text-foreground">
@@ -225,7 +189,7 @@ export default function PublicLocationRequestPageClient() {
                     ? error
                     : publicLocation
                       ? `${ownerLabel(invite)} shared this public location with you.`
-                      : `Enter your details to view ${ownerLabel(invite)}'s public location.`}
+                      : "This public link is active, but no location snapshot is attached."}
               </p>
             </div>
           </div>
@@ -233,13 +197,12 @@ export default function PublicLocationRequestPageClient() {
           {loading ? (
             <div className="space-y-3">
               <Skeleton className="h-11 rounded-xl" />
-              <Skeleton className="h-11 rounded-xl" />
               <Skeleton className="h-24 rounded-xl" />
               <Skeleton className="h-10 w-36 rounded-xl" />
             </div>
           ) : null}
 
-          {!loading && invite && !submission ? (
+          {!loading && invite ? (
             <div className="space-y-4">
               <div className="flex flex-wrap items-center gap-2 text-sm">
                 <Badge variant="secondary">
@@ -249,49 +212,14 @@ export default function PublicLocationRequestPageClient() {
                   {invite.durationHours}h public viewing window
                 </Badge>
               </div>
-              <Input
-                value={visitorDisplayName}
-                onChange={(event) => setVisitorDisplayName(event.target.value)}
-                placeholder="Your name"
-                autoComplete="name"
-                maxLength={120}
-              />
-              <Input
-                value={phoneNumber}
-                onChange={(event) => setPhoneNumber(event.target.value)}
-                placeholder="Phone number"
-                type="tel"
-                inputMode="tel"
-                autoComplete="tel"
-                maxLength={32}
-              />
-              <Textarea
-                value={message}
-                onChange={(event) => setMessage(event.target.value)}
-                placeholder="Optional message"
-                rows={4}
-                maxLength={500}
-              />
-              <Button onClick={() => void handleSubmit()} disabled={submitting}>
-                {submitting ? (
-                  <Loader2
-                    className="mr-2 h-4 w-4 animate-spin"
-                    aria-hidden="true"
-                  />
-                ) : (
-                  <Send className="mr-2 h-4 w-4" aria-hidden="true" />
-                )}
-                View Location
-              </Button>
-            </div>
-          ) : null}
-
-          {submission && publicLocation ? (
-            <PublicLocationMap point={publicLocation} />
-          ) : submission ? (
-            <div className="rounded-[var(--app-card-radius-standard)] border border-amber-500/30 bg-amber-500/10 p-4 text-sm leading-6 text-amber-800 dark:text-amber-100">
-              This link was opened, but no public location snapshot is attached.
-              Ask the sender to create a fresh public location link.
+              {publicLocation ? (
+                <PublicLocationMap point={publicLocation} />
+              ) : (
+                <div className="rounded-[var(--app-card-radius-standard)] border border-amber-500/30 bg-amber-500/10 p-4 text-sm leading-6 text-amber-800 dark:text-amber-100">
+                  This link opened correctly, but no public location is attached.
+                  Ask the sender to create a fresh public location link.
+                </div>
+              )}
             </div>
           ) : null}
         </div>

--- a/hushh-webapp/app/one/location/request/[token]/page-client.tsx
+++ b/hushh-webapp/app/one/location/request/[token]/page-client.tsx
@@ -5,8 +5,10 @@ import { useParams } from "next/navigation";
 import {
   AlertTriangle,
   CheckCircle2,
-  Clock3,
   Loader2,
+  MapPin,
+  Navigation,
+  Route,
   Send,
 } from "lucide-react";
 import { toast } from "sonner";
@@ -20,6 +22,7 @@ import { OneLocationService } from "@/lib/one-location/service";
 import type {
   OneLocationPublicInvite,
   OneLocationPublicInviteSubmission,
+  PlainLocationPoint,
 } from "@/lib/one-location/types";
 
 function formatDateTime(value?: string | null): string {
@@ -38,6 +41,85 @@ function ownerLabel(invite: OneLocationPublicInvite | null): string {
   return invite?.ownerLabel || "a trusted person";
 }
 
+function formatCoordinate(value: number): string {
+  return Number.isFinite(value) ? value.toFixed(6) : "0.000000";
+}
+
+function coordinateQuery(point: PlainLocationPoint): string {
+  return `${formatCoordinate(point.latitude)},${formatCoordinate(point.longitude)}`;
+}
+
+function googleMapsEmbedUrl(point: PlainLocationPoint): string {
+  return `https://www.google.com/maps?q=${encodeURIComponent(coordinateQuery(point))}&z=16&output=embed`;
+}
+
+function googleMapsDirectionsUrl(point: PlainLocationPoint): string {
+  return `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(
+    coordinateQuery(point),
+  )}&travelmode=driving`;
+}
+
+function googleMapsStartUrl(point: PlainLocationPoint): string {
+  return `${googleMapsDirectionsUrl(point)}&dir_action=navigate`;
+}
+
+function PublicLocationMap({ point }: { point: PlainLocationPoint }) {
+  const capturedAt = formatDateTime(point.capturedAt);
+  const accuracy =
+    typeof point.accuracyM === "number" && Number.isFinite(point.accuracyM)
+      ? `Accuracy +/- ${Math.round(point.accuracyM)} m`
+      : null;
+  return (
+    <div className="overflow-hidden rounded-[var(--app-card-radius-standard)] border border-border/70 bg-background">
+      <div className="relative h-64 overflow-hidden bg-muted">
+        <iframe
+          title="Public location map"
+          src={googleMapsEmbedUrl(point)}
+          loading="lazy"
+          referrerPolicy="no-referrer-when-downgrade"
+          allowFullScreen
+          className="h-full w-full border-0"
+        />
+        <div className="pointer-events-none absolute left-3 top-3 inline-flex items-center gap-2 rounded-full border border-emerald-300/40 bg-emerald-950/75 px-3 py-1.5 text-xs font-semibold text-emerald-50 shadow-lg backdrop-blur-xl">
+          <span className="h-2 w-2 animate-pulse rounded-full bg-emerald-300" />
+          Public location
+        </div>
+      </div>
+      <div className="space-y-3 p-3">
+        <div className="min-w-0">
+          <p className="text-sm font-semibold">Shared location</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Updated {capturedAt}
+            {accuracy ? ` - ${accuracy}` : ""}
+          </p>
+        </div>
+        <div className="grid gap-2 sm:grid-cols-2">
+          <Button asChild variant="outline" size="sm" className="h-10 rounded-full">
+            <a
+              href={googleMapsDirectionsUrl(point)}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Route className="h-4 w-4" aria-hidden="true" />
+              Directions
+            </a>
+          </Button>
+          <Button asChild size="sm" className="h-10 rounded-full">
+            <a
+              href={googleMapsStartUrl(point)}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Navigation className="h-4 w-4" aria-hidden="true" />
+              Start
+            </a>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function PublicLocationRequestPageClient() {
   const params = useParams<{ token?: string }>();
   const publicToken = useMemo(
@@ -47,6 +129,8 @@ export default function PublicLocationRequestPageClient() {
   const [invite, setInvite] = useState<OneLocationPublicInvite | null>(null);
   const [submission, setSubmission] =
     useState<OneLocationPublicInviteSubmission | null>(null);
+  const [publicLocation, setPublicLocation] =
+    useState<PlainLocationPoint | null>(null);
   const [visitorDisplayName, setVisitorDisplayName] = useState("");
   const [phoneNumber, setPhoneNumber] = useState("");
   const [message, setMessage] = useState("");
@@ -68,7 +152,7 @@ export default function PublicLocationRequestPageClient() {
           setError(
             loadError instanceof Error
               ? loadError.message
-              : "This request link is unavailable.",
+              : "This public location link is unavailable.",
           );
         }
       } finally {
@@ -78,7 +162,7 @@ export default function PublicLocationRequestPageClient() {
     if (publicToken) {
       void loadInvite();
     } else {
-      setError("This request link is invalid.");
+      setError("This public location link is invalid.");
       setLoading(false);
     }
     return () => {
@@ -100,22 +184,18 @@ export default function PublicLocationRequestPageClient() {
         message: message.trim() || undefined,
       });
       setSubmission(response.submission);
-      toast.success("Request sent.");
+      setPublicLocation(response.publicLocation ?? null);
+      toast.success("Location ready.");
     } catch (submitError) {
       toast.error(
         submitError instanceof Error
           ? submitError.message
-          : "Could not send request.",
+          : "Could not open this public location.",
       );
     } finally {
       setSubmitting(false);
     }
   };
-
-  const submittedCopy =
-    submission?.status === "matched_request_pending"
-      ? "Request sent. The owner must approve before encrypted location appears in your One Location Agent."
-      : "Request sent. Sign in with this phone and open One Location Agent once so the owner can approve encrypted sharing.";
 
   return (
     <main className="min-h-screen bg-background text-foreground">
@@ -125,10 +205,10 @@ export default function PublicLocationRequestPageClient() {
             <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-amber-500/10 text-amber-700 dark:text-amber-200">
               {error ? (
                 <AlertTriangle className="h-5 w-5" aria-hidden="true" />
-              ) : submission ? (
+              ) : publicLocation ? (
                 <CheckCircle2 className="h-5 w-5" aria-hidden="true" />
               ) : (
-                <Clock3 className="h-5 w-5" aria-hidden="true" />
+                <MapPin className="h-5 w-5" aria-hidden="true" />
               )}
             </div>
             <div className="min-w-0 flex-1">
@@ -136,14 +216,16 @@ export default function PublicLocationRequestPageClient() {
                 One Location
               </div>
               <h1 className="mt-2 text-3xl font-semibold tracking-normal sm:text-4xl">
-                Request location access
+                View shared location
               </h1>
               <p className="mt-3 text-sm leading-6 text-muted-foreground">
                 {loading
-                  ? "Checking request link."
+                  ? "Checking public location link."
                   : error
                     ? error
-                    : `${ownerLabel(invite)} will decide before location is shared.`}
+                    : publicLocation
+                      ? `${ownerLabel(invite)} shared this public location with you.`
+                      : `Enter your details to view ${ownerLabel(invite)}'s public location.`}
               </p>
             </div>
           </div>
@@ -164,7 +246,7 @@ export default function PublicLocationRequestPageClient() {
                   Expires {formatDateTime(invite.expiresAt)}
                 </Badge>
                 <Badge variant="outline">
-                  {invite.durationHours}h request window
+                  {invite.durationHours}h public viewing window
                 </Badge>
               </div>
               <Input
@@ -199,14 +281,17 @@ export default function PublicLocationRequestPageClient() {
                 ) : (
                   <Send className="mr-2 h-4 w-4" aria-hidden="true" />
                 )}
-                Send Request
+                View Location
               </Button>
             </div>
           ) : null}
 
-          {submission ? (
-            <div className="rounded-[var(--app-card-radius-standard)] border border-emerald-500/30 bg-emerald-500/10 p-4 text-sm leading-6 text-emerald-800 dark:text-emerald-100">
-              {submittedCopy}
+          {submission && publicLocation ? (
+            <PublicLocationMap point={publicLocation} />
+          ) : submission ? (
+            <div className="rounded-[var(--app-card-radius-standard)] border border-amber-500/30 bg-amber-500/10 p-4 text-sm leading-6 text-amber-800 dark:text-amber-100">
+              This link was opened, but no public location snapshot is attached.
+              Ask the sender to create a fresh public location link.
             </div>
           ) : null}
         </div>

--- a/hushh-webapp/app/one/location/request/[token]/page-client.tsx
+++ b/hushh-webapp/app/one/location/request/[token]/page-client.tsx
@@ -179,7 +179,7 @@ export default function PublicLocationRequestPageClient() {
               <div className="text-xs font-semibold uppercase tracking-[0.22em] text-amber-600 dark:text-amber-300">
                 One Location
               </div>
-              <h1 className="mt-2 text-3xl font-semibold tracking-normal sm:text-4xl">
+              <h1 className="mt-2 text-[28px] font-medium leading-[1.12] tracking-normal sm:text-[32px]">
                 View shared location
               </h1>
               <p className="mt-3 text-sm leading-6 text-muted-foreground">

--- a/hushh-webapp/app/profile/page.tsx
+++ b/hushh-webapp/app/profile/page.tsx
@@ -725,7 +725,6 @@ function ProfilePageContent() {
   const [marketplaceOptIn, setMarketplaceOptIn] = useState(false);
   const [loadingMarketplaceOptIn, setLoadingMarketplaceOptIn] = useState(true);
   const [savingMarketplaceOptIn, setSavingMarketplaceOptIn] = useState(false);
-  const [locationContextEnabled, setLocationContextEnabled] = useState(false);
   const [riaOnboardingStatus, setRiaOnboardingStatus] =
     useState<RiaOnboardingStatus | null>(null);
   const [loadingRiaOnboardingStatus, setLoadingRiaOnboardingStatus] =
@@ -2032,15 +2031,6 @@ function ProfilePageContent() {
         voiceAliases: ["access", "sharing", "consent access"],
       },
       {
-        id: "profile_location_context",
-        label: "Location",
-        purpose:
-          "toggles nearby advisors and local market hours on this device.",
-        actionId: "profile.location_context",
-        role: "switch",
-        voiceAliases: ["location", "nearby advisors", "local market hours"],
-      },
-      {
         id: "profile_vault",
         label: vaultSettingsRow.title,
         purpose: vaultSettingsRow.voicePurpose,
@@ -2155,7 +2145,6 @@ function ProfilePageContent() {
           "Access & sharing",
           "Gmail receipts",
           "Email",
-          "Location",
           "Preferences",
           "Security",
           "Support & feedback",
@@ -2194,7 +2183,6 @@ function ProfilePageContent() {
                   "Open Access & sharing",
                   "Open Gmail receipts",
                   "Open Email",
-                  locationContextEnabled ? "Turn off Location" : "Turn on Location",
                   "Open Support",
                 ];
 
@@ -2253,11 +2241,6 @@ function ProfilePageContent() {
             id: "email",
             title: "Email",
             purpose: "Requests and approval drafts.",
-          },
-          {
-            id: "location",
-            title: "Location",
-            purpose: "Nearby advisors and local market hours.",
           },
           {
             id: "support",
@@ -2332,7 +2315,6 @@ function ProfilePageContent() {
         google_email: gmail.status?.google_email || null,
         pkm_agent_lab_available: canShowPkmAgentLab,
         marketplace_opt_in: marketplaceOptIn,
-        location_context_enabled: locationContextEnabled,
         ria_regulatory_profile_visible: shouldShowRiaRegulatoryRow,
         ria_license_number: currentRiaLicenseNumber || null,
         ria_regulator: currentRiaRegulator,
@@ -2356,7 +2338,6 @@ function ProfilePageContent() {
     gmailStatusSummary.title,
     gmail.status?.google_email,
     lastVoiceControlId,
-    locationContextEnabled,
     marketplaceOptIn,
     passphraseDialogOpen,
     pendingConsents,
@@ -4266,30 +4247,6 @@ function ProfilePageContent() {
                   }
                   router.push(ROUTES.ONE_KYC);
                 }}
-              />
-              <SettingsRow
-                icon={MapPin}
-                title="Location"
-                description={
-                  locationContextEnabled
-                    ? "While using the app - every read is receipted."
-                    : "Nearby advisors and local market hours. Off by default."
-                }
-                trailing={
-                  <Switch
-                    checked={locationContextEnabled}
-                    aria-label="Toggle location"
-                    onPointerDown={(event) => {
-                      event.stopPropagation();
-                    }}
-                    onClick={(event) => event.stopPropagation()}
-                    onCheckedChange={setLocationContextEnabled}
-                  />
-                }
-                voiceControlId="profile_location_context"
-                voiceActionId="profile.location_context"
-                voiceLabel="Location"
-                voicePurpose="Nearby advisors and local market hours."
               />
             </SettingsGroup>
 

--- a/hushh-webapp/app/register-phone/page.tsx
+++ b/hushh-webapp/app/register-phone/page.tsx
@@ -9,6 +9,10 @@ import { HushhLoader } from "@/components/app-ui/hushh-loader";
 import { NativeRouteMarker } from "@/components/app-ui/native-route-marker";
 import { PhoneVerificationFlow } from "@/components/auth/phone-verification-flow";
 import { VaultLockGuard } from "@/components/vault/vault-lock-guard";
+import {
+  kaiAppHeroBodyClassName,
+  kaiAppHeroTitleClassName,
+} from "@/components/kai/shared/kai-typography";
 import { useAuth } from "@/lib/firebase/auth-context";
 import { ROUTES } from "@/lib/navigation/routes";
 import { AccountIdentityService } from "@/lib/services/account-identity-service";
@@ -142,11 +146,11 @@ function PhoneMandatePageContent() {
             role="heading"
             aria-level={1}
             aria-label="Verify your phone number"
-            className="mt-2.5 text-[38px] font-medium leading-[1.05] tracking-normal text-[#1d1d1f] sm:text-[40px] dark:text-[#f5f5f7]"
+            className={`mt-2.5 ${kaiAppHeroTitleClassName} text-[#1d1d1f] dark:text-[#f5f5f7]`}
           >
             Verify your phone number
           </div>
-          <p className="mx-auto mt-3 max-w-[20rem] text-[17px] font-normal leading-[1.42] tracking-normal text-[rgba(0,0,0,0.56)] sm:text-[18px] dark:text-[rgba(245,245,247,0.60)]">
+          <p className={`mx-auto mt-3 max-w-[20rem] ${kaiAppHeroBodyClassName} text-[rgba(0,0,0,0.56)] dark:text-[rgba(245,245,247,0.60)]`}>
             Add your phone number to continue.
           </p>
         </header>

--- a/hushh-webapp/app/register-phone/page.tsx
+++ b/hushh-webapp/app/register-phone/page.tsx
@@ -22,9 +22,9 @@ import { shouldBypassPhoneMandateForLocalhost } from "@/lib/services/phone-manda
 const FLOW_SHELL_STYLE = {
   "--page-top-local-offset": "0px",
   "--phone-mandate-safe-pt":
-    "calc(var(--app-safe-area-top-effective, env(safe-area-inset-top, 0px)) + 3rem)",
+    "calc(var(--app-safe-area-top-effective, env(safe-area-inset-top, 0px)) + 1.25rem)",
   "--phone-mandate-safe-pb":
-    "calc(var(--app-safe-area-bottom-effective, env(safe-area-inset-bottom, 0px)) + 2.5rem)",
+    "calc(var(--app-safe-area-bottom-effective, env(safe-area-inset-bottom, 0px)) + 1.25rem)",
 } as CSSProperties;
 
 function requiresVaultUnlockForRedirect(path?: string | null): boolean {
@@ -121,7 +121,7 @@ function PhoneMandatePageContent() {
     <FullscreenFlowShell
       as="main"
       width="narrow"
-      className="min-h-[100dvh] px-6 pb-[var(--phone-mandate-safe-pb)] pt-[var(--phone-mandate-safe-pt)]"
+      className="h-[100dvh] min-h-[100svh] justify-center overflow-hidden px-6 pb-[var(--phone-mandate-safe-pb)] pt-[var(--phone-mandate-safe-pt)]"
       style={FLOW_SHELL_STYLE}
     >
       <NativeRouteMarker
@@ -162,7 +162,7 @@ function PhoneMandatePageContent() {
           onCompleted={continueToNextRoute}
           onContinueExisting={continueToNextRoute}
           confirmLabel="Verify and continue"
-          className="mt-8 min-h-[24rem] gap-5"
+          className="mt-8 gap-5"
         />
 
         <div id="recaptcha-container" className="mt-6 min-h-0" />

--- a/hushh-webapp/app/register-phone/page.tsx
+++ b/hushh-webapp/app/register-phone/page.tsx
@@ -135,12 +135,12 @@ function PhoneMandatePageContent() {
           <Image
             src="/one-quiet-emoji.png"
             alt=""
-            width={48}
-            height={48}
+            width={44}
+            height={44}
             priority
             aria-hidden="true"
             draggable={false}
-            className="mx-auto h-12 w-12 select-none object-contain drop-shadow-[0_14px_28px_rgba(0,0,0,0.08)]"
+            className="mx-auto h-11 w-11 select-none object-contain drop-shadow-[0_12px_24px_rgba(0,0,0,0.08)]"
           />
           <div
             role="heading"

--- a/hushh-webapp/app/register-phone/page.tsx
+++ b/hushh-webapp/app/register-phone/page.tsx
@@ -10,8 +10,8 @@ import { NativeRouteMarker } from "@/components/app-ui/native-route-marker";
 import { PhoneVerificationFlow } from "@/components/auth/phone-verification-flow";
 import { VaultLockGuard } from "@/components/vault/vault-lock-guard";
 import {
-  kaiAppHeroBodyClassName,
-  kaiAppHeroTitleClassName,
+  kaiAppBodyClassName,
+  kaiAppCompactTitleClassName,
 } from "@/components/kai/shared/kai-typography";
 import { useAuth } from "@/lib/firebase/auth-context";
 import { ROUTES } from "@/lib/navigation/routes";
@@ -135,22 +135,22 @@ function PhoneMandatePageContent() {
           <Image
             src="/one-quiet-emoji.png"
             alt=""
-            width={52}
-            height={52}
+            width={48}
+            height={48}
             priority
             aria-hidden="true"
             draggable={false}
-            className="mx-auto h-[52px] w-[52px] select-none object-contain drop-shadow-[0_14px_28px_rgba(0,0,0,0.08)]"
+            className="mx-auto h-12 w-12 select-none object-contain drop-shadow-[0_14px_28px_rgba(0,0,0,0.08)]"
           />
           <div
             role="heading"
             aria-level={1}
             aria-label="Verify your phone number"
-            className={`mt-2.5 ${kaiAppHeroTitleClassName} text-[#1d1d1f] dark:text-[#f5f5f7]`}
+            className={`mt-2.5 ${kaiAppCompactTitleClassName} text-[#1d1d1f] dark:text-[#f5f5f7]`}
           >
             Verify your phone number
           </div>
-          <p className={`mx-auto mt-3 max-w-[20rem] ${kaiAppHeroBodyClassName} text-[rgba(0,0,0,0.56)] dark:text-[rgba(245,245,247,0.60)]`}>
+          <p className={`mx-auto mt-2.5 max-w-[20rem] ${kaiAppBodyClassName} text-[rgba(0,0,0,0.56)] dark:text-[rgba(245,245,247,0.60)]`}>
             Add your phone number to continue.
           </p>
         </header>
@@ -162,7 +162,7 @@ function PhoneMandatePageContent() {
           onCompleted={continueToNextRoute}
           onContinueExisting={continueToNextRoute}
           confirmLabel="Verify and continue"
-          className="mt-10 min-h-[25rem] gap-5"
+          className="mt-8 min-h-[24rem] gap-5"
         />
 
         <div id="recaptcha-container" className="mt-6 min-h-0" />

--- a/hushh-webapp/capacitor.config.ts
+++ b/hushh-webapp/capacitor.config.ts
@@ -23,6 +23,9 @@ const NORMALIZED_BACKEND_URL = (() => {
   const backendHost = hostFromUrl(normalized);
 
   if (process.env.CAPACITOR_PLATFORM !== "android") return normalized;
+  if (process.env.NEXT_PUBLIC_ANDROID_LOCAL_BACKEND_MODE === "adb_reverse") {
+    return normalized;
+  }
   // Android emulator cannot reach host loopback; use 10.0.2.2
   if (backendHost === "localhost") {
     return normalized.replace("localhost", "10.0.2.2");

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -27,6 +27,7 @@ import {
   ThumbsDown,
   ThumbsUp,
   UserRound,
+  X,
 } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -2774,6 +2775,19 @@ export function AgentChatWorkspace({
                   title="Minimize Agent"
                 >
                   <Minus className="h-4 w-4" />
+                </Button>
+              ) : null}
+              {isPopover && onMinimize ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-9 w-9 rounded-lg text-[rgba(0,0,0,0.56)] hover:bg-black/[0.04] hover:text-[#1d1d1f] focus-visible:ring-2 focus-visible:ring-primary/60 dark:text-zinc-300 dark:hover:bg-white/[0.07] dark:hover:text-zinc-50 sm:hidden"
+                  onClick={onMinimize}
+                  aria-label="Close Agent"
+                  title="Close Agent"
+                >
+                  <X className="h-4 w-4" />
                 </Button>
               ) : null}
               {windowControls ? <div className="ml-1">{windowControls}</div> : null}

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -288,10 +288,10 @@ function AgentWelcomePanel({
           <Sparkles className="h-3.5 w-3.5 text-primary" />
           Kai workspace
         </div>
-        <h2 className="text-4xl font-medium tracking-normal text-[#1d1d1f] sm:text-5xl dark:text-zinc-50">
+        <h2 className="text-[34px] font-medium leading-[1.08] tracking-normal text-foreground sm:text-[38px]">
           Hi {name}
         </h2>
-        <p className="mt-3 max-w-xl text-base leading-7 text-[rgba(0,0,0,0.56)] sm:text-lg dark:text-zinc-400">
+        <p className="mt-3 max-w-xl text-[16px] leading-7 text-muted-foreground sm:text-[17px]">
           Ask Agent about your markets, portfolio, memories, or Hushh workflows.
         </p>
         <div className="mt-8 grid gap-3 sm:grid-cols-3">
@@ -2668,10 +2668,10 @@ export function AgentChatWorkspace({
   return (
     <div
       className={cn(
-        "agent-chat-workspace flex min-h-0 w-full flex-col text-[#1d1d1f] dark:text-zinc-100",
+        "agent-chat-workspace flex min-h-0 w-full flex-col text-foreground",
         isPopover
-          ? "h-full overflow-hidden bg-white dark:bg-[#0d0f13]"
-          : "h-[calc(100dvh-var(--app-top-content-offset,0px)-var(--app-bottom-fixed-ui,0px)-var(--app-safe-area-bottom-effective,0px))] min-h-[420px] overflow-hidden bg-white dark:bg-[#0b0d10]",
+          ? "h-full overflow-hidden bg-background"
+          : "h-[calc(100dvh-var(--app-top-content-offset,0px)-var(--app-bottom-fixed-ui,0px)-var(--app-safe-area-bottom-effective,0px))] min-h-[420px] overflow-hidden bg-background",
         className
       )}
       data-agent-chat-workspace={variant}
@@ -2713,14 +2713,14 @@ export function AgentChatWorkspace({
 
         <section
           className={cn(
-            "relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-white dark:bg-[#15171c]",
+            "relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background",
             isPopover && "rounded-lg border border-black/10 shadow-sm dark:border-white/10"
           )}
           inert={isHistoryDrawerOpen}
         >
           <div
             className={cn(
-              "flex shrink-0 touch-pan-y items-center justify-between gap-3 border-b border-black/10 bg-white/95 px-3 pt-[var(--app-safe-area-top-effective,0px)] backdrop-blur dark:border-white/10 dark:bg-[#15171c]/95 sm:px-5",
+              "flex shrink-0 touch-pan-y items-center justify-between gap-3 border-b border-border/70 bg-background/92 px-3 pt-[var(--app-safe-area-top-effective,0px)] backdrop-blur sm:px-5",
               isPopover
                 ? "h-14 sm:h-16"
                 : "h-[calc(3.5rem+var(--app-safe-area-top-effective,0px))] sm:h-[calc(4rem+var(--app-safe-area-top-effective,0px))]",
@@ -2750,10 +2750,10 @@ export function AgentChatWorkspace({
                 <Bot className="h-4 w-4" />
               </div>
               <div className="min-w-0">
-                <div className="truncate text-sm font-semibold leading-5 text-[#1d1d1f] sm:text-base dark:text-zinc-100">
+                <div className="truncate text-sm font-medium leading-5 text-foreground sm:text-base">
                   Agent
                 </div>
-                <p className="hidden truncate text-xs text-[rgba(0,0,0,0.46)] dark:text-zinc-500 sm:block">
+                <p className="hidden truncate text-xs text-muted-foreground sm:block">
                   Kai workspace
                 </p>
               </div>
@@ -2788,7 +2788,7 @@ export function AgentChatWorkspace({
           >
             <div className="mx-auto flex min-h-full w-full max-w-3xl flex-col gap-6">
               {accessMessage ? (
-                <div className="flex flex-col gap-3 rounded-xl border border-black/10 bg-black/[0.035] px-4 py-4 text-sm text-[rgba(0,0,0,0.56)] dark:border-white/10 dark:bg-white/[0.03] dark:text-zinc-400 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex flex-col gap-3 rounded-xl border border-border/70 bg-muted/35 px-4 py-4 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
                   <span>{accessMessage}</span>
                   {accessAction ? (
                     <Button
@@ -2890,7 +2890,7 @@ export function AgentChatWorkspace({
           <form
             onSubmit={handleSubmit}
             className={cn(
-              "shrink-0 border-t border-black/10 bg-white/95 px-3 py-3 backdrop-blur dark:border-white/10 dark:bg-[#15171c]/95 sm:px-5",
+              "shrink-0 border-t border-border/70 bg-background/92 px-3 py-3 backdrop-blur sm:px-5",
               !isPopover && "pb-[calc(0.75rem+var(--app-safe-area-bottom-effective,0px))]"
             )}
           >

--- a/hushh-webapp/components/agent/agent-popover-provider.tsx
+++ b/hushh-webapp/components/agent/agent-popover-provider.tsx
@@ -304,10 +304,14 @@ function AgentPopoverSurface({ customSize, setCustomSize }: AgentPopoverSurfaceP
   const pathname = usePathname();
   const { expanded, hasOpened, motionState, sizeMode, setSizeMode, openAgent, minimizeAgent } =
     useAgentPopover();
+  const chromeState = getKaiChromeState(pathname);
   const isLegacyAgentRoute = pathname === ROUTES.AGENT;
   const isPhoneMandateRoute = pathname?.startsWith(ROUTES.PHONE_MANDATE);
-  const canShowAgent = isAuthenticated && !isLegacyAgentRoute && !isPhoneMandateRoute;
-  const chromeState = getKaiChromeState(pathname);
+  const canShowAgent =
+    isAuthenticated &&
+    !isLegacyAgentRoute &&
+    !isPhoneMandateRoute &&
+    !chromeState.hideCommandBar;
   const isKaiSurfaceRoute = Boolean(pathname?.startsWith("/kai"));
   const useEmbeddedAgentTrigger =
     isKaiSurfaceRoute || isRiaActionBarRoute(pathname) || !chromeState.hideCommandBar;

--- a/hushh-webapp/components/auth/phone-verification-flow.tsx
+++ b/hushh-webapp/components/auth/phone-verification-flow.tsx
@@ -370,9 +370,11 @@ export function PhoneVerificationFlow({
                 open={countryComboboxOpen}
                 onOpenChange={(open) => {
                   setCountryComboboxOpen(open);
-                  setCountryQuery(
-                    getCountryOptionLabel(selectedCountryOption ?? COUNTRY_PHONE_OPTIONS[0]!)
-                  );
+                  if (!open) {
+                    setCountryQuery(
+                      getCountryOptionLabel(selectedCountryOption ?? COUNTRY_PHONE_OPTIONS[0]!)
+                    );
+                  }
                 }}
                 value={selectedCountry}
                 onValueChange={handleCountrySelection}
@@ -390,6 +392,7 @@ export function PhoneVerificationFlow({
                   }}
                   onFocus={(event: React.FocusEvent<HTMLInputElement>) => {
                     setCountryComboboxOpen(true);
+                    setCountryQuery("");
                     event.currentTarget.select();
                   }}
                   className={`${FLOW_CONTROL_SHELL_CLASS_NAME} w-full`}

--- a/hushh-webapp/components/auth/phone-verification-flow.tsx
+++ b/hushh-webapp/components/auth/phone-verification-flow.tsx
@@ -349,9 +349,9 @@ export function PhoneVerificationFlow({
         </div>
         <Button
           onClick={() => void onContinueExisting?.()}
-          size="lg"
+          size="default"
           fullWidth
-          className={`mt-6 h-12 ${FLOW_SURFACE_RADIUS_CLASS_NAME}`}
+          className={`mt-6 h-12 text-[16px] font-medium ${FLOW_SURFACE_RADIUS_CLASS_NAME}`}
         >
           Continue
         </Button>
@@ -450,21 +450,21 @@ export function PhoneVerificationFlow({
             <Button
               onClick={() => void handleStartVerification(false)}
               loading={busy}
-              size="lg"
+              size="default"
               fullWidth
-              className={`h-12 ${FLOW_SURFACE_RADIUS_CLASS_NAME}`}
+              className={`h-12 text-[16px] font-medium ${FLOW_SURFACE_RADIUS_CLASS_NAME}`}
             >
               {busy ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : "Send verification code"}
             </Button>
             {onCancel ? (
               <Button
-                onClick={onCancel}
-                variant="none"
-                effect="fade"
-                fullWidth
-                disabled={busy}
-                className={`h-12 ${FLOW_SURFACE_RADIUS_CLASS_NAME}`}
-              >
+              onClick={onCancel}
+              variant="none"
+              effect="fade"
+              fullWidth
+              disabled={busy}
+              className={`h-12 text-[15px] font-medium ${FLOW_SURFACE_RADIUS_CLASS_NAME}`}
+            >
                 Cancel
               </Button>
             ) : null}
@@ -501,9 +501,9 @@ export function PhoneVerificationFlow({
             <Button
               onClick={() => void handleConfirmVerification()}
               loading={busy}
-              size="lg"
+              size="default"
               fullWidth
-              className={`h-12 ${FLOW_SURFACE_RADIUS_CLASS_NAME}`}
+              className={`h-12 text-[16px] font-medium ${FLOW_SURFACE_RADIUS_CLASS_NAME}`}
             >
               {busy ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : confirmLabel || "Verify and continue"}
             </Button>
@@ -511,10 +511,10 @@ export function PhoneVerificationFlow({
               onClick={() => void handleStartVerification(true)}
               variant="none"
               effect="glass"
-              size="lg"
+              size="default"
               fullWidth
               disabled={busy}
-              className={`h-12 ${FLOW_SURFACE_RADIUS_CLASS_NAME}`}
+              className={`h-12 text-[15px] font-medium ${FLOW_SURFACE_RADIUS_CLASS_NAME}`}
             >
               Resend code
             </Button>
@@ -526,7 +526,7 @@ export function PhoneVerificationFlow({
             effect="fade"
             fullWidth
             disabled={busy}
-            className={`h-12 ${FLOW_SURFACE_RADIUS_CLASS_NAME}`}
+            className={`h-12 text-[15px] font-medium ${FLOW_SURFACE_RADIUS_CLASS_NAME}`}
           >
             Use a different number
           </Button>

--- a/hushh-webapp/components/kai/cards/allocation-strip.tsx
+++ b/hushh-webapp/components/kai/cards/allocation-strip.tsx
@@ -60,7 +60,7 @@ export function AllocationStrip({ cashPct, equitiesPct, bondsPct }: AllocationSt
 
   return (
     <div className="space-y-2 rounded-xl border border-border/60 bg-card/70 p-4">
-      <h3 className="text-[11px] font-black uppercase tracking-[0.16em] text-muted-foreground">Allocation</h3>
+      <h3 className="text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">Allocation</h3>
       <div className="h-3 w-full overflow-hidden rounded-full bg-muted">
         <div className="flex h-full w-full">
           {segments.map((segment) => (

--- a/hushh-webapp/components/kai/cards/connect-portfolio-cta.tsx
+++ b/hushh-webapp/components/kai/cards/connect-portfolio-cta.tsx
@@ -12,7 +12,7 @@ export function ConnectPortfolioCta() {
     <SurfaceCard accent="emerald">
       <SurfaceCardContent className="space-y-4 p-6 text-center">
         <div className="space-y-2">
-          <h3 className="text-lg font-black tracking-tight">
+          <h3 className="text-lg font-semibold tracking-tight">
             See insights tailored to your portfolio
           </h3>
           <p className="text-sm text-muted-foreground">

--- a/hushh-webapp/components/kai/cards/dashboard-summary-hero.tsx
+++ b/hushh-webapp/components/kai/cards/dashboard-summary-hero.tsx
@@ -59,7 +59,7 @@ export function DashboardSummaryHero({
       <CardContent className="space-y-4 p-5 sm:p-6">
         <div className="space-y-2 text-center">
           <p className="text-sm font-medium text-muted-foreground">Total portfolio value</p>
-          <div className="flex items-center justify-center gap-2">
+          <div className="flex flex-wrap items-center justify-center gap-2">
             <Badge className="rounded-full bg-muted px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
               Risk: {normalizeRiskLabel(riskLabel)}
             </Badge>
@@ -72,14 +72,12 @@ export function DashboardSummaryHero({
               </Badge>
             )}
           </div>
-          <h2 className="text-[34px] font-medium leading-tight tracking-normal">{formatCurrency(totalValue)}</h2>
+          <h2 className="text-[28px] font-medium leading-tight tracking-normal sm:text-[32px]">{formatCurrency(totalValue)}</h2>
           <div className="flex items-center justify-center gap-2 text-sm">
-            <span className={positive ? "text-emerald-600" : "text-red-500"}>
-              <span className="inline-flex items-center font-medium">
-                <Icon icon={positive ? ArrowUpRight : ArrowDownRight} size="sm" className="mr-1" />
-                {formatChange(netChange)} ({changePct >= 0 ? "+" : ""}
-                {changePct.toFixed(2)}%)
-              </span>
+            <span className={positive ? "inline-flex items-center font-medium text-emerald-600 dark:text-emerald-400" : "inline-flex items-center font-medium text-rose-500 dark:text-rose-400"}>
+              <Icon icon={positive ? ArrowUpRight : ArrowDownRight} size="sm" className="mr-1" />
+              {formatChange(netChange)} ({changePct >= 0 ? "+" : ""}
+              {changePct.toFixed(2)}%)
             </span>
             <span className="text-muted-foreground">•</span>
             <span className="font-medium text-muted-foreground">{periodLabel}</span>

--- a/hushh-webapp/components/kai/cards/holding-position-card.tsx
+++ b/hushh-webapp/components/kai/cards/holding-position-card.tsx
@@ -43,11 +43,11 @@ export function HoldingPositionCard({ holding, onAnalyze, onManage }: HoldingPos
       <CardContent className="space-y-3 p-4">
         <div className="flex items-start justify-between">
           <div className="flex items-center gap-3">
-            <div className="grid h-10 w-10 place-items-center rounded-xl bg-muted text-xs font-black text-foreground">
+            <div className="grid h-10 w-10 place-items-center rounded-xl bg-muted text-xs font-semibold text-foreground">
               {tickerFallback(holding.symbol)}
             </div>
             <div>
-              <h4 className="text-sm font-black leading-tight">{holding.name}</h4>
+              <h4 className="text-sm font-semibold leading-tight">{holding.name}</h4>
               <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
                 {holding.symbol}
               </span>
@@ -78,17 +78,17 @@ export function HoldingPositionCard({ holding, onAnalyze, onManage }: HoldingPos
 
         <div className="grid grid-cols-2 gap-3 text-sm">
           <div>
-            <p className="text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground">Shares @ Price</p>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">Shares @ Price</p>
             <p className="font-medium">
               {holding.quantity.toLocaleString()} @ {formatCurrency(holding.price)}
             </p>
           </div>
           <div className="text-right">
-            <p className="text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground">Market Value</p>
-            <p className="font-black">{formatCurrency(holding.marketValue)}</p>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">Market Value</p>
+            <p className="font-semibold">{formatCurrency(holding.marketValue)}</p>
           </div>
           <div>
-            <p className="text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground">Gain/Loss</p>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">Gain/Loss</p>
             <p className={positive ? "font-semibold text-emerald-600" : "font-semibold text-red-500"}>
               {positive ? "+" : "-"}
               {formatCurrency(Math.abs(holding.gainLossValue))} ({holding.gainLossPct >= 0 ? "+" : ""}

--- a/hushh-webapp/components/kai/cards/kpi-card.tsx
+++ b/hushh-webapp/components/kai/cards/kpi-card.tsx
@@ -113,14 +113,14 @@ export function KPICard({
               {icon}
             </div>
           )}
-          <span className={cn("text-muted-foreground uppercase font-black tracking-widest leading-none", styles.title)}>
+          <span className={cn("text-muted-foreground uppercase font-semibold tracking-widest leading-none", styles.title)}>
             {title}
           </span>
         </div>
 
         {/* Value */}
         <p
-          className={cn("font-black tracking-tighter leading-tight", styles.value)}
+          className={cn("font-semibold tracking-tighter leading-tight", styles.value)}
           aria-label={`${title}: ${value}`}
         >
           {value}

--- a/hushh-webapp/components/kai/cards/new-holding-cta-card.tsx
+++ b/hushh-webapp/components/kai/cards/new-holding-cta-card.tsx
@@ -16,7 +16,7 @@ export function NewHoldingCtaCard({ onAddHolding, onImportStatement }: NewHoldin
     <Card variant="none" effect="glass" preset="default">
       <CardContent className="space-y-4 p-5">
         <div className="space-y-1">
-          <h4 className="text-sm font-black">New Holding Entry</h4>
+          <h4 className="text-sm font-semibold">New Holding Entry</h4>
           <p className="text-xs text-muted-foreground">
             Use Manage Portfolio for full edits, or import another statement for bulk updates.
           </p>

--- a/hushh-webapp/components/kai/cards/profile-based-picks-list.tsx
+++ b/hushh-webapp/components/kai/cards/profile-based-picks-list.tsx
@@ -151,7 +151,7 @@ export function ProfileBasedPicksList({
   return (
     <div className="space-y-2">
       <div className="space-y-0.5">
-        <h3 className="text-sm font-black">Personalized picks</h3>
+        <h3 className="text-sm font-semibold">Personalized picks</h3>
         <p className="text-[11px] text-muted-foreground">
           Source: Kai risk profile ({riskProfile}) + current holdings context.
         </p>
@@ -177,11 +177,11 @@ export function ProfileBasedPicksList({
                 className="flex items-center justify-between gap-3 p-3"
               >
                 <div className="flex min-w-0 items-center gap-3">
-                  <div className="grid h-9 w-9 place-items-center rounded-full border border-border/70 bg-muted text-[11px] font-black">
+                  <div className="grid h-9 w-9 place-items-center rounded-full border border-border/70 bg-muted text-[11px] font-semibold">
                     {pick.symbol}
                   </div>
                   <div className="min-w-0">
-                    <p className="truncate text-sm font-bold leading-tight">{pick.company_name}</p>
+                    <p className="truncate text-sm font-medium leading-tight">{pick.company_name}</p>
                     <p className="truncate text-xs font-medium text-muted-foreground">
                       {(pick.tier || "Tier N/A").toUpperCase()}
                       {pick.sector ? ` • ${pick.sector}` : ""}

--- a/hushh-webapp/components/kai/cards/renaissance-verdict-card.tsx
+++ b/hushh-webapp/components/kai/cards/renaissance-verdict-card.tsx
@@ -150,14 +150,14 @@ export function RenaissanceVerdictCard({
           </p>
           <div className="flex items-center gap-2">
             <VerdictIcon signal={signal} className={tone.icon} />
-            <p className={cn("text-xl font-bold tracking-tight", tone.label)}>
+            <p className={cn("text-base font-medium leading-tight tracking-normal", tone.label)}>
               {label}
             </p>
           </div>
         </div>
         <Badge
           variant="outline"
-          className={cn("shrink-0 text-[10px] font-bold uppercase tracking-wide", tone.badge)}
+          className={cn("shrink-0 text-[10px] font-semibold uppercase tracking-wide", tone.badge)}
         >
           {signal}
         </Badge>

--- a/hushh-webapp/components/kai/cards/spotlight-card.tsx
+++ b/hushh-webapp/components/kai/cards/spotlight-card.tsx
@@ -85,19 +85,19 @@ export function SpotlightCard(props: {
             <div className="flex min-w-0 items-start gap-3">
               <SymbolAvatar symbol={props.symbol} name={props.companyName} size="md" />
               <div className="min-w-0 space-y-1">
-                <h3 className="text-base font-black tracking-tight leading-tight">{props.title}</h3>
+                <h3 className="text-[15.5px] font-medium leading-tight tracking-normal sm:text-base">{props.title}</h3>
                 <p className="text-sm text-muted-foreground">{props.price}</p>
               </div>
             </div>
             <div className="flex items-center gap-1.5">
               {props.confidenceLabel ? (
-                <span className="inline-flex items-center rounded-full bg-background/75 px-2 py-1 text-[10px] font-bold tracking-wide text-muted-foreground transition-colors duration-200 group-hover:bg-background/85">
+                <span className="inline-flex items-center rounded-full bg-background/75 px-2 py-1 text-[10px] font-medium tracking-wide text-muted-foreground transition-colors duration-200 group-hover:bg-background/85">
                   {props.confidenceLabel}
                 </span>
               ) : null}
               <span
                 className={cn(
-                  "inline-flex items-center rounded-full px-3 py-1 text-[11px] font-extrabold tracking-wide",
+                  "inline-flex items-center rounded-full px-3 py-1 text-[11px] font-semibold tracking-wide",
                   decisionTone
                 )}
               >
@@ -106,7 +106,7 @@ export function SpotlightCard(props: {
             </div>
           </div>
 
-          <p className="text-sm font-medium leading-relaxed">{props.summary}</p>
+          <p className="text-sm font-normal leading-relaxed text-foreground/80">{props.summary}</p>
 
           <div className="flex items-center gap-2 border-t border-border/40 pt-3 text-xs text-muted-foreground transition-colors duration-200 group-hover:border-border/60">
             <Icon icon={LineChart} size="sm" />

--- a/hushh-webapp/components/kai/home/movers-tabs.tsx
+++ b/hushh-webapp/components/kai/home/movers-tabs.tsx
@@ -60,7 +60,7 @@ export function MoversTabs({ movers }: MoversTabsProps) {
   return (
     <Card variant="none" effect="glass" preset="compact">
       <CardContent className="space-y-3 p-4">
-        <p className="text-sm font-black tracking-tight">Market Movers</p>
+        <p className="text-sm font-semibold tracking-tight">Market Movers</p>
 
         <div className="flex gap-2 overflow-x-auto pb-1">
           {TABS.map((item) => (

--- a/hushh-webapp/components/kai/home/sector-rotation-card.tsx
+++ b/hushh-webapp/components/kai/home/sector-rotation-card.tsx
@@ -27,7 +27,7 @@ export function SectorRotationCard({ rows }: SectorRotationCardProps) {
   return (
     <Card variant="none" effect="glass" preset="compact">
       <CardContent className="space-y-3 p-4">
-        <p className="text-sm font-black tracking-tight">Sector Rotation</p>
+        <p className="text-sm font-semibold tracking-tight">Sector Rotation</p>
         <div className="space-y-2">
           {rows.slice(0, 6).map((row) => {
             const pct = typeof row.change_pct === "number" ? row.change_pct : 0;

--- a/hushh-webapp/components/kai/home/signal-chips.tsx
+++ b/hushh-webapp/components/kai/home/signal-chips.tsx
@@ -24,7 +24,7 @@ export function SignalChips({ signals }: SignalChipsProps) {
         <Card key={signal.id} variant="none" effect="glass" preset="compact">
           <CardContent className="space-y-2 p-3">
             <div className="flex items-start justify-between gap-2">
-              <p className="text-sm font-black tracking-tight">{signal.title}</p>
+              <p className="text-sm font-semibold tracking-tight">{signal.title}</p>
               <span className="rounded-full bg-background/70 px-2 py-0.5 text-[10px] font-semibold text-muted-foreground">
                 {(signal.confidence * 100).toFixed(0)}%
               </span>

--- a/hushh-webapp/components/kai/home/watchlist-strip.tsx
+++ b/hushh-webapp/components/kai/home/watchlist-strip.tsx
@@ -40,7 +40,7 @@ export function WatchlistStrip({ items }: WatchlistStripProps) {
               <CardContent className="space-y-2 p-3">
                 <div className="flex items-start justify-between gap-2">
                   <div className="min-w-0">
-                    <p className="truncate text-sm font-black">{item.symbol}</p>
+                    <p className="truncate text-sm font-semibold">{item.symbol}</p>
                     <p className="truncate text-[11px] text-muted-foreground">{item.company_name}</p>
                   </div>
                   <span
@@ -51,7 +51,7 @@ export function WatchlistStrip({ items }: WatchlistStripProps) {
                 </div>
 
                 <div>
-                  <p className="text-base font-extrabold tracking-tight">{formatCurrency(item.price)}</p>
+                  <p className="text-base font-semibold tracking-tight">{formatCurrency(item.price)}</p>
                   <p
                     className={cn(
                       "text-xs font-semibold",

--- a/hushh-webapp/components/kai/kai-command-bar-global.tsx
+++ b/hushh-webapp/components/kai/kai-command-bar-global.tsx
@@ -5,6 +5,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 import { useAuth } from "@/hooks/use-auth";
 import { KaiSearchBar } from "@/components/kai/kai-search-bar";
+import { useOptionalAgentPopover } from "@/components/agent/agent-popover-provider";
 import { usePersonaState } from "@/lib/persona/persona-context";
 import { useKaiSession } from "@/lib/stores/kai-session-store";
 import { CacheService, CACHE_KEYS } from "@/lib/services/cache-service";
@@ -132,6 +133,7 @@ export function KaiCommandBarGlobal() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const agentPopover = useOptionalAgentPopover();
   const { user, loading } = useAuth();
   const {
     activePersona,
@@ -310,6 +312,8 @@ export function KaiCommandBarGlobal() {
     [pathname]
   );
   const voiceEligibleRoute = isVoiceEligibleRouteScreen(routeInfo.screen, chromeState.hideCommandBar);
+  const agentWindowOpen =
+    agentPopover?.expanded || agentPopover?.motionState === "opening";
 
   useEffect(() => {
     if (!voiceEligibleRoute) {
@@ -727,7 +731,7 @@ export function KaiCommandBarGlobal() {
     return null;
   }
 
-  if (chromeState.hideCommandBar) {
+  if (chromeState.hideCommandBar || agentWindowOpen) {
     return null;
   }
 

--- a/hushh-webapp/components/kai/kai-command-bar-global.tsx
+++ b/hushh-webapp/components/kai/kai-command-bar-global.tsx
@@ -241,6 +241,9 @@ export function KaiCommandBarGlobal() {
   const reviewScreenActive = Boolean(
     busyOperations["portfolio_review_active"] || busyOperations["portfolio_save"]
   );
+  const portfolioImportSurfaceActive = Boolean(
+    busyOperations["portfolio_import_surface"]
+  );
   const reviewDirty = Boolean(
     busyOperations["portfolio_review_active"] && busyOperations["portfolio_review_dirty"]
   );
@@ -727,7 +730,7 @@ export function KaiCommandBarGlobal() {
     ]
   );
 
-  if (!mounted || loading || !user || reviewScreenActive) {
+  if (!mounted || loading || !user || reviewScreenActive || portfolioImportSurfaceActive) {
     return null;
   }
 

--- a/hushh-webapp/components/kai/kai-command-palette.tsx
+++ b/hushh-webapp/components/kai/kai-command-palette.tsx
@@ -31,6 +31,7 @@ import {
 import { searchKaiActions } from "@/lib/voice/kai-action-gateway";
 import type { AppRuntimeState } from "@/lib/voice/voice-types";
 import { Icon } from "@/lib/morphy-ux/ui";
+import { cn } from "@/lib/utils";
 
 export type KaiCommandPaletteSelection = {
   actionId: string;
@@ -406,16 +407,19 @@ export function KaiCommandPalette({
           value={query}
           onValueChange={setQuery}
           placeholder="Run Kai command or search ticker..."
-          className="pr-24"
+          className="pr-28"
         />
-        <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1.5">
+        <div className="absolute right-2.5 top-1/2 flex -translate-y-1/2 items-center gap-1.5">
           {!voiceHidden ? (
             <button
               type="button"
               aria-label={voiceActive ? "End Kai voice" : "Start Kai voice"}
               aria-disabled={voiceDisabled}
               onClick={onVoiceClick}
-              className="inline-flex h-9 w-9 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-black/[0.045] hover:text-foreground dark:hover:bg-white/10"
+              className={cn(
+                "inline-flex h-9 w-9 items-center justify-center rounded-full transition-colors hover:bg-black/[0.045] hover:text-foreground dark:hover:bg-white/10",
+                voiceActive ? "bg-primary text-primary-foreground hover:bg-primary/90" : "text-muted-foreground"
+              )}
             >
               <Mic className="h-4 w-4" strokeWidth={1.9} aria-hidden="true" />
             </button>

--- a/hushh-webapp/components/kai/kai-command-palette.tsx
+++ b/hushh-webapp/components/kai/kai-command-palette.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type MouseEvent } from "react";
 import {
   Activity,
   Compass,
   History,
+  Mic,
   Search,
   ShieldCheck,
   UserRound,
+  X,
 } from "lucide-react";
 
 import {
@@ -40,6 +42,10 @@ interface KaiCommandPaletteProps {
   onOpenChange: (open: boolean) => void;
   onSelectAction: (selection: KaiCommandPaletteSelection) => void;
   appRuntimeState?: AppRuntimeState;
+  onVoiceClick?: (event: MouseEvent<HTMLButtonElement>) => void;
+  voiceActive?: boolean;
+  voiceDisabled?: boolean;
+  voiceHidden?: boolean;
   portfolioTickers?: Array<{
     symbol: string;
     name?: string;
@@ -147,6 +153,10 @@ export function KaiCommandPalette({
   onOpenChange,
   onSelectAction,
   appRuntimeState,
+  onVoiceClick,
+  voiceActive = false,
+  voiceDisabled = false,
+  voiceHidden = false,
   portfolioTickers = [],
 }: KaiCommandPaletteProps) {
   const [query, setQuery] = useState("");
@@ -388,13 +398,38 @@ export function KaiCommandPalette({
     <CommandDialog
       open={open}
       onOpenChange={onOpenChange}
+      showCloseButton={false}
       className="top-[calc(var(--top-shell-reserved-height,0px)+0.75rem)] max-h-[min(70dvh,32rem)] w-[calc(100%-1rem)] translate-y-0 sm:top-1/2 sm:w-full sm:max-h-none sm:-translate-y-1/2"
     >
-      <CommandInput
-        value={query}
-        onValueChange={setQuery}
-        placeholder="Run Kai command or search ticker..."
-      />
+      <div className="relative">
+        <CommandInput
+          value={query}
+          onValueChange={setQuery}
+          placeholder="Run Kai command or search ticker..."
+          className="pr-24"
+        />
+        <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1.5">
+          {!voiceHidden ? (
+            <button
+              type="button"
+              aria-label={voiceActive ? "End Kai voice" : "Start Kai voice"}
+              aria-disabled={voiceDisabled}
+              onClick={onVoiceClick}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-black/[0.045] hover:text-foreground dark:hover:bg-white/10"
+            >
+              <Mic className="h-4 w-4" strokeWidth={1.9} aria-hidden="true" />
+            </button>
+          ) : null}
+          <button
+            type="button"
+            aria-label="Close command search"
+            onClick={() => onOpenChange(false)}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-black/[0.045] hover:text-foreground dark:hover:bg-white/10"
+          >
+            <X className="h-4 w-4" strokeWidth={1.9} aria-hidden="true" />
+          </button>
+        </div>
+      </div>
       <CommandList className="max-h-[min(56dvh,24rem)] sm:max-h-[300px]">
         <CommandEmpty>{commandEmptyMessage}</CommandEmpty>
 

--- a/hushh-webapp/components/kai/kai-flow.tsx
+++ b/hushh-webapp/components/kai/kai-flow.tsx
@@ -660,6 +660,19 @@ export function KaiFlow({
     stateRef.current = state;
   }, [state]);
 
+  const portfolioImportSurfaceActive =
+    state === "import_required" ||
+    state === "importing" ||
+    state === "import_complete" ||
+    state === "reviewing";
+
+  useEffect(() => {
+    setBusyOperation("portfolio_import_surface", portfolioImportSurfaceActive);
+    return () => {
+      setBusyOperation("portfolio_import_surface", false);
+    };
+  }, [portfolioImportSurfaceActive, setBusyOperation]);
+
   useScrollReset(`${mode}:${state}`, { enabled: true, behavior: "auto" });
 
   const plaidPortfolioData =

--- a/hushh-webapp/components/kai/kai-search-bar.tsx
+++ b/hushh-webapp/components/kai/kai-search-bar.tsx
@@ -9,7 +9,7 @@ import {
   useState,
   type MouseEvent,
 } from "react";
-import { Bot, Mic, Search, X } from "lucide-react";
+import { Mic, Search, X } from "lucide-react";
 
 import {
   KaiCommandPalette,
@@ -20,7 +20,6 @@ import {
 } from "@/components/kai/voice/voice-ambient-search-surface";
 import { VoiceDebugDrawer } from "@/components/kai/voice/voice-debug-drawer";
 import { ShellActionSurface } from "@/components/app-ui/shell-action-surface";
-import { useOptionalAgentPopover } from "@/components/agent/agent-popover-provider";
 import { morphyToast as toast } from "@/lib/morphy-ux/morphy";
 import { useKaiBottomChromeVisibility } from "@/lib/navigation/kai-bottom-chrome-visibility";
 import { KAI_COMMAND_BAR_OPEN_EVENT } from "@/lib/navigation/kai-command-bar-events";
@@ -313,7 +312,6 @@ export function KaiSearchBar({
   portfolioTickers = [],
 }: KaiSearchBarProps) {
   const { getVaultOwnerToken, vaultKey } = useVault();
-  const agentPopover = useOptionalAgentPopover();
   const [open, setOpen] = useState(false);
   const [voiceDebugOpen, setVoiceDebugOpen] = useState(false);
   const [voiceUiState, setVoiceUiState] = useState<VoiceUiState>("idle");
@@ -1687,7 +1685,7 @@ export function KaiSearchBar({
         >
           {isRiaSurface ? (
             <div
-              className="grid grid-cols-3 gap-1.5 rounded-full border border-[color:var(--app-shell-surface-border)] bg-[color:var(--app-shell-surface-bg)] bg-[image:var(--app-shell-surface-fill)] p-1 shadow-[var(--app-shell-surface-shadow)] backdrop-blur-[var(--app-shell-surface-blur)]"
+              className="grid grid-cols-2 gap-1.5 rounded-full border border-[color:var(--app-shell-surface-border)] bg-[color:var(--app-shell-surface-bg)] bg-[image:var(--app-shell-surface-fill)] p-1 shadow-[var(--app-shell-surface-shadow)] backdrop-blur-[var(--app-shell-surface-blur)]"
               data-testid="ria-action-bar"
             >
               <ShellActionSurface
@@ -1722,40 +1720,17 @@ export function KaiSearchBar({
                 )}
                 <span className="truncate">Voice</span>
               </ShellActionSurface>
-              <ShellActionSurface
-                variant="pill"
-                wrapperClassName="w-full"
-                className="h-10 w-full min-w-0 px-2 text-[12px] sm:text-[13px]"
-                contentClassName="gap-1.5"
-                aria-label="Open Agent"
-                disabled={!agentPopover}
-                onClick={() => agentPopover?.openAgent()}
-              >
-                <Bot className="h-4 w-4 shrink-0" />
-                <span className="truncate">Agent</span>
-              </ShellActionSurface>
             </div>
           ) : (
-            <div className="relative flex h-[114px] w-full items-end justify-end">
+            <div className="relative flex h-[58px] w-full items-end justify-end">
               <div
                 className={cn(
-                  "ml-auto flex flex-col items-end justify-end gap-2 transition-[width] duration-200 ease-out",
+                  "ml-auto flex items-end justify-end transition-[width] duration-200 ease-out",
                   compactDockExpanded
                     ? "w-[min(15.5rem,calc(100vw-2rem))]"
                     : "w-[58px]"
                 )}
               >
-                <button
-                  type="button"
-                  className="pointer-events-auto grid h-12 w-12 place-items-center rounded-full transition-transform duration-200 ease-out hover:scale-[1.03] active:scale-[0.94] disabled:cursor-not-allowed disabled:opacity-50"
-                  aria-label="Open Kai agent"
-                  disabled={!agentPopover}
-                  onClick={() => agentPopover?.openAgent()}
-                >
-                  <span className="kai-bottom-agent-action grid h-[40px] w-[40px] place-items-center rounded-[14px]">
-                    <Bot className="h-[18px] w-[18px]" strokeWidth={1.95} />
-                  </span>
-                </button>
                 <div
                   className={cn(
                     "pointer-events-auto grid rounded-full kai-bottom-search-action p-[5px]",

--- a/hushh-webapp/components/kai/kai-search-bar.tsx
+++ b/hushh-webapp/components/kai/kai-search-bar.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import {
   useCallback,
   useEffect,
@@ -17,7 +16,6 @@ import {
   type KaiCommandPaletteSelection,
 } from "@/components/kai/kai-command-palette";
 import {
-  VoiceAmbientSearchSurface,
   type VoiceAmbientMode,
 } from "@/components/kai/voice/voice-ambient-search-surface";
 import { VoiceDebugDrawer } from "@/components/kai/voice/voice-debug-drawer";
@@ -329,15 +327,10 @@ export function KaiSearchBar({
     null,
   );
   const [transcriptPreview, setTranscriptPreview] = useState<string>("");
-  const [finalTranscript, setFinalTranscript] = useState<string>("");
+  const [_finalTranscript, setFinalTranscript] = useState<string>("");
   const [lastReplyText, setLastReplyText] = useState<string>("");
   const [micPermissionStatus, setMicPermissionStatus] =
     useState<string>("unknown");
-    // If the text is stored in finalTranscript:
-const debouncedSearch = useDebouncedValue(finalTranscript, 500);
-
-// OR, if there is a standard text input state further down like 'query':
-// const debouncedSearch = useDebouncedValue(query, 500);
   const [stableMicDisabledReason, setStableMicDisabledReason] = useState<
     string | null
   >(null);
@@ -694,7 +687,7 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
     ],
   );
 
-  const submitDebugTurn = useCallback(() => {
+  const _submitDebugTurn = useCallback(() => {
     if (!VOICE_V2_FLAGS.submitDebugVisible) return;
     if (!realtimeSessionReady) {
       toast.info("Realtime session still connecting.");
@@ -709,7 +702,7 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
     );
   }, [emitDebug, realtimeSessionReady]);
 
-  const toggleMuteListening = useCallback(() => {
+  const _toggleMuteListening = useCallback(() => {
     const nextMuted = voiceSessionManager.toggleMuted();
     setSessionMuted(nextMuted);
     if (nextMuted) {
@@ -744,7 +737,7 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
     setFinalTranscript("");
   }, [sessionScopeId, setPendingConfirmation, transitionVoiceState]);
 
-  const handleReplay = useCallback(async () => {
+  const _handleReplay = useCallback(async () => {
     const replayText = String(lastReplyText || "").trim();
     if (!replayText) return;
     const turnId = createVoiceTurnId();
@@ -774,7 +767,7 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
     transitionVoiceState,
   ]);
 
-  const handleStopSpeaking = useCallback(
+  const _handleStopSpeaking = useCallback(
     (event?: MouseEvent<HTMLButtonElement>) => {
       event?.preventDefault();
       event?.stopPropagation();
@@ -901,13 +894,13 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
     transitionVoiceState,
   ]);
 
-  const handleRetry = useCallback(async () => {
+  const _handleRetry = useCallback(async () => {
     setPendingConfirmation(null);
     transitionVoiceState("idle", "retry_button_clicked");
     await startListening();
   }, [setPendingConfirmation, startListening, transitionVoiceState]);
 
-  const handleConfirmPending = useCallback(async () => {
+  const _handleConfirmPending = useCallback(async () => {
     if (!pendingConfirmation || !onVoiceResponseRef.current) {
       return;
     }
@@ -1022,7 +1015,7 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
     transitionVoiceState,
   ]);
 
-  const handleCancelPending = useCallback(() => {
+  const _handleCancelPending = useCallback(() => {
     if (!pendingConfirmation) return;
     setPendingConfirmation(null);
     setProcessingStageText("Voice action canceled.");
@@ -1647,6 +1640,7 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
   const riaVoiceActive = ambientMode !== "idle";
   const riaVoiceDisabled =
     !riaVoiceActive && (disabled || micDisabled || voiceVisibilityMode === "hidden");
+  const compactDockExpanded = open || riaVoiceActive;
   const handleRiaVoiceClick = useCallback(
     (event: MouseEvent<HTMLButtonElement>) => {
       if (riaVoiceDisabled) {
@@ -1742,8 +1736,15 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
               </ShellActionSurface>
             </div>
           ) : (
-            <div className="relative flex h-[124px] w-full items-end justify-end">
-              <div className="ml-auto flex w-[min(17rem,calc(100vw-2rem))] flex-col items-end justify-end gap-2">
+            <div className="relative flex h-[114px] w-full items-end justify-end">
+              <div
+                className={cn(
+                  "ml-auto flex flex-col items-end justify-end gap-2 transition-[width] duration-200 ease-out",
+                  compactDockExpanded
+                    ? "w-[min(15.5rem,calc(100vw-2rem))]"
+                    : "w-[58px]"
+                )}
+              >
                 <button
                   type="button"
                   className="pointer-events-auto grid h-12 w-12 place-items-center rounded-full transition-transform duration-200 ease-out hover:scale-[1.03] active:scale-[0.94] disabled:cursor-not-allowed disabled:opacity-50"
@@ -1755,66 +1756,56 @@ const debouncedSearch = useDebouncedValue(finalTranscript, 500);
                     <Bot className="h-[18px] w-[18px]" strokeWidth={1.95} />
                   </span>
                 </button>
-                <div className="pointer-events-auto w-full rounded-full kai-bottom-search-action p-[5px]">
-                  <VoiceAmbientSearchSurface
-                    mode={ambientMode}
-                    placeholder="Analyze, dashboard, consent with Kai"
-                    transcriptPreview={transcriptPreview}
-                    stageText={processingStageText}
-                    replyText={
-                      showSpeakingCompact || showRetryCompact
-                        ? lastReplyText || debouncedSearch
-                        : debouncedSearch
-                    }
-                    smoothedLevel={smoothedLevel}
+                <div
+                  className={cn(
+                    "pointer-events-auto grid rounded-full kai-bottom-search-action p-[5px]",
+                    compactDockExpanded ? "w-full grid-cols-2 gap-1" : "w-[58px] grid-cols-1"
+                  )}
+                  data-testid="kai-compact-search-surface"
+                  data-mode={ambientMode}
+                >
+                  <span data-testid="voice-ambient-preview" className="sr-only">
+                    {transcriptPreview || processingStageText || ""}
+                  </span>
+                  <button
+                    type="button"
+                    data-tour-id="kai-command-bar"
+                    aria-label="Open Kai command search"
+                    aria-expanded={open}
+                    aria-haspopup="dialog"
                     disabled={disabled}
-                    showMic={!micHidden}
-                    micDisabled={micDisabled}
-                    micDisabledReason={stableMicDisabledReason}
-                    showDebug={DEV_VOICE_DEBUG_ENABLED}
-                    debugActive={voiceDebugOpen}
-                    showSubmit={
-                      VOICE_V2_FLAGS.submitDebugVisible &&
-                      (showVoiceSheet || realtimeConnecting)
-                    }
-                    submitEnabled={
-                      VOICE_V2_FLAGS.submitDebugVisible && realtimeSessionReady
-                    }
-                    ttsPlaying={ttsPlaybackState === "playing"}
-                    pendingConfirmation={Boolean(
-                      showRetryCompact && pendingConfirmation,
+                    onClick={() => setOpen(true)}
+                    className={cn(
+                      "inline-flex h-11 min-w-0 items-center justify-center rounded-full px-3 text-[13px] font-semibold text-muted-foreground transition-colors hover:bg-black/[0.045] hover:text-foreground disabled:pointer-events-none disabled:opacity-50 dark:hover:bg-white/10",
+                      open && "bg-primary/10 text-primary"
                     )}
-                    onOpenSearch={() => setOpen(true)}
-                    onMicToggle={handleMicTap}
-                    onDebugToggle={(event) => {
-                      event.stopPropagation();
-                      setVoiceDebugOpen((current) => !current);
-                    }}
-                    onMuteToggle={toggleMuteListening}
-                    onSubmit={submitDebugTurn}
-                    onEnd={cancelListening}
-                    onStopSpeaking={handleStopSpeaking}
-                    onReplay={
-                      showSpeakingCompact || showRetryCompact
-                        ? handleReplay
-                        : undefined
-                    }
-                    onRetry={
-                      showRetryCompact && !pendingConfirmation
-                        ? handleRetry
-                        : undefined
-                    }
-                    onConfirm={
-                      showRetryCompact && pendingConfirmation
-                        ? handleConfirmPending
-                        : undefined
-                    }
-                    onCancel={
-                      showRetryCompact && pendingConfirmation
-                        ? handleCancelPending
-                        : undefined
-                    }
-                  />
+                  >
+                    <Search className="h-5 w-5 shrink-0" strokeWidth={1.9} />
+                    {compactDockExpanded ? <span className="ml-1.5 truncate">Search</span> : null}
+                  </button>
+                  {compactDockExpanded ? (
+                    <button
+                      type="button"
+                      aria-label={riaVoiceActive ? "End Kai voice" : "Start Kai voice"}
+                      aria-disabled={riaVoiceDisabled}
+                      disabled={voiceVisibilityMode === "hidden"}
+                      onClick={handleRiaVoiceClick}
+                      className={cn(
+                        "inline-flex h-11 min-w-0 items-center justify-center rounded-full px-3 text-[13px] font-semibold transition-colors hover:bg-black/[0.045] disabled:cursor-not-allowed dark:hover:bg-white/10",
+                        riaVoiceActive
+                          ? "bg-primary text-primary-foreground hover:bg-primary/90"
+                          : "text-muted-foreground hover:text-foreground",
+                        riaVoiceDisabled && "opacity-60"
+                      )}
+                    >
+                      {riaVoiceActive ? (
+                        <X className="h-5 w-5 shrink-0" strokeWidth={1.9} />
+                      ) : (
+                        <Mic className="h-5 w-5 shrink-0" strokeWidth={1.9} />
+                      )}
+                      <span className="ml-1.5 truncate">Voice</span>
+                    </button>
+                  ) : null}
                 </div>
               </div>
             </div>

--- a/hushh-webapp/components/kai/kai-search-bar.tsx
+++ b/hushh-webapp/components/kai/kai-search-bar.tsx
@@ -1643,7 +1643,6 @@ export function KaiSearchBar({
   const riaVoiceActive = ambientMode !== "idle";
   const riaVoiceDisabled =
     !riaVoiceActive && (disabled || micDisabled || voiceVisibilityMode === "hidden");
-  const compactDockExpanded = open || riaVoiceActive;
   const handleRiaVoiceClick = useCallback(
     (event: MouseEvent<HTMLButtonElement>) => {
       if (riaVoiceDisabled) {
@@ -1692,7 +1691,7 @@ export function KaiSearchBar({
           ref={barRef}
           className={cn(
             "pointer-events-none w-full",
-            isRiaSurface ? "max-w-[360px] sm:max-w-[392px]" : "max-w-[560px]"
+            isRiaSurface ? "max-w-[360px] sm:max-w-[392px]" : "max-w-[630px]"
           )}
         >
           {isRiaSurface ? (
@@ -1744,7 +1743,7 @@ export function KaiSearchBar({
               </div>
             </div>
           ) : (
-            <div className="relative flex h-[112px] w-full items-end justify-end">
+            <div className="relative ml-auto flex h-[112px] w-[58px] items-end justify-end">
               <button
                 type="button"
                 aria-label="Open Agent"
@@ -1755,16 +1754,13 @@ export function KaiSearchBar({
               </button>
               <div
                 className={cn(
-                  "ml-auto flex items-end justify-end transition-[width] duration-200 ease-out",
-                  compactDockExpanded
-                    ? "w-[min(15.5rem,calc(100vw-2rem))]"
-                    : "w-[58px]"
+                  "ml-auto flex w-[58px] items-end justify-end"
                 )}
               >
                 <div
                   className={cn(
                     "pointer-events-auto grid rounded-full kai-bottom-search-action p-[5px]",
-                    compactDockExpanded ? "w-full grid-cols-2 gap-1" : "w-[58px] grid-cols-1"
+                    "w-[58px] grid-cols-1"
                   )}
                   data-testid="kai-compact-search-surface"
                   data-mode={ambientMode}
@@ -1786,31 +1782,8 @@ export function KaiSearchBar({
                     )}
                   >
                     <Search className="h-5 w-5 shrink-0" strokeWidth={1.9} />
-                    {compactDockExpanded ? <span className="ml-1.5 truncate">Search</span> : null}
+                    <span className="sr-only">Search</span>
                   </button>
-                  {compactDockExpanded ? (
-                    <button
-                      type="button"
-                      aria-label={riaVoiceActive ? "End Kai voice" : "Start Kai voice"}
-                      aria-disabled={riaVoiceDisabled}
-                      disabled={voiceVisibilityMode === "hidden"}
-                      onClick={handleRiaVoiceClick}
-                      className={cn(
-                        "inline-flex h-11 min-w-0 items-center justify-center rounded-full px-3 text-[13px] font-semibold transition-colors hover:bg-black/[0.045] disabled:cursor-not-allowed dark:hover:bg-white/10",
-                        riaVoiceActive
-                          ? "bg-primary text-primary-foreground hover:bg-primary/90"
-                          : "text-muted-foreground hover:text-foreground",
-                        riaVoiceDisabled && "opacity-60"
-                      )}
-                    >
-                      {riaVoiceActive ? (
-                        <X className="h-5 w-5 shrink-0" strokeWidth={1.9} />
-                      ) : (
-                        <Mic className="h-5 w-5 shrink-0" strokeWidth={1.9} />
-                      )}
-                      <span className="ml-1.5 truncate">Voice</span>
-                    </button>
-                  ) : null}
                 </div>
               </div>
             </div>

--- a/hushh-webapp/components/kai/kai-search-bar.tsx
+++ b/hushh-webapp/components/kai/kai-search-bar.tsx
@@ -9,7 +9,7 @@ import {
   useState,
   type MouseEvent,
 } from "react";
-import { Mic, Search, X } from "lucide-react";
+import { Bot, Mic, Search, X } from "lucide-react";
 
 import {
   KaiCommandPalette,
@@ -20,6 +20,7 @@ import {
 } from "@/components/kai/voice/voice-ambient-search-surface";
 import { VoiceDebugDrawer } from "@/components/kai/voice/voice-debug-drawer";
 import { ShellActionSurface } from "@/components/app-ui/shell-action-surface";
+import { useOptionalAgentPopover } from "@/components/agent/agent-popover-provider";
 import { morphyToast as toast } from "@/lib/morphy-ux/morphy";
 import { useKaiBottomChromeVisibility } from "@/lib/navigation/kai-bottom-chrome-visibility";
 import { KAI_COMMAND_BAR_OPEN_EVENT } from "@/lib/navigation/kai-command-bar-events";
@@ -312,6 +313,7 @@ export function KaiSearchBar({
   portfolioTickers = [],
 }: KaiSearchBarProps) {
   const { getVaultOwnerToken, vaultKey } = useVault();
+  const agentPopover = useOptionalAgentPopover();
   const [open, setOpen] = useState(false);
   const [voiceDebugOpen, setVoiceDebugOpen] = useState(false);
   const [voiceUiState, setVoiceUiState] = useState<VoiceUiState>("idle");
@@ -1659,6 +1661,9 @@ export function KaiSearchBar({
       stableMicDisabledReason,
     ],
   );
+  const handleAgentClick = useCallback(() => {
+    agentPopover?.openAgent();
+  }, [agentPopover]);
 
   return (
     <>
@@ -1684,45 +1689,65 @@ export function KaiSearchBar({
           )}
         >
           {isRiaSurface ? (
-            <div
-              className="grid grid-cols-2 gap-1.5 rounded-full border border-[color:var(--app-shell-surface-border)] bg-[color:var(--app-shell-surface-bg)] bg-[image:var(--app-shell-surface-fill)] p-1 shadow-[var(--app-shell-surface-shadow)] backdrop-blur-[var(--app-shell-surface-blur)]"
-              data-testid="ria-action-bar"
-            >
-              <ShellActionSurface
-                variant="pill"
-                wrapperClassName="w-full"
-                className="h-10 w-full min-w-0 px-2 text-[12px] sm:text-[13px]"
-                contentClassName="gap-1.5"
-                aria-label="Search RIA workspace"
-                aria-expanded={open}
-                aria-haspopup="dialog"
-                onClick={() => setOpen(true)}
+            <div className="relative flex w-full items-end justify-end">
+              <button
+                type="button"
+                aria-label="Open Agent"
+                onClick={handleAgentClick}
+                disabled={!agentPopover}
+                className="kai-bottom-agent-action pointer-events-auto absolute -top-[54px] right-1 inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/30 disabled:pointer-events-none disabled:opacity-50"
               >
-                <Search className="h-4 w-4 shrink-0" />
-                <span className="truncate">Search</span>
-              </ShellActionSurface>
-              <ShellActionSurface
-                variant="pill"
-                wrapperClassName="w-full"
-                contentClassName="gap-1.5"
-                aria-label={riaVoiceActive ? "End RIA voice session" : "Start RIA voice"}
-                aria-disabled={riaVoiceDisabled}
-                className={cn(
-                  "h-10 w-full min-w-0 px-2 text-[12px] sm:text-[13px]",
-                  riaVoiceDisabled && "opacity-60"
-                )}
-                onClick={handleRiaVoiceClick}
+                <Bot className="h-[18px] w-[18px]" strokeWidth={1.9} />
+              </button>
+              <div
+                className="grid w-full grid-cols-2 gap-1.5 rounded-full border border-[color:var(--app-shell-surface-border)] bg-[color:var(--app-shell-surface-bg)] bg-[image:var(--app-shell-surface-fill)] p-1 shadow-[var(--app-shell-surface-shadow)] backdrop-blur-[var(--app-shell-surface-blur)]"
+                data-testid="ria-action-bar"
               >
-                {riaVoiceActive ? (
-                  <X className="h-4 w-4 shrink-0" />
-                ) : (
-                  <Mic className="h-4 w-4 shrink-0" />
-                )}
-                <span className="truncate">Voice</span>
-              </ShellActionSurface>
+                <ShellActionSurface
+                  variant="pill"
+                  wrapperClassName="w-full"
+                  className="h-10 w-full min-w-0 px-2 text-[12px] sm:text-[13px]"
+                  contentClassName="gap-1.5"
+                  aria-label="Search RIA workspace"
+                  aria-expanded={open}
+                  aria-haspopup="dialog"
+                  onClick={() => setOpen(true)}
+                >
+                  <Search className="h-4 w-4 shrink-0" />
+                  <span className="truncate">Search</span>
+                </ShellActionSurface>
+                <ShellActionSurface
+                  variant="pill"
+                  wrapperClassName="w-full"
+                  contentClassName="gap-1.5"
+                  aria-label={riaVoiceActive ? "End RIA voice session" : "Start RIA voice"}
+                  aria-disabled={riaVoiceDisabled}
+                  className={cn(
+                    "h-10 w-full min-w-0 px-2 text-[12px] sm:text-[13px]",
+                    riaVoiceDisabled && "opacity-60"
+                  )}
+                  onClick={handleRiaVoiceClick}
+                >
+                  {riaVoiceActive ? (
+                    <X className="h-4 w-4 shrink-0" />
+                  ) : (
+                    <Mic className="h-4 w-4 shrink-0" />
+                  )}
+                  <span className="truncate">Voice</span>
+                </ShellActionSurface>
+              </div>
             </div>
           ) : (
-            <div className="relative flex h-[58px] w-full items-end justify-end">
+            <div className="relative flex h-[112px] w-full items-end justify-end">
+              <button
+                type="button"
+                aria-label="Open Agent"
+                onClick={handleAgentClick}
+                disabled={!agentPopover}
+                className="kai-bottom-agent-action pointer-events-auto absolute right-[7px] top-0 inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/30 disabled:pointer-events-none disabled:opacity-50"
+              >
+                <Bot className="h-[18px] w-[18px]" strokeWidth={1.9} />
+              </button>
               <div
                 className={cn(
                   "ml-auto flex items-end justify-end transition-[width] duration-200 ease-out",

--- a/hushh-webapp/components/kai/kai-search-bar.tsx
+++ b/hushh-webapp/components/kai/kai-search-bar.tsx
@@ -9,6 +9,7 @@ import {
   useState,
   type MouseEvent,
 } from "react";
+import { useRouter } from "next/navigation";
 import { Bot, Mic, Search, X } from "lucide-react";
 
 import {
@@ -24,6 +25,7 @@ import { useOptionalAgentPopover } from "@/components/agent/agent-popover-provid
 import { morphyToast as toast } from "@/lib/morphy-ux/morphy";
 import { useKaiBottomChromeVisibility } from "@/lib/navigation/kai-bottom-chrome-visibility";
 import { KAI_COMMAND_BAR_OPEN_EVENT } from "@/lib/navigation/kai-command-bar-events";
+import { ROUTES } from "@/lib/navigation/routes";
 import { cn } from "@/lib/utils";
 import { useVault } from "@/lib/vault/vault-context";
 import { useAmplitudeMeter } from "@/lib/voice/use-amplitude-meter";
@@ -312,6 +314,7 @@ export function KaiSearchBar({
   surfaceVariant = "kai",
   portfolioTickers = [],
 }: KaiSearchBarProps) {
+  const router = useRouter();
   const { getVaultOwnerToken, vaultKey } = useVault();
   const agentPopover = useOptionalAgentPopover();
   const [open, setOpen] = useState(false);
@@ -1662,8 +1665,12 @@ export function KaiSearchBar({
     ],
   );
   const handleAgentClick = useCallback(() => {
-    agentPopover?.openAgent();
-  }, [agentPopover]);
+    if (agentPopover) {
+      agentPopover.openAgent();
+      return;
+    }
+    router.push(ROUTES.AGENT);
+  }, [agentPopover, router]);
 
   return (
     <>
@@ -1694,8 +1701,7 @@ export function KaiSearchBar({
                 type="button"
                 aria-label="Open Agent"
                 onClick={handleAgentClick}
-                disabled={!agentPopover}
-                className="kai-bottom-agent-action pointer-events-auto absolute -top-[54px] right-1 inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/30 disabled:pointer-events-none disabled:opacity-50"
+                className="kai-bottom-agent-action pointer-events-auto absolute -top-[54px] right-1 inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/30"
               >
                 <Bot className="h-[18px] w-[18px]" strokeWidth={1.9} />
               </button>
@@ -1743,8 +1749,7 @@ export function KaiSearchBar({
                 type="button"
                 aria-label="Open Agent"
                 onClick={handleAgentClick}
-                disabled={!agentPopover}
-                className="kai-bottom-agent-action pointer-events-auto absolute right-[7px] top-0 inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/30 disabled:pointer-events-none disabled:opacity-50"
+                className="kai-bottom-agent-action pointer-events-auto absolute right-[7px] top-0 inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/30"
               >
                 <Bot className="h-[18px] w-[18px]" strokeWidth={1.9} />
               </button>
@@ -1823,6 +1828,10 @@ export function KaiSearchBar({
         onOpenChange={setOpen}
         onSelectAction={onSelectAction}
         appRuntimeState={appRuntimeState}
+        onVoiceClick={handleRiaVoiceClick}
+        voiceActive={riaVoiceActive}
+        voiceDisabled={riaVoiceDisabled}
+        voiceHidden={voiceVisibilityMode === "hidden"}
         portfolioTickers={portfolioTickers}
       />
 

--- a/hushh-webapp/components/kai/kai-search-bar.tsx
+++ b/hushh-webapp/components/kai/kai-search-bar.tsx
@@ -1691,7 +1691,7 @@ export function KaiSearchBar({
           ref={barRef}
           className={cn(
             "pointer-events-none w-full",
-            isRiaSurface ? "max-w-[360px] sm:max-w-[392px]" : "max-w-[630px]"
+            isRiaSurface ? "max-w-[360px] sm:max-w-[392px]" : "max-w-[560px]"
           )}
         >
           {isRiaSurface ? (

--- a/hushh-webapp/components/kai/onboarding/KaiPersonaScreen.tsx
+++ b/hushh-webapp/components/kai/onboarding/KaiPersonaScreen.tsx
@@ -14,31 +14,35 @@ const PERSONA_CONFIG: Record<
     headline: string;
     support: string;
     footerTagline: string;
+    accent: string;
     icon: LucideIcon;
   }
 > = {
   conservative: {
-    pill: "YOU VALUE STABILITY",
-    title: "Ready for steady growth?",
-    headline: "You prefer steady progress without unnecessary swings",
-    support: "Kai helps you grow steadily - without exposing you to unnecessary risk",
+    pill: "Stability first",
+    title: "Your plan should feel steady.",
+    headline: "You prefer dependable progress with fewer surprises.",
+    support: "Kai will keep risk visible, pacing calm, and every move easy to understand.",
     footerTagline: "Smart growth. Less stress.",
+    accent: "text-emerald-600 bg-emerald-500/10 dark:text-emerald-300 dark:bg-emerald-400/12",
     icon: Shield,
   },
   balanced: {
-    pill: "YOU PLAY IT SMART",
-    title: "Ready to move ahead?",
-    headline: "You're comfortable with some ups and downs for consistent long-term growth",
-    support: "Kai balances opportunity and discipline to keep your growth on track",
-    footerTagline: "Progress - without overexposure",
+    pill: "Balanced growth",
+    title: "You like progress with discipline.",
+    headline: "You can accept some movement when the long-term path is clear.",
+    support: "Kai will balance opportunity, concentration, and timing before suggesting action.",
+    footerTagline: "Progress without overexposure.",
+    accent: "text-primary bg-primary/10 dark:text-blue-300 dark:bg-blue-400/12",
     icon: Target,
   },
   aggressive: {
-    pill: "YOU'RE BUILT FOR GROWTH",
-    title: "Ready to level up?",
-    headline: "You're comfortable with market swings when the potential reward justifies it.",
-    support: "Kai helps you pursue stronger growth while managing risk intelligently",
-    footerTagline: "Let's build momentum",
+    pill: "Growth focused",
+    title: "You are comfortable leaning in.",
+    headline: "You can handle larger swings when the upside is worth the risk.",
+    support: "Kai will help you pursue momentum while keeping downside and concentration in view.",
+    footerTagline: "Build momentum with guardrails.",
+    accent: "text-orange-600 bg-orange-500/10 dark:text-orange-300 dark:bg-orange-400/12",
     icon: TrendingUp,
   },
 };
@@ -54,56 +58,70 @@ export function KaiPersonaScreen(props: {
   return (
     <main
       data-top-content-anchor="true"
-      className="min-h-[100dvh] w-full bg-transparent flex flex-col px-8 pt-[var(--top-content-pad)] pb-[var(--app-screen-footer-pad)]"
+      className="flex min-h-[100dvh] w-full flex-col bg-transparent px-5 pt-[var(--top-content-pad)] pb-[var(--app-screen-footer-pad)] sm:px-6 lg:px-[var(--page-inline-gutter-standard)]"
     >
-      <div className="w-full max-w-md mx-auto flex-1 min-h-0 flex items-start sm:items-center">
-        <section className="relative w-full py-4">
-          <div className="relative z-10 space-y-6 text-left">
-            <div className="h-20 w-20 rounded-[24px] border border-border/60 bg-background/70 backdrop-blur-sm grid place-items-center shadow-sm">
-              <Icon icon={icon} size={40} className="text-[var(--brand-600)]" />
+      <div className="mx-auto flex min-h-[calc(100dvh-var(--top-content-pad)-var(--app-screen-footer-pad))] w-full max-w-[42rem] flex-1 items-center">
+        <section className="w-full rounded-[32px] border border-black/[0.06] bg-white/[0.74] p-5 text-center shadow-[0_24px_80px_-56px_rgba(0,0,0,0.55)] backdrop-blur-2xl sm:p-7 lg:p-8 dark:border-white/10 dark:bg-white/[0.07]">
+          <div className="mx-auto flex w-full max-w-[33rem] flex-col items-center">
+            <div
+              className={`grid h-14 w-14 place-items-center rounded-[18px] ${cfg.accent}`}
+              aria-hidden="true"
+            >
+              <Icon icon={icon} size={28} />
             </div>
 
-            <div className="space-y-3">
-              <p className="text-[13px] font-extrabold tracking-[0.2em] text-[var(--brand-600)] uppercase leading-tight">
+            <div className="mt-5 space-y-3">
+              <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
                 {cfg.pill}
               </p>
-              <h1 className="text-[clamp(2rem,9.5vw,2.75rem)] font-bold tracking-tight leading-[1.05] text-foreground">
+              <h1 className="text-balance text-[clamp(2rem,4.2vw,2.75rem)] font-normal leading-[1.06] tracking-normal text-foreground">
                 {cfg.title}
               </h1>
+              <p className="mx-auto max-w-[30rem] text-[16px] leading-[1.5] text-muted-foreground">
+                {cfg.support}
+              </p>
             </div>
 
-            <p className="text-[16px] font-medium leading-relaxed text-muted-foreground">
-              {cfg.support}
-            </p>
+            <div className="mt-7 w-full rounded-[24px] border border-black/[0.06] bg-background/72 px-5 py-5 text-left shadow-[0_18px_48px_-42px_rgba(0,0,0,0.65)] dark:border-white/10 dark:bg-white/[0.05]">
+              <p className="text-[13px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+                Kai profile
+              </p>
+              <p className="mt-2 text-[18px] font-medium leading-[1.45] text-foreground sm:text-[19px]">
+                {cfg.headline}
+              </p>
+              <p className="mt-3 text-[15px] leading-[1.45] text-muted-foreground">
+                {cfg.footerTagline}
+              </p>
+            </div>
 
-            <p className="text-[21px] font-semibold leading-relaxed text-foreground">
-              {cfg.headline}
-            </p>
+            <div className="mt-7 w-full space-y-3">
+              <Button
+                type="button"
+                size="lg"
+                fullWidth
+                onClick={props.onLaunchDashboard}
+                showRipple
+                className="h-11 rounded-full text-[15px] font-semibold shadow-[0_16px_34px_-24px_rgba(0,113,227,0.85)]"
+              >
+                Connect portfolio
+                <ArrowRight className="ml-2 h-5 w-5" aria-hidden="true" />
+              </Button>
 
-            <p className="text-[16px] font-medium leading-relaxed text-muted-foreground">
-              {cfg.footerTagline}
-            </p>
-
-            <Button type="button" size="lg" fullWidth onClick={props.onLaunchDashboard} showRipple>
-              Connect Portfolio
-              <ArrowRight className="ml-2 h-5 w-5" aria-hidden="true" />
-            </Button>
-
-            {props.onEditAnswers && (
-              <div className="pt-1">
+              {props.onEditAnswers && (
                 <Button
                   type="button"
-                  variant="blue-gradient"
+                  variant="none"
                   effect="fade"
                   size="lg"
                   fullWidth
                   onClick={props.onEditAnswers}
                   showRipple={false}
+                  className="h-11 rounded-full !bg-primary/10 text-[15px] font-semibold !text-primary shadow-none hover:!bg-primary/15 dark:!bg-primary/15"
                 >
                   Edit answers
                 </Button>
-              </div>
-            )}
+              )}
+            </div>
           </div>
         </section>
       </div>

--- a/hushh-webapp/components/kai/onboarding/KaiPersonaScreen.tsx
+++ b/hushh-webapp/components/kai/onboarding/KaiPersonaScreen.tsx
@@ -64,14 +64,14 @@ export function KaiPersonaScreen(props: {
       data-top-content-anchor="true"
       className="flex min-h-[100dvh] w-full flex-col bg-transparent px-5 pt-[var(--top-content-pad)] pb-[var(--app-screen-footer-pad)] sm:px-6 lg:px-[var(--page-inline-gutter-standard)]"
     >
-      <div className="mx-auto flex min-h-[calc(100dvh-var(--top-content-pad)-var(--app-screen-footer-pad))] w-full max-w-[42rem] flex-1 items-center">
-        <section className="w-full rounded-[32px] border border-black/[0.06] bg-white/[0.74] p-5 text-center shadow-[0_24px_80px_-56px_rgba(0,0,0,0.55)] backdrop-blur-2xl sm:p-7 lg:p-8 dark:border-white/10 dark:bg-white/[0.07]">
-          <div className="mx-auto flex w-full max-w-[33rem] flex-col items-center">
+      <div className="mx-auto flex min-h-[calc(100dvh-var(--top-content-pad)-var(--app-screen-footer-pad))] w-full max-w-[28rem] flex-1 items-center py-6">
+        <section className="w-full text-center">
+          <div className="mx-auto flex w-full flex-col items-center">
             <div
-              className={`grid h-14 w-14 place-items-center rounded-[18px] ${cfg.accent}`}
+              className={`grid h-[52px] w-[52px] place-items-center rounded-[17px] ${cfg.accent}`}
               aria-hidden="true"
             >
-              <Icon icon={icon} size={28} />
+              <Icon icon={icon} size={26} />
             </div>
 
             <div className="mt-5 space-y-3">
@@ -86,7 +86,7 @@ export function KaiPersonaScreen(props: {
               </p>
             </div>
 
-            <div className="mt-7 w-full rounded-[24px] border border-black/[0.06] bg-background/72 px-5 py-5 text-left shadow-[0_18px_48px_-42px_rgba(0,0,0,0.65)] dark:border-white/10 dark:bg-white/[0.05]">
+            <div className="mt-8 w-full border-y border-black/[0.08] py-5 text-left dark:border-white/10">
               <p className="text-[13px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
                 Kai profile
               </p>

--- a/hushh-webapp/components/kai/onboarding/KaiPersonaScreen.tsx
+++ b/hushh-webapp/components/kai/onboarding/KaiPersonaScreen.tsx
@@ -5,6 +5,10 @@ import { ArrowRight, Shield, Target, TrendingUp, type LucideIcon } from "lucide-
 import type { RiskProfile } from "@/lib/services/kai-profile-service";
 import { Button } from "@/lib/morphy-ux/button";
 import { Icon } from "@/lib/morphy-ux/ui";
+import {
+  kaiAppBodyClassName,
+  kaiAppDisplayTitleClassName,
+} from "@/components/kai/shared/kai-typography";
 
 const PERSONA_CONFIG: Record<
   RiskProfile,
@@ -74,10 +78,10 @@ export function KaiPersonaScreen(props: {
               <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
                 {cfg.pill}
               </p>
-              <h1 className="text-balance text-[clamp(2rem,4.2vw,2.75rem)] font-normal leading-[1.06] tracking-normal text-foreground">
+              <h1 className={`text-balance ${kaiAppDisplayTitleClassName} text-foreground`}>
                 {cfg.title}
               </h1>
-              <p className="mx-auto max-w-[30rem] text-[16px] leading-[1.5] text-muted-foreground">
+              <p className={`mx-auto max-w-[30rem] ${kaiAppBodyClassName} text-muted-foreground`}>
                 {cfg.support}
               </p>
             </div>

--- a/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
+++ b/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
@@ -197,7 +197,7 @@ export function KaiPreferencesWizard(props: {
       <div
         className={cn(
           isPageLayout
-            ? "mx-auto flex min-h-[calc(100dvh-var(--top-content-pad)-var(--app-screen-footer-pad))] w-full max-w-[33rem] flex-col justify-center"
+            ? "mx-auto flex min-h-[calc(100dvh-var(--top-content-pad)-var(--app-screen-footer-pad))] w-full max-w-[31rem] flex-col justify-center"
             : "w-full max-w-sm mx-auto flex min-h-[calc(100dvh-var(--app-screen-footer-pad))] flex-col",
           !isPageLayout && "min-h-0"
         )}
@@ -205,7 +205,7 @@ export function KaiPreferencesWizard(props: {
         <div
           className={cn(
             isPageLayout
-              ? "rounded-[26px] border border-black/[0.06] bg-white/[0.82] p-5 shadow-[0_22px_64px_-52px_rgba(0,0,0,0.48)] backdrop-blur-2xl sm:p-6 dark:border-white/10 dark:bg-white/[0.07]"
+              ? "rounded-[26px] border border-black/[0.06] bg-white/[0.82] p-5 shadow-[0_22px_64px_-52px_rgba(0,0,0,0.48)] backdrop-blur-2xl sm:p-5 dark:border-white/10 dark:bg-white/[0.07]"
               : "contents"
           )}
         >
@@ -252,7 +252,7 @@ export function KaiPreferencesWizard(props: {
           <div
             className={cn(
               isPageLayout
-                ? "mx-auto flex w-full max-w-[26rem] flex-col pt-6 sm:pt-7"
+                ? "mx-auto flex w-full max-w-[25rem] flex-col pt-5 sm:pt-6"
                 : "flex flex-1 flex-col pt-5"
             )}
           >
@@ -272,7 +272,7 @@ export function KaiPreferencesWizard(props: {
                 className={cn(
                   "tracking-normal text-balance text-foreground",
                   isPageLayout
-                    ? "text-[28px] font-medium leading-[1.08] sm:text-[30px]"
+                    ? "text-[25px] font-medium leading-[1.12] sm:text-[27px]"
                     : kaiAppSectionTitleClassName
                 )}
               >
@@ -283,7 +283,7 @@ export function KaiPreferencesWizard(props: {
             <RadioGroup
               value={activeValue ?? ""}
               onValueChange={handleSelect}
-              className={cn(isPageLayout ? "mt-7 gap-2.5 sm:mt-8" : "gap-3")}
+              className={cn(isPageLayout ? "mt-6 gap-2.5 sm:mt-7" : "gap-3")}
             >
               {activeQuestion.options.map((opt) => (
                 <RadioCardItem key={opt.value} value={opt.value} label={opt.label} />

--- a/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
+++ b/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
@@ -192,7 +192,7 @@ export function KaiPreferencesWizard(props: {
       <div
         className={cn(
           isPageLayout
-            ? "mx-auto flex min-h-[calc(100dvh-var(--top-content-pad)-var(--app-screen-footer-pad))] w-full max-w-[44rem] flex-col justify-center"
+            ? "mx-auto flex min-h-[calc(100dvh-var(--top-content-pad)-var(--app-screen-footer-pad))] w-full max-w-[38rem] flex-col justify-center"
             : "w-full max-w-sm mx-auto flex min-h-[calc(100dvh-var(--app-screen-footer-pad))] flex-col",
           !isPageLayout && "min-h-0"
         )}
@@ -200,7 +200,7 @@ export function KaiPreferencesWizard(props: {
         <div
           className={cn(
             isPageLayout
-              ? "rounded-[32px] border border-black/[0.06] bg-white/[0.72] p-5 shadow-[0_24px_80px_-56px_rgba(0,0,0,0.55)] backdrop-blur-2xl sm:p-7 lg:p-8 dark:border-white/10 dark:bg-white/[0.07]"
+              ? "rounded-[30px] border border-black/[0.06] bg-white/[0.78] p-5 shadow-[0_24px_80px_-58px_rgba(0,0,0,0.52)] backdrop-blur-2xl sm:p-7 dark:border-white/10 dark:bg-white/[0.07]"
               : "contents"
           )}
         >
@@ -247,7 +247,7 @@ export function KaiPreferencesWizard(props: {
           <div
             className={cn(
               isPageLayout
-                ? "mx-auto flex w-full max-w-[35rem] flex-col pt-8 sm:pt-10"
+                ? "mx-auto flex w-full max-w-[30rem] flex-col pt-7 sm:pt-8"
                 : "flex flex-1 flex-col pt-5"
             )}
           >
@@ -255,7 +255,7 @@ export function KaiPreferencesWizard(props: {
               <p
                 className={cn(
                   "text-muted-foreground leading-relaxed",
-                  isPageLayout ? "text-[15px] sm:text-[16px]" : "text-xs"
+                  isPageLayout ? "text-[14.5px] sm:text-[15.5px]" : "text-xs"
                 )}
               >
                 No right or wrong answers. We’ll tune Kai to your investing style.
@@ -267,7 +267,7 @@ export function KaiPreferencesWizard(props: {
                 className={cn(
                   "tracking-normal text-balance text-foreground",
                   isPageLayout
-                    ? "text-[clamp(1.85rem,2.6vw,2.35rem)] font-normal leading-[1.1]"
+                    ? "text-[clamp(1.65rem,2.25vw,2.05rem)] font-medium leading-[1.12]"
                     : "text-[clamp(0.95rem,2.8vw,1.2rem)] leading-[1.3] font-semibold"
                 )}
               >
@@ -278,14 +278,14 @@ export function KaiPreferencesWizard(props: {
             <RadioGroup
               value={activeValue ?? ""}
               onValueChange={handleSelect}
-              className={cn(isPageLayout ? "mt-8 gap-2.5 sm:mt-9" : "gap-3")}
+              className={cn(isPageLayout ? "mt-7 gap-2.5 sm:mt-8" : "gap-3")}
             >
               {activeQuestion.options.map((opt) => (
                 <RadioCardItem key={opt.value} value={opt.value} label={opt.label} />
               ))}
             </RadioGroup>
 
-            <div className={cn("space-y-3.5", isPageLayout ? "pt-6" : "mt-auto pt-6")}>
+            <div className={cn("space-y-3", isPageLayout ? "pt-6" : "mt-auto pt-6")}>
               <Button
                 type="button"
                 variant="none"
@@ -297,7 +297,7 @@ export function KaiPreferencesWizard(props: {
                 loading={isSubmitting}
                 showRipple
                 className={cn(
-                  "h-11 rounded-full text-[15px] font-semibold shadow-[0_16px_34px_-24px_rgba(0,113,227,0.85)]",
+                  "h-12 rounded-full text-[15.5px] font-medium shadow-[0_16px_34px_-24px_rgba(0,113,227,0.85)]",
                   canContinue
                     ? "!bg-primary !text-primary-foreground hover:!bg-primary/90"
                     : "!bg-muted !text-muted-foreground shadow-none"
@@ -318,7 +318,7 @@ export function KaiPreferencesWizard(props: {
                   disabled={isSubmitting}
                   loading={isSubmitting}
                   showRipple
-                  className="h-11 rounded-full !bg-primary/10 text-[15px] font-semibold !text-primary shadow-none hover:!bg-primary/15 dark:!bg-primary/15"
+                  className="h-11 rounded-full !bg-primary/10 text-[15px] font-medium !text-primary shadow-none hover:!bg-primary/15 dark:!bg-primary/15"
                 >
                   {isSubmitting ? "Saving..." : "Skip"}
                   {!isSubmitting && <ArrowRight className="ml-2 h-5 w-5" />}
@@ -421,7 +421,7 @@ function RadioCardItem(props: { value: string; label: string }) {
       value={props.value}
       className={cn(
         "group w-full rounded-[18px] border px-4 py-3.5 text-left transition-[background-color,border-color,box-shadow,transform] sm:px-5",
-        "min-h-[58px] focus:outline-hidden focus-visible:ring-2 focus-visible:ring-[var(--brand-primary)]/35",
+        "min-h-[56px] focus:outline-hidden focus-visible:ring-2 focus-visible:ring-[var(--brand-primary)]/35",
         "border-black/[0.08] bg-white/68 shadow-[0_10px_30px_-28px_rgba(0,0,0,0.5)] backdrop-blur-xl",
         "hover:-translate-y-0.5 hover:bg-white/86 hover:shadow-[0_16px_38px_-32px_rgba(0,0,0,0.55)]",
         "data-[state=checked]:border-primary/55 data-[state=checked]:bg-primary/[0.08] data-[state=checked]:shadow-[0_16px_38px_-32px_rgba(0,113,227,0.7)]",
@@ -429,7 +429,7 @@ function RadioCardItem(props: { value: string; label: string }) {
       )}
     >
       <div className="flex items-center justify-between gap-3">
-        <p className="text-[15px] font-medium leading-snug text-foreground sm:text-[16px]">
+        <p className="text-[15px] font-medium leading-snug text-foreground">
           {props.label}
         </p>
         <div

--- a/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
+++ b/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
@@ -23,6 +23,10 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import {
+  kaiAppDisplayTitleClassName,
+  kaiAppSectionTitleClassName,
+} from "@/components/kai/shared/kai-typography";
 
 type WizardAnswers = {
   investment_horizon: InvestmentHorizon | null;
@@ -267,8 +271,8 @@ export function KaiPreferencesWizard(props: {
                 className={cn(
                   "tracking-normal text-balance text-foreground",
                   isPageLayout
-                    ? "text-[clamp(1.65rem,2.25vw,2.05rem)] font-medium leading-[1.12]"
-                    : "text-[clamp(0.95rem,2.8vw,1.2rem)] leading-[1.3] font-semibold"
+                    ? kaiAppDisplayTitleClassName
+                    : kaiAppSectionTitleClassName
                 )}
               >
                 {activeQuestion.prompt}

--- a/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
+++ b/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
@@ -24,7 +24,8 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import {
-  kaiAppDisplayTitleClassName,
+  kaiAppBodyClassName,
+  kaiAppCardTitleClassName,
   kaiAppSectionTitleClassName,
 } from "@/components/kai/shared/kai-typography";
 
@@ -196,7 +197,7 @@ export function KaiPreferencesWizard(props: {
       <div
         className={cn(
           isPageLayout
-            ? "mx-auto flex min-h-[calc(100dvh-var(--top-content-pad)-var(--app-screen-footer-pad))] w-full max-w-[38rem] flex-col justify-center"
+            ? "mx-auto flex min-h-[calc(100dvh-var(--top-content-pad)-var(--app-screen-footer-pad))] w-full max-w-[33rem] flex-col justify-center"
             : "w-full max-w-sm mx-auto flex min-h-[calc(100dvh-var(--app-screen-footer-pad))] flex-col",
           !isPageLayout && "min-h-0"
         )}
@@ -204,7 +205,7 @@ export function KaiPreferencesWizard(props: {
         <div
           className={cn(
             isPageLayout
-              ? "rounded-[30px] border border-black/[0.06] bg-white/[0.78] p-5 shadow-[0_24px_80px_-58px_rgba(0,0,0,0.52)] backdrop-blur-2xl sm:p-7 dark:border-white/10 dark:bg-white/[0.07]"
+              ? "rounded-[26px] border border-black/[0.06] bg-white/[0.82] p-5 shadow-[0_22px_64px_-52px_rgba(0,0,0,0.48)] backdrop-blur-2xl sm:p-6 dark:border-white/10 dark:bg-white/[0.07]"
               : "contents"
           )}
         >
@@ -251,15 +252,15 @@ export function KaiPreferencesWizard(props: {
           <div
             className={cn(
               isPageLayout
-                ? "mx-auto flex w-full max-w-[30rem] flex-col pt-7 sm:pt-8"
+                ? "mx-auto flex w-full max-w-[26rem] flex-col pt-6 sm:pt-7"
                 : "flex flex-1 flex-col pt-5"
             )}
           >
-            <div className={cn(isPageLayout ? "space-y-4 text-center" : "space-y-3")}>
+            <div className={cn(isPageLayout ? "space-y-3 text-left" : "space-y-3")}>
               <p
                 className={cn(
                   "text-muted-foreground leading-relaxed",
-                  isPageLayout ? "text-[14.5px] sm:text-[15.5px]" : "text-xs"
+                  isPageLayout ? kaiAppBodyClassName : "text-xs"
                 )}
               >
                 No right or wrong answers. We’ll tune Kai to your investing style.
@@ -271,7 +272,7 @@ export function KaiPreferencesWizard(props: {
                 className={cn(
                   "tracking-normal text-balance text-foreground",
                   isPageLayout
-                    ? kaiAppDisplayTitleClassName
+                    ? "text-[28px] font-medium leading-[1.08] sm:text-[30px]"
                     : kaiAppSectionTitleClassName
                 )}
               >
@@ -425,7 +426,7 @@ function RadioCardItem(props: { value: string; label: string }) {
       value={props.value}
       className={cn(
         "group w-full rounded-[18px] border px-4 py-3.5 text-left transition-[background-color,border-color,box-shadow,transform] sm:px-5",
-        "min-h-[56px] focus:outline-hidden focus-visible:ring-2 focus-visible:ring-[var(--brand-primary)]/35",
+        "min-h-[54px] focus:outline-hidden focus-visible:ring-2 focus-visible:ring-[var(--brand-primary)]/35",
         "border-black/[0.08] bg-white/68 shadow-[0_10px_30px_-28px_rgba(0,0,0,0.5)] backdrop-blur-xl",
         "hover:-translate-y-0.5 hover:bg-white/86 hover:shadow-[0_16px_38px_-32px_rgba(0,0,0,0.55)]",
         "data-[state=checked]:border-primary/55 data-[state=checked]:bg-primary/[0.08] data-[state=checked]:shadow-[0_16px_38px_-32px_rgba(0,113,227,0.7)]",
@@ -433,7 +434,7 @@ function RadioCardItem(props: { value: string; label: string }) {
       )}
     >
       <div className="flex items-center justify-between gap-3">
-        <p className="text-[15px] font-medium leading-snug text-foreground">
+        <p className={cn(kaiAppCardTitleClassName, "text-foreground")}>
           {props.label}
         </p>
         <div

--- a/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
+++ b/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
@@ -197,7 +197,7 @@ export function KaiPreferencesWizard(props: {
       <div
         className={cn(
           isPageLayout
-            ? "mx-auto flex min-h-[calc(100dvh-var(--top-content-pad)-var(--app-screen-footer-pad))] w-full max-w-[31rem] flex-col justify-center"
+            ? "mx-auto flex min-h-[calc(100dvh-var(--top-content-pad)-var(--app-screen-footer-pad))] w-full max-w-[25rem] flex-col justify-center py-6"
             : "w-full max-w-sm mx-auto flex min-h-[calc(100dvh-var(--app-screen-footer-pad))] flex-col",
           !isPageLayout && "min-h-0"
         )}
@@ -205,7 +205,7 @@ export function KaiPreferencesWizard(props: {
         <div
           className={cn(
             isPageLayout
-              ? "rounded-[26px] border border-black/[0.06] bg-white/[0.82] p-5 shadow-[0_22px_64px_-52px_rgba(0,0,0,0.48)] backdrop-blur-2xl sm:p-5 dark:border-white/10 dark:bg-white/[0.07]"
+              ? "w-full"
               : "contents"
           )}
         >
@@ -233,7 +233,7 @@ export function KaiPreferencesWizard(props: {
               ) : (
                 <span />
               )}
-              <span className="rounded-full bg-black/[0.035] px-3 py-1 text-[12px] font-medium tabular-nums text-muted-foreground dark:bg-white/10">
+              <span className="text-[12px] font-medium tabular-nums text-muted-foreground">
                 {progressValue}%
               </span>
             </div>
@@ -252,7 +252,7 @@ export function KaiPreferencesWizard(props: {
           <div
             className={cn(
               isPageLayout
-                ? "mx-auto flex w-full max-w-[25rem] flex-col pt-5 sm:pt-6"
+                ? "mx-auto flex w-full flex-col pt-8 sm:pt-9"
                 : "flex flex-1 flex-col pt-5"
             )}
           >
@@ -272,7 +272,7 @@ export function KaiPreferencesWizard(props: {
                 className={cn(
                   "tracking-normal text-balance text-foreground",
                   isPageLayout
-                    ? "text-[25px] font-medium leading-[1.12] sm:text-[27px]"
+                    ? "text-[30px] font-medium leading-[1.06] sm:text-[34px]"
                     : kaiAppSectionTitleClassName
                 )}
               >
@@ -283,14 +283,14 @@ export function KaiPreferencesWizard(props: {
             <RadioGroup
               value={activeValue ?? ""}
               onValueChange={handleSelect}
-              className={cn(isPageLayout ? "mt-6 gap-2.5 sm:mt-7" : "gap-3")}
+              className={cn(isPageLayout ? "mt-8 gap-3 sm:mt-9" : "gap-3")}
             >
               {activeQuestion.options.map((opt) => (
                 <RadioCardItem key={opt.value} value={opt.value} label={opt.label} />
               ))}
             </RadioGroup>
 
-            <div className={cn("space-y-3", isPageLayout ? "pt-6" : "mt-auto pt-6")}>
+            <div className={cn("space-y-3", isPageLayout ? "pt-8" : "mt-auto pt-6")}>
               <Button
                 type="button"
                 variant="none"

--- a/hushh-webapp/components/kai/onboarding/kai-nav-tour.tsx
+++ b/hushh-webapp/components/kai/onboarding/kai-nav-tour.tsx
@@ -428,7 +428,7 @@ export function KaiNavTour() {
             </div>
 
             <div className="space-y-1">
-              <h3 className="text-base font-black">{activeStep.title}</h3>
+              <h3 className="text-base font-semibold">{activeStep.title}</h3>
               <p className="text-sm text-muted-foreground">{activeStep.description}</p>
             </div>
 

--- a/hushh-webapp/components/kai/shared/kai-typography.ts
+++ b/hushh-webapp/components/kai/shared/kai-typography.ts
@@ -4,25 +4,25 @@ export const kaiAppEyebrowClassName =
   "!text-[10.5px] !font-medium !leading-[1.2] uppercase !tracking-[0.14em]";
 
 export const kaiAppHeroTitleClassName =
-  "text-[36px] font-medium leading-[1.06] tracking-normal sm:text-[38px]";
+  "text-[38px] font-medium leading-[1.05] tracking-normal sm:text-[40px]";
 
 export const kaiAppHeroBodyClassName =
-  "text-[16.5px] font-normal leading-[1.42] tracking-normal sm:text-[17.5px]";
+  "text-[17px] font-normal leading-[1.42] tracking-normal sm:text-[18px]";
 
 export const kaiAppDisplayTitleClassName =
-  "!text-[28px] !font-medium !leading-[1.1] !tracking-normal sm:!text-[32px]";
+  "!text-[36px] !font-medium !leading-[1.06] !tracking-normal sm:!text-[48px]";
 
 export const kaiAppCompactTitleClassName =
-  "!text-[28px] !font-medium !leading-[1.1] !tracking-normal sm:!text-[32px]";
+  "!text-[34px] !font-medium !leading-[1.06] !tracking-normal sm:!text-[42px]";
 
 export const kaiAppBodyClassName =
-  "!text-[15.5px] !font-normal !leading-[1.46] !tracking-normal sm:!text-[16.5px]";
+  "!text-[16px] !font-normal !leading-[1.45] !tracking-normal sm:!text-[17px]";
 
 export const kaiAppSectionTitleClassName =
-  "!text-[17px] !font-medium !leading-[1.2] !tracking-normal sm:!text-[18px]";
+  "!text-[21px] !font-medium !leading-[1.12] !tracking-normal sm:!text-[24px]";
 
 export const kaiAppCardTitleClassName =
-  "!text-[15.5px] !font-medium !leading-[1.24] !tracking-normal sm:!text-[16px]";
+  "!text-[16.5px] !font-medium !leading-[1.22] !tracking-normal";
 
 export const kaiAppCardBodyClassName =
   "!text-[14px] !font-normal !leading-[1.42] !tracking-normal";

--- a/hushh-webapp/components/kai/shared/kai-typography.ts
+++ b/hushh-webapp/components/kai/shared/kai-typography.ts
@@ -4,22 +4,22 @@ export const kaiAppEyebrowClassName =
   "!text-[10.5px] !font-medium !leading-[1.2] uppercase !tracking-[0.14em]";
 
 export const kaiAppHeroTitleClassName =
-  "text-[38px] font-medium leading-[1.05] tracking-normal sm:text-[40px]";
+  "text-[36px] font-medium leading-[1.06] tracking-normal sm:text-[38px]";
 
 export const kaiAppHeroBodyClassName =
-  "text-[17px] font-normal leading-[1.42] tracking-normal sm:text-[18px]";
+  "text-[16.5px] font-normal leading-[1.42] tracking-normal sm:text-[17.5px]";
 
 export const kaiAppDisplayTitleClassName =
-  "!text-[30px] !font-medium !leading-[1.08] !tracking-normal sm:!text-[34px]";
+  "!text-[28px] !font-medium !leading-[1.1] !tracking-normal sm:!text-[32px]";
 
 export const kaiAppCompactTitleClassName =
-  "!text-[30px] !font-medium !leading-[1.08] !tracking-normal sm:!text-[34px]";
+  "!text-[28px] !font-medium !leading-[1.1] !tracking-normal sm:!text-[32px]";
 
 export const kaiAppBodyClassName =
-  "!text-[16px] !font-normal !leading-[1.45] !tracking-normal sm:!text-[17px]";
+  "!text-[15.5px] !font-normal !leading-[1.46] !tracking-normal sm:!text-[16.5px]";
 
 export const kaiAppSectionTitleClassName =
-  "!text-[18px] !font-medium !leading-[1.18] !tracking-normal sm:!text-[20px]";
+  "!text-[17px] !font-medium !leading-[1.2] !tracking-normal sm:!text-[18px]";
 
 export const kaiAppCardTitleClassName =
   "!text-[15.5px] !font-medium !leading-[1.24] !tracking-normal sm:!text-[16px]";

--- a/hushh-webapp/components/kai/shared/kai-typography.ts
+++ b/hushh-webapp/components/kai/shared/kai-typography.ts
@@ -3,20 +3,26 @@
 export const kaiAppEyebrowClassName =
   "!text-[10.5px] !font-medium !leading-[1.2] uppercase !tracking-[0.14em]";
 
+export const kaiAppHeroTitleClassName =
+  "text-[38px] font-medium leading-[1.05] tracking-normal sm:text-[40px]";
+
+export const kaiAppHeroBodyClassName =
+  "text-[17px] font-normal leading-[1.42] tracking-normal sm:text-[18px]";
+
 export const kaiAppDisplayTitleClassName =
-  "!text-[36px] !font-medium !leading-[1.06] !tracking-normal sm:!text-[48px]";
+  "!text-[30px] !font-medium !leading-[1.08] !tracking-normal sm:!text-[34px]";
 
 export const kaiAppCompactTitleClassName =
-  "!text-[34px] !font-medium !leading-[1.06] !tracking-normal sm:!text-[42px]";
+  "!text-[30px] !font-medium !leading-[1.08] !tracking-normal sm:!text-[34px]";
 
 export const kaiAppBodyClassName =
   "!text-[16px] !font-normal !leading-[1.45] !tracking-normal sm:!text-[17px]";
 
 export const kaiAppSectionTitleClassName =
-  "!text-[21px] !font-medium !leading-[1.12] !tracking-normal sm:!text-[24px]";
+  "!text-[18px] !font-medium !leading-[1.18] !tracking-normal sm:!text-[20px]";
 
 export const kaiAppCardTitleClassName =
-  "!text-[16.5px] !font-medium !leading-[1.22] !tracking-normal";
+  "!text-[15.5px] !font-medium !leading-[1.24] !tracking-normal sm:!text-[16px]";
 
 export const kaiAppCardBodyClassName =
   "!text-[14px] !font-normal !leading-[1.42] !tracking-normal";

--- a/hushh-webapp/components/kai/shared/kai-typography.ts
+++ b/hushh-webapp/components/kai/shared/kai-typography.ts
@@ -1,25 +1,25 @@
 "use client";
 
 export const kaiAppEyebrowClassName =
-  "text-[10.5px] font-medium uppercase tracking-[0.14em]";
+  "!text-[10.5px] !font-medium !leading-[1.2] uppercase !tracking-[0.14em]";
 
 export const kaiAppDisplayTitleClassName =
-  "text-[36px] font-medium leading-[1.06] tracking-normal sm:text-[48px]";
+  "!text-[36px] !font-medium !leading-[1.06] !tracking-normal sm:!text-[48px]";
 
 export const kaiAppCompactTitleClassName =
-  "text-[34px] font-medium leading-[1.06] tracking-normal sm:text-[42px]";
+  "!text-[34px] !font-medium !leading-[1.06] !tracking-normal sm:!text-[42px]";
 
 export const kaiAppBodyClassName =
-  "text-[16px] font-normal leading-[1.45] tracking-normal sm:text-[17px]";
+  "!text-[16px] !font-normal !leading-[1.45] !tracking-normal sm:!text-[17px]";
 
 export const kaiAppSectionTitleClassName =
-  "text-[21px] font-medium leading-[1.12] tracking-normal sm:text-[24px]";
+  "!text-[21px] !font-medium !leading-[1.12] !tracking-normal sm:!text-[24px]";
 
 export const kaiAppCardTitleClassName =
-  "text-[16.5px] font-medium leading-[1.22] tracking-normal";
+  "!text-[16.5px] !font-medium !leading-[1.22] !tracking-normal";
 
 export const kaiAppCardBodyClassName =
-  "text-[14px] font-normal leading-[1.42] tracking-normal";
+  "!text-[14px] !font-normal !leading-[1.42] !tracking-normal";
 
 export const kaiAppHelperClassName =
-  "text-[12.5px] font-normal leading-[1.45] tracking-normal";
+  "!text-[12.5px] !font-normal !leading-[1.45] !tracking-normal";

--- a/hushh-webapp/components/kai/views/analysis-history-dashboard.tsx
+++ b/hushh-webapp/components/kai/views/analysis-history-dashboard.tsx
@@ -549,14 +549,14 @@ function removeTickerFromHistoryMap(
 
 function EmptyState() {
   return (
-    <div className="flex max-w-xl flex-col items-start justify-center space-y-4 px-1 py-10">
+      <div className="flex max-w-xl flex-col items-start justify-center space-y-4 px-1 py-8">
       <div className="rounded-full border border-primary/10 bg-primary/5 p-3">
         <Icon icon={BarChart3} size={24} className="text-primary/70" aria-hidden="true" />
       </div>
       <div className="space-y-2 text-left">
-        <h3 className="text-[22px] font-semibold leading-tight tracking-normal text-foreground">
-          No analyses yet
-        </h3>
+          <h3 className="text-[20px] font-medium leading-tight tracking-normal text-foreground">
+            No analyses yet
+          </h3>
         <p className="max-w-md text-[15px] leading-6 text-muted-foreground">
           Search for a stock ticker below and let Agent Kai&apos;s multi-agent
           debate engine give you a data-driven recommendation.

--- a/hushh-webapp/components/kai/views/analysis-history-dashboard.tsx
+++ b/hushh-webapp/components/kai/views/analysis-history-dashboard.tsx
@@ -549,13 +549,15 @@ function removeTickerFromHistoryMap(
 
 function EmptyState() {
   return (
-    <div className="flex flex-col items-center justify-center py-12 px-4 space-y-6">
-      <div className="p-4 rounded-full bg-primary/5 border border-primary/10">
-        <Icon icon={BarChart3} size={32} className="text-primary/60" aria-hidden="true" />
+    <div className="flex max-w-xl flex-col items-start justify-center space-y-4 px-1 py-10">
+      <div className="rounded-full border border-primary/10 bg-primary/5 p-3">
+        <Icon icon={BarChart3} size={24} className="text-primary/70" aria-hidden="true" />
       </div>
-      <div className="text-center space-y-2 max-w-sm">
-        <h3 className="text-lg font-semibold">No analyses yet</h3>
-        <p className="text-sm text-muted-foreground leading-relaxed">
+      <div className="space-y-2 text-left">
+        <h3 className="text-[22px] font-semibold leading-tight tracking-normal text-foreground">
+          No analyses yet
+        </h3>
+        <p className="max-w-md text-[15px] leading-6 text-muted-foreground">
           Search for a stock ticker below and let Agent Kai&apos;s multi-agent
           debate engine give you a data-driven recommendation.
         </p>

--- a/hushh-webapp/components/kai/views/analysis-summary-view.tsx
+++ b/hushh-webapp/components/kai/views/analysis-summary-view.tsx
@@ -381,11 +381,11 @@ export function AnalysisSummaryView({
 
       {showHeader ? (
         <div className="flex items-center gap-4 px-1">
-          <div className="grid h-14 w-14 place-items-center rounded-full bg-black text-lg font-black text-white dark:bg-white dark:text-black">
+          <div className="grid h-14 w-14 place-items-center rounded-full bg-black text-lg font-semibold text-white dark:bg-white dark:text-black">
             {entry.ticker.slice(0, 1)}
           </div>
           <div>
-            <h2 className="text-2xl font-black tracking-tight leading-tight">{entry.ticker} Insight</h2>
+            <h2 className="text-[20px] font-medium leading-tight tracking-normal sm:text-[22px]">{entry.ticker} Insight</h2>
             <div className="mt-1 flex flex-wrap items-center gap-2">
               <span className="font-mono text-sm text-muted-foreground">{priceLabel}</span>
               {todayChangePct !== null ? (

--- a/hushh-webapp/components/kai/views/dashboard-master-view.tsx
+++ b/hushh-webapp/components/kai/views/dashboard-master-view.tsx
@@ -158,7 +158,7 @@ const portfolioChipTones = {
 const portfolioMetricLabelClassName =
   "text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground";
 const portfolioMetricValueClassName =
-  "mt-1 text-2xl font-medium tracking-normal sm:text-[1.65rem]";
+  "mt-1 text-[1.35rem] font-medium tracking-normal sm:text-[1.5rem]";
 const portfolioSummaryPillClassName =
   "rounded-2xl px-3 py-2 text-[12px] leading-5 text-muted-foreground";
 
@@ -2777,7 +2777,7 @@ export function DashboardMasterView({
                 </span>
               ) : null}
             </div>
-            <p className="text-[2.35rem] font-medium leading-none tracking-normal text-foreground sm:text-5xl">
+            <p className="text-[2rem] font-medium leading-none tracking-normal text-foreground sm:text-[2.5rem]">
               {formatCurrency(model.hero.totalValue)}
             </p>
             <div className="flex flex-wrap items-center justify-center gap-2 text-sm">

--- a/hushh-webapp/components/kai/views/decision-card.tsx
+++ b/hushh-webapp/components/kai/views/decision-card.tsx
@@ -493,7 +493,7 @@ function ConsensusDonut({ result }: { result: DecisionResult }) {
       <div className="space-y-3">
         <div className="flex items-end justify-between gap-3">
           <div>
-            <p className="text-2xl font-black tracking-tight text-foreground">{agreePct}%</p>
+            <p className="text-2xl font-semibold tracking-tight text-foreground">{agreePct}%</p>
             <p className="text-xs text-muted-foreground">Agents align with the final call</p>
           </div>
           <div className="rounded-xl border border-amber-500/15 bg-amber-500/[0.08] px-3 py-2 text-right">
@@ -759,7 +759,7 @@ function ConfidenceGauge({ confidence }: { confidence: number }) {
                       <tspan
                         x={viewBox.cx}
                         y={viewBox.cy}
-                        className="fill-foreground text-3xl font-black tracking-tighter"
+                        className="fill-foreground text-3xl font-semibold tracking-tighter"
                       >
                         {score}%
                       </tspan>
@@ -923,7 +923,7 @@ export function DecisionCard({ result }: { result: DecisionResult }) {
             {/* Main Decision Pill */}
             <div
                 className={cn(
-                "px-10 py-5 rounded-2xl border-2 text-4xl font-black uppercase tracking-tighter shadow-xl backdrop-blur-md transform transition-all duration-300 hover:scale-[1.02]",
+                "px-10 py-5 rounded-2xl border-2 text-2xl font-semibold uppercase tracking-normal shadow-xl backdrop-blur-md transform transition-all duration-300 hover:scale-[1.02]",
                 isBuy
                     ? "bg-emerald-500/10 border-emerald-500/20 text-emerald-500 shadow-emerald-500/10"
                     : isReduce

--- a/hushh-webapp/components/kai/views/history-detail-view.tsx
+++ b/hushh-webapp/components/kai/views/history-detail-view.tsx
@@ -170,7 +170,7 @@ export function HistoryDetailView({
             <CardContent className="p-4">
               <div className="flex items-center gap-3">
                 <SymbolAvatar symbol={entry.ticker} name={entry.ticker} size="md" />
-                <h2 className="text-2xl font-black tracking-tight">{entry.ticker}</h2>
+                <h2 className="text-2xl font-semibold tracking-tight">{entry.ticker}</h2>
                 <span className="text-sm font-semibold tabular-nums text-muted-foreground">{priceLabel}</span>
                 {todayChangePct !== null ? (
                   <span
@@ -234,7 +234,7 @@ export function HistoryDetailView({
               <div className="flex items-start gap-3">
                 <SymbolAvatar symbol={entry.ticker} name={entry.ticker} size="lg" className="mt-0.5" />
                 <div>
-                  <h1 className="text-2xl font-black tracking-tighter text-foreground leading-none">
+                  <h1 className="text-2xl font-semibold tracking-tighter text-foreground leading-none">
                     {entry.ticker}
                   </h1>
                   <div className="mt-1 flex items-center gap-2">

--- a/hushh-webapp/components/kai/views/kai-analysis-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-analysis-preview-view.tsx
@@ -584,7 +584,7 @@ export function KaiAnalysisPreviewView() {
           <div className="mt-5 flex items-start justify-between gap-3">
             <div>
               <p className="text-[13px] font-medium text-[color:var(--one-fg2)]">Portfolio value</p>
-              <p className="mt-1 text-[38px] font-semibold leading-none tracking-normal text-[color:var(--one-fg)] tabular-nums">
+              <p className="mt-1 text-[30px] font-medium leading-none tracking-normal text-[color:var(--one-fg)] tabular-nums sm:text-[34px]">
                 {rangeMeta.value}
               </p>
             </div>

--- a/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
@@ -2034,6 +2034,7 @@ export function KaiMarketPreviewView() {
       as="div"
       width="reading"
       className={oneMarketRootClassName}
+      data-one-market-surface="true"
       data-one-market-preview={localPreviewPayload ? "true" : undefined}
     >
       {localPreviewPayload ? (

--- a/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
@@ -148,8 +148,8 @@ const oneMarketRootClassName = cn(
   marketSurfaceVariablesClassName,
   "relative isolate mx-auto flex min-h-screen w-full !max-w-none flex-col overflow-x-hidden !px-0 pb-0",
   "bg-[color:var(--one-bg)] font-sans text-[color:var(--one-fg)] antialiased",
-  "[--one-bg:#ffffff] [--one-card:#ffffff] [--one-surface:#f2f2f7]",
-  "dark:[--one-bg:#000000] dark:[--one-card:#1c1c1e] dark:[--one-surface:#1c1c1e]",
+  "[--one-bg:var(--background)] [--one-card:#ffffff] [--one-surface:#f2f2f7]",
+  "dark:[--one-bg:rgb(28,28,30)] dark:[--one-card:#1c1c1e] dark:[--one-surface:#1c1c1e]",
   "[--one-hairline:rgba(0,0,0,0.08)] [--one-line:rgba(0,0,0,0.06)]",
   "dark:[--one-hairline:rgba(255,255,255,0.14)] dark:[--one-line:rgba(255,255,255,0.10)]",
   "[--one-fg:#1d1d1f] [--one-fg2:rgba(0,0,0,0.55)] [--one-fg3:rgba(0,0,0,0.42)]",
@@ -2041,13 +2041,13 @@ export function KaiMarketPreviewView() {
           {`
             html:has([data-one-market-preview="true"]),
             body {
-              background: #ffffff !important;
+              background: var(--background) !important;
             }
 
             body:has([data-one-market-preview="true"]) main,
             body:has([data-one-market-preview="true"]) [data-top-content-anchor="true"],
             body:has([data-one-market-preview="true"]) [class*="overflow-y-auto"][class*="touch-pan-y"] {
-              background: #ffffff !important;
+              background: var(--background) !important;
             }
 
             html.dark:has([data-one-market-preview="true"]),
@@ -2055,7 +2055,7 @@ export function KaiMarketPreviewView() {
             html.dark:has([data-one-market-preview="true"]) body main,
             html.dark:has([data-one-market-preview="true"]) body [data-top-content-anchor="true"],
             html.dark:has([data-one-market-preview="true"]) body [class*="overflow-y-auto"][class*="touch-pan-y"] {
-              background: #000000 !important;
+              background: rgb(28, 28, 30) !important;
             }
 
             nextjs-portal,

--- a/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
+++ b/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
@@ -743,7 +743,7 @@ export function ManagePortfolioView() {
               disabled={isSaving}
               variant="morphy"
               effect="fill"
-              className="w-full h-12 text-sm font-black rounded-xl border-none shadow-xl"
+              className="w-full h-12 text-sm font-semibold rounded-xl border-none shadow-xl"
               icon={{ 
                 icon: isSaving ? SpinningLoader : Save,
                 gradient: false 

--- a/hushh-webapp/components/kai/views/portfolio-import-view.tsx
+++ b/hushh-webapp/components/kai/views/portfolio-import-view.tsx
@@ -38,9 +38,9 @@ import {
 } from "@/components/kai/shared/kai-typography";
 
 const importCardTitleClassName =
-  "text-[22px] font-medium leading-[1.12] tracking-normal text-foreground sm:text-[24px]";
+  "!text-[22px] !font-medium !leading-[1.12] !tracking-normal text-foreground sm:!text-[24px]";
 const importDropzoneTitleClassName =
-  "text-[16px] font-medium leading-[1.24] tracking-normal sm:text-[17px]";
+  "!text-[16px] !font-medium !leading-[1.24] !tracking-normal sm:!text-[17px]";
 
 // =============================================================================
 // TYPES
@@ -219,8 +219,8 @@ export function PortfolioImportView({
           <MorphyButton
             variant="blue-gradient"
             effect="fill"
-            size="lg"
-            className="w-full rounded-full border-none font-medium shadow-[0_10px_30px_-20px_rgba(0,102,204,0.55)]"
+            size="default"
+            className="h-12 w-full rounded-full border-none text-[16px] font-medium shadow-[0_10px_30px_-20px_rgba(0,102,204,0.55)]"
             disabled={!onConnectPlaid || isUploading || isPreloadingSchema || isConnectingPlaid || plaidConfigured === false}
             onClick={handleConnectPlaid}
             icon={{
@@ -320,7 +320,7 @@ export function PortfolioImportView({
             variant="morphy"
             effect="fill"
             size="default"
-            className="w-full rounded-full border-none font-medium shadow-[0_10px_30px_-20px_rgba(0,102,204,0.55)]"
+            className="h-12 w-full rounded-full border-none text-[16px] font-medium shadow-[0_10px_30px_-20px_rgba(0,102,204,0.55)]"
             onClick={handleContinue}
             disabled={isUploading || isPreloadingSchema || !selectedFile}
             icon={{
@@ -349,8 +349,8 @@ export function PortfolioImportView({
           <MorphyButton
             variant="blue-gradient"
             effect="fill"
-            size="lg"
-            className="w-full rounded-full border-none font-medium shadow-[0_10px_30px_-20px_rgba(0,102,204,0.55)]"
+            size="default"
+            className="h-12 w-full rounded-full border-none text-[16px] font-medium shadow-[0_10px_30px_-20px_rgba(0,102,204,0.55)]"
             onClick={handlePreloadSchema}
             disabled={isUploading || isPreloadingSchema}
             icon={{
@@ -373,7 +373,7 @@ export function PortfolioImportView({
           effect="fade"
           onClick={onSkip}
           disabled={isUploading || isPreloadingSchema}
-          className="text-muted-foreground hover:text-foreground text-base"
+          className="h-11 rounded-full px-5 text-[15px] font-medium text-muted-foreground hover:text-foreground"
         >
           Skip for now
         </MorphyButton>

--- a/hushh-webapp/components/kai/views/portfolio-import-view.tsx
+++ b/hushh-webapp/components/kai/views/portfolio-import-view.tsx
@@ -30,7 +30,6 @@ import { SurfaceCard, SurfaceCardContent } from "@/components/app-ui/surfaces";
 import { Icon } from "@/lib/morphy-ux/ui";
 import { scrollAppToTop } from "@/lib/navigation/use-scroll-reset";
 import {
-  kaiAppBodyClassName,
   kaiAppCardBodyClassName,
   kaiAppCardTitleClassName,
   kaiAppCompactTitleClassName,
@@ -166,16 +165,16 @@ export function PortfolioImportView({
   ]);
 
   return (
-    <div className="mx-auto w-full space-y-4 pt-3 pb-6" style={APP_MEASURE_STYLES.reading}>
+    <div className="mx-auto w-full space-y-4 pb-6 pt-3" style={APP_MEASURE_STYLES.reading}>
       {/* Header */}
-      <div className="space-y-2 text-left">
+      <div className="space-y-1.5 text-left">
         <p className={cn(kaiAppEyebrowClassName, "text-muted-foreground")}>
           Getting started
         </p>
         <h1 className={cn(kaiAppCompactTitleClassName, "text-foreground")}>
           Portfolio
         </h1>
-        <p className={cn(kaiAppBodyClassName, "text-muted-foreground")}>
+        <p className={cn(kaiAppCardBodyClassName, "max-w-[32rem] text-muted-foreground sm:!text-[15px]")}>
           Let Kai analyze your holdings for precise advice
         </p>
       </div>
@@ -183,9 +182,9 @@ export function PortfolioImportView({
       {/* Plaid integration */}
       <SurfaceCard accent="sky">
         <SurfaceCardContent className="space-y-3 p-4 md:p-5">
-          <div className="flex items-center justify-between gap-3">
-            <div className="flex items-center gap-3 min-w-0">
-              <div className="w-12 h-12 rounded-full bg-primary/10 border border-primary/15 flex items-center justify-center shrink-0">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex min-w-0 items-center gap-3">
+              <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-primary/15 bg-primary/10">
                 <Icon icon={Link2} size="md" className="text-primary" />
               </div>
               <div className="min-w-0">
@@ -195,7 +194,7 @@ export function PortfolioImportView({
                 </p>
               </div>
             </div>
-            <div className="shrink-0 flex flex-col items-end gap-2">
+            <div className="flex shrink-0 flex-wrap gap-2 sm:justify-end">
               <Badge className="border border-[var(--brand-200)] bg-[var(--brand-50)] text-[var(--brand-700)]">
                 Read-only sync
               </Badge>
@@ -217,7 +216,7 @@ export function PortfolioImportView({
             variant="blue-gradient"
             effect="fill"
             size="default"
-            className="h-12 w-full rounded-full border-none text-[16px] font-medium shadow-[0_10px_30px_-20px_rgba(0,102,204,0.55)]"
+            className="h-11 w-full rounded-full border-none text-[15px] font-medium shadow-[0_10px_30px_-20px_rgba(0,102,204,0.55)]"
             disabled={!onConnectPlaid || isUploading || isPreloadingSchema || isConnectingPlaid || plaidConfigured === false}
             onClick={handleConnectPlaid}
             icon={{
@@ -251,7 +250,7 @@ export function PortfolioImportView({
       <SurfaceCard>
         <SurfaceCardContent className="space-y-4 p-4 md:p-5">
           <div className="flex items-center gap-3">
-            <div className="w-11 h-11 rounded-full bg-primary/10 border border-primary/15 flex items-center justify-center shrink-0">
+            <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-primary/15 bg-primary/10">
               <Icon icon={Upload} size="md" className="text-primary" />
             </div>
             <div>
@@ -268,7 +267,7 @@ export function PortfolioImportView({
             onDragOver={handleDragOver}
             onDragLeave={handleDragLeave}
             className={cn(
-              "relative border border-dashed rounded-3xl p-7 transition-all duration-200 text-center cursor-pointer min-h-44 flex flex-col items-center justify-center",
+              "relative flex min-h-40 cursor-pointer flex-col items-center justify-center rounded-[24px] border border-dashed p-6 text-center transition-all duration-200",
               isDragging
                 ? "border-primary bg-primary/8 scale-[1.01]"
                 : "border-border/70 hover:border-primary/50 hover:bg-muted/25",
@@ -277,8 +276,8 @@ export function PortfolioImportView({
             onClick={triggerFileInput}
           >
             {/* Upload Icon */}
-            <div className="mx-auto w-14 h-14 rounded-full bg-primary/10 border border-primary/15 flex items-center justify-center mb-3">
-              <Icon icon={Upload} size={30} className="text-primary" />
+            <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full border border-primary/15 bg-primary/10">
+              <Icon icon={Upload} size={26} className="text-primary" />
             </div>
 
             {/* Text */}
@@ -317,7 +316,7 @@ export function PortfolioImportView({
             variant="morphy"
             effect="fill"
             size="default"
-            className="h-12 w-full rounded-full border-none text-[16px] font-medium shadow-[0_10px_30px_-20px_rgba(0,102,204,0.55)]"
+            className="h-11 w-full rounded-full border-none text-[15px] font-medium shadow-[0_10px_30px_-20px_rgba(0,102,204,0.55)]"
             onClick={handleContinue}
             disabled={isUploading || isPreloadingSchema || !selectedFile}
             icon={{
@@ -347,7 +346,7 @@ export function PortfolioImportView({
             variant="blue-gradient"
             effect="fill"
             size="default"
-            className="h-12 w-full rounded-full border-none text-[16px] font-medium shadow-[0_10px_30px_-20px_rgba(0,102,204,0.55)]"
+            className="h-11 w-full rounded-full border-none text-[15px] font-medium shadow-[0_10px_30px_-20px_rgba(0,102,204,0.55)]"
             onClick={handlePreloadSchema}
             disabled={isUploading || isPreloadingSchema}
             icon={{
@@ -370,7 +369,7 @@ export function PortfolioImportView({
           effect="fade"
           onClick={onSkip}
           disabled={isUploading || isPreloadingSchema}
-          className="h-11 rounded-full px-5 text-[15px] font-medium text-muted-foreground hover:text-foreground"
+          className="h-10 rounded-full px-5 text-[14px] font-medium text-muted-foreground hover:text-foreground"
         >
           Skip for now
         </MorphyButton>

--- a/hushh-webapp/components/kai/views/portfolio-import-view.tsx
+++ b/hushh-webapp/components/kai/views/portfolio-import-view.tsx
@@ -32,15 +32,17 @@ import { scrollAppToTop } from "@/lib/navigation/use-scroll-reset";
 import {
   kaiAppBodyClassName,
   kaiAppCardBodyClassName,
+  kaiAppCardTitleClassName,
   kaiAppCompactTitleClassName,
   kaiAppEyebrowClassName,
   kaiAppHelperClassName,
+  kaiAppSectionTitleClassName,
 } from "@/components/kai/shared/kai-typography";
 
 const importCardTitleClassName =
-  "!text-[22px] !font-medium !leading-[1.12] !tracking-normal text-foreground sm:!text-[24px]";
+  cn(kaiAppSectionTitleClassName, "text-foreground");
 const importDropzoneTitleClassName =
-  "!text-[16px] !font-medium !leading-[1.24] !tracking-normal sm:!text-[17px]";
+  cn(kaiAppCardTitleClassName, "text-foreground");
 
 // =============================================================================
 // TYPES

--- a/hushh-webapp/components/kai/views/portfolio-import-view.tsx
+++ b/hushh-webapp/components/kai/views/portfolio-import-view.tsx
@@ -32,11 +32,15 @@ import { scrollAppToTop } from "@/lib/navigation/use-scroll-reset";
 import {
   kaiAppBodyClassName,
   kaiAppCardBodyClassName,
-  kaiAppCardTitleClassName,
   kaiAppCompactTitleClassName,
   kaiAppEyebrowClassName,
   kaiAppHelperClassName,
 } from "@/components/kai/shared/kai-typography";
+
+const importCardTitleClassName =
+  "text-[22px] font-medium leading-[1.12] tracking-normal text-foreground sm:text-[24px]";
+const importDropzoneTitleClassName =
+  "text-[16px] font-medium leading-[1.24] tracking-normal sm:text-[17px]";
 
 // =============================================================================
 // TYPES
@@ -163,7 +167,7 @@ export function PortfolioImportView({
     <div className="mx-auto w-full space-y-3.5 pt-3 pb-6" style={APP_MEASURE_STYLES.reading}>
       {/* Header */}
       <div className="space-y-2.5 text-center">
-        <h1 className={kaiAppCompactTitleClassName}>
+        <h1 className={cn(kaiAppCompactTitleClassName, "text-foreground")}>
           Your money
           <br />
           <span>Your options</span>
@@ -188,7 +192,7 @@ export function PortfolioImportView({
                 <Icon icon={Link2} size="md" className="text-primary" />
               </div>
               <div className="min-w-0">
-                <h3 className={kaiAppCardTitleClassName}>Connect with Plaid</h3>
+                <h3 className={importCardTitleClassName}>Connect with Plaid</h3>
                 <p className={cn(kaiAppCardBodyClassName, "mt-0.5 text-muted-foreground")}>
                   Automatically sync your brokerage accounts
                 </p>
@@ -254,7 +258,7 @@ export function PortfolioImportView({
               <Icon icon={Upload} size="md" className="text-primary" />
             </div>
             <div>
-              <h3 className={cn(kaiAppCardTitleClassName, "text-foreground")}>Upload statement</h3>
+              <h3 className={importCardTitleClassName}>Upload statement</h3>
               <p className={cn(kaiAppCardBodyClassName, "mt-0.5 text-muted-foreground")}>
                 Import official brokerage PDF or CSV manually
               </p>
@@ -282,7 +286,7 @@ export function PortfolioImportView({
 
             {/* Text */}
             <div className="space-y-1">
-              <h3 className={cn(kaiAppCardTitleClassName, "text-primary")}>
+              <h3 className={cn(importDropzoneTitleClassName, "text-primary")}>
                 {isDragging
                   ? "Drop your file here"
                   : "Tap to upload official statement"}

--- a/hushh-webapp/components/kai/views/portfolio-import-view.tsx
+++ b/hushh-webapp/components/kai/views/portfolio-import-view.tsx
@@ -166,22 +166,17 @@ export function PortfolioImportView({
   ]);
 
   return (
-    <div className="mx-auto w-full space-y-3.5 pt-3 pb-6" style={APP_MEASURE_STYLES.reading}>
+    <div className="mx-auto w-full space-y-4 pt-3 pb-6" style={APP_MEASURE_STYLES.reading}>
       {/* Header */}
-      <div className="space-y-2.5 text-center">
+      <div className="space-y-2 text-left">
+        <p className={cn(kaiAppEyebrowClassName, "text-muted-foreground")}>
+          Getting started
+        </p>
         <h1 className={cn(kaiAppCompactTitleClassName, "text-foreground")}>
-          Your money
-          <br />
-          <span>Your options</span>
+          Portfolio
         </h1>
         <p className={cn(kaiAppBodyClassName, "text-muted-foreground")}>
           Let Kai analyze your holdings for precise advice
-        </p>
-      </div>
-
-      <div className="text-center">
-        <p className={cn(kaiAppEyebrowClassName, "text-muted-foreground")}>
-          Choose import method
         </p>
       </div>
 

--- a/hushh-webapp/components/kai/views/portfolio-review-view.tsx
+++ b/hushh-webapp/components/kai/views/portfolio-review-view.tsx
@@ -1943,7 +1943,7 @@ export function PortfolioReviewView({
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex items-start gap-3">
           <div className="px-1">
-	            <h1 className="text-xl font-bold tracking-tight">Review Portfolio</h1>
+	            <h1 className="text-[20px] font-medium tracking-normal">Review Portfolio</h1>
 	            <p className="max-w-[28rem] text-sm leading-snug text-muted-foreground">
 	              {hasVault === false
 	                ? "Review your portfolio, then create your Vault to save it."
@@ -1981,7 +1981,7 @@ export function PortfolioReviewView({
                 <p className="text-xs font-bold uppercase tracking-widest text-muted-foreground mb-1">
                   Total Portfolio Value
                 </p>
-                <p className="max-w-full px-2 text-[clamp(1.7rem,8.5vw,2.55rem)] font-black leading-none tracking-tight tabular-nums whitespace-nowrap bg-linear-to-br from-foreground to-foreground/70 bg-clip-text text-transparent sm:text-4xl">
+                <p className="max-w-full px-2 text-[28px] font-medium leading-none tracking-normal tabular-nums whitespace-nowrap bg-linear-to-br from-foreground to-foreground/70 bg-clip-text text-transparent sm:text-[32px]">
                   <span title={formatCurrency(totalValue)}>{formatCurrencyCompact(totalValue)}</span>
                 </p>
 
@@ -2010,14 +2010,14 @@ export function PortfolioReviewView({
 
               <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 sm:gap-4 pt-6 border-t border-primary/10">
                 <div className="min-w-0 text-center sm:text-left sm:pl-4">
-                  <p className="text-2xl font-black">{activeHoldings.length}</p>
+                  <p className="text-[1.35rem] font-medium sm:text-[1.5rem]">{activeHoldings.length}</p>
                   <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">Assets</p>
                 </div>
                 <div className="min-w-0 flex flex-col items-center justify-center">
                   <Badge
                     variant="outline"
                     className={cn(
-                      "font-black text-[10px] uppercase tracking-widest px-2",
+                      "font-semibold text-[10px] uppercase tracking-widest px-2",
                       riskBucket === "aggressive"
                         ? "app-critical-badge"
                         : riskBucket === "moderate"
@@ -2032,7 +2032,7 @@ export function PortfolioReviewView({
                 <div className="min-w-0 text-center sm:text-right sm:pr-4">
                   <p
                     className={cn(
-                      "max-w-full text-[clamp(1.05rem,5.8vw,1.55rem)] font-black leading-none tabular-nums whitespace-nowrap sm:text-2xl",
+                      "max-w-full text-[20px] font-medium leading-none tracking-normal tabular-nums whitespace-nowrap sm:text-[22px]",
                       liveCashBalance < 0
                         ? "text-red-500 dark:text-red-400"
                         : "text-foreground"
@@ -2275,7 +2275,7 @@ export function PortfolioReviewView({
             <CardHeader className="border-b border-[color:var(--app-card-border-standard)] bg-[var(--app-card-surface-sticky-header)] px-6 pb-4 pt-6">
               <div className="flex items-center justify-between gap-2">
                 <div>
-                  <CardTitle className="text-lg font-black uppercase tracking-widest text-foreground">
+                  <CardTitle className="text-[15px] font-medium uppercase tracking-[0.14em] text-foreground">
                     Holdings ({holdings.length})
                     {pendingDeleteCount > 0 ? (
                       <span className="ml-2 text-[11px] font-semibold text-muted-foreground">

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -7,11 +7,11 @@ import React, { useEffect, useMemo, type CSSProperties } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import {
   ChartSpline,
+  ChartCandlestick,
+  CircleUserRound,
   Compass,
   FileSpreadsheet,
   House,
-  Landmark,
-  UserRound,
   Users,
   WalletCards,
 } from "lucide-react";
@@ -126,7 +126,7 @@ export const Navbar = () => {
             {
               value: "profile",
               label: "Profile",
-              icon: UserRound,
+              icon: CircleUserRound,
               badge: pendingConsents > 0 ? pendingConsents : undefined,
               dataTourId: "nav-profile",
             },
@@ -135,7 +135,7 @@ export const Navbar = () => {
             {
               value: "market",
               label: "Market",
-              icon: Landmark,
+              icon: ChartCandlestick,
               dataTourId: "nav-market",
             },
             {
@@ -159,7 +159,7 @@ export const Navbar = () => {
             {
               value: "profile",
               label: "Profile",
-              icon: UserRound,
+              icon: CircleUserRound,
               badge: pendingConsents > 0 ? pendingConsents : undefined,
               dataTourId: "nav-profile",
             },

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -6,6 +6,7 @@
 import React, { useEffect, useMemo, type CSSProperties } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import {
+  Bot,
   BriefcaseBusiness,
   ChartNoAxesColumnIncreasing,
   Compass,
@@ -288,6 +289,21 @@ export const Navbar = () => {
             )}
           />
         </div>
+        {agentPopover ? (
+          <button
+            type="button"
+            aria-label="Open Agent"
+            title="Open Agent"
+            data-testid="bottom-agent-trigger"
+            onClick={() => agentPopover.openAgent()}
+            className={cn(
+              "pointer-events-auto chrome-bottom-foreground flex h-[58px] w-[58px] shrink-0 items-center justify-center rounded-[22px] border border-black/[0.08] bg-white/92 text-[#1c1c1e] shadow-[0_10px_30px_rgba(15,23,42,0.16)] backdrop-blur-xl transition-colors hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 dark:border-white/[0.12] dark:bg-[#1c1c1e]/90 dark:text-white dark:shadow-black/30 dark:hover:bg-[#2c2c2e]",
+              hideBottomChrome && "pointer-events-none"
+            )}
+          >
+            <Bot className="h-5 w-5" aria-hidden="true" />
+          </button>
+        ) : null}
       </div>
     </nav>
   );

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -6,7 +6,6 @@
 import React, { useEffect, useMemo, type CSSProperties } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import {
-  Bot,
   BriefcaseBusiness,
   ChartNoAxesColumnIncreasing,
   Compass,
@@ -97,6 +96,9 @@ export const Navbar = () => {
     pathname === ROUTES.DEVELOPERS;
   const agentWindowOpen =
     agentPopover?.expanded || agentPopover?.motionState === "opening";
+  const portfolioImportSurfaceActive = Boolean(
+    busyOperations["portfolio_import_surface"]
+  );
 
   const navOptions = useMemo<SegmentedPillOption[]>(
     () =>
@@ -170,7 +172,7 @@ export const Navbar = () => {
     [activePersona, pendingConsents]
   );
 
-  if (hideNavbar || agentWindowOpen) {
+  if (hideNavbar || agentWindowOpen || portfolioImportSurfaceActive) {
     return null;
   }
 
@@ -289,21 +291,6 @@ export const Navbar = () => {
             )}
           />
         </div>
-        {agentPopover ? (
-          <button
-            type="button"
-            aria-label="Open Agent"
-            title="Open Agent"
-            data-testid="bottom-agent-trigger"
-            onClick={() => agentPopover.openAgent()}
-            className={cn(
-              "pointer-events-auto chrome-bottom-foreground flex h-[58px] w-[58px] shrink-0 items-center justify-center rounded-[22px] border border-black/[0.08] bg-white/92 text-[#1c1c1e] shadow-[0_10px_30px_rgba(15,23,42,0.16)] backdrop-blur-xl transition-colors hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 dark:border-white/[0.12] dark:bg-[#1c1c1e]/90 dark:text-white dark:shadow-black/30 dark:hover:bg-[#2c2c2e]",
-              hideBottomChrome && "pointer-events-none"
-            )}
-          >
-            <Bot className="h-5 w-5" aria-hidden="true" />
-          </button>
-        ) : null}
       </div>
     </nav>
   );

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -6,14 +6,16 @@
 import React, { useEffect, useMemo, type CSSProperties } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import {
-  ChartSpline,
-  ChartCandlestick,
+  BriefcaseBusiness,
+  ChartNoAxesColumnIncreasing,
+  ChartNoAxesCombined,
   CircleUserRound,
   Compass,
   FileSpreadsheet,
   House,
+  Network,
+  UserRound,
   Users,
-  WalletCards,
 } from "lucide-react";
 
 import { useAuth } from "@/hooks/use-auth";
@@ -135,31 +137,31 @@ export const Navbar = () => {
             {
               value: "market",
               label: "Market",
-              icon: ChartCandlestick,
+              icon: ChartNoAxesColumnIncreasing,
               dataTourId: "nav-market",
             },
             {
               value: "dashboard",
               label: "Portfolio",
-              icon: WalletCards,
+              icon: BriefcaseBusiness,
               dataTourId: "nav-portfolio",
             },
             {
               value: "analysis",
               label: "Analysis",
-              icon: ChartSpline,
+              icon: ChartNoAxesCombined,
               dataTourId: "nav-analysis",
             },
             {
               value: "connect",
               label: "Connect",
-              icon: Compass,
+              icon: Network,
               dataTourId: "nav-connect",
             },
             {
               value: "profile",
               label: "Profile",
-              icon: CircleUserRound,
+              icon: UserRound,
               badge: pendingConsents > 0 ? pendingConsents : undefined,
               dataTourId: "nav-profile",
             },

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -7,13 +7,13 @@ import React, { useEffect, useMemo, type CSSProperties } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import {
   BriefcaseBusiness,
+  ChartNoAxesColumnIncreasing,
   Compass,
   FileSpreadsheet,
-  LayoutDashboard,
-  LineChart,
-  Store,
-  User,
+  Landmark,
+  UserRound,
   Users,
+  WalletCards,
 } from "lucide-react";
 
 import { useAuth } from "@/hooks/use-auth";
@@ -128,7 +128,7 @@ export const Navbar = () => {
             {
               value: "profile",
               label: "Profile",
-              icon: User,
+              icon: UserRound,
               badge: pendingConsents > 0 ? pendingConsents : undefined,
               dataTourId: "nav-profile",
             },
@@ -137,19 +137,19 @@ export const Navbar = () => {
             {
               value: "market",
               label: "Market",
-              icon: Store,
+              icon: Landmark,
               dataTourId: "nav-market",
             },
             {
               value: "dashboard",
               label: "Portfolio",
-              icon: LayoutDashboard,
+              icon: WalletCards,
               dataTourId: "nav-portfolio",
             },
             {
               value: "analysis",
               label: "Analysis",
-              icon: LineChart,
+              icon: ChartNoAxesColumnIncreasing,
               dataTourId: "nav-analysis",
             },
             {
@@ -161,7 +161,7 @@ export const Navbar = () => {
             {
               value: "profile",
               label: "Profile",
-              icon: User,
+              icon: UserRound,
               badge: pendingConsents > 0 ? pendingConsents : undefined,
               dataTourId: "nav-profile",
             },

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -6,16 +6,14 @@
 import React, { useEffect, useMemo, type CSSProperties } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import {
-  BriefcaseBusiness,
-  ChartNoAxesColumnIncreasing,
-  ChartNoAxesCombined,
+  ChartSpline,
+  ChartCandlestick,
   CircleUserRound,
   Compass,
   FileSpreadsheet,
   House,
-  Network,
-  UserRound,
   Users,
+  WalletCards,
 } from "lucide-react";
 
 import { useAuth } from "@/hooks/use-auth";
@@ -142,31 +140,31 @@ export const Navbar = () => {
             {
               value: "market",
               label: "Market",
-              icon: ChartNoAxesColumnIncreasing,
+              icon: ChartCandlestick,
               dataTourId: "nav-market",
             },
             {
               value: "dashboard",
               label: "Portfolio",
-              icon: BriefcaseBusiness,
+              icon: WalletCards,
               dataTourId: "nav-portfolio",
             },
             {
               value: "analysis",
               label: "Analysis",
-              icon: ChartNoAxesCombined,
+              icon: ChartSpline,
               dataTourId: "nav-analysis",
             },
             {
               value: "connect",
               label: "Connect",
-              icon: Network,
+              icon: Compass,
               dataTourId: "nav-connect",
             },
             {
               value: "profile",
               label: "Profile",
-              icon: UserRound,
+              icon: CircleUserRound,
               badge: pendingConsents > 0 ? pendingConsents : undefined,
               dataTourId: "nav-profile",
             },

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -32,6 +32,7 @@ import { usePersonaState } from "@/lib/persona/persona-context";
 import { activeKaiRouteTabFromPath } from "@/lib/navigation/kai-route-tabs";
 import { activeRiaRouteTabFromPath } from "@/lib/navigation/ria-route-tabs";
 import { useVault } from "@/lib/vault/vault-context";
+import { useOptionalAgentPopover } from "@/components/agent/agent-popover-provider";
 
 type InvestorNavKey = "dashboard" | "market" | "connect" | "analysis" | "profile";
 type RiaNavKey = "home" | "clients" | "connect" | "picks" | "profile";
@@ -42,6 +43,7 @@ export const Navbar = () => {
   const router = useRouter();
   const { isAuthenticated } = useAuth();
   const { isVaultUnlocked } = useVault();
+  const agentPopover = useOptionalAgentPopover();
   const { activePersona } = usePersonaState();
   const pendingConsents = useConsentPendingSummaryCount();
   const pillRef = React.useRef<HTMLDivElement | null>(null);
@@ -93,9 +95,12 @@ export const Navbar = () => {
     }
   }, [pathname]);
   const hideNavbar =
+    pathname === ROUTES.AGENT ||
     pathname?.startsWith(ROUTES.PHONE_MANDATE) ||
     pathname?.startsWith(ROUTES.LABS_PROFILE_APPEARANCE) ||
     pathname === ROUTES.DEVELOPERS;
+  const agentWindowOpen =
+    agentPopover?.expanded || agentPopover?.motionState === "opening";
 
   const navOptions = useMemo<SegmentedPillOption[]>(
     () =>
@@ -169,7 +174,7 @@ export const Navbar = () => {
     [activePersona, pendingConsents]
   );
 
-  if (hideNavbar) {
+  if (hideNavbar || agentWindowOpen) {
     return null;
   }
 

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -6,14 +6,14 @@
 import React, { useEffect, useMemo, type CSSProperties } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import {
-  ChartSpline,
-  ChartCandlestick,
-  CircleUserRound,
+  BriefcaseBusiness,
   Compass,
   FileSpreadsheet,
-  House,
+  LayoutDashboard,
+  LineChart,
+  Store,
+  User,
   Users,
-  WalletCards,
 } from "lucide-react";
 
 import { useAuth } from "@/hooks/use-auth";
@@ -47,10 +47,7 @@ export const Navbar = () => {
   const pillRef = React.useRef<HTMLDivElement | null>(null);
   const chromeState = useMemo(() => getKaiChromeState(pathname), [pathname]);
   const useOnboardingChrome = chromeState.useOnboardingChrome;
-  const preserveBottomChrome = Boolean(
-    pathname?.startsWith("/ria") || pathname?.startsWith("/marketplace")
-  );
-  const allowScrollHide = isAuthenticated && !useOnboardingChrome && !preserveBottomChrome;
+  const allowScrollHide = false;
   const { hidden: hideBottomChrome, progress: hideBottomChromeProgress } = useKaiBottomChromeVisibility(allowScrollHide);
 
   const busyOperations = useKaiSession((s) => s.busyOperations);
@@ -107,7 +104,7 @@ export const Navbar = () => {
             {
               value: "home",
               label: "Home",
-              icon: House,
+              icon: BriefcaseBusiness,
               dataTourId: "nav-ria-home",
             },
             {
@@ -131,7 +128,7 @@ export const Navbar = () => {
             {
               value: "profile",
               label: "Profile",
-              icon: CircleUserRound,
+              icon: User,
               badge: pendingConsents > 0 ? pendingConsents : undefined,
               dataTourId: "nav-profile",
             },
@@ -140,19 +137,19 @@ export const Navbar = () => {
             {
               value: "market",
               label: "Market",
-              icon: ChartCandlestick,
+              icon: Store,
               dataTourId: "nav-market",
             },
             {
               value: "dashboard",
               label: "Portfolio",
-              icon: WalletCards,
+              icon: LayoutDashboard,
               dataTourId: "nav-portfolio",
             },
             {
               value: "analysis",
               label: "Analysis",
-              icon: ChartSpline,
+              icon: LineChart,
               dataTourId: "nav-analysis",
             },
             {
@@ -164,7 +161,7 @@ export const Navbar = () => {
             {
               value: "profile",
               label: "Profile",
-              icon: CircleUserRound,
+              icon: User,
               badge: pendingConsents > 0 ? pendingConsents : undefined,
               dataTourId: "nav-profile",
             },

--- a/hushh-webapp/components/onboarding/AuthStep.tsx
+++ b/hushh-webapp/components/onboarding/AuthStep.tsx
@@ -557,49 +557,48 @@ export function AuthStep({
             : "relative mx-auto flex h-full min-h-0 w-full max-w-[27rem] flex-col justify-center px-6 pb-[calc(58px+var(--app-screen-footer-pad))] pt-[calc(32px+var(--app-safe-area-top-effective,0px))]"
         }
       >
-        <div className="w-full shrink-0">
-          <header className="flex-none text-center">
-            <Image
-              src="/one-quiet-emoji.png"
-              alt="One"
-              width={48}
-              height={48}
-              priority
-              className="mx-auto h-12 w-12 object-contain drop-shadow-[0_14px_28px_rgba(0,0,0,0.08)]"
-            />
-            <div
-              role="heading"
-              aria-level={1}
-              aria-label="Sign in to One"
-              className={`mt-2.5 ${kaiAppHeroTitleClassName} text-[#1d1d1f] dark:text-[#f5f5f7]`}
-            >
-              Sign in to One.
-            </div>
-            <p className={`mx-auto mt-3 max-w-[20rem] ${kaiAppHeroBodyClassName} text-[rgba(0,0,0,0.56)] dark:text-[rgba(245,245,247,0.60)]`}>
-              Continue to your personal financial advisor.
-            </p>
-          </header>
-
-          <section
-            className={
-              compact
-                ? "flex-none pt-10"
-                : "flex-none pt-11"
-            }
+        <header className="flex-none text-center">
+          <Image
+            src="/one-quiet-emoji.png"
+            alt="One"
+            width={44}
+            height={44}
+            priority
+            className="mx-auto h-11 w-11 object-contain drop-shadow-[0_12px_24px_rgba(0,0,0,0.08)]"
+          />
+          <div
+            role="heading"
+            aria-level={1}
+            aria-label="Sign in to One"
+            className={`mt-2.5 ${kaiAppHeroTitleClassName} text-[#1d1d1f] dark:text-[#f5f5f7]`}
           >
-            <div className="mx-auto w-full max-w-[21.5rem] space-y-3">
-              {authOptions.map((option) => (
-                <AuthProviderButton
-                  key={option.id}
-                  label={option.label}
-                  icon={option.icon}
-                  onClick={option.onClick}
-                />
-              ))}
+            Sign in to One.
+          </div>
+          <p className={`mx-auto mt-3 max-w-[20rem] ${kaiAppHeroBodyClassName} text-[rgba(0,0,0,0.56)] dark:text-[rgba(245,245,247,0.60)]`}>
+            Continue to your personal financial advisor.
+          </p>
+        </header>
 
-              <p className="mx-auto max-w-[18.75rem] pt-2 text-center text-[13px] leading-[1.45] text-[#86868b] dark:text-[#8e8e93]">
-                A verified phone number is required before you continue.
-              </p>
+        <section
+          className={
+            compact
+              ? "flex-none pt-11"
+              : "flex-none pt-12"
+          }
+        >
+          <div className="mx-auto w-full max-w-[21.5rem] space-y-3">
+            {authOptions.map((option) => (
+              <AuthProviderButton
+                key={option.id}
+                label={option.label}
+                icon={option.icon}
+                onClick={option.onClick}
+              />
+            ))}
+
+            <p className="mx-auto max-w-[18.75rem] pt-2 text-center text-[13px] leading-[1.45] text-[#86868b] dark:text-[#8e8e93]">
+              A verified phone number is required before you continue.
+            </p>
 
               {(reviewModeConfig.enabled ||
                 nativeReviewerVisible ||
@@ -613,7 +612,6 @@ export function AuthStep({
               )}
             </div>
           </section>
-        </div>
 
         <footer className="absolute inset-x-6 bottom-[calc(20px+var(--app-screen-footer-pad))] flex-none">
           <p className="mx-auto max-w-[19.5rem] text-center text-[11px] leading-[1.45] text-[#86868b] dark:text-[#8e8e93]">

--- a/hushh-webapp/components/onboarding/AuthStep.tsx
+++ b/hushh-webapp/components/onboarding/AuthStep.tsx
@@ -524,7 +524,7 @@ export function AuthStep({
 
   return (
     <main
-      className="min-h-[100dvh] w-full bg-white text-[#1d1d1f] dark:bg-[#000000] dark:text-[#f5f5f7]"
+      className="h-[100dvh] min-h-[100svh] w-full overflow-hidden bg-white text-[#1d1d1f] dark:bg-[#000000] dark:text-[#f5f5f7]"
       data-testid="auth-step-primary"
     >
       <NativeTestBeacon
@@ -553,67 +553,69 @@ export function AuthStep({
       <div
         className={
           compact
-            ? "mx-auto flex min-h-[100dvh] w-full max-w-[27rem] flex-col px-6 pt-[calc(24px+var(--app-safe-area-top-effective,0px))] pb-[calc(24px+var(--app-screen-footer-pad))]"
-            : "mx-auto flex min-h-[100dvh] w-full max-w-[27rem] flex-col px-6 pt-[calc(48px+var(--app-safe-area-top-effective,0px))] pb-[calc(28px+var(--app-screen-footer-pad))]"
+            ? "relative mx-auto flex h-full min-h-0 w-full max-w-[27rem] flex-col justify-center px-6 pb-[calc(54px+var(--app-screen-footer-pad))] pt-[calc(24px+var(--app-safe-area-top-effective,0px))]"
+            : "relative mx-auto flex h-full min-h-0 w-full max-w-[27rem] flex-col justify-center px-6 pb-[calc(58px+var(--app-screen-footer-pad))] pt-[calc(32px+var(--app-safe-area-top-effective,0px))]"
         }
       >
-        <header className="flex-none text-center">
-          <Image
-            src="/one-quiet-emoji.png"
-            alt="One"
-            width={48}
-            height={48}
-            priority
-            className="mx-auto h-12 w-12 object-contain drop-shadow-[0_14px_28px_rgba(0,0,0,0.08)]"
-          />
-          <div
-            role="heading"
-            aria-level={1}
-            aria-label="Sign in to One"
-            className={`mt-2.5 ${kaiAppHeroTitleClassName} text-[#1d1d1f] dark:text-[#f5f5f7]`}
-          >
-            Sign in to One.
-          </div>
-          <p className={`mx-auto mt-3 max-w-[20rem] ${kaiAppHeroBodyClassName} text-[rgba(0,0,0,0.56)] dark:text-[rgba(245,245,247,0.60)]`}>
-            Continue to your personal financial advisor.
-          </p>
-        </header>
-
-        <section
-          className={
-            compact
-              ? "flex-none pt-11"
-              : "flex-none pt-12"
-          }
-        >
-          <div className="mx-auto w-full max-w-[21.5rem] space-y-3">
-            {authOptions.map((option) => (
-              <AuthProviderButton
-                key={option.id}
-                label={option.label}
-                icon={option.icon}
-                onClick={option.onClick}
-              />
-            ))}
-
-            <p className="mx-auto max-w-[18.75rem] pt-2 text-center text-[13px] leading-[1.45] text-[#86868b] dark:text-[#8e8e93]">
-              A verified phone number is required before you continue.
+        <div className="w-full shrink-0">
+          <header className="flex-none text-center">
+            <Image
+              src="/one-quiet-emoji.png"
+              alt="One"
+              width={48}
+              height={48}
+              priority
+              className="mx-auto h-12 w-12 object-contain drop-shadow-[0_14px_28px_rgba(0,0,0,0.08)]"
+            />
+            <div
+              role="heading"
+              aria-level={1}
+              aria-label="Sign in to One"
+              className={`mt-2.5 ${kaiAppHeroTitleClassName} text-[#1d1d1f] dark:text-[#f5f5f7]`}
+            >
+              Sign in to One.
+            </div>
+            <p className={`mx-auto mt-3 max-w-[20rem] ${kaiAppHeroBodyClassName} text-[rgba(0,0,0,0.56)] dark:text-[rgba(245,245,247,0.60)]`}>
+              Continue to your personal financial advisor.
             </p>
+          </header>
 
-            {(reviewModeConfig.enabled ||
-              nativeReviewerVisible ||
-              localReviewerCredentialsAvailable ||
-              isLocalReviewerSurface) && (
-              <AuthProviderButton
-                label="Continue as Reviewer"
-                icon={<Icon icon={Shield} size="md" />}
-                onClick={handleReviewerLogin}
-              />
-            )}
-          </div>
-        </section>
+          <section
+            className={
+              compact
+                ? "flex-none pt-10"
+                : "flex-none pt-11"
+            }
+          >
+            <div className="mx-auto w-full max-w-[21.5rem] space-y-3">
+              {authOptions.map((option) => (
+                <AuthProviderButton
+                  key={option.id}
+                  label={option.label}
+                  icon={option.icon}
+                  onClick={option.onClick}
+                />
+              ))}
 
-        <footer className={compact ? "mt-auto flex-none pt-8" : "mt-auto flex-none pt-10"}>
+              <p className="mx-auto max-w-[18.75rem] pt-2 text-center text-[13px] leading-[1.45] text-[#86868b] dark:text-[#8e8e93]">
+                A verified phone number is required before you continue.
+              </p>
+
+              {(reviewModeConfig.enabled ||
+                nativeReviewerVisible ||
+                localReviewerCredentialsAvailable ||
+                isLocalReviewerSurface) && (
+                <AuthProviderButton
+                  label="Continue as Reviewer"
+                  icon={<Icon icon={Shield} size="md" />}
+                  onClick={handleReviewerLogin}
+                />
+              )}
+            </div>
+          </section>
+        </div>
+
+        <footer className="absolute inset-x-6 bottom-[calc(20px+var(--app-screen-footer-pad))] flex-none">
           <p className="mx-auto max-w-[19.5rem] text-center text-[11px] leading-[1.45] text-[#86868b] dark:text-[#8e8e93]">
             By continuing, you agree to Kai&apos;s{" "}
             <button

--- a/hushh-webapp/components/onboarding/AuthStep.tsx
+++ b/hushh-webapp/components/onboarding/AuthStep.tsx
@@ -19,6 +19,10 @@ import { AuthProviderButton } from "@/components/onboarding/AuthProviderButton";
 import { PostAuthRouteService } from "@/lib/services/post-auth-route-service";
 import { AuthLegalDialog } from "@/components/onboarding/AuthLegalDialog";
 import {
+  kaiAppHeroBodyClassName,
+  kaiAppHeroTitleClassName,
+} from "@/components/kai/shared/kai-typography";
+import {
   isOnboardingFlowActiveCookieEnabled,
   setOnboardingFlowActiveCookie,
   setOnboardingRequiredCookie,
@@ -566,11 +570,11 @@ export function AuthStep({
             role="heading"
             aria-level={1}
             aria-label="Sign in to One"
-            className="mt-2.5 text-[38px] font-medium leading-[1.05] tracking-normal text-[#1d1d1f] sm:text-[40px] dark:text-[#f5f5f7]"
+            className={`mt-2.5 ${kaiAppHeroTitleClassName} text-[#1d1d1f] dark:text-[#f5f5f7]`}
           >
             Sign in to One.
           </div>
-          <p className="mx-auto mt-3 max-w-[20rem] text-[17px] font-normal leading-[1.42] tracking-normal text-[rgba(0,0,0,0.56)] sm:text-[18px] dark:text-[rgba(245,245,247,0.60)]">
+          <p className={`mx-auto mt-3 max-w-[20rem] ${kaiAppHeroBodyClassName} text-[rgba(0,0,0,0.56)] dark:text-[rgba(245,245,247,0.60)]`}>
             Continue to your personal financial advisor.
           </p>
         </header>

--- a/hushh-webapp/components/onboarding/AuthStep.tsx
+++ b/hushh-webapp/components/onboarding/AuthStep.tsx
@@ -561,10 +561,10 @@ export function AuthStep({
           <Image
             src="/one-quiet-emoji.png"
             alt="One"
-            width={52}
-            height={52}
+            width={48}
+            height={48}
             priority
-            className="mx-auto h-[52px] w-[52px] object-contain drop-shadow-[0_14px_28px_rgba(0,0,0,0.08)]"
+            className="mx-auto h-12 w-12 object-contain drop-shadow-[0_14px_28px_rgba(0,0,0,0.08)]"
           />
           <div
             role="heading"

--- a/hushh-webapp/components/onboarding/CarouselDemo.tsx
+++ b/hushh-webapp/components/onboarding/CarouselDemo.tsx
@@ -17,7 +17,7 @@ export function CarouselDemo() {
             <div className="p-1">
               <Card>
                 <CardContent className="flex aspect-square items-center justify-center p-6">
-                  <span className="text-4xl font-semibold">{index + 1}</span>
+                  <span className="text-2xl font-medium">{index + 1}</span>
                 </CardContent>
               </Card>
             </div>

--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -99,7 +99,7 @@ export function IntroStep({
             unoptimized
             aria-hidden="true"
             draggable={false}
-            className="relative h-[52px] w-[52px] select-none object-contain"
+            className="relative h-12 w-12 select-none object-contain"
           />
 
           <div

--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -99,7 +99,7 @@ export function IntroStep({
             unoptimized
             aria-hidden="true"
             draggable={false}
-            className="relative h-12 w-12 select-none object-contain"
+            className="relative h-11 w-11 select-none object-contain"
           />
 
           <div
@@ -115,13 +115,13 @@ export function IntroStep({
           </p>
         </section>
 
-        <div className="flex min-h-0 flex-1 items-center py-6">
+        <div className="flex min-h-0 flex-1 items-center py-7">
           <div className="relative w-full">
             <div className="relative z-10 mx-auto flex w-full max-w-[340px] flex-col gap-4">
               {INTRO_FEATURES.map((feature) => (
                 <div
                   key={feature.title}
-                  className="grid min-h-[64px] grid-cols-[48px_minmax(0,1fr)] items-center gap-4 rounded-[22px]"
+                  className="grid min-h-[68px] grid-cols-[48px_minmax(0,1fr)] items-center gap-4 rounded-[22px]"
                 >
                   <span
                     className={`grid h-12 w-12 place-items-center rounded-full border border-black/[0.04] dark:border-white/10 ${feature.tileClassName}`}
@@ -129,7 +129,7 @@ export function IntroStep({
                     <feature.icon className="h-[22px] w-[22px]" />
                   </span>
                   <div className="min-w-0">
-                    <p className="text-[17px] font-medium leading-[1.22] tracking-normal text-[#1d1d1f] dark:text-[#f5f5f7]">
+                    <p className="text-[16.5px] font-medium leading-[1.22] tracking-normal text-[#1d1d1f] dark:text-[#f5f5f7]">
                       {feature.title}
                     </p>
                     <p className="mt-1 text-[14.5px] leading-[1.35] tracking-normal text-[rgba(0,0,0,0.50)] dark:text-[rgba(245,245,247,0.56)]">

--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -3,6 +3,10 @@
 import Image from "next/image";
 import type { ComponentType, SVGProps } from "react";
 import { Button } from "@/lib/morphy-ux/button";
+import {
+  kaiAppHeroBodyClassName,
+  kaiAppHeroTitleClassName,
+} from "@/components/kai/shared/kai-typography";
 
 function ShieldBadgeIcon(props: SVGProps<SVGSVGElement>) {
   return (
@@ -102,11 +106,11 @@ export function IntroStep({
             role="heading"
             aria-level={1}
             aria-label="Meet One, Your Personal Financial Advisor"
-            className="relative mt-2.5 text-[38px] font-medium leading-[1.05] tracking-normal text-[#1d1d1f] sm:text-[40px] dark:text-[#f5f5f7]"
+            className={`relative mt-2.5 ${kaiAppHeroTitleClassName} text-[#1d1d1f] dark:text-[#f5f5f7]`}
           >
             Meet One.
           </div>
-          <p className="relative mt-3 text-[17px] font-normal leading-[1.42] tracking-normal text-[rgba(0,0,0,0.56)] sm:text-[18px] dark:text-[rgba(245,245,247,0.60)]">
+          <p className={`relative mt-3 ${kaiAppHeroBodyClassName} text-[rgba(0,0,0,0.56)] dark:text-[rgba(245,245,247,0.60)]`}>
             Your personal financial advisor.
           </p>
         </section>

--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -115,13 +115,13 @@ export function IntroStep({
           </p>
         </section>
 
-        <div className="flex min-h-0 flex-1 items-center py-7">
+        <div className="flex-none pt-9 pb-5">
           <div className="relative w-full">
-            <div className="relative z-10 mx-auto flex w-full max-w-[340px] flex-col gap-4">
+            <div className="relative z-10 mx-auto flex w-full max-w-[340px] flex-col gap-3">
               {INTRO_FEATURES.map((feature) => (
                 <div
                   key={feature.title}
-                  className="grid min-h-[68px] grid-cols-[48px_minmax(0,1fr)] items-center gap-4 rounded-[22px]"
+                  className="grid h-[70px] grid-cols-[48px_minmax(0,1fr)] items-center gap-4 rounded-[22px]"
                 >
                   <span
                     className={`grid h-12 w-12 place-items-center rounded-full border border-black/[0.04] dark:border-white/10 ${feature.tileClassName}`}

--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -88,61 +88,63 @@ export function IntroStep({
 }) {
   return (
     <main className="min-h-[100dvh] w-full bg-[#ffffff] text-[#1d1d1f] transition-colors duration-300 dark:bg-[#000000] dark:text-[#f5f5f7]">
-      <div className="mx-auto flex min-h-[100dvh] w-full max-w-[440px] flex-col px-6 pt-[calc(42px+var(--app-safe-area-top-effective,0px))]">
-        <section className="relative flex flex-none flex-col items-center text-center">
-          <Image
-            src="/one-quiet-emoji.png"
-            alt=""
-            width={762}
-            height={766}
-            priority
-            unoptimized
-            aria-hidden="true"
-            draggable={false}
-            className="relative h-11 w-11 select-none object-contain"
-          />
+      <div className="mx-auto flex min-h-[100dvh] w-full max-w-[440px] flex-col px-6 pt-[calc(34px+var(--app-safe-area-top-effective,0px))] pb-[calc(18px+var(--app-safe-area-bottom-effective,0px))]">
+        <div className="flex min-h-0 flex-1 flex-col justify-center py-6">
+          <section className="relative flex flex-none flex-col items-center text-center">
+            <Image
+              src="/one-quiet-emoji.png"
+              alt=""
+              width={762}
+              height={766}
+              priority
+              unoptimized
+              aria-hidden="true"
+              draggable={false}
+              className="relative h-11 w-11 select-none object-contain"
+            />
 
-          <div
-            role="heading"
-            aria-level={1}
-            aria-label="Meet One, Your Personal Financial Advisor"
-            className={`relative mt-2.5 ${kaiAppHeroTitleClassName} text-[#1d1d1f] dark:text-[#f5f5f7]`}
-          >
-            Meet One.
-          </div>
-          <p className={`relative mt-3 ${kaiAppHeroBodyClassName} text-[rgba(0,0,0,0.56)] dark:text-[rgba(245,245,247,0.60)]`}>
-            Your personal financial advisor.
-          </p>
-        </section>
+            <div
+              role="heading"
+              aria-level={1}
+              aria-label="Meet One, Your Personal Financial Advisor"
+              className={`relative mt-2.5 ${kaiAppHeroTitleClassName} text-[#1d1d1f] dark:text-[#f5f5f7]`}
+            >
+              Meet One.
+            </div>
+            <p className={`relative mt-3 ${kaiAppHeroBodyClassName} text-[rgba(0,0,0,0.56)] dark:text-[rgba(245,245,247,0.60)]`}>
+              Your personal financial advisor.
+            </p>
+          </section>
 
-        <div className="flex-none pt-9 pb-5">
-          <div className="relative w-full">
-            <div className="relative z-10 mx-auto flex w-full max-w-[340px] flex-col gap-3">
-              {INTRO_FEATURES.map((feature) => (
-                <div
-                  key={feature.title}
-                  className="grid h-[70px] grid-cols-[48px_minmax(0,1fr)] items-center gap-4 rounded-[22px]"
-                >
-                  <span
-                    className={`grid h-12 w-12 place-items-center rounded-full border border-black/[0.04] dark:border-white/10 ${feature.tileClassName}`}
+          <div className="flex-none pt-9">
+            <div className="relative w-full">
+              <div className="relative z-10 mx-auto flex w-full max-w-[340px] flex-col gap-3">
+                {INTRO_FEATURES.map((feature) => (
+                  <div
+                    key={feature.title}
+                    className="grid h-[70px] grid-cols-[48px_minmax(0,1fr)] items-center gap-4 rounded-[22px]"
                   >
-                    <feature.icon className="h-[22px] w-[22px]" />
-                  </span>
-                  <div className="min-w-0">
-                    <p className="text-[16.5px] font-medium leading-[1.22] tracking-normal text-[#1d1d1f] dark:text-[#f5f5f7]">
-                      {feature.title}
-                    </p>
-                    <p className="mt-1 text-[14.5px] leading-[1.35] tracking-normal text-[rgba(0,0,0,0.50)] dark:text-[rgba(245,245,247,0.56)]">
-                      {feature.subtitle}
-                    </p>
+                    <span
+                      className={`grid h-12 w-12 place-items-center rounded-full border border-black/[0.04] dark:border-white/10 ${feature.tileClassName}`}
+                    >
+                      <feature.icon className="h-[22px] w-[22px]" />
+                    </span>
+                    <div className="min-w-0">
+                      <p className="text-[16.5px] font-medium leading-[1.22] tracking-normal text-[#1d1d1f] dark:text-[#f5f5f7]">
+                        {feature.title}
+                      </p>
+                      <p className="mt-1 text-[14.5px] leading-[1.35] tracking-normal text-[rgba(0,0,0,0.50)] dark:text-[rgba(245,245,247,0.56)]">
+                        {feature.subtitle}
+                      </p>
+                    </div>
                   </div>
-                </div>
-              ))}
+                ))}
+              </div>
             </div>
           </div>
         </div>
 
-        <footer className="flex-none pb-[calc(18px+var(--app-safe-area-bottom-effective,0px))]">
+        <footer className="flex-none pt-3">
           <div className="space-y-4">
             <p className="mx-auto max-w-[34ch] text-center text-[13.5px] leading-5 tracking-normal text-[#86868b] dark:text-[rgba(245,245,247,0.44)]">
               One is consent-first. Your data stays in your vault — nothing is

--- a/hushh-webapp/components/onboarding/PreviewCarouselStep.tsx
+++ b/hushh-webapp/components/onboarding/PreviewCarouselStep.tsx
@@ -210,16 +210,16 @@ export function PreviewCarouselStep({ onContinue }: { onContinue: () => void }) 
             className={cn(
               "w-full mx-auto text-center flex flex-col justify-end gap-2",
               // Keep copy + spacing responsive without clipping on larger screens.
-              "min-h-[clamp(132px,18vh,190px)] pt-5",
+              "min-h-[clamp(118px,16vh,164px)] pt-4",
               "sm:max-w-lg"
             )}
           >
-            <h2 className="text-[32px] font-medium tracking-normal leading-[1.06] text-[#1d1d1f] sm:text-[40px] dark:text-[#f5f5f7]">
+            <h2 className="text-[28px] font-medium tracking-normal leading-[1.08] text-[#1d1d1f] sm:text-[34px] dark:text-[#f5f5f7]">
               {slides[displayIndex]?.title}{" "}
               <br />
               <span>{slides[displayIndex]?.accent}</span>
             </h2>
-            <p className="mx-auto max-w-[20rem] text-[16px] text-[rgba(0,0,0,0.56)] leading-[1.45] sm:text-[17px] dark:text-[rgba(245,245,247,0.60)]">
+            <p className="mx-auto max-w-[20rem] text-[15px] text-[rgba(0,0,0,0.56)] leading-[1.45] sm:text-[16px] dark:text-[rgba(245,245,247,0.60)]">
               {slides[displayIndex]?.subtitle}
             </p>
           </div>
@@ -239,10 +239,10 @@ export function PreviewCarouselStep({ onContinue }: { onContinue: () => void }) 
                     aria-current={idx === selectedIndex ? "step" : undefined}
                     className="basis-full pl-0 flex items-center justify-center"
                   >
-                    <div className="flex w-full min-h-[clamp(24rem,50vh,31rem)] items-center justify-center px-4 sm:px-6 md:px-8 py-3">
+                    <div className="flex w-full min-h-[clamp(23rem,48vh,29rem)] items-center justify-center px-4 sm:px-6 md:px-8 py-3">
                       <div
                         aria-hidden="true"
-                        className="h-[clamp(31rem,58vh,35rem)] w-full max-w-[22rem] sm:max-w-[24rem] md:max-w-[25rem] lg:max-w-[26rem] xl:max-w-[27rem]"
+                        className="h-[clamp(29rem,55vh,33rem)] w-full max-w-[22rem] sm:max-w-[23rem] md:max-w-[24rem] lg:max-w-[25rem]"
                       >
                         {slide.preview}
                       </div>

--- a/hushh-webapp/components/onboarding/PreviewCarouselStep.tsx
+++ b/hushh-webapp/components/onboarding/PreviewCarouselStep.tsx
@@ -224,7 +224,7 @@ export function PreviewCarouselStep({ onContinue }: { onContinue: () => void }) 
             </p>
           </div>
 
-          <div className="min-h-0 flex-1 flex items-center">
+          <div className="flex min-h-0 flex-1 items-start pt-5">
             <Carousel
               opts={{ align: "center", containScroll: "trimSnaps" }}
               setApi={setApi}
@@ -239,10 +239,10 @@ export function PreviewCarouselStep({ onContinue }: { onContinue: () => void }) 
                     aria-current={idx === selectedIndex ? "step" : undefined}
                     className="basis-full pl-0 flex items-center justify-center"
                   >
-                    <div className="flex w-full min-h-[clamp(23rem,48vh,29rem)] items-center justify-center px-4 sm:px-6 md:px-8 py-3">
+                    <div className="flex w-full items-start justify-center px-4 py-2 sm:px-6 md:px-8">
                       <div
                         aria-hidden="true"
-                        className="h-[clamp(29rem,55vh,33rem)] w-full max-w-[22rem] sm:max-w-[23rem] md:max-w-[24rem] lg:max-w-[25rem]"
+                        className="h-[clamp(24rem,50vh,29rem)] w-full max-w-[22rem] sm:max-w-[23rem] md:max-w-[24rem] lg:max-w-[25rem]"
                       >
                         {slide.preview}
                       </div>

--- a/hushh-webapp/components/onboarding/previews/PortfolioPreviewCompact.tsx
+++ b/hushh-webapp/components/onboarding/previews/PortfolioPreviewCompact.tsx
@@ -55,7 +55,7 @@ export function PortfolioPreviewCompact() {
               </span>
             </div>
 
-            <div className="mt-3 text-[38px] font-medium leading-none tracking-normal text-foreground sm:text-[48px]">
+            <div className="mt-3 text-[30px] font-medium leading-none tracking-normal text-foreground sm:text-[34px]">
               $142,893
             </div>
           </div>

--- a/hushh-webapp/components/one-location/activity-dashboard.tsx
+++ b/hushh-webapp/components/one-location/activity-dashboard.tsx
@@ -26,7 +26,7 @@ const ACTIVITY_RANGE_OPTIONS: {
 ];
 
 const activityPanelClassName =
-  "w-full min-w-0 max-w-full overflow-hidden rounded-[20px] border border-black/[0.05] bg-white shadow-[0_1px_2px_rgba(0,0,0,0.04),0_10px_30px_rgba(15,23,42,0.05)] dark:border-white/[0.08] dark:bg-[#1c1c1e]/90 dark:shadow-[0_12px_38px_rgba(0,0,0,0.28)]";
+  "w-full min-w-0 max-w-full overflow-hidden rounded-[24px] border border-black/[0.04] bg-white/95 shadow-[0_1px_2px_rgba(0,0,0,0.03),0_14px_34px_rgba(15,23,42,0.06)] backdrop-blur-xl dark:border-white/[0.08] dark:bg-[#1c1c1e]/90 dark:shadow-[0_12px_38px_rgba(0,0,0,0.24)]";
 
 function activityRangeLabel(range: OneLocationActivityRange): string {
   return (
@@ -50,7 +50,7 @@ function ActivitySectionLabel({ title }: { title: string }) {
     <div
       role="heading"
       aria-level={2}
-      className="ml-1 flex min-w-0 max-w-full flex-wrap items-center gap-1.5 text-[12px] font-semibold uppercase tracking-[0.08em] text-[#8e8e93] dark:text-white/45"
+      className="ml-1 flex min-w-0 max-w-full flex-wrap items-center gap-1.5 text-[12px] font-semibold uppercase tracking-[0.12em] text-[#8e8e93] dark:text-white/45"
     >
       {title}
     </div>
@@ -67,11 +67,11 @@ function ActivityMetricTile({
   detail: string;
 }) {
   return (
-    <div className="min-w-0 rounded-[14px] border border-black/[0.04] bg-[#f7f7fa] p-3 dark:border-white/[0.08] dark:bg-white/[0.07]">
+    <div className="min-w-0 rounded-[18px] border border-black/[0.04] bg-[#f7f7fa] p-3.5 dark:border-white/[0.08] dark:bg-white/[0.07]">
       <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[#8e8e93] dark:text-white/45">
         {label}
       </p>
-      <p className="mt-1 text-[24px] font-bold leading-none text-[#1c1c1e] dark:text-white">
+      <p className="mt-1 text-[24px] font-semibold leading-none text-[#1c1c1e] dark:text-white">
         {value}
       </p>
       <p className="mt-1 break-words text-[11px] font-medium text-[#8e8e93] [overflow-wrap:anywhere] dark:text-white/55">
@@ -91,7 +91,7 @@ function EmptyActivityState({
   description: string;
 }) {
   return (
-    <div className="flex flex-col items-center justify-center gap-2 rounded-[14px] border border-dashed border-black/[0.08] bg-[#f7f7fa] p-5 text-center dark:border-white/[0.12] dark:bg-white/[0.05]">
+    <div className="flex flex-col items-center justify-center gap-2 rounded-[18px] border border-dashed border-black/[0.08] bg-[#f7f7fa] p-5 text-center dark:border-white/[0.12] dark:bg-white/[0.05]">
       <Icon className="h-5 w-5 text-[#8e8e93]" aria-hidden="true" />
       <p className="text-[14px] font-semibold text-[#1c1c1e] dark:text-white">
         {title}
@@ -125,7 +125,7 @@ export function OneLocationActivityDashboard({
   return (
     <section className="min-w-0 max-w-full space-y-2 px-1">
       <ActivitySectionLabel title="Location activity" />
-      <div className={cn(activityPanelClassName, "space-y-4 p-3.5")}>
+      <div className={cn(activityPanelClassName, "space-y-4 p-4")}>
         <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="flex min-w-0 items-start gap-3">
             <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#eaf3ff] text-[#007aff] dark:bg-[#0a84ff]/15 dark:text-[#76b7ff]">
@@ -136,10 +136,10 @@ export function OneLocationActivityDashboard({
               )}
             </span>
             <div className="min-w-0">
-              <h3 className="text-[15px] font-bold tracking-tight text-[#1c1c1e] dark:text-white">
+              <h3 className="text-[16px] font-semibold tracking-normal text-[#1c1c1e] dark:text-white">
                 Activity history
               </h3>
-              <p className="mt-1 break-words text-[12px] leading-5 text-[#8e8e93] [overflow-wrap:anywhere] dark:text-white/55">
+              <p className="mt-1 break-words text-[13px] leading-5 text-[#6e6e73] [overflow-wrap:anywhere] dark:text-white/60">
                 {error ||
                   `${activityRangeLabel(range)} of shares, requests, views, and link responses.`}
               </p>

--- a/hushh-webapp/components/one-location/activity-dashboard.tsx
+++ b/hushh-webapp/components/one-location/activity-dashboard.tsx
@@ -26,7 +26,7 @@ const ACTIVITY_RANGE_OPTIONS: {
 ];
 
 const activityPanelClassName =
-  "overflow-hidden rounded-[20px] border border-black/[0.05] bg-white shadow-[0_1px_2px_rgba(0,0,0,0.04),0_10px_30px_rgba(15,23,42,0.05)] dark:border-white/[0.08] dark:bg-[#1c1c1e]/90 dark:shadow-[0_12px_38px_rgba(0,0,0,0.28)]";
+  "w-full min-w-0 max-w-full overflow-hidden rounded-[20px] border border-black/[0.05] bg-white shadow-[0_1px_2px_rgba(0,0,0,0.04),0_10px_30px_rgba(15,23,42,0.05)] dark:border-white/[0.08] dark:bg-[#1c1c1e]/90 dark:shadow-[0_12px_38px_rgba(0,0,0,0.28)]";
 
 function activityRangeLabel(range: OneLocationActivityRange): string {
   return (
@@ -50,7 +50,7 @@ function ActivitySectionLabel({ title }: { title: string }) {
     <div
       role="heading"
       aria-level={2}
-      className="ml-1 flex items-center gap-1.5 text-[12px] font-semibold uppercase tracking-[0.08em] text-[#8e8e93] dark:text-white/45"
+      className="ml-1 flex min-w-0 max-w-full flex-wrap items-center gap-1.5 text-[12px] font-semibold uppercase tracking-[0.08em] text-[#8e8e93] dark:text-white/45"
     >
       {title}
     </div>
@@ -67,14 +67,14 @@ function ActivityMetricTile({
   detail: string;
 }) {
   return (
-    <div className="rounded-[14px] border border-black/[0.04] bg-[#f7f7fa] p-3 dark:border-white/[0.08] dark:bg-white/[0.07]">
+    <div className="min-w-0 rounded-[14px] border border-black/[0.04] bg-[#f7f7fa] p-3 dark:border-white/[0.08] dark:bg-white/[0.07]">
       <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[#8e8e93] dark:text-white/45">
         {label}
       </p>
       <p className="mt-1 text-[24px] font-bold leading-none text-[#1c1c1e] dark:text-white">
         {value}
       </p>
-      <p className="mt-1 text-[11px] font-medium text-[#8e8e93] dark:text-white/55">
+      <p className="mt-1 break-words text-[11px] font-medium text-[#8e8e93] [overflow-wrap:anywhere] dark:text-white/55">
         {detail}
       </p>
     </div>
@@ -123,10 +123,10 @@ export function OneLocationActivityDashboard({
   const recentEvents = activity.events.slice(0, 5);
 
   return (
-    <section className="space-y-2 px-1">
+    <section className="min-w-0 max-w-full space-y-2 px-1">
       <ActivitySectionLabel title="Location activity" />
       <div className={cn(activityPanelClassName, "space-y-4 p-3.5")}>
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="flex min-w-0 items-start gap-3">
             <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#eaf3ff] text-[#007aff] dark:bg-[#0a84ff]/15 dark:text-[#76b7ff]">
               {loading ? (
@@ -139,7 +139,7 @@ export function OneLocationActivityDashboard({
               <h3 className="text-[15px] font-bold tracking-tight text-[#1c1c1e] dark:text-white">
                 Activity history
               </h3>
-              <p className="mt-1 text-[12px] leading-5 text-[#8e8e93] dark:text-white/55">
+              <p className="mt-1 break-words text-[12px] leading-5 text-[#8e8e93] [overflow-wrap:anywhere] dark:text-white/55">
                 {error ||
                   `${activityRangeLabel(range)} of shares, requests, views, and link responses.`}
               </p>
@@ -164,7 +164,7 @@ export function OneLocationActivityDashboard({
           </Select>
         </div>
 
-        <div className="grid gap-2 sm:grid-cols-3">
+        <div className="grid min-w-0 gap-2 sm:grid-cols-3">
           <ActivityMetricTile
             label="Shared with"
             value={activity.summary.sharedWithCount}
@@ -190,15 +190,15 @@ export function OneLocationActivityDashboard({
             aria-label={`One Location activity chart for ${activityRangeLabel(
               range,
             )}`}
-            className="rounded-[14px] border border-black/[0.04] bg-white/70 p-3 dark:border-white/[0.08] dark:bg-white/[0.04]"
+            className="min-w-0 max-w-full overflow-hidden rounded-[14px] border border-black/[0.04] bg-white/70 p-3 dark:border-white/[0.08] dark:bg-white/[0.04]"
           >
-            <div className="flex h-32 items-end gap-2">
+            <div className="flex h-32 min-w-0 items-end gap-1.5 sm:gap-2">
               {activity.buckets.map((bucket) => {
                 const height = Math.max(12, (bucket.total / maxBucketTotal) * 100);
                 return (
                   <div
                     key={bucket.key}
-                    className="flex min-w-0 flex-1 flex-col items-center gap-1"
+                    className="flex min-w-0 flex-1 basis-0 flex-col items-center gap-1"
                   >
                     <div className="flex h-24 w-full items-end">
                       <div
@@ -264,11 +264,11 @@ export function OneLocationActivityDashboard({
             <p className="ml-1 text-[11px] font-semibold uppercase tracking-[0.08em] text-[#8e8e93] dark:text-white/45">
               Recent history
             </p>
-            <div className="space-y-2">
+            <div className="min-w-0 space-y-2">
               {recentEvents.map((event) => (
                 <div
                   key={event.id}
-                  className="flex items-start gap-3 rounded-[14px] bg-[#f7f7fa] p-3 dark:bg-white/[0.07]"
+                  className="flex min-w-0 items-start gap-3 overflow-hidden rounded-[14px] bg-[#f7f7fa] p-3 dark:bg-white/[0.07]"
                 >
                   <span
                     className={cn(
@@ -279,10 +279,10 @@ export function OneLocationActivityDashboard({
                     <Clock3 className="h-4 w-4" aria-hidden="true" />
                   </span>
                   <div className="min-w-0 flex-1">
-                    <p className="truncate text-[14px] font-semibold text-[#1c1c1e] dark:text-white">
+                    <p className="break-words text-[14px] font-semibold text-[#1c1c1e] [overflow-wrap:anywhere] dark:text-white">
                       {event.title}
                     </p>
-                    <p className="mt-0.5 truncate text-[12px] font-medium text-[#8e8e93] dark:text-white/55">
+                    <p className="mt-0.5 break-words text-[12px] font-medium text-[#8e8e93] [overflow-wrap:anywhere] dark:text-white/55">
                       {event.detail}
                     </p>
                   </div>

--- a/hushh-webapp/components/vault/vault-flow.tsx
+++ b/hushh-webapp/components/vault/vault-flow.tsx
@@ -642,13 +642,13 @@ export function VaultFlow({
         effect="fill"
         className="overflow-hidden rounded-[28px] border border-border/35 bg-background/95 shadow-[0_24px_70px_rgba(15,23,42,0.16)] backdrop-blur-xl dark:bg-background/92"
       >
-        <CardContent className="max-h-[calc(100svh-2rem)] space-y-4 overflow-y-auto px-5 py-6 pb-[calc(1.5rem+env(safe-area-inset-bottom,0px))] [scrollbar-width:none] sm:max-h-[min(720px,calc(100svh-3rem))] sm:px-7 sm:py-7 [&::-webkit-scrollbar]:hidden">
+        <CardContent className="max-h-[min(680px,calc(100svh-2rem))] space-y-4 overflow-y-auto px-5 py-6 pb-[calc(1.5rem+env(safe-area-inset-bottom,0px))] [scrollbar-width:none] sm:max-h-[min(680px,calc(100svh-3rem))] sm:px-7 sm:py-7 [&::-webkit-scrollbar]:hidden">
           {/* Intro / Education Step */}
           {step === "intro" && (
-            <div className="mx-auto max-w-[22rem] animate-in space-y-5 text-center fade-in slide-in-from-bottom-4 duration-500">
+            <div className="mx-auto max-w-[21rem] animate-in space-y-4 text-center fade-in slide-in-from-bottom-4 duration-500">
               <div className="flex justify-center">
-                <div className="flex h-16 w-16 items-center justify-center rounded-[22px] bg-primary/10 ring-1 ring-primary/10">
-                  <Icon icon={Shield} size={30} className="text-primary" />
+                <div className="flex h-14 w-14 items-center justify-center rounded-[20px] bg-primary/10 ring-1 ring-primary/10">
+                  <Icon icon={Shield} size={26} className="text-primary" />
                 </div>
               </div>
                
@@ -656,17 +656,17 @@ export function VaultFlow({
                 <div
                   role="heading"
                   aria-level={2}
-                  className="text-[28px] font-medium leading-[1.05] tracking-normal text-foreground sm:text-[30px]"
+                  className="text-[25px] font-medium leading-[1.08] tracking-normal text-foreground sm:text-[27px]"
                 >
                   Secure Your Digital Vault
                 </div>
-                <p className="mx-auto max-w-[18rem] text-balance text-[16px] leading-[1.5] text-muted-foreground">
+                <p className="mx-auto max-w-[18rem] text-balance text-[14.5px] leading-[1.45] text-muted-foreground sm:text-[15px]">
                   Hussh uses end-to-end encryption to protect your personal data.
                   Create your passphrase first, then optionally enable faster sign-in.
                 </p>
               </div>
 
-              <div className="space-y-3 rounded-[22px] border border-border/45 bg-muted/35 p-4 text-left text-[15px] leading-[1.45] shadow-[inset_0_1px_0_rgba(255,255,255,0.35)]">
+              <div className="space-y-3 rounded-[20px] border border-border/45 bg-muted/35 p-4 text-left text-[14px] leading-[1.42] shadow-[inset_0_1px_0_rgba(255,255,255,0.35)]">
                 <div className="flex gap-3">
                   <div className="mt-0.5 min-w-[1.25rem] text-primary">
                     <Icon icon={Check} size="sm" />
@@ -709,24 +709,24 @@ export function VaultFlow({
 
           {/* Create Passphrase */}
           {step === "create" && (
-            <div className="mx-auto max-w-[22rem] space-y-4">
+            <div className="mx-auto max-w-[21rem] space-y-4">
               <div className="text-center">
-                <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-[18px] bg-primary/10 ring-1 ring-primary/10">
-                  <Icon icon={Lock} size={24} className="text-primary" />
+                <div className="mx-auto mb-3 flex h-11 w-11 items-center justify-center rounded-[17px] bg-primary/10 ring-1 ring-primary/10">
+                  <Icon icon={Lock} size={22} className="text-primary" />
                 </div>
                 <div
                   role="heading"
                   aria-level={2}
-                  className="text-[27px] font-medium leading-[1.08] tracking-normal text-foreground sm:text-[29px]"
+                  className="text-[25px] font-medium leading-[1.08] tracking-normal text-foreground sm:text-[27px]"
                 >
                   Create Your Vault Passphrase
                 </div>
-                <p className="mx-auto mt-2 max-w-[18rem] text-[15px] leading-[1.45] text-muted-foreground">
+                <p className="mx-auto mt-2 max-w-[18rem] text-[14.5px] leading-[1.45] text-muted-foreground">
                   This passphrase protects your Vault. Keep it private.
                 </p>
               </div>
               <div className="space-y-2">
-                <Label htmlFor="passphrase" className="text-[15px] font-medium">Passphrase</Label>
+                <Label htmlFor="passphrase" className="text-[14px] font-medium">Passphrase</Label>
                 <Input
                   id="passphrase"
                   type="password"
@@ -734,18 +734,18 @@ export function VaultFlow({
                   value={passphrase}
                   onChange={(e) => setPassphrase(e.target.value)}
                   autoFocus
-                  className="h-12 rounded-[18px] px-4 text-[16px] shadow-sm"
+                  className="h-11 rounded-[17px] px-4 text-[15px] shadow-sm"
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="confirm" className="text-[15px] font-medium">Confirm Passphrase</Label>
+                <Label htmlFor="confirm" className="text-[14px] font-medium">Confirm Passphrase</Label>
                 <Input
                   id="confirm"
                   type="password"
                   placeholder="Confirm your passphrase"
                   value={confirmPassphrase}
                   onChange={(e) => setConfirmPassphrase(e.target.value)}
-                  className="h-12 rounded-[18px] px-4 text-[16px] shadow-sm"
+                  className="h-11 rounded-[17px] px-4 text-[15px] shadow-sm"
                 />
                 {createPassphraseHelperText && (
                   <p className="text-xs font-medium text-destructive" role="status">
@@ -753,7 +753,7 @@ export function VaultFlow({
                   </p>
                 )}
               </div>
-              <div className="rounded-[20px] border border-border/45 bg-muted/30 p-4 text-[14px] leading-[1.45] text-muted-foreground">
+              <div className="rounded-[18px] border border-border/45 bg-muted/30 p-4 text-[13.5px] leading-[1.45] text-muted-foreground">
                 <p className="font-medium text-foreground">Passphrase requirements</p>
                 <ul className="mt-2 list-disc space-y-1 pl-4">
                   <li>Minimum 8 characters</li>

--- a/hushh-webapp/components/vault/vault-flow.tsx
+++ b/hushh-webapp/components/vault/vault-flow.tsx
@@ -640,47 +640,58 @@ export function VaultFlow({
       <Card
         variant="none"
         effect="fill"
-        className="overflow-hidden"
+        className="overflow-hidden rounded-[28px] border border-border/35 bg-background/95 shadow-[0_24px_70px_rgba(15,23,42,0.16)] backdrop-blur-xl dark:bg-background/92"
       >
-        <CardContent className="max-h-[calc(100svh-8rem)] space-y-3 overflow-y-auto p-4 pb-[calc(1rem+env(safe-area-inset-bottom,0px))] sm:max-h-[calc(100svh-10rem)] sm:space-y-4 sm:p-6">
+        <CardContent className="max-h-[calc(100svh-2rem)] space-y-4 overflow-y-auto px-5 py-6 pb-[calc(1.5rem+env(safe-area-inset-bottom,0px))] [scrollbar-width:none] sm:max-h-[min(720px,calc(100svh-3rem))] sm:px-7 sm:py-7 [&::-webkit-scrollbar]:hidden">
           {/* Intro / Education Step */}
           {step === "intro" && (
-            <div className="space-y-6 text-center animate-in fade-in slide-in-from-bottom-4 duration-500">
-              <div className="flex justify-center mb-4">
-                <div className="h-20 w-20 rounded-2xl bg-primary/10 flex items-center justify-center">
-                  <Icon icon={Shield} size={40} className="text-primary" />
+            <div className="mx-auto max-w-[22rem] animate-in space-y-5 text-center fade-in slide-in-from-bottom-4 duration-500">
+              <div className="flex justify-center">
+                <div className="flex h-16 w-16 items-center justify-center rounded-[22px] bg-primary/10 ring-1 ring-primary/10">
+                  <Icon icon={Shield} size={30} className="text-primary" />
                 </div>
               </div>
-              
+               
               <div className="space-y-2">
-                <h3 className="text-2xl font-bold tracking-tight">Secure Your Digital Vault</h3>
-                <p className="text-muted-foreground text-balance max-w-sm mx-auto">
+                <div
+                  role="heading"
+                  aria-level={2}
+                  className="text-[28px] font-medium leading-[1.05] tracking-normal text-foreground sm:text-[30px]"
+                >
+                  Secure Your Digital Vault
+                </div>
+                <p className="mx-auto max-w-[18rem] text-balance text-[16px] leading-[1.5] text-muted-foreground">
                   Hussh uses end-to-end encryption to protect your personal data.
                   Create your passphrase first, then optionally enable faster sign-in.
                 </p>
               </div>
 
-              <div className="text-left bg-muted/50 rounded-xl p-4 space-y-3 text-sm border border-border/50">
+              <div className="space-y-3 rounded-[22px] border border-border/45 bg-muted/35 p-4 text-left text-[15px] leading-[1.45] shadow-[inset_0_1px_0_rgba(255,255,255,0.35)]">
                 <div className="flex gap-3">
                   <div className="mt-0.5 min-w-[1.25rem] text-primary">
-                     <Icon icon={Check} size="md" />
+                    <Icon icon={Check} size="sm" />
                   </div>
-                  <p><span className="font-semibold block text-foreground">You hold the only key</span> We cannot see your data or reset your password.</p>
+                  <p>
+                    <span className="block font-medium text-foreground">You hold the only key</span>
+                    <span className="text-muted-foreground">We cannot see your data or reset your password.</span>
+                  </p>
                 </div>
                 <div className="flex gap-3">
-                   <div className="mt-0.5 min-w-[1.25rem] text-primary">
-                     <Icon icon={Check} size="md" />
+                  <div className="mt-0.5 min-w-[1.25rem] text-primary">
+                    <Icon icon={Check} size="sm" />
                   </div>
-                  <p><span className="font-semibold block text-foreground">Protected by default</span> Your data stays private and secure.</p>
+                  <p>
+                    <span className="block font-medium text-foreground">Protected by default</span>
+                    <span className="text-muted-foreground">Your data stays private and secure.</span>
+                  </p>
                 </div>
               </div>
 
-              <div className="space-y-2">
               <Button 
                   variant="gradient" 
                   size={ACTION_BUTTON_SIZE}
                   fullWidth
-                  className="group whitespace-normal text-center leading-snug px-4"
+                  className="group h-12 whitespace-normal rounded-full px-4 text-center text-[16px] font-medium leading-snug"
                   onClick={() => {
                     setError(null);
                     setStep("create");
@@ -693,23 +704,29 @@ export function VaultFlow({
                     className="ml-2 transition-transform group-hover:translate-x-1"
                   />
                 </Button>
-
-              </div>
             </div>
           )}
 
           {/* Create Passphrase */}
           {step === "create" && (
-            <div className="space-y-3">
+            <div className="mx-auto max-w-[22rem] space-y-4">
               <div className="text-center">
-                <Icon icon={Lock} size={36} className="mx-auto text-primary mb-3" />
-                <h3 className="text-lg font-semibold sm:text-xl">Create Your Vault Passphrase</h3>
-                <p className="mt-1.5 text-sm text-muted-foreground sm:text-base">
+                <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-[18px] bg-primary/10 ring-1 ring-primary/10">
+                  <Icon icon={Lock} size={24} className="text-primary" />
+                </div>
+                <div
+                  role="heading"
+                  aria-level={2}
+                  className="text-[27px] font-medium leading-[1.08] tracking-normal text-foreground sm:text-[29px]"
+                >
+                  Create Your Vault Passphrase
+                </div>
+                <p className="mx-auto mt-2 max-w-[18rem] text-[15px] leading-[1.45] text-muted-foreground">
                   This passphrase protects your Vault. Keep it private.
                 </p>
               </div>
               <div className="space-y-2">
-                <Label htmlFor="passphrase" className="text-sm sm:text-base">Passphrase</Label>
+                <Label htmlFor="passphrase" className="text-[15px] font-medium">Passphrase</Label>
                 <Input
                   id="passphrase"
                   type="password"
@@ -717,18 +734,18 @@ export function VaultFlow({
                   value={passphrase}
                   onChange={(e) => setPassphrase(e.target.value)}
                   autoFocus
-                  className="h-11 px-3 text-base sm:h-12 sm:px-4 sm:text-lg"
+                  className="h-12 rounded-[18px] px-4 text-[16px] shadow-sm"
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="confirm" className="text-sm sm:text-base">Confirm Passphrase</Label>
+                <Label htmlFor="confirm" className="text-[15px] font-medium">Confirm Passphrase</Label>
                 <Input
                   id="confirm"
                   type="password"
                   placeholder="Confirm your passphrase"
                   value={confirmPassphrase}
                   onChange={(e) => setConfirmPassphrase(e.target.value)}
-                  className="h-11 px-3 text-base sm:h-12 sm:px-4 sm:text-lg"
+                  className="h-12 rounded-[18px] px-4 text-[16px] shadow-sm"
                 />
                 {createPassphraseHelperText && (
                   <p className="text-xs font-medium text-destructive" role="status">
@@ -736,14 +753,14 @@ export function VaultFlow({
                   </p>
                 )}
               </div>
-              <div className="rounded-xl border border-border/60 bg-muted/20 p-2.5 text-[11px] text-muted-foreground sm:p-3 sm:text-sm">
-                <p className="font-semibold text-foreground">Passphrase requirements</p>
-                <ul className="mt-1 list-disc space-y-0.5 pl-4">
+              <div className="rounded-[20px] border border-border/45 bg-muted/30 p-4 text-[14px] leading-[1.45] text-muted-foreground">
+                <p className="font-medium text-foreground">Passphrase requirements</p>
+                <ul className="mt-2 list-disc space-y-1 pl-4">
                   <li>Minimum 8 characters</li>
                   <li>Use a memorable phrase unique to you</li>
                   <li>Avoid reused passwords from other apps</li>
                 </ul>
-                <p className="mt-1.5 text-[10px] text-muted-foreground sm:mt-2 sm:text-xs">
+                <p className="mt-3 text-[13px] leading-[1.4] text-muted-foreground">
                   You can enable passkey or device unlock later from Profile.
                 </p>
               </div>
@@ -752,7 +769,7 @@ export function VaultFlow({
                 effect="glass"
                 size="default"
                 fullWidth
-                className="mt-2 h-11 text-sm sm:mt-4 sm:h-12 sm:text-base"
+                className="mt-1 h-12 rounded-full text-[16px] font-medium"
                 onClick={handleCreatePassphrase}
                 disabled={isUnlocking || passphrase.length < 8 || passphrase !== confirmPassphrase}
               >
@@ -776,7 +793,13 @@ export function VaultFlow({
                   size={24}
                   className="mx-auto mb-2 text-primary"
                 />
-                <h3 className="text-base font-semibold sm:text-lg">Unlock Your Vault</h3>
+                <div
+                  role="heading"
+                  aria-level={2}
+                  className="text-[20px] font-medium leading-[1.14] tracking-normal text-foreground"
+                >
+                  Unlock Your Vault
+                </div>
                 <p className="mt-1 line-clamp-1 text-xs text-muted-foreground sm:text-sm">
                   {isGeneratedVaultMode
                     ? "Confirm with your device to open Vault"
@@ -814,7 +837,7 @@ export function VaultFlow({
                     effect="glass"
                     size="default"
                     fullWidth
-                    className="h-10 text-sm font-semibold sm:h-11"
+                    className="h-11 rounded-full text-[15px] font-medium"
                     onClick={() => void handleUnlockPassphrase()}
                     disabled={isUnlocking || !passphrase}
                   >
@@ -865,7 +888,7 @@ export function VaultFlow({
                           effect="fade"
                           size="default"
                           fullWidth
-                          className="h-10 px-2 text-xs sm:h-11 sm:text-sm"
+                          className="h-10 rounded-full px-2 text-[13px] font-medium sm:h-11 sm:text-[14px]"
                           data-testid="vault-use-passphrase-instead"
                           onClick={() => {
                             setError(null);
@@ -883,7 +906,7 @@ export function VaultFlow({
                           effect="fade"
                           size="default"
                           fullWidth
-                          className="h-10 px-2 text-xs sm:h-11 sm:text-sm"
+                          className="h-10 rounded-full px-2 text-[13px] font-medium sm:h-11 sm:text-[14px]"
                           onClick={() => {
                             setError(null);
                             setPassphrase("");
@@ -903,7 +926,7 @@ export function VaultFlow({
                           effect="glass"
                           size="default"
                           fullWidth
-                          className="h-10 px-2 text-xs sm:h-11 sm:text-sm"
+                          className="h-10 rounded-full px-2 text-[13px] font-medium sm:h-11 sm:text-[14px]"
                           onClick={() => {
                             setError(null);
                             setStep("recovery");
@@ -925,7 +948,13 @@ export function VaultFlow({
             <div className="space-y-2.5">
               <div className="text-center">
                 <Icon icon={Key} size={24} className="mx-auto mb-2 text-primary" />
-                <h3 className="text-base font-semibold sm:text-lg">Enter Recovery Key</h3>
+                <div
+                  role="heading"
+                  aria-level={2}
+                  className="text-[20px] font-medium leading-[1.14] tracking-normal text-foreground"
+                >
+                  Enter Recovery Key
+                </div>
                 <p className="mt-1 line-clamp-1 text-xs text-muted-foreground sm:text-sm">
                   Enter your recovery key to open Vault
                 </p>
@@ -952,7 +981,7 @@ export function VaultFlow({
                   effect="glass"
                   size="default"
                   fullWidth
-                  className="h-10 text-sm font-semibold sm:h-11"
+                  className="h-11 rounded-full text-[15px] font-medium"
                   onClick={handleRecoveryKeySubmit}
                   disabled={isUnlocking || !recoveryKeyInput}
                 >
@@ -972,7 +1001,7 @@ export function VaultFlow({
                       effect="glass"
                       size="default"
                       fullWidth
-                      className="h-10 px-2 text-xs sm:h-11 sm:text-sm"
+                      className="h-10 rounded-full px-2 text-[13px] font-medium sm:h-11 sm:text-[14px]"
                       onClick={() => {
                         setError(null);
                         setUnlockWithPassphraseFallback(true);
@@ -988,7 +1017,7 @@ export function VaultFlow({
                         effect="glass"
                         size="default"
                         fullWidth
-                        className="h-10 px-2 text-xs sm:h-11 sm:text-sm"
+                        className="h-10 rounded-full px-2 text-[13px] font-medium sm:h-11 sm:text-[14px]"
                         onClick={() => {
                           setError(null);
                           setPassphrase("");
@@ -1020,8 +1049,14 @@ export function VaultFlow({
                   size={36}
                   className="mx-auto mb-3 text-primary"
                 />
-                <h3 className="text-lg font-semibold sm:text-xl">Enable quicker unlock?</h3>
-                <p className="mt-1.5 text-sm text-muted-foreground sm:text-base">
+                <div
+                  role="heading"
+                  aria-level={2}
+                  className="text-[24px] font-medium leading-[1.1] tracking-normal text-foreground"
+                >
+                  Enable quicker unlock?
+                </div>
+                <p className="mt-2 text-[15px] leading-[1.45] text-muted-foreground">
                   You can keep passphrase unlock, or enable{" "}
                   {recommendedQuickMethod === "generated_default_web_prf" ||
                   recommendedQuickMethod === "generated_default_native_passkey_prf"
@@ -1037,7 +1072,7 @@ export function VaultFlow({
                   effect="glass"
                   size="default"
                   fullWidth
-                  className="h-11 text-sm sm:h-12 sm:text-base"
+                  className="h-12 rounded-full text-[16px] font-medium"
                   disabled={isUnlocking || !pendingUnlockKey || !recommendedQuickMethod}
                   onClick={async () => {
                     if (!pendingUnlockKey || !recommendedQuickMethod) return;
@@ -1088,7 +1123,7 @@ export function VaultFlow({
                   effect="fade"
                   size="default"
                   fullWidth
-                  className="h-11 whitespace-normal px-4 text-center text-sm leading-snug sm:h-12 sm:text-base"
+                  className="h-11 whitespace-normal rounded-full px-4 text-center text-[15px] font-medium leading-snug sm:h-12"
                   disabled={isUnlocking || !pendingUnlockKey}
                   onClick={async () => {
                     if (!pendingUnlockKey) return;
@@ -1123,31 +1158,35 @@ export function VaultFlow({
         onOpenChange={() => {}}
       >
         <DialogContent
-          className="z-[520] w-[calc(100%-1rem)] max-h-[calc(100svh-1rem)] overflow-y-auto sm:max-w-md"
+          className="z-[520] max-h-[calc(100svh-1rem)] w-[calc(100%-1rem)] overflow-y-auto rounded-[28px] border border-border/35 bg-background/95 p-6 shadow-[0_24px_70px_rgba(15,23,42,0.18)] backdrop-blur-xl sm:max-w-md sm:p-7"
           onPointerDownOutside={(e) => e.preventDefault()}
         >
           <DialogHeader>
-            <div className="flex items-center gap-2">
-              <Icon icon={Key} size="lg" className="text-orange-500" />
-              <DialogTitle>Save Your Recovery Key</DialogTitle>
+            <div className="flex items-center gap-3">
+              <div className="grid h-11 w-11 shrink-0 place-items-center rounded-[16px] bg-orange-500/10 ring-1 ring-orange-500/15">
+                <Icon icon={Key} size="sm" className="text-orange-500" />
+              </div>
+              <DialogTitle className="!text-[22px] !font-medium !leading-[1.12] !tracking-normal">
+                Save Your Recovery Key
+              </DialogTitle>
             </div>
-            <DialogDescription>
+            <DialogDescription className="pt-1 text-[14.5px] leading-[1.45]">
               This is the ONLY way to recover your vault if you forget your
               vault credentials. Store it somewhere safe!
             </DialogDescription>
           </DialogHeader>
 
           <div className="space-y-4">
-            <Alert className="bg-orange-500/10 border-orange-500/50">
+            <Alert className="rounded-[18px] border-orange-500/30 bg-orange-500/10">
               <Icon icon={AlertCircle} size="sm" className="text-orange-500" />
-              <AlertDescription className="text-orange-700 dark:text-orange-300">
+              <AlertDescription className="text-[13.5px] leading-[1.4] text-orange-700 dark:text-orange-300">
                 Write this down or save it securely. You cannot recover it
                 later!
               </AlertDescription>
             </Alert>
 
-            <div className="p-4 bg-muted rounded-lg border-2 border-dashed">
-              <code className="text-lg font-mono font-bold tracking-wide">
+            <div className="rounded-[18px] border border-dashed border-border bg-muted/45 p-4">
+              <code className="break-all font-mono text-[15px] font-medium leading-[1.5] tracking-normal">
                 {recoveryKey}
               </code>
             </div>
@@ -1155,7 +1194,7 @@ export function VaultFlow({
             <div className="flex flex-col gap-2 sm:flex-row">
               <Button
                 variant="none"
-                className="flex-1 border border-gray-200 dark:border-gray-700 whitespace-normal"
+                className="h-11 flex-1 whitespace-normal rounded-full border border-gray-200 text-[15px] font-medium dark:border-gray-700"
                 onClick={handleCopyRecoveryKey}
               >
                 {copied ? (
@@ -1172,7 +1211,7 @@ export function VaultFlow({
               </Button>
               <Button
                 variant="none"
-                className="flex-1 border border-gray-200 dark:border-gray-700 whitespace-normal"
+                className="h-11 flex-1 whitespace-normal rounded-full border border-gray-200 text-[15px] font-medium dark:border-gray-700"
                 onClick={async () => {
                   const content = `Hussh Recovery Key\n\n${recoveryKey}\n\nStore this file securely. This is the ONLY way to recover your vault if you lose your vault credentials.`;
                   await downloadTextFile(content, "hushh-recovery-key.txt");
@@ -1189,7 +1228,7 @@ export function VaultFlow({
               variant="gradient"
               effect="glass"
               size={ACTION_BUTTON_SIZE}
-              className="w-full whitespace-normal text-center leading-snug h-auto min-h-12 px-4"
+              className="h-12 w-full whitespace-normal rounded-full px-4 text-center text-[16px] font-medium leading-snug"
               onClick={handleRecoveryKeyContinue}
             >
               I've Saved My Recovery Key

--- a/hushh-webapp/ios/App/App/Plugins/HushhLocationPlugin.swift
+++ b/hushh-webapp/ios/App/App/Plugins/HushhLocationPlugin.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Capacitor
 import CoreLocation
+import UIKit
 
 /**
  * HushhLocationPlugin - foreground-only one-shot location capture.
@@ -15,6 +16,7 @@ public class HushhLocationPlugin: CAPPlugin, CAPBridgedPlugin, CLLocationManager
     public let jsName = "HushhLocation"
     public let pluginMethods: [CAPPluginMethod] = [
         CAPPluginMethod(name: "getPermissionState", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "openLocationSettings", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getCurrentPosition", returnType: CAPPluginReturnPromise)
     ]
 
@@ -28,6 +30,22 @@ public class HushhLocationPlugin: CAPPlugin, CAPBridgedPlugin, CLLocationManager
 
     @objc func getPermissionState(_ call: CAPPluginCall) {
         call.resolve(permissionPayload())
+    }
+
+    @objc func openLocationSettings(_ call: CAPPluginCall) {
+        guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else {
+            call.reject("Location settings are unavailable on this device.")
+            return
+        }
+
+        DispatchQueue.main.async {
+            UIApplication.shared.open(settingsUrl, options: [:]) { opened in
+                call.resolve([
+                    "opened": opened,
+                    "sourcePlatform": "ios"
+                ])
+            }
+        }
     }
 
     @objc func getCurrentPosition(_ call: CAPPluginCall) {
@@ -59,10 +77,11 @@ public class HushhLocationPlugin: CAPPlugin, CAPBridgedPlugin, CLLocationManager
     }
 
     private func permissionPayload() -> [String: Any] {
+        let locationServicesEnabled = CLLocationManager.locationServicesEnabled()
         let state: String
         switch manager.authorizationStatus {
         case .authorizedAlways, .authorizedWhenInUse:
-            state = "granted"
+            state = locationServicesEnabled ? "granted" : "unavailable"
         case .notDetermined:
             state = "prompt"
         case .denied:
@@ -83,7 +102,8 @@ public class HushhLocationPlugin: CAPPlugin, CAPBridgedPlugin, CLLocationManager
         return [
             "state": state,
             "precise": precise as Any,
-            "background": "foreground-only"
+            "background": "foreground-only",
+            "locationServicesEnabled": locationServicesEnabled
         ]
     }
 

--- a/hushh-webapp/lib/capacitor/index.ts
+++ b/hushh-webapp/lib/capacitor/index.ts
@@ -768,10 +768,15 @@ export type HushhLocationPermissionState = {
   state: "granted" | "denied" | "prompt" | "restricted" | "unavailable";
   precise: boolean | null;
   background: "foreground-only" | "available" | "restricted" | "unavailable";
+  locationServicesEnabled?: boolean | null;
 };
 
 export interface HushhLocationPlugin {
   getPermissionState(): Promise<HushhLocationPermissionState>;
+  openLocationSettings(): Promise<{
+    opened: boolean;
+    sourcePlatform: "web" | "ios" | "android" | "native";
+  }>;
   getCurrentPosition(options?: {
     enableHighAccuracy?: boolean;
     timeoutMs?: number;
@@ -799,6 +804,7 @@ export type HushhContactRecord = {
   id?: string | null;
   displayName?: string | null;
   phoneNumbers: string[];
+  emailAddresses?: string[];
 };
 
 export interface HushhContactsPlugin {

--- a/hushh-webapp/lib/capacitor/plugins/location-web.ts
+++ b/hushh-webapp/lib/capacitor/plugins/location-web.ts
@@ -10,10 +10,20 @@ function geolocationAvailable(): boolean {
 export class HushhLocationWeb implements HushhLocationPlugin {
   async getPermissionState(): Promise<HushhLocationPermissionState> {
     if (!geolocationAvailable()) {
-      return { state: "unavailable", precise: false, background: "unavailable" };
+      return {
+        state: "unavailable",
+        precise: false,
+        background: "unavailable",
+        locationServicesEnabled: false,
+      };
     }
     if (!navigator.permissions?.query) {
-      return { state: "prompt", precise: null, background: "foreground-only" };
+      return {
+        state: "prompt",
+        precise: null,
+        background: "foreground-only",
+        locationServicesEnabled: null,
+      };
     }
     const result = await navigator.permissions.query({
       name: "geolocation" as PermissionName,
@@ -22,7 +32,15 @@ export class HushhLocationWeb implements HushhLocationPlugin {
       state: result.state,
       precise: null,
       background: "foreground-only",
+      locationServicesEnabled: null,
     };
+  }
+
+  async openLocationSettings(): Promise<{
+    opened: boolean;
+    sourcePlatform: "web";
+  }> {
+    return { opened: false, sourcePlatform: "web" };
   }
 
   async getCurrentPosition(options?: {

--- a/hushh-webapp/lib/navigation/kai-chrome-state.ts
+++ b/hushh-webapp/lib/navigation/kai-chrome-state.ts
@@ -36,6 +36,7 @@ export function getKaiChromeState(
   const hideCommandBar =
     useOnboardingChrome ||
     path === ROUTES.HOME ||
+    path === ROUTES.AGENT ||
     path.startsWith(ROUTES.LOGIN) ||
     path.startsWith(ROUTES.PHONE_MANDATE) ||
     path.startsWith(ROUTES.LOGOUT) ||

--- a/hushh-webapp/lib/one-location/activity.ts
+++ b/hushh-webapp/lib/one-location/activity.ts
@@ -22,8 +22,31 @@ function formatDateTime(value?: string | null): string {
   }).format(date);
 }
 
-function safeLabel(value?: string | null, fallback = "KAI member"): string {
-  return String(value || "").trim() || fallback;
+function looksLikeInternalIdentifier(value: string): boolean {
+  const label = value.trim();
+  if (!label) return false;
+  if (
+    /^(actor|grant|invite|key|location|one_location|recipient|referral|request|submission|user)[_-]/i.test(
+      label,
+    )
+  ) {
+    return true;
+  }
+  if (/^[0-9a-f]{24,}$/i.test(label) || /^[0-9a-f-]{32,}$/i.test(label)) {
+    return true;
+  }
+  return (
+    /^[A-Za-z0-9_-]{16,}$/.test(label) &&
+    /[A-Z]/.test(label) &&
+    /[a-z]/.test(label) &&
+    /\d/.test(label)
+  );
+}
+
+function safeLabel(value?: string | null, fallback = "One user"): string {
+  const label = String(value || "").trim();
+  if (!label || looksLikeInternalIdentifier(label)) return fallback;
+  return label;
 }
 
 function grantCounterpartyLabel(grant: OneLocationGrant): string {
@@ -151,7 +174,7 @@ export function buildOneLocationActivityFallback(
       safeLabel(recipient.displayName),
     ]),
   );
-  const labelForUser = (userId?: string | null, fallback = "KAI member") =>
+  const labelForUser = (userId?: string | null, fallback = "One user") =>
     safeLabel(userId ? recipientLabels.get(userId) : null, fallback);
   const events: OneLocationActivityEvent[] = [];
   const addEvent = ({

--- a/hushh-webapp/lib/one-location/kai-circle-ctas.ts
+++ b/hushh-webapp/lib/one-location/kai-circle-ctas.ts
@@ -1,0 +1,75 @@
+import type {
+  KaiCircleCandidate,
+  KaiCircleCta,
+  OneLocationViewerCapabilities,
+} from "@/lib/one-location/types";
+
+export function resolveKaiCircleCtas(params: {
+  candidate: KaiCircleCandidate;
+  mode: "share" | "request";
+  viewerCapabilities?: OneLocationViewerCapabilities | null;
+  hasActiveOwnerGrant?: boolean;
+  hasReceivedGrant?: boolean;
+  hasPendingOwnerRequest?: boolean;
+}): KaiCircleCta[] {
+  const { candidate, mode, viewerCapabilities } = params;
+  const ctas: KaiCircleCta[] = [];
+
+  if (params.hasPendingOwnerRequest) {
+    ctas.push(
+      { id: "approve", label: "Approve", enabled: candidate.isShareReady },
+      { id: "deny", label: "Deny", enabled: true },
+    );
+    return ctas;
+  }
+
+  if (params.hasReceivedGrant) {
+    ctas.push({ id: "view_shared_location", label: "View Shared Location", enabled: true });
+  }
+
+  if (params.hasActiveOwnerGrant) {
+    ctas.push({ id: "revoke_access", label: "Revoke Access", enabled: true });
+  }
+
+  if (!candidate.userId || candidate.isPublicProfileOnly) {
+    ctas.push({
+      id: "open_connect_profile",
+      label: "Invite to One",
+      enabled: Boolean(candidate.profileHref || candidate.connectionHref),
+    });
+    return ctas;
+  }
+
+  if (mode === "share") {
+    if (candidate.isShareReady) {
+      ctas.push({ id: "share_location", label: "Share Location", enabled: true });
+    } else {
+      ctas.push({
+        id: "ask_to_setup_one_location",
+        label: "Ask to Setup One Location",
+        enabled: true,
+        reason: "They need a One Location recipient key before private sharing.",
+      });
+    }
+  } else {
+    ctas.push({
+      id: "request_location",
+      label: "Request Location",
+      enabled: viewerCapabilities?.canRequestLocation !== false,
+      reason:
+        viewerCapabilities?.hasLocationRecipientKey === false
+          ? "Your One Location key will be set up before sending the request."
+          : null,
+    });
+  }
+
+  if (candidate.profileHref || candidate.connectionHref) {
+    ctas.push({
+      id: "open_connect_profile",
+      label: "Open Connect Profile",
+      enabled: true,
+    });
+  }
+
+  return ctas;
+}

--- a/hushh-webapp/lib/one-location/kai-circle-sections.ts
+++ b/hushh-webapp/lib/one-location/kai-circle-sections.ts
@@ -1,0 +1,122 @@
+import type {
+  KaiCircleCandidate,
+  KaiCircleSection,
+  KaiCircleSectionKey,
+} from "@/lib/one-location/types";
+
+export const KAI_CIRCLE_SECTION_META: Record<
+  KaiCircleSectionKey,
+  Pick<KaiCircleSection, "title" | "description">
+> = {
+  needs_action: {
+    title: "Needs your approval",
+    description: "Requests and people waiting on a decision.",
+  },
+  trusted_circle: {
+    title: "Trusted Circle",
+    description: "People with active sharing, history, or referrals.",
+  },
+  professional_network: {
+    title: "Professional Network",
+    description: "RIA, investor, advisor, and marketplace signals.",
+  },
+  connect_matches: {
+    title: "Connect Matches",
+    description: "People discovered from Connect and contact matching.",
+  },
+  location_ready: {
+    title: "Location-ready KAI members",
+    description: "Verified KAI members ready for encrypted sharing.",
+  },
+  needs_setup: {
+    title: "Needs setup",
+    description: "People who need to open One Location once.",
+  },
+};
+
+export const KAI_CIRCLE_SECTION_EMPTY_COPY: Record<
+  KaiCircleSectionKey,
+  { title: string; description: string }
+> = {
+  needs_action: {
+    title: "No approvals waiting",
+    description: "New location requests and pending decisions will appear here.",
+  },
+  trusted_circle: {
+    title: "No trusted matches yet",
+    description: "Active shares, repeat approvals, and referrals will lift people here.",
+  },
+  professional_network: {
+    title: "No professional signals yet",
+    description: "RIA, investor, advisor, and marketplace matches will appear here.",
+  },
+  connect_matches: {
+    title: "No Connect matches yet",
+    description: "Contact and Connect matches will appear here after sync.",
+  },
+  location_ready: {
+    title: "No ready KAI members yet",
+    description: "Verified KAI members with location keys will appear here.",
+  },
+  needs_setup: {
+    title: "No setup blockers",
+    description: "Everyone in this section is ready enough for the current flow.",
+  },
+};
+
+export const KAI_CIRCLE_SECTION_ORDER: KaiCircleSectionKey[] = [
+  "needs_action",
+  "trusted_circle",
+  "professional_network",
+  "connect_matches",
+  "location_ready",
+  "needs_setup",
+];
+
+export function kaiCircleSectionKey(candidate: KaiCircleCandidate): KaiCircleSectionKey {
+  switch (candidate.recommendationCategory) {
+    case "needs_action":
+      return "needs_action";
+    case "trusted_circle":
+      return "trusted_circle";
+  }
+
+  if (candidate.connectStatus === "pending") return "needs_action";
+  if (candidate.connectStatus === "connected") return "trusted_circle";
+  if (candidate.isShareReady) return "location_ready";
+  if (
+    candidate.sourceTypes.includes("one_location_recipient") ||
+    candidate.readiness === "target_setup_needed" ||
+    candidate.readiness === "viewer_setup_needed"
+  ) {
+    return "needs_setup";
+  }
+
+  const isProfessional =
+    candidate.recommendationCategory === "professional_network" ||
+    candidate.recommendationTier === "kai_network" ||
+    ["ria", "investor", "public_profile"].includes(String(candidate.connectKind || "")) ||
+    candidate.sourceTypes.some((source) =>
+      ["marketplace_ria", "marketplace_investor", "public_sec", "active_connection"].includes(source),
+    );
+  if (isProfessional) return "professional_network";
+
+  if (candidate.sourceTypes.includes("contact_match")) return "connect_matches";
+  return "needs_setup";
+}
+
+export function buildKaiCircleSections(candidates: KaiCircleCandidate[]): KaiCircleSection[] {
+  const grouped = new Map<KaiCircleSectionKey, KaiCircleCandidate[]>();
+  KAI_CIRCLE_SECTION_ORDER.forEach((key) => grouped.set(key, []));
+
+  for (const candidate of candidates) {
+    grouped.get(kaiCircleSectionKey(candidate))?.push(candidate);
+  }
+
+  return KAI_CIRCLE_SECTION_ORDER.map((key) => ({
+    key,
+    title: KAI_CIRCLE_SECTION_META[key].title,
+    description: KAI_CIRCLE_SECTION_META[key].description,
+    candidates: grouped.get(key) ?? [],
+  }));
+}

--- a/hushh-webapp/lib/one-location/key-bootstrap.ts
+++ b/hushh-webapp/lib/one-location/key-bootstrap.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { ensureLocationRecipientKey } from "@/lib/one-location/encryption";
+import { OneLocationService } from "@/lib/one-location/service";
+import type { OneLocationRecipient } from "@/lib/one-location/types";
+
+export async function bootstrapCurrentUserLocationRecipientKey(params: {
+  userId: string;
+  vaultOwnerToken: string;
+}): Promise<OneLocationRecipient> {
+  const userId = String(params.userId || "").trim();
+  const vaultOwnerToken = String(params.vaultOwnerToken || "").trim();
+  if (!userId) throw new Error("Current user is required for One Location setup.");
+  if (!vaultOwnerToken) throw new Error("Vault owner token required for One Location setup.");
+
+  const key = await ensureLocationRecipientKey(userId);
+  return OneLocationService.registerRecipientKey({
+    vaultOwnerToken,
+    keyId: key.keyId,
+    publicKeyJwk: key.publicKeyJwk,
+    algorithm: key.algorithm,
+  });
+}

--- a/hushh-webapp/lib/one-location/notifications.ts
+++ b/hushh-webapp/lib/one-location/notifications.ts
@@ -8,6 +8,8 @@ export const ONE_LOCATION_NOTIFICATION_OPEN_VALUE = "opened";
 export const ONE_LOCATION_GRANT_ID_PARAM = "grantId";
 export const ONE_LOCATION_REQUEST_ID_PARAM = "requestId";
 export const ONE_LOCATION_REFERRAL_ID_PARAM = "referralId";
+export const ONE_LOCATION_SUBMISSION_ID_PARAM = "submissionId";
+export const ONE_LOCATION_SECTION_PARAM = "section";
 
 const OPENED_GRANTS_KEY_PREFIX = "one_location_opened_grants_v1";
 const LOCATION_SHARE_TASK_KIND = "one_location_share";
@@ -22,6 +24,14 @@ export type OneLocationWorkflowNotificationType =
   | "location_access_denied"
   | "location_referral_invite"
   | "location_public_invite_submitted";
+
+export type OneLocationNotificationSection =
+  | "people"
+  | "approvals"
+  | "shared"
+  | "my_requests"
+  | "public_responses"
+  | "activity";
 
 const WORKFLOW_COPY: Record<
   OneLocationWorkflowNotificationType,
@@ -150,6 +160,7 @@ export function buildOneLocationNotificationHref(grantId: string): string {
   const params = new URLSearchParams();
   params.set(ONE_LOCATION_GRANT_ID_PARAM, grantId);
   params.set(ONE_LOCATION_NOTIFICATION_OPEN_PARAM, ONE_LOCATION_NOTIFICATION_OPEN_VALUE);
+  params.set(ONE_LOCATION_SECTION_PARAM, "shared");
   return `/one/location?${params.toString()}`;
 }
 
@@ -157,20 +168,48 @@ export function buildOneLocationWorkflowHref(params: {
   grantId?: string | null;
   requestId?: string | null;
   referralId?: string | null;
+  submissionId?: string | null;
+  section?: OneLocationNotificationSection | null;
   openGrant?: boolean;
 }): string {
   const query = new URLSearchParams();
   const grantId = String(params.grantId || "").trim();
   const requestId = String(params.requestId || "").trim();
   const referralId = String(params.referralId || "").trim();
+  const submissionId = String(params.submissionId || "").trim();
+  const section = String(params.section || "").trim();
   if (grantId) query.set(ONE_LOCATION_GRANT_ID_PARAM, grantId);
   if (requestId) query.set(ONE_LOCATION_REQUEST_ID_PARAM, requestId);
   if (referralId) query.set(ONE_LOCATION_REFERRAL_ID_PARAM, referralId);
+  if (submissionId) query.set(ONE_LOCATION_SUBMISSION_ID_PARAM, submissionId);
+  if (section) query.set(ONE_LOCATION_SECTION_PARAM, section);
   if (grantId && params.openGrant) {
     query.set(ONE_LOCATION_NOTIFICATION_OPEN_PARAM, ONE_LOCATION_NOTIFICATION_OPEN_VALUE);
   }
   const suffix = query.toString();
   return suffix ? `/one/location?${suffix}` : "/one/location";
+}
+
+export function oneLocationSectionForWorkflowNotificationType(
+  type: OneLocationWorkflowNotificationType,
+): OneLocationNotificationSection {
+  switch (type) {
+    case "location_share_created":
+    case "location_access_approved":
+    case "location_share_revoked":
+    case "location_share_expired":
+      return "shared";
+    case "location_access_request":
+      return "approvals";
+    case "location_access_denied":
+      return "my_requests";
+    case "location_public_invite_submitted":
+      return "public_responses";
+    case "location_referral_invite":
+      return "my_requests";
+    default:
+      return "activity";
+  }
 }
 
 export function locationShareNotificationDescription(ownerLabel?: string | null): string {

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -65,6 +65,10 @@ export class OneLocationService {
     return HushhLocation.getPermissionState();
   }
 
+  static async openLocationSettings() {
+    return HushhLocation.openLocationSettings();
+  }
+
   static async captureCurrentPosition(): Promise<PlainLocationPoint> {
     return HushhLocation.getCurrentPosition({
       enableHighAccuracy: true,
@@ -137,6 +141,7 @@ export class OneLocationService {
 
   static async resolvePublicInvite(publicToken: string): Promise<{
     invite: OneLocationPublicInvite;
+    publicLocation?: PlainLocationPoint | null;
   }> {
     return apiJsonWithRetry(
       `/api/one/location/public-invites/${encodeURIComponent(publicToken)}`,

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -115,6 +115,7 @@ export class OneLocationService {
   static async createPublicInvite(params: {
     vaultOwnerToken: string;
     durationHours: number;
+    locationSnapshot: PlainLocationPoint;
   }): Promise<{
     invite: OneLocationPublicInvite;
     publicToken: string;
@@ -125,7 +126,10 @@ export class OneLocationService {
       {
         method: "POST",
         headers: jsonAuthHeaders(params.vaultOwnerToken),
-        body: JSON.stringify({ durationHours: params.durationHours }),
+        body: JSON.stringify({
+          durationHours: params.durationHours,
+          locationSnapshot: params.locationSnapshot,
+        }),
       },
       1,
     );
@@ -148,6 +152,7 @@ export class OneLocationService {
     message?: string;
   }): Promise<{
     submission: OneLocationPublicInviteSubmission;
+    publicLocation?: PlainLocationPoint | null;
     request?: OneLocationAccessRequest | null;
   }> {
     return apiJsonWithRetry(

--- a/hushh-webapp/lib/one-location/types.ts
+++ b/hushh-webapp/lib/one-location/types.ts
@@ -52,6 +52,87 @@ export type OneLocationRecipient = {
   lastInteractionAt?: string | null;
 };
 
+export type OneLocationViewerCapabilities = {
+  hasLocationRecipientKey?: boolean;
+  canBootstrapRecipientKey?: boolean;
+  canShareLocation?: boolean;
+  canRequestLocation?: boolean;
+};
+
+type KaiCircleCandidateReadiness =
+  | "location_ready"
+  | "target_setup_needed"
+  | "viewer_setup_needed"
+  | "invite_only"
+  | "not_shareable";
+
+export type KaiCircleCandidate = {
+  candidateId: string;
+  userId?: string | null;
+  displayName: string;
+  maskedPhone?: string | null;
+  phoneVerified: boolean;
+  keyId?: string | null;
+  publicKeyJwk?: JsonWebKey | null;
+  keyAlgorithm: string;
+  keyRegisteredAt?: string | null;
+  canReceiveLocation: boolean;
+  isShareReady: boolean;
+  readiness: KaiCircleCandidateReadiness;
+  connectCandidateId?: string | null;
+  connectKind?: string | null;
+  connectStatus?: string | null;
+  sourceTypes: string[];
+  profileHref?: string | null;
+  connectionHref?: string | null;
+  isPublicProfileOnly?: boolean;
+  isDiscoverable: boolean;
+  recommendationScore?: number;
+  recommendationRank?: number;
+  recommendationTier?: OneLocationRecommendationTier | null;
+  recommendationCategory?: OneLocationRecommendationCategory | null;
+  recommendationCategoryLabel?: string | null;
+  recommendationReasons?: OneLocationRecommendationReason[];
+  recommendationSummary?: string | null;
+  trustLevel?: "high" | "medium" | "new" | "setup_needed" | string | null;
+  relationshipType?: string | null;
+  profileHeadline?: string | null;
+  verificationBadge?: string | null;
+  lastInteractionAt?: string | null;
+};
+
+export type KaiCircleSectionKey =
+  | "needs_action"
+  | "trusted_circle"
+  | "professional_network"
+  | "connect_matches"
+  | "location_ready"
+  | "needs_setup";
+
+export type KaiCircleSection = {
+  key: KaiCircleSectionKey;
+  title: string;
+  description: string;
+  candidates: KaiCircleCandidate[];
+};
+
+type KaiCircleCtaId =
+  | "share_location"
+  | "request_location"
+  | "ask_to_setup_one_location"
+  | "open_connect_profile"
+  | "approve"
+  | "deny"
+  | "view_shared_location"
+  | "revoke_access";
+
+export type KaiCircleCta = {
+  id: KaiCircleCtaId;
+  label: string;
+  enabled: boolean;
+  reason?: string | null;
+};
+
 export type OneLocationGrant = {
   id: string;
   ownerUserId: string;
@@ -104,13 +185,13 @@ export type OneLocationPublicInvite = {
   ownerLabel?: string | null;
   ownerDisplayName?: string | null;
   ownerMaskedPhone?: string | null;
+  locationAvailable?: boolean;
   status: "active" | "expired" | "revoked" | string;
   durationHours: number;
   expiresAt?: string | null;
   createdAt?: string | null;
   updatedAt?: string | null;
   revokedAt?: string | null;
-  locationAvailable?: boolean;
 };
 
 export type OneLocationPublicInviteSubmission = {
@@ -137,6 +218,8 @@ export type OneLocationPublicInviteSubmission = {
 
 export type OneLocationState = {
   recipients: OneLocationRecipient[];
+  kaiCircleCandidates?: KaiCircleCandidate[];
+  viewerCapabilities?: OneLocationViewerCapabilities;
   ownerGrants: OneLocationGrant[];
   receivedGrants: OneLocationGrant[];
   requests: OneLocationAccessRequest[];

--- a/hushh-webapp/lib/one-location/types.ts
+++ b/hushh-webapp/lib/one-location/types.ts
@@ -110,6 +110,7 @@ export type OneLocationPublicInvite = {
   createdAt?: string | null;
   updatedAt?: string | null;
   revokedAt?: string | null;
+  locationAvailable?: boolean;
 };
 
 export type OneLocationPublicInviteSubmission = {

--- a/scripts/ci/verify-protected-pipeline-edits.py
+++ b/scripts/ci/verify-protected-pipeline-edits.py
@@ -159,7 +159,7 @@ def evaluate(
 
 
 def _self_test() -> int:
-    allowed = ["kushaltrivedi5", "Jhumma-hushh"]
+    allowed = ["kushaltrivedi5", "ankitkumarsingh1702", "RGlodAkshat", "azfx"]
     paths = list(DEFAULT_PROTECTED_PATHS)
     cases: list[tuple[str, list[str], str, int]] = [
         # name, changed_files, actor, expected_exit


### PR DESCRIPTION
## Summary
- restores the pre-polish Kai font hierarchy baseline for recent UI regression cleanup
- tightens the bottom nav/search alignment so the search button sits beside the nav instead of floating with a large gap
- balances the Meet One intro screen vertically while keeping the CTA lower and preserving existing actions

## Scope
UI-only. No route, link, backend, auth, data, or portfolio behavior changes.

## Verification
- npm run typecheck
- npm run verify:design-system

Browser tests intentionally skipped per request.