### PR TITLE
test(alert): cover alert data-slot contracts

### DIFF
--- a/hushh-webapp/__tests__/ui/alert.test.tsx
+++ b/hushh-webapp/__tests__/ui/alert.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@/components/ui/alert";
+
+describe("Alert", () => {
+  it("renders alert data-slot contracts", () => {
+    render(
+      <Alert>
+        <AlertTitle>Account notice</AlertTitle>
+        <AlertDescription>Review your account details.</AlertDescription>
+      </Alert>,
+    );
+
+    const alert = screen.getByRole("alert");
+
+    expect(alert.getAttribute("data-slot")).toBe("alert");
+    expect(
+      screen.getByText("Account notice").getAttribute("data-slot"),
+    ).toBe("alert-title");
+    expect(
+      screen.getByText("Review your account details.").getAttribute(
+        "data-slot",
+      ),
+    ).toBe("alert-description");
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for the Alert composition data-slot contracts.
- Assert the root alert, title, and description slots render with their expected data-slot values.

## Why
This locks the existing Alert UI contract without changing runtime behavior.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/ui/alert.test.tsx` only.
- This is a new test file and does not touch shared hot files such as `config.test.ts`, drawer/sheet/table/button/sonner/breadcrumb/pagination, One Location, Marketplace, RIA, Kai, or agent UI files.
- The test only imports `@/components/ui/alert` and makes no production-code changes.

## Validation
- `npm.cmd test -- __tests__/ui/alert.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.