### PR TITLE
fix(profile): hide decorative chevron icons in pkm manager

### DIFF
--- a/hushh-webapp/components/profile/pkm-data-manager.tsx
+++ b/hushh-webapp/components/profile/pkm-data-manager.tsx
@@ -142,7 +142,7 @@ function DomainCard({
             <span className="min-w-0 truncate">{domain.accessSummary}</span>
           </div>
         </div>
-        <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200 group-hover:translate-x-0.5" />
+        <ChevronRight aria-hidden="true" className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200 group-hover:translate-x-0.5" />
       </div>
     </button>
   );
@@ -399,7 +399,7 @@ function ConnectionCard({
             <span className="min-w-0 truncate">{connection.domains.slice(0, 2).join(" · ")}</span>
           </div>
         </div>
-        <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200 group-hover:translate-x-0.5" />
+        <ChevronRight aria-hidden="true" className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200 group-hover:translate-x-0.5" />
       </div>
     </button>
   );


### PR DESCRIPTION
## Summary

Hide decorative chevron icons from assistive technologies in the PKM data manager.

### Changes

* Added `aria-hidden="true"` to the decorative chevron icon in domain cards.
* Added `aria-hidden="true"` to the decorative chevron icon in connection cards.

### Why

The chevron icons are visual indicators used to suggest navigation or expansion. The surrounding button content already communicates the purpose of the interaction, so exposing these icons to assistive technologies provides no additional value and can create unnecessary screen reader noise.

### Testing

* Ran `npm run lint`
* Verified changes are limited to decorative chevron icons
* No functional behavior changes
