### PR TITLE
chore(ci): lock main promotion to pr train

### DIFF
--- a/.codex/skills/repo-operations/references/branch-runtime-ops.md
+++ b/.codex/skills/repo-operations/references/branch-runtime-ops.md
@@ -45,13 +45,18 @@ push safety, local runtime terminals, deploy cadence, and UAT release gates.
 ## Merge, Deploy, And UAT
 
 1. `merge to main` means land and monitor through `Main Post-Merge Smoke` only.
-2. `deploy to UAT` is separate: land on `main`, identify the green SHA,
+2. Normal feature/fix/docs work lands in `integration/pr-train` first, then
+   `integration/pr-train` promotes to `main`; do not use standing maintainer,
+   release, or community branches as alternate `main` heads.
+3. Maintainer bypass authority can waive review or queue mechanics when policy
+   explicitly allows it, but it does not change the normal promotion head.
+4. `deploy to UAT` is separate: land on `main`, identify the green SHA,
    dispatch UAT deploy for that SHA, and monitor terminal status.
-3. Monitor `PR Validation`, `Queue Validation`, `Main Post-Merge Smoke`,
+5. Monitor `PR Validation`, `Queue Validation`, `Main Post-Merge Smoke`,
    `Deploy to UAT`, and RCA-triggered release authority runs until terminal.
-4. Core runs in `queued`, `in_progress`, or `requested` state mean the task is
+6. Core runs in `queued`, `in_progress`, or `requested` state mean the task is
    not complete.
-5. For UAT runtime failures, start with the repo RCA command and classify
+7. For UAT runtime failures, start with the repo RCA command and classify
    secret drift, runtime mounts, DB drift, and semantic breakage before editing.
 
 ## DB Release Gate

