### PR TITLE
test(config): cover frontend origin in production environment

### DIFF
--- a/hushh-webapp/__tests__/lib/config.test.ts
+++ b/hushh-webapp/__tests__/lib/config.test.ts
@@ -109,4 +109,20 @@ describe("config", () => {
 
     expect(config.BACKEND_URL).toBe("https://uat-api.hushh.ai");
   });
+
+  it("uses runtime frontend origin in production environment", async () => {
+    const { resolveAppEnvironment } = await import("@/lib/app-env");
+    const { resolveRuntimeFrontendUrl } = await import(
+      "@/lib/runtime/settings"
+    );
+
+    vi.mocked(resolveAppEnvironment).mockReturnValue("production");
+    vi.mocked(resolveRuntimeFrontendUrl).mockReturnValue(
+      "https://app.hushh.ai/"
+    );
+
+    const config = await import("@/lib/config");
+
+    expect(config.APP_FRONTEND_ORIGIN).toBe("https://app.hushh.ai");
+  });
 });


### PR DESCRIPTION
## Summary
- Cover production frontend origin resolution in the config test suite.
- Verify runtime frontend settings are normalized before `APP_FRONTEND_ORIGIN` is exported.

## Scope Proof
- Test file touched: `hushh-webapp/__tests__/lib/config.test.ts`.
- Appended one focused `it()` block to the existing `config` describe.
- No runtime config implementation, app environment logic, or backend URL behavior changed.

## Caller Proof
- The test mocks `resolveAppEnvironment()` as `production`.
- It mocks `resolveRuntimeFrontendUrl()` with a trailing slash and verifies `APP_FRONTEND_ORIGIN` exports the normalized production origin.

## Validation
- `npx.cmd vitest run __tests__/lib/config.test.ts`
- `npx.cmd eslint __tests__/lib/config.test.ts --max-warnings=0`
- Verified the commit includes a DCO `Signed-off-by` trailer.
