### PR TITLE
fix(notification-panel): enforce button type and suppress decorative icon in dismiss control

### DIFF
--- a/hushh-webapp/components/app-ui/debate-task-center.tsx
+++ b/hushh-webapp/components/app-ui/debate-task-center.tsx
@@ -400,6 +400,7 @@ export function DebateTaskCenter({ triggerClassName, renderTrigger }: DebateTask
           ) : null}
           {task.status !== "running" ? (
             <Button
+              type="button"
               variant="none"
               effect="fade"
               size="icon"
@@ -544,6 +545,7 @@ export function DebateTaskCenter({ triggerClassName, renderTrigger }: DebateTask
                         ) : null}
                         {item.task.status !== "running" ? (
                           <Button
+                            type="button"
                             variant="none"
                             effect="fade"
                             size="icon"


### PR DESCRIPTION
﻿## Summary
- Add explicit `type="button"` to notification panel dismiss controls.
- Preserve the existing `aria-label="Dismiss task"` labels.
- Keep the decorative `X` icons hidden from assistive technology with `aria-hidden="true"`.

## Scope
- Changed file: `hushh-webapp/components/app-ui/debate-task-center.tsx`
- Production behavior unchanged.

## Validation
- `npx.cmd eslint components/app-ui/debate-task-center.tsx --max-warnings=0`
