### PR TITLE
fix(ui): hide ria clients loading spinner from assistive technology

### DIFF
--- a/hushh-webapp/app/ria/clients/page.tsx
+++ b/hushh-webapp/app/ria/clients/page.tsx
@@ -210,7 +210,7 @@ export default function RiaClientsPage() {
           >
             {clientsResource.loading ? (
               <div className="flex items-center gap-2 px-4 py-6 text-sm text-muted-foreground">
-                <Loader2 className="h-4 w-4 animate-spin" />
+                <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />
                 Loading clients...
               </div>
             ) : clientItems.length === 0 ? (


### PR DESCRIPTION
## Summary
- Hide the RIA clients loading spinner from assistive technology.
- Keep the visible `Loading clients...` text as the accessible loading cue.

## Scope Proof
- Runtime file touched: `hushh-webapp/app/ria/clients/page.tsx`.
- Only the `Loader2` icon in the clients loading state changed.
- No RIA client fetching, empty state, routing, or roster rendering behavior changed.

## Caller Proof
- The spinner sits beside visible text: `Loading clients...`.
- Marking the SVG `aria-hidden="true"` removes decorative icon noise while preserving the text announcement.

## Validation
- `npx.cmd eslint app/ria/clients/page.tsx --max-warnings=0`
- Verified the commit includes a DCO `Signed-off-by` trailer.
