### PR TITLE
test(pagination): add data-slot contract test

### DIFF
--- a/hushh-webapp/__tests__/ui/pagination.test.tsx
+++ b/hushh-webapp/__tests__/ui/pagination.test.tsx
@@ -1,0 +1,98 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+} from "@/components/ui/pagination";
+
+describe("Pagination", () => {
+  it("renders root with data-slot='pagination'", () => {
+    const { container } = render(
+      <Pagination>
+        <PaginationContent />
+      </Pagination>,
+    );
+
+    expect(container.querySelector('[data-slot="pagination"]')).toBeTruthy();
+  });
+
+  it("renders root with role='navigation' and aria-label='pagination'", () => {
+    const { container } = render(
+      <Pagination>
+        <PaginationContent />
+      </Pagination>,
+    );
+
+    const nav = container.querySelector('[data-slot="pagination"]');
+
+    expect(nav?.getAttribute("role")).toBe("navigation");
+    expect(nav?.getAttribute("aria-label")).toBe("pagination");
+  });
+
+  it("renders content with data-slot='pagination-content'", () => {
+    const { container } = render(
+      <Pagination>
+        <PaginationContent />
+      </Pagination>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="pagination-content"]'),
+    ).toBeTruthy();
+  });
+
+  it("renders item with data-slot='pagination-item'", () => {
+    const { container } = render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="#">1</PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="pagination-item"]'),
+    ).toBeTruthy();
+  });
+
+  it("renders link with data-slot='pagination-link' and data-active contract", () => {
+    const { container } = render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="#" isActive>
+              1
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+
+    const link = container.querySelector('[data-slot="pagination-link"]');
+
+    expect(link).toBeTruthy();
+    expect(link?.getAttribute("data-active")).toBe("true");
+  });
+
+  it("renders ellipsis with data-slot='pagination-ellipsis'", () => {
+    const { container } = render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationEllipsis />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="pagination-ellipsis"]'),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract test coverage for the Pagination component family.

## What

Creates a new test file:

`__tests__/ui/pagination.test.tsx`

The test verifies:

- `data-slot="pagination"` renders on the root
- Root accessibility contract (`role="navigation"` and `aria-label="pagination"`)
- `data-slot="pagination-content"`
- `data-slot="pagination-item"`
- `data-slot="pagination-link"`
- `data-active="true"` contract on active links
- `data-slot="pagination-ellipsis"`

## Why

Pagination exposes stable data-slot contracts but currently lacks dedicated contract test coverage.

This PR adds regression protection for those contracts while following the established UI primitive contract-test pattern used throughout the repository.

## Validation

- `npx vitest run __tests__/ui/pagination.test.tsx`
- `npx tsc --noEmit`
- `npx eslint __tests__/ui/pagination.test.tsx`

## Risk

Low.

- Test-only change
- New file only
- No production code modifications
- No runtime behavior changes
- No visual changes
- No accessibility behavior changes