### PR TITLE
test(drawer): verify safe-area footer

### DIFF
--- a/hushh-webapp/__tests__/ui/drawer.test.tsx
+++ b/hushh-webapp/__tests__/ui/drawer.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   Drawer,
   DrawerContent,
+  DrawerFooter,
   DrawerTitle,
 } from "@/components/ui/drawer";
 
@@ -34,5 +35,21 @@ describe("DrawerContent", () => {
     expect(
       screen.queryByRole("button", { name: /close/i }),
     ).toBeNull();
+  });
+});
+
+describe("DrawerFooter", () => {
+  it("renders with data-slot='drawer-footer' and safe-area footer class", () => {
+    const { container } = render(<DrawerFooter />);
+
+    const footer = container.querySelector(
+      '[data-slot="drawer-footer"]',
+    );
+
+    expect(footer).toBeTruthy();
+
+    expect(footer?.className).toContain(
+      "env(safe-area-inset-bottom)",
+    );
   });
 });


### PR DESCRIPTION
## Summary

Adds coverage for the `DrawerFooter` contract.

## What changed

* Added a standalone `DrawerFooter` test
* Verifies `data-slot="drawer-footer"` is rendered
* Verifies the footer includes the safe-area padding class containing `env(safe-area-inset-bottom)`

## Why

`DrawerFooter` exposes a stable footer layout contract that includes safe-area padding support for devices with bottom insets. This test ensures the contract remains present.

## Scope

* Additive-only test change
* No production code modifications
* No interaction, animation, or layout assertions
* Existing tests preserved unchanged

## Risk

* Test-only change
* No runtime behavior changes
* No visual changes
* No new dependencies
