### PR TITLE
test(navigation): characterize resolveInternalRouteHref multi-param order lock

### DIFF
--- a/hushh-webapp/__tests__/navigation/resolve-param-order.test.ts
+++ b/hushh-webapp/__tests__/navigation/resolve-param-order.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for resolveInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts).
+//
+// TRUTH-FIRST PREMISE CORRECTION:
+//   The task asked to verify that resolveInternalRouteHref "appends multiple
+//   query keys" and preserves "lexicographical or raw declaration order"
+//   throughout "resolution limits". Reading the source corrected that premise.
+//   resolveInternalRouteHref does NO query construction, parsing, sorting, or
+//   reordering. Its entire body is:
+//
+//     export function resolveInternalRouteHref(value, fallback) {
+//       return normalizeInternalRouteHref(value) ?? fallback;
+//     }
+//
+//   So it only: trims, rejects empty / non-"/"-leading / protocol-relative
+//   ("//") / CR-LF inputs, and otherwise returns the input string VERBATIM;
+//   on rejection it returns the provided fallback.
+//
+//   (Query KEY ORDERING in this module is the concern of the private withQuery
+//   helper, which uses URLSearchParams and emits keys in INSERTION order — but
+//   resolveInternalRouteHref never calls withQuery.)
+//
+//   These tests therefore pin the REAL contract: a pre-formed multi-key query
+//   string is passed through with its exact raw order preserved, with zero
+//   normalization, and invalid inputs fall back.
+
+describe("resolveInternalRouteHref — multi-param raw order pass-through", () => {
+  it("preserves the exact raw order of multiple query keys verbatim", () => {
+    const href = "/search?b=2&a=1&c=3";
+    expect(resolveInternalRouteHref(href, "/fallback")).toBe(href);
+  });
+
+  it("does NOT sort query keys lexicographically", () => {
+    const href = "/search?z=1&a=2";
+    const out = resolveInternalRouteHref(href, "/fallback");
+    expect(out).toBe("/search?z=1&a=2");
+    expect(out).not.toBe("/search?a=2&z=1");
+  });
+
+  it("preserves duplicate keys in their original positions", () => {
+    const href = "/list?tag=red&tag=blue&tag=green";
+    expect(resolveInternalRouteHref(href, "/fallback")).toBe(href);
+  });
+
+  it("preserves an empty-value key and bare key exactly as written", () => {
+    const href = "/p?a=&b&c=3";
+    expect(resolveInternalRouteHref(href, "/fallback")).toBe(href);
+  });
+
+  it("does not re-encode already percent-encoded query values", () => {
+    const href = "/search?q=a%20b&next=%2Fhome";
+    expect(resolveInternalRouteHref(href, "/fallback")).toBe(href);
+  });
+
+  it("returns the fallback when the value is null/undefined/empty", () => {
+    expect(resolveInternalRouteHref(null, "/fallback")).toBe("/fallback");
+    expect(resolveInternalRouteHref(undefined, "/fallback")).toBe("/fallback");
+    expect(resolveInternalRouteHref("   ", "/fallback")).toBe("/fallback");
+  });
+
+  it("returns the fallback for a protocol-relative or external multi-param URL", () => {
+    expect(
+      resolveInternalRouteHref("//evil.com/x?a=1&b=2", "/fallback")
+    ).toBe("/fallback");
+    expect(
+      resolveInternalRouteHref("https://evil.com/x?a=1&b=2", "/fallback")
+    ).toBe("/fallback");
+  });
+
+  it("trims surrounding whitespace but keeps interior query order intact", () => {
+    expect(resolveInternalRouteHref("  /go?x=1&y=2  ", "/fallback")).toBe(
+      "/go?x=1&y=2"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Documents the parameter-preservation contract of `resolveInternalRouteHref`
(`hushh-webapp/lib/navigation/routes.ts`) when a pre-formed multi-key query
string is passed through resolution.

## Truth-first premise correction

- The original task referenced `hushh-research/__tests__/navigation/...`. There
  is no top-level `__tests__` in this repo; vitest only includes `__tests__/**`
  under `hushh-webapp`. The file therefore lives at
  `hushh-webapp/__tests__/navigation/resolve-param-order.test.ts`.
- **The task premise was wrong and reading the source corrected it.**
  `resolveInternalRouteHref` does **not** append query keys, parse a query, or
  apply any lexicographical/declaration-order sorting. Its entire body is:

  ```ts
  export function resolveInternalRouteHref(value, fallback) {
    return normalizeInternalRouteHref(value) ?? fallback;
  }
  ```

  So it only trims, rejects empty / non-`/`-leading / protocol-relative (`//`) /
  CR-LF inputs, and otherwise returns the input string **verbatim**; on rejection
  it returns the provided `fallback`. The "multi-param order lock" it guarantees
  is therefore **raw pass-through order preservation**, not active ordering.
  (Query KEY ordering elsewhere in this module is the job of the private
  `withQuery` helper via `URLSearchParams` insertion order — but
  `resolveInternalRouteHref` never calls it.)

## Literal assertions pinned

- Raw order of multiple keys preserved verbatim (`/search?b=2&a=1&c=3` unchanged)
- Keys are **not** sorted lexicographically (`?z=1&a=2` stays, not `?a=2&z=1`)
- Duplicate keys keep their original positions
- Empty-value key + bare key preserved exactly (`/p?a=&b&c=3`)
- Already percent-encoded query values are **not** re-encoded
- `null` / `undefined` / whitespace-only → returns `fallback`
- Protocol-relative (`//evil.com/...`) and external (`https://...`) multi-param
  URLs → returns `fallback`
- Surrounding whitespace trimmed; interior query order intact

## Verification

- `npm test -- __tests__/navigation/resolve-param-order.test.ts` → 8/8 pass
- `git status` limited to the single new test file; no production source changed

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit is signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — corrects the "appends/sorts params" premise to the real
  validate-and-pass-through-or-fallback contract
