### PR TITLE
fix(ui): move CommandDialog header inside DialogContent portal to fix 11y associations

### DIFF
--- a/hushh-webapp/components/ui/command.tsx
+++ b/hushh-webapp/components/ui/command.tsx
@@ -44,14 +44,14 @@ function CommandDialog({
 }) {
   return (
     <Dialog {...props}>
-      <DialogHeader className="sr-only">
-        <DialogTitle>{title}</DialogTitle>
-        <DialogDescription>{description}</DialogDescription>
-      </DialogHeader>
       <DialogContent
         className={cn("overflow-hidden p-0", className)}
         showCloseButton={showCloseButton}
       >
+        <DialogHeader className="sr-only">
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
         <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>


### PR DESCRIPTION
Radix UI Dialog primitives require the `DialogTitle` and `DialogDescription` to be rendered inside the `DialogContent` (which is a React Portal) so that the accessibility properties (`aria-labelledby` and `aria-describedby`) can successfully wire the descriptions to the dialog container. 

Previously in `CommandDialog`, the `DialogHeader` (which contained the title and description) was placed outside the `DialogContent` as a sibling. This meant it rendered as a visually hidden inline element outside the portal, completely breaking the screen reader context for the Command Dialog. This commit moves the `DialogHeader` safely inside the `DialogContent`.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None specifically (generic UI components)
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None (Pure UI Primitives)
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable
- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes current reachable app surfaces — generic UI components.
- [x] Reachable production attach point: `components/ui/command.tsx`
- [x] Production surface proved: explicit A11y DOM structure restoration, zero logic change.
- [x] Commits are signed off and GitHub shows this branch is mergeable with main.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation
- [x] **iOS**: Not applicable — Web Accessibility Tree
- [x] **Android**: Not applicable — Web Accessibility Tree

## 🧪 Testing

- [x] Tested on Web (Verified the affected UI components correctly associate ARIA attributes to the portal contents)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Moves `CommandDialog` header inside `DialogContent` portal to fix a11y associations.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed