### PR TITLE
test(popover): assert PopoverTitle renders as h2 element

### DIFF
--- a/hushh-webapp/__tests__/ui/popover.test.tsx
+++ b/hushh-webapp/__tests__/ui/popover.test.tsx
@@ -89,4 +89,12 @@ describe("Popover", () => {
     ).toBeTruthy();
   });
 
+  it("renders PopoverTitle as an h2 element", () => {
+    const { container } = render(<PopoverTitle>Section</PopoverTitle>);
+
+    const el = container.querySelector('[data-slot="popover-title"]');
+
+    expect(el?.tagName).toBe("H2");
+  });
+
 });


### PR DESCRIPTION
## Summary

Adds one additive contract test covering the semantic HTML element
rendered by `PopoverTitle`.

## What & Why

The existing test suite verifies the `data-slot="popover-title"`
attribute but does not verify the underlying HTML element.

`PopoverTitle` is expected to render as an `<h2>`, and this test
documents and protects that semantic contract.

## Changes

- Appends one `it()` block to
  `__tests__/ui/popover.test.tsx`
- No production code changes
- No new imports
- No snapshots
- Existing tests remain unchanged

## Validation

```bash
npx vitest run __tests__/ui/popover.test.tsx
```

## Checklist

- [x] Test-only change
- [x] One existing file modified
- [x] Append-only diff
- [x] No production code changes
- [x] No import changes
- [x] No snapshots
- [x] Existing tests preserved
- [x] DCO signed (`git commit -s`)