### PR TITLE
fix(runtime): detect Windows virtual environment layout

### DIFF
--- a/scripts/runtime/run_backend_local.sh
+++ b/scripts/runtime/run_backend_local.sh
@@ -82,8 +82,12 @@ if [ ! -f "$BACKEND_ENV_FILE" ]; then
   exit 1
 fi
 
-BACKEND_VENV_PYTHON="$REPO_ROOT/consent-protocol/.venv/bin/python"
-if [ ! -x "$BACKEND_VENV_PYTHON" ]; then
+if [ -x "$REPO_ROOT/consent-protocol/.venv/bin/python" ]; then
+  BACKEND_VENV_PYTHON="$REPO_ROOT/consent-protocol/.venv/bin/python"
+elif [ -x "$REPO_ROOT/consent-protocol/.venv/Scripts/python.exe" ]; then
+  BACKEND_VENV_PYTHON="$REPO_ROOT/consent-protocol/.venv/Scripts/python.exe"
+else
+  BACKEND_VENV_PYTHON="$REPO_ROOT/consent-protocol/.venv/bin/python"
   echo "Missing backend virtualenv interpreter: $BACKEND_VENV_PYTHON" >&2
   echo "Run './bin/hushh bootstrap' or recreate consent-protocol/.venv before starting the local backend." >&2
   exit 1


### PR DESCRIPTION
## Summary

Adds support for detecting Windows virtual environment layouts in the local backend startup script.

## Problem

The local backend startup script only searched for the Unix virtual environment interpreter (`.venv/bin/python`). On Windows, virtual environments place the interpreter at `.venv/Scripts/python.exe`, causing the startup script to fail even when a valid virtual environment exists.

## Solution

* Detect the Unix virtual environment layout first.
* Fall back to the Windows virtual environment layout (`.venv/Scripts/python.exe`) when available.
* Preserve the existing behavior on Unix-based platforms.

## Testing

* Created a Python virtual environment on Windows.
* Started the backend using `./bin/hushh backend --mode local --skip-activate`.
* Confirmed that the runtime detected `.venv/Scripts/python.exe` and the backend started successfully.
