### PR TITLE
test(consent-events): characterize consent state changed event constant

### DIFF
--- a/hushh-webapp/__tests__/utils/consent-events.test.ts
+++ b/hushh-webapp/__tests__/utils/consent-events.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { CONSENT_STATE_CHANGED_EVENT } from "@/lib/consent/consent-events";
+
+describe("consent-events", () => {
+  it("preserves the consent-state-changed event name", () => {
+    expect(CONSENT_STATE_CHANGED_EVENT).toBe("consent-state-changed");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a focused characterization test for the exported
`CONSENT_STATE_CHANGED_EVENT` constant in
`lib/consent/consent-events.ts`.

## What & Why

`CONSENT_STATE_CHANGED_EVENT` defines the event name used for consent
state change notifications throughout the application.

This test locks the exported string value to help prevent accidental
renames that could silently break event listeners.

## Scope

- New test file only
- No production code changes
- No existing tests modified
- No mocks
- No snapshots
- Deterministic assertion

## Validation

```bash
npx vitest run __tests__/utils/consent-events.test.ts
```

## Checklist

- [x] Test-only change
- [x] New test file
- [x] No production code changes
- [x] No snapshots
- [x] No mocks
- [x] Deterministic
- [x] DCO signed (`git commit -s`)