### PR TITLE
fix(ui): hide top app bar navigation icons from assistive technology

### DIFF
--- a/hushh-webapp/components/app-ui/top-app-bar.tsx
+++ b/hushh-webapp/components/app-ui/top-app-bar.tsx
@@ -447,7 +447,7 @@ export function TopAppBar({ className }: TopAppBarProps) {
                         router.push(topShellBreadcrumb.backHref);
                       }}
                     >
-                      <ArrowLeft className="h-5 w-5" />
+                      <ArrowLeft className="h-5 w-5" aria-hidden="true" />
                     </ShellActionSurface>
                   ) : (
                     <div className="h-10 w-10" aria-hidden />
@@ -468,6 +468,7 @@ export function TopAppBar({ className }: TopAppBarProps) {
                             aria-label="Switch role"
                           >
                             <Icon
+                              aria-hidden="true"
                               icon={
                                 switchingPersona
                                   ? Loader2
@@ -495,7 +496,7 @@ export function TopAppBar({ className }: TopAppBarProps) {
                                 aria-label={`Active role: ${activePersona === "ria" ? "RIA" : "Investor"}`}
                               />
                             )}
-                            <ChevronDown className="h-4 w-4 shrink-0 text-current/70 transition-colors group-hover:text-current" />
+                            <ChevronDown className="h-4 w-4 shrink-0 text-current/70 transition-colors group-hover:text-current" aria-hidden="true" />
                           </ShellActionSurface>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent
@@ -508,7 +509,7 @@ export function TopAppBar({ className }: TopAppBarProps) {
                             className="group"
                           >
                             <div className="relative z-10 flex min-w-0 items-center gap-2 text-current">
-                              <UserRound className="h-4 w-4 text-current" />
+                              <UserRound className="h-4 w-4 text-current" aria-hidden="true" />
                               <span>Investor</span>
                             </div>
                             {activePersona === "investor" ? (
@@ -521,7 +522,7 @@ export function TopAppBar({ className }: TopAppBarProps) {
                             className="group"
                           >
                             <div className="relative z-10 flex min-w-0 items-center gap-2 text-current">
-                              <BriefcaseBusiness className="h-4 w-4 text-current" />
+                              <BriefcaseBusiness className="h-4 w-4 text-current" aria-hidden="true" />
                               <span>
                                 {riaCapability === "switch"
                                   ? "RIA"
@@ -547,6 +548,7 @@ export function TopAppBar({ className }: TopAppBarProps) {
                     >
                       {centerTitle.icon ? (
                         <Icon
+                          aria-hidden="true"
                           icon={centerTitle.icon}
                           size="sm"
                           className="shrink-0 text-current"


### PR DESCRIPTION
## Summary

- Hide decorative top app bar navigation/title icons from assistive technology.
- Keep the selected-role checkmarks and top app bar action icons unchanged.

## Scope Proof

- Runtime file touched: `hushh-webapp/components/app-ui/top-app-bar.tsx`.
- Added `aria-hidden="true"` to the back arrow, role switch trigger icon, role switch chevron, role menu leading icons, and static title icon.
- No navigation routing, role switching, notification, consent inbox, menu action, badge, or selected-role state behavior changed.

## Caller Proof

- The back button already exposes `aria-label="Go back"`.
- The role switch trigger already exposes `aria-label="Switch role"` and visible role text.
- The role menu items already expose visible `Investor`, `RIA`, or `Set up RIA` labels.
- The static title icon duplicates the visible title text.
- The active-role check icons were intentionally left visible to assistive technology because they can convey selected state.

## Validation

- `npx.cmd eslint components/app-ui/top-app-bar.tsx --max-warnings=0`
- Verified the commit includes a DCO `Signed-off-by` trailer.
