### PR TITLE
fix(profile): enforce explicit button type in pkm explorer panel

### DIFF
--- a/hushh-webapp/components/profile/pkm-explorer-panel.tsx
+++ b/hushh-webapp/components/profile/pkm-explorer-panel.tsx
@@ -241,6 +241,7 @@ export function PkmExplorerPanel() {
             />
           </div>
           <Button
+            type="button"
             variant="none"
             effect="fade"
             onClick={() => void handleRefresh()}


### PR DESCRIPTION
Adds an explicit `type="button"` attribute to the "Refresh saved PKM" action button in the `PkmExplorerPanel` component.

**Why**: Without this attribute, HTML `<button>` elements default to `type="submit"`. If the profile layout or settings overlay happens to be placed within a `<form>`, clicking this refresh action will inadvertently trigger a full-page form submission instead of the intended client-side state refresh. This brings the profile data management flow in line with the safe button enforcement patterns already merged into the codebase.

### PR Compliance

- [x] **DCO Signed-off**: Yes
- [x] **Scope**: Single-file, frontend-only UI fix
- [x] **Safety**: No logic, backend, API, or package changes
- [x] **Behavior**: No UI redesign, refactoring, or existing behavior changes
- [x] **Hygiene**: Passes all local typecheck and linting constraints
- [x] **Focus**: Targeted strictly to the exact bug surface to avoid `pr_claim_changed_surface_mismatch`