### PR TITLE
sync: merge main into integration/pr-train (unblock promotion #3104)

### DIFF
--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -1553,6 +1553,49 @@ md-ripple.morphy-md-ripple {
   }
 }
 
+@keyframes segmented-pill-active-content-pop {
+  0% {
+    transform: translateY(1px) scale(0.965);
+  }
+  56% {
+    transform: translateY(-1px) scale(1.035);
+  }
+  100% {
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes segmented-pill-active-pulse {
+  0% {
+    opacity: 0.32;
+    transform: scale(0.84);
+  }
+  54% {
+    opacity: 0.2;
+    transform: scale(1.08);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.16);
+  }
+}
+
+.segmented-pill-active-choice {
+  animation: segmented-pill-active-content-pop 420ms
+    cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+[data-segment-active-pulse] {
+  animation: segmented-pill-active-pulse 420ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .segmented-pill-active-choice,
+  [data-segment-active-pulse] {
+    animation: none;
+  }
+}
+
 .kai-bottom-nav-pill [role="radio"] {
   color: rgb(60 60 67 / 0.7) !important;
   min-height: 48px;
@@ -1660,6 +1703,17 @@ body:has([data-one-market-surface="true"]) .bar-glass-top {
   --app-bar-glass-bg-light: var(--background) !important;
   --app-bar-glass-bg-dark: rgb(28, 28, 30) !important;
   --app-bar-shadow: none !important;
+  --app-bar-fade-top-strong: transparent !important;
+  --app-bar-fade-top-medium: transparent !important;
+  --app-bar-fade-top-soft: transparent !important;
+  --app-bar-fade-top-trace: transparent !important;
+}
+
+body:has([data-one-market-surface="true"]) .bar-glass-top {
+  --app-bar-glass-bg-light: transparent !important;
+  --app-bar-glass-bg-dark: transparent !important;
+  --app-bar-shadow: none !important;
+  opacity: 0;
   --app-bar-fade-top-strong: transparent !important;
   --app-bar-fade-top-medium: transparent !important;
   --app-bar-fade-top-soft: transparent !important;

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -2831,6 +2831,19 @@ export function AgentChatWorkspace({
                   <X className="h-4 w-4" />
                 </Button>
               ) : null}
+              {isPopover && onMinimize ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-9 w-9 rounded-lg text-[rgba(0,0,0,0.56)] hover:bg-black/[0.04] hover:text-[#1d1d1f] focus-visible:ring-2 focus-visible:ring-primary/60 dark:text-zinc-300 dark:hover:bg-white/[0.07] dark:hover:text-zinc-50 sm:hidden"
+                  onClick={onMinimize}
+                  aria-label="Close Agent"
+                  title="Close Agent"
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              ) : null}
               {windowControls ? <div className="ml-1">{windowControls}</div> : null}
             </div>
           </div>


### PR DESCRIPTION
## Summary
Makes `integration/pr-train` a descendant of `main` so the promotion PR #3104 (train → main) becomes mergeable.

## Why
PR #3188 reconciled main into the train working set under a **main-wins** conflict policy, then DCO sign-off required rewriting 2 pre-existing unsigned main commits' SHAs. That SHA rewrite left #3104 in a CONFLICTING/DIRTY state even though content matched. This merge re-establishes a clean main→train ancestry.

## Resolution policy
- Train-wins on conflicts (train is the reconciled superset; already absorbed main content via #3188)
- Verified lossless: no functional main-only content dropped (e.g. agent close-button variants already superseded on train)
- `tsc --noEmit` passes on the merged tree

## Verification
- tsc green
- protocol lint green (./bin/hushh protocol fix)
- DCO: all commits signed