### PR TITLE
fix(consent): strip escaped control sequences from resolveConsentNavigationTarget inputs

### DIFF
--- a/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
+++ b/hushh-webapp/__tests__/utils/consent-sheet-route.test.ts
@@ -224,5 +224,14 @@ describe("path resolver safety — dangerous edge case handling", () => {
     );
     expect(result.kind).toBe("external");
   });
+
+  it("strips escaped control sequences such as backspaces from incoming path strings to ensure path isolation", () => {
+    const maliciousControlInput = "/consent/callback\b/unauthorized-leak";
+    const result = resolveConsentNavigationTarget(maliciousControlInput);
+
+    expect(result.href).not.toContain("\b");
+  });
 });
 // ── End path safety coverage ──────────────────────────────────────────────────
+
+

--- a/hushh-webapp/lib/consent/consent-sheet-route.ts
+++ b/hushh-webapp/lib/consent/consent-sheet-route.ts
@@ -10,6 +10,10 @@ export const CONSENT_LEGACY_PANEL_QUERY_KEY = "panel";
 export const CONSENT_LEGACY_PANEL_VALUE = "consents";
 export const CONSENT_TAB_QUERY_KEY = "tab";
 
+// Escaped control characters (\b backspace, \f form-feed, \v vertical-tab) that
+// must be stripped from incoming navigation paths to prevent path-leak bugs.
+const CONTROL_SEQUENCE_PATTERN = /[\b\f\v]/g;
+
 export type ConsentSheetView = "pending" | "active" | "previous";
 export type ConsentCenterManagerView = Extract<ConsentCenterView, "incoming" | "outgoing">;
 export type ConsentNavigationTarget =
@@ -226,7 +230,12 @@ export function resolveConsentNavigationTarget(
     from?: string;
   }
 ): ConsentNavigationTarget {
-  const nextHref = resolveConsentRequestHref(href, fallbackView, options);
+  const sanitizedHref =
+    typeof href === "string" && CONTROL_SEQUENCE_PATTERN.test(href)
+      ? href.replace(CONTROL_SEQUENCE_PATTERN, "")
+      : href;
+  const nextHref = resolveConsentRequestHref(sanitizedHref, fallbackView, options);
+
   if (isInternalAppHref(nextHref)) {
     const [pathname] = nextHref.split("?", 1);
     return {


### PR DESCRIPTION
## Summary
Patches an isolated path-leak boundary defect inside resolveConsentNavigationTarget to cleanly sanitize raw input variables from escaped control sequences.

## Production function exercised
- hushh-webapp/lib/consent/consent-sheet-route.ts targeting resolveConsentNavigationTarget

## CI gate checklist
- [x] PR Base Policy — targets integration/pr-train
- [x] DCO — Signed-off-by Verified
- [x] Narrow surface — Isolated core changes with minimal additive lines
- [x] Title Sync — Branch, title, and commit are strictly matched verbatim
- [x] Proof — local test runner verified clean output