### PR TITLE
test(utils): characterize formatCompleteJson unicase property invariants

### DIFF
--- a/hushh-webapp/__tests__/utils/format-unicase-properties.test.ts
+++ b/hushh-webapp/__tests__/utils/format-unicase-properties.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCompleteJson } from "@/lib/utils/json-to-human";
+
+// Characterization tests for formatCompleteJson
+// (hushh-webapp/lib/utils/json-to-human.ts) focused on mixed-case / Unicode
+// object keys.
+//
+// TRUTH-FIRST (verified against the source):
+//   - Unknown keys are labeled via getFieldLabel:
+//       key.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase())
+//   - `\w` is ASCII-only ([A-Za-z0-9_]). The ONLY transform is UP-casing the
+//     first ASCII word character of each whitespace-delimited token. There is
+//     NO down-casing anywhere, and non-ASCII letters are never `\w`, so any key
+//     made purely of non-ASCII characters is emitted VERBATIM.
+//   - Interior already-uppercase characters (ASCII or Unicode) are preserved.
+//   - Values pass through formatValue → for strings, only markdown is stripped
+//     and ends trimmed; letter case (incl. Unicode) is never changed.
+
+describe("formatCompleteJson — mixed-case / Unicode property keys", () => {
+  it("emits a pure non-ASCII uppercase key verbatim (never down-cased)", () => {
+    expect(formatCompleteJson({ "ÄÖÜ": "x" })).toBe("ÄÖÜ: x");
+  });
+
+  it("emits a pure non-ASCII lowercase key verbatim (no ASCII initial to up-case)", () => {
+    expect(formatCompleteJson({ "äöü": "x" })).toBe("äöü: x");
+  });
+
+  it("preserves a mixed-case Greek key verbatim", () => {
+    expect(formatCompleteJson({ "λΛ": "x" })).toBe("λΛ: x");
+  });
+
+  it("up-cases only the first ASCII letter, preserving interior case", () => {
+    // "fooBar" → "FooBar": leading 'f' up-cased; interior 'B' untouched.
+    expect(formatCompleteJson({ fooBar: "x" })).toBe("FooBar: x");
+  });
+
+  it("leaves an already-uppercase ASCII acronym key unchanged", () => {
+    expect(formatCompleteJson({ ABC: "x" })).toBe("ABC: x");
+  });
+
+  it("never alters letter case inside string values (ASCII or Unicode)", () => {
+    expect(formatCompleteJson({ alpha: "MiXeD Ünï" })).toBe("Alpha: MiXeD Ünï");
+  });
+
+  it("preserves a mixed-case non-ASCII key verbatim inside an object section", () => {
+    const out = formatCompleteJson({ portfolio_summary: { "ΩÇ": "val" } });
+    const lines = out.split("\n");
+    expect(lines[0]).toBe("");
+    expect(lines[1]).toBe("--- Portfolio Summary ---");
+    expect(lines[2]).toBe("  ΩÇ: val");
+  });
+});


### PR DESCRIPTION
## Summary

Characterizes how `formatCompleteJson` (`hushh-webapp/lib/utils/json-to-human.ts`)
treats object keys with mixed-case Unicode representations.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/utils/...`. There is no
  top-level `__tests__` in this repo; vitest only includes `__tests__/**` under
  `hushh-webapp`. The file therefore lives at
  `hushh-webapp/__tests__/utils/format-unicase-properties.test.ts`.
- **The formatter never applies any down-casing — and it is not case-preserving
  either.** Unknown keys are labeled via `getFieldLabel`:

  ```ts
  key.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
  ```

  `\w` is ASCII-only (`[A-Za-z0-9_]`). The single transform is **up-casing the
  first ASCII word character of each token**; there is no down-casing anywhere.
  Keys made purely of non-ASCII letters never match `\w`, so they are emitted
  **verbatim**. Interior already-uppercase characters (ASCII or Unicode) are
  preserved. String values pass through `formatValue`, which only strips markdown
  and trims ends — letter case (incl. Unicode) is untouched.

## Behavior pinned

- `{ "ÄÖÜ": "x" }` → `ÄÖÜ: x` (non-ASCII uppercase preserved verbatim)
- `{ "äöü": "x" }` → `äöü: x` (non-ASCII lowercase preserved; no ASCII initial)
- `{ "λΛ": "x" }` → `λΛ: x` (mixed-case Greek verbatim)
- `{ fooBar: "x" }` → `FooBar: x` (only leading ASCII letter up-cased)
- `{ ABC: "x" }` → `ABC: x` (already-uppercase ASCII acronym unchanged)
- `{ alpha: "MiXeD Ünï" }` → `Alpha: MiXeD Ünï` (value case never altered)
- `{ portfolio_summary: { "ΩÇ": "val" } }` → nested key `  ΩÇ: val` under
  `--- Portfolio Summary ---`

## Verification

- `npm test -- __tests__/utils/format-unicase-properties.test.ts` → 7/7 pass
- `git status` limited to the single new test file; no production source changed

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit is signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the actual "ASCII-initial up-case only, otherwise
  verbatim, never down-case" behavior rather than an assumed case-normalizer
