### PR TITLE
test(accordion): assert AccordionHeader data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/ui/accordion.test.tsx
+++ b/hushh-webapp/__tests__/ui/accordion.test.tsx
@@ -115,4 +115,20 @@ describe("Accordion", () => {
 
     expect(icon).toBeTruthy();
   });
+
+  it("renders AccordionTrigger wrapping element with data-slot='accordion-header'", () => {
+    const { container } = render(
+      <Accordion type="single">
+        <AccordionItem value="item-1">
+          <AccordionTrigger>Trigger</AccordionTrigger>
+          <AccordionContent>Content</AccordionContent>
+        </AccordionItem>
+      </Accordion>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="accordion-header"]'),
+    ).toBeTruthy();
+  });
+
 });


### PR DESCRIPTION
## Summary

Adds a contract test verifying the `data-slot="accordion-header"` wrapper rendered by `AccordionTrigger`.

## What changed

- Appended one test to `__tests__/ui/accordion.test.tsx`
- Verifies the `accordion-header` data-slot contract
- Complements the existing coverage for `accordion`, `accordion-item`, `accordion-trigger`, `accordion-content`, and the decorative icon

## Why

`AccordionTrigger` renders an internal `AccordionHeader` wrapper with `data-slot="accordion-header"`. The existing tests covered the other exported DOM contracts but did not verify this wrapper. This test documents that contract and protects it from accidental regressions.

## Risk

- Test-only change
- Append-only
- No production code changes
- No import changes
- Deterministic
- No snapshots