### PR TITLE
test(spotlight-card): assert card title semantics

### DIFF
--- a/hushh-webapp/__tests__/components/spotlight-card.test.tsx
+++ b/hushh-webapp/__tests__/components/spotlight-card.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { SpotlightCard } from "@/components/kai/cards/spotlight-card";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
+describe("SpotlightCard", () => {
+  it("renders card title with heading semantics", () => {
+    render(
+      <SpotlightCard
+        symbol="NVDA"
+        companyName="Nvidia"
+        title="AI infrastructure momentum"
+        price="$900.00"
+        decision="WATCH"
+        summary="Demand remains durable across accelerated compute workloads."
+        context="Renaissance market spotlight"
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", {
+        level: 3,
+        name: "AI infrastructure momentum",
+      }),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for SpotlightCard title semantics.
- Assert the rendered card title is exposed as a level-3 heading.

## Why
This protects the spotlight card heading contract used by assistive technology and document navigation.

## PR Base Policy
- Base branch: integration/pr-train.
- Branch was created directly from the fetched integration/pr-train head before this commit.

## No Overlap Proof
- Files changed: hushh-webapp/__tests__/components/spotlight-card.test.tsx only.
- This PR adds one focused SpotlightCard component test for card title semantics.
- No production files are changed.

## Validation
- npm.cmd test -- __tests__/components/spotlight-card.test.tsx

## DCO
- Commit includes Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>.