### PR TITLE
test(pagination): assert PaginationEllipsis screen-reader text contract

### DIFF
--- a/hushh-webapp/__tests__/ui/pagination.test.tsx
+++ b/hushh-webapp/__tests__/ui/pagination.test.tsx
@@ -119,4 +119,22 @@ describe("Pagination", () => {
     expect(links[0]?.getAttribute("aria-current")).toBe("page");
     expect(links[1]?.getAttribute("aria-current")).toBeNull();
   });
+
+  it("renders sr-only 'More pages' text inside the ellipsis for screen readers", () => {
+    const { container } = render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationEllipsis />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+
+    const srOnly = container.querySelector(
+      '[data-slot="pagination-ellipsis"] .sr-only',
+    );
+
+    expect(srOnly?.textContent).toBe("More pages");
+  });
 });


### PR DESCRIPTION
## Summary

Adds one accessibility contract test verifying the screen-reader text rendered by `PaginationEllipsis`.

## Motivation

`PaginationEllipsis` renders a visually hidden `<span className="sr-only">More pages</span>` alongside the decorative icon. This ensures assistive technologies announce the purpose of the ellipsis while the icon remains decorative. The existing test suite verified the rendered slot but did not verify this accessibility contract.

This test documents the current behavior by verifying that:

* the visually hidden element exists,
* its text content is exactly `"More pages"`.

## Changes

* Appends one `it()` block to `__tests__/ui/pagination.test.tsx`
* No production code changes
* No new files
* No import changes
* Existing tests remain unchanged

## Verification

```bash
npx vitest run __tests__/ui/pagination.test.tsx
```

All existing tests pass together with the newly added accessibility contract test.
