### PR TITLE
test(navigation): characterize normalizeInternalRouteHref multi-segment hash query chains

### DIFF
--- a/hushh-webapp/__tests__/navigation/normalize-hash-queries.test.ts
+++ b/hushh-webapp/__tests__/navigation/normalize-hash-queries.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for normalizeInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts) focused on hrefs that place the query
+// string AFTER the hash fragment (e.g. "/profile#settings?theme=dark").
+//
+// TRUTH-FIRST — LITERAL CONTRACT: normalizeInternalRouteHref is an OPAQUE
+// allow-list guard, not a URL parser. Its full body is:
+//   const href = String(value ?? "").trim();
+//   if (!href) return null;
+//   if (!href.startsWith("/") || href.startsWith("//")) return null;
+//   if (/[\r\n]/.test(href)) return null;
+//   return href;
+// It has ZERO awareness of `#` or `?`. It does NOT split, reorder, re-encode, or
+// canonicalize hash vs. query segments. So for any same-origin path-rooted href,
+// whatever trailing `#...?...` layout is supplied is preserved BYTE-FOR-BYTE
+// (after a leading/trailing whitespace trim). The only rejections are: empty,
+// not starting with "/", protocol-relative "//", or containing CR/LF.
+
+describe("normalizeInternalRouteHref — hash-then-query chains", () => {
+  it("preserves a query placed after the hash byte-for-byte", () => {
+    const href = "/profile#settings?theme=dark&status=active";
+    expect(normalizeInternalRouteHref(href)).toBe(href);
+  });
+
+  it("does NOT reorder hash and query (no canonicalization)", () => {
+    // A real URL parser would treat `?...` after `#` as part of the fragment.
+    // This guard performs no such parsing — the exact string survives.
+    const href = "/dashboard#tab=reports?sort=desc&page=2";
+    const out = normalizeInternalRouteHref(href);
+    expect(out).toBe(href);
+    expect(out).toContain("#tab=reports?sort=desc");
+  });
+
+  it("preserves multiple '?' and '#' characters in the trailing chain", () => {
+    const href = "/a#x?b=1?c=2#y&d=3";
+    expect(normalizeInternalRouteHref(href)).toBe(href);
+  });
+
+  it("does not re-encode special characters in the hash/query chain", () => {
+    const href = "/search#q=a b&list=[1,2]?flag=true%20";
+    expect(normalizeInternalRouteHref(href)).toBe(href);
+  });
+
+  it("trims surrounding whitespace but keeps the inner hash/query layout intact", () => {
+    const href = "  /profile#settings?theme=dark  ";
+    expect(normalizeInternalRouteHref(href)).toBe("/profile#settings?theme=dark");
+  });
+
+  it("rejects protocol-relative href even when it carries a hash+query chain", () => {
+    expect(
+      normalizeInternalRouteHref("//evil.example#settings?theme=dark")
+    ).toBeNull();
+  });
+
+  it("rejects an href with a CRLF embedded in the hash+query chain", () => {
+    expect(
+      normalizeInternalRouteHref("/profile#settings?theme=dark\nstatus=active")
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds an isolated characterization test for `normalizeInternalRouteHref`
(`hushh-webapp/lib/navigation/routes.ts`) documenting how the path guard behaves
when an href places the query string AFTER the hash fragment
(e.g. `/profile#settings?theme=dark&status=active`). Test-only; no production
change.

## Literal contract being characterized

`normalizeInternalRouteHref` is an **opaque allow-list guard, not a URL parser**.
Its full body is:

```ts
const href = String(value ?? "").trim();
if (!href) return null;
if (!href.startsWith("/") || href.startsWith("//")) return null;
if (/[\r\n]/.test(href)) return null;
return href;
```

It has **zero awareness of `#` or `?`** — it never splits, reorders, re-encodes,
or canonicalizes hash vs. query segments. Therefore, for any path-rooted
same-origin href, whatever trailing `#...?...` layout is supplied is preserved
**byte-for-byte** after a leading/trailing whitespace trim. The only rejections
are: empty, not starting with `/`, protocol-relative `//`, or containing CR/LF.

## Behavior pinned (7 cases)

- `/profile#settings?theme=dark&status=active` → returned unchanged
- `/dashboard#tab=reports?sort=desc&page=2` → NOT reordered; `#tab=reports?sort=desc` survives
- `/a#x?b=1?c=2#y&d=3` (multiple `?`/`#`) → returned unchanged
- `/search#q=a b&list=[1,2]?flag=true%20` (special chars) → NOT re-encoded
- `  /profile#settings?theme=dark  ` → trimmed to `/profile#settings?theme=dark`, inner layout intact
- `//evil.example#settings?theme=dark` → `null` (protocol-relative rejected)
- `/profile#settings?theme=dark\nstatus=active` → `null` (CRLF rejected)

## Truth-first scope note

The original task referenced `hushh-research/__tests__/navigation/...` and an
import from `lib/navigation/routes.ts`. There is no top-level `__tests__` in this
repo; vitest only includes `__tests__/**` under `hushh-webapp`, and the in-repo
alias for that module is `@/lib/navigation/routes`. The file therefore lives at
`hushh-webapp/__tests__/navigation/normalize-hash-queries.test.ts` and imports
via `@/lib/navigation/routes`.

## Verification

- `npm test -- __tests__/navigation/normalize-hash-queries.test.ts` → 7/7 pass
- `git status` limited to the single new test file; zero production source drift
- (An IDE-only `@/` module-resolution warning is a false positive — the alias
  resolves under vitest, as the passing run confirms.)

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — documents the real opaque-passthrough boundary
  (no hash/query parsing, reordering, or re-encoding); no un-implemented
  generalizations
