### PR TITLE
test(pkm-section-preview): assert empty preview fallback

### DIFF
--- a/hushh-webapp/__tests__/services/pkm-section-preview.test.ts
+++ b/hushh-webapp/__tests__/services/pkm-section-preview.test.ts
@@ -3,6 +3,25 @@ import { describe, expect, it } from "vitest";
 import { buildPkmSectionPreviewPresentation } from "@/lib/profile/pkm-section-preview";
 
 describe("buildPkmSectionPreviewPresentation", () => {
+  it("returns an empty preview fallback when section values are missing", () => {
+    const presentation = buildPkmSectionPreviewPresentation({
+      domain: "financial",
+      domainTitle: "Financial",
+      permissionLabel: "Portfolio",
+      permissionDescription: "Saved holdings and balances.",
+      topLevelScopePath: "portfolio",
+      value: null,
+    });
+
+    expect(presentation.title).toBe("Portfolio");
+    expect(presentation.description).toBe("Saved holdings and balances.");
+    expect(presentation.summary).toBe(
+      "No saved values are available for this section yet."
+    );
+    expect(presentation.stats).toEqual([]);
+    expect(presentation.groups).toEqual([]);
+  });
+
   it("unwraps single-key section payloads and converts entity maps into readable entries", () => {
     const presentation = buildPkmSectionPreviewPresentation({
       domain: "location",


### PR DESCRIPTION
## Summary
- Add focused coverage for the PKM section preview empty fallback.
- Assert missing section values preserve title and description while returning the empty summary with no stats or groups.

## Why
This locks the presentation fallback used when a PKM section has no saved values yet.

## PR Base Policy
- Base branch: integration/pr-train.
- Branch was created directly from the fetched integration/pr-train head before this commit.

## No Overlap Proof
- Files changed: hushh-webapp/__tests__/services/pkm-section-preview.test.ts only.
- This PR appends one buildPkmSectionPreviewPresentation test for the empty preview fallback.
- No production files are changed.

## Validation
- npm.cmd test -- __tests__/services/pkm-section-preview.test.ts

## DCO
- Commit includes Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>.