### PR TITLE
test(checkbox): cover aria-checked reflects controlled state

### DIFF
--- a/hushh-webapp/__tests__/ui/checkbox.test.tsx
+++ b/hushh-webapp/__tests__/ui/checkbox.test.tsx
@@ -17,4 +17,15 @@ describe("Checkbox", () => {
       container.querySelector('[data-slot="checkbox-indicator"]'),
     ).toBeTruthy();
   });
+
+  it("reflects controlled checked state with aria-checked", () => {
+    const { container, rerender } = render(<Checkbox checked={false} />);
+    const checkbox = container.querySelector('[data-slot="checkbox"]');
+
+    expect(checkbox?.getAttribute("aria-checked")).toBe("false");
+
+    rerender(<Checkbox checked />);
+
+    expect(checkbox?.getAttribute("aria-checked")).toBe("true");
+  });
 });


### PR DESCRIPTION
## Summary
- Add checkbox coverage for controlled checked state.
- Verify `aria-checked` reflects controlled rerenders.

## Scope Proof
- Test file touched: `hushh-webapp/__tests__/ui/checkbox.test.tsx`.
- Appended one focused `it()` block to the existing checkbox describe.
- No checkbox implementation, styling, or caller behavior changed.

## Caller Proof
- The test renders `Checkbox` with `checked={false}` and verifies `aria-checked="false"`.
- It rerenders with `checked` and verifies `aria-checked="true"`.

## Validation
- `npx.cmd vitest run __tests__/ui/checkbox.test.tsx`
- `npx.cmd eslint __tests__/ui/checkbox.test.tsx --max-warnings=0`
- Verified the commit includes a DCO `Signed-off-by` trailer.
