### PR TITLE
test(navigation): characterize normalizeInternalRouteHref relative dot segment chains

### DIFF
--- a/hushh-webapp/__tests__/navigation/normalize-dot-chains.test.ts
+++ b/hushh-webapp/__tests__/navigation/normalize-dot-chains.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for normalizeInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts) for route paths built from
+// consecutive relative single-dot navigation markers, e.g.
+// "/./legal/./privacy/./".
+//
+// TRUTH-FIRST — LITERAL CONTRACT:
+//
+//   export function normalizeInternalRouteHref(value): string | null {
+//     const href = String(value ?? "").trim();
+//     if (!href) return null;
+//     if (!href.startsWith("/") || href.startsWith("//")) return null;
+//     if (/[\r\n]/.test(href)) return null;
+//     return href;
+//   }
+//
+// CORRECTION TO THE TASK PREMISE: the path guard does NOT normalize, collapse,
+// resolve, or canonicalize "." (single-dot) segments. There is no path
+// resolution at all. It is a pure allow/deny gate that treats "." like any
+// other ordinary character. As long as the value starts with a single "/"
+// (not "//") and contains no CR/LF, the dot-chain is returned BYTE-FOR-BYTE
+// VERBATIM — "/./legal/./privacy/./" stays exactly as written; it is NOT
+// reduced to "/legal/privacy". The data is validated as a standard string
+// fragment, never resolved as filesystem-style relative navigation.
+
+describe("normalizeInternalRouteHref — relative single-dot segment chains are literal, not resolved", () => {
+  it("returns a dot-chain path verbatim (no collapse to /legal/privacy)", () => {
+    const out = normalizeInternalRouteHref("/./legal/./privacy/./");
+    expect(out).toBe("/./legal/./privacy/./");
+  });
+
+  it("does NOT canonicalize away the single-dot segments", () => {
+    const out = normalizeInternalRouteHref("/./legal/./privacy/./");
+    expect(out).not.toBe("/legal/privacy");
+    expect(out).not.toBe("/legal/privacy/");
+    expect(out).toContain("/./");
+  });
+
+  it("preserves a leading /./ prefix exactly", () => {
+    expect(normalizeInternalRouteHref("/./profile")).toBe("/./profile");
+  });
+
+  it("preserves a trailing /. exactly", () => {
+    expect(normalizeInternalRouteHref("/profile/.")).toBe("/profile/.");
+  });
+
+  it("preserves consecutive dot markers without dedupe", () => {
+    expect(normalizeInternalRouteHref("/./././x")).toBe("/./././x");
+  });
+
+  it("accepts a single '/.' rooted value verbatim (starts with one slash)", () => {
+    expect(normalizeInternalRouteHref("/.")).toBe("/.");
+  });
+
+  it("rejects a './'-leading value because it does not start with '/'", () => {
+    expect(normalizeInternalRouteHref("./legal/privacy")).toBeNull();
+  });
+
+  it("trims outer whitespace but keeps interior dot segments intact", () => {
+    expect(normalizeInternalRouteHref("  /./legal/.  ")).toBe("/./legal/.");
+  });
+
+  it("still rejects a protocol-relative '//' even with dot segments", () => {
+    expect(normalizeInternalRouteHref("//./legal")).toBeNull();
+  });
+
+  it("still rejects CR/LF injection alongside dot segments", () => {
+    expect(normalizeInternalRouteHref("/./legal\n./privacy")).toBeNull();
+    expect(normalizeInternalRouteHref("/./legal\r./privacy")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Pins and documents the current characterization of `normalizeInternalRouteHref`
(`hushh-webapp/lib/navigation/routes.ts`) when a route path is built from
redundant single-dot navigation components, e.g. `/./legal/./privacy/./`.
Test-only; no production change.

## Literal contract being characterized

```ts
export function normalizeInternalRouteHref(value): string | null {
  const href = String(value ?? "").trim();
  if (!href) return null;
  if (!href.startsWith("/") || href.startsWith("//")) return null;
  if (/[\r\n]/.test(href)) return null;
  return href;
}
```

## Truth-first correction to the task premise

The task asks whether the path guard "normalizes or validates" dot chains. The
verified answer: it **validates only — it does not normalize.** There is **no
path resolution, no segment collapsing, no canonicalization.** A `.` segment is
treated as an ordinary character. Any value that starts with a single `/` (not
`//`) and contains no CR/LF is returned **byte-for-byte verbatim**, so
`/./legal/./privacy/./` stays exactly as written — it is **NOT** reduced to
`/legal/privacy`. The data is handled as a standard string fragment, never
resolved as filesystem-style relative navigation.

## Behavior pinned (10 cases)

- `/./legal/./privacy/./` returned verbatim (no collapse)
- explicit assertion: output is NOT `/legal/privacy` and still contains `/./`
- leading `/./` prefix preserved
- trailing `/.` preserved
- consecutive `/./././x` preserved with no dedupe
- bare `/.` accepted verbatim (starts with one slash)
- `./legal/privacy` rejected → `null` (does not start with `/`)
- outer whitespace trimmed, interior dot segments intact
- `//./legal` rejected → `null` (protocol-relative gate)
- CR/LF alongside dot segments rejected → `null`

## Truth-first scope note

The task referenced `hushh-research/__tests__/navigation/...` and a bare
`'normalizeInternalRouteHref'` import. There is no top-level `__tests__` here;
vitest only includes `__tests__/**` under `hushh-webapp`, and the module alias is
`@/lib/navigation/routes`. The file therefore lives at
`hushh-webapp/__tests__/navigation/normalize-dot-chains.test.ts` and imports via
the `@/` alias.

## Verification

- `npm test -- __tests__/navigation/normalize-dot-chains.test.ts` → 10/10 pass
- `git status` limited to the single new test file; zero production source drift

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — corrects the "normalizes" premise; pins the real
  "validate-only, literal passthrough, no dot-segment resolution" contract
