### PR TITLE
fix(ui): hide consent audit timeline clock icon from assistive technology

### DIFF
--- a/hushh-webapp/components/consent/consent-audit-timeline.tsx
+++ b/hushh-webapp/components/consent/consent-audit-timeline.tsx
@@ -188,7 +188,7 @@ export function ConsentAuditTimeline({
               >
                 <div className="flex items-start gap-3">
                   <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-border/70 bg-background/80 text-muted-foreground">
-                    <Clock3 className="h-4 w-4" />
+                    <Clock3 aria-hidden="true" className="h-4 w-4" />
                   </div>
                   <div className="min-w-0 flex-1 space-y-1">
                     <div className="flex flex-wrap items-start justify-between gap-2">


### PR DESCRIPTION
## Summary
- Hide the decorative consent audit timeline clock icon from assistive technology.
- Keep the row aria label and visible timestamp as the accessible date cue.

## Scope Proof
- Runtime file touched: `hushh-webapp/components/consent/consent-audit-timeline.tsx`.
- Only the `Clock3` icon in the audit timeline row marker changed.
- No audit filtering, selection, labels, date formatting, or layout behavior changed.

## Caller Proof
- Each audit row already has an `aria-label` that includes the formatted event date.
- The visible timestamp is also rendered beside the icon, so hiding the SVG removes decorative noise without removing meaning.

## Validation
- `npx.cmd eslint components/consent/consent-audit-timeline.tsx --max-warnings=0`
- Verified the commit includes a DCO `Signed-off-by` trailer.
