### PR TITLE
refactor(api): parse upstream consent revoke error payloads as json

### DIFF
--- a/hushh-webapp/app/api/consent/revoke/route.ts
+++ b/hushh-webapp/app/api/consent/revoke/route.ts
@@ -56,25 +56,18 @@ export async function POST(request: NextRequest) {
       body: JSON.stringify({ userId, scope }),
     });
 
-    const responseText = await response.text();
-    console.log(`[API] Backend response status: ${response.status}`);
-    console.log(`[API] Backend response body: ${responseText}`);
-
     if (!response.ok) {
-      console.error("[API] Backend error:", responseText);
-      return NextResponse.json(
-        { error: responseText || "Failed to revoke consent" },
-        { status: response.status },
-      );
+      const errorPayload = await response
+        .json()
+        .catch(async () => ({
+          error: (await response.text().catch(() => "")) || "Failed to revoke consent",
+        }));
+      console.error("[API] Backend error:", response.status, errorPayload);
+      return NextResponse.json(errorPayload, { status: response.status });
     }
 
-    // Parse JSON response
-    try {
-      const data = JSON.parse(responseText);
-      return NextResponse.json(data);
-    } catch {
-      return NextResponse.json({ status: "revoked", raw: responseText });
-    }
+    const data = await response.json().catch(() => ({ status: "revoked" }));
+    return NextResponse.json(data);
   } catch (error) {
     console.error("[API] Revoke consent error:", error);
     return NextResponse.json(


### PR DESCRIPTION
### Description

Refactors `app/api/consent/revoke/route.ts` to natively parse upstream JSON errors instead of eagerly extracting text. Prevents double-stringification of error objects.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `app/api/consent/revoke/route.ts`

- Trust boundary touched:
  - [x] consent

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`app/api/consent/revoke/route.ts`)
- [ ] **iOS**: N/A (Web route only)
- [ ] **Android**: N/A (Web route only)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: consent
- [x] Error path, rollback, or safe-failure behavior proved: Upstream errors are now safely mapped to the frontend without stringification corruption.