### PR TITLE
test(format-json): characterize transaction truncation at 5 items

### DIFF
--- a/hushh-webapp/__tests__/utils/format-complete-json-bounds.test.ts
+++ b/hushh-webapp/__tests__/utils/format-complete-json-bounds.test.ts
@@ -123,4 +123,26 @@ describe("formatCompleteJson — array bounds with null and mixed primitives", (
     expect(out).toContain("--- Legal Disclosures (2 items) ---");
     expect(out).toContain("2 disclosure(s) extracted");
   });
+    
+  it("truncates the activity_and_transactions array to the first 5 items and reports the remainder", () => {
+    // Mirrors the already-tested holdings (10-item) and generic-array (3-item)
+    // truncation boundaries. The activity_and_transactions branch truncates
+    // at 5 and emits "... and N more transactions" — previously uncharacterized.
+    const transactions = Array.from({ length: 7 }, (_, i) => ({
+      date: `2024-01-0${i + 1}`,
+      transaction_type: "Buy",
+      amount: 100 + i,
+    }));
+
+    const out = formatCompleteJson({
+      activity_and_transactions: transactions,
+    });
+
+    expect(out).toContain("--- Transactions (7 items) ---");
+    expect(out).toContain("2024-01-01 - Buy");
+    expect(out).toContain("2024-01-05 - Buy");
+    expect(out).not.toContain("2024-01-06 - Buy");
+    expect(out).not.toContain("2024-01-07 - Buy");
+    expect(out).toContain("... and 2 more transactions");
+  });
 });


### PR DESCRIPTION
## Summary

Adds one characterization test for the `activity_and_transactions` truncation boundary in `formatCompleteJson`.

## Motivation

`formatCompleteJson` truncates the `activity_and_transactions` array after the first five entries and appends a summary line indicating the number of remaining transactions. While similar truncation behavior is already characterized for other array branches, this specific branch was not previously covered.

This test documents and protects the current behavior by verifying that:

* only the first five transactions are rendered,
* later transactions are omitted,
* the summary line reports the remaining transaction count.

## Changes

* Appends one `it()` block to `__tests__/utils/format-complete-json-bounds.test.ts`
* No production code changes
* No new files
* No import changes
* Existing tests remain unchanged

## Verification

```bash
npx vitest run __tests__/utils/format-complete-json-bounds.test.ts
```

All existing tests pass together with the newly added characterization test.
