### PR TITLE
test(field): add data-slot contract test

### DIFF
--- a/hushh-webapp/__tests__/ui/field.test.tsx
+++ b/hushh-webapp/__tests__/ui/field.test.tsx
@@ -1,0 +1,79 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldGroup,
+  FieldLegend,
+  FieldSet,
+  FieldTitle,
+} from "@/components/ui/field";
+
+describe("Field", () => {
+  it("renders root with data-slot='field' and role='group'", () => {
+    const { container } = render(<Field>content</Field>);
+
+    const field = container.querySelector('[data-slot="field"]');
+
+    expect(field).toBeTruthy();
+    expect(field?.getAttribute("role")).toBe("group");
+  });
+
+  it("defaults to data-orientation='vertical'", () => {
+    const { container } = render(<Field>content</Field>);
+
+    const field = container.querySelector('[data-slot="field"]');
+
+    expect(field?.getAttribute("data-orientation")).toBe("vertical");
+  });
+
+  it("renders FieldSet with data-slot='field-set'", () => {
+    const { container } = render(<FieldSet>content</FieldSet>);
+
+    expect(container.querySelector('[data-slot="field-set"]')).toBeTruthy();
+  });
+
+  it("renders FieldLegend with data-slot='field-legend'", () => {
+    const { container } = render(<FieldLegend>Legend</FieldLegend>);
+
+    expect(
+      container.querySelector('[data-slot="field-legend"]'),
+    ).toBeTruthy();
+  });
+
+  it("renders FieldGroup with data-slot='field-group'", () => {
+    const { container } = render(<FieldGroup>content</FieldGroup>);
+
+    expect(
+      container.querySelector('[data-slot="field-group"]'),
+    ).toBeTruthy();
+  });
+
+  it("renders FieldContent with data-slot='field-content'", () => {
+    const { container } = render(<FieldContent>content</FieldContent>);
+
+    expect(
+      container.querySelector('[data-slot="field-content"]'),
+    ).toBeTruthy();
+  });
+
+  it("renders FieldTitle with data-slot='field-label'", () => {
+    const { container } = render(<FieldTitle>Title</FieldTitle>);
+
+    expect(
+      container.querySelector('[data-slot="field-label"]'),
+    ).toBeTruthy();
+  });
+
+  it("renders FieldDescription with data-slot='field-description'", () => {
+    const { container } = render(
+      <FieldDescription>Description</FieldDescription>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="field-description"]'),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Adds data-slot contract coverage for the Field component family.

## What this PR covers

* `Field` → `data-slot="field"`, `role="group"`, default `data-orientation="vertical"`
* `FieldSet` → `data-slot="field-set"`
* `FieldLegend` → `data-slot="field-legend"`
* `FieldGroup` → `data-slot="field-group"`
* `FieldContent` → `data-slot="field-content"`
* `FieldTitle` → `data-slot="field-label"`
* `FieldDescription` → `data-slot="field-description"`

## Scope

This PR focuses only on stable, always-rendered DOM contracts and avoids assertions tied to generated ids, conditional rendering paths, or implementation details.

## Risk

* Test-only change
* New file only
* No production code modifications
* No runtime, visual, or behavior changes
* No portal, animation, or interaction dependencies
