### PR TITLE
test(utils): cover cn empty value handling

### DIFF
--- a/hushh-webapp/__tests__/utils/cn.test.ts
+++ b/hushh-webapp/__tests__/utils/cn.test.ts
@@ -12,4 +12,9 @@ describe("cn", () => {
   it("lets later tailwind classes override earlier conflicts", () => {
     expect(cn("p-2", "p-4")).toBe("p-4");
   });
+  it("ignores null, undefined, and empty string values", () => {
+  expect(cn("flex", null, undefined, "", "items-center")).toBe(
+    "flex items-center",
+  );
+});
 });


### PR DESCRIPTION
## Summary

Adds unit test coverage for the `cn` utility to verify that empty and falsy values are ignored when composing class names.

## Changes Made

* Added a test to ensure `cn()` ignores `null`, `undefined`, and empty string (`""`) values.
* Verifies that valid class names are preserved while empty inputs do not affect the output.
* Expands existing utility coverage with an additional edge-case scenario.

## Test

```bash
npx vitest run __tests__/utils/cn.test.ts
```
