### PR TITLE
test(test-helpers): cover GET request headers

### DIFF
--- a/hushh-webapp/__tests__/utils/test-helpers-get.test.ts
+++ b/hushh-webapp/__tests__/utils/test-helpers-get.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { createMockGET } from "./test-helpers";
+
+describe("createMockGET", () => {
+  it("preserves custom headers on GET requests", () => {
+    const request = createMockGET(
+      "/api/test",
+      { q: "hello" },
+      { Authorization: "Bearer test-token" },
+    );
+
+    expect(request.method).toBe("GET");
+    expect(request.nextUrl.pathname).toBe("/api/test");
+    expect(request.nextUrl.searchParams.get("q")).toBe("hello");
+    expect(request.headers.get("Authorization")).toBe("Bearer test-token");
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit test coverage for the `createMockGET` helper to verify that custom request headers are preserved correctly.

## Changes Made

* Added `__tests__/utils/test-helpers-get.test.ts`
* Verified that `createMockGET()` creates a GET request with the expected pathname
* Verified that query parameters are applied correctly
* Verified that custom headers are preserved on the generated request

## Testing

```bash
npx vitest run __tests__/utils/test-helpers-get.test.ts
```

## Result

The new test validates that GET request helpers correctly handle query parameters and custom headers, helping prevent regressions in API route test utilities.
