### PR TITLE
test(runtime-settings): cover false voice preference parsing

### DIFF
--- a/hushh-webapp/__tests__/lib/runtime-settings.test.ts
+++ b/hushh-webapp/__tests__/lib/runtime-settings.test.ts
@@ -47,4 +47,10 @@ describe("runtime settings", () => {
 
   expect(resolveVoiceDirectBackendPreference()).toBe(true);
   });
+
+  it("treats false as disabled for direct backend preference", () => {
+  process.env.NEXT_PUBLIC_VOICE_DIRECT_BACKEND = "false";
+
+  expect(resolveVoiceDirectBackendPreference()).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- Add runtime settings coverage for explicit false voice direct backend preference parsing.
- Assert `NEXT_PUBLIC_VOICE_DIRECT_BACKEND=false` resolves to `false`.

## Why
This locks the truthy-only parsing contract for voice direct backend runtime settings.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched `integration/pr-train` head before this commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/lib/runtime-settings.test.ts` only.
- This PR appends one focused runtime-settings test for false voice preference parsing.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/lib/runtime-settings.test.ts`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.