### PR TITLE
fix(ui): remove size-2.5 from tooltip arrow to prevent geometric distortion

### DIFF
--- a/hushh-webapp/components/ui/tooltip.tsx
+++ b/hushh-webapp/components/ui/tooltip.tsx
@@ -48,7 +48,7 @@ function TooltipContent({
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="fill-foreground z-50 size-2.5" />
+        <TooltipPrimitive.Arrow className="fill-foreground z-50" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )


### PR DESCRIPTION
# Description
Fixed a geometric distortion bug in the `Tooltip` component's pointer arrow.

The `TooltipPrimitive.Arrow` SVG was previously styled with the Tailwind `size-2.5` class, which hardcoded both its width and height to 10px. However, the native Radix tooltip arrow SVG is drawn with a 2:1 aspect ratio (10px wide, 5px high). Forcing it into a 10x10 square severely distorted the path, stretching the arrow vertically and creating an unnaturally sharp, elongated spike.

The explicit size override has been removed, allowing the SVG to correctly respect its native dimensions and render as a smooth, proportional triangle.

## 📌 Impact Map (Required)
- Routes touched: [x] None
- API / schema / type changes: [x] None
- Trust boundary touched: [x] None
- UI browser or Playwright proof: [x] Tooltip arrows now render proportionally without vertical stretching.
- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm test` *(Note: `kai-analysis-route` contract test is failing upstream in `pr-train`)*

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] Reachable production attach point: `components/ui/tooltip.tsx`
- [x] Production surface proved: All tooltips display the correct arrow geometry.
- [x] Required checks are current, commits are signed off, and branch is mergeable.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS** / **Android**: Not applicable (UI behavior only)

## 🧪 Testing & Consent
- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)
- [x] Sensitive surface touched: none