### PR TITLE
feat(one): gemini-3.5-flash convergence + screen-aware action enrichment (Epic 3a+3b)

### DIFF
--- a/config/available_models.txt
+++ b/config/available_models.txt
@@ -1,3 +1,6 @@
+models/gemini-3.5-flash
+models/gemini-3.1-pro-preview
+models/gemini-3.1-flash-lite
 models/gemini-3-pro-preview
 models/gemini-3-flash-preview
 models/gemini-3-pro-image-preview

--- a/consent-protocol/api/routes/kai/agent_chat.py
+++ b/consent-protocol/api/routes/kai/agent_chat.py
@@ -32,6 +32,7 @@ class AgentChatStreamRequest(BaseModel):
     message: str = Field(..., min_length=1, max_length=8000)
     conversation_id: Optional[str] = Field(default=None, max_length=128)
     pkm_context: Optional[str] = Field(default=None, max_length=20000)
+    screen_context: Optional[dict] = Field(default=None)
     runtime_credential: Optional[str] = Field(default=None, max_length=12000, exclude=True)
     runtime_credential_mode: Optional[str] = Field(default=None, max_length=64)
 
@@ -168,6 +169,7 @@ async def stream_agent_chat(
             runtime_client=runtime.client,
             runtime_model=runtime.model,
             pkm_context=body.pkm_context,
+            screen_context=body.screen_context,
         )
     except AgentRuntimeContractError as error:
         logger.warning(

--- a/consent-protocol/hushh_mcp/agents/kai/agent.yaml
+++ b/consent-protocol/hushh_mcp/agents/kai/agent.yaml
@@ -4,7 +4,7 @@ version: 2.0.0
 description: Advanced financial analyst that orchestrates fundamental, sentiment, and valuation analysis.
 model:
   provider: gemini
-  name: gemini-2.5-flash
+  name: gemini-3.5-flash
   mode: byok
   credential_ref: pkm:runtime_secrets.llm.gemini_api_key
 credential_policy:

--- a/consent-protocol/hushh_mcp/agents/one/agent.yaml
+++ b/consent-protocol/hushh_mcp/agents/one/agent.yaml
@@ -4,7 +4,16 @@ legacy_ids:
 name: Agent One
 version: 0.1.0
 description: Top personal agent that frames user intent and delegates specialist work.
-model: gemini-3-flash-preview
+model:
+  provider: gemini
+  name: gemini-3.5-flash
+  mode: byok
+  credential_ref: pkm:runtime_secrets.llm.gemini_api_key
+credential_policy:
+  default: hushh_managed_vertex
+  allowed:
+    - hushh_managed_vertex
+    - byok
 system_instruction: |
   You are One, the top personal agent in Hussh. Hold the relationship layer,
   clarify intent, and delegate finance work to Kai, privacy work to Nav, and

--- a/consent-protocol/hushh_mcp/services/agent_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/agent_chat_service.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import os
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime
 from pathlib import Path
 from typing import Any, AsyncGenerator, Literal
@@ -20,6 +20,7 @@ from google.genai import types as genai_types
 from db.db_client import get_db
 from hushh_mcp.hushh_adk.manifest import AgentModelConfig, ManifestLoader
 from hushh_mcp.runtime_settings import get_core_security_settings
+from hushh_mcp.services.voice_action_manifest import get_voice_manifest_action
 from hushh_mcp.types import EncryptedPayload
 from hushh_mcp.vault.encrypt import decrypt_data, encrypt_data
 from hussh_sdk import (
@@ -32,16 +33,18 @@ from hussh_sdk import (
 logger = logging.getLogger(__name__)
 
 AGENT_CHAT_MODEL_ENV = "AGENT_GEMINI_MODEL"
-DEFAULT_AGENT_CHAT_MODEL = "gemini-2.5-pro"
+DEFAULT_AGENT_CHAT_MODEL = "gemini-3.5-flash"
 KAI_AGENT_MANIFEST_PATH = Path(__file__).resolve().parents[1] / "agents" / "kai" / "agent.yaml"
-AGENT_SYSTEM_PROMPT = """You are Agent, the Kai-focused financial assistant inside Hussh.
+AGENT_SYSTEM_PROMPT = """You are One, the top personal agent inside Hussh.
+
+You hold the relationship layer with the user, clarify intent, and delegate specialist work (finance to Kai, privacy to Nav, identity/KYC to KYC). Until a specialist surface is engaged, answer directly within the capability boundary below.
 
 Current capability boundary:
 - Focus on markets, portfolio context, stock analysis, Kai workflows, consent/privacy surfaces, and how the Hussh app works.
 - Use the provided PKM context when it is relevant, especially when the user asks what Kai knows about them or shares preferences.
 - The PKM context may contain decrypted session-only details supplied by the frontend after vault unlock. Treat it as user-authorized memory for this turn, not as exhaustive truth. Do not invent personal facts outside that context and the current conversation.
-- If PKM context is present and the user asks to show, summarize, or reason over PKM, answer from that context. Do not claim Agent cannot access PKM.
-- When the user explicitly asks to save, remember, or add durable personal context to PKM, use the frontend PKM tool. Do not say Agent cannot save to PKM.
+- If PKM context is present and the user asks to show, summarize, or reason over PKM, answer from that context. Do not claim One cannot access PKM.
+- When the user explicitly asks to save, remember, or add durable personal context to PKM, use the frontend PKM tool. Do not say One cannot save to PKM.
 - Normal finance and app questions should be answered as streaming text. Use concise GitHub-flavored Markdown with headings, lists, links, code, or tables when structure makes the answer easier to scan.
 - When the stream includes a planned frontend app action, keep the reply to a short receipt. The frontend owns the actual navigation/action state.
 - For Connected Systems / Salesforce CRM, read/create/update requests are frontend tool proposals. Create and update execution requires explicit user approval in Profile > Connected Systems. Delete is blocked in v1.
@@ -49,11 +52,11 @@ Current capability boundary:
 - Keep answers concise, practical, and clear. Financial answers are educational, not personalized investment advice.
 """
 
-AGENT_ACTION_PLANNER_PROMPT = """You are Agent's action router inside Hussh.
+AGENT_ACTION_PLANNER_PROMPT = """You are One's action router inside Hussh.
 
 Decide whether the latest user message needs a frontend app function.
 
-Call exactly one function only when the user clearly asks Agent to do one of these:
+Call exactly one function only when the user clearly asks One to do one of these:
 - start stock analysis for a ticker or public company
 - open a Hussh/Kai app surface
 - save, remember, or add durable personal context to the user's PKM
@@ -220,15 +223,18 @@ _CRM_DELETE_PATTERNS = [
 _BLOCKED_ACTION_PATTERNS = [
     re.compile(r"\b(?:delete|erase|wipe)\b.*\b(?:account|vault|profile|data)\b", re.IGNORECASE),
     re.compile(
-        r"\b(?:revoke|approve|deny|grant)\b.*\b(?:consent|permission|request)\b", re.IGNORECASE
+        r"\b(?:revoke|approve|deny|grant)\b.*\b(?:consent|permission|request)\b",
+        re.IGNORECASE,
     ),
     re.compile(
-        r"\b(?:disconnect|unlink)\b.*\b(?:account|bank|brokerage|gmail|google)\b", re.IGNORECASE
+        r"\b(?:disconnect|unlink)\b.*\b(?:account|bank|brokerage|gmail|google)\b",
+        re.IGNORECASE,
     ),
     re.compile(r"\b(?:sign out|log out|logout)\b", re.IGNORECASE),
     re.compile(r"\b(?:cancel|stop)\b.*\b(?:active\s+)?analysis\b", re.IGNORECASE),
     re.compile(
-        r"\b(?:buy|sell|trade)\b.*\b(?:now|for me|on my behalf|in my account)\b", re.IGNORECASE
+        r"\b(?:buy|sell|trade)\b.*\b(?:now|for me|on my behalf|in my account)\b",
+        re.IGNORECASE,
     ),
     re.compile(r"\b(?:place|execute)\b.*\b(?:order|trade)\b", re.IGNORECASE),
 ]
@@ -288,9 +294,12 @@ class AgentChatActionPlan:
     slots: dict[str, Any]
     message: str
     reason: str | None = None
+    execution_policy: str | None = None
+    requires_confirmation: bool = False
+    reachable: bool | None = None
 
     def to_event_payload(self) -> dict[str, Any]:
-        return {
+        payload: dict[str, Any] = {
             "call_id": self.call_id,
             "action_id": self.action_id,
             "label": self.label,
@@ -299,6 +308,13 @@ class AgentChatActionPlan:
             "message": self.message,
             "reason": self.reason,
         }
+        if self.execution_policy is not None:
+            payload["execution_policy"] = self.execution_policy
+        if self.requires_confirmation:
+            payload["requires_confirmation"] = True
+        if self.reachable is not None:
+            payload["reachable"] = self.reachable
+        return payload
 
 
 @dataclass(frozen=True)
@@ -509,10 +525,17 @@ def _classify_gemini_error(error: Exception) -> dict[str, Any]:
         detail["provider_service"] = str(service)
 
     normalized_reason = reason.upper()
-    if normalized_reason in {"API_KEY_INVALID", "API_KEY_EXPIRED", "API_KEY_SERVICE_BLOCKED"}:
+    if normalized_reason in {
+        "API_KEY_INVALID",
+        "API_KEY_EXPIRED",
+        "API_KEY_SERVICE_BLOCKED",
+    }:
         detail["likely_issue"] = "invalid_or_unauthorized_api_key"
         detail["operator_hint"] = "Check the Gemini API key saved in encrypted PKM."
-    elif normalized_reason in {"CREDENTIALS_MISSING", "ACCESS_TOKEN_SCOPE_INSUFFICIENT"}:
+    elif normalized_reason in {
+        "CREDENTIALS_MISSING",
+        "ACCESS_TOKEN_SCOPE_INSUFFICIENT",
+    }:
         detail["likely_issue"] = "managed_google_credentials_unavailable"
         detail["operator_hint"] = "Check Hushh managed Gemini credentials for this runtime."
     elif status_code in {401, 403}:
@@ -555,7 +578,9 @@ def _runtime_provider_user_message(error_code: str) -> str:
     return "Kai could not reach the configured Gemini runtime."
 
 
-def _runtime_provider_error_from_exception(error: Exception) -> AgentRuntimeProviderError:
+def _runtime_provider_error_from_exception(
+    error: Exception,
+) -> AgentRuntimeProviderError:
     detail = _classify_gemini_error(error)
     error_code = _runtime_provider_error_code(detail)
     return AgentRuntimeProviderError(
@@ -582,6 +607,61 @@ def _trim_title(text: str) -> str:
 
 def _tool_call_id() -> str:
     return f"tool_{uuid4().hex[:12]}"
+
+
+def _current_screen_from_context(screen_context: dict[str, Any] | None) -> str | None:
+    """Extract the current screen id from a structured screen context.
+
+    Mirrors the shape the voice path already produces (route.screen /
+    surface.screen_id). Returns None when no screen is provided so callers can
+    treat reachability as unknown rather than failing closed on missing data.
+    """
+    if not isinstance(screen_context, dict):
+        return None
+    route = screen_context.get("route") if isinstance(screen_context.get("route"), dict) else {}
+    surface = (
+        screen_context.get("surface") if isinstance(screen_context.get("surface"), dict) else {}
+    )
+    candidate = route.get("screen") or surface.get("screen_id") or screen_context.get("screen")
+    screen = str(candidate or "").strip()
+    return screen or None
+
+
+def _enrich_plan_with_manifest(
+    plan: AgentChatActionPlan,
+    *,
+    current_screen: str | None,
+) -> AgentChatActionPlan:
+    """Make a frontend action plan screen-aware using the voice action manifest.
+
+    Attaches the manifest execution_policy, flags manual_only/confirm_required
+    actions as requiring confirmation, and computes reachability for the current
+    screen. Degrades gracefully: unknown actions or missing screen context leave
+    the plan unchanged (the frontend stays the source of truth for execution).
+    """
+    if plan.execution != "frontend" or not plan.action_id:
+        return plan
+    manifest_action = get_voice_manifest_action(plan.action_id)
+    if manifest_action is None:
+        return plan
+
+    risk = manifest_action.get("risk") if isinstance(manifest_action.get("risk"), dict) else {}
+    execution_policy = str(risk.get("execution_policy") or "allow_direct").strip() or "allow_direct"
+    requires_confirmation = execution_policy in {"manual_only", "confirm_required"}
+
+    scope = manifest_action.get("scope") if isinstance(manifest_action.get("scope"), dict) else {}
+    scoped_screens = {str(screen).strip() for screen in (scope.get("screens") or []) if screen}
+    if current_screen is None or not scoped_screens:
+        reachable: bool | None = None
+    else:
+        reachable = current_screen in scoped_screens
+
+    return replace(
+        plan,
+        execution_policy=execution_policy,
+        requires_confirmation=requires_confirmation,
+        reachable=reachable,
+    )
 
 
 def _sanitize_analysis_target(raw: str) -> str:
@@ -613,7 +693,9 @@ def _resolve_ticker(raw: str) -> str | None:
     if normalized in _STOCK_ALIAS_TO_TICKER:
         return _STOCK_ALIAS_TO_TICKER[normalized]
     normalized = re.sub(
-        r"\b(?:inc|corp|corporation|company|plc|ltd|limited|class\s+[ab])\b", " ", normalized
+        r"\b(?:inc|corp|corporation|company|plc|ltd|limited|class\s+[ab])\b",
+        " ",
+        normalized,
     )
     normalized = " ".join(normalized.split())
     if normalized in _STOCK_ALIAS_TO_TICKER:
@@ -685,7 +767,7 @@ def _agent_action_tool() -> genai_types.Tool:
                 parameters=_schema_object(
                     {
                         "reason": _schema_string(
-                            "Short safe reason explaining why Agent cannot perform the action."
+                            "Short safe reason explaining why One cannot perform the action."
                         )
                     }
                 ),
@@ -906,7 +988,10 @@ class AgentChatService:
                 ),
             )
 
-        logger.info("agent_chat_runtime_evidence=%s", _redacted_runtime_evidence(bundle.evidence))
+        logger.info(
+            "agent_chat_runtime_evidence=%s",
+            _redacted_runtime_evidence(bundle.evidence),
+        )
         return PreparedAgentRuntime(
             mode=contract.mode,
             provider=provider,
@@ -1286,10 +1371,13 @@ class AgentChatService:
         runtime_client: Any,
         runtime_model: str,
         pkm_context: str | None = None,
+        screen_context: dict[str, Any] | None = None,
     ) -> AgentChatActionPlan | None:
+        current_screen = _current_screen_from_context(screen_context)
+
         crm_action = self._plan_crm_action(user_message)
         if crm_action is not None:
-            return crm_action
+            return _enrich_plan_with_manifest(crm_action, current_screen=current_screen)
 
         deterministic_block = self._plan_blocked_action(user_message)
         if deterministic_block is not None:
@@ -1319,7 +1407,7 @@ class AgentChatService:
             for function_call in self._function_calls_from_response(response):
                 action_plan = self._action_plan_from_function_call(function_call)
                 if action_plan is not None:
-                    return action_plan
+                    return _enrich_plan_with_manifest(action_plan, current_screen=current_screen)
         except genai_errors.APIError as error:
             provider_error = _runtime_provider_error_from_exception(error)
             logger.warning(
@@ -1343,7 +1431,10 @@ class AgentChatService:
                 raise provider_error from error
             logger.exception("agent_chat.function_planning_failed")
 
-        return self.plan_action(user_message)
+        fallback_plan = self.plan_action(user_message)
+        if fallback_plan is None:
+            return None
+        return _enrich_plan_with_manifest(fallback_plan, current_screen=current_screen)
 
     def plan_action(self, user_message: str) -> AgentChatActionPlan | None:
         message = " ".join(str(user_message or "").split())

--- a/consent-protocol/tests/services/test_agent_chat_service.py
+++ b/consent-protocol/tests/services/test_agent_chat_service.py
@@ -6,10 +6,13 @@ import pytest
 
 from hushh_mcp.services.agent_chat_service import (
     AGENT_SYSTEM_PROMPT,
+    AgentChatActionPlan,
     AgentChatMessage,
     AgentChatService,
     AgentRuntimeContractError,
     RuntimeSecretSession,
+    _current_screen_from_context,
+    _enrich_plan_with_manifest,
     create_managed_runtime_client,
     create_runtime_client,
 )
@@ -24,7 +27,7 @@ from hussh_sdk import (
 def test_agent_chat_service_uses_agent_yaml_model(test_vault_key):
     service = AgentChatService(vault_key_hex=test_vault_key)
 
-    assert service.model == "gemini-2.5-flash"
+    assert service.model == "gemini-3.5-flash"
 
 
 def test_agent_chat_service_ignores_env_model_override(monkeypatch, test_vault_key):
@@ -32,7 +35,7 @@ def test_agent_chat_service_ignores_env_model_override(monkeypatch, test_vault_k
 
     service = AgentChatService(vault_key_hex=test_vault_key)
 
-    assert service.model == "gemini-2.5-flash"
+    assert service.model == "gemini-3.5-flash"
 
 
 def test_agent_chat_runtime_contract_defaults_to_hushh_managed(test_vault_key):
@@ -44,7 +47,9 @@ def test_agent_chat_runtime_contract_defaults_to_hushh_managed(test_vault_key):
     assert contract.credential_supplied is False
 
 
-def test_agent_chat_runtime_contract_accepts_byok_with_runtime_credential(test_vault_key):
+def test_agent_chat_runtime_contract_accepts_byok_with_runtime_credential(
+    test_vault_key,
+):
     service = AgentChatService(vault_key_hex=test_vault_key)
 
     contract = service.prepare_runtime_contract(
@@ -109,7 +114,7 @@ async def test_agent_chat_service_prepares_byok_runtime_from_pkm_secret(
     )
 
     assert prepared.mode == "byok"
-    assert prepared.model == "gemini-2.5-flash"
+    assert prepared.model == "gemini-3.5-flash"
     assert prepared.client.kind == "client"
     assert calls == [{"vertexai": False, "api_key": sample_runtime_value}]
     assert sample_runtime_value not in str(prepared.evidence)
@@ -239,7 +244,9 @@ def test_agent_chat_service_decrypts_encrypted_conversation_and_message(test_vau
     assert message.role == "assistant"
 
 
-def test_agent_chat_contents_use_system_instruction_boundary_and_planned_action(test_vault_key):
+def test_agent_chat_contents_use_system_instruction_boundary_and_planned_action(
+    test_vault_key,
+):
     service = AgentChatService(model="gemini-2.5-pro", vault_key_hex=test_vault_key)
     action_plan = service.plan_action("Start analysis of Nvidia")
     assert action_plan is not None
@@ -278,7 +285,7 @@ def test_agent_chat_contents_use_system_instruction_boundary_and_planned_action(
     )
     current_turn_text = contents[-1].parts[0].text or ""
 
-    assert "Kai-focused financial assistant" in AGENT_SYSTEM_PROMPT
+    assert "You are One, the top personal agent" in AGENT_SYSTEM_PROMPT
     assert contents[0].role == "user"
     assert contents[0].parts[0].text == "Can you help with stocks?"
     assert contents[1].role == "model"
@@ -292,7 +299,9 @@ def test_agent_chat_contents_use_system_instruction_boundary_and_planned_action(
     assert AGENT_SYSTEM_PROMPT not in current_turn_text
 
 
-def test_agent_chat_translates_gemini_function_call_to_frontend_analysis(test_vault_key):
+def test_agent_chat_translates_gemini_function_call_to_frontend_analysis(
+    test_vault_key,
+):
     service = AgentChatService(model="gemini-2.5-pro", vault_key_hex=test_vault_key)
 
     action_plan = service._action_plan_from_function_call(
@@ -310,7 +319,9 @@ def test_agent_chat_translates_gemini_function_call_to_frontend_analysis(test_va
     assert action_plan.slots == {"symbol": "NVDA"}
 
 
-def test_agent_chat_translates_gemini_function_call_to_frontend_navigation(test_vault_key):
+def test_agent_chat_translates_gemini_function_call_to_frontend_navigation(
+    test_vault_key,
+):
     service = AgentChatService(model="gemini-2.5-pro", vault_key_hex=test_vault_key)
 
     action_plan = service._action_plan_from_function_call(
@@ -406,3 +417,84 @@ def test_agent_chat_blocks_destructive_actions(test_vault_key):
     assert action_plan.action_id is None
     assert action_plan.execution == "blocked"
     assert action_plan.reason == "manual_or_destructive_action"
+
+
+def test_current_screen_from_context_reads_voice_shape():
+    assert _current_screen_from_context(None) is None
+    assert _current_screen_from_context({}) is None
+    assert (
+        _current_screen_from_context({"route": {"screen": "marketplace_ria_profile"}})
+        == "marketplace_ria_profile"
+    )
+    assert _current_screen_from_context({"surface": {"screen_id": "kai_home"}}) == "kai_home"
+
+
+def test_enrich_plan_with_manifest_flags_manual_only_and_reachability():
+    plan = AgentChatActionPlan(
+        call_id="tool_1",
+        action_id="marketplace.ria.request_advisory",
+        label="Request Advisory Access",
+        execution="frontend",
+        slots={},
+        message="Requesting advisory access.",
+    )
+
+    enriched = _enrich_plan_with_manifest(plan, current_screen="marketplace_ria_profile")
+
+    assert enriched.execution_policy == "manual_only"
+    assert enriched.requires_confirmation is True
+    assert enriched.reachable is True
+
+    payload = enriched.to_event_payload()
+    assert payload["execution_policy"] == "manual_only"
+    assert payload["requires_confirmation"] is True
+    assert payload["reachable"] is True
+
+
+def test_enrich_plan_with_manifest_marks_unreachable_off_screen():
+    plan = AgentChatActionPlan(
+        call_id="tool_2",
+        action_id="marketplace.ria.request_advisory",
+        label="Request Advisory Access",
+        execution="frontend",
+        slots={},
+        message="Requesting advisory access.",
+    )
+
+    enriched = _enrich_plan_with_manifest(plan, current_screen="kai_home")
+
+    assert enriched.reachable is False
+
+
+def test_enrich_plan_with_manifest_degrades_on_unknown_action():
+    plan = AgentChatActionPlan(
+        call_id="tool_3",
+        action_id="not.a.real.action",
+        label="Unknown",
+        execution="frontend",
+        slots={},
+        message="Doing something.",
+    )
+
+    enriched = _enrich_plan_with_manifest(plan, current_screen="kai_home")
+
+    assert enriched.execution_policy is None
+    assert enriched.requires_confirmation is False
+    assert enriched.reachable is None
+    assert "execution_policy" not in enriched.to_event_payload()
+
+
+def test_enrich_plan_with_manifest_unknown_screen_leaves_reachability_unknown():
+    plan = AgentChatActionPlan(
+        call_id="tool_4",
+        action_id="marketplace.ria.request_advisory",
+        label="Request Advisory Access",
+        execution="frontend",
+        slots={},
+        message="Requesting advisory access.",
+    )
+
+    enriched = _enrich_plan_with_manifest(plan, current_screen=None)
+
+    assert enriched.execution_policy == "manual_only"
+    assert enriched.reachable is None

--- a/consent-protocol/tests/test_agent_chat_routes.py
+++ b/consent-protocol/tests/test_agent_chat_routes.py
@@ -157,6 +157,7 @@ class _FakeAgentChatService:
         runtime_client,
         runtime_model: str,
         pkm_context: str | None = None,
+        screen_context: dict | None = None,
     ):
         assert user_message == "Hello Agent"
         assert history == []

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -94,6 +94,7 @@ import { useVault } from "@/lib/vault/vault-context";
 import { deriveVoiceRouteScreen } from "@/lib/voice/route-screen-derivation";
 import type { AppRuntimeState } from "@/lib/voice/voice-types";
 import { getVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
+import { buildStructuredScreenContext } from "@/lib/voice/screen-context-builder";
 
 type AgentMessage = {
   id: string;
@@ -2106,6 +2107,9 @@ export function AgentChatWorkspace({
         conversationId,
         vaultOwnerToken: token,
         pkmContext: agentPkmContext.text || undefined,
+        screenContext: buildStructuredScreenContext({
+          appRuntimeState: appRuntimeStateRef.current,
+        }) as unknown as Record<string, unknown>,
         signal: streamAbortController.signal,
         handlers: {
           onStart: ({ conversationId: nextConversationId }) => {

--- a/hushh-webapp/lib/services/agent-chat-client.ts
+++ b/hushh-webapp/lib/services/agent-chat-client.ts
@@ -114,6 +114,7 @@ export async function streamAgentChat(input: {
   conversationId?: string | null;
   vaultOwnerToken: string;
   pkmContext?: string;
+  screenContext?: Record<string, unknown> | null;
   runtimeCredential?: string | null;
   runtimeCredentialMode?: string | null;
   signal?: AbortSignal;
@@ -125,6 +126,7 @@ export async function streamAgentChat(input: {
     conversationId: input.conversationId || undefined,
     vaultOwnerToken: input.vaultOwnerToken,
     pkmContext: input.pkmContext,
+    screenContext: input.screenContext,
     runtimeCredential: input.runtimeCredential,
     runtimeCredentialMode: input.runtimeCredentialMode,
     signal: input.signal,

--- a/hushh-webapp/lib/services/api-service.ts
+++ b/hushh-webapp/lib/services/api-service.ts
@@ -2611,6 +2611,7 @@ export class ApiService {
     conversationId?: string;
     vaultOwnerToken: string;
     pkmContext?: string;
+    screenContext?: Record<string, unknown> | null;
     runtimeCredential?: string | null;
     runtimeCredentialMode?: string | null;
     signal?: AbortSignal;
@@ -2625,6 +2626,7 @@ export class ApiService {
         message: data.message,
         conversation_id: data.conversationId,
         pkm_context: data.pkmContext,
+        screen_context: data.screenContext || undefined,
         runtime_credential: data.runtimeCredential || undefined,
         runtime_credential_mode: data.runtimeCredentialMode || undefined,
       }),


### PR DESCRIPTION
## Epic 3a - model + persona convergence
- `config/available_models.txt`: add gemini-3.5-flash + gemini-3.1 family atop the gemini-3 set
- `kai/one agent.yaml`: pin gemini-3.5-flash with byok credential policy (One now mirrors Kai's structured model block)
- `agent_chat_service`: DEFAULT_AGENT_CHAT_MODEL -> gemini-3.5-flash; reframe system persona as One (top personal agent that delegates to Kai/Nav/KYC)

## Epic 3b - screen-aware contract-mapper
- `agent_chat_service`: enrich frontend action plans from the voice-action manifest (execution_policy, requires_confirmation, reachable-vs-current-screen) via immutable `dataclasses.replace`
- `agent_chat` route: accept `screen_context` on the stream request
- frontend: thread structured screen context through `streamAgentChat` (api-service, agent-chat-client, workspace via `buildStructuredScreenContext`)

## Validation
- backend: 170 passed (test_agent_chat_service, test_agent_chat_routes, test_agent_chat_connected_system_actions, test_kai_voice_contract, test_agent_manifests)
- frontend: typecheck clean, eslint --max-warnings=0 clean, agent-chat-client tests 10 passed
- model: gemini-3.5-flash reachable via Vertex; BYOK scaffolding preserved