### PR TITLE
test(consent-display): characterize humanizeConsentScope for pkm.read

### DIFF
--- a/hushh-webapp/__tests__/utils/consent-display-pkm.test.ts
+++ b/hushh-webapp/__tests__/utils/consent-display-pkm.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+import { humanizeConsentScope } from "@/lib/consent/consent-display";
+
+describe("humanizeConsentScope", () => {
+  it("returns 'Personal Knowledge Model access' for pkm.read scope", () => {
+    expect(humanizeConsentScope("pkm.read")).toBe(
+      "Personal Knowledge Model access",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds a focused characterization test for
`humanizeConsentScope`, covering the `"pkm.read"` mapping.

## What & Why

`humanizeConsentScope` exposes user-facing labels for consent scopes.
This test documents the existing mapping:

```ts
humanizeConsentScope("pkm.read")
```

returning:

```text
Personal Knowledge Model access
```

Locking this behavior helps prevent accidental regressions in consent UI
copy.

## Scope

- New test file only
- No production code changes
- No existing tests modified
- No mocks
- No snapshots
- Deterministic assertion

## Validation

```bash
npx vitest run __tests__/utils/consent-display-pkm.test.ts
```

## Checklist

- [x] Test-only change
- [x] New test file
- [x] No production code changes
- [x] No snapshots
- [x] Deterministic
- [x] DCO signed (`git commit -s`)