### PR TITLE
test(textarea): verify Textarea renders as a textarea element

### DIFF
--- a/hushh-webapp/__tests__/ui/textarea.test.tsx
+++ b/hushh-webapp/__tests__/ui/textarea.test.tsx
@@ -12,4 +12,13 @@ describe("Textarea", () => {
     expect(textarea).not.toBeNull();
     expect(textarea?.hasAttribute("disabled")).toBe(true);
   });
+
+  it("renders as a textarea element", () => {
+    const { container } = render(<Textarea />);
+
+    const el = container.querySelector('[data-slot="textarea"]');
+
+    expect(el?.tagName).toBe("TEXTAREA");
+  });
+
 });


### PR DESCRIPTION
## Summary

Adds one focused contract test verifying that the `Textarea` component
renders as a native `<textarea>` element.

## What

Appends a single `it()` block to the existing textarea test suite.

The new test verifies that the element with
`data-slot="textarea"` renders as:

- `<textarea>`

## Why

`Textarea` renders a native `<textarea data-slot="textarea">` element
directly. The existing suite already verifies styling and runtime behavior
but does not explicitly protect the underlying HTML element. This test
documents and preserves that DOM contract.

## Scope

- Test-only change
- One existing test file updated
- One new `it()` block
- No production code changes
- No import changes
- No snapshots
- No mocks

## Validation

```bash
npx vitest run __tests__/ui/textarea.test.tsx
```

## Checklist

- [x] Test-only change
- [x] Append-only update
- [x] No production code changes
- [x] No snapshots
- [x] Deterministic
- [x] DCO signed (`git commit -s`)