### PR TITLE
test(navigation): characterize resolveInternalRouteHref parameter key case matching

### DIFF
--- a/hushh-webapp/__tests__/navigation/resolve-key-casing.test.ts
+++ b/hushh-webapp/__tests__/navigation/resolve-key-casing.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for resolveInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts) focused on query parameters that share
+// a name but differ ONLY by letter casing (e.g. `userId` vs `userid`).
+//
+// TRUTH-FIRST — IMPORTANT CORRECTION: the premise that resolveInternalRouteHref
+// "parses search parameters" or applies "case-sensitivity invariants" / an
+// "override mapping" between duplicate-by-case keys is FALSE. It does NOT parse
+// the query string at all. Its entire body is:
+//
+//   export function resolveInternalRouteHref(value, fallback): string {
+//     return normalizeInternalRouteHref(value) ?? fallback;
+//   }
+//
+// normalizeInternalRouteHref only: trims, rejects empty/non-rooted/protocol-
+// relative/interior-CRLF hrefs, and otherwise returns the href VERBATIM. The
+// query string is OPAQUE — every key is preserved as written, in original order,
+// with no dedupe, no case-folding, and no last-wins/first-wins override. There is
+// no map keyed by parameter name, so "case collision" never occurs.
+//
+// These tests pin that real contract: differently-cased duplicate keys are
+// carried through untouched, and `fallback` is only used when the whole href is
+// rejected by normalize — never as a per-parameter resolution.
+
+const FALLBACK = "/";
+
+describe("resolveInternalRouteHref — query key casing", () => {
+  it("preserves BOTH differently-cased duplicate keys verbatim (no dedupe/override)", () => {
+    expect(
+      resolveInternalRouteHref("/profile?userId=123&userid=456", FALLBACK)
+    ).toBe("/profile?userId=123&userid=456");
+  });
+
+  it("retains original key order for mixed-case duplicates", () => {
+    expect(
+      resolveInternalRouteHref("/profile?userid=456&userId=123", FALLBACK)
+    ).toBe("/profile?userid=456&userId=123");
+  });
+
+  it("does NOT case-fold keys (UserID stays UserID)", () => {
+    const out = resolveInternalRouteHref(
+      "/profile?UserID=1&USERID=2&userid=3",
+      FALLBACK
+    );
+    expect(out).toBe("/profile?UserID=1&USERID=2&userid=3");
+    expect(out).toContain("UserID=1");
+    expect(out).toContain("USERID=2");
+    expect(out).toContain("userid=3");
+  });
+
+  it("treats exact same-case duplicate keys as opaque too (both kept)", () => {
+    expect(
+      resolveInternalRouteHref("/profile?userId=123&userId=456", FALLBACK)
+    ).toBe("/profile?userId=123&userId=456");
+  });
+
+  it("returns fallback only when the whole href is invalid, not per-key", () => {
+    // Protocol-relative href is rejected by normalize → fallback used.
+    expect(
+      resolveInternalRouteHref("//evil.com/profile?userId=1&userid=2", FALLBACK)
+    ).toBe(FALLBACK);
+  });
+
+  it("returns fallback for an empty value (no query to resolve)", () => {
+    expect(resolveInternalRouteHref("", FALLBACK)).toBe(FALLBACK);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an isolated characterization test for `resolveInternalRouteHref`
(`hushh-webapp/lib/navigation/routes.ts`) documenting how it treats query
parameters that share a name but differ only by letter casing
(e.g. `/profile?userId=123&userid=456`). Test-only; no production change.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/navigation/...`. There is
  no top-level `__tests__` in this repo; vitest only includes `__tests__/**` under
  `hushh-webapp`. The file lives at
  `hushh-webapp/__tests__/navigation/resolve-key-casing.test.ts`.
- **The premise that `resolveInternalRouteHref` "parses search parameters" or
  enforces "case-sensitivity invariants" / an "override mapping" between
  duplicate-by-case keys is FALSE.** It does NOT parse the query string at all.
  Its entire body is:
  ```
  export function resolveInternalRouteHref(value, fallback): string {
    return normalizeInternalRouteHref(value) ?? fallback;
  }
  ```
  `normalizeInternalRouteHref` only trims, rejects empty/non-rooted/protocol-
  relative/interior-CRLF hrefs, and otherwise returns the href **verbatim**.
- The query string is therefore **opaque**: every key is preserved as written, in
  original order, with **no dedupe, no case-folding, and no first/last-wins
  override**. There is no parameter-keyed map, so a "case collision" never occurs.
  `fallback` is used only when the whole href is rejected — never per-parameter.

## Behavior pinned

- `/profile?userId=123&userid=456` → verbatim (both casings kept, no override)
- `/profile?userid=456&userId=123` → verbatim (original order retained)
- `/profile?UserID=1&USERID=2&userid=3` → verbatim (no case-folding)
- `/profile?userId=123&userId=456` → verbatim (exact duplicates also opaque)
- `//evil.com/profile?userId=1&userid=2` → `fallback` (whole href rejected)
- `""` → `fallback`

## Verification

- `npm test -- __tests__/navigation/resolve-key-casing.test.ts` → 6/6 pass
- `git status` limited to the single new test file; zero production source drift
- (An IDE-only `@/` module-resolution warning is a false positive — the same
  alias resolves under vitest, as the passing run confirms.)

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the real "query is opaque, no key parsing / casing
  override" contract rather than an assumed case-aware parameter resolver
