### PR TITLE
test(navigation): characterize resolveInternalRouteHref hash fragment retention

### DIFF
--- a/hushh-webapp/__tests__/navigation/resolve-hash-retention.test.ts
+++ b/hushh-webapp/__tests__/navigation/resolve-hash-retention.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for resolveInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts), focused narrowly on URL HASH /
+// FRAGMENT retention (e.g. "/settings#security").
+//
+// Real implementation:
+//   resolveInternalRouteHref(value, fallback) =
+//     normalizeInternalRouteHref(value) ?? fallback
+//   normalizeInternalRouteHref trims, rejects empty / non-internal / "//" /
+//   CR|LF, and otherwise returns the (trimmed) string VERBATIM.
+//
+// Truth captured below: there is NO fragment parsing. The "#fragment" portion is
+// not split off, decoded, lowercased, or stripped — for a valid internal href it
+// rides along byte-for-byte. Fragment casing and encoding survive exactly.
+
+describe("resolveInternalRouteHref — hash fragment retention", () => {
+  it("preserves a simple trailing hash fragment verbatim", () => {
+    expect(resolveInternalRouteHref("/settings#security", "/")).toBe(
+      "/settings#security"
+    );
+  });
+
+  it("preserves fragment casing exactly (no normalization)", () => {
+    expect(resolveInternalRouteHref("/settings#Security-Tab", "/")).toBe(
+      "/settings#Security-Tab"
+    );
+  });
+
+  it("preserves both a query string and a fragment together", () => {
+    expect(
+      resolveInternalRouteHref("/settings?tab=privacy#security", "/")
+    ).toBe("/settings?tab=privacy#security");
+  });
+
+  it("preserves an empty trailing hash ('#') verbatim", () => {
+    expect(resolveInternalRouteHref("/settings#", "/")).toBe("/settings#");
+  });
+
+  it("preserves percent-encoding inside the fragment without re-encoding", () => {
+    expect(
+      resolveInternalRouteHref("/docs#a%20b", "/")
+    ).toBe("/docs#a%20b");
+  });
+
+  it("trims surrounding whitespace but keeps the fragment intact", () => {
+    expect(resolveInternalRouteHref("  /settings#security  ", "/")).toBe(
+      "/settings#security"
+    );
+  });
+
+  it("treats the bare root with a fragment as a valid internal href", () => {
+    expect(resolveInternalRouteHref("/#top", "/")).toBe("/#top");
+  });
+
+  it("falls back when the route is external/invalid, ignoring its fragment", () => {
+    expect(
+      resolveInternalRouteHref("https://evil.example.com/#security", "/safe")
+    ).toBe("/safe");
+    expect(resolveInternalRouteHref("//evil#security", "/safe")).toBe("/safe");
+  });
+});


### PR DESCRIPTION
## Summary

Characterizes the narrow behavioral contract of `resolveInternalRouteHref`
(`hushh-webapp/lib/navigation/routes.ts`) concerning trailing hash / fragment
handling (e.g. `/settings#security`).

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/navigation/...`. There
  is no top-level `__tests__` in this repo; vitest
  (`hushh-webapp/vitest.config.ts`) only includes `__tests__/**` under
  `hushh-webapp`. The runnable file therefore lives at
  `hushh-webapp/__tests__/navigation/resolve-hash-retention.test.ts`.
- Behavioral truth captured: `resolveInternalRouteHref(value, fallback)` returns
  `normalizeInternalRouteHref(value) ?? fallback`. For a valid internal href,
  `normalizeInternalRouteHref` only trims and returns the string **verbatim** —
  there is **no fragment parsing**. The `#fragment` portion is not split off,
  decoded, lowercased, or stripped, so it rides along byte-for-byte:
  - `/settings#security` → preserved as-is
  - fragment casing preserved (`#Security-Tab`)
  - query + fragment preserved together (`?tab=privacy#security`)
  - empty trailing `#` preserved
  - percent-encoding in the fragment preserved (no re-encode/decode)
  - surrounding whitespace trimmed but fragment intact
  - `/#top` is a valid internal href
  - external/`//` routes fall back regardless of their fragment.

## Verification

- `npm test -- __tests__/navigation/resolve-hash-retention.test.ts` → 8/8 pass
- `git status` limited to the single new test file; no production source changed

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit is signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — documents real verbatim fragment pass-through (no parsing)
