### PR TITLE
fix(ui): hide marketplace swipe action icons from assistive technology

### DIFF
--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -1324,7 +1324,7 @@ export default function MarketplacePage() {
                       onClick={passCurrentCard}
                       aria-label="Pass card"
                     >
-                      <X className="h-4 w-4 sm:mr-2" />
+                      <X aria-hidden="true" className="h-4 w-4 sm:mr-2" />
                       <span className="hidden sm:inline">Pass</span>
                     </Button>
                     <Button
@@ -1336,7 +1336,7 @@ export default function MarketplacePage() {
                       aria-label="View profile"
                     >
                       <span className="hidden sm:inline">View</span>
-                      <ArrowUpRight className="h-4 w-4 sm:ml-2" />
+                      <ArrowUpRight aria-hidden="true" className="h-4 w-4 sm:ml-2" />
                     </Button>
                     <Button
                       variant="blue-gradient"


### PR DESCRIPTION
## Summary
- Hide the marketplace swipe deck action icons from assistive technology.
- Keep the existing button labels and aria labels as the accessible action names.

## Scope Proof
- Runtime file touched: `hushh-webapp/app/marketplace/page.tsx`.
- Only the swipe card `Pass` and `View profile` action icons changed.
- No marketplace filtering, swipe gesture, profile opening, or action persistence behavior changed.

## Caller Proof
- The pass action already exposes `aria-label="Pass card"`.
- The view action already exposes `aria-label="View profile"`.
- Marking the decorative `X` and `ArrowUpRight` SVGs hidden avoids duplicate icon noise without changing button names.

## Validation
- `npx.cmd eslint app/marketplace/page.tsx --max-warnings=0`
- Verified the commit includes a DCO `Signed-off-by` trailer.
