### PR TITLE
refactor(api): cleanly propagate upstream json errors during consent history fetch

### DIFF
--- a/hushh-webapp/app/api/consent/history/route.ts
+++ b/hushh-webapp/app/api/consent/history/route.ts
@@ -78,10 +78,12 @@ export async function GET(request: NextRequest) {
 
       const payload = await response
         .json()
-        .catch(async () => ({ detail: await response.text().catch(() => "") }));
+        .catch(async () => ({
+          error: (await response.text().catch(() => "")) || "Failed to fetch consent history",
+        }));
       return {
-        status: response.ok ? response.status : response.status,
-        payload: response.ok ? payload : { error: "Failed to fetch consent history", detail: payload?.detail || "" },
+        status: response.status,
+        payload: response.ok ? payload : { error: "Failed to fetch consent history", ...payload },
       };
     })();
 


### PR DESCRIPTION
### Description

Refactors the error parsing logic inside `app/api/consent/history/route.ts` to cleanly propagate full JSON errors from the upstream Python API. Previously, it would parse the JSON but then completely discard all fields except `.detail`, swallowing the core error message.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `app/api/consent/history/route.ts`

- Trust boundary touched:
  - [x] consent / history fetching

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`app/api/consent/history/route.ts`)


## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: consent history
- [x] Error path, rollback, or safe-failure behavior proved: Upstream JSON errors are now fully propagated to the client instead of being destructively filtered.