### PR TITLE
test(empty): verify EmptyDescription renders as a p element

### DIFF
--- a/hushh-webapp/__tests__/ui/empty.test.tsx
+++ b/hushh-webapp/__tests__/ui/empty.test.tsx
@@ -111,4 +111,18 @@ describe("Empty", () => {
     expect(media?.getAttribute("data-variant")).toBe("default");
   });
 
+  it("renders EmptyDescription as a p element", () => {
+    const { container } = render(
+      <Empty>
+        <EmptyDescription>Try again later</EmptyDescription>
+      </Empty>,
+    );
+
+    const description = container.querySelector(
+      '[data-slot="empty-description"]',
+    );
+
+    expect(description?.tagName).toBe("P");
+  });
+
 });


### PR DESCRIPTION
## What

Adds a single contract test to the existing Empty test suite verifying that `EmptyDescription` renders as a native `<p>` element.

## Why

`EmptyDescription` is currently implemented using `React.ComponentProps<"p">` and renders a `<p data-slot="empty-description">` in production.

Existing tests verify the presence of the `empty-description` data-slot and validate rendered text content, but do not verify the underlying rendered HTML element type. Adding this assertion helps protect the component contract and detects unintended changes to the rendered element.

## Changes

* Added 1 new `it()` block to `__tests__/ui/empty.test.tsx`
* Verifies `EmptyDescription` renders as a `<p>` element
* No production code changes
* No existing tests modified
* No import changes
* No snapshots or mocks added

## Test Plan

```bash
npx vitest run __tests__/ui/empty.test.tsx
```

All tests pass locally.

## Risk

Low.

This is a test-only change that adds a single assertion to an existing test suite and does not affect runtime behavior.
