### PR TITLE
test(navigation): characterize resolveInternalRouteHref parameter array empty strings

### DIFF
--- a/hushh-webapp/__tests__/navigation/resolve-array-empty-strings.test.ts
+++ b/hushh-webapp/__tests__/navigation/resolve-array-empty-strings.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for resolveInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts) for query strings that carry repeated
+// array-style parameters with consecutive empty-string values, e.g.
+// `/api/v1?filters=&filters=&filters=active`.
+//
+// TRUTH-FIRST — LITERAL CONTRACT:
+//
+//   export function resolveInternalRouteHref(value, fallback): string {
+//     return normalizeInternalRouteHref(value) ?? fallback;
+//   }
+//
+// and normalizeInternalRouteHref:
+//
+//   const href = String(value ?? "").trim();
+//   if (!href) return null;
+//   if (!href.startsWith("/") || href.startsWith("//")) return null;
+//   if (/[\r\n]/.test(href)) return null;
+//   return href;
+//
+// CORRECTION TO THE TASK PREMISE: there is NO query parsing, NO array
+// extraction, and NO "construction/retention of blank positions". The function
+// is a pure allow/deny gate over the trimmed string. If the href passes the
+// three guards it is returned VERBATIM (query block untouched, every empty
+// `filters=` preserved exactly in place). If it fails a guard, the FALLBACK is
+// returned unchanged. These tests pin that real contract.
+
+const FALLBACK = "/fallback";
+
+describe("resolveInternalRouteHref — array params with consecutive empty strings", () => {
+  it("returns the href verbatim, preserving every empty array position", () => {
+    expect(
+      resolveInternalRouteHref("/api/v1?filters=&filters=&filters=active", FALLBACK),
+    ).toBe("/api/v1?filters=&filters=&filters=active");
+  });
+
+  it("does not collapse, dedupe, or reorder the repeated empty params", () => {
+    const out = resolveInternalRouteHref(
+      "/api/v1?filters=&filters=&filters=active",
+      FALLBACK,
+    );
+    // Three `filters=` occurrences are all retained.
+    expect(out.match(/filters=/g)?.length).toBe(3);
+  });
+
+  it("preserves a fully-empty array (all positions blank) verbatim", () => {
+    expect(
+      resolveInternalRouteHref("/api/v1?filters=&filters=&filters=", FALLBACK),
+    ).toBe("/api/v1?filters=&filters=&filters=");
+  });
+
+  it("preserves a leading empty position before a value", () => {
+    expect(resolveInternalRouteHref("/x?a=&a=1", FALLBACK)).toBe("/x?a=&a=1");
+  });
+
+  it("preserves bracketed array syntax with empty values verbatim", () => {
+    expect(
+      resolveInternalRouteHref("/x?a[]=&a[]=&a[]=z", FALLBACK),
+    ).toBe("/x?a[]=&a[]=&a[]=z");
+  });
+
+  it("trims outer whitespace but keeps the empty array positions intact", () => {
+    expect(
+      resolveInternalRouteHref("  /api/v1?filters=&filters=  ", FALLBACK),
+    ).toBe("/api/v1?filters=&filters=");
+  });
+
+  it("falls back when the array-bearing href is protocol-relative (//)", () => {
+    expect(
+      resolveInternalRouteHref("//evil.example/api?filters=&filters=", FALLBACK),
+    ).toBe(FALLBACK);
+  });
+
+  it("falls back when the array-bearing href is not rooted", () => {
+    expect(
+      resolveInternalRouteHref("api/v1?filters=&filters=", FALLBACK),
+    ).toBe(FALLBACK);
+  });
+
+  it("falls back when the array-bearing href contains a newline", () => {
+    expect(
+      resolveInternalRouteHref("/api/v1?filters=&filters=\ninject", FALLBACK),
+    ).toBe(FALLBACK);
+  });
+
+  it("falls back for null/empty input (no query to parse)", () => {
+    expect(resolveInternalRouteHref(null, FALLBACK)).toBe(FALLBACK);
+    expect(resolveInternalRouteHref("", FALLBACK)).toBe(FALLBACK);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an isolated characterization test for `resolveInternalRouteHref`
(`hushh-webapp/lib/navigation/routes.ts`) documenting its exact behavior when a
candidate href carries repeated array-style query params with consecutive empty
strings, e.g. `/api/v1?filters=&filters=&filters=active`. Test-only; no
production change.

## Literal contract being characterized

```ts
export function resolveInternalRouteHref(value, fallback): string {
  return normalizeInternalRouteHref(value) ?? fallback;
}

// normalizeInternalRouteHref:
const href = String(value ?? "").trim();
if (!href) return null;
if (!href.startsWith("/") || href.startsWith("//")) return null;
if (/[\r\n]/.test(href)) return null;
return href;
```

## Truth-first correction to the task premise

The task asks how "the extraction process constructs and retains these blank
positions." **There is no extraction process.** `resolveInternalRouteHref` does
no query parsing, no array splitting, no decoding, and no construction of any
position list. It is a pure allow/deny gate over the trimmed string:

- If the href passes the three guards (non-empty, single leading `/`, no CR/LF),
  it is returned **verbatim** — the entire query block, including every empty
  `filters=` slot, is preserved exactly in place.
- If it fails any guard, the supplied **fallback** is returned unchanged.

So the consecutive empty array positions are "retained" only in the trivial sense
that the whole string is passed through untouched — not because any parser
models them. These tests pin that real boundary so future readers don't assume a
URL/array parser exists here.

## Behavior pinned (10 cases)

- `/api/v1?filters=&filters=&filters=active` returned verbatim
- repeated empty params are not collapsed/deduped/reordered (3 `filters=` kept)
- fully-empty array `filters=&filters=&filters=` preserved verbatim
- leading empty position `?a=&a=1` preserved
- bracketed array syntax `?a[]=&a[]=&a[]=z` preserved verbatim
- outer whitespace trimmed while empty array positions stay intact
- protocol-relative `//evil.example/...?filters=&filters=` → fallback
- non-rooted `api/v1?filters=&filters=` → fallback
- newline-bearing `?filters=&filters=\ninject` → fallback
- `null`/empty input → fallback

## Truth-first scope note

The original task referenced `hushh-research/__tests__/navigation/...`, a bare
`lib/navigation/routes.ts` import, and `npm test -- hushh-research/...`. There is
no top-level `__tests__` in this repo; vitest only includes `__tests__/**` under
`hushh-webapp`, and the module alias is `@/lib/navigation/routes`. The file
therefore lives at
`hushh-webapp/__tests__/navigation/resolve-array-empty-strings.test.ts` and
imports via the `@/` alias.

## Verification

- `npm test -- __tests__/navigation/resolve-array-empty-strings.test.ts` → 10/10 pass
- `git status` limited to the single new test file; zero production source drift

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — corrects the "extraction/construction" premise; pins the real
  "no parse; verbatim passthrough or fallback" contract
