### PR TITLE
test(empty): add data-slot contract test

### DIFF
--- a/hushh-webapp/__tests__/ui/empty.test.tsx
+++ b/hushh-webapp/__tests__/ui/empty.test.tsx
@@ -1,0 +1,87 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+
+describe("Empty", () => {
+  it("renders root with data-slot='empty'", () => {
+    const { container } = render(<Empty />);
+
+    expect(container.querySelector('[data-slot="empty"]')).toBeTruthy();
+  });
+
+  it("renders root with role='status'", () => {
+    const { container } = render(<Empty />);
+
+    const empty = container.querySelector('[data-slot="empty"]');
+
+    expect(empty?.getAttribute("role")).toBe("status");
+  });
+
+  it("renders header with data-slot='empty-header'", () => {
+    const { container } = render(
+      <Empty>
+        <EmptyHeader>Header</EmptyHeader>
+      </Empty>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="empty-header"]'),
+    ).toBeTruthy();
+  });
+
+  it("renders media with data-slot='empty-icon'", () => {
+    const { container } = render(
+      <Empty>
+        <EmptyMedia>Icon</EmptyMedia>
+      </Empty>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="empty-icon"]'),
+    ).toBeTruthy();
+  });
+
+  it("renders title with data-slot='empty-title'", () => {
+    const { container } = render(
+      <Empty>
+        <EmptyTitle>No results</EmptyTitle>
+      </Empty>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="empty-title"]'),
+    ).toBeTruthy();
+  });
+
+  it("renders description with data-slot='empty-description'", () => {
+    const { container } = render(
+      <Empty>
+        <EmptyDescription>Try again later</EmptyDescription>
+      </Empty>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="empty-description"]'),
+    ).toBeTruthy();
+  });
+
+  it("renders content with data-slot='empty-content'", () => {
+    const { container } = render(
+      <Empty>
+        <EmptyContent>Body</EmptyContent>
+      </Empty>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="empty-content"]'),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract test coverage for the Empty component family.

## What

Creates a new test file:

`__tests__/ui/empty.test.tsx`

The test verifies:

* `data-slot="empty"` on the root component
* `role="status"` on the root component
* `data-slot="empty-header"`
* `data-slot="empty-icon"`
* `data-slot="empty-title"`
* `data-slot="empty-description"`
* `data-slot="empty-content"`

## Why

The Empty component family exposes multiple stable data-slot contracts but currently lacks dedicated contract test coverage.

This PR adds regression protection for those contracts while following the established UI primitive contract-test pattern used throughout the repository.

## Validation

* `npx vitest run __tests__/ui/empty.test.tsx`
* `npx tsc --noEmit`
* `npx eslint __tests__/ui/empty.test.tsx`

## Risk

Low.

* Test-only change
* New file only
* No production code modifications
* No runtime behavior changes
* No visual changes
* No accessibility behavior changes
