### PR TITLE
test(utils): characterize formatCompleteJson array nesting depth invariants

### DIFF
--- a/hushh-webapp/__tests__/utils/format-array-nesting.test.ts
+++ b/hushh-webapp/__tests__/utils/format-array-nesting.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCompleteJson } from "@/lib/utils/json-to-human";
+
+// Characterization tests for formatCompleteJson
+// (hushh-webapp/lib/utils/json-to-human.ts) focused on deeply nested numeric
+// arrays (e.g. [[[[[1]]]]]) routed through the GENERIC array branch.
+//
+// TRUTH-FIRST: formatCompleteJson does NOT recurse into nested arrays and does
+// NOT preserve brace/bracket structure at all. There is no "structural depth
+// layout" or brace-separator handling. The generic array branch:
+//   - emits a header line "" + "--- <Label> (<n> items) ---"
+//   - iterates only the first 3 TOP-LEVEL items (slice(0, 3))
+//   - for an object/array item, picks the first non-null Object.values entry and
+//     String()-coerces it; for a primitive item, String()-coerces directly
+//   - appends "  ... and <n-3> more" only when length > 3
+// Because depth is measured by the OUTER array length (always 1 for [[[[[1]]]]]),
+// nesting depth is invisible. JS String() coercion flattens single-element nested
+// arrays: String([[[[1]]]]) === "1". An empty inner array has no non-null value,
+// so the fallback literal "Item" is used. Brackets/commas never appear.
+
+describe("formatCompleteJson — deep nested array layout", () => {
+  it("collapses a 5-deep single-element array to one '• 1' bullet (depth invisible)", () => {
+    expect(formatCompleteJson({ data: [[[[[1]]]]] })).toBe(
+      "\n--- Data (1 items) ---\n  • 1"
+    );
+  });
+
+  it("reports outer length as 1 regardless of nesting depth", () => {
+    expect(formatCompleteJson({ data: [[[[[1]]]]] })).toContain(
+      "--- Data (1 items) ---"
+    );
+  });
+
+  it("String()-flattens a 3-deep wrapper the same way (no brackets emitted)", () => {
+    const out = formatCompleteJson({ data: [[[[1]]]] });
+    expect(out).toBe("\n--- Data (1 items) ---\n  • 1");
+    expect(out).not.toContain("[");
+    expect(out).not.toContain("]");
+  });
+
+  it("uses the first Object.values entry per top-level row of a matrix", () => {
+    expect(
+      formatCompleteJson({ matrix: [[1, 2], [3, 4], [5, 6], [7, 8]] })
+    ).toBe(
+      "\n--- Matrix (4 items) ---\n  • 1\n  • 3\n  • 5\n  ... and 1 more"
+    );
+  });
+
+  it("caps the listing at the first 3 top-level items with an overflow line", () => {
+    expect(formatCompleteJson({ matrix: [[1, 2], [3, 4], [5, 6], [7, 8]] }))
+      .toContain("... and 1 more");
+  });
+
+  it("falls back to literal 'Item' for an empty inner array (no non-null value)", () => {
+    expect(formatCompleteJson({ data: [[]] })).toBe(
+      "\n--- Data (1 items) ---\n  • Item"
+    );
+  });
+
+  it("formats a flat numeric array verbatim per element (no nesting at all)", () => {
+    expect(formatCompleteJson({ nums: [1, 2, 3] })).toBe(
+      "\n--- Nums (3 items) ---\n  • 1\n  • 2\n  • 3"
+    );
+  });
+
+  it("never emits bracket or comma separators for deep nesting", () => {
+    const out = formatCompleteJson({ data: [[[[[1]]]]] });
+    expect(out).not.toMatch(/[\[\]]/);
+  });
+});


### PR DESCRIPTION
## Summary

Establishes the layout invariants of `formatCompleteJson`
(`hushh-webapp/lib/utils/json-to-human.ts`) when a section value is a deeply
nested numeric array (e.g. `[[[[[1]]]]]`) routed through the generic array
branch. Test-only; no production change.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/utils/...`. There is no
  top-level `__tests__` in this repo; vitest only includes `__tests__/**` under
  `hushh-webapp`. The file lives at
  `hushh-webapp/__tests__/utils/format-array-nesting.test.ts`.
- **The premise of "structural depth layout" / "brace separators" is FALSE.**
  `formatCompleteJson` does **not** recurse into nested arrays and never emits
  brackets or commas. The generic array branch:
  - emits `"" + "--- <Label> (<n> items) ---"` where `<n>` is the **outer**
    array length;
  - lists only the first **3** top-level items (`slice(0, 3)`);
  - for an object/array item, picks the first non-null `Object.values` entry and
    `String()`-coerces it; for a primitive, `String()`-coerces directly;
  - appends `"  ... and <n-3> more"` only when `length > 3`.
- Nesting depth is therefore **invisible**: `[[[[[1]]]]]` has outer length 1, and
  JS `String([[[[1]]]]) === "1"` flattens the single-element wrapper to `"1"`. An
  empty inner array (`[[]]`) has no non-null value, so the fallback literal
  `"Item"` is used.

## Behavior pinned

- `{ data: [[[[[1]]]]] }` → `"\n--- Data (1 items) ---\n  • 1"` (depth invisible)
- `{ data: [[[[1]]]] }` → same, and output contains **no** `[` or `]`
- `{ matrix: [[1,2],[3,4],[5,6],[7,8]] }` → header `(4 items)`, bullets `1/3/5`,
  then `... and 1 more` (first `Object.values` entry per row; capped at 3)
- `{ data: [[]] }` → `"\n--- Data (1 items) ---\n  • Item"` (empty-inner fallback)
- `{ nums: [1,2,3] }` → `"\n--- Nums (3 items) ---\n  • 1\n  • 2\n  • 3"`
- deep nesting never emits bracket/comma separators (`/[\[\]]/` does not match)

## Verification

- `npm test -- __tests__/utils/format-array-nesting.test.ts` → 8/8 pass
- `git status` limited to the single new test file; zero production source drift

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the real non-recursive, outer-length / first-3 /
  String()-coercion behavior rather than an assumed depth-aware brace formatter
