### PR TITLE
fix(ui): hardware accelerate Progress component animations

### DIFF
--- a/hushh-webapp/__tests__/ui/progress.test.tsx
+++ b/hushh-webapp/__tests__/ui/progress.test.tsx
@@ -23,7 +23,7 @@ describe("Progress", () => {
       '[data-slot="progress-indicator"]',
     ) as HTMLElement;
 
-    expect(indicator.style.transform).toBe("translateX(-50%)");
+    expect(indicator.style.transform).toBe("translate3d(-50%, 0, 0)");
   });
 
   it("clamps values above 100", () => {
@@ -33,7 +33,7 @@ describe("Progress", () => {
       '[data-slot="progress-indicator"]',
     ) as HTMLElement;
 
-    expect(indicator.style.transform).toBe("translateX(-0%)");
+    expect(indicator.style.transform).toBe("translate3d(-0%, 0, 0)");
   });
 
   it("clamps values below 0", () => {
@@ -43,6 +43,6 @@ describe("Progress", () => {
       '[data-slot="progress-indicator"]',
     ) as HTMLElement;
 
-    expect(indicator.style.transform).toBe("translateX(-100%)");
+    expect(indicator.style.transform).toBe("translate3d(-100%, 0, 0)");
   });
 });

--- a/hushh-webapp/components/ui/progress.tsx
+++ b/hushh-webapp/components/ui/progress.tsx
@@ -31,7 +31,7 @@ function Progress({
       <ProgressPrimitive.Indicator
         data-slot="progress-indicator"
         className={cn("bg-primary h-full w-full flex-1 transition-all", indicatorClassName)}
-        style={{ transform: `translateX(-${100 - (safeValue || 0)}%)` }}
+        style={{ transform: `translate3d(-${100 - (safeValue || 0)}%, 0, 0)` }}
       />
     </ProgressPrimitive.Root>
   )


### PR DESCRIPTION
# Description
Hardware accelerated the `Progress` component animation in `components/ui/progress.tsx` by replacing `translateX` with `translate3d`. This forces the browser to use GPU compositing, preventing main-thread layout jank during progress state updates.

## 📌 Impact Map (Required)
- Routes touched: [x] None
- API / schema / type changes: [x] None
- Trust boundary touched: [x] None
- UI browser or Playwright proof: [x] Not applicable
- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm test`

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] Reachable production attach point: `components/ui/progress.tsx`
- [x] Production surface proved: Visual UI testing.
- [x] Required checks are current, commits are signed off, and branch is mergeable.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation

## 🧪 Testing & Consent
- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)
- [x] Sensitive surface touched: none