### PR TITLE
test(use-clipboard): cover successful copy sets copied state

### DIFF
--- a/hushh-webapp/__tests__/hooks/use-clipboard.test.tsx
+++ b/hushh-webapp/__tests__/hooks/use-clipboard.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useClipboard } from "@/hooks/use-clipboard";
+import { copyToClipboard } from "@/lib/utils/clipboard";
+
+vi.mock("@/lib/utils/clipboard", () => ({
+  copyToClipboard: vi.fn(),
+}));
+
+function Harness() {
+  const { copied, copy } = useClipboard();
+
+  return (
+    <button type="button" onClick={() => void copy("clipboard text")}>
+      {copied ? "Copied" : "Copy"}
+    </button>
+  );
+}
+
+describe("useClipboard", () => {
+  afterEach(() => {
+    vi.mocked(copyToClipboard).mockReset();
+  });
+
+  it("sets copied state after a successful copy", async () => {
+    vi.mocked(copyToClipboard).mockResolvedValue(true);
+
+    render(<Harness />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+
+    expect(copyToClipboard).toHaveBeenCalledWith("clipboard text");
+    expect((await screen.findByRole("button", { name: "Copied" })).textContent).toBe(
+      "Copied"
+    );
+  });
+});

--- a/hushh-webapp/hooks/use-clipboard.ts
+++ b/hushh-webapp/hooks/use-clipboard.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+import { copyToClipboard } from "@/lib/utils/clipboard";
+
+export function useClipboard() {
+  const [copied, setCopied] = useState(false);
+
+  const copy = useCallback(async (value: string) => {
+    const didCopy = await copyToClipboard(value);
+    setCopied(didCopy);
+    return didCopy;
+  }, []);
+
+  const reset = useCallback(() => {
+    setCopied(false);
+  }, []);
+
+  return { copied, copy, reset };
+}


### PR DESCRIPTION
## Summary
- Add a small `useClipboard` hook that owns copied state while delegating writes to the existing clipboard utility.
- Cover the successful copy path so `copied` flips after `copyToClipboard` resolves `true`.

## Scope Proof
- Runtime file added: `hushh-webapp/hooks/use-clipboard.ts`.
- Test file added: `hushh-webapp/__tests__/hooks/use-clipboard.test.tsx`.
- No existing clipboard utility, component copy flows, routing, or UI behavior was changed.

## Caller Proof
- The hook exposes `copied`, `copy`, and `reset` without changing existing callers.
- The test uses a harness button to prove a successful copy updates the rendered copied state.

## Validation
- `npx.cmd vitest run __tests__/hooks/use-clipboard.test.tsx`
- `npx.cmd eslint hooks/use-clipboard.ts __tests__/hooks/use-clipboard.test.tsx --max-warnings=0`
- Verified the commit includes a DCO `Signed-off-by` trailer.
