### PR TITLE
test(api-client): cover empty message fallback

### DIFF
--- a/hushh-webapp/__tests__/services/api-client.test.ts
+++ b/hushh-webapp/__tests__/services/api-client.test.ts
@@ -146,6 +146,14 @@ describe("apiJson", () => {
     } satisfies Partial<ApiError>);
   });
 });
+  it("falls back to the status code when message field is empty", async () => {
+    mockApiFetch.mockResolvedValueOnce(jsonResponse({ message: "" }, 400));
+
+    await expect(apiJson("/api/test")).rejects.toMatchObject({
+      message: "Request failed: 400",
+      status: 400,
+    } satisfies Partial<ApiError>);
+  });
 
 // ---------------------------------------------------------------------------
 // apiJson — response size boundary enforcement (CWE-400)


### PR DESCRIPTION
## Summary

Adds test coverage for API error responses where the `message` field is present but empty.

## Changes

* Added a test case for an empty string `message` field (`""`)
* Verifies that `apiJson` treats an empty message as unreadable content
* Confirms fallback to the default status-based error message
* Extends existing error handling edge-case coverage

## Test

```bash
npx vitest run __tests__/services/api-client.test.ts
```

Result:

* All tests passed
* No regressions introduced
