### PR TITLE
test(profile-based-picks-list): assert empty picks state

### DIFF
--- a/hushh-webapp/__tests__/components/profile-based-picks-list.test.tsx
+++ b/hushh-webapp/__tests__/components/profile-based-picks-list.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ProfileBasedPicksList } from "@/components/kai/cards/profile-based-picks-list";
+
+describe("ProfileBasedPicksList", () => {
+  it("renders empty picks state", async () => {
+    render(
+      <ProfileBasedPicksList
+        userId="user-1"
+        vaultOwnerToken="token-1"
+        symbols={[]}
+        onAdd={vi.fn()}
+      />,
+    );
+
+    expect(
+      await screen.findByText("No profile picks available from current market context."),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for ProfileBasedPicksList empty picks rendering.
- Assert the no-profile-picks message appears when current market context has no symbols.

## Why
This protects the empty-state copy shown when personalized profile picks are unavailable from the current context.

## PR Base Policy
- Base branch: integration/pr-train.
- Branch was created directly from the fetched integration/pr-train head before this commit.

## No Overlap Proof
- Files changed: hushh-webapp/__tests__/components/profile-based-picks-list.test.tsx only.
- This PR adds one focused ProfileBasedPicksList component test for empty picks state rendering.
- No production files are changed.

## Validation
- npm.cmd test -- __tests__/components/profile-based-picks-list.test.tsx

## DCO
- Commit includes Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>.