### PR TITLE
test(radio-group): cover only one option has aria-checked true

### DIFF
--- a/hushh-webapp/__tests__/ui/radio-group.test.tsx
+++ b/hushh-webapp/__tests__/ui/radio-group.test.tsx
@@ -37,4 +37,21 @@ describe("RadioGroup", () => {
       container.querySelector('[data-slot="radio-group-indicator"]'),
     ).toBeTruthy();
   });
+
+  it("marks only one option as aria-checked true", () => {
+    const { container } = render(
+      <RadioGroup defaultValue="b">
+        <RadioGroupItem value="a" />
+        <RadioGroupItem value="b" />
+        <RadioGroupItem value="c" />
+      </RadioGroup>,
+    );
+
+    const checkedOptions = Array.from(
+      container.querySelectorAll('[role="radio"][aria-checked="true"]'),
+    );
+
+    expect(checkedOptions).toHaveLength(1);
+    expect(checkedOptions[0].getAttribute("value")).toBe("b");
+  });
 });


### PR DESCRIPTION
## Summary
- Add a focused RadioGroup regression test for `aria-checked` state.
- Verify a three-option group exposes exactly one option with `aria-checked=true`.
- Keep the change limited to the existing UI test file.

## Scope
- Changed file: `hushh-webapp/__tests__/ui/radio-group.test.tsx`
- Production code unchanged.

## Validation
- `npx.cmd vitest run __tests__/ui/radio-group.test.tsx`