### PR TITLE
test(kai-command-bar-events): characterize command bar open event constant

### DIFF
--- a/hushh-webapp/__tests__/navigation/kai-command-bar-events.test.ts
+++ b/hushh-webapp/__tests__/navigation/kai-command-bar-events.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { KAI_COMMAND_BAR_OPEN_EVENT } from "@/lib/navigation/kai-command-bar-events";
+
+describe("kai-command-bar-events", () => {
+  it("preserves the kai command bar open event name", () => {
+    expect(KAI_COMMAND_BAR_OPEN_EVENT).toBe("kai:command-bar:open");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a focused characterization test for
`KAI_COMMAND_BAR_OPEN_EVENT` exported from
`lib/navigation/kai-command-bar-events.ts`.

This introduces a dedicated test file that locks the exported event
name used across the application.

## What & Why

`KAI_COMMAND_BAR_OPEN_EVENT` is shared between event dispatchers and
listeners responsible for opening the Kai command bar.

This test characterizes the existing contract by asserting the exported
constant remains:

```ts
"kai:command-bar:open"
```

Locking this value helps prevent accidental regressions that would break
cross-component event communication.

## Scope

- New test file only
- No production code changes
- No existing tests modified
- No mocks
- No snapshots
- Deterministic assertion

## Validation

```bash
npx vitest run __tests__/navigation/kai-command-bar-events.test.ts
```

## Checklist

- [x] Test-only change
- [x] New test file
- [x] No production code changes
- [x] No snapshots
- [x] No mocks
- [x] Deterministic
- [x] DCO signed (`git commit -s`)