### PR TITLE
test(onboarding-step-license): assert licence label-input association

### DIFF
--- a/hushh-webapp/__tests__/components/ria/onboarding-step-license.test.tsx
+++ b/hushh-webapp/__tests__/components/ria/onboarding-step-license.test.tsx
@@ -39,4 +39,21 @@ describe("OnboardingStepLicense", () => {
     expect(screen.getByRole("button", { name: "Verify licence" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Bypass for dev/UAT" })).toBeNull();
   });
+
+  it("associates licence label with input via htmlFor and id", () => {
+    const { container } = render(
+      <OnboardingStepLicense
+        licenseNumber=""
+        onLicenseNumberChange={vi.fn()}
+        verificationStatus="idle"
+        onVerify={vi.fn()}
+      />,
+    );
+
+    expect(container.querySelector("#ria-license-number")).toBeTruthy();
+
+    expect(
+      container.querySelector('label[for="ria-license-number"]'),
+    ).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary

Adds one additive accessibility contract test verifying that
`OnboardingStepLicense` correctly associates its licence label with the
license number input using matching `htmlFor` and `id` attributes.

## What & Why

The component renders:

- `<label htmlFor="ria-license-number">`
- `<input id="ria-license-number">`

This association is an important accessibility contract that enables
screen readers and improves form usability. The behavior already exists
but was previously untested.

## Changes

- Appends one `it()` block to
  `__tests__/components/ria/onboarding-step-license.test.tsx`
- No production code changes
- No new imports
- No snapshots
- Existing tests remain unchanged

## Validation

```bash
npx vitest run __tests__/components/ria/onboarding-step-license.test.tsx
```

## Checklist

- [x] Test-only change
- [x] Single existing file modified
- [x] Append-only diff
- [x] No production code changes
- [x] No import changes
- [x] No snapshots
- [x] Existing tests preserved
- [x] DCO signed (`git commit -s`)