### PR TITLE
test(dialog): cover close control data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/ui/dialog.test.tsx
+++ b/hushh-webapp/__tests__/ui/dialog.test.tsx
@@ -22,6 +22,20 @@ describe("DialogContent", () => {
     expect(screen.getByRole("button", { name: /close/i })).toBeTruthy();
   });
 
+  it("renders the close control with the dialog-close data-slot contract", () => {
+    render(
+      <Dialog open>
+        <DialogContent>
+          <DialogTitle>Test dialog</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    expect(screen.getByRole("button", { name: /close/i }).getAttribute("data-slot")).toBe(
+      "dialog-close",
+    );
+  });
+
   it("hides the close button when showCloseButton is false", () => {
     render(
       <Dialog open>


### PR DESCRIPTION
## Summary
- Adds one focused dialog UI test asserting the default close control carries `data-slot="dialog-close"`.

## Why
- Existing dialog coverage checks close button visibility. This locks the slot contract on the actual accessible close control.

## PR Base Policy
- Base branch: `integration/pr-train`.
- Head branch: `codex/dialog-close-data-slot-test`.
- Scope: one test file only.

## No Overlap Proof
- Only file changed: `hushh-webapp/__tests__/ui/dialog.test.tsx`.
- The new assertion targets the default `DialogContent` close control data-slot only.
- No implementation files or other UI component tests are touched.

## Validation
- Not run locally: this isolated worktree does not have `node_modules`, so `vitest` is not available.

## DCO
- Commit includes Signed-off-by footer.
