### PR TITLE
test(async-action-status): assert retrying status copy

### DIFF
--- a/hushh-webapp/__tests__/components/async-action-status.test.tsx
+++ b/hushh-webapp/__tests__/components/async-action-status.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { AsyncActionStatus } from "@/components/system/async-action-status";
+
+describe("AsyncActionStatus", () => {
+  it("renders retrying status copy", () => {
+    render(<AsyncActionStatus state="retrying" />);
+
+    const status = screen.getByRole("status");
+
+    expect(status.getAttribute("aria-live")).toBe("polite");
+    expect(status.textContent).toBe("Retrying\u2026");
+    expect(status.querySelector("svg")?.getAttribute("aria-hidden")).toBe(
+      "true",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for AsyncActionStatus retrying state copy.
- Assert the retrying state renders as a polite status region with decorative icon hidden from assistive technology.

## Why
This locks the user-facing retrying status copy used by async action surfaces.

## PR Base Policy
- Base branch: integration/pr-train.
- Branch was created directly from the fetched integration/pr-train head before this commit.

## No Overlap Proof
- Files changed: hushh-webapp/__tests__/components/async-action-status.test.tsx only.
- This PR adds one focused AsyncActionStatus component test for the retrying status copy.
- No production files are changed.

## Validation
- npm.cmd test -- __tests__/components/async-action-status.test.tsx

## DCO
- Commit includes Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>.