### PR TITLE
test(combobox): assert ComboboxValue data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/ui/combobox.test.tsx
+++ b/hushh-webapp/__tests__/ui/combobox.test.tsx
@@ -1,0 +1,35 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@base-ui/react", () => ({
+  Combobox: {
+    Root: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+    Value: ({
+      children,
+      "data-slot": dataSlot,
+    }: {
+      children?: React.ReactNode;
+      "data-slot"?: string;
+    }) => <span data-slot={dataSlot}>{children}</span>,
+  },
+}));
+
+import { Combobox, ComboboxValue } from "@/components/ui/combobox";
+
+describe("ComboboxValue", () => {
+  it("renders with data-slot='combobox-value'", () => {
+    const { container } = render(
+      <Combobox>
+        <ComboboxValue />
+      </Combobox>,
+    );
+
+    const element = container.querySelector(
+      '[data-slot="combobox-value"]',
+    );
+
+    expect(element?.getAttribute("data-slot")).toBe("combobox-value");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a focused test asserting that `ComboboxValue` renders with
`data-slot="combobox-value"`.

## What & Why

`ComboboxValue` exposes a `data-slot` attribute used by styling and
component contracts. This test characterizes that existing behavior to
help prevent accidental regressions.

## Scope

- New test file only
- No production code changes
- No existing tests modified
- Minimal mock of the required combobox primitives
- Deterministic assertion
- No snapshots

## Validation

```bash
npx vitest run __tests__/ui/combobox.test.tsx
```

## Checklist

- [x] Test-only change
- [x] New test file
- [x] No production code changes
- [x] No snapshots
- [x] Deterministic
- [x] DCO signed (`git commit -s`)