### PR TITLE
fix(a11y): add aria-hidden to decorative MoreHorizontalIcon in PaginationEllipsis

### DIFF
--- a/hushh-webapp/components/ui/pagination.tsx
+++ b/hushh-webapp/components/ui/pagination.tsx
@@ -126,7 +126,7 @@ function PaginationEllipsis({
       className={cn("flex size-9 items-center justify-center", className)}
       {...props}
     >
-      <MoreHorizontalIcon className="size-4" />
+      <MoreHorizontalIcon aria-hidden="true" className="size-4" />
       <span className="sr-only">More pages</span>
     </span>
   )


### PR DESCRIPTION
## Summary

Adds `aria-hidden="true"` to the decorative `MoreHorizontalIcon` used by `PaginationEllipsis`.

## Change

```diff
- <MoreHorizontalIcon className="size-4" />
+ <MoreHorizontalIcon aria-hidden="true" className="size-4" />
```

## Rationale

Other decorative icons in this component already use `aria-hidden="true"`.

This change aligns `MoreHorizontalIcon` with the existing accessibility pattern used by the pagination controls.

## Risk

* No logic changes
* No behavioral changes
* No visual changes
* No import changes
* One-line diff only

## Validation

* Verified `aria-hidden="true"` is present on `MoreHorizontalIcon`
* Existing test suite remains unchanged
