### PR TITLE
test(debate-stream-state): characterize initial round collapse state

### DIFF
--- a/hushh-webapp/__tests__/components/debate-stream-state.test.ts
+++ b/hushh-webapp/__tests__/components/debate-stream-state.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { getInitialRoundCollapseState } from "@/components/kai/debate-stream-state";
+
+describe("debate-stream-state", () => {
+  describe("getInitialRoundCollapseState", () => {
+    it("preserves round 1 expanded and round 2 collapsed by default", () => {
+      expect(getInitialRoundCollapseState()).toEqual({
+        1: false,
+        2: true,
+      });
+    });
+
+    it("preserves a fresh object on each call", () => {
+      expect(getInitialRoundCollapseState()).not.toBe(
+        getInitialRoundCollapseState(),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a focused characterization test for
`getInitialRoundCollapseState` in
`components/kai/debate-stream-state.ts`.

This introduces a dedicated test file covering the utility's default
return value and its fresh-object-per-call behavior.

## What & Why

`getInitialRoundCollapseState()` initializes the expand/collapse state
for debate stream rounds.

This test characterizes two existing contracts:

- the default state is:

```ts
{ 1: false, 2: true }
```

- each invocation returns a new object instance rather than sharing a
mutable reference.

Locking these behaviors helps prevent accidental regressions in initial
UI state and shared-state bugs.

## Scope

- New test file only
- No production code changes
- No existing tests modified
- No mocks
- No snapshots
- Deterministic assertions

## Validation

```bash
npx vitest run __tests__/components/debate-stream-state.test.ts
```

## Checklist

- [x] Test-only change
- [x] New test file
- [x] No production code changes
- [x] No snapshots
- [x] No mocks
- [x] Deterministic
- [x] DCO signed (`git commit -s`)