### PR TITLE
test(top-movers-card): assert mover list item rendering

### DIFF
--- a/hushh-webapp/__tests__/components/top-movers-card.test.tsx
+++ b/hushh-webapp/__tests__/components/top-movers-card.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { TopMoversCard } from "@/components/kai/cards/top-movers-card";
+
+describe("TopMoversCard", () => {
+  it("renders mover list items", () => {
+    render(
+      <TopMoversCard
+        holdings={[
+          {
+            symbol: "NVDA",
+            name: "Nvidia",
+            market_value: 1200,
+            unrealized_gain_loss_pct: 4.25,
+          },
+          {
+            symbol: "TSLA",
+            name: "Tesla",
+            market_value: 800,
+            unrealized_gain_loss_pct: -2.5,
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Gainers")).toBeTruthy();
+    expect(screen.getByText("NVDA")).toBeTruthy();
+    expect(screen.getByText("+4.25%")).toBeTruthy();
+    expect(screen.getByText("Losers")).toBeTruthy();
+    expect(screen.getByText("TSLA")).toBeTruthy();
+    expect(screen.getByText("-2.50%")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for TopMoversCard mover item rendering.
- Assert gainer and loser item symbols and formatted percentage changes render in their sections.

## Why
This protects the top movers card display for portfolio gainer and loser rows.

## PR Base Policy
- Base branch: integration/pr-train.
- Branch was created directly from the fetched integration/pr-train head before this commit.

## No Overlap Proof
- Files changed: hushh-webapp/__tests__/components/top-movers-card.test.tsx only.
- This PR adds one focused TopMoversCard component test for mover item rendering.
- No production files are changed.

## Validation
- npm.cmd test -- __tests__/components/top-movers-card.test.tsx

## DCO
- Commit includes Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>.