### PR TITLE
test(utils): characterize formatCompleteJson negative percentage formatting

### DIFF
--- a/hushh-webapp/__tests__/utils/format-json-exponential.test.ts
+++ b/hushh-webapp/__tests__/utils/format-json-exponential.test.ts
@@ -71,4 +71,17 @@ describe("formatCompleteJson — exponential / scientific notation numbers", () 
     });
     expect(out).toContain("Precise: 0.1235");
   });
+
+  it("renders a negative percentage field with a bare minus sign — no plus prefix", () => {
+    // formatPercent: sign = "" when value < 0; toFixed(2) supplies the "-" itself.
+    // Distinct from the positive branch ("+" + value.toFixed(2)) tested above.
+    const out = formatCompleteJson({
+      portfolio_summary: {
+        est_yield: -2.5,
+      },
+    });
+
+    expect(out).toContain("Yield: -2.50%");
+    expect(out).not.toContain("+");
+  });
 });


### PR DESCRIPTION
## Summary

Adds a characterization test covering negative percentage formatting in `formatCompleteJson`.

## Changes

* Appends one test to `__tests__/utils/format-json-exponential.test.ts`
* Verifies negative percentage values render with a minus sign and no `"+"` prefix
* No production code changes
* No new imports
* No snapshots

## Validation

```bash
npx vitest run __tests__/utils/format-json-exponential.test.ts
```

## Risk

* Test-only change
* Append-only diff
* No behavioral changes
