### PR TITLE
fix(ui): hide consent center search icon from assistive technology

### DIFF
--- a/hushh-webapp/components/consent/consent-center-page.tsx
+++ b/hushh-webapp/components/consent/consent-center-page.tsx
@@ -1149,7 +1149,7 @@ export function ConsentCenterPage() {
             <SettingsGroup embedded>
               <div className="px-4 py-4">
                 <div className="relative">
-                  <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <Search aria-hidden="true" className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                   <Input
                     value={searchValue}
                     onChange={(event) => {


### PR DESCRIPTION
## Summary
- Hide the decorative consent center search icon from assistive technology.
- Keep the search input placeholder and value behavior unchanged.

## Scope Proof
- Runtime file touched: `hushh-webapp/components/consent/consent-center-page.tsx`.
- Only the search field `Search` SVG changed.
- No consent list filtering, routing query params, tabs, or data loading behavior changed.

## Caller Proof
- The icon is purely visual and sits beside the searchable input.
- Marking it `aria-hidden="true"` removes decorative icon noise while preserving the input as the accessible control.

## Validation
- `npx.cmd eslint components/consent/consent-center-page.tsx --max-warnings=0`
- Verified the commit includes a DCO `Signed-off-by` trailer.
