### PR TITLE
test(utils): characterize formatCompleteJson array element interleaving limits

### DIFF
--- a/hushh-webapp/__tests__/utils/format-interleaving-limits.test.ts
+++ b/hushh-webapp/__tests__/utils/format-interleaving-limits.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCompleteJson } from "@/lib/utils/json-to-human";
+
+// Characterization tests for formatCompleteJson
+// (hushh-webapp/lib/utils/json-to-human.ts) focused on a top-level array whose
+// elements interleave objects, arrays, and primitive numbers
+// (e.g. [{}, [], 123, [{}]]).
+//
+// Relevant implementation (the "generic array" branch):
+//   lines.push("");
+//   lines.push(`--- ${label} (${value.length} items) ---`);
+//   for (const item of value.slice(0, 3)) {
+//     if (typeof item === "object" && item !== null) {
+//       const firstValue = Object.values(item).find(v => v != null);
+//       lines.push(`  • ${String(firstValue || "Item")}`);
+//     } else {
+//       lines.push(`  • ${String(item)}`);
+//     }
+//   }
+//   if (value.length > 3) lines.push(`  ... and ${value.length - 3} more`);
+//
+// TRUTH-FIRST: there are NO per-index "separators" and NO index numbers. Each
+// of the FIRST THREE elements becomes a `  • ` bullet line; any remainder
+// collapses to a single `  ... and N more` line. Type handling is lossy, not
+// structural:
+//   - object/array → the first non-null *value* via Object.values(...).find,
+//     else the literal "Item". An empty object `{}` and empty array `[]` both
+//     have no values → both render as `  • Item`.
+//   - an element whose first value is itself an object/array leaks
+//     `String(obj)` === "[object Object]".
+//   - primitives render as `String(item)`.
+// The premise of "index separators" / structural segmentation is FALSE; these
+// tests pin the real bullet/cap behavior.
+
+describe("formatCompleteJson — interleaved top-level array", () => {
+  it("renders [{}, [], 123, [{}]] as 3 bullets + a single overflow line (no index separators)", () => {
+    const out = formatCompleteJson({ items: [{}, [], 123, [{}]] });
+    expect(out).toBe(
+      "\n--- Items (4 items) ---\n  • Item\n  • Item\n  • 123\n  ... and 1 more"
+    );
+  });
+
+  it("collapses empty object and empty array elements both to '• Item'", () => {
+    const out = formatCompleteJson({ items: [{}, []] });
+    expect(out).toBe("\n--- Items (2 items) ---\n  • Item\n  • Item");
+  });
+
+  it("uses the first non-null property value for an object element", () => {
+    const out = formatCompleteJson({ items: [{ name: "Alpha" }, 7] });
+    expect(out).toBe("\n--- Items (2 items) ---\n  • Alpha\n  • 7");
+  });
+
+  it("leaks '[object Object]' when an element's first value is itself an object", () => {
+    const out = formatCompleteJson({ items: [[{ a: 1 }], 5] });
+    expect(out).toBe("\n--- Items (2 items) ---\n  • [object Object]\n  • 5");
+  });
+
+  it("shows exactly the first three elements when length is exactly 3 (no overflow line)", () => {
+    const out = formatCompleteJson({ items: [1, 2, 3] });
+    expect(out).toBe("\n--- Items (3 items) ---\n  • 1\n  • 2\n  • 3");
+  });
+
+  it("pluralizes the overflow count literally (no separators) for long arrays", () => {
+    const out = formatCompleteJson({ items: [1, 2, 3, 4, 5, 6] });
+    expect(out).toBe(
+      "\n--- Items (6 items) ---\n  • 1\n  • 2\n  • 3\n  ... and 3 more"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Pins how `formatCompleteJson` (`hushh-webapp/lib/utils/json-to-human.ts`)
renders a top-level array whose elements interleave objects, arrays, and
primitive numbers (e.g. `[{}, [], 123, [{}]]`). Test-only; no production change.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/utils/...`. There is no
  top-level `__tests__` in this repo; vitest only includes `__tests__/**` under
  `hushh-webapp`. The file therefore lives at
  `hushh-webapp/__tests__/utils/format-interleaving-limits.test.ts`.
- **There are no "index separators" and no structural per-element segmentation.**
  The generic-array branch is summarizing and lossy:

  ```ts
  lines.push("");
  lines.push(`--- ${label} (${value.length} items) ---`);
  for (const item of value.slice(0, 3)) {
    if (typeof item === "object" && item !== null) {
      const firstValue = Object.values(item).find(v => v != null);
      lines.push(`  • ${String(firstValue || "Item")}`);
    } else {
      lines.push(`  • ${String(item)}`);
    }
  }
  if (value.length > 3) lines.push(`  ... and ${value.length - 3} more`);
  ```

  Only the **first three** elements become `  • ` bullet lines; the remainder
  collapses into a single `  ... and N more` line. There are no indices, no
  commas, no positional separators.
- The premise of "segments individual index separators" is **false**. Type
  handling is collapsing, not structural:
  - `{}` and `[]` both have no own values → both render `  • Item`.
  - an object/array whose first value is itself an object leaks
    `String(obj)` === `[object Object]`.
  - primitives render via `String(item)`.

## Behavior pinned

- `[{}, [], 123, [{}]]` → `--- Items (4 items) ---` then `• Item`, `• Item`,
  `• 123`, `... and 1 more`
- `[{}, []]` → both collapse to `• Item`
- `[{ name: "Alpha" }, 7]` → `• Alpha`, `• 7`
- `[[{ a: 1 }], 5]` → `• [object Object]`, `• 5`
- `[1, 2, 3]` → three bullets, **no** overflow line
- `[1..6]` → first three bullets + `... and 3 more`

## Verification

- `npm test -- __tests__/utils/format-interleaving-limits.test.ts` → 6/6 pass
- `git status` limited to the single new test file; no production source changed

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the real first-3-bullets + overflow summary (lossy,
  no index separators) rather than an assumed structural index segmenter
