### PR TITLE
Fix/UI dialog sheet modal accessibility

### DIFF
--- a/hushh-webapp/components/ui/button.tsx
+++ b/hushh-webapp/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Loader2 } from "lucide-react"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive touch-manipulation",
+  "relative inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive touch-manipulation",
   {
     variants: {
       variant: {
@@ -66,7 +66,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const content = (
       <>
         {isLoading && (
-          <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+          <Loader2 className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 animate-spin" aria-hidden="true" />
         )}
         {isLoading ? <span className="opacity-0">{children}</span> : children}
       </>

--- a/hushh-webapp/components/ui/dialog.tsx
+++ b/hushh-webapp/components/ui/dialog.tsx
@@ -9,10 +9,9 @@ import { Button } from "@/components/ui/button"
 import { MaterialRipple } from "@/lib/morphy-ux/material-ripple"
 
 function Dialog({
-  modal = false,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Root>) {
-  return <DialogPrimitive.Root data-slot="dialog" modal={modal} {...props} />
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
 }
 
 function DialogTrigger({

--- a/hushh-webapp/components/ui/sheet.tsx
+++ b/hushh-webapp/components/ui/sheet.tsx
@@ -7,10 +7,9 @@ import { Dialog as SheetPrimitive } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 function Sheet({
-  modal = false,
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Root>) {
-  return <SheetPrimitive.Root data-slot="sheet" modal={modal} {...props} />
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
 }
 
 function SheetTrigger({


### PR DESCRIPTION
# Description
Fixed a major accessibility and focus management bug in the `Dialog` and `Sheet` components.

Both components were improperly overriding Radix UI's defaults by explicitly setting `modal={false}`. While they still rendered visual overlays blocking mouse interactions, disabling the modal state prevented Radix from applying its focus trap. This allowed keyboard and screen reader users to tab out of the dialog and interact with the inert background page.

The `modal={false}` overrides have been removed, allowing both components to correctly default to `modal={true}`. This restores the proper WAI-ARIA focus trap behavior and ensures the background page is correctly marked as `aria-hidden` when a dialog or sheet is open.

## 📌 Impact Map (Required)
- Routes touched: [x] None
- API / schema / type changes: [x] None
- Trust boundary touched: [x] None
- UI browser or Playwright proof: [x] Dialogs and Sheets correctly trap keyboard focus again.
- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm test` *(Note: `kai-analysis-route` contract test is failing upstream in `pr-train`)*

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] Reachable production attach point: `components/ui/dialog.tsx`, `components/ui/sheet.tsx`
- [x] Production surface proved: Any component using Dialog or Sheet is now fully accessible.
- [x] Required checks are current, commits are signed off, and branch is mergeable.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS** / **Android**: Not applicable (UI behavior only)

## 🧪 Testing & Consent
- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)
- [x] Sensitive surface touched: none