### PR TITLE
test(browser-navigation): cover push navigation event detail

### DIFF
--- a/hushh-webapp/__tests__/lib/utils/browser-navigation.test.ts
+++ b/hushh-webapp/__tests__/lib/utils/browser-navigation.test.ts
@@ -86,4 +86,48 @@ describe("browser navigation utilities", () => {
     },
   ]);
   });
+
+  it("dispatches push navigation event detail", () => {
+  const received: Array<{
+    href: string;
+    replace?: boolean;
+    scroll?: boolean;
+  }> = [];
+
+  const listener = (event: Event) => {
+    received.push(
+      (event as CustomEvent<{
+        href: string;
+        replace?: boolean;
+        scroll?: boolean;
+      }>).detail,
+    );
+  };
+
+  window.addEventListener(
+    INTERNAL_APP_NAVIGATION_REQUEST_EVENT,
+    listener,
+  );
+
+  try {
+    expect(
+      requestInternalAppNavigation({
+        href: `${ROUTES.KAI_ANALYSIS}?focus=active`,
+        scroll: true,
+      }),
+    ).toBe(true);
+  } finally {
+    window.removeEventListener(
+      INTERNAL_APP_NAVIGATION_REQUEST_EVENT,
+      listener,
+    );
+  }
+
+  expect(received).toEqual([
+    {
+      href: `${ROUTES.KAI_ANALYSIS}?focus=active`,
+      scroll: true,
+    },
+  ]);
+  });
 });


### PR DESCRIPTION
## Summary
- Add browser navigation coverage for direct push navigation event detail.
- Assert `requestInternalAppNavigation` dispatches the normalized href and scroll flag for push-style navigation.

## Why
This locks the internal navigation event payload contract used by app-level browser navigation helpers.

## PR Base Policy
- Base branch: `integration/pr-train`
- Branch was created directly from the fetched `integration/pr-train` head before this commit.

## No Overlap Proof
- Files changed: `hushh-webapp/__tests__/lib/utils/browser-navigation.test.ts` only.
- This PR appends one focused browser-navigation test for push navigation event detail.
- No production files are changed.

## Validation
- `npm.cmd test -- __tests__/lib/utils/browser-navigation.test.ts`

## DCO
- Commit includes `Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>`.