### PR TITLE
fix(kai): hide decorative search icons in market list

### DIFF
--- a/hushh-webapp/components/kai/cards/renaissance-market-list.tsx
+++ b/hushh-webapp/components/kai/cards/renaissance-market-list.tsx
@@ -396,7 +396,7 @@ export function RiaPicksList({
                 {activeMobileControl === "search" ? (
                   <SurfaceInset className="px-3 py-3">
                     <div className="relative">
-                      <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                      <Search aria-hidden="true" className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                       <Input
                         value={query}
                         onChange={(event) => setQuery(event.target.value)}
@@ -542,7 +542,7 @@ export function RiaPicksList({
               <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_180px]">
                 <MarketListControlField label="Search">
                   <div className="relative">
-                    <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                    <Search aria-hidden="true" className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                     <Input
                       value={query}
                       onChange={(event) => setQuery(event.target.value)}


### PR DESCRIPTION
## Summary

Hide decorative search icons from assistive technologies in the Renaissance market list search controls.

### Changes

* Added `aria-hidden="true"` to the mobile search field icon.
* Added `aria-hidden="true"` to the desktop search field icon.

### Why

The search inputs already provide the necessary context and functionality. These icons are purely visual indicators and do not convey additional semantic information. Hiding them from assistive technologies reduces unnecessary screen reader announcements and improves accessibility.

### Testing

* Ran `npm run lint`
* Verified the change is limited to decorative icons
* No functional behavior changes
