### PR TITLE
test(drawer): assert DrawerContent renders with role="dialog"

### DIFF
--- a/hushh-webapp/__tests__/ui/drawer.test.tsx
+++ b/hushh-webapp/__tests__/ui/drawer.test.tsx
@@ -53,4 +53,16 @@ describe("DrawerFooter", () => {
       "env(safe-area-inset-bottom)",
     );
   });
+
+  it("renders with role='dialog'", () => {
+    render(
+      <Drawer open>
+        <DrawerContent>
+          <DrawerTitle>Test drawer</DrawerTitle>
+        </DrawerContent>
+      </Drawer>,
+    );
+
+    expect(screen.getByRole("dialog")).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary

Adds one additive contract test covering the accessibility role exposed by
`DrawerContent`.

## What & Why

`DrawerContent` renders a dialog surface through Vaul's dialog primitive.
The existing test suite verifies the close-button visibility contract, but
does not verify that the rendered content exposes the expected
`role="dialog"` accessibility contract.

This test documents and protects that behavior.

## Changes

- Appends one `it()` block to `__tests__/ui/drawer.test.tsx`
- No production code changes
- No new imports
- No snapshots
- Existing tests remain unchanged

## Validation

```bash
npx vitest run __tests__/ui/drawer.test.tsx
```

## Checklist

- [x] Test-only change
- [x] One existing file modified
- [x] Append-only diff
- [x] No production code changes
- [x] No import changes
- [x] No snapshots
- [x] Existing tests preserved
- [x] DCO signed (`git commit -s`)