### PR TITLE
feat(one): immersive One surface, conversational bar trigger, sidebar UX

### DIFF
--- a/hushh-webapp/components/agent/agent-bar.tsx
+++ b/hushh-webapp/components/agent/agent-bar.tsx
@@ -15,6 +15,7 @@ import { usePathname } from "next/navigation";
 import { AudioLines, Mic } from "lucide-react";
 
 import { useOptionalAgentPopover } from "@/components/agent/agent-popover-provider";
+import { requestAgentConversation } from "@/lib/agent/agent-voice-settings";
 import { useAuth } from "@/hooks/use-auth";
 import { useKaiBottomChromeVisibility } from "@/lib/navigation/kai-bottom-chrome-visibility";
 import { getKaiChromeState } from "@/lib/navigation/kai-chrome-state";
@@ -84,6 +85,11 @@ export function AgentBar() {
 
   const openAgent = () => agentPopover.openAgent();
 
+  const startConversation = () => {
+    agentPopover.openAgent();
+    requestAgentConversation();
+  };
+
   return (
     <div
       className="pointer-events-none fixed inset-x-0 z-[118] flex justify-center px-4 transform-gpu"
@@ -137,9 +143,9 @@ export function AgentBar() {
         </button>
         <button
           type="button"
-          onClick={openAgent}
+          onClick={startConversation}
           aria-label="Start a conversational session"
-          title="Conversational mode (coming soon)"
+          title="Conversational mode"
           className={cn(
             "flex h-8 w-8 shrink-0 items-center justify-center rounded-full",
             "bg-black/[0.05] text-foreground/70 dark:bg-white/[0.07]",

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -71,6 +71,7 @@ import {
 import { handleAgentVoiceTranscriptTurn } from "@/lib/agent/agent-voice-turn";
 import { AgentTtsQueue, markdownToSpeechText } from "@/lib/agent/agent-voice-tts";
 import {
+  AGENT_CONVERSATION_REQUEST_EVENT,
   AGENT_VOICE_SETTINGS_CHANGED_EVENT,
   isAgentGeminiVoiceEnabled,
   readAgentVoiceSettings,
@@ -148,11 +149,11 @@ type AgentChatWorkspaceProps = {
 };
 
 const AGENT_GREETING =
-  "Hey, I'm Agent. Ask me about markets, your portfolio, Kai analysis, or consent workflows.";
+  "Hi, I'm One \u2014 your personal agent. Ask me about your markets, portfolio, memories, or consent workflows.";
 const AGENT_GREETING_TIMESTAMP = "Just now";
 const AGENT_WELCOME_PROMPTS = [
   "Review my portfolio",
-  "Save a PKM memory",
+  "Save a memory",
   "Explain consent flows",
 ] as const;
 
@@ -287,13 +288,13 @@ function AgentWelcomePanel({
       <div className="mx-auto w-full max-w-2xl">
         <div className="mb-7 inline-flex items-center gap-2 rounded-full border border-black/10 bg-black/[0.035] px-3 py-1.5 text-xs font-medium text-[rgba(0,0,0,0.56)] dark:border-white/10 dark:bg-white/[0.04] dark:text-zinc-400">
           <Sparkles className="h-3.5 w-3.5 text-primary" />
-          Kai workspace
+          One workspace
         </div>
         <h2 className="text-[34px] font-medium leading-[1.08] tracking-normal text-foreground sm:text-[38px]">
           Hi {name}
         </h2>
         <p className="mt-3 max-w-xl text-[16px] leading-7 text-muted-foreground sm:text-[17px]">
-          Ask Agent about your markets, portfolio, memories, or Hushh workflows.
+          Ask One about your markets, portfolio, memories, or consent workflows.
         </p>
         <div className="mt-8 grid gap-3 sm:grid-cols-3">
           {AGENT_WELCOME_PROMPTS.map((prompt) => (
@@ -2529,6 +2530,54 @@ export function AgentChatWorkspace({
     voiceActive,
   ]);
 
+  // Keep a live reference to the latest voice toggle so the conversation-request
+  // listener (registered once) always invokes the current handler.
+  const handleToggleVoiceRef = useRef(handleToggleVoice);
+  handleToggleVoiceRef.current = handleToggleVoice;
+
+  // The agent bar's conversational-mode control dispatches a request event after
+  // opening the surface. Auto-start a voice turn once the workspace is ready and
+  // not already in a voice session. Honors the same access gates as the in-chat
+  // voice button (vault unlock, fresh token, voice feature flag).
+  const conversationReady =
+    agentVoiceEnabled && hasChatAccess && !voiceActive && !isVoiceConnecting;
+  const conversationReadyRef = useRef(conversationReady);
+  conversationReadyRef.current = conversationReady;
+  const pendingConversationRequestRef = useRef(false);
+
+  const tryStartPendingConversation = useCallback(() => {
+    if (!pendingConversationRequestRef.current) return;
+    if (!conversationReadyRef.current) return;
+    pendingConversationRequestRef.current = false;
+    void handleToggleVoiceRef.current();
+  }, []);
+
+  useEffect(() => {
+    const handleConversationRequest = () => {
+      pendingConversationRequestRef.current = true;
+      tryStartPendingConversation();
+    };
+    window.addEventListener(
+      AGENT_CONVERSATION_REQUEST_EVENT,
+      handleConversationRequest,
+    );
+    return () => {
+      window.removeEventListener(
+        AGENT_CONVERSATION_REQUEST_EVENT,
+        handleConversationRequest,
+      );
+      pendingConversationRequestRef.current = false;
+    };
+  }, [tryStartPendingConversation]);
+
+  // If the request arrived before the workspace was ready (e.g. vault still
+  // unlocking), retry once readiness flips true.
+  useEffect(() => {
+    if (conversationReady) {
+      tryStartPendingConversation();
+    }
+  }, [conversationReady, tryStartPendingConversation]);
+
   const accessMessage = authLoading
     ? "Checking access..."
     : !user?.uid
@@ -2680,7 +2729,7 @@ export function AgentChatWorkspace({
       <div
         className={cn(
           "relative flex min-h-0 flex-1",
-          isPopover ? "overflow-hidden p-2 sm:p-3" : "overflow-hidden"
+          isPopover ? "overflow-hidden p-0 sm:p-3" : "overflow-hidden"
         )}
       >
         <div className="hidden h-full lg:flex">
@@ -2715,7 +2764,8 @@ export function AgentChatWorkspace({
         <section
           className={cn(
             "relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background",
-            isPopover && "rounded-lg border border-black/10 shadow-sm dark:border-white/10"
+            isPopover &&
+              "sm:rounded-lg sm:border sm:border-black/10 sm:shadow-sm sm:dark:border-white/10"
           )}
           inert={isHistoryDrawerOpen}
         >
@@ -2752,10 +2802,10 @@ export function AgentChatWorkspace({
               </div>
               <div className="min-w-0">
                 <div className="truncate text-sm font-medium leading-5 text-foreground sm:text-base">
-                  Agent
+                  One
                 </div>
                 <p className="hidden truncate text-xs text-muted-foreground sm:block">
-                  Kai workspace
+                  Your personal agent
                 </p>
               </div>
             </div>
@@ -2926,7 +2976,7 @@ export function AgentChatWorkspace({
                 <div className="flex min-h-14 items-end gap-2 rounded-[1.5rem] border border-black/10 bg-[#f5f5f7] px-3 py-2 shadow-lg shadow-black/[0.06] transition-colors focus-within:border-primary/55 focus-within:ring-2 focus-within:ring-primary/20 dark:border-white/12 dark:bg-[#0f1116] dark:shadow-black/15">
                   <textarea
                     ref={composerTextareaRef}
-                    aria-label="Message Agent"
+                    aria-label="Message One"
                     value={input}
                     onChange={(event) => setInput(event.target.value)}
                     onKeyDown={(event) => {
@@ -2939,7 +2989,7 @@ export function AgentChatWorkspace({
                       }
                     }}
                     disabled={!hasChatAccess || isLoadingHistory || isVoiceConnecting}
-                    placeholder="Message Agent..."
+                    placeholder="Message One..."
                     rows={1}
                     className="max-h-40 min-h-8 min-w-0 flex-1 resize-none bg-transparent px-1 py-2 text-sm leading-6 text-[#1d1d1f] outline-none placeholder:text-[rgba(0,0,0,0.42)] disabled:cursor-not-allowed disabled:opacity-60 dark:text-zinc-100 dark:placeholder:text-zinc-500"
                   />

--- a/hushh-webapp/components/agent/agent-history-sidebar.tsx
+++ b/hushh-webapp/components/agent/agent-history-sidebar.tsx
@@ -9,6 +9,7 @@ import {
   PanelLeftOpen,
   Pencil,
   Plus,
+  Search,
   Trash2,
   X,
 } from "lucide-react";
@@ -59,6 +60,49 @@ function conversationLabel(conversation: AgentChatConversation): string {
   return title || "New Agent chat";
 }
 
+function conversationTimestamp(conversation: AgentChatConversation): number {
+  const candidate =
+    conversation.last_message_at ||
+    conversation.updated_at ||
+    conversation.created_at ||
+    null;
+  if (!candidate) return 0;
+  const parsed = Date.parse(candidate);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+type ConversationGroupKey = "today" | "yesterday" | "previous7" | "earlier";
+
+const GROUP_LABELS: Record<ConversationGroupKey, string> = {
+  today: "Today",
+  yesterday: "Yesterday",
+  previous7: "Previous 7 days",
+  earlier: "Earlier",
+};
+
+const GROUP_ORDER: ConversationGroupKey[] = [
+  "today",
+  "yesterday",
+  "previous7",
+  "earlier",
+];
+
+function conversationGroupKey(
+  timestamp: number,
+  now: number,
+): ConversationGroupKey {
+  if (!timestamp) return "earlier";
+  const startOfToday = new Date(now);
+  startOfToday.setHours(0, 0, 0, 0);
+  const startOfTodayMs = startOfToday.getTime();
+  if (timestamp >= startOfTodayMs) return "today";
+  const startOfYesterdayMs = startOfTodayMs - 24 * 60 * 60 * 1000;
+  if (timestamp >= startOfYesterdayMs) return "yesterday";
+  const startOfPrevious7Ms = startOfTodayMs - 7 * 24 * 60 * 60 * 1000;
+  if (timestamp >= startOfPrevious7Ms) return "previous7";
+  return "earlier";
+}
+
 export function AgentHistorySidebar({
   conversations,
   activeConversationId,
@@ -77,11 +121,43 @@ export function AgentHistorySidebar({
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState("");
   const [deleteTarget, setDeleteTarget] = useState<AgentChatConversation | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
 
   const renamingConversation = useMemo(
     () => conversations.find((conversation) => conversation.id === renamingId) || null,
     [conversations, renamingId]
   );
+
+  const trimmedQuery = searchQuery.trim().toLowerCase();
+
+  const filteredConversations = useMemo(() => {
+    if (!trimmedQuery) return conversations;
+    return conversations.filter((conversation) =>
+      conversationLabel(conversation).toLowerCase().includes(trimmedQuery),
+    );
+  }, [conversations, trimmedQuery]);
+
+  const groupedConversations = useMemo(() => {
+    const now = Date.now();
+    const sorted = [...filteredConversations].sort(
+      (a, b) => conversationTimestamp(b) - conversationTimestamp(a),
+    );
+    const buckets = new Map<ConversationGroupKey, AgentChatConversation[]>();
+    for (const conversation of sorted) {
+      const key = conversationGroupKey(conversationTimestamp(conversation), now);
+      const bucket = buckets.get(key);
+      if (bucket) {
+        bucket.push(conversation);
+      } else {
+        buckets.set(key, [conversation]);
+      }
+    }
+    return GROUP_ORDER.filter((key) => buckets.has(key)).map((key) => ({
+      key,
+      label: GROUP_LABELS[key],
+      items: buckets.get(key) as AgentChatConversation[],
+    }));
+  }, [filteredConversations]);
 
   useEffect(() => {
     if (!renamingConversation) return;
@@ -111,6 +187,112 @@ export function AgentHistorySidebar({
     if (!deleteTarget) return;
     await onDeleteConversation(deleteTarget.id);
     setDeleteTarget(null);
+  };
+
+  const renderConversationItem = (conversation: AgentChatConversation) => {
+    const title = conversationLabel(conversation);
+    const active = conversation.id === activeConversationId;
+    const pending = actionPendingId === conversation.id;
+    const isRenaming = renamingId === conversation.id;
+
+    return (
+      <div
+        key={conversation.id}
+        role="listitem"
+        className={cn(
+          "group rounded-lg transition-colors",
+          active && "bg-primary/10 text-[#1d1d1f] ring-1 ring-primary/20 dark:bg-primary/15 dark:text-zinc-50",
+          !active && "text-[rgba(0,0,0,0.54)] hover:bg-black/[0.045] hover:text-[#1d1d1f] dark:text-zinc-400 dark:hover:bg-white/[0.06] dark:hover:text-zinc-100"
+        )}
+      >
+        {isRenaming ? (
+          <form
+            onSubmit={submitRename}
+            className="flex items-center gap-1 rounded-lg bg-black/[0.04] p-1 dark:bg-[#151820]"
+          >
+            <Input
+              value={renameValue}
+              onChange={(event) => setRenameValue(event.target.value)}
+              className="h-8 min-w-0 flex-1 border-black/10 bg-white/90 text-sm text-[#1d1d1f] dark:border-white/10 dark:bg-black/20 dark:text-zinc-100"
+              maxLength={160}
+              autoFocus
+              disabled={pending}
+              aria-label="Rename chat"
+              autoComplete="off"
+              autoCorrect="off"
+              spellCheck={false}
+            />
+            <Button
+              type="submit"
+              variant="ghost"
+              size="icon-xs"
+              disabled={pending || !normalizeTitle(renameValue)}
+              aria-label="Save chat name"
+            >
+              <Check className="h-3.5 w-3.5" aria-hidden="true" />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              onClick={cancelRename}
+              disabled={pending}
+              aria-label="Cancel rename"
+            >
+              <X className="h-3.5 w-3.5" aria-hidden="true" />
+            </Button>
+          </form>
+        ) : (
+          <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center">
+            <button
+              type="button"
+              className={cn(
+                "flex h-10 min-w-0 flex-1 items-center gap-2 rounded-lg text-left text-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary/60",
+                collapsed ? "justify-center px-0" : "px-2"
+              )}
+              onClick={() => onSelectConversation(conversation.id)}
+              disabled={disabled || pending}
+              aria-current={active ? "page" : undefined}
+              title={title}
+            >
+              <MessageSquare className="h-4 w-4 shrink-0 opacity-75" aria-hidden="true" />
+              {collapsed ? null : <span className="truncate">{title}</span>}
+            </button>
+            {collapsed ? null : (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    className="mr-1 text-[rgba(0,0,0,0.42)] opacity-0 transition-opacity hover:bg-black/[0.05] hover:text-[#1d1d1f] group-hover:opacity-100 focus-visible:opacity-100 dark:text-zinc-500 dark:hover:bg-white/[0.07] dark:hover:text-zinc-100"
+                    disabled={disabled || pending}
+                    onPointerDown={(event) => event.stopPropagation()}
+                    onClick={(event) => event.stopPropagation()}
+                    aria-label={`Open actions for ${title}`}
+                  >
+                    <MoreHorizontal className="h-3.5 w-3.5" aria-hidden="true" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" sideOffset={6} className="z-[520]">
+                  <DropdownMenuItem onSelect={() => startRename(conversation)}>
+                    <Pencil className="h-4 w-4" aria-hidden="true" />
+                    Rename chat
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    variant="destructive"
+                    onSelect={() => setDeleteTarget(conversation)}
+                  >
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
+                    Delete chat
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+          </div>
+        )}
+      </div>
+    );
   };
 
   return (
@@ -195,14 +377,31 @@ export function AgentHistorySidebar({
           ) : null}
         </div>
 
-        <div className="min-h-0 flex-1 overflow-y-auto p-2 scrollbar-thin scrollbar-thumb-muted scrollbar-track-transparent">
-          {collapsed ? (
-            <div className="h-4" aria-hidden="true" />
-          ) : (
-            <div className="px-2 pb-2 pt-1 text-[11px] font-medium uppercase tracking-[0.16em] text-[rgba(0,0,0,0.42)] dark:text-zinc-500">
-              Chats
+        {!collapsed ? (
+          <div className="border-b border-black/10 px-3 py-2 dark:border-white/10">
+            <div className="relative">
+              <Search
+                className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[rgba(0,0,0,0.4)] dark:text-zinc-500"
+                aria-hidden="true"
+              />
+              <Input
+                type="search"
+                value={searchQuery}
+                onChange={(event) => setSearchQuery(event.target.value)}
+                placeholder="Search chats"
+                aria-label="Search chats"
+                autoComplete="off"
+                autoCorrect="off"
+                spellCheck={false}
+                className="h-9 border-black/10 bg-black/[0.025] pl-8 text-sm text-[#1d1d1f] placeholder:text-[rgba(0,0,0,0.4)] dark:border-white/10 dark:bg-white/[0.04] dark:text-zinc-100 dark:placeholder:text-zinc-500"
+              />
             </div>
-          )}
+          </div>
+        ) : null}
+
+        <div className="min-h-0 flex-1 overflow-y-auto p-2 scrollbar-thin scrollbar-thumb-muted scrollbar-track-transparent">
+          {collapsed ? <div className="h-4" aria-hidden="true" /> : null}
+
           {loading ? (
             <div className="h-10 w-full rounded-lg bg-black/[0.04] dark:bg-white/[0.05]" />
           ) : null}
@@ -213,117 +412,45 @@ export function AgentHistorySidebar({
             </div>
           ) : null}
 
-          <div
-            className="space-y-1"
-            role="list"
-            aria-label="Conversation history"
-          >
-            {conversations.map((conversation) => {
-              const title = conversationLabel(conversation);
-              const active = conversation.id === activeConversationId;
-              const pending = actionPendingId === conversation.id;
-              const isRenaming = renamingId === conversation.id;
+          {!collapsed &&
+          !loading &&
+          conversations.length > 0 &&
+          filteredConversations.length === 0 ? (
+            <div className="grid min-h-24 place-items-center rounded-lg border border-dashed border-black/10 px-3 text-center text-xs text-[rgba(0,0,0,0.46)] dark:border-white/10 dark:text-zinc-500">
+              No chats match &ldquo;{searchQuery.trim()}&rdquo;
+            </div>
+          ) : null}
 
-              return (
-                <div
-                  key={conversation.id}
-                  role="listitem"
-                  className={cn(
-                    "group rounded-lg transition-colors",
-                    active && "bg-primary/10 text-[#1d1d1f] ring-1 ring-primary/20 dark:bg-primary/15 dark:text-zinc-50",
-                    !active && "text-[rgba(0,0,0,0.54)] hover:bg-black/[0.045] hover:text-[#1d1d1f] dark:text-zinc-400 dark:hover:bg-white/[0.06] dark:hover:text-zinc-100"
-                  )}
-                >
-                  {isRenaming ? (
-                    <form
-                      onSubmit={submitRename}
-                      className="flex items-center gap-1 rounded-lg bg-black/[0.04] p-1 dark:bg-[#151820]"
-                    >
-                      <Input
-                        value={renameValue}
-                        onChange={(event) => setRenameValue(event.target.value)}
-                        className="h-8 min-w-0 flex-1 border-black/10 bg-white/90 text-sm text-[#1d1d1f] dark:border-white/10 dark:bg-black/20 dark:text-zinc-100"
-                        maxLength={160}
-                        autoFocus
-                        disabled={pending}
-                        aria-label="Rename chat"
-                        autoComplete="off"
-                        autoCorrect="off"
-                        spellCheck={false}
-                      />
-                      <Button
-                        type="submit"
-                        variant="ghost"
-                        size="icon-xs"
-                        disabled={pending || !normalizeTitle(renameValue)}
-                        aria-label="Save chat name"
-                      >
-                        <Check className="h-3.5 w-3.5" aria-hidden="true" />
-                      </Button>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon-xs"
-                        onClick={cancelRename}
-                        disabled={pending}
-                        aria-label="Cancel rename"
-                      >
-                        <X className="h-3.5 w-3.5" aria-hidden="true" />
-                      </Button>
-                    </form>
-                  ) : (
-                    <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center">
-                      <button
-                        type="button"
-                        className={cn(
-                          "flex h-10 min-w-0 flex-1 items-center gap-2 rounded-lg text-left text-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary/60",
-                          collapsed ? "justify-center px-0" : "px-2"
-                        )}
-                        onClick={() => onSelectConversation(conversation.id)}
-                        disabled={disabled || pending}
-                        aria-current={active ? "page" : undefined}
-                        title={title}
-                      >
-                        <MessageSquare className="h-4 w-4 shrink-0 opacity-75" aria-hidden="true" />
-                        {collapsed ? null : <span className="truncate">{title}</span>}
-                      </button>
-                      {collapsed ? null : (
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="icon-xs"
-                              className="mr-1 text-[rgba(0,0,0,0.42)] opacity-0 transition-opacity hover:bg-black/[0.05] hover:text-[#1d1d1f] group-hover:opacity-100 focus-visible:opacity-100 dark:text-zinc-500 dark:hover:bg-white/[0.07] dark:hover:text-zinc-100"
-                              disabled={disabled || pending}
-                              onPointerDown={(event) => event.stopPropagation()}
-                              onClick={(event) => event.stopPropagation()}
-                              aria-label={`Open actions for ${title}`}
-                            >
-                              <MoreHorizontal className="h-3.5 w-3.5" aria-hidden="true" />
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="end" sideOffset={6} className="z-[520]">
-                            <DropdownMenuItem onSelect={() => startRename(conversation)}>
-                              <Pencil className="h-4 w-4" aria-hidden="true" />
-                              Rename chat
-                            </DropdownMenuItem>
-                            <DropdownMenuItem
-                              variant="destructive"
-                              onSelect={() => setDeleteTarget(conversation)}
-                            >
-                              <Trash2 className="h-4 w-4" aria-hidden="true" />
-                              Delete chat
-                            </DropdownMenuItem>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      )}
-                    </div>
-                  )}
+          {collapsed ? (
+            <div
+              className="space-y-1"
+              role="list"
+              aria-label="Conversation history"
+            >
+              {filteredConversations.map((conversation) =>
+                renderConversationItem(conversation),
+              )}
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {groupedConversations.map((group) => (
+                <div key={group.key}>
+                  <div className="px-2 pb-1 pt-1 text-[11px] font-medium uppercase tracking-[0.16em] text-[rgba(0,0,0,0.42)] dark:text-zinc-500">
+                    {group.label}
+                  </div>
+                  <div
+                    className="space-y-1"
+                    role="list"
+                    aria-label={`${group.label} conversations`}
+                  >
+                    {group.items.map((conversation) =>
+                      renderConversationItem(conversation),
+                    )}
+                  </div>
                 </div>
-              );
-            })}
-          </div>
+              ))}
+            </div>
+          )}
         </div>
       </aside>
 

--- a/hushh-webapp/components/agent/agent-popover-provider.tsx
+++ b/hushh-webapp/components/agent/agent-popover-provider.tsx
@@ -363,10 +363,10 @@ function AgentPopoverSurface({
         >
           <section
             className={cn(
-              "pointer-events-auto fixed flex min-h-0 origin-bottom-right flex-col overflow-hidden border border-black/10 bg-white/95 text-[#1d1d1f] shadow-2xl backdrop-blur-xl transition-[border-radius,filter,height,opacity,transform,width] duration-[360ms] ease-[cubic-bezier(0.22,1,0.36,1)] will-change-transform motion-reduce:transform-none motion-reduce:transition-none dark:border-white/10 dark:bg-[#1c1c1e]/95 dark:text-[#f5f5f7]",
+              "pointer-events-auto fixed flex min-h-0 origin-bottom-right flex-col overflow-hidden bg-white/95 text-[#1d1d1f] shadow-2xl backdrop-blur-xl transition-[border-radius,filter,height,opacity,transform,width] duration-[360ms] ease-[cubic-bezier(0.22,1,0.36,1)] will-change-transform motion-reduce:transform-none motion-reduce:transition-none dark:bg-[#1c1c1e]/95 dark:text-[#f5f5f7]",
               isFullscreen
-                ? "inset-0 rounded-none"
-                : "bottom-[calc(max(var(--app-safe-area-bottom-effective),0.5rem)+0.5rem)] right-2 h-[min(var(--agent-popover-height),calc(100dvh-1rem))] w-[min(var(--agent-popover-width),calc(100vw-1rem))] rounded-lg max-sm:inset-0 max-sm:h-auto max-sm:w-auto max-sm:rounded-none sm:right-4 sm:h-[min(var(--agent-popover-height),calc(100dvh-2rem))] sm:w-[min(var(--agent-popover-width),calc(100vw-2rem))]",
+                ? "inset-0 rounded-none border-0"
+                : "bottom-[calc(max(var(--app-safe-area-bottom-effective),0.5rem)+0.5rem)] right-2 h-[min(var(--agent-popover-height),calc(100dvh-1rem))] w-[min(var(--agent-popover-width),calc(100vw-1rem))] rounded-lg border border-black/10 max-sm:inset-0 max-sm:h-auto max-sm:w-auto max-sm:rounded-none max-sm:border-0 sm:right-4 sm:h-[min(var(--agent-popover-height),calc(100dvh-2rem))] sm:w-[min(var(--agent-popover-width),calc(100vw-2rem))] dark:border-white/10",
               expanded
                 ? "translate-x-0 translate-y-0 scale-100 opacity-100 blur-0"
                 : "pointer-events-none translate-x-3 translate-y-[calc(100%-5.75rem)] scale-[0.2] opacity-0 blur-sm",
@@ -374,7 +374,7 @@ function AgentPopoverSurface({
             )}
             style={panelStyle}
             role="dialog"
-            aria-label="Agent"
+            aria-label="One"
             aria-modal={false}
             aria-hidden={!expanded}
             inert={!expanded}
@@ -394,8 +394,8 @@ function AgentPopoverSurface({
                 onPointerMove={handleResizePointerMove}
                 onPointerUp={handleResizePointerEnd}
                 onPointerCancel={handleResizePointerEnd}
-                aria-label="Resize Agent"
-                title="Drag to resize Agent"
+                aria-label="Resize One"
+                title="Drag to resize One"
               >
                 <Grip className="h-3.5 w-3.5" />
               </Button>
@@ -438,7 +438,7 @@ function AgentPopoverWindowControls({
   return (
     <div
       className="hidden h-8 overflow-hidden rounded-md border border-black/10 bg-black/[0.035] dark:border-white/10 dark:bg-white/[0.03] sm:flex"
-      aria-label="Agent window controls"
+      aria-label="One window controls"
       role="group"
     >
       <Button
@@ -447,8 +447,8 @@ function AgentPopoverWindowControls({
         size="icon-xs"
         className="h-8 w-10 rounded-none text-[rgba(0,0,0,0.50)] hover:bg-black/[0.05] hover:text-[#1d1d1f] focus-visible:ring-2 focus-visible:ring-primary/60 dark:text-zinc-400 dark:hover:bg-white/[0.08] dark:hover:text-zinc-100"
         onClick={onMinimize}
-        aria-label="Minimize Agent"
-        title="Minimize Agent"
+        aria-label="Minimize One"
+        title="Minimize One"
       >
         <Minus className="h-3.5 w-3.5" />
       </Button>
@@ -458,8 +458,8 @@ function AgentPopoverWindowControls({
         size="icon-xs"
         className="h-8 w-10 rounded-none text-[rgba(0,0,0,0.50)] hover:bg-black/[0.05] hover:text-[#1d1d1f] focus-visible:ring-2 focus-visible:ring-primary/60 dark:text-zinc-400 dark:hover:bg-white/[0.08] dark:hover:text-zinc-100"
         onClick={() => setSizeMode(isFullscreen ? "large" : "fullscreen")}
-        aria-label={isFullscreen ? "Restore Agent" : "Maximize Agent"}
-        title={isFullscreen ? "Restore Agent" : "Maximize Agent"}
+        aria-label={isFullscreen ? "Restore One" : "Maximize One"}
+        title={isFullscreen ? "Restore One" : "Maximize One"}
       >
         {isFullscreen ? (
           <Minimize2 className="h-3.5 w-3.5" />
@@ -473,8 +473,8 @@ function AgentPopoverWindowControls({
         size="icon-xs"
         className="h-8 w-10 rounded-none text-[rgba(0,0,0,0.50)] hover:bg-red-500/85 hover:text-white focus-visible:ring-2 focus-visible:ring-red-400/70 dark:text-zinc-400"
         onClick={onClose}
-        aria-label="Close Agent"
-        title="Close Agent"
+        aria-label="Close One"
+        title="Close One"
       >
         <X className="h-3.5 w-3.5" />
       </Button>

--- a/hushh-webapp/lib/agent/agent-voice-settings.ts
+++ b/hushh-webapp/lib/agent/agent-voice-settings.ts
@@ -12,6 +12,20 @@ export const DEFAULT_AGENT_GEMINI_TTS_VOICE: AgentGeminiTtsVoice = "Sulafat";
 
 export const AGENT_VOICE_SETTINGS_CHANGED_EVENT = "hushh:agent-voice-settings-changed";
 
+// Dispatched by the agent bar's conversational-mode control to request the
+// agent workspace auto-start a voice turn once it has opened and is ready.
+export const AGENT_CONVERSATION_REQUEST_EVENT = "hushh:agent-conversation-request";
+
+/**
+ * Ask the agent workspace to start conversational (voice) mode. Safe to call
+ * before the workspace mounts; the workspace re-checks the pending request on
+ * mount. Callers should also open the agent surface (openAgent) alongside this.
+ */
+export function requestAgentConversation(): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(AGENT_CONVERSATION_REQUEST_EVENT));
+}
+
 const AGENT_VOICE_SETTINGS_STORAGE_KEY = "hushh.agent.voice.settings.v1";
 const DISABLED_FLAG_VALUES = new Set(["0", "false", "off", "disabled", "no"]);
 


### PR DESCRIPTION
## Summary
First slice of the One conversational agent program (frontend-only, no consent-protocol subtree).

### Epic 1 - Immersive One surface
- Agent popover is now edge-to-edge: fullscreen `inset-0 rounded-none border-0`; windowed card only at >=sm; mobile is full-bleed.
- Rebranded Agent -> One across popover aria-labels/titles and workspace copy (greeting, welcome prompts, header, input placeholder/aria).

### Epic 1b - Conversational mode on the bar
- The AgentBar AudioLines icon (previously a "coming soon" stub) now opens the surface and dispatches `AGENT_CONVERSATION_REQUEST_EVENT`.
- The workspace listens for that event and auto-starts a voice/conversational session once ready (gated by vault unlock + fresh token + voice feature flag); retries when readiness flips true during vault unlock. No new mic/STT/TTS path - reuses the existing voice toggle.

### Epic 2 - Conversation sidebar UX
- Added chat search/filter and Today / Yesterday / Previous 7 days / Earlier date grouping.
- Per-turn auto-refresh (already present) re-sorts groups. Collapse/rename/delete/new-chat and the encrypted thread model unchanged.

## Validation
- `tsc --noEmit` clean
- `eslint --max-warnings=0` clean (touched files)
- `verify:design-system`, `verify:service-boundary`, `audit:ui-surfaces` all pass
- `vitest __tests__/components` 145/145 pass

## Scope
5 frontend files; no backend / no DB / no new routes. Conversational interface mapped to the existing AgentBar icon (no new /agent route).