### PR TITLE
test(avatar): add data-slot contract test

### DIFF
--- a/hushh-webapp/__tests__/ui/avatar.test.tsx
+++ b/hushh-webapp/__tests__/ui/avatar.test.tsx
@@ -1,0 +1,97 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Avatar,
+  AvatarBadge,
+  AvatarFallback,
+  AvatarGroup,
+  AvatarGroupCount,
+} from "@/components/ui/avatar";
+
+describe("Avatar", () => {
+  it("renders root with data-slot='avatar'", () => {
+    const { container } = render(
+      <Avatar>
+        <AvatarFallback>JD</AvatarFallback>
+      </Avatar>,
+    );
+
+    expect(container.querySelector('[data-slot="avatar"]')).toBeTruthy();
+  });
+
+  it("defaults root to data-size='default'", () => {
+    const { container } = render(
+      <Avatar>
+        <AvatarFallback>JD</AvatarFallback>
+      </Avatar>,
+    );
+
+    const avatar = container.querySelector('[data-slot="avatar"]');
+
+    expect(avatar?.getAttribute("data-size")).toBe("default");
+  });
+
+  it("propagates size='lg' as data-size='lg'", () => {
+    const { container } = render(
+      <Avatar size="lg">
+        <AvatarFallback>JD</AvatarFallback>
+      </Avatar>,
+    );
+
+    const avatar = container.querySelector('[data-slot="avatar"]');
+
+    expect(avatar?.getAttribute("data-size")).toBe("lg");
+  });
+
+  it("renders fallback with data-slot='avatar-fallback'", () => {
+    const { container } = render(
+      <Avatar>
+        <AvatarFallback>JD</AvatarFallback>
+      </Avatar>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="avatar-fallback"]'),
+    ).toBeTruthy();
+  });
+
+  it("renders badge with data-slot='avatar-badge'", () => {
+    const { container } = render(
+      <Avatar>
+        <AvatarFallback>JD</AvatarFallback>
+        <AvatarBadge />
+      </Avatar>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="avatar-badge"]'),
+    ).toBeTruthy();
+  });
+
+  it("renders group with data-slot='avatar-group'", () => {
+    const { container } = render(
+      <AvatarGroup>
+        <Avatar>
+          <AvatarFallback>JD</AvatarFallback>
+        </Avatar>
+      </AvatarGroup>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="avatar-group"]'),
+    ).toBeTruthy();
+  });
+
+  it("renders group count with data-slot='avatar-group-count'", () => {
+    const { container } = render(
+      <AvatarGroup>
+        <AvatarGroupCount>+3</AvatarGroupCount>
+      </AvatarGroup>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="avatar-group-count"]'),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract test coverage for the Avatar component family.

## What

Creates a new test file:

`__tests__/ui/avatar.test.tsx`

The test verifies:

* `data-slot="avatar"` on the root component
* `data-size="default"` default behavior
* `data-size="lg"` size propagation
* `data-slot="avatar-fallback"`
* `data-slot="avatar-badge"`
* `data-slot="avatar-group"`
* `data-slot="avatar-group-count"`

## Scope Note

`AvatarImage` is intentionally excluded.

The Radix Avatar image primitive depends on browser image loading behavior that is not triggered naturally in JSDOM. Covering that path would require image-loading mocks and additional test setup, which is outside the scope of this additive contract test.

## Why

The Avatar family exposes multiple stable data-slot contracts but currently lacks dedicated contract test coverage.

This PR adds regression protection for those contracts while following the existing UI primitive contract test pattern used throughout the repository.

## Validation

* `npx vitest run __tests__/ui/avatar.test.tsx`
* `npx tsc --noEmit`
* `npx eslint __tests__/ui/avatar.test.tsx`

## Risk

Low.

* Test-only change
* New file only
* No production code modifications
* No runtime behavior changes
* No visual changes
* No accessibility changes
