### PR TITLE
test(popover): verify PopoverDescription renders as a p element

### DIFF
--- a/hushh-webapp/__tests__/ui/popover.test.tsx
+++ b/hushh-webapp/__tests__/ui/popover.test.tsx
@@ -97,4 +97,16 @@ describe("Popover", () => {
     expect(el?.tagName).toBe("H2");
   });
 
+  it("renders PopoverDescription as a p element", () => {
+    const { container } = render(
+      <PopoverDescription>Details</PopoverDescription>,
+    );
+
+    const description = container.querySelector(
+      '[data-slot="popover-description"]',
+    );
+
+    expect(description?.tagName).toBe("P");
+  });
+
 });


### PR DESCRIPTION
## What

Adds a single contract test to the existing Popover test suite verifying that `PopoverDescription` renders as a native `<p>` element.

## Why

`PopoverDescription` is currently implemented using `React.ComponentProps<"p">` and renders a `<p data-slot="popover-description">` in production.

Existing tests verify the presence of the `popover-description` data-slot, but do not verify the underlying rendered HTML element type. The suite already includes a corresponding tagName assertion for `PopoverTitle` (`h2`), so this adds matching coverage for the sibling description component.

## Changes

* Added 1 new `it()` block to `__tests__/ui/popover.test.tsx`
* Verifies `PopoverDescription` renders as a `<p>` element
* No production code changes
* No existing tests modified
* No import changes
* No snapshots or mocks added

## Test Plan

```bash
npx vitest run __tests__/ui/popover.test.tsx
```

All tests pass locally.

## Risk

Low.

This is a test-only change that adds a single assertion to an existing test suite and does not affect runtime behavior.
