### PR TITLE
test(navigation): characterize resolveInternalRouteHref parameter string boolean arrays

### DIFF
--- a/hushh-webapp/__tests__/navigation/resolve-boolean-arrays.test.ts
+++ b/hushh-webapp/__tests__/navigation/resolve-boolean-arrays.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for resolveInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts) focused on hrefs whose query string
+// carries repeated/array-style boolean params (e.g. "?flags=true&flags=false").
+//
+// TRUTH-FIRST — IMPORTANT CORRECTION: the premise that this utility runs an
+// "extraction process" that "isolates and registers" array boolean fields is
+// FALSE. `resolveInternalRouteHref` performs NO query parsing whatsoever. Its
+// full body is literally:
+//   return normalizeInternalRouteHref(value) ?? fallback;
+// and `normalizeInternalRouteHref` is an opaque allow-list guard:
+//   const href = String(value ?? "").trim();
+//   if (!href) return null;
+//   if (!href.startsWith("/") || href.startsWith("//")) return null;
+//   if (/[\r\n]/.test(href)) return null;
+//   return href;
+// So there is NO URLSearchParams, NO de-duplication, NO boolean coercion, NO
+// array registration. A valid same-origin href is returned VERBATIM (after a
+// whitespace trim), repeated `flags=...` pairs intact and in original order. An
+// invalid href short-circuits to the provided `fallback`. These tests pin that
+// real contract — not any imagined param extraction.
+
+const FALLBACK = "/home";
+
+describe("resolveInternalRouteHref — array-style boolean query params", () => {
+  it("returns the href verbatim, preserving repeated boolean params in order", () => {
+    const href = "/api/v1?flags=true&flags=false";
+    expect(resolveInternalRouteHref(href, FALLBACK)).toBe(href);
+  });
+
+  it("does NOT de-duplicate, coerce, or collapse repeated boolean values", () => {
+    const href = "/settings?on=true&on=true&on=false&off=false";
+    const out = resolveInternalRouteHref(href, FALLBACK);
+    expect(out).toBe(href);
+    // All four occurrences survive — no Set/Map/boolean folding.
+    expect((out.match(/on=true/g) ?? []).length).toBe(2);
+    expect(out).toContain("on=false");
+    expect(out).toContain("off=false");
+  });
+
+  it("preserves explicit bracketed array syntax untouched", () => {
+    const href = "/api/v1?flags[]=true&flags[]=false";
+    expect(resolveInternalRouteHref(href, FALLBACK)).toBe(href);
+  });
+
+  it("does not boolean-coerce param values (string 'true'/'false' kept as-is)", () => {
+    const href = "/x?a=TRUE&b=False&c=1&d=0";
+    expect(resolveInternalRouteHref(href, FALLBACK)).toBe(href);
+  });
+
+  it("falls back when the href is protocol-relative, even with boolean arrays", () => {
+    expect(
+      resolveInternalRouteHref("//evil.example?flags=true&flags=false", FALLBACK)
+    ).toBe(FALLBACK);
+  });
+
+  it("falls back on empty/nullish input regardless of intended params", () => {
+    expect(resolveInternalRouteHref("", FALLBACK)).toBe(FALLBACK);
+    expect(resolveInternalRouteHref(null, FALLBACK)).toBe(FALLBACK);
+    expect(resolveInternalRouteHref(undefined, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it("falls back when a CRLF is embedded in the boolean query chain", () => {
+    expect(
+      resolveInternalRouteHref("/api/v1?flags=true\n&flags=false", FALLBACK)
+    ).toBe(FALLBACK);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an isolated characterization test for `resolveInternalRouteHref`
(`hushh-webapp/lib/navigation/routes.ts`) documenting its exact behavior when an
href's query string carries repeated / array-style boolean params
(e.g. `/api/v1?flags=true&flags=false`). Test-only; no production change.

## Truth-first correction to the premise

The task framed this as a "parameter extraction process" that "isolates and
registers" array boolean fields. **That premise is false** —
`resolveInternalRouteHref` does **no query parsing at all**. Its full body is:

```ts
return normalizeInternalRouteHref(value) ?? fallback;
```

and `normalizeInternalRouteHref` is an opaque allow-list guard:

```ts
const href = String(value ?? "").trim();
if (!href) return null;
if (!href.startsWith("/") || href.startsWith("//")) return null;
if (/[\r\n]/.test(href)) return null;
return href;
```

There is **no `URLSearchParams`, no de-duplication, no boolean coercion, no array
registration**. A valid same-origin href is returned **verbatim** (after a
whitespace trim); an invalid one short-circuits to the supplied `fallback`. The
tests pin that real contract instead of an imagined parser.

## Behavior pinned (7 cases, fallback = `/home`)

- `/api/v1?flags=true&flags=false` → returned unchanged (repeated params kept, in order)
- `/settings?on=true&on=true&on=false&off=false` → unchanged; all 4 pairs survive (no folding)
- `/api/v1?flags[]=true&flags[]=false` → bracket array syntax preserved untouched
- `/x?a=TRUE&b=False&c=1&d=0` → no boolean coercion; values kept as raw strings
- `//evil.example?flags=true&flags=false` → `/home` (protocol-relative → fallback)
- `""` / `null` / `undefined` → `/home` (empty/nullish → fallback)
- `/api/v1?flags=true\n&flags=false` → `/home` (CRLF → fallback)

## Truth-first scope note

The original task referenced `hushh-research/__tests__/navigation/...`, an import
from `lib/navigation/routes.ts`, and `npm test -- hushh-research/...`. There is no
top-level `__tests__` in this repo; vitest only includes `__tests__/**` under
`hushh-webapp`, and the module's in-repo alias is `@/lib/navigation/routes`. The
file therefore lives at
`hushh-webapp/__tests__/navigation/resolve-boolean-arrays.test.ts`.

## Verification

- `npm test -- __tests__/navigation/resolve-boolean-arrays.test.ts` → 7/7 pass
- `git status` limited to the single new test file; zero production source drift
- (An IDE-only `@/` module-resolution warning is a false positive — the alias
  resolves under vitest, as the passing run confirms.)

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — corrects the false "param extraction" premise and pins the
  real opaque-passthrough-with-fallback contract; no un-implemented
  generalizations
