### PR TITLE
test(navigation): characterize normalizeInternalRouteHref multi-segment query merges

### DIFF
--- a/hushh-webapp/__tests__/navigation/normalize-query-merges.test.ts
+++ b/hushh-webapp/__tests__/navigation/normalize-query-merges.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for normalizeInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts) focused on deep multi-segment paths
+// that carry saturated query strings.
+//
+// Real guard:
+//   const href = String(value ?? "").trim();
+//   if (!href) return null;
+//   if (!href.startsWith("/") || href.startsWith("//")) return null;
+//   if (/[\r\n]/.test(href)) return null;
+//   return href;
+//
+// TRUTH-FIRST: the guard does NOT parse, merge, reorder, dedupe, or isolate
+// query parameters, and it does NOT collapse to a root segment. It is a pure
+// prefix/character gate. If the input starts with a single "/", is not "//",
+// and has no CR/LF, the ENTIRE string — path + "?" + full query string — is
+// returned VERBATIM. There is no "structural parameter merge" behavior to pin;
+// the whole query is preserved exactly as given.
+
+describe("normalizeInternalRouteHref — multi-segment paths with query merges", () => {
+  it("preserves a deep path with multiple query params verbatim (no isolation)", () => {
+    expect(
+      normalizeInternalRouteHref("/api/legal/v1/doc?type=json&status=active")
+    ).toBe("/api/legal/v1/doc?type=json&status=active");
+  });
+
+  it("does NOT reorder or dedupe repeated query keys", () => {
+    expect(
+      normalizeInternalRouteHref("/x?a=1&a=2&b=3&a=4")
+    ).toBe("/x?a=1&a=2&b=3&a=4");
+  });
+
+  it("preserves an empty-value and a valueless param exactly", () => {
+    expect(normalizeInternalRouteHref("/x?a=&b&c=3")).toBe("/x?a=&b&c=3");
+  });
+
+  it("keeps a trailing '?' with no params", () => {
+    expect(normalizeInternalRouteHref("/x?")).toBe("/x?");
+  });
+
+  it("retains a hash fragment after the query string", () => {
+    expect(normalizeInternalRouteHref("/x?a=1#frag")).toBe("/x?a=1#frag");
+  });
+
+  it("preserves percent-encoded values inside the query verbatim", () => {
+    expect(
+      normalizeInternalRouteHref("/search?q=hello%20world&lang=en%2Dus")
+    ).toBe("/search?q=hello%20world&lang=en%2Dus");
+  });
+
+  it("trims surrounding whitespace but keeps the full query intact", () => {
+    expect(
+      normalizeInternalRouteHref("   /api/doc?type=json&status=active   ")
+    ).toBe("/api/doc?type=json&status=active");
+  });
+
+  it("rejects a protocol-relative path even when it carries a query string", () => {
+    expect(
+      normalizeInternalRouteHref("//evil.com/doc?type=json")
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Extends characterization coverage for `normalizeInternalRouteHref`
(`hushh-webapp/lib/navigation/routes.ts`) to document how it treats deep
multi-segment paths carrying saturated query strings (e.g.
`/api/legal/v1/doc?type=json&status=active`). Test-only; no production change.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/navigation/...`. There
  is no top-level `__tests__` in this repo; vitest only includes `__tests__/**`
  under `hushh-webapp`. The file therefore lives at
  `hushh-webapp/__tests__/navigation/normalize-query-merges.test.ts`.
- **There is no query "merge", parse, reorder, dedupe, or root-isolation
  behavior.** The guard is a pure prefix/character gate:

  ```ts
  const href = String(value ?? "").trim();
  if (!href) return null;
  if (!href.startsWith("/") || href.startsWith("//")) return null;
  if (/[\r\n]/.test(href)) return null;
  return href;
  ```

  When the input starts with a single `/`, is not `//`, and has no CR/LF, the
  **entire string — path + `?` + full query (+ `#fragment`) — is returned
  verbatim**. Structural parameters are fully preserved; nothing is isolated to a
  root segment.

## Behavior pinned

- `/api/legal/v1/doc?type=json&status=active` → preserved verbatim
- `/x?a=1&a=2&b=3&a=4` → repeated keys kept in order (no reorder/dedupe)
- `/x?a=&b&c=3` → empty-value and valueless params kept exactly
- `/x?` → trailing `?` preserved
- `/x?a=1#frag` → hash fragment retained after query
- `/search?q=hello%20world&lang=en%2Dus` → percent-encoding preserved verbatim
- `   /api/doc?type=json&status=active   ` → ends trimmed, query intact
- `//evil.com/doc?type=json` → `null` (protocol-relative rejected regardless of query)

## Verification

- `npm test -- __tests__/navigation/normalize-query-merges.test.ts` → 8/8 pass
- `git status` limited to the single new test file; no production source changed

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the verbatim-or-null gate (no query manipulation / no
  root isolation) rather than an assumed parameter-merge behavior
