### PR TITLE
test(popover): assert PopoverAnchor data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/ui/popover.test.tsx
+++ b/hushh-webapp/__tests__/ui/popover.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   Popover,
+  PopoverAnchor,
   PopoverContent,
   PopoverDescription,
   PopoverHeader,
@@ -75,4 +76,17 @@ describe("Popover", () => {
       container.querySelector('[data-slot="popover-description"]'),
     ).toBeTruthy();
   });
+
+  it("renders PopoverAnchor with data-slot='popover-anchor'", () => {
+    const { container } = render(
+      <Popover>
+        <PopoverAnchor />
+      </Popover>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="popover-anchor"]'),
+    ).toBeTruthy();
+  });
+
 });


### PR DESCRIPTION
## Summary

Adds a contract test verifying that `PopoverAnchor` renders the expected `data-slot` attribute.

## What changed

- Added `PopoverAnchor` to the existing import list
- Appended one test to `__tests__/ui/popover.test.tsx`
- Verifies:
  - `data-slot="popover-anchor"`

## Why

`PopoverAnchor` is an exported Popover sub-component that was not previously covered by tests. This test completes the existing `data-slot` coverage for the Popover component family.

## Risk

- Test-only change
- Append-only
- No production code changes
- No runtime behaviour changes
- One additive import
- Deterministic test