### PR TITLE
test(navigation): characterize normalizeInternalRouteHref hash anchors

### DIFF
--- a/hushh-webapp/__tests__/navigation/normalize-hash-anchors.test.ts
+++ b/hushh-webapp/__tests__/navigation/normalize-hash-anchors.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeInternalRouteHref } from "@/lib/navigation/routes";
+
+describe("normalizeInternalRouteHref -- hash anchors", () => {
+  it("accepts root hash anchors but rejects bare hash-only anchors", () => {
+    expect(normalizeInternalRouteHref("/#top")).toBe("/#top");
+    expect(normalizeInternalRouteHref("  /#top  ")).toBe("/#top");
+
+    expect(normalizeInternalRouteHref("#top")).toBeNull();
+    expect(normalizeInternalRouteHref("  #top  ")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused characterization for normalizeInternalRouteHref hash-anchor handling.
- Assert root hash anchors are accepted while bare hash-only anchors are rejected.

## Why
This documents the helper boundary for internal route hrefs without changing navigation behavior.

## PR Base Policy
- Base branch: integration/pr-train.
- Branch was created directly from the fetched integration/pr-train head before this commit.

## No Overlap Proof
- Files changed: hushh-webapp/__tests__/navigation/normalize-hash-anchors.test.ts only.
- This PR adds one focused normalizeInternalRouteHref test for root hash anchors versus bare hash-only anchors.
- Existing hash tests cover route fragments, fragment spaces, and resolveInternalRouteHref retention; this PR does not modify those files.
- No production files are changed.

## Validation
- npm.cmd test -- __tests__/navigation/normalize-hash-anchors.test.ts

## DCO
- Commit includes Signed-off-by: Divya-rajendran009 <divya.rajendranps@gmail.com>.