### PR TITLE
refactor(api): cleanly parse upstream json errors during consent logout

### DIFF
--- a/hushh-webapp/app/api/consent/logout/route.ts
+++ b/hushh-webapp/app/api/consent/logout/route.ts
@@ -42,12 +42,13 @@ export async function POST(request: NextRequest) {
     });
 
     if (!response.ok) {
-      const error = await response.text();
-      console.error("[API] Backend error:", error);
-      return NextResponse.json(
-        { error: "Failed to destroy session tokens" },
-        { status: response.status },
-      );
+      const errorPayload = await response
+        .json()
+        .catch(async () => ({
+          error: (await response.text().catch(() => "")) || "Failed to destroy session tokens",
+        }));
+      console.error("[API] Backend error:", response.status, errorPayload);
+      return NextResponse.json(errorPayload, { status: response.status });
     }
 
     const data = await response.json();


### PR DESCRIPTION
### Description

Refactors the error parsing logic inside `app/api/consent/logout/route.ts` to cleanly parse structured JSON errors from the upstream Python API. This prevents upstream JSON error payloads from being swallowed and overridden by a generic "Failed to destroy session tokens" string.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `app/api/consent/logout/route.ts`

- Trust boundary touched:
  - [x] consent / auth logout

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`app/api/consent/logout/route.ts`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: consent logout
- [x] Error path, rollback, or safe-failure behavior proved: Upstream errors are now gracefully parsed as JSON instead of being discarded.