### PR TITLE
fix(vault): enforce explicit button types in recovery key dialog

### DIFF
--- a/hushh-webapp/components/vault/recovery-key-dialog.tsx
+++ b/hushh-webapp/components/vault/recovery-key-dialog.tsx
@@ -84,6 +84,7 @@ export function RecoveryKeyDialog({
 
           <div className="grid grid-cols-2 gap-2">
             <Button
+              type="button"
               onClick={handleCopy}
               className="w-full"
             >
@@ -101,6 +102,7 @@ export function RecoveryKeyDialog({
             </Button>
 
             <Button
+              type="button"
               onClick={handleDownload}
               className="w-full"
             >
@@ -112,6 +114,7 @@ export function RecoveryKeyDialog({
 
         <DialogFooter>
           <Button
+            type="button"
             onClick={onContinue}
             variant="gradient"
             effect="glass"


### PR DESCRIPTION
Adds explicit `type="button"` attributes to the action buttons ("Copy Key", "Download", "I've Saved My Recovery Key") in the `RecoveryKeyDialog` component.

**Why**: Without this attribute, HTML `<button>` elements default to `type="submit"`. If the vault layout or dialog overlay happens to be placed within a `<form>`, clicking these actions will inadvertently trigger a form submission. This brings the vault recovery flow in line with the safe button enforcement patterns already merged into the codebase.