### PR TITLE
test(voice-route-eligibility): cover route normalization

### DIFF
--- a/hushh-webapp/__tests__/voice/voice-route-eligibility.test.ts
+++ b/hushh-webapp/__tests__/voice/voice-route-eligibility.test.ts
@@ -16,4 +16,14 @@ describe("voice-route-eligibility", () => {
     expect(isVoiceEligibleRouteScreen("app", false)).toBe(false);
     expect(isVoiceEligibleRouteScreen("unknown", false)).toBe(false);
   });
+
+  it("normalizes screen names and rejects empty route values", () => {
+   expect(isVoiceEligibleRouteScreen(" Dashboard ", false)).toBe(true);
+   expect(isVoiceEligibleRouteScreen("PROFILE", false)).toBe(true);
+
+   expect(isVoiceEligibleRouteScreen("", false)).toBe(false);
+   expect(isVoiceEligibleRouteScreen("   ", false)).toBe(false);
+   expect(isVoiceEligibleRouteScreen(null, false)).toBe(false);
+   expect(isVoiceEligibleRouteScreen(undefined, false)).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

Adds coverage for route normalization behavior in
`isVoiceEligibleRouteScreen`.

## Added coverage

- Verifies leading/trailing whitespace is ignored.
- Verifies mixed-case route names are normalized.
- Verifies empty strings are rejected.
- Verifies whitespace-only values are rejected.
- Verifies null and undefined route values are rejected.

## Why

The helper normalizes route names before determining
voice eligibility. These tests document and protect
that behavior against future regressions.