### PR TITLE
fix(ui): add explicit button type to one location notification action

### DIFF
--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -1565,6 +1565,7 @@ function OneLocationAgentPageContent() {
             </p>
           </div>
           <button
+            type="button"
             onClick={() => {
               toast.dismiss(toastKey);
               openLocationShareFromNotification(grant.id);
@@ -1655,6 +1656,7 @@ function OneLocationAgentPageContent() {
               router.push(routeHref, { scroll: false });
               focusOneLocationSection(section);
             }}
+            type="button"
             className="rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background transition-colors"
           >
             Open


### PR DESCRIPTION
## Summary
- Add explicit `type="button"` to One Location notification toast action buttons.
- Prevent those actions from ever defaulting to submit behavior if rendered near a form context.

## Scope Proof
- Runtime file touched: `hushh-webapp/app/one/location/page.tsx`.
- Only One Location notification toast action `<button>` elements changed.
- No notification routing, toast timing, grant opening, or section focus behavior changed.

## Caller Proof
- Both buttons already use `onClick` handlers for navigation/opening behavior.
- Adding `type="button"` preserves the click behavior while making the button semantics explicit.

## Validation
- `npx.cmd eslint app/one/location/page.tsx --max-warnings=0`
- Verified the commit includes a DCO `Signed-off-by` trailer.
