### PR TITLE
test(agent-voice-state): cover remaining status labels

### DIFF
--- a/hushh-webapp/__tests__/lib/agent-voice-state.test.ts
+++ b/hushh-webapp/__tests__/lib/agent-voice-state.test.ts
@@ -28,10 +28,13 @@ describe("agent voice state", () => {
   });
 
   it("formats compact status labels", () => {
-    expect(getAgentVoiceStatusLabel("listening")).toBe("Listening");
-    expect(getAgentVoiceStatusLabel("muted")).toBe("Muted");
-    expect(getAgentVoiceStatusLabel("transcribing")).toBe("Transcribing");
-    expect(getAgentVoiceStatusLabel("thinking")).toBe("Thinking");
-    expect(getAgentVoiceStatusLabel("speaking")).toBe("Speaking");
+   expect(getAgentVoiceStatusLabel("idle")).toBe("Voice idle");
+   expect(getAgentVoiceStatusLabel("connecting")).toBe("Voice connecting");
+   expect(getAgentVoiceStatusLabel("listening")).toBe("Listening");
+   expect(getAgentVoiceStatusLabel("muted")).toBe("Muted");
+   expect(getAgentVoiceStatusLabel("transcribing")).toBe("Transcribing");
+   expect(getAgentVoiceStatusLabel("thinking")).toBe("Thinking");
+   expect(getAgentVoiceStatusLabel("speaking")).toBe("Speaking");
+   expect(getAgentVoiceStatusLabel("error")).toBe("Voice error");
   });
 });


### PR DESCRIPTION
## Summary

Adds test coverage for the remaining agent voice status label mappings.

### Added coverage

Verifies that `getAgentVoiceStatusLabel()` returns the expected labels for:

* `idle` → `Voice idle`
* `connecting` → `Voice connecting`
* `error` → `Voice error`

The existing test already covered:

* `listening`
* `muted`
* `transcribing`
* `thinking`
* `speaking`

### Why

`getAgentVoiceStatusLabel()` supports all voice status values defined by `AgentVoiceStatus`. This update completes coverage for the remaining status label mappings and helps protect against future regressions in status display behavior.
