### PR TITLE
test(route-suspense-fallback): assert loading status semantics

### DIFF
--- a/hushh-webapp/__tests__/components/route-suspense-fallback.test.tsx
+++ b/hushh-webapp/__tests__/components/route-suspense-fallback.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { RouteSuspenseFallback } from "@/components/system/route-suspense-fallback";
+
+describe("RouteSuspenseFallback", () => {
+  it("renders loading status semantics", () => {
+    render(<RouteSuspenseFallback label="Loading dashboard" />);
+
+    const [fallbackStatus, loaderStatus] = screen.getAllByRole("status");
+
+    expect(fallbackStatus.getAttribute("aria-live")).toBe("polite");
+    expect(loaderStatus.getAttribute("aria-live")).toBe("polite");
+    expect(loaderStatus.getAttribute("aria-busy")).toBe("true");
+    expect(loaderStatus.getAttribute("aria-atomic")).toBe("true");
+    expect(loaderStatus.textContent).toContain("Loading dashboard");
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for RouteSuspenseFallback loading status semantics.
- Assert the fallback and nested loader expose polite status behavior, with the loader marked busy and atomic.

## Why
This locks the accessible loading contract used while route content is suspended.

## PR Base Policy
- Base branch: integration/pr-train.
- Branch was created directly from the fetched integration/pr-train head before this commit.

## No Overlap Proof
- Files changed: hushh-webapp/__tests__/components/route-suspense-fallback.test.tsx only.
- This PR adds one focused RouteSuspenseFallback component test for loading status semantics.
- No production files are changed.

## Validation
- npm.cmd test -- __tests__/components/route-suspense-fallback.test.tsx

## DCO
- Commit includes Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>.