### PR TITLE
test(button): assert disabled state prevents aria-busy

### DIFF
--- a/hushh-webapp/__tests__/ui/button.test.tsx
+++ b/hushh-webapp/__tests__/ui/button.test.tsx
@@ -11,4 +11,13 @@ describe("Button", () => {
 
     expect(button.getAttribute("aria-busy")).toBe("true");
   });
+
+  it("does not set aria-busy when not in loading state", () => {
+    render(<Button>Submit</Button>);
+
+    const button = screen.getByRole("button", { name: /submit/i });
+
+    expect(button.getAttribute("aria-busy")).toBeNull();
+  });
+
 });


### PR DESCRIPTION
## Summary

Adds a contract test verifying that `Button` does not render the `aria-busy` attribute when it is not in the loading state.

## What changed

- Appended one test to `__tests__/ui/button.test.tsx`
- Verifies `aria-busy` is absent when `loading` is not enabled

## Why

The component only renders `aria-busy="true"` while loading. This test locks in the inverse contract so the attribute is not accidentally rendered in the normal state.

## Risk

- Test-only change
- Append-only
- No production code changes
- No runtime behaviour changes
- No new imports
- Deterministic test