### PR TITLE
test(table): assert data-slot on table element

### DIFF
--- a/hushh-webapp/__tests__/ui/table.test.tsx
+++ b/hushh-webapp/__tests__/ui/table.test.tsx
@@ -21,4 +21,19 @@ describe("Table", () => {
 
     expect(tableContainer?.getAttribute("tabindex")).toBe("0");
   });
+  it("renders the inner table element with the table data-slot contract", () => {
+    const { container } = render(
+      <Table>
+        <tbody>
+          <tr>
+            <td>Holding</td>
+          </tr>
+        </tbody>
+      </Table>,
+    );
+
+    const tableElement = container.querySelector("table");
+
+    expect(tableElement?.getAttribute("data-slot")).toBe("table");
+  });
 });


### PR DESCRIPTION
## Summary

Adds a focused contract test verifying that the rendered `<table>` element preserves the expected `data-slot="table"` attribute.

## What Changed

* Added a single additive contract test to `__tests__/ui/table.test.tsx`.
* Verifies the rendered native `<table>` element exposes `data-slot="table"`.

## Scope

* Test-only change.
* No production code modified.
* No component behavior changes.
* No styling changes.
* No API changes.

## Validation

```bash
npx vitest run __tests__/ui/table.test.tsx
```

## Risk

Low. This PR adds a deterministic contract test for an existing UI primitive without modifying runtime behavior.
