### PR TITLE
test(utils): characterize formatCompleteJson asset_allocation rendering

### DIFF
--- a/hushh-webapp/__tests__/utils/format-complete-json-bounds.test.ts
+++ b/hushh-webapp/__tests__/utils/format-complete-json-bounds.test.ts
@@ -123,4 +123,22 @@ describe("formatCompleteJson — array bounds with null and mixed primitives", (
     expect(out).toContain("--- Legal Disclosures (2 items) ---");
     expect(out).toContain("2 disclosure(s) extracted");
   });
+
+  it("renders a well-formed asset_allocation entry with category, percentage, and market value", () => {
+    // Happy path for the specialized asset_allocation branch.
+    // Existing coverage only documents the null-element TypeError boundary.
+    // percentage uses toFixed(1); market_value uses formatCurrency.
+    const out = formatCompleteJson({
+      asset_allocation: [
+        {
+          category: "Equity",
+          percentage: 65.3,
+          market_value: 100000,
+        },
+      ],
+    });
+
+    expect(out).toContain("--- Asset Allocation (1 items) ---");
+    expect(out).toContain("• Equity: 65.3% ($100,000.00)");
+  });
 });


### PR DESCRIPTION
## Summary

Adds a characterization test covering the happy-path rendering of the specialized `asset_allocation` branch in `formatCompleteJson`.

## Changes

* Appends one test to `__tests__/utils/format-complete-json-bounds.test.ts`
* Verifies the section header and formatted asset allocation entry
* No production code changes
* No new imports
* No snapshots

## Validation

```bash
npx vitest run __tests__/utils/format-complete-json-bounds.test.ts
```

## Risk

* Test-only change
* Append-only diff
* No production behavior modified
