### PR TITLE
test(navigation): characterize normalizeInternalRouteHref document extension guards

### DIFF
--- a/hushh-webapp/__tests__/navigation/normalize-extensions.test.ts
+++ b/hushh-webapp/__tests__/navigation/normalize-extensions.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for normalizeInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts) focused on route paths that end in a
+// file-format extension (e.g. /api/legal/privacy.json, /api/legal/terms.txt).
+//
+// Real implementation:
+//   export function normalizeInternalRouteHref(value) {
+//     const href = String(value ?? "").trim();
+//     if (!href) return null;
+//     if (!href.startsWith("/") || href.startsWith("//")) return null;
+//     if (/[\r\n]/.test(href)) return null;
+//     return href;
+//   }
+//
+// TRUTH-FIRST: the guard is extension-agnostic. It does NOT parse, track,
+// rewrite, or special-case `.json` / `.txt` / any asset extension. There are no
+// "tracking parameters." The only decisions are:
+//   - trim whitespace ends
+//   - reject (→ null) when empty, not "/"-prefixed, "//"-prefixed, or
+//     containing \r/\n
+//   - otherwise return the href VERBATIM (extension and any query/hash intact)
+// These tests pin that the literal asset string is preserved exactly.
+
+describe("normalizeInternalRouteHref — file-extension route paths", () => {
+  it("preserves a .json asset path verbatim", () => {
+    expect(normalizeInternalRouteHref("/api/legal/privacy.json")).toBe(
+      "/api/legal/privacy.json"
+    );
+  });
+
+  it("preserves a .txt asset path verbatim", () => {
+    expect(normalizeInternalRouteHref("/api/legal/terms.txt")).toBe(
+      "/api/legal/terms.txt"
+    );
+  });
+
+  it("does not strip or rewrite the extension when a query string follows", () => {
+    expect(normalizeInternalRouteHref("/files/report.csv?v=2")).toBe(
+      "/files/report.csv?v=2"
+    );
+  });
+
+  it("keeps an extension plus hash fragment intact", () => {
+    expect(normalizeInternalRouteHref("/docs/spec.pdf#page=3")).toBe(
+      "/docs/spec.pdf#page=3"
+    );
+  });
+
+  it("preserves multi-dot / uppercase extensions exactly (no normalization)", () => {
+    expect(normalizeInternalRouteHref("/assets/archive.TAR.GZ")).toBe(
+      "/assets/archive.TAR.GZ"
+    );
+  });
+
+  it("trims surrounding whitespace but keeps the extension", () => {
+    expect(normalizeInternalRouteHref("  /api/legal/privacy.json  ")).toBe(
+      "/api/legal/privacy.json"
+    );
+  });
+
+  it("rejects a protocol-relative href even when it ends in an extension", () => {
+    expect(normalizeInternalRouteHref("//cdn.example.com/app.js")).toBeNull();
+  });
+
+  it("rejects a bare (non-rooted) filename with an extension", () => {
+    expect(normalizeInternalRouteHref("privacy.json")).toBeNull();
+  });
+
+  it("trims a TRAILING newline before the CR/LF guard, so the path is accepted", () => {
+    // trim() runs first and removes the trailing \n, so /[\r\n]/ never matches.
+    expect(normalizeInternalRouteHref("/api/legal/terms.txt\n")).toBe(
+      "/api/legal/terms.txt"
+    );
+  });
+
+  it("rejects an INTERIOR newline within an extension path", () => {
+    expect(normalizeInternalRouteHref("/api/legal\n/terms.txt")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Pins how `normalizeInternalRouteHref`
(`hushh-webapp/lib/navigation/routes.ts`) treats route paths that end in a file
extension (e.g. `/api/legal/privacy.json`, `/api/legal/terms.txt`). Test-only;
no production change.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/navigation/...`. There
  is no top-level `__tests__` in this repo; vitest only includes `__tests__/**`
  under `hushh-webapp`. The file therefore lives at
  `hushh-webapp/__tests__/navigation/normalize-extensions.test.ts`.
- **The guard is extension-agnostic and has no "tracking parameters."** Full
  implementation:

  ```ts
  export function normalizeInternalRouteHref(value) {
    const href = String(value ?? "").trim();
    if (!href) return null;
    if (!href.startsWith("/") || href.startsWith("//")) return null;
    if (/[\r\n]/.test(href)) return null;
    return href;
  }
  ```

  It does not parse, track, or special-case `.json` / `.txt` / any asset
  extension. Accepted hrefs are returned **verbatim** (extension, query, and
  hash all intact). The premise of "tracking parameters inside ... when file
  extensions terminate route paths" is **false** — nothing is tracked.
- **Verified subtlety (a local test caught it):** `trim()` runs *before* the
  `/[\r\n]/` guard, so a **trailing** newline is stripped and the path is
  accepted; only an **interior** newline causes rejection. The suite pins both.

## Behavior pinned

- `/api/legal/privacy.json`, `/api/legal/terms.txt` → returned verbatim
- `/files/report.csv?v=2`, `/docs/spec.pdf#page=3` → extension + query/hash kept
- `/assets/archive.TAR.GZ` → multi-dot/uppercase preserved (no normalization)
- `  /api/legal/privacy.json  ` → ends trimmed, extension kept
- `//cdn.example.com/app.js` → `null` (protocol-relative rejected)
- `privacy.json` → `null` (not rooted)
- `/api/legal/terms.txt\n` → trailing `\n` trimmed → **accepted**
- `/api/legal\n/terms.txt` → interior `\n` → `null`

## Verification

- `npm test -- __tests__/navigation/normalize-extensions.test.ts` → 10/10 pass
- `git status` limited to the single new test file; no production source changed

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the extension-agnostic verbatim/reject guard (incl. the
  trim-before-CRLF nuance) rather than assumed extension "tracking parameters"
