### PR TITLE
test(paginated-list-footer): cover disabled navigation state

### DIFF
--- a/hushh-webapp/__tests__/components/paginated-list-footer.test.tsx
+++ b/hushh-webapp/__tests__/components/paginated-list-footer.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PaginatedListFooter } from "@/components/app-ui/paginated-list-footer";
+
+describe("PaginatedListFooter", () => {
+  it("disables navigation controls when movement is unavailable", () => {
+    render(
+      <PaginatedListFooter
+        page={1}
+        limit={10}
+        total={20}
+        hasMore={false}
+        onPrevious={vi.fn()}
+        onNext={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Go to previous page" }).hasAttribute(
+        "disabled",
+      ),
+    ).toBe(true);
+    expect(
+      screen.getByRole("button", { name: "Go to next page" }).hasAttribute(
+        "disabled",
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for PaginatedListFooter disabled navigation state.
- Assert previous and next controls are disabled when navigation is unavailable.

## Why
This locks the pagination footer navigation contract without changing runtime behavior.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched `integration/pr-train` head before this commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/components/paginated-list-footer.test.tsx` only.
- This PR creates one focused PaginatedListFooter component test for disabled navigation controls.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/components/paginated-list-footer.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.