### PR TITLE
test(portfolio-metrics-card): assert metric value fallback

### DIFF
--- a/hushh-webapp/__tests__/components/portfolio-metrics-card.test.tsx
+++ b/hushh-webapp/__tests__/components/portfolio-metrics-card.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PortfolioMetricsCard } from "@/components/kai/cards/portfolio-metrics-card";
+
+describe("PortfolioMetricsCard", () => {
+  it("renders metric value fallback when cost basis is missing", () => {
+    render(
+      <PortfolioMetricsCard
+        totalValue={1000}
+        holdings={[
+          {
+            symbol: "AAPL",
+            name: "Apple Inc.",
+            market_value: 1000,
+            sector: "Technology",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Cost Basis")).toBeTruthy();
+    expect(screen.getByText("$0")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for PortfolioMetricsCard metric value fallback rendering.
- Assert missing cost basis data renders the existing $0 Cost Basis metric fallback.

## Why
This protects the metrics card display when holdings omit optional cost basis values.

## PR Base Policy
- Base branch: integration/pr-train.
- Branch was created directly from the fetched integration/pr-train head before this commit.

## No Overlap Proof
- Files changed: hushh-webapp/__tests__/components/portfolio-metrics-card.test.tsx only.
- This PR adds one focused PortfolioMetricsCard component test for metric value fallback rendering.
- No production files are changed.

## Validation
- npm.cmd test -- __tests__/components/portfolio-metrics-card.test.tsx

## DCO
- Commit includes Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>.