### PR TITLE
fix(marketplace): enforce explicit button types on deck empty state controls

### DIFF
--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -1390,11 +1390,11 @@ export default function MarketplacePage() {
                 </p>
               ) : null}
               <div className="flex flex-wrap justify-center gap-2">
-                <Button variant="blue-gradient" effect="fill" size="sm" onClick={resetSwipeDeck}>
+                <Button type="button" variant="blue-gradient" effect="fill" size="sm" onClick={resetSwipeDeck}>
                   <RotateCcw className="mr-2 h-4 w-4" />
                   {directoryKind === "investors" ? "Refresh deck" : "Start over"}
                 </Button>
-                <Button variant="none" effect="fade" size="sm" onClick={() => setView("list")}>
+                <Button type="button" variant="none" effect="fade" size="sm" onClick={() => setView("list")}>
                   <List className="mr-2 h-4 w-4" />
                   Switch to list
                 </Button>


### PR DESCRIPTION
### Description

Fixes missing `type="button"` attributes on the "Refresh deck" and "Switch to list" `<Button>` components rendered in the empty state view of the marketplace swipe deck (`app/marketplace/page.tsx`). This enforces strict DOM hygiene and acts as a failsafe against unintended form submissions.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `app/marketplace/page.tsx`

- Trust boundary touched:
  - [x] none (purely presentational UI component)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`app/marketplace/page.tsx`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none
- [x] Error path, rollback, or safe-failure behavior proved: N/A - Pure UI prop enforcement change.