### PR TITLE
test(select): cover decorative icon aria-hidden contract

### DIFF
--- a/hushh-webapp/__tests__/ui/select.test.tsx
+++ b/hushh-webapp/__tests__/ui/select.test.tsx
@@ -49,4 +49,20 @@ describe("Select", () => {
 
     expect(trigger?.getAttribute("data-size")).toBe("sm");
   });
+
+  it("renders the decorative trigger icon with aria-hidden='true'", () => {
+    const { container } = render(
+      <Select>
+        <SelectTrigger>
+          <SelectValue placeholder="Pick one" />
+        </SelectTrigger>
+      </Select>,
+    );
+
+    const icon = container.querySelector(
+      '[data-slot="select-trigger"] [aria-hidden="true"]',
+    );
+
+    expect(icon).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary

Adds a contract test verifying that the decorative icon rendered inside `SelectTrigger` is hidden from assistive technology via `aria-hidden="true"`.

## What changed

* Added a single test to `__tests__/ui/select.test.tsx`
* Verifies the closed trigger contains a decorative element with `aria-hidden="true"`

## Why

The trigger's chevron icon is decorative and intentionally excluded from the accessibility tree. This test protects that accessibility contract from accidental regressions.

## Scope

* Test-only change
* Single additive test
* No dropdown interaction
* No portal rendering
* No component source changes

## Risk

* Additive-only change
* No production code changes
* No runtime changes
* No visual changes
* No new dependencies
* Minimal diff size
* Low conflict risk
