### PR TITLE
test(navigation): characterize normalizeInternalRouteHref double question mark queries

### DIFF
--- a/hushh-webapp/__tests__/navigation/normalize-double-questions.test.ts
+++ b/hushh-webapp/__tests__/navigation/normalize-double-questions.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for normalizeInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts) focused on non-standard DOUBLE
+// question marks inside raw query paths (e.g. "/search??query=value" or
+// "/page?id=1?type=all").
+//
+// TRUTH-FIRST: normalizeInternalRouteHref does NOT parse, split, or validate the
+// query string. It performs only structural guards on the whole href:
+//   - reject empty / whitespace-only input  → null
+//   - reject input not beginning with "/"   → null
+//   - reject protocol-relative "//..."       → null
+//   - reject input containing CR or LF        → null
+//   - otherwise return the (trimmed) string VERBATIM
+// The "?" character is never special-cased. A secondary "?" is therefore NOT
+// flagged, NOT collapsed, and NOT stripped — the entire path (including every
+// extra "?") is returned exactly as-is. The premise that the guard might "flag
+// the secondary characters" is FALSE; they are left verbatim.
+
+describe("normalizeInternalRouteHref — double question marks", () => {
+  it("returns a leading-double-question path verbatim (does not flag the 2nd ?)", () => {
+    expect(normalizeInternalRouteHref("/search??query=value")).toBe(
+      "/search??query=value"
+    );
+  });
+
+  it("returns an interior second-question path verbatim", () => {
+    expect(normalizeInternalRouteHref("/page?id=1?type=all")).toBe(
+      "/page?id=1?type=all"
+    );
+  });
+
+  it("preserves three or more question marks unchanged", () => {
+    expect(normalizeInternalRouteHref("/a???b")).toBe("/a???b");
+  });
+
+  it("keeps a trailing bare double-question verbatim", () => {
+    expect(normalizeInternalRouteHref("/results??")).toBe("/results??");
+  });
+
+  it("still rejects a double-question path that is not rooted (no leading slash)", () => {
+    expect(normalizeInternalRouteHref("search??query=value")).toBeNull();
+  });
+
+  it("still rejects a protocol-relative double-question path", () => {
+    expect(normalizeInternalRouteHref("//evil.com??x=1")).toBeNull();
+  });
+
+  it("trims a TRAILING newline then accepts (trim() runs before the CR/LF guard)", () => {
+    // trim() removes the trailing \n first, so the CR/LF guard never sees it.
+    expect(normalizeInternalRouteHref("/search??q=1\n")).toBe("/search??q=1");
+  });
+
+  it("still rejects a double-question path with an INTERIOR newline (CR/LF guard)", () => {
+    expect(normalizeInternalRouteHref("/search??q=1\nx=2")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Extends characterization coverage for `normalizeInternalRouteHref`
(`hushh-webapp/lib/navigation/routes.ts`) to map the contract boundary when a raw
internal path contains non-standard **double question marks**
(`/search??query=value`, `/page?id=1?type=all`). Test-only; no production change.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/navigation/...`. There is
  no top-level `__tests__` in this repo; vitest only includes `__tests__/**`
  under `hushh-webapp`. The file lives at
  `hushh-webapp/__tests__/navigation/normalize-double-questions.test.ts`.
- **The guard does NOT flag, collapse, or strip secondary `?` characters.**
  `normalizeInternalRouteHref` never parses the query string. It only applies
  whole-href structural guards (reject empty/whitespace-only, reject non-rooted,
  reject protocol-relative `//`, reject CR/LF) and otherwise returns the trimmed
  string **verbatim**. Every extra `?` is preserved exactly as-is. The premise
  that it might "flag the secondary characters" is **false**.
- A real ordering nuance is also pinned: `trim()` runs **before** the CR/LF
  guard, so a **trailing** newline is stripped and the path is **accepted**,
  while an **interior** newline is still **rejected** (→ `null`).

## Behavior pinned

- `/search??query=value` → returned verbatim
- `/page?id=1?type=all` → returned verbatim
- `/a???b` → returned verbatim (3+ `?`)
- `/results??` → returned verbatim (trailing bare double-?)
- `search??query=value` (no leading slash) → `null`
- `//evil.com??x=1` (protocol-relative) → `null`
- `/search??q=1\n` (trailing newline) → `/search??q=1` (trimmed, then accepted)
- `/search??q=1\nx=2` (interior newline) → `null`

## Verification

- `npm test -- __tests__/navigation/normalize-double-questions.test.ts` → 8/8 pass
- `git status` limited to the single new test file; zero production source drift

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the real verbatim pass-through of extra `?` (plus the
  trim-before-CR/LF ordering) rather than an assumed flagging/sanitizing guard
