### PR TITLE
test(scroll-area): assert ScrollArea root data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/ui/scroll-area.test.tsx
+++ b/hushh-webapp/__tests__/ui/scroll-area.test.tsx
@@ -19,4 +19,17 @@ describe("ScrollArea", () => {
     viewport?.focus();
     expect(document.activeElement).not.toBe(viewport);
   });
+
+  it("renders root with data-slot='scroll-area'", () => {
+    const { container } = render(
+      <ScrollArea className="h-20 w-40">
+        <div className="h-40">Scrollable content</div>
+      </ScrollArea>,
+    );
+
+    const root = container.querySelector('[data-slot="scroll-area"]');
+
+    expect(root).toBeTruthy();
+    expect(root?.getAttribute("data-slot")).toBe("scroll-area");
+  });
 });


### PR DESCRIPTION
## Summary

Adds one contract test verifying that the `ScrollArea` root element renders with `data-slot="scroll-area"`.

## Motivation

`ScrollArea` sets `data-slot="scroll-area"` on `ScrollAreaPrimitive.Root`. This attribute is used as a stable styling and theming hook throughout the component library, but it was not previously covered by the test suite.

The existing tests verify viewport behavior but do not assert the root element's DOM contract.

## Changes

* Appends one `it()` block to `__tests__/ui/scroll-area.test.tsx`
* No production code changes
* No import changes
* No new files
* Existing tests remain unchanged

## Verification

```bash
npx vitest run __tests__/ui/scroll-area.test.tsx
```

All existing tests pass together with the newly added contract test.
