### PR TITLE
test(stale-cache-timestamp): assert stale label rendering

### DIFF
--- a/hushh-webapp/__tests__/components/stale-cache-timestamp.test.tsx
+++ b/hushh-webapp/__tests__/components/stale-cache-timestamp.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { StaleCacheTimestamp } from "@/components/system/stale-cache-timestamp";
+
+describe("StaleCacheTimestamp", () => {
+  it("renders stale label", () => {
+    render(<StaleCacheTimestamp label="Using cached consent data" stale />);
+
+    expect(screen.getByText(/Using cached consent data.*stale/)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused coverage for StaleCacheTimestamp stale label rendering.
- Assert the stale state appends the stale label to the timestamp copy.

## Why
This protects the stale cache timestamp indicator shown when cached data is being surfaced.

## PR Base Policy
- Base branch: integration/pr-train.
- Branch was created directly from the fetched integration/pr-train head before this commit.

## No Overlap Proof
- Files changed: hushh-webapp/__tests__/components/stale-cache-timestamp.test.tsx only.
- This PR adds one focused StaleCacheTimestamp component test for stale label rendering.
- No production files are changed.

## Validation
- npm.cmd test -- __tests__/components/stale-cache-timestamp.test.tsx

## DCO
- Commit includes Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>.