### PR TITLE
test(api-config): cover base url fallback when env is undefined

### DIFF
--- a/hushh-webapp/__tests__/lib/api-config.test.ts
+++ b/hushh-webapp/__tests__/lib/api-config.test.ts
@@ -1,0 +1,21 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const ORIGINAL_ENV = process.env;
+
+describe("API_CONFIG", () => {
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.resetModules();
+  });
+
+  it("uses development base url fallback when backend env is undefined", async () => {
+    process.env = { ...ORIGINAL_ENV };
+    process.env.NEXT_PUBLIC_APP_ENV = "development";
+    delete process.env.NEXT_PUBLIC_BACKEND_URL;
+    vi.resetModules();
+
+    const { API_CONFIG } = await import("@/lib/constants");
+
+    expect(API_CONFIG.BASE_URL).toBe("http://127.0.0.1:8000");
+  });
+});


### PR DESCRIPTION
## Summary
- Add coverage for `API_CONFIG.BASE_URL` when `NEXT_PUBLIC_BACKEND_URL` is undefined.
- Assert the development fallback resolves to `http://127.0.0.1:8000`.

## Scope Proof
- Test file touched: `hushh-webapp/__tests__/lib/api-config.test.ts`.
- Runtime code was not changed.
- The test dynamically imports `@/lib/constants` after setting environment values so module-level resolution is exercised directly.

## Caller Proof
- `API_CONFIG.BASE_URL` is consumed as the shared backend base URL constant.
- This test only covers the existing fallback branch where the backend URL env var is absent and `NEXT_PUBLIC_APP_ENV` is `development`.

## Validation
- `npx.cmd vitest run __tests__/lib/api-config.test.ts`
- `npx.cmd eslint __tests__/lib/api-config.test.ts --max-warnings=0`
- Verified the commit includes a DCO `Signed-off-by` trailer.
