### PR TITLE
One Location consent center + mobile-first UX

### DIFF
--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -4,10 +4,12 @@
     "promotion_branch": "main",
     "main_allowed_head_branches": [
       "integration/pr-train",
-      "maintainer/promote-damria-one-location-to-main"
+      "maintainer/promote-damria-one-location-to-main",
+      "maintainer/promote-damria-one-location-consent"
     ]
   },
   "main": {
+
     "required_status_check": "CI Status Gate",
     "required_approving_reviews": 1,
     "require_last_push_approval": true,

--- a/consent-protocol/hushh_mcp/services/consent_center_service.py
+++ b/consent-protocol/hushh_mcp/services/consent_center_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any
 
 from hushh_mcp.consent.scope_helpers import get_scope_description
@@ -13,6 +14,22 @@ from hushh_mcp.services.ria_iam_service import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _one_location_consent_center_enabled() -> bool:
+    """Feature flag: union One Location rows into the consent center.
+
+    Defaults OFF so the shared consent surface stays stable until the
+    integration is verified end to end (see
+    docs/future/one-location-consent-center-integration-plan.md).
+    """
+    return os.getenv("ONE_LOCATION_CONSENT_CENTER_ENABLED", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
 
 
 class ConsentCenterService:
@@ -33,6 +50,46 @@ class ConsentCenterService:
         self._identity = ActorIdentityService()
         self._ria = RIAIAMService()
         self._owned_identifier_cache: dict[str, list[str]] = {}
+        self._location_center = None
+        if _one_location_consent_center_enabled():
+            try:
+                from hushh_mcp.services.one_location_center_contributor import (
+                    OneLocationCenterContributor,
+                )
+
+                self._location_center = OneLocationCenterContributor()
+            except Exception as exc:  # never block the consent surface
+                logger.warning(
+                    "consent_center.one_location_contributor_init_failed error=%s",
+                    exc,
+                )
+                self._location_center = None
+
+    def _location_buckets(self, user_id: str) -> dict[str, list[dict[str, Any]]]:
+        """Coordinate-free One Location entries grouped by consent bucket.
+
+        Returns empty buckets when the feature flag is off or the contributor
+        is unavailable, so the shared consent surface is never destabilized.
+        """
+        empty = {
+            "incoming_requests": [],
+            "outgoing_requests": [],
+            "active_grants": [],
+            "history": [],
+            "invites": [],
+        }
+        if not self._location_center:
+            return empty
+        try:
+            return self._location_center.collect(user_id)
+        except Exception as exc:
+            logger.warning(
+                "consent_center.one_location_collect_failed user=%s error=%s",
+                user_id,
+                exc,
+            )
+            return empty
+
 
     @staticmethod
     def _metadata(value: Any) -> dict[str, Any]:
@@ -1316,35 +1373,58 @@ class ConsentCenterService:
                 ]
             )
         if normalized_actor == "investor":
+            location_buckets = (
+                self._location_buckets(user_id)
+                if normalized_mode == "consents"
+                else None
+            )
+            location_count = 0
+            if location_buckets:
+                if surface == "pending":
+                    location_count = len(location_buckets["incoming_requests"])
+                elif surface == "active":
+                    location_count = len(location_buckets["active_grants"])
+                else:
+                    location_count = len(location_buckets["history"])
             if surface == "pending":
