### PR TITLE
fix(ui): resolve scrollbar gutter shifting inside Popover anchor boundaries

### DIFF
--- a/hushh-webapp/components/ui/popover.tsx
+++ b/hushh-webapp/components/ui/popover.tsx
@@ -31,7 +31,7 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden [scrollbar-gutter:stable]",
           className
         )}
         {...props}


### PR DESCRIPTION
## Overview
This PR stabilizes the shared Popover content overlay by reserving a stable scrollbar gutter on the floating content box. It addresses the same class of micro layout shift as the SelectTrigger corrections: interactive overlays should not cause neighboring text or anchor-aligned containers to nudge when browser scrollbar calculations change between open and closed states.

## Impact
- Low risk: one class update on the existing Popover content primitive.
- No route, backend, state, storage, or data-flow behavior changes.
- Preserves the existing Radix portal structure, dimensions, animation classes, anchor alignment, and caller `className` override path.

## Changes Cleared
- Adds `[scrollbar-gutter:stable]` to `PopoverContent`.
- Keeps Popover width, transform origin, side animations, border, padding, and shadow unchanged.
- Stabilizes overlay gutter calculations without introducing a wrapper or new primitive API.

## Verification
- `cd hushh-webapp && npm run verify:design-system`
- `cd hushh-webapp && npm run verify:cache`
- `cd hushh-webapp && npm run verify:docs`
- `cd hushh-webapp && npm run typecheck`
- `cd hushh-webapp && npm run lint -- --max-warnings=0`