### PR TITLE
fix(profile): add recaptcha-container for phone verification flow

### DIFF
--- a/hushh-webapp/app/profile/page.tsx
+++ b/hushh-webapp/app/profile/page.tsx
@@ -3947,25 +3947,28 @@ function ProfilePageContent() {
           ? "Verify a new number to replace the current one."
           : "Add a verified phone number to this account.",
         content: (
-          <PhoneVerificationFlow
-            mode={phoneNumber ? "replace" : "link"}
-            currentPhoneNumber={phoneNumber}
-            startVerification={
-              phoneNumber ? startPhoneReplacement : startPhoneVerification
-            }
-            confirmVerification={
-              phoneNumber ? confirmPhoneReplacement : confirmPhoneVerification
-            }
-            onCompleted={handleAccountPhoneCompleted}
-            onCancel={popProfileStack}
-            confirmLabel="Save phone number"
-            className="gap-5"
-            helperText={
-              phoneNumber
-                ? "Choose your country code and enter the new phone number you want to use for this account."
-                : "Choose your country code and enter your phone number. We’ll send you a verification code."
-            }
-          />
+          <>
+            <PhoneVerificationFlow
+              mode={phoneNumber ? "replace" : "link"}
+              currentPhoneNumber={phoneNumber}
+              startVerification={
+                phoneNumber ? startPhoneReplacement : startPhoneVerification
+              }
+              confirmVerification={
+                phoneNumber ? confirmPhoneReplacement : confirmPhoneVerification
+              }
+              onCompleted={handleAccountPhoneCompleted}
+              onCancel={popProfileStack}
+              confirmLabel="Save phone number"
+              className="gap-5"
+              helperText={
+                phoneNumber
+                  ? "Choose your country code and enter the new phone number you want to use for this account."
+                  : "Choose your country code and enter your phone number. We’ll send you a verification code."
+              }
+            />
+            <div id="recaptcha-container" className="min-h-0" />
+          </>
         ),
       });
     }


### PR DESCRIPTION
Merges @ahujagautam024's fix (originally #3488) directly to main.

## Summary
- Adds the missing `recaptcha-container` div to the profile page phone verification flow.
- `PhoneVerificationFlow` was rendered in `app/profile/page.tsx` without the required DOM anchor for Firebase invisible reCAPTCHA, causing a crash on every phone add/change attempt from the profile page.
- Brings the profile page to parity with `app/register-phone/page.tsx` which already has the container.

## Provenance
- Original author: Gautam Ahuja (@ahujagautam024), commit cherry-picked clean onto current main (DCO sign-off preserved).
- Supersedes #3488 (which targeted integration/pr-train); that PR is closed in favor of this main-targeted one.

## Impact Map
- Route: /profile (phone add/change)
- Trust boundary: auth/phone — reCAPTCHA verifier init
- 1 file, +22/-19