### PR TITLE
test(alert-dialog): add data-slot contract test

### DIFF
--- a/hushh-webapp/__tests__/ui/alert-dialog.test.tsx
+++ b/hushh-webapp/__tests__/ui/alert-dialog.test.tsx
@@ -13,6 +13,22 @@ import {
 } from "@/components/ui/alert-dialog";
 
 describe("AlertDialogContent", () => {
+  
+  it("renders with data-slot='alert-dialog-content'", () => {
+    const { baseElement } = render(
+      <AlertDialog open>
+        <AlertDialogContent>
+          <AlertDialogTitle>Test</AlertDialogTitle>
+          <AlertDialogDescription>Description</AlertDialogDescription>
+        </AlertDialogContent>
+      </AlertDialog>,
+    );
+
+    expect(
+      baseElement.querySelector('[data-slot="alert-dialog-content"]'),
+    ).toBeTruthy();
+  });
+
   it("renders the cancel button", () => {
     render(
       <AlertDialog open>
@@ -49,5 +65,28 @@ describe("AlertDialogContent", () => {
     );
 
     expect(screen.getByRole("button", { name: /continue/i })).toBeTruthy();
+  });
+});
+describe("AlertDialogHeader", () => {
+  it("renders with data-slot='alert-dialog-header'", () => {
+    const { container } = render(
+      <AlertDialogHeader>Header content</AlertDialogHeader>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="alert-dialog-header"]'),
+    ).toBeTruthy();
+  });
+});
+
+describe("AlertDialogFooter", () => {
+  it("renders with data-slot='alert-dialog-footer'", () => {
+    const { container } = render(
+      <AlertDialogFooter>Footer content</AlertDialogFooter>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="alert-dialog-footer"]'),
+    ).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

Extends `alert-dialog.test.tsx` with data-slot contract coverage for `AlertDialogContent`, `AlertDialogHeader`, and `AlertDialogFooter`.

## What changed

* Added a test verifying `AlertDialogContent` renders `data-slot="alert-dialog-content"`
* Added a test verifying `AlertDialogHeader` renders `data-slot="alert-dialog-header"`
* Added a test verifying `AlertDialogFooter` renders `data-slot="alert-dialog-footer"`
* Existing AlertDialog tests remain unchanged

## Why

These components expose stable data-slot contracts but previously had no direct test coverage.

`AlertDialogHeader` and `AlertDialogFooter` are plain DOM wrappers that render deterministically in JSDOM.

`AlertDialogContent` renders through a portal, so the test uses `baseElement.querySelector(...)` to locate the rendered content reliably.

## Scope

Included:

* `AlertDialogContent`
* `AlertDialogHeader`
* `AlertDialogFooter`

Excluded:

* Overlay assertions
* Interaction behavior beyond existing tests

## Risk

* Test-only change
* Existing tests preserved
* No production code modifications
* No runtime, visual, or behavior changes
* No new dependencies
