### PR TITLE
test(sidebar): cover sidebar rail data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/ui/sidebar.test.tsx
+++ b/hushh-webapp/__tests__/ui/sidebar.test.tsx
@@ -1,0 +1,18 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SidebarProvider, SidebarRail } from "@/components/ui/sidebar";
+
+describe("Sidebar", () => {
+  it("renders rail with data-slot='sidebar-rail'", () => {
+    const { container } = render(
+      <SidebarProvider>
+        <SidebarRail />
+      </SidebarProvider>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="sidebar-rail"]'),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for the SidebarRail data-slot contract.
- Assert the rendered sidebar rail exposes `data-slot=sidebar-rail` inside `SidebarProvider`.

## Why
This locks the SidebarRail slot contract without changing runtime behavior.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched `integration/pr-train` head before this commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/ui/sidebar.test.tsx` only.
- This PR creates a new focused sidebar UI test file for the rail data-slot contract.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/ui/sidebar.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.