### PR TITLE
test(theme-toggle): characterise resolveActiveTheme normalisation contract

### DIFF
--- a/hushh-webapp/__tests__/components/theme-toggle.test.tsx
+++ b/hushh-webapp/__tests__/components/theme-toggle.test.tsx
@@ -1,15 +1,5 @@
 import { describe, expect, it } from "vitest";
-
-// resolveActiveTheme is not exported, so we re-implement the contract inline.
-// This characterises the normalisation behaviour at the boundary.
-type ThemeOption = "light" | "dark" | "system";
-function resolveActiveTheme(theme: string | undefined): ThemeOption {
-  const normalized = (theme ?? "").trim().toLowerCase();
-  if (normalized === "light" || normalized === "dark" || normalized === "system") {
-    return normalized as ThemeOption;
-  }
-  return "system";
-}
+import { resolveActiveTheme } from "@/components/theme-toggle";
 
 describe("resolveActiveTheme", () => {
   it("returns light for light input", () => {

--- a/hushh-webapp/__tests__/components/theme-toggle.test.tsx
+++ b/hushh-webapp/__tests__/components/theme-toggle.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+// resolveActiveTheme is not exported, so we re-implement the contract inline.
+// This characterises the normalisation behaviour at the boundary.
+type ThemeOption = "light" | "dark" | "system";
+function resolveActiveTheme(theme: string | undefined): ThemeOption {
+  const normalized = (theme ?? "").trim().toLowerCase();
+  if (normalized === "light" || normalized === "dark" || normalized === "system") {
+    return normalized as ThemeOption;
+  }
+  return "system";
+}
+
+describe("resolveActiveTheme", () => {
+  it("returns light for light input", () => {
+    expect(resolveActiveTheme("light")).toBe("light");
+  });
+
+  it("returns dark for dark input", () => {
+    expect(resolveActiveTheme("dark")).toBe("dark");
+  });
+
+  it("returns system for system input", () => {
+    expect(resolveActiveTheme("system")).toBe("system");
+  });
+
+  it("returns system for undefined", () => {
+    expect(resolveActiveTheme(undefined)).toBe("system");
+  });
+
+  it("returns system for unknown value", () => {
+    expect(resolveActiveTheme("custom")).toBe("system");
+  });
+
+  it("normalises whitespace and casing", () => {
+    expect(resolveActiveTheme("  Light  ")).toBe("light");
+    expect(resolveActiveTheme("DARK")).toBe("dark");
+  });
+});

--- a/hushh-webapp/components/theme-toggle.tsx
+++ b/hushh-webapp/components/theme-toggle.tsx
@@ -26,7 +26,7 @@ const THEME_OPTIONS: Array<{
   { value: "system", label: "System", icon: Monitor },
 ];
 
-function resolveActiveTheme(theme: string | undefined): ThemeOption {
+export function resolveActiveTheme(theme: string | undefined): ThemeOption {
   const normalized = (theme ?? "").trim().toLowerCase();
   if (normalized === "light" || normalized === "dark" || normalized === "system") {
     return normalized as ThemeOption;


### PR DESCRIPTION
Characterises the resolveActiveTheme normalisation boundary in ThemeToggle:
- Returns correct ThemeOption for "light", "dark", "system"
- Falls back to "system" for undefined or unknown values
- Normalises whitespace and casing before comparison

Attach point: hushh-webapp/components/theme-toggle.tsx
Single file, single surface. No DOM rendering or mocks needed.