### PR TITLE
test(browser-navigation): assert INTERNAL_APP_NAVIGATION_REQUEST_EVENT constant value

### DIFF
--- a/hushh-webapp/__tests__/lib/utils/browser-navigation.test.ts
+++ b/hushh-webapp/__tests__/lib/utils/browser-navigation.test.ts
@@ -130,4 +130,11 @@ describe("browser navigation utilities", () => {
     },
   ]);
   });
+
+  it("exports the correct string value for the internal navigation event name", () => {
+    expect(INTERNAL_APP_NAVIGATION_REQUEST_EVENT).toBe(
+      "app-internal-navigation-requested",
+    );
+  });
+
 });


### PR DESCRIPTION
## Summary

Adds one focused unit test asserting the exported value of
`INTERNAL_APP_NAVIGATION_REQUEST_EVENT` in the existing browser navigation
test suite.

## What & Why

The constant is already imported and used throughout the existing tests as
an event name, but its exported string value was never directly asserted.

Since external consumers bind to this event name, pinning its exact value
helps prevent accidental regressions.

## Changes

- Appends one `it()` block to
  `__tests__/lib/utils/browser-navigation.test.ts`
- No production code changes
- No import changes
- No mocks
- No snapshots
- Existing tests remain unchanged

## Validation

```bash
npx vitest run __tests__/lib/utils/browser-navigation.test.ts
```

## Checklist

- [x] Test-only change
- [x] One existing file modified
- [x] Append-only diff
- [x] No production code changes
- [x] No import changes
- [x] No mocks introduced
- [x] No snapshots
- [x] Deterministic assertion
- [x] Existing tests preserved
- [x] DCO signed (`git commit -s`)