### PR TITLE
test(theme-focus-list): assert empty themes fallback

### DIFF
--- a/hushh-webapp/__tests__/components/theme-focus-list.test.tsx
+++ b/hushh-webapp/__tests__/components/theme-focus-list.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ThemeFocusList } from "@/components/kai/cards/theme-focus-list";
+
+describe("ThemeFocusList", () => {
+  it("renders empty themes fallback", () => {
+    render(<ThemeFocusList themes={[]} />);
+
+    expect(
+      screen.getByText("No active market themes are available right now."),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for ThemeFocusList empty themes fallback rendering.
- Assert the no-active-themes message appears when the theme list is empty.

## Why
This protects the existing empty-state copy for market themes when no theme data is available.

## PR Base Policy
- Base branch: integration/pr-train.
- Branch was created directly from the fetched integration/pr-train head before this commit.

## No Overlap Proof
- Files changed: hushh-webapp/__tests__/components/theme-focus-list.test.tsx only.
- This PR adds one focused ThemeFocusList component test for empty themes fallback rendering.
- No production files are changed.

## Validation
- npm.cmd test -- __tests__/components/theme-focus-list.test.tsx

## DCO
- Commit includes Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>.