### PR TITLE
test(tabs): assert disabled TabsTrigger sets data-disabled

### DIFF
--- a/hushh-webapp/__tests__/ui/tabs.test.tsx
+++ b/hushh-webapp/__tests__/ui/tabs.test.tsx
@@ -88,4 +88,22 @@ describe("Tabs", () => {
     const list = container.querySelector('[data-slot="tabs-list"]');
     expect(list?.getAttribute("data-variant")).toBe("line");
   });
+
+  it("renders disabled TabsTrigger with data-disabled attribute", () => {
+    const { container } = render(
+      <Tabs defaultValue="tab-1">
+        <TabsList>
+          <TabsTrigger value="tab-1" disabled>
+            Tab 1
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="tab-1">Content 1</TabsContent>
+      </Tabs>,
+    );
+
+    const trigger = container.querySelector('[data-slot="tabs-trigger"]');
+
+    expect(trigger?.getAttribute("data-disabled")).toBe("");
+  });
+
 });


### PR DESCRIPTION
## Summary

Adds a contract test verifying that a disabled `TabsTrigger` renders the expected `data-disabled` attribute.

## What changed

- Appended one test to `__tests__/ui/tabs.test.tsx`
- Verifies the disabled-state DOM contract for `TabsTrigger`
- Complements the existing coverage for slots, orientation, and variants

## Why

The existing tests verify structural contracts but do not cover the disabled state. This test documents the DOM contract emitted by the underlying Radix primitive when `disabled` is supplied, helping prevent regressions.

## Risk

- Test-only change
- Append-only
- No production code changes
- No import changes
- Deterministic
- No snapshots