### PR TITLE
fix(ui): hardware accelerate TooltipContent animation reveals via scale transforms

### DIFF
--- a/hushh-webapp/components/ui/tooltip.tsx
+++ b/hushh-webapp/components/ui/tooltip.tsx
@@ -42,7 +42,7 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          "bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) transform-gpu rounded-md px-3 py-1.5 text-xs text-balance will-change-transform",
           className
         )}
         {...props}


### PR DESCRIPTION
## Overview
This PR promotes the existing `TooltipContent` scale reveal onto the browser compositor by adding `transform-gpu` and `will-change-transform` to the shared Tooltip content viewport. The primitive already uses scale-based `zoom-in-95` / `zoom-out-95` animation classes, and this update makes that path explicit for smoother hover reveals on high refresh-rate displays.

## Impact
- Low risk: one class-list update on the existing Tooltip primitive.
- No route, backend, data, storage, or state behavior changes.
- Preserves Tooltip sizing, portal behavior, side offsets, arrow rendering, and caller `className` overrides.

## Changes Cleared
- Adds compositor-focused transform promotion to `TooltipContent`.
- Keeps the current fade and scale reveal semantics intact.
- Avoids layout-measuring animation changes, preventing paint invalidation frames during pointer-triggered tooltip reveals.

## Verification
- `cd hushh-webapp && npm run verify:design-system`
- `cd hushh-webapp && npm run verify:cache`
- `cd hushh-webapp && npm run verify:docs`
- `cd hushh-webapp && npm run typecheck`
- `cd hushh-webapp && npm run lint -- --max-warnings=0`