### PR TITLE
test(lib): add config security-event contract tests

### DIFF
--- a/hushh-webapp/__tests__/lib/config.test.ts
+++ b/hushh-webapp/__tests__/lib/config.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { SecurityEventType } from "@/lib/config";
 
 vi.mock("@/lib/app-env", () => ({
   resolveAppEnvironment: vi.fn(),
@@ -108,5 +109,142 @@ describe("config", () => {
     const config = await import("@/lib/config");
 
     expect(config.BACKEND_URL).toBe("https://uat-api.hushh.ai");
-  });
-});
+      });
+
+      it("keeps production frontend origin empty when runtime frontend url is empty", async () => {
+        const { resolveAppEnvironment } = await import("@/lib/app-env");
+        const { resolveRuntimeFrontendUrl } = await import(
+          "@/lib/runtime/settings"
+        );
+
+        vi.mocked(resolveAppEnvironment).mockReturnValue("production");
+        vi.mocked(resolveRuntimeFrontendUrl).mockReturnValue("");
+
+        const config = await import("@/lib/config");
+
+        expect(config.APP_FRONTEND_ORIGIN).toBe("");
+      });
+
+      it("resolves configured frontend origin", async () => {
+        const { resolveAppEnvironment } = await import("@/lib/app-env");
+        const { resolveRuntimeFrontendUrl } = await import(
+          "@/lib/runtime/settings"
+        );
+
+        vi.mocked(resolveAppEnvironment).mockReturnValue("uat");
+        vi.mocked(resolveRuntimeFrontendUrl).mockReturnValue(
+          " https://uat-app.hushh.ai/ "
+        );
+
+        const config = await import("@/lib/config");
+
+        expect(config.APP_FRONTEND_ORIGIN).toBe(
+          "https://uat-app.hushh.ai"
+        );
+      });
+    });
+
+    describe("config — ENVIRONMENT_MODE contract", () => {
+      beforeEach(() => {
+        vi.resetModules();
+      });
+
+      it("captures environment mode at import time", async () => {
+        const { resolveAppEnvironment } = await import("@/lib/app-env");
+
+        vi.mocked(resolveAppEnvironment).mockReturnValue("uat");
+
+        const config = await import("@/lib/config");
+
+        expect(config.ENVIRONMENT_MODE).toBe("uat");
+      });
+    });
+
+    describe("config — logSecurityEvent contract", () => {
+      beforeEach(() => {
+        vi.resetModules();
+        vi.spyOn(console, "log").mockImplementation(() => undefined);
+      });
+
+      afterEach(() => {
+        vi.restoreAllMocks();
+      });
+
+      it("logs security events with details payload", async () => {
+        const { resolveAppEnvironment } = await import("@/lib/app-env");
+
+        vi.mocked(resolveAppEnvironment).mockReturnValue("production");
+
+        const config = await import("@/lib/config");
+
+        const details = {
+          userId: "user-1",
+          customAuditField: "extra-context",
+        };
+
+        config.logSecurityEvent("TOKEN_VALID", details);
+
+        expect(console.log).toHaveBeenCalledTimes(1);
+
+        const [, loggedDetails] =
+          vi.mocked(console.log).mock.calls[0]!;
+
+        expect(loggedDetails).toEqual(details);
+      });
+    });
+
+    describe("config — SecurityEventType exhaustiveness contract", () => {
+      const ALL_SECURITY_EVENT_TYPES: SecurityEventType[] = [
+        "TOKEN_VALID",
+        "TOKEN_INVALID",
+        "TOKEN_VALIDATION_FAILED",
+        "TOKEN_VALIDATION_ERROR",
+        "SCOPE_MISMATCH",
+        "FIREBASE_TOKEN_VALID",
+        "FIREBASE_TOKEN_INVALID",
+        "FIREBASE_VALIDATION_ERROR",
+        "VAULT_READ_REJECTED",
+        "VAULT_READ_SUCCESS",
+        "VAULT_WRITE_REJECTED",
+        "VAULT_WRITE_SUCCESS",
+        "VAULT_KEY_REJECTED",
+        "VAULT_KEY_SUCCESS",
+        "VAULT_CHECK_REJECTED",
+        "VAULT_CHECK_SUCCESS",
+        "VAULT_SETUP_SUCCESS",
+        "PREFERENCES_READ_REJECTED",
+        "PREFERENCES_READ_SUCCESS",
+        "CONSENT_VERIFIED",
+        "CONSENT_REQUIRED",
+        "CONSENT_INVALID",
+        "USER_MISMATCH",
+        "CHAT_REJECTED",
+        "RECOMMEND_REJECTED",
+        "RECOMMEND_SUCCESS",
+        "DEV_AUTO_GRANT",
+        "DEV_FIREBASE_BYPASS",
+      ];
+
+      beforeEach(() => {
+        vi.resetModules();
+        vi.spyOn(console, "log").mockImplementation(() => undefined);
+      });
+
+      afterEach(() => {
+        vi.restoreAllMocks();
+      });
+
+      it("accepts all known security event types", async () => {
+        const { resolveAppEnvironment } = await import("@/lib/app-env");
+
+        vi.mocked(resolveAppEnvironment).mockReturnValue("production");
+
+        const config = await import("@/lib/config");
+
+        for (const event of ALL_SECURITY_EVENT_TYPES) {
+          expect(() =>
+            config.logSecurityEvent(event, {})
+          ).not.toThrow();
+        }
+      });
+    });


### PR DESCRIPTION
## Summary

Extends `__tests__/lib/config.test.ts` with contract coverage for configuration exports that currently lack dedicated tests.

## Coverage Added

* APP_FRONTEND_ORIGIN configured and empty-value paths
* ENVIRONMENT_MODE import-time resolution
* logSecurityEvent payload contract
* SecurityEventType exhaustiveness coverage

## Scope

* Test-only change
* No production code modified
* No dependency changes
* Existing mocking strategy reused

## Risk

Low. Existing test file extended with additive contract coverage only.
