### PR TITLE
fix(kai): enforce explicit button type for empty state add holding button

### DIFF
--- a/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
+++ b/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
@@ -723,7 +723,7 @@ export function ManagePortfolioView() {
                   <p className="text-muted-foreground mb-4">
                     No holdings yet. Add your first holding or import a portfolio statement.
                   </p>
-                  <Button onClick={handleAddHolding} icon={{ icon: Plus, gradient: false }}>
+                  <Button type="button" onClick={handleAddHolding} icon={{ icon: Plus, gradient: false }}>
                     Add Holding
                   </Button>
                 </CardContent>


### PR DESCRIPTION
### Description

Fixes a missing `type="button"` attribute on the "Add Holding" empty-state button inside `ManagePortfolioView`. Prevents unintended form submissions and page reloads when the component is rendered inside `<form>` elements.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/kai/views/manage-portfolio-view.tsx`

- Trust boundary touched:
  - [x] none (purely presentational UI component wrapper)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/kai/views/manage-portfolio-view.tsx`)
## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none