### PR TITLE
test(utils): cover cn class merge behavior

### DIFF
--- a/hushh-webapp/__tests__/utils/cn.test.ts
+++ b/hushh-webapp/__tests__/utils/cn.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { cn } from "@/lib/utils";
+
+describe("cn", () => {
+  it("merges conditional class names", () => {
+    expect(cn("flex", false && "hidden", "items-center")).toBe(
+      "flex items-center",
+    );
+  });
+
+  it("lets later tailwind classes override earlier conflicts", () => {
+    expect(cn("p-2", "p-4")).toBe("p-4");
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit test coverage for the `cn` utility function to verify:

* Conditional class names are merged correctly.
* Conflicting Tailwind classes are resolved with the later class taking precedence.

## Changes Made

* Added `__tests__/utils/cn.test.ts`
* Added coverage for conditional class merging behavior
* Added coverage for Tailwind class conflict resolution

## Testing

```bash
npx vitest run __tests__/utils/cn.test.ts
```

## Expected Result

The tests confirm that the `cn` helper produces the expected merged class string and correctly handles Tailwind class overrides.
