### PR TITLE
test(switch): assert data-size default and sm passthrough contract

### DIFF
--- a/hushh-webapp/__tests__/ui/switch.test.tsx
+++ b/hushh-webapp/__tests__/ui/switch.test.tsx
@@ -35,4 +35,16 @@ describe("Switch", () => {
         ?.getAttribute("data-slot"),
     ).toBe("switch-thumb");
   });
+  
+  it("renders with data-size='default' by default and data-size='sm' when size='sm'", () => {
+    const { rerender } = render(<Switch />);
+
+    expect(screen.getByRole("switch").getAttribute("data-size")).toBe(
+      "default",
+    );
+
+    rerender(<Switch size="sm" />);
+
+    expect(screen.getByRole("switch").getAttribute("data-size")).toBe("sm");
+  });
 });


### PR DESCRIPTION
## Summary

Adds a contract test covering the `data-size` attribute on the Switch root.

## Changes

* Appends one test to `__tests__/ui/switch.test.tsx`
* Verifies the default render exposes `data-size="default"`
* Verifies `size="sm"` updates the attribute to `data-size="sm"`
* No production code changes
* No new imports
* No snapshots

## Validation

```bash
npx vitest run __tests__/ui/switch.test.tsx
```

## Risk

* Test-only change
* Append-only diff
* No behavioral changes
