### PR TITLE
test(services): verify getErrorMessage handles objects missing standard stack strings

### DIFF
--- a/hushh-webapp/__tests__/lib/services/error-sanitizer.test.ts
+++ b/hushh-webapp/__tests__/lib/services/error-sanitizer.test.ts
@@ -429,4 +429,29 @@ describe("getErrorMessage", () => {
     expect(typeof result).toBe("string");
     expect(result.length).toBeGreaterThan(0);
   });
+
+  it("returns Error.message when the stack property is deleted", () => {
+    const error = err("missing stack message");
+
+    delete error.stack;
+
+    expect(() => getErrorMessage(error)).not.toThrow();
+    expect(getErrorMessage(error)).toBe("missing stack message");
+  });
+
+  it.each([
+    [{ frames: ["internal"] }],
+    [42],
+    [false],
+  ])("returns Error.message when stack is non-string data: %s", (stack) => {
+    const error = err("non-string stack message");
+
+    Object.defineProperty(error, "stack", {
+      configurable: true,
+      value: stack,
+    });
+
+    expect(() => getErrorMessage(error)).not.toThrow();
+    expect(getErrorMessage(error)).toBe("non-string stack message");
+  });
 });


### PR DESCRIPTION
## Overview
Adds regression coverage for the existing getErrorMessage service helper when Error instances do not carry a normal string stack. The tests construct real Error objects with deleted and non-string stack values and assert the helper still returns the core message without throwing nested runtime exceptions.

## Impact
This is a test-only change in the existing error-sanitizer service contract. It introduces zero production runtime changes, no frontend UI mutations, no backend route mutations, and no new capability surface.

## Changes Cleared
- Extended hushh-webapp/__tests__/lib/services/error-sanitizer.test.ts inside the existing getErrorMessage coverage block.
- Covered Error objects with deleted stack properties.
- Covered Error objects with object, numeric, and boolean stack values.
- Verified the helper returns Error.message and does not throw for malformed stack shapes.

## Verification
- cd hushh-webapp && npm run test:ci -- __tests__/lib/services/error-sanitizer.test.ts
- cd hushh-webapp && npm run typecheck
- cd hushh-webapp && npm run verify:docs
- cd hushh-webapp && npm run verify:service-boundary