### PR TITLE
test(services): add demo-mode-template-service contract tests

### DIFF
--- a/hushh-webapp/__tests__/services/demo-mode-template-service.test.ts
+++ b/hushh-webapp/__tests__/services/demo-mode-template-service.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { fetchDemoPortfolioTemplateAsset } from "@/lib/services/demo-mode-template-service";
+
+describe("demo-mode-template-service", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("requests the demo portfolio template asset", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+
+    vi.stubGlobal("fetch", mockFetch);
+
+    await fetchDemoPortfolioTemplateAsset();
+
+    const [url] = mockFetch.mock.calls[0];
+
+    expect(url).toContain("/demo-mode/portfolio-template.json");
+  });
+
+  it("returns the parsed JSON body on success", async () => {
+    const fixture = {
+      holdings: [],
+      generatedAt: "2026-01-01",
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(fixture),
+      }),
+    );
+
+    const result = await fetchDemoPortfolioTemplateAsset();
+
+    expect(result).toEqual(fixture);
+  });
+
+  it("throws when the response is not ok", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+      }),
+    );
+
+    await expect(
+      fetchDemoPortfolioTemplateAsset(),
+    ).rejects.toThrow("Demo template unavailable.");
+  });
+
+  it("returns an empty object when JSON parsing fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.reject(new Error("malformed json")),
+      }),
+    );
+
+    const result = await fetchDemoPortfolioTemplateAsset();
+
+    expect(result).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract coverage for fetchDemoPortfolioTemplateAsset in lib/services/demo-mode-template-service.ts.

## What changed

* Added **tests**/services/demo-mode-template-service.test.ts
* Verifies the service requests the expected demo template asset
* Verifies successful responses return parsed JSON
* Verifies non-ok responses throw the documented error
* Verifies malformed JSON falls back to an empty object

## Why

The service currently has no dedicated test coverage. These tests protect the public behavior of the service without coupling to implementation details such as fetch configuration or cache-busting mechanics.

## Scope

* Test-only change
* One new file
* No production code changes
* No new dependencies
* Network fully mocked via vi.stubGlobal("fetch")

## Risk

None. Additive test coverage only.
