### PR TITLE
test(navigation): characterize resolveInternalRouteHref query string handling

### DIFF
--- a/hushh-webapp/__tests__/navigation/resolve-query-strings.test.ts
+++ b/hushh-webapp/__tests__/navigation/resolve-query-strings.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for resolveInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts), focused on how query strings ride
+// along when appended to an internal route.
+//
+// Real implementation:
+//   resolveInternalRouteHref(value, fallback) =
+//     normalizeInternalRouteHref(value) ?? fallback
+//   normalizeInternalRouteHref trims, rejects non-internal / "//" / CR|LF, and
+//   otherwise returns the (trimmed) string VERBATIM.
+//
+// Truth captured below: resolveInternalRouteHref does NOT parse, re-order, or
+// re-encode the query string. For a valid internal href it passes the query
+// portion through byte-for-byte. There is no URLSearchParams round-trip on this
+// path, so parameter order, key casing, and existing percent-encoding survive
+// exactly as written.
+
+describe("resolveInternalRouteHref — query string preservation", () => {
+  it("preserves exact parameter order verbatim (no sorting)", () => {
+    expect(
+      resolveInternalRouteHref("/profile?z=1&a=2&m=3", "/")
+    ).toBe("/profile?z=1&a=2&m=3");
+  });
+
+  it("preserves key casing verbatim (no normalization)", () => {
+    expect(
+      resolveInternalRouteHref("/one/kai?Tab=Privacy&UserId=AB12", "/")
+    ).toBe("/one/kai?Tab=Privacy&UserId=AB12");
+  });
+
+  it("preserves existing percent-encoding without re-encoding or decoding", () => {
+    expect(
+      resolveInternalRouteHref("/search?q=hello%20world&filter=a%2Bb", "/")
+    ).toBe("/search?q=hello%20world&filter=a%2Bb");
+  });
+
+  it("does not encode raw special characters already present in the query", () => {
+    // The function performs no encoding pass, so a raw space / plus / ampersand
+    // structure is returned exactly as supplied.
+    expect(
+      resolveInternalRouteHref("/x?a=1&b=c+d&e=f", "/")
+    ).toBe("/x?a=1&b=c+d&e=f");
+  });
+
+  it("preserves repeated keys and empty values verbatim", () => {
+    expect(
+      resolveInternalRouteHref("/list?tag=a&tag=b&empty=", "/")
+    ).toBe("/list?tag=a&tag=b&empty=");
+  });
+
+  it("trims surrounding whitespace but leaves the query body intact", () => {
+    expect(
+      resolveInternalRouteHref("   /profile?z=1&a=2   ", "/")
+    ).toBe("/profile?z=1&a=2");
+  });
+
+  it("falls back when the route portion itself is invalid, ignoring the query", () => {
+    // Guard fires on the route shape before any query consideration.
+    expect(
+      resolveInternalRouteHref("https://evil.example.com/?a=1", "/safe")
+    ).toBe("/safe");
+    expect(resolveInternalRouteHref("//evil?a=1", "/safe")).toBe("/safe");
+  });
+});


### PR DESCRIPTION
## Summary

Documents the explicit parameter-preservation contract of
`resolveInternalRouteHref` (`hushh-webapp/lib/navigation/routes.ts`) when query
parameters are appended to an internal route.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/navigation/...`. There
  is no top-level `__tests__` in this repo; vitest
  (`hushh-webapp/vitest.config.ts`) only includes `__tests__/**` under
  `hushh-webapp`. The runnable file therefore lives at
  `hushh-webapp/__tests__/navigation/resolve-query-strings.test.ts`.
- Behavioral truth captured: `resolveInternalRouteHref(value, fallback)` returns
  `normalizeInternalRouteHref(value) ?? fallback`. For a valid internal href,
  `normalizeInternalRouteHref` only trims and returns the string **verbatim** —
  there is no `URLSearchParams` round-trip. Consequently the query string's
  parameter **order**, key **casing**, and existing **percent-encoding** are all
  preserved exactly. Raw special characters are not re-encoded; repeated keys and
  empty values pass through untouched. When the route shape itself is invalid
  (external URL, protocol-relative `//`), the function falls back to the
  caller-supplied route regardless of the query.

## Verification

- `npm test -- __tests__/navigation/resolve-query-strings.test.ts` → 7/7 pass
- `git status` limited to the single new test file; no production source changed

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit is signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — documents real verbatim pass-through (no re-encoding/sorting)
