### PR TITLE
test(shell-action-surface): cover icon button accessible label

### DIFF
--- a/hushh-webapp/__tests__/components/shell-action-surface.test.tsx
+++ b/hushh-webapp/__tests__/components/shell-action-surface.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ShellActionSurface } from "@/components/app-ui/shell-action-surface";
+
+describe("ShellActionSurface", () => {
+  it("exposes icon button accessible label", () => {
+    render(
+      <ShellActionSurface variant="icon" aria-label="Open account actions">
+        <span aria-hidden="true">...</span>
+      </ShellActionSurface>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Open account actions" }),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for ShellActionSurface icon button accessible naming.
- Assert the icon variant exposes its `aria-label` as the button accessible name.

## Why
This locks the icon shell action accessibility contract without changing runtime behavior.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched `integration/pr-train` head before this commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/components/shell-action-surface.test.tsx` only.
- This PR creates one focused ShellActionSurface component test for icon button accessible labels.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/components/shell-action-surface.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.