### PR TITLE
test(switch): assert root data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/ui/switch.test.tsx
+++ b/hushh-webapp/__tests__/ui/switch.test.tsx
@@ -34,5 +34,12 @@ describe("Switch", () => {
         .querySelector('[data-slot="switch-thumb"]')
         ?.getAttribute("data-slot"),
     ).toBe("switch-thumb");
+  });  
+  it("renders root with data-slot='switch'", () => {
+    render(<Switch />);
+
+    expect(
+      screen.getByRole("switch").getAttribute("data-slot"),
+    ).toBe("switch");
   });
 });


### PR DESCRIPTION
## Summary

Adds a contract test for the `data-slot="switch"` attribute on the `Switch` root element.

## Motivation

The `Switch` component renders `data-slot="switch"` on its root element. This attribute is used by styling and theming selectors but was not previously covered by tests.

## Changes

* Appends one test to `__tests__/ui/switch.test.tsx`
* No production code changes
* No import changes
* No new test files
* No existing tests modified

## Verification

```bash
npx vitest run __tests__/ui/switch.test.tsx
```

## Checklist

* [x] Test-only change
* [x] Append-only modification
* [x] No production code changes
* [x] Existing assertion style preserved
* [x] DCO signed (`git commit -s`)
