### PR TITLE
test(navigation): characterize normalizeInternalRouteHref trailing slash invariants

### DIFF
--- a/hushh-webapp/__tests__/navigation/normalize-trailing-slash.test.ts
+++ b/hushh-webapp/__tests__/navigation/normalize-trailing-slash.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for normalizeInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts), focused narrowly on TRAILING SLASH
+// handling.
+//
+// Real implemented guard:
+//   const href = String(value ?? "").trim();
+//   if (!href) return null;
+//   if (!href.startsWith("/") || href.startsWith("//")) return null;
+//   if (/[\r\n]/.test(href)) return null;
+//   return href;
+//
+// Truth captured below: there is NO trailing-slash policy. The function does not
+// enforce trailing-slash retention and does not strip trailing slashes. A valid
+// internal href is returned VERBATIM (after surrounding-whitespace trim only),
+// so terminal "/" characters are left un-mutated.
+
+describe("normalizeInternalRouteHref — trailing slash handling", () => {
+  it("leaves a single trailing slash un-mutated (no stripping)", () => {
+    expect(normalizeInternalRouteHref("/profile/")).toBe("/profile/");
+    expect(normalizeInternalRouteHref("/one/kai/")).toBe("/one/kai/");
+  });
+
+  it("leaves a path WITHOUT a trailing slash un-mutated (no enforcement)", () => {
+    expect(normalizeInternalRouteHref("/profile")).toBe("/profile");
+    expect(normalizeInternalRouteHref("/one/kai")).toBe("/one/kai");
+  });
+
+  it("treats with/without trailing slash as distinct outputs", () => {
+    // Documents that the two forms are NOT normalized to a single canonical form.
+    expect(normalizeInternalRouteHref("/agent/")).not.toBe(
+      normalizeInternalRouteHref("/agent")
+    );
+  });
+
+  it("preserves a query/fragment after a trailing slash verbatim", () => {
+    expect(normalizeInternalRouteHref("/profile/?tab=privacy")).toBe(
+      "/profile/?tab=privacy"
+    );
+    expect(normalizeInternalRouteHref("/terms/#Section-A")).toBe(
+      "/terms/#Section-A"
+    );
+  });
+
+  it("trims surrounding whitespace but keeps the terminal slash", () => {
+    expect(normalizeInternalRouteHref("  /profile/  ")).toBe("/profile/");
+  });
+
+  it("returns the root '/' verbatim (single slash is valid)", () => {
+    expect(normalizeInternalRouteHref("/")).toBe("/");
+  });
+
+  it("still rejects multi-slash even when it also has a trailing slash", () => {
+    // The leading "//" guard fires regardless of trailing characters.
+    expect(normalizeInternalRouteHref("//evil/")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Pins down the trailing-slash interaction behavior of `normalizeInternalRouteHref`
(`hushh-webapp/lib/navigation/routes.ts`), mapping how it handles paths with
terminal slash characters.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/navigation/...`. There
  is no top-level `__tests__` in this repo; vitest
  (`hushh-webapp/vitest.config.ts`) only includes `__tests__/**` under
  `hushh-webapp`. The runnable file therefore lives at
  `hushh-webapp/__tests__/navigation/normalize-trailing-slash.test.ts`.
- Behavioral truth captured: there is **no trailing-slash policy**. The guard is
  `trim → reject empty/non-"/"/"//"/CR|LF → return verbatim`. So the function
  neither **enforces** trailing-slash retention nor **strips** trailing slashes;
  it leaves terminal `/` characters **un-mutated**:
  - `"/profile/"` → `"/profile/"` (no stripping)
  - `"/profile"` → `"/profile"` (no enforcement)
  - `"/profile/"` and `"/profile"` are distinct outputs (no canonicalization)
  - query/fragment after a trailing slash is preserved verbatim
  - surrounding whitespace is trimmed but the terminal slash stays
  - root `"/"` is returned verbatim; `"//evil/"` is still rejected by the leading
    `//` guard.

## Verification

- `npm test -- __tests__/navigation/normalize-trailing-slash.test.ts` → 7/7 pass
- `git status` limited to the single new test file; no production source changed

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit is signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — documents real verbatim (no enforce/strip) trailing-slash behavior
