### PR TITLE
fix(ui): correct asymmetrical switch thumb positioning

### DIFF
--- a/hushh-webapp/components/ui/switch.tsx
+++ b/hushh-webapp/components/ui/switch.tsx
@@ -17,7 +17,7 @@ function Switch({
       data-slot="switch"
       data-size={size}
       className={cn(
-        "peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-5 data-[size=default]:w-9 data-[size=sm]:h-4 data-[size=sm]:w-7 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80",
+        "peer group/switch inline-flex shrink-0 items-center rounded-full border-2 border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-5 data-[size=default]:w-9 data-[size=sm]:h-4 data-[size=sm]:w-7 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80",
         className
       )}
       {...props}


### PR DESCRIPTION
# Description
Fixed a visual styling bug where the `Switch` component's thumb was positioned asymmetrically and failed to sit flush on the active side.

The track width and translation offsets (`translate-x-4` and `translate-x-3`) were mathematically mismatched with the 1px transparent border, leaving a 2px gap when the switch was in the checked state. Changing the track's transparent boundary to `border-2` balances the interior width, allowing the thumb's travel distance to land perfectly flush on both sides for both the default and small sizes.

## 📌 Impact Map (Required)
- Routes touched: [x] None
- API / schema / type changes: [x] None
- Trust boundary touched: [x] None
- UI browser or Playwright proof: [x] Switch thumb is perfectly symmetrical and flush when checked.
- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm test` *(Note: `kai-analysis-route` contract test fails upstream on `pr-train`)*

## ✅ Review-Ready Contract
- [x] Title, body, changed files, and tests describe the same contract.
- [x] Reachable production attach point: `components/ui/switch.tsx`
- [x] Production surface proved: All forms utilizing the `Switch` component.
- [x] Required checks are current, commits are signed off, and branch is mergeable.

## 🛑 Tri-Flow Architecture Check
- [x] **Web**: Next.js implementation
- [ ] **iOS** / **Android**: Not applicable (UI behavior only)

## 🧪 Testing & Consent
- [x] Verified mathematical layout consistency
- [x] Commits are signed off (`git commit -s`)
- [x] Sensitive surface touched: none