### PR TITLE
Promote to main: One Location consent center integration + mobile-first UX (+ prior branch commits)

### DIFF
--- a/consent-protocol/api/routes/connected_systems.py
+++ b/consent-protocol/api/routes/connected_systems.py
@@ -42,7 +42,15 @@ class CrmReadRequest(BaseModel):
 
 
 class CrmSearchRequest(CrmReadRequest):
-    pass
+    force_refresh: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("forceRefresh", "force_refresh"),
+        description=(
+            "Bypass the bound-read cache and re-search the CRM. When false "
+            "(default) and an active record binding exists, the bound record id "
+            "is returned without an MCP search call."
+        ),
+    )
 
 
 class CrmCreateIntentRequest(BaseModel):
@@ -227,6 +235,7 @@ async def search_connected_system_record(
             phone=body.phone,
             search_fields=body.search_fields,
             return_fields=body.return_fields,
+            force_refresh=body.force_refresh,
         )
     except ConnectedSystemsError as error:
         _raise_connected_system_error(error)

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 70,
+  "expected_migration_version": 71,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",
@@ -623,6 +623,45 @@
       "created_at",
       "revoked_at",
       "last_used_at"
+    ],
+    "enterprise_crm_registry": [
+      "crm_id",
+      "crm_enterprise_name",
+      "crm_type",
+      "environment",
+      "crm_base_url",
+      "crm_token_url",
+      "crm_mcp_endpoint",
+      "crm_client_id_ciphertext",
+      "crm_client_id_iv",
+      "crm_client_id_tag",
+      "crm_client_secret_ciphertext",
+      "crm_client_secret_iv",
+      "crm_client_secret_tag",
+      "encryption_algorithm",
+      "key_id",
+      "auth_header_style",
+      "supports_create",
+      "supports_read",
+      "supports_update",
+      "supports_delete",
+      "user_object_name",
+      "rate_limit_per_min",
+      "timeout_seconds",
+      "retry_count",
+      "is_active",
+      "business_owner",
+      "technical_owner",
+      "created_at",
+      "updated_at"
+    ],
+    "crm_operation_endpoints": [
+      "crm_id",
+      "operation",
+      "tool_name",
+      "http_method",
+      "path",
+      "description"
     ]
   }
 }

--- a/consent-protocol/db/migrations/071_enterprise_crm_registry.sql
+++ b/consent-protocol/db/migrations/071_enterprise_crm_registry.sql
@@ -1,0 +1,66 @@
+-- Enterprise CRM registry: DB-backed Connected Systems with AES-256-GCM credential envelopes.
+--
+-- Replaces the hardcoded ConnectedSystemDefinition + unauthenticated MCP endpoint in
+-- hushh_mcp/services/connected_systems_service.py. Credentials (client_id / client_secret)
+-- are stored as AES-256-GCM envelopes (matching hushh_mcp/vault/encrypt.py EncryptedPayload)
+-- and decrypted at request time with VAULT_DATA_KEY. No new long-lived secrets are introduced;
+-- the gateway URL is non-secret config and stored in plaintext.
+
+CREATE TABLE IF NOT EXISTS enterprise_crm_registry (
+  crm_id              TEXT PRIMARY KEY,
+  crm_enterprise_name TEXT NOT NULL,
+  crm_type            TEXT,
+  environment         TEXT NOT NULL DEFAULT 'production'
+                      CHECK (environment IN ('sandbox', 'production')),
+
+  crm_base_url        TEXT NOT NULL,
+  crm_token_url       TEXT,                       -- nullable: gateway uses header auth, not OAuth token URL
+  crm_mcp_endpoint    TEXT NOT NULL,              -- streamable-HTTP MCP URL (the Omni Gateway)
+
+  -- AES-256-GCM envelopes (matches hushh_mcp/vault/encrypt.py EncryptedPayload)
+  crm_client_id_ciphertext      TEXT NOT NULL,
+  crm_client_id_iv              TEXT NOT NULL,
+  crm_client_id_tag             TEXT NOT NULL,
+  crm_client_secret_ciphertext  TEXT NOT NULL,
+  crm_client_secret_iv          TEXT NOT NULL,
+  crm_client_secret_tag         TEXT NOT NULL,
+  encryption_algorithm          TEXT NOT NULL DEFAULT 'aes-256-gcm',
+  key_id                        TEXT NOT NULL DEFAULT 'vault_data_key_v1',
+
+  -- how the decrypted credentials map onto MCP transport headers
+  auth_header_style   TEXT NOT NULL DEFAULT 'client_id_secret_headers',
+
+  supports_create  BOOLEAN NOT NULL DEFAULT TRUE,
+  supports_read    BOOLEAN NOT NULL DEFAULT TRUE,
+  supports_update  BOOLEAN NOT NULL DEFAULT TRUE,
+  supports_delete  BOOLEAN NOT NULL DEFAULT FALSE,
+
+  user_object_name   TEXT DEFAULT 'Contact',
+  rate_limit_per_min INTEGER,
+  timeout_seconds    INTEGER NOT NULL DEFAULT 30,
+  retry_count        INTEGER NOT NULL DEFAULT 3,
+  is_active          BOOLEAN NOT NULL DEFAULT TRUE,
+
+  business_owner   TEXT,
+  technical_owner  TEXT,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (crm_enterprise_name, crm_type, environment)
+);
+
+CREATE INDEX IF NOT EXISTS idx_enterprise_crm_registry_active
+  ON enterprise_crm_registry (is_active, environment);
+
+-- Per-operation tool catalog: each CRUD operation maps to a distinct MCP tool name.
+-- read/create/update/delete differ in both their tool and required inputs, so they are
+-- modeled as rows rather than a single endpoint column. http_method / path are
+-- informational (MCP is JSON-RPC) and reserved for a future REST fallback.
+CREATE TABLE IF NOT EXISTS crm_operation_endpoints (
+  crm_id      TEXT NOT NULL REFERENCES enterprise_crm_registry(crm_id) ON DELETE CASCADE,
+  operation   TEXT NOT NULL CHECK (operation IN ('schema', 'create', 'read', 'update', 'delete')),
+  tool_name   TEXT NOT NULL,             -- MCP tool name, e.g. read-crm-record
+  http_method TEXT,                       -- informational
+  path        TEXT,                       -- informational / future REST fallback
+  description TEXT,
+  PRIMARY KEY (crm_id, operation)
+);

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -47,7 +47,8 @@
     "067_connected_systems.sql",
     "068_one_location_circle_invites.sql",
     "069_drop_kai_location_plaintext.sql",
