### PR TITLE
fix(kai/run-manager): suppress str(exc) from SSE worker error (CWE-209)

### DIFF
--- a/consent-protocol/api/routes/kai/run_manager.py
+++ b/consent-protocol/api/routes/kai/run_manager.py
@@ -184,7 +184,7 @@ class KaiAnalyzeRunManager:
                 event_name="error",
                 payload={
                     "code": "ANALYZE_RUN_WORKER_FAILED",
-                    "message": str(exc),
+                    "message": "Analysis run failed due to an internal error.",
                     "ticker": run.ticker,
                     "run_id": run.run_id,
                 },

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -19,3 +19,4 @@ tests/test_stream_path_query_bounds_cwe400.py
 tests/performance/test_market_cache_instrumentation.py
 tests/test_llm_operon_stream_error_leak.py
 tests/test_stream_agent_thinking_gemini_error_cwe209.py
+tests/test_sse_worker_exception_leak_cwe209.py

--- a/consent-protocol/tests/test_sse_worker_exception_leak_cwe209.py
+++ b/consent-protocol/tests/test_sse_worker_exception_leak_cwe209.py
@@ -1,0 +1,58 @@
+"""
+Regression tests for CWE-209 fix in run_manager.py SSE worker error payload.
+
+CWE-209 -- Information Exposure Through Error Messages:
+  run_manager.py echoed raw str(exc) into the ANALYZE_RUN_WORKER_FAILED SSE
+  event payload that is flushed directly to connected browser clients.
+
+Attach point:
+  GET /api/kai/analyze/run/{run_id}/stream  (run_manager.py worker)
+"""
+
+from __future__ import annotations
+
+import json
+
+_SENTINEL = "INTERNAL_SECRET_zP3mQw7nRk_LEAK_MARKER"
+
+
+class TestRunManagerWorkerExceptionLeak:
+    """KaiAnalyzeRunManager._run_worker must not echo exc detail in SSE payload."""
+
+    def test_worker_crash_does_not_echo_exception_detail(self):
+        import asyncio
+
+        from api.routes.kai.run_manager import AnalyzeRunRecord, KaiAnalyzeRunManager
+
+        manager = KaiAnalyzeRunManager()
+
+        run = AnalyzeRunRecord(
+            run_id="test-run-001",
+            user_id="user_test",
+            debate_session_id="debate-sess-001",
+            ticker="AAPL",
+            risk_profile="balanced",
+            context=None,
+            consent_token="test-token",  # noqa: S106
+        )
+
+        async def _crashing_factory(ticker, user_id, consent_token, risk_profile, context, req):
+            raise RuntimeError(_SENTINEL)
+            yield  # pragma: no cover -- make it an async generator
+
+        async def _run():
+            await manager._run_worker(run, _crashing_factory)
+
+        asyncio.run(_run())
+
+        assert run.status == "failed"
+
+        for frame in run.events:
+            data_str = frame.get("data", "")
+            assert _SENTINEL not in data_str, (
+                f"Internal exception detail leaked into SSE frame: {data_str!r}"
+            )
+
+        assert run.terminal_payload is not None
+        assert _SENTINEL not in json.dumps(run.terminal_payload)
+        assert run.terminal_payload.get("code") == "ANALYZE_RUN_WORKER_FAILED"


### PR DESCRIPTION
Single-file focus: run_manager.py. Replaces raw exception strings in SSE with opaque messages.