### PR TITLE
test(table): assert container role="region" accessibility contract

### DIFF
--- a/hushh-webapp/__tests__/ui/table.test.tsx
+++ b/hushh-webapp/__tests__/ui/table.test.tsx
@@ -21,4 +21,24 @@ describe("Table", () => {
 
     expect(tableContainer?.getAttribute("tabindex")).toBe("0");
   });
+  it("renders the table container with an accessible region role and label", () => {
+    const { container } = render(
+      <Table>
+        <tbody>
+          <tr>
+            <td>Holding</td>
+          </tr>
+        </tbody>
+      </Table>,
+    );
+
+    const tableContainer = container.querySelector(
+      '[data-slot="table-container"]',
+    );
+
+    expect(tableContainer?.getAttribute("role")).toBe("region");
+    expect(tableContainer?.getAttribute("aria-label")).toBe(
+      "Scrollable table",
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Adds an accessibility contract test for the table container.

## What changed

- Appended one test to `__tests__/ui/table.test.tsx`
- Verifies the table container exposes:
  - `role="region"`
  - `aria-label="Scrollable table"`

## Why

The accessibility attributes already exist in the component but were not covered by tests.

## Risk

- Test-only change
- Append-only
- No production code changes
- No runtime behaviour changes
- No new dependencies