### PR TITLE
feat(one): realtime full-duplex voice for One (Epic 4, opt-in)

### DIFF
--- a/consent-protocol/api/routes/kai/agent_realtime.py
+++ b/consent-protocol/api/routes/kai/agent_realtime.py
@@ -31,10 +31,12 @@ _REALTIME_SERVER_VAD_THRESHOLD = 0.72
 _REALTIME_SERVER_VAD_PREFIX_PADDING_MS = 450
 _REALTIME_SERVER_VAD_SILENCE_MS = 800
 _AGENT_REALTIME_INSTRUCTIONS = (
-    "You are Agent, a concise assistant inside Hussh. This demo supports text and "
-    "voice conversation, but has no tools, memory, portfolio access, PKM context, or "
-    "app context yet. Answer plainly and do not claim access to private user data or "
-    "app actions."
+    "You are One, the personal agent inside Hussh. You hold the relationship layer and "
+    "speak warmly and concisely. In this realtime voice conversation you have no tools, "
+    "memory, portfolio access, PKM context, or app actions, so do not claim access to "
+    "private user data or perform app actions. For finance defer to Kai, for privacy and "
+    "consent defer to Nav, and for identity defer to KYC, and let the user know they can "
+    "switch to typed chat for those workflows. Answer plainly in English."
 )
 
 

--- a/consent-protocol/tests/test_agent_realtime_persona.py
+++ b/consent-protocol/tests/test_agent_realtime_persona.py
@@ -1,0 +1,33 @@
+"""Contract tests for the One realtime voice persona.
+
+The realtime voice path (``/agent/realtime/session``) has no tools, memory, or
+app-action loop, so its persona MUST stay honest about that boundary while still
+presenting as One and routing specialist work to Kai/Nav/KYC per the agent
+ontology. These are pure-string assertions so they run without OpenAI or a live
+session.
+"""
+
+from __future__ import annotations
+
+from api.routes.kai.agent_realtime import _AGENT_REALTIME_INSTRUCTIONS
+
+
+def test_realtime_persona_presents_as_one() -> None:
+    assert _AGENT_REALTIME_INSTRUCTIONS.startswith("You are One")
+
+
+def test_realtime_persona_routes_specialists() -> None:
+    instructions = _AGENT_REALTIME_INSTRUCTIONS
+    assert "Kai" in instructions
+    assert "Nav" in instructions
+    assert "KYC" in instructions
+
+
+def test_realtime_persona_does_not_claim_private_data_access() -> None:
+    instructions = _AGENT_REALTIME_INSTRUCTIONS.lower()
+    assert "no tools" in instructions
+    assert "do not claim access to" in instructions
+
+
+def test_realtime_persona_drops_legacy_agent_branding() -> None:
+    assert "You are Agent" not in _AGENT_REALTIME_INSTRUCTIONS

--- a/hushh-webapp/__tests__/lib/agent-voice-settings.test.ts
+++ b/hushh-webapp/__tests__/lib/agent-voice-settings.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_AGENT_GEMINI_TTS_VOICE,
   isAgentGeminiVoiceEnabled,
+  isAgentRealtimeVoiceEnabled,
   normalizeAgentGeminiTtsVoice,
   readAgentVoiceSettings,
   writeAgentVoiceSettings,
