### PR TITLE
test(cash-flow-card): assert empty cash flow fallback

### DIFF
--- a/hushh-webapp/__tests__/components/cash-flow-card.test.tsx
+++ b/hushh-webapp/__tests__/components/cash-flow-card.test.tsx
@@ -1,0 +1,12 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { CashFlowCard } from "@/components/kai/cards/cash-flow-card";
+
+describe("CashFlowCard", () => {
+  it("renders empty fallback when cash flow has no balances or activity", () => {
+    const { container } = render(<CashFlowCard cashFlow={{}} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for CashFlowCard empty cash flow fallback.
- Assert an empty cash-flow payload renders the existing empty fallback contract.

## Why
This locks the CashFlowCard behavior used when cash flow balances and activity are unavailable.

## PR Base Policy
- Base branch: integration/pr-train.
- Branch was created directly from the fetched integration/pr-train head before this commit.

## No Overlap Proof
- Files changed: hushh-webapp/__tests__/components/cash-flow-card.test.tsx only.
- This PR adds one focused CashFlowCard component test for empty cash flow fallback.
- No production files are changed.

## Validation
- npm.cmd test -- __tests__/components/cash-flow-card.test.tsx

## DCO
- Commit includes Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>.