### PR TITLE
test(alert): verify AlertTitle renders as an h5 heading element

### DIFF
--- a/hushh-webapp/__tests__/ui/alert.test.tsx
+++ b/hushh-webapp/__tests__/ui/alert.test.tsx
@@ -56,4 +56,16 @@ describe("Alert", () => {
     expect(alert?.getAttribute("role")).toBe("alert");
     expect(slots).toEqual(["alert", "alert-title", "alert-description"]);
   });
+
+  it("renders AlertTitle as an h5 heading element", () => {
+    const { container } = render(
+      <Alert>
+        <AlertTitle>Title</AlertTitle>
+      </Alert>,
+    );
+
+    const title = container.querySelector('[data-slot="alert-title"]');
+
+    expect(title?.tagName).toBe("H5");
+  });
 });


### PR DESCRIPTION
## Summary

Adds one focused contract test verifying that `AlertTitle` renders as a
native `<h5>` element.

## What

Appends a single `it()` block to the existing `Alert` test suite.

The new test verifies that the rendered element with
`data-slot="alert-title"` is an `<h5>`.

## Why

`AlertTitle` already renders a native `<h5>` in production. The existing
suite verifies the `data-slot` contract but does not verify the semantic
HTML element. This test documents and protects that behavior.

## Scope

- Test-only change
- One existing test file updated
- One new `it()` block
- No production code changes
- No import changes
- No snapshots
- No mocks

## Validation

```bash
npx vitest run __tests__/ui/alert.test.tsx
```

## Checklist

- [x] Test-only change
- [x] Append-only update
- [x] No production code changes
- [x] No snapshots
- [x] Deterministic
- [x] DCO signed (`git commit -s`)