### PR TITLE
fix(ui): remove duplicate hidden scrollbars from DialogContent panel sheets

### DIFF
--- a/hushh-webapp/components/ui/dialog.tsx
+++ b/hushh-webapp/components/ui/dialog.tsx
@@ -63,7 +63,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-[500] flex w-full max-w-[calc(100%-2rem)] max-h-[calc(100dvh-2rem)] min-h-0 flex-col overflow-y-auto overscroll-contain [-webkit-overflow-scrolling:touch] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-[var(--app-card-radius-feature)] border border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-default-solid)] p-6 shadow-[var(--app-card-shadow-feature)] duration-200 outline-none sm:max-w-lg",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-[500] flex w-full max-w-[calc(100%-2rem)] max-h-[calc(100dvh-2rem)] min-h-0 flex-col overflow-hidden translate-x-[-50%] translate-y-[-50%] gap-4 rounded-[var(--app-card-radius-feature)] border border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-default-solid)] p-6 shadow-[var(--app-card-shadow-feature)] duration-200 outline-none sm:max-w-lg",
           className
         )}
         {...props}


### PR DESCRIPTION
## Overview
This PR sanitizes the shared DialogContent panel scroll boundary so modal sheets do not create competing vertical scroll containers. The panel now clips its chrome while composed dialog bodies can own the single scrollable region, which keeps header/footer containment crisp on Windows and Linux browsers.

## Impact
Low-risk layout-only refinement. This touches one stock Dialog primitive class list and does not change routes, data fetching, state machines, backend contracts, or application logic. Existing consumers that already provide explicit dialog body scrollers continue to own scrolling without a duplicate parent scrollbar.

## Changes Cleared
- Updated `hushh-webapp/components/ui/dialog.tsx` to replace panel-level `overflow-y-auto` with `overflow-hidden`.
- Removed panel-level momentum/overscroll utilities that only applied to the duplicate parent scroller.
- Preserved DialogContent sizing, positioning, animation, border, background, close button, and Radix behavior.

## Verification
- `cd hushh-webapp && npm run verify:design-system`
- `cd hushh-webapp && npm run verify:cache`
- `cd hushh-webapp && npm run verify:docs`
- `cd hushh-webapp && npm run typecheck`
- `cd hushh-webapp && npm run lint -- --max-warnings=0`