### PR TITLE
test(collapsible): cover content className passthrough

### DIFF
--- a/hushh-webapp/__tests__/ui/collapsible.test.tsx
+++ b/hushh-webapp/__tests__/ui/collapsible.test.tsx
@@ -42,4 +42,21 @@ describe("Collapsible", () => {
       container.querySelector('[data-slot="collapsible-content"]'),
     ).toBeTruthy();
   });
+
+  it("passes className through to content", () => {
+    const { container } = render(
+      <Collapsible defaultOpen>
+        <CollapsibleTrigger>Toggle</CollapsibleTrigger>
+        <CollapsibleContent className="custom-content-class">
+          Body
+        </CollapsibleContent>
+      </Collapsible>,
+    );
+
+    expect(
+      container
+        .querySelector('[data-slot="collapsible-content"]')
+        ?.classList.contains("custom-content-class"),
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- Add focused coverage for CollapsibleContent className passthrough.
- Assert a custom class is preserved on the rendered content element.

## Why
This locks the existing CollapsibleContent styling extension contract without changing runtime behavior.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched integration train before the commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/ui/collapsible.test.tsx` only.
- This PR appends one focused `it()` block to the existing Collapsible describe block.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/ui/collapsible.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.