### PR TITLE
fix(profile): enforce explicit button types in pkm natural panel

### DIFF
--- a/hushh-webapp/components/profile/pkm-natural-panel.tsx
+++ b/hushh-webapp/components/profile/pkm-natural-panel.tsx
@@ -417,11 +417,11 @@ export function PkmNaturalPanel({
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
-            <Button variant="none" effect="fade" onClick={() => setRefreshNonce((value) => value + 1)}>
+            <Button type="button" variant="none" effect="fade" onClick={() => setRefreshNonce((value) => value + 1)}>
               <RefreshCw className="mr-2 h-4 w-4" />
               Refresh
             </Button>
-            <Button variant="none" effect="fade" onClick={onOpenExplorer}>
+            <Button type="button" variant="none" effect="fade" onClick={onOpenExplorer}>
               Open Explorer view
             </Button>
           </div>


### PR DESCRIPTION
### Description

Fixes missing `type="button"` attributes on the "Refresh" and "Open Explorer view" buttons inside the `PkmNaturalPanel` component. This strictly prevents unintended form submissions if this component is ever rendered within a `<form>` tree.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/profile/pkm-natural-panel.tsx`

- Trust boundary touched:
  - [x] none (purely presentational UI component wrapper)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/profile/pkm-natural-panel.tsx`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none
- [x] Error path, rollback, or safe-failure behavior proved: N/A - Pure UI prop enforcement change.