### PR TITLE
test(kai-control-surface): cover close control button type

### DIFF
--- a/hushh-webapp/__tests__/components/kai-control-surface.test.tsx
+++ b/hushh-webapp/__tests__/components/kai-control-surface.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { KaiControlSurface } from "@/components/app-ui/kai-control-surface";
+
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => false,
+}));
+
+describe("KaiControlSurface", () => {
+  it("renders close control with type='button'", () => {
+    render(
+      <KaiControlSurface open onOpenChange={vi.fn()} title="Kai controls">
+        Control body
+      </KaiControlSurface>,
+    );
+
+    expect(screen.getByRole("button", { name: /close/i }).getAttribute("type")).toBe(
+      "button",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for the KaiControlSurface close control.
- Assert the rendered close control uses `type=button`.

## Why
This locks the close control button contract and prevents accidental submit behavior when the surface is used around form-like content.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched `integration/pr-train` head before this commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/components/kai-control-surface.test.tsx` only.
- This PR adds one focused KaiControlSurface component test for the close control button type contract.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/components/kai-control-surface.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.