### PR TITLE
test(feature-flags): cover flag disabled by default when env missing

### DIFF
--- a/hushh-webapp/__tests__/lib/feature-flags.test.ts
+++ b/hushh-webapp/__tests__/lib/feature-flags.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getVoiceV2Flags } from "@/lib/voice/voice-feature-flags";
+
+describe("feature flags", () => {
+  const ORIGINAL_SUBMIT_DEBUG_VISIBLE =
+    process.env.NEXT_PUBLIC_VOICE_V2_SUBMIT_DEBUG_VISIBLE;
+
+  afterEach(() => {
+    if (ORIGINAL_SUBMIT_DEBUG_VISIBLE === undefined) {
+      delete process.env.NEXT_PUBLIC_VOICE_V2_SUBMIT_DEBUG_VISIBLE;
+    } else {
+      process.env.NEXT_PUBLIC_VOICE_V2_SUBMIT_DEBUG_VISIBLE =
+        ORIGINAL_SUBMIT_DEBUG_VISIBLE;
+    }
+  });
+
+  it("keeps submit debug flag disabled by default when env is missing", () => {
+    delete process.env.NEXT_PUBLIC_VOICE_V2_SUBMIT_DEBUG_VISIBLE;
+
+    expect(getVoiceV2Flags().submitDebugVisible).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add feature flag coverage for the missing-env default path.
- Verify the submit debug flag stays disabled when its env variable is absent.

## Scope Proof
- Test file added: `hushh-webapp/__tests__/lib/feature-flags.test.ts`.
- No feature flag implementation, voice runtime, or caller behavior changed.

## Caller Proof
- The test deletes `NEXT_PUBLIC_VOICE_V2_SUBMIT_DEBUG_VISIBLE`.
- It verifies `getVoiceV2Flags().submitDebugVisible` remains `false`.

## Validation
- `npx.cmd vitest run __tests__/lib/feature-flags.test.ts`
- `npx.cmd eslint __tests__/lib/feature-flags.test.ts --max-warnings=0`
- Verified the commit includes a DCO `Signed-off-by` trailer.
