### PR TITLE
test(utils): characterize formatCompleteJson on RegExp instance variables

### DIFF
--- a/hushh-webapp/__tests__/utils/format-json-regexp.test.ts
+++ b/hushh-webapp/__tests__/utils/format-json-regexp.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCompleteJson } from "@/lib/utils/json-to-human";
+
+// Characterization tests for formatCompleteJson
+// (hushh-webapp/lib/utils/json-to-human.ts) when native RegExp instances are
+// embedded directly as values.
+//
+// TRUTH-FIRST — LITERAL CONTRACT: formatCompleteJson has NO RegExp-aware branch.
+// A RegExp is `typeof === "object"`, is NOT an Array, and is NOT a number/string,
+// so it falls into the generic "Handle objects" path. Crucially,
+// `Object.entries(/^[a-z]+$/gi)` is `[]` — a RegExp exposes NO own enumerable
+// properties (source/flags/lastIndex are non-enumerable). Therefore:
+//
+//  * A TOP-LEVEL RegExp value emits ONLY a section header (`"", "--- Label ---"`)
+//    and zero field lines — the pattern source and flags are NEVER rendered.
+//  * A RegExp NESTED inside a section object emits ONLY the field label followed
+//    by a bare colon (`"  Label:"`) via the nested-object branch, again with no
+//    pattern/flags text.
+//
+// These tests pin that exact "regex bodies are invisible" behavior. They do NOT
+// claim any regex serialization (no `.source`, no `.toString()`, no flags) —
+// because the implementation performs none.
+
+describe("formatCompleteJson — native RegExp instance values", () => {
+  it("renders a top-level RegExp as a header only (no source/flags)", () => {
+    const out = formatCompleteJson({ matcher: /^[a-z]+$/gi });
+    expect(out).toBe("\n--- Matcher ---");
+    // The pattern body and flags never appear in the output.
+    expect(out).not.toContain("[a-z]");
+    expect(out).not.toContain("gi");
+    expect(out).not.toContain("/");
+  });
+
+  it("renders a nested RegExp as a bare labelled line with no value", () => {
+    const out = formatCompleteJson({ validation: { pattern: /\d+/g } });
+    expect(out).toBe("\n--- Validation ---\n  Pattern:");
+    expect(out).not.toContain("\\d");
+    expect(out).not.toContain("/g");
+  });
+
+  it("does not invoke RegExp.toString() / .source anywhere in the output", () => {
+    const out = formatCompleteJson({ rules: { email: /.+@.+/i, zip: /^\d{5}$/ } });
+    // Each nested RegExp collapses to just its label + colon, in insertion order.
+    expect(out).toBe("\n--- Rules ---\n  Email:\n  Zip:");
+    expect(out).not.toContain("@");
+    expect(out).not.toContain("\\d{5}");
+  });
+
+  it("treats a RegExp like an empty object (same shape as {} produces)", () => {
+    const withRegExp = formatCompleteJson({ probe: /anything/ });
+    const withEmptyObject = formatCompleteJson({ probe: {} });
+    // Both yield only the section header — RegExp own-enumerable keys == {} keys == none.
+    expect(withRegExp).toBe(withEmptyObject);
+    expect(withRegExp).toBe("\n--- Probe ---");
+  });
+
+  it("interleaves a RegExp section between normal scalar sections without leaking the pattern", () => {
+    const out = formatCompleteJson({
+      account_type: "IRA",
+      matcher: /secret-[0-9]+/g,
+      cash_balance: 100,
+    });
+    // Scalar sections format normally; the RegExp contributes only its header.
+    expect(out).toContain("Account Type: IRA");
+    expect(out).toContain("--- Matcher ---");
+    expect(out).toContain("Cash Balance: $100.00");
+    expect(out).not.toContain("secret-");
+  });
+});


### PR DESCRIPTION
## Summary

Adds an isolated characterization test for `formatCompleteJson`
(`hushh-webapp/lib/utils/json-to-human.ts`) documenting its exact output when
native JavaScript `RegExp` instances (e.g. `/^[a-z]+$/gi`) are embedded directly
as dictionary values. Test-only; no production change.

## Literal contract being characterized

`formatCompleteJson` has **no RegExp-aware branch**. A `RegExp` is
`typeof === "object"`, is not an `Array`, and is not a number/string, so it falls
into the generic "Handle objects" path which iterates `Object.entries(...)`.
Crucially, `Object.entries(/^[a-z]+$/gi)` is `[]` — a RegExp exposes **no own
enumerable properties** (`source`, `flags`, `lastIndex` are all non-enumerable).
Therefore the pattern body and flags are **never rendered**:

- A **top-level** RegExp value emits only a section header (`"\n--- Label ---"`)
  and zero field lines.
- A **nested** RegExp emits only the field label plus a bare colon
  (`"  Label:"`) via the nested-object branch.

## Behavior pinned (5 cases)

- `{ matcher: /^[a-z]+$/gi }` → `"\n--- Matcher ---"` (no `[a-z]`, no `gi`, no `/`)
- `{ validation: { pattern: /\d+/g } }` → `"\n--- Validation ---\n  Pattern:"`
- `{ rules: { email: /.+@.+/i, zip: /^\d{5}$/ } }` → `"\n--- Rules ---\n  Email:\n  Zip:"`
- `{ probe: /anything/ }` produces the **same** output as `{ probe: {} }` (`"\n--- Probe ---"`)
- Interleaved `{ account_type: "IRA", matcher: /secret-[0-9]+/g, cash_balance: 100 }`
  → scalars format normally (`Account Type: IRA`, `Cash Balance: $100.00`), the
  RegExp contributes only `--- Matcher ---`, and `secret-` never leaks

## Truth-first scope note

The original task referenced `hushh-research/__tests__/utils/...` and
`npm test -- hushh-research/...`. There is no top-level `__tests__` in this repo;
vitest only includes `__tests__/**` under `hushh-webapp`, and the module's in-repo
alias is `@/lib/utils/json-to-human`. The file therefore lives at
`hushh-webapp/__tests__/utils/format-json-regexp.test.ts`.

## Verification

- `npm test -- __tests__/utils/format-json-regexp.test.ts` → 5/5 pass
- `git status` limited to the single new test file; zero production source drift
- (An IDE-only `@/` module-resolution warning is a false positive — the alias
  resolves under vitest, as the passing run confirms.)

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the real "RegExp == empty object, pattern invisible"
  behavior; explicitly does NOT assert any `.source`/`.toString()`/flags
  serialization the code does not perform
