### PR TITLE
test(agent-voice-settings): cover disabled voice flag values

### DIFF
--- a/hushh-webapp/__tests__/lib/agent-voice-settings.test.ts
+++ b/hushh-webapp/__tests__/lib/agent-voice-settings.test.ts
@@ -39,4 +39,9 @@ describe("agent voice settings", () => {
     vi.stubEnv("NEXT_PUBLIC_AGENT_GEMINI_VOICE_ENABLED", "1");
     expect(isAgentGeminiVoiceEnabled()).toBe(true);
   });
+  it("treats disabled flag values as disabled", () => {
+  vi.stubEnv("NEXT_PUBLIC_AGENT_GEMINI_VOICE_ENABLED", "disabled");
+
+  expect(isAgentGeminiVoiceEnabled()).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

Adds test coverage for Agent Gemini voice feature flag parsing.

### Added coverage

Verifies that the `"disabled"` flag value disables the Agent Gemini voice feature.

### Why

`isAgentGeminiVoiceEnabled()` explicitly supports several disabled flag values through `DISABLED_FLAG_VALUES`. This test documents and protects that behavior against future regressions.
