### PR TITLE
test(dashboard-summary-hero): assert metric label rendering

### DIFF
--- a/hushh-webapp/__tests__/components/dashboard-summary-hero.test.tsx
+++ b/hushh-webapp/__tests__/components/dashboard-summary-hero.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { DashboardSummaryHero } from "@/components/kai/cards/dashboard-summary-hero";
+
+describe("DashboardSummaryHero", () => {
+  it("renders metric labels", () => {
+    render(
+      <DashboardSummaryHero
+        totalValue={125000}
+        netChange={3200}
+        changePct={2.63}
+        holdingsCount={12}
+        riskLabel="aggressive"
+        brokerageName="Plaid"
+        periodRange="January 2026"
+        beginningBalance={121800}
+      />,
+    );
+
+    expect(screen.getByText("Total portfolio value")).toBeTruthy();
+    expect(screen.getByText("Risk: Aggressive")).toBeTruthy();
+    expect(screen.getByText("Holdings: 12")).toBeTruthy();
+    expect(screen.getByText("Beginning Balance:")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for DashboardSummaryHero metric label rendering.
- Assert portfolio value, risk, holdings, and beginning balance labels render from the component surface.

## Why
This protects the summary hero labels that orient users around portfolio metrics.

## PR Base Policy
- Base branch: integration/pr-train.
- Branch was created directly from the fetched integration/pr-train head before this commit.

## No Overlap Proof
- Files changed: hushh-webapp/__tests__/components/dashboard-summary-hero.test.tsx only.
- This PR adds one focused DashboardSummaryHero component test for metric label rendering.
- No production files are changed.

## Validation
- npm.cmd test -- __tests__/components/dashboard-summary-hero.test.tsx

## DCO
- Commit includes Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>.