### PR TITLE
test(pkm-upgrade-status-card): assert retry update button type

### DIFF
--- a/hushh-webapp/__tests__/components/pkm-upgrade-status-card.test.tsx
+++ b/hushh-webapp/__tests__/components/pkm-upgrade-status-card.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PkmUpgradeStatusCard } from "@/components/profile/pkm-upgrade-status-card";
+import type { PkmUpgradeStatus } from "@/lib/services/pkm-upgrade-service";
+
+const failedStatus: PkmUpgradeStatus = {
+  userId: "user-1",
+  modelVersion: 1,
+  storedModelVersion: 1,
+  effectiveModelVersion: 1,
+  targetModelVersion: 2,
+  currentPkmContractVersion: "1",
+  targetPkmContractVersion: "2",
+  currentReadableProjectionVersion: "1",
+  targetReadableProjectionVersion: "2",
+  upgradeStatus: "failed",
+  upgradableDomains: [],
+  lastUpgradedAt: null,
+  run: {
+    runId: "run-1",
+    userId: "user-1",
+    status: "failed",
+    mode: "real",
+    fromModelVersion: 1,
+    toModelVersion: 2,
+    currentDomain: null,
+    initiatedBy: "unlock_warm",
+    resumeCount: 0,
+    startedAt: null,
+    lastCheckpointAt: null,
+    completedAt: null,
+    lastError: "Upgrade paused",
+    errorContext: null,
+    createdAt: null,
+    updatedAt: null,
+    steps: [],
+  },
+};
+
+describe("PkmUpgradeStatusCard", () => {
+  it("renders retry update action with button type", () => {
+    render(
+      <PkmUpgradeStatusCard
+        status={failedStatus}
+        showRecoveryAction
+        vaultUnlocked
+        onResume={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: /retry update/i }).getAttribute("type")
+    ).toBe("button");
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for PkmUpgradeStatusCard retry update action.
- Assert the failed, unlocked recovery path renders Retry update as type=button.

## Why
This locks the retry action contract so the recovery control does not default to submit behavior near forms.

## PR Base Policy
- Base branch: integration/pr-train.
- Branch was created directly from the fetched integration/pr-train head before this commit.

## No Overlap Proof
- Files changed: hushh-webapp/__tests__/components/pkm-upgrade-status-card.test.tsx only.
- This PR adds one focused PkmUpgradeStatusCard component test for retry update button type.
- No production files are changed.

## Validation
- npm.cmd test -- __tests__/components/pkm-upgrade-status-card.test.tsx

## DCO
- Commit includes Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>.