### PR TITLE
chore(api): silence debug logs during pending consent approval

### DIFF
--- a/hushh-webapp/app/api/consent/pending/approve/route.ts
+++ b/hushh-webapp/app/api/consent/pending/approve/route.ts
@@ -76,8 +76,10 @@ export async function POST(request: NextRequest) {
       ));
     }
 
-    console.log(`[API] Approving consent request: ${requestId}`);
-    console.log(`[API] Export data present: ${!!encryptedData}`);
+    if (process.env.NODE_ENV !== "production") {
+      console.log(`[API] Approving consent request: ${requestId}`);
+      console.log(`[API] Export data present: ${!!encryptedData}`);
+    }
 
     // Forward to FastAPI with encrypted export
     const response = await fetch(`${BACKEND_URL}/api/consent/pending/approve`, {
@@ -130,7 +132,9 @@ export async function POST(request: NextRequest) {
     }
 
     const data = await response.json();
-    console.log(`[API] Consent approved with token`);
+    if (process.env.NODE_ENV !== "production") {
+      console.log(`[API] Consent approved with token`);
+    }
 
     return withSecurityHeaders(NextResponse.json(data));
   } catch (error) {


### PR DESCRIPTION
### Description

Silences development `console.log` statements inside `app/api/consent/pending/approve/route.ts` by properly wrapping them in `NODE_ENV !== "production"` checks. Prevents the route from leaking debug logs into the production server output on every pending consent approval.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `app/api/consent/pending/approve/route.ts`

- Trust boundary touched:
  - [x] none (purely logging)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`app/api/consent/pending/approve/route.ts`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none (internal logging only)
- [x] Error path, rollback, or safe-failure behavior proved: N/A - Purely a logging chore fix.