### PR TITLE
test(runtime): cover fraction boundaries inside resolveSlowRequestTimeoutMs under low latency

### DIFF
--- a/hushh-webapp/__tests__/utils/request-timeouts.test.ts
+++ b/hushh-webapp/__tests__/utils/request-timeouts.test.ts
@@ -156,6 +156,23 @@ describe("resolveSlowRequestTimeoutMs — fringe-input boundary fallbacks", () =
     expect(Number.isInteger(resolveSlowRequestTimeoutMs(9_999.1))).toBe(true);
   });
 
+  it("normalizes sub-millisecond fractional timeout inputs into integer ticks", () => {
+    process.env.NEXT_PUBLIC_APP_ENV = "uat";
+    delete process.env.HUSHH_SLOW_REQUEST_TIMEOUT_MS;
+
+    const microTick = resolveSlowRequestTimeoutMs(0.0045);
+    const lowLatencyTick = resolveSlowRequestTimeoutMs(0.85);
+
+    expect(microTick).toBe(0);
+    expect(lowLatencyTick).toBe(1);
+    expect(Number.isFinite(microTick)).toBe(true);
+    expect(Number.isFinite(lowLatencyTick)).toBe(true);
+    expect(Number.isInteger(microTick)).toBe(true);
+    expect(Number.isInteger(lowLatencyTick)).toBe(true);
+    expect(Number.isNaN(microTick)).toBe(false);
+    expect(Number.isNaN(lowLatencyTick)).toBe(false);
+  });
+
   // ── Empty options object ───────────────────────────────────────────────────
 
   it("behaves identically whether options is omitted or passed as an empty object", () => {


### PR DESCRIPTION
## Overview
Adds low-latency fractional boundary coverage for the existing resolveSlowRequestTimeoutMs utility in hushh-webapp/lib/utils/request-timeouts.ts. The test extends the established request-timeout contract and verifies tiny positive fractional inputs normalize into finite integer execution ticks without leaking fractional, NaN, or non-finite values.

## Impact
This is a test-only change built directly on top of the existing resolveSlowRequestTimeoutMs logic. It introduces zero production runtime changes, no frontend UI mutations, no backend route changes, and no new capability surface.

## Changes Cleared
- Extended hushh-webapp/__tests__/utils/request-timeouts.test.ts in the existing fringe-input timeout boundary suite.
- Covered ultra-low fractional inputs: 0.0045 and 0.85.
- Asserted normalized integer tick output for production-like runtime settings.
- Asserted no NaN, non-finite, or fractional timeout values escape the helper.

## Verification
- cd hushh-webapp && npm run test:ci -- __tests__/utils/request-timeouts.test.ts
- cd hushh-webapp && npm run typecheck
- cd hushh-webapp && npm run verify:docs
- cd hushh-webapp && npm run verify:service-boundary