### PR TITLE
fix(deploy-uat): harden Deployment summary against empty timing epoch → main

### DIFF
--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -897,7 +897,10 @@ jobs:
         run: |
           set -euo pipefail
           {
-            total_seconds=$(( $(date +%s) - ${{ steps.timing-start.outputs.epoch }} ))
+            total_seconds=$(( $(date +%s) - ${{ steps.timing-start.outputs.epoch || '0' }} ))
+            if [ "${{ steps.timing-start.outputs.epoch || '' }}" = "" ]; then
+              total_seconds=0
+            fi
             backend_build_seconds="${{ steps.deploy-backend.outputs.duration_seconds || '0' }}"
             frontend_build_seconds="${{ steps.deploy-frontend.outputs.duration_seconds || '0' }}"
             build_seconds=$(( backend_build_seconds + frontend_build_seconds ))

--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -7,7 +7,8 @@
       "maintainer/promote-damria-one-location-to-main",
       "maintainer/promote-damria-one-location-consent",
       "maintainer/promote-gautam-recaptcha-fix",
-      "maintainer/promote-governance-gautam-maintainer"
+      "maintainer/promote-governance-gautam-maintainer",
+      "maintainer/promote-uat-summary-hardening"
     ]
   },
   "main": {


### PR DESCRIPTION
Defensive fix surfaced while debugging the failed UAT deploy of Gautam's promotion.

## Problem
The `always()` 'Deployment summary' step computes `$(( $(date +%s) - <timing-start.epoch> ))`. When an early gate (actor policy / branch assert) fails BEFORE 'Capture deployment timing start' runs, `epoch` is empty → `$(( 1782331876 -  ))` bash syntax error, which masks the real failure with a confusing arithmetic error.

## Fix
Default epoch to 0 and zero `total_seconds` when unset, so the summary degrades gracefully and the true root-cause failure surfaces in logs.

1 workflow file + whitelist line. No behavior change on the happy path.