### PR TITLE
test(navigation): characterize resolveInternalRouteHref encoded query symbol traps

### DIFF
--- a/hushh-webapp/__tests__/navigation/resolve-encoded-symbols.test.ts
+++ b/hushh-webapp/__tests__/navigation/resolve-encoded-symbols.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for resolveInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts) focused on percent-encoded symbol
+// keys (%26 '&', %3D '=', %3F '?') inside search query values.
+//
+// TRUTH-FIRST: resolveInternalRouteHref is a thin wrapper —
+//   resolveInternalRouteHref(value, fallback)
+//     = normalizeInternalRouteHref(value) ?? fallback
+// It does NOT parse the query string, NOT decode percent-encodings, and NOT
+// distinguish encoded "%26/%3D/%3F" from LIVE structural delimiters "&/=/?".
+// An accepted href is returned VERBATIM (only surrounding whitespace trimmed);
+// the fallback is returned ONLY when normalize rejects the whole href
+// (empty/whitespace-only, non-rooted, protocol-relative "//", interior CR/LF).
+// So encoded symbols are preserved exactly as written — they are neither decoded
+// into delimiters nor re-encoded.
+
+const FALLBACK = "/home";
+
+describe("resolveInternalRouteHref — percent-encoded query symbols", () => {
+  it("keeps %26 verbatim (not decoded to a live '&' delimiter)", () => {
+    expect(resolveInternalRouteHref("/s?q=a%26b", FALLBACK)).toBe(
+      "/s?q=a%26b"
+    );
+  });
+
+  it("keeps %3D verbatim (not decoded to a live '=' delimiter)", () => {
+    expect(resolveInternalRouteHref("/s?q=a%3Db", FALLBACK)).toBe(
+      "/s?q=a%3Db"
+    );
+  });
+
+  it("keeps %3F verbatim (not decoded to a live '?' delimiter)", () => {
+    expect(resolveInternalRouteHref("/s?q=a%3Fb", FALLBACK)).toBe(
+      "/s?q=a%3Fb"
+    );
+  });
+
+  it("preserves a mix of encoded and live delimiters side by side", () => {
+    expect(resolveInternalRouteHref("/s?a=1%26&b=2%3D", FALLBACK)).toBe(
+      "/s?a=1%26&b=2%3D"
+    );
+  });
+
+  it("does not lowercase/normalize encoded hex casing (%2f stays %2f)", () => {
+    expect(resolveInternalRouteHref("/s?q=a%2fb", FALLBACK)).toBe(
+      "/s?q=a%2fb"
+    );
+  });
+
+  it("trims surrounding whitespace but keeps interior encodings intact", () => {
+    expect(resolveInternalRouteHref("  /s?q=a%26b  ", FALLBACK)).toBe(
+      "/s?q=a%26b"
+    );
+  });
+
+  it("returns the fallback for a non-rooted encoded-symbol href", () => {
+    expect(resolveInternalRouteHref("s?q=a%26b", FALLBACK)).toBe(FALLBACK);
+  });
+
+  it("returns the fallback for a protocol-relative encoded-symbol href", () => {
+    expect(resolveInternalRouteHref("//evil.com?q=a%26b", FALLBACK)).toBe(
+      FALLBACK
+    );
+  });
+
+  it("returns the fallback for null/empty input (no value to resolve)", () => {
+    expect(resolveInternalRouteHref(null, FALLBACK)).toBe(FALLBACK);
+    expect(resolveInternalRouteHref("", FALLBACK)).toBe(FALLBACK);
+  });
+});


### PR DESCRIPTION
## Summary

Maps the extraction stability of `resolveInternalRouteHref`
(`hushh-webapp/lib/navigation/routes.ts`) when query values contain
percent-encoded symbol keys (`%26` `&`, `%3D` `=`, `%3F` `?`, `%2f` `/`).
Test-only; no production change.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/navigation/...`. There is
  no top-level `__tests__` in this repo; vitest only includes `__tests__/**`
  under `hushh-webapp`. The file lives at
  `hushh-webapp/__tests__/navigation/resolve-encoded-symbols.test.ts`.
- `resolveInternalRouteHref(value, fallback)` is a thin wrapper —
  `normalizeInternalRouteHref(value) ?? fallback`.
- **The premise that the module "differentiates encoded symbols from live
  structural delimiters" is FALSE.** It does not parse the query string, does not
  decode percent-encodings, and does not re-encode anything. An accepted href is
  returned **verbatim** (only surrounding whitespace trimmed). The fallback is
  returned **only** when normalize rejects the whole href (empty/whitespace-only,
  non-rooted, protocol-relative `//`, interior CR/LF). So `%26`/`%3D`/`%3F` are
  preserved exactly — never decoded into delimiters, never normalized in hex case.

## Behavior pinned

- `/s?q=a%26b` → verbatim (`%26` not decoded to `&`)
- `/s?q=a%3Db` → verbatim (`%3D` not decoded to `=`)
- `/s?q=a%3Fb` → verbatim (`%3F` not decoded to `?`)
- `/s?a=1%26&b=2%3D` → verbatim (encoded + live delimiters preserved together)
- `/s?q=a%2fb` → verbatim (lowercase hex `%2f` not normalized)
- `  /s?q=a%26b  ` → `/s?q=a%26b` (whole-href trim only; interior intact)
- `s?q=a%26b` (non-rooted) → fallback `/home`
- `//evil.com?q=a%26b` (protocol-relative) → fallback `/home`
- `null` / `""` → fallback `/home`

## Verification

- `npm test -- __tests__/navigation/resolve-encoded-symbols.test.ts` → 9/9 pass
- `git status` limited to the single new test file; zero production source drift

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the real verbatim-or-fallback contract (no decode/parse/
  delimiter differentiation) rather than an assumed encoding-aware query resolver
