### PR TITLE
fix(sidebar): add explicit type="button" to SidebarGroupAction

### DIFF
--- a/hushh-webapp/components/ui/sidebar.tsx
+++ b/hushh-webapp/components/ui/sidebar.tsx
@@ -424,6 +424,7 @@ function SidebarGroupAction({
 
   return (
     <Comp
+      type={asChild ? undefined : "button"}
       data-slot="sidebar-group-action"
       data-sidebar="group-action"
       className={cn(


### PR DESCRIPTION
## Summary

Adds an explicit `type="button"` to `SidebarGroupAction` to prevent unintended form submission when rendered inside a form.

## Problem

`SidebarGroupAction` renders a native `<button>` when `asChild={false}` (the default) but does not specify a `type` attribute.

Native buttons default to `type="submit"` inside forms, which can trigger accidental form submissions.

## Fix

Add:

```tsx
type={asChild ? undefined : "button"}
```

to the rendered element.

This matches the existing implementation pattern already used by:

* `SidebarMenuButton`
* `SidebarMenuAction`

within the same file.

## Why this is safe

* `asChild={true}` remains unchanged
* No visual changes
* No API changes
* No styling changes
* No runtime behavior changes outside form contexts
* Prevents accidental submissions when used inside forms

## Diff Size

* 1 file changed
* 1 line added

## Risk

Very low.

The change aligns `SidebarGroupAction` with the established button-type pattern already present elsewhere in `sidebar.tsx`.
