### PR TITLE
fix(ticker-cache): distinguish empty cache from unloaded cache

### DIFF
--- a/consent-protocol/hushh_mcp/services/ticker_cache.py
+++ b/consent-protocol/hushh_mcp/services/ticker_cache.py
@@ -88,7 +88,7 @@ class TickerCache:
     @property
     def loaded(self) -> bool:
         with self._lock:
-            return bool(self._rows)
+            return self._loaded_at > 0.0
 
     @property
     def loaded_at(self) -> float:


### PR DESCRIPTION
## Summary

Update `TickerCache.loaded` to reflect whether the cache has been initialized rather than whether it currently contains rows.

## Problem

The previous implementation returned `bool(self._rows)`, which reported the cache as "not loaded" whenever it contained zero rows. An empty cache is a valid state after a successful load and should not be treated as uninitialized.

## Solution

* Base `loaded` on the cache initialization timestamp (`loaded_at`) instead of the current row count.
* Preserve the distinction between:

  * an uninitialized cache, and
  * a successfully loaded cache with zero results.

## Testing

* Ran the ticker cache test suite locally.

```text
28 passed in 1.35s
```
