### PR TITLE
fix(kai): hide decorative prompt icons in preview views

### DIFF
--- a/hushh-webapp/components/kai/views/kai-connect-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-connect-preview-view.tsx
@@ -341,7 +341,7 @@ function KaiSheet({
       <div className="mx-auto mt-[9px] h-[5px] w-9 rounded-full bg-[color:var(--one-fg3)]/35" />
       <header className="flex items-center gap-[11px] border-b border-[color:var(--one-line)] px-[18px] pb-3 pt-3">
         <span className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[color:var(--one-blue)] text-white">
-          <Bot className="h-4 w-4" />
+          <Bot aria-hidden="true" className="h-4 w-4" />
         </span>
         <span className="min-w-0 flex-1">
           <b className="block text-[17px] font-semibold text-[color:var(--one-fg)]">Kai</b>
@@ -710,7 +710,7 @@ export function KaiConnectPreviewView() {
             className={cn(connectGlassClassName, "mt-4 flex w-full items-center gap-[11px] rounded-2xl px-3.5 py-3 text-left transition-transform active:scale-[0.99]")}
           >
             <span className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-[color:var(--one-blue)] text-white">
-              <Bot className="h-4 w-4" />
+              <Bot aria-hidden="true" className="h-4 w-4" />
             </span>
             <span className="min-w-0 flex-1 text-[13px] leading-snug text-[color:var(--one-fg)]">
               <b className="font-semibold">Kai:</b> I compared all five against your portfolio - ask me why Emily fits best.

--- a/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
@@ -852,7 +852,7 @@ function OneMarketKaiSheet({
       <div className="mx-auto mt-2.5 h-[5px] w-9 rounded-full bg-[color:var(--one-fg3)] opacity-35" />
       <header className="flex items-center gap-3 border-b border-[color:var(--one-line)] px-[18px] pb-3 pt-3">
         <span className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[color:var(--one-blue)] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.30)]">
-          <Bot className="h-4 w-4" />
+          <Bot aria-hidden="true" className="h-4 w-4" />
         </span>
         <span className="min-w-0 flex-1">
           <b className="block text-[17px] font-semibold text-[color:var(--one-fg)]">Kai</b>
@@ -2127,12 +2127,12 @@ export function KaiMarketPreviewView() {
             className={cn(oneMarketGlassClassName, "mt-[22px] flex w-full items-center gap-[11px] rounded-2xl px-4 py-3.5 text-left transition-transform active:scale-[0.99]")}
           >
             <span className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-[color:var(--one-blue)] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.30)]">
-              <Bot className="h-4 w-4" />
+              <Bot aria-hidden="true" className="h-4 w-4" />
             </span>
             <span className="min-w-0 flex-1 text-[13px] leading-snug text-[color:var(--one-fg)]">
               <b className="font-semibold">Kai:</b> {kaiStripText}
             </span>
-            <ChevronRight className="h-[15px] w-[15px] shrink-0 text-[color:var(--one-fg3)]" />
+            <ChevronRight aria-hidden="true" className="h-[15px] w-[15px] shrink-0 text-[color:var(--one-fg3)]" />
           </button>
         </div>
 


### PR DESCRIPTION
## Summary

Hide decorative Kai prompt icons from assistive technologies in preview views.

### Changes

* Added `aria-hidden="true"` to decorative `Bot` icons in Kai preview sheets and prompt cards.
* Added `aria-hidden="true"` to the decorative `ChevronRight` icon used in the Kai market prompt card.

### Why

These icons are purely visual enhancements and do not convey information beyond the surrounding text content. Hiding them from assistive technologies reduces unnecessary screen reader announcements and improves accessibility.

### Testing

* Ran `npm run lint`
* Verified changes are limited to decorative icons
* No functional behavior changes
