### PR TITLE
test(browser-navigation): cover replace navigation events

### DIFF
--- a/hushh-webapp/__tests__/lib/utils/browser-navigation.test.ts
+++ b/hushh-webapp/__tests__/lib/utils/browser-navigation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   assignWindowLocation,
+  replaceWindowLocation,
   INTERNAL_APP_NAVIGATION_REQUEST_EVENT,
   normalizeInternalAppNavigationHref,
   requestInternalAppNavigation,
@@ -45,5 +46,44 @@ describe("browser navigation utilities", () => {
     expect(received).toEqual([
       { href: `${ROUTES.KAI_ANALYSIS}?focus=active`, scroll: false },
     ]);
+  });
+  it("routes internal replaceWindowLocation calls through the app navigation event", () => {
+  const received: Array<{
+    href: string;
+    replace?: boolean;
+    scroll?: boolean;
+  }> = [];
+
+  const listener = (event: Event) => {
+    received.push(
+      (event as CustomEvent<{
+        href: string;
+        replace?: boolean;
+        scroll?: boolean;
+      }>).detail,
+    );
+  };
+
+  window.addEventListener(
+    INTERNAL_APP_NAVIGATION_REQUEST_EVENT,
+    listener,
+  );
+
+  try {
+    replaceWindowLocation(`${ROUTES.KAI_ANALYSIS}?focus=active`);
+  } finally {
+    window.removeEventListener(
+      INTERNAL_APP_NAVIGATION_REQUEST_EVENT,
+      listener,
+    );
+  }
+
+  expect(received).toEqual([
+    {
+      href: `${ROUTES.KAI_ANALYSIS}?focus=active`,
+      replace: true,
+      scroll: false,
+    },
+  ]);
   });
 });


### PR DESCRIPTION
## Summary

Adds test coverage for internal replace navigation behavior.

### Added coverage

Verifies that `replaceWindowLocation()` dispatches an internal navigation event when given a routable application URL.

### Why

`replaceWindowLocation()` has different behavior from `assignWindowLocation()` because it emits navigation requests with `replace: true`.

This test documents and protects that behavior against future regressions.
