### PR TITLE
test(holding-position-card): assert action button type

### DIFF
--- a/hushh-webapp/__tests__/components/holding-position-card.test.tsx
+++ b/hushh-webapp/__tests__/components/holding-position-card.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { HoldingPositionCard } from "@/components/kai/cards/holding-position-card";
+
+describe("HoldingPositionCard", () => {
+  it("renders action buttons with explicit button type", () => {
+    render(
+      <HoldingPositionCard
+        holding={{
+          symbol: "AAPL",
+          name: "Apple Inc.",
+          quantity: 10,
+          price: 190,
+          marketValue: 1900,
+          gainLossValue: 120,
+          gainLossPct: 6.74,
+        }}
+        onAnalyze={vi.fn()}
+        onManage={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Edit AAPL" }).getAttribute("type")).toBe(
+      "button",
+    );
+    expect(screen.getByRole("button", { name: "Delete AAPL" }).getAttribute("type")).toBe(
+      "button",
+    );
+    expect(screen.getByRole("button", { name: "Connect Kai" }).getAttribute("type")).toBe(
+      "button",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for HoldingPositionCard action button type attributes.
- Assert Edit, Delete, and Connect Kai actions render as type=button controls.

## Why
This protects the card actions from accidentally behaving like submit buttons when embedded near forms.

## PR Base Policy
- Base branch: integration/pr-train.
- Branch was created directly from the fetched integration/pr-train head before this commit.

## No Overlap Proof
- Files changed: hushh-webapp/__tests__/components/holding-position-card.test.tsx only.
- This PR adds one focused HoldingPositionCard component test for action button type rendering.
- No production files are changed.

## Validation
- npm.cmd test -- __tests__/components/holding-position-card.test.tsx

## DCO
- Commit includes Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>.