### PR TITLE
test(progress): verify Progress has role='progressbar'

### DIFF
--- a/hushh-webapp/__tests__/ui/progress.test.tsx
+++ b/hushh-webapp/__tests__/ui/progress.test.tsx
@@ -62,4 +62,12 @@ describe("Progress", () => {
 
     expect(root?.getAttribute("aria-valuenow")).toBe("50");
   });
+
+  it("renders root with role='progressbar'", () => {
+    const { container } = render(<Progress value={50} />);
+
+    const root = container.querySelector('[data-slot="progress"]');
+
+    expect(root?.getAttribute("role")).toBe("progressbar");
+  });
 });


### PR DESCRIPTION
## Summary

Adds one focused accessibility contract test verifying that the `Progress`
root element exposes `role="progressbar"`.

## What

Appends a single `it()` block to the existing progress test suite.

The new test verifies that the element with
`data-slot="progress"` exposes:

- `role="progressbar"`

## Why

`Progress` wraps Radix's `ProgressPrimitive.Root`, which renders with
`role="progressbar"` as part of its accessibility contract. The existing
suite already verifies `aria-valuenow` and value clamping behavior but
does not explicitly protect the role attribute.

## Scope

- Test-only change
- One existing test file updated
- One new `it()` block
- No production code changes
- No import changes
- No snapshots
- No mocks

## Validation

```bash
npx vitest run __tests__/ui/progress.test.tsx
```

## Checklist

- [x] Test-only change
- [x] Append-only update
- [x] No production code changes
- [x] No snapshots
- [x] Deterministic
- [x] DCO signed (`git commit -s`)