### PR TITLE
test(utils): characterize formatCompleteJson undefined property filtering bounds

### DIFF
--- a/hushh-webapp/__tests__/utils/format-undefined-properties.test.ts
+++ b/hushh-webapp/__tests__/utils/format-undefined-properties.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCompleteJson } from "@/lib/utils/json-to-human";
+
+// Characterization tests for formatCompleteJson
+// (hushh-webapp/lib/utils/json-to-human.ts) focused on explicit `undefined`
+// object properties at both the top level and inside nested objects.
+//
+// TRUTH-FIRST: formatCompleteJson OMITS undefined (and null) properties — it
+// does NOT strip them to an empty line and does NOT convert them to the literal
+// string "undefined". The exact guards are:
+//   - top-level loop: `if (sectionValue === null || sectionValue === undefined)
+//     continue;`
+//   - nested-object loop: `if (value === null || value === undefined) continue;`
+//   - deeper-nested loop: `if (nestedValue === null || nestedValue === undefined)
+//     continue;`
+// So an undefined key contributes NOTHING to the output (no label, no bullet,
+// no placeholder). undefined is treated identically to null. The surviving keys
+// render exactly as if the undefined keys were never present. Note: because
+// `Record<string, unknown>` is typed, the test object is built with an explicit
+// `undefined` value cast to satisfy the signature; runtime behavior is what is
+// pinned here.
+
+describe("formatCompleteJson — undefined property handling", () => {
+  it("omits a top-level undefined key while keeping its siblings", () => {
+    expect(
+      formatCompleteJson({ alpha: 1, beta: undefined, gamma: "x" })
+    ).toBe("Alpha: 1\nGamma: x");
+  });
+
+  it("produces empty output when the only key is undefined", () => {
+    expect(formatCompleteJson({ beta: undefined })).toBe("");
+  });
+
+  it("never emits the literal string 'undefined'", () => {
+    expect(formatCompleteJson({ alpha: 1, beta: undefined })).not.toContain(
+      "undefined"
+    );
+  });
+
+  it("omits an undefined property inside a nested object", () => {
+    expect(
+      formatCompleteJson({ details: { a: 1, b: undefined, c: "y" } })
+    ).toBe("\n--- Details ---\n  A: 1\n  C: y");
+  });
+
+  it("omits an undefined property inside a deeper nested object", () => {
+    expect(
+      formatCompleteJson({ details: { nested: { p: undefined, q: 2 } } })
+    ).toBe("\n--- Details ---\n  Nested:\n    • Q: 2");
+  });
+
+  it("treats undefined identically to null (both fully omitted)", () => {
+    const withUndef = formatCompleteJson({ alpha: 1, beta: undefined });
+    const withNull = formatCompleteJson({ alpha: 1, beta: null });
+    expect(withUndef).toBe(withNull);
+    expect(withUndef).toBe("Alpha: 1");
+  });
+});


### PR DESCRIPTION
## Summary

Establishes the output rules of `formatCompleteJson`
(`hushh-webapp/lib/utils/json-to-human.ts`) when an object contains explicit
`undefined` properties at the top level and inside nested objects. Test-only; no
production change.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/utils/...`. There is no
  top-level `__tests__` in this repo; vitest only includes `__tests__/**` under
  `hushh-webapp`. The file lives at
  `hushh-webapp/__tests__/utils/format-undefined-properties.test.ts`.
- **The premise that the formatter "strips" or "converts" undefined keys is only
  half-right.** `formatCompleteJson` **omits** undefined (and null) properties
  entirely — it does **not** emit an empty placeholder line and does **not**
  serialize the literal string `"undefined"`. The exact guards are:
  - top-level: `if (sectionValue === null || sectionValue === undefined) continue;`
  - nested object: `if (value === null || value === undefined) continue;`
  - deeper nested: `if (nestedValue === null || nestedValue === undefined) continue;`
- `undefined` is treated **identically to `null`**: surviving keys render exactly
  as if the undefined key were never present.

## Behavior pinned

- `{ alpha: 1, beta: undefined, gamma: "x" }` → `"Alpha: 1\nGamma: x"`
- `{ beta: undefined }` → `""` (empty output, no label, no placeholder)
- output never contains the literal `"undefined"`
- `{ details: { a: 1, b: undefined, c: "y" } }` →
  `"\n--- Details ---\n  A: 1\n  C: y"`
- `{ details: { nested: { p: undefined, q: 2 } } }` →
  `"\n--- Details ---\n  Nested:\n    • Q: 2"`
- `{ alpha: 1, beta: undefined }` === `{ alpha: 1, beta: null }` → `"Alpha: 1"`

## Verification

- `npm test -- __tests__/utils/format-undefined-properties.test.ts` → 6/6 pass
- `git status` limited to the single new test file; zero production source drift

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the real "omit undefined === null, no placeholder, no
  'undefined' literal" behavior rather than an assumed strip/convert serializer
