### PR TITLE
fix(dashboard): enforce explicit button type in coming soon card

### DIFF
--- a/hushh-webapp/components/dashboard/coming-soon-card.tsx
+++ b/hushh-webapp/components/dashboard/coming-soon-card.tsx
@@ -31,7 +31,7 @@ export function ComingSoonCard({ title, description, icon: Icon, color = 'text-b
             🚧 This domain is under development
           </p>
         </div>
-        <Button variant="gradient" effect="glass" className="w-full" disabled showRipple>
+        <Button type="button" variant="gradient" effect="glass" className="w-full" disabled showRipple>
           Notify Me When Ready
         </Button>
       </CardContent>


### PR DESCRIPTION
### Description

Fixes a missing `type="button"` attribute on the "Notify Me" button inside `ComingSoonCard`. Prevents unintended form submissions if the component is ever nested inside a `<form>` context in the future.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/dashboard/coming-soon-card.tsx`

- Trust boundary touched:
  - [x] none (purely presentational UI component)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/dashboard/coming-soon-card.tsx`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none
- [x] Error path, rollback, or safe-failure behavior proved: N/A - Pure UI prop enforcement change.