### PR TITLE
fix(one-location): normalize network connection pair keys

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -3145,7 +3145,9 @@ class OneLocationAgentService:
               invite_id, status, connected_at, created_at, updated_at, metadata
             )
             VALUES (
-              :user_a_id, :user_b_id, :inviter_user_id, :invitee_user_id,
+              LEAST(CAST(:user_a_id AS TEXT), CAST(:user_b_id AS TEXT)), 
+              GREATEST(CAST(:user_a_id AS TEXT), CAST(:user_b_id AS TEXT)), 
+              :inviter_user_id, :invitee_user_id,
               CAST(:invite_id AS UUID), 'active', NOW(), NOW(), NOW(),
               CAST(:metadata_json AS JSONB)
             )


### PR DESCRIPTION
## Summary
- Normalize one-location network connection pair ordering using LEAST/GREATEST during insert into one_location_network_connections.
- Prevent duplicate connection rows when user_id order is reversed.
- This is a focused safety fix for invite/onboarding dedup behavior.

## Scope
- File: consent-protocol/hushh_mcp/services/one_location_agent_service.py
- SQL insert for network connection pair row