### PR TITLE
test(breadcrumb): assert BreadcrumbList data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/ui/breadcrumb.test.tsx
+++ b/hushh-webapp/__tests__/ui/breadcrumb.test.tsx
@@ -31,4 +31,19 @@ describe("Breadcrumb", () => {
     expect(list.children[1]).toBe(separator);
     expect(list.children[2]?.textContent).toBe("Settings");
   });
+
+  it('renders BreadcrumbList with data-slot="breadcrumb-list"', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>Home</BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+
+    const list = screen.getByRole("list");
+
+    expect(list.getAttribute("data-slot")).toBe("breadcrumb-list");
+  });
+
 });


### PR DESCRIPTION
## Summary

Adds a contract test verifying that `BreadcrumbList` exposes the expected `data-slot` attribute.

## What changed

- Appended one test to `__tests__/ui/breadcrumb.test.tsx`
- Verifies `BreadcrumbList` renders with:
  - `data-slot="breadcrumb-list"`

## Why

The component already renders this attribute, but it was not covered by tests.

## Risk

- Test-only change
- Append-only
- No production code changes
- No runtime behaviour changes
- No new dependencies
- Deterministic test