### PR TITLE
[codex] fix agent voice and mobile UX

### DIFF
--- a/hushh-webapp/__tests__/components/agent-popover-provider.test.tsx
+++ b/hushh-webapp/__tests__/components/agent-popover-provider.test.tsx
@@ -1,10 +1,29 @@
 import { render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { AgentPopoverProvider } from "@/components/agent/agent-popover-provider";
+import {
+  AgentPopoverProvider,
+  useOptionalAgentPopover,
+} from "@/components/agent/agent-popover-provider";
 
 const navigationMock = vi.hoisted(() => ({
   pathname: "/profile",
+}));
+
+const authMock = vi.hoisted(() => ({
+  state: {
+    isAuthenticated: true,
+    loading: false,
+    user: { uid: "user-1" },
+  },
+}));
+
+const vaultMock = vi.hoisted(() => ({
+  state: {
+    isVaultUnlocked: true,
+    vaultOwnerToken: "vault-token",
+    tokenExpiresAt: Date.now() + 60_000,
+  },
 }));
 
 vi.mock("next/navigation", () => ({
@@ -12,9 +31,11 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("@/hooks/use-auth", () => ({
-  useAuth: () => ({
-    isAuthenticated: true,
-  }),
+  useAuth: () => authMock.state,
+}));
+
+vi.mock("@/lib/vault/vault-context", () => ({
+  useVault: () => vaultMock.state,
 }));
 
 vi.mock("@/components/agent/agent-chat-workspace", () => ({
@@ -24,6 +45,15 @@ vi.mock("@/components/agent/agent-chat-workspace", () => ({
 vi.mock("@/components/agent/agent-voice-floating-indicator", () => ({
   AgentVoiceFloatingIndicator: () => null,
 }));
+
+function AgentAvailabilityProbe() {
+  const agentPopover = useOptionalAgentPopover();
+  return (
+    <button type="button" onClick={() => agentPopover?.openAgent()}>
+      {agentPopover?.available ? "available" : "blocked"}
+    </button>
+  );
+}
 
 function makeRect(input: {
   left: number;
@@ -50,6 +80,16 @@ describe("AgentPopoverProvider floating trigger", () => {
 
   beforeEach(() => {
     navigationMock.pathname = "/login";
+    authMock.state = {
+      isAuthenticated: true,
+      loading: false,
+      user: { uid: "user-1" },
+    };
+    vaultMock.state = {
+      isVaultUnlocked: true,
+      vaultOwnerToken: "vault-token",
+      tokenExpiresAt: Date.now() + 60_000,
+    };
     window.localStorage.clear();
     Object.defineProperty(window, "innerWidth", {
       configurable: true,
@@ -137,5 +177,35 @@ describe("AgentPopoverProvider floating trigger", () => {
     );
 
     expect(screen.queryByRole("button", { name: "Open Agent" })).toBeNull();
+  });
+
+  it("blocks Agent entrypoints until the vault is unlocked", () => {
+    navigationMock.pathname = "/profile";
+    vaultMock.state = {
+      isVaultUnlocked: false,
+      vaultOwnerToken: null,
+      tokenExpiresAt: null,
+    };
+
+    render(
+      <AgentPopoverProvider>
+        <AgentAvailabilityProbe />
+      </AgentPopoverProvider>
+    );
+
+    expect(screen.getByRole("button", { name: "blocked" })).toBeTruthy();
+    expect(screen.queryByTestId("agent-chat-workspace")).toBeNull();
+  });
+
+  it("exposes Agent entrypoints once auth and vault readiness are complete", () => {
+    navigationMock.pathname = "/profile";
+
+    render(
+      <AgentPopoverProvider>
+        <AgentAvailabilityProbe />
+      </AgentPopoverProvider>
+    );
+
+    expect(screen.getByRole("button", { name: "available" })).toBeTruthy();
   });
 });

--- a/hushh-webapp/__tests__/components/agent-theme-contract.test.ts
+++ b/hushh-webapp/__tests__/components/agent-theme-contract.test.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const WEBAPP_ROOT = path.resolve(__dirname, "../..");
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(WEBAPP_ROOT, relativePath), "utf8");
+}
+
+describe("Agent theme contract", () => {
+  it("keeps text and voice agent surfaces on app theme tokens", () => {
+    const surfaces = [
+      "components/agent/agent-chat-workspace.tsx",
+      "components/agent/agent-history-sidebar.tsx",
+      "components/agent/agent-popover-provider.tsx",
+    ].map(read);
+    const source = surfaces.join("\n");
+    const globals = read("app/globals.css");
+
+    expect(source).toContain("bg-background");
+    expect(source).toContain("agent-themed-card-surface");
+    expect(source).toContain("agent-themed-popover-surface");
+    expect(source).toContain("text-foreground");
+    expect(globals).toContain(".agent-themed-card-surface");
+    expect(globals).toContain("background-color: var(--app-card-surface-default-solid)");
+    expect(globals).toContain(".agent-themed-popover-surface");
+    expect(globals).toContain("background-color: var(--popover)");
+
+    for (const pinnedColor of [
+      "bg-[#f5f5f7]",
+      "bg-white/92",
+      "bg-white/95",
+      "dark:bg-[#0f1116]",
+      "dark:bg-[#101216]",
+      "dark:bg-[#15171c]",
+      "dark:bg-[#1c1c1e]",
+      "bg-card",
+      "bg-popover",
+      "text-[#1d1d1f]",
+    ]) {
+      expect(source).not.toContain(pinnedColor);
+    }
+  });
+});

--- a/hushh-webapp/__tests__/components/kai-command-palette-contract.test.ts
+++ b/hushh-webapp/__tests__/components/kai-command-palette-contract.test.ts
@@ -1,0 +1,22 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const WEBAPP_ROOT = path.resolve(__dirname, "../..");
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(WEBAPP_ROOT, relativePath), "utf8");
+}
+
+describe("Kai command palette contract", () => {
+  it("keeps the search tab free of voice controls", () => {
+    const source = read("components/kai/kai-command-palette.tsx");
+
+    expect(source).not.toContain("Start Kai voice");
+    expect(source).not.toContain("End Kai voice");
+    expect(source).not.toContain("<Mic");
+    expect(source).toContain('aria-label="Close command search"');
+    expect(source).toContain('className="pr-14"');
+  });
+});

--- a/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
+++ b/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
@@ -1,0 +1,27 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const WEBAPP_ROOT = path.resolve(__dirname, "../..");
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(WEBAPP_ROOT, relativePath), "utf8");
+}
+
+describe("Navbar bottom chrome contract", () => {
+  it("keeps Agent owned by search chrome instead of duplicating it beside the nav", () => {
+    const navbar = read("components/navbar.tsx");
+    const commandBar = read("components/kai/kai-command-bar-global.tsx");
+    const searchBar = read("components/kai/kai-search-bar.tsx");
+
+    expect(navbar).toContain("useOptionalAgentPopover");
+    expect(navbar).not.toContain('data-testid="bottom-agent-trigger"');
+    expect(commandBar).toContain("showAgent={localVoiceReady}");
+    expect(searchBar).toContain("showAgent?: boolean");
+    expect(searchBar).toContain("showAgent ? (");
+    expect(searchBar).toContain("kai-bottom-agent-action");
+    expect(searchBar).toContain('aria-label="Open Agent"');
+    expect(searchBar).toContain("agentPopover.openAgent()");
+  });
+});

--- a/hushh-webapp/__tests__/lib/agent-voice-tts.test.ts
+++ b/hushh-webapp/__tests__/lib/agent-voice-tts.test.ts
@@ -124,7 +124,7 @@ describe("agent voice TTS", () => {
     await vi.waitFor(() => expect(queue.hasPendingSpeech).toBe(false));
   });
 
-  it("uses browser speech fallback when backend TTS does not return audio", async () => {
+  it("does not use browser speech fallback by default when backend TTS fails", async () => {
     const synthesize = vi.fn().mockResolvedValue(new Response("unavailable", { status: 503 }));
     const playAudio = vi.fn().mockResolvedValue(undefined);
     const fallbackSpeak = vi.fn().mockResolvedValue(undefined);
@@ -141,16 +141,18 @@ describe("agent voice TTS", () => {
 
     queue.speakNow("Fallback sentence.");
 
-    await vi.waitFor(() => expect(fallbackSpeak).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() =>
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stage: "synthesize",
+          status: 503,
+        })
+      )
+    );
+    await vi.waitFor(() => expect(queue.hasPendingSpeech).toBe(false));
 
     expect(playAudio).not.toHaveBeenCalled();
-    expect(fallbackSpeak).toHaveBeenCalledWith("Fallback sentence.", expect.any(AbortSignal));
-    expect(onError).toHaveBeenCalledWith(
-      expect.objectContaining({
-        stage: "synthesize",
-        status: 503,
-      })
-    );
+    expect(fallbackSpeak).not.toHaveBeenCalled();
   });
 
   it("times out browser speech fallback so voice capture can resume", async () => {
@@ -181,6 +183,7 @@ describe("agent voice TTS", () => {
       playAudio,
       onError,
       maxAttempts: 1,
+      allowBrowserFallback: true,
     });
 
     queue.speakNow("Fallback speech that never reaches onend.");

--- a/hushh-webapp/__tests__/voice/api-service-voice.test.ts
+++ b/hushh-webapp/__tests__/voice/api-service-voice.test.ts
@@ -1,12 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const capacitorMock = vi.hoisted(() => ({
+  isNativePlatform: vi.fn(() => false),
+  getPlatform: vi.fn(() => "web"),
+  request: vi.fn(),
+}));
+
 vi.mock("@capacitor/core", () => ({
   Capacitor: {
-    isNativePlatform: () => false,
-    getPlatform: () => "web",
+    isNativePlatform: capacitorMock.isNativePlatform,
+    getPlatform: capacitorMock.getPlatform,
   },
   CapacitorHttp: {
-    request: vi.fn(),
+    request: capacitorMock.request,
   },
 }));
 
@@ -51,6 +57,9 @@ describe("ApiService voice planning contract", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
+    capacitorMock.isNativePlatform.mockReturnValue(false);
+    capacitorMock.getPlatform.mockReturnValue("web");
+    capacitorMock.request.mockReset();
     delete process.env.BACKEND_URL;
     delete process.env.NEXT_PUBLIC_BACKEND_URL;
     delete process.env.NEXT_PUBLIC_VOICE_DIRECT_BACKEND;
@@ -225,6 +234,51 @@ describe("ApiService voice planning contract", () => {
       text: "Starting Nvidia analysis.",
       voice: "Kore",
     });
+  });
+
+  it("requests Agent voice TTS as binary audio on native", async () => {
+    capacitorMock.isNativePlatform.mockReturnValue(true);
+    capacitorMock.getPlatform.mockReturnValue("ios");
+    process.env.NEXT_PUBLIC_BACKEND_URL = "https://api.example.com";
+    const audioText = "RIFFfake-wav";
+    capacitorMock.request.mockResolvedValueOnce({
+      status: 200,
+      headers: {
+        "content-type": "audio/wav",
+        "x-agent-tts-voice": "Kore",
+      },
+      data: btoa(audioText),
+      url: "https://api.example.com/api/kai/agent/voice/tts",
+    });
+    const { ApiService } = await import("@/lib/services/api-service");
+
+    const response = await ApiService.synthesizeAgentVoice({
+      userId: "user_1",
+      vaultOwnerToken: "vault_token",
+      text: "Starting Nvidia analysis.",
+      voice: "Kore",
+    });
+
+    expect(capacitorMock.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://api.example.com/api/kai/agent/voice/tts",
+        method: "POST",
+        responseType: "arraybuffer",
+        headers: expect.objectContaining({
+          Authorization: "Bearer vault_token",
+          "Content-Type": "application/json",
+        }),
+        data: expect.objectContaining({
+          user_id: "user_1",
+          text: "Starting Nvidia analysis.",
+          voice: "Kore",
+        }),
+      })
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("audio/wav");
+    expect(response.headers.get("x-agent-tts-voice")).toBe("Kore");
+    expect(await response.text()).toBe(audioText);
   });
 
   it("calls voice capability route with auth and turn id", async () => {

--- a/hushh-webapp/__tests__/voice/kai-search-bar.test.ts
+++ b/hushh-webapp/__tests__/voice/kai-search-bar.test.ts
@@ -99,6 +99,7 @@ vi.mock("@/components/app-ui/shell-action-surface", () => ({
 
 vi.mock("@/components/agent/agent-popover-provider", () => ({
   useOptionalAgentPopover: () => ({
+    available: true,
     openAgent: mockOpenAgent,
   }),
 }));
@@ -432,6 +433,7 @@ describe("kai-search-bar helpers", () => {
         voiceAvailable: false,
         voiceVisibilityMode: "disabled",
         voiceUnavailableReason: "Unlock your vault to use voice",
+        showAgent: true,
       }),
     );
 
@@ -443,6 +445,25 @@ describe("kai-search-bar helpers", () => {
     );
     expect(screen.queryByRole("button", { name: "Open Agent" })).toBeNull();
     expect(mockOpenAgent).not.toHaveBeenCalled();
+  });
+
+  it("hides Agent action until the shell marks Agent ready", () => {
+    vi.useRealTimers();
+
+    render(
+      createElement(KaiSearchBar, {
+        onSelectAction: vi.fn(),
+        onVoiceResponse: vi.fn(),
+        surfaceVariant: "ria",
+        userId: "user_1",
+        vaultOwnerToken: "vault_token",
+        voiceAvailable: false,
+        voiceVisibilityMode: "disabled",
+        showAgent: false,
+      }),
+    );
+
+    expect(screen.queryByRole("button", { name: "Open Agent" })).toBeNull();
   });
 
   it("keeps Kai voice inside the compact search surface", () => {

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1697,6 +1697,24 @@ body:has([data-one-market-surface="true"]) .bar-glass-top {
   background: transparent;
 }
 
+.agent-themed-card-surface {
+  background-color: var(--app-card-surface-default-solid);
+  color: var(--foreground);
+  border-color: var(--border);
+}
+
+.agent-themed-popover-surface {
+  background-color: var(--popover);
+  color: var(--popover-foreground);
+  border-color: var(--border);
+}
+
+.agent-themed-app-surface {
+  background-color: var(--background);
+  color: var(--foreground);
+  border-color: var(--border);
+}
+
 /* Custom Scrollbar Styles */
 @layer utilities {
   .scrollbar-thin {

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -14,19 +14,20 @@ import {
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
   Bot,
+  ChevronDown,
   Check,
   Copy,
   KeyRound,
   LogIn,
   Menu,
   Mic,
-  Minus,
   RotateCcw,
   Send,
   Sparkles,
   ThumbsDown,
   ThumbsUp,
   UserRound,
+  X,
 } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -284,7 +285,7 @@ function AgentWelcomePanel({
   return (
     <section className="flex min-h-[clamp(18rem,45vh,32rem)] flex-col justify-center py-6 sm:py-10">
       <div className="mx-auto w-full max-w-2xl">
-        <div className="mb-7 inline-flex items-center gap-2 rounded-full border border-black/10 bg-black/[0.035] px-3 py-1.5 text-xs font-medium text-[rgba(0,0,0,0.56)] dark:border-white/10 dark:bg-white/[0.04] dark:text-zinc-400">
+        <div className="mb-7 inline-flex items-center gap-2 rounded-full border border-border bg-muted/50 px-3 py-1.5 text-xs font-medium text-muted-foreground">
           <Sparkles className="h-3.5 w-3.5 text-primary" />
           Kai workspace
         </div>
@@ -301,7 +302,7 @@ function AgentWelcomePanel({
               type="button"
               disabled={disabled}
               onClick={() => onPromptSelect(prompt)}
-              className="group min-h-24 rounded-xl border border-black/10 bg-white/80 p-4 text-left text-sm font-medium text-[#1d1d1f] shadow-sm shadow-black/[0.03] transition hover:border-primary/40 hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-50 dark:border-white/10 dark:bg-white/[0.035] dark:text-zinc-200 dark:hover:bg-white/[0.06]"
+              className="agent-themed-card-surface group min-h-24 rounded-xl border border-border/70 p-4 text-left text-sm font-medium shadow-sm transition hover:border-primary/40 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-50"
             >
               <span className="block leading-5">{prompt}</span>
               <span className="mt-4 block h-px w-10 bg-primary/50 transition group-hover:w-14" />
@@ -529,7 +530,7 @@ function AgentBubble({
       )}
     >
       {!isUser ? (
-        <div className="mt-1 hidden h-7 w-7 shrink-0 place-items-center rounded-md border border-black/10 bg-black/[0.035] text-[rgba(0,0,0,0.58)] sm:grid dark:border-white/10 dark:bg-white/[0.04] dark:text-zinc-300">
+        <div className="mt-1 hidden h-7 w-7 shrink-0 place-items-center rounded-md border border-border bg-muted/50 text-muted-foreground sm:grid">
           <Bot className="h-3.5 w-3.5" />
         </div>
       ) : null}
@@ -545,7 +546,7 @@ function AgentBubble({
             "text-sm leading-6",
             isUser
               ? "rounded-2xl bg-primary px-4 py-2.5 text-primary-foreground shadow-sm shadow-primary/10"
-              : "px-0 py-1 text-[#1d1d1f] dark:text-zinc-200",
+              : "px-0 py-1 text-foreground",
             isError &&
               "rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-2.5 text-destructive"
           )}
@@ -568,7 +569,7 @@ function AgentBubble({
         </div>
         <div
           className={cn(
-            "mt-1 flex items-center gap-2 text-[11px] text-[rgba(0,0,0,0.46)] dark:text-zinc-500",
+            "mt-1 flex items-center gap-2 text-[11px] text-muted-foreground",
             isUser && "justify-end text-right"
           )}
         >
@@ -578,7 +579,7 @@ function AgentBubble({
               <button
                 type="button"
                 onClick={handleCopy}
-                className="grid h-7 w-7 place-items-center rounded-md border border-transparent text-[rgba(0,0,0,0.46)] transition hover:border-black/10 hover:bg-black/[0.04] hover:text-[#1d1d1f] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 dark:text-zinc-500 dark:hover:border-white/10 dark:hover:bg-white/[0.06] dark:hover:text-zinc-200"
+                className="grid h-7 w-7 place-items-center rounded-md border border-transparent text-muted-foreground transition hover:border-border hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
                 aria-label={copied ? "Response copied" : "Copy response"}
                 title={copied ? "Copied" : "Copy response"}
               >
@@ -594,8 +595,8 @@ function AgentBubble({
                 className={cn(
                   "grid h-7 w-7 place-items-center rounded-md border transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60",
                   liked
-                    ? "border-black/10 bg-black/[0.06] text-[#1d1d1f] dark:border-white/15 dark:bg-zinc-800 dark:text-zinc-100"
-                    : "border-transparent text-[rgba(0,0,0,0.46)] hover:border-black/10 hover:bg-black/[0.04] hover:text-[#1d1d1f] dark:text-zinc-500 dark:hover:border-white/10 dark:hover:bg-white/[0.06] dark:hover:text-zinc-200"
+                    ? "border-border bg-muted text-foreground"
+                    : "border-transparent text-muted-foreground hover:border-border hover:bg-muted hover:text-foreground"
                 )}
                 aria-label="Like response"
                 aria-pressed={liked}
@@ -613,8 +614,8 @@ function AgentBubble({
                 className={cn(
                   "grid h-7 w-7 place-items-center rounded-md border transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60",
                   disliked
-                    ? "border-black/10 bg-black/[0.06] text-[#1d1d1f] dark:border-white/15 dark:bg-zinc-800 dark:text-zinc-100"
-                    : "border-transparent text-[rgba(0,0,0,0.46)] hover:border-black/10 hover:bg-black/[0.04] hover:text-[#1d1d1f] dark:text-zinc-500 dark:hover:border-white/10 dark:hover:bg-white/[0.06] dark:hover:text-zinc-200"
+                    ? "border-border bg-muted text-foreground"
+                    : "border-transparent text-muted-foreground hover:border-border hover:bg-muted hover:text-foreground"
                 )}
                 aria-label="Dislike response"
                 aria-pressed={disliked}
@@ -627,7 +628,7 @@ function AgentBubble({
                   type="button"
                   onClick={onRetry}
                   disabled={retryDisabled}
-                  className="ml-1 inline-flex h-7 items-center gap-1.5 rounded-md border border-transparent px-2 text-xs font-medium text-[rgba(0,0,0,0.46)] transition hover:border-black/10 hover:bg-black/[0.04] hover:text-[#1d1d1f] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-45 dark:text-zinc-500 dark:hover:border-white/10 dark:hover:bg-white/[0.06] dark:hover:text-zinc-200"
+                  className="ml-1 inline-flex h-7 items-center gap-1.5 rounded-md border border-transparent px-2 text-xs font-medium text-muted-foreground transition hover:border-border hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-45"
                   aria-label="Try again"
                   title="Try again"
                 >
@@ -640,7 +641,7 @@ function AgentBubble({
         </div>
       </div>
       {isUser ? (
-        <div className="mt-1 hidden h-7 w-7 shrink-0 place-items-center rounded-md border border-black/10 bg-black/[0.035] text-[rgba(0,0,0,0.56)] sm:grid dark:border-white/10 dark:bg-white/[0.04] dark:text-zinc-400">
+        <div className="mt-1 hidden h-7 w-7 shrink-0 place-items-center rounded-md border border-border bg-muted/50 text-muted-foreground sm:grid">
           <UserRound className="h-3.5 w-3.5" />
         </div>
       ) : null}
@@ -1486,7 +1487,7 @@ export function AgentChatWorkspace({
           }
           if (!voiceTtsFailureReported) {
             voiceTtsFailureReported = true;
-            toast.error("Agent voice audio failed. Falling back to browser speech.");
+            toast.error("Agent voice audio failed. The text response is still available.");
           }
         },
       });
@@ -2687,7 +2688,7 @@ export function AgentChatWorkspace({
         </div>
         <div
           className={cn(
-            "fixed inset-0 z-[520] bg-black/35 backdrop-blur-sm transition-opacity duration-200 dark:bg-black/55 lg:hidden",
+            "fixed inset-0 z-[520] bg-foreground/25 backdrop-blur-sm transition-opacity duration-200 lg:hidden",
             isHistoryDrawerOpen ? "opacity-100" : "pointer-events-none opacity-0"
           )}
           aria-hidden="true"
@@ -2706,7 +2707,7 @@ export function AgentChatWorkspace({
           inert={!isHistoryDrawerOpen}
           onKeyDown={handleHistoryDrawerKeyDown}
         >
-          {renderHistorySidebar("h-full w-full shadow-2xl shadow-black/40", () =>
+          {renderHistorySidebar("h-full w-full shadow-2xl shadow-foreground/20", () =>
             setIsHistoryDrawerOpen(false)
           )}
         </div>
@@ -2714,13 +2715,13 @@ export function AgentChatWorkspace({
         <section
           className={cn(
             "relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background",
-            isPopover && "rounded-lg border border-black/10 shadow-sm dark:border-white/10"
+            isPopover && "rounded-lg border border-border shadow-sm"
           )}
           inert={isHistoryDrawerOpen}
         >
           <div
             className={cn(
-              "flex shrink-0 touch-pan-y items-center justify-between gap-3 border-b border-border/70 bg-background/92 px-3 pt-[var(--app-safe-area-top-effective,0px)] backdrop-blur sm:px-5",
+              "relative flex shrink-0 touch-pan-y items-center justify-between gap-3 bg-background/92 px-3 pt-[var(--app-safe-area-top-effective,0px)] backdrop-blur sm:px-5",
               isPopover
                 ? "h-14 sm:h-16"
                 : "h-[calc(3.5rem+var(--app-safe-area-top-effective,0px))] sm:h-[calc(4rem+var(--app-safe-area-top-effective,0px))]",
@@ -2732,13 +2733,14 @@ export function AgentChatWorkspace({
               swipeStartYRef.current = null;
             }}
           >
-            <div className="flex min-w-0 items-center gap-3">
+            <div className="pointer-events-none absolute inset-x-0 bottom-0 z-0 border-b border-border/70" />
+            <div className="relative z-10 flex min-w-0 items-center gap-3">
               {!isPopover ? (
                 <Button
                   type="button"
                   variant="ghost"
                   size="icon"
-                  className="h-9 w-9 rounded-lg text-[rgba(0,0,0,0.56)] hover:bg-black/[0.04] hover:text-[#1d1d1f] focus-visible:ring-2 focus-visible:ring-primary/60 dark:text-zinc-300 dark:hover:bg-white/[0.07] dark:hover:text-zinc-50 lg:hidden"
+                  className="h-9 w-9 rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary/60 lg:hidden"
                   onClick={openHistoryDrawer}
                   aria-label="Open chat history"
                   title="Open chat history"
@@ -2746,10 +2748,10 @@ export function AgentChatWorkspace({
                   <Menu className="h-4 w-4" />
                 </Button>
               ) : null}
-              <div className="grid h-8 w-8 shrink-0 place-items-center rounded-md border border-black/10 bg-black/[0.035] text-primary dark:border-white/10 dark:bg-white/[0.04]">
+              <div className="grid h-8 w-8 shrink-0 place-items-center rounded-md border border-border bg-background text-primary shadow-sm">
                 <Bot className="h-4 w-4" />
               </div>
-              <div className="min-w-0">
+              <div className="min-w-0 bg-background/95 pr-1">
                 <div className="truncate text-sm font-medium leading-5 text-foreground sm:text-base">
                   Agent
                 </div>
@@ -2759,8 +2761,8 @@ export function AgentChatWorkspace({
               </div>
             </div>
 
-            <div className="flex shrink-0 items-center gap-2">
-              <span className="hidden rounded-md border border-black/10 bg-black/[0.035] px-2.5 py-1 text-xs font-medium text-[rgba(0,0,0,0.56)] dark:border-white/10 dark:bg-white/[0.03] dark:text-zinc-400 sm:inline-flex">
+            <div className="relative z-10 flex shrink-0 items-center gap-2">
+              <span className="hidden rounded-md border border-border bg-muted/50 px-2.5 py-1 text-xs font-medium text-muted-foreground sm:inline-flex">
                 {statusText}
               </span>
               {!isPopover ? (
@@ -2768,12 +2770,25 @@ export function AgentChatWorkspace({
                   type="button"
                   variant="ghost"
                   size="icon"
-                  className="h-9 w-9 rounded-lg text-[rgba(0,0,0,0.56)] hover:bg-black/[0.04] hover:text-[#1d1d1f] focus-visible:ring-2 focus-visible:ring-primary/60 dark:text-zinc-300 dark:hover:bg-white/[0.07] dark:hover:text-zinc-50 lg:hidden"
+                  className="h-9 w-9 rounded-full border border-border bg-background text-muted-foreground shadow-sm hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary/60 lg:hidden"
                   onClick={handlePageMinimize}
-                  aria-label="Minimize Agent"
-                  title="Minimize Agent"
+                  aria-label="Close Agent"
+                  title="Close Agent"
                 >
-                  <Minus className="h-4 w-4" />
+                  <ChevronDown className="h-4 w-4" />
+                </Button>
+              ) : null}
+              {isPopover && onMinimize ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-9 w-9 rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary/60 sm:hidden"
+                  onClick={onMinimize}
+                  aria-label="Close Agent"
+                  title="Close Agent"
+                >
+                  <X className="h-4 w-4" />
                 </Button>
               ) : null}
               {windowControls ? <div className="ml-1">{windowControls}</div> : null}
@@ -2782,8 +2797,8 @@ export function AgentChatWorkspace({
 
           <div
             className={cn(
-              "min-h-0 flex-1 overflow-y-auto scroll-smooth px-4 pt-5 scrollbar-thin scrollbar-thumb-muted scrollbar-track-transparent sm:px-6",
-              isPopover ? "pb-4" : "pb-6 lg:px-8"
+              "min-h-0 flex-1 overflow-y-auto scroll-smooth px-4 scrollbar-thin scrollbar-thumb-muted scrollbar-track-transparent sm:px-6",
+              isPopover ? "pb-4 pt-5" : "pb-6 pt-8 sm:pt-10 lg:px-8 lg:pt-6"
             )}
           >
             <div className="mx-auto flex min-h-full w-full max-w-3xl flex-col gap-6">
@@ -2843,10 +2858,10 @@ export function AgentChatWorkspace({
           </div>
 
           {voiceTranscriptReview ? (
-            <div className="absolute inset-0 z-20 grid place-items-end bg-black/25 p-4 backdrop-blur-[2px] dark:bg-black/40 sm:place-items-center">
+            <div className="absolute inset-0 z-20 grid place-items-end bg-foreground/20 p-4 backdrop-blur-[2px] sm:place-items-center">
               <div
                 ref={voiceTranscriptDialogRef}
-                className="w-full max-w-sm rounded-xl border border-black/10 bg-white p-4 shadow-xl dark:border-white/10 dark:bg-[#15171c]"
+                className="agent-themed-popover-surface w-full max-w-sm rounded-xl border border-border p-4 shadow-xl"
                 role="dialog"
                 aria-modal="true"
                 aria-label="Confirm voice transcript"
@@ -2896,7 +2911,7 @@ export function AgentChatWorkspace({
           >
             <div className="mx-auto w-full max-w-3xl">
               {voiceActive ? (
-                <div className="rounded-2xl border border-black/10 bg-[#f5f5f7] p-2 shadow-lg shadow-black/[0.06] dark:border-white/10 dark:bg-[#0f1116] dark:shadow-black/15">
+                <div className="agent-themed-card-surface rounded-2xl border border-border p-2 shadow-[var(--app-card-shadow-standard)]">
                   <AgentVoiceWaveInput
                     status={voiceState}
                     level={voiceLevel}
@@ -2909,7 +2924,7 @@ export function AgentChatWorkspace({
                   />
                 </div>
               ) : (
-                <div className="flex min-h-14 items-end gap-2 rounded-[1.5rem] border border-black/10 bg-[#f5f5f7] px-3 py-2 shadow-lg shadow-black/[0.06] transition-colors focus-within:border-primary/55 focus-within:ring-2 focus-within:ring-primary/20 dark:border-white/12 dark:bg-[#0f1116] dark:shadow-black/15">
+                <div className="agent-themed-card-surface flex min-h-14 items-end gap-2 rounded-[1.5rem] border border-border px-3 py-2 shadow-[var(--app-card-shadow-standard)] transition-colors focus-within:border-primary/55 focus-within:ring-2 focus-within:ring-primary/20">
                   <textarea
                     ref={composerTextareaRef}
                     aria-label="Message Agent"
@@ -2927,14 +2942,14 @@ export function AgentChatWorkspace({
                     disabled={!hasChatAccess || isLoadingHistory || isVoiceConnecting}
                     placeholder="Message Agent..."
                     rows={1}
-                    className="max-h-40 min-h-8 min-w-0 flex-1 resize-none bg-transparent px-1 py-2 text-sm leading-6 text-[#1d1d1f] outline-none placeholder:text-[rgba(0,0,0,0.42)] disabled:cursor-not-allowed disabled:opacity-60 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+                    className="max-h-40 min-h-8 min-w-0 flex-1 resize-none bg-transparent px-1 py-2 text-sm leading-6 text-foreground outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-60"
                   />
                   {agentVoiceEnabled ? (
                     <Button
                       type="button"
                       variant="ghost"
                       size="icon"
-                      className="h-9 w-9 shrink-0 rounded-xl text-[rgba(0,0,0,0.50)] hover:bg-black/[0.04] hover:text-[#1d1d1f] focus-visible:ring-2 focus-visible:ring-primary/60 dark:text-zinc-400 dark:hover:bg-white/[0.07] dark:hover:text-zinc-100"
+                      className="h-9 w-9 shrink-0 rounded-xl text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary/60"
                       disabled={!canToggleVoice}
                       onClick={handleToggleVoice}
                       aria-label="Start voice mode"
@@ -2946,7 +2961,7 @@ export function AgentChatWorkspace({
                   <Button
                     type="submit"
                     size="icon"
-                    className="h-9 w-9 shrink-0 rounded-xl bg-primary text-primary-foreground shadow-sm shadow-primary/20 hover:bg-primary/90 focus-visible:ring-2 focus-visible:ring-primary/60 disabled:bg-black/[0.06] disabled:text-[rgba(0,0,0,0.36)] disabled:shadow-none dark:disabled:bg-white/[0.08] dark:disabled:text-zinc-500"
+                    className="h-9 w-9 shrink-0 rounded-xl bg-primary text-primary-foreground shadow-sm shadow-primary/20 hover:bg-primary/90 focus-visible:ring-2 focus-visible:ring-primary/60 disabled:bg-muted disabled:text-muted-foreground disabled:shadow-none"
                     disabled={!canSend}
                     aria-label="Send message"
                   >

--- a/hushh-webapp/components/agent/agent-history-sidebar.tsx
+++ b/hushh-webapp/components/agent/agent-history-sidebar.tsx
@@ -117,21 +117,21 @@ export function AgentHistorySidebar({
     <>
       <aside
         className={cn(
-          "flex min-h-0 shrink-0 flex-col overflow-hidden border-r border-black/10 bg-white/92 text-[#1d1d1f] shadow-[inset_-1px_0_0_rgba(255,255,255,0.55)] backdrop-blur-xl transition-[width] duration-200 ease-out dark:border-white/10 dark:bg-[#101216] dark:text-zinc-200 dark:shadow-none",
+          "agent-themed-card-surface flex min-h-0 shrink-0 flex-col overflow-hidden border-r border-border/70 shadow-[inset_-1px_0_0_var(--app-card-border-standard)] backdrop-blur-xl transition-[width] duration-200 ease-out",
           collapsed ? "w-16" : "w-72",
           className
         )}
         aria-label="Agent chat history"
         data-collapsed={collapsed ? "true" : "false"}
       >
-        <div className="flex items-center gap-2 border-b border-black/10 p-3 dark:border-white/10">
+        <div className="flex items-center gap-2 border-b border-border/70 p-3">
           {collapsed ? (
             <div className="flex w-full flex-col items-center gap-2">
               <Button
                 type="button"
                 variant="ghost"
                 size="icon"
-                className="h-10 w-10 rounded-lg border border-black/10 bg-black/[0.035] text-[rgba(0,0,0,0.62)] hover:bg-black/[0.06] hover:text-[#1d1d1f] focus-visible:ring-2 focus-visible:ring-primary/60 dark:border-white/10 dark:bg-white/[0.04] dark:text-zinc-100 dark:hover:bg-white/[0.08]"
+                className="h-10 w-10 rounded-lg border border-border bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary/60"
                 onClick={onToggleCollapsed}
                 aria-label="Expand chat history"
                 title="Expand chat history"
@@ -142,7 +142,7 @@ export function AgentHistorySidebar({
                 type="button"
                 variant="ghost"
                 size="icon"
-                className="h-10 w-10 rounded-lg text-[rgba(0,0,0,0.54)] hover:bg-black/[0.05] hover:text-[#1d1d1f] focus-visible:ring-2 focus-visible:ring-primary/60 dark:text-zinc-300 dark:hover:bg-white/[0.07] dark:hover:text-zinc-100"
+                className="h-10 w-10 rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary/60"
                 onClick={onCreateNew}
                 disabled={disabled}
                 aria-label="Create new Agent chat"
@@ -156,7 +156,7 @@ export function AgentHistorySidebar({
               <Button
                 type="button"
                 variant="ghost"
-                className="h-11 min-w-0 flex-1 justify-start gap-2 rounded-lg border border-black/10 bg-black/[0.035] px-3 text-sm font-medium text-[#1d1d1f] shadow-sm shadow-black/[0.03] transition-colors hover:bg-black/[0.06] focus-visible:ring-2 focus-visible:ring-primary/60 dark:border-white/10 dark:bg-white/[0.04] dark:text-zinc-100 dark:shadow-none dark:hover:bg-white/[0.08]"
+                className="h-11 min-w-0 flex-1 justify-start gap-2 rounded-lg border border-border bg-muted/50 px-3 text-sm font-medium text-foreground shadow-sm transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-primary/60"
                 onClick={onCreateNew}
                 disabled={disabled}
                 aria-label="Create new Agent chat"
@@ -170,7 +170,7 @@ export function AgentHistorySidebar({
                   type="button"
                   variant="ghost"
                   size="icon"
-                  className="hidden h-10 w-10 rounded-lg text-[rgba(0,0,0,0.46)] hover:bg-black/[0.05] hover:text-[#1d1d1f] focus-visible:ring-2 focus-visible:ring-primary/60 dark:text-zinc-400 dark:hover:bg-white/[0.07] dark:hover:text-zinc-100 lg:inline-flex"
+                  className="hidden h-10 w-10 rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary/60 lg:inline-flex"
                   onClick={onToggleCollapsed}
                   aria-label="Collapse chat history"
                   title="Collapse chat history"
@@ -185,7 +185,7 @@ export function AgentHistorySidebar({
               type="button"
               variant="ghost"
               size="icon"
-              className="h-10 w-10 rounded-lg text-[rgba(0,0,0,0.46)] hover:bg-black/[0.05] hover:text-[#1d1d1f] dark:text-zinc-400 dark:hover:bg-white/[0.07] dark:hover:text-zinc-100 lg:hidden"
+              className="h-10 w-10 rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground lg:hidden"
               onClick={onClose}
               aria-label="Close chat history"
               title="Close chat history"
@@ -199,16 +199,16 @@ export function AgentHistorySidebar({
           {collapsed ? (
             <div className="h-4" aria-hidden="true" />
           ) : (
-            <div className="px-2 pb-2 pt-1 text-[11px] font-medium uppercase tracking-[0.16em] text-[rgba(0,0,0,0.42)] dark:text-zinc-500">
+            <div className="px-2 pb-2 pt-1 text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
               Chats
             </div>
           )}
           {loading ? (
-            <div className="h-10 w-full rounded-lg bg-black/[0.04] dark:bg-white/[0.05]" />
+            <div className="h-10 w-full rounded-lg bg-muted" />
           ) : null}
 
           {!collapsed && !loading && conversations.length === 0 ? (
-            <div className="grid min-h-24 place-items-center rounded-lg border border-dashed border-black/10 px-3 text-center text-xs text-[rgba(0,0,0,0.46)] dark:border-white/10 dark:text-zinc-500">
+            <div className="grid min-h-24 place-items-center rounded-lg border border-dashed border-border px-3 text-center text-xs text-muted-foreground">
               No chats yet
             </div>
           ) : null}
@@ -230,19 +230,19 @@ export function AgentHistorySidebar({
                   role="listitem"
                   className={cn(
                     "group rounded-lg transition-colors",
-                    active && "bg-primary/10 text-[#1d1d1f] ring-1 ring-primary/20 dark:bg-primary/15 dark:text-zinc-50",
-                    !active && "text-[rgba(0,0,0,0.54)] hover:bg-black/[0.045] hover:text-[#1d1d1f] dark:text-zinc-400 dark:hover:bg-white/[0.06] dark:hover:text-zinc-100"
+                    active && "bg-primary/10 text-foreground ring-1 ring-primary/20",
+                    !active && "text-muted-foreground hover:bg-muted/70 hover:text-foreground"
                   )}
                 >
                   {isRenaming ? (
                     <form
                       onSubmit={submitRename}
-                      className="flex items-center gap-1 rounded-lg bg-black/[0.04] p-1 dark:bg-[#151820]"
+                      className="flex items-center gap-1 rounded-lg bg-muted/70 p-1"
                     >
                       <Input
                         value={renameValue}
                         onChange={(event) => setRenameValue(event.target.value)}
-                        className="h-8 min-w-0 flex-1 border-black/10 bg-white/90 text-sm text-[#1d1d1f] dark:border-white/10 dark:bg-black/20 dark:text-zinc-100"
+                        className="h-8 min-w-0 flex-1 border-border bg-background text-sm text-foreground"
                         maxLength={160}
                         autoFocus
                         disabled={pending}
@@ -294,7 +294,7 @@ export function AgentHistorySidebar({
                               type="button"
                               variant="ghost"
                               size="icon-xs"
-                              className="mr-1 text-[rgba(0,0,0,0.42)] opacity-0 transition-opacity hover:bg-black/[0.05] hover:text-[#1d1d1f] group-hover:opacity-100 focus-visible:opacity-100 dark:text-zinc-500 dark:hover:bg-white/[0.07] dark:hover:text-zinc-100"
+                              className="mr-1 text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100"
                               disabled={disabled || pending}
                               onPointerDown={(event) => event.stopPropagation()}
                               onClick={(event) => event.stopPropagation()}

--- a/hushh-webapp/components/agent/agent-popover-provider.tsx
+++ b/hushh-webapp/components/agent/agent-popover-provider.tsx
@@ -16,12 +16,20 @@ import {
   type SetStateAction,
 } from "react";
 import { usePathname } from "next/navigation";
-import { Bot, Grip, Maximize2, Minimize2, Minus, X } from "lucide-react";
+import {
+  Grip,
+  Maximize2,
+  MessageCircleMore,
+  Minimize2,
+  Minus,
+  X,
+} from "lucide-react";
 
 import { AgentChatWorkspace } from "@/components/agent/agent-chat-workspace";
 import { AgentVoiceFloatingIndicator } from "@/components/agent/agent-voice-floating-indicator";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/use-auth";
+import { useVault } from "@/lib/vault/vault-context";
 import {
   AGENT_POPOVER_DEFAULT_SIZE_MODE,
   AGENT_POPOVER_PRESET_SIZES,
@@ -41,6 +49,7 @@ import { ROUTES, isRiaActionBarRoute } from "@/lib/navigation/routes";
 import { cn } from "@/lib/utils";
 
 type AgentPopoverContextValue = {
+  available: boolean;
   expanded: boolean;
   hasOpened: boolean;
   motionState: AgentPopoverMotionState;
@@ -58,7 +67,9 @@ const AGENT_TRIGGER_FALLBACK_SIZE = 44;
 const AGENT_TRIGGER_DRAG_THRESHOLD_PX = 5;
 const AGENT_TRIGGER_TOP_GUARD_PX = 88;
 
-const AgentPopoverContext = createContext<AgentPopoverContextValue | null>(null);
+const AgentPopoverContext = createContext<AgentPopoverContextValue | null>(
+  null,
+);
 
 function getViewportSize() {
   if (typeof window === "undefined") {
@@ -73,12 +84,16 @@ function getViewportSize() {
 function readStoredSizeMode(): AgentPopoverSizeMode {
   if (typeof window === "undefined") return AGENT_POPOVER_DEFAULT_SIZE_MODE;
   const stored = window.localStorage.getItem(AGENT_POPOVER_STORAGE_KEYS.mode);
-  return isAgentPopoverSizeMode(stored) ? stored : AGENT_POPOVER_DEFAULT_SIZE_MODE;
+  return isAgentPopoverSizeMode(stored)
+    ? stored
+    : AGENT_POPOVER_DEFAULT_SIZE_MODE;
 }
 
 function readStoredCustomSize(): AgentPopoverSize {
   if (typeof window === "undefined") return DEFAULT_CUSTOM_SIZE;
-  const stored = window.localStorage.getItem(AGENT_POPOVER_STORAGE_KEYS.customSize);
+  const stored = window.localStorage.getItem(
+    AGENT_POPOVER_STORAGE_KEYS.customSize,
+  );
   if (!stored) return DEFAULT_CUSTOM_SIZE;
   try {
     const parsed = JSON.parse(stored) as Partial<AgentPopoverSize>;
@@ -86,7 +101,11 @@ function readStoredCustomSize(): AgentPopoverSize {
       return DEFAULT_CUSTOM_SIZE;
     }
     const viewport = getViewportSize();
-    return clampAgentPopoverSize(parsed as AgentPopoverSize, viewport.width, viewport.height);
+    return clampAgentPopoverSize(
+      parsed as AgentPopoverSize,
+      viewport.width,
+      viewport.height,
+    );
   } catch {
     return DEFAULT_CUSTOM_SIZE;
   }
@@ -94,7 +113,9 @@ function readStoredCustomSize(): AgentPopoverSize {
 
 function readStoredTriggerPosition(): AgentTriggerPosition | null {
   if (typeof window === "undefined") return null;
-  const stored = window.localStorage.getItem(AGENT_POPOVER_STORAGE_KEYS.triggerPosition);
+  const stored = window.localStorage.getItem(
+    AGENT_POPOVER_STORAGE_KEYS.triggerPosition,
+  );
   if (!stored) return null;
   try {
     const parsed = JSON.parse(stored) as Partial<AgentTriggerPosition>;
@@ -135,7 +156,8 @@ function resolveCssLength(anchor: HTMLElement | null, value: string): number {
 }
 
 function measureVisibleReservedBottom(selector: string): number {
-  if (typeof window === "undefined" || typeof document === "undefined") return 0;
+  if (typeof window === "undefined" || typeof document === "undefined")
+    return 0;
   const viewportHeight = window.innerHeight;
   let reservedBottom = 0;
 
@@ -149,20 +171,22 @@ function measureVisibleReservedBottom(selector: string): number {
   return reservedBottom;
 }
 
-function getAgentTriggerBounds(trigger: HTMLElement | null): AgentTriggerBounds {
+function getAgentTriggerBounds(
+  trigger: HTMLElement | null,
+): AgentTriggerBounds {
   const rect = trigger?.getBoundingClientRect();
   const reservedBottomFromChrome = Math.max(
     measureVisibleReservedBottom('[data-tour-id="kai-command-bar"]'),
     measureVisibleReservedBottom('[data-testid="ria-action-bar"]'),
-    measureVisibleReservedBottom('[aria-label="Main navigation"]')
+    measureVisibleReservedBottom('[aria-label="Main navigation"]'),
   );
   const reservedBottomFromCss = Math.max(
     resolveCssLength(trigger, "var(--bottom-chrome-full-height, 0px)"),
     resolveCssLength(trigger, "var(--bottom-chrome-stack-height, 0px)"),
     resolveCssLength(
       trigger,
-      "calc(var(--app-bottom-fixed-ui, 76px) + var(--kai-command-fixed-ui, 82px) + var(--bottom-chrome-fade-overscan, 18px))"
-    )
+      "calc(var(--app-bottom-fixed-ui, 76px) + var(--kai-command-fixed-ui, 82px) + var(--bottom-chrome-fade-overscan, 18px))",
+    ),
   );
 
   return {
@@ -172,7 +196,10 @@ function getAgentTriggerBounds(trigger: HTMLElement | null): AgentTriggerBounds 
     triggerHeight: Math.max(AGENT_TRIGGER_FALLBACK_SIZE, rect?.height ?? 0),
     reservedBottom: Math.max(reservedBottomFromChrome, reservedBottomFromCss),
     reservedTop: AGENT_TRIGGER_TOP_GUARD_PX,
-    safeTop: resolveCssLength(trigger, "var(--app-safe-area-top-effective, 0px)"),
+    safeTop: resolveCssLength(
+      trigger,
+      "var(--app-safe-area-top-effective, 0px)",
+    ),
     margin: 16,
   };
 }
@@ -194,8 +221,24 @@ export function AgentPopoverProvider({ children }: { children: ReactNode }) {
   const [hasOpened, setHasOpened] = useState(false);
   const [motionState, setMotionState] =
     useState<AgentPopoverMotionState>("idle");
-  const [sizeMode, setSizeModeState] = useState<AgentPopoverSizeMode>(AGENT_POPOVER_DEFAULT_SIZE_MODE);
-  const [customSize, setCustomSize] = useState<AgentPopoverSize>(DEFAULT_CUSTOM_SIZE);
+  const [sizeMode, setSizeModeState] = useState<AgentPopoverSizeMode>(
+    AGENT_POPOVER_DEFAULT_SIZE_MODE,
+  );
+  const [customSize, setCustomSize] =
+    useState<AgentPopoverSize>(DEFAULT_CUSTOM_SIZE);
+  const { user, loading: authLoading } = useAuth();
+  const { isVaultUnlocked, vaultOwnerToken, tokenExpiresAt } = useVault();
+  const pathname = usePathname();
+  const chromeState = getKaiChromeState(pathname);
+  const tokenIsFresh = !tokenExpiresAt || Date.now() < tokenExpiresAt;
+  const available = Boolean(
+    !authLoading &&
+      user?.uid &&
+      isVaultUnlocked &&
+      vaultOwnerToken &&
+      tokenIsFresh &&
+      !chromeState.hideCommandBar,
+  );
 
   useEffect(() => {
     setSizeModeState(readStoredSizeMode());
@@ -223,6 +266,7 @@ export function AgentPopoverProvider({ children }: { children: ReactNode }) {
   useEffect(() => clearMotionHandles, [clearMotionHandles]);
 
   const openAgent = useCallback(() => {
+    if (!available) return;
     if (expanded && motionState !== "closing") return;
 
     clearMotionHandles();
@@ -237,7 +281,7 @@ export function AgentPopoverProvider({ children }: { children: ReactNode }) {
         setMotionState("idle");
       }, AGENT_POPOVER_TRANSITION_MS);
     });
-  }, [clearMotionHandles, expanded, motionState]);
+  }, [available, clearMotionHandles, expanded, motionState]);
 
   const minimizeAgent = useCallback(() => {
     if (!expanded && motionState !== "opening") return;
@@ -253,6 +297,7 @@ export function AgentPopoverProvider({ children }: { children: ReactNode }) {
 
   const value = useMemo<AgentPopoverContextValue>(
     () => ({
+      available,
       expanded,
       hasOpened,
       motionState,
@@ -261,8 +306,24 @@ export function AgentPopoverProvider({ children }: { children: ReactNode }) {
       minimizeAgent,
       setSizeMode,
     }),
-    [expanded, hasOpened, minimizeAgent, motionState, openAgent, setSizeMode, sizeMode]
+    [
+      available,
+      expanded,
+      hasOpened,
+      minimizeAgent,
+      motionState,
+      openAgent,
+      setSizeMode,
+      sizeMode,
+    ],
   );
+
+  useEffect(() => {
+    if (available) return;
+    clearMotionHandles();
+    setExpanded(false);
+    setMotionState("idle");
+  }, [available, clearMotionHandles]);
 
   useEffect(() => {
     window.localStorage.setItem(AGENT_POPOVER_STORAGE_KEYS.mode, sizeMode);
@@ -271,7 +332,7 @@ export function AgentPopoverProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     window.localStorage.setItem(
       AGENT_POPOVER_STORAGE_KEYS.customSize,
-      JSON.stringify(customSize)
+      JSON.stringify(customSize),
     );
   }, [customSize]);
 
@@ -279,7 +340,7 @@ export function AgentPopoverProvider({ children }: { children: ReactNode }) {
     const handleResize = () => {
       const viewport = getViewportSize();
       setCustomSize((current) =>
-        clampAgentPopoverSize(current, viewport.width, viewport.height)
+        clampAgentPopoverSize(current, viewport.width, viewport.height),
       );
     };
     window.addEventListener("resize", handleResize);
@@ -289,7 +350,10 @@ export function AgentPopoverProvider({ children }: { children: ReactNode }) {
   return (
     <AgentPopoverContext.Provider value={value}>
       {children}
-      <AgentPopoverSurface customSize={customSize} setCustomSize={setCustomSize} />
+      <AgentPopoverSurface
+        customSize={customSize}
+        setCustomSize={setCustomSize}
+      />
     </AgentPopoverContext.Provider>
   );
 }
@@ -299,22 +363,33 @@ type AgentPopoverSurfaceProps = {
   setCustomSize: Dispatch<SetStateAction<AgentPopoverSize>>;
 };
 
-function AgentPopoverSurface({ customSize, setCustomSize }: AgentPopoverSurfaceProps) {
-  const { isAuthenticated } = useAuth();
+function AgentPopoverSurface({
+  customSize,
+  setCustomSize,
+}: AgentPopoverSurfaceProps) {
   const pathname = usePathname();
-  const { expanded, hasOpened, motionState, sizeMode, setSizeMode, openAgent, minimizeAgent } =
-    useAgentPopover();
+  const {
+    available,
+    expanded,
+    hasOpened,
+    motionState,
+    sizeMode,
+    setSizeMode,
+    openAgent,
+    minimizeAgent,
+  } = useAgentPopover();
   const chromeState = getKaiChromeState(pathname);
   const isLegacyAgentRoute = pathname === ROUTES.AGENT;
   const isPhoneMandateRoute = pathname?.startsWith(ROUTES.PHONE_MANDATE);
   const canShowAgent =
-    isAuthenticated &&
-    !isLegacyAgentRoute &&
-    !isPhoneMandateRoute &&
-    !chromeState.hideCommandBar;
-  const isKaiSurfaceRoute = Boolean(pathname?.startsWith("/kai"));
+    available && !isLegacyAgentRoute && !isPhoneMandateRoute;
+  const isKaiSurfaceRoute = Boolean(
+    pathname?.startsWith(ROUTES.KAI_HOME),
+  );
   const useEmbeddedAgentTrigger =
-    isKaiSurfaceRoute || isRiaActionBarRoute(pathname) || !chromeState.hideCommandBar;
+    isKaiSurfaceRoute ||
+    isRiaActionBarRoute(pathname) ||
+    !chromeState.hideCommandBar;
   const isCollapsing = motionState === "closing";
   const surfaceVisible = expanded || motionState !== "idle";
   const isFullscreen = sizeMode === "fullscreen";
@@ -342,7 +417,7 @@ function AgentPopoverSurface({ customSize, setCustomSize }: AgentPopoverSurfaceP
     return clampAgentPopoverSize(
       resolveAgentPopoverSize(sizeMode, customSize),
       viewport.width,
-      viewport.height
+      viewport.height,
     );
   }, [customSize, sizeMode]);
 
@@ -352,7 +427,7 @@ function AgentPopoverSurface({ customSize, setCustomSize }: AgentPopoverSurfaceP
         "--agent-popover-width": `${resolvedPanelSize.width}px`,
         "--agent-popover-height": `${resolvedPanelSize.height}px`,
       }) as CSSProperties,
-    [resolvedPanelSize.height, resolvedPanelSize.width]
+    [resolvedPanelSize.height, resolvedPanelSize.width],
   );
 
   const handleNavigationActionComplete = useCallback(() => {
@@ -376,7 +451,12 @@ function AgentPopoverSurface({ customSize, setCustomSize }: AgentPopoverSurfaceP
       };
       setSizeMode("custom");
     },
-    [isFullscreen, resolvedPanelSize.height, resolvedPanelSize.width, setSizeMode]
+    [
+      isFullscreen,
+      resolvedPanelSize.height,
+      resolvedPanelSize.width,
+      setSizeMode,
+    ],
   );
 
   const handleResizePointerMove = useCallback(
@@ -392,11 +472,11 @@ function AgentPopoverSurface({ customSize, setCustomSize }: AgentPopoverSurfaceP
             height: start.startHeight + start.startY - event.clientY,
           },
           viewport.width,
-          viewport.height
-        )
+          viewport.height,
+        ),
       );
     },
-    [setCustomSize]
+    [setCustomSize],
   );
 
   const handleResizePointerEnd = useCallback(
@@ -408,11 +488,14 @@ function AgentPopoverSurface({ customSize, setCustomSize }: AgentPopoverSurfaceP
         event.currentTarget.releasePointerCapture(event.pointerId);
       }
     },
-    []
+    [],
   );
 
   const clampTriggerPosition = useCallback((position: AgentTriggerPosition) => {
-    return clampAgentTriggerPosition(position, getAgentTriggerBounds(triggerRef.current));
+    return clampAgentTriggerPosition(
+      position,
+      getAgentTriggerBounds(triggerRef.current),
+    );
   }, []);
 
   const clampStoredTriggerPosition = useCallback(() => {
@@ -434,7 +517,10 @@ function AgentPopoverSurface({ customSize, setCustomSize }: AgentPopoverSurfaceP
     window.addEventListener("orientationchange", clampStoredTriggerPosition);
     return () => {
       window.removeEventListener("resize", clampStoredTriggerPosition);
-      window.removeEventListener("orientationchange", clampStoredTriggerPosition);
+      window.removeEventListener(
+        "orientationchange",
+        clampStoredTriggerPosition,
+      );
     };
   }, [canShowAgent, clampStoredTriggerPosition, useEmbeddedAgentTrigger]);
 
@@ -442,7 +528,7 @@ function AgentPopoverSurface({ customSize, setCustomSize }: AgentPopoverSurfaceP
     if (!triggerPosition) return;
     window.localStorage.setItem(
       AGENT_POPOVER_STORAGE_KEYS.triggerPosition,
-      JSON.stringify(triggerPosition)
+      JSON.stringify(triggerPosition),
     );
   }, [triggerPosition]);
 
@@ -455,7 +541,7 @@ function AgentPopoverSurface({ customSize, setCustomSize }: AgentPopoverSurfaceP
         triggerPosition ?? {
           x: rect.left,
           y: rect.top,
-        }
+        },
       );
 
       event.currentTarget.setPointerCapture(event.pointerId);
@@ -467,7 +553,7 @@ function AgentPopoverSurface({ customSize, setCustomSize }: AgentPopoverSurfaceP
         moved: false,
       };
     },
-    [clampTriggerPosition, triggerPosition]
+    [clampTriggerPosition, triggerPosition],
   );
 
   const handleTriggerPointerMove = useCallback(
@@ -488,10 +574,10 @@ function AgentPopoverSurface({ customSize, setCustomSize }: AgentPopoverSurfaceP
         clampTriggerPosition({
           x: start.startPosition.x + deltaX,
           y: start.startPosition.y + deltaY,
-        })
+        }),
       );
     },
-    [clampTriggerPosition]
+    [clampTriggerPosition],
   );
 
   const handleTriggerPointerEnd = useCallback(
@@ -508,7 +594,7 @@ function AgentPopoverSurface({ customSize, setCustomSize }: AgentPopoverSurfaceP
         skipTriggerClickRef.current = true;
       }
     },
-    []
+    [],
   );
 
   const handleTriggerClick = useCallback(() => {
@@ -518,10 +604,6 @@ function AgentPopoverSurface({ customSize, setCustomSize }: AgentPopoverSurfaceP
     }
     openAgent();
   }, [openAgent]);
-
-  if (!isAuthenticated) {
-    return null;
-  }
 
   if (!canShowAgent) {
     return null;
@@ -533,20 +615,20 @@ function AgentPopoverSurface({ customSize, setCustomSize }: AgentPopoverSurfaceP
         <div
           className={cn(
             "pointer-events-none fixed inset-0 z-[460] transition-opacity duration-300 motion-reduce:transition-none",
-            surfaceVisible ? "opacity-100" : "opacity-0"
+            surfaceVisible ? "opacity-100" : "opacity-0",
           )}
           aria-hidden={!expanded}
         >
           <section
             className={cn(
-              "pointer-events-auto fixed flex min-h-0 origin-bottom-right flex-col overflow-hidden border border-black/10 bg-white/95 text-[#1d1d1f] shadow-2xl backdrop-blur-xl transition-[border-radius,filter,height,opacity,transform,width] duration-[360ms] ease-[cubic-bezier(0.22,1,0.36,1)] will-change-transform motion-reduce:transform-none motion-reduce:transition-none dark:border-white/10 dark:bg-[#1c1c1e]/95 dark:text-[#f5f5f7]",
+              "agent-themed-popover-surface pointer-events-auto fixed flex min-h-0 origin-bottom-right flex-col overflow-hidden border border-border/70 shadow-2xl backdrop-blur-xl transition-[border-radius,filter,height,opacity,transform,width] duration-[360ms] ease-[cubic-bezier(0.22,1,0.36,1)] will-change-transform motion-reduce:transform-none motion-reduce:transition-none",
               isFullscreen
                 ? "inset-0 rounded-none"
                 : "bottom-[calc(max(var(--app-safe-area-bottom-effective),0.5rem)+0.5rem)] right-2 h-[min(var(--agent-popover-height),calc(100dvh-1rem))] w-[min(var(--agent-popover-width),calc(100vw-1rem))] rounded-lg max-sm:inset-0 max-sm:h-auto max-sm:w-auto max-sm:rounded-none sm:right-4 sm:h-[min(var(--agent-popover-height),calc(100dvh-2rem))] sm:w-[min(var(--agent-popover-width),calc(100vw-2rem))]",
               expanded
                 ? "translate-x-0 translate-y-0 scale-100 opacity-100 blur-0"
                 : "pointer-events-none translate-x-3 translate-y-[calc(100%-5.75rem)] scale-[0.2] opacity-0 blur-sm",
-              isCollapsing && "rounded-2xl ring-1 ring-primary/25"
+              isCollapsing && "rounded-2xl ring-1 ring-primary/25",
             )}
             style={panelStyle}
             role="dialog"
@@ -599,12 +681,12 @@ function AgentPopoverSurface({ customSize, setCustomSize }: AgentPopoverSurfaceP
           type="button"
           variant="secondary"
           className={cn(
-            "fixed z-[130] h-11 touch-none select-none gap-2 rounded-full border border-black/10 bg-white/92 px-4 text-[#1d1d1f] shadow-lg shadow-black/10 backdrop-blur-md transition-[box-shadow,opacity,transform,background-color,border-color] duration-300 ease-out hover:border-black/15 hover:bg-white hover:text-[#1d1d1f] focus-visible:ring-2 focus-visible:ring-primary/60 motion-reduce:transform-none motion-reduce:transition-none dark:border-white/15 dark:bg-[#1c1c1e]/90 dark:text-[#f5f5f7] dark:shadow-black/35 dark:hover:bg-[#2c2c2e]",
+            "agent-themed-app-surface fixed z-[130] h-11 touch-none select-none gap-2 rounded-full border border-border/70 px-4 shadow-lg backdrop-blur-md transition-[box-shadow,opacity,transform,background-color,border-color] duration-300 ease-out hover:border-border hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary/60 motion-reduce:transform-none motion-reduce:transition-none",
             "cursor-grab active:cursor-grabbing",
             expanded && !isCollapsing
               ? "pointer-events-none translate-y-3 scale-95 opacity-0"
               : "translate-y-0 scale-100 opacity-100",
-            isCollapsing && "ring-1 ring-primary/30 shadow-primary/20"
+            isCollapsing && "ring-1 ring-primary/30 shadow-primary/20",
           )}
           style={
             triggerPosition
@@ -626,7 +708,7 @@ function AgentPopoverSurface({ customSize, setCustomSize }: AgentPopoverSurfaceP
           aria-label="Open Agent"
           title="Drag to reposition Agent, tap to open"
         >
-          <Bot className="h-4 w-4" />
+          <MessageCircleMore className="h-4 w-4" />
           <span className="hidden text-sm font-medium sm:inline">Agent</span>
         </Button>
       ) : null}
@@ -651,7 +733,7 @@ function AgentPopoverWindowControls({
 
   return (
     <div
-      className="hidden h-8 overflow-hidden rounded-md border border-black/10 bg-black/[0.035] dark:border-white/10 dark:bg-white/[0.03] sm:flex"
+      className="hidden h-8 overflow-hidden rounded-md border border-border bg-muted/50 sm:flex"
       aria-label="Agent window controls"
       role="group"
     >
@@ -659,7 +741,7 @@ function AgentPopoverWindowControls({
         type="button"
         variant="ghost"
         size="icon-xs"
-        className="h-8 w-10 rounded-none text-[rgba(0,0,0,0.50)] hover:bg-black/[0.05] hover:text-[#1d1d1f] focus-visible:ring-2 focus-visible:ring-primary/60 dark:text-zinc-400 dark:hover:bg-white/[0.08] dark:hover:text-zinc-100"
+        className="h-8 w-10 rounded-none text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary/60"
         onClick={onMinimize}
         aria-label="Minimize Agent"
         title="Minimize Agent"
@@ -670,11 +752,11 @@ function AgentPopoverWindowControls({
         type="button"
         variant="ghost"
         size="icon-xs"
-        className="h-8 w-10 rounded-none text-[rgba(0,0,0,0.50)] hover:bg-black/[0.05] hover:text-[#1d1d1f] focus-visible:ring-2 focus-visible:ring-primary/60 dark:text-zinc-400 dark:hover:bg-white/[0.08] dark:hover:text-zinc-100"
+        className="h-8 w-10 rounded-none text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary/60"
         onClick={() => setSizeMode(isFullscreen ? "large" : "fullscreen")}
-      aria-label={isFullscreen ? "Restore Agent" : "Maximize Agent"}
-      title={isFullscreen ? "Restore Agent" : "Maximize Agent"}
-    >
+        aria-label={isFullscreen ? "Restore Agent" : "Maximize Agent"}
+        title={isFullscreen ? "Restore Agent" : "Maximize Agent"}
+      >
         {isFullscreen ? (
           <Minimize2 className="h-3.5 w-3.5" />
         ) : (
@@ -685,7 +767,7 @@ function AgentPopoverWindowControls({
         type="button"
         variant="ghost"
         size="icon-xs"
-        className="h-8 w-10 rounded-none text-[rgba(0,0,0,0.50)] hover:bg-red-500/85 hover:text-white focus-visible:ring-2 focus-visible:ring-red-400/70 dark:text-zinc-400"
+        className="h-8 w-10 rounded-none text-muted-foreground hover:bg-red-500/85 hover:text-white focus-visible:ring-2 focus-visible:ring-red-400/70"
         onClick={onClose}
         aria-label="Close Agent"
         title="Close Agent"

--- a/hushh-webapp/components/kai/kai-command-bar-global.tsx
+++ b/hushh-webapp/components/kai/kai-command-bar-global.tsx
@@ -806,6 +806,7 @@ export function KaiCommandBarGlobal() {
       appRuntimeState={appRuntimeState}
       voiceContext={voiceContext}
       surfaceVariant={useRiaActionBar ? "ria" : "kai"}
+      showAgent={localVoiceReady}
       portfolioTickers={portfolioTickers}
     />
   );

--- a/hushh-webapp/components/kai/kai-command-palette.tsx
+++ b/hushh-webapp/components/kai/kai-command-palette.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type MouseEvent } from "react";
 import {
   Activity,
   Compass,
@@ -8,6 +8,7 @@ import {
   Search,
   ShieldCheck,
   UserRound,
+  X,
 } from "lucide-react";
 
 import {
@@ -40,6 +41,10 @@ interface KaiCommandPaletteProps {
   onOpenChange: (open: boolean) => void;
   onSelectAction: (selection: KaiCommandPaletteSelection) => void;
   appRuntimeState?: AppRuntimeState;
+  onVoiceClick?: (event: MouseEvent<HTMLButtonElement>) => void;
+  voiceActive?: boolean;
+  voiceDisabled?: boolean;
+  voiceHidden?: boolean;
   portfolioTickers?: Array<{
     symbol: string;
     name?: string;
@@ -388,13 +393,27 @@ export function KaiCommandPalette({
     <CommandDialog
       open={open}
       onOpenChange={onOpenChange}
+      showCloseButton={false}
       className="top-[calc(var(--top-shell-reserved-height,0px)+0.75rem)] max-h-[min(70dvh,32rem)] w-[calc(100%-1rem)] translate-y-0 sm:top-1/2 sm:w-full sm:max-h-none sm:-translate-y-1/2"
     >
-      <CommandInput
-        value={query}
-        onValueChange={setQuery}
-        placeholder="Run Kai command or search ticker..."
-      />
+      <div className="relative">
+        <CommandInput
+          value={query}
+          onValueChange={setQuery}
+          placeholder="Run Kai command or search ticker..."
+          className="pr-14"
+        />
+        <div className="absolute right-2.5 top-1/2 flex -translate-y-1/2 items-center gap-1.5">
+          <button
+            type="button"
+            aria-label="Close command search"
+            onClick={() => onOpenChange(false)}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-black/[0.045] hover:text-foreground dark:hover:bg-white/10"
+          >
+            <X className="h-4 w-4" strokeWidth={1.9} aria-hidden="true" />
+          </button>
+        </div>
+      </div>
       <CommandList className="max-h-[min(56dvh,24rem)] sm:max-h-[300px]">
         <CommandEmpty>{commandEmptyMessage}</CommandEmpty>
 

--- a/hushh-webapp/components/kai/kai-search-bar.tsx
+++ b/hushh-webapp/components/kai/kai-search-bar.tsx
@@ -9,7 +9,7 @@ import {
   useState,
   type MouseEvent,
 } from "react";
-import { Mic, Search, X } from "lucide-react";
+import { Bot, Mic, Search, X } from "lucide-react";
 
 import {
   KaiCommandPalette,
@@ -20,6 +20,7 @@ import {
 } from "@/components/kai/voice/voice-ambient-search-surface";
 import { VoiceDebugDrawer } from "@/components/kai/voice/voice-debug-drawer";
 import { ShellActionSurface } from "@/components/app-ui/shell-action-surface";
+import { useOptionalAgentPopover } from "@/components/agent/agent-popover-provider";
 import { morphyToast as toast } from "@/lib/morphy-ux/morphy";
 import { useKaiBottomChromeVisibility } from "@/lib/navigation/kai-bottom-chrome-visibility";
 import { KAI_COMMAND_BAR_OPEN_EVENT } from "@/lib/navigation/kai-command-bar-events";
@@ -88,6 +89,7 @@ interface KaiSearchBarProps {
   onTtsPlayingChange?: (playing: boolean) => void;
   voiceContext?: Record<string, unknown>;
   surfaceVariant?: SearchSurfaceVariant;
+  showAgent?: boolean;
   portfolioTickers?: Array<{
     symbol: string;
     name?: string;
@@ -309,9 +311,11 @@ export function KaiSearchBar({
   onTtsPlayingChange,
   voiceContext,
   surfaceVariant = "kai",
+  showAgent = false,
   portfolioTickers = [],
 }: KaiSearchBarProps) {
   const { getVaultOwnerToken, vaultKey } = useVault();
+  const agentPopover = useOptionalAgentPopover();
   const [open, setOpen] = useState(false);
   const [voiceDebugOpen, setVoiceDebugOpen] = useState(false);
   const [voiceUiState, setVoiceUiState] = useState<VoiceUiState>("idle");
@@ -1659,6 +1663,11 @@ export function KaiSearchBar({
       stableMicDisabledReason,
     ],
   );
+  const handleAgentClick = useCallback(() => {
+    if (!showAgent) return;
+    if (!agentPopover) return;
+    agentPopover.openAgent();
+  }, [agentPopover, showAgent]);
 
   return (
     <>
@@ -1682,59 +1691,86 @@ export function KaiSearchBar({
             "pointer-events-none w-full",
             isRiaSurface ? "max-w-[360px] sm:max-w-[392px]" : "max-w-[548px]"
           )}
+          style={
+            isRiaSurface
+              ? undefined
+              : {
+                  width:
+                    "var(--app-bottom-route-group-width, min(calc(100vw - 2rem), 560px))",
+                }
+          }
         >
           {isRiaSurface ? (
-            <div
-              className="grid grid-cols-2 gap-1.5 rounded-full border border-[color:var(--app-shell-surface-border)] bg-[color:var(--app-shell-surface-bg)] bg-[image:var(--app-shell-surface-fill)] p-1 shadow-[var(--app-shell-surface-shadow)] backdrop-blur-[var(--app-shell-surface-blur)]"
-              data-testid="ria-action-bar"
-            >
-              <ShellActionSurface
-                variant="pill"
-                wrapperClassName="w-full"
-                className="h-10 w-full min-w-0 px-2 text-[12px] sm:text-[13px]"
-                contentClassName="gap-1.5"
-                aria-label="Search RIA workspace"
-                aria-expanded={open}
-                aria-haspopup="dialog"
-                onClick={() => setOpen(true)}
+            <div className="relative flex w-full items-end justify-end">
+              <div
+                className="grid w-full grid-cols-2 gap-1.5 rounded-full border border-[color:var(--app-shell-surface-border)] bg-[color:var(--app-shell-surface-bg)] bg-[image:var(--app-shell-surface-fill)] p-1 shadow-[var(--app-shell-surface-shadow)] backdrop-blur-[var(--app-shell-surface-blur)]"
+                data-testid="ria-action-bar"
               >
-                <Search className="h-4 w-4 shrink-0" />
-                <span className="truncate">Search</span>
-              </ShellActionSurface>
-              <ShellActionSurface
-                variant="pill"
-                wrapperClassName="w-full"
-                contentClassName="gap-1.5"
-                aria-label={riaVoiceActive ? "End RIA voice session" : "Start RIA voice"}
-                aria-disabled={riaVoiceDisabled}
-                className={cn(
-                  "h-10 w-full min-w-0 px-2 text-[12px] sm:text-[13px]",
-                  riaVoiceDisabled && "opacity-60"
-                )}
-                onClick={handleRiaVoiceClick}
-              >
-                {riaVoiceActive ? (
-                  <X className="h-4 w-4 shrink-0" />
-                ) : (
-                  <Mic className="h-4 w-4 shrink-0" />
-                )}
-                <span className="truncate">Voice</span>
-              </ShellActionSurface>
+                <ShellActionSurface
+                  variant="pill"
+                  wrapperClassName="w-full"
+                  className="h-10 w-full min-w-0 px-2 text-[12px] sm:text-[13px]"
+                  contentClassName="gap-1.5"
+                  aria-label="Search RIA workspace"
+                  aria-expanded={open}
+                  aria-haspopup="dialog"
+                  onClick={() => setOpen(true)}
+                >
+                  <Search className="h-4 w-4 shrink-0" />
+                  <span className="truncate">Search</span>
+                </ShellActionSurface>
+                <ShellActionSurface
+                  variant="pill"
+                  wrapperClassName="w-full"
+                  contentClassName="gap-1.5"
+                  aria-label={riaVoiceActive ? "End RIA voice session" : "Start RIA voice"}
+                  aria-disabled={riaVoiceDisabled}
+                  className={cn(
+                    "h-10 w-full min-w-0 px-2 text-[12px] sm:text-[13px]",
+                    riaVoiceDisabled && "opacity-60"
+                  )}
+                  onClick={handleRiaVoiceClick}
+                >
+                  {riaVoiceActive ? (
+                    <X className="h-4 w-4 shrink-0" />
+                  ) : (
+                    <Mic className="h-4 w-4 shrink-0" />
+                  )}
+                  <span className="truncate">Voice</span>
+                </ShellActionSurface>
+              </div>
             </div>
           ) : (
-            <div className="relative flex h-[58px] w-full items-end justify-end">
+            <div
+              className={cn(
+                "relative ml-auto flex w-[58px] items-end justify-end",
+                showAgent ? "h-[112px]" : "h-[58px]"
+              )}
+            >
+              {showAgent ? (
+                <button
+                  type="button"
+                  aria-label="Open Agent"
+                  onClick={handleAgentClick}
+                  className="kai-bottom-agent-action pointer-events-auto absolute right-[7px] top-0 inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/30"
+                >
+                  <Bot className="h-[18px] w-[18px]" strokeWidth={1.9} />
+                </button>
+              ) : null}
               <div
                 className={cn(
                   "ml-auto flex items-end justify-end transition-[width] duration-200 ease-out",
                   compactDockExpanded
                     ? "w-[min(15.5rem,calc(100vw-2rem))]"
-                    : "w-[58px]"
+                    : "w-[58px]",
                 )}
               >
                 <div
                   className={cn(
                     "pointer-events-auto grid rounded-full kai-bottom-search-action p-[5px]",
-                    compactDockExpanded ? "w-full grid-cols-2 gap-1" : "w-[58px] grid-cols-1"
+                    compactDockExpanded
+                      ? "w-full grid-cols-2 gap-1"
+                      : "w-[58px] grid-cols-1",
                   )}
                   data-testid="kai-compact-search-surface"
                   data-mode={ambientMode}
@@ -1770,7 +1806,7 @@ export function KaiSearchBar({
                         riaVoiceActive
                           ? "bg-primary text-primary-foreground hover:bg-primary/90"
                           : "text-muted-foreground hover:text-foreground",
-                        riaVoiceDisabled && "opacity-60"
+                        riaVoiceDisabled && "opacity-60",
                       )}
                     >
                       {riaVoiceActive ? (
@@ -1798,6 +1834,10 @@ export function KaiSearchBar({
         onOpenChange={setOpen}
         onSelectAction={onSelectAction}
         appRuntimeState={appRuntimeState}
+        onVoiceClick={handleRiaVoiceClick}
+        voiceActive={riaVoiceActive}
+        voiceDisabled={riaVoiceDisabled}
+        voiceHidden={voiceVisibilityMode === "hidden"}
         portfolioTickers={portfolioTickers}
       />
 

--- a/hushh-webapp/lib/agent/agent-voice-tts.ts
+++ b/hushh-webapp/lib/agent/agent-voice-tts.ts
@@ -17,6 +17,7 @@ export type AgentTtsQueueOptions = {
   synthesize?: (input: AgentTtsRequest) => Promise<Response>;
   playAudio?: (audio: Blob, signal: AbortSignal) => Promise<void>;
   fallbackSpeak?: (text: string, signal: AbortSignal) => Promise<void>;
+  allowBrowserFallback?: boolean;
   onStateChange?: (state: "idle" | "speaking") => void;
   onError?: (failure: AgentTtsFailure) => void;
   requestTimeoutMs?: number;
@@ -37,7 +38,7 @@ export type SpeechChunks = {
 const MAX_TTS_CHUNK_CHARS = 220;
 const MIN_TTS_CHUNK_CHARS = 12;
 const EARLY_TTS_CHUNK_CHARS = 90;
-const DEFAULT_TTS_REQUEST_TIMEOUT_MS = 30_000;
+const DEFAULT_TTS_REQUEST_TIMEOUT_MS = 55_000;
 const DEFAULT_TTS_MAX_ATTEMPTS = 2;
 const FALLBACK_SPEECH_TIMEOUT_BASE_MS = 4_000;
 const FALLBACK_SPEECH_TIMEOUT_PER_CHAR_MS = 90;
@@ -133,32 +134,60 @@ async function defaultPlayAudio(audio: Blob, signal: AbortSignal): Promise<void>
   const element = new Audio(url);
   element.preload = "auto";
   element.setAttribute("playsinline", "true");
+  element.setAttribute("webkit-playsinline", "true");
+  (element as HTMLAudioElement & { playsInline?: boolean }).playsInline = true;
+  element.style.position = "fixed";
+  element.style.left = "-9999px";
+  element.style.top = "0";
+  element.style.width = "1px";
+  element.style.height = "1px";
+  element.style.opacity = "0";
 
   try {
     await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      let playRequested = false;
       const cleanup = () => {
-        element.onended = null;
-        element.onerror = null;
+        element.removeEventListener("ended", handleEnded);
+        element.removeEventListener("error", handleError);
         signal.removeEventListener("abort", handleAbort);
+        element.pause();
+        element.removeAttribute("src");
+        element.load();
+        element.remove();
+      };
+      const settle = (callback: () => void) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        callback();
       };
       const handleAbort = () => {
-        element.pause();
-        cleanup();
-        reject(new DOMException("Aborted", "AbortError"));
+        settle(() => reject(new DOMException("Aborted", "AbortError")));
       };
-      element.onended = () => {
-        cleanup();
-        resolve();
+      const handleEnded = () => settle(resolve);
+      const handleError = () => {
+        settle(() => reject(new Error("Agent voice audio playback failed.")));
       };
-      element.onerror = () => {
-        cleanup();
-        reject(new Error("Agent voice audio playback failed."));
+      const requestPlayback = () => {
+        if (playRequested || settled) return;
+        playRequested = true;
+        void element.play().catch((error) => {
+          settle(() =>
+            reject(
+              error instanceof Error
+                ? error
+                : new Error("Agent voice playback failed.")
+            )
+          );
+        });
       };
+      element.addEventListener("ended", handleEnded);
+      element.addEventListener("error", handleError);
       signal.addEventListener("abort", handleAbort, { once: true });
-      void element.play().catch((error) => {
-        cleanup();
-        reject(error instanceof Error ? error : new Error("Agent voice playback failed."));
-      });
+      document.body?.appendChild(element);
+      element.load();
+      requestPlayback();
     });
   } finally {
     URL.revokeObjectURL(url);
@@ -222,7 +251,7 @@ export class AgentTtsQueue {
   private readonly voice?: string;
   private readonly synthesize: (input: AgentTtsRequest) => Promise<Response>;
   private readonly playAudio: (audio: Blob, signal: AbortSignal) => Promise<void>;
-  private readonly fallbackSpeak: (text: string, signal: AbortSignal) => Promise<void>;
+  private readonly fallbackSpeak?: (text: string, signal: AbortSignal) => Promise<void>;
   private readonly onStateChange?: (state: "idle" | "speaking") => void;
   private readonly onError?: (failure: AgentTtsFailure) => void;
   private readonly requestTimeoutMs: number;
@@ -240,7 +269,9 @@ export class AgentTtsQueue {
     this.voice = options.voice;
     this.synthesize = options.synthesize || defaultSynthesize;
     this.playAudio = options.playAudio || defaultPlayAudio;
-    this.fallbackSpeak = options.fallbackSpeak || defaultFallbackSpeak;
+    this.fallbackSpeak = options.allowBrowserFallback
+      ? options.fallbackSpeak || defaultFallbackSpeak
+      : undefined;
     this.onStateChange = options.onStateChange;
     this.onError = options.onError;
     this.requestTimeoutMs = Math.max(
@@ -389,6 +420,7 @@ export class AgentTtsQueue {
   }
 
   private async speakWithFallback(text: string, signal: AbortSignal): Promise<void> {
+    if (!this.fallbackSpeak) return;
     try {
       await this.fallbackSpeak(text, signal);
     } catch (error) {

--- a/hushh-webapp/lib/services/api-service.ts
+++ b/hushh-webapp/lib/services/api-service.ts
@@ -95,6 +95,57 @@ function normalizeNativeBackendUrl(raw: string): string {
   return trimmed;
 }
 
+function decodeNativeBinaryPayload(data: unknown): Uint8Array {
+  if (data instanceof ArrayBuffer) {
+    return new Uint8Array(data);
+  }
+  if (ArrayBuffer.isView(data)) {
+    return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+  }
+  if (Array.isArray(data)) {
+    return new Uint8Array(data);
+  }
+
+  const raw =
+    typeof data === "string"
+      ? data
+      : data &&
+          typeof data === "object" &&
+          "data" in data &&
+          typeof (data as { data?: unknown }).data === "string"
+        ? String((data as { data: string }).data)
+        : "";
+  const base64 = raw.includes(",") ? raw.split(",").pop() || "" : raw;
+  if (!base64) return new Uint8Array();
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const buffer = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(buffer).set(bytes);
+  return buffer;
+}
+
+function getNativeHeaderValue(
+  headers: Record<string, unknown> | undefined,
+  name: string
+): string | null {
+  if (!headers) return null;
+  const target = name.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() !== target || value === undefined || value === null) {
+      continue;
+    }
+    return Array.isArray(value) ? value.join(",") : String(value);
+  }
+  return null;
+}
+
 function detectHostedToLocalMismatch(apiBase: string): string | null {
   const backendHost = hostFromUrl(apiBase);
   if (!isLocalNativeHost(backendHost)) return null;
@@ -2589,6 +2640,67 @@ export class ApiService {
     voice?: string;
     signal?: AbortSignal;
   }): Promise<Response> {
+    if (Capacitor.isNativePlatform()) {
+      const apiBase = getApiBaseUrl();
+      if (!apiBase) {
+        throw new Error(
+          "Native Agent voice TTS requires NEXT_PUBLIC_BACKEND_URL."
+        );
+      }
+      const mismatchMessage = detectHostedToLocalMismatch(apiBase);
+      if (mismatchMessage) {
+        throw new Error(mismatchMessage);
+      }
+      if (data.signal?.aborted) {
+        throw new DOMException("Aborted", "AbortError");
+      }
+
+      const abortPromise = data.signal
+        ? new Promise<never>((_resolve, reject) => {
+            data.signal?.addEventListener(
+              "abort",
+              () => reject(new DOMException("Aborted", "AbortError")),
+              { once: true }
+            );
+          })
+        : null;
+      const requestPromise = CapacitorHttp.request({
+        url: `${apiBase}/api/kai/agent/voice/tts`,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${data.vaultOwnerToken}`,
+        },
+        data: {
+          user_id: data.userId,
+          text: data.text,
+          voice: data.voice,
+        },
+        responseType: "arraybuffer",
+        readTimeout: 55_000,
+        connectTimeout: 15_000,
+      });
+      const nativeResponse = abortPromise
+        ? await Promise.race([requestPromise, abortPromise])
+        : await requestPromise;
+      const headers = new Headers();
+      Object.entries(nativeResponse.headers || {}).forEach(([key, value]) => {
+        if (value === undefined || value === null) return;
+        headers.set(key, String(value));
+      });
+      const contentType =
+        getNativeHeaderValue(nativeResponse.headers, "content-type") ||
+        getNativeHeaderValue(nativeResponse.headers, "Content-Type") ||
+        "audio/wav";
+      headers.set("Content-Type", contentType);
+
+      const audioBytes = decodeNativeBinaryPayload(nativeResponse.data);
+      return new Response(toArrayBuffer(audioBytes), {
+        status: nativeResponse.status,
+        headers,
+      });
+    }
+
     return apiFetch("/api/kai/agent/voice/tts", {
       method: "POST",
       headers: {


### PR DESCRIPTION
## Summary
- Gate the Agent trigger behind authenticated/onboarded app readiness so it does not appear on login or initial flows.
- Polish mobile Agent chrome: top spacing, close control, header divider behavior, and light-mode theme tokens.
- Remove visible voice controls from search/command surfaces while hardening native TTS playback and fallback behavior.
- Add focused contracts for Agent availability, theme, command palette, search, and TTS behavior.

## Validation
- `npm run test -- __tests__/components/agent-popover-provider.test.tsx __tests__/components/agent-theme-contract.test.ts __tests__/components/kai-command-palette-contract.test.ts __tests__/components/navbar-agent-trigger.contract.test.ts __tests__/voice/kai-search-bar.test.ts __tests__/lib/agent-voice-tts.test.ts __tests__/voice/api-service-voice.test.ts`
- `GITHUB_BASE_SHA=$(git rev-parse origin/integration/pr-train) GITHUB_SHA=$(git rev-parse HEAD) ./bin/hushh codex pre-pr`

## Release Path
- Targeting `integration/pr-train` per branch governance.
- After train CI is green and merged, promote `integration/pr-train` to `main`, wait for green `Main Post-Merge Smoke`, then dispatch UAT from that exact green SHA.
