### PR TITLE
test(observability): add schema exhaustiveness tests

### DIFF
--- a/hushh-webapp/__tests__/services/observability-schema-exhaustiveness.test.ts
+++ b/hushh-webapp/__tests__/services/observability-schema-exhaustiveness.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { validateAndSanitizeEvent } from "@/lib/observability/schema";
+
+const BASE_CONTEXT = {
+  env: "uat",
+  platform: "web",
+  event_category: "system",
+  app_version: "1.0.0",
+} as const;
+
+describe("observability schema contracts", () => {
+  it("returns the documented result shape", () => {
+    const result = validateAndSanitizeEvent(
+      "page_view",
+      BASE_CONTEXT as never,
+    );
+
+    expect(typeof result.ok).toBe("boolean");
+    expect(typeof result.sanitized).toBe("object");
+    expect(Array.isArray(result.droppedKeys)).toBe(true);
+  });
+
+  it("preserves base context keys during sanitization", () => {
+    const { sanitized } = validateAndSanitizeEvent(
+      "page_view",
+      BASE_CONTEXT as never,
+    );
+
+    expect(sanitized.env).toBe("uat");
+    expect(sanitized.platform).toBe("web");
+    expect(sanitized.event_category).toBe("system");
+    expect(sanitized.app_version).toBe("1.0.0");
+  });
+
+  it("drops user_id fields", () => {
+    const result = validateAndSanitizeEvent(
+      "page_view",
+      {
+        ...BASE_CONTEXT,
+        user_id: "secret",
+      } as never,
+    );
+
+    expect(result.droppedKeys).toContain("user_id");
+  });
+
+  it("drops email fields", () => {
+    const result = validateAndSanitizeEvent(
+      "page_view",
+      {
+        ...BASE_CONTEXT,
+        user_email: "test@example.com",
+      } as never,
+    );
+
+    expect(result.droppedKeys).toContain("user_email");
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract coverage for validateAndSanitizeEvent in lib/observability/schema.ts.

## What changed

* Added **tests**/services/observability-schema-exhaustiveness.test.ts
* Verifies the documented result shape
* Verifies base context keys survive sanitization
* Verifies sensitive fields are removed from sanitized payloads

## Why

Existing schema tests focus on sanitization behavior for specific events. This test adds lightweight contract coverage for the schema layer without coupling tests to the complete observability event inventory.

## Scope

* Test-only change
* One new file
* No production code changes
* No runtime changes
* No mocks required

## Risk

None. Additive contract tests only.
