### PR TITLE
test(utils): characterize formatCompleteJson on inherited prototype fields

### DIFF
--- a/hushh-webapp/__tests__/utils/format-json-inheritance.test.ts
+++ b/hushh-webapp/__tests__/utils/format-json-inheritance.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCompleteJson } from "@/lib/utils/json-to-human";
+
+// Characterization tests for formatCompleteJson
+// (hushh-webapp/lib/utils/json-to-human.ts) focused on how it treats properties
+// that live on the PROTOTYPE CHAIN rather than directly on the object.
+//
+// TRUTH-FIRST — LITERAL CONTRACT: formatCompleteJson's top-level walk is exactly
+//   `for (const [sectionKey, sectionValue] of Object.entries(json)) { ... }`.
+// `Object.entries` enumerates ONLY the object's OWN ENUMERABLE string-keyed
+// properties. Therefore:
+//   1. inherited enumerable properties (set on a prototype) are NOT serialized,
+//   2. own NON-enumerable properties are NOT serialized,
+//   3. only OWN ENUMERABLE properties are serialized.
+// These tests pin that literal boundary — they do NOT claim any extra filtering
+// beyond what `Object.entries` itself provides.
+
+describe("formatCompleteJson — prototype-inherited field boundary", () => {
+  it("excludes an enumerable property inherited via prototype", () => {
+    const proto = { inherited_field: "from-proto" };
+    const obj = Object.create(proto) as Record<string, unknown>;
+    obj.own_field = "from-own";
+
+    const out = formatCompleteJson(obj);
+    expect(out).toBe("Own Field: from-own");
+    expect(out).not.toContain("inherited_field");
+    expect(out).not.toContain("from-proto");
+    expect(out).not.toContain("Inherited Field");
+  });
+
+  it("excludes own NON-enumerable properties (Object.entries skips them)", () => {
+    const obj: Record<string, unknown> = { visible: "yes" };
+    Object.defineProperty(obj, "hidden", {
+      value: "no",
+      enumerable: false,
+    });
+
+    const out = formatCompleteJson(obj);
+    expect(out).toBe("Visible: yes");
+    expect(out).not.toContain("hidden");
+    expect(out).not.toContain("Hidden");
+  });
+
+  it("serializes ONLY own enumerable keys, in own-key order", () => {
+    const proto = { a: 1 };
+    const obj = Object.create(proto) as Record<string, unknown>;
+    obj.b = 2;
+    obj.c = 3;
+
+    const out = formatCompleteJson(obj);
+    // `a` is inherited → excluded; only own `b`, `c` appear, in insertion order.
+    expect(out).toBe("B: 2\nC: 3");
+  });
+
+  it("produces empty output when every property is inherited (no own keys)", () => {
+    const proto = { only_inherited: "x" };
+    const obj = Object.create(proto) as Record<string, unknown>;
+
+    const out = formatCompleteJson(obj);
+    expect(out).toBe("");
+  });
+
+  it("an own property shadowing an inherited key serializes the OWN value only", () => {
+    const proto = { status: "inherited-status" };
+    const obj = Object.create(proto) as Record<string, unknown>;
+    obj.status = "own-status";
+
+    const out = formatCompleteJson(obj);
+    expect(out).toBe("Status: own-status");
+    expect(out).not.toContain("inherited-status");
+  });
+});


### PR DESCRIPTION
## Summary

Adds an isolated characterization test for `formatCompleteJson`
(`hushh-webapp/lib/utils/json-to-human.ts`) pinning its exact behavior when the
input object carries properties on its prototype chain. Test-only; no production
change.

## Literal code assertion being made

`formatCompleteJson`'s top-level walk is literally:

```ts
for (const [sectionKey, sectionValue] of Object.entries(json)) { ... }
```

`Object.entries` enumerates ONLY an object's **own enumerable** string-keyed
properties. The tests pin exactly that boundary — nothing more:

- An enumerable property set on a **prototype** is NOT serialized
  → `Object.create({ inherited_field }) + own_field` ⇒ output is `"Own Field: from-own"` only.
- An **own non-enumerable** property (via `Object.defineProperty(..., { enumerable: false })`)
  is NOT serialized → `{ visible }` + non-enum `hidden` ⇒ `"Visible: yes"`.
- Only **own enumerable** keys are serialized, in own-key insertion order
  → proto `{ a }` + own `b, c` ⇒ `"B: 2\nC: 3"`.
- An object whose properties are ALL inherited (zero own keys) ⇒ `""` (empty string).
- An own key that **shadows** an inherited key serializes the OWN value only
  → proto `status: inherited-status` + own `status: own-status` ⇒ `"Status: own-status"`.

These are characterization assertions of the existing `Object.entries` boundary;
they do NOT claim any additional prototype/non-enumerable filtering logic beyond
what `Object.entries` itself provides.

## Truth-first scope note

The original task referenced `hushh-research/__tests__/utils/...`. There is no
top-level `__tests__` in this repo; vitest only includes `__tests__/**` under
`hushh-webapp`, so the file lives at
`hushh-webapp/__tests__/utils/format-json-inheritance.test.ts`.

## Verification

- `npm test -- __tests__/utils/format-json-inheritance.test.ts` → 5/5 pass
- `git status` limited to the single new test file; zero production source drift
- (An IDE-only `@/` module-resolution warning is a false positive — the alias
  resolves under vitest, as the passing run confirms.)

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — documents the real `Object.entries` own-enumerable-only
  boundary; no un-implemented generalizations
