### PR TITLE
test(utils): characterize formatCompleteJson on proto property poisoning attempts

### DIFF
--- a/hushh-webapp/__tests__/utils/format-json-poisoning.test.ts
+++ b/hushh-webapp/__tests__/utils/format-json-poisoning.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { formatCompleteJson } from "@/lib/utils/json-to-human";
+
+// Characterization tests for formatCompleteJson
+// (hushh-webapp/lib/utils/json-to-human.ts) documenting its exact behavior when
+// the input object carries hazardous own keys: "__proto__", "constructor", and
+// "prototype" — the classic prototype-poisoning property names.
+//
+// TRUTH-FIRST — LITERAL CONTRACT: formatCompleteJson is a READ-ONLY serializer.
+// It only ever READS the input via `Object.entries(...)` / `Object.values(...)`
+// and appends strings to a local `lines` array. It performs NO assignment back
+// onto the input, NO `obj[key] = ...`, NO `Object.assign`, and NO recursive
+// merge. Therefore it CANNOT pollute `Object.prototype` regardless of what keys
+// the input contains.
+//
+// REAL RUNTIME PATH: in production these objects arrive via `tryFormatComplete`,
+// which does `JSON.parse(...)` then calls `formatCompleteJson`. Critically,
+// `JSON.parse('{"__proto__": ...}')` does NOT set the object's prototype — it
+// defines "__proto__" as an OWN, ENUMERABLE data property. So these tests build
+// payloads with `JSON.parse` (mirroring the real path) so that the hazardous
+// names are genuine own keys that `Object.entries` will iterate. We then pin
+// that the formatter (a) treats them as ordinary keys, and (b) never leaks onto
+// the global prototype chain.
+
+const OBJECT_PROTO = Object.prototype as unknown as Record<string, unknown>;
+
+afterEach(() => {
+  // Defensive cleanup: if any assertion above somehow polluted the chain, undo
+  // it so test isolation holds. (Expected to be a no-op.)
+  delete OBJECT_PROTO.polluted;
+  delete OBJECT_PROTO.injected;
+});
+
+describe("formatCompleteJson — prototype-poisoning property keys are handled safely", () => {
+  it("does NOT pollute Object.prototype from a JSON __proto__ payload", () => {
+    // JSON.parse makes "__proto__" an OWN enumerable key (not a prototype set).
+    const payload = JSON.parse('{"__proto__":{"polluted":"yes"}}') as Record<
+      string,
+      unknown
+    >;
+
+    // Sanity: the payload's own prototype is still the pristine Object.prototype,
+    // and the dangerous key is an own enumerable property (the real hazard shape).
+    expect(Object.getPrototypeOf(payload)).toBe(Object.prototype);
+    expect(Object.prototype.hasOwnProperty.call(payload, "__proto__")).toBe(
+      true,
+    );
+
+    const out = formatCompleteJson(payload);
+
+    expect(typeof out).toBe("string");
+    // The global prototype chain is untouched: a fresh object sees nothing.
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect("polluted" in Object.prototype).toBe(false);
+  });
+
+  it("treats an own __proto__ object key as an ordinary serialized section", () => {
+    const payload = JSON.parse('{"__proto__":{"alpha":"A"}}') as Record<
+      string,
+      unknown
+    >;
+    const out = formatCompleteJson(payload);
+    // TRUTH-FIRST QUIRK: the section label is derived from
+    // `SECTION_LABELS["__proto__"]`, and since SECTION_LABELS is a plain object
+    // literal, that lookup INHERITS `Object.prototype` (a truthy value) — so the
+    // label stringifies to "[object Object]" rather than a cleaned name. This is
+    // a harmless READ-only artifact of label resolution; the nested value is
+    // still rendered, and nothing is written to the global chain.
+    expect(out).toContain("[object Object]");
+    expect(out).toContain("Alpha: A");
+    expect(({} as Record<string, unknown>).alpha).toBeUndefined();
+  });
+
+  it("serializes a top-level scalar __proto__ value without pollution", () => {
+    const payload = JSON.parse('{"__proto__":"danger"}') as Record<
+      string,
+      unknown
+    >;
+    const out = formatCompleteJson(payload);
+    expect(out).toContain("danger");
+    expect("danger" in Object.prototype).toBe(false);
+  });
+
+  it("treats a 'constructor' own key as a normal field (no global mutation)", () => {
+    const payload = JSON.parse('{"constructor":{"x":1}}') as Record<
+      string,
+      unknown
+    >;
+    const out = formatCompleteJson(payload);
+    // TRUTH-FIRST QUIRK: like __proto__, the "constructor" section label is read
+    // from `SECTION_LABELS["constructor"]`, which inherits the native `Object`
+    // constructor function from the literal's prototype. It stringifies to
+    // "function Object() { [native code] }" — hence the label contains "Object".
+    // Still a harmless READ; nothing is mutated.
+    expect(out).toContain("Object");
+    expect(out).toContain("X: 1");
+    // Object's real constructor is unchanged.
+    expect(Object.prototype.constructor).toBe(Object);
+  });
+
+  it("treats a 'prototype' own key as a normal field", () => {
+    const payload = JSON.parse('{"prototype":{"y":2}}') as Record<
+      string,
+      unknown
+    >;
+    const out = formatCompleteJson(payload);
+    expect(out).toContain("Prototype");
+    expect(out).toContain("Y: 2");
+  });
+
+  it("handles a poisoning key nested inside a section object without pollution", () => {
+    const payload = JSON.parse(
+      '{"config":{"__proto__":"x","real":"r"}}',
+    ) as Record<string, unknown>;
+    const out = formatCompleteJson(payload);
+    expect(out).toContain("--- Config ---");
+    expect(out).toContain("Real: r");
+    expect(({} as Record<string, unknown>).real).toBeUndefined();
+  });
+
+  it("is read-only: does not throw and leaves the global prototype pristine across all keys", () => {
+    const payload = JSON.parse(
+      '{"__proto__":{"injected":"1"},"constructor":{"injected":"2"},"prototype":{"injected":"3"}}',
+    ) as Record<string, unknown>;
+    expect(() => formatCompleteJson(payload)).not.toThrow();
+    expect(({} as Record<string, unknown>).injected).toBeUndefined();
+    expect("injected" in Object.prototype).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an isolated characterization test for `formatCompleteJson`
(`hushh-webapp/lib/utils/json-to-human.ts`) documenting its exact behavior when
the input object carries the classic prototype-poisoning property names
(`__proto__`, `constructor`, `prototype`) as own enumerable keys. Test-only; no
production change.

## Literal contract being characterized

`formatCompleteJson` is a **read-only serializer**: it only ever READS the input
via `Object.entries(...)` / `Object.values(...)` and appends strings to a local
`lines` array. It performs **no** assignment back onto the input, no
`obj[key] = ...`, no `Object.assign`, and no recursive merge. Therefore it
**cannot pollute `Object.prototype`** regardless of the input keys.

The real runtime path is `tryFormatComplete` → `JSON.parse(...)` →
`formatCompleteJson`. Critically, `JSON.parse('{"__proto__": ...}')` does **not**
reassign the object's prototype — it defines `__proto__` as an **own enumerable
data property**. The tests build payloads via `JSON.parse` to mirror that exact
hazard shape so `Object.entries` actually iterates the dangerous keys.

## Truth-first findings (real behavior pinned, not assumed)

The verification gate surfaced two genuine behaviors I corrected my assertions to
match rather than forcing a convenient expectation:

1. **No prototype pollution — confirmed.** Across `__proto__`, `constructor`, and
   `prototype` payloads (top-level, nested, and combined), a freshly created `{}`
   never sees injected keys and `"x" in Object.prototype` stays `false`. The
   serializer does not write.
2. **Harmless label-lookup quirk — documented.** Section labels are resolved with
   `SECTION_LABELS[key]`, a plain object literal. For `__proto__` and
   `constructor` that read **inherits from the literal's own prototype**, so the
   label becomes the inherited `Object.prototype` (stringified `"[object Object]"`)
   or the native `Object` constructor (`"function Object() { [native code] }"`),
   instead of a cleaned name. This is a cosmetic READ-only artifact in label
   rendering — it does **not** mutate anything and does **not** leak globally. The
   nested values are still rendered normally. The tests pin this real output
   rather than a prettier-but-false expectation.

## Behavior pinned (7 cases)

- `{"__proto__":{...}}` → no `Object.prototype` pollution; payload proto stays
  pristine; `__proto__` is a real own key
- `__proto__` object section label renders as `[object Object]` (inherited-label
  quirk), nested `Alpha: A` still emitted
- scalar `{"__proto__":"danger"}` serialized; `"danger"` not added to prototype
- `{"constructor":{...}}` label renders as native `Object` string;
  `Object.prototype.constructor` unchanged
- `{"prototype":{...}}` renders as ordinary `Prototype` field
- poisoning key nested in a section object → no pollution
- combined `__proto__`/`constructor`/`prototype` payload → does not throw, global
  prototype stays pristine

## Truth-first scope note

The task referenced `hushh-research/__tests__/utils/...` and a bare
`'formatCompleteJson'` import. There is no top-level `__tests__` here; vitest only
includes `__tests__/**` under `hushh-webapp`, and the module alias is
`@/lib/utils/json-to-human`. The file therefore lives at
`hushh-webapp/__tests__/utils/format-json-poisoning.test.ts` and imports via the
`@/` alias.

## Verification

- `npm test -- __tests__/utils/format-json-poisoning.test.ts` → 7/7 pass
- `git status` limited to the single new test file; zero production source drift

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — documents real, existing boundaries: confirmed no
  prototype pollution AND the cosmetic inherited-label quirk for
  `__proto__`/`constructor`, instead of asserting idealized output
