### PR TITLE
fix(ui): unblock not-allowed cursor on disabled combobox chips

### DIFF
--- a/hushh-webapp/components/ui/combobox.tsx
+++ b/hushh-webapp/components/ui/combobox.tsx
@@ -255,7 +255,7 @@ function ComboboxChip({
     <ComboboxPrimitive.Chip
       data-slot="combobox-chip"
       className={cn(
-        "bg-muted text-foreground flex h-[calc(--spacing(5.5))] w-fit items-center justify-center gap-1 rounded-sm px-1.5 text-xs font-medium whitespace-nowrap has-disabled:pointer-events-none has-disabled:cursor-not-allowed has-disabled:opacity-50 has-data-[slot=combobox-chip-remove]:pr-0",
+        "bg-muted text-foreground flex h-[calc(--spacing(5.5))] w-fit items-center justify-center gap-1 rounded-sm px-1.5 text-xs font-medium whitespace-nowrap has-disabled:cursor-not-allowed has-disabled:opacity-50 has-data-[slot=combobox-chip-remove]:pr-0",
         className
       )}
       {...props}


### PR DESCRIPTION
This PR removes the `has-disabled:pointer-events-none` class from the `ComboboxChip` component. When both `pointer-events-none` and `cursor-not-allowed` were present, the pointer events blockage prevented the native 'not-allowed' cursor from appearing on hover, resulting in a dead UX state. Removing it restores standard native cursor feedback.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None

- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None
- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Not applicable

- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate:
- [x] This PR changes a current reachable app/backend/package/docs surface, or it is explicitly scoped as test/devex hygiene.
- [x] Reachable production attach point: `components/ui/combobox.tsx`
- [x] New helpers/components/services are wired to an existing route, caller, package export, generated contract, or documented devex entrypoint.
- [ ] Production surface proved:
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.
- [x] Maintainer edits are enabled, or the reason they cannot be enabled is listed here:

## 🛑 Tri-Flow Architecture Check

Every cross-platform feature must cover all affected layers or explicitly mark
the layer as not applicable with the reason.

- [x] **Web**: Next.js implementation (`app/api/...`)
- [ ] **iOS**: Swift Capacitor Plugin (`ios/App/App/Plugins/...`)
- [ ] **Android**: Kotlin Capacitor Plugin (`android/app/.../plugins/...`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Attach proof of work here. For UI-visible changes, include the route plus
Playwright spec/command, screenshot, video, or why browser proof is not
applicable.
*(Not applicable: Component-level DOM hygiene fix)*

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed