### PR TITLE
test(utils): characterize formatCompleteJson on large numeric bigint inputs

### DIFF
--- a/hushh-webapp/__tests__/utils/format-json-bigint.test.ts
+++ b/hushh-webapp/__tests__/utils/format-json-bigint.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCompleteJson } from "@/lib/utils/json-to-human";
+
+// Characterization tests for formatCompleteJson
+// (hushh-webapp/lib/utils/json-to-human.ts) focused on high-magnitude /
+// BigInt-like inputs.
+//
+// TRUTH-FIRST notes (verified against the source):
+//   - There is no special BigInt handling. formatValue branches on
+//     `typeof === "number" | "string" | "boolean"`, else `String(value)`.
+//   - A top-level `number` routes through the scalar branch → formatNumber
+//     (Intl en-US, maximumFractionDigits: 4) → grouped digits.
+//   - A real top-level `bigint` is NOT number/string, not an array, and
+//     `typeof bigint !== "object"`, so it matches NO top-level branch and is
+//     SILENTLY SKIPPED.
+//   - A `bigint` NESTED inside an object value falls through formatValue to
+//     `String(value)`, i.e. the plain decimal digits with NO grouping and NO
+//     trailing "n".
+//   - A BigInt-like STRING is treated as a string → markdown-cleaned, otherwise
+//     verbatim (full precision retained, since it never becomes a Number).
+
+describe("formatCompleteJson — high-magnitude / bigint inputs", () => {
+  it("formats a top-level safe large integer with en-US grouping", () => {
+    // Number.MAX_SAFE_INTEGER
+    const out = formatCompleteJson({ widget_count: 9007199254740991 });
+    expect(out).toBe("Widget Count: 9,007,199,254,740,991");
+  });
+
+  it("preserves a BigInt-like string verbatim (full precision, no grouping)", () => {
+    const big = "123456789012345678901234567890";
+    const out = formatCompleteJson({ ledger_id: big });
+    expect(out).toBe(`Ledger Id: ${big}`);
+  });
+
+  it("renders a nested bigint via String() — plain digits, no grouping, no 'n'", () => {
+    const out = formatCompleteJson({
+      account_metadata: { ledger_seq: 9007199254740993n },
+    });
+    expect(out).toContain("  Ledger Seq: 9007199254740993");
+    expect(out).not.toContain("9007199254740993n");
+    expect(out).not.toContain("9,007,199,254,740,993");
+  });
+
+  it("SKIPS a top-level bigint entirely (no line emitted)", () => {
+    expect(formatCompleteJson({ ledger_seq: 9007199254740993n })).toBe("");
+  });
+
+  it("rounds a top-level number beyond 4 fractional digits (formatNumber cap)", () => {
+    const out = formatCompleteJson({ ratio_metric: 1234.56789 });
+    // maximumFractionDigits: 4 → 1,234.5679
+    expect(out).toBe("Ratio Metric: 1,234.5679");
+  });
+
+  it("formats a nested currency field large integer as USD", () => {
+    const out = formatCompleteJson({
+      portfolio_summary: { ending_value: 1000000000 },
+    });
+    expect(out).toContain("  Ending Value: $1,000,000,000.00");
+  });
+
+  it("does not throw on a mix of bigint, big string, and big number", () => {
+    expect(() =>
+      formatCompleteJson({
+        account_metadata: {
+          seq: 9999999999999999n,
+          id: "999999999999999999999",
+          count: 1234567,
+        },
+      })
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Characterizes the output structure of `formatCompleteJson`
(`hushh-webapp/lib/utils/json-to-human.ts`) under high-magnitude numeric,
BigInt-like string, and real `bigint` field inputs.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/utils/...`. There is no
  top-level `__tests__` in this repo; vitest only includes `__tests__/**` under
  `hushh-webapp`. The file therefore lives at
  `hushh-webapp/__tests__/utils/format-json-bigint.test.ts`.
- **There is no special BigInt handling in the code; the test pins what really
  happens.** `formatValue` only branches on `typeof === number | string |
  boolean`, otherwise `String(value)`. Verified consequences:
  - A top-level `number` → scalar branch → `formatNumber` (Intl en-US,
    `maximumFractionDigits: 4`) with grouping:
    `9007199254740991` → `9,007,199,254,740,991`.
  - A top-level `number` with >4 fraction digits is rounded:
    `1234.56789` → `1,234.5679`.
  - A **real top-level `bigint` is silently skipped** — it is not number/string,
    not an array, and `typeof bigint !== "object"`, so it matches no branch and
    emits no line.
  - A **nested `bigint`** falls through `formatValue` to `String(value)`: plain
    decimal digits, **no** grouping and **no** trailing `n`
    (`9007199254740993n` → `9007199254740993`).
  - A **BigInt-like string** stays a string (markdown-cleaned, else verbatim),
    so full precision is retained because it never becomes a `Number`
    (`"123456789012345678901234567890"` preserved exactly).
  - Nested currency fields still format as USD (`ending_value: 1000000000` →
    `$1,000,000,000.00`).
  - A mixed bigint/big-string/big-number object does not throw.

## Verification

- `npm test -- __tests__/utils/format-json-bigint.test.ts` → 7/7 pass
- `git status` limited to the single new test file; no production source changed

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit is signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the real number/bigint/string behavior incl. the
  top-level-bigint skip and the nested `String()` fallthrough
