### PR TITLE
fix(investors): fix GET /stats route shadowing by GET /{investor_id}

### DIFF
--- a/consent-protocol/api/routes/investors.py
+++ b/consent-protocol/api/routes/investors.py
@@ -134,6 +134,16 @@ async def search_investors(
     return results
 
 
+@router.get("/stats")
+async def get_stats():
+    """Get statistics about investor profiles."""
+    # Use service layer
+    service = InvestorDBService()
+    stats = await service.get_investor_stats()
+
+    return {"total_profiles": stats.get("total", 0), "by_type": stats.get("by_type", {})}
+
+
 @router.get("/{investor_id}", response_model=InvestorProfile)
 async def get_investor(investor_id: int):
     """
@@ -289,13 +299,3 @@ async def bulk_create_investors(
     logger.info("investor.bulk_create.success count=%s", len(results))
 
     return {"created": len(results), "profiles": results}
-
-
-@router.get("/stats")
-async def get_stats():
-    """Get statistics about investor profiles."""
-    # Use service layer
-    service = InvestorDBService()
-    stats = await service.get_investor_stats()
-
-    return {"total_profiles": stats.get("total", 0), "by_type": stats.get("by_type", {})}

--- a/consent-protocol/tests/test_investors_stats_reachable.py
+++ b/consent-protocol/tests/test_investors_stats_reachable.py
@@ -1,0 +1,68 @@
+"""
+Regression proof: GET /api/investors/stats was shadowed by GET /api/investors/{investor_id}
+because FastAPI resolves routes in declaration order. Moving /stats above /{investor_id}
+makes the endpoint reachable.
+
+Canonical attach point:
+    api.routes.investors.get_investor_stats -> GET /api/investors/stats
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import api.routes.investors as investors_module
+from api.routes.investors import router
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+class TestInvestorStatsReachable:
+    def test_stats_route_returns_non_422(self):
+        """Prove /stats is not captured as investor_id=stats (which would 422)."""
+        app = _build_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        with patch.object(
+            investors_module.InvestorDBService,
+            "get_investor_stats",
+            new=AsyncMock(return_value={"total": 0, "by_type": {}}),
+        ):
+            resp = client.get("/api/investors/stats")
+        assert resp.status_code != 422, (
+            "422 means /stats was captured as /{investor_id} - route order not fixed"
+        )
+
+    def test_stats_route_returns_200(self):
+        """Prove /stats resolves to the stats handler and returns 200 with mocked DB."""
+        app = _build_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        with patch.object(
+            investors_module.InvestorDBService,
+            "get_investor_stats",
+            new=AsyncMock(return_value={"total": 42, "by_type": {"fund_manager": 10}}),
+        ):
+            resp = client.get("/api/investors/stats")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_profiles"] == 42
+
+    def test_investor_id_route_still_works(self):
+        """Prove /{investor_id} still resolves correctly after reorder."""
+        app = _build_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        with patch.object(
+            investors_module.InvestorDBService,
+            "get_investor_by_id",
+            new=AsyncMock(return_value=None),
+        ):
+            resp = client.get("/api/investors/999")
+        # 404 (not found) means the route matched correctly; 422 would mean validation failure
+        assert resp.status_code != 422
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

`GET /api/investors/stats` was declared after `GET /{investor_id}` in `api/routes/investors.py`. Since FastAPI's router matches path patterns by declaration order, a request to `/stats` was matched to the `/{investor_id}` route pattern first, then failed int conversion on the literal string `"stats"`, returning a 422 instead of ever reaching the stats handler. Moved `/stats` above `/{investor_id}` to fix the shadowing.

(An earlier version of this PR also included a batch-upsert change to `POST /investors/bulk`, but that fix is already present on `integration/pr-train` with additional rate limiting, so it has been dropped here to avoid a redundant conflicting diff.)

## Test plan

```
pytest consent-protocol/tests/test_investors_stats_reachable.py -v
```

All 3 tests pass: stats route returns non-422, returns 200 with mocked DB, and `/{investor_id}` still resolves correctly after the reorder.
