### PR TITLE
test(navigation): characterize normalizeInternalRouteHref trailing slash preservation

### DIFF
--- a/hushh-webapp/__tests__/navigation/normalize-trailing-slash.test.ts
+++ b/hushh-webapp/__tests__/navigation/normalize-trailing-slash.test.ts
@@ -45,6 +45,11 @@ describe("normalizeInternalRouteHref — trailing slash handling", () => {
     );
   });
 
+  it("preserves empty query and fragment delimiters after a trailing slash", () => {
+    expect(normalizeInternalRouteHref("/profile/?")).toBe("/profile/?");
+    expect(normalizeInternalRouteHref("/profile/#")).toBe("/profile/#");
+  });
+
   it("trims surrounding whitespace but keeps the terminal slash", () => {
     expect(normalizeInternalRouteHref("  /profile/  ")).toBe("/profile/");
   });


### PR DESCRIPTION
## Summary
- Adds one focused characterization for `normalizeInternalRouteHref` preserving empty query and fragment delimiters after a trailing slash.

## Why
- Existing trailing-slash coverage already checks ordinary trailing slashes and valued query/fragment suffixes. This locks the adjacent empty-delimiter boundary: `/profile/?` and `/profile/#`.

## PR Base Policy
- Base branch: `integration/pr-train`.
- Head branch: `codex/navigation-trailing-slash-preservation-test`.
- Scope: one test file only.

## No Overlap Proof
- Only file changed: `hushh-webapp/__tests__/navigation/normalize-trailing-slash.test.ts`.
- Existing tests cover `/profile/`, `/profile/?tab=privacy`, and `/terms/#Section-A`.
- This PR only adds the previously uncovered empty query/hash delimiter cases after a trailing slash: `/profile/?` and `/profile/#`.
- No implementation files or other navigation tests are touched.

## Validation
- Not run locally: this isolated worktree does not have `node_modules`, so `vitest` is not available.

## DCO
- Commit includes Signed-off-by footer.
