### PR TITLE
test(vault-unlock-dialog): assert VaultFlow renders inside open dialog

### DIFF
--- a/hushh-webapp/__tests__/components/vault-unlock-dialog.test.tsx
+++ b/hushh-webapp/__tests__/components/vault-unlock-dialog.test.tsx
@@ -32,4 +32,19 @@ describe("VaultUnlockDialog", () => {
 
     expect(onOpenChange).not.toHaveBeenCalled();
   });
+
+  it("renders VaultFlow inside the open dialog", () => {
+    render(
+      <VaultUnlockDialog
+        user={user}
+        open
+        onSuccess={vi.fn()}
+        title="Unlock vault"
+        description="Enter your passphrase."
+      />,
+    );
+
+    expect(screen.getByTestId("vault-flow")).toBeTruthy();
+  });
+
 });


### PR DESCRIPTION
## Summary

Adds one additive contract test verifying that `VaultUnlockDialog`
renders the mocked `VaultFlow` component when the dialog is open.

## What & Why

`VaultUnlockDialog` is primarily responsible for composing and displaying
`VaultFlow` inside the dialog. While the existing tests cover dialog
behavior, they do not verify that the dialog renders its core content.

This test documents that composition contract by asserting the mocked
`VaultFlow` is present when `open={true}`.

## Changes

- Appends one `it()` block to
  `__tests__/components/vault-unlock-dialog.test.tsx`
- No production code changes
- No new imports
- No snapshots
- Existing tests remain unchanged

## Validation

```bash
npx vitest run __tests__/components/vault-unlock-dialog.test.tsx
```

## Checklist

- [x] Test-only change
- [x] One existing file modified
- [x] Append-only diff
- [x] No production code changes
- [x] No import changes
- [x] No new mocks introduced
- [x] No snapshots
- [x] Existing tests preserved
- [x] DCO signed (`git commit -s`)