### PR TITLE
test(settings-ui): assert settings row button type

### DIFF
--- a/hushh-webapp/__tests__/components/settings-ui.test.tsx
+++ b/hushh-webapp/__tests__/components/settings-ui.test.tsx
@@ -8,6 +8,20 @@ import {
 } from "@/components/profile/settings-ui";
 
 describe("SettingsRow", () => {
+  it("sets clickable row button type", () => {
+    render(
+      <SettingsRow
+        title="Open settings"
+        description="Manage account preferences"
+        onClick={() => {}}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: /open settings/i }).getAttribute("type")
+    ).toBe("button");
+  });
+
   it("wraps both primary action and trailing in a single interactive row", () => {
     const handleOpen = vi.fn();
     const handleTrailing = vi.fn();


### PR DESCRIPTION
## Summary
- Add focused coverage for SettingsRow clickable row button type.
- Assert a SettingsRow with onClick renders a button with type=button.

## Why
This locks the settings row action contract so rows do not default to submit behavior when rendered near forms.

## PR Base Policy
- Base branch: integration/pr-train.
- Branch was created directly from the fetched integration/pr-train head before this commit.

## No Overlap Proof
- Files changed: hushh-webapp/__tests__/components/settings-ui.test.tsx only.
- This PR appends one SettingsRow test inside the existing SettingsRow describe block.
- No production files are changed.

## Validation
- npm.cmd test -- __tests__/components/settings-ui.test.tsx

## DCO
- Commit includes Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>.