### PR TITLE
fix(ui): enforce explicit button types in carousel navigation

### DIFF
--- a/hushh-webapp/components/ui/carousel.tsx
+++ b/hushh-webapp/components/ui/carousel.tsx
@@ -192,6 +192,7 @@ function CarouselPrevious({
 
   return (
     <Button
+      type="button"
       data-slot="carousel-previous"
       variant={variant}
       size={size}
@@ -222,6 +223,7 @@ function CarouselNext({
 
   return (
     <Button
+      type="button"
       data-slot="carousel-next"
       variant={variant}
       size={size}


### PR DESCRIPTION
Adds explicit `type="button"` to the `CarouselPrevious` and `CarouselNext` controls in the `Carousel` component.

**Why**: Without this attribute, HTML `<button>` elements default to `type="submit"`. If a `Carousel` is utilized anywhere inside a `<form>`, clicking the navigation arrows triggers an accidental form submission. This brings the Carousel component in line with the safe button enforcement patterns used in other components.

### PR Compliance

- [x] **DCO Signed-off**: Yes
- [x] **Scope**: Single-file, frontend-only UI fix
- [x] **Safety**: No logic, backend, API, or package changes
- [x] **Behavior**: No UI redesign, refactoring, or existing behavior changes
- [x] **Hygiene**: Passes all local typecheck and linting constraints
- [x] **Focus**: Targeted strictly to the exact bug surface to avoid `pr_claim_changed_surface_mismatch`