### PR TITLE
fix(ui): enforce explicit button type for dialog close button

### DIFF
--- a/hushh-webapp/components/ui/dialog.tsx
+++ b/hushh-webapp/components/ui/dialog.tsx
@@ -115,7 +115,7 @@ function DialogFooter({
       {children}
       {showCloseButton && (
         <DialogPrimitive.Close asChild>
-          <Button variant="outline">Close</Button>
+          <Button type="button" variant="outline">Close</Button>
         </DialogPrimitive.Close>
       )}
     </div>


### PR DESCRIPTION
### Description

Fixes a missing `type="button"` attribute on the `<Button>` component used as the Close button in the `DialogFooter` (`components/ui/dialog.tsx`). This enforces strict DOM hygiene and acts as a failsafe to prevent unintended form submissions when dialogs are rendered within `<form>` tags.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/ui/dialog.tsx`


## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/ui/dialog.tsx`)
## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none