### PR TITLE
test(profile-kai-preferences-panel): assert save button type

### DIFF
--- a/hushh-webapp/__tests__/components/profile-kai-preferences-panel.test.tsx
+++ b/hushh-webapp/__tests__/components/profile-kai-preferences-panel.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ProfileKaiPreferencesPanel } from "@/components/profile/profile-kai-preferences-panel";
+import { KaiProfileService } from "@/lib/services/kai-profile-service";
+import type { KaiProfileV2 } from "@/lib/services/kai-profile-service";
+
+vi.mock("@/lib/morphy-ux/hooks/use-fade-in-on-ready", () => ({
+  useFadeInOnReady: vi.fn(),
+}));
+
+vi.mock("@/lib/services/kai-profile-service", () => ({
+  KaiProfileService: {
+    getProfile: vi.fn(),
+    savePreferences: vi.fn(),
+  },
+}));
+
+const profile: KaiProfileV2 = {
+  schema_version: 2,
+  onboarding: {
+    completed: true,
+    completed_at: "2026-01-01T00:00:00.000Z",
+    skipped_preferences: false,
+    nav_tour_completed_at: null,
+    nav_tour_skipped_at: null,
+    version: 2,
+  },
+  preferences: {
+    investment_horizon: "medium_term",
+    investment_horizon_selected_at: "2026-01-01T00:00:00.000Z",
+    investment_horizon_anchor_at: "2026-01-01T00:00:00.000Z",
+    drawdown_response: "stay",
+    drawdown_response_selected_at: "2026-01-01T00:00:00.000Z",
+    volatility_preference: "moderate",
+    volatility_preference_selected_at: "2026-01-01T00:00:00.000Z",
+    risk_score: 3,
+    risk_profile: "balanced",
+    risk_profile_selected_at: "2026-01-01T00:00:00.000Z",
+  },
+  updated_at: "2026-01-01T00:00:00.000Z",
+};
+
+describe("ProfileKaiPreferencesPanel", () => {
+  it("renders save button with button type", async () => {
+    vi.mocked(KaiProfileService.getProfile).mockResolvedValue(profile);
+
+    render(
+      <ProfileKaiPreferencesPanel
+        userId="user-1"
+        vaultKey="vault-key"
+        vaultOwnerToken="owner-token"
+        canEdit
+        onRequestUnlock={vi.fn()}
+      />
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /next/i }));
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+    expect(
+      screen.getByRole("button", { name: /save changes/i }).getAttribute("type")
+    ).toBe("button");
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for ProfileKaiPreferencesPanel save action rendering.
- Assert the edit wizard's Save changes control is rendered as type=button through the real panel path.

## Why
This locks the preferences save action contract so it does not default to submit behavior near forms.

## PR Base Policy
- Base branch: integration/pr-train.
- Branch was created directly from the fetched integration/pr-train head before this commit.

## No Overlap Proof
- Files changed: hushh-webapp/__tests__/components/profile-kai-preferences-panel.test.tsx only.
- This PR adds one focused ProfileKaiPreferencesPanel component test for save button type.
- No production files are changed.

## Validation
- npm.cmd test -- __tests__/components/profile-kai-preferences-panel.test.tsx

## DCO
- Commit includes Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>.