### PR TITLE
fix(one-location): align invite migrations for location defaults

### DIFF
--- a/consent-protocol/db/migrations/064_one_location_public_invites.sql
+++ b/consent-protocol/db/migrations/064_one_location_public_invites.sql
@@ -84,7 +84,11 @@ ALTER TABLE one_location_events
       'location_referral_invite',
       'location_public_invite_created',
       'location_public_invite_revoked',
-      'location_public_invite_submitted'
+      'location_public_invite_submitted',
+      'location_circle_invite_created',
+      'location_circle_invite_claimed',
+      'location_circle_invite_revoked',
+      'location_one_network_joined'
     )
   );
 

--- a/consent-protocol/db/migrations/068_one_location_circle_invites.sql
+++ b/consent-protocol/db/migrations/068_one_location_circle_invites.sql
@@ -101,7 +101,7 @@ ALTER TABLE one_location_events
       'location_circle_invite_revoked',
       'location_one_network_joined'
     )
-  );
+  ) NOT VALID;
 
 COMMENT ON TABLE one_location_circle_invites IS
   'Hash-only Invite to One links. Claiming creates a mutual One Network connection and never grants live location access directly.';


### PR DESCRIPTION
Maintainer patch: normalizes the two one-location invite migration paths after the latest invite schema evolution.