### PR TITLE
fix(db): URL-encode database credentials

### DIFF
--- a/consent-protocol/db/connection.py
+++ b/consent-protocol/db/connection.py
@@ -173,8 +173,8 @@ def get_database_url() -> str:
         )
     if db_unix_socket:
         # Cloud SQL Unix socket path must be provided via query host parameter.
-        return f"postgresql://{db_user}:{db_password}@/{db_name}?host={quote_plus(db_unix_socket)}"
-    return f"postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}"
+        return f"postgresql://{quote_plus(db_user)}:{quote_plus(db_password)}@/{db_name}?host={quote_plus(db_unix_socket)}"
+    return f"postgresql://{quote_plus(db_user)}:{quote_plus(db_password)}@{db_host}:{db_port}/{db_name}"
 
 
 def get_database_ssl():

--- a/consent-protocol/db/db_client.py
+++ b/consent-protocol/db/db_client.py
@@ -283,7 +283,7 @@ def get_db_engine() -> Engine:
             # Cloud SQL Unix socket path must be passed in query host param.
             encoded_socket = quote_plus(db_unix_socket)
             database_url = (
-                f"postgresql+psycopg2://{db_user}:{db_password}@/{db_name}?host={encoded_socket}"
+                f"postgresql+psycopg2://{quote_plus(db_user)}:{quote_plus(db_password)}@/{db_name}?host={encoded_socket}"
             )
             target = db_unix_socket
         else:
@@ -292,7 +292,7 @@ def get_db_engine() -> Engine:
                 if ("supabase.com" in str(db_host) or "pooler.supabase" in str(db_host))
                 else ""
             )
-            database_url = f"postgresql+psycopg2://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}{ssl_suffix}"
+            database_url = f"postgresql+psycopg2://{quote_plus(db_user)}:{quote_plus(db_password)}@{db_host}:{db_port}/{db_name}{ssl_suffix}"
             target = f"{db_host}:{db_port}/{db_name}"
 
         connect_args: dict[str, Any] = {


### PR DESCRIPTION
## Summary

URL-encode database usernames and passwords when constructing PostgreSQL connection URLs.

## Problem

PostgreSQL connection URLs become invalid when database usernames or passwords contain reserved URI characters (for example `@`, `:`, `/`, `%`, or spaces). This can cause connection failures even when the supplied credentials are correct.

## Solution

* URL-encode `db_user` and `db_password` before constructing PostgreSQL connection URLs.
* Apply the same behavior consistently to both direct connection and SQLAlchemy connection paths.

## Testing

* Verified that all PostgreSQL connection URL builders now URL-encode database credentials.
* Confirmed the change is limited to credential encoding with no unrelated behavioral changes.
