### PR TITLE
test(devex): verify workspace configuration file paths strictly exclude root backup files

### DIFF
--- a/hushh-webapp/__tests__/devex-config.test.ts
+++ b/hushh-webapp/__tests__/devex-config.test.ts
@@ -2,6 +2,18 @@ import { describe, expect, it } from "vitest";
 import packageJson from "../package.json";
 import tsconfig from "../tsconfig.json";
 
+function tsconfigIncludeMatches(pattern: string, filePath: string): boolean {
+  const normalizedPattern = pattern.replace(/\\/g, "/");
+  const normalizedPath = filePath.replace(/\\/g, "/");
+  const escaped = normalizedPattern.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+  const regexSource = escaped
+    .replace(/\/\*\*\//g, "(?:/.*)?/")
+    .replace(/\*\*/g, ".*")
+    .replace(/\*/g, "[^/]*");
+
+  return new RegExp(`^${regexSource}$`).test(normalizedPath);
+}
+
 describe("DevEx configuration integrity", () => {
   it("keeps the package typecheck script aligned with the TypeScript project config", () => {
     expect(packageJson.scripts.typecheck).toBe("tsc --noEmit");
@@ -12,5 +24,28 @@ describe("DevEx configuration integrity", () => {
     expect(tsconfig.include).toEqual(
       expect.arrayContaining(["app/**/*.ts", "lib/**/*.ts"]),
     );
+  });
+
+  it("keeps root backup files outside active TypeScript include scans", () => {
+    const backupFiles = [
+      "workspace.bak",
+      "workspace.swp",
+      ".DS_Store",
+      "app/page.ts.bak",
+      "lib/cache/cache-service.ts.swp",
+    ];
+
+    expect(tsconfig.include).toEqual(expect.any(Array));
+    expect(tsconfig.include).not.toEqual(
+      expect.arrayContaining(["*.bak", "*.swp", ".DS_Store"]),
+    );
+
+    for (const backupFile of backupFiles) {
+      const matchingIncludes = tsconfig.include.filter((pattern) =>
+        tsconfigIncludeMatches(pattern, backupFile),
+      );
+
+      expect(matchingIncludes, `${backupFile} must not match tsconfig.include`).toEqual([]);
+    }
   });
 });


### PR DESCRIPTION
﻿## Overview
Adds a focused DevEx configuration regression test for active TypeScript project include paths. The new assertion programmatically checks `tsconfig.include` and proves root backup artifacts such as `*.bak`, `*.swp`, and `.DS_Store` do not match the workspace scan paths.

## Canonical Attachment Plan
- Canonical frontend package: `hushh-webapp`
- Canonical active configuration: `hushh-webapp/tsconfig.json`
- Canonical test contract: `hushh-webapp/__tests__/devex-config.test.ts`

## Impact
Low risk: this PR updates only an existing Vitest DevEx configuration test and introduces zero production runtime, frontend UI, backend, route, schema, or generated-contract mutations. High impact: it protects repository health by locking temporary local backup artifacts out of active project scanning paths.

## Changes Cleared
- Parses the active `tsconfig.include` array from the real configuration file.
- Asserts backup glob patterns are not added to include paths.
- Simulates root and nested backup file names against the active include matcher.
- Confirms backup artifacts cannot be pulled into TypeScript project scans through config drift.

## Verification
- `npm run test:ci -- __tests__/devex-config.test.ts` - passed, 2 tests
- `npm run typecheck` - passed
- `npm run verify:docs` - passed
- `npm run verify:service-boundary` - passed
