### PR TITLE
test(tickers-router): cover search result limit enforcement

### DIFF
--- a/consent-protocol/tests/test_tickers.py
+++ b/consent-protocol/tests/test_tickers.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routes import tickers as tickers_module
+
+
+def test_search_result_limit_enforcement_forwards_max_limit(monkeypatch):
+    captured: dict[str, int | str] = {}
+
+    class FakeTickerCache:
+        loaded = True
+
+        def search(self, query: str, *, limit: int):
+            captured["query"] = query
+            captured["limit"] = limit
+            return [{"symbol": f"TICKER{i}"} for i in range(limit)]
+
+    monkeypatch.setattr(tickers_module, "ticker_cache", FakeTickerCache())
+
+    app = FastAPI()
+    app.include_router(tickers_module.router)
+    client = TestClient(app)
+
+    response = client.get("/api/tickers/search", params={"q": "AAPL", "limit": "100"})
+
+    assert response.status_code == 200
+    assert captured == {"query": "AAPL", "limit": 100}
+    assert len(response.json()) == 100


### PR DESCRIPTION
## Summary

- Add a focused ticker router test for accepted search result limit enforcement.
- Verify `limit=100` is forwarded to the loaded ticker cache search path.
- Assert the response returns exactly the capped number of search results.

## Validation

- `C:\Users\DIVYA\Downloads\hushh-research-main\hushh-research-1\consent-protocol\.venv\Scripts\python.exe -m pytest tests/test_tickers.py`

## Notes

- Local pre-commit could not run because it invokes the Windows Store `python3` shim, which fails with `Permission denied`; the focused protocol pytest passed in the project venv.
