### PR TITLE
test(badge): cover badge data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/ui/badge.test.tsx
+++ b/hushh-webapp/__tests__/ui/badge.test.tsx
@@ -12,6 +12,16 @@ describe("Badge", () => {
     ).toBeTruthy();
   });
 
+  it("preserves the badge data-slot when rendered asChild", () => {
+    const { container } = render(
+      <Badge asChild>
+        <a href="/profile">Profile</a>
+      </Badge>,
+    );
+
+    expect(container.querySelector("a")?.getAttribute("data-slot")).toBe("badge");
+  });
+
   it("defaults to data-variant='default'", () => {
     const { container } = render(<Badge>Label</Badge>);
 


### PR DESCRIPTION
## Summary
- Adds one focused badge UI test asserting the badge data-slot is preserved when `Badge` renders through `asChild`.

## Why
- Existing coverage checks the default badge element. This locks the same slot contract on the alternate composed child surface.

## PR Base Policy
- Base branch: `integration/pr-train`.
- Head branch: `codex/badge-data-slot-contract-test`.
- Scope: one test file only.

## No Overlap Proof
- Only file changed: `hushh-webapp/__tests__/ui/badge.test.tsx`.
- The new assertion targets the `Badge asChild` path and does not touch badge implementation or other UI components.
- This is distinct from the existing default badge data-slot assertion.

## Validation
- Not run locally: this isolated worktree does not have `node_modules`, so `vitest` is not available.

## DCO
- Commit includes Signed-off-by footer.
