### PR TITLE
test(navigation): characterize normalizeInternalRouteHref double base slashes

### DIFF
--- a/hushh-webapp/__tests__/navigation/normalize-double-base.test.ts
+++ b/hushh-webapp/__tests__/navigation/normalize-double-base.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for normalizeInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts) focused on accidental MID-PATH double
+// forward slashes (e.g. "/app//legal/privacy").
+//
+// TRUTH-FIRST: normalizeInternalRouteHref does NOT collapse, clean, or "clear"
+// interior double slashes. Its only slash-related guard rejects a LEADING "//"
+// (the protocol-relative form). The full contract is:
+//   const href = String(value ?? "").trim();
+//   if (!href) return null;                                  // empty
+//   if (!href.startsWith("/") || href.startsWith("//")) return null; // rooted + not //
+//   if (/[\r\n]/.test(href)) return null;                    // no CR/LF
+//   return href;                                             // else VERBATIM
+// So a mid-path "//" is preserved exactly. Only a href that BEGINS with "//"
+// (protocol-relative) is rejected. The premise that interior duplicate slashes
+// are filtered/cleared is FALSE — they pass through untouched.
+
+describe("normalizeInternalRouteHref — mid-path double slashes", () => {
+  it("preserves a mid-path double slash verbatim (no collapsing)", () => {
+    expect(normalizeInternalRouteHref("/app//legal/privacy")).toBe(
+      "/app//legal/privacy"
+    );
+  });
+
+  it("preserves multiple interior double slashes verbatim", () => {
+    expect(normalizeInternalRouteHref("/a//b//c")).toBe("/a//b//c");
+  });
+
+  it("preserves a triple interior slash verbatim", () => {
+    expect(normalizeInternalRouteHref("/app///legal")).toBe("/app///legal");
+  });
+
+  it("preserves a trailing double slash verbatim", () => {
+    expect(normalizeInternalRouteHref("/app/legal//")).toBe("/app/legal//");
+  });
+
+  it("trims surrounding whitespace but keeps interior double slash", () => {
+    expect(normalizeInternalRouteHref("  /app//legal  ")).toBe("/app//legal");
+  });
+
+  it("rejects a LEADING double slash (protocol-relative form)", () => {
+    expect(normalizeInternalRouteHref("//app/legal")).toBeNull();
+  });
+
+  it("rejects a leading double slash even with deeper path segments", () => {
+    expect(normalizeInternalRouteHref("//evil.com//legal")).toBeNull();
+  });
+
+  it("still requires a rooted href (non-rooted with // is rejected)", () => {
+    expect(normalizeInternalRouteHref("app//legal")).toBeNull();
+  });
+
+  it("accepts a single-slash rooted path unchanged (control case)", () => {
+    expect(normalizeInternalRouteHref("/app/legal/privacy")).toBe(
+      "/app/legal/privacy"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Pins how `normalizeInternalRouteHref`
(`hushh-webapp/lib/navigation/routes.ts`) treats accidental mid-path double
forward slashes (e.g. `/app//legal/privacy`). Test-only; no production change.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/navigation/...`. There is
  no top-level `__tests__` in this repo; vitest only includes `__tests__/**`
  under `hushh-webapp`. The file lives at
  `hushh-webapp/__tests__/navigation/normalize-double-base.test.ts`.
- **The premise that the engine "filters and clears double paths" is FALSE for
  interior slashes.** `normalizeInternalRouteHref` does NOT collapse, clean, or
  dedupe interior `//`. The full contract is:
  ```
  const href = String(value ?? "").trim();
  if (!href) return null;                                  // empty
  if (!href.startsWith("/") || href.startsWith("//")) return null; // rooted & not protocol-relative
  if (/[\r\n]/.test(href)) return null;                    // no CR/LF
  return href;                                             // else VERBATIM
  ```
- The only slash-related guard rejects a **leading** `//` (the protocol-relative
  form, an open-redirect vector). A `//` anywhere after the first character is
  preserved exactly.

## Behavior pinned

- `/app//legal/privacy` → `/app//legal/privacy` (mid-path `//` preserved)
- `/a//b//c` → verbatim (multiple interior `//` preserved)
- `/app///legal` → verbatim (triple interior slash preserved)
- `/app/legal//` → verbatim (trailing `//` preserved)
- `  /app//legal  ` → `/app//legal` (trim only; interior intact)
- `//app/legal` → `null` (leading `//` rejected — protocol-relative)
- `//evil.com//legal` → `null` (leading `//` rejected)
- `app//legal` → `null` (non-rooted rejected)
- `/app/legal/privacy` → verbatim (single-slash control case)

## Verification

- `npm test -- __tests__/navigation/normalize-double-base.test.ts` → 9/9 pass
- `git status` limited to the single new test file; zero production source drift

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the real "reject leading `//`, preserve interior `//`
  verbatim" contract rather than an assumed slash-collapsing normalizer
