### PR TITLE
fix(ui): remove hardcoded tabIndex from ScrollArea Viewport to prevent double focus

### DIFF
--- a/hushh-webapp/__tests__/ui/scroll-area.test.tsx
+++ b/hushh-webapp/__tests__/ui/scroll-area.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
 describe("ScrollArea", () => {
-  it("allows keyboard focus on the scroll container", () => {
+  it("intentionally prevents keyboard focus on the scroll container to avoid tab-stop bloat", () => {
     const { container } = render(
       <ScrollArea className="h-20 w-40">
         <div className="h-40">Scrollable content</div>
@@ -17,6 +17,6 @@ describe("ScrollArea", () => {
 
     expect(viewport).toBeTruthy();
     viewport?.focus();
-    expect(document.activeElement).toBe(viewport);
+    expect(document.activeElement).not.toBe(viewport);
   });
 });

--- a/hushh-webapp/components/ui/scroll-area.tsx
+++ b/hushh-webapp/components/ui/scroll-area.tsx
@@ -17,7 +17,6 @@ function ScrollArea({
       {...props}
     >
       <ScrollAreaPrimitive.Viewport
-        tabIndex={0}
         data-slot="scroll-area-viewport"
         className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px]"
       >


### PR DESCRIPTION
# Description
Removed the explicitly hardcoded `tabIndex={0}` from `ScrollAreaPrimitive.Viewport` in `components/ui/scroll-area.tsx`. Radix UI handles focus management natively; when you manually hardcode `tabIndex={0}` onto the viewport, it forces an extra unnatural tab-stop on the element itself regardless of whether the content overflows or is already focusable. This prevents a frustrating "double focus" trap for keyboard users navigating through interactive children (like forms or lists) within the scroll area.

## 📌 Impact Map (Required)
- Routes touched: [x] None
- API / schema / type changes: [x] None
- Trust boundary touched: [x] None
- UI browser or Playwright proof: [x] Not applicable
- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm test`

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] Reachable production attach point: `components/ui/scroll-area.tsx`
- [x] Production surface proved: Keyboard navigation behavior verification.
- [x] Required checks are current, commits are signed off, and branch is mergeable.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS** / **Android**: Not applicable (UI behavior only)

## 🧪 Testing & Consent
- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)
- [x] Sensitive surface touched: none