### PR TITLE
test(input): assert autoCapitalize is not forced to none for type=text

### DIFF
--- a/hushh-webapp/__tests__/ui/input.test.tsx
+++ b/hushh-webapp/__tests__/ui/input.test.tsx
@@ -26,4 +26,12 @@ describe("Input", () => {
 
     expect(el?.classList.contains("test-class")).toBeTruthy();
   });
+
+  it("does not force autoCapitalize='none' for type='text'", () => {
+    const { container } = render(<Input type="text" />);
+
+    const el = container.querySelector('[data-slot="input"]');
+
+    expect(el?.getAttribute("autocapitalize")).not.toBe("none");
+  });
 });


### PR DESCRIPTION
## Summary

Adds a contract test for the non-email branch of the input component's mobile input behavior.

For `type="text"`, the component should **not** force:

* `autoCapitalize="none"`

This complements the existing email/search contract by verifying that text inputs retain their default behavior.

## Changes

* Appends one test to `__tests__/ui/input.test.tsx`
* No production code changes
* No import changes
* No new test files
* No existing tests modified

## Verification

```bash
npx vitest run __tests__/ui/input.test.tsx
```

## Checklist

* [x] Test-only change
* [x] Append-only modification
* [x] No production code changes
* [x] Existing test style preserved
* [x] DCO signed (`git commit -s`)
