### PR TITLE
test(tooltip): cover tooltip content data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/ui/tooltip.test.tsx
+++ b/hushh-webapp/__tests__/ui/tooltip.test.tsx
@@ -47,4 +47,22 @@ describe("Tooltip", () => {
       document.querySelector('[data-slot="tooltip-content"]'),
     ).toBeTruthy();
   });
+
+  it("preserves TooltipContent data-slot when className is provided", () => {
+    render(
+      <TooltipProvider>
+        <Tooltip defaultOpen>
+          <TooltipTrigger>Hover me</TooltipTrigger>
+          <TooltipContent className="custom-tooltip-content">
+            Tooltip text
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+    );
+
+    const content = document.querySelector('[data-slot="tooltip-content"]');
+
+    expect(content).toBeTruthy();
+    expect(content?.classList.contains("custom-tooltip-content")).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- Add focused coverage for the TooltipContent data-slot contract.
- Assert the rendered tooltip content keeps `data-slot=tooltip-content` when a custom className is passed.

## Why
This locks the TooltipContent slot contract through the className passthrough path without changing runtime behavior.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched `integration/pr-train` head before this commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/ui/tooltip.test.tsx` only.
- Existing coverage checks default open tooltip content slot presence.
- This PR adds one focused test for slot preservation when consumer classes are merged.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/ui/tooltip.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.