### PR TITLE
fix(ui): hide agent voice wave input icons from assistive technology

### DIFF
--- a/hushh-webapp/components/agent/agent-voice-wave-input.tsx
+++ b/hushh-webapp/components/agent/agent-voice-wave-input.tsx
@@ -42,17 +42,17 @@ export function AgentVoiceWaveInput({
         aria-label="Cancel voice mode"
         title="Cancel voice mode"
       >
-        <Keyboard className="h-4 w-4" />
+        <Keyboard aria-hidden="true" className="h-4 w-4" />
       </Button>
 
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2 text-xs font-medium text-foreground">
           {isBusy ? (
-            <Loader2 className="h-3.5 w-3.5 animate-spin text-primary" />
+            <Loader2 aria-hidden="true" className="h-3.5 w-3.5 animate-spin text-primary" />
           ) : muted ? (
-            <MicOff className="h-3.5 w-3.5 text-muted-foreground" />
+            <MicOff aria-hidden="true" className="h-3.5 w-3.5 text-muted-foreground" />
           ) : (
-            <Mic className="h-3.5 w-3.5 text-primary" />
+            <Mic aria-hidden="true" className="h-3.5 w-3.5 text-primary" />
           )}
           <span>{label}</span>
         </div>
@@ -90,7 +90,11 @@ export function AgentVoiceWaveInput({
         aria-label={muted ? "Unmute Agent voice" : "Mute Agent voice"}
         title={muted ? "Unmute Agent voice" : "Mute Agent voice"}
       >
-        {muted ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />}
+        {muted ? (
+          <MicOff aria-hidden="true" className="h-4 w-4" />
+        ) : (
+          <Mic aria-hidden="true" className="h-4 w-4" />
+        )}
       </Button>
 
       <Button
@@ -103,7 +107,7 @@ export function AgentVoiceWaveInput({
         aria-label="Exit voice mode"
         title="Exit voice mode"
       >
-        <X className="h-4 w-4" />
+        <X aria-hidden="true" className="h-4 w-4" />
       </Button>
     </div>
   );


### PR DESCRIPTION
## Summary

- Hide decorative Agent voice wave input icons from assistive technology.
- Preserve existing button `aria-label` values and visible status text as the accessible labels.

## Validation

- `npx.cmd eslint components/agent/agent-voice-wave-input.tsx --max-warnings=0`
