### PR TITLE
test(fullscreen-flow-shell): cover close button type contract

### DIFF
--- a/hushh-webapp/__tests__/components/fullscreen-flow-shell.test.tsx
+++ b/hushh-webapp/__tests__/components/fullscreen-flow-shell.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { FullscreenFlowShell } from "@/components/app-ui/fullscreen-flow-shell";
+
+describe("FullscreenFlowShell", () => {
+  it("renders close button with type='button'", () => {
+    render(
+      <FullscreenFlowShell onClose={vi.fn()}>
+        Content
+      </FullscreenFlowShell>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Close" }).getAttribute("type"),
+    ).toBe("button");
+  });
+});

--- a/hushh-webapp/components/app-ui/fullscreen-flow-shell.tsx
+++ b/hushh-webapp/components/app-ui/fullscreen-flow-shell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ComponentPropsWithoutRef, ElementType } from "react";
+import { XIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
@@ -26,12 +27,17 @@ const WIDTH_CLASS_MAP: Record<FullscreenFlowShellWidth, string> = {
 type FullscreenFlowShellProps<T extends ElementType> = {
   as?: T;
   width?: FullscreenFlowShellWidth;
+  onClose?: () => void;
+  closeLabel?: string;
 } & Omit<ComponentPropsWithoutRef<T>, "as">;
 
 export function FullscreenFlowShell<T extends ElementType = "main">({
   as,
   width = "standard",
+  onClose,
+  closeLabel = "Close",
   className,
+  children,
   style,
   ...props
 }: FullscreenFlowShellProps<T>) {
@@ -48,6 +54,18 @@ export function FullscreenFlowShell<T extends ElementType = "main">({
       data-fullscreen-flow-shell="true"
       data-top-content-anchor="true"
       {...props}
-    />
+    >
+      {onClose ? (
+        <button
+          type="button"
+          aria-label={closeLabel}
+          onClick={onClose}
+          className="absolute right-4 top-4 inline-flex size-10 items-center justify-center rounded-full bg-background/80 text-foreground shadow-sm ring-1 ring-border/70 backdrop-blur transition hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <XIcon className="size-4" aria-hidden="true" />
+        </button>
+      ) : null}
+      {children}
+    </Component>
   );
 }


### PR DESCRIPTION
## Summary
- Add an optional FullscreenFlowShell close control via `onClose` and `closeLabel`.
- Lock the close control contract so the rendered close button uses `type=button`.

## Why
Fullscreen flow close controls should never default to submit behavior when rendered inside forms or form-like flows.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched `integration/pr-train` head before this commit.

## No Overlap Proof
- Files changed: `hushh-webapp/components/app-ui/fullscreen-flow-shell.tsx` and `hushh-webapp/__tests__/components/fullscreen-flow-shell.test.tsx` only.
- The production change is limited to an opt-in close control on FullscreenFlowShell.
- The test adds one focused assertion for the close button `type=button` contract.

## Validation
- `npm.cmd test -- __tests__/components/fullscreen-flow-shell.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.