### PR TITLE
fix(navbar): flatten active bottom-nav segment indicator

### DIFF
--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -410,7 +410,10 @@ export const Navbar = () => {
               // Lean flat track matching the search button + top app bar
               // (ShellActionSurface): soft translucent surface, no shadow/blur.
               "bg-black/[0.05] shadow-none backdrop-blur-none dark:bg-white/[0.07]",
-              "[&_[aria-checked=true]]:text-primary [&_[data-segment-indicator]]:bg-primary/10 [&_[data-segment-indicator]]:shadow-sm",
+              // Active segment: flat translucent highlight, no inherited
+              // shadow/blur from the shared primitive (keeps it lean + matched).
+              "[&_[aria-checked=true]]:text-primary",
+              "[&_[data-segment-indicator]]:bg-black/[0.06] [&_[data-segment-indicator]]:shadow-none [&_[data-segment-indicator]]:backdrop-blur-none dark:[&_[data-segment-indicator]]:bg-white/[0.1]",
             )}
           />
         </div>


### PR DESCRIPTION
The shared SegmentedPill primitive applies a glassy default to the active segment indicator (shadow + backdrop-blur). On the bottom nav this clashed with the lean flat search circle and the flat Mic/AudioLines controls. This overrides the indicator to a flat translucent highlight (no shadow, no blur), scoped to the navbar caller only. Verified at runtime: indicator boxShadow=none, backdropFilter=none.