### PR TITLE
test(utils): characterize formatCompleteJson on native error instances

### DIFF
--- a/hushh-webapp/__tests__/utils/format-json-errors.test.ts
+++ b/hushh-webapp/__tests__/utils/format-json-errors.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCompleteJson } from "@/lib/utils/json-to-human";
+
+// Characterization tests for formatCompleteJson
+// (hushh-webapp/lib/utils/json-to-human.ts) when native JavaScript Error
+// instances are embedded directly as dictionary values.
+//
+// TRUTH-FIRST — LITERAL CONTRACT:
+//
+// formatCompleteJson iterates exclusively with `Object.entries(...)` at every
+// level. `Object.entries` returns only OWN + ENUMERABLE + string-keyed
+// properties. On a native Error, the standard `message`, `stack`, and `name`
+// properties are NON-ENUMERABLE (message/stack are own-but-non-enumerable; name
+// lives on the prototype). Therefore:
+//
+//   - An Error passed as a top-level SECTION value is `typeof === "object"` and
+//     not an array, so it emits the section header block:
+//         ""                       (blank separator line)
+//         "--- <Label> ---"
+//     and then `Object.entries(error)` yields NOTHING enumerable, so NO
+//     `message`/`stack`/`name` lines are produced.
+//
+//   - The ONLY way Error content surfaces is via OWN ENUMERABLE properties that
+//     code explicitly assigns (e.g. `err.code = "E_FAIL"`), which `Object.entries`
+//     then does include.
+//
+// These tests pin that real mapping baseline: stack traces and the built-in
+// message are invisible; only explicitly-assigned enumerable fields render.
+
+describe("formatCompleteJson — native Error instances as values", () => {
+  it("emits only the section header for a bare Error (message/stack are non-enumerable)", () => {
+    const out = formatCompleteJson({ failure: new Error("failed task") });
+    expect(out).toBe("\n--- Failure ---");
+  });
+
+  it("does not leak the Error message anywhere in the output", () => {
+    const out = formatCompleteJson({ failure: new Error("failed task") });
+    expect(out).not.toContain("failed task");
+    expect(out).not.toContain("message");
+  });
+
+  it("does not leak the Error stack trace into the output", () => {
+    const err = new Error("boom");
+    const out = formatCompleteJson({ failure: err });
+    expect(out).not.toContain("stack");
+    // A real stack mentions this test file / "Error:"; none of it should appear.
+    expect(out).not.toContain("Error:");
+    expect(out).not.toContain(".test.ts");
+  });
+
+  it("renders ONLY explicitly-assigned own enumerable properties on an Error", () => {
+    const err = new Error("failed task") as Error & {
+      code?: string;
+      detail?: string;
+    };
+    err.code = "E_FAIL";
+    err.detail = "downstream timeout";
+    const out = formatCompleteJson({ failure: err });
+    // Header + the two enumerable fields, in insertion order; message/stack absent.
+    expect(out).toBe(
+      [
+        "",
+        "--- Failure ---",
+        "  Code: E_FAIL",
+        "  Detail: downstream timeout",
+      ].join("\n"),
+    );
+  });
+
+  it("treats a nested Error value as an empty object (label with no children)", () => {
+    const out = formatCompleteJson({
+      section: { cause: new Error("nested failure") },
+    });
+    // The Error is object & non-array → emits the "Cause:" label header, then
+    // Object.entries(error) yields nothing enumerable → no nested bullet lines.
+    expect(out).toBe(
+      ["", "--- Section ---", "  Cause:"].join("\n"),
+    );
+    expect(out).not.toContain("nested failure");
+  });
+
+  it("renders an Error inside an array via the generic first-enumerable-value path", () => {
+    // Generic array branch uses Object.values(item).find(...) for the first
+    // non-null value. A bare Error has no enumerable values → falls back to
+    // the literal string "Item".
+    const out = formatCompleteJson({ items: [new Error("x")] });
+    expect(out).toBe(
+      ["", "--- Items (1 items) ---", "  • Item"].join("\n"),
+    );
+    expect(out).not.toContain("x");
+  });
+
+  it("uses the first enumerable own value for an Error in an array when one exists", () => {
+    const err = new Error("ignored message") as Error & { code?: string };
+    err.code = "E42";
+    const out = formatCompleteJson({ items: [err] });
+    expect(out).toBe(
+      ["", "--- Items (1 items) ---", "  • E42"].join("\n"),
+    );
+    expect(out).not.toContain("ignored message");
+  });
+
+  it("renders subclass-ASSIGNED fields (incl. an assigned name) but never the built-in message", () => {
+    // NUANCE pinned by the local run: assigning `this.name = ...` in a subclass
+    // constructor creates an OWN ENUMERABLE `name` that SHADOWS the prototype's
+    // non-enumerable `name`. So an assigned `name` DOES render, as does any
+    // assigned `status`. The built-in (super) `message` stays non-enumerable and
+    // remains hidden.
+    class HttpError extends Error {
+      status: number;
+      constructor(message: string, status: number) {
+        super(message);
+        this.name = "HttpError"; // assignment → own + enumerable → rendered
+        this.status = status; // own + enumerable → rendered
+      }
+    }
+    const out = formatCompleteJson({ request: new HttpError("nope", 503) });
+    expect(out).toBe(
+      ["", "--- Request ---", "  Status: 503", "  Name: HttpError"].join("\n"),
+    );
+    // The super() message is non-enumerable → never surfaces.
+    expect(out).not.toContain("nope");
+  });
+});


