### PR TITLE
test(new-holding-cta-card): assert add holding button type

### DIFF
--- a/hushh-webapp/__tests__/components/new-holding-cta-card.test.tsx
+++ b/hushh-webapp/__tests__/components/new-holding-cta-card.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { NewHoldingCtaCard } from "@/components/kai/cards/new-holding-cta-card";
+
+describe("NewHoldingCtaCard", () => {
+  it("renders add holding action with explicit button type", () => {
+    render(
+      <NewHoldingCtaCard
+        onAddHolding={vi.fn()}
+        onImportStatement={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Add Holding" }).getAttribute("type"),
+    ).toBe("button");
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for NewHoldingCtaCard add holding button type.
- Assert the Add Holding action renders with type=button.

## Why
This protects the add holding CTA from accidentally behaving like a submit button when embedded near forms.

## PR Base Policy
- Base branch: integration/pr-train.
- Branch was created directly from the fetched integration/pr-train head before this commit.

## No Overlap Proof
- Files changed: hushh-webapp/__tests__/components/new-holding-cta-card.test.tsx only.
- This PR adds one focused NewHoldingCtaCard component test for the Add Holding button type.
- No production files are changed.

## Validation
- npm.cmd test -- __tests__/components/new-holding-cta-card.test.tsx

## DCO
- Commit includes Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>.