### PR TITLE
fix(ui): eliminate redundant height constraints on Separator primitive inside flex rows

### DIFF
--- a/hushh-webapp/components/ui/separator.tsx
+++ b/hushh-webapp/components/ui/separator.tsx
@@ -17,7 +17,7 @@ function Separator({
       orientation={orientation}
       className={cn(
         "shrink-0 bg-border",
-        orientation === "horizontal" ? "h-px w-full" : "h-full w-px",
+        orientation === "horizontal" ? "h-px w-full" : "min-h-4 w-px self-stretch",
         className
       )}
       {...props}


### PR DESCRIPTION
## Overview
This PR stabilizes the shared Separator primitive when vertical dividers are rendered inside dynamic flex-row item arrays. The vertical orientation no longer depends on `h-full`, which can collapse when the parent row does not have a resolved stretched height.

## Impact
Low-risk layout-only refinement. This touches one stock UI primitive class list and does not change routes, data fetching, state machines, backend contracts, exports, or runtime behavior outside separator sizing.

## Changes Cleared
- Updated `hushh-webapp/components/ui/separator.tsx` to remove the vertical `h-full` dependency.
- Replaced the hard height requirement with `self-stretch` so flex rows can provide the cross-axis height naturally.
- Added a small `min-h-4` fallback so vertical separators remain visible in compact inline layouts with unresolved parent height.
- Preserved horizontal separator behavior as `h-px w-full`.

## Verification
- `cd hushh-webapp && npm run verify:design-system`
- `cd hushh-webapp && npm run verify:cache`
- `cd hushh-webapp && npm run verify:docs`
- `cd hushh-webapp && npm run typecheck`
- `cd hushh-webapp && npm run lint -- --max-warnings=0`