### PR TITLE
test(utils): characterize formatCompleteJson on extreme integer overflows

### DIFF
--- a/hushh-webapp/__tests__/utils/format-json-overflows.test.ts
+++ b/hushh-webapp/__tests__/utils/format-json-overflows.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCompleteJson } from "@/lib/utils/json-to-human";
+
+// Characterization tests for formatCompleteJson
+// (hushh-webapp/lib/utils/json-to-human.ts) focused on numbers that sit on or
+// outside standard safe integer bounds (Number.MAX_SAFE_INTEGER and beyond).
+//
+// TRUTH-FIRST: formatCompleteJson does NOT do any bigint promotion, overflow
+// guarding, or "safe integer" detection. A top-level scalar number flows through
+// formatValue:
+//   - currency keys → Intl.NumberFormat(style:"currency", 2 frac digits)
+//   - percentage keys → `${sign}${value.toFixed(2)}%`
+//   - everything else → formatNumber = Intl.NumberFormat(maximumFractionDigits:4)
+// Because the value is already a JS double, any precision loss happens at literal
+// parse time (e.g. MAX_SAFE_INTEGER + 10 rounds to ...741000 BEFORE formatting).
+// The formatter simply renders whatever double it receives, with en-US grouping.
+// Non-finite values are rendered by Intl as "∞", "-∞", "NaN" (currency: "$∞").
+
+describe("formatCompleteJson — extreme integer overflow boundaries", () => {
+  it("renders MAX_SAFE_INTEGER exactly with grouping (generic key)", () => {
+    expect(formatCompleteJson({ count: Number.MAX_SAFE_INTEGER })).toBe(
+      "Count: 9,007,199,254,740,991"
+    );
+  });
+
+  it("shows double rounding for MAX_SAFE_INTEGER + 10 (…991 + 10 → …741,000)", () => {
+    expect(formatCompleteJson({ count: Number.MAX_SAFE_INTEGER + 10 })).toBe(
+      "Count: 9,007,199,254,741,000"
+    );
+  });
+
+  it("renders MIN_SAFE_INTEGER - 10 with the same rounding, negative", () => {
+    expect(formatCompleteJson({ count: Number.MIN_SAFE_INTEGER - 10 })).toBe(
+      "Count: -9,007,199,254,741,000"
+    );
+  });
+
+  it("expands 1e21 to full grouped digits (no exponential in output)", () => {
+    expect(formatCompleteJson({ count: 1e21 })).toBe(
+      "Count: 1,000,000,000,000,000,000,000"
+    );
+  });
+
+  it("renders a currency-keyed overflow with $ and 2 fraction digits", () => {
+    expect(formatCompleteJson({ amount: Number.MAX_SAFE_INTEGER + 10 })).toBe(
+      "Amount: $9,007,199,254,741,000.00"
+    );
+  });
+
+  it("renders +Infinity as the ∞ glyph (generic key)", () => {
+    expect(formatCompleteJson({ count: Number.POSITIVE_INFINITY })).toBe(
+      "Count: ∞"
+    );
+  });
+
+  it("renders -Infinity as -∞ (generic key)", () => {
+    expect(formatCompleteJson({ count: Number.NEGATIVE_INFINITY })).toBe(
+      "Count: -∞"
+    );
+  });
+
+  it("renders NaN as the literal 'NaN' (generic key)", () => {
+    expect(formatCompleteJson({ count: Number.NaN })).toBe("Count: NaN");
+  });
+
+  it("renders a currency-keyed +Infinity as '$∞'", () => {
+    expect(formatCompleteJson({ amount: Number.POSITIVE_INFINITY })).toBe(
+      "Amount: $∞"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Establishes baseline layout metrics for `formatCompleteJson`
(`hushh-webapp/lib/utils/json-to-human.ts`) when top-level scalar numbers sit on
or beyond standard safe integer bounds (`Number.MAX_SAFE_INTEGER` and beyond),
plus the non-finite extremes. Test-only; no production change.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/utils/...`. There is no
  top-level `__tests__` in this repo; vitest only includes `__tests__/**` under
  `hushh-webapp`. The file lives at
  `hushh-webapp/__tests__/utils/format-json-overflows.test.ts`.
- **`formatCompleteJson` does NOT do any bigint promotion, overflow guarding, or
  "safe integer" detection.** A top-level scalar number is routed through
  `formatValue`:
  - currency keys → `Intl.NumberFormat(style:"currency", 2 frac digits)`
  - percentage keys → `` `${sign}${value.toFixed(2)}%` ``
  - everything else → `formatNumber` = `Intl.NumberFormat(maximumFractionDigits:4)`
- Any precision loss happens at **literal parse time** (the value is already a JS
  double before the formatter sees it). `MAX_SAFE_INTEGER + 10` is rounded to
  `…741000` *before* formatting — the formatter only adds en-US grouping.
- Non-finite values are passed straight to Intl, which renders `∞`, `-∞`, `NaN`
  (currency style: `$∞`). There is no sanitizing or fallback for these.

## Baseline output pinned

- `count: MAX_SAFE_INTEGER` → `Count: 9,007,199,254,740,991`
- `count: MAX_SAFE_INTEGER + 10` → `Count: 9,007,199,254,741,000` (double rounding)
- `count: MIN_SAFE_INTEGER - 10` → `Count: -9,007,199,254,741,000`
- `count: 1e21` → `Count: 1,000,000,000,000,000,000,000` (expanded, no exponential)
- `amount: MAX_SAFE_INTEGER + 10` → `Amount: $9,007,199,254,741,000.00`
- `count: +Infinity` → `Count: ∞`
- `count: -Infinity` → `Count: -∞`
- `count: NaN` → `Count: NaN`
- `amount: +Infinity` → `Amount: $∞`

## Verification

- `npm test -- __tests__/utils/format-json-overflows.test.ts` → 9/9 pass
- `git status` limited to the single new test file; zero production source drift

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the real Intl-double rendering (incl. parse-time rounding
  and `∞`/`NaN`/`$∞` glyphs) rather than an assumed bigint/overflow-safe path
