### PR TITLE
fix(ui): add type=button to dialog close and fix disabled cursor state

### DIFF
--- a/hushh-webapp/components/ui/dialog.tsx
+++ b/hushh-webapp/components/ui/dialog.tsx
@@ -72,8 +72,9 @@ function DialogContent({
 
         {showCloseButton && (
           <DialogPrimitive.Close
+            type="button"
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring group absolute top-4 right-4 z-30 isolate overflow-hidden rounded-full border border-transparent bg-[color:var(--app-card-surface-compact)] p-2 opacity-70 transition-[opacity,transform] duration-200 hover:opacity-100 active:scale-[0.97] focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="ring-offset-background focus:ring-ring group absolute top-4 right-4 z-30 isolate overflow-hidden rounded-full border border-transparent bg-[color:var(--app-card-surface-compact)] p-2 opacity-70 transition-[opacity,transform] duration-200 hover:opacity-100 active:scale-[0.97] focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon aria-hidden="true" />
             <MaterialRipple variant="none" effect="fade" className="z-10" />


### PR DESCRIPTION
This PR adds `type="button"` to the Dialog close button to prevent it from acting as a submit button when placed inside a form. It also fixes a bug where the disabled state used `pointer-events-none`, blocking the `not-allowed` cursor from appearing on hover, matching the fixes applied to other UI components.

# Description

This is a minimal, single-file hygiene PR for `components/ui/dialog.tsx`. 
1. **Prevent Unwanted Form Submissions**: The `<DialogPrimitive.Close>` button was missing the explicit `type="button"` attribute. When standard buttons inside a `<form>` lack this attribute, they default to `type="submit"`. Adding it prevents the dialog close button from accidentally submitting forms when used within form wrappers.
2. **Cursor UX Fix**: Replaced `disabled:pointer-events-none` with `disabled:cursor-not-allowed` on the exact same button to ensure standard native cursor feedback for disabled items, preventing users from experiencing a "dead" hover state.

Before requesting review, read
[`docs/reference/quality/pr-contributor-readiness.md`](docs/reference/quality/pr-contributor-readiness.md).
Green CI is intake only; merge readiness also requires a reachable attach point,
production-code proof, and a title/body that match the diff.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
  - [ ] Listed below:

- API / schema / type changes:
  - [x] None
  - [ ] Listed below:

- Cache keys touched:
  - [x] None
  - [ ] Listed below:

- Runtime DB data-plane changes:
  - [x] None
  - [ ] Listed below:

- World-model domain summary effects:
  - [x] None
  - [ ] Listed below:

- Mobile parity impacts:
  - [x] None
  - [ ] Listed below:

- Docs updated (exact files):
  - [x] None
  - [ ] Listed below:

- Top-level / devex / config / generated / ignore files touched:
  - [x] None
  - [ ] Listed below with the existing workflow they attach to:

- Trust boundary touched:
  - [x] None
  - [ ] Auth / consent / vault / PKM / finance / voice-action / KYC / schema / deploy / public ingress listed below:

- Caller / proxy / backend pairing:
  - [x] Not applicable
  - [ ] Listed below with contract proof:

- Rollback or safe-failure behavior:
  - [x] Not applicable
  - [ ] Listed below:

- UI browser or Playwright proof:
  - [x] Not applicable
  - [ ] Route/spec/command listed below:

- Verification commands executed:
  - [ ] `./bin/hushh codex pre-pr`
  - [x] `cd hushh-webapp && npm run typecheck`
  - [ ] `cd hushh-webapp && npm test`
  - [ ] `cd hushh-webapp && npm run build`
  - [ ] `cd hushh-webapp && npm run ios:test`
  - [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000`

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate:
- [x] This PR changes a current reachable app/backend/package/docs surface, or it is explicitly scoped as test/devex hygiene.
- [x] Reachable production attach point: `components/ui/dialog.tsx`
- [ ] New tests import and exercise production code, not only mock components/helpers defined inside the test file.
- [x] New helpers/components/services are wired to an existing route, caller, package export, generated contract, or documented devex entrypoint.
- [ ] Production surface proved:
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.
- [x] Maintainer edits are enabled, or the reason they cannot be enabled is listed here:
- [ ] If this is one PR in a stack, the predecessor PR is linked here:
- [ ] If this responds to requested changes, the new commit or material explanation is described here:

## 🛑 Tri-Flow Architecture Check

Every cross-platform feature must cover all affected layers or explicitly mark
the layer as not applicable with the reason.

- [x] **Web**: Next.js implementation (`app/api/...`)
- [ ] **iOS**: Swift Capacitor Plugin (`ios/App/App/Plugins/...`)
- [ ] **Android**: Kotlin Capacitor Plugin (`android/app/.../plugins/...`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)
- [ ] If generated files changed, they were regenerated by the canonical repo command listed above

## 📸 Screenshots / Video

Attach proof of work here. For UI-visible changes, include the route plus
Playwright spec/command, screenshot, video, or why browser proof is not
applicable.
*(Not applicable: Component-level DOM hygiene fix)*

## 🛡️ Privacy & Consent

- [ ] Does this change access user data?
- [ ] If yes, have you implemented `checkConsentToken()`?
- [x] Sensitive surface touched: none
- [ ] Error path, rollback, or safe-failure behavior proved:

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed