### PR TITLE
test(account): cover missing authorization header

### DIFF
--- a/hushh-webapp/__tests__/api/account-export-proxy.test.ts
+++ b/hushh-webapp/__tests__/api/account-export-proxy.test.ts
@@ -26,10 +26,12 @@ function request(headers: Record<string, string> = {}) {
 describe("GET /api/account/export proxy", () => {
   it("does not expose raw backend error text", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response("raw database failure with table names", { status: 500 })
+      new Response("raw database failure with table names", { status: 500 }),
     );
 
-    const response = await route.GET(request({ Authorization: "Bearer HCT:test" }));
+    const response = await route.GET(
+      request({ Authorization: "Bearer HCT:test" }),
+    );
     const payload = await response.json();
 
     expect(response.status).toBe(500);
@@ -37,12 +39,26 @@ describe("GET /api/account/export proxy", () => {
   });
 
   it("returns a stable error for invalid backend success payloads", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("not json", { status: 200 }));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("not json", { status: 200 }),
+    );
 
-    const response = await route.GET(request({ Authorization: "Bearer HCT:test" }));
+    const response = await route.GET(
+      request({ Authorization: "Bearer HCT:test" }),
+    );
     const payload = await response.json();
 
     expect(response.status).toBe(502);
     expect(payload).toEqual({ error: "Invalid response from backend" });
+  });
+
+  it("rejects requests without authorization", async () => {
+    const response = await route.GET(request());
+    const payload = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(payload).toEqual({
+      error: "Missing Authorization header",
+    });
   });
 });


### PR DESCRIPTION
## Summary

Adds test coverage for account export requests that do not provide an Authorization header.

### Changes Made

* Added a test case for requests missing the Authorization header.
* Verified the route returns HTTP 401 for unauthenticated requests.
* Verified the expected error payload is returned.
* Expanded validation coverage for the account export proxy route.

## Test

```bash
npx vitest run __tests__/api/account-export-proxy.test.ts
```
