### PR TITLE
test(navigation): characterize normalizeInternalRouteHref unicode space normalization

### DIFF
--- a/hushh-webapp/__tests__/navigation/normalize-unicode-spaces.test.ts
+++ b/hushh-webapp/__tests__/navigation/normalize-unicode-spaces.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for normalizeInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts) against non-breaking spaces and
+// alternative Unicode space characters in route values.
+//
+// TRUTH-FIRST — LITERAL CONTRACT:
+//
+//   const href = String(value ?? "").trim();
+//   if (!href) return null;
+//   if (!href.startsWith("/") || href.startsWith("//")) return null;
+//   if (/[\r\n]/.test(href)) return null;
+//   return href;
+//
+// The only space-related transformation is `String.prototype.trim()`. Per the
+// ECMAScript spec, `.trim()` removes leading/trailing code points in the union
+// of WhiteSpace + LineTerminator, which INCLUDES the Unicode Space_Separator
+// (Zs) category — so `\u00A0` (no-break space), `\u2002` (en space), `\u2003`
+// (em space), `\u3000` (ideographic space), and the BOM `\uFEFF` are all
+// stripped at the ENDS of the string.
+//
+// Consequences this test pins:
+//  * Leading/trailing Unicode spaces are TRIMMED (not preserved), and trimming
+//    can REVEAL a leading "/" so the value passes the guard.
+//  * INTERIOR Unicode spaces are PRESERVED VERBATIM — there is no collapse,
+//    replacement, or percent-encoding of mid-string spaces.
+//  * A value made up ONLY of Unicode spaces trims to "" and returns null.
+//  * The CRLF rejection regex is `/[\r\n]/` only; it does NOT reject Unicode
+//    spaces, so an interior `\u00A0` does not by itself cause a null.
+
+describe("normalizeInternalRouteHref — Unicode space handling", () => {
+  it("trims a leading no-break space (\\u00A0), revealing the leading '/'", () => {
+    expect(normalizeInternalRouteHref("\u00A0/dashboard")).toBe("/dashboard");
+  });
+
+  it("trims a trailing en space (\\u2002)", () => {
+    expect(normalizeInternalRouteHref("/dashboard\u2002")).toBe("/dashboard");
+  });
+
+  it("trims leading AND trailing mixed Unicode spaces", () => {
+    expect(normalizeInternalRouteHref("\u3000\u2003/profile\u00A0")).toBe(
+      "/profile",
+    );
+  });
+
+  it("PRESERVES an interior no-break space verbatim", () => {
+    expect(normalizeInternalRouteHref("/my\u00A0route")).toBe("/my\u00A0route");
+  });
+
+  it("PRESERVES an interior en space verbatim", () => {
+    expect(normalizeInternalRouteHref("/a\u2002b")).toBe("/a\u2002b");
+  });
+
+  it("returns null for a string of only Unicode spaces (trims to empty)", () => {
+    expect(normalizeInternalRouteHref("\u00A0\u2002\u3000")).toBeNull();
+  });
+
+  it("still rejects '//' even after trimming a leading Unicode space", () => {
+    // trim -> "//evil" which startsWith("//") -> rejected.
+    expect(normalizeInternalRouteHref("\u00A0//evil")).toBeNull();
+  });
+
+  it("does NOT reject an interior Unicode space (only \\r and \\n are rejected)", () => {
+    expect(normalizeInternalRouteHref("/x\u00A0y\u2002z")).toBe(
+      "/x\u00A0y\u2002z",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds an isolated characterization test for `normalizeInternalRouteHref`
(`hushh-webapp/lib/navigation/routes.ts`) documenting how non-breaking spaces and
alternative Unicode space characters behave in route values. Test-only; no
production change.

## Literal contract being characterized

```ts
const href = String(value ?? "").trim();
if (!href) return null;
if (!href.startsWith("/") || href.startsWith("//")) return null;
if (/[\r\n]/.test(href)) return null;
return href;
```

The only space-related transformation is `String.prototype.trim()`. Per the
ECMAScript spec, `.trim()` removes leading/trailing code points in the union of
WhiteSpace + LineTerminator, which **includes** the Unicode Space_Separator (Zs)
category — so `\u00A0` (no-break), `\u2002` (en), `\u2003` (em), `\u3000`
(ideographic), and `\uFEFF` (BOM) are all stripped at the **ends** of the string.

## Behavior pinned (8 cases)

Leading/trailing Unicode spaces are **trimmed** (can reveal a leading `/`):
- `"\u00A0/dashboard"` → `/dashboard`
- `"/dashboard\u2002"` → `/dashboard`
- `"\u3000\u2003/profile\u00A0"` → `/profile`
- `"\u00A0\u2002\u3000"` (all spaces) → `null` (trims to empty)

Interior Unicode spaces are **preserved verbatim** (no collapse / encode):
- `"/my\u00A0route"` → `/my\u00A0route`
- `"/a\u2002b"` → `/a\u2002b`
- `"/x\u00A0y\u2002z"` → `/x\u00A0y\u2002z`

Guard still applies after trim:
- `"\u00A0//evil"` → trim → `//evil` → `null` (explicit `startsWith("//")` reject)

## Truth-first note

`normalizeInternalRouteHref` does **not** Unicode-normalize, collapse, or
percent-encode spaces. The CRLF guard is `/[\r\n]/` only — it does **not** reject
interior Unicode spaces, so `\u00A0`/`\u2002` mid-path survive. The single
transformation is `.trim()`, which removes trailing/leading Zs whitespace and can
expose a leading `/`. The tests deliberately do not claim any interior-space
filtering or normalization the code does not perform.

## Truth-first scope note

The original task referenced `hushh-research/__tests__/navigation/...` and
`npm test -- hushh-research/...`. There is no top-level `__tests__` in this repo;
vitest only includes `__tests__/**` under `hushh-webapp`, and the module's in-repo
alias is `@/lib/navigation/routes`. The file therefore lives at
`hushh-webapp/__tests__/navigation/normalize-unicode-spaces.test.ts`.

## Verification

- `npm test -- __tests__/navigation/normalize-unicode-spaces.test.ts` → 8/8 pass
- `git status` limited to the single new test file; zero production source drift
- (An IDE-only `@/` module-resolution warning is a false positive — the alias
  resolves under vitest, as the passing run confirms.)

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the real "trim ends (incl. Unicode Zs), preserve
  interior verbatim, no normalization" behavior
