### PR TITLE
fix(navbar): restore lean flat bottom-nav pill surface

### DIFF
--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -407,6 +407,9 @@ export const Navbar = () => {
             ariaLabel="Route navigation"
             className={cn(
               "kai-bottom-nav-pill relative z-10 w-full chrome-bottom-foreground",
+              // Lean flat track matching the search button + top app bar
+              // (ShellActionSurface): soft translucent surface, no shadow/blur.
+              "bg-black/[0.05] shadow-none backdrop-blur-none dark:bg-white/[0.07]",
               "[&_[aria-checked=true]]:text-primary [&_[data-segment-indicator]]:bg-primary/10 [&_[data-segment-indicator]]:shadow-sm",
             )}
           />


### PR DESCRIPTION
## Summary
The bottom-nav pill reverted to the older heavy elevated theme because the shared `SegmentedPill` default uses `bg-background/80` + a large drop shadow + backdrop blur. This overrides the track for the bottom-nav pill only so it matches the lean flat surface used by the search button and top app bar controls.

## Change
- `components/navbar.tsx`: add `bg-black/[0.05] shadow-none backdrop-blur-none dark:bg-white/[0.07]` to the bottom-nav `SegmentedPill` className. Scoped via className; the shared primitive default is untouched for its other 3 callers (portfolio switcher, consent center x2).

## Validation
- `tsc --noEmit` clean; `eslint components/navbar.tsx` clean.
- Verified visually at runtime: lean flat track restored.

## Deploy intent
Merge to main, then re-dispatch Deploy to UAT once the post-merge smoke gate is green.