### PR TITLE
test(status-bar-manager): cover null DOM render contract

### DIFF
--- a/hushh-webapp/__tests__/components/status-bar-manager.test.tsx
+++ b/hushh-webapp/__tests__/components/status-bar-manager.test.tsx
@@ -1,0 +1,22 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ resolvedTheme: "light", theme: "light" }),
+}));
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: { isNativePlatform: () => false },
+  SystemBars: {},
+  SystemBarsStyle: { Dark: "dark", Light: "light" },
+  SystemBarType: { StatusBar: "status", NavigationBar: "navigation" },
+}));
+
+import { StatusBarManager } from "@/components/status-bar-manager";
+
+describe("StatusBarManager", () => {
+  it("renders nothing into the DOM", () => {
+    const { container } = render(<StatusBarManager />);
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
Covers the null DOM render contract of StatusBarManager — the component 
always returns null and mounts nothing into the DOM. It is a native-only 
runtime bridge used in app/providers.tsx.

Attach point: hushh-webapp/app/providers.tsx imports StatusBarManager.
Single file, single surface.