### PR TITLE
fix(ui): correct switch thumb translation geometry by using border-2

### DIFF
--- a/hushh-webapp/components/ui/switch.tsx
+++ b/hushh-webapp/components/ui/switch.tsx
@@ -17,7 +17,7 @@ function Switch({
       data-slot="switch"
       data-size={size}
       className={cn(
-        "peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-5 data-[size=default]:w-9 data-[size=sm]:h-4 data-[size=sm]:w-7 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80",
+        "peer group/switch inline-flex shrink-0 items-center rounded-full border-2 border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-5 data-[size=default]:w-9 data-[size=sm]:h-4 data-[size=sm]:w-7 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80",
         className
       )}
       {...props}


### PR DESCRIPTION
# Description
Fixed a geometric asymmetry in the `Switch` component's thumb translation. 

The switch track previously used a 1px `border`, giving it an inner width that was physically larger than the thumb's hard-coded translation distance. Because of this mathematical mismatch, the switch thumb would visibly fall 2px short of the right edge when checked, but touch the left edge perfectly when unchecked.

The track has been updated to use `border-2`. This provides a consistent 2px inset padding on all edges, reducing the inner track width to perfectly match the `translate-x-4` (16px) travel distance of the 16px thumb. The switch travel is now perfectly symmetric across both `default` and `sm` sizes.

## 📌 Impact Map (Required)
- Routes touched: [x] None
- API / schema / type changes: [x] None
- Trust boundary touched: [x] None
- UI browser or Playwright proof: [x] Switch thumb sits completely flush against the right edge when checked.
- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm test` *(Note: `kai-analysis-route` contract test is failing upstream in `pr-train`)*

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] Reachable production attach point: `components/ui/switch.tsx`
- [x] Production surface proved: Switch components animate symmetrically.
- [x] Required checks are current, commits are signed off, and branch is mergeable.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation

## 🧪 Testing & Consent
- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)
- [x] Sensitive surface touched: none