### PR TITLE
test(collapsible): add data-slot contract test

### DIFF
--- a/hushh-webapp/__tests__/ui/collapsible.test.tsx
+++ b/hushh-webapp/__tests__/ui/collapsible.test.tsx
@@ -1,0 +1,45 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+
+describe("Collapsible", () => {
+  it("renders root with data-slot='collapsible'", () => {
+    const { container } = render(
+      <Collapsible>
+        <CollapsibleTrigger>Toggle</CollapsibleTrigger>
+      </Collapsible>,
+    );
+
+    expect(container.querySelector('[data-slot="collapsible"]')).toBeTruthy();
+  });
+
+  it("renders trigger with data-slot='collapsible-trigger'", () => {
+    const { container } = render(
+      <Collapsible>
+        <CollapsibleTrigger>Toggle</CollapsibleTrigger>
+      </Collapsible>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="collapsible-trigger"]'),
+    ).toBeTruthy();
+  });
+
+  it("renders content with data-slot='collapsible-content' when open", () => {
+    const { container } = render(
+      <Collapsible defaultOpen>
+        <CollapsibleTrigger>Toggle</CollapsibleTrigger>
+        <CollapsibleContent>Body</CollapsibleContent>
+      </Collapsible>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="collapsible-content"]'),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract test coverage for the Collapsible primitive.

## What

Creates a new test file:

`__tests__/ui/collapsible.test.tsx`

The test verifies:

- `data-slot="collapsible"` renders on the root component
- `data-slot="collapsible-trigger"` renders on the trigger component
- `data-slot="collapsible-content"` renders when the component is opened using `defaultOpen`

## Why

The Collapsible primitive exposes stable `data-slot` contracts but currently has no dedicated contract test coverage.

This PR adds regression protection for those contracts and follows the same testing approach used across other UI primitive contract tests.

## Scope

- Test-only change
- New file only
- No production code modifications
- No runtime behavior changes
- No visual changes
- No accessibility changes

## Validation

- `npx vitest run __tests__/ui/collapsible.test.tsx`
- `npx tsc --noEmit`
- `npx eslint __tests__/ui/collapsible.test.tsx`

## Risk

Low.

This PR adds a single test file and does not modify any implementation code.