### PR TITLE
test(app-page-shell): cover shell data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/components/app-page-shell.test.tsx
+++ b/hushh-webapp/__tests__/components/app-page-shell.test.tsx
@@ -8,6 +8,14 @@ import {
 } from "@/components/app-ui/app-page-shell";
 
 describe("AppPageShell", () => {
+  it("renders shell with data-slot='app-page-shell'", () => {
+    render(<AppPageShell>Content</AppPageShell>);
+
+    expect(screen.getByRole("main").getAttribute("data-slot")).toBe(
+      "app-page-shell"
+    );
+  });
+
   it("defaults signed-in page shells to compact density", () => {
     render(
       <AppPageShell>

--- a/hushh-webapp/components/app-ui/app-page-shell.tsx
+++ b/hushh-webapp/components/app-ui/app-page-shell.tsx
@@ -82,6 +82,7 @@ export function AppPageShell<T extends ElementType = "main">({
         APP_SHELL_MAX_WIDTHS[width], // 4. Utilizing Tailwind utility classes over inline styles
         className
       )}
+      data-slot="app-page-shell"
       data-app-density={density}
       data-app-shell-width={width}
       data-top-content-anchor="true"


### PR DESCRIPTION
## Summary
- Add `data-slot=app-page-shell` to the AppPageShell root element.
- Add focused coverage for the shell data-slot contract.

## Why
This gives AppPageShell the same stable slot contract pattern used by the UI shell tests and locks it with coverage.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched `integration/pr-train` head before this commit.

## No Overlap Proof
- Files changed: `hushh-webapp/components/app-ui/app-page-shell.tsx` and `hushh-webapp/__tests__/components/app-page-shell.test.tsx` only.
- The production change is limited to adding the AppPageShell root `data-slot` attribute.
- The test adds one focused assertion for that shell slot contract.

## Validation
- `npm.cmd test -- __tests__/components/app-page-shell.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.