### PR TITLE
test(dialog): verify modal=false default

### DIFF
--- a/hushh-webapp/__tests__/ui/dialog.test.tsx
+++ b/hushh-webapp/__tests__/ui/dialog.test.tsx
@@ -32,3 +32,19 @@ describe("DialogContent", () => {
     expect(screen.queryByRole("button", { name: /close/i })).toBeNull();
   });
 });
+
+describe("Dialog", () => {
+  it("defaults to modal=false", () => {
+    render(
+      <Dialog open>
+        <DialogContent showCloseButton={false}>
+          <DialogTitle>Test dialog</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    const dialog = screen.getByRole("dialog");
+
+    expect(dialog.getAttribute("aria-modal")).not.toBe("true");
+  });
+});


### PR DESCRIPTION
## Summary

Adds coverage for the Dialog default modal contract.

## What changed

* Added a single test to `dialog.test.tsx`
* Verifies that Dialog does not render with `aria-modal="true"` when no `modal` prop is provided
* Existing tests remain unchanged

## Why

`Dialog` explicitly defaults `modal` to `false`.

This test verifies the corresponding DOM contract exposed by the rendered dialog element.

## Scope

* Additive-only test change
* No production code modifications
* No interaction, focus-management, keyboard, or portal behavior assertions
* Existing test coverage preserved

## Risk

* Test-only change
* No runtime behavior changes
* No visual changes
* No new dependencies
