### PR TITLE
fix(ui): add object-cover to avatar image to prevent aspect ratio distortion

### DIFF
--- a/hushh-webapp/components/ui/avatar.tsx
+++ b/hushh-webapp/components/ui/avatar.tsx
@@ -33,7 +33,7 @@ function AvatarImage({
   return (
     <AvatarPrimitive.Image
       data-slot="avatar-image"
-      className={cn("aspect-square size-full", className)}
+      className={cn("aspect-square size-full object-cover", className)}
       alt={alt}
       {...props}
     />


### PR DESCRIPTION
# Description
Fixed a visual distortion bug in the `AvatarImage` component where non-square images would appear squished or stretched.

The component's class string was missing the standard `object-cover` utility. Because the container forces an `aspect-square` ratio, any user-uploaded or external profile picture that wasn't perfectly square would stretch to fill the bounds instead of cropping gracefully. 

Adding `object-cover` ensures that all avatar images maintain their natural aspect ratios and cleanly cover the circular boundary without visual distortion.

## 📌 Impact Map (Required)
- Routes touched: [x] None
- API / schema / type changes: [x] None
- Trust boundary touched: [x] None
- UI browser or Playwright proof: [x] Non-square profile pictures correctly crop to fit the avatar circle instead of stretching horizontally or vertically.
- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm test` *(Note: `kai-analysis-route` contract test is failing upstream in `pr-train`)*

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] Reachable production attach point: `components/ui/avatar.tsx`
- [x] Production surface proved: Any UI rendering `Avatar` now properly handles non-square aspect ratio images.
- [x] Required checks are current, commits are signed off, and branch is mergeable.

## 🧪 Testing & Consent
- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)
- [x] Sensitive surface touched: none