### PR TITLE
fix(ui): correct Tooltip sideOffset to prevent arrow from overlapping trigger elements

### DIFF
--- a/hushh-webapp/components/ui/tooltip.tsx
+++ b/hushh-webapp/components/ui/tooltip.tsx
@@ -32,7 +32,7 @@ function TooltipTrigger({
 
 function TooltipContent({
   className,
-  sideOffset = 4,
+  sideOffset = 8,
   children,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content>) {


### PR DESCRIPTION
# Description
Increased the `sideOffset` on `TooltipContent` in `components/ui/tooltip.tsx` from `4` to `8`. Because Radix Tooltips with an `<Arrow />` element bleed slightly outside their bounding box, this prevents the arrow polygon from overlapping and intercepting pointer events on the tooltip trigger elements.

## 📌 Impact Map (Required)
- Routes touched: [x] None
- API / schema / type changes: [x] None
- Trust boundary touched: [x] None
- UI browser or Playwright proof: [x] Not applicable
- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm test`

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] Reachable production attach point: `components/ui/tooltip.tsx`
- [x] Production surface proved: Visual UI testing.
- [x] Required checks are current, commits are signed off, and branch is mergeable.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS** / **Android**: Not applicable (UI spacing only)

## 🧪 Testing & Consent
- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)
- [x] Sensitive surface touched: none