### PR TITLE
test(use-intersection-observer): cover ref not observed when disabled

### DIFF
--- a/hushh-webapp/__tests__/hooks/use-intersection-observer.test.tsx
+++ b/hushh-webapp/__tests__/hooks/use-intersection-observer.test.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+import { render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useIntersectionObserver } from "@/hooks/use-intersection-observer";
+
+const observeMock = vi.fn();
+const disconnectMock = vi.fn();
+
+class MockIntersectionObserver {
+  observe = observeMock;
+  disconnect = disconnectMock;
+}
+
+function Harness({ disabled }: { disabled: boolean }) {
+  const ref = React.useRef<HTMLDivElement>(null);
+  useIntersectionObserver(ref, { disabled });
+
+  return <div ref={ref} />;
+}
+
+describe("useIntersectionObserver", () => {
+  afterEach(() => {
+    observeMock.mockClear();
+    disconnectMock.mockClear();
+    vi.unstubAllGlobals();
+  });
+
+  it("does not observe the ref when disabled", () => {
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+
+    render(<Harness disabled />);
+
+    expect(observeMock).not.toHaveBeenCalled();
+    expect(disconnectMock).not.toHaveBeenCalled();
+  });
+});

--- a/hushh-webapp/hooks/use-intersection-observer.ts
+++ b/hushh-webapp/hooks/use-intersection-observer.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect, useState, type RefObject } from "react";
+
+type UseIntersectionObserverOptions = IntersectionObserverInit & {
+  disabled?: boolean;
+};
+
+export function useIntersectionObserver(
+  targetRef: RefObject<Element | null>,
+  options: UseIntersectionObserverOptions = {},
+) {
+  const { disabled = false, root = null, rootMargin, threshold } = options;
+  const [entry, setEntry] = useState<IntersectionObserverEntry | null>(null);
+
+  useEffect(() => {
+    const target = targetRef.current;
+    if (disabled || !target || typeof IntersectionObserver === "undefined") {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([nextEntry]) => {
+        setEntry(nextEntry ?? null);
+      },
+      { root, rootMargin, threshold },
+    );
+
+    observer.observe(target);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [disabled, root, rootMargin, targetRef, threshold]);
+
+  return entry;
+}


### PR DESCRIPTION
## Summary
- Add a small `useIntersectionObserver` hook with a disabled option.
- Cover the disabled path so the hook does not observe the attached ref.

## Scope Proof
- Runtime file added: `hushh-webapp/hooks/use-intersection-observer.ts`.
- Test file added: `hushh-webapp/__tests__/hooks/use-intersection-observer.test.tsx`.
- No existing hook callers, UI components, routing, or observer behavior elsewhere was changed.

## Caller Proof
- When `disabled` is true, the hook exits before creating or using an observer.
- The test stubs `IntersectionObserver` and verifies `observe` is never called for the rendered ref.

## Validation
- `npx.cmd vitest run __tests__/hooks/use-intersection-observer.test.tsx`
- `npx.cmd eslint hooks/use-intersection-observer.ts __tests__/hooks/use-intersection-observer.test.tsx --max-warnings=0`
- Verified the commit includes a DCO `Signed-off-by` trailer.
