### PR TITLE
test(navigation): characterize normalizeInternalRouteHref percent-encoded slashes

### DIFF
--- a/hushh-webapp/__tests__/navigation/normalize-encoded-slashes.test.ts
+++ b/hushh-webapp/__tests__/navigation/normalize-encoded-slashes.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for normalizeInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts) focused on percent-encoded forward
+// slashes (`%2F` / `%2f`) appearing inside path or query string parameters.
+//
+// Real implementation:
+//   const href = String(value ?? "").trim();
+//   if (!href) return null;
+//   if (!href.startsWith("/") || href.startsWith("//")) return null;
+//   if (/[\r\n]/.test(href)) return null;
+//   return href;
+//
+// TRUTH-FIRST: normalizeInternalRouteHref does NOT decode, parse, split, or
+// segment the path. It performs no `%2F` → `/` decoding and no "sub-segment
+// isolation". `%2F` is treated as three opaque characters and survives verbatim.
+// The only `/`-aware logic is the leading-character guard: the FIRST raw
+// character must be a single `/` (and the string must not start with `//`).
+// An encoded slash is never interpreted as a path delimiter.
+
+describe("normalizeInternalRouteHref — percent-encoded slashes (%2F)", () => {
+  it("retains %2F inside a path segment verbatim (no decode, no split)", () => {
+    expect(
+      normalizeInternalRouteHref("/docs/legal%2Farchive")
+    ).toBe("/docs/legal%2Farchive");
+  });
+
+  it("retains lowercase %2f verbatim (no case-folding, no decode)", () => {
+    expect(
+      normalizeInternalRouteHref("/docs/legal%2farchive")
+    ).toBe("/docs/legal%2farchive");
+  });
+
+  it("retains %2F inside a query parameter value verbatim", () => {
+    expect(
+      normalizeInternalRouteHref("/search?path=a%2Fb%2Fc")
+    ).toBe("/search?path=a%2Fb%2Fc");
+  });
+
+  it("retains multiple encoded slashes without collapsing them", () => {
+    expect(
+      normalizeInternalRouteHref("/a%2F%2Fb")
+    ).toBe("/a%2F%2Fb");
+  });
+
+  it("does NOT decode %2F into a leading double-slash (single real leading slash passes)", () => {
+    // The literal leading char is "/", and char 2 is "%", not "/", so the
+    // "//" protocol-relative guard does not trigger; the %2F stays encoded.
+    expect(
+      normalizeInternalRouteHref("/%2Fevil.com")
+    ).toBe("/%2Fevil.com");
+  });
+
+  it("still rejects a genuine protocol-relative prefix even with encoded slashes after", () => {
+    expect(
+      normalizeInternalRouteHref("//host%2Fpath")
+    ).toBeNull();
+  });
+
+  it("trims surrounding whitespace but keeps encoded slashes intact", () => {
+    expect(
+      normalizeInternalRouteHref("   /docs/legal%2Farchive   ")
+    ).toBe("/docs/legal%2Farchive");
+  });
+
+  it("rejects an href whose encoded-slash content carries an INTERIOR newline", () => {
+    // The CR/LF guard runs AFTER trim(), so a trailing "\n" is stripped and the
+    // href passes; only a newline embedded mid-string is rejected.
+    expect(
+      normalizeInternalRouteHref("/docs/legal%2F\narchive")
+    ).toBeNull();
+  });
+
+  it("accepts a trailing newline because trim() removes it before the CR/LF guard", () => {
+    expect(
+      normalizeInternalRouteHref("/docs/legal%2Farchive\n")
+    ).toBe("/docs/legal%2Farchive");
+  });
+
+});


### PR DESCRIPTION
## Summary

Pins how `normalizeInternalRouteHref`
(`hushh-webapp/lib/navigation/routes.ts`) reacts when a percent-encoded forward
slash (`%2F` / `%2f`) appears inside a path segment or query string parameter
(e.g. `/docs/legal%2Farchive`). Test-only; no production change.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/navigation/...`. There
  is no top-level `__tests__` in this repo; vitest only includes `__tests__/**`
  under `hushh-webapp`. The file therefore lives at
  `hushh-webapp/__tests__/navigation/normalize-encoded-slashes.test.ts`.
- **There is no path splitting, decoding, or sub-segment isolation.** The guard
  is a pure prefix/character gate:

  ```ts
  const href = String(value ?? "").trim();
  if (!href) return null;
  if (!href.startsWith("/") || href.startsWith("//")) return null;
  if (/[\r\n]/.test(href)) return null;
  return href;
  ```

  `%2F` is **not** decoded to `/` and is **never** treated as a path delimiter —
  it is three opaque characters returned verbatim. The only `/`-aware logic is
  the leading-character guard (first raw char must be a single `/`, not `//`).

## Behavior pinned

- `/docs/legal%2Farchive` → preserved verbatim (no decode/split)
- `/docs/legal%2farchive` → lowercase `%2f` preserved (no case-folding)
- `/search?path=a%2Fb%2Fc` → encoded slashes in a query value preserved
- `/a%2F%2Fb` → consecutive encoded slashes not collapsed
- `/%2Fevil.com` → accepted; leading char is the real `/`, char 2 is `%` (not a
  `//` protocol-relative prefix), so `%2F` stays encoded
- `//host%2Fpath` → `null` (genuine protocol-relative prefix still rejected)
- `   /docs/legal%2Farchive   ` → ends trimmed, encoded slashes intact

## Real boundary discovered during verification

The CR/LF guard runs **after** `trim()`. A test asserting that a *trailing*
newline is rejected initially failed — `trim()` strips it first, so the href
passes. The suite now pins both true behaviors:

- `/docs/legal%2F\narchive` (interior newline) → `null`
- `/docs/legal%2Farchive\n` (trailing newline) → `"/docs/legal%2Farchive"`
  (trimmed, accepted)

## Verification

- `npm test -- __tests__/navigation/normalize-encoded-slashes.test.ts` → 9/9 pass
- `git status` limited to the single new test file; no production source changed

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the verbatim-or-null gate (no `%2F` decode, no path
  isolation) and the trim-before-CR/LF interior-vs-trailing newline boundary
