### PR TITLE
test(utils): cover decimal amount boundaries in portfolio normalizer

### DIFF
--- a/hushh-webapp/__tests__/utils/portfolio-normalize.test.ts
+++ b/hushh-webapp/__tests__/utils/portfolio-normalize.test.ts
@@ -272,3 +272,26 @@ describe("portfolio normalizer - negative currency boundaries", () => {
     expect(consolidated[0].cost_basis).toBeCloseTo(-0.0001, 8);
   });
 });
+
+describe("portfolio normalizer - decimal amount boundaries", () => {
+  it("preserves sub-cent, negative-zero, and large safe decimal amount strings", () => {
+    const consolidated = consolidateHoldingsBySymbol([
+      {
+        symbol: "DEC",
+        name: "Decimal Boundary Holding",
+        quantity: "1",
+        market_value: "0.0000001",
+        cost_basis: "-0.00",
+        estimated_annual_income: "999999999.99",
+      },
+    ]);
+
+    expect(consolidated).toHaveLength(1);
+    expect(Number.isFinite(consolidated[0].market_value)).toBe(true);
+    expect(Number.isFinite(consolidated[0].cost_basis)).toBe(true);
+    expect(Number.isFinite(consolidated[0].estimated_annual_income)).toBe(true);
+    expect(consolidated[0].market_value).toBeCloseTo(0.0000001, 12);
+    expect(Object.is(consolidated[0].cost_basis, -0)).toBe(true);
+    expect(consolidated[0].estimated_annual_income).toBe(999999999.99);
+  });
+});


### PR DESCRIPTION
﻿## Overview
Adds focused decimal-boundary coverage to the existing portfolio normalization utility tests. The new assertion verifies that the production `consolidateHoldingsBySymbol` path preserves sub-cent values, negative-zero amount strings, and large safe decimal strings without producing `NaN` or losing precision.

## Canonical Attachment Plan
- Canonical frontend package: `hushh-webapp`
- Canonical runtime implementation: `hushh-webapp/lib/utils/portfolio-normalize.ts`
- Canonical test contract: `hushh-webapp/__tests__/utils/portfolio-normalize.test.ts`

## Impact
Low risk: this PR changes only an existing Vitest utility test file and introduces zero production runtime, frontend UI, backend, route, schema, or generated-contract mutations. High impact: it closes a pure data-invariant testing gap around decimal amount parsing before portfolio values reach user-facing review surfaces.

## Changes Cleared
- Covers sub-cent decimal amount string input: `0.0000001`.
- Covers negative-zero amount string input: `-0.00`.
- Covers large safe decimal amount string input: `999999999.99`.
- Asserts parsed values remain finite and preserve expected precision/sign behavior.

## Verification
- `npm run test:ci -- __tests__/utils/portfolio-normalize.test.ts` - passed, 12 tests
- `npm run typecheck` - passed
- `npm run verify:docs` - passed
- `npm run verify:service-boundary` - passed
