### PR TITLE
fix(consent): hide decorative search icon from assistive technology

### DIFF
--- a/hushh-webapp/components/consent/consent-center-page.tsx
+++ b/hushh-webapp/components/consent/consent-center-page.tsx
@@ -1149,7 +1149,7 @@ export function ConsentCenterPage() {
             <SettingsGroup embedded>
               <div className="px-4 py-4">
                 <div className="relative">
-                  <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <Search aria-hidden="true" className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                   <Input
                     value={searchValue}
                     onChange={(event) => {


### PR DESCRIPTION
## Summary

Hide a decorative search icon from assistive technologies in the consent center search field.

### Changes

* Added `aria-hidden="true"` to the decorative `Search` icon displayed inside the consent center search input.

### Why

The search input already provides the necessary context and functionality for users. The search icon is purely visual and does not convey additional semantic information. Hiding it from assistive technologies reduces unnecessary screen reader announcements and improves accessibility.

### Testing

* Ran `npm run lint`
* Verified the change is limited to a decorative icon
* No functional behavior changes
