### PR TITLE
test(navigation): characterize resolveInternalRouteHref array parameter strings

### DIFF
--- a/hushh-webapp/__tests__/navigation/resolve-array-params.test.ts
+++ b/hushh-webapp/__tests__/navigation/resolve-array-params.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for resolveInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts) focused on array-formatted query
+// variables (repeated keys and `key[]=` / `key[i]=` bracket syntax).
+//
+// Real implementation:
+//   export function resolveInternalRouteHref(value, fallback) {
+//     return normalizeInternalRouteHref(value) ?? fallback;
+//   }
+//   // normalizeInternalRouteHref: trim → null unless starts with single "/",
+//   // not "//", and no CR/LF → otherwise returns the string verbatim.
+//
+// TRUTH-FIRST: resolveInternalRouteHref does NOT parse query strings, does NOT
+// understand array parameters, does NOT split repeated keys into arrays, and
+// does NOT interpret `[]` / `[index]` brackets. It is a thin wrapper:
+//   - if the value is an accepted internal href, the WHOLE string (path + full
+//     query, including every array-style param and bracket, verbatim) is
+//     returned unchanged;
+//   - otherwise the provided fallback string is returned.
+// There are no "indices" parsed or retained — bracket characters survive only
+// because the entire href is passed through untouched.
+
+const FALLBACK = "/safe";
+
+describe("resolveInternalRouteHref — array-style query parameters", () => {
+  it("returns repeated-key arrays verbatim (no splitting/dedup)", () => {
+    expect(
+      resolveInternalRouteHref("/filter?tags=dev&tags=prod", FALLBACK)
+    ).toBe("/filter?tags=dev&tags=prod");
+  });
+
+  it("returns empty-bracket `tags[]=` syntax verbatim (brackets untouched)", () => {
+    expect(
+      resolveInternalRouteHref("/filter?tags[]=dev", FALLBACK)
+    ).toBe("/filter?tags[]=dev");
+  });
+
+  it("returns indexed-bracket `tags[0]=`/`tags[1]=` syntax verbatim", () => {
+    expect(
+      resolveInternalRouteHref("/filter?tags[0]=dev&tags[1]=prod", FALLBACK)
+    ).toBe("/filter?tags[0]=dev&tags[1]=prod");
+  });
+
+  it("preserves percent-encoded brackets exactly as supplied", () => {
+    expect(
+      resolveInternalRouteHref("/filter?tags%5B%5D=dev", FALLBACK)
+    ).toBe("/filter?tags%5B%5D=dev");
+  });
+
+  it("trims surrounding whitespace but keeps the array query intact", () => {
+    expect(
+      resolveInternalRouteHref("   /filter?tags=dev&tags=prod   ", FALLBACK)
+    ).toBe("/filter?tags=dev&tags=prod");
+  });
+
+  it("falls back when an array-param URL is protocol-relative", () => {
+    expect(
+      resolveInternalRouteHref("//evil.com/filter?tags[]=dev", FALLBACK)
+    ).toBe(FALLBACK);
+  });
+
+  it("falls back when an array-param URL is absolute (non-internal)", () => {
+    expect(
+      resolveInternalRouteHref("https://evil.com/f?tags=dev&tags=prod", FALLBACK)
+    ).toBe(FALLBACK);
+  });
+
+  it("falls back for null/empty input regardless of intended params", () => {
+    expect(resolveInternalRouteHref(null, FALLBACK)).toBe(FALLBACK);
+    expect(resolveInternalRouteHref("", FALLBACK)).toBe(FALLBACK);
+  });
+});


### PR DESCRIPTION
## Summary

Documents the characterization contract of `resolveInternalRouteHref`
(`hushh-webapp/lib/navigation/routes.ts`) when array-formatted query variables
(repeated keys and `key[]=` / `key[index]=` bracket syntax) are appended to an
internal route string. Test-only; no production change.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/navigation/...`. There
  is no top-level `__tests__` in this repo; vitest only includes `__tests__/**`
  under `hushh-webapp`. The file therefore lives at
  `hushh-webapp/__tests__/navigation/resolve-array-params.test.ts`.
- `resolveInternalRouteHref(value, fallback)` is a thin wrapper:

  ```ts
  return normalizeInternalRouteHref(value) ?? fallback;
  ```

  It does **not** parse query strings, does **not** understand array params,
  does **not** split repeated keys into arrays, and does **not** interpret `[]`
  / `[index]` brackets. There are no "indices parsed or retained" — bracket
  characters survive purely because the whole accepted href is returned verbatim.
  Otherwise the supplied `fallback` is returned.

## Behavior pinned (fallback = `/safe`)

- `/filter?tags=dev&tags=prod` → returned verbatim (no split/dedup)
- `/filter?tags[]=dev` → returned verbatim (brackets untouched)
- `/filter?tags[0]=dev&tags[1]=prod` → returned verbatim (indices untouched)
- `/filter?tags%5B%5D=dev` → percent-encoded brackets preserved exactly
- `   /filter?tags=dev&tags=prod   ` → ends trimmed, array query intact
- `//evil.com/filter?tags[]=dev` → `/safe` (protocol-relative rejected → fallback)
- `https://evil.com/f?tags=dev&tags=prod` → `/safe` (absolute/non-internal → fallback)
- `null` / `""` → `/safe` (fallback regardless of intended params)

## Verification

- `npm test -- __tests__/navigation/resolve-array-params.test.ts` → 8/8 pass
- `git status` limited to the single new test file; no production source changed

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the wrapper contract (verbatim internal href, else
  fallback; no query/array parsing) instead of an assumed array-digestion behavior
