### PR TITLE
fix(ui): replace pointer-events-none with cursor-not-allowed for disabled sheet close button

### DIFF
--- a/hushh-webapp/components/ui/sheet.tsx
+++ b/hushh-webapp/components/ui/sheet.tsx
@@ -78,7 +78,7 @@ function SheetContent({
       >
         {children}
         {showCloseButton && (
-          <SheetPrimitive.Close type="button" className="ring-offset-background focus:ring-ring absolute top-4 right-4 rounded-full border border-transparent bg-[color:var(--app-card-surface-compact)] p-2 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+          <SheetPrimitive.Close type="button" className="ring-offset-background focus:ring-ring absolute top-4 right-4 rounded-full border border-transparent bg-[color:var(--app-card-surface-compact)] p-2 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:cursor-not-allowed">
             <XIcon className="size-4" aria-hidden="true" />
             <span className="sr-only">Close</span>
           </SheetPrimitive.Close>


### PR DESCRIPTION
This PR replaces the `disabled:pointer-events-none` class with `disabled:cursor-not-allowed` on the `SheetClose` button. The `pointer-events-none` class was intercepting pointer events and preventing the native browser `not-allowed` cursor from appearing on hover. Explicitly using `cursor-not-allowed` restores standard hover cursor feedback for disabled sheet close buttons.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None

- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None
- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Not applicable

- UI browser or Playwright proof:
  - [x] Not applicable

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate:
- [x] This PR changes a current reachable app/backend/package/docs surface, or it is explicitly scoped as test/devex hygiene.
- [x] Reachable production attach point: `components/ui/sheet.tsx`
- [x] New helpers/components/services are wired to an existing route, caller, package export, generated contract, or documented devex entrypoint.
- [ ] Production surface proved:
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.
- [x] Maintainer edits are enabled, or the reason they cannot be enabled is listed here:

## 🛑 Tri-Flow Architecture Check

Every cross-platform feature must cover all affected layers or explicitly mark
the layer as not applicable with the reason.

- [x] **Web**: Next.js implementation (`app/api/...`)
- [ ] **iOS**: Swift Capacitor Plugin (`ios/App/App/Plugins/...`)
- [ ] **Android**: Kotlin Capacitor Plugin (`android/app/.../plugins/...`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Attach proof of work here. For UI-visible changes, include the route plus
Playwright spec/command, screenshot, video, or why browser proof is not
applicable.
*(Not applicable: Component-level DOM hygiene fix)*

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed