### PR TITLE
test(symbol-avatar): assert fallback initials rendering

### DIFF
--- a/hushh-webapp/__tests__/components/symbol-avatar.test.tsx
+++ b/hushh-webapp/__tests__/components/symbol-avatar.test.tsx
@@ -1,0 +1,16 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SymbolAvatar } from "@/components/kai/shared/symbol-avatar";
+
+describe("SymbolAvatar", () => {
+  it("renders fallback initials when logo loading fails", () => {
+    const { container } = render(<SymbolAvatar symbol="NVDA" name="Nvidia" />);
+
+    const logo = container.querySelector("img");
+    expect(logo).toBeTruthy();
+    fireEvent.error(logo!);
+
+    expect(screen.getByText("N")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for SymbolAvatar fallback rendering.
- Assert the symbol-derived fallback initial appears after logo loading fails.

## Why
This protects the avatar fallback path used when external company logos are unavailable.

## PR Base Policy
- Base branch: integration/pr-train.
- Branch was created directly from the fetched integration/pr-train head before this commit.

## No Overlap Proof
- Files changed: hushh-webapp/__tests__/components/symbol-avatar.test.tsx only.
- This PR adds one focused SymbolAvatar component test for fallback initials rendering.
- No production files are changed.

## Validation
- npm.cmd test -- __tests__/components/symbol-avatar.test.tsx

## DCO
- Commit includes Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>.