### PR TITLE
test(vault): cover unknown vault ownership state

### DIFF
--- a/hushh-webapp/__tests__/utils/vault-access-policy.test.ts
+++ b/hushh-webapp/__tests__/utils/vault-access-policy.test.ts
@@ -55,4 +55,21 @@ describe("vault access policy", () => {
       needsUnlock: false,
     });
   });
+  it("treats unknown vault ownership as unavailable until resolved", () => {
+  expect(
+    resolveVaultAvailabilityState({
+      hasVault: null,
+      isVaultUnlocked: false,
+      vaultKey: null,
+      vaultOwnerToken: null,
+    }),
+  ).toMatchObject({
+   hasVault: false,
+    vaultUnknown: true,
+    needsVaultCreation: false,
+    needsUnlock: false,
+    canReadSecureData: false,
+    canMutateSecureData: false,
+  });
+});
 });


### PR DESCRIPTION
## Summary

Adds unit test coverage for the vault access policy when vault ownership information is unavailable or unresolved.

## Changes Made

* Added a test case to `__tests__/utils/vault-access-policy.test.ts`
* Verified behavior when vault ownership status is unknown
* Confirmed that unresolved vault state is treated as unavailable for secure data access
* Verified that secure read and mutation capabilities remain disabled until vault ownership is resolved

## Testing

```bash
npx vitest run __tests__/utils/vault-access-policy.test.ts
```

## Result

The new test validates handling of unknown vault ownership scenarios and helps prevent regressions in vault availability state resolution. This improves confidence that secure capabilities remain restricted when vault status cannot yet be determined.
