### PR TITLE
fix(ui): hide renaissance market list search icons from assistive technology

### DIFF
--- a/hushh-webapp/components/kai/cards/renaissance-market-list.tsx
+++ b/hushh-webapp/components/kai/cards/renaissance-market-list.tsx
@@ -336,7 +336,7 @@ export function RiaPicksList({
                     )}
                     aria-label="Search list"
                   >
-                    <Search className="h-4 w-4" />
+                    <Search aria-hidden="true" className="h-4 w-4" />
                   </button>
                   <button
                     type="button"
@@ -369,7 +369,10 @@ export function RiaPicksList({
                 {activeMobileControl === "search" ? (
                   <SurfaceInset className="px-3 py-3">
                     <div className="relative">
-                      <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                      <Search
+                        aria-hidden="true"
+                        className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                      />
                       <Input
                         value={query}
                         onChange={(event) => setQuery(event.target.value)}
@@ -515,7 +518,10 @@ export function RiaPicksList({
               <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_180px]">
                 <MarketListControlField label="Search">
                   <div className="relative">
-                    <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                    <Search
+                      aria-hidden="true"
+                      className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                    />
                     <Input
                       value={query}
                       onChange={(event) => setQuery(event.target.value)}


### PR DESCRIPTION
## Summary
- Add `aria-hidden=true` to the Renaissance market list search icon button glyph.
- Add `aria-hidden=true` to the mobile and desktop search input adornment icons.
- Preserve the existing `Search list` button label, input placeholders, filtering behavior, and visual styling.

## Scope
- Changed file: `hushh-webapp/components/kai/cards/renaissance-market-list.tsx`
- Changed component: `RiaPicksList`
- Production behavior unchanged; this only hides decorative SVG icons from assistive technology.

## Validation
- `npx.cmd eslint components/kai/cards/renaissance-market-list.tsx --max-warnings=0`