### PR TITLE
test(test-helpers): cover POST request content type

### DIFF
--- a/hushh-webapp/__tests__/utils/test-helpers-post.test.ts
+++ b/hushh-webapp/__tests__/utils/test-helpers-post.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { createMockPOST } from "./test-helpers";
+
+describe("createMockPOST", () => {
+  it("sets json content type for post requests", () => {
+    const request = createMockPOST("/api/test", {
+      name: "gracy",
+    });
+
+    expect(request.method).toBe("POST");
+    expect(request.headers.get("content-type")).toContain(
+      "application/json",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit test coverage for the `createMockPOST` helper to verify that JSON requests are configured correctly.

## Changes Made

* Added `__tests__/utils/test-helpers-post.test.ts`
* Verified that `createMockPOST()` creates a POST request
* Verified that the helper automatically sets the `Content-Type` header to `application/json` when a request body is provided
* Extended coverage for request utility behavior used across API route tests

## Testing

```bash
npx vitest run __tests__/utils/test-helpers-post.test.ts
```

## Result

The new test confirms that POST request helpers correctly configure JSON request headers, helping prevent regressions in API route testing utilities and ensuring consistent request construction.
