### PR TITLE
test(kbd): verify Kbd renders as a kbd element

### DIFF
--- a/hushh-webapp/__tests__/ui/kbd.test.tsx
+++ b/hushh-webapp/__tests__/ui/kbd.test.tsx
@@ -9,4 +9,13 @@ describe("Kbd", () => {
 
     expect(container.querySelector('[data-slot="kbd"]')).not.toBeNull();
   });
+
+  it("renders as a kbd element", () => {
+    const { container } = render(<Kbd>⌘K</Kbd>);
+
+    const el = container.querySelector('[data-slot="kbd"]');
+
+    expect(el?.tagName).toBe("KBD");
+  });
+
 });


### PR DESCRIPTION
## Summary

Adds one focused semantic HTML contract test to the existing `Kbd`
test suite.

## What

Appends a single `it()` block verifying that the rendered keyboard key
component uses the native `<kbd>` HTML element.

The new assertion checks:

- `tagName === "KBD"`

## Why

The component renders a native `<kbd data-slot="kbd">` element. The
existing suite verifies the `data-slot` contract but does not protect the
underlying semantic HTML element. This test documents that contract and
guards against unintended regressions.

## Scope

- Test-only change
- One existing test file updated
- One new `it()` block
- No production code changes
- No import changes
- No snapshots
- No mocks

## Validation

```bash
npx vitest run __tests__/ui/kbd.test.tsx
```

## Checklist

- [x] Test-only change
- [x] Append-only update
- [x] No production code changes
- [x] No snapshots
- [x] Deterministic
- [x] DCO signed (`git commit -s`)