### PR TITLE
test(button-group): assert horizontal orientation data-orientation contract

### DIFF
--- a/hushh-webapp/__tests__/ui/button-group.test.tsx
+++ b/hushh-webapp/__tests__/ui/button-group.test.tsx
@@ -29,4 +29,15 @@ describe("ButtonGroup", () => {
 
     expect(group?.getAttribute("data-orientation")).toBe("vertical");
   });
+
+  it("renders with data-orientation='horizontal' when orientation is set to horizontal", () => {
+    const { container } = render(
+      <ButtonGroup orientation="horizontal">content</ButtonGroup>,
+    );
+
+    const group = container.querySelector('[data-slot="button-group"]');
+
+    expect(group?.getAttribute("data-orientation")).toBe("horizontal");
+  });
+
 });


### PR DESCRIPTION
## Summary

Adds a contract test verifying the `data-orientation="horizontal"` attribute when `ButtonGroup` is rendered with `orientation="horizontal"`.

## What changed

- Appended one test to `__tests__/ui/button-group.test.tsx`
- Verifies the horizontal orientation DOM contract
- Complements the existing vertical orientation test

## Why

The existing tests verify the `vertical` orientation but do not cover the `horizontal` rendering path. This test documents that contract and guards against future regressions.

## Risk

- Test-only change
- Append-only
- No production code changes
- No import changes
- Deterministic
- No snapshots