### PR TITLE
test(utils): characterize formatCompleteJson historical_values summary

### DIFF
--- a/hushh-webapp/__tests__/utils/format-complete-json-bounds.test.ts
+++ b/hushh-webapp/__tests__/utils/format-complete-json-bounds.test.ts
@@ -123,4 +123,14 @@ describe("formatCompleteJson — array bounds with null and mixed primitives", (
     expect(out).toContain("--- Legal Disclosures (2 items) ---");
     expect(out).toContain("2 disclosure(s) extracted");
   });
+    
+  it("emits a data-point count line for the historical_values array", () => {
+    // Specialized branch: skips per-item rendering and emits only the count line.
+    const out = formatCompleteJson({
+      historical_values: [{}, {}, {}],
+    });
+
+    expect(out).toContain("--- Historical Values (3 items) ---");
+    expect(out).toContain("3 data point(s) for portfolio history chart");
+  });
 });


### PR DESCRIPTION
## Summary

Adds a characterization test for the specialized `historical_values` branch in `formatCompleteJson`.

## Changes

* Appends one test to `__tests__/utils/format-complete-json-bounds.test.ts`
* Verifies the section header and data-point summary emitted for the `historical_values` array
* No production code changes
* No new imports
* No snapshots

## Validation

```bash
npx vitest run __tests__/utils/format-complete-json-bounds.test.ts
```

## Risk

* Test-only change
* Append-only diff
* No production behavior modified
