### PR TITLE
test(accessibility-announcer): assert empty message renders nothing

### DIFF
--- a/hushh-webapp/__tests__/components/accessibility-status-announcer.test.tsx
+++ b/hushh-webapp/__tests__/components/accessibility-status-announcer.test.tsx
@@ -14,4 +14,12 @@ describe("AccessibilityStatusAnnouncer", () => {
     expect(status.className).toContain("sr-only");
     expect(status.textContent).toBe("Filters updated");
   });
+  
+  it("renders nothing when message is empty", () => {
+    const { container } = render(
+      <AccessibilityStatusAnnouncer message="" />,
+    );
+
+    expect(container.innerHTML).toBe("");
+  });
 });


### PR DESCRIPTION
## Summary

Adds one additive contract test covering the empty-message early-return
behavior of `AccessibilityStatusAnnouncer`.

## What & Why

`AccessibilityStatusAnnouncer` returns `null` when `message` is falsy:

```tsx
if (!message) return null;
```

The existing test suite covers rendering of populated live regions but
does not verify this early-return path. This test documents and protects
the current behavior.

## Changes

- Appends one `it()` block to
  `__tests__/components/accessibility-status-announcer.test.tsx`
- No production code changes
- No new imports
- No snapshots
- Existing tests remain unchanged

## Validation

```bash
npx vitest run __tests__/components/accessibility-status-announcer.test.tsx
```

## Checklist

- [x] Test-only change
- [x] One existing file modified
- [x] Append-only diff
- [x] No production code changes
- [x] No import changes
- [x] No snapshots
- [x] Existing tests preserved
- [x] DCO signed (`git commit -s`)