### PR TITLE
test(navigation): characterize resolveInternalRouteHref empty query token anchors

### DIFF
--- a/hushh-webapp/__tests__/navigation/resolve-empty-queries.test.ts
+++ b/hushh-webapp/__tests__/navigation/resolve-empty-queries.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for resolveInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts) focused on trailing / empty query
+// tokens (e.g. "/search?q=").
+//
+// TRUTH-FIRST: resolveInternalRouteHref does NO query parsing. Its body is
+// `normalizeInternalRouteHref(value) ?? fallback`, which trims, rejects empty /
+// non-"/"-leading / protocol-relative ("//") / CR-LF inputs, and otherwise
+// returns the input string VERBATIM. There is therefore no "parsing collapse"
+// to guard against — an empty query token like "?q=" is preserved exactly
+// because the string is never decomposed.
+
+describe("resolveInternalRouteHref — empty / trailing query tokens", () => {
+  it("preserves a single trailing empty query value verbatim", () => {
+    expect(resolveInternalRouteHref("/search?q=", "/fallback")).toBe(
+      "/search?q="
+    );
+  });
+
+  it("preserves a bare '?' with no key", () => {
+    expect(resolveInternalRouteHref("/search?", "/fallback")).toBe("/search?");
+  });
+
+  it("preserves a bare key with no '=' (no collapse to '?key=')", () => {
+    expect(resolveInternalRouteHref("/search?q", "/fallback")).toBe("/search?q");
+  });
+
+  it("preserves multiple empty values in original order", () => {
+    expect(resolveInternalRouteHref("/p?a=&b=&c=", "/fallback")).toBe(
+      "/p?a=&b=&c="
+    );
+  });
+
+  it("preserves a mix of empty and populated values exactly", () => {
+    expect(resolveInternalRouteHref("/p?a=&b=2&c=", "/fallback")).toBe(
+      "/p?a=&b=2&c="
+    );
+  });
+
+  it("preserves a trailing '&' after an empty value", () => {
+    expect(resolveInternalRouteHref("/p?a=&", "/fallback")).toBe("/p?a=&");
+  });
+
+  it("trims surrounding whitespace but keeps the empty query token", () => {
+    expect(resolveInternalRouteHref("   /search?q=   ", "/fallback")).toBe(
+      "/search?q="
+    );
+  });
+
+  it("returns the fallback for an external URL even with an empty query", () => {
+    expect(
+      resolveInternalRouteHref("https://evil.com/search?q=", "/fallback")
+    ).toBe("/fallback");
+    expect(
+      resolveInternalRouteHref("//evil.com/search?q=", "/fallback")
+    ).toBe("/fallback");
+  });
+});


### PR DESCRIPTION
## Summary

Characterizes how `resolveInternalRouteHref`
(`hushh-webapp/lib/navigation/routes.ts`) treats internal routes with trailing /
empty query tokens such as `/search?q=`.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/navigation/...`. There
  is no top-level `__tests__` in this repo; vitest only includes `__tests__/**`
  under `hushh-webapp`. The file therefore lives at
  `hushh-webapp/__tests__/navigation/resolve-empty-queries.test.ts`.
- **There is no query parsing, so there is no "parsing collapse" to guard
  against.** `resolveInternalRouteHref`'s entire body is
  `normalizeInternalRouteHref(value) ?? fallback`: it trims, rejects empty /
  non-`/`-leading / protocol-relative (`//`) / CR-LF inputs, and otherwise
  returns the input string **verbatim**. Empty query tokens survive simply
  because the string is never decomposed.

## Behavior pinned

- `/search?q=` → preserved verbatim
- `/search?` (bare `?`) → preserved verbatim
- `/search?q` (bare key, no `=`) → preserved verbatim (no collapse to `?q=`)
- `/p?a=&b=&c=` → preserved in original order
- `/p?a=&b=2&c=` → mixed empty/populated preserved exactly
- `/p?a=&` (trailing `&`) → preserved verbatim
- `   /search?q=   ` → ends trimmed, empty query token kept (`/search?q=`)
- `https://evil.com/search?q=` and `//evil.com/search?q=` → return the fallback

## Verification

- `npm test -- __tests__/navigation/resolve-empty-queries.test.ts` → 8/8 pass
- `git status` limited to the single new test file; no production source changed

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit is signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the verbatim-pass-through-or-fallback contract; there is
  no query decomposition that could collapse an empty token
