### PR TITLE
fix(kai): hide decorative chevron icon in investments view

### DIFF
--- a/hushh-webapp/components/kai/views/investments-master-view.tsx
+++ b/hushh-webapp/components/kai/views/investments-master-view.tsx
@@ -1012,7 +1012,7 @@ export function InvestmentsMasterView({
                       Analyze
                     </Button>
                   ) : (
-                    <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                    <ChevronRight aria-hidden="true" className="h-4 w-4 text-muted-foreground" />
                   )}
                 </div>
               }


### PR DESCRIPTION
## Summary

Hide a decorative chevron icon from assistive technologies in the investments master view.

### Changes

* Added `aria-hidden="true"` to the decorative `ChevronRight` icon displayed for non-analyzable holdings.

### Why

The chevron icon is a visual affordance only and does not provide meaningful information beyond the surrounding content. Hiding it from assistive technologies reduces unnecessary screen reader announcements and improves accessibility.

### Testing

* Ran `npm run lint`
* Verified the change is limited to a decorative icon
* No functional behavior changes
