### PR TITLE
test(app-env): cover environment precedence

### DIFF
--- a/hushh-webapp/__tests__/lib/app-env.test.ts
+++ b/hushh-webapp/__tests__/lib/app-env.test.ts
@@ -14,6 +14,13 @@ describe("resolveAppEnvironment", () => {
 
     expect(resolveAppEnvironment()).toBe("development");
   });
+  it("prefers NEXT_PUBLIC_APP_ENV over fallback environments", () => {
+  process.env.NEXT_PUBLIC_APP_ENV = "development";
+  process.env.NEXT_PUBLIC_OBSERVABILITY_ENV = "uat";
+  process.env.NEXT_PUBLIC_ENVIRONMENT_MODE = "production";
+
+  expect(resolveAppEnvironment()).toBe("development");
+  });
 
   it("maps dev to development", () => {
     process.env.NEXT_PUBLIC_APP_ENV = "dev";


### PR DESCRIPTION
## Summary

Adds test coverage for environment resolution precedence.

### Added coverage

Verifies that `NEXT_PUBLIC_APP_ENV` takes precedence over fallback environment variables when multiple environment sources are configured.

### Why

`resolveAppEnvironment()` resolves environments in the following order:

1. `NEXT_PUBLIC_APP_ENV`
2. `NEXT_PUBLIC_OBSERVABILITY_ENV`
3. `NEXT_PUBLIC_ENVIRONMENT_MODE`
4. `NODE_ENV`

This test documents and protects the intended precedence behavior against future regressions.
