### PR TITLE
test(kbd): cover keyboard shortcut data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/ui/kbd.test.tsx
+++ b/hushh-webapp/__tests__/ui/kbd.test.tsx
@@ -20,4 +20,15 @@ describe("Kbd", () => {
 
     expect(container.querySelector('[data-slot="kbd-group"]')).toBeTruthy();
   });
+
+  it("renders keyboard shortcut keys with data-slot='kbd'", () => {
+    const { container } = render(
+      <KbdGroup>
+        <Kbd>Ctrl</Kbd>
+        <Kbd>K</Kbd>
+      </KbdGroup>,
+    );
+
+    expect(container.querySelectorAll('[data-slot="kbd"]')).toHaveLength(2);
+  });
 });


### PR DESCRIPTION
## Summary
- Add focused coverage for grouped keyboard shortcut key slots.
- Assert a composed shortcut renders each key with `data-slot=kbd`.

## Why
The train already covers the base Kbd and KbdGroup slots. This adds a composed shortcut assertion without changing runtime behavior.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched integration train before the commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/ui/kbd.test.tsx` only.
- This PR appends one focused `it()` block to the existing Kbd describe block.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/ui/kbd.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.