### PR TITLE
test(separator): cover decorative separator accessibility

### DIFF
--- a/hushh-webapp/__tests__/ui/separator.test.tsx
+++ b/hushh-webapp/__tests__/ui/separator.test.tsx
@@ -12,6 +12,13 @@ describe("Separator", () => {
     ).toBeTruthy();
   });
 
+  it("renders as decorative by default", () => {
+    const { container } = render(<Separator />);
+    const el = container.querySelector('[data-slot="separator"]');
+
+    expect(el?.getAttribute("role")).toBe("none");
+  });
+
   it("defaults to horizontal orientation", () => {
     const { container } = render(<Separator />);
     const el = container.querySelector('[data-slot="separator"]');


### PR DESCRIPTION
## Summary
- Add focused coverage for the default decorative Separator accessibility contract.
- Assert the rendered separator uses `role=none` when rendered with the default decorative behavior.

## Why
This locks the existing decorative separator accessibility behavior without changing runtime code.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched `integration/pr-train` head before this commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/ui/separator.test.tsx` only.
- This PR adds one focused test for the default decorative accessibility behavior.
- Existing tests cover data-slot and orientation; this PR covers the accessibility semantics of decorative separators.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/ui/separator.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.