### PR TITLE
test(progress): cover aria-valuenow

### DIFF
--- a/hushh-webapp/__tests__/ui/progress.test.tsx
+++ b/hushh-webapp/__tests__/ui/progress.test.tsx
@@ -45,4 +45,11 @@ describe("Progress", () => {
 
     expect(indicator.style.transform).toBe("translateX(-100%)");
   });
+  it("sets aria-valuenow to the provided value", () => {
+    const { container } = render(<Progress value={50} />);
+
+    const root = container.querySelector('[data-slot="progress"]');
+
+    expect(root?.getAttribute("aria-valuenow")).toBe("50");
+  });
 });


### PR DESCRIPTION
## Summary

Adds a contract test verifying that `Progress` exposes `aria-valuenow` when a value is provided.

## What changed

* Extended `__tests__/ui/progress.test.tsx`
* Added a single assertion for `aria-valuenow`

## Why

`aria-valuenow` communicates the current progress value to assistive technologies and is part of the component's accessibility contract.

## Scope

* Test-only change
* Single additional test
* No component source changes
* No behavior changes

## Risk

* Additive-only change
* No production code changes
* No runtime changes
* No visual changes
* No new dependencies
* Minimal diff size
* Low conflict risk
