### PR TITLE
test(input-group): verify role=group

### DIFF
--- a/hushh-webapp/__tests__/ui/input-group.test.tsx
+++ b/hushh-webapp/__tests__/ui/input-group.test.tsx
@@ -1,0 +1,25 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { InputGroup, InputGroupAddon } from "@/components/ui/input-group";
+
+describe("InputGroup", () => {
+  it("renders root with role='group'", () => {
+    const { container } = render(<InputGroup />);
+    const el = container.querySelector('[data-slot="input-group"]');
+
+    expect(el?.getAttribute("role")).toBe("group");
+  });
+
+  it("renders addon with role='group'", () => {
+    const { container } = render(
+      <InputGroup>
+        <InputGroupAddon>$</InputGroupAddon>
+      </InputGroup>,
+    );
+
+    const el = container.querySelector('[data-slot="input-group-addon"]');
+
+    expect(el?.getAttribute("role")).toBe("group");
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract tests verifying that `InputGroup` and `InputGroupAddon` expose `role="group"` as defined by their current accessibility contract.

## What changed

* Added `__tests__/ui/input-group.test.tsx`
* Verifies `InputGroup` renders with `role="group"`
* Verifies `InputGroupAddon` renders with `role="group"`

## Why

`role="group"` communicates that related controls are presented as a single logical grouping for assistive technologies. These roles are currently part of the component contract and should remain stable over time.

## Scope

* Test-only change
* New test file only
* Static accessibility assertions
* No interaction testing
* No component source changes

## Risk

* Additive-only change
* No production code changes
* No runtime changes
* No visual changes
* No new dependencies
* Minimal diff size
* Low conflict risk
