### PR TITLE
test(utils): cover cn empty input contract

### DIFF
--- a/hushh-webapp/__tests__/utils/utils.test.ts
+++ b/hushh-webapp/__tests__/utils/utils.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { cn } from "@/lib/utils";
+
+describe("cn", () => {
+  it("returns an empty string for empty input", () => {
+    expect(cn()).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit test coverage for the `cn` utility function when invoked with no arguments.

## Changes Made

* Added a test to verify that `cn()` returns an empty string when called without any inputs.
* Covers the utility's default behavior and protects against regressions.
* Keeps utility test coverage aligned with existing contracts.

## Test

```bash
npx vitest run __tests__/utils/utils.test.ts
```
