### PR TITLE
test(native-test-route-status): cover loaded route status semantics

### DIFF
--- a/hushh-webapp/__tests__/components/native-test-route-status.test.tsx
+++ b/hushh-webapp/__tests__/components/native-test-route-status.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { NativeTestRouteStatus } from "@/components/app-ui/native-test-route-status";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/",
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({
+    user: { uid: "user-1" },
+    loading: false,
+  }),
+}));
+
+vi.mock("@/lib/testing/native-test", () => ({
+  getNativeTestConfig: () => ({
+    enabled: true,
+    expectedMarker: "native-route-home",
+    expectedRoute: "/",
+    initialRoute: "/",
+  }),
+}));
+
+describe("NativeTestRouteStatus", () => {
+  it("renders loaded route status semantics", () => {
+    render(<NativeTestRouteStatus />);
+
+    const marker = screen.getByTestId("native-route-home");
+
+    expect(marker.getAttribute("aria-hidden")).toBe("true");
+    expect(marker.getAttribute("data-native-route-marker")).toBe("true");
+    expect(marker.getAttribute("data-native-route-id")).toBe("/");
+    expect(marker.getAttribute("data-native-auth-default")).toBe("authenticated");
+    expect(marker.getAttribute("data-native-data-default")).toBe("loaded");
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for NativeTestRouteStatus loaded route status semantics.
- Assert the hidden fallback marker exposes route id, authenticated auth default, and loaded data default attributes.

## Why
This locks the native test route status contract used by native automation without changing runtime behavior.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched `integration/pr-train` head before this commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/components/native-test-route-status.test.tsx` only.
- This PR creates one focused NativeTestRouteStatus component test for the loaded status semantics.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/components/native-test-route-status.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.