### PR TITLE
test(kai-control-surface): cover title render on desktop surface

### DIFF
--- a/hushh-webapp/__tests__/components/kai-control-surface.test.tsx
+++ b/hushh-webapp/__tests__/components/kai-control-surface.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/hooks/use-mobile", () => ({ useIsMobile: () => false }));
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <div role="heading">{children}</div>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("@/components/ui/drawer", () => ({
+  Drawer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DrawerContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DrawerHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DrawerTitle: ({ children }: { children: React.ReactNode }) => <div role="heading">{children}</div>,
+  DrawerDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DrawerFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+import { KaiControlSurface } from "@/components/app-ui/kai-control-surface";
+
+describe("KaiControlSurface", () => {
+  it("renders the title on desktop", () => {
+    render(
+      <KaiControlSurface
+        open={true}
+        onOpenChange={vi.fn()}
+        title="Analysis Settings"
+      >
+        <p>content</p>
+      </KaiControlSurface>
+    );
+    expect(screen.getByRole("heading", { name: "Analysis Settings" })).toBeDefined();
+  });
+});


### PR DESCRIPTION
Covers the title render contract on KaiControlSurface in desktop mode — 
when isMobile is false the Dialog path is taken and the title is mounted 
as a heading in the DOM.

Attach point: hushh-webapp/components/app-ui/kai-control-surface.tsx
Single file, single surface.