### PR TITLE
fix(kai): enforce explicit button types on optimization error state controls

### DIFF
--- a/hushh-webapp/app/one/kai/optimize/page.tsx
+++ b/hushh-webapp/app/one/kai/optimize/page.tsx
@@ -733,10 +733,11 @@ export default function PortfolioHealthPage() {
               </p>
             )}
             <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-              <Button size="default" onClick={() => router.refresh()}>
+              <Button type="button" size="default" onClick={() => router.refresh()}>
                 Retry optimization
               </Button>
               <Button
+                type="button"
                 size="default"
                 variant="blue-gradient"
                 effect="fade"


### PR DESCRIPTION
### Description

Fixes missing `type="button"` attributes on the "Retry optimization" and "Back to portfolio" fallback `<Button>` components rendered in the error state of the Kai portfolio optimizer (`app/one/kai/optimize/page.tsx`). This enforces strict DOM hygiene and acts as a failsafe against unintended form submissions.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `app/one/kai/optimize/page.tsx`

- Trust boundary touched:
  - [x] none (purely presentational UI component)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`app/one/kai/optimize/page.tsx`)
## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none