### PR TITLE
test(services): add kai-import-stream-config contract tests

### DIFF
--- a/hushh-webapp/__tests__/services/kai-import-stream-config.test.ts
+++ b/hushh-webapp/__tests__/services/kai-import-stream-config.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  KAI_PORTFOLIO_IMPORT_IDLE_TIMEOUT_MS,
+  KAI_PORTFOLIO_IMPORT_TIMEOUT_SECONDS,
+} from "@/lib/services/kai-import-stream-config";
+
+describe("kai-import-stream-config", () => {
+  it("exports a positive finite timeout in seconds", () => {
+    expect(typeof KAI_PORTFOLIO_IMPORT_TIMEOUT_SECONDS).toBe("number");
+    expect(Number.isFinite(KAI_PORTFOLIO_IMPORT_TIMEOUT_SECONDS)).toBe(true);
+    expect(KAI_PORTFOLIO_IMPORT_TIMEOUT_SECONDS).toBeGreaterThan(0);
+  });
+
+  it("locks the timeout contract at 360 seconds", () => {
+    expect(KAI_PORTFOLIO_IMPORT_TIMEOUT_SECONDS).toBe(360);
+  });
+
+  it("exports a positive finite idle timeout", () => {
+    expect(typeof KAI_PORTFOLIO_IMPORT_IDLE_TIMEOUT_MS).toBe("number");
+    expect(Number.isFinite(KAI_PORTFOLIO_IMPORT_IDLE_TIMEOUT_MS)).toBe(true);
+    expect(KAI_PORTFOLIO_IMPORT_IDLE_TIMEOUT_MS).toBeGreaterThan(0);
+  });
+
+  it("derives idle timeout from the backend timeout contract", () => {
+    expect(KAI_PORTFOLIO_IMPORT_IDLE_TIMEOUT_MS).toBe(
+      (KAI_PORTFOLIO_IMPORT_TIMEOUT_SECONDS + 60) * 1000,
+    );
+  });
+
+  it("keeps idle timeout greater than backend timeout", () => {
+    expect(KAI_PORTFOLIO_IMPORT_IDLE_TIMEOUT_MS).toBeGreaterThan(
+      KAI_PORTFOLIO_IMPORT_TIMEOUT_SECONDS * 1000,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract coverage for `kai-import-stream-config.ts`.

## What

Introduces a new test file:

* `__tests__/services/kai-import-stream-config.test.ts`

Coverage includes:

* Exported timeout constants exist
* Timeout values are finite positive numbers
* `KAI_PORTFOLIO_IMPORT_TIMEOUT_SECONDS` remains `360`
* Idle timeout is derived from the backend timeout contract
* Idle timeout remains greater than backend timeout

## Why

These constants define timeout behavior for Kai portfolio import streaming flows and currently have no dedicated contract coverage. The tests protect against accidental changes to timeout configuration while remaining implementation-light.

## Scope

* Test-only change
* One new file
* No production code changes
* No runtime behavior changes

## Risk

None. Additive contract tests only.
