### PR TITLE
test(alert-dialog): cover action and cancel data-slot contracts

### DIFF
--- a/hushh-webapp/__tests__/ui/alert-dialog.test.tsx
+++ b/hushh-webapp/__tests__/ui/alert-dialog.test.tsx
@@ -66,6 +66,30 @@ describe("AlertDialogContent", () => {
 
     expect(screen.getByRole("button", { name: /continue/i })).toBeTruthy();
   });
+
+  it("renders action and cancel buttons with their data-slot contracts", () => {
+    render(
+      <AlertDialog open>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+            <AlertDialogDescription>This action cannot be undone.</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction>Continue</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>,
+    );
+
+    expect(screen.getByRole("button", { name: /cancel/i }).getAttribute("data-slot")).toBe(
+      "alert-dialog-cancel",
+    );
+    expect(screen.getByRole("button", { name: /continue/i }).getAttribute("data-slot")).toBe(
+      "alert-dialog-action",
+    );
+  });
 });
 describe("AlertDialogHeader", () => {
   it("renders with data-slot='alert-dialog-header'", () => {


### PR DESCRIPTION
## Summary
- Adds one focused alert-dialog UI test asserting the action and cancel buttons expose their expected data-slot contracts.

## Why
- Locks the slot contract at the actual accessible button surfaces used by AlertDialogAction and AlertDialogCancel.

## PR Base Policy
- Base branch: `integration/pr-train`.
- Head branch: `codex/alert-dialog-action-cancel-slot-test`.
- Scope: one test file only.

## No Overlap Proof
- Only file changed: `hushh-webapp/__tests__/ui/alert-dialog.test.tsx`.
- The assertion targets `AlertDialogAction` and `AlertDialogCancel` button data-slot attributes only.
- No implementation files or other UI component tests are touched.

## Validation
- Not run locally: this isolated worktree does not have `node_modules`, so `vitest` is not available.

## DCO
- Commit includes Signed-off-by footer.
