### PR TITLE
fix(one-location): sync consent-manager location CTAs with One Location flow

### DIFF
--- a/hushh-webapp/__tests__/components/consent-center-page-deeplink.test.tsx
+++ b/hushh-webapp/__tests__/components/consent-center-page-deeplink.test.tsx
@@ -16,7 +16,11 @@ const mocks = vi.hoisted(() => ({
   handleApprove: vi.fn(),
   handleDeny: vi.fn(),
   handleRevoke: vi.fn(),
+  handleLocationApprove: vi.fn(),
+  handleLocationDeny: vi.fn(),
+  handleLocationRevoke: vi.fn(),
   busyRequestIds: new Set<string>(),
+
   busyScopes: new Set<string>(),
   activeAction: null as null | {
     key: string;
@@ -58,7 +62,19 @@ vi.mock("@/lib/consent", () => ({
     isScopeBusy: (scope?: string | null) =>
       mocks.busyScopes.has(String(scope || "")),
   }),
+  // One Location rows route through a dedicated hook; non-location consents
+  // never touch it, so a no-op mock is enough for these deep-link tests.
+  useOneLocationConsentActions: () => ({
+    handleApprove: mocks.handleLocationApprove,
+    handleDeny: mocks.handleLocationDeny,
+    handleRevoke: mocks.handleLocationRevoke,
+    activeAction: null,
+    activeActions: [],
+    isRequestBusy: () => false,
+    isScopeBusy: () => false,
+  }),
 }));
+
 
 vi.mock("@/lib/voice/voice-surface-metadata", () => ({
   usePublishVoiceSurfaceMetadata: vi.fn(),

--- a/hushh-webapp/__tests__/components/consent-center-page-location-actions.test.tsx
+++ b/hushh-webapp/__tests__/components/consent-center-page-location-actions.test.tsx
@@ -1,0 +1,331 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ConsentCenterPage } from "@/components/consent/consent-center-page";
+
+// Verifies that One Location rows in the Access Manager (/consents) route their
+// Allow / Don't allow / Revoke CTAs through the dedicated One Location hook
+// (E2E-encrypted endpoints), NOT the generic developer-consent pipeline. This
+// locks the parity fix so the consent manager behaves like the One Location
+// page Activity tab. Regression guard for the UAT "Failed to revoke consent"
+// bug on `one_location_grant:*` entries.
+
+const mocks = vi.hoisted(() => ({
+  replace: vi.fn(),
+  getIdToken: vi.fn().mockResolvedValue("id-token"),
+  getVaultOwnerToken: vi.fn(() => "vault-token"),
+  isVaultUnlocked: true,
+  search: "tab=active&requestId=one_location_grant:grant-1",
+  getSummary: vi.fn(),
+  listEntries: vi.fn(),
+  lookupPendingRequests: vi.fn(),
+  // generic developer-consent handlers (must NOT fire for location rows)
+  handleApprove: vi.fn(),
+  handleDeny: vi.fn(),
+  handleRevoke: vi.fn(),
+  // One Location handlers (must fire for location rows)
+  handleLocationApprove: vi.fn(),
+  handleLocationDeny: vi.fn(),
+  handleLocationRevoke: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mocks.replace }),
+  usePathname: () => "/consents",
+  useSearchParams: () => new URLSearchParams(mocks.search),
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({
+    user: { uid: "user-1", getIdToken: mocks.getIdToken },
+    loading: false,
+  }),
+}));
+
+vi.mock("@/lib/vault/vault-context", () => ({
+  useVault: () => ({
+    getVaultOwnerToken: mocks.getVaultOwnerToken,
+    isVaultUnlocked: mocks.isVaultUnlocked,
+  }),
+}));
+
+vi.mock("@/lib/consent", () => ({
+  useConsentActions: () => ({
+    handleApprove: mocks.handleApprove,
+    handleDeny: mocks.handleDeny,
+    handleRevoke: mocks.handleRevoke,
+    activeAction: null,
+    activeActions: [],
+    isRequestBusy: () => false,
+    isScopeBusy: () => false,
+  }),
+  useOneLocationConsentActions: () => ({
+    handleApprove: mocks.handleLocationApprove,
+    handleDeny: mocks.handleLocationDeny,
+    handleRevoke: mocks.handleLocationRevoke,
+    activeAction: null,
+    activeActions: [],
+    isRequestBusy: () => false,
+    isScopeBusy: () => false,
+  }),
+}));
+
+vi.mock("@/lib/voice/voice-surface-metadata", () => ({
+  usePublishVoiceSurfaceMetadata: vi.fn(),
+  useVoiceSurfaceControlTracking: () => ({
+    activeControlId: null,
+    lastInteractedControlId: null,
+  }),
+}));
+
+vi.mock("@/lib/cache/request-audit-log", () => ({
+  logRequestAudit: vi.fn(),
+}));
+
+vi.mock("@/lib/services/cache-service", () => ({
+  CacheService: {
+    getInstance: () => ({
+      peek: vi.fn(() => null),
+      subscribe: vi.fn(() => () => {}),
+    }),
+  },
+  CACHE_KEYS: {
+    CONSENT_CENTER_LIST: (...parts: unknown[]) => `list:${parts.join(":")}`,
+    CONSENT_CENTER_SUMMARY: (...parts: unknown[]) =>
+      `summary:${parts.join(":")}`,
+    CONSENT_CENTER: (...parts: unknown[]) => `center:${parts.join(":")}`,
+  },
+}));
+
+vi.mock("@/lib/services/consent-center-service", () => ({
+  CONSENT_CENTER_PAGE_SIZE: 20,
+  ConsentCenterService: {
+    getSummary: mocks.getSummary,
+    listEntries: mocks.listEntries,
+    lookupPendingRequests: mocks.lookupPendingRequests,
+  },
+}));
+
+function installDesktopMediaQuery() {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+function summaryResponse(counts: {
+  pending: number;
+  active: number;
+  previous: number;
+}) {
+  return {
+    user_id: "user-1",
+    actor: "investor",
+    mode: "consents",
+    counts,
+  };
+}
+
+function activeLocationGrantList() {
+  return {
+    user_id: "user-1",
+    actor: "investor",
+    mode: "consents",
+    surface: "active",
+    query: "",
+    page: 1,
+    limit: 20,
+    total: 1,
+    has_more: false,
+    items: [
+      {
+        id: "one_location_grant:grant-1",
+        kind: "active_grant",
+        status: "active",
+        action: "CONSENT_GRANTED",
+        scope: "cap.location.live.view",
+        scope_description: "Live location sharing",
+        counterpart_type: "investor",
+        counterpart_label: "hushh Social",
+        issued_at: "2026-06-24T18:03:06.000Z",
+        expires_at: "2026-06-25T00:03:06.000Z",
+        metadata: {
+          request_source: "one_location_share_grant",
+          section: "people",
+          grant_id: "grant-1",
+        },
+      },
+    ],
+  };
+}
+
+function pendingLocationRequestList() {
+  return {
+    user_id: "user-1",
+    actor: "investor",
+    mode: "consents",
+    surface: "pending",
+    query: "",
+    page: 1,
+    limit: 20,
+    total: 1,
+    has_more: false,
+    items: [
+      {
+        id: "one_location_request:req-1",
+        kind: "incoming_request",
+        status: "pending",
+        action: "REQUESTED",
+        scope: "cap.location.live.view",
+        scope_description: "Live location access request",
+        counterpart_type: "investor",
+        counterpart_label: "hushh Social",
+        request_id: "req-1",
+        issued_at: "2026-06-24T18:03:06.000Z",
+        metadata: {
+          request_source: "one_location_access_request",
+          section: "approvals",
+          request_id: "req-1",
+        },
+      },
+    ],
+  };
+}
+
+function activeDeveloperGrantList() {
+  return {
+    user_id: "user-1",
+    actor: "investor",
+    mode: "consents",
+    surface: "active",
+    query: "",
+    page: 1,
+    limit: 20,
+    total: 1,
+    has_more: false,
+    items: [
+      {
+        id: "grant-dev-1",
+        kind: "active_grant",
+        status: "active",
+        action: "CONSENT_GRANTED",
+        scope: "attr.shopping.receipts.*",
+        scope_description: "Shopping receipts",
+        counterpart_type: "developer",
+        counterpart_label: "Macy's CRM",
+        issued_at: "2026-06-24T18:03:06.000Z",
+        metadata: { request_source: "developer_api_v1" },
+      },
+    ],
+  };
+}
+
+describe("ConsentCenterPage One Location action routing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getVaultOwnerToken.mockImplementation(() => "vault-token");
+    mocks.isVaultUnlocked = true;
+    mocks.handleLocationApprove.mockResolvedValue(undefined);
+    mocks.handleLocationDeny.mockResolvedValue(undefined);
+    mocks.handleLocationRevoke.mockResolvedValue(undefined);
+    installDesktopMediaQuery();
+  });
+
+  it("revokes an active location grant through the One Location hook, not the generic flow", async () => {
+    mocks.search = "tab=active&requestId=one_location_grant:grant-1";
+    mocks.getSummary.mockResolvedValue(
+      summaryResponse({ pending: 0, active: 1, previous: 0 }),
+    );
+    mocks.listEntries.mockResolvedValue(activeLocationGrantList());
+
+    render(<ConsentCenterPage />);
+
+    const revokeButton = (await screen.findByRole("button", {
+      name: "Revoke",
+    })) as HTMLButtonElement;
+    fireEvent.click(revokeButton);
+
+    await waitFor(() => {
+      expect(mocks.handleLocationRevoke).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.handleLocationRevoke).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "one_location_grant:grant-1" }),
+    );
+    expect(mocks.handleRevoke).not.toHaveBeenCalled();
+  });
+
+  it("allows a pending location request through the One Location hook", async () => {
+    mocks.search = "tab=pending&requestId=one_location_request:req-1";
+    mocks.getSummary.mockResolvedValue(
+      summaryResponse({ pending: 1, active: 0, previous: 0 }),
+    );
+    mocks.listEntries.mockResolvedValue(pendingLocationRequestList());
+
+    render(<ConsentCenterPage />);
+
+    const allowButton = (await screen.findByRole("button", {
+      name: "Allow",
+    })) as HTMLButtonElement;
+    fireEvent.click(allowButton);
+    await waitFor(() => {
+      expect(mocks.handleLocationApprove).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.handleLocationApprove).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "one_location_request:req-1" }),
+      expect.anything(),
+    );
+    expect(mocks.handleApprove).not.toHaveBeenCalled();
+  });
+
+  it("denies a pending location request through the One Location hook", async () => {
+    mocks.search = "tab=pending&requestId=one_location_request:req-1";
+    mocks.getSummary.mockResolvedValue(
+      summaryResponse({ pending: 1, active: 0, previous: 0 }),
+    );
+    mocks.listEntries.mockResolvedValue(pendingLocationRequestList());
+
+    render(<ConsentCenterPage />);
+
+    const denyButton = (await screen.findByRole("button", {
+      name: "Don't allow",
+    })) as HTMLButtonElement;
+    fireEvent.click(denyButton);
+    await waitFor(() => {
+      expect(mocks.handleLocationDeny).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.handleLocationDeny).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "one_location_request:req-1" }),
+    );
+    expect(mocks.handleDeny).not.toHaveBeenCalled();
+  });
+
+
+  it("keeps non-location active grants on the generic consent revoke flow", async () => {
+    mocks.search = "tab=active&requestId=grant-dev-1";
+    mocks.getSummary.mockResolvedValue(
+      summaryResponse({ pending: 0, active: 1, previous: 0 }),
+    );
+    mocks.listEntries.mockResolvedValue(activeDeveloperGrantList());
+
+    render(<ConsentCenterPage />);
+
+    const revokeButton = (await screen.findByRole("button", {
+      name: "Revoke",
+    })) as HTMLButtonElement;
+    fireEvent.click(revokeButton);
+
+    await waitFor(() => {
+      expect(mocks.handleRevoke).toHaveBeenCalledWith("attr.shopping.receipts.*");
+    });
+    expect(mocks.handleLocationRevoke).not.toHaveBeenCalled();
+  });
+});

