### PR TITLE
test(native-route-marker): cover route marker data attributes

### DIFF
--- a/hushh-webapp/__tests__/components/native-route-marker.test.tsx
+++ b/hushh-webapp/__tests__/components/native-route-marker.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { NativeRouteMarker } from "@/components/app-ui/native-route-marker";
+
+describe("NativeRouteMarker", () => {
+  it("renders route marker data attributes", () => {
+    render(
+      <NativeRouteMarker
+        routeId="/one/location"
+        marker="native-route-one-location"
+        authState="authenticated"
+        dataState="loaded"
+      />,
+    );
+
+    const marker = screen.getByTestId("native-route-one-location");
+
+    expect(marker.getAttribute("aria-hidden")).toBe("true");
+    expect(marker.getAttribute("data-native-route-marker")).toBe("true");
+    expect(marker.getAttribute("data-native-route-id")).toBe("/one/location");
+    expect(marker.getAttribute("data-native-auth-default")).toBe(
+      "authenticated",
+    );
+    expect(marker.getAttribute("data-native-data-default")).toBe("loaded");
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for NativeRouteMarker route marker data attributes.
- Assert the marker renders hidden native route, route id, auth state, and data state attributes.

## Why
This locks the native route marker contract without changing runtime behavior.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched `integration/pr-train` head before this commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/components/native-route-marker.test.tsx` only.
- This PR creates one focused NativeRouteMarker component test for route marker data attributes.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/components/native-route-marker.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.