### PR TITLE
test(use-media-query): cover matches false on non-matching query

### DIFF
--- a/hushh-webapp/__tests__/hooks/use-media-query.test.tsx
+++ b/hushh-webapp/__tests__/hooks/use-media-query.test.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useMediaQuery } from "@/lib/morphy-ux/use-media-query";
+
+function Harness({
+  query,
+  onValue,
+}: {
+  query: string;
+  onValue: (value: boolean) => void;
+}) {
+  const matches = useMediaQuery(query);
+
+  React.useEffect(() => {
+    onValue(matches);
+  }, [matches, onValue]);
+
+  return null;
+}
+
+describe("useMediaQuery", () => {
+  it("returns false for a non-matching query", () => {
+    const callback = vi.fn();
+    const addEventListener = vi.fn();
+    const removeEventListener = vi.fn();
+
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener,
+      removeEventListener,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    render(<Harness query="(min-width: 1200px)" onValue={callback} />);
+
+    expect(window.matchMedia).toHaveBeenCalledWith("(min-width: 1200px)");
+    expect(callback).toHaveBeenLastCalledWith(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused hook test coverage for `useMediaQuery`.
- Verify a non-matching media query reports `false`.

## Scope Proof
- New test file only: `hushh-webapp/__tests__/hooks/use-media-query.test.tsx`.
- No runtime hook code changed.
- Covers the existing `lib/morphy-ux/use-media-query` hook directly.

## Impact
Test-only change. This locks the existing non-match behavior without changing application output.

## Validation
- `npx.cmd vitest run __tests__/hooks/use-media-query.test.tsx`
- Verified the commit includes a DCO `Signed-off-by` trailer.
