### PR TITLE
test(inline-loading-state): cover loading status semantics

### DIFF
--- a/hushh-webapp/__tests__/components/inline-loading-state.test.tsx
+++ b/hushh-webapp/__tests__/components/inline-loading-state.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { InlineLoadingState } from "@/components/app-ui/inline-loading-state";
+
+describe("InlineLoadingState", () => {
+  it("renders loading status with accessible label semantics", () => {
+    render(<InlineLoadingState label="Loading holdings" />);
+
+    const status = screen.getByRole("status", { name: "Loading holdings" });
+
+    expect(status).toBeTruthy();
+    expect(screen.getByText("Loading holdings")).toBeTruthy();
+    expect(status.querySelector("svg")?.getAttribute("aria-hidden")).toBe(
+      "true",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for InlineLoadingState status semantics.
- Assert the loading status is discoverable by accessible name and keeps the spinner icon hidden from assistive technology.

## Why
This locks the inline loading accessibility contract without changing runtime behavior.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched `integration/pr-train` head before this commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/components/inline-loading-state.test.tsx` only.
- This PR creates one focused InlineLoadingState component test for loading status semantics.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/components/inline-loading-state.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.