### PR TITLE
test(utils): characterize formatCompleteJson on date objects and ISO strings

### DIFF
--- a/hushh-webapp/__tests__/utils/format-json-dates.test.ts
+++ b/hushh-webapp/__tests__/utils/format-json-dates.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCompleteJson } from "@/lib/utils/json-to-human";
+
+// Characterization tests for formatCompleteJson
+// (hushh-webapp/lib/utils/json-to-human.ts) focused on native JavaScript Date
+// objects and raw ISO timestamp strings inside payload values.
+//
+// TRUTH-FIRST (verified against the source):
+//   - ISO timestamp STRINGS are values of typeof "string". At the top level
+//     they take the scalar branch:  `${label}: ${formatValue(key, value)}`.
+//     formatValue → cleanMarkdown only strips *, **, ***, ` and trims ends; an
+//     ISO string contains none of those, so it is emitted VERBATIM with full
+//     precision (fractional seconds and offset preserved).
+//   - A native Date is typeof "object" (and not an Array). At the TOP level it
+//     takes the "Handle objects" branch, which prints a `--- Label ---` header
+//     and then iterates Object.entries(date). A Date has NO own enumerable
+//     properties, so the loop yields nothing: the timestamp is silently DROPPED
+//     (no value line) and NO exception is thrown.
+//   - A Date NESTED inside an object section hits the nested-object branch,
+//     which prints `  <Label>:` and then iterates the Date's (empty) entries,
+//     so again only an empty label line remains — precision is dropped.
+//   - A Date inside an array hits the generic array branch: Object.values(date)
+//     is empty, so `String(firstValue || "Item")` collapses to the literal
+//     "Item".
+//   - The formatter NEVER calls .toISOString()/.toString() on a Date; it relies
+//     purely on enumerable own properties, which Date does not expose.
+
+describe("formatCompleteJson — ISO timestamp strings", () => {
+  it("emits a top-level ISO string verbatim with full precision", () => {
+    expect(
+      formatCompleteJson({ custom_ts: "2023-12-31T23:59:59.999Z" })
+    ).toBe("Custom Ts: 2023-12-31T23:59:59.999Z");
+  });
+
+  it("preserves fractional seconds and a numeric UTC offset exactly", () => {
+    expect(
+      formatCompleteJson({ custom_ts: "2023-06-15T08:30:00.123+05:30" })
+    ).toBe("Custom Ts: 2023-06-15T08:30:00.123+05:30");
+  });
+
+  it("emits an ISO string verbatim when nested inside an object section", () => {
+    expect(
+      formatCompleteJson({
+        portfolio_summary: { as_of: "2023-12-31T23:59:59.999Z" },
+      })
+    ).toBe(
+      "\n--- Portfolio Summary ---\n  As Of: 2023-12-31T23:59:59.999Z"
+    );
+  });
+});
+
+describe("formatCompleteJson — native Date objects", () => {
+  it("drops a top-level Date to a bare header (no value line, no throw)", () => {
+    const d = new Date("2023-12-31T23:59:59.999Z");
+    expect(formatCompleteJson({ custom_ts: d })).toBe("\n--- Custom Ts ---");
+  });
+
+  it("drops a nested Date to an empty label line (precision lost)", () => {
+    const d = new Date("2023-12-31T23:59:59.999Z");
+    expect(
+      formatCompleteJson({ portfolio_summary: { as_of: d } })
+    ).toBe("\n--- Portfolio Summary ---\n  As Of:");
+  });
+
+  it("collapses Date items in an array to the literal 'Item'", () => {
+    const a = new Date("2023-01-01T00:00:00.000Z");
+    const b = new Date("2024-01-01T00:00:00.000Z");
+    expect(formatCompleteJson({ events: [a, b] })).toBe(
+      "\n--- Events (2 items) ---\n  • Item\n  • Item"
+    );
+  });
+
+  it("does not throw on an invalid Date value", () => {
+    const invalid = new Date("not-a-real-date");
+    expect(() => formatCompleteJson({ custom_ts: invalid })).not.toThrow();
+    expect(formatCompleteJson({ custom_ts: invalid })).toBe(
+      "\n--- Custom Ts ---"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds an isolated characterization test for `formatCompleteJson`
(`hushh-webapp/lib/utils/json-to-human.ts`) that pins its exact, literal
serialization handling of native JavaScript `Date` instances and raw ISO
timestamp strings inside payload values. Test-only; no production source change.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/utils/...`. There is no
  top-level `__tests__` in this repo; vitest only includes `__tests__/**` under
  `hushh-webapp`. The file therefore lives at
  `hushh-webapp/__tests__/utils/format-json-dates.test.ts`.
- The formatter does **not** stringify `Date` via `.toISOString()`/`.toString()`.
  It branches on `typeof` and iterates **enumerable own properties**, which a
  `Date` does not expose — so `Date` timestamp precision is **dropped**, not
  preserved. ISO **strings**, by contrast, are preserved verbatim. The test pins
  both literal outcomes exactly.

## Literal assertions pinned

ISO timestamp strings (scalar branch → `formatValue` → `cleanMarkdown`, verbatim):
- `{ custom_ts: "2023-12-31T23:59:59.999Z" }` → `"Custom Ts: 2023-12-31T23:59:59.999Z"`
- `{ custom_ts: "2023-06-15T08:30:00.123+05:30" }` → `"Custom Ts: 2023-06-15T08:30:00.123+05:30"` (fractional seconds + offset exact)
- `{ portfolio_summary: { as_of: "2023-12-31T23:59:59.999Z" } }` → `"\n--- Portfolio Summary ---\n  As Of: 2023-12-31T23:59:59.999Z"`

Native `Date` objects (object/array branches iterate empty own-enumerables):
- top-level `Date` → `"\n--- Custom Ts ---"` (bare header, value dropped, no throw)
- nested `Date` → `"\n--- Portfolio Summary ---\n  As Of:"` (empty label line)
- `Date` items in an array → `"\n--- Events (2 items) ---\n  • Item\n  • Item"`
- invalid `Date` (`new Date("not-a-real-date")`) → does not throw; → `"\n--- Custom Ts ---"`

## Verification

- `npm test -- __tests__/utils/format-json-dates.test.ts` → 7/7 pass
- `git status` limited to the single new test file; zero production source drift

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — documents real, existing behavioral boundaries (Date
  precision is dropped via empty own-enumerables; ISO strings pass through verbatim)
- [x] Strict Literal Mapping — branch, commit subject, and PR title match verbatim:
  `test/characterize-format-complete-json-date-objects` /
  `test(utils): characterize formatCompleteJson on date objects and ISO strings`
