### PR TITLE
test(navigation): characterize resolveInternalRouteHref string encoded equals truncations

### DIFF
--- a/hushh-webapp/__tests__/navigation/resolve-equals-truncation.test.ts
+++ b/hushh-webapp/__tests__/navigation/resolve-equals-truncation.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for resolveInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts) focused on query strings whose
+// parameter VALUES contain un-encoded / multi-token assignment "=" symbols
+// (e.g. "/auth?token=abc=123").
+//
+// Implementation:
+//   export function resolveInternalRouteHref(value, fallback): string {
+//     return normalizeInternalRouteHref(value) ?? fallback;
+//   }
+// normalizeInternalRouteHref applies only whole-href structural guards
+// (reject empty/whitespace-only, reject non-rooted, reject protocol-relative
+// "//", reject CR/LF) and otherwise returns the trimmed string verbatim.
+//
+// TRUTH-FIRST: resolveInternalRouteHref does NOT parse the query string, does
+// NOT split on "=", and does NOT truncate at any "parsing threshold". A value
+// containing extra "=" characters is preserved exactly as-is (every "=" intact),
+// because an accepted href is returned verbatim by normalize. The fallback is
+// only ever returned when normalize REJECTS the input (→ null). The premise that
+// it "truncates parsing thresholds" is FALSE — string structure is maintained.
+
+const FALLBACK = "/home";
+
+describe("resolveInternalRouteHref — embedded '=' in parameter values", () => {
+  it("keeps a multi-equals token value verbatim (no truncation at the 2nd '=')", () => {
+    expect(resolveInternalRouteHref("/auth?token=abc=123", FALLBACK)).toBe(
+      "/auth?token=abc=123"
+    );
+  });
+
+  it("preserves base64-style padding '=' in a value", () => {
+    expect(
+      resolveInternalRouteHref("/cb?data=YWJjZGVm==", FALLBACK)
+    ).toBe("/cb?data=YWJjZGVm==");
+  });
+
+  it("preserves multiple params each containing extra '=' signs", () => {
+    expect(
+      resolveInternalRouteHref("/x?a=1=2&b=3=4", FALLBACK)
+    ).toBe("/x?a=1=2&b=3=4");
+  });
+
+  it("keeps a leading '=' in a value verbatim", () => {
+    expect(resolveInternalRouteHref("/p?q==eq", FALLBACK)).toBe("/p?q==eq");
+  });
+
+  it("returns the fallback for a non-rooted equals path (normalize rejects)", () => {
+    expect(resolveInternalRouteHref("auth?token=abc=123", FALLBACK)).toBe(
+      FALLBACK
+    );
+  });
+
+  it("returns the fallback for a protocol-relative equals path", () => {
+    expect(resolveInternalRouteHref("//evil.com?token=abc=123", FALLBACK)).toBe(
+      FALLBACK
+    );
+  });
+
+  it("returns the fallback for null/empty input (no value to maintain)", () => {
+    expect(resolveInternalRouteHref(null, FALLBACK)).toBe(FALLBACK);
+    expect(resolveInternalRouteHref("", FALLBACK)).toBe(FALLBACK);
+  });
+
+  it("trims surrounding whitespace but keeps interior '=' structure intact", () => {
+    expect(resolveInternalRouteHref("  /auth?token=abc=123  ", FALLBACK)).toBe(
+      "/auth?token=abc=123"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Documents the exact contract of `resolveInternalRouteHref`
(`hushh-webapp/lib/navigation/routes.ts`) when a parameter **value** contains
un-encoded / multi-token assignment `=` symbols (`/auth?token=abc=123`).
Test-only; no production change.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/navigation/...`. There is
  no top-level `__tests__` in this repo; vitest only includes `__tests__/**`
  under `hushh-webapp`. The file lives at
  `hushh-webapp/__tests__/navigation/resolve-equals-truncation.test.ts`.
- `resolveInternalRouteHref` is a thin wrapper:
  ```ts
  export function resolveInternalRouteHref(value, fallback): string {
    return normalizeInternalRouteHref(value) ?? fallback;
  }
  ```
  It takes a **required `fallback` argument** and returns the normalized href, or
  the fallback when normalize rejects the input.
- **The premise that it "truncates parsing thresholds" is FALSE.** Neither
  `resolveInternalRouteHref` nor `normalizeInternalRouteHref` parses the query
  string or splits on `=`. An accepted href is returned **verbatim** with every
  `=` intact; the only transformation is a surrounding `trim()`. The fallback is
  returned **only** when normalize rejects the whole href (empty/whitespace-only,
  non-rooted, protocol-relative `//`, or interior CR/LF) — never as a truncation.

## Behavior pinned

- `/auth?token=abc=123` → returned verbatim (no truncation at the 2nd `=`)
- `/cb?data=YWJjZGVm==` → verbatim (base64 padding `=` kept)
- `/x?a=1=2&b=3=4` → verbatim (multiple params, extra `=` each)
- `/p?q==eq` → verbatim (leading `=` in value kept)
- `auth?token=abc=123` (non-rooted) → fallback `/home`
- `//evil.com?token=abc=123` (protocol-relative) → fallback `/home`
- `null` / `""` → fallback `/home`
- `"  /auth?token=abc=123  "` → `/auth?token=abc=123` (trimmed, interior `=` intact)

## Verification

- `npm test -- __tests__/navigation/resolve-equals-truncation.test.ts` → 8/8 pass
- `git status` limited to the single new test file; zero production source drift

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the real verbatim pass-through of embedded `=` (fallback
  only on whole-href rejection) rather than an assumed truncating query parser
