### PR TITLE
test(navigation): characterize resolveInternalRouteHref null parameter values

### DIFF
--- a/hushh-webapp/__tests__/navigation/resolve-null-params.test.ts
+++ b/hushh-webapp/__tests__/navigation/resolve-null-params.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for resolveInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts) focused on hrefs whose query strings
+// contain "null" / empty parameter values (e.g. /dashboard?filter=null&mode=).
+//
+// Real implementation:
+//   export function resolveInternalRouteHref(value, fallback) {
+//     return normalizeInternalRouteHref(value) ?? fallback;
+//   }
+//   normalizeInternalRouteHref: trims; null if empty, not "/"-prefixed,
+//   "//"-prefixed, or containing \r/\n; otherwise returns the href verbatim.
+//
+// TRUTH-FIRST: resolveInternalRouteHref does NOT parse, decode, map, or strip
+// query parameters. There is no per-field handling. A query string is opaque
+// text inside the href. So "filter=null" and "mode=" are preserved EXACTLY as
+// written — `null` stays the literal 4-char string "null", and an empty value
+// (`mode=`) keeps its trailing `=`. The only decision is whole-href accept
+// (returned verbatim) vs. reject (replaced wholesale by `fallback`). The
+// premise of "mapping fields" or "stripping them seamlessly" is FALSE at this
+// layer; these tests pin the verbatim-or-fallback contract.
+
+const FALLBACK = "/home";
+
+describe("resolveInternalRouteHref — null/empty query parameters", () => {
+  it("preserves a literal `filter=null` and empty `mode=` verbatim (no field mapping/stripping)", () => {
+    expect(
+      resolveInternalRouteHref("/dashboard?filter=null&mode=", FALLBACK)
+    ).toBe("/dashboard?filter=null&mode=");
+  });
+
+  it("keeps the trailing `=` of an empty-valued param (does not strip it)", () => {
+    expect(resolveInternalRouteHref("/x?a=", FALLBACK)).toBe("/x?a=");
+  });
+
+  it("keeps a bare key with no `=` verbatim", () => {
+    expect(resolveInternalRouteHref("/x?flag", FALLBACK)).toBe("/x?flag");
+  });
+
+  it("does not coalesce the literal string 'null' to anything else", () => {
+    const out = resolveInternalRouteHref("/p?v=null", FALLBACK);
+    expect(out).toBe("/p?v=null");
+    expect(out).toContain("null");
+  });
+
+  it("preserves multiple empty params and their `&` separators", () => {
+    expect(resolveInternalRouteHref("/p?a=&b=&c=", FALLBACK)).toBe("/p?a=&b=&c=");
+  });
+
+  it("returns the fallback when the VALUE itself is null (not the params)", () => {
+    expect(resolveInternalRouteHref(null, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it("returns the fallback for an empty string value", () => {
+    expect(resolveInternalRouteHref("", FALLBACK)).toBe(FALLBACK);
+  });
+
+  it("returns the fallback for a protocol-relative href even with null params", () => {
+    expect(
+      resolveInternalRouteHref("//evil.com?filter=null", FALLBACK)
+    ).toBe(FALLBACK);
+  });
+
+  it("trims surrounding whitespace but keeps the query (incl. empty values) intact", () => {
+    expect(
+      resolveInternalRouteHref("  /dashboard?filter=null&mode=  ", FALLBACK)
+    ).toBe("/dashboard?filter=null&mode=");
+  });
+});


### PR DESCRIPTION
## Summary

Pins how `resolveInternalRouteHref`
(`hushh-webapp/lib/navigation/routes.ts`) behaves when an internal href carries
query parameters set to `null`/empty states (e.g. `/dashboard?filter=null&mode=`).
Test-only; no production change.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/navigation/...`. There
  is no top-level `__tests__` in this repo; vitest only includes `__tests__/**`
  under `hushh-webapp`. The file therefore lives at
  `hushh-webapp/__tests__/navigation/resolve-null-params.test.ts`.
- **There is no per-field query mapping or stripping.** The function is a thin
  wrapper:

  ```ts
  export function resolveInternalRouteHref(value, fallback) {
    return normalizeInternalRouteHref(value) ?? fallback;
  }
  ```

  `normalizeInternalRouteHref` trims, then returns `null` if the value is empty,
  not `/`-prefixed, `//`-prefixed, or contains `\r`/`\n`; otherwise it returns
  the href **verbatim**. The query string is opaque text — `filter=null` keeps
  the literal 4-char `null`, and `mode=` keeps its trailing `=`. Nothing is
  parsed, decoded, coalesced, or removed.
- The premise that fields are "mapped exactly as text or stripped seamlessly"
  is only half-true: there is no stripping at all. The real contract is
  **whole-href accept (verbatim) vs. reject (replaced wholesale by `fallback`)**.

## Behavior pinned

- `/dashboard?filter=null&mode=` → returned verbatim (literal `null`, empty `=`)
- `/x?a=` → trailing `=` kept; `/x?flag` → bare key kept
- `/p?v=null` → literal `null` never coalesced
- `/p?a=&b=&c=` → all empty params + `&` separators preserved
- `null` value → `fallback`; `""` value → `fallback`
- `//evil.com?filter=null` → `fallback` (protocol-relative rejected)
- `  /dashboard?filter=null&mode=  ` → ends trimmed, query intact

## Verification

- `npm test -- __tests__/navigation/resolve-null-params.test.ts` → 9/9 pass
- `git status` limited to the single new test file; no production source changed

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the verbatim-or-fallback contract (no query parsing,
  mapping, or stripping) rather than an assumed per-field resolver
