### PR TITLE
refactor(api): parse upstream json errors during consent cancel

### DIFF
--- a/hushh-webapp/app/api/consent/cancel/route.ts
+++ b/hushh-webapp/app/api/consent/cancel/route.ts
@@ -57,14 +57,15 @@ export async function POST(request: NextRequest) {
     });
 
     if (!response.ok) {
-      const error = await response.text();
+      const errorPayload = await response
+        .json()
+        .catch(async () => ({
+          error: (await response.text().catch(() => "")) || "Failed to cancel consent",
+        }));
       if (process.env.NODE_ENV !== "production") {
-        console.error("[API] Cancel consent error:", error);
+        console.error("[API] Cancel consent error:", response.status, errorPayload);
       }
-      return NextResponse.json(
-        { error: "Failed to cancel consent" },
-        { status: response.status },
-      );
+      return NextResponse.json(errorPayload, { status: response.status });
     }
 
     const data = await response.json();


### PR DESCRIPTION
### Description

Refactors the error parsing logic inside `app/api/consent/cancel/route.ts` to cleanly parse structured JSON errors from the upstream Python API. This prevents upstream JSON error payloads from being swallowed and overridden by generic fallback text.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `app/api/consent/cancel/route.ts`

- Trust boundary touched:
  - [x] consent / revocation

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`app/api/consent/cancel/route.ts`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: consent
- [x] Error path, rollback, or safe-failure behavior proved: Upstream errors are now gracefully parsed as JSON instead of being discarded.