### PR TITLE
test(ria-picks): cover advisor package save failures

### DIFF
--- a/hushh-webapp/__tests__/app/ria/picks-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/picks-page.test.tsx
@@ -565,4 +565,63 @@ describe("RiaPicksPage", () => {
       );
     });
   });
+  it("shows an error toast when saving the advisor package fails", async () => {
+  mocks.useStaleResource.mockReturnValue(
+    buildResource({
+      data: {
+        package: {
+          top_picks: [
+            {
+              ticker: "NVDA",
+              company_name: "NVIDIA Corporation",
+              sector: "Technology",
+              tier: "ACE",
+              investment_thesis: "Compounding AI infrastructure demand",
+            },
+          ],
+          avoid_rows: [],
+          screening_sections: [
+            { section: "investable_requirements", rows: [] },
+            { section: "automatic_avoid_triggers", rows: [] },
+            { section: "the_math", rows: [] },
+          ],
+          package_note: null,
+        },
+      },
+    })
+  );
+
+  mocks.riaService.savePickPackage.mockRejectedValue(
+    new Error("Save failed")
+  );
+
+  render(<RiaPicksPage />);
+
+  fireEvent.click(screen.getByRole("button", { name: /my list/i }));
+  fireEvent.click(screen.getByRole("button", { name: /^edit$/i }));
+
+  expect(
+    await screen.findByText(
+      "SEC-backed tickers only. Company and sector map from the maintained symbol master."
+    )
+  ).toBeTruthy();
+
+  fireEvent.change(
+    screen.getAllByPlaceholderText(
+      "Why this name belongs in the live debate universe"
+    )[0]!,
+    {
+      target: {
+        value: "Compounding AI infrastructure demand with advisor overlay",
+      },
+    }
+  );
+
+  fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+  await waitFor(() => {
+    expect(mocks.riaService.savePickPackage).toHaveBeenCalled();
+    expect(mocks.toast.error).toHaveBeenCalledWith("Save failed");
+  });
+  });
 });


### PR DESCRIPTION
## Summary

* add coverage for advisor package save failures
* verify save errors surface through user-facing toast notifications
* preserve error handling behavior when advisor package saves fail

## Testing

npx vitest run **tests**/app/ria/picks-page.test.tsx