### PR TITLE
test(hushh-loader): cover loader progress accessibility

### DIFF
--- a/hushh-webapp/__tests__/components/hushh-loader.test.tsx
+++ b/hushh-webapp/__tests__/components/hushh-loader.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { HushhLoader } from "@/components/app-ui/hushh-loader";
+
+describe("HushhLoader", () => {
+  it("renders progress status with polite busy semantics", () => {
+    render(<HushhLoader label="Loading portfolio" />);
+
+    const status = screen.getByRole("status");
+
+    expect(status.getAttribute("aria-live")).toBe("polite");
+    expect(status.getAttribute("aria-busy")).toBe("true");
+    expect(status.getAttribute("aria-atomic")).toBe("true");
+    expect(screen.getByText("Loading portfolio")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for HushhLoader progress accessibility.
- Assert the loader status exposes polite live-region, busy, and atomic semantics while rendering the visible loading label.

## Why
This locks the accessible progress contract for the canonical loader without changing runtime behavior.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched `integration/pr-train` head before this commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/components/hushh-loader.test.tsx` only.
- This PR creates one focused HushhLoader component test for progress accessibility semantics.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/components/hushh-loader.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.