### PR TITLE
fix(ui): hide agent chat copy status icons from assistive technology

### DIFF
--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -583,7 +583,11 @@ function AgentBubble({
                 aria-label={copied ? "Response copied" : "Copy response"}
                 title={copied ? "Copied" : "Copy response"}
               >
-                {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+                {copied ? (
+                  <Check aria-hidden="true" className="h-3.5 w-3.5" />
+                ) : (
+                  <Copy aria-hidden="true" className="h-3.5 w-3.5" />
+                )}
               </button>
               <button
                 type="button"


### PR DESCRIPTION
## Summary
- Hide the decorative agent chat copy status icons from assistive technology.
- Keep the copy button labels as the accessible copy/copy-complete state.

## Scope Proof
- Runtime file touched: `hushh-webapp/components/agent/agent-chat-workspace.tsx`.
- Only the `Check` and `Copy` icons inside the response copy button changed.
- No copy handling, response actions, feedback state, or chat behavior changed.

## Caller Proof
- The copy button already exposes `aria-label={copied ? "Response copied" : "Copy response"}`.
- Marking the swapped SVG icons `aria-hidden="true"` avoids duplicate decorative announcements while preserving the accessible button state.

## Validation
- `npx.cmd eslint components/agent/agent-chat-workspace.tsx --max-warnings=0`
- Verified the commit includes a DCO `Signed-off-by` trailer.
