### PR TITLE
test(constants): assert CONSENT_TOKEN_PREFIX constant contract

### DIFF
--- a/hushh-webapp/__tests__/lib/constants.test.ts
+++ b/hushh-webapp/__tests__/lib/constants.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { CONSENT_TOKEN_PREFIX } from "@/lib/constants";
+
+describe("constants", () => {
+  it("exports the correct consent token prefix", () => {
+    expect(CONSENT_TOKEN_PREFIX).toBe("HCT");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a focused test for `CONSENT_TOKEN_PREFIX` in a new test file under
`__tests__/lib`.

## What & Why

`CONSENT_TOKEN_PREFIX` is part of the public contract used for consent
token generation and validation. This test locks its expected value to
prevent accidental regressions.

## Changes

- Adds `__tests__/lib/constants.test.ts`
- One `describe()` block
- One deterministic `it()` block
- No production code changes
- No existing tests modified
- No mocks
- No snapshots

## Validation

```bash
npx vitest run __tests__/lib/constants.test.ts
```

## Checklist

- [x] Test-only change
- [x] New test file
- [x] No production code changes
- [x] No snapshots
- [x] No mocks
- [x] Deterministic
- [x] DCO signed (`git commit -s`)