### PR TITLE
test(card): verify CardDescription renders as a div element

### DIFF
--- a/hushh-webapp/__tests__/ui/card.test.tsx
+++ b/hushh-webapp/__tests__/ui/card.test.tsx
@@ -73,4 +73,21 @@ describe("Card", () => {
 
     expect(container.firstElementChild?.getAttribute("data-slot")).toBe("card-footer");
   });
+
+  it("renders CardDescription as a div element", () => {
+    const { container } = render(
+      <Card>
+        <CardHeader>
+          <CardDescription>Description</CardDescription>
+        </CardHeader>
+      </Card>,
+    );
+
+    const description = container.querySelector(
+      '[data-slot="card-description"]',
+    );
+
+    expect(description?.tagName).toBe("DIV");
+  });
+
 });


### PR DESCRIPTION
## What

Adds a single contract test to the existing Card test suite verifying that `CardDescription` renders as a native `<div>` element.

## Why

`CardDescription` is currently implemented using `React.ComponentProps<"div">` and renders a `<div data-slot="card-description">` in production. Existing tests verify the presence of the `card-description` data-slot, but do not verify the underlying rendered HTML element type.

Adding this assertion helps protect the component contract and detects unintended changes to the rendered element.

## Changes

* Added 1 new `it()` block to `__tests__/ui/card.test.tsx`
* Verifies `CardDescription` renders as a `<div>` element
* No production code changes
* No existing tests modified
* No import changes
* No snapshots or mocks added

## Test Plan

```bash
npx vitest run __tests__/ui/card.test.tsx
```

All tests pass locally.

## Risk

Low.

This is a test-only change that adds a single assertion to an existing test suite and does not affect runtime behavior.
