### PR TITLE
test(skeleton): cover skeleton data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/ui/skeleton.test.tsx
+++ b/hushh-webapp/__tests__/ui/skeleton.test.tsx
@@ -10,6 +10,12 @@ describe("Skeleton", () => {
     expect(container.querySelector('[data-slot="skeleton"]')).toBeTruthy();
   });
 
+  it("keeps the skeleton data-slot when custom layout classes are provided", () => {
+    const { container } = render(<Skeleton className="h-8 w-24" />);
+
+    expect(container.firstElementChild?.getAttribute("data-slot")).toBe("skeleton");
+  });
+
   it("renders with aria-hidden='true'", () => {
     const { container } = render(<Skeleton />);
 


### PR DESCRIPTION
## Summary
- Adds one focused skeleton UI test asserting `data-slot="skeleton"` is preserved when custom layout classes are supplied.

## Why
- Existing coverage checks the default skeleton slot. This locks the slot contract on the customized layout path.

## PR Base Policy
- Base branch: `integration/pr-train`.
- Head branch: `codex/skeleton-data-slot-contract-test`.
- Scope: one test file only.

## No Overlap Proof
- Only file changed: `hushh-webapp/__tests__/ui/skeleton.test.tsx`.
- The new assertion targets the `Skeleton` data-slot when custom `className` layout classes are provided.
- No implementation files or other UI component tests are touched.

## Validation
- Not run locally: this isolated worktree does not have `node_modules`, so `vitest` is not available.

## DCO
- Commit includes Signed-off-by footer.
