### PR TITLE
test(env-contract): cover production fallback when runtime url missing

### DIFF
--- a/hushh-webapp/__tests__/lib/env-contract.test.ts
+++ b/hushh-webapp/__tests__/lib/env-contract.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/app-env", () => ({
+  resolveAppEnvironment: vi.fn(),
+}));
+
+vi.mock("@/lib/runtime/settings", () => ({
+  resolveRuntimeBackendUrl: vi.fn(),
+  resolveRuntimeFrontendUrl: vi.fn(),
+}));
+
+describe("env contract", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("keeps production fallback empty when runtime urls are missing", async () => {
+    const { resolveAppEnvironment } = await import("@/lib/app-env");
+    const { resolveRuntimeBackendUrl, resolveRuntimeFrontendUrl } =
+      await import("@/lib/runtime/settings");
+
+    vi.mocked(resolveAppEnvironment).mockReturnValue("production");
+    vi.mocked(resolveRuntimeBackendUrl).mockReturnValue("");
+    vi.mocked(resolveRuntimeFrontendUrl).mockReturnValue("");
+
+    const config = await import("@/lib/config");
+
+    expect(config.BACKEND_URL).toBe("");
+    expect(config.APP_FRONTEND_ORIGIN).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
- Add an env contract test for production runtime URL fallback behavior.
- Mock production mode with missing backend and frontend runtime URLs.
- Verify config does not fall back to development localhost defaults in production.

## Scope
- Changed file: `hushh-webapp/__tests__/lib/env-contract.test.ts`
- Production code unchanged.

## Validation
- `npx.cmd vitest run __tests__/lib/env-contract.test.ts`