### PR TITLE
test(onboarding): cover clear marketing failure path

### DIFF
--- a/hushh-webapp/__tests__/services/onboarding-local-service.test.ts
+++ b/hushh-webapp/__tests__/services/onboarding-local-service.test.ts
@@ -95,6 +95,21 @@ describe("OnboardingLocalService", () => {
       });
       expect(mockRemoveLocalItem).toHaveBeenCalledWith("onboarding_marketing_seen_v1");
     });
+    it("does not throw when clearing marketing state fails", async () => {
+   const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    mockPreferences.set.mockRejectedValue(
+     new Error("Clear failed")
+    );
+
+    await expect(
+      OnboardingLocalService.clearMarketingSeen()
+    ).resolves.toBeUndefined();
+
+   expect(warnSpy).toHaveBeenCalled();
+
+   warnSpy.mockRestore();
+   });
   });
 
   describe("consumeForceIntroOnce", () => {


### PR DESCRIPTION
## Summary

* add coverage for clearMarketingSeen when Preferences operations fail
* verify the helper does not throw during storage failures
* ensure warning paths remain exercised and resilient

## Testing

npx vitest run **tests**/services/onboarding-local-service.test.ts
