### PR TITLE
test(route-scope): assert login route resolves to public scope

### DIFF
--- a/hushh-webapp/__tests__/navigation/route-scope.test.ts
+++ b/hushh-webapp/__tests__/navigation/route-scope.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+
+import { getRouteScope } from "@/lib/navigation/route-scope";
+import { ROUTES } from "@/lib/navigation/routes";
+
+describe("getRouteScope", () => {
+  it("resolves the login route to public scope", () => {
+    expect(getRouteScope(ROUTES.LOGIN)).toBe("public");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a focused unit test for `getRouteScope()` covering the login route
classification.

## What & Why

`getRouteScope()` classifies application routes into security scopes used
by routing and middleware. The login route is expected to resolve to the
`"public"` scope so it remains accessible without authentication.

This behavior existed but was not previously covered by a dedicated test.

## Changes

- Adds a new test file:
  `__tests__/navigation/route-scope.test.ts`
- One `describe()` block
- One deterministic `it()` block
- No production code changes
- No mocks
- No snapshots

## Validation

```bash
npx vitest run __tests__/navigation/route-scope.test.ts
```

## Checklist

- [x] Test-only change
- [x] One new test file
- [x] No production code changes
- [x] No snapshots
- [x] No mocks
- [x] Deterministic assertion
- [x] Uses `ROUTES.LOGIN` rather than a hardcoded path
- [x] DCO signed (`git commit -s`)