### PR TITLE
test(combobox): cover chip remove data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/ui/combobox.test.tsx
+++ b/hushh-webapp/__tests__/ui/combobox.test.tsx
@@ -1,0 +1,24 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Combobox,
+  ComboboxChip,
+  ComboboxChips,
+} from "@/components/ui/combobox";
+
+describe("ComboboxChip", () => {
+  it("renders chip remove with the combobox-chip-remove data-slot contract", () => {
+    const { container } = render(
+      <Combobox items={["Profile"]} multiple>
+        <ComboboxChips>
+          <ComboboxChip>Profile</ComboboxChip>
+        </ComboboxChips>
+      </Combobox>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="combobox-chip-remove"]'),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a focused combobox UI test covering the chip remove control's `data-slot="combobox-chip-remove"` contract.

## Why
- Locks the remove control slot on the exported `ComboboxChip` surface used by multi-select chip UI.

## PR Base Policy
- Base branch: `integration/pr-train`.
- Head branch: `codex/combobox-chip-remove-slot-test`.
- Scope: one new test file only.

## No Overlap Proof
- Only file changed: `hushh-webapp/__tests__/ui/combobox.test.tsx`.
- The assertion targets the `ComboboxChip` remove control data-slot only.
- No implementation files or other UI component tests are touched.

## Validation
- Not run locally: this isolated worktree does not have `node_modules`, so `vitest` is not available.

## DCO
- Commit includes Signed-off-by footer.
