### PR TITLE
test(checkbox): verify Checkbox has role='checkbox'

### DIFF
--- a/hushh-webapp/__tests__/ui/checkbox.test.tsx
+++ b/hushh-webapp/__tests__/ui/checkbox.test.tsx
@@ -28,4 +28,13 @@ describe("Checkbox", () => {
 
     expect(checkbox?.getAttribute("aria-checked")).toBe("true");
   });
+
+  it("has role='checkbox'", () => {
+    const { container } = render(<Checkbox />);
+
+    const checkbox = container.querySelector('[data-slot="checkbox"]');
+
+    expect(checkbox?.getAttribute("role")).toBe("checkbox");
+  });
+
 });


### PR DESCRIPTION
## Summary

Adds one focused accessibility contract test to the existing `Checkbox`
test suite.

## What

Appends a single `it()` block verifying that the rendered checkbox root
exposes the expected WAI-ARIA role.

The new assertion checks:

- `role="checkbox"`

## Why

The checkbox component is built on the Radix Checkbox primitive, which
renders the checkbox role as part of its accessibility contract. The
existing suite already verifies checked-state behavior but does not
explicitly protect this semantic attribute.

## Scope

- Test-only change
- One existing test file updated
- One new `it()` block
- No production code changes
- No import changes
- No snapshots
- No mocks

## Validation

```bash
npx vitest run __tests__/ui/checkbox.test.tsx
```

## Checklist

- [x] Test-only change
- [x] Append-only update
- [x] No production code changes
- [x] No snapshots
- [x] Deterministic
- [x] DCO signed (`git commit -s`)