### PR TITLE
test(navigation): characterize normalizeInternalRouteHref spaces in hash fragments

### DIFF
--- a/hushh-webapp/__tests__/navigation/normalize-hash-spaces.test.ts
+++ b/hushh-webapp/__tests__/navigation/normalize-hash-spaces.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for normalizeInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts) focused on spaces / encoding
+// variations inside a TRAILING hash fragment
+// (e.g. "/legal#privacy policy" vs "/legal#privacy%20policy").
+//
+// TRUTH-FIRST: normalizeInternalRouteHref does NOT parse, split, decode, or
+// re-encode the fragment. It applies only whole-href structural guards
+// (reject empty/whitespace-only, reject non-rooted, reject protocol-relative
+// "//", reject interior CR/LF) and otherwise returns the trimmed string
+// VERBATIM. The "#" character is never special-cased, so a fragment is treated
+// EXACTLY like any other path text:
+//   - a raw space inside the fragment is preserved (NOT encoded to %20)
+//   - an existing %20 is preserved (NOT decoded to a space)
+//   - leading/trailing whitespace on the whole href is trimmed (so a trailing
+//     space after the fragment is removed by trim())
+// The premise that fragments are "treated differently than standard path
+// segments" is FALSE — there is no fragment-specific manipulation.
+
+describe("normalizeInternalRouteHref — spaces in hash fragments", () => {
+  it("keeps a raw space inside the fragment verbatim (no %20 encoding)", () => {
+    expect(normalizeInternalRouteHref("/legal#privacy policy")).toBe(
+      "/legal#privacy policy"
+    );
+  });
+
+  it("keeps an existing %20 in the fragment verbatim (no decoding)", () => {
+    expect(normalizeInternalRouteHref("/legal#privacy%20policy")).toBe(
+      "/legal#privacy%20policy"
+    );
+  });
+
+  it("does not collapse multiple raw spaces inside the fragment", () => {
+    expect(normalizeInternalRouteHref("/legal#a  b")).toBe("/legal#a  b");
+  });
+
+  it("treats a space before '#' the same way (kept verbatim)", () => {
+    expect(normalizeInternalRouteHref("/legal #privacy")).toBe(
+      "/legal #privacy"
+    );
+  });
+
+  it("trims a trailing space AFTER the fragment (whole-href trim)", () => {
+    expect(normalizeInternalRouteHref("/legal#privacy policy ")).toBe(
+      "/legal#privacy policy"
+    );
+  });
+
+  it("preserves a bare trailing '#' with no fragment text", () => {
+    expect(normalizeInternalRouteHref("/legal#")).toBe("/legal#");
+  });
+
+  it("still rejects a non-rooted href even with a hash fragment", () => {
+    expect(normalizeInternalRouteHref("legal#privacy policy")).toBeNull();
+  });
+
+  it("still rejects a protocol-relative href with a hash fragment", () => {
+    expect(normalizeInternalRouteHref("//evil.com#privacy policy")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Pins the retention rules of `normalizeInternalRouteHref`
(`hushh-webapp/lib/navigation/routes.ts`) for space characters and encoding
variations inside a **trailing hash fragment**
(`/legal#privacy policy` vs `/legal#privacy%20policy`). Test-only; no production
change.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/navigation/...`. There is
  no top-level `__tests__` in this repo; vitest only includes `__tests__/**`
  under `hushh-webapp`. The file lives at
  `hushh-webapp/__tests__/navigation/normalize-hash-spaces.test.ts`.
- **The premise that fragments are "treated differently than standard path
  segments" is FALSE.** `normalizeInternalRouteHref` never special-cases `#`. It
  does not parse, split, decode, or re-encode the fragment. It applies only
  whole-href structural guards (reject empty/whitespace-only, reject non-rooted,
  reject protocol-relative `//`, reject interior CR/LF) and otherwise returns the
  **trimmed string verbatim**. A fragment is just trailing path text.

## Behavior pinned

- `/legal#privacy policy` → verbatim (raw space kept, **not** encoded to `%20`)
- `/legal#privacy%20policy` → verbatim (`%20` kept, **not** decoded)
- `/legal#a  b` → verbatim (multiple raw spaces not collapsed)
- `/legal #privacy` → verbatim (space before `#` treated identically)
- `/legal#privacy policy ` → `/legal#privacy policy` (whole-href `trim()` only)
- `/legal#` → verbatim (bare trailing `#` preserved)
- `legal#privacy policy` (non-rooted) → `null`
- `//evil.com#privacy policy` (protocol-relative) → `null`

## Verification

- `npm test -- __tests__/navigation/normalize-hash-spaces.test.ts` → 8/8 pass
- `git status` limited to the single new test file; zero production source drift

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the real verbatim-or-trim/reject contract (no
  fragment-specific space encoding/decoding) rather than an assumed fragment parser
