### PR TITLE
test(pagination): assert PaginationLink aria-current contract

### DIFF
--- a/hushh-webapp/__tests__/ui/pagination.test.tsx
+++ b/hushh-webapp/__tests__/ui/pagination.test.tsx
@@ -95,4 +95,28 @@ describe("Pagination", () => {
       container.querySelector('[data-slot="pagination-ellipsis"]'),
     ).toBeTruthy();
   });
+
+  it("sets aria-current='page' on an active link and omits it otherwise", () => {
+    const { container } = render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="#" isActive>
+              1
+            </PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="#">2</PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+
+    const links = container.querySelectorAll(
+      '[data-slot="pagination-link"]',
+    );
+
+    expect(links[0]?.getAttribute("aria-current")).toBe("page");
+    expect(links[1]?.getAttribute("aria-current")).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

Adds one contract test verifying the `aria-current` behavior of `PaginationLink`.

## Motivation

`PaginationLink` sets `aria-current="page"` when `isActive` is true and omits the attribute otherwise. While the existing test suite verifies the visual active state, the accessibility contract for `aria-current` was not previously covered.

This test documents the current behavior by verifying that:

* the active pagination link exposes `aria-current="page"`,
* inactive pagination links omit the `aria-current` attribute.

## Changes

* Appends one `it()` block to `__tests__/ui/pagination.test.tsx`
* No production code changes
* No new files
* No import changes
* Existing tests remain unchanged

## Verification

```bash
npx vitest run __tests__/ui/pagination.test.tsx
```

All existing tests pass together with the newly added contract test.
