### PR TITLE
fix(ui): restore missing focus-visible rings on custom Checkbox primitives

### DIFF
--- a/hushh-webapp/components/ui/checkbox.tsx
+++ b/hushh-webapp/components/ui/checkbox.tsx
@@ -14,7 +14,7 @@ function Checkbox({
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-[color,box-shadow] outline-none disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}


### PR DESCRIPTION
## Overview
This PR restores a clearly visible keyboard focus ring on the custom Checkbox primitive. The change aligns the Checkbox focus treatment with standard Shadcn-style focus-visible behavior by using a two-pixel ring with an offset so Tab navigation has a reliable visual target.

## Impact
Low-risk accessibility improvement. This touches one shared UI primitive class list only and does not modify routes, state, data fetching, backend contracts, exports, or application behavior outside keyboard focus styling.

## Changes Cleared
- Updated `hushh-webapp/components/ui/checkbox.tsx` to use `focus-visible:ring-2`.
- Added `focus-visible:ring-offset-2` with the background offset token for a clean visible outline.
- Preserved existing checked, invalid, disabled, sizing, and Radix Checkbox behavior.

## Verification
- `cd hushh-webapp && npm run verify:design-system`
- `cd hushh-webapp && npm run verify:cache`
- `cd hushh-webapp && npm run verify:docs`
- `cd hushh-webapp && npm run typecheck`
- `cd hushh-webapp && npm run lint -- --max-warnings=0`