### PR TITLE
fix(ui): hide agent popover close icon from assistive technology

### DIFF
--- a/hushh-webapp/components/agent/agent-popover-provider.tsx
+++ b/hushh-webapp/components/agent/agent-popover-provider.tsx
@@ -772,7 +772,7 @@ function AgentPopoverWindowControls({
         aria-label="Close Agent"
         title="Close Agent"
       >
-        <X className="h-3.5 w-3.5" />
+        <X aria-hidden="true" className="h-3.5 w-3.5" />
       </Button>
     </div>
   );


### PR DESCRIPTION
## Summary

- Hide the decorative Agent popover close icon from assistive technology.
- Keep the Close Agent button label as the accessible name via the existing `aria-label`.

## Validation

- `npx.cmd eslint components/agent/agent-popover-provider.tsx --max-warnings=0`
