### PR TITLE
fix(profile): hide decorative chevrons in pkm tree view

### DIFF
--- a/hushh-webapp/components/profile/pkm-tree-view.tsx
+++ b/hushh-webapp/components/profile/pkm-tree-view.tsx
@@ -103,9 +103,9 @@ function JsonNode({
             </p>
           </div>
           {open ? (
-            <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <ChevronDown  aria-hidden="true" className="h-4 w-4 shrink-0 text-muted-foreground" />
           ) : (
-            <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <ChevronRight aria-hidden="true" className="h-4 w-4 shrink-0 text-muted-foreground" />
           )}
         </CollapsibleTrigger>
         <CollapsibleContent className="px-3 pb-3">
@@ -172,9 +172,9 @@ function ManifestNode({
             </p>
           </div>
           {open ? (
-            <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <ChevronDown aria-hidden="true" className="h-4 w-4 shrink-0 text-muted-foreground" />
           ) : (
-            <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <ChevronRight aria-hidden="true" className="h-4 w-4 shrink-0 text-muted-foreground" />
           )}
         </CollapsibleTrigger>
         <CollapsibleContent className="px-3 pb-3">


### PR DESCRIPTION
## Summary

Hide decorative chevron icons from assistive technologies in the PKM tree view.

### Changes

* Added `aria-hidden="true"` to decorative `ChevronDown` icons used in expandable tree sections.
* Added `aria-hidden="true"` to decorative `ChevronRight` icons used in collapsed tree sections.

### Why

The expand/collapse state is already communicated by the collapsible trigger and its associated content. These chevron icons are purely visual indicators and do not provide additional semantic information for screen reader users.

### Testing

* Ran `npm run lint`
* Verified changes are limited to decorative icons
* No functional behavior changes
