### PR TITLE
test(async-action-status): assert error state uses assertive aria-live

### DIFF
--- a/hushh-webapp/__tests__/components/async-action-status.test.tsx
+++ b/hushh-webapp/__tests__/components/async-action-status.test.tsx
@@ -21,4 +21,13 @@ describe("AsyncActionStatus", () => {
 
     expect(container.innerHTML).toBe("");
   });
+
+  it("renders an assertive error status with the default copy", () => {
+    render(<AsyncActionStatus state="error" />);
+
+    const status = screen.getByRole("status");
+
+    expect(status.getAttribute("aria-live")).toBe("assertive");
+    expect(status.textContent).toBe("Action failed");
+  });
 });


### PR DESCRIPTION
## Summary

Adds one additive contract test covering the `error` state of
`AsyncActionStatus`.

## What & Why

`AsyncActionStatus` renders an assertive live region for the `error`
state:

```tsx
aria-live="assertive"
```

while displaying the default copy `"Action failed"`.

The existing test suite exercises the retrying state but does not verify
this accessibility contract. This test documents and protects the current
behavior.

## Changes

- Appends one `it()` block to
  `__tests__/components/async-action-status.test.tsx`
- No production code changes
- No new imports
- No snapshots
- Existing tests remain unchanged

## Validation

```bash
npx vitest run __tests__/components/async-action-status.test.tsx
```

## Checklist

- [x] Test-only change
- [x] One existing file modified
- [x] Append-only diff
- [x] No production code changes
- [x] No import changes
- [x] No snapshots
- [x] Existing tests preserved
- [x] DCO signed (`git commit -s`)