### PR TITLE
test(breadcrumb): assert BreadcrumbPage aria-current="page"

### DIFF
--- a/hushh-webapp/__tests__/ui/breadcrumb.test.tsx
+++ b/hushh-webapp/__tests__/ui/breadcrumb.test.tsx
@@ -31,4 +31,21 @@ describe("Breadcrumb", () => {
     expect(list.children[1]).toBe(separator);
     expect(list.children[2]?.textContent).toBe("Settings");
   });
+
+  it('renders BreadcrumbPage with aria-current="page"', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbPage>Settings</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+
+    expect(
+      screen.getByText("Settings").getAttribute("aria-current"),
+    ).toBe("page");
+  });
+
 });


### PR DESCRIPTION
## Summary

Adds a focused contract test verifying that `BreadcrumbPage` exposes the expected `aria-current="page"` accessibility contract.

## What Changed

- Added a single contract test to `__tests__/ui/breadcrumb.test.tsx`.
- Verifies that `BreadcrumbPage` renders with `aria-current="page"`.

## Scope

- Test-only change.
- No production code modified.
- No component behavior changes.
- No styling changes.
- No API changes.

## Validation

```bash
npx vitest run __tests__/ui/breadcrumb.test.tsx
```

## Risk

Low. This PR adds deterministic accessibility contract coverage for an existing UI primitive without modifying runtime behavior.