### PR TITLE
test(utils): characterize formatCompleteJson on non-enumerable properties

### DIFF
--- a/hushh-webapp/__tests__/utils/format-json-enumerable.test.ts
+++ b/hushh-webapp/__tests__/utils/format-json-enumerable.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCompleteJson } from "@/lib/utils/json-to-human";
+
+// Characterization tests for formatCompleteJson
+// (hushh-webapp/lib/utils/json-to-human.ts) for properties defined via
+// `Object.defineProperty` — specifically NON-ENUMERABLE properties.
+//
+// TRUTH-FIRST — LITERAL CONTRACT:
+//
+// Top-level iteration is `for (const [sectionKey, sectionValue] of
+// Object.entries(json))`, and nested object iteration is also
+// `Object.entries(...)`. `Object.entries` returns ONLY own ENUMERABLE
+// string-keyed properties. `Object.defineProperty` defaults `enumerable` to
+// `false`, so a property added that way is invisible to `Object.entries` unless
+// `enumerable: true` is explicitly passed.
+//
+// Therefore formatCompleteJson NEVER reads non-enumerable properties — there is
+// no "parsing of hidden attributes". It simply skips them, identical to an
+// object that never had the property at all. This is the literal property
+// boundary: enumerable-own-string only.
+
+describe("formatCompleteJson — non-enumerable property handling", () => {
+  it("ignores a top-level non-enumerable property entirely", () => {
+    const obj: Record<string, unknown> = {};
+    Object.defineProperty(obj, "account_metadata", {
+      value: { account_number: "123" },
+      enumerable: false, // default, stated for clarity
+      configurable: true,
+      writable: true,
+    });
+    // No enumerable keys -> no output.
+    expect(formatCompleteJson(obj)).toBe("");
+  });
+
+  it("renders an enumerable: true defineProperty value (boundary control)", () => {
+    const obj: Record<string, unknown> = {};
+    Object.defineProperty(obj, "account_metadata", {
+      value: { account_number: "123" },
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+    expect(formatCompleteJson(obj)).toBe(
+      "\n--- Account Information ---\n  Account Number: 123",
+    );
+  });
+
+  it("renders only the enumerable sibling when mixed with a non-enumerable one", () => {
+    const obj: Record<string, unknown> = { account_metadata: { account_number: "123" } };
+    Object.defineProperty(obj, "portfolio_summary", {
+      value: { total_value: 999 },
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    });
+    // The non-enumerable portfolio_summary is skipped; only account_metadata shows.
+    expect(formatCompleteJson(obj)).toBe(
+      "\n--- Account Information ---\n  Account Number: 123",
+    );
+  });
+
+
+  it("renders identically to an object that never had the non-enumerable key", () => {
+    const withHidden: Record<string, unknown> = { account_metadata: { account_number: "123" } };
+    Object.defineProperty(withHidden, "portfolio_summary", {
+      value: { total_value: 999 },
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    });
+    const without: Record<string, unknown> = { account_metadata: { account_number: "123" } };
+    expect(formatCompleteJson(withHidden)).toBe(formatCompleteJson(without));
+  });
+
+  it("ignores a NESTED non-enumerable property inside a section object", () => {
+    const nested: Record<string, unknown> = { account_number: "123" };
+    Object.defineProperty(nested, "ssn", {
+      value: "secret",
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    });
+    // Nested iteration also uses Object.entries -> "ssn" is invisible.
+    expect(formatCompleteJson({ account_metadata: nested })).toBe(
+      "\n--- Account Information ---\n  Account Number: 123",
+    );
+
+  });
+
+  it("treats an all-non-enumerable object as empty output", () => {
+    const obj: Record<string, unknown> = {};
+    Object.defineProperty(obj, "a", { value: 1, enumerable: false });
+    Object.defineProperty(obj, "b", { value: 2, enumerable: false });
+    expect(formatCompleteJson(obj)).toBe("");
+  });
+
+  it("does NOT read non-enumerable getter-backed accessors", () => {
+    const obj: Record<string, unknown> = {};
+    let getterCalls = 0;
+    Object.defineProperty(obj, "account_metadata", {
+      get() {
+        getterCalls += 1;
+        return { account_number: "123" };
+      },
+      enumerable: false,
+      configurable: true,
+    });
+    expect(formatCompleteJson(obj)).toBe("");
+    // Object.entries never enumerates it, so the getter is never invoked.
+    expect(getterCalls).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an isolated characterization test for `formatCompleteJson`
(`hushh-webapp/lib/utils/json-to-human.ts`) documenting its exact contract for
properties created via `Object.defineProperty`, specifically **non-enumerable**
properties. Test-only; no production change.

## Literal contract being characterized

Top-level iteration is `for (const [sectionKey, sectionValue] of Object.entries(json))`,
and nested object iteration is also `Object.entries(...)`. `Object.entries`
returns **only own enumerable string-keyed** properties. `Object.defineProperty`
defaults `enumerable` to `false`, so a property added that way is invisible to
`Object.entries` unless `enumerable: true` is passed explicitly.

## Truth-first note on the task premise

The task asks how the formatter "ignores or parses these hidden attributes." The
literal answer is: it **never parses** them. There is no hidden-attribute reading
path — non-enumerable properties are simply not iterated, so the output is
identical to an object that never had the property. The property boundary is
exactly: own + enumerable + string-keyed.

## Behavior pinned (7 cases)

- Top-level non-enumerable `account_metadata` → `""` (skipped entirely)
- Same key with `enumerable: true` → `\n--- Account Information ---\n  Account Number: 123`
  (boundary control proving the value itself is renderable; only enumerability gates it)
- Non-enumerable sibling alongside an enumerable section → only the enumerable
  section renders
- An object with a non-enumerable key renders **identically** to one that never
  had the key (`toBe` equality of both outputs)
- **Nested** non-enumerable property (`ssn` inside a section object) → invisible,
  because nested iteration also uses `Object.entries`
- All-non-enumerable object → `""`
- **Non-enumerable accessor (getter)** → `""` **and the getter is never invoked**
  (`getterCalls === 0`), proving `Object.entries` never even touches it

## Header-format correction (caught locally)

My first draft asserted `=== Label ===`; the local run showed the real header is
`--- Label ---`. Expectations were corrected to the actual output before the
final green run — pinning real behavior, not an assumed format.

## Truth-first scope note

The original task referenced `hushh-research/__tests__/utils/...` and
`npm test -- hushh-research/...`. There is no top-level `__tests__` in this repo;
vitest only includes `__tests__/**` under `hushh-webapp`, and the module alias is
`@/lib/utils/json-to-human`. The file therefore lives at
`hushh-webapp/__tests__/utils/format-json-enumerable.test.ts`.

## Verification

- `npm test -- __tests__/utils/format-json-enumerable.test.ts` → 7/7 pass
- `git status` limited to the single new test file; zero production source drift
- (An IDE-only `@/` module-resolution warning is a false positive — the alias
  resolves under vitest, as the passing run confirms.)

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the real "enumerable-own-string only; non-enumerable
  skipped, getter never invoked" boundary
