### PR TITLE
test(switch): cover controlled checked state semantics

### DIFF
--- a/hushh-webapp/__tests__/ui/switch.test.tsx
+++ b/hushh-webapp/__tests__/ui/switch.test.tsx
@@ -11,4 +11,18 @@ describe("Switch", () => {
       "checked",
     );
   });
+
+  it("reflects controlled checked state with aria-checked", () => {
+    const { rerender } = render(<Switch checked={false} />);
+
+    expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe(
+      "false",
+    );
+
+    rerender(<Switch checked />);
+
+    expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe(
+      "true",
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- Add focused coverage for controlled Switch checked-state semantics.
- Assert controlled `checked={false}` and `checked` values reflect through `aria-checked` on the rendered switch.

## Why
This locks the controlled Switch accessibility contract without changing runtime behavior.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched `integration/pr-train` head before this commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/ui/switch.test.tsx` only.
- Existing coverage checks the default checked state through `data-state`.
- This PR adds one focused controlled-state test for `aria-checked` semantics.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/ui/switch.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.