### PR TITLE
test(network-status-banner): assert offline status role

### DIFF
--- a/hushh-webapp/__tests__/components/network-status-banner.test.tsx
+++ b/hushh-webapp/__tests__/components/network-status-banner.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { NetworkStatusBanner } from "@/components/system/network-status-banner";
+import { useNetworkStatus } from "@/hooks/use-network-status";
+
+vi.mock("@/hooks/use-network-status", () => ({
+  useNetworkStatus: vi.fn(),
+}));
+
+describe("NetworkStatusBanner", () => {
+  it("renders offline status with status role", () => {
+    vi.mocked(useNetworkStatus).mockReturnValue({
+      online: false,
+      offline: true,
+    });
+
+    render(<NetworkStatusBanner />);
+
+    const status = screen.getByRole("status");
+
+    expect(status.getAttribute("aria-live")).toBe("polite");
+    expect(status.textContent).toContain("You are offline.");
+    expect(status.querySelector("svg")?.getAttribute("aria-hidden")).toBe(
+      "true",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for NetworkStatusBanner's offline status role.
- Assert the offline banner renders as a polite status region with the offline copy and decorative icon hidden from assistive technology.

## Why
This locks the accessibility contract for offline connection status announcements.

## PR Base Policy
- Base branch: integration/pr-train.
- Branch was created directly from the fetched integration/pr-train head before this commit.

## No Overlap Proof
- Files changed: hushh-webapp/__tests__/components/network-status-banner.test.tsx only.
- This PR adds one focused NetworkStatusBanner component test for the offline status role contract.
- No production files are changed.

## Validation
- npm.cmd test -- __tests__/components/network-status-banner.test.tsx

## DCO
- Commit includes Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>.