### PR TITLE
test(config): cover staging backend url resolution

### DIFF
--- a/hushh-webapp/__tests__/lib/config.test.ts
+++ b/hushh-webapp/__tests__/lib/config.test.ts
@@ -167,4 +167,20 @@ describe("config", () => {
 
     expect(config.APP_FRONTEND_ORIGIN).toBe("https://app.hushh.ai");
   });
+
+  it("resolves staging backend url through the normalized UAT environment", async () => {
+    const { resolveAppEnvironment } = await import("@/lib/app-env");
+    const { resolveRuntimeBackendUrl } = await import(
+      "@/lib/runtime/settings"
+    );
+
+    vi.mocked(resolveAppEnvironment).mockReturnValue("uat");
+    vi.mocked(resolveRuntimeBackendUrl).mockReturnValue(
+      "https://staging-api.hushh.ai/",
+    );
+
+    const config = await import("@/lib/config");
+
+    expect(config.BACKEND_URL).toBe("https://staging-api.hushh.ai");
+  });
 });


### PR DESCRIPTION
## Summary

- Add config test coverage for staging backend URL resolution.
- Cover the staging alias path by using the normalized UAT environment and a staging runtime backend URL.

## Scope

- Test-only change in `hushh-webapp/__tests__/lib/config.test.ts`.
- Appends one `it()` block without restructuring the existing suite.
- No runtime config behavior changed.

## Validation

- `npx.cmd vitest run __tests__/lib/config.test.ts`
- Verified the commit includes a DCO `Signed-off-by` trailer.
