### PR TITLE
fix(kai): promote typography and chrome hotfix

### DIFF
--- a/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
+++ b/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
@@ -15,7 +15,7 @@ describe("Navbar bottom chrome contract", () => {
     const searchBar = read("components/kai/kai-search-bar.tsx");
 
     expect(navbar).toContain("useOptionalAgentPopover");
-    expect(navbar).toContain('style={{ width: "calc(100% - 66px)" }}');
+    expect(navbar).toContain('style={{ width: "calc(100% - 62px)" }}');
     expect(navbar).not.toContain('data-testid="bottom-agent-trigger"');
     expect(searchBar).toContain("kai-bottom-agent-action");
     expect(searchBar).toContain('aria-label="Open Agent"');

--- a/hushh-webapp/components/kai/kai-search-bar.tsx
+++ b/hushh-webapp/components/kai/kai-search-bar.tsx
@@ -1691,7 +1691,7 @@ export function KaiSearchBar({
           ref={barRef}
           className={cn(
             "pointer-events-none w-full",
-            isRiaSurface ? "max-w-[360px] sm:max-w-[392px]" : "max-w-[560px]"
+            isRiaSurface ? "max-w-[360px] sm:max-w-[392px]" : "max-w-[548px]"
           )}
         >
           {isRiaSurface ? (

--- a/hushh-webapp/components/kai/kai-search-bar.tsx
+++ b/hushh-webapp/components/kai/kai-search-bar.tsx
@@ -1691,7 +1691,7 @@ export function KaiSearchBar({
           ref={barRef}
           className={cn(
             "pointer-events-none w-full",
-            isRiaSurface ? "max-w-[360px] sm:max-w-[392px]" : "max-w-[630px]"
+            isRiaSurface ? "max-w-[360px] sm:max-w-[392px]" : "max-w-[560px]"
           )}
         >
           {isRiaSurface ? (

--- a/hushh-webapp/components/kai/shared/kai-typography.ts
+++ b/hushh-webapp/components/kai/shared/kai-typography.ts
@@ -1,31 +1,31 @@
 "use client";
 
 export const kaiAppEyebrowClassName =
-  "type-micro";
+  "!text-[10.5px] !font-medium !leading-[1.2] uppercase !tracking-[0.14em]";
 
 export const kaiAppHeroTitleClassName =
-  "type-display";
+  "text-[38px] font-medium leading-[1.05] tracking-normal sm:text-[40px]";
 
 export const kaiAppHeroBodyClassName =
-  "type-body";
+  "text-[17px] font-normal leading-[1.42] tracking-normal sm:text-[18px]";
 
 export const kaiAppDisplayTitleClassName =
-  "type-title1";
+  "!text-[36px] !font-medium !leading-[1.06] !tracking-normal sm:!text-[48px]";
 
 export const kaiAppCompactTitleClassName =
-  "type-title1";
+  "!text-[34px] !font-medium !leading-[1.06] !tracking-normal sm:!text-[42px]";
 
 export const kaiAppBodyClassName =
-  "type-body";
+  "!text-[16px] !font-normal !leading-[1.45] !tracking-normal sm:!text-[17px]";
 
 export const kaiAppSectionTitleClassName =
-  "type-title3";
+  "!text-[21px] !font-medium !leading-[1.12] !tracking-normal sm:!text-[24px]";
 
 export const kaiAppCardTitleClassName =
-  "type-headline";
+  "!text-[16.5px] !font-medium !leading-[1.22] !tracking-normal";
 
 export const kaiAppCardBodyClassName =
-  "type-subhead";
+  "!text-[14px] !font-normal !leading-[1.42] !tracking-normal";
 
 export const kaiAppHelperClassName =
-  "type-footnote";
+  "!text-[12.5px] !font-normal !leading-[1.45] !tracking-normal";

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -271,12 +271,12 @@ export const Navbar = () => {
     >
       <div
         className={cn(
-          "relative flex w-full max-w-[560px] items-end gap-2",
+          "relative flex w-full max-w-[548px] items-end gap-1",
           "pointer-events-none",
           hideBottomChrome && "pointer-events-none"
         )}
       >
-        <div className="min-w-0 pointer-events-auto" style={{ width: "calc(100% - 66px)" }}>
+        <div className="min-w-0 pointer-events-auto" style={{ width: "calc(100% - 62px)" }}>
           <SegmentedPill
             ref={pillRef}
             size="compact"

--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -2,12 +2,12 @@
 
 import Image from "next/image";
 import type { ComponentType, SVGProps } from "react";
+import { OneLockup } from "@/components/app-ui/gold-period";
 import { Button } from "@/lib/morphy-ux/button";
 import {
   kaiAppHeroBodyClassName,
   kaiAppHeroTitleClassName,
 } from "@/components/kai/shared/kai-typography";
-import { OneLockup } from "@/components/app-ui/gold-period";
 
 function ShieldBadgeIcon(props: SVGProps<SVGSVGElement>) {
   return (
@@ -89,63 +89,65 @@ export function IntroStep({
 }) {
   return (
     <main className="min-h-[100dvh] w-full bg-[#ffffff] text-[#1d1d1f] transition-colors duration-300 dark:bg-[#000000] dark:text-[#f5f5f7]">
-      <div className="mx-auto flex min-h-[100dvh] w-full max-w-[440px] flex-col px-6 pt-[calc(42px+var(--app-safe-area-top-effective,0px))]">
-        <section className="relative flex flex-none flex-col items-center text-center">
-          <Image
-            src="/one-quiet-emoji.png"
-            alt=""
-            width={762}
-            height={766}
-            priority
-            unoptimized
-            aria-hidden="true"
-            draggable={false}
-            className="relative h-11 w-11 select-none object-contain"
-          />
+      <div className="mx-auto flex min-h-[100dvh] w-full max-w-[440px] flex-col px-6 pt-[calc(34px+var(--app-safe-area-top-effective,0px))] pb-[calc(18px+var(--app-safe-area-bottom-effective,0px))]">
+        <div className="flex min-h-0 flex-1 flex-col justify-center py-6">
+          <section className="relative flex flex-none flex-col items-center text-center">
+            <Image
+              src="/one-quiet-emoji.png"
+              alt=""
+              width={762}
+              height={766}
+              priority
+              unoptimized
+              aria-hidden="true"
+              draggable={false}
+              className="relative h-11 w-11 select-none object-contain"
+            />
 
-          <div
-            role="heading"
-            aria-level={1}
-            aria-label="Meet One, Your Personal Financial Advisor"
-            className={`relative mt-2.5 ${kaiAppHeroTitleClassName} text-[#1d1d1f] dark:text-[#f5f5f7]`}
-          >
-            Meet <OneLockup />
-          </div>
-          <p className={`relative mt-3 ${kaiAppHeroBodyClassName} text-[rgba(0,0,0,0.56)] dark:text-[rgba(245,245,247,0.60)]`}>
-            Your personal financial advisor.
-          </p>
-        </section>
+            <div
+              role="heading"
+              aria-level={1}
+              aria-label="Meet One, Your Personal Financial Advisor"
+              className={`relative mt-2.5 ${kaiAppHeroTitleClassName} text-[#1d1d1f] dark:text-[#f5f5f7]`}
+            >
+              Meet <OneLockup />
+            </div>
+            <p className={`relative mt-3 ${kaiAppHeroBodyClassName} text-[rgba(0,0,0,0.56)] dark:text-[rgba(245,245,247,0.60)]`}>
+              Your personal financial advisor.
+            </p>
+          </section>
 
-        <div className="flex-none pt-9 pb-5">
-          <div className="relative w-full">
-            <div className="relative z-10 mx-auto flex w-full max-w-[340px] flex-col gap-3">
-              {INTRO_FEATURES.map((feature) => (
-                <div
-                  key={feature.title}
-                  className="grid h-[70px] grid-cols-[48px_minmax(0,1fr)] items-center gap-4 rounded-[22px]"
-                >
-                  <span
-                    className={`grid h-12 w-12 place-items-center rounded-full border border-black/[0.04] dark:border-white/10 ${feature.tileClassName}`}
+          <div className="flex-none pt-9">
+            <div className="relative w-full">
+              <div className="relative z-10 mx-auto flex w-full max-w-[340px] flex-col gap-3">
+                {INTRO_FEATURES.map((feature) => (
+                  <div
+                    key={feature.title}
+                    className="grid h-[70px] grid-cols-[48px_minmax(0,1fr)] items-center gap-4 rounded-[22px]"
                   >
-                    <feature.icon className="h-[22px] w-[22px]" />
-                  </span>
-                  <div className="min-w-0">
-                    <p className="type-headline text-[#1d1d1f] dark:text-[#f5f5f7]">
-                      {feature.title}
-                    </p>
-                    <p className="type-subhead mt-1 text-[rgba(0,0,0,0.50)] dark:text-[rgba(245,245,247,0.56)]">
-                      {feature.subtitle}
-                    </p>
+                    <span
+                      className={`grid h-12 w-12 place-items-center rounded-full border border-black/[0.04] dark:border-white/10 ${feature.tileClassName}`}
+                    >
+                      <feature.icon className="h-[22px] w-[22px]" />
+                    </span>
+                    <div className="min-w-0">
+                      <p className="text-[16.5px] font-medium leading-[1.22] tracking-normal text-[#1d1d1f] dark:text-[#f5f5f7]">
+                        {feature.title}
+                      </p>
+                      <p className="mt-1 text-[14.5px] leading-[1.35] tracking-normal text-[rgba(0,0,0,0.50)] dark:text-[rgba(245,245,247,0.56)]">
+                        {feature.subtitle}
+                      </p>
+                    </div>
                   </div>
-                </div>
-              ))}
+                ))}
+              </div>
             </div>
           </div>
         </div>
 
-        <footer className="flex-none pb-[calc(18px+var(--app-safe-area-bottom-effective,0px))]">
+        <footer className="flex-none pt-3">
           <div className="space-y-4">
-            <p className="type-footnote mx-auto max-w-[34ch] text-center text-[#86868b] dark:text-[rgba(245,245,247,0.44)]">
+            <p className="mx-auto max-w-[34ch] text-center text-[13.5px] leading-5 tracking-normal text-[#86868b] dark:text-[rgba(245,245,247,0.44)]">
               One is consent-first. Your data stays in your vault — nothing is
               shared without your approval.
             </p>
@@ -154,14 +156,14 @@ export function IntroStep({
               fullWidth
               onClick={onNext}
               showRipple
-              className="type-headline h-[50px] rounded-full bg-[#0066cc] text-white shadow-none hover:bg-[#0071e3]"
+              className="h-[50px] rounded-full bg-[#0066cc] text-[17px] font-medium tracking-normal text-white shadow-none hover:bg-[#0071e3]"
             >
               Get started
             </Button>
             {onLogin ? (
               <button
                 type="button"
-                className="type-subhead mx-auto block min-h-10 px-4 text-[#0066cc] transition-colors hover:text-[#0071e3] dark:text-[#2997ff] dark:hover:text-[#5eb0ff]"
+                className="mx-auto block min-h-10 px-4 text-[15px] font-medium tracking-normal text-[#0066cc] transition-colors hover:text-[#0071e3] dark:text-[#2997ff] dark:hover:text-[#5eb0ff]"
                 onClick={onLogin}
               >
                 Log in


### PR DESCRIPTION
## Summary
- restore the prior Kai typography hierarchy via the shared Kai helper
- tighten the bottom nav/search chrome spacing
- rebalance the Meet One intro layout while preserving the existing One lockup helper

## Validation
- npm test -- --run __tests__/components/navbar-agent-trigger.contract.test.ts
- npm run typecheck
- npm run verify:design-system

Browser tests intentionally skipped per request.