### PR TITLE
test(table): verify Table container has role='region' and aria-label

### DIFF
--- a/hushh-webapp/__tests__/ui/table.test.tsx
+++ b/hushh-webapp/__tests__/ui/table.test.tsx
@@ -54,4 +54,26 @@ describe("Table", () => {
     expect(header).toBeTruthy();
     expect(header?.tagName).toBe("THEAD");
   });
+
+  it("renders the table container with role='region' and an aria-label", () => {
+    const { container } = render(
+      <Table>
+        <tbody>
+          <tr>
+            <td>Holding</td>
+          </tr>
+        </tbody>
+      </Table>,
+    );
+
+    const tableContainer = container.querySelector(
+      '[data-slot="table-container"]',
+    );
+
+    expect(tableContainer?.getAttribute("role")).toBe("region");
+    expect(tableContainer?.getAttribute("aria-label")).toBe(
+      "Scrollable table",
+    );
+  });
+
 });


### PR DESCRIPTION
## Summary

Adds one focused accessibility contract test verifying that the `Table`
scroll container exposes the expected accessibility attributes.

## What

Appends a single `it()` block to the existing table test suite.

The new test verifies that the element with
`data-slot="table-container"` exposes:

- `role="region"`
- `aria-label="Scrollable table"`

## Why

`components/ui/table.tsx` already renders these accessibility attributes
on the table container. The existing suite verifies other aspects of the
container but does not explicitly lock these attributes. This test
documents and protects that behavior.

## Scope

- Test-only change
- One existing test file updated
- One new `it()` block
- No production code changes
- No import changes
- No snapshots
- No mocks

## Validation

```bash
npx vitest run __tests__/ui/table.test.tsx
```

## Checklist

- [x] Test-only change
- [x] Append-only update
- [x] No production code changes
- [x] No snapshots
- [x] Deterministic
- [x] DCO signed (`git commit -s`)