### PR TITLE
test(empty): cover empty title and description slots

### DIFF
--- a/hushh-webapp/__tests__/ui/empty.test.tsx
+++ b/hushh-webapp/__tests__/ui/empty.test.tsx
@@ -73,6 +73,24 @@ describe("Empty", () => {
     ).toBeTruthy();
   });
 
+  it("renders title and description slots together", () => {
+    const { container } = render(
+      <Empty>
+        <EmptyHeader>
+          <EmptyTitle>No matches</EmptyTitle>
+          <EmptyDescription>Adjust your filters.</EmptyDescription>
+        </EmptyHeader>
+      </Empty>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="empty-title"]')?.textContent,
+    ).toBe("No matches");
+    expect(
+      container.querySelector('[data-slot="empty-description"]')?.textContent,
+    ).toBe("Adjust your filters.");
+  });
+
   it("renders content with data-slot='empty-content'", () => {
     const { container } = render(
       <Empty>


### PR DESCRIPTION
## Summary
- Add focused coverage for rendering EmptyTitle and EmptyDescription together.
- Assert both composed slots preserve their expected content and slot selectors.

## Why
This locks the existing Empty title/description composition contract without changing runtime behavior.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched integration train before the commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/ui/empty.test.tsx` only.
- This PR appends one focused `it()` block to the existing Empty describe block.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/ui/empty.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.