### PR TITLE
refactor(api): parse upstream vault error payloads as json

### DIFF
--- a/hushh-webapp/app/api/vault/primary/set/route.ts
+++ b/hushh-webapp/app/api/vault/primary/set/route.ts
@@ -52,11 +52,12 @@ export async function POST(request: NextRequest) {
     });
 
     if (!response.ok) {
-      const errorText = await response.text();
-      return NextResponse.json(
-        { error: errorText || "Backend error" },
-        { status: response.status }
-      );
+      const errorPayload = await response
+        .json()
+        .catch(async () => ({
+          error: (await response.text().catch(() => "")) || "Backend error",
+        }));
+      return NextResponse.json(errorPayload, { status: response.status });
     }
 
     const result = await response.json();


### PR DESCRIPTION
Refactors the error parsing logic inside `app/api/vault/primary/set/route.ts` to cleanly handle structured JSON errors from the upstream Python API.

**Why**: Previously, the route strictly used `await response.text()` for all non-200 responses. If the upstream API returned an actual JSON error object, it would either get double-stringified or wrapped awkwardly as `{ error: "{\"detail\":...}" }`. This refactor brings it in line with the error proxy patterns used in the other vault routes (e.g., `delete/route.ts`), ensuring the frontend receives clean, predictable error objects to map.