### PR TITLE
test(utils): characterize formatCompleteJson isolated per-tier rendering of repeated keys (no dedupe/overwrite)

### DIFF
--- a/hushh-webapp/__tests__/utils/format-key-redundancy.test.ts
+++ b/hushh-webapp/__tests__/utils/format-key-redundancy.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCompleteJson } from "@/lib/utils/json-to-human";
+
+// Characterization tests for formatCompleteJson
+// (hushh-webapp/lib/utils/json-to-human.ts) focused on objects that REUSE the
+// same key string at completely different structural tiers of the payload tree
+// (e.g. `{ id: 1, meta: { id: 2 } }`).
+//
+// TRUTH-FIRST — IMPORTANT CORRECTION: the premise of "variable scoping leaks" or
+// a shared key registry that could let a duplicate key at one tier overwrite or
+// collide with the same key at another tier is FALSE. formatCompleteJson holds NO
+// cross-level key map and NO accumulator keyed by name. It walks the tree with
+// plain `for...of Object.entries(...)` loops and pushes one independent output
+// line per entry. Each key is labeled/formatted in isolation at its own tier:
+//   Top-level scalar:  `Id: 1`                (no indent)
+//   Object section:    `\n--- Meta ---`        (header)
+//   Object field:      `  Id: 2`               (2-space indent)
+// So the SAME key name appears multiple times in the output, each at its own
+// level, with NO dedupe and NO last-wins overwrite. There is no token isolation
+// bug because there is no shared token state to leak.
+//
+// These tests pin that real isolated-per-tier contract.
+
+describe("formatCompleteJson — multi-tier duplicate key redundancy", () => {
+  it("renders the same key at two tiers independently (no overwrite/leak)", () => {
+    const input = { id: 1, meta: { id: 2 } };
+    expect(formatCompleteJson(input)).toBe("Id: 1\n\n--- Meta ---\n  Id: 2");
+  });
+
+  it("emits BOTH occurrences of a duplicate key (no dedupe)", () => {
+    const out = formatCompleteJson({ id: 1, meta: { id: 2 } });
+    const matches = out.match(/Id:/g) ?? [];
+    expect(matches.length).toBe(2);
+  });
+
+  it("keeps the deeper-tier value distinct from the top-level value", () => {
+    const out = formatCompleteJson({ id: 1, meta: { id: 2 } });
+    expect(out).toContain("Id: 1"); // top-level scalar
+    expect(out).toContain("  Id: 2"); // nested field, 2-space indent
+    expect(out).not.toContain("Id: 2\n"); // the "2" never appears at top level
+  });
+
+  it("isolates a triply-shared key across scalar/section/nested tiers", () => {
+    const input = { value: 10, alpha: { value: 20, beta: { value: 30 } } };
+    // Top scalar uses CURRENCY formatting for `value`; nested also currency.
+    expect(formatCompleteJson(input)).toBe(
+      "Value: $10.00\n\n--- Alpha ---\n  Value: $20.00\n  Beta:\n    • Value: $30.00"
+    );
+  });
+
+  it("does not let an earlier section's key bleed into a later section", () => {
+    // NB: getFieldLabel only splits on `_`, not camelCase, so `sectionA` →
+    // `SectionA` (first char upper-cased). The two sections stay independent.
+    const input = { sectionA: { id: "A" }, sectionB: { id: "B" } };
+    expect(formatCompleteJson(input)).toBe(
+      "\n--- SectionA ---\n  Id: A\n\n--- SectionB ---\n  Id: B"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds an isolated characterization test for `formatCompleteJson` (`hushh-webapp/lib/utils/json-to-human.ts`) documenting how it handles the SAME key string reused at different structural tiers of the payload tree (e.g. `{ id: 1, meta: { id: 2 } }`). Test-only; no production change.

### Reviewer response — `pr_claim_changed_surface_mismatch` (title corrected)
The blocker is addressed by tightening the claim to the verified surface. The prior title ("multi-tier object key **redundancy**") implied a dedupe/redundancy or shared-key mechanism. There is none — the real surface is **isolated per-tier rendering**: each duplicate key is emitted independently at its own tier with no shared key state, no dedupe, and no last-wins overwrite. The title now states that exact boundary so the claim matches what the test pins.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/utils/...`. There is no top-level `__tests__` in this repo; vitest only includes `__tests__/**` under `hushh-webapp`. The file lives at `hushh-webapp/__tests__/utils/format-key-redundancy.test.ts`.
- **The premise of "variable scoping leaks" / a shared key registry that lets a duplicate key at one tier overwrite or collide with the same key at another tier is FALSE.** `formatCompleteJson` holds NO cross-level key map and NO accumulator keyed by name. It walks the tree with plain `for...of Object.entries(...)` loops and pushes one independent output line per entry. Each key is labeled/formatted in isolation at its own tier (top scalar `Id: 1`, section header `--- Meta ---`, 2-space field `  Id: 2`). Duplicate keys are emitted as-is with **no dedupe** and **no last-wins overwrite** — there is no shared token state to leak.
- Additional truth caught during local verification: `getFieldLabel` only splits on `_` (snake_case), **not** camelCase. So `sectionA` → `SectionA`, not `Section A`. The test asserts the real label output.

## Behavior pinned

- `{ id: 1, meta: { id: 2 } }` → `Id: 1\n\n--- Meta ---\n  Id: 2`
- duplicate `Id:` appears exactly twice (no dedupe)
- nested `Id: 2` carries 2-space indent; top-level `Id: 1` does not; values stay tier-distinct
- triply-shared `value` across scalar/section/nested → `Value: $10.00 / Value: $20.00 / • Value: $30.00` (currency formatting applied independently at each tier)
- two sibling sections sharing key `id` render independently, with camelCase section labels left unsplit (`SectionA`, `SectionB`)

## Verification

- `npm test -- __tests__/utils/format-key-redundancy.test.ts` → 5/5 pass
- `git status` limited to the single new test file; zero production source drift
- (An IDE-only `@/` module-resolution warning is a false positive — the alias resolves under vitest, as the passing run confirms.)

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the real isolated-per-tier (no shared key state, no dedupe, camelCase labels unsplit) contract rather than an assumed scope-leak bug
- [x] Claim matches surface — title corrected to isolated per-tier rendering (no dedupe/overwrite)
