### PR TITLE
test(radio-group): assert decorative CircleIcon aria-hidden="true" contract

### DIFF
--- a/hushh-webapp/__tests__/ui/radio-group.test.tsx
+++ b/hushh-webapp/__tests__/ui/radio-group.test.tsx
@@ -54,4 +54,18 @@ describe("RadioGroup", () => {
     expect(checkedOptions).toHaveLength(1);
     expect(checkedOptions[0].getAttribute("value")).toBe("b");
   });
+
+  it("marks the decorative CircleIcon as aria-hidden", () => {
+    const { container } = render(
+      <RadioGroup defaultValue="a">
+        <RadioGroupItem value="a" />
+      </RadioGroup>,
+    );
+
+    const icon = container.querySelector(
+      '[data-slot="radio-group-indicator"] svg',
+    );
+
+    expect(icon?.getAttribute("aria-hidden")).toBe("true");
+  });
 });


### PR DESCRIPTION
## Summary

Adds a contract test verifying that the decorative `CircleIcon` rendered inside `RadioGroupItem` is marked with `aria-hidden="true"`.

## Changes

* Appends one test to `__tests__/ui/radio-group.test.tsx`
* Verifies the indicator SVG exposes `aria-hidden="true"`
* No production code changes
* No new imports
* No snapshots

## Validation

```bash
npx vitest run __tests__/ui/radio-group.test.tsx
```

## Risk

* Test-only change
* Append-only diff
* No behavioral changes
