### PR TITLE
test(pkm-settings-shell): assert shell heading semantics

### DIFF
--- a/hushh-webapp/__tests__/components/pkm-settings-shell.test.tsx
+++ b/hushh-webapp/__tests__/components/pkm-settings-shell.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PkmSettingsShell } from "@/components/profile/pkm-settings-shell";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/profile/pkm",
+}));
+
+vi.mock("@/lib/morphy-ux/hooks/use-page-enter", () => ({
+  usePageEnterAnimation: vi.fn(),
+}));
+
+vi.mock("@/lib/morphy-ux/gsap", () => ({
+  getGsap: vi.fn(),
+  prefersReducedMotion: () => true,
+}));
+
+vi.mock("@/lib/morphy-ux/gsap-init", () => ({
+  ensureMorphyGsapReady: vi.fn(),
+  getMorphyEaseName: () => "power2.out",
+}));
+
+describe("PkmSettingsShell", () => {
+  it("renders shell heading semantics", () => {
+    render(
+      <PkmSettingsShell
+        title="Memory controls"
+        description="Manage what Kai can remember."
+      >
+        <div>Settings content</div>
+      </PkmSettingsShell>
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Memory controls", level: 1 })
+    ).toBeTruthy();
+    expect(screen.getByText("Profile / Privacy")).toBeTruthy();
+    expect(screen.getByText("Manage what Kai can remember.")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for PkmSettingsShell heading semantics.
- Assert the shell renders its provided title as a level-one heading and preserves eyebrow and description copy.

## Why
This locks the PKM settings shell header contract used by profile privacy settings surfaces.

## PR Base Policy
- Base branch: integration/pr-train.
- Branch was created directly from the fetched integration/pr-train head before this commit.

## No Overlap Proof
- Files changed: hushh-webapp/__tests__/components/pkm-settings-shell.test.tsx only.
- This PR adds one focused PkmSettingsShell component test for heading semantics.
- No production files are changed.

## Validation
- npm.cmd test -- __tests__/components/pkm-settings-shell.test.tsx

## DCO
- Commit includes Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>.