### PR TITLE
test(separator): verify Separator renders as a div element

### DIFF
--- a/hushh-webapp/__tests__/ui/separator.test.tsx
+++ b/hushh-webapp/__tests__/ui/separator.test.tsx
@@ -40,4 +40,12 @@ describe("Separator", () => {
     expect(el?.getAttribute("role")).toBe("separator");
   });
 
+  it("renders as a div element", () => {
+    const { container } = render(<Separator />);
+
+    const el = container.querySelector('[data-slot="separator"]');
+
+    expect(el?.tagName).toBe("DIV");
+  });
+
 });


### PR DESCRIPTION
## Summary

Adds one focused contract test verifying that the `Separator` component
renders as a native `<div>` element.

## What

Appends a single `it()` block to the existing separator test suite.

The new test verifies that the element with
`data-slot="separator"` renders as:

- `<div>`

## Why

`Separator` wraps Radix's `SeparatorPrimitive.Root`, which renders a native
`<div>` by default. The existing suite already verifies accessibility
attributes such as `role="separator"` and `data-orientation`, but it does
not explicitly protect the underlying HTML element. This test documents and
preserves that DOM contract.

## Scope

- Test-only change
- One existing test file updated
- One new `it()` block
- No production code changes
- No import changes
- No snapshots
- No mocks

## Validation

```bash
npx vitest run __tests__/ui/separator.test.tsx
```

## Checklist

- [x] Test-only change
- [x] Append-only update
- [x] No production code changes
- [x] No snapshots
- [x] Deterministic
- [x] DCO signed (`git commit -s`)