### PR TITLE
test(test-helpers): cover POST request body

### DIFF
--- a/hushh-webapp/__tests__/utils/test-helpers-post-body.test.ts
+++ b/hushh-webapp/__tests__/utils/test-helpers-post-body.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { createMockPOST } from "./test-helpers";
+
+describe("createMockPOST", () => {
+  it("serializes request body as json", async () => {
+    const request = createMockPOST("/api/test", {
+      name: "gracy",
+      role: "tester",
+    });
+
+    await expect(request.json()).resolves.toEqual({
+      name: "gracy",
+      role: "tester",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit test coverage for the `createMockPOST` helper to verify that request bodies are serialized and exposed correctly.

## Changes Made

* Added `__tests__/utils/test-helpers-post-body.test.ts`
* Verified that `createMockPOST()` serializes the provided payload as JSON
* Verified that the request body can be parsed back using `request.json()`
* Extended coverage for API route testing utilities

## Testing

```bash
npx vitest run __tests__/utils/test-helpers-post-body.test.ts
```

## Result

The new test confirms that POST request helpers correctly serialize request payloads and preserve the expected body structure, helping prevent regressions in API route test infrastructure.
