### PR TITLE
test(auth-provider-button): assert explicit button type contract

### DIFF
--- a/hushh-webapp/__tests__/components/auth-provider-button.test.tsx
+++ b/hushh-webapp/__tests__/components/auth-provider-button.test.tsx
@@ -1,0 +1,35 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/morphy-ux/button", () => ({
+  Button: ({
+    children,
+    type,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    type?: string;
+    disabled?: boolean;
+  }) => (
+    <button
+      type={(type as "button" | "submit" | "reset") ?? "button"}
+      disabled={disabled}
+    >
+      {children}
+    </button>
+  ),
+}));
+
+import { AuthProviderButton } from "@/components/onboarding/AuthProviderButton";
+
+describe("AuthProviderButton", () => {
+  it("renders with explicit type='button' to prevent accidental form submission", () => {
+    const { container } = render(
+      <AuthProviderButton label="Google" icon={<span />} />,
+    );
+
+    const button = container.querySelector("button");
+
+    expect(button?.getAttribute("type")).toBe("button");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a focused test for `AuthProviderButton` asserting that the rendered
button exposes `type="button"`.

## What & Why

`AuthProviderButton` explicitly passes `type="button"` to the underlying
Button component to prevent accidental form submission when rendered
inside forms.

This test characterizes that existing behavior and helps prevent future
regressions.

## Scope

- New test file only
- No production code changes
- No existing tests modified
- One deterministic assertion
- No snapshots

## Validation

```bash
npx vitest run __tests__/components/auth-provider-button.test.tsx
```

## Checklist

- [x] Test-only change
- [x] New test file
- [x] No production code changes
- [x] No snapshots
- [x] Deterministic
- [x] DCO signed (`git commit -s`)