### PR TITLE
test(runtime-settings): cover backend URL precedence

### DIFF
--- a/hushh-webapp/__tests__/lib/runtime-settings.test.ts
+++ b/hushh-webapp/__tests__/lib/runtime-settings.test.ts
@@ -18,6 +18,15 @@ describe("runtime settings", () => {
     expect(resolveRuntimeBackendUrl()).toBe("https://runtime.example.com");
   });
 
+  it("prefers BACKEND_URL over NEXT_PUBLIC_BACKEND_URL", () => {
+  process.env.BACKEND_URL = "https://internal.example.com";
+  process.env.NEXT_PUBLIC_BACKEND_URL = "https://public.example.com";
+
+  expect(resolveRuntimeBackendUrl()).toBe(
+    "https://internal.example.com"
+  );
+  });
+
   it("returns an empty string when runtime backend urls are empty", async () => {
     process.env.BACKEND_URL = "";
     process.env.NEXT_PUBLIC_BACKEND_URL = "   ";


### PR DESCRIPTION
## Summary

Adds test coverage for runtime backend URL precedence.

### Added coverage

Verifies that `BACKEND_URL` takes precedence over `NEXT_PUBLIC_BACKEND_URL` when both values are configured.

### Why

`resolveRuntimeBackendUrl()` resolves the backend URL using `BACKEND_URL` first and falls back to `NEXT_PUBLIC_BACKEND_URL` only when needed. This test documents and protects that precedence behavior against future regressions.
