### PR TITLE
test(checkbox): cover aria-required

### DIFF
--- a/hushh-webapp/__tests__/ui/checkbox.test.tsx
+++ b/hushh-webapp/__tests__/ui/checkbox.test.tsx
@@ -17,4 +17,12 @@ describe("Checkbox", () => {
       container.querySelector('[data-slot="checkbox-indicator"]'),
     ).toBeTruthy();
   });
+
+  it("sets aria-required when required is true", () => {
+    const { container } = render(<Checkbox required />);
+
+    const el = container.querySelector('[data-slot="checkbox"]');
+
+    expect(el?.getAttribute("aria-required")).toBe("true");
+  });
 });


### PR DESCRIPTION
## Summary

Adds a contract test verifying that `Checkbox` exposes `aria-required` when the `required` prop is provided.

## What changed

* Extended `__tests__/ui/checkbox.test.tsx`
* Added a single assertion for `aria-required="true"`

## Why

`aria-required` communicates required form participation to assistive technologies and is part of the component's accessibility contract when the `required` prop is used.

## Scope

* Test-only change
* Single additional test
* No component source changes
* No behavior changes

## Risk

* Additive-only change
* No production code changes
* No runtime changes
* No visual changes
* No new dependencies
* Minimal diff size
* Low conflict risk
