### PR TITLE
test(accessibility-status-announcer): assert polite live region contract

### DIFF
--- a/hushh-webapp/__tests__/components/accessibility-status-announcer.test.tsx
+++ b/hushh-webapp/__tests__/components/accessibility-status-announcer.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { AccessibilityStatusAnnouncer } from "@/components/system/accessibility-status-announcer";
+
+describe("AccessibilityStatusAnnouncer", () => {
+  it("renders a polite live region by default", () => {
+    render(<AccessibilityStatusAnnouncer message="Filters updated" />);
+
+    const status = screen.getByRole("status");
+
+    expect(status.getAttribute("aria-live")).toBe("polite");
+    expect(status.getAttribute("aria-atomic")).toBe("true");
+    expect(status.className).toContain("sr-only");
+    expect(status.textContent).toBe("Filters updated");
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for AccessibilityStatusAnnouncer's default polite live region.
- Assert the rendered status region exposes polite live semantics, atomic updates, and the announcement text.

## Why
This locks the accessibility status announcer contract used for non-disruptive updates.

## PR Base Policy
- Base branch: integration/pr-train.
- Branch was created directly from the fetched integration/pr-train head before this commit.

## No Overlap Proof
- Files changed: hushh-webapp/__tests__/components/accessibility-status-announcer.test.tsx only.
- This PR adds one focused AccessibilityStatusAnnouncer component test for the polite live region contract.
- No production files are changed.

## Validation
- npm.cmd test -- __tests__/components/accessibility-status-announcer.test.tsx

## DCO
- Commit includes Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>.