### PR TITLE
test(sheet): assert SheetTitle renders with data-slot="sheet-title"

### DIFF
--- a/hushh-webapp/__tests__/ui/sheet.test.tsx
+++ b/hushh-webapp/__tests__/ui/sheet.test.tsx
@@ -58,3 +58,19 @@ describe("SheetFooter", () => {
     ).toBeTruthy();
   });
 });
+
+describe("SheetTitle", () => {
+  it("renders with data-slot='sheet-title'", () => {
+    render(
+      <Sheet open>
+        <SheetContent>
+          <SheetTitle>Sheet title</SheetTitle>
+        </SheetContent>
+      </Sheet>,
+    );
+
+    expect(
+      document.querySelector('[data-slot="sheet-title"]'),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Adds one additive contract test covering the `SheetTitle` data-slot
attribute.

## What & Why

`SheetTitle` renders with `data-slot="sheet-title"` as part of the
component contract. Existing tests already verify related components such
as `SheetHeader` and `SheetFooter`, but `SheetTitle` was not covered.

This test documents and protects the existing behavior.

## Changes

- Appends one new `describe()` block to
  `__tests__/ui/sheet.test.tsx`
- No production code changes
- No new imports
- No snapshots
- Existing tests remain unchanged

## Validation

```bash
npx vitest run __tests__/ui/sheet.test.tsx
```

## Checklist

- [x] Test-only change
- [x] One existing file modified
- [x] Append-only diff
- [x] No production code changes
- [x] No import changes
- [x] No snapshots
- [x] Existing tests preserved
- [x] DCO signed (`git commit -s`)