### PR TITLE
fix(one-location): stop notification spam, decouple view, add unwatch, route consent to consent surfaces

### DIFF
--- a/consent-protocol/hushh_mcp/services/consent_center_service.py
+++ b/consent-protocol/hushh_mcp/services/consent_center_service.py
@@ -19,17 +19,18 @@ logger = logging.getLogger(__name__)
 def _one_location_consent_center_enabled() -> bool:
     """Feature flag: union One Location rows into the consent center.
 
-    Defaults OFF so the shared consent surface stays stable until the
-    integration is verified end to end (see
-    docs/future/one-location-consent-center-integration-plan.md).
+    Defaults ON so location requests/approvals/active shares/history appear in
+    the shared Access Manager (the canonical consent surface) instead of only
+    the notification bell. The contributor is coordinate-free and the merge in
+    ``_location_buckets`` is wrapped in try/except, so a location failure can
+    never destabilize the consent surface. Set the env var to a falsey value
+    ("0"/"false"/"off") to explicitly disable.
+    See docs/future/one-location-consent-center-integration-plan.md.
     """
-    return os.getenv("ONE_LOCATION_CONSENT_CENTER_ENABLED", "").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
-
+    raw = os.getenv("ONE_LOCATION_CONSENT_CENTER_ENABLED", "").strip().lower()
+    if raw in {"0", "false", "no", "off"}:
+        return False
+    return True
 
 
 class ConsentCenterService:
@@ -89,7 +90,6 @@ class ConsentCenterService:
                 exc,
             )
             return empty
-
 
     @staticmethod
     def _metadata(value: Any) -> dict[str, Any]:
@@ -1374,9 +1374,7 @@ class ConsentCenterService:
             )
         if normalized_actor == "investor":
             location_buckets = (
-                self._location_buckets(user_id)
-                if normalized_mode == "consents"
-                else None
+                self._location_buckets(user_id) if normalized_mode == "consents" else None
             )
             location_count = 0
             if location_buckets:
@@ -1424,7 +1422,6 @@ class ConsentCenterService:
                 )
                 + location_count
             )
-
 
         if surface == "active":
             payload = await self._load_ria_active_entries(user_id, page=1, limit=1)
@@ -1635,7 +1632,6 @@ class ConsentCenterService:
             "active_grants": active_entries,
             "history": history_entries,
             "invites": invite_entries,
-
             "developer_requests": developer_requests,
             "requestor_groups": {
                 "pending": investor_pending_groups,
@@ -1745,9 +1741,7 @@ class ConsentCenterService:
                 else self._collapse_consent_chains(entries)
             )
             location_buckets = (
-                self._location_buckets(user_id)
-                if normalized_mode == "consents"
-                else None
+                self._location_buckets(user_id) if normalized_mode == "consents" else None
             )
             if location_buckets:
                 if normalized_surface == "pending":
@@ -1763,7 +1757,6 @@ class ConsentCenterService:
                 query=query,
             )
         elif normalized_surface == "active":
