### PR TITLE
test(sidebar): assert SidebarProvider renders data-slot

### DIFF
--- a/hushh-webapp/__tests__/ui/sidebar.test.tsx
+++ b/hushh-webapp/__tests__/ui/sidebar.test.tsx
@@ -15,4 +15,17 @@ describe("Sidebar", () => {
       container.querySelector('[data-slot="sidebar-rail"]'),
     ).toBeTruthy();
   });
+
+  it('renders SidebarProvider wrapper with data-slot="sidebar-wrapper"', () => {
+    const { container } = render(
+      <SidebarProvider>
+        <div />
+      </SidebarProvider>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="sidebar-wrapper"]'),
+    ).toBeTruthy();
+  });
+
 });


### PR DESCRIPTION
## Summary

Adds a contract test verifying that `SidebarProvider` renders its wrapper with the expected `data-slot` attribute.

## What changed

- Appended one test to `__tests__/ui/sidebar.test.tsx`
- Verifies the provider wrapper renders:
  - `data-slot="sidebar-wrapper"`

## Why

The component already renders this attribute, but it was not covered by tests.

## Risk

- Test-only change
- Append-only
- No production code changes
- No runtime behaviour changes
- No new dependencies
- Deterministic test