### PR TITLE
fix(db-proxy): replace token validation reason echoes with opaque messages (CWE-209)

### DIFF
--- a/consent-protocol/api/routes/db_proxy.py
+++ b/consent-protocol/api/routes/db_proxy.py
@@ -737,24 +737,31 @@ async def validate_vault_owner_token(consent_token: str, user_id: str) -> None:
         logger.error("Consent token validated but payload missing")
         raise HTTPException(
             status_code=401,
-            detail="Invalid consent token: missing token payload",
+            detail="Invalid or expired consent token",
             headers={"WWW-Authenticate": "Bearer"},
         )
 
     if token_obj.scope != ConsentScope.VAULT_OWNER:
+        # CWE-209: log scope details server-side only.
         logger.warning(
-            f"Insufficient scope: {token_obj.scope.value} (requires {ConsentScope.VAULT_OWNER.value})"
+            "validate_vault_owner_token: insufficient scope=%s user_id=%s",
+            token_obj.scope.value,
+            user_id,
         )
         raise HTTPException(
             status_code=403,
-            detail=f"Insufficient scope: {token_obj.scope.value}. VAULT_OWNER scope required.",
+            detail="Consent token does not have the required scope",
         )
 
     if str(token_obj.user_id) != user_id:
-        logger.warning(f"Token userId mismatch: {token_obj.user_id} != {user_id}")
+        logger.warning(
+            "validate_vault_owner_token: user_id mismatch token_user=%s requested=%s",
+            token_obj.user_id,
+            user_id,
+        )
         raise HTTPException(status_code=403, detail="Token userId does not match requested userId")
 
-    logger.info(f"✅ VAULT_OWNER token validated for {user_id}")
+    logger.info("validate_vault_owner_token: VAULT_OWNER token accepted user_id=%s", user_id)
 
 
 @router.post("/vault/status")

--- a/consent-protocol/tests/test_dbproxy_consent_cwe209_remaining.py
+++ b/consent-protocol/tests/test_dbproxy_consent_cwe209_remaining.py
@@ -1,11 +1,11 @@
 # tests/test_dbproxy_consent_cwe209_remaining.py
 """
 Regression tests for remaining CWE-209 information-exposure fixes in:
-  api/routes/db_proxy.py   -- require_vault_owner_consent_header (line 132)
-                           -- validate_vault_owner_token (lines 714, 732)
-  api/routes/consent.py    -- approve_consent (line 450)
-                           -- revoke_consent_by_scope (line 1101)
-                           -- refresh_consent_export (line 1327)
+  api/routes/db_proxy.py   -- require_vault_owner_consent_header (POST /db/vault/wrapper/delete)
+                           -- validate_vault_owner_token (POST /db/vault/status)
+  api/routes/consent.py    -- approve_consent (POST /api/consent/pending/approve)
+                           -- revoke_consent (POST /api/consent/revoke)
+                           -- upload_refreshed_export (POST /api/consent/export-refresh/upload)
 
 In all five locations the original code echoed internal token-validation
 reason strings or caller-supplied scope values back in HTTP error responses.
@@ -18,97 +18,119 @@ return value and assert it does NOT appear in the HTTP response body.
 
 from __future__ import annotations
 
-from contextlib import contextmanager
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
+
+import api.routes.consent as consent_mod
+import api.routes.db_proxy as db_proxy_mod
+from api.middleware import require_firebase_auth, require_vault_owner_token
+from hushh_mcp.services.consent_db import ConsentDBService
 
 _SENTINEL = "LEAKED_INTERNAL_DETAIL_sentinel_xyzzy_99"
 _GOOD_USER_ID = "firebase_uid_stub_28chars_abc"
 
 
-@contextmanager
-def _client():
-    from server import app
-    with TestClient(app, raise_server_exceptions=False) as c:
-        yield c
+def _db_proxy_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(db_proxy_mod.router)
+    app.dependency_overrides[require_firebase_auth] = lambda: _GOOD_USER_ID
+    return app
+
+
+def _consent_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(consent_mod.router)
+    app.dependency_overrides[require_vault_owner_token] = lambda: {"user_id": _GOOD_USER_ID}
+    return app
 
 
 # ---------------------------------------------------------------------------
-# db_proxy.py — require_vault_owner_consent_header
+# db_proxy.py -- require_vault_owner_consent_header (POST /db/vault/wrapper/delete)
 # ---------------------------------------------------------------------------
+
 
 def test_vault_consent_header_invalid_token_does_not_echo_reason():
     """
