### PR TITLE
fix(ui): use bg-muted instead of bg-accent for Skeletons to fix semantic visual hierarchy

### DIFF
--- a/hushh-webapp/components/ui/skeleton.tsx
+++ b/hushh-webapp/components/ui/skeleton.tsx
@@ -6,7 +6,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
       aria-hidden="true"
       data-slot="skeleton"
       className={cn(
-        "pointer-events-none overflow-hidden rounded-md bg-accent motion-safe:animate-pulse [contain:layout_paint]",
+        "pointer-events-none overflow-hidden rounded-md bg-muted motion-safe:animate-pulse [contain:layout_paint]",
         className
       )}
       {...props}


### PR DESCRIPTION
# Description
Replaced `bg-accent` with `bg-muted` on Skeletons in `components/ui/skeleton.tsx` to fix the semantic visual hierarchy, ensuring loading states do not falsely appear as interactive accent elements.

## 📌 Impact Map (Required)
- Routes touched: [x] None
- API / schema / type changes: [x] None
- Trust boundary touched: [x] None
- UI browser or Playwright proof: [x] Not applicable
- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm test`

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] Reachable production attach point: `components/ui/skeleton.tsx`
- [x] Production surface proved: Visual UI testing.
- [x] Required checks are current, commits are signed off, and branch is mergeable.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS** / **Android**: Not applicable (UI styling only)

## 🧪 Testing & Consent
- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)
- [x] Sensitive surface touched: none