### PR TITLE
test(input): cover input data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/ui/input.test.tsx
+++ b/hushh-webapp/__tests__/ui/input.test.tsx
@@ -12,6 +12,14 @@ describe("Input", () => {
     ).toBeTruthy();
   });
 
+  it("preserves data-slot='input' when type is set", () => {
+    const { container } = render(<Input type="search" />);
+
+    expect(
+      container.querySelector('input[type="search"][data-slot="input"]'),
+    ).toBeTruthy();
+  });
+
   it("forwards className to the input element", () => {
     const { container } = render(<Input className="test-class" />);
     const el = container.querySelector('[data-slot="input"]');


### PR DESCRIPTION
## Summary
- Add focused coverage for the Input data-slot contract when an input type is provided.
- Assert a search input still renders with `data-slot=input`.

## Why
The train already covers the default Input slot. This adds a typed-input assertion without changing runtime behavior.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched integration train before the commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/ui/input.test.tsx` only.
- This PR appends one focused `it()` block to the existing Input describe block.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/ui/input.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.