### PR TITLE
fix(ria): add max_length bound to universe tier query parameter

### DIFF
--- a/consent-protocol/api/routes/ria.py
+++ b/consent-protocol/api/routes/ria.py
@@ -521,7 +521,7 @@ async def create_ria_request_bundle(
 
 @router.get("/universe")
 async def renaissance_universe(
-    tier: str | None = Query(None),
+    tier: str | None = Query(None, max_length=50),
     firebase_uid: str = Depends(require_firebase_auth),
 ):
     """Return the Renaissance investable universe (default Kai stock list)."""


### PR DESCRIPTION
## Summary

Adds a `max_length` constraint to the `tier` query parameter on the Renaissance universe endpoint.

### Changes

* Added `max_length=50` to `tier: str | None = Query(...)`

### Why

This aligns the endpoint with existing query parameter bounds hardening patterns and helps prevent unbounded user-controlled input (CWE-400).

### Testing

* Verified lint passes in `hushh-webapp`
* Confirmed route signature change is isolated to a single parameter
