### PR TITLE
test(motion): add api-progress-tracker export contract tests

### DIFF
--- a/hushh-webapp/__tests__/services/api-progress-tracker.test.ts
+++ b/hushh-webapp/__tests__/services/api-progress-tracker.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  trackRequestEnd,
+  trackRequestStart,
+} from "@/lib/motion/api-progress-tracker";
+
+describe("api-progress-tracker", () => {
+  it("exports trackRequestStart as a function", () => {
+    expect(typeof trackRequestStart).toBe("function");
+  });
+
+  it("exports trackRequestEnd as a function", () => {
+    expect(typeof trackRequestEnd).toBe("function");
+  });
+
+  it("trackRequestStart is callable without throwing", () => {
+    expect(() => trackRequestStart()).not.toThrow();
+  });
+
+  it("trackRequestEnd is callable without throwing", () => {
+    expect(() => trackRequestEnd()).not.toThrow();
+  });
+
+  it("allows repeated start calls", () => {
+    expect(() => {
+      trackRequestStart();
+      trackRequestStart();
+      trackRequestStart();
+    }).not.toThrow();
+  });
+
+  it("allows repeated end calls", () => {
+    expect(() => {
+      trackRequestEnd();
+      trackRequestEnd();
+      trackRequestEnd();
+    }).not.toThrow();
+  });
+
+  it("allows interleaved start/end calls", () => {
+    expect(() => {
+      trackRequestStart();
+      trackRequestEnd();
+      trackRequestStart();
+      trackRequestEnd();
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Adds lightweight contract coverage for lib/motion/api-progress-tracker.ts.

## What changed

* Added **tests**/services/api-progress-tracker.test.ts
* Verifies trackRequestStart and trackRequestEnd remain exported
* Verifies both functions are callable without throwing
* Verifies repeated and interleaved calls remain stable

## Why

This module currently acts as a lightweight progress-tracking abstraction and has no dedicated test coverage. These tests protect the public export surface from accidental removal or renaming while avoiding assumptions about future implementation details.

## Scope

* Test-only change
* One new file
* No production code changes
* No runtime behavior changes
* No mocks required

## Risk

None. Additive contract tests only.
