### PR TITLE
test(use-debounced-value): cover null value debouncing

### DIFF
--- a/hushh-webapp/__tests__/hooks/use-debounced-value.test.tsx
+++ b/hushh-webapp/__tests__/hooks/use-debounced-value.test.tsx
@@ -194,4 +194,27 @@ describe("useDebouncedValue", () => {
 
     expect(onDebounced).toHaveBeenLastCalledWith(next);
   });
+
+  it("debounces null value transitions", () => {
+    const onDebounced = vi.fn();
+    const { rerender } = render(
+      <Harness<string | null> value="ready" delayMs={200} onDebounced={onDebounced} />
+    );
+    onDebounced.mockClear();
+
+    rerender(
+      <Harness<string | null> value={null} delayMs={200} onDebounced={onDebounced} />
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(199);
+    });
+    expect(onDebounced).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(onDebounced).toHaveBeenCalledTimes(1);
+    expect(onDebounced).toHaveBeenLastCalledWith(null);
+  });
 });


### PR DESCRIPTION
## Summary
- Add focused hook test coverage for null value debouncing.
- Verify `useDebouncedValue` waits for the delay before committing a transition from a string value to `null`.

## Scope Proof
- Test file touched: `hushh-webapp/__tests__/hooks/use-debounced-value.test.tsx`.
- No runtime hook code changed.
- Appends one new `it()` block inside the existing `describe("useDebouncedValue")` suite.

## Impact
Test-only change. This locks the existing null transition debounce behavior without changing application output.

## Validation
- `npx.cmd vitest run __tests__/hooks/use-debounced-value.test.tsx`
- Verified the commit includes a DCO `Signed-off-by` trailer.
