### PR TITLE
test(empty): assert EmptyMedia data-variant='default' contract

### DIFF
--- a/hushh-webapp/__tests__/ui/empty.test.tsx
+++ b/hushh-webapp/__tests__/ui/empty.test.tsx
@@ -102,4 +102,13 @@ describe("Empty", () => {
       container.querySelector('[data-slot="empty-content"]'),
     ).toBeTruthy();
   });
+
+  it("renders EmptyMedia with data-variant='default' when no variant is provided", () => {
+    const { container } = render(<EmptyMedia />);
+
+    const media = container.querySelector('[data-slot="empty-icon"]');
+
+    expect(media?.getAttribute("data-variant")).toBe("default");
+  });
+
 });


### PR DESCRIPTION
## Summary

Adds a contract test verifying the default `data-variant` rendered by `EmptyMedia`.

## What changed

- Appended one test to `__tests__/ui/empty.test.tsx`
- Verifies that `EmptyMedia` renders `data-variant="default"` when no `variant` prop is supplied.

## Why

`EmptyMedia` exposes a `data-variant` attribute used for styling variants. The existing tests verify the `data-slot` contract but do not pin the default variant value. This test documents that default contract and guards against accidental regressions.

## Risk

- Test-only change
- Append-only
- No production code changes
- No import changes
- Deterministic
- No snapshots