### PR TITLE
test(input-group): add data-slot contract test

### DIFF
--- a/hushh-webapp/__tests__/ui/input-group.test.tsx
+++ b/hushh-webapp/__tests__/ui/input-group.test.tsx
@@ -1,0 +1,40 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { InputGroup, InputGroupAddon } from "@/components/ui/input-group";
+
+describe("InputGroup", () => {
+  it("renders root with data-slot='input-group' and role='group'", () => {
+    const { container } = render(<InputGroup>content</InputGroup>);
+
+    const group = container.querySelector('[data-slot="input-group"]');
+
+    expect(group).toBeTruthy();
+    expect(group?.getAttribute("role")).toBe("group");
+  });
+
+  it("renders addon with data-slot='input-group-addon' and role='group'", () => {
+    const { container } = render(
+      <InputGroup>
+        <InputGroupAddon>icon</InputGroupAddon>
+      </InputGroup>,
+    );
+
+    const addon = container.querySelector('[data-slot="input-group-addon"]');
+
+    expect(addon).toBeTruthy();
+    expect(addon?.getAttribute("role")).toBe("group");
+  });
+
+  it("defaults addon to data-align='inline-start'", () => {
+    const { container } = render(
+      <InputGroup>
+        <InputGroupAddon>icon</InputGroupAddon>
+      </InputGroup>,
+    );
+
+    const addon = container.querySelector('[data-slot="input-group-addon"]');
+
+    expect(addon?.getAttribute("data-align")).toBe("inline-start");
+  });
+});


### PR DESCRIPTION
## Summary

Adds data-slot contract coverage for the InputGroup component family.

## What this PR covers

* `InputGroup` → `data-slot="input-group"` and `role="group"`
* `InputGroupAddon` → `data-slot="input-group-addon"` and `role="group"`
* Verifies the default `data-align="inline-start"` contract on `InputGroupAddon`

## Scope

This PR focuses only on self-contained, always-rendered DOM contracts.

Excluded components:

* `InputGroupText` — no `data-slot` contract exists
* `InputGroupButton` — wraps `Button`
* `InputGroupInput` and `InputGroupTextarea` — wrap other primitives and depend on implementation details outside this file

## Risk

* Test-only change
* New file only
* No production code modifications
* No runtime, visual, or behavior changes
* No portal, animation, or interaction dependencies
