### PR TITLE
test(profile): add api path helper coverage

### DIFF
--- a/hushh-webapp/__tests__/services/kai-profile-api-paths.test.ts
+++ b/hushh-webapp/__tests__/services/kai-profile-api-paths.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildGmailReceiptMemoryArtifactPath,
+  buildGmailReceiptsPath,
+  buildGmailStatusPath,
+  buildGmailSyncRunPath,
+} from "@/lib/services/kai-profile-api-paths";
+
+describe("kai-profile-api-paths", () => {
+  it("builds gmail status path", () => {
+    expect(buildGmailStatusPath("user123")).toBe(
+      "/api/kai/gmail/status/user123"
+    );
+  });
+
+  it("builds gmail sync run path", () => {
+    expect(buildGmailSyncRunPath("run123")).toBe(
+      "/api/kai/gmail/sync/run123"
+    );
+  });
+
+  it("builds gmail receipts path", () => {
+    expect(buildGmailReceiptsPath("user123")).toBe(
+      "/api/kai/gmail/receipts/user123"
+    );
+  });
+
+  it("builds gmail receipt memory artifact path", () => {
+    expect(buildGmailReceiptMemoryArtifactPath("artifact123")).toBe(
+      "/api/kai/gmail/receipts-memory/artifacts/artifact123"
+    );
+  });
+
+  it("trims whitespace from parameters", () => {
+    expect(buildGmailStatusPath("  user123  ")).toBe(
+      "/api/kai/gmail/status/user123"
+    );
+  });
+
+  it("url encodes path parameters", () => {
+    expect(buildGmailReceiptsPath("user 123")).toBe(
+      "/api/kai/gmail/receipts/user%20123"
+    );
+  });
+
+  it("encodes special characters", () => {
+    expect(buildGmailSyncRunPath("run/123")).toBe(
+      "/api/kai/gmail/sync/run%2F123"
+    );
+  });
+
+  it("handles empty values", () => {
+    expect(buildGmailStatusPath("")).toBe(
+      "/api/kai/gmail/status/"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds dedicated test coverage for Gmail API path helper utilities.

### Covered scenarios

* Builds Gmail status paths.
* Builds Gmail sync run paths.
* Builds Gmail receipts paths.
* Builds Gmail receipt memory artifact paths.
* Trims surrounding whitespace from path parameters.
* URL-encodes path parameters.
* Handles special characters safely.
* Handles empty parameter values.

## Testing

npx vitest run **tests**/services/kai-profile-api-paths.test.ts
