### PR TITLE
test(label): verify Label renders as a label element

### DIFF
--- a/hushh-webapp/__tests__/ui/label.test.tsx
+++ b/hushh-webapp/__tests__/ui/label.test.tsx
@@ -11,4 +11,13 @@ describe("Label", () => {
       container.querySelector('[data-slot="label"]')
     ).not.toBeNull();
   });
+
+  it("renders as a label element", () => {
+    const { container } = render(<Label>Email</Label>);
+
+    const label = container.querySelector('[data-slot="label"]');
+
+    expect(label?.tagName).toBe("LABEL");
+  });
+
 });


### PR DESCRIPTION
## Summary

Adds one focused contract test verifying that the `Label` component renders
as a native `<label>` element.

## What

Appends a single `it()` block to the existing label test suite.

The new test verifies that the element with
`data-slot="label"` renders as:

- `<label>`

## Why

`Label` wraps Radix's `LabelPrimitive.Root`, which renders a native
`<label>` element as part of its accessibility contract. The existing
suite already verifies styling and other behavior but does not explicitly
protect the underlying HTML element. This test documents and preserves
that DOM contract.

## Scope

- Test-only change
- One existing test file updated
- One new `it()` block
- No production code changes
- No import changes
- No snapshots
- No mocks

## Validation

```bash
npx vitest run __tests__/ui/label.test.tsx
```

## Checklist

- [x] Test-only change
- [x] Append-only update
- [x] No production code changes
- [x] No snapshots
- [x] Deterministic
- [x] DCO signed (`git commit -s`)