### PR TITLE
fix(kai): hide decorative search icons in preview views

### DIFF
--- a/hushh-webapp/components/kai/views/kai-connect-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-connect-preview-view.tsx
@@ -694,7 +694,7 @@ export function KaiConnectPreviewView() {
             onSubmit={(event) => event.preventDefault()}
             className="mt-5 flex h-12 items-center gap-2.5 rounded-[16px] bg-[color:var(--one-surface)] px-4"
           >
-            <Search className="h-[17px] w-[17px] shrink-0 text-[color:var(--one-fg3)]" />
+            <Search aria-hidden="true" className="h-[17px] w-[17px] shrink-0 text-[color:var(--one-fg3)]" />
             <input
               type="text"
               placeholder="Search advisors"

--- a/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
@@ -2104,7 +2104,7 @@ export function KaiMarketPreviewView() {
             }}
             className="mt-5 flex h-12 items-center gap-2.5 rounded-[16px] bg-[color:var(--one-surface)] px-4"
           >
-            <Search className="h-[17px] w-[17px] shrink-0 text-[color:var(--one-fg3)]" />
+            <Search aria-hidden="true" className="h-[17px] w-[17px] shrink-0 text-[color:var(--one-fg3)]" />
             <input
               type="text"
               placeholder="Search stocks, ETFs, indices"


### PR DESCRIPTION
## Summary

Hide decorative search icons from assistive technologies in Kai preview search interfaces.

### Changes

* Added `aria-hidden="true"` to the decorative search icon in the advisor search field.
* Added `aria-hidden="true"` to the decorative search icon in the market search field.

### Why

The search functionality is already communicated through the associated input fields and placeholders. Hiding decorative search icons reduces unnecessary screen reader announcements and improves accessibility.

### Testing

* Ran `npm run lint`
* Verified changes are limited to decorative search icons
* No functional behavior changes
