### PR TITLE
test(notifications-router): cover proxy path parameter boundary

### DIFF
--- a/consent-protocol/tests/test_notifications.py
+++ b/consent-protocol/tests/test_notifications.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routes import notifications
+
+
+def test_proxy_path_parameter_boundary_rejects_extra_segment(monkeypatch):
+    def _unexpected_auth(_auth_header: str | None):
+        raise AssertionError("extra proxy path segment should not reach auth")
+
+    monkeypatch.setattr(notifications, "verify_firebase_bearer", _unexpected_auth)
+
+    app = FastAPI()
+    app.include_router(notifications.router)
+    client = TestClient(app, raise_server_exceptions=False)
+
+    oversized_segment = "x" * 1025
+    response = client.post(f"/api/notifications/register/{oversized_segment}")
+
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary

- Add a focused notifications router test for proxy-like extra path segments.
- Verify an oversized extra segment under `/api/notifications/register/...` is rejected with `404`.
- Guard that the request does not reach Firebase auth when no notifications proxy path is defined.

## Validation

- `C:\Users\DIVYA\Downloads\hushh-research-main\hushh-research-1\consent-protocol\.venv\Scripts\python.exe -m pytest tests/test_notifications.py`

## Notes

- Local pre-commit could not run because it invokes the Windows Store `python3` shim, which fails with `Permission denied`; the focused protocol pytest passed in the project venv.
