### PR TITLE
docs: add git status quick check

### DIFF
--- a/docs/git-status-quick-check.md
+++ b/docs/git-status-quick-check.md
@@ -1,3 +1,5 @@
+# Git Status Quick Check
+
 ## Visual Map
 
 ```mermaid
@@ -6,3 +8,18 @@ flowchart TD
   B --> C[Review diff]
   C --> D[Commit with signoff]
   D --> E[Push branch]
+```
+
+## Quick Commands
+
+```bash
+git status
+git diff
+git add .
+git commit -s -m "message"
+git push origin <branch>
+```
+
+## Purpose
+
+This document provides a quick reference for checking repository status before creating commits and pull requests.

--- a/docs/git-status-quick-check.md
+++ b/docs/git-status-quick-check.md
@@ -1,0 +1,24 @@
+\# Git Status Quick Check
+
+
+
+\## Visual Context
+
+
+
+Canonical visual owner: docs/development-setup-guide.md
+
+
+
+```text
+
+Working tree
+
+├── Clean
+
+│   └── Safe to switch branches
+
+└── Modified
+
+&#x20;   └── Commit, stash, or restore changes
+

--- a/docs/git-status-quick-check.md
+++ b/docs/git-status-quick-check.md
@@ -1,24 +1,8 @@
-\# Git Status Quick Check
+## Visual Map
 
-
-
-\## Visual Context
-
-
-
-Canonical visual owner: docs/development-setup-guide.md
-
-
-
-```text
-
-Working tree
-
-├── Clean
-
-│   └── Safe to switch branches
-
-└── Modified
-
-&#x20;   └── Commit, stash, or restore changes
-
+```mermaid
+flowchart TD
+  A[Check branch] --> B[Check working tree]
+  B --> C[Review diff]
+  C --> D[Commit with signoff]
+  D --> E[Push branch]


### PR DESCRIPTION
## Summary

Adds a lightweight contributor reference for quickly checking repository status before creating commits, pushing branches, or opening pull requests.

## Changes

* Added a Git status quick-check guide
* Documents common commands for inspecting branch state
* Helps contributors verify working tree status before committing
* Improves contributor workflow and troubleshooting

## Test

Documentation-only change.
