### PR TITLE
test(async-action-status): assert idle state renders nothing

### DIFF
--- a/hushh-webapp/__tests__/components/async-action-status.test.tsx
+++ b/hushh-webapp/__tests__/components/async-action-status.test.tsx
@@ -15,4 +15,10 @@ describe("AsyncActionStatus", () => {
       "true",
     );
   });
+
+  it("renders nothing when state is idle", () => {
+    const { container } = render(<AsyncActionStatus state="idle" />);
+
+    expect(container.innerHTML).toBe("");
+  });
 });


### PR DESCRIPTION
## Summary

Adds one additive contract test covering the `idle` early-return behavior
of `AsyncActionStatus`.

## What & Why

`AsyncActionStatus` returns `null` when `state === "idle"`.

The existing test suite covers rendered status states but does not verify
this early-return path. This test documents and protects the current
behavior.

## Changes

- Appends one `it()` block to
  `__tests__/components/async-action-status.test.tsx`
- No production code changes
- No new imports
- No snapshots
- Existing tests remain unchanged

## Validation

```bash
npx vitest run __tests__/components/async-action-status.test.tsx
```

## Checklist

- [x] Test-only change
- [x] One existing file modified
- [x] Append-only diff
- [x] No production code changes
- [x] No import changes
- [x] No snapshots
- [x] Existing tests preserved
- [x] DCO signed (`git commit -s`)