### PR TITLE
fix(ui): hide ria onboarding loading spinner from assistive technology

### DIFF
--- a/hushh-webapp/app/ria/onboarding/page.tsx
+++ b/hushh-webapp/app/ria/onboarding/page.tsx
@@ -729,7 +729,7 @@ export default function RiaOnboardingPage() {
     if (loading) {
       return (
         <div className="flex min-h-56 items-center justify-center gap-2 text-sm text-muted-foreground">
-          <Loader2 className="h-4 w-4 animate-spin" />
+          <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />
           Loading...
         </div>
       );


### PR DESCRIPTION
## Summary
- Hide the RIA onboarding loading spinner from assistive technology.
- Keep the visible `Loading...` text as the accessible loading cue.

## Scope Proof
- Runtime file touched: `hushh-webapp/app/ria/onboarding/page.tsx`.
- Only the `Loader2` icon in the onboarding loading state changed.
- No onboarding state loading, draft handling, routing, or step rendering behavior changed.

## Caller Proof
- The spinner sits beside visible text: `Loading...`.
- Marking the SVG `aria-hidden="true"` removes decorative icon noise while preserving the text announcement.

## Validation
- `npx.cmd eslint app/ria/onboarding/page.tsx --max-warnings=0`
- Verified the commit includes a DCO `Signed-off-by` trailer.
