### PR TITLE
test(command-fields): cover clear selection button type contract

### DIFF
--- a/hushh-webapp/__tests__/components/command-fields.test.tsx
+++ b/hushh-webapp/__tests__/components/command-fields.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { CommandPickerField } from "@/components/app-ui/command-fields";
+
+describe("CommandPickerField", () => {
+  it("renders clear selection control as a button", () => {
+    render(
+      <CommandPickerField
+        title="Pick a tier"
+        value="ace"
+        placeholder="Select tier"
+        allowClear
+        onSelect={vi.fn()}
+        options={[
+          {
+            value: "ace",
+            label: "Ace",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Clear selection" }).getAttribute("type")).toBe(
+      "button",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for the CommandPickerField clear selection control.
- Assert the clear selection control renders with `type=button`.

## Why
This locks the command field clear action button contract and prevents accidental form-submit behavior.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched `integration/pr-train` head before this commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/components/command-fields.test.tsx` only.
- This PR adds one focused CommandPickerField test for the clear selection button type contract.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/components/command-fields.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.