### PR TITLE
test(navigation): characterize normalizeInternalRouteHref sub-domain isolation

### DIFF
--- a/hushh-webapp/__tests__/navigation/normalize-subdomains.test.ts
+++ b/hushh-webapp/__tests__/navigation/normalize-subdomains.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for normalizeInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts) focused on sub-domain / host-prefixed
+// strings.
+//
+// Real guard:
+//   const href = String(value ?? "").trim();
+//   if (!href) return null;
+//   if (!href.startsWith("/") || href.startsWith("//")) return null;
+//   if (/[\r\n]/.test(href)) return null;
+//   return href;
+//
+// TRUTH-FIRST: the guard does NOT parse hosts or distinguish "subdomains". It is
+// a pure prefix check. A bare host-prefixed string like "one.hushh.ai/dashboard"
+// does NOT start with "/", so it is REJECTED (returns null) — it is FILTERED OUT,
+// not converted/preserved as an external link. Protocol-relative "//host" is
+// explicitly rejected too. Only a value that already begins with a single "/"
+// survives as a local route, regardless of any host-looking text after it.
+
+describe("normalizeInternalRouteHref — sub-domain / host-prefixed inputs", () => {
+  it("rejects a bare subdomain-prefixed string (no leading slash)", () => {
+    expect(normalizeInternalRouteHref("one.hushh.ai/dashboard")).toBeNull();
+  });
+
+  it("rejects a protocol-relative subdomain URL ('//host/...')", () => {
+    expect(normalizeInternalRouteHref("//one.hushh.ai/dashboard")).toBeNull();
+  });
+
+  it("rejects an absolute https subdomain URL", () => {
+    expect(
+      normalizeInternalRouteHref("https://one.hushh.ai/dashboard")
+    ).toBeNull();
+  });
+
+  it("rejects an http subdomain URL", () => {
+    expect(normalizeInternalRouteHref("http://app.hushh.ai/x")).toBeNull();
+  });
+
+  it("keeps a local path that merely CONTAINS host-looking text after '/'", () => {
+    // Starts with a single "/", so it is a valid internal route verbatim — the
+    // "one.hushh.ai" substring is treated as ordinary path text, not a host.
+    expect(normalizeInternalRouteHref("/one.hushh.ai/dashboard")).toBe(
+      "/one.hushh.ai/dashboard"
+    );
+  });
+
+  it("preserves a normal internal route unaffected by host filtering", () => {
+    expect(normalizeInternalRouteHref("/one/dashboard")).toBe("/one/dashboard");
+  });
+
+  it("trims surrounding whitespace before applying the prefix rule", () => {
+    expect(normalizeInternalRouteHref("   one.hushh.ai/x   ")).toBeNull();
+    expect(normalizeInternalRouteHref("   /one/x   ")).toBe("/one/x");
+  });
+
+  it("rejects a mixed-case scheme subdomain URL (still not '/'-leading)", () => {
+    expect(normalizeInternalRouteHref("HTTPS://one.hushh.ai")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Characterizes how `normalizeInternalRouteHref`
(`hushh-webapp/lib/navigation/routes.ts`) treats sub-domain / host-prefixed
strings such as `one.hushh.ai/dashboard`.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/navigation/...`. There
  is no top-level `__tests__` in this repo; vitest only includes `__tests__/**`
  under `hushh-webapp`. The file therefore lives at
  `hushh-webapp/__tests__/navigation/normalize-subdomains.test.ts`.
- **The "absolute external link vs local route" framing is not how the code
  works.** `normalizeInternalRouteHref` does no host parsing and has no concept
  of "subdomains" or "external links." Its guard is a pure prefix check:

  ```ts
  const href = String(value ?? "").trim();
  if (!href) return null;
  if (!href.startsWith("/") || href.startsWith("//")) return null;
  if (/[\r\n]/.test(href)) return null;
  return href;
  ```

  So a host-prefixed string is **filtered out (returns `null`)**, never
  preserved or rewritten as an external link.

## Behavior pinned

- `one.hushh.ai/dashboard` → `null` (no leading slash → rejected)
- `//one.hushh.ai/dashboard` → `null` (protocol-relative explicitly rejected)
- `https://one.hushh.ai/dashboard`, `http://app.hushh.ai/x`,
  `HTTPS://one.hushh.ai` → `null` (still not `/`-leading)
- `/one.hushh.ai/dashboard` → preserved verbatim (host-looking text after a
  single `/` is just ordinary path text)
- `/one/dashboard` → preserved verbatim
- Whitespace is trimmed before the prefix rule (`   /one/x   ` → `/one/x`;
  `   one.hushh.ai/x   ` → `null`)

## Verification

- `npm test -- __tests__/navigation/normalize-subdomains.test.ts` → 8/8 pass
- `git status` limited to the single new test file; no production source changed

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit is signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — replaces the "external-link handling" premise with the real
  `/`-prefix-only allowlist that filters host-prefixed inputs to `null`
