### PR TITLE
test(transaction-activity): assert empty transactions fallback

### DIFF
--- a/hushh-webapp/__tests__/components/transaction-activity.test.tsx
+++ b/hushh-webapp/__tests__/components/transaction-activity.test.tsx
@@ -1,0 +1,12 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { TransactionActivity } from "@/components/kai/cards/transaction-activity";
+
+describe("TransactionActivity", () => {
+  it("renders empty transactions fallback", () => {
+    const { container } = render(<TransactionActivity transactions={[]} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for TransactionActivity empty transactions fallback rendering.
- Assert the component renders nothing when no valid transactions are available.

## Why
This protects the existing empty fallback contract for recent transaction activity.

## PR Base Policy
- Base branch: integration/pr-train.
- Branch was created directly from the fetched integration/pr-train head before this commit.

## No Overlap Proof
- Files changed: hushh-webapp/__tests__/components/transaction-activity.test.tsx only.
- This PR adds one focused TransactionActivity component test for empty transactions fallback rendering.
- No production files are changed.

## Validation
- npm.cmd test -- __tests__/components/transaction-activity.test.tsx

## DCO
- Commit includes Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>.