### PR TITLE
test(runtime-settings): assert resolveVoiceFailFastPolicy returns false

### DIFF
--- a/hushh-webapp/__tests__/lib/runtime-settings.test.ts
+++ b/hushh-webapp/__tests__/lib/runtime-settings.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   resolveRuntimeBackendUrl,
   resolveVoiceDirectBackendPreference,
+  resolveVoiceFailFastPolicy,
 } from "@/lib/runtime/settings";
 
 describe("runtime settings", () => {
@@ -49,8 +50,12 @@ describe("runtime settings", () => {
   });
 
   it("treats false as disabled for direct backend preference", () => {
-  process.env.NEXT_PUBLIC_VOICE_DIRECT_BACKEND = "false";
+    process.env.NEXT_PUBLIC_VOICE_DIRECT_BACKEND = "false";
 
-  expect(resolveVoiceDirectBackendPreference()).toBe(false);
+    expect(resolveVoiceDirectBackendPreference()).toBe(false);
+  });
+
+  it("resolves voice fail-fast policy as false unconditionally", () => {
+    expect(resolveVoiceFailFastPolicy()).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Adds one focused unit test covering `resolveVoiceFailFastPolicy()` in the
existing runtime settings test suite.

## What & Why

`resolveVoiceFailFastPolicy()` currently returns `false`
unconditionally. While the existing suite covers
`resolveRuntimeBackendUrl()` and
`resolveVoiceDirectBackendPreference()`, this function had no direct
coverage.

This test documents and protects that contract with a single
deterministic assertion.

## Changes

- Extends the existing named import with
  `resolveVoiceFailFastPolicy`
- Appends one additive `it()` block to
  `__tests__/lib/runtime-settings.test.ts`
- No production code changes
- No mocks
- No snapshots
- Existing tests remain unchanged

## Validation

```bash
npx vitest run __tests__/lib/runtime-settings.test.ts
```

## Checklist

- [x] Test-only change
- [x] One existing file modified
- [x] One additive test
- [x] No production code changes
- [x] No snapshots
- [x] No mocks introduced
- [x] Deterministic assertions
- [x] Existing tests preserved
- [x] DCO signed (`git commit -s`)