### PR TITLE
test(utils): characterize formatCompleteJson deep object value cyclic ref guards

### DIFF
--- a/hushh-webapp/__tests__/utils/format-cyclic-guards.test.ts
+++ b/hushh-webapp/__tests__/utils/format-cyclic-guards.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCompleteJson } from "@/lib/utils/json-to-human";
+
+// Characterization tests for formatCompleteJson
+// (hushh-webapp/lib/utils/json-to-human.ts) against cyclic self-references.
+//
+// TRUTH-FIRST — LITERAL CONTRACT: formatCompleteJson has NO cycle guard, NO
+// try/catch, and NO "strip looping params" logic. It does NOT need one, because
+// it is NOT recursive. It walks a HARD-CODED, FIXED depth of exactly three
+// levels via plain `for...of Object.entries(...)` loops:
+//
+//   level 1: section entries        (top-level keys)
+//   level 2: field entries          (inside an object section)
+//   level 3: nested-field entries   (inside a nested object field)
+//
+// At level 3 each value is passed to `formatValue`, whose fallthrough for a
+// non-null/number/string/boolean value is `return String(value)` ->
+// "[object Object]". There is no fourth level and no self-call, so a cyclic
+// reference can NEVER cause infinite recursion or a RangeError (stack overflow).
+// The cycle is simply truncated by the fixed depth and rendered as the literal
+// string "[object Object]".
+//
+// These tests pin that "no guard needed, naturally bounded, no throw" behavior.
+// They deliberately do NOT assert any WeakSet/seen-set protection, thrown
+// "Converting circular structure to JSON" error, or key stripping — the code
+// performs none of those.
+
+describe("formatCompleteJson — cyclic self-reference handling", () => {
+  it("does NOT throw on a direct self-cycle (obj.self = obj)", () => {
+    const obj: Record<string, unknown> = {};
+    obj.self = obj;
+    expect(() => formatCompleteJson(obj)).not.toThrow();
+  });
+
+  it("truncates a direct self-cycle at the fixed 3rd level as [object Object]", () => {
+    const obj: Record<string, unknown> = {};
+    obj.self = obj;
+    // level1 section "Self" -> level2 field "Self:" -> level3 "• Self: <String(obj)>"
+    expect(formatCompleteJson(obj)).toBe(
+      "\n--- Self ---\n  Self:\n    • Self: [object Object]",
+    );
+  });
+
+  it("does NOT throw on a two-node mutual cycle (a.b = b; b.a = a)", () => {
+    const a: Record<string, unknown> = {};
+    const b: Record<string, unknown> = {};
+    a.b = b;
+    b.a = a;
+    expect(() => formatCompleteJson(a)).not.toThrow();
+  });
+
+  it("renders a two-node mutual cycle bounded to three levels", () => {
+    const a: Record<string, unknown> = {};
+    const b: Record<string, unknown> = {};
+    a.b = b;
+    b.a = a;
+    expect(formatCompleteJson(a)).toBe(
+      "\n--- B ---\n  A:\n    • B: [object Object]",
+    );
+  });
+
+  it("keeps sibling scalar fields intact alongside a cyclic field (no stripping)", () => {
+    const node: Record<string, unknown> = { cash_balance: 100 };
+    node.loop = node;
+    const out = formatCompleteJson({ portfolio_summary: node });
+    // The real scalar still formats as currency; the cyclic field is not removed,
+    // it just bottoms out at [object Object] (no infinite expansion, no throw).
+    expect(out).toContain("--- Portfolio Summary ---");
+    expect(out).toContain("Cash Balance: $100.00");
+    expect(out).toContain("[object Object]");
+  });
+
+  it("completes synchronously and bounded even for a deep cycle (no RangeError)", () => {
+    const root: Record<string, unknown> = {};
+    let cursor = root;
+    for (let i = 0; i < 1000; i++) {
+      const next: Record<string, unknown> = {};
+      cursor.next = next;
+      cursor = next;
+    }
+    cursor.next = root; // close the loop
+    // Fixed-depth walk ignores the depth of the chain entirely — never recurses.
+    expect(() => formatCompleteJson(root)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Adds an isolated characterization test for `formatCompleteJson`
(`hushh-webapp/lib/utils/json-to-human.ts`) documenting its behavior when the
input object contains a cyclic self-reference (`obj.self = obj`). Test-only; no
production change.

## Literal contract being characterized

`formatCompleteJson` has **no cycle guard, no `try/catch`, and no "strip looping
params" logic** — and it does not need one, because it is **not recursive**. It
walks a hard-coded, fixed depth of exactly three levels via plain
`for...of Object.entries(...)` loops:

- level 1: section entries (top-level keys)
- level 2: field entries (inside an object section)
- level 3: nested-field entries (inside a nested object field)

At level 3 each value goes to `formatValue`, whose fallthrough for a
non-null/number/string/boolean value is `return String(value)` →
`"[object Object]"`. There is no fourth level and no self-call, so a cyclic
reference can **never** cause infinite recursion or a `RangeError`
(stack overflow). The cycle is simply truncated by the fixed depth.

## Behavior pinned (6 cases)

- `obj.self = obj` → does **not** throw
- `obj.self = obj` → `"\n--- Self ---\n  Self:\n    • Self: [object Object]"`
- mutual cycle `a.b = b; b.a = a` → does **not** throw
- mutual cycle → `"\n--- B ---\n  A:\n    • B: [object Object]"`
- `{ portfolio_summary: node }` with `node.cash_balance = 100; node.loop = node`
  → sibling scalar still renders `Cash Balance: $100.00`; the cyclic field is
  **not stripped**, it bottoms out at `[object Object]`
- a 1000-deep chain closed into a loop → completes, does **not** throw
  (fixed-depth walk ignores chain depth entirely)

## Truth-first framing

The task asked whether the utility "includes safety protections, throws a
standard error, or strips looping parameters." The honest answer is **none of
those** — and crucially, none are required. The function is structurally
cycle-safe by virtue of being a fixed 3-level iterator, not a recursive
serializer like `JSON.stringify` (which *would* throw
`Converting circular structure to JSON`). The tests assert that real property and
deliberately do **not** claim any WeakSet/seen-set guard, thrown error, or key
stripping that the code does not implement.

## Truth-first scope note

The original task referenced `hushh-research/__tests__/utils/...` and
`npm test -- hushh-research/...`. There is no top-level `__tests__` in this repo;
vitest only includes `__tests__/**` under `hushh-webapp`, and the module's in-repo
alias is `@/lib/utils/json-to-human`. The file therefore lives at
`hushh-webapp/__tests__/utils/format-cyclic-guards.test.ts`.

## Verification

- `npm test -- __tests__/utils/format-cyclic-guards.test.ts` → 6/6 pass
- `git status` limited to the single new test file; zero production source drift
- (An IDE-only `@/` module-resolution warning is a false positive — the alias
  resolves under vitest, as the passing run confirms.)

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the real "fixed-depth, naturally cycle-safe, no guard /
  no throw / no stripping" behavior; does NOT overclaim any circular-structure
  protection the code lacks
