### PR TITLE
test(dropdown-menu): cover separator data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/ui/dropdown-menu.test.tsx
+++ b/hushh-webapp/__tests__/ui/dropdown-menu.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   DropdownMenu,
+  DropdownMenuSeparator,
   DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
@@ -27,6 +28,14 @@ describe("DropdownMenu", () => {
 
     expect(
       container.querySelector('[data-slot="dropdown-menu-shortcut"]'),
+    ).toBeTruthy();
+  });
+
+  it("renders separator with data-slot='dropdown-menu-separator'", () => {
+    const { container } = render(<DropdownMenuSeparator />);
+
+    expect(
+      container.querySelector('[data-slot="dropdown-menu-separator"]'),
     ).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- Add focused coverage for the DropdownMenuSeparator data-slot contract.
- Assert the rendered separator exposes `data-slot=dropdown-menu-separator`.

## Why
This locks the existing dropdown menu separator UI contract without changing runtime behavior.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched integration train before the commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/ui/dropdown-menu.test.tsx` only.
- This PR appends one focused `it()` block to the existing DropdownMenu describe block.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/ui/dropdown-menu.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.