### PR TITLE
fix(ria): enforce explicit button types on dynamic table row controls

### DIFF
--- a/hushh-webapp/app/ria/picks/page.tsx
+++ b/hushh-webapp/app/ria/picks/page.tsx
@@ -792,7 +792,7 @@ function TopPicksEditor({
                   <p className="text-sm font-semibold text-foreground">Top pick {displayIndex}</p>
                   <p className="text-xs text-muted-foreground">Compact mobile editor</p>
                 </div>
-                <Button variant="none" effect="fade" size="sm" onClick={() => onRemoveRow(row.id)}>
+                <Button type="button" variant="none" effect="fade" size="sm" onClick={() => onRemoveRow(row.id)}>
                   <Trash2 className="h-4 w-4" />
                 </Button>
               </div>
@@ -902,7 +902,7 @@ function TopPicksEditor({
                   </TableCell>
                   <TableCell className="px-3 py-2.5 align-top">
                     <div className="flex justify-end">
-                      <Button variant="none" effect="fade" size="sm" onClick={() => onRemoveRow(row.id)}>
+                      <Button type="button" variant="none" effect="fade" size="sm" onClick={() => onRemoveRow(row.id)}>
                         <Trash2 className="h-4 w-4" />
                       </Button>
                     </div>
@@ -1026,7 +1026,7 @@ function AvoidEditor({
                   <p className="text-sm font-semibold text-foreground">Avoid row {displayIndex}</p>
                   <p className="text-xs text-muted-foreground">Compact mobile editor</p>
                 </div>
-                <Button variant="none" effect="fade" size="sm" onClick={() => onRemoveRow(row.id)}>
+                <Button type="button" variant="none" effect="fade" size="sm" onClick={() => onRemoveRow(row.id)}>
                   <Trash2 className="h-4 w-4" />
                 </Button>
               </div>
@@ -1159,7 +1159,7 @@ function AvoidEditor({
                   </TableCell>
                   <TableCell className="px-3 py-2.5 align-top">
                     <div className="flex justify-end">
-                      <Button variant="none" effect="fade" size="sm" onClick={() => onRemoveRow(row.id)}>
+                      <Button type="button" variant="none" effect="fade" size="sm" onClick={() => onRemoveRow(row.id)}>
                         <Trash2 className="h-4 w-4" />
                       </Button>
                     </div>
@@ -1255,7 +1255,7 @@ function ScreeningEditor({
                   </p>
                 </div>
                 <div className="flex justify-start sm:justify-end">
-                  <Button variant="none" effect="fade" size="sm" onClick={() => onAddRow(section.key)} className="w-full justify-center sm:w-auto">
+                  <Button type="button" variant="none" effect="fade" size="sm" onClick={() => onAddRow(section.key)} className="w-full justify-center sm:w-auto">
                     <Plus className="mr-2 h-4 w-4" />
                     Add rule
                   </Button>


### PR DESCRIPTION
### Description

Fixes multiple missing `type="button"` attributes on the dynamic table control `<Button>` components ("Add rule" and "Remove row") inside `app/ria/picks/page.tsx`. This enforces strict DOM hygiene and acts as a failsafe against unintended form submissions when manipulating table state.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `app/ria/picks/page.tsx`

- Trust boundary touched:
  - [x] none (purely presentational UI component)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`app/ria/picks/page.tsx`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none
- [x] Error path, rollback, or safe-failure behavior proved: N/A - Pure UI prop enforcement change.