### PR TITLE
test(navigation): characterize normalizeInternalRouteHref multi-dot path extensions

### DIFF
--- a/hushh-webapp/__tests__/navigation/normalize-multi-dots.test.ts
+++ b/hushh-webapp/__tests__/navigation/normalize-multi-dots.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for normalizeInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts) focused on multi-dot / explicit
+// relative path segments (e.g. "/app/../legal/..", "/a/./b", "/x..y").
+//
+// Real guard:
+//   const href = String(value ?? "").trim();
+//   if (!href) return null;
+//   if (!href.startsWith("/") || href.startsWith("//")) return null;
+//   if (/[\r\n]/.test(href)) return null;
+//   return href;
+//
+// TRUTH-FIRST: the guard performs NO path normalization or traversal
+// resolution. It does not collapse "..", "." or repeated dots. A string that
+// starts with a single "/", has no protocol-relative "//" prefix, and contains
+// no CR/LF is returned VERBATIM — dot segments included. There is no "tracking
+// logic isolation"; the dots are ordinary path characters that survive intact.
+
+describe("normalizeInternalRouteHref — multi-dot / relative segments", () => {
+  it("preserves '..' traversal segments verbatim (no collapse)", () => {
+    expect(normalizeInternalRouteHref("/app/../legal/..")).toBe(
+      "/app/../legal/.."
+    );
+  });
+
+  it("preserves a single './' current-dir segment verbatim", () => {
+    expect(normalizeInternalRouteHref("/a/./b")).toBe("/a/./b");
+  });
+
+  it("preserves a leading '/..' without resolving above root", () => {
+    expect(normalizeInternalRouteHref("/../secret")).toBe("/../secret");
+  });
+
+  it("preserves long dot runs as literal text", () => {
+    expect(normalizeInternalRouteHref("/x/..../y")).toBe("/x/..../y");
+  });
+
+  it("preserves dots embedded in a filename-like segment", () => {
+    expect(normalizeInternalRouteHref("/files/archive.tar.gz")).toBe(
+      "/files/archive.tar.gz"
+    );
+  });
+
+  it("still rejects a protocol-relative '//' host even with dot segments", () => {
+    expect(normalizeInternalRouteHref("//evil.com/../x")).toBeNull();
+  });
+
+  it("rejects a relative dot path that does not start with '/'", () => {
+    expect(normalizeInternalRouteHref("../legal")).toBeNull();
+    expect(normalizeInternalRouteHref("./legal")).toBeNull();
+  });
+
+  it("trims surrounding whitespace but keeps the dot segments", () => {
+    expect(normalizeInternalRouteHref("   /app/../legal   ")).toBe(
+      "/app/../legal"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Characterizes how `normalizeInternalRouteHref`
(`hushh-webapp/lib/navigation/routes.ts`) treats multi-dot / explicit relative
path segments such as `/app/../legal/..`.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/navigation/...`. There
  is no top-level `__tests__` in this repo; vitest only includes `__tests__/**`
  under `hushh-webapp`. The file therefore lives at
  `hushh-webapp/__tests__/navigation/normalize-multi-dots.test.ts`.
- **There is no "tracking logic" and no path normalization.** The guard is a
  pure prefix/character check:

  ```ts
  const href = String(value ?? "").trim();
  if (!href) return null;
  if (!href.startsWith("/") || href.startsWith("//")) return null;
  if (/[\r\n]/.test(href)) return null;
  return href;
  ```

  It never collapses `..`, `.` or repeated dots. Dot segments are ordinary path
  characters that survive verbatim when the input passes the prefix check.

## Behavior pinned

- `/app/../legal/..` → preserved verbatim (no traversal collapse)
- `/a/./b` → preserved verbatim
- `/../secret` → preserved verbatim (does not resolve above root)
- `/x/..../y` → long dot runs preserved as literal text
- `/files/archive.tar.gz` → dotted filename preserved
- `//evil.com/../x` → `null` (protocol-relative still rejected before dots matter)
- `../legal` and `./legal` → `null` (do not start with `/`)
- `   /app/../legal   ` → ends trimmed, dot segments kept (`/app/../legal`)

## Verification

- `npm test -- __tests__/navigation/normalize-multi-dots.test.ts` → 8/8 pass
- `git status` limited to the single new test file; no production source changed

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit is signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the no-normalization, verbatim-or-null guard rather than
  an assumed traversal-resolving / tracking-isolation behavior
