### PR TITLE
test(accordion): cover trigger data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/ui/accordion.test.tsx
+++ b/hushh-webapp/__tests__/ui/accordion.test.tsx
@@ -64,6 +64,21 @@ describe("Accordion", () => {
     ).toBeTruthy();
   });
 
+  it("keeps the accessible trigger button on the accordion-trigger data-slot", () => {
+    const { container } = render(
+      <Accordion type="single">
+        <AccordionItem value="item-1">
+          <AccordionTrigger>Trigger</AccordionTrigger>
+          <AccordionContent>Content</AccordionContent>
+        </AccordionItem>
+      </Accordion>,
+    );
+
+    const trigger = container.querySelector("button");
+
+    expect(trigger?.getAttribute("data-slot")).toBe("accordion-trigger");
+  });
+
   it("renders AccordionContent with data-slot='accordion-content' when item is open", () => {
     const { container } = render(
       <Accordion type="single" defaultValue="item-1">


### PR DESCRIPTION
## Summary
- Adds one focused accordion UI test asserting the accessible trigger button carries `data-slot="accordion-trigger"`.

## Why
- Locks the trigger slot contract at the actual interactive button surface, not only through a broad selector lookup.

## PR Base Policy
- Base branch: `integration/pr-train`.
- Head branch: `codex/accordion-trigger-data-slot-test`.
- Scope: one test file only.

## No Overlap Proof
- Only file changed: `hushh-webapp/__tests__/ui/accordion.test.tsx`.
- The assertion targets the accordion trigger button's `data-slot` attribute and does not touch accordion implementation or any other UI component.

## Validation
- Attempted: `npm.cmd test -- __tests__/ui/accordion.test.tsx`.
- Result: not run locally because this isolated worktree does not have `node_modules`; `vitest` is not available.

## DCO
- Commit includes Signed-off-by footer.
