### PR TITLE
test(button): assert explicit type="button" DOM contract

### DIFF
--- a/hushh-webapp/__tests__/ui/button.test.tsx
+++ b/hushh-webapp/__tests__/ui/button.test.tsx
@@ -18,6 +18,14 @@ describe("Button", () => {
     const button = screen.getByRole("button", { name: /submit/i });
 
     expect(button.getAttribute("aria-busy")).toBeNull();
+  });  
+  
+  it("renders with type='button' by default", () => {
+    render(<Button>Click me</Button>);
+
+    const button = screen.getByRole("button", { name: /click me/i });
+
+    expect(button.getAttribute("type")).toBe("button");
   });
 
 });


### PR DESCRIPTION
## Summary

Adds a contract test verifying that `Button` renders with the default `type="button"` attribute.

## What changed

- Appended one test to `__tests__/ui/button.test.tsx`
- Verifies the rendered button has:
  - `type="button"`

## Why

The component explicitly sets `type="button"` by default to prevent unintended form submission. This behavior was not previously covered by tests.

## Risk

- Test-only change
- Append-only
- No production code changes
- No runtime behaviour changes
- No new imports
- Deterministic test