### PR TITLE
fix(ui): remove buggy absolute positioning from radio group indicator dot

### DIFF
--- a/hushh-webapp/components/ui/radio-group.tsx
+++ b/hushh-webapp/components/ui/radio-group.tsx
@@ -38,7 +38,7 @@ function RadioGroupItem({
       >
         <CircleIcon
           aria-hidden="true"
-          className="fill-primary absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2"
+          className="fill-primary text-primary size-2"
         />
       </RadioGroupPrimitive.Indicator>
     </RadioGroupPrimitive.Item>


### PR DESCRIPTION
# Description
Fixed a major layout bug in `RadioGroupItem` where the active indicator dot escaped the component boundaries.

Previously, the `CircleIcon` used for the checked state was given `absolute` centering classes (`absolute top-1/2 left-1/2...`), but neither its parent `Indicator` wrapper nor the `RadioGroupItem` itself had `relative` positioning applied. This caused the dot to position itself relative to the nearest arbitrary `relative` ancestor on the page, completely detaching from the radio button.

The buggy absolute positioning classes have been removed. The parent `Indicator` wrapper already utilizes `flex items-center justify-center`, which now correctly and safely centers the dot natively within the bounds of the radio button.

## 📌 Impact Map (Required)
- Routes touched: [x] None
- API / schema / type changes: [x] None
- Trust boundary touched: [x] None
- UI browser or Playwright proof: [x] Checked radio buttons now correctly display the dot centered within their own bounds.
- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm test` *(Note: `kai-analysis-route` contract test is failing upstream in `pr-train`)*

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] Reachable production attach point: `components/ui/radio-group.tsx`
- [x] Production surface proved: Any form using RadioGroup correctly displays checked states.
- [x] Required checks are current, commits are signed off, and branch is mergeable.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS** / **Android**: Not applicable (UI behavior only)

## 🧪 Testing & Consent
- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)
- [x] Sensitive surface touched: none