### PR TITLE
test(navigation): characterize normalizeInternalRouteHref numeric sub-segment paths

### DIFF
--- a/hushh-webapp/__tests__/navigation/normalize-numeric-segments.test.ts
+++ b/hushh-webapp/__tests__/navigation/normalize-numeric-segments.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for normalizeInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts) focused on route paths made up entirely
+// of numeric directory segments (e.g. `/v2/1028/3403`).
+//
+// TRUTH-FIRST — IMPORTANT CORRECTION: the premise that numeric segments are
+// "validated", coerced to numbers, range-checked, or treated as "numeric
+// parameters" is FALSE. normalizeInternalRouteHref does NO per-segment parsing
+// and has NO notion of numeric vs. non-numeric tokens. It only:
+//   1. returns `null` for non-strings / empty-after-trim,
+//   2. trims surrounding whitespace,
+//   3. returns `null` for protocol-relative (`//`) or absolute-URL hrefs,
+//   4. returns `null` for hrefs not starting with `/`,
+//   5. returns `null` for hrefs containing interior CR/LF,
+//   6. otherwise returns the trimmed href VERBATIM.
+// Digits are just ordinary string characters: `/v2/1028/3403` passes through
+// unchanged, with NO leading-zero stripping, NO numeric coercion, and NO
+// collapsing of multi-digit segments. These tests pin that opaque string-token
+// contract.
+
+describe("normalizeInternalRouteHref — all-numeric path segments", () => {
+  it("returns a multi-segment numeric path verbatim", () => {
+    expect(normalizeInternalRouteHref("/v2/1028/3403")).toBe("/v2/1028/3403");
+  });
+
+  it("returns a purely numeric path verbatim", () => {
+    expect(normalizeInternalRouteHref("/1028/3403")).toBe("/1028/3403");
+  });
+
+  it("does NOT strip leading zeros from numeric segments", () => {
+    expect(normalizeInternalRouteHref("/v2/0007/0042")).toBe("/v2/0007/0042");
+  });
+
+  it("does NOT coerce or collapse large numeric segments", () => {
+    expect(
+      normalizeInternalRouteHref("/orders/900719925474099100")
+    ).toBe("/orders/900719925474099100");
+  });
+
+  it("trims surrounding whitespace but keeps the numeric path intact", () => {
+    expect(normalizeInternalRouteHref("  /v2/1028/3403  ")).toBe(
+      "/v2/1028/3403"
+    );
+  });
+
+  it("rejects a protocol-relative host even when segments are numeric", () => {
+    expect(normalizeInternalRouteHref("//1028/3403")).toBeNull();
+  });
+
+  it("rejects a numeric path that does not start with '/'", () => {
+    expect(normalizeInternalRouteHref("1028/3403")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds an isolated characterization test for `normalizeInternalRouteHref`
(`hushh-webapp/lib/navigation/routes.ts`) documenting how it handles route paths
made up entirely of numeric directory segments (e.g. `/v2/1028/3403`). Test-only;
no production change.

## Truth-first scope correction

- The original task referenced `hushh-research/__tests__/navigation/...`. There is
  no top-level `__tests__` in this repo; vitest only includes `__tests__/**` under
  `hushh-webapp`. The file lives at
  `hushh-webapp/__tests__/navigation/normalize-numeric-segments.test.ts`.
- **The premise that numeric segments are "validated", coerced to numbers,
  range-checked, or treated as "numeric parameters" is FALSE.**
  `normalizeInternalRouteHref` does NO per-segment parsing and has NO notion of
  numeric vs. non-numeric tokens. It only:
  1. returns `null` for non-strings / empty-after-trim,
  2. trims surrounding whitespace,
  3. returns `null` for protocol-relative (`//`) / absolute-URL hrefs,
  4. returns `null` for hrefs not starting with `/`,
  5. returns `null` for hrefs with interior CR/LF,
  6. otherwise returns the trimmed href **verbatim**.
- Digits are ordinary string characters: there is NO leading-zero stripping, NO
  numeric coercion, and NO collapsing of large/multi-digit segments.

## Behavior pinned

- `/v2/1028/3403` → verbatim
- `/1028/3403` → verbatim (purely numeric path)
- `/v2/0007/0042` → verbatim (leading zeros preserved)
- `/orders/900719925474099100` → verbatim (beyond `Number.MAX_SAFE_INTEGER`, not coerced)
- `  /v2/1028/3403  ` → `/v2/1028/3403` (surrounding whitespace trimmed)
- `//1028/3403` → `null` (protocol-relative rejected)
- `1028/3403` → `null` (not rooted)

## Verification

- `npm test -- __tests__/navigation/normalize-numeric-segments.test.ts` → 7/7 pass
- `git status` limited to the single new test file; zero production source drift
- (An IDE-only `@/` module-resolution warning is a false positive — the alias
  resolves under vitest, as the passing run confirms.)

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the real "numeric segments are opaque string tokens, no
  validation/coercion" contract rather than an assumed numeric-aware path guard
