### PR TITLE
test(projections-card): assert unavailable projection fallback

### DIFF
--- a/hushh-webapp/__tests__/components/projections-card.test.tsx
+++ b/hushh-webapp/__tests__/components/projections-card.test.tsx
@@ -1,0 +1,12 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ProjectionsCard } from "@/components/kai/cards/projections-card";
+
+describe("ProjectionsCard", () => {
+  it("renders unavailable projection fallback", () => {
+    const { container } = render(<ProjectionsCard projections={{}} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for ProjectionsCard unavailable projection fallback rendering.
- Assert the card renders nothing when cash-flow projections and RMD estimates are unavailable.

## Why
This protects the existing empty fallback contract for unavailable projection data.

## PR Base Policy
- Base branch: integration/pr-train.
- Branch was created directly from the fetched integration/pr-train head before this commit.

## No Overlap Proof
- Files changed: hushh-webapp/__tests__/components/projections-card.test.tsx only.
- This PR adds one focused ProjectionsCard component test for unavailable projection fallback rendering.
- No production files are changed.

## Validation
- npm.cmd test -- __tests__/components/projections-card.test.tsx

## DCO
- Commit includes Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>.