--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -3,8 +3,7 @@
     "train_branch": "integration/pr-train",
     "promotion_branch": "main",
     "main_allowed_head_branches": [
-      "integration/pr-train",
-      "maintainer/promote-damria-one-location-to-main"
+      "integration/pr-train"
     ]
   },
   "main": {

--- a/docs/reference/operations/branch-governance.md
+++ b/docs/reference/operations/branch-governance.md
@@ -16,7 +16,7 @@ flowchart LR
   green --> prod
 ```
 
-This repo now runs on a dedicated PR-train branch, a protected promotion branch, and SHA-based environment deployment:
+This repo runs on a dedicated PR-train branch, a queue-governed `main` promotion lane, and SHA-based environment deployment:
 
 | Lane | Purpose | Default policy |
 |---|---|---|
@@ -25,12 +25,14 @@ This repo now runs on a dedicated PR-train branch, a protected promotion branch,
 | UAT | Hosted validation environment | Manual deploy of an exact green `main` SHA |
 | Production | Live user traffic | Manual deploy of an approved green `main` SHA |
 
+No standing maintainer, community, or release-named branch may be added as a second allowed head into `main`. Maintainer bypass authority can waive review/queue mechanics when policy explicitly allows it, but it does not change the required head branch: normal promotion is `integration/pr-train -> main`.
+
 ## Working Rules
 
 1. Start all maintainer/developer branches from the current `integration/pr-train` unless an isolated `main` hotfix is explicitly required.
 2. Contributor PRs may still be opened to `main` for a familiar GitHub intake experience; maintainers or automation retarget normal intake to `integration/pr-train` before review, approval, queue, merge, maintainer patch, or harvest.
 3. Merge all normal feature/fix/docs work into `integration/pr-train`.
-4. Promote `integration/pr-train` into `main` through a PR after the train is green and ancestry-clean.
+4. Promote `integration/pr-train` into `main` through a PR after the train is green and ancestry-clean; use merge queue by default and do not substitute a named maintainer branch for the train.
 5. Do not merge direct feature, contributor, or agent PRs into `main`; CI blocks them unless the head branch is `integration/pr-train`.
 6. Continue follow-up fixes on the active development branch by default; do not create extra temporary branches for routine polish, validation follow-up, or same-lane fixes.
 7. Create a new branch only when isolation is materially required, such as a post-merge hotfix from `main`, a deploy blocker that must land independently, or unrelated in-flight changes on the current branch.
@@ -191,7 +193,7 @@ who can deploy is never a routine, self-mergeable change.
 7. Block branch deletion.
 8. Require at least 1 independent PR approval on `main`; CI status plus merge queue remain required merge gates.
 9. Use review bypass plus the dedicated `Allowed Maintainers to Approve` team for the sanctioned maintainer bypass cohort only; do not rely on overlapping push restrictions.
-10. Keep ordinary development off `main`; only promote from `integration/pr-train` except explicit emergency hotfixes.
+10. Keep ordinary development off `main`; only promote from `integration/pr-train` except explicit emergency hotfixes with a written operator decision and immediate back-sync.
 
 Current operating note:
 
@@ -207,7 +209,8 @@ Current operating note:
 - the sanctioned review-bypass cohort is intentional policy and should not be reported as governance drift when it matches `config/ci-governance.json`
 - if an admin needs to proceed on a green PR, verify whether the live ruleset allows queue entry; do not assume approval is implicitly satisfied
 - bypass actors may waive review through branch protection and bypass queue through the dedicated owner team path
-- direct pushes to `main` are not the default bypass model; the preferred path is a green `integration/pr-train` promotion PR plus bypass merge when justified
+- direct pushes to `main` are not the default bypass model; the preferred path is a green `integration/pr-train` promotion PR through merge queue, with bypass used only for the approval/queue mechanics when justified
+- do not create or reuse a standing `maintainer/*`, `release/*`, or community branch as an allowed `main` head; that widens release authority and can carry unrelated commits
 - CI should still gate the landing decision; bypass is for review policy, not for skipping validation
 
 ### Retired release branches

--- a/docs/reference/operations/ci.md
+++ b/docs/reference/operations/ci.md
@@ -7,11 +7,13 @@
 flowchart TB
   subgraph dev["Developer lanes"]
     feat["Feature / hotfix / developer branches"]
-    pr["Pull request to main"]
+    pr["Pull request to integration/pr-train"]
     prci["PR Validation<br/>medium-depth, path-filtered"]
   end
 
   subgraph integration["Integration lane"]
+    train["integration/pr-train"]
+    promote["promotion PR<br/>integration/pr-train -> main"]
     freshness["Main Freshness Gate"]
     status["CI Status Gate"]
     queueci["Queue Validation<br/>authoritative pre-merge"]
@@ -26,9 +28,9 @@ flowchart TB
     prod["Deploy to Production<br/>manual SHA dispatch"]
   end
 
-  feat --> pr --> prci
-  prci --> freshness
-  prci --> status
+  feat --> pr --> prci --> train --> promote
+  promote --> freshness
+  promote --> status
   freshness --> queue
   status --> queue
   queue --> queueci --> main --> smoke --> green
@@ -305,13 +307,14 @@ Practical maintainer rule:
 
 ## Branch Lanes
 
-1. `main` is the only integration branch for day-to-day development.
-2. A successful `Main Post-Merge Smoke` run produces the only deployable source of truth: the green `main` SHA.
-3. UAT deploys only by an explicit manual dispatch of that green `main` SHA through `.github/workflows/deploy-uat.yml`.
-4. Manual UAT dispatch is limited to `kushaltrivedi5`, `Akash-292`, `RGlodAkshat`, and `ankitkumarsingh1702`.
-5. Production deploys only through a manual SHA dispatch in `.github/workflows/deploy-production.yml`, and only `kushaltrivedi5` may trigger it.
-6. Manual UAT or production redeploys must use a SHA that is reachable from `origin/main` and already green in post-merge smoke.
-7. Feature or hotfix branches never deploy directly; they merge through `main`.
+1. `integration/pr-train` is the normal integration branch for day-to-day feature/fix/docs work.
+2. `main` receives normal changes only from a promotion PR whose head is `integration/pr-train`; standing maintainer, release, or community branches are not allowed as alternate `main` heads.
+3. A successful `Main Post-Merge Smoke` run produces the only deployable source of truth: the green `main` SHA.
+4. UAT deploys only by an explicit manual dispatch of that green `main` SHA through `.github/workflows/deploy-uat.yml`.
+5. Manual UAT dispatch is limited to the maintainer cohort configured in `config/ci-governance.json`.
+6. Production deploys only through a manual SHA dispatch in `.github/workflows/deploy-production.yml`, and only `kushaltrivedi5` may trigger it.
+7. Manual UAT or production redeploys must use a SHA that is reachable from `origin/main` and already green in post-merge smoke.
+8. Feature or hotfix branches never deploy directly; normal work merges through `integration/pr-train`, then the train promotes to `main`.
 
 Deploy to UAT is expected to behave as a closed-loop release lane:
 

--- a/scripts/ci/verify-pr-base-policy.py
+++ b/scripts/ci/verify-pr-base-policy.py
@@ -39,15 +39,21 @@ def evaluate(policy: dict[str, Any], *, base_ref: str, head_ref: str) -> tuple[b
     main_branch = str(branch_flow.get("promotion_branch") or "main")
     train_branch = str(branch_flow.get("train_branch") or "integration/pr-train")
     allowed_main_heads = set(branch_flow.get("main_allowed_head_branches") or [train_branch])
+    if allowed_main_heads != {train_branch}:
+        allowed = ", ".join(sorted(allowed_main_heads))
+        return (
+            False,
+            f"Branch policy misconfigured: only {train_branch} may open normal "
+            f"promotion PRs into {main_branch}; configured heads: {allowed}.",
+        )
 
     if not base_ref:
         return False, "PR base ref is missing; cannot enforce branch target policy."
     if base_ref == main_branch and head_ref not in allowed_main_heads:
-        allowed = ", ".join(sorted(allowed_main_heads))
         return (
             False,
-            f"Direct PRs into {main_branch} are blocked. Target {train_branch}, "
-            f"or promote {allowed} into {main_branch}.",
+            f"Direct PRs into {main_branch} are blocked. Target {train_branch}; "
+            f"only {train_branch} may promote into {main_branch}.",
         )
     return True, f"PR base policy passed for head={head_ref or '<unknown>'} base={base_ref}."
 


### PR DESCRIPTION
## Summary
- Remove the standing maintainer promotion branch from the `main` allowed-head policy.
- Make `verify-pr-base-policy.py` fail closed if any non-`integration/pr-train` branch is configured as a normal `main` promotion head.
- Align operations docs and repo-ops skill reference with the standard path: feature/fix/docs PR -> `integration/pr-train` -> train promotion PR -> `main` -> green SHA deploy.

## Verification
- `python3 scripts/ci/verify-pr-base-policy.py --self-test`
- `bash scripts/ci/verify-pr-train-governance.sh`
- `./bin/hushh docs verify`
- `python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py`
- `python3 -m py_compile scripts/ci/verify-pr-base-policy.py`

## Operator note
- Existing normal PRs that targeted `main` were retargeted to `integration/pr-train`; the only remaining open `main` PR is the intended `integration/pr-train -> main` promotion PR.
