### PR TITLE
test(select): cover select trigger data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/ui/select.test.tsx
+++ b/hushh-webapp/__tests__/ui/select.test.tsx
@@ -22,6 +22,21 @@ describe("Select", () => {
     ).toBeTruthy();
   });
 
+  it("preserves trigger data-slot when className is provided", () => {
+    const { container } = render(
+      <Select>
+        <SelectTrigger className="custom-select-trigger">
+          <SelectValue placeholder="Pick one" />
+        </SelectTrigger>
+      </Select>,
+    );
+
+    const trigger = container.querySelector('[data-slot="select-trigger"]');
+
+    expect(trigger).toBeTruthy();
+    expect(trigger?.classList.contains("custom-select-trigger")).toBe(true);
+  });
+
   it("defaults trigger to data-size='default'", () => {
     const { container } = render(
       <Select>


### PR DESCRIPTION
## Summary
- Add focused coverage for the SelectTrigger data-slot contract.
- Assert the rendered select trigger keeps `data-slot=select-trigger` when a custom className is passed.

## Why
This locks the SelectTrigger slot contract through the className passthrough path without changing runtime behavior.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched `integration/pr-train` head before this commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/ui/select.test.tsx` only.
- This PR adds one focused SelectTrigger test for the className passthrough path.
- The existing train test covers default trigger slot presence; this PR covers that the trigger slot contract is preserved when consumer classes are merged.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/ui/select.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.