### PR TITLE
feat(one): soft first-run One Setup gate (Epic 5)

### DIFF
--- a/hushh-webapp/__tests__/services/post-auth-route-service.test.ts
+++ b/hushh-webapp/__tests__/services/post-auth-route-service.test.ts
@@ -40,6 +40,7 @@ import {
   buildProfileVaultRoute,
   ROUTES,
 } from "@/lib/navigation/routes";
+import { OneSetupGateService } from "@/lib/services/one-setup-gate-service";
 import { PostAuthRouteService } from "@/lib/services/post-auth-route-service";
 
 describe("PostAuthRouteService", () => {
@@ -391,5 +392,110 @@ describe("PostAuthRouteService", () => {
         hostname: "127.0.0.1",
       })
     ).resolves.toBe(ROUTES.ONE_HOME);
+  });
+
+  describe("first-run One Setup gate", () => {
+    beforeEach(() => {
+      OneSetupGateService.reset("user_gate");
+    });
+
+    it("routes a first-run vault user to setup when the gate is enabled and unseen", async () => {
+      bootstrapStateMock.mockResolvedValue({
+        hasVault: true,
+        preOnboardingCompleted: true,
+        preOnboardingCompletedAt: 1,
+      });
+
+      await expect(
+        PostAuthRouteService.resolveAfterLogin({
+          userId: "user_gate",
+          phoneVerified: true,
+          enableFirstRunSetupGate: true,
+        })
+      ).resolves.toBe(ROUTES.ONE_SETUP);
+    });
+
+    it("routes a first-run no-vault user to setup when the gate is enabled and unseen", async () => {
+      bootstrapStateMock.mockResolvedValue({
+        hasVault: false,
+        preOnboardingCompleted: true,
+        preOnboardingCompletedAt: 1,
+        preOnboardingSkipped: false,
+      });
+      loadPendingOnboardingMock.mockResolvedValue(null);
+
+      await expect(
+        PostAuthRouteService.resolveAfterLogin({
+          userId: "user_gate",
+          phoneVerified: true,
+          enableFirstRunSetupGate: true,
+        })
+      ).resolves.toBe(ROUTES.ONE_SETUP);
+    });
+
+    it("does not gate when the setup nudge has already been seen", async () => {
+      OneSetupGateService.markSeen("user_gate");
+      bootstrapStateMock.mockResolvedValue({
+        hasVault: true,
+        preOnboardingCompleted: true,
+        preOnboardingCompletedAt: 1,
+      });
+
+      await expect(
+        PostAuthRouteService.resolveAfterLogin({
+          userId: "user_gate",
+          phoneVerified: true,
+          enableFirstRunSetupGate: true,
+        })
+      ).resolves.toBe(ROUTES.ONE_HOME);
+    });
+
+    it("does not gate when the caller has not opted in", async () => {
+      bootstrapStateMock.mockResolvedValue({
+        hasVault: true,
+        preOnboardingCompleted: true,
+        preOnboardingCompletedAt: 1,
+      });
+
+      await expect(
+        PostAuthRouteService.resolveAfterLogin({
+          userId: "user_gate",
+          phoneVerified: true,
+        })
+      ).resolves.toBe(ROUTES.ONE_HOME);
+    });
+
+    it("does not gate when an explicit redirect target is present", async () => {
+      bootstrapStateMock.mockResolvedValue({
+        hasVault: true,
+        preOnboardingCompleted: true,
+        preOnboardingCompletedAt: 1,
+      });
+
+      await expect(
+        PostAuthRouteService.resolveAfterLogin({
+          userId: "user_gate",
+          redirectPath: ROUTES.KAI_PORTFOLIO,
+          phoneVerified: true,
+          enableFirstRunSetupGate: true,
+        })
+      ).resolves.toBe(ROUTES.KAI_PORTFOLIO);
+    });
+
+    it("does not gate a user with unresolved onboarding", async () => {
+      bootstrapStateMock.mockResolvedValue({
+        hasVault: true,
+        preOnboardingCompleted: false,
+        preOnboardingCompletedAt: null,
+      });
+
+      await expect(
+        PostAuthRouteService.resolveAfterLogin({
+          userId: "user_gate",
+          phoneVerified: true,
+          enableFirstRunSetupGate: true,
+        })
+      ).resolves.toBe(ROUTES.ONE_ONBOARDING);
+    });
   });
 });

