### PR TITLE
test(progress): cover progress indicator data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/ui/progress.test.tsx
+++ b/hushh-webapp/__tests__/ui/progress.test.tsx
@@ -26,6 +26,16 @@ describe("Progress", () => {
     expect(indicator.style.transform).toBe("translate3d(-50%, 0, 0)");
   });
 
+  it("keeps the progress indicator data-slot when indicatorClassName is provided", () => {
+    const { container } = render(
+      <Progress value={25} indicatorClassName="custom-indicator" />,
+    );
+
+    expect(container.querySelector(".custom-indicator")?.getAttribute("data-slot")).toBe(
+      "progress-indicator",
+    );
+  });
+
   it("clamps values above 100", () => {
     const { container } = render(<Progress value={150} />);
 


### PR DESCRIPTION
## Summary
- Adds one focused progress UI test asserting the indicator keeps `data-slot="progress-indicator"` when `indicatorClassName` is provided.

## Why
- Existing coverage checks the broad root and indicator slots. This locks the indicator slot on the customized indicator path.

## PR Base Policy
- Base branch: `integration/pr-train`.
- Head branch: `codex/progress-indicator-data-slot-test`.
- Scope: one test file only.

## No Overlap Proof
- Only file changed: `hushh-webapp/__tests__/ui/progress.test.tsx`.
- The new assertion targets the `Progress` indicator data-slot when customized via `indicatorClassName`.
- No implementation files or other UI component tests are touched.

## Validation
- Not run locally: this isolated worktree does not have `node_modules`, so `vitest` is not available.

## DCO
- Commit includes Signed-off-by footer.
