### PR TITLE
fix(ria): hide decorative loaders from assistive technology

### DIFF
--- a/hushh-webapp/components/ria/onboarding/onboarding-step-license.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-step-license.tsx
@@ -60,7 +60,7 @@ export function OnboardingStepLicense({
       >
         {verificationStatus === "verifying" ? (
           <>
-            <Loader2 className="h-5 w-5 animate-spin" />
+            <Loader2 aria-hidden="true" className="h-5 w-5 animate-spin" />
             Verifying...
           </>
         ) : (
@@ -87,7 +87,7 @@ export function OnboardingStepLicense({
         <div className="space-y-3">
           {verificationStatus === "verifying" ? (
             <div className="flex items-center gap-3 rounded-[18px] border border-border/60 bg-card/70 px-4 py-3 backdrop-blur dark:bg-card/45">
-              <Loader2 className="h-4 w-4 shrink-0 animate-spin text-primary" />
+              <Loader2 aria-hidden="true" className="h-4 w-4 shrink-0 animate-spin text-primary" />
               <p className="text-[15px] text-muted-foreground">
                 Checking regulatory databases...
               </p>

--- a/hushh-webapp/components/ria/ria-client-account-detail.tsx
+++ b/hushh-webapp/components/ria/ria-client-account-detail.tsx
@@ -150,7 +150,7 @@ export function RiaClientAccountDetail({
       {loading ? (
         <div className="rounded-[var(--app-card-radius-standard)] bg-[color:var(--app-card-surface-default-solid)] p-4 shadow-[var(--app-card-shadow-standard)]">
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <Loader2 className="h-4 w-4 animate-spin" />
+            <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />
             Loading account detail...
           </div>
         </div>

--- a/hushh-webapp/components/ria/ria-client-request-detail.tsx
+++ b/hushh-webapp/components/ria/ria-client-request-detail.tsx
@@ -139,7 +139,7 @@ export function RiaClientRequestDetail({
       {loading ? (
         <div className="rounded-[var(--app-card-radius-standard)] bg-[color:var(--app-card-surface-default-solid)] p-4 shadow-[var(--app-card-shadow-standard)]">
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <Loader2 className="h-4 w-4 animate-spin" />
+            <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />
             Loading request detail...
           </div>
         </div>


### PR DESCRIPTION
## Summary

Hide decorative loading indicators from assistive technologies in RIA onboarding and client detail views.

### Changes

* Added `aria-hidden="true"` to decorative `Loader2` icons in the license verification flow.
* Added `aria-hidden="true"` to decorative `Loader2` icons in client account detail loading states.
* Added `aria-hidden="true"` to decorative `Loader2` icons in client request detail loading states.

### Why

The loading status is already communicated through adjacent text such as "Verifying...", "Loading account detail...", and "Loading request detail...". Hiding decorative loader icons reduces unnecessary screen reader announcements and improves accessibility.

### Testing

* Ran `npm run lint`
* Verified changes are limited to decorative loading indicators
* No functional behavior changes
