### PR TITLE
fix(consent): restore non-intrusive focus ring on consent scope panel

### DIFF
--- a/hushh-webapp/components/consent/consent-dialog.tsx
+++ b/hushh-webapp/components/consent/consent-dialog.tsx
@@ -146,7 +146,7 @@ export function ConsentDialog({
           <div
             ref={scopeInfoRef}
             tabIndex={-1}
-            className="flex items-start gap-3 p-3 rounded-xl bg-blue-50 dark:bg-blue-950/40 border border-blue-200/60 dark:border-blue-800/40 focus:outline-none"
+            className="flex items-start gap-3 p-3 rounded-xl bg-blue-50 dark:bg-blue-950/40 border border-blue-200/60 dark:border-blue-800/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
             style={scopeInfo.colorHex ? {
               backgroundColor: `${scopeInfo.colorHex}08`,
               borderColor: `${scopeInfo.colorHex}20`,


### PR DESCRIPTION
## Overview
This PR restores a visible, non-intrusive focus-visible marker on the consent scope panel in the consent dialog. The change replaces absolute focus suppression on the programmatically focused scope container with the standard ring layer used across the app, preserving the existing flex layout, border treatment, and dynamic scope color styling.

## Impact
- Low-risk: touches only one verified consent dialog layout file.
- No shared primitive mutation: does not alter Alert, Dialog, Button, or global design-system behavior.
- Accessibility-focused: restores keyboard-visible focus treatment without changing consent data flow, state machines, or backend contracts.

## Changes Cleared
- Replaced hardcoded focus outline suppression on the consent scope panel.
- Added focus-visible ring, primary ring color, and background-aware ring offset utilities.
- Preserved existing spacing, flex alignment, border colors, and dynamic scope styling.

## Verification
- npm run verify:design-system
- npm run verify:cache
- npm run verify:docs
- npm run typecheck
- npm run lint -- --max-warnings=0