### PR TITLE
test(carousel): add data-slot contract test

### DIFF
--- a/hushh-webapp/__tests__/ui/carousel.test.tsx
+++ b/hushh-webapp/__tests__/ui/carousel.test.tsx
@@ -1,0 +1,85 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+} from "@/components/ui/carousel";
+
+if (typeof globalThis.ResizeObserver === "undefined") {
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  // @ts-expect-error test-only polyfill
+  globalThis.ResizeObserver = ResizeObserverStub;
+}
+
+if (typeof globalThis.IntersectionObserver === "undefined") {
+  class IntersectionObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() {
+      return [];
+    }
+
+    readonly root = null;
+    readonly rootMargin = "";
+    readonly thresholds = [];
+  }
+
+  // @ts-expect-error test-only polyfill
+  globalThis.IntersectionObserver = IntersectionObserverStub;
+}
+
+describe("Carousel", () => {
+  it("renders root with carousel accessibility contract", () => {
+    const { container } = render(
+      <Carousel>
+        <CarouselContent>
+          <CarouselItem>Slide</CarouselItem>
+        </CarouselContent>
+      </Carousel>,
+    );
+
+    const root = container.querySelector('[data-slot="carousel"]');
+
+    expect(root).toBeTruthy();
+    expect(root?.getAttribute("role")).toBe("region");
+    expect(root?.getAttribute("aria-roledescription")).toBe("carousel");
+  });
+
+  it("renders content with data-slot='carousel-content'", () => {
+    const { container } = render(
+      <Carousel>
+        <CarouselContent>
+          <CarouselItem>Slide</CarouselItem>
+        </CarouselContent>
+      </Carousel>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="carousel-content"]'),
+    ).toBeTruthy();
+  });
+
+  it("renders item with slide contract", () => {
+    const { container } = render(
+      <Carousel>
+        <CarouselContent>
+          <CarouselItem>Slide</CarouselItem>
+        </CarouselContent>
+      </Carousel>,
+    );
+
+    const item = container.querySelector('[data-slot="carousel-item"]');
+
+    expect(item).toBeTruthy();
+    expect(item?.getAttribute("role")).toBe("group");
+    expect(item?.getAttribute("aria-roledescription")).toBe("slide");
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract test coverage for the Carousel component family.

## What

Creates a new test file:

`__tests__/ui/carousel.test.tsx`

The test verifies:

* `data-slot="carousel"`
* `role="region"`
* `aria-roledescription="carousel"`
* `data-slot="carousel-content"`
* `data-slot="carousel-item"`
* `role="group"`
* `aria-roledescription="slide"`

## Why

Carousel currently lacks dedicated contract test coverage.

This PR focuses only on stable, always-rendered contracts that exist immediately after mount and do not depend on user interaction, drag behavior, or carousel position.

## Scope

Included:

* Carousel root accessibility contract
* CarouselContent data-slot contract
* CarouselItem data-slot and slide accessibility contract

Excluded:

* CarouselPrevious
* CarouselNext
* Drag/scroll interactions
* Embla API behavior

## CI Note

Embla Carousel may access `ResizeObserver` during mount. A guarded test-local polyfill is included and only activates when `ResizeObserver` is unavailable.

## Validation

* `npx vitest run __tests__/ui/carousel.test.tsx`
* `npx tsc --noEmit`
* `npx eslint __tests__/ui/carousel.test.tsx`

## Risk

Low.

* Test-only change
* New file only
* No production code modifications
* No runtime behavior changes
* No visual changes
