### PR TITLE
test(dialog): cover data-slot contracts

### DIFF
--- a/hushh-webapp/__tests__/ui/dialog.test.tsx
+++ b/hushh-webapp/__tests__/ui/dialog.test.tsx
@@ -4,6 +4,8 @@ import { describe, expect, it } from "vitest";
 import {
   Dialog,
   DialogContent,
+  DialogFooter,
+  DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
 
@@ -30,5 +32,25 @@ describe("DialogContent", () => {
     );
 
     expect(screen.queryByRole("button", { name: /close/i })).toBeNull();
+  });
+});
+
+describe("DialogHeader", () => {
+  it("renders with data-slot='dialog-header'", () => {
+    const { container } = render(<DialogHeader>Header content</DialogHeader>);
+
+    expect(
+      container.querySelector('[data-slot="dialog-header"]'),
+    ).toBeTruthy();
+  });
+});
+
+describe("DialogFooter", () => {
+  it("renders with data-slot='dialog-footer'", () => {
+    const { container } = render(<DialogFooter>Footer content</DialogFooter>);
+
+    expect(
+      container.querySelector('[data-slot="dialog-footer"]'),
+    ).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

Extends `dialog.test.tsx` with data-slot contract coverage for `DialogHeader` and `DialogFooter`.

## What changed

* Added a test verifying `DialogHeader` renders `data-slot="dialog-header"`
* Added a test verifying `DialogFooter` renders `data-slot="dialog-footer"`
* Existing DialogContent tests remain unchanged

## Why

`DialogHeader` and `DialogFooter` are plain DOM wrappers that expose stable data-slot contracts but previously had no direct test coverage.

These components:

* Do not use portals
* Do not require interaction
* Do not depend on animation state
* Render deterministically in JSDOM

## Scope

Included:

* `DialogHeader`
* `DialogFooter`

Excluded:

* `dialog-content`
* `dialog-overlay`

Those elements are portal-rendered and intentionally remain outside the scope of this contract test update.

## Risk

* Test-only change
* Existing tests preserved
* No production code modifications
* No runtime, visual, or behavior changes
* No new dependencies
