### PR TITLE
test(app-env): assert legacy environment mode staging normalizes to uat

### DIFF
--- a/hushh-webapp/__tests__/lib/app-env.test.ts
+++ b/hushh-webapp/__tests__/lib/app-env.test.ts
@@ -78,4 +78,13 @@ describe("resolveAppEnvironment", () => {
 
     expect(resolveFreshAppEnvironment()).toBe("uat");
   });
+
+  it("normalizes staging to uat via the legacy environment mode fallback", () => {
+    delete process.env.NEXT_PUBLIC_APP_ENV;
+    delete process.env.NEXT_PUBLIC_OBSERVABILITY_ENV;
+    process.env.NEXT_PUBLIC_ENVIRONMENT_MODE = "staging";
+
+    expect(resolveAppEnvironment()).toBe("uat");
+  });
+
 });


### PR DESCRIPTION
## Summary

Adds one focused characterization test covering the legacy environment
fallback path in the existing `app-env` test suite.

## What & Why

The current suite already verifies that `"staging"` normalizes to `"uat"`
when provided through `NEXT_PUBLIC_APP_ENV`.

This PR covers the equivalent behavior through the lower-priority legacy
environment variable (`NEXT_PUBLIC_ENVIRONMENT_MODE`), ensuring the
fallback path continues to normalize `"staging"` to `"uat"`.

## Changes

- Appends one `it()` block to `__tests__/lib/app-env.test.ts`
- No production code changes
- No new imports
- No snapshots
- Existing tests remain unchanged

## Validation

```bash
npx vitest run __tests__/lib/app-env.test.ts
```

## Checklist

- [x] Test-only change
- [x] One additive test
- [x] No production code changes
- [x] No snapshots
- [x] No mocks
- [x] Deterministic
- [x] Existing `afterEach` handles environment cleanup
- [x] DCO signed (`git commit -s`)