### PR DESCRIPTION
## Summary

Adds an isolated characterization test for `formatCompleteJson`
(`hushh-webapp/lib/utils/json-to-human.ts`) documenting its exact output when
native JavaScript `Error` instances are embedded directly as dictionary values
(e.g. `new Error("failed task")`). Test-only; no production change.

## Truth-first mapping baseline

`formatCompleteJson` walks every level with `Object.entries(...)`, which returns
only **own + enumerable + string-keyed** properties. On a native `Error`:

- `message` and `stack` are **own but non-enumerable**
- `name` lives on the **prototype** (non-enumerable)

So `Object.entries(error)` yields **nothing** for a bare Error. The function
therefore treats an Error like an empty object — it emits the section/label
header and **no** message or stack lines. The built-in message and the full
stack trace are **never** rendered. Error content surfaces **only** through
properties that code explicitly assigns (e.g. `err.code = "E_FAIL"`), which are
own + enumerable.

## Behavior pinned (8 cases)

- bare Error as a top-level section → `"\n--- Failure ---"` only
- Error message never leaks into output
- Error stack trace never leaks (`stack` / `Error:` / `.test.ts` absent)
- only explicitly-assigned own enumerable props render (`code`, `detail`)
- nested Error value → `"Cause:"` label header with no children, message hidden
- Error in an array (generic branch) → falls back to literal `"• Item"`
- Error in an array with an assigned enumerable value → uses that first value
- subclass that assigns `this.name`/`this.status` → those render (assignment
  creates an own enumerable `name` that shadows the prototype), but the `super()`
  message stays hidden

## Truth-first correction recorded during local verification

The local run corrected one of my initial assumptions: I expected a subclass's
`name` to stay hidden, but assigning `this.name = "HttpError"` in the constructor
creates an **own enumerable** `name` that shadows the prototype's non-enumerable
one — so it **does** render. The test now pins that real behavior (assigned
fields render; only the built-in `super()` message stays non-enumerable/hidden).

## Truth-first scope note

The task referenced `hushh-research/__tests__/utils/...` and a bare
`'formatCompleteJson'` import. There is no top-level `__tests__` here; vitest only
includes `__tests__/**` under `hushh-webapp`, and the module alias is
`@/lib/utils/json-to-human`. The file therefore lives at
`hushh-webapp/__tests__/utils/format-json-errors.test.ts` and imports via `@/`.

## Verification

- `npm test -- __tests__/utils/format-json-errors.test.ts` → 8/8 pass
- `git status` limited to the single new test file; zero production source drift

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — pins the real "Object.entries → own+enumerable only; built-in
  message/stack hidden" mapping for Error instances
