### PR TITLE
fix(kai/import-run-manager): suppress str(exc) from SSE worker error (CWE-209)

### DIFF
--- a/consent-protocol/api/routes/kai/import_run_manager.py
+++ b/consent-protocol/api/routes/kai/import_run_manager.py
@@ -169,7 +169,7 @@ class KaiPortfolioImportRunManager:
                 event_name="error",
                 payload={
                     "code": "IMPORT_RUN_WORKER_FAILED",
-                    "message": str(exc),
+                    "message": "Import run failed due to an internal error.",
                     "run_id": run.run_id,
                 },
             )

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -19,3 +19,4 @@ tests/test_stream_path_query_bounds_cwe400.py
 tests/performance/test_market_cache_instrumentation.py
 tests/test_llm_operon_stream_error_leak.py
 tests/test_stream_agent_thinking_gemini_error_cwe209.py
+tests/test_import_run_manager_cwe209.py

--- a/consent-protocol/tests/test_import_run_manager_cwe209.py
+++ b/consent-protocol/tests/test_import_run_manager_cwe209.py
@@ -1,0 +1,57 @@
+"""
+Regression tests for CWE-209 fix in import_run_manager.py SSE worker error payload.
+
+CWE-209 -- Information Exposure Through Error Messages:
+  import_run_manager.py echoed raw str(exc) into the IMPORT_RUN_WORKER_FAILED SSE
+  event payload that is flushed directly to connected browser clients.
+
+Attach point:
+  GET /api/kai/import/run/{run_id}/stream  (import_run_manager.py worker)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from api.routes.kai.import_run_manager import (
+    KaiPortfolioImportRunManager,
+    PortfolioImportRunRecord,
+)
+
+_SENTINEL = "INTERNAL_SECRET_zP3mQw7nRk_LEAK_MARKER"
+
+
+class TestImportRunManagerWorkerExceptionLeak:
+    """KaiPortfolioImportRunManager._run_worker must not echo exc detail in SSE payload."""
+
+    def test_worker_crash_does_not_echo_exception_detail(self):
+        manager = KaiPortfolioImportRunManager()
+
+        run = PortfolioImportRunRecord(
+            run_id="test-import-run-001",
+            user_id="user_test",
+            filename="test.csv",
+            content=b"",
+            is_csv_upload=True,
+        )
+
+        async def _crashing_factory(run, req):
+            raise RuntimeError(_SENTINEL)
+            yield  # pragma: no cover -- make it an async generator
+
+        async def _run():
+            await manager._run_worker(run, _crashing_factory)
+
+        asyncio.run(_run())
+
+        assert run.status == "failed"
+
+        for frame in run.events:
+            data_str = frame.get("data", "")
+            assert _SENTINEL not in data_str, (
+                f"Internal exception detail leaked into import SSE frame: {data_str!r}"
+            )
+
+        all_data = json.dumps([f.get("data", "") for f in run.events])
+        assert _SENTINEL not in all_data


### PR DESCRIPTION
Narrowed scope: import_run_manager.py only. Replaces raw exception strings with opaque messages.