### PR TITLE
test(button-group): add data-slot contract test

### DIFF
--- a/hushh-webapp/__tests__/ui/button-group.test.tsx
+++ b/hushh-webapp/__tests__/ui/button-group.test.tsx
@@ -1,0 +1,32 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ButtonGroup } from "@/components/ui/button-group";
+
+describe("ButtonGroup", () => {
+  it("renders root with data-slot='button-group'", () => {
+    const { container } = render(<ButtonGroup>content</ButtonGroup>);
+
+    expect(
+      container.querySelector('[data-slot="button-group"]'),
+    ).toBeTruthy();
+  });
+
+  it("renders root with role='group'", () => {
+    const { container } = render(<ButtonGroup>content</ButtonGroup>);
+
+    const group = container.querySelector('[data-slot="button-group"]');
+
+    expect(group?.getAttribute("role")).toBe("group");
+  });
+
+  it("reflects an explicit orientation prop as data-orientation", () => {
+    const { container } = render(
+      <ButtonGroup orientation="vertical">content</ButtonGroup>,
+    );
+
+    const group = container.querySelector('[data-slot="button-group"]');
+
+    expect(group?.getAttribute("data-orientation")).toBe("vertical");
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract test coverage for the ButtonGroup component.

## What

Creates a new test file:

`__tests__/ui/button-group.test.tsx`

The test verifies:

* `data-slot="button-group"`
* `role="group"`
* Explicit `orientation` prop propagation via `data-orientation`

## Why

ButtonGroup exposes stable DOM contracts but currently lacks dedicated test coverage.

This PR adds regression protection for those contracts while keeping the scope intentionally minimal and deterministic.

## Scope

Included:

* ButtonGroup root
* data-slot contract
* role contract
* explicit orientation contract

Excluded:

* ButtonGroupText (no data-slot contract exists)
* ButtonGroupSeparator (delegates rendering to Separator)
* styling/classname assertions

## Validation

* `npx vitest run __tests__/ui/button-group.test.tsx`
* `npx tsc --noEmit`
* `npx eslint __tests__/ui/button-group.test.tsx`

## Risk

Low.

* Test-only change
* New file only
* No production code modifications
* No runtime behavior changes
* No visual changes
* No accessibility behavior changes
