### PR TITLE
test(route-error-boundary): cover retry button type contract

### DIFF
--- a/hushh-webapp/__tests__/components/route-error-boundary.test.tsx
+++ b/hushh-webapp/__tests__/components/route-error-boundary.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RouteErrorBoundary } from "@/components/app-ui/route-error-boundary";
+
+function BrokenRoute() {
+  throw new Error("Route failed");
+}
+
+describe("RouteErrorBoundary", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders retry button with type='button'", () => {
+    render(
+      <RouteErrorBoundary>
+        <BrokenRoute />
+      </RouteErrorBoundary>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Try again" }).getAttribute("type"),
+    ).toBe("button");
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for RouteErrorBoundary retry button type.
- Trigger the fallback UI and assert the `Try again` retry control renders with `type=button`.

## Why
This locks the retry control contract so it cannot accidentally fall back to submit behavior in route recovery UI.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched `integration/pr-train` head before this commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/components/route-error-boundary.test.tsx` only.
- This PR creates one focused RouteErrorBoundary component test for the retry button type contract.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/components/route-error-boundary.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.