### PR TITLE
fix(kai): hide decorative arrow icons in preferences wizard

### DIFF
--- a/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
+++ b/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
@@ -309,7 +309,7 @@ export function KaiPreferencesWizard(props: {
                 )}
               >
                 {isSubmitting ? "Saving..." : primaryLabel}
-                {!isSubmitting && <ArrowRight className="ml-2 h-5 w-5" />}
+                {!isSubmitting && <ArrowRight aria-hidden="true" className="ml-2 h-5 w-5" />}
               </Button>
 
               {props.mode === "onboarding" && props.onSkip && (
@@ -326,7 +326,7 @@ export function KaiPreferencesWizard(props: {
                   className="h-11 rounded-full !bg-primary/10 text-[15px] font-medium !text-primary shadow-none hover:!bg-primary/15 dark:!bg-primary/15"
                 >
                   {isSubmitting ? "Saving..." : "Skip"}
-                  {!isSubmitting && <ArrowRight className="ml-2 h-5 w-5" />}
+                  {!isSubmitting && <ArrowRight aria-hidden="true" className="ml-2 h-5 w-5" />}
                 </Button>
               )}
             </div>


### PR DESCRIPTION
## Summary

Hide decorative arrow icons from assistive technologies in the Kai Preferences Wizard.

### Changes

* Added `aria-hidden="true"` to the decorative `ArrowRight` icons displayed in the primary and skip action buttons.

### Why

The arrow icons are purely visual indicators and do not provide information beyond the adjacent button text. Hiding them from assistive technologies reduces unnecessary screen reader noise and improves accessibility.

### Testing

* Ran `npm run lint`
* Verified change is isolated to the Kai Preferences Wizard component
* No functional behavior changes
