### PR TITLE
test(card): cover card footer data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/ui/card.test.tsx
+++ b/hushh-webapp/__tests__/ui/card.test.tsx
@@ -67,4 +67,10 @@ describe("Card", () => {
 
     expect(title?.tagName).toBe("H3");
   });
+
+  it("renders CardFooter with the card-footer data-slot contract", () => {
+    const { container } = render(<CardFooter>Footer</CardFooter>);
+
+    expect(container.firstElementChild?.getAttribute("data-slot")).toBe("card-footer");
+  });
 });


### PR DESCRIPTION
## Summary
- Adds one focused CardFooter test asserting the rendered footer element carries `data-slot="card-footer"`.

## Why
- Existing coverage checks all card slots through a composed card render. This locks the footer slot contract directly on the `CardFooter` surface.

## PR Base Policy
- Base branch: `integration/pr-train`.
- Head branch: `codex/card-footer-data-slot-test`.
- Scope: one test file only.

## No Overlap Proof
- Only file changed: `hushh-webapp/__tests__/ui/card.test.tsx`.
- The new assertion targets `CardFooter` directly and does not touch card implementation or any other UI component.
- This is distinct from the existing broad composed-card slot smoke test.

## Validation
- Not run locally: this isolated worktree does not have `node_modules`, so `vitest` is not available.

## DCO
- Commit includes Signed-off-by footer.
