### PR TITLE
test(runtime-settings): cover voice preference truthy parsing

### DIFF
--- a/hushh-webapp/__tests__/lib/runtime-settings.test.ts
+++ b/hushh-webapp/__tests__/lib/runtime-settings.test.ts
@@ -1,14 +1,19 @@
 import { afterEach, describe, expect, it } from "vitest";
 
-import { resolveRuntimeBackendUrl } from "@/lib/runtime/settings";
+import {
+  resolveRuntimeBackendUrl,
+  resolveVoiceDirectBackendPreference,
+} from "@/lib/runtime/settings";
 
 describe("runtime settings", () => {
   const originalBackendUrl = process.env.BACKEND_URL;
   const originalPublicBackendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+  const originalVoiceDirectBackend = process.env.NEXT_PUBLIC_VOICE_DIRECT_BACKEND;
 
   afterEach(() => {
     process.env.BACKEND_URL = originalBackendUrl;
     process.env.NEXT_PUBLIC_BACKEND_URL = originalPublicBackendUrl;
+    process.env.NEXT_PUBLIC_VOICE_DIRECT_BACKEND = originalVoiceDirectBackend;
   });
 
   it("normalizes carriage return line endings around runtime backend urls", () => {
@@ -27,5 +32,10 @@ describe("runtime settings", () => {
     );
 
     expect(resolveFreshRuntimeBackendUrl()).toBe("");
+  });
+  it("treats enabled as truthy for direct backend preference", () => {
+  process.env.NEXT_PUBLIC_VOICE_DIRECT_BACKEND = "enabled";
+
+  expect(resolveVoiceDirectBackendPreference()).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Adds test coverage for voice preference truthy parsing.

### Added coverage

Verifies that `resolveVoiceDirectBackendPreference()` treats `"enabled"` as a truthy value.

### Why

Voice preference helpers rely on shared truthy parsing logic. This test documents and protects the expected behavior for supported truthy values.
