### PR TITLE
fix(ui): hide consent inbox loading spinner from assistive technology

### DIFF
--- a/hushh-webapp/components/consent/consent-inbox-dropdown.tsx
+++ b/hushh-webapp/components/consent/consent-inbox-dropdown.tsx
@@ -247,7 +247,7 @@ export function ConsentInboxDropdown({
               </p>
             </div>
             {summaryResource.loading || summaryResource.refreshing ? (
-              <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" />
+              <Loader2 aria-hidden="true" className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" />
             ) : null}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Hide the decorative consent inbox loading spinner from assistive technology.
- Keep the visible loading copy as the accessible loading cue.

## Scope Proof
- Runtime file touched: `hushh-webapp/components/consent/consent-inbox-dropdown.tsx`.
- Only the `Loader2` spinner in the consent inbox loading state changed.
- No consent inbox loading, cache, pending list, dropdown, or navigation behavior changed.

## Caller Proof
- The spinner appears next to visible text: `Loading pending consents…`.
- Marking the SVG `aria-hidden="true"` removes decorative icon noise while preserving the text cue.

## Validation
- `npx.cmd eslint components/consent/consent-inbox-dropdown.tsx --max-warnings=0`
- Verified the commit includes a DCO `Signed-off-by` trailer.
