### PR TITLE
test(utils): characterize formatCompleteJson object string length limits

### DIFF
--- a/hushh-webapp/__tests__/utils/format-string-lengths.test.ts
+++ b/hushh-webapp/__tests__/utils/format-string-lengths.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCompleteJson } from "@/lib/utils/json-to-human";
+
+// Characterization tests for formatCompleteJson
+// (hushh-webapp/lib/utils/json-to-human.ts) focused on how it handles very large
+// string payloads (10,000+ characters).
+//
+// Truth-first note: formatCompleteJson imposes NO string length limit and does
+// NOT truncate text. String values route through formatValue -> cleanMarkdown,
+// which only strips markdown markers (***, **, *, `) and trims surrounding
+// whitespace; the remaining characters are emitted in full. There is no
+// ellipsis, byte cap, or "... and N more" applied to scalar string fields.
+//
+// (The only truncation paths in this module are array element caps — e.g.
+// holdings.slice(0, 10) — not string-length caps.)
+
+const HUGE = "x".repeat(10_000);
+
+describe("formatCompleteJson — large string payloads", () => {
+  it("emits a 10,000+ char top-level string field in full (no truncation)", () => {
+    const out = formatCompleteJson({ description: HUGE });
+    expect(out).toContain(`Security: ${HUGE}`);
+    // The full payload survives: line length is at least the payload length.
+    expect(out.length).toBeGreaterThanOrEqual(HUGE.length);
+    expect(out).not.toContain("...");
+  });
+
+  it("emits a large string inside an object section in full", () => {
+    const out = formatCompleteJson({
+      account_metadata: {
+        institution_name: HUGE,
+      },
+    });
+    expect(out).toContain(`  Institution: ${HUGE}`);
+    expect(out).not.toContain("...");
+  });
+
+  it("strips markdown markers but preserves the large remaining body", () => {
+    const body = "y".repeat(10_000);
+    const withMarkdown = `**${body}**`;
+    const out = formatCompleteJson({ description: withMarkdown });
+    // cleanMarkdown removes the ** wrappers; the 10k body remains intact.
+    expect(out).toContain(`Security: ${body}`);
+    expect(out).not.toContain("**");
+  });
+
+  it("does not throw and remains performant on a very large payload", () => {
+    const big = "z".repeat(50_000);
+    const start = Date.now();
+    const out = formatCompleteJson({ description: big });
+    const elapsed = Date.now() - start;
+    expect(out).toContain(big);
+    // Generous upper bound — this is linear string work, not a parser blow-up.
+    expect(elapsed).toBeLessThan(2_000);
+  });
+
+  it("preserves embedded newlines within a large multi-line string", () => {
+    const block = Array.from({ length: 500 }, (_, i) => `line-${i}`).join("\n");
+    const out = formatCompleteJson({ description: block });
+    expect(out).toContain("line-0");
+    expect(out).toContain("line-499");
+  });
+});


### PR DESCRIPTION
## Summary

Establishes structural string-size characterization over the `formatCompleteJson`
serialization utility (`hushh-webapp/lib/utils/json-to-human.ts`), pinning how it
handles very large (10,000+ char) string payloads.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/utils/...`. There is no
  top-level `__tests__` in this repo; vitest (`hushh-webapp/vitest.config.ts`)
  only includes `__tests__/**` under `hushh-webapp`. The runnable file therefore
  lives at `hushh-webapp/__tests__/utils/format-string-lengths.test.ts`.
- The task asked to assert behavior "without memory or parsing limits." Truth:
  `formatCompleteJson` imposes **no string length limit and does not truncate
  text**. Scalar strings route through `formatValue → cleanMarkdown`, which only
  strips markdown markers (`***`, `**`, `*`, `` ` ``) and trims surrounding
  whitespace — the remaining characters are emitted in full. There is **no**
  ellipsis, byte cap, or `... and N more` applied to string fields.
- The only truncation paths in this module are array element caps
  (e.g. `holdings.slice(0, 10)`), not string-length caps. The suite asserts:
  - a 10k top-level string is emitted in full
  - a 10k string inside an object section is emitted in full
  - markdown wrappers are stripped while the 10k body survives
  - a 50k payload completes quickly without throwing (linear, no parser blow-up)
  - embedded newlines in a large multi-line string are preserved.

## Verification

- `npm test -- __tests__/utils/format-string-lengths.test.ts` → 5/5 pass
- `git status` limited to the single new test file; no production source changed

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit is signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — documents real no-length-limit / no-truncation string behavior