-    "070_developer_registry.sql"
+    "070_developer_registry.sql",
+    "071_enterprise_crm_registry.sql"
   ],
   "groups": {
     "iam": [
@@ -80,7 +81,8 @@
       "066_marketplace_visibility_posture.sql",
       "067_connected_systems.sql",
       "068_one_location_circle_invites.sql",
-      "069_drop_kai_location_plaintext.sql"
+      "069_drop_kai_location_plaintext.sql",
+      "071_enterprise_crm_registry.sql"
     ],
     "pkm": [
       "030_pkm_cutover.sql",

--- a/consent-protocol/hushh_mcp/runtime_settings.py
+++ b/consent-protocol/hushh_mcp/runtime_settings.py
@@ -172,6 +172,13 @@ def get_optional_plaid_access_token_key() -> str:
     return _clean_env(PLAID_ACCESS_TOKEN_KEY_ENV)
 
 
+def crm_registry_db_enabled() -> bool:
+    """Feature flag: resolve Connected Systems from the DB-backed enterprise CRM
+    registry (decrypting credentials with VAULT_DATA_KEY) instead of the
+    hardcoded in-code definition. Defaults off until cutover."""
+    return _bool_from_value(_clean_env("CRM_REGISTRY_DB_ENABLED"), default=False)
+
+
 @lru_cache(maxsize=1)
 def get_core_security_settings() -> CoreSecuritySettings:
     app_signing_key = _clean_env(APP_SIGNING_KEY_ENV)

--- a/consent-protocol/hushh_mcp/services/connected_systems_service.py
+++ b/consent-protocol/hushh_mcp/services/connected_systems_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import copy
 import json
+import logging
 import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -13,12 +14,22 @@ from uuid import uuid4
 
 from db.db_client import DatabaseExecutionError, get_db
 
+logger = logging.getLogger(__name__)
+
 CONNECTED_SYSTEM_SALESFORCE_ID = "salesforce-fsc-customer0"
 DEFAULT_TARGET = "Macys"
 DEFAULT_OBJECT_TYPE = "Contact"
 EXTERNAL_CRM_TRANSPORT = "external_crm_streamable_mcp"
 REGISTRY_SOURCE = "customer0_connected_system_registry"
-REGISTRY_MCP_ENDPOINT = "https://external-crm-mcp-gateway-a3e0me.y4rjsf.usa-e2.cloudhub.io/mcp"
+# Fallback (in-code) endpoint when the DB registry is disabled or the row is
+# missing. Points at the secured Omni Gateway, but the in-code definition carries
+# NO transport_headers — so an unauthenticated fallback call fails closed at the
+# gateway (411/401) rather than silently reaching an unauthenticated endpoint.
+# Production must use the DB registry (CRM_REGISTRY_DB_ENABLED=true) so credentials
+# are supplied as decrypted headers.
+REGISTRY_MCP_ENDPOINT = (
+    "https://hussh-og-nonprod-ingress-a3e0me.y4rjsf.usa-e2.cloudhub.io/crm-connect/v1/mcp"
+)
 TERMINAL_INTENT_STATUSES = frozenset({"rejected", "succeeded", "partial", "failed"})
 
 EXTERNAL_CRM_TOOL_CATALOG = (
@@ -582,6 +593,11 @@ class ConnectedSystemDefinition:
     transport_endpoint: str | None
     registry_source: str
     tool_catalog: tuple[dict[str, Any], ...]
+    # Decrypted transport auth headers (e.g. client_id / client_secret) carried
+    # from the DB registry into the MCP streamable-HTTP call. Default empty keeps
+    # the hardcoded in-code definitions backward compatible. NEVER surfaced in
+    # to_summary() — headers must not leak through the API.
+    transport_headers: tuple[tuple[str, str], ...] = ()
 
     def to_summary(self, *, endpoint_configured: bool, delete_enabled: bool) -> dict[str, Any]:
         return {
@@ -635,10 +651,12 @@ class ExternalCrmStreamableMcpAdapter:
         *,
         timeout_seconds: float = 30.0,
         tool_catalog: tuple[dict[str, Any], ...] | None = None,
+        headers: tuple[tuple[str, str], ...] = (),
     ):
         self.endpoint = endpoint
         self.timeout_seconds = timeout_seconds
         self.tool_catalog = tuple(tool_catalog or ())
+        self.headers = tuple(headers or ())
         self._demo_record: dict[str, Any] = {
             "Id": "003gK00000jlmaLQAQ",
             "FirstName": "Maria",
@@ -661,6 +679,7 @@ class ExternalCrmStreamableMcpAdapter:
         return cls(
             endpoint=system.transport_endpoint,
             tool_catalog=system.tool_catalog,
+            headers=system.transport_headers,
         )
 
     @property
@@ -694,7 +713,15 @@ class ExternalCrmStreamableMcpAdapter:
             from mcp.client.session import ClientSession
             from mcp.client.streamable_http import streamablehttp_client
 
-            async with streamablehttp_client(self.endpoint) as (read_stream, write_stream, _):
+            client_kwargs: dict[str, Any] = {}
+            if self.headers:
+                client_kwargs["headers"] = dict(self.headers)
+
+            async with streamablehttp_client(self.endpoint, **client_kwargs) as (
+                read_stream,
+                write_stream,
+                _,
+            ):
                 async with ClientSession(read_stream, write_stream) as session:
                     await session.initialize()
                     result = await session.call_tool(name, arguments)
@@ -1258,7 +1285,7 @@ class ConnectedSystemsService:
         registry: tuple[ConnectedSystemDefinition, ...] | None = None,
     ):
         self.registry = registry or REGISTERED_CONNECTED_SYSTEMS
-        default_system = self._registry_system(CONNECTED_SYSTEM_SALESFORCE_ID)
+        default_system = self._resolve_system(CONNECTED_SYSTEM_SALESFORCE_ID)
         self.adapter = adapter or ExternalCrmStreamableMcpAdapter.from_registry(default_system)
         self.store = store or DatabaseConnectedSystemIntentStore()
         self.delete_enabled = True if delete_enabled is None else delete_enabled
@@ -1273,6 +1300,33 @@ class ConnectedSystemsService:
         ]
 
     def get_system(self, system_id: str) -> ConnectedSystemDefinition:
+        return self._resolve_system(system_id)
+
+    def _resolve_system(self, system_id: str) -> ConnectedSystemDefinition:
+        """Resolve a connected system definition.
+
+        When CRM_REGISTRY_DB_ENABLED is on, the DB-backed enterprise CRM registry
+        is the ONLY source of truth: a missing/inactive row raises
+        ConnectedSystemNotFoundError ("no data found") rather than silently
+        falling back to a hardcoded definition. A decryption/configuration error
+        also surfaces (raised by the repo) so a misconfigured row fails loudly.
+
+        When the flag is off, the legacy hardcoded in-code registry is used.
+        """
+        from hushh_mcp.runtime_settings import crm_registry_db_enabled
+
+        if crm_registry_db_enabled():
+            from hushh_mcp.services import crm_registry_repo
+
+            definition = crm_registry_repo.load_active_definition(system_id)
+            if definition is None:
+                logger.warning("crm_registry.no_active_row system_id=%s db_enabled=true", system_id)
+                raise ConnectedSystemNotFoundError(
+                    "No active CRM registry entry found for this system.",
+                    code="CONNECTED_SYSTEM_REGISTRY_ROW_NOT_FOUND",
+                )
+            return definition
+
         return self._registry_system(system_id)
 
     def _registry_system(self, system_id: str) -> ConnectedSystemDefinition:
@@ -1372,7 +1426,49 @@ class ConnectedSystemsService:
         phone: str,
         search_fields: dict[str, Any] | None = None,
         return_fields: list[str] | None = None,
+        force_refresh: bool = False,
     ) -> dict[str, Any]:
+        # Bound-read optimization: read is a SOQL search on the CRM, which is
+        # the most expensive operation. When an active binding already holds the
+        # record id for this (user, system, object_type), serve it directly and
+        # skip the redundant CRM search. Pass force_refresh=True to bypass the
+        # cache and re-search (e.g. to reconcile a possibly-stale binding).
+        object_type_value = _normalize_object_type(object_type)
+        if not force_refresh:
+            existing = self.store.get_binding(
+                user_id=user_id,
+                system_id=system_id,
+                object_type=object_type_value,
+            )
+            existing_record_id = (
+                _clean_text(existing.get("record_id"), max_length=128) if existing else None
+            )
+            if existing and existing_record_id:
+                system = self.get_system(system_id)
+                self._audit(
+                    user_id=user_id,
+                    system_id=system_id,
+                    action="read",
+                    object_type=object_type_value,
+                    record_id=existing_record_id,
+                    field_names=[],
+                    mcp_result_class="served_from_binding",
+                    readback_result_class=None,
+                    status="succeeded",
+                    metadata={"served_from_binding": True},
+                )
+                return {
+                    "systemId": system_id,
+                    "target": system.target,
+                    "objectType": object_type_value,
+                    "resultClass": "succeeded",
+                    "recordId": existing_record_id,
+                    "servedFromBinding": True,
+                    "mcp": None,
+                    "bindingStatus": "active",
+                    "binding": self._public_binding(existing),
+                }
+
         read = await self.read_record(
             user_id=user_id,
             system_id=system_id,
@@ -1386,7 +1482,6 @@ class ConnectedSystemsService:
         binding: dict[str, Any] | None = None
         if read.get("resultClass") == "succeeded" and record_id:
             system = self.get_system(system_id)
-            object_type_value = _normalize_object_type(object_type)
             binding = self.store.upsert_binding(
                 {
                     "binding_id": _binding_id(),
@@ -1401,6 +1496,7 @@ class ConnectedSystemsService:
             )
         return {
             **read,
+            "servedFromBinding": False,
             "bindingStatus": "active" if binding else "unbound",
             "binding": self._public_binding(binding) if binding else None,
         }

--- a/consent-protocol/hushh_mcp/services/crm_registry_repo.py
+++ b/consent-protocol/hushh_mcp/services/crm_registry_repo.py
@@ -1,0 +1,176 @@
+"""DB-backed enterprise CRM registry repository.
+
+Loads an active `enterprise_crm_registry` row, decrypts the AES-256-GCM
+credential envelopes with `VAULT_DATA_KEY`, and returns the existing
+`ConnectedSystemDefinition` shape (with `transport_headers` carrying the
+decrypted client_id / client_secret) so the rest of Connected Systems is
+unchanged.
+
+No plaintext credentials are ever logged. Decryption failures surface as
+`ConnectedSystemConfigurationError` (fail-closed) rather than crashing the
+request path.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from db.db_client import get_db
+from hushh_mcp.config import VAULT_DATA_KEY
+from hushh_mcp.services.connected_systems_service import (
+    ConnectedSystemConfigurationError,
+    ConnectedSystemDefinition,
+)
+from hushh_mcp.types import EncryptedPayload
+from hushh_mcp.vault.encrypt import decrypt_data
+
+logger = logging.getLogger(__name__)
+
+EXTERNAL_CRM_TRANSPORT = "external_crm_streamable_mcp"
+REGISTRY_SOURCE = "enterprise_crm_registry"
+
+# Maps the row's auth_header_style to the header keys carrying each credential.
+_AUTH_HEADER_STYLES: dict[str, tuple[str, str]] = {
+    "client_id_secret_headers": ("client_id", "client_secret"),
+}
+
+
+def _vault_key_hex() -> str:
+    """Indirection so tests can monkeypatch the decryption key."""
+    return VAULT_DATA_KEY
+
+
+def _decrypt_envelope(
+    *, ciphertext: Any, iv: Any, tag: Any, algorithm: str, key_hex: str, label: str
+) -> str:
+    try:
+        payload = EncryptedPayload(
+            ciphertext=str(ciphertext or ""),
+            iv=str(iv or ""),
+            tag=str(tag or ""),
+            encoding="base64",
+            algorithm="aes-256-gcm"
+            if (algorithm or "aes-256-gcm") == "aes-256-gcm"
+            else "chacha20-poly1305",
+        )
+        return decrypt_data(payload, key_hex)
+    except Exception:  # noqa: BLE001 - fail closed, never leak plaintext/cause
+        # Do not include the underlying error (may carry ciphertext fragments).
+        raise ConnectedSystemConfigurationError(
+            f"Failed to decrypt CRM registry {label}.",
+            code="CONNECTED_SYSTEM_REGISTRY_DECRYPT_FAILED",
+        ) from None
+
+
+def _tool_catalog_from_rows(rows: list[dict[str, Any]]) -> tuple[dict[str, Any], ...]:
+    catalog: list[dict[str, Any]] = []
+    for row in rows:
+        name = str(row.get("tool_name") or "").strip()
+        operation = str(row.get("operation") or "").strip()
+        if not name or not operation:
+            continue
+        catalog.append(
+            {
+                "name": name,
+                "operation": operation,
+                "description": str(row.get("description") or "").strip(),
+            }
+        )
+    return tuple(catalog)
+
+
+def load_active_definition(
+    crm_id: str, *, db: Any | None = None
+) -> ConnectedSystemDefinition | None:
+    """Return the active CRM definition for `crm_id`, or None if not found/inactive.
+
+    Decrypts client_id / client_secret into `transport_headers`. Raises
+    `ConnectedSystemConfigurationError` if the row is malformed or cannot be
+    decrypted with the configured `VAULT_DATA_KEY`.
+    """
+    database = db if db is not None else get_db()
+
+    registry_rows = database.execute_raw(
+        """
+        SELECT *
+        FROM enterprise_crm_registry
+        WHERE crm_id = :crm_id
+          AND is_active = TRUE
+        LIMIT 1
+        """,
+        {"crm_id": crm_id},
+    ).data
+    if not registry_rows:
+        return None
+
+    row = registry_rows[0]
+
+    endpoint = str(row.get("crm_mcp_endpoint") or "").strip()
+    if not endpoint:
+        raise ConnectedSystemConfigurationError(
+            "CRM registry row is missing crm_mcp_endpoint.",
+            code="CONNECTED_SYSTEM_REGISTRY_INCOMPLETE",
+        )
+
+    key_hex = _vault_key_hex()
+    algorithm = str(row.get("encryption_algorithm") or "aes-256-gcm")
+
+    client_id = _decrypt_envelope(
+        ciphertext=row.get("crm_client_id_ciphertext"),
+        iv=row.get("crm_client_id_iv"),
+        tag=row.get("crm_client_id_tag"),
+        algorithm=algorithm,
+        key_hex=key_hex,
+        label="client_id",
+    )
+    client_secret = _decrypt_envelope(
+        ciphertext=row.get("crm_client_secret_ciphertext"),
+        iv=row.get("crm_client_secret_iv"),
+        tag=row.get("crm_client_secret_tag"),
+        algorithm=algorithm,
+        key_hex=key_hex,
+        label="client_secret",
+    )
+
+    style = str(row.get("auth_header_style") or "client_id_secret_headers")
+    header_keys = _AUTH_HEADER_STYLES.get(style)
+    if header_keys is None:
+        raise ConnectedSystemConfigurationError(
+            f"Unsupported CRM registry auth_header_style: {style}",
+            code="CONNECTED_SYSTEM_REGISTRY_AUTH_STYLE",
+        )
+    id_header, secret_header = header_keys
+    transport_headers = ((id_header, client_id), (secret_header, client_secret))
+
+    operation_rows = database.execute_raw(
+        """
+        SELECT operation, tool_name, http_method, path, description
+        FROM crm_operation_endpoints
+        WHERE crm_id = :crm_id
+        """,
+        {"crm_id": crm_id},
+    ).data
+    tool_catalog = _tool_catalog_from_rows(operation_rows)
+
+    logger.info(
+        "crm_registry.loaded crm_id=%s endpoint_configured=%s tools=%d",
+        crm_id,
+        bool(endpoint),
+        len(tool_catalog),
+    )
+
+    return ConnectedSystemDefinition(
+        system_id=str(row.get("crm_id")),
+        display_name=str(row.get("crm_enterprise_name") or ""),
+        customer_display_name=str(row.get("crm_enterprise_name") or ""),
+        system_type=str(row.get("crm_type") or ""),
+        system_name=str(row.get("crm_type") or ""),
+        target=str(row.get("crm_enterprise_name") or ""),
+        object_type_default=str(row.get("user_object_name") or "Contact"),
+        transport=EXTERNAL_CRM_TRANSPORT,
+        transport_endpoint=endpoint,
+        registry_source=REGISTRY_SOURCE,
+        tool_catalog=tool_catalog,
+        transport_headers=transport_headers,
+    )

--- a/consent-protocol/pyproject.toml
+++ b/consent-protocol/pyproject.toml
@@ -98,9 +98,9 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["S101"]  # Allow assert in tests
+"tests/*" = ["S101", "S105"]  # Allow assert + placeholder credential fixtures in tests
 "api/routes/*" = ["B008"]  # Redundant with global; FastAPI Depends() pattern
-"scripts/*" = ["S106"]  # Test/script fixtures may use placeholder tokens
+"scripts/*" = ["S101", "S106", "S108"]  # Verification scripts: assert-driven checks + isolated offline tmp db
 
 [tool.ruff.format]
 # Enable ruff format for consistent Python formatting

--- a/consent-protocol/scripts/ops/crm_registry_e2e_check.py
+++ b/consent-protocol/scripts/ops/crm_registry_e2e_check.py
@@ -1,0 +1,190 @@
+"""End-to-end live verification (Task 8) for the DB-backed CRM registry + Omni Gateway.
+
+Runs against the OFFLINE SQLite engine (DB_OFFLINE=1) so no production data is
+touched, but exercises the REAL path:
+  seed (encrypt) -> crm_registry_repo.load_active_definition (decrypt) ->
+  ConnectedSystemsService (flag on) -> ExternalCrmStreamableMcpAdapter ->
+  LIVE Omni Gateway over the network.
+
+The gateway credentials and VAULT_DATA_KEY are read from the environment at run
+time only. Nothing is printed in plaintext.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+# Force offline DB so we never touch prod; isolate to a temp sqlite file.
+os.environ["DB_OFFLINE"] = "1"
+os.environ.setdefault("OFFLINE_DB_PATH", "/tmp/crm_e2e_offline.db")
+os.environ["CRM_REGISTRY_DB_ENABLED"] = "true"
+
+from db.db_client import get_db  # noqa: E402
+from hushh_mcp.config import VAULT_DATA_KEY  # noqa: E402
+from hushh_mcp.services import crm_registry_repo  # noqa: E402
+from hushh_mcp.services.connected_systems_service import (  # noqa: E402  # noqa: E402
+    CONNECTED_SYSTEM_SALESFORCE_ID,
+    ConnectedSystemsService,
+    InMemoryConnectedSystemIntentStore,
+)
+from hushh_mcp.vault.encrypt import encrypt_data  # noqa: E402
+
+CRM_ID = CONNECTED_SYSTEM_SALESFORCE_ID
+ENDPOINT = os.environ["CRM_E2E_MCP_ENDPOINT"]
+CLIENT_ID = os.environ["CRM_E2E_CLIENT_ID"]
+CLIENT_SECRET = os.environ["CRM_E2E_CLIENT_SECRET"]
+
+
+def _create_tables(db) -> None:
+    db.execute_raw(
+        """
+        CREATE TABLE IF NOT EXISTS enterprise_crm_registry (
+          crm_id TEXT PRIMARY KEY,
+          crm_enterprise_name TEXT NOT NULL,
+          crm_type TEXT,
+          environment TEXT NOT NULL DEFAULT 'sandbox',
+          crm_base_url TEXT NOT NULL,
+          crm_token_url TEXT,
+          crm_mcp_endpoint TEXT NOT NULL,
+          crm_client_id_ciphertext TEXT NOT NULL,
+          crm_client_id_iv TEXT NOT NULL,
+          crm_client_id_tag TEXT NOT NULL,
+          crm_client_secret_ciphertext TEXT NOT NULL,
+          crm_client_secret_iv TEXT NOT NULL,
+          crm_client_secret_tag TEXT NOT NULL,
+          encryption_algorithm TEXT NOT NULL DEFAULT 'aes-256-gcm',
+          key_id TEXT NOT NULL DEFAULT 'vault_data_key_v1',
+          auth_header_style TEXT NOT NULL DEFAULT 'client_id_secret_headers',
+          supports_create INTEGER NOT NULL DEFAULT 1,
+          supports_read INTEGER NOT NULL DEFAULT 1,
+          supports_update INTEGER NOT NULL DEFAULT 1,
+          supports_delete INTEGER NOT NULL DEFAULT 0,
+          user_object_name TEXT DEFAULT 'Contact',
+          rate_limit_per_min INTEGER,
+          timeout_seconds INTEGER NOT NULL DEFAULT 30,
+          retry_count INTEGER NOT NULL DEFAULT 3,
+          is_active INTEGER NOT NULL DEFAULT 1,
+          business_owner TEXT,
+          technical_owner TEXT,
+          created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+          updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+        {},
+    )
+    db.execute_raw(
+        """
+        CREATE TABLE IF NOT EXISTS crm_operation_endpoints (
+          crm_id TEXT NOT NULL,
+          operation TEXT NOT NULL,
+          tool_name TEXT NOT NULL,
+          http_method TEXT,
+          path TEXT,
+          description TEXT,
+          PRIMARY KEY (crm_id, operation)
+        )
+        """,
+        {},
+    )
+
+
+def _seed(db) -> None:
+    cid = encrypt_data(CLIENT_ID, VAULT_DATA_KEY)
+    csec = encrypt_data(CLIENT_SECRET, VAULT_DATA_KEY)
+    db.execute_raw("DELETE FROM enterprise_crm_registry WHERE crm_id = :id", {"id": CRM_ID})
+    db.execute_raw("DELETE FROM crm_operation_endpoints WHERE crm_id = :id", {"id": CRM_ID})
+    db.execute_raw(
+        """
+        INSERT INTO enterprise_crm_registry (
+          crm_id, crm_enterprise_name, crm_type, environment,
+          crm_base_url, crm_mcp_endpoint,
+          crm_client_id_ciphertext, crm_client_id_iv, crm_client_id_tag,
+          crm_client_secret_ciphertext, crm_client_secret_iv, crm_client_secret_tag,
+          encryption_algorithm, key_id, auth_header_style,
+          supports_delete, user_object_name, is_active
+        ) VALUES (
+          :id, 'Macys', 'Salesforce', 'sandbox',
+          'https://api.salesforce.com/platform', :endpoint,
+          :cid_ct, :cid_iv, :cid_tag,
+          :csec_ct, :csec_iv, :csec_tag,
+          'aes-256-gcm', 'vault_data_key_v1', 'client_id_secret_headers',
+          0, 'Contact', 1
+        )
+        """,
+        {
+            "id": CRM_ID,
+            "endpoint": ENDPOINT,
+            "cid_ct": cid.ciphertext,
+            "cid_iv": cid.iv,
+            "cid_tag": cid.tag,
+            "csec_ct": csec.ciphertext,
+            "csec_iv": csec.iv,
+            "csec_tag": csec.tag,
+        },
+    )
+    for op, tool in (
+        ("schema", "object-schema"),
+        ("read", "read-crm-record"),
+        ("create", "create-crm-record"),
+        ("update", "update-crm-record"),
+        ("delete", "delete-crm-record"),
+    ):
+        db.execute_raw(
+            "INSERT INTO crm_operation_endpoints (crm_id, operation, tool_name) "
+            "VALUES (:id, :op, :tool)",
+            {"id": CRM_ID, "op": op, "tool": tool},
+        )
+
+
+async def main() -> int:
+    db = get_db()
+    _create_tables(db)
+    _seed(db)
+
+    # 1) Repo decrypts the row into headers (no plaintext printed).
+    definition = crm_registry_repo.load_active_definition(CRM_ID)
+    assert definition is not None, "registry row not loaded"
+    header_keys = {k for k, _ in definition.transport_headers}
+    assert header_keys == {"client_id", "client_secret"}, header_keys
+    print(
+        f"[1] repo loaded definition: endpoint_host={definition.transport_endpoint.split('/')[2]} "
+        f"header_keys={sorted(header_keys)} tools={len(definition.tool_catalog)}"
+    )
+
+    # 2) Service resolves DB-backed definition (flag on) and builds the adapter.
+    service = ConnectedSystemsService(store=InMemoryConnectedSystemIntentStore())
+    resolved = service.get_system(CRM_ID)
+    assert resolved.registry_source == "enterprise_crm_registry", resolved.registry_source
+    print(f"[2] service resolved from DB registry: source={resolved.registry_source}")
+
+    # 3) LIVE: object-schema through the gateway (header-authenticated).
+    schema = await service.get_schema(system_id=CRM_ID, object_type="Contact")
+    fields = schema.get("supportedFields", [])
+    assert fields, f"no schema fields returned: {schema}"
+    print(
+        f"[3] LIVE object-schema OK: {len(fields)} fields incl. "
+        f"{[f for f in fields if f in ('Email', 'Phone')]}"
+    )
+
+    # 4) LIVE: search (read) through the gateway.
+    read = await service.search_record(
+        user_id="e2e_user",
+        system_id=CRM_ID,
+        object_type="Contact",
+        email="e2e.probe@example.com",
+        phone="4155550000",
+    )
+    print(
+        f"[4] LIVE search OK: resultClass={read.get('resultClass')} "
+        f"servedFromBinding={read.get('servedFromBinding')} "
+        f"bindingStatus={read.get('bindingStatus')}"
+    )
+
+    print("E2E PASS: DB-backed registry -> decrypt -> gateway (header auth) verified.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/consent-protocol/scripts/ops/seed_crm_registry_row.py
+++ b/consent-protocol/scripts/ops/seed_crm_registry_row.py
@@ -1,0 +1,175 @@
+"""Maintainer seed script for the encrypted enterprise CRM registry row.
+
+Inserts (or updates) one `enterprise_crm_registry` row plus its
+`crm_operation_endpoints` catalog, encrypting client_id / client_secret with
+AES-256-GCM under VAULT_DATA_KEY. The plaintext credentials are read from the
+environment at run time ONLY and are never written to git, logs, or stdout.
+
+Usage (non-prod example):
+
+    cd consent-protocol
+    VAULT_DATA_KEY=<64-hex> \
+    DB_USER=... DB_PASSWORD=... DB_HOST=... DB_NAME=... \
+    CRM_SEED_CLIENT_ID=<id> \
+    CRM_SEED_CLIENT_SECRET=<secret> \
+    python scripts/ops/seed_crm_registry_row.py \
+      --crm-id salesforce-fsc-customer0 \
+      --enterprise-name "Macy's" \
+      --crm-type Salesforce \
+      --environment sandbox \
+      --mcp-endpoint https://hussh-og-nonprod-ingress-a3e0me.y4rjsf.usa-e2.cloudhub.io/crm-connect/v1/mcp \
+      --base-url https://api.salesforce.com/platform
+
+The script prints only the crm_id and a redacted confirmation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+from db.db_client import get_db
+from hushh_mcp.config import VAULT_DATA_KEY
+from hushh_mcp.vault.encrypt import encrypt_data
+
+# operation -> live MCP tool name (verified against testCrm-salesforce-mcp-server).
+_OPERATION_TOOLS = (
+    ("schema", "object-schema", "Discover the Salesforce Contact field schema."),
+    ("read", "read-crm-record", "Read a Contact by email and phone (search)."),
+    ("create", "create-crm-record", "Create a Contact from approved fields."),
+    ("update", "update-crm-record", "Update allowlisted Contact fields by id."),
+    ("delete", "delete-crm-record", "Delete a Contact by id (maintainer-gated)."),
+)
+
+
+def _require_env(name: str) -> str:
+    value = (os.getenv(name) or "").strip()
+    if not value:
+        print(f"ERROR: {name} must be set in the environment.", file=sys.stderr)
+        sys.exit(2)
+    return value
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Seed the encrypted enterprise CRM registry row.")
+    parser.add_argument("--crm-id", default="salesforce-fsc-customer0")
+    parser.add_argument("--enterprise-name", default="Macy's")
+    parser.add_argument("--crm-type", default="Salesforce")
+    parser.add_argument("--environment", default="sandbox", choices=["sandbox", "production"])
+    parser.add_argument("--mcp-endpoint", required=True)
+    parser.add_argument("--base-url", default="https://api.salesforce.com/platform")
+    parser.add_argument("--token-url", default=None)
+    parser.add_argument("--business-owner", default=None)
+    parser.add_argument("--technical-owner", default=None)
+    parser.add_argument(
+        "--supports-delete",
+        action="store_true",
+        help="Enable delete capability (default off).",
+    )
+    args = parser.parse_args()
+
+    # Validate the vault key early so we fail before touching the DB.
+    if not VAULT_DATA_KEY or len(VAULT_DATA_KEY) != 64:
+        print("ERROR: VAULT_DATA_KEY must be a 64-char hex string.", file=sys.stderr)
+        return 2
+
+    client_id = _require_env("CRM_SEED_CLIENT_ID")
+    client_secret = _require_env("CRM_SEED_CLIENT_SECRET")
+
+    cid = encrypt_data(client_id, VAULT_DATA_KEY)
+    csec = encrypt_data(client_secret, VAULT_DATA_KEY)
+
+    db = get_db()
+
+    db.execute_raw(
+        """
+        INSERT INTO enterprise_crm_registry (
+          crm_id, crm_enterprise_name, crm_type, environment,
+          crm_base_url, crm_token_url, crm_mcp_endpoint,
+          crm_client_id_ciphertext, crm_client_id_iv, crm_client_id_tag,
+          crm_client_secret_ciphertext, crm_client_secret_iv, crm_client_secret_tag,
+          encryption_algorithm, key_id, auth_header_style,
+          supports_create, supports_read, supports_update, supports_delete,
+          user_object_name, timeout_seconds, retry_count, is_active,
+          business_owner, technical_owner, updated_at
+        ) VALUES (
+          :crm_id, :crm_enterprise_name, :crm_type, :environment,
+          :crm_base_url, :crm_token_url, :crm_mcp_endpoint,
+          :cid_ct, :cid_iv, :cid_tag,
+          :csec_ct, :csec_iv, :csec_tag,
+          :algorithm, :key_id, :auth_header_style,
+          TRUE, TRUE, TRUE, :supports_delete,
+          'Contact', 30, 3, TRUE,
+          :business_owner, :technical_owner, NOW()
+        )
+        ON CONFLICT (crm_enterprise_name, crm_type, environment) DO UPDATE SET
+          crm_base_url = EXCLUDED.crm_base_url,
+          crm_token_url = EXCLUDED.crm_token_url,
+          crm_mcp_endpoint = EXCLUDED.crm_mcp_endpoint,
+          crm_client_id_ciphertext = EXCLUDED.crm_client_id_ciphertext,
+          crm_client_id_iv = EXCLUDED.crm_client_id_iv,
+          crm_client_id_tag = EXCLUDED.crm_client_id_tag,
+          crm_client_secret_ciphertext = EXCLUDED.crm_client_secret_ciphertext,
+          crm_client_secret_iv = EXCLUDED.crm_client_secret_iv,
+          crm_client_secret_tag = EXCLUDED.crm_client_secret_tag,
+          encryption_algorithm = EXCLUDED.encryption_algorithm,
+          key_id = EXCLUDED.key_id,
+          auth_header_style = EXCLUDED.auth_header_style,
+          supports_delete = EXCLUDED.supports_delete,
+          business_owner = EXCLUDED.business_owner,
+          technical_owner = EXCLUDED.technical_owner,
+          is_active = TRUE,
+          updated_at = NOW()
+        """,
+        {
+            "crm_id": args.crm_id,
+            "crm_enterprise_name": args.enterprise_name,
+            "crm_type": args.crm_type,
+            "environment": args.environment,
+            "crm_base_url": args.base_url,
+            "crm_token_url": args.token_url,
+            "crm_mcp_endpoint": args.mcp_endpoint,
+            "cid_ct": cid.ciphertext,
+            "cid_iv": cid.iv,
+            "cid_tag": cid.tag,
+            "csec_ct": csec.ciphertext,
+            "csec_iv": csec.iv,
+            "csec_tag": csec.tag,
+            "algorithm": "aes-256-gcm",
+            "key_id": "vault_data_key_v1",
+            "auth_header_style": "client_id_secret_headers",
+            "supports_delete": bool(args.supports_delete),
+            "business_owner": args.business_owner,
+            "technical_owner": args.technical_owner,
+        },
+    )
+
+    for operation, tool_name, description in _OPERATION_TOOLS:
+        db.execute_raw(
+            """
+            INSERT INTO crm_operation_endpoints (crm_id, operation, tool_name, description)
+            VALUES (:crm_id, :operation, :tool_name, :description)
+            ON CONFLICT (crm_id, operation) DO UPDATE SET
+              tool_name = EXCLUDED.tool_name,
+              description = EXCLUDED.description
+            """,
+            {
+                "crm_id": args.crm_id,
+                "operation": operation,
+                "tool_name": tool_name,
+                "description": description,
+            },
+        )
+
+    print(
+        f"Seeded enterprise_crm_registry crm_id={args.crm_id} "
+        f"environment={args.environment} endpoint_host="
+        f"{args.mcp_endpoint.split('/')[2] if '//' in args.mcp_endpoint else 'set'} "
+        "credentials=encrypted(aes-256-gcm) [plaintext never printed]"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/consent-protocol/tests/test_connected_systems_migration.py
+++ b/consent-protocol/tests/test_connected_systems_migration.py
@@ -20,7 +20,7 @@ def test_connected_systems_migration_is_registered_before_current_release_head()
     assert "067_connected_systems.sql" in manifest["groups"]["iam"]
 
     contract = json.loads((ROOT / "db" / "contracts" / "uat_integrated_schema.json").read_text())
-    assert contract["expected_migration_version"] == 70
+    assert contract["expected_migration_version"] == 71
     assert contract["migration_version_policy"] == "exact"
 
 

--- a/consent-protocol/tests/test_connected_systems_routes.py
+++ b/consent-protocol/tests/test_connected_systems_routes.py
@@ -243,6 +243,7 @@ def test_search_route_binds_matching_crm_record(monkeypatch):
         "phone": "1234567899",
         "search_fields": None,
         "return_fields": ["LeadSource", "MailingCity"],
+        "force_refresh": False,
     }
 
 

--- a/consent-protocol/tests/test_connected_systems_service.py
+++ b/consent-protocol/tests/test_connected_systems_service.py
@@ -8,6 +8,7 @@ from hushh_mcp.services.connected_systems_service import (
     CONNECTED_SYSTEM_SALESFORCE_ID,
     EXTERNAL_CRM_TOOL_CATALOG,
     ConnectedSystemBlockedError,
+    ConnectedSystemNotFoundError,
     ConnectedSystemsService,
     ConnectedSystemValidationError,
     ExternalCrmStreamableMcpAdapter,
@@ -148,6 +149,64 @@ async def test_search_found_record_creates_active_binding_without_raw_lookup_sto
     assert binding["record_id"] == "003gK00000demoQAA"
     assert "doe.john@abc.com" not in serialized
     assert "1234567899" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_bound_read_skips_redundant_mcp_search():
+    """Once a binding exists, a second search serves the bound id without an MCP call."""
+    service, adapter = build_service()
+
+    first = await service.search_record(
+        user_id="user_123",
+        system_id=CONNECTED_SYSTEM_SALESFORCE_ID,
+        object_type=None,
+        email="doe.john@abc.com",
+        phone="1234567899",
+    )
+    assert first["bindingStatus"] == "active"
+    assert first.get("servedFromBinding") is False
+    calls_after_first = len(adapter.calls)
+
+    # Second search for the same (user, system, object_type): no new MCP call.
+    second = await service.search_record(
+        user_id="user_123",
+        system_id=CONNECTED_SYSTEM_SALESFORCE_ID,
+        object_type=None,
+        email="doe.john@abc.com",
+        phone="1234567899",
+    )
+    assert second["servedFromBinding"] is True
+    assert second["recordId"] == "003gK00000demoQAA"
+    assert second["mcp"] is None
+    assert len(adapter.calls) == calls_after_first  # no extra read-crm-record call
+
+
+@pytest.mark.asyncio
+async def test_force_refresh_bypasses_binding_and_researches():
+    """force_refresh=True re-runs the MCP search even when a binding exists."""
+    service, adapter = build_service()
+
+    await service.search_record(
+        user_id="user_123",
+        system_id=CONNECTED_SYSTEM_SALESFORCE_ID,
+        object_type=None,
+        email="doe.john@abc.com",
+        phone="1234567899",
+    )
+    calls_after_first = len(adapter.calls)
+
+    refreshed = await service.search_record(
+        user_id="user_123",
+        system_id=CONNECTED_SYSTEM_SALESFORCE_ID,
+        object_type=None,
+        email="doe.john@abc.com",
+        phone="1234567899",
+        force_refresh=True,
+    )
+    assert refreshed["servedFromBinding"] is False
+    # A fresh read-crm-record call was made.
+    assert len(adapter.calls) == calls_after_first + 1
+    assert adapter.calls[-1][0] == "read-crm-record"
 
 
 @pytest.mark.asyncio
@@ -643,3 +702,203 @@ async def test_delete_is_blocked_unless_maintainer_flag_enabled():
             },
         )
     ]
+
+
+def test_definition_default_transport_headers_empty_and_not_in_summary():
+    """Hardcoded definitions carry no headers and never leak headers via summary."""
+    from hushh_mcp.services.connected_systems_service import SALESFORCE_CRM_SYSTEM
+
+    assert SALESFORCE_CRM_SYSTEM.transport_headers == ()
+    summary = SALESFORCE_CRM_SYSTEM.to_summary(endpoint_configured=True, delete_enabled=False)
+    serialized = json.dumps(summary)
+    assert "transport_headers" not in serialized
+    assert "client_secret" not in serialized
+    assert "client_id" not in serialized
+
+
+def test_adapter_passes_transport_headers_into_streamable_client(monkeypatch):
+    """client_id/client_secret from the definition reach streamablehttp_client(headers=...)."""
+    import contextlib
+
+    from hushh_mcp.services.connected_systems_service import ConnectedSystemDefinition
+
+    captured: dict = {}
+
+    @contextlib.asynccontextmanager
+    async def fake_streamable(url, **kwargs):
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+
+        class _Reader:
+            pass
+
+        yield (_Reader(), _Reader(), None)
+
+    class _FakeSession:
+        def __init__(self, *a, **k):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def initialize(self):
+            return None
+
+        async def call_tool(self, name, arguments):
+            class _Result:
+                isError = False
+                content = []
+
+            return _Result()
+
+    import mcp.client.session as session_mod
+    import mcp.client.streamable_http as streamable_mod
+
+    monkeypatch.setattr(streamable_mod, "streamablehttp_client", fake_streamable)
+    monkeypatch.setattr(session_mod, "ClientSession", _FakeSession)
+
+    definition = ConnectedSystemDefinition(
+        system_id="crm-x",
+        display_name="X",
+        customer_display_name="X",
+        system_type="Salesforce",
+        system_name="X",
+        target="X",
+        object_type_default="Contact",
+        transport="external_crm_streamable_mcp",
+        transport_endpoint="https://gateway.invalid/crm-connect/v1/mcp",
+        registry_source="enterprise_crm_registry",
+        tool_catalog=({"name": "object-schema", "operation": "schema"},),
+        transport_headers=(("client_id", "cid-1"), ("client_secret", "secret-1")),
+    )
+
+    adapter = ExternalCrmStreamableMcpAdapter.from_registry(definition)
+
+    import asyncio
+
+    asyncio.run(adapter.object_schema({"target": "X", "objectType": "Contact"}))
+
+    assert captured["url"] == "https://gateway.invalid/crm-connect/v1/mcp"
+    assert captured["kwargs"]["headers"] == {"client_id": "cid-1", "client_secret": "secret-1"}
+
+
+def test_adapter_without_headers_omits_headers_kwarg(monkeypatch):
+    """Legacy in-code definitions (no headers) pass no headers kwarg."""
+    import contextlib
+
+    captured: dict = {}
+
+    @contextlib.asynccontextmanager
+    async def fake_streamable(url, **kwargs):
+        captured["kwargs"] = kwargs
+
+        class _R:
+            pass
+
+        yield (_R(), _R(), None)
+
+    class _FakeSession:
+        def __init__(self, *a, **k):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def initialize(self):
+            return None
+
+        async def call_tool(self, name, arguments):
+            class _Result:
+                isError = False
+                content = []
+
+            return _Result()
+
+    import mcp.client.session as session_mod
+    import mcp.client.streamable_http as streamable_mod
+
+    monkeypatch.setattr(streamable_mod, "streamablehttp_client", fake_streamable)
+    monkeypatch.setattr(session_mod, "ClientSession", _FakeSession)
+
+    adapter = ExternalCrmStreamableMcpAdapter(
+        endpoint="https://gateway.invalid/mcp",
+        tool_catalog=({"name": "object-schema", "operation": "schema"},),
+    )
+
+    import asyncio
+
+    asyncio.run(adapter.object_schema({"target": "X", "objectType": "Contact"}))
+
+    assert "headers" not in captured["kwargs"]
+
+
+def test_resolve_system_uses_db_registry_when_flag_enabled(monkeypatch):
+    """With the flag on, the service resolves the DB-backed definition."""
+    from hushh_mcp.services import connected_systems_service as svc
+
+    db_definition = svc.ConnectedSystemDefinition(
+        system_id=CONNECTED_SYSTEM_SALESFORCE_ID,
+        display_name="Macy's",
+        customer_display_name="Macy's",
+        system_type="Salesforce",
+        system_name="Salesforce",
+        target="Macy's",
+        object_type_default="Contact",
+        transport="external_crm_streamable_mcp",
+        transport_endpoint="https://gateway.invalid/crm-connect/v1/mcp",
+        registry_source="enterprise_crm_registry",
+        tool_catalog=tuple(EXTERNAL_CRM_TOOL_CATALOG),
+        transport_headers=(("client_id", "cid"), ("client_secret", "sec")),
+    )
+
+    monkeypatch.setattr(svc, "crm_registry_db_enabled", lambda: True, raising=False)
+    import hushh_mcp.runtime_settings as rs
+
+    monkeypatch.setattr(rs, "crm_registry_db_enabled", lambda: True)
+
+    import hushh_mcp.services.crm_registry_repo as repo
+
+    monkeypatch.setattr(repo, "load_active_definition", lambda system_id, db=None: db_definition)
+
+    service = ConnectedSystemsService(
+        adapter=FakeExternalCrmAdapter(), store=InMemoryConnectedSystemIntentStore()
+    )
+    resolved = service.get_system(CONNECTED_SYSTEM_SALESFORCE_ID)
+    assert resolved.registry_source == "enterprise_crm_registry"
+    assert dict(resolved.transport_headers)["client_id"] == "cid"
+
+
+def test_resolve_system_falls_back_to_hardcoded_when_flag_disabled(monkeypatch):
+    """With the flag off, the service uses the in-code definition."""
+    import hushh_mcp.runtime_settings as rs
+
+    monkeypatch.setattr(rs, "crm_registry_db_enabled", lambda: False)
+
+    service = ConnectedSystemsService(
+        adapter=FakeExternalCrmAdapter(), store=InMemoryConnectedSystemIntentStore()
+    )
+    resolved = service.get_system(CONNECTED_SYSTEM_SALESFORCE_ID)
+    assert resolved.registry_source == "customer0_connected_system_registry"
+    assert resolved.transport_headers == ()
+
+
+def test_resolve_system_raises_when_db_row_missing(monkeypatch):
+    """Flag on but no DB row → no data found (NOT a hardcoded fallback)."""
+    import hushh_mcp.runtime_settings as rs
+
+    monkeypatch.setattr(rs, "crm_registry_db_enabled", lambda: True)
+
+    import hushh_mcp.services.crm_registry_repo as repo
+
+    monkeypatch.setattr(repo, "load_active_definition", lambda system_id, db=None: None)
+
+    with pytest.raises(ConnectedSystemNotFoundError):
+        ConnectedSystemsService(
+            adapter=FakeExternalCrmAdapter(), store=InMemoryConnectedSystemIntentStore()
+        )

--- a/consent-protocol/tests/test_crm_registry_repo.py
+++ b/consent-protocol/tests/test_crm_registry_repo.py
@@ -1,0 +1,172 @@
+"""Tests for the DB-backed enterprise CRM registry repository."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from hushh_mcp.services import crm_registry_repo
+from hushh_mcp.services.connected_systems_service import (
+    ConnectedSystemConfigurationError,
+    ConnectedSystemDefinition,
+)
+from hushh_mcp.vault.encrypt import encrypt_data
+
+# Fresh random 64-hex (256-bit) test key — generated per run, never a static
+# literal, so secret scanners do not flag it (matches conftest test_vault_key).
+TEST_VAULT_KEY = os.urandom(32).hex()
+
+CLIENT_ID = "test-crm-client-id-0000000000000000"
+CLIENT_SECRET = "test-crm-client-secret-1111111111111111"
+MCP_ENDPOINT = "https://example-crm-gateway.invalid/crm-connect/v1/mcp"
+
+
+def _encrypted_row() -> dict:
+    cid = encrypt_data(CLIENT_ID, TEST_VAULT_KEY)
+    csec = encrypt_data(CLIENT_SECRET, TEST_VAULT_KEY)
+    return {
+        "crm_id": "salesforce-fsc-customer0",
+        "crm_enterprise_name": "Macy's",
+        "crm_type": "Salesforce",
+        "environment": "sandbox",
+        "crm_base_url": "https://api.salesforce.com/platform",
+        "crm_token_url": None,
+        "crm_mcp_endpoint": MCP_ENDPOINT,
+        "crm_client_id_ciphertext": cid.ciphertext,
+        "crm_client_id_iv": cid.iv,
+        "crm_client_id_tag": cid.tag,
+        "crm_client_secret_ciphertext": csec.ciphertext,
+        "crm_client_secret_iv": csec.iv,
+        "crm_client_secret_tag": csec.tag,
+        "encryption_algorithm": "aes-256-gcm",
+        "key_id": "vault_data_key_v1",
+        "auth_header_style": "client_id_secret_headers",
+        "supports_create": True,
+        "supports_read": True,
+        "supports_update": True,
+        "supports_delete": False,
+        "user_object_name": "Contact",
+        "rate_limit_per_min": None,
+        "timeout_seconds": 30,
+        "retry_count": 3,
+        "is_active": True,
+        "business_owner": "Kushal",
+        "technical_owner": "MuleSoft",
+    }
+
+
+def _operation_rows() -> list[dict]:
+    return [
+        {
+            "crm_id": "salesforce-fsc-customer0",
+            "operation": "schema",
+            "tool_name": "object-schema",
+            "http_method": None,
+            "path": None,
+            "description": "Discover Contact schema.",
+        },
+        {
+            "crm_id": "salesforce-fsc-customer0",
+            "operation": "read",
+            "tool_name": "read-crm-record",
+            "http_method": None,
+            "path": None,
+            "description": "Read by email/phone.",
+        },
+        {
+            "crm_id": "salesforce-fsc-customer0",
+            "operation": "create",
+            "tool_name": "create-crm-record",
+            "http_method": None,
+            "path": None,
+            "description": "Create a Contact.",
+        },
+        {
+            "crm_id": "salesforce-fsc-customer0",
+            "operation": "update",
+            "tool_name": "update-crm-record",
+            "http_method": None,
+            "path": None,
+            "description": "Update by id.",
+        },
+        {
+            "crm_id": "salesforce-fsc-customer0",
+            "operation": "delete",
+            "tool_name": "delete-crm-record",
+            "http_method": None,
+            "path": None,
+            "description": "Delete by id.",
+        },
+    ]
+
+
+class _FakeQueryResult:
+    def __init__(self, data):
+        self.data = data
+
+
+class _FakeDb:
+    """Returns the registry row for the first SELECT, operations for the second."""
+
+    def __init__(self, registry_rows, operation_rows):
+        self._registry_rows = registry_rows
+        self._operation_rows = operation_rows
+        self.queries = []
+
+    def execute_raw(self, sql, params=None):
+        self.queries.append((sql, params))
+        if "crm_operation_endpoints" in sql:
+            return _FakeQueryResult(list(self._operation_rows))
+        return _FakeQueryResult(list(self._registry_rows))
+
+
+def test_load_active_definition_decrypts_credentials_into_headers(monkeypatch):
+    monkeypatch.setattr(crm_registry_repo, "_vault_key_hex", lambda: TEST_VAULT_KEY)
+    db = _FakeDb([_encrypted_row()], _operation_rows())
+
+    definition = crm_registry_repo.load_active_definition("salesforce-fsc-customer0", db=db)
+
+    assert isinstance(definition, ConnectedSystemDefinition)
+    assert definition.system_id == "salesforce-fsc-customer0"
+    assert definition.transport_endpoint == MCP_ENDPOINT
+    headers = dict(definition.transport_headers)
+    assert headers["client_id"] == CLIENT_ID
+    assert headers["client_secret"] == CLIENT_SECRET
+    # Tool catalog built from operation rows.
+    tool_names = {tool["name"] for tool in definition.tool_catalog}
+    assert {
+        "object-schema",
+        "read-crm-record",
+        "create-crm-record",
+        "update-crm-record",
+        "delete-crm-record",
+    } <= tool_names
+
+
+def test_load_active_definition_missing_row_returns_none(monkeypatch):
+    monkeypatch.setattr(crm_registry_repo, "_vault_key_hex", lambda: TEST_VAULT_KEY)
+    db = _FakeDb([], [])
+    assert crm_registry_repo.load_active_definition("does-not-exist", db=db) is None
+
+
+def test_load_active_definition_bad_key_raises_configuration_error(monkeypatch):
+    # Decrypt with the wrong key → GCM tag mismatch → configuration error, not crash.
+    monkeypatch.setattr(
+        crm_registry_repo,
+        "_vault_key_hex",
+        lambda: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    )
+    db = _FakeDb([_encrypted_row()], _operation_rows())
+    with pytest.raises(ConnectedSystemConfigurationError):
+        crm_registry_repo.load_active_definition("salesforce-fsc-customer0", db=db)
+
+
+def test_load_active_definition_does_not_log_plaintext(monkeypatch, caplog):
+    monkeypatch.setattr(crm_registry_repo, "_vault_key_hex", lambda: TEST_VAULT_KEY)
+    db = _FakeDb([_encrypted_row()], _operation_rows())
+    with caplog.at_level("DEBUG"):
+        crm_registry_repo.load_active_definition("salesforce-fsc-customer0", db=db)
+    joined = " ".join(record.getMessage() for record in caplog.records)
+    assert CLIENT_SECRET not in joined
+    assert CLIENT_ID not in joined

--- a/consent-protocol/tests/test_developer_registry_migration.py
+++ b/consent-protocol/tests/test_developer_registry_migration.py
@@ -12,14 +12,14 @@ def test_developer_registry_migration_is_registered_at_release_head():
     manifest = json.loads((ROOT / "db" / "release_migration_manifest.json").read_text())
     ordered = manifest["ordered_migrations"]
 
-    # 070 is registered and unique (release head in this train).
+    # 070 is registered and unique (071 enterprise_crm_registry is the new head).
     assert "070_developer_registry.sql" in ordered
     assert len(ordered) == len(set(ordered))
     # Registered under its own developer lane.
     assert "070_developer_registry.sql" in manifest["groups"]["developer"]
 
     contract = json.loads((ROOT / "db" / "contracts" / "uat_integrated_schema.json").read_text())
-    assert contract["expected_migration_version"] == 70
+    assert contract["expected_migration_version"] == 71
     assert contract["migration_version_policy"] == "exact"
 
 

--- a/consent-protocol/tests/test_enterprise_crm_registry_migration.py
+++ b/consent-protocol/tests/test_enterprise_crm_registry_migration.py
@@ -1,0 +1,75 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATIONS_DIR = ROOT / "db" / "migrations"
+
+
+def test_enterprise_crm_registry_migration_is_registered_at_release_head():
+    migration = MIGRATIONS_DIR / "071_enterprise_crm_registry.sql"
+    assert migration.exists()
+
+    manifest = json.loads((ROOT / "db" / "release_migration_manifest.json").read_text())
+    ordered = manifest["ordered_migrations"]
+
+    # 071 is the current release head and unique.
+    assert ordered[-1] == "071_enterprise_crm_registry.sql"
+    assert len(ordered) == len(set(ordered))
+    # Ordered immediately after 070.
+    idx = ordered.index("071_enterprise_crm_registry.sql")
+    assert ordered[idx - 1] == "070_developer_registry.sql"
+    # Registered under the iam lane (alongside connected systems).
+    assert "071_enterprise_crm_registry.sql" in manifest["groups"]["iam"]
+
+    contract = json.loads((ROOT / "db" / "contracts" / "uat_integrated_schema.json").read_text())
+    assert contract["expected_migration_version"] == 71
+    assert contract["migration_version_policy"] == "exact"
+
+
+def test_enterprise_crm_registry_migration_creates_canonical_tables():
+    sql = (MIGRATIONS_DIR / "071_enterprise_crm_registry.sql").read_text()
+
+    assert "CREATE TABLE IF NOT EXISTS enterprise_crm_registry" in sql
+    assert "CREATE TABLE IF NOT EXISTS crm_operation_endpoints" in sql
+
+    # AES-256-GCM envelope columns (matches hushh_mcp/vault/encrypt.py EncryptedPayload).
+    for column in (
+        "crm_client_id_ciphertext",
+        "crm_client_id_iv",
+        "crm_client_id_tag",
+        "crm_client_secret_ciphertext",
+        "crm_client_secret_iv",
+        "crm_client_secret_tag",
+        "encryption_algorithm",
+        "key_id",
+    ):
+        assert column in sql
+
+    # The gateway URL is non-secret config and stored in plaintext.
+    assert "crm_mcp_endpoint" in sql
+    # Per-operation tool catalog references the registry row.
+    assert "REFERENCES enterprise_crm_registry(crm_id)" in sql
+
+
+def test_enterprise_crm_registry_stores_no_plaintext_credentials():
+    """The registry must never declare a plaintext client_id/secret column."""
+    sql = (MIGRATIONS_DIR / "071_enterprise_crm_registry.sql").read_text()
+
+    # The migration DDL itself must only declare ciphertext envelope columns.
+    assert "crm_client_id_ciphertext" in sql
+    assert "crm_client_secret_ciphertext" in sql
+    # No bare plaintext credential column may be declared in the DDL.
+    assert "crm_client_id TEXT" not in sql
+    assert "crm_client_secret TEXT" not in sql
+
+    contract = json.loads((ROOT / "db" / "contracts" / "uat_integrated_schema.json").read_text())
+    registry_columns = set(contract["required_tables"]["enterprise_crm_registry"])
+
+    # Only ciphertext envelopes — never a raw secret column.
+    assert "crm_client_id" not in registry_columns  # bare plaintext column name
+    assert "crm_client_secret" not in registry_columns
+    assert "crm_client_id_ciphertext" in registry_columns
+    assert "crm_client_secret_ciphertext" in registry_columns
+    # Decryption-key material must never be persisted in the row.
+    assert "vault_data_key" not in registry_columns
+    assert "client_secret_plaintext" not in registry_columns

--- a/consent-protocol/tests/test_marketplace_visibility_posture_migration.py
+++ b/consent-protocol/tests/test_marketplace_visibility_posture_migration.py
@@ -19,7 +19,7 @@ def test_marketplace_visibility_posture_migration_is_registered() -> None:
     assert manifest["ordered_migrations"].index(migration_name) > manifest[
         "ordered_migrations"
     ].index("065_one_location_retention_indexes.sql")
-    assert schema_contract["expected_migration_version"] == 70
+    assert schema_contract["expected_migration_version"] == 71
 
 
 def test_marketplace_visibility_posture_migration_adds_safe_visibility_columns() -> None:

--- a/consent-protocol/tests/test_one_location_public_invite_migration.py
+++ b/consent-protocol/tests/test_one_location_public_invite_migration.py
@@ -37,7 +37,7 @@ def test_one_location_public_invite_migration_sequence_is_current_and_unique() -
         path.name for path in MIGRATIONS_DIR.glob("*one_location_retention_indexes.sql")
     }
     assert len(ordered) == len(set(ordered))
-    assert schema_contract["expected_migration_version"] == 70
+    assert schema_contract["expected_migration_version"] == 71
     assert migration_name in manifest["groups"]["iam"]
     assert retention_name in manifest["groups"]["iam"]
     assert circle_invite_name in manifest["groups"]["iam"]

--- a/consent-protocol/tests/test_seed_crm_registry_row.py
+++ b/consent-protocol/tests/test_seed_crm_registry_row.py
@@ -1,0 +1,170 @@
+"""Test the encrypted CRM registry seed script round-trips through the repo."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+from hushh_mcp.services import crm_registry_repo
+from hushh_mcp.types import EncryptedPayload
+from hushh_mcp.vault.encrypt import decrypt_data
+
+# Fresh random 64-hex (256-bit) test key — generated per run, never a static
+# literal, so secret scanners do not flag it (matches conftest test_vault_key).
+TEST_VAULT_KEY = os.urandom(32).hex()
+SEED_CLIENT_ID = "seed-client-id-abcdef0123456789"
+SEED_CLIENT_SECRET = "seed-client-secret-9876543210fedcba"
+MCP_ENDPOINT = "https://example-crm-gateway.invalid/crm-connect/v1/mcp"
+
+_SEED_PATH = Path(__file__).resolve().parents[1] / "scripts" / "ops" / "seed_crm_registry_row.py"
+
+
+def _load_seed_module():
+    spec = importlib.util.spec_from_file_location("seed_crm_registry_row", _SEED_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Result:
+    def __init__(self, data):
+        self.data = data
+
+
+class _CaptureDb:
+    """Captures the INSERT params so we can assert the encrypted envelope round-trips."""
+
+    def __init__(self):
+        self.registry_params = None
+        self.operation_params = []
+
+    def execute_raw(self, sql, params=None):
+        if "enterprise_crm_registry" in sql:
+            self.registry_params = params
+        elif "crm_operation_endpoints" in sql:
+            self.operation_params.append(params)
+        return _Result([])
+
+
+def test_seed_script_encrypts_and_round_trips(monkeypatch):
+    monkeypatch.setenv("CRM_SEED_CLIENT_ID", SEED_CLIENT_ID)
+    monkeypatch.setenv("CRM_SEED_CLIENT_SECRET", SEED_CLIENT_SECRET)
+
+    # Patch the seed module's VAULT_DATA_KEY and get_db.
+    seed = _load_seed_module()
+    monkeypatch.setattr(seed, "VAULT_DATA_KEY", TEST_VAULT_KEY)
+
+    capture = _CaptureDb()
+    monkeypatch.setattr(seed, "get_db", lambda: capture)
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "seed_crm_registry_row.py",
+            "--crm-id",
+            "salesforce-fsc-customer0",
+            "--enterprise-name",
+            "Macy's",
+            "--crm-type",
+            "Salesforce",
+            "--environment",
+            "sandbox",
+            "--mcp-endpoint",
+            MCP_ENDPOINT,
+        ],
+    )
+
+    rc = seed.main()
+    assert rc == 0
+
+    params = capture.registry_params
+    assert params is not None
+    # Ciphertext columns are populated and are NOT the plaintext.
+    assert params["cid_ct"] and params["cid_ct"] != SEED_CLIENT_ID
+    assert params["csec_ct"] and params["csec_ct"] != SEED_CLIENT_SECRET
+
+    # Round-trip: decrypt the stored envelope with the same key → original plaintext.
+    decrypted_id = decrypt_data(
+        EncryptedPayload(
+            ciphertext=params["cid_ct"],
+            iv=params["cid_iv"],
+            tag=params["cid_tag"],
+            encoding="base64",
+            algorithm="aes-256-gcm",
+        ),
+        TEST_VAULT_KEY,
+    )
+    decrypted_secret = decrypt_data(
+        EncryptedPayload(
+            ciphertext=params["csec_ct"],
+            iv=params["csec_iv"],
+            tag=params["csec_tag"],
+            encoding="base64",
+            algorithm="aes-256-gcm",
+        ),
+        TEST_VAULT_KEY,
+    )
+    assert decrypted_id == SEED_CLIENT_ID
+    assert decrypted_secret == SEED_CLIENT_SECRET
+
+    # All five operation rows seeded with live tool names.
+    tool_names = {p["tool_name"] for p in capture.operation_params}
+    assert tool_names == {
+        "object-schema",
+        "read-crm-record",
+        "create-crm-record",
+        "update-crm-record",
+        "delete-crm-record",
+    }
+
+
+def test_seed_then_load_active_definition_yields_headers(monkeypatch):
+    """The seeded envelope decrypts back into transport_headers via the repo."""
+    monkeypatch.setenv("CRM_SEED_CLIENT_ID", SEED_CLIENT_ID)
+    monkeypatch.setenv("CRM_SEED_CLIENT_SECRET", SEED_CLIENT_SECRET)
+
+    seed = _load_seed_module()
+    monkeypatch.setattr(seed, "VAULT_DATA_KEY", TEST_VAULT_KEY)
+    capture = _CaptureDb()
+    monkeypatch.setattr(seed, "get_db", lambda: capture)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "seed_crm_registry_row.py",
+            "--mcp-endpoint",
+            MCP_ENDPOINT,
+        ],
+    )
+    assert seed.main() == 0
+    p = capture.registry_params
+
+    # Build a registry row dict as the repo would SELECT it.
+    row = {
+        "crm_id": p["crm_id"],
+        "crm_enterprise_name": p["crm_enterprise_name"],
+        "crm_type": p["crm_type"],
+        "crm_mcp_endpoint": p["crm_mcp_endpoint"],
+        "crm_client_id_ciphertext": p["cid_ct"],
+        "crm_client_id_iv": p["cid_iv"],
+        "crm_client_id_tag": p["cid_tag"],
+        "crm_client_secret_ciphertext": p["csec_ct"],
+        "crm_client_secret_iv": p["csec_iv"],
+        "crm_client_secret_tag": p["csec_tag"],
+        "encryption_algorithm": "aes-256-gcm",
+        "key_id": "vault_data_key_v1",
+        "auth_header_style": "client_id_secret_headers",
+        "user_object_name": "Contact",
+    }
+
+    class _RepoDb:
+        def execute_raw(self, sql, params=None):
+            if "crm_operation_endpoints" in sql:
+                return _Result([])
+            return _Result([row])
+
+    monkeypatch.setattr(crm_registry_repo, "_vault_key_hex", lambda: TEST_VAULT_KEY)
+    definition = crm_registry_repo.load_active_definition(p["crm_id"], db=_RepoDb())
+    headers = dict(definition.transport_headers)
+    assert headers["client_id"] == SEED_CLIENT_ID
+    assert headers["client_secret"] == SEED_CLIENT_SECRET

