### PR TITLE
test(popover): cover popover content data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/ui/popover.test.tsx
+++ b/hushh-webapp/__tests__/ui/popover.test.tsx
@@ -36,6 +36,22 @@ describe("Popover", () => {
     ).toBeTruthy();
   });
 
+  it("preserves PopoverContent data-slot when className is provided", () => {
+    render(
+      <Popover defaultOpen>
+        <PopoverTrigger>Open</PopoverTrigger>
+        <PopoverContent className="custom-popover-content">
+          Content
+        </PopoverContent>
+      </Popover>,
+    );
+
+    const content = document.querySelector('[data-slot="popover-content"]');
+
+    expect(content).toBeTruthy();
+    expect(content?.classList.contains("custom-popover-content")).toBe(true);
+  });
+
   it("renders PopoverHeader with data-slot='popover-header'", () => {
     const { container } = render(<PopoverHeader />);
 


### PR DESCRIPTION
## Summary
- Add focused coverage for the PopoverContent data-slot contract.
- Assert the rendered popover content keeps `data-slot=popover-content` when a custom className is passed.

## Why
This locks the PopoverContent slot contract through the className passthrough path without changing runtime behavior.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched `integration/pr-train` head before this commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/ui/popover.test.tsx` only.
- This PR adds one focused PopoverContent test for the className passthrough path.
- The existing train test covers the default-open content slot presence; this PR covers that the same content slot contract is preserved when consumer classes are merged.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/ui/popover.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.