### PR TITLE
fix(ui): remove conflicting tracking-tight overrides from custom Heading components

### DIFF
--- a/hushh-webapp/lib/morphy-ux/surfaces.tsx
+++ b/hushh-webapp/lib/morphy-ux/surfaces.tsx
@@ -125,7 +125,7 @@ export const SurfaceCardTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <CardTitle
     ref={ref}
-    className={cn("text-sm font-semibold tracking-tight sm:text-[15px]", className)}
+    className={cn("text-sm font-semibold tracking-normal sm:text-[15px]", className)}
     {...props}
   />
 ));


### PR DESCRIPTION
## Overview
This PR removes the hardcoded `tracking-tight` override from the compact `SurfaceCardTitle` helper and returns the card heading letter spacing to the app's normal typography bounds. The change focuses on readability for dense card titles where tight letter spacing can make short headings feel cramped across modern mobile and desktop surfaces.

## Impact
- Low risk: one shared Morphy surface heading class update.
- No route, backend, data, storage, or consent behavior changes.
- Keeps the existing font size, weight, responsive title scale, and caller override behavior intact.

## Changes Cleared
- Replaces compact `SurfaceCardTitle` `tracking-tight` with `tracking-normal`.
- Preserves the standard `text-sm` / `sm:text-[15px]` heading scale.
- Aligns dense card heading readability with the existing `PageHeader` and `SectionHeader` normal tracking direction.

## Verification
- `cd hushh-webapp && npm run verify:design-system`
- `cd hushh-webapp && npm run verify:cache`
- `cd hushh-webapp && npm run verify:docs`
- `cd hushh-webapp && npm run typecheck`
- `cd hushh-webapp && npm run lint -- --max-warnings=0`