### PR TITLE
test(config): cover empty string app env treated as development

### DIFF
--- a/hushh-webapp/__tests__/lib/config.test.ts
+++ b/hushh-webapp/__tests__/lib/config.test.ts
@@ -167,4 +167,52 @@ describe("config", () => {
 
     expect(config.APP_FRONTEND_ORIGIN).toBe("https://app.hushh.ai");
   });
+
+  it("treats empty string app env as development", async () => {
+    const originalAppEnv = process.env.NEXT_PUBLIC_APP_ENV;
+    const originalObservabilityEnv = process.env.NEXT_PUBLIC_OBSERVABILITY_ENV;
+    const originalEnvironmentMode = process.env.NEXT_PUBLIC_ENVIRONMENT_MODE;
+    const originalNodeEnv = process.env.NODE_ENV;
+
+    vi.doUnmock("@/lib/app-env");
+    vi.resetModules();
+
+    process.env.NEXT_PUBLIC_APP_ENV = "";
+    delete process.env.NEXT_PUBLIC_OBSERVABILITY_ENV;
+    delete process.env.NEXT_PUBLIC_ENVIRONMENT_MODE;
+    process.env.NODE_ENV = "development";
+
+    const { resolveRuntimeBackendUrl, resolveRuntimeFrontendUrl } =
+      await import("@/lib/runtime/settings");
+
+    vi.mocked(resolveRuntimeBackendUrl).mockReturnValue("");
+    vi.mocked(resolveRuntimeFrontendUrl).mockReturnValue("");
+
+    const config = await import("@/lib/config");
+
+    expect(config.ENVIRONMENT_MODE).toBe("development");
+    expect(config.BACKEND_URL).toBe("http://127.0.0.1:8000");
+    expect(config.APP_FRONTEND_ORIGIN).toBe("http://localhost:3000");
+
+    if (originalAppEnv === undefined) {
+      delete process.env.NEXT_PUBLIC_APP_ENV;
+    } else {
+      process.env.NEXT_PUBLIC_APP_ENV = originalAppEnv;
+    }
+    if (originalObservabilityEnv === undefined) {
+      delete process.env.NEXT_PUBLIC_OBSERVABILITY_ENV;
+    } else {
+      process.env.NEXT_PUBLIC_OBSERVABILITY_ENV = originalObservabilityEnv;
+    }
+    if (originalEnvironmentMode === undefined) {
+      delete process.env.NEXT_PUBLIC_ENVIRONMENT_MODE;
+    } else {
+      process.env.NEXT_PUBLIC_ENVIRONMENT_MODE = originalEnvironmentMode;
+    }
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Add a focused config test for an empty `NEXT_PUBLIC_APP_ENV` string.
- Use the real `app-env` resolver in this test to prove the empty value falls back to development.
- Verify development backend and frontend defaults are selected when runtime URLs are empty.

## Scope
- Changed file: `hushh-webapp/__tests__/lib/config.test.ts`
- Production code unchanged.

## Validation
- `npx.cmd vitest run __tests__/lib/config.test.ts`