### PR TITLE
test(agent-voice-floating-indicator): cover null render when voice inactive

### DIFF
--- a/hushh-webapp/__tests__/components/agent-voice-floating-indicator.test.tsx
+++ b/hushh-webapp/__tests__/components/agent-voice-floating-indicator.test.tsx
@@ -1,0 +1,17 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/agent/agent-voice-state", () => ({
+  useAgentVoiceState: (selector: (s: { active: boolean; status: string; level: number; message: string }) => unknown) =>
+    selector({ active: false, status: "idle", level: 0, message: "" }),
+  getAgentVoiceStatusLabel: () => "Idle",
+}));
+
+import { AgentVoiceFloatingIndicator } from "@/components/agent/agent-voice-floating-indicator";
+
+describe("AgentVoiceFloatingIndicator", () => {
+  it("renders nothing when voice is inactive", () => {
+    const { container } = render(<AgentVoiceFloatingIndicator />);
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
Covers the null-render guard in AgentVoiceFloatingIndicator — when the 
voice state is inactive the component returns null and mounts nothing 
into the DOM.

Attach point: hushh-webapp/components/agent/agent-voice-floating-indicator.tsx
Single file, single surface.