### PR TITLE
test(api-retry-state): cover retry action button type

### DIFF
--- a/hushh-webapp/__tests__/components/api-retry-state.test.tsx
+++ b/hushh-webapp/__tests__/components/api-retry-state.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ApiRetryState } from "@/components/system/api-retry-state";
+
+describe("ApiRetryState", () => {
+  it("renders retry action with type='button'", () => {
+    render(<ApiRetryState onRetry={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: "Retry" }).getAttribute("type")).toBe(
+      "button",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for the ApiRetryState retry action.
- Assert the retry action renders with `type=button`.

## Why
This locks the retry action button contract and prevents accidental submit behavior when retry states appear near form-like surfaces.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched `integration/pr-train` head before this commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/components/api-retry-state.test.tsx` only.
- This PR adds one focused ApiRetryState component test for the retry action button type contract.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/components/api-retry-state.test.tsx`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.