### PR TITLE
chore(kai): silence debug logs during portfolio domain decryption

### DIFF
--- a/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
+++ b/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
@@ -228,7 +228,9 @@ export function ManagePortfolioView() {
           
           // Priority 2: Decrypt the financial PKM domain (fallback)
           if (!parsed) {
-            console.log("[ManagePortfolio] No cache, attempting to decrypt the financial PKM domain...");
+            if (process.env.NODE_ENV !== "production") {
+              console.log("[ManagePortfolio] No cache, attempting to decrypt the financial PKM domain...");
+            }
             try {
               const snapshot = await PkmDomainResourceService.getStaleFirst({
                 userId: user.uid,
@@ -247,10 +249,14 @@ export function ManagePortfolioView() {
 
                 // Update cache for future use
                 setCachePortfolioData(user.uid, parsed);
-                console.log("[ManagePortfolio] Decrypted and cached portfolio data");
+                if (process.env.NODE_ENV !== "production") {
+                  console.log("[ManagePortfolio] Decrypted and cached portfolio data");
+                }
               }
             } catch (decryptError) {
-              console.error("[ManagePortfolio] Failed to decrypt the financial PKM domain:", decryptError);
+              if (process.env.NODE_ENV !== "production") {
+                console.error("[ManagePortfolio] Failed to decrypt the financial PKM domain:", decryptError);
+              }
               toast.error("Unable to decrypt portfolio data. Please re-import your statement.");
             }
           }


### PR DESCRIPTION
### Description

Silences noisy debug `console.log` and `console.error` statements inside `components/kai/views/manage-portfolio-view.tsx` by wrapping them in a development environment check (`NODE_ENV !== "production"`). This prevents potentially sensitive state information from leaking into the browser console in production environments during the financial PKM domain decryption flow.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/kai/views/manage-portfolio-view.tsx`

- Trust boundary touched:
  - [x] none (purely logging)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/kai/views/manage-portfolio-view.tsx`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none (internal logging only)
- [x] Error path, rollback, or safe-failure behavior proved: N/A - Purely a logging chore.