### PR TITLE
test(step-progress-bar): cover progress aria value bounds

### DIFF
--- a/hushh-webapp/__tests__/components/step-progress-bar.test.tsx
+++ b/hushh-webapp/__tests__/components/step-progress-bar.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const mockProgressState = vi.hoisted(() => ({
+  progress: 42,
+  isLoading: true,
+}));
+
+vi.mock("@/lib/progress/step-progress-context", () => ({
+  useStepProgress: () => ({
+    registerSteps: vi.fn(),
+    completeStep: vi.fn(),
+    reset: vi.fn(),
+    progress: mockProgressState.progress,
+    isLoading: mockProgressState.isLoading,
+    beginTask: vi.fn(),
+    completeTaskStep: vi.fn(),
+    endTask: vi.fn(),
+  }),
+}));
+
+import { StepProgressBar } from "@/components/app-ui/step-progress-bar";
+
+describe("StepProgressBar", () => {
+  it("renders progress aria value bounds", () => {
+    render(<StepProgressBar />);
+
+    const progressbar = screen.getByRole("progressbar", {
+      name: "Page loading",
+    });
+
+    expect(progressbar.getAttribute("aria-valuemin")).toBe("0");
+    expect(progressbar.getAttribute("aria-valuemax")).toBe("100");
+    expect(progressbar.getAttribute("aria-valuenow")).toBe("42");
+    expect(progressbar.getAttribute("aria-valuetext")).toBe("42%");
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for StepProgressBar progress aria value bounds.
- Assert the rendered progressbar exposes `aria-valuemin`, `aria-valuemax`, `aria-valuenow`, and matching `aria-valuetext`.

## Why
This locks the page loading progress accessibility contract without changing runtime behavior.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched `integration/pr-train` head before this commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/components/step-progress-bar.test.tsx` only.
- This PR creates one focused StepProgressBar component test for progress aria value bounds.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/components/step-progress-bar.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.