### PR TITLE
fix(cwe209): redact CrdScrapeProxyError detail in crd_scraper responses

### DIFF
--- a/consent-protocol/api/routes/crd_scraper.py
+++ b/consent-protocol/api/routes/crd_scraper.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Request
@@ -17,6 +18,8 @@ from hushh_mcp.services.crd_scrape_proxy_service import (
 )
 
 router = APIRouter(prefix="/api/ria", tags=["RIA", "CRD Scraper"])
+
+logger = logging.getLogger(__name__)
 
 _JobId = Annotated[str, Path(min_length=1, max_length=128)]
 
@@ -113,7 +116,16 @@ async def _call_provider(coro: Any) -> CrdScrapeProviderResponse:
             detail={"code": "CRD_INVALID_REQUEST", "message": "Invalid request parameters."},
         )
     except CrdScrapeProxyError as exc:
-        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+        # CWE-209: do not forward the internal proxy error verbatim to the client.
+        # Log the detail server-side; return a generic message with the status.
+        logger.warning("crd_scraper.proxy_error status=%s: %s", exc.status_code, exc)
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail={
+                "code": "CRD_UPSTREAM_ERROR",
+                "message": "CRD lookup is temporarily unavailable.",
+            },
+        ) from exc
 
 
 def _request_id(request: Request) -> str | None:

--- a/consent-protocol/tests/test_crd_scraper_routes.py
+++ b/consent-protocol/tests/test_crd_scraper_routes.py
@@ -128,7 +128,13 @@ def test_crd_scrape_provider_errors_return_502() -> None:
     response = client.post("/api/ria/crd-scrape-jobs", json={"crd": "7413463"})
 
     assert response.status_code == 502
-    assert "provider request failed" in response.json()["detail"]
+    detail = response.json()["detail"]
+    # CWE-209: the internal proxy error must not be forwarded to the client.
+    assert detail == {
+        "code": "CRD_UPSTREAM_ERROR",
+        "message": "CRD lookup is temporarily unavailable.",
+    }
+    assert "provider request failed" not in str(detail)
 
 
 def test_create_financial_verification_job_proxies_payload_unchanged() -> None:


### PR DESCRIPTION
Re-lands the unmerged CWE-209 fix from #2444 onto `main` (the original targeted the retired `integration/pr-train` base and could not merge cleanly).

`main` still forwards the internal proxy error verbatim:
```python
except CrdScrapeProxyError as exc:
    raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
```
This leaks upstream/provider error detail to the client (**CWE-209: Information Exposure Through an Error Message**).

### Change
- `crd_scraper.py`: add a module logger; on `CrdScrapeProxyError`, log the detail server-side and return a generic `{code: CRD_UPSTREAM_ERROR, message: ...}` while preserving the HTTP status code.
- `test_crd_scraper_routes.py`: update the 502 test to assert the internal detail is no longer leaked.

### Validation
- `tests/test_crd_scraper_routes.py`: 7 passed
- `./bin/hushh protocol fix`: all checks passed, no unrelated drift