### PR TITLE
test(field): cover field label data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/ui/field.test.tsx
+++ b/hushh-webapp/__tests__/ui/field.test.tsx
@@ -6,6 +6,7 @@ import {
   FieldContent,
   FieldDescription,
   FieldGroup,
+  FieldLabel,
   FieldLegend,
   FieldSet,
   FieldTitle,
@@ -61,6 +62,14 @@ describe("Field", () => {
 
   it("renders FieldTitle with data-slot='field-label'", () => {
     const { container } = render(<FieldTitle>Title</FieldTitle>);
+
+    expect(
+      container.querySelector('[data-slot="field-label"]'),
+    ).toBeTruthy();
+  });
+
+  it("renders FieldLabel with data-slot='field-label'", () => {
+    const { container } = render(<FieldLabel>Label</FieldLabel>);
 
     expect(
       container.querySelector('[data-slot="field-label"]'),


### PR DESCRIPTION
## Summary
- Add focused coverage for the FieldLabel data-slot contract.
- Assert `FieldLabel` renders with `data-slot=field-label`.

## Why
This locks the existing FieldLabel UI contract without changing runtime behavior.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched integration train before the commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/ui/field.test.tsx` only.
- This PR appends one focused `it()` block to the existing Field describe block.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/ui/field.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.