### PR TITLE
test(accordion): cover decorative chevron aria-hidden contract

### DIFF
--- a/hushh-webapp/__tests__/ui/accordion.test.tsx
+++ b/hushh-webapp/__tests__/ui/accordion.test.tsx
@@ -98,4 +98,21 @@ describe("Accordion", () => {
     expect(items).toHaveLength(2);
     expect(triggers).toHaveLength(2);
   });
+
+  it("renders the decorative trigger icon with aria-hidden='true'", () => {
+    const { container } = render(
+      <Accordion type="single">
+        <AccordionItem value="item-1">
+          <AccordionTrigger>Trigger</AccordionTrigger>
+          <AccordionContent>Content</AccordionContent>
+        </AccordionItem>
+      </Accordion>,
+    );
+
+    const icon = container.querySelector(
+      '[data-slot="accordion-trigger"] [aria-hidden="true"]',
+    );
+
+    expect(icon).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary

Adds a contract test verifying that the decorative icon rendered by `AccordionTrigger` is hidden from assistive technology using `aria-hidden="true"`.

## What changed

* Added a single test to `__tests__/ui/accordion.test.tsx`
* Verifies the trigger contains a decorative element marked with `aria-hidden="true"`

## Why

The accordion chevron is decorative and intentionally excluded from the accessibility tree. This test helps prevent accidental regressions to that accessibility contract.

## Scope

* Test-only change
* Single additive test
* No expansion behavior tested
* No interaction testing
* No component source changes

## Risk

* Additive-only change
* No production code changes
* No runtime changes
* No visual changes
* No new dependencies
* Minimal diff size
* Low conflict risk
