### PR TITLE
test(test-helpers): cover request helper default origin

### DIFF
--- a/hushh-webapp/__tests__/utils/test-helpers.test.ts
+++ b/hushh-webapp/__tests__/utils/test-helpers.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { createMockRequest } from "./test-helpers";
+
+describe("test helpers", () => {
+  it("uses localhost as the default request origin", () => {
+    const request = createMockRequest("/api/test");
+
+    expect(request.nextUrl.origin).toBe("http://localhost:3000");
+    expect(request.nextUrl.pathname).toBe("/api/test");
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit test coverage for the request helper's default origin handling.

## Changes Made

* Added `__tests__/utils/test-helpers.test.ts`
* Verified that `createMockRequest()` uses `http://localhost:3000` as the default origin when a relative path is provided
* Verified that the generated request preserves the expected pathname

## Testing

```bash
npx vitest run __tests__/utils/test-helpers.test.ts
```

## Result

The new test confirms that request helper utilities consistently resolve relative paths against the default local origin, helping prevent regressions in request construction behavior.
