### PR TITLE
fix(ui): prevent auth debug labels from leaking into production console

### DIFF
--- a/hushh-webapp/components/onboarding/AuthStep.tsx
+++ b/hushh-webapp/components/onboarding/AuthStep.tsx
@@ -192,11 +192,13 @@ export function AuthStep({
   };
 
   const debugError = (label: string, error?: unknown) => {
-    if (process.env.NODE_ENV !== "production" && error !== undefined) {
-      console.error(label, error);
-      return;
+    if (process.env.NODE_ENV !== "production") {
+      if (error !== undefined) {
+        console.error(label, error);
+      } else {
+        console.error(label);
+      }
     }
-    console.error(label);
   };
 
   useEffect(() => {


### PR DESCRIPTION
### Description

Fixes a bug in the `debugError` utility inside `components/onboarding/AuthStep.tsx` that was inadvertently leaking debug labels to the production console. The utility was missing a proper guard for the fallback `console.error(label)` call, causing it to fire unconditionally outside of development mode.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/onboarding/AuthStep.tsx`

- Trust boundary touched:
  - [x] none (purely UI logging)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/onboarding/AuthStep.tsx`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none (internal logging only)