### PR TITLE
fix(ui): hide sector allocation expansion chevrons from assistive technology

### DIFF
--- a/hushh-webapp/components/kai/charts/sector-allocation-chart.tsx
+++ b/hushh-webapp/components/kai/charts/sector-allocation-chart.tsx
@@ -405,9 +405,9 @@ export function SectorAllocationChart({
                         {sector.count} holding{sector.count !== 1 ? "s" : ""}
                       </span>
                       {isOpen ? (
-                        <ChevronUp className="h-4 w-4 text-muted-foreground" />
+                        <ChevronUp aria-hidden="true" className="h-4 w-4 text-muted-foreground" />
                       ) : (
-                        <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                        <ChevronDown aria-hidden="true" className="h-4 w-4 text-muted-foreground" />
                       )}
                     </button>
                   </CollapsibleTrigger>


### PR DESCRIPTION
## Summary
- Add `aria-hidden=true` to the sector allocation expansion chevron icons.
- Preserve the collapsible button text, state, behavior, and styling.
- Keep the accessibility change scoped to the decorative SVG indicators.

## Scope
- Changed file: `hushh-webapp/components/kai/charts/sector-allocation-chart.tsx`
- Changed component: `SectorAllocationChart`
- Production behavior unchanged.

## Validation
- `npx.cmd eslint components/kai/charts/sector-allocation-chart.tsx --max-warnings=0`