### PR TITLE
fix(gmail): enforce explicit button type for vault unlock button

### DIFF
--- a/hushh-webapp/components/gmail/gmail-receipts-page.tsx
+++ b/hushh-webapp/components/gmail/gmail-receipts-page.tsx
@@ -1301,7 +1301,7 @@ export default function ProfileReceiptsPage() {
                 <Lock className="h-4 w-4" />
                 Unlock your vault to view and summarize synced receipts.
               </div>
-              <Button onClick={requestVaultUnlock}>Unlock vault</Button>
+              <Button type="button" onClick={requestVaultUnlock}>Unlock vault</Button>
             </SurfaceInset>
           ) : null}
 


### PR DESCRIPTION
### Description

Fixes a missing `type="button"` attribute on the "Unlock vault" button inside the Gmail receipts page. Enforcing this prevents unintended form submissions and layout refreshes if the component is ever placed inside a `<form>` context.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/gmail/gmail-receipts-page.tsx`

- Trust boundary touched:
  - [x] none (purely presentational UI component wrapper for vault unlock request)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/gmail/gmail-receipts-page.tsx`)
- [ ] **iOS**: N/A (Web UI only)
- [ ] **Android**: N/A (Web UI only)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none
- [x] Error path, rollback, or safe-failure behavior proved: N/A - Pure UI prop enforcement change.