--- a/hushh-webapp/__tests__/lib/consent/location-consent.test.ts
+++ b/hushh-webapp/__tests__/lib/consent/location-consent.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isLocationConsent,
+  parseLocationConsentEntry,
+} from "@/lib/consent/location-consent";
+
+describe("isLocationConsent", () => {
+  it("recognizes One Location request-source metadata", () => {
+    expect(
+      isLocationConsent({ request_source: "one_location_access_request" }),
+    ).toBe(true);
+    expect(
+      isLocationConsent({ request_source: "one_location_share_grant" }),
+    ).toBe(true);
+  });
+
+  it("recognizes location-family scopes", () => {
+    expect(isLocationConsent(null, "cap.location.live.view")).toBe(true);
+    expect(isLocationConsent(null, "attr.location.home")).toBe(true);
+  });
+
+  it("ignores unrelated developer consents", () => {
+    expect(
+      isLocationConsent(
+        { request_source: "developer_api_v1" },
+        "attr.shopping.receipts.*",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("parseLocationConsentEntry", () => {
+  it("maps an access request entry to the request kind + id", () => {
+    const ref = parseLocationConsentEntry({
+      id: "one_location_request:req_123",
+      request_id: "req_123",
+      metadata: { request_source: "one_location_access_request" },
+    });
+    expect(ref).toEqual({
+      kind: "access_request",
+      id: "req_123",
+      requestId: "req_123",
+    });
+  });
+
+  it("maps a share grant entry to the grant kind + id (no requestId)", () => {
+    const ref = parseLocationConsentEntry({
+      id: "one_location_grant:grant_456",
+      metadata: {
+        request_source: "one_location_share_grant",
+        grant_id: "grant_456",
+      },
+    });
+    expect(ref).toEqual({
+      kind: "share_grant",
+      id: "grant_456",
+      requestId: null,
+    });
+  });
+
+  it("maps a public invite entry to the public_invite kind", () => {
+    const ref = parseLocationConsentEntry({
+      id: "one_location_public:pi_789",
+      metadata: { request_source: "one_location_public_invite" },
+    });
+    expect(ref).toEqual({
+      kind: "public_invite",
+      id: "pi_789",
+      requestId: null,
+    });
+  });
+
+  it("maps a circle invite entry to the circle_invite kind", () => {
+    const ref = parseLocationConsentEntry({
+      id: "one_location_circle:ci_321",
+      metadata: { request_source: "one_location_circle_invite" },
+    });
+    expect(ref).toEqual({
+      kind: "circle_invite",
+      id: "ci_321",
+      requestId: null,
+    });
+  });
+
+  it("falls back to request_source when the id prefix is missing", () => {
+    const ref = parseLocationConsentEntry({
+      id: "req_999",
+      request_id: "req_999",
+      metadata: { request_source: "one_location_access_request" },
+    });
+    expect(ref.kind).toBe("access_request");
+    expect(ref.requestId).toBe("req_999");
+  });
+
+  it("recovers the grant id from metadata when the suffix is absent", () => {
+    const ref = parseLocationConsentEntry({
+      id: "one_location_grant:",
+      metadata: {
+        request_source: "one_location_share_grant",
+        grant_id: "grant_from_meta",
+      },
+    });
+    expect(ref).toEqual({
+      kind: "share_grant",
+      id: "grant_from_meta",
+      requestId: null,
+    });
+  });
+
+  it("returns unknown for non-location entries", () => {
+    const ref = parseLocationConsentEntry({
+      id: "identifier:macy",
+      metadata: { request_source: "developer_api_v1" },
+    });
+    expect(ref.kind).toBe("unknown");
+    expect(ref.requestId).toBeNull();
+  });
+});

--- a/hushh-webapp/components/consent/consent-center-page.tsx
+++ b/hushh-webapp/components/consent/consent-center-page.tsx
@@ -58,10 +58,12 @@ import {
 } from "@/lib/consent/consent-events";
 import {
   useConsentActions,
+  useOneLocationConsentActions,
   type ConsentActionState,
   type ConsentMutationDetail,
   type PendingConsent,
 } from "@/lib/consent";
+
 import { HandshakeTimeline } from "@/components/consent/handshake-timeline";
 import {
   humanizeConsentScope,
@@ -1291,14 +1293,83 @@ export function ConsentCenterPage() {
     handleApprove,
     handleDeny,
     handleRevoke,
-    activeAction,
-    isRequestBusy,
-    isScopeBusy,
+    activeAction: genericActiveAction,
+    isRequestBusy: isGenericRequestBusy,
+    isScopeBusy: isGenericScopeBusy,
   } = useConsentActions({
     userId: user?.uid,
   });
 
+  // One Location rows in the Access Manager are end-to-end encrypted and must go
+  // through the dedicated One Location endpoints + envelope publish, NOT the
+  // generic developer-consent flow. This hook mirrors the One Location page's
+  // Activity actions so Allow / Don't allow / Revoke behave identically on both
+  // surfaces (see lib/consent/use-one-location-consent-actions.ts).
+  const {
+    handleApprove: handleLocationApprove,
+    handleDeny: handleLocationDeny,
+    handleRevoke: handleLocationRevoke,
+    activeAction: locationActiveAction,
+    isRequestBusy: isLocationRequestBusy,
+    isScopeBusy: isLocationScopeBusy,
+  } = useOneLocationConsentActions({
+    userId: user?.uid,
+  });
+
+  const activeAction = genericActiveAction ?? locationActiveAction;
+  const isRequestBusy = useCallback(
+    (requestId?: string | null) =>
+      isGenericRequestBusy(requestId) || isLocationRequestBusy(requestId),
+    [isGenericRequestBusy, isLocationRequestBusy],
+  );
+  const isScopeBusy = useCallback(
+    (scope?: string | null) =>
+      isGenericScopeBusy(scope) || isLocationScopeBusy(scope),
+    [isGenericScopeBusy, isLocationScopeBusy],
+  );
+
+  // Route a consent entry to the correct backend pipeline. Location rows
+  // (`metadata.request_source` starts with `one_location`, or a location-family
+  // scope) use the One Location hook; everything else uses the generic flow.
+  const isLocationEntry = useCallback(
+    (entry: ConsentCenterEntry) =>
+      isLocationConsent(entry.metadata, entry.scope),
+    [],
+  );
+  const approveEntry = useCallback(
+    (entry: ConsentCenterEntry, durationHours?: number) => {
+      if (isLocationEntry(entry)) {
+        void handleLocationApprove(entry, durationHours);
+        return;
+      }
+      void handleApprove(toPendingConsent(entry, durationHours));
+    },
+    [handleApprove, handleLocationApprove, isLocationEntry],
+  );
+  const denyEntry = useCallback(
+    (entry: ConsentCenterEntry) => {
+      if (isLocationEntry(entry)) {
+        void handleLocationDeny(entry);
+        return;
+      }
+      void handleDeny(entry.request_id || entry.id);
+    },
+    [handleDeny, handleLocationDeny, isLocationEntry],
+  );
+  const revokeEntry = useCallback(
+    (entry: ConsentCenterEntry) => {
+      if (isLocationEntry(entry)) {
+        void handleLocationRevoke(entry);
+        return;
+      }
+      if (!entry.scope) return;
+      void handleRevoke(entry.scope);
+    },
+    [handleLocationRevoke, handleRevoke, isLocationEntry],
+  );
+
   const idTokenLoader = async () => user?.getIdToken();
+
 
   const summaryResource = useStaleResource({
     cacheKey: summaryCacheKey,
@@ -2142,6 +2213,7 @@ export function ConsentCenterPage() {
               trailing={
                 <div className="flex items-center gap-2">
                   {notificationAction === "approve" &&
+                  selectedEntry &&
                   selectedPendingConsent ? (
                     <Button
                       variant="blue-gradient"
@@ -2149,7 +2221,7 @@ export function ConsentCenterPage() {
                       size="sm"
                       disabled={isRequestBusy(selectedPendingConsent.id)}
                       onClick={() => {
-                        void handleApprove(selectedPendingConsent);
+                        approveEntry(selectedEntry);
                         closeDetailPanel();
                       }}
                     >
@@ -2168,12 +2240,11 @@ export function ConsentCenterPage() {
                         selectedEntry.request_id || selectedEntry.id,
                       )}
                       onClick={() => {
-                        void handleDeny(
-                          selectedEntry.request_id || selectedEntry.id,
-                        );
+                        denyEntry(selectedEntry);
                         closeDetailPanel();
                       }}
                     >
+
                       {activeAction?.kind === "deny" &&
                       activeAction.requestId ===
                         (selectedEntry.request_id || selectedEntry.id)
@@ -2244,19 +2315,19 @@ export function ConsentCenterPage() {
             actor={actor}
             entry={selectedEntry}
             onApprove={(entry, durationHours) => {
-              void handleApprove(toPendingConsent(entry, durationHours));
+              approveEntry(entry, durationHours);
               // Dismiss the panel immediately; the list already optimistically
               // removes the row and any failure surfaces via toast.
               closeDetailPanel();
             }}
             onDeny={(entry) => {
-              void handleDeny(entry.request_id || entry.id);
+              denyEntry(entry);
               closeDetailPanel();
             }}
             onRevoke={(entry) => {
-              if (!entry.scope) return;
-              void handleRevoke(entry.scope);
+              revokeEntry(entry);
             }}
+
             onRevokeScope={(scope) => void handleRevoke(scope)}
             activeAction={activeAction}
             isRequestBusy={isRequestBusy}

--- a/hushh-webapp/lib/consent/index.ts
+++ b/hushh-webapp/lib/consent/index.ts
@@ -12,3 +12,10 @@ export {
   type ConsentMutationDetail,
   type PendingConsent,
 } from "./use-consent-actions";
+
+// One Location Actions Hook (E2E location share lifecycle inside /consents)
+export {
+  useOneLocationConsentActions,
+  type LocationConsentActionEntry,
+} from "./use-one-location-consent-actions";
+

--- a/hushh-webapp/lib/consent/location-consent.ts
+++ b/hushh-webapp/lib/consent/location-consent.ts
@@ -80,3 +80,89 @@ export function locationConsentSummary(metadata: MetadataLike): string {
   }
   return `${who} wants to see your location through One Location.`;
 }
+
+/**
+ * The concrete One Location record a consent row maps back to. The backend
+ * `OneLocationCenterContributor` encodes the record kind in the entry id
+ * (`one_location_request:{id}`, `one_location_grant:{id}`,
+ * `one_location_public:{id}`, `one_location_circle:{id}`) and in
+ * `metadata.request_source`. The consent-manager CTAs use this to drive the
+ * correct One Location endpoint instead of the generic developer-consent flow.
+ */
+export type LocationConsentRecordKind =
+  | "access_request"
+  | "share_grant"
+  | "public_invite"
+  | "circle_invite"
+  | "unknown";
+
+export interface LocationConsentEntryRef {
+  /** The record kind this consent row maps back to. */
+  kind: LocationConsentRecordKind;
+  /** The underlying One Location record id (request/grant/invite id). */
+  id: string;
+  /** The access-request id, when this row is (or wraps) a request. */
+  requestId: string | null;
+}
+
+interface ParseableLocationConsentEntry {
+  id?: string | null;
+  request_id?: string | null;
+  metadata?: MetadataLike;
+}
+
+const _LOCATION_ID_PREFIXES: Record<string, LocationConsentRecordKind> = {
+  one_location_request: "access_request",
+  one_location_grant: "share_grant",
+  one_location_public: "public_invite",
+  one_location_circle: "circle_invite",
+};
+
+const _LOCATION_SOURCE_KINDS: Record<string, LocationConsentRecordKind> = {
+  one_location_access_request: "access_request",
+  one_location_share_grant: "share_grant",
+  one_location_public_invite: "public_invite",
+  one_location_circle_invite: "circle_invite",
+};
+
+/**
+ * Resolve a consent-center entry back to its One Location record. Prefers the
+ * prefixed entry id (most specific), then falls back to
+ * `metadata.request_source`. The trailing id is recovered from the entry id
+ * suffix or, when missing, from `metadata.grant_id` / `metadata.request_id`.
+ */
+export function parseLocationConsentEntry(
+  entry: ParseableLocationConsentEntry,
+): LocationConsentEntryRef {
+  const rawId = String(entry.id || "").trim();
+  const separatorIndex = rawId.indexOf(":");
+  const prefix = separatorIndex >= 0 ? rawId.slice(0, separatorIndex) : "";
+  const suffix = separatorIndex >= 0 ? rawId.slice(separatorIndex + 1) : "";
+
+  const kind: LocationConsentRecordKind =
+    _LOCATION_ID_PREFIXES[prefix] ??
+    _LOCATION_SOURCE_KINDS[readString(entry.metadata, "request_source")] ??
+    "unknown";
+
+
+  const metadataGrantId = readString(entry.metadata, "grant_id");
+  const metadataRequestId =
+    readString(entry.metadata, "request_id") ||
+    String(entry.request_id || "").trim();
+
+  let id = suffix.trim();
+  if (!id) {
+    id =
+      kind === "share_grant"
+        ? metadataGrantId
+        : kind === "access_request"
+          ? metadataRequestId
+          : "";
+  }
+
+  const requestId =
+    kind === "access_request" ? id || metadataRequestId || null : null;
+
+  return { kind, id, requestId };
+}
+

--- a/hushh-webapp/lib/consent/use-one-location-consent-actions.ts
+++ b/hushh-webapp/lib/consent/use-one-location-consent-actions.ts
@@ -1,0 +1,351 @@
+"use client";
+
+/**
+ * One Location Consent Actions Hook
+ * =================================
+ *
+ * The shared `/consents` Access Manager renders One Location rows (live
+ * location requests, share grants, public links) via the backend
+ * `OneLocationCenterContributor`. Those rows carry `metadata.request_source`
+ * starting with `one_location` (see `location-consent.ts`).
+ *
+ * The generic `useConsentActions` hook approves/denies/revokes through the
+ * developer-consent pipeline (`ApiService.approvePendingConsent` etc.), which is
+ * the WRONG backend for One Location: a location grant is end-to-end encrypted
+ * and must go through the dedicated One Location endpoints plus an envelope
+ * publish (capture position -> encrypt to the requester's recipient key -> store
+ * envelope). That is exactly what the One Location page's Activity actions do.
+ *
+ * This hook re-uses the *same* flow as `hushh-webapp/app/one/location/page.tsx`
+ * so the Allow / Don't allow / Revoke CTAs in the consent manager behave
+ * identically to the Activity tab on the One Location page. Both surfaces stay
+ * in sync because every successful action dispatches
+ * `CONSENT_STATE_CHANGED_EVENT`, which both the consent center and the One
+ * Location page already listen to.
+ */
+
+import { useCallback, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
+
+import { useVault } from "@/lib/vault/vault-context";
+import { dispatchConsentStateChanged } from "@/lib/consent/consent-events";
+import {
+  parseLocationConsentEntry,
+  type LocationConsentEntryRef,
+} from "@/lib/consent/location-consent";
+import { encryptLocationForRecipient } from "@/lib/one-location/encryption";
+import { OneLocationService } from "@/lib/one-location/service";
+import type {
+  ConsentActionKind,
+  ConsentActionState,
+} from "@/lib/consent/use-consent-actions";
+
+/**
+ * Minimal shape the hook needs from a `ConsentCenterEntry`. Kept structural so
+ * the hook does not have to import the full consent-center service types.
+ */
+export interface LocationConsentActionEntry {
+  id: string;
+  request_id?: string | null;
+  scope?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+interface UseOneLocationConsentActionsOptions {
+  /** User ID from auth context. Required to decrypt/own the action. */
+  userId?: string | null;
+  /** Called after a One Location action completes successfully. */
+  onActionComplete?: () => void;
+}
+
+function clampApprovalDurationHours(durationHours?: number): number {
+  // The consent-manager duration picker offers values in hours. One Location's
+  // backend clamps to its own policy window, so we only guard against missing /
+  // non-positive input here and let the server enforce the real ceiling.
+  if (!Number.isFinite(durationHours) || !durationHours || durationHours <= 0) {
+    return 24;
+  }
+  return durationHours;
+}
+
+function actionError(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}
+
+export function useOneLocationConsentActions(
+  options: UseOneLocationConsentActionsOptions = {},
+) {
+  const { getVaultOwnerToken } = useVault();
+  const { userId, onActionComplete } = options;
+  const [activeActions, setActiveActions] = useState<ConsentActionState[]>([]);
+  const inflight = useRef<Map<string, Promise<void>>>(new Map());
+
+  const runWithLock = useCallback(
+    (action: ConsentActionState, run: () => Promise<void>): Promise<void> => {
+      const existing = inflight.current.get(action.key);
+      if (existing) return existing;
+
+      setActiveActions((current) =>
+        current.some((item) => item.key === action.key)
+          ? current
+          : [...current, action],
+      );
+
+      const promise = (async () => {
+        try {
+          await run();
+        } finally {
+          inflight.current.delete(action.key);
+          setActiveActions((current) =>
+            current.filter((item) => item.key !== action.key),
+          );
+        }
+      })();
+      inflight.current.set(action.key, promise);
+      return promise;
+    },
+    [],
+  );
+
+  const emitComplete = useCallback(
+    (detail: { action: ConsentActionKind; requestId?: string; scope?: string }) => {
+      onActionComplete?.();
+      // Both the consent center and the One Location page listen for this event,
+      // so a CTA in either surface refreshes the other.
+      dispatchConsentStateChanged({
+        action: detail.action,
+        requestId: detail.requestId,
+        scope: detail.scope,
+        source: "one_location_consent_actions",
+      });
+    },
+    [onActionComplete],
+  );
+
+  const isRequestBusy = useCallback(
+    (requestId?: string | null) => {
+      const normalized = String(requestId || "").trim();
+      if (!normalized) return false;
+      return activeActions.some(
+        (action) =>
+          (action.kind === "approve" || action.kind === "deny") &&
+          action.requestId === normalized,
+      );
+    },
+    [activeActions],
+  );
+
+  const isScopeBusy = useCallback(
+    (scope?: string | null) => {
+      const normalized = String(scope || "").trim();
+      if (!normalized) return false;
+      return activeActions.some(
+        (action) => action.kind === "revoke" && action.scope === normalized,
+      );
+    },
+    [activeActions],
+  );
+
+  const activeAction = useMemo(() => activeActions[0] ?? null, [activeActions]);
+
+  const requireToken = useCallback((): string | null => {
+    const token = getVaultOwnerToken();
+    if (!token) {
+      toast.error("Unlock your vault to manage this location request.");
+      return null;
+    }
+    return token;
+  }, [getVaultOwnerToken]);
+
+  /**
+   * Approve a One Location access request: open the dedicated grant, capture the
+   * owner's current position, encrypt it to the requester's recipient key, and
+   * publish the envelope. Mirrors `handleApprove` in the One Location page.
+   */
+  const handleApprove = useCallback(
+    (entry: LocationConsentActionEntry, durationHours?: number): Promise<void> => {
+      const ref = parseLocationConsentEntry(entry);
+      const requestId = ref.requestId;
+      if (!requestId) {
+        toast.error("This location request can no longer be opened here.");
+        return Promise.resolve();
+      }
+      const actionKey = `approve:${requestId}`;
+      return runWithLock(
+        { key: actionKey, kind: "approve", requestId },
+        async () => {
+          if (!userId) return;
+          const vaultOwnerToken = requireToken();
+          if (!vaultOwnerToken) return;
+
+          const promise = (async () => {
+            const state = await OneLocationService.getState(vaultOwnerToken);
+            const request = state.requests.find(
+              (item) => item.id === requestId,
+            );
+            if (!request) {
+              throw new Error("This location request is no longer available.");
+            }
+            const requester = state.recipients.find(
+              (recipient) => recipient.userId === request.requesterUserId,
+            );
+            if (!requester?.keyId || !requester.publicKeyJwk) {
+              throw new Error(
+                "They need to open One Location once before approval can finish.",
+              );
+            }
+            const response = await OneLocationService.approveRequest({
+              vaultOwnerToken,
+              requestId,
+              durationHours: clampApprovalDurationHours(durationHours),
+            });
+            const point = await OneLocationService.captureCurrentPosition();
+            const envelope = await encryptLocationForRecipient({
+              point,
+              recipientPublicKeyJwk: requester.publicKeyJwk,
+              recipientKeyId: requester.keyId,
+            });
+            await OneLocationService.storeEnvelope({
+              vaultOwnerToken,
+              grantId: response.grant.id,
+              envelope,
+            });
+            return "Request approved and encrypted update published.";
+          })();
+
+          toast.promise(promise, {
+            id: actionKey,
+            loading: "Approving location request...",
+            success: (message) => `✅ ${message}`,
+            error: (error) => `❌ ${actionError(error, "Could not approve request.")}`,
+            duration: 3000,
+          });
+
+          try {
+            await promise;
+            emitComplete({ action: "approve", requestId });
+          } catch (error) {
+            console.error("[OneLocationConsent] approve failed:", error);
+          }
+        },
+      );
+    },
+    [emitComplete, requireToken, runWithLock, userId],
+  );
+
+  /** Deny a One Location access request. Mirrors `handleDeny` in the page. */
+  const handleDeny = useCallback(
+    (entry: LocationConsentActionEntry): Promise<void> => {
+      const ref = parseLocationConsentEntry(entry);
+      const requestId = ref.requestId;
+      if (!requestId) {
+        toast.error("This location request can no longer be opened here.");
+        return Promise.resolve();
+      }
+      const actionKey = `deny:${requestId}`;
+      return runWithLock(
+        { key: actionKey, kind: "deny", requestId },
+        async () => {
+          const vaultOwnerToken = requireToken();
+          if (!vaultOwnerToken) return;
+
+          const promise = (async () => {
+            await OneLocationService.denyRequest({ vaultOwnerToken, requestId });
+            return "Request denied.";
+          })();
+
+          toast.promise(promise, {
+            id: actionKey,
+            loading: "Denying location request...",
+            success: (message) => `❌ ${message}`,
+            error: (error) => `❌ ${actionError(error, "Could not deny request.")}`,
+            duration: 3000,
+          });
+
+          try {
+            await promise;
+            emitComplete({ action: "deny", requestId });
+          } catch (error) {
+            console.error("[OneLocationConsent] deny failed:", error);
+          }
+        },
+      );
+    },
+    [emitComplete, requireToken, runWithLock],
+  );
+
+  /**
+   * Revoke active One Location access. Routes by the underlying record kind:
+   * share grants, public links, and circle invites each have a dedicated
+   * endpoint. Mirrors the revoke handlers in the One Location page.
+   */
+  const handleRevoke = useCallback(
+    (entry: LocationConsentActionEntry): Promise<void> => {
+      const ref: LocationConsentEntryRef = parseLocationConsentEntry(entry);
+      const scope = String(entry.scope || "").trim();
+      const actionKey = `revoke:${ref.kind}:${ref.id || scope}`;
+      return runWithLock(
+        { key: actionKey, kind: "revoke", scope: scope || ref.id || undefined },
+        async () => {
+          const vaultOwnerToken = requireToken();
+          if (!vaultOwnerToken) return;
+          if (!ref.id) {
+            toast.error("This location grant can no longer be revoked here.");
+            return;
+          }
+
+          const promise = (async () => {
+            if (ref.kind === "share_grant") {
+              await OneLocationService.revokeGrant({
+                vaultOwnerToken,
+                grantId: ref.id,
+              });
+              return "Location access revoked.";
+            }
+            if (ref.kind === "public_invite") {
+              await OneLocationService.revokePublicInvite({
+                vaultOwnerToken,
+                inviteId: ref.id,
+              });
+              return "Public location link revoked.";
+            }
+            if (ref.kind === "circle_invite") {
+              await OneLocationService.revokeCircleInvite({
+                vaultOwnerToken,
+                inviteId: ref.id,
+              });
+              return "Invite to One link revoked.";
+            }
+            throw new Error("This location item cannot be revoked here.");
+          })();
+
+          toast.promise(promise, {
+            id: actionKey,
+            loading: "Revoking location access...",
+            success: (message) => `🔒 ${message}`,
+            error: (error) => `❌ ${actionError(error, "Could not revoke access.")}`,
+            duration: 3000,
+          });
+
+          try {
+            await promise;
+            emitComplete({ action: "revoke", scope: scope || undefined });
+          } catch (error) {
+            console.error("[OneLocationConsent] revoke failed:", error);
+          }
+        },
+      );
+    },
+    [emitComplete, requireToken, runWithLock],
+  );
+
+  return {
+    handleApprove,
+    handleDeny,
+    handleRevoke,
+    activeAction,
+    activeActions,
+    isRequestBusy,
+    isScopeBusy,
+  };
+}


### PR DESCRIPTION
## Problem
Location rows (one_location_*) in the /consents Access Manager rendered Allow / Don't allow / Revoke, but those CTAs fired the generic developer-consent pipeline instead of One Location's dedicated endpoints. Revoking an active location grant showed 'Failed to revoke consent' (UAT screenshot).

## Fix
- New useOneLocationConsentActions hook replicating the One Location page Activity approve/deny/revoke flow, incl. the E2E envelope publish on approve, dispatching CONSENT_STATE_CHANGED_EVENT so both surfaces stay in sync.
- New parseLocationConsentEntry helper maps each consent row to its real One Location record (access request / share grant / public invite / circle invite) so revoke hits the correct endpoint.
- ConsentCenterPage detects location rows via isLocationConsent and routes Allow / Don't allow / Revoke (detail panel + notification action) to the One Location hook; non-location consents unchanged. Preserves the panel-close useTransition optimization on main.

## Verification
- tsc --noEmit clean, eslint --max-warnings=0 clean
- 23/23 consent tests (incl. regression for the screenshot's active-grant Revoke); full webapp suite green
- Same content previously passed full PR CI on #3751 (now superseded).