### PR TITLE
promote: Gautam maintainer governance (ci-governance + apply script + drain-to-zero) → main

### DIFF
--- a/.codex/skills/pr-governance-review/scripts/automation/pr_train_autodrive.py
+++ b/.codex/skills/pr-governance-review/scripts/automation/pr_train_autodrive.py
@@ -92,15 +92,44 @@ def detect_repass(cr):
             if last_rev and last_act and last_act>last_rev: repass.append(n)
     return sorted(repass)
 
-def engine_scan(prs,tag,max_chunks):
+def engine_scan(prs,tag,max_chunks,max_age_s=7200):
+    """Scan actionable PRs in chunks of 50, caching each chunk's engine report.
+
+    REALTIME-DRAIN CACHE SEMANTICS (fixed 2026-06): the per-chunk cache file is
+    keyed by chunk INDEX, but the actionable PR set changes every run (new PRs,
+    repass activity). A stale cache therefore silently skips freshly-opened PRs
+    (the June-19 tranche bug). We now invalidate a cached chunk when EITHER:
+      (a) it is older than ``max_age_s`` (default 2h), OR
+      (b) the exact PR-number set in that chunk differs from what the cache was
+          built for (membership drift).
+    The cache stores the chunk's PR list alongside the reports so (b) is exact.
+    """
     os.makedirs(WORK,exist_ok=True)
     chunks=[prs[i:i+50] for i in range(0,len(prs),50)][:max_chunks]
     reps={}
     for idx,ch in enumerate(chunks):
         out=f"{WORK}/{tag}-{idx}.json"
-        if not os.path.exists(out):
+        fresh=False
+        if os.path.exists(out):
+            try:
+                age=time.time()-os.path.getmtime(out)
+                cached=json.load(open(out))
+                cached_prs=cached.get("_autodrive_chunk_prs")
+                # Fresh only if young AND same membership as this run's chunk.
+                fresh=(age<=max_age_s and cached_prs==list(ch))
+            except Exception:
+                fresh=False
+        if not fresh:
             run(["python3",ENGINE,"--repo",REPO,"--prs",",".join(map(str,ch)),
                  "--repass-after-changes","--json","--output",out],timeout=420,retries=1)
+            # Tag the freshly written report with the chunk's PR set so the next
+            # run can detect membership drift and avoid stale reuse.
+            try:
+                d=json.load(open(out))
+                d["_autodrive_chunk_prs"]=list(ch)
+                json.dump(d,open(out,"w"),default=str)
+            except Exception:
+                pass
         if os.path.exists(out):
             d=json.load(open(out))
             for r in d["reports"]:
@@ -158,8 +187,13 @@ def post_record(n,body,head=None):
 
 def main():
     ap=argparse.ArgumentParser()
