### PR TITLE
test(navigation): characterize normalizeInternalRouteHref encoded space invariants

### DIFF
--- a/hushh-webapp/__tests__/navigation/normalize-encoded-spaces.test.ts
+++ b/hushh-webapp/__tests__/navigation/normalize-encoded-spaces.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for normalizeInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts) focused on RAW spaces vs.
+// PERCENT-ENCODED spaces inside an internal path.
+//
+// Real guard:
+//   const href = String(value ?? "").trim();
+//   if (!href) return null;
+//   if (!href.startsWith("/") || href.startsWith("//")) return null;
+//   if (/[\r\n]/.test(href)) return null;
+//   return href;
+//
+// Truth-first note: the guard does NOT encode, decode, or re-format the path.
+//   - `.trim()` only strips LEADING/TRAILING ASCII whitespace; interior spaces
+//     are left untouched.
+//   - A percent-encoded space ("%20") is just ordinary characters to the guard;
+//     it is preserved verbatim.
+//   - A raw interior space (" ") is also preserved verbatim (space is not "/",
+//     not "\r", not "\n"), so "/legal docs" passes through UNCHANGED — it is not
+//     converted to "/legal%20docs" and not rejected.
+//   - There is no equivalence/normalization between "%20" and " ".
+
+describe("normalizeInternalRouteHref — raw vs percent-encoded spaces", () => {
+  it("preserves a percent-encoded space verbatim", () => {
+    expect(normalizeInternalRouteHref("/legal%20docs")).toBe("/legal%20docs");
+  });
+
+  it("preserves a raw interior space verbatim (no encoding applied)", () => {
+    expect(normalizeInternalRouteHref("/legal docs")).toBe("/legal docs");
+  });
+
+  it("does NOT treat '%20' and ' ' as equivalent (no normalization)", () => {
+    const encoded = normalizeInternalRouteHref("/legal%20docs");
+    const raw = normalizeInternalRouteHref("/legal docs");
+    expect(encoded).not.toBe(raw);
+  });
+
+  it("trims only leading/trailing whitespace, keeping interior raw spaces", () => {
+    expect(normalizeInternalRouteHref("   /legal docs   ")).toBe("/legal docs");
+  });
+
+  it("does not decode a percent-encoded space surrounded by trimmed whitespace", () => {
+    expect(normalizeInternalRouteHref("  /legal%20docs  ")).toBe("/legal%20docs");
+  });
+
+  it("preserves spaces (raw and encoded) inside query strings", () => {
+    expect(normalizeInternalRouteHref("/search?q=a b")).toBe("/search?q=a b");
+    expect(normalizeInternalRouteHref("/search?q=a%20b")).toBe("/search?q=a%20b");
+  });
+
+  it("still rejects a value that becomes empty after trimming whitespace", () => {
+    expect(normalizeInternalRouteHref("    ")).toBeNull();
+  });
+
+  it("rejects a space-bearing value that does not start with '/'", () => {
+    // After trim, "legal docs" does not begin with "/", so it is rejected.
+    expect(normalizeInternalRouteHref("  legal docs  ")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Extends characterization coverage for `normalizeInternalRouteHref`
(`hushh-webapp/lib/navigation/routes.ts`) to explicitly map how its path guard
reacts to raw spaces vs. percent-encoded spaces inside internal routes.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/navigation/...`. There
  is no top-level `__tests__` in this repo; vitest
  (`hushh-webapp/vitest.config.ts`) only includes `__tests__/**` under
  `hushh-webapp`. The runnable file therefore lives at
  `hushh-webapp/__tests__/navigation/normalize-encoded-spaces.test.ts`.
- Verified behavioral truth: the guard does **not** encode, decode, or re-format
  the path. It is `trim → reject empty → reject if !startsWith("/") OR
  startsWith("//") → reject CR/LF → return verbatim`. Consequences pinned:
  - `/legal%20docs` → preserved verbatim (`%20` is just ordinary characters)
  - `/legal docs` (raw interior space) → preserved verbatim; it is **not**
    converted to `%20` and **not** rejected (space is not `/`, `\r`, or `\n`)
  - `%20` and a raw space are **not** treated as equivalent (no normalization)
  - `.trim()` strips only leading/trailing whitespace; interior spaces survive
    (`   /legal docs   ` → `/legal docs`)
  - spaces (raw and encoded) inside query strings are preserved
  - a value that is all whitespace → `null` (empty after trim)
  - `  legal docs  ` → `null` (after trim it doesn't start with `/`).

## Verification

- `npm test -- __tests__/navigation/normalize-encoded-spaces.test.ts` → 8/8 pass
- `git status` limited to the single new test file; no production source changed

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit is signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — documents the real no-encode / no-normalize space contract
