### PR TITLE
test(services): add kai-profile-api-paths contract tests for path builder functions

### DIFF
--- a/hushh-webapp/__tests__/services/kai-profile-api-paths.test.ts
+++ b/hushh-webapp/__tests__/services/kai-profile-api-paths.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  GMAIL_RECEIPTS_API_TEMPLATES,
+  SUPPORT_API_TEMPLATES,
+  buildGmailReceiptMemoryArtifactPath,
+  buildGmailReceiptsPath,
+  buildGmailStatusPath,
+  buildGmailSyncRunPath,
+} from "@/lib/services/kai-profile-api-paths";
+
+describe("kai-profile-api-paths", () => {
+  it("exposes gmail receipts template contracts", () => {
+    expect(GMAIL_RECEIPTS_API_TEMPLATES.status).toBe(
+      "/api/kai/gmail/status/{user_id}",
+    );
+
+    expect(GMAIL_RECEIPTS_API_TEMPLATES.syncRun).toBe(
+      "/api/kai/gmail/sync/{run_id}",
+    );
+
+    expect(GMAIL_RECEIPTS_API_TEMPLATES.receipts).toBe(
+      "/api/kai/gmail/receipts/{user_id}",
+    );
+  });
+
+  it("exposes support template contracts", () => {
+    expect(SUPPORT_API_TEMPLATES.message).toBe(
+      "/api/kai/support/message",
+    );
+  });
+
+  it("builds gmail status paths", () => {
+    expect(buildGmailStatusPath("user-123")).toBe(
+      "/api/kai/gmail/status/user-123",
+    );
+  });
+
+  it("builds gmail sync run paths", () => {
+    expect(buildGmailSyncRunPath("run-456")).toBe(
+      "/api/kai/gmail/sync/run-456",
+    );
+  });
+
+  it("builds gmail receipts paths", () => {
+    expect(buildGmailReceiptsPath("user-789")).toBe(
+      "/api/kai/gmail/receipts/user-789",
+    );
+  });
+
+  it("builds gmail receipt memory artifact paths", () => {
+    expect(buildGmailReceiptMemoryArtifactPath("artifact-001")).toBe(
+      "/api/kai/gmail/receipts-memory/artifacts/artifact-001",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract tests for the path-builder helpers in `lib/services/kai-profile-api-paths.ts`.

## What changed

* Added `__tests__/lib/services/kai-profile-api-paths.test.ts`
* Verifies exported template constants
* Verifies path construction for all exported builder helpers

## Why

These helpers define API route shapes consumed by service callers. The tests protect those route contracts from accidental regression.

## Scope

* Test-only change
* One new file
* No production code changes
* No runtime behavior changes

## Risk

* Additive-only change
* No production changes
* No new dependencies
* Deterministic string assertions only
* Minimal diff size
