### PR TITLE
test(navigation): characterize normalizeInternalRouteHref absolute file paths

### DIFF
--- a/hushh-webapp/__tests__/navigation/normalize-absolute-files.test.ts
+++ b/hushh-webapp/__tests__/navigation/normalize-absolute-files.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for normalizeInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts) against absolute file-system / file://
+// style inputs.
+//
+// TRUTH-FIRST — LITERAL CONTRACT: normalizeInternalRouteHref is a same-origin
+// allow-list guard, NOT a path normalizer. Its full body is:
+//
+//   const href = String(value ?? "").trim();
+//   if (!href) return null;
+//   if (!href.startsWith("/") || href.startsWith("//")) return null;
+//   if (/[\r\n]/.test(href)) return null;
+//   return href;
+//
+// Consequences for "absolute file" shapes:
+//  * It does NO path resolution, NO `..` collapsing, NO drive-letter handling,
+//    NO percent-decoding. A surviving value is returned BYTE-FOR-BYTE (post-trim).
+//  * `file://...` is rejected because it starts with "f", not "/".
+//  * Windows paths like `C:\...` are rejected (start with "C").
+//  * `//server/share` (UNC / protocol-relative) is rejected by the explicit
+//    `startsWith("//")` guard — treated as EXTERNAL.
+//  * A POSIX-absolute string like `/etc/passwd` or `/C:/app/index.html` starts
+//    with a single "/" and is therefore treated as a same-origin route and
+//    returned VERBATIM. The guard is a scheme/origin gate, not a filesystem
+//    safety check — it does not "sanitize" traversal-looking paths.
+//
+// These tests pin exactly that boundary (external -> null, single-slash -> echo).
+
+describe("normalizeInternalRouteHref — absolute file / file:// inputs", () => {
+  it("rejects file:/// URIs (Windows drive) as external -> null", () => {
+    expect(normalizeInternalRouteHref("file:///C:/app/index.html")).toBeNull();
+  });
+
+  it("rejects POSIX file:/// URIs as external -> null", () => {
+    expect(normalizeInternalRouteHref("file:///etc/passwd")).toBeNull();
+  });
+
+  it("rejects bare Windows drive paths (C:\\...) as external -> null", () => {
+    expect(normalizeInternalRouteHref("C:\\app\\index.html")).toBeNull();
+  });
+
+  it("rejects UNC / protocol-relative double-slash paths -> null", () => {
+    expect(normalizeInternalRouteHref("//server/share/index.html")).toBeNull();
+  });
+
+  it("returns a single-slash POSIX-absolute path verbatim (no fs sanitizing)", () => {
+    // Looks like a root system file, but it starts with one "/" so the guard
+    // treats it as a same-origin route and echoes it unchanged.
+    expect(normalizeInternalRouteHref("/etc/passwd")).toBe("/etc/passwd");
+  });
+
+  it("returns a single-slash drive-style path verbatim (no drive parsing)", () => {
+    expect(normalizeInternalRouteHref("/C:/app/index.html")).toBe(
+      "/C:/app/index.html",
+    );
+  });
+
+  it("does NOT collapse traversal segments in a surviving single-slash path", () => {
+    expect(normalizeInternalRouteHref("/../../etc/passwd")).toBe(
+      "/../../etc/passwd",
+    );
+  });
+
+  it("trims surrounding whitespace before the slash check, then echoes verbatim", () => {
+    expect(normalizeInternalRouteHref("   /var/data/report.html   ")).toBe(
+      "/var/data/report.html",
+    );
+  });
+
+  it("rejects a CRLF-bearing absolute path even after trim -> null", () => {
+    expect(normalizeInternalRouteHref("/var/data\r\n/report.html")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds an isolated characterization test for `normalizeInternalRouteHref`
(`hushh-webapp/lib/navigation/routes.ts`) documenting how it treats absolute
file-system / `file://` style inputs (e.g. `file:///C:/app/index.html`,
`C:\app\index.html`, `/etc/passwd`). Test-only; no production change.

## Literal contract being characterized

`normalizeInternalRouteHref` is a same-origin **allow-list guard**, not a path
normalizer or filesystem safety check. Its full body:

```ts
const href = String(value ?? "").trim();
if (!href) return null;
if (!href.startsWith("/") || href.startsWith("//")) return null;
if (/[\r\n]/.test(href)) return null;
return href;
```

It performs **no path resolution, no `..` collapsing, no drive-letter parsing,
no percent-decoding**. A surviving value is returned **byte-for-byte** (after a
whitespace trim). The single-`/` allow-list is a scheme/origin gate.

## Behavior pinned (9 cases)

External → `null`:
- `file:///C:/app/index.html` (starts with `f`, not `/`)
- `file:///etc/passwd`
- `C:\app\index.html` (starts with `C`)
- `//server/share/index.html` (explicit `startsWith("//")` UNC / protocol-relative guard)
- `/var/data\r\n/report.html` (CRLF rejected even after trim)

Same-origin → returned **verbatim** (the guard does NOT sanitize traversal-looking paths):
- `/etc/passwd` → `/etc/passwd`
- `/C:/app/index.html` → `/C:/app/index.html` (no drive parsing)
- `/../../etc/passwd` → `/../../etc/passwd` (no `..` collapsing)
- `   /var/data/report.html   ` → `/var/data/report.html` (trim, then echo)

## Security framing (truth-first)

This is **not** a path-traversal sanitizer and the tests do not pretend it is.
The guard's job is to keep `next/router` navigation same-origin: anything not
beginning with exactly one `/` (schemes, UNC, protocol-relative) is rejected as
external; anything that does is handed back unchanged. Filesystem-style strings
like `/etc/passwd` survive because they are valid same-origin *route* strings —
they are never resolved against a real filesystem by this function.

## Truth-first scope note

The original task referenced `hushh-research/__tests__/navigation/...` and
`npm test -- hushh-research/...`. There is no top-level `__tests__` in this repo;
vitest only includes `__tests__/**` under `hushh-webapp`, and the module's in-repo
alias is `@/lib/navigation/routes`. The file therefore lives at
`hushh-webapp/__tests__/navigation/normalize-absolute-files.test.ts`.

## Verification

- `npm test -- __tests__/navigation/normalize-absolute-files.test.ts` → 9/9 pass
- `git status` limited to the single new test file; zero production source drift
- (An IDE-only `@/` module-resolution warning is a false positive — the alias
  resolves under vitest, as the passing run confirms.)

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the real "external → null, single-slash → verbatim"
  allow-list contract; explicitly does NOT claim traversal/drive sanitizing the
  function does not perform
