### PR TITLE
test(textarea): cover textarea data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/ui/textarea.test.tsx
+++ b/hushh-webapp/__tests__/ui/textarea.test.tsx
@@ -12,6 +12,17 @@ describe("Textarea", () => {
     ).toBeTruthy();
   });
 
+  it("preserves data-slot when textarea props are provided", () => {
+    const { container } = render(
+      <Textarea placeholder="Write a note" rows={4} />,
+    );
+    const el = container.querySelector('[data-slot="textarea"]');
+
+    expect(el).toBeTruthy();
+    expect(el?.getAttribute("placeholder")).toBe("Write a note");
+    expect(el?.getAttribute("rows")).toBe("4");
+  });
+
   it("forwards className to the textarea element", () => {
     const { container } = render(<Textarea className="test-class" />);
     const el = container.querySelector('[data-slot="textarea"]');


### PR DESCRIPTION
## Summary
- Add focused coverage for the Textarea data-slot contract.
- Assert the `data-slot=textarea` element remains present when native textarea props are passed through.

## Why
This locks the Textarea slot contract through native prop passthrough without changing runtime behavior.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched `integration/pr-train` head before this commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/ui/textarea.test.tsx` only.
- Existing tests cover the default textarea slot and className forwarding.
- This PR adds one focused test for slot preservation while forwarding native textarea props.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/ui/textarea.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.