### PR TITLE
fix(profile): fallback malformed receipt currency codes to USD

### DIFF
--- a/hushh-webapp/__tests__/services/pkm-section-preview.test.ts
+++ b/hushh-webapp/__tests__/services/pkm-section-preview.test.ts
@@ -113,4 +113,90 @@ describe("buildPkmSectionPreviewPresentation", () => {
       "Preference signals",
     ]);
   });
+
+  it.each([
+    ["empty string", ""],
+    ["unsupported alphabetic code", "XYZ"],
+    ["numeric string", "123"],
+    ["number", 123],
+  ])("falls back to USD for malformed receipt currency codes: %s", (_label, currency) => {
+    const presentation = buildPkmSectionPreviewPresentation({
+      domain: "shopping",
+      domainTitle: "Shopping",
+      permissionLabel: "Receipts memory",
+      topLevelScopePath: "receipts_memory",
+      value: {
+        receipts_memory: {
+          observed_facts: {
+            recent_highlights: {
+              items: [
+                {
+                  merchant_label: "Test merchant",
+                  amount: 12.34,
+                  currency,
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    const recentPurchases = presentation.groups.find(
+      (group) => group.kind === "entities" && group.title === "Recent purchases"
+    );
+
+    expect(recentPurchases?.kind).toBe("entities");
+    if (recentPurchases?.kind !== "entities") {
+      throw new Error("expected recent purchases entity group");
+    }
+
+    const amountField = recentPurchases.items[0]?.fields.find(
+      (field) => field.label === "Amount"
+    );
+
+    expect(amountField?.value).toMatch(/\$12\.34|US\$12\.34/);
+    if (String(currency)) {
+      expect(amountField?.value).not.toContain(String(currency));
+    }
+  });
+
+  it("preserves valid EUR receipt currency codes while guarding malformed values separately", () => {
+    const presentation = buildPkmSectionPreviewPresentation({
+      domain: "shopping",
+      domainTitle: "Shopping",
+      permissionLabel: "Receipts memory",
+      topLevelScopePath: "receipts_memory",
+      value: {
+        receipts_memory: {
+          observed_facts: {
+            recent_highlights: {
+              items: [
+                {
+                  merchant_label: "Euro merchant",
+                  amount: 45,
+                  currency: "eur",
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    const recentPurchases = presentation.groups.find(
+      (group) => group.kind === "entities" && group.title === "Recent purchases"
+    );
+
+    expect(recentPurchases?.kind).toBe("entities");
+    if (recentPurchases?.kind !== "entities") {
+      throw new Error("expected recent purchases entity group");
+    }
+
+    const amountField = recentPurchases.items[0]?.fields.find(
+      (field) => field.label === "Amount"
+    );
+
+    expect(amountField?.value).toMatch(/€45\.00|EUR\s*45\.00/);
+  });
 });

--- a/hushh-webapp/lib/profile/pkm-section-preview.ts
+++ b/hushh-webapp/lib/profile/pkm-section-preview.ts
@@ -67,6 +67,21 @@ const HIDDEN_CONSUMER_KEYS = new Set([
   "contract_version",
   "projection_version",
 ]);
+const FALLBACK_SUPPORTED_CURRENCY_CODES = new Set([
+  "USD",
+  "EUR",
+  "GBP",
+  "CAD",
+  "AUD",
+  "JPY",
+  "CHF",
+  "INR",
+]);
+const SUPPORTED_CURRENCY_CODES = new Set(
+  typeof Intl.supportedValuesOf === "function"
+    ? Intl.supportedValuesOf("currency")
+    : FALLBACK_SUPPORTED_CURRENCY_CODES
+);
 
 const ENTITY_TITLE_KEYS = ["title", "name", "label", "summary", "merchant", "symbol", "entity_id", "id"];
 const ENTITY_SUBTITLE_KEYS = ["kind", "status", "category"];
@@ -188,7 +203,14 @@ function formatPercent(value: unknown): string | null {
 
 function formatAmountValue(amount: unknown, currency: unknown): string | null {
   if (typeof amount !== "number" || !Number.isFinite(amount)) return null;
-  const code = typeof currency === "string" && currency.trim() ? currency.trim().toUpperCase() : "USD";
+  const candidate =
+    typeof currency === "string" && currency.trim()
+      ? currency.trim().toUpperCase()
+      : "USD";
+  const code =
+    /^[A-Z]{3}$/.test(candidate) && SUPPORTED_CURRENCY_CODES.has(candidate)
+      ? candidate
+      : "USD";
   try {
     return new Intl.NumberFormat(undefined, {
       style: "currency",


### PR DESCRIPTION
## Overview
This PR hardens receipt amount currency formatting in the PKM section preview path. It validates currency codes before passing them into `Intl.NumberFormat`, falling back to `USD` for empty, numeric, non-string, or unsupported values such as `XYZ`.

## Concrete Attachment Plan
- Canonical production formatter path: `hushh-webapp/lib/profile/pkm-section-preview.ts`
- Exported production entrypoint under test: `buildPkmSectionPreviewPresentation`
- Canonical test contract: `hushh-webapp/__tests__/services/pkm-section-preview.test.ts`
- Reachable surface: profile/PKM receipt preview presentation for shopping receipt memory amounts

## Impact
- Narrow production guard for malformed receipt currency codes only
- Defensive parsing tests cover empty strings, unsupported alphabetic codes, numeric strings, and non-string numeric inputs
- Valid supported currency codes such as `EUR` continue to format as expected
- No backend routes, schemas, consent contracts, package exports, or app navigation capabilities changed

## Verification
- `npm run test:ci -- __tests__/services/pkm-section-preview.test.ts` passed
- `npm run typecheck` passed
- `npm run verify:docs` passed
- `npm run verify:service-boundary` passed
- `npm run lint -- --max-warnings=0` passed