--- a/hushh-webapp/components/onboarding/AuthStep.tsx
+++ b/hushh-webapp/components/onboarding/AuthStep.tsx
@@ -139,6 +139,7 @@ export function AuthStep({
           redirectPath,
           idToken: resolvedIdToken,
           phoneNumber,
+          enableFirstRunSetupGate: true,
         });
 
         const resumeImportFlow =

--- a/hushh-webapp/components/onboarding/setup/one-setup-hub.tsx
+++ b/hushh-webapp/components/onboarding/setup/one-setup-hub.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { useRouter } from "next/navigation";
 import { Sparkles, type LucideIcon } from "lucide-react";
 
 import {
@@ -9,7 +10,11 @@ import {
   AppPageShell,
 } from "@/components/app-ui/app-page-shell";
 import { PageHeader } from "@/components/app-ui/page-sections";
+import { Button } from "@/components/ui/button";
 import { CapabilitySetupTile } from "@/components/onboarding/setup/capability-setup-tile";
+import { useAuth } from "@/lib/firebase/auth-context";
+import { ROUTES } from "@/lib/navigation/routes";
+import { OneSetupGateService } from "@/lib/services/one-setup-gate-service";
 import {
   CAPABILITY_SETUP_COPY,
   type CapabilitySetupCopy,
@@ -42,10 +47,19 @@ import { cn } from "@/lib/utils";
  * - One owns the voice: "Set up One", plain language, no system nouns.
  */
 export function OneSetupHub() {
+  const router = useRouter();
+  const { user } = useAuth();
   const { byId, isLoading } = useCapabilitySetupStates({
     enrichVault: true,
     enrichOauth: true,
   });
+
+  const handleNotNow = () => {
+    if (user?.uid) {
+      OneSetupGateService.markSeen(user.uid);
+    }
+    router.push(ROUTES.ONE_HOME);
+  };
 
   const items = useMemo(() => buildSetupItems(byId), [byId]);
 
@@ -79,6 +93,17 @@ export function OneSetupHub() {
           description={summary}
           icon={Sparkles}
           accent="neutral"
+          actions={
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={handleNotNow}
+              data-testid="one-setup-not-now"
+            >
+              Not now
+            </Button>
+          }
         />
       </AppPageHeaderRegion>
 

--- a/hushh-webapp/lib/services/one-setup-gate-service.ts
+++ b/hushh-webapp/lib/services/one-setup-gate-service.ts
@@ -1,0 +1,64 @@
+"use client";
+
+/**
+ * Soft, client-side "show once" gate for the One Setup hub.
+ *
+ * This is intentionally a localStorage flag (v1) so it requires no backend
+ * schema change. It only governs a one-time, dismissible nudge into
+ * `/one/setup` on the user's first organic login; it never blocks access and
+ * degrades to "already seen" whenever storage is unavailable (fail-open for
+ * navigation, so a storage error can never trap a user on the setup route).
+ */
+
+const STORAGE_PREFIX = "hushh.one_setup_seen.";
+
+function storageKey(userId: string): string {
+  return `${STORAGE_PREFIX}${userId}`;
+}
+
+function safeStorage(): Storage | null {
+  try {
+    if (typeof window === "undefined") return null;
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export class OneSetupGateService {
+  /** Whether the user has already seen (completed or dismissed) the setup nudge. */
+  static hasSeen(userId: string): boolean {
+    if (!userId) return true;
+    const store = safeStorage();
+    if (!store) return true; // fail-open: never strand a user on setup
+    try {
+      return store.getItem(storageKey(userId)) !== null;
+    } catch {
+      return true;
+    }
+  }
+
+  /** Mark the setup nudge as seen so it is not shown again. */
+  static markSeen(userId: string): void {
+    if (!userId) return;
+    const store = safeStorage();
+    if (!store) return;
+    try {
+      store.setItem(storageKey(userId), String(Date.now()));
+    } catch {
+      // best-effort; ignore quota/availability errors
+    }
+  }
+
+  /** Clear the seen flag (primarily for tests and account reset flows). */
+  static reset(userId: string): void {
+    if (!userId) return;
+    const store = safeStorage();
+    if (!store) return;
+    try {
+      store.removeItem(storageKey(userId));
+    } catch {
+      // ignore
+    }
+  }
+}

--- a/hushh-webapp/lib/services/post-auth-route-service.ts
+++ b/hushh-webapp/lib/services/post-auth-route-service.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { OneSetupGateService } from "@/lib/services/one-setup-gate-service";
 import { PreVaultOnboardingService } from "@/lib/services/pre-vault-onboarding-service";
 import { PreVaultUserStateService } from "@/lib/services/pre-vault-user-state-service";
 import { RiaService } from "@/lib/services/ria-service";
@@ -54,6 +55,26 @@ function inviteRedirectTargetFor(path: string): string | null {
 }
 
 export class PostAuthRouteService {
+  /**
+   * Apply the soft first-run One Setup gate to a home-bound destination.
+   *
+   * Returns `ROUTES.ONE_SETUP` only when the caller opted in, the login is
+   * organic (no explicit redirect target), and the user has not yet seen the
+   * one-time setup nudge. Otherwise returns the original home route unchanged,
+   * so existing post-auth behavior is preserved for every other path.
+   */
+  private static applyFirstRunSetupGate(params: {
+    userId: string;
+    homeRoute: string;
+    enableFirstRunSetupGate?: boolean;
+    hasExplicitRedirect: boolean;
+  }): string {
+    if (!params.enableFirstRunSetupGate) return params.homeRoute;
+    if (params.hasExplicitRedirect) return params.homeRoute;
+    if (OneSetupGateService.hasSeen(params.userId)) return params.homeRoute;
+    return ROUTES.ONE_SETUP;
+  }
+
   static async resolveAfterLogin(params: {
     userId: string;
     redirectPath?: string;
@@ -61,7 +82,9 @@ export class PostAuthRouteService {
     phoneNumber?: string | null;
     phoneVerified?: boolean | null;
     hostname?: string | null;
+    enableFirstRunSetupGate?: boolean;
   }): Promise<string> {
+    const hasExplicitRedirect = Boolean(params.redirectPath && params.redirectPath.trim());
     const fallbackRoute = normalizeRedirectPath(params.redirectPath);
     const remoteState = await PreVaultUserStateService.bootstrapState(params.userId);
     const canOverrideWithPersona =
@@ -116,6 +139,14 @@ export class PostAuthRouteService {
       ) {
         return buildPhoneMandateRoute(fallbackRoute);
       }
+      if (onboardingResolved && fallbackRoute === DEFAULT_HOME_ROUTE) {
+        return PostAuthRouteService.applyFirstRunSetupGate({
+          userId: params.userId,
+          homeRoute: fallbackRoute,
+          enableFirstRunSetupGate: params.enableFirstRunSetupGate,
+          hasExplicitRedirect,
+        });
+      }
       return fallbackRoute;
     }
 
@@ -168,6 +199,15 @@ export class PostAuthRouteService {
       })
     ) {
       return buildPhoneMandateRoute(inviteRedirectTarget ?? resolvedNoVaultRoute);
+    }
+
+    if (resolvedNoVaultRoute === NO_VAULT_DEFAULT_ROUTE) {
+      return PostAuthRouteService.applyFirstRunSetupGate({
+        userId: params.userId,
+        homeRoute: resolvedNoVaultRoute,
+        enableFirstRunSetupGate: params.enableFirstRunSetupGate,
+        hasExplicitRedirect,
+      });
     }
 
     return resolvedNoVaultRoute;


### PR DESCRIPTION
## Epic 5 - soft first-run onboarding gate

Adds a one-time, dismissible nudge into /one/setup on a user's first organic login. It never blocks access and preserves every existing post-auth ONE_HOME outcome.

- `one-setup-gate-service`: client-side localStorage 'show once' flag; fail-open (a storage error can never strand a user on /one/setup)
- `post-auth-route-service`: new opt-in `enableFirstRunSetupGate` param + `applyFirstRunSetupGate` helper. Gates the ONE_HOME exits (vault + no-vault branches) to ONE_SETUP only when ALL hold: opted-in, organic login (no explicit redirect), onboarding resolved, gate unseen. Existing callers/tests don't opt in, so behavior is unchanged.
- `AuthStep`: opts the primary organic sign-in into the gate
- `OneSetupHub`: adds a 'Not now' control that marks the gate seen and returns to /one

## Validation
- post-auth-route-service.test.ts: 23 passed (17 existing unchanged + 6 new gate cases)
- typecheck clean, eslint --max-warnings=0 clean, verify:design-system passed