### PR TITLE
test(devex): verify package configuration contains explicit non-overlapping module resolutions

### DIFF
--- a/hushh-webapp/__tests__/devex-config.test.ts
+++ b/hushh-webapp/__tests__/devex-config.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
 import packageJson from "../package.json";
 import tsconfig from "../tsconfig.json";
 
@@ -12,5 +15,41 @@ describe("DevEx configuration integrity", () => {
     expect(tsconfig.include).toEqual(
       expect.arrayContaining(["app/**/*.ts", "lib/**/*.ts"]),
     );
+  });
+
+  it("keeps TypeScript module path targets explicit, distinct, and mapped to package directories", () => {
+    const paths = tsconfig.compilerOptions.paths;
+    const seenTargets = new Map<string, string>();
+
+    expect(paths).toBeDefined();
+
+    for (const [alias, targets] of Object.entries(paths)) {
+      expect(alias.trim()).toBe(alias);
+      expect(alias).not.toBe("");
+      expect(Array.isArray(targets)).toBe(true);
+      expect(targets.length).toBeGreaterThan(0);
+
+      for (const target of targets) {
+        expect(target.trim()).toBe(target);
+        expect(target).not.toBe("");
+        expect(target).not.toMatch(/^(\.\.\/|\/|[A-Za-z]:[\\/])/);
+
+        const targetDirectory = target.replace(/\*.*$/, "") || ".";
+        const resolvedTarget = path.resolve(process.cwd(), targetDirectory);
+        const relativeTarget = path.relative(process.cwd(), resolvedTarget);
+
+        expect(relativeTarget).not.toMatch(/^(\.\.|[A-Za-z]:)/);
+        expect(existsSync(resolvedTarget)).toBe(true);
+
+        const normalizedTarget = path
+          .normalize(target)
+          .replace(/[\\/]+$/, "")
+          .replace(/\*.*$/, "*");
+        const previousAlias = seenTargets.get(normalizedTarget);
+
+        expect(previousAlias).toBeUndefined();
+        seenTargets.set(normalizedTarget, alias);
+      }
+    }
   });
 });


### PR DESCRIPTION
## Overview
This PR extends the existing DevEx configuration integrity test contract to validate TypeScript module path mappings. It loads the real `hushh-webapp/tsconfig.json` profile and asserts each configured module alias target is explicit, distinct, package-local, and resolvable on disk.

## Impact
- Test-only change in `hushh-webapp/__tests__/devex-config.test.ts`
- No production application routes, runtime code, backend APIs, schemas, package exports, or user-facing capabilities are changed
- Provides deterministic coverage for module-resolution hygiene without adding a new script or parallel configuration system

## Changes Cleared
- Verifies every `compilerOptions.paths` alias has at least one explicit target
- Rejects absolute or parent-directory module targets
- Confirms each mapped destination resolves inside the webapp package
- Confirms normalized path targets are non-overlapping across aliases

## Verification
- `npm run test:ci -- __tests__/devex-config.test.ts` passed
- `npm run typecheck` passed
- `npm run verify:docs` passed
- `npm run verify:service-boundary` passed