### PR TITLE
fix(ria): hide decorative sparkles icons in onboarding

### DIFF
--- a/hushh-webapp/components/ria/onboarding/onboarding-step-review.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-step-review.tsx
@@ -206,7 +206,7 @@ export function OnboardingStepReview({
         type="button"
         className="inline-flex min-h-9 items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-3.5 text-sm font-medium text-primary transition-colors hover:bg-primary/15"
       >
-        <Sparkles className="h-3.5 w-3.5" />
+        <Sparkles aria-hidden="true" className="h-3.5 w-3.5" />
         Ask Kai to update anything
       </button>
     </div>

--- a/hushh-webapp/components/ria/onboarding/onboarding-step-services.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-step-services.tsx
@@ -234,7 +234,7 @@ export function OnboardingStepServices({
           type="button"
           className="inline-flex min-h-9 items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-3.5 text-sm font-medium text-primary transition-colors hover:bg-primary/15"
         >
-          <Sparkles className="h-3.5 w-3.5" />
+          <Sparkles aria-hidden="true" className="h-3.5 w-3.5" />
           Ask Kai to draft a bio
         </button>
       </div>


### PR DESCRIPTION
## Summary

Hide decorative Sparkles icons from assistive technologies in RIA onboarding actions.

### Changes

* Added `aria-hidden="true"` to the decorative `Sparkles` icon in the "Ask Kai to update anything" action.
* Added `aria-hidden="true"` to the decorative `Sparkles` icon in the "Ask Kai to draft a bio" action.

### Why

These icons are purely visual enhancements and do not provide information beyond the adjacent button text. Hiding them from assistive technologies reduces unnecessary screen reader announcements and improves accessibility.

### Testing

* Ran `npm run lint`
* Verified changes are limited to onboarding action buttons
* No functional behavior changes
