### PR TITLE
test(top-shell-metrics): cover empty metrics fallback

### DIFF
--- a/hushh-webapp/__tests__/components/top-shell-metrics.test.ts
+++ b/hushh-webapp/__tests__/components/top-shell-metrics.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveTopShellMetrics } from "@/components/app-ui/top-shell-metrics";
+
+describe("resolveTopShellMetrics", () => {
+  it("returns root metrics for an empty pathname", () => {
+    expect(resolveTopShellMetrics("")).toEqual({
+      shellVisible: false,
+      hasTabs: false,
+      contentOffsetMode: "normal",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for the top shell metrics empty-path fallback.
- Assert an empty pathname resolves to the root route metrics with the shell hidden and normal content offset.

## Why
This locks the existing top shell metrics fallback behavior without changing runtime code.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched integration train before the commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/components/top-shell-metrics.test.ts` only.
- This is a new test file.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/components/top-shell-metrics.test.ts`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.