### PR TITLE
test(test-helpers): cover GET request query params

### DIFF
--- a/hushh-webapp/__tests__/utils/test-helpers-get-query.test.ts
+++ b/hushh-webapp/__tests__/utils/test-helpers-get-query.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { createMockGET } from "./test-helpers";
+
+describe("createMockGET", () => {
+  it("applies multiple query params to the request url", () => {
+    const request = createMockGET("/api/search", {
+      q: "vault",
+      page: "2",
+    });
+
+    expect(request.method).toBe("GET");
+    expect(request.nextUrl.pathname).toBe("/api/search");
+    expect(request.nextUrl.searchParams.get("q")).toBe("vault");
+    expect(request.nextUrl.searchParams.get("page")).toBe("2");
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit test coverage for the `createMockGET` helper to verify that query parameters are correctly applied to generated request URLs.

## Changes Made

* Added `__tests__/utils/test-helpers-get-query.test.ts`
* Verified that `createMockGET()` preserves the request pathname
* Verified that multiple query parameters are appended to the request URL
* Verified that query parameter values can be retrieved through `searchParams`

## Testing

```bash
npx vitest run __tests__/utils/test-helpers-get-query.test.ts
```

## Result

The new test confirms that GET request helpers correctly construct URLs with query parameters, helping prevent regressions in API route test utilities and ensuring consistent request generation behavior.
