### PR TITLE
test(utils): verify request timeout interceptor rejects zero and negative float values

### DIFF
--- a/hushh-webapp/__tests__/utils/request-timeouts.test.ts
+++ b/hushh-webapp/__tests__/utils/request-timeouts.test.ts
@@ -97,6 +97,20 @@ describe("resolveSlowRequestTimeoutMs — fringe-input boundary fallbacks", () =
     expect(resolveSlowRequestTimeoutMs(0)).toBe(SAFE_FLOOR);
   });
 
+  it.each([-15.5, -0.001, -0, 0.000])(
+    "falls back to the safe floor for non-positive float defaultMs values: %s",
+    (defaultMs) => {
+      process.env.NEXT_PUBLIC_APP_ENV = "uat";
+      delete process.env.HUSHH_SLOW_REQUEST_TIMEOUT_MS;
+
+      const result = resolveSlowRequestTimeoutMs(defaultMs);
+
+      expect(result).toBe(SAFE_FLOOR);
+      expect(Number.isFinite(result)).toBe(true);
+      expect(result).toBeGreaterThan(0);
+    }
+  );
+
   // ── NaN defaultMs ─────────────────────────────────────────────────────────
 
   it("falls back to the safe floor when defaultMs is NaN — no NaN escapes the function", () => {


### PR DESCRIPTION
## Overview
This PR adds focused coverage for non-positive floating-point timeout inputs in the existing `resolveSlowRequestTimeoutMs` utility. The test is attached to the current production helper and extends the existing request-timeout contract rather than adding a new helper or runtime surface.

## Impact
- Test-only change in `hushh-webapp/__tests__/utils/request-timeouts.test.ts`
- No production code, frontend UI, backend route, schema, or capability mutations
- Deterministically verifies negative float, negative near-zero, signed zero, and decimal zero inputs fall back to the hardcoded safe timeout floor

## Changes Cleared
- Covers `-15.5`, `-0.001`, `-0`, and `0.000` inputs
- Asserts the result remains finite and greater than zero
- Preserves the existing `75_000` ms safe-floor contract for invalid timeout defaults

## Verification
- `npm run test:ci -- __tests__/utils/request-timeouts.test.ts` passed
- `npm run typecheck` passed
- `npm run verify:docs` passed
- `npm run verify:service-boundary` passed