### PR TITLE
test(label): cover label data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/ui/label.test.tsx
+++ b/hushh-webapp/__tests__/ui/label.test.tsx
@@ -10,6 +10,14 @@ describe("Label", () => {
     expect(container.querySelector('[data-slot="label"]')).toBeTruthy();
   });
 
+  it("preserves data-slot='label' when htmlFor is set", () => {
+    const { container } = render(<Label htmlFor="email">Email</Label>);
+
+    expect(
+      container.querySelector('label[for="email"][data-slot="label"]'),
+    ).toBeTruthy();
+  });
+
   it("applies disabled peer styling class", () => {
     const { container } = render(<Label>Email</Label>);
 


### PR DESCRIPTION
## Summary
- Add focused coverage for the Label data-slot contract when `htmlFor` is set.
- Assert the associated label still renders with `data-slot=label`.

## Why
The train already covers the default Label slot. This adds an associated-label assertion without changing runtime behavior.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched integration train before the commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/ui/label.test.tsx` only.
- This PR appends one focused `it()` block to the existing Label describe block.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/ui/label.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.