### PR TITLE
test(switch): assert thumb data-slot='switch-thumb' contract

### DIFF
--- a/hushh-webapp/__tests__/ui/switch.test.tsx
+++ b/hushh-webapp/__tests__/ui/switch.test.tsx
@@ -25,4 +25,14 @@ describe("Switch", () => {
       "true",
     );
   });
+
+  it("renders thumb with data-slot='switch-thumb'", () => {
+    const { container } = render(<Switch />);
+
+    expect(
+      container
+        .querySelector('[data-slot="switch-thumb"]')
+        ?.getAttribute("data-slot"),
+    ).toBe("switch-thumb");
+  });
 });


### PR DESCRIPTION
## Summary

Adds a contract test for the `data-slot="switch-thumb"` attribute rendered by the Switch thumb element.

## Changes

- Appends one test to `__tests__/ui/switch.test.tsx`
- Verifies the thumb renders with `data-slot="switch-thumb"`
- No production code changes
- No new imports
- No snapshots

## Validation

```bash
npx vitest run __tests__/ui/switch.test.tsx