### PR TITLE
test(separator): assert non-decorative role='separator' contract

### DIFF
--- a/hushh-webapp/__tests__/ui/separator.test.tsx
+++ b/hushh-webapp/__tests__/ui/separator.test.tsx
@@ -32,4 +32,12 @@ describe("Separator", () => {
 
     expect(el?.getAttribute("data-orientation")).toBe("vertical");
   });
+
+  it("renders with role='separator' when decorative={false}", () => {
+    const { container } = render(<Separator decorative={false} />);
+    const el = container.querySelector('[data-slot="separator"]');
+
+    expect(el?.getAttribute("role")).toBe("separator");
+  });
+
 });


### PR DESCRIPTION
## Summary

Adds a contract test verifying that `Separator` renders `role="separator"` when `decorative={false}`.

## What changed

- Appended one test to `__tests__/ui/separator.test.tsx`
- Verifies the accessibility contract for the non-decorative rendering path
- Complements the existing coverage for the default decorative behavior

## Why

The existing tests cover the default decorative branch, but do not verify the opposite accessibility contract. This test pins the expected DOM output when `decorative={false}` so future changes cannot silently alter the behavior.

## Risk

- Test-only change
- Append-only
- No production code changes
- No import changes
- Deterministic
- No snapshots