### PR TITLE
test(utils): characterize formatCompleteJson on empty object configurations

### DIFF
--- a/hushh-webapp/__tests__/utils/format-empty-objects.test.ts
+++ b/hushh-webapp/__tests__/utils/format-empty-objects.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCompleteJson } from "@/lib/utils/json-to-human";
+
+// Characterization tests for formatCompleteJson
+// (hushh-webapp/lib/utils/json-to-human.ts) focused on deeply nested but
+// entirely empty object trees.
+//
+// TRUTH-FIRST (verified against the source):
+//   - formatCompleteJson emits NO brackets at all. There is no `{`/`}` in the
+//     output; it produces section headers (`--- Label ---`) and indented label
+//     lines instead. "Structural cleanliness" here means: empty objects collapse
+//     to headers/labels with no bracket characters.
+//   - Level 1 (top-level empty object `a: {}`): pushes a blank line then a
+//     `--- A ---` header; the entries loop over `{}` adds nothing.
+//   - Level 2 (`b: { c: {} }`): header `--- B ---`, then `  C:` (nested-object
+//     branch prints the label with a trailing colon), and the empty `{}` adds
+//     no child bullets.
+//   - Level 3 (`b: { c: { d: {} } }`): the 3rd-level empty object is NOT
+//     recursed; it reaches the scalar `formatValue` path as a bullet, and
+//     `formatValue` falls through to `String({})`, leaking the literal
+//     `[object Object]`. This is the real (leaky) boundary, pinned here.
+
+describe("formatCompleteJson — empty object trees", () => {
+  it("collapses a single top-level empty object to a bare header (no brackets)", () => {
+    const out = formatCompleteJson({ a: {} });
+    expect(out).toBe("\n--- A ---");
+    expect(out).not.toContain("{");
+    expect(out).not.toContain("}");
+  });
+
+  it("formats `{ a: {}, b: { c: {} } }` as headers + a single label line", () => {
+    const out = formatCompleteJson({ a: {}, b: { c: {} } });
+    expect(out).toBe("\n--- A ---\n\n--- B ---\n  C:");
+    expect(out).not.toContain("{");
+    expect(out).not.toContain("}");
+  });
+
+  it("emits no child bullets for a level-2 empty nested object", () => {
+    const out = formatCompleteJson({ b: { c: {} } });
+    expect(out).toBe("\n--- B ---\n  C:");
+    expect(out.split("\n")).toHaveLength(3);
+  });
+
+  it("leaks '[object Object]' for a level-3 empty object (real boundary)", () => {
+    const out = formatCompleteJson({ b: { c: { d: {} } } });
+    expect(out).toBe("\n--- B ---\n  C:\n    • D: [object Object]");
+  });
+
+  it("renders multiple sibling empty objects as independent headers", () => {
+    const out = formatCompleteJson({ a: {}, b: {}, c: {} });
+    expect(out).toBe("\n--- A ---\n\n--- B ---\n\n--- C ---");
+  });
+});


### PR DESCRIPTION
## Summary

Pins the formatting boundaries of `formatCompleteJson`
(`hushh-webapp/lib/utils/json-to-human.ts`) when traversing payloads containing
completely empty (blank) child object properties, including deeply nested empty
trees. Test-only; no production change.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/utils/...`. There is no
  top-level `__tests__` in this repo; vitest only includes `__tests__/**` under
  `hushh-webapp`. The file therefore lives at
  `hushh-webapp/__tests__/utils/format-empty-objects.test.ts`.
- **`formatCompleteJson` emits NO brackets at all** — there are no `{` / `}`
  characters in its output. "Structural cleanliness" is real but it is *not*
  expressed via open/close brackets: the formatter produces section headers
  (`--- Label ---`) and indented label / `•` bullet lines instead. The test
  asserts the actual header/label output and explicitly checks the output
  contains no braces, rather than asserting a (nonexistent) bracket layout.
- The traversal is **depth-limited**. Empty objects are flattened to headers
  only down to the levels the formatter recurses; at the 3rd nesting level an
  empty object is no longer recursed and instead hits the scalar `formatValue`
  path, which falls through to `String({})` and **leaks the literal
  `[object Object]`**. That leaky boundary is pinned here rather than hidden.

## Behavior pinned

- `{ a: {} }` → `"\n--- A ---"` (bare header, no braces)
- `{ a: {}, b: { c: {} } }` → `"\n--- A ---\n\n--- B ---\n  C:"`
- `{ b: { c: {} } }` → `"\n--- B ---\n  C:"` (no child bullets; 3 lines)
- `{ b: { c: { d: {} } } }` → `"\n--- B ---\n  C:\n    • D: [object Object]"`
  (real depth-limit leak)
- `{ a: {}, b: {}, c: {} }` → three independent `--- X ---` headers

## Verification

- `npm test -- __tests__/utils/format-empty-objects.test.ts` → 5/5 pass
- `git status` limited to the single new test file; no production source changed

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the real header/label output (no brackets) and the
  level-3 `[object Object]` leak, instead of an assumed open/close-bracket layout
