### PR TITLE
test(observability): add growth journey resolver contract tests

### DIFF
--- a/hushh-webapp/__tests__/lib/services/observability-growth-resolvers.test.ts
+++ b/hushh-webapp/__tests__/lib/services/observability-growth-resolvers.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveGrowthEntrySurface,
+  resolveGrowthJourneyForPath,
+  resolveGrowthWorkspaceSource,
+} from "@/lib/observability/growth";
+
+describe("resolveGrowthJourneyForPath", () => {
+  it("returns null for empty paths", () => {
+    expect(resolveGrowthJourneyForPath("")).toBeNull();
+  });
+
+  it("resolves ria paths", () => {
+    expect(resolveGrowthJourneyForPath("/ria")).toBe("ria");
+  });
+
+  it("resolves investor paths", () => {
+    expect(resolveGrowthJourneyForPath("/one/kai")).toBe("investor");
+  });
+
+  it("returns null for unrelated paths", () => {
+    expect(resolveGrowthJourneyForPath("/marketplace")).toBeNull();
+  });
+});
+
+describe("resolveGrowthEntrySurface", () => {
+  it("resolves login", () => {
+    expect(resolveGrowthEntrySurface("/login")).toBe("login");
+  });
+
+  it("resolves kai onboarding", () => {
+    expect(resolveGrowthEntrySurface("/one/onboarding")).toBe(
+      "kai_onboarding",
+    );
+  });
+
+  it("resolves kai import", () => {
+    expect(resolveGrowthEntrySurface("/one/kai/import")).toBe(
+      "kai_import",
+    );
+  });
+
+  it("resolves kai home", () => {
+    expect(resolveGrowthEntrySurface("/one/kai")).toBe(
+      "kai_home",
+    );
+  });
+
+  it("resolves marketplace", () => {
+    expect(resolveGrowthEntrySurface("/marketplace")).toBe(
+      "marketplace",
+    );
+  });
+
+  it("resolves ria onboarding", () => {
+    expect(resolveGrowthEntrySurface("/ria/onboarding")).toBe(
+      "ria_onboarding",
+    );
+  });
+
+  it("resolves ria home", () => {
+    expect(resolveGrowthEntrySurface("/ria")).toBe(
+      "ria_home",
+    );
+  });
+
+  it("returns unknown for unmatched paths", () => {
+    expect(resolveGrowthEntrySurface("/developers")).toBe(
+      "unknown",
+    );
+  });
+});
+
+describe("resolveGrowthWorkspaceSource", () => {
+  it("resolves ria workspace paths", () => {
+    expect(resolveGrowthWorkspaceSource("/ria")).toBe(
+      "ria_home",
+    );
+  });
+
+  it("returns unknown for unrelated paths", () => {
+    expect(resolveGrowthWorkspaceSource("/login")).toBe(
+      "unknown",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds contract coverage for the pure resolver helpers exported from lib/observability/growth.ts.

### Covered functions

* resolveGrowthJourneyForPath
* resolveGrowthEntrySurface
* resolveGrowthWorkspaceSource

## What changed

* Added **tests**/lib/services/observability-growth-resolvers.test.ts

## Coverage

* Journey resolution for investor and ria routes
* Entry-surface resolution across supported growth entry points
* Unknown-path fallbacks
* Workspace-source resolution for supported paths

## Scope

* Test-only change
* One new file
* No production code changes
* No network access
* No DOM dependencies
* No mocks required

## Risk

None. Additive contract coverage only.
