### PR TITLE
test(input-group): cover addon data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/ui/input-group.test.tsx
+++ b/hushh-webapp/__tests__/ui/input-group.test.tsx
@@ -26,6 +26,20 @@ describe("InputGroup", () => {
     expect(addon?.getAttribute("role")).toBe("group");
   });
 
+  it("preserves addon data-slot when align is set", () => {
+    const { container } = render(
+      <InputGroup>
+        <InputGroupAddon align="inline-end">icon</InputGroupAddon>
+      </InputGroup>,
+    );
+
+    expect(
+      container.querySelector(
+        '[data-slot="input-group-addon"][data-align="inline-end"]',
+      ),
+    ).toBeTruthy();
+  });
+
   it("defaults addon to data-align='inline-start'", () => {
     const { container } = render(
       <InputGroup>


### PR DESCRIPTION
## Summary
- Add focused coverage for the InputGroupAddon data-slot contract when alignment is explicit.
- Assert the addon keeps `data-slot=input-group-addon` with `data-align=inline-end`.

## Why
The train already covers the default addon slot. This adds a typed variant assertion without changing runtime behavior.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched integration train before the commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/ui/input-group.test.tsx` only.
- This PR appends one focused `it()` block to the existing InputGroup describe block.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/ui/input-group.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.