### PR TITLE
test(accessibility-announcer): assert assertive mode sets aria-live="assertive"

### DIFF
--- a/hushh-webapp/__tests__/components/accessibility-status-announcer.test.tsx
+++ b/hushh-webapp/__tests__/components/accessibility-status-announcer.test.tsx
@@ -22,4 +22,18 @@ describe("AccessibilityStatusAnnouncer", () => {
 
     expect(container.innerHTML).toBe("");
   });
+
+  it("renders an assertive live region when assertive is true", () => {
+    render(
+      <AccessibilityStatusAnnouncer
+        message="Critical alert"
+        assertive
+      />,
+    );
+
+    const status = screen.getByRole("status");
+
+    expect(status.getAttribute("aria-live")).toBe("assertive");
+    expect(status.textContent).toBe("Critical alert");
+  });
 });


### PR DESCRIPTION
## Summary

Adds one additive contract test covering the `assertive` branch of
`AccessibilityStatusAnnouncer`.

## What & Why

`AccessibilityStatusAnnouncer` sets:

```tsx
aria-live={assertive ? "assertive" : "polite"}
```

The existing test suite verifies the default `"polite"` behavior but does
not exercise the `assertive` path. This test pins the accessibility
contract by verifying that enabling `assertive` sets
`aria-live="assertive"` while rendering the expected message.

## Changes

- Appends one `it()` block to
  `__tests__/components/accessibility-status-announcer.test.tsx`
- No production code changes
- No new imports
- No snapshots
- No existing tests modified

## Validation

```bash
npx vitest run __tests__/components/accessibility-status-announcer.test.tsx
```

## Checklist

- [x] Test-only change
- [x] Single existing test file modified
- [x] Append-only diff
- [x] No production code changes
- [x] No new imports
- [x] No snapshots
- [x] Existing tests preserved
- [x] DCO signed (`git commit -s`)