### PR TITLE
test(sheet): cover data-slot contract parity

### DIFF
--- a/hushh-webapp/__tests__/ui/sheet.test.tsx
+++ b/hushh-webapp/__tests__/ui/sheet.test.tsx
@@ -4,6 +4,8 @@ import { describe, expect, it } from "vitest";
 import {
   Sheet,
   SheetContent,
+  SheetFooter,
+  SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
 
@@ -34,5 +36,24 @@ describe("SheetContent", () => {
     expect(
       screen.queryByRole("button", { name: /close/i }),
     ).toBeNull();
+  });
+});
+describe("SheetHeader", () => {
+  it("renders with data-slot='sheet-header'", () => {
+    const { container } = render(<SheetHeader>Header content</SheetHeader>);
+
+    expect(
+      container.querySelector('[data-slot="sheet-header"]'),
+    ).toBeTruthy();
+  });
+});
+
+describe("SheetFooter", () => {
+  it("renders with data-slot='sheet-footer'", () => {
+    const { container } = render(<SheetFooter>Footer content</SheetFooter>);
+
+    expect(
+      container.querySelector('[data-slot="sheet-footer"]'),
+    ).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

Extends `sheet.test.tsx` with data-slot contract coverage for `SheetHeader` and `SheetFooter`.

## What changed

* Added a test verifying `SheetHeader` renders `data-slot="sheet-header"`
* Added a test verifying `SheetFooter` renders `data-slot="sheet-footer"`
* Existing SheetContent tests remain unchanged

## Why

`SheetHeader` and `SheetFooter` are plain DOM wrappers that expose stable data-slot contracts but previously had no test coverage.

These components:

* Do not use portals
* Do not require interaction
* Do not depend on animation state
* Render deterministically in JSDOM

## Scope

Included:

* `SheetHeader`
* `SheetFooter`

Excluded:

* `sheet-content`
* `sheet-overlay`

Those elements are portal-rendered and intentionally remain outside the scope of this contract test update.

## Risk

* Test-only change
* Existing tests preserved
* No production code modifications
* No runtime, visual, or behavior changes
* No new dependencies
