### PR TITLE
test(alert): cover alert data-slot contracts

### DIFF
--- a/hushh-webapp/__tests__/ui/alert.test.tsx
+++ b/hushh-webapp/__tests__/ui/alert.test.tsx
@@ -39,4 +39,21 @@ describe("Alert", () => {
       container.querySelector('[data-slot="alert-description"]'),
     ).toBeTruthy();
   });
+
+  it("preserves alert data-slot contracts in a composed alert", () => {
+    const { container } = render(
+      <Alert>
+        <AlertTitle>Account notice</AlertTitle>
+        <AlertDescription>Review your account details.</AlertDescription>
+      </Alert>,
+    );
+
+    const alert = container.querySelector('[data-slot="alert"]');
+    const slots = Array.from(container.querySelectorAll("[data-slot]")).map(
+      (element) => element.getAttribute("data-slot"),
+    );
+
+    expect(alert?.getAttribute("role")).toBe("alert");
+    expect(slots).toEqual(["alert", "alert-title", "alert-description"]);
+  });
 });


### PR DESCRIPTION
## Summary
- Add a composed Alert test covering the root, title, and description data-slot contract together.
- Keep the existing integration-train Alert tests intact and add one focused `it()` block.

## Why
The integration train already has individual Alert slot tests. This PR adds a composed-render assertion so the full Alert structure keeps the expected slot order and alert role together.

## PR Base Policy
- Base branch: `integration/pr-train`
- This branch was rebased onto the train before opening the PR.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/ui/alert.test.tsx` only.
- The integration train already owns this test file, so this PR appends one new composed Alert scenario after the existing tests.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/ui/alert.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.