@@ -38,5 +39,24 @@ describe("agent voice settings", () => {
 
     vi.stubEnv("NEXT_PUBLIC_AGENT_GEMINI_VOICE_ENABLED", "1");
     expect(isAgentGeminiVoiceEnabled()).toBe(true);
+  });
+
+  it("treats realtime voice as disabled by default and only enables on an explicit opt-in", () => {
+    expect(isAgentRealtimeVoiceEnabled()).toBe(false);
+
+    vi.stubEnv("NEXT_PUBLIC_AGENT_REALTIME_VOICE_ENABLED", "");
+    expect(isAgentRealtimeVoiceEnabled()).toBe(false);
+
+    vi.stubEnv("NEXT_PUBLIC_AGENT_REALTIME_VOICE_ENABLED", "false");
+    expect(isAgentRealtimeVoiceEnabled()).toBe(false);
+
+    vi.stubEnv("NEXT_PUBLIC_AGENT_REALTIME_VOICE_ENABLED", "true");
+    expect(isAgentRealtimeVoiceEnabled()).toBe(true);
+
+    vi.stubEnv("NEXT_PUBLIC_AGENT_REALTIME_VOICE_ENABLED", "1");
+    expect(isAgentRealtimeVoiceEnabled()).toBe(true);
+
+    vi.stubEnv("NEXT_PUBLIC_AGENT_REALTIME_VOICE_ENABLED", "on");
+    expect(isAgentRealtimeVoiceEnabled()).toBe(true);
   });
 });

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -65,6 +65,10 @@ import {
   transcribeAgentVoice,
 } from "@/lib/services/agent-voice-client";
 import {
+  AgentRealtimeClient,
+  type AgentRealtimeVoiceState,
+} from "@/lib/services/agent-realtime-client";
+import {
   useAgentVoiceState,
   type AgentVoiceStatus,
 } from "@/lib/agent/agent-voice-state";
@@ -74,6 +78,7 @@ import {
   AGENT_CONVERSATION_REQUEST_EVENT,
   AGENT_VOICE_SETTINGS_CHANGED_EVENT,
   isAgentGeminiVoiceEnabled,
+  isAgentRealtimeVoiceEnabled,
   readAgentVoiceSettings,
   type AgentGeminiTtsVoice,
 } from "@/lib/agent/agent-voice-settings";
