### PR TITLE
test(email-helper-consent): characterize single-field consent summary

### DIFF
--- a/hushh-webapp/__tests__/utils/email-helper-consent-summary.test.ts
+++ b/hushh-webapp/__tests__/utils/email-helper-consent-summary.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { emailHelperConsentSummary } from "@/lib/consent/email-helper-consent";
+
+describe("emailHelperConsentSummary", () => {
+  it("returns single-field approval message when one required field is present", () => {
+    const result = emailHelperConsentSummary({
+      required_fields: ["risk_profile"],
+    });
+
+    expect(result).toBe(
+      "Email Helper needs approval to use your risk profile.",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds a focused characterization test for the single-field branch of
`emailHelperConsentSummary`.

## What

Introduces a new standalone test file covering the case where exactly one
required field is present.

## Why

`emailHelperConsentSummary` generates user-visible consent messaging.
The single-field path produces a unique interpolated string and performs
field-name normalization (`"_"` → `" "`). This behavior was previously
untested.

## Scope

- New test file only
- No production code changes
- No existing tests modified
- No mocks
- No snapshots
- Deterministic assertion

## Validation

```bash
npx vitest run __tests__/utils/email-helper-consent-summary.test.ts
```

## Checklist

- [x] Test-only change
- [x] New standalone test file
- [x] No production code changes
- [x] No snapshots
- [x] Deterministic
- [x] DCO signed (`git commit -s`)