-    An invalid VAULT_OWNER token must not echo the internal validation reason.
+    An invalid VAULT_OWNER token in the X-Hushh-Consent header must not echo
+    the internal validation reason.
     """
-    import hushh_mcp.consent.token as tok_mod
+    client = TestClient(_db_proxy_app(), raise_server_exceptions=False)
 
     async def _bad_token(token, scope=None):
         return False, _SENTINEL, None
 
-    with patch.object(tok_mod, "validate_token_with_db", side_effect=_bad_token):
-        with _client() as client:
-            r = client.get(
-                f"/vault/data/{_GOOD_USER_ID}",
-                headers={"X-Hushh-Consent": "Bearer fake_token_value"},
-            )
-            assert r.status_code == 401, r.text
-            assert _SENTINEL not in r.text, (
-                f"CWE-209: internal reason exposed in response: {r.text!r}"
-            )
+    with patch.object(db_proxy_mod, "validate_token_with_db", side_effect=_bad_token):
+        r = client.post(
+            "/db/vault/wrapper/delete",
+            json={
+                "userId": _GOOD_USER_ID,
+                "vaultKeyHash": "hash",
+                "method": "passkey",
+            },
+            headers={"X-Hushh-Consent": "Bearer fake_token_value"},
+        )
+        assert r.status_code == 401, r.text
+        assert _SENTINEL not in r.text, (
+            f"CWE-209: internal reason exposed in response: {r.text!r}"
+        )
 
 
 # ---------------------------------------------------------------------------
-# db_proxy.py — validate_vault_owner_token (inside vault routes)
+# db_proxy.py -- validate_vault_owner_token (POST /db/vault/status)
 # ---------------------------------------------------------------------------
 
-def test_vault_route_invalid_consent_token_does_not_echo_reason():
+
+def test_vault_status_invalid_consent_token_does_not_echo_reason():
     """
