### PR TITLE
test(native-test): cover placeholder user id sanitization

### DIFF
--- a/hushh-webapp/__tests__/lib/native-test-automation-guard.test.ts
+++ b/hushh-webapp/__tests__/lib/native-test-automation-guard.test.ts
@@ -5,6 +5,7 @@ import {
   isNativeUiTestSession,
   preferPassphraseUnlockForAutomation,
   shouldSkipGeneratedVaultUnlockForAutomation,
+  getNativeTestConfig,
 } from "@/lib/testing/native-test";
 
 describe("native test automation guards", () => {
@@ -45,5 +46,14 @@ describe("native test automation guards", () => {
     vi.stubGlobal("navigator", { webdriver: true });
     expect(preferPassphraseUnlockForAutomation()).toBe(true);
     expect(isNativeUiTestSession()).toBe(false);
+  });
+
+  it("ignores placeholder expected user ids in native test config", () => {
+   window.__HUSHH_NATIVE_TEST__ = {
+    enabled: true,
+    expectedUserId: "replace_with_user_id",
+   };
+
+   expect(getNativeTestConfig().expectedUserId).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Adds test coverage for placeholder native test configuration values.

### Added coverage

Verifies that `getNativeTestConfig()` ignores placeholder `expectedUserId` values such as:

* `replace_with_user_id`

### Why

Native UI test configuration sanitizes placeholder values before exposing them through the runtime configuration. This test documents and protects that behavior against future regressions.