--- a/docs/reference/architecture/runtime-db-data-plane-contract.json
+++ b/docs/reference/architecture/runtime-db-data-plane-contract.json
@@ -385,6 +385,22 @@
       "expected_row_growth": "medium_append_only"
     },
     {
+      "id": "enterprise_crm_registry",
+      "owner": "iam-consent-governance",
+      "data_class": "reference",
+      "lifecycle_status": "customer0",
+      "exact_tables": [
+        "enterprise_crm_registry",
+        "crm_operation_endpoints"
+      ],
+      "primary_access_path": "DB-backed Connected Systems resolution: gateway URL + per-operation MCP tool catalog for enterprise CRM integrations (replaces hardcoded ConnectedSystemDefinition)",
+      "retention_policy": "Retain active enterprise CRM integration config and per-operation tool catalog while the integration is provisioned; deactivate via is_active rather than delete to preserve audit lineage.",
+      "deletion_behavior": "Operator-managed reference config; not user-delete scoped. crm_operation_endpoints cascade-delete with their parent crm_id.",
+      "trust_boundary": "Client credentials stored only as AES-256-GCM envelopes (matches vault/encrypt.py EncryptedPayload), decrypted at request time with VAULT_DATA_KEY; gateway/base/token URLs are non-secret config in plaintext. No raw long-lived secrets at rest.",
+      "plaintext_posture": "config_urls_plaintext_credentials_encrypted",
+      "expected_row_growth": "low_reference"
+    },
+    {
       "id": "developer_access",
       "owner": "mcp-developer-surface",
       "data_class": "audit_regulated",

--- a/scripts/maintenance/clean_tmp.sh
+++ b/scripts/maintenance/clean_tmp.sh
@@ -45,6 +45,7 @@ FAMILIES=(
   "pr-governance-lane-"
   "contributor-impact-dashboard"
   "founder-brief"
+  "board-kpi"
   "autodrive-run"
   "patch-run"
   "patch-queue"


### PR DESCRIPTION
Summary
Consolidates the local enterprise-CRM / Connected-Systems work onto a clean branch off main (migration head 70 → 71). Replaces the hardcoded ConnectedSystemDefinition + unauthenticated MCP endpoint with a DB-backed registry whose credentials are stored as AES-256-GCM envelopes.

Migration 071_enterprise_crm_registry.sql
enterprise_crm_registry — gateway/base/token URLs (non-secret, plaintext) + client_id / client_secret as AES-256-GCM envelopes (matches vault/encrypt.py EncryptedPayload), decrypted at request time with VAULT_DATA_KEY. No new long-lived secrets at rest.
crm_operation_endpoints — per-operation MCP tool catalog (schema/create/read/update/delete), cascade-deleted with the parent crm_id.
Service + routes
crm_registry_repo.py — typed repo resolving Connected Systems from the DB.
connected_systems_service.py / routes — resolve via the registry behind the CRM_REGISTRY_DB_ENABLED flag (runtime_settings.crm_registry_db_enabled), defaulting off until cutover.
seed_crm_registry_row.py + crm_registry_e2e_check.py — ops tooling.
Governance
Manifest + UAT schema contract advanced to migration 71.
Data-plane contract classifies the enterprise_crm_registry family (data_class=reference; credentials-encrypted trust boundary) so data_model_audit.py passes with zero unclassified tables.
ruff per-file-ignores extended consistently (S105 test fixtures, S101/S108 verification scripts); strengthened the no-plaintext-credential migration test to assert against the DDL itself.
Verification (real runs)
data_model_audit.py → EXIT 0, zero unclassified tables.
verify_release_migration_contract.py → aligned at 71.
65 targeted tests pass (CRM repo/migration/seed, connected-systems service/routes/migration, developer-registry, one-location).
ruff clean + formatted.
Notes
Cleanly based on main (778be9d25); single DCO-signed commit. Migration-coupled, so promoted via the pre-authorized branch per the PR-base-policy SOP.