-    Invalid consent token on a vault route must not echo the validation reason.
+    Invalid consent token on POST /db/vault/status must not echo the
+    validation reason.
     """
-    import hushh_mcp.consent.token as tok_mod
+    client = TestClient(_db_proxy_app(), raise_server_exceptions=False)
 
     async def _bad_token(token, scope=None):
         return False, _SENTINEL, None
 
-    with patch.object(tok_mod, "validate_token_with_db", side_effect=_bad_token):
-        with _client() as client:
-            r = client.get(
-                f"/vault/data/{_GOOD_USER_ID}",
-                headers={
-                    "Authorization": f"Bearer {_GOOD_USER_ID}",
-                    "X-Hushh-Consent": f"Bearer consent_tok_{_GOOD_USER_ID}",
-                },
-            )
-            assert r.status_code in (401, 403, 404, 500), r.text
-            assert _SENTINEL not in r.text, (
-                f"CWE-209: internal reason exposed in response: {r.text!r}"
-            )
+    with patch.object(db_proxy_mod, "validate_token_with_db", side_effect=_bad_token):
+        r = client.post(
+            "/db/vault/status",
+            json={"userId": _GOOD_USER_ID, "consentToken": "fake_consent_token_value"},
+        )
+        assert r.status_code in (401, 403, 500), r.text
+        assert _SENTINEL not in r.text, (
+            f"CWE-209: internal reason exposed in response: {r.text!r}"
+        )
+
+
+def test_vault_status_invalid_token_returns_opaque_message():
+    """The error detail for an invalid vault-owner token must be a static string."""
+    client = TestClient(_db_proxy_app(), raise_server_exceptions=False)
+
+    async def _bad_token(token, scope=None):
+        return False, "Token expired", None
+
+    with patch.object(db_proxy_mod, "validate_token_with_db", side_effect=_bad_token):
+        r = client.post(
+            "/db/vault/status",
+            json={"userId": _GOOD_USER_ID, "consentToken": "bad_token"},
+        )
+        assert r.status_code in (401, 403, 500), r.text
+        assert "Token expired" not in r.text, r.text
 
 
 # ---------------------------------------------------------------------------
-# consent.py — scope_resolution_failed (approve_consent line 450)
+# consent.py -- scope_resolution_failed (approve_consent)
 # ---------------------------------------------------------------------------
+
 
 def test_approve_consent_scope_error_does_not_echo_scope():
     """
     When scope resolution fails in approve_consent, the scope string must
     not appear in the error response.
     """
-    from unittest.mock import AsyncMock
-
-    from fastapi import FastAPI
-
     sentinel_scope = f"SENTINEL_SCOPE_{_SENTINEL}"
-
-    import api.routes.consent as consent_mod
-    from api.middleware import require_vault_owner_token
-    from hushh_mcp.services.consent_db import ConsentDBService
-
-    app = FastAPI()
-    app.include_router(consent_mod.router)
-    app.dependency_overrides[require_vault_owner_token] = lambda: {"user_id": _GOOD_USER_ID}
+    client = TestClient(_consent_app(), raise_server_exceptions=False)
 
     def _bad_resolve(scope_str):
         raise ValueError(f"cannot resolve {scope_str}")
@@ -127,13 +149,9 @@ def test_approve_consent_scope_error_does_not_echo_scope():
         ),
     ):
         with patch.object(consent_mod, "resolve_scope_to_enum", side_effect=_bad_resolve):
-            client = TestClient(app, raise_server_exceptions=False)
             r = client.post(
                 "/api/consent/pending/approve",
-                json={
-                    "requestId": "req_12345",
-                    "userId": _GOOD_USER_ID,
-                },
+                json={"requestId": "req_12345", "userId": _GOOD_USER_ID},
             )
             assert r.status_code in (400, 401, 403, 422, 500), r.text
             assert sentinel_scope not in r.text, (
@@ -142,33 +160,22 @@ def test_approve_consent_scope_error_does_not_echo_scope():
 
 
 # ---------------------------------------------------------------------------
-# consent.py — No active consent for scope (revoke_consent_by_scope line 1101)
+# consent.py -- no active consent for scope (revoke_consent)
 # ---------------------------------------------------------------------------
 
-def test_revoke_by_scope_not_found_does_not_echo_scope():
+
+def test_revoke_not_found_does_not_echo_scope():
     """
     When no active consent exists for the requested scope, the scope value