-
             paged = await self._load_ria_active_entries(
                 user_id,
                 query=query,

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -3366,9 +3366,44 @@ class OneLocationAgentService:
         return invite
 
     def list_state(self, *, user_id: str) -> dict[str, Any]:
-        self._expire_stale_grants(user_id)
-        recipients = self.list_verified_recipients(owner_user_id=user_id)
-        owner_grants = self._execute_many(
+        # Resilience: one failing auxiliary section (e.g. schema drift on a
+        # rarely-used table) must NOT 500 the whole endpoint. A 500 here cascades
+        # into the consent-center contributor (which then returns empty buckets)
+        # AND breaks the One Location page on every load. Each section is wrapped
+        # so a partial failure degrades to an empty list, logged for triage,
+        # while the rest of the state still loads. The backend still enforces
+        # real access on every read/write path.
+        def _safe_many(label: str, sql: str, params: dict[str, Any]) -> list[dict[str, Any]]:
+            try:
+                return self._execute_many(sql, params)
+            except Exception as exc:  # noqa: BLE001 - degrade, never 500 the page
+                logger.warning(
+                    "one_location.list_state.section_failed section=%s user=%s error=%s",
+                    label,
+                    user_id,
+                    exc,
+                )
+                return []
+
+        try:
+            self._expire_stale_grants(user_id)
+        except Exception as exc:  # noqa: BLE001 - housekeeping must not block reads
+            logger.warning(
+                "one_location.list_state.expire_stale_failed user=%s error=%s",
+                user_id,
+                exc,
+            )
+        try:
+            recipients = self.list_verified_recipients(owner_user_id=user_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "one_location.list_state.recipients_failed user=%s error=%s",
+                user_id,
+                exc,
+            )
+            recipients = []
+        owner_grants = _safe_many(
+            "owner_grants",
             """
             SELECT
               g.*,
@@ -3382,7 +3417,8 @@ class OneLocationAgentService:
             """,
             {"user_id": user_id},
         )
-        received_grants = self._execute_many(
+        received_grants = _safe_many(
+            "received_grants",
             """
             SELECT
               g.*,
@@ -3396,7 +3432,8 @@ class OneLocationAgentService:
             """,
             {"user_id": user_id},
         )
-        requests = self._execute_many(
+        requests = _safe_many(
+            "requests",
             """
             SELECT
               req.*,
@@ -3410,7 +3447,8 @@ class OneLocationAgentService:
             """,
             {"user_id": user_id},
         )
-        referrals = self._execute_many(
+        referrals = _safe_many(
+            "referrals",
             """
             SELECT *
             FROM one_location_referrals
@@ -3422,7 +3460,8 @@ class OneLocationAgentService:
             """,
             {"user_id": user_id},
         )
-        public_invites = self._execute_many(
+        public_invites = _safe_many(
+            "public_invites",
             """
             SELECT *
             FROM one_location_public_invites
@@ -3432,7 +3471,8 @@ class OneLocationAgentService:
             """,
             {"user_id": user_id},
         )
-        circle_invites = self._execute_many(
+        circle_invites = _safe_many(
+            "circle_invites",
             """
             SELECT *
             FROM one_location_circle_invites
@@ -3443,7 +3483,8 @@ class OneLocationAgentService:
             """,
             {"user_id": user_id},
         )
-        network_connections = self._execute_many(
+        network_connections = _safe_many(
+            "network_connections",
             """
             SELECT *
             FROM one_location_network_connections
@@ -3454,7 +3495,8 @@ class OneLocationAgentService:
             """,
             {"user_id": user_id},
         )
-        public_submissions = self._execute_many(
+        public_submissions = _safe_many(
+            "public_submissions",
             """
             SELECT
               submission.*,

--- a/consent-protocol/tests/test_one_location_list_state_resilience.py
+++ b/consent-protocol/tests/test_one_location_list_state_resilience.py
@@ -1,0 +1,91 @@
+"""Resilience tests for OneLocationAgentService.list_state.
+
+These are hermetic: they stub the low-level DB executors so no database is
+required. They lock in the guarantee that a single failing/drifted section query
+degrades to an empty list instead of 500-ing the whole /api/one/location/state
+endpoint (which previously cascaded into empty consent-center tabs and a broken
+One Location page).
+"""
+
+from __future__ import annotations
+
+from hushh_mcp.services.one_location_agent_service import OneLocationAgentService
+
+
+class _PartialFailureService(OneLocationAgentService):
+    """Service whose received_grants query raises, all others return empty."""
+
+    def __init__(self) -> None:
+        self.section_calls: list[str] = []
+
+    # Housekeeping + recommendations are no-ops / empty in this harness.
+    def _expire_stale_grants(self, user_id: str) -> None:  # noqa: ARG002
+        return None
+
+    def list_verified_recipients(self, *, owner_user_id: str, limit: int = 50):  # noqa: ARG002
+        return []
+
+    def _execute_many(self, sql: str, params=None):  # noqa: ARG002
+        # The received_grants section selects "o.display_name AS owner_display_name".
+        if "owner_display_name" in sql:
+            raise RuntimeError("simulated schema drift on received_grants join")
+        return []
+
+
+class _RecipientsFailureService(OneLocationAgentService):
+    """Service whose recipients lookup raises; sections return empty."""
+
+    def _expire_stale_grants(self, user_id: str) -> None:  # noqa: ARG002
+        return None
+
+    def list_verified_recipients(self, *, owner_user_id: str, limit: int = 50):  # noqa: ARG002
+        raise RuntimeError("simulated recipients failure")
+
+    def _execute_many(self, sql: str, params=None):  # noqa: ARG002
+        return []
+
+
+def test_list_state_degrades_when_one_section_fails():
+    state = _PartialFailureService().list_state(user_id="user_a")
+    # The endpoint must still return a well-formed payload (no exception).
+    assert isinstance(state, dict)
+    # The failing section degrades to an empty list...
+    assert state["receivedGrants"] == []
+    # ...while the rest of the contract is intact.
+    for key in (
+        "recipients",
+        "ownerGrants",
+        "requests",
+        "referrals",
+        "publicInvites",
+        "circleInvites",
+        "networkConnections",
+        "publicInviteSubmissions",
+        "capabilityScopes",
+    ):
+        assert key in state
+
+
+def test_list_state_degrades_when_recipients_fail():
+    state = _RecipientsFailureService().list_state(user_id="user_a")
+    assert isinstance(state, dict)
+    assert state["recipients"] == []
+    # Capability scopes are always present so the client can render.
+    assert "capabilityScopes" in state
+
+
+def test_list_state_raises_nothing_for_clean_empty_user():
+    class _EmptyService(OneLocationAgentService):
+        def _expire_stale_grants(self, user_id: str) -> None:  # noqa: ARG002
+            return None
+
+        def list_verified_recipients(self, *, owner_user_id: str, limit: int = 50):  # noqa: ARG002
+            return []
+
+        def _execute_many(self, sql: str, params=None):  # noqa: ARG002
+            return []
+
+    state = _EmptyService().list_state(user_id="user_a")
+    assert state["ownerGrants"] == []
+    assert state["receivedGrants"] == []
+    assert state["requests"] == []

--- a/hushh-webapp/__tests__/one-location-notifications.test.ts
+++ b/hushh-webapp/__tests__/one-location-notifications.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the background-task store so the notification helpers run without the
+// real (sessionStorage-backed) implementation. We only need to confirm the
+// persistent de-dup + unwatch logic in notifications.ts.
+const tasks = new Map<string, { taskId: string; dismissedAt: string | null }>();
+
+vi.mock("@/lib/services/app-background-task-service", () => ({
+  AppBackgroundTaskService: {
+    getTask: (taskId: string) => tasks.get(taskId) ?? null,
+    startTask: (params: { taskId: string }) => {
+      tasks.set(params.taskId, { taskId: params.taskId, dismissedAt: null });
+      return params.taskId;
+    },
+    completeTask: () => undefined,
+    dismissTask: (taskId: string) => {
+      const existing = tasks.get(taskId);
+      if (existing) existing.dismissedAt = new Date().toISOString();
+    },
+  },
+}));
+
+import {
+  hasSeenOneLocationNotification,
+  isOneLocationGrantUnwatched,
+  markOneLocationGrantUnwatched,
+  recordOneLocationShareNotification,
+  recordOneLocationWorkflowNotification,
+} from "@/lib/one-location/notifications";
+
+const USER = "user_recipient_1";
+const GRANT = "grant_abc";
+
+beforeEach(() => {
+  tasks.clear();
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("One-Location persistent notification de-dup", () => {
+  it("creates a share notification only once, even after the task is dismissed (refresh)", () => {
+    const first = recordOneLocationShareNotification({
+      userId: USER,
+      grantId: GRANT,
+      ownerLabel: "Alex",
+    });
+    expect(first).toBe(true);
+    expect(hasSeenOneLocationNotification(USER, `share:${GRANT}`)).toBe(true);
+
+    // Simulate dismiss + page refresh (sessionStorage task store forgets it).
+    tasks.clear();
+
+    const second = recordOneLocationShareNotification({
+      userId: USER,
+      grantId: GRANT,
+      ownerLabel: "Alex",
+    });
+    // The persistent seen-set must block the duplicate.
+    expect(second).toBe(false);
+  });
+
+  it("does not re-create a workflow notification for the same (type,id) after refresh", () => {
+    const params = {
+      userId: USER,
+      notificationType: "location_share_revoked" as const,
+      id: GRANT,
+      title: "Location access removed",
+      description: "Alex removed your location access.",
+    };
+    expect(recordOneLocationWorkflowNotification(params)).toBe(true);
+
+    tasks.clear(); // refresh
+
+    expect(recordOneLocationWorkflowNotification(params)).toBe(false);
+  });
+});
+
+describe("One-Location consent-surface routing (not the general bell)", () => {
+  const CONSENT_EVENT = "consent-state-changed";
+
+  it("dispatches a consent refresh and does NOT create a bell task for a share", () => {
+    const events: string[] = [];
+    const handler = () => events.push("consent");
+    window.addEventListener(CONSENT_EVENT, handler);
+    try {
+      const created = recordOneLocationShareNotification({
+        userId: "user_routing_1",
+        grantId: "grant_routing_1",
+        ownerLabel: "Alex",
+      });
+      expect(created).toBe(true);
+      // Routed to the consent surface...
+      expect(events.length).toBe(1);
+      // ...and NOT written to the general bell (AppBackgroundTaskService).
+      expect(tasks.size).toBe(0);
+    } finally {
+      window.removeEventListener(CONSENT_EVENT, handler);
+    }
+  });
+
+  it("dispatches a consent refresh for a workflow (approve/deny/request) event", () => {
+    const events: string[] = [];
+    const handler = () => events.push("consent");
+    window.addEventListener(CONSENT_EVENT, handler);
+    try {
+      const created = recordOneLocationWorkflowNotification({
+        userId: "user_routing_2",
+        notificationType: "location_access_request",
+        id: "req_routing_1",
+        title: "Location request",
+        description: "Someone is asking to view your location.",
+      });
+      expect(created).toBe(true);
+      expect(events.length).toBe(1);
+      expect(tasks.size).toBe(0);
+    } finally {
+      window.removeEventListener(CONSENT_EVENT, handler);
+    }
+  });
+});
+
+describe("One-Location unwatch", () => {
+  it("hides a grant and suppresses its share notification", () => {
+    expect(isOneLocationGrantUnwatched(USER, GRANT)).toBe(false);
+    markOneLocationGrantUnwatched(USER, GRANT);
+    expect(isOneLocationGrantUnwatched(USER, GRANT)).toBe(true);
+
+    // An unwatched grant must never produce a share notification.
+    const created = recordOneLocationShareNotification({
+      userId: USER,
+      grantId: GRANT,
+      ownerLabel: "Alex",
+    });
+    expect(created).toBe(false);
+  });
+
+  it("persists the unwatch choice across reloads (localStorage)", () => {
+    markOneLocationGrantUnwatched(USER, GRANT);
+    // A fresh read (no in-memory state) still reports unwatched.
+    expect(isOneLocationGrantUnwatched(USER, GRANT)).toBe(true);
+  });
+});

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -83,11 +83,14 @@ import {
   buildOneLocationNotificationHref,
   buildOneLocationWorkflowHref,
   isOneLocationGrantOpened,
+  isOneLocationGrantUnwatched,
   locationShareNotificationDescription,
   locationWorkflowNotificationCopy,
   markOneLocationGrantOpened,
+  markOneLocationGrantUnwatched,
   ONE_LOCATION_GRANT_ID_PARAM,
   ONE_LOCATION_GRANT_OPENED_EVENT,
+  ONE_LOCATION_GRANT_UNWATCHED_EVENT,
   ONE_LOCATION_NOTIFICATION_OPEN_PARAM,
   ONE_LOCATION_NOTIFICATION_OPEN_VALUE,
   ONE_LOCATION_REFERRAL_ID_PARAM,
@@ -1531,6 +1534,9 @@ function OneLocationAgentPageContent() {
     Record<string, PlainLocationPoint>
   >({});
   const [openedGrantTick, setOpenedGrantTick] = useState(0);
+  // Bumped whenever the recipient unwatches a share, so the memoized
+  // "Shared with me" list recomputes immediately.
+  const [unwatchedTick, setUnwatchedTick] = useState(0);
   const [focusedSection, setFocusedSection] =
     useState<OneLocationFocusTarget | null>(null);
   const refreshInFlightRef = useRef<Promise<void> | null>(null);
@@ -1624,26 +1630,36 @@ function OneLocationAgentPageContent() {
       ),
     [auth.userId, state?.requests],
   );
+  // Every ACTIVE received share is shown inline in "Shared with me" so the
+  // recipient can view the live map directly - opening a notification is a
+  // convenience deep-link, NOT a requirement. Shares the recipient explicitly
+  // "unwatched" are hidden. Terminal (revoked/expired) grants are never listed
+  // here (the backend keeps them for ~12h for history only).
   const visibleReceivedGrants = useMemo(() => {
     void openedGrantTick;
-    return (state?.receivedGrants ?? []).filter((grant) =>
-      isOneLocationGrantOpened(auth.userId, grant.id),
+    void unwatchedTick;
+    return (state?.receivedGrants ?? []).filter(
+      (grant) =>
+        grant.status === "active" &&
+        !isOneLocationGrantUnwatched(auth.userId, grant.id),
     );
-  }, [auth.userId, openedGrantTick, state?.receivedGrants]);
+  }, [auth.userId, openedGrantTick, unwatchedTick, state?.receivedGrants]);
   const activeOwnerGrants = useMemo(
     () =>
       (state?.ownerGrants ?? []).filter((grant) => grant.status === "active"),
     [state?.ownerGrants],
   );
-  const activeVisibleReceivedGrants = useMemo(
-    () => visibleReceivedGrants.filter((grant) => grant.status === "active"),
-    [visibleReceivedGrants],
-  );
-  const hiddenReceivedGrantCount = (state?.receivedGrants ?? []).filter(
-    (grant) =>
-      grant.status === "active" &&
-      !isOneLocationGrantOpened(auth.userId, grant.id),
-  ).length;
+  const activeVisibleReceivedGrants = visibleReceivedGrants;
+  // Active shares the recipient unwatched (hidden locally). Used only to tailor
+  // the empty-state copy.
+  const unwatchedActiveReceivedGrantCount = useMemo(() => {
+    void unwatchedTick;
+    return (state?.receivedGrants ?? []).filter(
+      (grant) =>
+        grant.status === "active" &&
+        isOneLocationGrantUnwatched(auth.userId, grant.id),
+    ).length;
+  }, [auth.userId, unwatchedTick, state?.receivedGrants]);
   const activePublicInvites = useMemo(
     () =>
       (state?.publicInvites ?? []).filter(
@@ -2331,6 +2347,37 @@ function OneLocationAgentPageContent() {
   }, [auth.userId]);
 
   useEffect(() => {
+    if (!auth.userId || typeof window === "undefined") return;
+    const handleGrantUnwatched = (event: Event) => {
+      const detail =
+        (event as CustomEvent<{ userId?: string; grantId?: string }>).detail ||
+        {};
+      if (detail.userId && detail.userId !== auth.userId) return;
+      setUnwatchedTick((value) => value + 1);
+      // Drop any decrypted map point for the unwatched grant immediately.
+      const grantId = String(detail.grantId || "").trim();
+      if (grantId) {
+        setDecryptedPoints((current) => {
+          if (!(grantId in current)) return current;
+          const next = { ...current };
+          delete next[grantId];
+          return next;
+        });
+      }
+    };
+    window.addEventListener(
+      ONE_LOCATION_GRANT_UNWATCHED_EVENT,
+      handleGrantUnwatched,
+    );
+    return () => {
+      window.removeEventListener(
+        ONE_LOCATION_GRANT_UNWATCHED_EVENT,
+        handleGrantUnwatched,
+      );
+    };
+  }, [auth.userId]);
+
+  useEffect(() => {
     if (!auth.userId || !state?.receivedGrants?.length) return;
     for (const grant of state.receivedGrants) {
       if (grant.status !== "active") continue;
@@ -2390,7 +2437,30 @@ function OneLocationAgentPageContent() {
       }
     }
 
+    // Owners who currently have an ACTIVE share with me. When a person re-shares
+    // their location within an existing window, the backend silently supersedes
+    // the prior grant (sets it to "revoked" with NO push), so a stale
+    // revoked/expired row sits alongside a fresh active one. We must NOT raise a
+    // "location removed" / "expired" notification in that case - it is the core
+    // source of the false "location removed by this user" spam. Only notify when
+    // the owner has genuinely stopped sharing (no active grant remains).
+    const ownersWithActiveReceivedGrant = new Set(
+      (state.receivedGrants ?? [])
+        .filter((grant) => grant.status === "active")
+        .map((grant) => String(grant.ownerUserId || "").trim())
+        .filter(Boolean),
+    );
     for (const grant of state.receivedGrants ?? []) {
+      const ownerId = String(grant.ownerUserId || "").trim();
+      const supersededByNewerShare =
+        Boolean(ownerId) && ownersWithActiveReceivedGrant.has(ownerId);
+      // A recipient who unwatched this share does not want any follow-up noise.
+      const recipientUnwatched = isOneLocationGrantUnwatched(
+        auth.userId,
+        grant.id,
+      );
+      if (supersededByNewerShare || recipientUnwatched) continue;
+
       if (grant.status === "revoked") {
         showWorkflowToast({
           notificationType: "location_share_revoked",
@@ -2652,6 +2722,29 @@ function OneLocationAgentPageContent() {
       await viewGrantEnvelope(grant);
     },
     [viewGrantEnvelope],
+  );
+
+  // Recipient-side "Unwatch": locally hide a received share so it stops
+  // appearing in "Shared with me" and stops surfacing notifications. The owner's
+  // grant is unaffected server-side (a recipient cannot revoke it); the backend
+  // continues to enforce real access. The choice persists across refreshes.
+  const handleUnwatch = useCallback(
+    (grant: OneLocationGrant) => {
+      if (!auth.userId) return;
+      markOneLocationGrantUnwatched(auth.userId, grant.id);
+      // Optimistically reflect the change even before the event listener fires.
+      setUnwatchedTick((value) => value + 1);
+      setDecryptedPoints((current) => {
+        if (!(grant.id in current)) return current;
+        const next = { ...current };
+        delete next[grant.id];
+        return next;
+      });
+      toast.success(
+        `Stopped watching ${receivedGrantOwnerLabel(grant)}'s location.`,
+      );
+    },
+    [auth.userId],
   );
 
   // When a received grant is revoked or expires, immediately drop its decrypted
@@ -4661,20 +4754,32 @@ function OneLocationAgentPageContent() {
                               </div>
                             </div>
                             {grant.status === "active" ? (
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                onClick={() => void handleView(grant)}
-                                disabled={busy === "view"}
-                                className="w-full rounded-full border-black/[0.06] bg-[#f2f2f7] text-[#1c1c1e] hover:bg-white hover:text-[#1c1c1e] sm:w-auto dark:border-white/[0.08] dark:bg-white/10 dark:text-white dark:hover:bg-white/15 dark:hover:text-white"
-                              >
-                                {busy === "view" ? (
-                                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                                ) : (
-                                  <ShieldCheck className="mr-2 h-4 w-4" />
-                                )}
-                                View
-                              </Button>
+                              <div className="flex w-full shrink-0 flex-col gap-2 sm:w-auto sm:flex-row">
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  onClick={() => void handleView(grant)}
+                                  disabled={busy === "view"}
+                                  className="w-full rounded-full border-black/[0.06] bg-[#f2f2f7] text-[#1c1c1e] hover:bg-white hover:text-[#1c1c1e] sm:w-auto dark:border-white/[0.08] dark:bg-white/10 dark:text-white dark:hover:bg-white/15 dark:hover:text-white"
+                                >
+                                  {busy === "view" ? (
+                                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                  ) : (
+                                    <ShieldCheck className="mr-2 h-4 w-4" />
+                                  )}
+                                  View
+                                </Button>
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  aria-label={`Stop watching ${receivedGrantOwnerLabel(grant)}'s location`}
+                                  onClick={() => handleUnwatch(grant)}
+                                  className="w-full rounded-full border-black/[0.06] bg-transparent text-[#8e8e93] hover:bg-[#ff3b30]/10 hover:text-[#ff3b30] sm:w-auto dark:border-white/[0.08] dark:text-white/55 dark:hover:bg-[#ff453a]/15 dark:hover:text-[#ff9f9a]"
+                                >
+                                  <X className="mr-2 h-4 w-4" />
+                                  Unwatch
+                                </Button>
+                              </div>
                             ) : null}
                           </div>
                           {point ? (
@@ -4689,14 +4794,14 @@ function OneLocationAgentPageContent() {
                     <EmptyOneState
                       icon={MapPin}
                       title={
-                        hiddenReceivedGrantCount > 0
-                          ? "Open notification to view"
+                        unwatchedActiveReceivedGrantCount > 0
+                          ? "You unwatched your active shares"
                           : "Nothing shared with you"
                       }
                       description={
-                        hiddenReceivedGrantCount > 0
-                          ? "A location share is waiting in the notification bell."
-                          : "Approved recipient grants appear after you open their notification."
+                        unwatchedActiveReceivedGrantCount > 0
+                          ? "Refresh to start watching a hidden share again, or ask them to re-share."
+                          : "When someone shares their live location with you, it appears here automatically - no need to open a notification."
                       }
                     />
                   )}

--- a/hushh-webapp/lib/one-location/notifications.ts
+++ b/hushh-webapp/lib/one-location/notifications.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { AppBackgroundTaskService } from "@/lib/services/app-background-task-service";
+import { CONSENT_STATE_CHANGED_EVENT } from "@/lib/consent/consent-events";
 
 export const ONE_LOCATION_GRANT_OPENED_EVENT = "hushh:one-location-grant-opened";
 export const ONE_LOCATION_NOTIFICATION_OPEN_PARAM = "locationNotification";
@@ -12,8 +13,22 @@ export const ONE_LOCATION_SUBMISSION_ID_PARAM = "submissionId";
 export const ONE_LOCATION_SECTION_PARAM = "section";
 
 const OPENED_GRANTS_KEY_PREFIX = "one_location_opened_grants_v1";
+// Persistent (localStorage) record of every One-Location notification event we
+// have ALREADY surfaced for this user, keyed by a stable event identity. This is
+// the single source of truth for de-duplication so a notification is created at
+// most once per real event - even across page refreshes, tab switches, and
+// fresh app sessions. (The background-task store persists to sessionStorage and
+// therefore forgets dismissed notifications on reload, which is what caused the
+// duplicate / "reappearing after refresh" spam.)
+const SEEN_NOTIFICATIONS_KEY_PREFIX = "one_location_seen_notifications_v1";
+// Persistent (localStorage) set of received grant ids the recipient has chosen
+// to stop watching ("Unwatch"). Stored per-user so it survives refreshes.
+const UNWATCHED_GRANTS_KEY_PREFIX = "one_location_unwatched_grants_v1";
 const LOCATION_SHARE_TASK_KIND = "one_location_share";
 const LOCATION_WORKFLOW_TASK_KIND = "one_location_workflow";
+
+export const ONE_LOCATION_GRANT_UNWATCHED_EVENT =
+  "hushh:one-location-grant-unwatched";
 
 export type OneLocationWorkflowNotificationType =
   | "location_share_created"
@@ -133,6 +148,152 @@ export function markOneLocationGrantOpened(userId: string | null | undefined, gr
   if (typeof window !== "undefined") {
     window.dispatchEvent(
       new CustomEvent(ONE_LOCATION_GRANT_OPENED_EVENT, {
+        detail: { userId: normalizedUserId, grantId: normalizedGrantId },
+      }),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Persistent notification de-duplication ("seen" set)
+// ---------------------------------------------------------------------------
+// Every surfaced notification is keyed by a stable identity string so the same
+// real-world event never produces a second toast/bell entry. We persist this to
+// localStorage (survives refresh + new sessions), unlike the background-task
+// store which lives in sessionStorage.
+
+function seenNotificationsStorageKey(userId: string): string {
+  return `${SEEN_NOTIFICATIONS_KEY_PREFIX}:${userId}`;
+}
+
+function readSeenNotificationIds(userId: string): Set<string> {
+  const normalizedUserId = String(userId || "").trim();
+  if (!normalizedUserId) return new Set();
+  const storage = safeLocalStorage();
+  if (!storage) return new Set();
+  try {
+    const raw = storage.getItem(seenNotificationsStorageKey(normalizedUserId));
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? new Set(
+          parsed.map((item) => String(item || "").trim()).filter(Boolean),
+        )
+      : new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+function writeSeenNotificationIds(userId: string, ids: Set<string>): void {
+  const normalizedUserId = String(userId || "").trim();
+  if (!normalizedUserId) return;
+  const storage = safeLocalStorage();
+  if (!storage) return;
+  try {
+    // Cap the stored history so it can never grow unbounded.
+    const MAX_SEEN = 500;
+    const all = Array.from(ids).filter(Boolean);
+    const trimmed = all.length > MAX_SEEN ? all.slice(all.length - MAX_SEEN) : all;
+    storage.setItem(
+      seenNotificationsStorageKey(normalizedUserId),
+      JSON.stringify(trimmed),
+    );
+  } catch {
+    // Ignore storage write failures; backend still enforces access.
+  }
+}
+
+/** True if this exact notification event was already surfaced for the user. */
+export function hasSeenOneLocationNotification(
+  userId: string | null | undefined,
+  eventId: string,
+): boolean {
+  const normalizedEventId = String(eventId || "").trim();
+  if (!userId || !normalizedEventId) return false;
+  return readSeenNotificationIds(userId).has(normalizedEventId);
+}
+
+/** Mark a notification event as surfaced. Returns false if it was already seen. */
+export function markOneLocationNotificationSeen(
+  userId: string | null | undefined,
+  eventId: string,
+): boolean {
+  const normalizedUserId = String(userId || "").trim();
+  const normalizedEventId = String(eventId || "").trim();
+  if (!normalizedUserId || !normalizedEventId) return false;
+  const seen = readSeenNotificationIds(normalizedUserId);
+  if (seen.has(normalizedEventId)) return false;
+  seen.add(normalizedEventId);
+  writeSeenNotificationIds(normalizedUserId, seen);
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Recipient-side "Unwatch" (local hide of a received share)
+// ---------------------------------------------------------------------------
+// A recipient cannot revoke an owner's grant server-side, but they can choose to
+// stop watching it. We persist the hidden grant ids per-user so the choice
+// survives refresh. The backend continues to enforce real access.
+
+function unwatchedGrantsStorageKey(userId: string): string {
+  return `${UNWATCHED_GRANTS_KEY_PREFIX}:${userId}`;
+}
+
+export function readUnwatchedGrantIds(
+  userId: string | null | undefined,
+): string[] {
+  const normalizedUserId = String(userId || "").trim();
+  if (!normalizedUserId) return [];
+  const storage = safeLocalStorage();
+  if (!storage) return [];
+  try {
+    const raw = storage.getItem(unwatchedGrantsStorageKey(normalizedUserId));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.map((item) => String(item || "").trim()).filter(Boolean)
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+export function isOneLocationGrantUnwatched(
+  userId: string | null | undefined,
+  grantId: string,
+): boolean {
+  const normalizedGrantId = String(grantId || "").trim();
+  if (!userId || !normalizedGrantId) return false;
+  return readUnwatchedGrantIds(userId).includes(normalizedGrantId);
+}
+
+export function markOneLocationGrantUnwatched(
+  userId: string | null | undefined,
+  grantId: string,
+): void {
+  const normalizedUserId = String(userId || "").trim();
+  const normalizedGrantId = String(grantId || "").trim();
+  if (!normalizedUserId || !normalizedGrantId) return;
+  const current = readUnwatchedGrantIds(normalizedUserId);
+  if (!current.includes(normalizedGrantId)) {
+    const storage = safeLocalStorage();
+    if (storage) {
+      try {
+        storage.setItem(
+          unwatchedGrantsStorageKey(normalizedUserId),
+          JSON.stringify([...current, normalizedGrantId]),
+        );
+      } catch {
+        // Ignore storage write failures.
+      }
+    }
+  }
+  // Also dismiss any pending notification for this grant so it does not linger.
+  dismissOneLocationShareNotification(normalizedGrantId);
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(
+      new CustomEvent(ONE_LOCATION_GRANT_UNWATCHED_EVENT, {
         detail: { userId: normalizedUserId, grantId: normalizedGrantId },
       }),
     );
@@ -272,6 +433,38 @@ export function locationWorkflowNotificationCopy(params: {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Consent-surface routing
+// ---------------------------------------------------------------------------
+// One Location is a CONSENT feature, so its lifecycle events (share, access
+// request, approve, deny, revoke, expire) must surface in the consent
+// notification icon (the shield "Pending consents" dropdown) and the consent
+// manager tabs (Requests / Active Access / History) - NOT the general bell
+// (DebateTaskCenter / AppBackgroundTaskService). Those consent surfaces read
+// from /api/consent/center/*, which now includes One Location rows via the
+// backend OneLocationCenterContributor merge. Dispatching this event nudges the
+// consent inbox + consent manager to refetch so the new row appears promptly
+// instead of waiting for the next poll.
+function notifyConsentSurfaceRefresh(
+  notificationType: string,
+  id: string,
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.dispatchEvent(
+      new CustomEvent(CONSENT_STATE_CHANGED_EVENT, {
+        detail: {
+          source: "one_location_notification",
+          notificationType,
+          id,
+        },
+      }),
+    );
+  } catch {
+    // Best-effort: the consent surfaces also refresh on their own polling.
+  }
+}
+
 export function recordOneLocationShareNotification(params: {
   userId: string;
   grantId: string;
@@ -282,31 +475,17 @@ export function recordOneLocationShareNotification(params: {
   const userId = String(params.userId || "").trim();
   const grantId = String(params.grantId || "").trim();
   if (!userId || !grantId || isOneLocationGrantOpened(userId, grantId)) return false;
+  // The recipient explicitly stopped watching this share - never re-notify.
+  if (isOneLocationGrantUnwatched(userId, grantId)) return false;
 
-  const taskId = oneLocationGrantTaskId(grantId);
-  const existing = AppBackgroundTaskService.getTask(taskId);
-  if (existing && !existing.dismissedAt) return false;
+  // Persistent de-dup: a given share event yields at most one transient toast,
+  // ever (survives refresh, tab change, new session via localStorage).
+  const eventId = `share:${grantId}`;
+  if (hasSeenOneLocationNotification(userId, eventId)) return false;
+  markOneLocationNotificationSeen(userId, eventId);
 
-  const ownerLabel = String(params.ownerLabel || "").trim() || "A trusted person";
-  const description = locationShareNotificationDescription(ownerLabel);
-  AppBackgroundTaskService.startTask({
-    taskId,
-    userId,
-    kind: LOCATION_SHARE_TASK_KIND,
-    title: "Location shared",
-    description,
-    routeHref: buildOneLocationNotificationHref(grantId),
-    visibility: "primary",
-    groupLabel: "One Location",
-    autoClearAfterMs: 0,
-    metadata: {
-      grantId,
-      ownerLabel,
-      expiresAt: params.expiresAt || null,
-      durationHours: params.durationHours || null,
-    },
-  });
-  AppBackgroundTaskService.completeTask(taskId, description);
+  // Route to the consent surfaces (shield icon + consent manager), not the bell.
+  notifyConsentSurfaceRefresh("location_share_created", grantId);
   return true;
 }
 
@@ -323,27 +502,15 @@ export function recordOneLocationWorkflowNotification(params: {
   const id = String(params.id || "").trim();
   if (!userId || !id) return false;
 
-  const taskId = oneLocationWorkflowTaskId(params.notificationType, id);
-  const existing = AppBackgroundTaskService.getTask(taskId);
-  if (existing && !existing.dismissedAt) return false;
+  // Persistent de-dup keyed by (type, id): each consent event yields at most one
+  // transient toast, ever. This stops the "same notification again after refresh
+  // / tab change" spam (the seen-set lives in localStorage).
+  const eventId = `${params.notificationType}:${id}`;
+  if (hasSeenOneLocationNotification(userId, eventId)) return false;
+  markOneLocationNotificationSeen(userId, eventId);
 
-  AppBackgroundTaskService.startTask({
-    taskId,
-    userId,
-    kind: LOCATION_WORKFLOW_TASK_KIND,
-    title: params.title,
-    description: params.description,
-    routeHref: params.routeHref || "/one/location",
-    visibility: "primary",
-    groupLabel: "One Location",
-    autoClearAfterMs: 0,
-    metadata: {
-      notificationType: params.notificationType,
-      id,
-      ...(params.metadata || {}),
-    },
-  });
-  AppBackgroundTaskService.completeTask(taskId, params.description);
+  // Route to the consent surfaces (shield icon + consent manager), not the bell.
+  notifyConsentSurfaceRefresh(params.notificationType, id);
   return true;
 }
 


### PR DESCRIPTION
## Summary
Fixes the One Location feature across notifications, view UX, recipient controls, and the consent surfaces.

### Frontend (hushh-webapp)
- Persistent per-user localStorage seen-set keyed by stable event identity so each One Location notification surfaces once ever (kills duplicates after refresh, tab change, page load, new sessions).
- Suppress synthesized revoked/expired toasts when the owner still has an active share (re-share supersede) or the recipient unwatched — fixes false 'location removed' popups including the share-twice case.
- Decouple viewing from the notification: every active received share renders inline with the live map and survives refresh (no more 'Open notification to view').
- Add recipient-side Unwatch in 'Shared with me' (persists across refresh, silences notifications, drops the decrypted point).
- Route One Location CONSENT events (request/approve/deny/share/revoke/expire) to the consent shield icon + consent manager via consent-state-changed, NOT the general bell.

### Backend (consent-protocol)
- Enable One Location -> consent center merge by default so Requests/Active Access/History tabs populate (was env-gated OFF).
- Make list_state resilient: each section query degrades to an empty list instead of 500-ing the endpoint and emptying the consent tabs.

### Tests
- vitest one-location notifications: 6/6 (incl. consent-routing assertions)
- pytest list_state resilience: 3/3; consent-center contributor: 7/7
- eslint + py_compile clean

### Deferred (needs device repro)
- Intermittent 'geo denied while sharing' — existing foreground retry/permission-recovery handles the common path.