### PR TITLE
test(agent-popover-layout): cover fullscreen size resolution

### DIFF
--- a/hushh-webapp/__tests__/lib/agent-popover-layout.test.ts
+++ b/hushh-webapp/__tests__/lib/agent-popover-layout.test.ts
@@ -129,4 +129,16 @@ describe("agent popover layout", () => {
       y: 104,
     });
   });
+  
+  it("preserves custom size for fullscreen mode", () => {
+   expect(
+    resolveAgentPopoverSize("fullscreen", {
+      width: 900,
+      height: 700,
+    })
+   ).toEqual({
+    width: 900,
+    height: 700,
+   });
+  });
 });


### PR DESCRIPTION
## Summary

Adds coverage for fullscreen popover size resolution.

## Added coverage

- Verifies fullscreen mode preserves the provided custom size.
- Documents the current fallback behavior used by
  `resolveAgentPopoverSize`.

## Why

Compact and large preset modes already had coverage.
This test covers the remaining size mode branch and
helps prevent regressions in fullscreen sizing behavior.