### PR TITLE
fix(ui): eliminate redundant flex-shrink on AvatarImage to prevent layout squishing

### DIFF
--- a/hushh-webapp/components/ui/avatar.tsx
+++ b/hushh-webapp/components/ui/avatar.tsx
@@ -17,7 +17,7 @@ function Avatar({
       data-slot="avatar"
       data-size={size}
       className={cn(
-        "group/avatar relative flex size-8 shrink-0 overflow-hidden rounded-full select-none data-[size=lg]:size-10 data-[size=sm]:size-6",
+        "group/avatar relative flex aspect-square size-8 overflow-hidden rounded-full select-none data-[size=lg]:size-10 data-[size=sm]:size-6",
         className
       )}
       {...props}
@@ -33,7 +33,7 @@ function AvatarImage({
   return (
     <AvatarPrimitive.Image
       data-slot="avatar-image"
-      className={cn("aspect-square size-full", className)}
+      className={cn("size-full aspect-square object-cover", className)}
       alt={alt}
       {...props}
     />


### PR DESCRIPTION
## Overview
This PR tightens the foundational Avatar primitive so nested flex layouts do not compress avatar images into distorted shapes on constrained mobile rows. The Avatar root now keeps an explicit square aspect ratio without forcing a redundant flex-shrink constraint, and AvatarImage fills that square with object-cover rendering.

## Impact
Low-risk UI-only change. This touches a single shared presentation primitive, does not change routes, state machines, exports, data fetching, backend contracts, or runtime capability boundaries. The fix removes a small layout conflict while preserving existing size tokens and rounded avatar behavior.

## Changes Cleared
- Updated `hushh-webapp/components/ui/avatar.tsx` to remove the Avatar root `shrink-0` constraint.
- Added `aspect-square` on the Avatar wrapper so size variants remain stable in dynamic flex grids.
- Added `object-cover` on `AvatarImage` so image content fills the avatar circle without stretching.

## Verification
- `cd hushh-webapp && npm run verify:design-system`
- `cd hushh-webapp && npm run typecheck`
- `cd hushh-webapp && npm run lint -- --max-warnings=0`