### PR TITLE
test(breadcrumb): assert Breadcrumb root aria-label="breadcrumb"

### DIFF
--- a/hushh-webapp/__tests__/ui/breadcrumb.test.tsx
+++ b/hushh-webapp/__tests__/ui/breadcrumb.test.tsx
@@ -31,4 +31,19 @@ describe("Breadcrumb", () => {
     expect(list.children[1]).toBe(separator);
     expect(list.children[2]?.textContent).toBe("Settings");
   });
+
+  it('renders Breadcrumb root with aria-label="breadcrumb"', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>Home</BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+
+    const navigation = screen.getByRole("navigation");
+
+    expect(navigation.getAttribute("aria-label")).toBe("breadcrumb");
+  });
+
 });


### PR DESCRIPTION
## Summary

Adds a contract test verifying that the `Breadcrumb` root exposes the expected accessibility landmark.

## What changed

- Appended one test to `__tests__/ui/breadcrumb.test.tsx`
- Verifies the root navigation element exposes:
  - `aria-label="breadcrumb"`

## Why

The component already renders this accessibility attribute, but it was not covered by tests.

## Risk

- Test-only change
- Append-only
- No production code changes
- No runtime behaviour changes
- No new dependencies
- Deterministic test