### PR TITLE
test(textarea): assert disabled:opacity-50 class contract

### DIFF
--- a/hushh-webapp/__tests__/ui/textarea.test.tsx
+++ b/hushh-webapp/__tests__/ui/textarea.test.tsx
@@ -29,4 +29,12 @@ describe("Textarea", () => {
 
     expect(el?.classList.contains("test-class")).toBeTruthy();
   });
+
+  it("includes disabled:opacity-50 class for disabled styling", () => {
+    const { container } = render(<Textarea />);
+
+    const el = container.querySelector('[data-slot="textarea"]');
+
+    expect(el?.className).toContain("disabled:opacity-50");
+  });
 });


### PR DESCRIPTION
## Summary

Adds a contract test for the disabled styling class applied by the `Textarea` component.

The component includes the Tailwind utility `disabled:opacity-50` as part of its default class list. This test ensures the styling contract remains intact during future refactors.

## Changes

* Appends one test to `__tests__/ui/textarea.test.tsx`
* No production code changes
* No import changes
* No new test files
* No existing tests modified

## Verification

```bash
npx vitest run __tests__/ui/textarea.test.tsx
```

## Checklist

* [x] Test-only change
* [x] Append-only modification
* [x] No production code changes
* [x] Existing assertion style preserved
* [x] DCO signed (`git commit -s`)
