### PR TITLE
test(config): cover frontend origin matches production domain

### DIFF
--- a/hushh-webapp/__tests__/lib/config.test.ts
+++ b/hushh-webapp/__tests__/lib/config.test.ts
@@ -80,6 +80,22 @@ describe("config", () => {
     expect(config.APP_FRONTEND_ORIGIN).toBe("http://localhost:3000");
   });
 
+  it("resolves production frontend origin to the production domain", async () => {
+    const { resolveAppEnvironment } = await import("@/lib/app-env");
+    const { resolveRuntimeFrontendUrl } = await import(
+      "@/lib/runtime/settings"
+    );
+
+    vi.mocked(resolveAppEnvironment).mockReturnValue("production");
+    vi.mocked(resolveRuntimeFrontendUrl).mockReturnValue(
+      "https://kai.hushh.ai/"
+    );
+
+    const config = await import("@/lib/config");
+
+    expect(config.APP_FRONTEND_ORIGIN).toBe("https://kai.hushh.ai");
+  });
+
   it("keeps production backend empty when runtime backend url is empty", async () => {
     const { resolveAppEnvironment } = await import("@/lib/app-env");
     const { resolveRuntimeBackendUrl } = await import(


### PR DESCRIPTION
## Summary
- Add a focused config test for the production frontend origin.
- Mock production runtime settings with the canonical `https://kai.hushh.ai/` app URL.
- Verify `APP_FRONTEND_ORIGIN` normalizes to `https://kai.hushh.ai`.

## Scope
- Changed file: `hushh-webapp/__tests__/lib/config.test.ts`
- Production code unchanged.

## Validation
- `npx.cmd vitest run __tests__/lib/config.test.ts`