### PR TITLE
fix(app): enforce explicit button types on 404 page navigation buttons

### DIFF
--- a/hushh-webapp/app/not-found.tsx
+++ b/hushh-webapp/app/not-found.tsx
@@ -40,11 +40,11 @@ export default function AppNotFoundPage() {
               </p>
             </div>
             <div className="flex gap-3 pt-1">
-              <Button variant="muted" effect="glass" size="sm" onClick={handleGoBack}>
+              <Button type="button" variant="muted" effect="glass" size="sm" onClick={handleGoBack}>
                 <Icon icon={ArrowLeft} size="sm" className="mr-1.5" />
                 Go back
               </Button>
-              <Button variant="blue-gradient" effect="fill" size="sm" onClick={handleGoHome}>
+              <Button type="button" variant="blue-gradient" effect="fill" size="sm" onClick={handleGoHome}>
                 <Icon icon={Home} size="sm" className="mr-1.5" />
                 Go home
               </Button>


### PR DESCRIPTION
### Description

Fixes missing `type="button"` attributes on the navigational `<Button>` components ("Go back" and "Go home") inside the global `app/not-found.tsx` page. Ensures strict DOM hygiene and acts as a failsafe against unintended form submissions.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `app/not-found.tsx`

- Trust boundary touched:
  - [x] none (purely presentational UI component)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`app/not-found.tsx`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none
- [x] Error path, rollback, or safe-failure behavior proved: N/A - Pure UI prop enforcement change.