### PR TITLE
test(chart): assert ChartContainer preserves className/data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/ui/chart.test.tsx
+++ b/hushh-webapp/__tests__/ui/chart.test.tsx
@@ -21,4 +21,18 @@ describe("ChartContainer", () => {
 
     expect(container.querySelector('[data-slot="chart"]')).toBeTruthy();
   });
+
+  it('preserves custom className alongside data-slot="chart"', () => {
+    const { container } = render(
+      <ChartContainer config={{}} className="my-custom-chart">
+        <div />
+      </ChartContainer>,
+    );
+
+    const chartEl = container.querySelector('[data-slot="chart"]');
+
+    expect(chartEl).toBeTruthy();
+    expect(chartEl?.className).toContain("my-custom-chart");
+  });
+
 });


### PR DESCRIPTION
## Summary

Adds a contract test verifying that `ChartContainer` preserves a custom `className` while rendering the expected `data-slot` attribute.

## What changed

- Appended one test to `__tests__/ui/chart.test.tsx`
- Verifies:
  - `data-slot="chart"` is rendered
  - A custom `className` is preserved

## Why

The component already merges `className` into the root element, but this behavior was not covered by tests.

## Risk

- Test-only change
- Append-only
- No production code changes
- No runtime behaviour changes
- Reuses the existing Recharts mock
- Deterministic test