### PR TITLE
test(ui): cover combobox trigger data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/ui/combobox.test.tsx
+++ b/hushh-webapp/__tests__/ui/combobox.test.tsx
@@ -1,0 +1,18 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Combobox, ComboboxTrigger } from "@/components/ui/combobox";
+
+describe("Combobox", () => {
+  it("exposes the combobox trigger data-slot contract", () => {
+    const { container } = render(
+      <Combobox>
+        <ComboboxTrigger>Choose option</ComboboxTrigger>
+      </Combobox>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="combobox-trigger"]'),
+    ).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds test coverage for the Combobox trigger data-slot contract.

## Changes Made

* Added a unit test to verify that the `ComboboxTrigger` component exposes the expected `data-slot="combobox-trigger"` attribute.
* Ensures the trigger contract remains stable and helps prevent accidental regressions.
* Extends UI component contract coverage with a focused, low-risk test.

## Test

```bash
npx vitest run __tests__/ui/combobox.test.tsx
```
