### PR TITLE
test(tabs): cover tabs trigger data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/ui/tabs.test.tsx
+++ b/hushh-webapp/__tests__/ui/tabs.test.tsx
@@ -48,6 +48,23 @@ describe("Tabs", () => {
     expect(container.querySelector('[data-slot="tabs-trigger"]')).toBeTruthy();
   });
 
+  it("keeps the tabs trigger data-slot when custom className is provided", () => {
+    const { container } = render(
+      <Tabs defaultValue="tab-1">
+        <TabsList>
+          <TabsTrigger value="tab-1" className="custom-trigger">
+            Tab 1
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="tab-1">Content 1</TabsContent>
+      </Tabs>,
+    );
+
+    expect(container.querySelector(".custom-trigger")?.getAttribute("data-slot")).toBe(
+      "tabs-trigger",
+    );
+  });
+
   it("renders TabsContent with data-slot='tabs-content'", () => {
     const { container } = render(
       <Tabs defaultValue="tab-1">


### PR DESCRIPTION
## Summary
- Adds one focused tabs UI test asserting `TabsTrigger` keeps `data-slot="tabs-trigger"` when a custom className is provided.

## Why
- Existing coverage checks the broad trigger slot. This locks the trigger slot contract on the customized trigger path.

## PR Base Policy
- Base branch: `integration/pr-train`.
- Head branch: `codex/tabs-trigger-data-slot-test`.
- Scope: one test file only.

## No Overlap Proof
- Only file changed: `hushh-webapp/__tests__/ui/tabs.test.tsx`.
- The new assertion targets the `TabsTrigger` data-slot when customized via `className`.
- No implementation files or other UI component tests are touched.

## Validation
- Not run locally: this isolated worktree does not have `node_modules`, so `vitest` is not available.

## DCO
- Commit includes Signed-off-by footer.
