### PR TITLE
test(native-test-beacon): cover auth and data state attributes

### DIFF
--- a/hushh-webapp/__tests__/components/native-test-beacon.test.tsx
+++ b/hushh-webapp/__tests__/components/native-test-beacon.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+
+import { NativeTestBeacon } from "@/components/app-ui/native-test-beacon";
+
+describe("NativeTestBeacon", () => {
+  it("renders auth and data state attributes", () => {
+    render(
+      <NativeTestBeacon
+        routeId="native://one/dashboard"
+        marker="native-test-dashboard"
+        authState="authenticated"
+        dataState="loaded"
+      />,
+    );
+
+    const beacon = screen.getByTestId("native-test-dashboard");
+
+    expect(beacon.getAttribute("aria-hidden")).toBe("true");
+    expect(beacon.getAttribute("data-native-test-beacon")).toBe("true");
+    expect(beacon.getAttribute("data-native-route-id")).toBe("native://one/dashboard");
+    expect(beacon.getAttribute("data-native-auth-state")).toBe("authenticated");
+    expect(beacon.getAttribute("data-native-data-state")).toBe("loaded");
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for NativeTestBeacon auth and data state attributes.
- Assert the beacon renders native route, marker, auth state, and data state attributes.

## Why
This locks the native test beacon state contract without changing runtime behavior.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched `integration/pr-train` head before this commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/components/native-test-beacon.test.tsx` only.
- This PR creates one focused NativeTestBeacon component test for auth/data state attributes.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/components/native-test-beacon.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.