### PR TITLE
test(format-json): characterize cleanMarkdown triple-asterisk stripping

### DIFF
--- a/hushh-webapp/__tests__/utils/format-json-primitives.test.ts
+++ b/hushh-webapp/__tests__/utils/format-json-primitives.test.ts
@@ -83,4 +83,17 @@ describe("formatCompleteJson — boolean and symbol primitives", () => {
     expect(out).not.toContain("N/A");
     expect(out).toContain("Beginning Value: $1,000.00");
   });
+  it("strips triple-asterisk (bold+italic) markdown from a string primitive value", () => {
+    // cleanMarkdown strips "***" before "**" and "*" (regex order in source).
+    // The existing test above only exercises "**" and backtick stripping;
+    // the triple-asterisk path was previously uncharacterized.
+    const out = formatCompleteJson({
+      note: "***emphasis***",
+    });
+
+    expect(out).toContain("Note: emphasis");
+    expect(out).not.toContain("***");
+    expect(out).not.toContain("*");
+  });
+
 });


### PR DESCRIPTION
## Summary

Adds one characterization test documenting `cleanMarkdown` handling of triple-asterisk (`***`) markdown in `formatCompleteJson`.

## Motivation

`cleanMarkdown` strips triple-asterisk markdown before processing double-asterisk and single-asterisk formatting. Existing tests cover standard bold and inline code formatting, but the dedicated triple-asterisk path was not previously characterized.

This test documents the current behavior by verifying that:

* `***emphasis***` is rendered as plain text,
* triple-asterisk markers are removed,
* no residual asterisk characters remain in the formatted output.

## Changes

* Appends one `it()` block to `__tests__/utils/format-json-primitives.test.ts`
* No production code changes
* No new files
* No import changes
* Existing tests remain unchanged

## Verification

```bash
npx vitest run __tests__/utils/format-json-primitives.test.ts
```

All existing tests pass together with the newly added characterization test.
