### PR TITLE
fix(kai): enforce explicit button types in portfolio source switcher

### DIFF
--- a/hushh-webapp/components/kai/portfolio-source-switcher.tsx
+++ b/hushh-webapp/components/kai/portfolio-source-switcher.tsx
@@ -124,6 +124,7 @@ export function PortfolioSourceSwitcher({
           <div className="flex flex-wrap items-center gap-2">
             {showImportStatement ? (
               <Button
+                type="button"
                 variant="none"
                 effect="fade"
                 size="sm"
@@ -145,6 +146,7 @@ export function PortfolioSourceSwitcher({
                 </Badge>
                 {onRefreshPlaid ? (
                   <Button
+                    type="button"
                     variant="none"
                     effect="fade"
                     size="sm"
@@ -158,12 +160,12 @@ export function PortfolioSourceSwitcher({
                   </Button>
                 ) : null}
                 {onCancelRefreshPlaid && isRefreshing ? (
-                  <Button variant="none" effect="fade" size="sm" onClick={onCancelRefreshPlaid}>
+                  <Button type="button" variant="none" effect="fade" size="sm" onClick={onCancelRefreshPlaid}>
                     Cancel
                   </Button>
                 ) : null}
                 {onManageConnections ? (
-                  <Button variant="none" effect="fade" size="sm" onClick={onManageConnections}>
+                  <Button type="button" variant="none" effect="fade" size="sm" onClick={onManageConnections}>
                     {(freshness?.itemCount || 0) > 0 ? "Connect Another Brokerage" : "Connect Plaid"}
                   </Button>
                 ) : null}
@@ -171,6 +173,7 @@ export function PortfolioSourceSwitcher({
             ) : null}
             {onDeletePortfolio ? (
               <Button
+                type="button"
                 variant="none"
                 effect="fade"
                 size="sm"


### PR DESCRIPTION
### Description

Fixes missing `type="button"` attributes on 5 action buttons inside `PortfolioSourceSwitcher` (Import, Refresh, Cancel, Manage, Delete). Prevents unintended form submissions and page reloads when these components are nested inside `<form>` elements.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/kai/portfolio-source-switcher.tsx`

- Trust boundary touched:
  - [x] none (purely presentational UI component)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/kai/portfolio-source-switcher.tsx`)
- [ ] **iOS**: N/A (Web UI only)
- [ ] **Android**: N/A (Web UI only)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none
- [x] Error path, rollback, or safe-failure behavior proved: N/A - Pure UI prop enforcement change.