### PR TITLE
test(top-app-bar): cover notification loading status live region

### DIFF
--- a/hushh-webapp/__tests__/components/top-app-bar.contract.test.ts
+++ b/hushh-webapp/__tests__/components/top-app-bar.contract.test.ts
@@ -139,4 +139,17 @@ describe("Top app bar responsive contract", () => {
     expect(source).toContain("selected: null");
     expect(source).toContain("notificationAction: null");
   });
+
+  it("covers notification loading icon and status live region semantics", () => {
+    const source = read("components/app-ui/top-app-bar.tsx");
+
+    expect(source).toContain("<DebateTaskCenter");
+    expect(source).toContain('aria-label="Notifications"');
+    expect(source).toContain("activeCount > 0");
+    expect(source).toContain('className="h-5 w-5 animate-spin text-sky-500"');
+    expect(source).toContain('aria-hidden="true"');
+    expect(source).toContain('role="status"');
+    expect(source).toContain('aria-live="polite"');
+    expect(source).toContain('aria-atomic="true"');
   });
+});


### PR DESCRIPTION
## Summary
- Adds a top app bar source-contract test covering the Notifications trigger loading state and the shell live-region contract.

## Why
- Keeps notification loading visual state decorative while confirming the top app bar continues to expose a polite atomic status live region.

## PR Base Policy
- Base branch: `integration/pr-train`.
- Head branch: `codex/top-app-bar-notification-loading-status-test`.
- Scope: one existing contract test file only.

## No Overlap Proof
- Only file changed: `hushh-webapp/__tests__/components/top-app-bar.contract.test.ts`.
- The assertion targets the TopAppBar Notifications renderTrigger branch (`activeCount > 0`) and the existing sr-only live-region contract.
- It does not touch `components/app-ui/top-app-bar.tsx`, notification services, DebateTaskCenter, or other tests.
- Claim boundary: the notification spinner remains decorative (`aria-hidden="true"`); the live-region assertion covers the top-app-bar status region rather than adding new notification copy.

## Validation
- `git diff --check`
- Not run locally: this isolated worktree does not have `node_modules`, so `vitest` is not available.

## DCO
- Commit includes Signed-off-by footer.