-    ap.add_argument("--max-merge",type=int,default=40)
-    ap.add_argument("--max-chunks",type=int,default=8)
+    # Drain-to-zero defaults (2026-06): the goal is MINIMUM standing backlog —
+    # every actionable PR (unattended + repass) is driven to terminal each run,
+    # not a fixed slice. First cycle is heavy; steady state is light because only
+    # newly-opened or newly-updated (repass) PRs remain actionable. Override with
+    # smaller values for a quick partial pass. max-chunks 200 ⇒ up to 10k PRs/run.
+    ap.add_argument("--max-merge",type=int,default=10000)
+    ap.add_argument("--max-chunks",type=int,default=200)
     a=ap.parse_args()
     res={"queued":[],"block_recorded":[],"operator_patch":[],"security_review":[],
          "conflicting":[],"collision_defer":[],"self_hold":[],"skipped":[],"fail":[],

--- a/.codex/skills/repo-operations/SKILL.md
+++ b/.codex/skills/repo-operations/SKILL.md
@@ -63,6 +63,61 @@ Non-owned surfaces:
 8. For local runtime/server work, follow `branch-runtime-ops.md` for visible terminal defaults, inline override, restart, and health-probe rules.
 9. For UAT runtime failures, start with the repo RCA command before editing or redeploying.
 
+## Maintainer Allowlist & Merge-to-Main (standardized — do this once)
+
+`config/ci-governance.json` is the SINGLE SOURCE OF TRUTH for who can approve/merge
+to `main` and who can deploy. Editing that file is the ONLY thing a maintainer
+authors; one apply command pushes the intent to GitHub. Never click GitHub
+settings by hand — that is exactly what drifts.
+
+The four allowlists in `config/ci-governance.json`:
+
+1. `main.review_bypass_users` — can satisfy the required review on `main`
+   (a single-maintainer PR can self-clear the approval gate).
+2. `main.merge_queue_bypass_users` — backed by the org team
+   `allowed-maintainers-to-approve`; team membership IS this list.
+3. `uat.manual_dispatch_users` — can run the UAT deploy workflow.
+4. `production.manual_dispatch_users` — can run the production deploy (kept tiny).
+
+### To add (or remove) a maintainer — end to end
+
+```bash
+# 1. Edit the JSON. Add the GitHub login to the relevant list(s). For a full
+#    maintainer add the login to: main.review_bypass_users,
+#    main.merge_queue_bypass_users, and uat.manual_dispatch_users.
+#    (production stays restricted — add only on explicit owner instruction.)
+
+# 2. Push the intent to GitHub (idempotent; dry-run first).
+python3 scripts/ci/apply-governance.py            # dry-run: shows the plan
+python3 scripts/ci/apply-governance.py --apply    # writes branch protection + team
+
+# 3. Confirm zero drift.
+./scripts/ci/verify-main-branch-protection.sh     # must print ✅, no ERROR lines
+
+# 4. Land the JSON change through the train (it is a protected_pipeline_path).
+```
+
+Why both an apply AND a verify script: `apply-governance.py` is the write side
+(JSON -> GitHub); `verify-main-branch-protection.sh` is the read side (drift
+detection, runs in CI). They are mirror images. If verify ever reports drift,
+run apply.
+
+### "How do I merge my own PR to main?" (maintainer FAQ)
+
+Direct topic-branch PRs into `main` are blocked by `PR Base Policy`. Two
+sanctioned paths:
+
+- DEFAULT: target `integration/pr-train`. The train promotes to `main`.
+- PROMOTION (maintainer fast-path): branch named `maintainer/promote-*`, add
+  that exact branch name to `branch_flow.main_allowed_head_branches` (same JSON),
+  open the PR to `main`. Because you are in `main.review_bypass_users` and
+  `merge_queue_bypass_users` (after step 2 above), you can approve + enqueue your
+  own promotion PR. `gh pr merge <n> --squash --admin` works for the cohort.
+
+UAT deploy needs NO GitHub sync — `scripts/ci/assert-governed-actor.py` reads
+`uat.manual_dispatch_users` from the JSON at workflow runtime. Being in the list
+is sufficient.
+
 ## Handoff Rules
 
 1. Broad repo orientation starts with `repo-context`.
@@ -80,5 +135,6 @@ Non-owned surfaces:
 ./bin/hushh docs verify
 ./bin/hushh ci
 ./scripts/ci/verify-main-branch-protection.sh
+./scripts/ci/apply-governance.py            # write side: sync ci-governance.json -> GitHub (use --apply)
 ./scripts/ci/verify-production-environment-governance.sh
 ```

--- a/.codex/skills/repo-operations/SKILL.md
+++ b/.codex/skills/repo-operations/SKILL.md
@@ -62,61 +62,7 @@ Non-owned surfaces:
 7. For DB migration/contract changes, run the DB release gate before calling UAT ready.
 8. For local runtime/server work, follow `branch-runtime-ops.md` for visible terminal defaults, inline override, restart, and health-probe rules.
 9. For UAT runtime failures, start with the repo RCA command before editing or redeploying.
-
-## Maintainer Allowlist & Merge-to-Main (standardized — do this once)
-
-`config/ci-governance.json` is the SINGLE SOURCE OF TRUTH for who can approve/merge
-to `main` and who can deploy. Editing that file is the ONLY thing a maintainer
-authors; one apply command pushes the intent to GitHub. Never click GitHub
-settings by hand — that is exactly what drifts.
-
-The four allowlists in `config/ci-governance.json`:
-
-1. `main.review_bypass_users` — can satisfy the required review on `main`
-   (a single-maintainer PR can self-clear the approval gate).
-2. `main.merge_queue_bypass_users` — backed by the org team
-   `allowed-maintainers-to-approve`; team membership IS this list.
-3. `uat.manual_dispatch_users` — can run the UAT deploy workflow.
-4. `production.manual_dispatch_users` — can run the production deploy (kept tiny).
-
-### To add (or remove) a maintainer — end to end
-
-```bash
-# 1. Edit the JSON. Add the GitHub login to the relevant list(s). For a full
-#    maintainer add the login to: main.review_bypass_users,
-#    main.merge_queue_bypass_users, and uat.manual_dispatch_users.
-#    (production stays restricted — add only on explicit owner instruction.)
-
-# 2. Push the intent to GitHub (idempotent; dry-run first).
-python3 scripts/ci/apply-governance.py            # dry-run: shows the plan
-python3 scripts/ci/apply-governance.py --apply    # writes branch protection + team
-
-# 3. Confirm zero drift.
-./scripts/ci/verify-main-branch-protection.sh     # must print ✅, no ERROR lines
-
-# 4. Land the JSON change through the train (it is a protected_pipeline_path).
-```
-
-Why both an apply AND a verify script: `apply-governance.py` is the write side
-(JSON -> GitHub); `verify-main-branch-protection.sh` is the read side (drift
-detection, runs in CI). They are mirror images. If verify ever reports drift,
-run apply.
-
-### "How do I merge my own PR to main?" (maintainer FAQ)
-
-Direct topic-branch PRs into `main` are blocked by `PR Base Policy`. Two
-sanctioned paths:
-
-- DEFAULT: target `integration/pr-train`. The train promotes to `main`.
-- PROMOTION (maintainer fast-path): branch named `maintainer/promote-*`, add
-  that exact branch name to `branch_flow.main_allowed_head_branches` (same JSON),
-  open the PR to `main`. Because you are in `main.review_bypass_users` and
-  `merge_queue_bypass_users` (after step 2 above), you can approve + enqueue your
-  own promotion PR. `gh pr merge <n> --squash --admin` works for the cohort.
-
-UAT deploy needs NO GitHub sync — `scripts/ci/assert-governed-actor.py` reads
-`uat.manual_dispatch_users` from the JSON at workflow runtime. Being in the list
-is sufficient.
+10. To add/remove a maintainer or change deploy/merge authority, edit `config/ci-governance.json` (single source of truth) then run `python3 scripts/ci/apply-governance.py --apply` to sync GitHub; the JSON edit must LAND ON MAIN for runtime UAT/merge gates to see it. Full runbook in `docs/reference/operations/branch-governance.md` ("Adding or removing a maintainer").
 
 ## Handoff Rules
 
@@ -135,6 +81,6 @@ is sufficient.
 ./bin/hushh docs verify
 ./bin/hushh ci
 ./scripts/ci/verify-main-branch-protection.sh
-./scripts/ci/apply-governance.py            # write side: sync ci-governance.json -> GitHub (use --apply)
+./scripts/ci/apply-governance.py
 ./scripts/ci/verify-production-environment-governance.sh
 ```

--- a/.codex/skills/repo-operations/skill.json
+++ b/.codex/skills/repo-operations/skill.json
@@ -43,6 +43,7 @@
     "./bin/hushh docs verify",
     "./bin/hushh ci",
     "./scripts/ci/verify-main-branch-protection.sh",
+    "./scripts/ci/apply-governance.py",
     "./scripts/ci/verify-production-environment-governance.sh"
   ],
   "verification_bundles": [

--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -22,7 +22,8 @@
       "ankitkumarsingh1702",
       "azfx",
       "Jhumma-hushh",
-      "DamriaNeelesh"
+      "DamriaNeelesh",
+      "ahujagautam024"
     ],
     "review_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_required": true,
