### PR TITLE
test(spinner): verify Spinner renders as an svg element

### DIFF
--- a/hushh-webapp/__tests__/ui/spinner.test.tsx
+++ b/hushh-webapp/__tests__/ui/spinner.test.tsx
@@ -23,4 +23,11 @@ describe("Spinner", () => {
 
     expect(screen.getByRole("status", { name: "Saving" })).toBeTruthy();
   });
+
+  it("renders Spinner as an svg element", () => {
+    render(<Spinner />);
+
+    expect(screen.getByRole("status").tagName).toBe("svg");
+  });
+
 });


### PR DESCRIPTION
## What

Adds one assertion to the existing Spinner test suite verifying that
`Spinner` renders an SVG element.

## Why

`Spinner` is built on Lucide's `Loader2Icon`, which renders an SVG.
Existing tests verify accessibility semantics but do not verify the
underlying rendered element type.

## Scope

- Test-only change
- Single existing file modified
- One additive `it()` block
- No production code changes
- No import changes
- No snapshots
- Existing tests preserved

## Validation

```bash
npx vitest run __tests__/ui/spinner.test.tsx