### PR TITLE
test(dropdown-menu): add data-slot contract test

### DIFF
--- a/hushh-webapp/__tests__/ui/dropdown-menu.test.tsx
+++ b/hushh-webapp/__tests__/ui/dropdown-menu.test.tsx
@@ -1,0 +1,32 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  DropdownMenu,
+  DropdownMenuShortcut,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+describe("DropdownMenu", () => {
+  it("renders trigger with data-slot='dropdown-menu-trigger'", () => {
+    const { container } = render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+      </DropdownMenu>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="dropdown-menu-trigger"]'),
+    ).toBeTruthy();
+  });
+
+  it("renders shortcut with data-slot='dropdown-menu-shortcut'", () => {
+    const { container } = render(
+      <DropdownMenuShortcut>⌘K</DropdownMenuShortcut>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="dropdown-menu-shortcut"]'),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract test coverage for the always-rendered DropdownMenu slots.

## What

Creates a new test file:

`__tests__/ui/dropdown-menu.test.tsx`

The test verifies:

* `data-slot="dropdown-menu-trigger"`
* `data-slot="dropdown-menu-shortcut"`

## Why

`DropdownMenu` currently lacks dedicated contract test coverage.

The component architecture follows the same pattern as `Select`:

* `DropdownMenu` root is a Radix context provider and does not render a DOM node.
* Portal-rendered menu content is intentionally excluded from this test.
* Only stable, always-rendered, non-portal slots are asserted.

This keeps the test deterministic and aligned with existing UI primitive contract-test patterns.

## Scope

Included:

* `DropdownMenuTrigger`
* `DropdownMenuShortcut`

Excluded by design:

* `DropdownMenuContent`
* `DropdownMenuItem`
* `DropdownMenuLabel`
* `DropdownMenuSeparator`
* `DropdownMenuCheckboxItem`
* `DropdownMenuRadioItem`
* `DropdownMenuSub*`

These render through Radix portal/open-state behavior and are outside the scope of a minimal contract test.

## Validation

* `npx vitest run __tests__/ui/dropdown-menu.test.tsx`

## Risk

Low.

* Test-only change
* New file only
* No production code modifications
* No runtime behavior changes
* No visual changes
* No accessibility changes
