### PR TITLE
fix(ui): eliminate duplicate transition-all duration tags from Slider thumb markers

### DIFF
--- a/hushh-webapp/components/labs/liquid-glass-slider-demo.tsx
+++ b/hushh-webapp/components/labs/liquid-glass-slider-demo.tsx
@@ -341,7 +341,7 @@ function LiquidGlassSlider({
         className={
           disabled
             ? `absolute ${CONTROL_RESET_CLASS} cursor-not-allowed`
-            : `absolute ${CONTROL_RESET_CLASS} cursor-pointer transition-transform duration-150 ease-out`
+            : `absolute ${CONTROL_RESET_CLASS} cursor-pointer transition-transform duration-150 ease-out will-change-transform`
         }
         style={{
           height: dimensions.thumbHeight,


### PR DESCRIPTION
## Overview
This PR tightens the liquid-glass Slider thumb marker transition path by keeping the handle on a single transform-focused transition and adding an explicit compositor hint for the scrubbing element. The update is intentionally scoped to the existing lab Slider handle class list so the drag surface remains smooth without introducing new primitives, exports, or production route behavior.

## Impact
- Low risk: one Tailwind utility adjustment inside the existing Slider lab component.
- No frontend route, backend, data, consent, or storage behavior changes.
- Preserves the current sizing, pointer handling, spring positioning, and disabled-state class path.

## Changes Cleared
- Adds `will-change-transform` to the active Slider thumb marker.
- Keeps the thumb on the existing singular `transition-transform` path.
- Avoids broad `transition-all` animation on the handle scrub interaction.

## Verification
- `cd hushh-webapp && npm run verify:design-system`
- `cd hushh-webapp && npm run verify:cache`
- `cd hushh-webapp && npm run verify:docs`
- `cd hushh-webapp && npm run typecheck`
- `cd hushh-webapp && npm run lint -- --max-warnings=0`