### PR TITLE
test(observability): cover token whitespace in log redactor

### DIFF
--- a/hushh-webapp/__tests__/services/observability-log-redactor.test.ts
+++ b/hushh-webapp/__tests__/services/observability-log-redactor.test.ts
@@ -19,6 +19,30 @@ describe("observability log redactor", () => {
     expect(redacted).not.toContain("abcdefghijklmnopqrstuvwxyz123456");
   });
 
+  it("redacts whitespace-wrapped sensitive tokens without throwing or expanding the log line", () => {
+    const raw = [
+      "auth_header=Bearer abcdefghijklmnopqrstuvwxyz1234567890   ",
+      "owner_email=kai@example.com\r",
+      "vault_key=vault_whitespace_test_key_001\n",
+      "session=abcdefghijklmnopqrstuvwxyz1234567890abcdef      ",
+    ].join(" ");
+
+    expect(() => redactObservabilityLog(raw)).not.toThrow();
+
+    const redacted = redactObservabilityLog(raw);
+
+    expect(redacted).toContain("Bearer [REDACTED_TOKEN]");
+    expect(redacted).toContain("[REDACTED_EMAIL]");
+    expect(redacted).toContain("[REDACTED_VAULT_KEY]");
+    expect(redacted).toContain("[REDACTED_SECRET]");
+    expect(redacted).not.toContain("abcdefghijklmnopqrstuvwxyz1234567890");
+    expect(redacted).not.toContain("kai@example.com");
+    expect(redacted).not.toContain("vault_whitespace_test_key_001");
+    expect(redacted).toContain("\r");
+    expect(redacted).toContain("\n");
+    expect(redacted.length).toBeLessThan(raw.length);
+  });
+
   it("does not coerce non-string diagnostic values", () => {
     const value = { droppedKeys: ["user_id"] };
 


### PR DESCRIPTION
## Overview
This PR adds focused coverage for whitespace-wrapped sensitive tokens in the existing frontend observability log redactor. During the repo-backed premise check, `logRedactorLayer` was not found as an exported symbol, so this test attaches to the canonical production implementation: `redactObservabilityLog` in `hushh-webapp/lib/observability/log-redactor.ts`.

## Impact
- Test-only change in `hushh-webapp/__tests__/services/observability-log-redactor.test.ts`
- No production code, frontend UI, backend route, schema, or capability overlap
- Verifies tokens surrounded by carriage returns, newlines, and trailing spaces redact cleanly without throwing or expanding the log line

## Changes Cleared
- Covers whitespace-wrapped Bearer tokens, email addresses, vault keys, and long secret tokens
- Asserts raw sensitive values are removed from the redacted output
- Asserts structural `\r` and `\n` characters remain handled without runtime exceptions
- Confirms the redacted line is shorter than the raw input, guarding against overflow-style expansion

## Verification
- `npm run test:ci -- __tests__/services/observability-log-redactor.test.ts` passed
- `npm run typecheck` passed
- `npm run verify:docs` passed
- `npm run verify:service-boundary` passed