### PR TITLE
fix(ui): remove aria-hidden from wrapper in BreadcrumbEllipsis

### DIFF
--- a/hushh-webapp/components/ui/breadcrumb.tsx
+++ b/hushh-webapp/components/ui/breadcrumb.tsx
@@ -85,12 +85,10 @@ function BreadcrumbEllipsis({
   return (
     <span
       data-slot="breadcrumb-ellipsis"
-      role="presentation"
-      aria-hidden="true"
       className={cn("flex size-9 items-center justify-center", className)}
       {...props}
     >
-      <MoreHorizontal className="size-4" />
+      <MoreHorizontal className="size-4" aria-hidden="true" />
       <span className="sr-only">More</span>
     </span>
   )


### PR DESCRIPTION
This PR fixes an accessibility bug in the `BreadcrumbEllipsis` component. Previously, `aria-hidden="true"` and `role="presentation"` were placed on the outer `<span>` wrapper, which completely hid both the decorative icon and the screen-reader-only `<span>More</span>` text from assistive technologies. This PR moves `aria-hidden="true"` exclusively to the decorative `MoreHorizontal` icon and removes `role="presentation"` from the wrapper, ensuring the visually hidden text is correctly announced by screen readers.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None

- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None
- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Not applicable

- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate:
- [x] This PR changes a current reachable app/backend/package/docs surface, or it is explicitly scoped as test/devex hygiene.
- [x] Reachable production attach point: `components/ui/breadcrumb.tsx`
- [x] New helpers/components/services are wired to an existing route, caller, package export, generated contract, or documented devex entrypoint.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.
- [x] Maintainer edits are enabled, or the reason they cannot be enabled is listed here:

## 🛑 Tri-Flow Architecture Check

Every cross-platform feature must cover all affected layers or explicitly mark
the layer as not applicable with the reason.

- [x] **Web**: Next.js implementation (`app/api/...`)
- [ ] **iOS**: Swift Capacitor Plugin (`ios/App/App/Plugins/...`)
- [ ] **Android**: Kotlin Capacitor Plugin (`android/app/.../plugins/...`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Attach proof of work here. For UI-visible changes, include the route plus
Playwright spec/command, screenshot, video, or why browser proof is not
applicable.
*(Not applicable: Component-level DOM hygiene fix)*

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed