### PR TITLE
test(pkm-tree-view): assert tree item button type

### DIFF
--- a/hushh-webapp/__tests__/components/pkm-tree-view.test.tsx
+++ b/hushh-webapp/__tests__/components/pkm-tree-view.test.tsx
@@ -1,0 +1,21 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PkmJsonTree } from "@/components/profile/pkm-tree-view";
+
+describe("PkmJsonTree", () => {
+  it("renders expandable tree item trigger with button type", () => {
+    const { container } = render(
+      <PkmJsonTree
+        rootLabel="Profile memory"
+        value={{ identity: { name: "Avery" } }}
+      />
+    );
+
+    const trigger = container.querySelector('[data-slot="collapsible-trigger"]');
+
+    expect(trigger).toBeTruthy();
+    expect(trigger?.tagName).toBe("BUTTON");
+    expect(trigger?.getAttribute("type")).toBe("button");
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for PKM tree view expandable item triggers.
- Assert an expandable JSON tree item renders a button trigger with type=button.

## Why
This locks the tree item action contract so expandable PKM rows do not default to submit behavior near forms.

## PR Base Policy
- Base branch: integration/pr-train.
- Branch was created directly from the fetched integration/pr-train head before this commit.

## No Overlap Proof
- Files changed: hushh-webapp/__tests__/components/pkm-tree-view.test.tsx only.
- This PR adds one focused PkmJsonTree component test for tree item button type.
- No production files are changed.

## Validation
- npm.cmd test -- __tests__/components/pkm-tree-view.test.tsx

## DCO
- Commit includes Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>.