### PR TITLE
fix(ui): remove dangerous input autocomplete override in Input field

### DIFF
--- a/hushh-webapp/components/ui/input.tsx
+++ b/hushh-webapp/components/ui/input.tsx
@@ -7,7 +7,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
     <input
       type={type}
       data-slot="input"
-      autoComplete={type === "search" ? "off" : props.autoComplete}
+
       autoCapitalize={
         type === "email" || type === "search" ? "none" : props.autoCapitalize
       }


### PR DESCRIPTION
# Description
Removed the dangerous hardcoded `autoComplete` override from the `Input` component in `components/ui/input.tsx`. Previously, if the input type was `"search"`, the component forcefully applied `autoComplete="off"`, ignoring any explicit `autoComplete` prop passed by the developer. By removing this ternary constraint, the input now correctly respects the developer's intent via standard prop spreading, preventing native search histories and browser password managers from being unintentionally blocked.

## 📌 Impact Map (Required)
- Routes touched: [x] None
- API / schema / type changes: [x] None
- Trust boundary touched: [x] None
- UI browser or Playwright proof: [x] Not applicable
- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm test`

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] Reachable production attach point: `components/ui/input.tsx`
- [x] Production surface proved: Input behavior verification.
- [x] Required checks are current, commits are signed off, and branch is mergeable.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation

## 🧪 Testing & Consent
- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)
- [x] Sensitive surface touched: none