### PR TITLE
test(utils): characterize formatCompleteJson multi-byte UTF-16 character strings

### DIFF
--- a/hushh-webapp/__tests__/utils/format-utf16-strings.test.ts
+++ b/hushh-webapp/__tests__/utils/format-utf16-strings.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCompleteJson } from "@/lib/utils/json-to-human";
+
+// Characterization tests for formatCompleteJson
+// (hushh-webapp/lib/utils/json-to-human.ts) against multi-byte UTF-16 strings,
+// emoji (astral / surrogate-pair) characters, and emoji arrays.
+//
+// TRUTH-FIRST — LITERAL CONTRACT for non-numeric/boolean values:
+//  * String values flow through `formatValue` -> `cleanMarkdown`, which ONLY:
+//      - removes the literal markdown markers `***`, `**`, `*`, and backtick
+//      - calls `.trim()`
+//    It performs NO Unicode normalization (NFC/NFD), NO surrogate-pair
+//    re-encoding, NO escaping, and NO emoji stripping. So emoji and astral
+//    characters survive BYTE-FOR-BYTE except when they are adjacent to literal
+//    "*"/backtick markers (which are removed) or surrounding whitespace (trimmed).
+//  * Arrays use a header `--- <Label> (<N> items) ---` where N is the ARRAY
+//    element count (`Array.prototype.length`) — NOT a UTF-16 code-unit count. A
+//    single emoji string element counts as exactly one item even though it spans
+//    two UTF-16 code units.
+//  * Generic (non-special-cased) arrays render the first 3 elements as
+//    `  • ${String(item)}` and then `  ... and <N-3> more`. `String(emoji)`
+//    returns the emoji unchanged.
+//
+// These tests pin that "pass-through, no normalization, element-count not
+// code-unit-count" behavior precisely.
+
+describe("formatCompleteJson — multi-byte UTF-16 / emoji strings", () => {
+  it("passes an astral emoji in an object field through verbatim", () => {
+    expect(
+      formatCompleteJson({ account_metadata: { account_holder: "José 🚀🎉" } }),
+    ).toBe("\n--- Account Information ---\n  Account Holder: José 🚀🎉");
+  });
+
+  it("preserves surrogate-pair mathematical bold letters verbatim", () => {
+    expect(
+      formatCompleteJson({ account_metadata: { account_holder: "𝕳𝖚𝖘𝖍" } }),
+    ).toBe("\n--- Account Information ---\n  Account Holder: 𝕳𝖚𝖘𝖍");
+  });
+
+  it("strips markdown markers around an emoji but keeps the emoji", () => {
+    // "**🚀**" -> cleanMarkdown removes the "**" pairs -> "🚀"
+    expect(
+      formatCompleteJson({ account_metadata: { account_holder: "**🚀**" } }),
+    ).toBe("\n--- Account Information ---\n  Account Holder: 🚀");
+  });
+
+  it("renders a top-level emoji scalar string verbatim", () => {
+    expect(formatCompleteJson({ note: "🚀 launch" })).toBe("Note: 🚀 launch");
+  });
+
+  it("counts emoji array ITEMS by element, not UTF-16 code units, and lists first 3", () => {
+    // 4 single-emoji elements (each is a 2-code-unit surrogate pair).
+    expect(formatCompleteJson({ tags: ["🚀", "🎉", "😀", "🔥"] })).toBe(
+      "\n--- Tags (4 items) ---\n  • 🚀\n  • 🎉\n  • 😀\n  ... and 1 more",
+    );
+  });
+
+  it("treats a single multi-emoji string as one array element", () => {
+    // The whole "🚀🎉😀🔥" string is ONE element -> "(1 items)", String() verbatim.
+    expect(formatCompleteJson({ tags: ["🚀🎉😀🔥"] })).toBe(
+      "\n--- Tags (1 items) ---\n  • 🚀🎉😀🔥",
+    );
+  });
+
+  it("does NOT Unicode-normalize: decomposed (NFD) sequence is preserved", () => {
+    // "e" + U+0301 combining acute accent (NFD) must remain two code points,
+    // not be collapsed to the precomposed "é" (NFC).
+    const decomposed = "e\u0301"; // é in NFD form
+    const out = formatCompleteJson({
+      account_metadata: { account_holder: decomposed },
+    });
+    expect(out).toBe(
+      `\n--- Account Information ---\n  Account Holder: ${decomposed}`,
+    );
+    // Guard: it is still the 2-code-point decomposed form, not precomposed.
+    expect(out.endsWith("e\u0301")).toBe(true);
+    expect(out.endsWith("\u00e9")).toBe(false);
+  });
+
+  it("preserves a zero-width joiner (ZWJ) family emoji sequence verbatim", () => {
+    const family = "👩‍👩‍👧‍👦"; // multiple code points joined by U+200D
+    expect(
+      formatCompleteJson({ account_metadata: { account_holder: family } }),
+    ).toBe(`\n--- Account Information ---\n  Account Holder: ${family}`);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an isolated characterization test for `formatCompleteJson`
(`hushh-webapp/lib/utils/json-to-human.ts`) documenting how multi-byte UTF-16
strings, astral/surrogate-pair characters, and emoji arrays are serialized.
Test-only; no production change.

## Literal contract being characterized

For non-numeric / non-boolean values, `formatCompleteJson` -> `formatValue` ->
`cleanMarkdown`, which is:

```ts
text
  .replace(/\*\*\*/g, '')  // bold+italic markers
  .replace(/\*\*/g, '')    // bold markers
  .replace(/\*/g, '')      // italic markers
  .replace(/`/g, '')       // backticks
  .trim();
```

It performs **no** Unicode normalization (NFC/NFD), **no** surrogate-pair
re-encoding, **no** escaping, and **no** emoji stripping. Arrays use a header
`--- <Label> (<N> items) ---` where `N` is `Array.prototype.length` (element
count), and generic arrays render the first 3 elements as `  • ${String(item)}`.

## Behavior pinned (8 cases)

Strings — pass through byte-for-byte:
- `"José 🚀🎉"` (mixed BMP + astral emoji) → unchanged
- `"𝕳𝖚𝖘𝖍"` (U+1D573… mathematical bold, surrogate pairs) → unchanged
- `"🚀 launch"` as a top-level scalar → `Note: 🚀 launch`
- `"**🚀**"` → markdown `**` removed, emoji kept → `🚀`

No normalization:
- `"e\u0301"` (NFD decomposed `é`) stays 2 code points — **not** collapsed to
  precomposed `\u00e9` (asserted both directions)
- `"👩‍👩‍👧‍👦"` (ZWJ family sequence, multiple code points joined by U+200D) → unchanged

Arrays — element count, not code-unit count:
- `["🚀","🎉","😀","🔥"]` → `--- Tags (4 items) ---` then `• 🚀 / • 🎉 / • 😀 / ... and 1 more`
- `["🚀🎉😀🔥"]` → `--- Tags (1 items) ---` then `• 🚀🎉😀🔥` (one string element, not four)

## Truth-first note

This confirms `formatCompleteJson` is a display formatter, **not** a Unicode
sanitizer/normalizer. The "structural mapping precision" the task asks about is
real for the surrogate-pair / element-count dimension (counts are by JS array
element, and astral characters are preserved intact), with the one transformation
being `cleanMarkdown`'s literal `*`/backtick removal and `trim()`. The tests
deliberately do **not** claim any NFC/NFD normalization or escaping the code does
not perform.

## Truth-first scope note

The original task referenced `hushh-research/__tests__/utils/...` and
`npm test -- hushh-research/...`. There is no top-level `__tests__` in this repo;
vitest only includes `__tests__/**` under `hushh-webapp`, and the module's in-repo
alias is `@/lib/utils/json-to-human`. The file therefore lives at
`hushh-webapp/__tests__/utils/format-utf16-strings.test.ts`.

## Verification

- `npm test -- __tests__/utils/format-utf16-strings.test.ts` → 8/8 pass
- `git status` limited to the single new test file; zero production source drift
- (An IDE-only `@/` module-resolution warning is a false positive — the alias
  resolves under vitest, as the passing run confirms.)

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the real "pass-through, no normalization, element-count
  not code-unit-count" behavior, including the one `cleanMarkdown` transformation
