### PR TITLE
test(card): assert CardTitle renders as h3 element

### DIFF
--- a/hushh-webapp/__tests__/ui/card.test.tsx
+++ b/hushh-webapp/__tests__/ui/card.test.tsx
@@ -53,4 +53,18 @@ describe("Card", () => {
       container.querySelector('[data-slot="card-footer"]'),
     ).toBeTruthy();
   });
+
+  it("renders CardTitle as an h3 heading element", () => {
+    const { container } = render(
+      <Card>
+        <CardHeader>
+          <CardTitle>Title</CardTitle>
+        </CardHeader>
+      </Card>,
+    );
+
+    const title = container.querySelector('[data-slot="card-title"]');
+
+    expect(title?.tagName).toBe("H3");
+  });
 });


### PR DESCRIPTION
## Summary

Adds a focused contract test verifying the semantic heading element used by `CardTitle`.

## What Changed

* Added a single contract test confirming `CardTitle` renders as an `h3` element.

## Scope

* Test-only change.
* No production code modified.
* No component behavior changes.
* No styling changes.
* No API changes.

## Validation

```bash
npx vitest run __tests__/ui/card.test.tsx
```

## Risk

Very low. This PR adds deterministic semantic contract coverage to an existing UI primitive without changing runtime behavior.
