### PR TITLE
test(navigation): characterize normalizeInternalRouteHref windows dynamic path slashes

### DIFF
--- a/hushh-webapp/__tests__/navigation/normalize-windows-slashes.test.ts
+++ b/hushh-webapp/__tests__/navigation/normalize-windows-slashes.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for normalizeInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts) for path sequences that resemble
+// Windows file delimiters / backslashes, e.g. "/app\\legal\\privacy".
+//
+// TRUTH-FIRST — LITERAL CONTRACT:
+//
+//   export function normalizeInternalRouteHref(value): string | null {
+//     const href = String(value ?? "").trim();
+//     if (!href) return null;
+//     if (!href.startsWith("/") || href.startsWith("//")) return null;
+//     if (/[\r\n]/.test(href)) return null;
+//     return href;
+//   }
+//
+// CORRECTION TO THE TASK PREMISE: there is NO slash normalization. The utility
+// does NOT convert backslashes to forward slashes and does NOT split on path
+// delimiters. It is a pure allow/deny gate. A backslash is just an ordinary
+// character to every check:
+//   - `trim()` only strips outer ASCII whitespace (backslash is untouched)
+//   - `startsWith("/")` / `startsWith("//")` look ONLY at the first 1-2 chars
+//   - the reject regex matches ONLY CR/LF, NOT backslash
+// Therefore any rooted (single leading "/") href containing backslashes is
+// returned BYTE-FOR-BYTE VERBATIM — backslashes preserved as literal chars.
+// The routing engine treats them as literal characters; it never normalizes
+// them into web forward slashes.
+
+describe("normalizeInternalRouteHref — Windows-style backslashes are literal, not normalized", () => {
+  it("returns a backslash path verbatim (no conversion to forward slashes)", () => {
+    expect(normalizeInternalRouteHref("/app\\legal\\privacy")).toBe(
+      "/app\\legal\\privacy",
+    );
+  });
+
+  it("does NOT convert backslashes into forward slashes", () => {
+    const out = normalizeInternalRouteHref("/app\\legal\\privacy");
+    expect(out).not.toBe("/app/legal/privacy");
+    expect(out).toContain("\\");
+  });
+
+  it("preserves mixed forward/backslash separators exactly as given", () => {
+    expect(normalizeInternalRouteHref("/app/legal\\privacy")).toBe(
+      "/app/legal\\privacy",
+    );
+  });
+
+  it("preserves a single leading forward slash followed by a backslash segment", () => {
+    expect(normalizeInternalRouteHref("/\\legal")).toBe("/\\legal");
+  });
+
+  it("rejects a leading backslash (does not start with '/')", () => {
+    expect(normalizeInternalRouteHref("\\app\\legal")).toBeNull();
+  });
+
+  it("rejects a backslash-prefixed value even when whitespace-padded", () => {
+    expect(normalizeInternalRouteHref("  \\app\\legal  ")).toBeNull();
+  });
+
+  it("trims outer whitespace but keeps interior backslashes intact", () => {
+    expect(normalizeInternalRouteHref("  /app\\legal  ")).toBe("/app\\legal");
+  });
+
+  it("preserves a trailing backslash verbatim", () => {
+    expect(normalizeInternalRouteHref("/app\\")).toBe("/app\\");
+  });
+
+  it("preserves consecutive backslashes (UNC-style) after the leading slash", () => {
+    expect(normalizeInternalRouteHref("/\\\\server\\share")).toBe(
+      "/\\\\server\\share",
+    );
+  });
+
+  it("still rejects protocol-relative '//' even with trailing backslashes", () => {
+    expect(normalizeInternalRouteHref("//host\\path")).toBeNull();
+  });
+
+  it("still rejects CR/LF injection alongside backslashes", () => {
+    expect(normalizeInternalRouteHref("/app\\legal\ninject")).toBeNull();
+    expect(normalizeInternalRouteHref("/app\\legal\rinject")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds an isolated characterization test for `normalizeInternalRouteHref`
(`hushh-webapp/lib/navigation/routes.ts`) documenting how it handles path
sequences that resemble Windows file delimiters / backslashes, e.g.
`/app\legal\privacy`. Test-only; no production change.

## Literal contract being characterized

```ts
export function normalizeInternalRouteHref(value): string | null {
  const href = String(value ?? "").trim();
  if (!href) return null;
  if (!href.startsWith("/") || href.startsWith("//")) return null;
  if (/[\r\n]/.test(href)) return null;
  return href;
}
```

## Truth-first correction to the task premise

The task asks whether the routing engine "normalizes [backslashes] into standard
web forward slashes." **It does not.** `normalizeInternalRouteHref` performs **no
slash normalization** — it never converts `\` to `/` and never splits on path
delimiters. It is a pure allow/deny gate, and a backslash is just an ordinary
character to every check:

- `trim()` strips only outer ASCII whitespace (backslashes untouched)
- `startsWith("/")` / `startsWith("//")` inspect only the first 1–2 chars
- the reject regex matches only CR/LF, **not** backslash

So any rooted href (single leading `/`, not `//`, no CR/LF) that contains
backslashes is returned **byte-for-byte verbatim** — the engine treats them as
**literal characters**. The correct answer to the task's question is: **literal,
never normalized.**

## Behavior pinned (11 cases)

- `/app\legal\privacy` returned verbatim (no `\`→`/` conversion)
- explicit assertion that output is NOT `/app/legal/privacy` and still contains `\`
- mixed `/app/legal\privacy` preserved exactly
- `/\legal` (leading `/` then `\`) preserved
- leading backslash `\app\legal` → `null` (doesn't start with `/`)
- whitespace-padded leading backslash → `null`
- outer whitespace trimmed, interior `\` intact
- trailing backslash `/app\` preserved
- consecutive/UNC-style `/\\server\share` preserved
- protocol-relative `//host\path` → `null`
- CR/LF injection alongside backslashes → `null`

## Truth-first scope note

The task referenced `hushh-research/__tests__/navigation/...` and a bare
`'normalizeInternalRouteHref'` import. There is no top-level `__tests__` here;
vitest only includes `__tests__/**` under `hushh-webapp`, and the module alias is
`@/lib/navigation/routes`. The file therefore lives at
`hushh-webapp/__tests__/navigation/normalize-windows-slashes.test.ts` and imports
via the `@/` alias.

## Verification

- `npm test -- __tests__/navigation/normalize-windows-slashes.test.ts` → 11/11 pass
- `git status` limited to the single new test file; zero production source drift

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — corrects the "normalizes backslashes to forward slashes"
  premise; pins the real "literal passthrough / no normalization" contract
