### PR TITLE
test(input): verify Input renders as an input element

### DIFF
--- a/hushh-webapp/__tests__/ui/input.test.tsx
+++ b/hushh-webapp/__tests__/ui/input.test.tsx
@@ -34,4 +34,13 @@ describe("Input", () => {
 
     expect(el?.getAttribute("autocapitalize")).not.toBe("none");
   });
+
+  it("renders as an input element", () => {
+    const { container } = render(<Input />);
+
+    const el = container.querySelector('[data-slot="input"]');
+
+    expect(el?.tagName).toBe("INPUT");
+  });
+
 });


### PR DESCRIPTION
## Summary

Adds one focused contract test verifying that the `Input` component renders
as a native `<input>` element.

## What

Appends a single `it()` block to the existing input test suite.

The new test verifies that the element with
`data-slot="input"` renders as:

- `<input>`

## Why

`Input` renders a native `<input data-slot="input">` element directly. The
existing suite already verifies other runtime behavior but does not
explicitly protect the underlying HTML element. This test documents and
preserves that DOM contract.

## Scope

- Test-only change
- One existing test file updated
- One new `it()` block
- No production code changes
- No import changes
- No snapshots
- No mocks

## Validation

```bash
npx vitest run __tests__/ui/input.test.tsx
```

## Checklist

- [x] Test-only change
- [x] Append-only update
- [x] No production code changes
- [x] No snapshots
- [x] Deterministic
- [x] DCO signed (`git commit -s`)