### PR TITLE
test(services): cover malformed agent chat JSON payload handling

### DIFF
--- a/hushh-webapp/__tests__/services/agent-chat-client.test.ts
+++ b/hushh-webapp/__tests__/services/agent-chat-client.test.ts
@@ -244,6 +244,39 @@ describe("agent chat client", () => {
     expect(errors).toEqual(["Agent chat stream returned malformed data. Please retry."]);
   });
 
+  it.each([
+    ["unclosed object", '{"token":"unterminated"'],
+    ["unclosed nested array", '{"token":[[[[[[[[[[[[}'],
+    ["broken bracket payload", "[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[["],
+  ])("handles malformed %s SSE JSON without logging raw parser stacks", async (_label, payload) => {
+    vi.spyOn(ApiService, "streamAgentChat").mockResolvedValue(
+      sseResponse([
+        'event: start\ndata: {"conversation_id":"conversation-1","model":"gemini-2.5-pro"}\n\n',
+        `event: token\ndata: ${payload}\n\n`,
+      ])
+    );
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    const errors: string[] = [];
+
+    await expect(
+      streamAgentChat({
+        userId: "user-1",
+        message: "Hello",
+        vaultOwnerToken: "vault-token",
+        handlers: {
+          onError: (message) => errors.push(message),
+        },
+      })
+    ).rejects.toThrow("Agent chat stream returned malformed data. Please retry.");
+
+    expect(errors).toEqual(["Agent chat stream returned malformed data. Please retry."]);
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(consoleWarn).not.toHaveBeenCalled();
+    expect(consoleLog).not.toHaveBeenCalled();
+  });
+
   it("formats streamed runtime provider errors", async () => {
     vi.spyOn(ApiService, "streamAgentChat").mockResolvedValue(
       sseResponse([


### PR DESCRIPTION
## Overview
This PR adds focused coverage for malformed JSON payload handling in the existing agent chat streaming service contract. During the repo-backed premise check, `checkSafePayloadString` was not found as an existing helper, so the test is attached to the real production boundary: `streamAgentChat` in `hushh-webapp/lib/services/agent-chat-client.ts` and its existing private malformed SSE JSON parser path.

## Impact
- Test-only change in `hushh-webapp/__tests__/services/agent-chat-client.test.ts`
- No production code, frontend UI, backend route, schema, or capability surface mutations
- Verifies malformed, unclosed, and deeply broken SSE JSON payloads fail through the sanitized user-facing error path
- Ensures raw parser stacks or invalid payload details are not printed through console error/warn/log during this failure path

## Changes Cleared
- Added table-driven malformed JSON cases for unclosed object payloads, nested broken brackets, and invalid bracket-only payloads
- Asserted the existing sanitized error message remains stable
- Asserted console error, warn, and log paths remain silent for raw malformed parser details

## Verification
- `npm run test:ci -- __tests__/services/agent-chat-client.test.ts` passed
- `npm run typecheck` passed
- `npm run verify:docs` passed
- `npm run verify:service-boundary` passed