### PR TITLE
test(config): add ci-governance.json schema contract test

### DIFF
--- a/hushh-webapp/__tests__/ci-governance-schema.test.ts
+++ b/hushh-webapp/__tests__/ci-governance-schema.test.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+function loadCiGovernance() {
+  const filePath = path.resolve(
+    process.cwd(),
+    "../config/ci-governance.json",
+  );
+
+  return JSON.parse(
+    fs.readFileSync(filePath, "utf-8"),
+  ) as Record<string, unknown>;
+}
+
+describe("ci-governance.json", () => {
+  const governance = loadCiGovernance();
+
+  it("contains the required top-level sections", () => {
+    expect(governance).toHaveProperty("branch_flow");
+    expect(governance).toHaveProperty("main");
+    expect(governance).toHaveProperty("pr_train");
+    expect(governance).toHaveProperty("uat");
+    expect(governance).toHaveProperty("production");
+  });
+
+  it("defines branch flow strings", () => {
+    const branchFlow = governance.branch_flow as Record<string, unknown>;
+
+    expect(typeof branchFlow.train_branch).toBe("string");
+    expect(typeof branchFlow.promotion_branch).toBe("string");
+  });
+
+  it("defines governance rules for main", () => {
+    const main = governance.main as Record<string, unknown>;
+
+    expect(typeof main.required_status_check).toBe("string");
+    expect(typeof main.required_approving_reviews).toBe("number");
+    expect(typeof main.merge_queue_required).toBe("boolean");
+  });
+
+  it("defines governance rules for pr_train", () => {
+    const train = governance.pr_train as Record<string, unknown>;
+
+    expect(typeof train.required_status_check).toBe("string");
+    expect(typeof train.required_approving_reviews).toBe("number");
+    expect(typeof train.merge_queue_required).toBe("boolean");
+  });
+
+  it("defines uat environment metadata", () => {
+    const uat = governance.uat as Record<string, unknown>;
+
+    expect(typeof uat.environment).toBe("string");
+    expect(typeof uat.required_post_merge_check).toBe("string");
+  });
+
+  it("defines production environment metadata", () => {
+    const production = governance.production as Record<string, unknown>;
+
+    expect(typeof production.owner_environment).toBe("string");
+    expect(typeof production.required_post_merge_check).toBe("string");
+  });
+});


### PR DESCRIPTION
## Summary

Adds schema contract coverage for `config/ci-governance.json`.

## What changed

* Added `__tests__/ci-governance-schema.test.ts`
* Verifies required top-level governance sections exist
* Verifies expected configuration types for branch-flow, main, pr_train, uat, and production sections

## Why

The governance configuration is a repository-level contract. This test provides CI coverage for the expected structure while avoiding assertions on frequently changing operational values.

## Scope

* Test-only change
* One new file
* No production code changes
* No configuration changes

## Risk

None. Additive contract test only.
