### PR TITLE
test(timeout-config): cover zero timeout treated as immediate

### DIFF
--- a/hushh-webapp/__tests__/lib/timeout-config.test.ts
+++ b/hushh-webapp/__tests__/lib/timeout-config.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const ORIGINAL_ENV = process.env;
+
+describe("timeout config", () => {
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.resetModules();
+  });
+
+  it("treats zero consent timeout as immediate", async () => {
+    process.env = { ...ORIGINAL_ENV };
+    process.env.NEXT_PUBLIC_CONSENT_TIMEOUT_SECONDS = "0";
+    vi.resetModules();
+
+    const { API_TIMEOUTS, CONSENT_TIMEOUT_MS, CONSENT_TIMEOUT_SECONDS } =
+      await import("@/lib/constants");
+
+    expect(CONSENT_TIMEOUT_SECONDS).toBe(0);
+    expect(CONSENT_TIMEOUT_MS).toBe(0);
+    expect(API_TIMEOUTS.CONSENT_WAIT).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Add coverage for zero consent timeout configuration.
- Assert `NEXT_PUBLIC_CONSENT_TIMEOUT_SECONDS="0"` resolves to immediate timeout values.

## Scope Proof
- Test file touched: `hushh-webapp/__tests__/lib/timeout-config.test.ts`.
- Runtime code was not changed.
- The test dynamically imports `@/lib/constants` after setting the timeout env value so module-level constants are exercised directly.

## Caller Proof
- `CONSENT_TIMEOUT_SECONDS`, `CONSENT_TIMEOUT_MS`, and `API_TIMEOUTS.CONSENT_WAIT` are the exported timeout config values consumed by consent/API flows.
- This test covers only the existing zero-value branch and confirms it remains an explicit immediate timeout instead of falling back to the default.

## Validation
- `npx.cmd vitest run __tests__/lib/timeout-config.test.ts`
- `npx.cmd eslint __tests__/lib/timeout-config.test.ts --max-warnings=0`
- Verified the commit includes a DCO `Signed-off-by` trailer.
