### PR TITLE
promote: @ahujagautam024 recaptcha-container profile fix → main

### DIFF
--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -5,7 +5,8 @@
     "main_allowed_head_branches": [
       "integration/pr-train",
       "maintainer/promote-damria-one-location-to-main",
-      "maintainer/promote-damria-one-location-consent"
+      "maintainer/promote-damria-one-location-consent",
+      "maintainer/promote-gautam-recaptcha-fix"
     ]
   },
   "main": {

--- a/hushh-webapp/app/profile/page.tsx
+++ b/hushh-webapp/app/profile/page.tsx
@@ -3947,25 +3947,28 @@ function ProfilePageContent() {
           ? "Verify a new number to replace the current one."
           : "Add a verified phone number to this account.",
         content: (
-          <PhoneVerificationFlow
-            mode={phoneNumber ? "replace" : "link"}
-            currentPhoneNumber={phoneNumber}
-            startVerification={
-              phoneNumber ? startPhoneReplacement : startPhoneVerification
-            }
-            confirmVerification={
-              phoneNumber ? confirmPhoneReplacement : confirmPhoneVerification
-            }
-            onCompleted={handleAccountPhoneCompleted}
-            onCancel={popProfileStack}
-            confirmLabel="Save phone number"
-            className="gap-5"
-            helperText={
-              phoneNumber
-                ? "Choose your country code and enter the new phone number you want to use for this account."
-                : "Choose your country code and enter your phone number. We’ll send you a verification code."
-            }
-          />
+          <>
+            <PhoneVerificationFlow
+              mode={phoneNumber ? "replace" : "link"}
+              currentPhoneNumber={phoneNumber}
+              startVerification={
+                phoneNumber ? startPhoneReplacement : startPhoneVerification
+              }
+              confirmVerification={
+                phoneNumber ? confirmPhoneReplacement : confirmPhoneVerification
+              }
+              onCompleted={handleAccountPhoneCompleted}
+              onCancel={popProfileStack}
+              confirmLabel="Save phone number"
+              className="gap-5"
+              helperText={
+                phoneNumber
+                  ? "Choose your country code and enter the new phone number you want to use for this account."
+                  : "Choose your country code and enter your phone number. We’ll send you a verification code."
+              }
+            />
+            <div id="recaptcha-container" className="min-h-0" />
+          </>
         ),
       });
     }


### PR DESCRIPTION
Promotes @ahujagautam024's profile-page reCAPTCHA fix directly to main (supersedes #3488 which targeted integration/pr-train).

## Commits
1. `chore(ci)` — whitelist this maintainer/promote-* branch in config/ci-governance.json (matches existing convention).
2. `fix(profile)` — add the missing `recaptcha-container` div so the profile page phone-verification flow no longer crashes (parity with register-phone). Original author Gautam Ahuja, cherry-picked clean onto main, DCO preserved.

## Verification
- All CI gates passed on the original #3488 (Web/Next.js, Integration, Governance, Secret Scan, DCO).
- 1 file of product code changed (+22/-19), 1 governance line added.
- Closes #3488.