### PR TITLE
test(badge): verify Badge renders as a span element

### DIFF
--- a/hushh-webapp/__tests__/ui/badge.test.tsx
+++ b/hushh-webapp/__tests__/ui/badge.test.tsx
@@ -57,4 +57,13 @@ describe("Badge", () => {
       ).toBe(variant);
     });
   });
+
+  it("renders Badge as a span element", () => {
+    const { container } = render(<Badge>Label</Badge>);
+
+    const badge = container.querySelector('[data-slot="badge"]');
+
+    expect(badge?.tagName).toBe("SPAN");
+  });
+
 });


### PR DESCRIPTION
## What

Adds one assertion to the existing Badge test suite verifying that
`Badge` renders as a native `<span>` element when `asChild` is not used.

## Why

`Badge` defaults to rendering a `<span>` in production
(`components/ui/badge.tsx`). Existing tests verify `data-slot`
and `data-variant` contracts but do not verify the underlying
HTML element type.

## Scope

- Test-only change
- Single existing file modified
- One additive `it()` block
- No production code changes
- No import changes
- No snapshots
- Existing tests preserved

## Validation

```bash
npx vitest run __tests__/ui/badge.test.tsx