### PR TITLE
test(observability): add event category resolution contract tests

### DIFF
--- a/hushh-webapp/__tests__/services/observability-event-category.test.ts
+++ b/hushh-webapp/__tests__/services/observability-event-category.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveObservabilityEventCategory } from "@/lib/observability/events";
+
+describe("resolveObservabilityEventCategory", () => {
+  it("classifies system events", () => {
+    expect(
+      resolveObservabilityEventCategory("page_view"),
+    ).toBe("system");
+  });
+
+  it("classifies feature events", () => {
+    expect(
+      resolveObservabilityEventCategory("portfolio_viewed"),
+    ).toBe("feature");
+  });
+
+  it("classifies funnel events", () => {
+    expect(
+      resolveObservabilityEventCategory("growth_funnel_step_completed"),
+    ).toBe("funnel");
+  });
+
+  it("returns a valid category for representative events", () => {
+    expect([
+      "system",
+      "feature",
+      "funnel",
+    ]).toContain(
+      resolveObservabilityEventCategory("analysis_stream_started"),
+    );
+
+    expect([
+      "system",
+      "feature",
+      "funnel",
+    ]).toContain(
+      resolveObservabilityEventCategory("api_request_completed"),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract coverage for `resolveObservabilityEventCategory` in `lib/observability/events.ts`.

## What changed

* Added `__tests__/services/observability-event-category.test.ts`
* Verifies representative system, feature, and funnel event mappings
* Verifies category resolution returns valid category values

## Why

The observability suite contains coverage for several observability modules, but event-category resolution currently has no dedicated contract coverage.

## Scope

* Test-only change
* One new file
* No production code changes
* No runtime changes
* No mocks required

## Risk

None. Additive contract tests only.
