### PR TITLE
test(use-previous): cover returns undefined on first render

### DIFF
--- a/hushh-webapp/__tests__/hooks/use-previous.test.tsx
+++ b/hushh-webapp/__tests__/hooks/use-previous.test.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { usePrevious } from "@/hooks/use-previous";
+
+function Harness({
+  value,
+  onPrevious,
+}: {
+  value: string;
+  onPrevious: (value: string | undefined) => void;
+}) {
+  const previous = usePrevious(value);
+
+  React.useEffect(() => {
+    onPrevious(previous);
+  }, [onPrevious, previous]);
+
+  return null;
+}
+
+describe("usePrevious", () => {
+  it("returns undefined on the first render", () => {
+    const onPrevious = vi.fn();
+
+    render(<Harness value="first" onPrevious={onPrevious} />);
+
+    expect(onPrevious).toHaveBeenLastCalledWith(undefined);
+  });
+});

--- a/hushh-webapp/hooks/use-previous.ts
+++ b/hushh-webapp/hooks/use-previous.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+export function usePrevious<T>(value: T): T | undefined {
+  const previousRef = useRef<T | undefined>(undefined);
+
+  useEffect(() => {
+    previousRef.current = value;
+  }, [value]);
+
+  // `usePrevious` intentionally exposes the ref value captured before this render.
+  // eslint-disable-next-line react-hooks/refs
+  return previousRef.current;
+}


### PR DESCRIPTION
## Summary
- Add a small `usePrevious` hook for reading the value from the prior render.
- Cover the first-render behavior where no previous value exists yet.

## Scope Proof
- Runtime file added: `hushh-webapp/hooks/use-previous.ts`.
- Test file added: `hushh-webapp/__tests__/hooks/use-previous.test.tsx`.
- No existing hook callers, UI components, routing, or state flows were changed.

## Caller Proof
- The hook returns `undefined` before the first effect captures an initial value.
- The test renders a minimal harness and verifies the first observed previous value is `undefined`.

## Validation
- `npx.cmd vitest run __tests__/hooks/use-previous.test.tsx`
- `npx.cmd eslint hooks/use-previous.ts __tests__/hooks/use-previous.test.tsx --max-warnings=0`
- Verified the commit includes a DCO `Signed-off-by` trailer.
