### PR TITLE
test(chart): cover chart container data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/ui/chart.test.tsx
+++ b/hushh-webapp/__tests__/ui/chart.test.tsx
@@ -1,0 +1,24 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ChartContainer } from "@/components/ui/chart";
+
+vi.mock("recharts", () => ({
+  Legend: () => null,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  Tooltip: () => null,
+}));
+
+describe("ChartContainer", () => {
+  it("renders chart container data-slot contract", () => {
+    const { container } = render(
+      <ChartContainer config={{}}>
+        <div />
+      </ChartContainer>,
+    );
+
+    expect(container.querySelector('[data-slot="chart"]')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for the ChartContainer data-slot contract.
- Mock the Recharts boundary and assert the chart container renders `data-slot=chart`.

## Why
This locks the existing ChartContainer UI contract without changing runtime behavior.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched integration train before the commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/ui/chart.test.tsx` only.
- This is a new test file.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/ui/chart.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.