### PR TITLE
test(page-sections): assert page header data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/components/page-sections.test.tsx
+++ b/hushh-webapp/__tests__/components/page-sections.test.tsx
@@ -5,6 +5,15 @@ import { describe, expect, it } from "vitest";
 import { PageHeader, SectionHeader } from "@/components/app-ui/page-sections";
 
 describe("PageHeader", () => {
+  it("renders the page header data-slot contract", () => {
+    const { container } = render(<PageHeader title="Dashboard" />);
+
+    const header = container.querySelector('[data-slot="page-header"]');
+
+    expect(header).toBeTruthy();
+    expect(header?.getAttribute("data-page-primary")).toBe("true");
+  });
+
   it("uses the shared mobile stacking and description clamp slots", () => {
     const { container } = render(
       <PageHeader


### PR DESCRIPTION
## Summary
- Add focused coverage for the PageHeader root data-slot contract.
- Assert PageHeader keeps data-slot=page-header and the primary page marker.

## Why
This locks the page header selector contract used by shell and navigation surfaces.

## PR Base Policy
- Base branch: integration/pr-train.
- Branch was created directly from the fetched integration/pr-train head before this commit.

## No Overlap Proof
- Files changed: hushh-webapp/__tests__/components/page-sections.test.tsx only.
- This PR appends one PageHeader test inside the existing PageHeader describe block.
- No production files are changed.

## Validation
- npm.cmd test -- __tests__/components/page-sections.test.tsx

## DCO
- Commit includes Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>.