### PR TITLE
test(checkbox): assert data-disabled attribute on disabled state

### DIFF
--- a/hushh-webapp/__tests__/ui/checkbox.test.tsx
+++ b/hushh-webapp/__tests__/ui/checkbox.test.tsx
@@ -28,4 +28,11 @@ describe("Checkbox", () => {
 
     expect(checkbox?.getAttribute("aria-checked")).toBe("true");
   });
+
+  it("sets data-disabled attribute when disabled prop is passed", () => {
+    const { container } = render(<Checkbox disabled />);
+    const checkbox = container.querySelector('[data-slot="checkbox"]');
+
+    expect(checkbox?.getAttribute("data-disabled")).not.toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

Adds a contract test verifying that a disabled `Checkbox` renders the Radix `data-disabled` attribute.

## Changes

* Appends one test to `__tests__/ui/checkbox.test.tsx`
* Verifies `data-disabled` is present when `disabled` is passed
* No production code changes
* No new imports
* No snapshots

## Validation

```bash
npx vitest run __tests__/ui/checkbox.test.tsx
```

## Risk

* Test-only change
* Append-only diff
* No behavioral changes
