### PR TITLE
test(navigation): characterize normalizeInternalRouteHref percent-encoded spaces in query

### DIFF
--- a/hushh-webapp/__tests__/navigation/normalize-query-spaces.test.ts
+++ b/hushh-webapp/__tests__/navigation/normalize-query-spaces.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for normalizeInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts) focused on percent-encoded spaces
+// (`%20`) appearing inside the SEARCH QUERY portion of a rooted href.
+//
+// TRUTH-FIRST: normalizeInternalRouteHref does NOT parse or decode the query
+// string. Its full contract is:
+//   const href = String(value ?? "").trim();
+//   if (!href) return null;                                   // empty
+//   if (!href.startsWith("/") || href.startsWith("//")) return null; // rooted, not protocol-relative
+//   if (/[\r\n]/.test(href)) return null;                     // no CR/LF
+//   return href;                                              // else VERBATIM
+// So a `%20` in the query is RETAINED literally — it is never decoded to a
+// space, never re-encoded, and never collapsed. The only mutation that can apply
+// is an OUTER trim of the whole string. Outer-rejection rules (leading `//`,
+// CR/LF) still apply to the whole href even when the offending part is "in" the
+// query.
+
+describe("normalizeInternalRouteHref — percent-encoded spaces in query", () => {
+  it("retains a literal %20 in the query string verbatim", () => {
+    expect(normalizeInternalRouteHref("/search?q=open%20source")).toBe(
+      "/search?q=open%20source"
+    );
+  });
+
+  it("does NOT decode %20 into a real space", () => {
+    const out = normalizeInternalRouteHref("/search?q=open%20source");
+    expect(out).toContain("%20");
+    expect(out).not.toContain("open source");
+  });
+
+  it("retains multiple %20 sequences in one query value", () => {
+    expect(
+      normalizeInternalRouteHref("/search?q=a%20b%20c&sort=desc")
+    ).toBe("/search?q=a%20b%20c&sort=desc");
+  });
+
+  it("leaves a RAW space in the query untouched (no encoding added)", () => {
+    // The guard does not encode; a literal space stays a literal space.
+    expect(normalizeInternalRouteHref("/search?q=open source")).toBe(
+      "/search?q=open source"
+    );
+  });
+
+  it("trims only the OUTER whitespace, preserving inner %20", () => {
+    expect(normalizeInternalRouteHref("  /search?q=open%20source  ")).toBe(
+      "/search?q=open%20source"
+    );
+  });
+
+  it("still rejects a protocol-relative href even with %20 in the query", () => {
+    expect(normalizeInternalRouteHref("//evil.com/?q=open%20source")).toBeNull();
+  });
+
+  it("rejects an INTERIOR CR/LF even when %20 is present in the query", () => {
+    // The CR/LF guard catches newlines that survive the outer trim.
+    expect(
+      normalizeInternalRouteHref("/search?q=open%20\nsource")
+    ).toBeNull();
+  });
+
+  it("TRIMS a trailing newline (runs before the CR/LF guard) and returns verbatim", () => {
+    // TRUTH-FIRST: `.trim()` executes BEFORE the /[\r\n]/ check, so a trailing
+    // \n is stripped first and the href is accepted — it is NOT rejected.
+    expect(
+      normalizeInternalRouteHref("/search?q=open%20source\n")
+    ).toBe("/search?q=open%20source");
+  });
+});
+
+


### PR DESCRIPTION
## Summary

Extends characterization coverage for `normalizeInternalRouteHref`
(`hushh-webapp/lib/navigation/routes.ts`) to map how it treats percent-encoded
spaces (`%20`) inside the SEARCH QUERY portion of a rooted href
(e.g. `/search?q=open%20source`). Test-only; no production change.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/navigation/...`. There is
  no top-level `__tests__` in this repo; vitest only includes `__tests__/**` under
  `hushh-webapp`. The file lives at
  `hushh-webapp/__tests__/navigation/normalize-query-spaces.test.ts`.
- **`normalizeInternalRouteHref` does NOT parse, decode, or re-encode the query
  string.** Full contract:
  ```
  const href = String(value ?? "").trim();
  if (!href) return null;                                   // empty
  if (!href.startsWith("/") || href.startsWith("//")) return null; // rooted, not protocol-relative
  if (/[\r\n]/.test(href)) return null;                     // no CR/LF
  return href;                                              // else VERBATIM
  ```
- So `%20` in the query is **retained literally** — never decoded to a space,
  never re-encoded, never collapsed. The only mutation is an OUTER `.trim()`.

## Truth-first correction discovered while writing the test

An initial assertion assumed a trailing `\n` would be rejected by the CR/LF
guard. The local run proved that **FALSE**: `.trim()` executes *before* the
`/[\r\n]/` check, so a trailing newline is stripped first and the href is
**accepted**, not rejected. The CR/LF guard only rejects **interior** newlines
that survive the trim. The test was corrected to pin this real ordering.

## Behavior pinned

- `/search?q=open%20source` → verbatim (`%20` retained, not decoded)
- `%20` never becomes a literal space (no decode)
- `/search?q=a%20b%20c&sort=desc` → verbatim (multiple `%20` retained)
- `/search?q=open source` (raw space) → verbatim (no encoding added)
- `  /search?q=open%20source  ` → outer-trimmed, inner `%20` preserved
- `//evil.com/?q=open%20source` → `null` (protocol-relative rejected)
- `/search?q=open%20\nsource` (interior `\n`) → `null` (CR/LF guard)
- `/search?q=open%20source\n` (trailing `\n`) → trimmed → verbatim (NOT null)

## Verification

- `npm test -- __tests__/navigation/normalize-query-spaces.test.ts` → 8/8 pass
- `git status` limited to the single new test file; zero production source drift

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the real "query is opaque, `%20` retained verbatim,
  trim-before-CRLF-guard" contract rather than an assumed query normalizer
