### PR TITLE
fix(profile): enforce explicit button types in runtime secret settings

### DIFF
--- a/hushh-webapp/components/profile/runtime-secret-settings-card.tsx
+++ b/hushh-webapp/components/profile/runtime-secret-settings-card.tsx
@@ -459,6 +459,7 @@ export function RuntimeSecretSettingsCard({
                 </div>
                 <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-2 md:flex md:flex-nowrap">
                   <Button
+                    type="button"
                     onClick={() => void handleSave(provider)}
                     disabled={
                       saving ||
@@ -481,6 +482,7 @@ export function RuntimeSecretSettingsCard({
                     )}
                   </Button>
                   <Button
+                    type="button"
                     variant="none"
                     effect="fade"
                     onClick={() => void handleRemove(provider)}


### PR DESCRIPTION
Adds explicit `type="button"` attributes to the action buttons ("Save", "Remove") in the `RuntimeSecretSettingsCard` component.

**Why**: Without this attribute, HTML `<button>` elements default to `type="submit"`. If the profile layout or API key overlay happens to be placed within a `<form>`, clicking these actions will inadvertently trigger a full-page form submission instead of the intended client-side save or delete operations. This brings the developer settings flow in line with the safe button enforcement patterns already merged into the codebase.