### PR TITLE
test(consent-display): characterize humanizeConsentScope for vault.owner

### DIFF
--- a/hushh-webapp/__tests__/utils/consent-display.test.ts
+++ b/hushh-webapp/__tests__/utils/consent-display.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { humanizeConsentScope } from "@/lib/consent/consent-display";
+
+describe("consent-display", () => {
+  describe("humanizeConsentScope", () => {
+    it("preserves the full vault access label for vault.owner", () => {
+      expect(humanizeConsentScope("vault.owner")).toBe("Full vault access");
+    });
+
+    it("preserves the consent request fallback for empty scope", () => {
+      expect(humanizeConsentScope("")).toBe("Consent request");
+      expect(humanizeConsentScope(null)).toBe("Consent request");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a focused characterization test for `humanizeConsentScope` in
`lib/consent/consent-display.ts`.

This introduces a dedicated test file covering the `"vault.owner"`
mapping together with the empty/null fallback behavior.

## What & Why

`humanizeConsentScope()` is a pure exported helper used when presenting
consent scopes to users.

This PR characterizes two existing behaviors:

- `"vault.owner"` → `"Full vault access"`
- `""` and `null` → `"Consent request"`

Locking these outputs helps prevent unintended changes to user-facing
consent copy.

## Scope

- New test file only
- No production code changes
- No existing tests modified
- No snapshots
- No mocks
- Deterministic assertions only

## Validation

```bash
npx vitest run __tests__/utils/consent-display.test.ts
```

## Checklist

- [x] Test-only change
- [x] New test file
- [x] No production code changes
- [x] No snapshots
- [x] No mocks
- [x] Deterministic
- [x] DCO signed (`git commit -s`)