### PR TITLE
test(spinner): cover spinner status semantics

### DIFF
--- a/hushh-webapp/__tests__/ui/spinner.test.tsx
+++ b/hushh-webapp/__tests__/ui/spinner.test.tsx
@@ -17,4 +17,10 @@ describe("Spinner", () => {
       "Loading",
     );
   });
+
+  it("preserves status semantics with a custom accessible label", () => {
+    render(<Spinner aria-label="Saving" />);
+
+    expect(screen.getByRole("status", { name: "Saving" })).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary
- Add focused coverage for Spinner status semantics.
- Assert a custom accessible label still resolves on the rendered `role=status` element.

## Why
This locks the Spinner accessibility contract for status semantics without changing runtime behavior.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched `integration/pr-train` head before this commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/ui/spinner.test.tsx` only.
- Existing tests cover the default status role and default Loading label separately.
- This PR adds one focused test for custom accessible naming on the status element.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/ui/spinner.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.