-    must not appear verbatim in the 404 response body.
+    must not appear verbatim in the response body.
     """
-    from unittest.mock import AsyncMock
-
-    from fastapi import FastAPI
-
     sentinel_scope = f"SENTINEL_scope_{_SENTINEL}"
-
-    import api.routes.consent as consent_mod
-    from api.middleware import require_vault_owner_token
-    from hushh_mcp.services.consent_db import ConsentDBService
-
-    app = FastAPI()
-    app.include_router(consent_mod.router)
-    app.dependency_overrides[require_vault_owner_token] = lambda: {"user_id": _GOOD_USER_ID}
+    client = TestClient(_consent_app(), raise_server_exceptions=False)
 
     with patch.object(ConsentDBService, "get_active_tokens", new=AsyncMock(return_value=[])):
         with patch.object(
             ConsentDBService, "get_active_internal_tokens", new=AsyncMock(return_value=[])
         ):
-            client = TestClient(app, raise_server_exceptions=False)
             r = client.post(
                 "/api/consent/revoke",
                 json={"userId": _GOOD_USER_ID, "scope": sentinel_scope},
@@ -180,55 +187,36 @@ def test_revoke_by_scope_not_found_does_not_echo_scope():
 
 
 # ---------------------------------------------------------------------------
-# consent.py — export refresh invalid token (line 1327)
+# consent.py -- export refresh invalid token (upload_refreshed_export)
 # ---------------------------------------------------------------------------
 
-def test_export_refresh_invalid_token_does_not_echo_reason():
-    """
-    Invalid consent token during export refresh must not expose the validation reason.
-    """
-    import api.middleware as mw_mod
-    import hushh_mcp.consent.token as tok_mod
 
-    async def _bad_token(token, scope=None):
+def test_export_refresh_upload_invalid_token_does_not_echo_reason():
+    """
+    Invalid consent token during export-refresh upload must not expose the
+    validation reason.
+    """
+    client = TestClient(_consent_app(), raise_server_exceptions=False)
+
+    async def _bad_token(token, expected_scope=None, **kwargs):
         return False, _SENTINEL, None
 
-    with patch.object(tok_mod, "validate_token_with_db", side_effect=_bad_token):
-        with patch.dict(
-            __import__("server").app.dependency_overrides,
-            {mw_mod.require_vault_owner_token: lambda: {"user_id": _GOOD_USER_ID}},
-        ):
-            with _client() as client:
-                r = client.post(
-                    "/api/consent/export/refresh",
-                    json={
-                        "userId": _GOOD_USER_ID,
-                        "consentToken": "fake_consent_token_value",
-                    },
-                )
-                assert r.status_code in (401, 403, 422, 500), r.text
-                assert _SENTINEL not in r.text, (
-                    f"CWE-209: internal reason exposed in response: {r.text!r}"
-                )
-
-
-# ---------------------------------------------------------------------------
-# Verify opaque messages are present in known error responses
-# ---------------------------------------------------------------------------
-
-def test_vault_invalid_token_returns_opaque_message():
-    """The 401 detail for invalid vault token must be an opaque static string."""
-    import hushh_mcp.consent.token as tok_mod
-
-    async def _bad_token(token, scope=None):
-        return False, "Token expired", None
-
-    with patch.object(tok_mod, "validate_token_with_db", side_effect=_bad_token):
-        with _client() as client:
-            r = client.get(
-                f"/vault/data/{_GOOD_USER_ID}",
-                headers={"X-Hushh-Consent": "Bearer bad_token"},
-            )
-            assert r.status_code == 401, r.text
-            # The specific internal reason must not appear
-            assert "Token expired" not in r.text, r.text
+    with patch.object(consent_mod, "validate_token_with_db", side_effect=_bad_token):
+        r = client.post(
+            "/api/consent/export-refresh/upload",
+            json={
+                "userId": _GOOD_USER_ID,
+                "consentToken": "fake_consent_token_value",
+                "encryptedData": "data",
+                "encryptedIv": "iv",
+                "encryptedTag": "tag",
+                "wrappedExportKey": "wrapped_key",
+                "wrappedKeyIv": "wrapped_iv",
+                "wrappedKeyTag": "wrapped_tag",
+                "senderPublicKey": "sender_pub_key",
+            },
+        )
+        assert r.status_code in (401, 403, 422, 500), r.text
+        assert _SENTINEL not in r.text, (
+            f"CWE-209: internal reason exposed in response: {r.text!r}"
+        )

--- a/consent-protocol/tests/test_dbproxy_consent_cwe209_remaining.py
+++ b/consent-protocol/tests/test_dbproxy_consent_cwe209_remaining.py
@@ -1,0 +1,234 @@
+# tests/test_dbproxy_consent_cwe209_remaining.py
+"""
+Regression tests for remaining CWE-209 information-exposure fixes in:
+  api/routes/db_proxy.py   -- require_vault_owner_consent_header (line 132)
+                           -- validate_vault_owner_token (lines 714, 732)
+  api/routes/consent.py    -- approve_consent (line 450)
+                           -- revoke_consent_by_scope (line 1101)
+                           -- refresh_consent_export (line 1327)
+
+In all five locations the original code echoed internal token-validation
+reason strings or caller-supplied scope values back in HTTP error responses.
+Fixes replace them with static opaque messages while logging the full detail
+server-side.
+
+Verification strategy: inject a distinctive sentinel string into the mocked
+return value and assert it does NOT appear in the HTTP response body.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+_SENTINEL = "LEAKED_INTERNAL_DETAIL_sentinel_xyzzy_99"
+_GOOD_USER_ID = "firebase_uid_stub_28chars_abc"
+
+
+@contextmanager
+def _client():
+    from server import app
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# db_proxy.py — require_vault_owner_consent_header
+# ---------------------------------------------------------------------------
+
+def test_vault_consent_header_invalid_token_does_not_echo_reason():
+    """
+    An invalid VAULT_OWNER token must not echo the internal validation reason.
+    """
+    import hushh_mcp.consent.token as tok_mod
+
+    async def _bad_token(token, scope=None):
+        return False, _SENTINEL, None
+
+    with patch.object(tok_mod, "validate_token_with_db", side_effect=_bad_token):
+        with _client() as client:
+            r = client.get(
+                f"/vault/data/{_GOOD_USER_ID}",
+                headers={"X-Hushh-Consent": "Bearer fake_token_value"},
+            )
+            assert r.status_code == 401, r.text
+            assert _SENTINEL not in r.text, (
+                f"CWE-209: internal reason exposed in response: {r.text!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# db_proxy.py — validate_vault_owner_token (inside vault routes)
+# ---------------------------------------------------------------------------
+
+def test_vault_route_invalid_consent_token_does_not_echo_reason():
+    """
+    Invalid consent token on a vault route must not echo the validation reason.
+    """
+    import hushh_mcp.consent.token as tok_mod
+
+    async def _bad_token(token, scope=None):
+        return False, _SENTINEL, None
+
+    with patch.object(tok_mod, "validate_token_with_db", side_effect=_bad_token):
+        with _client() as client:
+            r = client.get(
+                f"/vault/data/{_GOOD_USER_ID}",
+                headers={
+                    "Authorization": f"Bearer {_GOOD_USER_ID}",
+                    "X-Hushh-Consent": f"Bearer consent_tok_{_GOOD_USER_ID}",
+                },
+            )
+            assert r.status_code in (401, 403, 404, 500), r.text
+            assert _SENTINEL not in r.text, (
+                f"CWE-209: internal reason exposed in response: {r.text!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# consent.py — scope_resolution_failed (approve_consent line 450)
+# ---------------------------------------------------------------------------
+
+def test_approve_consent_scope_error_does_not_echo_scope():
+    """
+    When scope resolution fails in approve_consent, the scope string must
+    not appear in the error response.
+    """
+    from unittest.mock import AsyncMock
+
+    from fastapi import FastAPI
+
+    sentinel_scope = f"SENTINEL_SCOPE_{_SENTINEL}"
+
+    import api.routes.consent as consent_mod
+    from api.middleware import require_vault_owner_token
+    from hushh_mcp.services.consent_db import ConsentDBService
+
+    app = FastAPI()
+    app.include_router(consent_mod.router)
+    app.dependency_overrides[require_vault_owner_token] = lambda: {"user_id": _GOOD_USER_ID}
+
+    def _bad_resolve(scope_str):
+        raise ValueError(f"cannot resolve {scope_str}")
+
+    with patch.object(
+        ConsentDBService,
+        "get_pending_by_request_id",
+        new=AsyncMock(
+            return_value={
+                "scope": sentinel_scope,
+                "user_id": _GOOD_USER_ID,
+                "developer": "dev_app",
+                "status": "pending",
+                "metadata": {},
+            }
+        ),
+    ):
+        with patch.object(consent_mod, "resolve_scope_to_enum", side_effect=_bad_resolve):
+            client = TestClient(app, raise_server_exceptions=False)
+            r = client.post(
+                "/api/consent/pending/approve",
+                json={
+                    "requestId": "req_12345",
+                    "userId": _GOOD_USER_ID,
+                },
+            )
+            assert r.status_code in (400, 401, 403, 422, 500), r.text
+            assert sentinel_scope not in r.text, (
+                f"CWE-209: scope echoed in error: {r.text!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# consent.py — No active consent for scope (revoke_consent_by_scope line 1101)
+# ---------------------------------------------------------------------------
+
+def test_revoke_by_scope_not_found_does_not_echo_scope():
+    """
+    When no active consent exists for the requested scope, the scope value
+    must not appear verbatim in the 404 response body.
+    """
+    from unittest.mock import AsyncMock
+
+    from fastapi import FastAPI
+
+    sentinel_scope = f"SENTINEL_scope_{_SENTINEL}"
+
+    import api.routes.consent as consent_mod
+    from api.middleware import require_vault_owner_token
+    from hushh_mcp.services.consent_db import ConsentDBService
+
+    app = FastAPI()
+    app.include_router(consent_mod.router)
+    app.dependency_overrides[require_vault_owner_token] = lambda: {"user_id": _GOOD_USER_ID}
+
+    with patch.object(ConsentDBService, "get_active_tokens", new=AsyncMock(return_value=[])):
+        with patch.object(
+            ConsentDBService, "get_active_internal_tokens", new=AsyncMock(return_value=[])
+        ):
+            client = TestClient(app, raise_server_exceptions=False)
+            r = client.post(
+                "/api/consent/revoke",
+                json={"userId": _GOOD_USER_ID, "scope": sentinel_scope},
+            )
+            assert r.status_code in (400, 401, 403, 404, 422, 500), r.text
+            assert sentinel_scope not in r.text, (
+                f"CWE-209: scope echoed in error: {r.text!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# consent.py — export refresh invalid token (line 1327)
+# ---------------------------------------------------------------------------
+
+def test_export_refresh_invalid_token_does_not_echo_reason():
+    """
+    Invalid consent token during export refresh must not expose the validation reason.
+    """
+    import api.middleware as mw_mod
+    import hushh_mcp.consent.token as tok_mod
+
+    async def _bad_token(token, scope=None):
+        return False, _SENTINEL, None
+
+    with patch.object(tok_mod, "validate_token_with_db", side_effect=_bad_token):
+        with patch.dict(
+            __import__("server").app.dependency_overrides,
+            {mw_mod.require_vault_owner_token: lambda: {"user_id": _GOOD_USER_ID}},
+        ):
+            with _client() as client:
+                r = client.post(
+                    "/api/consent/export/refresh",
+                    json={
+                        "userId": _GOOD_USER_ID,
+                        "consentToken": "fake_consent_token_value",
+                    },
+                )
+                assert r.status_code in (401, 403, 422, 500), r.text
+                assert _SENTINEL not in r.text, (
+                    f"CWE-209: internal reason exposed in response: {r.text!r}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Verify opaque messages are present in known error responses
+# ---------------------------------------------------------------------------
+
+def test_vault_invalid_token_returns_opaque_message():
+    """The 401 detail for invalid vault token must be an opaque static string."""
+    import hushh_mcp.consent.token as tok_mod
+
+    async def _bad_token(token, scope=None):
+        return False, "Token expired", None
+
+    with patch.object(tok_mod, "validate_token_with_db", side_effect=_bad_token):
+        with _client() as client:
+            r = client.get(
+                f"/vault/data/{_GOOD_USER_ID}",
+                headers={"X-Hushh-Consent": "Bearer bad_token"},
+            )
+            assert r.status_code == 401, r.text
+            # The specific internal reason must not appear
+            assert "Token expired" not in r.text, r.text


### PR DESCRIPTION
Narrowed scope: db_proxy.py only. Replaces token validation reason echoes with opaque messages.