@@ -752,6 +757,10 @@ export function AgentChatWorkspace({
     AppBackgroundTaskService.getState()
   );
   const voiceClientRef = useRef<AgentVoiceClient | null>(null);
+  const realtimeVoiceClientRef = useRef<AgentRealtimeClient | null>(null);
+  const realtimeVoiceActiveRef = useRef(false);
+  const realtimeUserTranscriptIdRef = useRef<string | null>(null);
+  const realtimeAssistantMessageIdRef = useRef<string | null>(null);
   const voiceTtsQueueRef = useRef<AgentTtsQueue | null>(null);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
   const composerTextareaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -778,6 +787,7 @@ export function AgentChatWorkspace({
   const isPkmMemoryWorking = activePkmToolCount > 0;
   const tokenIsFresh = !tokenExpiresAt || Date.now() < tokenExpiresAt;
   const agentVoiceEnabled = isAgentGeminiVoiceEnabled();
+  const agentRealtimeVoiceEnabled = isAgentRealtimeVoiceEnabled();
   const abortAgentTurnWork = useCallback(() => {
     streamAbortControllerRef.current?.abort();
     streamAbortControllerRef.current = null;
@@ -921,7 +931,9 @@ export function AgentChatWorkspace({
     !voiceActive &&
     input.trim().length > 0;
   const canToggleVoice =
-    agentVoiceEnabled && hasChatAccess && (!isVoiceConnecting || voiceActive);
+    (agentRealtimeVoiceEnabled || agentVoiceEnabled) &&
+    hasChatAccess &&
+    (!isVoiceConnecting || voiceActive);
   const historyInteractionDisabled =
     isLoadingHistory ||
     isChatLoading ||
@@ -1022,6 +1034,9 @@ export function AgentChatWorkspace({
       abortAgentTurnWork();
       void voiceClientRef.current?.stop();
       voiceClientRef.current = null;
+      realtimeVoiceActiveRef.current = false;
+      realtimeVoiceClientRef.current?.close();
+      realtimeVoiceClientRef.current = null;
       voiceTtsQueueRef.current?.cancel();
       voiceTtsQueueRef.current = null;
       resetGlobalVoiceState();
@@ -2518,14 +2533,171 @@ export function AgentChatWorkspace({
     }
   };
 
+  // Realtime full-duplex voice for One. Opt-in (NEXT_PUBLIC_AGENT_REALTIME_VOICE_ENABLED)
+  // and fail-closed: when the flag is off we never construct the realtime client and the
+  // conversational-mode control falls back to the turn-based path. Reuses the existing
+  // AgentRealtimeClient adapter over /agent/realtime/session (no new mic/STT/TTS code) and
+  // maps its voice state onto the shared agent voice store so the wave input renders as-is.
+  const mapRealtimeVoiceState = useCallback(
+    (state: AgentRealtimeVoiceState): AgentVoiceStatus => {
+      switch (state) {
+        case "connecting":
+          return "connecting";
+        case "listening":
+          return "listening";
+        case "thinking":
+          return "thinking";
+        case "speaking":
+          return "speaking";
+        case "idle":
+        default:
+          return "idle";
+      }
+    },
+    [],
+  );
+
+  const handleCancelRealtimeVoice = useCallback(async () => {
+    realtimeVoiceActiveRef.current = false;
+    realtimeUserTranscriptIdRef.current = null;
+    realtimeAssistantMessageIdRef.current = null;
+    realtimeVoiceClientRef.current?.close();
+    realtimeVoiceClientRef.current = null;
+    setIsVoiceConnecting(false);
+    setVoiceState("idle");
+    resetGlobalVoiceState();
+  }, [resetGlobalVoiceState]);
+
+  const handleToggleRealtimeVoice = async () => {
+    if (!agentRealtimeVoiceEnabled) {
+      addErrorMessage("Realtime voice is disabled for this environment.");
+      return;
+    }
+    if (!hasChatAccess || !user?.uid) return;
+
+    if (realtimeVoiceActiveRef.current) {
+      await handleCancelRealtimeVoice();
+      return;
+    }
+
+    const token = getVaultOwnerToken();
+    if (!token) {
+      addErrorMessage("Vault access expired. Unlock again to continue.");
+      return;
+    }
+
+    setIsVoiceConnecting(true);
+    setGlobalVoiceActive(true);
+    setAgentVoiceStatus("connecting");
+    realtimeVoiceActiveRef.current = true;
+
+    const client = new AgentRealtimeClient();
+    realtimeVoiceClientRef.current = client;
+
+    try {
+      await client.connect({ userId: user.uid, vaultOwnerToken: token });
+      await client.startMicrophone({
+        onVoiceState: (state) => {
+          if (!realtimeVoiceActiveRef.current) return;
+          if (state !== "connecting") {
+            setIsVoiceConnecting(false);
+          }
+          setAgentVoiceStatus(mapRealtimeVoiceState(state));
+        },
+        onInputTranscriptDelta: (delta) => {
+          if (!realtimeVoiceActiveRef.current || !delta) return;
+          const existingId = realtimeUserTranscriptIdRef.current;
+          if (existingId) {
+            updateMessage(existingId, (message) => ({
+              ...message,
+              text: `${message.text}${delta}`,
+            }));
+            return;
+          }
+          const id = `msg-${Date.now()}-user-voice`;
+          realtimeUserTranscriptIdRef.current = id;
+          appendMessage({
+            id,
+            role: "user",
+            text: delta,
+            timestamp: formatNow(),
+          });
+        },
+        onInputTranscriptDone: (text) => {
+          const existingId = realtimeUserTranscriptIdRef.current;
+          if (existingId && text.trim()) {
+            updateMessage(existingId, (message) => ({ ...message, text }));
+          }
+          realtimeUserTranscriptIdRef.current = null;
+        },
+        onResponseStart: () => {
+          if (!realtimeVoiceActiveRef.current) return;
+          const id = `msg-${Date.now()}-assistant-voice`;
+          realtimeAssistantMessageIdRef.current = id;
+          appendMessage({
+            id,
+            role: "assistant",
+            text: "",
+            timestamp: formatNow(),
+            status: "streaming",
+          });
+        },
+        onResponseDelta: (delta) => {
+          const existingId = realtimeAssistantMessageIdRef.current;
+          if (!existingId || !delta) return;
+          updateMessage(existingId, (message) => ({
+            ...message,
+            text: `${message.text}${delta}`,
+          }));
+        },
+        onResponseDone: (text) => {
+          const existingId = realtimeAssistantMessageIdRef.current;
+          if (existingId) {
+            updateMessage(existingId, (message) => ({
+              ...message,
+              text: text.trim() ? text : message.text,
+              status: "done",
+            }));
+          }
+          realtimeAssistantMessageIdRef.current = null;
+        },
+        onError: (message) => {
+          if (!realtimeVoiceActiveRef.current) return;
+          addErrorMessage(message);
+          setAgentVoiceStatus("error", message);
+          void handleCancelRealtimeVoice();
+        },
+      });
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : "Realtime voice session failed.";
+      addErrorMessage(message);
+      await handleCancelRealtimeVoice();
+    }
+  };
+
   useEffect(() => {
     if (!voiceActive) return;
-    if (agentVoiceEnabled && user?.uid && isVaultUnlocked && vaultOwnerToken && tokenIsFresh) {
+    if (
+      (agentVoiceEnabled || agentRealtimeVoiceEnabled) &&
+      user?.uid &&
+      isVaultUnlocked &&
+      vaultOwnerToken &&
+      tokenIsFresh
+    ) {
+      return;
+    }
+    if (realtimeVoiceActiveRef.current) {
+      void handleCancelRealtimeVoice();
       return;
     }
     void handleCancelVoice();
   }, [
     agentVoiceEnabled,
+    agentRealtimeVoiceEnabled,
+    handleCancelRealtimeVoice,
     handleCancelVoice,
     isVaultUnlocked,
     tokenIsFresh,
@@ -2535,16 +2707,21 @@ export function AgentChatWorkspace({
   ]);
 
   // Keep a live reference to the latest voice toggle so the conversation-request
-  // listener (registered once) always invokes the current handler.
-  const handleToggleVoiceRef = useRef(handleToggleVoice);
-  handleToggleVoiceRef.current = handleToggleVoice;
+  // listener (registered once) always invokes the current handler. When realtime
+  // voice is enabled the conversational-mode control prefers the realtime path;
+  // otherwise it falls back to the turn-based toggle (fail-closed default).
+  const startConversationalVoice = () =>
+    agentRealtimeVoiceEnabled ? handleToggleRealtimeVoice() : handleToggleVoice();
+  const handleToggleVoiceRef = useRef(startConversationalVoice);
+  handleToggleVoiceRef.current = startConversationalVoice;
 
   // The agent bar's conversational-mode control dispatches a request event after
   // opening the surface. Auto-start a voice turn once the workspace is ready and
   // not already in a voice session. Honors the same access gates as the in-chat
   // voice button (vault unlock, fresh token, voice feature flag).
+  const conversationVoiceEnabled = agentRealtimeVoiceEnabled || agentVoiceEnabled;
   const conversationReady =
-    agentVoiceEnabled && hasChatAccess && !voiceActive && !isVoiceConnecting;
+    conversationVoiceEnabled && hasChatAccess && !voiceActive && !isVoiceConnecting;
   const conversationReadyRef = useRef(conversationReady);
   conversationReadyRef.current = conversationReady;
   const pendingConversationRequestRef = useRef(false);
@@ -2970,8 +3147,18 @@ export function AgentChatWorkspace({
                     level={voiceLevel}
                     muted={voiceMuted}
                     disabled={!hasChatAccess || isVoiceConnecting}
-                    onToggleMute={handleToggleVoice}
+                    onToggleMute={
+                      realtimeVoiceActiveRef.current
+                        ? () => {
+                            void handleCancelRealtimeVoice();
+                          }
+                        : handleToggleVoice
+                    }
                     onCancel={() => {
+                      if (realtimeVoiceActiveRef.current) {
+                        void handleCancelRealtimeVoice();
+                        return;
+                      }
                       void handleCancelVoice();
                     }}
                   />
@@ -2997,14 +3184,16 @@ export function AgentChatWorkspace({
                     rows={1}
                     className="max-h-40 min-h-8 min-w-0 flex-1 resize-none bg-transparent px-1 py-2 text-sm leading-6 text-[#1d1d1f] outline-none placeholder:text-[rgba(0,0,0,0.42)] disabled:cursor-not-allowed disabled:opacity-60 dark:text-zinc-100 dark:placeholder:text-zinc-500"
                   />
-                  {agentVoiceEnabled ? (
+                  {agentRealtimeVoiceEnabled || agentVoiceEnabled ? (
                     <Button
                       type="button"
                       variant="ghost"
                       size="icon"
                       className="h-9 w-9 shrink-0 rounded-xl text-[rgba(0,0,0,0.50)] hover:bg-black/[0.04] hover:text-[#1d1d1f] focus-visible:ring-2 focus-visible:ring-primary/60 dark:text-zinc-400 dark:hover:bg-white/[0.07] dark:hover:text-zinc-100"
                       disabled={!canToggleVoice}
-                      onClick={handleToggleVoice}
+                      onClick={() => {
+                        void startConversationalVoice();
+                      }}
                       aria-label="Start voice mode"
                       title="Start voice mode"
                     >

--- a/hushh-webapp/lib/agent/agent-voice-settings.ts
+++ b/hushh-webapp/lib/agent/agent-voice-settings.ts
@@ -94,3 +94,21 @@ export function isAgentGeminiVoiceEnabled(): boolean {
   }
   return !DISABLED_FLAG_VALUES.has(String(configured).trim().toLowerCase());
 }
+
+const ENABLED_FLAG_VALUES = new Set(["1", "true", "on", "enabled", "yes"]);
+
+/**
+ * Realtime full-duplex voice for One. Opt-in and fail-closed: defaults to OFF so
+ * the agent surface keeps its turn-based voice path unless an operator explicitly
+ * enables realtime via NEXT_PUBLIC_AGENT_REALTIME_VOICE_ENABLED. When OFF, the
+ * conversational-mode control falls back to the existing turn-based flow.
+ */
+export function isAgentRealtimeVoiceEnabled(): boolean {
+  const configured =
+    process.env.NEXT_PUBLIC_AGENT_REALTIME_VOICE_ENABLED ??
+    process.env.AGENT_REALTIME_VOICE_ENABLED;
+  if (configured === undefined || configured === null || String(configured).trim() === "") {
+    return false;
+  }
+  return ENABLED_FLAG_VALUES.has(String(configured).trim().toLowerCase());
+}


### PR DESCRIPTION
## Epic 4 - realtime voice for One

Surfaces realtime full-duplex voice for the One agent by **reusing the existing** `AgentRealtimeClient` adapter over `/agent/realtime/session`. **No new microphone, STT, or TTS path** is introduced; mic + STT + TTS all stay inside the existing OpenAI WebRTC peer connection, satisfying the voice-governance runtime-boundary rule (adapter over existing runtime, not a parallel voice system).

### Changes
- `agent-voice-settings`: `isAgentRealtimeVoiceEnabled()` - opt-in, fail-closed, default OFF via `NEXT_PUBLIC_AGENT_REALTIME_VOICE_ENABLED`.
- `agent-chat-workspace`: wire `AgentRealtimeClient` connect + mic; map realtime voice state onto the shared agent voice store so `AgentVoiceWaveInput` renders unchanged; append realtime user/assistant transcripts to chat; route the conversational-mode control + mic button to realtime when enabled (else fall back to the turn-based Gemini path); full teardown on cancel/unmount/access-loss.
- `agent_realtime.py`: rebrand the realtime persona from 'Agent' to **One**, keep the honest no-tools/no-private-data boundary, and route finance->Kai / privacy->Nav / identity->KYC per the agent ontology.
- tests: realtime flag (default-off + opt-in matrix) and One persona contract.

### Fail-closed guarantees
- Flag default OFF -> behavior is identical to today (realtime client never constructed).
- `/agent/realtime/session` already returns 503 when `OPENAI_API_KEY` is missing; the toggle handler surfaces the error and tears down rather than silently degrading.
- `require_vault_owner_token` + `user_id` match enforce auth at the endpoint.

### Validation
- typecheck + eslint --max-warnings=0 clean
- agent-voice-settings: 5 tests; agent realtime persona: 4 tests
- kai voice contract: 68 tests; build:voice-gateway + verify:voice-gateway up to date (no contract drift)
- kai-search-bar + voice-realtime-client: 20 tests unchanged

No edits to `lib/voice/*`, the generated voice action manifest, or kai-search-bar.