### PR TITLE
test(table): assert TableHead scope="col" and TableHeader data-slot contracts

### DIFF
--- a/hushh-webapp/__tests__/ui/table.test.tsx
+++ b/hushh-webapp/__tests__/ui/table.test.tsx
@@ -1,7 +1,7 @@
 import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { Table } from "@/components/ui/table";
+import { Table, TableHead, TableHeader } from "@/components/ui/table";
 
 describe("Table", () => {
   it("sets tabIndex on the overflow container for keyboard scrolling", () => {
@@ -20,5 +20,38 @@ describe("Table", () => {
     );
 
     expect(tableContainer?.getAttribute("tabindex")).toBe("0");
+  });
+  it("renders TableHead as a th element with a column scope", () => {
+    const { container } = render(
+      <Table>
+        <thead>
+          <tr>
+            <TableHead>Symbol</TableHead>
+          </tr>
+        </thead>
+      </Table>,
+    );
+
+    const head = container.querySelector('[data-slot="table-head"]');
+
+    expect(head?.tagName).toBe("TH");
+    expect(head?.getAttribute("scope")).toBe("col");
+  });
+
+  it("renders TableHeader with the table-header data-slot contract", () => {
+    const { container } = render(
+      <Table>
+        <TableHeader>
+          <tr>
+            <th>Symbol</th>
+          </tr>
+        </TableHeader>
+      </Table>,
+    );
+
+    const header = container.querySelector('[data-slot="table-header"]');
+
+    expect(header).toBeTruthy();
+    expect(header?.tagName).toBe("THEAD");
   });
 });


### PR DESCRIPTION
## Summary

Adds focused contract tests covering `TableHead` and `TableHeader` rendering contracts.

## What Changed

* Added a contract test verifying `TableHead` renders as a native `th` element with `scope="col"`.
* Added a contract test verifying `TableHeader` renders with the expected `data-slot="table-header"` contract.

## Scope

* Test-only change.
* No production code modified.
* No component behavior changes.
* No styling changes.
* No API changes.

## Validation

```bash
npx vitest run __tests__/ui/table.test.tsx
```

## Risk

Low. This PR adds deterministic contract coverage for existing UI primitives without changing runtime behavior.
