### PR TITLE
test(use-toggle): cover initial false state

### DIFF
--- a/hushh-webapp/__tests__/hooks/use-toggle.test.tsx
+++ b/hushh-webapp/__tests__/hooks/use-toggle.test.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useToggle } from "@/hooks/use-toggle";
+
+function Harness({ onValue }: { onValue: (value: boolean) => void }) {
+  const { value } = useToggle();
+
+  React.useEffect(() => {
+    onValue(value);
+  }, [onValue, value]);
+
+  return null;
+}
+
+describe("useToggle", () => {
+  it("returns false for the initial state", () => {
+    const onValue = vi.fn();
+
+    render(<Harness onValue={onValue} />);
+
+    expect(onValue).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/hushh-webapp/hooks/use-toggle.ts
+++ b/hushh-webapp/hooks/use-toggle.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+export function useToggle(initialValue = false) {
+  const [value, setValue] = useState(initialValue);
+
+  const toggle = useCallback(() => {
+    setValue((current) => !current);
+  }, []);
+
+  const setOn = useCallback(() => {
+    setValue(true);
+  }, []);
+
+  const setOff = useCallback(() => {
+    setValue(false);
+  }, []);
+
+  return { value, toggle, setOn, setOff };
+}


### PR DESCRIPTION
## Summary
- Add a small `useToggle` hook with a default `false` state.
- Cover the initial false state in a focused hook test.

## Scope Proof
- Runtime file added: `hushh-webapp/hooks/use-toggle.ts`.
- Test file added: `hushh-webapp/__tests__/hooks/use-toggle.test.tsx`.
- No existing hook callers, UI components, routing, or state flows were changed.

## Caller Proof
- The hook exposes `value`, `toggle`, `setOn`, and `setOff` for future callers.
- The test renders a minimal harness and verifies the default initial value is `false`.

## Validation
- `npx.cmd vitest run __tests__/hooks/use-toggle.test.tsx`
- `npx.cmd eslint hooks/use-toggle.ts __tests__/hooks/use-toggle.test.tsx --max-warnings=0`
- Verified the commit includes a DCO `Signed-off-by` trailer.
