### PR TITLE
test(kbd): add data-slot contract test

### DIFF
--- a/hushh-webapp/__tests__/ui/kbd.test.tsx
+++ b/hushh-webapp/__tests__/ui/kbd.test.tsx
@@ -1,0 +1,23 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Kbd, KbdGroup } from "@/components/ui/kbd";
+
+describe("Kbd", () => {
+  it("renders with data-slot='kbd'", () => {
+    const { container } = render(<Kbd>⌘</Kbd>);
+
+    expect(container.querySelector('[data-slot="kbd"]')).toBeTruthy();
+  });
+
+  it("renders group with data-slot='kbd-group'", () => {
+    const { container } = render(
+      <KbdGroup>
+        <Kbd>⌘</Kbd>
+        <Kbd>K</Kbd>
+      </KbdGroup>,
+    );
+
+    expect(container.querySelector('[data-slot="kbd-group"]')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract test coverage for the Kbd component family.

## What

Creates a new test file:

`__tests__/ui/kbd.test.tsx`

The test verifies:

* `data-slot="kbd"` renders on the Kbd component
* `data-slot="kbd-group"` renders on the KbdGroup component

## Why

The Kbd component family exposes stable data-slot contracts but currently lacks dedicated contract test coverage.

This PR adds regression protection for those contracts while following the existing UI primitive contract-test pattern used throughout the repository.

## Validation

* `npx vitest run __tests__/ui/kbd.test.tsx`
* `npx tsc --noEmit`
* `npx eslint __tests__/ui/kbd.test.tsx`

## Risk

Low.

* Test-only change
* New file only
* No production code modifications
* No runtime behavior changes
* No visual changes
* No accessibility changes
