### PR TITLE
test(privacy-toggle): assert aria-checked false when unchecked

### DIFF
--- a/hushh-webapp/__tests__/components/privacy-toggle.test.tsx
+++ b/hushh-webapp/__tests__/components/privacy-toggle.test.tsx
@@ -64,4 +64,21 @@ describe("PrivacyToggle", () => {
     expect(toggle.getAttribute("tabindex")).toBe("-1");
     expect(handleCheckedChange).not.toHaveBeenCalled();
   });
+
+  it("reflects unchecked state via aria-checked false", () => {
+    render(
+      <PrivacyToggle
+        checked={false}
+        ariaLabel="Toggle analytics data"
+        onCheckedChange={() => {}}
+      />,
+    );
+
+    const toggle = screen.getByRole("switch", {
+      name: "Toggle analytics data",
+    });
+
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+  });
+
 });


### PR DESCRIPTION
## Summary

Adds one additive contract test covering the unchecked accessibility
state of `PrivacyToggle`.

## What & Why

The existing test suite verifies that `PrivacyToggle` exposes
`aria-checked="true"` when rendered in the checked state, but does not
verify the corresponding unchecked branch.

This test documents and protects the accessibility contract by asserting
that `aria-checked="false"` is rendered when `checked={false}`.

## Changes

- Appends one `it()` block to
  `__tests__/components/privacy-toggle.test.tsx`
- No production code changes
- No new imports
- No snapshots
- Existing tests remain unchanged

## Validation

```bash
npx vitest run __tests__/components/privacy-toggle.test.tsx
```

## Checklist

- [x] Test-only change
- [x] One existing file modified
- [x] Append-only diff
- [x] No production code changes
- [x] No import changes
- [x] No snapshots
- [x] Existing tests preserved
- [x] DCO signed (`git commit -s`)