### PR TITLE
test(constants): add country-phone-options invariant contract test

### DIFF
--- a/hushh-webapp/__tests__/lib/country-phone-options.test.ts
+++ b/hushh-webapp/__tests__/lib/country-phone-options.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { COUNTRY_PHONE_OPTIONS } from "@/lib/constants/country-phone-options";
+
+describe("country phone options", () => {
+  it("contains a non-trivial set of entries", () => {
+    expect(COUNTRY_PHONE_OPTIONS.length).toBeGreaterThanOrEqual(250);
+  });
+
+  it("has a unique ISO value for every entry", () => {
+    const values = COUNTRY_PHONE_OPTIONS.map((option) => option.value);
+    expect(new Set(values).size).toBe(values.length);
+  });
+
+  it("uses a two-letter uppercase code for every value", () => {
+    for (const option of COUNTRY_PHONE_OPTIONS) {
+      expect(option.value).toMatch(/^[A-Z]{2}$/);
+    }
+  });
+
+  it("has a non-empty trimmed label for every entry", () => {
+    for (const option of COUNTRY_PHONE_OPTIONS) {
+      expect(option.label.length).toBeGreaterThan(0);
+      expect(option.label).toBe(option.label.trim());
+    }
+  });
+
+  it("uses a plus-prefixed numeric dial code for every entry", () => {
+    for (const option of COUNTRY_PHONE_OPTIONS) {
+      expect(option.dialCode).toMatch(/^\+\d+$/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds invariant coverage for `lib/constants/country-phone-options.ts`.

## What

Introduces a new test file:

* `__tests__/lib/country-phone-options.test.ts`

Coverage includes:

* Minimum expected dataset size
* Unique ISO country codes
* ISO code format validation
* Non-empty trimmed labels
* Dial code format validation

## Why

`COUNTRY_PHONE_OPTIONS` is a large static dataset with no dedicated contract coverage. These tests protect against accidental malformed entries while avoiding assertions on ordering or other implementation details.

## Scope

* Test-only change
* One new file
* No production code changes
* No runtime behavior changes

## Risk

None. Additive invariant tests only.