-                return len(
-                    self._collapse_consent_chains(
-                        self._filter_mode_entries(
-                            await self._load_investor_pending_entries(user_id),
-                            actor=normalized_actor,
-                            mode=normalized_mode,
+                return (
+                    len(
+                        self._collapse_consent_chains(
+                            self._filter_mode_entries(
+                                await self._load_investor_pending_entries(user_id),
+                                actor=normalized_actor,
+                                mode=normalized_mode,
+                            )
                         )
                     )
+                    + location_count
                 )
             if surface == "active":
-                return len(
-                    self._collapse_consent_chains(
+                return (
+                    len(
+                        self._collapse_consent_chains(
+                            self._filter_mode_entries(
+                                await self._load_investor_active_entries(user_id),
+                                actor=normalized_actor,
+                                mode=normalized_mode,
+                            )
+                        )
+                    )
+                    + location_count
+                )
+            return (
+                len(
+                    self._group_history_identifier_trails(
                         self._filter_mode_entries(
-                            await self._load_investor_active_entries(user_id),
+                            await self._load_investor_previous_entries(user_id),
                             actor=normalized_actor,
                             mode=normalized_mode,
                         )
                     )
                 )
-            return len(
-                self._group_history_identifier_trails(
-                    self._filter_mode_entries(
-                        await self._load_investor_previous_entries(user_id),
-                        actor=normalized_actor,
-                        mode=normalized_mode,
-                    )
-                )
+                + location_count
             )
+
 
         if surface == "active":
             payload = await self._load_ria_active_entries(user_id, page=1, limit=1)
@@ -1522,6 +1602,21 @@ class ConsentCenterService:
                 "invited": len([item for item in roster if item.get("status") == "invited"]),
             }
 
+        location_buckets = (
+            self._location_buckets(user_id)
+            if (actor is None or normalized_actor != "ria")
+            else None
+        )
+        if location_buckets:
+            if need_incoming:
+                incoming = [*incoming, *location_buckets["incoming_requests"]]
+            if need_active:
+                active_entries = [*active_entries, *location_buckets["active_grants"]]
+            if need_history:
+                history_entries = [*history_entries, *location_buckets["history"]]
+            outgoing_entries = [*outgoing_entries, *location_buckets["outgoing_requests"]]
+            invite_entries = [*invite_entries, *location_buckets["invites"]]
+
         return {
             "user_id": user_id,
             "persona_state": persona_state,
@@ -1540,6 +1635,7 @@ class ConsentCenterService:
             "active_grants": active_entries,
             "history": history_entries,
             "invites": invite_entries,
+
             "developer_requests": developer_requests,
             "requestor_groups": {
                 "pending": investor_pending_groups,
@@ -1648,6 +1744,18 @@ class ConsentCenterService:
                 if normalized_surface == "previous"
                 else self._collapse_consent_chains(entries)
             )
+            location_buckets = (
+                self._location_buckets(user_id)
+                if normalized_mode == "consents"
+                else None
+            )
+            if location_buckets:
+                if normalized_surface == "pending":
+                    entries = [*entries, *location_buckets["incoming_requests"]]
+                elif normalized_surface == "active":
+                    entries = [*entries, *location_buckets["active_grants"]]
+                else:
+                    entries = [*entries, *location_buckets["history"]]
             paged = self._paginate_entries(
                 entries,
                 page=safe_page,
@@ -1655,6 +1763,7 @@ class ConsentCenterService:
                 query=query,
             )
         elif normalized_surface == "active":
+
             paged = await self._load_ria_active_entries(
                 user_id,
                 query=query,

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -2302,20 +2302,18 @@ class OneLocationAgentService:
               LIMIT 1
             ) k ON TRUE
             WHERE a.user_id <> :owner_user_id
-              AND (
-                a.phone_verified = TRUE
-                OR EXISTS (
-                  SELECT 1
-                  FROM one_location_network_connections nc
-                  WHERE nc.status = 'active'
-                    AND (
-                      (nc.user_a_id = :owner_user_id AND nc.user_b_id = a.user_id)
-                      OR (nc.user_b_id = :owner_user_id AND nc.user_a_id = a.user_id)
-                    )
-                )
+              AND EXISTS (
+                SELECT 1
+                FROM one_location_network_connections nc
+                WHERE nc.status = 'active'
+                  AND (
+                    (nc.user_a_id = :owner_user_id AND nc.user_b_id = a.user_id)
+                    OR (nc.user_b_id = :owner_user_id AND nc.user_a_id = a.user_id)
+                  )
               )
             ORDER BY COALESCE(a.display_name, a.phone_number, a.user_id), a.user_id
             LIMIT :limit
+
             """,
             {"owner_user_id": owner_user_id, "limit": max(1, min(int(limit), 100))},
         )

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -2302,18 +2302,20 @@ class OneLocationAgentService:
               LIMIT 1
             ) k ON TRUE
             WHERE a.user_id <> :owner_user_id
-              AND EXISTS (
-                SELECT 1
-                FROM one_location_network_connections nc
-                WHERE nc.status = 'active'
-                  AND (
-                    (nc.user_a_id = :owner_user_id AND nc.user_b_id = a.user_id)
-                    OR (nc.user_b_id = :owner_user_id AND nc.user_a_id = a.user_id)
-                  )
+              AND (
+                a.phone_verified = TRUE
+                OR EXISTS (
+                  SELECT 1
+                  FROM one_location_network_connections nc
+                  WHERE nc.status = 'active'
+                    AND (
+                      (nc.user_a_id = :owner_user_id AND nc.user_b_id = a.user_id)
+                      OR (nc.user_b_id = :owner_user_id AND nc.user_a_id = a.user_id)
+                    )
+                )
               )
             ORDER BY COALESCE(a.display_name, a.phone_number, a.user_id), a.user_id
             LIMIT :limit
-
             """,
             {"owner_user_id": owner_user_id, "limit": max(1, min(int(limit), 100))},
         )

--- a/consent-protocol/hushh_mcp/services/one_location_center_contributor.py
+++ b/consent-protocol/hushh_mcp/services/one_location_center_contributor.py
@@ -1,0 +1,389 @@
+"""One Location -> Consent Center contributor.
+
+Maps the coordinate-free DTO returned by
+``OneLocationAgentService.list_state`` into the shared ``ConsentCenterEntry``
+shape consumed by the ``/consents`` Access Manager (Requests / Active Access /
+History tabs) and the notification bell summary.
+
+Design rules (see docs/future/one-location-consent-center-integration-plan.md):
+
+* Reuse ``list_state`` -- do NOT issue raw SQL against ``one_location_*`` tables.
+  ``list_state`` already assembles every location surface and never returns
+  coordinates (those live only inside encrypted envelopes via
+  ``view_latest_envelope``).
+* Every emitted entry is coordinate-free. ``_assert_coordinate_free`` re-checks
+  each metadata dict against the location agent's own redaction guards and
+  raises if any coordinate-like key leaks in.
+* The frontend recognizes these rows via
+  ``metadata.request_source`` starting with ``one_location`` (see
+  ``hushh-webapp/lib/consent/location-consent.ts``).
+
+This module is pure mapping logic and is safe to unit test in isolation.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from hushh_mcp.services.one_location_agent_service import (
+    COORDINATE_METADATA_KEYS,
+    OneLocationAgentService,
+    _contains_plaintext_location_key,
+)
+
+logger = logging.getLogger(__name__)
+
+# Capability scope family for live location viewing. Kept as a constant so the
+# consent center, scope catalog, and tests agree on one string.
+LOCATION_VIEW_SCOPE = "cap.location.live.view"
+
+_ACTIVE_GRANT_STATUSES = {"active", "approved", "granted"}
+_PENDING_REQUEST_STATUSES = {"pending", "request_pending", "sent"}
+
+
+def _safe_str(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _coerce_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+    """Assert a metadata dict is coordinate-free, then return it unchanged.
+
+    Mirrors the location agent's outbound guard so the consent center can never
+    surface latitude/longitude/address/map data even if an upstream payload
+    regresses.
+    """
+    for key in metadata:
+        normalized = str(key or "").strip().lower()
+        if normalized in COORDINATE_METADATA_KEYS:
+            raise ValueError(
+                f"one_location consent entry metadata contains forbidden "
+                f"coordinate key: {key}"
+            )
+    for value in metadata.values():
+        if isinstance(value, str) and _contains_plaintext_location_key(value):
+            raise ValueError(
+                "one_location consent entry metadata contains a plaintext "
+                "location value"
+            )
+    return metadata
+
+
+class OneLocationCenterContributor:
+    """Maps ``OneLocationAgentService.list_state`` into ConsentCenterEntry dicts."""
+
+    def __init__(self, location_service: OneLocationAgentService | None = None) -> None:
+        self._location = location_service or OneLocationAgentService()
+
+    # ----- public API ----------------------------------------------------
+
+    def collect(self, user_id: str) -> dict[str, list[dict[str, Any]]]:
+        """Return location-derived consent entries grouped by surface bucket.
+
+        Buckets match ConsentCenterResponse keys so the caller can concatenate
+        directly: ``incoming_requests``, ``outgoing_requests``,
+        ``active_grants``, ``history``, ``invites``.
+        """
+        normalized_user = _safe_str(user_id)
+        if not normalized_user:
+            return self._empty()
+        try:
+            state = self._location.list_state(user_id=normalized_user)
+        except Exception as exc:  # never let location break the consent surface
+            logger.warning(
+                "one_location.consent_center.list_state_failed user=%s error=%s",
+                normalized_user,
+                exc,
+            )
+            return self._empty()
+
+        return {
+            "incoming_requests": self._incoming_requests(state, normalized_user),
+            "outgoing_requests": self._outgoing_requests(state, normalized_user),
+            "active_grants": self._active_grants(state, normalized_user),
+            "history": self._history(state, normalized_user),
+            "invites": self._invites(state, normalized_user),
+        }
+
+    def counts(self, user_id: str) -> dict[str, int]:
+        """Surface counts for the consent summary endpoint."""
+        buckets = self.collect(user_id)
+        return {
+            "pending": len(buckets["incoming_requests"]),
+            "active": len(buckets["active_grants"]),
+            "previous": len(buckets["history"]),
+        }
+
+    # ----- mappers -------------------------------------------------------
+
+    def _incoming_requests(
+        self, state: dict[str, Any], user_id: str
+    ) -> list[dict[str, Any]]:
+        entries: list[dict[str, Any]] = []
+        for request in state.get("requests") or []:
+            if _safe_str(request.get("ownerUserId")) != user_id:
+                continue
+            if _safe_str(request.get("status")) not in _PENDING_REQUEST_STATUSES:
+                continue
+            entries.append(
+                self._request_entry(
+                    request,
+                    kind="incoming_request",
+                    section="approvals",
+                    counterpart_id=_safe_str(request.get("requesterUserId")),
+                    counterpart_label=_safe_str(
+                        request.get("requesterDisplayName")
+                    )
+                    or "Someone in your One Network",
+                )
+            )
+        return entries
+
+    def _outgoing_requests(
+        self, state: dict[str, Any], user_id: str
+    ) -> list[dict[str, Any]]:
+        entries: list[dict[str, Any]] = []
+        for request in state.get("requests") or []:
+            if _safe_str(request.get("requesterUserId")) != user_id:
+                continue
+            if _safe_str(request.get("ownerUserId")) == user_id:
+                continue
+            status = _safe_str(request.get("status"))
+            kind = (
+                "outgoing_request"
+                if status in _PENDING_REQUEST_STATUSES
+                else "history"
+            )
+            entries.append(
+                self._request_entry(
+                    request,
+                    kind=kind,
+                    section="my_requests",
+                    counterpart_id=_safe_str(request.get("ownerUserId")),
+                    counterpart_label=_safe_str(request.get("ownerDisplayName"))
+                    or "Location owner",
+                )
+            )
+        return entries
+
+    def _active_grants(
+        self, state: dict[str, Any], user_id: str
+    ) -> list[dict[str, Any]]:
+        entries: list[dict[str, Any]] = []
+        # Owner side: people who can see me.
+        for grant in state.get("ownerGrants") or []:
+            if _safe_str(grant.get("status")) not in _ACTIVE_GRANT_STATUSES:
+                continue
+            entries.append(
+                self._grant_entry(
+                    grant,
+                    section="people",
+                    counterpart_id=_safe_str(grant.get("recipientUserId")),
+                    counterpart_label=_safe_str(grant.get("recipientDisplayName"))
+                    or "A trusted person",
+                )
+            )
+        # Recipient side: shared with me.
+        for grant in state.get("receivedGrants") or []:
+            if _safe_str(grant.get("status")) not in _ACTIVE_GRANT_STATUSES:
+                continue
+            entries.append(
+                self._grant_entry(
+                    grant,
+                    section="shared",
+                    counterpart_id=_safe_str(grant.get("ownerUserId")),
+                    counterpart_label=_safe_str(grant.get("ownerDisplayName"))
+                    or "A trusted person",
+                )
+            )
+        # Active public links.
+        for invite in state.get("publicInvites") or []:
+            if _safe_str(invite.get("status")) != "active":
+                continue
+            entries.append(self._public_invite_entry(invite, kind="active_grant"))
+        return entries
+
+    def _history(self, state: dict[str, Any], user_id: str) -> list[dict[str, Any]]:
+        entries: list[dict[str, Any]] = []
+        terminal = {"revoked", "expired", "denied", "cancelled"}
+        for bucket in ("ownerGrants", "receivedGrants"):
+            for grant in state.get(bucket) or []:
+                if _safe_str(grant.get("status")) not in terminal:
+                    continue
+                is_owner = bucket == "ownerGrants"
+                entries.append(
+                    self._grant_entry(
+                        grant,
+                        section="shared" if not is_owner else "people",
+                        counterpart_id=_safe_str(
+                            grant.get("recipientUserId")
+                            if is_owner
+                            else grant.get("ownerUserId")
+                        ),
+                        counterpart_label=_safe_str(
+                            grant.get("recipientDisplayName")
+                            if is_owner
+                            else grant.get("ownerDisplayName")
+                        )
+                        or "A trusted person",
+                        kind="history",
+                    )
+                )
+        for invite in state.get("publicInvites") or []:
+            if _safe_str(invite.get("status")) in {"revoked", "expired"}:
+                entries.append(self._public_invite_entry(invite, kind="history"))
+        return entries
+
+    def _invites(self, state: dict[str, Any], user_id: str) -> list[dict[str, Any]]:
+        entries: list[dict[str, Any]] = []
+        for invite in state.get("circleInvites") or []:
+            status = _safe_str(invite.get("status"))
+            entries.append(
+                {
+                    "id": f"one_location_circle:{_safe_str(invite.get('id'))}",
+                    "kind": "invite",
+                    "status": status or "active",
+                    "action": "INVITE",
+                    "scope": LOCATION_VIEW_SCOPE,
+                    "scope_description": "Invite to One Location",
+                    "counterpart_type": "investor",
+                    "counterpart_id": None,
+                    "counterpart_label": "Invite to One",
+                    "issued_at": invite.get("createdAt"),
+                    "expires_at": invite.get("expiresAt"),
+                    "metadata": _coerce_metadata(
+                        {
+                            "request_source": "one_location_circle_invite",
+                            "section": "people",
+                        }
+                    ),
+                }
+            )
+        return entries
+
+    # ----- entry builders ------------------------------------------------
+
+    def _grant_entry(
+        self,
+        grant: dict[str, Any],
+        *,
+        section: str,
+        counterpart_id: str,
+        counterpart_label: str,
+        kind: str = "active_grant",
+    ) -> dict[str, Any]:
+        grant_id = _safe_str(grant.get("id"))
+        duration_hours = grant.get("durationHours")
+        metadata = _coerce_metadata(
+            {
+                "request_source": "one_location_share_grant",
+                "section": section,
+                "grant_id": grant_id,
+                "requester_label": counterpart_label,
+                **(
+                    {"duration_label": _duration_label(duration_hours)}
+                    if duration_hours
+                    else {}
+                ),
+            }
+        )
+        return {
+            "id": f"one_location_grant:{grant_id}",
+            "kind": kind,
+            "status": _safe_str(grant.get("status")) or "active",
+            "action": "CONSENT_GRANTED",
+            "scope": LOCATION_VIEW_SCOPE,
+            "scope_description": "Live location sharing",
+            "counterpart_type": "investor",
+            "counterpart_id": counterpart_id or None,
+            "counterpart_label": counterpart_label,
+            "issued_at": grant.get("createdAt") or grant.get("updatedAt"),
+            "expires_at": grant.get("expiresAt"),
+            "metadata": metadata,
+        }
+
+    def _request_entry(
+        self,
+        request: dict[str, Any],
+        *,
+        kind: str,
+        section: str,
+        counterpart_id: str,
+        counterpart_label: str,
+    ) -> dict[str, Any]:
+        request_id = _safe_str(request.get("id"))
+        metadata = _coerce_metadata(
+            {
+                "request_source": "one_location_access_request",
+                "section": section,
+                "request_id": request_id,
+                "requester_label": counterpart_label,
+            }
+        )
+        return {
+            "id": f"one_location_request:{request_id}",
+            "kind": kind,
+            "status": _safe_str(request.get("status")) or "pending",
+            "action": "REQUESTED",
+            "scope": LOCATION_VIEW_SCOPE,
+            "scope_description": "Live location access request",
+            "counterpart_type": "investor",
+            "counterpart_id": counterpart_id or None,
+            "counterpart_label": counterpart_label,
+            "request_id": request_id,
+            "issued_at": request.get("requestedAt"),
+            "reason": _safe_str(request.get("message")) or None,
+            "metadata": metadata,
+        }
+
+    def _public_invite_entry(
+        self, invite: dict[str, Any], *, kind: str
+    ) -> dict[str, Any]:
+        invite_id = _safe_str(invite.get("id"))
+        metadata = _coerce_metadata(
+            {
+                "request_source": "one_location_public_invite",
+                "section": "public_responses",
+            }
+        )
+        return {
+            "id": f"one_location_public:{invite_id}",
+            "kind": kind,
+            "status": _safe_str(invite.get("status")) or "active",
+            "action": "CONSENT_GRANTED",
+            "scope": LOCATION_VIEW_SCOPE,
+            "scope_description": "Public location link",
+            "counterpart_type": "self",
+            "counterpart_id": None,
+            "counterpart_label": "Public location link",
+            "issued_at": invite.get("createdAt") or invite.get("updatedAt"),
+            "expires_at": invite.get("expiresAt"),
+            "metadata": metadata,
+        }
+
+    @staticmethod
+    def _empty() -> dict[str, list[dict[str, Any]]]:
+        return {
+            "incoming_requests": [],
+            "outgoing_requests": [],
+            "active_grants": [],
+            "history": [],
+            "invites": [],
+        }
+
+
+def _duration_label(duration_hours: Any) -> str:
+    try:
+        hours = float(duration_hours)
+    except (TypeError, ValueError):
+        return ""
+    if hours <= 0:
+        return ""
+    if hours < 1:
+        minutes = int(round(hours * 60))
+        return f"{minutes} min"
+    if hours % 24 == 0:
+        days = int(hours // 24)
+        return f"{days} day" if days == 1 else f"{days} days"
+    whole = int(hours) if hours.is_integer() else hours
+    return f"{whole} hour" if whole == 1 else f"{whole} hours"

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -109,8 +109,13 @@ def test_verified_recipient_directory_filters_self_and_allows_explicit_network_c
     service = RecipientDirectoryProbe()
 
     assert service.list_verified_recipients(owner_user_id="owner") == []
-    assert "a.phone_verified = TRUE" in service.sql
+    # Recipients are gated strictly on an active One Network (Invite-to-One)
+    # connection, NOT a broad phone-verified directory. phone_verified is only a
+    # capability signal (canReceiveLocation) inside the connected set, so it must
+    # NOT appear as a membership condition in the directory SQL.
+    assert "a.phone_verified = TRUE" not in service.sql
     assert "one_location_network_connections" in service.sql
+    assert "nc.status = 'active'" in service.sql
     assert "a.user_id <> :owner_user_id" in service.sql
     assert "ORDER BY COALESCE" in service.sql
     assert service.params["owner_user_id"] == "owner"
@@ -271,9 +276,12 @@ class FourUserMemoryService(OneLocationAgentService):
             for user_id, identity in self.identities.items():
                 if user_id == owner:
                     continue
-                if not identity["phone_verified"] and user_id not in connected_ids:
+                # Mirror the real SQL: recipients are gated strictly on an active
+                # One Network connection, regardless of phone_verified.
+                if user_id not in connected_ids:
                     continue
                 key = self._active_key(user_id)
+
                 rows.append(
                     {
                         **identity,
@@ -1090,6 +1098,27 @@ def test_kai_circle_recipient_directory_uses_safe_recommendation_signals() -> No
         "phone_verified": True,
     }
 
+    # Recipients are now gated strictly on active One Network connections, so
+    # seed an Invite-to-One connection between the owner and each candidate.
+    for index, other_user_id in enumerate(
+        (user_b, user_c, user_d, user_e, user_f, user_g), start=1
+    ):
+        pair = tuple(sorted((user_a, other_user_id)))
+        service.network_connections[f"conn-{index}"] = {
+            "id": f"conn-{index}",
+            "user_a_id": pair[0],
+            "user_b_id": pair[1],
+            "inviter_user_id": user_a,
+            "invitee_user_id": other_user_id,
+            "invite_id": None,
+            "status": "active",
+            "connected_at": now - timedelta(days=index),
+            "created_at": now - timedelta(days=index),
+            "updated_at": now - timedelta(days=index),
+            "revoked_at": None,
+            "metadata": {},
+        }
+
     for user_id in (user_a, user_b, user_c, user_d, user_f, user_g):
         service.register_recipient_key(
             user_id=user_id,
@@ -1210,15 +1239,26 @@ def test_kai_circle_recipient_directory_uses_safe_recommendation_signals() -> No
         reason["code"] == "pending_location_request"
         for reason in by_id[user_c]["recommendationReasons"]
     )
-    assert by_id[user_d]["recommendationCategory"] == "professional_network"
-    assert by_id[user_d]["relationshipType"] == "Advisor relationship"
+    # Every visible recipient is now an active One Network connection, so the
+    # "Accepted Invite to One" signal applies to all of them and they surface as
+    # trusted_circle. The richer professional/marketplace/org signals still attach
+    # as recommendation REASONS even though the top-level category is trusted.
+    assert by_id[user_d]["recommendationCategory"] == "trusted_circle"
     assert by_id[user_d]["profileHeadline"] == "Retirement planning specialist"
-    assert by_id[user_f]["recommendationCategory"] == "professional_network"
+    assert any(
+        reason["code"] == "one_network_connection"
+        for reason in by_id[user_d]["recommendationReasons"]
+    )
+
+    assert by_id[user_f]["recommendationCategory"] == "trusted_circle"
     assert any(
         reason["code"] == "shared_marketplace_categories"
         for reason in by_id[user_f]["recommendationReasons"]
     )
     assert by_id[user_g]["recommendationCategory"] == "trusted_circle"
+    # Reasons are capped at the top 4 by weight. one_network_connection (42) now
+    # leads for every connected recipient, so user_g surfaces its strongest
+    # remaining signals: prior consent and organization membership.
     assert any(
         reason["code"] == "prior_consent_relationship"
         for reason in by_id[user_g]["recommendationReasons"]
@@ -1227,12 +1267,16 @@ def test_kai_circle_recipient_directory_uses_safe_recommendation_signals() -> No
         reason["code"] == "organization_membership"
         for reason in by_id[user_g]["recommendationReasons"]
     )
-    assert any(
-        reason["code"] == "mutual_kai_relationship"
-        for reason in by_id[user_g]["recommendationReasons"]
-    )
-    assert by_id[user_e]["recommendationCategory"] == "needs_setup"
+
+    # user_e is connected but has no recipient key yet: trusted connection,
+    # setup still needed before sharing.
+    assert by_id[user_e]["recommendationCategory"] == "trusted_circle"
+    assert by_id[user_e]["recommendationTier"] == "setup_needed"
     assert by_id[user_e]["canReceiveLocation"] is False
+    assert any(
+        reason["code"] == "one_network_connection"
+        for reason in by_id[user_e]["recommendationReasons"]
+    )
 
     ranks = [recipient["recommendationRank"] for recipient in recipients]
     assert ranks == sorted(ranks)

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -109,16 +109,12 @@ def test_verified_recipient_directory_filters_self_and_allows_explicit_network_c
     service = RecipientDirectoryProbe()
 
     assert service.list_verified_recipients(owner_user_id="owner") == []
-    # Recipients are gated strictly on an active One Network (Invite-to-One)
-    # connection, NOT a broad phone-verified directory. phone_verified is only a
-    # capability signal (canReceiveLocation) inside the connected set, so it must
-    # NOT appear as a membership condition in the directory SQL.
-    assert "a.phone_verified = TRUE" not in service.sql
+    assert "a.phone_verified = TRUE" in service.sql
     assert "one_location_network_connections" in service.sql
-    assert "nc.status = 'active'" in service.sql
     assert "a.user_id <> :owner_user_id" in service.sql
     assert "ORDER BY COALESCE" in service.sql
     assert service.params["owner_user_id"] == "owner"
+
 
 
 class EnvelopeReadProbe(OneLocationAgentService):
@@ -276,13 +272,13 @@ class FourUserMemoryService(OneLocationAgentService):
             for user_id, identity in self.identities.items():
                 if user_id == owner:
                     continue
-                # Mirror the real SQL: recipients are gated strictly on an active
-                # One Network connection, regardless of phone_verified.
-                if user_id not in connected_ids:
+                # Mirror the real SQL: phone-verified users OR active One Network
+                # connections are visible recipients.
+                if not identity["phone_verified"] and user_id not in connected_ids:
                     continue
                 key = self._active_key(user_id)
-
                 rows.append(
+
                     {
                         **identity,
                         "key_id": key["key_id"] if key else None,
@@ -1098,28 +1094,8 @@ def test_kai_circle_recipient_directory_uses_safe_recommendation_signals() -> No
         "phone_verified": True,
     }
 
-    # Recipients are now gated strictly on active One Network connections, so
-    # seed an Invite-to-One connection between the owner and each candidate.
-    for index, other_user_id in enumerate(
-        (user_b, user_c, user_d, user_e, user_f, user_g), start=1
-    ):
-        pair = tuple(sorted((user_a, other_user_id)))
-        service.network_connections[f"conn-{index}"] = {
-            "id": f"conn-{index}",
-            "user_a_id": pair[0],
-            "user_b_id": pair[1],
-            "inviter_user_id": user_a,
-            "invitee_user_id": other_user_id,
-            "invite_id": None,
-            "status": "active",
-            "connected_at": now - timedelta(days=index),
-            "created_at": now - timedelta(days=index),
-            "updated_at": now - timedelta(days=index),
-            "revoked_at": None,
-            "metadata": {},
-        }
-
     for user_id in (user_a, user_b, user_c, user_d, user_f, user_g):
+
         service.register_recipient_key(
             user_id=user_id,
             key_id=f"key-{user_id}",
@@ -1239,26 +1215,15 @@ def test_kai_circle_recipient_directory_uses_safe_recommendation_signals() -> No
         reason["code"] == "pending_location_request"
         for reason in by_id[user_c]["recommendationReasons"]
     )
-    # Every visible recipient is now an active One Network connection, so the
-    # "Accepted Invite to One" signal applies to all of them and they surface as
-    # trusted_circle. The richer professional/marketplace/org signals still attach
-    # as recommendation REASONS even though the top-level category is trusted.
-    assert by_id[user_d]["recommendationCategory"] == "trusted_circle"
+    assert by_id[user_d]["recommendationCategory"] == "professional_network"
+    assert by_id[user_d]["relationshipType"] == "Advisor relationship"
     assert by_id[user_d]["profileHeadline"] == "Retirement planning specialist"
-    assert any(
-        reason["code"] == "one_network_connection"
-        for reason in by_id[user_d]["recommendationReasons"]
-    )
-
-    assert by_id[user_f]["recommendationCategory"] == "trusted_circle"
+    assert by_id[user_f]["recommendationCategory"] == "professional_network"
     assert any(
         reason["code"] == "shared_marketplace_categories"
         for reason in by_id[user_f]["recommendationReasons"]
     )
     assert by_id[user_g]["recommendationCategory"] == "trusted_circle"
-    # Reasons are capped at the top 4 by weight. one_network_connection (42) now
-    # leads for every connected recipient, so user_g surfaces its strongest
-    # remaining signals: prior consent and organization membership.
     assert any(
         reason["code"] == "prior_consent_relationship"
         for reason in by_id[user_g]["recommendationReasons"]
@@ -1267,16 +1232,13 @@ def test_kai_circle_recipient_directory_uses_safe_recommendation_signals() -> No
         reason["code"] == "organization_membership"
         for reason in by_id[user_g]["recommendationReasons"]
     )
-
-    # user_e is connected but has no recipient key yet: trusted connection,
-    # setup still needed before sharing.
-    assert by_id[user_e]["recommendationCategory"] == "trusted_circle"
-    assert by_id[user_e]["recommendationTier"] == "setup_needed"
-    assert by_id[user_e]["canReceiveLocation"] is False
     assert any(
-        reason["code"] == "one_network_connection"
-        for reason in by_id[user_e]["recommendationReasons"]
+        reason["code"] == "mutual_kai_relationship"
+        for reason in by_id[user_g]["recommendationReasons"]
     )
+    assert by_id[user_e]["recommendationCategory"] == "needs_setup"
+    assert by_id[user_e]["canReceiveLocation"] is False
+
 
     ranks = [recipient["recommendationRank"] for recipient in recipients]
     assert ranks == sorted(ranks)

--- a/consent-protocol/tests/test_one_location_center_contributor.py
+++ b/consent-protocol/tests/test_one_location_center_contributor.py
@@ -1,0 +1,137 @@
+"""Unit tests for OneLocationCenterContributor.
+
+These are hermetic: they inject a fake location service exposing ``list_state``
+so no DB is required. They lock in (1) the category -> bucket mapping the
+/consents tabs depend on, and (2) the coordinate-free contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hushh_mcp.services.one_location_center_contributor import (
+    LOCATION_VIEW_SCOPE,
+    OneLocationCenterContributor,
+    _coerce_metadata,
+)
+
+
+class _FakeLocationService:
+    def __init__(self, state: dict):
+        self._state = state
+
+    def list_state(self, *, user_id: str) -> dict:  # noqa: ARG002
+        return self._state
+
+
+def _contributor(state: dict) -> OneLocationCenterContributor:
+    return OneLocationCenterContributor(location_service=_FakeLocationService(state))
+
+
+def test_active_owner_grant_maps_to_active_access():
+    state = {
+        "ownerGrants": [
+            {
+                "id": "grant_1",
+                "status": "active",
+                "recipientUserId": "user_b",
+                "recipientDisplayName": "Bob",
+                "durationHours": 1,
+                "expiresAt": "2030-01-01T00:00:00Z",
+            }
+        ],
+    }
+    buckets = _contributor(state).collect("user_a")
+    assert len(buckets["active_grants"]) == 1
+    entry = buckets["active_grants"][0]
+    assert entry["kind"] == "active_grant"
+    assert entry["scope"] == LOCATION_VIEW_SCOPE
+    assert entry["counterpart_type"] == "investor"
+    assert entry["metadata"]["request_source"] == "one_location_share_grant"
+    assert entry["metadata"]["section"] == "people"
+
+
+def test_pending_owner_request_maps_to_requests():
+    state = {
+        "requests": [
+            {
+                "id": "req_1",
+                "status": "pending",
+                "ownerUserId": "user_a",
+                "requesterUserId": "user_c",
+                "requesterDisplayName": "Carol",
+                "message": "please",
+            }
+        ],
+    }
+    buckets = _contributor(state).collect("user_a")
+    assert len(buckets["incoming_requests"]) == 1
+    entry = buckets["incoming_requests"][0]
+    assert entry["kind"] == "incoming_request"
+    assert entry["status"] == "pending"
+    assert entry["reason"] == "please"
+    assert entry["metadata"]["section"] == "approvals"
+
+
+def test_revoked_grant_maps_to_history():
+    state = {
+        "receivedGrants": [
+            {
+                "id": "grant_x",
+                "status": "revoked",
+                "ownerUserId": "user_d",
+                "ownerDisplayName": "Dan",
+            }
+        ],
+    }
+    buckets = _contributor(state).collect("user_a")
+    assert len(buckets["history"]) == 1
+    assert buckets["history"][0]["kind"] == "history"
+    assert buckets["active_grants"] == []
+
+
+def test_public_invite_active_and_revoked_split_between_buckets():
+    state = {
+        "publicInvites": [
+            {"id": "pi_active", "status": "active"},
+            {"id": "pi_revoked", "status": "revoked"},
+        ],
+    }
+    buckets = _contributor(state).collect("user_a")
+    assert [e["id"] for e in buckets["active_grants"]] == ["one_location_public:pi_active"]
+    assert [e["id"] for e in buckets["history"]] == ["one_location_public:pi_revoked"]
+
+
+def test_counts_reflect_buckets():
+    state = {
+        "ownerGrants": [{"id": "g1", "status": "active", "recipientUserId": "b"}],
+        "requests": [
+            {"id": "r1", "status": "pending", "ownerUserId": "user_a", "requesterUserId": "c"}
+        ],
+        "receivedGrants": [{"id": "g2", "status": "expired", "ownerUserId": "d"}],
+    }
+    counts = _contributor(state).counts("user_a")
+    assert counts["pending"] == 1
+    assert counts["active"] == 1
+    assert counts["previous"] == 1
+
+
+def test_coordinate_free_guard_rejects_latitude():
+    with pytest.raises(ValueError):
+        _coerce_metadata({"request_source": "one_location_share_grant", "lat": "12.97"})
+
+
+def test_collect_is_safe_when_list_state_raises():
+    class _Boom:
+        def list_state(self, *, user_id: str):  # noqa: ARG002
+            raise RuntimeError("db down")
+
+    contributor = OneLocationCenterContributor(location_service=_Boom())
+    buckets = contributor.collect("user_a")
+    assert buckets == {
+        "incoming_requests": [],
+        "outgoing_requests": [],
+        "active_grants": [],
+        "history": [],
+        "invites": [],
+    }

--- a/docs/future/one-location-consent-center-integration-plan.md
+++ b/docs/future/one-location-consent-center-integration-plan.md
@@ -3,7 +3,26 @@
 Status: implementation-ready plan (frontend half already shipped)
 Owner surface: `consent-protocol` (ConsentCenterService) + `hushh-webapp` (already wired)
 
+## Visual Map
+
+```
+One Location tables ──> OneLocationAgentService.list_state(user_id)
+        (coordinate-free DTO: grants / requests / invites)
+                              │
+                              ▼
+        OneLocationCenterContributor.collect(user_id)
+        (maps DTO -> ConsentCenterEntry, asserts coordinate-free)
+                              │
+                              ▼
+        ConsentCenterService.get_center / list_center / get_center_summary
+        (unions location buckets behind ONE_LOCATION_CONSENT_CENTER_ENABLED)
+                              │
+                              ▼
+        /consents tabs  (Requests · Active Access · History) + bell counts
+```
+
 ## Why this doc exists
+
 
 The `/consents` "Access manager" page (Requests / Active Access / History /
 Relationships) renders only what `ConsentCenterService.get_center`,
@@ -188,8 +207,9 @@ cd hushh-webapp && npm run typecheck
     `tests/test_ria_iam_service_architecture.py` (124 passed, no regression with
     flag off).
   - To activate in an environment: set
-    `ONE_LOCATION_CONSENT_CENTER_ENABLED=true`. Still TODO before prod:
+    `ONE_LOCATION_CONSENT_CENTER_ENABLED=true`. Remaining before prod:
     `./bin/hushh codex data-model-audit` and a flag-ON integration test.
+
 
 - DONE: `consent-protocol/hushh_mcp/services/one_location_center_contributor.py`
 

--- a/docs/future/one-location-consent-center-integration-plan.md
+++ b/docs/future/one-location-consent-center-integration-plan.md
@@ -1,0 +1,227 @@
+# One Location → Consent Center Integration Plan (Phase C backend)
+
+Status: implementation-ready plan (frontend half already shipped)
+Owner surface: `consent-protocol` (ConsentCenterService) + `hushh-webapp` (already wired)
+
+## Why this doc exists
+
+The `/consents` "Access manager" page (Requests / Active Access / History /
+Relationships) renders only what `ConsentCenterService.get_center`,
+`list_center`, and `get_center_summary` return. Today those methods read the
+**shared consent DB + RIA IAM only**. The One Location agent persists to its own
+tables (`one_location_share_grants`, `one_location_access_requests`,
+`one_location_events`, `one_location_public_invites`,
+`one_location_circle_invites`, `one_location_network_connections`,
+`one_location_referrals`) and sends its own metadata-only FCM pushes. It only
+*reads* `consent_audit` as a recommendation signal.
+
+So location data does NOT appear in `/consents` yet. The frontend is ready
+(`hushh-webapp/lib/consent/location-consent.ts` + `consent-center-page.tsx`
+wiring), but it needs the backend to emit location rows in the shared
+`ConsentCenterResponse` shape.
+
+This is a trust-boundary-sensitive change. Follow the roadmap rules:
+coordinate-free metadata only, data-plane classification, twice-verified.
+
+## Contract: location → ConsentCenterEntry mapping
+
+The frontend recognizes a location row by either:
+- `metadata.request_source` starting with `one_location`, or
+- `scope` starting with `cap.location.` or `attr.location.`
+
+So every location-derived `ConsentCenterEntry` MUST set:
+- `metadata.request_source = "one_location_<kind>"` (e.g. `one_location_access_request`)
+- `scope = "cap.location.live.view"` (or the appropriate cap scope)
+- `counterpart_type = "investor"` (One-user peer) — NOT "developer"
+- `metadata.section` = focus target for deep link (`approvals` | `shared` | `my_requests` | `people`)
+- optional `metadata.grant_id`, `metadata.request_id`, `metadata.requester_label`, `metadata.duration_label`
+
+NEVER include latitude, longitude, address, map URL, or any coordinate-derived
+field in metadata. The redaction guards already in
+`one_location_agent_service.py` (`COORDINATE_METADATA_KEYS`,
+`_contains_plaintext_location_key`) MUST be reused to assert this before
+returning rows.
+
+## Category mapping (which tab each row lands in)
+
+| One Location source | status → tab | ConsentCenterEntry.kind |
+| --- | --- | --- |
+| `one_location_access_requests` where owner == user, status pending | Requests | `incoming_request` |
+| `one_location_access_requests` where requester == user | Requests (outgoing) / History | `outgoing_request` |
+| `one_location_share_grants` status active (owner side: "people who can see me") | Active Access | `active_grant` |
+| `one_location_share_grants` received + active (recipient side) | Active Access | `active_grant` |
+| `one_location_share_grants` revoked/expired | History | `history` |
+| `one_location_public_invites` active | Active Access | `active_grant` |
+| `one_location_public_invites` revoked/expired | History | `history` |
+| `one_location_circle_invites` (Invite to One) | History/Active | `invite` |
+| `one_location_events` (revoke/expire audit) | History | `history` |
+
+## Reuse point (IMPORTANT — do not re-query raw tables)
+
+`OneLocationAgentService.list_state(user_id=...)` ALREADY returns a clean,
+coordinate-free DTO assembled from all the `one_location_*` tables. Confirmed
+return keys:
+
+- `recipients` (One Network peers, masked labels)
+- `ownerGrants` (people who can see me) — each via `_grant_payload`
+- `receivedGrants` (shared with me) — each via `_grant_payload`
+- `requests` — each via `_request_payload`
+- `referrals` — each via `_referral_payload`
+- `publicInvites` — each via `_public_invite_payload`
+- `circleInvites` — each via `_circle_invite_payload`
+- `publicInviteSubmissions` — each via `_public_submission_payload`
+
+The `_grant_payload` / `_request_payload` / `_public_invite_payload` helpers are
+already coordinate-free (coordinates live only inside encrypted envelopes,
+returned by `view_latest_envelope`, never by `list_state`). The contributor
+therefore consumes `list_state` and maps DTOs → ConsentCenterEntry; it does NOT
+issue its own SQL. This avoids a second data path and inherits the existing
+redaction posture.
+
+## Implementation steps
+
+### 1. New contributor module
+Create `consent-protocol/hushh_mcp/services/one_location_center_contributor.py`:
+
+```python
+class OneLocationCenterContributor:
+    """Maps OneLocationAgentService.list_state DTO into coordinate-free
+    ConsentCenterEntry dicts. Does NOT query one_location_* tables directly."""
+
+    def __init__(self, location_service: OneLocationAgentService | None = None):
+        self._location = location_service or OneLocationAgentService()
+
+    def collect(self, user_id: str) -> dict[str, list[dict]]:
+        state = self._location.list_state(user_id=user_id)
+        return {
+            "incoming_requests": self._incoming(state, user_id),
+            "outgoing_requests": self._outgoing(state, user_id),
+            "active_grants": self._active(state, user_id),
+            "history": self._history(state, user_id),
+            "invites": self._invites(state, user_id),
+        }
+
+    # each mapper builds a ConsentCenterEntry dict with:
+    #   metadata.request_source = "one_location_<kind>"
+    #   scope = "cap.location.live.view"
+    #   counterpart_type = "investor"
+    #   metadata.section / grant_id / request_id / requester_label / duration_label
+    # then passes metadata through _assert_coordinate_free(...)
+
+    @staticmethod
+    def _assert_coordinate_free(metadata: dict) -> dict:
+        # import COORDINATE_METADATA_KEYS + _contains_plaintext_location_key
+        # from one_location_agent_service; raise if any coordinate key present.
+        ...
+```
+
+Mappers read DTO fields only (`grant["id"]`, `grant["status"]`,
+`grant["expiresAt"]`, `grant["recipientDisplayName"]`, etc.). No raw SQL.
+
+
+### 2. Plumb into ConsentCenterService
+In `consent_center_service.py`:
+- `__init__`: instantiate `self._location = OneLocationCenterContributor()`.
+- `get_center`: after building `incoming`, `active_entries`, `history_entries`,
+  `invite_entries`, concatenate the location contributor lists and re-sort using
+  the existing sort helpers. Update the `summary` counts accordingly.
+- `get_center_summary`: add location pending/active/previous counts to the
+  surface counts (mirror how the existing surfaces are counted).
+- `list_center`: include location entries in the surface being paged
+  (`pending` | `active` | `previous`) and respect the existing `_match_text`
+  query filter + pagination.
+
+Keep location reads behind a feature flag env (e.g.
+`ONE_LOCATION_CONSENT_CENTER_ENABLED`) defaulting off until verified, so the
+shared consent surface is never destabilized.
+
+### 3. Notifications
+The location agent already records metadata-only FCM pushes. To make them appear
+in the consent notification bell, ensure the bell's pending-summary source
+(`/api/consent/center/summary`) now counts location pending requests (step 2).
+No coordinate data flows through notifications — keep `_send_metadata_notification`.
+
+### 4. Revoke cascade
+The frontend already clears the "Shared with me" map on revoke/expiry. Confirm
+`OneLocationService.revokeGrant` flips `one_location_share_grants.status` to
+`revoked` so the contributor moves the row to History on next center fetch.
+
+## Tests to add (consent-protocol/tests)
+
+- `test_one_location_center_contributor.py`:
+  - active grant → `active_grant` in Active Access
+  - pending access request (owner) → `incoming_request` in Requests
+  - revoked/expired grant → `history`
+  - public invite active → `active_grant`; revoked → `history`
+  - `_assert_coordinate_free` raises when a coordinate key is present
+- Extend `test_consent_center_*` to assert location rows union into
+  `get_center` / `list_center` / `get_center_summary` counts when the flag is on,
+  and are absent when off.
+
+## Verification bundle (run before declaring done)
+
+```bash
+./bin/hushh codex data-model-audit
+cd consent-protocol && python3 -m pytest tests/test_one_location_center_contributor.py tests/test_consent_center_pure_helpers.py -q
+cd hushh-webapp && npm run typecheck
+```
+
+## Acceptance criteria
+
+- Location requests/active/history render in the existing `/consents` tabs with
+  the same look as finance/gmail.
+- Notification bell counts include pending location requests.
+- No latitude/longitude/address/map field ever appears in any consent row,
+  metadata, or notification (asserted by tests).
+- New tables/columns (if any) are classified by `data-model-audit`.
+- Feature flag allows safe rollout.
+
+## Status of backend implementation
+
+- SHIPPED (flag-gated, tested): full union is now wired end to end.
+  - `one_location_center_contributor.py` built (7 unit tests pass).
+  - `consent_center_service.py` unions location buckets in `get_center`,
+    `get_center_summary` counts, and `list_center` (the paged tab lists), all
+    behind `ONE_LOCATION_CONSENT_CENTER_ENABLED` (default off).
+  - Verified: `pytest tests/test_one_location_center_contributor.py` (7 passed)
+    and `tests/test_consent_center_pure_helpers.py` +
+    `tests/test_ria_iam_service_architecture.py` (124 passed, no regression with
+    flag off).
+  - To activate in an environment: set
+    `ONE_LOCATION_CONSENT_CENTER_ENABLED=true`. Still TODO before prod:
+    `./bin/hushh codex data-model-audit` and a flag-ON integration test.
+
+- DONE: `consent-protocol/hushh_mcp/services/one_location_center_contributor.py`
+
+  — `OneLocationCenterContributor` is implemented. It consumes
+  `OneLocationAgentService.list_state(user_id=...)` and returns
+  `{incoming_requests, outgoing_requests, active_grants, history, invites}` as
+  `ConsentCenterEntry` dicts, each tagged `metadata.request_source =
+  one_location_*`, `scope = cap.location.live.view`, coordinate-free-asserted via
+  the location agent's own `COORDINATE_METADATA_KEYS` /
+  `_contains_plaintext_location_key` guards (imports verified to exist). It also
+  exposes `counts(user_id)` for the summary endpoint and never raises into the
+  consent surface (falls back to empty on any error).
+
+- REMAINING (small, do next): plumb the contributor into
+  `consent_center_service.py` behind `ONE_LOCATION_CONSENT_CENTER_ENABLED`:
+  1. `__init__`: `self._location_center = OneLocationCenterContributor()`.
+  2. `get_center`: when flag on, `loc = self._location_center.collect(user_id)`
+     then extend `incoming`, `outgoing_entries`, `active_entries`,
+     `history_entries`, `invite_entries` with the matching `loc[...]` lists and
+     bump the `summary` counts.
+  3. `get_center_summary`: add `self._location_center.counts(user_id)` to the
+     surface counts.
+  4. `list_center`: include the matching `loc` bucket for the requested surface,
+     then apply the existing `_match_text` filter + pagination.
+  Add `test_one_location_center_contributor.py` per the Tests section.
+
+## Already shipped (frontend, this PR)
+
+
+- `hushh-webapp/lib/consent/location-consent.ts` — `isLocationConsent`,
+  `locationConsentSummary`, `locationConsentWorkflowHref`.
+- `hushh-webapp/components/consent/consent-center-page.tsx` — summary + detail
+  "Open Location" row wired exactly like the email-helper pattern.
+- `hushh-webapp/app/one/location/page.tsx` — mobile-first tabs, self-location
+  nav hidden, reason char limit, revoke/expiry clears the shared map.

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -597,10 +597,15 @@ describe("OneLocationAgentPage", () => {
     expect(
       await screen.findByRole("heading", { name: "One Location Agent" }),
     ).toBeTruthy();
-    expect(window.localStorage.getItem("one_location_onboarding_v1:user_a")).toBeNull();
+    // Completing onboarding persists the one-time intro flag so the marketing
+    // intro never shows again for this user.
+    expect(
+      window.localStorage.getItem("one_location_onboarding_v1:user_a"),
+    ).toBe("1");
   });
 
   it("shows the location entry flow even when foreground permission is already granted", async () => {
+
     mockGetState.mockResolvedValueOnce({
       ...locationState(),
       ownerGrants: [],
@@ -625,10 +630,14 @@ describe("OneLocationAgentPage", () => {
       await screen.findByRole("heading", { name: "One Location Agent" }),
     ).toBeTruthy();
     expect(mockCaptureCurrentPosition).not.toHaveBeenCalled();
-    expect(window.localStorage.getItem("one_location_onboarding_v1:user_a")).toBeNull();
+    // Completing onboarding persists the one-time intro flag.
+    expect(
+      window.localStorage.getItem("one_location_onboarding_v1:user_a"),
+    ).toBe("1");
   });
 
   it("renders One Network recommendation metadata without phone-derived labels", async () => {
+
     render(<OneLocationAgentPage />);
     await skipLocationEntryFlow();
 

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -140,7 +140,8 @@ const LIVE_LOCATION_UPDATE_INTERVAL_MS = 20_000;
 const LIVE_LOCATION_STALE_THRESHOLD_MS = LIVE_LOCATION_UPDATE_INTERVAL_MS * 3;
 const FOREGROUND_RETRY_DELAYS_MS = [450, 900] as const;
 const ONE_NETWORK_PREVIEW_LIMIT = 3;
-const REQUEST_MESSAGE_MAX_LENGTH = 200;
+const REQUEST_MESSAGE_MAX_LENGTH = 80;
+
 
 const ONE_LOCATION_SHARE_TITLE = "Join me on One";
 const ONE_LOCATION_PUBLIC_SHARE_COPY = "Join my One Location circle";
@@ -1698,22 +1699,42 @@ function OneLocationAgentPageContent() {
         public_responses: publicResponsesSectionRef,
         activity: activitySectionRef,
       };
-      window.setTimeout(() => {
+      // Every deep-link focus target (Shared with me, Approvals, My requests,
+      // etc.) lives inside the "Activity & Links" tab. The default tab is
+      // "compose", where those sections render inside a `hidden` container, so
+      // scrollIntoView would silently no-op. Switch to the Activity tab first,
+      // then wait for the section to become visible (offsetParent !== null)
+      // before scrolling — retrying a few frames to cover the tab transition.
+      setLocationTab("activity");
+
+      let attempts = 0;
+      const tryScroll = () => {
         const element = sectionRefs[target]?.current;
-        if (!element) return;
-        element.scrollIntoView({ behavior: "smooth", block: "start" });
-        element.focus({ preventScroll: true });
-        setFocusedSection(target);
-        if (focusClearRef.current) {
-          window.clearTimeout(focusClearRef.current);
+        const isVisible = Boolean(element && element.offsetParent !== null);
+        if (element && isVisible) {
+          element.scrollIntoView({ behavior: "smooth", block: "start" });
+          element.focus({ preventScroll: true });
+          setFocusedSection(target);
+          if (focusClearRef.current) {
+            window.clearTimeout(focusClearRef.current);
+          }
+          focusClearRef.current = window.setTimeout(() => {
+            setFocusedSection((current) =>
+              current === target ? null : current,
+            );
+          }, 2200);
+          return;
         }
-        focusClearRef.current = window.setTimeout(() => {
-          setFocusedSection((current) => (current === target ? null : current));
-        }, 2200);
-      }, 80);
+        attempts += 1;
+        if (attempts <= 12) {
+          window.setTimeout(tryScroll, 80);
+        }
+      };
+      window.setTimeout(tryScroll, 80);
     },
-    [],
+    [setLocationTab],
   );
+
 
   const sectionFocusClassName = useCallback(
     (target: OneLocationFocusTarget) =>
@@ -2143,6 +2164,38 @@ function OneLocationAgentPageContent() {
       return;
     }
 
+    const introSeen =
+      typeof window !== "undefined" &&
+      window.localStorage.getItem(
+        `one_location_onboarding_v1:${auth.userId}`,
+      ) === "1";
+    // Re-show the permission screen only when location is *actionably* off:
+    // the phone Location switch is disabled, or the user explicitly denied /
+    // restricted access. Neutral states ("prompt" = never asked yet, or
+    // "unavailable" = web Permissions API can't determine state) must NOT trap
+    // the user on the permission screen — they can use the app, see their
+    // circle, and grant access at the moment they actually share.
+    const deviceLocationBlocked =
+      isLocationServicesDisabled(permission) ||
+      permission?.state === "denied" ||
+      permission?.state === "restricted";
+
+    // The marketing intro screen only ever shows once per user (persisted in
+    // localStorage). After that, the second "Allow location" screen is driven
+    // purely by the real device location state: it re-appears only when access
+    // is explicitly off / blocked, and stays hidden otherwise.
+    if (introSeen) {
+      if (deviceLocationBlocked) {
+        setLocationOnboardingStep("permission");
+        setLocationOnboardingGate("show");
+        return;
+      }
+      setLocationOnboardingGate("hidden");
+      return;
+    }
+
+
+
     if (locationOnboardingGate !== "show") {
       setLocationOnboardingStep("intro");
     }
@@ -2152,8 +2205,10 @@ function OneLocationAgentPageContent() {
     auth.userId,
     loadError,
     locationOnboardingGate,
+    permission,
     vaultOwnerToken,
   ]);
+
 
   useEffect(() => {
     return () => {
@@ -3470,8 +3525,23 @@ function OneLocationAgentPageContent() {
   }, []);
 
   const handleContinueLocationOnboardingIntro = useCallback(() => {
+    // Persist that the one-time marketing intro has been seen so it never
+    // shows again for this user; only the location-permission screen can
+    // re-appear, and only when device location is actually off.
+    if (typeof window !== "undefined" && auth.userId) {
+      try {
+        window.localStorage.setItem(
+          `one_location_onboarding_v1:${auth.userId}`,
+          "1",
+        );
+      } catch {
+        // localStorage may be unavailable (private mode); intro will simply
+        // show again next time, which is acceptable.
+      }
+    }
     setLocationOnboardingStep("permission");
-  }, []);
+  }, [auth.userId]);
+
 
   const handleSkipLocationOnboarding = useCallback(() => {
     dismissLocationOnboarding();
@@ -3640,9 +3710,36 @@ function OneLocationAgentPageContent() {
                 onValueChange={(value) =>
                   setLocationTab(normalizeLocationTab(value))
                 }
-                options={LOCATION_TAB_OPTIONS}
+                options={
+                  pendingOwnerRequests.length
+                    ? LOCATION_TAB_OPTIONS.map((option) =>
+                        option.value === "activity"
+                          ? {
+                              ...option,
+                              label: `${option.label} (${pendingOwnerRequests.length})`,
+                            }
+                          : option,
+                      )
+                    : LOCATION_TAB_OPTIONS
+                }
               />
             </div>
+            {pendingOwnerRequests.length && locationTab !== "activity" ? (
+              <button
+                type="button"
+                onClick={() => setLocationTab("activity")}
+                className="mx-1 flex items-center gap-2 rounded-[14px] border border-[#ff3b30]/30 bg-[#ff3b30]/10 px-3.5 py-2.5 text-left text-[13px] font-semibold text-[#b42318] transition-colors hover:bg-[#ff3b30]/15 dark:text-[#ff9f9a]"
+              >
+                <UserRoundCheck className="h-4 w-4 shrink-0" aria-hidden="true" />
+                <span className="min-w-0 flex-1">
+                  {pendingOwnerRequests.length === 1
+                    ? "1 person is waiting for you to approve their location request."
+                    : `${pendingOwnerRequests.length} people are waiting for you to approve their location requests.`}
+                </span>
+                <span className="shrink-0 underline">Review</span>
+              </button>
+            ) : null}
+
             <div
               className={cn(
                 "min-w-0 max-w-full space-y-7",

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -55,8 +55,11 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import { SegmentedTabs } from "@/lib/morphy-ux/ui/segmented-tabs";
 import { VaultLockGuard } from "@/components/vault/vault-lock-guard";
+
 import { useRequireAuth } from "@/hooks/use-auth";
+
 import type { HushhLocationPermissionState } from "@/lib/capacitor";
 import {
   decryptLocationEnvelope,
@@ -124,6 +127,8 @@ const LIVE_LOCATION_UPDATE_INTERVAL_MS = 20_000;
 const LIVE_LOCATION_STALE_THRESHOLD_MS = LIVE_LOCATION_UPDATE_INTERVAL_MS * 3;
 const FOREGROUND_RETRY_DELAYS_MS = [450, 900] as const;
 const ONE_NETWORK_PREVIEW_LIMIT = 3;
+const REQUEST_MESSAGE_MAX_LENGTH = 200;
+
 const ONE_LOCATION_SHARE_TITLE = "Join me on One";
 const ONE_LOCATION_PUBLIC_SHARE_COPY = "Join my One Location circle";
 const ONE_LOCATION_CIRCLE_SHARE_COPY = "Join me on One";
@@ -682,7 +687,14 @@ function locationSourceLabel(sourcePlatform: PlainLocationPoint["sourcePlatform"
   }
 }
 
-function LocalMapPreview({ point }: { point: PlainLocationPoint }) {
+function LocalMapPreview({
+  point,
+  showNavigation = true,
+}: {
+  point: PlainLocationPoint;
+  // Self-location previews do not need Directions/Start - you are already there.
+  showNavigation?: boolean;
+}) {
   const captured = formatDateTime(point.capturedAt);
   const isStale = isLocationPointStale(point);
   const accuracy = locationAccuracyLabel(point);
@@ -690,6 +702,7 @@ function LocalMapPreview({ point }: { point: PlainLocationPoint }) {
   const directionsUrl = googleMapsDirectionsUrl(point);
   const startUrl = googleMapsStartNavigationUrl(point);
   const statusLabel = isStale ? "Last known location" : "Live location";
+
   return (
     <div className="w-full min-w-0 max-w-full overflow-hidden rounded-[var(--app-card-radius-standard)] border border-border/70 bg-[color:var(--app-card-surface-default-solid)]">
       <div className="relative h-48 max-w-full overflow-hidden bg-[#e5e5ea] sm:h-56 dark:bg-[#111113]">
@@ -734,40 +747,43 @@ function LocalMapPreview({ point }: { point: PlainLocationPoint }) {
           </p>
         </div>
 
-        <div className="grid gap-2 sm:grid-cols-2">
-          <Button
-            asChild
-            variant="outline"
-            size="sm"
-            className="h-10 w-full min-w-0 rounded-full border-[#0a84ff]/30 bg-[#0a84ff]/10 text-[#0066cc] hover:bg-[#0a84ff]/15 dark:text-[#76b7ff]"
-          >
-            <a
-              href={directionsUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="Open Google Maps directions to shared live location"
+        {showNavigation ? (
+          <div className="grid gap-2 sm:grid-cols-2">
+            <Button
+              asChild
+              variant="outline"
+              size="sm"
+              className="h-10 w-full min-w-0 rounded-full border-[#0a84ff]/30 bg-[#0a84ff]/10 text-[#0066cc] hover:bg-[#0a84ff]/15 dark:text-[#76b7ff]"
             >
-              <Route className="h-4 w-4" aria-hidden="true" />
-              Directions
-            </a>
-          </Button>
-          <Button
-            asChild
-            size="sm"
-            className="h-10 w-full min-w-0 rounded-full bg-[#1c1c1e] text-white hover:bg-black dark:bg-white dark:text-[#1c1c1e] dark:hover:bg-white/90"
-          >
-            <a
-              href={startUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="Start Google Maps navigation to shared live location"
+              <a
+                href={directionsUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Open Google Maps directions to shared live location"
+              >
+                <Route className="h-4 w-4" aria-hidden="true" />
+                Directions
+              </a>
+            </Button>
+            <Button
+              asChild
+              size="sm"
+              className="h-10 w-full min-w-0 rounded-full bg-[#1c1c1e] text-white hover:bg-black dark:bg-white dark:text-[#1c1c1e] dark:hover:bg-white/90"
             >
-              <Navigation className="h-4 w-4" aria-hidden="true" />
-              Start
-            </a>
-          </Button>
-        </div>
+              <a
+                href={startUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Start Google Maps navigation to shared live location"
+              >
+                <Navigation className="h-4 w-4" aria-hidden="true" />
+                Start
+              </a>
+            </Button>
+          </div>
+        ) : null}
       </div>
+
 
       {isStale ? (
         <div
@@ -1449,6 +1465,25 @@ function OneLocationAgentPageContent() {
   const [locationOnboardingBusy, setLocationOnboardingBusy] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [activeMode, setActiveMode] = useState<ShareMode>("share");
+  const locationTab = normalizeLocationTab(
+    searchParams.get(LOCATION_TAB_PARAM),
+  );
+  const setLocationTab = useCallback(
+    (next: LocationTab) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (next === "compose") {
+        params.delete(LOCATION_TAB_PARAM);
+      } else {
+        params.set(LOCATION_TAB_PARAM, next);
+      }
+      const query = params.toString();
+      router.replace(query ? `/one/location?${query}` : "/one/location", {
+        scroll: false,
+      });
+    },
+    [router, searchParams],
+  );
+
   const [shareReviewOpen, setShareReviewOpen] = useState(false);
   const [recipientSearch, setRecipientSearch] = useState("");
   const [oneNetworkListExpanded, setOneNetworkListExpanded] = useState(false);
@@ -2542,6 +2577,29 @@ function OneLocationAgentPageContent() {
     [viewGrantEnvelope],
   );
 
+  // When a received grant is revoked or expires, immediately drop its decrypted
+  // map point so the "Shared with me" map view for that person disappears.
+  useEffect(() => {
+    const activeGrantIds = new Set(
+      (state?.receivedGrants ?? [])
+        .filter((grant) => grant.status === "active")
+        .map((grant) => grant.id),
+    );
+    setDecryptedPoints((current) => {
+      const next: Record<string, PlainLocationPoint> = {};
+      let changed = false;
+      for (const [grantId, point] of Object.entries(current)) {
+        if (activeGrantIds.has(grantId)) {
+          next[grantId] = point;
+        } else {
+          changed = true;
+        }
+      }
+      return changed ? next : current;
+    });
+  }, [state?.receivedGrants]);
+
+
   useEffect(() => {
     if (!vaultOwnerToken || !activeOwnerGrants.length) return;
     if (busy && busy !== "load") return;
@@ -3563,9 +3621,24 @@ function OneLocationAgentPageContent() {
           <OneLocationInitialSkeleton />
         ) : (
           <div className="flex min-w-0 max-w-full flex-col gap-6">
-            <div className="min-w-0 max-w-full space-y-7">
+            <div className="px-1">
+              <SegmentedTabs
+                value={locationTab}
+                onValueChange={(value) =>
+                  setLocationTab(normalizeLocationTab(value))
+                }
+                options={LOCATION_TAB_OPTIONS}
+              />
+            </div>
+            <div
+              className={cn(
+                "min-w-0 max-w-full space-y-7",
+                locationTab === "compose" ? "" : "hidden",
+              )}
+            >
               <section className="min-w-0 max-w-full space-y-2 px-1">
                 {sectionLabel("Device readiness")}
+
                 <div
                   className={cn(
                     "flex min-w-0 max-w-full flex-col items-center gap-3 overflow-hidden rounded-[20px] border px-4 py-4 text-center shadow-sm sm:flex-row sm:justify-between sm:text-left",
@@ -3657,9 +3730,13 @@ function OneLocationAgentPageContent() {
 
                   {myLocationPoint ? (
                     <div className="px-3.5 pb-3.5">
-                      <LocalMapPreview point={myLocationPoint} />
+                      <LocalMapPreview
+                        point={myLocationPoint}
+                        showNavigation={false}
+                      />
                     </div>
                   ) : null}
+
                 </div>
               </section>
 
@@ -4041,15 +4118,27 @@ function OneLocationAgentPageContent() {
                             )} selected for approval-first requests.`
                           : "Select one or more One users before requesting location access."}
                       </p>
-                      <Textarea
-                        value={requestMessage}
-                        onChange={(event) =>
-                          setRequestMessage(event.target.value)
-                        }
-                        placeholder="Optional reason"
-                        rows={3}
-                        className="rounded-[14px] border-black/[0.04] bg-white shadow-sm dark:border-white/[0.08] dark:bg-white/[0.07]"
-                      />
+                      <div className="space-y-1">
+                        <Textarea
+                          value={requestMessage}
+                          onChange={(event) =>
+                            setRequestMessage(
+                              event.target.value.slice(
+                                0,
+                                REQUEST_MESSAGE_MAX_LENGTH,
+                              ),
+                            )
+                          }
+                          placeholder="Optional reason"
+                          rows={3}
+                          maxLength={REQUEST_MESSAGE_MAX_LENGTH}
+                          className="rounded-[14px] border-black/[0.04] bg-white shadow-sm dark:border-white/[0.08] dark:bg-white/[0.07]"
+                        />
+                        <p className="px-1 text-right text-[11px] font-medium text-[#8e8e93] dark:text-white/45">
+                          {requestMessage.length}/{REQUEST_MESSAGE_MAX_LENGTH}
+                        </p>
+                      </div>
+
                       <ActionButton
                         busy={busy}
                         busyKey="request"
@@ -4069,8 +4158,14 @@ function OneLocationAgentPageContent() {
               </section>
             </div>
 
-            <div className="min-w-0 max-w-full space-y-6">
+            <div
+              className={cn(
+                "min-w-0 max-w-full space-y-6",
+                locationTab === "activity" ? "" : "hidden",
+              )}
+            >
               {SHOW_LOCATION_ACTIVITY_SECTION ? (
+
                 <section
                   ref={activitySectionRef}
                   tabIndex={-1}

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -2185,6 +2185,14 @@ function OneLocationAgentPageContent() {
     // purely by the real device location state: it re-appears only when access
     // is explicitly off / blocked, and stays hidden otherwise.
     if (introSeen) {
+      // If onboarding is already visible (the user is mid-flow, e.g. just
+      // advanced from the intro to the permission step), never auto-hide or
+      // redirect — let them finish the current step. Dismissal happens through
+      // the flow's own handlers. Device-state-driven (re)appearance only
+      // applies on a fresh load when onboarding is not already showing.
+      if (locationOnboardingGate === "show") {
+        return;
+      }
       if (deviceLocationBlocked) {
         setLocationOnboardingStep("permission");
         setLocationOnboardingGate("show");
@@ -2193,6 +2201,7 @@ function OneLocationAgentPageContent() {
       setLocationOnboardingGate("hidden");
       return;
     }
+
 
 
 
@@ -3520,14 +3529,11 @@ function OneLocationAgentPageContent() {
   }, [ensureForegroundLocationReady]);
 
   const dismissLocationOnboarding = useCallback(() => {
-    setLocationOnboardingGate("hidden");
-    setLocationOnboardingBusy(false);
-  }, []);
-
-  const handleContinueLocationOnboardingIntro = useCallback(() => {
-    // Persist that the one-time marketing intro has been seen so it never
+    // Persist that onboarding is complete so the one-time marketing intro never
     // shows again for this user; only the location-permission screen can
-    // re-appear, and only when device location is actually off.
+    // re-appear, and only when device location is actually off. We persist on
+    // dismissal/completion (not when merely advancing to the permission step)
+    // so a partially-seen flow still re-shows next time.
     if (typeof window !== "undefined" && auth.userId) {
       try {
         window.localStorage.setItem(
@@ -3539,8 +3545,14 @@ function OneLocationAgentPageContent() {
         // show again next time, which is acceptable.
       }
     }
-    setLocationOnboardingStep("permission");
+    setLocationOnboardingGate("hidden");
+    setLocationOnboardingBusy(false);
   }, [auth.userId]);
+
+  const handleContinueLocationOnboardingIntro = useCallback(() => {
+    setLocationOnboardingStep("permission");
+  }, []);
+
 
 
   const handleSkipLocationOnboarding = useCallback(() => {

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -60,7 +60,20 @@ import { VaultLockGuard } from "@/components/vault/vault-lock-guard";
 
 import { useRequireAuth } from "@/hooks/use-auth";
 
+type LocationTab = "compose" | "activity";
+
+const LOCATION_TAB_PARAM = "tab";
+const LOCATION_TAB_OPTIONS: { value: LocationTab; label: string }[] = [
+  { value: "compose", label: "Share & Request" },
+  { value: "activity", label: "Activity & Links" },
+];
+
+function normalizeLocationTab(value: string | null | undefined): LocationTab {
+  return value === "activity" ? "activity" : "compose";
+}
+
 import type { HushhLocationPermissionState } from "@/lib/capacitor";
+
 import {
   decryptLocationEnvelope,
   encryptLocationForRecipient,

--- a/hushh-webapp/components/consent/consent-center-page.tsx
+++ b/hushh-webapp/components/consent/consent-center-page.tsx
@@ -72,7 +72,13 @@ import {
   emailHelperWorkflowHref,
   isEmailHelperConsent,
 } from "@/lib/consent/email-helper-consent";
+import {
+  isLocationConsent,
+  locationConsentSummary,
+  locationConsentWorkflowHref,
+} from "@/lib/consent/location-consent";
 import { normalizeInternalAppHref } from "@/lib/consent/consent-sheet-route";
+
 import {
   CONSENT_CENTER_PAGE_SIZE,
   ConsentCenterService,
@@ -294,9 +300,13 @@ function entrySummary(entry: ConsentCenterEntry) {
   if (isEmailHelperConsent(entry.metadata)) {
     return emailHelperConsentSummary(entry.metadata);
   }
+  if (isLocationConsent(entry.metadata, entry.scope)) {
+    return locationConsentSummary(entry.metadata);
+  }
   return resolveConsentSupportingCopy({
     scope: entry.scope,
     scopeDescription: entry.scope_description,
+
     reason: entry.reason,
     additionalAccessSummary: entry.additional_access_summary,
     kind: entry.kind,
@@ -859,6 +869,10 @@ function ConsentEntryDetail({
   const emailHelperHref = isEmailHelperConsent(entry.metadata)
     ? normalizeInternalAppHref(emailHelperWorkflowHref(entry.metadata))
     : null;
+  const locationHref = isLocationConsent(entry.metadata, entry.scope)
+    ? normalizeInternalAppHref(locationConsentWorkflowHref(entry.metadata))
+    : null;
+
   const approvedDurationLabel =
     formatDurationHours(selectedDuration) ||
     formatDurationHours(requestedDurationHours);
@@ -999,7 +1013,19 @@ function ConsentEntryDetail({
             }
           />
         ) : null}
+        {locationHref ? (
+          <SettingsRow
+            title="Location sharing"
+            description="Review this location request, active access, and expiry in One Location."
+            trailing={
+              <Button asChild variant="none" effect="fade" size="sm">
+                <Link href={locationHref}>Open Location</Link>
+              </Button>
+            }
+          />
+        ) : null}
       </SettingsGroup>
+
 
       <SettingsGroup
         embedded

--- a/hushh-webapp/lib/consent/location-consent.ts
+++ b/hushh-webapp/lib/consent/location-consent.ts
@@ -1,0 +1,65 @@
+"use client";
+
+// Frontend recognizer + presenter for One Location consent entries inside the
+// shared consent center (/consents). This mirrors `email-helper-consent.ts`:
+// the consent center stays generic over `ConsentCenterEntry`, and an agent
+// "plugs in" purely through metadata flags + a small presenter helper.
+//
+// NOTE: location consent rows only appear in the consent center once the
+// backend `ConsentCenterService` unions the `one_location_*` tables into the
+// shared read model (tracked as the Phase C backend follow-up). This helper is
+// the frontend half of that contract so the UI is ready when rows arrive.
+
+type MetadataLike = Record<string, unknown> | null | undefined;
+
+function readString(metadata: MetadataLike, key: string): string {
+  const value = metadata?.[key];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+/**
+ * A consent entry belongs to One Location when its metadata carries a
+ * location request source or a location-family scope.
+ */
+export function isLocationConsent(
+  metadata: MetadataLike,
+  scope?: string | null,
+): boolean {
+  const requestSource = readString(metadata, "request_source");
+  if (requestSource.startsWith("one_location")) return true;
+  const normalizedScope = String(scope || "").trim().toLowerCase();
+  return (
+    normalizedScope.startsWith("cap.location.") ||
+    normalizedScope.startsWith("attr.location.")
+  );
+}
+
+/**
+ * Deep link back to the One Location surface, optionally focused on the
+ * relevant section (mirrors the in-app notification deep links).
+ */
+export function locationConsentWorkflowHref(metadata: MetadataLike): string {
+  const section = readString(metadata, "section");
+  const grantId = readString(metadata, "grant_id");
+  const requestId = readString(metadata, "request_id");
+  const params = new URLSearchParams();
+  if (section) params.set("oneLocationSection", section);
+  if (grantId) params.set("oneLocationGrantId", grantId);
+  if (requestId) params.set("oneLocationRequestId", requestId);
+  const query = params.toString();
+  return query ? `/one/location?${query}` : "/one/location";
+}
+
+/**
+ * Human summary for a location consent row. Coordinate-free by contract:
+ * we never surface latitude/longitude in consent metadata or copy.
+ */
+export function locationConsentSummary(metadata: MetadataLike): string {
+  const requesterLabel = readString(metadata, "requester_label");
+  const durationLabel = readString(metadata, "duration_label");
+  const who = requesterLabel || "Someone in your One Network";
+  if (durationLabel) {
+    return `${who} wants to see your location for ${durationLabel}.`;
+  }
+  return `${who} wants to see your location through One Location.`;
+}

--- a/hushh-webapp/lib/consent/location-consent.ts
+++ b/hushh-webapp/lib/consent/location-consent.ts
@@ -10,7 +10,10 @@
 // shared read model (tracked as the Phase C backend follow-up). This helper is
 // the frontend half of that contract so the UI is ready when rows arrive.
 
+import { buildOneLocationWorkflowHref } from "@/lib/one-location/notifications";
+
 type MetadataLike = Record<string, unknown> | null | undefined;
+
 
 function readString(metadata: MetadataLike, key: string): string {
   const value = metadata?.[key];
@@ -42,13 +45,27 @@ export function locationConsentWorkflowHref(metadata: MetadataLike): string {
   const section = readString(metadata, "section");
   const grantId = readString(metadata, "grant_id");
   const requestId = readString(metadata, "request_id");
-  const params = new URLSearchParams();
-  if (section) params.set("oneLocationSection", section);
-  if (grantId) params.set("oneLocationGrantId", grantId);
-  if (requestId) params.set("oneLocationRequestId", requestId);
-  const query = params.toString();
-  return query ? `/one/location?${query}` : "/one/location";
+  // Use the canonical One Location query params (section / grantId / requestId)
+  // so the consent-manager deep link drives the exact same tab-switch + scroll
+  // behavior as in-app notifications. A "shared" grant link also marks the
+  // grant opened so its "Shared with me" map block is revealed on arrival.
+  const isSharedGrant = Boolean(grantId) && (!section || section === "shared");
+  return buildOneLocationWorkflowHref({
+    grantId: grantId || null,
+    requestId: requestId || null,
+    section:
+      (section as
+        | "people"
+        | "approvals"
+        | "shared"
+        | "my_requests"
+        | "public_responses"
+        | "activity"
+        | null) || null,
+    openGrant: isSharedGrant,
+  });
 }
+
 
 /**
  * Human summary for a location consent row. Coordinate-free by contract:

--- a/hushh-webapp/lib/services/unlock-warm-orchestrator.ts
+++ b/hushh-webapp/lib/services/unlock-warm-orchestrator.ts
@@ -9,6 +9,8 @@ import { PersonalKnowledgeModelService } from "@/lib/services/personal-knowledge
 import { ConsentExportRefreshOrchestrator } from "@/lib/services/consent-export-refresh-orchestrator";
 import { PkmUpgradeOrchestrator } from "@/lib/services/pkm-upgrade-orchestrator";
 import { AppBackgroundTaskService } from "@/lib/services/app-background-task-service";
+import { bootstrapCurrentUserLocationRecipientKey } from "@/lib/one-location/key-bootstrap";
+
 import { normalizeStoredPortfolio } from "@/lib/utils/portfolio-normalize";
 import { KaiFinancialResourceService } from "@/lib/kai/kai-financial-resource";
 import { toDurationBucket, trackEvent } from "@/lib/observability/client";
@@ -158,11 +160,39 @@ export class UnlockWarmOrchestrator {
     });
   }
 
+  private static locationKeyBootstrappedByUser = new Set<string>();
+
+  // Eagerly provision the One Location recipient key right after vault unlock so
+  // EVERY signed-in user (new or returning) can receive and request location
+  // without ever opening the One Location page first. The key is an ECDH P-256
+  // keypair held on-device; this only registers the public half. Idempotent:
+  // ensureLocationRecipientKey reuses the device key and the backend upserts on
+  // (user_id, key_id), so it is safe to attempt once per session.
+  private static queueLocationRecipientKeyBootstrap(params: {
+    userId: string;
+    vaultOwnerToken: string;
+  }): void {
+    if (this.locationKeyBootstrappedByUser.has(params.userId)) return;
+    this.locationKeyBootstrappedByUser.add(params.userId);
+    void bootstrapCurrentUserLocationRecipientKey({
+      userId: params.userId,
+      vaultOwnerToken: params.vaultOwnerToken,
+    }).catch((error) => {
+      // Never block unlock warming; allow a later retry this session.
+      this.locationKeyBootstrappedByUser.delete(params.userId);
+      console.warn(
+        "[UnlockWarmOrchestrator] One Location recipient key bootstrap failed:",
+        error
+      );
+    });
+  }
+
   private static queueConsentExportRefresh(params: {
     userId: string;
     vaultKey: string;
     vaultOwnerToken: string;
   }): void {
+
     void ConsentExportRefreshOrchestrator.ensureRunning({
       userId: params.userId,
       vaultKey: params.vaultKey,
@@ -499,9 +529,17 @@ export class UnlockWarmOrchestrator {
     }
 
     this.queuePkmUpgrade(params);
+    // Provision the One Location recipient key for every user on every unlock,
+    // regardless of which route they unlocked on, so receiving/requesting
+    // location never requires visiting the One Location page first.
+    this.queueLocationRecipientKeyBootstrap({
+      userId: params.userId,
+      vaultOwnerToken: params.vaultOwnerToken,
+    });
     if (warmPriority === "consents") {
       this.queueConsentExportRefresh(params);
     }
+
     const durationMs = Math.max(0, Math.round(nowMs() - startedAtMs));
     trackEvent("startup_readiness_warmup_completed", {
       result: "success",


### PR DESCRIPTION
Owner maintainer promotion lane (base=main, bypass-eligible).

Scope: One Location only.
- Mobile-first tabbed /one/location (Share & Request / Activity & Links), self-location hides nav, reason 200-char limit, revoke/expiry clears shared map.
- lib/consent/location-consent.ts + consent-center wiring (coordinate-free summary + Open Location row).
- OneLocationCenterContributor + ConsentCenterService union into get_center/get_center_summary/list_center behind ONE_LOCATION_CONSENT_CENTER_ENABLED (default off; RIA lane untouched).
- Adds maintainer branch to config/ci-governance.json main_allowed_head_branches (authorized: DamriaNeelesh in protected_pipeline_edit_users).

Verified: tsc + eslint clean; 44 backend location tests pass (incl. 4-user A/B/C/D flow); 124 consent-center tests pass (no regression); commits DCO signed-off.