@@ -35,7 +36,8 @@
       "ankitkumarsingh1702",
       "azfx",
       "Jhumma-hushh",
-      "DamriaNeelesh"
+      "DamriaNeelesh",
+      "ahujagautam024"
     ],
     "protected_pipeline_edit_users": [
       "kushaltrivedi5",
@@ -43,7 +45,8 @@
       "ankitkumarsingh1702",
       "azfx",
       "Jhumma-hushh",
-      "DamriaNeelesh"
+      "DamriaNeelesh",
+      "ahujagautam024"
     ],
     "protected_pipeline_paths": [
       ".github/workflows/",
@@ -65,7 +68,8 @@
       "ankitkumarsingh1702",
       "azfx",
       "Jhumma-hushh",
-      "DamriaNeelesh"
+      "DamriaNeelesh",
+      "ahujagautam024"
     ],
     "review_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_required": true,
@@ -78,7 +82,8 @@
       "ankitkumarsingh1702",
       "azfx",
       "Jhumma-hushh",
-      "DamriaNeelesh"
+      "DamriaNeelesh",
+      "ahujagautam024"
     ]
   },
   "uat": {
@@ -91,7 +96,8 @@
       "ankitkumarsingh1702",
       "azfx",
       "Jhumma-hushh",
-      "DamriaNeelesh"
+      "DamriaNeelesh",
+      "ahujagautam024"
     ]
   },
   "production": {

--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -6,7 +6,8 @@
       "integration/pr-train",
       "maintainer/promote-damria-one-location-to-main",
       "maintainer/promote-damria-one-location-consent",
-      "maintainer/promote-gautam-recaptcha-fix"
+      "maintainer/promote-gautam-recaptcha-fix",
+      "maintainer/promote-governance-gautam-maintainer"
     ]
   },
   "main": {

--- a/docs/reference/operations/branch-governance.md
+++ b/docs/reference/operations/branch-governance.md
@@ -75,7 +75,7 @@ Before deleting a local backup branch, classify its unique commits as:
 
 1. UAT deploys only through a manual workflow dispatch with an explicit green `main` SHA.
 2. The workflow checks out that exact chosen green `main` SHA.
-3. Manual dispatch is limited to the maintainer cohort in `config/ci-governance.json` (`uat.manual_dispatch_users`): `kushaltrivedi5`, `RGlodAkshat`, `ankitkumarsingh1702`, `azfx`, `Jhumma-hushh`, and `DamriaNeelesh`. This list is held equal to the merge cohort (`main.review_bypass_users`) by design — anyone trusted to land code on `main` may validate it in the UAT sandbox — and `scripts/ci/verify-deployment-environment-governance.py` fails if the two drift apart.
+3. Manual dispatch is limited to the maintainer cohort in `config/ci-governance.json` (`uat.manual_dispatch_users`) — see that file for the live list (do not hardcode names here; they drift). This list is held equal to the merge cohort (`main.review_bypass_users`) by design — anyone trusted to land code on `main` may validate it in the UAT sandbox — and `scripts/ci/verify-deployment-environment-governance.py` fails if the two drift apart. To change the cohort, edit the JSON then run `python3 scripts/ci/apply-governance.py --apply` (see "Adding or removing a maintainer" below).
 4. Workflow preflight fails if the requested SHA is not reachable from `origin/main`.
 5. Workflow preflight also fails if the SHA does not already have a successful `Main Post-Merge Smoke Gate`.
 6. The canonical GitHub deployment environment for this lane is `uat`.
@@ -135,8 +135,8 @@ outside it, and the boundaries are enforced, not informal:
 
 | Ring | Who | Authority | Source of truth |
 |---|---|---|---|
-| Merge cohort | `allowed-maintainers-to-approve` team (6) | bypass review + queue, edit pipeline | `main.review_bypass_users` / `merge_queue_bypass_users` / `protected_pipeline_edit_users` |
-| UAT deploy cohort | same 6 | dispatch UAT deploy of a green `main` SHA | `uat.manual_dispatch_users` (held == merge cohort) |
+| Merge cohort | `allowed-maintainers-to-approve` team | bypass review + queue, edit pipeline | `main.review_bypass_users` / `merge_queue_bypass_users` / `protected_pipeline_edit_users` |
+| UAT deploy cohort | same as merge cohort | dispatch UAT deploy of a green `main` SHA | `uat.manual_dispatch_users` (held == merge cohort) |
 | Production deploy cohort | `kushaltrivedi5` only | dispatch production deploy | `production.manual_dispatch_users` |
 
 Invariants enforced in CI by `verify-deployment-environment-governance.py`:
@@ -153,6 +153,39 @@ Changes to `manual_dispatch_users` (UAT or production) and to the maintainer
 cohort lists are protected-surface edits: they require maintainer-team code-owner
 review, pass the CI guard, and should be authored/merged by the owner. Widening
 who can deploy is never a routine, self-mergeable change.
+
+### Adding or removing a maintainer (the one standardized procedure)
+
+`config/ci-governance.json` is the single source of truth. Editing it is the only
+thing you author. One apply command pushes it to GitHub — never edit GitHub
+settings by hand, that is what drifts (and silently leaves a "maintainer" who
+cannot actually approve on `main`).
+
+```bash
+# 1. Edit config/ci-governance.json. For a full maintainer, add the GitHub login to:
+#      main.review_bypass_users
+#      main.merge_queue_bypass_users
+#      uat.manual_dispatch_users        (held equal to the merge cohort)
+#    Leave production.manual_dispatch_users = ["kushaltrivedi5"] unless the owner says otherwise.
+
+# 2. Push intent to GitHub (idempotent). Dry-run first, then apply:
+python3 scripts/ci/apply-governance.py
+python3 scripts/ci/apply-governance.py --apply
+
+# 3. Confirm no drift (these run in CI too):
+./scripts/ci/verify-main-branch-protection.sh
+python3 scripts/ci/verify-deployment-environment-governance.py
+
+# 4. Land the JSON edit through the train (it is a protected_pipeline_path —
+#    needs maintainer-team review and should be merged by the owner).
+```
+
+`apply-governance.py` is the write side (JSON → GitHub branch-protection
+review-bypass + the `allowed-maintainers-to-approve` team). The `verify-*`
+scripts are the read side (drift detection). They are mirror images: if a verify
+reports drift, run apply. UAT/production deploy authority needs no GitHub sync —
+`scripts/ci/assert-governed-actor.py` reads `manual_dispatch_users` from the JSON
+at workflow runtime.
 
 ## Hotfix Playbook
 
@@ -202,8 +235,8 @@ Current operating note:
 - admin ownership does not count as an independent PR approval
 - require approval of the most recent push is enabled, so stale approvals cannot carry newly pushed code
 - a PR author cannot self-approve through GitHub; sanctioned maintainer "self approval" means explicit branch-protection bypass, not a counted GitHub review
-- the current live branch protection review-bypass allowlist is `kushaltrivedi5`, `RGlodAkshat`, `ankitkumarsingh1702`, `azfx`, `Jhumma-hushh`, and `DamriaNeelesh`
-- the current live merge-queue bypass team is `Allowed Maintainers to Approve`, containing those same 6 users only
+- the current live branch protection review-bypass allowlist is whatever `config/ci-governance.json` `main.review_bypass_users` declares (kept in sync by `scripts/ci/apply-governance.py`); do not transcribe names here — they drift
+- the current live merge-queue bypass team is `Allowed Maintainers to Approve`, whose membership equals `main.merge_queue_bypass_users`
 - the sanctioned review-bypass cohort is intentional policy and should not be reported as governance drift when it matches `config/ci-governance.json`
 - if an admin needs to proceed on a green PR, verify whether the live ruleset allows queue entry; do not assume approval is implicitly satisfied
 - bypass actors may waive review through branch protection and bypass queue through the dedicated owner team path

--- a/scripts/ci/apply-governance.py
+++ b/scripts/ci/apply-governance.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Hushh
+"""Apply config/ci-governance.json to live GitHub state — the SINGLE command.
+
+This is the write-side counterpart to verify-main-branch-protection.sh (which is
+read-only / drift-detection). Editing config/ci-governance.json is the ONLY
+action a maintainer needs: this script pushes that intent to GitHub so the live
+state matches the committed policy.
+
+WHAT IT SYNCS (all idempotent — safe to re-run):
+  1. main branch protection `review_bypass_users`
+       <- main.review_bypass_users
+     (the list that was silently drifting: editing the JSON never reached GitHub,
+      so a maintainer added to the JSON still couldn't approve/merge to main.)
+  2. The `allowed-maintainers-to-approve` org team membership
+       <- union(main.review_bypass_users, main.merge_queue_bypass_users)
+     (this team is the merge-queue bypass actor list; membership IS the allowlist.)
+  3. UAT / production deploy allowlists need NO GitHub action — assert-governed-actor.py
+     reads uat.manual_dispatch_users / production.manual_dispatch_users from this
+     same JSON at workflow runtime. This script just reports them for transparency.
+
+USAGE:
+  python3 scripts/ci/apply-governance.py            # dry-run: show the plan, change nothing
+  python3 scripts/ci/apply-governance.py --apply    # actually push to GitHub
+
+After --apply, scripts/ci/verify-main-branch-protection.sh should pass clean.
+
+Requires: gh CLI authenticated with org admin (to edit team membership) and
+repo admin (to edit branch protection).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = "hushh-labs/hushh-research"
+ORG = "hushh-labs"
+TEAM_SLUG = "allowed-maintainers-to-approve"
+BRANCH = "main"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+POLICY_PATH = REPO_ROOT / "config" / "ci-governance.json"
+
+
+def gh(args: list[str], *, check: bool = True) -> tuple[int, str, str]:
+    p = subprocess.run(["gh", *args], capture_output=True, text=True)
+    if check and p.returncode != 0:
+        raise SystemExit(f"gh {' '.join(args)} failed:\n{p.stderr.strip()}")
+    return p.returncode, p.stdout, p.stderr
+
+
+def gh_json(args: list[str]):
+    _, out, _ = gh(args)
+    return json.loads(out) if out.strip() else None
+
+
+def load_policy() -> dict:
+    return json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+
+
+def desired_review_bypass(policy: dict) -> list[str]:
+    return sorted(set(policy["main"]["review_bypass_users"]))
+
+
+def desired_team_members(policy: dict) -> list[str]:
+    # The team backs merge-queue bypass; keep it the union of both main allowlists
+    # so a maintainer added to either list is fully empowered (approve + queue).
+    m = policy["main"]
+    return sorted(set(m["review_bypass_users"]) | set(m["merge_queue_bypass_users"]))
+
+
+def current_review_bypass() -> list[str]:
+    data = gh_json(["api", f"repos/{REPO}/branches/{BRANCH}/protection"])
+    users = (
+        (data or {})
+        .get("required_pull_request_reviews", {})
+        .get("bypass_pull_request_allowances", {})
+        .get("users", [])
+    )
+    return sorted(u["login"] for u in users if u.get("login"))
+
+
+def current_team_members() -> list[str]:
+    members = gh_json(["api", f"orgs/{ORG}/teams/{TEAM_SLUG}/members", "--paginate"]) or []
+    return sorted(m["login"] for m in members if m.get("login"))
+
+
+def apply_review_bypass(desired: list[str], *, apply: bool) -> bool:
+    """PUT the full required_pull_request_reviews object with the desired user
+    bypass list. We preserve every other review setting read from live state so
+    nothing else is reset. Returns True if a change was (or would be) made."""
+    cur = current_review_bypass()
+    if cur == desired:
+        print(f"  ✓ review_bypass_users already in sync: {desired}")
+        return False
+    print(f"  Δ review_bypass_users: {cur}  ->  {desired}")
+    if not apply:
+        return True
+
+    # Read the live review object to preserve all sibling settings.
+    data = gh_json(["api", f"repos/{REPO}/branches/{BRANCH}/protection"]) or {}
+    rpr = data.get("required_pull_request_reviews", {})
+    bp = rpr.get("bypass_pull_request_allowances", {})
+    team_slugs = [t["slug"] for t in bp.get("teams", []) if t.get("slug")]
+    app_slugs = [a.get("slug") for a in bp.get("apps", []) if a.get("slug")]
+
+    payload = {
+        "dismiss_stale_reviews": bool(rpr.get("dismiss_stale_reviews", False)),
+        "require_code_owner_reviews": bool(rpr.get("require_code_owner_reviews", False)),
+        "require_last_push_approval": bool(rpr.get("require_last_push_approval", False)),
+        "required_approving_review_count": int(rpr.get("required_approving_review_count", 1)),
+        "bypass_pull_request_allowances": {
+            "users": desired,
+            "teams": team_slugs,
+            "apps": app_slugs,
+        },
+    }
+    # PATCH only the required_pull_request_reviews sub-resource (leaves status
+    # checks, enforce_admins, etc. untouched).
+    proc = subprocess.run(
+        ["gh", "api", "--method", "PATCH",
+         f"repos/{REPO}/branches/{BRANCH}/protection/required_pull_request_reviews",
+         "--input", "-"],
+        input=json.dumps(payload), capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        raise SystemExit(f"Failed to update review bypass:\n{proc.stderr.strip()}")
+    print("  ✅ review_bypass_users updated on GitHub")
+    return True
+
+
+def apply_team_membership(desired: list[str], *, apply: bool) -> bool:
+    cur = set(current_team_members())
+    want = set(desired)
+    to_add = sorted(want - cur)
+    to_remove = sorted(cur - want)
+    if not to_add and not to_remove:
+        print(f"  ✓ team '{TEAM_SLUG}' membership already in sync: {sorted(want)}")
+        return False
+    if to_add:
+        print(f"  Δ team add: {to_add}")
+    if to_remove:
+        print(f"  Δ team remove: {to_remove}")
+    if not apply:
+        return True
+    for login in to_add:
+        gh(["api", "--method", "PUT",
+            f"orgs/{ORG}/teams/{TEAM_SLUG}/memberships/{login}",
+            "-f", "role=maintainer"])
+        print(f"  ✅ added {login} to {TEAM_SLUG}")
+    for login in to_remove:
+        gh(["api", "--method", "DELETE",
+            f"orgs/{ORG}/teams/{TEAM_SLUG}/memberships/{login}"])
+        print(f"  ✅ removed {login} from {TEAM_SLUG}")
+    return True
+
+
+def report_deploy_allowlists(policy: dict) -> None:
+    uat = policy.get("uat", {}).get("manual_dispatch_users", [])
+    prod = policy.get("production", {}).get("manual_dispatch_users", [])
+    print("\nDeploy allowlists (config-driven — no GitHub sync needed; "
+          "assert-governed-actor.py reads these at workflow runtime):")
+    print(f"  UAT  manual_dispatch_users:        {sorted(uat)}")
+    print(f"  PROD manual_dispatch_users:        {sorted(prod)}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--apply", action="store_true",
+                    help="Push changes to GitHub. Without this, runs dry (plan only).")
+    args = ap.parse_args()
+
+    if not POLICY_PATH.exists():
+        raise SystemExit(f"Policy file not found: {POLICY_PATH}")
+    policy = load_policy()
+
+    mode = "APPLY" if args.apply else "DRY-RUN (no changes — pass --apply to push)"
+    print(f"=== apply-governance [{mode}] — source: config/ci-governance.json ===\n")
+
+    print("1. main branch protection review_bypass_users")
+    changed_a = apply_review_bypass(desired_review_bypass(policy), apply=args.apply)
+
+    print(f"\n2. org team '{TEAM_SLUG}' membership (merge-queue bypass actors)")
+    changed_b = apply_team_membership(desired_team_members(policy), apply=args.apply)
+
+    report_deploy_allowlists(policy)
+
+    print()
+    if not args.apply and (changed_a or changed_b):
+        print("Plan has changes. Re-run with --apply to push them to GitHub.")
+        return 0
+    if args.apply:
+        print("✅ Governance applied. Run scripts/ci/verify-main-branch-protection.sh to confirm.")
+    else:
+        print("✅ Live GitHub state already matches config/ci-governance.json.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Lands the governance changes on main so runtime gates see them. The UAT deploy gate (#28126546486) refused ahujagautam024 because main's config/ci-governance.json never had him — this fixes that at the source of truth.

## Commits
1. chore(governance): add ahujagautam024 to allowlists (uat.manual_dispatch_users, main.review_bypass_users, merge_queue_bypass_users, protected_pipeline_edit_users).
2. fix(pr-governance): realtime drain-to-zero autodrive (cache invalidation by age+membership, uncapped defaults).
3. feat(governance): scripts/ci/apply-governance.py (one-command JSON→GitHub sync) + standardized maintainer/merge-to-main runbook in repo-operations SKILL.md and docs/reference/operations/branch-governance.md.
4. chore(ci): whitelist this promotion branch.

## Why direct-to-main
config/ci-governance.json is a protected_pipeline_path and runtime deploy/merge gates read it from main. Promotion branch follows the maintainer/promote-* convention.

After merge: re-run Deploy to UAT for the latest green main SHA as ahujagautam024 to confirm his access end-to-end.