### PR TITLE
test(agent-welcome-suggestions): cover query string routes

### DIFF
--- a/hushh-webapp/__tests__/lib/agent-welcome-suggestions.test.ts
+++ b/hushh-webapp/__tests__/lib/agent-welcome-suggestions.test.ts
@@ -47,4 +47,16 @@ describe("agent welcome suggestions", () => {
     expect(rotated).toHaveLength(3);
     expect(rotated).not.toEqual(first);
   });
+
+  it("matches route suggestions when pathname contains query parameters", () => {
+  const suggestions = resolveAgentWelcomeSuggestions({
+    userId: "user-query",
+    pathname: "/marketplace?tab=connect",
+    randomSeed: 7,
+  });
+
+  expect(
+    suggestions.some((item) => item.id === "connect-request")
+  ).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Adds test coverage for route-aware welcome suggestions when a pathname contains query parameters.

### Added coverage

Verifies that Marketplace-specific suggestions are still resolved when the pathname includes a query string, such as:

* `/marketplace?tab=connect`

### Why

`normalizeRoute()` strips query parameters before route matching. This test documents and protects that behavior to ensure route-specific welcome suggestions continue to work for URLs that include query strings.
