### PR TITLE
fix(ui): hide agent pkm review panel action icons from assistive technology

### DIFF
--- a/hushh-webapp/components/agent/agent-pkm-review-panel.tsx
+++ b/hushh-webapp/components/agent/agent-pkm-review-panel.tsx
@@ -60,7 +60,7 @@ export function AgentPkmReviewPanel({
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="flex min-w-0 gap-2">
           <div className="mt-0.5 grid h-8 w-8 shrink-0 place-items-center rounded-full bg-primary/10 text-primary">
-            <Brain className="h-4 w-4" />
+            <Brain aria-hidden="true" className="h-4 w-4" />
           </div>
           <div className="min-w-0">
             <p className="font-medium text-foreground">Save to PKM?</p>
@@ -78,7 +78,7 @@ export function AgentPkmReviewPanel({
             onClick={onDismiss}
             disabled={saving}
           >
-            <X className="h-3.5 w-3.5" />
+            <X aria-hidden="true" className="h-3.5 w-3.5" />
             Skip
           </Button>
           <Button
@@ -88,7 +88,11 @@ export function AgentPkmReviewPanel({
             onClick={onSave}
             disabled={saving}
           >
-            {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Check className="h-3.5 w-3.5" />}
+            {saving ? (
+              <Loader2 aria-hidden="true" className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Check aria-hidden="true" className="h-3.5 w-3.5" />
+            )}
             Save
           </Button>
         </div>


### PR DESCRIPTION
## Summary

- Mark the decorative PKM review panel brain icon as hidden from assistive technology.
- Mark the Skip and Save action icons as decorative so the text labels remain the accessible names.
- Keep the loading spinner hidden from screen readers while the Save button text remains available.

## Validation

- `npx.cmd eslint components/agent/agent-pkm-review-panel.tsx --max-warnings=0`
