### PR TITLE
test(email-helper-consent): characterize email helper consent detection

### DIFF
--- a/hushh-webapp/__tests__/utils/email-helper-consent.test.ts
+++ b/hushh-webapp/__tests__/utils/email-helper-consent.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { isEmailHelperConsent } from "@/lib/consent/email-helper-consent";
+
+describe("email-helper-consent", () => {
+  describe("isEmailHelperConsent", () => {
+    it("preserves detection for the one_email_kyc_v1 request source", () => {
+      expect(
+        isEmailHelperConsent({ request_source: "one_email_kyc_v1" }),
+      ).toBe(true);
+    });
+
+    it("preserves detection for paired workflow and gmail thread ids", () => {
+      expect(
+        isEmailHelperConsent({
+          workflow_id: "wf-123",
+          gmail_thread_id: "thread-456",
+        }),
+      ).toBe(true);
+    });
+
+    it("preserves false for unrelated metadata", () => {
+      expect(isEmailHelperConsent({})).toBe(false);
+      expect(isEmailHelperConsent(null)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a focused characterization test for `isEmailHelperConsent` in
`lib/consent/email-helper-consent.ts`.

This introduces a dedicated test file covering the three existing
decision paths of the helper.

## What & Why

`isEmailHelperConsent` determines whether a consent request should be
treated as an Email Helper workflow.

This PR characterizes the current behavior by verifying:

- `request_source: "one_email_kyc_v1"` returns `true`
- A paired `workflow_id` and `gmail_thread_id` returns `true`
- Empty or unrelated metadata returns `false`

These assertions help protect the consent routing logic from unintended
regressions.

## Scope

- New test file only
- No production code changes
- No existing tests modified
- No mocks
- No snapshots
- Deterministic assertions only

## Validation

```bash
npx vitest run __tests__/utils/email-helper-consent.test.ts
```

## Checklist

- [x] Test-only change
- [x] New test file
- [x] No production code changes
- [x] No snapshots
- [x] No mocks
- [x] Deterministic
- [x] DCO signed (`git commit -s`)