### PR TITLE
test(signed-in-shell-content-offset): characterize default page top offset

### DIFF
--- a/hushh-webapp/__tests__/components/signed-in-shell-content-offset.test.ts
+++ b/hushh-webapp/__tests__/components/signed-in-shell-content-offset.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveSignedInShellContentOffset } from "@/components/app-ui/signed-in-shell-content-offset";
+
+describe("resolveSignedInShellContentOffset", () => {
+  it("normalizes absent localOffset to zero and returns 32px page-top-start in standard mode", () => {
+    const result = resolveSignedInShellContentOffset({
+      shellVisible: true,
+      routeLayoutMode: "standard",
+    });
+
+    expect(result.mode).toBe("standard");
+    expect(result.localOffset).toBe("0px");
+    expect(result.style["--page-top-start"]).toBe("32px");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a focused characterization test for
`resolveSignedInShellContentOffset`, covering the default
`localOffset` normalization and the standard layout page offset.

## What & Why

The existing service-level test explicitly passes:

```ts
localOffset: "0px"
```

This test exercises a different code path by omitting
`localOffset` entirely and verifying:

- `mode` is `"standard"`
- `localOffset` defaults to `"0px"`
- `--page-top-start` resolves to `"32px"`

This documents the existing normalization behavior and helps prevent
future regressions.

## Scope

- New test file only
- No production code changes
- No existing tests modified
- No mocks
- No snapshots
- Deterministic assertions

## Validation

```bash
npx vitest run __tests__/components/signed-in-shell-content-offset.test.ts
```

## Checklist

- [x] Test-only change
- [x] New test file
- [x] No production code changes
- [x] No snapshots
- [x] Deterministic
- [x] DCO signed (`git commit -s`)