### PR TITLE
test(utils): characterize formatCompleteJson array object deep property ordering

### DIFF
--- a/hushh-webapp/__tests__/utils/format-property-ordering.test.ts
+++ b/hushh-webapp/__tests__/utils/format-property-ordering.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCompleteJson } from "@/lib/utils/json-to-human";
+
+// Characterization tests for formatCompleteJson
+// (hushh-webapp/lib/utils/json-to-human.ts) documenting how key/property order
+// is serialized when an array contains objects that share an identical key set
+// but were declared in completely different orders.
+//
+// TRUTH-FIRST — LITERAL CONTRACT: formatCompleteJson walks the input with
+// `Object.entries(...)` / `Object.values(...)` and never sorts, canonicalizes,
+// or re-orders keys. JavaScript object iteration order for string
+// (non-integer-like) keys is INSERTION ORDER. Therefore the formatter is
+// deterministic but it preserves each object's *own declaration order* exactly
+// as given — it does NOT impose a single shared/alphabetized ordering across
+// array elements. Two objects with the same keys in different orders serialize
+// according to their respective insertion orders.
+
+describe("formatCompleteJson — array object property ordering follows insertion order (no sort)", () => {
+  it("uses each object's own first-declared value in a generic array section", () => {
+    // Generic array handling emits `• <first non-null value>` per item, where
+    // "first" = first key in insertion order. Identical keys, reversed order.
+    const json = {
+      records: [
+        { gamma: "G", alpha: "A", bravo: "B" },
+        { alpha: "A", bravo: "B", gamma: "G" },
+      ],
+    };
+    const out = formatCompleteJson(json);
+    expect(out).toBe(
+      ["", "--- Records (2 items) ---", "  • G", "  • A"].join("\n"),
+    );
+  });
+
+  it("preserves object-section key order verbatim (not alphabetized)", () => {
+    const json = {
+      config: { gamma: "G", alpha: "A", bravo: "B" },
+    };
+    const out = formatCompleteJson(json);
+    expect(out).toBe(
+      [
+        "",
+        "--- Config ---",
+        "  Gamma: G",
+        "  Alpha: A",
+        "  Bravo: B",
+      ].join("\n"),
+    );
+    // Explicitly NOT alphabetical (which would be Alpha, Bravo, Gamma).
+    expect(out.indexOf("Gamma")).toBeLessThan(out.indexOf("Alpha"));
+  });
+
+  it("preserves a second object's differing key order independently", () => {
+    const json = {
+      config: { charlie: "C", bravo: "B", alpha: "A" },
+    };
+    const out = formatCompleteJson(json);
+    expect(out).toBe(
+      [
+        "",
+        "--- Config ---",
+        "  Charlie: C",
+        "  Bravo: B",
+        "  Alpha: A",
+      ].join("\n"),
+    );
+  });
+
+  it("preserves nested object key order verbatim", () => {
+    const json = {
+      config: {
+        nested: { zulu: "Z", yankee: "Y", xray: "X" },
+      },
+    };
+    const out = formatCompleteJson(json);
+    expect(out).toBe(
+      [
+        "",
+        "--- Config ---",
+        "  Nested:",
+        "    • Zulu: Z",
+        "    • Yankee: Y",
+        "    • Xray: X",
+      ].join("\n"),
+    );
+  });
+
+  it("is deterministic: identical input yields byte-identical output across calls", () => {
+    const json = {
+      config: { gamma: "G", alpha: "A", bravo: "B" },
+    };
+    expect(formatCompleteJson(json)).toBe(formatCompleteJson(json));
+  });
+
+  it("orders top-level sections by their own insertion order", () => {
+    const json = {
+      config: { alpha: "A" },
+      profile: { beta: "B" },
+    };
+    const out = formatCompleteJson(json);
+    expect(out.indexOf("--- Config ---")).toBeLessThan(
+      out.indexOf("--- Profile ---"),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Characterizes how `formatCompleteJson` (`hushh-webapp/lib/utils/json-to-human.ts`)
serializes property/key order when an array contains objects that share an
identical key set but were declared in completely different orders. Test-only;
no production change.

## Literal contract being characterized

`formatCompleteJson` walks the input exclusively with `Object.entries(...)` and
`Object.values(...)`. It never calls `.sort()`, never alphabetizes, and never
canonicalizes keys. JavaScript object iteration order for ordinary string
(non-integer-like) keys is **insertion order**.

## Truth-first correction to the task premise

The task frames this as "serialization order metrics … when keys are
structurally out of sequence," implying the formatter might re-sequence or
normalize key order toward a single canonical layout. It does **not.** The
output is **deterministic**, but only because it faithfully **preserves each
object's own insertion order** — it does **not** impose a shared or alphabetized
ordering across array elements. Two objects with the same keys in different
declaration orders serialize to **different** line orders, each matching its own
source object. "Layout determinism" here means *stable passthrough of input
order*, not *canonicalization*.

## Behavior pinned (6 cases)

- generic array section emits `• <first-inserted value>` per item — for
  `{gamma,alpha,bravo}` → `G`, for reversed `{alpha,bravo,gamma}` → `A`
- object section keys printed in insertion order (`Gamma, Alpha, Bravo`),
  explicitly NOT alphabetical
- a second object with a different key order prints in its own order
  (`Charlie, Bravo, Alpha`)
- nested object key order preserved verbatim (`Zulu, Yankee, Xray`)
- determinism: identical input → byte-identical output across repeated calls
- top-level sections emitted in their own insertion order

## Truth-first scope note

The task referenced `hushh-research/__tests__/utils/...` and a bare
`'formatCompleteJson'` import. There is no top-level `__tests__` here; vitest
only includes `__tests__/**` under `hushh-webapp`, and the module alias is
`@/lib/utils/json-to-human`. The file therefore lives at
`hushh-webapp/__tests__/utils/format-property-ordering.test.ts` and imports via
the `@/` alias.

## Verification

- `npm test -- __tests__/utils/format-property-ordering.test.ts` → 6/6 pass
- `git status` limited to the single new test file; zero production source drift

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — corrects the "re-sequence/canonicalize" premise; pins the
  real "insertion-order passthrough, no sort" contract
