### PR TITLE
test(top-shell-dropdown): cover menu trigger accessible label

### DIFF
--- a/hushh-webapp/__tests__/components/top-shell-dropdown.test.ts
+++ b/hushh-webapp/__tests__/components/top-shell-dropdown.test.ts
@@ -1,0 +1,23 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const WEBAPP_ROOT = path.resolve(__dirname, "../..");
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(WEBAPP_ROOT, relativePath), "utf8").replace(/\r\n/g, "\n");
+}
+
+describe("top shell dropdown triggers", () => {
+  it("preserves accessible labels for menu triggers", () => {
+    const topAppBar = read("components/app-ui/top-app-bar.tsx");
+    const consentInbox = read("components/consent/consent-inbox-dropdown.tsx");
+    const debateTaskCenter = read("components/app-ui/debate-task-center.tsx");
+
+    expect(topAppBar).toContain('aria-label="Open consent inbox"');
+    expect(topAppBar).toContain('aria-label="Notifications"');
+    expect(consentInbox).toContain('aria-label="Open consent inbox"');
+    expect(debateTaskCenter).toContain('aria-label="Notifications"');
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for top-shell dropdown trigger accessible labels.
- Assert the consent inbox and notification menu triggers keep accessible names in the shell and fallback dropdown consumers.

## Why
This locks the top-shell dropdown trigger label contract so icon-only menu controls stay discoverable to assistive technology.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched `integration/pr-train` head before this commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/components/top-shell-dropdown.test.ts` only.
- This PR adds one focused source-contract test for top-shell dropdown menu trigger labels.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/components/top-shell-dropdown.test.ts`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.