### PR TITLE
test(label): assert select-none class for user-select prevention

### DIFF
--- a/hushh-webapp/__tests__/ui/label.test.tsx
+++ b/hushh-webapp/__tests__/ui/label.test.tsx
@@ -25,4 +25,12 @@ describe("Label", () => {
 
     expect(label?.className).toContain("peer-disabled:opacity-50");
   });
+
+  it("renders with select-none class for user-select prevention", () => {
+    const { container } = render(<Label>Email</Label>);
+
+    const label = container.querySelector('[data-slot="label"]');
+
+    expect(label?.className).toContain("select-none");
+  });
 });


### PR DESCRIPTION
## Summary

Adds a contract test for the `select-none` utility class applied by the `Label` component.

The component includes the Tailwind `select-none` class as part of its default styling. This test ensures the class remains present, preventing accidental removal during future refactors.

## Changes

* Appends one test to `__tests__/ui/label.test.tsx`
* No production code changes
* No import changes
* No new test files
* No existing tests modified

## Verification

```bash
npx vitest run __tests__/ui/label.test.tsx
```

## Checklist

* [x] Test-only change
* [x] Append-only modification
* [x] No production code changes
* [x] Existing assertion style preserved
* [x] DCO signed (`git commit -s`)
